### PR TITLE
fix(service-datasource): a declared ssl reaches the mysql client on both branches, in the spelling mysql2 accepts (#8874)

### DIFF
--- a/.changeset/mysql-dsn-ssl-honoured.md
+++ b/.changeset/mysql-dsn-ssl-honoured.md
@@ -1,0 +1,15 @@
+---
+'@objectstack/service-datasource': patch
+---
+
+A mysql datasource that declares TLS now gets it, on both branches of the arm and in the spelling `mysql2` can read (#8874).
+
+Two defects with one cause — `buildMysqlConnection` resolved the TLS option and then handed it to a client that could not use it, or to nobody at all.
+
+**A declared `ssl` was dropped on the DSN branch.** With a `config.url` present the arm returned before the resolved option could be attached, so a datasource that declared TLS **and** wrote a connection url negotiated none — declared, resolved, dropped, with no diagnostic — while the discrete-fields branch of the same arm carried it. Whether a connection was encrypted therefore depended on which branch of one arm the datasource happened to take. The postgres arm has honoured this case since #4410 with its reasoning written in-code, and the same argument holds here: `mysql2` reads a uri and the `ssl` option as separate channels, and keeps the explicit key.
+
+**`ssl: true` was never a `mysql2` value.** Measured on mysql2 3.23.1, `new ConnectionConfig({ …, ssl: true })` throws `SSL profile must be an object, instead it's a boolean` — and `true` is exactly what a declared `ssl: { enabled: true }` with no certificate material resolves to, as does the `config.ssl` shorthand, whose schema is a boolean and so has no other authorable value. The branch that appeared to honour the declaration was therefore throwing on every connection acquisition for the commonest way of writing it. The resolved `true` is now translated to the empty-options object it is already documented to be short for (`{}`, which mysql2 normalises to `{ rejectUnauthorized: true }` — its own default for an object, not a verification policy chosen here). Certificate objects, `false`, and a stored profile name pass through untouched.
+
+**What does not change.** The DSN branch returns an object instead of the bare connection string **only when a declared `ssl` actually resolved** (or a secret is bound, unchanged from #8696). A datasource that declared neither still gets the byte-identical string knex has always parsed for it. Where the switch does happen, knex's own parse of the string and mysql2's parse of the same value as `uri` were compared key-by-key (`host`/`port`/`user`/`password`/`database`/`charset`/`timezone`/`connectTimeout`/`flags`/`socketPath`/`multipleStatements`) across the bare-username, embedded-password, no-userinfo, portless, percent-encoded-username and query-parameter forms — identical in every case, and pinned as a test rather than measured once.
+
+Nothing that declared no TLS moves, so the behaviour change is confined to the datasources that were already broken: the ones connecting in cleartext against their own metadata, and the ones that could not connect at all.

--- a/packages/services/service-datasource/src/__tests__/mysql-dsn-ssl.test.ts
+++ b/packages/services/service-datasource/src/__tests__/mysql-dsn-ssl.test.ts
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8874 — a declared `ssl` reaches the mysql CLIENT on both branches of the
+ * mysql arm, in the spelling mysql2 can actually read.
+ *
+ * ## The defect, in two halves
+ *
+ * `buildMysqlConnection` computed the TLS option and then returned before
+ * anything could use it:
+ *
+ * ```ts
+ * const mysqlSsl = resolveSslOption(spec);   // computed
+ * const url = cfg.url as string | undefined;
+ * if (url) { … }                             // returned without it
+ * return { …, ...(mysqlSsl !== undefined ? { ssl: mysqlSsl } : {}) };  // only here
+ * ```
+ *
+ * So a mysql datasource that declared TLS **and** wrote a `config.url`
+ * negotiated no TLS at all — declared, resolved, dropped, no diagnostic — while
+ * the discrete-fields branch of the same arm carried it. The postgres arm has
+ * honoured exactly this case on its DSN branch since #4410, with the reasoning
+ * written in-code, so whether a connection was encrypted depended on which
+ * branch of one arm a datasource happened to take.
+ *
+ * The second half was found while measuring the first, and is why this file
+ * pins the discrete branch too. The value `resolveSslOption` answers for the
+ * two commonest declarations — `ssl: { enabled: true }` with no certificate
+ * material, and the `config.ssl` shorthand, whose schema is `z.boolean()` and
+ * therefore has no other authorable value — is `true`, and **mysql2 rejects a
+ * boolean outright**. Measured on mysql2 3.23.1, no connection opened:
+ *
+ * ```text
+ * {host,port,database,user, ssl:true}   -> TypeError: SSL profile must be an object, instead it's a boolean
+ * {host,port,database,user, ssl:{}}     -> ssl {rejectUnauthorized:true}
+ * {uri:'mysql://app@db.internal:3306/app'}          -> ssl false        (the dropped DSN case)
+ * {uri:'mysql://app@db.internal:3306/app', ssl:{}}  -> ssl {rejectUnauthorized:true}
+ * ```
+ *
+ * The branch #8874 describes as "honouring" the declaration was therefore
+ * throwing on every connection acquisition for the commonest way of declaring
+ * it. Emitting `ssl: true` onto the DSN branch to close the first half would
+ * have shipped that throw to a second branch, so `mysqlSslOption` translates
+ * `true` to the empty-options object `resolveSslOption`'s own comment says it
+ * is short for.
+ *
+ * ## What is asserted, and at which layer
+ *
+ * Everything below reads what **mysql2 resolved** — `ConnectionConfig`, from
+ * the mysql2 module knex itself resolved (`knex.client.driver`), fed the exact
+ * `connectionSettings` knex will hand it. Nothing asserts on the `connection`
+ * object this factory emitted, and that is deliberate: it is the constraint
+ * inherited from #8873, where the postgres arm passed the equivalent
+ * config-layer assertion throughout the defect's entire life while the client
+ * threw the value away one layer below. Here it is the sharper of the two
+ * lessons, because the boolean half of this card is invisible at the config
+ * layer by construction — `{ ssl: true }` is a perfectly good-looking object
+ * and only the client's own parse says otherwise.
+ *
+ * `new ConnectionConfig(settings)` does no I/O — it parses the uri and
+ * validates the options — which is what makes this seam assertable without a
+ * server. No connection is opened anywhere in this file.
+ *
+ * ## Reverse verification (predicted in writing before running)
+ *
+ * Predicted with the pre-fix `buildMysqlConnection` restored over these tests
+ * at their fixed state: **8 failed / 6 passed**, and specifically —
+ *
+ *  - RED, the four DSN-branch TLS cases, on the dropped option: mysql2 resolves
+ *    `ssl false` because nothing was carried beside the uri.
+ *  - RED, the two discrete-branch TLS cases, by a DIFFERENT route from every
+ *    other failure — the old branch DID carry the option, as `true`, so mysql2
+ *    throws `SSL profile must be an object` and the case fails for want of a
+ *    resolved config rather than on a compared value. That direction is the
+ *    reason this file pins a branch the card describes as working.
+ *  - RED, the two shape assertions, on `'string'` where an object is required:
+ *    the emitted-shape mechanism pin, and the DSN `enabled: false` case, whose
+ *    resolved `ssl` is `false` either way but whose return shape is not.
+ *  - GREEN, the six that must not move: the nothing-declared passthrough and
+ *    the bound-secret-only control (the blast-radius bounds — if either moved,
+ *    the scoping claim would be false), the parser-equivalence sweep (it
+ *    compares two parses, not the fix), and the three discrete-branch cases
+ *    whose declaration was never the broken spelling — a certificate object, an
+ *    `enabled: false`, and no declaration at all.
+ *
+ * Measured exactly that set, case for case: **8 failed / 6 passed**.
+ *
+ * ```text
+ * × carries a declared TLS block onto the DSN branch with no secret bound
+ *     AssertionError: expected false to deeply equal { rejectUnauthorized: true }
+ * × carries TLS and a bound secret together on the DSN branch
+ *     AssertionError: expected false to deeply equal { rejectUnauthorized: false }
+ * × carries certificate material onto the DSN branch verbatim
+ *     AssertionError: expected false to deeply equal { …(2) }
+ * × carries the `config.ssl` on/off shorthand onto the DSN branch
+ *     AssertionError: expected false to deeply equal { rejectUnauthorized: true }
+ * × returns an object rather than the bare DSN string once TLS is declared
+ *     AssertionError: expected 'string' to be 'object'
+ * × honours a declared `enabled: false` on the DSN branch
+ *     AssertionError: expected 'string' to be 'object'
+ * × resolves TLS on the discrete-fields branch instead of throwing on a boolean
+ *     TypeError: SSL profile must be an object, instead it's a boolean
+ * × resolves the `config.ssl` shorthand on the discrete-fields branch too
+ *     TypeError: SSL profile must be an object, instead it's a boolean
+ * ```
+ *
+ * The ablation was restored from the commit and proven byte-identical
+ * (`git hash-object` on the restored file equals `git rev-parse HEAD:<path>`).
+ * Nothing is built for it: these tests import the factory source through the
+ * `.js`-to-`.ts` test alias, so the ablated code is the code that ran.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createDefaultDatasourceDriverFactory } from '../default-datasource-driver-factory.js';
+
+const factory = () => createDefaultDatasourceDriverFactory({ dev: false });
+
+/** The cleartext `DatasourceConnectionService` resolves a `credentialsRef` to. */
+const BOUND_SECRET = 's3cr3t-from-sys_secret';
+
+/** The one authorable URL shape post-#8082: a username, never a password. */
+const BARE_USERNAME_DSN = 'mysql://app@db.internal:3306/app';
+
+/** A CA certificate is only ever a string here; its bytes are never inspected. */
+const CA_PEM = '-----BEGIN CERTIFICATE-----\nMIIB…\n-----END CERTIFICATE-----';
+
+/**
+ * What `mysql2` made of this datasource — the layer that can answer "did the
+ * declared TLS arrive".
+ *
+ * `knex.client.driver` is the mysql2 module knex resolved for itself and
+ * `connectionSettings` is the object it passes to `createConnection` in
+ * `acquireRawConnection`, so this is the code path that actually runs. A
+ * `ConnectionConfig` is what that call builds first, and it is the whole of the
+ * client's opinion about `ssl`: it parses the uri, merges the sibling keys, and
+ * rejects a value it cannot use.
+ */
+async function mysqlResolved(spec: Record<string, unknown>): Promise<any> {
+  const handle: any = await factory().create({ driver: 'mysql', ...spec } as any);
+  try {
+    const knexClient = (handle.driver ?? handle).knex.client;
+    return new knexClient.driver.ConnectionConfig(knexClient.connectionSettings);
+  } finally {
+    // The pool is never opened — nothing in this file connects.
+    try { await handle.disconnect?.(); } catch { /* noop */ }
+  }
+}
+
+/**
+ * The `connection` object the factory emitted — asserted ONLY where the
+ * mechanism is the claim (a bare string cannot carry an `ssl` key, so the
+ * return shape is itself part of this card), never as evidence that TLS
+ * arrived.
+ */
+async function emittedConnection(spec: Record<string, unknown>): Promise<any> {
+  const handle: any = await factory().create({ driver: 'mysql', ...spec } as any);
+  try {
+    const driver = handle.driver ?? handle;
+    return (driver?.config ?? driver?.knexConfig ?? driver?.options ?? {}).connection;
+  } finally {
+    try { await handle.disconnect?.(); } catch { /* noop */ }
+  }
+}
+
+describe('#8874 — mysql: a declared `ssl` reaches the client on the DSN branch', () => {
+  it('carries a declared TLS block onto the DSN branch with no secret bound', async () => {
+    // The card's headline case, and the sub-case its cost estimate missed: with
+    // no secret bound this arm returned the bare DSN *string*, which has no key
+    // for an `ssl` option to live in. Before the fix mysql2 resolved `ssl false`
+    // — the datasource connected in cleartext while its metadata declared TLS.
+    const resolved = await mysqlResolved({
+      name: 'orders',
+      config: { url: BARE_USERNAME_DSN },
+      ssl: { enabled: true },
+    });
+
+    expect(resolved.ssl).toEqual({ rejectUnauthorized: true });
+    // And the DSN still describes the same server: mysql2 parses it, nothing
+    // in this repo rewrites or re-encodes a `mysql://…`.
+    expect(resolved).toMatchObject({
+      user: 'app',
+      host: 'db.internal',
+      port: 3306,
+      database: 'app',
+    });
+  });
+
+  it('carries TLS and a bound secret together on the DSN branch', async () => {
+    // The other DSN sub-case. #8696 made this branch return `{ uri, password }`
+    // and deliberately left `ssl` out of it, because carrying TLS only for
+    // datasources that happen to bind a credential would have been a second,
+    // stranger asymmetry. Both channels now ride together.
+    const resolved = await mysqlResolved({
+      name: 'orders-auth',
+      config: { url: BARE_USERNAME_DSN },
+      ssl: { enabled: true, rejectUnauthorized: false },
+      secret: BOUND_SECRET,
+    });
+
+    expect(resolved.ssl).toEqual({ rejectUnauthorized: false });
+    // Direct property access — knex's `setHiddenProperty` makes `password`
+    // non-enumerable, so a serialising probe reports a dropped secret that is
+    // in fact present.
+    expect(resolved.password).toBe(BOUND_SECRET);
+    expect(resolved.user).toBe('app');
+  });
+
+  it('carries certificate material onto the DSN branch verbatim', async () => {
+    // The shape `SSL_DETAIL_BELONGS_ON_DATASOURCE` tells authors to write, and
+    // the one whose silent loss the `datasource.ssl` schema comment warns about
+    // by name — "a TLS setting that never took effect looked identical to one
+    // that did".
+    const resolved = await mysqlResolved({
+      name: 'certs',
+      config: { url: BARE_USERNAME_DSN },
+      ssl: { enabled: true, ca: CA_PEM, rejectUnauthorized: true },
+    });
+
+    expect(resolved.ssl).toEqual({ ca: CA_PEM, rejectUnauthorized: true });
+  });
+
+  it('carries the `config.ssl` on/off shorthand onto the DSN branch', async () => {
+    // The second declared spelling (`MysqlConfigSchema.ssl`, and the target of
+    // its `sslmode`/`tls`/`usessl` aliases). It resolves to the same `true` the
+    // TLS block does, so it exercises the same translation.
+    const resolved = await mysqlResolved({
+      name: 'shorthand',
+      config: { url: BARE_USERNAME_DSN, ssl: true },
+    });
+
+    expect(resolved.ssl).toEqual({ rejectUnauthorized: true });
+  });
+
+  it('returns an object rather than the bare DSN string once TLS is declared', async () => {
+    // The mechanism, asserted at the config layer because the mechanism IS the
+    // return shape: `ssl` cannot be attached to a string. This is the "behaviour
+    // change for existing rows" the card flagged, and the assertion below is
+    // what bounds it — see the passthrough control.
+    const conn = await emittedConnection({
+      name: 'shape',
+      config: { url: BARE_USERNAME_DSN },
+      ssl: { enabled: true },
+    });
+
+    expect(typeof conn).toBe('object');
+    expect(conn.uri).toBe(BARE_USERNAME_DSN);
+  });
+
+  it('leaves a DSN with NOTHING declared exactly as it was (blast-radius control)', async () => {
+    // The scoping this whole card rests on: the shape changes only for the
+    // population that was broken. A datasource that declared no TLS and bound
+    // no secret still gets the byte-identical bare string knex has always
+    // parsed for it, and mysql2's own `ssl` default (`false`) is untouched.
+    const spec = { name: 'anon', config: { url: BARE_USERNAME_DSN } };
+
+    expect(await emittedConnection(spec)).toBe(BARE_USERNAME_DSN);
+    expect((await mysqlResolved(spec)).ssl).toBe(false);
+  });
+
+  it('leaves a DSN with only a secret bound as the #8696 shape (control)', async () => {
+    // Green before this change and after it. The `ssl` key must not appear on a
+    // connection that declared none — otherwise this card would have widened
+    // #8696's blast radius rather than added to it.
+    const conn = await emittedConnection({
+      name: 'secret-only',
+      config: { url: BARE_USERNAME_DSN },
+      secret: BOUND_SECRET,
+    });
+
+    expect(Object.getOwnPropertyNames(conn).sort()).toEqual(['password', 'uri']);
+    expect((await mysqlResolved({
+      name: 'secret-only',
+      config: { url: BARE_USERNAME_DSN },
+      secret: BOUND_SECRET,
+    })).password).toBe(BOUND_SECRET);
+  });
+
+  it('honours a declared `enabled: false` on the DSN branch', async () => {
+    // A declaration either way is a declaration, which is why the shape switch
+    // keys on `!== undefined` rather than on truthiness — the same rule the
+    // postgres arm applies. mysql2 resolves `false`, its own default, so this
+    // disables nothing that was enabled.
+    const spec = {
+      name: 'tls-off',
+      config: { url: BARE_USERNAME_DSN },
+      ssl: { enabled: false },
+    };
+
+    expect((await mysqlResolved(spec)).ssl).toBe(false);
+    expect(typeof await emittedConnection(spec)).toBe('object');
+  });
+
+  it('changes NOTHING else the DSN contributed — knex\'s parse vs mysql2\'s, key by key', async () => {
+    // Switching the no-secret return from a string to `{ uri, ssl }` moves the
+    // DSN from knex's own connection-string parser to mysql2's, so every
+    // non-TLS key it contributed has to arrive by the new route unchanged.
+    // Compared across the forms a stored row can hold; `ssl` is excluded
+    // because it is the one key this card deliberately moves.
+    const FIELDS = [
+      'host', 'port', 'user', 'password', 'database',
+      'charset', 'timezone', 'connectTimeout', 'flags', 'socketPath', 'multipleStatements',
+    ] as const;
+    const URLS = [
+      BARE_USERNAME_DSN,
+      'mysql://app:embedded-legacy@db.internal:3306/app',
+      'mysql://db.internal:3306/app',
+      'mysql://app@db.internal/app',
+      'mysql://app%40corp@db.internal:3306/app',
+      'mysql://app@db.internal:3306/app?charset=utf8mb4&connectTimeout=5000',
+      'mysql://app@db.internal:3306/app?timezone=Z',
+    ];
+
+    for (const url of URLS) {
+      const before = await mysqlResolved({ name: 'sweep', config: { url } });
+      const after = await mysqlResolved({ name: 'sweep', config: { url }, ssl: { enabled: true } });
+      for (const field of FIELDS) {
+        expect({ url, field, value: after[field] })
+          .toEqual({ url, field, value: before[field] });
+      }
+    }
+  });
+});
+
+describe('#8874 — mysql: the discrete-fields branch declares TLS mysql2 can read', () => {
+  const DISCRETE = { host: 'db.internal', port: 3306, database: 'app', username: 'app' };
+
+  it('resolves TLS on the discrete-fields branch instead of throwing on a boolean', async () => {
+    // The half found while measuring the first. This branch already carried the
+    // option — as `true`, which mysql2 refuses: `SSL profile must be an object,
+    // instead it's a boolean`, thrown from `new ConnectionConfig` and therefore
+    // from every `acquireRawConnection`. So the branch the card calls "honours
+    // it" could not open a connection at all for the commonest declaration, and
+    // emitting the same `true` onto the DSN branch would have spread the throw.
+    const resolved = await mysqlResolved({
+      name: 'discrete-tls',
+      config: DISCRETE,
+      ssl: { enabled: true },
+    });
+
+    expect(resolved.ssl).toEqual({ rejectUnauthorized: true });
+    expect(resolved).toMatchObject({ user: 'app', host: 'db.internal', database: 'app' });
+  });
+
+  it('resolves the `config.ssl` shorthand on the discrete-fields branch too', async () => {
+    // `DriverSslToggleSchema` is `z.boolean()`, so `true` is the ONLY value an
+    // author can write here — which is what made the boolean the common case
+    // rather than an edge one.
+    expect((await mysqlResolved({ name: 'discrete-shorthand', config: { ...DISCRETE, ssl: true } })).ssl)
+      .toEqual({ rejectUnauthorized: true });
+  });
+
+  it('keeps carrying certificate material and a bound secret together (control)', async () => {
+    // Green before this change and after it: an options object was never the
+    // broken spelling, and this is what proves the translation is confined to
+    // the boolean rather than rewriting what authors declared.
+    const resolved = await mysqlResolved({
+      name: 'discrete-certs',
+      config: DISCRETE,
+      ssl: { enabled: true, ca: CA_PEM, rejectUnauthorized: false },
+      secret: BOUND_SECRET,
+    });
+
+    expect(resolved.ssl).toEqual({ ca: CA_PEM, rejectUnauthorized: false });
+    expect(resolved.password).toBe(BOUND_SECRET);
+  });
+
+  it('honours a declared `enabled: false` on the discrete-fields branch', async () => {
+    expect((await mysqlResolved({ name: 'discrete-off', config: DISCRETE, ssl: { enabled: false } })).ssl)
+      .toBe(false);
+  });
+
+  it('leaves a discrete-fields datasource that declared no TLS alone (control)', async () => {
+    expect((await mysqlResolved({ name: 'discrete-plain', config: DISCRETE })).ssl).toBe(false);
+  });
+});

--- a/packages/services/service-datasource/src/default-datasource-driver-factory.ts
+++ b/packages/services/service-datasource/src/default-datasource-driver-factory.ts
@@ -349,6 +349,10 @@ function pgConnectionExtras(cfg: Record<string, unknown>): Record<string, unknow
  * schema comment warns about ("a TLS setting that never took effect looked
  * identical to one that did"). The block wins when present because it is the
  * more specific statement; `config.ssl` remains the boolean shorthand.
+ *
+ * ⚠️ The `true` this can return is a `pg` spelling, not a universal one — see
+ * {@link mysqlSslOption}, which re-expands it for `mysql2`. Do not "simplify"
+ * that call away.
  */
 function resolveSslOption(spec: DatasourceConnectionSpec): unknown {
   const block = spec.ssl as
@@ -369,6 +373,61 @@ function resolveSslOption(spec: DatasourceConnectionSpec): unknown {
   }
   const shorthand = (spec.config ?? {}).ssl;
   return shorthand == null ? undefined : shorthand;
+}
+
+/**
+ * {@link resolveSslOption}'s answer in the spelling `mysql2` accepts (#8874).
+ *
+ * ## `ssl: true` is not a mysql2 value — it throws
+ *
+ * `pg` takes a boolean; `mysql2` takes an object or the name of a bundled
+ * profile, and rejects everything else outright. Measured on mysql2 3.23.1,
+ * `lib/connection_config.js`:
+ *
+ * ```js
+ * this.ssl = typeof options.ssl === 'string'
+ *   ? ConnectionConfig.getSSLProfile(options.ssl)
+ *   : options.ssl || false;
+ * if (this.ssl) {
+ *   if (typeof this.ssl !== 'object') {
+ *     throw new TypeError(`SSL profile must be an object, instead it's a ${typeof this.ssl}`);
+ *   }
+ *   this.ssl.rejectUnauthorized = this.ssl.rejectUnauthorized !== false;
+ * }
+ * ```
+ *
+ * ```text
+ * {host,port,database,user, ssl:true}  -> TypeError: SSL profile must be an object, instead it's a boolean
+ * {host,port,database,user, ssl:{}}    -> ssl {rejectUnauthorized:true}
+ * ```
+ *
+ * `true` is exactly what `resolveSslOption` answers for the two commonest
+ * declarations — `ssl: { enabled: true }` with no certificate material, and the
+ * `config.ssl` shorthand, whose schema (`DriverSslToggleSchema`) is
+ * `z.boolean()` and so has no other authorable value. So the mysql arm's
+ * DISCRETE-FIELDS branch — the one #8874 describes as honouring the
+ * declaration — has been handing `mysql2` a value that makes every connection
+ * acquisition throw. That is the same declared-≠-enforced defect as the dropped
+ * DSN-branch block, one spelling further along, and it is fixed here rather
+ * than beside it: emitting `ssl: true` onto the DSN branch to "honour" the
+ * declaration would have shipped the throw to a second branch.
+ *
+ * ## Why `{}` is a translation and not a new policy
+ *
+ * `resolveSslOption` states the equivalence itself, above: the boolean IS the
+ * collapsed empty-options object (*"`ssl: {}` would read as 'TLS with default
+ * options' … which is what `enabled: true` with nothing else means anyway"*).
+ * This re-expands the same value for the client that cannot read the collapsed
+ * form. `rejectUnauthorized: true` on the result is `mysql2`'s own default for
+ * an object (line 171 above), not a verification policy chosen here.
+ *
+ * Everything else passes through untouched — an options object stays byte for
+ * byte what the TLS block resolved to, `false` stays `false` (mysql2's own
+ * default, so it disables nothing that was enabled), and a stored row holding a
+ * profile name (`'Amazon RDS'`) still reaches `getSSLProfile`.
+ */
+function mysqlSslOption(resolved: unknown): unknown {
+  return resolved === true ? {} : resolved;
 }
 
 /**
@@ -595,7 +654,9 @@ function buildSqlPool(spec: DatasourceConnectionSpec): Record<string, unknown> {
  *
  * `mysql2` merges a `uri` with sibling keys itself, and the EXPLICIT key wins
  * (`ConnectionConfig`: uri-derived values are only filled in for keys the
- * caller did not supply). So the DSN keeps being parsed by the client that
+ * caller supplied no TRUTHY value for — see the falsy-value note under #8874
+ * below, which matters for `ssl` and not for a bound secret). So the DSN keeps
+ * being parsed by the client that
  * owns its grammar — no URL parsing, no re-encoding, no second dialect of
  * `mysql://…` in this repo — and the bound secret overrides even a legacy
  * embedded password on a stored pre-#8082 row. Measured on mysql2 3.23.1:
@@ -624,21 +685,72 @@ function buildSqlPool(spec: DatasourceConnectionSpec): Record<string, unknown> {
  * clients disagreeing is exactly why each arm's precedence is measured rather
  * than assumed.
  *
- * A DSN with NOTHING bound still passes through as the bare string, so a
- * datasource that never bound a secret is byte-for-byte unaffected.
+ * ## A declared `ssl` reaches the client on the DSN branch too (#8874)
+ *
+ * The gap the paragraph above used to describe as "filed separately". This arm
+ * resolved the TLS option and then returned before anything could use it, so a
+ * mysql datasource that declared TLS **and** wrote a `config.url` negotiated no
+ * TLS at all — declared, resolved, dropped, with no diagnostic, while the
+ * discrete-fields branch of the same arm carried it. Whether a connection was
+ * encrypted therefore depended on which branch of one arm the datasource
+ * happened to take, which is the `datasource.pool` failure shape #5714 / #7243
+ * closed for a different key.
+ *
+ * `MysqlConfigSchema` declares the key honoured with no branch caveat (*"TLS
+ * settings, passed to `mysql2`"*), and its `sslmode` / `tls` / `usessl` aliases
+ * all rewrite to it — where the schema means "not honoured, put it in the url"
+ * it says so in as many words, as the `charset` guidance does. The mongo arm's
+ * *"TLS is a connection-string concern here"* guidance is that arm's, not this
+ * one's. So the triage ruling (honour the declared channel; refuse only if the
+ * branch genuinely cannot) applies with nothing to refuse: `mysql2` reads a
+ * DSN and the `ssl` option as separate channels, exactly as `pg` does, and the
+ * explicit key is the one it keeps.
+ *
+ * ```text
+ * mysql2 3.23.1, no connection opened
+ * {uri:'mysql://app@db.internal:3306/app'}                    -> ssl false      (before)
+ * {uri:'mysql://app@db.internal:3306/app', ssl:{}}            -> ssl {rejectUnauthorized:true}
+ * {uri:…, ssl:{rejectUnauthorized:false}, password:'INJECTED'} -> ssl {rejectUnauthorized:false}, password INJECTED
+ * ```
+ *
+ * ⚠️ mysql2's merge skips a **falsy** explicit value, not merely an absent one
+ * — `if (options[key]) continue;` in `lib/connection_config.js`, which is
+ * looser than a hasOwnProperty rule would be. It costs nothing here: a
+ * declared `ssl: false` is also mysql2's own default, so the only value it
+ * cannot override is a DSN's own `?ssl=`, and mysql2 parses that to a boolean
+ * and throws on it with or without this change.
+ *
+ * ## The shape only changes for datasources that were broken
+ *
+ * A bare DSN string is what knex has always parsed for the no-secret case, and
+ * `ssl` cannot be attached to a string — so honouring a declaration there means
+ * returning an object instead. That return is therefore made **only when a
+ * declared `ssl` actually resolved**; a datasource that declared none still
+ * gets the bare string, byte for byte. The switch is safe where it does happen:
+ * knex's own parse of the string and mysql2's parse of the same value as `uri`
+ * were compared key-by-key (`host`/`port`/`user`/`password`/`database`/
+ * `charset`/`timezone`/`connectTimeout`/`flags`/`socketPath`/
+ * `multipleStatements`) across the bare-username, embedded-password,
+ * no-userinfo, portless, percent-encoded-username and query-parameter
+ * (`?charset=`, `?connectTimeout=`, `?timezone=`) forms — **identical in every
+ * case**. That sweep is pinned in `mysql-dsn-ssl.test.ts`, not merely done once
+ * here.
  */
 function buildMysqlConnection(spec: DatasourceConnectionSpec): unknown {
   const cfg = (spec.config ?? {}) as Record<string, unknown>;
-  const mysqlSsl = resolveSslOption(spec);
+  const mysqlSsl = mysqlSslOption(resolveSslOption(spec));
   const url = cfg.url as string | undefined;
   if (url) {
-    if (!spec.secret) return url;
-    // `ssl` is deliberately NOT carried here: this arm drops a declared `ssl`
-    // block on the DSN branch whether or not a secret is bound (postgres'
-    // branch does carry it), and making TLS appear only for datasources that
-    // happen to bind a credential would be a second, stranger asymmetry. That
-    // gap is a defect of its own and is filed separately, not fixed in passing.
-    return { uri: url, password: spec.secret };
+    // Nothing to carry beside the DSN: the bare-string passthrough this arm has
+    // always emitted, unchanged. The blast radius of both #8696 and #8874 is
+    // "something was declared", so a datasource that declared neither a secret
+    // nor TLS must not move at all.
+    if (mysqlSsl === undefined && !spec.secret) return url;
+    return {
+      uri: url,
+      ...(spec.secret ? { password: spec.secret } : {}),
+      ...(mysqlSsl !== undefined ? { ssl: mysqlSsl } : {}),
+    };
   }
   return {
     host: cfg.host,


### PR DESCRIPTION
Fixes #8874

A mysql datasource that declared TLS **and** wrote a `config.url` negotiated no TLS at all. `buildMysqlConnection` resolved the option and then returned before anything could use it — declared, resolved, dropped, with no diagnostic — while the discrete-fields branch of the same arm carried it. Whether a connection was encrypted therefore depended on which branch of one arm the datasource happened to take.

The fork the card poses ("wire it, or refuse loudly") is taken as ruled at triage: **honour the declared channel**. There is nothing to refuse. `MysqlConfigSchema` declares the key honoured with no branch caveat, its `sslmode` / `tls` / `usessl` aliases all rewrite to it, and where that schema means "not honoured, put it in the url" it says so in as many words — the `charset` guidance does exactly that, and `ssl` does not. The *"TLS is a connection-string concern here"* line the card half-remembers is the **mongo** arm's guidance, not this one's. And mechanically the branch can honour it: `mysql2` reads a uri and the `ssl` option as separate channels, exactly as `pg` does.

## The card's cost estimate was wrong in a way that mattered, twice

**Half one — the no-secret sub-case is not one line.** With a secret bound, #8696 already made the branch return `{ uri, password }` and adding `ssl` there really is one line. With no secret bound the branch returned `if (!spec.secret) return url;` — a **bare string**, which has no key an `ssl` option can live in. That is the return-shape change the card flagged as deserving its own decision, and it is where most of this diff's care went.

**Half two — the branch the card calls "honouring it" was throwing.** Found while measuring half one. Measured on mysql2 3.23.1, `lib/connection_config.js`, no connection opened:

```text
{host,port,database,user, ssl:true}   -> TypeError: SSL profile must be an object, instead it's a boolean
{host,port,database,user, ssl:{}}     -> ssl {rejectUnauthorized:true}
{uri:'mysql://app@db.internal:3306/app'}          -> ssl false        (the dropped DSN case)
{uri:'mysql://app@db.internal:3306/app', ssl:{}}  -> ssl {rejectUnauthorized:true}
```

`true` is exactly what `resolveSslOption` answers for the two commonest declarations: `ssl: { enabled: true }` with no certificate material, and the `config.ssl` shorthand, whose schema is `z.boolean()` and therefore has **no other authorable value**. So the discrete-fields branch has been handing `mysql2` a value that makes every `acquireRawConnection` throw. `pg` takes a boolean; `mysql2` takes an object or a bundled profile name.

## What was fixed here, and why the second half is not scope creep

Both halves, in one arm, because they are one defect wearing two spellings — and because **emitting `ssl: true` onto the DSN branch to "honour" the declaration would have shipped the throw to a second branch**. Delivering this card's own acceptance criterion (a declared `ssl` *reaches the client*) requires the translation; applying it to only one branch would have planted the exact per-branch asymmetry this card exists to remove.

The translation is forced, not chosen: `resolveSslOption`'s own comment already states the equivalence — *"`ssl: {}` would read as 'TLS with default options' … which is what `enabled: true` with nothing else means anyway"* — so `mysqlSslOption` re-expands the collapsed form for the one client that cannot read it. `rejectUnauthorized: true` on the result is mysql2's own default for an object (`this.ssl.rejectUnauthorized = this.ssl.rejectUnauthorized !== false`), not a verification policy invented here. Certificate objects, `false`, and a stored profile name (`'Amazon RDS'`) all pass through untouched.

No new dependency. `pg-connection-string`, new in this package from #9090, is a **postgres** DSN parser and is deliberately not reached for — `mysql2` parses its own uri, so no second dialect of `mysql://…` enters this repo.

## The blast radius is exactly the broken population

The DSN branch returns an object instead of the bare string **only when a declared `ssl` actually resolved** (`mysqlSsl !== undefined`) — or when a secret is bound, unchanged from #8696. A datasource that declared neither still gets the byte-identical string knex has always parsed for it. That scoping is asserted, not merely intended: `leaves a DSN with NOTHING declared exactly as it was` and `leaves a DSN with only a secret bound as the #8696 shape` are two of the six cases that stay green under ablation.

Where the switch does happen the DSN moves from knex's own connection-string parser to mysql2's, so every non-TLS key it contributed has to arrive unchanged. Compared key-by-key on `host` / `port` / `user` / `password` / `database` / `charset` / `timezone` / `connectTimeout` / `flags` / `socketPath` / `multipleStatements`, across the bare-username, embedded-password, no-userinfo, portless, percent-encoded-username and query-parameter (`?charset=`, `?connectTimeout=`, `?timezone=`) forms: **identical in every case**. Pinned as a test, not measured once.

So the only datasources whose behaviour moves are the ones that were already broken — connecting in cleartext against their own metadata, or unable to connect at all.

A correction to an existing comment rides along, because this change depends on it: the #8696 paragraph describes mysql2's merge as filling in "keys the caller did not supply". It is actually `if (options[key]) continue;` — **falsy**, not absent. Harmless for a bound secret (always truthy), load-bearing for `ssl`, so it is now stated precisely.

## The stale comment the card asked about

The in-code comment declaring the omission deliberate and "filed separately" is gone, replaced by the section documenting how it was closed.

## The pin asserts at the client-resolution layer

Inherited from #9042 and #8873 rather than re-learned: every assertion reads what **mysql2 resolved** — `ConnectionConfig`, from the mysql2 module knex resolved for itself (`knex.client.driver`), fed the exact `connectionSettings` knex will hand it. Nothing asserts on the `connection` object the factory built, except the two places where the return *shape* is itself the claim (a string cannot carry an `ssl` key), and their comments say so.

Here that constraint is sharper than it was on the sibling cards: the boolean half is **invisible at the config layer by construction** — `{ ssl: true }` is a perfectly good-looking object, and only the client's own parse says otherwise. `new ConnectionConfig(settings)` does no I/O, which is what makes the seam assertable without a server.

### Reverse verification — predicted in writing, then measured

Predicted before running, with the pre-fix branch restored and the tests at their fixed state: **8 failed / 6 passed**, and specifically which. Measured exactly that set, case for case:

```text
× carries a declared TLS block onto the DSN branch with no secret bound
    AssertionError: expected false to deeply equal { rejectUnauthorized: true }
× carries TLS and a bound secret together on the DSN branch
    AssertionError: expected false to deeply equal { rejectUnauthorized: false }
× carries certificate material onto the DSN branch verbatim
    AssertionError: expected false to deeply equal { …(2) }
× carries the `config.ssl` on/off shorthand onto the DSN branch
    AssertionError: expected false to deeply equal { rejectUnauthorized: true }
× returns an object rather than the bare DSN string once TLS is declared
    AssertionError: expected 'string' to be 'object'
× honours a declared `enabled: false` on the DSN branch
    AssertionError: expected 'string' to be 'object'
× resolves TLS on the discrete-fields branch instead of throwing on a boolean
    TypeError: SSL profile must be an object, instead it's a boolean
× resolves the `config.ssl` shorthand on the discrete-fields branch too
    TypeError: SSL profile must be an object, instead it's a boolean
```

The last two are the sharper direction and the reason this file pins a branch the card describes as working: they go red by a **different route** from every other failure — the old branch *did* carry the option, as a value the client refuses. The six that stayed green are the ones that must not move: the two blast-radius bounds, the parser-equivalence sweep (it compares two parses, not the fix), and the three discrete-branch cases whose declaration was never the broken spelling.

The ablation was restored from the commit and proven byte-identical (`git hash-object` on the restored file equals `git rev-parse` of the same path at HEAD). Nothing is built for it: these tests import the factory source through the `.js`-to-`.ts` test alias, so the ablated code is the code that ran.

## Verification

All at `89c2e7ea`, the final commit, tree clean.

```text
pnpm --filter '@objectstack/service-datasource^...' build   success (fresh-worktree closure)
pnpm --filter @objectstack/service-datasource test          21 files, 468 tests passed (14 new)
pnpm --filter @objectstack/service-datasource typecheck     clean
```

Gates — everything `node scripts/pm/dispatch-gates.mjs` derived for the actual changed paths (seven path-matched, five convention-triggered by adding a test file), plus `check:nul-bytes`. All green:

```text
check:nul-bytes · check:changeset-gate-self-tests · check:objectui-changeset
check:test-source-alias · check:type-source-resolution · check-adr-0087-registration
check-changeset-no-major · check-empty-changeset · check:engine-double-contract
check:where-matcher · check:query-options-erasure · check:type-check-coverage
```

Not run locally: `check:type-check-debt --re-measure`. It needs the whole workspace closure built and re-runs `tsc` per **ledger entry** — `service-datasource` carries no entry (it declares a real `typecheck` script and passes it, green above), so nothing in this diff can move that ratchet. Its structural half is green above. CI runs it either way.

## Out of scope, filed not fixed

- #9125 — `MysqlConfigSchema.ssl`'s doc line still says "passed to `mysql2` verbatim", which this change makes stale for the boolean. It lands in `packages/spec`, a different verification surface (authorable-surface anchor, JSON-Schema projection), so it is a separate card rather than a rider. Nothing in this diff touches `packages/spec`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_