### PR TITLE
fix(create-objectstack): drop stale description on scaffold instead of carrying it over

### DIFF
--- a/.changeset/create-objectstack-drop-stale-description.md
+++ b/.changeset/create-objectstack-drop-stale-description.md
@@ -1,0 +1,32 @@
+---
+"create-objectstack": patch
+---
+
+Fix scaffolded projects describing themselves as the blank template (#9263)
+
+`rewriteProjectIdentity` rewrote `id` / `namespace` / `name` in both
+`objectstack.config.ts` and `objectstack.manifest.json` from the project name,
+but left `description` untouched — every scaffolded project carried the blank
+template's own line verbatim ("Minimal ObjectStack environment — a clean
+slate for building."), confidently wrong rather than empty, and printed by
+the first command the getting-started flow tells people to run (`os
+validate`).
+
+The scaffolder now drops `description` from both files instead of rewriting
+it. There is nothing but the project name to derive a replacement from, and a
+name-derived sentence (e.g. "Support Desk — an ObjectStack environment.")
+would be a bare restatement of the `name`/`displayName` row already shown —
+worse than no sentence at all. `os validate` already omits the description
+line entirely when the field is unset, so a freshly scaffolded project now
+prints cleanly:
+
+```
+  Support Desk v0.1.0
+```
+
+instead of
+
+```
+  Support Desk v0.1.0
+  Minimal ObjectStack environment — a clean slate for building.
+```

--- a/packages/create-objectstack/src/index.ts
+++ b/packages/create-objectstack/src/index.ts
@@ -24,6 +24,15 @@
  *   - objectstack.config.ts     manifest.id and manifest.name string literals
  *   - README.md                 first H1
  *
+ * The template's own `manifest.description` is DROPPED from both
+ * objectstack.manifest.json and objectstack.config.ts rather than carried
+ * over unrewritten (#9263): it describes the bundled template ("Minimal
+ * ObjectStack environment — a clean slate for building."), not the project
+ * being scaffolded, and there is nothing but the project name to derive a
+ * replacement from — which would only restate `name`/`displayName`. `os
+ * validate` already omits the description line entirely when the field is
+ * absent, so this is a clean landing rather than a placeholder.
+ *
  * Then we run `<pm> install` — and only afterwards can the Dockerfile's runtime
  * image tag be pinned, because the template carries a caret range and the tag
  * has to name the @objectstack/cli version npm actually resolved (#9017). With
@@ -164,7 +173,17 @@ function rewriteProjectIdentity(
     }
   }
 
-  // objectstack.manifest.json — set .name, .displayName, .namespace
+  // objectstack.manifest.json — set .name, .displayName, .namespace, and DROP
+  // .description (#9263). The template ships a generic line describing
+  // ITSELF ("Minimal ObjectStack environment — a clean slate for building."),
+  // not the project being scaffolded, and there is nothing but the project
+  // name to derive a replacement from — a name-derived sentence would be a
+  // bare restatement of `name`/`displayName` (e.g. "Support Desk — an
+  // ObjectStack environment.") and add no information the manifest doesn't
+  // already show. Measured against `os validate`'s printer
+  // (packages/cli/src/commands/validate.ts), which already skips the
+  // description line entirely when the field is absent — so dropping the key
+  // here is a clean, already-supported landing rather than a placeholder.
   const manifestPath = path.join(targetDir, 'objectstack.manifest.json');
   if (fs.existsSync(manifestPath)) {
     try {
@@ -172,6 +191,7 @@ function rewriteProjectIdentity(
       m.name = projectName;
       m.displayName = title;
       if ('namespace' in m) m.namespace = namespace;
+      delete m.description;
       fs.writeFileSync(manifestPath, JSON.stringify(m, null, 2) + '\n');
     } catch {
       // ignore
@@ -179,13 +199,21 @@ function rewriteProjectIdentity(
   }
 
   // objectstack.config.ts — rewrite manifest.id, manifest.name, manifest.namespace
-  // string literals. Conservative: only touches the first occurrence of each key.
+  // string literals, and DROP the manifest.description line for the same
+  // reason as above (#9263). Conservative: only touches the first occurrence
+  // of each key, and the description removal is anchored to the start of its
+  // own line so it cannot bleed into an unrelated `description:` elsewhere in
+  // the file. Checked against the shipped template (the only one this
+  // scaffolder bundles): `objectstack.config.ts` carries exactly one
+  // `description:`, inside `manifest` — the same single-occurrence property
+  // the pre-existing `name:`/`namespace:`/`id:` regexes above already rely on.
   const configPath = path.join(targetDir, 'objectstack.config.ts');
   if (fs.existsSync(configPath)) {
     let cfg = fs.readFileSync(configPath, 'utf8');
     cfg = cfg.replace(/(\bid:\s*)(['"`])[^'"`]*\2/, `$1$2${projectName}$2`);
     cfg = cfg.replace(/(\bnamespace:\s*)(['"`])[^'"`]*\2/, `$1$2${namespace}$2`);
     cfg = cfg.replace(/(\bname:\s*)(['"`])[^'"`]*\2/, `$1$2${title}$2`);
+    cfg = cfg.replace(/^[ \t]*description:\s*(['"`])[^'"`]*\1,?\r?\n/m, '');
     fs.writeFileSync(configPath, cfg);
   }
 

--- a/packages/create-objectstack/src/scaffold-description.test.ts
+++ b/packages/create-objectstack/src/scaffold-description.test.ts
@@ -11,9 +11,9 @@
 // `rewriteProjectIdentity` is not exported (and cannot be imported directly:
 // index.ts calls `program.parse()` at module scope — see
 // template-consistency.test.ts's comment on the same constraint), so this
-// exercises the real CLI end to end via `tsx`, the same no-build pattern
-// `packages/spec/scripts/dist-freshness.test.ts` uses to run a TS entrypoint
-// as a subprocess without depending on a prior `pnpm build`.
+// exercises the real CLI end to end via `tsx`, the same no-build pattern the
+// spec package's dist-freshness test uses to run a TS entrypoint as a
+// subprocess without depending on a prior `pnpm build`.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';

--- a/packages/create-objectstack/src/scaffold-description.test.ts
+++ b/packages/create-objectstack/src/scaffold-description.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+//
+// Regression cover for #9263: `rewriteProjectIdentity` rewrote manifest.id /
+// manifest.namespace / manifest.name (both in objectstack.config.ts and
+// objectstack.manifest.json) but left `description` untouched, so every
+// scaffolded project inherited the blank template's own line verbatim
+// ("Minimal ObjectStack environment — a clean slate for building.") —
+// confidently wrong on the first command the getting-started flow runs
+// (`os validate`), not merely empty.
+//
+// `rewriteProjectIdentity` is not exported (and cannot be imported directly:
+// index.ts calls `program.parse()` at module scope — see
+// template-consistency.test.ts's comment on the same constraint), so this
+// exercises the real CLI end to end via `tsx`, the same no-build pattern
+// `packages/spec/scripts/dist-freshness.test.ts` uses to run a TS entrypoint
+// as a subprocess without depending on a prior `pnpm build`.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(HERE, '..');
+const REPO_ROOT = path.resolve(PKG_ROOT, '..', '..');
+const TSX = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+const INDEX_TS = path.join(PKG_ROOT, 'src', 'index.ts');
+
+const TEMPLATE_DESCRIPTION_CONFIG =
+  'Minimal ObjectStack environment — a clean slate for building.';
+const TEMPLATE_DESCRIPTION_MANIFEST =
+  'Minimal ObjectStack environment with a single object — a clean slate for building.';
+
+let tmp: string;
+let projectDir: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'create-objectstack-desc-'));
+  execFileSync(
+    TSX,
+    [INDEX_TS, 'support-desk', '--template', 'blank', '--skip-install', '--skip-skills'],
+    { cwd: tmp, stdio: 'pipe' },
+  );
+  projectDir = path.join(tmp, 'support-desk');
+}, 30_000);
+
+afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+describe('scaffolded project description (#9263)', () => {
+  it('does not carry the blank template\'s own description into objectstack.manifest.json', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(projectDir, 'objectstack.manifest.json'), 'utf8'),
+    );
+    expect(manifest.description).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(manifest, 'description')).toBe(false);
+    // Sanity: prove this is a real assertion, not a check the template never
+    // shipped the key in the first place.
+    const templateManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(PKG_ROOT, 'src', 'templates', 'blank', 'objectstack.manifest.json'),
+        'utf8',
+      ),
+    );
+    expect(templateManifest.description).toBe(TEMPLATE_DESCRIPTION_MANIFEST);
+  });
+
+  it('does not carry the blank template\'s own description into objectstack.config.ts', () => {
+    const cfg = fs.readFileSync(path.join(projectDir, 'objectstack.config.ts'), 'utf8');
+    expect(cfg).not.toContain('description:');
+    expect(cfg).not.toContain(TEMPLATE_DESCRIPTION_CONFIG);
+    // Sanity: the template source really does ship the line this asserts is gone.
+    const templateConfig = fs.readFileSync(
+      path.join(PKG_ROOT, 'src', 'templates', 'blank', 'objectstack.config.ts'),
+      'utf8',
+    );
+    expect(templateConfig).toContain(`description: '${TEMPLATE_DESCRIPTION_CONFIG}'`);
+  });
+
+  it('still rewrites id/namespace/name — the description drop does not regress the existing rewrite', () => {
+    const cfg = fs.readFileSync(path.join(projectDir, 'objectstack.config.ts'), 'utf8');
+    expect(cfg).toContain("id: 'support-desk'");
+    expect(cfg).toContain("namespace: 'support_desk'");
+    expect(cfg).toContain("name: 'Support Desk'");
+    // The line immediately after the (now-removed) description must still be
+    // the `engines` comment/key — i.e. no stray blank line or dangling comma
+    // was left behind by the line-removal regex.
+    expect(cfg).toMatch(/name: 'Support Desk',\n\s*\/\/ Protocol compatibility range/);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(projectDir, 'objectstack.manifest.json'), 'utf8'),
+    );
+    expect(manifest.name).toBe('support-desk');
+    expect(manifest.namespace).toBe('support_desk');
+    expect(manifest.displayName).toBe('Support Desk');
+  });
+
+  it('produces objectstack.config.ts that still parses as valid TypeScript', () => {
+    // A regex-based line removal is exactly the kind of edit that can silently
+    // corrupt surrounding syntax (stray comma, unbalanced brace). Parse the
+    // scaffolded file with the TypeScript compiler's single-file transpile
+    // (syntactic-only — it never attempts to resolve `@objectstack/*`, so a
+    // real syntax defect can't hide behind an unrelated "cannot find module").
+    const source = fs.readFileSync(path.join(projectDir, 'objectstack.config.ts'), 'utf8');
+    const { diagnostics } = ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+      reportDiagnostics: true,
+    });
+    const messages = (diagnostics ?? []).map((d) =>
+      ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+    );
+    expect(messages).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #9263

## Problem

`rewriteProjectIdentity` (`packages/create-objectstack/src/index.ts`) rewrites `id` / `namespace` / `name` in both `objectstack.config.ts` and `objectstack.manifest.json` from the project name, but `description` was in neither key list. Every scaffolded project therefore carried the blank template's own line verbatim ("Minimal ObjectStack environment — a clean slate for building.") — confidently wrong, not empty, and printed by the first command the getting-started flow tells people to run (`os validate`).

## Fix

Both files now **drop** `description` at scaffold time instead of rewriting it:

- `objectstack.manifest.json`: `delete m.description;` alongside the existing `.name`/`.displayName`/`.namespace` rewrite.
- `objectstack.config.ts`: a new line-anchored regex (`^[ \t]*description:\s*(['"\`])[^'"\`]*\1,?\r?\n`) removes the whole `description:` line, alongside the existing `id`/`namespace`/`name` literal rewrites.

## Route decision: omit vs. derive (Zone 1 rule 2)

Measured, per the card's rule ("if the derived string would be a bare restatement of the project name … prefer omission"): the only input available at scaffold time is the project name itself, so any name-derived sentence (e.g. `"Support Desk — an ObjectStack environment."`) would restate exactly what the adjacent `name`/`displayName` row already shows — every scaffolded project would get the same generic suffix, carrying zero project-specific information. **Chose omission (b).**

Confirmed `os validate` (`packages/cli/src/commands/validate.ts:293-295`) already skips the description line entirely when the field is absent — this is a clean, already-supported landing rather than a placeholder. Confirmed `description` is `.optional()` on both the runtime manifest schema (`packages/spec/src/kernel/manifest.zod.ts`) and the template-manifest schema (`packages/spec/src/cloud/package.zod.ts`, inherited by `TemplateManifestSchema`), so omitting is spec-valid on both files.

Scaffolded and ran the CLI to observe the before/after directly:

```
# before
  Support Desk v0.1.0
  Minimal ObjectStack environment — a clean slate for building.

# after
  Support Desk v0.1.0
```

## Regex-over-source-text hazard (Zone 2 warning)

Checked what else in the shipped `blank` template declares `description` before writing the pattern, since `rewriteProjectIdentity`'s rewrites are regex replacements over source text, not structured edits:

- `objectstack.config.ts` has exactly **one** `description:` (inside `manifest`) — same single-occurrence property the pre-existing `name:`/`namespace:`/`id:` regexes already rely on.
- `objectstack.manifest.json` has exactly one `description` key (plain JSON property deletion, no regex).
- `src/objects/note.object.ts` also declares a `description`, but it's a **separate file** `rewriteProjectIdentity` never reads — no risk of cross-file bleed.
- `blank` is the only bundled template (`template-registry.ts`); the five remote templates are retired and unreachable.

The new removal regex is additionally anchored to the start of its own line (`^[ \t]*description:`), narrower than the existing unanchored `name:`/`namespace:`/`id:` patterns.

## Scope

File surface held to `packages/create-objectstack/src/index.ts` + a new sibling test (`scaffold-description.test.ts`) — no breach. #9264 (protocol-version drift, same package) is untouched, as instructed.

## Coupling (not acted on here)

#9152 (closed/landed) quotes the pre-fix description line verbatim in a transcript, because that's what the program printed at the time. This fix invalidates that transcript — a `domain:devx` follow-up, not an in-scope edit here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_