### PR TITLE
fix(objectql): make the statement cut template-aware so a value containing " - " keeps the diagnostic's head (#9275)

### DIFF
--- a/.changeset/value-bearing-cut-template-head.md
+++ b/.changeset/value-bearing-cut-template-head.md
@@ -1,0 +1,55 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/driver-sql": patch
+---
+
+fix(objectql): a caller value containing " - " no longer eats the diagnostic's template head, and no longer leaves its own suffix in the log (#9275)
+
+`redactStatementFromMessage` cuts the bound statement off a driver error at the
+**last** ` - `, because a bound value may itself contain that separator and
+cutting at the first would leave a fragment of the value standing.
+
+When the value the DATABASE inlines into its own diagnostic also contains ` - `,
+that reasoning inverts: the last separator lands **inside the diagnostic's
+value**, so the cut discards the template head — the half that could not leak —
+and keeps a suffix of the caller's data, which is the half that does. Re-measured
+at HEAD on live PostgreSQL 16.13 with the canary
+`SENSITIVE-CANARY-9275 - 2026 - Q3`:
+
+```
+raised:   insert into "t" ("age") values ($1)
+            - invalid input syntax for type integer: "SENSITIVE-CANARY-9275 - 2026 - Q3"
+logged:   Q3" [statement and bound values redacted]
+```
+
+`Q3` is the caller's data, at ERROR level, which is what this neighbourhood
+exists to prevent. Families with a right anchor (`for key …`,
+`for column … at row N`) already recovered through their `tail` pattern; the ones
+whose value runs to end of message had nothing to recover from.
+
+**The cut is now template-aware.** When a separator in the message stands
+immediately before a diagnostic head this file has measured, that separator is
+the true cut point whatever its position: the head survives and the value after
+it — separator and all — is dropped whole by the template that owns it. After
+the fix the same error logs
+`invalid input syntax for type integer: [value redacted] [statement and bound
+values redacted]`, so the operator keeps strictly more diagnostic than before.
+
+**Three families, not the two the card named.** `pg 22003` was left without a
+head-gone recovery on the reasoning that an out-of-range value is a number and a
+number cannot contain ` - `. Measured through the driver's own bind path, that is
+false — Postgres detects the overflow while scanning digits, *before* it rejects
+the trailing junk, so it echoes the caller's whole string:
+`insert({ age: '99999999999 - 2026 - Q3' })` logged `Q3` too. It keeps its right
+anchor, so it takes the #8823 anchor recovery rather than the new cut.
+
+The trade this takes deliberately, and its bound: matching a template before the
+cut lets a hostile value steer where the cut lands. That steering is bounded to
+**over-redaction, never exposure** — a template may declare a head only if its
+value runs to end of message, so a cut landing inside a statement is swallowed
+whole by that template; and the **last** matching head wins, so a value that
+mimics a head is cut at the mimic and cannot survive behind its own decoy. What a
+crafted value can do is suppress a real diagnostic; that cost is asserted by its
+own case rather than left to be discovered. The six identifier-bearing families
+the live probe pins are untouched — over-matching deletes the diagnostic an
+operator came for, and remains the expensive direction.

--- a/packages/drivers/driver-sql/src/sql-driver-diagnostic-value-probe.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-diagnostic-value-probe.test.ts
@@ -63,6 +63,20 @@ const MATRIX = 'value-bearing diagnostic';
 /** Planted so a leak is unmistakable in the recorded output. */
 const CANARY = 'SENSITIVE-CANARY-9160';
 
+/**
+ * [#9275] The same canary, carrying the statement separator INSIDE itself.
+ *
+ * knex joins `<statement> - <native message>`, and the redactor cuts at the last
+ * ` - `. When the value the server inlines into its OWN diagnostic contains the
+ * separator, that last ` - ` lands inside the value: the cut eats the template
+ * head and keeps a suffix of the caller's data. This canary is what makes that
+ * shape reproducible instead of anecdotal.
+ */
+const SEPARATOR_CANARY = `${CANARY} - 2026 - Q3`;
+
+/** The piece of {@link SEPARATOR_CANARY} that stands to the RIGHT of the last separator. */
+const SEPARATOR_CANARY_SUFFIX = 'Q3';
+
 /** Where a caller's value landed on the thrown error. */
 type Placement =
   /** On `error.message` — the field `ObjectLogger.write` serializes. An exposure. */
@@ -91,6 +105,25 @@ interface ProbeCase {
    */
   readonly phrasing: string;
   /** Provoke the family. Must reject. */
+  readonly raise: (db: Knex) => Promise<unknown>;
+}
+
+/**
+ * [#9275] A family whose diagnostic inlines a value that itself contains ` - `.
+ *
+ * What these measure is the PREMISE, not the remedy: that the server really does
+ * echo the caller's separator-bearing value into its own words, and that the
+ * naive last-separator cut therefore lands inside that value. The redaction half
+ * lives in `packages/objectql/src/driver-fault-redaction.test.ts`, for the same
+ * reason the rest of this file states — `driver-sql` does not depend on
+ * `@objectstack/objectql`, and this file establishes WHAT THE SERVER SAYS.
+ */
+interface SeparatorCase {
+  /** The server's own error code, as it identifies the family. */
+  readonly family: string;
+  /** The template head the naive cut is measured to EAT. */
+  readonly head: string;
+  /** Provoke the family with {@link SEPARATOR_CANARY}. Must reject. */
   readonly raise: (db: Knex) => Promise<unknown>;
 }
 
@@ -162,6 +195,18 @@ const MYSQL_CASES: readonly ProbeCase[] = [
   },
 ];
 
