### PR TITLE
test(lint): pin the four unprovisionedAnchors threading sites that the lint suite could not see

### DIFF
--- a/packages/lint/src/validate-react-page-props.test.ts
+++ b/packages/lint/src/validate-react-page-props.test.ts
@@ -1242,4 +1242,101 @@ describe('validateReactPageProps — unprovisioned injected anchors (#8340)', ()
     );
     expect(f).toEqual([]);
   });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // [#8943] The four `checkBlockFieldProps` calls that were threaded by
+  // CONVENTION ONLY.
+  //
+  // `checkFieldRefs` takes the anchor index as an OPTIONAL trailing
+  // parameter, so a call site that stops passing it keeps compiling and
+  // silently downgrades to the pre-#8340 behaviour: existence still
+  // answered, provenance never asked. Nothing else can see that happen —
+  // the parameter being optional means no type error, and the local
+  // `unprovisionedAnchors` binding stays READ by the sibling calls in the
+  // same function, so there is no TS6133 either. No CI gate reads call
+  // sites at all (#8664).
+  //
+  // #8943 measured all six threading sites by dropping the argument at each
+  // in turn. The two module seams were already pinned — `validatePageFieldBindings`
+  // and the `queried` bucket, both covered by the FILTER-position test above.
+  // The four below stayed GREEN across the whole packages/lint suite with the
+  // index dropped. Each test here was then written ablation-first and observed
+  // RED under its own site's ablation, which is precisely why it exists.
+  //
+  // The branches are disjoint by tag and prop, so each test names exactly one
+  // site: `own` refs reach `<ListView columns>`; the subform pair needs
+  // `<ObjectForm subforms>`; the COMPONENT_FIELD_SPECS table is reachable
+  // only through `<Block type>`, since no react tag's own schemaType
+  // (`list-view`, `object-form`, `object-chart`) is a key in it.
+  // ───────────────────────────────────────────────────────────────────────
+
+  /** A LOCAL object — platform storage is real, so it registers no unprovisioned anchor. */
+  const localOrder = { name: 'crm_order', fields: [{ name: 'code' }] };
+
+  it('[#8943] R1 — PINS the `own` display-ref call (the `skipped` bucket of REACT_FIELD_SPECS)', () => {
+    // `<ListView columns>` is a DISPLAY binding, not a query: the consequence
+    // clause is the blank-column one, not the constant-false one.
+    const f = validateReactPageProps(
+      extPage(`function Page(){ return <ListView objectName="ext_customer" columns={['owner_id']} />; }`),
+    );
+    expect(f.filter((x) => x.rule === PAGE_FIELD_UNKNOWN)).toHaveLength(0);
+    const warned = f.filter((x) => x.rule === PAGE_FIELD_UNPROVISIONED);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].severity).toBe('warning');
+    expect(warned[0].path).toBe('pages[0].source › columns[0]');
+    expect(warned[0].message).toContain('external object (ADR-0015)');
+    expect(warned[0].message).toContain('blank, on every record');
+  });
+
+  it('[#8943] R3 — PINS the ObjectForm subform CHILD refs (resolved against `childObject`)', () => {
+    // The child batch resolves against the subform's own object, so the
+    // external one is the CHILD here and the form's object is local.
+    const f = validateReactPageProps(
+      extPage(
+        `function Page(){ return <ObjectForm objectName="crm_order" subforms={[{ childObject: 'ext_customer', columns: ['owner_id'] }]} />; }`,
+        [extCustomer(), localOrder],
+      ),
+    );
+    expect(f.filter((x) => x.rule === PAGE_FIELD_UNKNOWN)).toHaveLength(0);
+    const warned = f.filter((x) => x.rule === PAGE_FIELD_UNPROVISIONED);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].severity).toBe('warning');
+    expect(warned[0].path).toBe('pages[0].source › subforms[0].columns[0]');
+    expect(warned[0].message).toContain('"ext_customer"');
+    expect(warned[0].message).toContain('blank, on every record');
+  });
+
+  it('[#8943] R4 — PINS the subform `totalField` rollup (resolved against the FORM object)', () => {
+    // The exception inside the exception: `totalField` names the PARENT
+    // object's field the child sum rolls up into, so the external object is
+    // the form's own and the child is local.
+    const f = validateReactPageProps(
+      extPage(
+        `function Page(){ return <ObjectForm objectName="ext_customer" subforms={[{ childObject: 'crm_order', columns: ['code'], totalField: 'owner_id' }]} />; }`,
+        [extCustomer(), localOrder],
+      ),
+    );
+    expect(f.filter((x) => x.rule === PAGE_FIELD_UNKNOWN)).toHaveLength(0);
+    const warned = f.filter((x) => x.rule === PAGE_FIELD_UNPROVISIONED);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].severity).toBe('warning');
+    expect(warned[0].path).toBe('pages[0].source › subforms[0].totalField');
+    expect(warned[0].message).toContain('"ext_customer"');
+  });
+
+  it('[#8943] R5 — PINS the COMPONENT_FIELD_SPECS path reached by `<Block type>`', () => {
+    // The shared table `validate-page-field-bindings` walks; on this surface
+    // it is reachable only by the type the author spells out, which is what
+    // makes the escape hatch checked rather than a hole.
+    const f = validateReactPageProps(
+      extPage(`function Page(){ return <Block type="element:form" objectName="ext_customer" fields={['owner_id']} />; }`),
+    );
+    expect(f.filter((x) => x.rule === PAGE_FIELD_UNKNOWN)).toHaveLength(0);
+    const warned = f.filter((x) => x.rule === PAGE_FIELD_UNPROVISIONED);
+    expect(warned).toHaveLength(1);
+    expect(warned[0].severity).toBe('warning');
+    expect(warned[0].where).toBe('page "p" › <Block>');
+    expect(warned[0].path).toBe('pages[0].source › fields[0]');
+    expect(warned[0].message).toContain('external object (ADR-0015)');
+  });
 });


