### PR TITLE
ci(scaffold-e2e): record why the unpublished-window fallback stays in the workflow, and narrow what its skip covers

### DIFF
--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -230,12 +230,42 @@ jobs:
         # The unpublished-version window is the one degradation, and it is
         # evidenced rather than blanket. The install step above carries the
         # fallback that rewrites unresolvable `@objectstack/*` ranges to
-        # `latest`; relocating that fallback into the scaffolder is a separate
-        # design (#9117), so this step cannot borrow it. When the scaffolder's
-        # install leaves no CLI behind, the registry is asked whether the
-        # emitted range was satisfiable at all: unsatisfiable ⇒ that known
-        # window, warn and skip; satisfiable ⇒ the scaffolder's install path is
-        # itself broken, which is a real defect and fails.
+        # `latest`; that fallback lives in THIS WORKFLOW rather than in the
+        # shipped scaffolder, so this step — whose whole point is to run the
+        # scaffolder's OWN install — cannot borrow it.
+        #
+        # WHY IT STILL LIVES HERE, RECORDED RATHER THAN TRIBAL (#9149).
+        # Relocating the fallback into the scaffolder would remove this
+        # degradation outright. It was considered and DECLINED at triage on
+        # 2026-08-17: `create-objectstack` is a PUBLISHED package, so a fallback
+        # that rewrites a real user's dependency ranges to `latest` is a
+        # user-visible public-surface expansion, not CI scaffolding — and a user
+        # scaffolding during a release window arguably wants a resolvable pin,
+        # not a floating tag. Reopening it needs a decision card answering
+        # #9149's three questions: where the rewrite belongs, whether `latest`
+        # is right for a real user at all, and what happens to the release-time
+        # stamping that rides the same step (`engines.protocol`, and since #9264
+        # `specVersion` too — see scripts/sync-template-versions.mjs). Until
+        # such a card is ruled, the degradation stays ON PURPOSE, and this
+        # pointer is why a reader finds that out here instead of rediscovering
+        # it.
+        #
+        # WHAT THE DEGRADATION IS NOT ALLOWED TO SWALLOW. The registry answer is
+        # classified THREE ways, not two. "npm says no version matches" and "npm
+        # could not be reached" both surface as an empty string, and both used
+        # to take the skip — so a registry outage could silently present itself
+        # as the known window and carry the leg green. Now:
+        #   * unreachable registry           ⇒ ::error:: — an unclassifiable
+        #     answer is never evidence of the window, so it is never skipped.
+        #   * reachable, range unsatisfiable ⇒ the known window ⇒ warn, and
+        #     assert the DEGRADED shape rather than nothing at all: with no
+        #     resolvable CLI the scaffolder pins nothing, so the template's own
+        #     `latest` tag must survive untouched. A tag that is neither
+        #     `latest` nor a resolved version means the scaffolder invented one
+        #     with nothing to resolve — a real defect this window must not hide.
+        #   * reachable, range satisfiable   ⇒ the scaffolder's install path is
+        #     itself broken ⇒ ::error::. Unchanged: this is the branch that
+        #     still catches a genuinely broken scaffolder install.
         run: |
           cd "$RUNNER_TEMP"
           node "$GITHUB_WORKSPACE/packages/create-objectstack/bin/create-objectstack.js" pinned-probe --skip-skills
@@ -243,10 +273,27 @@ jobs:
 
           if [ ! -f node_modules/@objectstack/cli/package.json ]; then
             RANGE=$(node -p "require('./package.json').devDependencies['@objectstack/cli']")
+
+            # Asked WITHOUT the range first, so an unreachable registry cannot
+            # masquerade as "that version is not published yet" and take the
+            # skip below. Both failures read as an empty string; only this
+            # rangeless probe tells them apart.
+            if [ -z "$(npm view "@objectstack/cli" version 2>/dev/null)" ]; then
+              echo "::error::cannot reach @objectstack/cli on the registry at all, so the emitted range '$RANGE' cannot be classified. An unreachable registry is NOT evidence of the unpublished-version window; refusing to skip the pinned-shape assertion on an answer this job cannot interpret."
+              exit 1
+            fi
+
             if [ -z "$(npm view "@objectstack/cli@$RANGE" version 2>/dev/null)" ]; then
-              echo "::warning::no @objectstack/cli matching '$RANGE' is on the registry — the unpublished-version window the install step's fallback exists for; the pinned-shape assertion is SKIPPED for this run"
+              echo "::warning::no @objectstack/cli matching '$RANGE' is on the registry — the unpublished-version window the install step's fallback exists for (that fallback lives in this workflow, not the scaffolder; #9149 records why). Pin-EQUALITY is SKIPPED for this run; the degraded shape is still asserted below."
+              TAG=$(sed -n 's|^FROM ghcr\.io/objectstack-ai/objectstack:||p' Dockerfile)
+              if [ "$TAG" != "latest" ]; then
+                echo "::error::the scaffolder resolved no @objectstack/cli (nothing on the registry satisfies '$RANGE'), so it must leave the template's runtime tag at 'latest' — but the emitted Dockerfile FROM tag is '${TAG:-<none>}'. A tag invented with nothing to resolve is a real defect, not the unpublished-version window."
+                exit 1
+              fi
+              echo "degraded shape as expected: no resolvable CLI, FROM tag left at 'latest'"
               exit 0
             fi
+
             echo "::error::the scaffolder ran its own install but left no node_modules/@objectstack/cli behind, though the registry does satisfy '$RANGE' — its install path is broken, so the Dockerfile pin can never run for a real user"
             exit 1
           fi


### PR DESCRIPTION
Fixes #9149

