### PR TITLE
feat(spec): refuse bound external.credentialsRef with a username-less composed mongo config at publish (#9147)

### DIFF
--- a/.changeset/datasource-credentialsref-mongo-composed-no-username-refused.md
+++ b/.changeset/datasource-credentialsref-mongo-composed-no-username-refused.md
@@ -1,0 +1,87 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): refuse the contradictory pair "`external.credentialsRef` bound + a composed mongo config naming no `username`" at publish (#9147)
+
+**BREAKING** accept-set narrowing, landing after the v17.0.0 cut (the lockstep
+launch-window convention ships it as `minor`, like the sibling refusals #8337,
+#9040 and #9041; the migration prescription is registered under protocol major
+18, where `os migrate meta` users will look).
+
+The COMPOSED-branch twin of #9041, and the last unserved corner of the "absence
+must be loud" half of the #8696 family. #9041 refused a bound
+`external.credentialsRef` beside a mongo `config.url` whose userinfo names no
+user; its fences deliberately scoped that to the URL branch, leaving the same
+defect one branch over still accepted:
+
+```yaml
+driver: mongodb
+config: { database: events, host: mongo.internal }
+external: { credentialsRef: sys_secret:01J9ZK4T2N }
+```
+
+With no `config.url` the driver factory COMPOSES the connection URI from the
+discrete fields, and the bound secret has exactly one route into it — the
+userinfo written beside a username (`buildMongoUrl`: `const auth = user ? … :
+''`). A falsy `username` closes that route, and this branch has no second one:
+`buildMongoAuth` returns early when there is no `url`, because the composed
+branch injects THROUGH the URI it builds rather than beside it. So the artefact
+above parsed green, connected **anonymously**, and told the operator nothing —
+byte for byte the defect #9041 closed, one branch over. Both branches were
+measured to agree on this input before either was refused, so this inherits
+#9041's ruling rather than re-opening it.
+
+The refusal is a one-condition widening of the same datasource-level
+refinement (the one door that sees both halves at once), pathed at
+`config.username`, and it names BOTH valid authoring fixes without prescribing
+either. Its message is deliberately **not** #9041's: there `config.url`
+supersedes the discrete `username` so the only fix is the URL's userinfo, while
+here `config.username` is the live field — a refusal naming a remedy that does
+not apply is worse than no refusal.
+
+**Scope fences, each measured**: mongodb arm only, legacy `driver: 'mongo'`
+rows judged identically via `resolveDriverId` (the postgres arm is not widened
+to — #8873 measured `pg` receiving the bound password regardless of the DSN
+naming a user); "names no username" is `undefined` **or** `''`, the two
+spellings that are falsy at the composer's `user ?` test and therefore drop the
+secret identically (note the deliberate asymmetry with #9041's present-but-empty
+userinfo carve-out: there `MongoClient` itself throws, so the shape is already
+loud, while `username: ''` here connects — silently); a non-string `username` is
+the driver-config gate's finding, not this one; an empty-string `credentialsRef`
+is not a binding (mirrors the connect path's truthy check); a composed config
+that names a user is untouched — that is the branch #8696 already works on.
+
+Also corrected while redrawing this boundary: **an empty `config.url` is the
+composed branch, not the URL branch.** `buildMongoUrl` opens `if (explicit)
+return explicit;`, so `url: ''` falls through and composes from the discrete
+fields — but #9041's arm judged it as a URL "naming no user" and refused it even
+with a live discrete `username`, i.e. rejected at publish a datasource that
+connects authenticated at runtime. Both arms now split on the factory's own
+branch test, so each judges exactly the branch that will run.
+
+## FROM → TO
+
+```yaml
+# before — parsed green; the binding was a silent no-op and the datasource
+# connected anonymously with the bound secret unused
+driver: mongodb
+config: { database: events, host: mongo.internal }
+external: { credentialsRef: sys_secret:01J9ZK4T2N }
+
+# after (authenticated intent) — name the user; the bound secret is
+# interpolated beside it into the composed URI at connect (#8696)
+driver: mongodb
+config: { database: events, host: mongo.internal, username: svc }
+external: { credentialsRef: sys_secret:01J9ZK4T2N }
+
+# after (anonymous intent) — drop the binding that could never land
+driver: mongodb
+config: { database: events, host: mongo.internal }
+```
+
+There is deliberately no automatic rewrite: the two fixes are contradictory
+intents — authenticate (name the user) versus anonymous (drop the binding) —
+and choosing between them requires knowing what the datasource is for.
+
+<!-- adr-0087: registered datasource-credentialsref-mongo-composed-no-username-refused -->

--- a/packages/services/service-datasource/src/__tests__/bound-secret-dsn-branches.test.ts
+++ b/packages/services/service-datasource/src/__tests__/bound-secret-dsn-branches.test.ts
@@ -388,4 +388,33 @@ describe('#8696 — mongodb: a bound secret reaches the client on the DSN branch
       secret: BOUND_SECRET,
     })).toMatchObject({ username: 'svc', password: BOUND_SECRET });
   });
