### PR TITLE
ci(docs-drift): tolerate transient API failures when delivering the advisory, loudly

### DIFF
--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -3,9 +3,13 @@ name: Docs Drift Check
 # When a PR changes packages/** code, flag the hand-written docs that NAME something the
 # change touched — a symbol, a wire route, or the SDK method a route ledger binds to it —
 # so they can be re-verified for implementation accuracy before the drift lands on main.
-# Advisory only: posts a PR comment, never fails the build. The actual LLM audit is run
-# on-demand / on a schedule via the `docs-accuracy-audit` workflow, scoped to exactly the
-# docs this check lists.
+# Advisory only: posts a PR comment, and its VERDICT never fails the build. Since #9373 a
+# transient GitHub API failure while DELIVERING that comment does not fail it either — but
+# it is never swallowed: the run then states, in its own job summary and a warning
+# annotation, that the advisory could not be delivered, so "could not tell" can never
+# render as "no drift". Scan and derivation errors DO still fail the job. The actual LLM
+# audit is run on-demand / on a schedule via the `docs-accuracy-audit` workflow, scoped to
+# exactly the docs this check lists.
 #
 # It used to list pages by PACKAGE DEPENDENCY ("which docs mention @objectstack/x"), and
 # #9192 measured that wrong in both directions on a real PR: 2 of 3 listed pages were
