### PR TITLE
docs(tooling): keep the read-seam rule's repaired #8845 exhibit as history and record the blind-spot measurement

### DIFF
--- a/scripts/check-durability-degradation-log-level.mjs
+++ b/scripts/check-durability-degradation-log-level.mjs
@@ -539,17 +539,64 @@ const FAILURE_PROPAGATION_SITES = new Map([
 //     — cuts the red set to 2, but buys that by exempting three REAL instances:
 //     `searchAll`'s per-object `continue` (hits silently short while
 //     `totalHits` is still reported as the count), `findReferencesToMeta`, and
-//     `cascadeDeleteRelations`, where a failed dependents probe skips a
-//     `restrict` guard altogether. Tuning a criterion until only the instance
-//     you already knew about is red is how a gate stops meaning anything.
+//     `cascadeDeleteRelations`, where a failed dependents probe skipped a
+//     `restrict` guard altogether (repaired since by #8895 — see EXHIBIT
+//     STATUS below; the other two are unchanged, so the narrowing still buys
+//     its number by exempting live instances). Tuning a criterion until only
+//     the instance you already knew about is red is how a gate stops meaning
+//     anything.
 //   - Even where the verdict is right, the ACCUMULATOR is often the wrong
 //     variable: `findReferencesToMeta`'s harm lives in `out`, not in the flagged
-//     `items`; `cascadeDeleteRelations` and `checkGovernance` have no
-//     accumulator at all, only a skipped guard. A message naming the wrong
-//     variable teaches the wrong fix.
+//     `items`; `checkGovernance` (#8906, still open) — and
+//     `cascadeDeleteRelations` as it read when measured — have no accumulator
+//     at all, only a skipped guard. A message naming the wrong variable
+//     teaches the wrong fix.
 //   - And the SCOPE is the only thing holding the line: drop the READ
 //     vocabulary and this shape matches 91 of the 314 catch clauses in these
 //     three roots.
+//
+// EXHIBIT STATUS — one instance named above has since been repaired, and the
+// numbers are deliberately NOT restated for it.
+//
+// Every count in this block measures `origin/main` @ 8664a2c and stays at its
+// measured value. Re-deriving the census against today's tree would swap a
+// reproducible number for an undated one, and decrementing it by hand would be
+// arithmetic standing in for a census — the count is not the argument, and a
+// number nobody can re-run is worth less than a smaller one anchored to a
+// commit. The anchor is checkable: run this gate at 8664a2c and it still
+// answers `66 read seam(s)`; today's main answers 67, a seam the scan roots
+// gained after that commit and NOT from #8895 (which moves nothing — below).
+//
+//   - `cascadeDeleteRelations` — REPAIRED by #8895. Its dependents probe now
+//     asks the declared `isMissingTableError` predicate and rethrows the rest,
+//     so the fail-open `continue` described above is gone. Kept as the worked
+//     example because its harm is still the clearest of the three to state,
+//     not because the seam is still open.
+//   - `searchAll`, `findReferencesToMeta`, `checkGovernance` — UNCHANGED, each
+//     re-read on its own rather than assumed to have moved with #8895
+//     (`checkGovernance` is #8906, open; the other two are metadata-protocol).
+//
+// The conclusion below is unaffected, and #8895 is evidence FOR it twice over.
+//
+// FIRST, the numbers: this gate's output is BYTE-IDENTICAL before and after
+// that fix — `67 read seam(s) … (7 … discriminated) (1 pass … through) (1
+// baselined)` on both trees, measured by ablating the fix back to its
+// pre-#8895 `catch { continue }` and re-running. And the seam is not merely
+// unseen: plant a `return []` in that same catch and the gate names it
+// (`engine.ts:10084 (in cascadeDeleteRelations())`, red). So it sits IN the
+// census throughout, reported clean while it was broken and reported clean now
+// that it is fixed — what decides visibility is the SHAPE of the exit, never
+// whether the seam is correct. A real fail-open on an integrity guard was
+// found, fixed and landed with nothing in this file able to see any of it:
+// surveyed, cleared, harmful — the #6116 shape a fourth time, and the sharpest
+// demonstration available that the blind spot is worth closing eventually.
+//
+// SECOND, the shape of that fix is the direction this block argues for: #8895
+// discriminates through a DECLARED predicate rather than a hand-rolled code
+// test — the "declared, checkable fact" the paragraph below asks for, applied
+// by hand at one seam precisely because no gate could ask for it.
+//
+// So: one exhibit repaired, no criterion made affordable, no verdict moved.
 //
 // The honest conclusion is that this shape does not need a looser invention
 // criterion. It needs the read-seam rule to acquire its OWN declared


### PR DESCRIPTION
Fixes #9004

Comment-only change to `scripts/check-durability-degradation-log-level.mjs`. The gate's behaviour, vocabulary, scan roots and baselines are untouched — the diff is 53 added / 6 removed lines, every one of them a comment line.

## The problem

The header block *"Measured and DELIBERATELY NOT added — the FALL-THROUGH / empty-accumulator criterion (#8845)"* named `cascadeDeleteRelations` in the present tense, twice, as a live fail-open instance. That seam was repaired by #8895 (`a751f7d4f`), so the block taught a repaired defect as a current one.

Both failure modes were live:

- **deleting** the exhibit would destroy the evidence for a decision still in force — the block exists so the next author reads the numbers before re-proposing the criterion, and #8901 cites it as the authority for exactly that;
- **leaving it** would send the next reader to a seam they will find already repaired, from which the whole measurement reads stale.

So the exhibit is kept **as history**, with its tense made true.

## Does the measurement's conclusion survive? Yes — and #8895 strengthens it

Checked leg by leg. The conclusion ("this shape does not need a looser invention criterion; it needs a declared failure-propagation vocabulary") rests on six supporting arguments. Five are untouched by #8895. The sixth — the jump-only narrowing that "buys its number by exempting three REAL instances" — needs at least one genuine instance to stand, and still has two.

Two ways #8895 is evidence *for* the conclusion, both now recorded in the block:

1. **The gate's output is byte-identical before and after the repair** — `67 read seam(s) … (7 … discriminated) (1 pass … through) (1 baselined)` on both trees. Measured by ablating the repair back to its pre-#8895 `catch { continue }` and re-running, with the ablation's diff scope proven to be the single intended hunk.
2. **The shape of the repair is the direction the block argues for** — it discriminates through a *declared* predicate (`isMissingTableError`) rather than a hand-rolled code test. That is the "declared, checkable fact" the block asks for, applied by hand at one seam because no gate could ask for it.

I went one step past the filed measurement: planting a `return []` in that same catch turns the gate **red**, naming `engine.ts:10084 (in cascadeDeleteRelations())`. So the seam sits **in** the census throughout — reported clean while it was broken, and reported clean now that it is repaired. What decides visibility is the *shape of the exit*, never whether the seam is correct. Surveyed, cleared, harmful: the #6116 shape a fourth time.

## The number question — anchored, not decremented

No census number is changed. The block already anchors every count to `origin/main` @ `8664a2c`, and I verified that anchor is real rather than decorative: the gate answers **66 read seams** at `8664a2c` and **67** on today's `main`. The extra seam was gained after that commit, and is *not* from #8895 — the ablation moves nothing.

Decrementing by hand would have been arithmetic standing in for a census. Re-deriving the whole census against today's tree would have swapped a reproducible number for an undated one, and re-done #8845's work inside a documentation-accuracy card. Instead the anchoring is made explicit and load-bearing, so the numbers stay checkable by anyone who runs the gate at that commit.

## Each exhibit verified independently

Not assumed to have moved together with #8895:

| exhibit | state |
|:--|:--|
| `cascadeDeleteRelations` (objectql) | **repaired** by #8895 — discriminates, then rethrows |
| `searchAll` (metadata-protocol) | unchanged, live — silent per-object `continue` |
| `findReferencesToMeta` (metadata-protocol) | unchanged, live — silent valueless `return` |
| `checkGovernance` (objectql lifecycle) | unchanged, live — #8906 remains open |

## Verification

Union re-run **after** the final commit, at `80fdecc9d`, clean tree:

- `pnpm check:durability-log-level` — pass, including its 35-case read-seam self-test. Its output is identical to the pre-edit baseline, which is the direct proof the change is inert.
- `pnpm check:cross-package-test-inputs` — pass. Not named in my dispatch prompt; picked up by re-deriving `node scripts/pm/dispatch-gates.mjs` against the actual changed path.
- `node scripts/check-nul-bytes.mjs` — pass, plus a control-character self-scan over the edited file, since the change discusses code shapes.

`skip-changeset`: `scripts/`-only and comment-only, so nothing user-visible is released.

## Out of scope

- #8897 (`pm:on-hold`) names this file as its restart trigger. Its three-way is answered on that card: **declined here and re-held on the same trigger**, with the hold's premise re-verified (the one live injected-logger seam still invents no answer, so the misclassification remains unreachable). It is not addressed in this PR.
- #8901 remains open and #8906 remains open. Neither is touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_