### PR TITLE
fix(security): sys_account.password and previous_password_hashes stop serializing on the data API (#8676)

### DIFF
--- a/.changeset/account-password-columns-internal.md
+++ b/.changeset/account-password-columns-internal.md
@@ -1,0 +1,75 @@
+---
+"@objectstack/platform-objects": patch
+"@objectstack/plugin-auth": patch
+---
+
+fix(security): `sys_account.password` and `previous_password_hashes` stop serializing on the data API — `internal: true`, with the raw-engine readers converted to the privileged accessor (#8676)
+
+<!-- adr-0087: not-required (no-migration-prescription) Two field-level flags
+added to one existing declaration, plus one new export on a plugin-internal
+helper module (`internal-field-readback.ts`, not an exported surface of the
+package). Nothing authorable is renamed, retired or tombstoned, so there is no
+conversion to register. The behavioural change is that two columns holding
+one-way password hashes stop being returned on the generic data path, while the
+ADR-0069 D1 reuse ring and better-auth's sign-in verifier keep reading them
+through the engine's privileged accessor. -->
+
+`sys_account.password` (the credential hash) and `previous_password_hashes` (the
+ADR-0069 D1 reuse-prevention ring) serialized on `/api/v1/data/sys_account`,
+which declares `apiEnabled: true, apiMethods: ['get','list']` — to an **admin
+for every user's row**, and to a **member for their own** (the
+`sys_account_self` RLS policy grants `select` on `user_id == current_user.id`).
+
+These are one-way hashes, not reversible outbound credentials — which is why
+#7987 correctly refused to bundle them with the OAuth tokens. But a served
+password hash is an offline-cracking target, and `previous_password_hashes`
+multiplies it by the history ring while its own declaration says it is *never
+exposed in UI*. This is the disposition #7728 already reached for
+`sys_api_key.key`, which was **also** a stored hash and was still ruled unfit to
+serialize through the API face.
+
+Neither credential collector could reach them: `collectMaskedReadFields` keys on
+the field **TYPE** (`secret` / `password`) *and* exempts objects declaring
+`managedBy: 'better-auth'`, which this object is — while these columns are
+`text` / `textarea`. Two independent barriers, both missing.
+
+**The fix is two declarations plus two recovery seams**, and the second seam is
+the part a bare flag would have missed:
+
+- both columns are declared `internal: true` — the opt-in, type-independent flag
+  from #7728 meaning *the declared value is never returned on the generic data
+  path*. Storage, filtering and indexing are untouched: the strip runs on rows
+  the driver has already produced.
+- **better-auth's adapter readers** are recovered by the existing per-object
+  readback table, widened with `password`: the sign-in verifier compares against
+  the hash on the row `internalAdapter.findCredentialAccount(userId)` returns,
+  so the strip alone would break password sign-in for every user.
+- **plugin-auth's own RAW-engine readers** are recovered by a new seam in the
+  same module, `recoverInternalFieldsForSystemRead`. This is the half that makes
+  the flag safe: the readback table is imported by exactly one file
+  (better-auth's storage adapter), so it cannot reach a caller that reads the
+  engine directly — and the engine's strip has **no `isSystem` carve-out** by
+  #7728's design. Measured against a real ObjectQL engine: the reuse ring's
+  `findOne` returns `{"id":"a1"}` for a query that names both columns in an
+  explicit projection under `context: { isSystem: true }`.
+
+  Left unrecovered, `assertPasswordNotReused` would become a **silent no-op** —
+  its comparison list empties, the loop never runs, `PASSWORD_REUSE` is never
+  thrown, and its own `catch { return undefined }` means nothing announces it.
+  The ADR-0069 D1 control would report success while accepting every reused
+  password. Its unit tests would have stayed green throughout, because they use
+  fake engines that never apply the strip.
+
+**No ADR-0100 guard change, and none was needed.** `Engine.resolveInternalField`
+has exactly one predicate — `internal === true` — so flagging the columns makes
+them legitimately dereferenceable through the privileged accessor. The ADR-0100
+sentence in its refusal message is prose explaining why a *non-flagged* field has
+other channels, not a second predicate; the guard stays exactly as selective as
+it was, and a non-flagged column on the same object is still refused with
+`INVALID_FIELD` / 400.
+
+Regression proof drives both directions on a real booted stack: both columns are
+absent for both personas — including a caller who spells them out in `?select=` —
+while the values remain on disk and reachable through the privileged accessor,
+password sign-in still works, and the reuse ring still grows across a password
+change on every transport lane.

--- a/packages/platform-objects/src/identity/sys-account.object.ts
+++ b/packages/platform-objects/src/identity/sys-account.object.ts
@@ -261,9 +261,32 @@ export const SysAccount = ObjectSchema.create({
       required: false,
     }),
     
+    // [#8676] `internal: true` — never returned on the generic data path.
+    // Both columns below are one-way password hashes (ADR-0100's third
+    // channel), and BOTH serialized on `/api/v1/data/sys_account` before this
+    // flag: to an admin for every user's row, and to a member for their own
+    // (the `sys_account_self` RLS policy grants `select` on `user_id ==
+    // current_user.id`). Neither credential collector catches them —
+    // `collectMaskedReadFields` keys on the field TYPE (`secret` / `password`)
+    // and additionally exempts `managedBy: 'better-auth'` objects, which this
+    // one is, while these are `text` / `textarea` columns. The flag is the
+    // third channel's answer, and it is the same disposition #7728 reached for
+    // `sys_api_key.key` — also a stored hash, also ruled unfit to serialize
+    // through the API face. Serving a password hash hands out an offline
+    // cracking target; the history ring multiplies it.
+    //
+    // ⚠️ Flagging a column STARVES every reader that takes it off a result
+    // row — with no `isSystem` carve-out, by #7728's design. Both columns have
+    // such readers, and each is recovered through the engine's privileged
+    // accessor (`Engine.resolveInternalField`, #8118) rather than by punching a
+    // hole in the strip: better-auth's adapter reads via the readback seam in
+    // `plugin-auth/src/internal-field-readback.ts`, and plugin-auth's own
+    // raw-engine readers (the ADR-0069 D1 reuse ring, the dev seed-admin
+    // probe) via `recoverInternalFieldsForSystemRead` in that same module.
     password: Field.text({
       label: 'Password Hash',
       required: false,
+      internal: true,
       description: 'Hashed password for email/password provider',
     }),
 
@@ -275,6 +298,7 @@ export const SysAccount = ObjectSchema.create({
       required: false,
       readonly: true,
       hidden: true,
+      internal: true,
       description: 'JSON array of prior password hashes (bounded by password_history_count); reuse-prevention only. System-managed.',
     }),
   },

--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -3295,6 +3295,123 @@ describe('AuthManager', () => {
       const written = JSON.parse(engine.update.mock.calls[0][1].previous_password_hashes);
       expect(written).toEqual(['hash:current', 'hash:old1']); // prepend + trim to 2
     });
+
+    // ---- #8676: the same control, against an engine that actually STRIPS ----
+    //
+    // ⚠️ Every test above uses `makeEngine`, which hands back the stored object
+    // untouched. That is a faithful model of a strip-less engine — and it is
+    // precisely why those tests carry NO information about #8676: once
+    // `sys_account.password` and `previous_password_hashes` are `internal:
+    // true`, the REAL engine omits both from this read, with no `isSystem`
+    // carve-out and in spite of the explicit projection (#7728's design;
+    // measured against a real ObjectQL engine + stub driver on #8676, which
+    // returned `{"id":"a1"}` for the exact query at `assertPasswordNotReused`).
+    // `compareList` then empties, the loop never runs, `PASSWORD_REUSE` is
+    // never thrown, and the method's own `catch { return undefined }` means
+    // nothing announces it. The suite above stays GREEN through all of that.
+    //
+    // So the strip is modelled explicitly here, together with the privileged
+    // accessor that recovers it — this block is the canary that block is not.
+    describe('under the `internal: true` strip (#8676)', () => {
+      /** Mimics the real engine: omit the flagged columns, offer the accessor. */
+      const INTERNAL = ['password', 'previous_password_hashes'] as const;
+      const makeStrippingEngine = (account: any, opts: { accessor?: boolean } = {}) => {
+        const strip = (row: any) => {
+          if (!row) return row;
+          const out = { ...row };
+          for (const f of INTERNAL) delete out[f];
+          return out;
+        };
+        // What the engine handed back, snapshotted AT RETURN TIME — the seam
+        // repairs rows in place, so re-reading the row afterwards shows the
+        // recovered copy and could never witness the strip.
+        const returned: any[] = [];
+        const engine: any = {
+          returned,
+          findOne: vi.fn(async (_o: string, q: any) => {
+            const w = q?.where ?? {};
+            if (!account) return null;
+            const ok = Object.entries(w).every(([k, v]) => (account as any)[k] === v);
+            if (!ok) return null;
+            const row = strip(account);
+            returned.push({ ...row });
+            return row;
+          }),
+          update: vi.fn(async () => ({})),
+        };
+        if (opts.accessor !== false) {
+          engine.resolveInternalField = vi.fn(
+            async (_object: string, ids: readonly string[], field: string) => {
+              const out = new Map<string, unknown>();
+              for (const id of ids) if (account && account.id === id) out.set(id, account[field] ?? null);
+              return out;
+            },
+          );
+        }
+        return engine;
+      };
+
+      it('still rejects reuse of the CURRENT password — the row arrives without it', async () => {
+        const engine = makeStrippingEngine(acct());
+        const m = mgr(engine, { passwordHistoryCount: 5 });
+        await expect((m as any).assertPasswordNotReused('u1', 'current', stubVerify)).rejects.toMatchObject({
+          body: { code: 'PASSWORD_REUSE' },
+        });
+        // The row really did arrive stripped — this is not the un-stripped
+        // path in disguise, which would make the rejection above vacuous.
+        expect(engine.returned).toHaveLength(1);
+        expect('password' in engine.returned[0]).toBe(false);
+        expect('previous_password_hashes' in engine.returned[0]).toBe(false);
+        // …and the rest of the row survived, so it is a real row, not an empty one.
+        expect(engine.returned[0].id).toBe('a1');
+        expect(engine.returned[0].provider_id).toBe('credential');
+      });
+
+      it('still rejects reuse of a HISTORICAL password — the ring is recovered too', async () => {
+        const m = mgr(makeStrippingEngine(acct()), { passwordHistoryCount: 5 });
+        await expect((m as any).assertPasswordNotReused('u1', 'old2', stubVerify)).rejects.toMatchObject({
+          body: { code: 'PASSWORD_REUSE' },
+        });
+      });
+
+      it('still accepts a fresh password and returns the CURRENT hash for the after-hook', async () => {
+        // Discriminating positive control for the two refusals above: the
+        // recovery is selective, not a blanket throw — a genuinely new password
+        // passes, and the hash it returns is the recovered one (empty string
+        // here would be the silent-no-op signature, and would also make
+        // `recordPasswordHistory` return early on `!oldHash`).
+        const m = mgr(makeStrippingEngine(acct()), { passwordHistoryCount: 5 });
+        await expect((m as any).assertPasswordNotReused('u1', 'brandnew', stubVerify)).resolves.toBe('hash:current');
+      });
+
+      it('recordPasswordHistory still grows the ring — it is rebuilt from the recovered column', async () => {
+        const engine = makeStrippingEngine(acct({ previous_password_hashes: JSON.stringify(['hash:old1', 'hash:old2']) }));
+        const m = mgr(engine, { passwordHistoryCount: 2 });
+        await (m as any).recordPasswordHistory('u1', 'hash:current');
+        const written = JSON.parse(engine.update.mock.calls[0][1].previous_password_hashes);
+        // Without the recovery this would be `['hash:current']` — a ring that
+        // silently never grows past one entry, forgetting every older password.
+        expect(written).toEqual(['hash:current', 'hash:old1']);
+        expect(engine.resolveInternalField).toHaveBeenCalledWith('sys_account', ['a1'], 'previous_password_hashes');
+        // …and it does NOT dereference `password`, which this path never reads.
+        expect(engine.resolveInternalField.mock.calls.map((c: any[]) => c[2])).not.toContain('password');
+      });
+
+      it('⛔ the recovery is LOAD-BEARING: drop the accessor and the control provably dies', async () => {
+        // The falsification arm. This is the pre-#8676 shape — a stripping
+        // engine with no privileged accessor — and it is what every assertion
+        // in this block would look like if the recovery were removed. Pinned so
+        // the four tests above can never pass vacuously: if the strip stopped
+        // mattering, THIS test goes red first.
+        const engine = makeStrippingEngine(acct(), { accessor: false });
+        const m = mgr(engine, { passwordHistoryCount: 5 });
+        // Reusing the CURRENT password sails straight through — no throw at all.
+        await expect(
+          (m as any).assertPasswordNotReused('u1', 'current', stubVerify),
+        ).resolves.toBe('');
+        expect(engine.resolveInternalField).toBeUndefined();
+      });
+    });
   });
 
   // ADR-0069 D1: password expiry posture + stamping (the session-gate infra).

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -21,6 +21,7 @@ import {
 import { postureEnforcesWall, type TenancyPosture } from '@objectstack/spec/security';
 import { MCP_OAUTH_SCOPES } from '@objectstack/spec/ai';
 import { createObjectQLAdapterFactory, withSystemReadContext } from './objectql-adapter.js';
+import { recoverInternalFieldsForSystemRead } from './internal-field-readback.js';
 import { runWithAuthActorScope, setAuthActorResolver } from './auth-actor-attribution.js';
 import {
   emitAuthSessionAuditEvent,
@@ -5034,6 +5035,17 @@ export class AuthManager {
         fields: ['id', 'password', 'previous_password_hashes'],
         context: SYSTEM_CTX,
       } as any);
+      // [#8676] Both columns are `internal: true`, so the engine's read path
+      // omits them from the row above — with no `isSystem` carve-out and in
+      // spite of the explicit projection (#7728's design). Recover them
+      // through the privileged accessor, or `compareList` below is empty and
+      // this control silently passes every reused password.
+      await recoverInternalFieldsForSystemRead(
+        engine as never,
+        'sys_account',
+        account,
+        ['password', 'previous_password_hashes'],
+      );
     } catch {
       return undefined; // fail-open on lookup error
     }
