### PR TITLE
ci: add an always-run roll-up job named `CI` so the queue's required check matches a real check run (#9318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1444,3 +1444,161 @@ jobs:
         with:
           path: packages/console/dist
           key: ${{ runner.os }}-console-dist-${{ hashFiles('.objectui-sha', 'scripts/build-console.sh') }}
+
+  # ── The queue's single required context (#9283 / #9318) ───────────────────
+  #
+  # THE NAME IS THE CONTRACT. Branch protection and the merge queue match a
+  # required check BY CHECK-RUN NAME, and a job's check-run name is its `name:`
+  # value. `name: CI` here is therefore the required-context literal, not a
+  # label: renaming this job silently detaches whatever branch protection lists
+  # — the identical trap `temporal-conformance` records above ("the name IS the
+  # required check, so renaming it would silently drop the gate"). Since #6865
+  # that half is asserted rather than only written down: this literal is pinned
+  # by `check:required-contexts`, so a rename fails in the ESLint job instead of
+  # in the queue.
+  #
+  # ── Why this job exists: two incidents, opposite failure modes ─────────────
+  #
+  #   - #9283: `Temporal Conformance (live PG + MySQL)` failed and the PR merged
+  #     anyway, because that job's name was not in the required set. The
+  #     maintainer's ruling was Option A — the full suite SHOULD block the merge
+  #     queue — and the required set then had to name every gate job one by one,
+  #     a list that drifts every time a gate is added or renamed.
+  #   - The first fix attempt registered the required check as `CI`, which is
+  #     this WORKFLOW's name (line 1) and matched no check run at all. A
+  #     workflow name is not a check-run name. The context sat permanently
+  #     "Expected", green merge groups timed out, and NOTHING merged for ~1h45m
+  #     on 2026-08-17 (11:29Z until the maintainer removed the entry ~13:15Z).
+  #     The failure mode had flipped from "red merges anyway" to "green cannot
+  #     merge".
+  #
+  # This job makes that name real. One context — `CI` — covers every gate below
+  # it, so the required set stops being a hand-maintained roster of job names:
+  # adding a gate to `needs:` here extends the queue's protection with no
+  # settings change, which is the durable form of the #9283 ruling.
+  #
+  # ⛔ Sequencing, recorded because it is what the second incident cost: this
+  # job must be LIVE ON `main` before `CI` goes back into the required set, and
+  # only the maintainer can make that settings change (no agent seat can read or
+  # write Settings → Rulesets — the API answers 403; see
+  # scripts/check-required-contexts.mjs).
+  #
+  # ── What it needs, and what it deliberately does not ──────────────────────
+  #
+  # `needs:` lists the jobs that carry a GATE VERDICT, plus `filter`:
+  #
+  #   test-gate · dogfood-gate · temporal-conformance · build-core ·
+  #   build-docs · console-pin
+  #
+  # `filter` is included because it is not merely plumbing here: if `filter`
+  # itself fails, every downstream `if:` evaluates against EMPTY outputs (see
+  # THE FILTER CONTRACT, #4928), so no scheduling decision in the run was
+  # actually made and a green roll-up would certify a run whose shape nobody
+  # chose. `test-gate` and `dogfood-gate` already read `needs.filter.result` for
+  # that reason; this makes it true for the run as a whole.
+  #
+  # The sharded matrices (`test`, `dogfood`, `dogfood-verify`) are deliberately
+  # ABSENT. Their verdicts reach this job through their aggregate gates, which
+  # COUNT per-shard attestations instead of reading one aggregate word — and
+  # #6082 measured both directions of what reading that word does: run
+  # 31120902911 painted a false red off the undocumented `abandoned`, and run
+  # 31114735713 had that same value SWALLOW a shard's real `failure`. Listing
+  # the matrices here would reintroduce exactly that read, one level up.
+  #
+  # ── Why the results are read explicitly ───────────────────────────────────
+  #
+  # `if: always()` is load-bearing twice over. Without it, a needed job that
+  # fails makes this job SKIP, and a skipped required context publishes nothing
+  # (permanent pending — the #3622 deadlock) or reads as green; and a docs-only
+  # PR, where every core gate is legitimately `skipped` by `filter`, must still
+  # publish a green `CI` or nothing could ever merge. Default `needs:`
+  # propagation cannot express that, which is why the verdict is computed from
+  # `needs.*.result` in the step below rather than left to GitHub.
+  #
+  # The verdict table:
+  #
+  #   success   → pass. The gate ran and was green.
+  #   skipped   → pass. `filter` said this run does not touch that surface; the
+  #               aggregate gates apply #4928's own guard to their skips.
+  #   failure   → FAIL.
+  #   cancelled → FAIL. This diverges on purpose from the shard gates, which
+  #               pass `cancelled` for #3668's reason (a superseded push cancels
+  #               the in-flight matrix, and failing there reds a SHA nobody is
+  #               merging). At whole-gate level the same word means the gate
+  #               never reached a verdict at all, and on a `merge_group` build
+  #               it means the queue build was dropped — neither is something a
+  #               green `CI` may certify. The superseded-SHA cost is unchanged:
+  #               a newer run publishes newer contexts on the newer SHA.
+  #   anything  → FAIL, loudly, naming the value. Runners really do produce
+  #   else        undocumented lifecycle values (`abandoned`, #6082), and the
+  #               maintainer REJECTED whitelisting one as a pass on 2026-08-07:
+  #               a discarded job is not moot while the queue is still consuming
+  #               the run's verdicts, so passing it publishes green over a gate
+  #               that never ran. A false red costs a re-run; a false green
+  #               merges unverified code.
+  #
+  # An empty `needs` context is a failure too, never a pass: a roll-up that read
+  # nothing has verified nothing (#4690).
+  ci-rollup:
+    name: CI
+    needs:
+      - filter
+      - test-gate
+      - dogfood-gate
+      - temporal-conformance
+      - build-core
+      - build-docs
+      - console-pin
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # No checkout: the whole input is the `needs` context, which the runner
+      # already has. Cost is a few seconds of one ubuntu-latest runner per run.
+      - name: Roll up every gate verdict
+        env:
+          # The whole context, so this step covers whatever `needs:` above
+          # lists — one roster to maintain instead of two that can disagree.
+          OS_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error::jq is unavailable on this runner, so no gate verdict could be read. Refusing to publish a green CI over an unread roll-up (#4690)."
+            exit 1
+          fi
+
+          verdicts="$(printf '%s' "$OS_NEEDS" | jq -r 'to_entries[] | "\(.key) \(.value.result // "«absent»")"' | sort)"
+
+          if [ -z "$verdicts" ]; then
+            echo "::error::the needs context is empty — this roll-up read no gate verdicts at all, so it cannot report success (#4690)."
+            exit 1
+          fi
+
+          failed=0
+          while read -r job result; do
+            case "$result" in
+              success|skipped)
+                printf '  ok   %-24s %s\n' "$job" "$result"
+                ;;
+              failure|cancelled)
+                printf '  FAIL %-24s %s\n' "$job" "$result"
+                echo "::error::gate '$job' concluded '$result' — CI is red."
+                failed=1
+                ;;
+              *)
+                printf '  FAIL %-24s %s (unrecognised)\n' "$job" "$result"
+                echo "::error::gate '$job' concluded '$result', which is not one of success/skipped/failure/cancelled. Treating an unrecognised runner lifecycle value as a PASS would publish a green required context over a gate that never ran (#6082); failing closed instead."
+                failed=1
+                ;;
+            esac
+          done <<< "$verdicts"
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::CI roll-up failed — see the per-gate lines above."
+            exit 1
+          fi
+
+          echo "✓ CI: every gate this run scheduled is green (skips counted as pass)."

