### PR TITLE
fix(metadata-protocol): fold diffMetaItem's type at the boundary and stop serving a history outage as an empty diff

### DIFF
--- a/.changeset/diff-meta-item-canonical-type-and-history-outage.md
+++ b/.changeset/diff-meta-item-canonical-type-and-history-outage.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `diffMetaItem` folds its type at the request boundary and stops serving a history outage as an empty diff (#8868, #8833)
+
+`GET /api/v1/meta/:type/:name/diff` is a routed live endpoint with a
+caller-supplied `:type`. Two independent defects in that one method, fixed
+together because they land in the same function.
+
+**#8868 — the canonical fold.** `diffMetaItem` was the NINTH `/meta` entry point
+on this URL family and the last one still deriving its type key from
+`PLURAL_TO_SINGULAR`, the manifest-COLLECTION map that #7894 moved this boundary
+off (#8769 routed `publishMetaItem`, #8819 routed `rollbackMetaItem`). It now
+routes through `canonicalizeMetaRequestType`, which changes three things:
+
+- **the answer.** For the four MANIFEST-ABSENT types — `field`, `seed`,
+  `external_catalog`, `translation`, legitimately absent from that map because
+  they are not stack collections — a plural spelling stayed plural all the way
+  into the `sys_metadata_history` query, matched no row, and the endpoint
+  answered a well-formed **empty diff** (`added: []`, `removed: []`,
+  `changed: []`) for an item that does have history. Not a refusal and not an
+  error: a silent "nothing changed". Manifest-present types (`views` → `view`)
+  folded already and were never affected.
+- **unrecognised spellings.** The #7894 boundary refusal never ran on this verb,
+  so a spelling like `viewes` was forwarded to the plugin path instead of
+  refused. It is now `400 INVALID_REQUEST`, naming both accepted spellings. The
+  refusal stays narrow by construction: a name that reaches for no declared type
+  (a possible plugin kind) is still served.
+- **the echoed `type`.** The response echoed the caller's spelling back while the
+  read had used a different key. It now reports the canonical spelling — the
+  precedent `saveMetaItem` and `deleteMetaItem` already set, both of which
+  `return { type: request.type }` after their own fold.
+
+**#8833 — the swallowed outage.** The history read sat in a `try` whose `catch`
+was empty apart from a comment. `histRows` stayed `[]` and the code below read
+that never-filled accumulator as a real answer, so a `sys_metadata_history`
+outage was served as a successful 200 with an empty diff — byte-identical to
+"these two versions are the same", with no log line either. An operator
+comparing versions before a rollback, and any SDK or agent reading this
+endpoint, acted on "unchanged" with full confidence.
+
+Per the maintainer ruling on #8833, the `catch` now routes through the
+platform's existing discrimination, `rethrowUnlessMetadataStoreUnprovisioned`:
+
+- a **genuinely absent table** — a minimal deployment that never provisioned
+  history — keeps its benign empty answer, so first boot does not explode;
+- **every other read failure** (connection drop, timeout, permission denial,
+  query error) propagates `503 SERVICE_UNAVAILABLE`, carrying the driver error
+  as `cause`. ADR-0110 D3: a miss and an outage are different facts. This is the
+  same guard #5532 restored for `getMetaItems`.
+
+⚠️ **Behaviour change worth reading before upgrading.** This ADDS loudness where
+there was none. PR #8841 had removed the last path that threw here, so as of
+that change the outage was silent for *every* type; a diff whose history store
+is unreachable now returns 503 where it previously returned 200 with an empty
+diff. A diff against a deployment that never provisioned `sys_metadata_history`
+is unaffected. No response field was added — a `historyUnavailable` key was
+considered and declined.

--- a/packages/metadata-protocol/src/protocol.diff-canonical-type-and-history-outage.test.ts
+++ b/packages/metadata-protocol/src/protocol.diff-canonical-type-and-history-outage.test.ts
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Two independent defects in one method, pinned in one file because they land in
+ * one function and were fixed in one PR — `diffMetaItem`.
+ *
+ * ## #8868 — the canonical fold
+ *
+ * `diffMetaItem` is the NINTH `/meta` entry point on this URL family and was the
+ * last one deriving its type key from `PLURAL_TO_SINGULAR` (the MANIFEST-
+ * COLLECTION map) instead of `canonicalizeMetaRequestType` (the #7894 request
+ * boundary). #8769 routed `publishMetaItem`, #8819 routed `rollbackMetaItem`.
+ *
+ * ## #8833 — the swallowed outage
+ *
+ * The history read's `catch` was empty and fell through, leaving `histRows` at
+ * `[]`; the code below read that never-filled accumulator as a real answer, so a
+ * `sys_metadata_history` outage was served as a well-formed 200 empty diff.
+ * Maintainer ruling (2026-08-15, #8833 comment 5302933802): route it through the
+ * platform's existing discrimination — genuinely-absent table stays benign,
+ * every other read failure propagates the 503 (ADR-0110 D3).
+ *
+ * ## ⛔ Why the fixture is `field`/`fields` and not `view`/`views`
+ *
+ * This is the anti-vacuity property of the whole file, and it is the lesson
+ * #8867 paid for: a cross-package pin there spelled its fixture so that the
+ * folded and unfolded spellings AGREED, which made the test structurally
+ * incapable of failing on the hazard it named.
+ *
+ * `views` IS in the manifest map, so it folded to `view` before this fix and
+ * after it — a pin using it proves nothing about the fold. The four
+ * MANIFEST-ABSENT types (`field`, `seed`, `external_catalog`, `translation`) are
+ * legitimately absent from that map because they are not stack collections, so
+ * `fields` stayed plural all the way into the history `where` and matched no
+ * row. `manifestMapStillDoesNotFoldTheFixture` below asserts that asymmetry
+ * directly: if `fields` ever enters `PLURAL_TO_SINGULAR`, every fold assertion
+ * here silently stops discriminating while staying green. That test going red is
+ * the signal to re-pick the fixture, not to delete the assertion.
+ */
+import { describe, expect, it } from 'vitest';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, hashSpec } from '@objectstack/metadata-core';
+import { PLURAL_TO_SINGULAR } from '@objectstack/spec/shared';
+import { ObjectStackProtocolImplementation } from './index.js';
+
+/** Manifest-ABSENT: `fields` is NOT in `PLURAL_TO_SINGULAR`. The subject. */
+const ABSENT_TYPE = 'field';
+const ABSENT_PLURAL = 'fields';
+/** Manifest-PRESENT: `views` folded through the old map too. The control. */
+const PRESENT_TYPE = 'view';
+const PRESENT_PLURAL = 'views';
+/**
+ * An unrecognised spelling whose singular IS a declared type — the one class
+ * `metaUrlSpellingRefusal` refuses. Measured against the real contract rather
+ * than guessed: `metaUrlSpellingRefusal('viewes')` returns
+ * `{ declared: 'view', hint: 'views' }`.
+ */
+const REFUSED_SPELLING = 'viewes';
+/**
+ * NOT a plural of anything declared, so it is indistinguishable from a
+ * plugin-registered runtime kind and MUST NOT be refused here. The positive
+ * control that keeps the refusal narrow instead of blanket.
+ */
+const PLUGIN_SHAPED_SPELLING = 'fieldz';
+
+/** Reads like a genuine outage to `isMissingTableError`: not benign. */
+const OUTAGE_ERROR = () => new Error('connection terminated unexpectedly');
+/**
+ * The ONE benign reason — the table was never provisioned (minimal deployment).
+ * SQLite/libsql phrasing, which `MISSING_TABLE.message` matches.
+ */
+const MISSING_TABLE_ERROR = () => new Error('no such table: sys_metadata_history');
+
+/**
+ * Scalar equality only, and it REFUSES a combinator rather than guessing —
+ * `check:where-matcher` shape (b): treating `$or` as a column name silently
+ * excludes rows and greens the suite against a query nobody wrote.
+ */
+function matches(r: Record<string, unknown>, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (k.startsWith('$')) {
+            throw new Error(
+                `stub engine: WHERE combinator '${k}' is not implemented by this double — `
+                + 'it matches scalar equality only. Implement it here rather than letting it '
+                + 'be read as a field name.',
+            );
+        }
+        if (v === undefined) continue;
+        if (r[k] !== v) return false;
+    }
+    return true;
+}
+
+/**
+ * Records the `type` every history read was issued under — the fold is a claim
+ * about the KEY the query used, and a value-only assertion cannot see it.
+ */
+function makeStubEngine(opts: { historyError?: () => Error } = {}) {
+    const tables: Record<string, Array<Record<string, unknown>>> = {
+        sys_metadata: [],
+        sys_metadata_history: [],
+    };
+    const historyTypeKeys: unknown[] = [];
+    const engine: any = {
+        async find(table: string, o: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                historyTypeKeys.push(o.where.type);
+                if (opts.historyError) throw opts.historyError();
+            }
+            return (tables[table] ?? []).filter((r) => matches(r, o.where));
+        },
+        async findOne(table: string, o: { where: Record<string, unknown> }) {
+            return (tables[table] ?? []).find((r) => matches(r, o.where)) ?? null;
+        },
+        async insert() { return { id: 'stub' }; },
+        async update(_t: string, data: Record<string, unknown>, o: { where: Record<string, unknown> }) {
+            assertEngineUpdateDispatch(data, o);
+            return { id: null };
+        },
+        async delete(_t: string, o?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(o);
+            return { deleted: 0 };
+        },
+        async transaction<T>(cb: (ctx: any, info: { owned: boolean }) => Promise<T>): Promise<T> {
+            return cb(undefined, { owned: true });
+        },
+        async syncObjectSchema() { /* no DDL in this stub */ },
+        registry: {
+            listItems: () => [],
+            isPackageDisabled: () => false,
+            getItem: () => undefined,
+            registerItem: () => {},
+            registerObject: () => {},
+            getPackage: () => undefined,
+        },
+    };
+    return { engine, tables, historyTypeKeys };
+}
+
+/** Two versions differing in exactly one top-level key, so the diff is unambiguous. */
+function seedTwoVersions(
+    tables: Record<string, Array<Record<string, unknown>>>,
+    type: string,
+    name: string,
+) {
+    const base = { organization_id: null, type, name };
+    [{ name, label: 'A' }, { name, label: 'B' }].forEach((body, i) => {
+        tables.sys_metadata_history!.push({
+            ...base,
+            id: `h_${i + 1}`,
+            version: i + 1,
+            event_seq: i + 1,
+            operation_type: i === 0 ? 'create' : 'update',
+            metadata: JSON.stringify(body),
+            checksum: hashSpec(body),
+            recorded_at: new Date(i + 1).toISOString(),
+        });
+    });
+}
+
+/** The real diff of the seeded pair — an EMPTY diff is the defect's signature. */
+const REAL_DIFF_BODY = {
+    added: [],
+    removed: [],
+    changed: [{ path: 'label', from: 'A', to: 'B' }],
+};
+
+describe('#8868 — diffMetaItem folds its type at the request boundary', () => {
+    it('manifestMapStillDoesNotFoldTheFixture: the anti-vacuity arm', () => {
+        // ⛔ Not decoration. This is the property that makes every assertion
+        // below capable of failing: the manifest map must NOT already fold
+        // `fields`, or folded and raw agree and the pins go vacuous — exactly
+        // the shape #8867 shipped. The `views` half is the contrast that proves
+        // the map is real and populated rather than empty in this environment.
+        expect(PLURAL_TO_SINGULAR[ABSENT_PLURAL]).toBeUndefined();
+        expect(PLURAL_TO_SINGULAR[PRESENT_PLURAL]).toBe(PRESENT_TYPE);
+    });
+
+    it('THE PIN: a plural of a manifest-ABSENT type answers the same diff as the canonical spelling', async () => {
+        // Before the fix the plural reached `sys_metadata_history` unfolded,
+        // matched no row, and this returned `{ added: [], removed: [], changed: [] }`
+        // for an item that plainly has history.
+        const canonical = makeStubEngine();
+        seedTwoVersions(canonical.tables, ABSENT_TYPE, 'my_field');
+        const plural = makeStubEngine();
+        seedTwoVersions(plural.tables, ABSENT_TYPE, 'my_field');
+
+        const viaCanonical: any = await new ObjectStackProtocolImplementation(canonical.engine)
+            .diffMetaItem({ type: ABSENT_TYPE, name: 'my_field', fromVersion: 1, toVersion: 2 });
+        const viaPlural: any = await new ObjectStackProtocolImplementation(plural.engine)
+            .diffMetaItem({ type: ABSENT_PLURAL, name: 'my_field', fromVersion: 1, toVersion: 2 });
+
+        // The real diff, not an empty one — stated positively so a future
+        // regression to `[]` cannot pass by both sides being equally empty.
+        expect(viaCanonical).toMatchObject(REAL_DIFF_BODY);
+        expect(viaPlural).toMatchObject(REAL_DIFF_BODY);
+        expect(viaPlural).toEqual(viaCanonical);
+        // The KEY the read actually used, which is the fold's real subject.
+        expect(plural.historyTypeKeys).toEqual([ABSENT_TYPE]);
+    });
+
+    it('the echoed `type` reports the CANONICAL spelling, not the caller`s', async () => {
+        // The card's one genuine sub-question. Answered by the precedent the
+        // family already set rather than minted here: `saveMetaItem` and
+        // `deleteMetaItem` both `return { type: request.type }` AFTER their
+        // fold, so the echo names the spelling the read used.
+        const { engine, tables } = makeStubEngine();
+        seedTwoVersions(tables, ABSENT_TYPE, 'my_field');
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await protocol.diffMetaItem({
+            type: ABSENT_PLURAL,
+            name: 'my_field',
+            fromVersion: 1,
+            toVersion: 2,
+        });
+
+        expect(res.type).toBe(ABSENT_TYPE);
+    });
+
+    it('a manifest-PRESENT type already agreed on the DIFF BODY — so the fixture choice is doing the work', async () => {
+        // THE CONTROL, and the two halves are asserted separately on purpose.
+        //
+        // Measured under ablation (fold removed, this file re-run) rather than
+        // assumed, because the naive whole-object `toEqual` blurred them:
+        //
+        //   • the BODY half is genuinely unchanged by this fix — `views` was
+        //     already in the manifest map, so both spellings resolved the real
+        //     diff before it. That is exactly why `fields` and not `views` is
+        //     the subject of the pin above, which fails on its body
+        //     (`changed: []`) the moment the fold is removed.
+        //   • the ECHO half DOES move for this type too (ablated, it answers
+        //     `type: 'views'`), because the echo was never fed by the manifest
+        //     map — it read `request.type` raw. So the fold fixes the echo for
+        //     every plural spelling, while it fixes the body only for the four
+        //     manifest-absent types.
+        //
+        // Collapsing these into one equality would report "the control also
+        // went red" without saying which half moved, which is the opposite of
+        // what a control is for.
+        const canonical = makeStubEngine();
+        seedTwoVersions(canonical.tables, PRESENT_TYPE, 'grid');
+        const plural = makeStubEngine();
+        seedTwoVersions(plural.tables, PRESENT_TYPE, 'grid');
+
+        const viaCanonical: any = await new ObjectStackProtocolImplementation(canonical.engine)
+            .diffMetaItem({ type: PRESENT_TYPE, name: 'grid', fromVersion: 1, toVersion: 2 });
+        const viaPlural: any = await new ObjectStackProtocolImplementation(plural.engine)
+            .diffMetaItem({ type: PRESENT_PLURAL, name: 'grid', fromVersion: 1, toVersion: 2 });
+
+        // Body: true before AND after the fix — the control's actual claim.
+        expect(viaCanonical).toMatchObject(REAL_DIFF_BODY);
+        expect(viaPlural).toMatchObject(REAL_DIFF_BODY);
+        // Echo: canonical for this type too, same as the manifest-absent one.
+        expect(viaCanonical.type).toBe(PRESENT_TYPE);
+        expect(viaPlural.type).toBe(PRESENT_TYPE);
+    });
+
+    it('refuses an unrecognised spelling of a DECLARED type with the 400 envelope', async () => {
+        const { engine, tables } = makeStubEngine();
+        seedTwoVersions(tables, PRESENT_TYPE, 'grid');
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        // ADR-0112 — assert the ENVELOPE (code AND status), not merely that
+        // something threw: a bare `Error` from anywhere below would satisfy
+        // `.rejects.toThrow()` while proving nothing about the refusal.
+        const err: any = await protocol
+            .diffMetaItem({ type: REFUSED_SPELLING, name: 'grid', fromVersion: 1, toVersion: 2 })
+            .then(() => null, (e: unknown) => e);
+
+        expect(err).toBeInstanceOf(Error);
+        expect(err.code).toBe('INVALID_REQUEST');
+        expect(err.status).toBe(400);
+        expect(err.message).toContain(REFUSED_SPELLING);
+        expect(err.message).toContain(PRESENT_TYPE);
+    });
+
+    it('does NOT refuse a spelling that reaches for no declared type — the refusal stays narrow', async () => {
+        // A plugin-registered runtime kind must never be refused by a static
+        // rule. `fieldz` is not a plural of anything declared, so the boundary
+        // is silent and the request is served (with no rows, truthfully).
+        const { engine } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await protocol.diffMetaItem({
+            type: PLUGIN_SHAPED_SPELLING,
+            name: 'x',
+            fromVersion: 1,
+            toVersion: 2,
+        });
+
+        expect(res.type).toBe(PLUGIN_SHAPED_SPELLING);
+        expect(res.changed).toEqual([]);
+    });
+});
+
+describe('#8833 — a history-store outage stops masquerading as an empty diff', () => {
+    it('THE PIN: a non-benign read failure propagates the 503 envelope', async () => {
+        const { engine, tables } = makeStubEngine({ historyError: OUTAGE_ERROR });
+        seedTwoVersions(tables, PRESENT_TYPE, 'grid');
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const err: any = await protocol
+            .diffMetaItem({ type: PRESENT_TYPE, name: 'grid', fromVersion: 1, toVersion: 2 })
+            .then(() => null, (e: unknown) => e);
+
+        // ADR-0112 envelope — code AND status. `.toThrow()` alone would stay
+        // green on a driver that threw a bare `Error`, i.e. on the very shape
+        // this card is about.
+        expect(err).toBeInstanceOf(Error);
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.status).toBe(503);
+        // The driver error rides as `cause` rather than being interpolated.
+        expect(err.cause).toBeInstanceOf(Error);
+        expect((err.cause as Error).message).toContain('connection terminated');
+    });
+
+    it('THE CONTROL: a genuinely-absent table still answers benignly', async () => {
+        // Without this arm the pin above cannot show the discrimination is
+        // SELECTIVE rather than a blanket "any failure 503s" — which would
+        // break first boot on a minimal deployment that never provisioned
+        // `sys_metadata_history`.
+        const { engine } = makeStubEngine({ historyError: MISSING_TABLE_ERROR });
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await protocol.diffMetaItem({
+            type: PRESENT_TYPE,
+            name: 'grid',
+            fromVersion: 1,
+            toVersion: 2,
+        });
+
+        expect(res.added).toEqual([]);
+        expect(res.removed).toEqual([]);
+        expect(res.changed).toEqual([]);
+        expect(res.type).toBe(PRESENT_TYPE);
+    });
+
+    it('the 503 does not depend on the type — gated-shut types propagate identically', async () => {
+        // Preserves #8798's subject under the new contract: one outage, ONE
+        // answer, not an answer decided by an authorization gate that has
+        // nothing to do with reading history.
+        const { engine, tables } = makeStubEngine({ historyError: OUTAGE_ERROR });
+        seedTwoVersions(tables, ABSENT_TYPE, 'my_field');
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const err: any = await protocol
+            .diffMetaItem({ type: ABSENT_TYPE, name: 'my_field', fromVersion: 1, toVersion: 2 })
+            .then(() => null, (e: unknown) => e);
+
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.status).toBe(503);
+    });
+});

