### PR TITLE
fix(metadata-protocol): SeedLoader asks the registry for a `name` column before probing it

### DIFF
--- a/.changeset/seed-loader-name-probe-asked-not-assumed.md
+++ b/.changeset/seed-loader-name-probe-asked-not-assumed.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): SeedLoader asks the registry for a `name` column before probing it — no more hundreds of provoked `INVALID_FILTER` refusals per seeded boot (#9071)
+
+`SeedLoaderService.resolveFromDatabase()` resolves a reference authored as a
+natural key by walking a probe chain: the target dataset's declared
+`externalId`, then the historical `name` default, then the internal `id`. The
+`name` leg was spelled **unconditionally** — including on objects that have no
+`name` column at all.
+
+On those objects the probe is not a cheap miss. The driver **refuses** it:
+
+```
+[sql-driver] INVALID_FILTER — Filter on 'name' names a column that object
+'crm_contact' has no column for, so the predicate never ran.
+ERROR Find operation failed {"object":"crm_contact", …}
+```
+
+and it is right to. A predicate naming a column the object does not have never
+ran, so answering "no rows" would be a lie (ADR-0110 D3 — a miss and a fault are
+different facts). One refusal is raised per reference value, per pass: a real
+`serve` boot with a 342-row seed emitted **hundreds of ERROR-level
+`Find operation failed` lines**, on every seeded boot and every per-organization
+replay, each reading exactly like a real failure that everyone downstream has to
+learn to ignore.
+
+**The fix is on the asking side, not the answering side.** The driver's refusal
+is untouched — not caught more quietly, not downgraded, not filtered out of the
+log. Instead the loader now asks the metadata registry whether the target
+declares a `name` column, through the same `resolveObjectDefinition` resolver it
+already builds the reference graph from (metadata service first, then the
+engine's own schema registry), and drops the leg when the answer is no.
+
+Which probe answers cannot change: on an object with no `name` column that leg
+could only ever throw, never match. The guard covers the leg in **both** of its
+positions — the fallback, and the first position it occupies when a referenced
+target carries no dataset in this load and keeps the metadata-level `name`
+default.
+
+**An unknown is not a denial.** When neither the metadata service nor the
+engine's schema registry can describe the object, the leg is kept — the
+historical behaviour — rather than narrowed on a fact nobody established. The
+answer is memoised per `load` (the question is asked once per unresolved
+reference value, hundreds per boot) and re-asked on the next one, since a
+publish between two loads can add the very column it is about.

--- a/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+// `.js`, not extensionless: under `moduleResolution: NodeNext` an extensionless
+// relative import does not resolve, and every symbol it names degrades to
+// `any` — the shape AGENTS.md names. The sibling seed-loader tests predate the
+// rule and sit in this package's frozen debt; a NEW file must not add to it.
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
@@ -76,14 +76,25 @@ function createColumnStrictEngine(columns: Record<string, string[]>) {
     find: vi.fn(async (objectName: string, query?: any) => {
       const declared = columns[objectName];
       let records = store[objectName] || [];
+      // Column resolution happens BEFORE row matching, exactly as the driver
+      // does it: a filter naming an unresolvable column is refused whether or
+      // not the table holds rows (a `.filter()` callback over an empty table
+      // never runs, and "no rows to test" must not read as "column fine").
       for (const key of Object.keys(query?.where || {})) {
+        if (key.startsWith('$')) throw new Error(`fake driver: unsupported operator ${key}`);
         if (declared && !declared.includes(key) && !ALWAYS_PRESENT.includes(key)) {
           refuse(objectName, key);
         }
       }
       if (query?.where) {
         records = records.filter((r) =>
-          Object.entries(query.where).every(([k, v]) => r[k] === v),
+          Object.entries(query.where).every(([k, v]) => {
+            // A combinator this double does not implement is REFUSED, never
+            // read as a field name — a double looser than the producer it
+            // stands in for turns a green suite into no suite.
+            if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+            return r[k] === v;
+          }),
         );
       }
       if (typeof query?.limit === 'number') records = records.slice(0, query.limit);

--- a/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-name-probe.test.ts
@@ -1,0 +1,368 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+import { SeedLoaderService } from './seed-loader';
+import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+
+/**
+ * [#9071] The seed loader's external-key lookup chain must ASK the metadata
+ * registry before it spells `where: { name }`.
+ *
+ * ## The observation
+ *
+ * A real `serve` boot with a 342-row seed (`objectstack-ai/cloud#1350`) emitted
+ * hundreds of ERROR-level `Find operation failed` lines: for every object whose
+ * dataset declares an `externalId` other than `name` and which has NO `name`
+ * column, the chain probed `name` anyway and the SQL driver refused the filter
+ * (`INVALID_FILTER` / 400 — `Filter on 'name' names a column that object '…'
+ * has no column for, so the predicate never ran.`).
+ *
+ * ## What is under test, and what is deliberately NOT
+ *
+ * The driver's refusal is CORRECT and stays exactly as it is: a predicate on a
+ * column the object does not have never ran, so answering "no rows" would be a
+ * lie (ADR-0110 D3 — a miss and a fault are different facts). So these tests
+ * never assert that the error is caught, downgraded or logged more quietly.
+ * They assert the only thing that removes the noise honestly: **the filter is
+ * never spelled**, so the refusal is never provoked.
+ *
+ * The fake engine below therefore refuses an unresolvable WHERE column with the
+ * driver's own envelope — `code`/`status` per ADR-0112 and the driver's first
+ * sentence — and every test counts the refusals it raised. A double that
+ * answered such a filter with `[]` would be looser than the producer it stands
+ * in for and would make this whole file green over the defect.
+ *
+ * Both directions are pinned, per the card: the leg DISAPPEARS on an object
+ * with no `name` column, and it still FIRES (and still answers) on one that
+ * declares it.
+ */
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+/** Columns every object has whether or not its author declared them. */
+const ALWAYS_PRESENT = ['id', 'organization_id', 'created_at', 'updated_at'];
+
+interface Refusal {
+  object: string;
+  column: string;
+}
+
+/**
+ * An engine whose `find` resolves WHERE columns against a declared column set
+ * and REFUSES what it cannot resolve — `driver-sql`'s behaviour, in the one
+ * respect this card is about.
+ */
+function createColumnStrictEngine(columns: Record<string, string[]>) {
+  const store: Record<string, any[]> = {};
+  const refusals: Refusal[] = [];
+  let idCounter = 0;
+
+  function refuse(object: string, column: string): never {
+    refusals.push({ object, column });
+    const err: any = new Error(
+      `Filter on '${column}' names a column that object '${object}' has no column for, ` +
+        'so the predicate never ran. A filter on a field that does not exist can only match ' +
+        'zero records, so the query was refused instead of answered with an empty list.',
+    );
+    err.code = 'INVALID_FILTER';
+    err.status = 400;
+    throw err;
+  }
+
+  const engine = {
+    find: vi.fn(async (objectName: string, query?: any) => {
+      const declared = columns[objectName];
+      let records = store[objectName] || [];
+      for (const key of Object.keys(query?.where || {})) {
+        if (declared && !declared.includes(key) && !ALWAYS_PRESENT.includes(key)) {
+          refuse(objectName, key);
+        }
+      }
+      if (query?.where) {
+        records = records.filter((r) =>
+          Object.entries(query.where).every(([k, v]) => r[k] === v),
+        );
+      }
+      if (typeof query?.limit === 'number') records = records.slice(0, query.limit);
+      return records;
+    }),
+    findOne: vi.fn(async (objectName: string, query?: any) => {
+      const rows = await (engine.find as any)(objectName, { ...query, limit: 1 });
+      return rows[0] ?? null;
+    }),
+    insert: vi.fn(async (objectName: string, data: any) => {
+      if (!store[objectName]) store[objectName] = [];
+      if (Array.isArray(data)) {
+        const records = data.map((d) => ({ id: `gen-${++idCounter}`, ...d }));
+        store[objectName].push(...records);
+        return records;
+      }
+      const record = { id: `gen-${++idCounter}`, ...data };
+      store[objectName].push(record);
+      return record;
+    }),
+    update: vi.fn(async (objectName: string, data: any) => {
+      assertEngineUpdateDispatch(data, undefined);
+      const records = store[objectName] || [];
+      const idx = records.findIndex((r) => r.id === data.id);
+      if (idx >= 0) {
+        records[idx] = { ...records[idx], ...data };
+        return records[idx];
+      }
+      return data;
+    }),
+    delete: vi.fn(async (_objectName: string, options?: any) => {
+      assertEngineDeleteDispatch(options);
+      return { deleted: 1 };
+    }),
+    count: vi.fn(async (objectName: string) => (store[objectName] || []).length),
+    aggregate: vi.fn(async () => []),
+  } as unknown as IDataEngine;
+
+  return { engine, store, refusals };
+}
+
+function createMetadata(objects: Record<string, any>): IMetadataService {
+  return {
+    getObject: vi.fn(async (name: string) => objects[name]),
+    listObjects: vi.fn(async () => Object.values(objects)),
+    register: vi.fn(async () => {}),
+    get: vi.fn(async (_t: string, name: string) => objects[name]),
+    list: vi.fn(async () => []),
+    unregister: vi.fn(async () => {}),
+    exists: vi.fn(async () => false),
+    listNames: vi.fn(async () => []),
+  } as unknown as IMetadataService;
+}
+
+const CONFIG = {
+  dryRun: false,
+  haltOnError: false,
+  multiPass: true,
+  defaultMode: 'upsert',
+  batchSize: 1000,
+  transaction: false,
+} as any;
+
+/** Every WHERE key any `find` call in this run filtered on, per object. */
+function filteredColumns(engine: IDataEngine, objectName: string): string[] {
+  return (engine.find as any).mock.calls
+    .filter(([obj]: [string]) => obj === objectName)
+    .flatMap(([, query]: [string, any]) => Object.keys(query?.where || {}));
+}
+
+// The card's shape: contact keyed by `email`, no `name` column anywhere on it;
+// an activity references it by that email.
+const CONTACT_WITHOUT_NAME = {
+  name: 'crm_contact',
+  fields: {
+    first_name: { type: 'text' },
+    last_name: { type: 'text' },
+    email: { type: 'email' },
+  },
+};
+
+const ACTIVITY = {
+  name: 'crm_activity',
+  fields: {
+    subject: { type: 'text' },
+    contact: { type: 'lookup', reference: 'crm_contact' },
+  },
+};
+
+describe('[#9071] SeedLoader external-key probe — the `name` leg is asked for, not assumed', () => {
+  it('never spells `where: { name }` on an object that declares no `name` column', async () => {
+    const { engine, store, refusals } = createColumnStrictEngine({
+      crm_contact: ['first_name', 'last_name', 'email'],
+      crm_activity: ['subject', 'contact'],
+    });
+    // A contact row already in the database, addressable only by its id — the
+    // `email` leg will MISS it, so the chain runs past the `name` leg to `id`.
+    store.crm_contact = [{ id: 'ctc_priya', email: 'priya.shah@lattice.example.com' }];
+
+    const metadata = createMetadata({ crm_contact: CONTACT_WITHOUT_NAME, crm_activity: ACTIVITY });
+
+    const result = await new SeedLoaderService(engine, metadata, createLogger()).load({
+      seeds: [
+        {
+          object: 'crm_contact',
+          externalId: 'email',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ first_name: 'Ada', last_name: 'Lovelace', email: 'ada@acme.example' }],
+        },
+        {
+          object: 'crm_activity',
+          externalId: 'subject',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ subject: 'Discovery Call', contact: 'ctc_priya' }],
+        },
+      ] as any[],
+      config: CONFIG,
+    } as any);
+
+    // The point of the card: no refusal was provoked, because no filter on a
+    // nonexistent column was ever sent.
+    expect(refusals).toEqual([]);
+    expect(filteredColumns(engine, 'crm_contact')).not.toContain('name');
+
+    // …and the lookup still resolves, through the same leg it always did.
+    expect(result.success).toBe(true);
+    const written = (engine.insert as any).mock.calls
+      .flatMap(([obj, data]: [string, any]) => (obj === 'crm_activity' ? [data].flat() : []));
+    expect(written[0].contact).toBe('ctc_priya');
+  });
+
+  it('still probes `name` — and still resolves through it — when the object declares one', async () => {
+    const { engine, store, refusals } = createColumnStrictEngine({
+      crm_account: ['name', 'code'],
+      crm_activity: ['subject', 'account'],
+    });
+    // Addressable by `name` only: the `code` leg misses, so the `name` leg is
+    // the one that must answer.
+    store.crm_account = [{ id: 'acc_acme', name: 'Acme Corp', code: 'ACME-1' }];
+
+    const metadata = createMetadata({
+      crm_account: { name: 'crm_account', fields: { name: { type: 'text' }, code: { type: 'text' } } },
+      crm_activity: {
+        name: 'crm_activity',
+        fields: { subject: { type: 'text' }, account: { type: 'lookup', reference: 'crm_account' } },
+      },
+    });
+
+    const result = await new SeedLoaderService(engine, metadata, createLogger()).load({
+      seeds: [
+        {
+          object: 'crm_account',
+          externalId: 'code',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          // A DIFFERENT account, so the in-memory map cannot answer for 'Acme Corp'.
+          records: [{ name: 'Globex Ltd', code: 'GLOBEX-1' }],
+        },
+        {
+          object: 'crm_activity',
+          externalId: 'subject',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ subject: 'Renewal Review', account: 'Acme Corp' }],
+        },
+      ] as any[],
+      config: CONFIG,
+    } as any);
+
+    expect(refusals).toEqual([]);
+    expect(filteredColumns(engine, 'crm_account')).toContain('name');
+    expect(result.success).toBe(true);
+    const written = (engine.insert as any).mock.calls
+      .flatMap(([obj, data]: [string, any]) => (obj === 'crm_activity' ? [data].flat() : []));
+    expect(written[0].account).toBe('acc_acme');
+  });
+
+  it('skips the leg in its FIRST position too — a target with no dataset defaults to `name`', async () => {
+    // A reference whose target carries no dataset in this load keeps the
+    // metadata-level `name` default as its FIRST probe (buildReferenceMap), so
+    // the same refusal is provoked one position earlier. Same defect, same fix.
+    const { engine, store, refusals } = createColumnStrictEngine({
+      crm_contact: ['first_name', 'last_name', 'email'],
+      crm_activity: ['subject', 'contact'],
+    });
+    store.crm_contact = [{ id: 'ctc_priya', email: 'priya.shah@lattice.example.com' }];
+
+    const metadata = createMetadata({ crm_contact: CONTACT_WITHOUT_NAME, crm_activity: ACTIVITY });
+
+    await new SeedLoaderService(engine, metadata, createLogger()).load({
+      seeds: [
+        {
+          object: 'crm_activity',
+          externalId: 'subject',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ subject: 'Discovery Call', contact: 'ctc_priya' }],
+        },
+      ] as any[],
+      config: CONFIG,
+    } as any);
+
+    expect(refusals).toEqual([]);
+    expect(filteredColumns(engine, 'crm_contact')).not.toContain('name');
+  });
+
+  it('keeps the leg when NOTHING can describe the object — an unknown is not a denial', async () => {
+    // Neither the metadata service nor an engine schema registry knows the
+    // target. The honest answer is "unknown", and the historical probe stands:
+    // narrowing the chain on a fact nobody established would be this file
+    // inventing a column list.
+    const { engine, refusals } = createColumnStrictEngine({
+      // `crm_contact` has a declared column set on the ENGINE (so the fake can
+      // still refuse) while no METADATA describes it.
+      crm_contact: ['email'],
+      crm_activity: ['subject', 'contact'],
+    });
+
+    const metadata = createMetadata({ crm_activity: ACTIVITY });
+
+    await new SeedLoaderService(engine, metadata, createLogger()).load({
+      seeds: [
+        {
+          object: 'crm_activity',
+          externalId: 'subject',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [{ subject: 'Discovery Call', contact: 'someone@example.com' }],
+        },
+      ] as any[],
+      config: CONFIG,
+    } as any);
+
+    expect(refusals.map((r) => r.column)).toContain('name');
+  });
+
+  it('re-asks the registry on the next load — a publish may have added the column', async () => {
+    // The answer is memoised per LOAD, not per service instance: a service is
+    // reused across loads and a publish between two of them can add the very
+    // column the memo is about.
+    const columns: Record<string, string[]> = {
+      crm_account: ['code'],
+      crm_activity: ['subject', 'account'],
+    };
+    const { engine, store, refusals } = createColumnStrictEngine(columns);
+    const objects: Record<string, any> = {
+      crm_account: { name: 'crm_account', fields: { code: { type: 'text' } } },
+      crm_activity: {
+        name: 'crm_activity',
+        fields: { subject: { type: 'text' }, account: { type: 'lookup', reference: 'crm_account' } },
+      },
+    };
+    const metadata = createMetadata(objects);
+    const loader = new SeedLoaderService(engine, metadata, createLogger());
+
+    const seeds = [
+      {
+        object: 'crm_activity',
+        externalId: 'subject',
+        mode: 'upsert',
+        env: ['prod', 'dev', 'test'],
+        records: [{ subject: 'Renewal Review', account: 'Acme Corp' }],
+      },
+    ] as any[];
+
+    await loader.load({ seeds, config: CONFIG } as any);
+    expect(filteredColumns(engine, 'crm_account')).not.toContain('name');
+
+    // The column is published — in the registry AND in the table — and the row
+    // it makes addressable appears.
+    objects.crm_account.fields.name = { type: 'text' };
+    columns.crm_account.push('name');
+    (engine.find as any).mockClear();
+    store.crm_account = [{ id: 'acc_acme', name: 'Acme Corp', code: 'ACME-1' }];
+
+    await loader.load({ seeds, config: CONFIG } as any);
+    expect(filteredColumns(engine, 'crm_account')).toContain('name');
+    expect(refusals).toEqual([]);
+  });
+});

