### PR TITLE
docs(deployment): promote Docker to the lead path in self-hosting

### DIFF
--- a/content/docs/deployment/self-hosting.mdx
+++ b/content/docs/deployment/self-hosting.mdx
@@ -1,13 +1,16 @@
 ---
 title: Self-Hosted Deployment
-description: Run a compiled ObjectStack app on your own infrastructure — bare Node.js, systemd, Docker, and Docker Compose with Postgres, including health checks, reverse-proxy wiring, and the secrets you must pin.
+description: Run a compiled ObjectStack app on your own infrastructure with the official Docker image — plus Compose with Postgres, Kubernetes, and the bare Node.js fallback, including health checks, reverse-proxy wiring, and the secrets you must pin.
 ---
 
 # Self-Hosted Deployment
 
 This guide takes the artifact produced by `os build` / `os compile` and runs it
-on infrastructure **you** operate: a Linux host, a Docker container, or a
-compose stack with Postgres. It assumes you have read
+on infrastructure **you** operate. **Docker is the standard path** — the
+platform publishes an official runtime image on every release, and Compose and
+Kubernetes are shapes of that same path rather than alternatives to it. Bare
+Node.js under systemd is the minority path, kept for hosts where a container
+runtime is not available or not permitted. It assumes you have read
 [Deployment Modes](/docs/deployment).
 
 The deployment model is deliberately simple:
@@ -46,54 +49,17 @@ OS_SECRET_KEY=$(openssl rand -hex 32)
 The full catalog is in
 [Environment Variables](/docs/deployment/environment-variables).
 
-## Option 1 — Bare Node.js (systemd)
+## Docker (official image) — the standard path
 
-The simplest deployment: Node 22+ and the CLI on a Linux host.
-
-```bash
-# On the host — no repo clone, just the CLI and your artifact
-npm install -g @objectstack/cli
-scp dist/objectstack.json server:/opt/my-app/objectstack.json
-```
-
-```ini title="/etc/systemd/system/my-app.service"
-[Unit]
-Description=My ObjectStack App
-After=network.target postgresql.service
-
-[Service]
-Type=simple
-User=objectstack
-WorkingDirectory=/opt/my-app
-Environment=NODE_ENV=production
-Environment=OS_ARTIFACT_PATH=/opt/my-app/objectstack.json
-Environment=OS_PORT=8080
-EnvironmentFile=/opt/my-app/secrets.env   # OS_DATABASE_URL, OS_AUTH_SECRET, OS_SECRET_KEY
-ExecStart=/usr/bin/os start
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-```
-
-```bash
-sudo systemctl enable --now my-app
-curl -fsS http://localhost:8080/api/v1/health
-```
-
-Upgrades are atomic: replace the artifact file and restart the service. Roll
-back by restoring the previous artifact.
-
-## Option 2 — Docker (official image)
-
-The artifact model maps cleanly onto containers, and ObjectStack ships an
-**official runtime image** for exactly this:
-`ghcr.io/objectstack-ai/objectstack` — Node 22 + `@objectstack/cli` +
-`os start`, running as a non-root user with a built-in health check and
-`OS_ARTIFACT_PATH` / `OS_PORT=8080` preset. Image tags mirror
-`@objectstack/cli` versions (`14.8.0`, `14.8`, `14`, `latest`) and the image
-is published multi-arch (amd64/arm64) on every framework release — **pin the
-exact version in production**, matching the CLI version in your
+The artifact model maps cleanly onto containers, and this is how the platform
+itself ships: ObjectStack builds and publishes an **official runtime image**
+on every framework release — `ghcr.io/objectstack-ai/objectstack`, Node 22 +
+`@objectstack/cli` + `os start`, running as a non-root user with a built-in
+health check and `OS_ARTIFACT_PATH` / `OS_PORT=8080` preset. Image tags mirror
+`@objectstack/cli` versions (`17.0.0`, `17.0`, `17`, `latest`) and the image is
+published multi-arch (amd64/arm64); the rolling `17.0` / `17` / `latest` tags
+move with every stable publish, while a prerelease gets only its exact tag.
+**Pin the exact version in production**, matching the CLI version in your
 `package.json`.
 
 The fastest path needs no image build at all — hand the official image your
@@ -107,7 +73,7 @@ docker run -p 8080:8080 \
   -e OS_DATABASE_URL="postgres://user:pass@db-host:5432/myapp" \
   -e OS_AUTH_SECRET \
   -e OS_SECRET_KEY \