--- a/packages/metadata-protocol/src/protocol.diff-dead-history-read.test.ts
+++ b/packages/metadata-protocol/src/protocol.diff-dead-history-read.test.ts
@@ -234,41 +234,50 @@ describe('#8798 — a history-table outage now answers the same way for every ty
      * by whether the type happened to pass an authorization gate that has
      * nothing to do with reading history.
      *
-     * These pins do not endorse swallowing the outage — that `catch` predates
-     * this card and is filed as #8833. They pin that the answer no longer
-     * depends on the type.
+     * ## [#8833] What these two pins assert now, and why they changed
+     *
+     * They used to assert that BOTH types fall through to an EMPTY DIFF, with a
+     * note saying they did not endorse swallowing the outage because that was
+     * #8833's question. #8833 has since been ruled (maintainer, 2026-08-15,
+     * comment 5302933802): the swallow was the defect, and a non-benign read
+     * failure now propagates a 503 through
+     * `rethrowUnlessMetadataStoreUnprovisioned`.
+     *
+     * So the ASSERTED VALUE moved while this describe block's SUBJECT did not.
+     * The subject was never "an outage is empty" — it is "one outage, one
+     * answer, not an answer decided by the type", and that is what both arms
+     * still pin. `makeStubEngine`'s `throwOnHistory` throws a generic
+     * `Error('history table unavailable (simulated outage)')`, which
+     * `isMissingTableError` does NOT classify as benign, so it is a genuine
+     * outage under the new rule. The benign case (a table that was never
+     * provisioned) has its own positive control next door, in
+     * `protocol.diff-canonical-type-and-history-outage.test.ts`.
      */
