### PR TITLE
fix(rest): refuse when findReferencesToMeta is absent instead of answering "nothing depends on this item"

### DIFF
--- a/.changeset/references-route-capability-gap-refused.md
+++ b/.changeset/references-route-capability-gap-refused.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): a missing `findReferencesToMeta` capability is refused, not answered as "nothing depends on this item" (#9326)
+
+`GET /api/v1/meta/:type/:name/references` feature-detects `findReferencesToMeta`
+on the resolved protocol. When the method was absent the route answered
+`200 { references: [] }` — so a **capability gap** reached the wire as the
+statement **"nothing depends on this item"**.
+
+Per ADR-0110 D3 those are different facts, and here they have opposite
+consequences. The consumer is the admin "Used by" panel, whose empty state reads,
+verbatim from `objectui`'s `metadata-admin/i18n.ts`:
+
+```
+'engine.edit.refsEmptyDesc': 'Nothing in the metadata graph points at this item. Safe to delete.'
+```
+
+An operator about to delete something was shown that sentence on a deployment
+where the question had never actually been asked.
+
+The branch now refuses:
+
+```
+501  { error: { code: 'NOT_IMPLEMENTED',
+                message: 'protocol.findReferencesToMeta() is not available in this kernel' } }
+```
+
+— the ADR-0112 nested envelope the sibling `/meta` 501 refusals converged on
+(#7035), so `body.error.code` is readable by the same one line of consumer code
+that already reads the others.
+
+**Does any caller's observed response change? Yes, on one deployment shape, and
+only there.** A protocol that *has* the method is untouched: both an empty and a
+non-empty result still pass through verbatim as `200`. What changes is the
+answer given when the protocol has no such method — previously `200` with an
+empty list, now `501`. No assembly in this repo produces such a protocol today:
+`ObjectStackProtocolImplementation` is the only implementation registered under
+the `protocol` service and it defines the method unconditionally. The branch is
+reachable rather than dead because `findReferencesToMeta` is **not** a member of
+`RestProtocol` (`= DataProtocol & MetadataProtocol`) and is not declared in
+`@objectstack/spec` at all — it is an ADR-0076 D9 server-only extension reached
+through a runtime cast. A host that implements the declared contract exactly, or
+that points `protocolServiceName` at its own service, is a *conforming*
+deployment that lands on this branch with no type error.
+
+Refusing at the route rather than asserting at assembly is deliberate: a
+boot-time assertion would promote an undeclared optional extension into a
+required one, which is a contract decision for `@objectstack/spec` rather than a
+route one, and it would reject the partial protocol doubles that legitimately
+exist today.

--- a/packages/rest/src/meta-references-capability-gap.test.ts
+++ b/packages/rest/src/meta-references-capability-gap.test.ts
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#9326] `GET /meta/:type/:name/references` — a MISSING capability is not an
+ * EMPTY reference list.
+ *
+ * ## The defect
+ *
+ * The handler feature-detects `findReferencesToMeta` on the resolved protocol
+ * and, when it is absent, used to answer:
+ *
+ * ```ts
+ * res.json({ references: [] })
+ * ```
+ *
+ * That is ADR-0110 D3 collapsed — *a miss and a fault are different facts*.
+ * The two conditions it merged are:
+ *
+ *   1. the graph WAS walked and nothing points at this item, and
+ *   2. the graph could not be walked at all, because this deployment's
+ *      protocol has no such method.
+ *
+ * They arrived on the wire as the same `200 { references: [] }`, so no consumer
+ * could tell them apart. The consumer is the admin "Used by" panel, whose empty
+ * state reads, verbatim from `objectui`'s `metadata-admin/i18n.ts`:
+ *
+ * ```
+ * 'engine.edit.refsEmptyDesc': 'Nothing in the metadata graph points at this item. Safe to delete.'
+ * ```
+ *
+ * — shown to an operator about to delete something, on a deployment where the
+ * question was never actually asked.
+ *
+ * ## Why the fix is a refusal at the route
+ *
+ * `findReferencesToMeta` is NOT a member of `RestProtocol`
+ * (`= DataProtocol & MetadataProtocol`); it is not declared anywhere in
+ * `packages/spec` at all. It is an ADR-0076 D9 server-only extension, which is
+ * why the handler reaches it through a runtime cast rather than a typed call.
+ * A host that implements the DECLARED contract exactly is therefore a
+ * CONFORMING deployment that lands on this branch with no type error — which is
+ * what makes the branch worth answering honestly rather than asserting away at
+ * boot. Promoting an undeclared optional extension into a required one is a
+ * `packages/spec` contract decision and is deliberately not taken here.
+ *
+ * ## What these cases assert, and why not `toThrow`
+ *
+ * This handler *sends*, it never throws, so a `toThrow`-shaped assertion could
+ * not separate "answered with the wrong body" from "did not refuse at all" —
+ * and the wrong body IS the defect. Every case asserts the ADR-0112 pair,
+ * `status` AND `body.error.code`, at the **nested** position (#7035), plus the
+ * load-bearing one this file exists for: the capability gap and a genuine zero
+ * do not produce the same answer.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+// `.js` on purpose — NodeNext resolution requires the extension, and this
+// package's TEST_DEBT ceiling has no margin for another TS2835 (#7248).
+import { RestServer } from './rest-server.js';
+
+const REFERENCES_PATH = '/api/v1/meta/:type/:name/references';
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function mockRes() {
+    const res: any = {
+        statusCode: 200,
+        json: vi.fn(function (this: any, body: any) { this._body = body; return this; }),
+        send: vi.fn(),
+        status: vi.fn(function (this: any, code: number) { this.statusCode = code; return this; }),
+        header: vi.fn(),
+    };
+    return res;
+}
+
+/**
+ * The read side every `/meta` route needs to register, and nothing more. The
+ * `findReferencesToMeta` slot is filled by the caller precisely because its
+ * presence or ABSENCE is the whole variable under test — anything else this
+ * stub gained would weaken what the cases below prove.
+ */
+function baseProtocol() {
+    return {
+        getDiscovery: vi.fn().mockResolvedValue({
+            version: 'v0',
+            routes: { data: '', metadata: '', ui: '', auth: '/auth' },
+        }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItems: vi.fn().mockResolvedValue([]),
+        getMetaItem: vi.fn().mockResolvedValue({ type: 'object', name: 'account', item: {}, lock: 'none' }),
+        findData: vi.fn().mockResolvedValue([]),
+        getData: vi.fn().mockResolvedValue({}),
+        createData: vi.fn().mockResolvedValue({ id: '1' }),
+        updateData: vi.fn().mockResolvedValue({}),
+        deleteData: vi.fn().mockResolvedValue({ success: true }),
+    };
+}
+
+function boot(protocol: Record<string, unknown>) {
+    const rest = new RestServer(
+        mockServer() as any,
+        protocol as any,
+        { api: { requireAuth: false } } as any,
+    );
+    // `isSystem` clears the capability gates that fire before the protocol is
+    // probed, so the request reaches the branch under test.
+    (rest as any).resolveExecCtx = async () => ({ isSystem: true });
+    rest.registerRoutes();
+
+    const found = (rest as any).getRoutes().find(
+        (r: any) => r.method === 'GET' && r.path === REFERENCES_PATH,
+    );
+    if (!found) throw new Error(`route not registered: GET ${REFERENCES_PATH}`);
+
+    return async () => {
+        const res = mockRes();
+        await found.handler(
+            { query: {}, headers: {}, body: {}, params: { type: 'object', name: 'account' } },
+            res,
+        );
+        return { status: res.statusCode, body: res.json.mock.calls.at(-1)?.[0] };
+    };
+}
+
+/** A protocol that CAN walk the graph and found nothing. The honest empty. */
+const answersEmpty = () => boot({
+    ...baseProtocol(),
+    findReferencesToMeta: vi.fn().mockResolvedValue({ references: [] }),
+});
+
+/** A protocol with no such method. The capability gap. */
+const hasNoCapability = () => boot(baseProtocol());
+
+/** A protocol that CAN walk the graph and found something. */
+const answersHits = () => boot({
+    ...baseProtocol(),
+    findReferencesToMeta: vi.fn().mockResolvedValue({
+        references: [{ type: 'view', name: 'account_list', path: 'object' }],
+    }),
+});
+
+describe('#9326 — a missing `findReferencesToMeta` is refused, not answered as "nothing depends on this item"', () => {
+    it('an absent capability answers 501 NOT_IMPLEMENTED at the ADR-0112 nested position', async () => {
+        const answer = await hasNoCapability()();
+
+        expect(answer.status).toBe(501);
+        // The pair ADR-0112 declares. `body.error.code` — NESTED, because the
+        // flat-sibling position is what makes `error.code` read `undefined`
+        // (#7035).
+        expect(answer.body?.error?.code).toBe('NOT_IMPLEMENTED');
+        expect(answer.body?.error?.message).toBe(
+            'protocol.findReferencesToMeta() is not available in this kernel',
+        );
+        // Dialect 1 retired: `code` as a sibling of `error`.
+        expect(answer.body).not.toHaveProperty('code');
+        // Dialect 2 retired: `error` as a bare string.
+        expect(typeof answer.body?.error).toBe('object');
+    });
+
+    it('⭐ THE PIN — the capability gap and a genuine zero are not the same answer', async () => {
+        // This is the whole defect in one assertion. Both of these used to be
+        // `200 { references: [] }`, so a consumer had no way to ask which one it
+        // was holding. If a future edit re-merges them — by restoring the empty
+        // body, or by teaching the honest-empty path to 501 — exactly one of the
+        // three expectations below goes red.
+        const gap = await hasNoCapability()();
+        const genuineZero = await answersEmpty()();
+
+        expect(gap.status).not.toBe(genuineZero.status);
+        expect(gap.body).not.toEqual(genuineZero.body);
+        // And the direction, so "different" cannot be satisfied by breaking the
+        // healthy side instead of fixing the broken one.
+        expect(genuineZero.status).toBe(200);
+        expect(genuineZero.body).toEqual({ references: [] });
+    });
+
+    it('a protocol that CAN answer is untouched — empty and non-empty both pass through verbatim', async () => {
+        // The refusal is scoped to the capability probe and nothing else: this
+        // route's success path is the same one it always had. Without this case
+        // the pin above could be satisfied by a route that refuses more often
+        // than it should.
+        const zero = await answersEmpty()();
+        expect(zero.status).toBe(200);
+        expect(zero.body).toEqual({ references: [] });
+
+        const hits = await answersHits()();
+        expect(hits.status).toBe(200);
+        expect(hits.body).toEqual({
+            references: [{ type: 'view', name: 'account_list', path: 'object' }],
+        });
+    });
+
+    it('the refusal is machine-readable by the SAME read as its `/meta` 501 siblings', async () => {
+        // `err.error.code` is the one position ADR-0112 declares, and #7035
+        // converged the `/meta` write refusals onto it. A consumer written
+        // against those reads this one with no second branch — which is the
+        // property that makes the refusal usable rather than merely loud.
+        const answer = await hasNoCapability()();
+        expect(answer.body?.error?.code).toBe('NOT_IMPLEMENTED');
+        expect(typeof answer.body?.error?.message).toBe('string');
+        // Not an empty-collection body under any spelling: the shapes a client
+        // might reasonably probe for a "no references" answer are all absent.
+        expect(answer.body).not.toHaveProperty('references');
+        expect(answer.body).not.toHaveProperty('items');
+    });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4203,7 +4203,42 @@ export class RestServer {
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
                         if (typeof (p as any).findReferencesToMeta !== 'function') {
-                            res.json({ references: [] });
+                            // [#9326 / ADR-0110 D3] A MISS and a FAULT are
+                            // different facts, and this branch is the second
+                            // one: the resolved protocol cannot compute the
+                            // reference graph AT ALL, so the question was never
+                            // asked. Answering `{ references: [] }` reported it
+                            // as the first — "nothing depends on this item" —
+                            // and the admin "Used by" panel renders that empty
+                            // case as "Nothing in the metadata graph points at
+                            // this item. Safe to delete.", shown to an operator
+                            // about to delete something.
+                            //
+                            // Refusing HERE rather than asserting at assembly is
+                            // deliberate. `findReferencesToMeta` is not a member
+                            // of `RestProtocol` (= `DataProtocol &
+                            // MetadataProtocol`) — it is an ADR-0076 D9
+                            // server-only extension, which is why it is reached
+                            // through a runtime cast at all. So a host that
+                            // implements the DECLARED contract exactly is a
+                            // CONFORMING deployment that lands here with no type
+                            // error, and a boot-time assertion would promote an
+                            // undeclared optional extension into a required one
+                            // — a `packages/spec` contract decision, not a
+                            // route one. What the route owes is that an
+                            // unanswerable question comes back unanswered.
+                            //
+                            // Envelope per #7035: the ADR-0112 NESTED
+                            // `{ error: { code, message } }` that the sibling
+                            // `/meta` 501 refusals converged on — never the
+                            // bare-string or sibling-`code` dialects, which make
+                            // `body.error.code` read `undefined`.
+                            res.status(501).json({
+                                error: {
+                                    code: 'NOT_IMPLEMENTED',
+                                    message: 'protocol.findReferencesToMeta() is not available in this kernel',
+                                },
+                            });
                             return;
                         }
                         const result = await (p as any).findReferencesToMeta({


### PR DESCRIPTION
Fixes #9326.

## The measurement came first, and it chose the fix

The card's own honesty note said live-reachability was never measured, and the
dispatch fence made producing that measurement the first deliverable. Here it is.

**Who can supply the protocol this route reads?** `resolveProtocol()` returns
either the `protocol` service of the request's per-environment kernel
(`kernelManager.getOrCreate(envId)`) or the one injected into `RestServer` by
`RestApiPlugin` — whose service name is host-configurable (`protocolServiceName`).

**Is there an in-repo assembly that produces one lacking `findReferencesToMeta`?
No.** `ObjectStackProtocolImplementation`
(`packages/metadata-protocol/src/protocol.ts`) is the only implementation
registered under the `protocol` service in production code, it reaches the kernel
through the one seam both mounts share (`assembleMetadataProtocol()`), and it
defines the method unconditionally as a class member. The sibling `cloud` repo
registers no `protocol` service of its own and never mentions the method
(control-queried: 24 `registerService(` sites there, zero for `'protocol'`).

**Is the branch therefore dead? No — and this is the part that decides the fix.**
`RestProtocol` is `DataProtocol & MetadataProtocol`, and **`findReferencesToMeta`
is a member of neither**. It is not declared anywhere in `packages/spec` at all
(control query: `getMetaItem(` matches in that very interface; the three
beyond-spec read verbs match zero times). It is an ADR-0076 D9 server-only
extension, which is exactly why the handler reaches it through a runtime cast.

So a host that implements the **declared** contract exactly and correctly is a
*conforming* deployment that lands on this branch, and `tsc` cannot say a word.
In-process partial protocol doubles already do precisely this today (five in
`packages/services/service-automation`). The gap is not "latent because nobody
could reach it"; it is "unreachable from today's in-repo assemblies, and reachable
from any conforming embedder, because the contract does not require the method."

## Why option 1 (refuse at the route), and why option 3 is not a complement

The fence put options 1 and 3 in scope and asked the measurement to choose. It
chose 1, and it rules 3 out rather than pairing with it:

- An assembly-time assertion would **promote an undeclared, deliberately optional
  extension into a required one**. That is a contract widening in everything but
  the file it is written in, and the contract lives in `packages/spec` — the
  territory this card explicitly does not carry authority over.
- ADR-0076 D9 is the standing decision that server-only extensions are
  runtime-detected rather than widened into `RestProtocol`. A boot assertion
  contradicts it.
- It would reject the partial protocol doubles that legitimately exist, and it
  could not cover the embedder path anyway, since `RestServer`'s constructor
  accepts anything typed `RestProtocol`.

And the house already answered this exact question, in this exact file:
`GET /meta/:type/:name/layers` — registered about fifty lines below `/references`,
in the same block, for the same class of missing extension — refuses with `501`
`NOT_IMPLEMENTED`, and its comment reasons verbatim as this card does. Three more
do the same (`getMetaDiagnostics`, `listDrafts`, `migrateStoredMetadata`).
`/references` was one of only two outliers.

## The change

```
501  { error: { code: 'NOT_IMPLEMENTED',
                message: 'protocol.findReferencesToMeta() is not available in this kernel' } }
```

The ADR-0112 **nested** envelope that #7035 converged the sibling `/meta` 501
refusals onto — never the bare-string or sibling-`code` dialects, which make
`body.error.code` read `undefined`. Deliberately **not** the shape `/layers` uses:
that one is the sibling-`code` dialect, counted by both shrink-only dialect
ratchets `check:route-envelope` holds on this file (`stringError: 44`,
`siblingCode: 69`), so copying it would have pushed a ratchet up. The nested shape
is counted by neither, and the ratchets are unmoved — verified, not assumed.

Message wording follows the three converted siblings
(`protocol.NAME() is not available in this kernel`).

## Does any caller's observed response change?

Yes, on one deployment shape, and only there. A protocol that *has* the method is
untouched: empty and non-empty results both still pass through verbatim as `200`.
What changes is the answer when the protocol has no such method — previously `200`
with an empty list, now `501`. No in-repo assembly produces that today (above).

## The pin

`packages/rest/src/meta-references-capability-gap.test.ts` asserts the thing the
defect actually was: **an absent capability does not produce the same body as a
genuine zero-references answer.** Both used to be `200 { references: [] }`.

Assertions are the ADR-0112 pair (`status` **and** `body.error.code`) plus the
message at the declared position — never a bare `toThrow`, which could not
separate "answered with the wrong body" from "did not refuse at all", and the
wrong body *is* the defect. A companion case keeps the healthy side honest, so the
inequality cannot be satisfied by breaking the success path instead of fixing the
broken one.

### Reverse verification — direction predicted in writing before running

Predicted: restoring the empty-body branch turns exactly three of the four new
cases red — the 501 assertion, the equivalence pin, and the machine-readable case
— while "a protocol that CAN answer is untouched" stays **green** (the ablation
does not touch the success path), and nothing else in the package moves. Observed,
exactly that:

```
 ❯ src/meta-references-capability-gap.test.ts (4 tests | 3 failed)
   × an absent capability answers 501 NOT_IMPLEMENTED at the ADR-0112 nested position
     AssertionError: expected 200 to be 501
   × ⭐ THE PIN — the capability gap and a genuine zero are not the same answer
     AssertionError: expected 200 not to be 200
   × the refusal is machine-readable by the SAME read as its `/meta` 501 siblings
     AssertionError: expected undefined to be 'NOT_IMPLEMENTED'
 Test Files  1 failed | 123 passed (124)
```

`expected 200 not to be 200` is the defect stating itself. The fix was committed
before the ablation and restored with `git checkout`, then proved byte-identical
to the committed state (`git diff --exit-code` empty).

## Zone 2 — the PM's assumptions, re-tested

**2a — PR #9324 did not close this. Confirmed, not inherited.** It is merged
(2026-08-17T14:38:10Z) and touched eight files, every one under
`packages/metadata-protocol`, `packages/objectql` or `.changeset` — **zero files in
`packages/rest`**. Its own tier-fence note records "no new refusal, no
response-shape change". It replaced a curated registry with a derived one *inside*
the protocol implementation, which cannot help a route that never calls it.

**2b — falsified. The references route is NOT the only limb with this shape.**
`GET /meta/:type/:name/audit` answers a missing `auditMetaItem` with
`res.json({ events: [] })` — the same capability gap rendered as a well-formed
empty answer, on a compliance surface, where it reads as "this item has no audit
trail". Filed separately, deliberately not a rider here. The sweep discriminates
rather than merely finding nothing: the same scan located four sibling limbs that
*do* refuse, so a zero was a possible outcome.

**2c — options 1 and 3 are not complements; see above.** The measurement chose,
and the reasoning is recorded here as the fence asked.

### One more finding, filed separately: the fix is necessary but not sufficient

Refusing at the route makes the **wire** honest. It does not by itself remove the
user-visible harm, because the consumer swallows it:
`objectui` `ResourceEditPage.tsx` catches every failure from `client.references()`
into `setRefs([])`, which renders the same "Nothing in the metadata graph points at
this item. Safe to delete." empty state, with only a `console.error`. So a truthful
`501` is currently collapsed back into the lie at the consumer. That is a second
defect, in a second repo, and it is filed rather than ridden on this PR — but the
producer is still the right place to fix the producer's half, and this half is
what makes the consumer's half fixable at all.

## Verification — all at `a412daaf8`, the final commit

```
pnpm --filter @objectstack/rest test        Test Files 124 passed (124)
                                                 Tests 2034 passed (2034)
pnpm --filter @objectstack/rest typecheck   tsc --noEmit, exit 0
pnpm exec eslint --no-inline-config [the two changed files]   exit 0
```

Gates re-derived from the **actual** changed paths with
`node scripts/pm/dispatch-gates.mjs`, which added several beyond the dispatched
list (the changeset family, and the convention-triggered family a new test file
pulls in). All pass:

```
check:authz-resolver                  OK
check:route-envelope                  OK   (rest-server.ts dialect ratchets unmoved)
check:dispatcher-error-vocabulary     OK   (0 awaiting a ledger entry)
check:cross-package-test-inputs       OK   (33 self-test cases; 12 packages declared)
check:changeset-gate-self-tests       OK
check:objectui-changeset              OK
check:query-options-erasure           OK   (baseline verified against 51a46a4: no files added)
check:engine-double-contract          OK   (319 pinned, 133 DEBT, 2 exempt)
check:where-matcher                   OK   (baseline verified against 51a46a4: no files added)
check:type-check-coverage             OK   (64/77 packages, 13 DEBT, 1 exempt)
check-adr-0087-registration           OK
check-changeset-no-major              OK
check-empty-changeset                 OK
check-cross-package-test-inputs.mjs   OK
check-affected-docs.mjs               OK   (197 self-test cases)
check-nul-bytes.mjs                   OK   (6118 files, no raw control bytes)
```

Ratchet family at the final head, after the full closure build
(`turbo run build --filter=./packages/* --filter=./packages/*/*`, 70/70 successful):

```
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 213.5s,
  1926 raw tsc error(s) total, none above its recorded number.
  surplus: none — every entry sits exactly at its measurement.
```

## Tier fence

Not tripped. No `packages/spec` edit, no `*.zod.ts`, no error-code ledger row —
`NOT_IMPLEMENTED` is already a registered code with canonical status 501
(`error-code-ledger.zod.ts`), so nothing is minted. Option 2 (a wire-level
`coverage` discriminator) was ruled out of scope by the fence and the measurement
did not point there: the honest distinction this route needed is a refusal, not a
new response key.

Declared file surface honoured: `packages/rest/src/rest-server.ts` (the references
route only), its test, and `.changeset/**`. Nothing else touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_