### PR TITLE
docs(plugin-security): freeze note on assertControlledByParentWrite (#9137)

### DIFF
--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -320,6 +320,12 @@ interface CbpRelation {
    * For every other declarable shape it is `false` and the gate keeps
    * answering, because validation does not cover the same ground there — see
    * the stand-down site for what a bare hand-over would mint.
+   *
+   * ⛔ [#9137] Do not widen this predicate to `true` for `readonly`/`system`, or
+   * to drop the `master_detail`+`required` condition, until #8772's ramp
+   * completes (#9138 builder-force + #9139 lint-at-v18). See the freeze note at
+   * the stand-down site (below, in {@link SecurityPlugin.assertControlledByParentWrite})
+   * for why.
    */
   omissionRefusedByValidation: boolean;
 }
@@ -5190,18 +5196,52 @@ export class SecurityPlugin implements Plugin {
       // every later by-id write through the stored-row leg below. The residual
       // envelope asymmetry is confined to exactly those shapes.
       //
-      // [#8959] ⛔ "Confined" is NOT a publish-time bound, and this comment used
-      // to claim it was. #8772 *proposes* a lint that would refuse these shapes;
-      // it is open and unruled, so nothing refuses them at publish today and any
-      // app can newly author one. Measured against the lint as it stands:
-      // `master_detail` with no `required` draws `severity: 'warning'` from
-      // `relationship/master-detail-required`, and only `error` findings fail a
-      // build; `required` + `readonly` and `required` + `system` draw nothing at
-      // all — no rule in `packages/lint/src/data-model-rules.ts` reads either
-      // flag. A freshly authored detail therefore reaches this branch and its
-      // 422, which makes the residue a live surface rather than a shrinking
-      // legacy tail. Whether that is acceptable is #8772's to rule; this comment
-      // may not presume an answer in either direction.
+      // [#8959, re-measured 2026-08-16] "Confined" is still NOT a publish-time
+      // bound today, though the reason has moved on from #8959's finding. #8772
+      // has since been RULED (2026-08-16, comment 5306089973) — it is no longer
+      // "open and unruled" — but the ramp it ordered has two code legs and
+      // neither has landed yet: Direction 2 (the authoring builder forces
+      // `required: true` under `controlled_by_parent`, #9138) is dispatchable
+      // now but not yet merged; Direction 1 (`relationship/master-detail-required`
+      // promoted `warning` → `error`, scoped to `controlled_by_parent`, #9139) is
+      // deliberately held for the **v18** boundary (`main` is still 17.x as of
+      // this note). So the lint measured by #8959 is unchanged: `master_detail`
+      // with no `required` still draws only `severity: 'warning'`, and
+      // `required` + `readonly` / `required` + `system` still draw nothing at
+      // all (`packages/lint/src/data-model-rules.ts`). A freshly authored detail
+      // therefore still reaches this branch and its `422` — the residue is a
+      // live, newly-authorable surface, not a shrinking legacy tail, until BOTH
+      // #9138 and #9139 land. Re-check this paragraph before trusting it; once
+      // both have landed it is the one that goes stale next.
+      //
+      // ⛔ [#9137] FREEZE NOTE — maintainer ruling on #8772, Direction 4,
+      // "immediately": until the two legs above both land, this `if` is the
+      // SOLE ENFORCEMENT POINT for the same three authorable
+      // `controlled_by_parent` master-reference shapes — `master_detail` with no
+      // `required`; `required: true` + `readonly`; `required: true` + `system`.
+      // They are the last three rows of #8772's five-shape measurement table,
+      // and exactly the three shapes `record-validator.ts` skips before its
+      // required check ever runs (`if (def.system || def.readonly) continue;`,
+      // insert-mode :993 / update-mode :1003) — `record-validator.ts` never
+      // throws on any of them, so nothing downstream of this gate would refuse
+      // the insert either.
+      //
+      // Do NOT move this gate, weaken it, or stand it down further for these
+      // three shapes — concretely: do not widen `omissionRefusedByValidation`
+      // (declared above) to admit any of them, and do not otherwise make this
+      // `if` return for them. This is not a hypothetical to pre-empt: the
+      // absent-master insert route #8688 proposed has ALREADY LANDED, and
+      // landed correctly narrowed to exactly the one shape validation covers —
+      // the `if (operation === 'insert' && rel.omissionRefusedByValidation)
+      // return;` two lines below IS that landing. The freeze is about not
+      // WIDENING an already-conditional stand-down, not about blocking a change
+      // that has not happened. Standing this gate down for any of the three
+      // would mint a detail row whose master FK is null — a row the
+      // `controlled_by_parent` read filter (`fk IN (readable masters)`) can
+      // never match, so unreadable by anyone, and answering `422
+      // MISSING_REQUIRED_FIELD` on every later by-id write forever after, since
+      // no payload the caller could send would restore a field the request
+      // never carried in the first place.
       //
       // Only the INSERT shape hands over. The stored-row shape (a by-id write
       // whose persisted FK is null) keeps its 422: the caller sent no such


### PR DESCRIPTION
Fixes #9137

## What

Adds the load-bearing freeze note the #8772 ruling's Direction 4 calls for
("immediately", ahead of or alongside the first ramp slice) at
`assertControlledByParentWrite`'s absent-master-FK branch in
`packages/plugins/plugin-security/src/security-plugin.ts`. **No behaviour
change** — comment-only.

The note states, in place:

- This `if` (and the `omissionRefusedByValidation` predicate it reads) is the
  **sole enforcement point** for three authorable `controlled_by_parent`
  master-reference shapes: `master_detail` with no `required`; `required:
  true` + `readonly`; `required: true` + `system` — the last three rows of
  #8772's five-shape measurement table, and exactly the three shapes
  `record-validator.ts` skips before its required check ever runs
  (`if (def.system || def.readonly) continue;`, insert-mode `:993` /
  update-mode `:1003`).
- ⛔ Do not move, weaken, or stand this gate down further for those three
  shapes — concretely, do not widen `omissionRefusedByValidation` to admit
  them — until **both** ramp legs land: (a) the authoring builder forces
  `required: true` under `controlled_by_parent` (#9138), and (b) lint refuses
  the shape at the **v18** boundary (#9139, held for the v18 window).
- Why, concretely: standing the gate down for any of the three would mint a
  detail row whose master FK is null, which the `controlled_by_parent` read
  filter (`fk IN (readable masters)`) can never match — unreadable by anyone,
  and `422 MISSING_REQUIRED_FIELD` on every later by-id write, permanently
  (no payload the caller could send would restore a field the request never
  carried).
- A matching one-line pointer was added at the `omissionRefusedByValidation`
  field declaration itself, since that predicate is the actual knob a future
  change would widen.

**Also corrects an adjacent, now-stale `[#8959]` paragraph in the same
branch.** It still read "#8772 *proposes* a lint … it is open and unruled" —
true when #8959 landed it, false today: #8772 was ruled and closed on
2026-08-16 ([comment 5306089973](https://github.com/objectstack-ai/objectstack/issues/8772#issuecomment-5306089973)).
Left uncorrected, it would have sat one paragraph above this PR's own freeze
note and contradicted it. The corrected paragraph keeps #8959's actual
finding intact and current: no publish-time gate refuses these three shapes
*yet* — that remains true until #9138 **and** #9139 both land — but it no
longer misdescribes #8772 itself as unruled.

## Premise re-check (the card asked for this before writing)

- `assertControlledByParentWrite` is confirmed live at
  `security-plugin.ts:5121` on `origin/main` (`git grep`).
- **The guard is not flatly unconditional any more.** PR #8879 (merged
  2026-08-15, closing #8688) already landed a *conditional* stand-down keyed
  on `CbpRelation.omissionRefusedByValidation`. For the three shapes this
  note is about, that predicate is always `false` by construction
  (`def?.type === 'master_detail' && !!def?.required && !def?.readonly &&
  !def?.system`), so the guard remains the sole, *unconditional* enforcement
  point for exactly those three — which is what the note now says, rather
  than the flat "still unconditional" framing the card anticipated as the
  default outcome of the re-check.
- **#8688 is not "still open and unruled."** It was ruled and merged (PR
  #8879, 2026-08-15). Its proposed route — stand the guard down for an
  absent master FK on insert — already landed, correctly narrowed to the one
  shape `validateRecord` actually covers. The freeze note is written
  accordingly: it protects against *widening* an already-landed, conditional
  stand-down, not against a still-hypothetical change. (Reported per the
  card's own instruction to adjust the framing rather than write a stale
  warning.)
- The three unsafe shapes were independently re-counted against
  `record-validator.ts`'s `if (def.system || def.readonly) continue;`
  (`:993` insert-mode, `:1003` update-mode) plus `validateOne`'s
  `def.required && isMissing(value)` check: exactly 3, matching the card and
  #8772's five-row measurement table.
- **A pinned test asserting the guard refuses the absent-master insert for
  all three shapes already exists** —
  `controlled-by-parent-sharing.test.ts`'s `it.each` block (`'[#8688] 422
  MISSING_REQUIRED_FIELD survives on insert: %s'`), added by PR #8879. Per
  the card's "check first" instruction, no duplicate test was added.

## Changeset

Comment-only, no behaviour change ⇒ no changeset. `skip-changeset` label
applied.

## Tests

All commands below were re-run at this PR's final commit,
`1a67152fc` (`git rev-parse --short HEAD`).

- `pnpm --filter '@objectstack/plugin-security^...' build` — dependency
  closure, green.
- `pnpm --filter @objectstack/plugin-security typecheck` — green (`tsc
  --noEmit`, exit 0).
- `pnpm --filter @objectstack/plugin-security test` — 66 test files, 1279
  tests, all passing (includes the already-pinned three-shape `it.each`
  above).
- `node scripts/check-cross-package-test-inputs.mjs`,
  `node scripts/check-test-source-alias.mjs`,
  `node scripts/check-type-source-resolution.mjs` — the three path-derived
  gates from `node scripts/pm/dispatch-gates.mjs` — all green.
- `node scripts/check-adr-anchors.mjs` — green (this file is ADR-0055
  content-anchored; the anchor is citation-based, not line-based, so the
  comment edit does not disturb it).
- `node scripts/check-nul-bytes.mjs` — clean.
- `node scripts/check-i18n-bundles.mjs` (after `pnpm exec turbo run build
  --filter=@objectstack/cli`) — "9 package(s) — all bundles in sync, no
  undeclared authoring keys" (comment-only edit produces no drift).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_