+
+  it.each([
+    ['no `username` key at all', undefined],
+    ['an empty-string `username`', ''],
+  ])('drops the bound secret on the composed branch with %s — the measured no-op #9147 refuses at publish', async (_label, username) => {
+    // The connect-path measurement the #9147 publish refusal rests on, pinned
+    // rather than described. `buildMongoUrl` composes the URI and the secret's
+    // ONLY route into it is the userinfo written beside a username
+    // (`const auth = user ? … : ''`); `buildMongoAuth` — the DSN branch's
+    // route — returns early on `!url`. So a falsy `username` leaves the bound
+    // secret with nowhere to go, and the datasource connects ANONYMOUSLY with
+    // the operator told nothing.
+    //
+    // Both spellings are pinned because both are authorable and both are
+    // silent: that is exactly why the refusal's fence is the falsy set rather
+    // than key-absence. Left unpinned, a later "improvement" that injected a
+    // fabricated empty username here would make the publish refusal wrong with
+    // nothing going red — and it is measurably the wrong direction anyway (the
+    // sibling pin above: `{username:''}` turns an anonymous connection that
+    // works into a guaranteed handshake failure).
+    const config: Record<string, unknown> = { host: 'db.internal', port: 27017, database: 'events' };
+    if (username !== undefined) config.username = username;
+
+    expect(await mongoCredentials({ name: 'composed-anon', config, secret: BOUND_SECRET }))
+      .toBeUndefined();
+    // And the composed URI itself carries no userinfo to have carried it.
+    expect(await mongoUrl({ name: 'composed-anon', config, secret: BOUND_SECRET }))
+      .toBe('mongodb://db.internal:27017/events');
+  });
 });

--- a/packages/spec/src/data/datasource.zod.ts
+++ b/packages/spec/src/data/datasource.zod.ts
@@ -365,9 +365,11 @@ export type ExternalDatasourceSettingsParsed = z.infer<typeof ExternalDatasource
  *  - **"bound" mirrors the connect path exactly**: `DatasourceConnectionService`
  *    resolves the ref under `if (credentialsRef)` — a truthy check — so an
  *    empty-string ref is not a binding there and is not one here.
- *  - The COMPOSED branch (no `url`; discrete `host`/`username` fields) is out
- *    of scope by the card's own fences: with no `url` the `username` field is
- *    live and the factory interpolates the secret into the URI it builds.
+ *  - The COMPOSED branch (no `url`) is judged by its own twin refusal since
+ *    #9147 — see {@link CREDENTIALS_REF_MONGO_NO_USERNAME_REFUSED}. It is a
+ *    separate message because the remedy differs: there the discrete
+ *    `username` field is live, so the fix is `config.username`, not the URL's
+ *    userinfo. #9041 fenced it out; #9147 widened the same refinement into it.
  */
 const CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED =
   'this mongo `config.url` names no user in its userinfo while `external.credentialsRef` binds '
@@ -383,6 +385,85 @@ const CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED =
   + 'injected at connect (#8696) — or, if the datasource is genuinely meant to connect '
   + 'unauthenticated, remove the `external.credentialsRef` binding. Runtime-environment DSNs '
   + '(`OS_DATABASE_URL` and friends) do not pass through this publish door and are unaffected.';
