### PR TITLE
docs: MISSING_REQUIRED_FIELD answers 422 without fields on the surviving controlled_by_parent refusals

### DIFF
--- a/content/docs/api/error-catalog.mdx
+++ b/content/docs/api/error-catalog.mdx
@@ -86,8 +86,47 @@ substitute. See the [Data API](/docs/api/data-api).
 
 ### `MISSING_REQUIRED_FIELD`
 **Cause:** A required field was not provided in the request body.  
-**Fix:** Include the missing field. Check `fields` for the field name.  
+**Fix:** Include the missing field. Check `fields` for the field name — **except** on the
+`controlled_by_parent` master-reference paths below, where the status is `422` and no
+`fields` array is sent; read the field name out of the message there.  
 **Retry:** `no_retry`
+
+<Callout type="warn">
+**`MISSING_REQUIRED_FIELD` is `400` with one exception: an absent `controlled_by_parent`
+master reference answers `422`, without `fields`.**
+
+An object whose `sharingModel` is `controlled_by_parent` derives its access from a master
+record, so the gate authorizing writes to it resolves that master *before* the executor —
+and the executor is where required-field validation runs. Which of the two refuses first
+depends on how the master reference is declared. A `master_detail` that is `required` and
+neither `readonly` nor `system` reaches validation and answers the documented
+`400 VALIDATION_FAILED` with `fields`. The other four declarable shapes never reach it and
+answer `422 MISSING_REQUIRED_FIELD` with no `fields`:
+
+- a `master_detail` with no `required`
+- a `master_detail` that is `required` + `readonly`
+- a `master_detail` that is `required` + `system`
+- a `required` `lookup`, when the object declares no `master_detail`
+
+The full matrix is on the protocol page:
+[`MISSING_REQUIRED_FIELD`](/docs/protocol/kernel/error-handling#missing_required_field).
+
+An update or delete **by id** whose *stored* master reference is null answers the same
+`422`, whatever the declaration — the caller sent no such field, so nothing could be named
+in `fields` and no payload would fix it.
+
+The refusal itself is correct and is not going to be relaxed: on those four shapes
+required-field validation does not fire (it skips `system` and `readonly` fields before its
+required check, and never fires on a field that is not `required`), so the gate is the only
+thing standing between the request and a detail record with a null master reference — which
+the `controlled_by_parent` read filter (`fk IN (readable masters)`) can never match, leaving
+a record readable by nobody.
+
+These shapes are **authorable today**: lint reports a `master_detail` without `required` as
+a warning only, and does not report the `readonly`, `system`, or fallback-`lookup` shapes at
+all. **Branch on `code`, treat `fields` as optional, and read the status off the response**
+rather than deriving it from the table at the end of this page.
+</Callout>
 
 ### `INVALID_FORMAT`
 **Cause:** Field value does not match the expected format (e.g., invalid email, wrong date format).  
@@ -632,6 +671,7 @@ async function handleApiCall() {
 | 403 | `authorization` | `PERMISSION_DENIED`, `FIELD_NOT_ACCESSIBLE`, `LICENSE_REQUIRED` |
 | 404 | `not_found` | `RECORD_NOT_FOUND`, `OBJECT_NOT_FOUND`, `ENDPOINT_NOT_FOUND` |
 | 409 | `conflict` | `CONCURRENT_MODIFICATION`, `DUPLICATE_RECORD`, `DELETE_RESTRICTED` |
+| 422 | `validation` | `MISSING_REQUIRED_FIELD` on an absent `controlled_by_parent` master reference (see [above](#missing_required_field)) — this row is an exception to the 400 row, not a second home for the code |
 | 429 | `rate_limit` | `RATE_LIMIT_EXCEEDED`, `QUOTA_EXCEEDED` |
 | 500 | `server` | `INTERNAL_ERROR`, `DATABASE_ERROR`, `TIMEOUT` |
 | 502 | `external` | `EXTERNAL_SERVICE_ERROR`, `INTEGRATION_ERROR` |

--- a/content/docs/protocol/kernel/error-handling.mdx
+++ b/content/docs/protocol/kernel/error-handling.mdx
@@ -90,7 +90,7 @@ ObjectStack uses standard HTTP status codes:
 | **403** | Forbidden | Authenticated but insufficient permissions |
 | **404** | Not Found | Resource doesn't exist |
 | **409** | Conflict | Resource already exists or version mismatch |
-| **422** | Unprocessable Entity | Semantic validation failed (e.g. metadata spec validation) |
+| **422** | Unprocessable Entity | Semantic validation failed (e.g. metadata spec validation); also an absent `controlled_by_parent` master reference — see [`MISSING_REQUIRED_FIELD`](#missing_required_field) |
 | **429** | Too Many Requests | Rate limit exceeded |
 | **500** | Internal Server Error | Server-side error |
 | **503** | Service Unavailable | Server overloaded or maintenance |
@@ -244,7 +244,7 @@ if (error.code === 'VALIDATION_ERROR') {
 ```
 
 #### `MISSING_REQUIRED_FIELD`
-**HTTP Status:** 400  
+**HTTP Status:** 400 — with one documented exception, which answers **422** (see below)  
 **Meaning:** Required field is missing
 
 **Example:**
@@ -261,6 +261,45 @@ if (error.code === 'VALIDATION_ERROR') {
   }
 }
 ```
+
+**Exception — an absent `controlled_by_parent` master reference answers 422 with no `fields`.**
+An object whose `sharingModel` is `controlled_by_parent` derives its access from a master
+record, so the gate that authorizes writes to it must resolve that master *before* the
+executor runs — and the executor is where required-field validation lives. When the master
+reference is absent, whichever of the two refuses first decides the envelope, and that
+depends on how the reference is declared:
+
+| Master reference declared as | Refused by | Status | `code` | `fields` |
+|---|---|:---:|---|:---:|
+| `master_detail` + `required`, not `readonly`/`system` | required-field validation | 400 | `VALIDATION_FAILED` | yes |
+| `master_detail` with no `required` | the master-access gate | **422** | `MISSING_REQUIRED_FIELD` | **absent** |
+| `master_detail` + `required` + `readonly` | the master-access gate | **422** | `MISSING_REQUIRED_FIELD` | **absent** |
+| `master_detail` + `required` + `system` | the master-access gate | **422** | `MISSING_REQUIRED_FIELD` | **absent** |
+| a `required` `lookup`, when the object declares no `master_detail` | the master-access gate | **422** | `MISSING_REQUIRED_FIELD` | **absent** |
+
+Only the first row is the documented 400 shape. On the other four, messages are prefixed
+`[Security] Missing master reference:` and name the object and the field, but no `fields`
+array rides along.
+
+The same `422 MISSING_REQUIRED_FIELD` also answers an update or delete **by id** whose
+*stored* master reference is null, whatever the declaration. That is a different path: the
+caller supplied no such field, so there is no request field to name in `fields` and no
+payload that would fix it.
+
+**Why the gate refuses rather than handing over.** Required-field validation skips
+provenance-flagged fields before its required check is reached (`system` and `readonly`
+fields are skipped outright) and never fires on a field that is not `required` at all. On
+those four shapes the gate is the only thing refusing the write, and letting it through was
+measured to create a detail record whose master reference is null — a record the
+`controlled_by_parent` read filter (`fk IN (readable masters)`) can never match, so it is
+readable by nobody and answers 422 on every later write by id. The refusal is correct; only
+its status departs from the rule above.
+
+**These shapes are authorable today.** Publish-time lint reports a `master_detail` without
+`required` as a *warning* (`relationship/master-detail-required`), and does not report the
+`readonly`, `system`, or fallback-`lookup` shapes at all — so a stack can publish clean and
+still reach the 422. Branch on `code`, and read the status off the response rather than
+deriving it from this page.
 
 #### `INVALID_FIELD`
 **HTTP Status:** 400  


### PR DESCRIPTION
Fixes #8880

Docs-only. Direction 1 of the card, per the maintainer ruling of 2026-08-15: the docs state the exception where it exists and name why the gate answers 422 there. No runtime edits — direction 2 (moving the wire to 400) was declined, and direction 3 (a catalog vs. runtime status conformance gate) stays its own card.

## The mismatch, re-measured on this branch's base

`MISSING_REQUIRED_FIELD` is documented as HTTP 400 carrying `fields`, while `assertControlledByParentWrite` answers `422 MISSING_REQUIRED_FIELD` with no `fields` on four declarable shapes. I verified each half from source rather than taking the card's summary:

**The four shapes** come from `resolveCbpRelation` (`packages/plugins/plugin-security/src/security-plugin.ts`), which sets the one bit the stand-down turns on:

```ts
omissionRefusedByValidation:
  def?.type === 'master_detail' && !!def?.required && !def?.readonly && !def?.system,
```

So the hand-over to `400 VALIDATION_FAILED` happens only for a `master_detail` that is `required` and neither `readonly` nor `system`. The 422 survives for: a `master_detail` with no `required`; `required` + `readonly`; `required` + `system`; and a `required` `lookup` resolved through the third fallback. All four are pinned in `controlled-by-parent-sharing.test.ts` on `err.status` / `err.statusCode` 422. The stored-row case (an update or delete by id whose persisted FK is null) travels the non-insert branch and keeps the same envelope.

**The 422 and the absent `fields` are confirmed at the door, not assumed.** `MasterReferenceMissingError` declares `code = 'MISSING_REQUIRED_FIELD'`, `status = 422`, `statusCode = 422` (`errors.ts`); `declaredHttpStatus` in `packages/rest/src/error-response.ts` reads `status` then `statusCode`, and its 4xx passthrough arm emits `{ error, code, object }` — no `fields`. `fields` is emitted only for the `VALIDATION_FAILED` duck-type, which this error is not. Both halves of the card check out.

## One claim from the card that I did NOT repeat

The card, the landed #8879 changeset, and two source comments all state that #8772's publish-time lint refuses these shapes, "so newly authored metadata cannot reach them". **That is not true today.** #8772 is still open, `relationship/master-detail-required` is `severity: 'warning'` (`packages/lint/src/data-model-rules.ts:491-499`), and no rule covers the `readonly`, `system`, or fallback-`lookup` shapes at all. Writing that bound into the docs would have documented a guarantee that does not exist, so the pages say instead that these shapes are authorable today. Filed separately as #8959 (sub-issue of #8772) — the stale claim is in landed source comments and a release-note-bound changeset, which is a runtime-adjacent fix and out of scope here.

Related to the same honesty point: nothing mechanically pins either side of this branch, so both pages tell clients to branch on `code` and read the status off the response rather than deriving it from a table.

## Changes

- `content/docs/protocol/kernel/error-handling.mdx` — the `MISSING_REQUIRED_FIELD` entry carries the exception, the full five-row matrix (which shape is refused by which subsystem, with status, code and whether `fields` rides along), why the gate refuses rather than handing over (the measured fail-open alternative), and the authorable-today note. The 422 row of the HTTP status table now points at it.
- `content/docs/api/error-catalog.mdx` — the entry's "Check `fields` for the field name" line is qualified, a `Callout` carries the same exception in list form, and the status quick reference gains a 422 row marked as an exception to the 400 row rather than a second home for the code. The matrix itself lives in one place only (the protocol page, linked) — duplicating it across two files is the drift this card is about.

## Verification

Gate union run **after** the final commit, at `8ead907cd`:

```
pnpm check:docs-audit-scope   ✓ scope in sync with content/docs/: 177 hand-written doc(s)
pnpm check:role-word          ✓ OK (43 baselined file(s), no new occurrences)
pnpm check:nul-bytes          ✓ OK (scanned 5935 text file(s); no raw ASCII control bytes)
pnpm check:error-code-casing  ✓ no lowercase error codes in 4119 scanned file(s)
```

Re-derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs` — it returns exactly `check:docs-audit-scope` and `check:role-word` for `content/docs`, adding nothing; `check:nul-bytes` and `check:error-code-casing` were run as the convention-scoped pair. No package builds or tests are implicated: no source file changed.

Anchor and cross-doc link forms were checked against real precedents in the tree (`#letting-a-delegate-invite-delegated_admin` confirms underscores survive slugification; `/docs/protocol/kernel/...` confirms the cross-page path). The exception is rendered as a list rather than a table inside the `Callout`, since no existing `Callout` in `content/docs` contains a markdown table.

`skip-changeset`: docs-only, nothing releasable.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_