### PR TITLE
fix(objectql): a TRUE readonlyWhen no longer strips hook-derived values — the conditional strip judges API-boundary callers only (#9107)

### DIFF
--- a/.changeset/readonly-when-supplied-values.md
+++ b/.changeset/readonly-when-supplied-values.md
@@ -1,0 +1,57 @@
+---
+"@objectstack/objectql": minor
+---
+
+fix(objectql): a TRUE `readonlyWhen` no longer strips hook-derived values — the conditional strip judges only API-boundary callers (#9107)
+
+`stripReadonlyWhenFields` runs AFTER the before-phase hooks and was keyed on
+`name in data` over the POST-hook payload, so a value a `beforeUpdate` hook
+computed was judged exactly like a key the caller forged. Unlike the static
+`readonly` strip immediately beside it, it carried no `isSystem` exemption
+either — so a field locked by a TRUE predicate had **no server-side write path
+at all**: a hook derived it and the strip deleted it; a cron or plugin wrote it
+with `{ context: { isSystem: true } }` and the strip deleted that too.
+
+Net effect before this change: the derived-field pattern (hook-computed column)
+and a conditional form lock could not coexist on one field. An author wanting
+"visible on the form but locked" **and** "recomputed by a hook" had no
+spec-compliant spelling, and the failure was silent behind an HTTP 200.
+
+Measured downstream (steedos-labs/os-project-titanwind-ehr#1446):
+`equipment.next_maintenance_date` is hook-derived (last maintenance date + cycle
+days) and declared with an always-true `readonlyWhen` to render
+visible-but-locked. After a maintenance sign-off the recompute never landed, and
+a scheduler keyed on that date regenerated the same maintenance plan on every
+scan — a user-visible duplicate-plans loop, diagnosed only by reading the
+engine's strip order in the dist bundle.
+
+The conditional strip now carries the exact key discipline #5591 gave the static
+one, on **both** branches (by-id and multi-row) off one engine-entry snapshot: a
+key is judged only while it is still an own property of the caller's payload as
+it arrived at engine entry AND still holds that caller's value by `Object.is`. A
+key a hook added, or overwrote, is a server value and survives.
+
+**The API-boundary lock is unchanged, and a caller cannot launder a write
+through the hook phase.** To reach the exempt side of either test a value must
+differ from what arrived at engine entry — which only server code can arrange. A
+client that echoes the locked key back is stripped exactly as before; if a hook
+overwrites that key, what persists is the **hook's** value, never the client's.
+`isSystem` is still deliberately NOT an exemption for `readonlyWhen`: a state
+lock that any system-context write could bypass would not be a state lock (the
+frozen paid-invoice-lines case depends on it).
+
+What moves for callers:
+
+- A `beforeUpdate` hook may now write a field locked by a TRUE `readonlyWhen`.
+  This is the sanctioned channel for a conditionally-locked derived field.
+- `onFieldsDropped` no longer reports such a key under `readonly_when` — it is
+  written, not dropped, so reporting it would make the observability seam lie.
+- `strictReadonlyWrites` no longer refuses a write whose only `readonlyWhen`
+  "drop" was a hook's own value; a caller-supplied locked field is still refused.
+- The `ERR_READONLY_FIELD_REJECTED` refusal message's `readonlyWhen` remedy
+  clause now reads "every **API-boundary** caller, isSystem included" and names
+  the hook path. The error `code` is unchanged; a pin on the exact message text
+  moves with it.
+
+If an app relied on the strip discarding a hook's own write to a locked field,
+that write now lands — remove the hook assignment, or narrow the predicate.

--- a/content/docs/data-modeling/fields.mdx
+++ b/content/docs/data-modeling/fields.mdx
@@ -375,6 +375,42 @@ protocol 17 (#3855): authoring it is rejected with an error naming the
 replacement, not silently stripped, and `os migrate meta --from 16` rewrites
 existing sources automatically.
 
+#### Who the lock applies to — and the derived-field write path
+
+A TRUE `readonlyWhen` predicate locks the field for **every API-boundary
+caller**. Unlike static `readonly`, passing `{ context: { isSystem: true } }`
+does **not** exempt it: a state lock any system-context write could bypass would
+not be a state lock, and the frozen-paid-invoice case depends on it.
+
+What the lock does **not** cover is the server's own trusted code. A value a
+`beforeUpdate` hook derives — or writes over a key the caller also sent — is a
+server value, not a caller write, and is never stripped. That is what makes
+"visible on the form but locked, and recomputed by a hook" a spelling the
+platform supports on one field:
+
+```typescript
+// The field renders locked, and only the hook may move it.
+next_maintenance_date: Field.date({
+  label: 'Next Maintenance',
+  readonlyWhen: P`true`,
+}),
+```
+
+```typescript
+// The hook is the write path.
+beforeUpdate: (ctx) => {
+  if ('period_days' in ctx.input.data) {
+    ctx.input.data.next_maintenance_date = addDays(today, ctx.input.data.period_days);
+  }
+},
+```
+
+A client cannot use this to launder a write. The engine snapshots the caller's
+payload **at entry**, before any middleware or hook runs, and judges a key only
+while it still holds that value — so echoing the locked key back never exempts
+it, and if a hook overwrites it, the value that persists is the hook's. Either
+way the caller's value does not land.
+
 #### Locking a detail from its master: `parent`
 
 On a **detail** object — one that declares a `master_detail` relationship — a

--- a/content/docs/kernel/contracts/data-engine.mdx
+++ b/content/docs/kernel/contracts/data-engine.mdx
@@ -306,7 +306,7 @@ The strips these two options cover are the engine's legal ones:
 | Strip | `reason` | Verbs | Writers it skips |
 |:---|:---|:---|:---|
 | Static `readonly: true` (#2948) | `readonly` | `update` | `isSystem` |
-| A TRUE `readonlyWhen` predicate (#3042) | `readonly_when` | `update` | none — every caller, `isSystem` included |
+| A TRUE `readonlyWhen` predicate (#3042) | `readonly_when` | `update` | none at the API boundary — every caller, `isSystem` included; a value a `beforeUpdate` hook derived or overwrote is not a caller write and is never stripped (#9107) |
 | Implicitly-readonly runtime-owned type (#5503 — `RUNTIME_OWNED_FIELD_TYPES`, today `autonumber`) | `readonly` | `insert` **and** `update` | `isSystem`, `preserveAudit` (#3493) |
 | Primary-key strip of a payload `id` the update dispatch already ruled is not an identifier (#6437) | `primary_key` | `update` | none |
 

--- a/packages/objectql/src/engine-dropped-fields-primary-key.test.ts
+++ b/packages/objectql/src/engine-dropped-fields-primary-key.test.ts
@@ -291,10 +291,18 @@ describe('#6437 — the refusal message is composed from `drops`, not from the c
     expect(err.message).toContain('SCALAR id');
   });
 
-  it('the READ-ONLY-only message is byte-identical to the pre-#6437 text', async () => {
-    // The compatibility half. Every caller and pin written against #5126's /
-    // #5503's wording must be untouched by a change that only teaches the
-    // error about a class those payloads do not carry.
+  it('the READ-ONLY-only message is unmoved by a NEW REASON CLASS', async () => {
+    // The compatibility half, and read it for what it actually asserts: adding
+    // a `reason` (#6437's whole change) must not disturb the wording payloads
+    // that carry no such class see. That property still holds.
+    //
+    // [#9107] What it never claimed is that the sentence is frozen for all
+    // time. The remedy clause moved ONCE, deliberately, when the maintainer
+    // ruled the conditional strip judges only API-boundary callers: the old
+    // text told a server author its hook-derived write was locked out, which
+    // stopped being true. A remedy sentence that has gone false is the one
+    // thing a refusal message may not keep — so the pin moves WITH the ruling,
+    // and stays a byte-exact pin so the next unintended drift is still caught.
     const { err } = await refuse({ id: 'rec_1', settled_total: 99 }, {});
     expect(err.message).toBe(
       `Update on 'task' was REFUSED: 1 caller-supplied field(s) ` +
@@ -304,7 +312,9 @@ describe('#6437 — the refusal message is composed from `drops`, not from the c
       `server-side code that legitimately writes read-only columns, pass ` +
       `{ context: { isSystem: true } } (this exempts statically 'readonly' fields, but NOT ` +
       `fields locked by a TRUE 'readonlyWhen' predicate — those stay locked for every ` +
-      `caller). To let the strip happen and merely observe it, drop ` +
+      `API-boundary caller, isSystem included. A value DERIVED by a beforeUpdate hook is ` +
+      `not a caller write and is never stripped — that is the sanctioned write path for a ` +
+      `conditionally-locked derived field). To let the strip happen and merely observe it, drop ` +
       `strictReadonlyWrites and pass options.onFieldsDropped instead (#3407).`,
     );
   });

--- a/packages/objectql/src/engine-readonly-when-derived-writes.test.ts
+++ b/packages/objectql/src/engine-readonly-when-derived-writes.test.ts
@@ -130,7 +130,10 @@ describe('readonlyWhen strips CALLER-submitted values only (#9107)', () => {
         next_maintenance_date: { type: 'date', readonlyWhen: 'true' },
         closed_note: { type: 'text', readonlyWhen: "record.status == 'closed'" },
       },
-    } as any);
+      // `packageId` is REQUIRED and passed on purpose: omitting it is what the
+      // TEST_DEBT ledger counts in this package, and a new test file may not
+      // add to a shrink-only ratchet.
+    } as any, 'test');
     const seed = (id: string, over: Record<string, unknown> = {}) =>
       storeFor('ehr_equipment').set(id, {
         id, name: 'Autoclave', status: 'open', period_days: 90,

--- a/packages/objectql/src/engine-readonly-when-derived-writes.test.ts
+++ b/packages/objectql/src/engine-readonly-when-derived-writes.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #9107 — the CONDITIONAL (`readonlyWhen`) strip on the UPDATE path judges only
+// the keys the CALLER submitted at engine entry, exactly as the static
+// `readonly` strip has since #5591. A value a `beforeUpdate` hook derived is a
+// SERVER value, and the strip that exists to stop caller forgeries must not
+// discard it.
+//
+// The gap this pins, as reported: `stripReadonlyWhenFields` ran after the
+// before-phase hooks, keyed on `name in data` over the POST-hook payload, and —
+// unlike the static strip immediately below it — carried neither an `isSystem`
+// exemption nor the `suppliedValues` discipline. So a field locked by a TRUE
+// predicate had NO server-side write path at all: a hook computed it and the
+// value was stripped; a cron/plugin wrote it with `{ context: { isSystem: true
+// } }` and it was stripped. The derived-field pattern (hook-computed column) and
+// a conditional form lock could not coexist on one field.
+//
+// The measured downstream shape (steedos-labs/os-project-titanwind-ehr#1446,
+// reproduced below): `equipment.next_maintenance_date` is derived by a hook
+// (last maintenance date + cycle days) and carries an always-TRUE `readonlyWhen`
+// so the edit form renders it visible-but-locked. After a maintenance sign-off
+// the recompute silently never landed — HTTP 200, field dropped — and a
+// scheduler keyed on that date regenerated the same maintenance plan on every
+// scan: a user-visible duplicate-plans loop, diagnosed only by reading the
+// engine's strip order in the dist bundle.
+//
+// What this suite is NOT: a relaxation of #3042 / #4889. The API-BOUNDARY lock
+// is unchanged and pinned here beside the fix, in all three directions the
+// maintainer's ruling names — a caller-supplied value on a TRUE predicate is
+// still stripped (`isSystem` included, so Option B stays rejected), and a caller
+// cannot launder its own value through the hook phase: when a hook overwrites a
+// key the caller also sent, what persists is the HOOK's value, never the
+// caller's.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from './engine.js';
+
+function makeDriver() {
+  const stores = new Map<string, Map<string, any>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  const matches = (row: any, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    return Object.entries(where).every(([k, v]: [string, any]) => {
+      if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+      return row?.[k] === v;
+    });
+  };
+  let n = 0;
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matches(r, ast?.where));
+    },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matches(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      n += 1;
+      const id = (data.id as string) ?? `r_${n}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const row = { ...s.get(id), ...data, id };
+      s.set(id, row);
+      return row;
+    },
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      let count = 0;
+      for (const row of [...s.values()]) {
+        if (!matches(row, ast?.where)) continue;
+        s.set(row.id, { ...row, ...data, id: row.id });
+        count += 1;
+      }
+      return count;
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count() { return 0; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r, undefined)));
+    },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { __trx: true, commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, storeFor };
+}
+
+/** What the hook derives — a fixed value so the assertions read as identities. */
+const DERIVED = '2026-11-14';
+/** What a caller forges. Never allowed to reach the row on a locked field. */
+const FORGED = '1999-01-01';
+
+describe('readonlyWhen strips CALLER-submitted values only (#9107)', () => {
+  let engine: ObjectQL;
+  let storeFor: ReturnType<typeof makeDriver>['storeFor'];
+  let warns: string[];
+
+  beforeEach(async () => {
+    warns = [];
+    const logger: any = {
+      warn: (m: string) => warns.push(String(m)),
+      debug() {}, info() {}, error() {}, trace() {}, fatal() {},
+      child() { return logger; },
+    };
+    engine = new ObjectQL({ logger });
+    const d = makeDriver();
+    storeFor = d.storeFor;
+    engine.registerDriver(d.driver, true);
+    await engine.init();
+
+    // The downstream object, trimmed to the fields the report turns on.
+    // `next_maintenance_date` is the derived, always-locked one; `closed_note`
+    // carries a STATE lock so the unlocked direction is testable on one object.
+    engine.registry.registerObject({
+      name: 'ehr_equipment',
+      fields: {
+        name: { type: 'text' },
+        status: { type: 'text' },
+        period_days: { type: 'number' },
+        next_maintenance_date: { type: 'date', readonlyWhen: 'true' },
+        closed_note: { type: 'text', readonlyWhen: "record.status == 'closed'" },
+      },
+    } as any);
+    const seed = (id: string, over: Record<string, unknown> = {}) =>
+      storeFor('ehr_equipment').set(id, {
+        id, name: 'Autoclave', status: 'open', period_days: 90,
+        next_maintenance_date: null, closed_note: null, ...over,
+      });
+    seed('eq_1');
+
+    // The recompute hook: derive `next_maintenance_date` whenever the write
+    // touches the cycle. This is the write that had no server-side path.
+    engine.registerHook('beforeUpdate', async (ctx: any) => {
+      if (Object.prototype.hasOwnProperty.call(ctx.input.data, 'period_days')) {
+        ctx.input.data.next_maintenance_date = DERIVED;
+      }
+    }, { object: 'ehr_equipment', priority: 50 });
+
+    (engine as any).__seed = seed;
+  });
+
+  const eq = (id = 'eq_1') => storeFor('ehr_equipment').get(id);
+  const seedRow = (id: string, over: Record<string, unknown> = {}) => (engine as any).__seed(id, over);
+
+  // ── The report ────────────────────────────────────────────────────
+
+  it('THE REPORT: a hook-derived value on a TRUE readonlyWhen field now LANDS', async () => {
+    // Exactly the reported call: a plain by-id update of the cycle. The hook
+    // derives the locked column; before the fix the strip deleted it and the row
+    // kept its stale value behind an HTTP 200.
+    await engine.update('ehr_equipment', { id: 'eq_1', period_days: 120 });
+
+    expect(eq().period_days).toBe(120);
+    // The regression, stated as the value it must NOT be.
+    expect(eq().next_maintenance_date).not.toBeNull();
+    expect(eq().next_maintenance_date).toBe(DERIVED);
+  });
+
+  it('the isSystem caller reported as equally broken lands its hook-derived value too', async () => {
+    // The card measured "no caller for which the hook's value persists" —
+    // plugin/cron writes with an explicit system context included. The context
+    // is NOT what unlocks it (Option B was rejected); the value surviving is the
+    // hook's authorship, and this pins that the two agree.
+    await engine.update(
+      'ehr_equipment', { id: 'eq_1', period_days: 30 },
+      { context: { isSystem: true } } as any,
+    );
+    expect(eq().next_maintenance_date).toBe(DERIVED);
+  });
+
+  // ── The API-boundary lock, all three directions ───────────────────
+
+  it('LOCK 1 — a caller-supplied value on a TRUE predicate is still stripped', async () => {
+    // No hook overwrite (the write does not touch `period_days`), so the value
+    // on the key is the caller's, and it goes. #3042 unchanged.
+    await engine.update('ehr_equipment', { id: 'eq_1', name: 'B', next_maintenance_date: FORGED });
+    expect(eq().name).toBe('B');
+    expect(eq().next_maintenance_date).toBeNull();
+    expect(warns.some((w) => w.includes("Field 'next_maintenance_date' is read-only (readonlyWhen)"))).toBe(true);
+  });
+
+  it('LOCK 2 — isSystem does NOT exempt a caller-supplied value (Option B stays rejected)', async () => {
+    // The documented asymmetry with static `readonly`, deliberately preserved:
+    // a state lock (#4889's paid-invoice-frozen class) must not be bypassable by
+    // any system-context write.
+    await engine.update(
+      'ehr_equipment', { id: 'eq_1', next_maintenance_date: FORGED },
+      { context: { isSystem: true } } as any,
+    );
+    expect(eq().next_maintenance_date).toBeNull();
+  });
+
+  it('LOCK 3 — LAUNDERING: caller sends the key AND a hook overwrites it ⇒ the HOOK value lands, never the caller value', async () => {
+    // The property that makes this safe: a client cannot turn its own value into
+    // a "hook-written" one. Echoing the key back does not launder it — the hook
+    // overwrote it, so what persists is the server's value. The caller's forgery
+    // is gone either way; only its authorship decides WHICH of the two facts
+    // (stripped, or replaced) does the work.
+    await engine.update('ehr_equipment', {
+      id: 'eq_1', period_days: 60, next_maintenance_date: FORGED,
+    });
+    expect(eq().next_maintenance_date).toBe(DERIVED);
+    expect(eq().next_maintenance_date).not.toBe(FORGED);
+  });
+
+  it('LOCK 3b — a hook that writes the caller value BACK is the caller value, and goes', async () => {
+    // The adversarial edge of the identity test: a hook that echoes
+    // `ctx.input.data.x = ctx.input.data.x` has written nothing, and `Object.is`
+    // says so. Pinned because "a hook touched this key" is exactly the weaker
+    // rule that WOULD open a laundering path.
+    engine.registerHook('beforeUpdate', async (ctx: any) => {
+      if (Object.prototype.hasOwnProperty.call(ctx.input.data, 'closed_note')) {
+        ctx.input.data.closed_note = ctx.input.data.closed_note;
+      }
+    }, { object: 'ehr_equipment', priority: 60 });
+
+    seedRow('eq_echo', { status: 'closed' });
+    await engine.update('ehr_equipment', { id: 'eq_echo', closed_note: FORGED });
+    expect(eq('eq_echo').closed_note).toBeNull();
+  });
+
+  // ── The unlocked direction is untouched ───────────────────────────
+
+  it('an UNLOCKED predicate still writes the caller value — the predicate decides', async () => {
+    // `status` is `open`, so `closed_note` is not locked and an ordinary caller
+    // write lands. The fix must not turn a conditional lock into a blanket one.
+    await engine.update('ehr_equipment', { id: 'eq_1', closed_note: 'ok' });
+    expect(eq().closed_note).toBe('ok');
+  });
+
+  it('a STATE lock still refuses the caller once the state flips', async () => {
+    seedRow('eq_closed', { status: 'closed', closed_note: 'sealed' });
+    await engine.update('ehr_equipment', { id: 'eq_closed', closed_note: FORGED });
+    expect(eq('eq_closed').closed_note).toBe('sealed');
+  });
+
+  // ── The bulk branch, on the same terms ────────────────────────────
+
+  it('the BULK path lands a hook-derived value on a locked field', async () => {
+    // `stripReadonlyWhenFieldsMulti` is a separate call site off the SAME entry
+    // snapshot — "both call sites" is the #3106 / #4441 shape that gets missed.
+    seedRow('eq_b1');
+    await engine.update(
+      'ehr_equipment', { period_days: 45 },
+      { where: { status: 'open' }, multi: true } as any,
+    );
+    expect(eq('eq_b1').next_maintenance_date).toBe(DERIVED);
+  });
+
+  it('the BULK path still strips a caller forge no hook overwrote', async () => {
+    seedRow('eq_b2', { name: 'bulk' });
+    await engine.update(
+      'ehr_equipment', { name: 'bulk2', next_maintenance_date: FORGED },
+      { where: { name: 'bulk' }, multi: true } as any,
+    );
+    expect(eq('eq_b2').name).toBe('bulk2');
+    expect(eq('eq_b2').next_maintenance_date).toBeNull();
+  });
+
+  // ── The observability seams must agree with the new verdict ───────
+
+  it('a hook-written locked key is NOT reported to onFieldsDropped', async () => {
+    // `DroppedFieldsEvent` is contracted as "dropped, and the write completed
+    // WITHOUT them" (#3407). The column IS written now, so reporting it would
+    // make the observability seam lie — the same correction #5591 made one strip
+    // over.
+    const events: any[] = [];
+    await engine.update(
+      'ehr_equipment', { id: 'eq_1', period_days: 15 },
+      { onFieldsDropped: (e: any) => events.push(e) } as any,
+    );
+    expect(events).toEqual([]);
+    expect(eq().next_maintenance_date).toBe(DERIVED);
+  });
+
+  it('onFieldsDropped still fires for a caller value that really is discarded', async () => {
+    const events: any[] = [];
+    await engine.update(
+      'ehr_equipment', { id: 'eq_1', name: 'B', next_maintenance_date: FORGED },
+      { onFieldsDropped: (e: any) => events.push(e) } as any,
+    );
+    expect(events).toEqual([
+      { object: 'ehr_equipment', fields: ['next_maintenance_date'], reason: 'readonly_when' },
+    ]);
+  });
+
+  it('strictReadonlyWrites refuses the caller forge and admits the hook write', async () => {
+    // #5126 refuses rather than committing without the stripped columns. A
+    // hook-written key is not stripped, so a strict caller has nothing to be
+    // refused for — its contract is about columns that would be MISSING.
+    await expect(engine.update(
+      'ehr_equipment', { id: 'eq_1', next_maintenance_date: FORGED },
+      { strictReadonlyWrites: true } as any,
+    )).rejects.toThrow(/readonlyWhen/);
+
+    await engine.update(
+      'ehr_equipment', { id: 'eq_1', period_days: 75 },
+      { strictReadonlyWrites: true } as any,
+    );
+    expect(eq().next_maintenance_date).toBe(DERIVED);
+  });
+
+  it('a hook can still SEE the caller-submitted locked value', async () => {
+    // Why the fix compares values instead of stripping ahead of the hooks: a
+    // `beforeUpdate` guard that reports on what the caller submitted reads
+    // `ctx.input.data`, and stripping first would silently empty that out.
+    const seen: unknown[] = [];
+    engine.registerHook('beforeUpdate', async (ctx: any) => {
+      seen.push(Object.keys(ctx.input.data));
+    }, { object: 'ehr_equipment', priority: 1 });
+
+    await engine.update('ehr_equipment', { id: 'eq_1', name: 'B', next_maintenance_date: FORGED });
+    expect(seen).toEqual([['id', 'name', 'next_maintenance_date']]);
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -9534,7 +9534,17 @@ export class ObjectQL implements IObjectQLEngine {
                const roWhenPreviousParent = repointsMaster
                    ? await this.resolveMasterDetailParent(updateSchema, null, priorRecord)
                    : undefined;
-               hookContext.input.data = stripReadonlyWhenFields(updateSchema as any, preRoWhen, priorRecord, this.logger, roWhenParent) as any;
+               // [#9107] `suppliedValues` — the SAME entry snapshot the static
+               // strip below consumes, now feeding the conditional one too, so
+               // both strips answer "did the CALLER write this key?" from one
+               // fact. Before this the conditional strip judged the post-hook
+               // payload, which gave a `readonlyWhen`-locked field no
+               // server-side write path at all: a hook derived the value and
+               // the strip deleted it, `isSystem` or not. The API-boundary lock
+               // is unchanged — a caller cannot make its own value look
+               // hook-written (see `ReadonlyWhenStripOptions`) — and `isSystem`
+               // is still NOT an exemption here, unlike the static strip below.
+               hookContext.input.data = stripReadonlyWhenFields(updateSchema as any, preRoWhen, priorRecord, this.logger, roWhenParent, { supplied: suppliedValues }) as any;
                reportDroppedFields(preRoWhen, hookContext.input.data as Record<string, unknown>, 'readonly_when');
                // [#2948] Enforce STATIC `readonly` on the write path for
                // non-system callers (system writes legitimately set read-only
@@ -9703,7 +9713,11 @@ export class ObjectQL implements IObjectQLEngine {
                        ? await this.resolveMasterDetailParents(updateSchema, null, priorRows)
                        : undefined;
                if (payloadHasReadonlyWhen) {
-                   hookContext.input.data = stripReadonlyWhenFieldsMulti(updateSchema as any, preRoWhenMulti, priorRows, this.logger, parentForRow) as any;
+                   // [#9107] Same entry snapshot, same authorship gate as the
+                   // by-id branch above — "both call sites" is the #3106 /
+                   // #4441 shape that gets missed, and a bulk write must not
+                   // reach a different verdict about who wrote a key.
+                   hookContext.input.data = stripReadonlyWhenFieldsMulti(updateSchema as any, preRoWhenMulti, priorRows, this.logger, parentForRow, { supplied: suppliedValues }) as any;
                    reportDroppedFields(preRoWhenMulti, hookContext.input.data as Record<string, unknown>, 'readonly_when');
                }
                // [#2948] Same static-`readonly` write guard on the bulk path —

--- a/packages/objectql/src/readonly-strict-errors.ts
+++ b/packages/objectql/src/readonly-strict-errors.ts
@@ -36,12 +36,22 @@ import type { DroppedFieldsEvent } from '@objectstack/spec/data';
  * relocate the exact harm PR #6433 refused to commit (a `reason` that lies)
  * from the event into the error.
  *
- * So the wording branches on the reasons actually present, and the
- * READ-ONLY-ONLY message stays **byte-identical** to #5126's / #5503's — every
- * caller and pin written against it is untouched, and only a payload carrying a
- * genuinely new strip class sees new prose. The error `code` does NOT branch:
+ * So the wording branches on the reasons actually present, and adding a strip
+ * CLASS leaves the read-only-only message untouched — only a payload carrying
+ * the new class sees new prose. The error `code` does NOT branch:
  * `ERR_READONLY_FIELD_REJECTED` is what callers catch, and `drops` is what they
  * read to tell the classes apart.
+ *
+ * [#9107] The `readonlyWhen` REMEDY clause did move once, and not because a
+ * class was added — because the behaviour it described changed. The conditional
+ * strip now judges only API-boundary callers, so "those stay locked for every
+ * caller" had become false in the one direction a server author acts on: a
+ * `beforeUpdate` hook's derived value is not a caller write and is never
+ * stripped. A remedy sentence that has gone false is worse than a reworded one
+ * — it sends the reader to `isSystem`, which does NOT exempt this strip and is
+ * a strictly worse posture adopted for nothing (the same trap #8141 names one
+ * log line over). The byte-exact pin in
+ * `engine-dropped-fields-primary-key.test.ts` moved with it.
  *
  * Identified by `code` rather than `instanceof` so it survives crossing package
  * boundaries — the convention `SummaryRecomputeError` / `DriverConnectError`
@@ -119,7 +129,9 @@ function buildRefusalMessage(
           `context { context: { preserveAudit: true } } (#3493). `
         : `{ context: { isSystem: true } } (this exempts statically 'readonly' fields, but NOT ` +
           `fields locked by a TRUE 'readonlyWhen' predicate — those stay locked for every ` +
-          `caller). `) +
+          `API-boundary caller, isSystem included. A value DERIVED by a beforeUpdate hook is ` +
+          `not a caller write and is never stripped — that is the sanctioned write path for a ` +
+          `conditionally-locked derived field). `) +
       tail
     );
   }
@@ -135,7 +147,9 @@ function buildRefusalMessage(
     `per reason: for a read-only lock, remove the field from the payload, or pass ` +
     `{ context: { isSystem: true } } for server-side code that legitimately writes ` +
     `statically 'readonly' columns (that exempts NEITHER a TRUE 'readonlyWhen' predicate ` +
-    `NOR the primary-key strip — both apply to every caller, isSystem included); for ` +
+    `NOR the primary-key strip — both apply to every API-boundary caller, isSystem included; ` +
+    `a 'readonlyWhen' value DERIVED by a beforeUpdate hook is not a caller write and is never ` +
+    `stripped); for ` +
     `'primary_key', pass a SCALAR id to update ONE row (\`update(object, { id, ...fields })\` ` +
     `or \`{ where: { id } }\`), or put the id set in \`where\` to SELECT rows ` +
     `(\`{ where: { id: { $in: [...] } }, multi: true }\`). ` +

--- a/packages/objectql/src/validation/rule-validator.test.ts
+++ b/packages/objectql/src/validation/rule-validator.test.ts
@@ -660,6 +660,106 @@ describe('readonlyWhen binds a TOTAL record (#4953)', () => {
   });
 });
 
+// #9107 — the CONDITIONAL strip judges only the keys the CALLER supplied at
+// engine entry, the same discipline #5591 gave the static strip below. The two
+// helpers are pinned here at the unit level; the engine-level consequences (the
+// derived-field write path, and the API-boundary lock surviving it) live in
+// `engine-readonly-when-derived-writes.test.ts`.
+describe('stripReadonlyWhen* — supplied-key discipline (#9107)', () => {
+  const lockedFields = {
+    fields: {
+      status: { type: 'text' },
+      amount: { type: 'number', readonlyWhen: "record.status == 'paid'" },
+    },
+  };
+  const paid = { status: 'paid', amount: 100 };
+
+  it('KEEPS a locked key a hook ADDED — the caller never named it', () => {
+    const out = stripReadonlyWhenFields(lockedFields, { amount: 999 }, paid, undefined, undefined, {
+      supplied: {},
+    });
+    expect(out).toEqual({ amount: 999 });
+    expect(out).toBe(out); // nothing dropped
+  });
+
+  it('KEEPS a locked key a hook OVERWROTE, even though the caller supplied it', () => {
+    // The caller echoed `amount` back; a hook then wrote its own value over it.
+    // What sits on the key now is a PLATFORM write, not a forgery.
+    const out = stripReadonlyWhenFields(lockedFields, { amount: 777 }, paid, undefined, undefined, {
+      supplied: { amount: 999 },
+    });
+    expect(out).toEqual({ amount: 777 });
+  });
+
+  it('STILL drops it when the hook wrote the caller value back unchanged', () => {
+    // Identity is the whole test: an unchanged value is indistinguishable from
+    // "no hook touched it", and the fail-safe direction is to strip. This is
+    // also what closes the laundering path — echoing a key cannot exempt it.
+    const out = stripReadonlyWhenFields(lockedFields, { amount: 999 }, paid, undefined, undefined, {
+      supplied: { amount: 999 },
+    });
+    expect(out).toEqual({});
+  });
+
+  it('drops a caller-forged NaN — `Object.is`, not `===`', () => {
+    const nanFields = {
+      fields: { status: { type: 'text' }, amount: { type: 'number', readonlyWhen: "record.status == 'paid'" } },
+    };
+    const out = stripReadonlyWhenFields(nanFields, { amount: Number.NaN }, paid, undefined, undefined, {
+      supplied: { amount: Number.NaN },
+    });
+    expect(out).toEqual({});
+  });
+
+  it('does not read an inherited `Object.prototype` key as caller-supplied', () => {
+    // `constructor` matches the machine-name regex, so it is a legal field
+    // name; `name in supplied` would be TRUE for it on any plain object.
+    const oddly = {
+      fields: { status: { type: 'text' }, constructor: { type: 'text', readonlyWhen: "record.status == 'paid'" } },
+    };
+    const out = stripReadonlyWhenFields(oddly, { constructor: 'hook-stamp' }, paid, undefined, undefined, {
+      supplied: {},
+    });
+    expect(out).toEqual({ constructor: 'hook-stamp' });
+  });
+
+  it('an ABSENT `supplied` judges the whole payload — the fail-SAFE default', () => {
+    // The pre-#9107 behaviour, deliberately kept as the default: a call site
+    // with no entry snapshot cannot tell a hook write from a forgery and must
+    // assume the forgery. Forgetting the option can only over-strip.
+    expect(stripReadonlyWhenFields(lockedFields, { amount: 999 }, paid)).toEqual({});
+  });
+
+  it('a hook-written key is not even EVALUATED — no unbound-root lock, no warn', () => {
+    // The fail-CLOSED unbound-root branch (#4889) exists to protect against an
+    // unjudgeable CALLER write. A hook write is not this strip's business at
+    // all, so the predicate never runs and the branch is never reached.
+    const parentScoped = {
+      fields: { quantity: { type: 'number', readonlyWhen: "parent.status == 'paid'" } },
+    };
+    const warnings: string[] = [];
+    const out = stripReadonlyWhenFields(parentScoped, { quantity: 9999 }, { id: 'l1' }, {
+      warn: (m: string) => warnings.push(m),
+    } as never, undefined, { supplied: {} });
+    expect(out).toEqual({ quantity: 9999 });
+    expect(warnings).toEqual([]);
+  });
+
+  it('the BULK strip applies the identical discipline', () => {
+    const rows = [{ status: 'paid', amount: 100 }, { status: 'draft', amount: 50 }];
+    // Hook-added ⇒ survives, even though row 1 locks the field.
+    expect(
+      stripReadonlyWhenFieldsMulti(lockedFields, { amount: 999 }, rows, undefined, undefined, { supplied: {} }),
+    ).toEqual({ amount: 999 });
+    // Caller-supplied ⇒ dropped for the whole batch (locked in ≥1 row).
+    expect(
+      stripReadonlyWhenFieldsMulti(lockedFields, { amount: 999 }, rows, undefined, undefined, {
+        supplied: { amount: 999 },
+      }),
+    ).toEqual({});
+  });
+});
+
 // #2948 — static `readonly:true` write enforcement (caller-supplied only).
 const stampedFields = {
   fields: {

--- a/packages/objectql/src/validation/rule-validator.ts
+++ b/packages/objectql/src/validation/rule-validator.ts
@@ -508,11 +508,89 @@ function readonlyWhenBindings(
 }
 
 /**
+ * Options shared by the single-id and bulk `readonlyWhen` strips.
+ *
+ * ## `supplied` — the key discipline, and why the lock survives it (#9107)
+ *
+ * The conditional strip runs AFTER the before-phase hooks, so by the time it
+ * looks at a key, "the caller wrote this" and "this key is in the payload" are
+ * two different facts. Until #9107 only the second was asked, and — unlike the
+ * static `readonly` strip, which has had the discipline since #5591 — the
+ * conditional one had no `isSystem` exemption either. A field locked by a TRUE
+ * predicate therefore had NO server-side write path at all: a `beforeUpdate`
+ * hook computed it and the strip deleted the computation; a cron or plugin
+ * wrote it with `{ context: { isSystem: true } }` and the strip deleted that
+ * too. The derived-field pattern and a conditional form lock could not coexist
+ * on one field, and the failure was silent behind an HTTP 200 (the measured
+ * downstream shape: a hook-derived maintenance date that never moved, feeding a
+ * scheduler that regenerated the same plan on every scan).
+ *
+ * So `supplied` is the CALLER's payload as snapshotted at ENGINE ENTRY, before
+ * any middleware or hook ran, and a key is judged only when it is still the
+ * caller's — the identical two-part test `stripReadonlyFields` applies:
+ *
+ *  1. the key is an OWN property of `supplied` (a key a hook ADDED is not), and
+ *  2. the payload still holds the caller's VALUE by `Object.is` (a key a hook
+ *     OVERWROTE now carries a platform value, not a forgery).
+ *
+ * ⚠️ **This does not weaken the lock at the API boundary, and the reason is
+ * that a caller cannot reach the exempt side of either test.** To be treated as
+ * hook-written, a value must differ from what arrived at engine entry — which
+ * only server code can arrange. A client that echoes the locked key back does
+ * not launder it: either no hook touched it (test 2 holds, it is stripped) or a
+ * hook overwrote it (the value that persists is the HOOK's, and the client's is
+ * gone regardless). What changed is who may write the column — the server's own
+ * trusted hooks — not whether a caller may. `isSystem` is deliberately still NOT
+ * an exemption here: a state lock that any system-context write could bypass
+ * would not be a state lock (#4889's frozen paid-invoice lines are built on it).
+ *
+ * ABSENT `supplied` means "treat the whole payload as caller-supplied" — the
+ * pre-#9107 behaviour, and the fail-SAFE default: a call site that has no entry
+ * snapshot to offer cannot tell a hook write from a forgery, and must assume the
+ * forgery. Forgetting to pass it can only over-strip, never open a lock.
+ */
+interface ReadonlyWhenStripOptions {
+  /**
+   * The caller's payload as it arrived at engine entry — before middleware and
+   * before the before-phase hooks. Omit to judge every key in the payload.
+   */
+  supplied?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Is this key still the CALLER's to be judged? (#9107 — see
+ * {@link ReadonlyWhenStripOptions}.) Shared by the single-id and bulk strips so
+ * the two can never disagree about what "caller-supplied" means, and written to
+ * be textually parallel with the same test inside {@link stripReadonlyFields}.
+ */
+function isCallerSuppliedValue(
+  data: Record<string, unknown>,
+  supplied: Readonly<Record<string, unknown>>,
+  name: string,
+): boolean {
+  // Own-property, never `in`: a field name is `^[a-z_][a-z0-9_]*$`, which
+  // admits `constructor` / `valueOf` — inherited from `Object.prototype` on any
+  // plain snapshot, so `in` would call a hook stamp caller-supplied and strip
+  // it (the trap #5591 names on the static strip, one function over).
+  if (!Object.prototype.hasOwnProperty.call(supplied, name)) return false;
+  // ...and it must still BE the caller's value. `Object.is`, not `===`, on
+  // purpose: `===` reports NaN !== NaN, which would read a caller-forged NaN as
+  // "a hook rewrote it" and KEEP the forgery — the one input where the loose
+  // operator inverts the verdict.
+  return Object.is(data[name], supplied[name]);
+}
+
+/**
  * Strip fields whose `readonlyWhen` CEL predicate is TRUE for the (merged)
  * record from an UPDATE payload — the field is locked, so an incoming change is
  * ignored (the persisted value is kept) rather than rejected. Returns the same
  * object when nothing is locked, else a shallow copy with the locked keys
  * removed.
+ *
+ * Only keys the CALLER supplied at engine entry are judged (#9107) — a value a
+ * hook derived or overwrote is a server value and survives. See
+ * {@link ReadonlyWhenStripOptions} for the two-part test and for why the lock
+ * at the API boundary is unchanged by it.
  *
  * `parent` (#4889) is the master-detail header row, bound for a detail object
  * so a `parent.<field>` predicate — the documented "once the header invoice is
@@ -533,13 +611,20 @@ export function stripReadonlyWhenFields(
   previous: Record<string, unknown> | undefined | null,
   logger?: EvaluateRulesOptions['logger'],
   parent?: ParentBinding,
+  options?: ReadonlyWhenStripOptions,
 ): Record<string, unknown> | undefined | null {
   const fields = objectSchema?.fields;
   if (!fields || !data) return data;
+  const supplied = options?.supplied ?? data;
   const view = readonlyWhenBindings(data, previous, fields);
   let result = data;
   for (const [name, def] of Object.entries(fields)) {
     if (!def?.readonlyWhen || !(name in data)) continue;
+    // [#9107] Asked BEFORE the predicate runs, not after: a hook-written value
+    // is not this strip's business at all, so there is nothing to evaluate and
+    // nothing to warn about — including the unbound-root LOCKED branch, whose
+    // fail-CLOSED verdict exists to protect against an unjudgeable CALLER write.
+    if (!isCallerSuppliedValue(data, supplied, name)) continue;
     if (isReadonlyWhenLocked(def, view.merged, view.previous, name, logger, parent)) {
       if (result === data) result = { ...data };
       delete (result as Record<string, unknown>)[name];
@@ -743,6 +828,11 @@ export function hasReadonlyWhenInPayload(
  * `readonlyWhen` field is actually in the payload, so a batch that touches none
  * still pays nothing.
  *
+ * Only keys the CALLER supplied at engine entry are judged (#9107), off the SAME
+ * entry snapshot the single-id strip uses — one payload, one authorship, so a
+ * bulk write cannot reach a different verdict about who wrote a key than a
+ * one-row write does. See {@link ReadonlyWhenStripOptions}.
+ *
  * Returns the same object when nothing is stripped, else a shallow copy with the
  * locked keys removed.
  */
@@ -752,9 +842,11 @@ export function stripReadonlyWhenFieldsMulti(
   priorRows: ReadonlyArray<Record<string, unknown>> | undefined | null,
   logger?: EvaluateRulesOptions['logger'],
   parentForRow?: (row: Record<string, unknown> | undefined) => ParentBinding,
+  options?: ReadonlyWhenStripOptions,
 ): Record<string, unknown> | undefined | null {
   const fields = objectSchema?.fields;
   if (!fields || !data) return data;
+  const supplied = options?.supplied ?? data;
   const rows = priorRows ?? [];
   // Built lazily: a payload writing no `readonlyWhen` field never reaches the
   // `.some()` below, and then no row view is materialised at all.
@@ -763,6 +855,9 @@ export function stripReadonlyWhenFieldsMulti(
   let result = data;
   for (const [name, def] of Object.entries(fields)) {
     if (!def?.readonlyWhen || !(name in data)) continue;
+    // [#9107] Same authorship gate as the single-id strip, asked before any row
+    // is judged — a hook-written key is exempt for the whole batch, not per row.
+    if (!isCallerSuppliedValue(data, supplied, name)) continue;
     const lockedInSomeRow = rowViews().some((view, i) =>
       isReadonlyWhenLocked(
         def,

--- a/packages/spec/src/contracts/data-engine.ts
+++ b/packages/spec/src/contracts/data-engine.ts
@@ -79,7 +79,10 @@ export interface WriteObservabilityOptions {
    * reported set, never an enumeration frozen at #5126. Today that is all three
    * `DroppedFieldsEvent['reason']` arms: static `readonly: true` (#2948, which
    * only runs for non-system callers), a TRUE `readonlyWhen` predicate (#3042,
-   * which runs for every caller, `isSystem` included), and the `primary_key`
+   * which runs for every API-BOUNDARY caller, `isSystem` included — but judges
+   * only the keys the caller supplied at engine entry, so a value a
+   * `beforeUpdate` hook derived or overwrote is never stripped, #9107), and the
+   * `primary_key`
    * strip (#6437) — plus, since #5503, the implicitly-readonly runtime-owned
    * strip, which reports under the same `'readonly'` arm rather than adding one
    * (see the INSERT section below). Covering only the static arm would leave a


### PR DESCRIPTION
Fixes #9107

Implements the maintainer's ruling of 2026-08-17 (comment 5311378122): **Option A — `suppliedValues` parity for `stripReadonlyWhenFields`**, on both the by-id and multi-row branches, with the docs and strict-mode refusal wording changed to "every **API-boundary** caller".

## The defect, re-measured on current `main`

The card cited `origin/main @ bb3def43c254`; `main` has moved a long way since, so the premise was re-verified from scratch rather than assumed. It holds, unchanged:

- `stripReadonlyWhenFields` runs **after** the before-phase hooks (`engine.ts`), is keyed on `name in data` over the **post-hook** payload, and — unlike the static `readonly` strip immediately below it — carries neither an `isSystem` exemption nor the `suppliedValues` discipline.
- The multi-row branch (`stripReadonlyWhenFieldsMulti`) has the same shape.

Consequence: a field locked by a TRUE `readonlyWhen` predicate had **no server-side write path at all**. A `beforeUpdate` hook computed it and the strip deleted the computation; a cron or plugin wrote it with `{ context: { isSystem: true } }` and the strip deleted that too.

The premise was also reproduced **empirically** before any fix was written. The new pin file was run against unmodified `main`: 6 of its 14 cases failed, and every one of them is a direction where a hook-derived value should have survived. The 8 cases asserting the API-boundary lock passed unchanged, before and after — which is the point.

## The fix

`stripReadonlyWhenFields` / `stripReadonlyWhenFieldsMulti` take the caller's engine-entry snapshot and judge a key only while **both** halves of the #5591 test hold:

1. the key is an **own** property of the snapshot (a key a hook ADDED is not), and
2. the payload still holds the caller's **value** by `Object.is` (a key a hook OVERWROTE now carries a platform value).

Both engine call sites pass the same `suppliedValues` snapshot the static strip already consumed, so the two strips answer "did the caller write this key?" from one fact. The test is asked **before** the predicate is evaluated: a hook-written value is not this strip's business, so there is nothing to evaluate and nothing to warn about.

An absent snapshot means "judge the whole payload" — the pre-change behaviour, and the fail-**safe** default: forgetting the option can only over-strip, never open a lock.

## The API-boundary lock is unchanged

This is the property the ruling calls load-bearing, so it is pinned in all three directions rather than argued:

- **A caller-supplied value on a TRUE predicate is still stripped** — `isSystem` included, so Option B stays rejected. A state lock any system-context write could bypass would not be a state lock.
- **A caller cannot launder its own value through the hook phase.** To reach the exempt side of either test a value must differ from what arrived at engine entry, which only server code can arrange. A client that echoes the locked key back is stripped exactly as before; if a hook overwrites that key, what persists is the **hook's** value — the client's is gone either way.
- **A hook that writes the caller's value back unchanged is not a hook write.** `Object.is` says so, and that is what closes the laundering path; pinned explicitly, because "a hook touched this key" is the weaker rule that would open one.

## Fork clause — measured, does not trigger

The ruling binds the implementer to stop and bring back a measurement if any consumer depends on the strip discarding hook-written values **as a state-lock guarantee**. Measured three ways; nothing does:

1. **Source sweep.** Repo-wide there are exactly two real `readonlyWhen` field declarations: `sys_permission_set.name` (ADR-0094 metadata identity, immutable after creation) and the showcase invoice/invoice-line locks. **No hook writes any of them.** The permission-set lock additionally states in its own comment that the data door independently rejects a rename with a 400, so the strip is explicitly not its sole guard.
2. **Pre-fix suite run.** The whole `@objectstack/objectql` suite on unmodified `main` was green apart from the 6 new intentionally-red cases — no existing test asserts that a hook-written locked value is discarded.
3. **Downstream consumer sweep** (below) — all green.

## Verification — union run at `e5ae4efd8`, the final commit

`git rev-parse --short HEAD` = **`e5ae4efd8`** (after merging `origin/main`; `packages/spec` moved on the incoming side, so it was rebuilt and `check:generated` re-run — all 13 artifacts up to date).

Tests, downstream direction (`--filter` prefix form = dependents of objectql):

| package | files | tests |
|:--|--:|--:|
| `@objectstack/objectql` | 214 | 3787 |
| `@objectstack/rest` | 122 | 2011 |
| `@objectstack/metadata-protocol` | 117 | 1617 |
| `@objectstack/plugin-security` | 66 | 1279 |
| `@objectstack/plugin-auth` | 55 | 1261 |
| `@objectstack/service-automation` | 80 | 967 |

All passed. `pnpm --filter @objectstack/objectql --filter @objectstack/spec typecheck` clean.

Gates derived from the actual changed paths via `node scripts/pm/dispatch-gates.mjs`, all re-run at `e5ae4efd8`: `check:nul-bytes`, `check:error-code-casing`, `check:cross-package-test-inputs`, `check:docs-audit-scope`, `check:docs-redirects`, `check:role-word`, `check:durability-log-level`, `check:merge-driver`, `check:spec-parsed-alias`, `check:stack-collection-maps`, `check:type-source-resolution`, `check:changeset-gate-self-tests`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:type-check-debt`, `check-adr-0087-registration`, `check-dev-prereqs`, `check-engine-split-ratio`, `docs-audit/check-affected-docs`, and the spec-liveness family (`check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs`) plus `@objectstack/lint check:doc-formula-expressions` — **all pass**.

One of them caught a real defect in this PR's own diff: `check:type-check-debt --re-measure` reported objectql's TEST_DEBT drifting `355 → 356`, because the new pin file called `registry.registerObject()` without its required `packageId` (the omission the ledger counts). Fixed at the source — the ledger was not raised — and the ratchet is flat again.

## Behaviour that moves for callers

- A `beforeUpdate` hook may now write a field locked by a TRUE `readonlyWhen`. This is the sanctioned channel for a conditionally-locked derived field.
- `onFieldsDropped` no longer reports such a key under `readonly_when` — it is written, not dropped, so reporting it would make the observability seam lie.
- `strictReadonlyWrites` no longer refuses a write whose only `readonlyWhen` drop was a hook's own value; a caller-supplied locked field is still refused.
- The `ERR_READONLY_FIELD_REJECTED` message's `readonlyWhen` remedy clause now reads "every **API-boundary** caller, isSystem included" and names the hook path. The error `code` is unchanged. The byte-exact pin on that message moved with it, and its test name and comment were rewritten to say why: the #6437 property it actually asserts (a new *reason class* does not disturb this wording) still holds; what moved is a remedy sentence that had gone false, which is the one thing a refusal message may not keep.

## Docs

- `content/docs/kernel/contracts/data-engine.mdx` — the strip table's "Writers it skips" cell.
- `content/docs/data-modeling/fields.mdx` — a new authoring section stating who the lock applies to and showing the derived-field write path, plus why a client cannot launder through it.
- `packages/spec/src/contracts/data-engine.ts` — the `strictReadonlyWrites` coverage sentence. TSDoc on a TS interface, not a Zod `.describe()`, so it feeds no generated artifact (verified: the text appears in no `content/docs/references/**` or `api-surface/` output).

## Notes

- Co-tenancy: branched from current `origin/main` and merged it again before finalising. PR #9235's merged filter-comparand work and #9284's in-flight roll-up surface are disjoint from the update-strip region; no collision, nothing of another seat's semantics touched.
- Downstream: once released, the titanwind-ehr predicate-token workaround can be retired per that project's recorded unblock condition. Worth flagging to them explicitly — under the new discipline their hook-set token field will now **persist** rather than always being stripped, which is a behaviour change to the workaround itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_