### PR TITLE
docs(getting-started): fix swapped master_detail delete-behavior default

### DIFF
--- a/content/docs/getting-started/common-patterns.mdx
+++ b/content/docs/getting-started/common-patterns.mdx
@@ -92,7 +92,7 @@ export default defineStack({
 
 ## 2. Master-Detail Relationship
 
-Create a parent-child relationship between a master and its detail records. Note that `master_detail` defaults to `deleteBehavior: 'set_null'`; set `deleteBehavior: 'cascade'` explicitly if you want child records deleted with the parent.
+Create a parent-child relationship between a master and its detail records. A `master_detail` child has no independent existence, so `master_detail` fields **cascade deletes by default** — deleting the parent deletes its children too. Set `deleteBehavior: 'restrict'` explicitly if you want the parent delete blocked while children still exist.
 
 {/* os:check */}
 ```typescript


### PR DESCRIPTION
Fixes #9164

## What was wrong

`content/docs/getting-started/common-patterns.mdx:95` told authors `master_detail`
defaults to `deleteBehavior: 'set_null'`, and that they must set `deleteBehavior: 'cascade'`
explicitly to get children deleted with the parent. Both clauses are false, and the two
defaults are swapped onto the wrong field type.

## Verification against the engine (re-derived, not copied from the issue)

`packages/objectql/src/engine.ts`, `cascadeDeleteRelations` (around line 10065, current
`origin/main`):

```ts
fdef.type === 'master_detail'
    ? (fdef.deleteBehavior === 'restrict' ? 'restrict' : 'cascade')
    : (fdef.deleteBehavior || 'set_null');
```

Read with my own eyes on this branch's `origin/main`, anchored on the symbol
(`cascadeDeleteRelations`) rather than the line number since anchors have been drifting:

- `master_detail` with no `deleteBehavior` (or any value other than `'restrict'`, including
  an explicit `'set_null'`) resolves to `cascade` — `set_null` is not reachable for this
  field type at all.
- `set_null` is the default for the *other* branch: a plain reference (`lookup`) with no
  `deleteBehavior`.

The doubly-commented block right above that ternary (lines 10026-10028) states the same
thing in prose: "`master_detail` defaults to `cascade` ... `lookup` defaults to
`set_null`". `content/docs/protocol/objectql/types.mdx:691` agrees (`Deletion | Always
cascade` for master-detail) and I re-checked it is still current — no drift there, so the
new docs wording is consistent with it rather than inventing a third phrasing.

## The harmful reading this fixes

The passive one: an author who followed the old sentence's instruction (set `cascade`
explicitly) was opting in to a no-op. The one who got hurt is the one who read "defaults
to `set_null`", concluded their child rows were safe, and changed nothing — then deleted a
parent and silently lost the children.

## The fix

```diff
-Create a parent-child relationship between a master and its detail records. Note that `master_detail` defaults to `deleteBehavior: 'set_null'`; set `deleteBehavior: 'cascade'` explicitly if you want child records deleted with the parent.
+Create a parent-child relationship between a master and its detail records. A `master_detail` child has no independent existence, so `master_detail` fields **cascade deletes by default** — deleting the parent deletes its children too. Set `deleteBehavior: 'restrict'` explicitly if you want the parent delete blocked while children still exist.
```

Corrected both false clauses, and (per the filer's suggestion) said *why* cascade is the
right default: a master-detail child has no independent existence — the fact the old
sentence was presumably reaching for. The override guidance now points at `restrict`
(the only other value the engine's ternary above ever resolves a `master_detail` field
to) rather than at `cascade`, which was never a real override.

The example code block a few lines down (`deleteBehavior: 'cascade'`, now redundant with
the corrected default) is left as-is — it was never false, being explicit there is
harmless, and touching it is outside what this card asked for.

## The one judgement that was mine to make

Triage left "should `getting-started/` state per-type defaults at all" for this PR to
decide. I kept it stating the `master_detail` default, scoped to just that one type:
this section's whole point is the master-detail pattern, so the default delete behavior
for *that* field type is directly on-topic and worth a reader knowing without a trip to
`types.mdx`. What I did not do is turn this into a defaults matrix covering `lookup`/
`set_null` as well — that comparison already lives in `types.mdx` (the "Difference from
`lookup`" table), stating it a second time here is exactly the kind of duplication that
drifted out of sync once already, and getting-started's job is one clear worked pattern,
not a second copy of the reference page.

## Scope

Docs-only, no engine change (the engine is correct). No sweep — this is the one page
named in the issue; other `getting-started/` pages were explicitly not audited for the
same shape and none were touched here.

## Tests / gates

Named by `node scripts/pm/dispatch-gates.mjs content/docs/getting-started/common-patterns.mdx`
(re-run against the actual changed path at the final commit, same 3 gates both times):

```
pnpm check:docs-audit-scope   # PASS
pnpm check:docs-redirects     # PASS
pnpm check:role-word          # PASS
```

Also ran, since the file has a fenced `os:check` TS block and this is a `content/docs`
edit:

```
pnpm check:doc-authoring   # PASS - 376 files clean, no bare metadata literals
pnpm check:doc-anchors     # PASS - 240 fragment links resolve
pnpm check:nul-bytes       # PASS
```

All six green at `ef3998635` (the final commit on this branch, quoted from
`git rev-parse --short HEAD` run after the last push).

## Changeset

None — docs-only, releases nothing. Applying `skip-changeset` on this PR (existing labels
preserved).

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_