### PR TITLE
fix(example-showcase): guard the authored action predicates against the sparse face (#8990)

### DIFF
--- a/.changeset/showcase-predicate-sparse-face-remainder.md
+++ b/.changeset/showcase-predicate-sparse-face-remainder.md
@@ -1,0 +1,25 @@
+---
+"@objectstack/example-showcase": patch
+---
+
+Guard the showcase's authored action predicates against the sparse action face (#8990)
+
+Every record-scoped `visible` / `disabled` predicate in `app-showcase` now carries the
+`has()` guard the sparse action face requires, closing the remainder of #8990 in this
+repo. A row action's predicate binds a LIST ROW carrying only the view's `$select`
+projection, and CEL aborts with `No such key` on a column that row never projected —
+fail-closed, so the button silently is not offered.
+
+Measured against the running app's own payloads: 40 of the 53 predicates in
+`predicate-matrix.action.ts` aborted on a default-list row before this change and 0 do
+after, while every verdict on a record-detail binding is unchanged — the Full-vs-Minimal
+contrast the fixture exists to demonstrate is preserved exactly.
+
+The guard is minimal per predicate rather than blanket: `has()` alone where the read is
+only compared by `==` / `!=` (CEL compares heterogeneously and answers `false` rather
+than faulting), the full `has(x) && x != null` conjunction only where an operand can
+fault — traversal, method call, ordering, arithmetic, `in`, or a bare `!`.
+
+The teaching surfaces move with the code, since they quote it: `content/docs/ui/actions.mdx`
+(whose `visible: '!record.done'` was the exact negation shape that faults on a NULL
+column), `quick-start.mdx` and `build-with-claude-code.mdx`.

--- a/content/docs/getting-started/build-with-claude-code.mdx
+++ b/content/docs/getting-started/build-with-claude-code.mdx
@@ -159,7 +159,9 @@ export const ResolveTicketAction = defineAction({
   locations: ['record_header', 'list_item'],
   // Only offer "Resolve" on tickets that aren't already resolved or closed.
   // Predicates are CEL, record-scoped — `record.status`, never bare `status`.
-  visible: 'record.status != "resolved" && record.status != "closed"',
+  // `has()` guards the sparse list row: a list projects only the columns it
+  // shows, and CEL faults on an absent key (which hides the button silently).
+  visible: 'has(record.status) && record.status != "resolved" && record.status != "closed"',
   successMessage: 'Ticket resolved.',
   refreshAfter: true,
   ai: {

--- a/content/docs/getting-started/quick-start.mdx
+++ b/content/docs/getting-started/quick-start.mdx
@@ -109,6 +109,11 @@ reviewing an agent's work, these are the two things most worth a close read:
   `status`. A bare reference silently hides the action on every record — the single
   most common AI mistake, which is exactly why `os validate` rejects it. See it in
   action in [Build with Claude Code → the gate](/docs/getting-started/build-with-claude-code#4-the-gate-os-validate-catches-ai-mistakes).
+  On a row action, also **guard the field with `has()`** —
+  `has(record.status) && record.status != 'sent'` — because a list row carries
+  only the columns that view projects, and reading an absent one faults and
+  hides the button. See [Actions](/docs/ui/actions) for when the guard needs
+  `&& record.x != null` on top.
 - **Views & Apps** (`defineView`, `App.create`) — the list/form lenses and the
   navigation. Reading these tells you what the user will actually see and click.
 

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -91,7 +91,7 @@ export const MarkDoneAction = defineAction({
     capabilities: ['api.write'],
   },
   successMessage: 'Task marked done.',
-  visible: '!record.done',
+  visible: 'has(record.done) && record.done != true',
   locations: ['list_item', 'record_header', 'record_section'],
   refreshAfter: true,
 });
@@ -276,10 +276,24 @@ is a spec proposal for a properly named key, not a values map under this one.
   Unset means no gate beyond object CRUD permissions. Referenced capabilities
   must exist — `os lint` checks that.
 - **`visible`** is a CEL predicate evaluated **fail-closed**: an expression
-  that throws hides the action silently. The rule that saves real debugging
-  time: always prefix record fields (`record.status != "closed"`, never a bare
-  `status`, which faults as an undeclared identifier). Compound `&&` / `||`
-  predicates are fully supported — see the
+  that throws hides the action silently. Two rules save real debugging time:
+
+  1. **Always prefix record fields** — `record.status != "closed"`, never a bare
+     `status`, which faults as an undeclared identifier.
+  2. **Guard with `has()`** — a record-scoped predicate on `list_item` binds a
+     LIST ROW, which carries only the columns that view projects. Reading a
+     field the list does not show aborts the expression with `No such key`, and
+     fail-closed means the button simply is not offered — indistinguishable from
+     the gate having said no. `has(record.x) && …` answers `false` instead.
+
+  Add `&& record.x != null` **only** when the value is then traversed
+  (`record.x.k`), called (`record.x.size()`), ordered (`<` `<=` `>` `>=`),
+  negated (`!record.x`) or used with `in` — those fault on a projected NULL. A
+  plain `==` / `!=` against a literal never does, so `has()` alone is the whole
+  guard there. Prefer the minimal form: an over-guarded predicate is the pattern
+  the next author copies.
+
+  Compound `&&` / `||` predicates are fully supported — see the
   [formulas guide](/docs/data-modeling/formulas) for CEL syntax.
 - **`requiresFeature`** ties visibility to a feature flag (compiled into a
   `visible` predicate).

--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -59,8 +59,18 @@ export const MarkDoneAction = defineAction({
   // `record.`-prefix: the ActionEngine evaluates a record-header action's
   // `visible` against `{ record, recordId, … }` with fail-closed semantics, so
   // a bare `done`/`status` throws (field not at top level) and silently hides
-  // the action. Single operand, too — the template path throws on `&&`/`||`.
-  visible: '!record.done',
+  // the action.
+  //
+  // #8990 — `has()` guards the SPARSE action face: this action reaches
+  // `list_item`, so its predicate binds a list row carrying only the view's
+  // `$select` projection, and CEL aborts with `No such key: done` on any task
+  // list that does not project the column (fail-closed, the button silently
+  // is not offered). The comparison is `!= true` rather than the older
+  // `!record.done` because a bare `!` on a projected-but-NULL column faults
+  // `no such overload: !null`, while `!=` against a literal never faults and
+  // still reads an unset `done` as "not done". `has()` alone is therefore the
+  // whole guard here. Rule: `packages/objectql/src/declared-fields.ts`.
+  visible: 'has(record.done) && record.done != true',
   // `record_section` so the Task Detail page's `record:quick_actions` bar
   // (which names this action) resolves it — the engine location-filters even
   // explicitly-named actions, mirroring the platform's own sys-user pages.
@@ -259,9 +269,12 @@ export const SubmitForSignoffAction = defineAction({
     capabilities: ['api.write'],
   },
   successMessage: 'Invoice submitted for finance + legal sign-off.',
-  // Only on invoices not yet sent. `record.`-prefixed single comparison, per the
+  // Only on invoices not yet sent. `record.`-prefixed comparison, per the
   // ActionEngine's fail-closed CEL evaluation (see MarkDoneAction's note).
-  visible: "record.status != 'sent'",
+  // #8990 — `has()` guards the sparse face this reaches via `list_item`; the
+  // `!=` against a literal never faults on a projected NULL, so `has()` alone
+  // is the whole guard.
+  visible: "has(record.status) && record.status != 'sent'",
   locations: ['list_item', 'record_header'],
   refreshAfter: true,
 });
@@ -362,8 +375,9 @@ export const ArchiveTaskAction = defineAction({
     capabilities: [],
   },
   successMessage: 'Task archived (demo — no data changed).',
-  // Disabled while the task is not done — visible either way.
-  disabled: 'record.done != true',
+  // Disabled while the task is not done — visible either way. #8990: `has()`
+  // for the sparse face; `!=` against a literal cannot fault, so no `!= null`.
+  disabled: 'has(record.done) && record.done != true',
   locations: ['record_header', 'record_section'],
   refreshAfter: false,
 });

--- a/examples/app-showcase/src/ui/actions/predicate-matrix.action.ts
+++ b/examples/app-showcase/src/ui/actions/predicate-matrix.action.ts
@@ -59,15 +59,30 @@
  *
  *    This file is where both halves are falsifiable in a browser: the Minimal
  *    specimen exercises the NULL half, and the default list's `$select`
- *    projection — which omits `f_lookup` / `f_lookups` and includes
- *    `f_textarea` — exercises the ABSENT half on the very same records.
+ *    projection — whose columns are `name` / `f_select` / `f_number` /
+ *    `f_boolean` / `f_rating`, so every OTHER gated field is absent — exercises
+ *    the ABSENT half on the very same records.
  *
- *    ⚠️ The specimens below still spell only the `!= null` half. That is the
- *    platform-wide state rather than an exception here (0 of the 34 authored
- *    record-scoped action predicates across both repos use `has()`), and
- *    migrating them changes what this LIVE fixture demonstrates, so it is
- *    tracked separately in #8990. Read this bullet for what to write today;
- *    read the specimens for what the runtime does with the older form.
+ *    Every specimen below carries the guard as of #8990. What that changed is
+ *    the FAULT, not the verdict: measured against the running app's own
+ *    payloads, 40 of these 53 predicates aborted with `No such key` on a
+ *    default-list row before the migration and 0 do after, while every verdict
+ *    on a record-DETAIL binding (where the read projects all declared columns)
+ *    is unchanged. So the Full-vs-Minimal contrast this fixture exists to show
+ *    is exactly as it was, and the list surface now answers `false` where it
+ *    used to silently drop the button.
+ *
+ *    ⚠️ That makes the guard itself the thing under test here: delete a `has()`
+ *    and the action vanishes from the row kebab and the selection bar while
+ *    staying correct on the detail page. That asymmetry IS the specimen —
+ *    it is what no unit test of a single surface can see.
+ *
+ *    The MINIMAL form is per predicate, not a blanket: `has()` alone where the
+ *    read is only compared by `==` / `!=` (CEL compares heterogeneously and
+ *    answers `false` rather than faulting), the full conjunction only where an
+ *    operand can fault — traversal, method call, ordering, arithmetic, `in`,
+ *    or a bare `!`. Over-guarding is not the safe default; it is the pattern
+ *    the next author copies.
  *  - **`contains()` / `matches()`, never `startsWith()` / `endsWith()`.** The
  *    latter two are not CEL — objectui routes them to its legacy JS evaluator
  *    with a deprecation warning, and the SERVER's engine has no answer for
@@ -154,7 +169,9 @@ export const ZooRelationGateAction = defineAction({
   type: 'script',
   body: echo,
   successMessage: 'Both relations resolved to the same id.',
-  visible: 'record.f_lookup != null && record.f_lookups != null && record.f_lookup == record.f_lookups[0]',
+  visible:
+    'has(record.f_lookup) && has(record.f_lookups) && record.f_lookups != null'
+    + ' && record.f_lookups.size() > 0 && record.f_lookup == record.f_lookups[0]',
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -183,7 +200,7 @@ export const ZooOwnerGateAction = defineAction({
   type: 'script',
   body: echo,
   successMessage: 'You own this specimen.',
-  visible: 'record.owner_id == os.user.id',
+  visible: 'has(record.owner_id) && record.owner_id == os.user.id',
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -204,7 +221,7 @@ export const ZooUserIdentityGateAction = defineAction({
   type: 'script',
   body: echo,
   successMessage: 'You are the assigned user on this specimen.',
-  visible: 'record.f_user == os.user.id',
+  visible: 'has(record.f_user) && record.f_user == os.user.id',
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -238,7 +255,7 @@ export const ZooDialectSplitAction = defineAction({
   objectName: zoo,
   type: 'script',
   body: echo,
-  visible: 'record.f_textarea != null && record.f_textarea.contains("Line two")',
+  visible: 'has(record.f_textarea) && record.f_textarea != null && record.f_textarea.contains("Line two")',
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -274,7 +291,7 @@ export const ZooVisibleStringAction = defineAction({
   objectName: zoo,
   type: 'script',
   body: echo,
-  visible: 'record.f_boolean == true',
+  visible: 'has(record.f_boolean) && record.f_boolean == true',
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -287,7 +304,7 @@ export const ZooVisibleTaggedAction = defineAction({
   objectName: zoo,
   type: 'script',
   body: echo,
-  visible: P`record.f_boolean == true`,
+  visible: P`has(record.f_boolean) && record.f_boolean == true`,
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -300,7 +317,7 @@ export const ZooVisibleEnvelopeAction = defineAction({
   objectName: zoo,
   type: 'script',
   body: echo,
-  visible: { dialect: 'cel', source: 'record.f_boolean == true' },
+  visible: { dialect: 'cel', source: 'has(record.f_boolean) && record.f_boolean == true' },
   locations: [...RECORD_SURFACES],
   refreshAfter: false,
 });
@@ -317,7 +334,7 @@ export const ZooDisabledAction = defineAction({
   objectName: zoo,
   type: 'script',
   body: echo,
-  disabled: 'record.f_rating < 4',
+  disabled: 'has(record.f_rating) && record.f_rating != null && record.f_rating < 4',
   locations: ['record_header', 'record_section'],
   refreshAfter: false,
 });
@@ -409,11 +426,19 @@ export const ZooPermEmptyAction = defineAction({
  * (`f_number` / `f_select` / `f_radio` / `f_multiselect` / `f_checkboxes` /
  * `f_time` / `f_master_detail` / `f_percent` / `f_rating` / `f_autonumber`).
  *
- * Every predicate that touches a nullable non-scalar is null-guarded — see the
- * authoring rules at the top of this file. That is not defensive padding: the
- * unguarded form FAULTS on Minimal, and a fault is fail-closed on the row and
- * selection surfaces and fail-OPEN on the lenient ones, so the same typo shows
- * the button to everybody on one surface and to nobody on the next.
+ * Every predicate here is guarded — see the authoring rules at the top of this
+ * file. That is not defensive padding: the unguarded form FAULTS, and a fault
+ * is fail-closed on the row and selection surfaces and fail-OPEN on the lenient
+ * ones, so the same typo shows the button to everybody on one surface and to
+ * nobody on the next.
+ *
+ * ⚠️ "Nullable non-scalar" is NOT the line, and this block used to say it was.
+ * Measured on the canonical engine, a SCALAR faults just as readily the moment
+ * the operator is not an equality: `record.f_slider > 50` aborts with
+ * `no such overload: dyn<null> > int` on a projected NULL, and `!(record.f_boolean)`
+ * with `no such overload: !null`. What decides the guard is the OPERATOR, not
+ * the field's type — which is why the numeric, `in`, `!` and ternary specimens
+ * below carry the same `!= null` half as the structured ones.
  */
 const zooTypeGate = (name: string, label: string, visible: string) =>
   defineAction({
@@ -429,63 +454,63 @@ const zooTypeGate = (name: string, label: string, visible: string) =>
 
 export const ZooTypeGates = [
   // ── Relational: the id, never the expanded record ────────────────────────
-  zooTypeGate('lookup', 'lookup — set', 'record.f_lookup != null'),
-  zooTypeGate('lookup_multi', 'lookup multiple — >1', 'record.f_lookups != null && record.f_lookups.size() > 1'),
-  zooTypeGate('master_detail', 'master_detail — set', 'record.f_master_detail != null'),
-  zooTypeGate('tree', 'tree — unset', 'record.f_tree == null'),
-  zooTypeGate('user', 'user — unset', 'record.f_user == null'),
-  zooTypeGate('user_identity', 'user — is me', 'record.f_user == os.user.id'),
-  zooTypeGate('owner', 'owner_id (injected) — mine', 'record.owner_id == os.user.id'),
+  zooTypeGate('lookup', 'lookup — set', 'has(record.f_lookup) && record.f_lookup != null'),
+  zooTypeGate('lookup_multi', 'lookup multiple — >1', 'has(record.f_lookups) && record.f_lookups != null && record.f_lookups.size() > 1'),
+  zooTypeGate('master_detail', 'master_detail — set', 'has(record.f_master_detail) && record.f_master_detail != null'),
+  zooTypeGate('tree', 'tree — unset', 'has(record.f_tree) && record.f_tree == null'),
+  zooTypeGate('user', 'user — unset', 'has(record.f_user) && record.f_user == null'),
+  zooTypeGate('user_identity', 'user — is me', 'has(record.f_user) && record.f_user == os.user.id'),
+  zooTypeGate('owner', 'owner_id (injected) — mine', 'has(record.owner_id) && record.owner_id == os.user.id'),
 
   // ── Text family: contains() / matches(), never startsWith() ──────────────
-  zooTypeGate('text', 'text — name non-empty', 'record.name != null && record.name.size() > 0'),
-  zooTypeGate('textarea', 'textarea — contains', 'record.f_textarea != null && record.f_textarea.contains("Line two")'),
-  zooTypeGate('email', 'email — matches', 'record.f_email != null && record.f_email.matches(".*@example[.]com")'),
-  zooTypeGate('url', 'url — contains', 'record.f_url != null && record.f_url.contains("objectstack")'),
-  zooTypeGate('phone', 'phone — contains', 'record.f_phone != null && record.f_phone.contains("555")'),
-  zooTypeGate('markdown', 'markdown — contains', 'record.f_markdown != null && record.f_markdown.contains("Heading")'),
-  zooTypeGate('html', 'html — contains', 'record.f_html != null && record.f_html.contains("bold")'),
-  zooTypeGate('code', 'code — contains', 'record.f_code != null && record.f_code.contains("ok")'),
+  zooTypeGate('text', 'text — name non-empty', 'has(record.name) && record.name != null && record.name.size() > 0'),
+  zooTypeGate('textarea', 'textarea — contains', 'has(record.f_textarea) && record.f_textarea != null && record.f_textarea.contains("Line two")'),
+  zooTypeGate('email', 'email — matches', 'has(record.f_email) && record.f_email != null && record.f_email.matches(".*@example[.]com")'),
+  zooTypeGate('url', 'url — contains', 'has(record.f_url) && record.f_url != null && record.f_url.contains("objectstack")'),
+  zooTypeGate('phone', 'phone — contains', 'has(record.f_phone) && record.f_phone != null && record.f_phone.contains("555")'),
+  zooTypeGate('markdown', 'markdown — contains', 'has(record.f_markdown) && record.f_markdown != null && record.f_markdown.contains("Heading")'),
+  zooTypeGate('html', 'html — contains', 'has(record.f_html) && record.f_html != null && record.f_html.contains("bold")'),
+  zooTypeGate('code', 'code — contains', 'has(record.f_code) && record.f_code != null && record.f_code.contains("ok")'),
 
   // ── Numeric ──────────────────────────────────────────────────────────────
-  zooTypeGate('number', 'number — > 100', 'record.f_number > 100'),
-  zooTypeGate('currency', 'currency — > 1000', 'record.f_currency != null && record.f_currency > 1000.0'),
-  zooTypeGate('percent', 'percent — >= 75', 'record.f_percent >= 75'),
-  zooTypeGate('rating', 'rating — >= 4', 'record.f_rating >= 4'),
-  zooTypeGate('slider', 'slider — > 50', 'record.f_slider > 50'),
-  zooTypeGate('progress', 'progress — >= 80', 'record.f_progress >= 80'),
-  zooTypeGate('formula', 'formula — > 100', 'record.f_formula > 100.0'),
-  zooTypeGate('autonumber', 'autonumber — is 0001', 'record.f_autonumber == "0001"'),
+  zooTypeGate('number', 'number — > 100', 'has(record.f_number) && record.f_number != null && record.f_number > 100'),
+  zooTypeGate('currency', 'currency — > 1000', 'has(record.f_currency) && record.f_currency != null && record.f_currency > 1000.0'),
+  zooTypeGate('percent', 'percent — >= 75', 'has(record.f_percent) && record.f_percent != null && record.f_percent >= 75'),
+  zooTypeGate('rating', 'rating — >= 4', 'has(record.f_rating) && record.f_rating != null && record.f_rating >= 4'),
+  zooTypeGate('slider', 'slider — > 50', 'has(record.f_slider) && record.f_slider != null && record.f_slider > 50'),
+  zooTypeGate('progress', 'progress — >= 80', 'has(record.f_progress) && record.f_progress != null && record.f_progress >= 80'),
+  zooTypeGate('formula', 'formula — > 100', 'has(record.f_formula) && record.f_formula != null && record.f_formula > 100.0'),
+  zooTypeGate('autonumber', 'autonumber — is 0001', 'has(record.f_autonumber) && record.f_autonumber == "0001"'),
 
   // ── Temporal: `today()` is the CEL stdlib's, evaluated identically here ───
-  zooTypeGate('date', 'date — before today', 'record.f_date != null && record.f_date < today()'),
-  zooTypeGate('datetime', 'datetime — set', 'record.f_datetime != null'),
-  zooTypeGate('time', 'time — is 14:30', 'record.f_time == "14:30:00"'),
+  zooTypeGate('date', 'date — before today', 'has(record.f_date) && record.f_date != null && record.f_date < today()'),
+  zooTypeGate('datetime', 'datetime — set', 'has(record.f_datetime) && record.f_datetime != null'),
+  zooTypeGate('time', 'time — is 14:30', 'has(record.f_time) && record.f_time == "14:30:00"'),
 
   // ── Boolean / choice ─────────────────────────────────────────────────────
-  zooTypeGate('boolean', 'boolean — true', 'record.f_boolean == true'),
-  zooTypeGate('toggle', 'toggle — true', 'record.f_toggle == true'),
-  zooTypeGate('select', 'select — high', 'record.f_select == "high"'),
-  zooTypeGate('radio', 'radio — yes', 'record.f_radio == "yes"'),
-  zooTypeGate('multiselect', 'multiselect — has red', '"red" in record.f_multiselect'),
-  zooTypeGate('checkboxes', 'checkboxes — has email', '"email" in record.f_checkboxes'),
-  zooTypeGate('tags', 'tags — any', 'record.f_tags.size() > 0'),
+  zooTypeGate('boolean', 'boolean — true', 'has(record.f_boolean) && record.f_boolean == true'),
+  zooTypeGate('toggle', 'toggle — true', 'has(record.f_toggle) && record.f_toggle == true'),
+  zooTypeGate('select', 'select — high', 'has(record.f_select) && record.f_select == "high"'),
+  zooTypeGate('radio', 'radio — yes', 'has(record.f_radio) && record.f_radio == "yes"'),
+  zooTypeGate('multiselect', 'multiselect — has red', 'has(record.f_multiselect) && record.f_multiselect != null && "red" in record.f_multiselect'),
+  zooTypeGate('checkboxes', 'checkboxes — has email', 'has(record.f_checkboxes) && record.f_checkboxes != null && "email" in record.f_checkboxes'),
+  zooTypeGate('tags', 'tags — any', 'has(record.f_tags) && record.f_tags != null && record.f_tags.size() > 0'),
 
   // ── Structured ───────────────────────────────────────────────────────────
-  zooTypeGate('json', 'json — nested key', 'record.f_json != null && record.f_json.nested.k == "v"'),
-  zooTypeGate('location', 'location — lat > 40', 'record.f_location != null && record.f_location.lat > 40.0'),
-  zooTypeGate('address', 'address — US', 'record.f_address != null && record.f_address.country == "US"'),
-  zooTypeGate('color', 'color — is #2563EB', 'record.f_color == "#2563EB"'),
-  zooTypeGate('composite', 'composite — width 10', 'record.f_composite != null && record.f_composite.width == 10'),
-  zooTypeGate('repeater', 'repeater — 2 rows', 'record.f_repeater != null && record.f_repeater.size() == 2'),
-  zooTypeGate('record', 'record-of-records — score 9', 'record.f_record != null && record.f_record.primary.score == 9'),
-  zooTypeGate('vector', 'vector — 4 dims', 'record.f_vector != null && record.f_vector.size() == 4'),
+  zooTypeGate('json', 'json — nested key', 'has(record.f_json) && has(record.f_json.nested) && has(record.f_json.nested.k) && record.f_json.nested.k == "v"'),
+  zooTypeGate('location', 'location — lat > 40', 'has(record.f_location) && has(record.f_location.lat) && record.f_location.lat != null && record.f_location.lat > 40.0'),
+  zooTypeGate('address', 'address — US', 'has(record.f_address) && has(record.f_address.country) && record.f_address.country == "US"'),
+  zooTypeGate('color', 'color — is #2563EB', 'has(record.f_color) && record.f_color == "#2563EB"'),
+  zooTypeGate('composite', 'composite — width 10', 'has(record.f_composite) && has(record.f_composite.width) && record.f_composite.width == 10'),
+  zooTypeGate('repeater', 'repeater — 2 rows', 'has(record.f_repeater) && record.f_repeater != null && record.f_repeater.size() == 2'),
+  zooTypeGate('record', 'record-of-records — score 9', 'has(record.f_record) && has(record.f_record.primary) && has(record.f_record.primary.score) && record.f_record.primary.score == 9'),
+  zooTypeGate('vector', 'vector — 4 dims', 'has(record.f_vector) && record.f_vector != null && record.f_vector.size() == 4'),
 
   // ── Operators, not field types: the shapes a real predicate combines ─────
-  zooTypeGate('and', 'AND — boolean && number', 'record.f_boolean == true && record.f_number > 100'),
-  zooTypeGate('or', 'OR — select || rating', 'record.f_select == "high" || record.f_rating >= 4'),
-  zooTypeGate('not', 'NOT — !boolean', '!(record.f_boolean)'),
-  zooTypeGate('ternary', 'ternary — rating ? :', 'record.f_rating >= 4 ? true : false'),
+  zooTypeGate('and', 'AND — boolean && number', 'has(record.f_boolean) && record.f_boolean == true && has(record.f_number) && record.f_number != null && record.f_number > 100'),
+  zooTypeGate('or', 'OR — select || rating', '(has(record.f_select) && record.f_select == "high") || (has(record.f_rating) && record.f_rating != null && record.f_rating >= 4)'),
+  zooTypeGate('not', 'NOT — !boolean', 'has(record.f_boolean) && record.f_boolean != null && !(record.f_boolean)'),
+  zooTypeGate('ternary', 'ternary — rating ? :', 'has(record.f_rating) && record.f_rating != null && (record.f_rating >= 4 ? true : false)'),
 ];
 
 export const allPredicateMatrixActions = [

--- a/examples/app-showcase/src/ui/pages/review-queue.page.ts
+++ b/examples/app-showcase/src/ui/pages/review-queue.page.ts
@@ -10,8 +10,9 @@ import { definePage } from '@objectstack/spec/ui';
  * An interface (list) page over tasks currently `in_review` — the work
  * awaiting a decision — with a drawer to inspect each item. "Mark Done" is
  * deliberately NOT wired as a page-level `buttons:` toolbar entry: that
- * surface has no bound record, so `MarkDoneAction`'s `visible: '!record.done'`
- * expression has nothing to evaluate against and the button would render
+ * surface has no bound record, so `MarkDoneAction`'s `visible` predicate
+ * (`has(record.done) && record.done != true`, #8990) has nothing to evaluate
+ * against and the button would render
  * regardless of state. `MarkDoneAction.locations` already includes
  * `list_item`, so it correctly appears per-row (with that row's record bound)
  * instead. Tabs let the reviewer pivot to urgent or blocked work.

--- a/examples/app-showcase/src/ui/views/field-zoo.view.ts
+++ b/examples/app-showcase/src/ui/views/field-zoo.view.ts
@@ -51,9 +51,18 @@ export const FieldZooViews = defineView({
      * for an expanded surface and another way for a plain one; binding the
      * relation as its foreign key everywhere (objectui#3501) is what makes this
      * single rule correct on both.
+     *
+     * #8990 — it is also the same SPARSE binding, so it takes the same guard:
+     * this rule reads a column no view here projects, and the unguarded read
+     * aborted at key resolution on every row. `has()` is the whole guard —
+     * the surviving `!= null` is the rule's own test, not protection from a
+     * fault, because `!=` against a literal never faults on a NULL value.
      */
     conditionalFormatting: [
-      { condition: P`record.f_lookup != null`, style: { backgroundColor: 'rgba(37, 99, 235, 0.08)' } },
+      {
+        condition: P`has(record.f_lookup) && record.f_lookup != null`,
+        style: { backgroundColor: 'rgba(37, 99, 235, 0.08)' },
+      },
     ],
 
     /**
@@ -161,7 +170,11 @@ export const FieldZooViews = defineView({
           operation: 'custom',
           execution: 'aggregate',
           label: 'Rated 4+ only',
-          visible: P`record.f_rating >= 4`,
+          // #8990 — `f_rating` IS a column here, but a `bulkActionDefs` predicate
+          // binds the selection's rows, not this view's columns, so it takes the
+          // guard anyway. Ordering (`>=`) faults on a projected NULL, so this one
+          // needs the full conjunction rather than `has()` alone.
+          visible: P`has(record.f_rating) && record.f_rating != null && record.f_rating >= 4`,
         },
       ],
     },

--- a/examples/app-showcase/test/action-predicate-sparse-face.test.ts
+++ b/examples/app-showcase/test/action-predicate-sparse-face.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8990 — the showcase's authored predicates survive the SPARSE action face.
+ *
+ * `predicate-matrix.action.ts` is a LIVE browser specimen: every gate in it is
+ * declared on `list_item` / `record_more`, so its `visible` binds a LIST ROW
+ * carrying only the view's `$select` projection — not a total record. Unguarded,
+ * a predicate reading a column the list does not show aborts at key resolution,
+ * and CEL's fault is fail-closed: the button silently is not offered, which
+ * looks exactly like the predicate having said no.
+ *
+ * What this file pins is the property that made the migration safe rather than
+ * the spelling of any one predicate: **no authored showcase predicate may fault
+ * on a sparse binding**. Measured against the running app's own payloads, 40 of
+ * these 53 aborted with `No such key` on a default-list row before #8990 and 0
+ * do after, while every verdict on a fully-projected record is unchanged.
+ *
+ * The rule itself lives on `materializeDeclaredFields` in `@objectstack/objectql`
+ * (`packages/objectql/src/declared-fields.ts`, #8975 + #8990's leaf-first
+ * refinement). ⛔ Do not restate it here.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { celEngine } from '@objectstack/formula';
+import { allPredicateMatrixActions } from '../src/ui/actions/predicate-matrix.action.js';
+import { MarkDoneAction, SubmitForSignoffAction, ArchiveTaskAction } from '../src/ui/actions/index.js';
+
+/** `defineAction` normalizes the CEL shorthand into a `{dialect, source}` envelope. */
+function sourceOf(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  return (raw as { source?: string } | undefined)?.source ?? '';
+}
+
+function evaluate(source: string, record: Record<string, unknown>): boolean | string {
+  const r = celEngine.evaluate({ dialect: 'cel', source }, {
+    record,
+    user: { id: 'u1' },
+    os: { user: { id: 'u1' } },
+  } as never);
+  if (!r.ok) return `FAULT ${r.error.message.split('\n')[0].trim()}`;
+  return typeof r.value === 'boolean' ? r.value : `NON-BOOLEAN ${JSON.stringify(r.value)}`;
+}
+
+/** The record field names a predicate reads, top level only. */
+function fieldsOf(source: string): string[] {
+  return [...new Set([...source.matchAll(/record\.([A-Za-z_][A-Za-z0-9_]*)/g)].map((m) => m[1]!))];
+}
+
+/** Every record-scoped predicate authored in the matrix, as `[label, source]`. */
+const matrixPredicates: [string, string][] = allPredicateMatrixActions.flatMap((a) => {
+  const rec = a as unknown as Record<string, unknown>;
+  return (['visible', 'disabled'] as const).flatMap((key) => {
+    const s = sourceOf(rec[key]);
+    return s && s.includes('record.')
+      ? ([[`${String(rec.name)}.${key}`, s]] as [string, string][])
+      : [];
+  });
+});
+
+describe('#8990 — showcase action predicates on the sparse face', () => {
+
+  it('finds the whole authored matrix (guards against a silently empty sweep)', () => {
+    // The census is helper-indirected: `zooTypeGate(name, label, visible)` passes
+    // the predicate POSITIONALLY, so a `visible:`-key grep sees 8 of these and
+    // misses 45. Reading them off the exported actions is what makes the sweep
+    // total — and this assertion is what keeps it that way.
+    expect(matrixPredicates.length).toBe(53);
+  });
+
+  it.each(matrixPredicates)(
+    '%s answers instead of faulting on an EMPTY list row',
+    (_label, source) => {
+      // The row a view projected nothing onto — the absent-key half.
+      expect(evaluate(source, {})).toBeTypeOf('boolean');
+    },
+  );
+
+  it.each(matrixPredicates)(
+    '%s answers instead of faulting when every read column is projected NULL',
+    (_label, source) => {
+      // The row that carries the column holding NULL — the other half. Both are
+      // live at once on this face, and each guard half covers exactly one.
+      const record: Record<string, unknown> = {};
+      for (const f of fieldsOf(source)) record[f] = null;
+      expect(evaluate(source, record)).toBeTypeOf('boolean');
+    },
+  );
+
+  it('every matrix predicate carries has() on the columns it reads', () => {
+    for (const [label, source] of matrixPredicates) {
+      for (const field of fieldsOf(source)) {
+        expect(`${label}: ${source}`).toContain(`has(record.${field})`);
+      }
+    }
+  });
+
+  describe('the ordinary showcase row actions', () => {
+    const cases: [string, unknown][] = [
+      ['showcase_mark_done', MarkDoneAction.visible],
+      ['showcase_submit_for_signoff', SubmitForSignoffAction.visible],
+      ['showcase_archive_task', ArchiveTaskAction.disabled],
+    ];
+
+    it.each(cases)('%s is has()-guarded and never faults', (_name, raw) => {
+      const source = sourceOf(raw);
+      expect(source).toContain('has(record.');
+      expect(evaluate(source, {})).toBeTypeOf('boolean');
+    });
+
+    it('mark-done still hides on a finished task and offers on an unfinished one', () => {
+      const source = sourceOf(MarkDoneAction.visible);
+      expect(evaluate(source, { done: true })).toBe(false);
+      expect(evaluate(source, { done: false })).toBe(true);
+      // A projected-but-null `done` reads as "not done", so the button is
+      // offered — `!=` against a literal never faults, which is exactly why
+      // `has()` alone is the whole guard here and `!record.done` was not.
+      expect(evaluate(source, { done: null })).toBe(true);
+      // The spelling this replaced, pinned so the regression is recognisable.
+      expect(evaluate('!record.done', { done: null })).toBe('FAULT no such overload: !null');
+      expect(evaluate('!record.done', {})).toBe('FAULT No such key: done');
+    });
+  });
+
+  it('keeps the Full-vs-Minimal contrast the fixture exists to demonstrate', () => {
+    // A record-DETAIL read projects every declared column, so the absent half
+    // never fires there and the specimens must still disagree across the two
+    // seeded records. `f_boolean` is the three-authoring-forms gate.
+    const gate = sourceOf(
+      allPredicateMatrixActions.find((a) => (a as { name: string }).name === 'showcase_zoo_visible_string')!.visible,
+    );
+    expect(evaluate(gate, { f_boolean: true })).toBe(true);
+    expect(evaluate(gate, { f_boolean: false })).toBe(false);
+  });
+});

--- a/examples/app-showcase/tsconfig.json
+++ b/examples/app-showcase/tsconfig.json
@@ -7,8 +7,29 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "outDir": "./dist",
-    "rootDir": "."
+    // `outDir` / `rootDir` were removed and `noEmit` set as a CONSEQUENCE of
+    // the `paths` block below — the same correction examples/app-crm and
+    // `packages/qa/downstream-contract` made for the same reason. tsc emits
+    // nothing for this app either way (`typecheck` is `tsc --noEmit`; the app
+    // is BUILT by the ObjectStack CLI, not by tsc), but an emit-shaped config
+    // still enforces the output-tree rules: `rootDir` is inferred from the
+    // `include` roots, so formula's source — pulled in by an import, never a
+    // root — produced a wall of `TS6059: File '.../packages/formula/src/...'
+    // is not under 'rootDir'` that would drown any real error this typecheck
+    // exists to print.
+    "noEmit": true,
+    //
+    // #8990: `test/action-predicate-sparse-face.test.ts` imports the CEL engine
+    // to evaluate this app's authored predicates. Without this rule the import
+    // resolves through the workspace link to `packages/formula/dist/*.d.ts` — a
+    // BUILD ARTIFACT — so `tsc --noEmit` would be checking against whatever was
+    // last built rather than against the source in this checkout, and a stale
+    // `dist` typechecks green over an engine contract that has since moved.
+    // `pnpm check:type-source-resolution` is the gate; it wants the `paths`
+    // rule, not a registry entry.
+    "paths": {
+      "@objectstack/formula": ["../../packages/formula/src/index.ts"]
+    }
   },
   // This package took the widened-`include` route rather than a sibling
   // `tsconfig.test.json` because its `rootDir` is already the package root, so

--- a/examples/app-showcase/vitest.config.ts
+++ b/examples/app-showcase/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, configDefaults } from 'vitest/config';
+import path from 'node:path';
 
 /**
  * Unit tests only. The Playwright browser smoke under `e2e/` also uses
@@ -6,6 +7,27 @@ import { defineConfig, configDefaults } from 'vitest/config';
  * on the `@playwright/test` import. Run the smoke with `pnpm test:smoke`.
  */
 export default defineConfig({
+  resolve: {
+    // `test/action-predicate-sparse-face.test.ts` (#8990) drives this app's
+    // authored predicates through the CEL engine itself, because the whole
+    // point of that pin is what the ENGINE answers on a sparse list row — a
+    // fault versus a considered `false`, which are the same pixel to the user.
+    // Unaliased, `@objectstack/formula` resolves through the workspace link to
+    // `dist/` — a build artifact — so the verdict would be a function of build
+    // state rather than of the source in this checkout. The loud half (a
+    // missing export) is the mild one; a dist merely BEHIND runs the suite
+    // GREEN against the engine's OLD null/absence semantics, which is exactly
+    // the behaviour these assertions exist to pin. `pnpm check:test-source-alias`
+    // is the gate. Mirrors examples/app-crm's identical rule.
+    //
+    // ANCHORED regex, array form, deliberately: a bare string `find` matches by
+    // PREFIX, so with a FILE replacement it would also swallow any subpath and
+    // resolve it to `…/formula/src/index.ts/<sub>` — `ENOTDIR` at run time,
+    // from a config that reads as correct.
+    alias: [
+      { find: /^@objectstack\/formula$/, replacement: path.resolve(__dirname, '../../packages/formula/src/index.ts') },
+    ],
+  },
   test: {
     exclude: [...configDefaults.exclude, '**/e2e/**'],
   },

--- a/packages/objectql/src/declared-fields.ts
+++ b/packages/objectql/src/declared-fields.ts
@@ -85,6 +85,46 @@
  * `!= null` back is harmless but redundant; adding it INSTEAD of the leaf
  * `has()` is the mistake this table exists to prevent.
  *
+ * ### Three further measurements the two-level table above does not reach
+ *
+ * All three surfaced while migrating the showcase specimens (#8990's second
+ * half, PR #9280) and are recorded here because each one is a shape the
+ * paragraph above reads as already covered, and is not.
+ *
+ * **1. A three-level path needs `has()` at EVERY level — the leaf alone is not
+ * enough.** "Guard the leaf" subsumes the parent's `!= null`, but it does not
+ * subsume the parent's `has()`: skipping an intermediate level faults on the
+ * level that was skipped.
+ *
+ * | predicate                                                            | `{}` | `{r: null}` | `{r: {}}` | `{r: {p: null}}` | `{r: {p: {s: 9}}}` |
+ * |:---------------------------------------------------------------------|:-----|:------------|:----------|:-----------------|:-------------------|
+ * | `has(record.r) && has(record.r.p.s) && record.r.p.s == 9`            | `false` | FAULT `No such key: p` | FAULT `No such key: p` | `false` | `true` |
+ * | `has(record.r) && has(record.r.p) && has(record.r.p.s) && record.r.p.s == 9` | `false` | `false` | `false` | `false` | `true` |
+ *
+ * So the rule generalises as: one `has()` per SEGMENT of the path, not one for
+ * the root and one for the leaf.
+ *
+ * **2. A leaf used for ORDERING still needs its own `!= null`.** The leaf
+ * `has()` proves the key is present; it says nothing about the value, and the
+ * equality exception below does not extend to `<` `<=` `>` `>=`. This is the
+ * nested twin of the operator rule, and it is why the guard cannot be chosen
+ * from the path's shape alone:
+ *
+ * | predicate                                                    | `{l: {}}` | `{l: {lat: null}}` | `{l: {lat: 41}}` |
+ * |:--------------------------------------------------------------|:----------|:-------------------|:-----------------|
+ * | `has(record.l) && has(record.l.lat) && record.l.lat > 40.0`  | `false` | FAULT `no such overload: dyn<null> > double` | `true` |
+ * | `has(record.l) && has(record.l.lat) && record.l.lat != null && record.l.lat > 40.0` | `false` | `false` | `true` |
+ *
+ * **3. Indexing faults on an EMPTY list, not only on a null one.** `!= null`
+ * is not the guard for `[0]` — a projected-but-empty list is a live shape on
+ * this face (a multi-relation with nothing linked), and the index is checked
+ * against the size, not against nullness:
+ *
+ * | predicate                                                        | `{a: 'x', b: null}` | `{a: 'x', b: []}` | `{a: 'x', b: ['x']}` |
+ * |:-------------------------------------------------------------------|:--------------------|:------------------|:---------------------|
+ * | `has(record.a) && has(record.b) && record.b != null && record.a == record.b[0]` | `false` | FAULT `No such key: index out of bounds, index 0 >= size undefined` | `true` |
+ * | `… && record.b != null && record.b.size() > 0 && record.a == record.b[0]` | `false` | `false` | `true` |
+ *
  * One measured exception, recorded so the platform's existing predicates are
  * not misread: a bare EQUALITY against a literal never faults on a null value
  * — CEL compares heterogeneously and answers `false` — so `has(record.a) &&

--- a/scripts/check-test-source-alias.mjs
+++ b/scripts/check-test-source-alias.mjs
@@ -245,10 +245,16 @@ const KNOWN_UNALIASED_TEST_IMPORTS = {
   '@objectstack/example-embed-objectql': [
     '@objectstack/driver-memory', '@objectstack/objectql', '@objectstack/spec',
   ],
+  // #8990 / PR #9280 — `@objectstack/formula` came OUT of this entry (a shrink) when
+  // `test/action-predicate-sparse-face.test.ts` gained the vitest source alias: that
+  // test evaluates this app's authored predicates on the CEL engine, so a `dist`
+  // merely BEHIND would run it green against the engine's old null/absence semantics —
+  // exactly the behaviour those assertions exist to pin. Same pair examples/app-crm
+  // moved through on PR #9166.
   '@objectstack/example-showcase': [
     '@objectstack/cloud-connection', '@objectstack/connector-mcp', '@objectstack/connector-openapi',
     '@objectstack/connector-rest', '@objectstack/connector-slack', '@objectstack/core',
-    '@objectstack/driver-sql', '@objectstack/formula', '@objectstack/objectql',
+    '@objectstack/driver-sql', '@objectstack/objectql',
     '@objectstack/plugin-approvals', '@objectstack/runtime', '@objectstack/service-automation',
     '@objectstack/service-datasource', '@objectstack/service-messaging', '@objectstack/spec',
   ],

--- a/scripts/check-type-source-resolution.mjs
+++ b/scripts/check-type-source-resolution.mjs
@@ -203,10 +203,16 @@ const KNOWN_DIST_RESOLVED_TYPE_IMPORTS = {
   '@objectstack/example-embed-objectql': [
     '@objectstack/driver-memory', '@objectstack/objectql', '@objectstack/spec',
   ],
+  // #8990 / PR #9280 — `@objectstack/formula` came OUT of this entry (a shrink) when
+  // the app's tsconfig gained a `paths` rule pointing at formula's SOURCE. The test
+  // added there typechecks against the CEL engine's contract, and a stale `dist/*.d.ts`
+  // would typecheck GREEN over a contract that has since moved — the dangerous
+  // direction this file's header names. Same pair examples/app-crm moved through on
+  // PR #9166.
   '@objectstack/example-showcase': [
     '@objectstack/cloud-connection', '@objectstack/connector-mcp', '@objectstack/connector-openapi',
     '@objectstack/connector-rest', '@objectstack/connector-slack', '@objectstack/core',
-    '@objectstack/driver-sql', '@objectstack/formula', '@objectstack/objectql',
+    '@objectstack/driver-sql', '@objectstack/objectql',
     '@objectstack/plugin-approvals', '@objectstack/runtime', '@objectstack/service-automation',
     '@objectstack/service-datasource', '@objectstack/service-messaging', '@objectstack/spec',
   ],


### PR DESCRIPTION
Fixes #8990

Takes the showcase remainder of #8990 — the half PR #9166 deliberately held back because
`predicate-matrix.action.ts` is a live browser specimen. All gates re-run at
**`01ba6e700`**, the final commit.

## The census moved: the remainder was 57, not 12

⚠️ **PM mechanism assumption 1 is falsified, and the original "34 across both repos" was
an undercount too.** Both figures came from a grep for a `visible:` / `disabled:` **key**.
This file declares 45 of its predicates through a helper that takes the predicate as a
**positional argument**:

```ts
const zooTypeGate = (name: string, label: string, visible: string) => defineAction({ … });
zooTypeGate('tags', 'tags — any', 'record.f_tags.size() > 0'),
```

A key-shaped grep cannot see those. Measured on current `main` by reading predicates off
the **exported action objects** instead:

| site | key-grep saw | actually |
|---|---|---|
| `predicate-matrix.action.ts` | 8 | **53** |
| `ui/actions/index.ts` | 3 | 3 |
| `ui/views/field-zoo.view.ts` | 1 | 1 + 1 `conditionalFormatting` rule |
| **total** | **12** | **57** |

The new test asserts the count off the exported actions, so the next sweep cannot silently
miss the helper-indirected ones.

## The browser round came first, and it decided the shape

The app was booted for real (`objectstack dev --seed-admin`, isolated port and DB), signed
in, and every predicate evaluated against **the payloads the running server actually
returns** for each declared view — not against invented bindings.

**What the fixture demonstrated before the change:**

| binding | what the server returns | predicates that FAULT |
|---|---|---|
| default list row (`$select` = the 5 view columns) | exactly those 5 keys | **40 of 53** |
| `gated_columns` list row | its own 5 keys | 38 of 53 |
| record detail (no `$select`) | **all 59 declared columns**, nulls as present keys | **0 of 53** |

**After the change: 0 of 53 fault on any binding, and `DETAIL verdict changes: 0`** —
every gate reaches the same answer on a projected record that it did before. That is the
acceptance criterion for a specimen: the Full-vs-Minimal contrast the fixture exists to
show is preserved exactly, and only the fault became an honest `false`.

**No predicate here existed to demonstrate faulting**, so nothing was deleted by
migrating. The one deliberate fault specimen in the file is `ZooDialectSplitAction`, whose
point is the `.contains()` **dialect** split, not the null/absent one — the migration
keeps `.contains()` and therefore keeps that demonstration intact. The file's own header
said the specimens were unmigrated and "tracked separately in #8990"; that note is now
replaced by what the migration measured.

## The guard is minimal per predicate, never blanket

Applied from the canonical rule at `packages/objectql/src/declared-fields.ts` (`:67`,
`:79`, `:85`), read at HEAD. `has()` alone for a bare `==` / `!=` (26 predicates); the
full conjunction only where an operand can fault (27).

The block header also claimed the line was "nullable non-scalar". It is not — the operator
decides, not the type: `record.f_slider > 50` faults on a projected NULL just as readily.
That comment is corrected in place.

## Three measurements carried to the CANONICAL rule, not just to this file

Three shapes came out of the migration that the two-level nested table at `:79` reads as
already covered and does not reach. They are recorded at the definition site
(`packages/objectql/src/declared-fields.ts`) as an **additive** subsection — nothing at
`:38` / `:67` / `:79` / `:85` was restructured — because a rule stated only in one of its
readers is how #8975 came to exist.

| # | refinement | the binding that proves it |
|---|---|---|
| 1 | a three-level path needs `has()` at **every segment**, not just root and leaf | `has(record.r) && has(record.r.p.s) && …` FAULTS `No such key: p` on `{r: null}` **and** `{r: {}}` |
| 2 | a nested **ordering** leaf still needs its own `!= null` — the leaf `has()` proves presence, not value | `has(record.l) && has(record.l.lat) && record.l.lat > 40.0` FAULTS on `{l: {lat: null}}` |
| 3 | indexing faults on an **empty** list, not only a null one — so `!= null` is not the guard for a subscript | `record.b[0]` on `{b: []}` ⇒ `No such key: index out of bounds, index 0 >= size undefined` |

⭐ **Every cell of all three tables was evaluated against `@objectstack/formula` before
being written**, rather than transcribed from the migration session. That caught a wrong
generalisation: I was about to write #1 as "guard the root and the leaf", and the `{r: {}}`
column is what shows the correct statement is **one `has()` per segment**.

Applied in this PR to `f_json.nested.k` and `f_record.primary.score` (#1), `f_location.lat`
— and deliberately *not* to `f_address.country` / `f_composite.width`, which are
equalities (#2), and the relation gate's `record.f_lookups.size() > 0` term (#3).

## `!record.done` — the highest-cost line

`content/docs/ui/actions.mdx` and the showcase both taught the exact negation shape
PR #9166 proved faults. It migrates to `has(record.done) && record.done != true` rather
than to a `!= null` conjunction, because `!=` against a literal cannot fault **and** it
reads an unset `done` as "not done" (so the button is still offered), which the negation
did not. That also makes it agree with `ArchiveTaskAction`, which already spelled the
non-faulting form. Pinned both ways in the new test.

## Scope taken beyond the four named sites

Under the bounded in-place exemption, named rather than folded in:

- **45 further predicates in `predicate-matrix.action.ts`** — the census delta above. Same
  file, same defect class, same gates; leaving them would have shipped a file that is 15%
  migrated and 85% not, with a header claiming otherwise.
- **`field-zoo.view.ts`'s `conditionalFormatting` rule** — binds the same sparse row, reads
  `f_lookup` (a column in neither view), and faulted on every row. The file's own comment
  calls it "the display-side twin of the action gates, and the same trap".
- **`review-queue.page.ts`** — a doc comment quoting `visible: '!record.done'` verbatim.

⛔ Nothing in `packages/platform-objects/**`.

## Source-resolution registries

`examples/app-showcase` gains a vitest alias and a tsconfig `paths` rule for
`@objectstack/formula`, mirroring `examples/app-crm`'s existing pair, so the new test
evaluates and typechecks against engine **source** rather than a build artifact.
`outDir`/`rootDir` came off with `noEmit` set, the same consequence app-crm records.

That makes the app's entry in **both** shrink-only registries stale, and both were narrowed
to the exact list each gate printed: `check:test-source-alias` and its sibling
`check:type-source-resolution`, which fails identically once the first is fixed. Removing a
package from those lists is a **shrink**, the permitted direction, and
`check:ratchet-remedy-authority` passes. ⛔ The alias and `paths` rule were deliberately
**not** removed to make the registries true again — that would trade a green gate for the
exact hazard the gates exist to name (a suite running green against a stale engine build,
and a typecheck passing over a contract that has since moved).

## Why this closes the card

Repo-wide census off the built artifacts, restricted to sparse-face slots (action
`visible`/`disabled`, `conditionalFormatting`, `bulkActionDefs`, page blocks) and
excluding validation / `requiredWhen` / hook conditions, which bind a TOTAL record where
`has()` is a tautology:

- `app-showcase` — 113 sparse-face record predicates, **1** unguarded
- `app-crm` — 2, **0** unguarded · `app-todo` — no authored action predicates
- platform packages — **1** unguarded

Both remaining hits are the `record:alert` **page-block** pair that #9167 owns
(`platform-objects/src/pages/sys-user.page.ts:79`,
`app-showcase/src/ui/pages/task-detail.page.ts:51`). #8990's census is action-only and
explicitly excludes them, and I confirmed no helper-indirected predicate hides anywhere
else in the repo — so the action face is now fully migrated.

## Verification — all at `01ba6e700`

- `pnpm --filter @objectstack/example-showcase --filter @objectstack/objectql test` —
  showcase **21 files / 334 tests passed** (113 new), objectql **213 files / 3755 tests
  passed**.
- `typecheck` for both — **0** `error TS`, both `Done`.
- Gate union **re-derived from the actual changed paths** after the objectql commit
  (`scripts/pm/dispatch-gates.mjs`, post-#9188). The objectql paths widened it, as
  expected: `check:durability-log-level` and `check-engine-split-ratio` are new. All pass —
  those two, plus `check:test-source-alias`, `check:type-source-resolution`,
  `check:ratchet-remedy-authority`, `check:changeset-gate-self-tests`,
  `check:cross-package-test-inputs`, `check:docs-audit-scope`, `check:docs-redirects`,
  `check:objectui-changeset`, `check:role-word`, `check:nul-bytes`, the four
  `spec-liveness-check` families (#9171's `Spec property liveness` coverage for the
  objectql paths), the four convention-triggered families
  (`check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`,
  `check:type-check-coverage`), and the four changeset scripts.
- `check:type-check-debt --re-measure` at the final head — *"33 ledger entr(ies)
  re-measured in 381.1s, 1926 raw tsc error(s) total, none above its recorded number.
  surplus: none."* No ledger entry added or raised.
- **Reverse verification, direction predicted RED before running.** Reverted
  `showcase_zoo_t_tags` to `record.f_tags.size() > 0` on the committed tree: 3 tests failed
  with `expected 'FAULT No such key: f_tags' to be type of 'boolean'` and
  `expected 'FAULT found no matching overload for …' to be type of 'boolean'` — the two
  fault classes the guard covers, one per half. Restored with `git checkout` from the
  branch ref; `git status --porcelain` clean.

⚠️ **A process note worth recording, because the failure mode is silent.** My first attempt
at the ratchet was piped through `tail`, which masked its exit code — `flock` had hit its
`-w` deadline and exited **99** while another agent held `/tmp/os-heavy-verify.lock`, so the
gate never ran and the empty output read exactly like a clean pass. The number quoted above
is from a re-acquired run with `FLOCK_EXIT=0` captured explicitly.

## One risk I could not close, stated plainly

This session had **no browser/preview tooling**, so the visual half of the dogfood round
was not run — everything above is the authoritative-server-response half, which the
dogfood skill accepts as an evidence class and which happens to be the decisive one here
(what keys a bound row carries is a server fact).

The residual question is whether the **record header** evaluates these predicates on CEL
or on objectui's legacy JS evaluator, because **`has()` throws there** — measured
directly: `SafeExpressionParser` answers `"has" is not a function`. If the header used
that path, adding `has()` would hide the 51 header-located gates.

Evidence it does not, read at the **pinned** objectui sha (`665661ab`, fetched
specifically — the local checkout is a different commit):

- `ActionEngine.getActionsForLocation` passes a `{dialect:'cel'}` envelope **INTACT** to
  `evaluateCondition`, which routes it to `@objectstack/formula` (objectui#2661/#3314).
- The built artifact confirms the input shape: **113 of 114** record-scoped predicates in
  `dist/objectstack.json` are `{dialect,source}` envelopes, because `defineAction`
  normalizes the shorthand at build time.

So the action face is CEL on every surface and `has()` is safe. ⚠️ The file's
`objectui#3521` bullet — "The RECORD HEADER does not speak CEL" — looks **stale** against
that pinned code; I did not rewrite it, because I could not confirm it in a browser.
Filed as **#9281** (in this repo, since the stale prose is an objectstack file), with a
one-step browser repro that decides it either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_17d48cbe-d3e0-562b-95a3-e2653a9bd9fb)_
