### PR TITLE
fix(devx): cap the docs-drift-check PR comment above 15 editable rows

### DIFF
--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -73,6 +73,17 @@ jobs:
             // their own section, carrying the instruction that makes them safe.
             const readOnly = data.releaseOwnedDocs || [];
             const editable = docs.filter(d => !readOnly.includes(d));
+            // Above this many editable rows, the list stops carrying per-PR information: a
+            // hub package (referenced by nearly every hand-written doc) posts the same
+            // near-invariant dump on every PR that touches it, relayed in full into every
+            // subscribed agent session on every push (#9037). Measured against this repo's
+            // actual per-package referencing-doc counts: @objectstack/spec sits at 106
+            // editable rows, the next-largest non-hub packages (cli/core/runtime) at 18-19,
+            // and the smallest packages that still warrant a real list (e.g.
+            // @objectstack/client) at 11 — 15 sits in the gap between those two clusters,
+            // so the suggested default is kept as-is.
+            const EDITABLE_ROW_CAP = 15;
+            const capped = editable.length > EDITABLE_ROW_CAP;
             let body;
             if (docs.length === 0) {
               body = `${marker}\n### 📓 Docs Drift Check\nNo hand-written docs reference the ${pkgs.length} changed package(s). ✅`;
@@ -84,26 +95,44 @@ jobs:
                 '### 📓 Docs Drift Check',
                 `This PR changes **${pkgs.length}** package(s): ${pkgs.map(p => `\`${p}\``).join(', ')}.`,
               ];
-              if (editable.length) {
+              if (capped) {
+                // NO row list above the cap — folding rows behind a details tag would
+                // still ship every row's bytes to the event relay that pushes this
+                // comment into subscribed agent sessions; only actually omitting them
+                // caps the tokens. The re-derivation command is the escape hatch: full
+                // fidelity is one command away, never lost.
                 body.push(
                   '',
-                  `**${editable.length}** hand-written doc(s) reference the affected code and may need an implementation-accuracy re-verification:`,
-                  '',
-                  editable.map(row).join('\n'),
+                  `**${editable.length}** hand-written doc(s) reference the affected code — list omitted above ${EDITABLE_ROW_CAP} rows. Re-derive: \`node scripts/docs-audit/affected-docs.mjs --json origin/${baseRef}\`.`,
                 );
