### PR TITLE
docs(permissions): narrow authorization.mdx's completeness claim to what CI checks (#9028)

### DIFF
--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authorization Architecture
-description: The one-page map of ObjectStack authorization — the enforcement chain, combination semantics, package provenance, lifecycle coverage, and the CI governance that keeps "declared" equal to "enforced". Stitches ADR-0049/0054/0056/0057/0066/0068/0069/0078/0086 into a single narrative.
+description: The one-page map of ObjectStack authorization — the enforcement chain, combination semantics, package provenance, lifecycle coverage, and the CI governance — with its limits — behind "declared" equals "enforced". Stitches ADR-0049/0054/0056/0057/0066/0068/0069/0078/0086 into a single narrative.
 ---
 
 # Authorization Architecture
@@ -15,9 +15,11 @@ nine ADRs to hold the model in your head.
 layer: anonymous deny → declaration-derived public-form grant → object CRUD
 (permission-set union) → OWD/sharing → row-level security → field-level
 security. Grants **union** most-permissively; hard prerequisites (**AND-gates**)
-and fail-closed defaults are the only implicit denies. The whole surface is
-governed by a CI-checked conformance matrix: a declared-but-unenforced
-primitive fails the build.
+and fail-closed defaults are the only implicit denies. Enforcement is tracked in
+a conformance matrix whose CI ratchet covers a **curated set of HTTP/transport
+entry points**: a new ungated route there, or a deleted guard on one already
+pinned, fails the build. For a primitive enforced by a predicate inside a
+resolver the matrix is a **hand-maintained** ledger, not a checked one.
 </Callout>
 
 ---
@@ -48,7 +50,7 @@ site — the file you read when behavior surprises you.
 
 | # | Gate | What it decides | Enforcement site | Failure direction |
 |---|---|---|---|---|
