### PR TITLE
test(lint): give the runtime lazy-deps guard an object-write leg

### DIFF
--- a/packages/lint/src/runtime-lazy-deps.test.ts
+++ b/packages/lint/src/runtime-lazy-deps.test.ts
@@ -16,9 +16,30 @@
 // TRIGGERING one. The rules #4463 wired to `runtime-publish` — flow, approval,
 // expression, reference — read structured metadata and parse no authored
 // source, so they cannot. This file is what keeps that true when the next rule
-// is wired to the surface: widen `runtimeTypes` to a type whose snapshot
-// carries a hook body or a react page and this goes red, which is the moment to
-// stop and think, not a moment to relax the assertion.
+// is wired to the surface: widen `runtimeTypes` onto a type whose snapshot
+// carries a hook body, a react page or a `json_schema` validation and this goes
+// red, which is the moment to stop and think, not a moment to relax the
+// assertion.
+//
+// ## Why the probe runs a flow AND an object (#4716)
+//
+// The prose above was, until #4716, wider than the assertion under it: every
+// gate-running probe in this file wrote a `type: 'flow'` body and nothing else.
+// Measured on the #4716 cost round, and re-measured on this branch: the heavy
+// dep that actually threatens the boot path is `ajv` (+ `ajv-formats`), and
+// **the written TYPE is what reaches it, not the rule set.** A `json_schema`
+// validation is authored on an OBJECT (`objects[].validations[]`), so a flow
+// write can never make `validateRuleCompilability` compile anything, while an
+// object write hands it a schema on a plate. Widen that CLI-only rule onto
+// `object` — precisely what #4716's first bullet proposes — and a flow-only
+// probe stays green while the kernel starts paying for a JSON-Schema compiler
+// on every Studio field edit.
+//
+// So the object leg below is not a second copy of the flow leg. It is the leg
+// that can actually fail, and it lands BEFORE any widening deliberately: a
+// guard authored after the event it was meant to catch cannot be shown to work
+// (the #8824 tripwire logic). The `ajv loads on demand` test at the bottom is
+// what shows this one can — see its own note.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -29,17 +50,24 @@ import { describe, it, expect } from 'vitest';
 
 const srcDir = dirname(fileURLToPath(import.meta.url));
 const distDir = join(srcDir, '..', 'dist');
+const runtimeCjs = join(distDir, 'runtime.cjs');
+const runtimeEsm = join(distDir, 'runtime.js');
+const indexCjs = join(distDir, 'index.cjs');
 
 // `ajv` joined the list in #4762: the rule-compilability gate needs a real
 // JSON-Schema compiler to judge a `json_schema` validation rule, and that rule
 // is CLI-only (`surfaceReason: RUNTIME_OBJECT_WRITES_P2`). So the boot path must
 // not pay for it — not at import, and not while gating. Should that rule ever be
-// widened to `runtime-publish`, this assertion is what says so out loud.
+// widened to `runtime-publish`, this assertion is what says so out loud — which
+// it can only do over a body carrying such a rule, hence `GATED_OBJECT` (#4716).
 // `ajv-formats` joined in #5029 for the same gate and the same trigger: the gate
 // compiles in the runtime's ajv ENVIRONMENT, and that environment now registers
 // the formats plugin. It carries ajv in with it, so listing it here is not
 // belt-and-braces — it is the second door onto the same load.
 const LAZY_DEPS = ['typescript', 'sucrase', 'ajv', 'ajv-formats'];
+
+/** The two deps only an OBJECT write can reach today — the #4716 leg's subject. */
+const SCHEMA_DEPS = ['ajv', 'ajv-formats'];
 
 const depLoaded = (cache: Record<string, unknown> | undefined, dep: string) =>
   Object.keys(cache ?? {}).some((p) => p.split(/[/\\]/).join('/').includes(`/node_modules/${dep}/`));
@@ -58,13 +86,73 @@ const GATED_FLOW = {
 };
 const OBJECTS = [{ name: 'leave_request', fields: { owner: { type: 'text' } } }];
 
