### PR TITLE
docs(cli): give `os migrate duplicates` its row and section in the data-migration docs

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -658,6 +658,7 @@ where the data lives.
 | `os migrate value-shapes` | Scan stored reference and structured-JSON field values against the platform's value contract, and record the deployment's migration flag when clean |
 | `os migrate summary-nulls` | Backfill roll-up `count` / `sum` columns still stored as `NULL` on parent rows created before the insert-time seed. Repairs values; no flag, nothing depends on it having run |
 | `os migrate meta --stored` | Replay the metadata conversion chain over this deployment's `sys_metadata` rows and rewrite the ones still carrying a pre-protocol shape. Hygiene, not a gate — nothing depends on it having run |
+| `os migrate duplicates` | Report business identifiers already minted twice across the organization partitions — a read-only inventory as JSON on stdout. Renumbers nothing and writes nothing at all; run it before the boot-time tenancy repair, which overwrites part of the evidence |
 
 ```bash
 os migrate files-to-references            # Dry run: full report, writes nothing
@@ -922,6 +923,69 @@ It returns the same report the CLI renders, and takes the same posture:
 not one item — and answers `403` otherwise. Flows need no extra setup on this
 path: the server already holds a live automation engine, so the run resolves the
 executor registry the conflict guard needs from the process it is running in.
+
+#### `os migrate duplicates`
+
+The one command in this family that is **not** a migration: it writes nothing
+under any flag, and there is nothing to apply. It inventories business
+identifiers the platform already handed out twice — one value held by rows in
+more than one of the organization partitions a
+[`unique: 'organization'`](/docs/data-modeling/indexing) index separates.
+
+The gap it reports is a real one and predates the repair for it. A seeded row
+written before any organization existed carries `organization_id = NULL`, an API
+row carries the signed-in organization, and the partitioned unique index
+`(COALESCE(organization_id, '__global__'), field)` does not bite across the two
+— so each side allocated from its own autonumber counter and both could mint
+`CASE-00001`.
+
+```bash
+os migrate duplicates                                  # The report — JSON on stdout
+os migrate duplicates > duplicates-2026-08-18.json     # Archive it; the file is the deliverable
+os migrate duplicates --object crm_case                # Restrict the scan to one object
+os migrate duplicates --database-url postgres://…      # Inspect a database directly
+```
+
+Output is **always** the JSON document. There is no `--json` flag and no
+human-rendered mode — the report is the deliverable, you archive it, and a
+second renderer would be a second contract to keep true. The boot behind it is
+read-only: no DDL, no seed, and a missing SQLite file is not brought into
+existence. A full run leaves the rows and the counters byte-identical, so
+pointing it at production changes nothing about production.
+
+**Run it before the repair reaches this deployment.** On its first boot after
+the upgrade, a single-organization deployment adopts those untenanted seed rows
+into its organization and merges the two counters — which is the same state
+this report reads. Half of what it can tell you does not survive that:
+
+| Reported | Survives the repair? |
+| :--- | :--- |
+| **The duplicates themselves** — every value held across two partitions, with the id, organization and creation time of each holder | **Yes.** The repair deliberately refuses to adopt a row whose identifier is already taken in the destination partition, so those rows keep `organization_id = NULL` and stay visible |
+| **The live condition** — an object still running a global counter beside an organization-scoped one, and therefore about to mint more duplicates | **No.** The repair merges the two counters and deletes the global one. Once that has happened, this line can never be produced again |
+
+Running it afterwards is still worth doing — the inventory is what you act on,
+and it is complete either way. What you cannot recover is the forward-looking
+half.
+
+A deployment holding **more than one organization** is skipped by that repair
+rather than guessed at: there is no derivable answer to which organization owns
+an untenanted row, so it logs the condition and the remedy and changes nothing.
+Its evidence therefore stays intact, and this report stays reproducible until
+somebody stamps those rows by hand.
+
+Nothing is renumbered, here or by the repair. A business identifier that has
+already left the building — on an invoice, in a notification, in another
+system's idempotence key — is not the platform's to rewrite, so both sides
+report and stop. Deciding what a duplicate should become is yours.
+
+The scan covers every organization-scoped object and, on it, every field that
+is an identifier: `type: 'autonumber'`, or carrying any `unique` spelling.
+Platform objects are **not** filtered out — that filter is right for a repair
+and wrong for a report, which must not silently omit a real duplicate. Anything
+that could not be probed is listed under `skipped` with its reason, because
+"found nothing" and "never looked" must not read the same. For the same reason
+a driver with no raw SQL seam (memory, MongoDB) fails the whole run with
+`error: "no_sql_seam"` rather than returning an empty inventory.
 
 ### Scaffolding
 


### PR DESCRIPTION
Fixes #9382

`os migrate duplicates` shipped as an operator command but never reached the operator docs. The data-migration table in `content/docs/deployment/cli.mdx` listed its four siblings and not it, and no section described it.

## What landed

**One table row**, appended after `os migrate meta --stored`, and **one `#### os migrate duplicates` section** at the end of the Data migrations block.

