### PR TITLE
pm-dispatch: `pm:on-hold` legal only with a machine-fireable `Restart-when:`; seam cards transfer at triage; H9/H10 detectors

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -149,12 +149,11 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
    (transfer 不可用时重建:出处头 + 裸 `#N` 改全名 + 关源单为 moved);不成立才是缝卡。**缝卡收窄到真
    协调卡**,留在 objectstack 带 `repo:objectui` / `repo:cloud`,且**正文必须具名读者**(哪个座位、哪一
    步读它 —— 只有标签没有具名读者的队列没人扫);维护者收件箱恒为 objectstack。在飞卡 ⛔ 不中途转仓。
-2. **Contract-first 拆分。** 跨仓 feature 永不是一次派发:父单 + 每仓一 sub-issue, spec/后端
-   先行,下游带 `Blocked-by: <owner/repo>#<n>`;凡 `Blocked-by` 未关闭/未合并的不派发(
-   对 GitHub 现验);被链接或同父的两单永不同批。**Pin 滞后是它的盲区**:本仓 pin 是否已覆盖那
-   个 commit 是第二个读数,派发前用 REST `compare` 核祖先关系(本地 `merge-base` 在浅检出上给
-   假「非祖先」);未覆盖 ⇒ 派发令要求 PR 正文留档分叉窗口,且 ⛔ pin bump 不做 rider(走专
-   用 bump 脚本连带 override 与 lockfile)。
+2. **Contract-first 拆分。** 跨仓 feature 永不是一次派发:父单 + 每仓一 sub-issue, spec/后端先行,下
+   游带 `Blocked-by: <owner/repo>#<n>`;凡 `Blocked-by` 未关闭/未合并的不派发(对 GitHub 现验);被链接
+   或同父的两单永不同批。**Pin 滞后是它的盲区**:本仓 pin 是否已覆盖那个 commit 是第二个读数,派发前
+   用 REST `compare` 核祖先关系(本地 `merge-base` 在浅检出上给假「非祖先」);未覆盖 ⇒ 派发令要求 PR
+   正文留档分叉窗口,且 ⛔ pin bump 不做 rider(走专用 bump 脚本连带 override 与 lockfile)。
 3. **联动杂事立单,不靠记忆。** 已验收 PR 的产物流向另一仓时,由**接受那个 PR 的执行座位**立即
    在消费仓立后续单(带 `Blocked-by:`);`domain:*` 仍由分诊补。
 4. **纵向拆分:一个分诊 PM + N 个执行 PM,一人一车道双射**(维护者 2026-08-05 拍板)。分诊座位全
@@ -278,12 +277,14 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 。**「生产者在哪?」是常设分诊问题**:declared ≠ enforced 形状的卡先问谁在写这个字段 —— 答案通
 常就是根因,并在派发前改变卡的范围与域标签。
 
-**发现分诊轮(队列的出水口)。** `finding` 恒 = 待首次定级、定级即离标(维护者 2026-08-13 意见;换标
-与 hold 评论纪律见 State model,hold 重验只在 `Restart-when:` 命中时发生,⛔ 不设逐卡豁免评论)。**首触定
-级每轮跑**:预算 3–5 张、优先于一切旧卡重验,先过时前提检查再三选一 —— 晋级 / 关闭 not planned(维
-护者可否决重开,PM 不等批准)/ hold;**判级发生在这里,不在立单时**。车道座位可附证据/前提重验,⛔
-不定级不改标(唯一例外:skills 车道 finding 由该席自分诊,全仓轮跳过)。**自动集中轮**(常设授权,维
-护者 2026-08-13):`finding` >15 ⇒ 下一 fire 跑域分批集中轮,sweep 打包晋级五条照用;原话、批量参数与五条细则见 `references/dispatch-runbook.md`。
+**发现分诊轮(队列的出水口)。** `finding` 恒 = 待首次定级、定级即离标(维护者 2026-08-13 意见;换标与
+hold 评论纪律见 State model,hold 重验只在 `Restart-when:` 命中时发生 —— closed 形态随每轮解锁扫描,可
+执行判据由分诊 Routine 每日一个低频子轮批量执行(十几条一行判据逐小时跑是浪费,每日即消化节奏),命中
+同 closed 命中一个待遇:回队前 ref 重验再回队;⛔ 不设逐卡豁免评论)。**首触定级每轮跑**:预算 3–5 张、
+优先于一切旧卡重验,先过时前提检查再三选一 —— 晋级 / 关闭 not planned(维护者可否决重开,PM 不等批准)
+/ hold;**判级发生在这里,不在立单时**。车道座位可附证据/前提重验,⛔ 不定级不改标(唯一例外:skills 车
+道 finding 由该席自分诊,全仓轮跳过)。**自动集中轮**(常设授权,维护者 2026-08-13):`finding` >15 ⇒ 下
+一 fire 跑域分批集中轮,sweep 打包晋级五条照用;原话、批量参数与五条细则见 `references/dispatch-runbook.md`。
 
 **发版板(`target:<major>`;运维细则见 `references/seat-post-protocol.md`)。** 判据二元(⛔ 不
 做优先级渐变 —— 渐变没人维护):「不修它,当前 RC 能不能发?」判阻塞四类:① 用户今天就撞的已发布
