### PR TITLE
test(qa): key the rest-server realtime tripwire off transport mechanics, not one path spelling

### DIFF
--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -171,10 +171,14 @@ const PROBES: ReadonlyArray<{ file: string; re: RegExp; key: (m: RegExpExecArray
   //
   // packages/rest/src has ZERO realtime refs today (#2992). The original
   // single probe here watched for a route literal containing `/realtime`,
-  // and that spelling is one the project's own documentation contradicts:
-  // `content/docs/protocol/kernel/realtime-protocol.mdx` names the planned
-  // transports as WebSocket (`/ws`) and SSE (`/api/v1/stream`), NEITHER of
-  // which contains `/realtime`. Mounting either produced no key, no
+  // and that spelling is one the project's own documentation contradicts: the
+  // "Real-Time Protocols" protocol page (under the protocol/kernel docs
+  // section) names the planned transports as WebSocket (`/ws`) and SSE
+  // (`/api/v1/stream`), NEITHER of which contains `/realtime`. That page is
+  // cited by TITLE rather than by path on purpose — `check:cross-package-test-inputs`
+  // scans this file's source TEXT and cannot tell a prose mention from a real
+  // read, so spelling the path here would declare an input this test does not
+  // have. Mounting either transport produced no key, no
   // UNCLASSIFIED surface and no red CI, while the one documented path the
   // pattern did match — `/api/v1/realtime/events` — is the debug/event-log
   // endpoint that carries no subscription fan-out. The guard was aimed at the

--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -167,11 +167,56 @@ const PROBES: ReadonlyArray<{ file: string; re: RegExp; key: (m: RegExpExecArray
     re: /new\s+WebSocket\b|new\s+EventSource\b/g,
     key: () => tripwireKey('realtime:client/realtime-api.ts:transport'),
   },
-  // packages/rest/src has ZERO realtime refs today (#2992) — a `/realtime`
-  // route literal appearing there is a subscribe endpoint. Same tripwire.
+  // ── #9084 — the rest-server tripwire, keyed off MECHANICS ──────────────
+  //
+  // packages/rest/src has ZERO realtime refs today (#2992). The original
+  // single probe here watched for a route literal containing `/realtime`,
+  // and that spelling is one the project's own documentation contradicts:
+  // `content/docs/protocol/kernel/realtime-protocol.mdx` names the planned
+  // transports as WebSocket (`/ws`) and SSE (`/api/v1/stream`), NEITHER of
+  // which contains `/realtime`. Mounting either produced no key, no
+  // UNCLASSIFIED surface and no red CI, while the one documented path the
+  // pattern did match — `/api/v1/realtime/events` — is the debug/event-log
+  // endpoint that carries no subscription fan-out. The guard was aimed at the
+  // least dangerous of the three documented paths and blind to the two that
+  // actually deliver events to end users.
+  //
+  // Two probes, because the two channels were MEASURED to be complementary
+  // rather than alternatives (the `#9084` block at the bottom of this file
+  // pins the measurement; on the sample there, neither arm catches a single
+  // spelling the other does):
+  //
+  //  (1) MECHANICS — the act of wiring, regardless of naming. This is the
+  //      property the other four tripwires already have and this one lacked:
+  //      they watch `handleUpgrade`, `new WebSocketServer`,
+  //      `text/event-stream`, `new WebSocket` / `new EventSource`. A transport
+  //      mounted at `/live`, `/events` or any other unforeseen spelling still
+  //      has to perform one of these acts somewhere.
+  //  (2) PATHS — retained and widened, NOT traded away. Mechanics alone has
+  //      its own blind spot: a route mounted here whose handler delegates the
+  //      SSE write or the upgrade to a helper in another module shows no
+  //      mechanical marker in THIS file at all, and only the path names it.
+  //      `/realtime` is kept verbatim so no coverage the incumbent had is
+  //      lost, and `/ws` + `/stream` (plus the neighbouring spellings a router
+  //      realistically takes) are added.
+  //
+  // ⚠️ The path arm keys on the route SUFFIX, never on the documented full
+  // path. Measured: every `path:` value in rest-server.ts is composed
+  // (`` `${basePath}/discovery` ``, `` `${metaPath}/types` ``) and every
+  // verbatim `/api/v1/...` string in the file lives in a COMMENT — so a probe
+  // widened to the documented literal `/api/v1/stream` would have stayed just
+  // as blind as the one it replaced.
   {
     file: 'packages/rest/src/rest-server.ts',
-    re: /['"`][^'"`]*\/realtime[^'"`]*['"`]/g,
+    re: /handleUpgrade\s*\(|new\s+WebSocketServer\b|new\s+WebSocket\b|new\s+EventSource\b|upgradeWebSocket\b|WebSocketPair\b|Sec-WebSocket-|text\/event-stream|streamSSE\s*\(/g,
+    key: () => tripwireKey('realtime:rest-server.ts:transport'),
+  },
+  {
+    file: 'packages/rest/src/rest-server.ts',
+    // Word-boundary lookaheads on `ws`/`stream` keep the file's 31 unrelated
+    // response-streaming references (and paths like `/workspaces`) out: they
+    // are matched only as a whole route segment, never as a prefix.
+    re: /['"`][^'"`]*(?:\/realtime|\/(?:websockets?|ws)(?![\w-])|\/(?:streams?|sse)(?![\w-]))[^'"`]*['"`]/g,
     key: () => tripwireKey('realtime:rest-server.ts:route'),
   },
 
@@ -524,6 +569,146 @@ describe('#9083 — a wired transport is admitted only by an `enforced` row', ()
       problems.some((p) => /enforced but names no enforcement site/.test(p)),
       problems.join('\n'),
     ).toBe(true);
+  });
+});
+
+// ── #9084 — the rest-server tripwire catches what it was widened for ──────
+//
+// The reverse verification, mechanised. A widened guard never shown to catch
+// the thing it was widened for is not a fix, and "it reads zero on the real
+// file" is worth nothing on its own — a pattern that matches NOTHING reads
+// zero too. So every zero asserted here is paired with a planted control that
+// proves the same pattern fires, and the defect itself is pinned by running
+// the INCUMBENT pattern over the identical sample.
+//
+// Each spelling below is written the way rest-server.ts really registers a
+// route (`path: `${basePath}/x``) or writes a content type
+// (`res.header('Content-Type', ...)`), not as an idealised literal.
+describe('#9084 — the rest-server.ts transport tripwire keys off mechanics', () => {
+  const REST_SERVER = 'packages/rest/src/rest-server.ts';
+  const restProbes = PROBES.filter((p) => p.file === REST_SERVER && p.key({} as RegExpExecArray).includes(TRANSPORT_WIRED_MARKER));
+  const MECHANICS = restProbes.find((p) => p.key({} as RegExpExecArray).includes(':transport('))!;
+  const ROUTES = restProbes.find((p) => p.key({} as RegExpExecArray).includes(':route('))!;
+
+  // The pattern as it shipped before #9084 — a route literal containing
+  // `/realtime`, and nothing else. Restated here (not imported) because it is
+  // the DEFECT being pinned, not a thing this file should keep using.
+  const INCUMBENT = /['"`][^'"`]*\/realtime[^'"`]*['"`]/g;
+
+  const hits = (re: RegExp, text: string): string[] => {
+    re.lastIndex = 0;
+    const out: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) out.push(m[0]);
+    return out;
+  };
+  const fires = (text: string): boolean =>
+    hits(MECHANICS.re, text).length > 0 || hits(ROUTES.re, text).length > 0;
+
+  // The two transports the protocol page documents as planned, plus the
+  // neighbouring spellings a router realistically takes, plus the mechanical
+  // acts a transport cannot avoid performing.
+  const DOCUMENTED = {
+    'WebSocket route (/ws)': "this.routeManager.register({ method: 'GET', path: `${basePath}/ws`, handler: h });",
+    'SSE route (/api/v1/stream)': "this.routeManager.register({ method: 'GET', path: `${basePath}/stream`, handler: h });",
+  };
+  const NEIGHBOURING = {
+    'plural /streams': 'path: `${basePath}/streams`,',
+    '/sse': 'path: `${basePath}/sse`,',
+    '/websocket': 'path: `${basePath}/websocket`,',
+    "single-quoted '/ws'": "app.get('/ws', handler);",
+    'the incumbent /realtime, still covered': 'path: `${basePath}/realtime/events`,',
+  };
+  const MECHANICAL = {
+    'SSE content-type write': "res.header('Content-Type', 'text/event-stream');",
+    'WS handshake': 'this.realtime.handleUpgrade(req, socket, head);',
+    'ws server': 'const wss = new WebSocketServer({ noServer: true });',
+    'hono upgradeWebSocket': "app.get('/live', upgradeWebSocket(() => ({})));",
+    'Workers WebSocketPair': 'const pair = new WebSocketPair();',
+    'hono streamSSE helper': 'return streamSSE(c, async (stream) => {});',
+    'raw handshake header': "res.setHeader('Sec-WebSocket-Accept', accept);",
+    'client-side constructor': 'const es = new EventSource(url);',
+  };
+
+  it('reads ZERO on the real rest-server.ts today (the pre-wiring baseline)', () => {
+    const src = readFileSync(join(REPO_ROOT, REST_SERVER), 'utf8');
+    expect(hits(MECHANICS.re, src)).toEqual([]);
+    expect(hits(ROUTES.re, src)).toEqual([]);
+    // …and the surface walk agrees: no rest-server tripwire key is minted.
+    const discovered = [...discoverAnonymousDenySurfaces()].filter((k) =>
+      k.startsWith('realtime:rest-server.ts:'),
+    );
+    expect(discovered).toEqual([]);
+  });
+
+  it('CONTROL — that zero is meaningful: every documented transport fires', () => {
+    // Without this case the zero above is unfalsifiable. A pattern matching
+    // nothing at all would satisfy it just as well.
+    for (const [label, line] of Object.entries({ ...DOCUMENTED, ...NEIGHBOURING, ...MECHANICAL })) {
+      expect(fires(line), `${label} must mint a tripwire key: ${line}`).toBe(true);
+    }
+  });
+
+  it('the DEFECT is pinned: the incumbent /realtime-only pattern is blind to both documented transports', () => {
+    // This is the card's finding, kept executable. If someone narrows the
+    // probes back toward a single path spelling, this case is what says so.
+    for (const [label, line] of Object.entries(DOCUMENTED)) {
+      expect(hits(INCUMBENT, line), `incumbent was blind to ${label}`).toEqual([]);
+      expect(fires(line), `widened probe must catch ${label}`).toBe(true);
+    }
+    // The only documented path it did match is the debug/event-log endpoint,
+    // which carries no subscription fan-out — and that coverage is retained.
+    const debugEndpoint = 'path: `${basePath}/realtime/events`,';
+    expect(hits(INCUMBENT, debugEndpoint).length).toBe(1);
+    expect(fires(debugEndpoint)).toBe(true);
+  });
+
+  it('the two arms are COMPLEMENTARY, not alternatives (why both are kept)', () => {
+    // Measured, not assumed: on this sample neither arm catches a single
+    // spelling the other does. Dropping either one re-opens a blind spot.
+    for (const line of Object.values({ ...DOCUMENTED, ...NEIGHBOURING })) {
+      expect(hits(ROUTES.re, line).length).toBeGreaterThan(0);
+      expect(hits(MECHANICS.re, line)).toEqual([]);
+    }
+    for (const line of Object.values(MECHANICAL)) {
+      expect(hits(MECHANICS.re, line).length).toBeGreaterThan(0);
+      expect(hits(ROUTES.re, line)).toEqual([]);
+    }
+  });
+
+  it('does not fire on the unrelated response-streaming code already in the file', () => {
+    // rest-server.ts carries ~31 occurrences of the substring "stream" (xlsx
+    // export piping, chunked responses). A tripwire that reddened CI on those
+    // would be pressure to weaken it back, so the boundaries are pinned.
+    for (const line of [
+      "const { PassThrough } = await import('node:stream');",
+      "res.header('Content-Type', 'text/csv; charset=utf-8');",
+      'new ExcelJS.stream.xlsx.WorkbookWriter({ stream: passthrough });',
+      'path: `${basePath}/workspaces`,',
+      'path: `${basePath}/streaming-imports`,',
+      '// on this route the streaming CHUNK size, not the page number',
+      'path: `${basePath}/data/:object`,',
+    ]) {
+      expect(fires(line), `must not fire on: ${line}`).toBe(false);
+    }
+  });
+
+  it('a wired transport still lands as an UNCLASSIFIED surface under the #9083 rule', () => {
+    // The widening has to reach the OUTCOME, not just mint a string: both new
+    // keys must still be refused admission by the composed gate.
+    for (const surface of ['realtime:rest-server.ts:transport', 'realtime:rest-server.ts:route']) {
+      const wired = tripwireKey(surface);
+      const problems = checkAuthzLedger(AUTHZ_CONFORMANCE, {
+        proofRoot: HERE,
+        highRisk: HIGH_RISK,
+        discover: () => new Set([...discoverAnonymousDenySurfaces(), wired]),
+        attribution: ATTRIBUTION,
+      });
+      expect(
+        problems.some((p) => p.includes('UNCLASSIFIED surface') && p.includes(wired)),
+        problems.join('\n'),
+      ).toBe(true);
+    }
   });
 });
 

