### PR TITLE
fix(plugin-sharing): the phantom-anchor write refusal stops being silent (#8418)

### DIFF
--- a/.changeset/phantom-anchor-write-deny-diagnostic.md
+++ b/.changeset/phantom-anchor-write-deny-diagnostic.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/plugin-sharing': minor
+---
+
+A write refused because a federated object's `owner_id` is the platform's phantom anchor now says so, once per object (#8418).
+
+**No verdict changes.** `checkEdit` / `checkDelete` stay fail-closed exactly as shipped — this adds a diagnostic and nothing else. Maintainer ruling 2026-08-13 (option C on #8418): keep `deny`, make the refusal visible.
+
+What was wrong: on an ADR-0015 federated object with no author-declared `owner_id`, the registry injects the anchor but the platform provisions no column behind it, so the ownership fast path selects `owner_id` off a remote table that does not have it. The SQL driver's recovery ladder DISCARDS a projection naming an unresolvable column and re-runs `select('*')` instead of raising — so `matchesOwnerScope` receives a good row that simply has no `owner_id` key, reads `owner == null`, and refuses. Because nothing threw, `writeGateFailClosed` was never reached and **nothing was logged anywhere**: the operator got a bare 403 with no trace, at every write depth (`org` included — the null-owner short-circuit runs before the scope is consulted). Only a `modifyAllRecords` holder could still write.
+
+`SharingService` now emits `PHANTOM_ANCHOR_WRITE_DENY_NOTICE` at `warn` on that path, naming the object, the owner field and the caller, with both remedies in the wording: declare the real remote owner column, or move the object off an owner-scoped sharing model. The constant is exported so a deployment can match on it.
+
+Deduped **per object**, for the service's lifetime. The condition is a property of the registered schema, identical for every row and every caller, so a bulk write emits one line rather than one per row and one misconfiguration is not multiplied by the principal count.
+
+It fires only on the phantom anchor, never on an ordinary owner-less row: the discrimination is `hasPhantomOwnerAnchor` provenance (is this `owner_id` the platform's injected constant, or a column the author declared?), not `owner == null` and not an `external` test. A federated object with a real declared remote owner column keeps scoping normally and stays silent.
+
+The diagnostic cannot cost a write — it returns `void`, its caller ignores it, and a throwing logger is swallowed, so no ordering of schema lookup, latch and logger can move a verdict.
+
+Also corrected in passing: this package attributed the driver's non-throwing unknown-column recovery to **SQLite specifically**. That understated it — the projection rung is gated by the driver's single shared `isUnresolvableColumnError` predicate, which spells all three dialects it speaks (`no such column`, `column … does not exist`, and since #8926 `Unknown column '…'`), so the silent refusal reproduced on every supported dialect. Wording only; no driver change.

--- a/packages/plugins/plugin-sharing/src/federated-phantom-owner-scoping.test.ts
+++ b/packages/plugins/plugin-sharing/src/federated-phantom-owner-scoping.test.ts
@@ -47,7 +47,7 @@
  * division of labour rather than a gap.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   OWNER_FIELD_DEF,
   assertEngineDeleteDispatch,
@@ -57,7 +57,7 @@ import {
   type EngineUpdateDispatchInput,
 } from '@objectstack/metadata-core';
 import { ERROR_CODE_LEDGER } from '@objectstack/spec/api';
-import { SharingService } from './sharing-service.js';
+import { SharingService, PHANTOM_ANCHOR_WRITE_DENY_NOTICE } from './sharing-service.js';
 
 /** The caller: an ordinary member whose read/write DEPTH is narrower than `org`. */
 const MEMBER = 'usr_member_1';
@@ -325,12 +325,23 @@ describe('[#7858] ownership scoping vs federated (external) objects', () => {
  *   NO throw, in any dialect position tested.
  * ```
  *
- * So on SQLite the driver does not raise, `writeGateFailClosed` is never
- * reached, and nothing is logged: the refusal is produced silently by
- * `matchesOwnerScope` reading `owner == null`. That is why the federated rows
- * below carry NO `owner_id` key rather than an explicit `null` and rather than
- * being absent altogether — a row that is simply missing would prove only that
- * the gate refuses unknown records, which it does for every object.
+ * So the driver does not raise and `writeGateFailClosed` is never reached: the
+ * refusal is produced by `matchesOwnerScope` reading `owner == null`. That is
+ * why the federated rows below carry NO `owner_id` key rather than an explicit
+ * `null` and rather than being absent altogether — a row that is simply missing
+ * would prove only that the gate refuses unknown records, which it does for
+ * every object.
+ *
+ * [#8418] Two corrections to the paragraph above, both measured after it was
+ * written. The measurement was taken on SQLite, but the non-throwing recovery is
+ * NOT a SQLite property: the projection rung is gated by the driver's single
+ * shared `isUnresolvableColumnError` predicate, which spells all three dialects
+ * it speaks — `no such column` (SQLite), `column … does not exist` (Postgres)
+ * and, since #8926, `Unknown column '…'` (MySQL) — so the silent `deny`
+ * reproduces on every supported dialect. And "nothing is logged" is no longer
+ * true: the refusal now emits `PHANTOM_ANCHOR_WRITE_DENY_NOTICE` once per
+ * object, pinned in the #8418 block at the bottom of this file. The VERDICT is
+ * untouched, which is what that block asserts alongside the line.
  *
  * ## Why `checkEdit` / `checkDelete` are pinned but NOT changed
  *
@@ -506,6 +517,222 @@ describe('[#8119] federated phantom anchor and the SINGLE-record gates', () => {
           { userId: MEMBER } as never,
         ),
       ).rejects.toThrow(/SHARING_NOT_ENABLED: 'showcase_ext_customer' is not under record-sharing/);
+    });
+  });
+});
+
+/**
+ * [#8418] The silent refusal gets a voice — and keeps its verdict.
+ *
+ * Maintainer ruling 2026-08-13 14:22Z, option C: `checkEdit` / `checkDelete`
+ * stay fail-closed exactly as shipped, and a once-per-object diagnostic is
+ * added so the refusal stops being invisible to the operator. Both halves are
+ * pinned here, and the SECOND is the one that matters most: a diagnostic
+ * inserted into a security gate's short-circuit is exactly the shape that can
+ * move a verdict by accident, so every case that asserts a log line asserts the
+ * verdict in the same breath.
+ *
+ * ## Why the refusal was silent in the first place
+ *
+ * Every other unresolvable write gate reaches `writeGateFailClosed`, which
+ * logs. This one cannot: the SQL driver's recovery ladder DISCARDS a projection
+ * naming a column the remote table lacks and re-runs `select('*')` instead of
+ * raising, so `matchesOwnerScope` receives a good row that merely has no
+ * `owner_id` key. No throw ⇒ no `catch` ⇒ no log. The operator got a bare 403
+ * with no trace anywhere on the server — on every supported dialect, not just
+ * the SQLite one the original measurement used (see this file's header).
+ *
+ * ## The discrimination these cases exist for
+ *
+ * `owner == null` has TWO causes and only one of them is this defect: an
+ * ordinary owner-less row (a system seed, a local object) reads `null` too, and
+ * it is NOT a misconfiguration — it is a row nobody owns, and the gate refusing
+ * it is ordinary correct behaviour. Attaching the line to `owner == null` alone
+ * would fire it on every seeded local row in the deployment. `LOCAL_OWNERLESS`
+ * below is what holds that apart, and it is the case that fails if the
+ * provenance predicate is ever dropped for a cheaper `owner == null` test.
+ */
+describe('[#8418] the phantom-anchor write refusal is diagnosed, not changed', () => {
+  /** A SECOND unstamped federated object — the per-object dedup needs two. */
+  const SECOND_PHANTOM = {
+    name: 'measure_ext_other',
+    external: { remoteName: 'vendors' },
+    fields: { owner_id: { ...OWNER_FIELD_DEF }, ...REMOTE_COLUMNS },
+  };
+
+  const FEDERATED_ROW = { id: 'c1', name: 'Aurora Labs', email: 'ap@aurora.example', region: 'NA' };
+  /**
+   * A LOCAL row with no owner. Same `owner == null` the phantom anchor produces,
+   * entirely different cause — the platform DID provision this column; this row
+   * simply has nobody in it.
+   */
+  const LOCAL_OWNERLESS = { id: 't9', name: 'Unowned task' };
+
+  let svc: SharingService;
+  let warn: ReturnType<typeof vi.fn>;
+  let logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+
+  const build = (log?: unknown) =>
+    new SharingService({
+      engine: makeEngine(
+        {
+          measure_ext_nostamp: federatedSchema(),
+          measure_ext_other: SECOND_PHANTOM,
+          ext_with_real_owner: DECLARED_REAL_OWNER,
+          local_task: LOCAL_PRIVATE,
+          showcase_ext_customer: GRANDFATHERED_SHOWCASE_SHAPE,
+          sys_record_share: { name: 'sys_record_share' },
+        },
+        {
+          measure_ext_nostamp: [FEDERATED_ROW],
+          measure_ext_other: [{ id: 'v1', name: 'Vendor' }],
+          ext_with_real_owner: [{ id: 'a1', owner_id: MEMBER, name: 'Acme' }],
+          local_task: [{ id: 't1', owner_id: MEMBER, name: 'My task' }, LOCAL_OWNERLESS],
+          showcase_ext_customer: [FEDERATED_ROW],
+        },
+      ),
+      ...(log === undefined ? {} : { logger: log as never }),
+    });
+
+  const ctx = (scope = 'own') => ({ userId: MEMBER, __writeScope: scope }) as never;
+  /** Every phantom-anchor WARN this logger saw. */
+  const notices = () => warn.mock.calls.filter((c) => c[0] === PHANTOM_ANCHOR_WRITE_DENY_NOTICE);
+
+  beforeEach(() => {
+    warn = vi.fn();
+    logger = { info: vi.fn(), warn, error: vi.fn() };
+    svc = build(logger);
+  });
+
+  describe('the diagnostic fires', () => {
+    it('emits ONE warn naming the object, and still DENIES', async () => {
+      // Both halves in one case on purpose: the line is worthless if it came at
+      // the cost of the verdict, and a verdict pinned in a different case could
+      // drift apart from the one the line was emitted for.
+      expect(await svc.checkEdit('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+
+      expect(notices()).toHaveLength(1);
+      expect(notices()[0][1]).toMatchObject({ object: 'measure_ext_nostamp', ownerField: 'owner_id' });
+    });
+
+    it('the wording names the cause AND the remedy', async () => {
+      // The defect is that an operator could not find out WHY. A line that says
+      // only "denied" would reproduce it with extra steps, so the message text
+      // is contract here, exactly as #6783 pins its own.
+      await svc.checkEdit('measure_ext_nostamp', 'c1', ctx());
+      const [message] = notices()[0];
+      expect(message).toContain('injected anchor');
+      expect(message).toContain('declare the real remote owner column');
+    });
+
+    it('fires on the DELETE gate too, which reaches the same short-circuit', async () => {
+      expect(await svc.checkDelete('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+      expect(notices()).toHaveLength(1);
+    });
+
+    it.each(['own', 'own_and_reports', 'unit', 'unit_and_below', 'org'] as const)(
+      'still denies at __writeScope=%s, and says so once',
+      async (scope) => {
+        // `org` is the load-bearing one: the null-owner short-circuit runs
+        // BEFORE the scope is consulted, so the widest non-bypass depth is
+        // refused too — the property the ruling refused to change.
+        expect(await svc.checkEdit('measure_ext_nostamp', 'c1', ctx(scope))).toBe('deny');
+        expect(notices()).toHaveLength(1);
+      },
+    );
+  });
+
+  describe('once per OBJECT — not per row, per call or per caller', () => {
+    it('collapses many calls on one object to a single line', async () => {
+      for (let i = 0; i < 5; i++) await svc.checkEdit('measure_ext_nostamp', 'c1', ctx());
+      await svc.checkDelete('measure_ext_nostamp', 'c1', ctx());
+      expect(notices()).toHaveLength(1);
+    });
+
+    it('a DIFFERENT caller on the same object does not re-arm it', async () => {
+      // The condition is a fact about the schema, identical for everyone. Keying
+      // by caller would multiply one misconfiguration by the principal count.
+      await svc.checkEdit('measure_ext_nostamp', 'c1', ctx());
+      await svc.checkEdit('measure_ext_nostamp', 'c1', { userId: 'usr_other', __writeScope: 'own' } as never);
+      expect(notices()).toHaveLength(1);
+    });
+
+    it('a SECOND phantom-anchored object gets its OWN line', async () => {
+      // ANTI-VACUITY for the latch: without this, a latch that suppressed
+      // everything after the first line ever would read identically.
+      expect(await svc.checkEdit('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+      expect(await svc.checkEdit('measure_ext_other', 'v1', ctx())).toBe('deny');
+      expect(notices().map((c) => (c[1] as { object: string }).object)).toEqual([
+        'measure_ext_nostamp',
+        'measure_ext_other',
+      ]);
+    });
+  });
+
+  describe('it does NOT fire where the null owner is not a phantom anchor', () => {
+    it('an owner-less LOCAL row denies in silence', async () => {
+      // The discrimination this whole diagnostic depends on. The column is real
+      // and provisioned; the row just has no owner. Same verdict, no line.
+      expect(await svc.checkEdit('local_task', 't9', ctx())).toBe('deny');
+      expect(notices()).toHaveLength(0);
+    });
+
+    it('a federated object with a DECLARED remote owner column is untouched', async () => {
+      // `external` is not the predicate — provenance is. This object still
+      // ALLOWS, so it never reaches the short-circuit at all.
+      expect(await svc.checkEdit('ext_with_real_owner', 'a1', ctx())).toBe('allow');
+      expect(notices()).toHaveLength(0);
+    });
+
+    it('a local object the caller owns allows, silently', async () => {
+      expect(await svc.checkEdit('local_task', 't1', ctx())).toBe('allow');
+      expect(notices()).toHaveLength(0);
+    });
+
+    it('the grandfathered showcase object abstains ABOVE this gate', async () => {
+      // `public_read_write` is judged before ownership, so the shipped federated
+      // objects never reach the short-circuit and must stay silent.
+      expect(await svc.checkEdit('showcase_ext_customer', 'c1', ctx())).toBe('abstain');
+      expect(notices()).toHaveLength(0);
+    });
+  });
+
+  describe('the diagnostic can never cost a write', () => {
+    it('a THROWING logger changes nothing — same verdict, no escape', async () => {
+      // This runs inside `checkEdit`'s own `try`, where an escaping error would
+      // be caught by `writeGateFailClosed` — which also returns `deny`, so the
+      // verdict would survive but the operator would be handed the WRONG
+      // diagnosis (an unresolvable gate) for a gate that resolved fine.
+      const boom = build({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: () => { throw new Error('logger exploded'); },
+      });
+      expect(await boom.checkEdit('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+      // And the latch was claimed BEFORE the log, so a throwing logger cannot
+      // turn one suppressed line into one throw per row.
+      expect(await boom.checkEdit('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+    });
+
+    it('NO logger at all is the ordinary deployment, and it still denies', async () => {
+      const quiet = build(undefined);
+      expect(await quiet.checkEdit('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+      expect(await quiet.checkDelete('measure_ext_nostamp', 'c1', ctx())).toBe('deny');
+    });
+
+    it('the verdict matrix is byte-identical to the pre-diagnostic baseline', async () => {
+      // The regression surface for the ruling's ⛔ "do not alter any verdict".
+      // Read against the #8119 block above: same objects, same answers.
+      const seen = [
+        await svc.checkEdit('measure_ext_nostamp', 'c1', ctx('org')),
+        await svc.checkDelete('measure_ext_nostamp', 'c1', ctx('org')),
+        await svc.checkEdit('ext_with_real_owner', 'a1', ctx()),
+        await svc.checkDelete('ext_with_real_owner', 'a1', ctx()),
+        await svc.checkEdit('local_task', 't1', ctx()),
+        await svc.checkEdit('local_task', 't9', ctx()),
+        await svc.checkEdit('showcase_ext_customer', 'c1', ctx()),
+      ];
+      expect(seen).toEqual(['deny', 'deny', 'allow', 'allow', 'allow', 'deny', 'abstain']);
     });
   });
 });

--- a/packages/plugins/plugin-sharing/src/index.ts
+++ b/packages/plugins/plugin-sharing/src/index.ts
@@ -14,6 +14,7 @@ export { SysBusinessUnit, SysBusinessUnitMember } from '@objectstack/platform-ob
 export {
   SharingService,
   effectiveSharingModel,
+  PHANTOM_ANCHOR_WRITE_DENY_NOTICE,
   type SharingEngine,
   type SharingServiceOptions,
   type OrphanShareSweepOptions,

--- a/packages/plugins/plugin-sharing/src/sharing-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-service.ts
@@ -144,6 +144,45 @@ function hasOwnerField(schema: any): boolean {
 }
 
 /**
+ * [#8418] The one WARN line a write gate emits when it refuses because the
+ * ownership fast-path was defeated by a FEDERATED object's phantom `owner_id`
+ * anchor.
+ *
+ * Ruled on #8418 (2026-08-13 14:22Z, option C): the verdict is UNCHANGED —
+ * `checkEdit` / `checkDelete` stay fail-closed exactly as shipped — and what is
+ * added is this diagnostic, so the refusal stops being invisible. Nothing about
+ * the adjudication reads this constant; removing it would change no verdict.
+ *
+ * ## Why this refusal was the silent one
+ *
+ * Every other unresolvable write gate in this class reaches
+ * {@link SharingService.writeGateFailClosed}, which logs. This one never does,
+ * and the reason is one rung of the SQL driver's recovery ladder: when a query's
+ * `fields` names a column the remote table lacks, the driver DISCARDS the whole
+ * projection and re-runs `select('*')` rather than raising, so
+ * {@link SharingService.matchesOwnerScope} gets a perfectly good row that simply
+ * has no `owner_id` key. No throw ⇒ no `catch` ⇒ no log; `owner == null` ⇒
+ * `false` ⇒ `deny`. The operator sees a bare 403 and there is no trace of it
+ * anywhere on the server.
+ *
+ * WARN, not INFO: unlike #6783's system-write skip — which is correct and
+ * self-healing, hence INFO — this names a deployment that cannot work as
+ * authored. Every principal at every write DEPTH is refused (`org` included:
+ * the null-owner short-circuit runs before the scope is consulted), and only a
+ * `modifyAllRecords` holder can still write. The remedies are the operator's:
+ * declare the real remote `owner_id` column, or put the object under a sharing
+ * model that does not scope by owner.
+ *
+ * It is a statement about the ANCHOR, not about the row or the caller — see
+ * {@link SharingService.notePhantomAnchorWriteDeny} for why that fixes the
+ * dedup key.
+ */
+export const PHANTOM_ANCHOR_WRITE_DENY_NOTICE =
+  '[sharing] write refused: the owner column on this federated object is the platform ' +
+  'injected anchor, not a remote column, so ownership can never match; ' +
+  'declare the real remote owner column or change the sharing model';
+
+/**
  * [ADR-0111 D2] The narrow slice of `ISecurityService` the management gate
  * needs — kept structural so unit tests can pass a stub and so a deployment
  * without `@objectstack/plugin-security` degrades to owner-only (fail closed).
@@ -256,6 +295,26 @@ export class SharingService implements ISharingService {
   private readonly securityService?: () => SharingSecurityProbe | null | undefined;
   private readonly tenancy?: () => SharingTenancyProbe | null | undefined;
   private readonly logger?: SharingServiceOptions['logger'];
+
+  /**
+   * [#8418] Objects that have already reported {@link
+   * PHANTOM_ANCHOR_WRITE_DENY_NOTICE}.
+   *
+   * Keyed by OBJECT NAME and nothing else, which is the whole design of the
+   * dedup and follows #6783's `notified` latch. The condition being reported is
+   * a property of the object's REGISTERED SCHEMA — the platform injected an
+   * `owner_id` into a federated object whose storage it never provisioned — so
+   * it is identical for every row and every caller, and it cannot change while
+   * that schema is registered. Keying by record would emit one line per row of
+   * a bulk write, and keying by caller would multiply one misconfiguration by
+   * the principal count; both trade silence for noise, which is the same defect
+   * wearing a different symptom (#6783 states this reasoning for its own line).
+   *
+   * Scoped to the service instance, the analogue of #6783's binding generation:
+   * the latch re-arms when the service is rebuilt, so a redeployed schema gets
+   * its own line rather than inheriting this instance's silence.
+   */
+  private readonly phantomAnchorNotified = new Set<string>();
 
   constructor(options: SharingServiceOptions) {
     this.engine = options.engine;
@@ -440,12 +499,58 @@ export class SharingService implements ISharingService {
       context: SYSTEM_CTX,
     });
     const owner = Array.isArray(own) && own[0] ? (own[0] as any)[OWNER_FIELD] : undefined;
-    if (owner == null) return false;
+    if (owner == null) {
+      // [#8418] The refusal is unchanged — `return false` below is the same
+      // `false` this line has always returned, and the diagnostic is emitted
+      // only for its side effect. It is placed INSIDE the `owner == null` arm
+      // rather than at the top of the method so it reports the state that
+      // actually defeats the fast path, not the mere fact that the object is
+      // federated: an author-declared remote `owner_id` that happens to be NULL
+      // on this row reaches here too, and `hasPhantomOwnerAnchor` is what tells
+      // the two apart (provenance, never an `external` test).
+      this.notePhantomAnchorWriteDeny(object, context);
+      return false;
+    }
     // Middleware-stamped, not a field of the envelope — see buildReadFilter().
     const writeScope = (context as any).__writeScope as ('own' | 'own_and_reports' | 'unit' | 'unit_and_below' | 'org' | undefined);
     if (writeScope === 'org') return true;
     const owners = await this.resolveOwnerScopeIds(context, writeScope);
     return owners.includes(String(owner));
+  }
+
+  /**
+   * [#8418] Emit {@link PHANTOM_ANCHOR_WRITE_DENY_NOTICE} at most once per
+   * object, and ONLY when the null owner is the platform's phantom anchor
+   * rather than an ordinary owner-less row.
+   *
+   * **Verdict-free by construction.** It returns `void`, every path through it
+   * is a no-op or a log, and its caller ignores it entirely — so no ordering of
+   * schema lookup, latch and logger can move a verdict. That is the ruled
+   * constraint (#8418 option C) expressed as a shape rather than as a promise.
+   *
+   * Never throws. This runs on the write path inside `checkEdit` /
+   * `checkDelete`'s own `try`, where an escaping error would be caught by
+   * {@link writeGateFailClosed} — which returns `deny` too, so the verdict
+   * would survive, but the operator would get the WRONG diagnosis (an
+   * unresolvable gate) for a gate that resolved perfectly well. A diagnostic
+   * that can misreport the thing it exists to explain is worse than silence.
+   * The latch is claimed BEFORE the log so a throwing logger cannot turn one
+   * suppressed line into one throw per row (#6783's ordering, same reason).
+   */
+  private notePhantomAnchorWriteDeny(object: string, context: ExecutionContext): void {
+    if (this.phantomAnchorNotified.has(object)) return;
+    try {
+      const schema = this.engine.getSchema?.(object);
+      if (!hasPhantomOwnerAnchor(schema)) return;
+      this.phantomAnchorNotified.add(object);
+      this.logger?.warn?.(PHANTOM_ANCHOR_WRITE_DENY_NOTICE, {
+        object,
+        ownerField: OWNER_FIELD,
+        userId: context?.userId ?? 'unknown',
+      });
+    } catch {
+      /* a diagnostic must never fail, or change, an operator's write */
+    }
   }
 
   /**
@@ -914,6 +1019,15 @@ export class SharingService implements ISharingService {
     // DEPTH (`org` included: the null-owner short-circuit runs before the scope is
     // consulted). Only the `modifyAllRecords` bypass can still reach `allow`, and
     // it does so without reading a share row.
+    //
+    // [#8418] The measurement was taken on SQLite, but the non-throwing recovery
+    // is NOT a SQLite property — this comment and #8209's changeset both used to
+    // say it was, and that UNDERSTATED the reach. The projection rung is gated by
+    // the driver's single shared `isUnresolvableColumnError` predicate, which
+    // spells all three dialects it speaks: `no such column` (SQLite), `column …
+    // does not exist` (Postgres) and, since #8926, `Unknown column '…'` (MySQL).
+    // One predicate, one ladder, so the silent `deny` reproduces on EVERY
+    // supported dialect rather than in one developer environment.
     //
     // A grant here is therefore inert BY CONSTRUCTION — the ADR-0078
     // silently-inert trap this whole guard (ADR-0111 D7) exists to close: "share"


### PR DESCRIPTION
Fixes #8418

Implements the ruled option C (maintainer, 2026-08-13 14:22Z, 「接受你的全部建议」, re-confirmed in the 2026-08-15 decision-box pass): keep `deny`, add the diagnostic. **No verdict moves.** `checkEdit` / `checkDelete` stay fail-closed exactly as shipped; no declared field, no config key, no widening of `allow`, no change to the adjudication logic.

## The defect

On an ADR-0015 federated object with no author-declared `owner_id`, the registry injects the anchor but the platform provisions no column behind it. The ownership fast path therefore selects `owner_id` off a remote table that does not have it — and the SQL driver's recovery ladder **discards** a projection naming an unresolvable column and re-runs `select('*')` rather than raising. So `matchesOwnerScope` receives a perfectly good row that merely has no `owner_id` key, reads `owner == null`, and refuses.

Because nothing threw, `writeGateFailClosed` was never reached and **nothing was logged anywhere**. The operator got a bare 403 with no trace, at every write depth — `org` included, since the null-owner short-circuit runs before the scope is consulted. Only a `modifyAllRecords` holder could still write.

## What this adds

`SharingService` emits `PHANTOM_ANCHOR_WRITE_DENY_NOTICE` at `warn` on that path, naming the object, the owner field and the caller, with both remedies in the wording (declare the real remote owner column, or move the object off an owner-scoped sharing model). The constant is exported so a deployment can match on it.

Follows the existing #6783 `SYSTEM_WRITE_SKIP_NOTICE` idiom already in this package rather than introducing a mechanism: exported message constant, `Set` latch, latch claimed **before** the log, whole emit wrapped so a throwing logger cannot fail a write. No new dependency or format.

**Dedup key: object name** (the design decision the card left open). The condition is a property of the registered schema — identical for every row and every caller, and unable to change while that schema is registered — so a bulk write emits one line rather than one per row, and one misconfiguration is not multiplied by the principal count. Latch scoped to the service instance, the analogue of #6783's binding generation. `warn`, not #6783's `info`: that skip is correct and self-healing, this names a deployment that cannot work as authored.

It fires **only** on the phantom anchor. `owner == null` has two causes and only one is this defect — an ordinary owner-less row (a system seed, a local object) reads `null` too and is not a misconfiguration. The discrimination is `hasPhantomOwnerAnchor` provenance, never `owner == null` and never an `external` test.

## Verification — union run at `9ad3166d7`, the final commit

- `pnpm --filter @objectstack/plugin-sharing test` — **617 passed (24 files)**, including 18 new cases.
- `pnpm --filter @objectstack/plugin-sharing typecheck` — clean.
- Gates green: `check:test-source-alias`, `check:type-source-resolution`, `check:i18n` (`plugin-sharing` in sync — a log string is not an authoring key), `check:nul-bytes`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt --re-measure`, and the five changeset-family gates.
- `check:type-check-debt` matters here specifically: `plugin-sharing` is a **TEST_DEBT** package, so its tsconfig hides its tests and the package `typecheck` never saw the new file. The re-measure reports "surplus: none — every entry sits exactly at its measurement", i.e. the entry stayed at exactly 3 and the new test code added zero type errors.

**Reverse verification, both legs run from the committed state:**

1. Removing the emit call: **11 failed | 34 passed**. The log-asserting cases go red while every verdict-asserting case stays green — which is the positive evidence that the diagnostic carries no verdict weight.
2. Replacing the provenance predicate with a bare null check: **exactly 1 failure**, "an owner-less LOCAL row denies in silence". The discrimination case is load-bearing, not vacuous.

A pin that only asserted the log line would miss what everyone will actually worry about, so every case asserting a line asserts the verdict in the same breath, and a final case pins the whole verdict matrix against the pre-diagnostic baseline.

## Adjacent wording fix (in-file, no separate PR, per the ruling)

This package attributed the driver's non-throwing unknown-column recovery to **SQLite specifically**, in `sharing-service.ts` and in the test file's header. Measured wrong: the projection rung is gated by the driver's single shared `isUnresolvableColumnError` predicate, which spells all three dialects it speaks — `no such column` (SQLite), `column … does not exist` (Postgres), and since #8926 `Unknown column '…'` (MySQL). The silent refusal reproduced on every supported dialect. **Wording only; `driver-sql` is untouched** (different lane).

Two notes on the sweep. #8209's changeset no longer exists in the tree — it was consumed by a release, so the live comments were the only remaining carriers. And `federated-phantom-anchors.ts` also says "dialect-dependent", which I deliberately **left alone**: that sentence describes the WHERE-clause path, a different clause position where the behaviour genuinely does differ by dialect. The test-header edit was required regardless of the free fix, because "nothing is logged" became false with this change.

## Premise notes for the PM

- Premise verified and intact, but **broader than the card states**: the card says two dialect families; #8926 landed MySQL into the shared predicate earlier the same day, so it is now all three.
- The card's line numbers have drifted (`driver-sql` `3858-3903` is now ~`625`/`4539`). I cited the predicate by symbol name instead, which does not rot.
- `checkEdit`/`checkDelete` gate on `hasOwnerField`, which answers YES for a phantom anchor — unlike `buildReadFilter`/`buildWriteFilter`, which already consult `hasPhantomOwnerAnchor` and return `null`. That asymmetry is what makes this path reachable, and it is unchanged here.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_