### PR TITLE
docs(api): caveat PUT /meta/:type/:name's create-refusal shapes

### DIFF
--- a/content/docs/api/metadata-api.mdx
+++ b/content/docs/api/metadata-api.mdx
@@ -55,6 +55,26 @@ Get a specific metadata item with optional ETag caching.
 
 Create or update a metadata item.
 
+Creates are gated per type: `MetadataTypeRegistryEntry.allowRuntimeCreate` decides
+whether a **brand-new** name may be minted under that type at all, separately from
+whether an item that already exists may be overlaid (`allowOrgOverride`). A type that
+declines the create half still accepts updates to names that already exist, and its
+refusal — `403 NOT_CREATABLE` — names the route that does work. The flags are
+documented on
+[`MetadataTypeRegistryEntry`](/docs/references/kernel/metadata-plugin#metadatatyperegistryentry);
+which types currently decline which half is tracked in the
+[overlay whitelist](/docs/concepts/metadata-lifecycle#overlay-whitelist-shared-db-tenancy-invariant)
+rather than enumerated on this page, so this caveat doesn't go stale the next time a
+type is retired.
+
+This verb also refuses a `:type` segment that is not a metadata type the platform
+declares at all — not a recognised spelling, and not a misspelling of one either —
+with `400 INVALID_REQUEST`, before any namespace is minted for it. The refusal is
+scoped to this verb: `GET` and `DELETE` on an item that already exists are
+unaffected. See [unrecognised type spelling](/docs/api/error-catalog#invalid_request--unrecognised-type-spelling)
+in the error catalog for the envelope — the same code and status cover both this
+refusal and the misspelling one above; the message text tells them apart.
+
 **Body**: `{ type: "object", name: "account", item: { ... } }`  
 **Response**: `{ success: true }`
 


### PR DESCRIPTION
Fixes #8498

## What was missing

`content/docs/api/metadata-api.mdx`'s `PUT /meta/:type/:name` entry said only
"Create or update a metadata item," with no mention that some types refuse the
create half, and no mention that a `:type` segment can itself be refused before
anything is minted. Two different refusal shapes hit that verb and neither was
documented.

## Measurement, before writing anything

**Generated surface for the per-type flags.** `content/docs/references/kernel/metadata-plugin.mdx`
is auto-generated (`build-docs.ts`, header says so) and documents `MetadataTypeRegistryEntry.allowRuntimeCreate`
/ `allowOrgOverride` — their existence, types and defaults — sourced from
`packages/spec/src/kernel/metadata-plugin.zod.ts`. It does **not** enumerate the
registry's concrete per-type values (that would need `build-docs.ts` to walk
`DEFAULT_METADATA_TYPE_REGISTRY` itself, which it doesn't). Current per-type
values already live in a separate, pre-existing hand-written table —
`content/docs/concepts/metadata-lifecycle.mdx#overlay-whitelist-shared-db-tenancy-invariant`
(added under #7893, not touched by this PR). So the instruction ("point at
wherever the flags are readable") has two real, non-invented targets: the
generated schema page for the flags themselves, and the existing lifecycle
table for current values. The new caveat links both instead of re-enumerating
`field`/`job` inline.

**Whether PR #8770 (#8421) has landed.** Verified merged to `main`
(`merged_at: 2026-08-15T11:10:35Z`, `merge_commit` reachable from `origin/main`).
The 2026-08-14 "not live yet" caution in this card's comments is stale — I
measured the current state rather than inheriting it. The refusal
(`unrecognisedMetaTypeRefusal` in `packages/spec/src/shared/metadata-url-spelling.ts`,
consumed by `refuseUnmintableMetaType` in `packages/metadata-protocol/src/protocol.ts`)
is live and is called **only** from `saveMetaItem` (the `PUT` path) — confirmed
by reading the call site, not inferred from the PR description. So the caveat
documents it, scoped to `PUT` only, per this card's own mandate.

**Distinguishing it from the refusal #9245 already documented.** `main` already
carries a caveat at the top of the `## Metadata` section (landed 2026-08-17 by
PR #9245, closing #9193) for `metaUrlSpellingRefusal` — a **misspelling of a
declared type** (`viewes` for `view`), which fires on nine verbs, reads
included. That is a **different** predicate from #8421/PR #8770's
`unrecognisedMetaTypeRefusal` — a segment that is **not a metadata type at
all** (`fieldz`), scoped to the mint door only. `error-catalog.mdx` already
flags the two are easy to conflate (same `INVALID_REQUEST`/400, different
message) in a callout under the misspelling entry, but had no home for the
second refusal's own caveat on the `PUT` entry itself — that's the gap this PR
closes, without touching PR #9245's prose.

**#9180 (the singular/plural ruling).** Read in full. Its step ① (#9157/PR
#9191) has landed — it narrows three **read** verbs
(`historyMetaItem`/`auditMetaItem`/`findReferencesToMeta`) to refuse plurals.
Step ③, which would rewrite `metadata-api.mdx`'s folding prose (the "singular
or plural" sentence under `GET /meta/:type`), is still "to file" — not landed.
That prose is unchanged by this PR: it remains an accurate description of the
currently-landed behavior for `GET /meta/:type` and `GET /meta/:type/:name`,
and rewriting it now would document a tolerance ahead of the ruling that
retires it.

## The change

Two paragraphs added under `### PUT /meta/:type/:name`, no type names
enumerated:

> Creates are gated per type: `MetadataTypeRegistryEntry.allowRuntimeCreate`
> decides whether a **brand-new** name may be minted under that type at all,
> separately from whether an item that already exists may be overlaid
> (`allowOrgOverride`). A type that declines the create half still accepts
> updates to names that already exist, and its refusal — `403 NOT_CREATABLE`
> — names the route that does work. The flags are documented on
> [`MetadataTypeRegistryEntry`](/docs/references/kernel/metadata-plugin#metadatatyperegistryentry);
> which types currently decline which half is tracked in the
> [overlay whitelist](/docs/concepts/metadata-lifecycle#overlay-whitelist-shared-db-tenancy-invariant)
> rather than enumerated on this page, so this caveat doesn't go stale the
> next time a type is retired.
>
> This verb also refuses a `:type` segment that is not a metadata type the
> platform declares at all — not a recognised spelling, and not a
> misspelling of one either — with `400 INVALID_REQUEST`, before any
> namespace is minted for it. The refusal is scoped to this verb: `GET` and
> `DELETE` on an item that already exists are unaffected. See
> [unrecognised type spelling](/docs/api/error-catalog#invalid_request--unrecognised-type-spelling)
> in the error catalog for the envelope — the same code and status cover
> both this refusal and the misspelling one above; the message text tells
> them apart.

`content/docs/releases/**` untouched. The refusal messages/codes/statuses
themselves untouched (out of scope, and not this card's tier). No `packages/spec`
or runtime source touched — docs only.

## Out of scope, deliberately

- `releases/v17.mdx` — release notes are compiled centrally; not this PR's
  input.
- The refusal messages themselves.
- Line 26's singular/plural folding prose — accurate as landed, and rewriting
  it ahead of #9180 step ③ would document a tolerance on its way out.
- Adding a dedicated `error-catalog.mdx` entry for `unrecognisedMetaTypeRefusal`
  — the existing "Not this error" callout under the misspelling entry already
  states the envelope shape (same code/status, different message) and is
  what this PR's new caveat links to; a full dedicated entry is a separate,
  larger change than this card's scope.

## Verification

Docs-only change; no package build required by the diff itself, but the four
`content/docs/**`-triggered spec-liveness gates and the docs-audit gates were
run anyway (re-derived via `node scripts/pm/dispatch-gates.mjs content/docs/api/metadata-api.mdx`,
plus `check:doc-anchors` added by hand since the diff adds two new markdown
anchor links), all at `6e51a7c3c` (this branch's head):

- `check:nul-bytes` — OK
- `check:docs-audit-scope` — OK (178 hand-written docs in scope, releases pages read-only)
- `check:docs-redirects` — OK
- `check:role-word` — OK
- `check:doc-anchors` — OK, **244 internal fragment links across 396 source files all resolve to a real heading** — confirms both new links in this PR resolve
- `pnpm --filter @objectstack/spec build` — OK (prerequisite for the liveness gates below; no generated-artifact drift, `git status` clean after)
- `pnpm --filter @objectstack/spec run check:empty-state` — OK
- `pnpm --filter @objectstack/spec run check:liveness` — OK
- `pnpm --filter @objectstack/spec run check:strictness-ledger` — OK
- `pnpm --filter @objectstack/spec run check:variant-docs` — OK

No changeset: `content/docs/**` maps to no npm package, so this PR releases
nothing (same treatment as PR #9245, the precedent for this exact shape of
change, which also carried no changeset). `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_