### PR TITLE
fix(seed): resolve relationship refs by natural key, not {externalId} objects (showcase + crm + compile-time guard)

### DIFF
--- a/.changeset/seed-reference-natural-key.md
+++ b/.changeset/seed-reference-natural-key.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/spec": patch
+"@objectstack/runtime": patch
+---
+
+fix(seed): reject object-wrapped relationship references and constrain them at compile time
+
+Seed datasets resolve `lookup` / `master_detail` references by matching the value
+against the target record's externalId — so the value must be the plain natural-key
+string (e.g. `account: 'Acme Corp'`), never a wrapper object like
+`account: { externalId: 'Acme Corp' }`. The wrapper was silently skipped by the
+loader, fell through unresolved, and reached the SQL driver as a non-bindable value —
+masked on an always-empty `:memory:` DB but crashing on a persistent one with
+"SQLite3 can only bind numbers, strings, bigints, buffers, and null" once seeds re-ran
+as updates.
+
+- `defineDataset` now constrains reference fields to `string | null` at compile time
+  (derived from each field's `type`), so the object form is a type error.
+- `SeedLoaderService` now fails loudly with an actionable message (and drops the value
+  instead of handing it to the driver) when a reference is an object — consistent
+  behavior across all drivers, no longer silently masked.

--- a/examples/app-crm/src/data/index.ts
+++ b/examples/app-crm/src/data/index.ts
@@ -22,9 +22,9 @@ const contacts = defineDataset(Contact, {
   mode: 'upsert',
   externalId: 'email',
   records: [
-    { first_name: 'Ada',    last_name: 'Lovelace', email: 'ada@acme.example',    account: { externalId: 'Acme Corp' } },
-    { first_name: 'Linus',  last_name: 'Torvalds', email: 'linus@globex.example', account: { externalId: 'Globex Ltd' } },
-    { first_name: 'Grace',  last_name: 'Hopper',   email: 'grace@initech.example', account: { externalId: 'Initech' } },
+    { first_name: 'Ada',    last_name: 'Lovelace', email: 'ada@acme.example',    account: 'Acme Corp' },
+    { first_name: 'Linus',  last_name: 'Torvalds', email: 'linus@globex.example', account: 'Globex Ltd' },
+    { first_name: 'Grace',  last_name: 'Hopper',   email: 'grace@initech.example', account: 'Initech' },
   ],
 });
 
@@ -33,26 +33,26 @@ const opportunities = defineDataset(Opportunity, {
   externalId: 'name',
   records: [
     // --- Open pipeline (no close yet) -----------------------------------
-    { name: 'Acme — Q3 Platform Renewal', account: { externalId: 'Acme Corp' },  stage: 'proposal',       amount: 120_000, probability: 70, close_date: cel`daysFromNow(30)` },
-    { name: 'Globex — New CRM Rollout',   account: { externalId: 'Globex Ltd' }, stage: 'qualification',  amount: 450_000, probability: 40, close_date: cel`daysFromNow(60)` },
-    { name: 'Initech — Expansion',        account: { externalId: 'Initech' },    stage: 'prospecting',    amount:  80_000, probability: 20, close_date: cel`daysFromNow(45)` },
-    { name: 'Acme — Add-on Module',       account: { externalId: 'Acme Corp' },  stage: 'qualification',  amount:  60_000, probability: 35, close_date: cel`daysFromNow(20)` },
+    { name: 'Acme — Q3 Platform Renewal', account: 'Acme Corp',  stage: 'proposal',       amount: 120_000, probability: 70, close_date: cel`daysFromNow(30)` },
+    { name: 'Globex — New CRM Rollout',   account: 'Globex Ltd', stage: 'qualification',  amount: 450_000, probability: 40, close_date: cel`daysFromNow(60)` },
+    { name: 'Initech — Expansion',        account: 'Initech',    stage: 'prospecting',    amount:  80_000, probability: 20, close_date: cel`daysFromNow(45)` },
+    { name: 'Acme — Add-on Module',       account: 'Acme Corp',  stage: 'qualification',  amount:  60_000, probability: 35, close_date: cel`daysFromNow(20)` },
 
     // --- Recently closed-won (current quarter — drives "Won This Quarter") -
-    { name: 'Initech — Pilot',                  account: { externalId: 'Initech' },    stage: 'closed_won', amount:  35_000, probability: 100, close_date: cel`daysAgo(7)` },
-    { name: 'Acme — Support Tier Upgrade',      account: { externalId: 'Acme Corp' },  stage: 'closed_won', amount:  90_000, probability: 100, close_date: cel`daysAgo(14)` },
-    { name: 'Globex — Analytics Pack',          account: { externalId: 'Globex Ltd' }, stage: 'closed_won', amount: 110_000, probability: 100, close_date: cel`daysAgo(21)` },
+    { name: 'Initech — Pilot',                  account: 'Initech',    stage: 'closed_won', amount:  35_000, probability: 100, close_date: cel`daysAgo(7)` },
+    { name: 'Acme — Support Tier Upgrade',      account: 'Acme Corp',  stage: 'closed_won', amount:  90_000, probability: 100, close_date: cel`daysAgo(14)` },
+    { name: 'Globex — Analytics Pack',          account: 'Globex Ltd', stage: 'closed_won', amount: 110_000, probability: 100, close_date: cel`daysAgo(21)` },
 
     // --- Previous-quarter wins (drives the "vs last quarter" comparison) ---
-    { name: 'Initech — POC',                    account: { externalId: 'Initech' },    stage: 'closed_won', amount:  25_000, probability: 100, close_date: cel`daysAgo(95)` },
-    { name: 'Globex — Initial Seats',           account: { externalId: 'Globex Ltd' }, stage: 'closed_won', amount: 145_000, probability: 100, close_date: cel`daysAgo(110)` },
+    { name: 'Initech — POC',                    account: 'Initech',    stage: 'closed_won', amount:  25_000, probability: 100, close_date: cel`daysAgo(95)` },
+    { name: 'Globex — Initial Seats',           account: 'Globex Ltd', stage: 'closed_won', amount: 145_000, probability: 100, close_date: cel`daysAgo(110)` },
 
     // --- Prior-year wins in the same window (drives "YoY" comparison) ------
-    { name: 'Acme — Year-Ago Renewal',          account: { externalId: 'Acme Corp' },  stage: 'closed_won', amount:  75_000, probability: 100, close_date: cel`daysAgo(380)` },
-    { name: 'Globex — Year-Ago Implementation', account: { externalId: 'Globex Ltd' }, stage: 'closed_won', amount: 210_000, probability: 100, close_date: cel`daysAgo(400)` },
+    { name: 'Acme — Year-Ago Renewal',          account: 'Acme Corp',  stage: 'closed_won', amount:  75_000, probability: 100, close_date: cel`daysAgo(380)` },
+    { name: 'Globex — Year-Ago Implementation', account: 'Globex Ltd', stage: 'closed_won', amount: 210_000, probability: 100, close_date: cel`daysAgo(400)` },
 
     // --- Closed lost (kept out of pipeline sum) ----------------------------
-    { name: 'Initech — Cancelled Eval',         account: { externalId: 'Initech' },    stage: 'closed_lost', amount: 15_000, probability: 0, close_date: cel`daysAgo(30)` },
+    { name: 'Initech — Cancelled Eval',         account: 'Initech',    stage: 'closed_lost', amount: 15_000, probability: 0, close_date: cel`daysAgo(30)` },
   ],
 });
 
@@ -66,7 +66,7 @@ const leads = defineDataset(Lead, {
       title: 'Director of Research', phone: '+1-555-0101',
       status: 'new', source: 'web', lead_score: 0,
       assigned_to: 'ada@acme.example',
-      account: { externalId: 'Acme Corp' },
+      account: 'Acme Corp',
     },
     // In qualification — high-value referral lead
     {
@@ -81,7 +81,7 @@ const leads = defineDataset(Lead, {
       title: 'CTO', phone: '+1-555-0303',
       status: 'qualified', source: 'event', lead_score: 85,
       assigned_to: 'grace@initech.example',
-      account: { externalId: 'Initech' },
+      account: 'Initech',
     },
     // Disqualified — poor fit
     {
@@ -96,7 +96,7 @@ const leads = defineDataset(Lead, {
       title: 'Chief Inventor', phone: '+1-555-0505',
       status: 'converted', source: 'partner', lead_score: 90,
       assigned_to: 'ada@acme.example',
-      converted_opportunity: { externalId: 'Acme — Q3 Platform Renewal' },
+      converted_opportunity: 'Acme — Q3 Platform Renewal',
     },
   ],
 });
@@ -109,9 +109,9 @@ const activities = defineDataset(Activity, {
       subject: 'Discovery Call — Bletchley Systems',
       type: 'call', status: 'completed',
       due_date: cel`daysAgo(3)`,
-      contact: { externalId: 'ada@acme.example' },
-      account: { externalId: 'Acme Corp' },
-      opportunity: { externalId: 'Acme — Q3 Platform Renewal' },
+      contact: 'ada@acme.example',
+      account: 'Acme Corp',
+      opportunity: 'Acme — Q3 Platform Renewal',
       duration_minutes: 45,
       outcome: 'Strong interest confirmed; sending proposal next week.',
     },
@@ -119,9 +119,9 @@ const activities = defineDataset(Activity, {
       subject: 'Product Demo — Globex New CRM',
       type: 'meeting', status: 'planned',
       due_date: cel`daysFromNow(5)`,
-      contact: { externalId: 'linus@globex.example' },
-      account: { externalId: 'Globex Ltd' },
-      opportunity: { externalId: 'Globex — New CRM Rollout' },
+      contact: 'linus@globex.example',
+      account: 'Globex Ltd',
+      opportunity: 'Globex — New CRM Rollout',
       duration_minutes: 90,
       description: 'Full platform walkthrough with IT and operations stakeholders.',
     },
@@ -129,25 +129,25 @@ const activities = defineDataset(Activity, {
       subject: 'Follow-up Email — Initech Expansion',
       type: 'email', status: 'completed',
       due_date: cel`daysAgo(7)`,
-      contact: { externalId: 'grace@initech.example' },
-      account: { externalId: 'Initech' },
-      opportunity: { externalId: 'Initech — Expansion' },
+      contact: 'grace@initech.example',
+      account: 'Initech',
+      opportunity: 'Initech — Expansion',
       outcome: 'Sent pricing breakdown; awaiting procurement sign-off.',
     },
     {
       subject: 'Proposal Review — Helix Analytics',
       type: 'task', status: 'in_progress',
       due_date: cel`daysFromNow(2)`,
-      contact: { externalId: 'grace@initech.example' },
-      account: { externalId: 'Initech' },
+      contact: 'grace@initech.example',
+      account: 'Initech',
       description: 'Prepare and review the commercial proposal before sending to Helix.',
     },
     {
       subject: 'Quarterly Business Review — Acme Corp',
       type: 'meeting', status: 'planned',
       due_date: cel`daysFromNow(14)`,
-      contact: { externalId: 'ada@acme.example' },
-      account: { externalId: 'Acme Corp' },
+      contact: 'ada@acme.example',
+      account: 'Acme Corp',
       duration_minutes: 60,
       description: 'QBR covering renewal roadmap and upsell opportunities.',
     },

--- a/examples/app-showcase/src/data/index.ts
+++ b/examples/app-showcase/src/data/index.ts
@@ -31,11 +31,11 @@ const projects = defineDataset(Project, {
   mode: 'upsert',
   externalId: 'name',
   records: [
-    { name: 'Website Relaunch', account: { externalId: 'Northwind' }, status: 'active', health: 'green', budget: 150_000, spent: 60_000, owner: 'ada@example.com', start_date: cel`daysAgo(30)`, end_date: cel`daysFromNow(60)` },
-    { name: 'Data Platform', account: { externalId: 'Contoso' }, status: 'active', health: 'yellow', budget: 600_000, spent: 420_000, owner: 'linus@example.com', start_date: cel`daysAgo(90)`, end_date: cel`daysFromNow(120)` },
-    { name: 'Compliance Audit', account: { externalId: 'Fabrikam' }, status: 'on_hold', health: 'red', budget: 90_000, spent: 88_000, owner: 'grace@example.com', start_date: cel`daysAgo(15)`, end_date: cel`daysFromNow(30)` },
-    { name: 'Mobile App', account: { externalId: 'Contoso' }, status: 'planned', health: 'green', budget: 200_000, spent: 0, owner: 'ada@example.com', start_date: cel`daysFromNow(14)`, end_date: cel`daysFromNow(140)` },
-    { name: 'Legacy Sunset', account: { externalId: 'Northwind' }, status: 'completed', health: 'green', budget: 50_000, spent: 48_000, owner: 'linus@example.com', start_date: cel`daysAgo(180)`, end_date: cel`daysAgo(20)` },
+    { name: 'Website Relaunch', account: 'Northwind', status: 'active', health: 'green', budget: 150_000, spent: 60_000, owner: 'ada@example.com', start_date: cel`daysAgo(30)`, end_date: cel`daysFromNow(60)` },
+    { name: 'Data Platform', account: 'Contoso', status: 'active', health: 'yellow', budget: 600_000, spent: 420_000, owner: 'linus@example.com', start_date: cel`daysAgo(90)`, end_date: cel`daysFromNow(120)` },
+    { name: 'Compliance Audit', account: 'Fabrikam', status: 'on_hold', health: 'red', budget: 90_000, spent: 88_000, owner: 'grace@example.com', start_date: cel`daysAgo(15)`, end_date: cel`daysFromNow(30)` },
+    { name: 'Mobile App', account: 'Contoso', status: 'planned', health: 'green', budget: 200_000, spent: 0, owner: 'ada@example.com', start_date: cel`daysFromNow(14)`, end_date: cel`daysFromNow(140)` },
+    { name: 'Legacy Sunset', account: 'Northwind', status: 'completed', health: 'green', budget: 50_000, spent: 48_000, owner: 'linus@example.com', start_date: cel`daysAgo(180)`, end_date: cel`daysAgo(20)` },
   ],
 });
 
@@ -44,16 +44,16 @@ const tasks = defineDataset(Task, {
   mode: 'upsert',
   externalId: 'title',
   records: [
-    { title: 'Audit current IA', project: { externalId: 'Website Relaunch' }, assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 8, progress: 100, done: true, created_at: cel`daysAgo(20)`, start_date: cel`daysAgo(20)`, end_date: cel`daysAgo(18)`, due_date: cel`daysAgo(18)`, location: { lat: 47.6062, lng: -122.3321 } },
-    { title: 'Design system', project: { externalId: 'Website Relaunch' }, assignee: 'ada@example.com', status: 'in_review', priority: 'high', estimate_hours: 24, progress: 80, done: false, created_at: cel`daysAgo(14)`, start_date: cel`daysAgo(12)`, end_date: cel`daysFromNow(2)`, due_date: cel`daysFromNow(2)`, location: { lat: 37.7749, lng: -122.4194 } },
-    { title: 'Build homepage', project: { externalId: 'Website Relaunch' }, assignee: 'sam@example.com', status: 'in_progress', priority: 'high', estimate_hours: 40, progress: 45, done: false, created_at: cel`daysAgo(8)`, start_date: cel`daysAgo(6)`, end_date: cel`daysFromNow(10)`, due_date: cel`daysFromNow(10)`, location: { lat: 40.7128, lng: -74.0060 } },
-    { title: 'SEO migration plan', project: { externalId: 'Website Relaunch' }, assignee: 'sam@example.com', status: 'todo', priority: 'medium', estimate_hours: 16, progress: 0, done: false, created_at: cel`daysAgo(3)`, start_date: cel`daysFromNow(5)`, end_date: cel`daysFromNow(15)`, due_date: cel`daysFromNow(15)`, location: { lat: 30.2672, lng: -97.7431 } },
-    { title: 'Content backlog', project: { externalId: 'Website Relaunch' }, assignee: 'grace@example.com', status: 'backlog', priority: 'low', estimate_hours: 12, progress: 0, done: false, created_at: cel`daysAgo(2)`, due_date: cel`daysFromNow(30)`, location: { lat: 41.8781, lng: -87.6298 } },
-    { title: 'Ingest pipeline', project: { externalId: 'Data Platform' }, assignee: 'linus@example.com', status: 'in_progress', priority: 'urgent', estimate_hours: 60, progress: 55, done: false, created_at: cel`daysAgo(40)`, start_date: cel`daysAgo(35)`, end_date: cel`daysFromNow(20)`, due_date: cel`daysFromNow(20)`, location: { lat: 39.7392, lng: -104.9903 } },
-    { title: 'Warehouse schema', project: { externalId: 'Data Platform' }, assignee: 'linus@example.com', status: 'in_review', priority: 'high', estimate_hours: 30, progress: 90, done: false, created_at: cel`daysAgo(25)`, start_date: cel`daysAgo(22)`, end_date: cel`daysFromNow(3)`, due_date: cel`daysFromNow(3)`, location: { lat: 42.3601, lng: -71.0589 } },
-    { title: 'PII access review', project: { externalId: 'Compliance Audit' }, assignee: 'grace@example.com', status: 'todo', priority: 'urgent', estimate_hours: 20, progress: 0, done: false, created_at: cel`daysAgo(5)`, start_date: cel`daysFromNow(2)`, end_date: cel`daysFromNow(12)`, due_date: cel`daysFromNow(12)`, location: { lat: 38.9072, lng: -77.0369 } },
-    { title: 'Evidence collection', project: { externalId: 'Compliance Audit' }, assignee: 'grace@example.com', status: 'backlog', priority: 'medium', estimate_hours: 18, progress: 0, done: false, created_at: cel`daysAgo(1)`, due_date: cel`daysFromNow(25)`, location: { lat: 34.0522, lng: -118.2437 } },
-    { title: 'App wireframes', project: { externalId: 'Mobile App' }, assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 16, progress: 100, done: true, created_at: cel`daysAgo(10)`, start_date: cel`daysAgo(10)`, end_date: cel`daysAgo(6)`, due_date: cel`daysAgo(6)`, location: { lat: 45.5152, lng: -122.6784 } },
+    { title: 'Audit current IA', project: 'Website Relaunch', assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 8, progress: 100, done: true, created_at: cel`daysAgo(20)`, start_date: cel`daysAgo(20)`, end_date: cel`daysAgo(18)`, due_date: cel`daysAgo(18)`, location: { lat: 47.6062, lng: -122.3321 } },
+    { title: 'Design system', project: 'Website Relaunch', assignee: 'ada@example.com', status: 'in_review', priority: 'high', estimate_hours: 24, progress: 80, done: false, created_at: cel`daysAgo(14)`, start_date: cel`daysAgo(12)`, end_date: cel`daysFromNow(2)`, due_date: cel`daysFromNow(2)`, location: { lat: 37.7749, lng: -122.4194 } },
+    { title: 'Build homepage', project: 'Website Relaunch', assignee: 'sam@example.com', status: 'in_progress', priority: 'high', estimate_hours: 40, progress: 45, done: false, created_at: cel`daysAgo(8)`, start_date: cel`daysAgo(6)`, end_date: cel`daysFromNow(10)`, due_date: cel`daysFromNow(10)`, location: { lat: 40.7128, lng: -74.0060 } },
+    { title: 'SEO migration plan', project: 'Website Relaunch', assignee: 'sam@example.com', status: 'todo', priority: 'medium', estimate_hours: 16, progress: 0, done: false, created_at: cel`daysAgo(3)`, start_date: cel`daysFromNow(5)`, end_date: cel`daysFromNow(15)`, due_date: cel`daysFromNow(15)`, location: { lat: 30.2672, lng: -97.7431 } },
+    { title: 'Content backlog', project: 'Website Relaunch', assignee: 'grace@example.com', status: 'backlog', priority: 'low', estimate_hours: 12, progress: 0, done: false, created_at: cel`daysAgo(2)`, due_date: cel`daysFromNow(30)`, location: { lat: 41.8781, lng: -87.6298 } },
+    { title: 'Ingest pipeline', project: 'Data Platform', assignee: 'linus@example.com', status: 'in_progress', priority: 'urgent', estimate_hours: 60, progress: 55, done: false, created_at: cel`daysAgo(40)`, start_date: cel`daysAgo(35)`, end_date: cel`daysFromNow(20)`, due_date: cel`daysFromNow(20)`, location: { lat: 39.7392, lng: -104.9903 } },
+    { title: 'Warehouse schema', project: 'Data Platform', assignee: 'linus@example.com', status: 'in_review', priority: 'high', estimate_hours: 30, progress: 90, done: false, created_at: cel`daysAgo(25)`, start_date: cel`daysAgo(22)`, end_date: cel`daysFromNow(3)`, due_date: cel`daysFromNow(3)`, location: { lat: 42.3601, lng: -71.0589 } },
+    { title: 'PII access review', project: 'Compliance Audit', assignee: 'grace@example.com', status: 'todo', priority: 'urgent', estimate_hours: 20, progress: 0, done: false, created_at: cel`daysAgo(5)`, start_date: cel`daysFromNow(2)`, end_date: cel`daysFromNow(12)`, due_date: cel`daysFromNow(12)`, location: { lat: 38.9072, lng: -77.0369 } },
+    { title: 'Evidence collection', project: 'Compliance Audit', assignee: 'grace@example.com', status: 'backlog', priority: 'medium', estimate_hours: 18, progress: 0, done: false, created_at: cel`daysAgo(1)`, due_date: cel`daysFromNow(25)`, location: { lat: 34.0522, lng: -118.2437 } },
+    { title: 'App wireframes', project: 'Mobile App', assignee: 'ada@example.com', status: 'done', priority: 'medium', estimate_hours: 16, progress: 100, done: true, created_at: cel`daysAgo(10)`, start_date: cel`daysAgo(10)`, end_date: cel`daysAgo(6)`, due_date: cel`daysAgo(6)`, location: { lat: 45.5152, lng: -122.6784 } },
   ],
 });
 
@@ -62,8 +62,8 @@ const categories = defineDataset(Category, {
   externalId: 'name',
   records: [
     { name: 'Engineering', sort_order: 1, color: '#3B82F6' },
-    { name: 'Frontend', parent: { externalId: 'Engineering' }, sort_order: 1, color: '#06B6D4' },
-    { name: 'Backend', parent: { externalId: 'Engineering' }, sort_order: 2, color: '#8B5CF6' },
+    { name: 'Frontend', parent: 'Engineering', sort_order: 1, color: '#06B6D4' },
+    { name: 'Backend', parent: 'Engineering', sort_order: 2, color: '#8B5CF6' },
     { name: 'Operations', sort_order: 2, color: '#10B981' },
   ],
 });
@@ -80,9 +80,9 @@ const teams = defineDataset(Team, {
 const memberships = defineDataset(ProjectMembership, {
   mode: 'insert',
   records: [
-    { team: { externalId: 'Experience' }, project: { externalId: 'Website Relaunch' }, role: 'owner', allocation_percent: 80 },
-    { team: { externalId: 'Platform' }, project: { externalId: 'Data Platform' }, role: 'owner', allocation_percent: 100 },
-    { team: { externalId: 'Platform' }, project: { externalId: 'Website Relaunch' }, role: 'contributor', allocation_percent: 20 },
+    { team: 'Experience', project: 'Website Relaunch', role: 'owner', allocation_percent: 80 },
+    { team: 'Platform', project: 'Data Platform', role: 'owner', allocation_percent: 100 },
+    { team: 'Platform', project: 'Website Relaunch', role: 'contributor', allocation_percent: 20 },
   ],
 });
 

--- a/packages/runtime/src/seed-loader.test.ts
+++ b/packages/runtime/src/seed-loader.test.ts
@@ -407,6 +407,48 @@ describe('SeedLoaderService', () => {
       expect(result.summary.totalReferencesResolved).toBe(0);
     });
 
+    it('should fail loudly when a reference is an object wrapper, not write it to the driver', async () => {
+      const metadata = createMockMetadata({
+        account: { name: 'account', fields: { name: { type: 'text' } } },
+        contact: {
+          name: 'contact',
+          fields: {
+            name: { type: 'text' },
+            account_id: { type: 'lookup', reference: 'account' },
+          },
+        },
+      });
+      const engine = createMockEngine();
+      const loader = new SeedLoaderService(engine, metadata, logger);
+
+      const result = await loader.load({
+        datasets: [
+          { object: 'account', externalId: 'name', mode: 'upsert', env: ['prod', 'dev', 'test'], records: [{ name: 'Acme Corp' }] },
+          // The previously-masked bug: a `{ externalId: 'X' }` wrapper instead of
+          // the plain natural-key string. Must be rejected, never handed to the driver.
+          { object: 'contact', externalId: 'name', mode: 'upsert', env: ['prod', 'dev', 'test'], records: [{ name: 'John', account_id: { externalId: 'Acme Corp' } }] },
+        ],
+        config: {
+          dryRun: false, haltOnError: false, multiPass: true,
+          defaultMode: 'upsert', batchSize: 1000, transaction: false,
+        },
+      });
+
+      // Load is marked unsuccessful and the error is actionable.
+      expect(result.success).toBe(false);
+      const refError = result.errors.find((e) => e.sourceObject === 'contact' && e.field === 'account_id');
+      expect(refError).toBeDefined();
+      expect(refError!.message).toContain('expected a account.name natural-key string');
+      expect(refError!.message).toContain("account_id: \"Acme Corp\"");
+
+      // The object wrapper must NOT reach the driver (it would throw "can only
+      // bind"); the guard drops it to null instead.
+      const contactInsertCall = (engine.insert as any).mock.calls.find((c: any[]) => c[0] === 'contact');
+      if (contactInsertCall) {
+        expect(contactInsertCall[1].account_id).toBeNull();
+      }
+    });
+
     it('should skip reference resolution for values that look like UUIDs', async () => {
       const metadata = createMockMetadata({
         account: { name: 'account', fields: { name: { type: 'text' } } },

--- a/packages/runtime/src/seed-loader.ts
+++ b/packages/runtime/src/seed-loader.ts
@@ -269,6 +269,37 @@ export class SeedLoaderService implements ISeedLoaderService {
         const fieldValue = record[ref.field];
         if (fieldValue === undefined || fieldValue === null) continue;
 
+        // LOUD FAILURE: a reference must be a natural-key string (or an
+        // internal id). An object value — e.g. the wrapper `{ externalId: 'X' }`
+        // — never resolves: it would otherwise fall through unresolved and reach
+        // the driver as a non-bindable value ("SQLite3 can only bind ..."). This
+        // used to be silently skipped (and only crashed on a persistent DB's
+        // update path), so catch it here and report the actionable fix instead.
+        if (typeof fieldValue === 'object') {
+          const wrapped = (fieldValue as Record<string, unknown>).externalId;
+          const hint =
+            wrapped !== undefined
+              ? ` Pass the natural key directly: ${ref.field}: ${JSON.stringify(wrapped)}.`
+              : ` Pass the target's ${ref.targetField} value as a plain string.`;
+          const error: ReferenceResolutionError = {
+            sourceObject: objectName,
+            field: ref.field,
+            targetObject: ref.targetObject,
+            targetField: ref.targetField,
+            attemptedValue: fieldValue,
+            recordIndex: i,
+            message:
+              `Invalid reference for ${objectName}.${ref.field}: expected a ` +
+              `${ref.targetObject}.${ref.targetField} natural-key string but got an object.${hint}`,
+          };
+          errors.push(error);
+          allErrors.push(error);
+          this.logger.warn(`[SeedLoader] ${error.message}`, { recordIndex: i });
+          // Drop the unresolvable value so it never reaches the driver.
+          record[ref.field] = null;
+          continue;
+        }
+
         // Skip if value looks like an internal ID (not a natural key)
         if (typeof fieldValue !== 'string' || this.looksLikeInternalId(fieldValue)) continue;
 

--- a/packages/spec/src/data/dataset.zod.ts
+++ b/packages/spec/src/data/dataset.zod.ts
@@ -68,17 +68,42 @@ export type DatasetInput = z.input<typeof DatasetSchema>;
 export type DatasetImportMode = z.infer<typeof DatasetMode>;
 
 /**
+ * Per-field value type for a seed record.
+ *
+ * Reference fields (`lookup` / `master_detail`) are resolved during seeding by
+ * matching the value against the target record's externalId — so the value MUST
+ * be the plain natural-key string (e.g. `account: 'Acme Corp'`), or `null`.
+ * Passing a wrapper object like `account: { externalId: 'Acme Corp' }` does NOT
+ * resolve: the loader skips non-string reference values, the raw object reaches
+ * the SQL driver, and on update it crashes with "SQLite3 can only bind numbers,
+ * strings, bigints, buffers, and null" (silently masked on an always-empty
+ * `:memory:` DB, fatal-looking on a persistent one). Constrain those fields to
+ * `string | null` at compile time; every other field stays `unknown`.
+ */
+type SeedFieldValue<TFieldDef> =
+  TFieldDef extends { type: 'lookup' | 'master_detail' } ? string | null : unknown;
+
+/** Shape of a single seed record, derived from the object's field definitions. */
+type SeedRecord<TFields> = {
+  [K in keyof TFields]?: SeedFieldValue<TFields[K]>;
+};
+
+/**
  * Type-safe factory for creating seed dataset definitions.
  * Infers valid field keys from the object definition passed in,
- * so typos in record field names are caught at compile time.
+ * so typos in record field names are caught at compile time. Reference
+ * fields (lookup/master_detail) are additionally constrained to the
+ * natural-key string the loader resolves — see {@link SeedFieldValue}.
  *
  * @example
  * ```ts
  * export const leadSeed = defineDataset(Lead, {
  *   externalId: 'email',
  *   records: [
- *     { first_name: 'Alice', lead_source: 'web' }, // ✅ type-checked
- *     { source: 'web' },                            // ❌ compile error
+ *     { first_name: 'Alice', lead_source: 'web' },   // ✅ type-checked
+ *     { source: 'web' },                              // ❌ compile error (unknown field)
+ *     { first_name: 'Bob', account: 'Acme Corp' },   // ✅ reference by natural key
+ *     { first_name: 'Bob', account: { externalId: 'Acme Corp' } }, // ❌ object not allowed
  *   ],
  * });
  * ```
@@ -88,7 +113,7 @@ export function defineDataset<
 >(
   objectDef: TObj,
   config: Omit<DatasetInput, 'object' | 'records'> & {
-    records: Array<Partial<Record<keyof TObj['fields'], unknown>>>;
+    records: Array<SeedRecord<TObj['fields']>>;
   }
 ): Dataset {
   return DatasetSchema.parse({ ...config, object: objectDef.name });


### PR DESCRIPTION
## Problem

Seed datasets wrote `lookup` / `master_detail` references as object literals, e.g. `project: { externalId: 'Website Relaunch' }`. The seed-loader resolves references from the **plain natural-key string** — it skips non-string values (`packages/runtime/src/seed-loader.ts:273`), so the wrapper object was never resolved and got handed straight to the SQL driver.

On a `:memory:` DB this was masked (always-empty at boot ⇒ INSERTs). Now that `objectstack dev` uses a **persistent SQLite DB**, restarting re-runs seeds as UPDATEs and better-sqlite3 throws:

```
SQLite3 can only bind numbers, strings, bigints, buffers, and null
```

— repeated `Update operation failed { object: showcase_task ... project = {externalId:...} }` noise, and those demo rows never update.

This was **not an isolated showcase typo**: `examples/app-crm` used the same object form throughout, and nothing stopped it — the seed record value type was `unknown`, so both forms compiled, and the failure only ever surfaced on a persistent DB.

## Changes

**1. Fix the example seed data** (`examples/app-showcase`, `examples/app-crm`) — switch every relationship reference from `{ externalId: 'X' }` to the plain natural-key string `'X'`:
- showcase: `project.account`, `task.project`, `category.parent`, `project_membership.team`/`project`
- crm: `contact/opportunity/lead/activity` → `account`/`contact`/`opportunity`

**2. Harden the framework so it can't recur** (`@objectstack/spec`, `@objectstack/runtime`):
- **Compile-time:** `defineDataset` now constrains `lookup`/`master_detail` field values to `string | null` (derived from each field's literal `type`). The object form is now a **type error**; all other fields stay `unknown`.
- **Runtime:** `SeedLoaderService` now **fails loudly** with an actionable message and drops the value (instead of silently skipping it and letting it reach the driver) when a reference is an object — consistent behavior across all drivers. Covered by a new unit test.

## Verification

- Booted **app-showcase** and **app-crm** dev servers **twice** each against a persistent SQLite DB: **0 "can only bind", 0 "Update operation failed", 0 invalid-reference, 0 insert/update failures**.
- All FKs resolve to real record ids, cross-table consistent (e.g. `task.project` == the Website Relaunch id; crm `contact.account` == `opportunity.account` for Acme). All 12 crm opportunities seed; even the **email-keyed** `activity.contact` resolves.
- Tests: `@objectstack/spec` (6628) ✅, `@objectstack/runtime` (342, incl. new guard test) ✅, `example-showcase` (20) ✅. Typecheck of app-showcase clean.

## Note for reviewers

`examples/app-crm` has **pre-existing** typecheck failures unrelated to this PR (`src/security`, `src/themes`, `src/webhooks` import symbols like `Security` that aren't exported by the current `@objectstack/spec` — API drift). This PR does not touch those; the seed data file (`src/data/index.ts`) typechecks clean.

https://claude.ai/code/session_014XvTsiH3dPPqKgU8uaRjXR