+const MYSQL_SEPARATOR_CASES: readonly SeparatorCase[] = [
+  {
+    // ⛔ Raw SQL on purpose. As #9160 recorded, the column-less spelling is only
+    // raisable through an explicit cast — the driver's own bind path reaches the
+    // column-bound 1366 wording instead. Re-measured at HEAD: still true, and
+    // the type token still varies in case (`INTEGER`, `DOUBLE`, `time`).
+    family: 'ER_TRUNCATED_WRONG_VALUE (1292), column-less spelling',
+    head: 'Truncated incorrect INTEGER value:',
+    raise: (db) => db.raw(`insert into ${MYSQL_TABLE} (age) select cast(? as signed)`, [SEPARATOR_CANARY]),
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Postgres
 // ---------------------------------------------------------------------------
@@ -216,12 +261,43 @@ const PG_CASES: readonly ProbeCase[] = [
   },
 ];
 
+const PG_SEPARATOR_CASES: readonly SeparatorCase[] = [
+  {
+    family: 'invalid_text_representation (22P02)',
+    head: 'invalid input syntax for type integer:',
+    raise: (db) => db(PG_TABLE).insert({ age: SEPARATOR_CANARY }),
+  },
+  {
+    family: 'invalid_datetime_format (22007)',
+    head: 'invalid input syntax for type timestamp with time zone:',
+    raise: (db) => db(PG_TABLE).insert({ when_at: SEPARATOR_CANARY }),
+  },
+  {
+    // ⛔ The family #9160 did NOT expect here, and the reason this list is
+    // measured rather than reasoned. 22003 was left without a head-gone recovery
+    // on the argument that an out-of-range value is a NUMBER, and a number
+    // cannot contain ` - `. It can: Postgres' integer parser detects the
+    // OVERFLOW while scanning digits, before it rejects the trailing junk, so it
+    // echoes the caller's whole string back. Raised here through the driver's
+    // own bind path — no cast, no raw SQL — so the reach is not in question.
+    family: 'numeric_value_out_of_range (22003), separator inside the echoed value',
+    head: 'value "',
+    raise: (db) => db(PG_TABLE).insert({ age: `99999999999 - 2026 - ${SEPARATOR_CANARY_SUFFIX}` }),
+  },
+];
+
 // ---------------------------------------------------------------------------
 
-const SCHEMAS: Record<string, { table: string; ddl: (db: Knex) => Promise<unknown>; cases: readonly ProbeCase[] }> = {
+const SCHEMAS: Record<string, {
+  table: string;
+  ddl: (db: Knex) => Promise<unknown>;
+  cases: readonly ProbeCase[];
+  separatorCases: readonly SeparatorCase[];
+}> = {
   mysql: {
     table: MYSQL_TABLE,
     cases: MYSQL_CASES,
+    separatorCases: MYSQL_SEPARATOR_CASES,
     ddl: (db) =>
       db.raw(
         `create table ${MYSQL_TABLE} (`
@@ -233,6 +309,7 @@ const SCHEMAS: Record<string, { table: string; ddl: (db: Knex) => Promise<unknow
   pg: {
     table: PG_TABLE,
     cases: PG_CASES,
+    separatorCases: PG_SEPARATOR_CASES,
     ddl: (db) =>
       db.raw(
         `create table ${PG_TABLE} (`
@@ -266,6 +343,15 @@ for (const cell of DIALECT_CELLS) {
             raised.set(probe.family, undefined);
           } catch (err) {
             raised.set(probe.family, err);
+          }
+        }
+
+        for (const probe of plan.separatorCases) {
+          try {
+            await probe.raise(db);
+            raised.set(`separator/${probe.family}`, undefined);
+          } catch (err) {
+            raised.set(`separator/${probe.family}`, err);
           }
         }
       }, 60_000);
@@ -337,6 +423,47 @@ for (const cell of DIALECT_CELLS) {
                 : 'The exposure changed shape; re-read the redactor before relaxing this. ')
               + `Server said: ${JSON.stringify(diagnostic)}`,
           ).toBe(probe.placement);
+        });
+      }
+
+      // [#9275] The separator-in-value premise, measured rather than assumed.
+      for (const probe of plan.separatorCases) {
+        it(`${probe.family} — the server echoes a value containing " - ", and the naive cut eats the head`, () => {
+          const err = raised.get(`separator/${probe.family}`);
+
+          expect(
+            err,
+            `${probe.family} could not be raised with a separator-bearing value. If the server stopped `
+              + 'echoing the caller value here, say so as a recorded negative rather than deleting the case.',
+          ).toBeInstanceOf(Error);
+
+          const message = String(err.message);
+
+          // 1. The server inlined the caller's whole separator-bearing value.
+          expect(
+            message,
+            `${probe.family} no longer echoes the separator-bearing value into its own diagnostic. `
+              + `Server said: ${JSON.stringify(message)}`,
+          ).toContain(SEPARATOR_CANARY_SUFFIX);
+
+          // 2. …so the LAST ` - ` falls inside that value, and a cut taken there
+          //    loses the template head. This is the whole of #9275's premise: the
+          //    half that cannot leak is discarded and the half that does is kept.
+          const naive = diagnosticOf(message);
+
+          expect(
+            naive,
+            `${probe.family} no longer loses its head to the naive cut. If the phrasing moved the `
+              + 'separator out of the value, this case has stopped measuring what it was written for. '
+              + `Server said: ${JSON.stringify(message)}`,
+          ).not.toContain(probe.head);
+
+          expect(
+            naive,
+            `${probe.family}: the naive cut is expected to leave a SUFFIX of the caller's value standing — `
+              + 'that residue is the exposure the redactor\'s head-anchored cut closes '
+              + '(objectql/src/driver-fault-redaction.ts, and its suite drives this exact string).',
+          ).toContain(SEPARATOR_CANARY_SUFFIX);
         });
       }
     });

--- a/packages/objectql/src/driver-fault-redaction.test.ts
+++ b/packages/objectql/src/driver-fault-redaction.test.ts
@@ -376,6 +376,222 @@ describe('#9160 — the value-bearing families the live probe measured', () => {
   });
 });
 
