### PR TITLE
docs: plugin distribution design (ADR-0025/0026 + design doc)

### DIFF
--- a/docs/adr/0025-plugin-package-distribution.md
+++ b/docs/adr/0025-plugin-package-distribution.md
@@ -1,0 +1,358 @@
+# ADR-0025: Plugin Package Distribution (Code + Dependencies)
+
+**Status**: Proposed
+**Deciders**: ObjectStack Protocol Architects
+**Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0004](./0004-cloud-multi-kernel.md) (cloud multi-kernel), [ADR-0010](./0010-metadata-protection-model.md) (L1/L2/L3 protection), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (package authoring & publish, local export/import)
+**Consumers**: `@objectstack/core` (kernel, plugin-loader, security), `@objectstack/runtime` (sandbox, marketplace install), `@objectstack/cli`, `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`, `../objectui` (Studio)
+
+---
+
+## 0. Context
+
+ObjectStack already ships a clean, low-risk distribution path for
+**pure-element packages** (metadata-only): a package is authored visually in
+Studio, bound to a `package_id`, compiled/exported to a single self-contained
+JSON manifest, and installed by **hot-registering** that JSON into the running
+engine (`engine.registerApp`). The publish/install loop is trivial precisely
+because the artifact is *declarative data* — no code runs, so there is nothing
+to build, no dependencies to resolve, and no trust boundary to cross.
+
+- Publish: `os package publish` → `POST /cloud/packages` → `POST
+  /cloud/packages/:id/versions` (snapshots `dist/objectstack.json` into
+  `sys_package_version.manifest_json`). See
+  `packages/cli/src/commands/package/publish.ts`.
+- Install (cloud): browse via `MarketplaceProxyPlugin`, install on cloud.
+- Install (local): `POST /api/v1/marketplace/install-local` with an inline
+  manifest, hot-registered into the kernel and cached on disk. See
+  `packages/runtime/src/cloud/marketplace-install-local-plugin.ts` and
+  ADR-0016 §9.
+
+The next step is **plugins**: distributable units that contain **executable
+code and npm dependencies**, not just metadata. The repository already has the
+*authoring* half of this story:
+
+- `packages/plugins/*` are real npm packages — each has a `package.json` (deps,
+  `tsup` build → `dist/`), an `objectstack.config.ts` exporting an
+  `ObjectStackManifest` (`id`, `type`, `capabilities` =
+  implements/provides/requires/extensionPoints/contributes, `configuration`
+  schema), and a `src/index.ts` with a lifecycle entry point.
+- The microkernel can already *load* code plugins: `packages/core/src/
+  plugin-loader.ts` (dependency ordering, health checks, `signature` field,
+  `startupTimeout`, `hotReloadable`), `packages/core/src/types.ts` (`Plugin`
+  with `init/start/destroy` + `PluginContext`),
+  `packages/core/src/security/plugin-permission-enforcer.ts`
+  (capability-based service/hook/file/network enforcement),
+  `PluginConfigValidator`, and `packages/runtime/src/sandbox/quickjs-runner.ts`
+  (a QuickJS-WASM sandbox that wires only capability-gated `ctx.api/crypto/log`
+  into untrusted code).
+
+**What is missing is the distribution layer**: there is no artifact format for
+code plugins, no build→sign→publish pipeline, and no permissioned install flow.
+A code plugin cannot be a JSON blob — it must be built, its dependencies must
+be resolved, and because it executes inside (or alongside) the host process it
+introduces a **trust boundary** the JSON flow never had.
+
+## 1. Goals & Non-goals
+
+### Goals
+
+- A distributable **plugin artifact** (`.osplugin`) for code + dependencies,
+  built deterministically from a plugin source package.
+- A **build → sign → publish** pipeline that extends `os package publish`
+  rather than forking a parallel system.
+- A **permissioned install flow**: compatibility check → explicit permission
+  consent → verified download → materialize → register → load.
+- A **trust/isolation tiering** that decides *how* plugin code is loaded
+  (in-process, sandboxed, out-of-process), reusing the existing loader,
+  permission enforcer, and QuickJS sandbox.
+- **Local-first parity** (ADR-0016 §9): install a local `.osplugin` with no
+  cloud account, mirroring `marketplace/install-local`.
+- **Unification**: a pure-element package is the degenerate case of a plugin
+  (empty `dist`, no permissions); both go through one install superset.
+
+### Non-goals
+
+- Marketplace monetization / billing (separate `service-marketplace`).
+- A from-scratch package registry: we reuse the `sys_*` schema family and add
+  blob storage for the artifact.
+- Full out-of-process isolation (Tier 2) in v1 — the design reserves the seam
+  but the first slice targets Tier 0/Tier 1.
+- Replacing the metadata-only JSON flow — it remains the fast path and becomes
+  a special case.
+
+## 2. Decision
+
+Introduce a **signed `.osplugin` artifact**, a **build/sign/publish pipeline**
+that stores both browsable JSON metadata *and* the binary artifact, and a
+**permissioned install flow** governed by trust tiers. Default packaging is
+**bundled** (dependencies pre-bundled into `dist`) so that, like the JSON flow,
+install is "unpack + verify" with **no npm at install time**.
+
+## 3. Detailed design
+
+### 3.1 Artifact format — `.osplugin`
+
+A `.osplugin` is a `tar.gz`:
+
+```
+<id>-<version>.osplugin
+├── objectstack.plugin.json   # compiled manifest (see §3.2)
+├── dist/                     # pre-built ESM bundle (tsup output)
+├── package.json              # runtime deps — only for the manifest-deps strategy
+├── pnpm-lock.yaml            # locked deps — only for the manifest-deps strategy
+├── assets/ README LICENSE icon
+└── SIGNATURE                 # detached signature + publisher cert chain
+```
+
+### 3.2 Compiled manifest (`objectstack.plugin.json`)
+
+Extends the existing `ObjectStackManifest` with three new blocks
+(`engines`, `runtime`, `permissions`, `integrity`):
+
+```jsonc
+{
+  "id": "com.acme.crm-enrich",
+  "version": "1.2.0",
+  "type": "plugin",
+  "engines": { "platform": ">=4.0 <5", "protocol": ">=1.0" },
+  "runtime": "node",                  // node | sandbox | worker  (see §3.6)
+  "packaging": "bundled",             // bundled | manifest-deps  (see §3.3)
+  "permissions": {                    // explicitly requested capabilities
+    "services": ["object", "http"],
+    "hooks": ["record.beforeInsert"],
+    "network": ["api.acme.com"],
+    "fs": []
+  },
+  "integrity": { "dist/index.mjs": "sha256-..." },  // per-file hashes
+  "configuration": { /* existing config schema (PluginConfigValidator) */ },
+  "capabilities": { /* existing implements/provides/requires/contributes */ },
+  "contributes": { /* OPTIONAL declarative metadata: objects/views/flows/... */ }
+}
+```
+
+`permissions` is the one new protocol surface the runtime must understand at
+install/load time; everything else is additive. `permissions` maps 1:1 onto the
+checks the existing `PluginPermissionEnforcer` already implements
+(`canAccessService`, `canTriggerHook`, `canReadFile/Write`, `canNetworkRequest`).
+
+### 3.3 Packaging strategies (default: bundled)
+
+- **Bundled (default, recommended).** `tsup` with `noExternal` bundles all JS
+  dependencies into `dist`. Native (`.node`) addons are disallowed. Install =
+  unpack + verify; **no npm/toolchain at install time**. This is the closest
+  analog to the JSON flow and keeps the security surface minimal.
+- **manifest-deps (opt-in).** Ships `package.json` + `pnpm-lock.yaml`; install
+  runs `pnpm install --frozen-lockfile --ignore-scripts` in an isolated dir.
+  Only for plugins that genuinely need native addons or very large deps; slower
+  and requires a toolchain/network at install. Disallowed for unverified
+  publishers (§3.7).
+
+### 3.4 Build → sign → publish pipeline
+
+```
+os plugin build  →  os plugin sign  →  os plugin publish
+```
+
+1. **build** — run `tsup`; validate the manifest (Zod `ObjectStackManifest` +
+   new `permissions` schema); check `engines.platform/protocol`; compute
+   per-file `integrity` hashes; emit `<id>-<version>.osplugin`.
+2. **sign** — sign the artifact with the publisher key (reuses the
+   `PluginMetadata.signature` field). May be done server-side at publish.
+3. **publish** — extends `os package publish`:
+   - `POST /cloud/plugins` → ensure a `sys_plugin` row (reverse-domain `id`,
+     `owner_org_id`).
+   - `POST /cloud/plugins/:id/versions` → upload the `.osplugin` blob to object
+     storage; store metadata (manifest, `permissions`, `integrity`, signature,
+     `engines`, size, SBOM) in `sys_plugin_version` with
+     `status: pending_review → published`.
+   - **Server-side gates**: manifest schema validation; secret/malware/known-vuln
+     dependency scan; **permission audit** (sensitive permissions trigger human
+     review); marketplace **counter-signs** with the platform key on approval.
+   - `marketplace_listed` flag reuses ADR-0016's catalog model so plugins appear
+     in the same marketplace as packages, with a "contains code" badge and a
+     permission-disclosure screen.
+
+The registry therefore stores **both** the browsable JSON metadata (unified
+marketplace UX with packages) **and** the binary artifact blob.
+
+### 3.5 Install flow
+
+Install is a deliberate, **permissioned** action — the key difference from the
+JSON flow:
+
+```
+resolve → compat check → permission consent → download+verify → materialize → register → load
+```
+
+1. **Resolve.** Ask the registry for `id@version` (or latest matching the engine
+   range); receive manifest + download URL + signature + declared permissions +
+   dependency closure.
+2. **Compatibility.** Verify `engines.platform/protocol` against the host;
+   resolve plugin→plugin `requires` deps and topologically order them (reuse the
+   loader's dependency ordering); fetch deps too.
+3. **Permission consent (new).** Present the declared `permissions` (services /
+   hooks / fs / network / extension points) to the admin. The **granted set** is
+   persisted and later enforced by `PluginPermissionEnforcer`.
+4. **Download + verify.** Download the `.osplugin`; verify the signature against
+   trusted publisher + marketplace keys; verify each file against `integrity`.
+   Reject on any mismatch.
+5. **Materialize.** Unpack to a per-environment, per-plugin dir
+   `<OS_HOME>/plugins/<env>/<id>/<version>/`. For manifest-deps, run
+   `pnpm install --frozen-lockfile --ignore-scripts` here.
+6. **Register.** Write `sys_plugin_installation` (`env_id`, `plugin_id`,
+   `version_id`, `granted_permissions`, `status`, `is_preview`) — parallel to
+   `sys_package_installation`. Persist to a local store so installs survive
+   restarts (reuse the ADR-0016 §9.7 `package-state-store.ts` pattern).
+7. **Load + activate.** On next boot (or hot, when `hotReloadable`), the loader
+   scans installed plugins, dynamic-imports the entry, wraps `PluginContext`
+   with the enforcer scoped to the granted set, and runs `init → start` in
+   dependency order. If the plugin also has `contributes` metadata, that JSON is
+   hot-registered exactly like a pure-element package.
+
+**Local-first parity.** `os plugin install ./foo.osplugin` and a Studio "Install
+plugin" upload both hit a `marketplace/install-local`-style endpoint (inline
+artifact, register-before-persist per ADR-0016 §9.3). Local artifacts need no
+cloud account; signature verification is still performed (publisher key or an
+explicit `--trust-unsigned` dev override).
+
+### 3.6 Trust / isolation tiers
+
+Because plugins execute code, the manifest's `runtime` field selects *how* the
+code is loaded:
+
+| Tier | `runtime` | How loaded | For | Status |
+|---|---|---|---|---|
+| **T0 Trusted** | `node` | In-process dynamic `import`; full `PluginContext` gated by declared capabilities | First-party / org-signed / verified plugins | loader exists |
+| **T1 Sandboxed** | `sandbox` | QuickJS-WASM (`quickjs-runner.ts`); no Node API; only capability-gated `ctx.api/crypto/log` | Pure-logic plugins (hooks, formulas, transforms) | sandbox exists; extend to "script plugins" |
+| **T2 Out-of-process** | `worker` | Worker thread / child process / WASM component + RPC bridge; crash/timeout/memory isolation | Untrusted 3rd-party needing richer APIs | reserved (future) |
+
+The marketplace may **force a lower-privilege tier** for unverified publishers
+(e.g. only `sandbox`/`worker`).
+
+### 3.7 Security model (reuses existing components)
+
+- **Signing.** `PluginMetadata.signature` exists. Publisher signs; marketplace
+  counter-signs on approval. Host ships trusted root keys; verify the chain at
+  install (§3.5 step 4) **and** at load (§3.5 step 7).
+- **Permissions.** New manifest `permissions` block → install-time consent →
+  granted set → `PluginPermissionEnforcer` (service/hook/file/network already
+  enforced). Principle of least privilege; all denials logged (existing
+  behavior).
+- **Config.** `PluginConfigValidator` validates plugin config against the
+  `configuration` schema.
+- **Supply chain.** Lockfile + per-file `integrity`; server-side scan for
+  secrets and known-vuln deps; SBOM stored on the version row; **always**
+  `--ignore-scripts` (no `postinstall`).
+- **Reversible disable.** Reuse the package enable/disable + disable-state-store
+  (ADR-0016 §9.5/§9.7): disabling a plugin stops loading its code and unregisters
+  its contributions on next boot.
+
+### 3.8 Versioning & lifecycle
+
+Reuse the `sys_*` shape:
+
+| Concern | Artifact |
+|---|---|
+| Plugin identity | `sys_plugin` (reverse-domain id, owner org, `marketplace_listed`) |
+| Immutable version | `sys_plugin_version` (semver, checksum, signature, `permissions`, `engines`, SBOM, blob pointer, `status`) |
+| Install state | `sys_plugin_installation` (`env_id`, `version_id`, `granted_permissions`, `is_preview`, `status`) |
+
+`engines` ranges gate compatibility; support deprecate/yank. **Update** = install
+the new version side-by-side, swap the installation pointer; if the new version
+**widens permissions**, require re-consent before activation.
+
+### 3.9 Composition with metadata packages (unification)
+
+A plugin may also ship declarative metadata via `contributes`. Install is then a
+**superset**: hot-register the JSON *and* load the code + grant permissions. A
+pure-element package is the degenerate plugin — `dist` empty, `permissions`
+empty — so it falls straight back onto today's simple JSON path. One install
+pipeline, two ends of a spectrum.
+
+## 4. Phasing
+
+- **Phase 1 — Artifact & build.** Define `.osplugin` + `objectstack.plugin.json`
+  (`permissions`/`engines`/`runtime` Zod schema in `@objectstack/spec/system`);
+  `os plugin build` (bundled strategy only); per-file integrity.
+- **Phase 2 — Local install.** `os plugin install ./x.osplugin` + Studio upload
+  → `marketplace/install-local`-style endpoint; materialize; `sys_plugin_*`
+  rows + disable-state persistence; T0 in-process load with permission consent.
+- **Phase 3 — Signing & registry.** Publisher signing + verification; `POST
+  /cloud/plugins` + `/versions` (blob storage); marketplace listing + permission
+  disclosure UI; server-side scans + counter-signing.
+- **Phase 4 — Sandbox tier.** T1 `sandbox` runtime for script plugins via
+  QuickJS; marketplace tier enforcement for unverified publishers.
+- **Phase 5 — manifest-deps & T2.** Opt-in `manifest-deps` packaging
+  (`pnpm install --ignore-scripts`); reserve and prototype out-of-process T2.
+
+## 5. Consequences
+
+### Positive
+
+- Closes the distribution gap for code plugins while **reusing** the kernel
+  loader, permission enforcer, QuickJS sandbox, and `sys_*` schema family.
+- Bundled-default keeps install nearly as simple as the JSON flow (unpack +
+  verify, no npm).
+- Explicit permission consent makes the new trust boundary visible and
+  auditable rather than implicit.
+- Unifies packages and plugins under one marketplace and one install superset.
+
+### Negative
+
+- Introduces a binary artifact + blob storage + signing/key management the
+  JSON-only flow never needed.
+- Permission consent + tiering add UX and lifecycle surface (re-consent on
+  permission widening, tier enforcement).
+- Bundled packaging excludes native addons by default (mitigated by the opt-in
+  manifest-deps strategy in Phase 5).
+
+### Neutral
+
+- The metadata-only JSON flow is unchanged and becomes the degenerate case.
+- Local-first install mirrors ADR-0016 §9; cloud publish layers on top.
+
+## 6. Alternatives considered
+
+1. **Distribute plugins as plain npm packages installed via `npm i`.** Rejected:
+   no signing, no permission consent, no `engines`/protocol gating, arbitrary
+   `postinstall` scripts — the trust boundary is wide open and install depends on
+   a registry + toolchain on every host.
+2. **Ship raw source and build on the host at install.** Rejected: slow,
+   non-deterministic, requires a full toolchain per host, and complicates
+   integrity/signing.
+3. **A second, parallel plugin registry separate from packages.** Rejected:
+   forks the marketplace UX and the `sys_*` schema; the superset/degenerate-case
+   model keeps one pipeline.
+4. **Always sandbox (no T0 in-process tier).** Rejected for v1: first-party and
+   verified plugins need full host APIs and performance; tiering lets policy, not
+   architecture, decide the privilege level.
+
+## 7. Open questions
+
+- **Key management & rotation.** Where do publisher keys live, and how are root
+  keys rotated/revoked on the host?
+- **Permission widening UX.** Auto-disable on update until re-consent, or run
+  with the old grant until an admin approves?
+- **Hot vs boot activation.** Which plugin types are safe to hot-load
+  (`hotReloadable`) vs require a restart to fully (un)register contributions?
+- **T2 RPC surface.** What is the minimal host-service RPC contract an
+  out-of-process plugin gets, and how does the enforcer mediate it?
+- **Cross-plugin dependency conflicts.** How are diamond dependencies / version
+  conflicts in plugin `requires` resolved at install time?
+
+## 8. References
+
+- [ADR-0003](./0003-package-as-first-class-citizen.md) — Package + versioned releases
+- [ADR-0004](./0004-cloud-multi-kernel.md) — Cloud multi-kernel
+- [ADR-0010](./0010-metadata-protection-model.md) — L1/L2/L3 protection
+- [ADR-0016](./0016-studio-package-authoring-and-publish.md) — Package authoring & publish; local export/import (§9)
+- `packages/core/src/plugin-loader.ts` — plugin loading, lifecycle, health, signature
+- `packages/core/src/types.ts` — `Plugin` (`init/start/destroy`) + `PluginContext`
+- `packages/core/src/security/plugin-permission-enforcer.ts` — capability-based enforcement
+- `packages/core/src/security/plugin-config-validator.ts` — config validation
+- `packages/runtime/src/sandbox/quickjs-runner.ts` — QuickJS-WASM sandbox (T1)
+- `packages/runtime/src/cloud/marketplace-install-local-plugin.ts` — local inline install (ADR-0016 §9)
+- `packages/runtime/src/cloud/marketplace-proxy-plugin.ts` — marketplace browse proxy
+- `packages/runtime/src/package-state-store.ts` — per-environment disable-state persistence
+- `packages/cli/src/commands/package/publish.ts` — existing package publish pipeline
+- `packages/plugins/driver-memory/objectstack.config.ts` — example plugin manifest (`ObjectStackManifest`)

