### PR TITLE
docs(blog): rename the ~16k measurement's host noun in context-window-is-the-constraint

### DIFF
--- a/content/blog/context-window-is-the-constraint.mdx
+++ b/content/blog/context-window-is-the-constraint.mdx
@@ -42,7 +42,7 @@ a dashboard, a lead-conversion flow, permission sets, an action, translations.
 | Lines | 1,792 |
 | Approximate tokens | ~16,000 |
 
-That's the **entire business system**. Not a module of it — the data model, the
+That's the **whole example app**. Not a module of it — the data model, the
 UI, the automation, the access rules, all of it. It fits in about 8% of a
 200k-token context window.
 


### PR DESCRIPTION
Fixes #9305

## What

`content/blog/context-window-is-the-constraint.mdx` is a fourth host of the
~16k-token `examples/app-crm` measurement (README.md, `metadata-driven.mdx`,
`how-ai-development-works.mdx` are the other three, all already renamed by
#9293). The blog post still called the measured app "the entire business
system", which collides with the adopted "a complete CRM in under 150k
tokens" tagline from #9242 -- two claims both asserting to be the whole
business system, at two different token counts.

Renamed the host noun in the one sentence immediately following the table
(disposition C from the triage comment): "entire business system" ->
"whole example app", matching the exact phrase the other three hosts now use
post-#9293. Nothing else in the post changed -- numbers (31 / 1,792 /
~16,000 / 8% / 200k), the `find … wc -l` snippet, and the rest of the
argument are untouched. Frontmatter `date: 2026-07-17` is untouched; this is
a dated post, not a living doc, so only the characterisation collision is in
scope (not a rewrite of the post's argument).

```diff
-That's the **entire business system**. Not a module of it — the data model, the
+That's the **whole example app**. Not a module of it — the data model, the
 UI, the automation, the access rules, all of it. It fits in about 8% of a
 200k-token context window.
```

## Consistency check across all four hosts (read, not swept)

Read how the other three now describe the measurement so this page would not
become a fourth *different* description:

- `README.md`: "...is **31 files, 1,792 lines, roughly 16k tokens**. That's
  the whole example app, in about 8% of a 200k-token context window."
- `content/docs/concepts/metadata-driven.mdx`: "That's the **whole example
  app** -- about 8% of a 200k-token context window."
- `content/docs/getting-started/how-ai-development-works.mdx`: "...**1,792
  lines across 31 files, about 16k tokens**. That's the whole example app,
  not a module of it."

All three converge on "the whole example app" as the host-noun phrase; this
PR brings the blog post's leading sentence into the same wording. The four
hosts do not fully diverge otherwise -- no further reconciliation performed
or needed.

## Tests

- `node scripts/check-nul-bytes.mjs` -- OK (6116 tracked text files scanned,
  no raw control bytes) at commit `5c517cf57`.
- `node scripts/pm/dispatch-gates.mjs content/blog/context-window-is-the-constraint.mdx`
  -- no check family names this path directly; `content/blog/**` is not an
  auto-gen or otherwise gated docs family (`content/docs/releases/`,
  `content/docs/references/`, `**/translations/*.generated.ts` do not apply
  here).
- Diff is a single one-word phrase swap in prose; no package build/typecheck
  applies (docs-only, no code/schema touched).

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_