--- a/packages/metadata-protocol/src/seed-loader.ts
+++ b/packages/metadata-protocol/src/seed-loader.ts
@@ -260,6 +260,19 @@ export class SeedLoaderService implements ISeedLoaderService {
    * so the sampling is exact.
    */
   private summariesStale = 0;
+  /**
+   * [#9071] Per-{@link load} memo of "does this object declare a `name`
+   * column?", keyed by object name — the question {@link resolveFromDatabase}
+   * must answer before it may spell `where: { name }`.
+   *
+   * Memoised because the question is asked once per unresolved reference VALUE
+   * (hundreds per seeded boot) while its answer is a property of the object,
+   * and `resolveObjectDefinition` reaches the metadata store. Cleared at the
+   * top of every `load` for the same reason {@link summariesStale} is: a
+   * service instance outlives a load, and a publish between two loads can add
+   * the very column this answer is about.
+   */
+  private declaresNameColumnCache = new Map<string, boolean>();
 
   constructor(engine: IDataEngine, metadata: IMetadataService, logger: Logger) {
     this.engine = engine;
@@ -287,6 +300,9 @@ export class SeedLoaderService implements ISeedLoaderService {
     const allResults: SeedLoadResultParsed[] = [];
     // Per-load counter — a service instance can be reused across loads.
     this.summariesStale = 0;
+    // [#9071] Same per-load lifetime, same reason: a publish between two loads
+    // can add (or drop) the `name` column this memo answers about.
+    this.declaresNameColumnCache.clear();
 
     // When the caller pinned no target org (an in-process publish has no active
     // user session — the AI build agent's publish path), BUSINESS seed rows
@@ -1177,6 +1193,31 @@ export class SeedLoaderService implements ISeedLoaderService {
     const probeFields = [targetField];
     if (targetField !== DEFAULT_EXTERNAL_ID_FIELD) probeFields.push(DEFAULT_EXTERNAL_ID_FIELD);
     if (targetField !== 'id') probeFields.push('id');
+
+    // [#9071] Ask the registry before spelling `name`, instead of probing it
+    // blind. On an object that declares no `name` column the driver REFUSES
+    // the filter (`INVALID_FILTER`) rather than answering "no rows" — and it
+    // is right to: a predicate naming a column the object does not have never
+    // ran, so "no match" would be a lie (ADR-0110 D3 — a miss and a fault are
+    // different facts). The refusal is caught below and the chain moves on, so
+    // the probe costs nothing but the ERROR line it provokes — one per
+    // reference value, per pass, hundreds per seeded boot and per per-org
+    // replay, each reading exactly like a real failure.
+    //
+    // The remedy therefore has to be on THIS side: stop asking. Softening,
+    // catching-with-a-quieter-log or downgrading the driver's answer would
+    // keep provoking a fault and then hide it, which is strictly worse than
+    // the noise.
+    //
+    // Dropping the leg cannot change WHICH probe answers: on an object with no
+    // `name` column this probe could only ever throw, never match. When the
+    // registry cannot answer at all (object unknown to metadata AND to the
+    // engine's schema registry), the leg is KEPT — an unknown is not a denial,
+    // and the historical behaviour is the safe default.
+    if (probeFields.includes(DEFAULT_EXTERNAL_ID_FIELD) && !(await this.declaresNameColumn(targetObject))) {
+      probeFields.splice(probeFields.indexOf(DEFAULT_EXTERNAL_ID_FIELD), 1);
+    }
+
     for (const probeField of probeFields) {
       try {
         const where: Record<string, unknown> = { [probeField]: value };
@@ -1204,6 +1245,48 @@ export class SeedLoaderService implements ISeedLoaderService {
       }
     }
     return null;
+  }
+
+  /**
+   * [#9071] Does `objectName` declare the historical `name` column?
+   *
+   * The one question {@link resolveFromDatabase} must be able to answer before
+   * it may add the `name` leg to its probe chain. Answered from the SAME
+   * definition resolver the reference graph is built from
+   * ({@link resolveObjectDefinition} — the metadata service first, then the
+   * engine's own schema registry), so the loader cannot form one opinion about
+   * an object's columns here and a different one two methods up. That resolver
+   * is already imported and already called at boot, so this asks the registry
+   * a question it is standing right next to; no new dependency, no new seam.
+   *
+   * **`true` on an unknown**, deliberately. Three populations reach here: an
+   * object the metadata service knows (authoritative), one only the engine's
+   * registry knows (marketplace-installed packages — the reason
+   * `resolveObjectDefinition` has its fallback at all), and one NEITHER can
+   * describe. For the third the honest answer is "unknown", and an unknown is
+   * not a denial: keeping the leg preserves today's behaviour exactly, and the
+   * probe against a genuinely absent object fails on its first leg regardless.
+   * Answering `false` there would be this file making up a column list.
+   */
+  private async declaresNameColumn(objectName: string): Promise<boolean> {
+    const memoised = this.declaresNameColumnCache.get(objectName);
+    if (memoised !== undefined) return memoised;
+
+    let declared = true;
+    try {
+      const objDef = await this.resolveObjectDefinition(objectName);
+      const fields = objDef?.fields as Record<string, unknown> | undefined;
+      if (fields && typeof fields === 'object') {
+        declared = Object.prototype.hasOwnProperty.call(fields, DEFAULT_EXTERNAL_ID_FIELD);
+      }
+    } catch {
+      // The registry itself could not answer (store outage, unknown type).
+      // Same verdict as an unknown object: keep the historical leg rather than
+      // narrow the chain on a fact nobody established.
+    }
+
+    this.declaresNameColumnCache.set(objectName, declared);
+    return declared;
   }
 
   private async resolveDeferredUpdates(


### PR DESCRIPTION
Fixes #9071

## What was wrong

`SeedLoaderService.resolveFromDatabase()` resolves a reference authored as a natural key by
walking a probe chain — the target dataset's declared `externalId`, then the historical
`name` default, then the internal `id`. The `name` leg was spelled **unconditionally**,
including on objects that have no `name` column at all.

On those objects the probe is not a cheap miss. The driver **refuses** it:

```
[sql-driver] INVALID_FILTER — Filter on 'name' names a column that object 'crm_contact'
has no column for, so the predicate never ran.
ERROR Find operation failed {"object":"crm_contact", ...}
```

One refusal per reference value, per pass — hundreds of ERROR-level `Find operation failed`
lines on every seeded boot and every per-organization replay, each reading exactly like a
real failure everyone downstream has to learn to ignore.

## What this does NOT do

The driver's refusal is **correct** and is left exactly as it is. A predicate naming a
column the object does not have never ran, so answering "no rows" would be a lie
(ADR-0110 D3 — a miss and a fault are different facts). Nothing here catches it more
quietly, downgrades it, lowers a log level or filters it out of the log. **The fix is to
stop asking, not to change the answer.**

## The fix

Ask the metadata registry whether the target declares a `name` column before adding that
leg — through the same `resolveObjectDefinition` resolver the loader already builds its
reference graph from (metadata service first, then the engine's own schema registry). The
answer is memoised per `load` (the question is asked once per unresolved reference value)
and re-asked on the next one, since a publish between two loads can add the very column it
is about.

Three properties worth stating explicitly:

- **Which probe answers cannot change.** On an object with no `name` column that leg could
  only ever throw, never match — so removing it cannot take a resolution away from any
  object. PM mechanism-assumption 1 ("does anything rely on the `name` leg answering?") is
  answered structurally rather than by sampling: the leg is dropped in exactly the
  population where it was incapable of answering, and kept everywhere else. The
  both-directions test pins that.
- **The guard covers the leg in BOTH positions.** The same refusal is provoked one position
  earlier when a referenced target carries no dataset in this load and therefore keeps the
  metadata-level `name` default as its FIRST probe (`buildReferenceMap`). Same defect
  class, same file, closed by the same guard rather than left for a second card.
- **An unknown is not a denial.** When neither the metadata service nor the engine's schema
  registry can describe the object, the leg is kept — today's behaviour — rather than
  narrowed on a fact nobody established.

On PM mechanism-assumption 2 (⚠️ do not assume the registry is importable): measured, and
it holds here — **no new import was needed**. `resolveObjectDefinition` is a private method
of `SeedLoaderService` itself, already called once per object at graph-build time, and
`IMetadataService` is a constructor argument. The alternative reading of the card — resolve
the object's ADR-0079 `nameField` and probe THAT instead of the literal `name` — was
rejected: on an object whose `nameField` points at some other column it would probe a
column never probed before and could resolve references that previously did not resolve,
which is the one thing the card says the fix must not do.

## Tests

New: `packages/metadata-protocol/src/seed-loader-name-probe.test.ts`. Its fake engine
resolves WHERE columns against a declared column set and **refuses** what it cannot
resolve, with the driver's own `INVALID_FILTER` / `400` envelope and first sentence — a
double that answered such a filter with an empty list would be looser than the producer it
stands in for and would make the whole file green over the defect. Every case counts the
refusals it raised.

Test-count direction: **up** — one new file, no existing case removed or rewritten. Both
directions are pinned: the leg disappears on an object with no `name` column (and the
lookup still resolves through the leg that always answered it), it still fires and still
answers on an object that declares one, it is skipped in its first position too, it is
KEPT when nothing can describe the object, and it is re-asked on the next `load`.

## Reproduction on a real boot

The card's observation came from a real `serve` boot, so the proof is one too — the same
app booted twice, once with each build of `@objectstack/metadata-protocol`.

**Fixture.** `examples/app-crm` already has the card's exact shape: `crm_contact` declares
no `name` column (`first_name` / `last_name` / `full_name` / `email` / `account`) and its
dataset is keyed by `email`, while `crm_activity.contact` references it by that natural
key. On a clean boot every reference hits the in-memory map, so the DB probe never runs —
so for the measurement, and **only** for it, the five `crm_activity.contact` values were
pointed at unseeded addresses (`ghost.*@lattice.example.com`), which is what makes the
lookup chain reach the database. That edit is a local experiment and is **not** in this PR;
`examples/` is untouched by the diff.

**Command.** `pnpm dev:crm -- --fresh -p PORT` (real `serve`, real sqlite driver, fresh
tempdir), 180 s window, log captured whole.

| | ERROR `Find operation failed` | `[sql-driver] INVALID_FILTER` | seed outcome |
|:---|---:|---:|:---|
| **before** (`seed-loader.ts` at `origin/main`) | **10** | **10** | `28 ok / 5 errors`, `{"inserted":28,"updated":0,"skipped":0,"errored":5,"referencesDropped":0}` |
| **after** (this branch) | **0** | **0** | `28 ok / 5 errors`, `{"inserted":28,"updated":0,"skipped":0,"errored":5,"referencesDropped":0}` |

Ten, from five rows across two passes — the card's "per row, per pass" exactly. Every one
of them was the same refusal:

```
[sql-driver] INVALID_FILTER — a WHERE column could not be resolved on 'crm_contact'
('name'). … select * from `crm_contact` where `name` = 'ghost.ada@lattice.example.com'
limit 1 - no such column: name
ERROR Find operation failed {"object":"crm_contact","error":{"message":"Filter on 'name'
names a column that object 'crm_contact' has no column for, so the predicate never ran. …
```

**The seed outcome is byte-identical across the two boots** — same counters, same five
legitimately-unresolved references, same `[SeedLoader] Deferred reference UNRESOLVED after
pass 2` lines (those are the loader correctly reporting that the ghost addresses do not
exist; they are a different thing from the noise and are untouched). That is PM
mechanism-assumption 1 answered empirically as well as structurally: **nothing relied on
the `name` leg answering.** What disappeared is exactly the ten provoked refusals.

## Verification

Local, at the exact head this body describes — **`52f9fcba9`**, the final commit (union
re-run after it, not before).

- `pnpm --filter '@objectstack/metadata-protocol^...' build` — the dependency closure first,
  in a fresh worktree.
- `pnpm --filter @objectstack/metadata-protocol test` — **113 files / 1572 tests passed**.
- `npx vitest run src/seed-loader-name-probe.test.ts` — **1 file / 5 tests passed**.
- `npx tsc --noEmit` in `packages/metadata-protocol` — **63 errors**, identical to the
  frozen DEBT ledger entry; the new file contributes none. (It contributed one TS2835
  before its import was spelled `./seed-loader.js` — an extensionless relative import does
  not resolve under `moduleResolution: NodeNext`. Caught by re-running the ratchet, and
  fixed rather than baselined.)
- Gate families, re-derived from the actual changed paths with
  `node scripts/pm/dispatch-gates.mjs` and all green: `check:nul-bytes`,
  `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`,
  `check:durability-log-level`, `check:objectui-changeset`,
  `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`,
  `check:type-check-coverage`, `check:test-source-alias`, and the ratchet
  `check:type-check-debt --re-measure` (**33 entries re-measured, none above its recorded
  number**).

**Reverse verification** — the fix committed first, then taken out with
`git checkout origin/main -- packages/metadata-protocol/src/seed-loader.ts` and restored
from the branch. Direction predicted before running, and observed: **red**, 3 of 5 cases
failing —

```
× never spells `where: { name }` on an object that declares no `name` column
× skips the leg in its FIRST position too — a target with no dataset defaults to `name`
× re-asks the registry on the next load — a publish may have added the column
AssertionError: expected [ { object: 'crm_contact', …(1) } ] to deeply equal []
AssertionError: expected [ 'name', 'id', 'name', 'id' ] to not include 'name'
```

The two that stay green under the revert are exactly the two asserting **preserved**
behaviour (the leg still fires when the column is declared; the leg is kept when nothing
can describe the object) — which is the property this change claims.

_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_
