### PR TITLE
docs: spell the console form routes with the real `/_console` mount

### DIFF
--- a/content/docs/protocol/objectui/actions.mdx
+++ b/content/docs/protocol/objectui/actions.mdx
@@ -49,7 +49,7 @@ The `type` field selects how an action is dispatched. The complete enum is **`sc
 | `flow` | Invoke a Screen/automation Flow by name. | Yes |
 | `modal` | Open a modal/page by name. | Yes |
 | `api` | Call an API endpoint (`method` defaults to `POST`). | Yes |
-| `form` | Open a FormView by name, routed to `/console/forms/:name` **inside the console shell**; the submit lands on the created record. | Yes |
+| `form` | Open a FormView by name, routed to `/_console/forms/:name` **inside the console shell**; the submit lands on the created record. | Yes |
 
 `target` is the canonical binding for every non-`script` type, and since protocol 17 it is the **only** one. The deprecated `execute` alias was removed (#3855): authoring it is rejected with an error naming the replacement, not silently stripped. Run `os migrate meta --from 16` to rewrite existing sources automatically — the removal also ships in the machine-readable change manifest (`spec-changes.json`), which composes across however many majors you are jumping.
 
@@ -150,7 +150,7 @@ refreshAfter: true
 
 ### Form Actions
 
-Open a FormView by name. The renderer routes to `/console/forms/:name`:
+Open a FormView by name. The renderer routes to `/_console/forms/:name`:
 
 ```yaml
 name: quick_edit