-  ghcr.io/objectstack-ai/objectstack:14.8.0
+  ghcr.io/objectstack-ai/objectstack:17.0.0
 ```
 
 (`OS_ARTIFACT_PATH` also accepts an `https://` URL, so the artifact can come
@@ -125,7 +91,7 @@ docker run -p 8080:8080 \
   -e OS_ARTIFACT_URL="https://releases.example.com/hotcrm-2.2.2.json#sha256=<64 hex chars>" \
   -e OS_DATABASE_URL="postgres://user:pass@db-host:5432/myapp" \
   -e OS_AUTH_SECRET -e OS_SECRET_KEY \
-  ghcr.io/objectstack-ai/objectstack:14.8.0
+  ghcr.io/objectstack-ai/objectstack:17.0.0
 ```
 
 Both schemes work: `https://…` is fetched at boot, `file:///…` is read directly
@@ -176,7 +142,7 @@ COPY . .
 RUN npx os build              # → dist/objectstack.json
 
 # ── Runtime: the official ObjectStack runtime image ──────────────────
-FROM ghcr.io/objectstack-ai/objectstack:14.8.0
+FROM ghcr.io/objectstack-ai/objectstack:17.0.0
 COPY --from=build --chown=node:node /app/dist/objectstack.json /srv/app/objectstack.json
 ```
 
@@ -194,9 +160,12 @@ image)? The official image is nothing more than:
 
 ```dockerfile title="Dockerfile (self-built runtime, equivalent)"
 FROM node:22-slim
+RUN npm install -g @objectstack/cli@17.0.0
+
 WORKDIR /srv/app
-RUN npm install -g @objectstack/cli@14.8.0
-COPY dist/objectstack.json ./objectstack.json
+RUN chown node:node /srv/app
+USER node
+COPY --chown=node:node dist/objectstack.json ./objectstack.json
 
 ENV NODE_ENV=production \
     OS_ARTIFACT_PATH=/srv/app/objectstack.json \
