### PR TITLE
chore(devx): lower @objectstack/lint TEST_DEBT to its measured 19 and re-tally its note (#8728)

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -209,25 +209,49 @@
 //               2026-08-06 on the objectql case: two back-to-back runs were
 //               byte-identical, so this gate has no known nondeterminism.
 //
-//               BOOTSTRAP MARGINS (#5278 option A). The two paragraphs above
-//               describe a race that the exact-calibration loop lost five times
-//               running -- objectql 333 -> 334 -> 335 -> 339 and lint 30 -> 32,
-//               each calibration stale within minutes of being pushed, while
-//               seven unrelated PRs were kicked from the queue as collateral.
-//               The maintainer's ruling was to land the invariant with a
-//               DOCUMENTED margin on the packages that proved hottest rather
-//               than run a sixth lap: `@objectstack/objectql`,
-//               `@objectstack/lint`, `@objectstack/rest`,
-//               `@objectstack/service-storage` and `@objectstack/mcp` are
-//               recorded at their measurement PLUS TEN, and each says so in its
-//               own note, naming the measured number and the sha. This is the
-//               ledger's ONLY
-//               slack and it is deliberately loud: nothing else here may sit
-//               above its measurement, and a margin is not a place to hide a
-//               real increase. Because shrinkage is informational, each of the
-//               five prints its own `ℹ ... can be lowered` line on every run --
-//               that line IS the tightening worklist, and closing it is a
-//               follow-up PR, not a thing to leave running for months.
+//               BOOTSTRAP MARGINS (#5278 option A) -- ALL FIVE PAID OFF, kept
+//               here because the shape is what the next hot landing will want.
+//               The two paragraphs above describe a race that the
+//               exact-calibration loop lost five times running -- objectql
+//               333 -> 334 -> 335 -> 339 and lint 30 -> 32, each calibration
+//               stale within minutes of being pushed, while seven unrelated PRs
+//               were kicked from the queue as collateral. The maintainer's
+//               ruling was to land the invariant with a DOCUMENTED margin on the
+//               packages that proved hottest rather than run a sixth lap:
+//               `@objectstack/objectql`, `@objectstack/lint`,
+//               `@objectstack/rest`, `@objectstack/service-storage` and
+//               `@objectstack/mcp` were recorded at their measurement PLUS TEN,
+//               each saying so in its own note with the measured number and sha.
+//
+//               ⚠️ NONE OF THE FIVE CARRIES THAT SLACK TODAY. The roster above is
+//               the ruling's, not a current inventory, and reading it as one is
+//               the mistake this paragraph exists to stop. Four were tightened
+//               onto their exact measurement: rest 163 -> 155 (#6939 / #7038,
+//               PR #7248), then lint 42 -> 20, mcp 63 -> 53 and
+//               service-storage 52 -> 51 in one sweep (#7888 / PR #8225), with
+//               lint going 20 -> 19 in #8728. The fifth was never lowered and did
+//               not need to be: objectql's RECORDED 355 is untouched and now
+//               MEASURES 355 exactly, so its +10 was spent by real growth rather
+//               than handed back. Both routes end in the same place, and it is
+//               the intended one -- every entry in both ledgers now sits at its
+//               measurement, so the next new error anywhere is red on arrival.
+//
+//               A margin remains the ledger's ONLY sanctioned slack, and it is
+//               deliberately loud: nothing here may sit above its measurement,
+//               and a margin is not a place to hide a real increase. Because
+//               shrinkage is informational, any entry above its measurement
+//               prints its own `ℹ ... can be lowered` line on every run -- that
+//               line IS the tightening worklist, and closing it is a follow-up
+//               PR, not a thing to leave running for months. Re-establishing a
+//               margin deliberately is still available and is a maintainer call,
+//               exactly as raising any ceiling is.
+//
+//               ⚠️ Two of the five notes -- mcp and service-storage -- still
+//               narrate their margin in the present tense ("RECORDED 63 is a
+//               bootstrap margin") against an `errors` that no longer carries
+//               one. Stale narration, not stale arithmetic: both `errors` are
+//               the measured values named above. Left to their own cards rather
+//               than rewritten from #8728, which is scoped to the lint entry.
 //
 //               The margins were not a precaution; two of the first four were
 //               paid out inside a single hour of the landing flight. objectql
@@ -710,14 +734,25 @@ const TEST_DEBT = {
   },
   '@objectstack/lint': {
     errors: 19,
-    note: 'TS7006 x22, TS2835 x6, TS6059 x4. Measured 26 -> 30 (5ab08428, the +4 being TS6059, a file '
-      + 'outside rootDir, a class the pre-#5278 note did not list) -> 32 (e8db1a230). The latest +2 are '
-      + 'both TS7006 and both in files that already existed; three lint test files changed in this window '
-      + '(#5762 / PR #5952, #5378 / PR #5904) and the pre-merge per-file counts were not retained, so the '
-      + 'delta is recorded rather than attributed. 10 of the 32 sit in '
-      + 'src/validate-visibility-predicates.test.ts. RECORDED 42 is a bootstrap margin (+10 over 32 '
-      + 'measured at e8db1a230 and re-confirmed at 32 an hour later at 77c7c884b) -- tighten via the ℹ '
-      + 'hint immediately after landing (#5278 option A).',
+    note: 'TS7006 x11, TS2835 x5, TS6059 x3, re-tallied from tsc at the 19 below -- not the older '
+      + 'composition rescaled. Per file: src/validate-semantic-roles.test.ts x5, '
+      + 'src/validate-dashboard-action-refs.test.ts x4, src/validate-translatable-sections.test.ts x3, '
+      + 'src/validate-filter-tokens.test.ts x3, src/validate-capability-references.test.ts x3, '
+      + 'src/validate-managed-api-methods.test.ts x1. The 5 TS2835 are one per file and all the same '
+      + "shape -- the test's own relative import of the module under test, missing its `.js`. All 3 "
+      + 'TS6059 sit in validate-translatable-sections.test.ts, which still imports contact.object.ts, '
+      + 'contact.view.ts and system/translations/index.ts from examples/app-showcase. '
+      + 'Measured 26 -> 30 (5ab08428, the +4 being TS6059, a file outside rootDir, a class the pre-#5278 '
+      + 'note did not list) -> 32 (e8db1a230), and RECORDED 42 was a bootstrap margin (+10 over that 32). '
+      + 'THE MARGIN IS GONE, and has been since #7888 / PR #8225 lowered 42 -> 20 against a measured 20 at '
+      + 'b5e09b21 -- that PR deliberately left this note describing the larger pile, because inventing a '
+      + 'composition for errors that are gone is the one thing this ledger forbids, so the tally above is '
+      + 'the first one taken at the size the entry actually is. Lowered 20 -> 19 at 585edf738 (#8728). '
+      + 'The -1 is attributed: #8515 / PR #8610 moved the translation-section-name-missing pins onto the '
+      + 'frozen src/showcase-shape.fixtures.ts snapshot and dropped the live `TaskViews` import, which is '
+      + 'the TS6059 that left -- the surviving three name exactly the three example files those tests '
+      + 'still import. One older claim is now false and is corrected rather than carried: '
+      + 'src/validate-visibility-predicates.test.ts held 10 of the 32 and reports none today.',
   },
   '@objectstack/plugin-security': { errors: 11, note: 'TS2739 x8, TS2740 x5, TS2345/TS2322/TS2741 x2 each -- incomplete literals. Re-measured 21 at 5ab08428, up from 20, and still 21 at e8db1a230 after the package gained a test file -- the file count moved, the error count did not (which is why the file count is derived here rather than written down, #5826).' },
   '@objectstack/formula': { errors: 17, note: 'TS2591 x6 (`process`), TS2345 x3, TS2352 x3, TS1470 x2, TS2339 x2. Re-measured 17 at 5ab08428, up from 12; the TS2591 half doubled, which is the missing `types:["node"]` again rather than five new defects.' },

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -709,7 +709,7 @@ const TEST_DEBT = {
       + "so none of the -33 is this PR's doing.",
   },
   '@objectstack/lint': {
-    errors: 20,
+    errors: 19,
     note: 'TS7006 x22, TS2835 x6, TS6059 x4. Measured 26 -> 30 (5ab08428, the +4 being TS6059, a file '
       + 'outside rootDir, a class the pre-#5278 note did not list) -> 32 (e8db1a230). The latest +2 are '
       + 'both TS7006 and both in files that already existed; three lint test files changed in this window '


### PR DESCRIPTION
Fixes #8728

`@objectstack/lint`'s `TEST_DEBT` entry recorded **20** where tsc measures **19**. Lowered
via the gate's own affordance, and the entry's `note` — stale in *both* the number it
claimed to explain and the pile it described — re-tallied from a fresh measurement rather
than rescaled.

Diff is one `errors:` digit, one rewritten `note`, and one corrected comment block. No
package source changes.

## Measured, and reproducible

Base `585edf738`, closure built exactly as `lint.yml` builds it
(`pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 tasks
successful, exit 0):

```
ℹ @objectstack/lint: TEST_DEBT records 20, tsc now reports 19 (-1) -- the entry can be lowered.

check-type-check-coverage --lower: 1 ledger entr(ies) lowered to their measurement.
  ↓ TEST_DEBT @objectstack/lint: 20 -> 19
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 213.1s,
1926 raw tsc error(s) total, none above its recorded number.
```

**Exactly one entry moved** — `--lower` reported one lowering and the diff is one digit.
The 33 entries / 1926 raw errors independently reproduce the reading recorded on the
now-closed duplicate #8922 (taken at `f9811727d`, 211.5s, 1926 raw) on a **different head**.
That is the bar the 2026-08-08 non-reproducibility incident sets for any number that carries
a policy: three readings of this very entry — 19, 39 and 147 — were in circulation in one
day, all from unbuilt closures.

## The note was wrong by 22, not just out of date

The card called the `note` stale in its composition. It was worse: it ended
`RECORDED 42 is a bootstrap margin (+10 over 32 ...)` beside an `errors` field reading
**20**, and its stated composition (`TS7006 x22, TS2835 x6, TS6059 x4`) summed to **32**.

Attributed, not guessed: **#7888 / PR #8225** lowered this entry 42 to 20 against a measured
20 at `b5e09b21`, and that PR states it deliberately left the note describing the larger pile
because "inventing a composition for errors that are gone is the one thing this ledger's own
rules forbid". So the note has been describing a 32-error pile through two tightenings. The
tally below is the first one taken at the size the entry actually is.

| | old note | measured now |
|---|---:|---:|
| TS7006 | 22 | 11 |
| TS2835 | 6 | 5 |
| TS6059 | 4 | 3 |
| **total** | **32** | **19** |

Per file: `validate-semantic-roles.test.ts` x5, `validate-dashboard-action-refs.test.ts` x4,
`validate-translatable-sections.test.ts` x3, `validate-filter-tokens.test.ts` x3,
`validate-capability-references.test.ts` x3, `validate-managed-api-methods.test.ts` x1.

The old note's claim that "10 of the 32 sit in `src/validate-visibility-predicates.test.ts`"
is now false — that file reports **none** — and is corrected rather than carried forward.

### The −1 is attributed

#8515 / PR #8610 dropped exactly one live import from
`validate-translatable-sections.test.ts`:

```
-import { TaskViews } from '../../../examples/app-showcase/src/ui/views/task.view.js';
```

while keeping the other three. That is the TS6059 that left: the surviving three name
`contact.object.ts`, `contact.view.ts` and `system/translations/index.ts` — exactly the three
example files those tests still import. Nothing here is recorded as unattributed.

## The bootstrap-margin block was stale too, and that mattered more

The top-of-ledger `BOOTSTRAP MARGINS` block still enumerated five packages as "recorded at
their measurement PLUS TEN, and each says so in its own note". **None of the five carries
that slack today** — verified against this run, not recalled:

| package | recorded | status |
|---|---:|---|
| `@objectstack/rest` | 155 | tightened 163 to 155 (#6939 / #7038, PR #7248) |
| `@objectstack/lint` | 19 | 42 to 20 (#7888 / PR #8225), 20 to 19 here |
| `@objectstack/mcp` | 53 | tightened 63 to 53 (#7888 / PR #8225) |
| `@objectstack/service-storage` | 51 | tightened 52 to 51 (#7888 / PR #8225) |
| `@objectstack/objectql` | 355 | never lowered — **measures 355 exactly**, so its +10 was spent by real growth |

This is the block documenting the ledger's *only* sanctioned slack, so a roster naming five
packages where the tree supports none is the more consequential of the two staleness bugs.
It is rewritten to keep the ruling's history and roster while stating plainly that it is not
a current inventory. The final `--re-measure` confirms the end state the block now claims:

```
surplus: none — every entry sits exactly at its measurement, so any new error is red.
```

## Why now rather than someday

While the gap was open, `@objectstack/lint`'s test layer had exactly **one error of free
headroom** — nothing else reads that layer, so a genuine new type error there landed green.
#6376 is the precedent the gate itself cites: driver-mongodb's 33 swallowed an entire
signature reversion.

## Verification

All gates run at final commit `81acf6f1f`, the head this PR pushes:

- `pnpm check:type-check-debt` — **green**. `33 ledger entr(ies) re-measured in 212.3s, 1926
  raw tsc error(s) total, none above its recorded number` and `surplus: none`.
- `pnpm check:type-check-coverage` — **green**. Self-test: 23 semantic + 24 observation + 25
  re-measure + 28 built-closure + 9 auto-lowering cases hold.
- `pnpm check:nul-bytes` — **green** (5935 text files, no raw control bytes). Explicit
  control-character self-scan over the changed file also clean.
- Gate list re-derived against the actual changed path via
  `node scripts/pm/dispatch-gates.mjs scripts/check-type-check-coverage.mjs`: it returns
  these same two families and adds none.

No changeset: `scripts/` is not published package source, so this releases nothing and the
PR carries `skip-changeset`.

## Out of scope — reported, not touched

Two of the five margin notes still narrate a margin in the present tense against an `errors`
field that no longer carries one — `@objectstack/mcp` ("RECORDED 63 is a bootstrap margin")
and `@objectstack/service-storage` ("RECORDED 52"). Stale narration, not stale arithmetic:
both `errors` values are their exact measurements. Same defect class as this card, left to
their own cards because this one is scoped to the lint entry; the corrected block names them
so the next reader is not misled meanwhile. Flagged for the PM to file.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_