+
+/**
+ * The COMPOSED-branch twin of the refusal above (#9147): `external.credentialsRef`
+ * bound while the mongo `config` authors no `url` AND names no `username`.
+ *
+ * Same defect, one branch over, and the branches were measured to agree on this
+ * input before either was refused — which is why this inherits #9041's ruling
+ * rather than re-opening it (the standing meta-rule: a sibling spelling of an
+ * already-ruled silent discard defaults into the existing refusal set).
+ *
+ * Why the pair cannot work as written, measured against
+ * `default-datasource-driver-factory.ts` on `origin/main` @ `b0fa4fc1a`:
+ *
+ *  - with no `url`, `buildMongoUrl` COMPOSES the URI from the discrete fields,
+ *    and the bound secret has exactly one route into it —
+ *    `const auth = user ? \`${user}:${password}@\` : ''`. A falsy `username`
+ *    closes that route: the composed URI is `mongodb://host:port/db`, no
+ *    userinfo, and `spec.secret` is read into a string nothing uses;
+ *  - the other route is shut on this branch by construction —
+ *    `buildMongoAuth` opens with `if (!url) return undefined`, because the
+ *    composed branch injects through the URI it builds rather than beside it.
+ *
+ * So the binding is a silent no-op: the datasource connects anonymously and the
+ * operator is told nothing. There is nothing to fabricate here either — a
+ * MongoDB handshake cannot authenticate from a password alone, which is the
+ * same measured asymmetry that made the URL branch's refusal the right answer
+ * rather than an unconditional injection.
+ *
+ * ## Why a SEPARATE message, and not #9041's
+ *
+ * The remedy differs, and a refusal naming a remedy that does not apply is
+ * worse than no refusal — the failure mode this module's own history section
+ * documents at length (the pre-#4410 `belongsInConfig` line, which sent an
+ * author who had made a recoverable mistake to a slot where the same mistake
+ * was silent again). On the URL branch `MongoConfigSchema.url` supersedes the
+ * discrete `username`, so the only fix is the URL's userinfo. Here `url` is
+ * absent and `config.username` is the live field, so `config.username` is the
+ * fix and userinfo is not even authorable.
+ *
+ * ## Scope fences
+ *
+ *  - **mongo arm ONLY**, judged through {@link resolveDriverId} — identical to
+ *    #9041's fence, so a stored legacy `driver: 'mongo'` row is judged the
+ *    same. The postgres arm is NOT widened to (#8873 measured `pg` receiving
+ *    the bound password regardless of the DSN naming a user), and neither is
+ *    any other driver.
+ *  - **"names no username" is `undefined` or `''`** — the two spellings that
+ *    are falsy at `buildMongoUrl`'s `user ?` test, which is what actually
+ *    decides whether the secret is used. `''` is included deliberately and it
+ *    is NOT a widening past the measured no-op: `username: ''` composes the
+ *    same userinfo-free URI and drops the same secret (measured). Excluding it
+ *    would leave this refusal prescribing `config.username` while the platform
+ *    still accepted the one spelling of `config.username` that keeps the
+ *    binding silent — the prescription must land somewhere enforced. Note the
+ *    deliberate asymmetry with #9041's fence, which DOES exclude its
+ *    present-but-empty forms: there `MongoClient` itself throws on them
+ *    (`URI contained empty userinfo section`), so only the `undefined` case is
+ *    silent. Here nothing throws — `username: ''` connects, anonymously — so
+ *    the silent set is the falsy set. Each fence follows the measurement on
+ *    its own branch rather than the other branch's shape.
+ *  - **A non-string `username` is the config gate's finding, not this one** —
+ *    same posture as #9041 takes toward a non-string `url`.
+ *  - **"bound" mirrors the connect path's truthy check**, exactly as above: an
+ *    empty-string `credentialsRef` is not a binding.
+ */
+const CREDENTIALS_REF_MONGO_NO_USERNAME_REFUSED =
+  'this mongo `config` authors no `url` and names no `username`, while `external.credentialsRef` '
+  + 'binds a secret — a pair that cannot work as written (#9147). With no `url` the connection '
+  + 'URI is COMPOSED from the discrete fields, and the bound secret has exactly one route into '
+  + 'it: the userinfo the composer writes beside a username. With `username` absent (or empty) '
+  + 'no userinfo is written at all, so the bound secret is never used — the binding is a silent '
+  + 'no-op: the datasource connects anonymously and the operator is told nothing. (There is no '
+  + 'username to fabricate: a MongoDB handshake cannot authenticate from a password alone.) Two '
+  + 'authoring fixes are valid, depending on what this datasource is meant to do: add `username` '
+  + 'to `config` — the discrete field is live on this branch, and the bound secret is '
+  + 'interpolated beside it at connect (#8696) — or, if the datasource is genuinely meant to '
+  + 'connect unauthenticated, remove the `external.credentialsRef` binding. (Replacing the '
+  + 'discrete fields with a `config.url` that names a user is a third valid shape; it is judged '
+  + 'by the URL-branch refusal, not by this one.)';
 
 /**
  * Replay a driver-config parse onto the datasource's own issue list (#4410).
@@ -608,20 +689,44 @@ export const DatasourceSchema = lazySchema(() => strictObject(
   // author's trust on a slot that cannot pay it back.
   reportDriverConfigIssues(ctx, ds.driver, ds.config, ['config']);
 
-  // #9041 — see CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED. This cannot live in
+  // #9041 (url branch) + #9147 (composed branch) — see
+  // CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED and
+  // CREDENTIALS_REF_MONGO_NO_USERNAME_REFUSED. Neither can live in
   // `MongoConfigSchema` (a config-level refinement sees only `config`;
-  // `credentialsRef` sits on the datasource), so it runs here, where both
-  // halves are visible at once. It composes independently with the config
+  // `credentialsRef` sits on the datasource), so both run here, where both
+  // halves are visible at once. They compose independently with the config
   // gate above: a config also violating #8082/#8336/#9040 reports those
   // issues too, each at its own path.
+  //
+  // The two arms split on the connect path's OWN branch test, not on key
+  // presence: `buildMongoUrl` opens `if (explicit) return explicit;`, so a
+  // TRUTHY `config.url` is the DSN branch and anything falsy composes from the
+  // discrete fields. Splitting any other way misjudges `url: ''` — before
+  // #9147 it took the url arm and was refused for "naming no user" even with a
+  // live discrete `username`, i.e. a configuration that connects
+  // authenticated today was rejected at publish. Each arm now judges exactly
+  // the branch that will run.
   if (resolveDriverId(ds.driver) === 'mongodb' && ds.external?.credentialsRef) {
     const url = ds.config?.['url'];
-    if (typeof url === 'string' && urlUserinfoUsername(url) === undefined) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['config', 'url'],
-        message: CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED,
-      });
+    if (typeof url === 'string' && url !== '') {
+      if (urlUserinfoUsername(url) === undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['config', 'url'],
+          message: CREDENTIALS_REF_MONGO_URL_NO_USER_REFUSED,
+        });
+      }
+    } else if (url === undefined || url === '') {
+      // A non-string `url` (`42`, `null`) reaches neither arm: it has no
+      // branch to predict and the config gate already reports the type error.
+      const username = ds.config?.['username'];
+      if (username === undefined || username === '') {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['config', 'username'],
+          message: CREDENTIALS_REF_MONGO_NO_USERNAME_REFUSED,
+        });
+      }
     }
   }
 

--- a/packages/spec/src/data/driver/driver-credential-refusal.test.ts
+++ b/packages/spec/src/data/driver/driver-credential-refusal.test.ts
@@ -808,17 +808,30 @@ describe('datasource — bound credentialsRef + user-less mongo url refused (#90
     }
   });
 
-  it('the COMPOSED branch (no `url`) is out of scope — discrete fields + binding stay accepted', () => {
+  it('the COMPOSED branch is #9147\'s arm, never this one — a composed config reports neither #9041 nor a `config.url` path', () => {
     // With no `url` the discrete `username` is live and the factory
     // interpolates the bound secret into the URI it composes (#8696's other
-    // branch), so there is no contradictory pair to refuse.
-    const result = parse({
+    // branch), so a composed config that NAMES a user has no contradictory
+    // pair at all …
+    const named = parse({
       name: 'events',
       driver: 'mongodb',
       config: { database: 'events', host: 'mongo.internal', username: 'svc' },
       external: { ...BOUND },
     });
-    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+    expect(named.success, JSON.stringify(named.error?.issues)).toBe(true);
+    // … and one that does not is judged by #9147's own message, with #9041's
+    // URL prescription (which would name a fix this branch cannot take) kept
+    // out. The two arms partition the input; they never both fire.
+    const unnamed = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { database: 'events', host: 'mongo.internal' },
+      external: { ...BOUND },
+    });
+    expect(unnamed.success).toBe(false);
+    expect(unnamed.error!.issues.some((i) => i.message.includes('#9041'))).toBe(false);
+    expect(unnamed.error!.issues.some((i) => i.path.join('.') === 'config.url')).toBe(false);
   });
 
   it('an empty-string `credentialsRef` is not a binding — mirrors the connect path\'s truthy check', () => {
@@ -879,6 +892,22 @@ describe('datasource — bound credentialsRef + user-less mongo url refused (#90
     expect(result.error!.issues.some((i) => i.message.includes('#9040'))).toBe(true);
   });
 
+  it('an empty `config.url` is the COMPOSED branch, not this one — a live discrete username is not refused', () => {
+    // The over-refusal #9147 corrected while redrawing this boundary. At
+    // connect `buildMongoUrl` opens `if (explicit) return explicit;`, so an
+    // empty `url` falls through and composes from the discrete fields — where
+    // `username: 'svc'` makes the bound secret live. Judging it as a "url
+    // naming no user" rejected, at publish, a datasource that connects
+    // authenticated. The arms split on truthiness, as the factory does.
+    const result = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { url: '', database: 'events', host: 'mongo.internal', username: 'svc' },
+      external: { ...BOUND },
+    });
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+  });
+
   it('composes with the #8082 userinfo refusal the other way: a password-bearing URL has a USER', () => {
     // `user:password@host` violates #8082, but its userinfo NAMES a user — so
     // this refusal correctly stays out and the author gets exactly the #8082
@@ -892,5 +921,205 @@ describe('datasource — bound credentialsRef + user-less mongo url refused (#90
     expect(result.success).toBe(false);
     expect(result.error!.issues.some((i) => i.message.includes('#8082'))).toBe(true);
     expect(result.error!.issues.some((i) => i.message.includes('#9041'))).toBe(false);
+  });
+});
+
+/**
+ * The COMPOSED-branch twin of the pair above (#9147) — `external.credentialsRef`
+ * bound while the mongo `config` authors no `url` and names no `username`.
+ *
+ * Same silent discard, one branch over, and the branches were measured to agree
+ * on this input before either was refused — so this inherits #9041's ruling
+ * rather than re-opening it. What does NOT carry over is the remedy: with no
+ * `url` the discrete `config.username` is the live field, so the fix is
+ * `config.username`, and #9041's "add the username to the URL's userinfo" would
+ * name a fix this branch cannot take.
+ *
+ * The mechanism, measured against `default-datasource-driver-factory.ts`: with
+ * no `url`, `buildMongoUrl` composes the URI and the bound secret's only route
+ * into it is the userinfo written beside a username (`const auth = user ? … :
+ * ''`); `buildMongoAuth`, the DSN branch's route, returns early on `!url`. So a
+ * falsy `username` leaves the secret with nowhere to go.
+ *
+ * Envelope note (same as the #8082/#9040/#9041 pins above): the zod issue's
+ * `code` and its pathed location are the whole envelope at this layer — every
+ * schema refusal is wrapped uniformly by the publish door (metadata-protocol's
+ * `422 INVALID_METADATA`, whose `issues[]` carry these codes verbatim).
+ */
+describe('datasource — bound credentialsRef + composed mongo config naming no username refused (#9147)', () => {
+  const BOUND = { credentialsRef: 'sys_secret:01J9ZK4T2N' } as const;
+  /** The composed branch's minimum viable target — no `url`, so the URI is built. */
+  const COMPOSED = { database: 'events', host: 'mongo.internal' } as const;
+  const parse = (ds: Record<string, unknown>) => DatasourceSchema.safeParse(ds);
+  const refusalOf = (ds: Record<string, unknown>) => {
+    const result = parse(ds);
+    if (result.success) return undefined;
+    return result.error.issues.find(
+      (i) => i.path.join('.') === 'config.username' && i.message.includes('#9147'),
+    );
+  };
+
+  // ── the newly-refused conjunction ─────────────────────────────────────────
+
+  it('refuses the pair, pathed at `config.username`, naming BOTH fixes and prescribing neither', () => {
+    const issue = refusalOf({
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED },
+      external: { ...BOUND },
+    });
+    expect(issue, 'refusal must be pathed at `config.username`').toBeDefined();
+    expect(issue!.code).toBe('custom');
+    // Both valid authoring fixes named, neither prescribed.
+    expect(issue!.message).toContain('add `username` to `config`');
+    expect(issue!.message).toContain('remove the `external.credentialsRef` binding');
+    // And the mechanism, so the author is told WHY the pair cannot work.
+    expect(issue!.message).toContain('silent no-op');
+    // The remedy that does NOT apply here must not be copied in: on this branch
+    // there is no URL to put a userinfo in, and a refusal naming an
+    // inapplicable fix is worse than no refusal (the pre-#4410
+    // `belongsInConfig` defect, documented in datasource.zod.ts).
+    expect(issue!.message).not.toContain('mongodb://user@host/db');
+    expect(issue!.message).not.toContain('add the username to the URL');
+  });
+
+  it('judges a legacy `driver: mongo` row identically (alias-resolved, like #9041 and the #9040 read path)', () => {
+    expect(refusalOf({
+      name: 'events',
+      driver: 'mongo',
+      config: { ...COMPOSED },
+      external: { ...BOUND },
+    })).toBeDefined();
+  });
+
+  it('an EMPTY-STRING `username` is refused too — it is the same silent no-op, and the prescription must land somewhere enforced', () => {
+    // Deliberate asymmetry with #9041's present-but-empty carve-out: there
+    // `MongoClient` throws on the empty userinfo forms, so the shape is
+    // already loud. Here nothing throws — `username: ''` is falsy at
+    // `buildMongoUrl`'s `user ?` test, composes the same userinfo-free URI and
+    // connects anonymously. Accepting it would leave this refusal prescribing
+    // `config.username` while the platform still accepted the one spelling of
+    // `config.username` that keeps the binding silent.
+    expect(refusalOf({
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED, username: '' },
+      external: { ...BOUND },
+    })).toBeDefined();
+  });
+
+  it('an empty `config.url` routes HERE, not to #9041 — the arms split on the factory\'s own branch test', () => {
+    const result = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { url: '', ...COMPOSED },
+      external: { ...BOUND },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.some((i) => i.message.includes('#9147'))).toBe(true);
+    expect(result.error!.issues.some((i) => i.message.includes('#9041'))).toBe(false);
+  });
+
+  // ── the fence: each single condition absent is still ACCEPTED ─────────────
+
+  it('near-miss ① `url` present (naming a user) — the discrete `username` is superseded, nothing to refuse', () => {
+    const ds = {
+      name: 'events',
+      driver: 'mongodb',
+      config: { url: 'mongodb://app@db.internal:27017/app' },
+      external: { ...BOUND },
+    };
+    const result = parse(ds);
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+    // Byte-identical across parses — this refusal changed nothing on this path.
+    expect(DatasourceSchema.parse(ds)).toEqual(result.data);
+  });
+
+  it('near-miss ① `url` present naming NO user — exactly ONE refusal fires, and it is #9041\'s', () => {
+    // The arms partition the input: the author must never receive two messages
+    // prescribing different fixes for one datasource.
+    const result = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { url: 'mongodb://db.internal:27017/app' },
+      external: { ...BOUND },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error!.issues.some((i) => i.message.includes('#9041'))).toBe(true);
+    expect(result.error!.issues.some((i) => i.message.includes('#9147'))).toBe(false);
+  });
+
+  it('near-miss ② a discrete `username` present — the branch where the bound secret is LIVE (#8696)', () => {
+    const ds = {
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED, username: 'svc' },
+      external: { ...BOUND },
+    };
+    const result = parse(ds);
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+    expect(result.data!.config).toEqual(ds.config);
+    expect(DatasourceSchema.parse(ds)).toEqual(result.data);
+  });
+
+  it('near-miss ③ no binding — a composed anonymous datasource is a legal intent', () => {
+    const ds = { name: 'events', driver: 'mongodb', config: { ...COMPOSED } };
+    const result = parse(ds);
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+    expect(DatasourceSchema.parse(ds)).toEqual(result.data);
+  });
+
+  it('near-miss ③ an empty-string `credentialsRef` is not a binding — mirrors the connect path\'s truthy check', () => {
+    // `DatasourceConnectionService` resolves the ref under `if (credentialsRef)`,
+    // so an empty ref binds nothing there and is not a binding here either.
+    expect(refusalOf({
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED },
+      external: { credentialsRef: '' },
+    })).toBeUndefined();
+  });
+
+  it('fence — the postgres arm is NOT widened to: a composed pg config with no username + binding stays accepted', () => {
+    // #8873 measured `pg` receiving the bound password regardless of the DSN
+    // naming a user, so the mongo mechanism does not transfer to it on this
+    // branch any more than it did on the URL branch.
+    const result = parse({
+      name: 'warehouse',
+      driver: 'postgres',
+      schemaMode: 'external',
+      config: { database: 'analytics', host: 'wh.internal' },
+      external: { ...BOUND, allowWrites: false },
+    });
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+  });
+
+  it('a non-string `username` is the config gate\'s finding, not this one', () => {
+    const result = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED, username: 42 },
+      external: { ...BOUND },
+    });
+    expect(result.success).toBe(false);
+    // The driver-config parse reports the type error at the same path; this
+    // refusal stays silent rather than judging a value with no branch to predict.
+    expect(result.error!.issues.some((i) => i.path.join('.') === 'config.username')).toBe(true);
+    expect(result.error!.issues.some((i) => i.message.includes('#9147'))).toBe(false);
+  });
+
+  it('composes with the #9040 passthrough refusal — one artefact, both findings, own paths', () => {
+    const result = parse({
+      name: 'events',
+      driver: 'mongodb',
+      config: { ...COMPOSED, options: { auth: { username: 'app', password: 'hunter2' } } },
+      external: { ...BOUND },
+    });
+    expect(result.success).toBe(false);
+    const paths = result.error!.issues.map((i) => i.path.join('.'));
+    expect(paths).toContain('config.username');
+    expect(paths).toContain('config.options.auth.password');
+    expect(result.error!.issues.some((i) => i.message.includes('#9147'))).toBe(true);
+    expect(result.error!.issues.some((i) => i.message.includes('#9040'))).toBe(true);
   });
 });