--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -211,6 +211,25 @@ export const REQUIRED_CONTEXTS = [
     carries: 'the live-server datetime conformance axis (#3912/#3942)',
   },
   {
+    workflow: 'ci.yml',
+    job: 'ci-rollup',
+    context: 'CI',
+    // Enrolled AHEAD of the settings change, deliberately, and this is the one
+    // row where that ordering is the point. #9283's ruling (Option A — the full
+    // suite blocks the queue) was first applied by registering `CI`, which is
+    // ci.yml's WORKFLOW name and matched no check run: the context sat
+    // permanently "Expected" and nothing merged for ~1h45m on 2026-08-17. The
+    // roll-up job makes the name real, and the maintainer re-adds `CI` to the
+    // required set only AFTER this lands. Until then the row is inert, which
+    // this registry's header already licenses ("adding a row here does NOT make
+    // a context required … a pin that is merely inert, never wrong") — while
+    // the pin it buys is live from day one: the whole point of the roll-up is
+    // that one stable string survives every job rename beneath it, so that
+    // string is exactly what must not move unnoticed.
+    authorized: '#9283 maintainer ruling (Option A, 2026-08-17) implemented by #9318; the settings entry is the maintainer step that follows this merge',
+    carries: 'every gate job in ci.yml, rolled up — the single required context that replaces the per-job roster the queue used to need',
+  },
+  {
     workflow: 'adr-merge-approval.yml',
     job: 'adr-merge-approval',
     context: 'ADR maintainer approval',


### PR DESCRIPTION
Fixes #9318

Implements #9283's maintainer ruling (Option A — the full suite blocks the merge queue) in its durable form: one always-run roll-up job whose **check-run name is exactly `CI`**, so the queue's required context finally matches a real check run.

## Why

Branch protection matches a required check **by check-run name**, and a job's check-run name is its `name:` value. The first attempt registered `CI` — which is this workflow's **workflow** name (line 1 of `ci.yml`), not any job's name. Nothing ever published that context, so it sat permanently "Expected": green merge groups timed out and nothing merged from 11:29Z until the maintainer removed the entry (~13:15Z) on 2026-08-17, ~1h45m. The failure mode had flipped from #9283's "red merges anyway" to "green cannot merge".

With this job, the required set stops being a hand-maintained roster of gate job names: adding a gate to `needs:` here extends the queue's protection with no settings change.

## What changed

**`.github/workflows/ci.yml`** — one appended job, plus the comment block the file's conventions call for (the name-is-the-contract note, the #9283/#9318 lineage, and why the results are read explicitly):

```yaml
  ci-rollup:
    name: CI
    needs: [filter, test-gate, dogfood-gate, temporal-conformance, build-core, build-docs, console-pin]
    if: always()
```

**The `needs:` list was re-derived from the file**, not taken from the card. It matches the card's six gate jobs plus `filter`, and three jobs are deliberately excluded:

| Job | In `needs:`? | Why |
| --- | --- | --- |
| `test-gate`, `dogfood-gate`, `temporal-conformance`, `build-core`, `build-docs`, `console-pin` | yes | the six jobs that carry a gate verdict |
| `filter` | **yes** | not pure plumbing here. If `filter` fails, every downstream `if:` evaluates against **empty outputs** (THE FILTER CONTRACT, #4928), so no scheduling decision in the run was actually made — a green roll-up would certify a run whose shape nobody chose. `test-gate`/`dogfood-gate` already read `needs.filter.result` for that reason; this makes it true for the run as a whole. |
| `test`, `dogfood`, `dogfood-verify` | **no** | their verdicts reach the roll-up through their aggregate gates, which **count per-shard attestations** rather than reading one aggregate word. #6082 measured that read failing in both directions (run 31120902911: a false red off the undocumented `abandoned`; run 31114735713: that same value swallowing a shard's real `failure`). Listing the matrices here would reintroduce exactly that read, one level up. |

**Verdict logic** — computed from `needs.*.result` in a small bash step over `toJSON(needs)`. Default `needs:` propagation is not usable: an upstream failure would make this job **skip**, and a skipped required context is the #3622 deadlock; meanwhile a docs-only PR legitimately skips every core gate and must still publish a green `CI`.

| `needs.*.result` | verdict |
| --- | --- |
| `success`, `skipped` | pass |
| `failure`, `cancelled` | **fail** |
| anything else | **fail**, naming the value |
| empty `needs` context | **fail** (#4690) |

Two of those are judgment calls, stated rather than buried:

- **`cancelled` fails**, diverging on purpose from the shard gates, which pass it for #3668's reason (a superseded push cancels the in-flight matrix, and failing there reds a SHA nobody is merging). At whole-gate level the word means the gate never reached a verdict, and on a `merge_group` build it means the queue build was dropped — neither is something a green `CI` may certify. The superseded-SHA cost is unchanged: a newer run publishes newer contexts on the newer SHA.
- **Unrecognised values fail closed.** Runners really do produce undocumented lifecycle values (`abandoned`, #6082), and the maintainer rejected whitelisting one as a pass on 2026-08-07: a discarded job is not moot while the queue is still consuming the run's verdicts. A false red costs a re-run; a false green merges unverified code.

**`scripts/check-required-contexts.mjs`** — one registry row pinning `ci.yml:ci-rollup → 'CI'`. This is the one file outside the card's declared surface, so the reasoning is here rather than implied: the pin (#6865) exists precisely so a rename cannot silently detach branch protection, and `CI` is about to be the single most load-bearing check name in the repo. Without the row it would be the **only** required context with no repo-side protection. The row is enrolled ahead of the settings change deliberately — the registry's own header licenses that ("adding a row here does NOT make a context required … a pin that is merely inert, never wrong"), and the `authorized` field says so in full. Reviewer's call: dropping this hunk leaves the workflow change fully functional and costs only the rename protection.

Not touched: triggers (`pull_request` + `merge_group` were already there), the `filter` job and what it skips, any other workflow, any repository setting.

## Sequencing — the maintainer step that follows

⛔ **This PR must merge through the queue before the settings change.** After it lands, the **maintainer** re-adds `CI` to the required checks (no agent seat can read or write Settings → Rulesets; the API answers 403). At that point the interim per-job entries — and even `Test Core` / `Dogfood Regression Gate` — can be pruned to the single `CI` entry.

## Verification

Union re-run after the final commit, at **`9b207e0`** (= `git rev-parse --short HEAD` at that run):

```
✓ check-required-contexts --self-test: 55 assertions
✓ check-required-contexts: 10 required context name(s) pinned across 3 workflow(s).
    ci.yml:ci-rollup → 'CI'                     ← new
✓ check-shard-attestation --self-test: 92 assertions
✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).
✓ check-workflow-status-functions --self-test: 34 assertions
check-workflow-status-functions: OK (25 workflow file(s), 45 job(s), 25 job-level if: expression(s);
  9 read needs.*.outputs.*, all naming a status function).
check-node-version: OK (28 setup-node step(s) across 25 workflow(s), all on Node 22).
✓ check-nul-bytes --self-test: 75 assertions
check-nul-bytes: OK (scanned 6076 text file(s); no raw ASCII control bytes).
eslint scripts/check-required-contexts.mjs — clean
```

Gate families derived, not recalled — `node scripts/pm/dispatch-gates.mjs .github/workflows/ci.yml scripts/check-required-contexts.mjs` names exactly those five, and re-deriving against the *actual* changed paths (both files) added nothing beyond the single-path derivation.

**Reverse verification of the pin** (run from the committed state, then restored and confirmed byte-identical to HEAD). Predicted direction: red, naming the job and the context. Observed:

```
✗ check-required-contexts — 1 problem(s)
  • ci.yml: job 'ci-rollup' is named "CI Roll-up", but branch protection requires the context 'CI'.
    The name IS the contract: GitHub matches a required check by its check-run name, so this rename
    silently detaches the gate. …
```

**The verdict logic was executed**, not eyeballed: the step's real `run:` text was lifted out of the parsed `ci.yml` (never retyped) and driven against synthetic `needs` contexts. All eight scenarios behaved as designed — including the card's three acceptance criteria:

| Scenario | exit |
| --- | --- |
| all gates green | 0 |
| **docs-only PR** (core gates `skipped` by `filter`) | **0** ✅ acceptance 1 |
| every gate skipped | 0 |
| **`temporal-conformance` = `failure`** (the #9283 job) | **1** ✅ acceptance 2 |
| a gate `cancelled` | 1 |
| `filter` itself failed | 1 |
| `abandoned` (#6082's undocumented value) | 1 |
| empty `needs` context (#4690) | 1 |

Acceptance 3 (the name is exactly `CI` in the check-run list) is what `check:required-contexts` now pins, and what the parsed YAML reports: `ci-rollup => "CI"`.

## Tier derivation

Verbatim from `node scripts/pm/dispatch-gates.mjs --tier .github/workflows/ci.yml`:

```
Model tier — no path-derived mandate: the surface hits none of the 1 declared glob(s), derived here, not recalled.
  The tier stays the PM's per-card judgment call (floor sonnet · default opus · ceiling fable).
  Clause ② is NOT reachable from paths: a card that changes contract accept/reject behaviour or widens the public surface is fable-mandatory too, judged from the card CONTENT. This line is a FLOOR, never a clearance.
```

## Changeset

None — workflow + gate-script only, nothing user-facing is published. Declared the way this repo actually declares it, the `skip-changeset` label (`pr-automation.yml`'s `changeset-check` exemption), applied at PR-creation time and read back after the labeler settled.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_