### PR TITLE
docs(spec): FieldSchema points a bare `currency` key at `currencyConfig` (#8163)

### DIFF
--- a/.changeset/field-currency-guidance.md
+++ b/.changeset/field-currency-guidance.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `FieldSchema` points a bare `currency` key at the declarable `currencyConfig` form (#8163)
+
+`currency` has never been a declared `FieldSchema` key — only `currencyConfig`
+is. Writing the natural spelling was always a loud parse error, but a **bare**
+one: the rejection carried only the surface history line ("Until #4001 closed
+this shape these were dropped silently…"), with no pointer to the declarable
+form. The spelling is not hypothetical — objectui's `resolveFieldCurrency`
+reads `field.currency` first from looser grid/column configs, so it circulates
+in configs an AI author will have seen.
+
+The target is a NESTED key (`currencyConfig.defaultCurrency` under
+`currencyMode: 'fixed'`), which a flat `aliases` rename cannot express — so
+this is prose (`guidance`), the same `storageNotNull`-style case already on
+this surface: `currency` is not a field key; a fixed currency is declared as
+`currencyConfig: { currencyMode: 'fixed', defaultCurrency: '…' }`. A field
+without one uses the tenant default at runtime.
+
+Accept/reject is byte-for-byte unchanged — `currency` was rejected before this
+change and stays rejected after it; only the rejection's message gains a
+prescription.

--- a/packages/spec/src/data/field.test.ts
+++ b/packages/spec/src/data/field.test.ts
@@ -168,6 +168,59 @@ describe('CurrencyValueSchema', () => {
   });
 });
 
+// ===========================================================================
+// #8163 — field-level `currency` is rejected with no pointer to the
+// declarable nested form (`currencyConfig.defaultCurrency`). Same
+// `unrecognized_keys`-probing pattern as
+// `shared/visible-when-alias-guidance.test.ts`: this is prose (`guidance`),
+// not a rename (`aliases`) — the target is a NESTED key a flat rename cannot
+// express — and acceptance is byte-identical: `currency` was rejected before
+// this card and stays rejected after it.
+// ===========================================================================
+
+/** The `unrecognized_keys` message for `value`, or a loud test failure. */
+function unrecognizedKeyMessage(value: unknown): string {
+  const r = FieldSchema.safeParse(value);
+  expect(r.success, `expected REJECTION, got a successful parse of ${JSON.stringify(value)}`).toBe(false);
+  const issues = (r as { success: false; error: { issues: Array<{ code?: string; message?: string }> } }).error.issues;
+  const hit = issues.find((i) => i.code === 'unrecognized_keys');
+  expect(hit, `no \`unrecognized_keys\` issue in ${JSON.stringify(issues)}`).toBeDefined();
+  return hit?.message ?? '';
+}
+
+describe('FieldSchema — field-level `currency` key guidance (#8163)', () => {
+  const FIELD = { name: 'amount', label: 'Amount', type: 'currency' } as const;
+
+  it('`currency` stays rejected — a prescription is not an acceptance', () => {
+    expect(FieldSchema.safeParse({ ...FIELD, currency: 'JPY' }).success).toBe(false);
+  });
+
+  it('names the declarable nested form, `currencyConfig` / `defaultCurrency`', () => {
+    const m = unrecognizedKeyMessage({ ...FIELD, currency: 'JPY' });
+    expect(m).toContain('`currency` is not a field key');
+    expect(m).toContain('currencyConfig');
+    expect(m).toContain('defaultCurrency');
+    // The claim the prose makes is real — the nested form it names really parses.
+    expect(
+      FieldSchema.safeParse({
+        ...FIELD,
+        currencyConfig: { currencyMode: 'fixed', defaultCurrency: 'JPY' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('is prose, not a rename — no `Did you mean` for `currency` (the target is a nested key)', () => {
+    const m = unrecognizedKeyMessage({ ...FIELD, currency: 'JPY' });
+    expect(m).not.toContain('Did you mean');
+  });
+
+  it('a sibling unknown key does NOT get the currency prescription (anti-vacuity)', () => {
+    const m = unrecognizedKeyMessage({ ...FIELD, totallyBogusKey: true });
+    expect(m).not.toContain('currencyConfig');
+    expect(m).not.toContain('defaultCurrency');
+  });
+});
+
 describe('FieldSchema', () => {
   describe('Basic Field Properties', () => {
     it('should accept valid field with minimal properties', () => {

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -573,6 +573,18 @@ export const FieldSchema = lazySchema(() => strictObject({
       '`columnName` was removed in the 16.x line (#2377) — the SQL driver hardcodes the physical '
       + 'column to the field key, so a custom name was ignored. External/federated objects map '
       + 'physical columns with `external.columnMap` (ADR-0062 D7).',
+    // `currency` is not, and has never been, a declared FieldSchema key — it is
+    // not a retirement, just a natural spelling with no landing key of its own
+    // (#8163). Prose rather than an `aliases` rename because the target is a
+    // NESTED key: `currencyConfig.defaultCurrency` under `currencyMode: 'fixed'`,
+    // which a flat rename cannot express. The spelling is not hypothetical —
+    // objectui's `resolveFieldCurrency` reads `field.currency` first from looser
+    // grid/column configs, so it circulates in configs an AI author will have
+    // seen.
+    currency:
+      '`currency` is not a field key — a fixed currency is declared as `currencyConfig: '
+      + '{ currencyMode: \'fixed\', defaultCurrency: \'JPY\' }`. A field without one uses '
+      + 'the tenant default at runtime.',
     referenceFilters:
       '`referenceFilters` (string[]) was removed in the 16.x line (#2377) — the lookup picker only '
       + 'ever read the structured form. Use `lookupFilters: [{ field, operator, value }]`.',


### PR DESCRIPTION
Fixes #8163

## What

`FieldSchema` is strict, and a field-level `currency` key was never declared
— only `currencyConfig` is. The rejection carried only the surface history
line ("Until #4001 closed this shape these were dropped silently…"), with no
suggestion and no prescription. This adds ONE `guidance` prose entry, per the
card's own drafted text and per the same `storageNotNull`-style case already
on this surface:

> `currency` is not a field key — a fixed currency is declared as
> `currencyConfig: { currencyMode: 'fixed', defaultCurrency: 'JPY' }`. A field
> without one uses the tenant default at runtime.

Not an `aliases` rename entry — the target is a NESTED key
(`currencyConfig.defaultCurrency`), which a flat rename cannot express (ruled
on the card).

## Why the spelling is not hypothetical

objectui's `resolveFieldCurrency` (`packages/i18n/src/currency.ts`) reads
`field.currency` first, from looser grid/column configs, so the spelling
circulates in real configs an AI author will have seen.

## Scope

- `packages/spec/src/data/field.zod.ts` — one `guidance` entry added to
  `FieldSchema`'s strict-object options (alongside the existing
  `columnName` / `referenceFilters` / `storageNotNull` / `tracked` / `visible`
  entries).
- `packages/spec/src/data/field.test.ts` — a new describe block asserting: the
  key stays rejected; the message names `currencyConfig` / `defaultCurrency`
  (and that nested form really parses); the message is prose, not a `Did you
  mean` rename; a sibling unknown key does NOT get the currency prescription
  (anti-vacuity, per the #9045 §4 precedent).
- `.changeset/field-currency-guidance.md` — patch (surface convention: the
  `#7887`/`#8199` family's `section-component-editability-boundary.md`
  changeset is the precedent for this exact class of fix).

**Accept/reject face is byte-for-byte unchanged** — `currency` was rejected
before this change and stays rejected after it; only the rejection's message
gains a prescription. `check:api-surface` reports no change.

No `Field.time` builder or any other `Field` builder change — the #8656
opportunistic rider was withdrawn from this dispatch (see the correction
comment on #8163); this PR does not touch the `Field` builder object.

## Tests

At commit `33eef60f9` (the final commit — this run matches HEAD):

- `pnpm --filter @objectstack/spec exec vitest run src/data/field.test.ts` —
  121 passed, including the 4 new `#8163` cases.
- `pnpm --filter @objectstack/spec exec vitest run src/data/authoring-key-lint.test.ts src/shared/alias-integrity.test.ts src/shared/visible-when-alias-guidance.test.ts src/shared/strict-object.test.ts` —
  90 passed.
- `pnpm --filter @objectstack/spec test` (full package) — 406 files / 10759
  tests passed.
- `pnpm --filter @objectstack/spec typecheck` — clean (`tsc --noEmit` +
  `check:scripts-typecheck` + `check:test-typecheck`).
- `pnpm --filter @objectstack/spec check:generated` — all 13 generated
  artifacts up to date (the guidance prose is not a `.describe()`, so no
  reference pages moved).
- Gate families re-derived against the actual diff via
  `node scripts/pm/dispatch-gates.mjs <changed paths>`, all green:
  `check:cross-package-test-inputs`, `check:doc-formula-expressions`,
  `check:merge-driver`, `check:spec-parsed-alias`,
  `check:type-source-resolution`,
  `node scripts/check-cross-package-test-inputs.mjs`,
  `node scripts/check-dev-prereqs.mjs` (after a full
  `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`
  — 70/70 tasks), plus the convention-triggered gates for the new test file:
  `check:query-options-erasure`, `check:type-check-coverage`,
  `check:type-check-debt --re-measure` (1926 raw errors, none above
  recorded), `check:engine-double-contract`, `check:where-matcher`.
- `node scripts/check-nul-bytes.mjs` on the changed files — clean.

CI convergence (the full gate farm) is the PM's to watch per the standing
dispatch contract — this report is filed at draft-PR time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_