### PR TITLE
fix(spec): correct stale "passed to mysql2 verbatim" doc comment on MysqlConfigSchema.ssl

### DIFF
--- a/.changeset/mysql-ssl-doc-comment-verbatim.md
+++ b/.changeset/mysql-ssl-doc-comment-verbatim.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): correct the stale "passed to `mysql2` verbatim" TS doc comment on `MysqlConfigSchema.ssl` (mysql.zod.ts) — since #8874, the resolved `true` is translated into mysql2's own default TLS options (`rejectUnauthorized: true`) before mysql2 sees it, because mysql2 rejects a bare boolean outright. Comment-only; accept/reject behaviour is unchanged, and the shared `DriverSslToggleSchema.describe()` (correct for the postgres/turso arms, which do pass the boolean verbatim) is untouched (#9125)

--- a/packages/spec/src/data/driver/mysql.zod.ts
+++ b/packages/spec/src/data/driver/mysql.zod.ts
@@ -112,7 +112,12 @@ export const MysqlConfigSchema = lazySchema(() => strictObject(
    */
   password: refusedInlineCredentialKey('password', 'Password'),
 
-  /** TLS settings, passed to `mysql2` verbatim. */
+  /**
+   * TLS on/off. `true` reaches `mysql2` as its own default TLS options
+   * (`rejectUnauthorized: true`), not the bare boolean — mysql2 rejects a
+   * boolean outright (#8874). Certificates and verification live in the
+   * datasource-level `ssl` block.
+   */
   ssl: DriverSslToggleSchema.optional().meta({ title: 'Use SSL/TLS' }),
 
   /** Dev-only, loosen-only schema self-heal (#2186). */


### PR DESCRIPTION
Fixes #9125

## What was stale

`packages/spec/src/data/driver/mysql.zod.ts`'s doc comment above `MysqlConfigSchema.ssl`
read:

```ts
/** TLS settings, passed to `mysql2` verbatim. */
```

Since #8874 (landed, `d70428a`) the resolved `true` — the only meaningful authorable value,
`DriverSslToggleSchema` being `z.boolean()` — is translated into mysql2's own default TLS
options object (`rejectUnauthorized: true`) before mysql2 sees it, because mysql2 rejects a
bare boolean outright. "Verbatim" was never accurate for this key.

## What changed

Rewrote the TS doc comment only, along the card's suggested wording:

```ts
/**
 * TLS on/off. `true` reaches `mysql2` as its own default TLS options
 * (`rejectUnauthorized: true`), not the bare boolean — mysql2 rejects a
 * boolean outright (#8874). Certificates and verification live in the
 * datasource-level `ssl` block.
 */
```

- Not touched: `DriverSslToggleSchema`'s shared `.describe()` in `common.zod.ts` — it is
  shared with the postgres and turso arms, where the boolean IS passed verbatim and the
  text is correct.
- Not touched: any `.meta()`/`.describe()` on the `ssl` key itself — this is a TS doc
  comment, not authorable metadata.

## Proof of no-op on generated artifacts

This is a comment-only change; accept/reject behaviour is byte-identical and no generated
artifact should move. Confirmed:

- `pnpm --filter @objectstack/spec run check:authorable-surface` — green, 1596 schemas
  generated, no diff beyond the pre-existing (unrelated) baseline-anchor drift note.
- `pnpm --filter @objectstack/spec run check:generated` — all 13 generated artifacts up to
  date.

No artifact regenerated; nothing to commit beyond the doc comment and the changeset.

## Tests

- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2
  src/data/driver-sql.test.ts src/data/driver/driver-credential-refusal.test.ts
  src/data/driver/driver-placeholder-refusal.test.ts src/data/datasource.test.ts` — 281
  passed (4 files), confirming the mysql/driver ssl-key behaviour is unchanged.
- `check:authorable-surface`, `check:generated` — both green (see above).

Commit under test: `53b14a344` (`git rev-parse --short HEAD`).

## Changeset

`.changeset/mysql-ssl-doc-comment-verbatim.md` — `@objectstack/spec` patch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_