### PR TITLE
pm-dispatch: make the skip-changeset review clause repo-conditional

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -173,10 +173,9 @@ UI 创建并勾 GitHub 连接器、UI 钉模型(会话内 create_trigger 的Rout
 
 **Anchoring rule(全案压在这一句上):**
 
-> Every package belongs to exactly **one** domain; an issue's `domain:*`
-> label is the domain of **the package the fix lands in**, decided at triage
-> by reading the code — **never guessed from the issue's title vocabulary**.
-> 说不出修复碰哪个文件,就还没分诊完,就不可标。
+> Every package belongs to exactly **one** domain; an issue's `domain:*` label is the domain
+> of **the package the fix lands in**, decided at triage by reading the code — **never guessed
+> from the issue's title vocabulary**. 说不出修复碰哪个文件,就还没分诊完,就不可标。
 
 | 标签 | 包家族 |
 |:--|:--|
@@ -473,8 +472,9 @@ You are the reviewer of record —— **对 GitHub 核验,不对报告的自述�
 - **PR 形态与范围**:draft、目标 `main`、首行 **`Fixes #<n>` 仅当合并应当关卡** ——半实施必
   须 `Part of #<n>`,否则合并静默关掉决策箱里的卡(收件箱过滤只看 open);翻 ready 前亲核首行。
   **`Fixes` 卡随关单自动离开在飞视图,`Part of` 卡合并后仍开着**:MERGED 的同一动作里摘
-  `pm:dispatched` 换回 `pm:queue`(或按剩余物定级)+ 评论写明已交付/还剩/归谁。changed files
-  范围检查(⛔ 不看报告自述);tests/docs-only 走`skip-changeset` 标签;测试证据要真实命令与输出。
+  `pm:dispatched` 换回 `pm:queue`(或按剩余物定级)+ 评论写明已交付/还剩/归谁。changed files 范围
+  检查(⛔ 不看报告自述);tests/docs-only 按仓库分流:本仓库 `skip-changeset` 标签是真实机制;
+  objectui 无此标签,空 frontmatter changeset 即声明,⛔ 永不铸标签;测试证据要真实命令与输出。
 - **报告在草稿 PR 时点到达,CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定): gate
   `in_progress` 是诚实读数;翻 ready / 挂 auto-merge / 入队前亲核门禁 job 结论,⛔ 不因「本地
   绿」跳过;收敛期转红走补丁轮(续派原 dev,不是 REWORK);重量级卡可在派发令写「本单等 CI」。

--- a/.claude/skills/pm-dispatch/references/review-checklist.md
+++ b/.claude/skills/pm-dispatch/references/review-checklist.md
@@ -19,9 +19,11 @@
   message 分开解析,细则见平台读数事实表);误关的卡以 completed 状态对一切「只看
   open」的过滤隐身,这一读是唯一能兜住它的机械检查。
 - **范围检查**(取 changed files,⛔ 不看报告自述):无 `content/docs/releases/` 改
-  动、用户可见改动有 changeset、无与卡无关的文件。Tests/docs-only PR 走
-  `skip-changeset` 标签,不走空 changeset(空 changeset 滞留发布);含读者可见生成产
-  物时 dev 选 changeset 是对的 —— 以 PR 正文说明的理由为准,两条路都有效,别来回改。
+  动、用户可见改动有 changeset、无与卡无关的文件。Tests/docs-only 按仓库分流:本仓
+  库走 `skip-changeset` 标签、不走空 changeset(空 changeset 在本仓库滞留发布);
+  objectui 无此标签 —— 空 frontmatter changeset 即声明、即正确形态,⛔ 永不要求或
+  铸出该标签;含读者可见生成产物时 dev 选 changeset 是对的 —— 以 PR 正文说明的理
+  由为准,两条路都有效,别来回改。
 - **就地修了范围外的邻接缺陷?**四条件逐条核(同缺陷类·机械·文件无他人认领·同门禁
   族),再核 claim 文件面同轮已修订、PR 正文点名该修并载证据;缺一条即判 REWORK。
 - **改动触及的每个包,`private: false` 即已发布 ⇒ 核 changeset 在不在**:判据是包
@@ -29,8 +31,7 @@
   断 —— 那个判断 dev 在时间压力下会乐观化。⛔ 缺了不入队 —— 合进 main 却永不发
   布,看起来像修好了,比不合更糟。
 - **测试证据**要有真实命令与通过输出,不是一句 tests pass。**测量类交付先看阳性对