@@ -192,12 +196,164 @@ jobs:
               );
               body = body.join('\n');
             }
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
-            });
+            // ── Delivery, and ONLY delivery, tolerates platform weather (#9373) ────
+            //
+            // Everything above is the VERDICT. Everything below merely carries it to the
+            // PR conversation. Those are two different failures and must not share one
+            // outcome:
+            //
+            //   the scan ran wrong / the body could not be built  → red job (unchanged)
+            //   the computed advisory could not be POSTED         → green job, said aloud
+            //
+            // Measured: this job died four consecutive times on PR #9370 (17:17Z-18:24Z,
+            // 2026-08-17), every time with
+            //   HttpError: No server is currently available to service your request.
+            //   response: { url: '.../issues/9370/comments', status: 503 }
+            // github-script hands any throw from this script to `main().catch(handleError)`
+            // -> `core.setFailed('Unhandled error: ...')`, so an advisory-only check went
+            // red on GitHub's weather and cost four re-runs that no local change could fix.
+            // That URL is the endpoint of BOTH `listComments` (GET) and `createComment`
+            // (POST), so the recorded log cannot say which call was rejected — both are
+            // covered below.
+            //
+            // ⛔ Deliberately NOT `continue-on-error: true`, and NOT a bare catch:
+            //   - this step also parses `affected.json` and builds `body`, so blanket
+            //     tolerance would let a malformed scan result or an over-long (422) comment
+            //     read as a clean run — real breakage wearing a green tick;
+            //   - a swallowed failure leaves the run saying NOTHING, and then "could not
+            //     tell" renders exactly like "no drift". That is the same defect in the
+            //     opposite mask, and it is precisely what this file's #9192 posture — say
+            //     what the run could not see — exists to prevent.
+            // So: a narrow transient class, bounded retries, and, when they are spent, a
+            // loud statement in the run's own output of exactly what was lost.
+
+            // Transient = the request never received a considered answer.
+            //   5xx  the server declined to serve it. octokit also normalises
+            //        network-layer failures into a 500-shaped RequestError; the explicit
+            //        code set covers any that arrive unnormalised.
+            //   429  rate limited.
+            //   403 + a rate-limit signature — GitHub answers a SECONDARY rate limit with
+            //        403 as well as 429, so the signature, never the status alone, is what
+            //        separates it from a genuine permission denial.
+            // Everything else stays fatal on purpose: 401 / plain 403 (the `permissions:`
+            // block above is wrong), 404 (wrong target), 422 (the body this workflow built
+            // is not postable — e.g. past GitHub's 65536-character comment limit), and any
+            // non-HTTP error such as a TypeError in the code above. Those are this repo's
+            // own bugs and must keep failing the job.
+            const TRANSIENT_NETWORK_CODES = new Set([
+              'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN', 'ENOTFOUND', 'EPIPE',
+              'EHOSTUNREACH', 'ENETUNREACH', 'UND_ERR_SOCKET', 'UND_ERR_CONNECT_TIMEOUT',
+            ]);
+            const isTransient = (error) => {
+              if (error && TRANSIENT_NETWORK_CODES.has(error.code)) return true;
+              const status = error && typeof error.status === 'number' ? error.status : null;
+              if (status === null) return false;
+              if (status >= 500 || status === 429) return true;
+              if (status === 403) {
+                const remaining = error.response?.headers?.['x-ratelimit-remaining'];
+                return String(remaining) === '0'
+                  || /secondary rate limit|abuse detection/i.test(String(error.message || ''));
+              }
+              return false;
+            };
+
+            // Bounded, and deliberately short. The measured incident ran over an hour — no
+            // retry budget rides that out, and pretending otherwise only burns runner
+            // minutes before degrading anyway. The retries are for a BLIP; the visible
+            // degradation below is what handles an incident. The delays are a judgement,
+            // not a measurement.
+            const RETRY_DELAYS_MS = [3000, 9000];
+            const ATTEMPTS = RETRY_DELAYS_MS.length + 1;
+            const deliver = async (label, call) => {
+              for (let attempt = 0; ; attempt++) {
+                try {
+                  return await call();
+                } catch (error) {
+                  if (!isTransient(error) || attempt >= RETRY_DELAYS_MS.length) throw error;
+                  const wait = RETRY_DELAYS_MS[attempt];
+                  core.info(`${label}: transient ${error.status ?? error.code} — retrying in ${wait}ms (attempt ${attempt + 2}/${ATTEMPTS})`);
+                  await new Promise((resolve) => setTimeout(resolve, wait));
+                }
+              }
+            };
+
+            // Degrade VISIBLY — the house pattern (check-links.yml's "the link check did
+            // not run", cross-repo-issue-closer.yml's missing-token notice). A reader looks
+            // for this advisory's verdict on the PR; when it cannot be put there, the run
+            // page must say so in full: what failed, what the reader must NOT infer from
+            // whatever is on the PR, and the verdict itself — degraded but delivered,
+            // never lost.
+            const degrade = async (stage, error, staleNote) => {
+              const detail = typeof error.status === 'number' ? `HTTP ${error.status}` : (error.code || 'error');
+              // Octokit messages usually end in a full stop; ours supplies its own.
+              const reason = `${detail}: ${String(error.message || '').replace(/\s*\.\s*$/, '')}`;
+              const note = [
+                '## ⚠️ Docs Drift Check — advisory computed, but NOT posted to this PR',
+                '',
+                `The scan completed; this is a **delivery** failure only. \`${stage}\` was rejected on all`,
+                `${ATTEMPTS} attempts: \`${reason}\`.`,
+                '',
+                `- ${staleNote}`,
+                '- The verdict this run computed is reproduced below. It is **not** on the pull request.',
+                '- This job is **green on purpose**: its conclusion reflects the scan, not the',
+                '  deliverability of its courtesy comment (#9373). The check is advisory either way.',
+                '- Re-run this job to retry delivery once the API recovers.',
+                '',
+                '---',
+                '',
+                body,
+                '',
+              ].join('\n');
+              try {
+                await core.summary.addRaw(note).write();
+              } catch (summaryError) {
+                // The summary is the richer channel, the annotation the reliable one.
+                // Losing the richer one must not restore the silence this exists to prevent.
+                core.info(`Could not write the job summary: ${summaryError.message}`);
+              }
+              core.warning(
+                `The docs-drift advisory was computed but could not be posted to this PR: `
+                + `${stage} failed ${ATTEMPTS}x with ${reason}. ${staleNote} `
+                + `The verdict is in this run's job summary. Transient GitHub API failure (#9373) — `
+                + `the job stays green because the scan itself is unaffected.`,
+                { title: 'Docs drift advisory not delivered' },
+              );
+            };
+
+            let comments;
+            try {
+              ({ data: comments } = await deliver('issues.listComments', () => github.rest.issues.listComments({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+              })));
+            } catch (error) {
+              if (!isTransient(error)) throw error;
+              // Without the listing there is no way to tell an update from a create.
+              // Posting blind would strand a SECOND advisory comment that the marker dedup
+              // then updates forever alongside the first, and every comment here is relayed
+              // into subscribed agent sessions (#9037). Saying so costs less than
+              // duplicating.
+              await degrade(
+                'issues.listComments',
+                error,
+                'This run could not even determine whether an advisory comment exists on this PR; if one is shown there, it is from an earlier push.',
+              );
+              return;
+            }
+
             const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
