### PR TITLE
docs(plugin-security): state the controlled_by_parent residue bound in the mood that is true

### DIFF
--- a/.changeset/cbp-missing-master-insert-validation-envelope.md
+++ b/.changeset/cbp-missing-master-insert-validation-envelope.md
@@ -60,10 +60,16 @@ mint a detail row with a null master FK, which the `controlled_by_parent` read
 filter (`fk IN (readable masters)`) can never match — readable by nobody, and
 answering `422` on every later by-id write.
 
-**So the envelope asymmetry is not gone, it is confined**, to precisely the
-shapes #8772's lint now refuses at publish time. An app that publishes cleanly
-sees one envelope; an app still carrying one of those declarations sees the old
-one until it is republished. One further residual, narrower still: a
+**So the envelope asymmetry is not gone, it is confined** — to precisely those
+three declarations, and no further. But confined is not unreachable: #8772
+*proposes* a publish-time lint that would refuse them, and that issue is open
+and unruled, so nothing refuses them at publish today. A `master_detail` with
+no `required` draws only a non-blocking `warning`; `required` + `readonly` and
+`required` + `system` draw nothing at all. An app can therefore newly declare
+any of the three, publish cleanly, and still see the old
+`422 MISSING_REQUIRED_FIELD` with no `fields[]` — so treat these shapes as a
+live surface to avoid authoring into, not as a legacy tail that is already
+closing. One further residual, narrower still: a
 `controlled_by_parent` object whose relation resolves through the required-*lookup*
 fallback also keeps the `422` — validation would cover it, but the ruling covers
 `master_detail`, and widening a ruling is not the implementer's call.

