### PR TITLE
docs(spec): STORED_TYPE_NOT_CANONICAL ledger comment names both producers and their atomicity

### DIFF
--- a/.changeset/error-code-ledger-stored-type-not-canonical-two-producers.md
+++ b/.changeset/error-code-ledger-stored-type-not-canonical-two-producers.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `STORED_TYPE_NOT_CANONICAL` ledger comment names both producers and their atomicity (#9361)
+
+The ledger entry at `error-code-ledger.zod.ts:381` described `STORED_TYPE_NOT_CANONICAL`'s
+only producer as the publish pre-flight ("refused at the publish pre-flight, batch-atomic").
+PR #9360 (#9174) added a second producer — `revertCommit`'s restore limb, which refuses
+per-item on its existing `failed[]` channel and is explicitly NOT batch-atomic — leaving the
+comment naming one of two producers, with the wrong atomicity for the one it omitted.
+
+The comment now names both: the publish pre-flight (batch-atomic, `#8908`) and
+`revertCommit`'s restore limb (per-item on `failed[]`, NOT batch-atomic, `#9174`).
+
+Text-only change — accept/reject behavior, the error code, and its envelope are all
+unchanged.

--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -378,7 +378,7 @@ export const ERROR_CODE_LEDGER = {
     'QUERY_OBJECT_MISMATCH',
     'REGISTRY_TYPE_NOT_CANONICAL',  // [#9111] a SchemaRegistry overlay entry was offered a non-canonical metadata `type` — the mint door asserts, the caller folds
     'ROLLED_BACK',             // atomic data-batch row was written, then undone by the batch rollback (#4793)
-    'STORED_TYPE_NOT_CANONICAL',  // [#8908] a package draft is stored under a non-canonical metadata type (pre-#7894 second-namespace residue) — refused at the publish pre-flight, batch-atomic
+    'STORED_TYPE_NOT_CANONICAL',  // [#8908] a package draft is stored under a non-canonical metadata type (pre-#7894 second-namespace residue) — refused at the publish pre-flight, batch-atomic; [#9174] also refused on `revertCommit`'s restore limb, per-item on `failed[]`, NOT batch-atomic
     'TENANT_SCOPE_REQUIRED',      // [#7780] destructive call named neither an organization nor an explicit cross-tenant intent; needs an explicit opt-in
     'UNSUPPORTED_QUERY_PARAM',
     'VALIDATION_FAILED',


### PR DESCRIPTION
Fixes #9361

## What changed

One comment line at `packages/spec/src/api/error-code-ledger.zod.ts:381`. `STORED_TYPE_NOT_CANONICAL` had a second producer land under PR #9360 (#9174, merged `2416dd588`), and the comment still named only the first.

**Before:**
```
'STORED_TYPE_NOT_CANONICAL',  // [#8908] a package draft is stored under a non-canonical metadata type (pre-#7894 second-namespace residue) — refused at the publish pre-flight, batch-atomic
```

**After:**
```
'STORED_TYPE_NOT_CANONICAL',  // [#8908] a package draft is stored under a non-canonical metadata type (pre-#7894 second-namespace residue) — refused at the publish pre-flight, batch-atomic; [#9174] also refused on `revertCommit`'s restore limb, per-item on `failed[]`, NOT batch-atomic
```

## Verification against merged code (not the issue's prose)

Both producer claims were checked against `main` directly, not assumed from the issue body:

- **Publish pre-flight** — `packages/metadata-protocol/src/protocol.ts:14432`, inside `publishPackageDrafts`. The refusal is pushed into `preflightViolations`, and `protocol.ts:14475` short-circuits the whole call with `publishedCount: 0` when that array is non-empty — batch-atomic, confirmed.
- **`revertCommit` restore limb** — `packages/metadata-protocol/src/protocol.ts:16399`, inside the per-item restore loop. The refusal does `failed.push({ ..., code: 'STORED_TYPE_NOT_CANONICAL' }); continue;` — per item, into `failed[]`, and the loop proceeds to the next item rather than aborting the batch — NOT batch-atomic, confirmed. Matches the method's own JSDoc at `protocol.ts:16193-16202`, which documents this refusal as landing under #9174.

Option 3 from the issue (deriving the producer list with a gate) is explicitly out of scope per the triage grading (2026-08-17T22:13Z) and PM claim comment (2026-08-17T23:22Z) — this PR is option 1 only, no behavior change, no other lines touched.

## Gates run (all green, HEAD `494d2a71f`)

- `pnpm --filter @objectstack/spec build` — clean
- `pnpm --filter @objectstack/spec test` — 408 files / 10898 tests passed
- `pnpm --filter @objectstack/spec typecheck` — clean (tsc, scripts, test-typecheck debt unchanged)
- `pnpm --filter @objectstack/spec run check:generated` — all 13 generated artifacts up to date; **none changed** by this comment edit
- `pnpm check:changeset-gate-self-tests`
- `pnpm check:cross-package-test-inputs`
- `pnpm check:dispatcher-error-vocabulary`
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions`
- `pnpm --filter @objectstack/spec run check:empty-state`
- `pnpm check:error-code-casing`
- `pnpm --filter @objectstack/spec run check:liveness`
- `pnpm check:merge-driver`
- `pnpm check:objectui-changeset`
- `pnpm check:spec-parsed-alias`
- `pnpm --filter @objectstack/spec run check:strictness-ledger`
- `pnpm check:type-source-resolution`
- `pnpm --filter @objectstack/spec run check:variant-docs`
- `node scripts/check-adr-0087-registration.mjs`
- `node scripts/check-changeset-no-major.mjs`
- `node scripts/check-cross-package-test-inputs.mjs`
- `node scripts/check-dev-prereqs.mjs --self-test` (CI's own lint.yml invokes this script's self-test half only, never the full-workspace scan half — see the script's own header and `lint.yml`'s "Self-test the dev-prereqs gate" step)
- `node scripts/check-empty-changeset.mjs`
- `node scripts/docs-audit/check-affected-docs.mjs`
- `node scripts/check-nul-bytes.mjs` (both changed files)

Changeset: `@objectstack/spec` patch, text face (accept/reject unchanged) — `.changeset/error-code-ledger-stored-type-not-canonical-two-producers.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_