### PR TITLE
fix(lint): a dashboard header modal action's target resolves against declared pages, only (#9013)

### DIFF
--- a/.changeset/dashboard-modal-target-page-only-lint.md
+++ b/.changeset/dashboard-modal-target-page-only-lint.md
@@ -1,0 +1,57 @@
+---
+'@objectstack/lint': minor
+'@objectstack/spec': minor
+---
+
+`os validate`: a dashboard header `modal` action's target resolves against declared PAGES, only (#9013)
+
+`validateDashboardActionRefs` resolved an `actionType: 'modal'` header button's
+`actionUrl` the way objectui's `DashboardView` used to dispatch it: a defined
+action name, a bare object name, or the `<verb>_<object>` prefix form
+(`create_`/`new_`/`add_`/`edit_`/`update_` + a defined object) all passed, and a
+target naming a declared page ERRORED unless it collided with one of those.
+
+That mirror is gone. Maintainer ruling objectstack#6739-A (2026-08-09): a
+`type: 'modal'` string target names a PAGE, only — the spec TSDoc, the published
+docs and `defineStack`'s cross-reference walk already said so, and objectui#4764
+/ objectui#4782 retired the renderer's object fallback and `DashboardView`'s
+second copy of the prefix convention (enumerated across both repos' corpora:
+zero producers). After that, `os validate` blessed exactly the buttons the
+runtime refuses — the false affordance the rule exists to eliminate — while
+refusing the one shape the runtime serves.
+
+**BREAKING** accept-set change on the `os validate` gating tier (landing after
+the v17.0.0 cut; the lockstep launch-window convention ships it as `minor`):
+
+- A `modal` header target naming a defined action, a bare object, or a
+  `<verb>_<object>` form now **fails** validation. Those buttons already
+  dispatch to a named refusal at runtime.
+- A `modal` header target naming a declared page now **passes** — it was
+  wrongly refused before.
+
+## FROM → TO
+
+```ts
+// before — passed validation; the runtime now refuses the click
+header: {
+  actions: [{ label: 'New Deal', actionType: 'modal', actionUrl: 'create_opportunity' }],
+}
+
+// after — name a declared page…
+header: {
+  actions: [{ label: 'Intake', actionType: 'modal', actionUrl: 'deal_intake' }], // pages: [{ name: 'deal_intake' }]
+}
+// …or, to open an object's form, use the validated first-class shape
+header: {
+  actions: [{ label: 'New Deal', actionType: 'form', actionUrl: 'opportunity.edit' }],
+}
+```
+
+There is deliberately no automatic rewrite: a retired-shape target is a
+name-shaped guess (`create_opportunity` names the page `create_opportunity`, or
+it names nothing — the ruling explicitly declined keeping the prefix), and only
+the author knows whether the button meant a page or an object form.
+`objectstack migrate meta` surfaces the change as a structured TODO (semantic
+entry `dashboard-header-modal-target-page-only`, protocol major 18).
+
+<!-- adr-0087: registered dashboard-header-modal-target-page-only -->

--- a/content/docs/deployment/validating-metadata.mdx
+++ b/content/docs/deployment/validating-metadata.mdx
@@ -72,11 +72,11 @@ lands on the draft→active promotion, per
 
 ### 3. Dead action/route references
 
-A dashboard `header.actions[]` button names a target: a `script`/`modal` action,
-or a `url` route. Nothing in the schema checks that the target exists, so a button
-can ship pointing at an action defined nowhere — it renders and then **silently
-does nothing** when clicked. This is ADR-0049's "declared ≠ enforced" gate applied
-to *references*.
+A dashboard `header.actions[]` button names a target: a `script` action, a
+`modal` page, or a `url` route. Nothing in the schema checks that the target
+exists, so a button can ship pointing at something defined nowhere — it renders
+and then **silently does nothing** when clicked. This is ADR-0049's
+"declared ≠ enforced" gate applied to *references*.
 
 This check covers the dashboard **header** only. It used to check a
 `widgets[].actionUrl` too — until #5010 measured that no renderer has ever drawn a
