### PR TITLE
test(objectql): pin the temporal-comparand door fixture's clock with fake timers (#8937)

### DIFF
--- a/packages/objectql/src/engine-temporal-comparand-door.test.ts
+++ b/packages/objectql/src/engine-temporal-comparand-door.test.ts
@@ -13,45 +13,46 @@
  * rather than refusing everything, and the two drifting apart into separate
  * cases is how that guarantee gets lost.
  *
- * ## [#8937] No calendar date is pinned anywhere in this file
+ * ## [#8937] The clock is pinned at the PROCESS clock, not through the context
  *
- * This suite originally fixed its clock at `2026-08-15T09:00:00.000Z` and
- * threaded it through the engine as `{ context: { now } }`, then asserted the
- * `{30_days_ago}` floor equalled that instant minus 30 days. That assertion
- * passed only while the REAL date and the fixture date agreed: at
- * 2026-08-16T00:00Z it went red on every branch at once, with no code change,
- * and misattributed itself to whatever PR happened to be open.
+ * This suite used to fix its clock at `2026-08-15T09:00:00.000Z` and thread it
+ * through the engine as `{ context: { now } as never }`, then assert the
+ * `{30_days_ago}` floor equalled that instant minus 30 days. That held only
+ * while the REAL date and the fixture date agreed: at 2026-08-16T00:00Z it went
+ * red on every branch at once, with no code change, and misattributed itself to
+ * whatever PR happened to be open.
  *
  * The mechanism was a clock the engine does not offer. `{30_days_ago}` is
  * resolved by `resolveFilterTokens` from an instant the engine never supplies,
- * so the resolver falls back to the process clock — `context.now` was never
- * read, and is not declared on `ExecutionContext` at all (the `as never` casts
- * that used to sit on those calls were the tell). Whether the engine SHOULD
- * expose an injectable clock is #8937's open half; it is a public-contract
- * question, not something this file may assume either way.
+ * so the resolver falls back to the PROCESS clock — `context.now` was never
+ * read, and is not declared on `ExecutionContext` at all (neither the spec
+ * schema nor `ExecutionContextLike` in `@objectstack/core` carries it; the
+ * `as never` casts were TypeScript already saying so). Whether the engine
+ * SHOULD expose a declared, injectable clock is #8937's open half — a
+ * public-contract question this file must not assume either way.
  *
- * So every temporal expectation here is derived, never written down:
+ * So the fixture now pins the clock the engine ACTUALLY reads, with fake
+ * timers, exactly as this package's sibling temporal suites already do
+ * (`engine-cel-default-temporal-shape`, the three `engine-autonumber-*`
+ * files): `vi.useFakeTimers({ toFake: ['Date'] })` — Date only, so the engine's
+ * async paths are untouched — plus `vi.setSystemTime(PINNED_NOW)`. Every
+ * temporal expectation below is then deterministic forever, and the written
+ * dates are honest: they are what the code under test really sees.
  *
- * - the fixture seeds from the real clock, keeping the card's 38-in / 13-out
- *   split at any wall time (the nearest in-window row is 28 days back against
- *   a 30-day floor — two days of margin, so a run may even cross UTC midnight);
- * - the floor assertion compares against what the platform's OWN resolver
- *   yields, bracketing the engine call so the comparison is exact rather than
- *   tolerant;
- * - a separate pin shows that resolver is genuinely clock-sensitive, so the
- *   bracket above cannot be satisfied by a frozen or constant floor.
- *
- * The rule this file now follows: assert the engine and the resolver AGREE.
- * Never assert what day it is.
+ * Two companion cases keep that honest rather than merely green: one shows the
+ * resolver genuinely tracks the clock it is given (so the pin above is not two
+ * constants agreeing), and one records as a TESTED fact that an injected
+ * `context.now` is inert today — the trap that armed this file in the first
+ * place, now stated instead of silent.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { resolveFilterTokens } from '@objectstack/core';
 import { ObjectQL } from './engine.js';
 
 /**
- * The `{30_days_ago}` floor the platform's own resolver yields for `instant` —
- * the single source of truth this file compares the engine against.
+ * The `{30_days_ago}` floor the platform's own resolver yields for `instant`.
+ * Used by the companion cases to show the resolver is clock-SENSITIVE.
  */
 function resolvedFloorAt(instant: Date): string {
   const out = resolveFilterTokens({ $gte: '{30_days_ago}' }, { now: instant });
@@ -143,14 +144,16 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
   let engine: ObjectQL;
   let reads: SeenRead[];
   /**
-   * [#8937] The REAL clock, read per run — never a pinned calendar date. The
-   * engine resolves `{30_days_ago}` against the process clock, so a fixture
-   * pinned to a written-down day is a test that arms itself to fail on a date.
+   * [#8937] Pinned as the PROCESS clock below, which is the clock the engine
+   * actually resolves `{30_days_ago}` against — so this date is deterministic,
+   * not a wager on what day the suite runs.
    */
-  let now: Date;
+  const now = new Date('2026-08-15T09:00:00.000Z');
 
   beforeEach(async () => {
-    now = new Date();
+    // Date only: the engine's async paths must keep real timers.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(now);
     const rec = makeRecordingDriver();
     reads = rec.reads;
     engine = new ObjectQL();
@@ -172,6 +175,8 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
     }
     reads.length = 0;
   });