+            try {
+              if (existing) {
+                await deliver('issues.updateComment', () => github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body }));
+              } else {
+                await deliver('issues.createComment', () => github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body }));
+              }
+            } catch (error) {
+              if (!isTransient(error)) throw error;
+              await degrade(
+                existing ? 'issues.updateComment' : 'issues.createComment',
+                error,
+                existing
+                  ? `The \`docs-drift-check\` comment on this PR still shows an EARLIER run's verdict — this run could not refresh it.`
+                  : 'No advisory comment was posted on this PR for this run.',
+              );
             }


### PR DESCRIPTION
Fixes #9373

## What was measured, not assumed

The card attributes the failure to "posting the advisory comment". Verified against a tree
asserted equal to `origin/main` (`51a46a440`), with one refinement worth recording: the URL in
the recorded error, `/repos/.../issues/9370/comments`, is the endpoint of **both**
`issues.listComments` (GET) and `issues.createComment` (POST). The job log therefore cannot say
which of the two calls was rejected, so both are covered here.

**Propagation path, confirmed rather than presumed.** There is no `continue-on-error` anywhere in
this workflow — not on the step, not on the job. `actions/github-script` registers
`main().catch(handleError)`, and `handleError` calls `core.setFailed("Unhandled error: " + err)`.
That is exactly the `##[error]Unhandled error: HttpError: ...` signature in the card. So any throw
from the inline script fails the step, and the step fails the job.

For calibration: this job's name, `Flag docs affected by code changes`, is **not** in the
`REQUIRED_CONTEXTS` registry, so the red did not block branch protection. Its measured cost is the
red check itself, the four re-run cycles, and the noise in `mergeable_state` — not a hard merge
block. Recording that so nobody inherits an overstatement.

## The fix, and the half that is binding

Delivery of the advisory — and only delivery — now tolerates transient platform weather. The
verdict is unchanged and still governs the job's conclusion.

**It does not fall silent.** When the bounded retries are spent the run says so, in its own output,
where a reader looks for this advisory's verdict:

- a **warning annotation** titled "Docs drift advisory not delivered";
- a **job summary** that names the failed call and status, states plainly that the verdict is
  **not** on the pull request, warns that any advisory comment shown there is from an **earlier
  push** and was not refreshed by this run, and then **reproduces the verdict this run actually
  computed**.

No verdict is emitted that was not computed. This matches the posture the file already takes for
its derivation limits — "this run has no opinion", plus a named list of what it could not anchor.

**Why not `continue-on-error: true`, and why not a bare catch.** The step also parses
`affected.json` and builds the comment body. Blanket tolerance would let a malformed scan result,
or a 422 from an over-long body, read as a clean run — real breakage wearing a green tick. And a
swallowed failure leaves the run saying nothing at all, so "could not tell" renders exactly like
"no drift", which is the same defect wearing the opposite mask.

**503 is not the right granularity — the class is.** Tolerated: 5xx, 429, `403` **carrying a
secondary-rate-limit signature** (GitHub answers a secondary limit with 403 as well as 429, so the
signature and not the status alone separates it from a real permission denial), and network-level
error codes. Still fatal, on purpose: 401, a plain 403 (the `permissions:` block is wrong), 404,
422, and every non-HTTP error such as a TypeError in the code above. Those are this repo's own bugs.

