### PR TITLE
feat(spec): refuse unknown top-level stack keys — ObjectStackDefinitionSchema goes strict (#8687)

### DIFF
--- a/.changeset/stack-top-level-unknown-keys-refused.md
+++ b/.changeset/stack-top-level-unknown-keys-refused.md
@@ -1,0 +1,62 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): refuse unknown top-level stack keys — `ObjectStackDefinitionSchema` goes strict (#8687, the outermost #4001 door)
+
+**BREAKING** accept-set narrowing, landing after the v17.0.0 cut (the lockstep
+launch-window convention ships it as `minor`; the migration prescription is
+registered under protocol major 18, where `os migrate meta` users will look).
+
+The top-level stack definition was the last strip-mode authoring surface of
+the #4001 campaign: an unknown top-level key parsed green and its value was
+silently dropped. Measured on 17.0.0 GA (#8687): three injected bogus
+top-level keys added ZERO warnings to `os validate` and exited 0 — even
+`--strict` could not catch them, because the `defineStack:` naming diagnostic
+printed at load, outside the warning tally. The failure population is a typo
+or stale key (`flow` for `flows`, `approvalProcesses` after the 7.4 removal)
+shipping an artifact with a whole metadata family absent at runtime — the
+root of hotcrm#1141.
+
+**What is refused:** any top-level key the schema does not declare, with a
+prescriptive message naming the surface and the offending key. A near miss
+carries the did-you-mean the load-time lint used to print (`objectz` →
+`objects`, `flow` → `flows`) — the near-miss resolver survives, now riding
+the refusal itself, and `lintUnknownStackKeys` goes quiet on the strict
+surface by its own posture rule (one voice, not two). Curated prescriptions
+answer the known retirements: `storage` (deployment config, `OS_STORAGE_*`),
+`approvals`/`approvalProcesses` (Approval-node flows, ADR-0019), `workflows`
+(`state_machine` validation rules, ADR-0020), `portals` (removed, #3464),
+`onDisable` (never invoked, #4212).
+
+**What stays accepted:** every declared key byte-identically — and `onEnable`
+is now DECLARED rather than undeclared-but-honoured: `AppPlugin` has always
+executed it off the authored bundle (#4095 grafts it back on artifact boot),
+and a strict close of an undeclared `onEnable` would have refused the pattern
+our own examples ship. `declared = honoured`, in both directions.
+`composeStacks` treats `onEnable` as single-valued: same value passes, a
+disagreement is refused naming both stacks.
+
+A strict parse failure fails `os validate` outright — exit 1 with or without
+`--strict` — so the CI gap closes with no warning-accounting change.
+
+## FROM → TO
+
+```ts
+// before — parsed green; the whole flows family was silently absent at runtime
+export default defineStack({ manifest, objects: [...], flow: [myFlow] });
+
+// after — refused at parse: "Unrecognized key(s) on this stack definition:
+// `flow`. Did you mean `flow` → `flows`?"
+export default defineStack({ manifest, objects: [...], flows: [myFlow] });
+```
+
+There is deliberately no automatic rewrite: an undeclared top-level key
+either names a capability the declaration surface does not deliver (blessing
+it would be declared-but-unenforced surface, ADR-0078) or is a spelling of a
+declared one, which the rejection names. `os migrate meta` surfaces the
+change as a structured TODO (semantic entry
+`stack-top-level-unknown-keys-refused`, protocol major 18 — this refusal is
+not part of the v17.0.0 cut).
+
+<!-- adr-0087: registered stack-top-level-unknown-keys-refused -->

--- a/packages/cli/src/commands/migrate/meta.stored-flow-resolution.integration.test.ts
+++ b/packages/cli/src/commands/migrate/meta.stored-flow-resolution.integration.test.ts
@@ -40,8 +40,8 @@ const engineOf = (stack: { kernel: any }): IObjectQLEngine =>
 const SYSTEM = { context: { isSystem: true } };
 
 const ARTIFACT = {
-  id: 'stored_flow_smoke',
-  name: 'Stored Flow Smoke',
+  // #8687: manifest fields under `manifest:` — the flat spelling is refused.
+  manifest: { id: 'stored_flow_smoke', name: 'Stored Flow Smoke', version: '0.0.0', type: 'app' },
   objects: [{ name: 'sfs_lead', fields: { title: { type: 'text' } } }],
 };
 

--- a/packages/cli/src/utils/schema-migrate.deferred-ddl.integration.test.ts
+++ b/packages/cli/src/utils/schema-migrate.deferred-ddl.integration.test.ts
@@ -21,8 +21,8 @@ import { SqlDriver } from '@objectstack/driver-sql';
 import { bootSchemaStack } from './schema-migrate.js';
 
 const ARTIFACT = {
-  id: 'defer_smoke',
-  name: 'Defer Smoke',
+  // #8687: manifest fields under `manifest:` — the flat spelling is refused.
+  manifest: { id: 'defer_smoke', name: 'Defer Smoke', version: '0.0.0', type: 'app' },
   objects: [
     {
       name: 'defer_widget',

--- a/packages/cli/src/utils/schema-migrate.integration.test.ts
+++ b/packages/cli/src/utils/schema-migrate.integration.test.ts
@@ -34,8 +34,9 @@ describe('bootSchemaStack + migrate engine (integration)', () => {
     writeFileSync(
       join(dir, 'dist', 'objectstack.json'),
       JSON.stringify({
-        id: 'mig_smoke',
-        name: 'Migrate Smoke',
+        // #8687: manifest fields belong under `manifest:` — the flat spelling
+        // was silently stripped before the strict close and is refused now.
+        manifest: { id: 'mig_smoke', name: 'Migrate Smoke', version: '0.0.0', type: 'app' },
         objects: [
           {
             name: 'mig_biz_unit',
@@ -149,8 +150,7 @@ describe('bootSchemaStack — dev-provisioned __search companions are not orphan
     writeFileSync(
       join(dir, 'dist', 'objectstack.json'),
       JSON.stringify({
-        id: 'mig_pinyin_smoke',
-        name: 'Migrate Pinyin Smoke',
+        manifest: { id: 'mig_pinyin_smoke', name: 'Migrate Pinyin Smoke', version: '0.0.0', type: 'app' },
         i18n: { defaultLocale: 'en', supportedLocales: ['en', 'zh-CN'], fallbackLocale: 'en' },
         objects: [
           {

--- a/packages/cli/src/utils/schema-migrate.readonly-probe.integration.test.ts
+++ b/packages/cli/src/utils/schema-migrate.readonly-probe.integration.test.ts
@@ -36,8 +36,8 @@ import { join } from 'node:path';
 import { bootSchemaStack, type PendingSchemaWork } from './schema-migrate.js';
 
 const ARTIFACT = {
-  id: 'probe_smoke',
-  name: 'Probe Smoke',
+  // #8687: manifest fields under `manifest:` — the flat spelling is refused.
+  manifest: { id: 'probe_smoke', name: 'Probe Smoke', version: '0.0.0', type: 'app' },
   objects: [
     { name: 'probe_widget', fields: { name: { type: 'text', required: true }, colour: { type: 'text' } } },
     { name: 'probe_gadget', fields: { label: { type: 'text' } } },

--- a/packages/cli/src/utils/schema-migrate.teardown.integration.test.ts
+++ b/packages/cli/src/utils/schema-migrate.teardown.integration.test.ts
@@ -52,8 +52,8 @@ describe('[#4747] bootSchemaStack teardown disarms the ADR-0057 sweep', () => {
     writeFileSync(
       join(dir, 'dist', 'objectstack.json'),
       JSON.stringify({
-        id: 'teardown_smoke',
-        name: 'Teardown Smoke',
+        // #8687: manifest fields under `manifest:` — the flat spelling is refused.
+        manifest: { id: 'teardown_smoke', name: 'Teardown Smoke', version: '0.0.0', type: 'app' },
         objects: [
           {
             name: 'td_note',

--- a/packages/cli/test/emit-json-pipe.test.ts
+++ b/packages/cli/test/emit-json-pipe.test.ts
@@ -178,7 +178,9 @@ describe('os validate --json over a pipe', () => {
     }
     writeFileSync(
       join(configDir, 'objectstack.config.ts'),
-      `export default ${JSON.stringify({ name: 'trunc', objects }, null, 2)};\n`,
+      // #8687: no stray top-level `name` — it would add a 901st (unrecognized_keys)
+      // error and break the exact-count assertion below.
+      `export default ${JSON.stringify({ objects }, null, 2)};\n`,
     );
   });
 

--- a/packages/cli/test/migrate-meta.e2e.test.ts
+++ b/packages/cli/test/migrate-meta.e2e.test.ts
@@ -38,8 +38,9 @@ const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
  */
 const PRE17_CONFIG = `
 export default {
-  name: 'migrate_meta_e2e',
-  label: 'Migrate Meta E2E',
+  // #8687: top-level name/label were never stack keys (silently stripped
+  // before the strict close, refused now) — the identity lives in manifest.
+  manifest: { id: 'migrate_meta_e2e', name: 'Migrate Meta E2E', version: '1.0.0', type: 'app' },
   objects: [{
     name: 'e2e_ticket',
     label: 'Ticket',

--- a/packages/cli/test/validate-top-level-strict.e2e.test.ts
+++ b/packages/cli/test/validate-top-level-strict.e2e.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8687 — `os validate` fails OUTRIGHT on an unknown top-level stack key, over
+ * the real CLI process.
+ *
+ * The card's measurement on 17.0.0 GA: three injected bogus top-level keys
+ * added ZERO warnings and `os validate` exited 0 — even `--strict` could not
+ * catch them, because the `defineStack:` naming diagnostic printed at load,
+ * outside the warning tally. There was no flag that turned a dropped top-level
+ * key into a non-zero exit.
+ *
+ * The maintainer-ruled fix (Shape B) closes `ObjectStackDefinitionSchema` at
+ * the top level, so the refusal happens in the one parse every authoring path
+ * shares — and a parse failure fails `validate` with exit 1 **without needing
+ * `--strict` at all** (B subsumes Shape A's warning-accounting change). The
+ * exit status is the whole point of the card — it is the only thing a CI
+ * pipeline reads — so this test spawns the real CLI (the
+ * `migrate-exit-code.e2e.test.ts` pattern: `bin/run-dev.js` + tsx, no
+ * dependency on `packages/cli/dist`) and asserts what the SHELL sees.
+ *
+ * Schema-layer pins (issue code/path, near-miss guidance, curated
+ * prescriptions, accept side) live in
+ * `packages/spec/src/stack-top-level-strict.test.ts`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const CLI = resolve(HERE, '../bin/run-dev.js');
+const TSX = resolve(HERE, '../../../node_modules/.bin/tsx');
+
+/** The card's failure shape: a valid stack plus ONE stray top-level key. */
+const CONFIG_WITH_STRAY_KEY = `
+export default {
+  manifest: { id: 'com.example.straykey', name: 'straykey', version: '1.0.0', type: 'app' },
+  objects: [{
+    name: 'sk_ticket',
+    label: 'Ticket',
+    sharingModel: 'private',
+    fields: { title: { type: 'text', label: 'Title' } },
+  }],
+  // One character off 'flows' — the family-dropping typo the card measured.
+  flow: [],
+};
+`;
+
+const CONFIG_CLEAN = `
+export default {
+  manifest: { id: 'com.example.straykey', name: 'straykey', version: '1.0.0', type: 'app' },
+  objects: [{
+    name: 'sk_ticket',
+    label: 'Ticket',
+    sharingModel: 'private',
+    fields: { title: { type: 'text', label: 'Title' } },
+  }],
+  flows: [],
+};
+`;
+
+interface Run {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], cwd: string): Promise<Run> {
+  return new Promise((resolvePromise) => {
+    execFile(
+      TSX,
+      [CLI, ...args],
+      { cwd, maxBuffer: 16 * 1024 * 1024, env: { ...process.env, NO_COLOR: '1' } },
+      (err, stdout, stderr) => {
+        resolvePromise({
+          code: err ? (typeof (err as { code?: unknown }).code === 'number' ? (err as unknown as { code: number }).code : 1) : 0,
+          stdout: String(stdout),
+          stderr: String(stderr),
+        });
+      },
+    );
+  });
+}
+
+let strayDir: string;
+let cleanDir: string;
+
+beforeAll(() => {
+  strayDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-e2e-stray-'));
+  writeFileSync(join(strayDir, 'objectstack.config.ts'), CONFIG_WITH_STRAY_KEY);
+  cleanDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-e2e-clean-'));
+  writeFileSync(join(cleanDir, 'objectstack.config.ts'), CONFIG_CLEAN);
+});
+
+afterAll(() => {
+  rmSync(strayDir, { recursive: true, force: true });
+  rmSync(cleanDir, { recursive: true, force: true });
+});
+
+describe('#8687 — os validate refuses an unknown top-level stack key', () => {
+  it('exits non-zero WITHOUT --strict, naming the key and the near-miss', async () => {
+    const run = await runCli(['validate'], strayDir);
+    expect(run.code, `expected non-zero exit; stdout:\n${run.stdout}\nstderr:\n${run.stderr}`).not.toBe(0);
+    const out = run.stdout + run.stderr;
+    expect(out).toContain('`flow`');
+    expect(out).toContain('Did you mean `flow` → `flows`?');
+  }, 120_000);
+
+  it('control: the identical stack with the key spelled `flows` exits 0', async () => {
+    const run = await runCli(['validate'], cleanDir);
+    expect(run.code, `expected exit 0; stdout:\n${run.stdout}\nstderr:\n${run.stderr}`).toBe(0);
+  }, 120_000);
+});

--- a/packages/lint/src/validate-org-axis-red-lines.test.ts
+++ b/packages/lint/src/validate-org-axis-red-lines.test.ts
@@ -368,23 +368,29 @@ describe('validateOrgAxisRedLines — undeclared keys are the schema’s job, no
     expect(rules({ objects: [{ name: 'work_order', rls: [ORG_WALKING_POLICY] }] })).toEqual([]);
   });
 
-  it('`permissionSets` / `sharing` are not stack-root keys — the root STRIPS them before any rule runs', () => {
+  it('`permissionSets` / `sharing` are not stack-root keys — the root now REFUSES them (#8687)', () => {
     const rootKeys = Object.keys(ObjectStackSchema.shape);
     expect(rootKeys).toEqual(expect.arrayContaining(['permissions', 'sharingRules']));
     expect(rootKeys).not.toContain('permissionSets');
     expect(rootKeys).not.toContain('sharing');
 
-    // Unlike the `.strict()` sub-schemas this one strips rather than rejects,
-    // which is precisely why the dead branch was invisible: the stack parses,
-    // and the key the rule reached for is simply gone.
+    // When this pin was written the root STRIPPED rather than rejected — which
+    // is precisely why the dead branch was invisible: the stack parsed, and the
+    // key the rule reached for was simply gone. #8687 closed the root
+    // (`strictObject`, the last #4001 door), so the same wrong spellings now
+    // fail the parse loudly, naming both keys. The rule's position is
+    // unchanged either way: the diagnostic belongs to the schema.
     const parsed = ObjectStackSchema.safeParse({
       manifest: MANIFEST,
       permissionSets: [{ name: 'pset', label: 'P', objects: {} }],
       sharing: [{ name: 'r', type: 'criteria', object: 'o', sharedWith: HQ_TEAM, condition: 'true' }],
     });
-    expect(parsed.success).toBe(true);
-    expect(parsed.data).not.toHaveProperty('permissionSets');
-    expect(parsed.data).not.toHaveProperty('sharing');
+    expect(parsed.success).toBe(false);
+    const issue = parsed.success ? undefined : parsed.error.issues.find((i) => i.code === 'unrecognized_keys');
+    expect(issue).toBeDefined();
+    expect((issue as unknown as { keys: string[] }).keys).toEqual(
+      expect.arrayContaining(['permissionSets', 'sharing']),
+    );
 
     // So the rule reads the declared spellings only. A stack that spells them
     // the other way gets its diagnostic from the schema, not from a red line

--- a/packages/lint/src/validate-rule-schema-formats.test.ts
+++ b/packages/lint/src/validate-rule-schema-formats.test.ts
@@ -94,7 +94,7 @@ describe('validateRuleSchemaFormats — the dropped keyword goes RED (#5178)', (
     // stack could not parse, the finding would be unreachable on the compile
     // path this rule is registered `input: 'parsed'` for (#5018/#5046).
     const stack = {
-      ...MANIFEST,
+      manifest: MANIFEST,
       ...objectWith(schemaRule({ type: 'object', properties: { email: { type: 'string', format: 'emial' } } })),
     };
     const parsed = ObjectStackSchema.safeParse(stack);
@@ -388,7 +388,7 @@ describe('validateRuleSchemaFormats is wired into every authoring command', () =
 
   it.each([...AUTHORING_COMMANDS])('os %s reports the misspelling as an error', (command) => {
     const stack = {
-      ...MANIFEST,
+      manifest: MANIFEST,
       ...objectWith(schemaRule({ type: 'object', properties: { email: { type: 'string', format: 'emial' } } })),
     };
     const findings = runAuthoringRules(command, { normalized: stack, parsed: stack });

--- a/packages/metadata/src/plugin-hmr-reload.test.ts
+++ b/packages/metadata/src/plugin-hmr-reload.test.ts
@@ -25,14 +25,18 @@ function fakeCtx() {
 function writeArtifact(flowName: string): string {
     const dir = mkdtempSync(join(tmpdir(), 'os-hmr-'));
     const file = join(dir, 'objectstack.json');
+    // Manifest fields under `manifest:` — the flattened spelling was never a
+    // compiled-artifact shape (the strip-mode schema dropped all seven keys);
+    // #8687's strict close refuses the flat keys.
     const artifact = {
-        id: 'com.example.test',
-        name: 'test',
-        version: '0.0.0',
-        type: 'app',
-        scope: 'app',
-        namespace: 'test',
-        defaultDatasource: 'memory',
+        manifest: {
+            id: 'com.example.test',
+            name: 'test',
+            version: '0.0.0',
+            type: 'app',
+            namespace: 'test',
+            defaultDatasource: 'memory',
+        },
         // Seeds have no `name`, so they never enter the MetadataManager —
         // they reach reload consumers only via the `metadata:reloaded`
         // payload (AppPlugin's hot-reload seeder). Pin that pass-through.

--- a/packages/metadata/src/plugin.test.ts
+++ b/packages/metadata/src/plugin.test.ts
@@ -81,14 +81,19 @@ describe('MetadataPlugin._parseAndRegisterArtifact — view name resolution (PR-
             logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
         } as any;
 
+        // Manifest fields belong under `manifest:` — the flattened spelling this
+        // fixture used to carry was never a compiled-artifact shape (the strip-
+        // mode schema silently dropped all seven keys, and `scope: 'app'` is not
+        // even a manifest scope). #8687's strict close refuses the flat keys.
         const artifact = {
-            id: 'com.example.test',
-            name: 'test',
-            version: '0.0.0',
-            type: 'app',
-            scope: 'app',
-            namespace: 'test',
-            defaultDatasource: 'memory',
+            manifest: {
+                id: 'com.example.test',
+                name: 'test',
+                version: '0.0.0',
+                type: 'app',
+                namespace: 'test',
+                defaultDatasource: 'memory',
+            },
             views: [
                 {
                     // intentionally NO top-level name — mirrors compiled artifact shape
@@ -131,14 +136,16 @@ describe('MetadataPlugin._parseAndRegisterArtifact — package docs (ADR-0046)',
             logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
         } as any;
 
+        // Same #8687 re-spell as above: manifest fields under `manifest:`.
         const artifact = {
-            id: 'com.example.docs',
-            name: 'test',
-            version: '0.0.0',
-            type: 'app',
-            scope: 'app',
-            namespace: 'test',
-            defaultDatasource: 'memory',
+            manifest: {
+                id: 'com.example.docs',
+                name: 'test',
+                version: '0.0.0',
+                type: 'app',
+                namespace: 'test',
+                defaultDatasource: 'memory',
+            },
             docs: [
                 { name: 'test_index', label: 'Overview', content: '# Overview\n' },
                 { name: 'test_guide', content: '# Guide\n' },

--- a/packages/spec/src/data/authoring-key-lint.ts
+++ b/packages/spec/src/data/authoring-key-lint.ts
@@ -172,28 +172,29 @@ export const STACK_KEY_GUIDANCE: Readonly<
 });
 
 /**
- * Authored TOP-LEVEL members the **runtime executes off the bundle**, which the
- * stack schema therefore does not — and cannot — declare.
+ * Authored TOP-LEVEL members the **runtime executes off the bundle**.
  *
- * `onEnable` is a function. It cannot survive `ObjectStackDefinitionSchema`
- * (which does not declare it) and it cannot survive `dist/objectstack.json`
- * (JSON has no functions), yet it is not lost: `AppPlugin` reads it straight
- * off the authored bundle and calls it at `start()`, and on the artifact-boot
- * path the CLI grafts it back (#4095). It is the documented place to register
- * action handlers, and `examples/app-todo` and `examples/app-showcase` both
- * ship it.
+ * `onEnable` is a function. It cannot survive `dist/objectstack.json` (JSON
+ * has no functions), yet it is not lost: `AppPlugin` reads it off the authored
+ * bundle and calls it at `start()`, and on the artifact-boot path the CLI
+ * grafts it back (#4095). It is the documented place to register action
+ * handlers, and `examples/app-todo` and `examples/app-showcase` both ship it.
  *
- * So the lint must stay SILENT here. "Not declared" and "dropped at load" are
- * different claims, and this is the one surface where they come apart — telling
- * an author their working `onEnable` is being discarded would be a confident
- * lie about the pattern we ship in our own examples.
+ * HISTORY: until #8687 the stack schema deliberately did NOT declare
+ * `onEnable`, and this list existed to keep the top-level lint from calling a
+ * working handler registration "dropped at load" — "not declared" and
+ * "dropped at load" are different claims, and this was the one surface where
+ * they came apart. #8687 closed `ObjectStackDefinitionSchema` against unknown
+ * keys, which forced the honest resolution: both members are now DECLARED
+ * (`declared = honoured`), the strict parse accepts them, and the lint goes
+ * quiet on the whole strict surface by its own posture rule. The list stays
+ * because the CLI's graft derives from it (see below); each member also
+ * self-excludes from the lint the way `functions` always did.
  *
- * `functions` is listed for the same reason (a name → handler map the runtime
- * resolves string-named hooks against); the schema happens to declare it too,
- * so it self-excludes. `onDisable` is deliberately ABSENT: no kernel, runtime
- * or service ever called it (the protocol declared it until #4212 retired the
- * whole uninvoked lifecycle family), so a value written there really does go
- * nowhere and the lint should say so.
+ * `onDisable` is deliberately ABSENT: no kernel, runtime or service ever
+ * called it (the protocol declared it until #4212 retired the whole uninvoked
+ * lifecycle family), so a value written there really does go nowhere — the
+ * strict parse now refuses it with that prescription.
  *
  * Single source of truth — the CLI's `GRAFTABLE_RUNTIME_MEMBERS` is derived
  * from this, so the list that decides what gets grafted and the list that

--- a/packages/spec/src/integration/connector.test.ts
+++ b/packages/spec/src/integration/connector.test.ts
@@ -807,8 +807,12 @@ describe('[#4911] `./integration` no longer publishes an outbound rate-limit sha
     // is only worth anything if it fires through `stack.connectors[]`, which is
     // the surface an author actually writes (`DeclarativeConnectorEntrySchema`
     // is `ConnectorSchema.superRefine(…)`, so it inherits the tombstone).
+    // No top-level `name` here: it was never a declared stack key — the strip-
+    // mode schema used to swallow it, and the #8687 strict close refuses it,
+    // which would have made the positive control below fail for the wrong
+    // reason. The stack's identity lives in `manifest`, which this probe does
+    // not need.
     const rejected = ObjectStackSchema.safeParse({
-      name: 'acme',
       connectors: [{ ...connector, rateLimitConfig: { maxRequests: 1 } }],
     });
     expect(rejected.success).toBe(false);
@@ -816,7 +820,7 @@ describe('[#4911] `./integration` no longer publishes an outbound rate-limit sha
 
     // Positive control: the identical stack minus the retired key parses, so the
     // failure above is attributable to `rateLimitConfig` and nothing else.
-    expect(ObjectStackSchema.safeParse({ name: 'acme', connectors: [connector] }).success)
+    expect(ObjectStackSchema.safeParse({ connectors: [connector] }).success)
       .toBe(true);
   });
 

--- a/packages/spec/src/kernel/metadata-authoring-lint.test.ts
+++ b/packages/spec/src/kernel/metadata-authoring-lint.test.ts
@@ -366,57 +366,55 @@ describe('nested descent (#4001 evidence phase)', () => {
   });
 });
 
-describe('top-level stack keys (#4167)', () => {
+describe('top-level stack keys (#4167 → #8687)', () => {
   const lint = (raw: unknown) => lintUnknownStackKeys(raw, ObjectStackDefinitionSchema);
 
-  it('covers ground the collection walker cannot reach', () => {
-    // The complementarity proof, and the reason this is a second pass rather
-    // than a tidier fold into the walker: the walker iterates COLLECTIONS, so a
-    // stack whose only mistake is at the envelope level — no objects, no pages,
-    // nothing to iterate — walks clean and reports nothing.
-    const raw = { storage: { adapter: 's3', s3: { bucket: 'app-files' } } };
-    expect(lintUnknownAuthoringKeys(raw)).toEqual([]);
-    expect(lint(raw)).toHaveLength(1);
-  });
+  // GRADUATION (#8687): `ObjectStackDefinitionSchema` is now `.strict()`, so
+  // against the REAL schema this lint is deliberately silent — the parse
+  // rejects loudly on its own, with the same did-you-mean/guidance riding the
+  // refusal message (`stack-top-level-strict.test.ts` pins that side). What
+  // this suite used to pin against the real schema — the `storage` guidance,
+  // the `datasource` → `datasources` edit-distance fallback, the `onDisable`
+  // report — moved to the refusal path; what remains HERE is the posture
+  // agreement (silence on strict) and the strip-mode behaviour against
+  // injected schemas, which is still the lint's living surface for any future
+  // strip-mode envelope.
 
-  it('reports the worked example with its guidance and no suggestion', () => {
-    // `storage` is 5 edits from `sharingRules`; "did you mean sharingRules?"
-    // would be confident nonsense pointed at a real key. A `why` must win.
-    const [finding, ...rest] = lint({ storage: { adapter: 's3' } });
-    expect(rest).toEqual([]);
-    expect(finding).toMatchObject({ path: 'stack.storage', surface: 'stack', key: 'storage' });
-    expect(finding.suggestion).toBeUndefined();
-    // The prescription has to name where the setting DOES live, or the author
-    // learns only that they were wrong — the #4167 complaint in miniature.
-    expect(finding.guidance).toContain('OS_STORAGE_');
-  });
-
-  it('falls back to edit distance for a near-miss on a declared key', () => {
-    const [finding] = lint({ datasource: [{ name: 'db' }] });
-    expect(finding).toMatchObject({ path: 'stack.datasource', suggestion: 'datasources' });
+  it('goes quiet against the now-strict stack schema — one voice, not two', () => {
+    for (const raw of [
+      { storage: { adapter: 's3', s3: { bucket: 'app-files' } } },
+      { datasource: [{ name: 'db' }] },
+      { onDisable: () => {} },
+      { objectz: [] },
+    ]) {
+      expect(lint(raw)).toEqual([]);
+    }
   });
 
   it('is silent on a clean stack, and on the packaging channel', () => {
     expect(lint({ objects: [], pages: [], manifest: { name: 'app' }, _packageId: 'p' })).toEqual([]);
   });
 
-  it('stays silent on the runtime members the schema cannot declare', () => {
-    // The regression that shipped in review: `onEnable` is a function, so the
-    // schema does not declare it — but `AppPlugin` calls it off the authored
-    // bundle, and `examples/app-todo` and `examples/app-showcase` both ship it.
-    // The first version of this lint told both of them their working handler
-    // registration was "dropped at load".
+  it('stays silent on the runtime members (now declared by the schema)', () => {
+    // `onEnable` was undeclared-but-honoured until #8687 declared it as part
+    // of the strict close; `functions` was always declared. Either way the
+    // lint must never call a working handler registration "dropped at load".
     expect(lint({ onEnable: () => {}, functions: { doThing: () => {} } })).toEqual([]);
   });
 
-  it('still reports `onDisable`, which really does go nowhere', () => {
-    // The distinction the exclusion list has to preserve: no kernel, runtime
-    // or service ever called `onDisable` (the protocol declared it until
-    // #4212 retired the uninvoked lifecycle family), so a value written there
-    // IS lost and the author should hear about it.
-    const [finding, ...rest] = lint({ onDisable: () => {} });
+  it('still reports strip-mode findings against an injected strip schema', () => {
+    // The lint's own machinery — guidance table, edit-distance fallback, the
+    // underscore channel — is unchanged; only the real stack schema's posture
+    // graduated. Pin the machinery against a synthetic strip-mode envelope so
+    // it cannot rot silently while the real surface is strict.
+    const declared = z.object({ datasources: z.array(z.unknown()).optional() });
+    const [finding, ...rest] = lintUnknownStackKeys({ datasource: [] }, declared);
     expect(rest).toEqual([]);
-    expect(finding).toMatchObject({ path: 'stack.onDisable', key: 'onDisable' });
+    expect(finding).toMatchObject({ path: 'stack.datasource', suggestion: 'datasources' });
+    const [storageFinding] = lintUnknownStackKeys({ storage: {} }, declared);
+    expect(storageFinding).toMatchObject({ path: 'stack.storage', key: 'storage' });
+    expect(storageFinding!.suggestion).toBeUndefined();
+    expect(storageFinding!.guidance).toContain('OS_STORAGE_');
   });
 
   it('agrees with the injected schema posture instead of asserting its own', () => {
@@ -450,14 +448,19 @@ describe('STACK_KEY_GUIDANCE does not rot', () => {
     }
   });
 
-  it('no runtime member is silently excluded for a key the schema declares', () => {
-    // `functions` legitimately appears in both lists. But if a member ever
-    // exists ONLY here while the schema also declares it and the runtime has
-    // stopped reading it, the exclusion is dead weight hiding a real finding.
-    // Pin the one that carries the exclusion's whole weight instead of trusting
-    // the list's shape: `onEnable` must be excluded AND undeclared.
+  it('every runtime member is a key the schema now declares (#8687)', () => {
+    // Until #8687 this pin ran the other way: `onEnable` had to be excluded
+    // AND undeclared, because the exclusion list was what kept the lint from
+    // calling an honoured-but-undeclared member "dropped at load". The strict
+    // close resolved that split honestly — a strict schema cannot leave an
+    // honoured member undeclared without refusing it, so BOTH members are now
+    // declared (`declared = honoured`) and each self-excludes the way
+    // `functions` always did. The list itself must stay: the CLI's graft
+    // (`GRAFTABLE_RUNTIME_MEMBERS`) derives from it.
     expect(STACK_RUNTIME_MEMBERS).toContain('onEnable');
-    expect(declared, 'onEnable became a declared key — the exclusion is now dead').not.toContain('onEnable');
+    for (const member of STACK_RUNTIME_MEMBERS) {
+      expect(declared, `runtime member '${member}' must be declared by the strict schema`).toContain(member);
+    }
     expect(STACK_RUNTIME_MEMBERS, 'onDisable is honoured nowhere; excluding it would hide a real drop')
       .not.toContain('onDisable');
   });

--- a/packages/spec/src/migrations/entries/semantic/18.stack-top-level-unknown-keys-refused.ts
+++ b/packages/spec/src/migrations/entries/semantic/18.stack-top-level-unknown-keys-refused.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { SemanticMigration } from '../../types.js';
+
+export const entry: SemanticMigration = {
+  id: 'stack-top-level-unknown-keys-refused',
+  surface: 'top-level stack definition keys (`ObjectStackDefinitionSchema`) — undeclared keys',
+  replacement: 'the declared top-level surface. A key the schema does not declare is refused at '
+    + 'parse with a prescriptive message naming the key, suggesting the closest declared key on '
+    + 'a near miss (`objectz` → `objects`, `flow` → `flows`), and carrying a curated '
+    + 'prescription for the known retirements (`approvals`/`approvalProcesses` → Approval-node '
+    + 'flows per ADR-0019; `workflows` → `state_machine` validation rules per ADR-0020; '
+    + '`portals` removed in #3464; `storage` is deployment config, OS_STORAGE_*; `onDisable` '
+    + 'was never invoked, #4212). `onEnable` is now DECLARED rather than silently stripped — '
+    + 'the runtime has always executed it off the authored bundle (#4095)',
+  reason:
+    'The outermost authoring door was the last strip-mode surface of the #4001 campaign: an '
+    + 'unknown top-level stack key parsed green and its value was silently dropped. Measured on '
+    + '17.0.0 GA (#8687): three injected bogus top-level keys added ZERO warnings to '
+    + '`os validate` and exited 0 — even `--strict` could not catch them, because the '
+    + '`defineStack:` naming diagnostic printed at load, outside the warning tally. The failure '
+    + 'population is a typo or stale key (`flow` for `flows`, `approvalProcesses` after the 7.4 '
+    + 'removal) shipping an artifact with a whole metadata family absent at runtime, debugged '
+    + 'from the far end — the root of hotcrm#1141. Unknown top-level keys are now refused at '
+    + 'parse time, which fails `validate` (and every other path through this one parse) '
+    + 'outright; the near-miss guidance that used to arrive as a load-time warning now rides '
+    + 'the refusal itself.',
+  acceptanceCriteria:
+    'A stack authoring only declared top-level keys parses byte-identically to before, '
+    + '`onEnable`/`functions` included. Any undeclared top-level key fails the parse with '
+    + '`unrecognized_keys` naming the key; a one-edit near miss carries a rename suggestion; '
+    + 'the curated retirements answer with their prescriptions. `os validate` exits non-zero '
+    + 'on a stack carrying any undeclared top-level key, with or without `--strict`.',
+};

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -5656,6 +5656,36 @@ const step18: MigrationStep = {
         + 'not collapse.',
     },
     {
+      id: 'stack-top-level-unknown-keys-refused',
+      surface: 'top-level stack definition keys (`ObjectStackDefinitionSchema`) — undeclared keys',
+      replacement: 'the declared top-level surface. A key the schema does not declare is refused at '
+        + 'parse with a prescriptive message naming the key, suggesting the closest declared key on '
+        + 'a near miss (`objectz` → `objects`, `flow` → `flows`), and carrying a curated '
+        + 'prescription for the known retirements (`approvals`/`approvalProcesses` → Approval-node '
+        + 'flows per ADR-0019; `workflows` → `state_machine` validation rules per ADR-0020; '
+        + '`portals` removed in #3464; `storage` is deployment config, OS_STORAGE_*; `onDisable` '
+        + 'was never invoked, #4212). `onEnable` is now DECLARED rather than silently stripped — '
+        + 'the runtime has always executed it off the authored bundle (#4095)',
+      reason:
+        'The outermost authoring door was the last strip-mode surface of the #4001 campaign: an '
+        + 'unknown top-level stack key parsed green and its value was silently dropped. Measured on '
+        + '17.0.0 GA (#8687): three injected bogus top-level keys added ZERO warnings to '
+        + '`os validate` and exited 0 — even `--strict` could not catch them, because the '
+        + '`defineStack:` naming diagnostic printed at load, outside the warning tally. The failure '
+        + 'population is a typo or stale key (`flow` for `flows`, `approvalProcesses` after the 7.4 '
+        + 'removal) shipping an artifact with a whole metadata family absent at runtime, debugged '
+        + 'from the far end — the root of hotcrm#1141. Unknown top-level keys are now refused at '
+        + 'parse time, which fails `validate` (and every other path through this one parse) '
+        + 'outright; the near-miss guidance that used to arrive as a load-time warning now rides '
+        + 'the refusal itself.',
+      acceptanceCriteria:
+        'A stack authoring only declared top-level keys parses byte-identically to before, '
+        + '`onEnable`/`functions` included. Any undeclared top-level key fails the parse with '
+        + '`unrecognized_keys` naming the key; a one-edit near miss carries a rename suggestion; '
+        + 'the curated retirements answer with their prescriptions. `os validate` exits non-zero '
+        + 'on a stack carrying any undeclared top-level key, with or without `--strict`.',
+    },
+    {
       id: 'ui-record-blocks-unknown-keys-refused',
       surface: 'page `record:alert` / `record:quick_actions` / `record:history` / '
         + '`record:discussion` components — `properties` (undeclared keys, notably a typo\'d '

--- a/packages/spec/src/stack-top-level-strict.test.ts
+++ b/packages/spec/src/stack-top-level-strict.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8687 — the TOP-LEVEL stack door refuses unknown keys (maintainer-ruled
+ * Shape B, 2026-08-16).
+ *
+ * Before this close, `ObjectStackDefinitionSchema` was the last strip-mode
+ * surface of the #4001 campaign: an unknown top-level key parsed green and its
+ * value was silently dropped. The card's own measurement on 17.0.0 GA: three
+ * injected bogus top-level keys added ZERO warnings to `os validate` and
+ * exited 0 — even `--strict` could not catch them, because the `defineStack:`
+ * diagnostic printed at load, outside the warning tally. This file pins the
+ * inversion of exactly that measurement, plus the accept side that must not
+ * move.
+ *
+ * ## Rejection-pin convention (the standing minimum)
+ *
+ * Each rejection asserts the Zod issue's **`code` and `path`** (and the
+ * offending key via `keys`/message). `status` is the publish door's uniform
+ * wrap — the ADR-0112 envelope is applied where a parse failure crosses the
+ * HTTP boundary, not minted per-schema — so at this layer it is stated as the
+ * family convention rather than asserted.
+ *
+ * ## `validate --strict` subsumption (Shape B subsumes Shape A)
+ *
+ * A strict parse failure fails `os validate` outright (`safeParse` failure →
+ * exit 1, with or without `--strict`), so no warning-accounting change is
+ * needed. The CLI-level exit-code pin lives in
+ * `packages/cli/test/validate-top-level-strict.e2e.test.ts`; this file pins
+ * the schema layer those commands share.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ObjectStackDefinitionSchema, defineStack } from './stack.zod';
+import { lintUnknownStackKeys } from './kernel/metadata-authoring-lint';
+
+/** A legal, representative stack touching several collections. */
+const legalStack = () => ({
+  manifest: { id: 'com.example.probe', name: 'probe', version: '1.0.0', type: 'app' as const, namespace: 'probe' },
+  objects: [{ name: 'probe_task', label: 'Task', fields: { title: { type: 'text', label: 'Title' } } }],
+  views: [],
+  apps: [],
+  flows: [],
+  requires: ['automation'],
+});
+
+const parseTopLevel = (raw: Record<string, unknown>) => ObjectStackDefinitionSchema.safeParse(raw);
+
+describe('#8687 — unknown top-level stack keys are refused at parse', () => {
+  it("inverts the card's measured control: the three bogus keys now FAIL parse instead of adding zero warnings", () => {
+    // Measured on 17.0.0 GA: each of these parsed `success: true` with the key
+    // silently dropped, and injecting all three into a real app config added
+    // ZERO warnings (88 → 88, identical sets) with exit 0 even under --strict.
+    for (const key of ['flow', 'approvalProcesses', 'totallyBogusTopLevelKey']) {
+      const result = parseTopLevel({ ...legalStack(), [key]: [] });
+      expect(result.success, `'${key}' must now refuse at parse`).toBe(false);
+      if (result.success) continue;
+      const issue = result.error.issues.find((i) => i.code === 'unrecognized_keys');
+      expect(issue, `'${key}' must raise unrecognized_keys`).toBeDefined();
+      expect(issue!.code).toBe('unrecognized_keys');
+      // The refusal is raised at the object root — the envelope level itself.
+      expect(issue!.path).toEqual([]);
+      expect((issue as unknown as { keys: string[] }).keys).toContain(key);
+      expect(issue!.message).toContain(`\`${key}\``);
+    }
+  });
+
+  it('positive control: the same stack without the stray key parses green', () => {
+    expect(parseTopLevel(legalStack()).success).toBe(true);
+  });
+
+  it("carries the near-miss guidance through the refusal: `objectz` → did you mean `objects`", () => {
+    // The resolver used to speak through `lintUnknownStackKeys` as a load-time
+    // warning; after the strict close the lint goes quiet (posture rule) and
+    // the SAME did-you-mean rides the refusal message itself.
+    const result = parseTopLevel({ objectz: [] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.code === 'unrecognized_keys')!;
+    expect(issue.message).toContain('Did you mean `objectz` → `objects`?');
+  });
+
+  it('suggests the plural for a one-character singular miss (`flow` → `flows`)', () => {
+    const result = parseTopLevel({ flow: [] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.code === 'unrecognized_keys')!;
+    expect(issue.message).toContain('Did you mean `flow` → `flows`?');
+  });
+
+  it('answers the curated retirements with their prescriptions, not a rename', () => {
+    const cases: ReadonlyArray<[key: string, mustContain: string]> = [
+      // The #4167 worked example: where the setting DOES live.
+      ['storage', 'OS_STORAGE_'],
+      // ADR-0019: approvals are Approval-node flows.
+      ['approvals', 'ADR-0019'],
+      ['approvalProcesses', 'ADR-0019'],
+      // ADR-0020: record state machines are a validation rule.
+      ['workflows', 'state_machine'],
+      // #3464: the collection was removed outright.
+      ['portals', '#3464'],
+      // #4212: the uninvoked lifecycle family.
+      ['onDisable', '#4212'],
+    ];
+    for (const [key, mustContain] of cases) {
+      const result = parseTopLevel({ [key]: [] });
+      expect(result.success, `'${key}' must refuse`).toBe(false);
+      if (result.success) continue;
+      const issue = result.error.issues.find((i) => i.code === 'unrecognized_keys')!;
+      expect(issue.message, `'${key}' prescription`).toContain(mustContain);
+      expect(issue.message, `'${key}' must not get a rename suggestion`).not.toContain('Did you mean');
+    }
+  });
+
+  it('names where the legal keys are enumerated', () => {
+    const result = parseTopLevel({ totallyBogusTopLevelKey: 1 });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.code === 'unrecognized_keys')!;
+    expect(issue.message).toContain('ObjectStackDefinitionSchema');
+  });
+});
+
+describe('#8687 — the accept side does not move', () => {
+  it('accepts every declared top-level key', () => {
+    // Structural sweep: a declared key must never be refused as unknown. All
+    // 40+ top-level keys are optional (tombstones included), so presence with
+    // `undefined` isolates exactly the door being tested.
+    const shape = (ObjectStackDefinitionSchema as unknown as { shape: Record<string, unknown> }).shape;
+    const keys = Object.keys(shape);
+    expect(keys.length).toBeGreaterThan(40); // non-vacuity
+    for (const key of keys) {
+      const result = parseTopLevel({ [key]: undefined });
+      expect(result.success, `declared key '${key}' must stay accepted`).toBe(true);
+    }
+  });
+
+  it('keeps the runtime members: `onEnable` and `functions` parse green — and `onEnable` now survives', () => {
+    // `onEnable` was undeclared-but-honoured (STACK_RUNTIME_MEMBERS): the
+    // parse stripped it while AppPlugin executed it off the authored bundle.
+    // A strict close of an undeclared `onEnable` would have refused the
+    // pattern our own examples ship, so #8687 declares it: accepted at parse,
+    // and — new — retained in the parsed output (declared = honoured). JSON
+    // serialization still drops it from artifacts, as ever (#4095 grafts).
+    const onEnable = () => {};
+    const result = parseTopLevel({ ...legalStack(), onEnable, functions: { doThing: () => {} } });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(typeof (result.data as { onEnable?: unknown }).onEnable).toBe('function');
+  });
+
+  it('parses a legal stack without adding or dropping top-level keys', () => {
+    // "Byte-identical" at the level this PR touches: the top-level key set is
+    // preserved exactly. Item-level defaults (`field.required: false`, …) are
+    // the pre-existing ADR-0122 parse behaviour, unchanged here.
+    const fixture = legalStack();
+    const result = parseTopLevel(fixture);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(Object.keys(result.data).sort()).toEqual(Object.keys(fixture).sort());
+    expect(result.data.requires).toEqual(fixture.requires);
+    expect(result.data.objects![0]!.name).toBe('probe_task');
+  });
+});
+
+describe('#8687 — one voice: the lint yields to the strict parse', () => {
+  it('lintUnknownStackKeys goes quiet on the now-strict stack schema (its own posture rule)', () => {
+    // The graduation day the lint's docblock always promised: a strict schema
+    // rejects loudly on its own, so the lint must not become a second,
+    // possibly disagreeing voice. The guidance lives in the refusal now.
+    expect(lintUnknownStackKeys({ storage: {} }, ObjectStackDefinitionSchema)).toEqual([]);
+    expect(lintUnknownStackKeys({ objectz: [] }, ObjectStackDefinitionSchema)).toEqual([]);
+  });
+});
+
+describe('#8687 — defineStack surfaces the refusal', () => {
+  it('throws with the curated message, did-you-mean included', () => {
+    expect(() => defineStack({ objectz: [] } as never)).toThrowError(
+      /Unrecognized key\(s\) on this stack definition: `objectz`\. Did you mean `objectz` → `objects`\?/,
+    );
+  });
+
+  it('still parses the legal stack (control)', () => {
+    expect(() => defineStack(legalStack() as never)).not.toThrow();
+  });
+});

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -10,6 +10,7 @@ import { TranslationBundleSchema, TranslationConfigSchema } from './system/trans
 import { StackServerConfigSchema } from './system/stack-server.zod';
 import { hasPlatformObjectPrefix } from './system/constants/platform-object-names';
 import { objectStackErrorMap, formatZodError } from './shared/error-map.zod';
+import { strictObject } from './shared/strict-object';
 import { deepEqualAuthored } from './shared/deep-equal';
 import { normalizeStackInput, type MetadataCollectionInput, type MapSupportedField } from './shared/metadata-collection.zod';
 import type { ConversionNotice } from './conversions/types.js';
@@ -178,7 +179,57 @@ function applyApiEndpointGates(
  * - AI Agents generate this to create apps.
  * - CI Tools deploy this to the server.
  */
-export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
+/*
+ * #8687 — the TOP-LEVEL door is `strictObject` like every inner authorable
+ * surface the #4001 campaign closed. Before this, an unknown top-level key
+ * parsed green and was silently dropped: a `flow`-for-`flows` typo (or the
+ * stale `approvalProcesses`) shipped an artifact missing that whole metadata
+ * family, with `os validate` — even `--strict` — exiting 0, because the
+ * `defineStack:` diagnostic was printed at load, outside the warning tally.
+ *
+ * The near-miss guidance that used to arrive through `lintUnknownStackKeys`
+ * (`objectz` → "did you mean `objects`?") now arrives through the refusal
+ * itself: `strictObject`'s error map suggests the closest declared key, and
+ * the lint deliberately goes quiet on a strict schema (its own posture rule —
+ * see `kernel/metadata-authoring-lint.ts`), so there is one voice, not two.
+ *
+ * The `guidance` entries are the curated half: retired/never-keys where a
+ * rename suggestion would be wrong. `storage` mirrors `STACK_KEY_GUIDANCE`
+ * (`data/authoring-key-lint.ts`), which stays exported for the generic lint
+ * API but no longer fires for this surface.
+ */
+export const ObjectStackDefinitionSchema = lazySchema(() => strictObject({
+  surface: 'this stack definition',
+  history:
+    'Until #8687 closed this surface (the outermost #4001 door), an unknown top-level stack '
+    + 'key parsed green and its value was silently dropped — a one-character typo could ship '
+    + 'an artifact missing a whole metadata family while `os validate` exited 0. The declared '
+    + 'keys are enumerated by `ObjectStackDefinitionSchema` (@objectstack/spec, stack.zod.ts) '
+    + 'and in the stack-definition reference docs.',
+  guidance: {
+    storage:
+      'the file-storage backend is a deployment concern, not an application declaration. '
+      + 'Configure it with the OS_STORAGE_* environment variables, or per-deployment in Setup → '
+      + 'Settings → Storage (which also holds credentials — a stack definition would commit them '
+      + 'to git and to any published artifact).',
+    approvals:
+      'approvals are not a top-level collection (ADR-0019): author an approval as a flow with '
+      + 'one or more Approval nodes, in `flows`.',
+    approvalProcesses:
+      'approvals are not a top-level collection (ADR-0019, standalone `approvals` removed in '
+      + '7.4): author an approval as a flow with one or more Approval nodes, in `flows`.',
+    workflows:
+      'there is no top-level `workflows` collection (ADR-0020): a record state machine is a '
+      + '`state_machine` validation rule on the object it governs.',
+    portals:
+      'the top-level `portals` collection was removed (#3464) — nothing ever consumed it. '
+      + 'Author external-user UI with `apps`/`views` plus positions and permission sets.',
+    onDisable:
+      'no kernel, runtime or service ever called `onDisable` (#4212 retired the uninvoked '
+      + 'lifecycle family), so a value written here goes nowhere. Do teardown inside the '
+      + 'resources `onEnable` acquires.',
+  },
+}, {
   /** System Configuration */
   manifest: ManifestSchema.optional().describe('Project Package Configuration'),
   datasources: z.array(DatasourceSchema).optional().describe('External Data Connections'),
@@ -507,6 +558,27 @@ export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
       effect: FlowFunctionEffectSchema.optional(),
     })),
   ]).optional().describe('Named handler functions referenced by hooks/actions/script nodes (optionally declaring their effect)'),
+
+  /**
+   * App lifecycle hook the runtime EXECUTES off the authored bundle:
+   * `AppPlugin` invokes it at `start()` with the host context (`ctx.ql`) —
+   * the documented place to register action handlers and drivers
+   * (`examples/app-todo` and `examples/app-showcase` both ship one).
+   *
+   * DECLARED since #8687 closed this schema against unknown keys. Before
+   * that, `onEnable` was deliberately undeclared — the parse stripped it and
+   * the runtime read it off the authored object — and the top-level lint
+   * stayed quiet about it via `STACK_RUNTIME_MEMBERS` ("not declared" and
+   * "dropped at load" are different claims). A strict close of an undeclared
+   * `onEnable` would have refused the pattern our own examples ship, so the
+   * key is now declared: `declared = honoured`, in both directions.
+   *
+   * A function still cannot survive `dist/objectstack.json` — on the
+   * artifact-boot path the CLI grafts it back from the authored module
+   * (#4095, `GRAFTABLE_RUNTIME_MEMBERS`, derived from
+   * `STACK_RUNTIME_MEMBERS`).
+   */
+  onEnable: z.function().optional().describe('App lifecycle hook invoked by AppPlugin at start() with the host context (ctx.ql) — register action handlers and drivers here. Executed off the authored bundle; never serialized into the JSON artifact (#4095 grafts it back on artifact boot).'),
   mappings: z.array(MappingSchema).optional().describe('Data Import/Export Mappings'),
   analyticsCubes: z.array(CubeSchema).optional().describe('Analytics Semantic Layer Cubes'),
 
@@ -1744,6 +1816,14 @@ const COMPOSE_KEY_DISPOSITIONS: Record<keyof ObjectStackDefinition, ComposeDispo
   api: 'single',
   server: 'single',
   runtimeModule: 'single',
+  // #8687: declared alongside the strict close (it was undeclared-but-honoured
+  // before, so composition never saw it through a parsed stack). One bundle
+  // gets one `onEnable` (`AppPlugin` invokes a single hook at start()); two
+  // stacks shipping DIFFERENT hooks cannot be merged without inventing an
+  // execution order neither author wrote — refuse and name them, like
+  // `api`/`server`. Multi-app hosts keep per-app hooks by composing PLUGINS
+  // (each AppPlugin carries its own bundle), not by folding stacks into one.
+  onEnable: 'single',
   // #5051: the last key still on last-wins; aligned here, see the note above.
   i18n: 'single',
 };

--- a/scripts/check-stack-collection-maps.mjs
+++ b/scripts/check-stack-collection-maps.mjs
@@ -263,12 +263,19 @@ export function stringArrayItems(body) {
  * arrays but not metadata collections, and no site is expected to carry them.
  */
 export function stackCollections(stackSource) {
-  const sliced = sliceBody(
+  // #8687 closed the top level with the shared `strictObject` template
+  // (`shared/strict-object.ts`): the FIRST argument is the authoring-surface
+  // options object (surface / history / guidance) and the SECOND is the shape
+  // this gate reads. Slice the options body to find where it ends, then slice
+  // the shape body that opens right after it.
+  const options = sliceBody(
     stackSource,
-    'export const ObjectStackDefinitionSchema = lazySchema(() => z.object({',
+    'export const ObjectStackDefinitionSchema = lazySchema(() => strictObject({',
   );
-  if (!sliced) return null;
-  return objectEntries(sliced.body)
+  if (!options) return null;
+  const shape = sliceBody(stackSource, '{', options.end + 1);
+  if (!shape) return null;
+  return objectEntries(shape.body)
     .filter(({ value }) => /^z\.array\(\s*[A-Za-z_$][\w$]*Schema\s*\)/.test(value))
     .map(({ key }) => key);
 }
@@ -732,7 +739,11 @@ function selfTest() {
   };
 
   const stack = `
-export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
+export const ObjectStackDefinitionSchema = lazySchema(() => strictObject({
+  surface: 'this stack definition',
+  history: 'a history sentence with brackets { } that the options slice must survive',
+  guidance: { storage: 'a prescription' },
+}, {
   manifest: ManifestSchema.optional(),
   objects: z.array(ObjectSchema).optional().describe('Business Objects'),
   // a commented-out collection must NOT count:
@@ -742,10 +753,15 @@ export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
   devPlugins: z.array(z.union([ManifestSchema, z.string()])).optional(),
   api: z.object({ nested: z.array(NestedSchema) }).optional(),
   data: z.array(SeedSchema).optional(),
-}));
+}).superRefine(gates));
 `;
   eq('stackCollections() takes z.array(<X>Schema) only', stackCollections(stack), ['objects', 'data']);
   eq('stackCollections() returns null when the anchor is gone', stackCollections('export const Other = 1;'), null);
+  eq(
+    'stackCollections() returns null when the shape argument is missing',
+    stackCollections('export const ObjectStackDefinitionSchema = lazySchema(() => strictObject({ surface: \'x\' }));'),
+    null,
+  );
 
   eq(
     'stringArrayItems() ignores nested literals and comments',
@@ -804,7 +820,7 @@ export const ObjectStackDefinitionSchema = lazySchema(() => z.object({
     for (const f of failures) console.error(`  • ${f}\n`);
     return 1;
   }
-  console.log('✓ check-stack-collection-maps --self-test: 11 assertions over synthetic sources');
+  console.log('✓ check-stack-collection-maps --self-test: 12 assertions over synthetic sources');
   return 0;
 }
 


### PR DESCRIPTION
Fixes #8687

Maintainer-ruled Shape B (2026-08-16, recorded 13:03Z on the card): top-level `.strict()` on `ObjectStackDefinitionSchema`, keeping the already-written near-miss resolver. B subsumes Shape A — a strict parse failure fails `os validate` outright, so no warning-accounting change is made. This also closes the root cause behind objectstack-ai/hotcrm#1141 (plain reference — that card is in a different repo and is not closed by this PR).

## What changed

**`packages/spec/src/stack.zod.ts`** — the top-level stack door is now the shared `strictObject` template (the #4001 campaign idiom, same as `IndexSchema`'s #9045 close), `.superRefine(applyApiEndpointGates)` retained:

- An unknown top-level key REFUSES at parse (`unrecognized_keys`, path `[]`), naming the surface and the key. The card's own measured control inverts: `flow`, `approvalProcesses` and a stray key now fail parse instead of adding zero warnings with exit 0.
- **Near-miss resolver survives, relocated into the refusal**: `strictObject`'s edit-distance suggester answers `objectz` with ``Did you mean `objectz` → `objects`?`` (and `flow` → `flows`). `lintUnknownStackKeys` goes quiet on the strict surface by its own posture rule — one voice, not two; the generic lint machinery is unchanged and re-pinned against a synthetic strip-mode schema.
- **Curated prescriptions** (no rename suggestion, per the campaign's finding-7 discipline): `storage` (deployment config, `OS_STORAGE_*` / Setup → Settings → Storage), `approvals`/`approvalProcesses` (Approval-node flows, ADR-0019), `workflows` (`state_machine` validation rules, ADR-0020), `portals` (removed, #3464), `onDisable` (never invoked, #4212). The `history` sentence names where the legal keys are enumerated.
- **`onEnable` is now DECLARED** (`z.function().optional()`). It was undeclared-but-honoured (`STACK_RUNTIME_MEMBERS`): the parse stripped it while `AppPlugin` executed it off the authored bundle — a strict close of an undeclared `onEnable` would have refused the pattern `examples/app-todo` and `app-showcase` ship. Declared = honoured, in both directions; #4095 artifact-boot grafting is unchanged (`GRAFTABLE_RUNTIME_MEMBERS` still derives from `STACK_RUNTIME_MEMBERS`). `composeStacks` gives it a `'single'` disposition: same value passes, disagreement refuses naming both stacks.

**Contract plumbing (campaign shipping shape):**

- Protocol-18 semantic entry `packages/spec/src/migrations/entries/semantic/18.stack-top-level-unknown-keys-refused.ts`; `registry.ts` regenerated via `gen:migration-registry` (never hand-edited).
- Changeset: `@objectstack/spec` **minor with BREAKING annotation**, FROM → TO guidance, `adr-0087: registered stack-top-level-unknown-keys-refused` marker — matching the #9045-family changesets.
- `scripts/check-stack-collection-maps.mjs`: re-anchored on the new declaration shape (the gate failed loudly by design when the `z.object` anchor vanished; its own error text prescribes fixing the anchor). Self-test updated to the new shape + a missing-shape-argument case (11 → 12 assertions).

## Tests

- `packages/spec/src/stack-top-level-strict.test.ts` (new): rejection pins assert issue `code` + `path` + `keys` (`status` is the publish door's uniform ADR-0112 wrap — stated in the docblock as the family convention, since this layer is pre-HTTP); near-miss pin; curated-prescription pins; accept-side pins (all 44 declared keys still accepted; representative stack keeps its top-level key set exactly — item-level defaults are pre-existing ADR-0122 behaviour); `onEnable` accepted AND retained in parsed output; lint-quiescence pin; `defineStack` throw-path pin.
- `packages/cli/test/validate-top-level-strict.e2e.test.ts` (new): real-CLI exit-status pin (`bin/run-dev.js` + tsx, the `migrate-exit-code` pattern) — a stack with `flow:` exits non-zero **without `--strict`**, naming the key and the near-miss; the identical stack spelled `flows:` exits 0.
- `metadata-authoring-lint.test.ts`: the stack section graduated — real-schema tests now pin silence (the refusal side moved to the new file); the lint's own machinery re-pinned against injected strip schemas; the runtime-member rot pin now asserts every `STACK_RUNTIME_MEMBERS` member is declared.

## Fixture/consumer sweep

Consumers swept (downstream of `@objectstack/spec`, `pnpm --filter '&lt;pkg&gt;...'` closure built first): **spec, objectql, metadata, metadata-protocol, lint, runtime, cli** test suites + **examples build** (app-todo / app-crm / app-showcase / embed-objectql). **13 repo-internal fixtures fixed** — every one carried authoring that was never spec-valid and had been silently stripped:

- `packages/metadata` (3): artifacts with manifest fields flattened at top level (incl. `scope: 'app'`, not even a manifest scope) → nested under `manifest:`.
- `packages/cli` (7): five schema-migrate/stored-flow integration artifacts + `migrate-meta.e2e` pre-17 config (top-level `name`/`label`) + `emit-json-pipe` (stray top-level `name` would have added a 901st error to an exact-count assertion).
- `packages/lint` (2): `...MANIFEST` spread flat into the stack → `manifest: MANIFEST`; the org-axis test that PINNED the strip behaviour rewritten to pin the refusal.
- `packages/spec` (1): connector reachability probe carried a stray top-level `name`.

`composeStacks`' #5005 completeness pin forced the `onEnable` disposition (the type-level half of that gate working as designed).

## Verification (union run at final head `9b89f58da`)

- Suites: spec **407 files / 10827 tests** green; cli **123 / 1360**; lint 73 files; metadata-protocol 115; objectql 213; runtime 165; metadata 31 — all green. Examples build green (64 turbo tasks).
- Typecheck: spec (src + scripts + test-layer), cli, lint green. `@objectstack/metadata` declares no `typecheck` script (ledgered) — verified as a zero-match rather than read as green; its edits are test-only and runtime-verified.
- Gate union (re-derived from actual changed paths via `dispatch-gates.mjs`, run at `9b89f58da`): changeset-gate-self-tests, cross-package-test-inputs, doc-formula-expressions, durability-log-level, merge-driver, objectui-changeset, spec-parsed-alias, **stack-collection-maps**, type-source-resolution, adr-0087-registration, changeset-no-major, empty-changeset, dev-prereqs, query-options-erasure, engine-double-contract, where-matcher, nul-bytes, type-check-coverage, **type-check-debt (--re-measure, full built closure)**, migration-registry, check:generated, **check:authorable-surface**, strictness-ledger — all green.
- **Reverse verification** (fix committed first; ablation = `git checkout` of the pre-change `stack.zod.ts`, spec tests run on source so no dist rebuild involved): exactly the new pins went red — 10 tests (all rejection/near-miss/curated/onEnable-survival/lint-quiescence pins) — while the 30 accept-side controls stayed green; restore is byte-identical to the commit and the two files are 40/40 green again.

## Behaviour notes for review

- `defineStack(config, { strict: false })` skips the parse entirely (unchanged); such a stack now gets NO top-level unknown-key warning (the lint yields to a strict schema it cannot know was bypassed). The key is no longer dropped on that path either (no parse ⇒ no strip) — the warning it loses was always slightly wrong there ("dropped at load" while nothing dropped). Called out rather than hidden.
- Stored artifacts from the drift window that carry a stray top-level key now fail artifact ingestion loudly (`_parseAndRegisterArtifact`) — the population the ruling accepts as "breaking exactly for those already silently broken".

_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01225pUjnCKWqxcc1PeqKFUq)_