### PR TITLE
docs(qa): land the five re-verified environment facts in RUNNER.md

### DIFF
--- a/docs/qa/platform-checklist/RUNNER.md
+++ b/docs/qa/platform-checklist/RUNNER.md
@@ -96,6 +96,67 @@ contradicts it, and correct it here when it does.
   lock the console renders is a *different* gate (see
   `access-security.readonly-package-locks-studio`).
 
+- **`objectstack verify --rls` is a separate invocation — bare `verify` prints no RLS
+  section at all.** `runRlsProofs` runs only behind the flag
+  (`packages/cli/src/commands/verify.ts`: `rls: Flags.boolean({ default: false })`, the
+  proofs sit inside `if (flags.rls)`, and the report prints `if (rls)`). **Check:** the
+  last block of a bare run is the CRUD summary — `── 15 verified, 0 gaps, 0 FAILED, 1
+  needs-fixture, 7 skipped` on stock showcase — with no `PROVEN`/`HOLES` line anywhere.
+  Adding `--rls` appends the RLS block: `20 PROVEN (20 consistent, 0 HOLES)` over 23
+  objects, plus `9 of 9 declared position(s) probed`. ⛔ Do not cite plain `verify`
+  output as the oracle for an RLS clause — that run never consulted one.
+
+- **Playwright needs an explicit `executablePath` on these containers.**
+  `@playwright/test` 1.62.1 resolves chromium build **1234**; only **1194** is installed.
+  **Check:** `grep -A2 '"name": "chromium"' node_modules/playwright-core/browsers.json`
+  against `ls $PLAYWRIGHT_BROWSERS_PATH` (`/opt/pw-browsers` here, holding
+  `chromium-1194` / `chromium_headless_shell-1194` only). The stock
+  `examples/app-showcase/playwright.config.ts` sets no `executablePath`, so every test
+  dies at browser launch. Pass
+  `launchOptions.executablePath=/opt/pw-browsers/chromium-1194/chrome-linux/chrome` and
+  the same specs pass. **The discriminator is uniformity:** a launch/environment failure
+  takes down the whole run at once (`showcase-smoke.spec.ts` generates one test per
+  `SURFACES` entry — 31 today, so "31 failed" means all of them), while a product defect
+  fails selectively. ⛔ Do not file a whole-run red as a product defect before checking
+  the browser resolved.
+
+- **`?id=` on `/api/v1/meta/app` keys on the app NAME, never the package id.** The filter
+  matches `a.name === id` against the App document's identity (`packages/rest/src/rest-server.ts`),
+  and App declares no `id` of its own. `?id=com.example.showcase` (the package id, from
+  `objectstack.config.ts`) returns `{"items":[]}` — which reads exactly like "the app
+  metadata is gone", the highest-value false P0 shape there is. Real names: `showcase_app`
+  (showcase), `setup` / `studio` / `account` (platform built-ins). ⚠️ **An empty
+  `items` has two distinct causes** — a wrong spelling, or an app that is genuinely not
+  installed. `studio` is defined (`packages/platform-objects/src/apps/studio.app.ts`) but
+  the showcase does **not** install it, so `?id=studio` is legitimately empty there; a
+  stock admin list is `["showcase_app","setup","account"]`. **Check:** fetch
+  `/api/v1/meta/app` with no query first and read the names it actually returns, then
+  filter.
+
+- **`ss` is not installed in these containers — read liveness with `curl`, never a socket
+  table.** `ss` and `netstat` are both absent (`command not found`); `lsof` and `fuser`
+  are present. The trap is that the usual spelling hides the cause: `ss -ltn | grep :3000`
+  sends the error to stderr and prints nothing, so a **live** server is indistinguishable
+  from a dead one — empty stdout, exit 1, no clue why. **Check instead:**
+  `curl -s -o /dev/null -w '%{http_code}' http://localhost:PORT/api/v1/health` (substitute
+  the real port). This is "zero hits needs a positive control" applied to one tool: a
+  negative from a command that never ran is not evidence.
+
+- **A cold tree cannot boot the app from the console-build recipe alone.**
+  `pnpm objectui:build` runs `scripts/build-console.sh`, which builds the **console**, not
+  the framework CLI. On a fresh tree `packages/cli` has no `dist`, and the bare binary
+  then answers `Error: command dev not found` (exit 2) — a message that names neither the
+  cause nor the fix. **Check:** `node scripts/check-dev-prereqs.mjs`; it reports every
+  package whose declared `dist/` entry point is missing, and exits non-zero. **Fix:
+  `pnpm build`** — that is what the guard itself prescribes, and it is what turns the
+  guard green. ⛔ A targeted `turbo run build --filter=@objectstack/cli...
+  --filter=@objectstack/example-showcase...` is **not** enough: it makes the `objectstack`
+  binary resolve `dev`, but measured here it still left 8 of 67 packages unbuilt, so
+  `check:dev-prereqs` stays red and `pnpm dev` still refuses to boot. Note the root
+  `pnpm dev` script runs that guard **before** booting, so a runner who uses `pnpm dev`
+  gets the diagnostic and the fix; the cryptic `command dev not found` only appears when
+  the bare binary is invoked directly.
+
 ### Trap vocabulary (`traps` field)
 
 | trap | what it fakes | counter |
