### PR TITLE
docs(qa): reword the #2567 Phase 2 authz-conformance comment off a fixed route list

### DIFF
--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -10,10 +10,11 @@
 // deleted proof, breaks the build.
 //
 // #2567 Phase 2 — the anonymous-deny SURFACES are additionally pinned by the
-// `discover()` ratchet: this test STATICALLY enumerates the data/meta/graphql
-// HTTP entry points from source and asserts each is classified by a matrix row.
-// A new ungated `/data` route (or a removed/stale `covers` key) then fails CI as
-// UNCLASSIFIED / STALE — the surface can't silently regress.
+// `discover()` ratchet: this test STATICALLY enumerates the HTTP/transport
+// entry points named in the curated `PROBES` table below and asserts each is
+// classified by a matrix row. A new ungated route (or a removed/stale
+// `covers` key) then fails CI as UNCLASSIFIED / STALE — the surface can't
+// silently regress.
 
 import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
@@ -43,13 +44,14 @@ const ATTRIBUTION = { marker: ATTRIBUTION_MARKER, scan: scanProofCandidates } as
 
 // ── #2567 ratchet — static enumeration of anonymous-deny HTTP entry points ──
 //
-// A CURATED per-file probe table (not a blind repo grep): scoped to the four
-// source files and to data/meta/graphql segments only, so control-plane routes
-// (/health, /auth, /ready, /discovery) are never enumerated as data surfaces.
-// But each probe is pattern-based WITHIN its file, so a genuinely new `/data`
-// route (or a new graphql/meta handler) is auto-discovered → new key → a
-// missing `covers` fails CI. Keys are derived from source CONTENT (route
-// literals / handler names), never line numbers, so they don't churn on edits.
+// A CURATED per-file probe table (not a blind repo grep): scoped to the
+// source files and route families named in PROBES below, so control-plane
+// routes (/health, /auth, /ready, /discovery) are never enumerated as data
+// surfaces. But each probe is pattern-based WITHIN its file, so a genuinely
+// new route or handler matching an existing probe's pattern is auto-discovered
+// → new key → a missing `covers` fails CI. Keys are derived from source
+// CONTENT (route literals / handler names), never line numbers, so they don't
+// churn on edits.
 const PROBES: ReadonlyArray<{ file: string; re: RegExp; key: (m: RegExpExecArray) => string }> = [
   // REST /meta umbrella registrar — one guarded registrar covers all ~17 routes.
   {
@@ -222,9 +224,9 @@ describe('ADR-0056 D10 — authorization conformance matrix', () => {
     const problems = checkLedger(AUTHZ_CONFORMANCE, {
       proofRoot: HERE, // proofs are dogfood test files alongside this one
       highRisk: HIGH_RISK,
-      // The ratchet: every discovered data/meta/graphql entry point must be
-      // classified by exactly one row's `covers`, and no `covers` key may be
-      // stale (no longer in source).
+      // The ratchet: every discovered PROBES entry point must be classified
+      // by exactly one row's `covers`, and no `covers` key may be stale (no
+      // longer in source).
       discover: () => discoverAnonymousDenySurfaces(),
       // #7976 — and the cited proofs must NAME the rows they prove.
       attribution: ATTRIBUTION,


### PR DESCRIPTION
Fixes #9027

## What

`packages/qa/dogfood/test/authz-conformance.test.ts` carried a "#2567 Phase 2" comment describing `discover()`'s static enumeration as covering `data/meta/graphql` HTTP entry points only. That was accurate when written but the `PROBES` table has grown well past it. Reworded the description generically instead of naming a fixed route-segment list, per the issue's own reasoning: an enumerated list is what drifted in the first place, so swapping one fixed list for another (even an up-to-date one) re-creates the exact mechanism that produced this finding.

`discover()` itself is unchanged and correct — this is a prose-only fix to three comments in one file.

## Re-derived numbers (per triage instruction — not copied from the card)

Re-derived on current `origin/main` (after confirming #9026 landed as `2ce1eb41b`) with a small extraction script that parses every `file:` key out of the `PROBES` array literal — verified the extraction actually reads real quoted paths (not a guessed regex silently returning zero matches):

- **15 probes** over **11 named source files**, spanning **7 route families**: `meta`, `actions`, `automation`, `packages`, `data`, `realtime`, `mcp`.
- No `graphql` probe exists in the table today — the old "data/meta/graphql" wording was already stale on that front too (searched: `graphql` appears only in the comments being fixed here, never in a `PROBES` entry).

This matches the card's own re-derivation (15/11), independently confirmed rather than copied.

## Bounded in-place sweep

The issue names one specific comment block (quoted verbatim, unique "Phase 2" text at the top of the file). While fixing it I found the identical stale claim ("data/meta/graphql") repeated twice more in the same file — immediately above the `PROBES` table declaration, and inline inside the `checkLedger` call — both describing the same table using the same now-inaccurate vocabulary. Extended the fix to all three per the bounded in-place exemption: same defect class, mechanical (same generic-wording treatment already decided for the named comment, applied consistently), file held only by this claim, no new verification surface (comments only). Leaving two of three near-identical descriptions stale while fixing the third would have left contradictory claims meters apart in the same file.

## Tests

Union run at final commit `60fc93198`:

```
pnpm --filter "@objectstack/dogfood^..." build                         → 0 (dependency closure built)
pnpm --filter "@objectstack/dogfood" exec vitest run test/authz-conformance.test.ts --maxWorkers=2
  → Test Files  1 passed (1) / Tests  15 passed (15)
pnpm --filter "@objectstack/dogfood" typecheck                          → clean (tsc --noEmit)
pnpm check:test-source-alias                                            → OK
pnpm check:type-source-resolution                                       → OK
pnpm check:engine-double-contract                                       → OK — 311 pinned, 133 in DEBT ledger, 2 exempt (unchanged)
pnpm check:where-matcher                                                → holds, 247/247, none new
pnpm check:query-options-erasure                                        → holds, 67 unswept non-test sites, none new
node scripts/check-nul-bytes.mjs <changed file>                         → OK
```

Gate selection: `check:test-source-alias` / `check:type-source-resolution` are the path-derived gates for `packages/qa`; `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure` are convention-triggered by editing a test file (`node scripts/pm/dispatch-gates.mjs`). Did not run the repo-wide `check:type-check-coverage` / `check:type-check-debt` re-measure — the diff is comments only in an already-typechecked, already-tracked file (no new file, no new export, no code-path change), so the package's own clean `tsc --noEmit` stands in for it; flagging this choice rather than silently skipping it.

## Changeset

Test-file comment change, nothing published — no changeset. Applying the `skip-changeset` label (this repo's real mechanism, per the maintainer note on #9133) as part of this PR, reading back the label set after the changeset-gate bot's first pass rather than declaring it done on the write alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_