+/**
+ * The #4716 worked example: an OBJECT write that carries the exact artifact the
+ * heavy dep exists to judge — a `json_schema` validation whose `schema` ajv
+ * refuses to compile (`type` is not a JSON-Schema type, `required` is not an
+ * array).
+ *
+ * Two properties this body must keep, or the leg below stops meaning anything:
+ *
+ * 1. **It must trip a rule that gates `object` today**, so the dep probe is not
+ *    vacuously true over a gate that judged nothing. The `relatedListFilter`
+ *    compares a datetime against the bare date-range preset `last_30_days` in
+ *    an ORDERING position, which `validatePresetComparands` (gated on
+ *    `dashboard`/`view`/`object`/`page`/`flow`) refuses as
+ *    `filter-preset-comparand`. Everything else here is deliberately clean —
+ *    `sharingModel` is authored so `validateSecurityPosture`, the other rule
+ *    gating `object`, contributes nothing and the expected finding set stays
+ *    exactly the one this fixture is authored to produce.
+ * 2. **Its `schema` must stay one ajv rejects**, so the positive control at the
+ *    bottom keeps proving the require-cache probe can SEE the load. That test
+ *    fails loudly if this stops being true, rather than letting the negative
+ *    leg quietly degrade into "a body with nothing in it loads nothing".
+ */
+const GATED_OBJECT = {
+  name: 'leave_request',
+  label: 'Leave Request',
+  sharingModel: 'private',
+  fields: {
+    owner: { type: 'text' },
+    created_at: { type: 'datetime' },
+    approvals: {
+      type: 'lookup',
+      reference_to: 'leave_approval',
+      relatedList: true,
+      relatedListFilter: { created_at: { $gte: 'last_30_days' } },
+    },
+  },
+  validations: [
+    { name: 'payload_shape', type: 'json_schema', schema: { type: 'not_a_real_type', required: 'owner' } },
+  ],
+};
+
+/**
+ * The stored row this write updates. Same name, so the gate's replace-not-erase
+ * snapshot exercises the real update path (`buildRuntimeWriteSnapshots`) rather
+ * than an insert into an empty tenant, and clean, so nothing in the BASELINE
+ * pass can be mistaken for something this write added.
+ */
+const OBJECT_CONTEXT = [
+  { name: 'leave_request', sharingModel: 'private', fields: { owner: { type: 'text' } } },
+];
+
 // Same shape as lazy-deps.test.ts: a spawned child is the only place a native
 // require-cache probe means anything, because vitest inlines static imports
 // through its transform and they never reach that cache.
-const childBody = `
+//
+// `loaded` / `fail` are split out of `check` (#4716) because the positive
+// control at the bottom of this file needs the same probe over a DIFFERENT
+// question — "did it load?" rather than "did it stay clean?" — and a second
+// copy of the cache walk would be a second opinion about what "loaded" means.
+const probeHelpers = `
   const probe = require('node:module').createRequire(process.cwd() + '/probe.js');
   const loaded = (dep) => Object.keys(probe.cache ?? {}).some((p) => p.split(/[/\\\\]/).join('/').includes('/node_modules/' + dep + '/'));
   const fail = (msg) => { console.error(msg); process.exit(1); };