-  照**:对照本身失败 ⇒ 该读数记 INCONCLUSIVE,⛔ 不把它的「绿」当被测风险的证据入
-  账。
+  照**:对照本身失败 ⇒ 该读数记 INCONCLUSIVE,⛔ 不把它的「绿」当被测风险的证据入账。
 - **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点交
   报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge
   / 入队前亲核 ESLint 与 TypeScript Type Check 两个 job 的 `conclusion` 已为
@@ -38,9 +39,8 @@
   (SendMessage 续派原 dev —— 那是这笔交换已付过的价钱,不是 REWORK 的理由;红着
   合并才是)。重量级卡可在派发令显式写「本单等 CI」。
 - **每个门禁读数先钉到 PR 的当前 head**:先读 PR 的 `head.sha`,再比对 run 的
-  `head_sha` —— 不一致的 run 是关于一个死提交的读数,绿与红**双向都不入账**(旧
-  head 的绿把「新推送未验」读成「消费者干净」,旧 head 的红把已修掉的缺陷重新挂回
-  PR)。
+  `head_sha` —— 不一致的 run 是关于一个死提交的读数,绿与红**双向都不入账**(旧 head
+  的绿把「新推送未验」读成「消费者干净」,旧 head 的红把已修掉的缺陷重新挂回 PR)。
 - **dev 本地跑的门禁并集,同样先钉 head —— 同一条纪律**:dev 的契约要求在**最后一
   次提交之后**跑并集,并把那一跑的 `git rev-parse --short HEAD` 抄进报告与 PR 正
   文;复核就读这个 HEAD 与 PR 当前 `head.sha` 比一次。对不上 ⇒ 那份「本地全绿」是


### PR DESCRIPTION
Fixes #8970

Mirrors the already-landed dev-side fix (os-dev.md's repo-conditional skip-changeset clause) onto the two PM-side review texts that still taught the label unconditionally.

## What changed

1. **`.claude/skills/pm-dispatch/SKILL.md`** — the review-skeleton clause 「tests/docs-only 走`skip-changeset` 标签」 is now repo-conditional in os-dev.md's terms: this repo's label is the real mechanism (真实机制); objectui has no such label — an empty-frontmatter changeset is the tests/docs-only declaration, and the clause forbids minting the label (⛔ 永不铸标签). The skeleton keeps os-dev.md's compressed register; the review-side detail (never demand it, never mint it) is spelled out in the checklist below, and the whole-set-PUT / read-back / first-run-race mechanics stay where they already live, in os-dev.md — all three remain intact and this-repo-scoped there.
2. **`references/review-checklist.md`** — the scope-check bullet's double inversion is fixed: the branch structure now reads 本仓库走 `skip-changeset` 标签、不走空 changeset, with the release-stall parenthetical scoped as a this-repo fact (空 changeset 在本仓库滞留发布); for objectui the empty-frontmatter changeset is stated as the declaration and the correct form (即声明、即正确形态), and the reviewer is forbidden to demand or mint the label (⛔ 永不要求或铸出该标签). The pre-existing generated-artifacts clause (dev choosing a changeset is valid, judged by the PR body's stated reason) is preserved unchanged.

## Ratchet funding (both files at headroom 0)

Net line counts are unchanged — SKILL.md 686/686, review-checklist.md 82/82. The added lines are funded by pure rewrap with zero wording change in the funding lines:

- SKILL.md: the Domain-lanes anchoring-rule blockquote rewrapped 4 lines to 3.
- review-checklist.md: two bullets with near-empty trailing lines (账。 / PR)。) rewrapped 3 to 2 and 4 to 3.

No ceiling raise was needed.

## Verification

Union run at `189faab32` (the PR head), after the final commit:

- `pnpm check:pm-skill-ratchet` — green: SKILL.md 686 (ceiling 686), review-checklist.md 82 (ceiling 82)
- `pnpm check:pm-skill-id-lint` — green (9 files clean)
- `pnpm check:skill-frame-sync` — green (4 copies isomorphic, 3 axes; edits touch neither the frame nor its anchors)
- `pnpm check:skill-frame-freshness` — green (frame current with origin/main)
- `pnpm check:nul-bytes` — green
- `pnpm check:doc-authoring` — green (376 files clean)
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — green
- `pnpm check:pm-dispatch-gates` / `pnpm check:pm-half-states` self-tests — green

Gate list re-derived from the actual diff via `node scripts/pm/dispatch-gates.mjs` at the same head; the derivation added nothing beyond the set above. Model tier: fable-mandatory, derived via `--tier` over the file surface.

## Landing

This PR touches `.claude/skills/**` — a skills root. Per the maintainer ruling on skills updates it is **ADR-class: human merge only**. It stays draft; no seat marks it ready, queues it, or arms auto-merge.

This is a `.claude/`-only PR — releases nothing; `skip-changeset` label applied (this repo: real mechanism).

---
_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_