### PR TITLE
docs(adr): attribute ADR-0002's discarded alternative to the pre-registry v3.4 document

### DIFF
--- a/docs/adr/0002-environment-database-isolation.md
+++ b/docs/adr/0002-environment-database-isolation.md
@@ -119,7 +119,7 @@ The migration is **non-destructive** and **idempotent**: each legacy org's datab
 1. **Stay with per-org DB + `env_id` column.** Rejected — the failure modes above are structural, not implementation bugs.
 2. **Schema-per-environment inside one DB.** Works for Postgres but not Turso/libSQL/SQLite, and defeats the backup/DR argument. Rejected.
 3. **Row-level security via Postgres RLS.** Strengthens the `env_id` approach but still leaves schema evolution coupled and DR complex. Rejected.
-4. **One global DB + tenant column.** Was never on the table — already discarded in v3.4's ADR-0001.
+4. **One global DB + tenant column.** Was never on the table — already discarded in the v3.4-era "ADR-0001", a pre-registry document this repository has never contained and not the unrelated metadata-service record that held the number here ([tombstone](./0001-withdrawn-metadata-service-architecture.md#what-adr-0002-actually-cites)).
 
 ## References
 


### PR DESCRIPTION
Fixes #7963

One sentence in ADR-0002's *Alternatives Considered* list. No other line of the ADR, the tombstone, or any tooling is touched.

## The change

`docs/adr/0002-environment-database-isolation.md:122`

Before:

```md
4. **One global DB + tenant column.** Was never on the table — already discarded in v3.4's ADR-0001.
```

After:

```md
4. **One global DB + tenant column.** Was never on the table — already discarded in the v3.4-era "ADR-0001", a pre-registry document this repository has never contained and not the unrelated metadata-service record that held the number here ([tombstone](./0001-withdrawn-metadata-service-architecture.md#what-adr-0002-actually-cites)).
```

The historical rejection — *"was never on the table … already discarded"* — is preserved word for word. Only its **provenance** is made honest.

## Why this wording

Maintainer ruling of 2026-08-14 on #7963 (verbatim, untranslated: 「同意你的建议」) selected **wording option 2** of the three the card offered: qualify the sentence so the discarded alternative is attributed to the pre-registry v3.4 document rather than a bare `ADR-0001`. Option 1 (leave it) and option 3 (drop the citation) were both closed by that ruling, so the historical fact stays.

The hazard is sharper today than when the card was filed. Since the ADR-0001 tombstone landed, a bare `ADR-0001` **does** now point at a real file — `0001-withdrawn-metadata-service-architecture.md`, a record deciding how the `metadata` *service* is registered, which says nothing about tenancy or database topology. That is a wrong-but-resolving citation, the most dangerous kind in this registry: `check:adr-anchors` verifies that a cited record **exists**, never that it says what the citer claims, so no gate can catch it.

**The vocabulary is the tombstone's, not a new one.** `0001-withdrawn-metadata-service-architecture.md` already dissects this exact citation under *"What ADR-0002 actually cites"*, and describes the cited artifact as *"The v3.4-era 'ADR-0001'"* and *"a pre-registry document that this repository has never contained"*. Both phrases are reused verbatim here, so the two records describe one discrepancy in one set of terms — two records describing it in incompatible terms would be a worse defect than the one being fixed. The link closes the loop the tombstone was written for: it was authored for the reader arriving from ADR-0002, and until now ADR-0002 gave that reader no way to arrive.

## Verification

All gates run locally against the final commit `3b3bb0a0c`, the tree this PR pushes.

| gate | result |
|---|---|
| `node scripts/check-adr-anchors.mjs` | `OK … 25855 citation(s) across 3227 file(s) resolve` — exit 0 |
| `node scripts/check-adr-links.mjs` | `544 relative link destination(s) under docs/adr/ resolve` — exit 0 |
| `node scripts/check-nul-bytes.mjs` | `OK (scanned 5998 text file(s) … no raw ASCII control bytes)` — exit 0 |

The gate list was re-derived from the actual changed path (`node scripts/pm/dispatch-gates.mjs docs/adr/0002-environment-database-isolation.md`) and matched; `check-nul-bytes` was added because any edit is in its surface.

**Reverse verification — both gates were proved to actually read this line**, run from the committed state and restored byte-identically afterwards (`git hash-object` match, `git status --porcelain` empty):

- Mutating the citation in the new sentence to a number with no record made `check-adr-anchors` go **red**: `ADR-9993 is cited by 1 file(s) but names no record under docs/adr/ — docs/adr/0002-environment-database-isolation.md`.
- Mutating the new link's target made `check-adr-links` go **red**: `docs/adr/0002-environment-database-isolation.md:122 -> … (missing)`.

Both are the expected direction. The heading fragment itself is checked by no gate — `check-adr-links` strips `#fragment` deliberately — so it was verified by hand against the tombstone's `## What ADR-0002 actually cites` heading.

**No changeset**: `docs/adr/**` is an internal decision record, published by no package, so this PR releases nothing. Labelled `skip-changeset`.

## ⚠️ The `ADR maintainer approval` context is RED here, by design — and is not being fixed

`docs/adr/**` is maintainer-merge territory with no size exemption (Prime Directive #14). `check-adr-merge-approval.mjs` passes only when an **approving human review** exists on the PR, which no agent seat can supply. Its red is therefore the gate working, and a green there would mean it had been subverted rather than satisfied. It is left red and untouched.

Accordingly this PR is **not** merged, **not** queued, and has **no** auto-merge armed by any agent seat. It is flipped out of draft so a human can act on it — parking it as a draft would be the opposite of ready for the maintainer, not a safety measure.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_