### PR TITLE
fix(security): explain's field-mask layer reports partial masking — hidden / partially masked / readable (#9127)

### DIFF
--- a/.changeset/explain-partial-mask-reporting.md
+++ b/.changeset/explain-partial-mask-reporting.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/plugin-security": minor
+---
+
+fix(security): security explain reports partial masking — the field-mask layer gains the third state instead of calling gated fields hidden and gate-less rule fields readable (#9127)
+
+<!-- adr-0087: not-required (no-migration-prescription) Nothing authorable
+changes. No `packages/spec` property is added, renamed, retired or tombstoned:
+`field.maskingRule` was minted by #8993 and is untouched here, and the explain
+report's own schema (`ExplainLayerSchema`) keeps its exact shape — the fix
+lands entirely in what the `fls` layer's existing `verdict` and `detail` say.
+There is no stored data to migrate and no author-facing spelling to convert. -->
+
+#8993 landed partial masking on the enforcement channel: a field declaring
+`maskingRule` is no longer deleted from a masked caller's response, its value
+is **replaced** (`13812345678` → `138****5678`), with the field's
+`requiredPermissions` acting as the unmask gate. The access-explanation
+engine's field-mask layer predates that and read only the binary mask, so on
+the one surface whose whole job is to describe enforcement it stated two
+things that were not true:
+
+- a field with `maskingRule` **and** a `requiredPermissions` gate the caller
+  does not hold was listed under *"N field(s) masked from responses"* — an
+  admin reading the report concluded the key was absent, while the caller was
+  in fact receiving the partially masked value;
+- a field with `maskingRule` and **no** gate was reported under *"No
+  field-level masking applies"* — invisible in the report, and masked for
+  every non-system caller in reality.
+
+Both directions matter, and they fail opposite ways: the first overstates the
+protection in place, the second hides that any applies at all.
+
+The `fls` layer now reports the three states the enforcement path actually
+produces — **hidden** (key deleted), **partially masked** (key served, value
+replaced, the applicable rule named) and **readable** — and answers `narrows`
+whenever either dimension bites, where a gate-less rule previously produced
+`not_applicable`.
+
+**Mirrored, not re-derived.** The composition deciding which rules apply to a
+caller — `computePartialMaskRules` AND the explicit-deny exclusion that a
+permission-set `readable: false` still wins outright — is lifted into one
+method on the plugin (`computeReadPartialMaskRules`) that the result-masking
+middleware, the readable-field projection and now explain all call. The
+hidden/partial split in the report is `FieldMasker.maskResults`' own rule
+(`!(field in rules)`), so the report cannot disagree with the masking it
+describes. A second, independent derivation inside the explain engine is
+exactly how this drift opened in the first place; `security-service.ts`'s
+module contract claims explain *"matches enforcement by construction"*, and
+this restores that for the partial-mask dimension.
+
+**Breaking for direct embedders of the engine** (hence `minor`, not `patch`):
+`ExplainEngineDeps` gains a **required** `getPartialMaskRules`. It is required
+rather than optional on purpose — the field-mask decision has three outcomes
+and the existing binary `getFieldMask` can express only two, so an engine
+wired without it would silently reproduce both misreports above. A compile
+error is the correct way for that omission to surface. Callers going through
+`SecurityPlugin` / the `security` service's `explain()` — every consumer in
+this repo — need no change.

--- a/packages/plugins/plugin-security/src/explain-engine.test.ts
+++ b/packages/plugins/plugin-security/src/explain-engine.test.ts
@@ -36,6 +36,7 @@ function makeDeps(overrides: Partial<ExplainEngineDeps> & { sets?: any[]; schema
     },
     computeRlsFilter: async () => overrides.rls !== undefined ? overrides.rls : null,
     getFieldMask: () => ({}),
+    getPartialMaskRules: async () => ({}),
     baselinePermissionSets: ['member_default'],
     ...overrides,
   };
@@ -168,6 +169,153 @@ describe('explainAccess (ADR-0090 D6)', () => {
     const fls = d.layers.find((l) => l.layer === 'fls')!;
     expect(fls.verdict).toBe('narrows');
     expect(fls.detail).toContain('salary');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [#9127] fls — the THREE-state field mask (hidden / partially masked /
+// readable). #8993 landed partial masking on the enforcement channel; this
+// layer reported only the binary mask, so a gated rule field read as fully
+// hidden and a gate-less rule field as fully readable. `getPartialMaskRules`
+// carries the enforcement composition in (never a re-derivation), and the
+// hidden/partial split here is `FieldMasker.maskResults`' own.
+// ---------------------------------------------------------------------------
+describe('explainAccess — fls reports partial masking (#9127)', () => {
+  const flsOf = async (over: Partial<ExplainEngineDeps>) => {
+    const d = await explainAccess(makeDeps(over), {
+      object: 'leave_request',
+      operation: 'read',
+      context: CTX,
+    });
+    return d.layers.find((l) => l.layer === 'fls')!;
+  };
+
+  it('HIDDEN: a field the mask denies with no applicable rule is still reported deleted', async () => {
+    const fls = await flsOf({
+      getFieldMask: () => ({ ssn: { readable: false }, name: { readable: true } }),
+      getPartialMaskRules: async () => ({}),
+    });
+    expect(fls.verdict).toBe('narrows');
+    expect(fls.detail).toContain('1 field(s) masked from responses');
+    expect(fls.detail).toContain('ssn');
+    expect(fls.detail).not.toContain('PARTIALLY');
+  });
+
+  it('PARTIAL (gated): a rule field the caller has not unmasked is NOT reported as hidden', async () => {
+    // The requiredPermissions fold marks `phone` non-readable; the rule turns
+    // that deletion into a replacement, so the caller receives `138****5678`,
+    // not an absent key. Pre-#9127 this read "1 field(s) masked from
+    // responses: [phone]" — the first misreport on the card.
+    const fls = await flsOf({
+      getFieldMask: () => ({ phone: { readable: false } }),
+      getPartialMaskRules: async () => ({ phone: 'phone' }),
+    });
+    expect(fls.verdict).toBe('narrows');
+    expect(fls.detail).not.toContain('masked from responses');
+    expect(fls.detail).toContain('1 field(s) PARTIALLY masked');
+    expect(fls.detail).toContain('phone (phone)');
+  });
+
+  it('PARTIAL (gate-less): a rule with no requiredPermissions is reported, not passed over', async () => {
+    // No permission entry exists for `bank` — the binary mask is silent — yet
+    // every non-system caller sees it masked. Pre-#9127 this layer answered
+    // `not_applicable` / "No field-level masking applies": the second misreport.
+    const fls = await flsOf({
+      getFieldMask: () => ({}),
+      getPartialMaskRules: async () => ({ bank: 'bank_account' }),
+    });
+    expect(fls.verdict).toBe('narrows');
+    expect(fls.detail).not.toBe('No field-level masking applies.');
+    expect(fls.detail).toContain('1 field(s) PARTIALLY masked');
+    expect(fls.detail).toContain('bank (bank_account)');
+  });
+
+  it('READABLE: a field in neither set appears in neither list', async () => {
+    const fls = await flsOf({
+      getFieldMask: () => ({ ssn: { readable: false }, name: { readable: true } }),
+      getPartialMaskRules: async () => ({ phone: 'phone' }),
+    });
+    expect(fls.detail).toContain('masked from responses: [ssn]');
+    expect(fls.detail).toContain('PARTIALLY masked');
+    expect(fls.detail).not.toContain('name');
+  });
+
+  it('reports all three states together, splitting hidden from partially masked', async () => {
+    const fls = await flsOf({
+      getFieldMask: () => ({
+        ssn: { readable: false },
+        phone: { readable: false },
+        name: { readable: true },
+      }),
+      getPartialMaskRules: async () => ({ phone: 'phone', bank: 'bank_account' }),
+    });
+    expect(fls.verdict).toBe('narrows');
+    // `phone` is denied by the binary mask AND carries a rule → partial, not hidden.
+    expect(fls.detail).toContain('1 field(s) masked from responses: [ssn]');
+    expect(fls.detail).toContain('2 field(s) PARTIALLY masked');
+    expect(fls.detail).toContain('phone (phone)');
+    expect(fls.detail).toContain('bank (bank_account)');
+  });
+
+  it('an explicit permission-set DENY stays HIDDEN — explain follows enforcement, it does not assume', async () => {
+    // A rule never widens an explicit deny, so enforcement drops such fields
+    // from `partialRules` before this layer sees them. The engine must report
+    // whatever the composition hands it rather than re-deriving "has a rule ⇒
+    // partial" — that second derivation is how explain drifted in the first place.
+    const fls = await flsOf({
+      getFieldMask: () => ({ phone: { readable: false } }),
+      getPartialMaskRules: async () => ({}),
+    });
+    expect(fls.detail).toContain('masked from responses: [phone]');
+    expect(fls.detail).not.toContain('PARTIALLY');
+  });
+
+  it('names an explicit keepHead/keepTail span rather than a preset', async () => {
+    const fls = await flsOf({
+      getPartialMaskRules: async () => ({ code: { keepHead: 2, keepTail: 2 } }),
+    });
+    expect(fls.detail).toContain('code (keepHead 2, keepTail 2)');
+  });
+
+  it('keeps the D10 delegator suffix when only partial masks apply', async () => {
+    const d = await explainAccess(
+      makeDeps({
+        // A resolvable delegator — otherwise D10 fails closed as 'missing' and
+        // `delegatorSets` stays null, which is a different report entirely.
+        ql: {
+          getSchema: () => PRIVATE_SCHEMA,
+          findOne: async () => ({ id: 'u_boss' }),
+          find: async () => [],
+        },
+        getPartialMaskRules: async () => ({ phone: 'phone' }),
+      }),
+      {
+        object: 'leave_request',
+        operation: 'read',
+        context: { ...CTX, onBehalfOf: { userId: 'u_boss' } },
+      },
+    );
+    const fls = d.layers.find((l) => l.layer === 'fls')!;
+    expect(fls.detail).toContain('PARTIALLY masked');
+    expect(fls.detail).toContain('D10');
+  });
+
+  it('stays not_applicable when neither dimension applies', async () => {
+    const fls = await flsOf({});
+    expect(fls.verdict).toBe('not_applicable');
+    expect(fls.detail).toBe('No field-level masking applies.');
+  });
+
+  it('passes the delegator sets through to the enforcement composition (D10)', async () => {
+    let seen: unknown = 'not-called';
+    await flsOf({
+      getPartialMaskRules: async (_sets, _object, delegatorSets) => {
+        seen = delegatorSets;
+        return {};
+      },
+    });
+    // No on-behalf-of in CTX → the engine must pass null, not undefined.
+    expect(seen).toBeNull();
   });
 });
 

--- a/packages/plugins/plugin-security/src/explain-engine.ts
+++ b/packages/plugins/plugin-security/src/explain-engine.ts
@@ -27,6 +27,7 @@ import {
 } from '@objectstack/core';
 import { matchesFilterCondition } from '@objectstack/formula';
 import { BUILTIN_IDENTITY_PLATFORM_ADMIN, ORGANIZATION_ADMIN_GRANTS } from '@objectstack/spec';
+import type { FieldMaskingRule } from '@objectstack/spec/data';
 import type { PermissionSet } from '@objectstack/spec/security';
 import type {
   AuthzPosture,
@@ -174,6 +175,28 @@ export interface ExplainEngineDeps {
     object: string,
     fieldRequiredPermissions: Record<string, string[]>,
   ) => Record<string, { readable?: boolean; editable?: boolean }>;
+  /**
+   * [#9127] The middleware's EFFECTIVE partial-mask set for this caller — the
+   * `partialRules` argument enforcement hands `FieldMasker.maskResults`, after
+   * the explicit-deny exclusion. Keyed by field, valued by the rule that will
+   * be applied.
+   *
+   * REQUIRED, deliberately. The field-mask decision has three outcomes
+   * (deleted / partially masked / served whole) and the binary
+   * {@link getFieldMask} can express only two, so an engine wired without this
+   * would report a partially-masked field as fully hidden and a gate-less
+   * rule field as fully readable — the exact misreport this dep exists to
+   * close. An optional dep would have let a new embedder re-open it silently;
+   * a required one makes the omission a compile error.
+   *
+   * Supply the enforcement composition, never a re-derivation of it: explain's
+   * module contract is that it "matches enforcement by construction".
+   */
+  getPartialMaskRules: (
+    sets: PermissionSet[],
+    object: string,
+    delegatorSets: PermissionSet[] | null,
+  ) => Promise<Record<string, FieldMaskingRule>>;
   /**
    * Configured additive baseline set NAMES (default `['member_default']`), for
    * attribution.
@@ -502,6 +525,17 @@ export function intersectFieldMasks(
     out[k] = { readable: ar && br, editable: ae && be };
   }
   return out;
+}
+
+/**
+ * [#9127] Render a `maskingRule` for the report. PRESENTATION ONLY — it never
+ * decides whether the rule applies (that is enforcement's call, arriving via
+ * `deps.getPartialMaskRules`); it only names the rule the caller's masked
+ * value was produced by, so an admin reading "why is this `138****5678`" gets
+ * the preset or the explicit span instead of a bare field name.
+ */
+function describeMaskingRule(rule: FieldMaskingRule): string {
+  return typeof rule === 'string' ? rule : `keepHead ${rule.keepHead}, keepTail ${rule.keepTail}`;
 }
 
 /** D1-equivalent OWD reading (mirrors plugin-sharing's effectiveSharingModel). */
@@ -1013,12 +1047,42 @@ export async function explainAccess(deps: ExplainEngineDeps, input: ExplainInput
   const mask = delegatorSets
     ? intersectFieldMasks(agentMask, deps.getFieldMask(delegatorSets, object, secMeta.fieldRequiredPermissions))
     : agentMask;
-  const hidden = Object.entries(mask).filter(([, p]) => p?.readable === false).map(([f]) => f);
+  // [#9127] The field-mask decision has THREE outcomes, not two — hidden
+  // (key deleted), PARTIALLY masked (key served, value replaced by the
+  // field's `maskingRule`), and readable. `deps.getPartialMaskRules` is the
+  // enforcement composition verbatim, never a second derivation of it: the
+  // binary mask below cannot express the middle state, and reading it alone
+  // is what made this layer call a partially-masked field fully hidden and a
+  // gate-less rule field fully readable.
+  //
+  // The hidden/partial split is `FieldMasker.maskResults`' own: it deletes a
+  // field when the binary mask denies it AND no rule applies, so a rule that
+  // survived the explicit-deny exclusion always demotes `hidden` to `partial`
+  // — including the capability-gated case, where the mask says `readable:
+  // false` precisely because the unmask gate is what the rule softens.
+  const partialRules = await deps.getPartialMaskRules(sets, object, delegatorSets);
+  const partial = Object.keys(partialRules);
+  const hidden = Object.entries(mask)
+    .filter(([f, p]) => p?.readable === false && !(f in partialRules))
+    .map(([f]) => f);
+  const listFields = (fields: string[], label: (f: string) => string): string =>
+    `[${fields.slice(0, 25).map(label).join(', ')}${fields.length > 25 ? ', …' : ''}]`;
+  const maskNarrows = hidden.length > 0 || partial.length > 0;
   layers.push({
     layer: 'fls',
-    verdict: hidden.length > 0 ? 'narrows' : 'not_applicable',
-    detail: hidden.length > 0
-      ? `${hidden.length} field(s) masked from responses: [${hidden.slice(0, 25).join(', ')}${hidden.length > 25 ? ', …' : ''}]` +
+    verdict: maskNarrows ? 'narrows' : 'not_applicable',
+    detail: maskNarrows
+      ? [
+          hidden.length > 0
+            ? `${hidden.length} field(s) masked from responses: ${listFields(hidden, (f) => f)}`
+            : null,
+          partial.length > 0
+            ? `${partial.length} field(s) PARTIALLY masked — the key is still served, its value ` +
+              `replaced: ${listFields(partial, (f) => `${f} (${describeMaskingRule(partialRules[f])})`)}`
+            : null,
+        ]
+          .filter((s): s is string => s !== null)
+          .join('; ') +
         (delegatorSets ? ' (intersection of agent + delegator masks, D10).' : '.')
       : 'No field-level masking applies.',
     contributors: [],

--- a/packages/plugins/plugin-security/src/field-masking-rule.test.ts
+++ b/packages/plugins/plugin-security/src/field-masking-rule.test.ts
@@ -341,4 +341,51 @@ describe('SecurityPlugin — maskingRule middleware enforcement (#8993)', () => 
     const readable = await svc.getReadableFields('contact', { userId: 'u1', positions: [], permissions: [] });
     expect(readable).not.toContain('phone');
   });
+
+  // -------------------------------------------------------------------------
+  // [#9127] explain ↔ enforcement, on THIS fixture. The suites above pin what
+  // the caller actually receives; these pin that `explain` says the same thing
+  // about the same (caller, object) pair. Same harness, same permission sets,
+  // same schema — so a future change that moves one channel without the other
+  // fails here rather than shipping an access report that contradicts the
+  // access. That is the module contract's own claim: explain "matches
+  // enforcement by construction".
+  // -------------------------------------------------------------------------
+  const explainFlsFor = async (sets: PermissionSet[], fallback: string, permissions: string[] = []) => {
+    const h = harnessFor(sets, fallback);
+    await h.plugin.init(h.ctx); await h.plugin.start(h.ctx);
+    const svc: any = h.ctx.registerService.mock.calls.find((c: any[]) => c[0] === 'security')?.[1];
+    const decision = await svc.explain(
+      { object: 'contact', operation: 'read' },
+      { userId: 'u1', positions: [], permissions },
+    );
+    return decision.layers.find((l: any) => l.layer === 'fls');
+  };
+
+  it('explain reports the partially masked fields the read path actually serves masked', async () => {
+    const fls = await explainFlsFor([setNoCap], 'msk_member');
+    // The enforcement test above serves this caller `138****5678` / `***…1234`
+    // — the keys ARE present, so neither may be reported deleted.
+    expect(fls.verdict).toBe('narrows');
+    expect(fls.detail).not.toContain('masked from responses');
+    expect(fls.detail).toContain('PARTIALLY masked');
+    expect(fls.detail).toContain('phone (phone)');
+    expect(fls.detail).toContain('bank (bank_account)');
+  });
+
+  it('explain drops the gated field from the masked set once the caller holds the unmask capability', async () => {
+    const fls = await explainFlsFor([setWithCap], 'msk_pii', ['msk_pii']);
+    // Enforcement serves `phone` whole and `bank` masked for this caller.
+    expect(fls.detail).not.toContain('phone');
+    expect(fls.detail).toContain('bank (bank_account)');
+  });
+
+  it('explain reports an explicit permission-set DENY as HIDDEN, not partially masked', async () => {
+    const fls = await explainFlsFor([setFieldDeny], 'msk_deny');
+    // Enforcement DELETES the key for this caller (a rule never widens an
+    // explicit deny), so the report must say deleted — not "value replaced".
+    expect(fls.detail).toContain('masked from responses');
+    expect(fls.detail).toContain('phone');
+    expect(fls.detail).not.toContain('phone (phone)');
+  });
 });

--- a/packages/plugins/plugin-security/src/metadata-unresolvable-posture.test.ts
+++ b/packages/plugins/plugin-security/src/metadata-unresolvable-posture.test.ts
@@ -195,6 +195,7 @@ describe('[#3545] unresolvable object metadata — security posture fails closed
         },
         computeRlsFilter: async () => null,
         getFieldMask: () => ({}),
+        getPartialMaskRules: async () => ({}),
         baselinePermissionSets: ['member_default'],
       }) as any;
 

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -2610,12 +2610,9 @@ export class SecurityPlugin implements Plugin {
         // EXCEPT where a permission set explicitly marks the field
         // non-readable (strictest wins: a masking rule never widens an
         // explicit deny, so those callers keep getting the key deleted).
-        const partialRules = this.computePartialMaskRules(secMeta, permissionSets, delegatorSets);
-        for (const f of Object.keys(partialRules)) {
-          if (basePerms[f]?.readable === false || delBasePerms?.[f]?.readable === false) {
-            delete partialRules[f];
-          }
-        }
+        const partialRules = this.computeReadPartialMaskRules(
+          secMeta, permissionSets, delegatorSets, basePerms, delBasePerms,
+        );
         if (Object.keys(fieldPerms).length > 0 || Object.keys(partialRules).length > 0) {
           opCtx.result = this.fieldMasker.maskResults(opCtx.result, fieldPerms, opCtx.object, partialRules);
         }
@@ -3133,6 +3130,18 @@ export class SecurityPlugin implements Plugin {
           let fp = this.permissionEvaluator.getFieldPermissions(o, sets as any);
           fp = this.foldFieldRequiredPermissions(fp, fieldRequired, sets as any);
           return fp as any;
+        },
+        // [#9127] The partial-mask dimension of the SAME field-mask decision,
+        // read straight off the enforcement composition (`maskResults`' own
+        // `partialRules` argument) rather than re-derived — explain reports the
+        // three states, it does not compute them.
+        getPartialMaskRules: async (sets, o, delSets) => {
+          const meta = await this.getObjectSecurityMeta(o);
+          const basePerms = this.permissionEvaluator.getFieldPermissions(o, sets as any);
+          const delBasePerms = delSets
+            ? this.permissionEvaluator.getFieldPermissions(o, delSets as any)
+            : null;
+          return this.computeReadPartialMaskRules(meta, sets as any, delSets as any, basePerms, delBasePerms);
         },
         baselinePermissionSets: this.baselinePermissionSets,
         // ── record-grained deps (only consulted when recordId is present) ──
@@ -3764,12 +3773,9 @@ export class SecurityPlugin implements Plugin {
     // whose masked values the same caller's rows carry). Mirrors the step-4
     // exclusion exactly: an explicit permission-set deny keeps the field
     // deleted, hence out of the projection.
-    const partialRules = this.computePartialMaskRules(secMeta, permissionSets, delegatorSets);
-    for (const f of Object.keys(partialRules)) {
-      if (basePerms[f]?.readable === false || delBasePerms?.[f]?.readable === false) {
-        delete partialRules[f];
-      }
-    }
+    const partialRules = this.computeReadPartialMaskRules(
+      secMeta, permissionSets, delegatorSets, basePerms, delBasePerms,
+    );
 
     // Readable = every schema field NOT explicitly masked non-readable. A field
     // with no permission entry passes through (the field allow-list only
@@ -5585,6 +5591,42 @@ export class SecurityPlugin implements Plugin {
       if (!unmasked) out[field] = rule;
     }
     return out;
+  }
+
+  /**
+   * [#8993 / #9127] The READ path's EFFECTIVE partial-mask set: the caller's
+   * applicable rules ({@link computePartialMaskRules}) MINUS every field an
+   * explicit permission-set grant marks non-readable.
+   *
+   * That subtraction is the second half of the enforcement semantics and it is
+   * NOT expressible from the folded mask: `foldFieldRequiredPermissions` forces
+   * `readable: false` on exactly the capability-gated fields a masking rule is
+   * meant to cover, so the exclusion must consult the RAW evaluator maps
+   * (`basePerms` / `delBasePerms`) — a rule never widens an explicit deny,
+   * while a capability gate it does soften into a partial mask.
+   *
+   * It lives here, in one place, because THREE surfaces have to agree on it —
+   * result masking (step 4), the readable-field projection
+   * ({@link getReadableFields}) and the explain engine's `fls` layer (#9127).
+   * The explain surface's own module contract promises it "matches enforcement
+   * by construction"; a second, independent derivation of this composition is
+   * precisely how that promise was broken once already, so explain calls THIS
+   * method through its injected dep instead of re-deriving the shape.
+   */
+  private computeReadPartialMaskRules(
+    secMeta: { fieldMaskingRules: Record<string, FieldMaskingRule>; fieldRequiredPermissions: Record<string, string[]> },
+    permissionSets: PermissionSet[],
+    delegatorSets: PermissionSet[] | null,
+    basePerms: Record<string, { readable?: boolean; editable?: boolean }>,
+    delBasePerms: Record<string, { readable?: boolean; editable?: boolean }> | null,
+  ): Record<string, FieldMaskingRule> {
+    const rules = this.computePartialMaskRules(secMeta, permissionSets, delegatorSets);
+    for (const f of Object.keys(rules)) {
+      if (basePerms[f]?.readable === false || delBasePerms?.[f]?.readable === false) {
+        delete rules[f];
+      }
+    }
+    return rules;
   }
 
   private foldFieldRequiredPermissions(


### PR DESCRIPTION
Fixes #9127

## What was wrong

#8993 landed partial masking on the enforcement channel: a field declaring `maskingRule` is no longer deleted from a masked caller's response — its value is **replaced** (`13812345678` becomes `138****5678`), with the field's `requiredPermissions` acting as the unmask gate.

The explain engine's field-mask layer predates that change and read only the binary mask from `getFieldMask`. On the one surface whose entire job is to describe enforcement, it stated two things that were not true — both reproduced verbatim by the ablation below:

| case | shipped report | what the caller actually gets |
| --- | --- | --- |
| `maskingRule` + a `requiredPermissions` gate the caller lacks | `1 field(s) masked from responses: [phone]` | the key IS served, carrying `138****5678` |
| `maskingRule` with no gate | `No field-level masking applies.` (verdict `not_applicable`) | masked for every non-system caller |

They fail in opposite directions: the first overstates the protection in place, the second hides that any applies at all. `security-service.ts`'s module contract claims explain "runs the same resolution/evaluator/compiler the enforcement path uses, so the explanation matches enforcement by construction" — the partial-mask dimension had fallen outside that construction.

## The fix

The `fls` layer now reports the three states enforcement actually produces — **hidden** (key deleted), **partially masked** (key served, value replaced, applicable rule named) and **readable** — and answers `narrows` whenever either dimension bites.

**Mirrored, not re-derived** (the binding instruction from triage). The composition that decides which rules apply to a caller is `computePartialMaskRules` **plus** the explicit-deny exclusion — a permission-set `readable: false` still wins outright, and that exclusion must consult the RAW evaluator map, because `foldFieldRequiredPermissions` forces `readable: false` on exactly the capability-gated fields a rule is meant to soften. That two-part composition was already duplicated at two enforcement sites; it is lifted into one `SecurityPlugin.computeReadPartialMaskRules` that result masking (step 4), the readable-field projection (`getReadableFields`) and now explain all call.

Explain reaches it through a new **required** `ExplainEngineDeps.getPartialMaskRules`, and the hidden/partial split in the report is `FieldMasker.maskResults`' own rule (a field carrying a surviving rule is never in the delete set). The engine reports the three states; it derives none of them.

`getPartialMaskRules` is required rather than optional deliberately: the field-mask decision has three outcomes and the existing binary `getFieldMask` can express only two, so an engine wired without it would silently reproduce both misreports above. A compile error is the right way for that omission to surface. Every consumer in this repo goes through `SecurityPlugin` / the `security` service's `explain()` and needs no change.

## Reverse verification — direction predicted before running

Predicted **red** on the two misreports, **green** on the states the old code already got right. The ablation kept the dep plumbing and reverted only the reporting rule, so nothing could fail for a missing-symbol reason. Observed, against the committed fix:

```
× PARTIAL (gated) …     expected '1 field(s) masked from responses: [ph…' not to contain 'masked from responses'
× PARTIAL (gate-less) … expected 'not_applicable' to be 'narrows'
× explain reports the partially masked fields the read path actually serves masked   (integration)
× explain drops the gated field from the masked set once the caller holds the unmask capability
  … 8 failed | 1284 passed (1292)
```

Both card misreports reproduced exactly. Green in both directions, as predicted: the `HIDDEN` control, `stays not_applicable when neither dimension applies`, and **both** explicit-permission-set-deny cases — the state where a rule must NOT demote a deletion. The ablation was reverted from the commit and the tree re-verified clean (zero `ABLATION` markers).

## Tests

New coverage pins all three states, in two places:

- **`explain-engine.test.ts`** — unit, 10 cases: each state alone, all three together, a rule that lost to an explicit deny (staying hidden), the `keepHead`/`keepTail` rule label, the D10 delegator suffix, and the delegator-sets pass-through.
- **`field-masking-rule.test.ts`** — integration, 3 cases on the **same harness, permission sets and schema** the #8993 enforcement suites use, so explain and enforcement are asserted about one fixture. A future change that moves one channel without the other fails here instead of shipping an access report that contradicts the access.

`metadata-unresolvable-posture.test.ts` builds its own deps literal and gained the same default.

## Verification, at `032321660` (the final commit)

- `pnpm --filter @objectstack/plugin-security test` — **66 files, 1292 tests, all passing**
- `pnpm --filter @objectstack/plugin-security typecheck` — clean
- Gates derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths, all run and passing: `check:nul-bytes`, `check:authz-resolver`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-cross-package-test-inputs.mjs`, `check-empty-changeset.mjs`, `check-affected-docs.mjs`
- The two gates needing a built workspace were run on a real build (`turbo run build`, 70/70 successful) rather than skipped: **`check:i18n`** — 9 packages, all bundles in sync; **`check:type-check-debt --re-measure`** — 33 ledger entries re-measured, 1926 raw tsc errors total, none above its recorded number. `plugin-security` carries a `TEST_DEBT` entry (`errors: 11`), so edits to its test files genuinely move this ratchet — hence the full run rather than a reasoned skip.

Changeset added (`minor` — the required dep is type-breaking for a direct embedder of the engine).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_