### PR TITLE
fix(metadata-protocol): propagate the metadata-store 503 out of getMetaDiagnostics (#8855)

### DIFF
--- a/.changeset/diagnostics-store-outage-503.md
+++ b/.changeset/diagnostics-store-outage-503.md
@@ -1,0 +1,70 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `getMetaDiagnostics` stops publishing an unreadable metadata store as "0 problems" (#8855)
+
+<!-- adr-0087: not-required (no-migration-prescription) One `catch` inside one
+method is narrowed from untyped to "rethrow the 503 the producer already
+classified". No authorable key is added, renamed, retired or tombstoned, no
+stored shape changes, and the response type is byte-identical — so there is
+nothing for a conversion entry to convert. -->
+
+`GET /api/v1/meta/diagnostics` sweeps every metadata type and publishes four
+numeric facts about the corpus. Its per-type read was wrapped in an **untyped**
+`catch` that `continue`d, and the comment above it named a benign reason ("type
+not listable in this kernel scope") that is genuinely real. The catch took
+everything else with it — including the one error the callee exists to raise.
+
+`getMetaItems` classifies a failed `sys_metadata` read by error **type** and
+throws a 503 (`SERVICE_UNAVAILABLE`) for every read failure that is not "the
+table has not been provisioned yet" — the discrimination #5532 introduced so an
+outage would stop looking like emptiness. `getMetaDiagnostics` caught that 503
+back into emptiness one layer up, then published the emptiness as a **number**.
+
+**Measured on `origin/main` @ `8664a2c99` before the fix**, prediction written
+down first and matched exactly. With an engine whose every read rejects:
+
+```
+[outage: connect ECONNREFUSED 10.0.0.5:5432]     RESOLVED
+  total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=0
+[benign: SQLITE_ERROR: no such table: sys_metadata]  RESOLVED
+  total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=26
+```
+
+Two user-visible harms from one `catch`, and the benign run is what makes them
+legible — it is the same payload minus the `stats`:
+
+- `stats[t]` is never written, so an unreadable type is **absent** from the
+  response rather than zero. The Studio directory tile the field's own doc names
+  loses the type, byte-shaped like an environment that declares none of it.
+- `total` counts entries that **failed validation**, and a store nobody can read
+  contributes none — so the endpoint whose whole job is reporting problems
+  answered `total: 0` at the exact moment it could read nothing. Green was the
+  failure mode.
+
+`scannedTypes` reported the full 26 in both runs: it is computed from the intent
+(`targetTypes.length`, fixed before the loop) and never decremented on
+`continue`.
+
+**The fix narrows the catch; it does not delete it.** A 503 arriving from the
+read is rethrown **unchanged** and the sweep fails loudly (ADR-0110 D3: a miss
+and an outage are different facts with opposite dispositions). Every other
+failure still skips that one type, so a kernel scope that cannot enumerate one
+type does not fail the whole governance sweep.
+
+**No response field was added.** A per-type degradation marker would be a
+public-surface addition, and the payload type is unchanged.
+
+The envelope is **propagated, not rebuilt**: re-running the driver-error
+classification here would re-wrap an already-shaped 503 in a second one and
+displace the driver error riding as `cause` — the object `logWithheldServerFault`
+prints for the operator. The REST boundary needs no change: the handler already
+routes thrown errors through `handleRouteError`, which preserves the 503.
+
+The pin carries the discriminating control in the same file: an unprovisioned
+`sys_metadata` still answers benignly with every type present at `count: 0`, a
+type that is genuinely not listable is still skipped at the cost of one type,
+and a healthy store still counts its rows — while the outage cases throw. "0
+problems" is the right answer in the benign cell, and it is exactly the answer a
+blanket change would have kept producing in the wrong one.

--- a/packages/metadata-protocol/src/protocol.diagnostics-store-outage.test.ts
+++ b/packages/metadata-protocol/src/protocol.diagnostics-store-outage.test.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#8855] A diagnostics sweep that could not READ the store must not publish
+// "0 problems".
+//
+// ---------------------------------------------------------------------------
+// The defect, measured on origin/main @ 8664a2c99 BEFORE the fix
+// ---------------------------------------------------------------------------
+// `getMetaDiagnostics` wrapped its per-type read in an UNTYPED `catch` that
+// `continue`d. The comment named a benign reason ("type not listable in this
+// kernel scope") and that reason is real — but the catch took everything else
+// with it, including the one error the callee exists to raise: the 503 #5532
+// raised out of `getMetaItems` so that an outage would stop looking like
+// emptiness.
+//
+// Prediction was written down BEFORE the run; the run matched it exactly. With
+// an engine whose every read rejects, `getMetaDiagnostics({})`:
+//
+//   [outage: connect ECONNREFUSED 10.0.0.5:5432]  RESOLVED
+//     total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=0
+//   [benign: SQLITE_ERROR: no such table: sys_metadata]  RESOLVED
+//     total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=26
+//     every stat = {"count":0,"locked":0,"packages":[]}
+//
+// Two user-visible harms out of one `catch`, and the benign run above is what
+// makes them legible — it is the SAME payload shape minus the missing `stats`:
+//
+//   * `stats[t]` is never written, so an unreadable type is ABSENT from the
+//     response rather than zero. The Studio directory tile the field's own doc
+//     names ("so the Studio directory page can render tile counts") simply
+//     loses the type, byte-shaped like an environment that declares none of it.
+//   * `total` counts entries that FAILED validation, and a store nobody can
+//     read contributes none — so the endpoint whose whole job is reporting
+//     problems answered `total: 0` at the exact moment it could read nothing.
+//     Green is the failure mode.
+//
+// `scannedTypes` stayed at the full 26 in both runs: it is computed from the
+// INTENT (`targetTypes.length`, fixed before the loop) and never decremented on
+// `continue`, so the payload asserted "I scanned 26" having scanned 0.
+//
+// ---------------------------------------------------------------------------
+// What the fix is, and what it deliberately is NOT
+// ---------------------------------------------------------------------------
+// NOT "delete the catch" — the benign skip is genuine and stays. The catch is
+// NARROWED: the 503 the producer already classified is rethrown UNCHANGED,
+// everything else still skips the type. No payload field was added; a per-type
+// degradation marker would be a public-surface addition and is explicitly not
+// this card's to make.
+//
+// Classification reads the envelope the PRODUCER built rather than re-deriving
+// it. Re-running `isMissingTableError` here would re-wrap an already-shaped 503
+// in another 503 and displace the driver error riding as `cause` — which is why
+// `expect(caught.cause).toBe(err)` below is an identity check, not a shape
+// check: it is what proves the envelope was propagated and not rebuilt.
+//
+// ---------------------------------------------------------------------------
+// Reverse verification, direction predicted BEFORE running
+// ---------------------------------------------------------------------------
+// Ordinary red, and — this is the point — red on the OUTAGE half only. Restore
+// the bare `} catch { continue; }` and the three outage cases go red by
+// RESOLVING instead of throwing, while every benign / selective / healthy case
+// below stays green. A blanket "diagnostics now throws" would have taken the
+// benign and selective controls with it; a fix that only looked like it worked
+// would leave the outage cases green. The two halves are in one file so a
+// future edit that re-widens the catch is a diff nobody can read as harmless.
+
+import { describe, it, expect, vi } from 'vitest';
+import { ErrorCode } from '@objectstack/spec/api';
+import { DEFAULT_METADATA_TYPE_REGISTRY, getMetadataTypeSchema } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+/**
+ * The set the sweep walks — derived from the same two spec symbols the
+ * implementation derives `targetTypes` from, so this pin does not rot into a
+ * hardcoded 26 the day the registry grows.
+ */
+const SWEPT_TYPES: string[] = DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => getMetadataTypeSchema(e.type))
+    .map((e) => e.type);
+
+/** A registry with nothing in it — the overlay read is the only source. */
+function emptyRegistry(overrides: Record<string, unknown> = {}) {
+    return {
+        getObject: () => undefined,
+        getItem: () => undefined,
+        listItems: () => [],
+        applyNavContributions: (x: any) => x,
+        isPackageDisabled: () => false,
+        getObjectOwner: () => undefined,
+        ...overrides,
+    };
+}
+
+/** An engine whose every read REJECTS — a metadata store the protocol cannot reach. */
+function engineThatCannotBeRead(error: () => unknown) {
+    const reject = vi.fn(async () => { throw error(); });
+    return { registry: emptyRegistry(), find: reject, findOne: reject } as any;
+}
+
+/** The real driver phrasing for "the table has not been provisioned yet". */
+const missingTable = () =>
+    Object.assign(new Error('SQLITE_ERROR: no such table: sys_metadata'), { code: 'SQLITE_ERROR' });
+
+/** An outage: the rows may well exist and simply were not seen. */
+const connectionRefused = () =>
+    Object.assign(new Error('connect ECONNREFUSED 10.0.0.5:5432'), { code: 'ECONNREFUSED' });
+
+/** Capture a rejection without letting a resolve pass silently. */
+async function rejection(run: () => Promise<unknown>): Promise<any> {
+    let caught: any;
+    let resolved: unknown;
+    let didResolve = false;
+    try {
+        resolved = await run();
+        didResolve = true;
+    } catch (e) {
+        caught = e;
+    }
+    expect(
+        didResolve,
+        `expected a rejection, but the sweep resolved with ${JSON.stringify(resolved)}`,
+    ).toBe(false);
+    return caught;
+}
+
+/** Every assertion the outage envelope owes a caller (the #5532 envelope, unchanged). */
+function expectStoreUnavailable(caught: any, cause: unknown) {
+    expect(caught?.status).toBe(503);
+    expect(caught?.code).toBe('SERVICE_UNAVAILABLE');
+    // ADR-0112: the wire code must be in the declared vocabulary, or the
+    // envelope fails `ApiErrorSchema.parse` at the boundary that ships it.
+    expect(ErrorCode.safeParse(caught?.code).success).toBe(true);
+    // The words a client reads say "unknown", never "does not exist".
+    expect(caught.message).toContain('unknown');
+    // IDENTITY, not shape: the driver error rides as `cause` on the envelope
+    // #5532 built. A re-classification here would have re-wrapped that envelope
+    // and put the 503 itself in `cause`, hiding the driver line
+    // `logWithheldServerFault` prints for the operator (#5437).
+    expect(caught.cause).toBe(cause);
+}
+
+describe('[#8855] an unreadable metadata store stops being published as "0 problems"', () => {
+    it('the whole-corpus sweep propagates the 503 instead of answering total: 0, stats: {}', async () => {
+        const err = connectionRefused();
+        const p = new ObjectStackProtocolImplementation(engineThatCannotBeRead(() => err));
+
+        const caught = await rejection(() => p.getMetaDiagnostics({}));
+        expectStoreUnavailable(caught, err);
+    });
+
+    it('the single-type sweep is held to the same rule', async () => {
+        const err = connectionRefused();
+        const p = new ObjectStackProtocolImplementation(engineThatCannotBeRead(() => err));
+
+        const caught = await rejection(() => p.getMetaDiagnostics({ type: 'object' }));
+        expectStoreUnavailable(caught, err);
+    });
+
+    it('an outage and a first boot are now distinguishable by the caller — which is the whole point', async () => {
+        // ADR-0110 D3, stated as the two answers side by side: the benign case
+        // still ANSWERS (200-shaped, every type present at count 0) while the
+        // outage THROWS. Before the fix these two produced the same status and
+        // differed only by `stats` being empty — a difference no client is
+        // documented to read, and one an environment that genuinely declares
+        // nothing would produce as well.
+        const benign = new ObjectStackProtocolImplementation(engineThatCannotBeRead(missingTable));
+        const outage = new ObjectStackProtocolImplementation(engineThatCannotBeRead(connectionRefused));
+
+        const benignResult: any = await benign.getMetaDiagnostics({});
+        expect(benignResult.total).toBe(0);
+        expect(Object.keys(benignResult.stats)).toHaveLength(SWEPT_TYPES.length);
+
+        const caught = await rejection(() => outage.getMetaDiagnostics({}));
+        expect([caught.status, caught.code]).toEqual([503, 'SERVICE_UNAVAILABLE']);
+    });
+});
+
+describe('[#8855] the discrimination is selective, not a blanket refusal', () => {
+    it('an unprovisioned sys_metadata still answers benignly, every type present at count 0', async () => {
+        // The control that matters most. `getMetaItems` classifies this by
+        // error TYPE (`isMissingTableError`) and returns normally with
+        // `items: []`, so it never reaches the diagnostics catch at all — and
+        // the sweep must keep publishing a full, honest, all-zero payload.
+        // "0 problems" is the RIGHT answer in this cell, and it is exactly the
+        // answer a blanket change would have destroyed.
+        const p = new ObjectStackProtocolImplementation(engineThatCannotBeRead(missingTable));
+
+        const res: any = await p.getMetaDiagnostics({});
+        expect(res.total).toBe(0);
+        expect(res.entries).toEqual([]);
+        expect(res.scannedItems).toBe(0);
+        expect(res.scannedTypes).toBe(SWEPT_TYPES.length);
+        expect(Object.keys(res.stats)).toHaveLength(SWEPT_TYPES.length);
+        for (const t of SWEPT_TYPES) {
+            expect(res.stats[t]).toEqual({ count: 0, locked: 0, packages: [] });
+        }
+    });
+
+    it('a type that is genuinely not listable in this kernel scope is still skipped', async () => {
+        // The benign reason the original comment named, kept alive on purpose:
+        // this failure never went through the store-read classification (the
+        // registry listing is not one of the guarded reads), carries no 503,
+        // and must still cost exactly one type rather than the whole sweep.
+        const unlistable = SWEPT_TYPES.find((t) => t !== 'object')!;
+        const engine = {
+            registry: emptyRegistry({
+                listItems: (type: string) => {
+                    if (type === unlistable) {
+                        throw new Error(`type ${unlistable} is not listable in this kernel scope`);
+                    }
+                    return [];
+                },
+            }),
+            find: vi.fn(async () => []),
+            findOne: vi.fn(async () => null),
+        } as any;
+        const p = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await p.getMetaDiagnostics({});
+        expect(res.stats[unlistable]).toBeUndefined();
+        expect(Object.keys(res.stats)).toHaveLength(SWEPT_TYPES.length - 1);
+        expect(res.stats.object).toEqual({ count: 0, locked: 0, packages: [] });
+    });
+
+    it('a healthy store still counts the rows it holds', async () => {
+        // The positive control on the other side: the sweep is not merely
+        // "throws less often", it still does its job.
+        const engine = {
+            registry: emptyRegistry(),
+            find: vi.fn(async (_object: string, opts: any) => (
+                opts?.where?.type === 'object' && opts?.where?.state === 'active'
+                    ? [{
+                        type: 'object',
+                        name: 'acct',
+                        state: 'active',
+                        package_id: 'crm',
+                        metadata: JSON.stringify({ name: 'acct', label: 'Account' }),
+                    }]
+                    : []
+            )),
+            findOne: vi.fn(async () => null),
+        } as any;
+        const p = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await p.getMetaDiagnostics({});
+        expect(res.stats.object.count).toBe(1);
+        expect(res.stats.object.packages).toEqual(['crm']);
+        expect(res.scannedItems).toBe(1);
+        expect(res.scannedTypes).toBe(SWEPT_TYPES.length);
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -4730,8 +4730,59 @@ export class ObjectStackProtocolImplementation implements
                     organizationId: request.organizationId,
                     packageId: request.packageId,
                 } as any);
-            } catch {
-                // Type not listable in this kernel scope — skip.
+            } catch (error) {
+                // [#8855] TWO different failures used to leave through this
+                // `continue`, and only one of them is benign.
+                //
+                // BENIGN, and the reason the comment named — it is real, which
+                // is why this `catch` is narrowed rather than deleted: the type
+                // is not listable in THIS kernel scope. Skipping it is the
+                // truth, and a scope that cannot enumerate one type must not
+                // fail the whole governance sweep.
+                //
+                // NOT BENIGN: the read already ran the platform's single
+                // discrimination — `getMetaItems` classifies by error TYPE
+                // through {@link rethrowUnlessMetadataStoreUnprovisioned},
+                // returns normally for the one benign driver reason
+                // (`isMissingTableError`: `sys_metadata` not provisioned yet,
+                // so `items: []` IS the truth), and throws
+                // {@link metadataStoreUnavailableError} — a 503 — for every
+                // other read failure. That 503 says "whether rows exist is
+                // UNKNOWN". Swallowing it here put the emptiness straight back
+                // one layer up, and then published it as a NUMBER:
+                //
+                //   * `stats[t]` was never written, so the type is ABSENT from
+                //     the response — not zero, absent — byte-shaped like an
+                //     environment that declares none of it, and the Studio
+                //     directory tile the field exists to feed simply loses it;
+                //   * `total` counts entries that FAILED validation, and a
+                //     store nobody can read contributes none — so a diagnostics
+                //     endpoint whose whole job is reporting problems answered
+                //     `0 problems` precisely when it could not read anything.
+                //
+                // ADR-0110 D3 is the rule: a miss and an outage are different
+                // facts with opposite dispositions ("nothing to fix" vs "the
+                // backend is down, retry"), and a consumer must never read one
+                // as the other. #5108 restored it in `DatabaseLoader`, #5532 in
+                // `getMetaItems` itself — this is the same rule one layer up,
+                // on the consumer that turns the read into a published count.
+                //
+                // Classification is by the envelope the PRODUCER already built,
+                // not by a second reading of the driver error. Re-running
+                // `isMissingTableError` / `rethrowUnlessMetadataStoreUnprovisioned`
+                // on what arrives here would re-wrap an already-shaped 503 in
+                // another one and displace the driver error riding as `cause` —
+                // the object `logWithheldServerFault` prints for the operator
+                // (#5437). The original is rethrown UNCHANGED, so the envelope
+                // that reaches the REST boundary is the one #5532 shaped.
+                //
+                // The test is `status === 503` rather than the narrower
+                // `code === 'SERVICE_UNAVAILABLE'` on purpose, and in the
+                // direction `rethrowUnlessMetadataStoreUnprovisioned`'s own doc
+                // argues: a false "benign" silently mis-answers a question
+                // nobody can re-ask, while a false "real" costs one 503 the
+                // caller can retry.
+                if ((error as { status?: unknown } | null | undefined)?.status === 503) throw error;
                 continue;
             }
             const items: any[] = Array.isArray(listed?.items)


### PR DESCRIPTION
Fixes #8855

Implements triage ruling [`5302846257`](https://github.com/objectstack-ai/objectstack/issues/8855#issuecomment-5302846257) as written: classify by error type through the existing discrimination and **propagate the 503**. Not "delete the catch"; no payload field added.

## The defect

`getMetaDiagnostics` sweeps every metadata type and publishes four numeric facts about the corpus. Its per-type read was wrapped in an **untyped** `catch` that `continue`d. The comment above it named a benign reason — "type not listable in this kernel scope" — and that reason is genuinely real, which is why this PR narrows the catch instead of removing it. The catch took everything else with it, including the one error the callee exists to raise.

`getMetaItems` classifies a failed `sys_metadata` read by error **type** through `rethrowUnlessMetadataStoreUnprovisioned`: it returns normally for the one benign driver reason (`isMissingTableError` — the table is not provisioned yet, so `items: []` IS the truth) and throws a 503 for every other read failure. That is the discrimination #5532 introduced so an outage would stop looking like emptiness. `getMetaDiagnostics` caught the 503 back into emptiness one layer up, then published the emptiness as a **number**.

## Measured before writing anything

The card's repro was written but never run, and triage asked for prediction-then-measurement. Prediction was recorded first; the run matched it exactly. Protocol-level, on `origin/main` @ `8664a2c99`, with an engine whose every read rejects:

```
[outage: connect ECONNREFUSED 10.0.0.5:5432]         RESOLVED
  total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=0
[benign: SQLITE_ERROR: no such table: sys_metadata]  RESOLVED
  total=0  scannedTypes=26  scannedItems=0  Object.keys(stats).length=26
  every stat = {"count":0,"locked":0,"packages":[]}
```

The benign run is what makes the harm legible — it is the same payload minus the `stats`. Two user-visible harms out of one `catch`:

- `stats[t]` is never written, so an unreadable type is **absent** from the response rather than zero. The Studio directory tile the field's own doc names loses the type, byte-shaped like an environment that declares none of it.
- `total` counts entries that **failed validation**, and a store nobody can read contributes none — so the endpoint whose whole job is reporting problems answered `total: 0` at the exact moment it could read nothing. Green was the failure mode.

`scannedTypes` reported the full 26 in both runs: it is computed from the intent (`targetTypes.length`, fixed before the loop) and never decremented on `continue`.

## The fix

One narrowed `catch` inside one method. A 503 arriving from the read is rethrown **unchanged**; every other failure still skips that one type, so a kernel scope that cannot enumerate one type does not fail the whole governance sweep. ADR-0110 D3: a miss and an outage are different facts with opposite dispositions, and a consumer must never read one as the other.

**The envelope is propagated, not rebuilt.** Re-running `isMissingTableError` / `rethrowUnlessMetadataStoreUnprovisioned` on what arrives here would re-wrap an already-shaped 503 in a second one and displace the driver error riding as `cause` — the object `logWithheldServerFault` prints for the operator (#5437). `isMissingTableError` walks the cause chain, so that re-wrap is not hypothetical. The pin asserts `cause` by **identity**, which is what proves propagation rather than reclassification.

The test is `status === 503` rather than the narrower code check deliberately, in the direction `rethrowUnlessMetadataStoreUnprovisioned`'s own doc argues: a false "benign" silently mis-answers a question nobody can re-ask, while a false "real" costs one 503 the caller can retry.

## Scope held

- **No response field added.** A per-type degradation marker is a public-surface addition and the ruling reserves it for escalation. The payload type is byte-identical.
- **The shared helper is untouched.** `rethrowUnlessMetadataStoreUnprovisioned` has seven other call sites and reaches two live sibling dispatches; this PR calls the discrimination's *result*, it does not modify the producer. The diff sits entirely inside `getMetaDiagnostics`.
- **No widening into `packages/rest`.** Re-measured rather than trusted: the card's UNVERIFIED note put the handler at `rest-server.ts:4759`, but #8887 moved it to `:3478`. It already wraps the call in `try/catch` and routes through `handleRouteError`, which preserves `status` — so the 503 reaches the wire with no change in that lane.
- **`organizationId` left unmeasured**, per the ruling — it belongs to the #8805 tenant-scoping thread.

## Verification

New pin `packages/metadata-protocol/src/protocol.diagnostics-store-outage.test.ts` carries the discriminating control in the same file, because a refusal pin with no positive control cannot show the discrimination is selective rather than blanket:

| case | expected |
|:--|:--|
| outage, whole-corpus sweep | 503 envelope, `cause` identity |
| outage, single-type sweep | 503 |
| outage vs first boot, side by side | benign answers, outage throws |
| unprovisioned `sys_metadata` | resolves, every type present at `count: 0` |
| a type genuinely not listable | resolves, that one type skipped, the rest counted |
| healthy store | resolves, real counts |

"0 problems" is the right answer in the benign cell, and it is exactly the answer a blanket change would have kept producing in the wrong one.

**Ablation — direction predicted before running: ordinary red, on the outage half only.** Restoring the bare `} catch { continue; }` gives **3 failed / 3 passed**, and the three reds fail by *resolving* with the defect's payload verbatim:

```
AssertionError: expected a rejection, but the sweep resolved with
  {"entries":[],"total":0,"scannedTypes":26,"scannedItems":0,"stats":{}}
```

The three benign/selective/healthy controls stay green through the ablation — that separation is what shows the change is the outage split and not a blanket throw.

**Suites** (all at the head quoted below):

- `@objectstack/metadata-protocol` — 103 files / 1493 tests passed
- **Downstream consumers** (prefix filter, `...@objectstack/metadata-protocol`): the three that touch this surface — `@objectstack/objectql` 210 files / 3675 tests, `@objectstack/rest` 118 files / 1948 tests, `@objectstack/client` 23 files / 301 tests. `objectql` carries `diagnostics-clean-baseline.test.ts` and is the consumer that went red on #8867 after a green edited-package suite.

**Gates** — derived from the actual changed paths via `scripts/pm/dispatch-gates.mjs`, then re-run at the post-merge head: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:durability-log-level`, `check:filter-alias-parity`, `check:objectui-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, plus the convention-triggered `check:query-options-erasure`, `check:type-check-coverage` and `check:type-check-debt --re-measure`, and `check:nul-bytes` / `check:engine-double-contract` / `check:error-code-casing` / `check:adr-anchors` added beyond the derived list. All pass.

**TEST_DEBT measured directly on a built workspace**, since `@objectstack/metadata-protocol` sits in the DEBT ledger and `pnpm typecheck` carries zero information about it: full workspace build, then `--re-measure` re-ran tsc per ledger entry — `none above its recorded number`, the package's recorded 63 unchanged, so the new test file contributes **0** errors. No ceiling raised.

---

Verified at `b1de760d6` (post-merge head; the union above was run at this sha).

_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_