### PR TITLE
fix(spec): correct mongo options describe string to state the real refusal boundary

### DIFF
--- a/.changeset/mongo-options-describe-boundary.md
+++ b/.changeset/mongo-options-describe-boundary.md
@@ -1,0 +1,20 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): correct `MongoConfigSchema.options`'s field description to state the actual refusal boundary — only `auth.password` is refused inline; `proxyPassword`, `tlsCertificateKeyFilePassword`, `key`, and `passphrase` are accepted, stored at rest in cleartext, and redacted only on read (#9254)
+
+The old string claimed "credential material is refused" for the whole `options`
+passthrough. That was true for exactly one nested path
+(`options.auth.password`, `MONGO_OPTIONS_CREDENTIAL_PATHS` / #9040) — four
+other honoured, credential-shaped keys were never refused, only redacted when
+a datasource is read back (`PASSTHROUGH_SECRET_PATHS` in
+`datasource-credential-redaction.ts`). This string renders verbatim into
+`content/docs/references/data/driver-mongo.mdx` and the Studio "Add
+Datasource" connection form's field help text, so an author configuring a
+proxy password or a TLS key passphrase was told it would be refused when it
+would actually be accepted and stored in cleartext.
+
+Describe-only: no schema shape or refusal-path change — every previously-valid
+`options` input still parses byte-identically. The corrected text agrees with
+the accurate statement #9124 landed in `content/docs/data-modeling/drivers.mdx`.

--- a/content/docs/references/data/driver-mongo.mdx
+++ b/content/docs/references/data/driver-mongo.mdx
@@ -48,7 +48,7 @@ MongoDB Connection Configuration
 | **username** | `string` | optional | Authentication user |
 | **password** | `never` | optional | Set through the connection form's secret field or `external.credentialsRef` — encrypted into `sys_secret`, never stored in `config` (#7990) |
 | **authSource** | `string` | optional | Authentication database |
-| **options** | `Record<string, any>` | optional | Extra MongoClient options (replicaSet, tls, timeouts, …; credential material is refused — bind secrets via the connection form / external.credentialsRef) |
+| **options** | `Record<string, any>` | optional | Extra MongoClient options (replicaSet, tls, timeouts, …). Only `auth.password` is refused inline — bind it via the connection form / external.credentialsRef. `proxyPassword`, `tlsCertificateKeyFilePassword`, `key`, and `passphrase` are accepted and stored at rest in cleartext; they're redacted only when the datasource is read back, not refused at write. |
 
 
 ---

--- a/packages/spec/src/data/driver/mongo.zod.ts
+++ b/packages/spec/src/data/driver/mongo.zod.ts
@@ -136,7 +136,7 @@ export const MongoConfigSchema = lazySchema(() => strictObject(
     placeholderFreeDeep(z.record(z.string(), z.unknown()), 'options'),
     'options',
   ).optional()
-    .describe('Extra MongoClient options (replicaSet, tls, timeouts, …; credential material is refused — bind secrets via the connection form / external.credentialsRef)'),
+    .describe('Extra MongoClient options (replicaSet, tls, timeouts, …). Only `auth.password` is refused inline — bind it via the connection form / external.credentialsRef. `proxyPassword`, `tlsCertificateKeyFilePassword`, `key`, and `passphrase` are accepted and stored at rest in cleartext; they\'re redacted only when the datasource is read back, not refused at write.'),
 })
   .describe('MongoDB Connection Configuration')
   .superRefine((cfg, ctx) => {


### PR DESCRIPTION
Fixes #9254

## What

`MongoConfigSchema.options`'s `.describe()` string in
`packages/spec/src/data/driver/mongo.zod.ts` claimed "credential material is
refused" for the entire passthrough. Measured on this tree: that refusal is
true for exactly one nested path — `options.auth.password`
(`MONGO_OPTIONS_CREDENTIAL_PATHS` in `driver/common.zod.ts`, #9040). Four
other honoured, credential-shaped `options.*` keys — `proxyPassword`,
`tlsCertificateKeyFilePassword`, `key`, `passphrase` — are accepted, stored at
rest in `sys_metadata` as cleartext, and redacted only on **read**
(`PASSTHROUGH_SECRET_PATHS` in `datasource-credential-redaction.ts`).

This string renders verbatim into `content/docs/references/data/driver-mongo.mdx`
and, via the JSON Schema projection, the Studio "Add Datasource" connection
form's field help text — so an author configuring an authenticated SOCKS5
proxy or a passphrase-protected TLS key was told the opposite of what the
platform actually does.

## Fix

Rewrote the describe string to name the real boundary, and regenerated
`content/docs/references/data/driver-mongo.mdx` via
`pnpm --filter @objectstack/spec check:generated --fix` (only `check:docs` was
stale; everything else was already current).

**Describe-only** — no schema shape or refusal-path change. Every
previously-valid `options` input still parses byte-identically; the
`superRefine` in `credentialFreeMongoOptions` is untouched.

New text agrees with the accurate statement #9124 already landed in
`content/docs/data-modeling/drivers.mdx`'s "Secret-shaped keys with no binder
slot" section (same four accepted-and-redacted keys, same posture).

## Note on a premise in the dispatch

One measured correction to the dispatch prompt's framing: `AWS_SESSION_TOKEN`
(`options.authMechanismProperties.AWS_SESSION_TOKEN`) is **not** in
`MONGO_OPTIONS_CREDENTIAL_PATHS` — it is *not* refused at publish by our
schema. `driver/common.zod.ts` documents it as deliberately absent from the
write-door refusal list (the mongodb client itself throws on it under the
`MONGODB-AWS` auth mechanism; under any other mechanism nothing reads it). It
*is* redacted on read, in the same `PASSTHROUGH_SECRET_PATHS` bucket as the
other four keys, but `content/docs/data-modeling/drivers.mdx`'s own table
doesn't list it either. I kept the new describe string's example list aligned
with that doc's four-key table rather than adding a fifth key neither the
code's own refusal-list comment nor the reference doc treats as "refused" —
happy to add it if a maintainer wants the describe string to be
fully-exhaustive rather than representative.

## Tests

- `pnpm --filter @objectstack/spec build` — clean
- `pnpm --filter @objectstack/spec check:generated` — all 13 generated
  artifacts green (was 1 stale — `check:docs` — before `--fix`)
- `pnpm --filter @objectstack/spec test` — 408 test files / 10872 tests passed
- `pnpm --filter @objectstack/spec typecheck` — clean (incl.
  `check:scripts-typecheck`, `check:test-typecheck`)
- Dispatch-named local gates, re-derived against the actual diff via
  `node scripts/pm/dispatch-gates.mjs`, all green: `check:cross-package-test-inputs`,
  `check:doc-formula-expressions`, `check:docs-audit-scope`,
  `check:docs-redirects`, `check:empty-state`, `check:liveness`,
  `check:merge-driver`, `check:quick-reference-counts`, `check:role-word`,
  `check:spec-parsed-alias`, `check:strictness-ledger`,
  `check:type-source-resolution`, `check:variant-docs`,
  `check:dev-prereqs --self-test` (matches CI's own self-test-only
  invocation), `check-affected-docs.mjs` (self-test-only by design, matches
  `docs-drift-check.yml`)
- `node scripts/check-nul-bytes.mjs` on both edited files — clean

Verified at `b4f4731de` (the tip of this branch, matches the commit these
gates ran against).

## Not a duplicate

No open PR touches `mongo.zod.ts` or `driver-mongo.mdx` at claim time (per
triage comment on #9254); this diff is disjoint from #9269's
`error-code-ledger.zod.ts` / `references/api/**` surface.

---

**Per the dispatch: left as draft, not flipped ready** — below-floor
text-face dispatch, held for the PM's contract-review label step per
established procedure.

_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_