+
+  afterEach(() => { vi.useRealTimers(); });
 
   const refusalOf = async (p: Promise<unknown>) =>
     p.then(() => null, (e: any) => e as Error & { code?: string; status?: number });
@@ -199,38 +204,32 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
     // ── the POSITIVE CONTROL, in this same test by ruling ───────────────────
     // Without it the four refusals above are equally consistent with a gate
     // that refuses everything.
-    // [#8937] Bracket the call rather than writing a date down: the engine
-    // resolves against the process clock, so the floor it produced must be the
-    // one the platform's own resolver yields for some instant inside the call.
-    // Both ends are almost always the same string; they differ only if the call
-    // straddles UTC midnight, which this comparison then absorbs exactly.
-    const before = new Date();
+    // [#8937] Deterministic because the PROCESS clock is pinned to `now` — the
+    // clock the engine really resolves against — rather than injected through a
+    // context key nothing reads.
+    const floor = new Date(now.getTime() - 30 * 86_400_000).toISOString().slice(0, 10);
+    expect(floor).toBe('2026-07-16');
     const inWindow = await engine.find(
       'support_case',
       { where: { created_date: { $gte: '{30_days_ago}' } } },
     );
-    const after = new Date();
-
     expect(inWindow).toHaveLength(38);
     // The token really resolved — the door let the platform's own spelling
     // through untouched rather than judging it as an uninterpretable string.
     // Indexed rather than `.at(-1)`: this package's tsconfig targets a lib
     // older than ES2022, so `Array.prototype.at` is not declared for it.