-    it('gated-open type falls through to an empty diff instead of throwing', async () => {
+    it('gated-open type propagates the outage as a 503 instead of an empty diff', async () => {
         const { engine, tables } = makeStubEngine({ throwOnHistory: true });
         seedTwoVersions(tables, ORDINARY_TYPE, 'grid');
         const protocol = new ObjectStackProtocolImplementation(engine);
 
-        const res: any = await protocol.diffMetaItem({
-            type: ORDINARY_TYPE,
-            name: 'grid',
-            fromVersion: 1,
-            toVersion: 2,
-        });
+        const err: any = await protocol
+            .diffMetaItem({ type: ORDINARY_TYPE, name: 'grid', fromVersion: 1, toVersion: 2 })
+            .then(() => null, (e: unknown) => e);
 
-        expect(res.added).toEqual([]);
-        expect(res.removed).toEqual([]);
-        expect(res.changed).toEqual([]);
+        expect(err).toBeInstanceOf(Error);
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.status).toBe(503);
     });
 
-    it('gated-shut type answers identically — unchanged by #8798', async () => {
+    it('gated-shut type answers identically — the answer still does not depend on the type', async () => {
         const { engine, tables } = makeStubEngine({ throwOnHistory: true });
         seedTwoVersions(tables, EARLY_RETURN_TYPE, 'my_field');
         const protocol = new ObjectStackProtocolImplementation(engine);
 
-        const res: any = await protocol.diffMetaItem({
-            type: EARLY_RETURN_TYPE,
-            name: 'my_field',
-            fromVersion: 1,
-            toVersion: 2,
-        });
+        const err: any = await protocol
+            .diffMetaItem({ type: EARLY_RETURN_TYPE, name: 'my_field', fromVersion: 1, toVersion: 2 })
+            .then(() => null, (e: unknown) => e);
 
-        expect(res.added).toEqual([]);
-        expect(res.removed).toEqual([]);
-        expect(res.changed).toEqual([]);
+        expect(err).toBeInstanceOf(Error);
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.status).toBe(503);
     });
 });

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -15907,6 +15907,24 @@ export class ObjectStackProtocolImplementation implements
      * is used. Returns `{ added, removed, changed }` keyed by JSON
      * pointer-style paths for primitive leaves; nested objects/arrays
      * are reported as a single change record.
