### PR TITLE
docs(releases): document objectui#2743, the Console half of the mark-as-read change

### DIFF
--- a/content/docs/releases/v16.mdx
+++ b/content/docs/releases/v16.mdx
@@ -824,6 +824,8 @@ pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
 - **`engine-owned` lifecycle bucket in the Console (objectui#2739 + the
   #2712/#2724 `userActions` parser consolidation),** the UI union that unblocked
   the framework enum split.
+- **Notifications are marked read through the REST surface, not direct receipt
+  writes (objectui#2743),** the client half of framework#3354.
 - **Fixes:** kanban / calendar surface write failures instead of swallowing
   them (objectui#2716); the earlier post-`rc.0` items (import wizard `auto`,
   flow `keyValue`/`numberList`, ActionParamDialog upload guard, system-field


### PR DESCRIPTION
Fixes #9080

Adds **one bullet** to `content/docs/releases/v16.mdx` documenting objectui#2743 — the Console half of the mark-as-read change whose framework half, framework#3354, the same page already documents.

## The change

Under `### New in Console (objectui, now bundled 94d4876 → 69fa5d163a97)`:

```
- **Notifications are marked read through the REST surface, not direct receipt
  writes (objectui#2743),** the client half of framework#3354.
```

It is placed after the `engine-owned` bullet and before the terminal `**Fixes:**` catch-all. That mirrors the ordering of the backend section above — framework#3343 then framework#3354 — and keeps the catch-all last.

## Provenance — strictly changeset-derived

The wording is derived from changeset `a791200` in `packages/console/CHANGELOG.md`. Two sections carry that changeset text; the one read here is the one that establishes the release, `## 16.0.0-rc.1` at line 2115 (the aggregating `## 16.0.0` section repeats it at line 2058):

```
- a791200: Console (objectui) refreshed to `69fa5d163a97`. Frontend changes in this range:

  - fix(app-shell): mark notifications read via the REST surface, not direct receipt writes (#2743)

  objectui range: `af1b0db96e44...69fa5d163a97`
```

That confirms the card's assumption: objectui#2743 is the **sole** frontend change in the `af1b0db96e44...69fa5d163a97` window, and that window sits inside the range the target heading names. No free prose beyond the changeset title and the house-style pairing tail.

## House style

The control is the existing bullet in the same section:

```
- **Action result dialogs render the new translation slot (objectui#2736),** the
  client half of framework#3347.
```

Same shape: bold user-visible outcome with the objectui number inline, then the `the client half of framework#NNNN` tail. The framework bullet already states the server-side outcome (the notifications REST routes being mounted in the standalone dispatcher), so this one reads as its counterpart rather than repeating it.

## Why this page is edited at all

`content/docs/releases/` is release-owned and normally off-limits to a PR. This is the sanctioned exception: a **dedicated docs-only PR** carrying a **per-card maintainer approval** — the ruling recorded in issue comment `5307570963` (2026-08-16), which approved one bullet for objectui#2743 under *New in Console*, changeset-derived, never a rider.

That approval is **per-card, not a general license**. The card fences off three known omissions (objectui#2726, objectui#2718 / objectui#2695, objectui#2721) as deliberate curation, and they are untouched here. No sweep was performed. The diff is one file, two lines added.

## A stale premise in the card, recorded

The card's headline measurement says `grep 2743` over `v16.mdx` returns **no match**. That is no longer true, and the way it fails matters: line 713 now matches, via `pin advancing 94d4876 → 69fa5d163a97 (objectui #2701–#2743)` — a pin-range **endpoint** in the section preamble that landed after the card was filed.

The card's substance is unaffected. That line names the bundled commit window and documents nothing about mark-as-read; there was still no bullet for objectui#2743. Recorded here because a bare string grep now returns a hit that would wrongly support "already documented" — the check has to be by section, not by string count.

## Verification

All gates run on the final commit `291378a09`, re-derived from the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/releases/v16.mdx` (which named exactly these five; `check:nul-bytes` added because the task edits a file):

| gate | result |
| :-- | :-- |
| `pnpm check:release-notes` | OK — every released major has a curated, navigable release page |
| `pnpm check:release-page-status` | OK — 2 GA majors in scope (v16, v17); each status blockquote and index entry describes a shipped release |
| `pnpm check:docs-audit-scope` | OK — 178 hand-written docs in sync; 9 release-owned pages review-only |
| `pnpm check:docs-redirects` | OK — 92 entries, 98 chain probes |
| `pnpm check:role-word` | OK — 43 baselined files, no new occurrences |
| `pnpm check:nul-bytes` | OK — 5998 text files scanned, no raw ASCII control bytes |

No changeset: the diff is documentation only and publishes nothing, so the PR carries `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_