### PR TITLE
perf(devx): hoist findEscapingPackages() out of unionInto's per-declaration loop

### DIFF
--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -702,12 +702,20 @@ function unionInto(listPath, changedPath) {
     .filter(Boolean);
 
   const present = new Set(items.map((i) => i.name));
+  // findEscapingPackages() walks packages/, apps/ and examples/ in full and reads
+  // every *.test.* file it finds; its answer does not vary between iterations of
+  // the loop below, so it is indexed ONCE here rather than re-walked per matching
+  // declaration. Nothing between here and the old per-iteration call site writes
+  // to packages/apps/examples (the only write in this function is the final
+  // `writeFileSync(listPath, ...)`, to the turbo-ls.json output, after this
+  // point), so hoisting cannot change what the walk sees.
+  const escapingDirs = new Map([...findEscapingPackages()].map(([n, info]) => [n, info.dir]));
   const added = [];
   for (const [name, { globs }] of Object.entries(CROSS_PACKAGE_TEST_INPUTS)) {
     if (present.has(name)) continue;
     const hit = changed.find((f) => matchesAny(f, globs));
     if (!hit) continue;
-    const dir = [...findEscapingPackages()].find(([n]) => n === name)?.[1]?.dir;
+    const dir = escapingDirs.get(name);
     if (!dir) continue;
     items.push({ name, path: join(REPO_ROOT, dir) });
     added.push(`${name}  (declared glob matched ${hit})`);


### PR DESCRIPTION
Fixes #8900

## What

`check-cross-package-test-inputs.mjs`'s `unionInto()` (Layer A — the `turbo ls
--affected` union that runs on the CI PR path) called `findEscapingPackages()`
— a full `packages/`/`apps/`/`examples/` walk that reads every `*.test.*` file
it finds — once per declared radius the diff touched, inside the
per-declaration loop. `findEscapingPackages()` takes no arguments and its
answer does not vary between calls, so this repeated the whole-repo walk once
per matching declaration for nothing.

Fix: index it once into a `name → dir` map before the loop, and look up by
`name` inside it, instead of re-walking and re-`find`ing per iteration.

```diff
   const present = new Set(items.map((i) => i.name));
+  const escapingDirs = new Map([...findEscapingPackages()].map(([n, info]) => [n, info.dir]));
   const added = [];
   for (const [name, { globs }] of Object.entries(CROSS_PACKAGE_TEST_INPUTS)) {
     if (present.has(name)) continue;
     const hit = changed.find((f) => matchesAny(f, globs));
     if (!hit) continue;
-    const dir = [...findEscapingPackages()].find(([n]) => n === name)?.[1]?.dir;
+    const dir = escapingDirs.get(name);
     if (!dir) continue;
```

`--verify` and `--list-escapes` each call `findEscapingPackages()` exactly
once and are untouched by this PR — only `unionInto`'s loop changes.

## Why the hoist is safe (no behaviour change)

Nothing between the old per-iteration call site and the new pre-loop call
site writes to `packages/`, `apps/` or `examples/` — the only write in
`unionInto` is the final `writeFileSync(listPath, ...)`, which targets the
`turbo ls` JSON output file, not the source tree, and happens *after* both
call sites. So the walk sees an identical tree at either point and its
result cannot diverge.

## Proof: byte-identical output, old vs new, on a diff that hits multiple declarations

Constructed a synthetic changed-files list that trips **9 of the repo's 12**
`CROSS_PACKAGE_TEST_INPUTS` declarations at once (a single-declaration diff
can't distinguish the two implementations — the loop only runs once):

```
packages/platform-objects/src/foo.object.ts   → @objectstack/spec, @objectstack/platform-objects, @objectstack/plugin-auth
packages/core/src/index.ts                    → @objectstack/core
packages/spec/src/security/rls.zod.ts         → @objectstack/plugin-security, @objectstack/formula
scripts/check-durability-degradation-log-level.mjs → @objectstack/metadata-protocol
packages/spec/package.json                    → @objectstack/downstream-contract
content/docs/guides/foo.mdx                   → create-objectstack
```

Method: committed the fix first (restore point). Ran the post-fix script
against the synthetic input. Then temporarily overwrote the working-tree
file with the pre-fix content (`git show HEAD~1:scripts/check-cross-package-test-inputs.mjs`,
via plain `cp`, not staged) and ran it against the same input. Restored with
`git checkout HEAD -- scripts/check-cross-package-test-inputs.mjs` (index and
tree both back to the committed fix; confirmed with a `0`-line
`git diff --stat HEAD` afterward). Diffed both the mutated `turbo-ls.json`
and stdout, old vs new, byte-for-byte:

```
$ diff old-out.json new-out.json && echo IDENTICAL
IDENTICAL
$ diff old-stdout.txt new-stdout.txt && echo IDENTICAL
IDENTICAL
$ sha256sum old-out.json new-out.json
2bb5cbd...  old-out.json
2bb5cbd...  new-out.json          # same hash
$ sha256sum old-stdout.txt new-stdout.txt
65d8502...  old-stdout.txt
65d8502...  new-stdout.txt        # same hash
```

stdout (identical both runs):

```
Cross-package scans pulled into this run because the diff touched their declared inputs:
  + @objectstack/spec  (declared glob matched packages/platform-objects/src/foo.object.ts)
  + @objectstack/core  (declared glob matched packages/platform-objects/src/foo.object.ts)
  + @objectstack/platform-objects  (declared glob matched packages/platform-objects/src/foo.object.ts)
  + @objectstack/plugin-auth  (declared glob matched packages/platform-objects/src/foo.object.ts)
  + @objectstack/plugin-security  (declared glob matched packages/spec/src/security/rls.zod.ts)
  + @objectstack/formula  (declared glob matched packages/spec/src/security/rls.zod.ts)
  + @objectstack/metadata-protocol  (declared glob matched scripts/check-durability-degradation-log-level.mjs)
  + @objectstack/downstream-contract  (declared glob matched packages/spec/src/security/rls.zod.ts)
  + create-objectstack  (declared glob matched content/docs/guides/foo.mdx)
```

Two more cases, same method, both also byte-identical:
- a diff matching **zero** declarations (`README.md`) — same `"No
  cross-package scan..."` stdout, same untouched `items` array.
- a diff matching several declarations where **two are already present** in
  `items` (exercises the `present.has(name) → continue` branch, which never
  reaches the lookup) — same stdout, same `items` array.

## Speed, for context (not the acceptance bar — unchanged output is)

Same 9-declaration-hit input, 3 runs each, wall clock:

```
NEW (1 walk/run):  real 0m0.984s   (~0.33s/run)
OLD (9 walks/run): real 0m6.880s   (~2.29s/run)
```

## One stale number, re-derived

The card's own body carries a stale figure (it repeats issue #8900's original
"PR #8899 raises the declaration count from 9 to 12"); the dispatch also
flagged that as possibly stale and asked me to re-derive rather than trust
it. Measured on this PR's base (`main` @ `ab4bb08b`, i.e. after #8991):
`CROSS_PACKAGE_TEST_INPUTS` has **12** entries. Doesn't change the fix or its
verification — the loop still runs at most once per declaration either way —
noted only because the card's premise text asked for it to be checked.

## Out of scope (left alone, per the dispatch)

`--verify` / `--list-escapes` call sites, `CROSS_PACKAGE_TEST_INPUTS` entries,
`turbo.json`, `content/docs/releases/`.

## Tests

- `pnpm check:cross-package-test-inputs` (lint.yml) — self-test (26/26) +
  `--verify`: `OK: 12 package(s) read outside themselves, all declared, and
  turbo.json hashes every declared glob.`
- `node scripts/check-cross-package-test-inputs.mjs` (ci.yml, bare
  `--verify` default) — same `OK` line.
- `pnpm check:nul-bytes` (any-edit gate) — green (`5943 text file(s)`
  scanned, `0` raw control bytes).
- `node scripts/pm/dispatch-gates.mjs scripts/check-cross-package-test-inputs.mjs`
  re-derived against the actual changed path — matches exactly the two named
  families above (`check:cross-package-test-inputs` [lint.yml],
  `check:cross-package-test-inputs.mjs` bare [ci.yml]); no additional family
  is implicated by this diff (no test file added/edited, no i18n config
  touched).
- `npx eslint scripts/check-cross-package-test-inputs.mjs --no-inline-config`
  — clean, no findings.
- Head at report time: `338e27184` (`git rev-parse --short HEAD`), same
  commit the gate runs above were taken against.

## Changeset

`scripts/` is not published package source → `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_