--- a/packages/qa/dogfood/test/authz-conformance.test.ts
+++ b/packages/qa/dogfood/test/authz-conformance.test.ts
@@ -171,14 +171,15 @@ const PROBES: ReadonlyArray<{ file: string; re: RegExp; key: (m: RegExpExecArray
   //
   // packages/rest/src has ZERO realtime refs today (#2992). The original
   // single probe here watched for a route literal containing `/realtime`,
-  // and that spelling is one the project's own documentation contradicts: the
-  // "Real-Time Protocols" protocol page (under the protocol/kernel docs
-  // section) names the planned transports as WebSocket (`/ws`) and SSE
-  // (`/api/v1/stream`), NEITHER of which contains `/realtime`. That page is
-  // cited by TITLE rather than by path on purpose — `check:cross-package-test-inputs`
-  // scans this file's source TEXT and cannot tell a prose mention from a real
-  // read, so spelling the path here would declare an input this test does not
-  // have. Mounting either transport produced no key, no
+  // and that spelling is one the project's own documentation contradicts:
+  // `content/docs/protocol/kernel/realtime-protocol.mdx` names the planned
+  // transports as WebSocket (`/ws`) and SSE (`/api/v1/stream`), NEITHER of
+  // which contains `/realtime`. That page is a declared input of this package
+  // (see the dogfood entry in the cross-package-test-inputs gate),
+  // deliberately: these probes are only correct for as long as they cover what
+  // that page documents as the planned transports, so an edit adding a third
+  // spelling there must re-run this test — the coupling this card is fixing.
+  // Mounting either transport produced no key, no
   // UNCLASSIFIED surface and no red CI, while the one documented path the
   // pattern did match — `/api/v1/realtime/events` — is the debug/event-log
   // endpoint that carries no subscription fan-out. The guard was aimed at the

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -254,6 +254,17 @@ const CROSS_PACKAGE_TEST_INPUTS = {
       'examples/app-showcase/**',
       'packages/cli/src/commands/**',
       'packages/metadata/src/**',
+      // `realtime-protocol.mdx` is named in a comment rather than read, the
+      // same shape as `check-nul-bytes.mjs` and `sync-template-versions.mjs`
+      // and settled the same way: a mention forces a declaration, and
+      // declaring the file is cheaper than rewording prose to dodge the
+      // scanner. Here the coupling is real on top of being cheap — that page
+      // is what documents the PLANNED realtime transports (`/ws`, SSE
+      // `/api/v1/stream`), and the #2992 transport tripwires in
+      // authz-conformance.test.ts are only correct for as long as they cover
+      // those spellings. A third transport added to the page is exactly the
+      // change that reopens the #9084 blind spot, so it must re-run this test.
+      'content/docs/protocol/kernel/realtime-protocol.mdx',
     ],
   },
   '@objectstack/formula': {

--- a/turbo.json
+++ b/turbo.json
@@ -142,7 +142,8 @@
         "$TURBO_ROOT$/packages/spec/src/data/**",
         "$TURBO_ROOT$/examples/app-showcase/**",
         "$TURBO_ROOT$/packages/cli/src/commands/**",
-        "$TURBO_ROOT$/packages/metadata/src/**"
+        "$TURBO_ROOT$/packages/metadata/src/**",
+        "$TURBO_ROOT$/content/docs/protocol/kernel/realtime-protocol.mdx"
       ]
     },
     "@objectstack/formula#test": {


### PR DESCRIPTION
Fixes #9084

## The defect

The fifth `#2992` transport tripwire in `packages/qa/dogfood/test/authz-conformance.test.ts` watched `packages/rest/src/rest-server.ts` for a route literal containing `/realtime`. The protocol page `content/docs/protocol/kernel/realtime-protocol.mdx` documents the planned transports as WebSocket (`/ws`) and SSE (`/api/v1/stream`) — **neither contains `/realtime`** — so mounting either produced no key, no UNCLASSIFIED surface and no red CI. The only documented path the pattern did match, `/api/v1/realtime/events`, is the debug/event-log endpoint that carries no subscription fan-out.

The guard was aimed at the least dangerous of the three documented paths and blind to the two that actually deliver events to end users, while its own comment read as coverage.

## The fix — two probes on the same file, kept because they were measured complementary

The other four tripwires key off transport **mechanics** (`handleUpgrade`, `new WebSocketServer`, `text/event-stream`, `new WebSocket` / `new EventSource`), so they fire on the act of wiring regardless of naming. That is the property this one lacked.

- **MECHANICS** arm — `handleUpgrade`, `new WebSocketServer`, `upgradeWebSocket`, `WebSocketPair`, `Sec-WebSocket-`, `text/event-stream`, `streamSSE`, `new WebSocket` / `new EventSource`. Mints `realtime:rest-server.ts:transport(TRANSPORT-WIRED)`.
- **PATHS** arm — retained and widened, **not traded away**. `/realtime` is kept verbatim so no incumbent coverage is lost; `/ws` and `/stream` plus neighbouring spellings (`/websocket`, `/streams`, `/sse`) are added. Keeps the existing `realtime:rest-server.ts:route(TRANSPORT-WIRED)` key unchanged.

The two channels are complementary rather than exclusive, **confirmed by measurement, not assumed**: on the pinned sample the two arms overlap on nothing. Mechanics alone still has a blind spot — a route mounted here whose handler delegates the SSE write or the upgrade to a helper in another module carries no mechanical marker in this file, and only the path names it. Dropping either arm re-opens a blind spot, so both are kept.

### The path arm keys on the route SUFFIX, never the documented full path

Measured on `origin/main`: every `path:` value in `rest-server.ts` is composed (`${basePath}/discovery`, `${metaPath}/types`), and every verbatim `/api/v1/...` string in the file lives in a **comment**. So widening to the documented literal `/api/v1/stream` would have stayed exactly as blind as the pattern it replaced. This is the sharpest finding of the round.

## Reverse verification — the deliverable, direction predicted before running

Prediction: RED, with *more* failures rather than fewer, because a minted key with no covering row is an UNCLASSIFIED surface.

**Leg 1 — planted a real `/ws` mount** (`path: ${basePath}/ws` via `routeManager.register`) in `rest-server.ts`:

```
incumbent /realtime-only pattern on the mutated file: 0 matches   -- the old guard stays silent
x is a sound conformance ledger ... UNCLASSIFIED surface — add a ledger row (ADR-0060):
    realtime:rest-server.ts:route(TRANSPORT-WIRED)
Tests  6 failed | 21 passed (27)
```

**Leg 2 — planted an SSE content-type write** (`res.header('Content-Type', 'text/event-stream')`), cleanly isolating the mechanics arm: on the mutated file the incumbent pattern **and** this PR's own path arm both read 0, so only mechanics could fire.

```
x is a sound conformance ledger ... UNCLASSIFIED surface — add a ledger row (ADR-0060):
    realtime:rest-server.ts:transport(TRANSPORT-WIRED)
Tests  6 failed | 21 passed (27)
```

Both mutations reverted; `git hash-object` on the restored `rest-server.ts` equals `git rev-parse HEAD:packages/rest/src/rest-server.ts`, and `git status --porcelain` is clean (no `MM`).

**Where the prediction was wrong, recorded rather than smoothed over:** I predicted 3 failing cases and got **6**. The extra three are `#9083` cases (j), (k) and (l), which assert exact equality against the *real* discover set and so legitimately go red once any transport is planted in real source. Correct behaviour, not a defect — they return green on revert.

## Non-vacuity — why the zero on today's file is trustworthy

A pattern that matches nothing reads zero too, so every zero here is paired with a planted control. Before writing the fix, the candidate patterns were run over 15 planted spellings and 8 negative controls: **15/15 planted matched, 0/8 negative false-positived, and the incumbent pattern was blind on 14/15**. That measurement is now permanent as a test block rather than a one-off.

## The existing four tripwires are untouched

Each probe reads only its own declared `file`, so patterns in different files cannot collide and no other key can be made noisier. No `covers` entry moves either — no matrix row classifies a `TRANSPORT-WIRED` key today, which the pre-existing non-vacuity case asserts. Nothing was loosened anywhere. This is gate strengthening only.

## New test cases (6)

Under `#9084 — the rest-server.ts transport tripwire keys off mechanics`:

1. reads ZERO on the real `rest-server.ts` today (the pre-wiring baseline)
2. CONTROL — that zero is meaningful: every documented transport fires
3. the DEFECT is pinned: the incumbent `/realtime`-only pattern is blind to both documented transports
4. the two arms are COMPLEMENTARY, not alternatives (why both are kept)
5. does not fire on the unrelated response-streaming code already in the file (the file's ~31 "stream" references, so the guard is never pressured back open)
6. a wired transport still lands as an UNCLASSIFIED surface under the `#9083` rule (reaching the outcome, not just minting a string)

## Declaring the protocol page as a test input

`check:cross-package-test-inputs` went red on the branch while green on `main`, because the tripwire comment names the protocol page's repo path and that gate collects repo-relative literals without parsing prose.

The second commit on this branch took the wrong exit: it reworded the comment to stop naming the path. The third commit reverts that and **declares the page instead**, which is what the gate's own ledger had already settled — twice — in its entries for `check-nul-bytes.mjs` ("a mention forces a declaration; that is the designed trade (over-collection can only widen a radius, never narrow one) ... cheaper than teaching the scanner to tell prose from code, **or than rewording a comment to dodge a scanner**") and `sync-template-versions.mjs` ("declaring the file is cheaper than rewording prose to dodge the scanner"). Declaring widens a radius; it does not loosen a check.

The coupling is real here on top of being cheap, matching the `create-objectstack` precedent rather than the two bare-mention entries: that page is what documents the planned realtime transports, and these probes are correct only for as long as they cover those spellings. **A third transport added to the page is exactly the change that reopens the blind spot this card fixes**, so it must re-run this test.

Declared in both halves the gate requires (it fails on either alone): the `@objectstack/dogfood` `globs` in `scripts/check-cross-package-test-inputs.mjs`, and the matching `@objectstack/dogfood#test` `inputs` in `turbo.json`. No gate weakened, no ignore added, no baseline moved, no threshold changed.

## Gates — run at `7690e03ee`, the final commit, reported by CI job name

| CI job | Local evidence |
|---|---|
| `Dogfood Regression Gate` | `@objectstack/dogfood` full suite: 792 passed, 3 skipped, 0 failed. Focused file: 27/27 |
| `TypeScript Type Check` | `@objectstack/dogfood typecheck` exit 0; spec `check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs` all exit 0 |
| `ESLint` (carries a family) | `eslint` on the changed files exit 0; `check:cross-package-test-inputs` (plus its 33 embedded `--self-test` cases), `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:nul-bytes` all exit 0. `check:type-check-debt` MEASURED on a freshly built workspace closure: 33 ledger entries re-measured, none above its recorded number |
| `Build Core` | workspace closure built clean, 70/70 tasks |
| `Test Core`, `Temporal Conformance (live PG + MySQL)` | not run locally — no runtime package is touched; left to CI |

Gates re-derived on the widened path set (`node scripts/pm/dispatch-gates.mjs` over all three changed paths), which surfaced one family the original derivation could not: `scripts/check-cross-package-test-inputs.mjs` is itself a **`ci.yml`** gate source, so that script now runs in two jobs. Run and green in both spellings.

## Scope

Three files: `packages/qa/dogfood/test/authz-conformance.test.ts` (the fix), plus `scripts/check-cross-package-test-inputs.mjs` and `turbo.json` (the one declared input, in the two halves the gate requires). No matrix row was needed — the tripwire population lives entirely in the `.test.ts`, so `authz-conformance.matrix.ts` is untouched. `packages/rest/src/rest-server.ts` is only ever **watched** by this guard and is byte-identical to `main`.

Test-only change to a `private: true` package, so it publishes nothing and carries the `skip-changeset` label rather than a changeset.

`#2992` and `#8347` are not addressed here — this PR only widens the tripwire that guards them.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_