-    const boundFloor = reads[reads.length - 1].ast.where.created_date.$gte;
-    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(boundFloor);
-    // …and it is a resolved DAY, not the placeholder surviving to the driver —
-    // the failure this positive control exists to catch.
-    expect(boundFloor).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(reads[reads.length - 1].ast.where.created_date.$gte).toBe(floor);
   });
 
   /**
    * [#8937] The discriminating half of the floor assertion above.
    *
-   * `toContain` against a resolver-derived value would also pass if the
-   * resolver were frozen, constant, or clock-blind — in which case the engine
-   * and the "source of truth" would agree on a wrong answer forever. These pins
-   * show the resolver's floor genuinely tracks the instant it is handed, so
-   * agreement with it is a real statement about the engine's clock.
+   * A pinned clock plus a written-down floor would also pass if the resolver
+   * ignored its instant entirely and returned a constant. These pins show the
+   * floor genuinely tracks the instant handed to it, so the positive control
+   * above is a statement about a live clock rather than two frozen values
+   * agreeing. Written dates here are the resolver's INPUTS, so nothing in this
+   * case can rot on a calendar date.
    */
   it('resolves {30_days_ago} against the instant it is given, not a constant', () => {
     const a = new Date('2026-03-10T12:00:00.000Z');
@@ -238,17 +237,12 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
     // Two instants five days apart yield two DIFFERENT floors, five days apart.
     expect(resolvedFloorAt(a)).toBe('2026-02-08');
     expect(resolvedFloorAt(b)).toBe('2026-02-13');
-    expect(resolvedFloorAt(a)).not.toBe(resolvedFloorAt(b));
-    // A month/year boundary. Safe to write down because these are the
-    // resolver's INPUTS, not the wall clock: this case cannot rot on a date.
+    // A month/year boundary, and the leap-free February this floor crosses.
     expect(resolvedFloorAt(new Date('2026-01-05T00:00:00.000Z'))).toBe('2025-12-06');
-    // With no instant supplied at all the resolver falls back to the process
-    // clock — the behaviour the engine relies on. Bracketed, not compared to a
-    // written-down day, so it holds across a UTC midnight too.
-    const before = new Date();
-    const fallback = resolveFilterTokens({ $gte: '{30_days_ago}' }, {}).$gte;
-    const after = new Date();
-    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(fallback);
+    // With no instant supplied the resolver falls back to the process clock —
+    // the path the engine actually takes. Deterministic here because that clock
+    // is pinned, which is the whole point of pinning it.
+    expect(resolveFilterTokens({ $gte: '{30_days_ago}' }, {}).$gte).toBe('2026-07-16');
   });
 
   /**
@@ -266,19 +260,18 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
    * clock — this pin SHOULD go red: delete it in that PR, deliberately.
    */
   it('does not honour an injected context.now today — the engine reads the process clock', async () => {
-    // An instant far from now: were it honoured, the floor would be near it.
+    // Five years off: were it honoured, the floor would land in 2020.
     const injected = new Date('2020-06-01T00:00:00.000Z');
-    const before = new Date();
     await engine.find(
       'support_case',
       { where: { created_date: { $gte: '{30_days_ago}' } } },
       { context: { now: injected } as never },
     );
-    const after = new Date();
 
     const boundFloor = reads[reads.length - 1].ast.where.created_date.$gte;
     expect(boundFloor).not.toBe(resolvedFloorAt(injected));
-    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(boundFloor);
+    // It tracked the pinned PROCESS clock instead — the real source.
+    expect(boundFloor).toBe('2026-07-16');
   });
 
   it('refuses on both doors — the lowered object form and the authored array sugar', async () => {

--- a/packages/objectql/src/engine-temporal-comparand-door.test.ts
+++ b/packages/objectql/src/engine-temporal-comparand-door.test.ts
@@ -12,10 +12,51 @@
  * refusal pin with no positive control cannot show the gate is discriminating
  * rather than refusing everything, and the two drifting apart into separate
  * cases is how that guarantee gets lost.
+ *
+ * ## [#8937] No calendar date is pinned anywhere in this file
+ *
+ * This suite originally fixed its clock at `2026-08-15T09:00:00.000Z` and
+ * threaded it through the engine as `{ context: { now } }`, then asserted the
+ * `{30_days_ago}` floor equalled that instant minus 30 days. That assertion
+ * passed only while the REAL date and the fixture date agreed: at
+ * 2026-08-16T00:00Z it went red on every branch at once, with no code change,
+ * and misattributed itself to whatever PR happened to be open.
+ *
+ * The mechanism was a clock the engine does not offer. `{30_days_ago}` is
+ * resolved by `resolveFilterTokens` from an instant the engine never supplies,
+ * so the resolver falls back to the process clock — `context.now` was never
+ * read, and is not declared on `ExecutionContext` at all (the `as never` casts
+ * that used to sit on those calls were the tell). Whether the engine SHOULD
+ * expose an injectable clock is #8937's open half; it is a public-contract
+ * question, not something this file may assume either way.
+ *
+ * So every temporal expectation here is derived, never written down:
+ *
+ * - the fixture seeds from the real clock, keeping the card's 38-in / 13-out
+ *   split at any wall time (the nearest in-window row is 28 days back against
+ *   a 30-day floor — two days of margin, so a run may even cross UTC midnight);
+ * - the floor assertion compares against what the platform's OWN resolver
+ *   yields, bracketing the engine call so the comparison is exact rather than
+ *   tolerant;
+ * - a separate pin shows that resolver is genuinely clock-sensitive, so the
+ *   bracket above cannot be satisfied by a frozen or constant floor.
+ *
+ * The rule this file now follows: assert the engine and the resolver AGREE.
+ * Never assert what day it is.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveFilterTokens } from '@objectstack/core';
 import { ObjectQL } from './engine.js';
+
+/**
+ * The `{30_days_ago}` floor the platform's own resolver yields for `instant` —
+ * the single source of truth this file compares the engine against.
+ */
+function resolvedFloorAt(instant: Date): string {
+  const out = resolveFilterTokens({ $gte: '{30_days_ago}' }, { now: instant });
+  return out.$gte as string;
+}
 
 /** Days back from `now`, as the canonical UTC instant the store holds. */
 function daysAgoIso(now: Date, days: number): string {
@@ -101,9 +142,15 @@ function makeRecordingDriver() {
 describe('[#8690] the temporal-comparand door at the engine collection point', () => {
   let engine: ObjectQL;
   let reads: SeenRead[];
-  const now = new Date('2026-08-15T09:00:00.000Z');
+  /**
+   * [#8937] The REAL clock, read per run — never a pinned calendar date. The
+   * engine resolves `{30_days_ago}` against the process clock, so a fixture
+   * pinned to a written-down day is a test that arms itself to fail on a date.
+   */
+  let now: Date;
 
   beforeEach(async () => {
+    now = new Date();
     const rec = makeRecordingDriver();
     reads = rec.reads;
     engine = new ObjectQL();
@@ -132,8 +179,10 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
   it('refuses the card\'s comparands with code AND status, while the positive control still returns 38', async () => {
     // ── the defect's own cells ──────────────────────────────────────────────
     for (const comparand of ['last_30_days', 'not-a-date-at-all', 'last_7_days', 'last_90_days']) {
+      // No context is threaded: the refusal precedes token resolution entirely,
+      // so no clock — injected or otherwise — can participate in this verdict.
       const err = await refusalOf(
-        engine.find('support_case', { where: { created_date: { $gte: comparand } } }, { context: { now } as never }),
+        engine.find('support_case', { where: { created_date: { $gte: comparand } } }),
       );
       expect(err, `${comparand} must be refused, not answered with an empty chart`).not.toBeNull();
       // The reverse-verification requirement: BOTH halves of the envelope.
@@ -150,18 +199,86 @@ describe('[#8690] the temporal-comparand door at the engine collection point', (
     // ── the POSITIVE CONTROL, in this same test by ruling ───────────────────
     // Without it the four refusals above are equally consistent with a gate
     // that refuses everything.
-    const floor = new Date(now.getTime() - 30 * 86_400_000).toISOString().slice(0, 10);
+    // [#8937] Bracket the call rather than writing a date down: the engine
+    // resolves against the process clock, so the floor it produced must be the
+    // one the platform's own resolver yields for some instant inside the call.
+    // Both ends are almost always the same string; they differ only if the call
+    // straddles UTC midnight, which this comparison then absorbs exactly.
+    const before = new Date();
     const inWindow = await engine.find(
       'support_case',
       { where: { created_date: { $gte: '{30_days_ago}' } } },
-      { context: { now } as never },
     );
+    const after = new Date();
+
     expect(inWindow).toHaveLength(38);
     // The token really resolved — the door let the platform's own spelling
     // through untouched rather than judging it as an uninterpretable string.
     // Indexed rather than `.at(-1)`: this package's tsconfig targets a lib
     // older than ES2022, so `Array.prototype.at` is not declared for it.
-    expect(reads[reads.length - 1].ast.where.created_date.$gte).toBe(floor);
+    const boundFloor = reads[reads.length - 1].ast.where.created_date.$gte;
+    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(boundFloor);
+    // …and it is a resolved DAY, not the placeholder surviving to the driver —
+    // the failure this positive control exists to catch.
+    expect(boundFloor).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  /**
+   * [#8937] The discriminating half of the floor assertion above.
+   *
+   * `toContain` against a resolver-derived value would also pass if the
+   * resolver were frozen, constant, or clock-blind — in which case the engine
+   * and the "source of truth" would agree on a wrong answer forever. These pins
+   * show the resolver's floor genuinely tracks the instant it is handed, so
+   * agreement with it is a real statement about the engine's clock.
+   */
+  it('resolves {30_days_ago} against the instant it is given, not a constant', () => {
+    const a = new Date('2026-03-10T12:00:00.000Z');
+    const b = new Date('2026-03-15T12:00:00.000Z');
+    // Two instants five days apart yield two DIFFERENT floors, five days apart.
+    expect(resolvedFloorAt(a)).toBe('2026-02-08');
+    expect(resolvedFloorAt(b)).toBe('2026-02-13');
+    expect(resolvedFloorAt(a)).not.toBe(resolvedFloorAt(b));
+    // A month/year boundary. Safe to write down because these are the
+    // resolver's INPUTS, not the wall clock: this case cannot rot on a date.
+    expect(resolvedFloorAt(new Date('2026-01-05T00:00:00.000Z'))).toBe('2025-12-06');
+    // With no instant supplied at all the resolver falls back to the process
+    // clock — the behaviour the engine relies on. Bracketed, not compared to a
+    // written-down day, so it holds across a UTC midnight too.
+    const before = new Date();
+    const fallback = resolveFilterTokens({ $gte: '{30_days_ago}' }, {}).$gte;
+    const after = new Date();
+    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(fallback);
+  });
+
+  /**
+   * [#8937] A CHARACTERIZATION pin, not an endorsement.
+   *
+   * `now` is not declared on `ExecutionContext` (neither the spec schema nor
+   * `ExecutionContextLike` in `@objectstack/core` carries it), and nothing on
+   * the engine's read path reads it — `filterTokenContextFrom` takes an
+   * explicit `now` argument the engine never passes. An injected `context.now`
+   * is therefore inert today, which is exactly what let a date-armed fixture
+   * look like it was pinning a clock.
+   *
+   * Recorded here so the trap is a stated, tested fact instead of a silent one.
+   * If #8937's open half lands — the engine gaining a declared, injectable
+   * clock — this pin SHOULD go red: delete it in that PR, deliberately.
+   */
+  it('does not honour an injected context.now today — the engine reads the process clock', async () => {
+    // An instant far from now: were it honoured, the floor would be near it.
+    const injected = new Date('2020-06-01T00:00:00.000Z');
+    const before = new Date();
+    await engine.find(
+      'support_case',
+      { where: { created_date: { $gte: '{30_days_ago}' } } },
+      { context: { now: injected } as never },
+    );
+    const after = new Date();
+
+    const boundFloor = reads[reads.length - 1].ast.where.created_date.$gte;
+    expect(boundFloor).not.toBe(resolvedFloorAt(injected));
+    expect([resolvedFloorAt(before), resolvedFloorAt(after)]).toContain(boundFloor);
   });
 
   it('refuses on both doors — the lowered object form and the authored array sugar', async () => {


### PR DESCRIPTION
Part of #8937

Stops the bleeding on the p0: from 2026-08-16T00:00Z `engine-temporal-comparand-door.test.ts` failed deterministically on every branch, blocking the merge queue for everyone. It deliberately does **not** decide the card's other half, so it does not close it — see "What this PR leaves open".

## What was actually wrong

The suite pinned its clock at `2026-08-15T09:00:00.000Z`, threaded it through the engine as `{ context: { now } as never }`, and asserted the `{30_days_ago}` floor equalled that instant minus 30 days. That held only while the real date and the fixture date agreed. It armed itself to fail the next day.

The clock it threaded does not exist:

- `now` is declared on **neither** `ExecutionContextSchema` (`@objectstack/spec`, `kernel/execution-context.zod.ts`) **nor** `ExecutionContextLike` (`@objectstack/core`, `utils/filter-tokens.ts`).
- Nothing on the engine read path reads it. `filterTokenContextFrom(execCtx, now?)` takes an explicit `now` **argument**, and `engine.resolveWhereTokens` never passes one — so `resolveFilterTokens` falls back to `new Date()`.
- The `as never` casts on those two call sites were the tell: TypeScript was already refusing the key.

The issue proposed limb 1 ("honour the injected `context.now`") on the grounds that the door's docblock "declares `now` among its context". That docblock sentence reads:

> `packages/core`'s `resolveFilterTokens` is field-AGNOSTIC by construction — its context is `now` / `timezone` / `userId` / `orgId` ...

"its" is **`resolveFilterTokens`'s** context — `FilterTokenResolutionContext`. The field names settle it: that list ends in `orgId`, which is `FilterTokenResolutionContext`; `ExecutionContextLike` spells the same concept `tenantId`, and `filterTokenContextFrom` is precisely the bridge between the two types. So honouring `context.now` would **add** a caller-injectable clock to the engine's public execution envelope, not restore a declared one.

## What this PR does

It pins the clock the engine **actually reads** — the process clock — using this package's established convention for exactly this, as used by `engine-cel-default-temporal-shape` and the three `engine-autonumber-*` suites:

```
vi.useFakeTimers({ toFake: ['Date'] });
vi.setSystemTime(now);
```

`toFake: ['Date']` leaves real timers alone, so the engine's async paths are untouched. With that in place the original readable assertion (`floor === '2026-07-16'`) is deterministic forever, and the written dates are honest again: they are what the code under test really sees. The `as never` context injection is gone from the positive control and from the refusal loop, where no clock can participate anyway.

Two companion cases keep the pin honest rather than merely green:

1. **`resolves {30_days_ago} against the instant it is given, not a constant`** — a pinned clock plus a written-down floor would *also* pass if the resolver ignored its instant and returned a constant. This shows two instants five days apart yield two floors five days apart, plus a month/year-boundary case. Its dates are resolver **inputs**, so nothing in it can rot.
2. **`does not honour an injected context.now today`** — a characterization pin, not an endorsement. It records the trap as a stated, tested fact instead of a silent one: an injected `now` five years off is ignored and the floor tracks the pinned process clock. If the engine ever gains a declared injectable clock this pin **should** go red — the docblock says to delete it in that PR, deliberately.

An earlier commit on this branch derived everything from the real clock with bracketed comparisons; it worked, but the fake-timer form matches local precedent, keeps the readable assertions, and needs no bracketing, so it supersedes that.

## What this PR leaves open — why `Part of`, not a closing keyword

Whether the engine should expose a declared, injectable clock is a **public-contract** question: it needs `now` on `ExecutionContextSchema` in `packages/spec` (which this card's dispatch scoped out), and it adds a new caller-settable surface to every data operation. I measured that it *would* work and that it would break no existing caller — zero producers of `context.now` exist, and the wire path `delete options.context` unconditionally, so no client could reach it. But "it works and breaks nothing" is not authority to widen a public contract, so it is escalated rather than guessed. Full three-axis analysis in the report on #8937.

Because that half is undecided, merging this must not close the card — hence `Part of`.

## Verification

All at commit `34c19e6`.

- Target file: **10 passed (10)** — was 1 failed / 7 passed. Green *today* (2026-08-16) while asserting a 2026-07-16 floor is itself the proof the process clock is overridden; under the old code today's real clock produced 2026-07-17.
- Full `@objectstack/objectql` suite: **211 files / 3697 tests passed**, up from 210 passed + 1 failed / 3694. `tsc --noEmit` clean.
- `TZ=Asia/Tokyo` (already the next local calendar day) — 10/10.
- Gate union re-derived from the changed path via `scripts/pm/dispatch-gates.mjs`, all green: `check-nul-bytes`, `check:durability-log-level`, `check-engine-split-ratio`, `check:query-options-erasure`, `check:type-check-coverage`, and `check:type-check-debt --re-measure` (33 ledger entries, none above its recorded number) on a fully built workspace closure.
- No runtime code changed, so there is no consumer sweep to run — the diff is one test file. `skip-changeset` applies and is on the PR.

One process note worth recording: while measuring limb 1 I built `@objectstack/core` with a probe, reverted the source, and re-ran — and the test went **green on the probe's stale `dist/`**, which would have certified the opposite conclusion. A source-level revert is not enough when the consumer resolves from `dist/`; the rebuild is part of the revert.

_Generated by [Claude Code](https://claude.ai/code/session_01Fgvh1iEJfxetei7aNVdtJt)_
