### PR TITLE
cli: explain os meta resync's skip count instead of a silent no-op look (#9184)

### DIFF
--- a/.changeset/resync-skip-summary-explanation.md
+++ b/.changeset/resync-skip-summary-explanation.md
@@ -1,0 +1,37 @@
+---
+'@objectstack/cli': patch
+---
+
+`os meta resync`: explain a nonzero skip count instead of leaving it to look like a no-op (#9184)
+
+`resynced 0 / skipped 8` is a **permanent, by-design** outcome on any install
+created before #8692's forward-only ruling — the platform's own seeder wrote
+the `'admin'` stamp those rows still carry, and #8692 deliberately never
+migrates it (a stored `'admin'` cannot be told apart from a genuine Setup
+takeover). The docblock half of this (#9130 / PR #9183) already explained it
+in source; this is the half the operator actually sees, at the terminal,
+without going looking:
+
+```
+⚠ Left 8 set(s) untouched (admin- or package-owned).
+  Expected, not a failure — resync only reconciles platform-owned rows. A stored
+  'admin' stamp (or the legacy 'user' spelling) isn't always a deliberate Setup
+  takeover: on installs from before #8692, the platform's own seeded defaults
+  carry that same stamp, so a persistent skip count here can be permanent by
+  design. A package-owned row, by contrast, is always a deliberate override by
+  the package that owns it.
+```
+
+The new line fires on the same condition the skip-count summary itself
+already used (`resyncSkipped > 0`) — a partial skip gets the same
+explanation as a total one. `--json` output is unchanged; `resyncSkipped` is
+already a plain number a script can act on without prose.
+
+While here, the skip-count summary's own wording is corrected: it read
+`(admin- or package-owned override)`, uniformly claiming "override" for
+both provenance classes. That is accurate for a package-owned row (always a
+deliberate override, per the seeder's docblock) but was already the exact
+false framing PR #9183 removed from the per-row log line for the
+admin-owned case — a pre-#8692 seeded row was never overridden by anybody.
+The summary now reads `(admin- or package-owned)`, and the new explanatory
+line carries the nuance instead.

--- a/packages/cli/src/commands/meta/resync-skip-explanation.test.ts
+++ b/packages/cli/src/commands/meta/resync-skip-explanation.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #9184 — `os meta resync` reports a nonzero skip count with no explanation.
+//
+// The docblock half (#9130 / PR #9183) already explains, IN SOURCE, that a
+// stored `'admin'` (or legacy `'user'`) stamp is not always a deliberate
+// Setup takeover — on any install created before #8692 the platform's own
+// seeder wrote that exact stamp, so `resynced 0 / skipped N` is a permanent,
+// by-design outcome there. This card is the runtime-output half: the same
+// explanation has to reach the operator who is staring at the terminal,
+// never having gone looking for the source.
+//
+// What is pinned here:
+//   • the explanation fires exactly when `resyncSkipped > 0` — the same
+//     condition the skip-count summary itself uses, never a narrower one
+//     (e.g. `resynced === 0`);
+//   • it names BOTH spellings of the legacy-vs-current provenance value
+//     (`admin` and `user`), because a stored legacy row can surface under
+//     either;
+//   • it says the skip is expected / by design / not a failure — the whole
+//     point of the card;
+//   • it does NOT reintroduce "intentional override" framing for the
+//     admin-owned case — the docblock removed that as false (a pre-#8692
+//     seeder wrote the stamp, not an admin), and this line must not
+//     contradict it.
+
+import { describe, it, expect } from 'vitest';
+import { resyncSkipExplanationLine } from './resync.js';
+
+describe('resyncSkipExplanationLine — the runtime-output half of #9184', () => {
+  it('is silent when nothing was skipped', () => {
+    expect(resyncSkipExplanationLine(0)).toBeNull();
+  });
+
+  it('is silent for a negative count too (defensive — should never occur)', () => {
+    expect(resyncSkipExplanationLine(-1)).toBeNull();
+  });
+
+  it('fires for a full skip (the classic pre-#8692 "resynced 0 / skipped N" case)', () => {
+    const line = resyncSkipExplanationLine(8);
+    expect(line).not.toBeNull();
+    expect(line).toContain('admin');
+    expect(line).toContain('user');
+    expect(line).toContain('#8692');
+  });
+
+  it('fires identically for a PARTIAL skip — same trigger as the summary, not `resynced === 0`', () => {
+    // The card requires this line to ride the same condition as the skip
+    // summary (`resyncSkipped > 0`), not a narrower "totally stuck" gate. A
+    // caller with resynced=3/skipped=2 must get the same explanation as
+    // resynced=0/skipped=8.
+    expect(resyncSkipExplanationLine(2)).toBe(resyncSkipExplanationLine(8));
+  });
+
+  it('says the outcome is expected / by design / not a failure', () => {
+    const line = resyncSkipExplanationLine(1)!;
+    expect(line.toLowerCase()).toMatch(/expected|by design/);
+    expect(line.toLowerCase()).toContain('not a failure');
+  });
+
+  it('never claims the admin-owned case is a deliberate override — the framing PR #9183 removed', () => {
+    const line = resyncSkipExplanationLine(1)!;
+    // The pre-#8692 case is exactly the platform's own seeder inheriting a
+    // field default, not an administrator deciding anything — the docblock
+    // in bootstrap-platform-admin.ts is explicit that stating this as
+    // "(intentional override)" is a lie for those rows. This line must keep
+    // that same neutral framing rather than reintroducing it.
+    expect(line).toContain("isn't always a deliberate Setup takeover");
+    expect(line).not.toMatch(/admin[^.]*\(intentional override\)/i);
+  });
+
+  it('keeps the package-owned case correctly framed as ALWAYS deliberate, unlike admin', () => {
+    // Unlike a stored 'admin'/'user' stamp, a package-owned row genuinely is
+    // always a deliberate override — the docblock draws this distinction and
+    // the runtime line must not blur it by applying uniform "override"
+    // language to both provenance classes.
+    const line = resyncSkipExplanationLine(1)!;
+    expect(line).toMatch(/package-owned row.*always a deliberate override/s);
+  });
+});

--- a/packages/cli/src/commands/meta/resync.ts
+++ b/packages/cli/src/commands/meta/resync.ts
@@ -36,6 +36,44 @@ function safeGetService(kernel: any, name: string): any {
 }
 
 /**
+ * The dim explanatory line printed under the skip-summary `printWarning`
+ * when `resyncSkipped > 0` — the runtime-output half of #9184 (the docblock
+ * half, #9130/PR #9183, already explains this in source).
+ *
+ * `null` when nothing was skipped, so the caller's `if (resyncSkipped > 0)`
+ * gate is the single source of truth for the trigger condition: this line
+ * rides the SAME condition as the skip-count summary it sits under, never a
+ * separate one (e.g. `resynced === 0`) — a partial skip deserves the same
+ * explanation as a total one, and "alongside the skip summary" in the issue
+ * means exactly that pairing.
+ *
+ * Deliberately neutral about the skipped row's OWN provenance, matching the
+ * seeder docblock (`bootstrap-platform-admin.ts`) this line must not
+ * contradict: the skip decision is unconditionally intentional (only
+ * platform-owned rows are ever reconciled), but a stored `'admin'` stamp is
+ * NOT always a deliberate Setup takeover — on any install predating #8692
+ * the platform's own seeder wrote that exact stamp, so `resynced 0 / skipped
+ * N` is a permanent, by-design outcome there rather than a sign the command
+ * failed. `'user'` is named too: it is the legacy spelling of the same
+ * class, healed to `'admin'` by `normalizeManagedByVocab`, so a stored
+ * legacy row can still surface here under either spelling.
+ */
+export function resyncSkipExplanationLine(resyncSkipped: number): string | null {
+  if (resyncSkipped <= 0) return null;
+  // One unwrapped sentence per concatenated piece — never split by an
+  // embedded '\n' — so a key phrase can never straddle a hard line break
+  // (the terminal soft-wraps on its own, same as the file's other dim
+  // follow-up lines a few lines up).
+  return (
+    "  Expected, not a failure — resync only reconciles platform-owned rows. " +
+    "A stored 'admin' stamp (or the legacy 'user' spelling) isn't always a deliberate Setup takeover: " +
+    "on installs from before #8692, the platform's own seeded defaults carry that same stamp, so a " +
+    "persistent skip count here can be permanent by design. A package-owned row, by contrast, is " +
+    "always a deliberate override by the package that owns it."
+  );
+}
+
+/**
  * `os meta resync` — reconcile materialized metadata to the compiled `dist`
  * without a `--fresh` wipe (#2705).
  *
@@ -169,7 +207,9 @@ export default class MetaResync extends Command {
         printInfo('Nothing reconciled.');
       }
       if (resyncSkipped > 0) {
-        printWarning(`Left ${resyncSkipped} set(s) untouched (admin- or package-owned override).`);
+        printWarning(`Left ${resyncSkipped} set(s) untouched (admin- or package-owned).`);
+        const note = resyncSkipExplanationLine(resyncSkipped);
+        if (note) console.log(chalk.dim(note));
       }
       console.log(chalk.dim(`  ${timer.display()}`));
       console.log('');


### PR DESCRIPTION
Fixes #9184

## What changed

`os meta resync` already knows *how many* default permission-set rows it skipped (`resyncSkipped`), but the human-readable output never said *why* — leaving an operator staring at `resynced 0 / skipped 8` with no signal that this is a permanent, by-design outcome on any install created before #8692's forward-only ruling, not a failure.

This is the runtime-output half of #9130 (the docblock half landed as PR #9183, `50900479f`).

Two changes to `packages/cli/src/commands/meta/resync.ts`, both in the human-text branch only (`--json` is untouched — `resyncSkipped` is already a plain number a script can act on):

1. **New `resyncSkipExplanationLine(resyncSkipped)`** — a pure, exported helper. Returns `null` when nothing was skipped; otherwise a dim follow-up line printed right under the existing skip-count `printWarning`:

   ```
   ⚠ Left 8 set(s) untouched (admin- or package-owned).
     Expected, not a failure — resync only reconciles platform-owned rows. A stored 'admin'
     stamp (or the legacy 'user' spelling) isn't always a deliberate Setup takeover: on
     installs from before #8692, the platform's own seeded defaults carry that same stamp,
     so a persistent skip count here can be permanent by design. A package-owned row, by
     contrast, is always a deliberate override by the package that owns it.
   ```

   (shown wrapped for the PR body; the actual string carries no embedded newline — the
   terminal soft-wraps it, same as any other long line)

2. **Corrected the skip-count summary's own wording.** It read `(admin- or package-owned override)` — uniformly calling both provenance classes an "override". That's accurate for a package-owned row (always deliberate, per the seeder's docblock) but is the exact "intentional override" framing PR #9183 already removed from the *per-row* log line for the admin-owned case, because a pre-#8692 seeded row was never overridden by anybody — the platform's own seeder wrote that stamp. The *summary* line still carried it. Now reads `(admin- or package-owned)`; the new explanatory line carries the nuance.

## Decisions the issue left to this PR

- **Trigger condition: `resyncSkipped > 0`.** Same condition the skip-count summary itself already used — "alongside the skip summary" reads most naturally as *the same* condition, and a partial skip (e.g. `resynced 3 / skipped 2`) deserves the same explanation as a total one (`resynced 0 / skipped N`), not a narrower `resynced === 0` gate. Pinned by the "fires identically for a partial skip" test.
- **Wording matches the landed docblock, not the issue's illustrative example.** The issue's suggested shape ends `(see --help)`; I dropped that — oclif's `--help` renders `static description`/`examples` only, never the source-level JSDoc block that actually carries this explanation, so pointing there would be a broken promise for an operator who follows it. The line is self-contained instead.
- **Names both provenance spellings** (`'admin'` and legacy `'user'`, healed by `normalizeManagedByVocab`), and **does not claim "intentional override"** for the admin-owned case — matching `bootstrap-platform-admin.ts`'s current docblock, which explicitly removed that framing as false for pre-#8692 rows. It **does** call a package-owned row a deliberate override, which the same docblock says is accurate.
- **Placement**: directly under the existing `printWarning` for the skip count, via `console.log(chalk.dim(...))` — the same "printWarning + dim follow-up" pattern the file already uses two lines up for its confirmation-prompt explanation.

## Changeset

Added `.changeset/resync-skip-summary-explanation.md` — **patch, `@objectstack/cli`**. This changes what a published CLI prints on a real, common path (any pre-#8692 install running `os meta resync`), which is observable user-facing behavior — not a docs/test/workflow-only change, so `skip-changeset` does not apply here.

## Tests

`packages/cli/src/commands/meta/resync-skip-explanation.test.ts` (new) pins the pure helper directly, following the `configLoadFailureCheck` / `describeRegisteredDriver` convention already in this package (export the pure decision function, unit-test it without booting a runtime):

- `resyncSkipExplanationLine(0)` / `(-1)` → `null` (the negative case).
- fires for a full skip (`8`) and names both `admin` and `user`, plus `#8692`.
- fires **identically** for a partial skip (`2`) as for a total one (`8`) — pins the trigger-condition decision above.
- asserts the "expected / by design … not a failure" framing.
- asserts it does **not** reintroduce "intentional override" framing for the admin case, and correctly keeps "always a deliberate override" for the package case.

```
$ pnpm --filter @objectstack/cli exec vitest run src/commands/meta/resync-skip-explanation.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ pnpm --filter @objectstack/cli typecheck
> tsc --noEmit          (clean, exit 0)
```

Both at `0e7733cf1` (this PR's head).

## Gates

`node scripts/pm/dispatch-gates.mjs` against the changed paths (`resync.ts`, the new test file, the changeset), re-derived at the final commit:

- `check:cross-package-test-inputs` — OK, 12 packages read outside themselves, all declared.
- `check:changeset-gate-self-tests` family — `check-empty-changeset.mjs`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs` — all OK (1 non-breaking, non-empty, non-major changeset).
- `check:objectui-changeset` (`objectui-changeset-digest.mjs` / `objectui-range.mjs` `--self-test`) — both self-tests pass; irrelevant to this diff's content (objectui pin-bump tooling), matched only because dispatch-gates keys on any `.changeset/**` touch.
- Convention-triggered (new test file): `check:query-options-erasure` (ratchet holds, no new sites), `check:where-matcher` (no new/changed matchers), `check:engine-double-contract` (no new fake-engine doubles) — all OK.
- `check:type-check-coverage` (the structural half) — OK, 64/77 packages type-checked, `@objectstack/cli` among them (not in the DEBT ledger).
- `check:type-check-debt --re-measure` (the ratchet half) — **not run.** It refuses outright on this worktree (`--re-measure cannot run: … @objectstack/service-knowledge` has no built `dist`) unless the **entire** `packages/*` closure is built first (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`), which is the full-farm build this dispatch's "Local verification scope" says is CI's job, not a per-PR local one. This diff adds no export and touches no public type — only an internal helper inside one CLI command plus a same-package test file — so there is no plausible path by which it moves another package's measured count; CI's own ratchet run is the actual verification for this family.

All at `git rev-parse --short HEAD` = `0e7733cf1`.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_