### PR TITLE
feat(connector-mcp): adopt MCP servers as connectors (ADR-0024)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -38,6 +38,7 @@
       "@objectstack/plugin-sharing",
       "@objectstack/plugin-webhooks",
       "@objectstack/plugin-trigger-record-change",
+      "@objectstack/connector-mcp",
       "@objectstack/connector-rest",
       "@objectstack/connector-slack",
       "@objectstack/express",

--- a/.changeset/connector-mcp.md
+++ b/.changeset/connector-mcp.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/connector-mcp": minor
+---
+
+MCP Connector (ADR-0024) — adopt any Model Context Protocol server as a connector.
+
+Adds `@objectstack/connector-mcp`, a single generic adapter that turns *any*
+MCP server into an ordinary `type: 'api'` connector on the automation engine —
+no per-server code:
+
+- `createMcpConnector({ transport, include?, … })` connects over **stdio** or
+  **streamable-HTTP**, calls `tools/list`, and maps each tool to a connector
+  action (`name → key`, `description → label/description`,
+  `inputSchema → inputSchema`). Handlers dispatch to `tools/call` and normalise
+  the result to the shared `{ ok, content, … }` envelope (logical tool errors
+  surface as `ok: false` rather than throwing).
+- `ConnectorMcpPlugin` registers the connector via the existing
+  `engine.registerConnector()` path (no new engine surface, no `mcp_call` node)
+  and tears the MCP connection down on shutdown. Fail-soft: an unreachable
+  server or missing automation engine is logged and skipped.
+- Credentials live with the MCP server (transport `env`/`headers`), never in
+  `ConnectorSchema` and never in the serialized, discovery-exposed `def`.
+
+Open-tier scope: client adapter + operator-supplied static credentials. A
+curated server registry, managed secrets, per-tenant lifecycle, and sandboxed
+stdio execution remain the enterprise tier.

--- a/packages/connectors/connector-mcp/LICENSE
+++ b/packages/connectors/connector-mcp/LICENSE
@@ -1,0 +1,93 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             ObjectStack AI LLC
+Licensed Work:        ObjectStack Runtime: the BSL-licensed packages
+                      of the ObjectStack monorepo as listed in LICENSING.md.
+                      Copyright (c) 2026 ObjectStack AI LLC.
+Additional Use Grant: You may make production use of the Licensed Work, provided
+                      Your use does not include offering the Licensed Work to third
+                      parties on a hosted or embedded basis in order to compete with 
+                      ObjectStack AI LLC's paid version(s) of the Licensed Work. For purposes 
+                      of this license:
+
+                      A "competitive offering" is a Product that is offered to third
+                      parties on a paid basis, including through paid support 
+                      arrangements, that significantly overlaps with the capabilities 
+                      of ObjectStack AI LLC's paid version(s) of the Licensed Work. If Your 
+                      Product is not a competitive offering when You first make it 
+                      generally available, it will not become a competitive offering
+                      later due to ObjectStack AI LLC releasing a new version of the Licensed 
+                      Work with additional capabilities. In addition, Products that 
+                      are not provided on a paid basis are not competitive.
+
+                      "Product" means software that is offered to end users to manage 
+                      in their own environments or offered as a service on a hosted 
+                      basis.
+
+                      "Embedded" means including the source code or executable code 
+                      from the Licensed Work in a competitive offering. "Embedded" 
+                      also means packaging the competitive offering in such a way 
+                      that the Licensed Work must be accessed or downloaded for the 
+                      competitive offering to operate.
+
+                      Hosting or using the Licensed Work(s) for internal purposes 
+                      within an organization is not considered a competitive 
+                      offering. ObjectStack AI LLC considers your organization to include all 
+                      of your affiliates under common control.
+
+                      For binding interpretive guidance on using ObjectStack AI LLC products 
+                      under the Business Source License, please visit our FAQ. 
+                      (see LICENSING.md in this repository)
+Change Date:          Four years from the date the Licensed Work is published.
+Change License:       Apache License, Version 2.0
+
+For information about alternative licensing arrangements for the Licensed Work,
+please contact licensing@objectstack.dev.
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/packages/connectors/connector-mcp/package.json
+++ b/packages/connectors/connector-mcp/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@objectstack/connector-mcp",
+  "version": "7.3.0",
+  "license": "Apache-2.0",
+  "description": "Model Context Protocol (MCP) connector for ObjectStack — a generic adapter that turns any MCP server's tools into a connector's actions on the automation engine's connector registry (ADR-0024).",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ../../../tsup.config.ts",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@objectstack/core": "workspace:*",
+    "@objectstack/spec": "workspace:*"
+  },
+  "devDependencies": {
+    "@objectstack/service-automation": "workspace:*",
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  },
+  "keywords": [
+    "objectstack",
+    "connector",
+    "mcp",
+    "model-context-protocol",
+    "integration",
+    "ai",
+    "tools"
+  ]
+}

