### PR TITLE
docs: re-derive the three scaffolded-project transcripts after the description drop (#9342)

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -495,7 +495,6 @@ os info --json         # JSON output for tooling
 
   My App v0.1.0
   my-app
-  Minimal ObjectStack environment — a clean slate for building.
     Namespace: my_app
     Type: app
 

--- a/content/docs/deployment/validating-metadata.mdx
+++ b/content/docs/deployment/validating-metadata.mdx
@@ -538,7 +538,6 @@ A clean run walks the registry and reports timing:
   ✓ Validation passed (64ms)
 
   Support Desk v0.1.0
-  Minimal ObjectStack environment — a clean slate for building.
 
   Data: 2 Objects  6 Fields
   UI: 1 Apps  1 Views  1 Actions

--- a/content/docs/getting-started/build-with-claude-code.mdx
+++ b/content/docs/getting-started/build-with-claude-code.mdx
@@ -290,7 +290,6 @@ Once it's clean:
   ✓ Validation passed (37ms)
 
   Support Desk v0.1.0
-  Minimal ObjectStack environment — a clean slate for building.
 
   Data: 2 Objects  6 Fields
   UI: 1 Apps  1 Views  1 Actions


### PR DESCRIPTION
Fixes #9342

#9263 (merged via PR #9335) makes `create-objectstack` **drop** the blank template's own `manifest.description` at scaffold time. Three docs pages still quoted that line inside a **scaffolded-project** transcript, so all three had gone stale together.

Both printers guard on presence (`packages/cli/src/commands/validate.ts:294`, `packages/cli/src/commands/info.ts:64`), so the row does not become empty or `undefined` — **it disappears entirely**. Confirmed in my own runs, not inherited.

## Re-derived from real runs — not hand-edited

CLI and scaffolder built at `origin/main` (`b2d9e04d1`); both fixtures scaffolded from the `blank` template with the built `create-objectstack`.

**Fixture A — Support Desk (`os validate`).** Scaffolded `support-desk`, then applied `build-with-claude-code.mdx`'s **own listings**: the ticket object, the resolve action, the ticket views and the Support app, wired through the `src/objects/index.ts` barrel and the `actions:` / `views:` / `apps:` arrays exactly as the page's prose describes.

```
  ✓ Validation passed (180ms)

  Support Desk v0.1.0

  Data: 2 Objects  6 Fields
  UI: 1 Apps  1 Views  1 Actions
  Runtime: 3 plugins
```

**Fixture B — my-app (`os info`).** A different command surface, which is why this page could not be fixed from #9263's one-page framing. Scaffolded `my-app`, added the ticket object, one view and one action (no app), reproducing `1 Views  1 Actions` and both object rows verbatim.

```
◆ Info
────────────────────────────────────────

  My App v0.1.0
  my-app
    Namespace: my_app
    Type: app

  Data: 2 Objects  6 Fields
  UI: 1 Views  1 Actions
  Runtime: 3 plugins

  Objects:
    my_app_note (2 fields, user) — Note
    my_app_ticket (4 fields, user) — Ticket

  Loaded in 88ms
```

**Verified mechanically, not by eye.** Each edited block was diffed line by line against its run after normalising the config path and the timings. All three match; the only residual difference is `Loaded in 59ms` vs `88ms` on `cli.mdx`. Timings and the sanitised `/path/to/...` are **machine identity, not fixture identity**, and are left as #9151 / #9262 left them.

## #9152's work does reconstruct

The Support Desk fixture was built **only** from `build-with-claude-code.mdx`'s own listings, and it reproduces every documented row — `2 Objects  6 Fields`, `1 Apps  1 Views  1 Actions`, `3 plugins`, and `Running author-time rules (41)`. The self-reconstructibility PR #9262 established is intact; no regression to report there.

## Scope

Three line deletions, nothing else. Deliberately untouched:

- `cli.mdx`'s *Data migrations* section — its row is #9382's work, already verified on that card.
- `cli.mdx`'s `os compile` block — re-derived by #9092 / PR #9151.
- `cli.mdx:1461`'s manifest-configuration example, which still shows a `description:` key. That is a hand-authored config, not a scaffolded-project transcript, and `description` remains an authorable manifest field — only the scaffolder's carry-over went away.

The card's own acceptance check now holds: `git grep -n "Minimal ObjectStack environment" -- content/docs/` returns no hits.

## Gates

Union re-derived from the actual changed paths with `node scripts/pm/dispatch-gates.mjs`, run **after** the final commit, at `e92291332` — all green:

`check:nul-bytes` · `check:docs-audit-scope` · `check:docs-redirects` · `check:role-word` · `spec check:empty-state` · `spec check:liveness` · `spec check:strictness-ledger` · `spec check:variant-docs` · `check-cross-package-test-inputs`

Plus a control-byte self-scan over the three changed files (no hits).

Docs-only, releases nothing — `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_