### PR TITLE
fix(docs): rename apps/docs's start script to match its own convention

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "pnpm --filter @objectstack/spec gen:schema && pnpm --filter @objectstack/spec gen:docs && NODE_OPTIONS='--max-old-space-size=4096' next build",
-    "site:start": "next start",
+    "start": "next start",
     "site:lint": "next lint",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx",


### PR DESCRIPTION
Fixes #9086

## The defect

`pnpm docs:start` has never worked. Both lines landed together in `159e29944` (2026-08-15): the root `package.json` delegate calls `pnpm --filter @objectstack/docs start`, but `apps/docs/package.json` declared `site:start`, not `start`.

## Determination: the app's script name is the outlier, not the root delegate

Re-derived from scratch (not copied from the issue's provenance note):

- Root `package.json`'s two sibling, already-working delegates map onto **bare** script names in `apps/docs`: `docs:dev` → `dev`, `docs:build` → `build`. That is the established, working convention.
- `apps/docs/README.md` (unrelated to this fix, pre-existing) documents the deployment step as:
  ```
  # From repository root
  pnpm docs:start
  # Or from apps/docs
  pnpm start
  ```
  i.e. the app's own docs already say the local command is `pnpm start`, not `pnpm site:start`.
- No other file in the repo references `site:start` — not `.github/workflows/**`, not `apps/docs/vercel.json` (which only sets a build command, not start), not `scripts/**`. Renaming it is safe.

So the root delegate was already correctly named; the bug is that `apps/docs/package.json` declared the wrong script name. Fix: rename `site:start` → `start` in `apps/docs/package.json`. **The root `package.json` is unchanged.**

`site:lint` is a separate, similarly-styled key but nothing in the repo delegates to it and it isn't broken, so it's left untouched — out of scope for this card.

## Proof it was broken (on `origin/main`, HEAD `4e3a4c3c8`, before this fix)

```
$ pnpm docs:start

> @objectstack/spec-monorepo@4.0.1 docs:start /home/user/objectstack-9086
> pnpm --filter @objectstack/docs start

 ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT  None of the selected packages has a "start" script
 ELIFECYCLE  Command failed with exit code 1.
EXIT=1
```

## Proof it works (on this branch, HEAD `5fd08318d`)

Built the docs site (`pnpm docs:build`, exit 0, 1184 static pages generated), then:

```
$ PORT=48174 pnpm docs:start

> @objectstack/spec-monorepo@4.0.1 docs:start
> pnpm --filter @objectstack/docs start

> @objectstack/docs@4.2.1 start
> next start

▲ Next.js 16.2.12
- Local:         http://localhost:48174
✓ Ready in 153ms
```

```
$ curl -sS -o /dev/null -w "HTTP_STATUS=%{http_code}\n" http://localhost:48174/
HTTP_STATUS=200
```

Confirmed the response body is the real docs homepage (`<title>ObjectStack — A complete business system in 16k tokens</title>`). Server stopped afterward (`kill`, then re-curled to confirm the port is closed — no server left running).

Note: `next start` prints `⚠ "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.` — pre-existing, unrelated to this fix (Next.js config choice), and the server demonstrably does work (200 + real HTML) despite the warning, so not addressed here.

## Verification

- `node scripts/pm/dispatch-gates.mjs apps/docs/package.json` at the final diff: 0 gate families name this path directly (101 discovered, 66 silent w.r.t. this path, 35 undetermined-by-source, 0 matched).
- `pnpm check:nul-bytes` (applies to any edit): green at HEAD `5fd08318d` — `check-nul-bytes: OK (scanned 5973 text file(s) ... no raw ASCII control bytes)`.
- `pnpm docs:build` succeeded (exit 0) at HEAD `5fd08318d`.
- `node -e "JSON.parse(...)"` confirms `apps/docs/package.json` is valid JSON post-edit.

## Changeset

Root-manifest/app-script rename only, publishes nothing → `skip-changeset` label applied; read back to confirm.

## Out of scope

`site:lint` naming (same file, same `site:` prefix habit, but not currently broken/referenced anywhere) — not touched. Not filed as a separate finding: nothing invokes it incorrectly, so it doesn't corroborate #9089's "invocation actually fails" class.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_