@@ -204,7 +173,7 @@ ENV NODE_ENV=production \
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=15s \
-  CMD node -e "fetch('http://localhost:8080/api/v1/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+  CMD node -e "fetch('http://localhost:'+(process.env.OS_PORT||8080)+'/api/v1/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 CMD ["os", "start"]
 ```
@@ -216,9 +185,11 @@ auto-minted dev crypto key inside a container — it lives on the ephemeral
 filesystem and dies with it.
 </Callout>
 
-## Option 3 — Docker Compose with Postgres
+## Docker Compose with Postgres
 
-A complete single-host production stack:
+The same path with a database attached — `build: .` is the Dockerfile from the
+section above, so the app container is still the official runtime image with
+your artifact on top. A complete single-host production stack:
 
 ```yaml title="docker-compose.yml"
 services:
@@ -353,6 +324,48 @@ readiness probe drains the replica while the database is away and re-admits it
 afterwards. Restart only when the process is genuinely stuck, and note that a
 replica which *booted* without its database never re-runs its schema sync.
 </Callout>
+
+## Bare Node.js (systemd) — without containers
+
+The minority path, and a deliberate one: reach for it when the host has no
+container runtime available or permitted, when an existing systemd /
+configuration-management estate already owns process supervision, or when you
+are debugging directly on the box. It needs Node 22+ and the CLI on a Linux
+host, and nothing else.
+
+```bash
+# On the host — no repo clone, just the CLI and your artifact
+npm install -g @objectstack/cli
+scp dist/objectstack.json server:/opt/my-app/objectstack.json
+```
+
+```ini title="/etc/systemd/system/my-app.service"
+[Unit]
+Description=My ObjectStack App
+After=network.target postgresql.service
+
+[Service]
+Type=simple
+User=objectstack
+WorkingDirectory=/opt/my-app
+Environment=NODE_ENV=production
+Environment=OS_ARTIFACT_PATH=/opt/my-app/objectstack.json
+Environment=OS_PORT=8080
+EnvironmentFile=/opt/my-app/secrets.env   # OS_DATABASE_URL, OS_AUTH_SECRET, OS_SECRET_KEY
+ExecStart=/usr/bin/os start
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable --now my-app
+curl -fsS http://localhost:8080/api/v1/health
+```
+
+Upgrades are atomic: replace the artifact file and restart the service. Roll
+back by restoring the previous artifact.
 
 ## Reverse proxy & TLS
 


### PR DESCRIPTION
Fixes #8911

Docker is not one option among three — it is how the platform ships. `docker/Dockerfile` and `.github/workflows/docker-publish.yml` build and publish `ghcr.io/objectstack-ai/objectstack` on every framework release; the page's ordering told a new reader the opposite, and ordering is the strongest signal a docs page has.

This is the re-framing the card asked for, not a rewrite. Prose that was already correct is left alone.

## What changed — one file, `content/docs/deployment/self-hosting.mdx`

- **Docker leads.** `## Option 2 — Docker (official image)` becomes `## Docker (official image) — the standard path` and moves to the front of the deployment paths. The `Option 1/2/3` peer numbering is gone from all three headings — that numbering was the thing asserting they were equals.
- **Compose and Kubernetes are shapes of the same path.** Compose gains one lead-in sentence tying `build: .` back to the Dockerfile in the section above; the Kubernetes subsection already opened with "The same image works unchanged" and is untouched.
- **Bare Node.js is demoted, not deleted.** It moves after the Docker family and opens with a new sentence on when it is genuinely the right choice (no container runtime available or permitted, an existing systemd / configuration-management estate, debugging directly on the box). **Its body is byte-identical across the move** — `git hash-object` reads `e48b3aed70947447d4d21e3373b4f6cffcef8129` on both sides.
- **Intro paragraph and frontmatter description** re-ordered to match. The `It assumes you have read…` sentence that #8947 rewrote is preserved exactly as it landed.
- **`OS_ARTIFACT_URL` stays on this page**, unchanged, as Axis A operational detail. Its heading text is deliberately untouched: `environment-variables.mdx`, `cli.mdx` and `docker/Dockerfile` all point at the `#artifact-pinned-boot-os_artifact_url` anchor.

## Image facts, verified from the tree

Per the card, no image reference was copied out of the existing prose.

| Claim in the prose | Checked against | Verdict |
|---|---|---|
| Registry and name `ghcr.io/objectstack-ai/objectstack` | `docker-publish.yml` `IMAGE:`, `docker/Dockerfile` header | correct |
| Tag ladder: exact / major.minor / major / `latest` | `docker-publish.yml` `metadata-action` `tags:` | correct |
| `latest` only on stable publishes | `enable=${{ !contains(version, '-') }}` | correct — now stated in the prose |
| Published multi-arch | `platforms: linux/amd64,linux/arm64` | correct |
| non-root user, health check, `OS_ARTIFACT_PATH` / `OS_PORT=8080` preset | `docker/Dockerfile` | correct |
| **Example version `14.8.0`** | `packages/cli/package.json` is **17.0.0** | **stale — fixed** |

`14.8.0` appeared five times while the CLI is at 17.0.0 (GA'd 2026-08-14, per `content/docs/releases/v17.mdx`) — three majors stale, in what this PR makes the lead position, which is the failure the card called out as worse than the ordering itself. All five now read `17.0.0`.

### One bounded in-place fix, named with its evidence

The `Dockerfile (self-built runtime, equivalent)` block claimed equivalence with the official image while omitting two things `docker/Dockerfile` actually does: it ran as root (missing `RUN chown node:node /srv/app` and `USER node`, source lines 52-53) and hard-coded `8080` in the health check where the real one reads `process.env.OS_PORT||8080` (source line 63). Same defect class as the card (Docker prose drifted from the tree), mechanical, correct form pinned verbatim by the source file, no other claim on this file, same gate families. Fixed here rather than filed, because the prose two paragraphs above advertises non-root as a property of the image being described.

## Verification

Gates run at `e9a250f`, the final commit:

- `pnpm check:docs-audit-scope` — scope in sync with `content/docs/`, 177 hand-written docs; release-owned pages review-only
- `pnpm check:role-word` — 43 baselined files, no new occurrences (this page has zero and is not baselined)
- `pnpm check:nul-bytes` — 5935 text files scanned, no raw ASCII control bytes

The set was re-derived against the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/deployment/self-hosting.mdx`, which returns exactly `check:docs-audit-scope` and `check:role-word`; `check:nul-bytes` is the any-edit convention. No links were added or removed, and the only inbound-linked anchor on this page is preserved.

Docs-only, no user-visible package change — `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_