### PR DESCRIPTION
Fixes #8943

`checkFieldRefs` takes the anchor index as an **optional trailing parameter**, so a call site that stops passing it keeps compiling and silently downgrades to the pre-#8340 behaviour: existence still answered, provenance never asked. #8943 measured all six in-repo threading sites — the two module seams are pinned, and four calls inside `checkBlockFieldProps` were threaded by convention only.

This adds one behaviour test per uncovered site, through `validateReactPageProps`, asserting `page-field-unprovisioned` on an ADR-0015 `external` object — mirroring the existing FILTER-position test, with the #8404 pin's comment style so the next reader knows what each test is for.

**Test-only. No production file is touched** — `validate-react-page-props.ts` is byte-identical to `origin/main` (blob `a560d360b` on both, verified after the last ablation).

## Ablation evidence — each test observed RED at its own site

Every test was written ablation-first: drop the `unprovisionedAnchors` argument at that site, run, restore. Each leg was then re-run against the **full 2051-test suite** — not a filtered subset — because the claim being pinned is that *nothing else* catches the drop.

| site | call site | full-suite result with the index dropped |
|---|---|---|
| R1 | `own` refs, the `skipped` bucket of `REACT_FIELD_SPECS` | **1 failed, 2050 passed** — only the R1 test |
| R3 | ObjectForm subform CHILD refs (resolved against `childObject`) | **1 failed, 2050 passed** — only the R3 test |
| R4 | subform `totalField` rollup (resolved against the FORM object) | **1 failed, 2050 passed** — only the R4 test |
| R5 | the `COMPONENT_FIELD_SPECS` path reached by Block `type` | **1 failed, 2050 passed** — only the R5 test |

Exactly one red per leg carries both halves of the claim: **no pre-existing test covers any of the four sites** (a second failure would have shown one), and each new test pins **exactly one** call site rather than the group. Restored between every leg, with the blob hash checked back against `origin/main` at the end.

The branches are disjoint by tag and prop, which is what makes that attribution possible: `own` refs reach ListView `columns`; the subform pair needs ObjectForm `subforms`; and `COMPONENT_FIELD_SPECS` is reachable only through Block `type`, since no react tag's own `schemaType` (`list-view`, `object-form`, `object-chart`) is a key in that table.

**Why no other instrument sees this**: measured under the R5 ablation, `pnpm --filter @objectstack/lint typecheck` exits **0**. The parameter is optional, so there is no type error, and the local `unprovisionedAnchors` binding stays read by the sibling calls, so there is no TS6133 either. Only a behaviour test can see it.

## Verification

Gate union run **after** the final commit, at `dcecc68ec`:

- `pnpm --filter @objectstack/lint test` — 73 files, **2051 passed** (2047 on `main` + the 4 new)
- `pnpm --filter @objectstack/lint typecheck` — clean
- `pnpm check:cross-package-test-inputs` and `node scripts/check-cross-package-test-inputs.mjs` — OK, 12 packages read outside themselves, all declared
- `pnpm check:nul-bytes` — OK, 5938 files scanned
- Re-derived against the actual changed path with `scripts/pm/dispatch-gates.mjs`, which added three convention-triggered gates the dispatch list did not name; all run and green:
  - `pnpm check:query-options-erasure` — ratchet holds, test surface unchanged at the ceiling
  - `pnpm check:type-check-coverage` — OK
  - `pnpm check:type-check-debt` — OK, 33 ledger entries re-measured, none above its recorded number. Run with the full workspace closure built, as the gate requires. `@objectstack/lint` measures 19 against its recorded 20, so the new test file adds **zero** type errors. (Its `tsconfig.json` excludes `*.test.ts`, so this ratchet — not the package `typecheck` — is what actually reads the new file.)

`skip-changeset`: test-only, nothing user-visible to release.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_