@@ -5071,6 +5083,15 @@ export class AuthManager {
         context: SYSTEM_CTX,
       } as any);
       if (!account?.id) return;
+      // [#8676] As above — the flagged column is omitted from the read, so
+      // recover it before extending the ring. Without this the ring is rebuilt
+      // from an empty history on every change and never grows past one entry.
+      await recoverInternalFieldsForSystemRead(
+        engine as never,
+        'sys_account',
+        account,
+        ['previous_password_hashes'],
+      );
       const prev = this.parseHashes(account.previous_password_hashes);
       const next = [oldHash, ...prev.filter((h) => h !== oldHash)].slice(0, count);
       await engine.update(

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -27,6 +27,7 @@ import {
   type AuthManagerOptions,
 } from './auth-manager.js';
 import { ensureDefaultOrganization } from './ensure-default-organization.js';
+import { recoverInternalFieldsForSystemRead } from './internal-field-readback.js';
 import { runAttributedToUser } from './auth-actor-attribution.js';
 import type { AuthEventAuditSurface } from './auth-session-audit.js';
 import type { ResolvedSocialProvider } from './backfill-account-issuer.js';
@@ -1539,6 +1540,12 @@ export class AuthPlugin implements Plugin {
           { context: { isSystem: true } },
         )
         .catch(() => []);
+      // [#8676] `sys_account.password` is `internal: true`, so the row above
+      // arrives without it — the engine's strip has no `isSystem` carve-out.
+      // Recover it through the privileged accessor; otherwise this probe reads
+      // `undefined` on every boot and the dev credential hint silently stops
+      // appearing (fails soft, which is why it would never be noticed).
+      await recoverInternalFieldsForSystemRead(ql, 'sys_account', accounts, ['password']);
       const hash = Array.isArray(accounts) ? accounts[0]?.password : undefined;
       if (typeof hash !== 'string' || hash.length === 0) return;
 

--- a/packages/plugins/plugin-auth/src/internal-field-readback.test.ts
+++ b/packages/plugins/plugin-auth/src/internal-field-readback.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 //
-// #7823 + #7987 — the internal-field READBACK seam, unit-pinned from both
-// directions.
+// #7823 + #7987 + #8676 — the internal-field READBACK seams, unit-pinned from
+// both directions.
 //
 // The engine's `internal: true` read strip removes the flagged column from
 // every find/findOne result; better-auth reads those columns back OFF adapter
@@ -22,9 +22,18 @@
 //    accessor — that state is exactly what turns a security control into a
 //    silent no-op and an OAuth refresh into a 400, so it must never pass
 //    quietly.
+//
+// [#8676] The module now owns TWO seams and this file pins both. The adapter
+// seam above is reachable only from `objectql-adapter.ts`; plugin-auth's own
+// raw-engine readers (the ADR-0069 D1 password-reuse ring, the dev seed-admin
+// probe) bypass it entirely and are recovered by
+// `recoverInternalFieldsForSystemRead` — the last describe block below.
 
 import { describe, it, expect, vi } from 'vitest';
-import { reattachInternalFieldsOnRead } from './internal-field-readback.js';
+import {
+  reattachInternalFieldsOnRead,
+  recoverInternalFieldsForSystemRead,
+} from './internal-field-readback.js';
 
 const resolver = (map: Record<string, Record<string, unknown>>) =>
   vi.fn(async (_object: string, ids: readonly string[], field: string) => {
@@ -144,9 +153,10 @@ describe('#7987 reattachInternalFieldsOnRead — sys_account OAuth columns', () 
     expect(rows[0].refresh_token).toBe('rt-1');
     expect(rows[0].id_token).toBe('it-1');
     expect(rows[1].refresh_token).toBe('rt-2');
-    // Three columns, two rows ⇒ THREE reads, not six. The accessor resolves one
-    // field per call by contract (#8118); the batching that matters is per-page.
-    expect(resolveInternalField).toHaveBeenCalledTimes(3);
+    // FOUR columns (#8676 added `password`), two rows ⇒ FOUR reads, not eight.
+    // The accessor resolves one field per call by contract (#8118); the
+    // batching that matters is per-page.
+    expect(resolveInternalField).toHaveBeenCalledTimes(4);
     expect(resolveInternalField).toHaveBeenCalledWith('sys_account', ['a1', 'a2'], 'access_token');
     expect(resolveInternalField).toHaveBeenCalledWith('sys_account', ['a1', 'a2'], 'refresh_token');
     expect(resolveInternalField).toHaveBeenCalledWith('sys_account', ['a1', 'a2'], 'id_token');
@@ -200,23 +210,41 @@ describe('#7987 reattachInternalFieldsOnRead — sys_account OAuth columns', () 
     await reattachInternalFieldsOnRead({ resolveInternalField }, 'sys_account', row);
     expect(row.refresh_token).toBe('already-here');
     expect(row.access_token).toBe('at-1');
-    expect(resolveInternalField).toHaveBeenCalledTimes(2);
+    // `access_token`, `id_token` and `password` were missing; `refresh_token`
+    // was not, so it costs no privileged read.
+    expect(resolveInternalField).toHaveBeenCalledTimes(3);
+    expect(resolveInternalField.mock.calls.map((c: any[]) => c[2])).not.toContain('refresh_token');
   });
 
-  it('⛔ never re-attaches `password` or `previous_password_hashes`', async () => {
-    // The card's explicit scope guard: those are one-way hashes (ADR-0100's
-    // third channel), they are not flagged `internal`, and the accessor would
-    // refuse them anyway. Pinned here so a future widening of the table has to
-    // walk past a red test.
-    const resolveInternalField = resolver({ a1: { password: 'HASH' } });
+  it('[#8676] re-attaches `password` — better-auth\'s sign-in verifier reads it off the row', async () => {
+    // `internalAdapter.findCredentialAccount(userId)` returns the row whose
+    // `password` the verifier compares the submitted one against. Under the
+    // #8676 flag that row arrives stripped, so without this entry password
+    // sign-in fails for every user.
+    const resolveInternalField = resolver({ a1: { password: 'argon2:stored' } });
     const row: any = ACCOUNT_ROW();
     await reattachInternalFieldsOnRead({ resolveInternalField }, 'sys_account', row);
-    expect('password' in row).toBe(false);
+    expect(row.password).toBe('argon2:stored');
+  });
+
+  it('⛔ [#8676] never re-attaches `previous_password_hashes` — better-auth has ZERO readers', async () => {
+    // The bound on the table, and the half of the old scope guard that
+    // SURVIVES #8676. The reuse ring is an ObjectStack-only column read solely
+    // by `auth-manager.ts` off the RAW engine, which never passes through this
+    // adapter seam — so a row here would be dead code, and re-attaching it
+    // would hand better-auth a credential column nothing asked for. Pinned so a
+    // future widening of the table has to walk past a red test.
+    const resolveInternalField = resolver({ a1: { previous_password_hashes: '["h1"]' } });
+    const row: any = ACCOUNT_ROW();
+    await reattachInternalFieldsOnRead({ resolveInternalField }, 'sys_account', row);
     expect('previous_password_hashes' in row).toBe(false);
     for (const call of resolveInternalField.mock.calls) {
-      expect(call[2]).not.toBe('password');
       expect(call[2]).not.toBe('previous_password_hashes');
     }
+    // Discriminating positive control: the refusal above is SELECTIVE, not a
+    // seam that simply attaches nothing — `password` on the same row, in the
+    // same call, was resolved.
+    expect(resolveInternalField.mock.calls.map((c: any[]) => c[2])).toContain('password');
   });
 
   it('an engine with NO accessor is left alone — absence is ordinary on these columns', async () => {
@@ -252,5 +280,87 @@ describe('#7987 reattachInternalFieldsOnRead — sys_account OAuth columns', () 
     };
     await expect(reattachInternalFieldsOnRead({}, 'sys_account', row)).resolves.toBeUndefined();
     expect(row.access_token).toBe('at');
+  });
+});
+
+describe('#8676 recoverInternalFieldsForSystemRead — plugin-auth\'s own RAW-engine reads', () => {
+  // The second seam. `reattachInternalFieldsOnRead` above is imported by
+  // exactly one file (`objectql-adapter.ts`), so it only ever repairs rows
+  // better-auth asked the adapter for. plugin-auth's ADR-0069 D1 reuse ring and
+  // the dev seed-admin probe call the engine directly and are starved by the
+  // same flag — this is what recovers them.
+
+  it('recovers the exact columns the ADR-0069 D1 reuse ring reads', async () => {
+    const resolveInternalField = resolver({
+      a1: { password: 'hash:current', previous_password_hashes: '["hash:old1"]' },
+    });
+    const row: any = { id: 'a1' }; // what the real engine returns for the :5033 query
+    await recoverInternalFieldsForSystemRead({ resolveInternalField }, 'sys_account', row, [
+      'password',
+      'previous_password_hashes',
+    ]);
+    expect(row.password).toBe('hash:current');
+    expect(row.previous_password_hashes).toBe('["hash:old1"]');
+    // One batched privileged read per COLUMN — the accessor's per-field contract.
+    expect(resolveInternalField).toHaveBeenCalledTimes(2);
+    expect(resolveInternalField).toHaveBeenCalledWith('sys_account', ['a1'], 'password');
+  });
+
+  it('is bounded by the caller\'s list — it does NOT recover every flagged column', async () => {
+    // `recordPasswordHistory` reads only the ring. Pulling `password` too would
+    // be an unasked-for dereference of a credential column.
+    const resolveInternalField = resolver({
+      a1: { password: 'hash:current', previous_password_hashes: '["h"]' },
+    });
+    const row: any = { id: 'a1' };
+    await recoverInternalFieldsForSystemRead({ resolveInternalField }, 'sys_account', row, [
+      'previous_password_hashes',
+    ]);
+    expect(row.previous_password_hashes).toBe('["h"]');
+    expect('password' in row).toBe(false);
+    expect(resolveInternalField).toHaveBeenCalledTimes(1);
+    // Discriminating positive control: the omission is the BOUND, not a dead
+    // seam — the column that WAS asked for came back on the same call.
+    expect(resolveInternalField.mock.calls[0]![2]).toBe('previous_password_hashes');
+  });
+
+  it('handles the ql.find shape (an array) — the dev seed-admin probe', async () => {
+    const resolveInternalField = resolver({ a1: { password: 'argon2:seed' } });
+    const rows: any[] = [{ id: 'a1', provider_id: 'credential' }];
+    await recoverInternalFieldsForSystemRead({ resolveInternalField }, 'sys_account', rows, [
+      'password',
+    ]);
+    expect(rows[0].password).toBe('argon2:seed');
+  });
+
+  it('stays INERT against an engine with no accessor — it never stripped anything', async () => {
+    // Required posture, not a default. `previous_password_hashes` is genuinely
+    // absent on a credential account that has never changed its password, so
+    // "the key is missing ⇒ the strip ran" is false for it; a seam that threw
+    // on absence would break the FIRST password change of every user, and every
+    // unit test built on a strip-less fake engine.
+    const row: any = { id: 'a1' };
+    await expect(
+      recoverInternalFieldsForSystemRead({}, 'sys_account', row, ['previous_password_hashes']),
+    ).resolves.toBeUndefined();
+    expect('previous_password_hashes' in row).toBe(false);
+  });
+
+  it('leaves a row that already carries the column untouched, issuing no privileged read', async () => {
+    const resolveInternalField = resolver({ a1: { password: 'FROM-ACCESSOR' } });
+    const row: any = { id: 'a1', password: 'already-here' };
+    await recoverInternalFieldsForSystemRead({ resolveInternalField }, 'sys_account', row, [
+      'password',
+    ]);
+    expect(row.password).toBe('already-here');
+    expect(resolveInternalField).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on a nullish row, so callers need no null check', async () => {
+    const resolveInternalField = resolver({});
+    await expect(
+      recoverInternalFieldsForSystemRead({ resolveInternalField }, 'sys_account', null, ['password']),
+    ).resolves.toBeUndefined();
+    expect(resolveInternalField).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/plugin-auth/src/internal-field-readback.ts
+++ b/packages/plugins/plugin-auth/src/internal-field-readback.ts
@@ -52,6 +52,23 @@
  * empty string. That is the risk #7987 was parked on, and the reason the
  * mechanism is a readback rather than a bare flag.
  *
+ * **`sys_account.password`** (#8676) — the credential hash. better-auth's
+ * sign-in verifier reads it off an adapter result row
+ * (`internalAdapter.findCredentialAccount(userId)`), so it belongs to this
+ * seam for the same reason the OAuth columns do.
+ *
+ * ## TWO seams, not one — this module owns both (#8676)
+ *
+ * The table above serves better-auth's storage adapter, which is the only
+ * importer of {@link reattachInternalFieldsOnRead}. plugin-auth also has
+ * readers of its own that reach the RAW engine and never pass through the
+ * adapter — the ADR-0069 D1 password-reuse ring and the dev seed-admin probe.
+ * The strip has no `isSystem` carve-out, so those are starved by a flag just
+ * the same, and the table cannot reach them.
+ * {@link recoverInternalFieldsForSystemRead} is their seam; its own doc carries
+ * the measurement and the reason a bare flag would have shipped a security
+ * control that reports success while doing nothing.
+ *
  * ## The shape (maintainer ruling 2026-08-13, Q2: compose)
  *
  * `Engine.resolveInternalField` — the purpose-built privileged batch accessor
@@ -145,14 +162,32 @@ interface ReadbackColumn {
  */
 const READBACK_FIELDS: Readonly<Record<string, readonly ReadbackColumn[]>> = {
   [SystemObjectName.SESSION]: [{ field: 'token', absenceProvesStrip: true }],
-  // [#7987] All three OAuth credential columns. `password` /
-  // `previous_password_hashes` are NOT here and must not be: they are
-  // better-auth one-way hashes (ADR-0100's third channel), they are not
-  // flagged `internal`, and the accessor refuses any field that is not.
+  // [#7987] All three OAuth credential columns, plus [#8676] `password`.
+  //
+  // `password` is here because better-auth's sign-in verifier reads it OFF an
+  // adapter result row: `internalAdapter.findCredentialAccount(userId)` returns
+  // the row whose `password` is then compared against the submitted one. Under
+  // the #8676 flag that row comes back without the column, so without this row
+  // password sign-in would fail for every user. `absenceProvesStrip: false`
+  // because `sys_account.password` is `required: false` and genuinely empty on
+  // OAuth-only accounts — see the field's own doc above for why that
+  // discriminator is not a detail.
+  //
+  // ⛔ `previous_password_hashes` is deliberately NOT here, and adding it would
+  // be dead code: better-auth has ZERO readers of that column. It is an
+  // ObjectStack-only column read solely by `auth-manager.ts`'s ADR-0069 D1
+  // reuse ring, which reaches the RAW engine and therefore never passes through
+  // this adapter seam at all — it is recovered by
+  // {@link recoverInternalFieldsForSystemRead} instead. A flagged column nobody
+  // reads back through the adapter must stay stripped here, which is the whole
+  // point of the bound. (`sys_api_key.key` is absent for the sibling reason:
+  // its mint route returns the plaintext it generated and never reads the
+  // stored hash back — #7728.)
   [SystemObjectName.ACCOUNT]: [
     { field: 'access_token', absenceProvesStrip: false },
     { field: 'refresh_token', absenceProvesStrip: false },
     { field: 'id_token', absenceProvesStrip: false },
+    { field: 'password', absenceProvesStrip: false },
   ],
 };
 
@@ -189,7 +224,80 @@ export async function reattachInternalFieldsOnRead(
 ): Promise<void> {
   const fields = READBACK_FIELDS[objectName];
   if (!fields) return;
+  await recoverColumns(engine, objectName, rows, fields, requestedFields);
+}
 
+/**
+ * [#8676] Recover flagged columns for one of plugin-auth's OWN raw-engine
+ * reads — the second seam, and the reason a bare flag was not enough.
+ *
+ * ## Why this exists beside {@link reattachInternalFieldsOnRead}
+ *
+ * That function is table-driven and lives on better-auth's storage-adapter
+ * path: it is imported by exactly one file (`objectql-adapter.ts`), so it can
+ * only repair rows that better-auth itself asked the adapter for. Several of
+ * plugin-auth's own readers bypass the adapter entirely and call
+ * `engine.findOne` / `ql.find` directly, and the engine's strip has **no
+ * `isSystem` carve-out** (#7728's design — measured: a `findOne` with
+ * `context: { isSystem: true }` AND an explicit projection naming the column
+ * still comes back without it). Those readers are starved by the flag and the
+ * adapter table cannot reach them.
+ *
+ * What that costs if it is skipped is not hypothetical. `assertPasswordNotReused`
+ * — the ADR-0069 D1 reuse-prevention control — builds its comparison list as
+ * `[currentHash, ...parseHashes(row.previous_password_hashes)].filter(Boolean)`.
+ * With both keys stripped that list is `[]`, the comparison loop never runs,
+ * `PASSWORD_REUSE` is never thrown, and the lookup's own `catch { return
+ * undefined }` means nothing announces it: a security control reporting success
+ * while doing nothing — the same shape #7823 fixed for `revoke-other-sessions`.
+ * Worse, the unit tests around it use fake engines that never apply the strip,
+ * so they stay GREEN while the control is dead.
+ *
+ * ## Posture: recover when the engine can, stay inert when it cannot
+ *
+ * Every column reached through here is treated as `absenceProvesStrip: false`,
+ * and that is a requirement rather than a default. `previous_password_hashes`
+ * is legitimately absent on a credential account that has never changed its
+ * password — the ordinary case for a brand-new account — so "the key is missing
+ * ⇒ the engine stripped it" is simply false for it, and a seam that threw on
+ * absence would break the FIRST password change of every user. `password` is
+ * `required: false` for the sibling reason (OAuth-only accounts carry none).
+ * An engine offering no `resolveInternalField` does not implement the `internal`
+ * channel at all — both halves ship together on the ObjectQL engine — so it
+ * cannot have stripped anything and there is nothing to recover.
+ *
+ * @param engine      The RAW data engine (privileged verb holder).
+ * @param objectName  Protocol object name of the rows just read.
+ * @param rows        The row or rows to repair, mutated in place. A nullish
+ *                    row is a no-op, so a caller may pass a `findOne` result
+ *                    straight through without a null check.
+ * @param fields      The flagged columns this caller actually reads. Keep it to
+ *                    what the caller consumes: each entry costs one id-batched
+ *                    driver read, and the accessor resolves ONE field per call.
+ */
+export async function recoverInternalFieldsForSystemRead(
+  engine: InternalFieldResolvingEngine,
+  objectName: string,
+  rows: unknown,
+  fields: readonly string[],
+): Promise<void> {
+  if (fields.length === 0) return;
+  await recoverColumns(
+    engine,
+    objectName,
+    rows,
+    fields.map((field) => ({ field, absenceProvesStrip: false })),
+  );
+}
+
+/** The shared recovery loop behind both seams above. */
+async function recoverColumns(
+  engine: InternalFieldResolvingEngine,
+  objectName: string,
+  rows: unknown,
+  fields: readonly ReadbackColumn[],
+  requestedFields?: readonly string[],
+): Promise<void> {
   const list = (Array.isArray(rows) ? rows : [rows]).filter(
     (r): r is Record<string, unknown> => Boolean(r) && typeof r === 'object',
   );

--- a/packages/qa/dogfood/test/account-oauth-tokens-not-serialized.dogfood.test.ts
+++ b/packages/qa/dogfood/test/account-oauth-tokens-not-serialized.dogfood.test.ts
@@ -1,8 +1,20 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * #7987 — `sys_account`'s three OAuth credential columns must not come back on
+ * #7987 (+ #8676) — `sys_account`'s credential columns must not come back on
  * the generic data path.
+ *
+ * [#8676] The file was #7987's three OAuth columns; it now covers the object's
+ * other two credential columns as well — `password` and
+ * `previous_password_hashes`, the one-way hashes of ADR-0100's third channel.
+ * They belong here rather than in a fixture of their own because they are the
+ * SAME object, the SAME read path, the SAME two failed barriers and the SAME
+ * two personas — so every persona arm below simply asserts one wider column
+ * set (`assertNoCredentialColumns`). What differs is the recovery: the OAuth
+ * columns are read back only by better-auth's adapter, while the password
+ * columns are also read by plugin-auth's own RAW-engine callers (the ADR-0069
+ * D1 reuse ring, the dev seed-admin probe), which the adapter seam cannot
+ * reach — see `recoverInternalFieldsForSystemRead`.
  *
  * `access_token`, `refresh_token` and `id_token` hold the user's LIVE bearer
  * credentials for someone else's service (Google, GitHub, an OIDC IdP), stored
@@ -75,6 +87,17 @@ const PLANTED = {
 
 const TOKEN_COLUMNS = ['access_token', 'refresh_token', 'id_token'] as const;
 
+/**
+ * [#8676] The two one-way password hashes on the same object — ADR-0100's third
+ * channel. They serialized on this very read path alongside the OAuth columns
+ * (the #8676 key list was captured on this fixture's own ablation run), through
+ * the same two barriers that miss them: `collectMaskedReadFields` keys on the
+ * field TYPE and exempts `managedBy: 'better-auth'`, while these are
+ * `text` / `textarea`. Asserted through the SAME persona matrix below, because
+ * the personas are identical — admin cross-user, and the member on their own row.
+ */
+const PASSWORD_HASH_COLUMNS = ['password', 'previous_password_hashes'] as const;
+
 describe('#7987: sys_account OAuth tokens never serialize on the generic data path', () => {
   let stack: VerifyStack;
   let ql: any;
@@ -96,11 +119,13 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     return map.get(memberAccountId);
   };
 
-  const assertNoTokenColumns = (record: Record<string, unknown>): void => {
+  const assertNoCredentialColumns = (record: Record<string, unknown>): void => {
     // OMIT, not mask: the key must be ABSENT. `toBeUndefined()` would also pass
     // on a masked value of `undefined`, which still ships a key whose presence
     // says "this user has a linked provider credential".
-    for (const column of TOKEN_COLUMNS) expect(Object.keys(record)).not.toContain(column);
+    const keys = Object.keys(record);
+    for (const column of TOKEN_COLUMNS) expect(keys).not.toContain(column);
+    for (const column of PASSWORD_HASH_COLUMNS) expect(keys).not.toContain(column);
   };
 
   beforeAll(async () => {
@@ -176,7 +201,7 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     const memberRow = rows.find((r: any) => String(r.id) === memberAccountId);
     expect(memberRow, "admin must still SEE the member's account row").toBeTruthy();
 
-    for (const row of rows) assertNoTokenColumns(row);
+    for (const row of rows) assertNoCredentialColumns(row);
 
     // Falsifiability: these are real, populated rows — not empty objects that
     // would satisfy any absence assertion.
@@ -190,7 +215,7 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     expect(res.status).toBe(200);
     const record = ((await res.json()) as any).record ?? {};
 
-    assertNoTokenColumns(record);
+    assertNoCredentialColumns(record);
 
     // The row is still readable and still identifies the link — admins keep the
     // account-management surface, they just stop receiving the credentials.
@@ -211,12 +236,12 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
 
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.every((r: any) => String(r.user_id) === memberUserId)).toBe(true);
-    for (const row of rows) assertNoTokenColumns(row);
+    for (const row of rows) assertNoCredentialColumns(row);
 
     const own = await stack.apiAs(memberToken, 'GET', `/data/sys_account/${memberAccountId}`);
     expect(own.status).toBe(200);
     const record = ((await own.json()) as any).record ?? {};
-    assertNoTokenColumns(record);
+    assertNoCredentialColumns(record);
     expect(record.id).toBe(memberAccountId);
   });
 
@@ -228,7 +253,7 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     // column out.
     const rows = await listAccountsAsAdmin('?select=id,access_token,refresh_token,id_token');
     expect(rows.length).toBeGreaterThan(0);
-    for (const row of rows) assertNoTokenColumns(row);
+    for (const row of rows) assertNoCredentialColumns(row);
     expect(rows.every((r: any) => typeof r.id === 'string')).toBe(true);
 
     const byId = await stack.apiAs(
@@ -238,7 +263,7 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     );
     expect(byId.status).toBe(200);
     const record = ((await byId.json()) as any).record ?? {};
-    assertNoTokenColumns(record);
+    assertNoCredentialColumns(record);
     expect(record.id).toBe(memberAccountId);
 
     // And the member cannot spell their way to their own refresh token either.
@@ -249,8 +274,24 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     );
     expect(memberSelect.status).toBe(200);
     for (const row of ((await memberSelect.json()) as any).records ?? []) {
-      assertNoTokenColumns(row);
+      assertNoCredentialColumns(row);
     }
+
+    // [#8676] The same spelling attack aimed at the password hashes, from both
+    // personas. The member's own row is the one that matters most here: the
+    // `sys_account_self` policy grants the read, so this is a LEGAL request for
+    // their own record that must still come back without the hash.
+    const hashSelect = '?select=id,password,previous_password_hashes';
+    const adminHashRows = await listAccountsAsAdmin(hashSelect);
+    expect(adminHashRows.length).toBeGreaterThan(0);
+    for (const row of adminHashRows) assertNoCredentialColumns(row);
+    expect(adminHashRows.every((r: any) => typeof r.id === 'string')).toBe(true);
+
+    const memberHash = await stack.apiAs(memberToken, 'GET', `/data/sys_account${hashSelect}`);
+    expect(memberHash.status).toBe(200);
+    const memberHashRows = ((await memberHash.json()) as any).records ?? [];
+    expect(memberHashRows.length).toBeGreaterThan(0);
+    for (const row of memberHashRows) assertNoCredentialColumns(row);
   });
 
   it('the system read path is stripped too — there is no `isSystem` carve-out', async () => {
@@ -263,7 +304,7 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
       context: { isSystem: true },
     });
     expect(rows.length).toBe(1);
-    assertNoTokenColumns(rows[0]);
+    assertNoCredentialColumns(rows[0]);
     expect(rows[0].id).toBe(memberAccountId);
   });
 
@@ -285,21 +326,62 @@ describe('#7987: sys_account OAuth tokens never serialize on the generic data pa
     expect(byToken.length).toBe(1);
     expect(String(byToken[0].id)).toBe(memberAccountId);
     // …while that same row comes back with no token columns on it.
-    assertNoTokenColumns(byToken[0]);
+    assertNoCredentialColumns(byToken[0]);
   });
 
-  it('⛔ the accessor refuses a column that is not flagged — `password` stays unreachable', async () => {
-    // The card's scope guard, held mechanically. `password` and
-    // `previous_password_hashes` are better-auth one-way hashes (ADR-0100's
-    // third channel) and are deliberately NOT `internal`; dereferencing one
-    // through this accessor would be a mask bypass rather than a read of the
-    // internal channel, so the engine refuses it (ADR-0112 code + status).
+  it('⛔ the accessor refuses a column that is not flagged — and the refusal is SELECTIVE', async () => {
+    // The guard this test has always asserted: `resolveInternalField` has
+    // exactly one predicate — `internal === true` — so a column without the
+    // flag is refused (ADR-0112 code + status).
+    //
+    // ⚠️ Its instance changed with #8676, and only its instance. This test used
+    // to spell the predicate with `password`, because #7987 deliberately left
+    // that column unflagged and the test marked THAT card's scope boundary
+    // ("a column that is **not flagged** … are deliberately NOT `internal`").
+    // #8676 flags it, so the premise of `password`-as-example disappears while
+    // the proposition itself is untouched: `scope` is an ordinary unflagged
+    // `sys_account` column and stands in as the example. What is NOT weakened
+    // is the guard — no ADR-0100 carve-out was added, and the positive arm
+    // below is what proves the refusal is selective rather than blanket.
     const err: any = await ql
-      .resolveInternalField('sys_account', [memberAccountId], 'password')
+      .resolveInternalField('sys_account', [memberAccountId], 'scope')
       .then(() => null, (e: any) => e);
     expect(err, 'resolveInternalField must refuse a non-internal column').toBeTruthy();
     expect(err.code).toBe('INVALID_FIELD');
     expect(err.status).toBe(400);
+
+    // The discriminating positive control, in the same test: a column that IS
+    // flagged resolves through the same accessor on the same row. Without this
+    // arm the refusal above is equally satisfied by an accessor that refuses
+    // everything — including one broken by a future edit.
+    const flagged = await ql.resolveInternalField('sys_account', [memberAccountId], 'refresh_token');
+    expect(flagged.get(memberAccountId)).toBe(PLANTED.refresh_token);
+  });
+
+  it('[#8676] `password` and `previous_password_hashes` are stripped, and reachable only through the accessor', async () => {
+    // The card's own assertions, both directions. These are one-way password
+    // hashes — ADR-0100's third channel — and they serialized on the generic
+    // data API before #8676: to an admin for every user's row, and to a member
+    // for their own.
+    const rows: any[] = await ql.find('sys_account', {
+      where: { id: memberAccountId },
+      context: { isSystem: true },
+    });
+    expect(rows.length).toBe(1);
+    expect('password' in rows[0]).toBe(false);
+    expect('previous_password_hashes' in rows[0]).toBe(false);
+    // Falsifiability: a real row, not an emptied one.
+    expect(String(rows[0].id)).toBe(memberAccountId);
+
+    // …and the value is still on disk, reachable through the privileged
+    // accessor — which is how the ADR-0069 D1 reuse ring and better-auth's
+    // sign-in verifier still read it. A change that deleted the column outright
+    // would satisfy every absence assertion above and fail here.
+    const stored = await ql.resolveInternalField('sys_account', [memberAccountId], 'password');
+    const hash = stored.get(memberAccountId);
+    expect(typeof hash).toBe('string');
+    expect(String(hash).length).toBeGreaterThan(8);
+    expect(String(hash)).not.toBe(MEMBER_PASSWORD); // stored hashed, not plaintext
   });
 
   it('sign-in still works — the account read path is on the authentication route', async () => {

--- a/packages/qa/dogfood/test/bearer-lane-password-change.dogfood.test.ts
+++ b/packages/qa/dogfood/test/bearer-lane-password-change.dogfood.test.ts
@@ -193,7 +193,17 @@ describe('#8049: /auth/change-password clears the force-change flag and enforces
         SYS,
       )
     )[0];
-    const raw = account?.previous_password_hashes;
+    // [#8676] `previous_password_hashes` is `internal: true`, so it is omitted
+    // from the row above — there is no `isSystem` carve-out on the strip. Read
+    // it through the engine's privileged accessor, which is the same channel
+    // the production reuse ring now uses. ⛔ Do NOT "fix" a `[]` here by
+    // un-flagging the column: an empty history is exactly what this file's
+    // `historyGrows` assertions exist to catch, so a silently-stripped read
+    // would turn this canary into a test that cannot fail.
+    const raw = account?.id
+      ? (await ql.resolveInternalField('sys_account', [String(account.id)], 'previous_password_hashes'))
+        .get(String(account.id))
+      : undefined;
     let history: string[] = [];
     if (typeof raw === 'string' && raw.trim()) {
       try {


### PR DESCRIPTION
Fixes #8676

Implements **option A** as adjudicated in comment `5297315744`. Verification union run at `5322ccc` (tree clean).

## What the card is

`sys_account.password` (the credential hash) and `previous_password_hashes` (the ADR-0069 D1 reuse ring) serialized on `/api/v1/data/sys_account` — to an **admin for every user's row**, and to a **member for their own** via the `sys_account_self` RLS policy. Both credential collectors miss them: `collectMaskedReadFields` keys on the field **TYPE** and additionally exempts `managedBy: 'better-auth'` objects, while these are `text` / `textarea`.

The card's provenance caveat said the personas were *inherited from #7987's measurement, not independently confirmed*. **They are confirmed now** — see the ablation below, which reproduces the disclosure on a real booted stack.

## The change

| | |
|---|---|
| `sys-account.object.ts` | both columns declared `internal: true` |
| `internal-field-readback.ts` | `password` added to the per-object readback table (better-auth's adapter readers) |
| `internal-field-readback.ts` | **new** `recoverInternalFieldsForSystemRead` — the second seam |
| `auth-manager.ts` | `assertPasswordNotReused` + `recordPasswordHistory` converted to it |
| `auth-plugin.ts` | dev seed-admin probe converted to it |

The second seam is the half a bare flag would have missed. The readback table is imported by exactly one file (`objectql-adapter.ts`), so it cannot reach a caller that reads the engine directly — and the strip has **no `isSystem` carve-out** by #7728's design.

`previous_password_hashes` is deliberately **not** in the readback table: better-auth has zero readers of it, so a row there would be dead code. It is the harder half, not the easier one.

## Zone 2 measurements — all four, none forced

**1. The silent no-op REPRODUCES.** Against a real ObjectQL engine + stub driver, issuing the exact query from `assertPasswordNotReused`:

```
[8676] M1 system findOne w/ explicit projection -> {"id":"a1"}
[8676] M1 compareList -> [] | currentHash -> ""
```

Both columns gone despite `context: { isSystem: true }` **and** an explicit projection naming them. `compareList` empties ⇒ the loop never runs ⇒ `PASSWORD_REUSE` never throws, and `catch { return undefined }` means nothing announces it. The ruling's load-bearing reason holds. No STOP.

**2. The ADR-0100 guard needed NO change, and was not weakened.** `resolveInternalField`'s only predicate is `collectInternalReadFields(schema).includes(field)`, i.e. `internal === true` — no type inspection. The ADR-0100 sentence is prose in the refusal message, not a second predicate. Measured, with a discriminating control on the same object:

```
[8676] M2 resolveInternalField password -> [["a1","hash:current"]]
[8676] M2 resolveInternalField history  -> [["a1","[\"hash:old1\",\"hash:old2\"]"]]
[8676] M3 refusal (NON-flagged column)  -> INVALID_FIELD 400
[8676] M4 where-filter on flagged column matched rows -> 1
```

No general mask-bypass; the refusal stays selective. **No STOP condition was hit.**

**3. Fail-closed posture** — every column here is `absenceProvesStrip: false`-shaped, and that is a requirement rather than a default: `previous_password_hashes` is genuinely absent on a credential account that has never changed its password, so a seam throwing on absence would break the *first* password change of every user.

**4. The pinned fixture — I agree it is a scope guard, not policy.** Three independent signals: the title states the general proposition ("a column that is **not flagged**") and names `password` only as its example; the comment derives the refusal *from* the flag state ("are deliberately NOT `internal`"); and the file's subject is #7987's scope boundary. Policy would have read "`password` must never be dereferenceable, whatever its flag" — it says the opposite. So the proposition is **preserved, not deleted**: the test now spells it with `scope` (a genuinely unflagged column) and gains a positive control proving the accessor still resolves a flagged one.

## Ablation — the assertions are not vacuous

`packages/qa/dogfood` resolves from built `dist/`, so: flags removed, `platform-objects` rebuilt, mutation proven to reach the artifact (`ablation-dist-preflight … --absent` ⇒ *"marker absent from all 66 built files"*), suite run, then restored, rebuilt, and re-proven present in 4 built files.

**13 tests went red**, reproducing the card's premise directly:

```
AssertionError: expected [ 'id', 'created_at', …(10) ] to not include 'password'
AssertionError: expected [ 'id', 'password', …(1) ] to not include 'password'   ← ?select= arm
```

— on the admin cross-user arm, the member self arm, the `?select=` arm and the system read path.

⚠️ Stated precisely: the three `bearer-lane` reds are its helper's accessor call being refused for a now-unflagged column — real evidence that the helper reads through the accessor, but **not** evidence about the reuse control itself. That evidence is the unit canary below.

## The canary the old suite could not be

Every pre-existing ADR-0069 D1 test uses a fake engine that never strips, so all of them stay green while the control dies. A new block models the strip explicitly, and carries its own falsification arm:

- reuse of the current / historical password still rejected, with the returned row asserted stripped **at return time** (the seam repairs in place, so reading it back afterwards could never witness the strip);
- the ring still grows, and `password` is *not* dereferenced on the path that never reads it;
- `⛔ the recovery is LOAD-BEARING: drop the accessor and the control provably dies` — pins the pre-fix silent no-op, so the four tests above can never pass vacuously.

## Verification (`5322ccc`, tree clean)

- **Unit / consumers, all green:** plugin-auth 1250, platform-objects 409, rest 1948, runtime 2452, plugin-security 1235, plugin-sharing 599, metadata 603, plugin-audit 239, verify 28, objectql 3679. Consumer direction is **downstream** (`--filter '...@objectstack/pkg'`), derived from the 24 packages that actually declare either edited package.
- **Dogfood:** 2 files / 21 tests green on a real booted stack.
- **Gates re-derived from actual changed paths** via `scripts/pm/dispatch-gates.mjs`, then run: `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:engine-double-contract`, `check:query-options-erasure`, `check:i18n`, `check:changeset`, `check:type-check-coverage`, `check:type-check-debt`, ESLint (`--no-inline-config`, as CI invokes it). All exit 0.
- **TEST_DEBT measured directly, not assumed.** `plugin-auth` hides `**/*.test.ts` from tsc, so its green `typecheck` carries zero information about my test edits — measured with a temp tsconfig that includes them: my added block (`auth-manager.test.ts` 3315-3401) and `internal-field-readback.test.ts` are **type-clean**; the ratchet reports *"none above its recorded number"*.
- **`check:i18n` reports `platform-objects` in sync** — `internal: true` regenerates no translation bundles, so the i18n-collision concern this card was once held on does not apply to it at all.

## Notes for the reviewer

- ⛔ **Draft, and auto-merge deliberately NOT armed** — the maintainer veto window on the fixture change is still open and unanswered.
- No ADR touched; no engine carve-out added; `packages/spec` untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_