### PR TITLE
Parse every body the dispatcher door emits: gate the error-code vocabulary against the ADR-0112 ledger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -437,6 +437,25 @@ jobs:
       - name: Documented HTTP status matches the status the runtime emits
         run: pnpm check:error-status-conformance
 
+      # #8087: ADR-0112 closes `error.code`, and the dispatcher door did not
+      # enforce it — `errorFromThrown` puts the producer's string on the wire
+      # un-narrowed, and its conformance suite parsed only the cases it drove,
+      # so three suites pinned bodies `ApiErrorSchema` rejects with CI green.
+      # Maintainer ruling 2026-08-12: option B, delivered as a GATE rather than
+      # a sweep — a one-time sweep is a snapshot that decays, and "an unswept
+      # producer just re-opens the hole". The scan finds every site stamping a
+      # code the ledger does not know; the declared table
+      # (packages/runtime/src/dispatcher-error-vocabulary.ts) records the verdict
+      # WITH its evidence, because reachability is not decidable from source —
+      # a boot refusal and a live wire code are written identically. Reconciled
+      # in both directions, so a new producer fails AND a row whose code has
+      # since been registered fails (that is how the spec half, #8846, ratchets
+      # the list down). No `paths:` filter, deliberately: the producers live in
+      # any package, and the registered vocabulary lives in packages/spec.
+      # Runs its own --self-test first.
+      - name: Dispatcher error-code vocabulary guard
+        run: pnpm check:dispatcher-error-vocabulary
+
       # Namespace-wildcard fall-through guard (#4116). A handler mounted on
       # `<prefix>/*` claims the whole namespace, and Hono's first-registered
       # handler that answers wins — so a TERMINAL wildcard makes every other

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "check:route-envelope": "node scripts/check-route-envelope.mjs --self-test && node scripts/check-route-envelope.mjs",
     "check:error-code-casing": "node scripts/check-error-code-casing.mjs --self-test && node scripts/check-error-code-casing.mjs",
     "check:error-status-conformance": "node scripts/check-error-status-conformance.mjs --self-test && node scripts/check-error-status-conformance.mjs",
+    "check:dispatcher-error-vocabulary": "node scripts/check-dispatcher-error-vocabulary.mjs --self-test && node scripts/check-dispatcher-error-vocabulary.mjs",
     "check:wildcard-fallthrough": "node scripts/check-wildcard-fallthrough.mjs --self-test && node scripts/check-wildcard-fallthrough.mjs",
     "check:meta-type-normalized": "node scripts/check-meta-type-normalized.mjs --self-test && node scripts/check-meta-type-normalized.mjs",
     "check:filter-alias-parity": "node scripts/check-filter-alias-parity.mjs --self-test && node scripts/check-filter-alias-parity.mjs",

