### PR TITLE
fix(automation): answer real HTTP status codes on both trigger routes

### DIFF
--- a/.changeset/automation-trigger-status-unification.md
+++ b/.changeset/automation-trigger-status-unification.md
@@ -1,0 +1,71 @@
+---
+'@objectstack/service-automation': minor
+'@objectstack/runtime': minor
+'@objectstack/client': minor
+---
+
+**BREAKING** — both automation `trigger` routes answer real HTTP status codes for a flow
+that ran and failed, instead of HTTP 200 wrapping an inner `{success: false}`.
+
+This is the second and wider half of the migration the resume route shipped in the same
+release (#8684, merged 2026-08-17): one SDK-visible behaviour change, one migration note.
+The resume flip touched the screen-flow runner; this one touches the door every app
+dispatches flows through.
+
+Until now a flow driven to a node failure answered:
+
+```
+HTTP 200
+{"success":true,"data":{"success":false,"error":"Node 'create_opportunity' failed: …"}}
+```
+
+The run genuinely failed; the transport reported success. A scripted or integration caller
+that branches on the HTTP status alone read a failed run as a successful one. This applies
+the `/actions` ruling (business failures must not ride HTTP 200 inside a double envelope)
+to `POST /api/v1/automation/:name/trigger` and to the legacy
+`POST /api/v1/automation/trigger/:name` — the shape `client.automation.trigger()` calls.
+Both doors answer through one mapper, so they cannot drift.
+
+What changes on the wire:
+
+- **A flow that ran and then failed ⇒ `400` with `error.code: 'FLOW_FAILED'`.** The node
+  failure stays the human-readable `error.message`. The flow author's own `errorMessage`
+  travels in `error.details.errorMessage` — one documented location, the same one the
+  console reads — and the run's per-node accounting in `error.details.summary`. A flow
+  whose `errorHandling.strategy` is `retry` answers the same way once its attempts are
+  exhausted. `durationMs` is no longer carried on this response.
+- **A flow name the deployment does not hold ⇒ `404`,** answered before anything is
+  dispatched, through the same registry probe `POST /:name/toggle` and `GET /:name` use.
+- **Unchanged:** a successful run still answers 200 with its result, and a run that PAUSED
+  at a `screen` node still answers 200 with the next screen — a pause is not a failure.
+- **Also unchanged, pending a ruling:** a DISABLED flow and one with no start node still
+  answer 200 with the inner failure. Both are exits that never dispatched anything, and
+  telling them apart needs a producer-side classification the closed
+  `AutomationResult.code` union cannot yet express. Tracked on #9378.
+
+**`@objectstack/service-automation`:** `execute()` now stamps `status: 'failed'` on the
+results of runs that dispatched and were rejected — the same lifecycle verdict it already
+writes to the run log. Its never-dispatched exits carry no `status`, which is what lets a
+transport answer the two classes differently without inspecting the result's internals.
+
+**`@objectstack/client`:** `client.automation.trigger()`, `client.automation.execute()` and
+`client.project(id).automation.execute()` now **reject** on a failed run instead of
+resolving with `{ success: false, error }` — the SDK throws on every non-2xx before
+unwrapping. Callers that inspected the resolved value must move to a `catch`:
+
+```ts
+try {
+  await client.automation.execute(flow, { params });
+} catch (err: any) {
+  err.code;                   // 'FLOW_FAILED' (400) — the run ran and failed
+  err.httpStatus;             // 400 | 404
+  err.message;                // the node failure, verbatim
+  err.details?.errorMessage;  // the flow author's own message, when the flow declares one
+  err.details?.summary;       // which node failed
+}
+```
+
+Raw-HTTP callers that treated `2xx` as success and never opened the inner envelope now see
+the failure they were already being told about, one level up.
+
+<!-- adr-0087: not-required (no-migration-prescription) retires no metadata surface: no Zod schema, no authorable key, no stored sys_metadata row changes shape, so `objectstack migrate meta` has nothing to rewrite and no ledger entry can be written for it. What changes is an HTTP status plus an SDK method's promise contract, and the only channel that reaches those consumers is this changeset itself. -->

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1354,6 +1354,90 @@ describe('ObjectStackClient.automation', () => {
         expect(err.message).toMatch(/no longer exists in flow/);
     });
 
+    // [#9378] BREAKING, and the wide half of the same flip: DISPATCHING a flow.
+    // `client.automation.trigger()` (legacy route) and `.execute()` used to
+    // resolve with `{ success: false, error }` under HTTP 200 for a run that
+    // ran and failed — every app dispatches flows through this door, so a
+    // caller that never opened the inner envelope read every failed run as a
+    // successful one. The route answers 400 `FLOW_FAILED` now and this SDK's
+    // fetch layer throws on non-2xx before any unwrapping, so both surfaces
+    // REJECT. No SDK code changed; the contract did, and these are its pins.
+    //
+    // Both spellings are pinned, not one: `trigger()` reads `res.json()` while
+    // `execute()` reads `unwrapResponse()`, so a regression in either unwrap
+    // path would be invisible from the other's test.
+    const failedRunBody = {
+        success: false,
+        error: {
+            code: 'FLOW_FAILED',
+            message: "Node 'create_opportunity' failed: Amount must be greater than zero",
+            httpStatus: 400,
+            details: {
+                errorMessage: 'We could not create the opportunity — check the amount and try again.',
+                summary: { nodes: [{ nodeId: 'create_opportunity', status: 'failure' }] },
+            },
+        },
+    };
+
+    it('should reject with FLOW_FAILED when a triggered flow runs and fails (legacy trigger)', async () => {
+        const { client } = createMockClient(failedRunBody, 400);
+
+        const err: any = await client.automation
+            .trigger('my_flow', { amount: 0 })
+            .then(() => { throw new Error('expected the failed trigger to reject'); }, (e) => e);
+
+        // The classification, not merely that it threw: an SDK rejecting with a
+        // bare `Error` would satisfy `.rejects.toThrow()` while losing
+        // everything a caller branches on.
+        expect(err.code).toBe('FLOW_FAILED');
+        expect(err.httpStatus).toBe(400);
+        expect(err.message).toMatch(/Node 'create_opportunity' failed/);
+        // The flow author's own text keeps its one documented location — the
+        // ADR-0112 envelope has no `data`, and the console reads it from here.
+        expect(err.details?.errorMessage)
+            .toBe('We could not create the opportunity — check the amount and try again.');
+    });
+
+    it('should reject with FLOW_FAILED when execute() dispatches a flow that fails', async () => {
+        const { client } = createMockClient(failedRunBody, 400);
+
+        const err: any = await client.automation
+            .execute('my_flow', { params: { amount: 0 } })
+            .then(() => { throw new Error('expected the failed execute to reject'); }, (e) => e);
+
+        expect(err.code).toBe('FLOW_FAILED');
+        expect(err.httpStatus).toBe(400);
+        expect(err.details?.summary?.nodes?.[0]?.status).toBe('failure');
+    });
+
+    it('should reject with 404 when the triggered flow does not exist', async () => {
+        const { client } = createMockClient({
+            success: false,
+            error: { code: 'RESOURCE_NOT_FOUND', message: "Flow 'no_such_flow' not found", httpStatus: 404 },
+        }, 404);
+
+        const err: any = await client.automation
+            .execute('no_such_flow', {})
+            .then(() => { throw new Error('expected the unknown flow to reject'); }, (e) => e);
+
+        expect(err.httpStatus).toBe(404);
+        expect(err.code).not.toBe('FLOW_FAILED');
+        expect(err.message).toContain('no_such_flow');
+    });
+
+    it('should still resolve when a triggered flow succeeds', async () => {
+        // The other half of the contract: a successful dispatch is untouched,
+        // including the paused screen-flow shape the runner drives.
+        const { client } = createMockClient({
+            success: true,
+            data: { success: true, status: 'paused', runId: 'run_1', screen: { nodeId: 'collect', fields: [] } },
+        }, 200);
+
+        const result: any = await client.automation.execute('my_flow', {});
+        expect(result.status).toBe('paused');
+        expect(result.runId).toBe('run_1');
+    });
+
     it('should fetch the screen a paused run awaits', async () => {
         const { client, fetchMock } = createMockClient({
             success: true,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3016,6 +3016,28 @@ export class ObjectStackClient {
   automation = {
       /**
        * Trigger a named automation flow (legacy endpoint)
+       *
+       * **BREAKING since #9378 — a failed run REJECTS instead of resolving.**
+       * A flow that ran and then failed used to come back as a resolved
+       * `{ success: false, error }` riding HTTP 200, so a caller that did not
+       * open the inner envelope read a failed run as a successful one. The
+       * route answers **400** `FLOW_FAILED` now (inheriting #3962's ruling for
+       * `/actions`, applied to the resume route by #8684), and every non-2xx
+       * throws out of this SDK's fetch layer — so this promise **rejects**:
+       *
+       * ```ts
+       * try { await client.automation.trigger(flow, payload); }
+       * catch (err: any) {
+       *   err.code;                    // 'FLOW_FAILED'
+       *   err.httpStatus;              // 400
+       *   err.message;                 // the node failure, verbatim
+       *   err.details?.errorMessage;   // the flow author's `errorMessage`
+       *   err.details?.summary;        // per-node accounting of the failed run
+       * }
+       * ```
+       *
+       * A flow name the deployment does not hold rejects with **404** instead.
+       * A run that PAUSED at a screen node is not a failure and still resolves.
        */
       trigger: async (triggerName: string, payload: any) => {
           const route = this.getRoute('automation');
@@ -3168,7 +3190,15 @@ export class ObjectStackClient {
           const res = await this.fetch(`${this.baseUrl}${route}/${encodeURIComponent(name)}`);
           return this.unwrapResponse(res) as Promise<T>;
       },
-      /** Execute (trigger) a flow with an execution context. */
+      /**
+       * Execute (trigger) a flow with an execution context.
+       *
+       * **BREAKING since #9378**: a run that ran and failed now REJECTS with
+       * `400` `FLOW_FAILED` (author text on `err.details.errorMessage`, per-node
+       * accounting on `err.details.summary`) instead of resolving with an inner
+       * `{ success: false }` under HTTP 200; an unknown flow rejects with `404`.
+       * See `automation.trigger` for the full shape — both call the same door.
+       */
       execute: async <T = any>(name: string, ctx?: Record<string, any>): Promise<T> => {
           const route = this.getRoute('automation');
           const res = await this.fetch(`${this.baseUrl}${route}/${encodeURIComponent(name)}/trigger`, {
@@ -5342,6 +5372,12 @@ export class ScopedProjectClient {
     /**
      * Execute (trigger) a flow by name. The request body is forwarded as the
      * automation execution context (e.g. `{ params, trigger }`).
+     *
+     * Mirrors the unscoped `client.automation.execute` — including its
+     * **breaking #9378 behaviour**: a run that ran and then failed REJECTS with
+     * `400` `FLOW_FAILED` (author text on `err.details.errorMessage`) instead of
+     * resolving with an inner `{ success: false }` under HTTP 200, and an
+     * unknown flow rejects with `404`. See that method for the full shape.
      */
     execute: async <T = any>(name: string, ctx?: Record<string, any>): Promise<T> => {
       const res = await this.parent._fetch(this.url(`/automation/${encodeURIComponent(name)}/trigger`), {

--- a/packages/qa/dogfood/test/flow-runas.dogfood.test.ts
+++ b/packages/qa/dogfood/test/flow-runas.dogfood.test.ts
@@ -19,6 +19,13 @@
 // object the member cannot read or write directly:
 //   • system flows succeed on the admin's note  → elevation is REAL,
 //   • user flows are RLS-denied on the same note → de-elevation is REAL.
+// The two user-mode legs are denied DIFFERENTLY, and both shapes are asserted:
+// the WRITE is refused at the record layer, so the run fails and the trigger
+// route answers 400 `FLOW_FAILED` (#9378 — it rode HTTP 200 with an inner
+// `{success:false}` until then); the READ is filtered by RLS, so the run
+// SUCCEEDS with an empty `found`. Neither is a status band: a write leg that
+// started answering 403/500, or a read leg that started failing outright, is a
+// different bug and must not pass here.
 // Before the #1888 fix the user flows wrongly succeed (CRUD nodes passed no
 // identity → security skipped) → this file is RED; after the fix → GREEN.
 
@@ -61,13 +68,68 @@ describe('objectstack verify FLOW: runAs identity enforcement (#flow-runas)', ()
     return (j.record ?? j).status;
   }
 
-  /** Trigger a flow as the restricted member; returns the inner AutomationResult. */
+  /**
+   * Trigger a flow as the restricted member and require the run to have
+   * COMPLETED; returns the inner AutomationResult.
+   *
+   * [#9378] Since the trigger route answers real HTTP status codes, this helper
+   * is also the discriminator it could not be before: a run that fails now
+   * comes back 400 and is rejected HERE. Until then a failed run rode HTTP 200
+   * with `{success:false}` inside, so the read leg below — which only checks
+   * that `found` is falsy — passed identically whether the RLS-scoped read
+   * returned EMPTY (the thing it means to prove) or the run DIED before
+   * reading anything at all.
+   */
   async function memberTrigger(flow: string, noteId: string): Promise<{ success?: boolean; output?: any }> {
     const res = await stack.apiAs(memberToken, 'POST', `/automation/${flow}/trigger`, { params: { noteId } });
     expect(res.status, `trigger ${flow} HTTP failed: ${res.status} ${await res.clone().text()}`).toBeLessThan(300);
     const body = (await res.json()) as { success?: boolean; data?: { success?: boolean; output?: any } };
     expect(body.success).toBe(true);
     return body.data ?? {};
+  }
+
+  /**
+   * Trigger a flow as the restricted member and require the run to have RUN AND
+   * FAILED on a record-access refusal — the de-elevation proof's write leg.
+   *
+   * [#9378] The transport contract this asserts, in full rather than by status
+   * band: the route answers **400** `FLOW_FAILED` (ADR-0112 envelope), the node
+   * failure is `error.message` verbatim, and the per-node accounting in
+   * `error.details.summary` names WHICH node failed. Asserting the band
+   * (`>= 400`) or the throw alone would keep passing if the refusal turned into
+   * a 403 authorization verdict or a 500 fault — both of which would mean the
+   * de-elevation broke in a different way, and both of which this file exists
+   * to catch.
+   *
+   * Before #9378 this same run answered `HTTP 200 {"success":true,"data":{
+   * "success":false,…}}`, so the ONLY visible trace of the denial was the
+   * record staying unchanged. That assertion is still below and still the
+   * primary proof; this one is the transport half that used to be invisible.
+   */
+  async function memberTriggerExpectingAccessRefusal(flow: string, noteId: string, failingNodeId: string) {
+    const res = await stack.apiAs(memberToken, 'POST', `/automation/${flow}/trigger`, { params: { noteId } });
+    const text = await res.clone().text();
+    expect(res.status, `trigger ${flow} should be 400 FLOW_FAILED: ${res.status} ${text}`).toBe(400);
+
+    const body = (await res.json()) as {
+      success?: boolean;
+      data?: unknown;
+      error?: { code?: string; message?: string; httpStatus?: number; details?: { summary?: { nodes?: any[] } } };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error?.code, `expected FLOW_FAILED: ${text}`).toBe('FLOW_FAILED');
+    expect(body.error?.httpStatus).toBe(400);
+    // The double envelope is GONE, not re-labelled: nothing is left for a
+    // status-blind caller to misread as a successful run.
+    expect(body.data).toBeUndefined();
+    // The failure is the RLS refusal on the note, named node-first — not a
+    // generic "flow failed", which would pass while the run died of anything.
+    expect(body.error?.message).toContain(`Node '${failingNodeId}' failed`);
+    expect(body.error?.message).toMatch(/do not have access to this record/i);
+    // Which node failed survives the envelope change — the reason `summary`
+    // rides in `details` at all.
+    const failed = body.error?.details?.summary?.nodes?.find((n) => n?.nodeId === failingNodeId);
+    expect(failed?.status, `no failure entry for node '${failingNodeId}' in ${text}`).toBe('failure');
   }
 
   it('precondition: the automation service is wired and a flow is registered', async () => {
@@ -102,7 +164,13 @@ describe('objectstack verify FLOW: runAs identity enforcement (#flow-runas)', ()
 
   it("runAs:'user' DE-ELEVATES — member-triggered user flow is RLS-DENIED on the same record", async () => {
     const id = await adminCreateNote('user-touch');
-    await memberTrigger('runas_user_touch', id);
+    // The de-elevated run reaches the record layer as the MEMBER and the write
+    // is refused there, so the run fails on its `touch` node — surfaced since
+    // #9378 as 400 `FLOW_FAILED` instead of a 200 wrapping the inner failure.
+    // The refusal text is asserted in the helper: this leg proves the identity
+    // switch is real, so "denied because of WHO ran it" is the load-bearing
+    // part, not merely "something went wrong".
+    await memberTriggerExpectingAccessRefusal('runas_user_touch', id, 'touch');
     // The run executed as the member; the by-id write to the admin's note is
     // RLS-denied, so the record is unchanged. (Before the fix it would read
     // 'touched-user' — the privilege-boundary surprise this gate pins.)

--- a/packages/runtime/src/domain-handler-registry.test.ts
+++ b/packages/runtime/src/domain-handler-registry.test.ts
@@ -620,7 +620,12 @@ describe('HttpDispatcher extracted domains (PR-6: automation)', () => {
      */
     it('both trigger routes translate the body and forward the caller identity', async () => {
         const execute = vi.fn().mockResolvedValue({ success: true });
-        const automation = { execute, listFlows: vi.fn(), getFlow: vi.fn() };
+        // [#9378] `getFlow` resolves the flow rather than `undefined`: both
+        // trigger doors now answer 404 through the same shared existence probe
+        // `POST /:name/toggle` and `GET /:name` use, so a fixture whose
+        // registry claims the flow does not exist never reaches `execute` —
+        // which is this test's subject.
+        const automation = { execute, listFlows: vi.fn(), getFlow: vi.fn().mockResolvedValue({ name: 'nurture' }) };
         const ctx: any = {
             executionContext: {
                 userId: 'u-1',
@@ -668,7 +673,9 @@ describe('HttpDispatcher extracted domains (PR-6: automation)', () => {
     it('never calls a non-contract `trigger` method, even when one exists', async () => {
         const trigger = vi.fn().mockResolvedValue({ success: true });
         const execute = vi.fn().mockResolvedValue({ success: true });
-        const automation = { trigger, execute, listFlows: vi.fn(), getFlow: vi.fn() };
+        // [#9378] See the note on the fixture above: the trigger door consults
+        // the shared existence probe before dispatching.
+        const automation = { trigger, execute, listFlows: vi.fn(), getFlow: vi.fn().mockResolvedValue({ name: 'nurture' }) };
 
         const result = await makeDispatcher({ automation, auth })
             .dispatch('POST', '/automation/trigger/nurture', {}, {}, {} as any);

--- a/packages/runtime/src/domains/automation-trigger-route-status.test.ts
+++ b/packages/runtime/src/domains/automation-trigger-route-status.test.ts
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #9378 — the two `trigger` doors answer real HTTP status codes.
+ *
+ * `POST /api/v1/automation/:name/trigger` and the legacy
+ * `POST /api/v1/automation/trigger/:name` (the shape
+ * `client.automation.trigger()` calls) both ended
+ * `return deps.success(result)` unconditionally, so a flow that RAN AND FAILED
+ * came back as
+ *
+ * ```
+ * HTTP 200 {"success":true,"data":{"success":false,"error":"Node 'x' failed: …"}}
+ * ```
+ *
+ * — the double envelope #3962 ruled out for `/actions` and #8684 closed on the
+ * resume route. A caller that branches on the HTTP status alone read a failed
+ * run as a successful one, and this is the door every app dispatches flows
+ * through, so the blast radius is the whole SDK surface rather than the screen
+ * flow runner.
+ *
+ * Both routes are exercised for EVERY arm below, from one table: they share
+ * one context builder (#4127) and now one response mapper, and a test that
+ * covered only the canonical spelling would let the legacy one — the one the
+ * SDK actually calls — drift back to 200 unnoticed.
+ *
+ * The classification asserted here is the maintainer ruling recorded on the
+ * card (2026-08-17). Two of its four rows are deliberately NOT implemented yet
+ * and are pinned as unchanged, with the reason, at the bottom of this file.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpDispatcher } from '../http-dispatcher.js';
+import type { AutomationResult } from '@objectstack/spec/contracts';
+
+const CTX = { request: {}, executionContext: { userId: 'user_1' } } as any;
+
+/** Both spellings of the same door. `path` takes the flow name. */
+const ROUTES: Array<{ label: string; path: (flow: string) => string }> = [
+    { label: 'POST /:name/trigger', path: (f) => `/${f}/trigger` },
+    { label: 'legacy POST /trigger/:name', path: (f) => `/trigger/${f}` },
+];
+
+/**
+ * An automation service holding exactly the flows it is given, answering
+ * `execute` with a scripted result — the shape the real engine presents:
+ * `getFlow` resolves `null` for an unknown name, and `execute` returns an
+ * `AutomationResult` rather than throwing.
+ */
+function makeDispatcher(opts: {
+    flows?: string[];
+    result?: AutomationResult;
+    omitGetFlow?: boolean;
+} = {}) {
+    const names = opts.flows ?? ['welcome_flow'];
+    const flows = new Map(names.map((n) => [n, { name: n }]));
+    const execute = vi.fn(async (): Promise<AutomationResult> => opts.result ?? { success: true, output: {} });
+    const getFlow = vi.fn(async (name: string) => flows.get(name) ?? null);
+    const automation: Record<string, unknown> = opts.omitGetFlow ? { execute } : { execute, getFlow };
+    const services: Record<string, unknown> = { automation };
+    const resolve = (name: string) => services[name];
+    const kernel: any = {
+        getService: resolve,
+        getServiceAsync: async (name: string) => resolve(name),
+        context: { getService: resolve },
+    };
+    return { dispatcher: new HttpDispatcher(kernel), execute, getFlow };
+}
+
+/**
+ * The engine's ran-and-failed result, as `execute()` builds it since #9378:
+ * `status: 'failed'` is the producer's own verdict — the same one it writes to
+ * the run log — and it is the ONLY thing that separates this class from the
+ * exits that never dispatched anything.
+ */
+const RAN_AND_FAILED: AutomationResult = {
+    success: false,
+    status: 'failed',
+    error: "Node 'create_opportunity' failed: Amount must be greater than zero",
+    durationMs: 45,
+    summary: {
+        selected: 0, acted: 0, skipped: 0, unmeasured: 0,
+        nodes: [{ nodeId: 'create_opportunity', nodeType: 'create_record', status: 'failure', runs: 1, failures: 1 }],
+    } as AutomationResult['summary'],
+};
+
+describe('#9378 — a trigger that ran and failed answers 400 FLOW_FAILED, not 200', () => {
+    for (const route of ROUTES) {
+        it(`${route.label}: answers 400 FLOW_FAILED with no inner envelope`, async () => {
+            const { dispatcher } = makeDispatcher({ result: RAN_AND_FAILED });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', { amount: 0 }, CTX);
+
+            expect(result.handled).toBe(true);
+            expect(result.response?.status).toBe(400);
+            expect(result.response?.body?.error?.code).toBe('FLOW_FAILED');
+            expect(result.response?.body?.error?.httpStatus).toBe(400);
+            // The node failure stays the human-readable message, verbatim.
+            expect(result.response?.body?.error?.message).toMatch(/Node 'create_opportunity' failed/);
+            // The double envelope is GONE, not merely re-labelled: there is no
+            // inner `data` left for a status-blind caller to misread.
+            expect(result.response?.body?.data).toBeUndefined();
+            expect(result.response?.body?.success).toBe(false);
+        });
+
+        it(`${route.label}: carries the run summary in the 400 details`, async () => {
+            const { dispatcher } = makeDispatcher({ result: RAN_AND_FAILED });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+            // WHICH node failed survives the envelope change — it is why a
+            // caller reads the body at all, and it rode the 200 body before.
+            expect(result.response?.body?.error?.details?.summary?.nodes?.[0]?.status).toBe('failure');
+            // `code` is promoted out of `details` into the declared field,
+            // never duplicated in both (`error-envelope.ts`).
+            expect(result.response?.body?.error?.details?.code).toBeUndefined();
+        });
+
+        it(`${route.label}: carries the flow author's errorMessage in details, not folded into the message`, async () => {
+            // ⚠️ The single point where the consumer contract can be silently
+            // lost. objectui reads the author's own failure text from
+            // `error.details.errorMessage` and nowhere else (objectui
+            // `flowResponse.ts`, PR #4899); the ADR-0112 envelope has no
+            // `data`, so a producer that builds its message out of
+            // `result.error` alone drops the author's words while every status
+            // assertion stays green.
+            const { dispatcher } = makeDispatcher({
+                result: {
+                    ...RAN_AND_FAILED,
+                    errorMessage: 'We could not create the opportunity — check the amount and try again.',
+                },
+            });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+            expect(result.response?.body?.error?.details?.errorMessage)
+                .toBe('We could not create the opportunity — check the amount and try again.');
+            expect(result.response?.body?.error?.message).toMatch(/Node 'create_opportunity' failed/);
+        });
+
+        it(`${route.label}: a retry-strategy run that exhausted its attempts is the same 400`, async () => {
+            // `errorHandling.strategy: 'retry'` returns through
+            // `retryExecution`, a different exit with no `summary` — and it is
+            // still a run that dispatched and was rejected, so it must not be
+            // the one failure shape left riding HTTP 200.
+            const { dispatcher } = makeDispatcher({
+                result: { success: false, status: 'failed', error: 'Max retries exceeded', durationMs: 300 },
+            });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+            expect(result.response?.status).toBe(400);
+            expect(result.response?.body?.error?.code).toBe('FLOW_FAILED');
+            expect(result.response?.body?.error?.message).toBe('Max retries exceeded');
+        });
+
+        it(`${route.label}: an unknown flow is 404, and is never dispatched`, async () => {
+            const { dispatcher, execute, getFlow } = makeDispatcher();
+
+            const result = await dispatcher.handleAutomation(route.path('definitely_not_a_flow'), 'POST', {}, CTX);
+
+            expect(result.response?.status).toBe(404);
+            expect(result.response?.body?.error?.code).toBe('RESOURCE_NOT_FOUND');
+            // Named, so the caller knows WHICH name failed to resolve.
+            expect(result.response?.body?.error?.message).toContain('definitely_not_a_flow');
+            // The same shared `getFlow` probe `POST /:name/toggle` (#7535) and
+            // `GET /:name` use, so no two doors can disagree about which flows
+            // exist — and the engine is never asked to run a name it does not
+            // hold.
+            expect(getFlow).toHaveBeenCalledWith('definitely_not_a_flow');
+            expect(execute).not.toHaveBeenCalled();
+        });
+
+        it(`${route.label}: a successful run still answers 200 with its result`, async () => {
+            const { dispatcher } = makeDispatcher({
+                result: { success: true, output: { created: 'opp_1' }, durationMs: 12 },
+            });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', { a: 1 }, CTX);
+
+            expect(result.response?.status).toBe(200);
+            expect(result.response?.body?.success).toBe(true);
+            expect(result.response?.body?.data?.output).toEqual({ created: 'opp_1' });
+        });
+
+        it(`${route.label}: a run that PAUSED still answers 200 with the screen`, async () => {
+            // A pause is not a failure — the screen-flow runner drives the next
+            // screen off this 200, and a status flip here would break every
+            // multi-screen flow.
+            const { dispatcher } = makeDispatcher({
+                result: { success: true, status: 'paused', runId: 'run_1', screen: { nodeId: 'collect', fields: [] } },
+            });
+
+            const result = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+            expect(result.response?.status).toBe(200);
+            expect(result.response?.body?.data?.runId).toBe('run_1');
+            expect(result.response?.body?.data?.screen?.nodeId).toBe('collect');
+        });
+
+        it(`${route.label}: an implementation without \`getFlow\` keeps the probe optional`, async () => {
+            // `getFlow?` is optional on `IAutomationService`. A service that
+            // omits it cannot be asked whether a flow exists, so the trigger
+            // proceeds rather than this inventing a 404 — while the
+            // ran-and-failed mapping, which needs no probe, still applies.
+            const { dispatcher, execute } = makeDispatcher({ omitGetFlow: true, result: RAN_AND_FAILED });
+
+            const result = await dispatcher.handleAutomation(route.path('anything'), 'POST', {}, CTX);
+
+            expect(execute).toHaveBeenCalledTimes(1);
+            expect(result.response?.status).toBe(400);
+            expect(result.response?.body?.error?.code).toBe('FLOW_FAILED');
+        });
+    }
+});
+
+/**
+ * The route reads the ENGINE's classification; it does not infer one.
+ *
+ * These two exits — a DISABLED flow (the ruling's 409) and one with NO START
+ * NODE (the ruling's 422) — never dispatched anything, and the engine cannot
+ * yet say which is which: `AutomationResult.code` is a closed union of
+ * resume-refusal members with no honest home for either, and the maintainer
+ * ruling on #9384 (2026-08-17) keeps it closed, routing any new member to the
+ * spec seat.
+ *
+ * So they keep TODAY's behaviour, pinned here rather than left unexamined —
+ * and pinning them is what proves the 400 arm is not a shape heuristic: both
+ * carry `success: false` exactly like the ran-and-failed exit, and both stay
+ * 200 because they carry no `status: 'failed'`. When the union question is
+ * ruled, these two assertions are the ones that flip.
+ */
+describe('#9378 — the two never-dispatched exits the ruling leaves open stay unchanged', () => {
+    for (const route of ROUTES) {
+        for (const [label, result] of [
+            ['a disabled flow', { success: false, error: "Flow 'welcome_flow' is disabled" }],
+            ['a flow with no start node', { success: false, error: 'Flow has no start node' }],
+        ] as Array<[string, AutomationResult]>) {
+            it(`${route.label}: ${label} is NOT reported as a failed run`, async () => {
+                const { dispatcher } = makeDispatcher({ result });
+
+                const r = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+                expect(r.response?.status).toBe(200);
+                expect(r.response?.body?.error?.code).not.toBe('FLOW_FAILED');
+                expect(r.response?.body?.data?.success).toBe(false);
+            });
+        }
+
+        it(`${route.label}: does not classify off \`summary\` or \`durationMs\``, async () => {
+            // The tolerant-consumer shape PD #12 forbids, and the one #8684
+            // deliberately did not reproduce: a never-dispatched exit carrying
+            // the same incidental fields as a failed run must NOT be promoted
+            // to 400 by their presence.
+            const { dispatcher } = makeDispatcher({
+                result: {
+                    success: false,
+                    error: "Flow 'welcome_flow' is disabled",
+                    durationMs: 45,
+                    summary: RAN_AND_FAILED.summary,
+                },
+            });
+
+            const r = await dispatcher.handleAutomation(route.path('welcome_flow'), 'POST', {}, CTX);
+
+            expect(r.response?.status).toBe(200);
+        });
+    }
+});

--- a/packages/runtime/src/domains/automation.ts
+++ b/packages/runtime/src/domains/automation.ts
@@ -459,6 +459,93 @@ function flowDefinitionRefusal(err: any): unknown {
 }
 
 /**
+ * [#9378] The ONE mapper both trigger doors answer through — `POST
+ * /:name/trigger` and the legacy `POST /trigger/:name`, which
+ * `client.automation.trigger()` calls. Extracted rather than written twice:
+ * the two routes already shared one context builder so they could not drift
+ * about what a body means (#4127), and they must not drift about what a
+ * failed run means either.
+ *
+ * Until now both ended `return deps.success(result)` unconditionally, so a
+ * flow that RAN AND FAILED came back as
+ * `HTTP 200 {success:true,data:{success:false,error:"…"}}` — the double
+ * envelope #3962 ruled out for `/actions` and #8684 closed on the resume
+ * route. A caller that branches on the HTTP status alone read a failed run as
+ * a successful one, and this is the door every app dispatches flows through.
+ *
+ * Implements the maintainer ruling on #9378 (2026-08-17) for the two rows it
+ * can answer without inventing vocabulary:
+ *
+ * | engine exit                | reality            | answer                |
+ * |----------------------------|--------------------|-----------------------|
+ * | flow not found             | never dispatched   | `404`                 |
+ * | ran and failed (incl. the retry-strategy exits) | ran, rejected | `400` `FLOW_FAILED` |
+ *
+ * **404 is answered by the registry probe, not by reading the result.** It is
+ * the SAME `getFlow` probe `POST /:name/toggle` (#7535) and `GET /:name` use,
+ * so no two doors can disagree about which flows exist — and existence is a
+ * question the transport legitimately owns, the way every REST resource route
+ * owns its own 404. `getFlow` is optional on `IAutomationService`; an
+ * implementation that omits it cannot be asked, so the trigger proceeds as
+ * before rather than this inventing an answer.
+ *
+ * **400 is answered by the ENGINE's classification, never by sniffing.** The
+ * engine stamps `status: 'failed'` on exactly the exits that dispatched the
+ * flow and were rejected (#9378, engine `execute` / `retryExecution`); its
+ * never-dispatched exits carry no `status`. So this reads a producer verdict —
+ * it does not inspect `summary` / `durationMs` / the message text to guess the
+ * class, which is the tolerant-consumer shape PD #12 forbids and the one
+ * #8684 deliberately did not reproduce.
+ *
+ * ⚠️ `errorMessage` is the flow AUTHOR's own failure text and travels in
+ * `details`, the one place the console reads it from (objectui
+ * `flowResponse.ts`, PR #4899): the ADR-0112 envelope carries no `data`, so a
+ * producer that builds its message out of `result.error` alone drops the
+ * author's words silently. `summary` rides along for the same reason it was on
+ * the 200 body — it is how a caller finds WHICH node failed.
+ *
+ * ⛔ **The ruling's other two rows are NOT mapped here, deliberately.** A
+ * DISABLED flow (⇒ 409) and one with NO START NODE (⇒ 422) are both
+ * never-dispatched exits, and telling them apart needs the producer to say
+ * which is which — `AutomationResult.code` is a closed union of resume-refusal
+ * members with no honest home for either, and the maintainer ruling on #9384
+ * (2026-08-17) keeps it closed, routing any new member to the spec seat. The
+ * two alternatives were both rejected rather than quietly taken: matching the
+ * engine's message text is a regex on prose, and probing enable-state here
+ * would put a second copy of the engine's own execution policy in the
+ * transport, with a window in which a flow disabled between probe and dispatch
+ * is answered as a malformed definition. So those two exits keep TODAY's
+ * behaviour (200 with the inner failure) until the union question is ruled;
+ * nothing about them is guessed. See #9378 for the escalation.
+ */
+async function respondToFlowTrigger(
+    deps: DomainHandlerDeps,
+    automationService: IAutomationService,
+    flowName: string,
+    body: any,
+    context: HttpProtocolContext,
+): Promise<HttpDispatcherResult> {
+    if (typeof automationService.getFlow === 'function') {
+        const existing = await automationService.getFlow(flowName);
+        if (!existing) {
+            return { handled: true, response: deps.error(`Flow '${flowName}' not found`, 404) };
+        }
+    }
+    const result = await automationService.execute(flowName, buildAutomationContext(body, context));
+    if (result?.success === false && result.status === 'failed') {
+        return {
+            handled: true,
+            response: deps.error(result.error ?? 'Flow run failed', 400, {
+                code: 'FLOW_FAILED',
+                ...(result.errorMessage !== undefined ? { errorMessage: result.errorMessage } : {}),
+                ...(result.summary !== undefined ? { summary: result.summary } : {}),
+            }),
+        };
+    }
+    return { handled: true, response: deps.success(result) };
+}
+
+/**
  * Handles Automation requests
  * path: sub-path after /automation/
  *
@@ -472,7 +559,9 @@ function flowDefinitionRefusal(err: any): unknown {
  *   POST   /                     → createFlow (registerFlow)
  *   PUT    /:name                → updateFlow
  *   DELETE /:name                → deleteFlow (unregisterFlow)
- *   POST   /:name/trigger        → execute (legacy: trigger/:name also supported)
+ *   POST   /:name/trigger        → execute (legacy: trigger/:name also supported;
+ *                                  unknown name → 404, a run that ran and failed →
+ *                                  400 `FLOW_FAILED`, #9378)
  *   POST   /:name/toggle         → toggleFlow (unknown name → 404, #7535)
  *   GET    /:name/runs           → listRuns (query: limit, cursor — validated, #7300;
  *                                  status — validated AND honoured, #7359)
@@ -558,7 +647,8 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
 
     // Legacy: POST /automation/trigger/:name — the shape
     // `client.automation.trigger()` calls. Same handling as
-    // `POST /:name/trigger` below: one context builder, one service method.
+    // `POST /:name/trigger` below: one context builder, one service method,
+    // and since #9378 one response mapper.
     //
     // [#4127] This branch used to probe `automationService.trigger(name, body,
     // { request })` first and "fall back" to `execute`. Nothing in the repo has
@@ -567,11 +657,14 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
     // on every deployment and the fallback WAS the route. Declaring `trigger?`
     // to make the probe honest would have blessed a second name for `execute`
     // (Prime Directive #12); the dead branch is gone instead.
+    //
+    // [#9378] Both doors answer through `respondToFlowTrigger` — see its
+    // docblock for the status table, and for the two rows it deliberately
+    // leaves on today's 200 pending the closed-union ruling.
     if (parts[0] === 'trigger' && parts[1] && m === 'POST') {
         const triggerName = parts[1];
         if (typeof automationService.execute === 'function') {
-            const result = await automationService.execute(triggerName, buildAutomationContext(body, context));
-            return { handled: true, response: deps.success(result) };
+            return respondToFlowTrigger(deps, automationService, triggerName, body, context);
         }
     }
 
@@ -741,8 +834,7 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
         // legacy `POST /trigger/:name` above so the two routes cannot drift.
         if (parts[1] === 'trigger' && m === 'POST') {
             if (typeof automationService.execute === 'function') {
-                const result = await automationService.execute(name, buildAutomationContext(body, context));
-                return { handled: true, response: deps.success(result) };
+                return respondToFlowTrigger(deps, automationService, name, body, context);
             }
         }
 

--- a/packages/services/service-automation/src/engine.test.ts
+++ b/packages/services/service-automation/src/engine.test.ts
@@ -3055,3 +3055,123 @@ describe('AutomationEngine - Start Condition Gate', () => {
         expect(ran).toBe(0);
     });
 });
+
+/**
+ * [#9378] `execute()` says WHICH terminal class its `success: false` result is.
+ *
+ * The trigger routes (`POST /automation/:name/trigger` and the legacy
+ * `POST /automation/trigger/:name`) answered HTTP 200 wrapping an inner
+ * `{success:false}` for every failure alike — the double envelope #3962 ruled
+ * out for `/actions`. Mapping the ruled statuses needs the transport to tell a
+ * run that DISPATCHED AND WAS REJECTED from one that never started, and the
+ * producer is the only component that knows.
+ *
+ * `status: 'failed'` is that verdict, and it is existing vocabulary — declared
+ * on `AutomationResult` as the run's lifecycle status, and already the value
+ * these exits write to the run log. The maintainer ruling on #9384
+ * (2026-08-17) keeps `AutomationResult.code` closed, so a new member was not
+ * an option here and is not needed for this half.
+ *
+ * The never-dispatched exits are asserted to carry NO status in the same
+ * breath: it is their ABSENCE that makes the transport's arm provable rather
+ * than a heuristic, so a later edit that stamps `'failed'` on all of them —
+ * the natural-looking tidy-up — has to fail a test.
+ */
+describe('#9378 — execute() classifies terminal exits for the trigger transport', () => {
+    let engine: AutomationEngine;
+
+    beforeEach(() => {
+        engine = new AutomationEngine(createTestLogger());
+    });
+
+    /** start → `bad` (no executor registered for its type) → end. */
+    const failingFlow = (name: string, extra: Record<string, unknown> = {}) => ({
+        name, label: name, type: 'autolaunched' as const,
+        nodes: [
+            { id: 'start', type: 'start' as const, label: 'Start' },
+            { id: 'bad', type: 'script' as const, label: 'Bad' },
+            { id: 'end', type: 'end' as const, label: 'End' },
+        ],
+        edges: [
+            { id: 'e1', source: 'start', target: 'bad' },
+            { id: 'e2', source: 'bad', target: 'end' },
+        ],
+        ...extra,
+    });
+
+    it('reports a run that dispatched and failed as status failed', async () => {
+        engine.registerFlow('ran_and_failed', failingFlow('ran_and_failed'));
+
+        const result = await engine.execute('ran_and_failed');
+
+        expect(result.success).toBe(false);
+        expect(result.status).toBe('failed');
+        // The verdict agrees with the run log's, because it IS the log's.
+        const runs = await engine.listRuns('ran_and_failed');
+        expect(runs[0].status).toBe('failed');
+        // What the transport carries into `error.details` alongside it.
+        expect(result.error).toBeTruthy();
+        expect(result.summary).toBeDefined();
+    });
+
+    it('reports an exhausted retry strategy as status failed too', async () => {
+        // `errorHandling.strategy: 'retry'` returns through `retryExecution`,
+        // a different exit — and the flow still ran, so it is the same class.
+        // Without this the ONE failure shape left riding HTTP 200 would be the
+        // flows whose authors asked for the most robustness.
+        engine.registerFlow('retrying', failingFlow('retrying', {
+            errorHandling: { strategy: 'retry', maxRetries: 1, backoffMs: 1 },
+        }));
+
+        const result = await engine.execute('retrying');
+
+        expect(result.success).toBe(false);
+        expect(result.status).toBe('failed');
+    });
+
+    it('leaves a run that never dispatched WITHOUT a status — all three exits', async () => {
+        // 1. No such flow.
+        const missing = await engine.execute('no_such_flow');
+        expect(missing.success).toBe(false);
+        expect(missing.error).toContain('not found');
+        expect(missing.status).toBeUndefined();
+
+        // 2. Registered but disabled.
+        engine.registerFlow('disabled_flow', failingFlow('disabled_flow'));
+        await engine.toggleFlow('disabled_flow', false);
+        const disabled = await engine.execute('disabled_flow');
+        expect(disabled.success).toBe(false);
+        expect(disabled.error).toContain('is disabled');
+        expect(disabled.status).toBeUndefined();
+
+        // 3. Malformed definition: no start node. Registration accepts it —
+        // `FlowSchema` requires no `start` member — so this exit is reachable
+        // from the trigger door and is not dead code.
+        engine.registerFlow('startless', {
+            name: 'startless', label: 'Startless', type: 'autolaunched',
+            nodes: [{ id: 'middle', type: 'script', label: 'Middle' }],
+            edges: [],
+        });
+        const startless = await engine.execute('startless');
+        expect(startless.success).toBe(false);
+        expect(startless.error).toBe('Flow has no start node');
+        expect(startless.status).toBeUndefined();
+    });
+
+    it('leaves a successful and a paused run unchanged', async () => {
+        engine.registerFlow('fine', {
+            name: 'fine', label: 'Fine', type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [{ id: 'e1', source: 'start', target: 'end' }],
+        });
+
+        const ok = await engine.execute('fine');
+        expect(ok.success).toBe(true);
+        // Success keeps the shape it had: `status` is the classification this
+        // card needed, not a field being backfilled everywhere.
+        expect(ok.status).toBeUndefined();
+    });
+});

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3302,6 +3302,29 @@ export class AutomationEngine implements IAutomationService {
                 success: false,
                 error: errorMessage,
                 durationMs,
+                // [#9378] RAN AND FAILED, said by the producer that knows —
+                // the same lifecycle verdict this exit just wrote to the run
+                // log two statements up, now also on the result.
+                //
+                // Load-bearing, not decoration: `execute()` has three OTHER
+                // `success: false` exits that never dispatched anything (flow
+                // not found, flow disabled, no start node), and a transport
+                // cannot tell them from this one without either a message
+                // regex or sniffing `summary` / `durationMs` — the
+                // tolerant-consumer shape PD #12 forbids, and the one #8684
+                // deliberately did not reproduce on the resume route. Those
+                // three exits carry NO `status`, this one carries `'failed'`,
+                // so "the run dispatched and was rejected" is a fact the route
+                // reads rather than infers.
+                //
+                // `status` and not a new `code`: `AutomationResult.code` is a
+                // closed union whose members are all resume-refusal
+                // vocabulary, and the maintainer ruling on #9384 (2026-08-17)
+                // keeps it closed — the engine classifies with EXISTING
+                // vocabulary. `status?: 'completed' | 'paused' | 'failed'` is
+                // exactly that: declared, documented as the run's lifecycle
+                // verdict, and already the value recorded in the log.
+                status: 'failed',
                 // A failed run's counts matter MORE, not less: they say how far
                 // it got before dying — how many rows it had already written.
                 summary: logged.summary,
@@ -6106,7 +6129,12 @@ export class AutomationEngine implements IAutomationService {
             if (result.success) return result;
             lastError = result.error ?? 'Unknown error';
         }
-        return { success: false, error: lastError, durationMs: Date.now() - startTime };
+        // [#9378] Same "ran and was rejected" class as `execute()`'s own failure
+        // exit — every attempt above dispatched the flow — so it carries the
+        // same lifecycle verdict, and a transport answers it the same way.
+        // Without it, a flow whose author chose `errorHandling.strategy:
+        // 'retry'` would be the ONE failure shape that still rode HTTP 200.
+        return { success: false, error: lastError, durationMs: Date.now() - startTime, status: 'failed' };
     }
 
     /**
@@ -6239,7 +6267,12 @@ export class AutomationEngine implements IAutomationService {
                 steps,
                 error: errorMessage,
             });
-            return { success: false, error: errorMessage, durationMs, summary: logged.summary };
+            // [#9378] The retry loop reads only `result.success` and this
+            // result never escapes `retryExecution` on its own, but it is the
+            // same ran-and-failed exit as the two above and is classified the
+            // same: a selective classification is the one a later reader
+            // mistakes for a rule.
+            return { success: false, error: errorMessage, durationMs, status: 'failed', summary: logged.summary };
         }
     }
 }


### PR DESCRIPTION
Part of #9378 — `Part of`, not `Fixes`, deliberately: two of the four rows the ruling
decided are NOT implemented here and the card must stay open for them. Which two, and
why, is the second section below.

Both automation `trigger` doors answered `HTTP 200` wrapping an inner `{success: false}`
for a flow that ran and failed:

```
HTTP 200
{"success":true,"data":{"success":false,"error":"Node 'create_opportunity' failed: …"}}
```

That is the double envelope #3962 ruled out for `/actions` and #8684 closed on the resume
route (PR #9379, merged 2026-08-17). This is the wider half of the same residue: the
trigger route is the door every app dispatches flows through, so a caller that branches on
the HTTP status alone read *every* failed run as a successful one.

Implemented per the maintainer ruling recorded on the card (2026-08-17), inheriting
#9379's shape in full: producer classifies, route maps, `packages/spec` untouched, no
sniffing.

## What changes

**Producer first — `packages/services/service-automation/src/engine.ts`.** `execute()`
stamps `status: 'failed'` on the exits where a run DISPATCHED and was rejected — the
ordinary failure exit, the exhausted `errorHandling.strategy: 'retry'` exit, and
`executeWithoutRetry`'s catch. It is the same lifecycle verdict the exit already writes to
the run log two statements earlier. Its three never-dispatched exits (flow not found, flow
disabled, no start node) carry no `status`, and that absence is what makes the transport's
arm provable rather than a heuristic.

`status` and not a new `code`: `AutomationResult.code` is a closed union of resume-refusal
members, and the ruling on #9384 (2026-08-17) keeps it closed — the engine classifies with
EXISTING vocabulary. `status?: 'completed' | 'paused' | 'failed'` is exactly that:
declared on the contract, documented as the run's lifecycle verdict. No `packages/spec`
edit, measured — `tsc --noEmit` on `service-automation` holds at its 3 ledgered TS2341
errors, unchanged.

**Route stays a pure mapper — `packages/runtime/src/domains/automation.ts`.** Both doors
answer through one extracted `respondToFlowTrigger`, the way they already shared one
context builder (#4127) so they could not drift about what a body means.

| engine exit | reality | answer |
|---|---|---|
| flow not found | never dispatched | `404` (registry probe, before dispatch) |
| ran and failed · retry attempts exhausted | ran, rejected | `400` `FLOW_FAILED` |
| flow disabled · no start node | never dispatched | **unchanged 200** — see below |

**The 404 is the shared existence probe, not a result reading.** It is the same
`getFlow` probe `POST /:name/toggle` (#7535) and `GET /:name` use, so no two doors can
disagree about which flows exist, and the engine is never asked to run a name it does not
hold. The line this draws is principled and worth a reviewer's eye: **existence is a
question the transport owns** (every REST resource route owns its own 404); **execution
policy is the producer's**. `getFlow` is optional on `IAutomationService`, so an
implementation that omits it is unchanged rather than 404'd on a guess.

**The consumer contract is carried, not dropped.** The ADR-0112 envelope has no `data`, so
the flow author's own `errorMessage` travels in `error.details.errorMessage` — the one
documented location the console reads (objectui `flowResponse.ts`, PR #4899) — and the
run's per-node `summary` rides in `details` for the same reason it was on the 200 body: it
is how a caller finds WHICH node failed. objectui already classifies `400` `FLOW_FAILED`
and `404` on these routes as terminal (objectui#4784 / PR #4899); nothing there is
changed by this PR.

**`@objectstack/client`** needed no code change and this is a measured finding, not an
omission: `fetch` already throws on every non-2xx before any unwrapping, so
`client.automation.trigger()`, `client.automation.execute()` and
`client.project(id).automation.execute()` now **reject** with `err.code === 'FLOW_FAILED'`,
`err.httpStatus` and `err.details.errorMessage` instead of resolving with an inner failure.
All three surfaces document the new contract and all are pinned by tests — `trigger()`
reads `res.json()` while `execute()` reads `unwrapResponse()`, so both unwrap paths are
pinned separately.

## The two rows this does NOT implement, and why they are reported rather than resolved

The ruling's table has four rows. Two of them — **flow disabled ⇒ 409** and **no start
node ⇒ 422** — cannot be delivered honestly under the constraints the same ruling carries,
and the dispatch's own instruction for that case is to stop on the arm and report back.

Both are **never-dispatched** exits, so separating them needs the producer to say which is
which, and the closed `AutomationResult.code` union has no honest member for either:
`RUN_NOT_FOUND` is documented as "no suspension exists for the run id", `RESUME_IN_PROGRESS`
is a concurrent-resume refusal, and nothing in it maps to 422 at all. Widening the union is
a `packages/spec` fragment the ruling on #9384 routes to the spec seat, and it explicitly
forbids minting one mid-PR.

The two workarounds were considered and rejected, not overlooked:

- **Match the engine's message text** (`"is disabled"` / `"has no start node"`) — a regex
  on prose, the tolerant-consumer shape PD #12 forbids.
- **Probe enable-state at the route** via `getFlowRuntimeStates()` — this would put a
  second copy of the engine's own execution policy in the transport, and it cannot answer
  422 except by elimination, which mis-answers the TOCTOU case: a flow disabled between
  probe and dispatch would be reported as a malformed definition. Wrong for a new reason
  is not better than unchanged.

So those two exits keep TODAY's behaviour, and both are PINNED as unchanged in
`automation-trigger-route-status.test.ts` rather than left unexamined. Pinning them is also
what proves the 400 arm is not a shape heuristic: both carry `success: false` exactly like
a failed run — one of them carrying `summary` and `durationMs` too — and both stay 200
because they carry no `status: 'failed'`. When the union question is ruled, those are the
assertions that flip.

**For the spec seat, one line:** adding `'FLOW_DISABLED'` and `'FLOW_NO_START_NODE'` to
that union would let the engine name both classes directly and this route gain two more
coded arms. Same measured cost as #9384 recorded for `FLOW_FAILED`: union members plus
TSDoc, no generated-artifact churn.

## Consumer migration — the dogfood gate found a real one (second commit)

`Dogfood Regression Gate` went red on
`packages/qa/dogfood/test/flow-runas.dogfood.test.ts`, and it was right to: the
`runAs:'user'` WRITE leg of the #1888 identity proof triggers a flow whose `update_record`
node is refused at the record layer, so the run fails and now answers `400` `FLOW_FAILED`
instead of a 200 wrapping the inner failure. Its `memberTrigger` helper asserted a blanket
`< 300`.

The semantic that file pins is unchanged and still primary — the run executes AS the
member, so the admin's note stays `'new'`. Only the transport expectation moved, and it is
asserted **precisely** rather than as a widened band: status `400`, `error.code`
`FLOW_FAILED`, the node-first access-refusal text, and the `touch` node's `failure` entry
in `error.details.summary`. A `403` or `500` there would mean de-elevation broke in a
different way, and this file exists to catch exactly that.

The READ leg is deliberately **not** migrated — measured, not assumed: an RLS-scoped read
is FILTERED rather than refused, so that run still succeeds with an empty `found` and keeps
its `< 300` expectation. That leg also gains discrimination for free: until now a failed
run and an empty read were indistinguishable there, because both left `found` falsy under
HTTP 200.

Every other `trigger` caller in `packages/qa/dogfood` expects the run to SUCCEED (or
asserts an anonymous 401), so none is touched by this contract — swept rather than assumed,
and all of them were run locally (below). No changeset change: `@objectstack/dogfood` is
private internal QA and the wire change is already documented in the changeset.

## Scope held

- **`packages/spec` untouched**, per the ruling.
- **objectui untouched** — its consumer half is already landed (objectui#4784 / PR #4899);
  cited, not changed.
- **`content/docs/releases/` untouched**; the changeset is this PR's only release input.
- Two fixtures in `domain-handler-registry.test.ts` gained a resolving `getFlow` stub:
  their subject is body translation and contract-method preference, and a registry that
  claims the flow does not exist never reaches `execute` now. Disposition per fixture
  triage: declarations added, no assertion weakened.

## Verification

Union of gates re-run at `4a37192` — the final commit, tree clean, nothing pushed after it.
Re-derived against the actual changed paths, which is what caught the four spec-liveness
families the dogfood path pulls in (`packages/qa/dogfood/**` is a CI trigger for
`spec-liveness-check.yml`, because the liveness ledger reads dogfood usage as evidence):

```
Local gates for this card (paste into the dispatch prompt):
  - pnpm check:changeset-gate-self-tests   [lint.yml]
  - pnpm check:cross-package-test-inputs   [lint.yml]
  - pnpm --filter @objectstack/spec run check:empty-state   [spec-liveness-check.yml]
  - pnpm --filter @objectstack/spec run check:liveness   [spec-liveness-check.yml]
  - pnpm check:objectui-changeset   [lint.yml]
  - pnpm check:route-envelope   [lint.yml]
  - pnpm --filter @objectstack/spec run check:strictness-ledger   [spec-liveness-check.yml]
  - pnpm check:test-source-alias   [lint.yml]
  - pnpm check:type-source-resolution   [lint.yml]
  - pnpm --filter @objectstack/spec run check:variant-docs   [spec-liveness-check.yml]
  - node scripts/check-adr-0087-registration.mjs   [cut-rc.yml, pr-automation.yml]
  - node scripts/check-changeset-no-major.mjs   [cut-rc.yml, pr-automation.yml]
  - node scripts/check-cross-package-test-inputs.mjs   [ci.yml]
  - node scripts/check-empty-changeset.mjs   [cut-rc.yml, pr-automation.yml]
  - node scripts/docs-audit/check-affected-docs.mjs   [docs-drift-check.yml]

Convention-triggered gates (this change KIND moves them):
  adds or edits a test file:
    - pnpm check:query-options-erasure
    - pnpm check:type-check-coverage
    - pnpm check:type-check-debt
    - pnpm check:engine-double-contract
    - pnpm check:where-matcher
```

All green at `4a37192`, plus `check:nul-bytes`. `check:type-check-debt --re-measure` ran on
a fully built workspace closure: 33 ledger entries, 1926 raw errors, none above its
recorded number, surplus none. `check:where-matcher`: 253 matchers, 0 silently wrong.
`check:liveness`: every governed-type property classified, README state table current.
`check-adr-0087-registration` answered `not-required (no-migration-prescription)` — this
retires no metadata surface, so `objectstack migrate meta` has nothing to rewrite; the
changeset is the channel that reaches these consumers. `check-changeset-no-major` refused a
`major` for the same reason #9379 recorded (one Changesets fixed group ⇒ a single major
promotes the monorepo), so the bump is `minor` with the BREAKING framing kept in the body.

Tests: `@objectstack/runtime` 166 files / 2489 tests, `@objectstack/service-automation`
80 files / 973 tests, `@objectstack/client` 23 files / 307 tests — all passing.
`typecheck` green for `runtime`, `client` and `dogfood`; `service-automation` has no
`typecheck` script and its 3 ledgered TS2341 errors (in a file this PR does not touch) are
unchanged.

Dogfood, run locally on a built workspace closure (the red gate reproduced first, then
fixed):

```
flow-runas.dogfood.test.ts                              5 passed   (was 1 failed)
flow-node · flow-function-effect · flow-durable-suspend ·
  showcase-declarative-mcp                             17 passed
showcase-anonymous-deny-surfaces · authz-conformance   46 passed
```

**Reverse verification, direction predicted before running, both legs from the committed
state:**

- Ablating the engine's `status: 'failed'` on the ran-and-failed exit ⇒ predicted RED, one
  engine test: `expected undefined to be 'failed'`. Observed exactly that (1 failed, 3
  passed).
- Ablating the route's `FLOW_FAILED` arm ⇒ predicted RED on the 400 assertions only, GREEN
  on the 404 probe, the success/paused arms and the two unchanged-200 pins. Observed 10
  failed / 12 passed, the failures being `expected 200 to be 400` and the two `details`
  reads — i.e. the 200 pins held while the 400 pins fell, which is the shape that proves
  they are pinning different facts.

Both ablations restored with a checkout of the committed path, and the tree re-verified
clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_