### PR TITLE
test(driver-mongodb): skip suite when in-memory MongoDB binary is unavailable

### DIFF
--- a/packages/plugins/driver-mongodb/src/mongodb-driver.test.ts
+++ b/packages/plugins/driver-mongodb/src/mongodb-driver.test.ts
@@ -4,14 +4,30 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { MongoDBDriver } from './mongodb-driver.js';
 
-describe('MongoDBDriver', () => {
-  let mongod: MongoMemoryServer;
+// `mongodb-memory-server` downloads a real MongoDB binary from
+// fastdl.mongodb.org on first use. In sandboxed / offline CI that download can
+// fail; when it does we **skip** this suite rather than failing the whole
+// package's test run (and, with it, the monorepo `Test Core` job). The startup
+// is attempted once here so availability is known at collection time — a
+// throwing `beforeAll` would *fail* every test instead of skipping it.
+let sharedMongod: MongoMemoryServer | undefined;
+try {
+  sharedMongod = await MongoMemoryServer.create({
+    instance: { launchTimeout: 60_000 },
+  });
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[driver-mongodb] Skipping MongoDBDriver suite — mongodb-memory-server could not start ' +
+      `(MongoDB binary unavailable / download blocked): ${(err as Error)?.message ?? String(err)}`,
+  );
+}
+
+describe.skipIf(!sharedMongod)('MongoDBDriver', () => {
+  const mongod = sharedMongod as MongoMemoryServer;
   let driver: MongoDBDriver;
 
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create({
-      instance: { launchTimeout: 60_000 },
-    });
     const uri = mongod.getUri();
     driver = new MongoDBDriver({ url: uri, database: 'test_db' });
     await driver.connect();


### PR DESCRIPTION
## Problem

The monorepo `Test Core` job runs `pnpm turbo run test`, which includes `@objectstack/driver-mongodb`. That package's `mongodb-driver.test.ts` uses `mongodb-memory-server`, which **downloads a real MongoDB binary** from `fastdl.mongodb.org` on first use. When that download is blocked (sandboxed / offline CI runners, transient network), the suite fails hard — turning `Test Core` red on **unrelated** PRs and forcing empty-commit re-triggers (seen on #1436 and #1440).

## Fix

Attempt to start the in-memory server **once at collection time** and `describe.skipIf` the suite when startup fails, so it **skips cleanly** instead of failing. A throwing `beforeAll` would *fail* every test rather than skip it, which is why the startup moves to a top-level guard. When the binary is available (normal CI), the suite runs exactly as before.

Test-only change; no runtime/published code is touched.

## Verification (offline sandbox, where the binary can't download)

```
Test Files  2 passed | 1 skipped (3)
     Tests  38 passed | 37 skipped (75)
```
`driver-mongodb` test now exits **0** (previously: hard failure on the download error).

https://claude.ai/code/session_01Tv6F1Ub6bhCedrx3r8sZM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tv6F1Ub6bhCedrx3r8sZM4)_