--- a/packages/connectors/connector-mcp/src/connector-mcp-plugin.test.ts
+++ b/packages/connectors/connector-mcp/src/connector-mcp-plugin.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { LiteKernel } from '@objectstack/core';
+import { AutomationServicePlugin, type AutomationEngine } from '@objectstack/service-automation';
+import { ConnectorMcpPlugin } from './connector-mcp-plugin.js';
+import type { McpClientLike, McpToolDescriptor } from './mcp-connector.js';
+
+const TOOLS: McpToolDescriptor[] = [
+    {
+        name: 'create_issue',
+        description: 'Create a GitHub issue',
+        inputSchema: {
+            type: 'object',
+            properties: { repo: { type: 'string' }, title: { type: 'string' } },
+            required: ['repo', 'title'],
+        },
+    },
+];
+
+/** A fake MCP client recording calls; injected via the plugin's clientFactory. */
+function fakeClient() {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    let closed = false;
+    const client: McpClientLike = {
+        listTools: async () => TOOLS,
+        callTool: async (name, args) => {
+            calls.push({ name, args });
+            return { content: [{ type: 'text', text: 'created #42' }], structuredContent: { number: 42 } };
+        },
+        close: async () => { closed = true; },
+    };
+    return { client, calls, isClosed: () => closed };
+}
+
+describe('ConnectorMcpPlugin — end to end with the automation engine', () => {
+    it('registers the MCP-backed connector so a connector_action flow dispatches to tools/call', async () => {
+        const { client, calls, isClosed } = fakeClient();
+
+        const kernel = new LiteKernel();
+        kernel.use(new AutomationServicePlugin());
+        kernel.use(
+            new ConnectorMcpPlugin({
+                name: 'github_mcp',
+                label: 'GitHub MCP',
+                transport: { kind: 'stdio', command: 'noop' },
+                clientFactory: async () => client,
+            }),
+        );
+        await kernel.bootstrap();
+
+        const engine = kernel.getService<AutomationEngine>('automation');
+
+        // The baseline node and the MCP-backed connector are both present; to the
+        // registry it is an ordinary connector.
+        expect(engine.getRegisteredNodeTypes()).toContain('connector_action');
+        expect(engine.getRegisteredConnectors()).toContain('github_mcp');
+
+        engine.registerFlow('open_issue', {
+            name: 'open_issue',
+            label: 'Open an issue via MCP',
+            type: 'autolaunched',
+            variables: [{ name: 'call.structuredContent', type: 'json', isOutput: true }],
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                {
+                    id: 'call',
+                    type: 'connector_action',
+                    label: 'create_issue',
+                    connectorConfig: {
+                        connectorId: 'github_mcp',
+                        actionId: 'create_issue',
+                        input: { repo: 'acme/app', title: 'Bug' },
+                    },
+                },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'call' },
+                { id: 'e2', source: 'call', target: 'end' },
+            ],
+        });
+
+        const result = await engine.execute('open_issue');
+
+        expect(result.success).toBe(true);
+        // The MCP connector handled the dispatch: one tools/call with the input.
+        expect(calls).toEqual([{ name: 'create_issue', args: { repo: 'acme/app', title: 'Bug' } }]);
+        // The normalised structuredContent propagated back into the flow.
+        expect(result.output).toEqual({ 'call.structuredContent': { number: 42 } });
+
+        // Shutdown tears the MCP connection down.
+        await kernel.shutdown();
+        expect(isClosed()).toBe(true);
+    });
+});