--- a/packages/runtime/src/dispatcher-error-vocabulary.ts
+++ b/packages/runtime/src/dispatcher-error-vocabulary.ts
@@ -1,0 +1,335 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The dispatcher door's declared `error.code` vocabulary (#8087).
+ *
+ * ## What this file is for
+ *
+ * ADR-0112 makes `error.code` a closed set — `ApiErrorSchema.code` parses
+ * against `ErrorCode` = `StandardErrorCode ∪ ERROR_CODE_LEDGER` — and the
+ * ledger's own note says an unregistered code "fails schema parse — which fails
+ * the envelope conformance suites — which fails CI. That friction is the
+ * point."
+ *
+ * The dispatcher door did not have that friction. `HttpDispatcher.errorFromThrown`
+ * puts `resolveThrownHttpError(e).declaredCode` — the producer's own string,
+ * verbatim and un-narrowed — straight into `error.code`, and its conformance
+ * suite parsed only the cases it happened to drive. So a producer emitting a
+ * code the ledger does not know produced a body that could never satisfy the
+ * schema it claims to satisfy, and nothing noticed.
+ *
+ * The maintainer ruling of 2026-08-12 chose **option B delivered as a gate**:
+ * parse every body the door emits, then register what the gate reports —
+ * rather than hand-registering the three known codes and trusting a sweep. This
+ * file is the gate's declaration half. `scripts/check-dispatcher-error-vocabulary.mjs`
+ * re-derives the same set from source on every CI run and fails when the two
+ * disagree, in EITHER direction:
+ *
+ *   - a code-stamping site the table does not classify  → a new unswept
+ *     producer; classify it (and register it, if it reaches a wire)
+ *   - a table row whose site is gone                    → stale row; delete it
+ *   - a `pending-registration` row whose code HAS been registered → the row's
+ *     job is done; delete it (this is how #8846 landing ratchets the list down)
+ *
+ * ## Why the table is declared rather than inferred
+ *
+ * Whether a thrown value reaches an HTTP response envelope is a reachability
+ * question, and no source scan decides it: `MEMORY_MULTI_TENANT_UNSUPPORTED` is
+ * stamped exactly like `FLOW_FAILED` and one of them is a boot refusal the CLI
+ * rethrows pre-HTTP. So the scan REPORTS sites and this table RECORDS the
+ * verdict with its reason — the same shape `check-route-envelope`'s module
+ * table uses, and for the same reason: silently applying a default to an
+ * unknown site is what lets a real emitter hide.
+ *
+ * A site the scan finds and the table does not carry is an ERROR, never a
+ * default. That is the ratchet — an unswept producer added next month reddens
+ * CI instead of silently re-opening the hole.
+ *
+ * ## Scope — this table classifies, it does not register
+ *
+ * Registering a code widens the accepted set (`ApiErrorSchema.code` parses
+ * against the union), which is a contract-semantics change owned by the
+ * `packages/spec` lane. The `pending-registration` rows below are the input to
+ * **#8846**, which is `Blocked-by:` this card. ⛔ Nothing here edits the ledger.
+ */
+
+/** How the code literal is written at the site — what the scanner matched. */
+export type CodeStampShape =
+    /** `err.code = 'X'` — stamped onto a value about to be thrown. */
+    | 'assign'
+    /** `readonly code = 'X'` — an error class's own identity. */
+    | 'classfield'
+    /** `readonly code = CONST` — the same, through a resolved constant. */
+    | 'classconst'
+    /** `code: 'X'` in an object literal. */
+    | 'objlit';
+
+/**
+ * Where the stamped code can end up. `dispatcher` is the door this card is
+ * about; `rest` is the direct-mount registrar, whose own `sendError` overload
+ * (`packages/rest/src/error-response.ts`, `error: any`) does NOT narrow;
+ * `none` means the value never reaches an HTTP error envelope at all.
+ */
+export type CodeDoor = 'dispatcher' | 'rest' | 'none';
+
+export type CodeVerdict =
+    /**
+     * Reaches a wire `error.code` verbatim and the ledger does not know it.
+     * The body cannot parse. ⇒ #8846's registration input.
+     */
+    | 'pending-registration'
+    /**
+     * Authored OUTSIDE the platform — a metadata app's action code, carried
+     * across the sandbox boundary deliberately (#7867). No ledger can enumerate
+     * it; see the note on `SANDBOX_AUTHORED_LIMB` below.
+     */
+    | 'sandbox-authored'
+    /**
+     * Belongs to a different vocabulary that merely spells itself `code` — a
+     * Node errno, a driver errno, an automation RESULT envelope. Not an
+     * ADR-0112 `error.code` and not the ledger's business (ADR-0112 D6/D6c
+     * draw the same line for field-level and diagnostic codes).
+     */
+    | 'foreign-vocabulary'
+    /**
+     * A refusal raised before any HTTP boundary exists — the CLI rethrows it
+     * and aborts. The ledger's own note ratifies this class by name:
+     * `MONGODB_MULTI_TENANT_UNSUPPORTED` was UNregistered by #8035 for exactly
+     * this reason, and "host boot matching is not wire vocabulary".
+     */
+    | 'boot-refusal';
+
+export interface UnregisteredCodeSite {
+    /** The literal as it is stamped. */
+    readonly code: string;
+    /** Repo-relative file. No line number — line numbers rot, files do not. */
+    readonly file: string;
+    readonly shape: CodeStampShape;
+    readonly door: CodeDoor;
+    readonly verdict: CodeVerdict;
+    /** Why this verdict — the evidence, not a restatement of the verdict. */
+    readonly why: string;
+}
+
+/**
+ * Every site where a code the ledger does not know is stamped onto a value,
+ * measured over `packages/**` non-test source and classified.
+ *
+ * MEASURED, not chosen. Re-derive with:
+ *   node scripts/check-dispatcher-error-vocabulary.mjs --report
+ */
+export const UNREGISTERED_CODE_SITES: readonly UnregisteredCodeSite[] = [
+    // ── pending registration: real producers, real wire, unknown to the ledger ──
+    {
+        code: 'FLOW_FAILED',
+        file: 'packages/runtime/src/action-execution.ts',
+        shape: 'assign',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why:
+            'A flow that RAN and rejected is tagged `status 400` + `code FLOW_FAILED` here (#3962) so ' +
+            'callers can branch on it, and `/actions` serves that throw through `errorFromThrown`. ' +
+            'One of the three codes this card was filed for, and the only one of the three with a ' +
+            'producer. Owning package for the ledger row: @objectstack/runtime.',
+    },
+    {
+        code: 'QUERY_OBJECT_MISMATCH',
+        file: 'packages/metadata-protocol/src/protocol.ts',
+        shape: 'assign',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why:
+            'Stamped onto a thrown error in the protocol layer; `/meta` and `/packages` both serve ' +
+            'protocol throws through `errorFromThrown`. Owning package: @objectstack/metadata-protocol.',
+    },
+    {
+        code: 'ERR_AUTONUMBER_COLLISION',
+        file: 'packages/objectql/src/engine.ts',
+        shape: 'objlit',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why:
+            "Thrown by the single-row insert path after the counter was re-seeded and re-issued and the " +
+            'driver still refused. An unswept member of a family the ledger already registers for this ' +
+            'package (ERR_DRIVER_CONNECT, ERR_DATASOURCE_UNAVAILABLE, ERR_READONLY_FIELD_REJECTED, ' +
+            'ERR_SUMMARY_RECOMPUTE, ERR_BULK_RESULT_MISMATCH). Owning package: @objectstack/objectql.',
+    },
+    {
+        code: 'ERR_TRANSACTION_UNSUPPORTED',
+        file: 'packages/objectql/src/transaction-errors.ts',
+        shape: 'classfield',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why:
+            'Error-class identity, thrown to the caller; reaches the door through any domain that runs a ' +
+            'transaction. Same unswept ERR_* family as above. Owning package: @objectstack/objectql.',
+    },
+    {
+        code: 'ERR_CROSS_DATASOURCE_TRANSACTION_WRITE',
+        file: 'packages/objectql/src/transaction-errors.ts',
+        shape: 'classfield',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why: 'Sibling of ERR_TRANSACTION_UNSUPPORTED in the same module and the same family.',
+    },
+    {
+        code: 'ERR_HOOK_TARGET_REBIND',
+        file: 'packages/objectql/src/hook-target-rebind-errors.ts',
+        shape: 'classconst',
+        door: 'dispatcher',
+        verdict: 'pending-registration',
+        why:
+            'Error-class identity via HOOK_TARGET_REBIND_ERROR_CODE; a hook refusal raised during a write ' +
+            'the dispatcher is serving. Same family. Owning package: @objectstack/objectql.',
+    },
+    {
+        code: 'FIELD_VISIBILITY_UNRESOLVED',
+        file: 'packages/rest/src/error-response.ts',
+        shape: 'objlit',
+        door: 'rest',
+        verdict: 'pending-registration',
+        why:
+            "[ADR-0106 D6 tier 3] `sendFieldVisibilityFault` hands it to this module's OWN `sendError` " +
+            "overload (`error: any`), not to @objectstack/types' closed-`ErrorCode` one — so it reaches " +
+            'the REST wire at 503 un-narrowed. Reported here because the ledger is door-agnostic; the ' +
+            'REST door having the same hole is filed separately. Owning package: @objectstack/rest.',
+    },
+
+    // ── sandbox-authored: outside any ledger, by design ────────────────────
+    // (no source site — the producer is tenant code; see SANDBOX_AUTHORED_LIMB)
+
+    // ── foreign vocabularies: spelled `code`, not an ADR-0112 error.code ────
+    {
+        code: 'MODULE_NOT_FOUND',
+        file: 'packages/types/src/node.ts',
+        shape: 'objlit',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            "Node's own errno, synthesized so `isModuleNotFoundError` keeps answering true for a host " +
+            'import failure. Every caller classifies on it in-process; it names a module resolution ' +
+            'outcome, not a request refusal.',
+    },
+    {
+        code: 'INVALID_SCREEN_INPUT',
+        file: 'packages/services/service-automation/src/engine.ts',
+        shape: 'objlit',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            'RETURNED in an automation result envelope (`{ success: false, code, error }`), never thrown. ' +
+            'When a rejected run reaches the door, `action-execution.ts` converts the result into a ' +
+            'throw of its own carrying FLOW_FAILED — so this string is not what lands in `error.code`.',
+    },
+    {
+        code: 'IMPERSONATION_ROTATION_FAILED',
+        file: 'packages/plugins/plugin-auth/src/impersonation-bearer-rotation.ts',
+        shape: 'objlit',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            "better-auth's own `APIError` vocabulary, and it cannot reach this door: `domains/auth.ts` " +
+            'catches everything the auth service throws and answers `deps.error(INTERNAL_ERROR_MESSAGE, 500)` ' +
+            '— the message withheld UNCONDITIONALLY and the code status-derived, never `errorFromThrown` ' +
+            '(#5085). better-auth answers its own failures with a `Response` rather than by throwing, and ' +
+            'that body is returned untouched as `result`. So the string never lands in an ADR-0112 ' +
+            '`error.code`. This is the row that shows why verdicts are DECLARED: it is written exactly ' +
+            'like FLOW_FAILED and a documented catch one layer up makes it unreachable.',
+    },
+    {
+        code: 'SQLITE_ERROR',
+        file: 'packages/spec/src/migrations/entries/semantic/18.driver-sql-unresolvable-where-column-refused.ts',
+        shape: 'objlit',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why: "A SQLite driver errno quoted in a migration entry's before/after sample. Not a producer.",
+    },
+    {
+        code: 'SQLITE_ERROR',
+        file: 'packages/spec/src/migrations/registry.ts',
+        shape: 'objlit',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why: 'Same driver errno, same migration sample, carried in the registry index.',
+    },
+
+    // ── boot refusals: no HTTP boundary exists yet ─────────────────────────
+    {
+        code: 'MONGODB_MULTI_TENANT_UNSUPPORTED',
+        file: 'packages/drivers/driver-mongodb/src/mongodb-tenancy-guard.ts',
+        shape: 'classconst',
+        door: 'none',
+        verdict: 'boot-refusal',
+        why:
+            'The ledger note names this exact code as the class precedent: registered by #3724, ' +
+            'UNregistered by #8035 because the CLI rethrows it pre-HTTP and aborts. "Host boot matching ' +
+            'is not wire vocabulary." Its throw site and constant deliberately live on.',
+    },
+    {
+        code: 'MEMORY_MULTI_TENANT_UNSUPPORTED',
+        file: 'packages/drivers/driver-memory/src/memory-tenancy-guard.ts',
+        shape: 'classconst',
+        door: 'none',
+        verdict: 'boot-refusal',
+        why:
+            'The driver-memory twin of the row above — same guard shape, same MULTI_TENANT_UNSUPPORTED_CODE ' +
+            'constant name, same pre-HTTP abort. Ruled by the same #8035 reasoning.',
+    },
+];
+
+/**
+ * The codes #8846 has to register, deduped and sorted — the deliverable this
+ * card owes its downstream.
+ *
+ * ⚠️ This list is the OUTPUT of a measurement, not a wish: every member has a
+ * live producer and a door. It shrinks only by being registered.
+ */
+export const PENDING_LEDGER_REGISTRATION: readonly string[] = Object.freeze(
+    [...new Set(UNREGISTERED_CODE_SITES.filter((s) => s.verdict === 'pending-registration').map((s) => s.code))].sort(),
+);
+
+/** The subset that reaches the DISPATCHER door — what this card's suite drives. */
+export const PENDING_AT_DISPATCHER_DOOR: readonly string[] = Object.freeze(
+    [
+        ...new Set(
+            UNREGISTERED_CODE_SITES.filter((s) => s.verdict === 'pending-registration' && s.door === 'dispatcher').map(
+                (s) => s.code,
+            ),
+        ),
+    ].sort(),
+);
+
+/**
+ * ## The limb no ledger can close, measured while building this gate
+ *
+ * `SandboxError` carries a user action's own `.code` across the QuickJS
+ * boundary on purpose — "Author-thrown structured errors get the same
+ * treatment; nothing here is objectql-specific"
+ * (`sandbox/error-passthrough.test.ts`) — and `domains/actions.ts` serves that
+ * error through `errorFromThrown`, so the string lands in `error.code`
+ * verbatim. `domains/actions-validation-envelope.test.ts` pins exactly that,
+ * end to end, with `DUPLICATE`.
+ *
+ * So the dispatcher's `error.code` has a limb whose vocabulary is authored by
+ * TENANTS, in metadata apps, at runtime. Registration cannot close it: the
+ * ledger would have to enumerate strings that do not exist when CI runs. This
+ * is not an argument for option C (ruled inadmissible — the closure is
+ * load-bearing for every platform producer, and the six rows above are exactly
+ * what it catches); it is a bound on what "closed" can mean at THIS door, and
+ * it post-dates the ruling.
+ *
+ * ⛔ Deliberately NOT decided here — deciding it means either narrowing the
+ * sandbox boundary or declaring a second, non-ledger vocabulary for
+ * author-thrown codes, and both are contract-shaped. Reported to #8087 /
+ * #8846 rather than guessed at.
+ *
+ * `DUPLICATE` is the pinned witness, so it is named here rather than left as an
+ * un-owned literal in a test — and it is deliberately NOT re-spelled to a
+ * registered code, because re-spelling it would delete the only evidence in the
+ * repo that this limb is open.
+ */
+export const SANDBOX_AUTHORED_LIMB = Object.freeze({
+    witness: 'DUPLICATE',
+    pinnedBy: 'packages/runtime/src/domains/actions-validation-envelope.test.ts',
+    boundary: 'packages/runtime/src/sandbox/quickjs-runner.ts',
+});

--- a/packages/runtime/src/dispatcher-validation-error.test.ts
+++ b/packages/runtime/src/dispatcher-validation-error.test.ts
@@ -173,16 +173,30 @@ describe('#3918 — HttpDispatcher.errorFromThrown maps VALIDATION_FAILED', () =
         // Anti-regression for the #3867 tier this sits next to: an ordinary
         // throw still takes the caller's 500 fallback and its `issues`/`code`
         // details shape.
+        // [#8087] The vehicle was `STORAGE_FAILURE`, which no producer in this
+        // repo emits — the fixture invented it — and which the ledger therefore
+        // does not register, so this pin asserted a body `ApiErrorSchema`
+        // rejects. Collapsed to `DATABASE_ERROR`, a StandardErrorCode: the
+        // producer here is `metadata-protocol`, whose vocabulary IS
+        // ledger-governed, so an unregistered string was a fixture bug rather
+        // than a wire value worth keeping.
+        //
+        // Deliberately NOT the status-derived code: 500 derives `INTERNAL_ERROR`
+        // (`standardErrorCodeForHttpStatus`), so using it would make the
+        // assertion below pass whether the code was promoted or merely derived
+        // — a green test over nothing. `DATABASE_ERROR` is registered AND
+        // distinct from the derived one, so the pin still proves what it was
+        // written to prove: the producer's own code wins.
         const err = Object.assign(new Error('publish backend unavailable'), {
-            code: 'STORAGE_FAILURE',
+            code: 'DATABASE_ERROR',
             issues: [{ path: 'a', message: 'b', code: 'c' }],
         });
         const res = await publishPackage(err);
 
         expect(res.status).toBe(500);
-        // [#3842] `STORAGE_FAILURE` is the error's own code and now reaches the
-        // declared field instead of `details`; `issues` stays context.
-        expect(res.body.error.code).toBe('STORAGE_FAILURE');
+        // [#3842] the error's own code reaches the declared field instead of
+        // `details`; `issues` stays context.
+        expect(res.body.error.code).toBe('DATABASE_ERROR');
         expect(res.body.error.details).toEqual({
             issues: [{ path: 'a', message: 'b', code: 'c' }],
         });

--- a/packages/runtime/src/error-envelope.conformance.test.ts
+++ b/packages/runtime/src/error-envelope.conformance.test.ts
@@ -235,7 +235,10 @@ describe('#8087 — every code the dispatcher door can emit is parsed against Ap
         // every per-code assertion below would vacuously pass and this suite
         // would go quiet exactly when it had the most to say.
         expect(PENDING_AT_DISPATCHER_DOOR.length).toBeGreaterThan(0);
-        expect(PENDING_LEDGER_REGISTRATION).toEqual(expect.arrayContaining(PENDING_AT_DISPATCHER_DOOR));
+        // Spread: both lists are `readonly string[]`, and `arrayContaining`
+        // takes a mutable one — passing the frozen list straight in is a tsc
+        // error that only the TEST_DEBT ratchet would have caught.
+        expect(PENDING_LEDGER_REGISTRATION).toEqual(expect.arrayContaining([...PENDING_AT_DISPATCHER_DOOR]));
     });
 
     for (const code of PENDING_AT_DISPATCHER_DOOR) {

--- a/packages/runtime/src/error-envelope.conformance.test.ts
+++ b/packages/runtime/src/error-envelope.conformance.test.ts
@@ -27,9 +27,22 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { ApiErrorSchema, BaseResponseSchema, DispatcherErrorCode, envelopeViolations } from '@objectstack/spec/api';
+import {
+    ApiErrorSchema,
+    BaseResponseSchema,
+    DispatcherErrorCode,
+    ErrorCode,
+    envelopeViolations,
+    standardErrorCodeForHttpStatus,
+} from '@objectstack/spec/api';
 import { HttpDispatcher } from './http-dispatcher.js';
 import { buildApiError, splitSemanticCode } from './error-envelope.js';
+import {
+    PENDING_AT_DISPATCHER_DOOR,
+    PENDING_LEDGER_REGISTRATION,
+    SANDBOX_AUTHORED_LIMB,
+    UNREGISTERED_CODE_SITES,
+} from './dispatcher-error-vocabulary.js';
 
 /** Minimal kernel — these branches fail before any service is reached. */
 function makeDispatcher(kernel: any = { context: { getService: () => null } }) {
@@ -190,6 +203,128 @@ describe('#3842 — every dispatcher error exit answers in the declared envelope
         expect(result.response?.headers).toEqual({ Allow: 'GET' });
         const error = expectConformantError(result.response);
         expect(error.code).toBe('METHOD_NOT_ALLOWED');
+    });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * [#8087] Direction 3 — the vocabulary, not just the cases this file drives
+ *
+ * The suite above parses the bodies it DRIVES, which is how three suites came
+ * to pin bodies `ApiErrorSchema` rejects without anything noticing: a
+ * conformance suite can only ever cover the branches that existed the day it
+ * was written. `check:dispatcher-error-vocabulary` derives the whole set of
+ * codes this door can emit from source; this block drives every
+ * dispatcher-reachable member of that derivation through the REAL builder and
+ * parses the result.
+ *
+ * That is the "parse EVERY body it emits" half of the maintainer ruling
+ * (2026-08-12, option B as a gate) — the gate finds the set, and this asserts
+ * on it, so a producer added next month is driven here without anyone adding
+ * a case for it.
+ * ──────────────────────────────────────────────────────────────────────────── */
+describe('#8087 — every code the dispatcher door can emit is parsed against ApiErrorSchema', () => {
+    /** The real error path: a producer throw, resolved and built exactly as production does. */
+    const emitFor = (code: string, status: number) =>
+        (makeDispatcher() as any).errorFromThrown(
+            Object.assign(new Error('a producer refused'), { code, status }),
+            500,
+        );
+
+    it('drives a code from the derivation rather than a list written by hand', () => {
+        // Guards the wiring itself: if the derivation ever produced nothing,
+        // every per-code assertion below would vacuously pass and this suite
+        // would go quiet exactly when it had the most to say.
+        expect(PENDING_AT_DISPATCHER_DOOR.length).toBeGreaterThan(0);
+        expect(PENDING_LEDGER_REGISTRATION).toEqual(expect.arrayContaining(PENDING_AT_DISPATCHER_DOOR));
+    });
+
+    for (const code of PENDING_AT_DISPATCHER_DOOR) {
+        it(`'${code}' reaches the wire verbatim, and ApiErrorSchema rejects it on \`code\` alone`, () => {
+            const response = emitFor(code, 500);
+
+            // Verbatim — option B was ruled, so the door does NOT narrow. A
+            // failure here means someone quietly implemented option A.
+            expect(response.body.error.code).toBe(code);
+
+            // The body is STRUCTURALLY conformant — right envelope, status
+            // mirrored, `details` context only — so the one thing standing
+            // between it and its declared schema is the missing ledger row.
+            // That is precisely the claim handed to #8846.
+            expect(envelopeViolations(response.body)).toEqual([]);
+            expect(response.body.success).toBe(false);
+            expect(response.body.error.httpStatus).toBe(response.status);
+
+            const parsed = ApiErrorSchema.safeParse(response.body.error);
+            expect(parsed.success).toBe(false);
+            // Rejected on `code` and nothing else — an entry that failed for a
+            // second reason would be a different defect wearing this one's label.
+            expect([...new Set((parsed.error?.issues ?? []).map((i) => i.path.join('.')))]).toEqual(['code']);
+
+            // MEASURED while writing this: the damage is not confined to the
+            // nested error object. `BaseResponseSchema` embeds `ApiErrorSchema`,
+            // so the WHOLE response body fails to parse — one unregistered
+            // string invalidates the envelope every consumer validates against,
+            // for the same single reason and no other.
+            const envelope = BaseResponseSchema.safeParse(response.body);
+            expect(envelope.success).toBe(false);
+            expect([...new Set((envelope.error?.issues ?? []).map((i) => i.path.join('.')))]).toEqual(['error.code']);
+        });
+    }
+
+    it('the same drive with a REGISTERED code is fully conformant — the control', () => {
+        // Without this, "ApiErrorSchema rejects it" above would also be
+        // satisfied by a builder that emits a broken envelope for everything.
+        const error = expectConformantError(emitFor('DATABASE_ERROR', 500));
+        expect(error.code).toBe('DATABASE_ERROR');
+        // And not merely the status-derived answer — 500 derives INTERNAL_ERROR,
+        // so this proves the producer's code was carried, not invented.
+        expect(standardErrorCodeForHttpStatus(500)).not.toBe('DATABASE_ERROR');
+    });
+
+    it('every pending code is still unregistered — the row comes out when #8846 lands', () => {
+        // The ratchet's test-side half. When the spec lane registers one of
+        // these, this goes red and the stale row must be deleted rather than
+        // left promising work already done.
+        for (const code of PENDING_LEDGER_REGISTRATION) {
+            expect(ErrorCode.safeParse(code).success, `${code} is registered now — drop its row`).toBe(false);
+        }
+    });
+
+    it('the status-derived limb cannot produce an unregistered code, by construction', () => {
+        // The third limb of `buildApiError`'s precedence needs no ledger row and
+        // no gate: `standardErrorCodeForHttpStatus` returns a StandardErrorCode
+        // for every input, so a branch that spells no code of its own is always
+        // parseable. Asserted rather than assumed, across the bands the
+        // dispatcher actually answers with.
+        for (const status of [400, 401, 403, 404, 405, 409, 415, 422, 428, 429, 500, 501, 503, 504, 507]) {
+            const derived = standardErrorCodeForHttpStatus(status);
+            expect(ErrorCode.safeParse(derived).success, `${status} derived an unregistered ${derived}`).toBe(true);
+        }
+    });
+
+    it('records the sandbox limb as open rather than pretending the door is closed', () => {
+        // `SandboxError` carries a metadata app's OWN `.code` across the QuickJS
+        // boundary on purpose (#7867), and `domains/actions.ts` serves it through
+        // `errorFromThrown`. So this door's vocabulary has a limb authored by
+        // tenants at runtime, which no ledger can enumerate — the honest bound on
+        // what "closed" can mean here, and the reason the witness below is NOT
+        // re-spelled to a registered code.
+        const witness = SANDBOX_AUTHORED_LIMB.witness;
+        expect(ErrorCode.safeParse(witness).success).toBe(false);
+        expect(emitFor(witness, 400).body.error.code).toBe(witness);
+        // It is deliberately absent from the registration hand-off: registering
+        // it would close nothing, since the next app picks a different string.
+        expect(PENDING_LEDGER_REGISTRATION).not.toContain(witness);
+    });
+
+    it('classifies every derived site — no verdict is left to a default', () => {
+        for (const site of UNREGISTERED_CODE_SITES) {
+            expect(site.why.length, `${site.code} at ${site.file} carries no evidence`).toBeGreaterThan(40);
+            // A site that reaches a door must be on its way to a ledger row;
+            // anything else must say which non-wire vocabulary it belongs to.
+            if (site.door !== 'none') expect(site.verdict).toBe('pending-registration');
+            else expect(site.verdict).not.toBe('pending-registration');
+        }
     });
 });
 

--- a/packages/runtime/src/http-dispatcher.error-leak.test.ts
+++ b/packages/runtime/src/http-dispatcher.error-leak.test.ts
@@ -106,16 +106,22 @@ describe('#3867 follow-up — HttpDispatcher.error() does not return raw driver 
         // The semantic code and the per-field `issues` the UI maps back to inputs
         // are never free-form driver prose, so the 5xx guard must not touch them
         // — it only ever replaces `message`.
+        // [#8087] Was `STORAGE_FAILURE` — a code the fixture invented, that no
+        // producer emits and the ledger does not register, so the pinned body
+        // could never satisfy `ApiErrorSchema`. `DATABASE_ERROR` is a
+        // StandardErrorCode and is NOT what 500 derives (`INTERNAL_ERROR`), so
+        // the assertion still distinguishes "promoted from the throw" from
+        // "derived from the status". See dispatcher-error-vocabulary.ts.
         const err = Object.assign(new Error(SQL_DUMP), {
             status: 500,
-            code: 'STORAGE_FAILURE',
+            code: 'DATABASE_ERROR',
             issues: [{ path: 'name', message: 'taken', code: 'duplicate' }],
         });
         const result: any = await putMeta(err);
 
         expect(result.response.body.error.message).toBe('Internal server error');
         // [#3842] The code is in the declared field; `details` keeps the issues.
-        expect(result.response.body.error.code).toBe('STORAGE_FAILURE');
+        expect(result.response.body.error.code).toBe('DATABASE_ERROR');
         expect(result.response.body.error.details).toMatchObject({
             issues: [{ path: 'name', message: 'taken', code: 'duplicate' }],
         });

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -760,13 +760,20 @@ export class HttpDispatcher {
      */
     private errorFromThrown(e: any, fallbackStatus = 500) {
         const thrown = resolveThrownHttpError(e, fallbackStatus);
-        // `declaredCode`, NOT the narrowed `code`: this door's `error.code` is
-        // not closed in practice and three suites pin that — `STORAGE_FAILURE`,
-        // `FLOW_FAILED` and `DUPLICATE` are all unregistered and all expected on
-        // the wire verbatim. The REST door takes the narrowed spelling because
-        // its own conformance suite parses its bodies against the ledger. Both
-        // spellings come from the one resolver, so the difference is a stated
-        // one; see its module note.
+        // `declaredCode`, NOT the narrowed `code`: this door puts a producer's
+        // own string on the wire. The REST door takes the narrowed spelling
+        // because its own conformance suite parses its bodies against the
+        // ledger. Both spellings come from the one resolver, so the difference
+        // is a stated one; see its module note.
+        //
+        // [#8087] Ruled option B (maintainer, 2026-08-12): the verbatim spelling
+        // STAYS, and the set of producers emitting codes the ledger does not
+        // know is now measured and gated rather than named in a comment that
+        // rots — `./dispatcher-error-vocabulary.ts` carries the classified list
+        // and `pnpm check:dispatcher-error-vocabulary` fails on an unswept
+        // producer added later. `error-envelope.conformance.test.ts` drives
+        // every dispatcher-reachable member of that list through this method and
+        // parses the body, which is the "parse every body it emits" half.
         return this.error(thrown.message, thrown.status, thrown.details, thrown.declaredCode);
     }
 

--- a/packages/runtime/src/package-door-error-parity.test.ts
+++ b/packages/runtime/src/package-door-error-parity.test.ts
@@ -127,17 +127,29 @@ describe('#8016 — the dispatcher package door answers the shared mapping', () 
      * The one place the two doors' codes differ, pinned so it stays a stated
      * difference rather than a drift.
      *
-     * This door puts a producer's code on the wire verbatim — `STORAGE_FAILURE`,
-     * `FLOW_FAILED` and `DUPLICATE` are all outside
-     * `StandardErrorCode ∪ ERROR_CODE_LEDGER` and all pinned by existing suites
-     * here. The REST door cannot: `sendError` takes the closed `ErrorCode`, and
-     * that door's conformance suite parses its bodies against the ledger, so an
-     * unregistered code there is a failing test rather than a wire answer.
+     * This door puts a producer's code on the wire verbatim. The REST door
+     * cannot: `@objectstack/types`' `sendError` takes the closed `ErrorCode`,
+     * and that door's conformance suite parses its bodies against the ledger, so
+     * an unregistered code there is a failing test rather than a wire answer.
      *
-     * The STATUS agrees either way, which is what #8016 was about. Whether this
-     * door's `error.code` should be closed too is a live contract question
-     * (`ApiErrorSchema` would reject these bodies) and is filed separately — it
-     * is not a decision this fix took.
+     * The STATUS agrees either way, which is what #8016 was about.
+     *
+     * [#8087] The three codes this comment used to name are no longer one list.
+     * The maintainer ruled option B — keep the verbatim spelling, and make the
+     * set of unregistered producers a MEASURED, gated one instead of a
+     * hand-maintained sentence that goes stale (this one had):
+     *
+     *   - `FLOW_FAILED` has a real producer and is awaiting a ledger entry
+     *     (#8846); it stays verbatim, which is the whole point of option B.
+     *   - `STORAGE_FAILURE` had no producer anywhere — two fixtures invented it
+     *     — so it was collapsed to a registered code rather than registered.
+     *   - `DUPLICATE` is AUTHOR-thrown: it crosses the sandbox boundary from a
+     *     metadata app's own action code, so no ledger can enumerate it.
+     *
+     * `packages/runtime/src/dispatcher-error-vocabulary.ts` is the live list and
+     * `pnpm check:dispatcher-error-vocabulary` keeps it honest. The vehicle
+     * below stays a deliberately unregistered string, because what this case
+     * pins is the SPELLING DIFFERENCE, not any particular producer.
      */
     it('an unregistered code reaches this door verbatim, and the narrowed spelling differs', () => {
         const error = thrown('dialect', { status: 409, code: 'PACKAGE_IS_HAUNTED' });

--- a/packages/types/src/thrown-http-error.ts
+++ b/packages/types/src/thrown-http-error.ts
@@ -43,10 +43,16 @@
  *
  * {@link ThrownHttpError.declaredCode} is the producer's own string, verbatim
  * and un-narrowed, which is what the dispatcher door has always put on the
- * wire — `STORAGE_FAILURE`, `FLOW_FAILED` and `DUPLICATE` are all unregistered
- * and all pinned by existing dispatcher tests. Narrowing it here would rewrite
- * a behaviour three suites assert, which is a contract decision (should the
- * dispatcher's `error.code` be closed too?) and not this function's to take.
+ * wire.
+ *
+ * [#8087] That contract question — should the dispatcher's `error.code` be
+ * closed too? — has since been ruled: **option B**, keep the verbatim spelling
+ * and register the producers, delivered as a GATE rather than a one-time sweep
+ * (maintainer, 2026-08-12). So `declaredCode` stays exactly as it is; what
+ * changed is that the unregistered producers are now measured and classified
+ * (`packages/runtime/src/dispatcher-error-vocabulary.ts`,
+ * `pnpm check:dispatcher-error-vocabulary`) instead of being named in prose
+ * here. Narrowing this spelling would be option A, which was NOT ruled.
  *
  * So the doors agree on **status** unconditionally and on **code** for every
  * registered code, and differ only where a producer emits a code the ledger

--- a/scripts/check-dispatcher-error-vocabulary.mjs
+++ b/scripts/check-dispatcher-error-vocabulary.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Dispatcher error-code vocabulary gate (#8087, ADR-0112).
+ *
+ *   node scripts/check-dispatcher-error-vocabulary.mjs
+ *   node scripts/check-dispatcher-error-vocabulary.mjs --self-test
+ *   node scripts/check-dispatcher-error-vocabulary.mjs --report   # print the derivation
+ *
+ * ## What it guards
+ *
+ * `ApiErrorSchema.code` parses against `ErrorCode` = `StandardErrorCode` ∪
+ * `ERROR_CODE_LEDGER`, and the ledger's own note says an unregistered code
+ * "fails schema parse — which fails the envelope conformance suites — which
+ * fails CI. That friction is the point."
+ *
+ * The dispatcher door had no such friction. `HttpDispatcher.errorFromThrown`
+ * puts `resolveThrownHttpError(e).declaredCode` — the producer's own string,
+ * un-narrowed — into `error.code`, and its conformance suite parsed only the
+ * handful of cases it drove. Three suites pinned bodies `ApiErrorSchema` would
+ * reject and CI stayed green.
+ *
+ * The maintainer ruling of 2026-08-12 chose option B **delivered as a gate**:
+ * parse every body the door emits, then register what the gate reports. This is
+ * the finding half. `packages/runtime/src/dispatcher-error-vocabulary.ts` is the
+ * declaration half; `error-envelope.conformance.test.ts` drives every code this
+ * gate classifies as dispatcher-reachable through the real builder and parses
+ * the body.
+ *
+ * ## Why a scan plus a declared table, rather than either alone
+ *
+ * A scan alone cannot answer the question that matters. Whether a stamped code
+ * reaches an HTTP response envelope is REACHABILITY, and the two ends of that
+ * question are written identically in source: `MEMORY_MULTI_TENANT_UNSUPPORTED`
+ * and `FLOW_FAILED` are both `code` on a thrown value, and one of them is a boot
+ * refusal the CLI rethrows before any HTTP boundary exists. Inferring a default
+ * for an unknown site is exactly how a real emitter hides.
+ *
+ * A table alone is a snapshot that starts decaying the moment it lands — the
+ * card's own objection to a one-time sweep ("an unswept producer just re-opens
+ * the hole").
+ *
+ * So: the scan finds sites, the table records verdicts with evidence, and the
+ * two are reconciled in BOTH directions. A site the table does not carry fails.
+ * A table row whose site is gone fails. A `pending-registration` row whose code
+ * has since been registered fails — which is how #8846 landing ratchets this
+ * list down instead of leaving stale rows promising work already done.
+ *
+ * ## Why textual, not AST
+ *
+ * The same reasoning `check-error-code-casing` records: the failure mode is a
+ * string literal in one of a handful of syntactic positions, and the positions
+ * are more varied than an AST shape for "the value of an error's code property"
+ * would cover (class field, constructor-side object literal, post-hoc
+ * assignment, a constant one module over). The four shapes below are published
+ * rather than left inside the implementation, and `--self-test` pins each one —
+ * because the price of a source scan is that it sees only the spellings it
+ * knows, and an unrecognised one produces no finding, SILENTLY. Reaching for a
+ * spelling that is not here? Extend `SHAPES` and add a `--self-test` case in the
+ * same edit.
+ *
+ * ## Declared bounds — printed on every run, so a partial gate cannot read as a
+ * ## complete one
+ *
+ *   - Scanned: `packages/**` non-test TypeScript source. Not `apps/`, not
+ *     `examples/`, not tests — a test that CONSTRUCTS a code is not a producer
+ *     (the ledger's own rule, and #4984's phantom-check family).
+ *   - Reported: only codes the registered vocabulary does NOT contain. A
+ *     registered code is by construction parseable, whatever door it reaches.
+ *   - Only SCREAMING_SNAKE literals. Lowercase code literals are a different
+ *     defect with its own gate (`check:error-code-casing`, ADR-0112 D6/D6b/D6c).
+ *   - A constant this gate cannot resolve is REPORTED as unresolved, never
+ *     dropped: a deriver that goes quietly blind is the same failure one layer
+ *     down.
+ *   - The sandbox limb is OUT of this scan's reach by construction — a metadata
+ *     app's action code is authored at runtime, not in this repo. See
+ *     `SANDBOX_AUTHORED_LIMB` in the declaration file.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative, dirname, resolve } from 'node:path';
+
+const ROOT = resolve(new URL('..', import.meta.url).pathname);
+const SCAN_ROOT = 'packages';
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.turbo', 'coverage', 'build']);
+
+const LEDGER_ZOD = 'packages/spec/src/api/error-code-ledger.zod.ts';
+const ERRORS_ZOD = 'packages/spec/src/api/errors.zod.ts';
+const DECLARATION = 'packages/runtime/src/dispatcher-error-vocabulary.ts';
+
+// ---------------------------------------------------------------------------
+// The registered vocabulary — read from spec SOURCE, never from a build
+// ---------------------------------------------------------------------------
+
+/**
+ * `ERROR_CODE_LEDGER`'s members. Anchored on the declaration and its
+ * `} as const` terminator rather than scanning the whole file, so the prose
+ * above it (which quotes retired codes by name) cannot leak in.
+ */
+export function parseLedgerCodes(source) {
+  const start = source.indexOf('export const ERROR_CODE_LEDGER');
+  if (start < 0) throw new Error(`${LEDGER_ZOD}: ERROR_CODE_LEDGER not found — the deriver's anchor moved.`);
+  const body = source.slice(start);
+  const end = body.indexOf('\n} as const');
+  if (end < 0) throw new Error(`${LEDGER_ZOD}: ERROR_CODE_LEDGER terminator not found — the deriver's anchor moved.`);
+  return new Set([...body.slice(0, end).matchAll(/'([A-Z][A-Z0-9_]*)'/g)].map((m) => m[1]));
+}
+
+/** `StandardErrorCode`'s members. */
+export function parseStandardCodes(source) {
+  const block = /export const StandardErrorCode = z\.enum\(\[([\s\S]*?)\]\)/.exec(source);
+  if (!block) throw new Error(`${ERRORS_ZOD}: StandardErrorCode enum not found — the deriver's anchor moved.`);
+  return new Set([...block[1].matchAll(/'([A-Z][A-Z0-9_]*)'/g)].map((m) => m[1]));
+}
+
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+/** Comments stripped: prose naming a retired code is not a producer. */
+export function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+/**
+ * The recognised ways this repo stamps a semantic code onto a value.
+ * PUBLISHED, and each pinned by `--self-test`. See the header on why.
+ */
+export const SHAPES = [
+  // `err.code = 'X'` — stamped onto a value about to be thrown.
+  { name: 'assign', re: /(?:^|[^\w.$])[\w$]+\.code\s*=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+  // `readonly code = 'X'` / `readonly code: T = 'X'` — an error class's identity.
+  { name: 'classfield', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+  // `readonly code = CONST` — the same, one indirection away.
+  { name: 'classconst', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*([A-Z][A-Z0-9_]*)\s*[;,\n]/g, literal: false },
+  // `code: 'X'` in an object literal (constructor options, Object.assign, a
+  // returned envelope). The broadest shape, and the reason verdicts exist:
+  // plenty of these are not wire codes at all.
+  { name: 'objlit', re: /\bcode:\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+];
+
+const isTestFile = (rel) =>
+  /\.(test|spec)\.[cm]?tsx?$/.test(rel) || /(^|\/)(__tests__|__mocks__|fixtures)\//.test(rel);
+
+/**
+ * The declaration file is a TABLE ABOUT producers, not a producer: every row
+ * spells `code: 'X'` for a code stamped somewhere else, so scanning it makes the
+ * gate rediscover its own contents as thirteen brand-new findings in the file
+ * that classifies them. Excluded by path, and pinned by `--self-test` so the
+ * exclusion cannot be widened into a blanket ignore that hides a real emitter.
+ */
+const isDeclarationFile = (rel) => rel === DECLARATION;
+
+export function* walkSources(dir, root) {
+  for (const entry of readdirSync(dir).sort()) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      yield* walkSources(abs, root);
+      continue;
+    }
+    if (!/\.[cm]?tsx?$/.test(entry) || /\.d\.[cm]?ts$/.test(entry)) continue;
+    const rel = relative(root, abs).replace(/\\/g, '/');
+    if (isTestFile(rel) || isDeclarationFile(rel)) continue;
+    yield { rel, abs };
+  }
+}
+
+/**
+ * Resolve `NAME` to its string value: the declaring file first, then the module
+ * it is imported from. Two packages export a `MULTI_TENANT_UNSUPPORTED_CODE`
+ * with DIFFERENT values, so a repo-wide name lookup would answer confidently
+ * and wrongly — the in-file declaration has to win, and the import has to be
+ * followed to its own file rather than guessed.
+ *
+ * Returns `null` when it cannot be resolved; the caller reports that, never
+ * drops it.
+ */
+export function resolveConstant(name, fileSource, fileRel, readFile) {
+  const local = new RegExp(`\\b(?:export\\s+)?const\\s+${name}\\s*(?::[^=]+)?=\\s*'([A-Za-z][A-Za-z0-9_]*)'`).exec(
+    fileSource,
+  );
+  if (local) return local[1];
+
+  // `import { A, NAME, B } from './x.js'` — find the specifier that names it.
+  const imports = [...fileSource.matchAll(/import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*'([^']+)'/g)];
+  for (const [, clause, spec] of imports) {
+    const named = clause.split(',').map((s) => s.trim().split(/\s+as\s+/)[0].trim());
+    if (!named.includes(name)) continue;
+    if (!spec.startsWith('.')) return null; // a dependency's constant — out of scan reach
+    const base = join(dirname(fileRel), spec.replace(/\.[cm]?js$/, ''));
+    for (const cand of [`${base}.ts`, `${base}.mts`, `${base}/index.ts`]) {
+      const abs = join(ROOT, cand);
+      if (!existsSync(abs)) continue;
+      const target = stripComments(readFile(abs));
+      const hit = new RegExp(
+        `\\bexport\\s+const\\s+${name}\\s*(?::[^=]+)?=\\s*'([A-Za-z][A-Za-z0-9_]*)'`,
+      ).exec(target);
+      if (hit) return hit[1];
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Every site in scanned source that stamps a code the registered vocabulary
+ * does not contain.
+ */
+export function deriveSites({ registered, files, readFile }) {
+  const sites = [];
+  const unresolved = [];
+  for (const { rel, source } of files) {
+    const stripped = stripComments(source);
+    for (const shape of SHAPES) {
+      shape.re.lastIndex = 0;
+      for (const m of stripped.matchAll(shape.re)) {
+        let code = m[1];
+        if (!shape.literal) {
+          const value = resolveConstant(code, stripped, rel, readFile);
+          if (value === null) {
+            unresolved.push({ file: rel, shape: shape.name, constant: code });
+            continue;
+          }
+          code = value;
+        }
+        if (!/^[A-Z][A-Z0-9_]*$/.test(code)) continue; // lowercase → check:error-code-casing
+        if (registered.has(code)) continue;
+        if (sites.some((s) => s.code === code && s.file === rel && s.shape === shape.name)) continue;
+        sites.push({ code, file: rel, shape: shape.name });
+      }
+    }
+  }
+  sites.sort((a, b) => a.code.localeCompare(b.code) || a.file.localeCompare(b.file));
+  return { sites, unresolved };
+}
+
+// ---------------------------------------------------------------------------
+// The declaration
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the declared table out of the TypeScript source. Textual for the same
+ * reason the rest of this file is, and anchored on the array so the doc prose
+ * (which names codes) cannot leak in.
+ */
+export function parseDeclaration(source) {
+  const start = source.indexOf('export const UNREGISTERED_CODE_SITES');
+  if (start < 0) throw new Error(`${DECLARATION}: UNREGISTERED_CODE_SITES not found — the anchor moved.`);
+  const body = stripComments(source.slice(start));
+  const end = body.indexOf('\n];');
+  if (end < 0) throw new Error(`${DECLARATION}: UNREGISTERED_CODE_SITES terminator not found — the anchor moved.`);
+  const rows = [];
+  for (const entry of body.slice(0, end).split(/\}\s*,/)) {
+    const code = /\bcode:\s*'([^']+)'/.exec(entry);
+    const file = /\bfile:\s*'([^']+)'/.exec(entry);
+    const shape = /\bshape:\s*'([^']+)'/.exec(entry);
+    const door = /\bdoor:\s*'([^']+)'/.exec(entry);
+    const verdict = /\bverdict:\s*'([^']+)'/.exec(entry);
+    if (!code || !file || !shape || !door || !verdict) continue;
+    rows.push({
+      code: code[1],
+      file: file[1],
+      shape: shape[1],
+      door: door[1],
+      verdict: verdict[1],
+    });
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+const key = (s) => `${s.code}@${s.file}#${s.shape}`;
+
+export function reconcile({ sites, declared, registered, unresolved }) {
+  const findings = [];
+  const declaredByKey = new Map(declared.map((d) => [key(d), d]));
+  const siteKeys = new Set(sites.map(key));
+
+  for (const site of sites) {
+    if (declaredByKey.has(key(site))) continue;
+    findings.push({
+      kind: 'unclassified-site',
+      text:
+        `${site.file} stamps unregistered code '${site.code}' (${site.shape}) and ` +
+        `${DECLARATION} does not classify it.\n` +
+        `      Add a row with a verdict and its evidence. If it reaches a wire, the verdict is ` +
+        `'pending-registration' and the code belongs in #8846's ledger batch.`,
+    });
+  }
+
+  for (const row of declared) {
+    if (!siteKeys.has(key(row))) {
+      findings.push({
+        kind: 'stale-row',
+        text:
+          `${DECLARATION} declares '${row.code}' at ${row.file} (${row.shape}) but the scan no longer ` +
+          `finds it. The producer moved or went away — delete the row.`,
+      });
+    }
+    if (row.verdict === 'pending-registration' && registered.has(row.code)) {
+      findings.push({
+        kind: 'now-registered',
+        text:
+          `'${row.code}' is registered now — the row in ${DECLARATION} has done its job and must come ` +
+          `out. (This is the ratchet: #8846 landing a registration turns its row stale.)`,
+      });
+    }
+  }
+
+  for (const u of unresolved) {
+    findings.push({
+      kind: 'unresolved-constant',
+      text:
+        `${u.file}: the code constant '${u.constant}' (${u.shape}) could not be resolved to a literal. ` +
+        `Reported rather than dropped — see the header's bounds. Resolve it, or teach ` +
+        `resolveConstant() the spelling.`,
+    });
+  }
+
+  findings.sort((a, b) => a.kind.localeCompare(b.kind) || a.text.localeCompare(b.text));
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Self-test
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const fail = [];
+  const ok = (cond, what) => { if (!cond) fail.push(what); };
+
+  // Each published SHAPE matches what it claims to.
+  const samples = {
+    assign: `const err = new Error('x'); err.code = 'FLOW_FAILED'; throw err;`,
+    classfield: `class E extends Error { readonly code = 'ERR_X' as const; }`,
+    classconst: `const ERR_CONST = 'RESOLVED_ONE';\nclass E { readonly code = ERR_CONST; }`,
+    objlit: `throw Object.assign(new Error('x'), { code: 'OBJ_LIT_ONE' });`,
+  };
+  const registered = new Set(['ALREADY_REGISTERED']);
+  for (const [name, source] of Object.entries(samples)) {
+    const { sites } = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source }],
+      readFile: () => '',
+    });
+    ok(sites.some((s) => s.shape === name), `SHAPE '${name}' matched nothing in its own sample`);
+  }
+
+  // A resolved constant reports its VALUE, not the constant's name.
+  {
+    const { sites } = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source: samples.classconst }],
+      readFile: () => '',
+    });
+    ok(
+      sites.some((s) => s.code === 'RESOLVED_ONE'),
+      'classconst resolved to the constant name instead of its value',
+    );
+  }
+
+  // The in-file declaration WINS over an import of the same name — the
+  // two-drivers-one-constant-name case that a repo-wide lookup gets wrong.
+  {
+    const source = `import { MULTI_TENANT_UNSUPPORTED_CODE } from './other.js';\nexport const MULTI_TENANT_UNSUPPORTED_CODE = 'MEMORY_ONE';\nclass G { readonly code = MULTI_TENANT_UNSUPPORTED_CODE; }`;
+    const { sites } = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source }],
+      readFile: () => `export const MULTI_TENANT_UNSUPPORTED_CODE = 'MONGO_ONE';`,
+    });
+    ok(sites.some((s) => s.code === 'MEMORY_ONE'), 'in-file constant did not win over the imported one');
+    ok(!sites.some((s) => s.code === 'MONGO_ONE'), 'resolved through the import when a local declaration existed');
+  }
+
+  // An unresolvable constant is REPORTED, never silently dropped.
+  {
+    const { sites, unresolved } = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source: `class E { readonly code = SOME_UNKNOWN_CONST; }` }],
+      readFile: () => '',
+    });
+    ok(unresolved.length === 1, 'an unresolvable code constant produced no finding');
+    ok(sites.length === 0, 'an unresolvable constant leaked into the site list');
+  }
+
+  // A registered code produces no finding; comments never do.
+  {
+    const { sites } = deriveSites({
+      registered: new Set(['ALREADY_REGISTERED']),
+      files: [
+        { rel: 'packages/x/src/a.ts', source: `err.code = 'ALREADY_REGISTERED';` },
+        { rel: 'packages/x/src/b.ts', source: `// err.code = 'IN_A_COMMENT';\n/* code: 'BLOCK_COMMENT' */` },
+      ],
+      readFile: () => '',
+    });
+    ok(sites.length === 0, `registered/commented codes produced findings: ${JSON.stringify(sites)}`);
+  }
+
+  // Lowercase belongs to check:error-code-casing, not here.
+  {
+    const { sites } = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source: `err.code = 'lowercase_thing';` }],
+      readFile: () => '',
+    });
+    ok(sites.length === 0, 'a lowercase literal was claimed by this gate');
+  }
+
+  // Reconciliation: both directions, plus the now-registered ratchet.
+  {
+    const sites = [{ code: 'NEW_ONE', file: 'packages/x/src/a.ts', shape: 'assign' }];
+    const findings = reconcile({ sites, declared: [], registered: new Set(), unresolved: [] });
+    ok(findings.some((f) => f.kind === 'unclassified-site'), 'an unclassified site did not fail');
+  }
+  {
+    const declared = [{ code: 'GONE', file: 'packages/x/src/a.ts', shape: 'assign', door: 'dispatcher', verdict: 'pending-registration' }];
+    const findings = reconcile({ sites: [], declared, registered: new Set(), unresolved: [] });
+    ok(findings.some((f) => f.kind === 'stale-row'), 'a stale declared row did not fail');
+  }
+  {
+    const site = { code: 'FLOW_FAILED', file: 'packages/x/src/a.ts', shape: 'assign' };
+    const declared = [{ ...site, door: 'dispatcher', verdict: 'pending-registration' }];
+    const findings = reconcile({
+      sites: [site],
+      declared,
+      registered: new Set(['FLOW_FAILED']),
+      unresolved: [],
+    });
+    ok(findings.some((f) => f.kind === 'now-registered'), 'a registered pending row did not ratchet down');
+  }
+  {
+    const site = { code: 'STILL_PENDING', file: 'packages/x/src/a.ts', shape: 'assign' };
+    const findings = reconcile({
+      sites: [site],
+      declared: [{ ...site, door: 'dispatcher', verdict: 'pending-registration' }],
+      registered: new Set(),
+      unresolved: [],
+    });
+    ok(findings.length === 0, `a matched declaration still failed: ${JSON.stringify(findings)}`);
+  }
+
+  // The two path exclusions are exactly as narrow as they claim to be — a
+  // blanket directory ignore is what lets a real emitter hide.
+  {
+    ok(isTestFile('packages/x/src/a.test.ts'), 'a .test.ts file was not treated as a test');
+    ok(isTestFile('packages/x/src/__tests__/a.ts'), 'a __tests__/ file was not treated as a test');
+    ok(!isTestFile('packages/x/src/testing-helpers.ts'), 'a source file with "test" in its name was skipped');
+    ok(isDeclarationFile(DECLARATION), 'the declaration file is not excluded from its own scan');
+    ok(
+      !isDeclarationFile('packages/runtime/src/dispatcher-error-vocabulary-extra.ts'),
+      'the declaration exclusion matched by prefix instead of exactly',
+    );
+    ok(!isDeclarationFile('packages/runtime/src/http-dispatcher.ts'), 'the declaration exclusion is too wide');
+  }
+
+  // The spec anchors still parse — a moved anchor must throw, not return empty.
+  {
+    const ledger = parseLedgerCodes(readFileSync(join(ROOT, LEDGER_ZOD), 'utf8'));
+    ok(ledger.size > 100, `ledger parse returned ${ledger.size} codes — the anchor probably moved`);
+    ok(ledger.has('DESTRUCTIVE_CHANGE'), 'ledger parse missed a known member');
+    const standard = parseStandardCodes(readFileSync(join(ROOT, ERRORS_ZOD), 'utf8'));
+    ok(standard.size > 20, `StandardErrorCode parse returned ${standard.size} codes — the anchor probably moved`);
+    ok(standard.has('INTERNAL_ERROR'), 'StandardErrorCode parse missed a known member');
+    let threw = false;
+    try { parseLedgerCodes('export const SOMETHING_ELSE = {};'); } catch { threw = true; }
+    ok(threw, 'a missing ledger anchor returned quietly instead of throwing');
+  }
+
+  // The declaration file parses into rows with every field present.
+  {
+    const rows = parseDeclaration(readFileSync(join(ROOT, DECLARATION), 'utf8'));
+    ok(rows.length > 0, 'the declaration parsed to zero rows');
+    ok(
+      rows.every((r) => r.code && r.file && r.shape && r.door && r.verdict),
+      'a declaration row parsed with a missing field',
+    );
+  }
+
+  if (fail.length) {
+    console.error('check-dispatcher-error-vocabulary --self-test FAILED:');
+    for (const f of fail) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+  console.log(`check-dispatcher-error-vocabulary --self-test: ${Object.keys(samples).length} shapes + 10 cases OK`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv.includes('--self-test')) return selfTest();
+
+  const readFile = (abs) => readFileSync(abs, 'utf8');
+  const ledger = parseLedgerCodes(readFileSync(join(ROOT, LEDGER_ZOD), 'utf8'));
+  const standard = parseStandardCodes(readFileSync(join(ROOT, ERRORS_ZOD), 'utf8'));
+  const registered = new Set([...ledger, ...standard]);
+
+  const files = [];
+  for (const { rel, abs } of walkSources(join(ROOT, SCAN_ROOT), ROOT)) {
+    files.push({ rel, source: readFile(abs) });
+  }
+
+  const { sites, unresolved } = deriveSites({ registered, files, readFile });
+  const declared = parseDeclaration(readFileSync(join(ROOT, DECLARATION), 'utf8'));
+  const findings = reconcile({ sites, declared, registered, unresolved });
+
+  const pending = declared.filter((d) => d.verdict === 'pending-registration');
+  const bounds =
+    `  scope: ${files.length} non-test source files under ${SCAN_ROOT}/; ` +
+    `${registered.size} registered codes (${ledger.size} ledger + ${standard.size} standard); ` +
+    `${sites.length} unregistered code-stamping site(s) found; ${declared.length} classified.\n` +
+    `  the sandbox limb (author-thrown codes from metadata-app action code) is outside this scan ` +
+    `by construction — see SANDBOX_AUTHORED_LIMB in ${DECLARATION}.`;
+
+  if (argv.includes('--report')) {
+    console.log('Derived sites (code / shape / file):');
+    for (const s of sites) {
+      const row = declared.find((d) => key(d) === key(s));
+      console.log(`  ${s.code.padEnd(40)} ${s.shape.padEnd(11)} ${row ? row.verdict : 'UNCLASSIFIED'}  ${s.file}`);
+    }
+    console.log(`\nPending ledger registration (#8846's input): ${pending.length}`);
+    for (const p of [...new Set(pending.map((d) => d.code))].sort()) {
+      const doors = [...new Set(pending.filter((d) => d.code === p).map((d) => d.door))].join(',');
+      console.log(`  ${p.padEnd(40)} door=${doors}`);
+    }
+    console.log(`\n${bounds}`);
+  }
+
+  if (findings.length) {
+    console.error(`\ncheck-dispatcher-error-vocabulary: ${findings.length} finding(s)\n`);
+    for (const f of findings) console.error(`  [${f.kind}] ${f.text}\n`);
+    console.error(bounds);
+    process.exit(1);
+  }
+
+  console.log(
+    `check-dispatcher-error-vocabulary: OK — ${sites.length} unregistered code-stamping site(s), all classified; ` +
+      `${new Set(pending.map((d) => d.code)).size} awaiting a ledger entry (#8846).`,
+  );
+  console.log(bounds);
+}
+
+main();