Both are derived from the command as it exists on `main`, not from the card's prose. I read `packages/cli/src/commands/migrate/duplicates.ts` and re-ran the derivation rather than transcribing:

- read-only boot (`deferSchemaDdl` + `readOnlyProbe`) — no DDL, no seed, and a missing SQLite file is not created;
- JSON on stdout always, with no `--json` flag and no human renderer;
- flags `--object` and `--database-url`;
- the `no_sql_seam` refusal on a driver with no raw SQL seam, rather than an empty inventory;
- `skipped` targets carried with a reason.

### Changes from the row the card suggested

The card's suggested wording was accurate but did not match the table's real shape, so I rewrote it:

- **dropped the `#8686` reference** — none of the four sibling rows carries an issue number, so the row now names the repair functionally ("the boot-time tenancy repair");
- **no trailing period**, matching all four siblings;
- **reordered** so the read-only nature leads, since this is the one entry in a table whose own introduction says "a *data* migration rewrites rows" that rewrites nothing.

## The ordering claim, re-measured

The load-bearing sentence for an operator is the direction, so I confirmed it from the tests rather than from the card. `duplicates.pre-repair.test.ts` runs the real `backfillSeedTenancy` between two reports and measures both halves:

- **the live condition does not survive** — the repair merges the two counters and deletes the global one, so `liveConditions` goes to `[]` and that line can never be produced again;
- **the inventory does survive** — the repair refuses to adopt a row whose identifier is already taken in the destination partition, so those rows keep `organization_id = NULL`.

All three "verified facts" the card listed were re-confirmed against the current tree; none had drifted. `duplicates.integration.test.ts` pins the whole run, boot included, as writing nothing.

One fact the card did not carry, added because it changes what an operator does: a **multi-organization** deployment is skipped by that repair rather than guessed at, so its evidence stays intact and the report stays reproducible.

## Deliverable 2 has no target — filed as #9441

The card's second half asks for a cross-reference "wherever the #8686 / PR #8832 tenancy backfill is described for operators". I searched for that page and it does not exist: greps over `content/docs/**` for `backfillSeedTenancy`, `__global__`, seed tenancy, tenancy split and `organization_id = NULL` find no page describing the repair at all. It runs automatically at `kernel:ready` with no docs section, no preview and no opt-out.

The nearest neighbours are unrelated — `tenancy-modes.mdx`'s "Backfill for pre-existing users" is the **membership** backfill (`OS_SKIP_MEMBERSHIP_BACKFILL`), and `cli.mdx`'s only other `__global__` mention is the `replace_unique_index` row.

Rather than invent a home for the cross-reference, I filed #9441 to document the backfill for operators first. That is the prerequisite for this card's second deliverable. ⚠️ Reviewer's call: if #9382 should stay open tracking that residual instead of closing on merge, change the first line above to `Part of` before merging.

The ordering guidance itself is **not** lost in the meantime — it is written into the new section, which is where an operator actually meets the command.

## Contested-file check

`cli.mdx` carries three live fences. This diff is **58 insertions, 0 deletions**, in two pure-insertion hunks at lines 661 and 927:

```
@@ -660,0 +661 @@
@@ -925,0 +927,57 @@
```

The fenced regions sit at lines 383 (`os compile`, PR #9151), 482 (`os info`, issue #9430) and 498 (the environment transcript line PR #9429 deletes). All are above both hunks, and with zero deletions a textual conflict is mechanically impossible. Nothing in those regions was read, re-added or altered.

## Gates

Nine families derived from the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/deployment/cli.mdx`, all run **after** the final commit and green at `a86d197f7`:

```
[0] pnpm check:docs-audit-scope
[0] pnpm check:docs-redirects
[0] pnpm check:role-word
[0] pnpm check:cross-package-test-inputs
[0] pnpm --filter @objectstack/spec run check:empty-state
[0] pnpm --filter @objectstack/spec run check:liveness
[0] pnpm --filter @objectstack/spec run check:strictness-ledger
[0] pnpm --filter @objectstack/spec run check:variant-docs
[0] node scripts/check-cross-package-test-inputs.mjs
```

`check:role-word` matters here: `cli.mdx` sits in the ratchet baseline at 1 occurrence, so the new prose deliberately avoids the reserved word. Re-measured at 1, unchanged.

MDX parse confirmed by re-running `fumadocs-mdx` over the edited tree. Control-character scan clean.

Docs-only, publishes nothing, so `skip-changeset` applies — the label is applied on this PR rather than a changeset added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_