### PR TITLE
docs(metadata-protocol): add the #8957 fourth decline bullet to migrateStoredMetadata's JSDoc

### DIFF
--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -13090,10 +13090,13 @@ export class ObjectStackProtocolImplementation implements
      *
      * ## What it declines to touch, and says so
      *
-     * This section documents the function's full internal surface, including
-     * paths no CLI caller can reach: `os migrate meta --stored` always passes
-     * its own automation engine (see `canonicalizeFlow` above), so the first
-     * bullet below is never observed from that door.
+     * This section documents the function's internal surface, which is not
+     * always identical to what an operator running the CLI can observe:
+     * `os migrate meta --stored` always passes its own automation engine
+     * (see `canonicalizeFlow` above), so the first bullet below is never
+     * observed from that door. That does not by itself account for every
+     * difference between this list and `content/docs/deployment/cli.mdx`'s
+     * decline table — see #9271.
      *
      * - **`flow` rows with no reachable automation engine.** Flow-node
      *   conversions carry ADR-0078's open-namespace conflict guard, which

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -13090,6 +13090,11 @@ export class ObjectStackProtocolImplementation implements
      *
      * ## What it declines to touch, and says so
      *
+     * This section documents the function's full internal surface, including
+     * paths no CLI caller can reach: `os migrate meta --stored` always passes
+     * its own automation engine (see `canonicalizeFlow` above), so the first
+     * bullet below is never observed from that door.
+     *
      * - **`flow` rows with no reachable automation engine.** Flow-node
      *   conversions carry ADR-0078's open-namespace conflict guard, which
      *   needs the engine's live executor registry. When one is reachable —
@@ -13120,6 +13125,17 @@ export class ObjectStackProtocolImplementation implements
      *   body is a genuine contract violation, not chain-owned history. They
      *   surface as `failed` with the validation message, keep reading through
      *   the chain, and stay fixable in Studio.
+     * - **Rows stored under a non-canonical metadata type spelling** (#8957,
+     *   {@link isNonCanonicalStoredType}). This pass canonicalizes BODIES;
+     *   rewriting a stored type spelling is an identity move — a new
+     *   `(org, type, name, package_id)` key, not an edit — so it is out of
+     *   its reach. Nothing on the canonical type can see such a row — no
+     *   registry read, no compliance query — and the batch publish refuses
+     *   it for the same reason (`STORED_TYPE_NOT_CANONICAL`). Reported
+     *   `skipped`, not `failed`: nothing is broken about this pass, the row
+     *   is simply outside its reach. Re-author the item under the canonical
+     *   type (`PUT /meta/<canonical>/<name>`) and drop the non-canonical
+     *   row.
      */
     async migrateStoredMetadata(request: {
         /** Write. Omitted / false = preview: reports what it would do, writes nothing. */


### PR DESCRIPTION
Fixes #9196

## What

`migrateStoredMetadata`'s own JSDoc header (`packages/metadata-protocol/src/protocol.ts`, immediately above the method signature, ~L13052–13142) has a "## What it declines to touch, and says so" section. Measured at HEAD (`739fe5b79`, before this branch): it still listed exactly **three** decline paths, and had never picked up the fourth #8957 (PR #9059, `b740440bd`) added — a row stored under a non-canonical metadata type, reported `outcome: 'skipped'`.

This PR adds that fourth bullet, mirroring the wording already written at the `isNonCanonicalStoredType(rawType)` branch's own inline comment (same file, ~L13254–13268) and its `reason:` string.

It also adds a short lead-in note to the section: `os migrate meta --stored` always passes its own automation engine (per this same JSDoc's `canonicalizeFlow` parameter doc a few lines above, and per `content/docs/deployment/cli.mdx`'s "Flows are covered, and cost one extra plugin" section, which confirms the CLI boots an inert engine specifically for this), so the JSDoc's "`flow` rows with no reachable automation engine" bullet is never observed from the CLI door — that is why `cli.mdx`'s decline table has no row for it. The note is deliberately narrow: it explains only that one direction of the discrepancy, not the reverse one (the JSDoc lacking `cli.mdx`'s "flow whose rename the conflict guard refused" row, which *is* internal to the function and so isn't accounted for by a CLI-reachability argument). No bullets were added or removed to reconcile the two lists.

## Scope fence — not resolved here (by design)

The two lists' gaps run in opposite directions and are not both explained by the same reasoning (see the note above). That is a maintainer question, tracked separately as #9271 ("[Decision] `migrateStoredMetadata`'s JSDoc decline list and `cli.mdx`'s decline table document different sets — intentional scope split, or two lists that drifted?"). This PR does not resolve it — no bullets were added or removed to make the two lists agree.

## Region-level surface

Only the JSDoc header immediately above `migrateStoredMetadata` was touched — two additive hunks, no reflow or reformatting elsewhere in `protocol.ts` (the repo's hottest file, with PR #9173 in flight against `hydrateOverlayIntoRegistry` at a different region).

## Tests

At commit `937f982aa` (current HEAD of this branch):

- `node scripts/check-nul-bytes.mjs` — OK.
- `pnpm check:filter-alias-parity` — OK (self-test + real run green).
- `pnpm check:durability-log-level` — OK (self-test 35/35, real run green).
- `pnpm check:cross-package-test-inputs` — OK (self-test 33/33, real run green).
- `pnpm --filter '@objectstack/metadata-protocol^...' build` then `pnpm --filter @objectstack/metadata-protocol build` — clean (DTS build succeeds, JSDoc is well-formed).
- `pnpm --filter @objectstack/metadata-protocol exec vitest run --maxWorkers=2` — 116 test files / 1606 tests passed (run at the prior commit `6d952880e`; this commit is comment-only within the same block, re-verified via the clean rebuild above).

Gate families re-derived against the actual changed path via `node scripts/pm/dispatch-gates.mjs packages/metadata-protocol/src/protocol.ts`: the three above, plus a docs-drift-check advisory (`content/docs/concepts/metadata-lifecycle.mdx`, via the `ObjectStackProtocolImplementation` symbol) — checked and clean: that page mentions `migrateStoredMetadata` once (the `job` type's skip behavior) but does not restate the decline list or any count, so it is not stale.

No gate enforces the JSDoc's bullet count — the artifact is the evidence; the full block is quoted verbatim in the linked issue's dev report.

## Changeset

None. This is a comment-only change (no accept/reject behaviour, no exported symbol, no runtime effect) — `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_