@@ -163,11 +163,11 @@ target: customer_quick_edit
 
 `type: 'form'` is the platform's first-class way to open an object's form — the shape that replaced the `type: 'modal'` object fallback — so its contract is stated here rather than left to each renderer to decide (ruled 2026-08-10 on [#7245](https://github.com/objectstack-ai/objectstack/issues/7245)):
 
-1. **It renders in-shell.** The internal form route nests **inside** the console shell: sidebar, app navigation and breadcrumb stay. A form action never drops the operator onto an unchromed standalone page with the browser Back button as the only way home. The route survives too — `/console/forms/:name` stays deep-linkable and bookmarkable, which is what a route buys you over a transient dialog.
-2. **A successful submit lands on the created record.** On the internal path the default post-submit behavior is a **redirect to the record that was just created**, not a confirmation panel. The `thank-you` panel is the default for the **public** `/console/f/:slug` path only, where there is no record the anonymous submitter is allowed to see.
+1. **It renders in-shell.** The internal form route nests **inside** the console shell: sidebar, app navigation and breadcrumb stay. A form action never drops the operator onto an unchromed standalone page with the browser Back button as the only way home. The route survives too — `/_console/forms/:name` stays deep-linkable and bookmarkable, which is what a route buys you over a transient dialog.
+2. **A successful submit lands on the created record.** On the internal path the default post-submit behavior is a **redirect to the record that was just created**, not a confirmation panel. The `thank-you` panel is the default for the **public** `/_console/f/:slug` path only, where there is no record the anonymous submitter is allowed to see.
 3. **An explicit `submitBehavior` on the FormView always wins**, in either mode. The defaults above are what you get for declaring nothing; they are not a ceiling.
 
-| | Public path (`/console/f/:slug`) | Form action / internal path (`/console/forms/:name`) |
+| | Public path (`/_console/f/:slug`) | Form action / internal path (`/_console/forms/:name`) |
 | --- | --- | --- |
 | Audience | anonymous visitors | authed operators — where `type: 'form'` sends them |
 | Chrome | standalone page, no console chrome | nested inside the console shell |

--- a/content/docs/ui/forms.mdx
+++ b/content/docs/ui/forms.mdx
@@ -9,8 +9,8 @@ ObjectStack Forms are Airtable-style **metadata-driven** forms with two render m
 
 | Mode | Route | Auth | Spec source | Submit target |
 |---|---|---|---|---|
-| **Public** | `/console/f/:slug` | anonymous | `GET /api/v1/forms/:slug` (resolved by `sharing.publicLink`) | `POST /api/v1/forms/:slug/submit` (field whitelist + declaration-derived `publicFormGrant`) |
-| **Internal** | `/console/forms/:name` | authed | `GET /api/v1/meta/view/:name` (+ `meta/object/:object`) | `POST /api/v1/data/:object` (full RBAC) |
+| **Public** | `/_console/f/:slug` | anonymous | `GET /api/v1/forms/:slug` (resolved by `sharing.publicLink`) | `POST /api/v1/forms/:slug/submit` (field whitelist + declaration-derived `publicFormGrant`) |
+| **Internal** | `/_console/forms/:name` | authed | `GET /api/v1/meta/view/:name` (+ `meta/object/:object`) | `POST /api/v1/data/:object` (full RBAC) |
 
 Both modes:
 
@@ -311,11 +311,11 @@ async function submit(slug: string, payload: Record<string, unknown>) {
 }
 ```
 
-The ObjectUI console (a separate package/repo) ships a unified `FormPage` renderer at `/console/f/:slug` (public) and `/console/forms/:name` (internal) that does exactly this.
+The ObjectUI console (a separate package/repo) ships a unified `FormPage` renderer at `/_console/f/:slug` (public) and `/_console/forms/:name` (internal) that does exactly this.
 
-## 6. Internal forms (`/console/forms/:name`)
+## 6. Internal forms (`/_console/forms/:name`)
 
-Sometimes you want the same FormView metadata to power an authed operator flow — "new lead", "new ticket", a queue triage screen. Set the FormView up normally (no `sharing.allowAnonymous`) and navigate to `/console/forms/<view_name>`:
+Sometimes you want the same FormView metadata to power an authed operator flow — "new lead", "new ticket", a queue triage screen. Set the FormView up normally (no `sharing.allowAnonymous`) and navigate to `/_console/forms/<view_name>`:
 
 ```ts
 // hotcrm/src/views/lead.view.ts (internal form variant)
@@ -342,7 +342,7 @@ export default defineView({
 });
 ```
 
-Operators hit `/console/forms/quick_create`. The renderer:
+Operators hit `/_console/forms/quick_create`. The renderer:
 
 - Loads metadata via `GET /api/v1/meta/view/quick_create`
 - Pulls the object schema via `GET /api/v1/meta/object/lead`
@@ -355,8 +355,8 @@ Permissions are enforced server-side just like every other authed write — no `
 Both modes accept `?prefill_<field_name>=<value>` query params. Use this to seed forms from email links, CRM segments, or campaign pages:
 
 ```
-/console/f/contact-us?prefill_company=Acme&prefill_email=ada@example.com
-/console/forms/quick_create?prefill_lead_source=event_booth_2026
+/_console/f/contact-us?prefill_company=Acme&prefill_email=ada@example.com
+/_console/forms/quick_create?prefill_lead_source=event_booth_2026
 ```
 
 The renderer maps each `prefill_<name>` param to the corresponding form field. Values are still subject to validation and (for public mode) the server-side whitelist — prefill is a UX shortcut, not a permissions bypass.
@@ -429,14 +429,14 @@ Widening this — an allowlist of absolute origins, say — waits for measured d
 
 | Mode | Default when `submitBehavior` is omitted | Why |
 |---|---|---|
-| **Public** (`/console/f/:slug`) | `{ kind: 'thank-you' }` — the confirmation panel | The anonymous submitter may not read the record back, so a receipt is all there is to show. |
-| **Internal** (`/console/forms/:name`) | Redirect to the **created record** | An operator who just created a record belongs on that record, not on a "submission received" receipt. |
+| **Public** (`/_console/f/:slug`) | `{ kind: 'thank-you' }` — the confirmation panel | The anonymous submitter may not read the record back, so a receipt is all there is to show. |
+| **Internal** (`/_console/forms/:name`) | Redirect to the **created record** | An operator who just created a record belongs on that record, not on a "submission received" receipt. |
 
 An explicit `submitBehavior` overrides the default in either mode, so nothing here removes an option — it only changes what an author gets for declaring nothing.
 
 ## 9. `type: 'form'` action — declarative form launchers
 
-App actions can declare `type: 'form'` to open a FormView without resorting to free-form URLs. The `target` is the FormView name; the runtime navigates to `/console/forms/:name` **inside the console shell** — the operator keeps the sidebar, navigation and breadcrumb, and a successful submit lands on the created record per the mode-aware default above. The full contract is stated on the [Action Protocol page](/docs/protocol/objectui/actions#what-type-form-promises).
+App actions can declare `type: 'form'` to open a FormView without resorting to free-form URLs. The `target` is the FormView name; the runtime navigates to `/_console/forms/:name` **inside the console shell** — the operator keeps the sidebar, navigation and breadcrumb, and a successful submit lands on the created record per the mode-aware default above. The full contract is stated on the [Action Protocol page](/docs/protocol/objectui/actions#what-type-form-promises).
 
 {/* os:check */}
 ```ts
@@ -451,7 +451,7 @@ export default Action.create({
 });
 ```
 
-Compared to `{ type: 'url', target: '/console/forms/quick_create' }`, the `'form'` variant is portable across runtimes — Studio/console/native shells can route it through their own form renderer instead of a raw navigation.
+Compared to `{ type: 'url', target: '/_console/forms/quick_create' }`, the `'form'` variant is portable across runtimes — Studio/console/native shells can route it through their own form renderer instead of a raw navigation.
 
 ## 10. Record detail is driven by semantic roles, not a form binding
 

--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -1805,7 +1805,7 @@ Register them under `defineStack({ actions: [...] })`.
 | `modal`  | Open a dialog (typically collecting `params`, then executing `body`) | `target`     |
 | `flow`   | Launch a screen/auto-launched flow by name                         | `target`       |
 | `api`    | Call a registered API endpoint                                     | `target`       |
-| `form`   | Open a FormView by name (routed to `/console/forms/:name`)         | `target`       |
+| `form`   | Open a FormView by name (routed to `/_console/forms/:name`)        | `target`       |
 
 ### Where Actions Appear (`locations`)
 


### PR DESCRIPTION
Fixes #9050

Documentation only. No route, code or config is changed.

## The fork: this was a CORRECTION, not a convention choice

The card framed the canonical spelling as an open decision, and the dispatch split on it: if `/console/forms/:name` does not resolve, the 14 sites are simply wrong; if both spellings resolve, it is a real convention choice and I must stop rather than pick. **It does not resolve**, so this is a correction.

What I read to decide — the route mounting, not the URL string:

- `packages/cli/src/utils/console.ts:43` — `export const CONSOLE_PATH = '/_console'`. A hardcoded constant; nothing configurable feeds it.
- Same file `:534-541` — the **only** three registrations: `/` redirects to `/_console/`; bare `/_console` redirects to `/_console/`; `/_console/*` serves the SPA. Nothing registers a bare `/console`, and there is no catch-all that would reach one.
- Same file `:516` — the mount injects a base-href tag pinned to `/_console/`, from which React Router derives its basename.
- objectui `apps/console/src/App.tsx:225` — `path="/forms/:name"` is a route *inside* that SPA, so it hangs off the basename above ⇒ live URL `/_console/forms/:name`. This matches the browser measurement recorded during #7245's triage.

The one configurable knob is `uiBasePath` (default `/_console`, `packages/spec/src/system/auth-config.zod.ts:302`). It is **not** an outer-prefix switch: its only consumers are in `plugin-auth`, which uses it to build links into the Console's auth pages (`auth-manager.ts:3622-3632`). It cannot make a bare `/console` request resolve, so the "both spellings resolve" branch of the fork is closed on evidence rather than assumption.

Checked and explicitly **not** a spelling ruling: the `ruled 2026-08-10 on #7245` line quoted in `view.zod.ts:2446` pins the *mode-aware `submitBehavior` default*. The paths in that comment are incidental prose, so nothing here contradicts a landed ruling.

## Re-derived enumeration

The card's count was measured at filing time, so I re-ran its own command on this branch's base (`2cb69c31c`) rather than trusting it:

```
$ grep -rn "console/forms/" content/docs skills | grep -v "_console" | wc -l
14
```

**14 — exactly the card's number.** No drift across today's merges (#9033 / #9051 / #9052 / #9056). All 14 are swept here; none legitimately needs the other spelling.

## One extension beyond the card's 14, named deliberately

The card measured `/console/forms/` only. The sibling **public** form path is documented as `/console/f/:slug` — **6 further occurrences** in the same two files — and it is the identical defect: same missing underscore, same SPA, pinned by the same route table (`apps/console/src/App.tsx:180`, `path="/f/:slug"`).

I swept those 6 as well, because leaving them is precisely the failure the card exists to prevent. They are not in some distant file — they are interleaved with the lines being fixed:

- `forms.mdx:12` (public) sits directly above `:13` (internal), two rows of one table;
- `forms.mdx:314` carries both spellings **in a single sentence**;
- `actions.mdx:170` carries both **in one table row**.

Fixing only the internal path would have left one sentence reading "`/console/f/:slug` (public) and `/_console/forms/:name` (internal)", which is strictly more confusing than the state before this PR.

Total: **20 occurrences** (14 internal + 6 public) across 3 files.

## Verified as a false positive, deliberately untouched

`forms.mdx:454` matches a naive `/console/` grep, but only as the prose fragment `Studio/console/native shells` — a list of shell names, not a path. It is unchanged.

## Scope boundaries respected

`packages/spec/src/ui/view.zod.ts` (`:2446`, `:2449`) and `action.zod.ts` (`:500`) carry the same wrong spelling in JSDoc comments. Those are code and out of scope for this documentation-only card, so they are **filed as #9078**, not edited here. (They are comments, not `.describe()` strings, and no generated reference page carries the text today, so nothing published depends on them.)

## Verification

Gate families derived from the final diff, not recalled — `node scripts/pm/dispatch-gates.mjs content/docs/ui/forms.mdx content/docs/protocol/objectui/actions.mdx skills/objectstack-ui/SKILL.md` returned three: `check:docs-audit-scope`, `check:docs-redirects`, `check:role-word`. I added three the derivation did not name but the diff visibly implicates: `check:nul-bytes` (any edit), `check:doc-authoring`, and `check:doc-anchors` — the last because this diff **renames a heading**, `## 6. Internal forms (...)`, which changes its anchor slug.

All six run at the final commit `c7b75b292`, all green:

```
===== check:nul-bytes =====        [exit 0]
===== check:docs-audit-scope =====
✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s).
                                   [exit 0]
===== check:docs-redirects =====
check-docs-redirects: OK (apps/docs/redirects.mjs: 92 entries -- 89 page destination(s)
resolved against content/docs, 3 wildcard destination(s) ..., 98 chain probe(s) matched)
                                   [exit 0]
===== check:role-word =====
check-role-word: OK (43 baselined file(s), no new occurrences).
                                   [exit 0]
===== check:doc-authoring =====
✓ doc authoring guard: 376 files clean — no bare metadata literals.
                                   [exit 0]
===== check:doc-anchors =====
✅ check-doc-anchors: 239 internal #fragment link(s) across 396 source file(s)
   all resolve to a real heading
                                   [exit 0]
```

The renamed heading is safe on two independent readings: `check:doc-anchors` resolves all 239 fragment links, and a direct search for inbound links to that heading (`internal-forms`) finds none anywhere in `content/docs`, `skills` or `packages`.

`Check Documentation Links` covers page-path links rather than `#fragment` anchors, so it does not overlap with the gate above — but it is unaffected here regardless: `grep -noE '\]\([^)]*console[^)]*\)'` over all three changed files returns nothing, i.e. this diff touches no markdown link target. Every one of the 20 edits sits inside backticks or a fenced code block.

Also scanned beyond the gate for control bytes, since paths and escapes are being edited: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the three files is clean.

No changeset: this PR changes only `content/docs/**` and `skills/**` and publishes no package, so it releases nothing — `skip-changeset` applied.

## Merge posture

⛔ This PR touches `skills/objectstack-ui/SKILL.md`, an AI-no-merge path (#7623 / #7548). It is deliberately a **draft**, is **not** queued, and has **no** auto-merge. It waits for a human reviewer.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_