### PR TITLE
docs(data): accept-and-document mongo/turso passthrough secrets with no binder slot

### DIFF
--- a/content/docs/data-modeling/drivers.mdx
+++ b/content/docs/data-modeling/drivers.mdx
@@ -164,6 +164,46 @@ which the Studio connection form renders — so the form offers exactly the fiel
 the validator accepts.
 </Callout>
 
+### Secret-shaped keys with no binder slot: accepted at-rest risk
+
+The datasource secret binder injects exactly **one** secret per datasource —
+the login password, resolved through `external.credentialsRef` (or the
+connection form's password field) into `sys_secret` at connect time. A small
+number of other config keys are secret-shaped too, but the binder has no
+second slot to put them in, and the client library that owns them — not
+ObjectStack — is what makes them secrets:
+
+| Driver | Key | What it carries |
+| :--- | :--- | :--- |
+| `mongo` \| `mongodb` | `options.proxyPassword` | SOCKS5 proxy password |
+| `mongo` \| `mongodb` | `options.tlsCertificateKeyFilePassword` | TLS key-file passphrase |
+| `mongo` \| `mongodb` | `options.key` | TLS private key material (PEM) |
+| `mongo` \| `mongodb` | `options.passphrase` | TLS key passphrase |
+| `turso` \| `libsql` | `encryptionKey` | AES-256 key for the local database file |
+
+Unlike `password` / `authToken` (typed `never` in their schemas — the parse
+refuses them outright), these five keys are **writable**: the parse accepts
+them, and they are stored **at rest in `sys_metadata` as plain text**, right
+alongside the rest of the datasource row. The protection that exists today is
+on the READ side only — every one of them is stripped before a datasource
+record is ever served back over the admin API or shown in the Setup UI
+(`PASSTHROUGH_SECRET_PATHS` / `STILL_WRITABLE_CREDENTIAL_KEYS` in
+`datasource-credential-redaction.ts`, shipped in
+[#9040](https://github.com/objectstack-ai/objectstack/issues/9040)). That stops the value
+round-tripping through a read; it is not encryption at rest, and an operator
+with direct access to the metadata store can still read the plain-text value.
+
+<Callout type="warn">
+**This is a deliberate, documented trade-off ([#9124](https://github.com/objectstack-ai/objectstack/issues/9124)), not an oversight.**
+The binder has exactly one named slot. Refusing these five keys at write time
+would remove the only way to configure an authenticated SOCKS5 proxy or a
+passphrase-protected TLS key — a capability the client genuinely honours, with
+no working refusal remedy. **Restart condition:** the first real deployment
+that needs an authenticated proxy or a passphrase-protected key converts this
+into named binder-slot support — one mechanism covering all five keys — rather
+than the current per-key accept-and-document posture.
+</Callout>
+
 ## Startup: a driver that cannot connect aborts the boot
 
 `ObjectQLEngine.init()` connects every registered driver during kernel


### PR DESCRIPTION
Fixes #9124

## What

Maintainer ruling 2026-08-17 03:19Z (issue comment 5311378700): **Option B — accept-and-document.** This PR is the docs deliverable only; Option A (named binder slots) and Option C (publish-door refusal) stay out of scope by that ruling.

Adds a new subsection to `content/docs/data-modeling/drivers.mdx` — **"Secret-shaped keys with no binder slot: accepted at-rest risk"**, placed directly under the existing "`config` is validated per driver" section (the section a reader configuring any datasource driver already lands on). It:

- Names the five keys: mongo's `options.proxyPassword`, `options.tlsCertificateKeyFilePassword`, `options.key`, `options.passphrase`, and turso's `encryptionKey`.
- States plainly that they are **writable** (the parse accepts them) and stored **at rest in `sys_metadata` as plain text**.
- States the protection that exists today is read-side only: they are stripped before ever being served back over the admin API / Setup UI (#9040, shipped).
- Records the **named restart condition** from the ruling: the first real deployment needing an authenticated SOCKS5 proxy or a passphrase-protected key converts this into the binder-slot programme (Option A) — one mechanism covering all five keys.

## Verification of the card's premises (done before writing, per the dispatch instructions)

- `PASSTHROUGH_SECRET_PATHS` in `packages/spec/src/data/datasource-credential-redaction.ts` covers exactly the four mongo keys (`options.auth.password`, `options.proxyPassword`, `options.tlsCertificateKeyFilePassword`, `options.key`, `options.passphrase`, plus `options.authMechanismProperties.AWS_SESSION_TOKEN`) — the four named in the card are all present and confirmed still-writable (only `auth.password` is also refused at write, mirrored in `refusedPassthroughSecretPaths`).
- The restore mirror lives in `packages/services/service-datasource/src/datasource-config-redaction.ts` (`restoreRedactedConfig`), imports `passthroughSecretPaths` from spec, and is wired into `datasource-admin-service.ts` (`merged.config = restoreRedactedConfig(...)`) — confirmed.
- turso's `encryptionKey` (`packages/spec/src/data/driver/turso.zod.ts`) is `z.string().optional()` with `format: 'password'` metadata — a **top-level** writable config key (`STILL_WRITABLE_CREDENTIAL_KEYS.turso`), a different code path from mongo's **nested passthrough** keys (`PASSTHROUGH_SECRET_PATHS`). The outcome shape the card claims — writable, stored cleartext at rest, redacted only on read — is genuinely the same for both; the underlying mechanism is not identical, and the doc text says "same … posture," not "same mechanism."
- Confirmed `sys_metadata` is the real, durable storage table for datasource records (`packages/services/service-datasource/src/datasource-admin-plugin.ts`, `packages/metadata-core/src/objects/sys-metadata.object.ts`).

## Scope discipline

No runtime code changed — this PR touches only `content/docs/data-modeling/drivers.mdx`. Per the dispatch scope fence: no publish-door refusal added (Option C), no binder slot growth (Option A).

**Out-of-scope finding, not fixed here — filed as #9254:** the auto-generated `options` field description in `packages/spec/src/data/driver/mongo.zod.ts` (rendered into `content/docs/references/data/driver-mongo.mdx` and the Studio connection-form help text) currently reads *"credential material is refused"* — true only for `auth.password`, not for the four keys this card is about. Not fixed in-place here: it is a `packages/spec` source edit that pulls in the spec build/docs-regen gate surface, a different verification surface than this docs-only PR.

## Tests

Documentation-only change; no test suite applies. Local gates, all green at `5dd33ddd0`:

- `pnpm check:nul-bytes`
- `pnpm check:docs-audit-scope`
- `pnpm check:docs-redirects`
- `pnpm check:role-word`
- `pnpm --filter @objectstack/spec run check:empty-state`
- `pnpm --filter @objectstack/spec run check:liveness`
- `pnpm --filter @objectstack/spec run check:strictness-ledger`
- `pnpm --filter @objectstack/spec run check:variant-docs`

(the four spec gates run because `content/docs/**` is a CI trigger path in `spec-liveness-check.yml`, per `node scripts/pm/dispatch-gates.mjs content/docs/data-modeling/drivers.mdx`; `packages/spec` was built first per the toolchain-trap note.)

## Changeset

None — docs-only, nothing published moves. `skip-changeset` label applied.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_
