### PR TITLE
fix(devx): keep check-regen-pending's self-test gate stub out of the fixture index

### DIFF
--- a/scripts/check-regen-pending.mjs
+++ b/scripts/check-regen-pending.mjs
@@ -65,7 +65,7 @@
  */
 
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -383,7 +383,14 @@ function fixtureSelfTest() {
     console.log(`  ${cond ? '✓' : '✗'} ${label}`);
   };
 
-  /** Run the real script inside the fixture, with the stub gate in the given state. */
+  /**
+   * Run the real script inside the fixture, with the stub gate in the given state.
+   *
+   * ⚠️ This WRITES `package.json` into the fixture worktree, and it is called while
+   * a merge is in progress. That is only safe because the stub is kept out of the
+   * index — see the `info/exclude` note below, and #9258 for what it cost when it
+   * was not.
+   */
   const runHook = (gate, args = []) => {
     writeFileSync(
       join(dir, 'package.json'),
@@ -406,6 +413,34 @@ function fixtureSelfTest() {
     git(['config', 'user.name', 'os-regen fixture']);
     git(['config', 'core.hooksPath', '/dev/null']); // the fixture drives the script itself
     const gitDir = git(['rev-parse', '--absolute-git-dir']).trim();
+
+    // `package.json` here is the HARNESS's gate stub — `runHook` rewrites it to flip
+    // the stub `check:spec-changes` between passing and failing — not part of the
+    // two-commit scenario under test. It must therefore never enter the index, and
+    // this repo-local exclude is what keeps that true: the `git add -A` on `side2`
+    // below otherwise sweeps the stub into a commit, and from that point on every
+    // `runHook` call made DURING a merge leaves a tracked file whose stat data no
+    // longer matches the index entry the merge just recorded.
+    //
+    // `git merge --abort` is a `reset --merge`, which refuses to discard a tracked
+    // file that is not up to date — so the fixture crashed there, and crashed only
+    // SOMETIMES, because git compares mtime at one-second granularity: the abort
+    // survived exactly when the rewrite happened to land in the same wall-clock
+    // second as the merge's index write, and failed when it landed in the next one.
+    // The stub's CONTENT is identical either way; the file is only ever stat-dirty,
+    // which is why nothing in the fixture's own assertions could see it coming.
+    //
+    // Measured on #9258: two crashes in five CI runs across four PRs that never
+    // touched this script; reproduced 10/10 by delaying the rewrite past a second
+    // boundary, and 0/10 at that same delay with this exclude in place.
+    //
+    // `.git/info/exclude` and not a `.gitignore`: the latter would itself be a
+    // tracked file inside the merges under test, changing the scenario to protect
+    // the harness. `mkdirSync` because a custom `init.templateDir` need not ship
+    // `info/`, and a fixture that guards against flakiness may not add one.
+    mkdirSync(join(gitDir, 'info'), { recursive: true });
+    appendFileSync(join(gitDir, 'info', 'exclude'), '\n# the self-test gate stub (#9258) — never track it\npackage.json\n');
+
     const marker = join(gitDir, PENDING_MARKER);
     const pendingPath = 'packages/spec/spec-changes.json'; // a real REGEN_ARTIFACTS entry
     const write = (f, c) => writeFileSync(join(dir, f), c);
@@ -452,6 +487,13 @@ function fixtureSelfTest() {
     const second = runHook('stale');
     check('a SECOND merge cannot defer on top of an outstanding deferral', second.code === 1);
     check('  …so the exemption stays one commit deep', /one commit deep/.test(second.out));
+    // The invariant that keeps the abort below deterministic, asserted where it is
+    // load-bearing rather than left to the accident that used to hold it (#9258).
+    // Deliberately a state assertion and not a retry: if the stub is in the index,
+    // `merge --abort` fails on a coin flip, so only the state is reportable — the
+    // symptom is not. It covers every `git add` above, not just the one that broke.
+    check('  …with the gate stub still OUT of the index, so `merge --abort` cannot trip on it',
+      git(['ls-files', '--', 'package.json']).trim() === '');
     git(['merge', '--abort']);
 
     // The push is the other event that can follow a merge: it must not carry an


### PR DESCRIPTION
Fixes #9258

`pnpm check:merge-driver` runs `node scripts/check-regen-pending.mjs --self-test`, and its fixture crashed on ~40% of observed CI runs — 2 of 5 today, across 4 PRs, none of which touch this script:

```
error: Entry 'package.json' not uptodate. Cannot merge.
fatal: Could not reset index file to revision 'HEAD'.
```

## Root cause, measured

The card offered two candidate mechanisms and asked for one to be established. They turn out to be two halves of the same thing, and measurement separates them cleanly.

**1. The defect: the fixture's `package.json` is TRACKED.** It is the harness's gate stub — `runHook` rewrites it to flip the stub `check:spec-changes` between `exit 0` and `exit 1` — and it is no part of the two-commit scenario under test. It became tracked by accident: the `git add -A` on the `side2` branch sweeps it in. Probed directly: `git log --diff-filter=A -- package.json` names the `side2` commit, and the stub is untracked through the whole first merge.

**2. The intermittency: git compares mtime at one-second granularity.** `runHook` is called between `git merge --no-commit --no-ff side2` and `git merge --abort`, so it rewrites a tracked file just after the merge recorded that file's stat data in the index. The stub's content is byte-identical every time, so the file is only ever **stat-dirty** — and `merge --abort` is a `reset --merge`, whose `verify_uptodate` compares mtime in whole seconds. Land the rewrite in the same wall-clock second as the merge's index write and the entry reads clean; land it in the next second and the abort refuses to discard the file.

So it was never "the tree is sometimes dirty". The tree is dirty on every single run. What varies is only whether git can see it.

## Deterministic reproduction

The card asked for this first, and it is the part that makes the rest checkable. All on this box, git 2.43.0:

| scenario | `merge --abort` failed |
|---|---|
| `origin/main` script, as-is | 0/30 |
| `origin/main` script, rewrite delayed past a second boundary | **5/5** |
| isolated replay, rewrite +400ms | 4/10 |
| isolated replay, rewrite +1100ms | 10/10 |
| isolated replay, stub kept out of the index | 0/10 at every delay |
| this PR's script, rewrite delayed past a second boundary | **0/10** |
| this PR's script, as-is | 0/30 |

The forced-failure runs reproduce the CI signature byte for byte, including the frame the issue quotes:

```
Error: Command failed: git merge --abort
error: Entry 'package.json' not uptodate. Cannot merge.
fatal: Could not reset index file to revision 'HEAD'.
    at fixtureSelfTest (.../scripts/check-regen-pending.mjs:455:5)
```

The delay was injected by a PATH shim that pauses 1.1s after any `git merge --no-commit`, modelling a loaded runner. Real git underneath, unmodified; the +400ms row shows the same knob reproducing the observed CI rate.

The local box could never have found this by re-running: it passes 30/30 either way, exactly as the card warned. The variable is timing, and the shim is what supplies it.

## The fix

Shape (c) of the three the card named: the stub never enters the index. One repo-local `info/exclude` line, written right after `git init`, so that **every** `git add` in the fixture — the ones here today and the ones added later — leaves the stub alone. `.git/info/exclude` rather than a `.gitignore`, because a `.gitignore` would itself be a tracked file inside the merges under test: changing the scenario in order to protect the harness.

Shapes (a) and (b) are rejected on the measurement, not on taste:

- **(a) move the abort before the `runHook` that dirties the tree** is unreachable. That `runHook` *is* the assertion — it has to run while `MERGE_HEAD` exists, which is the entire content of the case ("a SECOND merge cannot defer on top of an outstanding deferral").
- **(b) restore `package.json` to its committed content while a merge is in progress** is a no-op. The content already *is* the committed content, byte for byte. Only the stat differs — so restoring content fixes nothing, and restoring the mtime would couple the harness to git's stat-comparison internals, which is a worse thing to depend on than the thing being fixed.

No retry, no `try`/`catch`, no `|| true` anywhere near the abort — per the card, and because a swallowed abort failure is precisely the class of defect this script exists to prevent.

## The regression guard

One new assertion, placed where the invariant is load-bearing:

```
  ✓   …with the gate stub still OUT of the index, so `merge --abort` cannot trip on it
```

Deliberately a **state** assertion rather than the symptom: with the stub in the index the crash is a coin flip, so the state is the only thing reportable. Ablated (exclude removed, assertion kept) it goes red 5/5 with no shim and no crash — an intermittent crash converted into a deterministic, self-explaining assertion failure. It covers every `git add` in the fixture, not only the one that broke.

## Verification

Gate union re-derived with `node scripts/pm/dispatch-gates.mjs` from the **`git merge-base`** diff (not `origin/main..HEAD`), against the one changed path, and run at HEAD `cba224879`:

| gate | result |
|---|---|
| `pnpm check:merge-driver` (derived) | pass — `✓ check-regen-pending self-test passed.` |
| `pnpm check:nul-bytes` | pass — 6067 files, no raw control bytes |
| `pnpm exec eslint scripts/check-regen-pending.mjs --no-inline-config` | pass |
| `pnpm check:required-contexts` | pass |

Self-test pass rate: **30/30 before, 30/30 after** on this box, and **0/10 vs 5/5** under the adverse timing that is the actual bug.

## The second item, stopped and reported

The card asked, if cheap, to make the failure surface say which gate broke — today a merge-driver crash reports as a failing check named `ESLint`.

It is not cheap, and the reason is in-repo. `scripts/check-required-contexts.mjs` pins the job `name:` literals as contract, and `ESLint` is a registered entry (`authorized: '#5617 maintainer ruling 2026-08-07 — applied to the settings the same day'`). A GitHub required status check is matched by check-run name, so renaming the job makes the old required context sit permanently pending, which wedges every PR and the merge queue. The corresponding Settings entry cannot be changed from an agent seat — that same file records `GET /repos/objectstack-ai/objectstack/branches/main/protection` answering 403 `GitHub access is not enabled for this session`, and I re-confirmed there is no `gh` on this runner either.

There is also no atomic ordering: repo-side rename and Settings-side rename cannot land together, so either sequence leaves a window where the gate is pending-forever or silently advisory — the second being #5617 verbatim. That needs a maintainer, so it is filed as #9325 rather than ridden in here — with the two-halves-cannot-land-atomically analysis, the registry pin, and three candidate shapes.

## Changeset

None. The change is confined to `scripts/`, a dev-tooling self-test fixture; nothing published moves. Carrying the `skip-changeset` label instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_
