### PR TITLE
docs(pm-dispatch): claim protocol reads triage-named cross-lane siblings for pin read-coupling; tier quoted from derivation

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -360,21 +360,22 @@ PR 前合一次 main;③ 兄弟卡落地后再合一次;④ 冲突交合并队�
    > Worktree: `<repo>-issue-<n>`
    > Domain: `domain:<x>`
    > File surface: `<预期触碰的目录>` (stop on breach; explain in the report)
-   > Container & model: `<S 级机械卡 / M / L>`, `mode:subagent | mode:cloud`, `model: sonnet | opus | fable`
-   > Serial constraints cleared: `<点名同文件/同包的前驱 PR 与在飞认领;无则 "none">`
+   > Container & model: `<S 级机械卡 / M / L>`, `mode:subagent | mode:cloud`, `model: sonnet | opus | fable`(档位引当次 `node scripts/pm/dispatch-gates.mjs --tier <paths>` 输出,⛔ 不凭记忆)
+   > Serial constraints cleared: `<点名同文件/同包的前驱 PR 与在飞认领,及分诊点名的任意车道在飞兄弟卡中本卡 pin 断言其行为者;无则 "none">`
 
-末行把「查过串行约束」变成落在评论里的读数(同包在飞单不点名等于没查);文件面对跨域例外单**必
-填**、普通单建议(定向在飞检查与 epic 领地判断的唯一输入);分支名必须带 issue 号(否
-则 `ls-remote | grep issue-<n>` 找不到)。**Assign 与评论是不可分割的一个动作,限流不拆它**
-—— 评论发不出就撤 assign 或压根不开始;配额没了就把整对排队,永不留半个。
+末行把「查过串行约束」变成落在评论里的读数(同包在飞单不点名等于没查);兄弟卡必读,因为文件面
+不相交挡不住**读耦合**:本卡 pin 断言兄弟卡在改的行为 ⇒ 各自全绿、先合者令后者 CI 无因变红;派
+发令点名跨车道兄弟时**应**注明本卡 pin 是否断言其面,是则在用例内预登记翻转触发词(兄弟行为落
+地即变红:删除或反转,⛔ 不修绿)。文件面对跨域例外单**必填**、普通单建议(定向在飞检查与 epic
+领地判断的唯一输入);分支名必须带 issue 号(否则 `ls-remote | grep issue-<n>` 找不到)。**Assign
+与评论是不可分割的一个动作,限流不拆它**:发不出评论就撤 assign 或不开始;配额尽则整对排队,永不留半个。
 3. **竞态复读**:自己的认领评论上墙后重读全线程 —— assignment 幂等,两个 agent 都会「成功」,**
    认领评论时间戳是唯一仲裁**;更早的评论带不同 session ID/分支 ⇒ 你输了,回「already claimed
    — yielding」另选。**让行是交接不是退场**:连同让行评论交出已诊断的一切与 PM 侧已取的板面读
    数(复现命令、依赖路径、已确认的坑、在飞同文件PR、区域申报、串行约束),赢家不必重扫。
 
-dev 侧推分支要早 —— 远程分支是在飞工作最硬的证据。**Stale-claim reclaim**:认领
->~24h、承诺的分支不存在、无 PR ⇒ 视为死认领 —— 评论询问,再静默一窗后摘 assignee
-(注明原因)回队;有带提交的活分支的认领永不回收。
+dev 侧推分支要早 —— 远程分支是在飞工作最硬的证据。**Stale-claim reclaim**:认领 >~24h、承诺分支
+不存在、无 PR ⇒ 死认领 —— 评论询问,静默一窗后摘 assignee(注明原因)回队;有带提交活分支的认领永不回收。
 
 ### 派发
 


### PR DESCRIPTION
Fixes #8281

## What this changes

All edits are in `.claude/skills/pm-dispatch/SKILL.md`, 认领 (claim) section — the graded deliverable plus the PM's declared rider, per the skills-seat grading on the card:

1. **`Serial constraints cleared:` required reading extended** (graded deliverable, direction 1): the claim template line now also names, beyond same-file/same-package in-flight work, the in-flight cards named as siblings by triage — in any lane — whose behaviour this card's pins assert about. Direction 3 (a global in-flight check) stays rejected; the addition is scoped to the already-surfaced triage-named sibling set.
2. **Read-coupling rationale + the SHOULD** (direction 2's pre-registration habit): the explanatory paragraph states the incident class self-contained (file-disjoint batches still collide when one card's pins encode a fact about a behaviour a sibling card is changing — both suites green in isolation, the first merge turns the other's CI red for reasons its own diff cannot explain), and adds the SHOULD: when a dispatch order names a cross-lane sibling, it states whether this card's pins assert about that sibling's surface — if yes, the flip trigger is pre-registered in the test file (goes red the day the sibling's behaviour lands: delete or invert, never repair to green).
3. **Declared rider**: the claim template's `Container &amp; model:` line now carries the derived-tier reference — the tier is quoted from the current `node scripts/pm/dispatch-gates.mjs --tier` output, never recalled.

## Ratchet funding

SKILL.md ceiling is 686; the file was at 685 (headroom 1). The additions were funded by compressing the stale-claim paragraph (3 lines to 2) and densely rewrapping the claim-notes paragraph, landing the file at exactly **686 = ceiling, net +1** — within the card's declared budget (net growth at most 1). No raise of the ceiling; id-lint clean (no issue-ID citations in the new text); frame-sync anchors untouched; new prose Chinese, machine literals (template field names, the `--tier` invocation) English.

## Verification

Full gate union run at final commit **05d564717** (`git rev-parse --short HEAD` from the same run), all green:

- `pnpm check:pm-skill-ratchet` — SKILL.md 686/686, pass
- `pnpm check:pm-skill-id-lint` — 9 file(s) clean
- `pnpm check:skill-frame-sync` — 4 copies isomorphic across 3 files
- `pnpm check:skill-frame-freshness` — frame current with origin/main
- `pnpm check:nul-bytes` — 5955 text files clean
- `pnpm check:doc-authoring` — 376 files clean (derivation-added family, not in the dispatch prompt's list)
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — clean after building the lint dependency closure (derivation-added family)

Gate list re-derived from the actual changed path with `node scripts/pm/dispatch-gates.mjs .claude/skills/pm-dispatch/SKILL.md`; the tier half of the same derivation mandates `claude-fable-5` for this path, which is the tier this card ran at.

## Landing

This PR edits the PM dispatch skill (ADR-class per the grading comment): **human merge only** — please do not ready, queue, or arm auto-merge; the maintainer lands it by hand. No changeset: `.claude/`-only change, releases nothing (`skip-changeset` applied).

_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_