### PR TITLE
feat(examples): add app-showcase kitchen-sink reference workspace

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Welcome to the ObjectStack examples catalog! This directory contains carefully c
 |-------|----------|-------------|
 | 🟢 **Beginner** | [App Todo](#app-todo), [Plugin BI](#plugin-bi) | Start here - simple, focused examples |
 | 🟡 **Intermediate** | [HotCRM](https://github.com/objectstack-ai/hotcrm) | Real-world enterprise application (separate repo) |
+| 🟣 **Reference** | [App Showcase](./app-showcase/) | Kitchen-sink — **every** metadata type, view type, and chart type, plus a coverage test |
 | 🔴 **Advanced** | [Server](../apps/objectos/) | Server hosting & plugin orchestration |
 
 ### By Protocol Category
@@ -74,6 +75,33 @@ app-todo/
 cd examples/app-todo
 pnpm install
 pnpm typecheck
+```
+
+---
+
+### App Showcase
+**Path:** [`examples/app-showcase/`](./app-showcase/)
+**Level:** 🟣 Reference
+**Protocols:** Data, UI, System, Automation, AI, Auth
+
+A **kitchen-sink** workspace built for demonstration, debugging, and
+coverage-driven verification. It pairs a realistic project-delivery domain
+with synthetic "gallery" objects that exhaust protocol variants, and ties them
+together with a coverage manifest that the test suite checks against the
+protocol's own Zod enums.
+
+**What's included:**
+- **All 49 field types** (`src/objects/field-zoo.object.ts`) + every relationship kind (lookup, master-detail, self-referencing tree, many-to-many junction)
+- **All 8 list-view types** on one object (grid, kanban, gallery, calendar, timeline, gantt, map, chart) + all 5 form types
+- **All 38 chart types** in one dashboard + all 4 report types (tabular/summary/matrix/joined)
+- The action **type × location** matrix and a component-gallery page
+- Capability chains: security (RBAC + FLS + RLS + sharing + policy), automation (flow → approval → webhook → job → email), and AI (agent + tool + skill)
+- A **coverage test** that introspects the spec enums and fails when a new variant is left uncovered
+
+```bash
+cd examples/app-showcase
+pnpm verify    # typecheck + coverage test
+pnpm dev       # → http://localhost:3000/_studio
 ```
 
 ---

--- a/examples/app-showcase/README.md
+++ b/examples/app-showcase/README.md
@@ -1,0 +1,124 @@
+# ObjectStack Showcase (`@objectstack/example-showcase`)
+
+> A kitchen-sink workspace that exercises **every metadata type, every view
+> type, every chart type**, and the major **end-to-end capability chains** —
+> built for three audiences at once: **demonstration**, **debugging**, and
+> **verification**.
+
+Most example apps are intentionally minimal. This one is deliberately
+*exhaustive*. It pairs a coherent business domain (project delivery) with a
+set of synthetic "gallery" objects whose only job is to cover protocol
+variants, and ties the two together with a **coverage manifest** that the test
+suite checks against the protocol's own Zod enums.
+
+## Why it exists
+
+Demonstration and verification pull in opposite directions:
+
+- **Demo** wants a believable, connected app — but a realistic app never
+  naturally uses all 49 field types, all 8 view types, or all 38 chart types.
+- **Verify** wants every variant present and *asserted* — which a single
+  realistic domain can't provide.
+
+So the showcase splits into two tracks:
+
+| Track | Purpose | Where |
+| :--- | :--- | :--- |
+| **Realistic backbone** | A connected delivery domain with seeded data, so every view renders something real. | `Account → Project → Task`, `Team`, `Category` |
+| **Gallery / specimens** | Synthetic objects & views that exhaust protocol variants. | `Field Zoo`, the Task view gallery, the Chart Gallery |
+
+## Quick start
+
+```bash
+pnpm install
+pnpm --filter @objectstack/spec build   # if not already built
+
+# Demonstration — open Studio and click through the gallery
+pnpm dev            # → http://localhost:3000/_studio
+
+# Verification — typecheck + coverage test
+pnpm verify
+```
+
+## What it covers
+
+### Data layer (ObjectQL)
+- **All 49 field types** — `src/objects/field-zoo.object.ts` carries one field
+  of every `FieldType`, with the remainder appearing naturally on the backbone
+  objects.
+- **Every relationship kind** — `lookup` (project → account, category → self),
+  `master_detail` (task → project), self-referencing **hierarchy/tree**
+  (`Category.parent`), and **many-to-many** via the
+  `showcase_project_membership` junction.
+- **Formulas, validations, and a status state machine** on `Project` and
+  `Task`.
+
+### View layer (ObjectUI)
+- **All 8 list-view types** on a single object (`src/views/task.view.ts`):
+  grid, kanban, gallery, calendar, timeline, gantt, map, chart. The Task object's
+  fields are chosen so one object can back every type.
+- **All 5 form-view types**: simple, tabbed, wizard, split, drawer.
+- **The full chart taxonomy** — `src/dashboards/chart-gallery.dashboard.ts`
+  has one widget per chart family (all 38 `ChartType`s).
+- **All 4 report types**: tabular, summary, matrix, joined
+  (`src/reports/index.ts`).
+- **The action matrix** — every `ActionType` (script/url/flow/modal/api/form)
+  across every `ActionLocation`.
+- **A component-gallery page** placing the standard page components.
+
+### Capability chains (the "complex abilities")
+- **Security** (`src/security/index.ts`): a role hierarchy + a permission set
+  that layers object CRUD, **field-level security (FLS)**, and
+  **row-level security (RLS)**, plus criteria- and owner-based **sharing rules**
+  and an org **policy**.
+- **Automation**: a record-triggered flow → a screen-flow wizard → a multi-step
+  **approval** → an outbound **webhook** → a scheduled **job** → an **email**
+  template.
+- **AI**: an **agent** wired to a **tool** and a **skill**.
+- **i18n / theming / portals**: `en` + `zh-CN` translations, light + dark
+  themes, and an external client portal.
+
+## The coverage manifest — how "confirm" works
+
+`src/coverage.ts` declares what the showcase is supposed to cover and provides
+the collectors the test uses. `test/coverage.test.ts` then **introspects the
+protocol's own enums** (`FieldType`, `ChartTypeSchema`, `ReportType`,
+`ActionType`, `ACTION_LOCATIONS`) and asserts every member appears at least
+once across the registered metadata.
+
+Because the expected sets come from the **spec** — not a hand-maintained list —
+the test fails automatically when the platform gains a new field type, chart
+type, or report type that the showcase hasn't demonstrated yet. That keeps this
+example a **living conformance fixture**, not a static snapshot. (`defineStack`
+itself also runs full schema + cross-reference validation when the config is
+imported, so `pnpm test` proves the whole stack loads cleanly.)
+
+## Directory layout
+
+```
+app-showcase/
+├── objectstack.config.ts        # defineStack — registers everything
+├── src/
+│   ├── coverage.ts              # coverage manifest + collectors (the soul)
+│   ├── objects/                 # field-zoo + backbone + junction + tree
+│   ├── views/                   # all 8 list types + all 5 form types
+│   ├── dashboards/              # chart gallery (all 38 chart types)
+│   ├── reports/                 # tabular / summary / matrix / joined
+│   ├── actions/                 # type × location matrix
+│   ├── pages/                   # component gallery
+│   ├── apps/                    # navigation linking every surface
+│   ├── security/                # roles + FLS + RLS + sharing + policy
+│   ├── flows/ approvals/ webhooks/ jobs/ emails/   # automation chain
+│   ├── agents/                  # agent + tool + skill
+│   ├── themes/ translations/ datasources/ portals/
+│   └── data/                    # seed data sized to feed every view
+└── test/
+    ├── coverage.test.ts         # introspects spec enums, asserts coverage
+    └── seed.test.ts             # stack-loads + breadth smoke test
+```
+
+## Extending it
+
+When you add a new variant to the platform, the coverage test will go red and
+point at the gap. Add a field/view/widget that uses it, reference it in
+`COVERAGE`, and the test goes green again.

--- a/examples/app-showcase/objectstack.config.ts
+++ b/examples/app-showcase/objectstack.config.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineStack } from '@objectstack/spec';
+
+import * as objects from './src/objects/index.js';
+import { TaskViews, ProjectViews } from './src/views/index.js';
+import { ShowcaseApp } from './src/apps/index.js';
+import { ChartGalleryDashboard } from './src/dashboards/index.js';
+import { allReports } from './src/reports/index.js';
+import { allActions } from './src/actions/index.js';
+import { ComponentGalleryPage } from './src/pages/index.js';
+import { allFlows } from './src/flows/index.js';
+import { allApprovals } from './src/approvals/index.js';
+import { allWebhooks } from './src/webhooks/index.js';
+import { allJobs } from './src/jobs/index.js';
+import { allEmails } from './src/emails/index.js';
+import { ShowcaseAssistantAgent, ProjectOpsSkill } from './src/agents/index.js';
+import {
+  allRoles,
+  allPermissionSets,
+  allSharingRules,
+  allPolicies,
+} from './src/security/index.js';
+import { allThemes } from './src/themes/index.js';
+import { ShowcaseTranslationBundle } from './src/translations/index.js';
+import { allDatasources } from './src/datasources/index.js';
+import { allPortals } from './src/portals/index.js';
+import { ShowcaseSeedData } from './src/data/index.js';
+
+/**
+ * Showcase — a kitchen-sink workspace that exercises every metadata type,
+ * every view type, every chart type, and the major end-to-end capability
+ * chains. It is built for three audiences at once:
+ *
+ *   • Demonstration — a coherent project-delivery domain with seeded data
+ *     so every view renders something real.
+ *   • Debugging — open in Studio (`pnpm dev` → http://localhost:3000/_studio)
+ *     and click through the gallery navigation.
+ *   • Verification — `pnpm verify` runs typecheck + the coverage test, which
+ *     introspects the protocol's own enums and fails if any field/chart/
+ *     report type is left uncovered.
+ */
+export default defineStack({
+  manifest: {
+    id: 'com.example.showcase',
+    namespace: 'showcase',
+    version: '0.1.0',
+    type: 'app',
+    name: 'ObjectStack Showcase',
+    description: 'Kitchen-sink workspace covering all metadata types, all view types, and the major capability chains.',
+  },
+
+  requires: ['ui', 'automation'],
+
+  // Infrastructure
+  datasources: allDatasources,
+  datasourceMapping: [
+    { namespace: 'showcase', datasource: 'showcase_primary' },
+    { default: true, datasource: 'showcase_primary' },
+  ],
+
+  // i18n
+  translations: [ShowcaseTranslationBundle],
+  i18n: {
+    defaultLocale: 'en',
+    supportedLocales: ['en', 'zh-CN'],
+    fallbackLocale: 'en',
+    messageFormat: 'simple',
+    lazyLoad: false,
+    cache: true,
+  },
+
+  // Data
+  objects: Object.values(objects),
+
+  // UI
+  apps: [ShowcaseApp],
+  portals: allPortals,
+  views: [TaskViews, ProjectViews],
+  pages: [ComponentGalleryPage],
+  dashboards: [ChartGalleryDashboard],
+  reports: allReports,
+  actions: allActions,
+  themes: allThemes,
+
+  // Logic
+  flows: allFlows,
+  approvals: allApprovals,
+  jobs: allJobs,
+  emailTemplates: allEmails,
+  webhooks: allWebhooks,
+
+  // Security
+  roles: allRoles,
+  permissions: allPermissionSets,
+  sharingRules: allSharingRules,
+  policies: allPolicies,
+
+  // AI
+  agents: [ShowcaseAssistantAgent],
+  skills: [ProjectOpsSkill],
+
+  // Seed data
+  data: ShowcaseSeedData,
+});

--- a/examples/app-showcase/package.json
+++ b/examples/app-showcase/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@objectstack/example-showcase",
+  "version": "0.1.0",
+  "description": "Kitchen-sink showcase workspace — exercises every metadata type, every view type, every chart type, and the major end-to-end capability chains (security, automation, AI). Built for demonstration, debugging, and coverage-driven verification.",
+  "license": "Apache-2.0",
+  "private": true,
+  "main": "./objectstack.config.ts",
+  "types": "./objectstack.config.ts",
+  "exports": {
+    ".": "./objectstack.config.ts",
+    "./objectstack.config": "./objectstack.config.ts",
+    "./coverage": "./src/coverage.ts"
+  },
+  "scripts": {
+    "dev": "objectstack dev",
+    "start": "objectstack start",
+    "build": "objectstack build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "verify": "pnpm typecheck && pnpm test"
+  },
+  "dependencies": {
+    "@objectstack/runtime": "workspace:*",
+    "@objectstack/spec": "workspace:*"
+  },
+  "devDependencies": {
+    "@objectstack/cli": "workspace:*",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/examples/app-showcase/src/actions/index.ts
+++ b/examples/app-showcase/src/actions/index.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Action } from '@objectstack/spec/ui';
+
+const task = 'showcase_task';
+
+/**
+ * Action matrix — covers every `ActionType` (script / url / flow / modal /
+ * api / form) surfaced across a spread of `ActionLocation`s (toolbar, row,
+ * record header/more, related list, global nav).
+ */
+
+/** script — inline handler, shown on each row and the record header. */
+export const MarkDoneAction: Action = {
+  name: 'showcase_mark_done',
+  label: 'Mark Done',
+  icon: 'check',
+  objectName: task,
+  type: 'script',
+  locations: ['list_item', 'record_header'],
+  refreshAfter: true,
+};
+
+/** url — navigate out, from the row overflow menu. */
+export const OpenDocsAction: Action = {
+  name: 'showcase_open_docs',
+  label: 'Open Docs',
+  icon: 'book-open',
+  objectName: task,
+  type: 'url',
+  target: 'https://docs.objectstack.ai',
+  locations: ['record_more'],
+  refreshAfter: false,
+};
+
+/** flow — launch a screen flow wizard from the toolbar. */
+export const BulkReassignAction: Action = {
+  name: 'showcase_bulk_reassign',
+  label: 'Bulk Reassign',
+  icon: 'users',
+  objectName: task,
+  type: 'flow',
+  target: 'showcase_reassign_wizard',
+  locations: ['list_toolbar'],
+  refreshAfter: true,
+};
+
+/** modal — open a dialog/page. */
+export const QuickViewAction: Action = {
+  name: 'showcase_quick_view',
+  label: 'Quick View',
+  icon: 'eye',
+  objectName: task,
+  type: 'modal',
+  target: 'showcase_component_gallery',
+  locations: ['list_item'],
+  refreshAfter: false,
+};
+
+/** api — call a custom endpoint. */
+export const RecalcEstimateAction: Action = {
+  name: 'showcase_recalc_estimate',
+  label: 'Recalculate Estimate',
+  icon: 'calculator',
+  objectName: task,
+  type: 'api',
+  target: '/api/v1/showcase/recalc',
+  locations: ['record_more', 'record_section'],
+  refreshAfter: true,
+};
+
+/** form — open a parameter form dialog. */
+export const LogTimeAction: Action = {
+  name: 'showcase_log_time',
+  label: 'Log Time',
+  icon: 'clock',
+  objectName: task,
+  type: 'form',
+  target: 'showcase_task.default',
+  locations: ['record_header', 'record_related'],
+  refreshAfter: true,
+};
+
+/** global nav command-palette action. */
+export const NewTaskAction: Action = {
+  name: 'showcase_new_task',
+  label: 'New Task',
+  icon: 'plus',
+  objectName: task,
+  type: 'modal',
+  target: 'showcase_component_gallery',
+  locations: ['global_nav'],
+  refreshAfter: true,
+};
+
+export const allActions = [
+  MarkDoneAction,
+  OpenDocsAction,
+  BulkReassignAction,
+  QuickViewAction,
+  RecalcEstimateAction,
+  LogTimeAction,
+  NewTaskAction,
+];

--- a/examples/app-showcase/src/agents/index.ts
+++ b/examples/app-showcase/src/agents/index.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineAgent, defineSkill, defineTool } from '@objectstack/spec';
+
+/** Tool — look up a project by name. */
+export const FindProjectTool = defineTool({
+  name: 'showcase_find_project',
+  label: 'Find Project',
+  description: 'Find a project by name.',
+  parameters: {
+    type: 'object',
+    properties: { name: { type: 'string', description: 'Project name' } },
+    required: ['name'],
+  },
+  requiresConfirmation: false,
+  active: true,
+  builtIn: false,
+});
+
+/** Skill — bundles the project tools. */
+export const ProjectOpsSkill = defineSkill({
+  name: 'showcase_project_ops',
+  label: 'Project Operations',
+  description: 'Tools and prompts for working with projects and tasks.',
+  tools: ['showcase_find_project'],
+  active: true,
+});
+
+/** Agent — a delivery assistant for the showcase workspace. */
+export const ShowcaseAssistantAgent = defineAgent({
+  name: 'showcase_assistant',
+  label: 'Delivery Assistant',
+  role: 'You are a helpful delivery-operations assistant.',
+  instructions:
+    'Help users find projects, summarise task status, and flag at-risk projects. Ask before making destructive changes.',
+  active: true,
+  visibility: 'global',
+});

--- a/examples/app-showcase/src/approvals/index.ts
+++ b/examples/app-showcase/src/approvals/index.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Budget Approval — a two-step approval that locks a project when its budget
+ * exceeds a threshold: manager first, then executive for very large budgets.
+ * Validated (and its string criteria coerced to expressions) by `defineStack`.
+ */
+export const BudgetApprovalProcess = {
+  name: 'showcase_budget_approval',
+  label: 'Project Budget Approval',
+  object: 'showcase_project',
+  active: true,
+  description: 'Two-step approval for projects above budget thresholds.',
+  entryCriteria: 'record.budget > 100000',
+  lockRecord: true,
+  steps: [
+    {
+      name: 'manager_review',
+      label: 'Manager Review',
+      description: 'Project manager reviews the budget.',
+      approvers: [{ type: 'role' as const, value: 'manager' }],
+      behavior: 'first_response' as const,
+      rejectionBehavior: 'reject_process' as const,
+    },
+    {
+      name: 'exec_review',
+      label: 'Executive Review',
+      description: 'Executive signs off on budgets above $500k.',
+      entryCriteria: 'record.budget > 500000',
+      approvers: [{ type: 'role' as const, value: 'exec' }],
+      behavior: 'unanimous' as const,
+      rejectionBehavior: 'back_to_previous' as const,
+    },
+  ],
+};
+
+export const allApprovals = [BudgetApprovalProcess];

--- a/examples/app-showcase/src/apps/index.ts
+++ b/examples/app-showcase/src/apps/index.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { App } from '@objectstack/spec/ui';
+
+/**
+ * Showcase app — navigation that links to every surface so a human can click
+ * through the whole gallery: the data objects, the Task view gallery, the
+ * Chart Gallery dashboard, the reports, and the component-gallery home page.
+ */
+export const ShowcaseApp = App.create({
+  name: 'showcase_app',
+  label: 'Showcase',
+  icon: 'sparkles',
+  branding: { primaryColor: '#7C3AED' },
+
+  navigation: [
+    {
+      id: 'grp_data',
+      type: 'group',
+      label: 'Data Model',
+      icon: 'database',
+      children: [
+        { id: 'nav_projects', type: 'object', objectName: 'showcase_project', label: 'Projects', icon: 'folder-kanban' },
+        { id: 'nav_tasks', type: 'object', objectName: 'showcase_task', label: 'Tasks', icon: 'check-square' },
+        { id: 'nav_accounts', type: 'object', objectName: 'showcase_account', label: 'Accounts', icon: 'building' },
+        { id: 'nav_teams', type: 'object', objectName: 'showcase_team', label: 'Teams', icon: 'users' },
+        { id: 'nav_categories', type: 'object', objectName: 'showcase_category', label: 'Categories', icon: 'list-tree' },
+        { id: 'nav_field_zoo', type: 'object', objectName: 'showcase_field_zoo', label: 'Field Zoo', icon: 'shapes' },
+      ],
+    },
+    {
+      id: 'grp_analytics',
+      type: 'group',
+      label: 'Analytics',
+      icon: 'chart-bar',
+      children: [
+        { id: 'nav_charts', type: 'dashboard', dashboardName: 'showcase_chart_gallery', label: 'Chart Gallery', icon: 'layout-dashboard' },
+        { id: 'nav_report_tabular', type: 'report', reportName: 'showcase_task_list', label: 'Task List', icon: 'table' },
+        { id: 'nav_report_summary', type: 'report', reportName: 'showcase_hours_by_status', label: 'Hours by Status', icon: 'sigma' },
+        { id: 'nav_report_matrix', type: 'report', reportName: 'showcase_status_priority_matrix', label: 'Status × Priority', icon: 'grid-3x3' },
+        { id: 'nav_report_joined', type: 'report', reportName: 'showcase_task_overview', label: 'Task Overview', icon: 'layers' },
+      ],
+    },
+    {
+      id: 'grp_pages',
+      type: 'group',
+      label: 'Pages',
+      icon: 'layout',
+      children: [
+        { id: 'nav_gallery', type: 'page', pageName: 'showcase_component_gallery', label: 'Component Gallery', icon: 'layout-template' },
+      ],
+    },
+  ],
+});

--- a/examples/app-showcase/src/coverage.ts
+++ b/examples/app-showcase/src/coverage.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Coverage manifest — the soul of the showcase.
+ *
+ * This module declares *what the showcase is supposed to cover* and provides
+ * the helpers the coverage test uses to prove it. The test (see
+ * `test/coverage.test.ts`) introspects the protocol's own Zod enums
+ * (`FieldTypeSchema`, `ChartTypeSchema`, `ReportType`, `ActionType`,
+ * `ACTION_LOCATIONS`) and asserts every member appears at least once across
+ * the registered metadata. Because the expected sets come from the *spec*,
+ * the test fails automatically when the platform gains a new field type,
+ * chart type, or report type that the showcase has not yet demonstrated —
+ * keeping this example a living conformance fixture, not a static snapshot.
+ */
+
+/** List-view visualisation types (ListViewSchema `type`). */
+export const LIST_VIEW_TYPES = [
+  'grid',
+  'kanban',
+  'gallery',
+  'calendar',
+  'timeline',
+  'gantt',
+  'map',
+  'chart',
+] as const;
+
+/** Form-view layout types (FormViewSchema `type`). */
+export const FORM_VIEW_TYPES = ['simple', 'tabbed', 'wizard', 'split', 'drawer'] as const;
+
+/**
+ * Human/CI-readable map of each coverage dimension to where it is exercised.
+ * Useful as documentation and as a checklist when extending the showcase.
+ */
+export const COVERAGE = {
+  fieldTypes: {
+    source: 'FieldTypeSchema',
+    coveredBy: 'objects/field-zoo.object.ts (+ relationship/date/select fields on the backbone objects)',
+  },
+  relationships: {
+    coveredBy: [
+      'lookup → project.account, category.parent (self-referencing tree)',
+      'master_detail → task.project, project_membership.{team,project}',
+      'many-to-many → showcase_project_membership junction',
+    ],
+  },
+  listViewTypes: {
+    expected: LIST_VIEW_TYPES,
+    coveredBy: 'views/task.view.ts (all 8) + views/project.view.ts',
+  },
+  formViewTypes: {
+    expected: FORM_VIEW_TYPES,
+    coveredBy: 'views/task.view.ts formViews (simple/tabbed/wizard/split/drawer)',
+  },
+  chartTypes: {
+    source: 'ChartTypeSchema',
+    coveredBy: 'dashboards/chart-gallery.dashboard.ts (one widget per chart family)',
+  },
+  reportTypes: {
+    source: 'ReportType',
+    coveredBy: 'reports/index.ts (tabular/summary/matrix/joined)',
+  },
+  actionTypesAndLocations: {
+    source: 'ActionType + ACTION_LOCATIONS',
+    coveredBy: 'actions/index.ts (script/url/flow/modal/api/form across all locations)',
+  },
+  capabilityChains: {
+    security: 'security/index.ts — roles + permission set (CRUD + FLS + RLS) + sharing + policy',
+    automation: 'flows/index.ts + approvals/index.ts + webhooks/index.ts + jobs/index.ts + emails/index.ts',
+    ai: 'agents/index.ts — agent + tool + skill',
+  },
+  i18nThemingPortals: {
+    coveredBy: 'translations/index.ts (en + zh-CN), themes/index.ts (light + dark), portals/index.ts',
+  },
+} as const;
+
+/** Collect every field `type` used across a set of object definitions. */
+export function collectFieldTypes(objects: Array<{ fields?: Record<string, { type?: string }> }>): Set<string> {
+  const used = new Set<string>();
+  for (const obj of objects) {
+    for (const field of Object.values(obj.fields ?? {})) {
+      if (field?.type) used.add(field.type);
+    }
+  }
+  return used;
+}
+
+/** Collect every list-view `type` from a set of `defineView` results. */
+export function collectListViewTypes(views: Array<{ list?: { type?: string }; listViews?: Record<string, { type?: string }> }>): Set<string> {
+  const used = new Set<string>();
+  for (const view of views) {
+    if (view.list?.type) used.add(view.list.type);
+    for (const lv of Object.values(view.listViews ?? {})) {
+      if (lv?.type) used.add(lv.type);
+    }
+  }
+  return used;
+}
+
+/** Collect every form-view `type` from a set of `defineView` results. */
+export function collectFormViewTypes(views: Array<{ formViews?: Record<string, { type?: string }> }>): Set<string> {
+  const used = new Set<string>();
+  for (const view of views) {
+    for (const fv of Object.values(view.formViews ?? {})) {
+      if (fv?.type) used.add(fv.type);
+    }
+  }
+  return used;
+}

--- a/examples/app-showcase/src/dashboards/chart-gallery.dashboard.ts
+++ b/examples/app-showcase/src/dashboards/chart-gallery.dashboard.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Dashboard } from '@objectstack/spec/ui';
+
+const task = 'showcase_task';
+const project = 'showcase_project';
+
+/**
+ * Chart Gallery — one widget per chart family so the dashboard renderer can
+ * be exercised against every visualisation type. `type` accepts the full
+ * `ChartTypeSchema` taxonomy (38 members); this dashboard covers a
+ * representative widget for each category (comparison, trend, distribution,
+ * relationship, composition, performance, tabular).
+ */
+export const ChartGalleryDashboard: Dashboard = {
+  name: 'showcase_chart_gallery',
+  label: 'Chart Gallery',
+  description: 'A representative widget for every chart family — visual coverage of the dashboard renderer.',
+  columns: 12,
+  widgets: [
+    // ── Performance / KPI ────────────────────────────────────────────────
+    { id: 'kpi_total_tasks', type: 'metric', title: 'Total Tasks', object: task, aggregate: 'count', layout: { x: 0, y: 0, w: 3, h: 2 } },
+    { id: 'kpi_open_tasks', type: 'kpi', title: 'Open Tasks', object: task, aggregate: 'count', filter: { done: false }, layout: { x: 3, y: 0, w: 3, h: 2 } },
+    { id: 'gauge_progress', type: 'gauge', title: 'Avg Progress', object: task, aggregate: 'avg', valueField: 'progress', layout: { x: 6, y: 0, w: 3, h: 2 } },
+    { id: 'bullet_budget', type: 'bullet', title: 'Budget vs Spend', object: project, aggregate: 'sum', valueField: 'spent', layout: { x: 9, y: 0, w: 3, h: 2 } },
+
+    // ── Comparison ───────────────────────────────────────────────────────
+    { id: 'bar_by_status', type: 'bar', title: 'Tasks by Status', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 0, y: 2, w: 4, h: 4 } },
+    { id: 'column_by_priority', type: 'column', title: 'Tasks by Priority', object: task, aggregate: 'count', categoryField: 'priority', layout: { x: 4, y: 2, w: 4, h: 4 } },
+    { id: 'hbar_hours', type: 'horizontal-bar', title: 'Hours by Status', object: task, aggregate: 'sum', valueField: 'estimate_hours', categoryField: 'status', layout: { x: 8, y: 2, w: 4, h: 4 } },
+    { id: 'stacked_bar', type: 'stacked-bar', title: 'Status × Priority', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 0, y: 6, w: 4, h: 4 } },
+    { id: 'grouped_bar', type: 'grouped-bar', title: 'Grouped Status', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 4, y: 6, w: 4, h: 4 } },
+
+    // ── Trend ────────────────────────────────────────────────────────────
+    { id: 'line_created', type: 'line', title: 'Tasks Created (monthly)', object: task, aggregate: 'count', categoryField: 'created_at', categoryGranularity: 'month', layout: { x: 8, y: 6, w: 4, h: 4 } },
+    { id: 'area_created', type: 'area', title: 'Cumulative (area)', object: task, aggregate: 'count', categoryField: 'created_at', categoryGranularity: 'month', layout: { x: 0, y: 10, w: 4, h: 4 } },
+    { id: 'stacked_area', type: 'stacked-area', title: 'Stacked Area', object: task, aggregate: 'count', categoryField: 'created_at', categoryGranularity: 'month', layout: { x: 4, y: 10, w: 4, h: 4 } },
+    { id: 'spline_trend', type: 'spline', title: 'Smoothed Trend', object: task, aggregate: 'count', categoryField: 'created_at', categoryGranularity: 'week', layout: { x: 8, y: 10, w: 4, h: 4 } },
+
+    // ── Distribution ─────────────────────────────────────────────────────
+    { id: 'pie_status', type: 'pie', title: 'Status Split', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 0, y: 14, w: 3, h: 4 } },
+    { id: 'donut_priority', type: 'donut', title: 'Priority Split', object: task, aggregate: 'count', categoryField: 'priority', layout: { x: 3, y: 14, w: 3, h: 4 } },
+    { id: 'funnel_pipeline', type: 'funnel', title: 'Task Funnel', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 6, y: 14, w: 3, h: 4 } },
+    { id: 'pyramid_priority', type: 'pyramid', title: 'Priority Pyramid', object: task, aggregate: 'count', categoryField: 'priority', layout: { x: 9, y: 14, w: 3, h: 4 } },
+
+    // ── Relationship ─────────────────────────────────────────────────────
+    { id: 'scatter_estimate', type: 'scatter', title: 'Estimate vs Progress', object: task, aggregate: 'avg', valueField: 'estimate_hours', categoryField: 'progress', layout: { x: 0, y: 18, w: 4, h: 4 } },
+    { id: 'bubble_budget', type: 'bubble', title: 'Budget Bubble', object: project, aggregate: 'sum', valueField: 'budget', categoryField: 'account', layout: { x: 4, y: 18, w: 4, h: 4 } },
+    { id: 'heatmap_load', type: 'heatmap', title: 'Load Heatmap', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 8, y: 18, w: 4, h: 4 } },
+
+    // ── Composition ──────────────────────────────────────────────────────
+    { id: 'treemap_hours', type: 'treemap', title: 'Hours Treemap', object: task, aggregate: 'sum', valueField: 'estimate_hours', categoryField: 'status', layout: { x: 0, y: 22, w: 4, h: 4 } },
+    { id: 'sunburst_status', type: 'sunburst', title: 'Status Sunburst', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 4, y: 22, w: 4, h: 4 } },
+    { id: 'sankey_flow', type: 'sankey', title: 'Status Flow (Sankey)', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 8, y: 26, w: 4, h: 4 } },
+    { id: 'radar_priority', type: 'radar', title: 'Priority Radar', object: task, aggregate: 'count', categoryField: 'priority', layout: { x: 8, y: 22, w: 4, h: 4 } },
+    { id: 'waterfall_budget', type: 'waterfall', title: 'Budget Waterfall', object: project, aggregate: 'sum', valueField: 'budget', categoryField: 'status', layout: { x: 0, y: 26, w: 6, h: 4 } },
+
+    // ── Tabular ──────────────────────────────────────────────────────────
+    { id: 'table_projects', type: 'table', title: 'Projects Table', object: project, aggregate: 'count', layout: { x: 6, y: 26, w: 6, h: 4 } },
+    { id: 'pivot_tasks', type: 'pivot', title: 'Tasks Pivot', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 0, y: 30, w: 12, h: 4 } },
+
+    // ── Remaining chart families (full ChartType coverage) ───────────────
+    { id: 'bipolar_bar', type: 'bi-polar-bar', title: 'Bi-polar Bar', object: task, aggregate: 'count', categoryField: 'status', layout: { x: 0, y: 34, w: 3, h: 4 } },
+    { id: 'step_line', type: 'step-line', title: 'Step Line', object: task, aggregate: 'count', categoryField: 'created_at', categoryGranularity: 'week', layout: { x: 3, y: 34, w: 3, h: 4 } },
+    { id: 'solid_gauge', type: 'solid-gauge', title: 'Solid Gauge', object: task, aggregate: 'avg', valueField: 'progress', layout: { x: 6, y: 34, w: 3, h: 4 } },
+    { id: 'word_cloud', type: 'word-cloud', title: 'Label Cloud', object: task, aggregate: 'count', categoryField: 'labels', layout: { x: 9, y: 34, w: 3, h: 4 } },
+    { id: 'choropleth', type: 'choropleth', title: 'Choropleth', object: task, aggregate: 'count', categoryField: 'location', layout: { x: 0, y: 38, w: 4, h: 4 } },
+    { id: 'bubble_map', type: 'bubble-map', title: 'Bubble Map', object: task, aggregate: 'count', categoryField: 'location', layout: { x: 4, y: 38, w: 4, h: 4 } },
+    { id: 'gl_map', type: 'gl-map', title: 'GL Map', object: task, aggregate: 'count', categoryField: 'location', layout: { x: 8, y: 38, w: 4, h: 4 } },
+    { id: 'box_plot', type: 'box-plot', title: 'Estimate Box Plot', object: task, aggregate: 'avg', valueField: 'estimate_hours', categoryField: 'status', layout: { x: 0, y: 42, w: 3, h: 4 } },
+    { id: 'violin', type: 'violin', title: 'Estimate Violin', object: task, aggregate: 'avg', valueField: 'estimate_hours', categoryField: 'priority', layout: { x: 3, y: 42, w: 3, h: 4 } },
+    { id: 'candlestick', type: 'candlestick', title: 'Budget Candlestick', object: project, aggregate: 'sum', valueField: 'budget', categoryField: 'start_date', categoryGranularity: 'month', layout: { x: 6, y: 42, w: 3, h: 4 } },
+    { id: 'stock', type: 'stock', title: 'Spend Stock', object: project, aggregate: 'sum', valueField: 'spent', categoryField: 'start_date', categoryGranularity: 'month', layout: { x: 9, y: 42, w: 3, h: 4 } },
+  ],
+};

--- a/examples/app-showcase/src/dashboards/index.ts
+++ b/examples/app-showcase/src/dashboards/index.ts
@@ -1,0 +1,3 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+export { ChartGalleryDashboard } from './chart-gallery.dashboard.js';

--- a/examples/app-showcase/src/data/index.ts
+++ b/examples/app-showcase/src/data/index.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineDataset } from '@objectstack/spec/data';
+import { cel } from '@objectstack/spec';
+import { Account } from '../objects/account.object.js';
+import { Project } from '../objects/project.object.js';
+import { Task } from '../objects/task.object.js';
+import { Category } from '../objects/category.object.js';
+import { Team, ProjectMembership } from '../objects/team.object.js';
+
+/**
+ * Seed data sized to "feed every view": every Kanban column is populated,
+ * tasks carry due/start/end/created dates (calendar, gantt, timeline) and a
+ * work location (map), and projects span every status and health.
+ */
+
+const accounts = defineDataset(Account, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    { name: 'Northwind', industry: 'retail', annual_revenue: 8_000_000, website: 'https://northwind.example' },
+    { name: 'Contoso', industry: 'technology', annual_revenue: 25_000_000, website: 'https://contoso.example' },
+    { name: 'Fabrikam', industry: 'healthcare', annual_revenue: 12_000_000, website: 'https://fabrikam.example' },
+  ],
+});
+
+const projects = defineDataset(Project, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    { name: 'Website Relaunch', account: { externalId: 'Northwind' }, status: 'active', health: 'green', budget: 150_000, spent: 60_000, owner: 'ada@example.com', start_date: cel`daysAgo(30)`, end_date: cel`daysFromNow(60)` },
+    { name: 'Data Platform', account: { externalId: 'Contoso' }, status: 'active', health: 'yellow', budget: 600_000, spent: 420_000, owner: 'linus@example.com', start_date: cel`daysAgo(90)`, end_date: cel`daysFromNow(120)` },
+    { name: 'Compliance Audit', account: { externalId: 'Fabrikam' }, status: 'on_hold', health: 'red', budget: 90_000, spent: 88_000, owner: 'grace@example.com', start_date: cel`daysAgo(15)`, end_date: cel`daysFromNow(30)` },
+    { name: 'Mobile App', account: { externalId: 'Contoso' }, status: 'planned', health: 'green', budget: 200_000, spent: 0, owner: 'ada@example.com', start_date: cel`daysFromNow(14)`, end_date: cel`daysFromNow(140)` },
+    { name: 'Legacy Sunset', account: { externalId: 'Northwind' }, status: 'completed', health: 'green', budget: 50_000, spent: 48_000, owner: 'linus@example.com', start_date: cel`daysAgo(180)`, end_date: cel`daysAgo(20)` },
+  ],
+});
+
+// Tasks across all five board columns, with dates + locations to drive every view.
+const tasks = defineDataset(Task, {
+  mode: 'upsert',
+  externalId: 'title',
+  records: [
+    { title: 'Audit current IA', project: { externalId: 'Website Relaunch' }, assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 8, progress: 100, done: true, created_at: cel`daysAgo(20)`, start_date: cel`daysAgo(20)`, end_date: cel`daysAgo(18)`, due_date: cel`daysAgo(18)` },
+    { title: 'Design system', project: { externalId: 'Website Relaunch' }, assignee: 'ada@example.com', status: 'in_review', priority: 'high', estimate_hours: 24, progress: 80, done: false, created_at: cel`daysAgo(14)`, start_date: cel`daysAgo(12)`, end_date: cel`daysFromNow(2)`, due_date: cel`daysFromNow(2)` },
+    { title: 'Build homepage', project: { externalId: 'Website Relaunch' }, assignee: 'sam@example.com', status: 'in_progress', priority: 'high', estimate_hours: 40, progress: 45, done: false, created_at: cel`daysAgo(8)`, start_date: cel`daysAgo(6)`, end_date: cel`daysFromNow(10)`, due_date: cel`daysFromNow(10)` },
+    { title: 'SEO migration plan', project: { externalId: 'Website Relaunch' }, assignee: 'sam@example.com', status: 'todo', priority: 'medium', estimate_hours: 16, progress: 0, done: false, created_at: cel`daysAgo(3)`, start_date: cel`daysFromNow(5)`, end_date: cel`daysFromNow(15)`, due_date: cel`daysFromNow(15)` },
+    { title: 'Content backlog', project: { externalId: 'Website Relaunch' }, assignee: 'grace@example.com', status: 'backlog', priority: 'low', estimate_hours: 12, progress: 0, done: false, created_at: cel`daysAgo(2)`, due_date: cel`daysFromNow(30)` },
+    { title: 'Ingest pipeline', project: { externalId: 'Data Platform' }, assignee: 'linus@example.com', status: 'in_progress', priority: 'urgent', estimate_hours: 60, progress: 55, done: false, created_at: cel`daysAgo(40)`, start_date: cel`daysAgo(35)`, end_date: cel`daysFromNow(20)`, due_date: cel`daysFromNow(20)` },
+    { title: 'Warehouse schema', project: { externalId: 'Data Platform' }, assignee: 'linus@example.com', status: 'in_review', priority: 'high', estimate_hours: 30, progress: 90, done: false, created_at: cel`daysAgo(25)`, start_date: cel`daysAgo(22)`, end_date: cel`daysFromNow(3)`, due_date: cel`daysFromNow(3)` },
+    { title: 'PII access review', project: { externalId: 'Compliance Audit' }, assignee: 'grace@example.com', status: 'todo', priority: 'urgent', estimate_hours: 20, progress: 0, done: false, created_at: cel`daysAgo(5)`, start_date: cel`daysFromNow(2)`, end_date: cel`daysFromNow(12)`, due_date: cel`daysFromNow(12)` },
+    { title: 'Evidence collection', project: { externalId: 'Compliance Audit' }, assignee: 'grace@example.com', status: 'backlog', priority: 'medium', estimate_hours: 18, progress: 0, done: false, created_at: cel`daysAgo(1)`, due_date: cel`daysFromNow(25)` },
+    { title: 'App wireframes', project: { externalId: 'Mobile App' }, assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 16, progress: 100, done: true, created_at: cel`daysAgo(10)`, start_date: cel`daysAgo(10)`, end_date: cel`daysAgo(6)`, due_date: cel`daysAgo(6)` },
+  ],
+});
+
+const categories = defineDataset(Category, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    { name: 'Engineering', sort_order: 1, color: '#3B82F6' },
+    { name: 'Frontend', parent: { externalId: 'Engineering' }, sort_order: 1, color: '#06B6D4' },
+    { name: 'Backend', parent: { externalId: 'Engineering' }, sort_order: 2, color: '#8B5CF6' },
+    { name: 'Operations', sort_order: 2, color: '#10B981' },
+  ],
+});
+
+const teams = defineDataset(Team, {
+  mode: 'upsert',
+  externalId: 'name',
+  records: [
+    { name: 'Platform', lead: 'linus@example.com', capacity_hours: 200 },
+    { name: 'Experience', lead: 'ada@example.com', capacity_hours: 160 },
+  ],
+});
+
+const memberships = defineDataset(ProjectMembership, {
+  mode: 'insert',
+  records: [
+    { team: { externalId: 'Experience' }, project: { externalId: 'Website Relaunch' }, role: 'owner', allocation_percent: 80 },
+    { team: { externalId: 'Platform' }, project: { externalId: 'Data Platform' }, role: 'owner', allocation_percent: 100 },
+    { team: { externalId: 'Platform' }, project: { externalId: 'Website Relaunch' }, role: 'contributor', allocation_percent: 20 },
+  ],
+});
+
+export const ShowcaseSeedData = [accounts, projects, tasks, categories, teams, memberships];

--- a/examples/app-showcase/src/datasources/index.ts
+++ b/examples/app-showcase/src/datasources/index.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/** Primary datasource — in-memory SQLite for the example. */
+export const ShowcaseDatasource = {
+  name: 'showcase_primary',
+  label: 'Showcase Primary Database',
+  driver: 'sqlite',
+  config: { filename: ':memory:' },
+  pool: { min: 1, max: 5 },
+  active: true,
+};
+
+export const allDatasources = [ShowcaseDatasource];

--- a/examples/app-showcase/src/emails/index.ts
+++ b/examples/app-showcase/src/emails/index.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/** Email template fired by the Task Completed flow. */
+export const TaskDoneEmail = {
+  name: 'showcase_task_done_email',
+  label: 'Task Done Notification',
+  category: 'workflow' as const,
+  locale: 'en',
+  subject: '✅ Task done: {{title}}',
+  bodyHtml: '<p>The task <strong>{{title}}</strong> on project {{project}} was marked done.</p>',
+  bodyText: 'The task {{title}} on project {{project}} was marked done.',
+  variables: [
+    { name: 'title', type: 'string' as const, required: true, description: 'Task title' },
+    { name: 'project', type: 'string' as const, required: false, description: 'Project name' },
+  ],
+  active: true,
+  isSystem: false,
+};
+
+export const allEmails = [TaskDoneEmail];

--- a/examples/app-showcase/src/flows/index.ts
+++ b/examples/app-showcase/src/flows/index.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineFlow } from '@objectstack/spec';
+
+/**
+ * Task Completed → Notify — an autolaunched, record-triggered flow that fires
+ * when a task transitions to Done and emails the project owner.
+ */
+export const TaskCompletedFlow = defineFlow({
+  name: 'showcase_task_completed',
+  label: 'Notify on Task Completed',
+  description: 'Emails the project owner when a task is marked Done.',
+  type: 'autolaunched',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'On Task Update',
+      config: {
+        objectName: 'showcase_task',
+        triggerType: 'record-after-update',
+        condition: 'status == "done" && previous.status != "done"',
+      },
+    },
+    {
+      id: 'notify',
+      type: 'script',
+      label: 'Send Completion Email',
+      config: {
+        actionType: 'email',
+        inputs: {
+          to: '{record.project.owner}',
+          subject: '✅ Task done: {record.title}',
+          template: 'showcase_task_done_email',
+        },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'notify' },
+    { id: 'e2', source: 'notify', target: 'end' },
+  ],
+});
+
+/**
+ * Reassign Wizard — a screen flow launched from the Tasks toolbar action
+ * (`showcase_bulk_reassign`). Collects a new assignee and writes it back.
+ */
+export const ReassignWizardFlow = defineFlow({
+  name: 'showcase_reassign_wizard',
+  label: 'Reassign Task',
+  description: 'Screen flow that reassigns a task to a new owner.',
+  type: 'screen',
+  status: 'active',
+  runAs: 'user',
+  variables: [
+    { name: 'recordId', type: 'text', isInput: true, isOutput: false },
+    { name: 'new_assignee', type: 'text', isInput: true, isOutput: false },
+  ],
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    {
+      id: 'collect',
+      type: 'screen',
+      label: 'New Assignee',
+      config: {
+        fields: [
+          { name: 'new_assignee', label: 'New Assignee', type: 'text', required: true },
+        ],
+      },
+    },
+    {
+      id: 'apply',
+      type: 'update_record',
+      label: 'Apply Reassignment',
+      config: {
+        objectName: 'showcase_task',
+        filter: { id: '{recordId}' },
+        fields: { assignee: '{new_assignee}' },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'collect' },
+    { id: 'e2', source: 'collect', target: 'apply' },
+    { id: 'e3', source: 'apply', target: 'end' },
+  ],
+});
+
+export const allFlows = [TaskCompletedFlow, ReassignWizardFlow];

--- a/examples/app-showcase/src/jobs/index.ts
+++ b/examples/app-showcase/src/jobs/index.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineJob } from '@objectstack/spec';
+
+/** Nightly job — recompute project health. Handler is registered in defineStack({ functions }). */
+export const HealthSweepJob = defineJob({
+  name: 'showcase_health_sweep',
+  label: 'Nightly Project Health Sweep',
+  description: 'Recomputes project health from budget burn and task progress.',
+  schedule: { type: 'cron', expression: '0 1 * * *', timezone: 'UTC' },
+  handler: 'sweepProjectHealth',
+  retryPolicy: { maxRetries: 2, backoffMs: 5000, backoffMultiplier: 2 },
+  timeout: 300000,
+  enabled: true,
+});
+
+export const allJobs = [HealthSweepJob];

--- a/examples/app-showcase/src/objects/account.object.ts
+++ b/examples/app-showcase/src/objects/account.object.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * Account — a customer org. Lookup target for projects and the field zoo.
+ */
+export const Account = ObjectSchema.create({
+  name: 'showcase_account',
+  label: 'Account',
+  pluralLabel: 'Accounts',
+  icon: 'building',
+  description: 'A company the org delivers projects for.',
+
+  fields: {
+    name: Field.text({ label: 'Account Name', required: true, searchable: true, maxLength: 200 }),
+    industry: Field.select({
+      label: 'Industry',
+      options: [
+        { label: 'Technology', value: 'technology', default: true },
+        { label: 'Finance', value: 'finance' },
+        { label: 'Healthcare', value: 'healthcare' },
+        { label: 'Retail', value: 'retail' },
+      ],
+    }),
+    annual_revenue: Field.currency({ label: 'Annual Revenue', scale: 2, min: 0 }),
+    website: Field.url({ label: 'Website' }),
+    hq: Field.location({ label: 'Headquarters' }),
+  },
+});

--- a/examples/app-showcase/src/objects/category.object.ts
+++ b/examples/app-showcase/src/objects/category.object.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * Category — a self-referencing hierarchy (tree). `parent` points back at
+ * the same object, exercising recursive/hierarchical relationships.
+ */
+export const Category = ObjectSchema.create({
+  name: 'showcase_category',
+  label: 'Category',
+  pluralLabel: 'Categories',
+  icon: 'list-tree',
+  description: 'Hierarchical tagging tree — demonstrates self-referencing relations.',
+
+  fields: {
+    name: Field.text({ label: 'Name', required: true, searchable: true, maxLength: 120 }),
+    parent: Field.lookup('showcase_category', { label: 'Parent Category' }),
+    color: Field.color({ label: 'Color' }),
+    sort_order: Field.number({ label: 'Sort Order', min: 0, defaultValue: 0 }),
+  },
+});

--- a/examples/app-showcase/src/objects/field-zoo.object.ts
+++ b/examples/app-showcase/src/objects/field-zoo.object.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { cel } from '@objectstack/spec';
+
+/**
+ * Field Zoo — one field of (almost) every `FieldType` the protocol defines.
+ *
+ * This is a synthetic "standard" object whose only job is exhaustive
+ * data-layer coverage: the {@link COVERAGE} manifest and the coverage test
+ * assert that every member of `FieldTypeSchema` appears at least once across
+ * the stack, and this object carries the bulk of them. Builder helpers
+ * (`Field.text(...)`) are used where they exist; the remaining types are
+ * declared as raw `{ type, ... }` literals (the field input is
+ * `Omit<Partial<Field>, 'type'>`, so any valid type string is accepted).
+ *
+ * Relationship types (`lookup`, `master_detail`, `tree`) point at the other
+ * showcase objects so $expand and hierarchy resolution have real targets.
+ */
+export const FieldZoo = ObjectSchema.create({
+  name: 'showcase_field_zoo',
+  label: 'Field Zoo',
+  pluralLabel: 'Field Zoo',
+  icon: 'shapes',
+  description: 'One field of every supported type — exhaustive data-layer coverage.',
+
+  fields: {
+    // ── Core text ───────────────────────────────────────────────────────
+    name: Field.text({ label: 'Name', required: true, searchable: true, maxLength: 200 }),
+    f_textarea: Field.textarea({ label: 'Textarea' }),
+    f_email: Field.email({ label: 'Email', searchable: true }),
+    f_url: Field.url({ label: 'URL' }),
+    f_phone: Field.phone({ label: 'Phone' }),
+    f_password: Field.password({ label: 'Password (one-way hash)' }),
+    f_secret: Field.secret({ label: 'Secret (encrypted at rest)' }),
+
+    // ── Rich content ─────────────────────────────────────────────────────
+    f_markdown: Field.markdown({ label: 'Markdown' }),
+    f_html: Field.html({ label: 'HTML' }),
+    f_richtext: Field.richtext({ label: 'Rich Text' }),
+
+    // ── Numbers ──────────────────────────────────────────────────────────
+    f_number: Field.number({ label: 'Number', min: 0, max: 1000 }),
+    f_currency: Field.currency({ label: 'Currency', scale: 2, min: 0 }),
+    f_percent: Field.percent({ label: 'Percent', min: 0, max: 100, defaultValue: 50 }),
+
+    // ── Date & time ──────────────────────────────────────────────────────
+    f_date: Field.date({ label: 'Date' }),
+    f_datetime: Field.datetime({ label: 'Date / Time' }),
+    f_time: { type: 'time', label: 'Time' },
+
+    // ── Logic ────────────────────────────────────────────────────────────
+    f_boolean: Field.boolean({ label: 'Boolean' }),
+    f_toggle: { type: 'toggle', label: 'Toggle', defaultValue: false },
+
+    // ── Selection ────────────────────────────────────────────────────────
+    f_select: Field.select({
+      label: 'Select',
+      options: [
+        { label: 'Low', value: 'low', default: true, color: '#94A3B8' },
+        { label: 'Medium', value: 'medium', color: '#F59E0B' },
+        { label: 'High', value: 'high', color: '#EF4444' },
+      ],
+    }),
+    f_multiselect: {
+      type: 'multiselect',
+      label: 'Multi-select',
+      options: [
+        { label: 'Red', value: 'red' },
+        { label: 'Green', value: 'green' },
+        { label: 'Blue', value: 'blue' },
+      ],
+    },
+    f_radio: {
+      type: 'radio',
+      label: 'Radio',
+      options: [
+        { label: 'Yes', value: 'yes' },
+        { label: 'No', value: 'no' },
+      ],
+    },
+    f_checkboxes: {
+      type: 'checkboxes',
+      label: 'Checkboxes',
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'SMS', value: 'sms' },
+        { label: 'Push', value: 'push' },
+      ],
+    },
+    f_tags: { type: 'tags', label: 'Tags' },
+
+    // ── Relational ───────────────────────────────────────────────────────
+    f_lookup: Field.lookup('showcase_account', { label: 'Lookup → Account' }),
+    f_master_detail: Field.masterDetail('showcase_project', { label: 'Master-Detail → Project' }),
+    f_tree: { type: 'tree', label: 'Tree (self/category)', reference: 'showcase_category' },
+
+    // ── Media ────────────────────────────────────────────────────────────
+    f_image: Field.image({ label: 'Image' }),
+    f_file: Field.file({ label: 'File' }),
+    f_avatar: Field.avatar({ label: 'Avatar' }),
+    f_video: { type: 'video', label: 'Video' },
+    f_audio: { type: 'audio', label: 'Audio' },
+
+    // ── Calculated / system ──────────────────────────────────────────────
+    f_formula: Field.formula({
+      label: 'Formula (number × percent)',
+      expression: cel`(f_number == null ? 0 : f_number) * (f_percent == null ? 0 : f_percent) / 100`,
+    }),
+    f_summary: Field.summary({ label: 'Roll-up Summary' }),
+    f_autonumber: Field.autonumber({ label: 'Auto Number' }),
+
+    // ── Embedded structured values (stored as JSON on the row) ───────────
+    f_composite: { type: 'composite', label: 'Composite (embedded object)' },
+    f_repeater: { type: 'repeater', label: 'Repeater (embedded array)' },
+    f_record: { type: 'record', label: 'Record (name-keyed map)' },
+
+    // ── Enhanced types ───────────────────────────────────────────────────
+    f_location: Field.location({ label: 'Location (GPS)' }),
+    f_address: Field.address({ label: 'Address' }),
+    f_code: Field.code('json', { label: 'Code Editor' }),
+    f_json: Field.json({ label: 'JSON' }),
+    f_color: Field.color({ label: 'Color' }),
+    f_rating: Field.rating(5, { label: 'Rating' }),
+    f_slider: Field.slider({ label: 'Slider', min: 0, max: 100, step: 5 }),
+    f_signature: Field.signature({ label: 'Signature' }),
+    f_qrcode: Field.qrcode({ label: 'QR / Barcode' }),
+    f_progress: { type: 'progress', label: 'Progress', min: 0, max: 100 },
+
+    // ── AI / ML ──────────────────────────────────────────────────────────
+    f_vector: Field.vector(1536, { label: 'Embedding Vector' }),
+  },
+});

--- a/examples/app-showcase/src/objects/index.ts
+++ b/examples/app-showcase/src/objects/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+export { Account } from './account.object.js';
+export { Project } from './project.object.js';
+export { Task } from './task.object.js';
+export { Category } from './category.object.js';
+export { Team, ProjectMembership } from './team.object.js';
+export { FieldZoo } from './field-zoo.object.js';

--- a/examples/app-showcase/src/objects/project.object.ts
+++ b/examples/app-showcase/src/objects/project.object.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+import { cel, P } from '@objectstack/spec';
+
+/**
+ * Project — the realistic backbone object. Demonstrates lookup relations,
+ * a formula field, a select that drives Kanban grouping, date fields that
+ * drive Gantt/timeline views, validations, and a status state machine.
+ */
+export const Project = ObjectSchema.create({
+  name: 'showcase_project',
+  label: 'Project',
+  pluralLabel: 'Projects',
+  icon: 'folder-kanban',
+  description: 'A delivery project for an account.',
+
+  fields: {
+    name: Field.text({ label: 'Project Name', required: true, searchable: true, maxLength: 200 }),
+    account: Field.lookup('showcase_account', { label: 'Account', required: true }),
+    status: Field.select({
+      label: 'Status',
+      required: true,
+      options: [
+        { label: 'Planned', value: 'planned', default: true, color: '#94A3B8' },
+        { label: 'Active', value: 'active', color: '#3B82F6' },
+        { label: 'On Hold', value: 'on_hold', color: '#F59E0B' },
+        { label: 'Completed', value: 'completed', color: '#10B981' },
+        { label: 'Cancelled', value: 'cancelled', color: '#EF4444' },
+      ],
+    }),
+    health: Field.select({
+      label: 'Health',
+      options: [
+        { label: 'Green', value: 'green', default: true, color: '#10B981' },
+        { label: 'Yellow', value: 'yellow', color: '#F59E0B' },
+        { label: 'Red', value: 'red', color: '#EF4444' },
+      ],
+    }),
+    budget: Field.currency({ label: 'Budget', scale: 2, min: 0 }),
+    spent: Field.currency({ label: 'Spent', scale: 2, min: 0, defaultValue: 0 }),
+    budget_remaining: Field.formula({
+      label: 'Budget Remaining',
+      expression: cel`(budget == null ? 0 : budget) - (spent == null ? 0 : spent)`,
+    }),
+    start_date: Field.date({ label: 'Start Date' }),
+    end_date: Field.date({ label: 'Target End Date' }),
+    owner: Field.text({ label: 'Owner', maxLength: 200 }),
+    summary: Field.summary({ label: 'Open Tasks' }),
+  },
+
+  validations: [
+    {
+      type: 'cross_field' as const,
+      name: 'end_after_start',
+      label: 'End After Start',
+      description: 'Target end date must be on or after the start date.',
+      fields: ['start_date', 'end_date'],
+      condition: P`has(start_date) && has(end_date) && end_date < start_date`,
+      message: 'Target End Date must be on or after the Start Date.',
+    },
+    {
+      type: 'script' as const,
+      name: 'spent_within_budget',
+      label: 'Spend Within 120% of Budget',
+      description: 'Flag projects spending more than 120% of budget.',
+      condition: P`budget != null && spent != null && spent > budget * 1.2`,
+      message: 'Spend exceeds 120% of budget — escalate before continuing.',
+      severity: 'error' as const,
+    },
+    {
+      type: 'state_machine' as const,
+      name: 'project_status_flow',
+      label: 'Project Status Flow',
+      description: 'Projects progress through valid status transitions.',
+      field: 'status',
+      message: 'Invalid project status transition.',
+      transitions: {
+        planned: ['active', 'cancelled'],
+        active: ['on_hold', 'completed', 'cancelled'],
+        on_hold: ['active', 'cancelled'],
+        completed: [],
+        cancelled: ['planned'],
+      },
+    },
+  ],
+});

--- a/examples/app-showcase/src/objects/task.object.ts
+++ b/examples/app-showcase/src/objects/task.object.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * Task — a master-detail child of Project. This object is the primary
+ * subject of the view gallery: its fields are chosen so a single object can
+ * back all eight list-view types —
+ *
+ *   • `status`  → Kanban grouping
+ *   • `due_date` → Calendar
+ *   • `created_at` → Timeline
+ *   • `start_date` / `end_date` → Gantt
+ *   • `location` → Map
+ *   • `cover` → Gallery cards
+ *   • plus Grid and an aggregate Chart view
+ */
+export const Task = ObjectSchema.create({
+  name: 'showcase_task',
+  label: 'Task',
+  pluralLabel: 'Tasks',
+  icon: 'check-square',
+  description: 'A unit of work inside a project.',
+
+  fields: {
+    title: Field.text({ label: 'Title', required: true, searchable: true, maxLength: 200 }),
+    project: Field.masterDetail('showcase_project', { label: 'Project', required: true }),
+    assignee: Field.text({ label: 'Assignee', maxLength: 200 }),
+    status: Field.select({
+      label: 'Status',
+      required: true,
+      options: [
+        { label: 'Backlog', value: 'backlog', default: true, color: '#94A3B8' },
+        { label: 'To Do', value: 'todo', color: '#3B82F6' },
+        { label: 'In Progress', value: 'in_progress', color: '#F59E0B' },
+        { label: 'In Review', value: 'in_review', color: '#8B5CF6' },
+        { label: 'Done', value: 'done', color: '#10B981' },
+      ],
+    }),
+    priority: Field.select({
+      label: 'Priority',
+      options: [
+        { label: 'Low', value: 'low', color: '#94A3B8' },
+        { label: 'Medium', value: 'medium', default: true, color: '#3B82F6' },
+        { label: 'High', value: 'high', color: '#F59E0B' },
+        { label: 'Urgent', value: 'urgent', color: '#EF4444' },
+      ],
+    }),
+    estimate_hours: Field.number({ label: 'Estimate (h)', min: 0, max: 1000 }),
+    progress: { type: 'progress', label: 'Progress', min: 0, max: 100, defaultValue: 0 },
+    done: Field.boolean({ label: 'Done', defaultValue: false }),
+    due_date: Field.date({ label: 'Due Date' }),
+    start_date: Field.date({ label: 'Start Date' }),
+    end_date: Field.date({ label: 'End Date' }),
+    created_at: Field.datetime({ label: 'Created At' }),
+    location: Field.location({ label: 'Work Location' }),
+    cover: Field.image({ label: 'Cover Image' }),
+    labels: { type: 'tags', label: 'Labels' },
+    notes: Field.textarea({ label: 'Notes' }),
+  },
+
+  validations: [
+    {
+      type: 'state_machine' as const,
+      name: 'task_status_flow',
+      label: 'Task Status Flow',
+      description: 'Tasks move forward through the board (reopen allowed from Done).',
+      field: 'status',
+      message: 'Invalid task status transition.',
+      transitions: {
+        backlog: ['todo'],
+        todo: ['in_progress', 'backlog'],
+        in_progress: ['in_review', 'todo'],
+        in_review: ['done', 'in_progress'],
+        done: ['in_progress'],
+      },
+    },
+  ],
+});

--- a/examples/app-showcase/src/objects/team.object.ts
+++ b/examples/app-showcase/src/objects/team.object.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { ObjectSchema, Field } from '@objectstack/spec/data';
+
+/**
+ * Team and ProjectMembership — a many-to-many relationship modelled with a
+ * junction object. A Team can staff many Projects and a Project can be
+ * staffed by many Teams; `showcase_project_membership` is the join row.
+ */
+export const Team = ObjectSchema.create({
+  name: 'showcase_team',
+  label: 'Team',
+  pluralLabel: 'Teams',
+  icon: 'users',
+  description: 'A delivery team that can be assigned to many projects.',
+
+  fields: {
+    name: Field.text({ label: 'Team Name', required: true, searchable: true, maxLength: 120 }),
+    lead: Field.text({ label: 'Team Lead', maxLength: 200 }),
+    capacity_hours: Field.number({ label: 'Weekly Capacity (h)', min: 0, defaultValue: 160 }),
+  },
+});
+
+/** Junction row joining Team ↔ Project (many-to-many). */
+export const ProjectMembership = ObjectSchema.create({
+  name: 'showcase_project_membership',
+  label: 'Project Membership',
+  pluralLabel: 'Project Memberships',
+  icon: 'link',
+  description: 'Join object linking teams to projects (many-to-many).',
+
+  fields: {
+    team: Field.masterDetail('showcase_team', { label: 'Team', required: true }),
+    project: Field.masterDetail('showcase_project', { label: 'Project', required: true }),
+    role: Field.select({
+      label: 'Role',
+      options: [
+        { label: 'Owner', value: 'owner', default: true },
+        { label: 'Contributor', value: 'contributor' },
+        { label: 'Reviewer', value: 'reviewer' },
+      ],
+    }),
+    allocation_percent: Field.percent({ label: 'Allocation', min: 0, max: 100, defaultValue: 100 }),
+  },
+});

--- a/examples/app-showcase/src/pages/index.ts
+++ b/examples/app-showcase/src/pages/index.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Page } from '@objectstack/spec/ui';
+
+/**
+ * Component Gallery — a custom page that places a spread of standard page
+ * components (header, card, tabs, text/number/image/divider/button elements,
+ * and the AI chat window) so the page renderer and component registry can be
+ * exercised visually.
+ */
+export const ComponentGalleryPage: Page = {
+  name: 'showcase_component_gallery',
+  label: 'Component Gallery',
+  type: 'home',
+  template: 'header-sidebar-main',
+  isDefault: true,
+  kind: 'full',
+  regions: [
+    {
+      name: 'header',
+      width: 'full',
+      components: [
+        {
+          type: 'page:header',
+          properties: {
+            title: 'ObjectStack Showcase',
+            subtitle: 'Every metadata type, every view, every chart — in one workspace.',
+          },
+        },
+      ],
+    },
+    {
+      name: 'main',
+      width: 'large',
+      components: [
+        { type: 'element:text', properties: { content: 'This page demonstrates the standard page component set. Open the navigation to explore objects, the 8 list-view types on Tasks, the Chart Gallery dashboard, and the four report types.' } },
+        { type: 'element:divider', properties: {} },
+        { type: 'page:card', properties: { title: 'Getting Started' } },
+        { type: 'element:number', properties: { label: 'Demo Tasks', value: 12 } },
+        { type: 'element:image', properties: { src: 'https://objectstack.ai/logo.png', alt: 'Logo' } },
+        { type: 'element:button', properties: { label: 'Create Task', actionName: 'showcase_new_task' } },
+      ],
+    },
+    {
+      name: 'sidebar',
+      width: 'small',
+      components: [
+        { type: 'ai:chat_window', properties: { agentName: 'showcase_assistant' } },
+      ],
+    },
+  ],
+};

--- a/examples/app-showcase/src/portals/index.ts
+++ b/examples/app-showcase/src/portals/index.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Client Portal — an external-user projection of the showcase. Demonstrates
+ * the portal kind discriminator, profile scoping, and view-backed navigation.
+ */
+export const ClientPortal = {
+  kind: 'portal' as const,
+  id: 'showcase_client_portal',
+  label: 'Client Portal',
+  description: 'External portal for clients to track their projects.',
+  routePrefix: '/portal/client',
+  layout: 'minimal',
+  authMode: 'magic-link',
+  locale: 'auto',
+  profiles: ['client_portal_user'],
+  seo: { title: 'Client Portal — Showcase', description: 'Track your projects.', robots: 'noindex' as const },
+  navigation: [
+    { type: 'view' as const, id: 'my_projects', label: 'My Projects', icon: 'folder-kanban', order: 1, viewRef: 'showcase_project.list' },
+    { type: 'view' as const, id: 'my_tasks', label: 'My Tasks', icon: 'check-square', order: 2, viewRef: 'showcase_task.grid' },
+  ],
+};
+
+export const allPortals = [ClientPortal];

--- a/examples/app-showcase/src/reports/index.ts
+++ b/examples/app-showcase/src/reports/index.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Report } from '@objectstack/spec/ui';
+
+const task = 'showcase_task';
+
+/** 1 ── Tabular: a flat list of records. */
+export const TaskListReport: Report = {
+  name: 'showcase_task_list',
+  label: 'Task List (Tabular)',
+  description: 'Flat list of all tasks.',
+  objectName: task,
+  type: 'tabular',
+  columns: [
+    { field: 'title', label: 'Title' },
+    { field: 'project', label: 'Project' },
+    { field: 'assignee', label: 'Assignee' },
+    { field: 'status', label: 'Status' },
+    { field: 'estimate_hours', label: 'Estimate' },
+  ],
+};
+
+/** 2 ── Summary: grouped down by status with a sum. */
+export const HoursByStatusReport: Report = {
+  name: 'showcase_hours_by_status',
+  label: 'Hours by Status (Summary)',
+  description: 'Estimated hours grouped by task status.',
+  objectName: task,
+  type: 'summary',
+  columns: [
+    { field: 'status', label: 'Status' },
+    { field: 'estimate_hours', label: 'Hours', aggregate: 'sum' },
+  ],
+  groupingsDown: [{ field: 'status', sortOrder: 'asc' }],
+};
+
+/** 3 ── Matrix: status (down) × priority (across) cross-tab. */
+export const StatusPriorityMatrixReport: Report = {
+  name: 'showcase_status_priority_matrix',
+  label: 'Status × Priority (Matrix)',
+  description: 'Task counts cross-tabulated by status and priority.',
+  objectName: task,
+  type: 'matrix',
+  columns: [{ field: 'estimate_hours', label: 'Hours', aggregate: 'sum' }],
+  groupingsDown: [{ field: 'status', sortOrder: 'asc' }],
+  groupingsAcross: [{ field: 'priority', sortOrder: 'asc' }],
+};
+
+/** 4 ── Joined: multiple stacked blocks in one report. */
+export const TaskOverviewReport: Report = {
+  name: 'showcase_task_overview',
+  label: 'Task Overview (Joined)',
+  description: 'Multiple task sub-reports stacked into one joined view.',
+  objectName: task,
+  type: 'joined',
+  columns: [],
+  blocks: [
+    {
+      name: 'open_block',
+      label: 'Open Tasks',
+      type: 'summary',
+      objectName: task,
+      columns: [{ field: 'estimate_hours', label: 'Hours', aggregate: 'sum' }],
+      groupingsDown: [{ field: 'status', sortOrder: 'asc' }],
+      filter: { done: false },
+    },
+    {
+      name: 'done_block',
+      label: 'Completed Tasks',
+      type: 'tabular',
+      objectName: task,
+      columns: [
+        { field: 'title', label: 'Title' },
+        { field: 'assignee', label: 'Assignee' },
+      ],
+      filter: { done: true },
+    },
+  ],
+};
+
+export const allReports = [
+  TaskListReport,
+  HoursByStatusReport,
+  StatusPriorityMatrixReport,
+  TaskOverviewReport,
+];

--- a/examples/app-showcase/src/security/index.ts
+++ b/examples/app-showcase/src/security/index.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Security capability chain — a role hierarchy, a permission set that layers
+ * object CRUD + field-level security (FLS) + row-level security (RLS), two
+ * sharing rules (criteria- and owner-based), and an org security policy.
+ * Together these exercise RBAC, FLS, RLS, and sharing in one place. These are
+ * plain objects validated by `defineStack` (which coerces string predicates
+ * and fills CRUD defaults).
+ */
+
+// ── Roles (hierarchy) ──────────────────────────────────────────────────────
+export const ContributorRole = {
+  name: 'contributor',
+  label: 'Contributor',
+  description: 'Works tasks on their own projects.',
+};
+
+export const ManagerRole = {
+  name: 'manager',
+  label: 'Project Manager',
+  description: 'Manages projects and the contributors on them.',
+  parent: 'contributor',
+};
+
+export const ExecRole = {
+  name: 'exec',
+  label: 'Executive',
+  description: 'Read-all visibility for reporting.',
+  parent: 'manager',
+};
+
+// ── Permission set: CRUD + FLS + RLS ──────────────────────────────────────
+export const ContributorPermissionSet = {
+  name: 'showcase_contributor',
+  label: 'Showcase Contributor',
+  description: 'Standard access for contributors, with budget fields hidden and row-level scoping to own records.',
+  isProfile: false,
+  objects: {
+    showcase_project: { allowRead: true, allowCreate: false, allowEdit: true, allowDelete: false },
+    showcase_task: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: false },
+    showcase_account: { allowRead: true, allowCreate: false, allowEdit: false, allowDelete: false },
+  },
+  // Field-level security — contributors can read but not edit budget figures.
+  fields: {
+    budget: { readable: true, editable: false },
+    spent: { readable: true, editable: false },
+    budget_remaining: { readable: true, editable: false },
+  },
+  // Row-level security — contributors only see tasks assigned to them.
+  rowLevelSecurity: [
+    {
+      name: 'task_own_rows',
+      label: 'Own Tasks Only',
+      description: 'Contributors can only select tasks assigned to them.',
+      object: 'showcase_task',
+      operation: 'select' as const,
+      using: "assignee == current_user.name",
+      roles: ['contributor'],
+      enabled: true,
+      priority: 10,
+    },
+  ],
+};
+
+// ── Sharing rules ──────────────────────────────────────────────────────────
+/** criteria-based: red-health projects are shared up to executives. */
+export const RedProjectSharingRule = {
+  type: 'criteria' as const,
+  name: 'share_red_projects_with_execs',
+  label: 'Red Projects → Executives',
+  description: 'Automatically share at-risk (red health) projects with executives.',
+  object: 'showcase_project',
+  condition: "record.health == 'red'",
+  accessLevel: 'read' as const,
+  sharedWith: { type: 'role' as const, value: 'exec' },
+  active: true,
+};
+
+/** owner-based: a contributor's tasks are shared read-only with managers. */
+export const ContributorTaskSharingRule = {
+  type: 'owner' as const,
+  name: 'share_contributor_tasks_with_manager',
+  label: "Contributor Tasks → Manager",
+  description: "Share each contributor's tasks with managers for oversight.",
+  object: 'showcase_task',
+  ownedBy: { type: 'role' as const, value: 'contributor' },
+  accessLevel: 'read' as const,
+  sharedWith: { type: 'role' as const, value: 'manager' },
+  active: true,
+};
+
+// ── Org security policy ─────────────────────────────────────────────────────
+export const ShowcasePolicy = {
+  name: 'showcase_default_policy',
+  password: {
+    minLength: 12,
+    requireUppercase: true,
+    requireLowercase: true,
+    requireNumbers: true,
+    requireSymbols: true,
+    expirationDays: 90,
+    historyCount: 5,
+  },
+  session: { idleTimeout: 30, absoluteTimeout: 480, forceMfa: false },
+  audit: { logRetentionDays: 365, sensitiveFields: ['budget', 'spent'], captureRead: false },
+  isDefault: true,
+};
+
+export const allRoles = [ContributorRole, ManagerRole, ExecRole];
+export const allPermissionSets = [ContributorPermissionSet];
+export const allSharingRules = [RedProjectSharingRule, ContributorTaskSharingRule];
+export const allPolicies = [ShowcasePolicy];

--- a/examples/app-showcase/src/themes/index.ts
+++ b/examples/app-showcase/src/themes/index.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+const colors = {
+  primary: '#7C3AED',
+  secondary: '#6C757D',
+  accent: '#06B6D4',
+  background: '#FFFFFF',
+  surface: '#F8F9FA',
+  text: '#1F2937',
+  textSecondary: '#6B7280',
+  border: '#E5E7EB',
+  success: '#10B981',
+  warning: '#F59E0B',
+  error: '#EF4444',
+  info: '#3B82F6',
+};
+
+export const ShowcaseLightTheme = {
+  name: 'showcase_light',
+  label: 'Showcase Light',
+  description: 'Default showcase theme — violet accent, light mode.',
+  mode: 'light' as const,
+  colors,
+};
+
+export const ShowcaseDarkTheme = {
+  name: 'showcase_dark',
+  label: 'Showcase Dark',
+  description: 'Showcase theme — dark mode.',
+  mode: 'dark' as const,
+  colors: { ...colors, background: '#0B0F19', surface: '#111827', text: '#F9FAFB', textSecondary: '#9CA3AF', border: '#1F2937' },
+};
+
+export const allThemes = [ShowcaseLightTheme, ShowcaseDarkTheme];

--- a/examples/app-showcase/src/translations/index.ts
+++ b/examples/app-showcase/src/translations/index.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/** English + Simplified Chinese labels for the core showcase objects. */
+export const ShowcaseTranslationBundle = {
+  en: {
+    objects: {
+      showcase_project: {
+        label: 'Project',
+        pluralLabel: 'Projects',
+        fields: {
+          name: { label: 'Project Name' },
+          account: { label: 'Account' },
+          status: { label: 'Status' },
+          budget: { label: 'Budget' },
+        },
+      },
+      showcase_task: {
+        label: 'Task',
+        pluralLabel: 'Tasks',
+        fields: {
+          title: { label: 'Title' },
+          status: { label: 'Status' },
+          priority: { label: 'Priority' },
+          due_date: { label: 'Due Date' },
+        },
+      },
+    },
+  },
+  'zh-CN': {
+    objects: {
+      showcase_project: {
+        label: '项目',
+        pluralLabel: '项目',
+        fields: {
+          name: { label: '项目名称' },
+          account: { label: '客户' },
+          status: { label: '状态' },
+          budget: { label: '预算' },
+        },
+      },
+      showcase_task: {
+        label: '任务',
+        pluralLabel: '任务',
+        fields: {
+          title: { label: '标题' },
+          status: { label: '状态' },
+          priority: { label: '优先级' },
+          due_date: { label: '截止日期' },
+        },
+      },
+    },
+  },
+};

--- a/examples/app-showcase/src/views/index.ts
+++ b/examples/app-showcase/src/views/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+export { TaskViews } from './task.view.js';
+export { ProjectViews } from './project.view.js';

--- a/examples/app-showcase/src/views/project.view.ts
+++ b/examples/app-showcase/src/views/project.view.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineView } from '@objectstack/spec';
+
+const data = { provider: 'object' as const, object: 'showcase_project' };
+
+/** Project views — grid + a status Kanban + a budget chart. */
+export const ProjectViews = defineView({
+  list: {
+    label: 'All Projects',
+    type: 'grid',
+    data,
+    columns: [
+      { field: 'name' },
+      { field: 'account' },
+      { field: 'status' },
+      { field: 'health' },
+      { field: 'budget' },
+      { field: 'budget_remaining' },
+      { field: 'end_date' },
+    ],
+  },
+  listViews: {
+    by_status: {
+      label: 'By Status',
+      type: 'kanban',
+      data,
+      columns: ['name', 'account', 'budget'],
+      kanban: { groupByField: 'status', summarizeField: 'budget', columns: ['name', 'account', 'budget'] },
+    },
+    budget_chart: {
+      label: 'Budget by Account',
+      type: 'chart',
+      data,
+      columns: ['account', 'budget'],
+      chart: { chartType: 'bar', xAxisField: 'account', yAxisFields: ['budget', 'spent'], aggregation: 'sum' },
+    },
+  },
+  formViews: {
+    default: {
+      type: 'simple',
+      data,
+      sections: [
+        { label: 'Project', columns: 2, fields: ['name', 'account', 'status', 'health', 'owner'] },
+        { label: 'Budget & Schedule', columns: 2, fields: ['budget', 'spent', 'start_date', 'end_date'] },
+      ],
+    },
+  },
+});

--- a/examples/app-showcase/src/views/task.view.ts
+++ b/examples/app-showcase/src/views/task.view.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineView } from '@objectstack/spec';
+
+const data = { provider: 'object' as const, object: 'showcase_task' };
+
+/**
+ * Task view gallery — a single object backing **all eight** list-view types
+ * plus the simple / tabbed / wizard / split / drawer form variants. This is
+ * the heart of the view-layer coverage: the coverage manifest references
+ * each `listViews.*.type` here.
+ */
+export const TaskViews = defineView({
+  // Default list shown when the object is opened.
+  list: {
+    label: 'All Tasks',
+    type: 'grid',
+    data,
+    columns: [
+      { field: 'title' },
+      { field: 'project' },
+      { field: 'assignee' },
+      { field: 'status' },
+      { field: 'priority' },
+      { field: 'due_date' },
+      { field: 'progress' },
+    ],
+  },
+
+  listViews: {
+    // 1 ── Grid ─────────────────────────────────────────────────────────
+    grid: {
+      label: 'Grid',
+      type: 'grid',
+      data,
+      columns: [
+        { field: 'title' },
+        { field: 'assignee' },
+        { field: 'status' },
+        { field: 'priority' },
+        { field: 'estimate_hours' },
+        { field: 'due_date' },
+      ],
+      rowColor: { field: 'priority' },
+    },
+
+    // 2 ── Kanban ───────────────────────────────────────────────────────
+    board: {
+      label: 'Board (Kanban)',
+      type: 'kanban',
+      data,
+      columns: ['title', 'assignee', 'priority'],
+      kanban: {
+        groupByField: 'status',
+        summarizeField: 'estimate_hours',
+        columns: ['title', 'assignee', 'priority'],
+      },
+    },
+
+    // 3 ── Gallery ──────────────────────────────────────────────────────
+    cards: {
+      label: 'Cards (Gallery)',
+      type: 'gallery',
+      data,
+      columns: ['title', 'assignee', 'status'],
+      gallery: {
+        coverField: 'cover',
+        coverFit: 'cover',
+        cardSize: 'medium',
+        titleField: 'title',
+        visibleFields: ['assignee', 'status', 'priority'],
+      },
+    },
+
+    // 4 ── Calendar ─────────────────────────────────────────────────────
+    calendar: {
+      label: 'Calendar',
+      type: 'calendar',
+      data,
+      columns: ['title', 'assignee'],
+      calendar: {
+        startDateField: 'due_date',
+        titleField: 'title',
+        colorField: 'status',
+      },
+    },
+
+    // 5 ── Timeline ─────────────────────────────────────────────────────
+    timeline: {
+      label: 'Activity Timeline',
+      type: 'timeline',
+      data,
+      columns: ['title'],
+      timeline: {
+        startDateField: 'created_at',
+        titleField: 'title',
+        groupByField: 'status',
+        colorField: 'priority',
+        scale: 'week',
+      },
+    },
+
+    // 6 ── Gantt ────────────────────────────────────────────────────────
+    gantt: {
+      label: 'Schedule (Gantt)',
+      type: 'gantt',
+      data,
+      columns: ['title', 'assignee'],
+      gantt: {
+        startDateField: 'start_date',
+        endDateField: 'end_date',
+        titleField: 'title',
+        progressField: 'progress',
+      },
+    },
+
+    // 7 ── Map ──────────────────────────────────────────────────────────
+    map: {
+      label: 'Work Locations (Map)',
+      type: 'map',
+      data,
+      columns: ['title', 'location', 'assignee'],
+    },
+
+    // 8 ── Chart ────────────────────────────────────────────────────────
+    chart: {
+      label: 'Hours by Status (Chart)',
+      type: 'chart',
+      data,
+      columns: ['status', 'estimate_hours'],
+      chart: {
+        chartType: 'bar',
+        xAxisField: 'status',
+        yAxisFields: ['estimate_hours'],
+        aggregation: 'sum',
+        groupByField: 'priority',
+      },
+    },
+  },
+
+  formViews: {
+    // simple ── single-section form ──────────────────────────────────────
+    default: {
+      type: 'simple',
+      data,
+      sections: [
+        {
+          label: 'Task',
+          columns: 2,
+          fields: [
+            { field: 'title', required: true },
+            { field: 'project', required: true },
+            { field: 'assignee' },
+            { field: 'status', required: true },
+            { field: 'priority' },
+            { field: 'due_date' },
+          ],
+        },
+      ],
+    },
+
+    // tabbed ── sections rendered as tabs ────────────────────────────────
+    tabbed: {
+      type: 'tabbed',
+      data,
+      sections: [
+        { name: 'overview', label: 'Overview', columns: 2, fields: ['title', 'project', 'assignee', 'status'] },
+        { name: 'schedule', label: 'Schedule', columns: 2, fields: ['start_date', 'end_date', 'due_date', 'progress'] },
+        { name: 'details', label: 'Details', columns: 1, fields: ['estimate_hours', 'labels', 'location', 'notes'] },
+      ],
+    },
+
+    // wizard ── step-by-step creation ────────────────────────────────────
+    wizard: {
+      type: 'wizard',
+      data,
+      sections: [
+        { name: 'step_basics', label: 'Basics', columns: 1, fields: ['title', 'project'] },
+        { name: 'step_assign', label: 'Assignment', columns: 1, fields: ['assignee', 'priority'] },
+        { name: 'step_schedule', label: 'Schedule', columns: 2, fields: ['start_date', 'end_date', 'due_date'] },
+      ],
+    },
+
+    // split ── master-detail split pane ──────────────────────────────────
+    split: {
+      type: 'split',
+      data,
+      sections: [{ label: 'Task', columns: 1, fields: ['title', 'status', 'assignee'] }],
+    },
+
+    // drawer ── side panel quick edit ────────────────────────────────────
+    quick: {
+      type: 'drawer',
+      data,
+      sections: [{ label: 'Quick Edit', columns: 1, fields: ['status', 'priority', 'progress'] }],
+    },
+  },
+});

--- a/examples/app-showcase/src/webhooks/index.ts
+++ b/examples/app-showcase/src/webhooks/index.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Outbound webhook — fans out task changes to an external endpoint with a
+ * retry policy. Validated as part of `defineStack({ webhooks })`.
+ */
+export const TaskChangedWebhook = {
+  name: 'showcase_task_changed',
+  label: 'Task Changed → External',
+  object: 'showcase_task',
+  triggers: ['create', 'update', 'delete'] as ('create' | 'update' | 'delete')[],
+  url: 'https://hooks.example/showcase/task',
+  method: 'POST' as const,
+  retryPolicy: { maxRetries: 3, backoffStrategy: 'exponential' as const, initialDelayMs: 1000, maxDelayMs: 30000 },
+  isActive: true,
+  description: 'Sends task lifecycle events to an external system.',
+};
+
+export const allWebhooks = [TaskChangedWebhook];

--- a/examples/app-showcase/test/coverage.test.ts
+++ b/examples/app-showcase/test/coverage.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { FieldType } from '@objectstack/spec/data';
+import * as ui from '@objectstack/spec/ui';
+
+import * as objects from '../src/objects/index.js';
+import { TaskViews, ProjectViews } from '../src/views/index.js';
+import { ChartGalleryDashboard } from '../src/dashboards/index.js';
+import { allReports } from '../src/reports/index.js';
+import { allActions } from '../src/actions/index.js';
+import {
+  LIST_VIEW_TYPES,
+  FORM_VIEW_TYPES,
+  collectFieldTypes,
+  collectListViewTypes,
+  collectFormViewTypes,
+} from '../src/coverage.js';
+
+/** Read the string members of a Zod enum (or a plain array constant). */
+function enumValues(schema: unknown): string[] {
+  const s = schema as { options?: string[]; _def?: { values?: string[] } };
+  if (Array.isArray(schema)) return schema as string[];
+  return s?.options ?? s?._def?.values ?? [];
+}
+
+/** Assert every member of `expected` appears in `used`, reporting the gap. */
+function expectFullCoverage(label: string, expected: string[], used: Set<string>) {
+  const missing = expected.filter((v) => !used.has(v));
+  expect(missing, `${label}: uncovered → ${missing.join(', ')}`).toEqual([]);
+}
+
+const objectList = Object.values(objects);
+const views = [TaskViews, ProjectViews];
+
+describe('showcase coverage (introspected against the spec)', () => {
+  it('covers every FieldType', () => {
+    const expected = enumValues(FieldType);
+    expect(expected.length).toBeGreaterThan(40);
+    expectFullCoverage('FieldType', expected, collectFieldTypes(objectList as never));
+  });
+
+  it('covers every list-view type', () => {
+    expectFullCoverage('ListViewType', [...LIST_VIEW_TYPES], collectListViewTypes(views as never));
+  });
+
+  it('covers every form-view type', () => {
+    expectFullCoverage('FormViewType', [...FORM_VIEW_TYPES], collectFormViewTypes(views as never));
+  });
+
+  it('covers every ChartType', () => {
+    const expected = enumValues(ui.ChartTypeSchema);
+    expect(expected.length).toBeGreaterThan(30);
+    const used = new Set<string>();
+    for (const w of ChartGalleryDashboard.widgets ?? []) if (w.type) used.add(w.type);
+    expectFullCoverage('ChartType', expected, used);
+  });
+
+  it('covers every report type', () => {
+    const expected = enumValues((ui as Record<string, unknown>).ReportType ?? (ui as Record<string, unknown>).ReportTypeSchema);
+    const used = new Set<string>();
+    for (const r of allReports) {
+      if (r.type) used.add(r.type);
+      for (const b of (r as { blocks?: Array<{ type?: string }> }).blocks ?? []) if (b.type) used.add(b.type);
+    }
+    expectFullCoverage('ReportType', expected, used);
+  });
+
+  it('covers every action type and location', () => {
+    const types = enumValues((ui as Record<string, unknown>).ActionType ?? (ui as Record<string, unknown>).ActionTypeSchema);
+    const locations = enumValues((ui as Record<string, unknown>).ACTION_LOCATIONS ?? (ui as Record<string, unknown>).ActionLocationSchema);
+
+    const usedTypes = new Set<string>();
+    const usedLocations = new Set<string>();
+    for (const a of allActions) {
+      if (a.type) usedTypes.add(a.type);
+      for (const loc of a.locations ?? []) usedLocations.add(loc);
+    }
+    expectFullCoverage('ActionType', types, usedTypes);
+    expectFullCoverage('ActionLocation', locations, usedLocations);
+  });
+});

--- a/examples/app-showcase/test/seed.test.ts
+++ b/examples/app-showcase/test/seed.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import stack from '../objectstack.config.js';
+
+/**
+ * Smoke test — the stack loads and registers the expected breadth of
+ * metadata. This guards the metadata-loading pipeline end-to-end.
+ */
+describe('showcase stack', () => {
+  it('registers the core objects', () => {
+    const names = (stack.objects ?? []).map((o: { name: string }) => o.name);
+    expect(names).toContain('showcase_project');
+    expect(names).toContain('showcase_task');
+    expect(names).toContain('showcase_field_zoo');
+    // 6 objects: account, project, task, category, team, membership, field_zoo
+    expect((stack.objects ?? []).length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('registers UI, automation, security, and AI metadata', () => {
+    expect((stack.views ?? []).length).toBeGreaterThan(0);
+    expect((stack.dashboards ?? []).length).toBeGreaterThan(0);
+    expect((stack.reports ?? []).length).toBe(4);
+    expect((stack.flows ?? []).length).toBeGreaterThan(0);
+    expect((stack.approvals ?? []).length).toBeGreaterThan(0);
+    expect((stack.roles ?? []).length).toBe(3);
+    expect((stack.agents ?? []).length).toBe(1);
+  });
+});

--- a/examples/app-showcase/tsconfig.json
+++ b/examples/app-showcase/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "objectstack.config.ts", "test/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,25 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  examples/app-showcase:
+    dependencies:
+      '@objectstack/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../packages/spec
+    devDependencies:
+      '@objectstack/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   examples/app-todo:
     dependencies:
       '@objectstack/client':


### PR DESCRIPTION
## Summary

Adds `@objectstack/example-showcase` — a **kitchen-sink reference workspace** designed to show off the whole platform at once, built for three audiences: **demonstration**, **debugging**, and **coverage-driven verification**.

It deliberately splits into two tracks to resolve the demo-vs-verify tension:
- a **realistic backbone** (`Account → Project → Task`, `Team`, `Category`) with seeded data so every view renders something real;
- synthetic **gallery/specimen** objects whose only job is to exhaust protocol variants;

…tied together by a **coverage manifest** (`src/coverage.ts`) that the test suite checks against the protocol's own Zod enums.

## What it covers

**Data layer**
- All **49 field types** (`src/objects/field-zoo.object.ts`)
- Every relationship kind: `lookup`, `master_detail`, self-referencing **tree** (`Category.parent`), and **many-to-many** via the `showcase_project_membership` junction
- Formulas, validations, and a status state machine

**View layer**
- **All 8 list-view types** on a single object (grid, kanban, gallery, calendar, timeline, gantt, map, chart)
- **All 5 form-view types** (simple, tabbed, wizard, split, drawer)
- **All 38 chart types** in one dashboard
- **All 4 report types** (tabular, summary, matrix, joined)
- The action **type × location** matrix and a component-gallery page

**Capability chains**
- Security: roles + permission set with object CRUD + **FLS** + **RLS** + sharing rules + policy
- Automation: record-triggered flow → screen-flow wizard → multi-step **approval** → **webhook** → scheduled **job** → **email**
- AI: **agent** + **tool** + **skill**
- i18n (`en` + `zh-CN`), light/dark themes, datasource, and an external portal

## Verification ("confirm")

`test/coverage.test.ts` **introspects the spec's own enums** (`FieldType`, `ChartType`, `ReportType`, `ActionType`, `ACTION_LOCATIONS`) and asserts every member appears at least once across the registered metadata. Because the expected sets come from the spec — not a hand-maintained list — the test **fails automatically when the platform gains a new variant** that the showcase hasn't demonstrated, keeping it a living conformance fixture rather than a static snapshot. `defineStack` also runs full schema + cross-reference validation on import.

```
pnpm verify   # tsc --noEmit + vitest → green (8/8 tests pass)
```

## Notes for reviewers
- The example uses the **current** named-type import convention (`@objectstack/spec/ui`, `/data`, etc.) and `define*`/`*.create` builders. (Aside: the existing `examples/app-crm` still uses the older root-namespace style — `UI.Report`, `Automation.ApprovalProcess` — which no longer typechecks against the current spec, and email templates there are missing the now-required `isSystem`. Happy to follow up on app-crm in a separate PR if useful.)
- `examples/README.md` updated with a Showcase entry.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CsmomJsLjCknpDjc1XjUcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsmomJsLjCknpDjc1XjUcY)_