### PR TITLE
fix(ci): check-required-contexts' `carries` names the gate family instead of a step count that nothing asserts

### DIFF
--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -18,10 +18,10 @@
  * the merge queue), or, if the stale context is then quietly removed from the
  * settings to unwedge things, every gate that job carries degrades to advisory
  * with no signal anywhere. The second shape is #5617 verbatim: PR #5584 merged
- * with its ESLint job red for 19 minutes, because the job carrying 25 `check:*`
- * gates was not in the required set at all. Four more merges repeated it that
- * night (#6067/#6096/#6051/#6103) before the settings were fixed on
- * 2026-08-07.
+ * with its ESLint job red for 19 minutes, because the job carrying the whole
+ * `check:*` gate family was not in the required set at all. Four more merges
+ * repeated it that night (#6067/#6096/#6051/#6103) before the settings were
+ * fixed on 2026-08-07.
  *
  * ci.yml already writes this contract down in prose — at least eight places,
  * e.g. "the NAME is the required check, so renaming it would silently drop the
@@ -136,6 +136,22 @@ import { fileURLToPath } from 'node:url';
  * job id), and every matrix shard name. Assertions 4, 6 and 7 below are exactly
  * the machine-readable form of the first three exclusions, so enrolling one of
  * them by mistake fails here instead of in the merge queue.
+ *
+ * ⛔ `carries` names the gate FAMILY and never a step count — assertion 10
+ * enforces that, because prose here reads as measurement while being asserted
+ * by nothing. Both counts this registry used to carry were wrong on the day
+ * they were WRITTEN, not merely outgrown: at the authoring commit (d3e53f2d8,
+ * 2026-08-09) the ESLint entry said "(25 steps)" against a job running 35
+ * `pnpm check:*` steps, and the typecheck entry said "(33 steps)" against 10
+ * (43 by the loosest caliber that counts its `--filter` spellings, 29 by
+ * non-setup steps — no caliber yields 33, so what was even measured is no
+ * longer recoverable). 25 was roughly the ESLint count at the #5617 INCIDENT
+ * (24 on 2026-08-06), i.e. a historical figure that had drifted into a
+ * present-tense field. Then it rotted at about three steps a day: 24 → 54
+ * between 2026-08-06 and 2026-08-16, gaining two more while #9103 — the card
+ * reporting the staleness — sat open, every gate green throughout. The count
+ * is a property of the workflow, so the workflow is where it is read from: the
+ * job's own step list, one grep away and never stale (#9103).
  */
 export const REQUIRED_CONTEXTS = [
   {
@@ -143,14 +159,14 @@ export const REQUIRED_CONTEXTS = [
     job: 'lint',
     context: 'ESLint',
     authorized: '#5617 maintainer ruling 2026-08-07 — applied to the settings the same day',
-    carries: 'the whole check:* gate family (25 steps) — the job whose red did not block #5584',
+    carries: 'the whole check:* gate family — the job whose red did not block #5584',
   },
   {
     workflow: 'lint.yml',
     job: 'typecheck',
     context: 'TypeScript Type Check',
     authorized: '#5617 maintainer ruling 2026-08-07 — applied to the settings the same day',
-    carries: 'the type-check + generated-artifact gate family (33 steps)',
+    carries: 'the type-check + generated-artifact gate family',
   },
   {
     workflow: 'ci.yml',
@@ -271,6 +287,27 @@ export function judge({ registry, workflows }) {
       );
     } else {
       byContext.set(entry.context, entry);
+    }
+  }
+
+  // (10) `carries` describes the gate family; it may not embed a step count.
+  // A number in this field reads as a measurement of what the required context
+  // covers — the thing a reader consults to decide whether some gate is
+  // protected — while being asserted by nothing, so it rots green. Measured:
+  // both counts the registry once carried were already wrong at their authoring
+  // commit, and the ESLint job went 24 → 54 `check:*` steps in the ten days to
+  // 2026-08-16 with no gate anywhere noticing (#9103). Re-stamping the number
+  // would only reschedule that; the workflow's step list is the count.
+  for (const entry of registry) {
+    const counted = typeof entry.carries === 'string' ? entry.carries.match(/\b\d+\s+steps?\b/i) : null;
+    if (counted) {
+      problems.push(
+        `the registry's \`carries\` for '${entry.context}' embeds a step count (${JSON.stringify(counted[0])}). ` +
+          `That number is asserted by nothing and rots silently as the gate family grows — both counts this registry used to ` +
+          `carry were wrong on the day they were written, and the ESLint job's went 24 → 54 in ten days with every gate green ` +
+          `(#9103). Name the gate FAMILY here and let the '${entry.job}' job's step list in .github/workflows/${entry.workflow} ` +
+          `be the count.`,
+      );
     }
   }
 
@@ -659,6 +696,28 @@ async function selfTest() {
     workflows: new Map(Object.entries(sources).map(([f, text]) => [f, { doc: parse(text) }])),
   });
   assert(doubled.problems.some((p) => p.includes('twice')), 'a context registered against two jobs ⇒ red');
+
+  // ── (10) a `carries` string that embeds a step count ─────────────────────
+  // The rot mode #9103 recorded, now with an assertion on it. Both spellings
+  // the registry actually used are exercised, since the parenthesised form is
+  // the one a future author is most likely to reintroduce.
+  const workflowsFor = () => new Map(Object.entries(sources).map(([f, text]) => [f, { doc: parse(text) }]));
+  for (const spelling of ['the whole check:* gate family (25 steps)', 'the type-check family, 33 steps']) {
+    const stale = judge({
+      registry: [{ ...REQUIRED_CONTEXTS[0], carries: spelling }, ...REQUIRED_CONTEXTS.slice(1)],
+      workflows: workflowsFor(),
+    });
+    assert(
+      stale.problems.some((p) => p.includes('embeds a step count')),
+      `a \`carries\` string carrying a step count ⇒ red (${JSON.stringify(spelling)})`,
+    );
+  }
+  // The live registry must satisfy it — the half that would have been green for
+  // ten days while the real count doubled.
+  assert(
+    REQUIRED_CONTEXTS.every((entry) => !/\b\d+\s+steps?\b/i.test(entry.carries ?? '')),
+    'no entry in the real registry embeds a step count',
+  );
 
   // ── missing input is a failure, never a pass (#4690) ─────────────────────
   assert(judge({ registry: [], workflows: new Map() }).problems.length === 1, 'an empty registry ⇒ red, never a silent tick');

--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -809,7 +809,8 @@ async function selfTest() {
   }
   console.log(
     `✓ check-required-contexts --self-test: ${checked} assertions ` +
-      `(rename ablations across both workflows + matrix/continue-on-error/trigger shapes + the shard-name collision + the #4690 pins).`,
+      `(rename ablations across both workflows + matrix/continue-on-error/trigger shapes + the shard-name collision + ` +
+      `the \`carries\` step-count ban + the #4690 pins).`,
   );
 }
 