--- a/packages/connectors/connector-mcp/src/connector-mcp-plugin.ts
+++ b/packages/connectors/connector-mcp/src/connector-mcp-plugin.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Plugin, PluginContext } from '@objectstack/core';
+import type { Connector } from '@objectstack/spec/integration';
+import { createMcpConnector, type McpConnectorOptions } from './mcp-connector.js';
+
+/**
+ * Minimal surface of the automation engine this plugin depends on — the
+ * connector registry from ADR-0018 §Addendum. Kept structural so the plugin
+ * needs no runtime dependency on `@objectstack/service-automation`.
+ */
+export interface ConnectorRegistrySurface {
+    registerConnector(
+        def: Connector,
+        handlers: Record<
+            string,
+            (input: Record<string, unknown>, ctx: unknown) => Promise<Record<string, unknown>>
+        >,
+    ): void;
+    unregisterConnector(name: string): void;
+}
+
+export interface ConnectorMcpPluginOptions extends McpConnectorOptions {}
+
+/**
+ * ConnectorMcpPlugin — connects to an MCP server, discovers its tools, and
+ * registers them as a single connector on the automation engine (ADR-0024).
+ * One generic adapter, configured per server (transport + `include`), never
+ * per-server code.
+ *
+ * Lifecycle: on `start()` it connects and builds the connector once; on
+ * `stop()` it tears the MCP connection down. If no automation engine is present
+ * — or the server is unreachable at boot — the plugin logs and skips: a missing
+ * optional connector is not a fatal error (same posture as `ConnectorRestPlugin`).
+ */
+export class ConnectorMcpPlugin implements Plugin {
+    name = 'com.objectstack.connector.mcp';
+    version = '1.0.0';
+    type = 'standard' as const;
+    // Ensure the automation engine (and its connector registry) is started first.
+    dependencies = ['com.objectstack.service-automation'];
+
+    private readonly options: ConnectorMcpPluginOptions;
+    private connectorName?: string;
+    private automation?: ConnectorRegistrySurface;
+    private close?: () => Promise<void>;
+
+    constructor(options: ConnectorMcpPluginOptions) {
+        this.options = options;
+    }
+
+    async init(_ctx: PluginContext): Promise<void> {
+        // No services to register; the connector is registered in start() once
+        // the automation engine is available and the MCP server has been queried.
+    }
+
+    async start(ctx: PluginContext): Promise<void> {
+        let automation: ConnectorRegistrySurface | undefined;
+        try {
+            automation = ctx.getService<ConnectorRegistrySurface>('automation');
+        } catch {
+            automation = undefined;
+        }
+
+        if (!automation || typeof automation.registerConnector !== 'function') {
+            ctx.logger.info('ConnectorMcpPlugin: no automation engine — MCP connector not registered');
+            return;
+        }
+
+        let bundle;
+        try {
+            bundle = await createMcpConnector(this.options);
+        } catch (err) {
+            // The MCP server is unreachable / failed discovery at boot. Skip the
+            // optional connector rather than failing the whole bootstrap.
+            ctx.logger.warn(
+                `ConnectorMcpPlugin: could not connect to MCP server — connector not registered: ${(err as Error).message}`,
+            );
+            return;
+        }
+
+        automation.registerConnector(bundle.def, bundle.handlers);
+        this.automation = automation;
+        this.connectorName = bundle.def.name;
+        this.close = bundle.close;
+        ctx.logger.info(
+            `ConnectorMcpPlugin: MCP connector '${bundle.def.name}' registered with ${bundle.def.actions?.length ?? 0} action(s)`,
+        );
+    }
+
+    /**
+     * Destroy phase — the kernel's shutdown hook (the `Plugin` lifecycle exposes
+     * `destroy()`, not `stop()`). Unregister the connector and tear the MCP
+     * connection down so no child process / socket is leaked.
+     */
+    async destroy(): Promise<void> {
+        if (this.automation && this.connectorName) {
+            try { this.automation.unregisterConnector(this.connectorName); } catch { /* ignore */ }
+        }
+        if (this.close) {
+            try { await this.close(); } catch { /* ignore */ }
+        }
+    }
+}

