### PR TITLE
docs: re-derive the Support Desk clean-run stats from one real run

### DIFF
--- a/content/docs/deployment/validating-metadata.mdx
+++ b/content/docs/deployment/validating-metadata.mdx
@@ -538,9 +538,11 @@ A clean run walks the registry and reports timing:
   ✓ Validation passed (64ms)
 
   Support Desk v0.1.0
+  Minimal ObjectStack environment — a clean slate for building.
 
-  Data: 1 Objects  6 Fields
+  Data: 2 Objects  6 Fields
   UI: 1 Apps  1 Views  1 Actions
+  Runtime: 3 plugins
 ```
 
 On failure the exit code is non-zero and the error is located and corrective —

--- a/content/docs/getting-started/build-with-claude-code.mdx
+++ b/content/docs/getting-started/build-with-claude-code.mdx
@@ -194,11 +194,44 @@ export const TicketViews = defineView({
 });
 ```
 
+```typescript title="src/apps/support.app.ts"
+import { defineApp } from '@objectstack/spec';
+
+export const SupportApp = defineApp({
+  name: 'support_desk_support',
+  label: 'Support',
+  navigation: [
+    {
+      id: 'grp_support',
+      type: 'group',
+      label: 'Support',
+      expanded: true,
+      children: [
+        {
+          id: 'nav_open_tickets',
+          type: 'object',
+          label: 'Open',
+          objectName: 'support_desk_ticket',
+          viewName: 'open',
+        },
+      ],
+    },
+  ],
+});
+```
+
 The agent also **wires the new files into `objectstack.config.ts`** — the object
-through the `src/objects/index.ts` barrel, and the action and view via the
-`actions:` / `views:` arrays in `defineStack()`. There is no filename-suffix
-magic: metadata exists in the app only if the config imports it, so if a
-freshly-authored action doesn't show up, the wiring is the first thing to check.
+through the `src/objects/index.ts` barrel, and the action, view and app via the
+`actions:` / `views:` / `apps:` arrays in `defineStack()`. There is no
+filename-suffix magic: metadata exists in the app only if the config imports it,
+so if a freshly-authored action doesn't show up, the wiring is the first thing to
+check.
+
+What it does **not** touch is the starter `note` object the `blank` template
+scaffolded in step 1 (`src/objects/note.object.ts`, two fields). Nothing asked
+for it to go, so it stays in the project — which is why the counts below read
+**two** objects and **six** fields, not one and four. Delete it once the ticket
+object has replaced it and the same run reports `1 Objects  4 Fields`.
 
 This is the same metadata that powers the REST API, the Console UI, **and the MCP
 tools exposed to AI** — define it once, and ObjectStack derives the rest.
@@ -255,9 +288,11 @@ Once it's clean:
   ✓ Validation passed (37ms)
 
   Support Desk v0.1.0
+  Minimal ObjectStack environment — a clean slate for building.
 
-  Data: 1 Objects  6 Fields
+  Data: 2 Objects  6 Fields
   UI: 1 Apps  1 Views  1 Actions
+  Runtime: 3 plugins
 ```
 
 <Callout type="tip">


### PR DESCRIPTION
Fixes #9152

Both pages printed a stats line no run can emit. The card diagnosed it as "6 should be 4"; measuring says the opposite half is wrong.

## What was measured

The CLI built at `origin/main`, driving a project scaffolded exactly as step 1 of `build-with-claude-code.mdx` describes (`create-objectstack`, `blank` template, name `support-desk`) with the page's own listings applied:

```
  ✓ Validation passed (103ms)

  Support Desk v0.1.0
  Minimal ObjectStack environment — a clean slate for building.

  Data: 2 Objects  6 Fields
  UI: 1 Apps  1 Views  1 Actions
  Runtime: 3 plugins
```

`6 Fields` is **correct** and always was: 2 fields from the starter `note` object the `blank` template scaffolds (`title`, `body`) plus 4 from the page's `ticket`. The wrong number is `1 Objects`.

The old line spliced two different projects together. Both were run:

| project | emits |
|:--|:--|
| page followed literally — starter `note` kept | `2 Objects  6 Fields` |
| starter `note` deleted | `1 Objects  4 Fields` |

`1 Objects  6 Fields` is the object count of the second and the field count of the first. That is why it was not reconstructible, and why correcting only the field count (as the card proposed) would have left the block just as unreachable.

`stats.fields` is a plain count — `collectMetadataStats` in `packages/cli/src/utils/format.ts` sums `Object.keys(obj.fields).length` over configured objects, injecting nothing.

## What changed

Both clean-run blocks now carry the same run's output:

- `Data: 1 Objects` is now `Data: 2 Objects`.
- The `Runtime: 3 plugins` line is restored — the `blank` template ships `ConnectorRestPlugin`, `ConnectorOpenApiPlugin` and `ConnectorMcpPlugin`, so every scaffolded project emits it. The card's second finding, confirmed.
- The manifest description line under the banner is restored, for the same reason: the program prints it, and a transcript that drops a printed line is the defect this card is about.

And the run is now reconstructible from the page, which it previously was not:

- **The Support-nav app listing is added.** Step 2's prompt asks for "an app with a Support nav group" and step 5 tells the reader to open it, but no listing ever showed it — so `1 Apps` was as unreachable as the field count. This is the card's own "fully specified on the page" route.
- **The starter `note` object is named**, with a line saying the counts include it and what they become if you delete it (measured, not assumed).

## Scope notes

- **No product surface was invented.** No fields were added to reach 6; the two extra fields were already on disk in every scaffolded project.
- **Timings are untouched.** A duration is machine identity, not fixture identity, and #9151 set that precedent one line up. The lines that are fixture identity now agree across both pages.
- **The "verbatim" cross-reference is intact.** `validating-metadata.mdx` sends readers to the bare-reference example on the other page; that block is byte-identical to `origin/main` (sha256 compared, both sides).
- Docs-only, so `skip-changeset`.

## Verification

Gates re-derived from the actual changed paths via `node scripts/pm/dispatch-gates.mjs`, which named four beyond the dispatch list (the `spec-liveness-check.yml` family, triggered by `content/docs/**`). All run on `4b8ff84c6`, a clean tree:

```
pnpm check:docs-audit-scope                          OK (178 hand-written docs in sync)
pnpm check:docs-redirects                            OK (92 entries, 98 chain probes)
pnpm check:role-word                                 OK (43 baselined files, no new occurrences)
pnpm check:nul-bytes                                 OK (6054 files, no raw control bytes)
pnpm --filter @objectstack/spec check:empty-state    OK (all classified)
pnpm --filter @objectstack/spec check:liveness       OK (30 governed types)
pnpm --filter @objectstack/spec check:strictness-ledger  OK (61 files, 5 directories)
pnpm --filter @objectstack/spec check:variant-docs   OK (18 unions, 8 governed)
```

The load-bearing check is not a gate: the fixture was rebuilt a second time **from the updated page's four listings** and re-run, reproducing the transcript above line for line. The page now reconstructs its own output.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_