### PR TITLE
fix(spec): enforce the list-comparand rule at the shared compile face, so a scalar in/nin cannot reach a driver

### DIFF
--- a/.changeset/list-comparand-shape-door.md
+++ b/.changeset/list-comparand-shape-door.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/spec": patch
+"@objectstack/objectql": patch
+---
+
+fix(spec): enforce the list-comparand rule at the shared compile face, so a scalar `in`/`nin` no longer reaches a driver (#9228)
+
+<!-- adr-0087: not-required (no-migration-prescription) No authorable key is
+added, renamed, retired or tombstoned. The change moves an existing runtime rule
+from `@objectstack/objectql` to `@objectstack/spec` and calls it from
+`parseFilterAST`; the authorable metadata surface is byte-identical. -->
+
+`FieldOperatorsSchema` has always declared `$in` / `$nin` as `z.array(z.any())`
+and `$between` as `z.tuple([min, max])`, and #5869 / PR #6209 built the gate that
+enforces it — but only at `@objectstack/objectql`'s lowering seam. That covers
+every query reaching a driver **through the engine** and nothing else. A caller
+that lowers a filter with `parseFilterAST` and calls a driver directly — an
+embedder, and this repo's own driver conformance suites — met no gate at all:
+`parseFilterAST([['name', 'notin', 'alpha']])` returned `{ name: { $nin:
+'alpha' } }`, a shape the contract forbids, and handed it over.
+
+That path was carried by mingo's own coercion of a non-array `$in`/`$nin`
+operand. mingo 7.2.3 removed the coercion, so from 7.2.4 on the same input
+escapes as an unhandled third-party `TypeError: b.filter is not a function` —
+no `code`, no `status`, no field name — straight to the caller. It is the sole
+failure blocking the `mingo` 7.2.2 -> 7.2.4 bump.
+
+**Fixed at the shared face, with exactly one implementation.** The rule now
+lives in `@objectstack/spec`'s `data/filter-comparand-shape.ts`, the same place
+the comparand-TYPE door (#7872 / PR #8234) was promoted to for the same reason
+("enforced once at the shared compile face for all five drivers"), and
+`parseFilterAST` runs it on everything it returns — shape first, then type, the
+order the engine's own seam already applied. `@objectstack/objectql`'s
+`assertListComparandShapes` is now a delegating wrapper whose only remaining job
+is the engine's `find('deal'): ` caller prefix; no driver was patched (both
+driver families are under the #5499 investment freeze).
+
+**The accept/reject delta is narrow and one-directional.** Newly refused, with
+the ADR-0112 `INVALID_FILTER` / 400 envelope: a non-array `$in` / `$nin`
+comparand and a non-`[min, max]` `$between` comparand, reaching a driver via a
+direct `parseFilterAST` call. Nothing else changes — every filter the engine
+accepted still lowers byte-identically, `$in: []` / `$nin: []` remain legitimate
+declared predicates, list MEMBER types stay unjudged here, and a field spec with
+no `$` key is still not descended into. The same inputs were already refused
+with the same envelope on every engine verb and at the REST ingress, so no
+authored metadata in the repo or in `objectui` produces a shape that newly
+fails: a survey of `examples/**`, `content/docs/**`, fixtures, seeded platform
+objects and objectui's view definitions found every membership rule already
+carrying an array.
+
+`parseFilterAST` gains an optional second argument, `context` — the caller
+prefix both doors in `@objectstack/spec` already take. It is additive and
+defaulted; existing calls are unaffected.

--- a/packages/drivers/driver-memory/src/memory-filter-ast-vocabulary.test.ts
+++ b/packages/drivers/driver-memory/src/memory-filter-ast-vocabulary.test.ts
@@ -77,10 +77,36 @@ describe('InMemoryDriver filter vocabulary ↔ VALID_AST_OPERATORS', () => {
     expect(VALID_AST_OPERATORS.size).toBeGreaterThan(0);
   });
 
+  /**
+   * [#9228] Which `$` operator an authoring spelling lowers to, derived by
+   * LOWERING one rather than by hand.
+   *
+   * `valueFor` used to name the membership spellings in a literal list, and it
+   * named three of the four: `notin` (and, had it been in the vocabulary, any
+   * later spelling) fell through to the scalar default. That handed the driver
+   * `{ name: { $nin: 'alpha' } }` — a shape the declared contract forbids —
+   * which mingo silently coerced until 7.2.3 and answers with a raw
+   * `TypeError: b.filter is not a function` from 7.2.4 on. The accident was
+   * load-bearing: it was the one probe covering the shape hole #9228 closed.
+   * Deriving the value from the spec's own lowering closes the CLASS instead of
+   * the instance — a membership spelling added to `AST_OPERATOR_MAP` tomorrow
+   * gets a list here without anyone remembering to edit this line.
+   *
+   * The probe uses a two-element array, which is legal for all three list
+   * operators, so it never trips the shape door it is used to satisfy.
+   */
+  const loweredOperatorOf = (op: string): string | undefined => {
+    const lowered = parseFilterAST([['probe', op, ['a', 'b']]]) as Record<string, unknown> | undefined;
+    const spec = lowered?.probe;
+    if (spec === null || typeof spec !== 'object' || Array.isArray(spec)) return undefined;
+    return Object.keys(spec).find((key) => key.startsWith('$'));
+  };
+
   /** A representative value per operator, so each one is actually exercised. */
   const valueFor = (op: string): unknown => {
-    if (op === 'in' || op === 'nin' || op === 'not_in') return ['alpha'];
-    if (op === 'between') return [0, 100];
+    const lowered = loweredOperatorOf(op);
+    if (lowered === '$in' || lowered === '$nin') return ['alpha'];
+    if (lowered === '$between') return [0, 100];
     if (/null|empty/.test(op)) return true;
     if (/contains|like|startswith|starts_with|endswith|ends_with/.test(op)) return 'alp';
     return 'alpha';
@@ -140,6 +166,29 @@ describe('InMemoryDriver filter vocabulary ↔ VALID_AST_OPERATORS', () => {
     expect(err.status).toBe(400);
     expect(err.message).toContain('[min, max]');
   });
+
+  it.each([['in'], ['nin'], ['not_in'], ['notin']])(
+    '[#9228] refuses a scalar comparand on %s instead of letting it reach mingo',
+    async (op) => {
+      // The escape this card closed. `valueFor` above hands every membership
+      // spelling a list now, so nothing in this suite produces the shape any
+      // more — which is exactly why it is pinned HERE, deliberately, rather
+      // than left to the accident that used to cover it.
+      //
+      // Before #9228 the shape reached `Query.compile` and answered two ways
+      // depending on a transitive dependency's minor version: mingo <= 7.2.2
+      // coerced it and returned rows; mingo >= 7.2.3 threw
+      // `TypeError: b.filter is not a function` — no `code`, no `status`, no
+      // field name — which is why BOTH envelope halves are asserted and not
+      // just "it throws". A bare `toThrow()` here passed on 7.2.4 while the
+      // defect was wide open.
+      const err = await refusalOf(() => findAuthored([['name', op, 'alpha']]));
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.status).toBe(400);
+      expect(err.message).toContain('requires an ARRAY');
+      expect(err.message).toContain('name');
+    },
+  );
 
   it('still honours a well-formed logical node', async () => {
     const rows = await findAuthored(['or', ['name', '=', 'alpha'], ['name', '=', 'beta']]);

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -722,7 +722,13 @@ function lowerWhereFilterArray<T extends object | undefined>(
   }
 
   // (2) The declared path.
-  const condition = parseFilterAST(where);
+  // [#9228] The context prefix is passed because `parseFilterAST` now runs the
+  // #5869 shape gate itself, one step before this branch could: a scalar `$nin`
+  // is refused DURING lowering. Handing it `${operation}('${object}')` is what
+  // keeps this branch's pinned `find('deal'): ` prefix on that refusal — and on
+  // the #7872 type door's, which `parseFilterAST` has always run and which used
+  // to answer this branch unprefixed.
+  const condition = parseFilterAST(where, `${operation}('${object}')`);
   if (condition === undefined) {
     // Unreachable by construction — `isFilterAST` accepted the shape, so
     // `parseFilterAST` has a lowering for it. Loud rather than silent because
@@ -734,11 +740,14 @@ function lowerWhereFilterArray<T extends object | undefined>(
       `unfiltered (#5158).`,
     );
   }
-  // [#5869] Door 2's half of the same check. `isFilterAST` vouched for the
-  // OPERATOR and `parseFilterAST` lowered it, but neither looks at the
-  // comparand — `['status', 'not_in', 'done']` lowers to `{status: {$nin:
-  // 'done'}}` and a scalar `$nin` is what reached the driver as a 500.
-  assertListComparandShapes(object, operation, condition);
+  // [#5869] Door 2's half of the same check USED to be a second
+  // `assertListComparandShapes(object, operation, condition)` call here.
+  // [#9228] moved the rule into `parseFilterAST` itself, which this branch
+  // calls three lines up with the same context — so the call became provably
+  // unreachable (nothing between the two can introduce a list operator) and is
+  // deleted rather than kept as a gate that reads live and never fires. The
+  // OBJECT branch above keeps its call: that `where` never passes
+  // `parseFilterAST` at all, which is the whole reason both branches exist.
   // [#8296] Same door as the object branch above, on the LOWERED condition —
   // the array sugar (`[['is_open','=',true]]`) names fields too, and a gate on
   // one branch would answer one mistake two ways depending on the spelling.

--- a/packages/objectql/src/filter-comparand-shape.ts
+++ b/packages/objectql/src/filter-comparand-shape.ts
@@ -1,100 +1,48 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * [#5869] The comparand-shape gate for the LIST-SHAPED filter operators, at the
- * engine's single filter collection point.
+ * [#5869] The engine's binding of the comparand-SHAPE gate for the LIST-SHAPED
+ * filter operators, at its single filter collection point — plus the
+ * unmaterializable-FIELD gate (#8296) that answers a different question about
+ * the same predicate.
  *
- * `FieldOperatorsSchema` (`spec/data/filter.zod.ts`) declares three operators
- * whose comparand is a LIST rather than a scalar:
+ * ## The shape rule itself has moved (#9228) — this file only binds it
  *
- * ```
- * $in:      z.array(z.any())
- * $nin:     z.array(z.any())
- * $between: z.tuple([min, max])
- * ```
+ * `assertListComparandShapes` below is a DELEGATING WRAPPER. The rule "a list
+ * operator takes a list" has exactly one implementation, and it is
+ * `@objectstack/spec/data`'s `filter-comparand-shape.ts`, whose module note
+ * carries the divergence table, the #5499 freeze argument and the
+ * deliberately-not-refused list. Read that file for the rule; read this
+ * function for the engine's two call sites and its wording contract.
  *
- * Nothing enforced that declaration on the way in. `isFilterAST` checks the
- * OPERATOR and the tuple's arity, never the comparand's shape, and
- * `parseFilterAST` lowers `['status', 'not_in', 'done']` to
- * `{ status: { $nin: 'done' } }` without complaint — so a scalar reached the
- * driver, where each backend answered differently:
+ * The gate shipped here (PR #6209) because the engine's lowering seam is the
+ * one place every query passes through *on its way to a driver through the
+ * engine*. That last clause was the hole: a caller that lowers a filter with
+ * `parseFilterAST` and calls a driver directly — `InMemoryDriver.find()`, which
+ * is what an embedder does and what this repo's own driver conformance suites
+ * do — never reaches this seam. mingo's coercion of a non-array `$in`/`$nin`
+ * operand hid it until mingo 7.2.3 removed the coercion; from 7.2.4 on the same
+ * input escapes as a raw `TypeError` with no `code` and no `status`. So the
+ * rule moved one layer down to the face `parseFilterAST` itself can reach —
+ * the routing PR #8234 settled for the sibling comparand-TYPE question
+ * ("enforced once at the shared compile face for all five drivers") — and this
+ * wrapper keeps the engine's `find('deal'): ` prefix on the refusal.
  *
- * | comparand              | driver-sql            | driver-memory        | driver-mongodb    |
- * |:-----------------------|:----------------------|:---------------------|:------------------|
- * | `$in` / `$nin` scalar  | `whereIn(f, scalar)` → **500 DATABASE_ERROR** | evaluated as-is | emitted as-is |
- * | `$between` non-2-tuple | refused, 400          | refused, 400 (#5328) | arm falls through, no range predicate |
+ * ## Why the wrapper is not deleted along with the body
  *
- * The 500 is the reported defect (#5869): a server-fault code for a filter the
- * CALLER can fix, with no word about which operator, which field, or what shape
- * was expected. It is also reachable from spec-VALID authoring —
- * `ViewFilterRuleSchema.value` is `string | number | boolean | null | (string |
- * number)[]` and does not constrain the value by operator, so
- * `{ field: 'status', operator: 'not_in', value: 'done' }` publishes cleanly and
- * 500s on first render.
- *
- * ## Why here and not in each driver
- *
- * The table above IS the argument: three backends, three answers, one declared
- * contract. `driver-memory` already carries a shape gate
- * (`filter-refusal.ts`), but it is that package's own and no other driver reads
- * it — and both driver families are under a maintainer investment freeze
- * (#5499). The engine's lowering seam is the ONE place every query passes
- * through regardless of which door it came in by or which driver it lands on,
- * so the gate belongs here and every backend inherits one answer.
- *
- * ## Both doors, because only one of them carries an array
- *
- * The refusal that already lives at this seam only inspects `where` when it
- * arrives as a `FilterArray`. That is Door 2 (a direct in-process engine call).
- * Door 1 — the protocol/HTTP face, and the door #5869 was actually measured
- * through — runs its own `isFilterAST` → `parseFilterAST` in
- * `metadata-protocol/protocol.ts` and hands the engine an already-lowered
- * `FilterCondition` OBJECT. A guard on the array branch alone would therefore
- * have left the reported defect exactly where it was. This gate runs on the
- * lowered condition, so both doors are covered by one check.
- *
- * ## Deliberately NOT refused
- *
- * - **`$in: []` / `$nin: []`.** An empty list is a legitimate, declared
- *   predicate — "matches nothing" and "matches everything" respectively — and
- *   both drivers say so in as many words. Arity is not this gate's business;
- *   only "is it a list at all".
- * - **The MEMBER types of any list.** `$between`'s members are checked by
- *   nobody (`driver-sql` checks arity and nothing else, and #5041 measured the
- *   member case and deliberately left it — ISO date strings are a legitimate
- *   range on every backend); `$in`/`$nin` members are #5234's subject, on the
- *   `driver-sql` object-syntax face, and are not re-judged here.
- * - **A field spec with no `$` keys** (`{ author: { name: 'x' } }`) — a
- *   deep-equality comparand to `driver-memory` and `driver-mongodb` alike. This
- *   gate does not descend into one, for the same reason `filter-refusal.ts`
- *   does not: a comparand is data, and a stricter reading here would invent a
- *   contract no backend agrees with.
+ * The engine calls the gate on BOTH branches of `lowerWhereFilterArray`, with
+ * its own `object` / `operation` pair, and `engine-filter-array-lowering.test.ts`
+ * pins the assembled prefix. Keeping the four-argument signature here means the
+ * engine's call sites, its message and its verdicts are untouched by the move:
+ * one implementation, one wording, no second copy.
  */
 
 import { StandardErrorCode } from '@objectstack/spec/api';
-import { isVirtualSearchField, classifyDottedFilterHead } from '@objectstack/spec/data';
-
-/**
- * The operators whose comparand `FieldOperatorsSchema` declares as a list, with
- * the authoring spellings that lower to each.
- *
- * The spellings matter to the message and not to the check: an author writes
- * `not_in` on a `ViewFilterRule` and never types `$nin`, so a refusal naming
- * only the lowered form sends them looking for a key that is not in their
- * metadata. Values are the `AST_OPERATOR_MAP` keys (`spec/data/filter.zod.ts`)
- * that map to each `$` operator.
- */
-const LIST_COMPARAND_OPERATORS: ReadonlyMap<string, readonly string[]> = new Map([
-  ['$in', ['in']],
-  ['$nin', ['nin', 'not_in', 'notin']],
-  ['$between', ['between']],
-]);
-
-/** What a caller most likely meant when they wrote a scalar. */
-const SCALAR_ALTERNATIVE: ReadonlyMap<string, string> = new Map([
-  ['$in', '"=" ($eq)'],
-  ['$nin', '"!=" ($ne)'],
-]);
+import {
+  assertListComparandShapes as assertListComparandShapesAt,
+  isVirtualSearchField,
+  classifyDottedFilterHead,
+} from '@objectstack/spec/data';
 
 /**
  * A plain object — filter STRUCTURE rather than a comparand.
@@ -110,38 +58,6 @@ function isFilterNode(value: unknown): value is Record<string, unknown> {
     && !Array.isArray(value)
     && !(value instanceof Date)
   );
-}
-
-/** `string` / `number` / `null` / `object` … — the word the message uses. */
-function describeOperand(value: unknown): string {
-  if (value === null) return 'null';
-  if (value === undefined) return 'undefined';
-  if (Array.isArray(value)) return 'array';
-  if (value instanceof Date) return 'Date';
-  return typeof value;
-}
-
-/**
- * A short, bounded rendering of the offending value.
- *
- * Bounded because the value came off the wire and a filter comparand can be
- * arbitrarily large; the message is for a human reading a 400, not a dump.
- *
- * The whole message has a second, harder bound: `rest-server.ts` TRUNCATES a
- * declared-4xx message at `CLIENT_MESSAGE_MAX` (500) before it reaches the
- * client (#5423). Everything a caller needs in order to act — operator, field,
- * received value, position, corrected shape — is therefore front-loaded, and
- * the test file pins the assembled length under that bound so a later edit
- * cannot silently push the tail off the wire.
- */
-function shapePreview(value: unknown): string {
-  let text: string;
-  try {
-    text = JSON.stringify(value) ?? String(value);
-  } catch {
-    text = String(value);
-  }
-  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
 }
 
 /**
@@ -166,78 +82,20 @@ export function invalidFilterError(message: string): Error {
 }
 
 /**
- * `$in` / `$nin` whose comparand is not a list at all.
+ * Refuse every list-shaped operator whose comparand cannot be one — the
+ * engine's binding of `@objectstack/spec/data`'s `assertListComparandShapes`.
  *
- * Names the operator (in both the lowered and the authoring spelling), the
- * field, the received shape, the position, and the expected shape — the #5346 /
- * #5348 wording contract. The closing sentence is the one a caller cannot infer
- * from a status code: the query did not run.
- */
-function nonListComparandError(
-  object: string,
-  operation: string,
-  op: string,
-  field: string,
-  value: unknown,
-  path: string,
-): Error {
-  const spellings = LIST_COMPARAND_OPERATORS.get(op) ?? [];
-  const alternative = SCALAR_ALTERNATIVE.get(op);
-  return invalidFilterError(
-    `${operation}('${object}'): Operator "${op}" on field "${field}" requires an ARRAY of ` +
-    `values. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
-    `"${op}" tests membership of a list — write ${shapePreview([value])} for a single value` +
-    (alternative ? `, or use ${alternative} to compare against it` : '') +
-    `. Authoring spellings: ${spellings.join(', ')}. The filter was NOT applied, and an ` +
-    `unapplied filter would have returned the UNFILTERED result set (#5869).`,
-  );
-}
-
-/**
- * `$between` whose comparand is not a two-element `[min, max]` array.
- *
- * Arity only — the exact condition `driver-sql`'s `$between` arm and
- * `driver-memory`'s `isBetweenComparand` already apply, hoisted so that the
- * backends which check NEITHER stop answering silently. The leading sentence is
- * kept verbatim from those two so one condition keeps one wording across the
- * platform (#5240's rule, applied across packages rather than within one).
- */
-function malformedRangeComparandError(
-  object: string,
-  operation: string,
-  field: string,
-  value: unknown,
-  path: string,
-): Error {
-  return invalidFilterError(
-    `${operation}('${object}'): Operator "$between" on field "${field}" requires a [min, max] ` +
-    `value array. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
-    `A range needs exactly two bounds, in order; the authoring spelling that lowers to ` +
-    `"$between" is "between". The filter was NOT applied, and an unapplied filter would have ` +
-    `returned the UNFILTERED result set (#5869).`,
-  );
-}
-
-/**
- * Walk one `FilterCondition` and refuse every list-shaped operator whose
- * comparand cannot be one.
+ * [#9228] The walk, the wording and the `INVALID_FILTER` / 400 envelope all
+ * live in the spec module now; the ONE thing this wrapper adds is the engine's
+ * caller prefix (`find('deal'): `), assembled from the `object` / `operation`
+ * pair the engine has at its collection point and the spec face does not.
+ * `parseFilterAST` runs the same gate one step earlier for callers that never
+ * reach an engine, and it takes the same `context` argument, so an array-form
+ * `where` refused during lowering still carries this prefix.
  *
  * Read-only and allocation-free on the overwhelmingly common path (a filter
  * with no list operator walks its own keys and returns). Runs on every engine
- * read and write, so it stays a walk rather than a schema parse — that cost is
- * now the whole reason, and this gate deliberately enforces only the three
- * list declarations the drivers genuinely cannot agree on.
- *
- * [#5685] This paragraph used to carry a second reason: that
- * `FieldOperatorsSchema` was "stricter than the runtime in ways the runtime
- * deliberately allows", because `$gt` was declared `number | Date |
- * FieldReference` while `['created_at', '>', '2026-01-01']` lowers to a STRING
- * bound that every backend accepts and the showcase apps rely on. That was a
- * real mismatch and it is **fixed at the source** rather than tolerated here:
- * the four ordering slots now declare `string` too, so the observation that
- * motivated this note no longer describes the schema. It is recorded rather
- * than deleted because this file's workaround is part of the evidence that
- * closed #5685 — the schema, not the runtime, was the wrong side.
+ * read and write, so it stays a walk rather than a schema parse.
  */
 export function assertListComparandShapes(
   object: string,
@@ -245,57 +103,7 @@ export function assertListComparandShapes(
   node: unknown,
   path = 'where',
 ): void {
-  if (!isFilterNode(node)) return;
-  for (const [key, value] of Object.entries(node)) {
-    const here = `${path}.${key}`;
-    if (key === '$and' || key === '$or') {
-      // A non-array operand is a different defect, owned by the drivers'
-      // combinator checks; this gate only walks what it can.
-      if (Array.isArray(value)) {
-        value.forEach((child, index) =>
-          assertListComparandShapes(object, operation, child, `${here}[${index}]`));
-      }
-      continue;
-    }
-    if (key === '$not') {
-      assertListComparandShapes(object, operation, value, here);
-      continue;
-    }
-    // Any other `$` key at node level is a logical operator this gate does not
-    // judge — an unknown one is already refused downstream, by name.
-    if (key.startsWith('$')) continue;
-    assertFieldListComparands(object, operation, key, value, here);
-  }
-}
-
-/** One field constraint: `{ field: <spec> }`. */
-function assertFieldListComparands(
-  object: string,
-  operation: string,
-  field: string,
-  spec: unknown,
-  path: string,
-): void {
-  // A spec that is not a plain object is a comparand (implicit equality) and
-  // carries no operator to check.
-  if (!isFilterNode(spec)) return;
-  const keys = Object.keys(spec);
-  // No `$` key at all → a deep-equality comparand or a nested-relation
-  // condition. Not descended into; see the module note.
-  if (!keys.some((key) => key.startsWith('$'))) return;
-  for (const op of keys) {
-    if (!LIST_COMPARAND_OPERATORS.has(op)) continue;
-    const comparand = spec[op];
-    if (op === '$between') {
-      if (!Array.isArray(comparand) || comparand.length !== 2) {
-        throw malformedRangeComparandError(object, operation, field, comparand, `${path}.${op}`);
-      }
-      continue;
-    }
-    if (!Array.isArray(comparand)) {
-      throw nonListComparandError(object, operation, op, field, comparand, `${path}.${op}`);
-    }
-  }
+  assertListComparandShapesAt(node, `${operation}('${object}')`, path);
 }
 
 /**

--- a/packages/spec/api-surface/data.json
+++ b/packages/spec/api-surface/data.json
@@ -632,6 +632,7 @@
     "apiExposureDenialReason (function)",
     "asciiCaseInsensitiveContains (function)",
     "asciiCaseInsensitiveRegexSource (function)",
+    "assertListComparandShapes (function)",
     "bareDateRangePresetComparandMessage (function)",
     "canServeApiOperation (function)",
     "canonicalAstOperator (function)",

--- a/packages/spec/export-origins/data.json
+++ b/packages/spec/export-origins/data.json
@@ -632,6 +632,7 @@
     "apiExposureDenialReason": "src/data/api-derivation.ts#apiExposureDenialReason (function)",
     "asciiCaseInsensitiveContains": "src/data/filter.zod.ts#asciiCaseInsensitiveContains (function)",
     "asciiCaseInsensitiveRegexSource": "src/data/filter.zod.ts#asciiCaseInsensitiveRegexSource (function)",
+    "assertListComparandShapes": "src/data/filter-comparand-shape.ts#assertListComparandShapes (function)",
     "bareDateRangePresetComparandMessage": "src/data/date-range-presets.ts#bareDateRangePresetComparandMessage (function)",
     "canServeApiOperation": "src/data/api-derivation.ts#canServeApiOperation (function)",
     "canonicalAstOperator": "src/data/filter.zod.ts#canonicalAstOperator (function)",

--- a/packages/spec/src/data/filter-comparand-shape.test.ts
+++ b/packages/spec/src/data/filter-comparand-shape.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#9228] The comparand-SHAPE door, at the face `parseFilterAST` reaches.
+ *
+ * The rule ("a list operator takes a list") is #5869's and shipped at the
+ * engine's lowering seam, where it covered every query that reaches a driver
+ * THROUGH the engine — and nothing else. A caller that lowers a filter with
+ * `parseFilterAST` and calls a driver directly met no gate: `InMemoryDriver`'s
+ * own conformance suite does exactly that, and so does an embedder. mingo's
+ * coercion of a non-array `$in`/`$nin` operand hid it until mingo 7.2.3 removed
+ * the coercion; from 7.2.4 on the same input escapes as
+ * `TypeError: b.filter is not a function` — no `code`, no `status`, no field
+ * name, straight to the caller.
+ *
+ * This file pins the door at the face itself. The ENGINE's binding of the same
+ * one implementation keeps its own suite (`engine-filter-array-lowering.test.ts`,
+ * `@objectstack/objectql`), which is what proves the move changed no verdict
+ * there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StandardErrorCode } from '../api/errors.zod';
+import { parseFilterAST, VALID_AST_OPERATORS } from './filter.zod';
+import { assertListComparandShapes } from './filter-comparand-shape';
+
+type Refusal = Error & { code?: string; status?: number };
+
+const refusalOf = (run: () => unknown): Refusal => {
+  try {
+    run();
+  } catch (e) {
+    return e as Refusal;
+  }
+  throw new Error('expected the shape door to refuse this filter, but it returned');
+};
+
+/**
+ * Which `$` operator an authoring spelling lowers to, derived by LOWERING one
+ * rather than by reading a table this file would then be a second copy of.
+ * A two-element array is legal for all three list operators, so the probe never
+ * trips the door it is used to find.
+ */
+const loweredOperatorOf = (op: string): string | undefined => {
+  const lowered = parseFilterAST([['probe', op, ['a', 'b']]]) as Record<string, unknown> | undefined;
+  const spec = lowered?.probe;
+  if (spec === null || typeof spec !== 'object' || Array.isArray(spec)) return undefined;
+  return Object.keys(spec).find((key) => key.startsWith('$'));
+};
+
+describe('the list-comparand shape door (#5869) runs inside parseFilterAST (#9228)', () => {
+  // ── the escape this card closes ────────────────────────────────────────
+
+  it.each([
+    ['in', 'in'],
+    ['nin', 'nin'],
+    ['not_in', 'not_in'],
+    // The spelling the driver-memory vocabulary suite fed a scalar to, which
+    // is how the hole was found at all.
+    ['notin', 'notin'],
+  ])('refuses a scalar comparand on the membership spelling %s', (_label, op) => {
+    const err = refusalOf(() => parseFilterAST([['name', op, 'alpha']]));
+    // ADR-0112 class 1. BOTH halves, never just "it throws": before this door
+    // the same input threw too — a raw mingo `TypeError` with neither field
+    // set, which is the failure this assertion has to be able to see.
+    expect(err.code).toBe(StandardErrorCode.enum.INVALID_FILTER);
+    expect(err.status).toBe(400);
+  });
+
+  it('refuses the OBJECT passthrough form too, not only the lowered array', () => {
+    // `parseFilterAST({...})` returns a FilterCondition unchanged apart from
+    // the doors; a direct driver caller hands it exactly this.
+    for (const where of [{ name: { $nin: 'alpha' } }, { name: { $in: 'alpha' } }]) {
+      const err = refusalOf(() => parseFilterAST(where));
+      expect(err.code).toBe(StandardErrorCode.enum.INVALID_FILTER);
+      expect(err.status).toBe(400);
+    }
+  });
+
+  it.each([
+    ['null', { stage: { $in: null } }],
+    ['a number', { amount: { $nin: 10 } }],
+    ['a plain object', { stage: { $in: { a: 1 } } }],
+    ['a Date', { at: { $in: new Date('2026-01-01') } }],
+  ])('refuses a comparand that is %s — every non-list, not just strings', (_label, where) => {
+    const err = refusalOf(() => parseFilterAST(where));
+    expect(err.code).toBe(StandardErrorCode.enum.INVALID_FILTER);
+    expect(err.status).toBe(400);
+  });
+
+  it.each([
+    ['a scalar', [['amount', 'between', 5]]],
+    ['a 1-tuple', [['amount', 'between', [1]]]],
+    ['a 3-tuple', [['amount', 'between', [1, 2, 3]]]],
+  ])('refuses a $between comparand that is %s', (_label, where) => {
+    const err = refusalOf(() => parseFilterAST(where));
+    expect(err.code).toBe(StandardErrorCode.enum.INVALID_FILTER);
+    expect(err.status).toBe(400);
+  });
+
+  // ── the wording contract (#5346 / #5348), unchanged by the move ────────
+
+  it('names the operator, the field, what arrived, where, and the fix', () => {
+    const err = refusalOf(() => parseFilterAST([['stage', 'not_in', 'won']]));
+    expect(err.message).toMatch(/Operator "\$nin"/);
+    expect(err.message).toMatch(/field "stage"/);
+    expect(err.message).toMatch(/Received string \("won"\)/);
+    expect(err.message).toMatch(/where\.stage\.\$nin/);
+    expect(err.message).toMatch(/\["won"\]/);
+    expect(err.message).toMatch(/"!=" \(\$ne\)/);
+    expect(err.message).toMatch(/not_in/);
+    expect(err.message).toMatch(/NOT applied/);
+    expect(err.message).toMatch(/UNFILTERED result set/);
+  });
+
+  it('a spec-level caller gets NO entry-point prefix; a caller that names one keeps it', () => {
+    // The `context` parameter is the engine's #5346 wording contract, and it is
+    // the reason `@objectstack/objectql` could delegate here without changing a
+    // single pinned message. Without one the message starts at its first
+    // load-bearing word rather than at a stray ": ".
+    expect(refusalOf(() => parseFilterAST([['stage', 'in', 'won']])).message)
+      .toMatch(/^Operator "\$in"/);
+    expect(refusalOf(() => parseFilterAST([['stage', 'in', 'won']], "find('deal')")).message)
+      .toMatch(/^find\('deal'\): Operator "\$in"/);
+    expect(refusalOf(() => assertListComparandShapes({ stage: { $in: 'won' } }, "count('deal')")).message)
+      .toMatch(/^count\('deal'\): /);
+  });
+
+  it('the whole refusal fits under the 500-char client bound (#5423)', () => {
+    // `rest-server.ts` truncates a declared-4xx message at 500 before it
+    // reaches the client, and the "NOT applied" sentence sits at the END — so
+    // an overflow loses exactly the sentence the refusal exists to deliver.
+    for (const where of [
+      [['stage', 'not_in', 'won']],
+      [['stage', 'in', 'won']],
+      [['amount', 'between', 5]],
+    ]) {
+      const err = refusalOf(() => parseFilterAST(where, "find('deal')"));
+      expect(err.message.length, JSON.stringify(where)).toBeLessThan(500);
+      expect(err.message, JSON.stringify(where)).toMatch(/UNFILTERED result set/);
+    }
+  });
+
+  it('walks $and / $or / $not, and reports the offender by its own path', () => {
+    expect(refusalOf(() => parseFilterAST(['and', ['amount', '>', 5], ['stage', 'nin', 'won']])).message)
+      .toMatch(/where\.\$and\[1\]\.stage\.\$nin/);
+    expect(refusalOf(() => parseFilterAST({ $not: { stage: { $in: 'won' } } })).message)
+      .toMatch(/where\.\$not\.stage\.\$in/);
+    expect(refusalOf(() => parseFilterAST({ $or: [{ stage: { $in: 'won' } }] })).message)
+      .toMatch(/where\.\$or\[0\]\.stage\.\$in/);
+  });
+
+  // ── the reconciliation pin: the message's spelling list vs the vocabulary ─
+
+  it('every AST spelling that lowers to a list operator is refused AND named', () => {
+    // The refusal's "Authoring spellings" list is hand-written (deriving it
+    // from `AST_OPERATOR_MAP` would be an import cycle — `filter.zod.ts`
+    // imports the door). This is what keeps it honest: add `not_in_any` to the
+    // vocabulary without adding it to that list and this test says so, in the
+    // same edit rather than a release later.
+    const membership = [...VALID_AST_OPERATORS].filter((op) => {
+      const lowered = loweredOperatorOf(op);
+      return lowered === '$in' || lowered === '$nin';
+    });
+    // Guards the loop from passing vacuously.
+    expect(membership.sort()).toEqual(['in', 'nin', 'not_in', 'notin']);
+    for (const op of membership) {
+      const err = refusalOf(() => parseFilterAST([['name', op, 'alpha']]));
+      expect(err.status, op).toBe(400);
+      expect(err.message, `"${op}" is refused but the refusal does not name it`)
+        .toContain(op);
+    }
+    // `between` is the third list operator and its own message names its own
+    // spelling; it is checked here so a fourth list operator cannot arrive
+    // with neither branch covering it.
+    expect([...VALID_AST_OPERATORS].filter((op) => loweredOperatorOf(op) === '$between'))
+      .toEqual(['between']);
+  });
+
+  // ── what must KEEP working — the door is narrow, not merely present ─────
+
+  it('lowers every legal list comparand untouched', () => {
+    expect(parseFilterAST([['stage', 'in', ['won', 'lost']]])).toEqual({ stage: { $in: ['won', 'lost'] } });
+    expect(parseFilterAST([['stage', 'not_in', ['lost']]])).toEqual({ stage: { $nin: ['lost'] } });
+    expect(parseFilterAST([['amount', 'between', [5, 25]]])).toEqual({ amount: { $between: [5, 25] } });
+  });
+
+  it('an EMPTY list is a declared predicate, not a malformed one', () => {
+    // `$in: []` matches nothing, `$nin: []` matches everything. Arity is not
+    // this door's business for membership; only "is it a list at all".
+    expect(parseFilterAST({ stage: { $in: [] } })).toEqual({ stage: { $in: [] } });
+    expect(parseFilterAST({ stage: { $nin: [] } })).toEqual({ stage: { $nin: [] } });
+  });
+
+  it('leaves alone everything it deliberately does not judge', () => {
+    // A field spec with no `$` key is a deep-equality / nested-relation
+    // comparand, not an operator bag — descending into one would invent a
+    // contract no backend agrees with.
+    expect(parseFilterAST({ author: { name: 'x' } })).toEqual({ author: { name: 'x' } });
+    // A scalar operator carrying an array is answered per driver, not here.
+    expect(parseFilterAST({ tags: { $eq: ['a', 'b'] } })).toEqual({ tags: { $eq: ['a', 'b'] } });
+    // An implicit-equality array comparand keeps its array-equality semantics.
+    expect(parseFilterAST({ tags: ['a', 'b'] })).toEqual({ tags: ['a', 'b'] });
+    // An unknown `$` key at node level belongs to the by-name refusals
+    // downstream, which carry the specific prescription.
+    expect(parseFilterAST({ $wat: [{ stage: { $in: ['won'] } }] }))
+      .toEqual({ $wat: [{ stage: { $in: ['won'] } }] });
+    // Nothing to walk.
+    expect(parseFilterAST(undefined)).toBeUndefined();
+    expect(parseFilterAST([])).toBeUndefined();
+  });
+
+  it('returns the SAME reference on the passthrough path — the door allocates nothing', () => {
+    const where = { stage: { $in: ['won'] } };
+    expect(parseFilterAST(where)).toBe(where);
+  });
+});

--- a/packages/spec/src/data/filter-comparand-shape.ts
+++ b/packages/spec/src/data/filter-comparand-shape.ts
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#5869] The Filter Protocol's **comparand-shape door** for the LIST-SHAPED
+ * operators — the one place that decides whether `$in` / `$nin` / `$between`
+ * received a list at all, for every driver.
+ *
+ * `FieldOperatorsSchema` (`./filter.zod.ts`) declares three operators whose
+ * comparand is a LIST rather than a scalar:
+ *
+ * ```
+ * $in:      z.array(z.any())
+ * $nin:     z.array(z.any())
+ * $between: z.tuple([min, max])
+ * ```
+ *
+ * Nothing enforced that declaration on the way in. `isFilterAST` checks the
+ * OPERATOR and the tuple's arity, never the comparand's shape, and
+ * {@link parseFilterAST} lowers `['status', 'not_in', 'done']` to
+ * `{ status: { $nin: 'done' } }` — so a scalar reached the driver, where each
+ * backend answered differently:
+ *
+ * | comparand              | driver-sql            | driver-memory        | driver-mongodb    |
+ * |:-----------------------|:----------------------|:---------------------|:------------------|
+ * | `$in` / `$nin` scalar  | `whereIn(f, scalar)` -> **500 DATABASE_ERROR** | evaluated as-is | emitted as-is |
+ * | `$between` non-2-tuple | refused, 400          | refused, 400 (#5328) | arm falls through, no range predicate |
+ *
+ * The 500 is the reported defect (#5869): a server-fault code for a filter the
+ * CALLER can fix, with no word about which operator, which field, or what shape
+ * was expected. It is also reachable from spec-VALID authoring —
+ * `ViewFilterRuleSchema.value` is `string | number | boolean | null | (string |
+ * number)[]` and does not constrain the value by operator, so
+ * `{ field: 'status', operator: 'not_in', value: 'done' }` publishes cleanly and
+ * 500s on first render.
+ *
+ * ## Why here, and why this file is the ONLY implementation
+ *
+ * The table above IS the argument for a shared face: three backends, three
+ * answers, one declared contract. `driver-memory` already carries a shape gate
+ * (`filter-refusal.ts`), but it is that package's own and no other driver reads
+ * it — and both driver families are under a maintainer investment freeze
+ * (#5499), so the policy cannot be grown per driver.
+ *
+ * [#9228] It now lives in `packages/spec` rather than in the engine. The gate
+ * shipped at `@objectstack/objectql`'s lowering seam (PR #6209), which covers
+ * every query that reaches a driver THROUGH the engine — and nothing else. A
+ * caller that compiles a filter with {@link parseFilterAST} and hands it
+ * straight to a driver (`InMemoryDriver.find()`: an embedder, and this repo's
+ * own driver conformance suites) met no gate at all. That path was carried by
+ * mingo's own coercion of a non-array `$in`/`$nin` operand until mingo 7.2.3
+ * removed it; from 7.2.4 on the same input escapes as an unhandled third-party
+ * `TypeError` with no `code` and no `status`. Moving the rule to the face
+ * {@link parseFilterAST} itself can reach closes that door for every driver at
+ * once — the routing PR #8234 settled for the sibling comparand-TYPE question
+ * one branch over ("enforced once at the shared compile face for all five
+ * drivers"). `@objectstack/objectql`'s `assertListComparandShapes` is now a
+ * delegating wrapper that supplies the engine's `find('deal')` context prefix;
+ * there is exactly one implementation of "a list operator takes a list".
+ *
+ * ## Both engine doors, because only one of them carries an array
+ *
+ * The engine calls this on the LOWERED condition on both of its branches. Door
+ * 2 is a direct in-process engine call carrying a `FilterArray`; Door 1 — the
+ * protocol/HTTP face, the door #5869 was actually measured through — runs its
+ * own `isFilterAST` -> {@link parseFilterAST} in `metadata-protocol` and hands
+ * the engine an already-lowered `FilterCondition` OBJECT. A guard on the array
+ * branch alone would therefore have left the reported defect exactly where it
+ * was.
+ *
+ * ## Deliberately NOT refused
+ *
+ * - **`$in: []` / `$nin: []`.** An empty list is a legitimate, declared
+ *   predicate — "matches nothing" and "matches everything" respectively — and
+ *   both drivers say so in as many words. Arity is not this gate's business;
+ *   only "is it a list at all".
+ * - **The MEMBER types of any list.** `$between`'s members are checked by
+ *   nobody (`driver-sql` checks arity and nothing else, and #5041 measured the
+ *   member case and deliberately left it — ISO date strings are a legitimate
+ *   range on every backend); `$in`/`$nin` members are #5234's subject, on the
+ *   `driver-sql` object-syntax face, and are not re-judged here. The six
+ *   accepted comparand TYPES are a different question, answered one file over
+ *   by {@link normalizeFilterComparandTypes} (#7872).
+ * - **A field spec with no `$` keys** (`{ author: { name: 'x' } }`) — a
+ *   deep-equality comparand to `driver-memory` and `driver-mongodb` alike. This
+ *   gate does not descend into one: a comparand is data, and a stricter reading
+ *   here would invent a contract no backend agrees with.
+ *
+ * ## Refusal envelope
+ *
+ * Every refusal carries `code: 'INVALID_FILTER'` and `status: 400` (ADR-0112
+ * class 1 — a caller mistake). The literal is spelled here rather than imported
+ * from `../api/errors.zod` because `api/` imports from `data/` and the reverse
+ * edge would be a cycle — the same argument `filter-comparand-type.ts` records;
+ * `filter-comparand-shape.test.ts` pins the literal to
+ * `StandardErrorCode.enum.INVALID_FILTER` so the two cannot drift.
+ *
+ * @see https://github.com/objectstack-ai/objectstack/issues/5869 (the rule)
+ * @see https://github.com/objectstack-ai/objectstack/issues/9228 (the move)
+ */
+
+/**
+ * The operators whose comparand `FieldOperatorsSchema` declares as a list, with
+ * the authoring spellings that lower to each.
+ *
+ * The spellings matter to the message and not to the check: an author writes
+ * `not_in` on a `ViewFilterRule` and never types `$nin`, so a refusal naming
+ * only the lowered form sends them looking for a key that is not in their
+ * metadata. Values are the `AST_OPERATOR_MAP` keys (`./filter.zod.ts`) that map
+ * to each `$` operator — spelled here rather than derived from that table
+ * because `filter.zod.ts` imports THIS module, and the reverse edge would be a
+ * cycle. `filter-comparand-shape.test.ts` reconciles the two sets, so a new
+ * membership spelling cannot land with this message left behind.
+ */
+const LIST_COMPARAND_OPERATORS: ReadonlyMap<string, readonly string[]> = new Map([
+  ['$in', ['in']],
+  ['$nin', ['nin', 'not_in', 'notin']],
+  ['$between', ['between']],
+]);
+
+/** What a caller most likely meant when they wrote a scalar. */
+const SCALAR_ALTERNATIVE: ReadonlyMap<string, string> = new Map([
+  ['$in', '"=" ($eq)'],
+  ['$nin', '"!=" ($ne)'],
+]);
+
+/**
+ * A plain object — filter STRUCTURE rather than a comparand.
+ *
+ * `Date` and other class instances are comparands even though `typeof` calls
+ * them objects, and an array is a comparand at this position too (it is what a
+ * list operator is FOR). Same classification `driver-memory`'s gate makes.
+ */
+function isFilterNode(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !(value instanceof Date)
+  );
+}
+
+/** `string` / `number` / `null` / `object` … — the word the message uses. */
+function describeOperand(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return 'array';
+  if (value instanceof Date) return 'Date';
+  return typeof value;
+}
+
+/**
+ * A short, bounded rendering of the offending value.
+ *
+ * Bounded because the value came off the wire and a filter comparand can be
+ * arbitrarily large; the message is for a human reading a 400, not a dump.
+ *
+ * The whole message has a second, harder bound: `rest-server.ts` TRUNCATES a
+ * declared-4xx message at `CLIENT_MESSAGE_MAX` (500) before it reaches the
+ * client (#5423). Everything a caller needs in order to act — operator, field,
+ * received value, position, corrected shape — is therefore front-loaded, and
+ * the test file pins the assembled length under that bound so a later edit
+ * cannot silently push the tail off the wire.
+ */
+function shapePreview(value: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(value) ?? String(value);
+  } catch {
+    text = String(value);
+  }
+  return text.length > 60 ? `${text.slice(0, 59)}…` : text;
+}
+
+/**
+ * The wire envelope every filter refusal on the platform carries — ADR-0112
+ * class 1. See the module note for why the code is a literal here.
+ *
+ * `context` is the optional caller prefix (`find('deal')`) that carries the
+ * engine's refusal-wording contract (#5346); it is the same parameter, in the
+ * same position, as {@link normalizeFilterComparandTypes}'s. A spec-level
+ * caller with no operation to name passes none, and the message reads from its
+ * first load-bearing word.
+ */
+function invalidFilterComparandError(context: string | undefined, message: string): Error {
+  const err = new Error(`${context ? `${context}: ` : ''}${message}`) as Error & {
+    code?: string;
+    status?: number;
+  };
+  err.code = 'INVALID_FILTER';
+  err.status = 400;
+  return err;
+}
+
+/**
+ * `$in` / `$nin` whose comparand is not a list at all.
+ *
+ * Names the operator (in both the lowered and the authoring spelling), the
+ * field, the received shape, the position, and the expected shape — the #5346 /
+ * #5348 wording contract. The closing sentence is the one a caller cannot infer
+ * from a status code: the query did not run.
+ */
+function nonListComparandError(
+  context: string | undefined,
+  op: string,
+  field: string,
+  value: unknown,
+  path: string,
+): Error {
+  const spellings = LIST_COMPARAND_OPERATORS.get(op) ?? [];
+  const alternative = SCALAR_ALTERNATIVE.get(op);
+  return invalidFilterComparandError(
+    context,
+    `Operator "${op}" on field "${field}" requires an ARRAY of ` +
+    `values. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
+    `"${op}" tests membership of a list — write ${shapePreview([value])} for a single value` +
+    (alternative ? `, or use ${alternative} to compare against it` : '') +
+    `. Authoring spellings: ${spellings.join(', ')}. The filter was NOT applied, and an ` +
+    `unapplied filter would have returned the UNFILTERED result set (#5869).`,
+  );
+}
+
+/**
+ * `$between` whose comparand is not a two-element `[min, max]` array.
+ *
+ * Arity only — the exact condition `driver-sql`'s `$between` arm and
+ * `driver-memory`'s `isBetweenComparand` already apply, hoisted so that the
+ * backends which check NEITHER stop answering silently. The leading sentence is
+ * kept verbatim from those two so one condition keeps one wording across the
+ * platform (#5240's rule, applied across packages rather than within one).
+ */
+function malformedRangeComparandError(
+  context: string | undefined,
+  field: string,
+  value: unknown,
+  path: string,
+): Error {
+  return invalidFilterComparandError(
+    context,
+    `Operator "$between" on field "${field}" requires a [min, max] ` +
+    `value array. Received ${describeOperand(value)} (${shapePreview(value)}) at ${path}. ` +
+    `A range needs exactly two bounds, in order; the authoring spelling that lowers to ` +
+    `"$between" is "between". The filter was NOT applied, and an unapplied filter would have ` +
+    `returned the UNFILTERED result set (#5869).`,
+  );
+}
+
+/**
+ * Walk one `FilterCondition` and refuse every list-shaped operator whose
+ * comparand cannot be one.
+ *
+ * Read-only and allocation-free on the overwhelmingly common path (a filter
+ * with no list operator walks its own keys and returns). Runs on every engine
+ * read and write and inside every {@link parseFilterAST} call, so it stays a
+ * walk rather than a schema parse — that cost is now the whole reason, and this
+ * gate deliberately enforces only the three list declarations the drivers
+ * genuinely cannot agree on.
+ *
+ * @param node    the LOWERED `FilterCondition` — never the authoring array.
+ * @param context optional caller prefix (`find('deal')`), the engine's #5346
+ *                wording contract; omitted by spec-level callers.
+ * @param path    the key path reported in the refusal, seeded at `where`.
+ *
+ * [#5685] This paragraph used to carry a second reason: that
+ * `FieldOperatorsSchema` was "stricter than the runtime in ways the runtime
+ * deliberately allows", because `$gt` was declared `number | Date |
+ * FieldReference` while `['created_at', '>', '2026-01-01']` lowers to a STRING
+ * bound that every backend accepts and the showcase apps rely on. That was a
+ * real mismatch and it is **fixed at the source** rather than tolerated here:
+ * the four ordering slots now declare `string` too, so the observation that
+ * motivated this note no longer describes the schema. It is recorded rather
+ * than deleted because this gate's workaround is part of the evidence that
+ * closed #5685 — the schema, not the runtime, was the wrong side.
+ */
+export function assertListComparandShapes(
+  node: unknown,
+  context?: string,
+  path = 'where',
+): void {
+  if (!isFilterNode(node)) return;
+  for (const [key, value] of Object.entries(node)) {
+    const here = `${path}.${key}`;
+    if (key === '$and' || key === '$or') {
+      // A non-array operand is a different defect, owned by the drivers'
+      // combinator checks; this gate only walks what it can.
+      if (Array.isArray(value)) {
+        value.forEach((child, index) =>
+          assertListComparandShapes(child, context, `${here}[${index}]`));
+      }
+      continue;
+    }
+    if (key === '$not') {
+      assertListComparandShapes(value, context, here);
+      continue;
+    }
+    // Any other `$` key at node level is a logical operator this gate does not
+    // judge — an unknown one is already refused downstream, by name.
+    if (key.startsWith('$')) continue;
+    assertFieldListComparands(context, key, value, here);
+  }
+}
+
+/** One field constraint: `{ field: <spec> }`. */
+function assertFieldListComparands(
+  context: string | undefined,
+  field: string,
+  spec: unknown,
+  path: string,
+): void {
+  // A spec that is not a plain object is a comparand (implicit equality) and
+  // carries no operator to check.
+  if (!isFilterNode(spec)) return;
+  const keys = Object.keys(spec);
+  // No `$` key at all → a deep-equality comparand or a nested-relation
+  // condition. Not descended into; see the module note.
+  if (!keys.some((key) => key.startsWith('$'))) return;
+  for (const op of keys) {
+    if (!LIST_COMPARAND_OPERATORS.has(op)) continue;
+    const comparand = spec[op];
+    if (op === '$between') {
+      if (!Array.isArray(comparand) || comparand.length !== 2) {
+        throw malformedRangeComparandError(context, field, comparand, `${path}.${op}`);
+      }
+      continue;
+    }
+    if (!Array.isArray(comparand)) {
+      throw nonListComparandError(context, op, field, comparand, `${path}.${op}`);
+    }
+  }
+}

--- a/packages/spec/src/data/filter-field-reference-lowering.test.ts
+++ b/packages/spec/src/data/filter-field-reference-lowering.test.ts
@@ -150,14 +150,32 @@ describe('[#7597] equality triples with a `{ $field }` comparand', () => {
     // vocabulary means a fifth `$eq` spelling entering `AST_OPERATOR_MAP`
     // cannot re-open the defect at a name this file never heard of.
     const offenders: string[] = [];
+    // [#9228] The LIST-shaped operators never reach the "what did it lower to"
+    // question any more: a `{ $field }` comparand is not an array, and the
+    // #5869 shape door now runs inside `parseFilterAST` rather than only at the
+    // engine's lowering seam — where this same input has been refused since
+    // #6209, so nothing that used to execute stops executing. Recorded in its
+    // own list rather than swallowed by a bare `catch`: a spelling that starts
+    // refusing when it used to lower is a change this pin must SHOW.
+    const refused: string[] = [];
     for (const op of VALID_AST_OPERATORS) {
-      const lowered = parseFilterAST(['amount', op, REF]) as Record<string, unknown>;
+      let lowered: Record<string, unknown> | undefined;
+      try {
+        lowered = parseFilterAST(['amount', op, REF]) as Record<string, unknown>;
+      } catch {
+        refused.push(op);
+        continue;
+      }
       const spec = lowered?.amount;
       if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
         const keys = Object.keys(spec as Record<string, unknown>);
         if (keys.length === 1 && keys[0] === '$field') offenders.push(op);
       }
     }
+    expect(
+      refused.sort(),
+      'the list-shaped operators, and only those, refuse a non-array comparand at this face',
+    ).toEqual(['between', 'in', 'nin', 'not_in', 'notin']);
     expect(offenders, 'these spellings lower a `{ $field }` comparand to a bare, unimplemented field spec').toEqual([]);
   });
 });

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { z } from 'zod';
+import { assertListComparandShapes } from './filter-comparand-shape';
 import { normalizeFilterComparandTypes } from './filter-comparand-type';
 import { bareDateRangePresetComparandMessage, isDateRangePresetName } from './date-range-presets';
 
@@ -1854,10 +1855,22 @@ function convertComparison(node: [string, string, unknown]): FilterCondition {
  * If the input is already a FilterCondition object (not an array), it is returned as-is.
  * If the input is `null` or `undefined`, it is returned as-is.
  *
- * ## This is the comparand-type door (#7872)
+ * ## This is the comparand SHAPE door (#5869) and TYPE door (#7872)
+ *
+ * [#9228] Whatever this function returns has first passed
+ * {@link assertListComparandShapes}: `$in` / `$nin` carry an ARRAY and
+ * `$between` a `[min, max]` pair, or the call is refused with the
+ * `INVALID_FILTER` / 400 envelope. That gate used to run only at the engine's
+ * lowering seam, so a caller that lowered a filter here and handed it straight
+ * to a driver (`InMemoryDriver.find()` — an embedder, and this repo's own
+ * driver conformance suites) met nothing: the shape was carried by mingo's
+ * coercion of a non-array `$in`/`$nin` operand until mingo 7.2.3 removed it,
+ * and from 7.2.4 on it escapes as a raw third-party `TypeError` with no `code`
+ * and no `status`. Shape first, then type — the same order the engine's own
+ * seam applies, so one input gets one verdict whichever door it came in by.
  *
  * Whatever this function returns — the lowered AST form or the object
- * passthrough — has passed {@link normalizeFilterComparandTypes} first: every
+ * passthrough — has then passed {@link normalizeFilterComparandTypes}: every
  * LITERAL comparand is one of the accepted six types
  * (`string | number | bigint | boolean | null | Date`), an exact-range
  * `bigint` has been narrowed to its number (copy-on-write, so the object
@@ -1882,9 +1895,16 @@ function convertComparison(node: [string, string, unknown]): FilterCondition {
  * parseFilterAST({ status: "active" })
  * // → { status: "active" }
  */
-export function parseFilterAST(filter: unknown): FilterCondition | undefined {
+export function parseFilterAST(filter: unknown, context?: string): FilterCondition | undefined {
   const lowered = lowerFilterAST(filter);
-  return lowered === undefined ? undefined : normalizeFilterComparandTypes(lowered);
+  if (lowered === undefined) return undefined;
+  // [#9228] `context` is the optional caller prefix (`find('deal')`) both doors
+  // already take — the engine's #5346 refusal-wording contract. It is passed
+  // through rather than minted here so the engine's array branch keeps the
+  // exact message it has pinned since #6209, now that the shape gate refuses
+  // one step earlier than the engine's own call to it.
+  assertListComparandShapes(lowered, context);
+  return normalizeFilterComparandTypes(lowered, context);
 }
 
 /**

--- a/packages/spec/src/data/index.ts
+++ b/packages/spec/src/data/index.ts
@@ -11,6 +11,14 @@ export * from './filter.zod';
 // drivers (#5499) inherit one answer instead of crashing (memory × BigInt) or
 // letting the BSON encoder edit the query (mongo × undefined → match-all).
 export * from './filter-comparand-type';
+// The comparand-SHAPE door (#5869, moved here by #9228) — the one
+// implementation of "a list operator takes a list" (`$in` / `$nin` need an
+// array, `$between` needs a [min, max] pair). It ran only at the engine's
+// lowering seam, so a caller that compiled a filter with `parseFilterAST` and
+// handed it straight to a driver met no gate; `@objectstack/objectql`'s
+// `assertListComparandShapes` now delegates here and `parseFilterAST` enforces
+// it for every direct driver caller too.
+export * from './filter-comparand-shape';
 // Canonical conformance cases for the filter logical combinators — the shared
 // standard the five independent FilterCondition backends are each checked
 // against, so they cannot drift apart again (#3774; the fifth — MongoDB's


### PR DESCRIPTION
Fixes #9228

The #5869 rule — "a list operator takes a list" — shipped at `@objectstack/objectql`'s
lowering seam (PR #6209). That covers every query reaching a driver **through the
engine**, and nothing else. A caller that lowers a filter with `parseFilterAST` and calls
a driver directly — an embedder, and this repo's own driver conformance suites — met no
gate at all, and mingo's coercion of a non-array `$in`/`$nin` operand carried the shape
until mingo 7.2.3 removed it.

This moves the rule to the face `parseFilterAST` itself can reach. **Exactly one
implementation exists when this lands**: `packages/spec/src/data/filter-comparand-shape.ts`.
`@objectstack/objectql`'s `assertListComparandShapes` is now a delegating wrapper whose
only remaining job is the engine's `find('deal'): ` caller prefix. No driver behaviour is
patched — both driver families are under the #5499 investment freeze — and no `mingo`
version, `package.json` range or `pnpm-lock.yaml` entry is touched.

## Accept / reject delta — the whole of it

**Newly refused** (ADR-0112 envelope: `code: 'INVALID_FILTER'`, `status: 400`), and only
through a **direct `parseFilterAST` call that does not go on to an engine**:

| input | before | after |
|:---|:---|:---|
| `parseFilterAST([['n','in','a']])`, and the `nin` / `not_in` / `notin` spellings | lowered to `{ n: { $nin: 'a' } }` and returned | `INVALID_FILTER` / 400 |
| `parseFilterAST({ n: { $in: 'a' } })` — the object passthrough | returned unchanged | `INVALID_FILTER` / 400 |
| `parseFilterAST([['amt','between',5]])`, 1-tuple, 3-tuple | lowered and returned | `INVALID_FILTER` / 400 |

**Already refused before this change, with the same code and status** — so no caller that
reaches a driver through a door loses or gains anything:

- every engine verb (`find` / `findOne` / `count` / `aggregate` / `update` / `delete`),
  on both the array and the object branch — `assertListComparandShapes` at
  `lowerWhereFilterArray`, since PR #6209;
- authoring time, on a `ViewFilterRule` (`checkViewFilterRuleValueShape`, #6227) and on a
  skill trigger condition (#7113) — both refuse the same shape at publish;
- the REST/protocol ingress, which lowers through `parseFilterAST` and then hands the
  engine the object form.

**Unchanged, deliberately** — the door is narrow, and the tests pin each of these:
`$in: []` / `$nin: []` stay legitimate declared predicates ("matches nothing" / "matches
everything"); list MEMBER types are still not judged here (#5234 owns them, and the
comparand-TYPE door one file over owns the six accepted types); a field spec with no `$`
key is still not descended into; a scalar operator carrying an array keeps its per-driver
semantics; an unknown `$` key at node level is still left to the by-name refusals
downstream. Every message is byte-identical to the one #6209 shipped, modulo the caller
prefix described next.

**One message change, on one path.** `parseFilterAST` gains an optional second argument,
`context` — the same caller-prefix parameter `normalizeFilterComparandTypes` already
takes, additive and defaulted. The engine passes it on its array branch, which is what
keeps the `find('deal'): ` prefix that `engine-filter-array-lowering.test.ts` has pinned
since #6209 now that the refusal happens during lowering. As a side effect the #7872
**type** door's refusals on that same array branch gain the prefix they previously
lacked, which makes the array branch agree with the object branch. A caller with no
operation to name (the protocol ingress, a direct driver caller) gets the message with no
prefix, matching that door's own filter refusals (`Query parameter 'filter' …`).

The engine's second `assertListComparandShapes` call, on the array branch only, is
deleted: `parseFilterAST` three lines above now runs the identical gate on the identical
condition, so the call was provably unreachable. The **object** branch keeps its call —
that `where` never passes `parseFilterAST` at all, which is why both branches exist.

## Premises, measured

**A1 — dependency direction allows the sink: HOLDS.** `@objectstack/objectql` depends on
`@objectstack/spec`, not the reverse, and the moved module drags no engine concept with
it: the engine-only `object` / `operation` pair collapses into the `context` string the
spec's sibling door already takes. The new module imports nothing (the `'INVALID_FILTER'`
literal is spelled inline for the `api/` ⇢ `data/` cycle reason `filter-comparand-type.ts`
already records, and the test pins it to `StandardErrorCode.enum.INVALID_FILTER`).

**A2 — nothing in-tree authors a scalar membership comparand: HOLDS.** Surveyed
`examples/**`, `content/**`, `packages/**` (including `packages/qa/dogfood/test/fixtures`,
the only `fixtures/` directory in the tree), the seeded platform objects and plugin
objects, and the sibling `objectui` checkout at `375efb4`. Every authored membership rule
already carries an array — `plugin-audit`, `plugin-sharing`, `plugin-approvals`,
`platform-objects`' `sys_invitation`, `service-messaging`, the CRM and showcase examples,
the docs. The only non-array occurrences anywhere are tests that assert the refusal
(`view-filter-rule-value-shape.test.ts`, `skill-trigger-condition-value-shape.test.ts`,
`view-public-picker.test.ts`) plus one objectui builder-fold unit test whose sibling test
already records that `ViewFilterRuleSchema` refuses the shape. No stored view metadata in
JSON or YAML carries a membership operator at all. Normalising a scalar to a one-element
list therefore never came up as a live option.

**A3 — this is a coverage hole in an already-declared rule, not a new contract: HOLDS.**
`FieldOperatorsSchema` has declared `$in`/`$nin` as `z.array(z.any())` and `$between` as
`z.tuple([min, max])` all along; the `LIST_COMPARAND_OPERATORS` branch in
`filter-comparand-type.ts` guarded on `Array.isArray(comparand)` and fell through in
silence, with a comment naming the engine's #5869 gate as the owner. No path refused the
shape before an engine.

## Measurements

**mingo 7.2.4, through a temporary local override — the escape is gone.** Override
`mingo: '7.2.4'` added to `pnpm-workspace.yaml`'s `overrides`, `pnpm install`, resolved
version confirmed `7.2.4`:

```
pnpm --filter @objectstack/driver-memory exec vitest run --maxWorkers=2
  Test Files  25 passed (25)
       Tests  760 passed (760)
```

**Reverse verification, on that same mingo 7.2.4** — direction predicted before running
it: RED. With `packages/spec/src/data/filter.zod.ts` and
`memory-filter-ast-vocabulary.test.ts` restored from `origin/main` and `packages/spec`
rebuilt, the reported CI failure reproduces exactly:

```
 × expresses notin without dropping it
AssertionError: promise rejected "TypeError: b.filter is not a function" instead of resolving
  Test Files  1 failed (1)
       Tests  1 failed | 63 passed (64)
```

Both files were then restored from the commit and the suite re-run green on 7.2.4.

**The override was reverted and committed nowhere.** `pnpm-workspace.yaml` and
`pnpm-lock.yaml` were restored with `git checkout HEAD --` and proved byte-identical to
their pre-override state by object id (`d56d7c98…` / `25a37d11…` before and after), with
`pnpm install` re-run and `mingo` confirmed back at `7.2.2`. `git status` is clean and the
PR diff contains no manifest or lockfile path.

## Tests and gates — all at `c44f4f29f`

Suites (`vitest run --maxWorkers=2`), on mingo 7.2.2:

```
@objectstack/spec               408 files, 10855 tests — passed
@objectstack/objectql           213 files,  3755 tests — passed
@objectstack/driver-memory       25 files,   760 tests — passed
@objectstack/driver-sql          99 files,  1734 tests — passed (4 files / 57 tests skipped)
@objectstack/metadata-protocol   77 files,  1722 tests — passed
@objectstack/service-analytics  115 files,  1588 tests — passed
```

`typecheck` green for spec (including `check:scripts-typecheck` and
`check:test-typecheck`), objectql, driver-memory, driver-sql.

Gates, re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs` and all
green: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`,
`check:doc-formula-expressions`, `check:durability-log-level`, `check:empty-state`,
`check:liveness`, `check:merge-driver`, `check:objectui-changeset`,
`check:spec-parsed-alias`, `check:stack-collection-maps`, `check:strictness-ledger`,
`check:test-source-alias`, `check:type-source-resolution`, `check:variant-docs`,
`check:exported-any`, `check:dual-source-exports`, `check:nul-bytes`,
`check-adr-0087-registration`, `check-changeset-no-major`, `check-cross-package-test-inputs`,
`check-dev-prereqs`, `check-empty-changeset`, `check-engine-split-ratio`,
`docs-audit/check-affected-docs`, and the convention-triggered
`check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt`
(`--re-measure`, 33 entries, none above its recorded number), `check:engine-double-contract`,
`check:where-matcher`. `pnpm --filter @objectstack/spec check:generated` is clean;
`api-surface/data.json` and `export-origins/data.json` each gained exactly one line for
the one new export.

## Fixture triage

Two suites were re-judged rather than mass-edited:

- `memory-filter-ast-vocabulary.test.ts` — its `valueFor` named the membership spellings
  in a literal list and named three of four, so `notin` fell to the scalar default. That
  accident was the only probe covering this hole. It now derives the value from the spec's
  own lowering, which closes the **class**: a membership spelling added to
  `AST_OPERATOR_MAP` tomorrow gets a list without anyone editing this file. A new case
  pins the refusal envelope directly, since nothing in the suite produces the shape any
  more.
- `filter-field-reference-lowering.test.ts` — its vocabulary sweep feeds every operator a
  `{ $field }` comparand, which is not an array. The five list-shaped spellings now refuse
  at this face (as they have refused at the engine since #6209, so nothing that executed
  stops executing). The sweep records them in a named `refused` list asserted against the
  exact expected five, rather than swallowing them in a bare `catch` — a spelling that
  starts refusing when it used to lower still has to show.

## One correction to the card

The card and its dispatch list `not in` (space-spelled) among the membership spellings the
spec accepts. It is not in `AST_OPERATOR_MAP`, so `VALID_AST_OPERATORS` does not contain
it, `isFilterAST` refuses it, and `metadata-protocol` answers `unrecognised operator "not in"`
— pinned in `protocol.malformed-filter.test.ts`. The real set is `in` / `nin` / `not_in` /
`notin`, and the test asserts exactly that set rather than a hand-written four. The
driver-local `case 'not in':` arm in the frozen `driver-memory` is filed separately as an
observation.

## Review routing

This diff touches `packages/spec/src/**` and was produced at `opus` under the maintainer's
quota exemption, below `CONTRACT_REVIEW_TIER`. It carries `needs:contract-review`; the
contract-facing change is deliberately kept to one new module (a move), one optional
parameter, one barrel line and one call site, so the reviewer's surface is the delta table
above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDA9nN6nXQngoQUAAzRdMb)_