### PR TITLE
fix(driver-sql): a dialect error the driver cannot attribute leaves the read exits as an ADR-0112 backend-fault envelope (#8931)

### DIFF
--- a/.changeset/driver-sql-backend-fault-envelope.md
+++ b/.changeset/driver-sql-backend-fault-envelope.md
@@ -1,0 +1,76 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+fix(driver-sql): a dialect error the driver cannot attribute leaves the read exits as an ADR-0112 backend-fault envelope instead of raw (#8931)
+
+<!-- adr-0087: not-required (no-migration-prescription) Nothing authorable is
+added, renamed, retired or tombstoned — no metadata key, no spec surface, no
+declaration an author writes. The change is entirely in what a failing READ
+throws: an error that already declared no `status` and carried the compiled
+statement now declares `DATABASE_ERROR` / 500 and does not. There is no source
+file for a consumer to migrate and therefore no semantic-migration TODO to
+emit; the accept set is unchanged, since every condition below failed before
+this change and fails after it. -->
+
+`SqlDriver.find()` / `findOne()` / `count()` had one exit that answered with the
+**database's own error object**: a `code` from the backend's vocabulary
+(`42P01`, `SQLITE_ERROR`, `42601`, `22P02`, …), **no `status`** at all, and a
+message opening with the compiled statement. Two things travelled out of it that
+should not have — the statement's shape, and on one measured row the caller's
+own value.
+
+Ruled 2026-08-17 on #8931: the driver stops answering an unenveloped dialect
+error. Any dialect error the existing classification does not claim now leaves
+as a **generic backend-fault envelope**, `DATABASE_ERROR` / 500, asserting only
+*"the backend rejected this statement"*.
+
+**Not a filter verdict, and that is the ruling rather than a preference.**
+Measured live on PostgreSQL 16.13, a dotted WHERE key and a table that was never
+created raise the *same* SQLSTATE:
+
+```
+dotted key        42P01  missing FROM-clause entry for table "title"
+table not created 42P01  relation "no_such_object" does not exist
+```
+
+An `INVALID_FILTER` here would tell an operator whose schema sync had not run
+that their *filter* was wrong. The signal cannot support the claim, so the
+envelope does not make it — and the driver still never inspects the caller's key
+for a `.` (that verdict is #8371's, and it landed there).
+
+**Mechanism: a terminal catch-all, not a new recognizer.** No predicate learns
+`42P01`. `isUnresolvableColumnError` and `isMissingTableError` are untouched, so
+the #8790 refusal (`INVALID_FILTER` / 400 naming the column) still wins wherever
+it applies, and the #3821 projection / ORDER-BY recoveries still return rows.
+
+**What now takes the envelope**, measured on live PG 16.13 and better-sqlite3:
+a table that was never provisioned; a dotted WHERE key on Postgres; a
+comparand-shape syntax fault; a value the column type rejects; and connection,
+pool-acquisition, timeout or permission failures.
+
+**The disclosure this closes on a route nobody had named.** Postgres puts the
+caller's rejected VALUE in its own `22P02` diagnostic (`invalid input syntax for
+type integer: "…"`), *downstream* of everything knex parameterised — so no
+statement cut removes it. Withholding the dialect text whole is what closes it.
+(#8931's headline premise, a bound literal inlined on the *dotted* route, was
+measured false and pinned by #9108; this is the neighbouring row where a value
+really does travel.)
+
+**The original error is kept as a non-enumerable `cause`.** That is load-bearing,
+not tidiness: `isMissingTableError` follows `cause`, and thirteen read paths use
+it to tell "the table was never provisioned" — a benign emptiness — from a
+failure that must stay loud. Non-enumerable so the statement cannot ride back
+out through `JSON.stringify(err)` or a spread.
+
+**For callers.** At the REST boundary the wire answer for these conditions is
+materially unchanged — `mapDataError` already derived `500` + `DATABASE_ERROR`
+for them by sniffing the message; it is now *declared* by the producer that
+knows, per ADR-0112, and every non-REST consumer (an in-process ObjectQL caller,
+a plugin, an AI-authored action) gets the same declared answer instead of having
+to pattern-match a SQLSTATE that differs per backend. Two consequences worth
+naming: code that matched on the raw dialect `code` or message of a failing
+**read** must read `error.cause` instead; and a read against a **registered
+object whose table was never created** now answers `500 DATABASE_ERROR` where it
+previously answered `404 OBJECT_NOT_FOUND` with the body `Object 'x' is not
+registered` — a sentence that was false in exactly that state.

--- a/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
@@ -1,0 +1,401 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectstack#8931 — the driver stops answering an unenveloped dialect error.
+ *
+ * Maintainer ruling 2026-08-17 (「同意 C」, recorded on the card): the read
+ * exits of `driver-sql` gain a TERMINAL CATCH-ALL. Any dialect error the
+ * existing classification does not claim leaves as a GENERIC backend-fault
+ * envelope — `DATABASE_ERROR` / 500 — asserting only *"the backend rejected
+ * this statement"*, with no dialect text in the caller-visible message.
+ *
+ * ## The three fences, each of which is a way to get this wrong
+ *
+ * 1. **No filter verdict.** ⛔ Not `INVALID_FILTER`. Measured live on
+ *    PostgreSQL 16.13, the two conditions below raise the SAME SQLSTATE and
+ *    differ only in Postgres' own prose:
+ *
+ *    ```
+ *    dotted WHERE key   42P01  missing FROM-clause entry for table "title"
+ *    table not created  42P01  relation "no_such_object" does not exist
+ *    ```
+ *
+ *    A driver that answered `INVALID_FILTER` here would tell an operator whose
+ *    schema sync had not run that their FILTER was wrong. The signal cannot
+ *    support the claim, so the envelope does not make it.
+ *
+ * 2. **No new per-error-class predicate.** The envelope comes from the exit,
+ *    not from recognising `42P01`. A second recognizer beside
+ *    `isUnresolvableColumnError` is the split-predicate shape the #8926 ruling
+ *    refused — two spellings of "the driver recognises this dialect error" with
+ *    different consequences in one file. `isUnresolvableColumnError` and
+ *    `isMissingTableError` are both untouched by this card, and the caller's
+ *    key is still never inspected for a `.` (#8371 owns that verdict and it
+ *    landed there, PR #8936).
+ *
+ * 3. **No statement shape in the caller-visible message** — no physical table
+ *    names, no quoted references, no `$n`. The dialect's full text goes to the
+ *    server log instead.
+ *
+ * ## What now takes the envelope — the enumeration, measured not predicted
+ *
+ * Every read failure that is not an unresolvable WHERE column (which
+ * `unresolvableFilterColumnRefusal` already answered since #8790) and is not
+ * already ADR-0112-enveloped. On `origin/main` every one of these left the
+ * driver as the dialect's own error object — backend `code`, NO `status`, and a
+ * message opening with the compiled statement:
+ *
+ * | condition                    | pg      | sqlite         |
+ * |------------------------------|---------|----------------|
+ * | table never provisioned      | `42P01` | `SQLITE_ERROR` |
+ * | a dotted WHERE key           | `42P01` | *(refused since #8790)* |
+ * | comparand-shape syntax fault | `42601` | `SQLITE_ERROR` |
+ * | value rejected by the type   | `22P02` | *(coerced, no error)* |
+ * | connection / timeout / ACL   | the dialect's own, no `status` |
+ *
+ * ⭐ The `22P02` row is worth naming: Postgres puts the caller's REJECTED VALUE
+ * in its own diagnostic (`invalid input syntax for type integer:
+ * "zz-not-a-number"`), downstream of everything knex parameterised. No
+ * statement cut removes it — a redaction that keeps the diagnostic tail keeps
+ * the value with it — which is why this envelope COMPOSES its message instead
+ * of deriving one, and why closing this row is a genuine disclosure fix rather
+ * than a shape change. #8931's own headline premise (a bound literal inlined on
+ * the DOTTED route) was measured false and pinned by PR #9108; this is the
+ * neighbouring row where a value really does travel.
+ *
+ * ## What must NOT change, and is pinned here because it is the fork risk
+ *
+ * `isMissingTableError` (`@objectstack/metadata`) is how thirteen read paths
+ * tell "the table was never provisioned" — a benign emptiness — from a failure
+ * that must stay loud: `seedAutonumber` returns 0 rather than restarting a
+ * counter against a full table, `resolveFileReferences` fails open silently,
+ * the delete-dependents probe skips a relation. Wrapping WITHOUT the original
+ * attached would flip all three to their loud branch, which is a change to what
+ * the platform ACCEPTS and is expressly outside this ruling.
+ *
+ * The predicate already follows `error.cause` four levels deep, with its own
+ * pins (`schema-sync-errors.test.ts`, "follows an error wrapped as `cause`"),
+ * because "drivers commonly re-throw with the original attached as `cause`" is
+ * a case it was built for. So the wrap keeps the original there — and this
+ * suite pins the driver's half of that contract: the cause is present, it is
+ * the untouched dialect error, and it is NON-ENUMERABLE so it cannot ride back
+ * onto a wire through `JSON.stringify` or a spread.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { SqlDriver } from './sql-driver.js';
+import { DIALECT_CELLS, declareDialectCell, type DialectCell } from './live-dialect-matrix.testkit.js';
+
+const TABLE = 'backend_fault_task';
+const MISSING_TABLE = 'backend_fault_never_created';
+
+/**
+ * The caller's value, distinctive on purpose. It is asserted absent from every
+ * caller-visible surface — and on the `22P02` cell it is the value Postgres
+ * itself prints in its diagnostic, which is what makes that assertion a
+ * measurement rather than a formality.
+ */
+const SECRET_LITERAL = 'zz-backend-fault-must-not-leak';
+
+/**
+ * The two predicates the pg-only rows are about, typed rather than cast.
+ *
+ * `DriverQuery` rather than `as any`: a direct caller holding only a `where`
+ * used to reach for a blanket cast and lose `where`'s type with it, which is
+ * the erasure `check:query-options-erasure` ratchets — and the same reason the
+ * sibling refusal suite spells its cases this way.
+ */
+const DOTTED_KEY: NonNullable<DriverQuery['where']> = { 'title.x': SECRET_LITERAL };
+const TYPE_REJECTED: NonNullable<DriverQuery['where']> = { rank: SECRET_LITERAL };
+const UNRESOLVABLE_COLUMN: NonNullable<DriverQuery['where']> = { nosuchcol: SECRET_LITERAL };
+
+async function caught(run: () => Promise<unknown>): Promise<any> {
+  try {
+    await run();
+  } catch (err) {
+    return err;
+  }
+  return expect.fail('expected the query to fail, but it resolved');
+}
+
+/** Capture the driver's server-log line for one call. */
+async function withLog(
+  driver: SqlDriver,
+  run: () => Promise<unknown>,
+): Promise<{ err: any; logged: string[] }> {
+  const logged: string[] = [];
+  const sink = { warn: (m: string) => logged.push(String(m)), info: () => {}, error: () => {} };
+  const original = (driver as unknown as { logger: unknown }).logger;
+  (driver as unknown as { logger: unknown }).logger = sink;
+  try {
+    return { err: await caught(run), logged };
+  } finally {
+    (driver as unknown as { logger: unknown }).logger = original;
+  }
+}
+
+/**
+ * The disclosure clause, applied to one caller-visible message.
+ *
+ * ⛔ Asserted as a NEGATIVE set plus a positive anchor: the negatives are the
+ * ruling ("no statement shape"), the anchor is what stops an emptied message
+ * from satisfying them trivially — the same non-triviality guard #9108 added to
+ * the dotted disclosure pins, for the same reason.
+ */
+function expectNoStatementShape(message: string, object: string, half: string): void {
+  expect(message, `${half}: no compiled statement`).not.toMatch(/\bselect\s/i);
+  expect(message, `${half}: no positional placeholder`).not.toMatch(/\$\d/);
+  expect(message, `${half}: no quoted physical reference`).not.toMatch(/["`]/);
+  expect(message, `${half}: no bound literal`).not.toContain(SECRET_LITERAL);
+  expect(message, `${half}: the caller is still told which object failed`).toContain(object);
+}
+
+function declareSweep(cell: DialectCell): void {
+describe(`[#8931] driver-sql — the terminal backend-fault envelope (${cell.label})`, () => {
+  let driver: SqlDriver;
+
+  beforeAll(async () => {
+    driver = new SqlDriver(cell.config());
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.execute(`drop table if exists ${MISSING_TABLE}`).catch(() => {});
+    await driver.initObjects([
+      { name: TABLE, fields: { title: { type: 'string' }, rank: { type: 'integer' } } },
+    ]);
+    await driver.create(TABLE, { id: 't1', title: 'Design', rank: 1 }, { bypassTenantAudit: true });
+    await driver.create(TABLE, { id: 't2', title: 'Build', rank: 2 }, { bypassTenantAudit: true });
+  });
+
+  afterAll(async () => {
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.disconnect();
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // THE RULING — one envelope, both halves, no dialect text
+  // ───────────────────────────────────────────────────────────────
+
+  it('a read against a table that was never provisioned takes the envelope on BOTH halves', async () => {
+    for (const [half, run] of [
+      ['find', () => driver.find(MISSING_TABLE, {})],
+      ['count', () => driver.count(MISSING_TABLE, {})],
+    ] as const) {
+      const err = await caught(run);
+      expect(err.code, `${half}: code`).toBe('DATABASE_ERROR');
+      expect(err.status, `${half}: status`).toBe(500);
+      expectNoStatementShape(String(err.message), MISSING_TABLE, half);
+    }
+  });
+
+  // The invariant #8790 established on this path — one condition, one answer,
+  // whichever half asked — extended by this ruling to every condition the
+  // ladder cannot recover. A list view calls both halves, so a split here is
+  // what produces an empty page next to a 500-shaped total.
+  it('find() and count() answer an unclassified fault the SAME way', async () => {
+    const onFind = await caught(() => driver.find(MISSING_TABLE, {}));
+    const onCount = await caught(() => driver.count(MISSING_TABLE, {}));
+    expect({ code: onCount.code, status: onCount.status, message: onCount.message })
+      .toEqual({ code: onFind.code, status: onFind.status, message: onFind.message });
+  });
+
+  // ⛔ THE FENCE: the envelope must claim nothing about the filter. A table that
+  // was never created is not a filter fault, and on Postgres it raises the very
+  // SQLSTATE the dotted key does — so an `INVALID_FILTER` here would be the
+  // wrong verdict reached through the right code path.
+  it('the envelope makes NO claim about the filter (#8931 fence 1)', async () => {
+    const err = await caught(() => driver.find(MISSING_TABLE, {}));
+    expect(err.code).not.toBe('INVALID_FILTER');
+    expect(err.status).not.toBe(400);
+    expect(String(err.message)).not.toMatch(/filter/i);
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // THE CAUSE — what keeps `isMissingTableError` truthful
+  // ───────────────────────────────────────────────────────────────
+
+  it('keeps the original dialect error as a NON-ENUMERABLE `cause`', async () => {
+    const err = await caught(() => driver.find(MISSING_TABLE, {}));
+    const cause = (err as { cause?: any }).cause;
+    expect(cause, 'the original dialect error must survive as `cause`').toBeDefined();
+    // Untouched: the backend's own code and its own words, which is what every
+    // cause-following predicate downstream reads.
+    expect(typeof cause.code, 'the dialect code is preserved').toBe('string');
+    expect(String(cause.message)).toContain(MISSING_TABLE);
+    // ⛔ Not enumerable: an enumerable `cause` rides out through
+    // `JSON.stringify(err)` and `{ ...err }`, putting the compiled statement —
+    // and on the dialects that inline them, the caller's bound literals — back
+    // on any wire that serialises the error.
+    expect(Object.keys(err), 'own enumerable keys').toEqual(['code', 'status']);
+    expect(JSON.stringify(err), 'a serialised envelope carries no dialect text')
+      .not.toContain('select');
+  });
+
+  // The cross-package consequence, asserted structurally because the predicate
+  // itself lives in `@objectstack/metadata` (not a dependency of this package,
+  // and deliberately not made one for a test). `isMissingTableError` reads
+  // `code` then `message` then one step down `cause` — so these three facts
+  // ARE its inputs, and its own suite pins that it follows them.
+  it('the `cause` carries everything `isMissingTableError` reads', async () => {
+    const err = await caught(() => driver.find(MISSING_TABLE, {}));
+    const cause = (err as { cause?: any }).cause;
+    const codeOrMessageIdentifiesAMissingTable =
+      cause.code === '42P01'
+      || cause.code === 'ER_NO_SUCH_TABLE'
+      || /no such table|relation ["'`][^"'`]+["'`] does not exist|table ["'`][^"'`]+["'`] doesn'?t exist/i
+        .test(String(cause.message));
+    expect(
+      codeOrMessageIdentifiesAMissingTable,
+      'the wrapper must not hide the missing-table signal — three read paths turn a benign '
+        + 'emptiness into a loud failure if it does',
+    ).toBe(true);
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // THE LOG — a withholding, not a deletion
+  // ───────────────────────────────────────────────────────────────
+
+  it('writes the full dialect text to the SERVER LOG, statement included', async () => {
+    const { err, logged } = await withLog(driver, () => driver.find(MISSING_TABLE, {}));
+    expect(err.code).toBe('DATABASE_ERROR');
+    const line = logged.find((l) => l.includes(MISSING_TABLE));
+    expect(line, 'an operator must still be able to read what the backend said').toBeDefined();
+    // The half that makes it a redaction rather than a deletion: the statement
+    // the caller may not see is in the log, where an operator can.
+    expect(String(line)).toMatch(/\bselect\b/i);
+    expect(String(line)).toContain('DATABASE_ERROR');
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // CONTROLS — the catch-all is TERMINAL, not blanket
+  // ───────────────────────────────────────────────────────────────
+
+  it('CONTROL a working query is untouched on both halves', async () => {
+    expect((await driver.find(TABLE, { where: { title: 'Design' } })).map((r: any) => r.id))
+      .toEqual(['t1']);
+    expect(await driver.count(TABLE, { where: { title: 'Design' } })).toBe(1);
+  });
+
+  it('CONTROL a predicate that genuinely matches nothing is still an honest empty list', async () => {
+    expect(await driver.find(TABLE, { where: { title: 'no-such-title' } })).toEqual([]);
+    expect(await driver.count(TABLE, { where: { title: 'no-such-title' } })).toBe(0);
+  });
+
+  // ⛔ The precise refusal must WIN over the generic one. If the catch-all ever
+  // ran first, #8790's `INVALID_FILTER` — the answer that names the column a
+  // caller can fix — would be buried under a 500 that names nothing.
+  it('CONTROL the #8790 filter refusal still wins over the catch-all', async () => {
+    for (const [half, run] of [
+      ['find', () => driver.find(TABLE, { where: UNRESOLVABLE_COLUMN })],
+      ['count', () => driver.count(TABLE, { where: UNRESOLVABLE_COLUMN })],
+    ] as const) {
+      const err = await caught(run);
+      expect(err.code, `${half}`).toBe('INVALID_FILTER');
+      expect(err.status, `${half}`).toBe(400);
+      expect(String(err.message), `${half}`).toContain('nosuchcol');
+    }
+  });
+
+  // The #3821 ladder is upstream of the catch-all and must stay so: a
+  // recoverable projection or sort still returns rows rather than a 500.
+  it('CONTROL the #3821 recoveries still return rows, not the envelope', async () => {
+    const rows = await driver.find(TABLE, {
+      fields: ['title', 'nosuchfield'],
+      orderBy: [{ field: 'alsomissing', order: 'asc' }],
+      where: { rank: { $gte: 1 } },
+    });
+    expect(rows).toHaveLength(2);
+  });
+});
+}
+
+// A matrix that silently finds zero cells reports OK — assert the axis is real
+// before iterating it.
+describe('[#8931] the dialect axis this suite runs', () => {
+  it('runs every dialect this driver speaks', () => {
+    expect(DIALECT_CELLS.map((c) => c.id)).toEqual(['sqlite', 'pg', 'mysql']);
+  });
+});
+
+for (const cell of DIALECT_CELLS) {
+  declareDialectCell(cell, 'terminal backend-fault envelope', declareSweep);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// POSTGRES-ONLY — the two rows the SQLite cell structurally cannot show
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * The card's own route, and the row where a caller's VALUE really travels.
+ *
+ * Both need a live Postgres because both are facts about Postgres' parser:
+ * SQLite refuses a dotted key as an unresolvable COLUMN (so #8790 already
+ * answered it, and it never reaches the catch-all), and SQLite coerces
+ * `'zz-…'` against an INTEGER column without complaining at all.
+ */
+const PG = DIALECT_CELLS.find((c) => c.id === 'pg')!;
+
+declareDialectCell(PG, 'backend-fault envelope — the pg-only rows', (cell) => {
+describe('[#8931] postgres — the dotted route and the value-bearing diagnostic', () => {
+  let driver: SqlDriver;
+
+  beforeAll(async () => {
+    driver = new SqlDriver(cell.config());
+    await driver.execute(`drop table if exists ${TABLE}_pg`).catch(() => {});
+    await driver.initObjects([
+      { name: `${TABLE}_pg`, fields: { title: { type: 'string' }, rank: { type: 'integer' } } },
+    ]);
+    await driver.create(`${TABLE}_pg`, { id: 't1', title: 'Design', rank: 1 }, { bypassTenantAudit: true });
+  });
+
+  afterAll(async () => {
+    await driver.execute(`drop table if exists ${TABLE}_pg`).catch(() => {});
+    await driver.disconnect();
+  });
+
+  // ⭐ THE CARD. Before this ruling both halves answered a raw `42P01` with no
+  // `status`, carrying `select … where "title"."x" = $1 - missing FROM-clause
+  // entry for table "title"` — the statement's shape, to the caller.
+  it('a dotted WHERE key is enveloped on both halves, with no statement shape', async () => {
+    for (const [half, run] of [
+      ['find', () => driver.find(`${TABLE}_pg`, { where: DOTTED_KEY })],
+      ['count', () => driver.count(`${TABLE}_pg`, { where: DOTTED_KEY })],
+    ] as const) {
+      const err = await caught(run);
+      expect(err.code, `${half}`).toBe('DATABASE_ERROR');
+      expect(err.status, `${half}`).toBe(500);
+      expectNoStatementShape(String(err.message), `${TABLE}_pg`, half);
+      // ⛔ Specifically: none of the three shapes the card measured escaping.
+      expect(String(err.message), `${half}`).not.toContain('missing FROM-clause entry');
+      expect(String(err.message), `${half}`).not.toContain('title');
+    }
+  });
+
+  // ⭐ The row where Postgres itself inlines the caller's value — in its OWN
+  // diagnostic, after knex parameterised the statement. A statement-cut
+  // redaction keeps the tail and therefore keeps the value; withholding the
+  // dialect text whole is what closes it.
+  it('a value the column type rejects never reaches the caller (22P02)', async () => {
+    const { err, logged } = await withLog(driver, () =>
+      driver.find(`${TABLE}_pg`, { where: TYPE_REJECTED }),
+    );
+    expect(err.code).toBe('DATABASE_ERROR');
+    expect(err.status).toBe(500);
+    expect((err as { cause?: any }).cause?.code, 'the pg SQLSTATE for a bad input value').toBe('22P02');
+    expectNoStatementShape(String(err.message), `${TABLE}_pg`, '22P02');
+    for (const key of Object.keys(err ?? {})) {
+      const value = (err as Record<string, unknown>)[key];
+      if (typeof value === 'string') {
+        expect(value, `own property '${key}'`).not.toContain(SECRET_LITERAL);
+      }
+    }
+    // POSITIVE CONTROL — the value really was in the dialect's text, so the
+    // absence above is a withholding rather than a statement about a string
+    // that never held it. This is the assertion that would go green for the
+    // wrong reason if pg ever stopped naming the value.
+    expect(
+      logged.some((l) => l.includes(SECRET_LITERAL)),
+      "postgres' own 22P02 diagnostic should have carried the caller's value into the log",
+    ).toBe(true);
+  });
+});
+});

--- a/packages/drivers/driver-sql/src/sql-driver-unresolvable-where-column-refusal.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-unresolvable-where-column-refusal.test.ts
@@ -78,9 +78,36 @@
  * was missing, so the property stops being an unstated accident of the client
  * library: see `DOTTED_STATUS_QUO.literalWithheldBy`, the disclosure pins in
  * each cell's sweep, and the mechanism pin at the bottom of the file.
- * ⛔ The dotted route's `code` and `status` are unchanged and stay recorded
- * rather than asserted — questions 1 (can it be enveloped without judging the
- * key) and 2 (which envelope) are unruled and are the maintainer's.
+ *
+ * [#8931 questions 1 and 2, maintainer ruling 2026-08-17 「同意 C」] Those two
+ * are now ruled, and the Postgres row of `DOTTED_STATUS_QUO` changes with them
+ * — DELIBERATELY, so ⛔ do not read the changed cells as drift. The ruling: the
+ * driver stops answering an unenveloped dialect error at all. Any dialect error
+ * the existing classification does not claim leaves the read exits as a GENERIC
+ * backend-fault envelope (`DATABASE_ERROR` / 500) asserting only "the backend
+ * rejected this statement" — ⛔ never `INVALID_FILTER`, and no verdict about the
+ * filter, because on Postgres `42P01` is the same signal for a dotted key and
+ * for a table that was never provisioned (measured below) and cannot honestly
+ * support one. It is a terminal CATCH-ALL, ⛔ not a new recognizer on `42P01`:
+ * `isUnresolvableColumnError` is untouched, the key is still never inspected
+ * for a `.`, and #8371's verdict (landed in PR #8936) stays the only one.
+ *
+ * Two consequences this file now pins rather than records:
+ *
+ *  - the pg cell's `code`/`status` move from `42P01`/`undefined` to
+ *    `DATABASE_ERROR`/`500`, and its caller-visible message loses the dialect
+ *    text entirely — statement, quoted references and `$n` alike;
+ *  - `literalWithheldBy` for pg moves from `NEVER_INLINED` to the envelope, and
+ *    the knex fact it used to name moves one slot over, to
+ *    `dialectTextInlinesLiteral` — asserted now against the SERVER LOG, which
+ *    is where the dialect text still goes. The distinction #9108 paid for is
+ *    kept, not collapsed: "the value was never in the text" and "the text was
+ *    withheld" remain different facts about different strings.
+ *
+ * The end-to-end envelope, its enumeration and its `cause` preservation live in
+ * `sql-driver-backend-fault-envelope.test.ts`; what stays here is the DOTTED
+ * route, because that is the route this file has measured across three dialects
+ * since #8790.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -188,17 +215,54 @@ const UNRESOLVABLE: ReadonlyArray<{ label: string; where: NonNullable<DriverQuer
  * `13d78642d` evidence) does not hold on Postgres. ⚠️ The property is real but
  * INCIDENTAL — it belongs to knex's binding path, not to any rule this repo
  * states — so it is asserted here, and the mechanism pin at the bottom fails
- * the day that path changes. What remains genuinely open on the pg cell is the
- * ENVELOPE (a raw `42P01` with no `status`, carrying the compiled statement's
- * shape), and that is questions 1 and 2, unruled.
+ * the day that path changes.
+ *
+ * ## [#8931 Q1+Q2, ruled 2026-08-17] The pg cell's answer changes — on purpose
+ *
+ * The envelope that was open when the paragraphs above were written is now
+ * ruled, so the pg cell reads `DATABASE_ERROR` / 500 with a COMPOSED message
+ * and no dialect text at all. That collapses the caller-visible half of the
+ * mechanism distinction — a withheld message carries no literal whatever knex
+ * did with the bindings — so the knex fact is kept on its own axis
+ * ({@link DottedCell.dialectTextInlinesLiteral}) and asserted where the dialect
+ * text still exists: the SERVER LOG line the driver writes on the way out.
+ *
+ * ⛔ Collapsing the two into "no literal reaches the caller" is exactly what let
+ * #8931's false premise stand for a month; the axis is kept for that reason and
+ * ⛔ must not be removed because the caller-side assertion became uniform.
  */
 interface DottedCell {
-  /** The `code` the caller receives. ⛔ Recorded, not adjudicated (#8931 Q1/Q2). */
+  /**
+   * The `code` the caller receives.
+   *
+   * [#8931 Q1/Q2] For sqlite/mysql this is still RECORDED (the #8790 refusal
+   * decides it, and #8371 owns the dotted verdict). For pg it is now the ruled
+   * generic backend-fault envelope — the terminal catch-all's answer, which
+   * makes no claim about the filter.
+   */
   code: string;
-  /** Does the answer carry the ADR-0112 envelope (`status: 400`)? */
-  enveloped: boolean;
-  /** [#8931 Q3] Which of the two mechanisms above keeps the literal off the wire. */
-  literalWithheldBy: typeof REFUSAL_ENVELOPE | typeof NEVER_INLINED;
+  /**
+   * The `status` the caller receives — `undefined` would mean an unenveloped
+   * dialect error escaped, which since the 2026-08-17 ruling no cell may do.
+   */
+  status: number;
+  /** [#8931 Q3] Which mechanism keeps the literal out of the CALLER's message. */
+  literalWithheldBy:
+    | typeof REFUSAL_ENVELOPE
+    | typeof NEVER_INLINED
+    | typeof BACKEND_FAULT_ENVELOPE;
+  /**
+   * [#8931 Q3, re-homed by Q1/Q2] Does the dialect's own text — the string that
+   * now reaches only the server log — carry the caller's bound literal?
+   *
+   * The half of `literalWithheldBy` that survives the envelope: `true` means
+   * the log line proves the message COULD have carried the value (sqlite and
+   * mysql leave `?` for knex's formatter to substitute), `false` means it never
+   * could (pg positions bindings to `$n` first). Asserting only the caller's
+   * side would make every cell pass for a different reason and record none of
+   * them.
+   */
+  dialectTextInlinesLiteral: boolean;
   /**
    * Substrings the caller-visible message MUST still carry.
    *
@@ -213,26 +277,43 @@ interface DottedCell {
 const REFUSAL_ENVELOPE = 'the #8790 refusal envelope (a real redaction)';
 /** knex parameterised the value, so the message never carried it. */
 const NEVER_INLINED = 'knex parameterisation — the literal was never in the text';
+/** [#8931 Q1/Q2] The whole dialect text is withheld, so nothing in it can travel. */
+const BACKEND_FAULT_ENVELOPE = 'the #8931 backend-fault envelope (the dialect text is withheld whole)';
 
 const DOTTED_STATUS_QUO: Readonly<Record<string, DottedCell>> = {
   sqlite: {
     code: 'INVALID_FILTER',
-    enveloped: true,
+    status: 400,
     literalWithheldBy: REFUSAL_ENVELOPE,
+    dialectTextInlinesLiteral: true,
     identifies: ['title.x', TABLE],
   },
+  // [#8931 Q1+Q2, ruled 2026-08-17 「同意 C」] ⚠️ CHANGED CELL, and the reason is
+  // recorded here so the next reader does not read it as drift. Postgres
+  // classifies the dotted key as an undefined TABLE (`42P01`) — the identical
+  // signal it raises for a relation that was never provisioned — so no honest
+  // verdict about the FILTER can be read out of it. The ruling therefore does
+  // not teach any predicate to recognise it: the terminal catch-all wraps every
+  // dialect error the existing classification leaves unclaimed, and this cell
+  // is one of them. `code`/`status` move from `42P01`/`undefined` to
+  // `DATABASE_ERROR`/`500`, and the message stops carrying the statement.
   pg: {
-    code: '42P01',
-    enveloped: false,
-    literalWithheldBy: NEVER_INLINED,
-    // The raw dialect text, which on this cell IS the caller-visible message:
-    // `select … where "title"."x" = $1 - missing FROM-clause entry for table "title"`.
-    identifies: ['missing FROM-clause entry for table', '"title"."x"', TABLE],
+    code: 'DATABASE_ERROR',
+    status: 500,
+    literalWithheldBy: BACKEND_FAULT_ENVELOPE,
+    // Still false, still the #9108 measurement, now asserted on the LOG line —
+    // the only string that still holds the dialect's words.
+    dialectTextInlinesLiteral: false,
+    // The composed message names the caller's own object and nothing else: ⛔ no
+    // table name, no quoted reference, no `$n`. The negative half of this is
+    // asserted for every cell in the disclosure sweep below.
+    identifies: [TABLE],
   },
   mysql: {
     code: 'INVALID_FILTER',
-    enveloped: true,
+    status: 400,
     literalWithheldBy: REFUSAL_ENVELOPE,
+    dialectTextInlinesLiteral: true,
     identifies: ['title.x', TABLE],
   },
 };
@@ -314,7 +395,28 @@ describe(`[#8790] driver-sql — unresolvable WHERE column refuses on BOTH halve
     expect(expected, `no recorded status quo for cell '${cell.id}'`).toBeDefined();
     const err = await caught(() => driver.find(TABLE, { where: { 'title.x': SECRET_LITERAL } }));
     expect(err.code).toBe(expected.code);
-    expect(err.status).toBe(expected.enveloped ? 400 : undefined);
+    expect(err.status).toBe(expected.status);
+  });
+
+  // [#8931 Q1+Q2, ruled 2026-08-17] The half of the ruling that is true of
+  // EVERY cell and does not depend on which envelope a dialect lands in: no
+  // dotted route may answer an unenveloped dialect error. Stated separately
+  // from the per-cell record above so that a future cell added to
+  // `DOTTED_STATUS_QUO` cannot record `status: undefined` and pass.
+  it('no dialect answers a dotted key with an unenveloped dialect error (#8931)', async () => {
+    for (const [half, run] of [
+      ['find', () => driver.find(TABLE, { where: { 'title.x': SECRET_LITERAL } })],
+      ['count', () => driver.count(TABLE, { where: { 'title.x': SECRET_LITERAL } })],
+    ] as const) {
+      const err = await caught(run);
+      expect(typeof err.status, `${half}: an ADR-0112 status`).toBe('number');
+      expect(err.status, `${half}`).toBeGreaterThanOrEqual(400);
+      expect(typeof err.code, `${half}: an ADR-0112 code`).toBe('string');
+      // The dialect's own vocabulary must not survive as the caller's `code`.
+      expect(err.code, `${half}`).not.toBe('SQLITE_ERROR');
+      expect(err.code, `${half}`).not.toBe('42P01');
+      expect(err.code, `${half}`).not.toBe('ER_BAD_FIELD_ERROR');
+    }
   });
 
   // ───────────────────────────────────────────────────────────────
@@ -348,6 +450,15 @@ describe(`[#8790] driver-sql — unresolvable WHERE column refuses on BOTH halve
       for (const needle of expected.identifies) {
         expect(err.message, `${half}: the caller must still be told '${needle}'`).toContain(needle);
       }
+      // [#8931 Q1+Q2] The disclosure clause of the 2026-08-17 ruling, asserted
+      // on every cell rather than only the one that changed: the caller-visible
+      // message carries no STATEMENT SHAPE. Before the ruling the pg cell
+      // failed all three of these — its message opened `select * from
+      // "unresolvable_where_task" where "title"."x" = $1` — which is what made
+      // "the caller sees the query's structure" the residue #9108 left open.
+      expect(err.message, `${half}: no compiled statement`).not.toMatch(/\bselect\s/i);
+      expect(err.message, `${half}: no positional placeholder`).not.toMatch(/\$\d/);
+      expect(err.message, `${half}: no quoted physical reference`).not.toMatch(/["`]/);
     }
   });
 
@@ -371,20 +482,36 @@ describe(`[#8790] driver-sql — unresolvable WHERE column refuses on BOTH halve
 
     expect(err.message).not.toContain(SECRET_LITERAL);
 
-    if (expected.literalWithheldBy === REFUSAL_ENVELOPE) {
-      // A REAL redaction: the dialect text did carry the caller's value, and
-      // the refusal moved it to the server log (#7929's line, #8790's seam).
-      // This is the proof the message "would have carried the literal".
+    // [#8931 Q1+Q2, ruled 2026-08-17] Since the catch-all, EVERY cell writes
+    // the dialect's own text to the server log on the way out — the pg cell
+    // included, which before this ruling logged nothing at all because nothing
+    // recognised its error. So the control is now uniform on the log's
+    // EXISTENCE, and the per-cell fact it proves is what that text contains.
+    const dialectText = logged.find((line) => line.includes(' - ') || line.includes('select '));
+    expect(
+      dialectText,
+      'the dialect message must reach the server log — that is what makes this a withholding rather than a deletion',
+    ).toBeDefined();
+
+    if (expected.dialectTextInlinesLiteral) {
+      // sqlite / mysql: knex leaves `?` standing, so its error formatter
+      // substituted the caller's value into the text. The log carrying it is
+      // the proof the caller's message "could have" carried it — without this,
+      // "no literal in the message" is a claim about a string nobody showed
+      // ever held one.
       expect(
         logged.some((line) => line.includes(SECRET_LITERAL)),
         'the dialect text should have reached the server log with the literal intact',
       ).toBe(true);
     } else {
-      // Postgres: NOT a redaction. The value was parameterised, so a `$n`
-      // placeholder stands where it would have been — and nothing was logged,
-      // because nothing recognised the error in the first place. ⛔ Do not
-      // read this cell as "the redaction works here"; see `literalWithheldBy`.
-      expect(err.message, 'the value should stand as a placeholder, not a literal').toMatch(/\$\d/);
+      // Postgres: the value was parameterised BEFORE the failing statement was
+      // formatted, so a `$n` placeholder stands where it would have been — in
+      // the log, which since the ruling is the only place the dialect text
+      // exists. ⛔ Do not read this cell as "the redaction works here": nothing
+      // was redacted, the value was never in the string. The mechanism pin at
+      // the bottom of this file is why that stays true.
+      expect(String(dialectText), 'the value should stand as a placeholder, not a literal')
+        .toMatch(/\$\d/);
       expect(logged.some((line) => line.includes(SECRET_LITERAL))).toBe(false);
     }
   });
@@ -430,9 +557,19 @@ describe(`[#8790] driver-sql — unresolvable WHERE column refuses on BOTH halve
     expect(await driver.count(TABLE, { where: { title: 'no-such-title' } })).toBe(0);
   });
 
-  it('CONTROL an error that is not about an unresolvable column still propagates unchanged', async () => {
+  // [#8931] This used to assert the error "propagates unchanged", which since
+  // the 2026-08-17 ruling is no longer what happens and would have been a
+  // misleading name to leave standing: an unclassified dialect error now takes
+  // the generic backend-fault envelope. What the control is FOR is unchanged —
+  // the #8790 refusal must stay selective, i.e. a failure that is not about an
+  // unresolvable column must not be answered as if it were. The full envelope,
+  // its enumeration and its `cause` preservation are pinned in
+  // `sql-driver-backend-fault-envelope.test.ts`.
+  it('CONTROL an error that is not about an unresolvable column is NOT answered as a filter fault', async () => {
     const err = await caught(() => driver.find('no_such_table_at_all', {}));
     expect(err.code).not.toBe('INVALID_FILTER');
+    expect(err.code).toBe('DATABASE_ERROR');
+    expect(err.status).toBe(500);
   });
 
   // ───────────────────────────────────────────────────────────────
@@ -540,6 +677,15 @@ const DIALECT_MESSAGES: ReadonlyArray<{
   // predicate matches it — before this card or after. Teaching the classifier
   // this shape would mint a dotted-path verdict the driver has no business
   // making; #8371 owns that. See `DOTTED_STATUS_QUO`.
+  //
+  // [#8931 Q1+Q2, ruled 2026-08-17] `recognised: false` is still correct and is
+  // now load-bearing in a second way: the pg dotted route is enveloped, but ⛔
+  // NOT by this predicate learning `42P01`. It is enveloped by the terminal
+  // CATCH-ALL, which claims no error class at all. A future reader tempted to
+  // flip this to `true` "because pg is enveloped now" would be minting exactly
+  // the second recognizer the ruling forbids — and, since `42P01` is also how
+  // Postgres reports a table that was never provisioned, would answer
+  // `INVALID_FILTER` for an unsynced schema.
   {
     dialect: 'postgres, DOTTED key — undefined_table, NOT recognised',
     message: 'select * from "task" where "title"."x" = $1 - missing FROM-clause entry for table "title"',
@@ -656,6 +802,17 @@ describe('[#8790] dialect wording — what the refusal recognises and what it na
  * knex upgrade ever positions bindings after formatting (or teaches the
  * formatter `$n`), this goes red and the pg cell becomes a genuine leak that
  * question 3 would then have to fix for real.
+ *
+ * [#8931 Q1+Q2, ruled 2026-08-17] ⚠️ This pin's CONSUMER moved, and it is worth
+ * a sentence because a reader could otherwise conclude the envelope retired it.
+ * The caller-visible message no longer carries the dialect text on any cell, so
+ * the fact below no longer protects the caller — it protects the SERVER LOG,
+ * which is where the driver now writes the dialect's words. A knex upgrade that
+ * inlined pg bindings would put the caller's value in that log line, which is
+ * precisely the exposure `redactBoundStatement` (`@objectstack/objectql`)
+ * closes for the engine's own log slots. The pin therefore stays live and its
+ * red still means "re-measure by hand"; only the string it is a statement about
+ * has changed.
  *
  * ⚠️ `positionBindings` is knex's own seam, not a public API contract. That is
  * the point: a red here means "the assumption underneath the pg cell moved",

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -730,6 +730,120 @@ function unresolvableFilterColumnError(object: string, column: string | null): E
 }
 
 /**
+ * [#8931, maintainer ruling 2026-08-17 「同意 C」] The backend rejected the
+ * statement, and the driver claims NOTHING beyond that.
+ *
+ * # What this envelope asserts, and what it deliberately refuses to assert
+ *
+ * Exactly one thing: *the backend would not run this statement*. It is not
+ * `INVALID_FILTER` and carries no verdict about the filter, the projection, the
+ * sort or the object. That restraint is the ruling, and it is forced by a
+ * measurement rather than chosen for tone: on Postgres a dotted WHERE key
+ * (`{'title.x': v}`, which knex compiles to the qualified reference
+ * `"title"."x"`) and a table that was never provisioned raise the SAME
+ * SQLSTATE — `42P01` — differing only in Postgres' own prose:
+ *
+ * ```
+ * dotted key      42P01  missing FROM-clause entry for table "title"   (errorMissingRTE)
+ * missing table   42P01  relation "no_such_object" does not exist      (parserOpenTable)
+ * ```
+ *
+ * Measured on a live PostgreSQL 16.13. A driver that answered `INVALID_FILTER`
+ * here would tell an operator whose schema sync had not run that their FILTER
+ * was wrong; one that answered "table not provisioned" would tell a caller with
+ * a dotted key that the object is missing. Neither claim is supportable from
+ * the signal, so this envelope makes neither.
+ *
+ * # Why a catch-all rather than a predicate
+ *
+ * The alternative — recognise `42P01` and answer something specific — is a
+ * SECOND recognizer on an error class beside {@link isUnresolvableColumnError},
+ * i.e. two spellings of "the driver recognises this dialect error" with
+ * different consequences in one file. That is the split-predicate shape the
+ * #8926 ruling already refused, and it is refused again here. The rule stays
+ * the ruled one: refuse what the backend could not resolve, and ⛔ never
+ * inspect the caller's key for a `.` — the dotted-path VERDICT is #8371's, and
+ * it landed there (PR #8936).
+ *
+ * # `DATABASE_ERROR` / 500, and why that is the honest pair
+ *
+ * `DATABASE_ERROR` is the catalog's own "database operation failed"
+ * (`StandardErrorCode`, `## Server Errors (500)`), and it is already the verdict
+ * `packages/rest` derives for this condition by sniffing the message
+ * (`DATA_STORE_FAULT` — `500` + `DATABASE_ERROR`). So the wire answer a REST
+ * caller sees does not move; what moves is WHERE it is decided. It is declared
+ * by the producer that actually knows, per ADR-0112, instead of re-derived from
+ * prose at a boundary — and every non-REST consumer (an in-process ObjectQL
+ * caller, a plugin, an AI-authored action) gets the same declared answer, which
+ * before this had to pattern-match a SQLSTATE that differs per backend.
+ *
+ * 400 was not available: it would assert the caller's request is at fault, and
+ * this envelope exists precisely because the driver cannot attribute the
+ * failure. 500 also keeps the answer inside `declaresServerFault`
+ * (`@objectstack/types`), so both HTTP doors withhold the prose and log it.
+ *
+ * # The original is kept as `cause`, and that is load-bearing
+ *
+ * `isMissingTableError` (`@objectstack/metadata`) is the predicate three read
+ * paths use to tell "the table was never provisioned" — a benign emptiness —
+ * from a failure that must stay loud: `seedAutonumber` (returns 0),
+ * `resolveFileReferences` (fails open silently) and the delete-dependents probe
+ * (skips the relation). Wrapping WITHOUT the original attached would have
+ * flipped all three to their loud branch, which is a change to what the
+ * platform accepts — expressly outside this ruling.
+ *
+ * That predicate already follows `error.cause` up to four levels, with its own
+ * pins (`schema-sync-errors.test.ts`, "follows an error wrapped as `cause`"),
+ * because "drivers commonly re-throw with the original attached as `cause`" is
+ * a case it was built for. So the wrap is transparent to it and to every other
+ * cause-following consumer, and ⛔ the predicate itself is untouched.
+ *
+ * The property is defined NON-ENUMERABLE, the same shape `new Error(msg, {
+ * cause })` produces. An enumerable `cause` would ride out through
+ * `JSON.stringify(err)` and `{ ...err }` — putting the compiled statement, and
+ * on the dialects that inline them the caller's bound literals, back on any
+ * wire that serialises the error. The carrier must be readable by code and
+ * invisible to serialisation, which is the same reasoning
+ * {@link WITHHELD_FILTER_DIAGNOSTIC} applies one refusal over.
+ *
+ * @param object - the API object name the caller asked for. Its own vocabulary,
+ *                 never the physical table: see the message note below.
+ * @param cause  - the dialect error, kept whole for the log and for
+ *                 cause-following predicates.
+ */
+function backendStatementFaultError(object: string, cause: unknown): Error {
+  // ⛔ No dialect text reaches the caller — not the statement, not the quoted
+  // references, not the `$n` placeholders, not the backend's own prose. The
+  // ruling's disclosure clause, and it is why this message is COMPOSED rather
+  // than derived from the dialect's: measured on live PG 16.13, a derivation
+  // that keeps the diagnostic tail (the shape `redactStatementFromMessage`
+  // produces) still ships `invalid input syntax for type integer:
+  // "zz-not-a-number"` — Postgres inlines the caller's value in its OWN
+  // diagnostic on `22P02`, downstream of anything knex parameterised. There is
+  // no cut that keeps a dialect's words and reliably drops a caller's value,
+  // so none is attempted.
+  //
+  // The object name is the caller's own input (the API name it passed), not
+  // the physical table it maps to, so echoing it discloses nothing the caller
+  // did not write — the same line every sibling refusal in this file draws.
+  const err = new Error(
+    `The database refused to run this query for object '${object}'. The driver could not ` +
+      'attribute the failure to any part of the request, so no verdict about the query is ' +
+      "claimed here. The backend's own diagnostic and the compiled statement were written " +
+      'to the server log for an operator to read.',
+  ) as Error & { code?: string; status?: number };
+  err.code = StandardErrorCode.enum.DATABASE_ERROR;
+  err.status = 500;
+  Object.defineProperty(err, 'cause', {
+    value: cause,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+  return err;
+}
+
+/**
  * [#7929] The full, operand-naming text of a refusal whose caller-visible
  * message was redacted — carried on the Error under a SYMBOL key.
  *
@@ -4593,7 +4707,12 @@ export class SqlDriver implements IDataDriver {
         }
         if (!recovered) throw this.unresolvableFilterColumnRefusal(object, lastError);
       } else {
-        throw error;
+        // [#8931] The terminal catch-all — see
+        // {@link SqlDriver.backendStatementFault}. This is the `find` half of
+        // the exit `count` spells below; both halves must answer one condition
+        // one way, which is the invariant #8790 established on this path and
+        // this ruling extends to every condition the ladder does not recover.
+        throw this.backendStatementFault(object, error);
       }
     }
 
@@ -6383,6 +6502,69 @@ export class SqlDriver implements IDataDriver {
     return unresolvableFilterColumnError(object, column);
   }
 
+  /**
+   * [#8931, maintainer ruling 2026-08-17] The TERMINAL of both read halves:
+   * compose {@link backendStatementFaultError} for a dialect error nothing
+   * above classified, writing the dialect's own message to the SERVER LOG on
+   * the way.
+   *
+   * # What reaches here, measured on live PG 16.13 and on better-sqlite3
+   *
+   * Everything the read path can throw that is not an unresolvable WHERE column
+   * (which {@link SqlDriver.unresolvableFilterColumnRefusal} already answers)
+   * and not already ADR-0112-enveloped:
+   *
+   * | condition                | before                                   |
+   * |--------------------------|------------------------------------------|
+   * | table never provisioned  | `42P01` / `SQLITE_ERROR`, no `status`    |
+   * | a dotted WHERE key on pg | `42P01`, no `status` — **this card**     |
+   * | comparand-shape syntax   | `42601` / `SQLITE_ERROR`, no `status`    |
+   * | value/type rejection     | `22P02`, no `status`, **value inlined**  |
+   * | connection, timeout, ACL | the dialect's own error, no `status`     |
+   *
+   * All of them left the driver as the dialect's raw error object: a `code`
+   * from the backend's vocabulary, no `status`, and a message opening with the
+   * compiled statement. The last row is the one worth naming — Postgres puts
+   * the caller's rejected VALUE in its own `22P02` prose (`invalid input syntax
+   * for type integer: "…"`), which no statement-cut removes, and this envelope
+   * closes it as a consequence of withholding the dialect text wholesale.
+   *
+   * ⛔ Deliberately NOT here: the WRITE paths. `create`/`update`/`delete` faults
+   * are classified at the REST boundary FROM their message text — a unique
+   * violation becomes `409 UNIQUE_VIOLATION`, an unknown column `400
+   * INVALID_FIELD` — so composing a message over them would turn precise 4xx
+   * answers into a generic 500. Those routes have their own cards; this ruling
+   * is about the read exits, and the boundary is drawn here rather than left to
+   * be discovered.
+   *
+   * Returns the error rather than throwing it, the shape both siblings on this
+   * path use, so each call site spells its own `throw`.
+   */
+  protected backendStatementFault(object: string, error: unknown): Error {
+    // Never re-envelope something that already declares one. Nothing on
+    // today's read path can (the filter compiler's refusals are raised before
+    // the statement is executed, outside the `try`), but this method is the
+    // terminal of a subclassable driver — `driver-turso` and
+    // `driver-sqlite-wasm` both extend `SqlDriver` — and a double wrap would
+    // bury a precise refusal under a generic one. Asked over the DECLARED
+    // status, the same gate `packages/rest`'s `declaredHttpStatus` reads, and
+    // ⛔ not over any error CLASS: this is "is it already ours", not a second
+    // recognizer for a dialect condition.
+    const declared = (error as { status?: unknown } | null | undefined)?.status;
+    if (typeof declared === 'number') return error as Error;
+
+    const detail = (error as { message?: unknown } | null | undefined)?.message;
+    const code = (error as { code?: unknown } | null | undefined)?.code;
+    this.logger.warn(
+      `[sql-driver] DATABASE_ERROR — the backend refused a read on '${object}'` +
+        (typeof code === 'string' && code.length > 0 ? ` (${code})` : '') +
+        '. The dialect message below is kept server-side: it carries the compiled statement, ' +
+        'and on the dialects that inline them the bound literals too (#7929, #8931): ' +
+        `${typeof detail === 'string' ? detail : String(error)}`,
+    );
+    return backendStatementFaultError(object, error);
+  }
+
   async count(object: string, query?: DriverQuery, options?: DriverOptions): Promise<number> {
     const builder = this.getBuilder(object, options);
     this.applyTenantScope(builder, object, options);
@@ -6406,7 +6588,8 @@ export class SqlDriver implements IDataDriver {
       if (isUnresolvableColumnError(error)) {
         throw this.unresolvableFilterColumnRefusal(object, error);
       }
-      throw error;
+      // [#8931] The terminal catch-all — see {@link SqlDriver.backendStatementFault}.
+      throw this.backendStatementFault(object, error);
     }
     if (result && result.length > 0) {
       const row: any = result[0];

--- a/packages/runtime/src/metadata-list-ambient-vs-bare-transaction.integration.test.ts
+++ b/packages/runtime/src/metadata-list-ambient-vs-bare-transaction.integration.test.ts
@@ -224,8 +224,28 @@ describe('#7842 metadata list under an open transaction: ambient vs bare (real O
       expect((engine as any).txStore.getStore()).toBeUndefined();
 
       const started = Date.now();
-      await expect(loader.list('object')).rejects.toThrow(/Timeout acquiring a connection/i);
+      // [#8931, maintainer ruling 2026-08-17] This used to read
+      // `rejects.toThrow(/Timeout acquiring a connection/i)` — knex's own words,
+      // reaching the caller because `driver-sql`'s read exits let an
+      // unclassified dialect error out raw. They no longer do: every dialect
+      // error the driver cannot attribute now leaves as the generic
+      // backend-fault envelope (`DATABASE_ERROR` / 500), with the dialect's text
+      // kept to the server log and carried on `cause`.
+      //
+      // ⛔ The DISCRIMINATION this assertion exists for is not weakened, only
+      // re-homed. What it must still separate is "the read failed by waiting on
+      // the pool" from "the read failed for some other reason" — a distinction
+      // the elapsed-time bounds below cannot make on their own — so it is asked
+      // of the same string, at the place that string now lives.
+      const fault = await loader.list('object').then(
+        () => undefined,
+        (e: unknown) => e as { code?: string; status?: number; cause?: { message?: string } },
+      );
       const elapsed = Date.now() - started;
+      expect(fault, 'the bare-transaction read must fail, not quietly succeed').toBeDefined();
+      expect(fault?.code).toBe('DATABASE_ERROR');
+      expect(fault?.status).toBe(500);
+      expect(String(fault?.cause?.message)).toMatch(/Timeout acquiring a connection/i);
 
       // It failed by WAITING on the pool, not instantly for some other reason...
       expect(elapsed).toBeGreaterThanOrEqual(ACQUIRE_MS / 2);


### PR DESCRIPTION
Fixes #8931

Implements the maintainer ruling of 2026-08-17 (「同意 C」): **the driver stops answering an unenveloped dialect error at all.** Any dialect error the existing classification does not claim now leaves `driver-sql`'s read exits as a **generic backend-fault envelope** — `DATABASE_ERROR` / 500 — asserting only *"the backend rejected this statement"*.

All measurements below are from a **live PostgreSQL 16.13** provisioned in-container (same version as the card's evidence) plus better-sqlite3. No live MySQL was provisioned; its cells are declared un-run rather than skipped silently.

## The three fences, and how each is honoured

**1. No filter verdict.** The envelope is `DATABASE_ERROR`, never `INVALID_FILTER`, and it says nothing about the filter. Measured, and this is *why*:

```
dotted WHERE key    42P01  missing FROM-clause entry for table "title"   routine=errorMissingRTE
table not created   42P01  relation "no_such_object" does not exist      routine=parserOpenTable
```

Same SQLSTATE. `isMissingTableError` returns **true** for both (verified live, on the real predicate). An `INVALID_FILTER` here would tell an operator whose schema sync had not run that their *filter* was wrong.

**2. No new per-error-class predicate.** No predicate learns `42P01`. `isUnresolvableColumnError` and `isMissingTableError` are byte-untouched; the caller's key is still never inspected for a `.` (#8371 owns that verdict and it landed there). The envelope comes from the *exit*, not from recognising anything — the two call sites are the `else` of `findRows`' recovery ladder and the tail of `count`.

**3. No statement shape in the caller-visible message.** No table names, no quoted references, no `$n`. Asserted as a negative set plus a positive anchor on every dialect cell.

## What the catch-all now envelopes — the enumeration, measured

| condition | pg before | sqlite before | after |
|---|---|---|---|
| table never provisioned | `42P01`, no `status` | `SQLITE_ERROR`, no `status` | `DATABASE_ERROR` / 500 |
| a dotted WHERE key | `42P01`, no `status` | *(refused since #8790)* | `DATABASE_ERROR` / 500 |
| comparand-shape syntax fault | `42601`, no `status` | `SQLITE_ERROR`, no `status` | `DATABASE_ERROR` / 500 |
| value rejected by column type | `22P02`, no `status`, **value inlined** | *(coerced, no error)* | `DATABASE_ERROR` / 500 |
| connection / pool / timeout / ACL | the dialect's own, no `status` | same | `DATABASE_ERROR` / 500 |

Everything else on the read path is untouched: the #8790 `INVALID_FILTER` refusal still wins where it applies, and the #3821 projection / ORDER-BY recoveries still return rows.

⛔ **Write paths are deliberately NOT in scope.** `create`/`update`/`delete` faults are classified at the REST boundary *from their message text* — a unique violation becomes `409 UNIQUE_VIOLATION`, an unknown column `400 INVALID_FIELD` — so composing a message over them would turn precise 4xx answers into a generic 500. The boundary is drawn in the code comment rather than left to be discovered.

## A disclosure this closes that nobody had named

Postgres puts the caller's **rejected value** in its own `22P02` diagnostic, *downstream* of everything knex parameterised:

```
select * from "t" where "rank" = $1 - invalid input syntax for type integer: "zz-not-a-number"
```

No statement cut removes it — a redaction that keeps the diagnostic tail keeps the value with it. This is the measured reason the envelope **composes** its message instead of deriving one from the dialect's, and it is why `redactStatementFromMessage` is not called here (see "Deviations" below). #8931's headline premise — a bound literal inlined on the *dotted* route — was measured false and pinned by #9108; this is the neighbouring row where a value really does travel.

## The fork risk, and what prevents it

`isMissingTableError` is how **13 non-test call sites** across `metadata`, `objectql` and `metadata-protocol` tell "the table was never provisioned" — a benign emptiness — from a failure that must stay loud: `seedAutonumber` returns 0 rather than restarting a counter against a full table, `resolveFileReferences` fails open silently, the delete-dependents probe skips a relation. Wrapping without the original attached would have flipped all of them to their loud branch, which **is** a change to what the platform accepts, and expressly outside this ruling.

The wrapper keeps the dialect error as a **non-enumerable `cause`**. That predicate already follows `cause` four levels deep, with its own pins (`schema-sync-errors.test.ts`, *"follows an error wrapped as `cause`"*) — so the wrap is transparent to it, and the predicate itself is untouched. Verified live: `isMissingTableError(wrapped)` is `true` on both pg and sqlite, for both `find` and `count`. Non-enumerable so the statement cannot ride back out through `JSON.stringify(err)` or a spread.

## Downstream consequences, measured at the boundary

Run through the real `mapDataError` with the exact recorded driver errors:

| route | before | after |
|---|---|---|
| pg dotted key (**this card**) | `500` `DATABASE_ERROR` | `500` `DATABASE_ERROR` |
| pg `22P02` / `42601` | `500` `DATABASE_ERROR` | `500` `DATABASE_ERROR` |
| **read on a registered object whose table was never created** | **`404` `OBJECT_NOT_FOUND`** | **`500` `DATABASE_ERROR`** |

The card's own route comes out **unchanged on the wire** — `mapDataError` already derived `500` + `DATABASE_ERROR` for it by sniffing the message; what moves is that it is now *declared* by the producer that knows, per ADR-0112, so every non-REST consumer gets the same answer instead of pattern-matching a SQLSTATE that differs per backend.

The last row is a real change and is flagged for review rather than buried. It is a consequence of the ruled mechanism (the two 42P01s are indistinguishable without the predicate the ruling forbids). Note the body it replaces said `Object 'x' is not registered`, which was **false** in exactly that state — the object *is* registered, its table is not provisioned. No test pinned the end-to-end behaviour; the unknown-object heuristic suites feed synthetic strings straight to `mapDataError` and are unaffected.

One consumer test pinned the old raw escape and is updated in this PR: `runtime`'s #7842 ambient-vs-bare transaction integration test asserted `rejects.toThrow(/Timeout acquiring a connection/i)` — knex's own words reaching the caller. The discrimination it exists for is **not** weakened, only re-homed: it now asserts the envelope *and* reads the same string off `cause`.

## Verification

All at `fc3d82286`, tree clean, gate union re-run at that head.

- **Live PG 16.13** provisioned in-container (`initdb` + `pg_ctl`, port 54931, `timezone=Asia/Shanghai`, process `TZ=America/New_York` — the three-way zone skew the matrix's own non-vacuity guard demands), torn down afterwards.
- `pnpm --filter @objectstack/driver-sql test` with live PG: **103 files passed | 1 skipped, 1998 tests passed | 34 skipped** (the skips are the MySQL cells, declared un-run).
- `pnpm --filter @objectstack/driver-sql typecheck`: clean.
- **Downstream sweep** (dependents of driver-sql — the *prefix* direction, i.e. packages that consume it): `driver-turso` 1003, `driver-sqlite-wasm` 395, `rest` 2011, `runtime` 2464, `dogfood` 780, `service-analytics` 1722, `service-automation` 967, `service-datasource` 478, `service-messaging` 242, `cli` 1367, `plugin-security` 1279, `plugin-auth` 1261, `plugin-sharing` 617, `plugin-approvals` 496, `plugin-reports` 70, `trigger-record-change` 78 — all green.
- **Gates**, re-derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths, all **PASS**: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-cross-package-test-inputs`, `docs-audit/check-affected-docs`, plus the convention-triggered `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt`, `check:engine-double-contract`, `check:where-matcher`, and the implicated `check:nul-bytes`, `check:error-code-casing`, `check:error-status-conformance`, `check:driver-conformance`, `check:route-envelope`, `check:driver-memory-census`, `check:durability-log-level`.

**Reverse verification** — direction predicted before each run, all three as predicted:

| ablation | predicted | observed |
|---|---|---|
| revert `findRows`' catch-all to `throw error` | broad red, `count` half staying green | **19 failed / 53 passed**, including *"find() and count() answer an unclassified fault the SAME way"* |
| drop the `cause` | narrow red on the two cause pins only | **5 failed / 67 passed** |
| make the `cause` enumerable | red on the serialisation pins only | **2 failed / 70 passed** |

The `cause` ablation was also run against `runtime`'s consumer, which resolves `@objectstack/driver-sql` through `exports` to `dist/` with no vitest alias. **The first attempt was a stale-dist false green**; the leg was redone with `pnpm --filter @objectstack/driver-sql build` and `node scripts/ablation-dist-preflight.mjs … --absent` proving the mutation reached the artifact, after which it went red as predicted (`expected 'undefined' to match /Timeout acquiring a connection/i`). Source restored **and dist rebuilt**, with the preflight re-run in the present direction to prove the mutation is gone from the artifact.

## Deviations from the dispatch, stated rather than hidden

**`redactStatementFromMessage` is not called.** The ruling asked for it to be reused. Two measured reasons it cannot serve this envelope, both worth a reviewer's judgment:

1. **Layering.** It lives in `@objectstack/objectql`. `driver-sql` depends on `core`/`observability`/`spec`/`types` only, and no driver in this repo depends on the engine. Importing it would invert the layering; moving it is a cross-package refactor this card does not authorise.
2. **It would not satisfy the disclosure clause anyway.** It cuts at the last ` - ` and keeps the dialect's diagnostic tail. On the card's own route that tail is `missing FROM-clause entry for table "title"` — a physical table name in a quoted reference, which fence 3 forbids — and on the `22P02` route it is `invalid input syntax for type integer: "zz-not-a-number"`, i.e. it would ship the caller's value.

⛔ No second redaction vocabulary is minted: the caller-visible message is **composed**, so there is nothing to redact, and the server-log line is the dialect's text verbatim — the same shape `unresolvableFilterColumnRefusal` one method over already writes.

**No semantic-migration entry.** ADR-0087 D3 entries are structured TODOs for **metadata source files** (`replacement` is "the canonical replacement the author should move to"). Nothing authorable changes here and there is no source for a consumer to migrate, so there is no TODO to emit; `check:adr-0087-registration` passes and the changeset carries the `not-required` marker with that reasoning. Flagged in case a reviewer reads the #8790 precedent more widely.

**A retry hint is not expressible under the ruled shape.** A pool-acquisition timeout is transient and would ideally answer `503 SERVICE_UNAVAILABLE`; distinguishing it needs a per-error-class predicate, which fence 2 forbids. It answers `500 DATABASE_ERROR` like every other unattributable fault. Recorded as a known limitation of the one-envelope shape, not worked around.

_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_