### PR TITLE
fix(runtime): demote non-enum author-thrown codes to `declaredCode` — `error.code` closed at every door (#9106)

### DIFF
--- a/.changeset/actions-door-demotes-author-codes.md
+++ b/.changeset/actions-door-demotes-author-codes.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/spec": minor
+"@objectstack/types": minor
+"@objectstack/runtime": minor
+---
+
+`error.code` is a closed vocabulary at every door (#9106, maintainer ruling
+2026-08-16): the runtime dispatcher's thrown-error exits
+(`HttpDispatcher.errorFromThrown`, `dispatcher-plugin`'s `errorResponseBase`,
+`endpoint-executor`'s `endpointErrorAnswer` — the actions door among them) now
+serve the narrowed `code` the shared resolver (`resolveThrownHttpError`,
+`@objectstack/types`) has always computed, exactly as the REST door has since
+#8016. A thrown code that is not a member of `StandardErrorCode ∪
+ERROR_CODE_LEDGER` no longer reaches `error.code`.
+
+It is not dropped: `ApiErrorSchema` declares a new optional `declaredCode`
+field — the open, author-authored channel — and the demoted spelling rides
+there. Presence means demotion: the field is absent whenever the producer's
+code is a vocabulary member (it is already in `error.code`) or the producer
+declared none. The #7867 sandbox passthrough capability is preserved — a
+metadata app's own thrown `.code` still crosses the QuickJS boundary and still
+reaches the wire.
+
+For a metadata app that throws its own code (e.g.
+`Object.assign(new Error('pick another'), { code: 'DUPLICATE' })` in an action
+body) and reads it back from an actions-door failure:
+
+- FROM: `error.code === 'DUPLICATE'`
+- TO: `error.code` is the closed member the status derives (e.g.
+  `VALIDATION_ERROR` on a 400) and `error.declaredCode === 'DUPLICATE'`.
+  One-line fix: branch on `error.declaredCode` for app-specific spellings;
+  branch on `error.code` for platform conditions.
+
+Platform producers are unaffected: every registered code reaches `error.code`
+verbatim, as before (post-#8846 the dispatcher-vocabulary gate holds that set
+registered). Measured before landing (the ruling's binding precondition): no
+existing consumer of the actions door branches on author-authored strings in
+`error.code`.
+
+`@objectstack/types` adds `demotedDeclaredCode(thrown)` — the one definition of
+"which spelling a boundary surfaces beside the closed `code`".

--- a/content/docs/references/api/analytics.mdx
+++ b/content/docs/references/api/analytics.mdx
@@ -44,7 +44,7 @@ const result = AnalyticsEndpoint.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; title?: string; measures: object[]; dimensions: object[] }[]` | ✅ | Available cubes, each as the `CubeMeta` discovery projection — the cube name, its title, and the measures/dimensions a client may name in a query. A bare array: there is no `cubes` wrapper object, and no cube `sql` is published. |
 
@@ -79,7 +79,7 @@ const result = AnalyticsEndpoint.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ rows: Record<string, any>[]; fields: object[]; sql?: string }` | ✅ |  |
 
@@ -93,7 +93,7 @@ const result = AnalyticsEndpoint.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ sql: string; params: any[] }` | ✅ |  |
 

--- a/content/docs/references/api/auth.mdx
+++ b/content/docs/references/api/auth.mdx
@@ -117,7 +117,7 @@ const result = AuthProvider.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ session: object; user: object; token?: string }` | ✅ |  |
 
@@ -153,7 +153,7 @@ const result = AuthProvider.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ id: string; email: string; emailVerified: boolean; name: string; … }` | ✅ |  |
 

--- a/content/docs/references/api/automation-api.mdx
+++ b/content/docs/references/api/automation-api.mdx
@@ -119,7 +119,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label: string; description?: string; successMessage?: string; … }` | ✅ | The created flow definition |
 
@@ -144,7 +144,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; deleted: boolean }` | ✅ |  |
 
@@ -187,7 +187,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label: string; description?: string; successMessage?: string; … }` | ✅ | Full flow definition |
 
@@ -213,7 +213,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ id: string; flowName: string; flowVersion?: integer; status: Enum<'pending' \| 'running' \| 'paused' \| 'completed' \| 'failed' \| 'cancelled' \| … +2 more>; … }` | ✅ | Full execution log with step details |
 
@@ -241,7 +241,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ flows: object[]; total?: integer; nextCursor?: string; hasMore: boolean }` | ✅ |  |
 
@@ -269,7 +269,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ runs: object[]; total?: integer; nextCursor?: string; hasMore: boolean }` | ✅ |  |
 
@@ -295,7 +295,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; enabled: boolean }` | ✅ |  |
 
@@ -325,7 +325,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ success: boolean; output?: any; error?: string; durationMs?: number }` | ✅ |  |
 
@@ -351,7 +351,7 @@ const result = AutomationApiErrorCode.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label: string; description?: string; successMessage?: string; … }` | ✅ | The updated flow definition |
 

--- a/content/docs/references/api/batch.mdx
+++ b/content/docs/references/api/batch.mdx
@@ -55,7 +55,7 @@ const result = BatchConfigSchema.parse(data);
 | :--- | :--- | :--- | :--- |
 | **id** | `string` | optional | Record ID if operation succeeded |
 | **success** | `boolean` | ✅ | Whether this record was processed successfully |
-| **errors** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }[]` | optional | Array of errors if operation failed. Branch on `errors[0].code` — an atomic batch that rolled back marks rows that were written then undone with code ROLLED_BACK and rows never reached with NOT_ATTEMPTED, while the causal row keeps its own error (#4793). A NON-atomic batch that stopped (the `continueOnError: false` default) marks its un-attempted tail with the same NOT_ATTEMPTED code — rows before the failure stay written and keep reporting success, since nothing was rolled back (#7539). |
+| **errors** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }[]` | optional | Array of errors if operation failed. Branch on `errors[0].code` — an atomic batch that rolled back marks rows that were written then undone with code ROLLED_BACK and rows never reached with NOT_ATTEMPTED, while the causal row keeps its own error (#4793). A NON-atomic batch that stopped (the `continueOnError: false` default) marks its un-attempted tail with the same NOT_ATTEMPTED code — rows before the failure stay written and keep reporting success, since nothing was rolled back (#7539). |
 | **data** | `Record<string, any>` | optional | Full record data (if returnRecords=true) |
 | **index** | `number` | optional | Index of the record in the request array |
 | **droppedFields** | `{ object: string; fields: string[]; reason: Enum<'readonly' \| 'readonly_when' \| 'primary_key'> }[]` | optional | Write-observability (#3407/#3431/#3455): caller-supplied fields LEGALLY stripped from THIS row before it was written — static `readonly` (#2948) / TRUE `readonlyWhen` (#3042) on update, or the #3043 create-ingress strip. Per-row because a batch can drop different fields on different rows (`readonlyWhen` is record-state-dependent). Present ONLY when ≥1 field was dropped for this row; the row still succeeded (success unchanged). A single response header cannot express per-row drops, so this body field is the canonical bulk channel — REST does not emit `X-ObjectStack-Dropped-Fields` for batches. Optional — omit-when-empty keeps the shape backward-compatible. |
@@ -122,7 +122,7 @@ const result = BatchConfigSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | optional | Operation type that was performed |
 | **total** | `number` | ✅ | Total number of records in the batch |

--- a/content/docs/references/api/contract.mdx
+++ b/content/docs/references/api/contract.mdx
@@ -28,6 +28,7 @@ const result = ApiErrorSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **code** | `Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| 'INVALID_FORMAT' \| 'VALUE_TOO_LONG' \| 'VALUE_TOO_SHORT' \| 'VALUE_OUT_OF_RANGE' \| … +281 more>` | ✅ | Error code (e.g. VALIDATION_ERROR; StandardErrorCode ∪ the ledger the serving side registers — ERROR_CODE_LEDGER for framework packages) |
+| **declaredCode** | `string` | optional | The producer-declared code, verbatim, when it is not a member of the closed `code` vocabulary — the open, author-authored channel (app-specific spellings; ADR-0112, #9106) |
 | **message** | `string` | ✅ | Readable error message |
 | **category** | `string` | optional | Error category (e.g. validation, authorization) |
 | **httpStatus** | `integer` | optional | HTTP status of the response carrying this error |
@@ -335,7 +336,7 @@ const result = ApiErrorSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 
 
@@ -374,7 +375,7 @@ const result = ApiErrorSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ id?: string; success: boolean; errors?: object[]; index?: number; … }[]` | ✅ | Results for each item in the batch |
 
@@ -416,7 +417,7 @@ const result = ApiErrorSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **id** | `string` | ✅ | ID of the deleted record |
 
@@ -468,7 +469,7 @@ const result = ApiErrorSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `Record<string, any>[]` | ✅ | Array of matching records |
 | **pagination** | `{ total?: number; limit?: number; offset?: number; cursor?: string; … }` | ✅ | Pagination info |
@@ -484,7 +485,7 @@ const result = ApiErrorSchema.parse(data);
 | :--- | :--- | :--- | :--- |
 | **id** | `string` | optional | Record ID if processed |
 | **success** | `boolean` | ✅ |  |
