### PR TITLE
fix(cli): correct os-doctor claim in --confirm-global-uniques comment

### DIFF
--- a/packages/cli/src/commands/package/install.ts
+++ b/packages/cli/src/commands/package/install.ts
@@ -74,8 +74,12 @@ export default class PackageInstall extends Command {
     // [ADR-0120 D5e] The installer's answer to the `isolated`-posture question.
     // Deliberately NOT default-on and deliberately not named `--force`: it
     // records an affirmative fact ("these constraints are genuinely
-    // platform-wide") into the install manifest, where `os doctor` can later
-    // show who affirmed it and when.
+    // platform-wide") into the install manifest, rather than overriding a
+    // check. `os doctor` reads that record back on every later run, but only
+    // to SUPPRESS re-reporting the constraints this ceremony already answered
+    // for (`unconfirmedGlobalUniques` in `@objectstack/types`) — an attested
+    // install does not become the recurring nag the gate exists to avoid. It
+    // does not display who affirmed it or when.
     'confirm-global-uniques': Flags.boolean({
       description:
         "Confirm this app's installation-wide (`unique: 'global'`) constraints are genuinely platform-wide when "


### PR DESCRIPTION
Fixes #9022

## The gap

The justification comment for `--confirm-global-uniques` in
`packages/cli/src/commands/package/install.ts` claimed `os doctor` "can
later show who affirmed it and when". That is not what `os doctor` does.

## What I verified before rewording

Per the triage comment's instruction, I did not trust the card's paraphrase
— I re-derived the claim from the actual code:

- `packages/cli/src/commands/doctor.ts` (`findUnscopedGlobalUniques`) reads
  `entry?.globalUniqueAttestation` and hands it to `unconfirmedGlobalUniques`
  purely to **subtract** already-affirmed findings from the tenancy
  advisory, so an attested install is not re-nagged on every later run.
- `unconfirmedGlobalUniques` (`packages/types/src/unique-scope-install-gate.ts`)
  reads only `attestation.posture` and `attestation.confirmed` — nothing
  else.
- A repo-wide grep for `attestedAt` / `attestedBy` (proved working first
  against known-present neighbours `posture` / `confirmed`, which the same
  grep surfaced correctly) turns up exactly four kinds of hit: the
  `GlobalUniqueAttestation` interface declaration, `recordGlobalUniqueAttestation`
  (the writer), and two unit-test files asserting the writer sets them. No
  production code anywhere reads either field for display. **The card's
  central claim holds** — nothing surfaces `attestedAt` / `attestedBy` today.

## The fix (comment-only, scope per triage)

Reworded the comment to describe the measured suppression behaviour instead
of the unearned "os doctor can show who/when" claim, while preserving the
two things the original got right: the flag is deliberately **not**
default-on, and deliberately **not** named `--force`, because it records an
affirmative fact rather than overriding a check.

```diff
-    // platform-wide") into the install manifest, where `os doctor` can later
-    // show who affirmed it and when.
+    // platform-wide") into the install manifest, rather than overriding a
+    // check. `os doctor` reads that record back on every later run, but only
+    // to SUPPRESS re-reporting the constraints this ceremony already answered
+    // for (`unconfirmedGlobalUniques` in `@objectstack/types`) — an attested
+    // install does not become the recurring nag the gate exists to avoid. It
+    // does not display who affirmed it or when.
```

## Out of scope (deferred by triage, not implemented here)

Surfacing `attestedAt` / `attestedBy` in `os doctor` output. Zero measured
pull today (no consumer reads them; the card was found while writing docs,
not from an operator request) — deferred under the startup-scope discipline
with a named restart condition (an operator or regulated-industry
requirement actually asking "who affirmed this and when"). The fields
themselves are **not** touched — `GlobalUniqueAttestation` still declares
`attestedAt`/`attestedBy` and `recordGlobalUniqueAttestation` still
maintains them; they remain the audit record the deferred restart condition
would consume.

## Changeset

None added. This changes a code comment only — no CLI behaviour, output, or
public API is different before/after. Nothing user-visible to describe in a
changelog.

## Tests

Comment-only change; verification is about not having broken anything and
about the claim above being true, not new behaviour to cover.

- `pnpm --filter '@objectstack/cli^...' build` — dependency closure builds
  clean.
- `pnpm --filter @objectstack/cli typecheck` — green (`tsc --noEmit`).
- `vitest run packages/cli/test/serve-marketplace-offline-install.test.ts
  packages/cli/test/package-install-storage-dir.test.ts` — 2 files, 14
  tests, all passing.
- `node scripts/check-cross-package-test-inputs.mjs` (named by
  `scripts/pm/dispatch-gates.mjs` for this path) — green.
- `node scripts/check-nul-bytes.mjs` on the edited file — clean.

All at head `68e57b101`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_