### PR TITLE
docs(cli): migrateStoredMetadata declines four things, not three

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -855,11 +855,12 @@ mutation projectors, exactly like an author's save. The history entry's source
 is `migrate-stored`, so a later diff shows which changes were an upgrade and
 which were somebody's edit.
 
-Three things it deliberately declines, and names in the report rather than
+What it deliberately declines, and names in the report rather than
 counting as done:
 
 | Not rewritten | Why |
 | :--- | :--- |
+| A row stored under a non-canonical metadata type (a plural or alias spelling, e.g. `fields`) | Canonicalizing bodies is an edit; rewriting a stored *type* spelling is an identity move — a new `(org, type, name, package_id)` key — which this pass is not ruled to make. Re-author the item under its canonical type and drop the old row |
 | Types with no repository write path (`agent`) | Their write path records no history and would force a draft live — a half-write is worse than leaving the row to the read path |
 | Rows that still fail the current schema after conversion | That is a genuine contract violation, not chain-owned history. The write path's rejection is correct; fix the row in Studio |
 | A flow whose rename the conflict guard refused | The old node-type token is a live name something else owns here. Rewriting would clobber that owner, so the row fails loudly naming the token — never a silent skip |


### PR DESCRIPTION
Fixes #9175

## What was wrong

`content/docs/deployment/cli.mdx` said `migrateStoredMetadata` deliberately
declines "Three things" and tabled three. #8957 (PR #9059, `b740440bd`) added
a fourth decline path this shift and the docs face was never carried.

## How I enumerated the declines (verified against code, not the card)

Read `migrateStoredMetadata` end to end on `origin/main`
(`packages/metadata-protocol/src/protocol.ts`, anchored on the symbol — not a
line number, which drifts) and listed every `record({ outcome: 'skipped' |
'failed', ... })` call site rather than trusting the issue's count. There are
seven such sites in the function body. Three of them are call-site-specific
variants of "no reachable automation engine for a flow" and "invalid JSON /
flow schema hard-fail at conversion time" that the page's own surrounding
prose already excludes or folds elsewhere (the "Flows are covered, and cost
one extra plugin" paragraph explains why the CLI never actually surfaces the
missing-engine skip — the CLI always supplies one). The remaining four are
exactly the ones the table is about — real, CLI-observable, distinct refusal
classes:

1. **(new)** a row stored under a non-canonical metadata type — `outcome:
   'skipped'`, added by #8957/PR #9059. This is the one the card names.
2. types with no repository write path (`agent`) — `outcome: 'skipped'`
3. rows that still fail the current schema after conversion — `outcome:
   'failed'` on the post-conversion `saveMetaItem` rejection
4. a flow whose rename the conflict guard refused — `outcome: 'failed'`

This also matches the function's own `## What it declines to touch, and says
so` JSDoc header (which independently documents 3 of these — though that
comment enumerates a slightly different triple, since it talks about the
"no reachable engine" flow skip rather than the "conflict guard refused" one;
that pre-existing JSDoc/docs-page framing difference is unrelated to this
card and out of scope here).

## The fix

- Table gets its fourth row for the non-canonical-stored-type decline, with
  the same "identity move, not an edit" reasoning the code's own comment at
  the `isNonCanonicalStoredType` guard gives.
- The lead-in sentence drops the hard-coded count: `"Three things it
  deliberately declines"` → `"What it deliberately declines"`. This costs
  nothing (single-word-scope edit, no prose contortion) and removes exactly
  the kind of declared-vs-enforced pair-with-no-enforcement the issue is
  about — the table itself is now the only place a count lives, so a future
  fifth decline can't leave stale prose beside it. I looked for an existing
  `os:check`-style anchor idiom already in use on this page family (e.g.
  `scripts/check-doc-anchors.mjs`, which is a fragment-link ↔ heading-id
  checker, not a code ↔ prose-count checker) and found none that fits this
  shape, so this is the mirror fix, not a new mechanism — per the triage's
  explicit instruction not to build generation on this card.

## Scope

Docs-only (`content/docs/deployment/cli.mdx`), no `content/docs/releases/`
touched, no other pages swept (per the card: this page only; other counted
prose elsewhere is reported, not fixed, if noticed — none was).

## Tests

- `pnpm check:cross-package-test-inputs` — pass (33/33 self-test cases, 12
  packages declared)
- `pnpm check:docs-audit-scope` — pass (178 hand-written docs in scope, 9
  release-owned pages correctly read-only)
- `pnpm check:docs-redirects` — pass (92 entries, 98 chain probes matched)
- `pnpm check:role-word` — pass (43 baselined files, no new occurrences)
- `node scripts/check-doc-anchors.mjs` — pass (240 internal fragment links,
  396 source files, all resolve)
- `node scripts/check-nul-bytes.mjs` — pass
- `packages/spec`: `check:liveness`, `check:empty-state`,
  `check:variant-docs`, `check:strictness-ledger` — all pass (matched via
  `spec-liveness-check.yml`'s `content/docs/**` CI trigger; unaffected by
  this change, run under the shared verify lock)

Gates derived with `node scripts/pm/dispatch-gates.mjs content/docs/deployment/cli.mdx`
(9 of 103 discovered families placed against this path; the rest are either
undetermined-by-path or silent-for-this-path per that script's own
disclaimer).

All at `ab09610db` (`git rev-parse --short HEAD`, quoted after the final
commit).

## skip-changeset

Docs-only change, publishes nothing. `skip-changeset` label applied (this
repo's mechanism — read back after the bot settles, per AGENTS.md).

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_