### PR TITLE
docs(deployment): put widget-binding integrity on the runtime publish door

### DIFF
--- a/content/docs/deployment/validating-metadata.mdx
+++ b/content/docs/deployment/validating-metadata.mdx
@@ -58,6 +58,18 @@ dashboard, widget, filter, field, and object. Opt a widget out with
 `filterBindings: { <name>: false }`, or re-target the filter to one of that
 object's own fields.
 
+This is no longer only a CLI verdict. Since #7529 the same rule also runs at the
+**runtime publish door** for `dashboard` writes, so a board published from
+Studio, `PUT /api/v1/meta/*` or an MCP/AI author is refused there too — the same
+located `422 invalid_metadata` envelope, naming the dashboard, the widget and the
+key path. All six of the rule's error-tier findings gate that door as one "this
+board cannot render" class, the filter-field arm above included, while its
+warnings still ride the advisory channel and never block. So an author working
+entirely in Studio, who never runs `os validate`, no longer ships a silently
+empty chart. A **draft** save may still hold a forward reference — the refusal
+lands on the draft→active promotion, per
+[The one gate, four doors](#the-one-gate-four-doors) below.
+
 ### 3. Dead action/route references
 
 A dashboard `header.actions[]` button names a target: a `script`/`modal` action,
@@ -371,7 +383,7 @@ one. `sys_metadata` overlay rows are not in any config file, so there is no
 | CEL / predicate validation (ADR-0032) | ✓ | ✓ | ✓ | ✓ᶠ |
 | List-view navigation modes (ADR-0053) | ✓ | ✓ | ✓ | — |
 | View container shape | ✓ | ✓ | ✓ | — |
-| Widget-binding integrity (ADR-0021) | ✓ | ✓ | ✓ | — |
+| Widget-binding integrity (ADR-0021) | ✓ | ✓ | ✓ | ✓ᵈ |
 | Dashboard action/route references (ADR-0049) | ✓ | ✓ | ✓ | — |
 | Filter placeholder resolvability (#3574) | ✓ | ✓ | ✓ | — |
 | Empty filter combinators — `$and: []`, `$or: []`, `$not: {}` (#5330) | ✓ | ✓ | ✓ | ✓ᶠ |
@@ -399,11 +411,13 @@ one. `sys_metadata` overlay rows are not in any config file, so there is no
 | Emits `dist/objectstack.json` | — | ✓ | — | — |
 
 **`✓ᶠ` means the rule runs at that door for `flow` writes; `✓ᵛ` for `view`
-writes.** Those are the two metadata types rules declare there today — #4463
-shipped P1 as one type and four rule families, and #7220 added the second type
-by moving the whole `views[]` visibility-predicate family across in one edit. So
-an object, page or dashboard save is still checked by the schema parse and by
-nothing else, and the `—` cells above are `—` for two different reasons: some
+writes; `✓ᵈ` for `dashboard` writes.** Each marker names the metadata types that
+rule's own `runtimeTypes` declares, and that entry in `AUTHORING_RULES` is the
+authority — the set has grown a type at a time (#4463 shipped P1 as `flow` and
+four rule families, #7220 moved the whole `views[]` visibility-predicate family
+across in one edit, #7529 put widget-binding integrity on `dashboard`), so read
+the rule rather than assuming a save of some other type reaches storage
+unjudged. The `—` cells above are `—` for two different reasons: some
 rules read a stack-wide collection a one-item write does not carry (pages,
 dashboards, navigation, permission sets), and some parse authored source through
 `typescript`, which the kernel boot path must never load.


### PR DESCRIPTION
Fixes #8903

#7529 flipped `validateWidgetBindings` from `surfaces: CLI_ONLY` to `CLI_AND_RUNTIME` with `runtimeTypes: ['dashboard']`, so a dangling widget dataset binding is now refused at the **runtime publish door** — `sys_metadata` overlay writes via Studio, `PUT /api/v1/meta/*`, MCP — not only by `os validate` / `os build` / `os lint`. `content/docs/deployment/validating-metadata.mdx` still presented it as a CLI-only concern, which is exactly the belief #7529 existed to end: an author working entirely in Studio now gets a located 422 at publish, and the page told them the overlay path was unchecked.

Docs-only. Verified against `origin/main` @ `1a7f9073e`, sourced from `packages/lint/src/authoring-rules.ts` and `packages/lint/src/validate-widget-bindings.ts`, not from the card's summary.

## The three corrections

**1. §2 "Dangling widget bindings" gains the publish-door paragraph.** The card named §2 as the natural home, and it is: §2's second paragraph already documents the `dashboard-filter-field-unknown` arm, which is one of the six error ids that crossed. The paragraph states the located `422 invalid_metadata` envelope, that all six error-tier findings gate as one "this board cannot render" class while warnings still ride the advisory channel, and the ruled carve-out that a **draft** may hold a forward reference — the refusal lands on the draft to active promotion.

**2. The "one gate, four doors" table row was flatly false.** `Widget-binding integrity (ADR-0021)` carried `—` in the `runtime publish` column. That is the machine-readable form of the same claim, and it is now wrong, so it becomes `✓ᵈ` (a new marker for `dashboard` writes, alongside the existing `✓ᶠ` / `✓ᵛ`).

**3. The footnote below the table is falsified by that row — and it loses the hard count rather than gaining a wrong one.** It asserted "Those are the **two** metadata types rules declare there today" and "So an object, page or **dashboard** save is still checked by the schema parse and by nothing else." My row edit contradicts both, two lines apart, so leaving it would be worse than either state.

I did not write "three". Measured against `AUTHORING_RULES`, three is *also* false — `validatePresetComparands` declares `runtimeTypes: ['dashboard', 'view', 'object', 'page', 'flow']` and `validateSecurityPosture` declares `['seed', 'permission', 'book', 'object']`, so object, page, seed, permission and book are gated there too. Adjusting a number to match an assumption is the trap this very card flags about the "five publish gates" heading, so the sentence now points at each rule's own `runtimeTypes` as the authority and makes no closed-set claim. Those other two rows are separately stale and are filed, not fixed here (below).

## The "five publish gates" question: **unchanged — the count is correct, no edit**

The card deliberately did not assert this was wrong, so I read the section before touching anything. The verdict is that the two "publish gates" are **different populations that share a phrase**.

`content/docs/protocol/kernel/http-protocol.mdx` line 1246 `### The five publish gates` is nested under `## Declarative Endpoints (apis:)` (line 1154). Its five are the **per-endpoint** gates on an `apis:` declaration under ADR-0121 — Namespace, Supported target, Mapping, Policy, Uniqueness — each rejecting a malformed *endpoint declaration*. `packages/lint`'s `validateWidgetBindings` is an authoring rule over dashboard metadata; it is not an endpoint gate, and the #7529 flip neither adds a sixth member to that table nor widens any of the five. The same five are described consistently at `content/docs/references/system/stack-server.mdx:59` and in the `App.apis` removal note in `content/docs/references/ui/app.mdx:83`.

So the flip does neither of the two things the card asked about — it does not add a gate there and does not widen one. **That half is closed with no change.**

## Verification

Gate union re-run **after** the final commit, at `d39e165e2` with a clean tree (the first run predated the commit; re-run so the green is over the head tree):

```
check-nul-bytes: OK (scanned 5945 text file(s); no raw ASCII control bytes)
check-doc-anchors: 228 internal #fragment link(s) across 396 source file(s) all resolve to a real heading
check-audit-scope: docs-accuracy-audit scope in sync — 178 hand-written doc(s)
                   release-owned pages in scope and read-only — 9 page(s) review-only
check-role-word: OK (43 baselined file(s), no new occurrences)
check-doc-authoring: 376 files clean — no bare metadata literals
```

Derived with `node scripts/pm/dispatch-gates.mjs content/docs/deployment/validating-metadata.mdx`, which named `check:docs-audit-scope` and `check:role-word`; I added `check:nul-bytes` (any edit), `check:doc-anchors` (I added a fragment link) and `check:doc-authoring` (docs corpus). `check:doc-anchors` is the one that matters for the new link — my only added link is the same-page fragment `#the-one-gate-four-doors`, and it resolves. No page-path link was added or changed, so the `Check Documentation Links` job's lychee half has nothing new to resolve; that heading is also deep-linked from `content/docs/deployment/cli.mdx:459` and is unchanged.

`skip-changeset`: docs-only, releases nothing.

## Boundaries respected

- `content/docs/releases/v17.mdx` and `v9.mdx` untouched — release-owned.
- `content/docs/concepts/metadata-lifecycle.mdx:110` untouched — the card pre-recorded that its `dashboard` row is about org-overlay semantics, not validation timing.
- Skimmed `hook-bodies.mdx`, `services-checklist.mdx`, `authorization.mdx` as advised; nothing about widget-binding validation timing. Low yield as predicted.
- `packages/lint/src/validate-null-guards.ts`, `packages/objectql/src/declared-fields.ts` and `examples/app-showcase/src/ui/actions/predicate-matrix.action.ts` untouched — PR #8997 owns those. I confirmed from its head that its file surface does not overlap this page.

_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_