### PR DESCRIPTION
Fixes #8087

Implements the maintainer ruling of 2026-08-12 — **option B, delivered as a gate rather than a sweep** — for the `domain:cli` half of the triage split (2026-08-15). The `packages/spec` half is #8846 and its input is the list at the bottom of this body. ⛔ Nothing here edits `packages/spec`; the gate only *reads* the ledger to know what is registered.

Verified green at `a2eefbe19` (gate union re-run at that exact head, after the final commit).

## The gap, restated from measurement

`ApiErrorSchema.code` parses against `ErrorCode` = `StandardErrorCode` ∪ `ERROR_CODE_LEDGER`. `HttpDispatcher.errorFromThrown` puts `resolveThrownHttpError(e).declaredCode` — the producer's own string, un-narrowed — into `error.code`, and its conformance suite parsed only the cases it happened to drive. So unregistered codes reached the wire and CI stayed green.

One thing measured here is sharper than the card assumed: an unregistered code does **not** merely fail the nested `ApiErrorSchema`. `BaseResponseSchema` embeds it, so the **whole response body** fails to parse — the envelope every consumer validates against, invalidated by one string. That is asserted per code in the suite.

## What landed

**`scripts/check-dispatcher-error-vocabulary.mjs`** (+ `pnpm check:dispatcher-error-vocabulary`, wired into `lint.yml` with no `paths:` filter — producers live in any package and the registered vocabulary lives in `packages/spec`).

