### PR TITLE
docs(releases): correct the 16.0.0-rc.1 Console pin in v16.mdx to 69fa5d163a97

### DIFF
--- a/content/docs/releases/v16.mdx
+++ b/content/docs/releases/v16.mdx
@@ -569,8 +569,8 @@ directly) and the removal of the Gantt mobile QR-share context action
 > **Console vs. pin.** This section is sourced from **objectui's own
 > changesets**, not only the `@objectstack/console` bundle-bump summaries (a
 > bump pins a SHA and can lag objectui `main`). The `rc.0` bundle pins
-> `94d4876`; the pin advanced to `af1b0db` before the `16.0.0-rc.1` cut — that
-> later Console work is under
+> `94d4876`; the pin advanced to `69fa5d163a97` before the `16.0.0-rc.1` cut —
+> that later Console work is under
 > [Landed since 16.0.0-rc.0](#landed-since-1600-rc0).
 
 ### Approvals inbox goes metadata-driven (#2678 line)
@@ -701,8 +701,8 @@ The four frontend changes that were pending when this page was first written
 `numberList` flow mapping — objectui#2708; ActionParamDialog upload guard +
 `autonumber` — objectui#2707; system-field classifier consolidation —
 objectui#2706) **are now bundled**: the console pin advanced `94d4876 →
-af1b0db`, released as `@objectstack/console` 16.0.0-rc.1. They plus a further
-wave of Console work are described under
+69fa5d163a97`, released as `@objectstack/console` 16.0.0-rc.1. They plus a
+further wave of Console work are described under
 [Landed since 16.0.0-rc.0](#landed-since-1600-rc0) below.
 
 ## Landed since 16.0.0-rc.0
@@ -710,7 +710,7 @@ wave of Console work are described under
 These changes are on `main` after the `rc.0` cut and **rolled into
 `16.0.0-rc.1`**, cut on 2026-07-20 — the train's last RC, so every entry below
 shipped in **16.0.0**. Backend from those changesets, Console from the objectui
-pin advancing `94d4876 → af1b0db` (objectui #2706–#2736), bundled as
+pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
 `@objectstack/console` 16.0.0-rc.1. Sourced from each repo's own changesets.
 
 ### Breaking / behavior
@@ -799,7 +799,7 @@ pin advancing `94d4876 → af1b0db` (objectui #2706–#2736), bundled as
   so mark-as-read works on `os dev` / standalone instead of leaving unread
   state that could never clear.
 
-### New in Console (objectui, now bundled `94d4876 → af1b0db`)
+### New in Console (objectui, now bundled `94d4876 → 69fa5d163a97`)
 
 - **Option-widget `visibleWhen` parity.** Per-option cascading + `dependsOn`
   gating lands across the widget family so client and server agree on which


### PR DESCRIPTION
Fixes #9035

`content/docs/releases/v16.mdx` named `af1b0db` as the objectui pin that the `16.0.0-rc.1` cut landed on, in four places. `af1b0db96e44` is an **intermediate** pin inside rc.1, not its endpoint — rc.1 ended at `69fa5d163a97`.

This is the releases-page **factual-correction** lane from `CLAUDE.md` — *"If you believe a releases page has a factual error, file an issue or make it a dedicated docs-only PR — never a rider on code changes."* Docs-only, one file, six lines, no content added.

## The chain, re-derived from scratch

Not copied from the card. Re-derived mechanically from `packages/console/CHANGELOG.md`'s `## 16.0.0-rc.1` section, which holds exactly four pin-bump changesets, each stating its own `objectui range`:

| changeset | stated range | refreshed to |
| :-- | :-- | :-- |
| `a276969` | `94d4876df090...0318118e02fd` | `0318118e02fd` |
| `bfa3c3f` | `0318118e02fd...3b2e4d98d904` | `3b2e4d98d904` |
| `1965549` | `3b2e4d98d904...af1b0db96e44` | `af1b0db96e44` |
| `a791200` | `af1b0db96e44...69fa5d163a97` | `69fa5d163a97` |

⇒ `94d4876df090 → 0318118e02fd → 3b2e4d98d904 → af1b0db96e44 → 69fa5d163a97`

Three checks beyond reading the table off the page:

1. **Internal consistency** — each entry's stated range endpoint must equal its own "refreshed to" sha. All four agree, so the two independent statements inside every entry corroborate each other.
2. **The chain is closed and total** — following the links from `94d4876df090` consumes all four entries with no orphan and no fork; every range starts exactly where the previous one ends, so there is no room for a fifth, unlisted bump.
3. **Both boundaries corroborate from outside rc.1** — rc.0's last bump (`39b56d0`) ends at `94d4876df090`, exactly where the chain starts; the GA-cut bump (`db34d54`) states `69fa5d163a97...9a5f016f7d5c`, exactly where it ends.

**My reading matches the card's chain and its endpoint exactly** — same four links, same intermediate, same endpoint `69fa5d163a97`.

## What changed — four sites, one fact

| where | was | now |
| :-- | :-- | :-- |
| "Console vs. pin" blockquote | "the pin advanced to `af1b0db` before the `16.0.0-rc.1` cut" | `69fa5d163a97` |
| "Console changes after the `rc.0` pin" | "the console pin advanced `94d4876 → af1b0db`" | `94d4876 → 69fa5d163a97` |
| "Landed since 16.0.0-rc.0" intro | "pin advancing `94d4876 → af1b0db` (objectui #2706–#2736)" | `94d4876 → 69fa5d163a97` (objectui #2701–#2743) |
| "New in Console" heading | "now bundled `94d4876 → af1b0db`" | `94d4876 → 69fa5d163a97` |

The corrected sha is spelled in the 12-character form the changelog and the page's own GA-pin line already use, so it is greppable against both; `94d4876` is left at its existing width because it is correct and is spelled that way elsewhere on the page.

### The PR-number span was independently wrong

The *Landed since 16.0.0-rc.0* line also carried `(objectui #2706–#2736)`. The page's convention — confirmed against the rc.0 line's own `#2589–#2705` — is the **min/max of trailing PR numbers** in the pin window: `#2231` is a *referenced* issue inside rc.0's span and is correctly excluded, while `#2589` and `#2705` are both trailing PR numbers.

Computed over rc.1's 21 trailing PR numbers: **`#2701`–`#2743`**.

Worth noting `#2706–#2736` was wrong at **both** ends even for the page's own (mistaken) `af1b0db` window, whose span is `#2701`–`#2739` — `#2701` (import-wizard `auto` policy) sits below the old floor and `#2739` (`engine-owned` lifecycle bucket) above its ceiling, and both are described in the page's own bullet list. So this is a second factual error in the same sentence, not merely a knock-on of the pin fix.

## The objectui#2743 consequence: verified true, and deliberately not folded in

The card raised this as an inference, and the dispatch asked for it to be tested rather than assumed. Tested: grepping the page for `2743` returns nothing, while `3354` — the framework half of the same mark-as-read fix — is documented at line 793, its prose describing the user-visible outcome directly. **The hypothesis holds.**

It is nevertheless not in this PR, and the reason is a measurement rather than caution. Correcting the heading widens the window it names, so the honest question is whether that induces a fresh overclaim about the bullet list underneath. It does not, because **the list is already a curated highlights list, not an enumeration**: the `1965549` window alone holds 16 frontend changes and the list itemizes 13. The three it passes over — objectui#2718 (docs build resilient to remote badge fetch failures), objectui#2721 (coerce i18n tab-label helpers to string), objectui#2726 (type the exportDownload test fetch mock) — are internal, and their omission predates and is independent of the pin error.

⇒ The heading's parenthetical is a **pin** claim, a fact about what the release bundles; the bullet list's contents are a curation question. Correcting the first cannot falsify the second, because the second never claimed to be exhaustive.

Adding objectui#2743 would therefore be adding what is missing — the **completeness** lane, which on release-owned surface carries its own per-card approval requirement, and which #8917 and #8916 were deliberately split apart to keep separate from correctness. Filed instead as #9080, unassigned, with the measurement above and the asymmetry that makes it worth a card: unlike those three internal omissions, objectui#2743 is user-visible and its counterpart half is documented in the same page.

## Verification

Gate families derived from the actual changed path after the final commit, not recalled:

```
node scripts/pm/dispatch-gates.mjs content/docs/releases/v16.mdx
```

All green at `8a98f4832` (the commit this PR head points at):

| gate | result |
| :-- | :-- |
| `check:docs-audit-scope` | OK — 178 hand-written docs; 9 release-owned pages in scope and review-only |
| `check:docs-redirects` | OK — 92 entries, 98 chain probes |
| `check:release-notes` | OK — every released major has a curated, navigable page |
| `check:release-page-status` | OK — 2 GA majors in scope (v16, v17), both status blockquotes and index entries describe a shipped release |
| `check:role-word` | OK — 43 baselined files, no new occurrences |
| `check:nul-bytes` | OK — 5966 text files scanned, no raw ASCII control bytes |

Additional checks on the diff itself:

- `grep af1b0db content/docs/releases/v16.mdx` now returns **no match** — all four sites moved, none missed.
- Nothing links to the changed heading's anchor: `grep -rn new-in-console content/` returns nothing, so renaming it breaks no in-page navigation.
- The page's other pin claims re-check as correct and are untouched: rc.0's `077e45b..94d4876` / `#2589–#2705`, the GA bump to `9a5f016f7d5c`, and 16.1.0's single bump `9a5f016f7d5c → cf2d56e32a11` (verified against the `7b07417` entry).
- No other release page is touched. #8916's v9/v12/v14 status lines and #8917's completeness surface are both out of scope here and remain open.

Docs-only, so `skip-changeset` applies — no package is released by this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_