### PR TITLE
test(approvals): pin the deliberately-unfiltered position expansion of the #8710 carve-out

### DIFF
--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -744,6 +744,86 @@ describe('ApprovalService (node era)', () => {
     expect(req.pending_approvers).toEqual(['position:sales_manager']);
   });
 
+  // ── the #8710 carve-out, asserted on THIS side (#8863) ──────────────────
+  //
+  // Maintainer ruling, 2026-08-15 (#8710, inheriting #8613), verbatim:
+  //
+  //   > Access-conferring paths filter deactivated positions; addressing
+  //   > paths do not.
+  //
+  // Approver routing is an ADDRESSING path, so `expandPositionUsers` reads the
+  // directory RAW where `PositionGraphService.expandPositionUsers` (sharing,
+  // access-conferring) filters. Until these two cases the carve-out was held up
+  // on this side by a doc comment alone: `sharing-rule.test.ts`'s
+  // `the ADDRESSING primitive stays a RAW directory read` guards the sharing
+  // helper, not this one, so "fixing" the apparent oversight here left the whole
+  // suite green. The regression it would ship is a step that routes to NOBODY —
+  // the expansion comes back short, and when it comes back empty the slot falls
+  // through to the `position:sales_manager` literal no user can ever act on, i.e.
+  // the permanently stuck request of #3807 / #3424, surfacing a deployment later.
+  // Dropping a holder here is fail-OPEN; that is why the lapsed holder stays.
+
+  it('position approver: an EXPIRED sys_user_position row STILL routes (ADR-0091 D2 is not applied here)', async () => {
+    // ⛔ The load-bearing negative pin. An ablation that adds the ADR-0091 D2
+    // window to `expandPositionUsers` — the `isGrantActive` filter plus the
+    // `valid_from`/`valid_until` projection that sharing's `position-graph.ts`
+    // carries — turns this red on `u5`.
+    //
+    // ⚠️ The pin is only worth its line count if the fixture is REALLY expired:
+    // an assertion that "the expired holder is still in the slate" degrades into
+    // a tautology the moment the seeded row stops carrying a lapsed window, and
+    // it degrades SILENTLY (`isGrantActive` reads an absent bound as unbounded,
+    // so a window-less row survives any filter and the case passes green with
+    // its own subject ablated — measured on a sibling pin, #9085). The window
+    // columns below are therefore load-bearing fixture, not decoration, and the
+    // two guards under them fail loudly if a later edit dulls the blade.
+    const LAPSED_UNTIL = '2025-06-30T00:00:00Z';
+    const OPEN_UNTIL = '2099-01-01T00:00:00Z';
+    // Past/future of BOTH clocks on purpose — the injected test clock and the
+    // wall clock — so the pin does not quietly depend on which one a would-be
+    // filter reads (sharing's reads `Date.now()`; this service has a `clock`).
+    expect(Date.parse(LAPSED_UNTIL)).toBeLessThan(Math.min(baseTime, Date.now()));
+    expect(Date.parse(OPEN_UNTIL)).toBeGreaterThan(Math.max(baseTime, Date.now()));
+
+    engine._tables['sys_user_position'] = [
+      // Lapsed over a year before the request opens — a filter WOULD drop this.
+      { id: 'up_lapsed', user_id: 'u5', position: 'sales_manager', organization_id: 't1',
+        valid_from: '2024-01-01T00:00:00Z', valid_until: LAPSED_UNTIL },
+      // The in-window control: proves an ablation's red is the window filter
+      // biting, not the fixture failing to seed or the org scope excluding both.
+      { id: 'up_current', user_id: 'u6', position: 'sales_manager', organization_id: 't1',
+        valid_from: '2024-01-01T00:00:00Z', valid_until: OPEN_UNTIL },
+    ];
+
+    const req = await svc.openNodeRequest(positionInput(), CTX);
+    expect(req.pending_approvers.sort()).toEqual(['u5', 'u6']);
+  });
+
+  it('position approver: the routing read never consults the sys_position catalogue', async () => {
+    // Limb 3 of the same ruling. `sys_position.active` is gated on the sharing
+    // side at the RULE EVALUATOR's call site (`positionConfersAccess` in
+    // `sharing-rule-service.ts`), never inside the graph primitive; the ruling
+    // gives this path no counterpart gate, so a deactivated position keeps
+    // routing here too.
+    //
+    // Pinned on the READ and not only on the slate, because the slate alone
+    // cannot fail: nothing here queries `sys_position` at all, so a deactivated
+    // row is not "kept despite the flag", it is never looked at — and an
+    // outcome-only assertion would pass for that reason rather than for the
+    // ruled one. Asserting the absent read is what an ablation adding the
+    // catalogue lookup + `active` filter turns red.
+    engine._tables['sys_position'] = [
+      { id: 'pos_sm', name: 'sales_manager', organization_id: 't1', active: false },
+    ];
+    engine._tables['sys_user_position'] = [
+      { id: 'up1', user_id: 'u5', position: 'sales_manager', organization_id: 't1' },
+    ];
+
+    const req = await svc.openNodeRequest(positionInput(), CTX);
+    expect(req.pending_approvers).toEqual(['u5']);
+    expect(engine._finds.map(f => f.object)).not.toContain('sys_position');
+  });
+
   // ── approver expansion: org_membership_level + its deprecated `role` alias
   //    (ADR-0090 D3) ────────────────────────────────────────────────────────
 

