### PR TITLE
docs(deployment): rewrite the section index around the two lifecycles and re-order meta.json (#8913)

### DIFF
--- a/content/docs/api/environment-routing.mdx
+++ b/content/docs/api/environment-routing.mdx
@@ -125,5 +125,5 @@ one, so they are intentionally excluded from data-plane resolution.
 ## Related
 
 - [Single-Environment Mode](/docs/deployment/single-project-mode)
-- [Deployment Modes](/docs/deployment)
+- [Deployment Overview](/docs/deployment)
 - [Client SDK](/docs/api/client-sdk)

--- a/content/docs/deployment/environment-variables.mdx
+++ b/content/docs/deployment/environment-variables.mdx
@@ -63,7 +63,7 @@ read at startup unless noted otherwise. Boolean variables accept `true` / `false
 
 | Variable | Type | Default | Description |
 |:---|:---|:---|:---|
-| `OS_SECRET_KEY` | string | — | 32-byte master key (64 hex chars or base64) for `sys_secret` encryption — encrypted settings, `secret` fields, datasource credentials. **Required** for containerized or multi-node deployments; on a single durable host `os start` mints and persists a dev key instead. See [Deployment Modes](/docs/deployment#environment-variables). |
+| `OS_SECRET_KEY` | string | — | 32-byte master key (64 hex chars or base64) for `sys_secret` encryption — encrypted settings, `secret` fields, datasource credentials. **Required** for containerized or multi-node deployments; on a single durable host `os start` mints and persists a dev key instead. See [Self-Hosted Deployment](/docs/deployment/self-hosting#the-minimum-viable-production-environment). |
 | `OS_DEV_CRYPTO_KEY` | string | — | Development convenience crypto key, consulted after `OS_SECRET_KEY`. Do not use in production. |
 | `OS_CLUSTER_DRIVER` | string | `memory` | Cluster coordination driver id. When set to anything other than `memory`, the runtime treats the deployment as multi-node (and requires `OS_SECRET_KEY`). Non-memory drivers are opt-in sibling packages (e.g. `redis` via `@objectstack/service-cluster-redis`) — see [Cluster](/docs/kernel/cluster). |
 | `OS_REDIS_URL` | url | — | Connection URL passed to a non-memory cluster driver (e.g. `OS_CLUSTER_DRIVER=redis`). |

--- a/content/docs/deployment/index.mdx
+++ b/content/docs/deployment/index.mdx
@@ -141,8 +141,8 @@ Publishing and installing are **separate steps**. `os package publish` uploads a
 versioned package to your organization's catalog and changes nothing that is
 running; installing a version into an environment is what moves an app. For an
 unattended pipeline, `os cloud login --email … --password …` skips the browser
-device flow — and note that under `--json` that command emits **NDJSON**, one
-compact JSON document per line, so parse its stdout line by line rather than
+device flow — and note that under `--json` that command emits **NDJSON**:
+compact JSON documents, one per line. Parse its stdout line by line rather than
 with a single `JSON.parse` (see [`os cloud
 login`](/docs/deployment/cli#os-cloud-login)).
 

--- a/content/docs/deployment/index.mdx
+++ b/content/docs/deployment/index.mdx
@@ -1,183 +1,205 @@
 ---
-title: Deployment Modes
-description: Choose between local standalone runtime and Cloud-managed environment deployment.
+title: Deployment Overview
+description: Two things deploy on this platform and they move on separate clocks — the platform runtime you operate, and the metadata app you build. Which one you are doing decides which pages in this section are yours.
 ---
 
-# Deployment Modes
+# Deployment Overview
 
-This repository ships the framework runtime, examples, adapters, CLI, docs, and
-the published console bundle. Local development is a single-environment runtime.
-Cloud deployment uses a separate ObjectOS Cloud control plane plus the
-environment-aware runtime seams exported from `@objectstack/runtime`.
+Two different things get deployed here, and they run on **separate clocks**:
 
-| Mode | Runs from this repo | Environment selection | Typical use |
-|:---|:---:|:---|:---|
-| Local example | Yes | One active `OS_ENVIRONMENT_ID` | Framework development and smoke tests |
-| Standalone app | Yes | One compiled artifact or stack config | Self-hosted app backend |
-| Cloud-managed environment | Runtime seams only | Cloud control plane, hostname, scoped URL, header, or session | SaaS and multi-environment deployments |
+| | **The platform runtime** | **Your metadata app** |
+|:---|:---|:---|
+| The sentence that fits | "I operate ObjectStack." | "I build an app that runs on it." |
+| Ships as | a Docker image (or the `os` CLI on a host) | a compiled artifact, `dist/objectstack.json` |
+| Versioned by | our release train (`17.0.0`) | your own catalog |
+| Whose cadence | ours | yours |
+| The deploy action | move the image tag, restart | compile, then install it or pin it at boot |
+| Rolling back | restore the previous tag or artifact | install the previous version |
 
----
+The two are genuinely independent: a deployment can move from platform 16 to 17
+without touching its app, and publish twelve app versions without moving the
+platform. Most deployment questions are really the question *which of these am I
+doing* — so this section is ordered that way, and so is the sidebar.
 
-## Local runtime
+**Where it runs — Docker, Compose, Kubernetes, a bare Node.js host, or an
+ObjectStack Cloud environment — is a detail inside the first of those two, not a
+third thing alongside them.** Pick which job you are doing first; the venue is a
+choice you make inside it.
 
-Use the repo scripts for framework development:
-
-```bash
-OS_PORT=3000 pnpm dev
-pnpm dev:crm -- --fresh -p 38421
-pnpm docs:dev
-```
-
-`pnpm dev` starts the showcase kitchen-sink example. It is the best local
-exercise path for objects, views, flows, AI metadata, security, and the console
-bundle.
-
-For a generated app:
-
-```bash
-os dev
-os start
-os start --artifact ./dist/objectstack.json
-```
-
-The active environment is selected with `OS_ENVIRONMENT_ID`.
+<Callout type="info">
+**Doing both is normal; doing both in one motion is not.** A team that
+self-hosts its own app operates the runtime *and* ships the app — still two
+jobs, two cadences, two checklists. Read the one you are acting on today.
+</Callout>
 
 ---
 
-## Standalone artifact runtime
+## The platform runtime — you operate it
 
-Any directory with a compiled `dist/objectstack.json` can boot through the CLI
-or `@objectstack/runtime` helpers:
+The platform ships as a single version-locked train: every `@objectstack/*`
+package shares one version number, and that number is the platform version. It
+is published as an official runtime image, `ghcr.io/objectstack-ai/objectstack`,
+whose tags mirror `@objectstack/cli` versions (`17.0.0`, `17.0`, `17`,
+`latest`). Pin the exact version in production and move it deliberately.
 
-```bash
-os compile
-OS_ENVIRONMENT_ID=env_prod OS_ARTIFACT_PATH=./dist/objectstack.json os serve
-```
+### Where it runs
 
-Deployment config stays outside the artifact. Database URLs, auth secrets,
-runtime credentials, and environment identity are injected through process env
-or the host's deployment config.
+- **Docker — the standard path.** The image is Node 22 + `@objectstack/cli` +
+  `os start`, running as a non-root user with a built-in health check. Compose
+  with Postgres and Kubernetes are shapes of that same path rather than
+  alternatives to it; [bare Node.js under
+  systemd](/docs/deployment/self-hosting#bare-nodejs-systemd--without-containers)
+  is the minority path, for hosts where a container runtime is not available.
+  See [Docker (official
+  image)](/docs/deployment/self-hosting#docker-official-image--the-standard-path).
+- **ObjectStack Cloud.** The control plane provisions environments and operates
+  the runtime for you, and apps arrive by installing a package version from your
+  organization's catalog. Cloud hosts, database provisioning, billing, and
+  public SaaS distribution live outside this repository; the framework runtime
+  exposes the environment registry, marketplace proxy, and runtime-config seams
+  that distribution consumes.
+- **A local runtime, for development.** `pnpm dev` in this repository, or
+  `os dev` in a generated app: one process, one active environment, no
+  control-plane hop. See [Single-Environment
+  Mode](/docs/deployment/single-project-mode).
 
----
+### How many environments one runtime serves
 
-## Cloud-managed deployment
+A single-environment host owns exactly one active environment, selected with
+`OS_ENVIRONMENT_ID`. An environment-aware host resolves one **per request** —
+from the scoped URL, the hostname, `X-Environment-Id`, the session, or a
+configured default. That is a property of the runtime you operate, not of the
+app it runs; the full precedence list is [Resolution
+order](/docs/api/environment-routing#resolution-order). Control-plane endpoints
+under `/api/v1/cloud/...` manage environments rather than running inside one and
+are deliberately excluded from it.
 
-Publishing and installing are **separate steps**. The CLI publishes a
-**versioned package** to your organization's catalog — it does not touch any
-environment, and you never pass an environment id:
+### The pages for operating the platform
 
-```bash
-os cloud login        # once: stores a cloud token
-os package publish     # → sys_package + immutable, checksummed sys_package_version
-```
-
-See the cloud [package](/docs/references/cloud/package) and
-[package-version](/docs/references/cloud/package-version) references.
-
-> **Automating the login step.** `os cloud login` uses the browser device flow
-> in an interactive terminal, and under `--json` it is one of the CLI's two
-> declared **NDJSON** commands (`os login` is the other): stdout is a stream of
-> compact JSON documents, **one per line**, and the verification-URL record is
-> written *before* you authorize so a script can show it while it still
-> matters. Parse that stdout line by line, not with a single `JSON.parse`. See
-> [`os cloud login`](/docs/deployment/cli#os-cloud-login) in the CLI reference.
-> For an unattended pipeline, `os cloud login --email … --password …` skips the
-> device flow entirely and emits a single record.
-
-Installing then happens **inside the target environment**: sign in to that
-environment's Console → **Marketplace** → pick the package → **Install**. The
-install is authorized by your environment login and applied to that environment
-(metadata + sample data); the kernel is evicted so it is live on the next
-request — no restart, and no environment id to remember.
-
-> **CI shortcut.** A pipeline deploying to a *known* environment can publish and
-> install in one call: `os package publish --env <id> --install`. This is for
-> automation only — interactive installs happen in the environment Marketplace.
-
-> **Removed: the legacy env-revision path.** The direct-to-environment `os publish`
-> / `os rollback` commands (which wrote `sys_environment_revision`) were **removed**
-> (#2237, ADR-0006 v4). All publishing now goes through the package flow above
-> (`os package publish`); to change what an environment runs, install a package
-> version into it.
-
-Cloud control-plane hosts, database provisioning, billing, and public SaaS
-deployment are outside this framework repository. The framework runtime exposes
-the environment registry, marketplace proxy, and runtime-config seams consumed
-by that distribution.
-
----
-
-## Routing precedence
-
-Environment-aware hosts resolve requests in this order:
-
-1. `/api/v1/environments/:environmentId/...`
-2. Hostname through the environment registry
-3. `X-Environment-Id`
-4. `session.activeEnvironmentId`
-5. Configured default environment
-6. Single unambiguous environment
-
-Control-plane paths under `/api/v1/cloud/environments/...` are not data-plane
-requests and do not run through a target environment kernel.
-
----
-
-## Environment variables
-
-| Variable | Purpose |
+| Page | What it answers |
 |:---|:---|
-| `OS_ENVIRONMENT_ID` | Active local or publish target environment. |
-| `OS_CLOUD_URL` | Cloud control-plane base URL used by publish/package commands. |
-| `OS_ARTIFACT_PATH` | Artifact path for `os serve` and standalone hosts. |
-| `OS_DATABASE_URL` | Local runtime business database URL. |
-| `OS_DATABASE_DRIVER` | Local runtime driver id. |
-| `OS_AUTH_SECRET` | Better Auth session secret for hosted runtimes. |
-| `OS_SECRET_KEY` | 32-byte master key for `sys_secret` encryption (encrypted settings, `secret` fields, datasource credentials). 64 hex chars or base64 of 32 bytes. |
-| `OS_CLUSTER_DRIVER` | Cluster coordination driver. When set, the runtime treats the deployment as multi-node. |
-| `OS_PORT` | HTTP listen port. |
+| [Self-Hosted Deployment](/docs/deployment/self-hosting) | Running the artifact on infrastructure you operate — Docker, Compose with Postgres, Kubernetes, systemd, health checks, reverse proxy and TLS, and the four values every deployment must pin |
+| [Production Readiness](/docs/deployment/production-readiness) | Security headers, rate limiting, observability, and the [go-live checklist](/docs/deployment/production-readiness#go-live-checklist) |
+| [Backup & Restore](/docs/deployment/backup-restore) | What state a deployment actually holds, how to back up each piece per database driver, and the restore drill to rehearse before you need it |
+| [Tenancy Postures & Membership](/docs/deployment/tenancy-modes) | Which of the three postures this deployment runs in, how new users join an organization, and the degraded-tenancy boot guard |
+| [Single-Environment Mode](/docs/deployment/single-project-mode) | The one-environment boot shape — what it includes, and what it deliberately does not |
 
-Third-party provider variables such as `OPENAI_API_KEY`, `TURSO_*`,
-`RESEND_API_KEY`, and OAuth client secrets keep their provider names. Mail
-settings are the exception — they route through the email service's
-env-override convention as `OS_EMAIL_<KEY>` (e.g. `OS_EMAIL_PROVIDER`,
-`OS_EMAIL_API_KEY`, `OS_EMAIL_FROM`), not a raw `SMTP_*` name.
+### Upgrading the platform
+
+Moving the platform forward is its own procedure: move the tag, restart, and
+know what the boot does when the database is still shaped for the previous
+version. See [Upgrading → The platform
+runtime](/docs/upgrading#the-platform-runtime).
+
+---
+
+## Your metadata app — you build it
+
+An app is **not part of the platform**. It compiles to its own immutable
+artifact, carries its own version, and is released by you, when you decide:
+
+```text
+objectstack.config.ts ──(os compile)──▶ dist/objectstack.json
+```
+
+Deployment config stays **outside** that artifact. Database URLs, auth secrets,
+runtime credentials, and environment identity are host inputs, injected as
+`OS_*` variables or CLI flags.
+
+### Validate before you compile
+
+ObjectStack metadata is data, not code paths, so most mistakes pass `tsc` and
+then fail silently at runtime. One command catches them at author time:
+
+```bash
+os validate     # schema + CEL predicates + widget bindings — no artifact
+```
+
+Run it after every metadata edit — see [Validating
+Metadata](/docs/deployment/validating-metadata).
+
+### How the app reaches a running platform
+
+There are two ways in, and picking the wrong one is the expensive mistake:
+
+| | **Catalog install** | **Artifact-pinned boot** |
+|:---|:---|:---|
+| The app arrives | *after* the platform is running | *at boot*, as an input to the process |
+| Named by | package id + version (`com.acme.crm@1.2.0`) | a URL to the compiled artifact (`OS_ARTIFACT_URL`) |
+| Switching versions | install another version; no restart | change the variable, restart |
+| Apps per runtime | many, side by side | one — it *is* this runtime's app |
+
+One question decides it: **is this app the reason the runtime exists?** If yes,
+pin the artifact — the deployment defines the app. If no, install from the
+catalog — the runtime is a platform that receives apps. The full comparison, the
+tie-breakers, and every publish command are on [Publish, Versioning &
+Preview](/docs/deployment/publish-and-preview#the-two-ways-in); the operational
+detail of the pinned path is [Artifact-pinned
+boot](/docs/deployment/self-hosting#artifact-pinned-boot-os_artifact_url).
+
+Publishing and installing are **separate steps**. `os package publish` uploads a
+versioned package to your organization's catalog and changes nothing that is
+running; installing a version into an environment is what moves an app. For an
+unattended pipeline, `os cloud login --email … --password …` skips the browser
+device flow — and note that under `--json` that command emits **NDJSON**, one
+compact JSON document per line, so parse its stdout line by line rather than
+with a single `JSON.parse` (see [`os cloud
+login`](/docs/deployment/cli#os-cloud-login)).
+
+### The pages for shipping an app
+
+| Page | What it answers |
+|:---|:---|
+| [Publish, Versioning & Preview](/docs/deployment/publish-and-preview) | Compile the artifact, publish a version, install it, and the preview patterns — including how to rehearse a pinned rollout locally |
+| [Validating Metadata](/docs/deployment/validating-metadata) | The mistakes a type-checker cannot see, and the one gate that rejects them before you ship |
+
+### Upgrading the app
+
+`os migrate meta --from <major>` replays every step between the major your
+metadata was authored against and this runtime's, in one pass; you then rebuild
+and ship as usual. See [Upgrading → The metadata
+app](/docs/upgrading#the-metadata-app).
+
+---
+
+## Where the two meet
+
+Three places, and each is where treating the two as one thing goes wrong:
+
+1. **The `engines.protocol` handshake.** The artifact declares which platform
+   majors it can run on, and a runtime outside that range **refuses** the app
+   rather than half-loading it. Everything else about the two version numbers is
+   independent.
+2. **The artifact source is an operator's input.** Whoever runs the platform
+   sets it, and it selects which version of the app boots. The sources have a
+   fixed precedence, so a container that presets one variable cannot shadow a
+   deliberate override:
+
+   ```text
+   --artifact  >  OS_ARTIFACT_URL  >  OS_ARTIFACT_PATH  >  <cwd>/dist/objectstack.json
+   ```
+
+3. **The database.** Moving either side can leave the physical schema shaped for
+   the other. `os migrate plan` reports the drift, categorised safe /
+   needs-confirm / destructive; `os migrate apply` reconciles it.
 
 <Callout type="tip">
 **Every deployed app is AI-operable by default:** an MCP server is served at
-`/api/v1/mcp` in every deployment mode, exposing your objects and actions to AI clients
-under the same permissions and RLS (set `OS_MCP_SERVER_ENABLED=false` to opt out). See
-[MCP Server env vars](/docs/deployment/environment-variables#mcp-server) and
-[Your app as an MCP server](/docs/api#your-app-as-an-mcp-server).
-</Callout>
-
-<Callout type="warn">
-**Set `OS_SECRET_KEY` for any containerized or multi-node deployment.** The
-default `LocalCryptoProvider` encrypts every `sys_secret` value under one
-32-byte key. On a single host, `os start` mints and persists that key to
-`~/.objectstack/dev-crypto-key` automatically, so the zero-config quickstart
-just works. But on an **ephemeral filesystem (containers)** the minted key is
-lost on restart, and across **multiple nodes** each node would mint a
-*different* key — in both cases previously-encrypted secrets become
-undecryptable.
-
-Provision one stable key shared by every node and every restart:
-
-```bash
-OS_SECRET_KEY=$(openssl rand -hex 32)
-```
-
-When `OS_CLUSTER_DRIVER` is set (multi-node), `os start` will **not** auto-mint
-a key — it fails loud at boot until `OS_SECRET_KEY` is provided, rather than
-silently running under a key that won't survive. For production, prefer a
-managed KMS / Vault provider behind the same `ICryptoProvider` seam.
+`/api/v1/mcp` in every deployment, exposing your objects and actions to AI
+clients under the same permissions and RLS (set `OS_MCP_SERVER_ENABLED=false` to
+opt out). See [MCP Server env
+vars](/docs/deployment/environment-variables#mcp-server) and [Your app as an MCP
+server](/docs/api#your-app-as-an-mcp-server).
 </Callout>
 
 ---
 
-## Related
+## Shared reference
 
-- [Self-Hosted Deployment](/docs/deployment/self-hosting)
-- [Single-Environment Mode](/docs/deployment/single-project-mode)
-- [Environment-Scoped Routing](/docs/api/environment-routing)
-- [Publish, Versioning & Preview](/docs/deployment/publish-and-preview)
+Three pages belong to neither side and are read from both:
+
+| Page | Why both |
+|:---|:---|
+| [CLI reference](/docs/deployment/cli) | One command surface covers both jobs: [`os start`](/docs/deployment/cli#os-start) and `os migrate` operate the runtime, while `os validate`, `os compile`, and `os package publish` ship the app |
+| [Environment Variables](/docs/deployment/environment-variables) | The canonical `OS_*` catalog. Configuration belongs to the **host** rather than to either shipped thing, which is exactly why it is neither side's page |
+| [Troubleshooting & FAQ](/docs/deployment/troubleshooting) | Symptom-first answers for validation, query, configuration, and performance problems on either side |

--- a/content/docs/deployment/meta.json
+++ b/content/docs/deployment/meta.json
@@ -2,15 +2,15 @@
   "title": "Deployment & Operations",
   "pages": [
     "index",
-    "cli",
-    "validating-metadata",
     "self-hosting",
-    "backup-restore",
     "production-readiness",
-    "publish-and-preview",
-    "environment-variables",
-    "single-project-mode",
+    "backup-restore",
     "tenancy-modes",
+    "single-project-mode",
+    "publish-and-preview",
+    "validating-metadata",
+    "cli",
+    "environment-variables",
     "troubleshooting"
   ]
 }

--- a/content/docs/deployment/publish-and-preview.mdx
+++ b/content/docs/deployment/publish-and-preview.mdx
@@ -218,6 +218,6 @@ boot-time schema-drift policy, against a local file.
 - [Artifact-pinned boot](/docs/deployment/self-hosting#artifact-pinned-boot-os_artifact_url) — the operational detail for `OS_ARTIFACT_URL`: schemes, integrity pinning, cache behaviour, pre-signed URLs
 - [CLI reference](/docs/deployment/cli)
 - [Packages](/docs/plugins/packages)
-- [Deployment Modes](/docs/deployment)
+- [Deployment Overview](/docs/deployment)
 - [Environment Variables](/docs/deployment/environment-variables)
 - [Environment-Scoped Routing](/docs/api/environment-routing)

--- a/content/docs/deployment/self-hosting.mdx
+++ b/content/docs/deployment/self-hosting.mdx
@@ -11,7 +11,7 @@ platform publishes an official runtime image on every release, and Compose and
 Kubernetes are shapes of that same path rather than alternatives to it. Bare
 Node.js under systemd is the minority path, kept for hosts where a container
 runtime is not available or not permitted. It assumes you have read
-[Deployment Modes](/docs/deployment).
+[Deployment Overview](/docs/deployment).
 
 The deployment model is deliberately simple:
 
@@ -430,7 +430,7 @@ Disable with `OS_MCP_SERVER_ENABLED=false`. See
 ## Related
 
 - [Backup & Restore](/docs/deployment/backup-restore) — what to back up, and the restore drill
-- [Deployment Modes](/docs/deployment) — the map of local / standalone / Cloud
+- [Deployment Overview](/docs/deployment) — the two lifecycles this section is organised around, and which pages belong to each
 - [`os start` reference](/docs/deployment/cli#os-start) — every flag and env var
 - [Environment Variables](/docs/deployment/environment-variables) — the full catalog
 - [Troubleshooting & FAQ](/docs/deployment/troubleshooting)

--- a/content/docs/deployment/single-project-mode.mdx
+++ b/content/docs/deployment/single-project-mode.mdx
@@ -17,8 +17,11 @@ This is the mode used by:
 - `createStandaloneStack()` / `createDefaultHostConfig()` in
   `@objectstack/runtime`
 
-Use [Deployment Modes](/docs/deployment) when you need to publish to an
-ObjectOS Cloud control plane or test environment-scoped routing.
+Need more than one environment? [Publish, Versioning &
+Preview](/docs/deployment/publish-and-preview) covers publishing to an ObjectOS
+Cloud control plane, and [Environment-Scoped
+Routing](/docs/api/environment-routing) covers resolving an environment per
+request.
 
 ---
 
@@ -107,5 +110,5 @@ environments, provision databases, or mount a control plane.
 ## Related
 
 - [Environment-Scoped Routing](/docs/api/environment-routing)
-- [Deployment Modes](/docs/deployment)
+- [Deployment Overview](/docs/deployment)
 - [CLI reference](/docs/deployment/cli)


### PR DESCRIPTION
Fixes #8913

Card 05 — the keystone of the deployment restructure. Per the card, every blocker was
verified **merged on `origin/main` by content**, not by merge-commit subject, before the
first edit:

| Blocker | Content check on `origin/main` |
|:---|:---|
| #8904 | no `vercel.mdx` / ObjectQL-migration page in `content/docs/deployment/` (12 files remain) |
| #8909 | `content/docs/upgrading.mdx` exists, 206 lines; **0** files under `content/docs/upgrading/` (positive control: 12 under `content/docs/deployment/`) |
| #8910 | `publish-and-preview.mdx` is 223 lines and carries `## The two ways in` |
| #8911 | `## Docker (official image) — the standard path` present in `self-hosting.mdx`; the `## Option 1 / 2 / 3` peer numbering is gone |

Every page name, heading and anchor referenced below was read off that merged tree — the
point of landing this card last.

## The rewrite

`content/docs/deployment/index.mdx` forked on **venue** ("Deployment Modes": local /
standalone / Cloud-managed). It now forks on **lifecycle**, because that is what a reader
arrives with:

- **The platform runtime — you operate it.** Ships as a Docker image on our release train,
  moved on our cadence. Venue (Docker, Compose, Kubernetes, bare Node.js under systemd,
  ObjectStack Cloud) is a bullet list *inside* this half, not a peer of it.
- **Your metadata app — you build it.** Compiles to `dist/objectstack.json`, versioned in
  your catalog, shipped on your cadence.

The old content that was not wrong survives, relocated rather than deleted:

| Old section | Where it went |
|:---|:---|
| `## Local runtime` | a bullet under "Where it runs" — a local runtime is a shape of the platform half, with the commands left to Single-Environment Mode and the CLI reference |
| `## Standalone artifact runtime` | the app half's compile step, plus the artifact-source precedence under "Where the two meet" |
| `## Cloud-managed deployment` | split: the Cloud venue bullet in the platform half, the publish/install mechanics in the app half pointing at `publish-and-preview` (which now owns them) |
| `## Routing precedence` | compressed to a pointer at `/docs/api/environment-routing#resolution-order`, which carries the identical six-step list *and* the control-plane exclusion. The index no longer keeps a second copy that can drift |
| `## Environment variables` (partial table + two callouts) | the MCP callout is kept; the `OS_SECRET_KEY` callout is dropped as a third copy — `self-hosting.mdx` carries both halves of it already ("The minimum viable production environment" for the ephemeral-filesystem case, "Scaling beyond one node" for the multi-node refusal-to-boot case) |
| `## Related` | replaced by three in-page tables that name every page in the section and say what it answers |

New closing section, **"Where the two meet"** — the `engines.protocol` handshake, the
artifact-source precedence (an operator input that selects an app version), and database
drift. These are the three seams where treating the two lifecycles as one goes wrong.

Title changed `Deployment Modes` to `Deployment Overview`: "Modes" is the venue fork's own
vocabulary. The new name matches this repo's existing section-index convention (`API
Overview`, `AI Overview`).

## `meta.json`

Re-ordered to match — platform pages, app pages, then shared reference:

```
index,
self-hosting, production-readiness, backup-restore, tenancy-modes, single-project-mode,
publish-and-preview, validating-metadata,
cli, environment-variables, troubleshooting
```

Every assignment was checked against the merged page rather than the card's proposal, and
all ten hold. `cli.mdx` stays reference by its own measurement — 1398 lines of which
`## Commands` spans 68–1283 — and is cross-linked from both halves in the "Shared
reference" table, split by which commands serve which lifecycle. It is not split, and it
did not drift into the platform half.

## The cross-group link

`/docs/upgrading` — a **single page in the Build group**, not a `content/docs/upgrading/`
section. The card body's wording is stale here and the correction comment on the card is
right; measured again on the merged tree (0 files under that directory). The index links
its two halves individually: `/docs/upgrading#the-platform-runtime` from the platform half
and `/docs/upgrading#the-metadata-app` from the app half, which is the navigable form of
the split. No directory was created.

## Pointer fixes this rewrite forced (named, with evidence)

Five files beyond the two the card names. Each is a pointer that this change made wrong,
each is mechanical, and all are in the same gate family:

1. `content/docs/deployment/environment-variables.mdx` — its `OS_SECRET_KEY` row linked
   `/docs/deployment#environment-variables`, an anchor this rewrite deletes. Retargeted to
   `self-hosting#the-minimum-viable-production-environment`, which carries the same
   guidance in the operator's context. Without this `check:doc-anchors` goes red — it is
   the only inbound anchor into the index in the whole corpus (grep over
   `docs/deployment#`).
2. `content/docs/deployment/self-hosting.mdx` (2 lines) — one link label, and one Related
   entry that described the deleted structure verbatim ("the map of local / standalone /
   Cloud").
3. `content/docs/deployment/single-project-mode.mdx` (2 places) — one Related label, and a
   sentence sending readers to the index "when you need to publish to an ObjectOS Cloud
   control plane", which the index no longer explains; retargeted to `publish-and-preview`
   and `environment-routing`.
4. `content/docs/deployment/publish-and-preview.mdx` (1 line) — Related label.
5. `content/docs/api/environment-routing.mdx` (1 line) — Related label.

After this, `grep -rn 'Deployment Modes' content/` returns nothing.

**Deliberately not swept:** `ui/setup-app.mdx`, `automation/hook-bodies.mdx` and
`kernel/index.mdx` link the index under labels ("Cloud Deployment", "Deployment &
Operations") that do not name the old title and are no more wrong after this change than
before it. Pre-existing looseness, not created here — recorded as #8984.

## Where I disagree with the card

The card asks me to flag `single-project-mode` folding into `self-hosting` if the merged
state strengthens the case. **It weakens it.** After #8911, `self-hosting.mdx` is 436
lines that are firmly about production infrastructure (Docker, Compose, Kubernetes,
systemd, TLS, health checks). `single-project-mode.mdx` is about the default *boot shape* —
`pnpm dev`, `os dev`, `createStandaloneStack()` — and its real subject after this
restructure is **environment selection**: one active `OS_ENVIRONMENT_ID` versus a host that
resolves one per request. Folding it into the production page would put local development
inside a production guide. If a follow-up is still wanted, the better shape is a merge with
the environment-routing framing, not with self-hosting. No issue filed — this is the
card's flag-it-in-the-PR path, and the disposition is the PM's.

## Round 2 — merge-queue repair (`b40e5fefb`)

The first head was dequeued on CI_FAILURE: `packages/cli/test/cloud-login-json-ndjson.e2e.test.ts`
pins the #6730 NDJSON exception in this page as well as in the CLI reference, asserting
`/NDJSON/`, `/one\s+per\s+line/i` and the `/docs/deployment/cli#os-cloud-login` link all
appear in `content/docs/deployment/index.mdx`.

The rewrite kept every fact the pin protects — NDJSON named, the anchor kept, "parse line
by line" kept — but spelled the middle one "one **compact JSON document** per line", which
breaks the token adjacency the second regex needs. Repaired by rewording that one clause to
"emits **NDJSON**: compact JSON documents, one per line." Meaning, framing and placement
unchanged; the rewrite is not reverted.

Verified rather than eyeballed, from the committed state:

| state | `NDJSON` | `one per line` | anchor | the test |
|:---|:---|:---|:---|:---|
| `HEAD~1` restored into the tree (pre-fix wording) | true | **false** | true | **1 failed** |
| `b40e5fefb` (fix) | true | true | true | **1 passed**, 11 skipped |

The pre-fix leg was run by checking the old file out of the *committed* parent and restored
with `git checkout HEAD -- ...`, then proven byte-identical
(`git hash-object` = `git rev-parse HEAD:...` = `7b1fe377c`, `git status --porcelain` empty).

Swept for the rest of the class rather than fixing only the reported one: of the seven files
this PR changes, `content/docs/deployment/index.mdx` is the **only** one any test reads —
the other CLI docs pins target `cli.mdx`, which this PR does not touch, and no test
references `self-hosting`, `single-project-mode`, `publish-and-preview`,
`environment-variables`, `environment-routing` or the section `meta.json`.

Why PR-side CI could not see it, and the follow-up: `@objectstack/cli#test` declares no
`content/docs` input glob, and `pnpm check:cross-package-test-inputs` nevertheless passes —
the three CLI tests that read these pages seed their paths with
`resolve(fileURLToPath(import.meta.url), '..')`, a spelling the detector's published list
does not carry, so the read is invisible to the gate *and* to turbo's affected set. Filed as
#8995 (blocked by #8946, which is editing the same declaration block).

## Verification

Gate union re-run **after the final commit**, at `b40e5fefb`, clean tree
(`git status --porcelain` empty), all exit 0:

| Gate | Result |
|:---|:---|
| `pnpm check:doc-anchors` | 227 internal `#fragment` links across 396 source files all resolve to a real heading |
| `pnpm check:role-word` | 43 baselined files, no new occurrences (the ratchet family, re-run at the new head) |
| `pnpm check:docs-audit-scope` | audit scope in sync, 178 hand-written docs; 9 release-owned pages read-only |
| `pnpm check:nul-bytes` | 5938 text files, no raw ASCII control bytes |
| `pnpm check:doc-authoring` | 376 files clean |
| `vitest run test/cloud-login-json-ndjson.e2e.test.ts -t 'documents the exception where the cloud login step is prescribed'` | 1 passed, 11 skipped (the spawn-based cases are name-filtered out; they need a built dependency closure and are unrelated to this diff) |

Path-derived set (`node scripts/pm/dispatch-gates.mjs` over the seven changed paths) is
`check:docs-audit-scope` + `check:role-word`; `check:doc-anchors`, `check:nul-bytes` and
`check:doc-authoring` were added on top because this change adds cross-page anchor links
and touches only hand-written docs. The CLI pin is not derivable from either source — it
lives inside a test file's `readFileSync`, which is what #8995 is about.

Additionally, all six changed `.mdx` files were compiled through `@mdx-js/mdx` +
`remark-gfm` (the pipeline `fumadocs-mdx` uses) at the same commit — all six compile.
Anchors were computed with the workspace's own `github-slugger`, the same package
`fumadocs-core` imports, before being written.

Docs-only: no changeset, `skip-changeset` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_