It derives every site stamping a code the ledger does not know, over `packages/**` non-test source, in four **published** shapes (`err.code = 'X'`, `readonly code = 'X'`, `readonly code = CONST`, `code: 'X'`), resolving constants across files. Two packages export a `MULTI_TENANT_UNSUPPORTED_CODE` with different values, so the in-file declaration wins over an import — pinned in `--self-test`. **An unresolvable constant is reported, never dropped.**

**`packages/runtime/src/dispatcher-error-vocabulary.ts`** records the verdict for each site *with its evidence*. Reachability is not decidable from a source scan — `MEMORY_MULTI_TENANT_UNSUPPORTED` and `FLOW_FAILED` are written identically and one is a boot refusal the CLI rethrows pre-HTTP. So the scan finds sites and the table records verdicts, the same shape `check-route-envelope`'s module table uses.

Reconciled in **both** directions: an unclassified site fails; a stale row fails; and a `pending-registration` row whose code has *since been registered* fails — which is how #8846 landing ratchets this list down instead of leaving rows promising work already done.

**`error-envelope.conformance.test.ts`** gains a third direction: it drives every dispatcher-reachable member of the derivation through the real builder and parses the body. That is the "parse **every** body it emits" half — a producer added next month is driven here without anyone writing a case for it. Each pending code asserts the door emits it verbatim (option B, not A), that the envelope is structurally conformant, and that the schema rejects on `code` **alone**. A registered code is driven as the control, so "the schema rejects it" cannot be satisfied by a builder that is simply broken.