@@ -89,18 +89,25 @@ carrying the fix.
 ```ts
 header: {
   actions: [
-    // ✗ script/modal target resolves to no defined action → error
+    // ✗ script target resolves to no defined action → error
     { label: 'Export PDF', actionType: 'script', actionUrl: 'export_dashboard_pdf' },
-    // ✓ modal <verb>_<object> against a real `opportunity` object
+    // ✗ modal target names no declared page → error. A modal target names a
+    //   PAGE, only — `create_opportunity` no longer resolves through the
+    //   retired `<verb>_<object>` convention, however real the object is.
+    //   To open an object's form, use actionType: 'form' with an
+    //   '<object>.<view>' form-view target.
     { label: 'New Deal', actionType: 'modal', actionUrl: 'create_opportunity' },
+    // ✓ modal target naming a declared page (`pages: [{ name: 'deal_intake' }]`)
+    { label: 'Intake', actionType: 'modal', actionUrl: 'deal_intake' },
     // ⚠ url path matching no in-app route → warning
     { label: 'Forecast', actionType: 'url', actionUrl: '/reports/forecast' },
   ],
 }
 ```
 
-`script`/`modal` targets that resolve nowhere **fail** validation; a `url` path
-whose `objects/reports/dashboards/pages/views` route is unregistered is **warned**
+A `script` target that names no defined action, or a `modal` target that names
+no declared page, **fails** validation; a `url` path whose
+`objects/reports/dashboards/pages/views` route is unregistered is **warned**
 (external, interpolated, and opaque routes are skipped).
 
 ### 4. Dangling object and action names

--- a/packages/lint/src/authoring-rules.ts
+++ b/packages/lint/src/authoring-rules.ts
@@ -516,9 +516,11 @@ export const AUTHORING_RULES: readonly AuthoringRule[] = [
     runtimeTypes: ['dashboard'],
     run: (stack) => validateWidgetBindings(stack),
   },
