### PR TITLE
fix(service-automation): sys_automation_run reads the declared tenantId, and pin the org-attribution defect with its negative control (cloud#1395)

### DIFF
--- a/.changeset/org-less-customer-activity-1395.md
+++ b/.changeset/org-less-customer-activity-1395.md
@@ -1,0 +1,10 @@
+---
+'@objectstack/service-automation': patch
+'@objectstack/plugin-approvals': patch
+---
+
+`sys_automation_run` resolves its organization from the DECLARED `AutomationContext.tenantId` and from no other spelling (cloud#1395).
+
+The suspended-run store read `context.organizationId ?? context.tenantId`. `AutomationContext` declares `tenantId` and not `organizationId`, and no producer writes the latter — `RecordChangeTrigger.buildContext` maps the hook session's organization onto `tenantId`, and the runtime's automation domain sets `tenantId` directly. The dead limb was not inert: the one test covering `sys_automation_run.organization_id` fed the phantom key, so the column's only coverage exercised a path production cannot reach and said nothing about the live one. The limb is removed, the fixture speaks the declared contract, and a test now asserts the absence so restoring the alias goes red.
+
+Both `sys_approval_request.organization_id` and `sys_automation_run.organization_id` now document the measured attribution defect this uncovered and the negative control that makes it a defect: on a walled single-database boot these two tables stored customer activity with no organization (27/27 and 31/31) while `sys_audit_log` (1669 rows) was correctly attributed on the same boot, because the audit writer resolves the organization from the record the row is ABOUT rather than from the acting context. The write-side repair is not in this change — which column a side-table row should follow is an open contract question, since the audit resolver is scope-pinned to audit stamping by the #8778 ruling. The current behaviour is pinned by test so the fix must promote the assertion rather than quietly satisfy it.

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -87,10 +87,45 @@ export const SysApprovalRequest = ObjectSchema.create({
   fields: {
     id: Field.text({ label: 'Request ID', required: true, readonly: true, group: 'System' }),
 
+    // ⚠️ MEASURED DEFECT, cloud#1395 — read this before trusting the column.
+    //
+    // An approval request DOES belong to an organization: it is read through the
+    // organization wall by the approvals inbox, and on a shared-database
+    // deployment a row carrying no organization is not filtered BY that wall —
+    // it is either invisible to everyone or visible to everyone, decided by
+    // whatever filter each surface happens to apply rather than by the data.
+    //
+    // The value is resolved from the ACTING CONTEXT only (`openNodeRequest`'s
+    // `ctxOrg`), so it is NULL whenever the flow that opened the request ran
+    // without one — every schedule / time-relative / api triggered run, none of
+    // which sets a tenant. On a walled single-database HotCRM SaaS boot this
+    // measured 27 of 27 rows org-less, each naming an `object_name` /
+    // `record_id` owned by a specific customer.
+    //
+    // ⛔ Do NOT read that as "platform tables do not carry an organization".
+    // `sys_audit_log` (1669 rows) was correctly attributed on the SAME boot,
+    // because its writer takes the organization from the RECORD the row is
+    // about, with the session only as fallback (plugin-audit
+    // `resolveRecordOrganizationField`, #8707 honouring #8287's ruling). Two
+    // writers read the actor; a third reads the subject. That disagreement is
+    // the defect.
+    //
+    // Which of the two a side-table row should follow is an open contract
+    // question on cloud#1395 — the audit resolver is scope-pinned to audit
+    // stamping by the #8778 ruling, so this writer needs its own. The same
+    // `ctxOrg` also stamps `sys_approval_action` and `sys_approval_approver`,
+    // so all three move together.
     organization_id: Field.lookup('sys_organization', {
       label: 'Organization',
       required: false,
       group: 'System',
+      // ⛔ String unchanged on purpose: it is extracted into the generated i18n
+      // bundles (`translations/*.objects.generated.ts`, as `help`), so rewording
+      // it is a translation-regeneration change and not a comment. The
+      // correction it needs — it claims a propagation that measurably does not
+      // happen, and says "Tenant" where ADR-0120 §Terminology requires
+      // "organization" — rides the cloud#1395 write-side fix, which rewrites the
+      // sentence and regenerates the four locales in one pass.
       description: 'Tenant that owns this approval request (propagated from submitter context)',
     }),
 

--- a/packages/services/service-automation/src/suspended-run-store.test.ts
+++ b/packages/services/service-automation/src/suspended-run-store.test.ts
@@ -75,7 +75,13 @@ const baseRun = (): SuspendedRun => ({
     nodeId: 'approve_step',
     variables: { $runId: 'run_abc', pause: { snapshot: { nested: { value: 42 }, arr: [1, 2, 3] } } },
     steps: [{ nodeId: 'start', nodeType: 'start', status: 'success', startedAt: '2026-01-01T00:00:00.000Z' }],
-    context: { object: 'crm_deal', userId: 'u1', organizationId: 'org_1', record: { id: 'd1', amount: 100 } } as any,
+    // [cloud#1395] `tenantId`, NOT `organizationId`. This fixture used to spell
+    // it `organizationId` — a key `AutomationContext` does not declare and no
+    // producer writes — and `serialize()` carried a matching consumer-side alias
+    // limb, so this assertion passed against a path production never takes. The
+    // fixture now speaks the declared contract, which is what makes
+    // `organization_id: 'org_1'` below evidence about the real writer.
+    context: { object: 'crm_deal', userId: 'u1', tenantId: 'org_1', record: { id: 'd1', amount: 100 } } as any,
     startedAt: '2026-01-01T00:00:00.000Z',
     startTime: 1735689600000,
     correlation: 'areq_1',
@@ -539,5 +545,80 @@ describe('ObjectStoreSuspendedRunStore — trigger attribution columns (#7533)',
         });
         expect(hits).toHaveLength(1);
         expect(hits[0].id).toBe('run_r6');
+    });
+});
+
+// ─── Organization attribution on the row (cloud#1395) ────────────────────────
+//
+// The finding this pins was measured from UNDER the wall, on a walled
+// single-database HotCRM SaaS boot (cloud#1338's `verify-hotcrm-saas.mjs`,
+// check `a4`): `sys_automation_run` carried `organization_id = NULL` on 31 of
+// 31 rows while every one of them described a record owned by a specific
+// customer — on a boot where `sys_audit_log` (1669 rows) was correctly
+// attributed. That negative control is the whole reason this is a defect and
+// not "platform tables do not carry an organization", so it is restated in
+// every comment here and must stay restated.
+//
+// These assertions read the persisted CELL for the same reason the #7533 group
+// above does: the column is what a wall filters on, and what an inbox query
+// filters by. A value that round-trips through the mapper but never reaches the
+// cell is invisible to both.
+describe('ObjectStoreSuspendedRunStore — organization attribution (cloud#1395)', () => {
+    it('takes the organization from the DECLARED `tenantId`, and reads no other spelling', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+
+        await store.save({ ...baseRun(), context: { object: 'crm_deal', tenantId: 'org_1' } as any });
+        expect(engine.rows.get('run_abc').organization_id).toBe('org_1');
+    });
+
+    it('⛔ does NOT read a `context.organizationId` — the key is undeclared and has no producer', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+
+        // `AutomationContext` declares `tenantId` and not `organizationId`, and
+        // no trigger surface writes the latter. A consumer-side alias for it
+        // would be a second de-facto contract (PD #12) — and was worse than
+        // inert here, because the only test covering this column fed it, so the
+        // column's sole coverage exercised a path production cannot reach.
+        // Falsifiability: restore the alias limb in `serialize()` and this goes
+        // red, which is the point of asserting the ABSENCE rather than trusting
+        // the removal.
+        await store.save({ ...baseRun(), context: { object: 'crm_deal', organizationId: 'org_1' } as any });
+        expect(engine.rows.get('run_abc').organization_id).toBeNull();
+    });
+
+    // ⛔ PINNED DEFECT — this is cloud#1395 IN THE SHAPE MEASURED, not a
+    // specification of desired behaviour. It asserts what the writer does
+    // today: a run whose trigger carried no acting tenant persists NO
+    // organization, even though `trigger_object` / `trigger_record_id` on the
+    // very same row name a record that belongs to one.
+    //
+    // The schedule, time-relative and api triggers set no tenant AT ALL — by
+    // construction, since a scheduled sweep has no single acting organization —
+    // so this is not an edge case, it is every run those triggers produce.
+    //
+    // ⛔ When the write side is fixed, this test must FAIL and be rewritten to
+    // assert the organization resolved from the trigger record. Do not "repair"
+    // it to keep it green; a pinned defect that quietly adapts to the fix is the
+    // unfalsifiable green this whole line of work exists to prevent. Its sibling
+    // pin is check `a4` in cloud's `verify-hotcrm-saas.mjs`, which carries the
+    // same instruction and must be promoted in the same change.
+    it('PINNED: a tenant-less trigger context persists organization_id = NULL beside a record that HAS an organization', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+
+        // The shape a schedule / api trigger produces: a real triggering record,
+        // carrying its own `organization_id`, and no tenant on the context.
+        await store.save({
+            ...baseRun(),
+            context: { object: 'crm_deal', record: { id: 'd1', organization_id: 'org_1' } } as any,
+        });
+
+        const row = engine.rows.get('run_abc');
+        expect(row.trigger_record_id, 'the row names the record it is about').toBe('d1');
+        // …and stores no organization for it. Both halves asserted together:
+        // the NULL alone would be satisfiable by a row that describes nothing.
+        expect(row.organization_id, 'PINNED DEFECT cloud#1395 — fix this and PROMOTE the assertion').toBeNull();
     });
 });