@@ -110,6 +171,7 @@ contradicts it, and correct it here when it does.
 | `dispatcher-vs-hono-route` | route exists in unit tests, 404s on the real server | oracle = live server trace, never simulated dispatch |
 | `wrong-panel` | feature looks missing on a sibling surface | item's `steps` name the exact surface; check it |
 | `wrong-persona` | admin privileges mask a guard | run guard checks as the non-privileged persona |
+| `absence-inference` | a missing flag/key/script read as a missing capability | follow the forwarding chain to where the default is actually decided, before writing the finding down. A scaffold's bare `objectstack dev` still serves the console: `serve`'s `ui` flag is `default: true, allowNo: true`, so `--no-ui` is the off switch and absence means on |
 
 ## Run records — the GitHub issue is the report
 

--- a/docs/qa/platform-checklist/RUNNER.md
+++ b/docs/qa/platform-checklist/RUNNER.md
@@ -112,9 +112,16 @@ contradicts it, and correct it here when it does.
   against `ls $PLAYWRIGHT_BROWSERS_PATH` (`/opt/pw-browsers` here, holding
   `chromium-1194` / `chromium_headless_shell-1194` only). The stock
   `examples/app-showcase/playwright.config.ts` sets no `executablePath`, so every test
-  dies at browser launch. Pass
-  `launchOptions.executablePath=/opt/pw-browsers/chromium-1194/chrome-linux/chrome` and
-  the same specs pass. **The discriminator is uniformity:** a launch/environment failure
+  dies at browser launch — the error names the **headless-shell** variant it wanted
+  (`Executable doesn't exist at .../chromium_headless_shell-1234/...`), which is the
+  signature to recognise. Pass `launchOptions.executablePath=/opt/pw-browsers/chromium`
+  and the same specs pass (verified: Playwright launches through it, reporting Chromium
+  141.0.7390.37, and drives a real page). ⚠️ Use that **alias**, not the versioned
+  `chromium-1194/chrome-linux/chrome` beneath it: `/opt/pw-browsers/chromium` is a
+  symlink maintained by the image build, so it still resolves after the image moves to
+  1234, while the versioned literal stops existing at exactly that moment — and a dead
+  path copied out of this section is the `absence-inference` trap one level up.
+  **The discriminator is uniformity:** a launch/environment failure
   takes down the whole run at once (`showcase-smoke.spec.ts` generates one test per
   `SURFACES` entry — 31 today, so "31 failed" means all of them), while a product defect
   fails selectively. ⛔ Do not file a whole-run red as a product defect before checking


### PR DESCRIPTION
Fixes #9386

Docs-only. Lands the five environment facts the #9296 QA wave paid container time to
learn into the `Environment facts the runner should not re-derive` section of
`docs/qa/platform-checklist/RUNNER.md`, plus the `absence-inference` row in the trap
vocabulary table.

Each fact is written as something the next runner can **check** and that **changes what
they do**: a mechanism, a concrete check command, and the action. No run narrative.

## Every fact was re-measured against this tree, not transcribed

Verified at `51a46a440` (= `origin/main` at branch time); gate union re-run at head
`adc9de82e`. **Three of the five needed correcting**, which is why the card asked for
re-verification.

| # | fact | verdict |
|---|---|---|
| 1 | `verify --rls` is a separate invocation | **confirmed, unchanged** |
| 2 | Playwright needs an explicit `executablePath` | **confirmed**; prescribed path hardened, see follow-up |
| 3 | `?id=` on `/api/v1/meta/app` keys on the app name | mechanism confirmed, **app list corrected** |
| 4 | `ss` blindness | conclusion confirmed, **mechanism was wrong** |
| 5 | cold tree cannot boot from the console-build recipe | symptom confirmed, **prescription was wrong, rider stale** |

**1 — confirmed.** Source: `packages/cli/src/commands/verify.ts` gates the proofs behind
`rls: Flags.boolean({ default: false })` and prints the report only `if (rls)`. Measured
live on showcase: bare `verify` ends at `15 verified, 0 gaps, 0 FAILED, 1 needs-fixture,
7 skipped` with no `PROVEN`/`HOLES` line; `--rls` appends `20 PROVEN (20 consistent, 0
HOLES)` over 23 objects and `9 of 9 declared position(s) probed` — matching the card's
numbers exactly.

