### PR TITLE
test(spec,create-objectstack): make the remaining git-reading harnesses hermetic

### DIFF
--- a/packages/create-objectstack/src/template-consistency.test.ts
+++ b/packages/create-objectstack/src/template-consistency.test.ts
@@ -27,6 +27,51 @@ const ownMajor = Number(ownPkg.version.split('.')[0]);
 const registryTemplates = Object.keys(TEMPLATES);
 const REGISTRY_SOURCE = fs.readFileSync(path.join(pkgRoot, 'src', 'index.ts'), 'utf8');
 
+// ── #9109 — the git reads below cannot be redirected off this checkout ───────
+//
+// The skills-catalog block asks git two questions whose answers ARE its verdict:
+// `ls-files *SKILL.md` (which skill files exist) and `git grep` (which surfaces
+// advertise a repo-root install). Both were spawned with `cwd: repoRoot` and
+// nothing else, so they inherited every `GIT_*` variable in the environment —
+// and `GIT_DIR`, `GIT_INDEX_FILE` or `GIT_OBJECT_DIRECTORY` pointing elsewhere
+// makes git answer for a DIFFERENT repository while the `cwd` still reads as
+// this one. That is the #9068 exposure class: not a flake, a test that silently
+// measures another repository. A leaked `GIT_CEILING_DIRECTORIES` covering
+// `repoRoot` is the other direction — git then refuses to find this repo at all.
+//
+// Scrubbing those pointers is the whole fix here, and it is deliberately where
+// this file stops. Unlike the fixture harnesses this pattern comes from, these
+// two commands read the REAL checkout rather than a repo the test just created:
+//
+//   * no `[gc]` hardening, because there is no fixture repo to write config
+//     into, and this file must not touch the developer's own repository config;
+//   * the global/system config is left OPEN on purpose. `GIT_CONFIG_GLOBAL=/dev/null`
+//     is right for a fixture the test owns, but here it would also discard
+//     `safe.directory` — which is global config, and is exactly what lets git
+//     read a checkout owned by another user inside a container. Closing it could
+//     turn a passing read into `detected dubious ownership`, which is a
+//     regression this file gets no isolation benefit in exchange for.
+const LEAKED_GIT_ENV = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_COMMON_DIR',
+  'GIT_INDEX_FILE',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_NAMESPACE',
+  'GIT_CEILING_DIRECTORIES',
+  'GIT_TEMPLATE_DIR',
+  'GIT_CONFIG',
+] as const;
+
+/** The environment the repo-reading git calls below get: this process's, minus
+ *  every variable that could aim them at a different repository. */
+const REPO_READ_ENV: NodeJS.ProcessEnv = (() => {
+  const env = { ...process.env };
+  for (const key of LEAKED_GIT_ENV) delete env[key];
+  return env;
+})();
+
 describe('blank template package.json', () => {
   const templatePkg = JSON.parse(
     fs.readFileSync(
@@ -260,6 +305,7 @@ describe('skills catalog boundary', () => {
   const trackedSkillFiles = execFileSync('git', ['ls-files', '*SKILL.md'], {
     cwd: repoRoot,
     encoding: 'utf8',
+    env: REPO_READ_ENV,
   })
     .split('\n')
     .filter(Boolean);
@@ -326,7 +372,7 @@ describe('skills catalog boundary', () => {
       candidates = execFileSync(
         'git',
         ['grep', '-nF', 'skills add objectstack-ai/objectstack', '--', ...surfaces],
-        { cwd: repoRoot, encoding: 'utf8' },
+        { cwd: repoRoot, encoding: 'utf8', env: REPO_READ_ENV },
       );
     } catch {
       // git grep exits 1 on no matches — nothing to check then.

--- a/packages/spec/scripts/sharded-artifacts.test.ts
+++ b/packages/spec/scripts/sharded-artifacts.test.ts
@@ -391,6 +391,67 @@ describe('sharded artifacts — entry-point shard naming (#5837)', () => {
   });
 });
 
+// ── #9109 — this file's fixture repos inherit nothing from the machine ───────
+//
+// Same exposure class #9068 closed for `build-schemas-check-mode.test.ts`, and
+// the same two layers, applied here verbatim. The fixtures below were spawned
+// with `cwd` and two `-c user.*` args only, so they inherited the ambient global
+// and system git config, `init.templateDir`, and every `GIT_*` variable.
+//
+// The half that matters here is env leakage rather than gc: no fixture in this
+// file writes `.git/shallow`, so an ordinary gc leaves its fresh reachable
+// objects alone. What a leaked `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`
+// or `GIT_ALTERNATE_OBJECT_DIRECTORIES` does instead is point a fixture's git at
+// a repository other than the directory it was handed — and these cases read a
+// revision back out of the repo they just built, so that is not a flake, it is a
+// test that silently measures another repository. The repo-local `[gc]` block is
+// carried anyway, because it is the layer that binds a git process this file
+// never launched, and it costs one `config` call per fixture.
+//
+// Nothing about what these cases assert changes: the fixtures are built from the
+// same writes and read by the same `readShardedKeysAtRev`, only insulated.
+
+/** `GIT_*` variables that would point a fixture's git at a different repository
+ *  (or a different index/object store) than the directory it was handed. */
+const LEAKED_GIT_ENV = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_COMMON_DIR',
+  'GIT_INDEX_FILE',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_NAMESPACE',
+  'GIT_CEILING_DIRECTORIES',
+  'GIT_TEMPLATE_DIR',
+  'GIT_CONFIG',
+] as const;
+
+/** The environment every fixture git in this file gets. */
+const HERMETIC_ENV: NodeJS.ProcessEnv = (() => {
+  const env = { ...process.env };
+  for (const key of LEAKED_GIT_ENV) delete env[key];
+  // git's own documented "read no config file" spellings. `/dev/null` parses as
+  // an empty config, which is what makes `init.templateDir`, `core.hooksPath`
+  // and any ambient `[gc]` block unable to reach a fixture.
+  env.GIT_CONFIG_GLOBAL = '/dev/null';
+  env.GIT_CONFIG_SYSTEM = '/dev/null';
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  return env;
+})();
+
+/** Passed to every fixture git invocation — including the `init` that runs
+ *  before the repo-local config below exists. Identity first (with the global
+ *  config closed, there is no other source for it), then the maintenance switches. */
+const FIXTURE_GIT_ARGS = [
+  '-c', 'user.name=t',
+  '-c', 'user.email=t@example.invalid',
+  '-c', 'gc.auto=0',
+  '-c', 'maintenance.auto=false',
+  '-c', 'gc.pruneExpire=never',
+  '-c', 'gc.reflogExpire=never',
+  '-c', 'gc.reflogExpireUnreachable=never',
+];
+
 describe('sharded artifacts — the historical baseline reader (#5837)', () => {
   /**
    * The deletion gates anchor on an already-merged upstream commit, and commits
@@ -399,25 +460,65 @@ describe('sharded artifacts — the historical baseline reader (#5837)', () => {
    * layout wins where it exists, the retired single file is read where it is all
    * the revision has, and "neither" stays the `nothing to compare` verdict the
    * single-file gates already drew.
+   *
+   * Non-throwing by contract: this runner is handed to `readShardedKeysAtRev`,
+   * which reads `status` itself and reports a bad revision as `{ error }`. The
+   * fixture-BUILDING calls below get their loudness from `mustSucceed` instead.
    */
   const gitIn = (cwd: string) => (...args: string[]) => {
     const { spawnSync } = require('node:child_process') as typeof import('node:child_process');
-    return spawnSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@example.invalid', ...args], {
+    return spawnSync('git', [...FIXTURE_GIT_ARGS, ...args], {
       cwd,
       encoding: 'utf-8' as const,
+      env: HERMETIC_ENV,
     });
   };
+
+  /**
+   * `git init` plus the repo-local half of the isolation above.
+   *
+   * Local config is the layer that survives a git process this file did not
+   * start: `gc.auto=0` stops the fixture's own commits from triggering one, and
+   * the `never` expiries mean a gc arriving from anywhere else — an ambient
+   * maintenance schedule, a `[gc]` block in someone's global config — finds
+   * nothing it is allowed to drop.
+   */
+  function initFixtureRepo(root: string): void {
+    const git = gitIn(root);
+    const mustSucceed = (...args: string[]): void => {
+      const r = git(...args);
+      // Silent failure here used to surface as an empty `rev` and a confusing
+      // assertion three calls downstream; a broken fixture says so instead.
+      if (r.status !== 0) {
+        throw new Error(`git ${args.join(' ')} failed (${r.status}) in ${root}: ${r.stderr}`);
+      }
+    };
+    mustSucceed('init', '-q', '-b', 'main', '.');
+    for (const [key, value] of [
+      ['gc.auto', '0'],
+      ['gc.autoDetach', 'false'],
+      ['maintenance.auto', 'false'],
+      ['gc.pruneExpire', 'never'],
+      ['gc.reflogExpire', 'never'],
+      ['gc.reflogExpireUnreachable', 'never'],
+      // Reflogs are the other thing standing between a fixture commit and a
+      // prune, and an ambient `core.logAllRefUpdates=false` would have taken
+      // them away.
+      ['core.logAllRefUpdates', 'true'],
+    ] as const) {
+      mustSucceed('config', key, value);
+    }
+    mustSucceed('add', '-A');
+    mustSucceed('commit', '-q', '-m', 'fixture');
+  }
 
   function repoWith(write: (root: string) => void): { root: string; rev: string } {
     const root = path.join(dir, 'repo');
     const pkg = path.join(root, 'packages', 'spec');
     fs.mkdirSync(pkg, { recursive: true });
     write(pkg);
-    const git = gitIn(root);
-    git('init', '-q', '-b', 'main', '.');
-    git('add', '-A');
-    git('commit', '-q', '-m', 'fixture');
-    return { root: pkg, rev: git('rev-parse', 'HEAD').stdout.trim() };
+    initFixtureRepo(root);
+    return { root: pkg, rev: gitIn(root)('rev-parse', 'HEAD').stdout.trim() };
   }
 
   it('reads the sharded layout when the revision has one', () => {


### PR DESCRIPTION
Fixes #9109

Test-harness hardening only. No production code, no assertion changed in either file —
what changes is what the git invocations inherit.

**Declared file surface** (cross-lane, carried here under the triage seat's cross-domain
exception):

- `packages/spec/scripts/sharded-artifacts.test.ts` — `domain:spec`
- `packages/create-objectstack/src/template-consistency.test.ts` — `domain:cli` surface,
  carried by the spec seat per the triage designation

## The card's premise, verified against origin/main first

One half held exactly; the other half did not, and the difference changed the fix.

**`packages/spec/scripts/sharded-artifacts.test.ts` — confirmed verbatim.** `repoWith()`
builds a real fixture repository per test (`git init` at :417 in the card's numbering) and
spawns git with `cwd` plus two `-c user.*` args only, so it inherited the ambient global
and system config, `init.templateDir`, and every `GIT_*` variable. The card's severity
reading also held: nothing here writes `.git/shallow`, so the gc half is precautionary and
the env half is the live exposure.

**`packages/create-objectstack/src/template-consistency.test.ts` — the premise is wrong in
its stated form, and the file is still in scope.** The card says both files "spawn git with
`cwd` and `-c user.name` / `-c user.email` only" and were "found by walking every test file
that runs `git init` against a temp directory". This file runs no `git init` and builds no
fixture repository at all — its temp directory holds an `npm pack` tarball. What it does is
run two git commands against the **real checkout** (`repoRoot`):

- `git ls-files '*SKILL.md'` — decides which skill files the boundary block judges
- `git grep -nF 'skills add objectstack-ai/objectstack'` — decides which surfaces advertise
  a repo-root install

Neither passed an `env`, so both inherited every `GIT_*` variable. The exposure is therefore
the same class the card names — a leaked `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_OBJECT_DIRECTORY`
makes git answer for a different repository while `cwd` still reads as this one — but it lands
on the real repo rather than a fixture, so the fix is the env layer only. Measured below; it
is not theoretical.

I also re-walked the tree for the "third" harness the dispatch prompt expected in
`packages/spec/scripts`. There isn't one: the three helpers the card counts are these two plus
`build-schemas-check-mode.test.ts`, which PR #9104 already hardened. Two files is the whole
surface.

## What changed

**`sharded-artifacts.test.ts`** — the full #9104 pattern, copied:

- `HERMETIC_ENV` on every fixture git: the ten redirecting `GIT_*` variables deleted, plus
  `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` set to `/dev/null` and `GIT_CONFIG_NOSYSTEM=1`.
- `FIXTURE_GIT_ARGS` on every invocation, including the `init` that runs before repo-local
  config exists.
- `initFixtureRepo()` writes the repo-local `[gc]` block (`gc.auto=0`, `gc.autoDetach=false`,
  `maintenance.auto=false`, the three `never` expiries, `core.logAllRefUpdates=true`) — the
  layer that binds a git process the file never launched.
- The fixture-building calls (`init`, `config`, `add`, `commit`) now throw on a non-zero exit
  naming the repo. The runner handed to `readShardedKeysAtRev` keeps its non-throwing
  `spawnSync`-result contract unchanged — that function reads `status` itself and reports a bad
  revision as `{ error }`, so making it throw would have broken six assertions. Silent failure
  there previously surfaced as an empty `rev` and a confusing assertion three calls downstream.

**`template-consistency.test.ts`** — the env layer, and deliberately only that:

- `REPO_READ_ENV` scrubs the same ten redirecting variables and is passed to both git reads.
- **No `[gc]` config**, because there is no fixture repo to write into and this file must not
  touch the developer's own repository config.
- **The global/system config is left open on purpose.** `GIT_CONFIG_GLOBAL=/dev/null` is right
  for a fixture the test owns, but here it would also discard `safe.directory` — which lives in
  global config and is exactly what lets git read a checkout owned by another user inside a
  container. Closing it could turn a passing read into `detected dubious ownership`, a
  regression this file gets no isolation benefit in exchange for. The reasoning is recorded in
  the file, not just here.

**Helper placement: duplicated, not lifted.** The two files are in different packages, and
`packages/spec/scripts` is not importable from `create-objectstack` — a shared util would mint
a new cross-package dependency, which the triage note explicitly rules out as the tie-breaker.
Within `packages/spec` the alternative was to lift the block out of `build-schemas-check-mode.test.ts`,
which would mean rewriting a just-merged PR's diff for no behavioural gain. Per triage's
"prefer whichever keeps the diff mechanical", each file carries the slice it needs. A later
consolidation is a card, not a rider on this one.

## Verification — every run below at `8de2f8ed8`, the head of this branch

**Suites.** Full `@objectstack/spec` suite: **406 files / 10816 tests passed** (334.8 s).
Full `create-objectstack` suite: **4 files / 58 tests passed**. `@objectstack/spec typecheck`
(tsc + `check:scripts-typecheck` + `check:test-typecheck`) and `create-objectstack typecheck`
both exit 0.

**Isolation demonstrated — A/B under a hostile ambient environment**, matching #9104's idiom
(no new committed test; the harness swap is the measurement). Same subsets, same environment:
`GIT_DIR` aimed at a decoy repository plus a global config carrying `gc.pruneExpire` /
`reflogExpire` `= now`. Direction predicted (red on main) before running:

| subset | origin/main's harness | this branch |
| --- | --- | --- |
| `sharded-artifacts` &mdash; historical baseline reader | **6 failed / 1 passed** | **7 passed** |
| `template-consistency` &mdash; skills catalog boundary | **1 failed / 4 passed** | **5 passed** |

On main the six spec cases fail as `expected null to deeply equal ...` — the reader returned
"nothing to compare" because the leaked `GIT_DIR` pointed it at the decoy. That is the card's
"a test that silently measures another repository", reproduced.

The create-objectstack leg is worth reading closely: only the **sanity** case fails
(`expected 0 to be greater than 0`, because `ls-files` answered for the decoy). Its two sibling
assertions — every SKILL.md outside `skills/` is marked internal, and no curated entry is —
**passed vacuously** on main, iterating an empty list. The sanity guard is the only thing
between a redirected git and a silently green boundary check, which is precisely the
wrong-verdict shape the card was filed about.

**Gates.** Re-derived from the actual changed paths with `node scripts/pm/dispatch-gates.mjs`.
Green at this commit: `check:merge-driver`, `check:type-source-resolution`,
`check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`,
`check:where-matcher`, `check:nul-bytes`, `check:scripts-typecheck`, `check:test-typecheck`.

Two are **not measured locally, deliberately** — the same two, for the same reason, as #9104:
`check:type-check-debt` and `check-dev-prereqs.mjs` both refuse on a worktree with no built
closure ("measuring now would not fail, it would silently measure a DIFFERENT WORLD"; 55
workspace dependencies have no built type entry point here). Their population is `src/**/*.test.ts`
and workspace `dist/`, neither of which this diff touches. CI is the authority on both.

Also verified rather than assumed: `pnpm --filter '@objectstack/spec^...' build` matches zero
projects because both packages are workspace-dependency leaves, not because the filter was
mistyped.

## Changeset

`skip-changeset`, matching #9104's precedent exactly (tests-only, nothing published; that PR
carried the label and no `.changeset/*.md`). **Label not applied by me** — dev label writes get
eaten by the labeler; flagged to the PM to apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_