--- a/packages/services/service-automation/src/suspended-run-store.ts
+++ b/packages/services/service-automation/src/suspended-run-store.ts
@@ -394,7 +394,33 @@ export class ObjectStoreSuspendedRunStore implements SuspendedRunStore {
   /** Flatten a run into a `sys_automation_run` row (state columns JSON-encoded). */
   private serialize(run: SuspendedRun): Record<string, unknown> {
     const ctx = (run.context ?? {}) as Record<string, unknown>;
-    const org = ctx.organizationId ?? ctx.tenantId ?? null;
+    // [cloud#1395] `tenantId` is the ONLY spelling — it is the field
+    // `AutomationContext` declares for the triggering identity's organization,
+    // and the only one any producer writes: `RecordChangeTrigger.buildContext`
+    // maps the hook session's `organizationId` onto it, and the runtime's
+    // automation domain sets it directly. A `ctx.organizationId` limb used to
+    // sit ahead of this read with ZERO producers behind it (PD #12 — the
+    // consumer-side alias that fossilizes a second de-facto contract), and it
+    // was not harmless: the ONE test asserting this column fed the phantom key,
+    // so the only coverage `organization_id` had proved the dead limb worked
+    // and said nothing about the live one. Removed rather than kept "for
+    // safety"; a producer that wants this row attributed sets the declared
+    // `tenantId`.
+    //
+    // ⚠️ MEASURED, and NOT fixed by the line above (cloud#1395): this resolves
+    // to null on every trigger path that carries no acting tenant — the
+    // schedule, time-relative and api triggers set none at all, by
+    // construction, because a scheduled run has no one organization. Those runs
+    // persist `organization_id = NULL` while describing a record that DOES
+    // belong to a customer. `sys_audit_log` does not have this defect on the
+    // same boot because its writer resolves the organization from the RECORD it
+    // describes (plugin-audit `resolveRecordOrganizationField`, #8707 honouring
+    // #8287's ruling) and falls back to the session only when the record has
+    // none. ⛔ Do not read that asymmetry as "platform tables carry no org" —
+    // it is two writers reading the acting context where a third reads the
+    // subject. Which column a side-table row should take its organization from
+    // is the open contract question on cloud#1395.
+    const org = ctx.tenantId ?? null;
     // #7533 — the same three trigger columns the terminal path writes. A paused
     // row is a `sys_automation_run` row too, and leaving them null here would
     // make "which runs did this record provoke?" answer for finished runs while

--- a/packages/services/service-automation/src/sys-automation-run.object.ts
+++ b/packages/services/service-automation/src/sys-automation-run.object.ts
@@ -67,10 +67,41 @@ export const SysAutomationRun = ObjectSchema.create({
   fields: {
     id: Field.text({ label: 'Run ID', required: true, readonly: true, group: 'System' }),
 
+    // ⚠️ MEASURED DEFECT, cloud#1395 — read this before trusting the column.
+    //
+    // The value is resolved from the ACTING CONTEXT (`AutomationContext.
+    // tenantId`) and from nothing else, so it is NULL for every run whose
+    // trigger carries no acting organization — which is all of them on the
+    // schedule, time-relative and api triggers, none of which sets a tenant, by
+    // construction: a scheduled sweep has no one acting organization. On a
+    // walled single-database HotCRM SaaS boot this measured 31 of 31 rows
+    // org-less, each one naming a `trigger_object` / `trigger_record_id` that
+    // DOES belong to a specific customer.
+    //
+    // ⛔ Do NOT read that as "platform tables do not carry an organization".
+    // The negative control on the same boot refutes it: `sys_audit_log` (1669
+    // rows) was correctly attributed throughout, because its writer resolves the
+    // organization from the RECORD the row is about and falls back to the
+    // session only when the record has none (plugin-audit
+    // `resolveRecordOrganizationField`, #8707 honouring #8287's ruling). Three
+    // platform side tables, two answers — that disagreement is the defect, not
+    // the column.
+    //
+    // Which column a side-table row should take its organization from is an
+    // open contract question on cloud#1395: the audit writer's resolver is
+    // scope-pinned to audit stamping by the #8778 ruling, so a second consumer
+    // needs its own. Pinned meanwhile by `suspended-run-store.test.ts`
+    // ('PINNED: a tenant-less trigger context…') and by check `a4` in cloud's
+    // `verify-hotcrm-saas.mjs`; both must be PROMOTED, never repaired, when the
+    // write side is fixed.
     organization_id: Field.lookup('sys_organization', {
       label: 'Organization',
       required: false,
       group: 'System',
+      // ⛔ String unchanged on purpose — same reason as
+      // `sys_approval_request.organization_id`: it is extracted into the
+      // generated i18n bundles, so the reword rides the write-side fix and its
+      // regeneration pass rather than arriving as a silent bundle drift here.
       description: 'Tenant that owns this run (propagated from the trigger context)',
     }),
 


### PR DESCRIPTION
Part of objectstack-ai/cloud#1395. This lands the half that is unambiguous and pins the half that is not; the write-side repair needs a maintainer ruling (see "The open question" below).

## What was measured

cloud#1395 reported, from under the wall on a walled single-database HotCRM SaaS boot, that `sys_approval_request` (27/27) and `sys_automation_run` (31/31) store `organization_id = NULL` while naming records owned by specific customers — on a boot where `sys_audit_log` (1669 rows) is correctly attributed.

The card's first question was whether the column is **declared but unwritten** or **absent entirely**. Neither, exactly:

- Both objects **declare** `organization_id` as a `sys_organization` lookup, and both writers **do** write it.
- They write it from the **acting context** only — `ctxOrg` in `ApprovalService.openNodeRequest`, `ctx.tenantId` in `ObjectStoreSuspendedRunStore.serialize`, `record.organizationId` in `recordTerminal`.
- That context carries no organization on the schedule, time-relative and api triggers. None of them sets a tenant at all, and that is correct by construction: a scheduled sweep has no one acting organization. So the NULL is not an edge case — it is every run those triggers produce.

The negative control explains itself once you read the third writer: `plugin-audit` resolves the organization from **the record the row is about**, with the session only as fallback (`resolveRecordOrganizationField`, #8707 honouring #8287's ruling). Two writers read the actor; a third reads the subject. **That disagreement is the defect** — not "platform tables do not carry an organization".

Semantically the answer is unambiguous: an approval request **does** belong to an organization. It is read through the organization wall by the approvals inbox, and on a shared database a row carrying none is not filtered by that wall — it is either invisible to everyone or visible to everyone, decided by whichever filter each surface happens to apply rather than by the data.

## What this PR changes

**1. A phantom alias, and the reason nobody caught this.** `serialize()` read `ctx.organizationId ?? ctx.tenantId`. `AutomationContext` declares `tenantId` and **not** `organizationId`, and no producer writes the latter — `RecordChangeTrigger.buildContext` maps the hook session's organization onto `tenantId`, the runtime's automation domain sets `tenantId` directly. The dead limb was worse than inert: the **one** test covering this column fed the phantom key, so the column's only coverage exercised a path production cannot reach. Limb removed, fixture moved to the declared contract, and the absence is now asserted so restoring the alias goes red.

**2. Both declarations document the measured defect and the negative control**, so the next reader cannot conclude "platform tables just don't carry an organization". Comments only — the `description` strings are extracted into the generated i18n bundles, so their reword rides the write-side fix and its regeneration pass rather than arriving as silent bundle drift here.

**3. The current behaviour is PINNED, not specified.** `PINNED: a tenant-less trigger context persists organization_id = NULL beside a record that HAS an organization` asserts what the writer does today, and says in its own comment that the fix must **promote** it, never repair it. Its sibling is check `a4` in cloud's `verify-hotcrm-saas.mjs`, which carries the same instruction.

## The open question — why the write-side repair is not here

The repair is to resolve the organization from the record the row describes, exactly as the audit writer does. Reusing that resolver is blocked by an explicit scope pin in `packages/spec/src/data/object.zod.ts`:

> Scope-pinned by the #8778 ruling: this is ONE stamp-only declaration key, not the opening move of a general field-roles mechanism — a consumer other than audit stamping needs its own ruling before reading it.

The fork is real, not procedural. `tenancy.organizationField` answers "which column says who this row is ABOUT"; `tenantField` / `organization_id` answers "what is this object WALLED by". For ordinary business objects they coincide. For `sys_api_key` they deliberately do not — and an approval row and an audit row about the same record would then land in **different** organizations, which is the same two-tables-disagree pathology this card exists to end. Picking a side silently is what I declined to do; the options and a recommendation are in the report on cloud#1395.

## Verification

Union re-derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs`, and run at the head below.

```
git rev-parse --short HEAD  ->  e9daa7f9e

pnpm --filter @objectstack/service-automation --filter @objectstack/plugin-approvals test
  service-automation   Test Files  80 passed (80)   Tests  965 passed (965)
  plugin-approvals     Test Files  23 passed (23)   Tests  486 passed (486)

pnpm --filter @objectstack/plugin-approvals typecheck   ->  clean
check:nul-bytes / check:engine-double-contract / check:where-matcher
check:test-source-alias / check:empty-changeset          ->  PASS
node scripts/check-i18n-bundles.mjs  ->  OK (9 packages, all bundles in sync)
```

`check:i18n` was named by the derivation for the plugin-approvals edit and is green — which is the check on the comments-only decision above.

**Reverse verification.** Predicted direction: restoring the alias limb turns exactly the absence assertion red and leaves everything else green — an ablation that reddened the whole group would have meant the fixture change, not the limb, was carrying the tests.

```
ablated (const org = ctx.organizationId ?? ctx.tenantId ?? null):
  x  does NOT read a `context.organizationId` - the key is undeclared and has no producer
  Tests  1 failed | 25 passed (26)
restored: git diff --quiet -> byte-identical
```

_Generated by [Claude Code](https://claude.ai/code/session_0137TnZzVmkSjXxoSVgPFS6S)_


---
_Generated by [Claude Code](https://claude.ai/code/session_0137TnZzVmkSjXxoSVgPFS6S)_