### PR TITLE
docs(objectql,lint,examples): state one guard idiom for the sparse action face

### DIFF
--- a/content/docs/automation/flows.mdx
+++ b/content/docs/automation/flows.mdx
@@ -1259,9 +1259,17 @@ evaluate cleanly instead of aborting with `No such key`. `has(record.x)` is
 therefore uniformly `true` for a *declared* field the moment it's present at
 all — including when its value is `null` — so it answers "is `x` declared on
 this object", never "does `x` have a value". Guard emptiness with
-`record.x != null` / `isBlank(record.x)`, same as everywhere else CEL runs
-(see the [`has()` gotcha](/docs/data-modeling/formulas#cel-primer) above).
-`has()` still earns its keep against a genuinely *undeclared* key.
+`record.x != null` / `isBlank(record.x)` — the same rule every other ***total***
+binding carries (see the [`has()` gotcha](/docs/data-modeling/formulas#cel-primer)
+above). `has()` still earns its keep against a genuinely *undeclared* key.
+
+⚠️ **That scoping is load-bearing, not pedantry.** One binding on the platform
+is *sparse* by decision: an [action](/docs/ui/actions) `visible` / `disabled`
+predicate is evaluated against whatever record the client already fetched —
+on a list row, only the columns that view actually projected. There
+`record.x != null` **is itself a fault** on an absent key, and the guard is the
+conjunction `has(record.x) && record.x != null`. Flows are not that face; the
+rule above holds here. Just don't carry it across to one where it doesn't.
 </Callout>
 
 ## Run a flow via API

--- a/examples/app-showcase/src/ui/actions/predicate-matrix.action.ts
+++ b/examples/app-showcase/src/ui/actions/predicate-matrix.action.ts
@@ -40,11 +40,34 @@
  *
  *  - **Prefix with `record.`** A bare `f_boolean` is an undeclared variable on
  *    the record-header path and throws (fail-closed hide).
- *  - **Null-guard before you traverse or call.** `record.f_json.nested.k` and
- *    `record.f_tags.size()` FAULT on a record where the field is `null` —
- *    `null` has no members and no methods. `record.f_json != null &&
- *    record.f_json.nested.k == "v"` is the portable form, and it is why the
- *    Minimal specimen is worth having.
+ *  - **Guard with `has(record.x) && record.x != null` before you traverse,
+ *    call, order or subtract.** TWO failure modes are live on this face, and
+ *    each half of that conjunction covers exactly one. `record.f_json.nested.k`
+ *    and `record.f_tags.size()` FAULT where the field is `null` (`null` has no
+ *    members and no methods) — the `!= null` half. And `record.f_json` FAULTS
+ *    outright with `No such key` on a LIST ROW that never projected the column
+ *    — the `has()` half — because this face binds whatever record the client
+ *    already fetched and stays sparse by decision (#4953 clause 2). Neither
+ *    half alone is a guard; both faults are fail-closed, so the button just
+ *    silently is not there.
+ *
+ *    ⛔ Do not restate the rule here. The CANONICAL statement, with the
+ *    measured three-binding table, lives in `materializeDeclaredFields`'s doc
+ *    comment (`packages/objectql/src/declared-fields.ts`) — this file used to
+ *    carry a second, differently worded version of it that said the opposite
+ *    ("`record.f_json != null && …` is the portable form"), which is #8975.
+ *
+ *    This file is where both halves are falsifiable in a browser: the Minimal
+ *    specimen exercises the NULL half, and the default list's `$select`
+ *    projection — which omits `f_lookup` / `f_lookups` and includes
+ *    `f_textarea` — exercises the ABSENT half on the very same records.
+ *
+ *    ⚠️ The specimens below still spell only the `!= null` half. That is the
+ *    platform-wide state rather than an exception here (0 of the 34 authored
+ *    record-scoped action predicates across both repos use `has()`), and
+ *    migrating them changes what this LIVE fixture demonstrates, so it is
+ *    tracked separately in #8990. Read this bullet for what to write today;
+ *    read the specimens for what the runtime does with the older form.
  *  - **`contains()` / `matches()`, never `startsWith()` / `endsWith()`.** The
  *    latter two are not CEL — objectui routes them to its legacy JS evaluator
  *    with a deprecation warning, and the SERVER's engine has no answer for

--- a/packages/lint/src/validate-null-guards.ts
+++ b/packages/lint/src/validate-null-guards.ts
@@ -52,17 +52,27 @@
  * #1871/#4649). Measured against `@marcbachmann/cel-js`, the two bindings do
  * not merely differ in wording — they inarguably invert:
  *
- * | predicate                | TOTAL binding (`{a: null}`) | SPARSE binding (`{}`)  |
- * |:-------------------------|:----------------------------|:-----------------------|
- * | `has(record.a)`          | `true`  ← the trap          | `false` ← a real guard |
- * | `record.a < record.b`    | FAULT `no such overload`    | FAULT `No such key: a` |
- * | `record.a != null`       | `false` ← **the fix works** | FAULT `No such key: a` |
+ * | predicate                | TOTAL binding (`{a: null}`) | SPARSE binding (`{}`)         |
+ * |:-------------------------|:----------------------------|:------------------------------|
+ * | `has(record.a)`          | `true`  ← the trap          | `false` ← guards ABSENCE only |
+ * | `record.a < record.b`    | FAULT `no such overload`    | FAULT `No such key: a`        |
+ * | `record.a != null`       | `false` ← **the fix works** | FAULT `No such key: a`        |
  *
  * So on a total binding `has()` is uniformly true and useless while `!= null`
- * is the cure; on a sparse binding `has()` is exactly the right guard and
- * `!= null` **is itself a fault**. Running this gate over a sparse-bound
- * surface would therefore reject correct metadata and prescribe a "fix" that
- * breaks it — strictly worse than not covering the surface at all. Hence:
+ * is the cure; on a sparse binding `!= null` **is itself a fault**. That
+ * inversion is this module's whole wiring criterion: running this gate over a
+ * sparse-bound surface would reject correct metadata and prescribe a "fix"
+ * that breaks it — strictly worse than not covering the surface at all.
+ *
+ * ⚠️ Read the SPARSE column as an argument about THIS GATE's prescription, not
+ * as the sparse face's authoring rule. It is not the mirror image: a sparse
+ * surface's record can ALSO carry a projected column holding `null`, so
+ * `has()` alone is not the cure over there the way `!= null` is the cure here
+ * (`has(record.a) && record.a > 1` faults on `{a: null}`). The rule for that
+ * face is the CONJUNCTION `has(record.x) && record.x != null`, stated
+ * canonically in `materializeDeclaredFields`'s doc comment
+ * (`packages/objectql/src/declared-fields.ts`, #8975) and deferred to here.
+ * Hence:
  *
  * **This module may only be wired to a surface whose record binding is total.**
  * Necessary, not sufficient — see the `readonlyWhen` row below, where a total
@@ -141,7 +151,9 @@
  *    rather than open: #4953 clause 2 defers making this binding total —
  *    it would mean every REST read padding out all declared columns — so the
  *    face stays sparse, is documented as sparse, and an author there guards
- *    with `has()` (`declared-fields.ts` says the same from the engine's side).
+ *    with `has(record.x) && record.x != null` — BOTH halves, for the reason
+ *    measurement 4 below gives. That sentence is `declared-fields.ts`'s to
+ *    state (#8975); this row follows it and does not re-derive it.
  *    The exclusion is permanent under the current decision, not pending one.
  *
  *    **The MIRROR gate the ruling named — flag `!= null` on a sparse binding —
@@ -193,10 +205,13 @@
  *         the author a correction that breaks it"), mirrored.
  *
  *    Consequence for the sentence four lines up: "an author there guards with
- *    `has()`" is correct about SPARSENESS and insufficient on its own, and this
- *    file and `declared-fields.ts` currently state it without the `!= null`
- *    half. Correcting that authoring contract is filed separately — it changes
- *    what authors are told to write, which is not a lint change.
+ *    `has()`" was correct about SPARSENESS and insufficient on its own. That
+ *    authoring contract was corrected in #8975, which is why the row above now
+ *    reads `has(record.x) && record.x != null` — and why it points at
+ *    `declared-fields.ts` rather than spelling the rule a third time. The
+ *    correction was a separate card on purpose: it changes what authors are
+ *    TOLD TO WRITE, which is not a lint change, and it does not disturb this
+ *    row's verdict (still excluded, still permanently).
  *  - **Flow / edge `condition` — the row where `binding` and `verdict` came
  *    apart, same shape as `readonlyWhen` above.** #4811 originally excluded
  *    these for flattened-scope ambiguity ("a bare identifier may be a flow

--- a/packages/objectql/src/declared-fields.ts
+++ b/packages/objectql/src/declared-fields.ts
@@ -28,10 +28,55 @@
  * One binding is still sparse, and by decision rather than by gap:
  *
  *  - objectui's action `visible` / `disabled` binds whatever record the client
- *    already fetched. That one is a DECISION (#4953 item 2): making it total
- *    would mean every REST read padding out all declared columns, so it stays
- *    sparse and is documented as sparse — an author on that surface guards with
- *    `has()`, not `!= null`.
+ *    already fetched — a record-detail read, or a LIST ROW carrying only the
+ *    view's `$select` projection. That one is a DECISION (#4953 item 2):
+ *    making it total would mean every REST read padding out all declared
+ *    columns, so it stays sparse, permanently, and is documented as sparse.
+ *
+ * ## The authoring guard for that sparse face (#8975)
+ *
+ * **`has(record.x) && record.x != null`** — before any traversal
+ * (`record.x.k`), method call (`record.x.size()`), ordering (`< <= > >=`) or
+ * arithmetic use of `record.x`.
+ *
+ * This doc comment is the CANONICAL statement of that rule. The showcase
+ * fixture (`examples/app-showcase/src/ui/actions/predicate-matrix.action.ts`)
+ * and the surface ledger in `packages/lint/src/validate-null-guards.ts` defer
+ * to it instead of restating it — three independently worded copies of one
+ * rule is how #8975 came to exist: two of them said opposite things
+ * (`has()` "not `!= null`" here, "`!= null` is the portable form" there) and
+ * measured, NEITHER HALF ALONE IS A GUARD on this face.
+ *
+ * The reason is that two failure modes are live at once. A list row can OMIT a
+ * column (absent key) and can carry a projected column holding NULL, and each
+ * half covers exactly one of them. Measured against the canonical
+ * `@objectstack/formula` CEL engine:
+ *
+ * | predicate                                           | `{}` (absent)          | `{a: null}` (projected) | `{a: 5}` |
+ * |:----------------------------------------------------|:-----------------------|:------------------------|:---------|
+ * | `record.a != null && record.a > 1`                  | FAULT `No such key: a` | `false`                 | `true`   |
+ * | `has(record.a) && record.a > 1`                     | `false`                | FAULT `no such overload: dyn(null) > int` | `true` |
+ * | `has(record.a) && record.a != null && record.a > 1` | `false`                | `false`                 | `true`   |
+ *
+ * Only the conjunction is safe across all three bindings. Prescribing `has()`
+ * on its own does not fix the face, it MIRRORS the bug: a fault here is
+ * fail-closed, the action silently vanishes, and that is indistinguishable
+ * from the gate having said no — so trading a null-shaped vanish for an
+ * absence-shaped one buys nothing.
+ *
+ * One measured exception, recorded so the platform's existing predicates are
+ * not misread: a bare EQUALITY against a literal never faults on a null value
+ * — CEL compares heterogeneously and answers `false` — so `has(record.a) &&
+ * record.a == "high"` is already safe on all three bindings without the
+ * `!= null` half. The conjunction is correct on every shape, which is why it
+ * is what the rule prescribes; the exception explains why the 34 authored
+ * predicates that spell only `!= null` are not uniformly broken in the same
+ * way (their migration is tracked in #8990, not here).
+ *
+ * ⛔ Not enforced by a lint rule, and that is decided rather than pending: the
+ * mirror gate was evaluated and DECLINED (#8881 / PR #8979) because sparseness
+ * is a property of the view's `$select` projection and of row DATA, not of the
+ * metadata a linter sees.
  *
  * CEL is strict about missing keys: `record.x` on a record that does not carry
  * the key `x` aborts the whole expression with `No such key`, which is NOT the
@@ -64,6 +109,13 @@
  * field>)` is uniformly TRUE (a materialised `null` is a present key holding
  * null — CEL's own rule). `has()` therefore guards against an UNDECLARED key,
  * not against an empty value; test emptiness with `record.x != null`.
+ *
+ * That sentence is about the TOTAL bindings this function creates — every
+ * surface listed at the top. It is not in tension with the sparse-face rule
+ * above: on a total record the `has()` half is a tautology and `!= null` is
+ * the whole guard, while on the sparse action face the key may genuinely be
+ * absent and both halves are load-bearing. Same conjunction, one half of it
+ * simply free once the record is total.
  */
 export function materializeDeclaredFields<T extends Record<string, unknown>>(
   record: T,


### PR DESCRIPTION
Fixes #8975

Comment-only. Three platform documents described the guard idiom for the sparse action `visible`/`disabled` face and two of them said opposite things. This states the rule **once**, authoritatively, and makes the others defer to it.

## What was measured, not transcribed

The card's three-row table was re-measured against the canonical `@objectstack/formula` CEL engine (`celEngine.evaluate`, `dialect: 'cel'`) on this branch's tree. It reproduces **exactly**:

| predicate | `{}` (absent) | `{a: null}` (projected null) | `{a: 5}` |
|---|---|---|---|
| `record.a != null && record.a > 1` | FAULT `No such key: a` | `false` | `true` |
| `has(record.a) && record.a > 1` | `false` | FAULT `no such overload: dyn( null ) > int` | `true` |
| `has(record.a) && record.a != null && record.a > 1` | `false` | `false` | `true` |

So the sentence the card fixes uniquely is confirmed: **`has(record.x) && record.x != null`**, before any traversal, method call, ordering or arithmetic use.

Two extra measurements taken beyond the card's table, both of which changed what got written:

- **A bare equality against a literal does not need the `!= null` half.** `has(record.a) && record.a == "high"` is green on all three bindings — CEL compares heterogeneously and answers `false` rather than faulting. Recorded as a stated exception so the 34 existing `!= null`-only predicates are not misread as uniformly broken.
- **Traversal and method-call forms behave as the ordering row does.** `has(record.a) && record.a.size() ` faults on `{a: null}`; with the `!= null` half it does not. This is what makes the rule's "before any traversal or call" scoping load-bearing rather than decorative.

## The changes

- **`packages/objectql/src/declared-fields.ts`** — the authority. The sparse-face bullet now carries the full rule, the measured table, why neither half alone is a guard, the equality exception, and the ⛔ pointer that no lint rule enforces it. The pre-existing "test emptiness with `record.x != null`" consequence at the bottom is now explicitly scoped to the TOTAL bindings this function creates, so the two statements cannot be read as contradicting each other.
- **`examples/app-showcase/src/ui/actions/predicate-matrix.action.ts`** — the "is the portable form" authoring rule is replaced by the conjunction, with an explicit ⛔ do-not-restate pointer at `declared-fields.ts`. It also says which half each specimen falsifies in the browser (Minimal exercises NULL; the default list's `$select` exercises ABSENT).
- **`packages/lint/src/validate-null-guards.ts`** — the follower. Its own table annotation (`false` "← a real guard") is corrected to "guards ABSENCE only"; the summary paragraph keeps its wiring argument intact but no longer implies the sparse case is the clean mirror image; the action row now reads `has(record.x) && record.x != null` and defers; and the trailing "correcting that authoring contract is filed separately" paragraph is updated to record that it landed here.
- **`content/docs/automation/flows.mdx`** — added in the patch round below.

## Patch round: the fourth file, and why it was taken in-place

Review found one `content/docs` page this PR makes actively misleading. `flows.mdx`'s null-guard callout is correct about flows — it explicitly scopes itself to the TOTAL binding — but closed with:

> Guard emptiness with `record.x != null` / `isBlank(record.x)`, **same as everywhere else CEL runs**

That trailing generalization is exactly what the rest of this PR falsifies. Amended to "the same rule every other **total** binding carries", plus one paragraph naming the single sparse face and its conjunction guard, so a reader cannot carry the flows rule across to a face it breaks on. The flows rule itself is unchanged and still holds there.

Taken in-place rather than filed: same defect class as the card (a guard sentence overstating its reach), the correct form already pinned by the measurement above, no other claim on the file, and — verified, not assumed — it pulls in only additive gate families. The declared file surface is amended to four files.

Two pages were checked and **deliberately left alone**, both verified by reading the hit's context rather than the grep line:

- `content/docs/protocol/objectui/record-alert.mdx:96` looks like the fault shape but its own binding table says `record` is "the loaded record" — a total binding. Not this face.
- `content/docs/data-modeling/formulas.mdx:157-161` is correctly scoped and claims no universality.

## Scope, and what was deliberately not done

- ⛔ **The 34 authored predicates are untouched.** Migrating them is behaviour-visible (the showcase file is a live browser fixture) and outside triage's "no acceptance behavior changes" bound. Filed as **#8990**, unassigned, with the measured scoping notes.
- ⛔ Both standing refusals honored, not re-opened: #4953 clause 2 (the binding stays sparse, permanently) and #8881 / PR #8979 (no lint gate — DECLINED on measured grounds). Neither of those cards is addressed here.
- ⛔ `content/docs/releases` untouched — release-owned.

## Verification — all at `647e8fdb3` (the final commit)

Gate union re-derived with `node scripts/pm/dispatch-gates.mjs` against the **four** changed paths. Adding the docs page pulled in **two new families** (`check:docs-audit-scope`, `check:role-word`); `check:doc-anchors`, `check:doc-authoring` and the lint package's `check:doc-formula-expressions` scored silent/undetermined but are plainly implicated by a docs edit, so they were run too. All green:

```
pnpm check:nul-bytes                    ✓ 5942 text files, no raw control bytes
pnpm check:docs-audit-scope             ✓ NEW — 178 hand-written docs in sync; releases read-only
pnpm check:role-word                    ✓ NEW — 43 baselined files, no new occurrences
pnpm check:doc-anchors                  ✓ 228 internal fragment links across 396 files resolve
pnpm check:doc-authoring                ✓ 376 files clean, no bare metadata literals
pnpm check:cross-package-test-inputs    ✓ 12 packages read outside themselves, all declared
node scripts/check-cross-package-test-inputs.mjs  ✓ 67 read seams, none invents an answer
pnpm check:durability-log-level         ✓ 25 durability-critical catch seams, all loud
node scripts/check-engine-split-ratio.mjs         ✓ ADR-0076 D7 metric printed
lint check:doc-formula-expressions      ✓ 22 record-scoped formula examples across 395 files clean
apps/docs fumadocs-mdx                  ✓ MDX regenerates — the new callout paragraph parses
```

Packages, at `3c5c5945c` (the patch commit is MDX-only and touches no package source, so these were not re-run — stated rather than implied):

```
pnpm --filter 'PKG^...' build                   → exit 0 (dependency closure, all three)
typecheck  objectql · lint · example-showcase   → Done, exit 0
@objectstack/lint      test →  73 files, 2047 tests passed
@objectstack/objectql  test → 211 files, 3721 tests passed
example-showcase       test →  20 files,  221 tests passed
```

(`PKG` stands in for each package name — GitHub's body sanitizer strips an angle-bracket placeholder even inside a fence, which is why it is spelled this way.)

Downstream-consumer sweep not applicable in either direction: no type, export or signature changed. No ablation and no reverse verification were run, deliberately: the diff is comment-only, so there is no artifact to mutate and no diagnostic that could flip direction — the falsifiable measurement carrying this PR is the positive engine table above.

`skip-changeset`: the diff is comments plus one docs page — it releases nothing and changes no runtime behaviour, so no changeset is owed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_