-              }
-              if (readOnly.length) {
-                body.push(
-                  '',
-                  `⛔ **${readOnly.length}** release-owned page(s) ${editable.length ? 'also ' : ''}reference the affected code. These are **read-only**:`,
-                  '',
-                  readOnly.map(row).join('\n'),
-                  '',
-                  '> `content/docs/releases/` is RELEASE-OWNED (AGENTS.md "Documentation Guardrails"): release',
-                  '> notes are written centrally at release time, and a code PR that edits them is the exact PR',
-                  '> that guardrail exists to stop. They are still audited — read-only. If one of them is actually',
-                  '> wrong, **file an issue** or open a dedicated docs-only PR; do not edit it here.',
-                );
+                if (readOnly.length) {
+                  body.push(
+                    '',
+                    `⛔ **${readOnly.length}** release-owned page(s) also affected — read-only, see AGENTS.md Documentation Guardrails.`,
+                  );
+                }
+              } else {
+                if (editable.length) {
+                  body.push(
+                    '',
+                    `**${editable.length}** hand-written doc(s) reference the affected code and may need an implementation-accuracy re-verification:`,
+                    '',
+                    editable.map(row).join('\n'),
+                  );
+                }
+                if (readOnly.length) {
+                  body.push(
+                    '',
+                    `⛔ **${readOnly.length}** release-owned page(s) ${editable.length ? 'also ' : ''}reference the affected code. These are **read-only**:`,
+                    '',
+                    readOnly.map(row).join('\n'),
+                    '',
+                    '> `content/docs/releases/` is RELEASE-OWNED (AGENTS.md "Documentation Guardrails"): release',
+                    '> notes are written centrally at release time, and a code PR that edits them is the exact PR',
+                    '> that guardrail exists to stop. They are still audited — read-only. If one of them is actually',
+                    '> wrong, **file an issue** or open a dedicated docs-only PR; do not edit it here.',
+                  );
+                }
               }
               body.push(
                 '',


### PR DESCRIPTION
Fixes #9037

## What changed

`docs-drift-check.yml`'s "Comment on PR" step now caps the editable-doc row list at
`EDITABLE_ROW_CAP = 15`. Above the cap, the comment posts **no row list** — one summary
line (count + a runnable `--json` re-derivation command) plus one line for the
release-owned subset. At or under the cap, rendering is unchanged (byte-identical).

This is presentation only: `affected-docs.mjs` computes exactly what it computed before
(nothing about "what is computed" changed, per #7009's closed-not-planned ruling).
No details-tag folding — the rows are actually omitted from the posted text, since a
collapsed disclosure element still ships every row's bytes to the event relay that
delivers this comment into every subscribed agent session.

Kept unchanged, per the card's keep-list: the docs-drift-check HTML-comment marker
(in-place update dedup), the benign "0 changed package(s)" comment, the mapper self-test
step, and the release-owned partition semantics (`releaseOwnedDocs` stays computed and
flagged read-only — only its rendering compresses above the threshold). The
`docs-accuracy-audit` workflow is untouched — it recomputes from `affected-docs.mjs`,
never from this comment.

## Numbers — re-derived today against `origin/main` (not copied from the card)

Ran `node scripts/docs-audit/affected-docs.mjs --json origin/main` against two real
changed-package sets:

- **Hub package** (PR #9020's actual head commit, `@objectstack/spec`): **106 editable +
  7 release-owned = 113 total** rows — matches the card's reading exactly on today's
  `origin/main`.
- **Small package** (a trivial one-line JSDoc-comment edit to `packages/client/src/index.ts`,
  committed on a throwaway branch, then discarded): **11 editable + 3 release-owned = 14
  total** — matches the card's "`@objectstack/client` JSDoc edit lists 11" reading exactly.

## N=15 — tuned, not just copied

Measured the full distribution: for every one of the 72 packages under `packages/**`,
how many of the repo's 178 hand-written docs would be flagged if that package alone
changed (mention of its npm name or its repo path). Sorted descending, the top of the
table:

```
editable  release  total  package
     106        7    113  @objectstack/spec
      19        3     22  @objectstack/cli
      18        4     22  @objectstack/core
      18        2     20  @objectstack/runtime
      13        1     14  @objectstack/objectql
      12        1     13  @objectstack/plugin-security
      11        3     14  @objectstack/client
      11        1     12  @objectstack/mcp
       9        3     12  @objectstack/rest
       8        1      9  @objectstack/driver-sql
```

`@objectstack/spec` is a singular, extreme outlier (59.6% of all hand-written docs
mention it) — the next tier (cli/core/runtime) sits at 18-19, then a smooth taper down
through 11 (`@objectstack/client`, which the card requires to keep its full list) and
below. There's no comparably sharp break anywhere in the 11-19 range to justify moving
off the suggested default, and 15 sits cleanly in the one real gap (above the
"actionable short list" cluster, below the 18+ tier). Kept **N=15**.

## Rendered comment — before/after, both limbs

Above threshold (`@objectstack/spec`, PR #9020's data): **8923 bytes / 113 list-row
lines to 558 bytes / 0 list-row lines** (93.7% reduction). New body reads:

> ### Docs Drift Check
> This PR changes **1** package(s): `@objectstack/spec`.
>
> **106** hand-written doc(s) reference the affected code — list omitted above 15 rows. Re-derive: `node scripts/docs-audit/affected-docs.mjs --json origin/main`.
>
> **7** release-owned page(s) also affected — read-only, see AGENTS.md Documentation Guardrails.
>
> Advisory only. To re-verify, run the `docs-accuracy-audit` workflow scoped to these files:
> `node scripts/docs-audit/affected-docs.mjs origin/main` (pass the list as `args.docs`).

(plus the leading dedup marker comment and the emoji before "Docs Drift Check", omitted
above only to keep this quote block from tripping the body sanitizer on raw angle
brackets — unchanged in the actual workflow code, see the diff.)

At/under threshold (`@objectstack/client`, 11 editable): **1887 bytes / 14 list-row
lines to 1887 bytes / 14 list-row lines** — 0 bytes changed, byte-identical to the old
rendering, confirming the small-package short list is untouched.

## Verification

- `node scripts/docs-audit/affected-docs.mjs --self-test` → 56 cases pass (file
  untouched by this diff; sanity-checked anyway).
- Gate families derived via `node scripts/pm/dispatch-gates.mjs .github/workflows/docs-drift-check.yml`
  after the diff was final: `check:node-version`, `check:required-contexts`,
  `check:shard-attestation`, `check:workflow-status-functions` — all green. Plus
  `check:nul-bytes` (any-edit convention) — green.
- All gates re-run at the final commit `be5bb3392` (`git rev-parse --short HEAD`), all
  green.
- No `packages/**` touched, so no package build/test/typecheck applies.

## Out of scope

Nothing filed — no defects found outside this card's scope during this pass. The
measurement above (per-package distribution) was produced solely to validate `N`, not as
a new finding.

`.github/**`-only change — no published package source touched, so no changeset;
`skip-changeset` will be applied once labels settle and read back.

_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_