### PR TITLE
test(metadata-fs): triage snapshot on the #9339 anchor-event failure message

### DIFF
--- a/packages/metadata-fs/test/watch-write-registration.test.ts
+++ b/packages/metadata-fs/test/watch-write-registration.test.ts
@@ -163,7 +163,20 @@ describe('FileSystemRepository watcher — writes register their own path (#7282
     const anchored = nextEvent();
     await fs.writeFile(path.join(viewDir, 'anchor.json'), JSON.stringify({ label: 'anchor' }, null, 2));
     await Promise.race([anchored, sleep(EVENT_WAIT_MS)]);
-    expect(events.map((e) => e.ref.name)).toContain('anchor');
+    // #9339: on failure, snapshot chokidar's own watched-set for viewDir. That
+    // one datum splits the failure into two disjoint classes — absent means
+    // the loss is upstream of `_handleFile` (the directory scan/poll layer);
+    // present means the loss is at or after the emit gate (`_handleFile` ran
+    // but no event reached this iterator). This does not change what makes
+    // the case pass or fail, only what the failure says when it does.
+    const anchorWatched = watchedIn(repo, viewDir);
+    expect(
+      events.map((e) => e.ref.name),
+      `#9339 triage — getWatched()[${JSON.stringify(viewDir)}] = ${JSON.stringify(anchorWatched)}. ` +
+        (anchorWatched.includes('anchor.json')
+          ? `'anchor.json' IS present in the watched set: the loss is at or after the emit gate (_handleFile ran, no event reached the iterator).`
+          : `'anchor.json' is ABSENT from the watched set: the loss is upstream of _handleFile (the directory scan/poll layer never registered the path).`),
+    ).toContain('anchor');
 
     // ── The measurement ──────────────────────────────────────────────────
     await repo.put(ref('fresh'), { label: 'fresh' }, { parentVersion: null, actor: 'tester' });


### PR DESCRIPTION
Part of #9339 — the small `Part of` the [PM review](https://github.com/objectstack-ai/objectstack/issues/9339#issuecomment-5321122271) ruled in on Q1 of the [investigation report](https://github.com/objectstack-ai/objectstack/issues/9339#issuecomment-5321108186). Out of scope: #9339's own decision (fix-at-the-coupling vs. quarantine) — it remains open and is not addressed here.

## What changed

`packages/metadata-fs/test/watch-write-registration.test.ts`'s line-166 assertion —

```ts
expect(events.map((e) => e.ref.name)).toContain('anchor');
```

— cannot currently tell apart the six independently-measured one-shot delivery gates (`mtime-tie`, `readdir-throttle`, `readdirp-miss`, `add-throttle`, `pending-write`, `awf-enoent`) that the investigation found all reproduce the CI signature byte-identically. This PR adds a `getWatched()[viewDir]` snapshot to that assertion's **failure message only**:

```ts
const anchorWatched = watchedIn(repo, viewDir);
expect(
  events.map((e) => e.ref.name),
  `#9339 triage — getWatched()[${JSON.stringify(viewDir)}] = ${JSON.stringify(anchorWatched)}. ` +
    (anchorWatched.includes('anchor.json')
      ? `'anchor.json' IS present in the watched set: the loss is at or after the emit gate (_handleFile ran, no event reached the iterator).`
      : `'anchor.json' is ABSENT from the watched set: the loss is upstream of _handleFile (the directory scan/poll layer never registered the path).`),
).toContain('anchor');
```

That single datum splits the six candidate mechanisms into two disjoint classes, so the next CI ejection arrives pre-triaged instead of reopening the whole question.

## What did NOT change (byte-identical)

- **Assertion semantics** — still `expect(events.map((e) => e.ref.name)).toContain('anchor')`, same condition, same pass/fail boundary. `watchedIn(repo, viewDir)` is a synchronous read of chokidar's already-armed watcher state; capturing it adds no await and does not touch timing.
- **`EVENT_WAIT_MS`** — untouched at `20_000`. The investigation established the anchor phase has exactly one delivery attempt, so widening buys nothing; this PR does not reopen that.
- **`packages/metadata-fs/src/repository.ts`** and every other production file — untouched. No `awaitWriteFinish` / `pollInterval` / `interval` / `usePolling` tuning.
- No skip/`.skip`/`.todo`/retry-wrap of the test.
- No retry or content-keyed re-check added — that is the candidate fix and it is still the maintainer's open decision.

## Proof the message is real

Forced the assertion to fail with a throwaway local edit (`events.length = 0;` right before the snapshot, immediately reverted — never committed), then ran the real test and captured the rendered output verbatim:

```
FAIL  test/watch-write-registration.test.ts > FileSystemRepository watcher — writes register their own path (#7282) > registers a put() path with the watcher without waiting for a poll
AssertionError: #9339 triage — getWatched()["/tmp/objectstack-fs7282-Pb2jid/view"] = ["anchor.json","seed.json"]. 'anchor.json' IS present in the watched set: the loss is at or after the emit gate (_handleFile ran, no event reached the iterator).: expected [] to include 'anchor'
 ❯ test/watch-write-registration.test.ts:180:7
```

Confirmed both branches read correctly in code (present → "at or after the emit gate"; absent → "upstream of `_handleFile`"); only the present branch was forced and observed directly, since forcing the absent branch would require faulting chokidar's internals rather than the test's own event array.

## Tests

At final commit `466299153` (worktree off `origin/main` `e1bb0cad6`):

- `pnpm --filter '@objectstack/metadata-fs^...' build` — dependency closure (spec, metadata-core) built clean.
- `pnpm --filter '@objectstack/metadata-fs' test -- --maxWorkers=2` — **6 files / 51 tests passed**, including the target test, both before staging the change and again at the final commit head.
- `pnpm --filter '@objectstack/metadata-fs' typecheck` — clean (`tsc --noEmit` + `tsc --noEmit -p tsconfig.test.json`).
- `node scripts/check-nul-bytes.mjs` — OK, 6107 files scanned.
- Gate list re-derived against the actual changed path via `node scripts/pm/dispatch-gates.mjs packages/metadata-fs/test/watch-write-registration.test.ts`:
  - `node scripts/docs-audit/check-affected-docs.mjs` — OK, 155 self-test cases pass.
  - `pnpm check:query-options-erasure` — ratchet holds, 67 unswept non-test sites unchanged, test surface 240/47 unchanged (no new query-options sites added).
  - `pnpm check:engine-double-contract` — OK, 317 pinned / 133 DEBT / 2 exempt, none new (this test declares no engine double).
  - `node scripts/check-where-matcher-conformance.mjs` — OK, 253/253 conform, none new (this test declares no WHERE matcher).
  - `pnpm check:type-check-coverage` / `check:type-check-debt` (`--re-measure`) — **not run to full re-measure**: it requires the entire ~53-package workspace closure built (`pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`), which is disproportionate for this change. Confirmed instead that `@objectstack/metadata-fs` is not a DEBT/TEST_DEBT-ledgered package (it graduated in #7923 via the sibling-`tsconfig.test.json` route) and that its own `typecheck` script — which covers both `src/` and `test/` under that route — passes cleanly at this commit, so the ratchet is not implicated by a test-file-only, cleanly-typechecking diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_