### PR TITLE
docs(drivers): add AWS_SESSION_TOKEN to the no-binder-slot table

### DIFF
--- a/content/docs/data-modeling/drivers.mdx
+++ b/content/docs/data-modeling/drivers.mdx
@@ -179,10 +179,11 @@ ObjectStack — is what makes them secrets:
 | `mongo` \| `mongodb` | `options.tlsCertificateKeyFilePassword` | TLS key-file passphrase |
 | `mongo` \| `mongodb` | `options.key` | TLS private key material (PEM) |
 | `mongo` \| `mongodb` | `options.passphrase` | TLS key passphrase |
+| `mongo` \| `mongodb` | `options.authMechanismProperties.AWS_SESSION_TOKEN` | AWS STS session token (`MONGODB-AWS` auth) |
 | `turso` \| `libsql` | `encryptionKey` | AES-256 key for the local database file |
 
 Unlike `password` / `authToken` (typed `never` in their schemas — the parse
-refuses them outright), these five keys are **writable**: the parse accepts
+refuses them outright), these six keys are **writable**: the parse accepts
 them, and they are stored **at rest in `sys_metadata` as plain text**, right
 alongside the rest of the datasource row. The protection that exists today is
 on the READ side only — every one of them is stripped before a datasource
@@ -193,15 +194,28 @@ record is ever served back over the admin API or shown in the Setup UI
 round-tripping through a read; it is not encryption at rest, and an operator
 with direct access to the metadata store can still read the plain-text value.
 
+`options.authMechanismProperties.AWS_SESSION_TOKEN` is writable for a
+different reason than the other five: it isn't refused at the write door
+because the MongoDB client **itself** throws on it under `authMechanism:
+'MONGODB-AWS'` (`MongoAPIError: AWS_SESSION_TOKEN cannot be provided…`,
+driver v7 requires AWS SDK-sourced credentials) — a spec-level refusal would
+just be naming a remedy the client already enforces — and under any other
+auth mechanism nothing reads it at all. Either way, a stored value is
+accepted, held in `sys_metadata` as plain text, and redacted on read exactly
+like the rest of this table.
+
 <Callout type="warn">
 **This is a deliberate, documented trade-off ([#9124](https://github.com/objectstack-ai/objectstack/issues/9124)), not an oversight.**
-The binder has exactly one named slot. Refusing these five keys at write time
-would remove the only way to configure an authenticated SOCKS5 proxy or a
-passphrase-protected TLS key — a capability the client genuinely honours, with
-no working refusal remedy. **Restart condition:** the first real deployment
-that needs an authenticated proxy or a passphrase-protected key converts this
-into named binder-slot support — one mechanism covering all five keys — rather
-than the current per-key accept-and-document posture.
+The binder has exactly one named slot. Refusing `proxyPassword`,
+`tlsCertificateKeyFilePassword`, `key`, `passphrase`, or turso's
+`encryptionKey` at write time would remove the only way to configure an
+authenticated SOCKS5 proxy, a passphrase-protected TLS key, or a
+locally-encrypted database file — a capability the client genuinely honours,
+with no working refusal remedy. (`AWS_SESSION_TOKEN` isn't part of that
+trade-off — see above.) **Restart condition:** the first real deployment
+that needs an authenticated proxy or a passphrase-protected key converts
+that group into named binder-slot support — one mechanism covering those
+five keys — rather than the current per-key accept-and-document posture.
 </Callout>
 
 ## Startup: a driver that cannot connect aborts the boot


### PR DESCRIPTION
Fixes #9279

## What

`content/docs/data-modeling/drivers.mdx`'s "Secret-shaped keys with no binder slot" table listed four mongo/turso keys, but `PASSTHROUGH_SECRET_PATHS` (`packages/spec/src/data/datasource-credential-redaction.ts`) redacts five mongo `options.*` keys on read — the table was missing `options.authMechanismProperties.AWS_SESSION_TOKEN`.

- Added the fifth row: `options.authMechanismProperties.AWS_SESSION_TOKEN` (`mongo` / `mongodb`).
- Updated the "these five keys" prose to "these six keys" (four mongo + turso `encryptionKey`, now plus this row = six total).
- Added a short paragraph explaining that `AWS_SESSION_TOKEN` is writable for a *different* reason than the other five: it isn't refused at the write door because the MongoDB client itself throws on it under `authMechanism: 'MONGODB-AWS'` (per `driver/common.zod.ts`), not because the binder lacks a slot for it. Under any other mechanism nothing reads it. Either way it's accepted, stored cleartext, and redacted on read — same posture as the rest of the table.
- Reworded the trade-off `Callout` to name the SOCKS5/TLS-key/turso group explicitly (its "no working refusal remedy" rationale) and note that `AWS_SESSION_TOKEN` isn't part of that trade-off.

Docs-only. No `packages/spec/src/**` changes — the redaction source of truth already covered this key; the doc just undercounted it.

## Out of scope (per triage)

Per the issue's coordination note, #9254's `mongo.zod.ts` describe string (PR #9277) is a separate, discretionary follow-through and is **not** touched here.

## Verification

Built at `fc0cd0a93`. Local gates run against the actual diff (`node scripts/pm/dispatch-gates.mjs content/docs/data-modeling/drivers.mdx`):

- `pnpm check:nul-bytes` — OK (6066 files scanned, no raw control bytes)
- `pnpm check:role-word` — OK (43 baselined files, no new occurrences)
- `pnpm check:docs-redirects` — OK (92 entries, no dead pages)
- `pnpm check:quick-reference-counts` — OK
- `pnpm check:docs-audit-scope` — OK (178 hand-written docs in scope)
- `pnpm --filter @objectstack/spec run check:empty-state` — OK
- `pnpm --filter @objectstack/spec run check:liveness` — OK (pre-existing warnings unrelated to this diff)
- `pnpm --filter @objectstack/spec run check:strictness-ledger` — OK
- `pnpm --filter @objectstack/spec run check:variant-docs` — OK

This repo uses the `skip-changeset` label for docs-only PRs (applied by the PM) — no changeset fabricated here.

_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_