### PR TITLE
fix(gate): see a non-literal `code:` in an object literal — a constant resolves, a template is reported (#9223)

### DIFF
--- a/packages/runtime/src/dispatcher-error-vocabulary.ts
+++ b/packages/runtime/src/dispatcher-error-vocabulary.ts
@@ -68,7 +68,22 @@ export type CodeStampShape =
     /** `readonly code = CONST` — the same, through a resolved constant. */
     | 'classconst'
     /** `code: 'X'` in an object literal. */
-    | 'objlit';
+    | 'objlit'
+    /**
+     * [#9223] `code: CONST` in an object literal — the same indirection
+     * `classconst` follows, in the shape that stamps most of this repo's codes.
+     * Missing from the scan until #9223, which is why the rows carrying it were
+     * all added at once: `objlit` demanded a quoted literal, so a constant in an
+     * object literal matched NOTHING and was not even reported as unresolved.
+     */
+    | 'objlitconst'
+    /**
+     * [#9223] `` code: `A_${x}_B` `` — a code built by interpolation. No source
+     * scan can evaluate one, so the gate reports it under its FAMILY identity
+     * (`${…}` → `*`, e.g. `APPROVAL_*_FAILED`) and a row must classify it. The
+     * only verdict that can honestly cover a family is `runtime-pinned`.
+     */
+    | 'objlittemplate';
 
 /**
  * Where the stamped code can end up. `dispatcher` is the door this card is
@@ -86,7 +101,15 @@ export type CodeStampShape =
  * reachability question this table answers. Both were spelled `sendError` until
  * #9098; that collision is what let the door's hole read as closed.
  */
-export type CodeDoor = 'dispatcher' | 'rest' | 'none';
+ *
+ * [#9223] `plugin-route` is a THIRD door, surfaced by the widened scan: a plugin
+ * that mounts its own Hono routes answers refusals with its own `c.json({
+ * success: false, error: { code, message } })` and passes through neither the
+ * dispatcher's `errorFromThrown` nor `packages/rest`'s doors. The envelope is
+ * still an ADR-0112 `error.code` on a wire with a live reader, so a code that
+ * reaches it is a registration question exactly like the other two.
+ */
+export type CodeDoor = 'dispatcher' | 'rest' | 'plugin-route' | 'none';
 
 export type CodeVerdict =
     /**
@@ -114,7 +137,25 @@ export type CodeVerdict =
      * `MONGODB_MULTI_TENANT_UNSUPPORTED` was UNregistered by #8035 for exactly
      * this reason, and "host boot matching is not wire vocabulary".
      */
-    | 'boot-refusal';
+    | 'boot-refusal'
+    /**
+     * [#9223] The site builds its code by INTERPOLATION, so no source scan can
+     * say which codes it produces or whether they are registered — and a named
+     * test does that job at runtime instead, by enumerating the family and
+     * parsing each member against the closed union.
+     *
+     * This is the one verdict that does not decide reachability; it records a
+     * DIVISION OF LABOUR, and it is deliberately hard to misuse:
+     * `check-dispatcher-error-vocabulary` refuses it on any shape other than
+     * `objlittemplate` (on a literal it would be an exemption from the registry
+     * check — the very hole this gate exists to close) and fails when the
+     * {@link UnregisteredCodeSite.pin} file does not exist.
+     *
+     * ⛔ Not a place to park a template nobody checks. If no runtime pin covers
+     * the family, the fix is to stamp a LITERAL code per branch — then the scan
+     * checks it like any other and the door can narrow it.
+     */
+    | 'runtime-pinned';
 
 export interface UnregisteredCodeSite {
     /** The literal as it is stamped. */
@@ -126,6 +167,13 @@ export interface UnregisteredCodeSite {
     readonly verdict: CodeVerdict;
     /** Why this verdict — the evidence, not a restatement of the verdict. */
     readonly why: string;
+    /**
+     * [#9223] Required by `runtime-pinned`, meaningless otherwise: the
+     * repo-relative test that does at runtime what the scan cannot do
+     * statically. The gate checks that this file EXISTS — a deleted pin would
+     * otherwise leave the row asserting a guarantee nothing provides.
+     */
+    readonly pin?: string;
 }
 
 /**
@@ -145,6 +193,48 @@ export const UNREGISTERED_CODE_SITES: readonly UnregisteredCodeSite[] = [
     // whose code is registered fails the gate in the other direction. A future
     // unswept producer lands here as an `unclassified-site` finding and gets a
     // new row (then a spec-lane registration, then the row comes out again). ──
+
+    // ── pending registration, found by #9223's widened scan ────────────────
+    {
+        code: 'UNIQUE_SCOPE_CONFIRMATION_REQUIRED',
+        file: 'packages/cloud-connection/src/marketplace-install-local-plugin.ts',
+        shape: 'objlitconst',
+        door: 'plugin-route',
+        verdict: 'pending-registration',
+        why:
+            'Returned as `error.code` by the marketplace install seam when the ADR-0120 D5e posture gate ' +
+            'stops an install, and READ off the wire: `packages/cli/src/commands/package/install.ts` ' +
+            "branches on `res.body?.error?.code === 'UNIQUE_SCOPE_CONFIRMATION_REQUIRED'` to print the " +
+            'per-index decision list. That the seam speaks REGISTERED vocabulary is measurable rather ' +
+            'than assumed: every sibling code in the same file (PLUGIN_MANIFEST_INVALID, ' +
+            'MARKETPLACE_UNAVAILABLE, INVALID_REQUEST, RESOURCE_NOT_FOUND, CLOUD_FETCH_FAILED, …) is in ' +
+            'the ledger already, which is why the scan never reported them — this one member is the gap. ' +
+            'Invisible until #9223 for one reason only: it is stamped through a constant ' +
+            '(GLOBAL_UNIQUE_CONFIRMATION_REQUIRED, `packages/types/src/unique-scope-install-gate.ts`) in ' +
+            'an object literal, the shape `objlit` could not see. ⇒ the spec lane registers it.',
+    },
+
+    // ── runtime-pinned: an interpolated family, checked where it can be ─────
+    {
+        code: 'APPROVAL_*_FAILED',
+        file: 'packages/rest/src/rest-server.ts',
+        shape: 'objlittemplate',
+        door: 'rest',
+        verdict: 'runtime-pinned',
+        pin: 'packages/rest/src/rest-approvals-wire-codes.test.ts',
+        why:
+            "Three approvals route factories (`decisionRoute`, `flowMoveRoute`, `threadRoute`) spell the " +
+            'terminal 500 catch\'s code as a template — `` `APPROVAL_${action.toUpperCase()}_FAILED` `` and ' +
+            'two siblings — so the family, not a literal, is what exists in source. #8885 registered all ' +
+            'nine codes the family produces, and its pin is what keeps that true: it enumerates the ' +
+            'registered `POST /approvals/requests/:id/<action>` routes and asserts the code each catch arm ' +
+            "would generate parses against ApiErrorSchema's closed union, mirroring the production " +
+            "template exactly (single-occurrence `.replace('-', '_')` included). So a tenth action route " +
+            'whose generated code nobody registers fails THERE, mechanically. This row records that ' +
+            'division of labour instead of letting the scan imply it checked something it cannot: #9223 ' +
+            'widened the scan enough to SEE the template, and seeing it is what makes the pin an ' +
+            'accounted-for half rather than a local habit in one package.',
+    },
 
     // ── sandbox-authored: outside any ledger, by design ────────────────────
     // (no source site — the producer is tenant code; see SANDBOX_AUTHORED_LIMB)
@@ -186,6 +276,61 @@ export const UNREGISTERED_CODE_SITES: readonly UnregisteredCodeSite[] = [
             'that body is returned untouched as `result`. So the string never lands in an ADR-0112 ' +
             '`error.code`. This is the row that shows why verdicts are DECLARED: it is written exactly ' +
             'like FLOW_FAILED and a documented catch one layer up makes it unreachable.',
+    },
+    {
+        code: 'YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER',
+        file: 'packages/plugins/plugin-auth/src/auth-manager.ts',
+        shape: 'objlitconst',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            "better-auth's own APIError vocabulary — the vendor's `YOU_ARE_NOT_ALLOWED_TO_*` family, " +
+            'thrown as `new APIError(\'FORBIDDEN\', { message, code })` so the remove-member guard\'s ' +
+            'refusal SET stays byte-for-byte the vendor\'s (see the contract note in ' +
+            '`remove-member-permission-guard.ts`; only the envelope differs). It cannot reach this door, ' +
+            'by the same route the IMPERSONATION_ROTATION_FAILED row documents and re-verified here: ' +
+            '`domains/auth.ts` catches everything the auth service throws and answers ' +
+            '`deps.error(INTERNAL_ERROR_MESSAGE, 500)` — unconditionally, never `errorFromThrown` (#5085). ' +
+            'So the string never lands in an ADR-0112 `error.code`.',
+    },
+    {
+        code: 'OS_METADATA_CONVERTED',
+        file: 'packages/spec/src/conversions/apply.ts',
+        shape: 'objlitconst',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            'The ADR-0087 D4 conversion-notice vocabulary, not an error vocabulary at all: ' +
+            '`applyConversions` PASSES this code to an `onNotice` callback in a structured ' +
+            'ConversionNotice, and the loader, `validate` and the MCP deprecations surface consume that ' +
+            'shape. Nothing is thrown and no envelope is built. Same class as the INVALID_SCREEN_INPUT ' +
+            'row — a result envelope that merely spells itself `code`.',
+    },
+    {
+        code: 'OS_METADATA_CONVERSION_CONFLICT',
+        file: 'packages/spec/src/conversions/apply.ts',
+        shape: 'objlitconst',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            'The conflict twin of the OS_METADATA_CONVERTED row: handed to `onConflict` when a rename ' +
+            "target is a live name owned by something else, so the conversion refuses to rewrite it and " +
+            'surfaces a loud diagnostic instead (ADR-0078: never silent). A callback payload, not a ' +
+            'thrown error and not a response body.',
+    },
+    {
+        code: 'ERR_BULK_PER_ROW_HOOK_LIMIT',
+        file: 'packages/spec/src/data/bulk-write-hook-conformance.ts',
+        shape: 'objlitconst',
+        door: 'none',
+        verdict: 'foreign-vocabulary',
+        why:
+            'The declaring source rules on this itself, in the doc comment on the constant: ' +
+            '"Deliberately an `ERR_`-prefixed operational code on the thrown error\'s own property bag, ' +
+            'NOT an ADR-0112 wire code … minting a member of it by side effect is the exact ' +
+            '`declared != enforced` shape that vocabulary exists to prevent." It is RETURNED in a ' +
+            '`BulkPerRowHookBudgetVerdict` by a function documented pure and total (no throw); the engine ' +
+            'raises, the contract decides.',
     },
     {
         code: 'SQLITE_ERROR',

--- a/packages/runtime/src/dispatcher-error-vocabulary.ts
+++ b/packages/runtime/src/dispatcher-error-vocabulary.ts
@@ -100,7 +100,6 @@ export type CodeStampShape =
  * — so a code stamped on a thrown value and passed through remains exactly the
  * reachability question this table answers. Both were spelled `sendError` until
  * #9098; that collision is what let the door's hole read as closed.
- */
  *
  * [#9223] `plugin-route` is a THIRD door, surfaced by the widened scan: a plugin
  * that mounts its own Hono routes answers refusals with its own `c.json({

--- a/packages/runtime/src/error-envelope.conformance.test.ts
+++ b/packages/runtime/src/error-envelope.conformance.test.ts
@@ -242,12 +242,15 @@ describe('#8087 — every code the dispatcher door can emit is parsed against Ap
         );
 
     it('drives a code from the derivation rather than a list written by hand', () => {
-        // #8846 registered every code the first derivation reported, so the
-        // pending list is EMPTY now and the per-code rejection drives below
-        // are vacuous BY DESIGN — that emptiness is the discharged state, not
-        // a broken wiring. The suite does not go quiet with it: the seven
-        // registered codes are driven POSITIVELY in the '#8846 discharge' case
-        // below, and a future pending row re-populates the loop on its own.
+        // #8846 registered every code the FIRST derivation reported, which
+        // emptied this list; [#9223] widening the scan to see a `code: CONST`
+        // in an object literal re-populated it with one member —
+        // UNIQUE_SCOPE_CONFIRMATION_REQUIRED, at the marketplace install seam's
+        // `plugin-route` door — which is the loop working, not a regression.
+        // PENDING_AT_DISPATCHER_DOOR stays empty because that code never passes
+        // through this door, so the per-code drives below remain vacuous BY
+        // DESIGN; the suite does not go quiet with them, since the seven
+        // registered codes are driven POSITIVELY in the '#8846 discharge' case.
         // Spread: both lists are `readonly string[]`, and `arrayContaining`
         // takes a mutable one — passing the frozen list straight in is a tsc
         // error that only the TEST_DEBT ratchet would have caught.
@@ -360,8 +363,33 @@ describe('#8087 — every code the dispatcher door can emit is parsed against Ap
             expect(site.why.length, `${site.code} at ${site.file} carries no evidence`).toBeGreaterThan(40);
             // A site that reaches a door must be on its way to a ledger row;
             // anything else must say which non-wire vocabulary it belongs to.
-            if (site.door !== 'none') expect(site.verdict).toBe('pending-registration');
-            else expect(site.verdict).not.toBe('pending-registration');
+            //
+            // [#9223] One exception, and it is about what a SOURCE SCAN can
+            // know rather than about reachability: a code built by template
+            // interpolation reaches the `rest` door and yet has no literal to
+            // register, so `runtime-pinned` names the test that enumerates the
+            // family at runtime. It stays out of PENDING_LEDGER_REGISTRATION
+            // deliberately — a family identity like `APPROVAL_*_FAILED` can
+            // never be registered, and parking it in that list would hand
+            // #8846 a debt nobody can discharge.
+            if (site.door !== 'none') {
+                expect(['pending-registration', 'runtime-pinned']).toContain(site.verdict);
+            } else {
+                expect(site.verdict).not.toBe('pending-registration');
+            }
+        }
+    });
+
+    it('[#9223] every runtime-pinned row names its runtime half, and only a template may', () => {
+        // The declaration-side half of the same guard the gate enforces on the
+        // scan side. `runtime-pinned` is the one verdict that does not decide
+        // reachability, so it is the one that could become an exemption from
+        // the registry check — on a literal it would be exactly that.
+        for (const site of UNREGISTERED_CODE_SITES.filter((s) => s.verdict === 'runtime-pinned')) {
+            expect(site.shape, `${site.code} is runtime-pinned but spells a literal`).toBe('objlittemplate');
+            expect(site.pin, `${site.code} is runtime-pinned with no pin`).toBeTruthy();
+            expect(site.code, `${site.code} is not a template family identity`).toContain('*');
+            expect(PENDING_LEDGER_REGISTRATION).not.toContain(site.code);
         }
     });
 });

--- a/scripts/check-dispatcher-error-vocabulary.mjs
+++ b/scripts/check-dispatcher-error-vocabulary.mjs
@@ -58,12 +58,21 @@
  * string literal in one of a handful of syntactic positions, and the positions
  * are more varied than an AST shape for "the value of an error's code property"
  * would cover (class field, constructor-side object literal, post-hoc
- * assignment, a constant one module over). The four shapes below are published
+ * assignment, a constant one module over). The six shapes below are published
  * rather than left inside the implementation, and `--self-test` pins each one —
  * because the price of a source scan is that it sees only the spellings it
  * knows, and an unrecognised one produces no finding, SILENTLY. Reaching for a
  * spelling that is not here? Extend `SHAPES` and add a `--self-test` case in the
  * same edit.
+ *
+ * [#9223] That price was being paid, by this gate, in the shape it scans most.
+ * `objlit` demanded a QUOTED literal, so `code: SOME_CONST` and a
+ * template-generated `` code: `A_${x}_B` `` in an object literal matched
+ * nothing — not reported as unresolved, not reported at all. The bound below
+ * ("REPORTED as unresolved, never dropped") held for `classconst` and for
+ * nothing else, and #8885 had already paid for the gap once: it could not lean
+ * on this gate for the template-generated `APPROVAL_*_FAILED` family and wrote
+ * a bespoke runtime pin instead. `objlitconst` and `objlittemplate` close it.
  *
  * ## Declared bounds — printed on every run, so a partial gate cannot read as a
  * ## complete one
@@ -77,7 +86,16 @@
  *     defect with its own gate (`check:error-code-casing`, ADR-0112 D6/D6b/D6c).
  *   - A constant this gate cannot resolve is REPORTED as unresolved, never
  *     dropped: a deriver that goes quietly blind is the same failure one layer
- *     down.
+ *     down. [#9223] A constant imported from a WORKSPACE package is resolved
+ *     rather than reported — `packages/` is inside the scan by construction —
+ *     but only to a unique value within that package; an ambiguous one is
+ *     reported. A third-party dependency's constant stays out of reach.
+ *   - [#9223] A code built by TEMPLATE INTERPOLATION cannot be evaluated by any
+ *     source scan, so it is reported under its family identity (`${…}` → `*`)
+ *     and must be classified like any other site. Its verdict may be
+ *     `runtime-pinned` — the one verdict that names a test doing at runtime
+ *     what this scan cannot do statically — and that verdict is refused on any
+ *     other shape and requires a `pin:` file that EXISTS.
  *   - The sandbox limb is OUT of this scan's reach by construction — a metadata
  *     app's action code is authored at runtime, not in this repo. Ruled by
  *     #9106: demoted to the wire's `declaredCode` at the door. See
@@ -140,15 +158,27 @@ export function stripComments(source) {
  */
 export const SHAPES = [
   // `err.code = 'X'` — stamped onto a value about to be thrown.
-  { name: 'assign', re: /(?:^|[^\w.$])[\w$]+\.code\s*=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+  { name: 'assign', re: /(?:^|[^\w.$])[\w$]+\.code\s*=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, resolve: 'literal' },
   // `readonly code = 'X'` / `readonly code: T = 'X'` — an error class's identity.
-  { name: 'classfield', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+  { name: 'classfield', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*'([A-Za-z][A-Za-z0-9_]*)'/g, resolve: 'literal' },
   // `readonly code = CONST` — the same, one indirection away.
-  { name: 'classconst', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*([A-Z][A-Z0-9_]*)\s*[;,\n]/g, literal: false },
+  { name: 'classconst', re: /\breadonly\s+code\s*(?::[^=;\n]+)?=\s*([A-Z][A-Z0-9_]*)\s*[;,\n]/g, resolve: 'constant' },
   // `code: 'X'` in an object literal (constructor options, Object.assign, a
   // returned envelope). The broadest shape, and the reason verdicts exist:
   // plenty of these are not wire codes at all.
-  { name: 'objlit', re: /\bcode:\s*'([A-Za-z][A-Za-z0-9_]*)'/g, literal: true },
+  { name: 'objlit', re: /\bcode:\s*'([A-Za-z][A-Za-z0-9_]*)'/g, resolve: 'literal' },
+  // [#9223] `code: CONST` in an object literal — the SAME indirection
+  // `classconst` already follows, in the shape that stamps most of this repo's
+  // codes. Left out of the original four, it was the gate's own blind spot:
+  // `objlit` required a quoted literal, so a constant in an object literal
+  // matched nothing at all and was never even reported as unresolved.
+  { name: 'objlitconst', re: /\bcode:\s*([A-Z][A-Z0-9_]*)\s*[,;}\n]/g, resolve: 'constant' },
+  // [#9223] A template-literal `code:`. Evaluating one needs the RUNTIME values
+  // of its interpolations, which a source scan does not have — so it is
+  // reported as unresolved, which is what the header's bound requires of any
+  // value this gate cannot reduce to a literal. A template with no
+  // interpolation is just a literal wearing backticks and is treated as one.
+  { name: 'objlittemplate', re: /\bcode:\s*`([^`]*)`/g, resolve: 'template' },
 ];
 
 const isTestFile = (rel) =>
@@ -162,6 +192,20 @@ const isTestFile = (rel) =>
  * exclusion cannot be widened into a blanket ignore that hides a real emitter.
  */
 const isDeclarationFile = (rel) => rel === DECLARATION;
+
+/** [#9223] Every workspace `package.json` under the scan root. */
+export function* walkManifests(dir, root) {
+  for (const entry of readdirSync(dir).sort()) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const abs = join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      yield* walkManifests(abs, root);
+      continue;
+    }
+    if (entry !== 'package.json') continue;
+    yield { rel: relative(root, abs).replace(/\\/g, '/'), abs };
+  }
+}
 
 export function* walkSources(dir, root) {
   for (const entry of readdirSync(dir).sort()) {
@@ -179,16 +223,51 @@ export function* walkSources(dir, root) {
 }
 
 /**
+ * `@objectstack/spec/api` → `@objectstack/spec`; `node:path` → `node:path`.
+ * The subpath is dropped because the package's export map, not the subpath,
+ * decides which file actually declares a name — and this gate reads source.
+ */
+export function packageOfSpecifier(spec) {
+  const m = /^(@[^/]+\/[^/]+|[^./][^/]*)/.exec(spec);
+  return m ? m[1] : null;
+}
+
+/**
+ * `name` → repo-relative directory, read from each workspace `package.json`.
+ * Derived rather than assumed: `@objectstack/plugin-auth` lives at
+ * `packages/plugins/plugin-auth`, so name-to-path arithmetic answers wrongly.
+ */
+export function parsePackageDirs(manifests) {
+  const dirs = new Map();
+  for (const { rel, source } of manifests) {
+    let name;
+    try { name = JSON.parse(source).name; } catch { continue; }
+    if (typeof name === 'string' && name) dirs.set(name, rel.replace(/\/package\.json$/, ''));
+  }
+  return dirs;
+}
+
+/**
  * Resolve `NAME` to its string value: the declaring file first, then the module
  * it is imported from. Two packages export a `MULTI_TENANT_UNSUPPORTED_CODE`
  * with DIFFERENT values, so a repo-wide name lookup would answer confidently
  * and wrongly — the in-file declaration has to win, and the import has to be
  * followed to its own file rather than guessed.
  *
+ * [#9223] A bare specifier is followed too, but ONLY when it names a workspace
+ * package: `import { ANONYMOUS_DENY_CODE } from '@objectstack/core'` points at
+ * `packages/core/`, which is inside this scan by construction, so treating it
+ * as out of reach reported eight resolvable constants as unresolvable. The
+ * lookup is scoped to THAT package's sources and requires a UNIQUE value — the
+ * two-drivers-one-constant-name hazard above is a repo-wide lookup's failure,
+ * and the same hazard inside one package (two spellings, two values) resolves
+ * to `null` and is reported rather than guessed. A genuine third-party
+ * dependency has no workspace directory and stays out of reach.
+ *
  * Returns `null` when it cannot be resolved; the caller reports that, never
  * drops it.
  */
-export function resolveConstant(name, fileSource, fileRel, readFile) {
+export function resolveConstant(name, fileSource, fileRel, readFile, ctx = {}) {
   const local = new RegExp(`\\b(?:export\\s+)?const\\s+${name}\\s*(?::[^=]+)?=\\s*'([A-Za-z][A-Za-z0-9_]*)'`).exec(
     fileSource,
   );
@@ -199,7 +278,7 @@ export function resolveConstant(name, fileSource, fileRel, readFile) {
   for (const [, clause, spec] of imports) {
     const named = clause.split(',').map((s) => s.trim().split(/\s+as\s+/)[0].trim());
     if (!named.includes(name)) continue;
-    if (!spec.startsWith('.')) return null; // a dependency's constant — out of scan reach
+    if (!spec.startsWith('.')) return resolveFromWorkspacePackage(name, spec, ctx);
     const base = join(dirname(fileRel), spec.replace(/\.[cm]?js$/, ''));
     for (const cand of [`${base}.ts`, `${base}.mts`, `${base}/index.ts`]) {
       const abs = join(ROOT, cand);
@@ -216,25 +295,89 @@ export function resolveConstant(name, fileSource, fileRel, readFile) {
 }
 
 /**
+ * [#9223] A template's FAMILY identity: every `${…}` becomes `*`, so
+ * `` `APPROVAL_${action.toUpperCase()}_FAILED` `` is `APPROVAL_*_FAILED`.
+ *
+ * Why an identity rather than an unresolved note. The gate's declared bound is
+ * that a value it cannot reduce to a literal is REPORTED, never dropped — and
+ * the strongest available report is the one the rest of this gate already uses:
+ * a SITE, which the declaration table must classify with evidence and which
+ * reconciles in BOTH directions (the row goes stale when the template moves).
+ * An "unresolved" note would be reported once and could never be discharged,
+ * which in practice means a permanently red gate or a deleted check.
+ *
+ * The family is also the right grain: the three approvals routes differ only in
+ * how they spell the interpolation, one runtime pin covers all three, and a
+ * NEW family (`BILLING_*_FAILED`) is a new identity and a new finding.
+ */
+export function templateFamily(raw) {
+  return raw.replace(/\$\{[^}]*\}/g, '*');
+}
+
+/**
+ * [#9223] The workspace half of the resolver. Scoped to the named package's
+ * own scanned sources, and unique-or-nothing: two different values for one
+ * name inside one package is exactly the ambiguity this gate must report
+ * rather than pick a side of.
+ */
+function resolveFromWorkspacePackage(name, spec, { scanned, packageDirs } = {}) {
+  if (!scanned || !packageDirs) return null;
+  const dir = packageDirs.get(packageOfSpecifier(spec) ?? '');
+  if (!dir) return null; // a genuine third-party dependency — out of scan reach
+  const re = new RegExp(`\\bexport\\s+const\\s+${name}\\s*(?::[^=]+)?=\\s*'([A-Za-z][A-Za-z0-9_]*)'`);
+  const values = new Set();
+  for (const f of scanned) {
+    if (!f.rel.startsWith(`${dir}/`)) continue;
+    const hit = re.exec(f.stripped);
+    if (hit) values.add(hit[1]);
+  }
+  return values.size === 1 ? [...values][0] : null;
+}
+
+/**
+ * One entry per (file, shape, value). The same constant stamped six times in
+ * one file is one unresolved value to go and fix, not six lines of noise —
+ * but the file is part of the key, so the same name in two files (the
+ * two-drivers-one-constant-name case) stays two findings.
+ */
+function addUnresolved(list, entry) {
+  if (list.some((u) => u.file === entry.file && u.shape === entry.shape && u.value === entry.value)) return;
+  list.push(entry);
+}
+
+/**
  * Every site in scanned source that stamps a code the registered vocabulary
  * does not contain.
  */
-export function deriveSites({ registered, files, readFile }) {
+export function deriveSites({ registered, files, readFile, packageDirs = new Map() }) {
   const sites = [];
   const unresolved = [];
-  for (const { rel, source } of files) {
-    const stripped = stripComments(source);
+  // Stripped once: the workspace resolver reads these same sources, and a
+  // comment naming a constant must not resolve one either.
+  const scanned = files.map(({ rel, source }) => ({ rel, stripped: stripComments(source) }));
+  const ctx = { scanned, packageDirs };
+  for (const { rel, stripped } of scanned) {
     for (const shape of SHAPES) {
       shape.re.lastIndex = 0;
       for (const m of stripped.matchAll(shape.re)) {
         let code = m[1];
-        if (!shape.literal) {
-          const value = resolveConstant(code, stripped, rel, readFile);
+        if (shape.resolve === 'constant') {
+          const value = resolveConstant(code, stripped, rel, readFile, ctx);
           if (value === null) {
-            unresolved.push({ file: rel, shape: shape.name, constant: code });
+            addUnresolved(unresolved, { file: rel, shape: shape.name, value: code, reason: 'constant' });
             continue;
           }
           code = value;
+        } else if (shape.resolve === 'template' && !/^[A-Za-z][A-Za-z0-9_]*$/.test(code)) {
+          // Interpolated: no literal exists to check against the registry. It
+          // becomes a site under its FAMILY identity (`${…}` → `*`) rather than
+          // being dropped — see `templateFamily`.
+          code = templateFamily(code);
+          if (!/^[A-Z*][A-Z0-9_*]*$/.test(code)) continue; // lowercase → check:error-code-casing
+          if (!sites.some((s) => s.code === code && s.file === rel && s.shape === shape.name)) {
+            sites.push({ code, file: rel, shape: shape.name });
+          }
+          continue;
         }
         if (!/^[A-Z][A-Z0-9_]*$/.test(code)) continue; // lowercase → check:error-code-casing
         if (registered.has(code)) continue;
@@ -269,6 +412,7 @@ export function parseDeclaration(source) {
     const shape = /\bshape:\s*'([^']+)'/.exec(entry);
     const door = /\bdoor:\s*'([^']+)'/.exec(entry);
     const verdict = /\bverdict:\s*'([^']+)'/.exec(entry);
+    const pin = /\bpin:\s*'([^']+)'/.exec(entry);
     if (!code || !file || !shape || !door || !verdict) continue;
     rows.push({
       code: code[1],
@@ -276,6 +420,7 @@ export function parseDeclaration(source) {
       shape: shape[1],
       door: door[1],
       verdict: verdict[1],
+      pin: pin ? pin[1] : undefined,
     });
   }
   return rows;
@@ -294,6 +439,20 @@ export function reconcile({ sites, declared, registered, unresolved }) {
 
   for (const site of sites) {
     if (declaredByKey.has(key(site))) continue;
+    if (site.shape === 'objlittemplate') {
+      findings.push({
+        kind: 'unclassified-site',
+        text:
+          `${site.file} stamps its code from a TEMPLATE of the family '${site.code}' and ${DECLARATION} ` +
+          `does not classify it.\n` +
+          `      This gate cannot evaluate an interpolation, so it cannot tell you whether what the ` +
+          `template produces is registered — reported rather than dropped, per the header's bounds.\n` +
+          `      Two ways out: stamp a LITERAL code per branch (then the scan checks it like any other, ` +
+          `and the door can narrow it), or add a row whose verdict is 'runtime-pinned' naming the ` +
+          `\`pin:\` that enumerates the family's codes and parses each against the closed union.`,
+      });
+      continue;
+    }
     findings.push({
       kind: 'unclassified-site',
       text:
@@ -313,6 +472,39 @@ export function reconcile({ sites, declared, registered, unresolved }) {
           `finds it. The producer moved or went away — delete the row.`,
       });
     }
+    // [#9223] `runtime-pinned` exists for the one case a source scan cannot
+    // decide — an interpolated code. On any other shape it would be a way to
+    // declare a literal exempt from the registry check, which is the hole this
+    // gate is, so it is refused there. The pin must also still EXIST: an
+    // evidence file that has been deleted is the same silent blindness one
+    // layer out, and the header's anchor rule already says so.
+    if (row.verdict === 'runtime-pinned') {
+      if (row.shape !== 'objlittemplate') {
+        findings.push({
+          kind: 'misused-verdict',
+          text:
+            `${DECLARATION} declares '${row.code}' at ${row.file} (${row.shape}) as 'runtime-pinned', but ` +
+            `that verdict is only for an interpolated \`code:\` this gate cannot evaluate. A ${row.shape} ` +
+            `site spells a literal — check it against the registry instead of exempting it.`,
+        });
+      } else if (!row.pin) {
+        findings.push({
+          kind: 'missing-pin',
+          text:
+            `${DECLARATION} declares '${row.code}' at ${row.file} as 'runtime-pinned' without a \`pin:\` ` +
+            `naming the test that enumerates the family. The verdict IS the pin — without it the row ` +
+            `only says the gate gave up.`,
+        });
+      } else if (!existsSync(join(ROOT, row.pin))) {
+        findings.push({
+          kind: 'missing-pin',
+          text:
+            `${DECLARATION} declares '${row.code}' at ${row.file} as 'runtime-pinned' by '${row.pin}', but ` +
+            `that file does not exist. The runtime half is what makes this verdict honest — restore it, ` +
+            `point the row at its replacement, or make the site stamp literal codes.`,
+        });
+      }
+    }
     if (row.verdict === 'pending-registration' && registered.has(row.code)) {
       findings.push({
         kind: 'now-registered',
@@ -327,7 +519,7 @@ export function reconcile({ sites, declared, registered, unresolved }) {
     findings.push({
       kind: 'unresolved-constant',
       text:
-        `${u.file}: the code constant '${u.constant}' (${u.shape}) could not be resolved to a literal. ` +
+        `${u.file}: the code constant '${u.value}' (${u.shape}) could not be resolved to a literal. ` +
         `Reported rather than dropped — see the header's bounds. Resolve it, or teach ` +
         `resolveConstant() the spelling.`,
     });
@@ -441,6 +633,9 @@ function selfTest() {
     classfield: `class E extends Error { readonly code = 'ERR_X' as const; }`,
     classconst: `const ERR_CONST = 'RESOLVED_ONE';\nclass E { readonly code = ERR_CONST; }`,
     objlit: `throw Object.assign(new Error('x'), { code: 'OBJ_LIT_ONE' });`,
+    // [#9223] the two shapes that used to match nothing at all.
+    objlitconst: `const OBJ_CONST = 'OBJ_CONST_ONE';\nthrow Object.assign(new Error('x'), { code: OBJ_CONST });`,
+    objlittemplate: 'send(res, { code: `TEMPLATE_${action.toUpperCase()}_FAILED`, status: 500 });',
   };
   const registered = new Set(['ALREADY_REGISTERED']);
   for (const [name, source] of Object.entries(samples)) {
@@ -510,6 +705,155 @@ function selfTest() {
       readFile: () => '',
     });
     ok(sites.length === 0, 'a lowercase literal was claimed by this gate');
+  }
+
+  // [#9223] The two new shapes, in both directions. Each is pinned on the
+  // property that was missing: a constant in an object literal RESOLVES (it
+  // used to match nothing), and an interpolated code becomes a reportable
+  // site (it used to match nothing either).
+  {
+    const one = (source, extra = {}) =>
+      deriveSites({ registered, files: [{ rel: 'packages/x/src/a.ts', source }], readFile: () => '', ...extra });
+
+    // A constant in an object literal reports its VALUE, like `classconst`.
+    const resolved = one(samples.objlitconst);
+    ok(
+      resolved.sites.some((s) => s.code === 'OBJ_CONST_ONE' && s.shape === 'objlitconst'),
+      'objlitconst reported the constant name instead of its value',
+    );
+    ok(
+      !resolved.sites.some((s) => s.code === 'OBJ_CONST'),
+      'objlitconst leaked the constant NAME into the site list',
+    );
+
+    // …and an unresolvable one is reported, not dropped — the bound that did
+    // not hold for object literals before this shape existed.
+    const blind = one(`throw Object.assign(new Error('x'), { code: SOME_UNKNOWN_CONST });`);
+    ok(blind.unresolved.length === 1, 'an unresolvable constant in an object literal produced no finding');
+    ok(blind.sites.length === 0, 'an unresolvable objlit constant leaked into the site list');
+
+    // The same constant stamped many times in one file is ONE thing to fix.
+    const repeated = one(
+      `f({ code: UNKNOWN_ONE });\ng({ code: UNKNOWN_ONE });\nh({ code: UNKNOWN_ONE });`,
+    );
+    ok(repeated.unresolved.length === 1, `repeated unresolvable constants were not deduped: ${repeated.unresolved.length}`);
+
+    // A template becomes a site under its FAMILY identity.
+    const tpl = one(samples.objlittemplate);
+    ok(
+      tpl.sites.some((s) => s.code === 'TEMPLATE_*_FAILED' && s.shape === 'objlittemplate'),
+      `a template code did not report its family: ${JSON.stringify(tpl.sites)}`,
+    );
+    ok(templateFamily('APPROVAL_${a.b()}_FAILED') === 'APPROVAL_*_FAILED', 'templateFamily did not collapse the interpolation');
+
+    // Three spellings of one family in one file are ONE finding — which is the
+    // grain a runtime pin covers.
+    const family = one(
+      'a({ code: `AP_${x.toUpperCase()}_FAILED` });\n' +
+      "b({ code: `AP_${y.toUpperCase().replace('-', '_')}_FAILED` });",
+    );
+    ok(
+      family.sites.filter((s) => s.shape === 'objlittemplate').length === 1,
+      `one template family produced ${family.sites.length} sites instead of one`,
+    );
+
+    // A template with NO interpolation is a literal wearing backticks.
+    const plain = one('a({ code: `PLAIN_BACKTICK_ONE` });');
+    ok(plain.sites.some((s) => s.code === 'PLAIN_BACKTICK_ONE'), 'a non-interpolated template was not read as a literal');
+    ok(
+      one('a({ code: `ALREADY_REGISTERED` });').sites.length === 0,
+      'a registered code in backticks was still reported',
+    );
+
+    // Lowercase stays with check:error-code-casing, in both new shapes.
+    ok(one('a({ code: `lower_${x}_thing` });').sites.length === 0, 'a lowercase template family was claimed by this gate');
+    ok(
+      one(`const lc = 'lower_thing';\na({ code: lc });`).sites.length === 0,
+      'a lowercase-named constant was claimed by this gate',
+    );
+  }
+
+  // [#9223] Workspace-package resolution: `packages/` is inside the scan, so a
+  // sibling package's constant resolves rather than being reported.
+  {
+    const consumer = {
+      rel: 'packages/runtime/src/x.ts',
+      source: `import { DENY_CODE } from '@objectstack/core';\nf({ code: DENY_CODE });`,
+    };
+    const declarer = { rel: 'packages/core/src/deny.ts', source: `export const DENY_CODE = 'WORKSPACE_ONE';` };
+    const packageDirs = parsePackageDirs([
+      { rel: 'packages/core/package.json', source: '{"name":"@objectstack/core"}' },
+      { rel: 'packages/plugins/plugin-auth/package.json', source: '{"name":"@objectstack/plugin-auth"}' },
+    ]);
+    ok(
+      packageDirs.get('@objectstack/plugin-auth') === 'packages/plugins/plugin-auth',
+      'parsePackageDirs assumed name-to-path arithmetic instead of reading the manifest',
+    );
+    ok(packageOfSpecifier('@objectstack/spec/api') === '@objectstack/spec', 'a subpath import lost its package name');
+
+    const resolved = deriveSites({ registered, files: [consumer, declarer], readFile: () => '', packageDirs });
+    ok(
+      resolved.sites.some((s) => s.code === 'WORKSPACE_ONE'),
+      `a workspace constant did not resolve: ${JSON.stringify(resolved)}`,
+    );
+    ok(resolved.unresolved.length === 0, 'a resolvable workspace constant was still reported unresolved');
+
+    // Two values for one name inside one package: reported, never guessed —
+    // the two-drivers hazard, one package in.
+    const ambiguous = deriveSites({
+      registered,
+      files: [consumer, declarer, { rel: 'packages/core/src/other.ts', source: `export const DENY_CODE = 'OTHER_ONE';` }],
+      readFile: () => '',
+      packageDirs,
+    });
+    ok(ambiguous.unresolved.length === 1, 'an ambiguous workspace constant was resolved to one of its two values');
+    ok(!ambiguous.sites.some((s) => s.code === 'OTHER_ONE' || s.code === 'WORKSPACE_ONE'), 'an ambiguous constant produced a site');
+
+    // A genuine third-party dependency stays out of reach, and says so.
+    const thirdParty = deriveSites({
+      registered,
+      files: [{ rel: 'packages/x/src/a.ts', source: `import { CODE } from 'better-auth';\nf({ code: CODE });` }],
+      readFile: () => '',
+      packageDirs,
+    });
+    ok(thirdParty.unresolved.length === 1, "a third-party dependency's constant was not reported as unresolved");
+  }
+
+  // [#9223] `runtime-pinned` is narrow by construction: template shapes only,
+  // and only with a pin file that exists. Otherwise it is a way to declare a
+  // literal exempt from the registry — the hole this gate is.
+  {
+    const tplSite = { code: 'AP_*_FAILED', file: 'packages/rest/src/r.ts', shape: 'objlittemplate' };
+    const row = (over = {}) => ({ ...tplSite, door: 'rest', verdict: 'runtime-pinned', pin: DECLARATION, ...over });
+
+    ok(
+      reconcile({ sites: [tplSite], declared: [row()], registered: new Set(), unresolved: [] }).length === 0,
+      'a template row pinned by an existing file still failed',
+    );
+    ok(
+      reconcile({ sites: [tplSite], declared: [row({ pin: undefined })], registered: new Set(), unresolved: [] })
+        .some((f) => f.kind === 'missing-pin'),
+      'a runtime-pinned row with no pin passed',
+    );
+    ok(
+      reconcile({
+        sites: [tplSite],
+        declared: [row({ pin: 'packages/rest/src/deleted-pin.test.ts' })],
+        registered: new Set(),
+        unresolved: [],
+      }).some((f) => f.kind === 'missing-pin'),
+      'a runtime-pinned row whose pin file is gone passed — the runtime half can vanish silently',
+    );
+    const literalSite = { code: 'LITERAL_ONE', file: 'packages/x/src/a.ts', shape: 'objlit' };
+    ok(
+      reconcile({
+        sites: [literalSite],
+        declared: [{ ...literalSite, door: 'rest', verdict: 'runtime-pinned', pin: DECLARATION }],
+        registered: new Set(),
+        unresolved: [],
+      }).some((f) => f.kind === 'misused-verdict'),
+      'runtime-pinned exempted a LITERAL code from the registry check',
+    );
   }
 
   // Reconciliation: both directions, plus the now-registered ratchet.
@@ -686,7 +1030,11 @@ function main() {
     files.push({ rel, source: readFile(abs) });
   }
 
-  const { sites, unresolved } = deriveSites({ registered, files, readFile });
+  const packageDirs = parsePackageDirs(
+    [...walkManifests(join(ROOT, SCAN_ROOT), ROOT)].map(({ rel, abs }) => ({ rel, source: readFile(abs) })),
+  );
+
+  const { sites, unresolved } = deriveSites({ registered, files, readFile, packageDirs });
   const declared = parseDeclaration(readFileSync(join(ROOT, DECLARATION), 'utf8'));
   const findings = reconcile({ sites, declared, registered, unresolved });
 


### PR DESCRIPTION
Fixes #9223

`check-dispatcher-error-vocabulary` publishes a bound in its own header — "A constant this gate cannot resolve is REPORTED as unresolved, never dropped" — and that bound held for `classconst` and for nothing else. `objlit` demanded a **quoted literal**, so a `code: SOME_CONST` or a template-generated `` code: `A_${x}_B` `` in an object literal matched *nothing*: not a finding, not an unresolved note, not a line of output. A partial gate read as a complete one. This makes the header's bound true for object-literal `code:` sites.

Verified against current `origin/main` (`2f65b1b42`), which is past PR #9222's door-typing half (`0668f02`) — the card quotes pre-#9222 line content; the `SHAPES` table it describes is unchanged by that merge, so the premise held.

## What changed

**Two new shapes** in `SHAPES`, with `--self-test` cases in the same edit as the header's edit rule demands (`literal: true|false` became an explicit `resolve: 'literal' | 'constant' | 'template'`, since there are now three ways a match becomes a code):

- `objlitconst` — `code: CONST` in an object literal. The same indirection `classconst` already followed, in the shape that stamps most of this repo's codes.
- `objlittemplate` — an interpolated `code:`. No source scan can evaluate one, so it is reported under a **family identity** (`${…}` → `*`, e.g. `APPROVAL_*_FAILED`) and must be classified like any other site. A template with no interpolation is a literal wearing backticks and is read as one.

**The resolver now follows workspace-package imports.** `resolveConstant` treated every bare specifier as "a dependency's constant — out of scan reach", but `@objectstack/core` is inside the scan by construction. Without this, the widening reported 8 resolvable constants as unresolvable (7 × `ANONYMOUS_DENY_CODE`, which resolves to the registered `UNAUTHENTICATED`) — noise that would have buried the real finding. Scoped to the named package's own sources and **unique-or-nothing**: two values for one name inside one package resolves to `null` and is reported, never guessed. That is the header's two-drivers-one-constant-name hazard, one package in. A genuine third-party dependency has no workspace directory and stays out of reach. Package directories are read from each `package.json` rather than derived from the name — `@objectstack/plugin-auth` lives at `packages/plugins/plugin-auth`, so name-to-path arithmetic answers wrongly.

**`runtime-pinned`**, a new verdict for the one thing a source scan cannot decide, and deliberately hard to misuse: refused on any shape other than `objlittemplate` (on a literal it would be an exemption from the registry check — the very hole this gate is), required to name a `pin:` file, and the gate fails when that file does not exist.

## What the widening surfaced — measured before scope was settled

Running the widened gate against the whole tree turned a green gate (7 classified sites) into **15 findings**; the workspace resolver removed 8 of those as resolvable, leaving 6 real sites now classified in `dispatcher-error-vocabulary.ts`. Final state: **13 sites, all classified, gate green.**

One is a genuine, previously-invisible hole rather than a bookkeeping row:

**`UNIQUE_SCOPE_CONFIRMATION_REQUIRED` reaches a wire unregistered** — the ADR-0120 D5e posture gate stopping a marketplace install returns it as `error.code`, and `packages/cli/.../install.ts` **reads that exact spelling off the wire** to print the per-index decision list. That the seam speaks registered vocabulary is measurable, not assumed: every sibling code in the same file (`PLUGIN_MANIFEST_INVALID`, `MARKETPLACE_UNAVAILABLE`, `INVALID_REQUEST`, `RESOURCE_NOT_FOUND`, …) is already in the ledger, which is why the scan never reported them. It hid for one reason only: it is stamped through a constant in an object literal. Classified `pending-registration` at a new `plugin-route` door (a plugin mounting its own Hono routes passes through neither the dispatcher nor the `packages/rest` doors); the ledger edit itself belongs to the spec lane, which this table explicitly does not touch — filed as #9246. `PENDING_LEDGER_REGISTRATION` is non-empty again and the ratchet is armed: when that registration lands, the stale row reddens CI and must come out.

The other four are non-wire and say which vocabulary they belong to: better-auth's own `YOU_ARE_NOT_ALLOWED_TO_DELETE_THIS_MEMBER` (`domains/auth.ts` catches everything the auth service throws and answers `INTERNAL_ERROR_MESSAGE, 500` — re-verified, not inherited from the older row), the two ADR-0087 conversion diagnostics passed to `onNotice`/`onConflict`, and `ERR_BULK_PER_ROW_HOOK_LIMIT`, whose declaring source already rules on itself ("Deliberately … NOT an ADR-0112 wire code").

## Disposition: `rest-approvals-wire-codes.test.ts` STAYS as the runtime half

Required by the card, so stated plainly: the #8885 bespoke pin is **not** redundant under the widened gate, and it is **not** edited here.

The measurement is what decides it. The widened scan can now *see* the three approvals templates — that is the fix — but seeing an interpolation is not evaluating one. The gate cannot say which codes `` `APPROVAL_${action.toUpperCase()}_FAILED` `` produces, so it cannot say whether they are registered; all nine ARE, and nothing in a source scan can know that. The pin does exactly the job the scan structurally cannot: it enumerates the registered `POST /approvals/requests/:id/&lt;action&gt;` routes and asserts the code each catch arm would generate parses against `ApiErrorSchema`'s closed union, mirroring the production template exactly. A tenth action route whose generated code nobody registers fails there, mechanically.

So the two halves are now **explicitly complementary instead of accidentally overlapping**, which is the real repair to #8885's complaint that "one package has a hand-written class pin doing the job the repo-wide gate advertises". The gate no longer advertises that job for templates: the `APPROVAL_*_FAILED` row names the pin in `pin:`, and the gate **fails if that file disappears** — so the runtime half can no longer be deleted silently, which was true before this PR. What remains genuinely unsolved for any other package is unchanged and now visible: a new template family anywhere is an `unclassified-site` finding demanding either literal codes or its own pin.

## Verification

Run at final HEAD `887fc557a`:

- `pnpm check:dispatcher-error-vocabulary` — green. `--self-test: 6 shapes + 62 assertions OK` (was 4 shapes + 37); main run `OK — 13 unregistered code-stamping site(s), all classified; 1 awaiting a ledger entry`.
- `pnpm --filter @objectstack/runtime test` — **165 files / 2464 tests passed**. Includes the declaration half's conformance suite, whose `door !== 'none' ⇒ pending-registration` invariant had to admit `runtime-pinned` (a source-scan limit, not a reachability claim), plus a new case asserting every `runtime-pinned` row names its runtime half and only a template may carry it. A stale comment claiming the pending list is empty was corrected — it is not, and the reason is now recorded there.
- `pnpm --filter @objectstack/runtime typecheck` — clean.
- Re-derived gates for the actual diff (`node scripts/pm/dispatch-gates.mjs`, beyond the dispatch list): `check:cross-package-test-inputs`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:error-code-casing`, `check:nul-bytes`, `scripts/docs-audit/check-affected-docs.mjs` — all green. `check:type-check-debt --re-measure` needs a full workspace build and is left to CI; no new test file was added, so its structural half cannot move.
- **Ablation, on the real tree, both restored afterwards.** A new `code: ABLATION_PROBE_CODE` producer in `endpoint-policy.ts` ⇒ `[unclassified-site] … 'ABLATION_PROBE_ONE' (objlitconst)`, exit 1 — the class of site that produced *no output at all* before this PR. Renaming the pin file away ⇒ `[missing-pin] … but that file does not exist`, exit 1.

No changeset: scripts and an internal declaration table publish nothing user-visible.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_