+`;
+
+const childBody = `
+  ${probeHelpers}
   const check = (mod) => {
     for (const dep of ${JSON.stringify(LAZY_DEPS)}) {
       if (loaded(dep)) fail(dep + ' was loaded merely by importing @objectstack/lint/runtime');
@@ -80,6 +168,25 @@ const childBody = `
     for (const dep of ${JSON.stringify(LAZY_DEPS)}) {
       if (loaded(dep)) fail(dep + ' was loaded by RUNNING the runtime publish gate');
     }
+
+    // #4716: the same claim over an OBJECT write carrying a \`json_schema\`
+    // validation — the only written type that can reach ajv today.
+    const objectResult = mod.runRuntimeAuthoringRules({
+      type: 'object',
+      item: ${JSON.stringify(GATED_OBJECT)},
+      context: { objects: ${JSON.stringify(OBJECT_CONTEXT)} },
+    });
+    if (objectResult.rulesRun.length === 0) {
+      fail('no rule gates an object write — the object leg would then assert nothing');
+    }
+    if (!objectResult.errors.some((f) => f.rule === 'filter-preset-comparand')) {
+      fail('the gate produced no finding on the object write — the probe below would be vacuously true');
+    }
+    for (const dep of ${JSON.stringify(LAZY_DEPS)}) {
+      if (loaded(dep)) {
+        fail(dep + ' was loaded by RUNNING the runtime publish gate on an OBJECT write carrying a json_schema validation');
+      }
+    }
     console.log('OK');
   };
 `;
@@ -88,12 +195,12 @@ const childBody = `
 const COLD_LOAD_TIMEOUT_MS = 30_000;
 
 describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
-  it.skipIf(!existsSync(join(distDir, 'runtime.cjs')))(
+  it.skipIf(!existsSync(runtimeCjs))(
     'built CJS runtime entry loads no heavy dep, at import OR while gating',
     () => {
       const out = execFileSync(
         process.execPath,
-        ['-e', `${childBody}; check(require(${JSON.stringify(join(distDir, 'runtime.cjs'))}));`],
+        ['-e', `${childBody}; check(require(${JSON.stringify(runtimeCjs)}));`],
         { encoding: 'utf8' },
       );
       expect(out).toContain('OK');
@@ -101,7 +208,7 @@ describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
     COLD_LOAD_TIMEOUT_MS,
   );
 
-  it.skipIf(!existsSync(join(distDir, 'runtime.js')))(
+  it.skipIf(!existsSync(runtimeEsm))(
     'built ESM runtime entry loads no heavy dep, at import OR while gating',
     () => {
       const out = execFileSync(
@@ -112,7 +219,7 @@ describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
           `import { createRequire } from 'node:module';
            const require = createRequire(process.cwd() + '/probe.js');
            ${childBody};
-           check(await import(${JSON.stringify(pathToFileURL(join(distDir, 'runtime.js')).href)}));`,
+           check(await import(${JSON.stringify(pathToFileURL(runtimeEsm).href)}));`,
         ],
         { encoding: 'utf8' },
       );
@@ -146,6 +253,92 @@ describe('@objectstack/lint/runtime (kernel boot-path contract, #4463)', () => {
       ).toBe(false);
     }
   }, COLD_LOAD_TIMEOUT_MS);