-| **errors** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }[]` | optional |  |
+| **errors** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }[]` | optional |  |
 | **index** | `number` | optional | Index in original request |
 | **data** | `any` | optional | Result data (e.g. created record) |
 
@@ -523,7 +524,7 @@ Key-value map of record data
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `Record<string, any>` | ✅ | The requested or modified record |
 

--- a/content/docs/references/api/error-code-ledger.mdx
+++ b/content/docs/references/api/error-code-ledger.mdx
@@ -80,15 +80,19 @@ consolidating any of them onto its standard member is a deliberate wire
 change DEFERRED by the #8211 adjudication (option B) until a specific code
 has a measured victim.
 
-One rule, two doors (#8087): registration here is the ADMISSION door — what
-the vocabulary may contain. The DISPATCHER door is ruled (#8087, option
-B-as-a-gate, maintainer 2026-08-12) to parse every body it emits against the
-closed vocabulary; until that gate lands, `resolveThrownHttpError`
-(`@objectstack/types`, PR #8088) carries `code` (narrowed) / `declaredCode`
-(verbatim) across the gap. Both doors state the same rule: a code either IS
-the standard member for its condition, or it is registered here — and if it
-merely re-spells a standard member, that registration is a recorded waiver,
-never drift.
+One rule, two doors (#8087, completed by #9106): registration here is the
+ADMISSION door — what the vocabulary may contain. The DISPATCHER door is
+gated (#8087, option B-as-a-gate, maintainer 2026-08-12:
+`check:dispatcher-error-vocabulary` sweeps its producers) and, since the
+#9106 ruling (maintainer 2026-08-16), NARROWS exactly as the REST door
+always has: `resolveThrownHttpError` (`@objectstack/types`) answers `code`
+(a member of this union) for `error.code` at BOTH doors, and a producer's
+unregistered spelling is demoted to the wire's `declaredCode` — the open,
+author-authored channel `ApiErrorSchema` declares for it. Both doors state
+the same rule: a code either IS the standard member for its condition, or it
+is registered here — and if it merely re-spells a standard member, that
+registration is a recorded waiver, never drift. A code registered NOWHERE
+(a tenant app's own spelling) still reaches the wire, in `declaredCode`.
 
 A code emitted by several packages is listed once per emitting package —
 the union dedupes; the per-package rows are provenance, not identity.

--- a/content/docs/references/api/export.mdx
+++ b/content/docs/references/api/export.mdx
@@ -57,7 +57,7 @@ const result = CreateExportJobRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ jobId: string; status: Enum<'pending' \| 'processing' \| 'completed' \| 'failed' \| 'cancelled' \| 'expired'>; estimatedRecords?: integer; createdAt: string }` | ✅ |  |
 
@@ -157,7 +157,7 @@ const result = CreateExportJobRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ jobId: string; status: Enum<'pending' \| 'processing' \| 'completed' \| 'failed' \| 'cancelled' \| 'expired'>; format: Enum<'csv' \| 'json' \| 'jsonl' \| 'xlsx' \| 'parquet'>; totalRecords?: integer; … }` | ✅ |  |
 
@@ -231,7 +231,7 @@ const result = CreateExportJobRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ jobId: string; downloadUrl: string; fileName: string; fileSize: integer; … }` | ✅ |  |
 
@@ -449,7 +449,7 @@ Type: `{ sourceField: string; targetField: string; targetLabel?: string; transfo
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ totalRecords: integer; validRecords: integer; invalidRecords: integer; duplicateRecords: integer; … }` | ✅ |  |
 
@@ -488,7 +488,7 @@ Type: `{ sourceField: string; targetField: string; targetLabel?: string; transfo
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ jobs: object[]; nextCursor?: string; hasMore: boolean }` | ✅ |  |
 
@@ -546,7 +546,7 @@ Type: `{ sourceField: string; targetField: string; targetLabel?: string; transfo
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ id: string; name: string; enabled: boolean; nextRunAt?: string; … }` | ✅ |  |
 

--- a/content/docs/references/api/metadata.mdx
+++ b/content/docs/references/api/metadata.mdx
@@ -51,7 +51,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label: string \| Record<string, string>; description?: string \| Record<string, string>; icon?: string; … }` | ✅ | Full App Configuration |
 
@@ -65,7 +65,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label: string; icon?: string; description?: string }[]` | ✅ | List of available concepts (Objects, Apps, Flows) |
 
@@ -92,7 +92,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ total: integer; succeeded: integer; failed: integer; errors?: object[] }` | ✅ | Bulk operation result |
 
@@ -117,7 +117,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ type: string; name: string }` | ✅ |  |
 
@@ -131,7 +131,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ sourceType: string; sourceName: string; targetType: string; targetName: string; … }[]` | ✅ | Items this item depends on |
 
@@ -145,7 +145,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ sourceType: string; sourceName: string; targetType: string; targetName: string; … }[]` | ✅ | Items that depend on this item |
 
@@ -159,7 +159,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `Record<string, any>` | optional | Effective metadata with all overlays applied |
 
@@ -173,7 +173,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ exists: boolean }` | ✅ |  |
 
@@ -200,7 +200,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `any` | ✅ | Exported metadata bundle |
 
@@ -228,7 +228,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ total: integer; imported: integer; skipped: integer; failed: integer; … }` | ✅ | Import result |
 
@@ -242,7 +242,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ type: string; name: string; definition: Record<string, any> }` | ✅ | Metadata item |
 
@@ -256,7 +256,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `Record<string, any>[]` | ✅ | Array of metadata definitions |
 
@@ -270,7 +270,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `string[]` | ✅ | Array of metadata item names |
 
@@ -284,7 +284,7 @@ const result = AppDefinitionResponseSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ id: string; baseType: string; baseName: string; packageId?: string; … }` | optional | Overlay definition, undefined if none |
 
@@ -348,7 +348,7 @@ Metadata query with filtering, sorting, and pagination
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ items: object[]; total: integer; page: integer; pageSize: integer }` | ✅ | Paginated query result |
 
@@ -406,7 +406,7 @@ Metadata query with filtering, sorting, and pagination
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ type: string; label: string; description?: string; filePatterns: string[]; … }` | optional | Type info |
 
@@ -420,7 +420,7 @@ Metadata query with filtering, sorting, and pagination
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `string[]` | ✅ | Registered metadata type identifiers |
 
@@ -446,7 +446,7 @@ Metadata query with filtering, sorting, and pagination
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ valid: boolean; errors?: object[]; warnings?: object[] }` | ✅ | Validation result |
 
@@ -460,7 +460,7 @@ Metadata query with filtering, sorting, and pagination
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ name: string; label?: string; pluralLabel?: string; description?: string; … }` | ✅ | Full Object Schema |
 

--- a/content/docs/references/api/package-api.mdx
+++ b/content/docs/references/api/package-api.mdx
@@ -57,7 +57,7 @@ Get installed package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ manifest: object; status?: Enum<'installed' \| 'disabled' \| 'installing' \| 'upgrading' \| 'uninstalling' \| 'error'>; enabled?: boolean; installedAt?: string; … }` | ✅ | Installed package details |
 
@@ -89,7 +89,7 @@ List installed packages response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ packages: object[]; total?: integer; nextCursor?: string; hasMore: boolean }` | ✅ |  |
 
@@ -143,7 +143,7 @@ Install package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ package: object; dependencyResolution?: object; namespaceConflicts?: object[]; message?: string }` | ✅ |  |
 
@@ -185,7 +185,7 @@ Rollback package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ success: boolean; restoredVersion?: string; message?: string }` | ✅ |  |
 
@@ -220,7 +220,7 @@ Upgrade package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ success: boolean; phase: string; plan?: object; snapshotId?: string; … }` | ✅ |  |
 
@@ -250,7 +250,7 @@ Resolve dependencies response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ dependencies: object[]; canProceed: boolean; requiredActions: object[]; installOrder: string[]; … }` | ✅ | Dependency resolution result with topological sort |
 
@@ -277,7 +277,7 @@ Uninstall package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ packageId: string; success: boolean; message?: string }` | ✅ |  |
 
@@ -309,7 +309,7 @@ Upload artifact response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ success: boolean; artifactRef?: object; submissionId?: string; message?: string }` | ✅ |  |
 

--- a/content/docs/references/api/protocol.mdx
+++ b/content/docs/references/api/protocol.mdx
@@ -280,7 +280,7 @@ const result = AiAgentCapabilitiesSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | optional | Operation type that was performed |
 | **total** | `number` | ✅ | Total number of records in the batch |
@@ -428,7 +428,7 @@ const result = AiAgentCapabilitiesSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | optional | Operation type that was performed |
 | **total** | `number` | ✅ | Total number of records in the batch |
@@ -1528,7 +1528,7 @@ Uninstall package response
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **operation** | `Enum<'create' \| 'update' \| 'upsert' \| 'delete'>` | optional | Operation type that was performed |
 | **total** | `number` | ✅ | Total number of records in the batch |

--- a/content/docs/references/api/storage.mdx
+++ b/content/docs/references/api/storage.mdx
@@ -46,7 +46,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ fileId: string; key: string; size: integer; mimeType: string; … }` | ✅ |  |
 
