### PR TITLE
feat(messaging): IEmailService gains a render-only renderTemplate seam, consumed by the inbox channel (#9225)

### DIFF
--- a/.changeset/email-render-only-seam.md
+++ b/.changeset/email-render-only-seam.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/spec": minor
+"@objectstack/plugin-email": minor
+"@objectstack/service-messaging": minor
+---
+
+feat(messaging): `IEmailService` gains a render-only `renderTemplate({ template, locale, data, timezone }) → { subject, html, text }`, and the inbox channel consumes it — localized `sys_email_template` content now reaches `sys_inbox_message` (#9225)
+
+A template-path notify node with `channels: ['inbox', 'email']` delivered a
+localized email and an inbox row whose title was the topic and whose body was
+empty: the locale ladder + `{{var}}` renderer (ADR-0053 format filters
+included) lived inside plugin-email's `sendTemplate`, unreachable without
+sending mail (maintainer-ruled seam, 2026-08-17, on #9225).
+
+- `IEmailService.renderTemplate` (new contract method, `packages/spec`)
+  resolves a `sys_email_template` bundle by `(name, locale)` with the same
+  documented en-US ladder as `sendTemplate`, validates required variables, and
+  returns the rendered `{ subject, html, text }` — strictly render-only: no
+  transport call, no queueing, no `sys_email` row. Implemented ONCE in
+  plugin-email by extracting the resolver `sendTemplate` already used;
+  `sendTemplate` now delivers what the shared resolver renders, byte for byte.
+- The messaging inbox channel consumes it the way the email channel consumes
+  `sendTemplate`: a delivery whose payload carries a notify `template`
+  reference renders `subject` into the row's `title` and `text` into
+  `body_md`, per recipient, at delivery time. A registered email service
+  without the method — or no email service at all — fails the delivery LOUDLY
+  (`TEMPLATE_UNSUPPORTED`, graded permanent) instead of silently degrading to
+  topic-as-title; renderer failure codes (`TEMPLATE_NOT_FOUND` /
+  `TEMPLATE_INACTIVE` / `MISSING_VARIABLES`) land on the delivery row and are
+  graded permanent, mirroring the email channel.
+
+The result shape follows what `sys_email_template` rows carry
+(`subject`/`body_html`/`body_text?`): `html` is the rendered `body_html`,
+`text` is the rendered `body_text` or, when the row declares none, derived
+from the rendered HTML.

--- a/packages/plugins/plugin-auth/src/change-email-delete-user-wiring.test.ts
+++ b/packages/plugins/plugin-auth/src/change-email-delete-user-wiring.test.ts
@@ -151,6 +151,11 @@ function createRecordingEmailService(failOn?: string) {
       }
       return { id: `email_${sent.length}`, status: 'sent' };
     },
+    // Render-only face (#9225) — nothing in these tests renders without
+    // sending, so the fake honestly refuses rather than inventing content.
+    async renderTemplate(input) {
+      throw new Error(`TEMPLATE_NOT_FOUND: ${input.template} (locale=en-US)`);
+    },
   };
   return { service, sent };
 }