### PR DESCRIPTION
Fixes #9103

`check-required-contexts`' `carries` prose claimed the ESLint job carries 25 `check:*` steps. It does not — and the fix is not to write a bigger number.

## What I measured (not the card's 52, and not the dispatch's)

Counted at HEAD `1af1f9ba4`, by YAML-parsing `lint.yml` rather than slicing it textually:

| job | total steps | `pnpm check:*` steps | any `check:*` script (incl. `--filter` spellings) | registry said |
| --- | --- | --- | --- | --- |
| `lint` (ESLint) | 61 | **54** | 54 | 25 |
| `typecheck` (TypeScript Type Check) | 43 | 11 | 26 (28 counting direct `node scripts/check-*.mjs`) | 33 |

**Caliber**, stated because it is where this defect breeds: a step counts when its `run:` invokes a `check:*` npm script. Neither job declares a `strategy.matrix` (assertion 4 pins exactly that), so there is no expansion to count. For the ESLint job all three calibers agree at 54 — every check step uses the bare `pnpm check:*` spelling. For `typecheck` they do not agree, spanning 11 to 43, which is the point below.

The card measured 52 at `4e3a4c3c8`. I measure 54 at HEAD. Both are honest: **the job gained two steps while the card sat open.**

## Two findings the card did not have