--- a/packages/connectors/connector-mcp/src/index.ts
+++ b/packages/connectors/connector-mcp/src/index.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * @objectstack/connector-mcp
+ *
+ * A generic adapter that turns *any* Model Context Protocol (MCP) server into a
+ * {@link Connector} registered on the automation engine (ADR-0024). On connect
+ * it lists the server's tools and maps each one to a connector action; the
+ * baseline `connector_action` node then dispatches calls to the server's
+ * `tools/call`. One adapter unlocks the entire MCP ecosystem with no per-server
+ * code — and, because MCP is itself an LLM tool protocol, every imported tool
+ * doubles as an AI tool under ADR-0011.
+ *
+ * Open-source scope: the MCP client adapter (stdio + http transports),
+ * `tools/list` → actions, `tools/call` dispatch, and operator-supplied static
+ * credentials passed through the transport. A curated server registry, managed
+ * secrets, per-tenant lifecycle, and sandboxed stdio execution are the
+ * enterprise tier (ADR-0024 §4).
+ */
+
+export {
+    createMcpConnector,
+    type McpConnectorOptions,
+    type McpConnectorBundle,
+    type McpTransport,
+    type McpToolDescriptor,
+    type McpClientLike,
+} from './mcp-connector.js';
+export {
+    ConnectorMcpPlugin,
+    type ConnectorMcpPluginOptions,
+    type ConnectorRegistrySurface,
+} from './connector-mcp-plugin.js';

