### PR TITLE
fix(pm): make check:i18n derivable from a metadata form module edit

### DIFF
--- a/scripts/check-i18n-bundles.mjs
+++ b/scripts/check-i18n-bundles.mjs
@@ -28,8 +28,10 @@
 // `ObjectStackDefinitionSchema` strict (rejected option C, which would silence
 // the lint itself — see `metadata-authoring-lint.ts`).
 //
-// Coverage needs no manifest: `findConfigs` walks `packages/`, so a config that
-// lands tomorrow is gated tomorrow.
+// Coverage needs no manifest: `findExtractConfigs` walks `packages/`, so a
+// config that lands tomorrow is gated tomorrow. That walk is shared with the
+// dispatch-gates derivation rather than mirrored by it (#9116) — see
+// SURFACE_MODULE below.
 //
 // The command each package is checked with is not repeated here: it is parsed
 // out of the config file's own docstring, which already documents how to
@@ -84,9 +86,7 @@
 // is the classifier that closes that gap, and the verdict it raises is a hard
 // prerequisite failure naming the package whose dist is stale — never a count.
 import { spawnSync } from 'node:child_process';
-import { readFileSync, existsSync } from 'node:fs';
-import { readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import {
   CLI,
   CLI_BUILD_FIX,
@@ -96,6 +96,24 @@ import {
   resolveCliCommandFile,
   workspaceBuildFix,
 } from './cli-build-prerequisite.mjs';
+import { findExtractConfigs, flagsFromDocstring } from './i18n-bundle-surface.mjs';
+
+/**
+ * The module this gate's POPULATION is enumerated by, declared as a whole
+ * literal so the derivation can see it (#9116).
+ *
+ * `findConfigs` and `flagsFromDocstring` used to live in this file, and
+ * scripts/pm/dispatch-gates.mjs carried a hand-written mirror of the first —
+ * two spellings of one contract, agreeing only until one side moved. They are
+ * imported from one module now. That module is a real input of this gate, but
+ * an import specifier is not a discoverable watch hint (the leading `./`
+ * strips to a bare filename), so a card editing the shared enumeration would
+ * derive nothing at all. Naming it here as a bare module-body constant is what
+ * makes this family match such a card — the same declared-coupling shape
+ * check-type-check-coverage.mjs uses for the root-program script whose errors
+ * it ratchets, and it is pinned live in dispatch-gates' own self-test.
+ */
+const SURFACE_MODULE = 'scripts/i18n-bundle-surface.mjs';
 
 /** The one command this gate invokes per package, as oclif topic/command parts. */
 const EXTRACT_COMMAND_ID = ['i18n', 'extract'];
@@ -103,28 +121,11 @@ const write = process.argv.includes('--write');
 const filterArg = process.argv.find((a) => a.startsWith('--filter='));
 const filter = filterArg ? filterArg.slice('--filter='.length) : '';
 
-/** Every `scripts/i18n-extract.config.ts` under packages/. */
-function findConfigs(dir, out = []) {
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    if (e.name === 'node_modules' || e.name === 'dist' || e.name.startsWith('.')) continue;
-    const p = join(dir, e.name);
-    if (e.isDirectory()) findConfigs(p, out);
-    else if (e.name === 'i18n-extract.config.ts' && p.includes('/scripts/')) out.push(p);
-  }
-  return out;
-}
-
-/**
- * Read the regenerate command the config documents about itself. Every flag the
- * gate passes comes from there, so a package that changes its locales or output
- * directory updates one place and the gate follows.
- */
-function flagsFromDocstring(configPath) {
-  const src = readFileSync(configPath, 'utf8');
-  const head = src.slice(0, src.indexOf('*/') + 2);
-  const flags = head.match(/--(?:locales|fill|out)=[^\s\\*]+|--(?:objects-only|no-metadata-forms|no-merge)\b/g) ?? [];
-  return [...new Set(flags)];
-}
+// `findConfigs` (every scripts/i18n-extract.config.ts under packages/) and
+// `flagsFromDocstring` (the regenerate command each config documents about
+// itself) moved to the shared module named in SURFACE_MODULE above. This gate
+// and the dispatch-gates derivation now run the SAME walk instead of two
+// spellings of it; see that module's header for why the mirror had to go.
 
 // ---------------------------------------------------------------------------
 // Output classifiers. Pure string -> findings, so `--self-test` can drive them
@@ -653,7 +654,10 @@ function checkCliBuildPrerequisite() {
 
 checkCliBuildPrerequisite();
 
-const configs = findConfigs('packages').sort().filter((c) => !filter || c.includes(filter));
+const configs = findExtractConfigs('packages', 'packages')
+  .map((c) => c.rel)
+  .sort()
+  .filter((c) => !filter || c.includes(filter));
 if (configs.length === 0) {
   console.error(`check-i18n-bundles: no extract configs matched${filter ? ` --filter=${filter}` : ''}`);
   process.exit(1);

--- a/scripts/i18n-bundle-surface.mjs
+++ b/scripts/i18n-bundle-surface.mjs
@@ -58,7 +58,9 @@
  * and the registry module itself decides which forms are walked. Editing either
  * moves the same four bundles and matches no convention here, because neither
  * carries a filename that distinguishes it. Closing that edge needs an anchor
- * this module does not have; it is filed rather than guessed at.
+ * this module does not have, and the candidates trade off against each other
+ * rather than being one obvious shape, so it is filed rather than guessed at:
+ * issue 9144.
  */
 
 import { readFileSync } from 'node:fs';

--- a/scripts/i18n-bundle-surface.mjs
+++ b/scripts/i18n-bundle-surface.mjs
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * i18n-bundle-surface — the ONE enumeration of what moves a translation bundle.
+ *
+ * Two readers need the same answer and used to compute it apart:
+ *
+ *   - scripts/check-i18n-bundles.mjs   the GATE. Walks packages/ for extract
+ *     configs, reads each config's documented flags, re-extracts, fails on drift.
+ *   - scripts/pm/dispatch-gates.mjs    the DERIVATION. Has to predict, from a
+ *     card's file surface alone, whether that gate can move — before the code
+ *     exists.
+ *
+ * The derivation used to mirror the gate's walk by hand ("same skip set, same
+ * filename test", said its comment). A mirror is a second contract: it agrees
+ * until the day one side changes, and the day it disagrees nothing says so. So
+ * the walk lives here once and both import it — the shape scripts/cli-build-
+ * prerequisite.mjs already has for the two prerequisite classifiers this gate
+ * and check-i18n-coverage.mjs share.
+ *
+ * ## Why the metadata-forms half is here and not inferred
+ *
+ * A bundle has two producers, and only one of them lives in the package that
+ * owns the bundle:
+ *
+ *   - `objects` — the config's own package enumerates them, so the owning
+ *     package IS the trigger surface;
+ *   - `metadataForms` — registry-driven and identical for every stack, so
+ *     exactly one package commits that baseline (platform-objects today) and
+ *     every other config passes --no-metadata-forms. Its source is not in the
+ *     owning package at all: it is the form modules in packages/spec that
+ *     METADATA_FORM_REGISTRY collects.
+ *
+ * That second edge is what cost PR 9113 a CI round: two form entries were added
+ * in packages/spec, four platform-objects bundles moved, check:i18n went red,
+ * and no derivation from those paths could have named the family — the gate's
+ * own walk never reaches packages/spec, and packages/spec owns no extract
+ * config. The KIND is written down (a form module), the POPULATION is walked at
+ * runtime, and whether the surface is extracted AT ALL is read from the configs'
+ * own documented flags rather than assumed.
+ *
+ * ## The one convention this module writes down
+ *
+ * A metadata form module is a file whose name ends `.form.ts`. That is the
+ * producer's own convention, stated by the registry it feeds — packages/spec/
+ * src/system/metadata-form-registry.ts: "the FormView produced by
+ * defineForm({ schemaId }) in the corresponding *.form.ts". Measured on this
+ * tree when this module landed: 17 files in the repo carry that suffix, all of
+ * them under packages/spec/src, and the registry has exactly 17 entries with a
+ * form — the convention and the population coincide, with nothing left over on
+ * either side.
+ *
+ * What it deliberately does NOT cover, measured and stated so the next reader
+ * does not mistake silence for coverage: the type-level half of the same
+ * surface. `walkMetadataForms` in packages/cli/src/utils/i18n-extract.ts emits
+ * `metadataForms.TYPE.label`/`.description` for every entry of
+ * DEFAULT_METADATA_TYPE_REGISTRY (packages/spec/src/kernel/metadata-plugin.zod.ts),
+ * and the registry module itself decides which forms are walked. Editing either
+ * moves the same four bundles and matches no convention here, because neither
+ * carries a filename that distinguishes it. Closing that edge needs an anchor
+ * this module does not have; it is filed rather than guessed at.
+ */
+
+import { readFileSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+/** Directory entries no walk here descends into — the gate's original skip set. */
+const SKIPPED_DIRS = new Set(['node_modules', 'dist']);
+
+/** The filename every extract config carries. */
+export const EXTRACT_CONFIG_FILENAME = 'i18n-extract.config.ts';
+
+/**
+ * The flag a package passes to keep the shared Studio metadata-form baseline
+ * out of its own bundles.
+ *
+ * Mirrors the ONE condition the emitter uses (`emitsMetadataForms` in
+ * packages/cli/src/commands/i18n/extract.ts): the companion
+ * metadata-forms.generated.ts file is written when the `metadata-forms` boolean
+ * flag is on and the locale has keys. `--objects-only` is orthogonal — that one
+ * picks a sub-tree of the objects module and the emitter says so in its own
+ * comment — so it is deliberately not consulted here.
+ */
+export const METADATA_FORMS_OPT_OUT_FLAG = '--no-metadata-forms';
+
+/** The filename suffix of a metadata form module. See the module note. */
+export const METADATA_FORM_MODULE_SUFFIX = '.form.ts';
+
+/**
+ * Does this path name an extract config? The FILENAME plus a `scripts/`
+ * segment — the gate's original test, kept whole rather than approximated.
+ */
+export function isExtractConfigPath(path) {
+  return basename(path) === EXTRACT_CONFIG_FILENAME && path.includes('/scripts/');
+}
+
+/**
+ * Does this path name a metadata form module?
+ *
+ * The suffix must be preceded by a name: a file called exactly `.form.ts` is a
+ * dotted entry every walk here already skips, and accepting it would let the
+ * bare suffix match as a path.
+ */
+export function isMetadataFormModulePath(path) {
+  const name = basename(path);
+  return name.length > METADATA_FORM_MODULE_SUFFIX.length && name.endsWith(METADATA_FORM_MODULE_SUFFIX);
+}
+
+/**
+ * Every extract config under `absDir`, as `{ rel, abs }`.
+ *
+ * Both halves are returned because both readers need a different one: the gate
+ * runs from the repo root and reports repo-relative paths, while a caller
+ * walking from an absolute root still has to OPEN each config to read its
+ * documented flags. Deriving one from the other at the call site is how the two
+ * spellings drift.
+ */
+export function findExtractConfigs(absDir, rel, out = []) {
+  for (const e of readdirSync(absDir, { withFileTypes: true })) {
+    if (SKIPPED_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+    const child = `${rel}/${e.name}`;
+    const abs = join(absDir, e.name);
+    if (e.isDirectory()) findExtractConfigs(abs, child, out);
+    else if (isExtractConfigPath(child)) out.push({ rel: child, abs });
+  }
+  return out;
+}
+
+/**
+ * Every metadata form module under `absDir`, repo-relative, in walk order.
+ *
+ * Same skip set as the config walk: a form module inside node_modules or dist
+ * is a build artifact of one, not a source the extractor reads.
+ */
+export function findMetadataFormModules(absDir, rel, out = []) {
+  for (const e of readdirSync(absDir, { withFileTypes: true })) {
+    if (SKIPPED_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+    const child = `${rel}/${e.name}`;
+    if (e.isDirectory()) findMetadataFormModules(join(absDir, e.name), child, out);
+    else if (isMetadataFormModulePath(child)) out.push(child);
+  }
+  return out;
+}
+
+/**
+ * Read the regenerate command a config documents about itself. Every flag the
+ * gate passes comes from there, so a package that changes its locales or output
+ * directory updates one place and both readers follow.
+ */
+export function flagsFromDocstring(configPath) {
+  const src = readFileSync(configPath, 'utf8');
+  const head = src.slice(0, src.indexOf('*/') + 2);
+  const flags = head.match(/--(?:locales|fill|out)=[^\s\\*]+|--(?:objects-only|no-metadata-forms|no-merge)\b/g) ?? [];
+  return [...new Set(flags)];
+}
+
+/** Same question, over already-parsed flags — the pure half, for offline tests. */
+export function flagsExtractMetadataForms(flags) {
+  return !flags.includes(METADATA_FORMS_OPT_OUT_FLAG);
+}
+
+/**
+ * Does ANY discovered config still commit the shared metadata-form baseline?
+ *
+ * This is the applicability question the form-module convention hangs on, and
+ * it is read from the configs rather than assumed: the day the last config
+ * passes --no-metadata-forms, no form module can move a committed bundle any
+ * more, and a derivation that kept naming check:i18n for one would be sending
+ * every spec card to a gate that cannot go red.
+ */
+export function anyConfigExtractsMetadataForms(configs) {
+  return configs.some((c) => flagsExtractMetadataForms(flagsFromDocstring(c.abs)));
+}

--- a/scripts/pm/check-dispatch-gates.mjs
+++ b/scripts/pm/check-dispatch-gates.mjs
@@ -104,8 +104,24 @@ import process from 'node:process';
 
 const ROOT = new URL('../..', import.meta.url).pathname;
 
-/** The tool under test, repo-relative — and this gate's only watch hint. */
+/** The tool under test, repo-relative — and one of this gate's two watch hints. */
 const TOOL = 'scripts/pm/dispatch-gates.mjs';
+
+/**
+ * The tool's shared enumeration module, declared so a card editing it derives
+ * this gate (#9116).
+ *
+ * The tool imports its i18n walks from there instead of mirroring the gate's
+ * copies, which is the point of that module — but an import specifier is not a
+ * discoverable watch hint (`../i18n-bundle-surface.mjs` strips to a bare
+ * filename, which the extractor rejects as unpathy). Without this constant, a
+ * change to the shared module would move this gate's verdict — the tool's
+ * self-test drives those very functions — while deriving nothing, which is the
+ * blind-spot shape the tool exists to remove. Named here, not in the tool: this
+ * family resolves to THIS file, and hints are scanned from the file a family
+ * resolves to. Pinned live in the tool's own self-test.
+ */
+const SURFACE_MODULE = 'scripts/i18n-bundle-surface.mjs';
 
 const result = spawnSync(process.execPath, [join(ROOT, TOOL), '--self-test'], { stdio: 'inherit' });
 

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -1774,9 +1774,16 @@ function selfTest() {
   // stays green through a prefix-preserving rename, the one rot the STALE branch
   // exists to catch.
   const formHit = changeKindLines(['packages/spec/src/data/object.form.ts', 'packages/spec/src/data/field.form.ts'], resolved);
-  t('the measured incident paths now emit the metadata-form section', formHit.length === 2 && formHit[0].includes('metadata form module'));
+  // The `?? ''` is not defensive noise: reverse-verifying this block by making
+  // every config opt out emptied `formHit`, and the bare index CRASHED the whole
+  // self-test on a TypeError — one stack in place of 180-odd named verdicts. A
+  // case that stopped holding must fail BY NAME, with its reason, the way the
+  // i18n gate's own self-test says it (its `staleForDetail` fallback exists for
+  // exactly this). Ablating the entry now reddens these three and nothing else.
+  const formKindLine = formHit[0] ?? '';
+  t('the measured incident paths now emit the metadata-form section', formHit.length === 2 && formKindLine.includes('metadata form module'));
   t('that section names check:i18n exactly, runnably', formHit.some((l) => l.includes('- pnpm check:i18n   —')));
-  t('and it names both incident paths, not just the first', formHit[0].includes('object.form.ts') && formHit[0].includes('field.form.ts'));
+  t('and it names both incident paths, not just the first', formKindLine.includes('object.form.ts') && formKindLine.includes('field.form.ts'));
   // The over-trigger direction, which the card demanded in its own right: a spec
   // change that touches no form must NOT be pushed into this gate. Both a schema
   // beside a real form module and an unrelated package are pinned, because the

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -68,8 +68,21 @@
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import process from 'node:process';
+import {
+  anyConfigExtractsMetadataForms,
+  findExtractConfigs,
+  findMetadataFormModules,
+  flagsExtractMetadataForms,
+  isExtractConfigPath,
+  isMetadataFormModulePath,
+} from '../i18n-bundle-surface.mjs';
+
+// Re-exported so this tool's self-test drives the SAME predicates the gate
+// runs, not copies of them. They used to be written twice — see the shared
+// module's header, and the i18n entry in CHANGE_KIND_GATES below.
+export { isExtractConfigPath, isMetadataFormModulePath };
 
 const ROOT = new URL('../..', import.meta.url).pathname;
 
@@ -681,17 +694,14 @@ export function isTestFilePath(path) {
 }
 
 /**
- * Does this path name an i18n extract config, judged the way `check:i18n`
- * judges it? `scripts/check-i18n-bundles.mjs` (`findConfigs`, ~line 107) tests
- * the FILENAME and additionally requires the file to sit under a `scripts/`
- * directory: `e.name === 'i18n-extract.config.ts' && p.includes('/scripts/')`.
- * Mirrored exactly rather than approximated — a copy that widened the test
- * would name a gate that cannot move, the failure mode this whole script
- * exists to avoid.
+ * `isExtractConfigPath` is imported at the top of this file, not defined here.
+ *
+ * It used to be a hand-written mirror of the gate's own filename test, with a
+ * comment saying so ("mirrored exactly rather than approximated"). A mirror is
+ * a second contract: it agrees until one side moves, and nothing reports the
+ * day it stops agreeing. The test, the walk and the docstring-flag parse now
+ * live once in the shared module and BOTH readers import them (#9116).
  */
-export function isExtractConfigPath(path) {
-  return basename(path) === 'i18n-extract.config.ts' && path.includes('/scripts/');
-}
 
 /**
  * The package directory that OWNS an extract config: everything above the
@@ -725,39 +735,74 @@ export function isInI18nBundlePackage(path, ownerDirs) {
 }
 
 /**
- * Walk `packages/` for extract configs exactly the way the gate walks it —
- * same skip set (`node_modules`, `dist`, dotted entries), same file test — and
- * return the repo-relative package directories that own one, deduped.
+ * The repo-relative package directories that own an extract config, deduped —
+ * derived from the GATE'S OWN walk, imported rather than mirrored.
  *
  * Runtime discovery, like `extractCheckInvocations` re-reading the workflows:
  * when a tenth package grows a bundle, the next run matches it with nothing to
- * update here. `absDir` is the directory to read; `rel` is the repo-relative
- * path it corresponds to, so the answers are comparable to the input paths a
- * card is dispatched with.
+ * update here.
  */
-export function findI18nBundlePackages(absDir, rel = 'packages', out = []) {
-  for (const e of readdirSync(absDir, { withFileTypes: true })) {
-    if (e.name === 'node_modules' || e.name === 'dist' || e.name.startsWith('.')) continue;
-    const child = `${rel}/${e.name}`;
-    if (e.isDirectory()) findI18nBundlePackages(join(absDir, e.name), child, out);
-    else if (isExtractConfigPath(child)) {
-      const owner = owningPackageOfExtractConfig(child);
-      if (owner && !out.includes(owner)) out.push(owner);
-    }
+export function findI18nBundlePackages(configs) {
+  const out = [];
+  for (const { rel } of configs) {
+    const owner = owningPackageOfExtractConfig(rel);
+    if (owner && !out.includes(owner)) out.push(owner);
   }
   return out;
 }
 
 /**
- * The walk, memoised per process — one answer serves every input path. An
+ * The two walks, memoised per process — one answer serves every input path. An
  * unreadable `packages/` throws rather than degrading to "no owners": under
  * this script's contract unreadable input must never look like an empty
  * answer, and the entrypoint turns the throw into a non-zero exit.
  */
+let i18nConfigs = null;
+function i18nExtractConfigs() {
+  i18nConfigs ??= findExtractConfigs(join(ROOT, 'packages'), 'packages');
+  return i18nConfigs;
+}
+
 let i18nOwnerDirs = null;
 export function i18nBundlePackageDirs() {
-  i18nOwnerDirs ??= findI18nBundlePackages(join(ROOT, 'packages'));
+  i18nOwnerDirs ??= findI18nBundlePackages(i18nExtractConfigs());
   return i18nOwnerDirs;
+}
+
+/**
+ * The metadata form modules in the tree, memoised — the population of the
+ * SECOND i18n entry below.
+ */
+let formModules = null;
+export function metadataFormModulePaths() {
+  formModules ??= findMetadataFormModules(join(ROOT, 'packages'), 'packages');
+  return formModules;
+}
+
+/**
+ * Does any package still commit the shared Studio metadata-form baseline?
+ * Read from the configs' own documented flags, memoised — see the shared
+ * module's `anyConfigExtractsMetadataForms`.
+ */
+let metadataFormsExtracted = null;
+export function metadataFormsSurfaceIsExtracted() {
+  metadataFormsExtracted ??= anyConfigExtractsMetadataForms(i18nExtractConfigs());
+  return metadataFormsExtracted;
+}
+
+/**
+ * Does this input path reach a metadata form module?
+ *
+ * A card's surface is named before its code exists, so a directory argument
+ * counts when it CONTAINS one — `packages/spec/src/ui` really does cover seven
+ * of them. The containment is one-directional in the same sense
+ * `isInI18nBundlePackage` is: an input that collapses to a bare top-level
+ * directory (`packages`) is refused, because such an input covers the whole
+ * tree below it and would print this gate for every card in the repo.
+ */
+export function reachesMetadataFormModule(path, modulePaths) {
+  if (!path.includes('/')) return false;
+  return modulePaths.some((m) => m === path || m.startsWith(`${path}/`));
 }
 
 /**
@@ -847,15 +892,42 @@ export function i18nBundlePackageDirs() {
  * that objection because the trigger is the gates' own population test, mirrored
  * (`isTestFilePath`), not a guess at which scripts look test-flavoured.
  *
- * ## What the i18n entry still refuses to list
+ * ## What the two i18n entries still refuse to list
  *
- * Its `matches` does not enumerate the packages that own a bundle today — it
- * repeats the gate's own walk (`findI18nBundlePackages` mirrors `findConfigs`
- * in `scripts/check-i18n-bundles.mjs`: same skip set, same filename-plus-
- * `/scripts/` test). What is written down here is the KIND, not its
- * population, so a tenth package growing a bundle is matched by the next run
- * with nothing to update — the same runtime-discovery contract the workflow
- * and package.json reads already keep.
+ * Neither `matches` enumerates anything. The first walks for the packages that
+ * own a bundle, the second for the tree's metadata form modules, and both walks
+ * are the GATE'S OWN, imported from `scripts/i18n-bundle-surface.mjs` rather
+ * than mirrored here. That import is the fix for a defect this file used to
+ * carry in its own comment: `findI18nBundlePackages` was a hand-written copy
+ * described as mirroring `findConfigs` "exactly", which is a second contract
+ * with no way to report the day it stopped agreeing. What is written down here
+ * is the KIND, not its population, so a tenth package growing a bundle — or an
+ * eighteenth form module — is matched by the next run with nothing to update.
+ *
+ * ## Why the SECOND i18n entry exists (#9116)
+ *
+ * The owning-package entry answers for one of a bundle's two producers. The
+ * `objects` half is enumerated by the config's own package, so the owning
+ * package is the trigger surface. The `metadataForms` half is registry-driven
+ * and identical for every stack, so exactly ONE package commits that baseline
+ * (`platform-objects`; every other config passes `--no-metadata-forms`) while
+ * its source sits in `packages/spec`, which owns no extract config and which
+ * the gate's walk never reaches.
+ *
+ * Measured, and paid for once: PR #9113 added two form entries in
+ * `packages/spec/src/data/`, four `platform-objects` metadata-form bundles
+ * moved, `check:i18n` reddened on CI, and the dev's diff-derived gate union
+ * could not have named the family — the path derivation misses it for the
+ * reason stated above, and the owning-package entry does not cover
+ * `packages/spec`. Cost: one CI round trip plus a patch commit. The invariant
+ * the card states is the one this entry restores — a gate a diff can move must
+ * be derivable FROM that diff; `undetermined` is an honest unknown, not a
+ * standing blind spot on a known edge.
+ *
+ * Its applicability is read, never assumed: `metadataFormsSurfaceIsExtracted`
+ * asks the configs' own documented flags whether any package still commits that
+ * baseline. The day the last one opts out, no form module can move a committed
+ * bundle and this entry stops firing on its own.
  *
  * ## How these entries stay honest
  *
@@ -906,6 +978,11 @@ export function i18nBundlePackageDirs() {
  *     owning package path starts with — the path half matches and this entry
  *     is redundant. Growing more prerequisite paths does not qualify; that is
  *     what it already has.
+ *   - metadata-form entry: when every extract config passes
+ *     `--no-metadata-forms`, no form module can move a committed bundle. That
+ *     day the entry stops firing by itself (its `matches` reads the flags), so
+ *     delete it only once the opt-out is the permanent shape rather than a
+ *     transient one.
  *
  *   Delete an entry the day its criterion is met, not before.
  */
@@ -943,6 +1020,16 @@ export const CHANGE_KIND_GATES = [
       {
         name: 'check:i18n',
         why: "it re-extracts every owning package's translation bundles and fails on drift, so any edit that changes what the extractor emits (an object definition, a label, the config itself) moves it — regenerate with `node scripts/check-i18n-bundles.mjs --write`",
+      },
+    ],
+  },
+  {
+    kind: 'edits a metadata form module (a *.form.ts the Studio form registry collects)',
+    matches: (path) => metadataFormsSurfaceIsExtracted() && reachesMetadataFormModule(path, metadataFormModulePaths()),
+    gates: [
+      {
+        name: 'check:i18n',
+        why: "the metadataForms half of the bundles is registry-driven, so a form's sections, field labels, helpText or placeholder are extracted into ONE package's committed bundles — platform-objects today — and a form edit drifts them from a package your diff never touches. This is the edge PR #9113 paid a CI round for. Same repair as the entry above: regenerate with `node scripts/check-i18n-bundles.mjs --write` and commit the moved bundles",
       },
     ],
   },
@@ -1647,6 +1734,58 @@ function selfTest() {
   t('the i18n section names check:i18n exactly, runnably', i18nHit.some((l) => l.includes('- pnpm check:i18n   —')));
   t('a path outside every owning package emits no i18n section', !changeKindLines(['packages/objectql/src/engine.ts'], resolved).some((l) => l.includes('check:i18n')));
 
+  // ── The metadata-form edge (#9116) ────────────────────────────────────────
+  //
+  // The bundles' OTHER producer, and the half no owning-package test can reach:
+  // the metadataForms surface is registry-driven, its source lives in
+  // packages/spec, and packages/spec owns no extract config. Pure judgments
+  // first, then the live tree, then both rendering directions.
+  t('a form module is one', isMetadataFormModulePath('packages/spec/src/data/object.form.ts'));
+  t('its sibling schema is not', !isMetadataFormModulePath('packages/spec/src/data/object.zod.ts'));
+  t('a bare .form.ts with no name is not one', !isMetadataFormModulePath('packages/spec/src/data/.form.ts'));
+  t('a form module test file is not one', !isMetadataFormModulePath('packages/spec/src/data/object.form.test.ts'));
+
+  const formMods = ['packages/spec/src/data/object.form.ts', 'packages/spec/src/ui/view.form.ts'];
+  t('the module itself reaches', reachesMetadataFormModule('packages/spec/src/data/object.form.ts', formMods));
+  t('a directory CONTAINING one reaches (a card surface is named before its files exist)', reachesMetadataFormModule('packages/spec/src/ui', formMods));
+  t('a sibling sharing a name prefix does not', !reachesMetadataFormModule('packages/spec/src/dat', formMods));
+  t('an unrelated package does not', !reachesMetadataFormModule('packages/objectql/src/engine.ts', formMods));
+  // The over-broad direction, the expensive one: a bare top-level directory
+  // covers the whole tree below it, so it must not drag every form module in.
+  t('a bare top-level directory is refused', !reachesMetadataFormModule('packages', formMods));
+
+  // Applicability is READ from the configs, not assumed — the flag that decides
+  // whether any package still commits the shared baseline at all.
+  t('a config with no opt-out extracts the metadata-form surface', flagsExtractMetadataForms(['--locales=zh-CN', '--fill=default']));
+  t('the opt-out flag removes it', !flagsExtractMetadataForms(['--objects-only', '--no-metadata-forms']));
+
+  // The live tree — the half no fixture can prove.
+  const liveForms = metadataFormModulePaths();
+  t('the live walk discovers form modules', liveForms.length > 0 && liveForms.every((f) => f.endsWith('.form.ts')));
+  t('the live walk finds no duplicates', new Set(liveForms).size === liveForms.length);
+  // If this flips, the entry stops firing BY DESIGN (every package opted out of
+  // the shared baseline) — read the entry's deletion criterion before "fixing" it.
+  t('some package still commits the shared metadata-form baseline', metadataFormsSurfaceIsExtracted());
+
+  // Regression pin for the measured incident (PR #9113): these two exact paths
+  // moved four platform-objects bundles, reddened check:i18n on CI, and derived
+  // NOTHING — the family appeared in neither half of the output. Anchored on the
+  // rendered delimiters for the reason the entry above states: a bare substring
+  // stays green through a prefix-preserving rename, the one rot the STALE branch
+  // exists to catch.
+  const formHit = changeKindLines(['packages/spec/src/data/object.form.ts', 'packages/spec/src/data/field.form.ts'], resolved);
+  t('the measured incident paths now emit the metadata-form section', formHit.length === 2 && formHit[0].includes('metadata form module'));
+  t('that section names check:i18n exactly, runnably', formHit.some((l) => l.includes('- pnpm check:i18n   —')));
+  t('and it names both incident paths, not just the first', formHit[0].includes('object.form.ts') && formHit[0].includes('field.form.ts'));
+  // The over-trigger direction, which the card demanded in its own right: a spec
+  // change that touches no form must NOT be pushed into this gate. Both a schema
+  // beside a real form module and an unrelated package are pinned, because the
+  // first is the one a filename convention could plausibly over-reach into.
+  t('a spec schema next door to a form emits no i18n section', !changeKindLines(['packages/spec/src/data/filter.zod.ts'], resolved).some((l) => l.includes('check:i18n')));
+  t('an unrelated package still emits no i18n section', !changeKindLines(['packages/rest/src/rest-server.ts'], resolved).some((l) => l.includes('check:i18n')));
+  const formStale = changeKindLines(['packages/spec/src/data/object.form.ts'], () => null);
+  t('an undiscoverable check:i18n renders STALE for this entry too', formStale.filter((l) => l.includes('⚠ check:i18n: STALE')).length === 1);
+
   // The measured incident (#8410 / PR #8399), pinned against the REAL workflow
   // rather than a fixture: a fixture proves the parser, only the live file
   // proves that THIS repo's changeset gate is reachable. `Check Changeset`
@@ -1764,6 +1903,30 @@ function selfTest() {
     'so a card editing that script is MATCHED through that constant, not dropped as silent',
     coupledVerdict.verdict === 'matched' && coupledVerdict.hits[0]?.hint === 'scripts/check-test-typecheck.mts',
   );
+
+  // The same coupling, for the module this file now IMPORTS its i18n walks from
+  // (#9116). Sharing one enumeration between the gate and this tool removed a
+  // mirror, and it would have opened a smaller hole of exactly the kind this
+  // card is about: an import specifier is not a discoverable hint, so a card
+  // editing the shared module could move two gates while deriving neither.
+  // Both are pinned LIVE against the real files — delete either constant and
+  // this reddens instead of the silence coming back.
+  const SHARED = 'scripts/i18n-bundle-surface.mjs';
+  t(
+    'the i18n gate declares the module its population is enumerated by',
+    covers(readHints('scripts/check-i18n-bundles.mjs'), SHARED),
+  );
+  t(
+    'the dispatch-gates gate declares it too, since the tool self-test drives those functions',
+    covers(readHints('scripts/pm/check-dispatch-gates.mjs'), SHARED),
+  );
+  t(
+    'and that gate still reaches the tool it runs — the new constant displaces nothing',
+    covers(readHints('scripts/pm/check-dispatch-gates.mjs'), 'scripts/pm/dispatch-gates.mjs'),
+  );
+  // The shared module is a real file, so the two claims above are live rather
+  // than a pair of matching strings.
+  t('the declared shared module exists', existsSync(join(ROOT, SHARED)));
 
   // ── A family's OWN script files as match keys (#8509) ─────────────────────
   //


### PR DESCRIPTION
Fixes #9116

A `.form.ts` change in `packages/spec` moves platform-objects' committed metadata-form bundles, but no derived gate list could name `check:i18n` for it. PR #9113 paid one CI round trip plus a patch commit for that edge.

## Why the derivation could not see it

A bundle has two producers, and only one lives in the package that owns the bundle:

- `objects` — enumerated by the config's own package, so the owning package IS the trigger surface. This is what the existing convention entry covers.
- `metadataForms` — registry-driven and identical for every stack, so exactly one package commits that baseline (`platform-objects`; every other config passes `--no-metadata-forms`) while its source sits in `packages/spec`, which owns no extract config and which the gate's walk never reaches.

So the family scored neither `matched` nor `undetermined` — printed nowhere at all.

## What changed

**`scripts/i18n-bundle-surface.mjs` (new)** — the config walk and the docstring-flag parse move here and BOTH readers import them. `dispatch-gates.mjs` used to carry a hand-written mirror of the gate's walk, described in its own comment as mirroring `findConfigs` "exactly": a second contract that agrees until one side moves, with nothing to report the day it stops. Same shape `scripts/cli-build-prerequisite.mjs` already has for the classifiers this gate shares with `check-i18n-coverage.mjs`.

**A second `CHANGE_KIND_GATES` entry** for a metadata form module. The KIND is written down; the POPULATION is walked at runtime; and applicability is **read from the configs' own documented flags** (`anyConfigExtractsMetadataForms`) rather than assumed — the day every config passes `--no-metadata-forms`, no form module can move a committed bundle and the entry stops firing by itself. That is its stated deletion criterion.

The one convention written down is the suffix `.form.ts`, which is the producer's own — stated by the registry it feeds (`packages/spec/src/system/metadata-form-registry.ts`: "the FormView produced by `defineForm({ schemaId })` in the corresponding `*.form.ts`"). Measured: 17 files in the repo carry that suffix, all under `packages/spec/src`, and the registry has exactly 17 form entries — the convention and the population coincide with nothing left over on either side.

**A declared coupling in both consumers.** An import specifier is not a discoverable watch hint (`../i18n-bundle-surface.mjs` strips to a bare filename the extractor rejects), so without it a card editing the shared enumeration would move two gates while deriving neither — the same blind spot one layer down. Both declare it as a bare module-body constant, the shape `check-type-check-coverage.mjs` already uses, pinned live in the tool's self-test.

## The before/after that is the deliverable

Reproducing PR #9113's shape (`object.form.ts` + `field.form.ts`), counting mentions of `check:i18n` in the whole output:

| surface | before (`origin/main` @ `24206416a`) | after (`d1945d278`) |
|---|---|---|
| `object.form.ts` + `field.form.ts` | **0** — neither matched nor undetermined | **1**, under its own convention heading, runnable |
| `packages/spec/src/data/filter.zod.ts` (a schema next door to a real form module) | 0 | **0** — no over-trigger |
| `packages/rest/src/rest-server.ts` | 0 | **0** — no over-trigger |

After:

```
Convention-triggered gates (this change KIND moves them; no path derivation can name them):
  edits a metadata form module (a *.form.ts the Studio form registry collects):
      packages/spec/src/data/object.form.ts, packages/spec/src/data/field.form.ts
    - pnpm check:i18n   — the metadataForms half of the bundles is registry-driven, ...
```

A card editing the new shared module now derives both gates it can move (`check:i18n`, `check:pm-dispatch-gates`).

## Verification at `d1945d278`

- `pnpm check:i18n` — **green, full run** on a built closure: 9 packages, all bundles in sync (`platform-objects in sync (8 bundle(s))`, the other eight 4 each). The refactored walk returns the same 9 configs in the same sorted order as the pre-change one, and each resolves the same documented `--out` directory.
- `pnpm check:pm-dispatch-gates` — green, 183 self-test cases (up from 179; the new cases are the metadata-form edge in both directions plus the two live coupling pins).
- `node scripts/check-nul-bytes.mjs` — green.
- Gate families re-derived from the actual changed paths, not the dispatch prompt's list: `check:i18n` and `check:pm-dispatch-gates`, both run above.

**Reverse verification** (direction decided first: ablating the *applicability read*, not the entry, should stop the entry firing). Adding `--no-metadata-forms` to platform-objects' config docstring made `anyConfigExtractsMetadataForms` go false, the incident paths derive **0** mentions of `check:i18n`, and exactly 5 named self-test cases went red — all of them the new claims, nothing else. Restored byte-identical (`cmp` against a pre-ablation copy), green again.

That ablation also caught a real defect in the first draft of the self-test: an empty rendering crashed it on a `TypeError`, replacing 183 named verdicts with one stack. Fixed in its own commit — a case that stops holding must fail by name, the discipline `check-i18n-bundles.mjs` states for its own classifiers.

## Scope note — an edge this deliberately does NOT close

Measured while enumerating the trigger surface: `walkMetadataForms` (`packages/cli/src/utils/i18n-extract.ts`) emits `metadataForms.TYPE.label` / `.description` for every entry of `DEFAULT_METADATA_TYPE_REGISTRY` (`packages/spec/src/kernel/metadata-plugin.zod.ts`), and `metadata-form-registry.ts` decides which forms are walked at all. Editing either moves the same four bundles and matches no convention here, because neither carries a filename that distinguishes it. Closing it needs an anchor this change does not have, and the candidates trade off against each other rather than being one obvious shape, so it is filed rather than guessed at: #9144 (which stays open — it is not addressed here). The shared module's header states the same gap at the source, so the omission is visible there and not only in this description.

Tooling-only (`scripts/`), no user-visible change — `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_