### PR TITLE
docs: drop stale renderer-status notes now that type:'form' is shipped

### DIFF
--- a/content/docs/protocol/objectui/actions.mdx
+++ b/content/docs/protocol/objectui/actions.mdx
@@ -175,17 +175,6 @@ target: customer_quick_edit
 
 The four `submitBehavior` kinds and their options are documented on the [Forms guide](/docs/ui/forms).
 
-<Callout type="warn">
-**Current renderer status (2026-08-10).** The console shipping at the pinned
-`.objectui-sha` does **not** implement this contract yet: it renders
-`/console/forms/:name` as a top-level page outside the shell, and it falls back
-to the `thank-you` panel in both modes. The statement above is the contract —
-the renderer half is tracked in ObjectUI and linked from the
-[#7245 thread](https://github.com/objectstack-ai/objectstack/issues/7245). Until
-it lands, an internal FormView that must land on its new record has to declare
-`submitBehavior` explicitly.
-</Callout>
-
 ### Modal Actions
 
 Open a modal/page by name. `target` is resolved as a **page** first, then as an object (which opens that object's create/edit form); when it names neither, the action falls through to its server-side handler.

--- a/content/docs/ui/forms.mdx
+++ b/content/docs/ui/forms.mdx
@@ -434,8 +434,6 @@ Widening this — an allowlist of absolute origins, say — waits for measured d
 
 An explicit `submitBehavior` overrides the default in either mode, so nothing here removes an option — it only changes what an author gets for declaring nothing.
 
-> **Current renderer status (2026-08-10).** The console shipping at the pinned `.objectui-sha` still applies `thank-you` as the default in **both** modes. The table above is the contract; the renderer half is tracked in ObjectUI and linked from the [#7245 thread](https://github.com/objectstack-ai/objectstack/issues/7245). Until it lands, declare `submitBehavior` explicitly on an internal FormView that must land somewhere specific.
-
 ## 9. `type: 'form'` action — declarative form launchers
 
 App actions can declare `type: 'form'` to open a FormView without resorting to free-form URLs. The `target` is the FormView name; the runtime navigates to `/console/forms/:name` **inside the console shell** — the operator keeps the sidebar, navigation and breadcrumb, and a successful submit lands on the created record per the mode-aware default above. The full contract is stated on the [Action Protocol page](/docs/protocol/objectui/actions#what-type-form-promises).


### PR DESCRIPTION
Fixes #7245

Both halves of #7245 have landed — the contract statement (PR #7417, this card's own first PR) and the objectui renderer half (objectui#4109, merged 2026-08-11). This PR is the triage-scoped cleanup: remove the two now-stale "Current renderer status (2026-08-10)" caveats those pages carried while the renderer half was still pending.

## Premise re-verified before touching anything

Per the card's instruction, re-derived at the pin that is on `origin/main` right now (`.objectui-sha` = `665661ab093263f39f2e660a295ea615dbcee35a`, unchanged since triage's 01:20Z measurement) — by content, not ancestry:

- `apps/console/src/components/FormPage.tsx` — `resolveSubmitBehavior(mode, declared)` returns `{ kind: 'created-record' }` for `mode === 'internal'` (and `{ kind: 'thank-you' }` only for `'public'`), when the form declares nothing.
- `apps/console/src/App.tsx` — the `/forms/:name` route element is a `ProtectedRoute` wrapping `InternalFormRoute`, and `InternalFormRoute` wraps `FormPage mode="internal"` in `DefaultHomeLayout` (console shell chrome — header, workspace switcher, nav).

Both match the 2026-08-10 ruling this card recorded. Premise held, so the notes came out.

## What changed

- `content/docs/protocol/objectui/actions.mdx:179` — removed the Callout warn block ("Current renderer status") under "What type: form promises". The contract prose and table above it already state the shipped behavior; no rewrite needed.
- `content/docs/ui/forms.mdx:437` — removed the single-line "Current renderer status" blockquote under "The default is mode-aware", for the same reason.
- **Untouched, verified by content**: `content/docs/ui/forms.mdx:424`, the *other* dated note ("Current renderer status (2026-08-11)") about redirect-token substitution — that belongs to the still-open objectui#4190 (consumer half not landed) and is a different card.

Diff is exactly these two deletions (+0 -13, 2 files) — nothing else touched.

## Two open follow-ups checked per the dispatch instructions

1. `packages/spec/src/ui/view.zod.ts` JSDoc "thank-you (default)" — already filed and **resolved**: #7441, closed completed via merged PR #7473.
2. Docs spelling the console mount /console/forms/:name vs the measured live /_console/forms/... — **not previously filed**; filed now as #9050 (unassigned, no domain label, per boundary).

## Verification

- `pnpm check:nul-bytes` — OK (5956 text files scanned, 0 raw control bytes).
- `pnpm check:role-word` — OK (43 baselined files, no new occurrences).
- `pnpm check:docs-audit-scope` — OK (178 hand-written docs in sync; 9 release-owned pages correctly review-only).
- Gate families derived via `node scripts/pm/dispatch-gates.mjs content/docs/protocol/objectui/actions.mdx content/docs/ui/forms.mdx` -> `check:docs-audit-scope`, `check:role-word` (both above). `check:doc-anchors` doesn't apply (no #fragment links touched); page-path links are Check Documentation Links (CI, no local lychee binary available) — the diff only removes an external GitHub issue link and prose, adds no links, so no new link surface.
- Head verified at `b7a436fc7` (`git rev-parse --short HEAD`) — same tree the checks above ran against.

Docs-only; no packages/, no console pin, no objectui touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_