### PR TITLE
feat(cli): os migrate duplicates — report the business identifiers already minted twice by the tenancy split

### DIFF
--- a/.changeset/cli-migrate-duplicates-inventory.md
+++ b/.changeset/cli-migrate-duplicates-inventory.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/cli": minor
+---
+
+feat(cli): `os migrate duplicates` — an operator-facing inventory of the business identifiers the tenancy split already minted twice (#8928)
+
+Two producers of untenanted rows have been closed (#8686's seed loader plus its
+one-shot backfill, and #8844's runtime system-context write). Neither touches
+the **damage already done**, and both rulings say the same thing about it: a
+business identifier that has already been handed out — on an invoice, in a
+notification, in another system's idempotence key — is not the platform's to
+rewrite. What an operator needs instead is to know **which ones they are**.
+
+```bash
+os migrate duplicates                        # the whole report, JSON on stdout
+os migrate duplicates > duplicates-2026-08-17.json
+os migrate duplicates --object crm_case      # narrowed (and the report says so)
+```
+
+**Run it BEFORE the #8686 backfill is applied.** The evidence is perishable:
+`organization_id = NULL` is the marker that says "this row came from the
+untenanted side", and it is exactly what that repair overwrites. The repair also
+merges and deletes the `__global__` counter, which is the report's only
+forward-looking line — an install that repairs before reporting can never
+produce it again. The command itself applies nothing: it boots read-only (no
+DDL, no seed, no database file brought into existence) and issues SELECTs only.
+
+What the report contains, per the 2026-08-16 maintainer ruling on all five of
+the card's decision points:
+
+- **one row per duplicated value, with its holders** — id, organization,
+  partition and creation timestamp per row, so the operator can decide case by
+  case rather than per value. JSON on stdout, no persistence and no new schema:
+  the operator archives it;
+- **the narrow definition of duplicate** — a value held by rows in more than one
+  of the partitions `COALESCE(organization_id, '__global__')` separates
+  (ADR-0120 D3). A value repeated *inside* one partition is refused by the
+  partitioned unique index and is not reported;
+- **the live condition too** — an object still running a `__global__` counter
+  beside an organization-scoped one is about to mint more duplicates;
+- **a data-side probe** — `GROUP BY <field> HAVING COUNT(*) > 1` over the
+  object's own table, never an enumeration of `_objectstack_sequences`, so a
+  duplicate whose counter was since merged is still found. The counter table is
+  read for the live condition alone, because that fact lives nowhere else.
+
+Scope is every registered object that is organization-scoped, and on it every
+`autonumber` or `unique` field. `sys_` / `cloud_` / `ai_` objects are **not**
+filtered out — that filter is correct for a repair (platform seeds stay global
+by design) and wrong for a report, which must not silently omit a real
+duplicate. Anything that could not be probed is listed in `skipped` with the
+driver's own message, so a target the command could not read never reads as a
+target with no findings; a driver with no raw-SQL seam refuses loudly and exits
+non-zero rather than reporting zero duplicates.
+
+⛔ Reporting is all it does. Renumbering, deduplicating or otherwise rewriting an
+already-minted identifier stays out of scope per both rulings.

--- a/packages/cli/src/commands/migrate/duplicates.contract.test.ts
+++ b/packages/cli/src/commands/migrate/duplicates.contract.test.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8928 — the report's JSON contract, measured against a real SQLite database.
+ *
+ * The ruling made the output a machine-readable artifact: an operator archives
+ * it, and auditors and tools read it. So the document's shape is a contract in
+ * practice, and this file is what stops it from becoming an accident of the
+ * implementation — every field a consumer may rely on is asserted here, whole,
+ * rather than sampled.
+ *
+ * A real driver, not a double: the probes are SQL, and the three things most
+ * likely to be wrong about them (the `COALESCE` partition test, `COUNT(DISTINCT
+ * …)`, and reading a column the object does not have) are facts about a real
+ * dialect that no hand-rolled exec double can testify to.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqlDriver } from '@objectstack/driver-sql';
+import {
+  normalizeRows,
+  GLOBAL_TENANT,
+  ORGANIZATION_FIELD,
+  SEQUENCES_TABLE,
+  type SeedTenancyExec,
+} from '@objectstack/metadata-protocol';
+import { collectDuplicateIdentifierReport } from './duplicates.js';
+
+/**
+ * The registry view the booted stack hands the command — the same objects
+ * `stack.allObjects()` returns, written out here so the fixture states its own
+ * metadata.
+ */
+const OBJECTS = [
+  {
+    name: 'crm_case',
+    fields: {
+      case_number: { type: 'autonumber' },
+      external_ref: { type: 'text', unique: 'organization' },
+      subject: { type: 'text' },
+    },
+  },
+  {
+    // No `created_at`: an object that opted out of system fields still has to
+    // produce holders, with a null timestamp rather than a failed probe.
+    name: 'crm_ticket',
+    fields: { ticket_number: { type: 'autonumber' } },
+  },
+];
+
+let dir: string;
+let dbFile: string;
+let driver: SqlDriver;
+let exec: SeedTenancyExec;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'os-8928-contract-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  dbFile = join(dir, 'data', 'app.db');
+  driver = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: dbFile },
+    useNullAsDefault: true,
+  });
+  // The same wrapper `resolveSeedTenancyExec` builds around a driver that
+  // exposes `execute(sql, params)`.
+  exec = (sql: string, params?: unknown[]) => driver.execute(sql, (params ?? []) as any[]);
+  const k = (driver as any).knex;
+
+  await k.schema.createTable('crm_case', (t: any) => {
+    t.string('id').primary();
+    t.timestamp('created_at');
+    t.string('organization_id');
+    t.string('case_number');
+    t.string('external_ref');
+  });
+  await k('crm_case').insert([
+    // The seeded side: written while the install had no organization yet.
+    { id: 's1', created_at: '2026-01-01T00:00:00.000Z', organization_id: null, case_number: 'CASE-00001', external_ref: null },
+    { id: 's2', created_at: '2026-01-01T00:00:01.000Z', organization_id: null, case_number: 'CASE-00002', external_ref: null },
+    { id: 's3', created_at: '2026-01-01T00:00:02.000Z', organization_id: null, case_number: 'CASE-00038', external_ref: null },
+    // The API side: written by a signed-in user, in the install's organization.
+    { id: 'a1', created_at: '2026-02-01T00:00:00.000Z', organization_id: 'org_x', case_number: 'CASE-00001', external_ref: 'REF-1' },
+    { id: 'a2', created_at: '2026-02-01T00:00:01.000Z', organization_id: 'org_x', case_number: 'CASE-00002', external_ref: 'REF-1' },
+  ]);
+
+  await k.schema.createTable('crm_ticket', (t: any) => {
+    t.string('id').primary();
+    t.string('organization_id');
+    t.string('ticket_number');
+  });
+  await k('crm_ticket').insert([
+    { id: 't1', organization_id: null, ticket_number: 'TKT-1' },
+    { id: 't2', organization_id: 'org_x', ticket_number: 'TKT-1' },
+  ]);
+
+  await k.schema.createTable(SEQUENCES_TABLE, (t: any) => {
+    t.string('key_hash', 64).notNullable().primary();
+    t.string('object').notNullable();
+    t.string('tenant_id').notNullable();
+    t.string('field').notNullable();
+    t.string('scope', 1024).notNullable().defaultTo('');
+    t.bigInteger('last_value').notNullable().defaultTo(0);
+    t.timestamp('updated_at');
+  });
+  await k(SEQUENCES_TABLE).insert([
+    { key_hash: 'h1', object: 'crm_case', tenant_id: GLOBAL_TENANT, field: 'case_number', scope: '', last_value: 38 },
+    { key_hash: 'h2', object: 'crm_case', tenant_id: 'org_x', field: 'case_number', scope: '', last_value: 4 },
+    // Only a `__global__` row: no organization-scoped counter stands beside it,
+    // so this is NOT the condition the ruling asked to be reported.
+    { key_hash: 'h3', object: 'crm_ticket', tenant_id: GLOBAL_TENANT, field: 'ticket_number', scope: '', last_value: 9 },
+  ]);
+});
+
+afterAll(async () => {
+  try { await driver.disconnect(); } catch { /* already down */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const collect = (objectFilter?: string) =>
+  collectDuplicateIdentifierReport({
+    exec,
+    normalize: normalizeRows,
+    objects: OBJECTS,
+    database: 'better-sqlite3 (fixture)',
+    globalTenant: GLOBAL_TENANT,
+    organizationField: ORGANIZATION_FIELD,
+    sequencesTable: SEQUENCES_TABLE,
+    client: 'better-sqlite3',
+    now: () => new Date('2026-08-17T12:00:00.000Z'),
+    ...(objectFilter ? { objectFilter } : {}),
+  });
+
+describe('#8928 os migrate duplicates — the report document', () => {
+  it('is exactly this shape, whole', async () => {
+    expect(await collect()).toEqual({
+      report: 'duplicate-identifiers',
+      reportVersion: 1,
+      generatedAt: '2026-08-17T12:00:00.000Z',
+      database: 'better-sqlite3 (fixture)',
+      globalPartition: '__global__',
+      filter: null,
+      counters: { table: SEQUENCES_TABLE, status: 'read' },
+      scanned: [
+        {
+          object: 'crm_case',
+          field: 'case_number',
+          partitionField: 'organization_id',
+          identifier: 'autonumber',
+          uniqueScope: null,
+        },
+        {
+          object: 'crm_case',
+          field: 'external_ref',
+          partitionField: 'organization_id',
+          identifier: 'unique',
+          uniqueScope: 'organization',
+        },
+        {
+          object: 'crm_ticket',
+          field: 'ticket_number',
+          partitionField: 'organization_id',
+          identifier: 'autonumber',
+          uniqueScope: null,
+        },
+      ],
+      skipped: [],
+      duplicates: [
+        {
+          object: 'crm_case',
+          field: 'case_number',
+          value: 'CASE-00001',
+          holderCount: 2,
+          partitions: ['__global__', 'org_x'],
+          holders: [
+            { id: 's1', organization: null, partition: '__global__', createdAt: '2026-01-01T00:00:00.000Z' },
+            { id: 'a1', organization: 'org_x', partition: 'org_x', createdAt: '2026-02-01T00:00:00.000Z' },
+          ],
+        },
+        {
+          object: 'crm_case',
+          field: 'case_number',
+          value: 'CASE-00002',
+          holderCount: 2,
+          partitions: ['__global__', 'org_x'],
+          holders: [
+            { id: 's2', organization: null, partition: '__global__', createdAt: '2026-01-01T00:00:01.000Z' },
+            { id: 'a2', organization: 'org_x', partition: 'org_x', createdAt: '2026-02-01T00:00:01.000Z' },
+          ],
+        },
+        {
+          object: 'crm_ticket',
+          field: 'ticket_number',
+          value: 'TKT-1',
+          holderCount: 2,
+          partitions: ['__global__', 'org_x'],
+          // The object carries no `created_at`; the holders are still reported.
+          holders: [
+            { id: 't1', organization: null, partition: '__global__', createdAt: null },
+            { id: 't2', organization: 'org_x', partition: 'org_x', createdAt: null },
+          ],
+        },
+      ],
+      liveConditions: [
+        {
+          object: 'crm_case',
+          field: 'case_number',
+          globalLastValue: 38,
+          organizationCounters: [{ organization: 'org_x', lastValue: 4 }],
+        },
+      ],
+      summary: {
+        objectsScanned: 2,
+        fieldsScanned: 3,
+        duplicateValues: 3,
+        duplicateRows: 6,
+        liveConditions: 1,
+      },
+    });
+  });
+
+  it('does NOT report a value repeated inside ONE partition — the narrow ruled definition', async () => {
+    // `REF-1` is held twice, both times by `org_x`. That is a repeat the
+    // partitioned unique index already refuses; reporting it would be the wider
+    // reading ("any unique-declared field with repeated values, whatever the
+    // cause") the ruling explicitly declined.
+    const report = await collect();
+    expect(report.duplicates.map((d) => d.field)).not.toContain('external_ref');
+  });
+
+  it('records the --object narrowing, so an archived report cannot read as a full scan', async () => {
+    const report = await collect('crm_case');
+    expect(report.filter).toEqual({ object: 'crm_case' });
+    expect(report.summary.objectsScanned).toBe(1);
+    expect(new Set(report.duplicates.map((d) => d.object))).toEqual(new Set(['crm_case']));
+  });
+
+  it('reports an unreadable object as skipped, never as an object with no findings', async () => {
+    const report = await collectDuplicateIdentifierReport({
+      exec,
+      normalize: normalizeRows,
+      objects: [...OBJECTS, { name: 'crm_never_created', fields: { code: { type: 'autonumber' } } }],
+      database: 'better-sqlite3 (fixture)',
+      globalTenant: GLOBAL_TENANT,
+      organizationField: ORGANIZATION_FIELD,
+      sequencesTable: SEQUENCES_TABLE,
+      client: 'better-sqlite3',
+    });
+    expect(report.skipped).toEqual([
+      expect.objectContaining({
+        object: 'crm_never_created',
+        field: 'code',
+        reason: expect.stringContaining('duplicate probe failed'),
+      }),
+    ]);
+    // …and the objects it COULD read are still reported in full.
+    expect(report.summary.duplicateValues).toBe(3);
+  });
+});

--- a/packages/cli/src/commands/migrate/duplicates.integration.test.ts
+++ b/packages/cli/src/commands/migrate/duplicates.integration.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8928 end-to-end: the wiring `os migrate duplicates` actually runs on.
+ *
+ * The unit files pin the probes and the document; this one pins the three seams
+ * between them and the real platform, none of which a double can vouch for:
+ *
+ *  1. the read-only boot (`deferSchemaDdl` + `readOnlyProbe`) hands back the
+ *     registry the scan population is derived from — `stack.allObjects()`;
+ *  2. `resolveSeedTenancyExec` finds a raw-SQL seam on the booted engine, which
+ *     is where the report's every probe is issued;
+ *  3. **the boot itself changes nothing.** The command's whole reason to exist
+ *     is that the evidence is destroyed by repair, so "this command applies
+ *     nothing" has to hold for the BOOT too, not merely for the probes. Booting
+ *     is the part of the run with the most write paths behind it (schema sync,
+ *     the artifact seed, the `kernel:ready` migrations), so it is the part worth
+ *     measuring rather than reasoning about.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqlDriver } from '@objectstack/driver-sql';
+import {
+  resolveSeedTenancyExec,
+  normalizeRows,
+  GLOBAL_TENANT,
+  ORGANIZATION_FIELD,
+  ORGANIZATION_TABLE,
+  SEQUENCES_TABLE,
+} from '@objectstack/metadata-protocol';
+import { bootSchemaStack } from '../../utils/schema-migrate.js';
+import { collectDuplicateIdentifierReport } from './duplicates.js';
+
+let dir: string;
+let dbFile: string;
+const savedEnv: Record<string, string | undefined> = {};
+
+/** Read the fixture with a connection of our own — never the booted stack's. */
+async function readState(): Promise<unknown> {
+  const probe = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: dbFile },
+    useNullAsDefault: true,
+  });
+  try {
+    const k = (probe as any).knex;
+    return {
+      cases: await k('crm_case').select('*').orderBy('id'),
+      sequences: await k(SEQUENCES_TABLE).select('*').orderBy(['object', 'tenant_id']),
+    };
+  } finally {
+    await probe.disconnect();
+  }
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'os-8928-e2e-'));
+  mkdirSync(join(dir, 'dist'), { recursive: true });
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  dbFile = join(dir, 'data', 'app.db');
+
+  writeFileSync(
+    join(dir, 'dist', 'objectstack.json'),
+    JSON.stringify({
+      manifest: { id: 'dup_smoke', name: 'Duplicates Smoke', version: '0.0.0', type: 'app' },
+      objects: [
+        {
+          name: 'crm_case',
+          fields: {
+            subject: { type: 'text' },
+            case_number: { type: 'autonumber' },
+          },
+        },
+      ],
+    }),
+  );
+
+  // An install carrying the damage: two counters, and one number minted on both
+  // sides of the organization partition.
+  const seed = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: dbFile },
+    useNullAsDefault: true,
+  });
+  const k = (seed as any).knex;
+  await k.schema.createTable('crm_case', (t: any) => {
+    t.string('id').primary();
+    t.timestamp('created_at');
+    t.timestamp('updated_at');
+    t.string('organization_id');
+    t.string('subject');
+    t.string('case_number');
+  });
+  await k('crm_case').insert([
+    { id: 's1', created_at: '2026-01-01T00:00:00.000Z', organization_id: null, subject: 'seeded', case_number: 'CASE-00001' },
+    { id: 'a1', created_at: '2026-02-01T00:00:00.000Z', organization_id: 'org_x', subject: 'api', case_number: 'CASE-00001' },
+  ]);
+  await k.schema.createTable(ORGANIZATION_TABLE, (t: any) => {
+    t.string('id').primary();
+    t.string('name');
+  });
+  await k(ORGANIZATION_TABLE).insert([{ id: 'org_x', name: 'Acme' }]);
+  await k.schema.createTable(SEQUENCES_TABLE, (t: any) => {
+    t.string('key_hash', 64).notNullable().primary();
+    t.string('object').notNullable();
+    t.string('tenant_id').notNullable();
+    t.string('field').notNullable();
+    t.string('scope', 1024).notNullable().defaultTo('');
+    t.bigInteger('last_value').notNullable().defaultTo(0);
+    t.timestamp('updated_at');
+  });
+  await k(SEQUENCES_TABLE).insert([
+    { key_hash: 'h1', object: 'crm_case', tenant_id: GLOBAL_TENANT, field: 'case_number', scope: '', last_value: 38 },
+    { key_hash: 'h2', object: 'crm_case', tenant_id: 'org_x', field: 'case_number', scope: '', last_value: 1 },
+  ]);
+  await seed.disconnect();
+
+  savedEnv.OS_ARTIFACT_PATH = process.env.OS_ARTIFACT_PATH;
+  savedEnv.NODE_ENV = process.env.NODE_ENV;
+  process.env.OS_ARTIFACT_PATH = join(dir, 'dist', 'objectstack.json');
+  process.env.NODE_ENV = 'production'; // no dev-time auto-reconcile
+}, 120_000);
+
+afterAll(() => {
+  process.env.OS_ARTIFACT_PATH = savedEnv.OS_ARTIFACT_PATH;
+  process.env.NODE_ENV = savedEnv.NODE_ENV;
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('#8928 os migrate duplicates — against a really booted stack', () => {
+  it('reports the duplicate and the live condition, and leaves the install untouched', async () => {
+    const before = await readState();
+
+    const stack = await bootSchemaStack({
+      jsonOutput: false, // this test owns stdout
+      databaseUrl: `file:${dbFile}`,
+      deferSchemaDdl: true,
+      readOnlyProbe: true,
+      projectRoot: dir,
+    });
+    let produced;
+    try {
+      const ql = (stack.kernel as { getService?: (n: string) => unknown }).getService?.('objectql');
+      const exec = resolveSeedTenancyExec(ql);
+      expect(exec, 'the booted SQL stack must expose a raw-SQL seam').toBeTypeOf('function');
+
+      // The population comes from the booted registry, so an object installed by
+      // a package is scanned exactly like one from this project's config.
+      expect((stack.allObjects() as Array<{ name?: string }>).map((o) => o?.name)).toContain('crm_case');
+
+      produced = await collectDuplicateIdentifierReport({
+        exec: exec!,
+        normalize: normalizeRows,
+        objects: stack.allObjects(),
+        database: stack.dbLabel,
+        globalTenant: GLOBAL_TENANT,
+        organizationField: ORGANIZATION_FIELD,
+        sequencesTable: SEQUENCES_TABLE,
+        client: String((stack.driver?.config as { client?: unknown })?.client ?? ''),
+      });
+    } finally {
+      await stack.shutdown();
+    }
+
+    expect(produced.duplicates).toEqual([
+      expect.objectContaining({
+        object: 'crm_case',
+        field: 'case_number',
+        value: 'CASE-00001',
+        holderCount: 2,
+        partitions: ['__global__', 'org_x'],
+      }),
+    ]);
+    expect(produced.duplicates[0].holders.map((h) => h.id).sort()).toEqual(['a1', 's1']);
+    expect(produced.liveConditions).toEqual([
+      {
+        object: 'crm_case',
+        field: 'case_number',
+        globalLastValue: 38,
+        organizationCounters: [{ organization: 'org_x', lastValue: 1 }],
+      },
+    ]);
+
+    // The whole run — boot included — wrote nothing. If a future change arms a
+    // repair on this boot path, THIS is the assertion that says so, before an
+    // operator finds out by losing their evidence.
+    expect(await readState()).toEqual(before);
+  }, 120_000);
+});

--- a/packages/cli/src/commands/migrate/duplicates.pre-repair.test.ts
+++ b/packages/cli/src/commands/migrate/duplicates.pre-repair.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8928 — the binding timing note, measured.
+ *
+ * The ruling's perishability clause is the reason this card exists:
+ * `organization_id = NULL` is the marker that says "this row came from the
+ * untenanted side", and it is exactly what the #8686 repair overwrites. So the
+ * report must be runnable BEFORE the repair, and must not itself be a repair.
+ *
+ * Both halves are asserted here against the real migration, not a description of
+ * it — `backfillSeedTenancy` from `@objectstack/metadata-protocol` is imported
+ * and RUN in the second test, and what it destroys is measured rather than
+ * assumed. (Reading that module is expected for this card; editing it is out of
+ * surface, and nothing here does.)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SqlDriver } from '@objectstack/driver-sql';
+import {
+  backfillSeedTenancy,
+  normalizeRows,
+  GLOBAL_TENANT,
+  ORGANIZATION_FIELD,
+  ORGANIZATION_TABLE,
+  SEQUENCES_TABLE,
+  type SeedTenancyExec,
+} from '@objectstack/metadata-protocol';
+import { collectDuplicateIdentifierReport } from './duplicates.js';
+
+const OBJECTS = [{ name: 'crm_case', fields: { case_number: { type: 'autonumber' } } }];
+
+let dir: string;
+let driver: SqlDriver;
+let exec: SeedTenancyExec;
+
+/** Everything this fixture holds, in one comparable document. */
+async function snapshot(): Promise<unknown> {
+  const k = (driver as any).knex;
+  return {
+    cases: await k('crm_case').select('*').orderBy('id'),
+    sequences: await k(SEQUENCES_TABLE).select('*').orderBy(['object', 'tenant_id']),
+    organizations: await k(ORGANIZATION_TABLE).select('*').orderBy('id'),
+  };
+}
+
+const report = () =>
+  collectDuplicateIdentifierReport({
+    exec,
+    normalize: normalizeRows,
+    objects: OBJECTS,
+    database: 'fixture',
+    globalTenant: GLOBAL_TENANT,
+    organizationField: ORGANIZATION_FIELD,
+    sequencesTable: SEQUENCES_TABLE,
+    client: 'better-sqlite3',
+  });
+
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), 'os-8928-prerepair-'));
+  mkdirSync(join(dir, 'data'), { recursive: true });
+  driver = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: join(dir, 'data', 'app.db') },
+    useNullAsDefault: true,
+  });
+  exec = (sql: string, params?: unknown[]) => driver.execute(sql, (params ?? []) as any[]);
+  const k = (driver as any).knex;
+
+  await k.schema.createTable('crm_case', (t: any) => {
+    t.string('id').primary();
+    t.timestamp('created_at');
+    t.string('organization_id');
+    t.string('case_number');
+  });
+  await k('crm_case').insert([
+    { id: 's1', created_at: '2026-01-01T00:00:00.000Z', organization_id: null, case_number: 'CASE-00001' },
+    { id: 's2', created_at: '2026-01-01T00:00:01.000Z', organization_id: null, case_number: 'CASE-00038' },
+    { id: 'a1', created_at: '2026-02-01T00:00:00.000Z', organization_id: 'org_x', case_number: 'CASE-00001' },
+  ]);
+  await k.schema.createTable(ORGANIZATION_TABLE, (t: any) => {
+    t.string('id').primary();
+    t.string('name');
+  });
+  await k(ORGANIZATION_TABLE).insert([{ id: 'org_x', name: 'Acme' }]);
+  await k.schema.createTable(SEQUENCES_TABLE, (t: any) => {
+    t.string('key_hash', 64).notNullable().primary();
+    t.string('object').notNullable();
+    t.string('tenant_id').notNullable();
+    t.string('field').notNullable();
+    t.string('scope', 1024).notNullable().defaultTo('');
+    t.bigInteger('last_value').notNullable().defaultTo(0);
+    t.timestamp('updated_at');
+  });
+  await k(SEQUENCES_TABLE).insert([
+    { key_hash: 'h1', object: 'crm_case', tenant_id: GLOBAL_TENANT, field: 'case_number', scope: '', last_value: 38 },
+    { key_hash: 'h2', object: 'crm_case', tenant_id: 'org_x', field: 'case_number', scope: '', last_value: 4 },
+  ]);
+});
+
+afterEach(async () => {
+  try { await driver.disconnect(); } catch { /* already down */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('#8928 — the report is an inventory, not a repair', () => {
+  it('leaves every row and every counter exactly as it found them', async () => {
+    const before = await snapshot();
+    const produced = await report();
+    // It really did look — a run that found nothing would pass a
+    // "changed nothing" assertion trivially.
+    expect(produced.summary.duplicateValues).toBe(1);
+    expect(produced.summary.liveConditions).toBe(1);
+    expect(await snapshot()).toEqual(before);
+  });
+});
+
+describe('#8928 — why it must run BEFORE the #8686 backfill', () => {
+  it('the live condition is destroyed by the repair; the inventory is what survives', async () => {
+    const beforeRepair = await report();
+    expect(beforeRepair.liveConditions).toEqual([
+      {
+        object: 'crm_case',
+        field: 'case_number',
+        globalLastValue: 38,
+        organizationCounters: [{ organization: 'org_x', lastValue: 4 }],
+      },
+    ]);
+
+    // The real repair, run exactly as a boot would run it.
+    const repair = await backfillSeedTenancy(exec);
+    expect(repair.status).toBe('applied');
+
+    const afterRepair = await report();
+
+    // 1. The forward-looking half is GONE: the `__global__` counter was merged
+    //    into the organization-scoped one and deleted, so nothing is left to
+    //    report as a condition. An install that repaired before reporting can
+    //    never produce this line again.
+    expect(afterRepair.liveConditions).toEqual([]);
+    expect(afterRepair.counters.status).toBe('read');
+
+    // 2. The already-minted duplicate itself survives — and NOT by luck: the
+    //    backfill deliberately refuses to move a row whose identifier is already
+    //    taken in the destination partition, which is the same ruling ("report,
+    //    do not rewrite") seen from the repair's side. What the operator loses by
+    //    repairing first is the condition above, not the inventory.
+    expect(afterRepair.duplicates.map((d) => d.value)).toEqual(['CASE-00001']);
+    expect(afterRepair.duplicates[0].partitions).toEqual(['__global__', 'org_x']);
+
+    // 3. And the rows that had no conflict DID move — the `organization_id =
+    //    NULL` marker is overwritten for them, which is the perishability the
+    //    ruling names. Before the repair the report saw an untenanted CASE-00038;
+    //    after it, that row is indistinguishable from an API-created one.
+    const k = (driver as any).knex;
+    const moved = await k('crm_case').where({ id: 's2' }).first();
+    expect(moved.organization_id).toBe('org_x');
+  });
+});

--- a/packages/cli/src/commands/migrate/duplicates.probe-sql.test.ts
+++ b/packages/cli/src/commands/migrate/duplicates.probe-sql.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8928 — the SHAPE of the probes `os migrate duplicates` issues.
+ *
+ * These are statement-level assertions because two of the five ruled points are
+ * properties of the statements themselves, invisible to a test that only reads
+ * the report:
+ *
+ *  - **point 5, data-side** — the duplicate probe must read the object's own
+ *    table and never enumerate `_objectstack_sequences`. A counter-keyed probe
+ *    would still find every duplicate on the card's own repro (the counters are
+ *    right there) and silently miss the ones whose counter was since merged.
+ *  - **point 2, the narrow definition** — the grouping key is the value and the
+ *    filter is "held in more than one `COALESCE(<tenant column>, '__global__')`
+ *    partition". A probe that dropped the partition test would report ordinary
+ *    in-partition repeats, which is the wider reading the ruling declined.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { GLOBAL_TENANT, ORGANIZATION_FIELD, SEQUENCES_TABLE } from '@objectstack/metadata-protocol';
+import {
+  buildDuplicateProbeSql,
+  buildHolderProbeSql,
+  buildLiveConditionProbeSql,
+  buildSequencesPresenceProbeSql,
+  collectScanTargets,
+  quoteIdent,
+} from './duplicates.js';
+
+const base = {
+  object: 'crm_case',
+  field: 'case_number',
+  partitionField: ORGANIZATION_FIELD,
+  globalTenant: GLOBAL_TENANT,
+};
+
+describe('#8928 duplicate probe — data-side, partitioned, ruled shape', () => {
+  it('groups by the value and keeps only values held in more than one partition', () => {
+    const sql = buildDuplicateProbeSql(base);
+    expect(sql).toContain('FROM "crm_case"');
+    expect(sql).toContain('GROUP BY "case_number"');
+    // The ruled probe: `GROUP BY value HAVING count > 1`, narrowed to the
+    // cross-partition case that is the ruled definition of duplicate.
+    expect(sql).toContain('HAVING COUNT(*) > 1');
+    expect(sql).toContain(`COUNT(DISTINCT COALESCE("organization_id", '${GLOBAL_TENANT}')) > 1`);
+  });
+
+  it('never reads the driver-private counter table', () => {
+    // The whole point of point 5: a report keyed on `_objectstack_sequences`
+    // cannot see a duplicate whose counter was merged away, and cannot run at
+    // all on a driver that keeps no counters.
+    expect(buildDuplicateProbeSql(base)).not.toContain(SEQUENCES_TABLE);
+    expect(
+      buildHolderProbeSql({ ...base, valueCount: 2, withCreatedAt: true }),
+    ).not.toContain(SEQUENCES_TABLE);
+  });
+
+  it('honours a declared tenantField as the partition column', () => {
+    const sql = buildDuplicateProbeSql({ ...base, partitionField: 'workspace_id' });
+    expect(sql).toContain(`COALESCE("workspace_id", '${GLOBAL_TENANT}')`);
+    expect(sql).not.toContain('organization_id');
+  });
+
+  it('binds the values it asks holders about, and never interpolates them', () => {
+    const sql = buildHolderProbeSql({ ...base, valueCount: 3, withCreatedAt: true });
+    expect(sql).toContain('IN (?, ?, ?)');
+    expect(sql).toContain('AS holder_id');
+    expect(sql).toContain('AS organization');
+    expect(sql).toContain('AS created_at');
+    // The retry shape for an object that opted out of system fields.
+    expect(buildHolderProbeSql({ ...base, valueCount: 1, withCreatedAt: false })).not.toContain('created_at');
+  });
+
+  it('refuses an identifier that is not a plain SQL name', () => {
+    expect(() => buildDuplicateProbeSql({ ...base, object: 'crm_case"; DROP TABLE x --' })).toThrow(
+      /unsafe identifier/,
+    );
+    expect(() => buildHolderProbeSql({ ...base, field: 'a-b', valueCount: 1, withCreatedAt: true })).toThrow(
+      /unsafe identifier/,
+    );
+  });
+
+  it('quotes for the dialect actually connected — MySQL does not run ANSI_QUOTES', () => {
+    expect(quoteIdent('crm_case')).toBe('"crm_case"');
+    expect(quoteIdent('crm_case', 'mysql2')).toBe('`crm_case`');
+    const mysql = buildDuplicateProbeSql({ ...base, client: 'mysql2' });
+    expect(mysql).toContain('FROM `crm_case`');
+    // Under MySQL's default sql_mode a double-quoted name is a string literal,
+    // so a probe written with one quoting style for every dialect would compare
+    // the literal 'case_number' with itself and report nothing, forever.
+    expect(mysql).not.toContain('"case_number"');
+  });
+});
+
+describe('#8928 live-condition probe — a __global__ counter standing BESIDE an org one', () => {
+  it('inner-joins the two counter rows and binds the sentinel', () => {
+    const sql = buildLiveConditionProbeSql(SEQUENCES_TABLE);
+    expect(sql).toContain(`FROM "${SEQUENCES_TABLE}" g JOIN "${SEQUENCES_TABLE}" o`);
+    expect(sql).toContain('o.tenant_id <> ?');
+    expect(sql).toContain('WHERE g.tenant_id = ?');
+    // "Beside" is the claim: a LEFT JOIN would also report an object whose
+    // organization-scoped counter does not exist yet, which is the *repair's*
+    // trigger, not the condition the ruling asked to be reported.
+    expect(sql).not.toMatch(/LEFT JOIN/i);
+  });
+
+  it('probes for the counter table before reading it', () => {
+    expect(buildSequencesPresenceProbeSql(SEQUENCES_TABLE)).toBe(
+      `SELECT tenant_id FROM "${SEQUENCES_TABLE}" WHERE 1 = 0`,
+    );
+  });
+});
+
+describe('#8928 scan targets — which (object, field) pairs are in the population', () => {
+  const objects = [
+    {
+      name: 'crm_case',
+      fields: {
+        case_number: { type: 'autonumber' },
+        external_ref: { type: 'text', unique: 'organization' },
+        subject: { type: 'text' },
+      },
+    },
+    { name: 'crm_note', fields: { body: { type: 'text' } } },
+    {
+      name: 'sys_license',
+      tenancy: { enabled: false },
+      fields: { serial: { type: 'text', unique: 'global' } },
+    },
+    {
+      name: 'ai_thread',
+      fields: { thread_no: { type: 'autonumber' } },
+    },
+    {
+      name: 'wk_task',
+      tenancy: { enabled: true, tenantField: 'workspace_id' },
+      fields: { workspace_id: { type: 'text' }, task_no: { type: 'autonumber' } },
+    },
+  ];
+
+  it('scans autonumber and unique fields, and no others', () => {
+    const { targets } = collectScanTargets(objects, { organizationField: ORGANIZATION_FIELD });
+    expect(targets.map((t) => `${t.object}.${t.field}`)).toEqual([
+      // Platform namespaces are NOT filtered out: that filter is correct for a
+      // repair and wrong for a report, which must not omit a real duplicate.
+      'ai_thread.thread_no',
+      'crm_case.case_number',
+      'crm_case.external_ref',
+      'wk_task.task_no',
+    ]);
+    expect(targets.find((t) => t.field === 'task_no')?.partitionField).toBe('workspace_id');
+    expect(targets.find((t) => t.field === 'case_number')?.identifier).toBe('autonumber');
+    expect(targets.find((t) => t.field === 'external_ref')?.uniqueScope).toBe('organization');
+  });
+
+  it('says out loud why an organization-unscoped object was not scanned', () => {
+    const { skipped } = collectScanTargets(objects, { organizationField: ORGANIZATION_FIELD });
+    expect(skipped).toEqual([
+      {
+        object: 'sys_license',
+        reason: 'object declares tenancy.enabled = false — its uniqueness is not organization-partitioned',
+      },
+    ]);
+  });
+
+  it('narrows to one object when asked, and reports nothing else', () => {
+    const { targets } = collectScanTargets(objects, {
+      organizationField: ORGANIZATION_FIELD,
+      objectFilter: 'crm_case',
+    });
+    expect(new Set(targets.map((t) => t.object))).toEqual(new Set(['crm_case']));
+  });
+});

--- a/packages/cli/src/commands/migrate/duplicates.ts
+++ b/packages/cli/src/commands/migrate/duplicates.ts
@@ -1,0 +1,736 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { Command, Flags } from '@oclif/core';
+import { emitJson, isExitSignal } from '../../utils/format.js';
+import { bootSchemaStack } from '../../utils/schema-migrate.js';
+// The `objectql` slot's contract (#4251) — read the registry through it rather
+// than erasing the lookup to `any`, so a rename breaks this at compile time
+// instead of silently reporting zero objects.
+import type { IObjectQLEngine } from '@objectstack/spec/contracts';
+// TYPE-ONLY on purpose. The value side (`resolveSeedTenancyExec` and the three
+// platform constants) is loaded with `await import()` inside `run()`: oclif
+// `import()`s every command module on every CLI invocation, so a heavy static
+// import here is charged to whatever command the operator actually ran (#5726
+// makes the same point about driver packages).
+import type { SeedTenancyExec } from '@objectstack/metadata-protocol';
+
+/**
+ * `os migrate duplicates` — the operator-facing inventory of business
+ * identifiers the tenancy split already minted twice (#8928).
+ *
+ * ## What this is, and what it deliberately is not
+ *
+ * Two producers of untenanted rows have been closed (#8686's seed loader plus
+ * its one-shot backfill, and #8844's runtime system-context write). Neither
+ * touches the damage already done, and both rulings say the same thing about
+ * it: **a business identifier that has already been handed out is not the
+ * platform's to rewrite.** So this command produces an inventory and nothing
+ * else — it never renumbers, deduplicates, moves a row between partitions or
+ * writes anything at all.
+ *
+ * Implemented to the 2026-08-16 maintainer ruling on #8928, which settled all
+ * five of the card's decision points:
+ *
+ *  1. **CLI door only** — this command, beside the rest of the `os migrate`
+ *     family. No REST endpoint, no boot-time report.
+ *  2. **The narrow definition of "duplicate"** — one object/field value held by
+ *     rows in more than one of the partitions `COALESCE(organization_id,
+ *     '__global__')` separates (ADR-0120 D3). Repeated values *within* one
+ *     partition are not reported: the partitioned unique index bites there, so
+ *     a repeat inside a partition is a different defect with a different cause.
+ *  3. **JSON to stdout, no persistence** — the operator archives it. No new
+ *     schema, no rows written, nothing left behind.
+ *  4. **The live CONDITION is reported too** — an install still holding a
+ *     `__global__` counter beside an organization-scoped one for the same
+ *     object is about to mint more duplicates. The only forward-looking line in
+ *     the report.
+ *  5. **A data-side probe** — `GROUP BY <field> HAVING COUNT(*) > 1` within the
+ *     object's own table, never an enumeration of `_objectstack_sequences`. A
+ *     duplicate on an object whose counter was since merged is therefore still
+ *     found, and the probe does not assume the driver keeps counters at all.
+ *
+ * ## Why the evidence is perishable, and what that demands of this command
+ *
+ * `organization_id = NULL` is the marker that says "this row came from the
+ * untenanted side", and it is exactly what the #8686 backfill overwrites. The
+ * ruling's binding timing note follows: this report must be runnable **before**
+ * that repair is applied on an install, and must not depend on state the repair
+ * destroys. Two consequences, both load-bearing:
+ *
+ *  - **This command applies nothing.** It boots read-only (the same
+ *    `deferSchemaDdl` + `readOnlyProbe` boot `os migrate plan` uses, so no DDL,
+ *    no seed and no database file are created) and issues SELECTs only.
+ *    `duplicates.pre-repair.test.ts` pins that a full run leaves both the rows
+ *    and `_objectstack_sequences` byte-identical, and that the repair — run
+ *    afterwards, in the same test — is what makes the live condition vanish.
+ *  - **The duplicate probe reads user data, not counters.** The counter table
+ *    is consulted for one thing only, the live condition of point 4, which is a
+ *    fact about counters and lives nowhere else. When that table is absent the
+ *    duplicate inventory is still complete.
+ *
+ * ## Scope of the scan
+ *
+ * Every registered object that is organization-scoped, and on it every field
+ * that is an identifier — `type: 'autonumber'`, or carrying any `unique`
+ * spelling. `sys_` / `cloud_` / `ai_` objects are **not** filtered out: that
+ * filter is correct for a *repair* (platform seeds stay global by design) and
+ * wrong for a report, which must not silently omit a real duplicate. Anything
+ * that could not be probed is listed in `skipped` with the reason — a target
+ * this command could not read is never reported as a target with no findings.
+ */
+
+/** One `(object, field)` this run probed. */
+export interface DuplicateScanTarget {
+  object: string;
+  field: string;
+  /** Column the ADR-0120 D3 partition is keyed on for this object. */
+  partitionField: string;
+  /** Why the field is an identifier at all. */
+  identifier: 'autonumber' | 'unique';
+  /** The authored `unique` spelling, when the field carries one. */
+  uniqueScope: 'organization' | 'global' | null;
+}
+
+/** One `(object, field)` this run could NOT probe, and why. */
+export interface DuplicateSkippedTarget {
+  object: string;
+  field?: string;
+  reason: string;
+}
+
+/** One row holding a duplicated value. */
+export interface DuplicateHolder {
+  /** The row's id, as stored. */
+  id: string | null;
+  /** The row's organization, or `null` for the untenanted side. */
+  organization: string | null;
+  /** The partition the row falls in — `organization` or the global sentinel. */
+  partition: string;
+  /** The row's `created_at`, or `null` when the object carries no such column. */
+  createdAt: string | null;
+}
+
+/** One value held across more than one partition. */
+export interface DuplicateIdentifier {
+  object: string;
+  field: string;
+  /** The value, rendered as text — autonumber formats are strings anyway. */
+  value: string;
+  /** How many rows hold it. */
+  holderCount: number;
+  /** The distinct partitions it is held in, sorted. */
+  partitions: string[];
+  holders: DuplicateHolder[];
+}
+
+/**
+ * One object/field still running two counters — the live condition (point 4).
+ *
+ * Not damage: a prediction. While both counters stand, each allocates within
+ * its own partition and neither can see the other's numbers.
+ */
+export interface DuplicateLiveCondition {
+  object: string;
+  field: string;
+  globalLastValue: number;
+  organizationCounters: Array<{ organization: string; lastValue: number }>;
+}
+
+/**
+ * The report — a machine-readable contract, consumed by auditors and tools.
+ *
+ * Shaped deliberately and pinned by `duplicates.contract.test.ts`: the fields
+ * below are what a consumer may rely on, so the shape is not free to drift with
+ * the implementation. `reportVersion` is what changes when it must.
+ */
+export interface DuplicateIdentifierReport {
+  report: 'duplicate-identifiers';
+  reportVersion: 1;
+  /** ISO-8601, so archived reports sort and diff. */
+  generatedAt: string;
+  /** The database this describes, in the same words the migrate family prints. */
+  database: string;
+  /** The sentinel the NULL-organization partition folds into (ADR-0120 D3). */
+  globalPartition: string;
+  /** `null` unless `--object` narrowed the run — an archived report must not read as a full scan. */
+  filter: { object: string } | null;
+  /** Where the live condition was read from, and whether it could be read. */
+  counters: { table: string; status: 'read' | 'absent' };
+  scanned: DuplicateScanTarget[];
+  skipped: DuplicateSkippedTarget[];
+  duplicates: DuplicateIdentifier[];
+  liveConditions: DuplicateLiveCondition[];
+  summary: {
+    objectsScanned: number;
+    fieldsScanned: number;
+    duplicateValues: number;
+    duplicateRows: number;
+    liveConditions: number;
+  };
+}
+
+/**
+ * Reject anything that is not a plain SQL identifier.
+ *
+ * Object and field names are interpolated into the probes, because a table name
+ * cannot be a bound parameter in any supported dialect. Every VALUE is bound;
+ * only identifiers are interpolated, and only after passing this. The platform's
+ * naming rule is `snake_case` machine names, so a name this rejects is one the
+ * platform could not have written. (Same guard, same reasoning, as the one in
+ * `seed-tenancy-backfill.ts`.)
+ */
+function isSafeIdentifier(name: unknown): name is string {
+  return typeof name === 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/**
+ * Quote an identifier for the dialect actually connected.
+ *
+ * MySQL does not run with `ANSI_QUOTES`, so `"x"` there is a string literal and
+ * not an identifier — a probe written with one quoting style for every dialect
+ * cannot run on all three. The client name comes from the live driver config
+ * (`sqlite3` / `better-sqlite3` / `pg` / `mysql` / `mysql2`), the same source
+ * the migrate family reads to name the database.
+ */
+export function quoteIdent(name: string, client?: string): string {
+  const c = String(client ?? '').toLowerCase();
+  if (c === 'mysql' || c === 'mysql2') return `\`${name.replace(/`/g, '``')}\``;
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/** A string literal safe to inline — the platform's own sentinel, never user input. */
+function quoteLiteral(value: string): string {
+  if (value.includes("'")) throw new Error(`unsafe literal in duplicate probe: ${value}`);
+  return `'${value}'`;
+}
+
+/** Field map or field array — both authoring shapes are accepted. */
+function fieldEntriesOf(fields: unknown): Array<{ name: string; def: Record<string, unknown> }> {
+  if (!fields) return [];
+  if (Array.isArray(fields)) {
+    return fields
+      .filter((f): f is Record<string, unknown> => !!f && typeof f === 'object' && (f as any).name != null)
+      .map((f) => ({ name: String((f as any).name), def: f }));
+  }
+  if (typeof fields !== 'object') return [];
+  return Object.entries(fields as Record<string, unknown>).map(([name, def]) => ({
+    name,
+    def: (def ?? {}) as Record<string, unknown>,
+  }));
+}
+
+/**
+ * The NULL-safe partition key part, ADR-0120 D3's exact form — the expression
+ * the platform's own unique index is built on, restated here because it is what
+ * "the same value across partitions" MEANS.
+ */
+export function partitionExpression(partitionField: string, globalTenant: string, client?: string): string {
+  return `COALESCE(${quoteIdent(partitionField, client)}, ${quoteLiteral(globalTenant)})`;
+}
+
+/**
+ * The ruled probe (point 5): group the object's own rows by the identifier
+ * value and keep the values held more than once — then narrow to the ones held
+ * in more than one partition, which is the ruled definition of duplicate
+ * (point 2).
+ *
+ * Both halves are expressed in SQL rather than filtered in memory: the
+ * in-partition repeats a `HAVING COUNT(*) > 1` alone would return are exactly
+ * what the partitioned unique index already prevents, and on a large table they
+ * are the bulk of the rows a naive probe would drag back.
+ *
+ * ⛔ Reads the object's table only. `_objectstack_sequences` is deliberately
+ * absent: a duplicate whose counter was since merged is invisible to a
+ * counter-keyed enumeration, and a driver that keeps no counters at all has the
+ * same duplicates.
+ */
+export function buildDuplicateProbeSql(opts: {
+  object: string;
+  field: string;
+  partitionField: string;
+  globalTenant: string;
+  client?: string;
+}): string {
+  const { object, field, partitionField, globalTenant, client } = opts;
+  if (!isSafeIdentifier(object) || !isSafeIdentifier(field) || !isSafeIdentifier(partitionField)) {
+    throw new Error(`unsafe identifier in duplicate probe: ${object}.${field}`);
+  }
+  const t = quoteIdent(object, client);
+  const f = quoteIdent(field, client);
+  const p = partitionExpression(partitionField, globalTenant, client);
+  return (
+    `SELECT ${f} AS dup_value, COUNT(*) AS holder_count, ` +
+    `COUNT(DISTINCT ${p}) AS partition_count ` +
+    `FROM ${t} WHERE ${f} IS NOT NULL ` +
+    `GROUP BY ${f} ` +
+    `HAVING COUNT(*) > 1 AND COUNT(DISTINCT ${p}) > 1 ` +
+    `ORDER BY ${f}`
+  );
+}
+
+/**
+ * The holder rows behind one batch of duplicated values — ids, organizations
+ * and creation timestamps, one row per holder, which is what makes the report
+ * actionable per record rather than per value.
+ *
+ * `created_at` is platform-provisioned but an object may opt out of system
+ * fields, so the caller retries without it; `withCreatedAt: false` is that
+ * second attempt, and the holders it produces carry `createdAt: null`.
+ */
+export function buildHolderProbeSql(opts: {
+  object: string;
+  field: string;
+  partitionField: string;
+  valueCount: number;
+  withCreatedAt: boolean;
+  client?: string;
+}): string {
+  const { object, field, partitionField, valueCount, withCreatedAt, client } = opts;
+  if (!isSafeIdentifier(object) || !isSafeIdentifier(field) || !isSafeIdentifier(partitionField)) {
+    throw new Error(`unsafe identifier in holder probe: ${object}.${field}`);
+  }
+  if (!Number.isInteger(valueCount) || valueCount < 1) {
+    throw new Error(`holder probe needs at least one value: ${object}.${field}`);
+  }
+  const t = quoteIdent(object, client);
+  const f = quoteIdent(field, client);
+  const p = quoteIdent(partitionField, client);
+  const placeholders = Array.from({ length: valueCount }, () => '?').join(', ');
+  const created = withCreatedAt ? `, ${quoteIdent('created_at', client)} AS created_at` : '';
+  return (
+    `SELECT ${quoteIdent('id', client)} AS holder_id, ${f} AS dup_value, ${p} AS organization${created} ` +
+    `FROM ${t} WHERE ${f} IN (${placeholders}) ` +
+    `ORDER BY ${f}, ${quoteIdent('id', client)}`
+  );
+}
+
+/**
+ * The live condition (point 4): every object/field whose `__global__` counter
+ * is still standing BESIDE an organization-scoped one.
+ *
+ * An INNER JOIN, deliberately — "beside" is the whole claim. (The backfill's own
+ * probe is a LEFT JOIN because it triggers a *repair*, which must also fire on a
+ * fresh install where the organization-scoped counter does not exist yet. This
+ * is a different question with a different answer.)
+ *
+ * This is the one probe that reads the driver-private counter table, because
+ * this is the one fact that lives nowhere else. Point 5's "not keyed on
+ * `_objectstack_sequences`" governs the duplicate inventory above, which is
+ * about rows.
+ */
+export function buildLiveConditionProbeSql(sequencesTable: string, client?: string): string {
+  if (!isSafeIdentifier(sequencesTable)) {
+    throw new Error(`unsafe identifier in live-condition probe: ${sequencesTable}`);
+  }
+  const t = quoteIdent(sequencesTable, client);
+  return (
+    `SELECT g.object AS object, g.field AS field, g.last_value AS global_last_value, ` +
+    `o.tenant_id AS organization, o.last_value AS organization_last_value ` +
+    `FROM ${t} g JOIN ${t} o ON g.object = o.object AND g.field = o.field AND o.tenant_id <> ? ` +
+    `WHERE g.tenant_id = ? ` +
+    `ORDER BY g.object, g.field, o.tenant_id`
+  );
+}
+
+/** Probe statement: does the counter table exist at all? */
+export function buildSequencesPresenceProbeSql(sequencesTable: string, client?: string): string {
+  if (!isSafeIdentifier(sequencesTable)) {
+    throw new Error(`unsafe identifier in presence probe: ${sequencesTable}`);
+  }
+  return `SELECT tenant_id FROM ${quoteIdent(sequencesTable, client)} WHERE 1 = 0`;
+}
+
+function toNumber(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Which `(object, field)` pairs are in the population at all.
+ *
+ * An identifier field is one the platform mints or constrains — `autonumber`,
+ * or any `unique` spelling. An object with none is not a candidate and is not
+ * listed; an object that HAS them but is not organization-scoped is listed in
+ * `skipped`, because a reader would otherwise be left wondering.
+ */
+export function collectScanTargets(
+  objects: unknown[],
+  opts: { organizationField: string; objectFilter?: string },
+): { targets: DuplicateScanTarget[]; skipped: DuplicateSkippedTarget[] } {
+  const targets: DuplicateScanTarget[] = [];
+  const skipped: DuplicateSkippedTarget[] = [];
+
+  for (const obj of Array.isArray(objects) ? (objects as Array<Record<string, unknown>>) : []) {
+    const objectName = typeof obj?.name === 'string' ? obj.name.trim() : '';
+    if (!objectName) continue;
+    if (opts.objectFilter && objectName !== opts.objectFilter) continue;
+
+    const entries = fieldEntriesOf(obj?.fields);
+    const identifiers = entries.filter(({ def }) => {
+      const unique = def?.unique;
+      return def?.type === 'autonumber' || unique === true || unique === 'organization' || unique === 'global';
+    });
+    if (identifiers.length === 0) continue;
+
+    if (!isSafeIdentifier(objectName)) {
+      skipped.push({ object: objectName, reason: 'object name is not a plain SQL identifier' });
+      continue;
+    }
+
+    // `tenancy.enabled === false` opts the object out of row-level organization
+    // scoping (ADR-0066), so its uniqueness is NOT partitioned and a value
+    // repeated across organizations is refused by a plain index rather than
+    // hidden by a partitioned one. Out of the ruled population — and said out
+    // loud, not dropped.
+    const tenancy = obj?.tenancy as { enabled?: boolean; tenantField?: string } | undefined;
+    if (tenancy?.enabled === false) {
+      skipped.push({
+        object: objectName,
+        reason: 'object declares tenancy.enabled = false — its uniqueness is not organization-partitioned',
+      });
+      continue;
+    }
+
+    // Mirrors the driver's own `computeTenantField`: a declared name is honoured
+    // only when the object really has that field, otherwise the platform column.
+    const declared = tenancy?.tenantField;
+    const partitionField =
+      declared && entries.some(({ name }) => name === declared) ? declared : opts.organizationField;
+    if (!isSafeIdentifier(partitionField)) {
+      skipped.push({
+        object: objectName,
+        reason: `tenancy.tenantField '${String(declared)}' is not a plain SQL identifier`,
+      });
+      continue;
+    }
+
+    for (const { name, def } of identifiers) {
+      if (!isSafeIdentifier(name)) {
+        skipped.push({ object: objectName, field: name, reason: 'field name is not a plain SQL identifier' });
+        continue;
+      }
+      const unique = def?.unique;
+      targets.push({
+        object: objectName,
+        field: name,
+        partitionField,
+        identifier: def?.type === 'autonumber' ? 'autonumber' : 'unique',
+        uniqueScope: unique === 'global' ? 'global' : unique ? 'organization' : null,
+      });
+    }
+  }
+
+  targets.sort((a, b) => a.object.localeCompare(b.object) || a.field.localeCompare(b.field));
+  skipped.sort(
+    (a, b) => a.object.localeCompare(b.object) || String(a.field ?? '').localeCompare(String(b.field ?? '')),
+  );
+  return { targets, skipped };
+}
+
+/** How many values one holder query asks about — bound-parameter limits are per dialect. */
+const HOLDER_BATCH = 200;
+
+export interface CollectDuplicateReportOptions {
+  exec: SeedTenancyExec;
+  /** Flattens the three dialect result shapes — `normalizeRows` from metadata-protocol. */
+  normalize: (result: unknown) => Array<Record<string, unknown>>;
+  /** Every object the booted stack knows about. */
+  objects: unknown[];
+  database: string;
+  globalTenant: string;
+  organizationField: string;
+  sequencesTable: string;
+  client?: string;
+  objectFilter?: string;
+  /** Injected so the contract test can pin a stable document. */
+  now?: () => Date;
+}
+
+/**
+ * Run every probe and assemble the report.
+ *
+ * Read-only from end to end: SELECTs, no transaction, nothing written. A probe
+ * that throws produces a `skipped` entry naming the driver's own message and
+ * never aborts the run — a report that stopped at the first unreadable object
+ * would be a report the operator cannot trust to be complete.
+ */
+export async function collectDuplicateIdentifierReport(
+  opts: CollectDuplicateReportOptions,
+): Promise<DuplicateIdentifierReport> {
+  const { exec, normalize, globalTenant, organizationField, sequencesTable, client } = opts;
+  const { targets, skipped } = collectScanTargets(opts.objects, {
+    organizationField,
+    ...(opts.objectFilter ? { objectFilter: opts.objectFilter } : {}),
+  });
+
+  const duplicates: DuplicateIdentifier[] = [];
+
+  for (const target of targets) {
+    let values: Array<{ value: string; holderCount: number }>;
+    try {
+      const rows = normalize(
+        await exec(
+          buildDuplicateProbeSql({
+            object: target.object,
+            field: target.field,
+            partitionField: target.partitionField,
+            globalTenant,
+            ...(client ? { client } : {}),
+          }),
+        ),
+      );
+      values = rows
+        .filter((r) => r.dup_value != null)
+        .map((r) => ({ value: String(r.dup_value), holderCount: toNumber(r.holder_count) }));
+    } catch (error) {
+      skipped.push({
+        object: target.object,
+        field: target.field,
+        reason: `duplicate probe failed: ${messageOf(error)}`,
+      });
+      continue;
+    }
+    if (values.length === 0) continue;
+
+    const holdersByValue = new Map<string, DuplicateHolder[]>();
+    let holderReadFailed: string | undefined;
+    for (let i = 0; i < values.length; i += HOLDER_BATCH) {
+      const batch = values.slice(i, i + HOLDER_BATCH).map((v) => v.value);
+      let rows: Array<Record<string, unknown>> | undefined;
+      for (const withCreatedAt of [true, false]) {
+        try {
+          rows = normalize(
+            await exec(
+              buildHolderProbeSql({
+                object: target.object,
+                field: target.field,
+                partitionField: target.partitionField,
+                valueCount: batch.length,
+                withCreatedAt,
+                ...(client ? { client } : {}),
+              }),
+              batch,
+            ),
+          );
+          break;
+        } catch (error) {
+          holderReadFailed = messageOf(error);
+        }
+      }
+      if (!rows) break;
+      holderReadFailed = undefined;
+      for (const row of rows) {
+        if (row.dup_value == null) continue;
+        const organization = row.organization == null ? null : String(row.organization);
+        const holder: DuplicateHolder = {
+          id: row.holder_id == null ? null : String(row.holder_id),
+          organization,
+          partition: organization ?? globalTenant,
+          createdAt: row.created_at == null ? null : String(row.created_at),
+        };
+        const key = String(row.dup_value);
+        const list = holdersByValue.get(key);
+        if (list) list.push(holder);
+        else holdersByValue.set(key, [holder]);
+      }
+    }
+    if (holderReadFailed) {
+      // The value IS a duplicate — that much was measured — but this run cannot
+      // say which rows hold it. Reported as a finding with no holders AND as a
+      // skip, never as a clean read.
+      skipped.push({
+        object: target.object,
+        field: target.field,
+        reason: `holder rows unreadable: ${holderReadFailed}`,
+      });
+    }
+
+    for (const { value, holderCount } of values) {
+      const holders = (holdersByValue.get(value) ?? []).sort(
+        (a, b) => a.partition.localeCompare(b.partition) || String(a.id).localeCompare(String(b.id)),
+      );
+      duplicates.push({
+        object: target.object,
+        field: target.field,
+        value,
+        holderCount,
+        partitions: [...new Set(holders.map((h) => h.partition))].sort(),
+        holders,
+      });
+    }
+  }
+
+  duplicates.sort(
+    (a, b) =>
+      a.object.localeCompare(b.object) || a.field.localeCompare(b.field) || a.value.localeCompare(b.value),
+  );
+
+  // ── The live condition (point 4) ────────────────────────────────────
+  let counterStatus: 'read' | 'absent' = 'read';
+  const liveConditions: DuplicateLiveCondition[] = [];
+  try {
+    await exec(buildSequencesPresenceProbeSql(sequencesTable, client));
+  } catch {
+    counterStatus = 'absent';
+  }
+  if (counterStatus === 'read') {
+    try {
+      const rows = normalize(
+        await exec(buildLiveConditionProbeSql(sequencesTable, client), [globalTenant, globalTenant]),
+      );
+      const byKey = new Map<string, DuplicateLiveCondition>();
+      for (const row of rows) {
+        const object = row.object == null ? '' : String(row.object);
+        const field = row.field == null ? '' : String(row.field);
+        const organization = row.organization == null ? '' : String(row.organization);
+        if (!object || !field || !organization) continue;
+        const key = `${object}.${field}`;
+        const entry = byKey.get(key) ?? {
+          object,
+          field,
+          globalLastValue: toNumber(row.global_last_value),
+          organizationCounters: [],
+        };
+        entry.organizationCounters.push({
+          organization,
+          lastValue: toNumber(row.organization_last_value),
+        });
+        byKey.set(key, entry);
+      }
+      liveConditions.push(...byKey.values());
+      liveConditions.sort((a, b) => a.object.localeCompare(b.object) || a.field.localeCompare(b.field));
+    } catch (error) {
+      counterStatus = 'absent';
+      skipped.push({ object: sequencesTable, reason: `live-condition probe failed: ${messageOf(error)}` });
+    }
+  }
+
+  const objectsScanned = new Set(targets.map((t) => t.object)).size;
+  return {
+    report: 'duplicate-identifiers',
+    reportVersion: 1,
+    generatedAt: (opts.now?.() ?? new Date()).toISOString(),
+    database: opts.database,
+    globalPartition: globalTenant,
+    filter: opts.objectFilter ? { object: opts.objectFilter } : null,
+    counters: { table: sequencesTable, status: counterStatus },
+    scanned: targets,
+    skipped,
+    duplicates,
+    liveConditions,
+    summary: {
+      objectsScanned,
+      fieldsScanned: targets.length,
+      duplicateValues: duplicates.length,
+      duplicateRows: duplicates.reduce((total, d) => total + d.holderCount, 0),
+      liveConditions: liveConditions.length,
+    },
+  };
+}
+
+export default class MigrateDuplicates extends Command {
+  static override description =
+    'Report business identifiers already minted twice across the organization partitions (#8928). ' +
+    'Read-only inventory as JSON on stdout — never renumbers, deduplicates or rewrites anything. ' +
+    'Run it BEFORE the #8686 tenancy backfill: the repair overwrites the evidence.';
+
+  static override examples = [
+    '$ os migrate duplicates',
+    '$ os migrate duplicates > duplicates-2026-08-17.json',
+    '$ os migrate duplicates --object crm_case',
+    '$ os migrate duplicates --database-url postgres://…',
+  ];
+
+  static override flags = {
+    'database-url': Flags.string({
+      description: 'Database URL to inspect (defaults to $OS_DATABASE_URL / the project DB)',
+      env: 'OS_DATABASE_URL',
+    }),
+    object: Flags.string({
+      description: 'Restrict the scan to one object (recorded in the report, so a narrowed run cannot be mistaken for a full one)',
+    }),
+  };
+
+  /**
+   * Output is ALWAYS the JSON document — there is no `--json` flag and no human
+   * renderer, per the ruling's point 3: the report IS the deliverable, the
+   * operator archives it, and a second renderer would be a second contract to
+   * keep true. stdout is therefore reserved for the payload for the whole run
+   * (`jsonOutput: true`), so the boot's own log lines go to stderr (#6217).
+   */
+  async run(): Promise<void> {
+    const { flags } = await this.parse(MigrateDuplicates);
+
+    let stack;
+    try {
+      // Read-only boot: `deferSchemaDdl` holds back create-table/add-column DDL
+      // and suppresses the artifact seed, `readOnlyProbe` refuses to bring a
+      // missing sqlite file into existence. Between them this command cannot
+      // change the install it is describing.
+      stack = await bootSchemaStack({
+        jsonOutput: true,
+        ...(flags['database-url'] ? { databaseUrl: flags['database-url'] } : {}),
+        deferSchemaDdl: true,
+        readOnlyProbe: true,
+      });
+    } catch (error: unknown) {
+      await emitJson({ error: 'boot_failed', detail: messageOf(error) }, 1, { compact: true });
+      return;
+    }
+
+    try {
+      const {
+        resolveSeedTenancyExec,
+        normalizeRows,
+        GLOBAL_TENANT,
+        ORGANIZATION_FIELD,
+        SEQUENCES_TABLE,
+      } = await import('@objectstack/metadata-protocol');
+
+      const getService = (stack.kernel as { getService?: (name: string) => unknown })?.getService;
+      const ql = getService?.call(stack.kernel, 'objectql') as IObjectQLEngine | undefined;
+      const exec = resolveSeedTenancyExec(ql);
+      if (!exec) {
+        // Loud absence, never a clean empty report: a driver with no raw-SQL
+        // seam (memory, mongodb) cannot be grouped by value from here, and
+        // "zero duplicates" would be indistinguishable from "never looked".
+        await emitJson(
+          {
+            error: 'no_sql_seam',
+            detail:
+              'The active driver exposes no raw SQL seam, so the data-side duplicate probe cannot run. ' +
+              'This report supports the SQL drivers (sqlite / postgres / mysql / turso).',
+          },
+          1,
+          { compact: true },
+        );
+        return;
+      }
+
+      const report = await collectDuplicateIdentifierReport({
+        exec,
+        normalize: normalizeRows,
+        objects: stack.allObjects(),
+        database: stack.dbLabel,
+        globalTenant: GLOBAL_TENANT,
+        organizationField: ORGANIZATION_FIELD,
+        sequencesTable: SEQUENCES_TABLE,
+        ...(((stack.driver?.config as { client?: unknown } | undefined)?.client)
+          ? { client: String((stack.driver?.config as { client?: unknown }).client) }
+          : {}),
+        ...(flags.object ? { objectFilter: flags.object } : {}),
+      });
+
+      await emitJson(report);
+    } catch (error: unknown) {
+      if (isExitSignal(error)) throw error;
+      await emitJson({ error: 'report_failed', detail: messageOf(error) }, 1, { compact: true });
+    } finally {
+      await stack.shutdown();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #8928

`os migrate duplicates` — a read-only, operator-facing inventory of the business identifiers the seed/API tenancy split already minted twice. Implemented to the 2026-08-16 maintainer ruling, which settled all five of the card's decision points; this PR is the implementation of that ruling, not a new reading of it.

## What the five ruled points look like in code

| Ruled | Where it lives |
|---|---|
| **1. CLI door only**, beside `os migrate` | `packages/cli/src/commands/migrate/duplicates.ts` → `os migrate duplicates`, a sibling of the family's other read-only data command, `os migrate value-shapes`. No REST route, no boot hook. |
| **2. The narrow definition of duplicate** | A value held by rows in more than one of the partitions `COALESCE(organization_id, '__global__')` separates (ADR-0120 D3). A value repeated *inside* one partition is refused by the partitioned unique index and is deliberately not reported — pinned by a fixture row that holds `REF-1` twice in the same organization and does not appear in the report. |
| **3. JSON to stdout, no persistence** | Output is always the JSON document; there is no `--json` flag and no human renderer, so there is one contract rather than two. No new schema, no rows written, nothing left behind. |
| **4. The live condition too** | `liveConditions` — every object/field still running a `__global__` counter **beside** an organization-scoped one. An INNER JOIN, deliberately: "beside" is the whole claim (the backfill's own probe is a LEFT JOIN because it triggers a *repair*, which must also fire where no organization-scoped counter exists yet). |
| **5. Data-side probe** | `GROUP BY  field  HAVING COUNT(*) > 1` over the object's own table, narrowed to the cross-partition case. `_objectstack_sequences` appears in exactly one probe — the live condition of point 4, which is a fact about counters and lives nowhere else. A duplicate whose counter was since merged is still found. |

Binding from the #8844 ruling and honoured throughout: **report, do not rewrite.** Nothing here renumbers, deduplicates or moves a row.

## The timing note, measured rather than asserted

The ruling's perishability clause is why the card exists: `organization_id = NULL` is the marker saying "this row came from the untenanted side", and it is exactly what the #8686 repair overwrites. Two things were measured rather than reasoned about.

**The command applies nothing — boot included.** It boots read-only (`deferSchemaDdl` + `readOnlyProbe`, the same boot `os migrate plan` uses: no DDL, no seed, no database file brought into existence) and issues SELECTs only. `duplicates.integration.test.ts` boots the **real** standalone stack over a fixture carrying the damage and asserts the database is byte-identical afterwards, read through a connection of the test's own.

**What the repair destroys, and what it does not.** `duplicates.pre-repair.test.ts` runs the real `backfillSeedTenancy` between two report runs and measures the difference:

- the **live condition is gone** — the `__global__` counter was merged and deleted, so that line can never be produced again on that install;
- the **inventory survives** — and not by luck: the backfill deliberately refuses to move a row whose identifier is already taken in the destination partition, which is the same ruling seen from the repair's side;
- the rows that had **no** conflict did move, so their `organization_id = NULL` marker is gone — the perishability the ruling names.

That distinction is sharper than "run it first or lose everything", and it is what an operator actually needs to know.

## Scope of the scan

Every registered object that is organization-scoped, and on it every field that is an identifier — `type: 'autonumber'`, or carrying any `unique` spelling. Two deliberate choices:

- **`sys_` / `cloud_` / `ai_` are not filtered out.** That filter is correct for a *repair* (platform seeds stay global by design) and wrong for a report, which per the card must not silently omit a real duplicate.
- **Absence is loud.** Anything that could not be probed lands in `skipped` with the driver's own message, so a target the command could not read never reads as a target with no findings; a driver with no raw-SQL seam (memory, mongodb) refuses with `no_sql_seam` and a non-zero exit rather than reporting zero duplicates. `--object` narrowing is recorded in the report, so an archived narrowed run cannot be mistaken for a full scan.

## The output is a contract, and it is pinned as one

Point 8 of the dispatch: the JSON is consumed by auditors and tools, so its shape must not be an accident of the implementation. `duplicates.contract.test.ts` asserts the **whole** document against a real SQLite fixture — one row per duplicated value with holder ids, organizations, partitions and creation timestamps, plus `scanned` / `skipped` / `liveConditions` / `summary` and a `reportVersion` that is what changes when the shape must.

```json
{
  "report": "duplicate-identifiers",
  "reportVersion": 1,
  "duplicates": [
    { "object": "crm_case", "field": "case_number", "value": "CASE-00001", "holderCount": 2,
      "partitions": ["__global__", "org_x"],
      "holders": [
        { "id": "s1", "organization": null,    "partition": "__global__", "createdAt": "2026-01-01T00:00:00.000Z" },
        { "id": "a1", "organization": "org_x", "partition": "org_x",      "createdAt": "2026-02-01T00:00:00.000Z" }
      ] }
  ],
  "liveConditions": [
    { "object": "crm_case", "field": "case_number", "globalLastValue": 38,
      "organizationCounters": [{ "organization": "org_x", "lastValue": 4 }] }
  ]
}
```

An object with no `created_at` (system fields opted out) still produces holders, with a null timestamp — the holder probe retries without the column rather than failing the target.

## Two things worth a reviewer's attention

**Dialect-aware quoting.** MySQL does not run with `ANSI_QUOTES`, so a probe quoted `"like this"` on every dialect compares a string literal with itself there. These probes read the live `driver.config.client` and quote with backticks for `mysql`/`mysql2`, double quotes otherwise. The convention in `seed-tenancy-backfill.ts` is the unconditional one; that is filed separately as #9381 rather than changed here (that file was out of surface, and the fix belongs with a live-MySQL run).

**A gate two packages away decides whether a booted report is safe.** `assembleMetadataProtocol` arms the #8686 backfill on `kernel:ready` behind `if (environmentId === undefined)`, and the standalone stack stamps `'proj_local'` — so today the migration never arms on a self-hosted boot at all. That is why booting is safe here, and it is a defect in its own right (the #8686 "existing install" half reaches no self-hosted install), filed as #9380 with the measurement. The integration test above is the assertion that will turn red the day that gate is fixed, which is the right place for that conversation to happen.

## Verification

All gates re-derived from the actual changed paths (`node scripts/pm/dispatch-gates.mjs`) and run at `8e22df84c`, the final commit:

| Gate | Result |
|---|---|
| `pnpm --filter @objectstack/cli test` | 131 files / **1412 tests** pass (includes the 4 new files, 18 tests) |
| `pnpm --filter @objectstack/cli typecheck` | pass (`tsconfig.json` includes `src` with no test exclusion, so the new tests are really compiled) |
| `pnpm check:cross-package-test-inputs` | OK — 12 packages read outside themselves, all declared |
| `pnpm check:engine-double-contract` | OK — 317 pinned, no new double |
| `pnpm check:where-matcher` | OK — 253 matchers, none new |
| `pnpm check:query-options-erasure` | OK — baseline key set verified, no files added |
| `pnpm check:type-check-coverage` / `check:type-check-debt` | OK — 33 ledger entries re-measured on the built closure, none above its recorded number |
| `pnpm check:nul-bytes` | OK — 6103 files scanned |
| changeset family (`adr-0087-registration`, `empty-changeset`, `changeset-no-major`, `check:objectui-changeset`, `check:changeset-gate-self-tests`) | OK — 1 non-breaking changeset seen |
| `scripts/docs-audit/check-affected-docs.mjs` | OK (advisory; the one doc it names is reached through an unrelated route anchor) |
| `pnpm exec eslint` on the five new files | clean |

**Reverse verification.** Dropping the partition test from the duplicate probe was predicted to make findings go **up**, not down — and did: `duplicateValues` 3 → 4, the in-partition repeat `REF-1` appears, 4 tests red across two files. Restored from the commit and re-run green.

## Follow-ups filed, not folded in

- **#9380** — the `kernel:ready` migrations never arm on a self-hosted boot (measured; the reason a booted report is safe today).
- **#9381** — metadata-protocol's raw-SQL migrations quote identifiers for one dialect only.
- **#9382** — the docs row for this command, and the backfill cross-reference the ruling asked for (`content/docs/**` was outside this card's file surface).

Renumbering is out of scope entirely, per both rulings. #8844 is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_