### PR TITLE
fix(plugin-email): harden htmlToText against double-escaping & incomplete tag stripping

### DIFF
--- a/.changeset/fix-email-htmltotext-sanitization.md
+++ b/.changeset/fix-email-htmltotext-sanitization.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/plugin-email': patch
+---
+
+Harden `htmlToText` against double-escaping and incomplete tag stripping
+
+Fixes two CodeQL high-severity alerts in `template-engine.ts`:
+
+- `js/double-escaping`: the order-dependent chain of single-entity
+  `.replace()` calls could double-unescape (e.g. `&amp;lt;` → `&lt;` → `<`).
+  Entities are now decoded in a single left-to-right pass via one alternation
+  regex, so each entity decodes exactly once.
+- `js/incomplete-multi-character-sanitization`: the single `<[^>]+>` strip
+  could leave a live tag behind on crafted/overlapping input
+  (e.g. `<scr<script>ipt>`). Tag stripping now loops until the string is
+  stable, and runs before entity decoding so decoding cannot re-introduce a
+  tag.
+
+Adds adversarial unit tests covering nested entities and overlapping tags.

--- a/packages/plugins/plugin-email/src/template-engine.test.ts
+++ b/packages/plugins/plugin-email/src/template-engine.test.ts
@@ -72,5 +72,38 @@ describe('template-engine', () => {
     it('collapses 3+ newlines to 2', () => {
       expect(htmlToText('<p>a</p><p>b</p>')).toBe('a\nb');
     });
+
+    describe('adversarial sanitization', () => {
+      it('does not double-unescape entities', () => {
+        // &amp;lt; must decode ONCE to the literal text "&lt;", never to "<".
+        const out = htmlToText('&amp;lt;script&amp;gt;');
+        expect(out).toBe('&lt;script&gt;');
+        expect(out).not.toContain('<');
+        expect(out).not.toContain('>');
+      });
+
+      it('decodes single-escaped entities exactly once', () => {
+        // Sanity counterpart: single-escaped sequences still decode normally.
+        expect(htmlToText('a &amp;&amp; b')).toBe('a && b');
+      });
+
+      it('strips overlapping/nested tags so no tag survives', () => {
+        const out = htmlToText('<scr<script>ipt>alert(1)</script>');
+        expect(out).not.toContain('<');
+        expect(out.toLowerCase()).not.toContain('<script');
+      });
+
+      it('strips tags that re-form after a single pass', () => {
+        const out = htmlToText('<<script>script>alert(1)<</p>/p>');
+        expect(out).not.toContain('<');
+        expect(out.toLowerCase()).not.toContain('<script');
+      });
+
+      it('handles deeply nested entities without producing a live tag', () => {
+        const out = htmlToText('&amp;amp;lt;img src=x onerror=alert(1)&amp;amp;gt;');
+        expect(out).not.toContain('<');
+        expect(out).not.toContain('>');
+      });
+    });
   });
 });

--- a/packages/plugins/plugin-email/src/template-engine.ts
+++ b/packages/plugins/plugin-email/src/template-engine.ts
@@ -70,23 +70,65 @@ export function requireVars(
 }
 
 /**
+ * Decode the small set of HTML entities `escapeHtml` can emit, in a
+ * SINGLE left-to-right pass. Doing this with one alternation regex —
+ * rather than a chain of `.replace('&amp;','&').replace('&lt;','<')…`
+ * — is deliberate: a sequential chain is order-dependent and can
+ * double-unescape (e.g. `&amp;lt;` → `&lt;` → `<`). Because each match
+ * is consumed and the scan resumes *after* it, `&amp;lt;` decodes to
+ * the literal text `&lt;` and stops, never to `<`.
+ */
+const ENTITIES: Record<string, string> = {
+  '&nbsp;': ' ',
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+};
+const ENTITY_RE = /&(?:nbsp|amp|lt|gt|quot|#39);/g;
+
+function decodeEntities(s: string): string {
+  return s.replace(ENTITY_RE, (m) => ENTITIES[m] ?? m);
+}
+
+const TAG_RE = /<[^>]*>/g;
+
+/**
+ * Remove HTML tags robustly. A single `.replace(/<[^>]*>/g, '')` pass
+ * is not enough: stripping a tag can splice the surrounding text into a
+ * fresh tag (e.g. `<scr<script>ipt>` → `<script>`), so we loop until the
+ * string stops changing. This closes the "incomplete multi-character
+ * sanitization" gap where crafted/overlapping input leaves a `<…>` tag
+ * behind.
+ */
+function stripTags(s: string): string {
+  let prev: string;
+  let out = s;
+  do {
+    prev = out;
+    out = out.replace(TAG_RE, '');
+  } while (out !== prev);
+  return out;
+}
+
+/**
  * Strip HTML tags + collapse whitespace to derive a plain-text body
  * from an HTML template. Conservative: keeps line breaks at block
  * boundaries (<br>, </p>, </div>) so the resulting text is at least
  * paragraph-shaped.
+ *
+ * Order matters for safety: tags are stripped (looping until stable)
+ * *before* entities are decoded, and entities are decoded in a single
+ * pass — so neither tag removal nor entity decoding can re-introduce a
+ * live tag or double-unescape an entity.
  */
 export function htmlToText(html: string): string {
   if (!html) return '';
-  return html
+  const withBreaks = html
     .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n');
+  return decodeEntities(stripTags(withBreaks))
     .replace(/[ \t]+/g, ' ')
     .replace(/\n[ \t]+/g, '\n')
     .replace(/\n{3,}/g, '\n\n')


### PR DESCRIPTION
## Summary

Fixes two pre-existing CodeQL high-severity alerts (created 2026-05-19, on `main`) in `packages/plugins/plugin-email/src/template-engine.ts`, in the `htmlToText()` function. These surfaced as "new" on every PR's CodeQL check and were leaving PR CI status UNSTABLE.

This is independent pre-existing security debt in the email plugin — unrelated to ADR-0032 (the expression layer).

## Alerts addressed

1. **`js/double-escaping`** — the old chain of sequential single-entity replaces (`.replace(/&amp;/g,'&').replace(/&lt;/g,'<')…`) was order-dependent and could double-unescape (e.g. `&amp;lt;` → `&lt;` → `<`). Replaced with a **single-pass alternation regex** that decodes each entity once and resumes scanning *after* the match, so `&amp;lt;` decodes to the literal text `&lt;` and stops.

2. **`js/incomplete-multi-character-sanitization`** — the old single `.replace(/<[^>]+>/g, '')` pass could leave a live tag behind on crafted/overlapping input (e.g. `<scr<script>ipt>`). Now tag stripping **loops until the string is stable**.

Order also matters: tags are stripped *before* entities are decoded, so decoding can never re-introduce a live tag.

## Tests

Added adversarial unit tests asserting no `<`/tag survives and no double-unescape occurs:
- `&amp;lt;script&amp;gt;` → decodes once to `&lt;script&gt;` (no real `<`)
- `<scr<script>ipt>alert(1)</script>` → no surviving tag
- tags that re-form after a single pass
- deeply nested entities

## Verification

```
pnpm --filter @objectstack/plugin-email build   # ✅
pnpm --filter @objectstack/plugin-email test    # ✅ 49 passed
```

CodeQL alerts expected to clear on this PR.

https://claude.ai/code/session_014e59DF7CNAYxj89on1fvCp

---
_Generated by [Claude Code](https://claude.ai/code/session_014e59DF7CNAYxj89on1fvCp)_