--- a/packages/spec/src/migrations/entries/semantic/18.datasource-credentialsref-mongo-composed-no-username-refused.ts
+++ b/packages/spec/src/migrations/entries/semantic/18.datasource-credentialsref-mongo-composed-no-username-refused.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import type { SemanticMigration } from '../../types.js';
+
+// The COMPOSED-branch twin of `datasource-credentialsref-mongo-url-no-user-refused`
+// (#9147 widening #9041's refinement). Same silent discard, one branch over, and a
+// DIFFERENT remedy — which is why it is its own entry rather than a widened surface
+// on that one: with no `url` the discrete `config.username` is the live field, so the
+// fix is `config.username`, not the URL's userinfo.
+export const entry: SemanticMigration = {
+  id: 'datasource-credentialsref-mongo-composed-no-username-refused',
+  surface: 'datasource (mongodb) — `external.credentialsRef` bound while `config` authors no ' +
+    '`url` and names no `username`',
+  replacement: 'decide what the datasource is meant to do, then make the two halves agree: ' +
+    'add `username` to `config` so the bound secret is interpolated beside it into the ' +
+    'composed connection URI at connect (#8696) — or, for a datasource genuinely meant to ' +
+    'connect unauthenticated, remove the `external.credentialsRef` binding (and unbind the ' +
+    'orphaned `sys_secret` row via the Setup → Datasources form). Authoring a `config.url` ' +
+    'that names a user is a third valid shape, judged by the sibling #9041 prescription.',
+  reason:
+    'The pair cannot work as written, and until protocol 18 it was accepted in silence at ' +
+    'every door it passed. With no `config.url` the driver factory COMPOSES the connection ' +
+    'URI from the discrete fields, and the bound secret has exactly one route into it — the ' +
+    'userinfo written beside a username (`buildMongoUrl`: `const auth = user ? … : \'\'`). A ' +
+    'falsy `username` closes that route, and the branch has no second one: `buildMongoAuth` ' +
+    'returns early when there is no `url`, because the composed branch injects THROUGH the ' +
+    'URI it builds rather than beside it. So `credentialsRef` bound with no `url` and no ' +
+    '`username` composed `mongodb://host:port/db`, connected ANONYMOUSLY, and told the ' +
+    'operator nothing. Nothing can be fabricated to rescue it: a MongoDB handshake cannot ' +
+    'authenticate from a password alone — the same measured asymmetry behind the sibling ' +
+    'URL-branch refusal. Both branches had always agreed on this input, so this inherits that ' +
+    'ruling rather than re-opening it, and lands at the same authoring/publish door — the one ' +
+    'place both halves are visible at once — as the "absence must be loud" half of the ' +
+    '#7314/#7385/#8152/#8875/#8696 family. Deliberately NOT refused, each measured: a ' +
+    'discrete `username` that is present and non-empty (the secret is live there — that is ' +
+    'the branch #8696 already works on), an empty-string `credentialsRef` (not a binding — ' +
+    'the connect path resolves under a truthy check), a non-string `username` (the driver ' +
+    'config gate already reports the type error), and every other driver arm (the postgres ' +
+    'equivalent is re-judged after #8873, never inherited — `pg` receives the bound password ' +
+    'regardless of the DSN naming a user). An EMPTY-STRING `username` IS refused, unlike the ' +
+    'sibling entry\'s present-but-empty userinfo carve-out: there MongoClient itself throws ' +
+    '(`URI contained empty userinfo section`) so the shape is already loud, while here ' +
+    '`username: \'\'` composes the same userinfo-free URI and connects — silently. There is ' +
+    'no mechanical rewrite because the valid fixes are CONTRADICTORY intents — authenticate ' +
+    '(name the user) versus anonymous (drop the binding) — and choosing between them requires ' +
+    'knowing what the datasource is for.',
+  acceptanceCriteria:
+    'Every mongodb datasource that binds `external.credentialsRef` and authors no `config.url` ' +
+    'names a non-empty `config.username` and connects authenticated as that user; every ' +
+    'datasource meant to connect anonymously carries no `credentialsRef`; no datasource parse ' +
+    'reports the #9147 refusal.',
+};