@@ -667,10 +668,9 @@ pull(今天谁撞上;零拉动默认 defer/ remove);③ AI-agent error-resistanc
 ```
 
 `premise_still_valid: false` + `pr: null` 是合法终报 —— 当再分诊输入复核,永不当失败派发。
-`status: needs_decision` 时 `open_questions` 必须非空。`out_of_scope_findings` 应已由 dev 立
-成无 assignee 的卡(查重先行、归挂判据、`finding` 标注,立在修复落地仓并带回链);PM 核验它们存
-在,**并把同轮并行报告互相对读** —— 两个 dev 同一小时审相邻代码会立出孪生卡,只有 PM 同时看得
-见两份报告。
+`status: needs_decision` 时 `open_questions` 必须非空。`out_of_scope_findings` 应已由 dev 立成无 assignee 的卡
+(查重先行、归挂判据、`finding` 标注,立在修复落地仓并带回链);PM 核验它们存在,**并把同轮并行报告互相
+对读** —— 两个 dev 同一小时审相邻代码会立出孪生卡,只有 PM 同时看得见两份报告。
 
 ## 机械守卫索引(原则在此,细节以脚本头为权威)
 

--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -20,11 +20,10 @@ metadata:
 :**select → claim → dispatch → collect → review → report → next batch**。维护者只在两个点进
 入循环:轮次报告,和 `needs-user-decision` 决策卡。
 
-本文只写**原则、状态机与查表数据**(维护者 2026-08-12 裁定:「现有的项目经理skills 应该大幅简
-化,只需要说原则,不需要写细节」;「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」)
-。每条经验自含失效模式与边界,⛔ 操作文本不引用issue 编号,不期待读者去翻原始 issue;裁决保留**
-日期 + 原话**;凡钩子/门禁/脚本已机械强制的只留一句原则,细节以脚本头为权威;按需查阅的事实表住
-在 `references/`。
+本文只写**原则、状态机与查表数据**(维护者 2026-08-12 裁定:「现有的项目经理skills 应该大幅简化,只需
+要说原则,不需要写细节」;「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」)。每条经验自含
+失效模式与边界,⛔ 操作文本不引用issue 编号,不期待读者去翻原始 issue;裁决保留**日期 + 原话**;凡钩子
+/门禁/脚本已机械强制的只留一句原则,细节以脚本头为权威;按需查阅的事实表住在 `references/`。
 
 ## 入口与角色
 
@@ -75,7 +74,7 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 | **assignee 已设** | 已认领/在飞 —— 不是你的就永不碰 |
 | `pm:dispatched` | 已派发(派发评论记轮次);与摘 `pm:queue` **同一次标签写入**成对落地 |
 | `needs-user-decision` | 决定**待做** —— 永不派发、除已裁代裁通道外永不代答;维护者的收件箱 |
-| `pm:on-hold` | 决定**已做**且答案是「不是现在」—— 不派发也不催;hold 评论带**日期、理由、具名重启条件、出处**(维护者裁或座位定级 —— 出处住评论,⛔ 不设第二个标签区分) |
+| `pm:on-hold` | 决定**已做**且答案是「不是现在」—— 不派发也不催;**仅当正文带机器可读行 `Restart-when: closed <owner/repo>#N`(由 `Blocked-by:` 的同一遍解锁扫描点火、同一正文单通道)或 `Restart-when: <一行可执行判据>` 时才合法**;hold 评论带日期、理由、出处(维护者裁或座位定级,⛔ 不设第二个标签区分) |
 | `pm:blocked` + 正文行 `Blocked-by: #N` | 等上游 —— 选择期跳过,#N 关闭时由解锁扫描放回 |
 | `pm:blocking` | 有 open 下游依赖者(分诊 sweep 自 `Blocked-by:` 索引推导的缓存,⛔ 不手工挂);进选择优先级全序 |
 | `finding` | 观察类记录,恒 = **待首次定级**(定级即离标:晋级换 `pm:queue` / 关闭 / hold 换 `pm:on-hold`;裸标签数即健康读数)—— 不占队列不进收件箱 |
@@ -88,10 +87,14 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 
 **标签纪律 —— 标签就是状态机,必须诚实:**
 
