### PR TITLE
docs: adopt the new tagline across README and the docs homepage hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)
 ![Tests](https://img.shields.io/badge/tests-6%2C507%20passing-brightgreen.svg)
 
-> ## A complex CRM system in 170k tokens.
+> ## Apps small enough for AI to hold whole.
 >
-> ObjectStack compresses an entire app — data model, UI, workflows,
-> permissions — into typed metadata an AI agent can hold in context, reason
-> about, and refactor whole ([a complete CRM is under 170k
-> tokens](#why-the-mistakes-dont-ship)). That metadata is your **business
-> ontology** — an open, versioned definition of your objects, permissions, and
-> flows that you own, not code scattered across a framework. Strict TypeScript,
-> Zod schemas, and a validation gate catch the agent's mistakes at authoring
-> time; the runtime derives the database, REST API, UI, and MCP server, and
-> enforces permissions and audit on every call.
+> ObjectStack turns the whole app — data model, UI, workflows, permissions —
+> into typed metadata: a complete CRM in under 150k tokens, one context window.
+> Agents read it whole, reason it whole, refactor it whole.
+>
+> The business logic alone — every object, workflow and permission — is under
+> 100k tokens; the UI adds just 50k more.
+>
+> That metadata is your **business ontology** — an open, versioned definition of
+> your objects, permissions, and flows that you own, not code scattered across a
+> framework. Strict TypeScript, Zod schemas, and a validation gate catch the
+> agent's mistakes at authoring time; the runtime derives the database, REST API,
+> UI, and MCP server, and enforces permissions and audit on every call.
 
 `Fits in an agent's context` · `Typed, validated, governed` · `Self-host anywhere` · Apache-2.0
 

--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -18,10 +18,10 @@ const mono = IBM_Plex_Mono({
 
 export const metadata: Metadata = {
   title: {
-    absolute: 'ObjectStack — A complete business system in 16k tokens',
+    absolute: 'ObjectStack — Apps small enough for AI to hold whole.',
   },
   description:
-    'ObjectStack compresses an entire business app — data model, UI, workflows, permissions — into typed metadata an AI agent can hold in context, reason about, and refactor whole; a complete CRM is under 2,000 lines. That metadata is your business ontology — an open, versioned definition you own. Strict TypeScript, Zod, and a validation gate catch the agent\'s mistakes at authoring time, and the runtime derives the database, REST API, UI, and MCP server, enforcing permissions and audit on every call.',
+    'ObjectStack turns the whole app — data model, UI, workflows, permissions — into typed metadata: a complete CRM in under 150k tokens, one context window. Agents read it whole, reason it whole, refactor it whole. The business logic alone — every object, workflow and permission — is under 100k tokens; the UI adds just 50k more. That metadata is your business ontology — an open, versioned definition you own. Strict TypeScript, Zod, and a validation gate catch the agent\'s mistakes at authoring time, and the runtime derives the database, REST API, UI, and MCP server, enforcing permissions and audit on every call.',
 };
 
 const VOCABULARY: { tag: string; title: string; copy: string }[] = [
@@ -114,19 +114,25 @@ export default function HomePage() {
               className="mt-5 text-[2.6rem]/[1.06] font-bold tracking-tight text-balance md:text-6xl/[1.04]"
               style={{ fontFamily: 'var(--l-display)' }}
             >
-              A complete business system{' '}
+              Apps small enough{' '}
               <span className="block bg-gradient-to-r from-indigo-500 to-purple-500 bg-clip-text text-transparent dark:from-indigo-400 dark:to-purple-400">
-                in 16k tokens.
+                for AI to hold whole.
               </span>
             </h1>
             <p className="mt-6 max-w-xl text-lg text-fd-muted-foreground text-pretty">
-              ObjectStack compresses an entire app — data model, UI, workflows, permissions —
-              into typed metadata an AI agent can hold in context, reason about, and refactor
-              whole; a complete CRM is under 2,000 lines. That metadata is your business
-              ontology — an open, versioned definition you own. Strict TypeScript, Zod schemas,
-              and a validation gate catch the agent's mistakes at authoring time, and the
-              runtime derives the database, REST API, UI, and MCP server — permissions and
-              audit enforced on every call.
+              ObjectStack turns the whole app — data model, UI, workflows, permissions — into
+              typed metadata: a complete CRM in under 150k tokens, one context window. Agents
+              read it whole, reason it whole, refactor it whole.
+            </p>
+            <p className="mt-4 max-w-xl text-lg text-fd-muted-foreground text-pretty">
+              The business logic alone — every object, workflow and permission — is under 100k
+              tokens; the UI adds just 50k more.
+            </p>
+            <p className="mt-4 max-w-xl text-base text-fd-muted-foreground text-pretty">
+              That metadata is your business ontology — an open, versioned definition you own.
+              Strict TypeScript, Zod schemas, and a validation gate catch the agent's mistakes
+              at authoring time, and the runtime derives the database, REST API, UI, and MCP
+              server — permissions and audit enforced on every call.
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-3">
               <Link


### PR DESCRIPTION
Fixes #9241

Adopts the maintainer's definitive tagline (2026-08-17) on the root README first screen and the docs-site homepage hero, and adds the business-logic split line. **Both blocks are used verbatim — not one word rewritten or polished.** Verified mechanically rather than by eye: the flowed text of each surface is normalized for whitespace and asserted to contain the definitive strings as substrings (README hero, docs hero, docs page metadata: all three green).

Number discipline held everywhere the copy landed: **150k is always the whole app including UI; 100k is always the business logic alone.** The two numbers never swap host nouns.

## Changed — 2 files, 6 spots

| # | Location | Was | Now |
| :-- | :-- | :-- | :-- |
| 1 | `README.md:7` | `## A complex CRM system in 170k tokens.` | `## Apps small enough for AI to hold whole.` |
| 2 | `README.md:9-13` | `ObjectStack compresses an entire app … refactor whole ([a complete CRM is under 170k tokens](#why-the-mistakes-dont-ship))` | tagline body verbatim, then the split line as its own paragraph |
| 3 | `apps/docs/app/[lang]/page.tsx:21` | metadata title `ObjectStack — A complete business system in 16k tokens` | `ObjectStack — Apps small enough for AI to hold whole.` |
| 4 | `apps/docs/app/[lang]/page.tsx:24` | metadata description opening `ObjectStack compresses an entire business app … a complete CRM is under 2,000 lines` | tagline + split line verbatim |
| 5 | `apps/docs/app/[lang]/page.tsx` h1 | `A complete business system` / `in 16k tokens.` | `Apps small enough` / `for AI to hold whole.` (gradient span kept on the second half) |
| 6 | `apps/docs/app/[lang]/page.tsx` lead paragraph | old `compresses an entire app` paragraph | tagline paragraph, split-line paragraph, then the surviving ontology/typed tail |

Two shape notes, both formatting only, no words touched:

- The tagline's **first sentence becomes the headline** (README H2, docs h1, docs metadata title) and the remaining two sentences the body — exactly the split the README already used for the retired copy. Concatenating headline + body reproduces the definitive paragraph verbatim.
- The old anchor link `[a complete CRM is under 170k tokens](#why-the-mistakes-dont-ship)` is **dropped, not re-pointed**: the definitive copy carries no link, and inserting one would be editing it. The heading it pointed at is untouched and still reachable from the README table of contents.

The ontology / TypeScript / runtime-derives tail of both paragraphs is retained — it is separate content, not the retired tagline, and the definitive copy does not replace it.

## Swept and deliberately NOT changed

Grep sweep over `README*`, `content/docs/**`, `apps/docs/app/**`, `content/blog/**` for `170k`, `A complex business system`, `compresses an entire app`, `hold in context`, `one context window`, `entire/whole app`, and every `100k` / `150k` / `2,000 lines` token claim. Residual old copy after this PR: **zero hits**.

| Location | Hit | Why it stays |
| :-- | :-- | :-- |
| `README.md` "The other half is size" | `examples/app-crm` is `31 files, 1,792 lines, roughly 16k tokens` — "the whole business system, in about 8% of a 200k-token context window" | A **measured count of the bundled example**, reproducible by the `find … wc -l` command printed directly beneath it. Not the retired tagline and not a 150k/100k host-noun claim. See the flag below. |
| `content/docs/concepts/metadata-driven.mdx:219-232` | same 31 / 1,792 / ~16k table + the same 8% sentence | Same measured count, same reason. |
| `content/docs/getting-started/how-ai-development-works.mdx:29-34` | same measured count in prose | Same measured count, same reason. |
| `content/docs/concepts/metadata-driven.mdx:11-14` (Callout) | "the whole app is a few hundred lines of typed, analyzable metadata … it fits in an agent's context window" | Carries no token number and none of the retired phrases; nothing to align. |
| `content/blog/context-window-is-the-constraint.mdx:43-52` | 16k (CRM) · ~14.5k (Todo) · ~101k (showcase) | Outside this card's declared surface (`content/blog` is neither `README*` nor a `content/docs` home/overview page), and the ~101k is a measurement of the kitchen-sink showcase app **including UI** — it is not the 100k business-logic host noun. Listed for sweep completeness. |
| `content/docs/references/**` | `contextWindow`, `compression` field rows | Generated schema reference; unrelated to tagline copy. |
| `content/docs/capabilities/approvals.mdx:22`, `content/docs/protocol/objectui/index.mdx:511`, `skills/**`, `packages/**` | `100k` / `100K` as currency amounts, row counts, log-rotation sizes | Unrelated to token claims. |
| `content/docs/index.mdx` and the section overview pages (`capabilities`, `build-without-code`, `getting-started`, `concepts`) | — | Read in full; they carry no retired tagline, so there was nothing to align. |
| `content/docs/releases/**` | — | Repo rule: never touched in a code PR. |
| GitHub repo `description` field | — | Not in git. Per the issue, the maintainer pastes the first two sentences in the UI; out of this PR's reach. |

**One thing for the maintainer to decide (not fixed here).** The tagline says a complete CRM is under **150k** tokens, while three docs surfaces measure the bundled `examples/app-crm` at **~16k**. Both claims read as "a complete CRM". This tension is **pre-existing, not introduced here** — the retired tagline said 170k while the same pages already said 16k, so the two figures have coexisted on `main` by prior arrangement (tagline = a full-featured CRM; the example = the minimal bundled one). Re-measuring or reconciling them would mean either inventing numbers or editing the definitive copy, so this PR does neither and surfaces it instead.

## Verification

Union re-run **after** the final commit, at `89e946c50` (`git rev-parse --short HEAD`):

- `node scripts/check-nul-bytes.mjs --self-test` — 75 assertions green; `node scripts/check-nul-bytes.mjs` — OK, 6039 text files, no raw control bytes. Plus a targeted `grep -naP` control-byte self-scan of both changed files: clean.
- `pnpm --filter @objectstack/docs types:check` (`fumadocs-mdx && next typegen && tsc --noEmit`) — green, exit 0. The apostrophe in `agent's` inside JSX is the same construct the retired paragraph already used at that spot.
- `node scripts/pm/dispatch-gates.mjs README.md 'apps/docs/app/[lang]/page.tsx'` — re-derived against the actual changed paths: no check family names these paths and no workflow path filter schedules one for them; no model-tier path mandate. `check:nul-bytes` was run anyway as the every-edit family.

No changeset: both surfaces are unpublished (`@objectstack/docs` is `private: true`, the README ships in no package), so this PR releases nothing — `skip-changeset` applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_