--- a/docs/adr/0025-plugin-package-distribution.md
+++ b/docs/adr/0025-plugin-package-distribution.md
@@ -4,6 +4,22 @@
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0004](./0004-cloud-multi-kernel.md) (cloud multi-kernel), [ADR-0010](./0010-metadata-protection-model.md) (L1/L2/L3 protection), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (package authoring & publish, local export/import)
 **Consumers**: `@objectstack/core` (kernel, plugin-loader, security), `@objectstack/runtime` (sandbox, marketplace install), `@objectstack/cli`, `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`, `../objectui` (Studio)
+**Related**: [ADR-0026](./0026-client-ui-plugin-distribution.md) (client-side UI plugins — out of scope here), [ADR-0007](./0007-settings-manifest-and-kv-store.md) (settings + secret store), [ADR-0022](./0022-connectors-vs-messaging-channels.md)/[ADR-0023](./0023-openapi-to-connector-generator.md)/[ADR-0024](./0024-mcp-connectors.md) (connectors)
+
+---
+
+> **Revision note (2026-06-01) — read §3.10 first.** §§1–3.9 capture the original
+> two-channel framing (declarative JSON package vs. `.osplugin` code plugin).
+> A scenario review (what the marketplace actually needs to carry) surfaced six
+> refinements, consolidated in **§3.10**. The headline corrections: (1) trust is
+> **default-deny** — third-party plugins default to an isolated tier, in-process
+> `node` is opt-in via verification; (2) `@objectstack/*` deps are **externalized
+> as peer deps** (host-provided singletons), never bundled; (3) compatibility is
+> gated **protocol-first**, not on platform semver; (4) plugin permissions compose
+> with the **object/field-level RLS** layer; (5) secrets live in the **settings/KV
+> store** (ADR-0007), never in the artifact; (6) connectors span a declarative
+> (OpenAPI/MCP-generated) sub-path, not only hand-written code plugins. Client-side
+> **UI** plugins are split out to ADR-0026.
 
 ---
 