**2 — confirmed.** `playwright-core@1.62.1`'s `browsers.json` pins chromium revision
`1234` (browserVersion 151.0.7922.34); `/opt/pw-browsers` holds only `chromium-1194`
(Chromium 141.0.7390.37). The stock showcase `playwright.config.ts` sets no
`executablePath`. The "31" is verified as exactly the number of `SURFACES` entries in
`showcase-smoke.spec.ts`. I wrote the **uniformity discriminator** (whole run red =
environment, selective = product) rather than pinning the brittle count as the signal.

**3 — mechanism confirmed, app list corrected.** `rest-server.ts` matches
`a.name === appIdFilter`, so the package id `com.example.showcase` yields `items: []`.
But the card's name list is misleading: `studio` is **not installed on stock showcase**, so
`?id=studio` is legitimately empty there too. An empty `items` therefore has two distinct
causes, and the file now says so and tells the runner to read the unfiltered list first.

**4 — conclusion confirmed, mechanism corrected.** `ss` does not "return empty" here — it
is **not installed at all**, and neither is `netstat` (`lsof` and `fuser` are present).
Measured against a live listener: `ss -ltn 2>/dev/null | grep :PORT` gives empty stdout and
exit 1 while `curl` returns 200. The operational rule is unchanged and stronger, but the
stated mechanism would have sent a runner looking for a socket-table quirk that does not
exist.

**5 — symptom confirmed, prescription wrong, rider stale.** `pnpm objectui:build` builds
the console only, and a cold tree has no `packages/cli/dist`, so the bare binary answers
`Error: command dev not found` (exit 2) — verbatim as filed. Two corrections:

- The card's prescribed step, `turbo run build --filter=@objectstack/cli...
  --filter=@objectstack/example-showcase...`, is **not sufficient**. Measured: it makes the
  binary resolve `dev`, but leaves **8 of 67** packages unbuilt, so `check:dev-prereqs`
  still exits 1 and `pnpm dev` still refuses. `pnpm build` (71 tasks) is what turns it
  green — and is what the guard itself prescribes.
- The rider asking RUNNER.md to point runners at the cold-tree `objectui:build` ordering
  bug in #9307 is **stale**: that card is no longer open and its remedy shipped in PR
  #9396. `scripts/build-console.sh` now builds the client through turbo and keys its guard
  on `dist/index.d.ts`. Writing it in would have told runners to expect a failure that no
  longer happens, so it is deliberately omitted.

The genuinely useful addition here is that the root `pnpm dev` script runs
`check:dev-prereqs` first, so the cryptic error only appears when a runner bypasses it by
invoking the bare binary.

## Follow-up commit `adc9de82e` — durability of the fact 2 copy-paste value

Review raised that prescribing the versioned literal
`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` rots at the next image bump, inside
the one section contracted to be trusted without re-derivation. Verified rather than
assumed, and the change is made:

- `/opt/pw-browsers/chromium` is a symlink maintained by the image build, resolving to
  `chromium-1194/chrome-linux/chrome` today.
- **Playwright accepts a symlinked `executablePath`** — launched through the alias with
  1.62.1, got Chromium 141.0.7390.37 and drove a real page. So the hazard-free option is
  also a working one; no trade-off to record.
- Control leg confirms the mismatch is live: a default launch fails with
  `Executable doesn't exist at .../chromium_headless_shell-1234/...`. That names the
  **headless-shell** variant, so the file now records that as the signature to recognise.

The prescribed value is now the alias; the `1194` / `1234` numbers stay where they do
diagnostic work — the mechanism prose and the `grep`/`ls` check.

## Trap row

`absence-inference` — a missing flag/key/script read as a missing capability. Counter
verified: `serve`'s `ui` flag is `default: true, allowNo: true`, so `--no-ui` is the off
switch and a scaffold's bare `objectstack dev` still serves the console. Line numbers
deliberately omitted; the flag spelling is greppable and does not drift.

## Not folded in

The two facts offered as dispatch input are **not** among the five and are not written in.
Worth recording: the "turbo replays its cache across worktrees, so a fresh worktree is not
cold" observation did **not** hold here — this fresh worktree built `1 cached of 55`, i.e.
effectively cold. It looks condition-dependent rather than a standing environment fact, so
it would have been a poor entry in a section whose contract is that entries are trusted
without re-derivation.

## Verification

Gate derivation for `docs/qa/platform-checklist/RUNNER.md` names no family (a `silent`
verdict, not a clearance). Re-derived from the actual changed path and re-run on the new
head `adc9de82e` with a clean tree: `check:nul-bytes` PASS, `check:platform-checklist`
PASS (15 areas, 190 items), `check:doc-anchors` PASS (244 fragment links resolve),
`check:doc-authoring` PASS (376 files clean).

No `areas/*.json` edits, no `.claude/skills/**`, no CI posture changes — the card's three
scope fences hold.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_
