### PR TITLE
fix(spec): correct console route spellings in JSDoc to /_console/…

### DIFF
--- a/.changeset/console-route-jsdoc-spelling.md
+++ b/.changeset/console-route-jsdoc-spelling.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): correct stale `/console/…` route spellings to `/_console/…` in JSDoc comments on `FormViewSchema.submitBehavior` (view.zod.ts) and the `type: 'form'` action target doc (action.zod.ts) — the mount is `CONSOLE_PATH = '/_console'`, no bare `/console` route resolves. Comment-only; accept/reject behaviour is unchanged (#9078)

--- a/packages/spec/src/ui/action.zod.ts
+++ b/packages/spec/src/ui/action.zod.ts
@@ -497,7 +497,7 @@ const TARGET_REQUIRED_TYPES: ReadonlySet<string> = new Set(
  * - `type: 'flow'`   — `target` is **required** (the flow name to invoke).
  * - `type: 'modal'`  — `target` is **required** (the modal/page name to open).
  * - `type: 'api'`    — `target` is **required** (the API endpoint to call).
- * - `type: 'form'`   — `target` is **required** (the FormView name to open, routed to `/console/forms/:name`).
+ * - `type: 'form'`   — `target` is **required** (the FormView name to open, routed to `/_console/forms/:name`).
  * 
  * The `execute` alias was **removed in protocol 17** (#3855). `target` is the
  * only handler slot, so no consumer has a second slot to disagree about. An

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -2443,10 +2443,10 @@ export const FormViewSchema = lazySchema(() => strictObject({
    * What happens after a successful submit.
    *
    * The default when this is omitted is **mode-aware**, not a single fixed
-   * kind (ruled 2026-08-10 on #7245): the public `/console/f/:slug` path
+   * kind (ruled 2026-08-10 on #7245): the public `/_console/f/:slug` path
    * defaults to `thank-you` — there is no record an anonymous submitter is
    * allowed to read back, so a confirmation panel is all there is to show.
-   * The internal `/console/forms/:name` path — where `type: 'form'` actions
+   * The internal `/_console/forms/:name` path — where `type: 'form'` actions
    * send operators — defaults to redirecting to the record that was just
    * created, since an operator who just created a record belongs on that
    * record. An explicit `submitBehavior` always wins, in either mode.


### PR DESCRIPTION
Fixes #9078

## What

Three JSDoc sites in `packages/spec/src/ui/{view,action}.zod.ts` spelled the console form routes without the `/_console` underscore, against the measured mount (`CONSOLE_PATH = '/_console'` in `packages/cli/src/utils/console.ts:43`). No bare `/console` route resolves.

- `view.zod.ts:2446` — `` `/console/f/:slug` `` → `` `/_console/f/:slug` `` (inside the `FormViewSchema.submitBehavior` doc, including the `2026-08-10 #7245` ruling sentence — the ruling itself pins the mode-aware submitBehavior default, not path spelling, so only the incidental path text changed; the ruling's substance is byte-identical)
- `view.zod.ts:2449` — `` `/console/forms/:name` `` → `` `/_console/forms/:name` `` (same doc block)
- `action.zod.ts:500` — `` `/console/forms/:name` `` → `` `/_console/forms/:name` `` (the `type: 'form'` action target doc)

Sweep guard: grepped both files for any other bare `/console/` spelling — none found beyond the three named sites.

## Why

These are JSDoc comments, not `.describe()` strings, so this is a comment-only, byte-identical-behavior change — no schema/accept/reject-path is touched.

## Products follow source

Ran the regen pipeline per AGENTS.md: `pnpm --filter @objectstack/spec build` then `pnpm --filter @objectstack/spec check:generated`. All 13 generated artifacts (including `check:docs` → `content/docs/references/**`) report up to date — **no diff produced**. This confirms the issue's premise: these JSDoc blocks are not currently published to any reference page, so the regen step is a no-op here. Nothing to commit under `content/docs/references/`.

## Tests

At head `a3ddfeee7`:
- `pnpm --filter @objectstack/spec build` — green
- `pnpm --filter @objectstack/spec check:generated` — all 13 generated artifacts up to date (no-op, as expected for a comment-only change)
- `pnpm --filter @objectstack/spec typecheck` — green (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`)
- `pnpm --filter @objectstack/spec test` — 406 test files / 10807 tests passed
- `pnpm check:cross-package-test-inputs` — green
- `pnpm check:merge-driver` — green
- `pnpm check:spec-parsed-alias` — green (ADR-0122 alias convention: 1518 bare aliases, 837 pinned isomorphic, 681 paired)
- `pnpm check:type-source-resolution` — green
- `pnpm check:i18n` — green (built `@objectstack/cli` first per the gate's own prerequisite message; 9 packages, all bundles in sync, no undeclared authoring keys)
- `pnpm check:nul-bytes` — green (5998 tracked text files scanned)
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — green

Gate union derived from actual changed paths via `node scripts/pm/dispatch-gates.mjs packages/spec/src/ui/view.zod.ts packages/spec/src/ui/action.zod.ts` — all 7 matched families run above; nothing further implicated by this diff.

## Changeset

`.changeset/console-route-jsdoc-spelling.md` — `@objectstack/spec` patch.

_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_