--- a/packages/plugins/plugin-email/src/email-service.ts
+++ b/packages/plugins/plugin-email/src/email-service.ts
@@ -6,6 +6,8 @@ import type {
   SendEmailInput,
   SendEmailResult,
   SendTemplateInput,
+  RenderTemplateInput,
+  RenderTemplateResult,
   NormalizedEmailMessage,
   EmailAddress,
   EmailDeliveryStatus,
@@ -1158,11 +1160,15 @@ export class EmailService implements IEmailService {
   }
 
   /**
-   * Render a named template from sys_email_template and deliver via
-   * send(). Looks up `(name, locale)` then falls back to
-   * `(name, {@link DEFAULT_TEMPLATE_LOCALE})`.
+   * Resolve `(template, locale)` and render subject/html/text — the ONE
+   * resolver + renderer behind both {@link sendTemplate} (which delivers the
+   * result) and {@link renderTemplate} (which only returns it, #9225). The
+   * resolved row rides along so `sendTemplate` can keep reading its envelope
+   * columns (`from_address`/`from_name`/`reply_to`).
    */
-  async sendTemplate(input: SendTemplateInput): Promise<SendEmailResult> {
+  private async resolveAndRenderTemplate(
+    input: RenderTemplateInput,
+  ): Promise<{ row: EmailTemplateRow; rendered: RenderTemplateResult }> {
     if (!input?.template) {
       throw new Error('VALIDATION_FAILED: template name is required');
     }
@@ -1240,6 +1246,32 @@ export class EmailService implements IEmailService {
     const text = row.body_text
       ? renderTemplate(row.body_text, data, renderOpts)
       : htmlToText(html);
+
+    return { row, rendered: { subject, html, text } };
+  }
+
+  /**
+   * Render a named template from sys_email_template WITHOUT sending —
+   * `IEmailService.renderTemplate` (#9225). Strictly render-only: the shared
+   * resolver above never touches the transport, the queue, persistence or
+   * the outbox; it only resolves `(name, locale)` per the documented ladder,
+   * validates required variables, and renders the `{{var}}` holes (ADR-0053
+   * format filters included).
+   */
+  async renderTemplate(input: RenderTemplateInput): Promise<RenderTemplateResult> {
+    const { rendered } = await this.resolveAndRenderTemplate(input);
+    return rendered;
+  }
+
+  /**
+   * Render a named template from sys_email_template and deliver via
+   * send(). Looks up `(name, locale)` then falls back to
+   * `(name, {@link DEFAULT_TEMPLATE_LOCALE})` — the shared
+   * {@link resolveAndRenderTemplate} ladder.
+   */
+  async sendTemplate(input: SendTemplateInput): Promise<SendEmailResult> {
+    const { row, rendered } = await this.resolveAndRenderTemplate(input);
+    const { subject, html, text } = rendered;
 
     const from: EmailAddress | undefined = input.from
       ?? (row.from_address

--- a/packages/plugins/plugin-email/src/render-template.test.ts
+++ b/packages/plugins/plugin-email/src/render-template.test.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `IEmailService.renderTemplate` (#9225) — the render-only face of the one
+ * template resolver. Same `(name, locale)` ladder, same `{{var}}` renderer
+ * (ADR-0053 format filters included) as `sendTemplate`, ZERO send path: no
+ * transport call, no `sys_email` row, no queue.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EmailService, type TemplateLoader, type EmailTemplateRow } from './email-service.js';
+import type { IEmailTransport, NormalizedEmailMessage, TransportSendResult } from '@objectstack/spec/contracts';
+
+class CaptureTransport implements IEmailTransport {
+  public sent: NormalizedEmailMessage[] = [];
+  async send(message: NormalizedEmailMessage): Promise<TransportSendResult> {
+    this.sent.push(message);
+    return { messageId: `msg-${this.sent.length}` };
+  }
+}
+
+/** Exact-locale loader — the en-US fallback lives in the service's ladder. */
+function makeLoader(rows: EmailTemplateRow[]): TemplateLoader {
+  return {
+    async load(name, locale) {
+      if (locale === undefined) return rows.find((r) => r.name === name) ?? null;
+      return rows.find((r) => r.name === name && r.locale === locale) ?? null;
+    },
+  };
+}
+
+function makeService(rows: EmailTemplateRow[]) {
+  const transport = new CaptureTransport();
+  const inserts: Array<Record<string, any>> = [];
+  const svc = new EmailService({
+    transport,
+    defaultFrom: { address: 'no-reply@x.com' },
+    templateLoader: makeLoader(rows),
+    persistence: {
+      async insert(row) { inserts.push(row); return { id: row.id }; },
+      async update() { /* noop */ },
+    },
+  });
+  return { svc, transport, inserts };
+}
+
+const enUs: EmailTemplateRow = {
+  name: 'deal.won',
+  locale: 'en-US',
+  subject: 'Deal won: {{deal.name}}',
+  body_html: '<p>Hi {{user.name}}, deal <b>{{deal.name}}</b> closed.</p>',
+  body_text: 'Hi {{user.name}}, deal {{deal.name}} closed.',
+  active: true,
+};
+
+const zhCn: EmailTemplateRow = {
+  name: 'deal.won',
+  locale: 'zh-CN',
+  subject: '赢单:{{deal.name}}',
+  body_html: '<p>{{user.name}},{{deal.name}} 已成交。</p>',
+  active: true,
+};
+
+describe('EmailService.renderTemplate (#9225)', () => {
+  it('renders subject/html/text from the resolved row WITHOUT sending — no transport call, no sys_email row', async () => {
+    const { svc, transport, inserts } = makeService([enUs]);
+
+    const out = await svc.renderTemplate({
+      template: 'deal.won',
+      data: { user: { name: 'Alice' }, deal: { name: 'Acme' } },
+    });
+
+    expect(out).toEqual({
+      subject: 'Deal won: Acme',
+      html: '<p>Hi Alice, deal <b>Acme</b> closed.</p>',
+      text: 'Hi Alice, deal Acme closed.',
+    });
+    // Strictly render-only (the ruling's zero-send-path clause): nothing
+    // reached the transport and nothing was persisted.
+    expect(transport.sent).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('resolves the recipient locale exactly, and derives text from html when the row has no body_text', async () => {
+    const { svc } = makeService([enUs, zhCn]);
+
+    const out = await svc.renderTemplate({
+      template: 'deal.won',
+      locale: 'zh-CN',
+      data: { user: { name: '张三' }, deal: { name: 'Acme' } },
+    });
+
+    expect(out.subject).toBe('赢单:Acme');
+    expect(out.html).toBe('<p>张三,Acme 已成交。</p>');
+    // zh-CN row declares no body_text → text is htmlToText(rendered html).
+    expect(out.text).toBe('张三,Acme 已成交。');
+  });
+
+  it('falls back to en-US when the requested locale has no row (the documented ladder)', async () => {
+    const { svc } = makeService([enUs, zhCn]);
+
+    const out = await svc.renderTemplate({
+      template: 'deal.won',
+      locale: 'ja-JP',
+      data: { user: { name: 'Yuki' }, deal: { name: 'Acme' } },
+    });
+
+    expect(out.subject).toBe('Deal won: Acme');
+  });
+
+  it('renders ADR-0053 format-filter holes with the input reference timezone', async () => {
+    const tpl: EmailTemplateRow = {
+      name: 'order.shipped',
+      locale: 'en-US',
+      subject: 'Shipped',
+      body_html: '<p>Ships {{ shipAt | datetime }}</p>',
+      body_text: 'Ships {{ shipAt | datetime }}',
+      active: true,
+    };
+    const { svc } = makeService([tpl]);
+
+    // 2026-06-02T01:30Z is still 2026-06-01 in America/New_York.
+    const out = await svc.renderTemplate({
+      template: 'order.shipped',
+      data: { shipAt: '2026-06-02T01:30:00.000Z' },
+      timezone: 'America/New_York',
+    });
+
+    expect(out.text).toContain('6/1/26'); // shifted to the NY calendar day
+    expect(out.text).not.toContain('2026-06-02T01:30'); // not raw ISO
+  });
+
+  it('throws TEMPLATE_NOT_FOUND when no row matches (name, locale|en-US)', async () => {
+    const { svc, transport } = makeService([enUs]);
+    await expect(svc.renderTemplate({ template: 'no.such_template' }))
+      .rejects.toThrow(/TEMPLATE_NOT_FOUND/);
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it('throws TEMPLATE_INACTIVE for a resolvable but deactivated row', async () => {
+    const { svc } = makeService([{ ...enUs, active: false }]);
+    await expect(svc.renderTemplate({ template: 'deal.won' }))
+      .rejects.toThrow(/TEMPLATE_INACTIVE/);
+  });
+
+  it('throws MISSING_VARIABLES naming the absent required variables', async () => {
+    const tpl: EmailTemplateRow = {
+      ...enUs,
+      variables_json: JSON.stringify([
+        { name: 'user.name', required: true },
+        { name: 'deal.name', required: true },
+      ]),
+    };
+    const { svc } = makeService([tpl]);
+    await expect(svc.renderTemplate({ template: 'deal.won', data: { user: { name: 'Alice' } } }))
+      .rejects.toThrow(/MISSING_VARIABLES: deal.name/);
+  });
+
+  it('throws VALIDATION_FAILED without a template name, and TEMPLATE_NOT_FOUND without a loader', async () => {
+    const { svc } = makeService([enUs]);
+    await expect(svc.renderTemplate({ template: '' }))
+      .rejects.toThrow(/VALIDATION_FAILED: template name is required/);
+
+    const bare = new EmailService({ transport: new CaptureTransport() });
+    await expect(bare.renderTemplate({ template: 'deal.won' }))
+      .rejects.toThrow(/TEMPLATE_NOT_FOUND: no templateLoader configured/);
+  });
+});

--- a/packages/services/service-messaging/src/email-channel.ts
+++ b/packages/services/service-messaging/src/email-channel.ts
@@ -46,6 +46,21 @@ export interface EmailSenderSurface {
         data?: Record<string, unknown>;
         locale?: string;
     }): Promise<{ id?: string; status?: string; error?: string } | unknown>;
+    /**
+     * Structural mirror of `IEmailService.renderTemplate` (#9225) — resolves a
+     * `sys_email_template` bundle by `(template, locale)` with the same
+     * documented en-US ladder as `sendTemplate` and returns the rendered
+     * content WITHOUT sending. OPTIONAL for the same reason `sendTemplate` is:
+     * an older or third-party email implementation may not provide it, and a
+     * consumer that needs it (the inbox channel's template path) then fails
+     * LOUDLY on the delivery row rather than degrading silently
+     * (declared = enforced, ADR-0049).
+     */
+    renderTemplate?(input: {
+        template: string;
+        data?: Record<string, unknown>;
+        locale?: string;
+    }): Promise<{ subject: string; html: string; text: string }>;
 }
 
 export interface EmailChannelOptions {

--- a/packages/services/service-messaging/src/inbox-channel.test.ts
+++ b/packages/services/service-messaging/src/inbox-channel.test.ts
@@ -168,4 +168,131 @@ describe('inbox channel', () => {
         expect(data.findOnes).toHaveLength(0);
         expect(data.inserts[0].row.user_id).toBe('usr_42');
     });
+
+    // ── The localizable template path (#9225): a notify `template` reference
+    // rides in the payload; the channel consumes the email service's
+    // render-only face (`IEmailService.renderTemplate`) the way the email
+    // channel consumes `sendTemplate` — one resolver, two channels.
+    describe('notify template path (#9225)', () => {
+        /** A fake render-only email surface recording every renderTemplate call. */
+        function fakeRenderer(impl?: (input: any) => { subject: string; html: string; text: string }) {
+            const calls: any[] = [];
+            return {
+                calls,
+                email: {
+                    async send() { return {}; },
+                    async renderTemplate(input: any) {
+                        calls.push(input);
+                        if (impl) return impl(input);
+                        return {
+                            subject: `[${input.locale ?? 'no-locale'}] subject for ${input.template}`,
+                            html: '<p>html body</p>',
+                            text: 'text body',
+                        };
+                    },
+                },
+            };
+        }
+
+        const templateDelivery = (locale?: string) => delivery({
+            // The emit-time degraded fallback (title=topic, body='') that the
+            // renderer must REPLACE.
+            title: 'deal.won',
+            body: '',
+            payload: {
+                template: 'deal.won_email',
+                templateData: { deal: 'Acme' },
+                ...(locale ? { locale } : {}),
+            },
+        });
+
+        it('renders title/body_md through renderTemplate: subject → title, text → body_md', async () => {
+            const data = fakeData();
+            const r = fakeRenderer();
+            const ch = createInboxChannel({ getData: () => data.engine, getEmail: () => r.email });
+
+            const result = await ch.send(silentCtx(), templateDelivery('zh-CN'));
+
+            expect(result.ok).toBe(true);
+            expect(r.calls).toEqual([{
+                template: 'deal.won_email',
+                data: { deal: 'Acme' },
+                locale: 'zh-CN',
+            }]);
+            expect(data.inserts[0].row.title).toBe('[zh-CN] subject for deal.won_email');
+            expect(data.inserts[0].row.body_md).toBe('text body');
+        });
+
+        it('falls back to the deployment default locale when the payload names none', async () => {
+            const data = fakeData();
+            const r = fakeRenderer();
+            const ch = createInboxChannel({
+                getData: () => data.engine,
+                getEmail: () => r.email,
+                getDefaultTemplateLocale: () => 'ja-JP',
+            });
+
+            await ch.send(silentCtx(), templateDelivery());
+
+            expect(r.calls[0].locale).toBe('ja-JP');
+        });
+
+        it('fails LOUDLY (TEMPLATE_UNSUPPORTED) when no email service is registered', async () => {
+            const data = fakeData();
+            const ch = createInboxChannel({ getData: () => data.engine });
+
+            const result = await ch.send(silentCtx(), templateDelivery());
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toMatch(/^TEMPLATE_UNSUPPORTED:/);
+            expect(result.error).toContain("no 'email' service is registered");
+            expect(data.inserts).toHaveLength(0);
+            // Wrong wiring, not a transient fault — never burn the retry schedule.
+            expect(ch.classifyError?.(result.error)).toBe('permanent');
+        });
+
+        it('fails LOUDLY when the registered email service has no renderTemplate()', async () => {
+            const data = fakeData();
+            const ch = createInboxChannel({
+                getData: () => data.engine,
+                getEmail: () => ({ async send() { return {}; } }),
+            });
+
+            const result = await ch.send(silentCtx(), templateDelivery());
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toMatch(/^TEMPLATE_UNSUPPORTED:/);
+            expect(result.error).toContain('does not provide it');
+            expect(data.inserts).toHaveLength(0);
+        });
+
+        it('surfaces renderTemplate failure codes on the delivery row and grades them permanent', async () => {
+            const data = fakeData();
+            const r = fakeRenderer(() => {
+                throw new Error('TEMPLATE_NOT_FOUND: deal.won_email (locale=zh-CN)');
+            });
+            const ch = createInboxChannel({ getData: () => data.engine, getEmail: () => r.email });
+
+            const result = await ch.send(silentCtx(), templateDelivery('zh-CN'));
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toMatch(/^TEMPLATE_NOT_FOUND:/);
+            expect(data.inserts).toHaveLength(0);
+            expect(ch.classifyError?.(result.error)).toBe('permanent');
+            // The general grading is untouched: a plain insert failure stays retryable.
+            expect(ch.classifyError?.(new Error('db down'))).toBe('retryable');
+        });
+
+        it('never consults the renderer for a non-template delivery', async () => {
+            const data = fakeData();
+            const r = fakeRenderer();
+            const ch = createInboxChannel({ getData: () => data.engine, getEmail: () => r.email });
+
+            await ch.send(silentCtx(), delivery());
+
+            expect(r.calls).toHaveLength(0);
+            expect(data.inserts[0].row.title).toBe('Deal closed');
+            expect(data.inserts[0].row.body_md).toBe('Acme signed 🎉');
+        });
+    });
 });

--- a/packages/services/service-messaging/src/inbox-channel.ts
+++ b/packages/services/service-messaging/src/inbox-channel.ts
@@ -8,6 +8,7 @@ import type {
     MessagingChannelContext,
     SendResult,
 } from './channel.js';
+import type { EmailSenderSurface } from './email-channel.js';
 
 /** The object the inbox channel writes rows to. */
 export const INBOX_OBJECT = 'sys_inbox_message';
@@ -29,6 +30,25 @@ export interface InboxChannelOptions {
     receiptObject?: string;
     /** Clock injection for deterministic tests. Defaults to `new Date()`. */
     now?(): string;
+    /**
+     * Resolve the email service's render-only face (#9225) for the notify
+     * `template` path — the inbox consumes `IEmailService.renderTemplate` the
+     * way the email channel consumes `sendTemplate`: one resolver + renderer
+     * (locale ladder, `{{var}}` holes, ADR-0053 filters) in plugin-email, two
+     * channels. `undefined` (or a service without `renderTemplate`) fails a
+     * template-path delivery LOUDLY on the delivery row — a notify node that
+     * references a `sys_email_template` needs the subsystem that owns those
+     * rows; silently writing topic-as-title would hide the wiring gap.
+     * Non-template deliveries never consult this.
+     */
+    getEmail?(): EmailSenderSurface | undefined;
+    /**
+     * The recipient locale for `sys_email_template` resolution on the
+     * template path — same lazily-probed deployment-default source as
+     * `EmailChannelOptions.getDefaultTemplateLocale` (#9205), consulted only
+     * when the delivery's payload carries no `locale`.
+     */
+    getDefaultTemplateLocale?(): string | undefined;
 }
 
 /**
@@ -95,12 +115,58 @@ export function createInboxChannel(opts: InboxChannelOptions): MessagingChannel 
             const userId = delivery.recipient;
             const at = now();
 
+            // ── The localizable path (#9225): a `notify` node's `template`
+            // reference, carried in the payload exactly as the email channel
+            // reads it (#9205). Without a renderer the emit-time fallback has
+            // already degraded title/body to topic/'' — honest but unlocalized
+            // — so a template-path delivery renders here, per recipient,
+            // through `IEmailService.renderTemplate`'s `(name, locale)` ladder:
+            // `subject` becomes the row's title and `text` its markdown body.
+            let title = n.title;
+            let bodyMd = n.body;
+            const payload = (n.payload ?? {}) as Record<string, unknown>;
+            const templateName =
+                typeof payload.template === 'string' && payload.template.trim()
+                    ? payload.template.trim()
+                    : undefined;
+            if (templateName) {
+                const email = opts.getEmail?.();
+                if (!email || typeof email.renderTemplate !== 'function') {
+                    // Declared ≠ deliverable — fail loudly on the delivery row
+                    // rather than silently downgrading to unlocalized content
+                    // (mirrors the email channel's sendTemplate refusal).
+                    return {
+                        ok: false,
+                        error: `TEMPLATE_UNSUPPORTED: notify template '${templateName}' needs an email service with renderTemplate(); ${email ? "the registered 'email' service does not provide it" : "no 'email' service is registered"}`,
+                    };
+                }
+                const templateLocale = typeof payload.locale === 'string' && payload.locale.trim()
+                    ? payload.locale.trim()
+                    : opts.getDefaultTemplateLocale?.();
+                const templateData = (payload.templateData ?? undefined) as Record<string, unknown> | undefined;
+                try {
+                    const rendered = await email.renderTemplate({
+                        template: templateName,
+                        ...(templateData !== undefined ? { data: templateData } : {}),
+                        ...(templateLocale ? { locale: templateLocale } : {}),
+                    });
+                    title = rendered.subject;
+                    bodyMd = rendered.text;
+                } catch (err) {
+                    // renderTemplate's failure vocabulary (TEMPLATE_NOT_FOUND /
+                    // TEMPLATE_INACTIVE / MISSING_VARIABLES) arrives as a thrown
+                    // Error — keep the code at the front of the row's error so
+                    // classifyError() below can grade it permanent.
+                    return { ok: false, error: (err as Error)?.message ?? String(err) };
+                }
+            }
+
             const row: Record<string, unknown> = {
                 user_id: userId,
                 notification_id: n.notificationId ?? null,
                 topic: n.topic,
-                title: n.title,
-                body_md: n.body,
+                title,
+                body_md: bodyMd,
                 severity: n.severity ?? 'info',
                 action_url: n.actionUrl,
                 organization_id: n.organizationId ?? null,
@@ -128,7 +194,18 @@ export function createInboxChannel(opts: InboxChannelOptions): MessagingChannel 
             return { ok: true, externalId: inboxId };
         },
 
-        classifyError(_err: unknown): ErrorClass {
+        classifyError(err: unknown): ErrorClass {
+            // #9225 — a template-resolution failure is wrong METADATA, not a
+            // transport hiccup (same grading as the email channel, #9205):
+            // re-trying the identical delivery can never succeed until someone
+            // edits the template/node, so grade it permanent instead of
+            // burning the retry schedule. These are
+            // `IEmailService.renderTemplate`'s own error codes plus this
+            // channel's missing-capability refusal above.
+            const msg = typeof err === 'string' ? err : String((err as Error)?.message ?? err ?? '');
+            if (/\b(TEMPLATE_NOT_FOUND|TEMPLATE_INACTIVE|MISSING_VARIABLES|TEMPLATE_UNSUPPORTED)\b/.test(msg)) {
+                return 'permanent';
+            }
             // A failed local insert is almost always transient (lock/timeout).
             return 'retryable';
         },

--- a/packages/services/service-messaging/src/messaging-service-plugin.ts
+++ b/packages/services/service-messaging/src/messaging-service-plugin.ts
@@ -123,8 +123,40 @@ export class MessagingServicePlugin implements Plugin {
             mandatoryTopics: this.options.mandatoryTopics,
         });
 
+        // Lazy `email` service resolver — shared by the email channel (send +
+        // sendTemplate) and the inbox channel's render-only template path
+        // (#9225): one resolver in plugin-email, two channels. Probed at
+        // delivery time (never captured at boot) so plugin init order and
+        // live service replacement don't matter.
+        const getEmail = () => {
+            try {
+                return ctx.getService<import('./email-channel.js').EmailSenderSurface>('email');
+            } catch {
+                return undefined;
+            }
+        };
+        // #9205 — the recipient locale for `sys_email_template` resolution
+        // on the notify template path. Probed lazily at delivery time (not
+        // captured at boot) so it tracks live `localization.locale` /
+        // stack-config changes; same ruled source as the auth emails
+        // (#8195: `II18nService.getDefaultLocale()`), because the platform
+        // has no per-user locale yet and no request exists at async
+        // delivery time. Both hops probed: `getService` throws for an
+        // unregistered service, and `getDefaultLocale` is optional on the
+        // contract — either missing leaves the locale unset, which lands
+        // the documented en-US default.
+        const getDefaultTemplateLocale = (): string | undefined => {
+            try {
+                const i18n = ctx.getService<{ getDefaultLocale?: () => string }>('i18n');
+                const locale = typeof i18n?.getDefaultLocale === 'function' ? i18n.getDefaultLocale() : undefined;
+                return typeof locale === 'string' && locale.trim() ? locale : undefined;
+            } catch {
+                return undefined;
+            }
+        };
+
         if (this.options.registerInbox) {
-            service.registerChannel(createInboxChannel({ getData }));
+            service.registerChannel(createInboxChannel({ getData, getEmail, getDefaultTemplateLocale }));
         }
 
         ctx.registerService('messaging', service);
@@ -212,32 +244,6 @@ export class MessagingServicePlugin implements Plugin {
         // dispatcher looks channels up dynamically, so registering after it is fine.
         if (typeof ctx.hook === 'function') {
             const templateStore = new NotificationTemplateStore({ getData });
-            const getEmail = () => {
-                try {
-                    return ctx.getService<import('./email-channel.js').EmailSenderSurface>('email');
-                } catch {
-                    return undefined;
-                }
-            };
-            // #9205 — the recipient locale for `sys_email_template` resolution
-            // on the notify template path. Probed lazily at delivery time (not
-            // captured at boot) so it tracks live `localization.locale` /
-            // stack-config changes; same ruled source as the auth emails
-            // (#8195: `II18nService.getDefaultLocale()`), because the platform
-            // has no per-user locale yet and no request exists at async
-            // delivery time. Both hops probed: `getService` throws for an
-            // unregistered service, and `getDefaultLocale` is optional on the
-            // contract — either missing leaves the locale unset, which lands
-            // `sendTemplate`'s documented en-US default.
-            const getDefaultTemplateLocale = (): string | undefined => {
-                try {
-                    const i18n = ctx.getService<{ getDefaultLocale?: () => string }>('i18n');
-                    const locale = typeof i18n?.getDefaultLocale === 'function' ? i18n.getDefaultLocale() : undefined;
-                    return typeof locale === 'string' && locale.trim() ? locale : undefined;
-                } catch {
-                    return undefined;
-                }
-            };
             ctx.hook('kernel:ready', async () => {
                 if (getEmail()) {
                     service.registerChannel(createEmailChannel({ getEmail, getData, store: templateStore, getDefaultTemplateLocale }));

--- a/packages/spec/api-surface/contracts.json
+++ b/packages/spec/api-surface/contracts.json
@@ -231,6 +231,8 @@
     "RecordShare (interface)",
     "RecordShareRecipientType (type)",
     "RemoteTable (interface)",
+    "RenderTemplateInput (interface)",
+    "RenderTemplateResult (interface)",
     "ReportFormat (type)",
     "ReportQuery (interface)",
     "ReportRunResult (interface)",

--- a/packages/spec/export-origins/contracts.json
+++ b/packages/spec/export-origins/contracts.json
@@ -231,6 +231,8 @@
     "RecordShare": "src/contracts/sharing-service.ts#RecordShare (interface)",
     "RecordShareRecipientType": "src/contracts/sharing-service.ts#RecordShareRecipientType (type)",
     "RemoteTable": "src/contracts/external-datasource-service.ts#RemoteTable (interface)",
+    "RenderTemplateInput": "src/contracts/email-service.ts#RenderTemplateInput (interface)",
+    "RenderTemplateResult": "src/contracts/email-service.ts#RenderTemplateResult (interface)",
     "ReportFormat": "src/contracts/report-service.ts#ReportFormat (type)",
     "ReportQuery": "src/contracts/report-service.ts#ReportQuery (interface)",
     "ReportRunResult": "src/contracts/report-service.ts#ReportRunResult (interface)",

--- a/packages/spec/src/contracts/email-service.ts
+++ b/packages/spec/src/contracts/email-service.ts
@@ -185,6 +185,53 @@ export interface SendTemplateInput {
 }
 
 /**
+ * Input for IEmailService.renderTemplate() — the render-only subset of
+ * {@link SendTemplateInput}: everything template resolution + rendering
+ * needs, nothing the delivery pipeline reads.
+ */
+export interface RenderTemplateInput {
+  /**
+   * Template identifier (matches `sys_email_template.name`), e.g.
+   * `'auth.password_reset'`.
+   */
+  template: string;
+  /** Render context — placeholders in subject/body are resolved against this object. */
+  data?: Record<string, unknown>;
+  /**
+   * Preferred BCP-47 locale. Resolution is the SAME ladder as
+   * {@link SendTemplateInput.locale} — exact match, then `'en-US'`, then
+   * (no-locale calls only) the bundle's deterministic single-locale answer.
+   */
+  locale?: string;
+  /**
+   * Reference timezone (IANA name) for rendering `datetime` holes —
+   * `{{ ts | datetime }}` (ADR-0053 Phase 2). Same semantics as
+   * {@link SendTemplateInput.timezone}.
+   */
+  timezone?: string;
+}
+
+/**
+ * Outcome of IEmailService.renderTemplate() — the rendered content of the
+ * resolved `sys_email_template` row, mirroring what the row itself carries:
+ * a subject, an HTML body, and a plain-text body (the row's `body_text`
+ * when present, otherwise derived from the rendered HTML). Consumers pick
+ * the face they need — an email composer uses `html`/`text`, an in-app
+ * inbox row uses `subject`/`text`.
+ */
+export interface RenderTemplateResult {
+  /** Rendered subject line. */
+  subject: string;
+  /** Rendered HTML body (`sys_email_template.body_html`). */
+  html: string;
+  /**
+   * Rendered plain-text body — the row's `body_text` when declared,
+   * otherwise derived from the rendered HTML.
+   */
+  text: string;
+}
+
+/**
  * Email service contract.
  */
 export interface IEmailService {
@@ -209,4 +256,23 @@ export interface IEmailService {
    * - `MISSING_VARIABLES`  — declared `required` variables absent from `data`.
    */
   sendTemplate(input: SendTemplateInput): Promise<SendEmailResult>;
+
+  /**
+   * Resolve a named template from `sys_email_template` and render its
+   * subject/body against `input.data` — WITHOUT sending anything. Strictly
+   * render-only: no delivery, no queueing, no `sys_email` row. One resolver,
+   * many channels (#9225): the same locale ladder + `{{var}}` renderer
+   * (ADR-0053 format filters included) that `sendTemplate` delivers through,
+   * exposed so non-email consumers (e.g. the messaging inbox channel) render
+   * localized template content instead of duplicating the resolver.
+   *
+   * Locale resolution is the ladder on {@link SendTemplateInput.locale}.
+   *
+   * Errors (same vocabulary as `sendTemplate`, since resolution is shared):
+   * - `TEMPLATE_NOT_FOUND` — no row matches `(name, locale|en-US)`, and (for a
+   *   call that named no locale) the name carries no rows at all.
+   * - `TEMPLATE_INACTIVE`  — row exists but `active=false`.
+   * - `MISSING_VARIABLES`  — declared `required` variables absent from `data`.
+   */
+  renderTemplate(input: RenderTemplateInput): Promise<RenderTemplateResult>;
 }


### PR DESCRIPTION
Fixes #9225

Implements the maintainer-ruled seam (2026-08-17, comment on the card, accepted verbatim 「同意」): `IEmailService` gains a **render-only** method, implemented once in plugin-email beside the existing locale ladder + `{{var}}` renderer (ADR-0053 format filters included), consumed by the inbox channel the way the email channel consumes `sendTemplate`. One resolver, two channels; **zero send-path changes**.

## What changed

- **`packages/spec/src/contracts/email-service.ts`** — new `RenderTemplateInput` (`template`, `data?`, `locale?`, `timezone?`) and `RenderTemplateResult` (`subject`, `html`, `text`), and a required `renderTemplate(input)` method on `IEmailService`, documented with the same locale ladder and the same error vocabulary as `sendTemplate` (`TEMPLATE_NOT_FOUND` / `TEMPLATE_INACTIVE` / `MISSING_VARIABLES`), minus everything delivery-related.
- **`packages/plugins/plugin-email/src/email-service.ts`** — the resolver + renderer that `sendTemplate` already used is extracted into a private `resolveAndRenderTemplate` (ladder, `active` check, `variables_json` validation, row-locale-authority render opts — moved verbatim, zero behaviour change); `renderTemplate` returns its output, `sendTemplate` delivers it. The send path is byte-for-byte the same code it was; the existing `sendTemplate` suite passes unchanged, which is the zero-send-path-change evidence.
- **`packages/services/service-messaging/src/inbox-channel.ts`** — a delivery whose payload carries a notify `template` reference (the #9205 path, read exactly as the email channel reads it) renders through the email service's render-only face: `subject` becomes the row's `title`, `text` becomes `body_md`. Locale: `payload.locale`, else the deployment default (same `getDefaultTemplateLocale` source as the email channel, #9205/#8195). No email service, or one without `renderTemplate` ⇒ the delivery fails LOUDLY (`TEMPLATE_UNSUPPORTED`); renderer error codes land on the delivery row; `classifyError` grades all four codes `permanent` (mirrors the email channel's #9205 grading). Non-template deliveries are untouched.
- **`packages/services/service-messaging/src/email-channel.ts`** — `EmailSenderSurface` (the structural view of the runtime-resolved `email` service) gains an optional `renderTemplate` mirror.
- **`packages/services/service-messaging/src/messaging-service-plugin.ts`** — the lazy `getEmail` / `getDefaultTemplateLocale` resolvers are hoisted above inbox registration and shared by both channels (probed at delivery time, so init order and live service replacement don't matter — unchanged semantics).
- **`packages/plugins/plugin-auth/src/change-email-delete-user-wiring.test.ts`** — consumer fixture triage: the one object literal in the tree typed `IEmailService` gains the new required method (an honest refusal stub; nothing in those tests renders without sending). Repo-wide sweep direction: **downstream consumers of `@objectstack/spec`** — searched every package for `implements IEmailService` and `: IEmailService` annotations; this fake was the only non-plugin-email implementer.
- Tests: `packages/plugins/plugin-email/src/render-template.test.ts` (new — ladder, filter + timezone, html→text derivation, error vocabulary, and a zero-send assertion: no transport call, no `sys_email` insert) and template-path cases in `inbox-channel.test.ts`.
- `.changeset/email-render-only-seam.md` — minor for spec / plugin-email / service-messaging.
- `packages/spec/api-surface/` + `export-origins/` regenerated (exactly the two new interface exports).

## Return-shape note (dispatch assumption 1, measured)

The ruling spells the result `{ subject, body }`; the card body spells it `{ subject, html/text }`. Measured: `sys_email_template` rows carry `subject` / `body_html` / `body_text?`, and the render already produces subject + html + text (text derived from html when the row declares none), while the inbox row needs `title` + `body_md`. A single `body` would force the contract to pick one face and lose the other, so the implemented shape is `{ subject, html, text }` — the card body's spelling made concrete. The inbox consumes `subject`/`text`; an email-shaped consumer uses `html`/`text`. Assumption 2 held as stated: the inbox write site consumed the rendered content with no new contract face (channel options within the same package only).

## Verification (all at `567619ff7`, clean tree)

- `pnpm --filter @objectstack/spec test` — 407 files, 10846 passed
- `pnpm --filter @objectstack/plugin-email test` — 26 files, 417 passed
- `pnpm --filter @objectstack/service-messaging test` — 22 files, 242 passed
- `pnpm --filter @objectstack/plugin-auth test` — 55 files, 1261 passed
- `pnpm typecheck` (spec, plugin-email, service-messaging, plugin-auth, rest) — clean; plugin-email/service-messaging typecheck resolving the newly-exported contract names is itself proof the rebuilt spec `.d.ts` was read (a stale dist could only fail these imports, not pass them)
- Reverse verification (fix committed first): `inbox-channel.ts` restored to origin/main ⇒ 5 of the 6 new template-path tests red (the sixth, "never consults the renderer for a non-template delivery", stays green vacuously on the old channel — reported as observed); restored, suite green
- Derived gates re-taken from the actual diff (`node scripts/pm/dispatch-gates.mjs`): changeset-gate-self-tests, cross-package-test-inputs, merge-driver, objectui-changeset, spec-parsed-alias, test-source-alias, type-source-resolution, query-options-erasure, nul-bytes, spec empty-state / liveness / strictness-ledger / variant-docs, doc-formula-expressions, adr-0087-registration, changeset-no-major, empty-changeset, dev-prereqs (after full packages build), affected-docs, type-check-coverage, type-check-debt (`--re-measure`, none above recorded), engine-double-contract, where-matcher, i18n — **all green**. Beyond the dispatch-time list, the re-derivation added the test-file convention gates (query-options-erasure, type-check-coverage/debt, engine-double-contract, where-matcher) and the changeset gates — all run, all green; `check:i18n` was named conditionally and measured unmoved (no extractor-visible change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_