### PR TITLE
docs(api): catalog the unmintable `/meta` type refusal

### DIFF
--- a/content/docs/api/error-catalog.mdx
+++ b/content/docs/api/error-catalog.mdx
@@ -526,8 +526,10 @@ if (!res.success) showToast(res.error);
 `/meta` refusals carry codes registered to `@objectstack/metadata-protocol` in the
 [error-code ledger](/docs/references/api/error-code-ledger), not the standard catalog
 above — so their status is published here rather than inherited from a category. This
-section documents the **type-spelling** refusal the `/meta` request boundary raises. It
-is not a complete inventory of `/meta` errors.
+section documents the two **type-boundary** refusals the `/meta` request boundary raises:
+the type-spelling refusal, and the unmintable-type refusal that guards writes. Both answer
+`INVALID_REQUEST` with `400`, so the code and the status cannot tell them apart — only the
+message can. It is not a complete inventory of `/meta` errors.
 
 ### `INVALID_REQUEST` — unrecognised type spelling
 
@@ -571,10 +573,86 @@ boundary is what keeps one type to one key.
 
 ⛔ **Not this error:** a segment that reaches for no declared type — `/meta/fieldz`, or
 a plugin-registered kind such as `theme` — is not a misspelling of anything the platform
-declares, so this rule stays silent and the request continues down the plugin path. A
-**write** whose segment is not a metadata type at all is refused separately: same
-`INVALID_REQUEST` code and `400` status, different message (*"… is not a metadata
-type"*). Tell the two apart by the message, not the code.
+declares, so this rule stays silent. On a **read** the request continues down the plugin
+path; on a **write** it meets the separate unmintable-type refusal documented immediately
+below, which carries the same `INVALID_REQUEST` code and `400` status and differs only in
+its message. Tell the two apart by the message, not the code.
+
+### `INVALID_REQUEST` — unmintable metadata type
+
+**HTTP Status:** 400  
+**Cause:** A **write** addresses a `:type` segment that is not a metadata type at all —
+not a misspelling of a declared type, but a name the platform has no type for.
+`PUT /meta/fieldz/showcase_task.title` is refused because nothing declares `fieldz`, and
+since `additionalTypes` was retired a plugin cannot declare one either — so the write
+would mint a `sys_metadata` namespace under `type='fieldz'` that nothing reads and nothing
+serves.
+
+**Fix:** Address a real metadata type; `GET /api/v1/meta/types` lists the ones the
+deployment carries. Unlike the spelling refusal above, this message names no replacement —
+the segment reaches for no declared type, so there is nothing to suggest.
+See the [Metadata API](/docs/api/metadata-api).  
+**Retry:** `no_retry` — replaying the same request against the same deployment returns the
+same `400`. ⚠️ That is stability, not determinism: the verdict is not a pure function of
+the type segment, and the exemptions below decide whether it fires at all.
+
+`PUT /api/v1/meta/fieldz/showcase_task.title` answers `400` with:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "[invalid_request] 'fieldz' is not a metadata type. The platform declares no such type, and since #8586 retired 'additionalTypes' a plugin cannot declare one either — so this write would mint a sys_metadata namespace under type='fieldz' that nothing reads and nothing serves. Address a real metadata type; GET /api/v1/meta/types lists the ones this deployment carries.",
+    "httpStatus": 400
+  }
+}
+```
+
+<Callout type="warn">
+**Two shapes reach this door and are served, not refused** — neither of them visible in
+the message, so a caller who does not read this entry finds them by collision:
+
+1. **Compound arity.** A `name` containing `/` exempts the request, because at that arity
+   the `:type` segment carries an **object** name rather than a type claim:
+   `PUT /meta/lead/views/all_leads` is `type='lead'`, `name='views/all_leads'`, and no
+   static contract can enumerate the objects a deployment carries. Residue, stated rather
+   than hidden: `PUT /meta/fieldz/a/b` is therefore **accepted** — at that arity `fieldz`
+   is a claim about an object, not about a metadata type. The exemption is the **arity**,
+   not the name: `PUT /meta/lead/all_leads` is still refused.
+2. **Pre-existing namespace.** If `sys_metadata` already holds rows under that type key,
+   the write proceeds. The **store** decides this, never the caller — the probe runs only
+   after the static verdict has already fired, and it asks whether the *namespace* exists,
+   not whether your item does. This is what keeps rows minted before this refusal existed
+   editable by the tooling that copies and re-saves them.
+
+⇒ **The same segment can be refused on one deployment and served on another, depending on
+stored state.** A `400` here is a statement about *this* deployment, not a portable
+verdict about the type name — so do not cache it as one, and do not treat a colleague's
+successful `PUT` as evidence that yours will be served.
+</Callout>
+
+**It is write-scoped.** The verdict runs on the one entry point that *mints* a namespace
+and nowhere else. Reads of an unrecognised type still answer — the live type set
+legitimately holds keys the static contract does not, and refusing reads would answer
+`400` for types this same service advertises through `GET /meta/types`. Rows already
+stored under an unrecognised type stay **deletable** for the opposite reason: refusing to
+delete them would strand the accumulation permanently instead of letting an operator clear
+it.
+
+**Why it is refused rather than passed through.** A namespace nothing reads and nothing
+serves is not a harmless extra key — it accumulates silently, and every row in it is
+invisible to the tooling that lists, validates and ships metadata. Refusing at the mint
+door is what stops the first row from being written; the exemptions above are what keep
+that refusal from stranding the rows written before it existed.
+
+⛔ **Not this error:** a segment that *misspells a type the platform declares* —
+`/meta/viewes` for `view` — is the spelling refusal documented above, which can name the
+replacement. And if the namespace probe fails for any reason *other* than `sys_metadata`
+not being provisioned yet, the request answers `503` rather than this `400`: a deployment
+whose metadata store is unreachable is not told its type does not exist. An
+**unprovisioned** store is the one read failure that does not escalate — it counts as "no
+rows", and this `400` stands.
 
 ---
 


### PR DESCRIPTION
Fixes #9243

The `/meta` type boundary raises **two** refusals that share one envelope — `INVALID_REQUEST` / `400` — so code and status cannot tell them apart; only the message can. PR #9245 (for #9193) documented the spelling refusal and named this one in a single disambiguation line. This adds the sibling entry it deliberately did not absorb.

Docs-only. **No behaviour change** — #8421 scoped this refusal deliberately and it is correct; only its documentation was absent.

## The load-bearing part: the two exemptions

A bare envelope row would have been worse than no entry, because it would assert a determinism the code does not have. `refuseUnmintableMetaType` is **not** a pure function of the type segment — two shapes reach the door and are *served*:

1. **Compound arity** — a `name` containing `/` exempts the request, because at that arity the type segment carries an **object** name rather than a type claim (`PUT /meta/lead/views/all_leads` is `type='lead'`, `name='views/all_leads'`). Residue stated rather than hidden: `PUT /meta/fieldz/a/b` is therefore **accepted**. The exemption is the arity, not the name — `PUT /meta/lead/all_leads` is still refused.
2. **Pre-existing namespace** — if `sys_metadata` already holds rows under that type key, the write proceeds. The **store** decides this, never the caller.

⇒ **The same segment can be refused on one deployment and served on another, depending on stored state.** The entry says this plainly, since it is the one thing a caller could otherwise only learn by collision.

Also documented: the refusal is **write-scoped** (one call site, in `saveMetaItem`; reads still answer and residue rows stay deletable), and the namespace probe raises `503` when the store is unreachable — while an *unprovisioned* store is the one read failure that does not escalate, so the `400` stands.

## Verified against source, not restated from the card

All three properties were re-derived in the worktree (the card's line numbers had moved and are not repeated):

- envelope `code = 'INVALID_REQUEST'`, `status = 400` — `packages/metadata-protocol/src/protocol.ts`
- exemption 1 is the literal `if (request.name.includes('/')) return;`
- exemption 2 is `if (await this.metaTypeNamespaceExists(unrecognised.type)) return;`, which reads `sys_metadata` by `type` alone
- write-scoping: exactly **one** call site of `refuseUnmintableMetaType`, inside `saveMetaItem`
- the static half is `unrecognisedMetaTypeRefusal` in `packages/spec/src/shared/metadata-url-spelling.ts`

Each is independently pinned by existing tests in `packages/metadata-protocol/src/protocol.unrecognised-meta-type.test.ts` (including the anti-vacuity control for arity and the positive control for the namespace exemption) and `packages/runtime/src/meta-compound-arity-mint-door.test.ts`. The quoted JSON message is verbatim from the producer.

## Changes to the neighbouring entry, per the pair requirement

Two edits beyond the new entry, both because a second entry made the existing text inaccurate rather than merely redundant:

- **Section intro** said the section "documents the **type-spelling** refusal" (singular). It now names both refusals and states up front that they share a code and status.
- **The spelling entry's disambiguation line** half-restated this refusal's envelope inline. It now points at the entry below instead of duplicating it, and its read/write split is made explicit (on a read the request continues down the plugin path; on a write it meets this refusal). Keeping both the line and a full entry with duplicated envelope text would have been a drift pair.

## Scope

Per the card: one envelope, this one. ⛔ Not a sweep — the wider class of wire-visible refusals with no catalog entry stays unmeasured, as #9193 already recorded. `#8421` is not addressed here beyond documenting its behaviour.

## Gates

Derived from the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/api/error-catalog.mdx` (8 families, matching the dispatch list exactly), and re-run as a union **after** the final commit, at `ae6c0624b`:

| gate | result |
|---|---|
| `check:error-status-conformance` | ✅ 54 codes reconciled; `INVALID_REQUEST` read as a ledger code the page publishes a status for |
| `check:docs-audit-scope` | ✅ 178 hand-written docs in sync |
| `check:docs-redirects` | ✅ 92 entries resolved |
| `check:role-word` | ✅ no new occurrences |
| `check:empty-state` | ✅ all classified |
| `check:liveness` | ✅ |
| `check:strictness-ledger` | ✅ |
| `check:variant-docs` | ✅ |

The new heading uses the whitelisted `code + descriptive suffix` shape from the conformance gate's `ENTRY_HEADING_SHAPES`, so it is read rather than landing in the unreadable-heading census. It claims `400`, the same status the sibling entry already claims for this code, so the reconciled set is unchanged.

Docs-only, publishes nothing ⇒ `skip-changeset`.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_