-  // ADR-0049 / #3367 — a header or widget action naming a `script`/`modal`
-  // target that resolves to no defined action ships a button that renders and
-  // silently does nothing on click. Unresolved `url` routes stay advisory.
+  // ADR-0049 / #3367 — a dashboard header action naming a dead target ships a
+  // button that renders and refuses (or does nothing) on click: a `script`
+  // target must name a defined action, a `modal` target must name a declared
+  // page (objectstack#6739-A — a modal string target names a PAGE, only).
+  // Unresolved `url` routes stay advisory.
   {
     name: 'validateDashboardActionRefs',
     tier: 'gating',

--- a/packages/lint/src/validate-dashboard-action-refs.test.ts
+++ b/packages/lint/src/validate-dashboard-action-refs.test.ts
@@ -54,41 +54,45 @@ describe('validateDashboardActionRefs (ADR-0049 references / #3367)', () => {
     expect(findings[0].message).toContain('export_dashboard_pdf');
   });
 
-  it('passes a modal action that names a defined action', () => {
+  // objectstack#6739-A (2026-08-09): a `modal` string target names a PAGE, and
+  // only a page. The four tests below pin BOTH directions of that ruling: the
+  // one shape the runtime serves resolves, and each retired limb — a defined
+  // action name, the `<verb>_<object>` prefix convention, a bare object name —
+  // is refused. Until objectui#4782 deleted `DashboardView`'s own modal
+  // handler (the convention's last live copy), this file pinned the opposite:
+  // the three retired shapes passed and a page-named target ERRORED, so
+  // `os validate` blessed exactly the buttons the runtime refuses.
+  it('passes a modal action that names a declared page', () => {
+    const findings = validateDashboardActionRefs(
+      dashWithHeaderActions(
+        [{ label: 'New Deal', actionType: 'modal', actionUrl: 'deal_intake' }],
+        { pages: [{ name: 'deal_intake' }] },
+      ),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('ERRORS on a modal action that names a defined action — an action is not a page', () => {
     const findings = validateDashboardActionRefs(
       dashWithHeaderActions(
         [{ label: 'New Deal', actionType: 'modal', actionUrl: 'quick_create_deal' }],
         { actions: [{ name: 'quick_create_deal', type: 'modal' }] },
       ),
     );
-    expect(findings).toEqual([]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: DASHBOARD_ACTION_TARGET_UNDEFINED,
+    });
+    expect(findings[0].message).toContain('quick_create_deal');
+    expect(findings[0].message).toContain('names no declared page');
   });
 
-  it('passes a modal action using the <verb>_<object> convention against a real object', () => {
+  it('ERRORS on the retired <verb>_<object> convention, even against a real object', () => {
     const findings = validateDashboardActionRefs(
       dashWithHeaderActions(
         [{ label: 'New Deal', actionType: 'modal', actionUrl: 'create_opportunity' }],
         { objects: [{ name: 'opportunity' }] },
-      ),
-    );
-    expect(findings).toEqual([]);
-  });
-
-  it('passes a modal action that is a bare object name (create-form fallback)', () => {
-    const findings = validateDashboardActionRefs(
-      dashWithHeaderActions(
-        [{ label: 'Add Lead', actionType: 'modal', actionUrl: 'lead' }],
-        { objects: [{ name: 'lead' }] },
-      ),
-    );
-    expect(findings).toEqual([]);
-  });
-
-  it('ERRORS on a modal action whose target is neither a defined action nor a real object', () => {
-    const findings = validateDashboardActionRefs(
-      dashWithHeaderActions(
-        [{ label: 'New Deal', actionType: 'modal', actionUrl: 'create_opportunity' }],
-        { objects: [{ name: 'account' }] }, // no `opportunity`
       ),
     );
     expect(findings).toHaveLength(1);
@@ -97,7 +101,27 @@ describe('validateDashboardActionRefs (ADR-0049 references / #3367)', () => {
       rule: DASHBOARD_ACTION_TARGET_UNDEFINED,
     });
     expect(findings[0].message).toContain('create_opportunity');
-    expect(findings[0].message).toContain('or object');
+    // The ruling explicitly declined the middle shape (keep the prefix, reject
+    // bare object names): `create_opportunity` names the page
+    // `create_opportunity`, or it names nothing.
+    expect(findings[0].message).toContain('names no declared page');
+    expect(findings[0].hint).toContain("actionType: 'form'");
+  });
+
+  it('ERRORS on a bare object name — the create-form fallback is retired', () => {
+    const findings = validateDashboardActionRefs(
+      dashWithHeaderActions(
+        [{ label: 'Add Lead', actionType: 'modal', actionUrl: 'lead' }],
+        { objects: [{ name: 'lead' }] },
+      ),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: DASHBOARD_ACTION_TARGET_UNDEFINED,
+    });
+    expect(findings[0].message).toContain('lead');
+    expect(findings[0].hint).toContain('stack.pages');
   });
 
   it('passes a url action pointing at a registered report route', () => {
@@ -210,9 +234,10 @@ describe('validateDashboardActionRefs (ADR-0049 references / #3367)', () => {
   });
 
   it('covers the issue #3367 repro: one script + one modal error, one url warning', () => {
-    // Faithful to the runtime: `create_opportunity` resolves via the modal
-    // <verb>_<object> convention ONLY when an `opportunity` object exists. Here
-    // it does not, so all three targets are dead.
+    // Faithful to the runtime: `create_opportunity` would resolve only as the
+    // name of a declared PAGE (objectstack#6739-A — the <verb>_<object>
+    // convention is retired). No page is declared here, so all three targets
+    // are dead.
     const findings = validateDashboardActionRefs(
       dashWithHeaderActions([
         { label: 'Export PDF', actionType: 'script', actionUrl: 'export_dashboard_pdf' },

--- a/packages/lint/src/validate-dashboard-action-refs.ts
+++ b/packages/lint/src/validate-dashboard-action-refs.ts
@@ -38,19 +38,27 @@
  * in `@objectstack/spec` 17.0.0, so authoring one is a `tsc` error and a parse
  * error carrying the prescription. There is no widget target left to resolve.
  *
- * Resolution mirrors the objectui runtime dispatch (`DashboardRenderer` +
- * `DashboardView`) so the lint flags exactly what would fail to resolve at
- * runtime:
+ * Resolution mirrors the objectui runtime dispatch (`DashboardRenderer`
+ * hands the target to the SHARED `useActionModal` since objectui#4782) so the
+ * lint flags exactly what would fail to resolve at runtime:
  *
  *   actionType 'script' → `actionUrl` must name a DEFINED action (`stack.actions`
  *       or any `object.actions`, by `name`). A script target that names no
  *       defined action fails open at runtime ("action not found"). → ERROR.
  *
- *   actionType 'modal'  → `actionUrl` resolves if it names a defined action, OR
- *       matches the runtime `<verb>_<object>` convention the modalHandler
- *       implements (create_/new_/add_/edit_/update_ + a defined object), OR is a
- *       bare defined object name (the handler falls back to that object's create
- *       form). Otherwise → ERROR.
+ *   actionType 'modal'  → `actionUrl` names a declared PAGE (`stack.pages`), and
+ *       only a page — maintainer ruling objectstack#6739-A (2026-08-09). This
+ *       rule used to accept a defined action name, a bare object name, and the
+ *       `<verb>_<object>` convention (create_/new_/add_/edit_/update_ + object),
+ *       on the claim that it mirrored `DashboardView`'s own modal handler. That
+ *       handler — the convention's last live copy — was deleted by objectui#4782
+ *       (after objectui#4764 retired the object fallback in `useActionModal`):
+ *       the runtime resolves a string modal target against page metadata and
+ *       REFUSES everything else, so each retired limb here blessed a button that
+ *       dispatches to a named refusal at runtime. The ruling explicitly declined
+ *       the middle shape (keep the prefix, reject bare object names): a target
+ *       names the page `create_opportunity`, or it names nothing. Opening an
+ *       object's form is `actionType: 'form'`. Otherwise → ERROR.
  *
  *   actionType 'url'    → a relative in-app path. WARN when a recognizable
  *       `<collection>/<name>` segment (objects/reports/dashboards/pages/views)
@@ -110,11 +118,6 @@ function strName(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined;
 }
 
-/** The runtime modal `<verb>_<object>` convention (objectui `DashboardView`
- *  modalHandler): `create_/new_/add_/edit_/update_` + an object name opens that
- *  object's create/edit form. */
-const MODAL_VERB_RE = /^(?:create|new|add|edit|update)_(.+)$/;
-
 /** URL path segments that name a metadata collection, mapped to the stack key
  *  whose members can appear after them in an in-app route
  *  (`/…/objects/crm_lead`, `/reports/forecast`, `/dashboards/exec`, …). Both the
@@ -147,7 +150,7 @@ function viewContainerName(item: AnyRec): string | undefined {
 interface KnownTargets {
   /** Every action name defined in the stack (global + object-embedded). */
   actions: Set<string>;
-  /** Object names (also valid as bare modal targets and `objects/<name>` routes). */
+  /** Object names (valid in `objects/<name>` routes). */
   objects: Set<string>;
   reports: Set<string>;
   dashboards: Set<string>;
@@ -196,15 +199,15 @@ function resolveActionTarget(
   target: string,
   known: KnownTargets,
 ): boolean {
-  if (known.actions.has(target)) return true;
   if (actionType === 'modal') {
-    // Runtime modalHandler convention: `<verb>_<object>` or a bare object name
-    // opens that object's create/edit form.
-    if (known.objects.has(target)) return true;
-    const m = MODAL_VERB_RE.exec(target);
-    if (m && known.objects.has(m[1])) return true;
+    // A modal string target names a declared PAGE, and only a page
+    // (objectstack#6739-A). The runtime resolves it against page metadata and
+    // refuses everything else — a defined action name, a bare object name, and
+    // the retired `<verb>_<object>` prefix convention all dispatch to a named
+    // refusal, so accepting any of them here blesses a dead button.
+    return known.pages.has(target);
   }
-  return false;
+  return known.actions.has(target);
 }
 
 /**
@@ -275,22 +278,25 @@ export function validateDashboardActionRefs(stack: AnyRec): DashboardActionRefFi
 
     if (actionType === 'script' || actionType === 'modal') {
       if (resolveActionTarget(actionType, target, known)) return;
-      const kindWord = actionType === 'script' ? 'script' : 'modal';
       findings.push({
         severity: 'error',
         rule: DASHBOARD_ACTION_TARGET_UNDEFINED,
         where,
         path,
         message:
-          `${kindWord} action target "${target}" resolves to no defined action` +
-          (actionType === 'modal' ? ' or object' : '') +
-          `. The button renders but does nothing when clicked — a dangling reference ` +
-          `the runtime cannot dispatch (ADR-0049: a declared reference must resolve).`,
+          actionType === 'modal'
+            ? `modal action target "${target}" names no declared page — a modal target ` +
+              `names a PAGE, only (objectstack#6739). The button renders but the runtime ` +
+              `refuses the dispatch when clicked — a dangling reference ` +
+              `(ADR-0049: a declared reference must resolve).`
+            : `script action target "${target}" resolves to no defined action. ` +
+              `The button renders but does nothing when clicked — a dangling reference ` +
+              `the runtime cannot dispatch (ADR-0049: a declared reference must resolve).`,
         hint:
           actionType === 'modal'
-            ? `Define an action named "${target}" (stack.actions or the object's actions), ` +
-              `use the "<verb>_<object>" convention against a real object ` +
-              `(e.g. "create_<object>"), point actionUrl at an existing object, or remove the button.`
+            ? `Point actionUrl at a declared page (stack.pages), or use ` +
+              `actionType: 'form' with an "<object>.<view>" form-view target to open ` +
+              `an object's form, or remove the button.`
             : `Define a script action named "${target}" (stack.actions or the object's actions) ` +
               `with an inline body or a registered handler, or remove the button.`,
       });

--- a/packages/spec/src/migrations/entries/semantic/18.dashboard-header-modal-target-page-only.ts
+++ b/packages/spec/src/migrations/entries/semantic/18.dashboard-header-modal-target-page-only.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { SemanticMigration } from '../../types.js';
+
+export const entry: SemanticMigration = {
+  id: 'dashboard-header-modal-target-page-only',
+  surface:
+    'dashboard `header.actions[]` entries with `actionType: \'modal\'` — an `actionUrl` naming '
+    + 'a defined action, a bare object name, or the `<verb>_<object>` prefix form '
+    + '(`create_`/`new_`/`add_`/`edit_`/`update_` + object). The keys themselves are unchanged '
+    + 'and still parse; what changed is what the string RESOLVES to',
+  replacement:
+    'a declared page name (`stack.pages`, by `name`) — a modal target names a PAGE, only. To '
+    + 'open an object\'s create/edit form from a dashboard header, use `actionType: \'form\'` '
+    + 'with an `<object>.<view>` form-view target (`actionType` accepts the full action-type '
+    + 'enum, so that shape reaches this surface too)',
+  reason:
+    'Maintainer ruling objectstack#6739-A (2026-08-09): a `type: \'modal\'` string target names '
+    + 'a PAGE, only — the spec TSDoc, the published docs and `defineStack`\'s cross-reference '
+    + 'walk already agreed, and the renderer\'s page-then-object leniency (self-labelled '
+    + 'Back-compat) was retired rather than codified. objectui#4764 deleted the object fallback '
+    + 'in the shared `useActionModal`; objectui#4782 deleted `DashboardView`\'s own second copy '
+    + 'of the prefix convention (which had no page resolution at all), after enumerating both '
+    + 'repos\' corpora and finding zero producers of the prefix form. The `os validate` lint '
+    + 'rule (`validateDashboardActionRefs`) then still pointed the other way: it accepted the '
+    + 'retired shapes — blessing buttons that dispatch to a named refusal at runtime — and '
+    + 'ERRORED on a page-named target, the one shape the runtime serves. The rule now resolves '
+    + 'a modal target against declared pages, only. The ruling explicitly declined the middle '
+    + 'shape (keep the prefix, reject bare object names): `create_opportunity` names the page '
+    + '`create_opportunity`, or it names nothing.',
+  acceptanceCriteria:
+    'Every dashboard `header.actions[]` entry with `actionType: \'modal\'` has an `actionUrl` '
+    + 'naming a declared page (`os validate` passes the dashboard-action-refs rule); header '
+    + 'buttons meant to open an object\'s form declare `actionType: \'form\'` with an '
+    + '`<object>.<view>` target instead. Clicking each converted button opens the intended '
+    + 'page or form rather than a refusal dialog.',
+};

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -4963,6 +4963,39 @@ const step18: MigrationStep = {
         + '`dimension`/`granularity`/`dateRange`. Declared keys parse byte-identically to before.',
     },
     {
+      id: 'dashboard-header-modal-target-page-only',
+      surface:
+        'dashboard `header.actions[]` entries with `actionType: \'modal\'` — an `actionUrl` naming '
+        + 'a defined action, a bare object name, or the `<verb>_<object>` prefix form '
+        + '(`create_`/`new_`/`add_`/`edit_`/`update_` + object). The keys themselves are unchanged '
+        + 'and still parse; what changed is what the string RESOLVES to',
+      replacement:
+        'a declared page name (`stack.pages`, by `name`) — a modal target names a PAGE, only. To '
+        + 'open an object\'s create/edit form from a dashboard header, use `actionType: \'form\'` '
+        + 'with an `<object>.<view>` form-view target (`actionType` accepts the full action-type '
+        + 'enum, so that shape reaches this surface too)',
+      reason:
+        'Maintainer ruling objectstack#6739-A (2026-08-09): a `type: \'modal\'` string target names '
+        + 'a PAGE, only — the spec TSDoc, the published docs and `defineStack`\'s cross-reference '
+        + 'walk already agreed, and the renderer\'s page-then-object leniency (self-labelled '
+        + 'Back-compat) was retired rather than codified. objectui#4764 deleted the object fallback '
+        + 'in the shared `useActionModal`; objectui#4782 deleted `DashboardView`\'s own second copy '
+        + 'of the prefix convention (which had no page resolution at all), after enumerating both '
+        + 'repos\' corpora and finding zero producers of the prefix form. The `os validate` lint '
+        + 'rule (`validateDashboardActionRefs`) then still pointed the other way: it accepted the '
+        + 'retired shapes — blessing buttons that dispatch to a named refusal at runtime — and '
+        + 'ERRORED on a page-named target, the one shape the runtime serves. The rule now resolves '
+        + 'a modal target against declared pages, only. The ruling explicitly declined the middle '
+        + 'shape (keep the prefix, reject bare object names): `create_opportunity` names the page '
+        + '`create_opportunity`, or it names nothing.',
+      acceptanceCriteria:
+        'Every dashboard `header.actions[]` entry with `actionType: \'modal\'` has an `actionUrl` '
+        + 'naming a declared page (`os validate` passes the dashboard-action-refs rule); header '
+        + 'buttons meant to open an object\'s form declare `actionType: \'form\'` with an '
+        + '`<object>.<view>` target instead. Clicking each converted button opens the intended '
+        + 'page or form rather than a refusal dialog.',
+    },
+    {
       id: 'datasource-config-url-query-credential-refused',
       surface: 'datasource.config.url / datasource.config.syncUrl (turso) and ' +
         'datasource.config.url (postgres) — credential-bearing URL query parameters ' +


### PR DESCRIPTION
Fixes #9013

## What broke, and which way

`validateDashboardActionRefs`'s `resolveActionTarget` accepted, for `actionType: 'modal'`, a defined action name, a bare object name, and the `verb_object` prefix form (`create_`/`new_`/`add_`/`edit_`/`update_` + a defined object) — on its docblock's claim that it mirrored the objectui runtime dispatch. That mirror was deleted: maintainer ruling objectstack#6739-A (2026-08-09) decided a `type: 'modal'` string target names a PAGE, only; objectui#4764 retired the object fallback in the shared `useActionModal`, and objectui#4782 (merged 2026-08-16T06:28:14Z) deleted `DashboardView`'s own second copy of the prefix convention after enumerating both repos' corpora and finding zero producers.

The inversion ran **both ways**: `os validate` blessed buttons that now dispatch to a named refusal at runtime, and it ERRORED on a page-named modal target — the one shape the runtime serves (the old resolver consulted actions and objects, never `stack.pages`).

## The changes (the card's three items, plus two named additions)

1. **`packages/lint/src/validate-dashboard-action-refs.ts`** — for `actionType: 'modal'`, a string target resolves only against declared pages (`stack.pages`). `MODAL_VERB_RE` is deleted; the docblock's mirror claim is rewritten to cite the post-#4782 dispatch; the modal refusal message/hint now name the page contract and point at `actionType: 'form'` with an `object.view` form-view target (mirroring objectui's shared `modalTargetRefusalMessage` wording). `script` resolution is unchanged.
2. **`packages/lint/src/validate-dashboard-action-refs.test.ts`** — the pinning tests flip: the three retired shapes (defined action name, `verb_object` against a real object, bare object name) are now pinned as refusals, and a new test pins that a declared-page target resolves. The #3367 repro keeps its 2-errors-1-warning shape with its comment corrected.
3. **`content/docs/deployment/validating-metadata.mdx`** — the example no longer marks `create_opportunity` (verb-prefix form) as valid; it now shows it as an error with the prescription, plus a valid declared-page target.
4. **`packages/lint/src/authoring-rules.ts`** (same file surface, same defect class) — the rule's registration comment still described "a header or widget action ... resolves to no defined action"; corrected to the script/action, modal/page split.
5. **ADR-0087 semantic entry `dashboard-header-modal-target-page-only`** (`packages/spec/src/migrations/entries/semantic/18.…` + regenerated `registry.ts`). This is the changeset machinery's own requirement, not scope creep: the changeset below is declared **BREAKING** and carries a FROM → TO prescription, so the only honest `check:adr-0087-registration` disposition is `registered`. `spec-changes.json` and the upgrade guide are byte-unchanged by design — step-18 entries project into those artifacts at the major cut (same as `analytics-authorable-unknown-keys-refused`).

## Changeset — real, `minor`, declared BREAKING

`@objectstack/lint` is published and this narrows the accept set of a gating `os validate` rule, so no `skip-changeset`. Bump is `minor` per the post-v17-cut lockstep convention (`check-changeset-no-major.mjs` pushes breaking changes to `minor` outside the launch window; precedent: `analytics-authorable-unknown-keys-refused`), with a `**BREAKING**` declaration, the FROM → TO, and `adr-0087: registered dashboard-header-modal-target-page-only`. `@objectstack/spec` is bumped too because the ledger entry lands in its shipped registry.

## Proof the narrowing refuses (reverse verification, direction decided in advance)

Predicted: against the origin/main resolver, exactly 4 tests red — 3 because the old code **accepts** the retired shapes, 1 because the old code **refuses** a page-named target; the #3367 repro green in both regimes (its stack declares neither page nor object, dead either way). Measured exactly that (fix committed first; old source stood up via `git restore --source=origin/main`, then restored from HEAD):

```
× passes a modal action that names a declared page
× ERRORS on a modal action that names a defined action — an action is not a page
× ERRORS on the retired verb_object convention, even against a real object
× ERRORS on a bare object name — the create-form fallback is retired
Test Files  1 failed | 72 passed (73) · Tests  4 failed | 2057 passed
```

Restored at HEAD: `73 passed (73) · 2061 passed | 4 skipped`.

## Verification at `25bd737b5` (the union ran after the final commit, clean tree)

- `pnpm --filter @objectstack/lint test` — 73 files / 2061 passed; `typecheck` clean.
- `pnpm --filter @objectstack/spec test` — 406 files / 10743 passed; `typecheck` clean; `check:generated` — all 13 artifacts current (`check:migration-registry`, `check:spec-changes`, `check:upgrade-guide` included).
- Gate union derived via `node scripts/pm/dispatch-gates.mjs` over the real changed paths, all green at `25bd737b5`: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:doc-formula-expressions` (lint), `check:docs-audit-scope`, `check:merge-driver`, `check:objectui-changeset`, `check:role-word`, `check:spec-parsed-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-dev-prereqs` (after the full packages-closure build, as lint.yml runs it), `check-empty-changeset`, `check:nul-bytes`, plus the test-file convention gates `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt` (re-measure, no drift), `check:engine-double-contract`, `check:where-matcher`.
- Consumption-radius sweep: no other fixture or rule spells the retired shapes — the only remaining `verb_object` mentions are immutable CHANGELOG history; other `create_opportunity` hits are unrelated (a flow name, a convert param, a translation fixture).

Corpus note: no dashboard in this repo's examples/apps authors `header.actions[]` at all (matching objectui#4782's enumeration), so no fixture re-spelling was needed outside the rule's own tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_