@@ -79,6 +95,12 @@ introduces a **trust boundary** the JSON flow never had.
   but the first slice targets Tier 0/Tier 1.
 - Replacing the metadata-only JSON flow — it remains the fast path and becomes
   a special case.
+- **Client-side UI plugins** (custom field renderers, view types, widgets) —
+  these load in the browser and need a different module/sandbox model; see
+  ADR-0026.
+- **Sandboxed-script packages** (validations, formulas, small automations) — these
+  ride the existing JSON flow + QuickJS bodies (the "L1" layer in §3.10) and need
+  neither the `.osplugin` pipeline nor an install-time permission prompt.
 
 ## 2. Decision
 
@@ -146,6 +168,14 @@ checks the existing `PluginPermissionEnforcer` already implements
   Only for plugins that genuinely need native addons or very large deps; slower
   and requires a toolchain/network at install. Disallowed for unverified
   publishers (§3.7).
+
+**Externalize the host runtime (both strategies).** `@objectstack/*` packages
+(`core`, `spec`, …) are declared as **peerDependencies** and marked `external` in
+the bundle — the plugin binds to the **host's** copy at load time. Bundling them
+would create a second engine/Zod instance inside the plugin (duplicate registries,
+broken `instanceof`, double validation). Rule: **bundle third-party libs,
+externalize `@objectstack/*` (host-provided singletons)**. Version compatibility
+of these peers is gated by §3.8.
 
 ### 3.4 Build → sign → publish pipeline
 
@@ -226,8 +256,13 @@ code is loaded:
 | **T1 Sandboxed** | `sandbox` | QuickJS-WASM (`quickjs-runner.ts`); no Node API; only capability-gated `ctx.api/crypto/log` | Pure-logic plugins (hooks, formulas, transforms) | sandbox exists; extend to "script plugins" |
 | **T2 Out-of-process** | `worker` | Worker thread / child process / WASM component + RPC bridge; crash/timeout/memory isolation | Untrusted 3rd-party needing richer APIs | reserved (future) |
 
-The marketplace may **force a lower-privilege tier** for unverified publishers
-(e.g. only `sandbox`/`worker`).
+**Trust is default-deny.** Tier 0 (`node`, in-process) means *arbitrary code in
+the host process* — the platform's single biggest risk surface. It is **reserved
+for first-party and verified/enterprise-signed publishers**. Community / unverified
+third-party plugins **default to T1 (`sandbox`) or T2 (`worker`)**; `node` is an
+opt-in privilege unlocked only after publisher verification. The marketplace
+enforces this at publish time (an unverified publisher cannot ship `runtime:
+'node'`), not merely "may force" it at install.
 
 ### 3.7 Security model (reuses existing components)
 
@@ -257,9 +292,14 @@ Reuse the `sys_*` shape:
 | Immutable version | `sys_plugin_version` (semver, checksum, signature, `permissions`, `engines`, SBOM, blob pointer, `status`) |
 | Install state | `sys_plugin_installation` (`env_id`, `version_id`, `granted_permissions`, `is_preview`, `status`) |
 
