### PR TITLE
docs(docs-audit): record that the periodic full-audit backstop is not running

### DIFF
--- a/scripts/docs-audit/README.md
+++ b/scripts/docs-audit/README.md
@@ -403,6 +403,19 @@ monthly / per-release) catches drift the CI gate missed — it runs the
    meant to cover. A backstop has to run `--all`: all 178 hand-written docs (run
    `check-audit-scope.mjs` for today's number rather than trusting this one).
 
+3. **And the obvious cheap substitute is not a backstop either.** When the backstop is
+   missing, the tempting one-line fix is to widen the audit's scope back to the coarse
+   `packageMentionDocs` set part 1 still emits. Measured across the 8 most recent
+   `packages/**`-touching commits on `main`: it is wider (21 pages vs 5 on `a4331227b`)
+   but it is **not a superset** — in every one of the 8, between 3 and 7 pages present in
+   the precise `docs` set are absent from `packageMentionDocs`
+   (`api/error-catalog.mdx`, `automation/approvals.mdx`, `api/plugin-endpoints.mdx`,
+   `data-modeling/relationships.mdx` among them). That is #9192's finding restated: the
+   two sets miss in *different* directions, because the coarse one is a dependency-graph
+   proxy and pages documenting a change through the SDK surface never name the
+   implementing package. Swapping to it trades one incomplete set for another and loses
+   pages the precise scope gets right. Only `--all` is a backstop.
+
 ---
 
 **Cost note:** a full audit is ~2 agents per doc — measured at ~2.8M output tokens /

--- a/scripts/docs-audit/README.md
+++ b/scripts/docs-audit/README.md
@@ -370,10 +370,12 @@ monthly / per-release) catches drift the CI gate missed — it runs the
    re-deriving them:
 
    - **GitHub Actions** — no workflow runs this audit at all. Of the 31 workflows
-     registered on the repo, the 11 carrying a `schedule:` trigger (`codeql`,
-     `coverage-nightly`, `cut-rc`, `engine-split-metric`, `prerelease-pin-watch`,
-     `publish-smoke`, `rerun-safety-nightly`, `scaffold-e2e`, `showcase-smoke`, `stale`,
-     `validate-deps`) are all unrelated.
+     registered on the repo, the 10 carrying a `schedule:` trigger (`codeql`,
+     `coverage-nightly`, `engine-split-metric`, `prerelease-pin-watch`, `publish-smoke`,
+     `rerun-safety-nightly`, `scaffold-e2e`, `showcase-smoke`, `stale`, `validate-deps`)
+     are all unrelated. Derive that list with `grep -rl '^\s*schedule:' .github/workflows/`
+     rather than copying it: an unanchored grep for `schedule:` also matches `cut-rc.yml`,
+     whose only hit is a comment saying it deliberately has no schedule.
      ⚠️ **Read the registered workflow list and its run history, not the YAML on disk.**
      The two disagree in *both* directions: a workflow can be registered in Actions with
      no file on `main` (`matrix-aggregate-experiment.yml` is, today), and a scheduled