--- a/packages/connectors/connector-mcp/src/mcp-connector.test.ts
+++ b/packages/connectors/connector-mcp/src/mcp-connector.test.ts
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+    createMcpConnector,
+    type McpClientLike,
+    type McpToolDescriptor,
+} from './mcp-connector.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+interface CapturedCall {
+    name: string;
+    args: Record<string, unknown>;
+}
+
+/** A fake MCP client recording `tools/call` invocations and returning a fixed result. */
+function fakeClient(
+    tools: McpToolDescriptor[],
+    result: unknown = { content: [{ type: 'text', text: 'ok' }] },
+) {
+    const calls: CapturedCall[] = [];
+    let closed = false;
+    const client: McpClientLike = {
+        listTools: async () => tools,
+        callTool: async (name, args) => {
+            calls.push({ name, args });
+            return result;
+        },
+        close: async () => {
+            closed = true;
+        },
+    };
+    return { client, calls, isClosed: () => closed };
+}
+
+const SAMPLE_TOOLS: McpToolDescriptor[] = [
+    {
+        name: 'create_issue',
+        description: 'Create a GitHub issue',
+        inputSchema: {
+            type: 'object',
+            properties: { repo: { type: 'string' }, title: { type: 'string' } },
+            required: ['repo', 'title'],
+        },
+    },
+    {
+        name: 'list_issues',
+        description: 'List issues in a repo',
+        inputSchema: { type: 'object', properties: { repo: { type: 'string' } } },
+        outputSchema: { type: 'object', properties: { issues: { type: 'array' } } },
+    },
+];
+
+// ─── tools/list → connector actions ───────────────────────────────────
+
+describe('createMcpConnector — discovery maps tools to actions', () => {
+    it('builds a type:api connector with one action per tool, mapping name/description/schemas', async () => {
+        const { client } = fakeClient(SAMPLE_TOOLS);
+        const { def } = await createMcpConnector({
+            name: 'github_mcp',
+            label: 'GitHub MCP',
+            transport: { kind: 'stdio', command: 'noop' },
+            clientFactory: async () => client,
+        });
+
+        expect(def.name).toBe('github_mcp');
+        expect(def.label).toBe('GitHub MCP');
+        expect(def.type).toBe('api');
+        // Credentials live with the server — the def carries no upstream auth.
+        expect(def.authentication).toEqual({ type: 'none' });
+
+        expect(def.actions).toHaveLength(2);
+        const create = def.actions?.find((a) => a.key === 'create_issue');
+        expect(create?.description).toBe('Create a GitHub issue');
+        expect(create?.label).toBe('Create Issue');
+        expect(create?.inputSchema).toEqual(SAMPLE_TOOLS[0].inputSchema);
+        // Tools without an outputSchema leave it unset.
+        expect(create?.outputSchema).toBeUndefined();
+
+        const list = def.actions?.find((a) => a.key === 'list_issues');
+        expect(list?.outputSchema).toEqual(SAMPLE_TOOLS[1].outputSchema);
+    });
+
+    it('derives a snake_case name from the label when name is omitted', async () => {
+        const { client } = fakeClient(SAMPLE_TOOLS);
+        const { def } = await createMcpConnector({
+            label: 'My Cool Server!',
+            transport: { kind: 'http', url: 'https://mcp.example.com' },
+            clientFactory: async () => client,
+        });
+        expect(def.name).toBe('my_cool_server');
+        expect(def.name).toMatch(/^[a-z_][a-z0-9_]*$/);
+    });
+
+    it('applies the include allowlist to keep the palette lean', async () => {
+        const { client } = fakeClient(SAMPLE_TOOLS);
+        const { def, handlers } = await createMcpConnector({
+            name: 'gh',
+            transport: { kind: 'stdio', command: 'noop' },
+            include: (tool) => tool === 'create_issue',
+            clientFactory: async () => client,
+        });
+        expect(def.actions).toHaveLength(1);
+        expect(def.actions?.[0].key).toBe('create_issue');
+        expect(Object.keys(handlers)).toEqual(['create_issue']);
+    });
+
+    it('passes the configured transport and client info to the factory', async () => {
+        const { client } = fakeClient(SAMPLE_TOOLS);
+        const factory = vi.fn(async () => client);
+        const transport = { kind: 'http' as const, url: 'https://mcp.example.com', headers: { Authorization: 'Bearer t' } };
+        await createMcpConnector({
+            name: 'gh',
+            transport,
+            clientInfo: { name: 'tester', version: '9.9.9' },
+            clientFactory: factory,
+        });
+        expect(factory).toHaveBeenCalledWith(transport, { name: 'tester', version: '9.9.9' });
+    });
+});
+
+// ─── tools/call dispatch + result normalisation ───────────────────────
+
+describe('createMcpConnector — handlers dispatch to tools/call', () => {
+    it('forwards input to callTool and normalises the result to an { ok, content } envelope', async () => {
+        const { client, calls } = fakeClient(SAMPLE_TOOLS, {
+            content: [{ type: 'text', text: 'created #1' }],
+            structuredContent: { number: 1 },
+        });
+        const { handlers } = await createMcpConnector({
+            name: 'gh',
+            transport: { kind: 'stdio', command: 'noop' },
+            clientFactory: async () => client,
+        });
+
+        const out = await handlers.create_issue({ repo: 'acme/app', title: 'Bug' }, {});
+
+        expect(calls).toEqual([{ name: 'create_issue', args: { repo: 'acme/app', title: 'Bug' } }]);
+        expect(out).toEqual({
+            ok: true,
+            content: [{ type: 'text', text: 'created #1' }],
+            structuredContent: { number: 1 },
+        });
+    });
+
+    it('surfaces a tool error as ok:false without throwing', async () => {
+        const { client } = fakeClient(SAMPLE_TOOLS, {
+            isError: true,
+            content: [{ type: 'text', text: 'boom' }],
+        });
+        const { handlers } = await createMcpConnector({
+            name: 'gh',
+            transport: { kind: 'stdio', command: 'noop' },
+            clientFactory: async () => client,
+        });
+
+        const out = await handlers.list_issues({ repo: 'acme/app' }, {});
+        expect(out).toEqual({ ok: false, content: [{ type: 'text', text: 'boom' }], isError: true });
+    });
+});
+
+// ─── lifecycle ────────────────────────────────────────────────────────
+
+describe('createMcpConnector — lifecycle', () => {
+    it('exposes close() that tears the client down', async () => {
+        const { client, isClosed } = fakeClient(SAMPLE_TOOLS);
+        const { close } = await createMcpConnector({
+            name: 'gh',
+            transport: { kind: 'stdio', command: 'noop' },
+            clientFactory: async () => client,
+        });
+        expect(isClosed()).toBe(false);
+        await close();
+        expect(isClosed()).toBe(true);
+    });
+
+    it('closes the client when discovery (tools/list) fails', async () => {
+        let closed = false;
+        const client: McpClientLike = {
+            listTools: async () => { throw new Error('list boom'); },
+            callTool: async () => ({}),
+            close: async () => { closed = true; },
+        };
+        await expect(
+            createMcpConnector({
+                name: 'gh',
+                transport: { kind: 'stdio', command: 'noop' },
+                clientFactory: async () => client,
+            }),
+        ).rejects.toThrow('list boom');
+        expect(closed).toBe(true);
+    });
+});

