### PR TITLE
docs(cli): name the admin-owned skip class in os meta resync's docblock

### DIFF
--- a/packages/cli/src/commands/meta/resync.ts
+++ b/packages/cli/src/commands/meta/resync.ts
@@ -48,9 +48,16 @@ function safeGetService(kernel: any, name: string): any {
  * boot; this command closes the one remaining gap by force-reconciling the
  * default permission-set rows to the shipped declaration.
  *
- * Business data is never touched — only `sys_permission_set` definition rows.
- * A row an admin has taken over in Setup (`managed_by:'user'`) or a package
- * owns (`'package'`) is an intentional override and is left alone.
+ * Business data is never touched — only `sys_permission_set` definition rows,
+ * and only rows still `managed_by:'platform'` are reconciled. A row a package
+ * owns (`'package'`) is left alone as a deliberate override. A row stamped
+ * `'admin'` — or the legacy spelling `'user'`, healed to `'admin'` by the
+ * boot-time vocabulary normalizer (`normalizeManagedByVocab`) — is left alone
+ * too, but is NOT always a deliberate override: on any install created before
+ * #8692 (2026-08-15) the platform's OWN seeded default sets carry that same
+ * `'admin'` stamp, indistinguishable from a genuine Setup takeover, so
+ * `resynced 0 / skipped N` is a permanent, by-design outcome on those
+ * installs rather than a bug.
  */
 export default class MetaResync extends Command {
   static override description =


### PR DESCRIPTION
Fixes #9130

## What

`os meta resync`'s docblock (`packages/cli/src/commands/meta/resync.ts`, ~line 51) enumerated the rows the command leaves alone as `'user'` and `'package'`, but never named `'admin'` — the canonical value of the tri-state `managed_by` vocabulary (`platform` / `package` / `admin`).

Re-verified the vocabulary on current `origin/main` before writing, per the triage comment's instruction not to copy it from the card:

- `packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts`: the `managed_by` select field's live options are `platform` / `package` / `admin`. Its description says legacy rows may carry `'user'` (== admin).
- `packages/plugins/plugin-security/src/normalize-managed-by.ts` (`normalizeManagedByVocab`): heals the legacy `'user'` spelling to `'admin'` on `sys_permission_set` at `kernel:ready`, after the seeders. Idempotent, best-effort.
- `packages/plugins/plugin-security/src/bootstrap-platform-admin.ts` (`resync: true` path): a row is reconciled only when `managed_by` is falsy or `'platform'`; anything else (`'admin'`, `'package'`, or an un-normalized `'user'`) is skipped. Its own docblock (added by #9129, PR for #8692's forward-only ruling `712e185db`) explains that installs created before 2026-08-15 have their platform-seeded default sets stamped `'admin'` — indistinguishable from a genuine Setup takeover — so the skip is permanent and by design for those installs.

`'user'` is kept in the enumeration (not dropped) since the boot normalizer's existence implies stored legacy rows can still exist; this docblock describes stored data, not just the CLI's own live-boot behavior.

## Change

Docblock-only, `packages/cli/src/commands/meta/resync.ts`:
- Added `'admin'` to the enumeration alongside `'package'`, and kept the legacy `'user'` spelling with a note that it's healed to `'admin'` by `normalizeManagedByVocab`.
- Added the pre-#8692 legacy-install sentence: those installs permanently report `resynced 0 / skipped N`, by design, not a bug.
- Corrected the "intentional override" framing for the admin-owned case to match the neutral framing `bootstrap-platform-admin.ts`'s own log message already adopted under the #8692 ruling (calling every admin-owned skip "intentional" is false for a pre-#8692 install, where the only writer was the seeder's field default, not an admin decision). `'package'`-owned rows are genuinely deliberate and keep that framing.

No runtime behavior change — the command's actual resync/skip logic is untouched.

## Out of scope (per triage)

The triage comment on #9130 explicitly deferred whether the CLI's *runtime output* (the interactive confirm-prompt text and the post-run skip-count message) should also explain a nonzero skip count, with a named restart condition (an operator actually asking). Not built here. While implementing I did not hit a case where the docblock's honesty depended on touching that output, so no scope-conflict to report.

## Tests

- `pnpm --filter '@objectstack/cli^...' build` (dependency closure) — green.
- `pnpm --filter '@objectstack/cli' typecheck` — green (`tsc --noEmit`, no errors), re-run at final head `58f2faf4d`.
- `pnpm --filter '@objectstack/cli' test -- --maxWorkers=2` — 122 test files / 1358 tests passed.
- `node scripts/check-cross-package-test-inputs.mjs` (named by `node scripts/pm/dispatch-gates.mjs packages/cli/src/commands/meta/resync.ts`, both `lint.yml`/`ci.yml` copies of this family) — green, re-run at final head.
- `node scripts/check-nul-bytes.mjs` — green, re-run at final head.

All re-run at the final commit `58f2faf4d` (matches `git rev-parse --short HEAD`).

## Changeset

None — docblock-only change to a CLI source file, releases nothing observable. `skip-changeset` label applied.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_