### PR TITLE
docs: name the 16k measurement's host "the bundled example CRM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ The reason this works is the same reason TypeScript was the right host language:
 **an agent's errors become located, corrective text it can read and fix itself**,
 in seconds — instead of a silent runtime failure nobody traces back.
 
-The other half is size. The CRM in this repo — [`examples/app-crm`](./examples/app-crm):
+The other half is size. The bundled example CRM — [`examples/app-crm`](./examples/app-crm):
 six objects, views, a dashboard, a lead-conversion flow, permission sets, actions,
 translations — is **31 files, 1,792 lines, roughly 16k tokens**. That's the whole
-business system, in about 8% of a 200k-token context window. Count it yourself:
+example app, in about 8% of a 200k-token context window. Count it yourself:
 
 ```bash
 find examples/app-crm/src -name '*.ts' -not -name '*.test.ts' | xargs cat | wc -l

--- a/content/docs/concepts/metadata-driven.mdx
+++ b/content/docs/concepts/metadata-driven.mdx
@@ -211,7 +211,7 @@ React           Flutter
 
 A simple CRUD feature that takes ~300 lines of hand-written code is ~30 lines of
 metadata. But per-feature ratios are the least interesting part. Here is the
-measurement that matters — the CRM bundled in this repo
+measurement that matters — the bundled example CRM
 ([`examples/app-crm`](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm):
 six objects, views, a dashboard, a lead-conversion flow, permission sets,
 actions, translations):
@@ -222,7 +222,7 @@ actions, translations):
 | Lines | 1,792 |
 | Approximate tokens | ~16,000 |
 
-That's the **whole business system** — about 8% of a 200k-token context window.
+That's the **whole example app** — about 8% of a 200k-token context window.
 Count it yourself:
 
 ```bash

--- a/content/docs/getting-started/how-ai-development-works.mdx
+++ b/content/docs/getting-started/how-ai-development-works.mdx
@@ -26,10 +26,10 @@ build the thing I actually meant?*
 ## Why it's fast
 
 A typical enterprise app spreads CRUD, forms, queries, permissions, and API glue
-across dozens of files. ObjectStack keeps only the part that's yours: the CRM
-bundled in this repo — six objects, views, a dashboard, a lead-conversion flow,
+across dozens of files. ObjectStack keeps only the part that's yours: the bundled
+example CRM — six objects, views, a dashboard, a lead-conversion flow,
 permission sets, actions, translations — is **1,792 lines across 31 files, about
-16k tokens**. That's the entire business system, not a module of it.
+16k tokens**. That's the whole example app, not a module of it.
 
 The point isn't lines of code; it's **fit in an agent's context window.** When the
 entire business system is small, typed, and declarative, an agent can load it


### PR DESCRIPTION
Fixes #9293

Three passages measure `examples/app-crm` at ~16k tokens and called their subject "the whole business system" / "the entire business system". Next to the new tagline — "a complete CRM in under 150k tokens" — two different numbers were claiming the same host noun on the first screen, and 16k also collided with the README's own "business logic alone ... under 100k tokens" line.

This renames the host noun only. After it, each number owns exactly one host: **16k = the bundled example CRM · 150k = a complete CRM · 100k = the business logic alone.**

## The three positions (host noun before to after)

| File | Before | After |
| :--- | :--- | :--- |
| `README.md` | "The CRM in this repo — ... That's the whole business system, in about 8% of a 200k-token context window." | "The bundled example CRM — ... That's the whole example app, in about 8% of a 200k-token context window." |
| `content/docs/concepts/metadata-driven.mdx` | "the CRM bundled in this repo" / "That's the **whole business system** — about 8% of a 200k-token context window." | "the bundled example CRM" / "That's the **whole example app** — about 8% of a 200k-token context window." |
| `content/docs/getting-started/how-ai-development-works.mdx` | "the CRM bundled in this repo — ... That's the entire business system, not a module of it." | "the bundled example CRM — ... That's the whole example app, not a module of it." |

The "8% of a 200k-token context window" sentence is the second half of the same measurement (8% is computed from 16k), so its host was renamed in step with the table above, per the card.

## What was deliberately not touched

- **Both numbers stand unchanged**: 31 files / 1,792 lines / roughly 16k tokens / ~16,000 / 8% / 200k. The diff contains no numeric edit.
- **The tagline copy is not edited** — the finalized README hero and the 150k / 100k split lines are untouched.
- **The reproducible command stays verbatim**: `find examples/app-crm/src -name '*.ts' -not -name '*.test.ts' | xargs cat | wc -l`.
- `content/docs/releases/**` untouched. No contract surface, no code, docs prose only.

Note on the follow-on paragraphs: "when the entire business system is small, typed, and declarative ..." is a general claim with no number attached to it, so it keeps its wording — the rename is scoped to the hosts the 16k figure actually pins.

## Verification

Docs-only, so no package build or test surface is involved. Gate families re-derived against the real changed paths with `node scripts/pm/dispatch-gates.mjs README.md content/docs/concepts/metadata-driven.mdx content/docs/getting-started/how-ai-development-works.mdx` (7 families) and run as a union at the final commit `7dbab2bc3`:

```
HEAD=7dbab2bc3
PASS check:nul-bytes
PASS check:docs-audit-scope
PASS check:docs-redirects
PASS check:role-word
PASS spec/check:variant-docs
PASS spec/check:empty-state
PASS spec/check:liveness
PASS spec/check:strictness-ledger
HEAD_AFTER=7dbab2bc3
```

`check:nul-bytes` was added because any edit implicates it; a `grep -naP` control-character self-scan of the three edited files also comes back empty.

No changeset: this PR releases nothing (root README plus two docs pages), matching the precedent of the tagline PR #9242, which shipped README + docs with no changeset. `skip-changeset` applied.

_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_017TNzEetykdh7ceZGwuAPLq)_