--- a/packages/connectors/connector-mcp/src/mcp-connector.ts
+++ b/packages/connectors/connector-mcp/src/mcp-connector.ts
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { Connector } from '@objectstack/spec/integration';
+
+/**
+ * MCP connector — a *generic* adapter that turns any Model Context Protocol
+ * server into a {@link Connector} (ADR-0024). Where `connector-rest` and
+ * `connector-slack` are concrete, per-service connectors, this one is a single
+ * adapter that adopts the entire MCP ecosystem with **no per-server code**:
+ *
+ *   1. connect to the MCP server over the configured transport,
+ *   2. call `tools/list` and map each tool to a connector action
+ *      (`name → key`, `description → label/description`, `inputSchema → inputSchema`),
+ *   3. build an ordinary `type: 'api'` {@link Connector} once, and
+ *   4. dispatch each `connector_action` call to the server's `tools/call`.
+ *
+ * After construction the registry, the `connector_action` node, the discovery
+ * route, and the Studio palette all see a plain connector — they never know it
+ * is backed by MCP (ADR-0024 §2).
+ *
+ * **Credentials live with the MCP server, not in `ConnectorSchema`** (ADR-0024
+ * §3). The operator supplies `env` (stdio) / `headers` (http) which we pass
+ * straight to the transport; they are never copied into the serialized `def`
+ * (which is exposed via discovery) and must never be logged.
+ *
+ * **Trust:** launching a stdio server runs a local process. Sandboxed,
+ * multi-tenant execution and managed secrets are the enterprise tier (ADR-0024
+ * §4); the open adapter runs an operator-provided server with operator-provided
+ * credentials and documents that trust assumption.
+ */
+
+/** How to reach the MCP server. */
+export type McpTransport =
+    | {
+          kind: 'stdio';
+          /** Executable to launch (e.g. `npx`). */
+          command: string;
+          /** Arguments passed to the command. */
+          args?: string[];
+          /** Environment variables for the child process — carries credentials. */
+          env?: Record<string, string>;
+      }
+    | {
+          kind: 'http';
+          /** Streamable-HTTP endpoint of the MCP server. */
+          url: string;
+          /** Headers sent on every request — carries credentials (e.g. a bearer token). */
+          headers?: Record<string, string>;
+      };
+
+/** A tool as advertised by an MCP server's `tools/list`. */
+export interface McpToolDescriptor {
+    name: string;
+    description?: string;
+    /** JSON Schema for the tool's arguments. */
+    inputSchema?: Record<string, unknown>;
+    /** JSON Schema for the tool's result (optional — many servers omit it). */
+    outputSchema?: Record<string, unknown>;
+}
+
+/**
+ * The minimal slice of an MCP client the adapter needs. Kept structural so
+ * tests can inject a fake and the real SDK stays an implementation detail
+ * (mirrors `fetchImpl` injection in `connector-rest`).
+ */
+export interface McpClientLike {
+    /** List the server's tools (`tools/list`). */
+    listTools(): Promise<McpToolDescriptor[]>;
+    /** Invoke a tool (`tools/call`); returns the raw MCP result. */
+    callTool(name: string, args: Record<string, unknown>): Promise<unknown>;
+    /** Close the connection / tear down the transport. */
+    close(): Promise<void>;
+}
+
+export interface McpConnectorOptions {
+    /** Connector machine name (snake_case). Defaults to a slug of `label`, else `mcp`. */
+    name?: string;
+    /** Human-readable label. Defaults to a title derived from `name`. */
+    label?: string;
+    /** Connector description for the palette. */
+    description?: string;
+    /** Icon identifier. Defaults to `plug`. */
+    icon?: string;
+    /** How to reach the MCP server. */
+    transport: McpTransport;
+    /** Only expose tools whose name matches (allowlist) — keeps the palette lean. */
+    include?: (toolName: string) => boolean;
+    /** Identifies this client to the MCP server during the handshake. */
+    clientInfo?: { name: string; version: string };
+    /**
+     * Injected for tests; defaults to the real SDK-backed client. Receives the
+     * configured transport and returns a connected {@link McpClientLike}.
+     */
+    clientFactory?: (transport: McpTransport, clientInfo: { name: string; version: string }) => Promise<McpClientLike>;
+}
+
+/**
+ * A connector definition + handlers, ready for `engine.registerConnector()`,
+ * plus a `close()` for the connection lifecycle (called by the plugin's stop()).
+ */
+export interface McpConnectorBundle {
+    def: Connector;
+    handlers: Record<
+        string,
+        (input: Record<string, unknown>, ctx: unknown) => Promise<Record<string, unknown>>
+    >;
+    /** Tear down the MCP client/connection. */
+    close(): Promise<void>;
+}
+
+const DEFAULT_CLIENT_INFO = { name: 'objectstack-connector-mcp', version: '1.0.0' } as const;
+
+/** Slugify a label into a valid connector `name` (`/^[a-z_][a-z0-9_]*$/`). */
+function slugify(input: string): string {
+    const slug = input
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+    if (!slug) return 'mcp';
+    // The name must start with a letter or underscore.
+    return /^[a-z_]/.test(slug) ? slug : `mcp_${slug}`;
+}
+
+/** Title-case a snake_case name for a default label (`github_issues` → `Github Issues`). */
+function titleize(name: string): string {
+    return name
+        .split('_')
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
+/**
+ * Normalise an MCP `tools/call` result into the connector handler's return
+ * shape, mirroring the `{ ok, … }` envelope the other connectors expose. An MCP
+ * result carries `content` blocks and an optional `isError` flag /
+ * `structuredContent`; we surface `ok` from `isError` (never throwing on a
+ * logical tool error so the flow author can branch on `${node.ok}`).
+ */
+function normalizeResult(raw: unknown): Record<string, unknown> {
+    const result = (raw ?? {}) as Record<string, unknown>;
+    const isError = result.isError === true;
+    const out: Record<string, unknown> = {
+        ok: !isError,
+        content: result.content ?? [],
+    };
+    if (result.structuredContent !== undefined) out.structuredContent = result.structuredContent;
+    if (isError) out.isError = true;
+    return out;
+}
+
+/**
+ * The default {@link McpClientLike} — lazily imports the official MCP SDK so it
+ * is only loaded when a real connection is made (tests inject their own client).
+ */
+async function defaultClientFactory(
+    transport: McpTransport,
+    clientInfo: { name: string; version: string },
+): Promise<McpClientLike> {
+    const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+    const client = new Client(clientInfo, { capabilities: {} });
+
+    if (transport.kind === 'stdio') {
+        const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+        await client.connect(
+            new StdioClientTransport({
+                command: transport.command,
+                args: transport.args,
+                env: transport.env,
+            }),
+        );
+    } else {
+        const { StreamableHTTPClientTransport } = await import(
+            '@modelcontextprotocol/sdk/client/streamableHttp.js'
+        );
+        await client.connect(
+            new StreamableHTTPClientTransport(new URL(transport.url), {
+                requestInit: transport.headers ? { headers: transport.headers } : undefined,
+            }),
+        );
+    }
+
+    return {
+        async listTools() {
+            const res = await client.listTools();
+            return (res.tools ?? []) as McpToolDescriptor[];
+        },
+        async callTool(name, args) {
+            return client.callTool({ name, arguments: args });
+        },
+        async close() {
+            await client.close();
+        },
+    };
+}
+
+/**
+ * Connect to an MCP server, discover its tools, and build a {@link Connector}
+ * whose actions dispatch to the server's `tools/call`. The connection is held
+ * open for the lifetime of the bundle; call {@link McpConnectorBundle.close} to
+ * tear it down.
+ */
+export async function createMcpConnector(opts: McpConnectorOptions): Promise<McpConnectorBundle> {
+    const clientInfo = opts.clientInfo ?? DEFAULT_CLIENT_INFO;
+    const factory = opts.clientFactory ?? defaultClientFactory;
+
+    const client = await factory(opts.transport, clientInfo);
+
+    let tools: McpToolDescriptor[];
+    try {
+        tools = await client.listTools();
+    } catch (err) {
+        // Discovery failed after connecting — release the connection rather than
+        // leaking it, then surface the error to the caller (the plugin fail-soft).
+        await client.close().catch(() => {});
+        throw err;
+    }
+
+    const include = opts.include ?? (() => true);
+    const selected = tools.filter((t) => include(t.name));
+
+    const name = opts.name ?? slugify(opts.label ?? 'mcp');
+    const label = opts.label ?? titleize(name);
+
+    const handlers: McpConnectorBundle['handlers'] = {};
+    const def: Connector = {
+        name,
+        label,
+        type: 'api',
+        description:
+            opts.description ?? `MCP connector exposing ${selected.length} tool(s) from a Model Context Protocol server.`,
+        icon: opts.icon ?? 'plug',
+        // MCP servers own their own auth (passed via transport env/headers); we
+        // do not model the upstream's credentials in ConnectorSchema (ADR-0024 §3).
+        authentication: { type: 'none' },
+        // Defaulted by ConnectorSchema; set explicitly so the literal satisfies
+        // the (post-parse) Connector output type.
+        status: 'active',
+        enabled: true,
+        connectionTimeoutMs: 30000,
+        requestTimeoutMs: 30000,
+        actions: selected.map((tool) => ({
+            key: tool.name,
+            // MCP tool names are machine names; derive a readable label and keep
+            // the server's description verbatim (ADR-0024 `description → label/description`).
+            label: titleize(slugify(tool.name)),
+            description: tool.description,
+            // The MCP inputSchema is already JSON Schema — pass it straight through.
+            inputSchema: tool.inputSchema,
+            // Many servers omit outputSchema; leave it unset when absent (as the
+            // REST connector does for untyped responses).
+            outputSchema: tool.outputSchema,
+        })),
+    };
+
+    for (const tool of selected) {
+        handlers[tool.name] = async (input) => normalizeResult(await client.callTool(tool.name, input));
+    }
+
+    return {
+        def,
+        handlers,
+        close: () => client.close(),
+    };
+}

--- a/packages/connectors/connector-mcp/tsconfig.json
+++ b/packages/connectors/connector-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,6 +662,31 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/connectors/connector-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@objectstack/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../spec
+    devDependencies:
+      '@objectstack/service-automation':
+        specifier: workspace:*
+        version: link:../../services/service-automation
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/connectors/connector-rest:
     dependencies:
       '@objectstack/core':


### PR DESCRIPTION
## Summary

Implements [ADR-0024](docs/adr/0024-mcp-connectors.md): ship `@objectstack/connector-mcp`, a **single generic adapter** that turns *any* Model Context Protocol (MCP) server into an ordinary `type: 'api'` connector on the automation engine — with **no per-server code**. One adapter unlocks the entire MCP ecosystem (filesystem, GitHub, Slack, databases, search, hundreds of community servers).

## What's in the package

Mirrors the `connector-rest` / `connector-slack` conventions (Apache-2.0, tsup build, a `create…Connector` factory + a `…Plugin`).

- **`createMcpConnector({ transport, include?, … })`** — connects over **stdio** or **streamable-HTTP**, calls `tools/list`, and builds the `Connector` definition once. Each tool maps mechanically to an action (`name → key`, `description → label/description`, `inputSchema → inputSchema`); each handler closes over the tool name and dispatches to `tools/call`. Results normalise to the shared `{ ok, content, … }` envelope — a logical tool error surfaces as `ok: false` rather than throwing, so a flow can branch on `${node.ok}`.
- **`ConnectorMcpPlugin`** — registers the connector through the existing `engine.registerConnector()` path (**no new engine surface, no `mcp_call` node, no parallel registry** — the anti-patterns ADR-0024 §5 rules out) and tears the MCP connection down on `destroy()`. Fail-soft: an unreachable server or a missing automation engine is logged and skipped.
- After construction the registry, the `connector_action` node, the discovery route, and the Studio palette all see a plain connector — they never know it is MCP-backed (ADR-0024 §2).

## Security posture (ADR-0024 §3)

Credentials live **with the MCP server**, not in `ConnectorSchema`. The operator-supplied transport `env` (stdio) / `headers` (http) are passed straight to the MCP client and kept out of the serialized, discovery-exposed `def`. The open tier runs an operator-provided server with operator-provided credentials; managed secrets, per-tenant lifecycle, and sandboxed stdio execution remain the **enterprise tier** (§4).

## Implementation notes

- The real MCP SDK client is **lazily imported and injectable** (`clientFactory`), mirroring `connector-rest`'s `fetchImpl` — so unit tests stay hermetic and the SDK only loads when a real connection is made.
- The `Plugin` lifecycle exposes `destroy()` (not `stop()`), so teardown is wired to `destroy()` to ensure the MCP connection / child process is actually released on shutdown.

## Testing

- `pnpm build` — ✅ ESM + CJS + DTS
- `pnpm exec tsc --noEmit` — ✅ strict
- `pnpm test` — ✅ 9 passing (discovery → action mapping, `include` allowlist, `tools/call` dispatch + result normalisation incl. `isError`, lifecycle/`close`, and an end-to-end flow through `LiteKernel` + the automation engine)

## Follow-ups (out of scope, per ADR-0024)

- A worked `examples/` entry (reference filesystem / GitHub MCP server → allowlisted actions in a flow).
- Wiring MCP-backed actions into the ADR-0011 AI-tool surface.

https://claude.ai/code/session_01G9v2WA48voVBSkQ7sjFkqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9v2WA48voVBSkQ7sjFkqC)_