-`engines` ranges gate compatibility; support deprecate/yank. **Update** = install
-the new version side-by-side, swap the installation pointer; if the new version
-**widens permissions**, require re-consent before activation.
+Compatibility is gated **protocol-first** (per §3.10 #3): the host checks that it
+provides every `capabilities.implements[].protocol` at a compatible version, then
+falls back to `engines.platform`/`engines.protocol` ranges as a secondary guard.
+This is more stable than platform semver and reuses the existing capability
+declaration. Support deprecate/yank. **Update** = install the new version
+side-by-side, swap the installation pointer; if the new version **widens
+permissions** (services, hooks, network hosts, or RLS scopes — §3.10 #4), require
+re-consent before activation.
 
 ### 3.9 Composition with metadata packages (unification)
 
@@ -268,6 +308,56 @@ A plugin may also ship declarative metadata via `contributes`. Install is then a
 pure-element package is the degenerate plugin — `dist` empty, `permissions`
 empty — so it falls straight back onto today's simple JSON path. One install
 pipeline, two ends of a spectrum.
+
+### 3.10 Refinements from scenario review (2026-06-01)
+
+A pass over *what the marketplace must actually carry* (vertical apps, templates,
+drivers, connectors, AI extensions, auth, automation, governance, UI widgets)
+yielded a sharper model and six corrections.
+
+**Three artifact layers, not two.** The metadata/code split is really a spectrum:
+
+| Layer | Form | Install trust decision | Channel |
+|---|---|---|---|
+| **L0 declarative** | objects/views/flows/dashboards/permissions/themes/translations JSON | none (it is data) | existing JSON hot-register |
+| **L1 declarative + sandboxed script** | JSON carrying L1 expression / L2 `ScriptBody` (validations, formulas, small automations) | "scripts allowed" only; runs in the existing QuickJS sandbox | JSON flow — **no `.osplugin`** |
+| **L2 code plugin** | real npm deps + host APIs (drivers, connectors, AI, auth, …) | explicit permission consent + signature | `.osplugin` (this ADR) |
+
+Recognizing **L1** explicitly means most "custom logic" (the bulk of what users
+think needs code) rides the simple JSON flow + sandbox and never touches the
+heavy code-plugin pipeline. This *strengthens* the §3.9 superset/spectrum claim.
+
+**The six corrections:**
+
+1. **Default-deny trust (see §3.6).** T0 in-process is reserved for first-party /
+   verified publishers; third-party defaults to T1/T2; enforced at publish.
+2. **Externalize `@objectstack/*` (see §3.3).** Host runtime is a peer-dep
+   singleton; bundling it forks the engine.
+3. **Protocol-first compatibility (see §3.8).** Gate primarily on the
+   `capabilities.implements[].protocol` version the host provides (e.g.
+   `storage.protocol.v1`), with `engines.platform` as a secondary guard —
+   protocols are stable across platform major versions, semver is not.
+4. **Permissions compose with RLS.** The coarse service/hook/file/network gate is
+   necessary but not sufficient for connectors. Data-affecting permissions
+   (which objects/fields a plugin may read/write, which OAuth scopes, which
+   external hosts) must compose with the platform's object/field-level security
+   (`plugin-security` / RLS), not be a parallel coarse gate. The granted set in
+   `sys_plugin_installation` therefore references RLS scopes, not just service
+   names.
+5. **Secrets never ship in the artifact.** Connectors need credentials
+   (API keys, OAuth tokens). The `.osplugin` must not carry secrets; the
+   `configuration` schema marks secret fields, and install wires them to the
+   platform settings / KV secret store (ADR-0007) via secret-refs. The plugin
+   reads them through `PluginContext`, gated by the network/service permission.
+6. **Connectors span declarative + code.** With ADR-0023 (OpenAPI→connector) and
+   ADR-0024 (MCP connectors), any integration describable by OpenAPI/MCP is a
+   **declarative connector config** (closer to L0/L1); only integrations needing
+   custom auth, pagination, or streaming fall to an L2 code plugin. The connector
+   catalog is therefore not monolithically "code plugins."
+
+**Client-side UI plugins** (field renderers, view types, widgets) are a real
+marketplace need this ADR does **not** cover — they load in the browser and need
+a module-federation / iframe-sandbox model. Split to **ADR-0026**.
 
 ## 4. Phasing
 
@@ -346,6 +436,10 @@ pipeline, two ends of a spectrum.
 - [ADR-0004](./0004-cloud-multi-kernel.md) — Cloud multi-kernel
 - [ADR-0010](./0010-metadata-protection-model.md) — L1/L2/L3 protection
 - [ADR-0016](./0016-studio-package-authoring-and-publish.md) — Package authoring & publish; local export/import (§9)
+- [ADR-0007](./0007-settings-manifest-and-kv-store.md) — Settings manifest + KV/secret store (§3.10 #5)
+- [ADR-0022](./0022-connectors-vs-messaging-channels.md) / [ADR-0023](./0023-openapi-to-connector-generator.md) / [ADR-0024](./0024-mcp-connectors.md) — Connectors: declarative generation vs. code plugins (§3.10 #6)
+- [ADR-0026](./0026-client-ui-plugin-distribution.md) — Client-side UI plugin distribution (browser module/sandbox)
+- `packages/plugins/plugin-security/` — RBAC/RLS; composes with plugin permissions (§3.10 #4)
 - `packages/core/src/plugin-loader.ts` — plugin loading, lifecycle, health, signature
 - `packages/core/src/types.ts` — `Plugin` (`init/start/destroy`) + `PluginContext`
 - `packages/core/src/security/plugin-permission-enforcer.ts` — capability-based enforcement

--- a/docs/adr/0025-plugin-package-distribution.md
+++ b/docs/adr/0025-plugin-package-distribution.md
@@ -4,7 +4,7 @@
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0004](./0004-cloud-multi-kernel.md) (cloud multi-kernel), [ADR-0010](./0010-metadata-protection-model.md) (L1/L2/L3 protection), [ADR-0016](./0016-studio-package-authoring-and-publish.md) (package authoring & publish, local export/import)
 **Consumers**: `@objectstack/core` (kernel, plugin-loader, security), `@objectstack/runtime` (sandbox, marketplace install), `@objectstack/cli`, `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`, `../objectui` (Studio)
-**Related**: [ADR-0026](./0026-client-ui-plugin-distribution.md) (client-side UI plugins — out of scope here), [ADR-0007](./0007-settings-manifest-and-kv-store.md) (settings + secret store), [ADR-0022](./0022-connectors-vs-messaging-channels.md)/[ADR-0023](./0023-openapi-to-connector-generator.md)/[ADR-0024](./0024-mcp-connectors.md) (connectors)
+**Related**: [ADR-0019](./0019-app-as-consumer-unit.md) (App is the only consumer-facing unit — this pipeline serves developers/operators, see §3.11), [ADR-0026](./0026-client-ui-plugin-distribution.md) (client-side UI plugins — out of scope here), [ADR-0007](./0007-settings-manifest-and-kv-store.md) (settings + secret store), [ADR-0022](./0022-connectors-vs-messaging-channels.md)/[ADR-0023](./0023-openapi-to-connector-generator.md)/[ADR-0024](./0024-mcp-connectors.md) (connectors)
 
 ---
 
@@ -19,7 +19,10 @@
 > with the **object/field-level RLS** layer; (5) secrets live in the **settings/KV
 > store** (ADR-0007), never in the artifact; (6) connectors span a declarative
 > (OpenAPI/MCP-generated) sub-path, not only hand-written code plugins. Client-side
-> **UI** plugins are split out to ADR-0026.
+> **UI** plugins are split out to ADR-0026. **Audience (§3.11):** per ADR-0019 the
+> only consumer-facing unit is the **App**; this `.osplugin` pipeline serves
+> **developers/operators/ISVs** — plugins reach a tenant *bundled inside an App* or
+> *operator-provisioned*, never browsed/installed by an end consumer.
 
 ---
 
@@ -359,6 +362,53 @@ heavy code-plugin pipeline. This *strengthens* the §3.9 superset/spectrum claim
 marketplace need this ADR does **not** cover — they load in the browser and need
 a module-federation / iframe-sandbox model. Split to **ADR-0026**.
 
+### 3.11 Audience & relation to ADR-0019 (consumer surface)
+
+ADR-0019 makes the **App** the *only* consumer-facing unit: a consumer browses,
+installs, opens, and uninstalls an **App** (`type: app`), and **internal
+contributions** — `plugin`, `driver`, `server`, `ui`, `theme`, `agent`, … — are
+*never* independently installed by a consumer (`isConsumerInstallable` filters the
+consumer Marketplace to `type: app`). This ADR must not be read as "consumers
+install plugins from a marketplace." It is reconciled as follows:
+
+1. **Audience = developers / operators / ISVs, not end consumers.** The
+   `.osplugin` pipeline is the **supply-side mechanism** for code-bearing
+   contributions. A plugin reaches a tenant by exactly the two ADR-0019 routes:
+   - **Bundled into an App** — the App author lists plugins as internal
+     contributions (`plugins: [...]` in `defineStack`, per
+     `docs/design/marketplace-publishing.md` §6.1); the consumer installs the App
+     and the bundled plugins ride inside it. The `.osplugin` is then a **build-time
+     dependency** the App author composes, signed and version-pinned.
+   - **Operator-provisioned** — a platform operator/admin installs a plugin into a
+     runtime/environment out-of-band (drivers, auth providers, observability
+     exporters, connectors). This is the `os plugin install` / control-plane path
+     in §3.4–§3.5, performed by an operator with the permission-consent step,
+     **not** surfaced in the consumer App Marketplace.
+
+2. **Two catalogs, one backbone.** The browsable listing built in §3.4 is a
+   **developer/operator contribution catalog** (drivers, connectors, AI
+   extensions, …), distinct from the consumer **App Marketplace** of ADR-0019 D2.
+   Both reuse the same `sys_*` registry, signing, and artifact storage; they
+   differ only in *who* may install and *which* `type`s each surface lists. The
+   consumer App Marketplace stays `type: app`-only (ADR-0019 D2, enforced in
+   `MarketplaceListingSchema.packageType`); the contribution catalog lists the
+   internal `type`s and is reachable by operators/developers.
+
+3. **This ADR is the gate ADR-0019 deferred.** ADR-0019 §Out-of-scope explicitly
+   parks a *self-serve, consumer-facing, code-bearing* marketplace as a separate
+   gated bet, and names its load-bearing wall: "**the L2 hook sandbox +
+   capability/permission enforcer** … *this* — not review, not a purity rule — is
+   the load-bearing wall, and its hardness must be proven first." ADR-0025's
+   default-deny tiers (§3.6: T1 QuickJS sandbox, T2 out-of-process) + the
+   permission-consent flow (§3.5) + RLS composition (§3.10 #4) **are exactly that
+   wall.** So this ADR does not *open* the self-serve-consumer gate; it builds and
+   hardens the mechanism that a future go/no-go could open the gate *on top of*.
+   Until that decision, the pipeline serves developers and operators only.
+
+In short: ADR-0019 governs **what a consumer sees** (only Apps); ADR-0025 governs
+**how code contributions are built, signed, distributed, and safely loaded** for
+the developers and operators who compose Apps and provision runtimes.
+
 ## 4. Phasing
 
 - **Phase 1 — Artifact & build.** Define `.osplugin` + `objectstack.plugin.json`
@@ -438,7 +488,10 @@ a module-federation / iframe-sandbox model. Split to **ADR-0026**.
 - [ADR-0016](./0016-studio-package-authoring-and-publish.md) — Package authoring & publish; local export/import (§9)
 - [ADR-0007](./0007-settings-manifest-and-kv-store.md) — Settings manifest + KV/secret store (§3.10 #5)
 - [ADR-0022](./0022-connectors-vs-messaging-channels.md) / [ADR-0023](./0023-openapi-to-connector-generator.md) / [ADR-0024](./0024-mcp-connectors.md) — Connectors: declarative generation vs. code plugins (§3.10 #6)
+- [ADR-0019](./0019-app-as-consumer-unit.md) — App is the only consumer-facing unit; internal contributions ship inside Apps or are operator-provisioned (§3.11); names the L2-sandbox + enforcer as the gate's load-bearing wall
 - [ADR-0026](./0026-client-ui-plugin-distribution.md) — Client-side UI plugin distribution (browser module/sandbox)
+- `docs/design/marketplace-publishing.md` — Marketplace publishing flow; App composition (§6) consuming bundled plugins
+- `packages/spec/src/kernel/plugin.zod.ts` — `isConsumerInstallable` (consumer surface = `type: app`)
 - `packages/plugins/plugin-security/` — RBAC/RLS; composes with plugin permissions (§3.10 #4)
 - `packages/core/src/plugin-loader.ts` — plugin loading, lifecycle, health, signature
 - `packages/core/src/types.ts` — `Plugin` (`init/start/destroy`) + `PluginContext`

--- a/docs/adr/0026-client-ui-plugin-distribution.md
+++ b/docs/adr/0026-client-ui-plugin-distribution.md
@@ -1,0 +1,235 @@
+# ADR-0026: Client-Side UI Plugin Distribution
+
+**Status**: Proposed
+**Deciders**: ObjectStack Protocol Architects
+**Builds on**: [ADR-0025](./0025-plugin-package-distribution.md) (plugin package distribution — server/runtime plugins), [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0010](./0010-metadata-protection-model.md) (protection model)
+**Consumers**: `@objectstack/client-react`, `@objectstack/console`, `../objectui` (Studio), `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`
+
+---
+
+## 0. Context
+
+ADR-0025 designs distribution for **server/runtime** plugins (`.osplugin`,
+`runtime: node|sandbox|worker`). A scenario review (ADR-0025 §3.10) surfaced a
+category it explicitly does **not** cover: **client-side UI plugins** that run in
+the browser inside the ObjectUI console SPA —
+
+- **Custom field renderers** (signature pad, rich geo/map, barcode/QR, color
+  picker, masked input, dependent-picklist UI).
+- **Custom view types** (beyond the built-in grid/kanban/gantt/calendar — e.g.
+  org chart, timeline, map view, image gallery).
+- **Custom widgets** (KPI/chart variants, embedded BI, custom list cards).
+- **Page sections / layout blocks** and behavior-carrying themes.
+
+These cannot ride the server plugin pipeline as-is: they load in the browser,
+render React against the host's component model, and must be sandboxed against a
+*client* threat model (DOM access, token exfiltration, CSP), not a Node one. The
+existing `ObjectStackManifest` already has the declarative seam —
+`capabilities.extensionPoints` / `extensions` and `contributes` — and ObjectUI
+already has a fixed catalog of view/widget types; what is missing is **how a
+third party ships browser code that registers a new field/view/widget at
+runtime, and how that code is isolated**.
+
+## 1. Goals & Non-goals
+
+### Goals
+
+- A **client UI plugin artifact** carrying a browser bundle that registers
+  field renderers / view types / widgets / page sections into the running
+  console via a stable contract.
+- **Reuse ADR-0025's distribution backbone** — same `sys_plugin*` registry,
+  publish, signing, and install flow; UI plugins are a `runtime: 'ui'` variant of
+  the `.osplugin`, not a parallel system.
+- A **two-tier loading model** mirroring ADR-0025's trust split: verified →
+  in-app module (shared singletons), third-party → **iframe-sandboxed**.
+- **Server-authoritative data**: UI plugins read/write only through the client
+  SDK under the user's session, so all access stays **RLS-gated server-side** —
+  the client grant never bypasses server permissions.
+- **Compatibility gating** on the ObjectUI protocol version + shared-singleton
+  (React/design-system) version ranges.
+
+### Non-goals
+
+- Server/runtime plugins — covered by ADR-0025.
+- A new component framework — UI plugins target React + the host design system.
+- Declarative-only UI (themes, translations, view *config*) — that stays an L0
+  JSON package (ADR-0025 §3.10); this ADR is for UI that ships *code*.
+- Native mobile widgets (separate track).
+
+## 2. Decision
+
+Ship client UI plugins as a **`runtime: 'ui'` variant of the `.osplugin`**
+artifact (ADR-0025 §3.1) whose `dist` is a **browser ESM bundle**. The console
+loads it at runtime into an **ObjectUI extension registry**, isolating it by trust
+tier: **verified** plugins load as in-app modules sharing host singletons;
+**third-party** plugins render inside a **sandboxed iframe** that talks to the host
+over a constrained `postMessage` RPC bridge. Distribution (publish/sign/install)
+is the ADR-0025 pipeline unchanged.
+
+## 3. Detailed design
+
+### 3.1 Artifact & manifest
+
+A UI plugin is an `.osplugin` with:
+
+```jsonc
+{
+  "id": "com.acme.signature-field",
+  "version": "1.0.0",
+  "type": "ui-plugin",
+  "runtime": "ui",                       // new tier (ADR-0025 §3.6)
+  "engines": { "objectui": ">=1.0 <2", "react": "^19" },  // protocol + shared singletons
+  "ui": {
+    "entry": "dist/plugin.mjs",          // browser ESM, default-exports a register fn
+    "shared": ["react", "react-dom", "@objectstack/client-react"],  // host-provided
+    "extends": [                         // maps to ObjectStackManifest extensions
+      { "point": "fieldType", "name": "signature" },
+      { "point": "viewType",  "name": "map" },
+      { "point": "widget",    "name": "gauge" }
+    ]
+  },
+  "permissions": {                       // client-scoped (ADR-0025 §3.10 #4)
+    "data": { "read": ["account"], "write": [] },  // via client SDK, RLS-gated server-side
+    "network": ["tiles.acme.com"],       // becomes per-plugin CSP connect-src
+    "navigation": true
+  },
+  "integrity": { "dist/plugin.mjs": "sha256-..." }
+}
+```
+
+`extends` reuses the existing `capabilities.extensionPoints`/`extensions` seam;
+`ui.shared` lists singletons the host injects (never bundled — same externalize
+rule as ADR-0025 §3.3, applied to browser deps).
+
+### 3.2 Extension contract
+
+The entry default-exports a register function called with a typed host API:
+
+```ts
+export default function register(host: UiPluginHost) {
+  host.registerFieldType('signature', { Display, Edit });   // React components
+  host.registerViewType('map', { View });
+  host.registerWidget('gauge', { Widget, configSchema });
+}
+```
+
+Components receive **props only** (value, record context, field config, a scoped
+`sdk` for data, a `theme` token set) — no direct access to host stores, router
+internals, or other plugins. The contract versions with `engines.objectui`.
+
+### 3.3 Loading & isolation tiers
+
+Mirrors ADR-0025's trust split (default-deny):
+
+| Tier | For | Mechanism | Isolation |
+|---|---|---|---|
+| **U0 In-app module** | First-party / verified | Native ESM `import()` + import-map (or module federation) sharing `react`/`client-react`/design-system singletons; components mount directly in the host tree | Trust-based; runs with host privileges, gated by declared permissions |
+| **U1 Iframe sandbox** | Third-party / unverified (**default**) | Plugin renders inside a `sandbox`ed `<iframe>` (`allow-scripts`, no `allow-same-origin`); host↔plugin via `postMessage` RPC; per-plugin **CSP** from `permissions.network` | Strong: separate origin, no host DOM/token access, no cookie/localStorage of host |
+
+As in ADR-0025 §3.6, `runtime: 'ui'` + **U0** is reserved for verified
+publishers and enforced at publish; unverified UI plugins ship **U1 only**.
+
+### 3.4 Data & security model
+
+- **Server-authoritative.** All data access goes through the scoped client `sdk`,
+  which calls the same REST API under the **user's session** — every read/write is
+  re-checked by server RLS (`plugin-security`). The manifest `permissions.data` is
+  a UI-affordance hint and a client-side guard, **not** the security boundary; the
+  server is.
+- **No host-token leakage.** U1 iframes have no `allow-same-origin`, so they
+  cannot read host cookies/`localStorage`; the RPC bridge forwards only the data
+  the contract allows, never raw credentials.
+- **Per-plugin CSP.** `permissions.network` becomes the iframe's `connect-src` /
+  `img-src` allowlist; an unverified widget cannot beacon to arbitrary hosts.
+- **Integrity + signing.** Same as ADR-0025 §3.5 — bundle is hashed and signed;
+  the console verifies before mounting.
+
+### 3.5 Distribution & install (reuses ADR-0025)
+
+- **Publish**: identical pipeline — `sys_plugin` / `sys_plugin_version` (blob =
+  browser bundle) / `marketplace_listed`; publish-time gate enforces the U0/U1
+  rule by publisher verification.
+- **Install**: `sys_plugin_installation` per environment records the enabled UI
+  plugins and granted client permissions. No on-disk Node materialize step — the
+  bundle is served to the SPA (via the marketplace proxy / artifact storage) and
+  registered into the ObjectUI extension registry at console boot.
+- **Local-first parity**: a local `.osplugin` (`runtime: 'ui'`) can be installed
+  with no cloud account (ADR-0025 §3.5 local path); the console loads it from the
+  local artifact store.
+
+### 3.6 Compatibility
+
+Gate on `engines.objectui` (the ObjectUI extension-contract version) **first**,
+then shared-singleton ranges (`react` major must match the host to allow U0 module
+sharing; a mismatch forces U1 iframe, which can carry its own React). This is the
+client analog of ADR-0025 §3.8 protocol-first gating.
+
+## 4. Phasing
+
+- **Phase 1 — Contract & registry.** Define `runtime: 'ui'` + `ui` manifest block
+  (Zod, in `@objectstack/spec/system`); ObjectUI extension registry +
+  `UiPluginHost` API for fieldType/viewType/widget.
+- **Phase 2 — U1 iframe loader (default).** Sandboxed-iframe host + postMessage
+  RPC bridge + per-plugin CSP; install/enable via `sys_plugin_installation`;
+  scoped data SDK.
+- **Phase 3 — U0 module loader.** Import-map / module-federation shared singletons
+  for verified plugins; publish-time verification gate.
+- **Phase 4 — Authoring.** `os plugin build` UI target (browser bundle,
+  externalize shared singletons); Studio "Install UI plugin" + per-env enable.
+- **Phase 5 — Page sections / themes-with-behavior** and richer extension points.
+
+## 5. Consequences
+
+### Positive
+
+- Closes the UI-extension gap without forking ADR-0025's distribution backbone.
+- Default-deny iframe isolation makes untrusted third-party widgets safe to run in
+  the console; verified plugins keep native performance via U0.
+- Server-authoritative data means a compromised/malicious widget still cannot
+  exceed the user's RLS-granted access.
+
+### Negative
+
+- Two loaders (U0 module + U1 iframe) to build and keep contract-compatible.
+- Iframe RPC adds latency/serialization overhead vs. in-tree components (mitigated
+  by reserving U1 for untrusted plugins).
+- A stable `UiPluginHost` contract is now a public API surface that must version
+  carefully.
+
+### Neutral
+
+- Declarative UI (themes/translations/view config) is unaffected — stays L0 JSON.
+- Reuses ADR-0025 signing, registry, and install records verbatim.
+
+## 6. Alternatives considered
+
+1. **Server-render plugin UI (no client code).** Rejected: too limiting for rich
+   interactions (maps, signature, drag-drop); the console is a client SPA.
+2. **Web Components instead of React contract.** Considered; deferred — the host is
+   React and the design system is React; a WC bridge can come later for framework
+   neutrality.
+3. **Always in-app modules (no iframe).** Rejected: a third-party module in the
+   host tree can read tokens and the whole DOM — unacceptable for an open
+   marketplace. Iframe must be the third-party default.
+4. **A separate UI-plugin registry.** Rejected: forks ADR-0025; `runtime: 'ui'`
+   keeps one pipeline.
+
+## 7. Open questions
+
+- **Module federation vs. native import-map** for U0 — which gives cleaner
+  singleton sharing across host + plugin React?
+- **RPC contract surface** — minimal `sdk` for U1 (data CRUD, navigation, toast,
+  file pick) without re-exposing the whole client SDK.
+- **Design-system theming across the iframe boundary** — pass tokens via CSS vars
+  / `postMessage`, or ship a lightweight themed component kit to U1 plugins?
+- **Offline/local-first** — how do UI plugin bundles cache for offline console use
+  (service worker), consistent with the local-first install path?
+
+## 8. References
+
+- [ADR-0025](./0025-plugin-package-distribution.md) — Plugin package distribution (server); `runtime` tiers, signing, registry, §3.10 refinements
+- [ADR-0010](./0010-metadata-protection-model.md) — Protection model (lock states for installed UI extensions)
+- `packages/client-react/` — React client SDK + view/field rendering
+- `packages/console/` — console SPA (load target for UI plugins)
+- `packages/plugins/plugin-security/` — RLS that keeps data access server-authoritative (§3.4)
+- `packages/spec/src/system/` — `ObjectStackManifest` `capabilities.extensionPoints`/`extensions` seam reused by `ui.extends`

--- a/docs/adr/0026-client-ui-plugin-distribution.md
+++ b/docs/adr/0026-client-ui-plugin-distribution.md
@@ -3,6 +3,7 @@
 **Status**: Proposed
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0025](./0025-plugin-package-distribution.md) (plugin package distribution — server/runtime plugins), [ADR-0003](./0003-package-as-first-class-citizen.md) (package + versioned releases), [ADR-0010](./0010-metadata-protection-model.md) (protection model)
+**Related**: [ADR-0019](./0019-app-as-consumer-unit.md) (App is the only consumer-facing unit — UI plugins ship inside Apps or are operator-provisioned, see §3.7)
 **Consumers**: `@objectstack/client-react`, `@objectstack/console`, `../objectui` (Studio), `@objectstack/spec/system` (ObjectStackManifest), `@objectstack/spec/cloud`
 
 ---
@@ -164,6 +165,25 @@ then shared-singleton ranges (`react` major must match the host to allow U0 modu
 sharing; a mismatch forces U1 iframe, which can carry its own React). This is the
 client analog of ADR-0025 §3.8 protocol-first gating.
 
+### 3.7 Audience & relation to ADR-0019
+
+As in ADR-0025 §3.11, a UI plugin (`type: ui-plugin`) is an **internal
+contribution**, not a consumer-installable unit (ADR-0019 D2:
+`isConsumerInstallable` = `type: app` only). It reaches a tenant by the same two
+routes:
+
+- **Bundled inside an App** — the App author registers the field/view/widget
+  contributions as part of the App bundle; the consumer installs the App and the
+  UI extensions load with it. This is the dominant path (a "map view" or
+  "signature field" is part of *some App's* UX).
+- **Operator-provisioned** — an admin enables a UI plugin org-wide as a console
+  capability (e.g. a corporate barcode-scanner field across all Apps).
+
+The consumer never browses a "UI plugin" listing; the U0/U1 loading and isolation
+of §3.3 govern *how the host runs* a contribution that arrived by either route.
+The signed registry/install backbone is shared with ADR-0025 (and thus the
+developer/operator contribution catalog, not the consumer App Marketplace).
+
 ## 4. Phasing
 
 - **Phase 1 — Contract & registry.** Define `runtime: 'ui'` + `ui` manifest block
@@ -228,6 +248,7 @@ client analog of ADR-0025 §3.8 protocol-first gating.
 ## 8. References
 
 - [ADR-0025](./0025-plugin-package-distribution.md) — Plugin package distribution (server); `runtime` tiers, signing, registry, §3.10 refinements
+- [ADR-0019](./0019-app-as-consumer-unit.md) — App is the only consumer-facing unit; UI plugins ship inside Apps or are operator-provisioned (§3.7)
 - [ADR-0010](./0010-metadata-protection-model.md) — Protection model (lock states for installed UI extensions)
 - `packages/client-react/` — React client SDK + view/field rendering
 - `packages/console/` — console SPA (load target for UI plugins)

--- a/docs/design/marketplace-publishing.md
+++ b/docs/design/marketplace-publishing.md
@@ -28,6 +28,17 @@
 
 This document defines the **Marketplace Protocol** for the ObjectStack ecosystem — a comprehensive specification covering how metadata-driven packages are published to the marketplace and how customers discover, install, and manage them.
 
+> **Companion document:** code-bearing contributions (plugins with npm
+> dependencies, drivers, connectors, AI extensions, and client UI plugins) have
+> their own supply-side distribution design in
+> [`plugin-distribution.md`](./plugin-distribution.md) (decisions:
+> [ADR-0025](../adr/0025-plugin-package-distribution.md),
+> [ADR-0026](../adr/0026-client-ui-plugin-distribution.md)). Per ADR-0019 those
+> contributions are **never** consumer-installed directly — they ship *inside an
+> App* or are *operator-provisioned*. This document covers the consumer-facing
+> **App** flow; the companion covers the developer/operator **contribution
+> catalog**. Both share one signed `sys_*` registry + artifact backbone.
+
 ### Key Components
 
 The marketplace protocol consists of three primary schema files:

--- a/docs/design/plugin-distribution.md
+++ b/docs/design/plugin-distribution.md
@@ -1,0 +1,301 @@
+# Design Document: Plugin Distribution — Code-Bearing Contributions
+
+> **Author:** ObjectStack Core Team
+> **Created:** 2026-06-01
+> **Status:** Design Specification
+> **Decisions:** [ADR-0025](../adr/0025-plugin-package-distribution.md) (server/runtime plugins), [ADR-0026](../adr/0026-client-ui-plugin-distribution.md) (client UI plugins)
+> **Companion to:** [`marketplace-publishing.md`](./marketplace-publishing.md) (metadata-package / App flow)
+
+---
+
+## Table of Contents
+
+- [1. Scope & Relationship to the App Marketplace](#1-scope--relationship-to-the-app-marketplace)
+- [2. The Three Distribution Layers](#2-the-three-distribution-layers)
+- [3. What Belongs in the Contribution Catalog](#3-what-belongs-in-the-contribution-catalog)
+- [4. Artifact Format](#4-artifact-format)
+- [5. Build → Sign → Publish](#5-build--sign--publish)
+- [6. Install & Load](#6-install--load)
+- [7. Trust & Isolation Tiers](#7-trust--isolation-tiers)
+- [8. Security Model](#8-security-model)
+- [9. Versioning & Lifecycle](#9-versioning--lifecycle)
+- [10. Worked Examples](#10-worked-examples)
+- [11. Open Questions](#11-open-questions)
+
+---
+
+## 1. Scope & Relationship to the App Marketplace
+
+This document operationalizes how **code-bearing contributions** (plugins with
+executable code + npm dependencies, and client UI plugins) are built, signed,
+distributed, and loaded. It is the supply-side companion to
+[`marketplace-publishing.md`](./marketplace-publishing.md), which covers the
+**consumer-facing App** flow (metadata packages).
+
+**Audience boundary (ADR-0019).** The consumer Marketplace lists **only Apps**
+(`type: app`; `isConsumerInstallable`). Plugins, drivers, UI extensions, themes,
+agents, and other internal contributions are **never** browsed or installed by an
+end consumer. They reach a tenant by exactly two routes:
+
+1. **Bundled inside an App** — the App author composes them as build-time
+   dependencies (`plugins: [...]` in `defineStack`), and the consumer installs the
+   App as one atomic unit.
+2. **Operator-provisioned** — a platform operator/admin installs them into a
+   runtime/environment out-of-band (drivers, auth providers, connectors,
+   observability exporters).
+
+Accordingly there are **two catalogs over one backbone**:
+
+| | Consumer App Marketplace | Developer/Operator Contribution Catalog |
+|---|---|---|
+| Lists | `type: app` only | `plugin`/`driver`/`ui`/`server`/`agent`/… |
+| Who installs | Any tenant user | App authors (compose) / operators (provision) |
+| Surface | Console "App Marketplace" | CLI `os plugin …` + operator/dev tooling |
+| Backbone | shared `sys_*` registry, signing, artifact storage | same |
+
+This design specifies the **contribution catalog + backbone**. It does **not**
+open a self-serve consumer-facing code marketplace — that remains the gated bet
+ADR-0019 §Out-of-scope parks, whose load-bearing wall (L2 sandbox + permission
+enforcer) is precisely what §7–§8 here build and harden.
+
+## 2. The Three Distribution Layers
+
+The "metadata vs code" split is really a spectrum (ADR-0025 §3.10). Choosing a
+layer is a single question: **does it need to execute code / reach an external
+system?**
+
+| Layer | Form | Trust decision at install | Channel | Doc |
+|---|---|---|---|---|
+| **L0 — declarative** | objects/views/flows/dashboards/permissions/themes/translations JSON | none (it is data) | JSON hot-register | `marketplace-publishing.md` |
+| **L1 — declarative + sandboxed script** | JSON carrying L1 expressions / L2 `ScriptBody` (validations, formulas, small automations) | "scripts allowed" only; runs in the existing QuickJS sandbox | JSON flow — no `.osplugin` | this doc §7 (T1) |
+| **L2 — code plugin** | npm deps + host APIs (drivers, connectors, AI, auth, …) | explicit permission consent + signature | `.osplugin` | this doc |
+
+**Design consequence:** most "custom logic" is L1 and never touches the heavy
+code-plugin pipeline. Reserve L2 (and this document's machinery) for
+contributions that genuinely carry dependencies or reach the host/network.
+
+## 3. What Belongs in the Contribution Catalog
+
+A scenario-driven catalog, with the recommended layer/tier for each. (Items
+already present in `packages/plugins/*` are marked ✅.)
+
+| Category | Examples | Layer | Tier | Notes |
+|---|---|---|---|---|
+| **Data-source drivers** | MongoDB ✅, SQL ✅, SQLite-WASM ✅, ClickHouse, Redis, S3 | L2 | T0 | Implements the storage protocol; holds a client/pool. Operator-provisioned. |
+| **Connectors / integrations** | Salesforce, Stripe, Slack, Twilio, SAP, Shopify, GitHub, DocuSign, WeCom/DingTalk | L2 (declarative sub-path) | T0 internal / **T2 third-party** | OpenAPI/MCP-describable ones are **declarative** (ADR-0023/0024); only custom-auth/pagination/streaming fall to code. Secrets via KV (ADR-0007). |
+| **AI / ML extensions** | LLM providers, Embedder ✅, vector stores, RAG backends ✅, reranker, OCR/speech, agent tools | L2 | T0/T2 | Network + service permissions; agent tools may run T1. |
+| **Identity / auth** | SAML/OIDC SSO ✅, SCIM, LDAP, MFA | L2 | T0 | First-party/verified; deep host hooks. Operator-provisioned. |
+| **Automation / channels / notifications** | record-change ✅ & schedule ✅ triggers, Webhooks ✅, FCM/APNs, SMS, email ✅, bidirectional channels | L2 (+ some L1) | T0/T2 | Small rules are L1; channel adapters are L2. |
+| **Governance / observability** | audit ✅, RBAC/RLS ✅, org-scoping ✅, masking/DLP, backup, OTel/Datadog/Sentry exporters | L2 | T0 | First-party/verified; compose with RLS (§8). |
+| **Protocol / server surfaces** | HTTP/GraphQL/gRPC gateway ✅ (hono), MCP server ✅, REST | L2 | T0 | Operator-provisioned. |
+| **Business rules / formulas** | validation packs, computed-field libs, approval conditions, field dependencies | **L1** | T1 | Ride the JSON flow + sandbox; **no `.osplugin`**. |
+| **Vertical apps & templates** | CRM, PM, HRM, ITSM, dashboards, report/theme/translation/permission packs | **L0** | — | Consumer **Apps** / declarative packages — *not* this catalog. |
+| **Client UI extensions** | field renderers (signature, map, barcode), view types (org-chart, timeline, map), widgets | UI (ADR-0026) | U0/U1 | Browser bundle; bundled in an App or operator-provisioned. |
+
+**Best fit for the `.osplugin` L2 pipeline:** drivers, connectors, AI extensions,
+auth providers, notification/channel adapters, observability exporters, server
+surfaces — each is *bounded code + deps + a clear capability/permission surface*
+that maps cleanly onto the manifest's `capabilities`/`permissions` and the tiers.
+
+**Deliberately NOT code plugins:** vertical apps/templates/themes (L0) and
+validation/formula logic (L1) — making these `.osplugin` artifacts would be
+over-engineering.
+
+## 4. Artifact Format
+
+### 4.1 `.osplugin` (server/runtime — ADR-0025 §3.1–§3.2)
+
+A `tar.gz`:
+
+```
+<id>-<version>.osplugin
+├── objectstack.plugin.json   # compiled manifest (below)
+├── dist/                     # pre-built ESM bundle (tsup); @objectstack/* externalized
+├── package.json              # only for the manifest-deps strategy
+├── pnpm-lock.yaml            # only for the manifest-deps strategy
+├── assets/ README LICENSE icon
+└── SIGNATURE                 # detached signature + publisher cert chain
+```
+
+Compiled manifest adds four blocks to the existing `ObjectStackManifest`:
+`engines` (protocol + platform ranges), `runtime` (`node|sandbox|worker`),
+`packaging` (`bundled|manifest-deps`), `permissions` (services/hooks/network/fs
++ RLS data scopes), and `integrity` (per-file hashes).
+
+### 4.2 UI plugin (`runtime: 'ui'` — ADR-0026 §3.1)
+
+Same `.osplugin` envelope, but `type: ui-plugin`, `dist` is a **browser ESM
+bundle** default-exporting a `register(host)` function, and the manifest carries a
+`ui` block (`entry`, `shared` singletons, `extends` extension points) plus
+client-scoped `permissions` (data read/write via SDK, network → CSP, navigation).
+
+### 4.3 Packaging strategies (default: bundled)
+
+- **Bundled (default).** `tsup --noExternal` bundles third-party JS into `dist`;
+  no npm at install time. **`@objectstack/*` is externalized** as a host-provided
+  peer-dep singleton (bundling it forks the engine — duplicate registries / broken
+  `instanceof` / double Zod validation). Native addons disallowed.
+- **manifest-deps (opt-in).** Ships `package.json` + lockfile; install runs
+  `pnpm install --frozen-lockfile --ignore-scripts`. For native addons / huge
+  deps only; disallowed for unverified publishers.
+
+## 5. Build → Sign → Publish
+
+```
+os plugin build  →  os plugin sign  →  os plugin publish
+```
+
+1. **build** — run `tsup` (externalize `@objectstack/*`); validate the manifest
+   (Zod + the new `permissions` schema); gate on protocol/engine compatibility;
+   compute per-file `integrity`; emit `<id>-<version>.osplugin`.
+2. **sign** — sign with the publisher key (`PluginMetadata.signature`); may be
+   server-side at publish.
+3. **publish** — extends `os package publish`:
+   - `POST /cloud/plugins` → ensure a `sys_plugin` row (reverse-domain id, owner
+     org).
+   - `POST /cloud/plugins/:id/versions` → upload the `.osplugin` blob to object
+     storage; store manifest/permissions/integrity/signature/engines/size/SBOM in
+     `sys_plugin_version` (`status: pending_review → published`).
+   - **Server gates:** schema validation; secret/malware/known-vuln scan;
+     **permission audit** (sensitive permissions → human review); **publish-time
+     tier enforcement** (an unverified publisher cannot ship `runtime: 'node'` or
+     `manifest-deps`); marketplace **counter-signs** with the platform key on
+     approval.
+   - Listed in the **contribution catalog** (not the consumer App Marketplace),
+     with a "contains code" badge and a permission-disclosure screen.
+
+## 6. Install & Load
+
+Install is a deliberate, **permissioned** action performed by a developer
+(composing an App) or an operator (provisioning a runtime):
+
+```
+resolve → compat check → permission consent → download+verify → materialize → register → load
+```
+
+1. **Resolve** `id@version` (or latest matching the engine/protocol range) → manifest,
+   download URL, signature, declared permissions, dependency closure.
+2. **Compatibility (protocol-first).** Verify the host provides each
+   `capabilities.implements[].protocol` at a compatible version; then
+   `engines.platform`/`engines.protocol` as a secondary guard. Topologically order
+   plugin→plugin `requires`; fetch deps.
+3. **Permission consent.** Present declared permissions (services / hooks / fs /
+   network hosts / RLS data scopes / extension points). The **granted set** is
+   persisted and enforced by `PluginPermissionEnforcer`. Secret-typed config fields
+   are wired to the KV secret store (ADR-0007) — never stored in the artifact.
+4. **Download + verify.** Verify signature (publisher + marketplace keys) and each
+   file against `integrity`; reject on mismatch.
+5. **Materialize.** Unpack to `<OS_HOME>/plugins/<env>/<id>/<version>/`;
+   manifest-deps runs `pnpm install --frozen-lockfile --ignore-scripts` here.
+6. **Register.** Write `sys_plugin_installation` (env_id, plugin_id, version_id,
+   granted_permissions incl. RLS scopes, status, is_preview). Persist to a local
+   store so installs survive restarts (the ADR-0016 §9.7 disable-state pattern).
+7. **Load + activate.** On boot (or hot, when `hotReloadable`), the loader scans
+   installed plugins, dynamic-imports the entry, wraps `PluginContext` with the
+   enforcer scoped to the granted set, and runs `init → start` in dependency
+   order. `contributes` metadata is hot-registered like a pure-element package.
+
+**Local-first parity.** `os plugin install ./x.osplugin` (and a Studio upload for
+operators) hit a `marketplace/install-local`-style endpoint (inline artifact,
+register-before-persist per ADR-0016 §9.3). Local artifacts need no cloud account;
+signature is still verified (or `--trust-unsigned` for dev).
+
+**UI plugins (ADR-0026 §3.5).** No on-disk Node materialize — the browser bundle
+is served to the SPA and registered into the ObjectUI extension registry at console
+boot; `sys_plugin_installation` records enabled UI plugins + client grants.
+
+## 7. Trust & Isolation Tiers
+
+Server/runtime (ADR-0025 §3.6), **default-deny**:
+
+| Tier | `runtime` | Load | For | Mechanism |
+|---|---|---|---|---|
+| **T0 Trusted** | `node` | in-process dynamic `import` | first-party / verified / enterprise-signed | full `PluginContext`, capability-gated |
+| **T1 Sandboxed** | `sandbox` | QuickJS-WASM (`quickjs-runner.ts`) | pure-logic plugins (hooks/formulas/transforms) — also the L1 layer | no Node API; only gated `ctx.api/crypto/log` |
+| **T2 Out-of-process** | `worker` | worker/child-process/WASM + RPC | untrusted 3rd-party needing richer APIs | crash/timeout/memory isolation |
+
+**T0 is opt-in, not default.** In-process = arbitrary code in the host process =
+the platform's biggest risk surface; it is reserved for verified publishers and
+enforced at publish. Unverified third-party plugins default to T1/T2.
+
+Client UI (ADR-0026 §3.3): **U0 in-app module** (verified; shared React/design-
+system singletons) vs **U1 iframe sandbox** (third-party default; `postMessage`
+RPC + per-plugin CSP, no `allow-same-origin`).
+
+## 8. Security Model
+
+Reuses existing components, adds two compositions:
+
+- **Signing.** Publisher signs; marketplace counter-signs on approval; host ships
+  trusted roots; verify chain at install **and** load.
+- **Permissions + RLS.** The coarse service/hook/file/network gate
+  (`PluginPermissionEnforcer`) is **composed with object/field-level security**
+  (`plugin-security`/RLS): data-affecting grants reference RLS scopes, so a
+  connector authorized for `account` reads still cannot exceed field-level RLS.
+  All denials logged. (ADR-0025 §3.10 #4.)
+- **Secrets.** `configuration` secret fields → KV secret store (ADR-0007) via
+  secret-refs; the artifact never carries credentials; the plugin reads them
+  through `PluginContext` gated by the network/service permission.
+- **Supply chain.** Lockfile + per-file integrity; server-side secret/vuln scans;
+  SBOM on the version row; **always `--ignore-scripts`** (no `postinstall`).
+- **Server-authoritative UI data.** UI plugins read/write only via the client SDK
+  under the user's session → every access re-checked by server RLS; manifest
+  `permissions.data` is a UI hint/guard, not the boundary. U1 iframes cannot read
+  host cookies/tokens.
+- **Reversible disable.** Reuse package enable/disable + disable-state-store
+  (ADR-0016 §9.5/§9.7).
+
+## 9. Versioning & Lifecycle
+
+Parallel to packages: `sys_plugin` (identity) / `sys_plugin_version` (immutable
+semver, checksum, signature, permissions, engines, SBOM, blob pointer) /
+`sys_plugin_installation` (env ↔ version, granted permissions, is_preview).
+
+- **Compatibility** gated protocol-first (§6 step 2). Support deprecate/yank.
+- **Update** = install the new version side-by-side, swap the installation
+  pointer. **If the new version widens permissions** (services, hooks, network
+  hosts, or RLS scopes), **require re-consent** before activation.
+- **Disable** stops loading code + unregisters contributions on next boot;
+  reversible and non-destructive.
+
+## 10. Worked Examples
+
+**A. ClickHouse driver (operator-provisioned, T0).**
+`type: driver`, `runtime: node`, implements `storage.protocol.v1`, `permissions:
+{ network: ['clickhouse.internal'] }`, secret DSN via KV. Operator runs
+`os plugin install`, consents to the network grant, the driver registers into the
+driver registry on boot. Never in the consumer Marketplace.
+
+**B. Stripe connector bundled into a "Billing" App (T0 internal).**
+App author composes `@acme/connector-stripe` (`.osplugin`) as a build-time
+dependency; the connector's `permissions` (network `api.stripe.com`, RLS write on
+`invoice`) surface in the App's permission-disclosure screen. The consumer installs
+the **App**; the connector rides inside it. Stripe API key → KV secret-ref at App
+install.
+
+**C. Community "fancy gauge" widget (UI, U1 default).**
+`type: ui-plugin`, `runtime: ui`, unverified publisher → **U1 iframe** only, CSP
+`connect-src` empty, data via scoped SDK (RLS-gated). Bundled into whatever App's
+dashboard uses it, or operator-enabled org-wide.
+
+**D. A validation pack (L1, no `.osplugin`).**
+A "VAT number format" check ships as JSON with an L2 `ScriptBody`; installs via the
+normal JSON package flow, runs in the QuickJS sandbox (T1). No signing, no
+permission prompt, no artifact.
+
+## 11. Open Questions
+
+- **Key management & rotation** for publisher and host root keys.
+- **Permission-widening UX** on update — auto-disable until re-consent vs. run on
+  old grant.
+- **T2 RPC surface** — the minimal host-service contract an out-of-process plugin
+  gets, mediated by the enforcer.
+- **Cross-plugin dependency conflicts** (diamond/version) at install time.
+- **UI U0 sharing** — module federation vs. native import-map for React/design-
+  system singletons.
+- **When (if ever) to open the self-serve consumer code marketplace** — the
+  ADR-0019 gated bet, contingent on proving §7–§8 hardness.
+
+---
+
+**End of Document**


### PR DESCRIPTION
## What

Design docs for distributing **code-bearing** marketplace contributions (plugins with npm deps, drivers, connectors, AI extensions, client UI plugins), alongside the existing pure-element / metadata-only JSON package flow. **Docs only — no code or schema changes.**

- **ADR-0025 — Plugin Package Distribution (server/runtime)**: `.osplugin` artifact, build→sign→publish, permissioned install, trust/isolation tiers.
- **ADR-0026 — Client-Side UI Plugin Distribution**: `runtime:'ui'` variant reusing the ADR-0025 backbone (field renderers / view types / widgets in the browser).
- **`docs/design/plugin-distribution.md`** — supply-side companion to the existing `marketplace-publishing.md`: operationalizes the ADRs into layers, a scenario catalog, and workflows.

## Why

Pure-element packages compile to JSON and publish/install trivially because nothing executes. Code contributions carry executable code + deps, so distribution must additionally solve **build/bundling, dependency handling, trust/security, and version compatibility**. The repo already has the *authoring* half (`packages/plugins/*`, microkernel `plugin-loader`, `PluginPermissionEnforcer`, QuickJS sandbox, `sys_*` schema); these docs design the missing *distribution* layer on top.

## ADR-0025 key decisions

- `.osplugin` artifact + compiled `objectstack.plugin.json` (adds `engines`/`runtime`/`permissions`/`integrity`).
- build → sign → publish extending `os package publish`; registry stores browsable metadata **and** the binary blob (`sys_plugin`/`sys_plugin_version`/`sys_plugin_installation`).
- Permissioned install: resolve → compat → consent → verified download → materialize → register → load.
- Trust tiers: in-process (T0) / QuickJS sandbox (T1) / out-of-process (T2).
- Bundled-default packaging (no npm at install time); `manifest-deps` opt-in.

## Scenario-review refinements (§3.10)

1. **Default-deny trust** — T0 reserved for verified publishers; third-party defaults to sandbox/worker, enforced at publish.
2. **Externalize `@objectstack/*`** as host-provided peer-dep singletons (bundling forks the engine).
3. **Protocol-first compatibility** over platform semver.
4. **Permissions compose with object/field-level RLS**.
5. **Secrets via settings/KV store (ADR-0007)**, never in the artifact.
6. **Connectors span declarative (OpenAPI/MCP) + code-plugin** sub-paths.
7. Explicit **three-layer model**: L0 declarative JSON / L1 sandboxed-script JSON / L2 code plugin.

## ADR-0026 key decisions

- UI plugin = `runtime:'ui'` `.osplugin` (browser ESM bundle registering field/view/widget extensions).
- Two-tier loading: **U0 in-app module** (verified) / **U1 iframe sandbox** (third-party default, postMessage RPC + per-plugin CSP).
- **Server-authoritative data** — UI plugins read/write only via the client SDK under the user's session, so all access stays RLS-gated server-side.

## Reconciliation with ADR-0019 (important)

ADR-0019 makes the **App** the only consumer-facing unit; plugins/drivers/UI/themes are **internal contributions** a consumer never installs directly. These docs (ADR-0025 §3.11, ADR-0026 §3.7) reconcile explicitly:

- **Audience = developers/operators/ISVs.** A plugin reaches a tenant **bundled inside an App** or **operator-provisioned** — not browsed in the consumer Marketplace.
- **Two catalogs, one backbone**: consumer App Marketplace (`type: app`) vs developer/operator contribution catalog — same signed `sys_*` registry + artifact storage.
- This pipeline **builds the L2-sandbox + permission-enforcer "load-bearing wall"** that ADR-0019 §Out-of-scope named as the prerequisite for any future self-serve code marketplace; it does **not** open that gate.

## Scope

Design/ADRs + one design doc only. Phasing in each doc's §4. Builds on ADR-0003/0004/0007/0010/0016/0019/0022/0023/0024.

https://claude.ai/code/session_01DRww7tXjCVdqXsHtv5gDq6