--- a/packages/spec/src/migrations/registry.ts
+++ b/packages/spec/src/migrations/registry.ts
@@ -5169,6 +5169,54 @@ const step18: MigrationStep = {
         'the connection form) and still connects; no URL-embedded credential remains in any ' +
         'stored `sys_metadata` row or authored source.',
     },
+    // The COMPOSED-branch twin of `datasource-credentialsref-mongo-url-no-user-refused`
+    // (#9147 widening #9041's refinement). Same silent discard, one branch over, and a
+    // DIFFERENT remedy — which is why it is its own entry rather than a widened surface
+    // on that one: with no `url` the discrete `config.username` is the live field, so the
+    // fix is `config.username`, not the URL's userinfo.
+    {
+      id: 'datasource-credentialsref-mongo-composed-no-username-refused',
+      surface: 'datasource (mongodb) — `external.credentialsRef` bound while `config` authors no ' +
+        '`url` and names no `username`',
+      replacement: 'decide what the datasource is meant to do, then make the two halves agree: ' +
+        'add `username` to `config` so the bound secret is interpolated beside it into the ' +
+        'composed connection URI at connect (#8696) — or, for a datasource genuinely meant to ' +
+        'connect unauthenticated, remove the `external.credentialsRef` binding (and unbind the ' +
+        'orphaned `sys_secret` row via the Setup → Datasources form). Authoring a `config.url` ' +
+        'that names a user is a third valid shape, judged by the sibling #9041 prescription.',
+      reason:
+        'The pair cannot work as written, and until protocol 18 it was accepted in silence at ' +
+        'every door it passed. With no `config.url` the driver factory COMPOSES the connection ' +
+        'URI from the discrete fields, and the bound secret has exactly one route into it — the ' +
+        'userinfo written beside a username (`buildMongoUrl`: `const auth = user ? … : \'\'`). A ' +
+        'falsy `username` closes that route, and the branch has no second one: `buildMongoAuth` ' +
+        'returns early when there is no `url`, because the composed branch injects THROUGH the ' +
+        'URI it builds rather than beside it. So `credentialsRef` bound with no `url` and no ' +
+        '`username` composed `mongodb://host:port/db`, connected ANONYMOUSLY, and told the ' +
+        'operator nothing. Nothing can be fabricated to rescue it: a MongoDB handshake cannot ' +
+        'authenticate from a password alone — the same measured asymmetry behind the sibling ' +
+        'URL-branch refusal. Both branches had always agreed on this input, so this inherits that ' +
+        'ruling rather than re-opening it, and lands at the same authoring/publish door — the one ' +
+        'place both halves are visible at once — as the "absence must be loud" half of the ' +
+        '#7314/#7385/#8152/#8875/#8696 family. Deliberately NOT refused, each measured: a ' +
+        'discrete `username` that is present and non-empty (the secret is live there — that is ' +
+        'the branch #8696 already works on), an empty-string `credentialsRef` (not a binding — ' +
+        'the connect path resolves under a truthy check), a non-string `username` (the driver ' +
+        'config gate already reports the type error), and every other driver arm (the postgres ' +
+        'equivalent is re-judged after #8873, never inherited — `pg` receives the bound password ' +
+        'regardless of the DSN naming a user). An EMPTY-STRING `username` IS refused, unlike the ' +
+        'sibling entry\'s present-but-empty userinfo carve-out: there MongoClient itself throws ' +
+        '(`URI contained empty userinfo section`) so the shape is already loud, while here ' +
+        '`username: \'\'` composes the same userinfo-free URI and connects — silently. There is ' +
+        'no mechanical rewrite because the valid fixes are CONTRADICTORY intents — authenticate ' +
+        '(name the user) versus anonymous (drop the binding) — and choosing between them requires ' +
+        'knowing what the datasource is for.',
+      acceptanceCriteria:
+        'Every mongodb datasource that binds `external.credentialsRef` and authors no `config.url` ' +
+        'names a non-empty `config.username` and connects authenticated as that user; every ' +
+        'datasource meant to connect anonymously carries no `credentialsRef`; no datasource parse ' +
+        'reports the #9147 refusal.',
+    },
     {
       id: 'datasource-credentialsref-mongo-url-no-user-refused',
       surface: 'datasource (mongodb) — `external.credentialsRef` bound while `config.url` names ' +


### PR DESCRIPTION
Fixes #9147

The composed-branch twin of #9041: `external.credentialsRef` bound while a mongo `config` authors no `url` and names no `username` is the same silent no-op, and is now refused at the same publish door.

## Where this actually landed

The card and the dispatch both name `packages/services/service-datasource`. The refinement to extend is not there — PR #9146 landed #9041's recognizer in **`packages/spec/src/data/datasource.zod.ts`** (`DatasourceSchema`'s `superRefine`), pinned in `packages/spec/src/data/driver/driver-credential-refusal.test.ts`. `service-datasource` holds the *connect path* the refusal is measured against. This PR extends the landed refinement in place — no second recognizer.

## The defect, re-measured on `origin/main` @ `b0fa4fc1a`

```yaml
driver: mongodb
config: { database: events, host: mongo.internal }
external: { credentialsRef: "sys_secret:01J9ZK4T2N" }
```

Parsed **green**, connected **anonymously**, bound secret never used, operator told nothing.

Mechanism, read off `default-datasource-driver-factory.ts` and pinned as a runtime test in this PR:

- with no `url`, `buildMongoUrl` **composes** the URI, and the bound secret's only route into it is the userinfo written beside a username — `const auth = user ? ... : ''`. A falsy `username` closes that route;
- the DSN branch's route is shut here by construction: `buildMongoAuth` opens with `if (!url) return undefined`, because the composed branch injects *through* the URI it builds rather than beside it.

So the secret has nowhere to go, and nothing can be fabricated to rescue it — a MongoDB handshake cannot authenticate from a password alone, the same measured asymmetry that made #9041's refusal the right answer rather than an unconditional injection.

## Its own message, not #9041's

The remedy differs, and a refusal naming a remedy that does not apply is worse than no refusal — the failure mode this module's own history section documents (the pre-#4410 `belongsInConfig` line). On the URL branch `config.url` supersedes the discrete `username`, so the only fix is the URL's userinfo. Here `url` is absent and `config.username` is the live field. The new message names both valid fixes and prescribes neither: **add `username` to `config`**, or **remove the `external.credentialsRef` binding**. It is pathed at `config.username`, and a test asserts #9041's URL remedy text is *not* copied in.

## The fence — both directions pinned

Refused (new): mongodb arm only, `url` absent, `username` absent, `credentialsRef` bound. Legacy `driver: 'mongo'` is judged identically via `resolveDriverId`.

Every near-miss is pinned as still **accepted**, because the near-misses are what prove the fence:

| near-miss | verdict |
| --- | --- |
| `url` present naming a user (condition 1 absent) | accepted, byte-identical |
| `url` present naming no user | exactly **one** refusal fires, and it is #9041's |
| discrete `username` present (condition 2 absent) | accepted, byte-identical — the branch #8696 already works on |
| no binding (condition 3 absent) | accepted — anonymous intent is legal |
| empty-string `credentialsRef` | accepted — mirrors the connect path's truthy check |
| postgres composed, no username, bound | accepted — #8873, not widened to |
| non-string `username` | the config gate's finding, not this one |

## Two judgment calls, named rather than buried

**1. "names no username" is the falsy set (`undefined` or `''`), not key-absence.** `username: ''` composes the identical userinfo-free URI and drops the identical secret — measured, and now pinned in `bound-secret-dsn-branches.test.ts`. It refuses nothing that works today, so it does not widen past the measured no-op; excluding it would leave this refusal prescribing `config.username` while the platform still accepted the one spelling of `config.username` that keeps the binding silent. Note the deliberate asymmetry with #9041's present-but-empty userinfo carve-out: there `MongoClient` itself throws (`URI contained empty userinfo section`) so the shape is already loud, while here nothing throws. Each fence follows the measurement on its own branch. **This is the one place the implementation reads the dispatch's three-condition fence as "names no username" rather than "key absent"** — reversible in one token if the PM disagrees.

**2. An empty `config.url` is the composed branch — an over-refusal in the landed #9041 arm, corrected here.** `buildMongoUrl` opens `if (explicit) return explicit;`, so `url: ''` falls through and composes from the discrete fields, where a live discrete `username` makes the bound secret work. #9041's arm judged it as a URL "naming no user" and refused it — i.e. rejected at publish a datasource that connects **authenticated** at runtime, and a shape the Setup form can plausibly submit from an untouched empty "Connection URI" input (measured: refused on `origin/main`, accepted here). Both arms now split on the factory's own branch test, so each judges exactly the branch that will run. Same refinement, same defect class, same gate families, evidence pinned by `buildMongoUrl` itself — corrected in place rather than filed, and named here per the bounded in-place rule.

## Verification

Union run at **`2444d022b`** — the final commit, tree clean.

- `pnpm --filter @objectstack/spec test` — **408 files / 10885 tests passed**
- `pnpm --filter @objectstack/service-datasource test` — **21 files / 480 tests passed**
- `pnpm --filter @objectstack/spec typecheck` — OK (test layer at its frozen debt, no drift)
- `pnpm --filter @objectstack/service-datasource typecheck` — OK
- **Reverse verification** (fix committed first, refinement reverted to `origin/main`, restored): **7 failures**, exactly the predicted set — the 4 refusal-direction pins, the 2 `url: ''` routing pins, and the #9040 composition pin. The near-miss acceptance pins correctly stay green in both states; they pin the fence, not the fix.
- **Consumer sweep** (downstream of the narrowed rule, `credentialsRef` across `packages`/`apps`/`examples`/`content`): no mongo fixture anywhere binds `credentialsRef`; every other binder is sqlite/postgres. No doc example carries the refused shape.

Gates, derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths (merge-base diff) and all run green: `check:migration-registry`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:doc-formula-expressions`, `check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs`, `check:merge-driver`, `check:objectui-changeset`, `check:spec-parsed-alias`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-cross-package-test-inputs`, `check-dev-prereqs`, `check-empty-changeset`, `check-affected-docs`, `check-nul-bytes`; convention-triggered: `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt --re-measure` (33 ledger entries, none above its recorded number — run against the built workspace closure).

ADR-0087 semantic entry registered under protocol major 18 and the registry regenerated with `gen:migration-registry`; changeset added (`@objectstack/spec` minor, the launch-window convention #9041 used).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_