**Reconciled with PR #8088's resolver, not around it.** `declaredCode` is untouched and still what this door serves; `package-door-error-parity.test.ts` keeps its pin and its deliberately-unregistered vehicle, because what it pins is the *spelling difference*, not any producer. Narrowing `declaredCode` would have been option A, which was not ruled.

## (a) Genuinely wrong ⇒ collapsed here, pin rewritten

**`STORAGE_FAILURE` — no producer anywhere in the repo.** Only two fixtures, which invented it, plus prose. By the ledger's own rule ("tests that merely CONSTRUCT the code are not producers, and a test pinned to a producerless code is pinning nothing"), it is not wire vocabulary and must not be registered — that would mint a row unemittable from birth, the `MONGODB_MULTI_TENANT_UNSUPPORTED` class #8035 exists to prevent.

Both pins move to **`DATABASE_ERROR`**, a `StandardErrorCode`. Deliberately *not* the status-derived code: 500 derives `INTERNAL_ERROR`, so using that would make the assertions pass whether the code was promoted or merely derived — a green test over nothing. `DATABASE_ERROR` is registered **and** distinct from the derived one, so both pins still prove what they were written to prove.

A note on the card's wording: "collapse to the status-derived standard code" presumes the code is *on the wire*. For a producerless fixture-only code there is nothing on the wire to collapse, and collapsing at the *door* would be option A. Re-spelling the fixture is the only in-lane action that exists, and it changes no behaviour.