@@ -72,7 +72,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ url: string }` | ✅ |  |
 
@@ -101,7 +101,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ path: string; name: string; size: integer; mimeType: string; … }` | ✅ | Uploaded file metadata |
 
@@ -147,7 +147,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ uploadId: string; resumeToken: string; fileId: string; totalChunks: integer; … }` | ✅ |  |
 
@@ -161,7 +161,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ uploadUrl: string; downloadUrl?: string; fileId: string; method: Enum<'PUT' \| 'POST'>; … }` | ✅ |  |
 
@@ -175,7 +175,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ key: string }` | ✅ |  |
 
@@ -202,7 +202,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ chunkIndex: integer; eTag: string; bytesReceived: integer }` | ✅ |  |
 
@@ -216,7 +216,7 @@ const result = CompleteChunkedUploadRequestSchema.parse(data);
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | **success** | `boolean` | ✅ | Operation success status |
-| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; message: string; category?: string; httpStatus?: integer; … }` | optional | Error details if success is false |
+| **error** | `{ code: Enum<'VALIDATION_ERROR' \| 'INVALID_FIELD' \| 'MISSING_REQUIRED_FIELD' \| … +285 more>; declaredCode?: string; message: string; category?: string; … }` | optional | Error details if success is false |
 | **meta** | `{ timestamp: string; duration?: number; requestId?: string; traceId?: string }` | optional | Response metadata |
 | **data** | `{ uploadId: string; fileId: string; filename: string; totalSize: integer; … }` | ✅ |  |
 

--- a/packages/runtime/src/dispatcher-error-vocabulary.ts
+++ b/packages/runtime/src/dispatcher-error-vocabulary.ts
@@ -12,11 +12,15 @@
  * point."
  *
  * The dispatcher door did not have that friction. `HttpDispatcher.errorFromThrown`
- * puts `resolveThrownHttpError(e).declaredCode` — the producer's own string,
+ * put `resolveThrownHttpError(e).declaredCode` — the producer's own string,
  * verbatim and un-narrowed — straight into `error.code`, and its conformance
  * suite parsed only the cases it happened to drive. So a producer emitting a
  * code the ledger does not know produced a body that could never satisfy the
- * schema it claims to satisfy, and nothing noticed.
+ * schema it claims to satisfy, and nothing noticed. (Since #9106 the door
+ * NARROWS — `error.code` takes the resolver's closed `code`, the unregistered
+ * spelling rides the wire's `declaredCode` — so such a body now parses; what
+ * an unswept producer loses instead is its semantic code, silently demoted
+ * off `error.code` until registered. The sweep below is what notices.)
  *
  * The maintainer ruling of 2026-08-12 chose **option B delivered as a gate**:
  * parse every body the door emits, then register what the gate reports —
@@ -83,7 +87,8 @@ export type CodeVerdict =
     /**
      * Authored OUTSIDE the platform — a metadata app's action code, carried
      * across the sandbox boundary deliberately (#7867). No ledger can enumerate
-     * it; see the note on `SANDBOX_AUTHORED_LIMB` below.
+     * it; since #9106 it is demoted to the wire's `declaredCode` at the door
+     * rather than reaching `error.code`. See `SANDBOX_AUTHORED_LIMB` below.
      */
     | 'sandbox-authored'
     /**
@@ -237,33 +242,33 @@ export const PENDING_AT_DISPATCHER_DOOR: readonly string[] = Object.freeze(
 );
 
 /**
- * ## The limb no ledger can close, measured while building this gate
+ * ## The limb no ledger can close — measured while building this gate, RULED
+ * ## by #9106
  *
  * `SandboxError` carries a user action's own `.code` across the QuickJS
  * boundary on purpose — "Author-thrown structured errors get the same
  * treatment; nothing here is objectql-specific"
  * (`sandbox/error-passthrough.test.ts`) — and `domains/actions.ts` serves that
- * error through `errorFromThrown`, so the string lands in `error.code`
- * verbatim. `domains/actions-validation-envelope.test.ts` pins exactly that,
- * end to end, with `DUPLICATE`.
+ * error through `errorFromThrown`. So the dispatcher door's vocabulary has a
+ * limb authored by TENANTS, in metadata apps, at runtime. Registration cannot
+ * close it: the ledger would have to enumerate strings that do not exist when
+ * CI runs.
  *
- * So the dispatcher's `error.code` has a limb whose vocabulary is authored by
- * TENANTS, in metadata apps, at runtime. Registration cannot close it: the
- * ledger would have to enumerate strings that do not exist when CI runs. This
- * is not an argument for option C (ruled inadmissible — the closure is
- * load-bearing for every platform producer, and the six rows above are exactly
- * what it catches); it is a bound on what "closed" can mean at THIS door, and
- * it post-dates the ruling.
+ * The maintainer ruling (#9106, 2026-08-16) closed it the way the REST door
+ * always was: `error.code` is a closed vocabulary at every door, and an
+ * author-thrown code that is not an `ErrorCode` member is DEMOTED to the
+ * wire's `declaredCode` at the door. The #7867 capability is preserved — the
+ * author's code still crosses the sandbox and still reaches the wire, in the
+ * open, author-authored channel `ApiErrorSchema.declaredCode` declares.
+ * `domains/actions-validation-envelope.test.ts` pins the demote end to end,
+ * with `DUPLICATE`.
  *
- * ⛔ Deliberately NOT decided here — deciding it means either narrowing the
- * sandbox boundary or declaring a second, non-ledger vocabulary for
- * author-thrown codes, and both are contract-shaped. Reported to #8087 /
- * #8846 rather than guessed at.
- *
- * `DUPLICATE` is the pinned witness, so it is named here rather than left as an
- * un-owned literal in a test — and it is deliberately NOT re-spelled to a
- * registered code, because re-spelling it would delete the only evidence in the
- * repo that this limb is open.
+ * `DUPLICATE` is the pinned witness, so it is named here rather than left as
+ * an un-owned literal in a test — re-homed under the demote rule by the #9106
+ * ruling, and deliberately NOT registered (fenced off from #8846):
+ * registering it would close nothing, since the next app picks a different
+ * string, and it would falsely promote one tenant spelling into the platform
+ * vocabulary every consumer branches on.
  */
 export const SANDBOX_AUTHORED_LIMB = Object.freeze({
     witness: 'DUPLICATE',

--- a/packages/runtime/src/dispatcher-plugin.ts
+++ b/packages/runtime/src/dispatcher-plugin.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { Plugin, PluginContext, IHttpServer } from '@objectstack/core';
-import { looksLikeInternalErrorLeak, declaresServerFault, INTERNAL_ERROR_MESSAGE } from '@objectstack/types';
+import { looksLikeInternalErrorLeak, declaresServerFault, INTERNAL_ERROR_MESSAGE, resolveThrownHttpError, demotedDeclaredCode } from '@objectstack/types';
 import { DispatcherErrorCode } from '@objectstack/spec/api';
 import type { IAuthService, IMetadataService } from '@objectstack/spec/contracts';
 import type { CounterStore } from '@objectstack/plugin-auth/rate-limit-storage';
@@ -521,20 +521,34 @@ function errorResponseBase(err: any, res: any, securityHeaders?: Record<string, 
         declaresServerFault(err) || (httpStatus >= 500 && looksLikeInternalErrorLeak(raw))
             ? INTERNAL_ERROR_MESSAGE
             : raw || 'Internal Server Error';
-    // [#3842] A thrown error's own `.code` finally has somewhere to go. This
-    // exit used to drop it outright — `HttpDispatcher.errorFromThrown` at least
-    // parked it in `details` — because `error.code` was occupied by the status.
-    // Both exits now put it in the declared field, so the same SDK method
-    // reports the same code whichever one answered. `validation` last, so
-    // `VALIDATION_FAILED` wins for an error matched by `name` alone, exactly as
-    // it does in `errorFromThrown`.
+    // [#3842] A thrown error's own `.code` finally has somewhere to go — the
+    // declared field, so the same SDK method reports the same code whichever
+    // exit answered. [#9106] WHICH spelling goes there is the shared resolver's
+    // answer, not this exit's: `error.code` is a closed vocabulary at every
+    // door (maintainer ruling 2026-08-16), so the resolver's narrowed `code` is
+    // passed explicitly — for a registered code that IS the producer's own
+    // spelling, for a validation shape it is `VALIDATION_FAILED`, exactly the
+    // answers this exit's details-promotion used to produce — and an
+    // unregistered spelling rides the wire's `declaredCode` sibling instead
+    // (presence means demotion; the tenant-authored limb #9106 measured). The
+    // resolver's status chain is byte-identical to `httpStatus` above (status →
+    // statusCode → validation 400 → 500), so the two reads cannot disagree. A
+    // non-string `.code` (a driver errno) stays in `details`, as context.
+    const thrown = resolveThrownHttpError(err, 500);
+    const declaredCode = demotedDeclaredCode(thrown);
     const details =
-        err?.code || validation
-            ? { ...(err?.code ? { code: err.code } : {}), ...(validation ?? {}) }
+        (err?.code && typeof err.code !== 'string') || validation
+            ? { ...(err?.code && typeof err.code !== 'string' ? { code: err.code } : {}), ...(validation ?? {}) }
             : undefined;
     res.json({
         success: false,
-        error: buildApiError({ message, httpStatus, details }),
+        error: buildApiError({
+            message,
+            httpStatus,
+            code: thrown.code,
+            details,
+            ...(declaredCode !== undefined ? { extra: { declaredCode } } : {}),
+        }),
     });
 }
 

--- a/packages/runtime/src/domains/actions-validation-envelope.test.ts
+++ b/packages/runtime/src/domains/actions-validation-envelope.test.ts
@@ -83,8 +83,10 @@ describe('#3918 follow-up — /actions surfaces code + fields on a validation fa
 
         expect(response.status).toBe(400);
         // The semantic code is promoted into `error.code` (#3971); `fields`
-        // stay in `details`.
+        // stay in `details`. A REGISTERED code is already in `error.code`, so
+        // no `declaredCode` sibling appears — presence means demotion (#9106).
         expect(response.body.error.code).toBe('VALIDATION_FAILED');
+        expect(response.body.error.declaredCode).toBeUndefined();
         expect(response.body.error.details).toMatchObject({ fields: FIELDS });
     });
 
@@ -116,13 +118,32 @@ describe('#3918 follow-up — /actions surfaces code + fields on a validation fa
         expect(response.body.error.details).toBeUndefined();
     });
 
-    it('carries a code without fields when that is all the error had', async () => {
+    /**
+     * [#9106] The pinned witness to the TENANT-AUTHORED limb, re-homed under
+     * the demote rule (maintainer ruling 2026-08-16). `DUPLICATE` is a metadata
+     * app's OWN spelling — authored at runtime, enumerable by no ledger — so it
+     * must NOT reach `error.code`, which is a closed vocabulary at every door.
+     * It is not dropped either: #7867's capability is preserved, and the
+     * author's code crosses the sandbox and reaches the wire in
+     * `error.declaredCode`, the open author-authored channel. Apps branch on
+     * enum codes; app-specific spellings ride `declaredCode`.
+     *
+     * ⛔ Do not "fix" a red here by registering `DUPLICATE` in
+     * `ERROR_CODE_LEDGER` — registering one tenant spelling closes nothing
+     * (the next app picks a different string) and promotes it into the
+     * platform vocabulary. See `SANDBOX_AUTHORED_LIMB` in
+     * `../dispatcher-error-vocabulary.ts`.
+     */
+    it('demotes an author-thrown code to `declaredCode` — `error.code` stays closed (#9106)', async () => {
         const response = await invoke(
             new SandboxError("action 'x' threw: pick another", 'pick another', { code: 'DUPLICATE' }),
         );
 
         expect(response.status).toBe(400);
         expect(response.body.error.message).toBe('pick another');
-        expect(response.body.error.code).toBe('DUPLICATE');
+        // The closed member the 400 derives — never the author's spelling.
+        expect(response.body.error.code).toBe('VALIDATION_ERROR');
+        // The author's spelling still reaches the wire, in the open channel.
+        expect(response.body.error.declaredCode).toBe('DUPLICATE');
     });
 });

--- a/packages/runtime/src/endpoint-executor.ts
+++ b/packages/runtime/src/endpoint-executor.ts
@@ -49,10 +49,10 @@ import type { ApiEndpointMatch, IAutomationService } from '@objectstack/spec/con
 import type { AutomationContext } from '@objectstack/spec/contracts';
 import type { ExecutionContext } from '@objectstack/spec/kernel';
 import { serviceUnavailableMessage } from '@objectstack/spec/system';
-import { INTERNAL_ERROR_MESSAGE, looksLikeInternalErrorLeak } from '@objectstack/types';
+import { INTERNAL_ERROR_MESSAGE, looksLikeInternalErrorLeak, resolveThrownHttpError, demotedDeclaredCode } from '@objectstack/types';
 import { apiErrorResponse } from './error-envelope.js';
 import { isServiceServeable } from './service-serveable.js';
-import { validationFailure, validationFailureDetails, VALIDATION_FAILED_STATUS } from './validation-failure.js';
+import { validationFailure } from './validation-failure.js';
 import { buildAutomationContext } from './domains/automation.js';
 import type { HttpProtocolContext } from './http-dispatcher.js';
 
@@ -284,32 +284,28 @@ function sanitizeMessage(message: string, httpStatus: number): string {
 /**
  * A THROWN failure from a delegated pipeline → the existing error envelope.
  *
- * A restatement of `HttpDispatcher.errorFromThrown` (`http-dispatcher.ts:530`)
- * over this module's answer type rather than the dispatcher's private one: same
- * status precedence (`.status` → `.statusCode` → validation ⇒ 400 → fallback),
- * same `details` assembly (`code`, `issues`, then `fields[]` last so
- * `VALIDATION_FAILED` wins for an error matched by `name` alone), same 5xx
- * sanitisation. No new envelope shape and no new code vocabulary: `code` is the
- * producer's own or is derived from the status by `buildApiError`.
+ * [#9106] No longer a restatement of `HttpDispatcher.errorFromThrown` — a
+ * DELEGATION to the same shared resolver that exit and the REST door call
+ * (`resolveThrownHttpError`, `@objectstack/types`): same status precedence
+ * (`.status` → `.statusCode` → validation ⇒ 400 → fallback), same `details`
+ * assembly (non-string `code` as context, `issues`, `fields[]`), and — the
+ * #9106 ruling — the same closed `error.code`: the resolver's narrowed `code`
+ * is what reaches the declared field, and a producer's unregistered spelling
+ * rides the wire's `declaredCode` sibling instead (presence means demotion).
+ * This matters HERE because a delegated pipeline runs tenant-authored hooks —
+ * the same author-thrown limb `domains/actions.ts` serves. The 5xx
+ * sanitisation stays this module's (a boundary property, not the throw's).
  */
 export function endpointErrorAnswer(e: any, fallbackStatus = 500): EndpointExecutionAnswer {
-    const validation = validationFailureDetails(e);
-    const status =
-        typeof e?.status === 'number' ? e.status
-        : typeof e?.statusCode === 'number' ? e.statusCode
-        : validation ? VALIDATION_FAILED_STATUS
-        : fallbackStatus;
-    const issues = Array.isArray(e?.issues) ? e.issues : undefined;
-    const details =
-        issues || e?.code || validation
-            ? {
-                ...(e?.code ? { code: e.code } : {}),
-                ...(issues ? { issues } : {}),
-                ...(validation ?? {}),
-            }
-            : undefined;
-    const message = sanitizeMessage(e?.message ?? String(e), status);
-    return apiErrorResponse({ message, httpStatus: status, details });
+    const thrown = resolveThrownHttpError(e, fallbackStatus);
+    const declaredCode = demotedDeclaredCode(thrown);
+    return apiErrorResponse({
+        message: sanitizeMessage(thrown.message, thrown.status),
+        httpStatus: thrown.status,
+        code: thrown.code,
+        details: thrown.details,
+        ...(declaredCode !== undefined ? { extra: { declaredCode } } : {}),
+    });
 }
 
 /** The 501 answer for a declaration this runtime cannot delegate. */

--- a/packages/runtime/src/error-envelope.conformance.test.ts
+++ b/packages/runtime/src/error-envelope.conformance.test.ts
@@ -75,6 +75,17 @@ function expectConformantError(response: { status: number; body: any } | undefin
     expect(body.error.details?.code).toBeUndefined();
     expect(body.error.details?.type).toBeUndefined();
 
+    // [#9106] `declaredCode` means demotion: when present it is a producer
+    // spelling the closed vocabulary does NOT contain — never a second copy of
+    // `code`, never a registered member. Asserted for every body so a branch
+    // that starts emitting it redundantly (two spellings of one fact on every
+    // refusal) fails here rather than shipping.
+    if (body.error.declaredCode !== undefined) {
+        expect(typeof body.error.declaredCode).toBe('string');
+        expect(body.error.declaredCode).not.toBe(body.error.code);
+        expect(ErrorCode.safeParse(body.error.declaredCode).success).toBe(false);
+    }
+
     return body.error;
 }
 
@@ -244,35 +255,25 @@ describe('#8087 — every code the dispatcher door can emit is parsed against Ap
     });
 
     for (const code of PENDING_AT_DISPATCHER_DOOR) {
-        it(`'${code}' reaches the wire verbatim, and ApiErrorSchema rejects it on \`code\` alone`, () => {
+        it(`'${code}' is DEMOTED off \`error.code\` until its ledger row lands (#9106)`, () => {
             const response = emitFor(code, 500);
 
-            // Verbatim — option B was ruled, so the door does NOT narrow. A
-            // failure here means someone quietly implemented option A.
-            expect(response.body.error.code).toBe(code);
+            // [#9106] The door narrows now (maintainer ruling 2026-08-16:
+            // `error.code` is a closed vocabulary at every door): the
+            // unregistered spelling rides the wire's `declaredCode`, and the
+            // closed slot takes the status-derived member. So an unswept
+            // producer's body PARSES — what it loses is its semantic code,
+            // silently absent from `error.code` until registration. That
+            // silent demotion is exactly why a pending-registration row is a
+            // debt the gate carries to the spec lane, not a curiosity.
+            expect(response.body.error.code).toBe(standardErrorCodeForHttpStatus(response.status));
+            expect(response.body.error.declaredCode).toBe(code);
 
-            // The body is STRUCTURALLY conformant — right envelope, status
-            // mirrored, `details` context only — so the one thing standing
-            // between it and its declared schema is the missing ledger row.
-            // That is precisely the claim handed to #8846.
-            expect(envelopeViolations(response.body)).toEqual([]);
-            expect(response.body.success).toBe(false);
-            expect(response.body.error.httpStatus).toBe(response.status);
-
-            const parsed = ApiErrorSchema.safeParse(response.body.error);
-            expect(parsed.success).toBe(false);
-            // Rejected on `code` and nothing else — an entry that failed for a
-            // second reason would be a different defect wearing this one's label.
-            expect([...new Set((parsed.error?.issues ?? []).map((i) => i.path.join('.')))]).toEqual(['code']);
-
-            // MEASURED while writing this: the damage is not confined to the
-            // nested error object. `BaseResponseSchema` embeds `ApiErrorSchema`,
-            // so the WHOLE response body fails to parse — one unregistered
-            // string invalidates the envelope every consumer validates against,
-            // for the same single reason and no other.
-            const envelope = BaseResponseSchema.safeParse(response.body);
-            expect(envelope.success).toBe(false);
-            expect([...new Set((envelope.error?.issues ?? []).map((i) => i.path.join('.')))]).toEqual(['error.code']);
+            // Fully conformant — right envelope, status mirrored, and the
+            // declared schema accepts it (`declaredCode` is a declared
+            // `ApiErrorSchema` field, the open author-authored channel).
+            const error = expectConformantError(response);
+            expect(error.declaredCode).toBe(code);
         });
     }
 