+
+  // #4716. The leg that can actually fail: `json_schema` validations are
+  // authored on objects, so this is the only written type whose snapshot can
+  // hand `validateRuleCompilability` a schema to compile. Runs in-process for
+  // the same reason the flow leg does, and BEFORE the positive control below
+  // (which is spawned precisely so it can never poison this cache).
+  it('gating an object that carries a json_schema validation loads no compiler, and still finds the defect', async () => {
+    const req = createRequire(import.meta.url);
+    const { runRuntimeAuthoringRules } = await import('./runtime.js');
+
+    const result = runRuntimeAuthoringRules({
+      type: 'object',
+      item: GATED_OBJECT,
+      context: { objects: OBJECT_CONTEXT },
+    });
+    // Two non-vacuity claims, because an object write can be empty in two ways:
+    // no rule gating the type at all, or a body no gating rule objects to.
+    expect(
+      result.rulesRun.length,
+      'no registry rule gates an object write — this leg would then prove nothing about the boot path',
+    ).toBeGreaterThan(0);
+    expect(result.errors.map((f) => f.rule)).toContain('filter-preset-comparand');
+
+    for (const dep of LAZY_DEPS) {
+      expect(
+        depLoaded(req.cache, dep),
+        `${dep} loaded while gating an OBJECT write carrying a json_schema validation. The metadata ` +
+          `write path is on the kernel boot path: Studio's designer reaches it on every field edit, and ` +
+          `it may not start paying for a JSON-Schema compiler. If a rule was just widened onto 'object', ` +
+          `this is the moment to stop and think (#4716) — not to relax the assertion`,
+      ).toBe(false);
+    }
+  }, COLD_LOAD_TIMEOUT_MS);
+
+  // #4716 — the probe's own non-vacuity, and the reason to trust the leg above.
+  //
+  // A require-cache walk that reports "clean" proves nothing until it has been
+  // shown to report "dirty" for the load it exists to catch. So: hand the SAME
+  // object body to `validateRuleCompilability` — the CLI-only rule that would
+  // run at the gate if #4716's first bullet widened it onto `object` — and
+  // demand that ajv and ajv-formats DO appear in the cache. Measured on this
+  // branch: 63 ajv modules + 3 ajv-formats modules, cold ~56 ms vs warm ~11 ms.
+  //
+  // Spawned, never in-process: this test deliberately loads the deps every
+  // other test here forbids, and the native require cache it writes into is the
+  // very one the in-process leg reads.
+  it.skipIf(!existsSync(indexCjs) || !existsSync(runtimeCjs))(
+    'the same object body DOES load ajv when the compilability rule judges it (probe is not vacuous)',
+    () => {
+      const out = execFileSync(
+        process.execPath,
+        [
+          '-e',
+          `${probeHelpers}
+           const rt = require(${JSON.stringify(runtimeCjs)});
+           const full = require(${JSON.stringify(indexCjs)});
+           for (const dep of ${JSON.stringify(SCHEMA_DEPS)}) {
+             if (loaded(dep)) fail(dep + ' was loaded merely by importing the full @objectstack/lint barrel');
+           }
+           const snapshots = rt.buildRuntimeWriteSnapshots({
+             type: 'object',
+             item: ${JSON.stringify(GATED_OBJECT)},
+             context: { objects: ${JSON.stringify(OBJECT_CONTEXT)} },
+           });
+           if (!snapshots) fail('the gate builds no snapshot for an object write — the leg above is then untested');
+           const findings = full.validateRuleCompilability(snapshots.candidate);
+           if (!findings.some((f) => f.rule === 'validation-rule-json-schema-uncompilable')) {
+             fail('GATED_OBJECT no longer carries a schema ajv refuses to compile, so the negative leg ' +
+                  'above has degraded into "a body with nothing in it loads nothing". Restore a schema ' +
+                  'ajv rejects rather than deleting this test.');
+           }
+           for (const dep of ${JSON.stringify(SCHEMA_DEPS)}) {
+             if (!loaded(dep)) {
+               fail(dep + ' did NOT load even though the compilability rule just compiled this body. The ' +
+                    'require-cache probe cannot see the load it exists to catch, so every clean result in ' +
+                    'this file is vacuous — fix the probe, do not trust the greens.');
+             }
+           }
+           console.log('OK');`,
+        ],
+        { encoding: 'utf8' },
+      );
+      expect(out).toContain('OK');
+    },
+    COLD_LOAD_TIMEOUT_MS,
+  );
 
   it('the runtime entry re-exports the gate and nothing that carries a parser', async () => {
     const mod = await import('./runtime.js');


### PR DESCRIPTION
Part of #4716 — the one ruled **prerequisite**, not the card. #4716's own acceptance criterion (the false-positive budget against a stored `sys_metadata` replay corpus) is untouched and stays the maintainer's; nothing here approaches the gate's behaviour.

## The defect

`packages/lint/src/runtime-lazy-deps.test.ts` guards the kernel boot path. Its docblock promised:

> widen `runtimeTypes` to a type whose snapshot carries a hook body or a react page and this goes red

but **every gate-running probe in it wrote a `type: 'flow'` body and nothing else**. The guard was narrower than its own prose, and the gap is not cosmetic: a `json_schema` validation is authored on an **object** (`objects[].validations[]`), so a flow write can never make `validateRuleCompilability` compile anything, while an object write hands it a schema on a plate. **The written TYPE reaches the heavy dep, not the rule set.**

Widen that CLI-only rule onto `object` — precisely what #4716's first bullet proposes — and the guard stays green while the kernel boot path starts paying for a JSON-Schema compiler on every Studio field edit.

Landing **before** any widening is the ruling, not a preference: a guard authored after the event it was meant to catch cannot be shown to work.

## Measured on this branch (built worktree, spawned-process `require.cache` walk)

| probe | ajv | ajv-formats |
|---|---|---|
| import `dist/runtime.cjs` | – | – |
| import full `dist/index.cjs` barrel | – | – |
| RUN today's gate, **flow** write | – | – |
| RUN today's gate, **object** write carrying a `json_schema` validation | – | – |
| RUN `validateRuleCompilability` over that same object body | **63 modules** | **3 modules** |

Non-vacuity of the probe itself: that last row returns exactly **1 finding**, `validation-rule-json-schema-uncompilable`; cold **56.4 ms** vs warm **11.5 ms**. Re-derived registry facts: `runtimeGatedTypes()` returns 8 types (`book, dashboard, flow, object, page, permission, seed, view`), **11 of 41** rules declare `runtime-publish`, and the two gating `object` today are `validatePresetComparands` + `validateSecurityPosture`.

## The change

One test file. Adds:

1. an **object-write leg** — in-process and in both spawned dist entries (CJS + ESM) — over a body carrying an uncompilable `json_schema` validation. Non-vacuous twice over: it asserts a rule actually gates `object` (`rulesRun.length > 0`) and that the gate produced the finding the fixture is authored to produce (`filter-preset-comparand`, from the `relatedListFilter` comparing a datetime against the bare preset `last_30_days`). `sharingModel` is authored so the other object-gating rule contributes nothing and the expected finding set stays exactly the intended one;
2. a spawned **positive control** — the same object body handed to `validateRuleCompilability` must load ajv + ajv-formats. A require-cache walk reporting "clean" proves nothing until it has been shown to report "dirty" for the load it exists to catch. It also fails loudly if the fixture's schema ever stops being one ajv rejects, rather than letting the negative leg degrade into "a body with nothing in it loads nothing";
3. the docblock corrected to match what the assertions now say.

`loaded` / `fail` are lifted out of `check` so the positive control uses the *same* cache walk rather than a second opinion about what "loaded" means.

## Reverse verification — the guard was falsified, then shown to fire

Ablation: `validateRuleCompilability` temporarily flipped to `surfaces: CLI_AND_RUNTIME, runtimeTypes: ['object']` and the package rebuilt — i.e. exactly the widening #4716's first bullet proposes.

- **Old guard (`origin/main`'s file) on that tree: 4/4 GREEN**, while ajv was demonstrably loading onto the kernel boot path. That is the blind spot, measured rather than argued.
- **New guard on the same tree: 3 of 6 legs RED** — spawned CJS, spawned ESM, and the in-process object leg, each naming ajv. The flow leg stayed **green**, which is precisely why flow-only was blind.

Ablation restored and the artifact re-proved clean: after rebuild, `runtimeAuthoringRulesFor('object')` reports `["validatePresetComparands","validateSecurityPosture"]` — the mutation is out of `dist/`, not merely out of `src/`. Working tree byte-identical to the commit (`git diff HEAD` empty).

## Scope

Test-only. **No rule, no `AUTHORING_RULES` entry, no `runtimeTypes`, no gate dispatch, and nothing that changes what the gate accepts or refuses.** No `TEST_DEBT` entry raised. No changeset: the PR releases nothing, so it takes `skip-changeset` by the workflow's own prescription.

## Verification — all at `0f405abc1` (the head commit)

```
pnpm --filter @objectstack/lint test          73 files, 2067 tests passed
pnpm --filter @objectstack/lint typecheck     tsc --noEmit, clean
vitest run src/runtime-lazy-deps.test.ts      6 passed (was 4)
```

Gate union re-derived at the final path set via `node scripts/pm/dispatch-gates.mjs`, all green: `check:nul-bytes`, `check:cross-package-test-inputs`, `check:engine-double-contract` (315 pinned / 133 debt / 2 exempt, unchanged), `check:where-matcher` (251 matchers, none new), `check:query-options-erasure` (baseline unchanged, no files added), `check:type-check-coverage`, `scripts/docs-audit/check-affected-docs.mjs`. The `check:type-check-debt` ratchet's subject was checked directly by reproducing its test-inclusive project for `@objectstack/lint`: the edited file contributes **0** tsc diagnostics, so the ledgered count cannot drift up from this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_