## (b) Merely unregistered ⇒ handed to #8846

Seven codes, each with a live producer and a door. Complete and precise enough to act on without re-running the gate — regenerate any time with `node scripts/check-dispatcher-error-vocabulary.mjs --report`.

| code | owning package | door | site |
|---|---|---|---|
| `FLOW_FAILED` | `@objectstack/runtime` | dispatcher | `packages/runtime/src/action-execution.ts` |
| `QUERY_OBJECT_MISMATCH` | `@objectstack/metadata-protocol` | dispatcher | `packages/metadata-protocol/src/protocol.ts` |
| `ERR_AUTONUMBER_COLLISION` | `@objectstack/objectql` | dispatcher | `packages/objectql/src/engine.ts` |
| `ERR_TRANSACTION_UNSUPPORTED` | `@objectstack/objectql` | dispatcher | `packages/objectql/src/transaction-errors.ts` |
| `ERR_CROSS_DATASOURCE_TRANSACTION_WRITE` | `@objectstack/objectql` | dispatcher | `packages/objectql/src/transaction-errors.ts` |
| `ERR_HOOK_TARGET_REBIND` | `@objectstack/objectql` | dispatcher | `packages/objectql/src/hook-target-rebind-errors.ts` |
| `FIELD_VISIBILITY_UNRESOLVED` | `@objectstack/rest` | **rest** | `packages/rest/src/error-response.ts` |