Retries are bounded and short — 3 attempts, 3s then 9s. The measured incident ran over an hour; no
retry budget rides that out, and pretending otherwise only burns runner minutes before degrading
anyway. The retries are for a blip; the visible-degradation path is what handles an incident.

## Verification — a simulated failure path, not an observed 503

A real 503 cannot be summoned, and none was observed. Instead the inline `github-script` source was
extracted from the workflow and executed against a mocked octokit and `@actions/core`, reproducing
github-script's own `main().catch(handleError)` propagation. Backoff was made instant by overriding
`setTimeout` in the harness, so the shipped workflow carries **no test hook**. The harness lives in
the session scratchpad, not in this diff — adding a workflow-script test rig is outside this card's
scope.

Baseline, against this file as it stands on `origin/main`:

| scenario | before |
|---|---|
| 503 on the write, persistent | **FAILURE** — `Unhandled error: HttpError: No server is currently available to service your request.` |
| 503 on the listing, persistent | **FAILURE** — same signature |
| happy path | success |

After, all ten scenarios:

| scenario | API calls | job | warning | summary |
|---|---|---|---|---|
| happy path | list, create | success | 0 | — |
| 503 on write, clears on retry | list, create, create | success | 0 | — |
| 503 on write, persistent | list, create x3 | **success** | 1 | 1832 B |
| 503 on listing, persistent | list x3 | **success** | 1 | 1907 B |
| 503 while updating an existing comment | list, update x3 | **success** | 1 | 1887 B |
| network `ECONNRESET` | list, create x3 | **success** | 1 | 1829 B |
| 403 secondary rate limit | list, create, create | success | 0 | — |
| 422 body too long | list, create | **FAILURE** | 0 | — |
| 403 plain permission denial | list, create | **FAILURE** | 0 | — |
| malformed `affected.json` | none | **FAILURE** | 0 | — |

Both halves of the ruling, demonstrated: the job does **not** fail on the transient class, and the
run **states** what happened. The degraded warning reads:

> The docs-drift advisory was computed but could not be posted to this PR: issues.listComments
> failed 3x with HTTP 503: No server is currently available to service your request. This run could
> not even determine whether an advisory comment exists on this PR; if one is shown there, it is
> from an earlier push. The verdict is in this run's job summary. Transient GitHub API failure
> (#9373) — the job stays green because the scan itself is unaffected.

The three FAILURE rows are the important ones: they are what separates this from the swallow-it fix.

One design note recorded in the file: when the **listing** is what fails, the run degrades without
posting blind. It cannot tell an update from a create, and posting anyway would strand a second
advisory comment that the marker dedup would then update forever alongside the first — and every
comment here is relayed into subscribed agent sessions.

## Scope

One file, `.github/workflows/docs-drift-check.yml`, and within it only the delivery tail plus the
file-header comment that described the old contract (it claimed "never fails the build", which was
untrue in exactly the way this card records). The advisory's derivation logic is untouched — that
is #9282 / #9294 / #9331 territory, deliberately not entered here.

Because this PR edits the workflow's own file, which is in its own `paths:` trigger, the modified
job runs on this PR and exercises the happy delivery path live.

## Gates

Re-derived from the actual changed path via `node scripts/pm/dispatch-gates.mjs`, which added one
family the dispatch list did not name: the workflow's own self-test. All run at final commit
`86aab217e`:

```
pnpm check:node-version                            exit=0
pnpm check:required-contexts                       exit=0
pnpm check:shard-attestation                       exit=0
pnpm check:workflow-status-functions               exit=0
pnpm check:nul-bytes                               exit=0
node scripts/docs-audit/check-affected-docs.mjs    exit=0   (197 cases)
node scripts/check-shard-attestation.mjs           exit=0
```

`check:workflow-status-functions` is a no-op for this change by construction: no job-level `if:` is
added or altered, and the job reads no `needs.*.outputs.*` at all.

Workflow-only, publishes nothing, so `skip-changeset` rather than a changeset file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_