@@ -332,18 +333,25 @@ describe('#8087 — every code the dispatcher door can emit is parsed against Ap
         }
     });
 
-    it('records the sandbox limb as open rather than pretending the door is closed', () => {
+    it('demotes the sandbox limb to `declaredCode` — the door is closed WITHOUT dropping the author code (#9106)', () => {
         // `SandboxError` carries a metadata app's OWN `.code` across the QuickJS
         // boundary on purpose (#7867), and `domains/actions.ts` serves it through
-        // `errorFromThrown`. So this door's vocabulary has a limb authored by
-        // tenants at runtime, which no ledger can enumerate — the honest bound on
-        // what "closed" can mean here, and the reason the witness below is NOT
-        // re-spelled to a registered code.
+        // `errorFromThrown`. So this door's vocabulary had a limb authored by
+        // tenants at runtime, which no ledger can enumerate. The #9106 ruling
+        // (maintainer 2026-08-16) closed it by DEMOTION: the author's spelling
+        // rides `error.declaredCode` — the open, author-authored channel — and
+        // `error.code` takes the closed member the status derives. #7867's
+        // capability is preserved: the code still crosses the sandbox and still
+        // reaches the wire.
         const witness = SANDBOX_AUTHORED_LIMB.witness;
         expect(ErrorCode.safeParse(witness).success).toBe(false);
-        expect(emitFor(witness, 400).body.error.code).toBe(witness);
-        // It is deliberately absent from the registration hand-off: registering
-        // it would close nothing, since the next app picks a different string.
+        const response = emitFor(witness, 400);
+        const error = expectConformantError(response);
+        expect(error.code).toBe(standardErrorCodeForHttpStatus(400));
+        expect(error.declaredCode).toBe(witness);
+        // It stays absent from the registration hand-off (fenced off from
+        // #8846): registering one tenant spelling would close nothing, since
+        // the next app picks a different string.
         expect(PENDING_LEDGER_REGISTRATION).not.toContain(witness);
     });
 

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -3,7 +3,7 @@
 import {
     ObjectKernel, getEnv, evaluateAuthGate, isAuthGateAllowlisted,
 } from '@objectstack/core';
-import { isMcpServerEnabled, looksLikeInternalErrorLeak, INTERNAL_ERROR_MESSAGE, resolveThrownHttpError } from '@objectstack/types';
+import { isMcpServerEnabled, looksLikeInternalErrorLeak, INTERNAL_ERROR_MESSAGE, resolveThrownHttpError, demotedDeclaredCode } from '@objectstack/types';
 import { measureServerTiming, allowPerfDisclosure, isPerfDisclosurePrincipal } from '@objectstack/observability';
 import { CoreServiceName, serviceUnavailableMessage, inProcessServiceMessage } from '@objectstack/spec/system';
 import type { IDataEngine, IObjectQLEngine } from '@objectstack/spec/contracts';
@@ -711,13 +711,16 @@ export class HttpDispatcher {
      * delegates to has already answered the code question for both package
      * doors; every other call site still expresses its code the way it did (a
      * `details.code` to promote, or none at all and let the status derive one).
+     *
+     * [#9106] `extra` carries declared siblings of `code` (today only the
+     * demoted `declaredCode`); again only {@link errorFromThrown} passes it.
      */
-    private error(message: string, httpStatus: number = 500, details?: any, code?: string) {
+    private error(message: string, httpStatus: number = 500, details?: any, code?: string, extra?: Record<string, unknown>) {
         const safe =
             httpStatus >= 500 && looksLikeInternalErrorLeak(message)
                 ? INTERNAL_ERROR_MESSAGE
                 : message;
-        return apiErrorResponse({ message: safe, httpStatus, details, ...(code ? { code } : {}) });
+        return apiErrorResponse({ message: safe, httpStatus, details, ...(code ? { code } : {}), ...(extra ? { extra } : {}) });
     }
 
     /**
@@ -730,10 +733,10 @@ export class HttpDispatcher {
      * offending field. Falls back to `fallbackStatus` and behaves exactly like
      * `error()` for errors that carry neither.
      *
-     * [#3842] The error's own `.code` still travels as `details.code` from here,
-     * which is the carrier `buildApiError` promotes into `error.code` — so it
-     * ends up in the declared field without this method needing to know how the
-     * envelope is assembled.
+     * [#3842 → #9106] The error's own `.code` reaches the declared field only
+     * when the ledger knows it: the resolver's narrowed `code` is passed
+     * explicitly, and an unregistered spelling travels as the wire's
+     * `declaredCode` sibling instead (see the note inside the method).
      *
      * [#3918] A record-level `ValidationError` is the third structured shape,
      * and it used to fall through BOTH branches: it carries no `.status` (so a
@@ -760,21 +763,30 @@ export class HttpDispatcher {
      */
     private errorFromThrown(e: any, fallbackStatus = 500) {
         const thrown = resolveThrownHttpError(e, fallbackStatus);
-        // `declaredCode`, NOT the narrowed `code`: this door puts a producer's
-        // own string on the wire. The REST door takes the narrowed spelling
-        // because its own conformance suite parses its bodies against the
-        // ledger. Both spellings come from the one resolver, so the difference
-        // is a stated one; see its module note.
+        // [#9106] `code`, the NARROWED spelling — the same one the REST door
+        // has served since #8016, so the two doors now agree on `error.code`
+        // unconditionally (maintainer ruling 2026-08-16: `error.code` is a
+        // closed vocabulary at every door). A producer's unregistered spelling
+        // is not dropped: it rides the wire's `declaredCode`
+        // (`ApiErrorSchema.declaredCode`, the open author-authored channel),
+        // which is how a metadata app's own thrown code — the #7867 capability,
+        // measured as the tenant-authored limb no ledger can enumerate — still
+        // reaches the wire. Emitted only when the demote actually happened, so
+        // presence means demotion (see `demotedDeclaredCode`'s note).
         //
-        // [#8087] Ruled option B (maintainer, 2026-08-12): the verbatim spelling
-        // STAYS, and the set of producers emitting codes the ledger does not
-        // know is now measured and gated rather than named in a comment that
-        // rots — `./dispatcher-error-vocabulary.ts` carries the classified list
-        // and `pnpm check:dispatcher-error-vocabulary` fails on an unswept
-        // producer added later. `error-envelope.conformance.test.ts` drives
-        // every dispatcher-reachable member of that list through this method and
-        // parses the body, which is the "parse every body it emits" half.
-        return this.error(thrown.message, thrown.status, thrown.details, thrown.declaredCode);
+        // [#8087] The producer sweep is unchanged by this: platform producers
+        // must still register — `./dispatcher-error-vocabulary.ts` carries the
+        // classified list and `pnpm check:dispatcher-error-vocabulary` fails on
+        // an unswept producer, whose semantic code would otherwise silently
+        // demote off the wire. `error-envelope.conformance.test.ts` drives
+        // every dispatcher-reachable member of that list through this method
+        // and parses the body against `ApiErrorSchema`, which now PASSES for
+        // every body this door emits — the "parse every body it emits" half.
+        const declaredCode = demotedDeclaredCode(thrown);
+        return this.error(
+            thrown.message, thrown.status, thrown.details, thrown.code,
+            declaredCode !== undefined ? { declaredCode } : undefined,
+        );
     }
 
 

--- a/packages/runtime/src/package-door-error-parity.test.ts
+++ b/packages/runtime/src/package-door-error-parity.test.ts
@@ -29,10 +29,10 @@
  * `@objectstack/types`: `resolveThrownHttpError`. Each door is pinned to that
  * function from its own side, and the halves compose —
  *
- *   REST door  == resolveThrownHttpError.code          (packages/rest/src/package-routes-coded-error-mapping.test.ts)
- *   dispatcher == resolveThrownHttpError.declaredCode  (this file)
+ *   REST door  == resolveThrownHttpError.code  (packages/rest/src/package-routes-coded-error-mapping.test.ts)
+ *   dispatcher == resolveThrownHttpError.code  (this file; `.declaredCode` until #9106)
  *   status: the SAME field on both
- *   ⇒ same status always, same code for every registered code
+ *   ⇒ same status AND same code, always
  *
  * — with each half independently falsifiable: a door that grows a second
  * mapping of its own turns its own half red. Comparing to the shared rule is
@@ -40,10 +40,13 @@
  * about hand-written literals only ever agree about the shapes someone thought
  * to enumerate, which is how the divergence arose in the first place.
  *
- * The two code spellings are one function's two outputs, not two rules. They
- * differ only for a code outside `StandardErrorCode ∪ ERROR_CODE_LEDGER`, which
- * this door emits verbatim and the REST door cannot — that difference is
- * pinned explicitly at the bottom of this file, with the reason.
+ * [#9106] The two code spellings are one function's two outputs, not two
+ * rules — and since the 2026-08-16 ruling they no longer diverge on any wire's
+ * `error.code`: a code outside `StandardErrorCode ∪ ERROR_CODE_LEDGER` is
+ * DEMOTED at this door exactly as at the REST door, and the verbatim spelling
+ * rides the wire's `declaredCode` sibling instead (the open, author-authored
+ * channel `ApiErrorSchema` declares). The demote is pinned explicitly at the
+ * bottom of this file.
  *
  * ## What is deliberately NOT asserted: the message
  *
@@ -119,48 +122,50 @@ describe('#8016 — the dispatcher package door answers the shared mapping', () 
             expect(ApiErrorSchema.safeParse((response.body as any).error).success).toBe(true);
 
             expect({ status: response.status, code: (response.body as any).error.code })
-                .toEqual({ status: expected.status, code: expected.declaredCode ?? expected.code });
+                .toEqual({ status: expected.status, code: expected.code });
+            // Every shape here carries a REGISTERED code (or none) — no demote,
+            // so no `declaredCode` sibling appears (#9106: presence means
+            // demotion).
+            expect((response.body as any).error.declaredCode).toBeUndefined();
         });
     }
 
     /**
-     * The one place the two doors' codes differ, pinned so it stays a stated
-     * difference rather than a drift.
+     * The place the two doors' codes USED to differ — now the pin on the
+     * demote that removed the difference (#9106, maintainer ruling
+     * 2026-08-16: `error.code` is a closed vocabulary at every door).
      *
-     * This door puts a producer's code on the wire verbatim. The REST door
-     * cannot: `@objectstack/types`' `sendError` takes the closed `ErrorCode`,
-     * and that door's conformance suite parses its bodies against the ledger, so
-     * an unregistered code there is a failing test rather than a wire answer.
+     * An unregistered code cannot reach `error.code` through either door: the
+     * REST door's `sendError` takes the closed `ErrorCode`, and this door now
+     * serves the resolver's narrowed `code` too. The producer's verbatim
+     * spelling is not dropped — it rides the wire's `declaredCode` sibling,
+     * the open author-authored channel `ApiErrorSchema` declares, which is how
+     * the #7867 sandbox passthrough capability survives the closure (a
+     * metadata app's own thrown code still reaches the wire).
      *
-     * The STATUS agrees either way, which is what #8016 was about.
-     *
-     * [#8087] The three codes this comment used to name are no longer one list.
-     * The maintainer ruled option B — keep the verbatim spelling, and make the
-     * set of unregistered producers a MEASURED, gated one instead of a
-     * hand-maintained sentence that goes stale (this one had):
-     *
-     *   - `FLOW_FAILED` has a real producer and is awaiting a ledger entry
-     *     (#8846); it stays verbatim, which is the whole point of option B.
-     *   - `STORAGE_FAILURE` had no producer anywhere — two fixtures invented it
-     *     — so it was collapsed to a registered code rather than registered.
-     *   - `DUPLICATE` is AUTHOR-thrown: it crosses the sandbox boundary from a
-     *     metadata app's own action code, so no ledger can enumerate it.
-     *
-     * `packages/runtime/src/dispatcher-error-vocabulary.ts` is the live list and
-     * `pnpm check:dispatcher-error-vocabulary` keeps it honest. The vehicle
-     * below stays a deliberately unregistered string, because what this case
-     * pins is the SPELLING DIFFERENCE, not any particular producer.
+     * History: #8087 first ruled the verbatim spelling stays and gated the
+     * producer set (`dispatcher-error-vocabulary.ts`,
+     * `pnpm check:dispatcher-error-vocabulary`); #8846 registered every
+     * platform producer the gate found; #9106 then ruled the remaining,
+     * unregisterable TENANT-AUTHORED limb demoted — completing the closure.
+     * The vehicle below stays a deliberately unregistered string, because what
+     * this case pins is the DEMOTE, not any particular producer.
      */
-    it('an unregistered code reaches this door verbatim, and the narrowed spelling differs', () => {
+    it('an unregistered code is demoted: the narrowed spelling in `error.code`, the verbatim one in `declaredCode`', () => {
         const error = thrown('dialect', { status: 409, code: 'PACKAGE_IS_HAUNTED' });
         const resolved = resolveThrownHttpError(error, 500);
         const response = errorFromThrown(error, 500);
 
         expect(resolved.declaredCode).toBe('PACKAGE_IS_HAUNTED');
         expect(resolved.code).toBe('RESOURCE_CONFLICT');
-        expect((response.body as any).error.code).toBe('PACKAGE_IS_HAUNTED');
+        expect((response.body as any).error.code).toBe('RESOURCE_CONFLICT');
+        expect((response.body as any).error.declaredCode).toBe('PACKAGE_IS_HAUNTED');
         // The half that must never differ.
         expect(response.status).toBe(resolved.status);
+        // And the demoted body satisfies its declared schema — the property an
+        // unregistered code could never have before #9106.
+        expect(ApiErrorSchema.safeParse((response.body as any).error).success).toBe(true);
+        expect(envelopeViolations(response.body)).toEqual([]);
     });
 
     it('the shapes really do produce different answers', () => {

--- a/packages/runtime/src/package-door-error-parity.test.ts
+++ b/packages/runtime/src/package-door-error-parity.test.ts
@@ -174,9 +174,11 @@ describe('#8016 — the dispatcher package door answers the shared mapping', () 
      *     passed through verbatim, and out of #9106's ruled scope (which named
      *     the actions door and the resolver both doors above share). That path
      *     puts `code` at the body's TOP level rather than in `error.code`, so
-     *     it is not the field this ruling closed, and its envelope position is
-     *     an open finding of its own (#7035).
-     *     `check:dispatcher-error-vocabulary` is what keeps it honest meanwhile.
+     *     it is not the field this ruling closed. Filed as #9232 rather than
+     *     fixed here; `check:dispatcher-error-vocabulary` sweeps its platform
+     *     producers meanwhile. ⚠️ #9098's note pointed at #7035 for the
+     *     envelope-position half — that card is CLOSED (PR #7293, three /meta
+     *     501 handlers), so #9232 is the live one to read.
      *
      * History: #8087 first ruled the verbatim spelling stays and gated the
      * producer set (`dispatcher-error-vocabulary.ts`,

--- a/packages/spec/authorable-surface/api.json
+++ b/packages/spec/authorable-surface/api.json
@@ -131,6 +131,7 @@
     "api/ApiEndpoint:type",
     "api/ApiError:category",
     "api/ApiError:code",
+    "api/ApiError:declaredCode",
     "api/ApiError:details",
     "api/ApiError:httpStatus",
     "api/ApiError:message",

--- a/packages/spec/src/api/contract.zod.ts
+++ b/packages/spec/src/api/contract.zod.ts
@@ -24,6 +24,27 @@ export const ApiErrorSchema = lazySchema(() => z.object({
    * which is that union as a single parse.
    */
   code: ErrorCode.describe('Error code (e.g. VALIDATION_ERROR; StandardErrorCode ∪ the ledger the serving side registers — ERROR_CODE_LEDGER for framework packages)'),
+  /**
+   * The producer's own code, verbatim, when it is NOT a member of the closed
+   * `code` vocabulary above — the open, author-authored channel (#9106,
+   * ADR-0112 amendment 2026-08-17).
+   *
+   * `code` is closed at every door: a thrown code outside `StandardErrorCode ∪
+   * <the serving side's ledger>` is DEMOTED here, and `code` carries the
+   * member the HTTP status derives instead (`resolveThrownHttpError` in
+   * `@objectstack/types` is the one rule both doors read). This is how a
+   * metadata app's own `throw Object.assign(new Error(msg), { code })` still
+   * reaches the wire — #7867's capability, preserved — without opening the
+   * closed set consumers branch on exhaustively: platform conditions are
+   * matched on `code`; app-specific spellings ride here.
+   *
+   * ABSENT whenever the producer's code IS a vocabulary member (it is already
+   * in `code`, and repeating it would make every registered refusal carry two
+   * spellings of one fact) and whenever the producer declared none. Presence
+   * therefore MEANS demotion: a consumer that sees this field knows the
+   * producer spelled a code the serving side's ledger does not know.
+   */
+  declaredCode: z.string().optional().describe('The producer-declared code, verbatim, when it is not a member of the closed `code` vocabulary — the open, author-authored channel (app-specific spellings; ADR-0112, #9106)'),
   message: z.string().describe('Readable error message'),
   category: z.string().optional().describe('Error category (e.g. validation, authorization)'),
   /**

--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -76,15 +76,19 @@
  * change DEFERRED by the #8211 adjudication (option B) until a specific code
  * has a measured victim.
  *
- * One rule, two doors (#8087): registration here is the ADMISSION door — what
- * the vocabulary may contain. The DISPATCHER door is ruled (#8087, option
- * B-as-a-gate, maintainer 2026-08-12) to parse every body it emits against the
- * closed vocabulary; until that gate lands, `resolveThrownHttpError`
- * (`@objectstack/types`, PR #8088) carries `code` (narrowed) / `declaredCode`
- * (verbatim) across the gap. Both doors state the same rule: a code either IS
- * the standard member for its condition, or it is registered here — and if it
- * merely re-spells a standard member, that registration is a recorded waiver,
- * never drift.
+ * One rule, two doors (#8087, completed by #9106): registration here is the
+ * ADMISSION door — what the vocabulary may contain. The DISPATCHER door is
+ * gated (#8087, option B-as-a-gate, maintainer 2026-08-12:
+ * `check:dispatcher-error-vocabulary` sweeps its producers) and, since the
+ * #9106 ruling (maintainer 2026-08-16), NARROWS exactly as the REST door
+ * always has: `resolveThrownHttpError` (`@objectstack/types`) answers `code`
+ * (a member of this union) for `error.code` at BOTH doors, and a producer's
+ * unregistered spelling is demoted to the wire's `declaredCode` — the open,
+ * author-authored channel `ApiErrorSchema` declares for it. Both doors state
+ * the same rule: a code either IS the standard member for its condition, or it
+ * is registered here — and if it merely re-spells a standard member, that
+ * registration is a recorded waiver, never drift. A code registered NOWHERE
+ * (a tenant app's own spelling) still reaches the wire, in `declaredCode`.
  *
  * A code emitted by several packages is listed once per emitting package —
  * the union dedupes; the per-package rows are provenance, not identity.

--- a/packages/types/src/thrown-http-error.ts
+++ b/packages/types/src/thrown-http-error.ts
@@ -42,23 +42,33 @@
  * unregistered code there is a failing test, not a wire answer.
  *
  * {@link ThrownHttpError.declaredCode} is the producer's own string, verbatim
- * and un-narrowed, which is what the dispatcher door has always put on the
- * wire.
+ * and un-narrowed. Until #9106 it was what the dispatcher door put in
+ * `error.code`; since the #9106 ruling it is what BOTH doors surface as the
+ * wire's `declaredCode` when it is not a vocabulary member (see below).
  *
- * [#8087] That contract question — should the dispatcher's `error.code` be
- * closed too? — has since been ruled: **option B**, keep the verbatim spelling
- * and register the producers, delivered as a GATE rather than a one-time sweep
- * (maintainer, 2026-08-12). So `declaredCode` stays exactly as it is; what
- * changed is that the unregistered producers are now measured and classified
+ * [#8087] The first ruling on that gap (maintainer, 2026-08-12) kept the
+ * dispatcher's verbatim spelling and delivered a GATE — the unregistered
+ * producers are measured and classified
  * (`packages/runtime/src/dispatcher-error-vocabulary.ts`,
- * `pnpm check:dispatcher-error-vocabulary`) instead of being named in prose
- * here. Narrowing this spelling would be option A, which was NOT ruled.
+ * `pnpm check:dispatcher-error-vocabulary`) instead of named in prose here.
+ * The gate's own first derivation then measured the limb no registration can
+ * close: a metadata app's action code crosses the sandbox boundary carrying
+ * the app's OWN `.code` (#7867), authored by tenants at runtime.
  *
- * So the doors agree on **status** unconditionally and on **code** for every
- * registered code, and differ only where a producer emits a code the ledger
- * does not know — a case that is already a contract violation on either door.
- * Both answers come from ONE function, which is what keeps that difference a
- * documented one rather than a drift.
+ * [#9106] That limb was ruled (maintainer, 2026-08-16): **`error.code` is a
+ * closed vocabulary at every door.** The dispatcher door now takes
+ * {@link ThrownHttpError.code} — the demote this resolver has always computed,
+ * and the REST door's spelling since #8016 — and a producer's unregistered
+ * string rides the wire's `declaredCode` (declared on `ApiErrorSchema`)
+ * instead of `error.code`. #7867's capability is preserved: the author's code
+ * still crosses the sandbox and still reaches the wire — in the open,
+ * author-authored channel, not the closed one. Use
+ * {@link demotedDeclaredCode} to read the spelling a boundary should surface
+ * beside the closed `code`.
+ *
+ * So the doors agree on **status** and on **code** unconditionally now — both
+ * answers come from ONE function, which is what keeps agreement a construction
+ * rather than two suites agreeing about literals.
  *
  * ## What this deliberately does NOT decide
  *
@@ -117,8 +127,10 @@ export interface ThrownHttpError {
   code: ErrorCode;
   /**
    * The producer's own code, verbatim and un-narrowed, or `undefined` when it
-   * declared none. For the dispatcher door, whose `error.code` is not closed in
-   * practice. See the module note on why there are two.
+   * declared none. Never for `error.code` — that slot takes {@link code} at
+   * every door (#9106) — but for the wire's `declaredCode` channel when the
+   * spelling is not a vocabulary member ({@link demotedDeclaredCode}). See the
+   * module note on why there are two.
    */
   declaredCode?: string;
   /** The thrown message, UNSANITISED — see the module note on disclosure. */
@@ -196,4 +208,23 @@ export function resolveThrownHttpError(error: unknown, fallbackStatus = 500): Th
     message: typeof e?.message === 'string' ? e.message : String(error),
     ...(Object.keys(details).length > 0 ? { details } : {}),
   };
+}
+
+/**
+ * The producer's spelling a boundary should surface as the wire's
+ * `declaredCode` beside the closed `code` — or `undefined` when there is
+ * nothing to surface (#9106).
+ *
+ * Present exactly when the throw spelled a code that did NOT survive into
+ * {@link ThrownHttpError.code} — i.e. the demote happened. A registered code
+ * is already in `code`, so emitting it again would put two spellings of one
+ * fact on every refusal; a throw with no code has nothing to declare. Spelled
+ * once here rather than as three `!==` comparisons at three exits, so
+ * "presence means demotion" (`ApiErrorSchema.declaredCode`'s documented
+ * semantics) has one definition.
+ */
+export function demotedDeclaredCode(thrown: ThrownHttpError): string | undefined {
+  return thrown.declaredCode !== undefined && thrown.declaredCode !== thrown.code
+    ? thrown.declaredCode
+    : undefined;
 }

--- a/scripts/adr-anchors/packages__types__src__thrown-http-error.ts.json
+++ b/scripts/adr-anchors/packages__types__src__thrown-http-error.ts.json
@@ -1,0 +1,7 @@
+{
+  "file": "packages/types/src/thrown-http-error.ts",
+  "adrs": [
+    "ADR-0112"
+  ],
+  "invariant": "This is the ONE definition of how a thrown error becomes an HTTP answer, and the two spellings it returns are not a redundancy to tidy away. ADR-0112 makes `error.code` a CLOSED vocabulary (`StandardErrorCode` union the registered ledger), and the 2026-08-16 ruling on #9106 extended that from the REST package door to every door this function serves: `code` is always a union member — a throw whose `.code` is unregistered falls to the member the status derives — while `declaredCode` keeps the producer's verbatim string. `demotedDeclaredCode()` is the single rule for which spelling a boundary surfaces beside the closed one, and it answers `undefined` for a registered code on purpose: emitting both would put two spellings of one fact on every refusal, and `ApiErrorSchema.declaredCode`'s documented semantics are that PRESENCE MEANS DEMOTION. Do not 'simplify' a boundary by writing `thrown.declaredCode` into `error.code` — that is the pre-#9106 dispatcher behaviour, and it re-opens the tenant-authored limb #9106 closed: a metadata app's action code crosses the QuickJS sandbox carrying the app's own `.code` (#7867, a capability deliberately granted and preserved), so `error.code` would again carry strings authored by tenants at runtime, which no ledger can enumerate and no gate can sweep. The author's spelling is not dropped — it rides the wire's open `declaredCode` channel instead."
+}

--- a/scripts/check-dispatcher-error-vocabulary.mjs
+++ b/scripts/check-dispatcher-error-vocabulary.mjs
@@ -16,10 +16,15 @@
  * fails CI. That friction is the point."
  *
  * The dispatcher door had no such friction. `HttpDispatcher.errorFromThrown`
- * puts `resolveThrownHttpError(e).declaredCode` — the producer's own string,
+ * put `resolveThrownHttpError(e).declaredCode` — the producer's own string,
  * un-narrowed — into `error.code`, and its conformance suite parsed only the
  * handful of cases it drove. Three suites pinned bodies `ApiErrorSchema` would
- * reject and CI stayed green.
+ * reject and CI stayed green. Since #9106 the door NARROWS (`error.code` takes
+ * the resolver's closed `code`; an unregistered spelling rides the wire's
+ * `declaredCode`), so the failure this gate catches changed shape without
+ * getting smaller: an unswept producer's semantic code no longer breaks the
+ * schema — it silently DEMOTES off `error.code` until registered, which is
+ * still a real emitter hiding, and still this gate's job to report.
  *
  * The maintainer ruling of 2026-08-12 chose option B **delivered as a gate**:
  * parse every body the door emits, then register what the gate reports. This is
@@ -74,7 +79,8 @@
  *     dropped: a deriver that goes quietly blind is the same failure one layer
  *     down.
  *   - The sandbox limb is OUT of this scan's reach by construction — a metadata
- *     app's action code is authored at runtime, not in this repo. See
+ *     app's action code is authored at runtime, not in this repo. Ruled by
+ *     #9106: demoted to the wire's `declaredCode` at the door. See
  *     `SANDBOX_AUTHORED_LIMB` in the declaration file.
  */
 


### PR DESCRIPTION
Part of #9106

⚠️ **`Part of`, not `Fixes`, by PM ruling** (superseding the dispatch prompt, which had specified `Fixes #9106`). The ruling on #9106 names the **ADR-0112 prose** as the deliverable that matters most, and that prose is in **#9233**, behind a human-approval gate. If this PR carried the closing keyword, the card would auto-close the moment the code landed while half its ruling sat unmerged — the exact silent half-delivered state #9106 exists to prevent. **#9233 carries the closing keyword instead**, so #9106 closes only when both halves are in.

Implements the maintainer ruling of 2026-08-16: **`error.code` is a closed vocabulary at every door.** An author-thrown code that is not an `ErrorCode` member is **demoted** to the wire's `declaredCode` at the dispatcher exits, mirroring what `resolveThrownHttpError` already computed for the REST package door — and #7867's capability is preserved: the author's code still crosses the sandbox and still reaches the wire, in the open channel instead of the closed one.

## The two binding items from the ruling

**1. The binding precondition — measured, empty, search proven.** No existing consumer of the actions door branches on author-authored strings in `error.code`. Method and full classification are on the issue; the load-bearing parts, re-run independently at this head:

- The closed union was extracted from the **built** spec (288 members — the same count `check:dispatcher-error-vocabulary` reports), not from a hand list.
- **Widened literal scan**, not a comparison-shape scan: every SCREAMING_SNAKE string literal across `packages/client`, `client-react`, `examples`, `packages/qa`, the objectui checkout and the hand-written docs — 480 distinct literals, 409 outside the union. The widening is the point: objectui branches through a helper (`errorCodeIs`), which an `x.code === 'LIT'` scan cannot see.
- **Proof-of-search before believing the empty result:** the scan finds the known-present out-of-vocabulary literals (`ANALYTICS_NOT_INSTALLED`, `DEV_ENV_PLAN_LOCKED`) and it sees the helper-mediated `ATTACHMENT_DOWNLOAD_DENIED` branch that a comparison-shape scan misses.
- **Every helper-mediated branch code enumerated:** 12 distinct codes reach `errorCodeIs` / `errorCodeIsAnyOf`; 11 are closed-union members. The twelfth, `INVALID_PAYLOAD`, has **zero producers anywhere in this repo** and rides an OR with the registered `INVALID_METADATA` plus a `status === 422` test — nothing demotes, and the affordance cannot be lost.
- **The actions door specifically:** `objectui/packages/core/src/actions/actionResponse.ts` is, by its own docblock, "the ONE place a `POST /api/v1/actions/...` response is interpreted", and it resolves failures through `actionErrorDetail`, which reads `error` / `error.message` / `message` and **never** `code`.
- Zero branches on `DUPLICATE` anywhere.
- **Named residual:** `objectstack-ai/cloud` is not reachable from this session (I attempted to attach it; access denied). Evidence it is unaffected is unchanged: cloud's consumer-branched entitlement codes ride its own control-plane sender, not this repo's dispatcher exits.

**2. ADR-0112 text — drafted, in its own PR, awaiting maintainer merge.** Prime Directive #14 keeps `docs/adr/**` off this PR: the amendment is **#9233** on `claude/issue-9106-adr-0112-closed-everywhere`. It states the closure holds everywhere, names `declaredCode` as the open author-authored channel, pins "presence means demotion" as its semantics, records that #7867 is preserved rather than retired, names where the rule is pinned, and fences `DUPLICATE` off from the ledger. ⛔ **This PR can land without it — but the card stays open until it lands, which is what the `Part of` above buys.**

## Review notes on the inherited commit

The implementation commit was written by a previous session that died mid-verification, so nothing in it had passing evidence behind it. Reviewed as a stranger's PR; it held up, with these corrections:

- **Merge conflict with #9098 resolved semantically, both intents stacked.** #9098 landed a correction saying `packages/rest` has a second, `error: any` responder and that thrown errors there are "NOT narrowed, deliberately and symmetrically with this door". The branch's rewrite had dropped that paragraph and re-asserted the claim #9098 had just falsified. The merged text keeps #9098's correction, scopes "either door" to the two this resolver actually serves, and states the flat-dialect path per path.
- **#7035 is no longer open** (landed via PR #7293, three `/meta` 501 handlers) — #9098's prose cites it as the live envelope card. Corrected here and in the ADR; the real remaining question is filed as **#9232**.
- **ADR anchor added** (PD#13) for `packages/types/src/thrown-http-error.ts`, the definition site of both spellings.
- **Vacuity noted, not papered over:** the rewritten assertions inside the `for (const code of PENDING_AT_DISPATCHER_DOOR)` loop in `error-envelope.conformance.test.ts` currently generate **zero tests** — that list is empty post-#8846. The demote's real coverage is the three cases named below, each independently falsified.

## Verification

Everything below at **`c6255040e`**, after `git merge origin/main` (which had moved substantially) plus the deferred regeneration.

| What | Result |
|---|---|
| `pnpm --filter @objectstack/runtime test` | 165 files, **2463 passed** |
| `pnpm --filter @objectstack/types test` | 12 files, **348 passed** |
| `pnpm --filter @objectstack/spec test` | 407 files, **10834 passed** |
| `pnpm --filter @objectstack/rest test` | 122 files, **2011 passed** |
| `typecheck` (types, runtime) | clean |
| `pnpm --filter @objectstack/spec check:generated` | **13 of 13** artifacts up to date |
| `check:dispatcher-error-vocabulary` | OK — 7 sites, all classified, 0 awaiting a ledger entry |
| `check:type-check-debt --re-measure` | OK — 33 entries, none above its recorded number |

**Reverse verification — direction predicted before running, and observed: red.** With the demote ablated in `errorFromThrown` (the pre-ruling `thrown.declaredCode` straight into `error.code`), exactly three cases fail: the actions-door `DUPLICATE` witness, the sandbox-limb conformance case, and the package-door demote pin. Restored from the committed branch state, tree verified clean, and the gate union re-run afterwards.

**Gate union derived from the real changed paths** (`node scripts/pm/dispatch-gates.mjs`), not from memory — the derivation added `check:query-options-erasure`, `check:where-matcher`, `check:engine-double-contract`, `check:type-check-debt` (convention-triggered by the touched test files) and the changeset family. All run, all green. `check:type-check-debt` is the gate that refuses on an unbuilt closure — the workspace was built exactly as `lint.yml` does (`turbo run build --filter=./packages/* --filter=./packages/*/*`) before it.

## What honours the ruling's fences

- **`DUPLICATE` is re-homed, NOT registered.** It stays absent from `ERROR_CODE_LEDGER` and from the `PENDING_LEDGER_REGISTRATION` hand-off (asserted), fenced off from #8846. Registering one tenant spelling closes nothing — the next app picks a different string.
- **#7867's capability is preserved.** The author's code crosses the sandbox and reaches the wire; only its slot changed. The actions-door test pins exactly that end to end.
- **Presence means demotion.** `declaredCode` is emitted only when the demote actually happened — never as a second copy of a registered `code`. `demotedDeclaredCode()` is the single definition, and the conformance suite asserts the property for *every* body the door emits.

## Model-tier substitution — recorded, not silent

The card and its triage comment mandate **`model: claude-fable-5`** for this work under the standing tiering clause (wire-contract behaviour change). **That tier's quota is exhausted, and the maintainer explicitly approved finishing on opus instead.** The tiering rule was **waived by an explicit maintainer decision** for this card — it was not overlooked, and this note exists so a future reader can see which of the two it was.

## Out of scope, filed not fixed

- **#9232** — `packages/rest`'s flat `sendThrownError` still passes a thrown `code` through un-narrowed. Left alone deliberately: that file is #9098's surface, the field is the body's top-level `code` rather than `error.code`, and #9098's own note calls narrowing it a separate public-contract decision. Going to the maintainer, not carved into the invariant here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_