--- a/packages/plugins/plugin-approvals/src/approval-service.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.test.ts
@@ -796,7 +796,17 @@ describe('ApprovalService (node era)', () => {
     ];
 
     const req = await svc.openNodeRequest(positionInput(), CTX);
-    expect(req.pending_approvers.sort()).toEqual(['u5', 'u6']);
+    // Narrowed off the `autoApproved` discriminant rather than read through the
+    // union: the neighbours' bare `req.pending_approvers` is what TEST_DEBT's
+    // frozen TS2339 pile is made of, and a new case may not add to a shrink-only
+    // ratchet. It reads as an assertion too — an auto-approve outcome here would
+    // mean the slate came back EMPTY, which is the failure this case is about.
+    if ('autoApproved' in req) throw new Error('expected a pending request, not an auto-approve outcome');
+    // `?.slice().sort()` and not the neighbours' in-place `.sort()`: the field is
+    // optional on the row, so the bare call is TS18048 under the TEST_DEBT
+    // re-measure, and an absent slate then reads as `undefined` here — red, which
+    // is the honest verdict — instead of throwing before any assertion runs.
+    expect(req.pending_approvers?.slice().sort()).toEqual(['u5', 'u6']);
   });
 
   it('position approver: the routing read never consults the sys_position catalogue', async () => {
@@ -820,6 +830,7 @@ describe('ApprovalService (node era)', () => {
     ];
 
     const req = await svc.openNodeRequest(positionInput(), CTX);
+    if ('autoApproved' in req) throw new Error('expected a pending request, not an auto-approve outcome');
     expect(req.pending_approvers).toEqual(['u5']);
     expect(engine._finds.map(f => f.object)).not.toContain('sys_position');
   });


### PR DESCRIPTION
Fixes #8863

The 2026-08-15 ruling on #8710 — *"Access-conferring paths filter deactivated positions; addressing paths do not"* — has two sides, and only the sharing side was asserted by a test. `ApprovalService.expandPositionUsers` reads `sys_user_position` RAW on purpose, and until now that carve-out was held up on this side by a doc comment alone: `sharing-rule.test.ts`'s `the ADDRESSING primitive stays a RAW directory read` guards the sharing helper, not this one, so "fixing" the apparent oversight here left the whole suite green while shipping a step that routes to nobody (#3807 / #3424).

Tests only. No production behaviour changed — `approval-service.ts` is byte-identical to `origin/main` (blob `4f0a054e` in the working tree, at `HEAD`, and at `origin/main`).

## What landed

Two negative pins in `packages/plugins/plugin-approvals/src/approval-service.test.ts`, next to the existing position-expansion cases:

1. **`an EXPIRED sys_user_position row STILL routes`** — the card's deliverable. Seeds a holder whose ADR-0091 D2 window lapsed in 2025 alongside an in-window control, and asserts both stay in the slate.
2. **`the routing read never consults the sys_position catalogue`** — limb 3 of the same ruling, named in `expandPositionUsers`' own doc block. Same file, same defect class, same gate families; called out here because it is beyond the shape triage sketched. It asserts the absent `sys_position` read and not only the slate, because the slate alone cannot fail: nothing queries the catalogue at all, so a deactivated row is never looked at rather than deliberately kept, and an outcome-only assertion would pass for the wrong reason.

## Ablation evidence — both pins were made to fail

A pin asserting "the expired holder is still there" degrades into a tautology the moment its fixture stops carrying a lapsed window, and it degrades silently (`isGrantActive` reads an absent bound as unbounded, so a window-less row survives any filter). That is not hypothetical here — #9085 records a sibling case that passes with its subject fully ablated. So both pins were run against a deliberately-broken tree, at the final assertions:

| Ablation (local, never committed) | Result |
| --- | --- |
| Window filter: `isGrantActive` + the `valid_from`/`valid_until` projection copied from sharing's `position-graph.ts` | pin 1 **RED** — `expected [ 'u6' ] to deeply equal [ 'u5', 'u6' ]`; 287 others green |
| Catalogue gate: a `sys_position` lookup dropping holders on `active === false` | pin 2 **RED** — `expected [ 'position:sales_manager' ] to deeply equal [ 'u5' ]`; 287 others green |

Each ablation turns exactly **one** test red — which is itself the card's premise measured: no other case in the suite covers this behaviour. Pin 2's failure output is the predicted regression stated literally: the slate collapses to the `position:sales_manager` literal no user can act on.

Restoration proved by blob identity, not by eye: `git hash-object` on the working tree, `git rev-parse HEAD:&lt;path&gt;` and `git rev-parse origin/main:&lt;path&gt;` all report `4f0a054ee2708ac86e5923063754adddd468a719`.

## TEST_DEBT ratchet

The first draft added +2 `TS2339` to `@objectstack/plugin-approvals`' frozen `TEST_DEBT` entry (348 → 350) — the same error the neighbouring position cases contribute via a bare `req.pending_approvers` on the `ApprovalRequestRow | ApprovalNodeAutoOutcome` union. Fixed at the source rather than by raising the ledger: narrowed off the `autoApproved` discriminant, and the optional slate read with `?.slice().sort()`. Entry back to **348, unchanged** — `--re-measure` reports "surplus: none".

## Verification — union run at `cab5c4b28` (the final commit)

- `pnpm --filter @objectstack/plugin-approvals test` — 23 files, **486 passed**
- `pnpm --filter @objectstack/plugin-approvals typecheck` — clean
- `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, `check:i18n` — all exit 0
- `check:type-check-debt --re-measure` — exit 0, 33 entries re-measured on the built closure, none above its recorded number

`scripts/pm/dispatch-gates.mjs` re-derived against the actual changed path names exactly the families the dispatch listed — nothing missed. `check:i18n` needed `@objectstack/cli` built before it measured anything (it exits 1 with "PREREQUISITE NOT MET" otherwise, which is not drift); it is green on the built closure.

Tests-only, so no changeset — `skip-changeset` is already on the card.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_