### PR TITLE
docs(skills): remove stale templates repo pointer from README

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -112,6 +112,3 @@ A few common decision points where the right skill isn't obvious:
 ## Related repositories
 
 - [`../objectui`](https://github.com/objectstack-ai/objectui) — Studio UI (separate repo).
-- [`../templates`](https://github.com/objectstack-ai/templates) — template library
-  consumed by `create-objectstack` (separate repo). Scaffolds reference these
-  skills; keep this index in sync when adding or renaming a skill.


### PR DESCRIPTION
Fixes #8694

## What changed

`skills/README.md`, under **Related repositories**, listed
`objectstack-ai/templates` as a "template library consumed by
`create-objectstack`". Both halves were false: the repository was
delisted from the official marketplace and is no longer maintained
(maintainer, 2026-08-14: 「已经从官方应用市场下架了，停止维护了」), and
#8693 (merged) removed the tarball-fetch consumption path from
`create-objectstack` — nothing in this repo consumes that repository
anymore.

## Fix

Removed the `../templates` bullet entirely (docs-only, `skills/README.md`
lines 115-117 at branch point). Verified stale at the fetched head
(`b50c0ef27`) before editing.

The bullet's trailing half-sentence — "Scaffolds reference these
skills; keep this index in sync when adding or renaming a skill" — was
removed along with it rather than kept standalone: its whole rationale
was that `create-objectstack` scaffolds referenced skill names from
this repo, which is no longer true now that the consumption path is
gone. Nothing else currently reads this "Related repositories" list in
a way that "keep in sync" would still be actionable advice for. The
remaining `../objectui` entry is untouched and still accurate.

Scope stops at this entry — the issue's on-card audit already reviewed
the other historical, past-tense references to `objectstack-ai/templates`
(`docs/PLATFORM_GAPS_FROM_TEMPLATES.md`, a comment in
`packages/create-objectstack/src/rewrite-identity.ts`, and a comment in
`packages/runtime/src/sandbox/nested-write-real-sqlite.integration.test.ts`)
and found them fine as-is; none of those are touched here.

## Verification

- `node scripts/pm/dispatch-gates.mjs skills/README.md` — no `check:*`
  family names this path directly (the doc-scoped families
  `check:doc-authoring`/`check:doc-anchors`/`check:docs-audit-scope`
  scope to `content/docs/` and `.claude/`/`SKILL.md` frontmatter, not
  `skills/README.md` prose).
- `pnpm check:nul-bytes` — green (`check-nul-bytes: OK`, 5936 tracked
  text files scanned, no raw control bytes).
- Head at time of this verification run: `56064bca8`.

## ADR-class — awaits manual merge

`skills/**` is a skill root; per the maintainer's standing ADR-class
rule for this surface, this PR is **not** auto-mergeable and is left
as a draft, visibly awaiting a human merge. Please do not flip it to
ready or add it to the merge queue on my behalf.

## Changeset

Docs-only prose fix with no package release surface — no
`.changeset/*.md` added; will apply the `skip-changeset` label once
the PR exists.

_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_