-- `needs-user-decision` vs `pm:on-hold` = **决定待做 vs 已做**,挂错招来重复升级或永久沉默
-  ;hold 没有重启条件 = 谁都无法合法退出的状态。**机会主义重启条件必须点名触发文件**(维护
-  者 2026-08-11 接受)——「下个碰这些文件的 PR 顺手带上」在命中那一刻没有读者;处方:hold 评论写
-  触发文件清单,车道座位贴设「派发前必查」段,派发卡文件面与清单相交时点名该单、顺手活列为申报过的增项。
+- `needs-user-decision` vs `pm:on-hold` = **决定待做 vs 已做**,挂错招来重复升级或永久沉默;hold 没
+  有可点火的出口 = 谁都无法合法退出的状态,`manual — <理由>` ⛔ 不是合法出口 —— 没有机制能唤醒的卡不
+  hold,按「暂时不准备开发 ⇒ 直接关闭」(维护者 2026-08-16 原话:「我建议有些暂时不准备开发的应该直接
+  关闭。」)关 not planned,理由与出处写进关单评论:卡即记录、重开免费、维护者可否决。**关闭默认不适用
+  `type:Bug` 的 hold**,三分支:可复现且用户可达 ⇒ 回 `pm:queue`(Bug 优先只作用于队列卡,held bug 就
+  是被藏起的缺陷);declared≠enforced 观察类 ⇒ 转 enforce-or-remove 通道(其真实解决路径,不 hold 不裸
+  关);真 won't-fix 候选 ⇒ 逐卡进决策箱 —— 座位永不自行关闭真实缺陷。**机会主义重启条件必须点名触发文
+  件**(维护者 2026-08-11 接受):hold 评论写触发文件清单,座位贴设「派发前必查」段,派发卡文件面与清单相交时点名该单、顺手活列为申报过的增项。
 - **`Blocked-by:` 行是机器可 grep 的反向索引**,一遍读喂三个职责:上游关单时放回被解锁的、按解
   锁扇出排序选择、**在合并后的 ref 上重验每张回队卡的文件面**(⛔ 只做第一件)。**一个标签存在
   ,当且仅当有具名读者**;2026-08-11 的「⛔ 不落存储标签」已被维护者 2026-08-13 意见取代(原话
@@ -141,10 +144,11 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 产品横跨三仓,依赖方向固定:`objectstack`(后端;`packages/spec` 是唯一契约)→ `objectui`(前端,构
 建产物经 `pnpm objectui:refresh` 回流)与 `cloud`。
 
-1. **Issue 住在修复落地的仓**(维护者 2026-08-10 裁决)。两个例外:**维护者收件箱恒
-   为 objectstack**(分诊时转仓路由;transfer 不可用时重建:出处头 + 裸 `#N` 改全名 + 关源单
-   为 moved);**缝卡留在 objectstack** 带 `repo:objectui` / `repo:cloud` —— 判据:正文抽
-   掉 objectstack 还成立就 file-at-destination,不成立才是缝卡。在飞卡 ⛔ 不中途转仓。
+1. **Issue 住在修复落地的仓,分诊时按判据严格执行**(维护者 2026-08-10 裁决;2026-08-16 重申收紧)。判
+   据:正文抽掉 objectstack 还成立 ⇒ file-at-destination,分诊当场转仓 —— console/UI 缺陷即转 objectui
+   (transfer 不可用时重建:出处头 + 裸 `#N` 改全名 + 关源单为 moved);不成立才是缝卡。**缝卡收窄到真
+   协调卡**,留在 objectstack 带 `repo:objectui` / `repo:cloud`,且**正文必须具名读者**(哪个座位、哪一
+   步读它 —— 只有标签没有具名读者的队列没人扫);维护者收件箱恒为 objectstack。在飞卡 ⛔ 不中途转仓。
 2. **Contract-first 拆分。** 跨仓 feature 永不是一次派发:父单 + 每仓一 sub-issue, spec/后端
    先行,下游带 `Blocked-by: <owner/repo>#<n>`;凡 `Blocked-by` 未关闭/未合并的不派发(
    对 GitHub 现验);被链接或同父的两单永不同批。**Pin 滞后是它的盲区**:本仓 pin 是否已覆盖那
@@ -160,8 +164,7 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
    直派通道** (2026-08-10 常设授权):维护者当面指挥的 PM 会话直接路由,审计评论逐字引用授权指
    令,只对明示指挥的卡成立。分诊空缺时会话型执行 PM 可**代扫**(只做分诊动作,不跨车道认领,座
    位贴注明),座位有主立即停止 —— 两个分类生产者并存,单一生产者的保障当场归零。
-5. **One board, no second tracker。** pm 标签就是状态机;org Project 只是维护者的聚合视图,权
-   威层坚持 issue 正文 + REST。
+5. **One board, no second tracker。** pm 标签就是状态机;org Project 只是维护者的聚合视图,权威层坚持 issue 正文 + REST。
 
 **跨座位转移**:工作跨座位线,PM 永不跨(唯一豁免:简单阻塞项直接接手,见「候选与批次」)—— 落到
 对方队列(目标仓立单带 `pm:queue` +出处行),依赖走 `Blocked-by:`;后续杂事由消费侧座位立;凡触
@@ -189,9 +192,8 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 | `domain:cli` | `packages/cli`、`runtime`、`verify`、`qa`、`types`、`packages/rest`、`packages/mcp`、`packages/observability`、`packages/client*`、`cloud-connection`、`create-objectstack`、`packages/adapters/*`、`plugin-hono-server`、`plugin-dev` |
 | (无固定归属,按落点分诊) | `packages/apps/*`、`packages/console`(dist 由脚本生成 ⛔ 手改;UI 缺陷走 `repo:objectui`,pin/刷新脚本归 `scripts/` 行)、`examples/*`(归它演练的子系统) |
 
-表未覆盖的包在首次分诊时归类并**走 PR 更新本表**;**新增或退役一个 `domain:*` 必须同批改本表
-**(在流通而不在表 = 无主车道)。座位在编情况以 `label:pm:seat` 索引为准,每
-个 `domain:*` 与 `repo:*` 恰一张座位贴。
+表未覆盖的包在首次分诊时归类并**走 PR 更新本表**;**新增或退役一个 `domain:*` 必须同批改本表**(在流
+通而不在表 = 无主车道)。座位在编情况以 `label:pm:seat` 索引为准,每个 `domain:*` 与 `repo:*` 恰一张座位贴。
 
 **spec 席内分派参考**(维护者 2026-08-16 裁定合并车道:原 `domain:spec-surface` / `domain:spec-tooling` 标签已退役,
 三面同归 `domain:spec` 一席,anchoring rule 双射恢复;以下判据降为席内分派与定价依据):语义/文本按
@@ -277,7 +279,7 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 常就是根因,并在派发前改变卡的范围与域标签。
 
 **发现分诊轮(队列的出水口)。** `finding` 恒 = 待首次定级、定级即离标(维护者 2026-08-13 意见;换标
-与 hold 评论纪律见 State model,hold 重验只在具名重启条件命中时发生,⛔ 不设逐卡豁免评论)。**首触定
+与 hold 评论纪律见 State model,hold 重验只在 `Restart-when:` 命中时发生,⛔ 不设逐卡豁免评论)。**首触定
 级每轮跑**:预算 3–5 张、优先于一切旧卡重验,先过时前提检查再三选一 —— 晋级 / 关闭 not planned(维
 护者可否决重开,PM 不等批准)/ hold;**判级发生在这里,不在立单时**。车道座位可附证据/前提重验,⛔
 不定级不改标(唯一例外:skills 车道 finding 由该席自分诊,全仓轮跳过)。**自动集中轮**(常设授权,维
@@ -418,12 +420,11 @@ sonnet/opus;机器面默认 opus,门禁语义设计时升 fable;下游适配卡�
 - **Premise-first 写明**:issue 正文是线索不是规格;`premise_still_valid: false` +无 PR 是合法
   且常常有价值的交付 —— 派发词预设 issue 为真,就把好运行变成表面抗命。
 
-**资源与后端(维护者 2026-08-12 裁定:中级卡改子 agent、模型由 PM 按难度逐卡指定;覆盖
-2026-08-10 的「M 及以上默认云卡」)。** S 级机械 + M ⇒ `mode:subagent`(PM 容器内并行,档位按
-Model tiering 显式传参);S 级但不机械(判断面在设计不在门禁)按 M 待遇。`mode:cloud` 只保留给
-:L/XL、必须活过 PM 会话的工作、浏览器/dogfood 验证、逐卡判断的 build 重 M 卡(论证
-见 `references/dispatch-runbook.md`)。**归档义务只落在云卡**;OOM 死的单独重派;判定连同档位写
-进认领评论。
+**资源与后端(维护者 2026-08-12 裁定:中级卡改子 agent、模型由 PM 按难度逐卡指定;覆盖 2026-08-10 的
+「M 及以上默认云卡」)。** S 级机械 + M ⇒ `mode:subagent`(PM 容器内并行,档位按 Model tiering 显式传
+参);S 级但不机械(判断面在设计不在门禁)按 M 待遇。`mode:cloud` 只保留给:L/XL、必须活过 PM 会话的工
+作、浏览器/dogfood 验证、逐卡判断的 build 重 M 卡(论证见 `references/dispatch-runbook.md`)。**归档义
+务只落在云卡**;OOM 死的单独重派;判定连同档位写进认领评论。
 
 **云卡四课**(细则见 `references/dispatch-runbook.md`;一次性云卡用 `create_session`,⛔ 不用
 create_trigger+fire —— 维护者 2026-08-07 拍板,trigger 流只留给定时/重复型):① 授权面随
@@ -483,9 +484,8 @@ You are the reviewer of record —— **对 GitHub 核验,不对报告的自述�
 - **删除与二进制**:死代码删除在 `origin/main` 亲核引用面再 ACCEPT;`+0/-0` 先疑NUL。sweep 类
   交付的范围外产出在 ACCEPT 评论成组列出。
 
-**判决**:**ACCEPT**(issue 英文评论链接 PR 总结)→ 驱动落地;**REWORK**(逐项反馈,同认领重派;补
-丁轮优先 SendMessage 续派原 dev —— 上下文保留省掉全部重验;最多2 轮,第三次升级);**ESCALATE**(
-见「升级与决策」)。
+**判决**:**ACCEPT**(issue 英文评论链接 PR 总结)→ 驱动落地;**REWORK**(逐项反馈,同认领重派;补丁轮
+优先 SendMessage 续派原 dev —— 上下文保留省掉全部重验;最多2 轮,第三次升级);**ESCALATE**(见「升级与决策」)。
 
 **ACCEPT 之后的路径分叉(动手之前先分,不是事后对照)。** 翻 ready / 挂 auto-merge / 入队前,先
 取一次 PR 的路径面(`get_files`,⛔ 不看报告自述)。路径面**一条命中** `docs/adr/**`、
@@ -534,8 +534,8 @@ You are the reviewer of record —— **对 GitHub 核验,不对报告的自述�
 
 停:队列空或 `rounds` 用尽(**仅一次性调用适用**);一轮 ≥ 半数派发失败或升级(系统性问题,继续
 烧 backlog 是浪费);维护者打断。**常设座位队列清空 ≠ 退场**,是切换待命姿态:巡检放宽 60–70 分
-钟(有在飞收紧回 ≤45),待命五项 —— findings 配合(附证据/前提重验,⛔ 不定级不改标)、`pm:blocked` 解锁扫描(含回
-队前 ref 重验与扇出索引更新)、在飞/已入队 PR 跟到 MERGED、决策箱仅在报告中列出 ⛔ 不 nag、跨
+钟(有在飞收紧回 ≤45),待命五项 —— findings 配合(附证据/前提重验,⛔ 不定级不改标)、`pm:blocked`/`pm:on-hold` 解锁扫描(含回
+队前 ref 重验与扇出索引更新;hold 侧读 `Restart-when:`)、在飞/已入队 PR 跟到 MERGED、决策箱仅在报告中列出 ⛔ 不 nag、跨
 车道备忘跟进。退场只有两个入口:维护者交接令(走交接收尾清单),或被惰性回收。
 
 ## 队列管家职责

--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -80,6 +80,25 @@
  *       accelerator, never an exhaustive audit: a delivery older than the
  *       window is invisible, and the finding clears when the paired write
  *       lands, not when the PR ages out.
+ *   H9  `pm:on-hold` without a machine-fireable `Restart-when:` body line —
+ *       the state model (post 2026-08-16 ruling) makes the hold state legal
+ *       ONLY with a machine-readable exit: `Restart-when: closed <owner/repo>#N`
+ *       (fired by the same unlock scan as `Blocked-by:`, same single body
+ *       channel) or a one-line executable predicate. A hold nothing can fire
+ *       is indistinguishable from an abandoned card. `Restart-when: manual — …`
+ *       counts as MISSING, deliberately: the protocol says a card no mechanism
+ *       can revive is closed `not planned` (reason + provenance in the closing
+ *       comment), so accepting a `manual` line here would hand every seat a
+ *       one-word spelling that defeats the invariant this item enforces.
+ *   H10 `priority:p0`, open, unassigned, and no activity past the threshold —
+ *       p0 is queue-jump priority (dispatched immediately, past batch and
+ *       round boundaries), so an unclaimed p0 holding still for longer than
+ *       any legal round latency almost always means NO seat's scan scope
+ *       covers the queue it sits in (the measured specimen: a correctly
+ *       triaged p0 that sat ~36h because the label queue it was routed to had
+ *       no named reader). Staleness is read from `updated_at` — an
+ *       unparseable timestamp reports as a finding, never as fresh (#4690:
+ *       "could not read the input" must not look like "input is clean").
  *
  * ## The close mechanism, measured (#8293)
  *
@@ -464,6 +483,80 @@ export function h8MergedPrStillDispatched(issue, mergedPrs) {
 }
 
 // ---------------------------------------------------------------------------
+// H9 — `pm:on-hold` without a machine-fireable `Restart-when:` body line.
+//
+// Same shape as H4 (label's machine half is a body line), same single body
+// channel: the unlock scan greps issue bodies only, so a condition parked in a
+// comment does not exist to the machinery — which is exactly the population
+// this detector exists to surface.
+// ---------------------------------------------------------------------------
+
+/**
+ * H9 — null when clean, else the finding sentence.
+ *
+ * Legal iff SOME `Restart-when:` line carries a value that is not `manual…`.
+ * The spelling is case-sensitive and byte-stable like `Blocked-by:` (H4): the
+ * scan that fires these lines greps the literal, so a lowercase variant is a
+ * line the machinery cannot see and must be flagged, not tolerated.
+ */
+export function h9OnHoldNoRestartWhen(issue) {
+  if (!labelNames(issue).includes('pm:on-hold')) return null;
+  const values = [...(issue.body ?? '').matchAll(/^\s*Restart-when:[ \t]*(\S.*)$/gm)].map((m) =>
+    m[1].trim(),
+  );
+  if (values.some((v) => !/^manual\b/i.test(v))) return null;
+  const shape =
+    values.length === 0
+      ? 'no `Restart-when:` body line'
+      : 'its only `Restart-when:` is `manual`, which no mechanism can fire';
+  return (
+    `\`pm:on-hold\` with ${shape} — the hold state is legal only with a machine-fireable exit ` +
+    `(\`Restart-when: closed <owner/repo>#N\`, or a one-line executable predicate). Add the line, ` +
+    `or apply the protocol's default: a card no mechanism can revive is closed \`not planned\` ` +
+    `with reason + provenance in the closing comment (type:Bug holds re-route instead — see the ` +
+    `state model's Bug branch).`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// H10 — stale unclaimed p0 (routing-gap backstop).
+// ---------------------------------------------------------------------------
+
+/**
+ * H10 threshold — p0 protocol latency is measured in minutes-to-hours (queue
+ * jump, dispatch past batch limits), so 24h of silence while unclaimed exceeds
+ * any legal round latency severalfold while still tolerating weekend lulls;
+ * the measured no-reader specimen sat ~36h and would have been caught a day
+ * earlier.
+ */
+export const P0_UNCLAIMED_STALE_HOURS = 24;
+
+/**
+ * H10 — null when clean, else the finding sentence.
+ *
+ * Deliberately the bare conjunction the protocol names (p0 + open + unassigned
+ * + stale): no carve-out for decision/blocked/hold states, because a p0 aging
+ * in ANY box is exactly what the triage brief should be showing the maintainer
+ * — the flag is report-only and p0 volume is tiny by construction.
+ */
+export function h10StaleUnclaimedP0(issue, nowMs = Date.now()) {
+  if (!labelNames(issue).includes('priority:p0')) return null;
+  if ((issue.assignees ?? []).length > 0) return null;
+  const updated = Date.parse(issue.updated_at ?? '');
+  const ageHours = Number.isFinite(updated) ? (nowMs - updated) / 3_600_000 : null;
+  if (ageHours !== null && ageHours <= P0_UNCLAIMED_STALE_HOURS) return null;
+  const reading =
+    ageHours === null
+      ? 'its `updated_at` is unreadable (an unreadable timestamp must not read as fresh)'
+      : `no activity for ~${Math.round(ageHours)}h (threshold ${P0_UNCLAIMED_STALE_HOURS}h)`;
+  return (
+    `\`priority:p0\`, open and unassigned, with ${reading} — p0 is queue-jump priority, so a ` +
+    `stale unclaimed one usually means no seat's declared scan scope covers the queue it sits ` +
+    `in. Put it in the triage round brief / decision box and name its reader.`
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Transport prerequisite — the classifier (pure) and the probe that feeds it.
 //
 // Modelled on `scripts/cli-build-prerequisite.mjs`: the knowledge lives in pure
@@ -759,7 +852,7 @@ function reportPrerequisiteNotMet(v, options = {}) {
   const nothing =
     swept === 0
       ? [
-          `  Nothing was swept: no issue was listed and no predicate (H1–H6) ran, so this`,
+          `  Nothing was swept: no issue was listed and no predicate (H1–H10) ran, so this`,
           `  result says NOTHING about whether the board carries half-states. It is not a`,
           `  clean board and it is not a dirty one — it is no reading at all.`,
         ]
@@ -838,7 +931,7 @@ async function sweep() {
     console.log(`  ${code} #${issue.number} ${msg}\n     ${issue.html_url}`);
   }
   console.log(
-    `check-half-states: swept ${seen.size} open pm-labeled issue(s), ${seenPrs.size} open PR(s) ` +
+    `check-half-states: swept ${seen.size} open pm-/p0-labeled issue(s), ${seenPrs.size} open PR(s) ` +
       `and ${seenMerged.size} recently-merged PR(s) in ${OWNER_REPO} — ${findings.length} half-state(s) found. ` +
       `Report-only: findings are patrol input, not a gate verdict.`,
   );
@@ -875,7 +968,7 @@ async function listRecentlyMergedPullRequests() {
 }
 
 async function sweepInto(findings, seen, seenPrs, seenMerged) {
-  for (const label of ['pm:dispatched', 'pm:queue', 'pm:blocked', 'pm:seat']) {
+  for (const label of ['pm:dispatched', 'pm:queue', 'pm:blocked', 'pm:seat', 'pm:on-hold', 'priority:p0']) {
     for (const issue of await listIssues(label)) seen.set(issue.number, issue);
   }
 
@@ -890,6 +983,10 @@ async function sweepInto(findings, seen, seenPrs, seenMerged) {
     if (h4BlockedNoBlockedBy(issue)) {
       findings.push([issue, 'H4', '`pm:blocked` without a `Blocked-by:` body line']);
     }
+    const restartless = h9OnHoldNoRestartWhen(issue);
+    if (restartless) findings.push([issue, 'H9', restartless]);
+    const staleP0 = h10StaleUnclaimedP0(issue);
+    if (staleP0) findings.push([issue, 'H10', staleP0]);
     if (labels.includes('pm:seat')) {
       const desync = h5SeatStickerDesync(issue);
       if (desync) findings.push([issue, 'H5', desync]);
@@ -897,11 +994,13 @@ async function sweepInto(findings, seen, seenPrs, seenMerged) {
         const kb = (Buffer.byteLength(issue.body ?? '', 'utf8') / 1024).toFixed(1);
         findings.push([issue, 'H6', `seat body is ${kb} KB (soft bound ~10 KB) — compact to the six-section current-state template (#7583; edit history is the archive)`]);
       }
-    } else if ((issue.assignees ?? []).length > 0 && labels.some((l) => l.startsWith('pm:'))) {
-      // H2 needs the comment thread — fetched only for candidates, and only
-      // their first pages: a claim comment is posted at claim time, so on a
-      // healthy card it is early in the thread; a >100-comment card with a
-      // late claim shows up as a finding the patrol then reads by hand.
+    } else if ((issue.assignees ?? []).length > 0 && labels.some((l) => l === 'pm:queue' || l === 'pm:dispatched')) {
+      // H2 needs the comment thread — fetched only for candidates (exactly the
+      // pm-tracked set h2 judges; the on-hold/p0 listings above must not buy
+      // comment fetches h2 would discard), and only their first pages: a claim
+      // comment is posted at claim time, so on a healthy card it is early in
+      // the thread; a >100-comment card with a late claim shows up as a
+      // finding the patrol then reads by hand.
       const comments = await rest(`/repos/${OWNER_REPO}/issues/${issue.number}/comments?per_page=100`);
       if (h2AssigneeNoClaimComment(issue, comments.map((c) => c.body))) {
         findings.push([issue, 'H2', 'assignee set but no claim comment on the thread']);
@@ -1157,6 +1256,47 @@ function selfTest() {
   );
   t('H8: empty merged window -> clean', h8MergedPrStillDispatched(dispatched(4321), []), null);
   t('H8: missing merged window -> clean', h8MergedPrStillDispatched(dispatched(4321), undefined), null);
+
+  // -- H9: `pm:on-hold` without a machine-fireable `Restart-when:` ------------
+  const hold = (body) => issue(['pm:on-hold'], [], body);
+  t('H9: hold with no Restart-when line -> finding', typeof h9OnHoldNoRestartWhen(hold('parked until the train ships')), 'string');
+  t('H9: …and the finding prescribes the close default', h9OnHoldNoRestartWhen(hold('parked')).includes('not planned'), true);
+  t('H9: closed-upstream form -> clean', h9OnHoldNoRestartWhen(hold('Restart-when: closed acme/widgets#123')), null);
+  t('H9: executable-predicate form -> clean', h9OnHoldNoRestartWhen(hold('Restart-when: npm view create-objectstack dist-tags reports >= 17.0.0')), null);
+  t('H9: mid-body line -> clean', h9OnHoldNoRestartWhen(hold('Context first.\nRestart-when: closed acme/widgets#123\nMore prose.')), null);
+  // `manual` is a hold trying to opt out of having an exit — it counts as
+  // missing, or the one-word spelling defeats the invariant.
+  t('H9: manual form -> finding', typeof h9OnHoldNoRestartWhen(hold('Restart-when: manual — first EE customer asking')), 'string');
+  t('H9: …and the finding names the manual shape', h9OnHoldNoRestartWhen(hold('Restart-when: manual — reason')).includes('manual'), true);
+  t('H9: Manual case-insensitive as a VALUE -> finding', typeof h9OnHoldNoRestartWhen(hold('Restart-when: Manual — reason')), 'string');
+  t('H9: manual line + fireable line -> clean', h9OnHoldNoRestartWhen(hold('Restart-when: manual — x\nRestart-when: closed acme/widgets#9')), null);
+  // The KEY is byte-stable like `Blocked-by:` — a lowercase key is a line the
+  // unlock scan cannot see, so it must flag, not pass.
+  t('H9: lowercase key is invisible to the scan -> finding', typeof h9OnHoldNoRestartWhen(hold('restart-when: closed acme/widgets#123')), 'string');
+  t('H9: empty-valued line does not count', typeof h9OnHoldNoRestartWhen(hold('Restart-when:')), 'string');
+  t('H9: prose mentioning the literal inline does not count', typeof h9OnHoldNoRestartWhen(hold('add a Restart-when: line later')), 'string');
+  t('H9: card without pm:on-hold is out of scope', h9OnHoldNoRestartWhen(issue(['pm:queue'], [], 'no line at all')), null);
+  t('H9: missing body -> finding', typeof h9OnHoldNoRestartWhen(issue(['pm:on-hold'], [], undefined)), 'string');
+
+  // -- H10: stale unclaimed p0 (routing-gap backstop) -------------------------
+  const NOW = Date.parse('2026-08-16T12:00:00Z');
+  const hoursAgo = (h) => new Date(NOW - h * 3_600_000).toISOString();
+  const p0 = (assignees, updatedAt, extra = []) => ({
+    ...issue(['priority:p0', ...extra], assignees),
+    updated_at: updatedAt,
+  });
+  t('H10: unassigned p0 past the threshold -> finding', typeof h10StaleUnclaimedP0(p0([], hoursAgo(36), ['pm:queue']), NOW), 'string');
+  t('H10: …and the finding names the threshold', h10StaleUnclaimedP0(p0([], hoursAgo(36)), NOW).includes(`${P0_UNCLAIMED_STALE_HOURS}h`), true);
+  t('H10: fresh unassigned p0 -> clean', h10StaleUnclaimedP0(p0([], hoursAgo(1)), NOW), null);
+  t('H10: exactly at the threshold -> clean (strictly beyond fires)', h10StaleUnclaimedP0(p0([], hoursAgo(P0_UNCLAIMED_STALE_HOURS)), NOW), null);
+  t('H10: assigned p0 is out of scope however old', h10StaleUnclaimedP0(p0(['os-help'], hoursAgo(200)), NOW), null);
+  t('H10: non-p0 card is out of scope', h10StaleUnclaimedP0({ ...issue(['pm:queue']), updated_at: hoursAgo(200) }, NOW), null);
+  // #4690 in miniature: an unreadable timestamp must not read as fresh.
+  t('H10: unparseable updated_at -> finding, not fresh', typeof h10StaleUnclaimedP0(p0([], 'not-a-date'), NOW), 'string');
+  t('H10: absent updated_at -> finding, not fresh', typeof h10StaleUnclaimedP0(p0([], undefined), NOW), 'string');
+  // The bare conjunction, no state carve-outs: a p0 aging in the decision box
+  // is exactly what the brief should show (report-only, tiny population).
+  t('H10: p0 aging under needs-user-decision still flags', typeof h10StaleUnclaimedP0(p0([], hoursAgo(48), ['needs-user-decision']), NOW), 'string');
 
   // -- transport prerequisite (#7412) ---------------------------------------
   // The three container classes are REAL measurements, not invented fixtures;

--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -99,6 +99,16 @@
  *       no named reader). Staleness is read from `updated_at` — an
  *       unparseable timestamp reports as a finding, never as fresh (#4690:
  *       "could not read the input" must not look like "input is clean").
+ *   H11 the important-parked inventory — a card carrying an importance signal
+ *       (native type `Bug`, or a `bug` / `security` / `priority:*` label)
+ *       sitting in `pm:blocked` or `pm:on-hold` and open past the threshold.
+ *       Maintainer concern, 2026-08-16, verbatim: 「我担心的优先的，重要的问
+ *       题，比如bug 被放进 blocked 或者 on-hold 没人理会」. Distinct from H10
+ *       (p0 + UNASSIGNED regardless of state): H11 is the broader
+ *       importance × parked-state cross, so every triage fire prints the
+ *       inventory of important cards that a parked state could otherwise
+ *       hide indefinitely. Report-only like everything here — the remedy is
+ *       the triage round re-checking the card's exit liveness, not a gate.
  *
  * ## The close mechanism, measured (#8293)
  *
@@ -557,6 +567,56 @@ export function h10StaleUnclaimedP0(issue, nowMs = Date.now()) {
 }
 
 // ---------------------------------------------------------------------------
+// H11 — the important-parked inventory (maintainer concern, 2026-08-16).
+// ---------------------------------------------------------------------------
+
+/**
+ * H11 threshold — importance signals parked in `pm:blocked`/`pm:on-hold` are
+ * exactly the cards the maintainer fears go unwatched; 7 days is one full
+ * triage week — long enough that a legitimate short park has cleared, short
+ * enough that a real defect cannot age a release cycle out of sight.
+ */
+export const IMPORTANT_PARKED_STALE_DAYS = 7;
+
+/**
+ * H11 — null when clean, else the finding sentence.
+ *
+ * Importance is read from BOTH the native issue type (`Bug`, object or string
+ * shape — REST serializes it as an object) and the label vocabulary
+ * (`bug` / `security` / any `priority:*`), because the triage protocol only
+ * types new cards and deliberately does not backfill the stock — a label-only
+ * reading would hide exactly the older cards most at risk of being forgotten.
+ * Age is `created_at` ("open longer than", per the card); an unreadable
+ * timestamp flags rather than reading as fresh (#4690 direction, same as H10).
+ */
+export function h11ImportantParked(issue, nowMs = Date.now()) {
+  const labels = labelNames(issue);
+  const parked = labels.includes('pm:blocked') || labels.includes('pm:on-hold');
+  if (!parked) return null;
+  const typeName = typeof issue.type === 'string' ? issue.type : issue.type?.name;
+  const signals = [];
+  if (typeName === 'Bug') signals.push('type:Bug');
+  for (const l of labels) {
+    if (l === 'bug' || l === 'security' || l.startsWith('priority:')) signals.push(l);
+  }
+  if (signals.length === 0) return null;
+  const created = Date.parse(issue.created_at ?? '');
+  const ageDays = Number.isFinite(created) ? (nowMs - created) / 86_400_000 : null;
+  if (ageDays !== null && ageDays <= IMPORTANT_PARKED_STALE_DAYS) return null;
+  const state = labels.includes('pm:blocked') ? 'pm:blocked' : 'pm:on-hold';
+  const age =
+    ageDays === null
+      ? 'an unreadable `created_at` (which must not read as fresh)'
+      : `open ~${Math.round(ageDays)}d`;
+  return (
+    `important card parked: ${signals.join(' + ')} sitting in \`${state}\`, ${age} ` +
+    `(threshold ${IMPORTANT_PARKED_STALE_DAYS}d) — the important-parked inventory exists so a bug ` +
+    `or security card cannot age out of sight inside a parked state. Re-check the card's ` +
+    `\`Blocked-by:\` / \`Restart-when:\` liveness in the triage round.`
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Transport prerequisite — the classifier (pure) and the probe that feeds it.
 //
 // Modelled on `scripts/cli-build-prerequisite.mjs`: the knowledge lives in pure
@@ -852,7 +912,7 @@ function reportPrerequisiteNotMet(v, options = {}) {
   const nothing =
     swept === 0
       ? [
-          `  Nothing was swept: no issue was listed and no predicate (H1–H10) ran, so this`,
+          `  Nothing was swept: no issue was listed and no predicate (H1–H11) ran, so this`,
           `  result says NOTHING about whether the board carries half-states. It is not a`,
           `  clean board and it is not a dirty one — it is no reading at all.`,
         ]
@@ -987,6 +1047,8 @@ async function sweepInto(findings, seen, seenPrs, seenMerged) {
     if (restartless) findings.push([issue, 'H9', restartless]);
     const staleP0 = h10StaleUnclaimedP0(issue);
     if (staleP0) findings.push([issue, 'H10', staleP0]);
+    const parked = h11ImportantParked(issue);
+    if (parked) findings.push([issue, 'H11', parked]);
     if (labels.includes('pm:seat')) {
       const desync = h5SeatStickerDesync(issue);
       if (desync) findings.push([issue, 'H5', desync]);
@@ -1297,6 +1359,31 @@ function selfTest() {
   // The bare conjunction, no state carve-outs: a p0 aging in the decision box
   // is exactly what the brief should show (report-only, tiny population).
   t('H10: p0 aging under needs-user-decision still flags', typeof h10StaleUnclaimedP0(p0([], hoursAgo(48), ['needs-user-decision']), NOW), 'string');
+
+  // -- H11: important-parked inventory (2026-08-16 maintainer concern) --------
+  const daysAgo = (d) => new Date(NOW - d * 86_400_000).toISOString();
+  const parkedCard = (labels, { assignees = [], type, created = daysAgo(10) } = {}) => ({
+    ...issue(labels, assignees),
+    type,
+    created_at: created,
+  });
+  t('H11: type Bug + on-hold past threshold -> finding', typeof h11ImportantParked(parkedCard(['pm:on-hold'], { type: { name: 'Bug' } }), NOW), 'string');
+  t('H11: type as plain string is read too', typeof h11ImportantParked(parkedCard(['pm:on-hold'], { type: 'Bug' }), NOW), 'string');
+  t('H11: bug label + blocked -> finding', typeof h11ImportantParked(parkedCard(['bug', 'pm:blocked']), NOW), 'string');
+  t('H11: security label + on-hold -> finding', typeof h11ImportantParked(parkedCard(['security', 'pm:on-hold']), NOW), 'string');
+  t('H11: priority:p1 + blocked -> finding', typeof h11ImportantParked(parkedCard(['priority:p1', 'pm:blocked']), NOW), 'string');
+  t('H11: …and the finding names the parked state', h11ImportantParked(parkedCard(['bug', 'pm:blocked']), NOW).includes('pm:blocked'), true);
+  t('H11: …and the threshold', h11ImportantParked(parkedCard(['bug', 'pm:blocked']), NOW).includes(`${IMPORTANT_PARKED_STALE_DAYS}d`), true);
+  t('H11: fresh park is clean', h11ImportantParked(parkedCard(['bug', 'pm:on-hold'], { created: daysAgo(2) }), NOW), null);
+  t('H11: exactly at the threshold is clean (strictly beyond fires)', h11ImportantParked(parkedCard(['bug', 'pm:on-hold'], { created: daysAgo(IMPORTANT_PARKED_STALE_DAYS) }), NOW), null);
+  t('H11: important but not parked is out of scope', h11ImportantParked(parkedCard(['bug', 'pm:queue']), NOW), null);
+  t('H11: parked but unimportant is out of scope', h11ImportantParked(parkedCard(['pm:on-hold'], { type: { name: 'Task' } }), NOW), null);
+  // Distinct from H10: an ASSIGNED old parked p0 is out of H10's scope
+  // (assignee set) but squarely in H11's — the cross is the point.
+  t('H11: assigned parked p0 still flags (H10 would not)', typeof h11ImportantParked(parkedCard(['priority:p0', 'pm:blocked'], { assignees: ['os-help'] }), NOW), 'string');
+  t('H11: …and that same card is H10-clean', h10StaleUnclaimedP0({ ...parkedCard(['priority:p0', 'pm:blocked'], { assignees: ['os-help'] }), updated_at: daysAgo(10) }, NOW), null);
+  // #4690 direction, same as H10: unreadable age must not read as fresh.
+  t('H11: unreadable created_at -> finding, not fresh', typeof h11ImportantParked(parkedCard(['bug', 'pm:on-hold'], { created: 'not-a-date' }), NOW), 'string');
 
   // -- transport prerequisite (#7412) ---------------------------------------
   // The three container classes are REAL measurements, not invented fixtures;


### PR DESCRIPTION
Fixes #9043
Fixes #9063

Two-card bundle (anchor + member, overlapping file surface — one PR per the bundle claim on the anchor). **ADR-class: skills update — human merge only.** Per the maintainer's 2026-08-11 ruling (「所有 skills 的更新和adr 类似,需要人工审核」) this PR must not be merged, queued, or auto-merged by any AI seat.

## Maintainer rulings implemented (2026-08-16, verbatim, untranslated)

> 我建议有些暂时不准备开发的应该直接关闭。

> 用 B

> 确认，先处理 objectstack

## `.claude/skills/pm-dispatch/SKILL.md`

1. **`pm:on-hold` 定位收窄** (state-model row + label-discipline bullet): the state is legal ONLY with a machine-readable body line — `Restart-when: closed &lt;owner/repo&gt;#N` (fired by the same unlock scan as `Blocked-by:`, same single body channel) or a one-line executable predicate. `manual — &lt;reason&gt;` is NOT a legal exit: a card no mechanism can revive is closed `not planned` with reason + provenance in the closing comment (card is the record, reopen is free, maintainer veto preserved). The first ruling above is quoted verbatim in the protocol text.
2. **Bug branch** (in the same clause): the close-default does NOT apply to `type:Bug` holds — reproducible and user-reachable goes back to `pm:queue` (Bug priority only acts on queued cards; a held bug is a hidden bug); declared-vs-enforced observation-class routes to the enforce-or-remove program; genuine won't-fix candidates go per-card to the maintainer's decision box — seats never close a real defect on their own authority.
3. **多仓协调 #1 tightening (「用 B」)**: file-at-destination enforced strictly by the existing criterion — console/UI defects transfer to objectui at triage time (the transfer-unavailable rebuild recipe stays cited); the seam-card category shrinks to genuine coordination cards, which must name their reader in the card body. The 2026-08-10 file-at-destination ruling stays cited — this is enforcement, not new law.
4. Standby unlock scan extended to `pm:on-hold` (reads `Restart-when:`); the finding-round hold re-verify is keyed to `Restart-when:` hits. This builds on the trap-rows bundle PR's single-body-channel restoration (`Blocked-by:` body-only reads); that PR is open awaiting human merge — measured, noted below.
5. **Predicate-form cadence (patch round, maintainer question)**: executable-predicate `Restart-when:` lines are batch-executed once daily by the triage Routine's unlock scan as a low-frequency sub-round (hourly execution of a dozen one-line predicates is waste; daily is the digestion cadence); a firing predicate gets the same re-verify-then-requeue treatment as a closed-#N hit. Ceiling still 686 — +2 lines funded by two further pure rewraps.

**Ratchet accounting — ceiling 686 held, no raise.** Net +5 lines of new protocol text (hold bullet 4 to 8, seam rule 4 to 5) funded by -5 lines of pure rewraps with zero semantic loss (intro principles paragraph 5 to 4, domain-table footer 3 to 2, 多仓协调 #5 2 to 1, 资源与后端 6 to 5, 判决 3 to 2 — line-break moves only, every ruling quote byte-identical).

## `scripts/pm/check-half-states.mjs` (report-only, following the H-detector conventions)

- **H9** — `pm:on-hold` without a machine-fireable `Restart-when:` body line. `Restart-when: manual — …` counts as missing by design (accepting it would hand every seat a one-word spelling that defeats the invariant); a line whose value is fireable clears the card even when a manual line coexists. The key is byte-stable/case-sensitive like `Blocked-by:` (a lowercase key is a line the unlock scan cannot see, so it flags). Finding text prescribes the close default and names the Bug-branch exception.
- **H10** — `priority:p0` + open + unassigned + no activity beyond `P0_UNCLAIMED_STALE_HOURS` (named constant, 24, one-line rationale at the declaration: p0 latency is minutes-to-hours by protocol, 24h exceeds any legal round latency while tolerating weekend lulls; the measured no-reader specimen sat ~36h). Deliberately the bare conjunction the card names — no carve-outs for decision/blocked/hold states (a p0 aging in any box belongs in the triage brief; report-only, tiny population). An unparseable `updated_at` flags rather than reading as fresh (#4690 direction).
- **H11** (patch round; maintainer concern, verbatim: 「我担心的优先的，重要的问题，比如bug 被放进 blocked 或者 on-hold 没人理会」) — the important-parked inventory: a card carrying an importance signal (native type `Bug`, or a `bug` / `security` / `priority:*` label) sitting in `pm:blocked` or `pm:on-hold`, open past `IMPORTANT_PARKED_STALE_DAYS` (7 — one triage week; rationale at the constant). Distinct from H10 (p0 + unassigned regardless of state): H11 is the broader importance × parked-state cross, and the self-test pins an assigned parked p0 as H11-flagged but H10-clean. Importance reads the type AND the labels (the stock is deliberately not type-backfilled); unreadable `created_at` flags rather than reads fresh.
- Sweep wiring: `pm:on-hold` and `priority:p0` added to the label listings; the sweep summary line renamed accordingly; the stale "(H1–H6)" range in the prerequisite report corrected to H1–H11 (bounded in-place fix: same file, same stale-range defect class, mechanical). H2's comment-fetch candidate filter narrowed from `pm:*`-prefix to the exact `pm:queue`/`pm:dispatched` set `h2` judges — behavior-preserving (h2 returned `false` for the others anyway); without it the new on-hold listing would buy ~85 discarded comment fetches per sweep.
- Self-tests: +36 cases (H9 x13, H10 x9, H11 x14), 128 total, all passing.

## Verification-step audit (member card; listing only — transfers are post-merge triage bookkeeping)

**Dead-letter labels (open stock, no declared reader in any seat post's 范围 line):**
- `repo:objectui` on objectstack — 10 open. The objectui seat's scope reads, in full, 「objectui 全仓队列」; nothing names this queue. This is the measured incident class; resolved by the transfer rule above.
- `repo:cloud` on objectstack — 2 open. Same gap (cloud seat: 「cloud 全仓队列」).
- All nine `domain:*` labels have live seated readers (skills, metadata, cli, devx, identity, services, drivers, engine-core, spec incl. the merged surface/tooling satellites). objectui and cloud repos carry NO `domain:*`/`repo:*` labels at all — no dead-letter stock there.

**Seam stock re-classified under the tightened criterion** (does the body still stand with objectstack removed?):
- Transfer candidates (console/UI or sibling-repo defect; coordination expressible as `Blocked-by:`): objectstack#8815 (the filterBuilder p0 — the measured specimen), #8669, #8018, #7973, #7494, #7366, #7345; cloud-bound: #8573, #7251.
- Genuine coordination cards (stay, must name their reader in the body per the new rule): #8668 (epic tracking card spanning both repos), #7250 (paired retirement half with cross-repo `Blocked-by:` structure), #6275 (parity-tripwire companion to a spec retirement; also currently a `Restart-when:`-less hold H9 will flag).

## Measured note on a dispatch assumption

The dispatch order stated the unlock scan was "just re-anchored by the trap-rows PR to body-only reads" as landed text. Measured at my fetched head (`6a99ead9b`): the trap-rows bundle (branch `claude/issue-8942-trap-rows-bundle`) is pushed and its PR open but NOT yet merged — `references/platform-readings.md` on main still carries the older 「连评论一起扫 `in:comments`」 row. This PR's SKILL.md text asserts the single-body-channel semantics per the ruling (not re-litigated) and touches neither references file nor the ratchet ceilings, so it lands cleanly whichever merges first; the references row swap remains the trap-rows PR's own diff.

## Gates (union run at the final commit, `40eb86d44`)

Derived via `node scripts/pm/dispatch-gates.mjs .claude/skills/pm-dispatch/SKILL.md scripts/pm/check-half-states.mjs` (tier line: "Model tier — MANDATORY: claude-fable-5"; this session ran on claude-fable-5). All pass at `40eb86d44`: `check:pm-half-states` (114 self-test cases), `check:pm-skill-id-lint`, `check:pm-skill-ratchet` (686/686, headroom 0), `check:skill-frame-sync`, `check:skill-frame-freshness` (run beyond the derived list — named in the skill's guard index), `check:partof-closing-keyword` (28 cases; imports from the edited file), `check:doc-authoring`, `check:nul-bytes`, `pnpm --filter @objectstack/lint run check:doc-formula-expressions` (after building the lint dependency closure).

**Patch round** (predicate cadence clause at `4b5348468`, then H11 at `4277e922d` — the current head): gate family re-run at `4277e922d` — `check:pm-half-states` (128 cases), `check:pm-skill-ratchet` (686/686), `check:pm-skill-id-lint`, `check:skill-frame-sync`, `check:skill-frame-freshness`, `check:nul-bytes`, `check:doc-authoring`, `check:partof-closing-keyword` (re-run because it imports from the detector file) all pass; `check:doc-formula-expressions` unaffected by the patch diffs (no code fence added to SKILL.md) — its `40eb86d44` reading stands, CI re-runs the farm either way.

`skip-changeset`: `.claude/` + `scripts/pm/` only — releases nothing.

_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_