### PR TITLE
fix(tests): give two default-vitest-timeout cases real margin

### DIFF
--- a/.changeset/default-timeout-margin-repair.md
+++ b/.changeset/default-timeout-margin-repair.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/types": patch
+"@objectstack/dogfood": patch
+---
+
+fix(tests): give two default-vitest-timeout cases real margin instead of a bare default (#9311)
+
+Two cases only passed `pnpm test` when they were not competing for CPU — the
+same defect class as the already-closed precedents #3662, #4186, #4485,
+#5421, #6329: a test running under vitest's **default** `testTimeout` /
+`hookTimeout` with no margin for anything heavier than an idle box.
+
+**`packages/types/src/node.test.ts`** — `"falls back to the importing
+package's own resolution when the host does not declare"` is the only case
+in the file that performs a real dynamic `import()` of `@objectstack/spec` (a
+multi-megabyte package); every sibling in the same `describe` block resolves
+a small on-disk fixture or fails fast, all under 10ms. Measured on this box:
+~0.9-1.1s unloaded, already observed failing at 5061ms against the 5000ms
+default under nothing heavier than `turbo run test --concurrency=2` (#9311's
+own isolation runs). Gave that one case an explicit 30s `testTimeout` — the
+same order of magnitude the repo already uses for subprocess/real-load cases
+(`#3662` precedent) — and left every sub-10ms sibling alone.
+
+**`packages/qa/dogfood/test/semantic-roles.dogfood.test.ts`** — its
+`beforeAll` boots the full showcase stack (ObjectQL + ~45 plugins) through
+`@objectstack/verify`'s `bootStack`, which does not fit vitest's 10s
+`hookTimeout` default with any margin at all: observed failing at 10027ms
+against the 10000ms budget, and this file's own isolated run measured 18.3s
+(vitest `Duration`) / 19.5s wall clock for the whole file even with the box
+otherwise idle. Gave the hook an explicit 180s timeout, matching this
+package's own existing house pattern for the identical
+`bootStack(showcaseStack, …)` call
+(`admin-identity-audit-trail.dogfood.test.ts`'s `beforeAll(…, 180_000)`)
+rather than inventing a new number for the same operation.
+
+**No behaviour change** — both suites already pass; this only gives the two
+timeout-sensitive cases room to finish on a loaded box. The repo's full test
+suite is confirmed green at low concurrency (#9311), so this is margin
+repair, not a product fix. `turbo.json`'s default concurrency is out of scope
+for this change (a maintainer-level default, per #9311's own filing).

--- a/packages/qa/dogfood/test/semantic-roles.dogfood.test.ts
+++ b/packages/qa/dogfood/test/semantic-roles.dogfood.test.ts
@@ -49,10 +49,20 @@ async function servedObject(name: string): Promise<Record<string, any>> {
   return envelope.item as Record<string, any>;
 }
 
+// Explicit hookTimeout (#9311): booting the full showcase stack (ObjectQL +
+// ~45 plugins) through `@objectstack/verify`'s `bootStack` does not fit
+// vitest's 10_000ms `hookTimeout` default with any real margin — observed
+// failing at 10027ms against the 10000ms budget, and this file's own isolated
+// run measured 18.3s (vitest-reported `Duration`) / 19.5s wall clock for the
+// whole file even on an otherwise-idle box (boot dominates; the 5 tests
+// themselves run in ~3.5s). 180_000ms follows this package's existing house
+// pattern for the identical `bootStack(showcaseStack, …)` call — see
+// `admin-identity-audit-trail.dogfood.test.ts`'s `beforeAll(…, 180_000)` —
+// rather than inventing a new number for the same operation.
 beforeAll(async () => {
   stack = await bootStack(showcaseStack);
   token = await stack.signIn();
-});
+}, 180_000);
 
 afterAll(async () => {
   await stack?.stop();

--- a/packages/types/src/node.test.ts
+++ b/packages/types/src/node.test.ts
@@ -175,14 +175,27 @@ describe('host-app package resolution (cloud#1013, #4700)', () => {
     expect(new mod.OrganizationsPlugin().name).toBe('com.objectstack.organizations');
   });
 
-  it("falls back to the importing package's own resolution when the host does not declare", async () => {
-    // Whatever the host app does not declare must still load from the framework
-    // package's own dependencies — that fallback is what keeps every
-    // framework-owned load in `serve` (plugin-auth, plugin-security,
-    // service-i18n, …) and in `bootStack` working exactly as before.
-    const mod = await createHostImporter(undeclaringRoot)('@objectstack/spec');
-    expect(mod).toBeTypeOf('object');
-  });
+  it(
+    "falls back to the importing package's own resolution when the host does not declare",
+    async () => {
+      // Whatever the host app does not declare must still load from the framework
+      // package's own dependencies — that fallback is what keeps every
+      // framework-owned load in `serve` (plugin-auth, plugin-security,
+      // service-i18n, …) and in `bootStack` working exactly as before.
+      const mod = await createHostImporter(undeclaringRoot)('@objectstack/spec');
+      expect(mod).toBeTypeOf('object');
+    },
+    // Explicit testTimeout (#9311): this is the ONE case in this file that
+    // actually loads `@objectstack/spec` — a real dynamic `import()` of a
+    // multi-megabyte package, not the small on-disk fixtures its siblings use
+    // (all <10ms). Measured unloaded on a 4-CPU box: ~0.9-1.1s. Under nothing
+    // heavier than `turbo run test --concurrency=2` it was already observed at
+    // 5061ms against the 5000ms default — margin, not correctness, is the
+    // defect (#9311). 30s matches the #3662 precedent for subprocess/real-load
+    // cases elsewhere in the repo (~30x the unloaded cost, ~6x the already-
+    // observed loaded failure point) rather than a bare guess.
+    30_000,
+  );
 
   it('reports a package that neither can resolve as module-not-found', async () => {
     const importFromHost = createHostImporter(hostRoot);


### PR DESCRIPTION
Fixes #9311

## What

Two explicit timeouts, exactly the scope the card's triage comment fenced:

1. **`packages/types/src/node.test.ts:178`** — `"falls back to the importing package's own resolution when the host does not declare"` gets an explicit **30s `testTimeout`**. It is the only case in its `describe` block that performs a real dynamic `import()` of `@objectstack/spec` (a multi-megabyte package); every sibling resolves a small on-disk fixture or fails fast, all under 10ms — checked directly, not assumed. Measured on this box: ~0.9-1.1s unloaded across 3 isolated runs. The card's own isolation runs already showed it failing at 5061ms against the 5000ms default under nothing heavier than `turbo run test --concurrency=2`, so 30s (matching the repo's `#3662` precedent for subprocess/real-load cases) gives real headroom without masking a genuine hang.

2. **`packages/qa/dogfood/test/semantic-roles.dogfood.test.ts:52`** — the `beforeAll` that boots the full showcase stack (ObjectQL + ~45 plugins) through `@objectstack/verify`'s `bootStack` gets an explicit **180s `hookTimeout`**. This file's own isolated run here measured 18.3s (vitest `Duration`) / 19.5s wall clock for the whole file (boot dominates; the 5 tests themselves run in ~3.5s) — in the same range as the card's own ~27s unloaded measurement. The previously observed failure was 10027ms against the 10000ms default, essentially zero margin even idle. 180_000ms follows this package's own existing house pattern for the identical `bootStack(showcaseStack, …)` call — `admin-identity-audit-trail.dogfood.test.ts`'s `beforeAll(…, 180_000)` — rather than inventing a new number.

No sibling dogfood file carries a package-level `hookTimeout` override (`vitest.config.ts` sets none), so the per-hook precedent above is the house pattern being followed.

## Why this and not `turbo.json` concurrency

Both cases pass in isolation and the repo's full suite is confirmed green at `--concurrency=2 --continue` (comment on #9311). The margin was never sized for the work these two cases actually do (a real package import; a 45-plugin stack boot) — that is the "budget never sized for the work" case the dispatch explicitly distinguished from "hides work that got slower." Neither timeout changes behaviour; both suites already pass today. `turbo.json`'s default concurrency is out of scope per the card's own filing (a maintainer-level default) and is not touched here.

## Verification

- `packages/types`: `tsc --noEmit` clean; `vitest run` — **348/348 tests pass**, matching the card's own suite-size measurement.
- `packages/qa/dogfood`: `tsc --noEmit` clean; the changed file alone — `vitest run test/semantic-roles.dogfood.test.ts` — **5/5 pass**, run 3× for timing consistency (Duration 18.26s / 19.5s wall clock).
- Static gates run clean at head `dc151fd0` (all exit 0): `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:cross-package-test-inputs`, `check:slot-lookup`, `check:nul-bytes`, `check:type-check-coverage`, and the `packages/spec` liveness family (`check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs`), plus `scripts/docs-audit/check-affected-docs.mjs`.
- `check:type-check-debt` (the re-measure half) could not complete locally — it needs the **full** 78-package workspace closure built (`pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`) and this worktree hit a missing `@objectstack/service-knowledge` dist partway through an unrelated package's dependency chain. Neither `@objectstack/types` nor `@objectstack/dogfood` appears in the `DEBT`/`TEST_DEBT` ledgers in `scripts/check-type-check-coverage.mjs` (grepped directly), so this diff — test-file-only, no new imports, no new test files — cannot move that ratchet; CI's own build will run it in a clean environment.
- Did **not** run the full `@objectstack/dogfood` package suite (~780 tests across ~100 stack-booting files) locally — a real attempt ran past 8+ minutes without finishing under `--maxWorkers=2` on this shared, multi-agent-contended box, and continuing would hold the container-wide heavy-verification lock for an extended period at every other parallel agent's expense for a change with zero behavioural surface. The specific changed file was verified directly (above); CI runs the full suite in its own environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_