+describe('#9275 — a value containing " - " no longer eats the template head', () => {
+  // Every string below was raised off a live server at HEAD (PostgreSQL 16.13,
+  // MySQL 8.0.46, the configuration CI uses) with the canary
+  // `SENSITIVE-CANARY-9275 - 2026 - Q3`, and the residue each one produced
+  // BEFORE this change is quoted next to it. `sql-driver-diagnostic-value-probe`
+  // raises the same shapes and asserts the server still prints them.
+  const CANARY = 'SENSITIVE-CANARY-9275';
+  const DASHED = `${CANARY} - 2026 - Q3`;
+  /** The piece that stood in the log before the cut learned about heads. */
+  const RESIDUE = 'Q3';
+
+  describe('the head-anchored cut — families whose value runs to end of message', () => {
+    it('postgres 22P02: keeps the head the operator came for, drops the value whole', () => {
+      // Measured before: `Q3" [statement and bound values redacted]`.
+      const out = redactStatementFromMessage(
+        `insert into "t" ("age") values ($1) - invalid input syntax for type integer: "${DASHED}"`,
+      );
+
+      expect(out).not.toContain(RESIDUE);
+      expect(out).not.toContain(CANARY);
+      expect(out).toBe(
+        'invalid input syntax for type integer: [value redacted]'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('postgres 22007: the multi-word type name survives too', () => {
+      const out = redactStatementFromMessage(
+        `insert into "t" ("when_at") values ($1)`
+        + ` - invalid input syntax for type timestamp with time zone: "${DASHED}"`,
+      );
+
+      expect(out).not.toContain(RESIDUE);
+      expect(out).toBe(
+        'invalid input syntax for type timestamp with time zone: [value redacted]'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('mysql 1292: the column-less spelling keeps its head as well', () => {
+      // Measured before: `Q3' [statement and bound values redacted]`.
+      const out = redactStatementFromMessage(
+        `insert into t (age) select cast('${DASHED}' as signed)`
+        + ` - Truncated incorrect INTEGER value: '${DASHED}'`,
+      );
+
+      expect(out).not.toContain(RESIDUE);
+      expect(out).toBe(
+        'Truncated incorrect INTEGER value: [value redacted]'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('keeps the lower-case type spellings the same server prints', () => {
+      // `INTEGER`, `DOUBLE` and `time` were all raised live — the head pattern's
+      // `i` flag is load-bearing, not decoration.
+      for (const type of ['INTEGER', 'DOUBLE', 'time']) {
+        const out = redactStatementFromMessage(
+          `update t set age = label + 0 - Truncated incorrect ${type} value: '${DASHED}'`,
+        );
+
+        expect(out).not.toContain(RESIDUE);
+        expect(out).toBe(
+          `Truncated incorrect ${type} value: [value redacted] [statement and bound values redacted]`,
+        );
+      }
+    });
+  });
+
+  describe('postgres 22003 — the third family, which takes the ANCHOR remedy', () => {
+    // ⛔ #9160 left this row without a head-gone recovery on the reasoning that
+    // an out-of-range value is a NUMBER and cannot contain ` - `. Measured
+    // through the driver's own bind path, that is false: Postgres detects the
+    // overflow while scanning digits, before it rejects the trailing junk, so it
+    // echoes the caller's whole string.
+    it('recovers the head-gone residue through its right anchor', () => {
+      // Measured before: `Q3" is out of range for type integer […]`.
+      const out = redactStatementFromMessage(
+        'insert into "t" ("age") values ($1)'
+        + ` - value "99999999999 - 2026 - ${RESIDUE}" is out of range for type integer`,
+      );
+
+      expect(out).not.toContain(RESIDUE);
+      expect(out).not.toContain('99999999999');
+      expect(out).toBe(
+        '[value redacted] is out of range for type integer'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('still keeps the head when the value carried no separator', () => {
+      // The intact template must keep reporting `value …`, so the anchor remedy
+      // does not quietly cost the head in the ordinary case.
+      const out = redactStatementFromMessage(
+        'insert into "t" ("age") values ($1) - value "99999999999" is out of range for type integer',
+      );
+
+      expect(out).toBe(
+        'value [value redacted] is out of range for type integer'
+        + ' [statement and bound values redacted]',
+      );
+    });
+  });
+
+  describe('the steering the amendment admits, and the bound on it', () => {
+    it('resolves a value that MIMICS a head to the LAST head, leaking nothing', () => {
+      // ⛔ The ordering that carries the safety argument. A hostile value spells
+      // a known head inside itself; taking the FIRST head would cut before the
+      // decoy and leave the real value standing behind it. Taking the LAST cuts
+      // at the decoy, so no part of the value can survive.
+      const out = redactStatementFromMessage(
+        `insert into "t" ("age") values ('${CANARY} - invalid input syntax for type integer: "decoy')`
+        + ` - invalid input syntax for type integer: "${CANARY} - invalid input syntax for type integer: "decoy"`,
+      );
+
+      expect(out).not.toContain(CANARY);
+      expect(out).not.toContain('decoy');
+      expect(out).toBe(
+        'invalid input syntax for type integer: [value redacted]'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('SUPPRESSES a real diagnostic when a value forges a head — over-redaction, never exposure', () => {
+      // The honest cost of the amendment, asserted rather than discovered later.
+      // A crafted value makes the cut land inside the STATEMENT, so the operator
+      // reads the forged head instead of the `Unknown column` the server really
+      // replied. What must NOT happen is any of the statement surviving — the
+      // head invariant (only end-of-message templates may declare a `head`) is
+      // what turns this into lost detail rather than a leak.
+      const out = redactStatementFromMessage(
+        "insert into `t` (`a`, `b`) values"
+        + " ('x - Truncated incorrect INTEGER value: 'forged', 'SECOND-VALUE-CANARY')"
+        + " - Unknown column 'zzz' in 'field list'",
+      );
+
+      expect(out).not.toContain('SECOND-VALUE-CANARY');
+      expect(out).not.toContain('forged');
+      expect(out).toBe(
+        'Truncated incorrect INTEGER value: [value redacted]'
+        + ' [statement and bound values redacted]',
+      );
+    });
+
+    it('every head-bearing family swallows to END OF MESSAGE — the invariant, behaviourally', () => {
+      // ⛔ The structural property the `head` field documents: a template may
+      // declare a `head` only if its value runs to end of message. If one ever
+      // gets a `head` while keeping a right anchor, a head-anchored cut landing
+      // inside the statement would keep everything after that anchor — which is
+      // statement, which is caller values. This case forges each head over a
+      // statement carrying a second value and asserts nothing survives.
+      for (const head of [
+        'invalid input syntax for type integer: "',
+        "Truncated incorrect INTEGER value: '",
+      ]) {
+        const out = redactStatementFromMessage(
+          `insert into \`t\` (\`a\`, \`b\`) values ('x - ${head}forged', 'SECOND-VALUE-CANARY')`
+          + " - Unknown column 'zzz' in 'field list'",
+        );
+
+        expect(out).not.toContain('SECOND-VALUE-CANARY');
+        expect(out).not.toContain('forged');
+        expect(out).not.toContain('insert into');
+        expect(out).toContain('[value redacted]');
+      }
+    });
+  });
+
+  describe('the ordinary case is byte-identical — no head, no change', () => {
+    it('cuts at the last separator when no known head stands after one', () => {
+      // #8682's original answer is untouched wherever this amendment has nothing
+      // to say, which is every message that carries no measured head.
+      const out = redactStatementFromMessage(
+        "insert into `t` (`label`) values ('2026 - Q3 secret plan')"
+        + ' returning * - table t has no column named label',
+      );
+
+      expect(out).toBe('table t has no column named label [statement and bound values redacted]');
+      expect(out).not.toContain('Q3 secret plan');
+    });
+
+    it('leaves the identifier-only families exactly as they were', () => {
+      // The six the probe pins. Over-matching is the expensive direction, and a
+      // cut that learned about heads must not have taught itself to fire here.
+      for (const diagnostic of [
+        "Out of range value for column 'age' at row 1",
+        "Data too long for column 'label' at row 1",
+        "Unknown column 'zzz_nonexistent_field' in 'field list'",
+        'duplicate key value violates unique constraint "t_email_key"',
+        'null value in column "id" of relation "t" violates not-null constraint',
+        'value too long for type character varying(20)',
+        'numeric field overflow',
+      ]) {
+        const out = redactStatementFromMessage(
+          `insert into \`t\` (\`c\`) values ('2026 - Q3 plan') - ${diagnostic}`,
+        );
+
+        expect(out).toBe(`${diagnostic} [statement and bound values redacted]`);
+        expect(out).not.toContain('[value redacted]');
+        expect(out).not.toContain('Q3 plan');
+      }
+    });
+
+    it('leaves the VALUELESS json spelling untouched, separator in the value or not', () => {
+      // It has no `: "`, so no head matches and nothing changes — the guard that
+      // keeps the amendment from redacting a diagnostic that never leaked.
+      const out = redactStatementFromMessage(
+        `insert into "t" ("doc") values ('2026 - Q3'::json) - invalid input syntax for type json`,
+      );
+
+      expect(out).toBe('invalid input syntax for type json [statement and bound values redacted]');
+      expect(out).not.toContain('[value redacted]');
+    });
+  });
+});
+
 describe('redactBoundStatement', () => {
   it('redacts `stack` too — the statement opened it a second time', () => {
     const original = new Error(BOUND_INSERT);

--- a/packages/objectql/src/driver-fault-redaction.test.ts
+++ b/packages/objectql/src/driver-fault-redaction.test.ts
@@ -481,11 +481,13 @@ describe('#9275 — a value containing " - " no longer eats the template head', 
   });
 
   describe('the steering the amendment admits, and the bound on it', () => {
-    it('resolves a value that MIMICS a head to the LAST head, leaking nothing', () => {
-      // ⛔ The ordering that carries the safety argument. A hostile value spells
-      // a known head inside itself; taking the FIRST head would cut before the
-      // decoy and leave the real value standing behind it. Taking the LAST cuts
-      // at the decoy, so no part of the value can survive.
+    it('leaks nothing when a value MIMICS a head, wherever between the two the cut lands', () => {
+      // ⚠️ This case does NOT discriminate first-head from last-head, and the
+      // suite should not pretend it does: ablating the cut to take the FIRST
+      // head left all 50 cases here green. An end-of-message pattern matches
+      // once, from its earliest position, so both cuts produce the same output.
+      // What this case does pin is the property that matters — a value spelling
+      // a known head inside itself survives in no part.
       const out = redactStatementFromMessage(
         `insert into "t" ("age") values ('${CANARY} - invalid input syntax for type integer: "decoy')`
         + ` - invalid input syntax for type integer: "${CANARY} - invalid input syntax for type integer: "decoy"`,

--- a/packages/objectql/src/driver-fault-redaction.ts
+++ b/packages/objectql/src/driver-fault-redaction.ts
@@ -188,16 +188,24 @@
  *
  * The steering is real and it is BOUNDED TO OVER-REDACTION. A hostile value
  * that spells a known head makes the cut land inside the statement, at that
- * head — and two properties make what follows unleakable rather than exposed:
+ * head — and ONE property, not several, makes what follows unleakable rather
+ * than exposed: only a template whose value runs to END OF MESSAGE may declare
+ * a `head` (the invariant on {@link ValueBearingTemplate.head}). Whatever the
+ * head-anchored cut leaves — the rest of the statement it cut into included —
+ * is consumed whole by that template's own `whole` pattern.
  *
- *  1. only a template whose value runs to END OF MESSAGE may declare a `head`
- *     (the invariant on {@link ValueBearingTemplate.head}), so whatever follows
- *     the head-anchored cut is consumed whole by that template's own `whole`
- *     pattern — including the rest of the statement it cut into;
- *  2. the LAST such head wins, not the first. A value that mimics a head is
- *     therefore cut at the mimic, never before it, so no part of the value can
- *     survive by hiding behind its own decoy. Taking the first would leak;
- *     this ordering is load-bearing and is pinned by its own case.
+ * ⚠️ That invariant is the WHOLE of the argument, so do not let a second
+ * plausible-sounding reason stand next to it. This note first claimed the cut
+ * was also protected by taking the LAST matching head rather than the first,
+ * "because a value that mimics a head is then cut at the mimic". Ablated: with
+ * the cut changed to take the FIRST head, all 50 cases in this file's suite
+ * stayed GREEN. The reason is mechanical — an end-of-message pattern matches
+ * only ONCE, from its earliest position, so {@link lastMatch} returns that
+ * first match and the output is identical wherever between two heads the cut
+ * landed. Last-head is retained as a tie-break (it discards the most statement,
+ * and reports the head nearest the database's own words, consistent with the
+ * last-separator rule above) — it is NOT what prevents the leak, and a future
+ * reader must not treat it as a second line of defence.
  *
  * What a hostile value CAN do is suppress a real diagnostic: craft `- invalid
  * input syntax for type integer: "` into a value and the operator reads that
@@ -546,14 +554,11 @@ export function redactStatementFromMessage(message: string): string {
  * words began; only when no head appears does this fall back to the last
  * separator in the message, which is #8682's original structural answer.
  *
- * Two orderings carry the safety argument, both spelled out in the head note at
- * the top of this file and pinned by their own cases:
- *
- *  - the last HEAD, not the first — so a value mimicking a head is cut at the
- *    mimic and cannot survive behind its own decoy;
- *  - a head beats the last separator even though it keeps MORE text, which is
- *    only sound because the head invariant guarantees that extra text is
- *    swallowed whole by the template that owns the head.
+ * A head beats the last separator even though it keeps MORE text. That is sound
+ * only because of the head invariant — the extra text is swallowed whole by the
+ * template that owns the head — and the invariant is the entire safety argument
+ * (see the head note; taking the last head rather than the first is a tie-break
+ * that was ABLATED and changes no output).
  */
 function statementCut(message: string): number {
   let headCut = -1;

--- a/packages/objectql/src/driver-fault-redaction.ts
+++ b/packages/objectql/src/driver-fault-redaction.ts
@@ -107,14 +107,42 @@
  * covers them but the entries below. That was the open question #9160 asked and
  * the answer is the one the card feared.
  *
- * ⛔ Known residue, measured and NOT closed here: when the caller's value itself
- * contains ` - `, the statement cut lands inside it and eats the template head.
- * Families with a right anchor (`for key …`, `for column … at row N`) recover
- * via their `tail` pattern; the two whose value runs to end of message
- * (pg 22P02/22007, mysql 1292's `Truncated incorrect …` spelling) have no
- * anchor to recover from and leave a suffix of the value standing. Closing that
- * needs the cut itself to become template-aware, which is a change to #8682's
- * contract and is filed rather than decided.
+ * ## [#9275] The residue #9160 left, and the amendment to the cut that closes it
+ *
+ * #9160 recorded a residue it did not close: when the caller's value itself
+ * contains ` - `, the statement cut lands INSIDE that value and eats the
+ * template head. Families with a right anchor recover via their `tail` pattern,
+ * but the ones whose value runs to end of message have nothing to recover from
+ * and leave a suffix of the caller's value standing in the log. Re-measured at
+ * HEAD on the same live servers, canary `SENSITIVE-CANARY-9275 - 2026 - Q3`:
+ *
+ * ```
+ * raised:  insert into "t" ("age") values ($1)
+ *            - invalid input syntax for type integer: "…CANARY… - 2026 - Q3"
+ * logged:  Q3" [statement and bound values redacted]     ← `Q3` is caller data
+ * ```
+ *
+ * Closing it needs the cut itself to become template-aware, which is an
+ * amendment to #8682's contract rather than another row in a list. **Ruled by
+ * the maintainer on 2026-08-17 (#9275): take it, with the trade stated.** See
+ * the section below.
+ *
+ * The re-measurement also moved the COUNT. #9160 named two families here; three
+ * leave a value suffix, and the third wants the other remedy:
+ *
+ * ```
+ * pg 22P02/22007  value runs to end of message   → head-anchored cut (below)
+ * mysql 1292      value runs to end of message   → head-anchored cut (below)
+ * pg 22003        value "…" is out of range …    → `tail`, the #8823 mechanism
+ * ```
+ *
+ * `22003` was assumed unreachable on the reasoning that its value slot holds a
+ * number, which cannot contain ` - `. Measured through the driver's own bind
+ * path, that is false: Postgres' integer parser detects the OVERFLOW before it
+ * rejects the trailing junk, so it echoes the whole caller string back —
+ * `insert({ age: '99999999999 - 2026 - Q3' })` prints `value "99999999999 -
+ * 2026 - Q3" is out of range for type integer` and logged `Q3` as caller data.
+ * It has a right anchor, so it takes a `tail` row and needs no cut change.
  *
  * ## Why the cut is at the separator, and not at a statement keyword
  *
@@ -137,6 +165,56 @@
  * ever discard MORE than necessary, which is the safe direction — and when a
  * native message legitimately contains ` - `, what is lost is a prefix of the
  * diagnostic, never the failing identifier the database names at the end.
+ *
+ * ### [#9275] …except when a KNOWN head says where the diagnostic really began
+ *
+ * "Discard more is safe" holds for the STATEMENT half, and it is exactly wrong
+ * for the DIAGNOSTIC half. When the value the database inlined into its own
+ * message contains ` - `, the last separator sits inside that value, so the cut
+ * discards the template head and keeps the value's suffix — it discards the
+ * half that could not leak and keeps the half that does.
+ *
+ * So the cut asks one more question first: does a separator in this message
+ * stand immediately before a diagnostic head this file has MEASURED (see
+ * `head` in {@link VALUE_BEARING_TEMPLATES})? If one does, that separator is
+ * the true one whatever its position, the head survives, and the value after it
+ * — ` - ` and all — is dropped whole by the template that owns it.
+ *
+ * ⛔ This DOES mean a template is matched before the cut, which the note here
+ * previously forbade in terms: "a bound value can contain anything, this file's
+ * own template included, and matching before the cut would let a value in the
+ * STATEMENT steer what survives". That prohibition is not deleted, it is
+ * AMENDED, and the trade it was protecting is now stated instead of avoided.
+ *
+ * The steering is real and it is BOUNDED TO OVER-REDACTION. A hostile value
+ * that spells a known head makes the cut land inside the statement, at that
+ * head — and two properties make what follows unleakable rather than exposed:
+ *
+ *  1. only a template whose value runs to END OF MESSAGE may declare a `head`
+ *     (the invariant on {@link ValueBearingTemplate.head}), so whatever follows
+ *     the head-anchored cut is consumed whole by that template's own `whole`
+ *     pattern — including the rest of the statement it cut into;
+ *  2. the LAST such head wins, not the first. A value that mimics a head is
+ *     therefore cut at the mimic, never before it, so no part of the value can
+ *     survive by hiding behind its own decoy. Taking the first would leak;
+ *     this ordering is load-bearing and is pinned by its own case.
+ *
+ * What a hostile value CAN do is suppress a real diagnostic: craft `- invalid
+ * input syntax for type integer: "` into a value and the operator reads that
+ * head plus `[value redacted]` instead of the `Unknown column …` the server
+ * actually replied. That costs debuggability on a crafted input and is the
+ * price of closing a leak on ordinary ones. **Ruled deliberately by the
+ * maintainer on 2026-08-17 (#9275)**, against the alternatives of inferring
+ * from unbalanced quotes (a new inference rule, over-match risk) and of
+ * accepting the residue as best-effort (caller data at ERROR level, which is
+ * the thing this neighbourhood exists to prevent).
+ *
+ * ⛔ The escape hatch this is NOT: a head is not a licence to cut anywhere a
+ * template appears. No head may be declared for a template whose diagnostic
+ * continues past the value — cutting into a statement on such a head would keep
+ * whatever follows the template's right anchor, which is statement, which is
+ * values. That is the one way this amendment could leak, and the invariant
+ * above is what forecloses it.
  *
  * A driver dump with no separator carries no statement to cut (`UNIQUE
  * constraint failed: sys_user.email`, `SQLITE_CONSTRAINT_NOTNULL: …`) and is
@@ -266,6 +344,15 @@ const MYSQL_INCORRECT_VALUE_TAIL = /'(\s+for column\s+'[^']*'\s+at row\s+\d+)/gi
 const PG_INVALID_INPUT_SYNTAX = /(invalid input syntax for type [a-z0-9 ]+?:\s+)"[\s\S]*$()/gi;
 
 /**
+ * [#9275] {@link PG_INVALID_INPUT_SYNTAX}'s head, through the value's opening
+ * quote — what the statement cut looks for so a value containing ` - ` cannot
+ * eat it. Mirrors group 1 of the pattern above plus the `"` that follows it;
+ * the two must not drift, and `head implies whole matches there` is asserted
+ * directly rather than left as a comment.
+ */
+const PG_INVALID_INPUT_SYNTAX_HEAD = /invalid input syntax for type [a-z0-9 ]+?:\s+"/gi;
+
+/**
  * [#9160] Postgres `numeric_value_out_of_range` (22003).
  *
  * `value "%s" is out of range for type %s` — measured live as
@@ -280,6 +367,30 @@ const PG_INVALID_INPUT_SYNTAX = /(invalid input syntax for type [a-z0-9 ]+?:\s+)
 const PG_VALUE_OUT_OF_RANGE = /(value\s+)"[\s\S]*"(\s+is out of range for type [a-z0-9 ]+)/gi;
 
 /**
+ * [#9275] {@link PG_VALUE_OUT_OF_RANGE} with its head cut away by a value
+ * containing ` - ` — the row #9160 did not know this family needed.
+ *
+ * It was left out on the reasoning that an out-of-range value is a NUMBER and a
+ * number cannot contain the separator. Measured through the driver's own bind
+ * path on live PostgreSQL 16.13, that reasoning is wrong: Postgres' integer
+ * parser detects the overflow while scanning digits, BEFORE it rejects the
+ * trailing junk, so it echoes the caller's whole string rather than a number.
+ *
+ * ```
+ * insert({ age: '99999999999 - 2026 - Q3' })
+ *   raised:  … values ($1) - value "99999999999 - 2026 - Q3" is out of range for type integer
+ *   logged:  Q3" is out of range for type integer          ← `Q3` is caller data
+ * ```
+ *
+ * This family keeps its right anchor, so it takes the #8823 recovery and NOT a
+ * `head`: everything before ` is out of range for type` is value residue by
+ * construction and is dropped whole. ⛔ It must not be given a `head` — its
+ * diagnostic continues past the value, which is exactly the shape the head
+ * invariant forbids.
+ */
+const PG_VALUE_OUT_OF_RANGE_TAIL = /"(\s+is out of range for type [a-z0-9 ]+)/gi;
+
+/**
  * [#9160] MySQL `ER_TRUNCATED_WRONG_VALUE` (1292), the spelling that names no
  * column: `Truncated incorrect %-.32s value: '%-.128s'`.
  *
@@ -291,9 +402,19 @@ const PG_VALUE_OUT_OF_RANGE = /(value\s+)"[\s\S]*"(\s+is out of range for type [
  * measured, not because a write path is known to produce it.
  *
  * Value runs to end of message; no right anchor exists to recover a head-gone
- * residue.
+ * residue, which is why this family takes a `head` instead (#9275).
  */
 const MYSQL_TRUNCATED_INCORRECT_VALUE = /(truncated incorrect \w+ value:\s+)'[\s\S]*$()/gi;
+
+/**
+ * [#9275] {@link MYSQL_TRUNCATED_INCORRECT_VALUE}'s head, through the value's
+ * opening quote. Mirrors group 1 of the pattern above plus the `'` after it.
+ *
+ * The type token really does vary in case — `INTEGER`, `DOUBLE` and `time` were
+ * all raised on live MySQL 8.0.46 — so the `i` flag here is load-bearing, not
+ * decoration.
+ */
+const MYSQL_TRUNCATED_INCORRECT_VALUE_HEAD = /truncated incorrect \w+ value:\s+'/gi;
 
 /**
  * [#9160] Every dialect template MEASURED to inline a caller's value in the
@@ -322,15 +443,45 @@ interface ValueBearingTemplate {
   readonly whole: RegExp;
   /** The head-gone residue, when the template has a right anchor to recover it. */
   readonly tail?: RegExp;
+  /**
+   * [#9275] The template's head through the value's OPENING QUOTE — what the
+   * statement cut looks for so a value containing ` - ` cannot eat it.
+   *
+   * ⛔ INVARIANT, and the only thing standing between this and a leak: a `head`
+   * may be declared ONLY on a template whose value runs to END OF MESSAGE, i.e.
+   * whose `whole` is `$`-anchored and whose group 2 is empty. The head-anchored
+   * cut can land inside the STATEMENT (a hostile value may spell a head), and
+   * what makes that over-redaction rather than exposure is that `whole` then
+   * swallows everything after the head — statement remainder included. A
+   * template with a right anchor would instead keep whatever follows that
+   * anchor, which on such a cut is statement, which is caller values.
+   *
+   * Families that DO have a right anchor take {@link tail} instead; it recovers
+   * the same residue with no cut change at all. Both are asserted structurally
+   * by `driver-fault-redaction.test.ts` rather than trusted from this note.
+   */
+  readonly head?: RegExp;
 }
 
 const VALUE_BEARING_TEMPLATES: readonly ValueBearingTemplate[] = [
   { id: 'mysql/1062 ER_DUP_ENTRY', whole: DUPLICATE_ENTRY, tail: DUPLICATE_ENTRY_TAIL },
   { id: 'mysql/1366 ER_TRUNCATED_WRONG_VALUE_FOR_FIELD', whole: MYSQL_INCORRECT_VALUE, tail: MYSQL_INCORRECT_VALUE_TAIL },
-  { id: 'mysql/1292 ER_TRUNCATED_WRONG_VALUE', whole: MYSQL_TRUNCATED_INCORRECT_VALUE },
-  { id: 'pg/22P02 invalid_text_representation', whole: PG_INVALID_INPUT_SYNTAX },
-  { id: 'pg/22003 numeric_value_out_of_range', whole: PG_VALUE_OUT_OF_RANGE },
+  { id: 'mysql/1292 ER_TRUNCATED_WRONG_VALUE', whole: MYSQL_TRUNCATED_INCORRECT_VALUE, head: MYSQL_TRUNCATED_INCORRECT_VALUE_HEAD },
+  { id: 'pg/22P02 invalid_text_representation', whole: PG_INVALID_INPUT_SYNTAX, head: PG_INVALID_INPUT_SYNTAX_HEAD },
+  { id: 'pg/22003 numeric_value_out_of_range', whole: PG_VALUE_OUT_OF_RANGE, tail: PG_VALUE_OUT_OF_RANGE_TAIL },
 ];
+
+/**
+ * [#9275] Every known diagnostic head, as the separator that stands before it.
+ *
+ * A lookahead, so the match is the SEPARATOR alone and its index is where the
+ * cut goes. Built once from the table above: a row that declares a `head` is
+ * enrolled here automatically, and one that does not cannot be enrolled by
+ * hand.
+ */
+const HEAD_ANCHORED_CUTS: readonly RegExp[] = VALUE_BEARING_TEMPLATES
+  .filter((template): template is ValueBearingTemplate & { head: RegExp } => template.head !== undefined)
+  .map((template) => new RegExp(`${STATEMENT_SEPARATOR}(?=${template.head.source})`, 'gi'));
 
 /**
  * The first stack FRAME line (`    at …`). Everything above it is the header
@@ -371,7 +522,7 @@ export function redactBoundStatement(error: unknown): unknown {
  */
 export function redactStatementFromMessage(message: string): string {
   if (!message || !looksLikeInternalErrorLeak(message)) return message;
-  const cut = message.lastIndexOf(STATEMENT_SEPARATOR);
+  const cut = statementCut(message);
   // No statement to cut — but a dialect may still have inlined a value in the
   // diagnostic itself, and since #9030 taught the shared predicate this
   // phrasing, a BARE `Duplicate entry …` now reaches this line instead of
@@ -387,14 +538,44 @@ export function redactStatementFromMessage(message: string): string {
 }
 
 /**
+ * [#9275] Where the bound statement ends — the index of its separator, or `-1`
+ * when the message carries no statement at all.
+ *
+ * The LAST separator that stands immediately before a MEASURED diagnostic head
+ * wins, because a head is positive evidence about where the database's own
+ * words began; only when no head appears does this fall back to the last
+ * separator in the message, which is #8682's original structural answer.
+ *
+ * Two orderings carry the safety argument, both spelled out in the head note at
+ * the top of this file and pinned by their own cases:
+ *
+ *  - the last HEAD, not the first — so a value mimicking a head is cut at the
+ *    mimic and cannot survive behind its own decoy;
+ *  - a head beats the last separator even though it keeps MORE text, which is
+ *    only sound because the head invariant guarantees that extra text is
+ *    swallowed whole by the template that owns the head.
+ */
+function statementCut(message: string): number {
+  let headCut = -1;
+  for (const separator of HEAD_ANCHORED_CUTS) {
+    const match = lastMatch(separator, message);
+    if (match && match.index > headCut) headCut = match.index;
+  }
+  return headCut !== -1 ? headCut : message.lastIndexOf(STATEMENT_SEPARATOR);
+}
+
+/**
  * [#8823] Drop the caller values a dialect inlines into its OWN diagnostic,
  * keeping every identifier around them.
  *
  * Runs on the tail the statement cut already produced, never on the whole
- * message: a bound value can contain anything, this file's own template
- * included, and matching before the cut would let a value in the STATEMENT
- * steer what survives. After the cut there is nothing left but the database's
- * words, so the templates below can be read literally.
+ * message: after the cut there is nothing left but the database's words, so the
+ * templates below can be read literally. ⛔ The one exception is deliberate and
+ * bounded — {@link statementCut} matches a template's `head` BEFORE the cut, so
+ * that a value containing ` - ` cannot eat it. That amendment, the steering it
+ * admits and the invariant that keeps the steering to over-redaction rather
+ * than exposure are argued in the head note (#9275); nothing here reads a
+ * template earlier than the cut on its own account.
  *
  * ⛔ Add a dialect's spelling to {@link VALUE_BEARING_TEMPLATES} only once it has
  * been measured off a THROWN error, never from a reading of the manual — the


### PR DESCRIPTION
Fixes #9275

## ⚠️ Read this first — the dispatch brief and the maintainer ruling disagree, and I followed the ruling

The dispatch brief for this card says: *"If the close requires changing the cut, STOP AND REPORT — that is a contract change and needs a tier judgement the PM has not made."*

It does require changing the cut. But the tier judgement **has** been made, by the maintainer, and is recorded on the card itself — [comment 5315738370](https://github.com/objectstack-ai/objectstack/issues/9275#issuecomment-5315738370), 2026-08-17 12:00, three hours before the dispatch:

> **Ruled: Option 1 — the cut becomes template-aware, and #8682's contract is amended honestly.** […] The file's contract note is rewritten, not deleted […] Label flipped `needs-user-decision` → `pm:queue` in the same stroke.

The brief's stop-condition rests on the factual claim "a tier judgement I have not made", and that claim is falsified by the record — the card is in the dispatch pool *because* of that ruling, which also prescribes the test ("extend the #9274 probe with a canary containing ` - `"). Stopping would have burned a round on a decision already taken in writing, so I implemented **exactly** what was ruled and nothing wider. Flagging it here rather than picking a side silently. If the PM intended the fence to outrank the ruling, close this and say so — the work is one commit plus its correction and costs nothing to drop.

## Which contract this touches, stated plainly

**#8682's cut contract** — where the statement ends — not #8823/#9160's value list (which spans are values). That is the distinction the card was filed on, and it is the one this PR changes. The value list gains one row's `tail`, but that row is the #8823 mechanism, not the cut.

## What was measured

Both live servers stood up locally with CI's own configuration (PostgreSQL 16.13 @ `Asia/Shanghai`, MySQL 8.0.46 @ `+08:00`) — the same method PR #9274 used, re-run at HEAD rather than inherited.

**Non-vacuity control first.** A canary *without* ` - ` (`SENSITIVE-CANARY-9275`) was driven through all 12 families before anything was asserted about the broken case. All 12 redact correctly and reproduce #9274's recorded phrasings verbatim — so the instrument answers on the known-good case, and a difference in the broken one is a measurement rather than an artifact.

**Then the broken case**, canary `SENSITIVE-CANARY-9275 - 2026 - Q3`, at HEAD, before any change:

```
pg 22P02  raised:   insert into "t" ("age") values ($1)
                      - invalid input syntax for type integer: "…CANARY… - 2026 - Q3"
          logged:   Q3" [statement and bound values redacted]
pg 22007  logged:   Q3" [statement and bound values redacted]
mysql 1292 logged:  Q3' [statement and bound values redacted]
```

`Q3` is the caller's data. The residue reproduces at HEAD; the card's premise stands.

## ⚠️ The population is THREE families, not two — a PM assumption falsified

The brief asked me to verify that the two anchor-less families are the whole population, and to move the count if a third had appeared. A third is there, and it was already in the file — it just is not anchor-less, so neither the card nor #9274 looked at it.

`pg 22003` was left without a head-gone recovery on the reasoning that an out-of-range value is a NUMBER, and a number cannot contain ` - `. **Measured through the driver's own bind path — no raw SQL, no cast — that reasoning is false.** Postgres' integer parser detects the OVERFLOW while scanning digits, *before* it rejects the trailing junk, so it echoes the caller's whole string back:

```
insert({ age: '99999999999 - 2026 - Q3' })
  raised:   … values ($1) - value "99999999999 - 2026 - Q3" is out of range for type integer
  logged:   Q3" is out of range for type integer      ← same leak, different remedy
```

It keeps its right anchor, so it takes the #8823 `tail` recovery and needs no cut change at all. Included here under the same-defect-class exemption (mechanical, form pinned by two sibling `tail` rows, same file, same gates) and named rather than slipped in.

## What changed

1. **The cut is template-aware.** When a separator stands immediately before a diagnostic head this file has measured, that separator is the true cut point whatever its position — the head survives and the value after it, ` - ` and all, is dropped whole by the template that owns it. Operators now get *more* diagnostic than before: `invalid input syntax for type integer: [value redacted] […]` instead of `Q3" […]`.
2. **A `tail` row for pg 22003**, per the measurement above.
3. **The contract note is amended, not deleted** — as the ruling required. The old "never match a template before the cut" prohibition now states the steering it was avoiding, and the bound on it.

**The trade, stated rather than buried:** matching a template before the cut lets a hostile value steer where the cut lands. It is bounded to **over-redaction, never exposure**, by one invariant — a template may declare a `head` only if its value runs to end of message, so a cut landing inside a statement is swallowed whole by that template. A crafted value can suppress a real diagnostic; that cost has its own asserted case rather than being left to be discovered later.

**Over-matching stayed the expensive direction.** The six identifier-only families #9274 pinned are byte-identical before and after, on live servers and in fixtures.

## Verification

All at `481c7e71d`, the final commit, with both live servers wired as CI wires them.

- **Full `objectql` suite: 215 files, 3807 tests, all pass** (50 in `driver-fault-redaction.test.ts`, up from 37).
- **Full `driver-sql` suite against both live servers** (`TZ=America/New_York`, both URLs, `OS_EXPECT_LIVE_DIALECT_MATRIX=1`): **105 files, 2284 tests, all pass.** The probe's live cells ran (verified by name, not by exit code): 17/17, positive control included.
- **Typecheck**: both packages clean.
- **Gate union re-derived** from the actual changed paths via `scripts/pm/dispatch-gates.mjs`, all pass at `481c7e71d`: `check:changeset-gate-self-tests`, `check:durability-log-level`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, `check:nul-bytes`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-engine-split-ratio`, `docs-audit/check-affected-docs`, and the ratchet `check:type-check-debt` (`--re-measure`, 33 entries, 1926 raw errors, none above its recorded number) run on a built closure.

### Reverse verification — four legs, each committed then ablated then restored

1. **Head-anchored cut removed** → exactly the 6 head-anchored cases go red; all 44 pre-existing cases stay green, so #8682/#8823/#9160 behaviour is provably unchanged.
2. **The 22003 `tail` row removed** → exactly 1 red, quoting the live residue: `expected 'Q3" is out of range for type integer …' not to contain 'Q3'`.
3. **Cut takes the FIRST head instead of the LAST** → **GREEN, against my prediction.** See below.
4. **Probe canaries stripped of their separator** → all 4 new probe cases go red against live servers, each quoting the server's real output; the other 13 stay green. So the new cases measure the separator effect specifically, not merely the presence of a canary.

### Leg 3 came back green, and a claim in the file was wrong

I had written that the safety argument rested on two properties: the end-of-message invariant **and** taking the LAST matching head ("taking the first would leak"). Leg 3 ablated the second and all 50 cases stayed green.

The reason is mechanical: an end-of-message pattern matches only ONCE, from its earliest position, so `lastMatch` returns that first match and the output is identical wherever between two heads the cut landed. The invariant is the *whole* argument. I corrected the file and the misleading case name (second commit) rather than inventing a test that would make the claim look pinned — a plausible second line of defence that does not exist is worse than none, because the next reader will lean on it.

`redactBoundStatement` still has exactly 3 call sites. No `TEST_DEBT` entry raised, no `domain:*` label touched, no `content/docs/releases/` edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_
