### PR TITLE
docs(plugin-sharing): record the write-scope provenance omission as ruled, not oversight

### DIFF
--- a/packages/plugins/plugin-sharing/src/sharing-plugin.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-plugin.ts
@@ -1009,6 +1009,41 @@ export function buildSharingMiddleware(
       // may write, exactly as the read path scopes finds. The verb is threaded
       // through so a bulk DELETE scopes to owned rows alone (no share widening),
       // while a bulk UPDATE keeps the edit-share widening (ADR-0111 D3).
+      //
+      // [#8792, maintainer ruling 2026-08-15] ⛔ This merge carries NO
+      // `markFilterSubtreeProvenance` and NO `vouchCallerWhereBeforeRewrite`,
+      // and that is RULED, not an oversight. #8220 declares the mark for
+      // READ-scope merge boundaries; write-scope refusal semantics stay
+      // deliberately unspecified rather than inherited from it. So the
+      // asymmetry with the read path above — which marks each injected scope
+      // `'policy'` and vouches the caller's `where` `'author'` — is the ruled
+      // boundary itself. ⛔ Do not "complete" the pattern here. Why:
+      //
+      //  - nothing is disclosed by the omission. Unmarked ⇒ WITHHELD, so a
+      //    cross-field refusal raised anywhere in this composed tree already
+      //    keeps the #7929 redaction. Unmarked is the SAFE fail direction, and
+      //    it is what happens today;
+      //  - marking the injected filter `'policy'` would therefore change no
+      //    behaviour at all, and the only thing the `'author'` vouch would ADD
+      //    is the author's own diagnostic on the author's own predicate — an
+      //    author-experience gain, never a disclosure fix;
+      //  - ⚠️ and that gain is not free, which is the real reason. Vouching the
+      //    caller's `where` on a WRITE boundary WIDENS what a bulk
+      //    update/delete refusal is permitted to name, on a boundary whose
+      //    current behaviour is exactly that redaction. Widening a disclosure
+      //    surface is a product decision wearing a lint's clothing;
+      //  - and there is no inherited answer to widen it BY. A bulk write that
+      //    refuses has already passed the per-verb gate (ADR-0111 D3) and the
+      //    `probeAuthoredRowWrite` deferral above, so "what may a refusal name
+      //    here" is a question read scope never had to answer.
+      //
+      // Re-open trigger, named by the ruling so this is not a permanent "no":
+      // a real report of an author unable to diagnose a bulk-write refusal on
+      // their own predicate. That makes the extension a pulled feature with a
+      // consumer attached, and it returns as a decision — with write-scope
+      // refusal semantics to specify and pin at a real driver, and #8836's
+      // request-scoped invariant to carry (no filter object that can be
+      // vouched `'author'` may outlive the request that vouched it).
       let writeFilter = await service.buildWriteFilter(ctx.object, exec ?? {}, verb);
       // [ADR-0090 D10] Intersect the delegator's writable set for on-behalf-of.
       if (exec?.onBehalfOf?.userId) {
@@ -1018,6 +1053,10 @@ export function buildSharingMiddleware(
           onBehalfOf: undefined,
           __writeScope: exec.__delegatorWriteScope,
         }, verb);
+        // [#8792] Unmarked deliberately too — same ruling, same reasons as
+        // above, not repeated here. Its read-path twin (the delegator's
+        // `buildReadFilter`) IS marked `'policy'`; that difference is the ruled
+        // read/write boundary, not drift between two copies of one pattern.
         writeFilter = composeAnd(writeFilter, delFilter);
       }
       if (writeFilter) {


### PR DESCRIPTION
Fixes #8792

Comments only. No behaviour change, no runtime code touched — `git diff` is 39 added lines, every one of them a `//` comment.

## What this lands

The maintainer ruling of 2026-08-15 took the **"no"** branch on #8792: `markFilterSubtreeProvenance`'s declared meaning stays **read-scope**, and write-scope refusal semantics stay unspecified rather than inherited from #8220. The remaining deliverable was the deliberate-omission comments at the two write-side merge sites in `buildSharingMiddleware`, so the next reader does not "complete" the pattern by reflex.

Two comments in `packages/plugins/plugin-sharing/src/sharing-plugin.ts`:

- the **bulk-write merge** (before `buildWriteFilter`) carries the full explanation;
- the **delegator's second `buildWriteFilter`** carries a three-line back-reference rather than a duplicate, matching what the read-side comments already do.

⛔ Explicitly *not* done: no `markFilterSubtreeProvenance` call was added to the write path. That is the rejected branch.

## Why the comment says what it says

The reader it is written for has just noticed three marked read merges and two unmarked write ones in one file and concluded it is drift. The ruling's existence will not stop that person; the reason has to. The four points the comment makes:

- unmarked ⇒ **withheld**, so a cross-field refusal in this composed tree already keeps the #7929 redaction — the omission is the safe fail direction and costs nothing in disclosure terms today;
- the only thing a mark would add here is the author's own diagnostic on the author's own predicate — an author-experience gain, not a disclosure fix;
- "completing" the pattern would **widen what a bulk-write refusal is permitted to name**, on a boundary whose current behaviour is exactly that redaction;
- and there is no inherited answer to widen it by: write refusals sit behind the per-verb gate (ADR-0111 D3) and the `probeAuthoredRowWrite` deferral, so *"what may a refusal name here"* is a question read scope never had to answer.

The ruling's named **re-open trigger** is included, so this reads as a decision with a falsifier rather than a permanent "no": a real report of an author unable to diagnose a bulk-write refusal on their own predicate.

One precision the comment adds beyond the card's framing, because it is what makes the ruling legible: the write branch omits **both** halves of the pattern, and they are not equally consequential. Marking the injected filter `'policy'` would change no behaviour at all (unmarked already withholds); the user-visible half is `vouchCallerWhereBeforeRewrite`, and that is the one that would widen the refusal surface. The comment names which half carries the risk.

## Consistency with what landed since the card was written

- **#8791 (the read-side marking) has landed** — the card and its triage comment both record *zero* `markFilterSubtreeProvenance` call sites in this package, which is now false. The comment is written against the asymmetry as it actually exists in the file today, per the ruling's own instruction to keep the wording consistent with what #8791 shipped.
- **#9073 / #8836** rewrote the mark's docblock in `packages/spec` and added the request-scoped invariant. The comment does not contradict it and carries it forward as an obligation the re-open would inherit.
- Line numbers are deliberately **not** cited in the comment text. The ruling named `:984`/`:987`; the sites were at `:1012`/`:1015` at claim time. The comment anchors on code identifiers only, so it cannot drift the same way.

## Verification

All gates run at the final commit `65a85d11a`, working tree clean.

| gate | result |
| --- | --- |
| `pnpm check:test-source-alias` | OK — 72 packages with tests scanned |
| `pnpm check:type-source-resolution` | OK — 76 packages with a tsconfig.json scanned |
| `pnpm check:i18n` | OK — 9 packages, `plugins/plugin-sharing in sync (4 bundle(s))` |
| `pnpm check:nul-bytes` | OK — 5975 text files, no raw ASCII control bytes |
| `pnpm --filter @objectstack/plugin-sharing typecheck` | exit 0 |
| `pnpm --filter @objectstack/plugin-sharing test` | **24 files, 617 tests passed** |

`check:i18n` first exited 1 with `PREREQUISITE NOT MET — the workspace CLI is not built`, which says nothing about bundle sync. Resolved with `turbo run build --filter=@objectstack/cli`; the table row is the second, real run.

`node scripts/pm/dispatch-gates.mjs packages/plugins/plugin-sharing/src/sharing-plugin.ts` re-derived at the final head names exactly the two lint gates above plus the convention-triggered `check:i18n` — nothing the dispatch missed.

Comments-only, nothing published ⇒ `skip-changeset`.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_