Workflow-only change to `.github/workflows/scaffold-e2e.yml`. The shipped scaffolder is **not** touched — see "Scope fork" below, which the reviewer should read first.

## What landed

**1. The designed degradation gains a recorded reason (the graded route).**

The pinned-shape leg warns and skips during the unpublished-version window because the range-rewrite fallback lives in this workflow's install step, not in the scaffolder. That was tribal knowledge spread across three issues. The step's comment now states it in place: why the fallback sits here, that relocating it into the published scaffolder was **considered and declined at triage on 2026-08-17** as a user-visible public-surface expansion, and that reopening it needs a decision card answering this card's three questions. The `specVersion` coupling introduced by #9264 is named there too, so a future taker inherits it instead of rediscovering it.

**2. The skip no longer swallows two real defects.**

The registry answer was classified two ways. "npm says no version matches" and "npm could not be reached" both surface as an empty string, so **a registry outage presented itself as the known window and carried the leg green**. And once the skip fired, it asserted nothing at all, so a bogus tag emitted during the window was invisible.

Now three ways:

| registry answer | verdict |
| --- | --- |
| unreachable | `::error::` — an unclassifiable answer is never evidence of the window |
| reachable, range unsatisfiable | the known window: warn, skip pin-**equality**, still assert the **degraded** shape — with no resolvable CLI the scaffolder pins nothing, so the template's own `latest` tag must survive untouched |
| reachable, range satisfiable | `::error::` — **unchanged**; still the branch that catches a genuinely broken scaffolder install |

The degradation itself is intact: the unpublished-version window still does not redden this leg.

## Scope fork — please rule before closing

The dispatch that produced this PR framed the defect as *where the fallback lives* and opened the file surface to `packages/create-objectstack/src/**`, suggesting the fallback be relocated into the scaffolder.

The maintainer's first-touch grading on the issue (2026-08-17) says the opposite, and is quoted verbatim:

> Route (b) — relocating the range-rewrite fallback into the published scaffolder — is deliberately **not** chosen at triage: it converts a CI-only fallback into user-visible published behaviour (rewriting a real user's ranges to `latest`), i.e. a public-surface expansion, which sits on the manual floor. Anyone wanting (b) should raise a decision card answering this card's three questions.
>
> File surface: the workflow file carrying the scaffold-e2e leg only.

I followed the maintainer's ruling and stayed in the workflow file. Relocating would have meant writing speculative code on an explicitly-undecided public-surface question. The narrowing above is the part of the dispatch's goal — reduce the gap between what CI exercises and what a user runs — that is reachable **without** expanding the published surface, and it is the alternative the dispatch itself named as acceptable.

## A measured correction to the dispatch's premise

The dispatch stated that a relocated fallback "**must** cover `specVersion` alongside `engines.protocol`". Measured: `specVersion` is **advisory-only** and, on this path, unread.

- `checkSpecVersionGap` (`packages/cli/src/utils/spec-version.ts`) documents itself as "advisory-only — it never fails a build/validate", and only fires when the declared major is **older** than the installed one.
- It reads `config.manifest.specVersion`, and the blank template's `objectstack.config.ts` manifest declares no `specVersion` at all — only `objectstack.manifest.json` does, which is template-registry metadata.

So the workflow fallback's asymmetry (it re-stamps `engines.protocol` but not `specVersion`) is **not** a live defect: `engines.protocol` is re-stamped because the ADR-0087 D1 handshake hard-refuses the boot, and `specVersion` has no equivalent enforcement. The coupling is real for the release-time pass; it is not load-bearing for this fallback. A relocation card should still handle it, but as tidiness, not as a boot-blocker.

## Verification

Gate union re-run on the final commit `c9da9ca0e`; `dispatch-gates.mjs` re-derived from the actual changed path.

| check | result |
| --- | --- |
| `check:node-version` | exit 0 |
| `check:required-contexts` | exit 0 |
| `check:shard-attestation` | exit 0 |
| `check:workflow-status-functions` | exit 0 |
| `node scripts/check-shard-attestation.mjs` | exit 0 |
| `check:nul-bytes` | exit 0 |
| YAML parse + `bash -n` on the extracted step | OK |

**Behavioural verification of the new classifier.** The classification block was extracted **verbatim** from the workflow (parsed out of the YAML, not retyped) and run against a stubbed `npm` in four scenarios:

| scenario | new | old (`origin/main`) |
| --- | --- | --- |
| registry unreachable | exit 1 `::error::` | **exit 0, green** |
| window, tag `latest` | exit 0, warn + degraded assert | exit 0 |
| window, tag `16.2.0` (invented) | exit 1 `::error::` | **exit 0, green** |
| range satisfiable | exit 1 `::error::` | exit 1 |

The two bolded rows are the previously-swallowed defects; the reverse verification ran the old block from `origin/main` against the same fixtures to prove the narrowing is real rather than cosmetic.

**Not verified locally, and it cannot be:** `Scaffold E2E` is CI-only (its header declares `dispatch-gates: no-check-families`) and needs a real registry, Docker and a network. The stubbed run above exercises the classification logic, **not** the end-to-end leg. A gate that refuses to run is not a gate that passed.

**Prettier:** not configured and not a gate in this repo; the file fails prettier defaults identically before and after this change, so no formatting regression is introduced and the file's existing quote style is left alone.

## No changeset, by the workflow's own prescription

This PR changes CI only and releases nothing, which `lint.yml` calls "the textbook `skip-changeset` case — such a PR releases nothing". The `skip-changeset` label is applied instead of a changeset, which would otherwise fabricate a user-facing release note for a change no user can observe.


---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_