### PR TITLE
docs: drop stale spec-version claim from build-with-claude-code.mdx

### DIFF
--- a/content/docs/getting-started/build-with-claude-code.mdx
+++ b/content/docs/getting-started/build-with-claude-code.mdx
@@ -239,8 +239,8 @@ This is the same metadata that powers the REST API, the Console UI, **and the MC
 tools exposed to AI** — define it once, and ObjectStack derives the rest.
 
 <Callout type="info">
-Every example on this page was authored against `@objectstack/spec` 16.x and
-passes `os validate` verbatim in a freshly scaffolded project.
+Every example on this page passes `os validate` verbatim in a freshly scaffolded
+project.
 </Callout>
 
 ## 4. The gate: `os validate` catches AI mistakes


### PR DESCRIPTION
Fixes #9265

## What

`content/docs/getting-started/build-with-claude-code.mdx` carried an info callout
claiming its examples were "authored against `@objectstack/spec` 16.x" while the
repo ships 17.0.0. The examples themselves were measured to pass `os validate`
verbatim on 17 during #9152 — only the version half of the claim was stale.

Before:

> Every example on this page was authored against `@objectstack/spec` 16.x and
> passes `os validate` verbatim in a freshly scaffolded project.

After:

> Every example on this page passes `os validate` verbatim in a freshly scaffolded
> project.

Per triage (issue comment) and Zone 1 rulings: drop the version number rather than
re-pin it to `17.x` (which would only reacquire the same staleness on the next
major bump), and keep the durable, measured-true half of the claim. Inventing a
prose-stamping mechanism is explicitly out of scope — that is its own card.

## Scan for sibling pages (Zone 2 of the dispatch)

Triage's dispatch order was to scan `content/docs/**` for hand-written
`@objectstack/spec *.x` claims first, and stop/report if several pages carry them.
Ran that scan fresh from `origin/main` (`fab693bee`) — it returns 3 hits, but only
1 is the relevant class:

| hit | text | class |
|:--|:--|:--|
| `content/docs/kernel/runtime-services/storage-service.mdx:35` | `services.storage.list?(prefix)` was removed in `@objectstack/spec` 5.x | historical fact — untouched |
| `content/docs/kernel/contracts/storage-service.mdx:173` | `list(prefix)` was removed in `@objectstack/spec` 5.x | historical fact — untouched |
| `content/docs/getting-started/build-with-claude-code.mdx:242` | Every example on this page was authored against `@objectstack/spec` 16.x | currency claim — fixed here |

The two `storage-service.mdx` lines state *when* something was removed — they are
correct and durable, and become wrong if "updated". Only the `:242` line asserts
*currency*. So the stop condition (several pages carrying a currency-style version
claim) is not tripped; this PR is the single-page fix triage's first branch called
for.

## Scope

Docs-only. `content/docs/releases/**` untouched, as always.

## Tests

Local gates run from a fresh worktree on `origin/main` (`fab693bee`), commit `cf4735ef9`:

- `pnpm check:docs-audit-scope` — pass
- `pnpm check:docs-redirects` — pass
- `pnpm check:role-word` — pass
- `pnpm check:nul-bytes` — pass
- `pnpm --filter @objectstack/spec check:liveness` — pass
- `pnpm --filter @objectstack/spec check:empty-state` — pass
- `pnpm --filter @objectstack/spec check:variant-docs` — pass
- `pnpm --filter @objectstack/spec check:strictness-ledger` — pass

Docs-only content change, no user-visible package release — applying
`skip-changeset`.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_