-| 1 | **Anonymous deny** | No identity → HTTP 401. **Uniform across every HTTP surface that reaches object data** (#2567): REST `/data` and the metadata endpoints (`/meta`) — the raw-hono standard `/data` routes left the matrix when that duplicate surface was deleted in v17 (#4073), and the dispatcher GraphQL endpoint left when the GraphQL surface was removed (`/graphql` now 404s) — one shared decision, so a caller denied on `/data` can't read the same rows through a sibling door. **Unconditional** (#3963, closing out ADR-0056 D2): the `api.requireAuth: false` opt-out was retired in v17 — the key is tombstoned, so authoring it is a parse error, and anonymous callers are denied on every data surface with no deployment-level escape hatch. Narrower public surfaces do **not** need it — each derives its own authorization from a declaration rather than from the deployment posture: control plane (`/auth`, `/health`, `/discovery`) is allow-listed; public form submission carries a `publicFormGrant` (ADR-0056 Option A); share-links validate their token then read as SYSTEM; and an anonymous **GET** of the book/doc read surface is admitted so `book.audience: 'public'` works under the secure default, with the ADR-0046 §6.7 audience gate — `'public'` only, fail-closed — doing the authorizing (#3963). | `packages/core/src/security/anonymous-deny.ts` `shouldDenyAnonymous` — called by `rest-server.ts` `enforceAuth` and the dispatcher `handleMetadata`/`handleAI` (default in `packages/spec/src/api/rest-server.zod.ts`); a source-enumerating ratchet in `authz-conformance.test.ts` fails CI if a new surface ships ungated | fail-closed |
+| 1 | **Anonymous deny** | No identity → HTTP 401. **Uniform across every HTTP surface that reaches object data** (#2567): REST `/data` and the metadata endpoints (`/meta`) — the raw-hono standard `/data` routes left the matrix when that duplicate surface was deleted in v17 (#4073), and the dispatcher GraphQL endpoint left when the GraphQL surface was removed (`/graphql` now 404s) — one shared decision, so a caller denied on `/data` can't read the same rows through a sibling door. **Unconditional** (#3963, closing out ADR-0056 D2): the `api.requireAuth: false` opt-out was retired in v17 — the key is tombstoned, so authoring it is a parse error, and anonymous callers are denied on every data surface with no deployment-level escape hatch. Narrower public surfaces do **not** need it — each derives its own authorization from a declaration rather than from the deployment posture: control plane (`/auth`, `/health`, `/discovery`) is allow-listed; public form submission carries a `publicFormGrant` (ADR-0056 Option A); share-links validate their token then read as SYSTEM; and an anonymous **GET** of the book/doc read surface is admitted so `book.audience: 'public'` works under the secure default, with the ADR-0046 §6.7 audience gate — `'public'` only, fail-closed — doing the authorizing (#3963). | `packages/core/src/security/anonymous-deny.ts` `shouldDenyAnonymous` — called by `rest-server.ts` `enforceAuth` and the dispatcher `handleMetadata`/`handleAI` (default in `packages/spec/src/api/rest-server.zod.ts`); a ratchet in `authz-conformance.test.ts` enumerates these entry points from source across a curated file list, and fails CI if a new surface ships ungated in one of those files | fail-closed |
 | 2 | **Public-form grant** | An anonymous form submission carries a declaration-derived `publicFormGrant` authorizing ONLY create + read-back on the form's declared target object — never anything else (ADR-0056 Option A). No guest-portal configuration needed (anonymous principals hold the `guest` position). | `packages/plugins/plugin-security/src/security-plugin.ts` (ObjectQL middleware) | scope-limited allow |
 | 3 | **Object CRUD** | `allowRead/Create/Edit/Delete` (+ the destructive lifecycle class `allowTransfer/Restore/Purge`, gated ahead of the M2 operations — #1883) resolved across the caller's permission sets. | `packages/plugins/plugin-security/src/permission-evaluator.ts` `checkObjectPermission` | fail-closed 403 |
 | 4 | **OWD / sharing** | Org-wide default (`private` / `public_read` / `public_read_write` / `controlled_by_parent`; **unset or unknown ⇒ `private`, fail-closed** — ADR-0090 D1) plus the external dial (`externalSharingModel`, ADR-0090 D11), manual record shares, criteria sharing rules (owner-type rules were removed from the authoring surface in v17 rather than left declared-but-skipped — [Sharing Rules](/docs/permissions/sharing-rules#recipient-types)), business-unit hierarchy widening (ADR-0057 D5: scope-depth hierarchy lives on `sys_business_unit`, not positions). | `packages/plugins/plugin-sharing/src/sharing-service.ts` + `sharing-rule-service.ts` | fail-closed to owner-only |
@@ -254,7 +256,7 @@ one of two doors, each writing only what it owns:
 | 1 · Package development | Zod-validated authoring; positions / sharingRules / permissions seeded at boot with provenance | ADR-0057 D6, ADR-0086 D5, ADR-0049/0078 gates |
 | 2 · Distribution / install / upgrade / uninstall | Install-consent scopes (ADR-0025 — consent ≠ RBAC grants); namespaced, collision-free composition; provenance axis makes uninstall well-defined | ADR-0025/0028/0048/0086 |
 | 3 · Environment composition / assignment | Platform-owned assignment records (`sys_user_position` etc.); anti-escalation; union semantics | ADR-0057 D4 |
-| 4 · Runtime enforcement | The six-gate chain above; ~18 primitives enforced and CI-guarded | ADR-0056 D10 matrix |
+| 4 · Runtime enforcement | The six-gate chain above; each enforced primitive holds a row naming its enforcement site — the matrix file is the authority on the count and on which rows CI can check | ADR-0056 D10 matrix |
 | 5 · Production / enterprise | ADR-0056 D8 dispositions settled (2026-07): compliance configs, data masking, the global RLSConfig, and agent `visibility` were **removed** (never enforced — for `visibility`, correct owner/org enforcement is undesigned, so it was dropped rather than carried; re-introduce under #1901); field encryption stays honestly `[EXPERIMENTAL]` (roadmap — stable schema shape). Enterprise authentication hardening staged per ADR-0069 | ADR-0049/0056 D8, ADR-0069 |
 
 ## Explaining a decision (ADR-0090 D6)
@@ -421,12 +423,27 @@ Five mechanisms — four CI-time, one runtime — make the security posture a
 - **Conformance matrix** (`packages/qa/dogfood/test/authz-conformance.matrix.ts`,
   ADR-0056 D10): every authorization primitive sits in exactly one honest
   state — `enforced` (must name its enforcement site; high-risk rows must
-  reference an end-to-end dogfood proof), `experimental`, or `removed`. A new
-  fail-open or a deleted proof fails CI. A cited proof must also **name the rows
-  it proves** — a header `// authz-row: <id>` line — and CI asserts the pairing
-  is mutual in both directions (#7976), so a row cannot cite a test that
-  exercises a neighbouring primitive, and a shared proof file has to say which
-  rows it covers.
+  reference an end-to-end dogfood proof), `experimental`, or `removed`. CI
+  checks the row shape, that every cited proof file exists, and that the row ↔
+  proof pairing is **mutual** in both directions (#7976) — a cited proof must
+  **name the rows it proves** via a header `// authz-row: <id>` line, so a row
+  cannot cite a test that exercises a neighbouring primitive, and a shared proof
+  file has to say which rows it covers. A **surface ratchet** additionally
+  enumerates HTTP/transport entry points from source over a curated file list:
+  a new ungated route in one of those files fails CI as an unclassified surface,
+  and deleting a guard that a row pins makes the pinned key vanish from source,
+  so the row goes stale and the build goes red. Most keys pinned this way name
+  the enforcement **call** rather than merely a function name, which is what
+  makes them anti-regression — removing the check breaks CI, not just renaming
+  something.
+
+  What CI does **not** check is "one row per primitive" itself. A primitive
+  enforced by a predicate inside an existing resolver adds no HTTP entry point,
+  so the ratchet cannot see it — and most `enforced` rows are exactly that
+  shape. For them the matrix is a **hand-maintained** ledger kept honest by
+  review. Read a row as "this is where the check lives", not as "CI proves
+  nothing was forgotten"; the matrix header carries the measured breakdown.
+
 - **Liveness ledger** (`packages/spec/liveness/`, ADR-0049/0054): every
   governed spec property is classified live / experimental / dead, with
   author-time warnings for declared-but-unenforced flags.


### PR DESCRIPTION
Fixes #9028.

Prose only, one file. Nothing about any gate's checking behaviour changes — no gate, test, or matrix row is touched.

## Which revision of PR #9026 this mirrors

**The landed one.** PR #9026 merged at `2ce1eb41b` and this branch was cut from `origin/main` at exactly that commit, so the wording here was mirrored from the merged matrix header and companion test, never from the proposal. (I was dispatched while #9026 was still open and received a mid-task note that it had merged; by then I had already read the landed text, because the worktree was cut after the merge.)

## The claim, and where measurement contradicted it

The published page stated the completeness claim more strongly than the test file it describes:

- `:19-20` — "The whole surface is governed by a CI-checked conformance matrix: a declared-but-unenforced primitive fails the build."
- `:421-425` — "every authorization primitive sits in exactly one honest state … A new fail-open or a deleted proof fails CI."

That is true only inside the curated set of HTTP/transport entry points the ratchet enumerates. The reader it misleads is an auditor evaluating the platform's authorization posture, who has no access to the measurement.

### Numbers re-derived against `origin/main` at `2ce1eb41b` — not copied from the card

Every figure in the card was treated as a pointer and re-measured before any of it informed the prose. All six reproduced exactly:

| Figure | Card | Re-derived | Method |
|---|---|---|---|
| Matrix rows | 50 | **50** | row-start parse of `authz-conformance.matrix.ts` |
| Rows with no `covers` | 43 | **43** | 50 total minus 7 carrying the key |
| Rows with `covers` / keys | 7 / 9 | **7 / 9** | 2+1+1+1+1+2+1 |
| `enforced` rows | 43 | **43** | state tally: 43 enforced, 2 experimental, 5 removed |
| `enforced` rows outside the ratchet | 37 | **37** | 43 enforced minus the 6 enforced rows that carry `covers` (the 7th, `realtime-delivery-authz`, is `experimental`) |
| Probes / named source files | 15 / 11 | **15 / 11** | 15 `file:` entries over 11 distinct paths |

The 5-of-9 gate-pin split also reproduced: the pins whose regex matches the enforcement **call** are the three `shouldDenyAnonymous` domain probes plus `buildMcpBridge(deps, context)` and `resolveStdioExecutionContext`. The other four (`registerMetadataEndpoints`, `handleMetadata`, `handleMcp`, `async publish`) match a declaration name only.

## The real property is preserved — verified by ablation, not by assertion

The card asked me to confirm the anti-regression property myself rather than take its word. I did, with a real source ablation on a clean tree:

1. Baseline: `vitest run authz-conformance` → `Test Files 1 passed (1)`, `Tests 15 passed (15)`.
2. Ablated the `/actions` gate — replaced the `shouldDenyAnonymous(...)` call in `packages/runtime/src/domains/actions.ts` so the probe regex matches zero times (verified: `probe regex matches now: 0`). No rebuild needed and none done, deliberately: `discover()` reads **source** text via `readFileSync`, not `dist/`, so this is not a dogfood-dist ablation and a stale build cannot fake the result.
3. Re-ran. Predicted direction before running was red, and red is what happened:

```
AssertionError: STALE covers — surface no longer in source: actions:domains/actions.ts:anonymous-gate
Tests  3 failed | 12 passed (15)
```

4. Restored with `git checkout --` and confirmed **byte identity** — `git hash-object` returned `cc7a8e4ace650eff5afcb8dd2cd5bd0e860c100a`, matching the pre-ablation hash, and `git status` clean.

So the rewritten text keeps saying, in the customer's language, that deleting a pinned guard reddens the build. A rewrite leaving the reader thinking nothing is enforced would have been false in the opposite direction.

## The bounding sweep — three further edits on the same page, same defect class

Named here because an unnamed drive-by is unreviewable.

**`:51`, the "source-enumerating ratchet" clause — narrowed, not removed.** My judgment differs slightly from the filer's guess. "Source-enumerating" is *accurate*: `discover()` genuinely derives keys from source content, and within a listed file it is pattern-based, so a new `rawApp` `/data` route really does auto-appear. What overstates is the unqualified "if a new surface ships ungated" — a new entry point in an unlisted file is invisible. The edit adds the file-list qualifier and leaves the rest standing.

**`:257`, "~18 primitives enforced and CI-guarded" — count elided, deliberately not updated.** The card's tripwire was to establish what "~18" counted before touching it. I could not, and the failure is informative:

- The local clone is **shallow** (115 commits, grafted at `159e29944`), so `git blame` attributes the line to the graft root rather than its author — a false lead that would have read as "written 2026-08-15".
- Walking the real history through the GitHub API back to 2026-07-04, the figure is **already present at every reachable revision**, and at every one of them it already disagreed with the matrix: 28 rows / 22 enforced on 2026-07-04, 30 / 23 on 2026-07-08, 35 / 28 on 2026-07-16, 43 / 35 on 2026-07-19.
- It matches no other grouping either: `HIGH_RISK` is 11, `covers` rows 7, keys 9, probes 15, probe files 11.

So "~18" is not 50 gone stale; it counted something else, or was never derived. Swapping it for a freshly-measured 50 would have put two different countings behind one number — the exact failure the card warned about. The count is removed and the matrix file named as the authority instead, following the pattern PR #9005 landed (replacing a hard-coded enumeration with "that entry in `AUTHORING_RULES` is the authority"). There is also older precedent in this file's own history: commit `d54be2895` (2026-07-05) removed count-style statistics from docs on the reasoning that "counts drift from the implementation and don't help readers."

**The frontmatter `description`** carried the same claim verbatim — "the CI governance that keeps 'declared' equal to 'enforced'" — and is customer-facing meta text, so it is narrowed the same way.

### One deliberate omission: no counts in the published prose

The measured numbers are *not* written into the page, even though I re-derived them. Putting 43/50, 37/43, 15/11 and 5/9 into customer-facing prose while deleting `:257` for being an undocumented drifting count would be self-contradictory, and those five figures moved twice in the last week (#8812 alone moved two of them). The page states the *shape* of the claim qualitatively and points at the matrix header, which carries the measured breakdown and sits next to the rows where drift is visible. Flagging it explicitly since it is a judgment call, not an oversight.

## Filer's note 1: `delegated-administration.mdx` confirmed clean, not edited

Re-grepped as instructed, per-term rather than as one pattern: `conformance`, `matrix`, `primitive`, `breaks CI`, `fail-open`, `ledger`, `ratchet`, `fails the build`, `CI-guarded`, `CI-checked` — **0 hits each**. A transitive advisory flag with nothing to fix. Untouched.

## Verification

All at HEAD `6d2f79492`, tree clean, run **after** the final commit.

Gate families derived from the actual changed path rather than assumed — `node scripts/pm/dispatch-gates.mjs content/docs/permissions/authorization.mdx` named two path-matched families; I added `check:nul-bytes` (any edit), the two the dispatch named, and `check:doc-authoring`, which the derivation left undetermined but which plainly reads this corpus:

- `pnpm check:docs-audit-scope` — OK, 178 hand-written docs in sync, 9 release-owned pages read-only.
- `pnpm check:role-word` — OK, 43 baselined files, no new occurrences.
- `pnpm check:doc-anchors` — OK, 232 internal fragment links across 396 source files all resolve.
- `pnpm check:doc-authoring` — OK, 376 files clean.
- `pnpm check:nul-bytes` — OK, 5956 text files scanned, no raw control bytes. Plus a manual `grep -naP` control-byte scan of the changed file: clean.

`Check Documentation Links` (lychee, file-resolution only) is left to CI: the diff introduces no new link and removes none, and `check:doc-anchors` already covers the fragment half locally — the two gates do not overlap.

Conformance test itself, proving the untouched-behaviour boundary: `Tests 15 passed (15)`, identical to before the edit, with the only red being the deliberate ablation described above.

## Findings filed

- **#9055** — `realtime-protocol.mdx:15` claims the conformance matrix "enforces this in CI" for per-recipient realtime delivery authorization. Measured: the row is `experimental`, and the transport tripwires turn a wired transport into an unclassified surface until the row is upgraded with an enforcement site — they force a classification decision, they cannot verify the re-check was implemented. Same class as this card, one page over. Filed unassigned and unlabelled.

Checked and found accurate, so deliberately left alone: `authorization.mdx:78-79` ("a fail-open regression breaks CI like any other surface", about the two MCP rows) is *true* — both MCP identity pins are among the five gate-pins, so dropping the context threading or the stdio principal binding does redden CI. `protocol/objectql/security.mdx:349` merely records a disposition and makes no completeness claim.

## Labels

`skip-changeset` — docs-only, publishes nothing. Confirmed from the final diff: one file, `content/docs/permissions/authorization.mdx`, no package source touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_