The four `ERR_*` are unswept members of a family `@objectstack/objectql` **already** registers (`ERR_DRIVER_CONNECT`, `ERR_DATASOURCE_UNAVAILABLE`, `ERR_READONLY_FIELD_REJECTED`, `ERR_SUMMARY_RECOMPUTE`, `ERR_BULK_RESULT_MISMATCH`) — the exact "an unswept producer re-opens the hole" shape the gate exists to stop.

`FIELD_VISIBILITY_UNRESOLVED` is the odd one: it reaches the **REST** wire, not this door. `packages/rest/src/error-response.ts` has its own `sendError(res, error: any)` overload, which is *not* the closed-`ErrorCode` one in `@objectstack/types`, so it does not narrow. Listed because the ledger is door-agnostic; the REST door having the same class of hole is filed separately (see below).

The tail is **7, not large** — reported before treating it as settled, as asked.

## Classified as NOT ledger business, with evidence

`MONGODB_MULTI_TENANT_UNSUPPORTED`, `MEMORY_MULTI_TENANT_UNSUPPORTED` (boot refusals — the ledger note names the first as the class precedent); `MODULE_NOT_FOUND` (Node errno); `SQLITE_ERROR` ×2 (driver errno quoted in a migration sample); `INVALID_SCREEN_INPUT` (**returned** in an automation result envelope, never thrown — a rejected run reaches the door as `FLOW_FAILED`); `IMPERSONATION_ROTATION_FAILED` (better-auth `APIError` — `domains/auth.ts` catches everything the auth service throws and answers a status-derived `INTERNAL_ERROR` with the message withheld unconditionally, #5085, so the string never lands in an ADR-0112 `error.code`).

That last row is the one that shows why verdicts are **declared**: it is written exactly like `FLOW_FAILED`, and a documented catch one layer up makes it unreachable.

## ⚠️ Measured while building this — a limb no ledger can close

`SandboxError` carries a metadata app's **own** `.code` across the QuickJS boundary on purpose — *"Author-thrown structured errors get the same treatment; nothing here is objectql-specific"* (`sandbox/error-passthrough.test.ts`, #7867) — and `domains/actions.ts` serves that error through `errorFromThrown`. `domains/actions-validation-envelope.test.ts` pins it end to end.

So this door's `error.code` has a limb whose vocabulary is **authored by tenants, at runtime**. Registration cannot close it: the ledger would have to enumerate strings that do not exist when CI runs.

This is **not** an argument for option C — the closure is load-bearing for every platform producer, and the seven rows above are exactly what it catches. It is a bound on what "closed" can mean at this door, and it post-dates the ruling. ⛔ Deliberately not decided here: the two available answers (narrow the sandbox boundary, or declare a second non-ledger vocabulary for author-thrown codes) are both contract-shaped. `DUPLICATE` is the pinned witness and is deliberately **not** re-spelled — re-spelling it would delete the only evidence in the repo that this limb is open.

That also revises the card's premise on the third named code: `DUPLICATE` is neither "wrong" nor "merely unregistered". It is the open limb.

## Verification

- `pnpm --filter @objectstack/runtime test` — **165 files / 2468 tests pass**
- `pnpm --filter @objectstack/runtime --filter @objectstack/types typecheck` — clean
- Gate union at `a2eefbe19`: `check:dispatcher-error-vocabulary`, `check:cross-package-test-inputs`, `check:nul-bytes`, `check:error-code-casing`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:type-check-debt`, `check:node-version`, `check:required-contexts`, `check:shard-attestation`, `check:workflow-status-functions`, `check:partof-closing-keyword` — all pass
- **Reverse verification of the gate**: added a source file stamping `PROBE_UNSWEPT_PRODUCER`, gate exited **1** naming the code and file; removed it, gate exited **0**. Direction as expected (red).
- `check:type-check-debt` initially caught a real **+1** drift from this PR's own test code (`readonly string[]` into `arrayContaining`). Fixed, not banked — TEST_DEBT sits exactly at its measurement, so re-measure now reports "none above its recorded number".

No changeset: tests, a CI gate, a workflow step, and one package-internal module that is not exported from `packages/runtime`'s single `.` entry — nothing user-visible is published. `skip-changeset` applied.

## Filed separately, not fixed here

- **#9098** — `packages/rest` has a *second, same-named* `sendError` (`error: any`) that route modules reach for, and it does not narrow. The reason that door was believed safe (`sendError`'s closed `ErrorCode` parameter, quoted in `resolveThrownHttpError`'s module note and in the parity pin) is a type the module in question does not use. Same class as this card, one door over; out of this card's file surface.

#8846 consumes list (b) above and remains open. #8211 is out of scope here. #9098 remains open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_