--- a/scripts/docs-audit/README.md
+++ b/scripts/docs-audit/README.md
@@ -352,17 +352,60 @@ Always follow a run with the docs build gate:
 pnpm --filter @objectstack/docs build   # must compile all pages clean
 ```
 
-## 4. Scheduled routine — periodic backstop
+## 4. Scheduled routine — periodic backstop ⛔ NOT RUNNING
 
-A cron routine (created via the `schedule` skill) runs on a cadence (default monthly /
-per-release) to catch drift the CI gate missed. It computes the change-scoped doc list
-since the last audit, runs the `docs-accuracy-audit` workflow on it, runs the build, and
-opens a PR when there are fixes. See the routine prompt for the exact steps.
+**Measured 2026-08-18: no live schedule runs this audit.** This section previously
+described the backstop in the present tense; it does not exist, so **it cannot be cited
+as coverage for what the part-1 scope leaves out.** Recorded rather than fixed on the
+spot: standing up a periodic LLM audit spends real budget on a cadence, which is the
+maintainer's call.
+
+The intended design, for whoever stands it up: a cron routine on a cadence (default
+monthly / per-release) catches drift the CI gate missed — it runs the
+`docs-accuracy-audit` workflow, runs the build, and opens a PR when there are fixes.
+
+**Two independent defects in the old text, both worth keeping in view:**
+
+1. **It never ran.** Checked four ways, all negative — repeat these rather than
+   re-deriving them:
+
+   - **GitHub Actions** — no workflow runs this audit at all. Of the 31 workflows
+     registered on the repo, the 11 carrying a `schedule:` trigger (`codeql`,
+     `coverage-nightly`, `cut-rc`, `engine-split-metric`, `prerelease-pin-watch`,
+     `publish-smoke`, `rerun-safety-nightly`, `scaffold-e2e`, `showcase-smoke`, `stale`,
+     `validate-deps`) are all unrelated.
+     ⚠️ **Read the registered workflow list and its run history, not the YAML on disk.**
+     The two disagree in *both* directions: a workflow can be registered in Actions with
+     no file on `main` (`matrix-aggregate-experiment.yml` is, today), and a scheduled
+     workflow that GitHub auto-disabled after 60 days of repo inactivity leaves its file
+     byte-identical. "The file is there" cannot answer "is it running" — the same
+     read-a-conclusion-off-a-field-that-cannot-carry-it failure this docs-audit subsystem
+     keeps paying for.
+   - **Routines** — the Claude Code Remote `list_triggers` tool lists every Routine the
+     agent-seat account owns, and this is the surface that answers the question (it was
+     once written off as unreadable by any agent; it is not). The only cron Routine is the
+     hourly triage seat, `18 * * * *`. There is no docs-audit Routine, enabled *or*
+     disabled. A cron Routine is never hidden by the `include_completed` filter, so the
+     absence is real rather than a listing artifact.
+   - **The creation mechanism this section named is gone** — there is no `schedule` skill
+     in `.claude/skills/`.
+   - **No trace of a periodic run.** Repo history holds exactly three docs-accuracy audit
+     PRs (#3243, #4219, #4312), every one hand-initiated against a named issue family, the
+     most recent 2026-07-31. Nothing on a cadence.
+
+2. **A change-scoped run is not a backstop.** The old text had the routine compute "the
+   change-scoped doc list since the last audit", while the cost note below calls part 4 the
+   "periodic **full** backstop". Those are two different runs and only the second is a
+   backstop — a change-scoped list is derived by the very anchor heuristic whose misses
+   the backstop exists to catch, so scoping it that way re-inherits the blind spot it is
+   meant to cover. A backstop has to run `--all`: all 178 hand-written docs (run
+   `check-audit-scope.mjs` for today's number rather than trusting this one).
 
 ---
 
 **Cost note:** a full audit is ~2 agents per doc — measured at ~2.8M output tokens /
 ~160 agents when the scope was 128 docs, and the hand-written set is 178 today (run
 `check-audit-scope.mjs` for the current number; don't trust a count written down here).
-Always prefer the change-scoped list (`affected-docs.mjs`) over `--all` except for the
-periodic full backstop.
+Always prefer the change-scoped list (`affected-docs.mjs`) over `--all`; reach for `--all`
+only for a deliberate full audit. (This sentence used to name the periodic full backstop as
+the exception — see part 4: that backstop is not running.)


### PR DESCRIPTION
Fixes #9231

## Answer: the backstop does not exist

This card was a verification first. The answer is **no** — there is no live schedule running the docs-accuracy `--all` full audit, and there never was one.

`scripts/docs-audit/README.md` §4 described a cron routine on a monthly / per-release cadence. Measured 2026-08-18, four independent ways, all negative:

| check | result |
|:--|:--|
| GitHub Actions workflows | No workflow runs this audit at all. 31 workflows registered on the repo; the 10 carrying a `schedule:` trigger are all unrelated. |
| Routines (`list_triggers`) | The only cron Routine on the agent-seat account is the hourly triage seat, `18 * * * *`. No docs-audit Routine, enabled **or** disabled. |
| The named creation mechanism | The `schedule` skill §4 pointed at is not in `.claude/skills/`. |
| Trace of any periodic run | Exactly three docs-accuracy audit PRs in repo history (#3243, #4219, #4312), each hand-initiated against a named issue family, most recent 2026-07-31. No cadence. |

Two notes on method, because the card was explicitly about not reading a conclusion off a field that cannot carry it:

- **The scheduled-workflow list was derived, not copied — and copying it was wrong.** The first push of this PR said 11 and included `cut-rc`, inherited from an earlier triage comment on the card. On `main`, `cut-rc.yml` has no `schedule:` trigger; its only `schedule:` match is a comment saying it deliberately has none, which an unanchored grep counts. Ten workflows carry a real one. The conclusion is unchanged, but consuming a stated list as authoritative is precisely the failure this card measures, so the README now carries the derivation command rather than the list alone.
- **The workflow list was read from the Actions API, not from disk.** The two disagree in both directions: `matrix-aggregate-experiment.yml` is registered in Actions with no file on `main` today, and a scheduled workflow auto-disabled after 60 days of inactivity leaves its file byte-identical. Neither view alone answers "is it running".
- **The Routines surface is readable by an agent.** The earlier triage note on this card recorded that Routine state is "readable only from the maintainer's Routines UI — no agent-facing surface can confirm it". That is falsified: `list_triggers` enumerates every Routine the account owns, and a cron Routine is never hidden by the `include_completed` filter, so its absence is a real reading rather than a listing artifact.

## Second finding: change-scoped is not a backstop

Independent of whether it ran. §4 scoped the routine to "the change-scoped doc list since the last audit", while the cost note in the same file calls part 4 the "periodic **full** backstop". Those are different runs and only the second is a backstop — a change-scoped list is derived by the very anchor heuristic whose misses the backstop exists to catch, so scoping it that way re-inherits the blind spot it is meant to cover.

So the leg was doubly unsound: absent, and mis-specified even as written. For the record, `--all` itself is sound as a coverage mechanism — it enumerates all 178 hand-written docs, verified against the audit workflow's own inline scope via `check-audit-scope.mjs`.

## Third finding: the named fallback is not a backstop either

The card names a cheap fallback — point the audit's args wiring at `packageMentionDocs`. It was not implemented (see below), and it also would not work. Measured across the 8 most recent `packages/**`-touching commits on `main`, the coarse set is wider but **not a superset**:

| commit | precise `docs` | `packageMentionDocs` | in `docs` but NOT in `packageMentionDocs` |
|:--|--:|--:|--:|
| `a4331227b` | 5 | 21 | 3 |
| `48032c927` | 9 | 31 | 3 |
| `19539b4b2` | 41 | 119 | 6 |
| `40d5b2d4c` | 45 | 120 | 6 |
| `42d899071` | 47 | 120 | 7 |

In every one of the 8, between 3 and 7 pages the precise scope correctly finds are absent from the coarse set — `api/error-catalog.mdx`, `automation/approvals.mdx`, `api/plugin-endpoints.mdx`, `data-modeling/relationships.mdx` among them. That is #9192's own finding restated: the two sets miss in *different* directions, because the coarse one is a dependency-graph proxy and pages documenting a change through the SDK surface never name the implementing package.

So the fallback trades one incomplete set for another **and loses pages the current scope gets right**. Only `--all` is a backstop. This is a fact the PM should have before revisiting the ruling, not a recommendation.

## What this changes

Documentation only. §4 now states the measured fact, carries the four checks so the next person re-reads them instead of re-deriving them, and keeps the intended design for whoever stands the routine up. The cost note no longer names a backstop that is not running.

⛔ Deliberately **not** done, both being the maintainer's / PM's call:
- No scheduled full-audit workflow or Routine was created or re-enabled — a periodic LLM audit spends real budget on a cadence.
- The cheap fallback the card names (pointing the audit's args wiring at `packageMentionDocs`) is **not** implemented. Choosing it means revisiting the #9192 option-A ruling, whose second leg this PR shows is absent.

`scripts/docs-audit/affected-docs.mjs` was not touched — it is held by #9294.

## Verification

Gate union re-run on the final commit `673885abd`, working tree clean:

```
node scripts/docs-audit/check-affected-docs.mjs
  ✓ affected-docs self-test: 197 cases pass.
node scripts/docs-audit/check-audit-scope.mjs
  ✓ docs-accuracy-audit scope is in sync with content/docs/: 178 hand-written doc(s).
  ✓ release-owned pages are in scope and read-only: 9 page(s) under content/docs/releases/
node scripts/check-nul-bytes.mjs
  check-nul-bytes: OK (scanned 6122 text file(s) ... no raw ASCII control bytes)
```

Gate family derived from the changed path with `node scripts/pm/dispatch-gates.mjs scripts/docs-audit/README.md`, which named `check-affected-docs.mjs` via the `scripts/docs-audit/**` trigger in `docs-drift-check.yml`.

No changeset: this is an internal tooling README, publishing nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_


---
_Generated by [Claude Code](https://claude.ai/code)_