--- a/packages/plugins/plugin-security/src/errors.ts
+++ b/packages/plugins/plugin-security/src/errors.ts
@@ -179,8 +179,11 @@ export class DetailRecordNotFoundError extends Error {
  *     (a `master_detail` with no `required`; `required` + `readonly`;
  *     `required` + `system`) — there this gate is the only refusal there is,
  *     and its 422 is what stops an unreadable orphan detail row being minted.
- *     #8772's lint refuses those shapes at publish time; until an app is
- *     republished, this is the answer they get.
+ *     #8772 *proposes* a publish-time lint that would refuse those shapes, but
+ *     it is open and unruled — nothing refuses them at publish today, so an app
+ *     can newly declare one and land here (#8959). This is the answer those
+ *     shapes get for as long as they stay declarable, not merely until some
+ *     legacy app is republished.
  *
  * The wording is unchanged in both, so a surface that pins either sentence sees
  * the same string it always did — what moved is WHICH inserts arrive here.

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -5110,8 +5110,20 @@ export class SecurityPlugin implements Plugin {
       // unmatchable by the `controlled_by_parent` read filter (`fk IN
       // (readable masters)`), so readable by nobody, and answering `422` on
       // every later by-id write through the stored-row leg below. The residual
-      // envelope asymmetry is confined to exactly those shapes, which #8772's
-      // lint now refuses at publish time.
+      // envelope asymmetry is confined to exactly those shapes.
+      //
+      // [#8959] ⛔ "Confined" is NOT a publish-time bound, and this comment used
+      // to claim it was. #8772 *proposes* a lint that would refuse these shapes;
+      // it is open and unruled, so nothing refuses them at publish today and any
+      // app can newly author one. Measured against the lint as it stands:
+      // `master_detail` with no `required` draws `severity: 'warning'` from
+      // `relationship/master-detail-required`, and only `error` findings fail a
+      // build; `required` + `readonly` and `required` + `system` draw nothing at
+      // all — no rule in `packages/lint/src/data-model-rules.ts` reads either
+      // flag. A freshly authored detail therefore reaches this branch and its
+      // 422, which makes the residue a live surface rather than a shrinking
+      // legacy tail. Whether that is acceptable is #8772's to rule; this comment
+      // may not presume an answer in either direction.
       //
       // Only the INSERT shape hands over. The stored-row shape (a by-id write
       // whose persisted FK is null) keeps its 422: the caller sent no such


### PR DESCRIPTION
Fixes #8959

Three landed artifacts asserted, in the **present tense**, that a publish-time lint refuses the declarable shapes on which `assertControlledByParentWrite` still answers `422 MISSING_REQUIRED_FIELD`. No such lint exists. The issue that *proposes* one is open and unruled, so the documented blast-radius bound was false on the day it landed — and one of the three artifacts is a changeset still sitting unconsumed in `.changeset/`, i.e. a **pending release note** scheduled to ship that claim to users.

This PR is **direction 1 only**: correct the mood of the three artifacts. No runtime behaviour changes. `packages/lint/src/data-model-rules.ts` is untouched.

## What changed

| artifact | was | now |
|---|---|---|
| `packages/plugins/plugin-security/src/security-plugin.ts` (stand-down site) | "confined to exactly those shapes, which #8772's lint **now refuses** at publish time" | states that "confined" is not a publish-time bound, with the measured lint verdicts |
| `packages/plugins/plugin-security/src/errors.ts` (`MasterReferenceMissingError`) | "#8772's lint **refuses** those shapes at publish time; until an app is republished…" | "#8772 *proposes* a publish-time lint that **would** refuse those shapes, but it is open and unruled" |
| `.changeset/cbp-missing-master-insert-validation-envelope.md` | "precisely the shapes #8772's lint **now refuses** at publish time. An app that publishes cleanly sees one envelope" | confinement kept, reachability corrected: an app can newly declare any of the three, publish cleanly, and still see the old envelope |

## The measurement the new text rests on

Re-derived against `origin/main` in this worktree rather than taken from the card — all four rows hold:

| surviving 422 shape | publish-time lint verdict, measured |
|---|---|
| `master_detail`, no `required` | `severity: 'warning'` — `relationship/master-detail-required`, `packages/lint/src/data-model-rules.ts` R2. Only `error` findings fail a build (`packages/cli/src/commands/lint.ts` exits non-zero on errors only; `compile.ts` splits by severity and blocks on errors) |
| `master_detail` + `required` + `readonly` | **nothing** — no rule in `data-model-rules.ts` reads `readonly` |
| `master_detail` + `required` + `system` | **nothing** — no rule in `data-model-rules.ts` reads `system` |
| required-`lookup` fallback relation | **nothing** — `validate-security-posture.ts` refuses only a `controlled_by_parent` object with *no* resolvable relation at all |

So a freshly authored object declaring `master_detail` + `required` + `readonly` publishes with no warning and no error, and its inserts answer `422 MISSING_REQUIRED_FIELD` with no `fields[]`. The residue is a **live surface any new app can reach**, not a shrinking legacy tail — and the corrected text says so, because the landed rationale read as acceptable only under the false bound.

## What the text deliberately does not say

It asserts **no outcome** for the proposed lint, in either direction. Writing "will refuse" would be the same error in a different tense — trading a false present for a false future. All of that issue's directions are live and the maintainer has not ruled; #8772 remains open, and this PR neither predicts nor presumes its ruling.

## Why `skip-changeset` rather than a new changeset

Deliberate, not a default. This diff is comment prose plus a correction to an **existing, unconsumed** changeset's body. It ships no behaviour of its own, so a new changeset would mint a second release entry and another version bump for zero behaviour change. The correction reaches users through the changeset that is already pending. Note the gate counts changesets a PR **adds** (`--diff-filter=A`), so editing one in place scores zero by design — the label is the correct mechanism here, not a workaround.

## Verification

Gate union re-run **after** the final commit, at `370a67e35`:

```
pnpm check:changeset-gate-self-tests       EXIT=0
pnpm check:objectui-changeset              EXIT=0
pnpm check:test-source-alias               EXIT=0
pnpm check:type-source-resolution          EXIT=0
pnpm check:nul-bytes                       EXIT=0
pnpm check:cross-package-test-inputs       EXIT=0
node scripts/check-adr-0087-registration.mjs  EXIT=0
node scripts/check-changeset-no-major.mjs     EXIT=0
node scripts/check-empty-changeset.mjs        EXIT=0
pnpm check:i18n                            EXIT=0  (9 packages, all bundles in sync)
pnpm --filter @objectstack/plugin-security typecheck   EXIT=0
pnpm --filter @objectstack/plugin-security test        65 files, 1240 tests passed
```

Gates derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths, not recalled. `check:i18n` came from the script's convention-triggered set (the package owns an `i18n-extract.config.ts`); it first refused to run at all until `@objectstack/cli` was built — reported as a hard failure rather than a skip, which is the intended "absence must be loud" behaviour — and passed once built.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_