### PR TITLE
ci(lint): rename the `ESLint` required context to `Lint & Repo Gates` (#9325) — DRAFT, needs a maintainer-present Settings swap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,21 @@ concurrency:
 jobs:
 
   lint:
-    name: ESLint
+    # ⚠️ This `name:` IS the required-status-check context in repository
+    # Settings → Rulesets (a job's check-run name is its `name:`), so it is
+    # pinned as contract by `scripts/check-required-contexts.mjs` and may only
+    # be changed together with that registry AND the Settings entry, in one
+    # maintainer-present sitting (#9325 ruling 2026-08-17). Either half alone
+    # is an outage: rename-first leaves the old context permanently pending,
+    # which wedges every open PR and the merge queue; settings-first drops the
+    # whole gate family to advisory with no signal anywhere, which is #5617
+    # verbatim.
+    #
+    # It is not called `ESLint` any more because it never was only that: the
+    # `pnpm lint` step below is one of ~70 sequential gate steps, so a red here
+    # was routinely read as "a lint problem" when it was a repo gate — three
+    # mis-routed diagnoses on 2026-08-17 alone (#9258, PRs #9256/#9291).
+    name: Lint & Repo Gates
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,8 +333,9 @@ Even inside your own worktree, operate defensively:
    yet"; `in_progress` is not a pass. Arming a red PR does not queue it, it hides it:
    every poll then misreads "not on `main` yet" as "queued". Always read *two* things
    when checking a landing: the queue branch **and** `origin/main`. And **the queue
-   enforces only the required set** — **ESLint** and **TypeScript Type Check** block by
-   maintainer decision (2026-08-07); everything else is advisory and rides through, and
+   enforces only the required set** — **Lint & Repo Gates** (called `ESLint` until the
+   #9325 rename) and **TypeScript Type Check** block by maintainer decision
+   (2026-08-07); everything else is advisory and rides through, and
    an advisory red that lands rides `main`'s merge ref into every following PR until
    stanched. That is why "arm only on green" is a rule, not a formality.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,11 +333,13 @@ Even inside your own worktree, operate defensively:
    yet"; `in_progress` is not a pass. Arming a red PR does not queue it, it hides it:
    every poll then misreads "not on `main` yet" as "queued". Always read *two* things
    when checking a landing: the queue branch **and** `origin/main`. And **the queue
-   enforces only the required set** — **Lint & Repo Gates** (called `ESLint` until the
-   #9325 rename) and **TypeScript Type Check** block by maintainer decision
-   (2026-08-07); everything else is advisory and rides through, and
-   an advisory red that lands rides `main`'s merge ref into every following PR until
-   stanched. That is why "arm only on green" is a rule, not a formality.
+   enforces only the required set** — **Lint & Repo Gates** (the whole `check:*` gate
+   family, formerly published under a name that described only one of its steps) and
+   **TypeScript Type Check** block by maintainer decision (2026-08-07); everything else
+   is advisory and rides through, and an advisory red that lands rides `main`'s merge ref
+   into every following PR until stanched. A required context is matched by check-run
+   name, so a job rename detaches its gate silently — treat those names as contract.
+   That is why "arm only on green" is a rule, not a formality.
 
    **Re-arm awareness** — none of these is a reason to avoid the queue; all are reasons
    to confirm a PR is still *in* it: a red queue build **ejects** your entry and drops

--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -157,8 +157,19 @@ export const REQUIRED_CONTEXTS = [
   {
     workflow: 'lint.yml',
     job: 'lint',
-    context: 'ESLint',
-    authorized: '#5617 maintainer ruling 2026-08-07 — applied to the settings the same day',
+    // Renamed from 'ESLint' under the #9325 ruling: the old name described one
+    // of the job's steps and mis-routed the diagnosis of every other gate it
+    // carries. The rename lands in two halves that CANNOT be atomic — this
+    // registry + the workflow `name:` here, and the required-context entry in
+    // repository Settings → Rulesets — so it is done in one maintainer-present
+    // sitting: merge, then swap the Settings entry immediately. Either half
+    // alone is an outage (permanently-pending, or advisory-with-no-signal =
+    // #5617). If you are reading this while a required context named 'ESLint'
+    // is still live in Settings, that swap has not happened yet.
+    context: 'Lint & Repo Gates',
+    authorized:
+      '#5617 maintainer ruling 2026-08-07 (enrolment, applied to the settings the same day); ' +
+      'renamed from `ESLint` by the #9325 maintainer ruling 2026-08-17, swapped in the settings in the same sitting as the merge',
     carries: 'the whole check:* gate family — the job whose red did not block #5584',
   },
   {
@@ -540,12 +551,21 @@ async function selfTest() {
   // Predicted direction: RED, naming the job, the new name and the required
   // context. A rename is the whole defect #6865 is about, so a green here would
   // mean the gate is decorative.
-  const renamedEslint = fixture('rename ESLint', 'lint.yml', (s) => s.replace('    name: ESLint\n', '    name: ESLint (fast)\n'));
-  assert(
-    renamedEslint.problems.some((p) => p.includes("job 'lint'") && p.includes('"ESLint (fast)"') && p.includes("'ESLint'") && p.includes('The name IS the contract')),
-    "renaming lint.yml's ESLint job ⇒ red, naming the job, the new name and the required context",
+  // The anchor is the CURRENT name of the gate-family job (renamed away from
+  // `ESLint` by #9325); the mutation restores the OLD spelling on purpose, so
+  // this fixture doubles as the regression test for that rename: reverting
+  // lint.yml alone, without this registry, is exactly the half-landed state
+  // the #9325 sequencing exists to prevent, and it must be red.
+  const renamedGateJob = fixture('rename the gate-family job back to ESLint', 'lint.yml', (s) =>
+    s.replace('    name: Lint & Repo Gates\n', '    name: ESLint\n'),
   );
-  assert(renamedEslint.problems.length === 1, `renaming ESLint produces exactly the one finding — got ${JSON.stringify(renamedEslint.problems)}`);
+  assert(
+    renamedGateJob.problems.some(
+      (p) => p.includes("job 'lint'") && p.includes('"ESLint"') && p.includes("'Lint & Repo Gates'") && p.includes('The name IS the contract'),
+    ),
+    "renaming lint.yml's gate-family job ⇒ red, naming the job, the new name and the required context",
+  );
+  assert(renamedGateJob.problems.length === 1, `renaming the gate-family job produces exactly the one finding — got ${JSON.stringify(renamedGateJob.problems)}`);
 
   // The second-batch half: a name the maintainer approved on 2026-08-09, which
   // had no assertion of any kind before this script.
@@ -609,7 +629,7 @@ async function selfTest() {
   // ── (6) the merge_group trigger ──────────────────────────────────────────
   const noQueue = fixture('drop merge_group from lint.yml', 'lint.yml', (s) => s.replace('\n  merge_group:\n', '\n'));
   assert(
-    noQueue.problems.some((p) => p.includes('merge_group') && p.includes('ESLint') && p.includes('TypeScript Type Check')),
+    noQueue.problems.some((p) => p.includes('merge_group') && p.includes('Lint & Repo Gates') && p.includes('TypeScript Type Check')),
     'a required-context workflow without merge_group ⇒ red, naming every context it would strand',
   );
   assert(
@@ -782,7 +802,7 @@ async function selfTest() {
     const lintJob = uncommented(lintJobStart === -1 ? '' : sources['lint.yml'].slice(lintJobStart, lintJobEnd === -1 ? undefined : lintJobEnd));
     assert(
       /run: pnpm check:required-contexts\b/.test(lintJob),
-      'wiring: lint.yml\'s ESLint job must run `pnpm check:required-contexts` — an unwired pin verifies nothing (#4690)',
+      'wiring: lint.yml\'s `lint` job (the "Lint & Repo Gates" context) must run `pnpm check:required-contexts` — an unwired pin verifies nothing (#4690)',
     );
     const step = lintJob.split(/\n(?=      - name: )/).find((s) => /run: pnpm check:required-contexts\b/.test(s)) ?? '';
     assert(
@@ -794,8 +814,10 @@ async function selfTest() {
     assert(/check-required-contexts\.mjs --self-test/.test(wiring), 'wiring: `check:required-contexts` must run this file\'s --self-test first');
     assert(/check-required-contexts\.mjs(?! --self-test)/.test(wiring), 'wiring: `check:required-contexts` must also run the real pin, not only the self-test');
     // The pin lives in a job it also pins. That is deliberate and worth stating:
-    // renaming the ESLint job turns this gate red under the NEW name, while the
-    // old required context stops reporting — the PR is blocked from both sides.
+    // renaming the gate-family job turns this gate red under the NEW name, while
+    // the old required context stops reporting — the PR is blocked from both
+    // sides. That is also why the #9325 rename could not be self-serve: the
+    // repo-side half is checkable here, the Settings half is not reachable at all.
     assert(
       REQUIRED_CONTEXTS.some((entry) => entry.workflow === 'lint.yml' && entry.job === 'lint'),
       'wiring: the job this gate runs in is itself registered, so a rename of it cannot be the one rename nothing notices',


### PR DESCRIPTION
Part of #9325 — this is the **repo-side half only**. The card closes after the Settings swap below is done and verified, so this PR deliberately does not close it.

---

## ⛔ DO NOT MERGE UNATTENDED — READ THIS FIRST

**This PR stays DRAFT. Do not mark it ready. Do not enable auto-merge. Do not enqueue it.**

A GitHub required status check is matched **by check-run name**, and a job's check-run name is its `name:`. This PR renames that name. The matching entry in **Settings → Rulesets** is maintainer-only and cannot be read or written from an agent seat (`GET /repos/objectstack-ai/objectstack/branches/main/protection` answers HTTP 403 `GitHub access is not enabled for this session` — measured in #6865, re-confirmed on this runner).

⇒ **If this merges while Settings still requires `ESLint`, every open PR and the merge queue wedge on a permanently-pending context that can never report again.** That is the incident class recorded on this card on 2026-08-17.

### The maintainer sitting (per the #9325 ruling, 2026-08-17)

> ⚠️ **Superseded on the ordering — see the PM's correction comment below.** This PR's own head publishes `Lint & Repo Gates` and no `ESLint`, so while `ESLint` is still required this PR can never satisfy it. The corrected order is: **remove `ESLint` from the required set first, then merge, then add the new name.** The steps below are kept as filed for provenance; follow the correction comment, not this list.

1. Merge this PR.
2. **Immediately** swap the required-context entry in Settings → Rulesets:

   | | value |
   |---|---|
   | remove | `ESLint` |
   | add | `Lint & Repo Gates` |

   Copy-paste literal, no surrounding whitespace: `Lint & Repo Gates`

3. Confirm a PR opened after the swap shows `Lint & Repo Gates` as a required check.

The minutes-scale advisory window between steps 1 and 2 is accepted by the ruling; do it in a low-traffic window. Reversing the order is the other outage (the gate family degrades to advisory with no signal anywhere — #5617 verbatim, where PR #5584 merged with this job red for 19 minutes and four more merges repeated it that night).

---

## What this changes

The `lint` job publishes one check run for **~70 sequential `pnpm check:*` steps**, and it was called `ESLint` — the name of exactly one of those steps. Every other gate's failure therefore announced itself as a lint problem on a PR whose diff may have nothing to do with linting: the reader had to open the log, discover the job is a gate chain, scroll to the failing step, and only then decide whose problem it was. Paid three times on 2026-08-17 alone (#9258, PRs #9256/#9291).

The compounding harm is the one that matters: a check whose name does not describe what it verifies trains readers to re-run on red, which is the structural channel through which a genuine regression in this gate family gets waved through.

Two files, one coherent pair:

- `.github/workflows/lint.yml` — the job `name:`, plus a comment stating why the literal is load-bearing and that it may only move in a maintainer-present sitting.
- `scripts/check-required-contexts.mjs` — the pinned registry literal (#6865), its `authorized` provenance, and the self-test fixtures that anchor on it.

`AGENTS.md` carries one sentence naming the required set for the merge-queue rule; it now names the new context, gives the name history as prose, and states why those names are contract at all.

### Why `Lint & Repo Gates`

Final spelling is the implementer's per the ruling; I kept the working title, with reasoning:

- **It is truthful about both halves.** The job really does run ESLint, and it really does run the repo gate family. A name that dropped "Lint" would mis-route in the opposite direction the first time `pnpm lint` itself fails.
- **It matches house style in the file it lives in.** `lint.yml`'s workflow-level name is already `Lint & Type Check` — same ampersand, same shape, unquoted, and it has parsed for months. Verified here: the YAML parser reads `Lint & Repo Gates` unquoted correctly (an ampersand is only an anchor sigil in first position).
- **It stays short enough to read unwrapped in the PR checks list**, which is the surface the whole card is about.
- **It does not collide.** Assertion 9 of the pin rejects any unregistered job carrying a registered name; the union run below is green, so no other job in the three scanned workflows publishes this name.

Rejected: `Repo Gates` (drops the lint half), `Lint and Repo Gates` (diverges from the file's own `&` style for no gain, and the `&`/`and` ambiguity is itself a hand-typing hazard for the Settings edit — which is why the copy-paste literal is given instead).

## Reverse verification

**Predicted direction: RED**, naming the job, the new name and the required context. A rename detaching the gate is the entire defect #6865 exists to catch, so a green here would mean the pin is decorative.

**Observed**, with `lint.yml` renamed and `scripts/check-required-contexts.mjs` restored to `origin/main` (the half-landed state the sequencing exists to prevent):

```
✗ check-required-contexts — 1 problem(s)

  • lint.yml: job 'lint' is named "Lint & Repo Gates", but branch protection requires
    the context 'ESLint'. The name IS the contract: GitHub matches a required check by
    its check-run name, so this rename silently detaches the gate. Rename it back, or
    have a maintainer update the required set FIRST and this registry with it (#6865).
```

Exit 1. The `--self-test` leg goes red in the same state from two independent directions — the baseline assertion, and the fixture anti-vacuous-green guard firing on its stale anchor:

```
• the checked-in workflows pass the pin — got ["lint.yml: job 'lint' is named ...]
• fixture 'rename ESLint': its lint.yml anchor no longer matches — the assertion
  below would judge the pristine workflow
```

That second line is why the fixture had to move rather than merely be tolerated. It now anchors on the **new** name and mutates it **back** to `ESLint`, which makes the self-test the standing regression test for this very change: reverting `lint.yml` alone, without the registry, is red.

The tree was restored byte-identically afterwards (`git diff HEAD --stat` empty) and the union below re-run at the final commit.

## Tests

Union re-run at final commit `b47e0f3` (`git rev-parse --short HEAD` from that run):

```
check:pm-skill-id-lint         -> exit 0
check:required-contexts        -> exit 0
check:node-version             -> exit 0
check:shard-attestation        -> exit 0
check:workflow-status-functions-> exit 0
check:type-check-coverage      -> exit 0
check:nul-bytes                -> exit 0
```

`check:pm-skill-id-lint` is in the union because CI caught it red at the first head: `AGENTS.md` is in that gate's scan set, and the rename commit's edit to it cited an issue number. The gate enforces the 2026-08-12 maintainer ruling that operative agent-protocol text distils its lesson in place rather than pointing at a card. The sentence was rewritten to carry the name history as prose and to state the operative fact it had been missing — a required context is matched by check-run name, so a job rename detaches its gate silently. `9 file(s) clean (pattern /#[0-9]{3,}/g)`.

```
✓ check-required-contexts --self-test: 55 assertions (rename ablations across both
  workflows + matrix/continue-on-error/trigger shapes + the shard-name collision +
  the `carries` step-count ban + the #4690 pins).
✓ check-required-contexts: 9 required context name(s) pinned across 3 workflow(s).
    lint.yml:lint → 'Lint & Repo Gates'
    lint.yml:typecheck → 'TypeScript Type Check'
    ...
```

Assertion count is unchanged from baseline (55 before and after), so the rename moved the fixtures rather than dropping any.

Gate families derived from the changed paths, not recalled — `node scripts/pm/dispatch-gates.mjs .github/workflows/lint.yml scripts/check-required-contexts.mjs AGENTS.md`, verbatim `--tier`:

```
Model tier — no path-derived mandate: the surface hits none of the 1 declared glob(s), derived here, not recalled.
  The tier stays the PM's per-card judgment call (floor sonnet · default opus · ceiling fable).
  Clause ② is NOT reachable from paths: a card that changes contract accept/reject behaviour or widens the public surface is fable-mandatory too, judged from the card CONTENT. This line is a FLOOR, never a clearance.
```

One derived family is **not** green locally and is not this diff's: `check:type-check-debt` refuses to run without a built workspace closure (`--re-measure cannot run: 55 workspace dependenc(ies) ... have no built type entry point on disk`). That is a stated precondition of the script, independent of the diff — this PR contains no TypeScript. CI runs it after the closure build, as `lint.yml` does.

`skip-changeset` per precedent: workflow + gate script + one AGENTS.md sentence publish nothing.

## Out of scope, filed separately

`.claude/skills/pm-dispatch/references/review-checklist.md` instructs the review seat to verify the `ESLint` job's `conclusion` before arming a PR, so it points at the old name too. It is **not** changed here: `dispatch-gates.mjs` reports that any diff touching `.claude/skills/pm-dispatch/**` is model-tier-mandatory for a seat this one is not, so editing it from here would violate the tiering ruling. Filed as #9420 (unassigned, `Blocked-by: #9325`); it should land in or right after the same maintainer sitting — landing it earlier makes the checklist wrong in the other direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_