**1. The counts were wrong on the day they were written, not merely outgrown.** At the pin's authoring commit `d3e53f2d8` (2026-08-09) the ESLint job ran 35 `pnpm check:*` steps while the entry said 25; the typecheck job ran 10 while its entry said 33. No caliber I tried reproduces 33 at that commit — 10 bare, 23 including `--filter` spellings, 29 non-setup, 38 total. So the number never measured anything recoverable. 25 was approximately the ESLint count at the #5617 **incident** (24 on 2026-08-06), i.e. a historical figure that drifted out of the header narrative into a present-tense field.

**2. There is a second stale count.** The `typecheck` entry's `(33 steps)` is the identical defect one line below the one the card names. Fixed here under the same change: leaving it would have closed the instance and kept the class.

## The drift curve, measured from git

`lint` job, `check:*` steps: 24 (08-06) → 29 (08-07) → 32 (08-08) → 36 (08-09) → 38 (08-11) → 47 (08-13) → 54 (08-16). About three a day, every gate green throughout.

## Why option 1 (re-stamp to 54) was rejected

The dispatch's hard criterion was to explain why a refreshed number would not rot again. I cannot, and the evidence runs the other way: the number gains ~3/day, and it moved by 2 during the few hours between the card being filed and being picked up. A re-stamp schedules the same card for next week.

## What this does instead — option 2, plus the guard that closes the class

- Both parenthetical counts are removed. `carries` now names the gate **family**; the authoritative count is the job's own step list in the workflow, one grep away and never stale.
- Line 21's header narrative drops its `25` too. That sentence describes the #5617 blast radius, for which "the whole `check:*` gate family" is both the durable fact and the point.
- **New assertion 10** in the pin's enforcement path: a `carries` string may not embed a step count. This is what the card observed was missing — the number was asserted by nothing. Re-adding one now turns `check:required-contexts` red on the PR that does it.

Assertion 10 costs no recurring maintenance, which is why it is preferable to option 3 (assert the count itself): asserting a step count would make every PR that adds a `check:` step also edit this registry — a mandatory cross-file edit on a repo doing ~18 merges/day, i.e. a merge-conflict magnet, in exchange for a number nothing consumes. `carries` has no programmatic consumers; I grepped.

## Verification

All at `1af1f9ba4`, the final commit:

```
✓ check-required-contexts --self-test: 55 assertions (rename ablations across both workflows +
  matrix/continue-on-error/trigger shapes + the shard-name collision + the `carries` step-count
  ban + the #4690 pins).
✓ check-required-contexts: 9 required context name(s) pinned across 3 workflow(s).
✓ check-nul-bytes: OK (scanned 5989 text files; no raw ASCII control bytes)
✓ eslint scripts/check-required-contexts.mjs — clean
```

Gate derivation over the actual changed path (`node scripts/pm/dispatch-gates.mjs scripts/check-required-contexts.mjs`) places exactly one family on this card, `check:required-contexts` — the one run above.

**Reverse verification** (direction decided in advance: red). With the original `(25 steps)` restored into the live registry, the pin exits 1 with assertion 10's finding, and the self-test's real-registry assertion fires:

```
✗ check-required-contexts — 1 problem(s)
  • the registry's `carries` for 'ESLint' embeds a step count ("25 steps"). That number is
    asserted by nothing and rots silently as the gate family grows …
```

The self-test also carries two permanent ablations covering both spellings a future author would reach for — `(25 steps)` and the unparenthesised `, 33 steps`.

No changeset: this is repo-internal CI tooling with no user-visible surface, so the PR carries `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_