+     *
+     * The `type` is folded to its canonical spelling at the boundary
+     * ({@link canonicalizeMetaRequestType}), so the echoed `type` reports the
+     * spelling the history read actually used, not the caller's.
+     *
+     * @throws `INVALID_REQUEST` — 400, when `type` is an unrecognised spelling
+     *         of a type the platform DECLARES (`viewes`). Narrow by
+     *         construction: a name that reaches for no declared type is a
+     *         possible plugin kind and is served, not refused (#7894).
+     * @throws {@link metadataStoreUnavailableError} — 503 /
+     *         `SERVICE_UNAVAILABLE` (#8833), when the `sys_metadata_history`
+     *         read failed for any reason other than the table not being
+     *         provisioned yet, carrying the driver error on `cause`. The one
+     *         non-throwing failure is that unprovisioned table, where "no
+     *         history rows" is the truth rather than an unknown, so a minimal
+     *         deployment still gets its benign empty diff. Without that
+     *         asymmetry an outage would be indistinguishable from "these two
+     *         versions are identical" (ADR-0110 D3).
      */
     async diffMetaItem(request: {
         type: string;

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -15923,7 +15923,44 @@ export class ObjectStackProtocolImplementation implements
         removed: Array<{ path: string; value: unknown }>;
         changed: Array<{ path: string; from: unknown; to: unknown }>;
     }> {
-        const singularType = PLURAL_TO_SINGULAR[request.type] ?? request.type;
+        // [#8868] #4432 / #7894 — CANONICAL TYPE KEY. See {@link canonicalMetaType}.
+        // `diffMetaItem` is the NINTH `/meta` entry point on this URL family
+        // (`GET /api/v1/meta/:type/:name/diff`, caller-supplied `:type`, registered
+        // at `rest-route-ledger.ts:184`) and was the last one still deriving its type
+        // key from `PLURAL_TO_SINGULAR` — the MANIFEST-COLLECTION map #7894 moved this
+        // boundary off. The same one-line replacement #8769 (`publishMetaItem`) and
+        // #8819 (`rollbackMetaItem`) made, for the same reason.
+        //
+        // What the fold reaches here, measured rather than assumed:
+        //
+        //  • the history read below, which queries `sys_metadata_history` by `type`.
+        //    For the four MANIFEST-ABSENT types (`field`, `seed`, `external_catalog`,
+        //    `translation` — legitimately absent from the manifest map because they
+        //    are not stack collections) a plural stayed plural all the way into that
+        //    `where`, matched no row, and this function answered a well-formed EMPTY
+        //    diff for an item that DOES have history. Not a refusal and not an error:
+        //    a silent "nothing changed" on a routed live endpoint, which is why this
+        //    is a wrong-answer defect rather than #8819's protection-bypass class.
+        //    Manifest-PRESENT types (`views` → `view`) folded already and were never
+        //    affected — that asymmetry is what makes `fields` the discriminating
+        //    fixture in the pins and `views` a fold that proves nothing.
+        //  • the #7894 boundary REFUSAL, which never ran on this verb at all: an
+        //    unrecognised spelling of a declared type (`viewes`) was forwarded to the
+        //    plugin path instead of refused `400 INVALID_REQUEST`.
+        //  • the echoed `type` in the response below. Reassigning `request` is what
+        //    makes that echo report the CANONICAL spelling, and that is the precedent
+        //    this family already set rather than a new answer: `saveMetaItem` and
+        //    `deleteMetaItem` both `return { type: request.type }` AFTER their fold,
+        //    and #8819's own header calls reporting the CALLER's spelling for a row
+        //    addressed under the canonical one the defect it was fixing. The echo now
+        //    names the spelling the read actually used.
+        request = canonicalizeMetaRequestType(request);
+        // Canonical by construction from the fold above. NOT a second fold: the
+        // `PLURAL_TO_SINGULAR` lookup that used to stand here is exactly what #7894
+        // removed from this boundary. The binding survives under its own name because
+        // the read below reads it as "the key the row is stored under" — the same
+        // shape {@link rollbackMetaItem} keeps.
+        const singularType = request.type;
         const orgId = request.organizationId ?? null;
         // [#8798] Read the history rows DIRECTLY, once. `historyMetaItem`
         // cannot serve this function: its `MetadataEvent` shape doesn't carry
@@ -15970,8 +16007,46 @@ export class ObjectStackProtocolImplementation implements
                     : (typeof r.metadata === 'string' ? JSON.parse(r.metadata) : r.metadata);
                 histRows.push({ version: r.version ?? 0, body });
             }
-        } catch {
-            // history table unavailable — fall through with empty list
+        } catch (error) {
+            // [#8833] ADR-0110 D3 — a miss and an outage are different facts, and a
+            // consumer must never read one as the other.
+            //
+            // This `catch` used to be EMPTY and fall through, leaving `histRows` at
+            // `[]`. The invention then happened below, where that never-filled
+            // accumulator is read as though it were a real answer: a
+            // `sys_metadata_history` outage was served as a well-formed 200 with
+            // `added`/`removed`/`changed` all empty — byte-identical to "these two
+            // versions are the same". An operator comparing versions before a
+            // rollback, and any SDK or agent reading this endpoint, acted on
+            // "unchanged" with full confidence, and no log line was emitted either.
+            // (That fall-through shape is also why `check-durability-degradation-log-
+            // level`'s read-seam-invention rule cannot see this seam despite scanning
+            // this package: it keys on `ts.isReturnStatement` and this `catch`
+            // returned nothing. Extending that gate is #8845 in the devx lane.)
+            //
+            // Maintainer ruling (2026-08-15, #8833 comment 5302933802): route the
+            // failure through the platform's EXISTING discrimination rather than
+            // adding a response field. The genuinely-absent-table case — a minimal
+            // deployment that never provisioned history — keeps its benign empty
+            // answer, because there really are no rows and a first boot must not
+            // explode. EVERY other read failure (connection drop, timeout, permission
+            // denial, query error) propagates the 503.
+            // {@link rethrowUnlessMetadataStoreUnprovisioned} is that single
+            // discriminator — the same guard #5532 restored for `getMetaItems` and
+            // #8855 carries for `getMetaDiagnostics` — and it is conservative in the
+            // safe direction: an UNRECOGNISED error is loud, never benign.
+            //
+            // ⚠️ This ADDS loudness where there is now none, uniformly for every
+            // type. Before PR #8841 the outage threw for gated-open types (`view`)
+            // and was swallowed for gated-shut ones (`field`, `job`, `api`,
+            // `capability`, `agent`); #8841 deleted the discarded `historyMetaItem`
+            // round trip that caused that split, so it had become silent everywhere.
+            // The ruling was made against that post-#8841 state.
+            //
+            // ⛔ A `historyUnavailable: true` response key (the card's option B) was
+            // DECLINED in the same ruling — a new published key with no consumer, on
+            // the manual floor. Do not reintroduce it as "more informative".
+            this.rethrowUnlessMetadataStoreUnprovisioned(error);
         }
         const byVersion = new Map<number, Record<string, unknown> | null>();
         for (const r of histRows) byVersion.set(r.version, r.body);


### PR DESCRIPTION
Fixes #8868
Fixes #8833

Two independent defects in one method — `diffMetaItem` in
`packages/metadata-protocol/src/protocol.ts` — folded into one PR at the
maintainer's suggestion on #8833 (comment 5302933802: *"the metadata seat may
sensibly dispatch #8868 + this card as one `diffMetaItem` PR (fold + 503)"*).
They are kept legible as two separate changes in the diff.

`GET /api/v1/meta/:type/:name/diff` is a routed live endpoint with a
caller-supplied `:type` (`rest-route-ledger.ts:184`).

## 1. #8868 — the canonical fold

`diffMetaItem` was the NINTH `/meta` entry point on this URL family and the last
one still deriving its type key from `PLURAL_TO_SINGULAR`, the manifest-COLLECTION
map that #7894 moved this boundary off. It now routes through
`canonicalizeMetaRequestType` — the same one-line replacement #8769
(`publishMetaItem`) and #8819 (`rollbackMetaItem`) made. Three things change:

- **the answer.** For the four MANIFEST-ABSENT types (`field`, `seed`,
  `external_catalog`, `translation` — legitimately absent from that map because
  they are not stack collections) a plural spelling stayed plural all the way into
  the `sys_metadata_history` query, matched no row, and the endpoint answered a
  well-formed **empty diff** for an item that does have history. Measured:
  `PLURAL_TO_SINGULAR['fields']` is `undefined` while `PLURAL_TO_SINGULAR['views']`
  is `'view'`, which is exactly why manifest-present types were never affected.
- **unrecognised spellings.** The #7894 boundary refusal never ran on this verb.
  `viewes` is now refused `400 INVALID_REQUEST` naming both accepted spellings.
  The refusal stays narrow: a name reaching for no declared type (`fieldz`, a
  possible plugin kind) is still served.
- **the echoed `type`.** Now the canonical spelling — i.e. the one the read
  actually used. See "the one sub-question" below.

## 2. #8833 — the swallowed outage

The history read sat in a `try` whose `catch` was empty apart from a comment.
`histRows` stayed `[]` and the code below read that never-filled accumulator as a
real answer, so a `sys_metadata_history` outage was served as a successful 200
with an empty diff — byte-identical to "these two versions are the same", with no
log line either.

Implementing the maintainer ruling as written, not re-adjudicated: the `catch`
routes through the platform's **existing** discrimination,
`rethrowUnlessMetadataStoreUnprovisioned` (called, not modified).

- a **genuinely absent table** (minimal deployment) keeps its benign empty answer;
- **every other read failure** propagates `503 SERVICE_UNAVAILABLE` with the
  driver error as `cause`. ADR-0110 D3 — a miss and an outage are different facts.

Option B (a `historyUnavailable` response key) was declined in the ruling and is
not present here.

⚠️ **This adds loudness where there was none, uniformly.** PR #8841 removed the
last path that threw here, so the outage had become silent for every type. The
ruling was made against that post-#8841 state, and I re-verified it on today's
`main` before building: no `historyMetaItem` round trip remains in this method.

Both thrown contracts are declared on the method's docblock, stating the
discrimination rather than just the status code — a caller reading the docblock
learns that an unprovisioned history table still answers benignly, which is the
whole point of the ruling.

## The one sub-question the card named, answered from precedent

Should the response echo the canonical spelling or the caller's? #8769 and #8819
**agree**, so no third answer was minted: both reassign `request` at the top, which
makes every downstream read of `request.type` report the canonical spelling.
#8819's own header calls reporting the caller's spelling for a row addressed under
the canonical one the defect it was fixing. The two folded siblings that *do* echo
a `type` in their response body — `saveMetaItem` and `deleteMetaItem` — both
`return { type: request.type }` **after** their fold. This PR inherits that
mechanism exactly.

## Verification — full union at HEAD `f9811727d`

Gate union re-derived from the actual changed paths via
`node scripts/pm/dispatch-gates.mjs`, then run:

| gate | result |
|---|---|
| `check:changeset-gate-self-tests`, `check:objectui-changeset` | PASS |
| `check:cross-package-test-inputs` | PASS (12 packages) |
| `check:durability-log-level` | PASS (66 read seams, none invents) |
| `check:filter-alias-parity` | PASS |
| `check:query-options-erasure` | PASS (no files added to baseline) |
| `check:type-check-coverage` | PASS |
| `check:type-check-debt --re-measure` | PASS — 33 entries, none above its recorded number |
| `check:engine-double-contract` | PASS — 266 pinned, my new double is PINNED, no ledger row |
| `check:error-code-casing`, `check:nul-bytes` | PASS |
| `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset` | PASS |

Added beyond the script's derived list (it derives from paths and cannot see
diff-content-keyed families): `check:engine-double-contract` (new fake engine),
`check:error-code-casing`, `check:nul-bytes`.

Tests, with the **consumption radius** run rather than just the edited package:

- `@objectstack/metadata-protocol` — 103 files, 1496 tests pass
- `@objectstack/objectql` — 210 files, 3675 tests pass (the consumer that went red
  on #8867 after a green edited-package suite)
- `@objectstack/rest` — 118 files, 1948 tests pass (owns the route)
- `typecheck` green for all three
- TEST_DEBT measured directly on a **built** workspace, since `metadata-protocol`
  hides `**/*.test.ts` from tsc and a green `typecheck` carries zero information
  about the ratchet

### Second commit at HEAD `3dae00805` — docblock only

`3dae00805` adds the two `@throws` entries to `diffMetaItem`'s docblock and
changes nothing else (one hunk, 18 insertions, 0 deletions, no behaviour). Gates
re-derived for that single path and re-run at the new head:
`check:cross-package-test-inputs`, `check:durability-log-level`,
`check:filter-alias-parity`, `check:nul-bytes` — all PASS. The ratchet families
are not re-run for this commit by explicit instruction, and are structurally
unmovable by it: `check:type-check-debt` counts tsc errors, `query-options-erasure`
counts sites in test files, and `engine-double-contract` scans doubles — a
comment-only diff touches none of those inputs.

## The pins are proved capable of failing

#8867 in this lane shipped a pin whose fixture made folded and raw agree, so it
could not fail. Both halves here were ablated and observed red:

**Fold ablated** (`canonicalizeMetaRequestType` call removed, manifest lookup
restored) — 4 red, and the failure text is the defect itself:

```
AssertionError: expected { type: 'fields', ...(6) } to match object { added: [], removed: [], ...(1) }
-   "changed": [ { "from": "A", "path": "label", "to": "B" } ],
+   "changed": [],
```

plus `expected 'fields' to be 'field'` on the echo and the 400 refusal going
unrefused. The `#8833` arms stayed green — the two changes are independent.

**503 ablated** (swallow restored) — the two outage pins plus the two re-pointed
#8798 pins went red (`expected null to be an instance of Error`), while
**`THE CONTROL: a genuinely-absent table still answers benignly` stayed GREEN**.
That pair is what shows the discrimination is selective rather than a blanket
"any failure 503s".

**One observed direction did not match my prediction, reported rather than
smoothed over.** I expected the manifest-PRESENT control (`views`) to stay fully
green under the fold ablation; it went red. Cause: my first version compared whole
response objects, and the **echo** moves for manifest-present types too (the echo
never read the manifest map). The control has been split so each half states its
own fact — body arms (unchanged by this fix, which is the control's real claim)
and echo arm (does move) — and the comment records the measurement. Re-ablated
after the split: body arms green, only the echo arm red, at
`protocol.diff-canonical-type-and-history-outage.test.ts:255`.

## Fixture triage on the pre-existing pins

`protocol.diff-dead-history-read.test.ts` had two `#8798` pins asserting that an
outage falls through to an empty diff — exactly the limb this PR deletes. They
were **re-pointed, not deleted**: their subject was never "an outage is empty" but
"one outage, one answer, not decided by the type", and both arms still pin that,
now against the 503. Their stub throws a generic `Error`, which
`isMissingTableError` does not classify as benign, so it is a genuine outage under
the new rule. The benign case gets its own positive control in the new file.

## Scope

Edits are confined to `diffMetaItem` — the region declared at dispatch
(`origin/main` @ `8664a2c99` `:15911` → end of method) plus its docblock
(`:15902`–`:15910`), the latter under a narrow widening the PM authorized after I
stopped and reported rather than taking it myself. `rethrowUnlessMetadataStoreUnprovisioned`
is **called, not modified**. No sibling region touched, and no `content/docs/**`
change: `http-protocol.mdx` documents neither this endpoint nor any 503, so
nothing there is stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_
