### PR TITLE
feat(spec): declare viewMode on GanttConfigSchema (#9463)

### DIFF
--- a/.changeset/gantt-viewmode-declared.md
+++ b/.changeset/gantt-viewmode-declared.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": minor
+---
+
+Declare `viewMode` on `GanttConfigSchema` (the `gantt` view block): an optional enum of the gantt renderer's measured granularity vocabulary — `'day' | 'week' | 'month' | 'quarter' | 'year'`. The member list is measured from objectui `plugin-gantt` (`GanttView.tsx` `GanttViewMode` / `VIEW_MODES`), not invented. No spec-side default on purpose: the renderer resolves an omitted `viewMode` through its persisted-layout seeding before falling back to `'day'`, so a materialized default would read as an explicit author choice. Spec half of the objectui#5074 both-branches ruling (#9463); an out-of-vocabulary value is now refused at authoring instead of silently falling back.

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -332,6 +332,7 @@ Gallery/card view configuration
 | **tooltipFields** | `(string \| { field: string; label?: string })[]` | optional | Fields to surface in the hover tooltip, in display order |
 | **quickFilters** | `{ field: string; label?: string; options?: (string \| object)[] }[]` | optional | Multi-select filter dropdowns rendered above the chart |
 | **autoZoomToFilter** | `boolean` | optional | When true (default), filtering zooms the range to the filtered tasks |
+| **viewMode** | `Enum<'day' \| 'week' \| 'month' \| 'quarter' \| 'year'>` | optional | Timeline granularity — one column per day/week/month/quarter/year (also the resource-view column granularity; renderer default 'day') |
 
 
 ---

--- a/packages/spec/authorable-surface/ui.json
+++ b/packages/spec/authorable-surface/ui.json
@@ -530,6 +530,7 @@
     "ui/GanttConfig:titleField",
     "ui/GanttConfig:tooltipFields",
     "ui/GanttConfig:typeField",
+    "ui/GanttConfig:viewMode",
     "ui/GanttQuickFilter:field",
     "ui/GanttQuickFilter:label",
     "ui/GanttQuickFilter:options",

--- a/packages/spec/liveness/view.json
+++ b/packages/spec/liveness/view.json
@@ -99,7 +99,7 @@
         },
         "gantt": {
           "status": "live",
-          "note": "objectui: ObjectGantt.tsx:236 (audit L16)."
+          "note": "objectui: ObjectGantt.tsx:236 (audit L16). One key rides this blanket verdict at PLANNED strength, mirroring the #9340 map precedent one level down: `viewMode` (#9463, the spec half of the objectui#5074 both-branches ruling) is measured from the renderer's own vocabulary (objectui plugin-gantt GanttView.tsx GanttViewMode/VIEW_MODES: day/week/month/quarter/year, default 'day') but today only the resourceView branch reads it (objectui ObjectGantt.tsx:1445, an `as any` cast); the timeline branch passes nothing, so authoring it changes the majority path not at all until objectui#5074 (pm:blocked on #9463) wires both branches and retires the cast. Amend this note to plain live, citing the timeline-branch read, when that lands — measured objectui at origin/main 68d9e282c on 2026-08-18."
         },
         "gallery": {
           "status": "live",

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -263,6 +263,53 @@ describe('GanttConfigSchema', () => {
     expect(() => GanttConfigSchema.parse(config)).not.toThrow();
     expect(GanttConfigSchema.parse(config)).toMatchObject({ lockField: 'is_locked', defaultCollapsedDepth: 2 });
   });
+
+  // #9463 — `viewMode`, the spec half of objectui#5074's ruled both-branches
+  // wiring. The member list is MEASURED from the renderer (objectui
+  // plugin-gantt GanttView.tsx: `GanttViewMode` / the `VIEW_MODES` runtime
+  // guard), not invented; if a granularity joins or leaves the renderer, this
+  // pin and the schema move together.
+  describe('viewMode (#9463)', () => {
+    const base = {
+      startDateField: 'start_date',
+      endDateField: 'end_date',
+      titleField: 'name',
+    };
+
+    it.each(['day', 'week', 'month', 'quarter', 'year'] as const)(
+      "accepts the measured granularity '%s'",
+      (viewMode) => {
+        const r = GanttConfigSchema.safeParse({ ...base, viewMode });
+        expect(r.success, `expected acceptance of viewMode '${viewMode}'`).toBe(true);
+        expect(r.data).toMatchObject({ viewMode });
+      },
+    );
+
+    it('leaves an omitted viewMode ABSENT — no materialized default', () => {
+      // The renderer's absence behaviour is not a constant: an omitted
+      // viewMode lets a persisted layout seed the granularity before falling
+      // back to 'day' (objectui GanttView.tsx). A spec-side `.default('day')`
+      // would materialize an explicit author choice and defeat that seeding.
+      const parsed = GanttConfigSchema.parse(base);
+      expect('viewMode' in parsed).toBe(false);
+    });
+
+    it('refuses an out-of-vocabulary granularity, naming the members', () => {
+      // 'hour' is a real granularity on the TIMELINE block's `scale` but not
+      // in the gantt renderer's VIEW_MODES — exactly the near-miss an author
+      // would try. Declared-key values are judged even inside this
+      // deliberately-passthrough parent.
+      const r = GanttConfigSchema.safeParse({ ...base, viewMode: 'hour' });
+      expect(r.success).toBe(false);
+      const issues = JSON.stringify(r.error?.issues);
+      expect(issues).toContain('viewMode');
+      expect(issues).toContain('invalid_value');
+      // The prescription carries the full measured vocabulary.
+      for (const member of ['day', 'week', 'month', 'quarter', 'year']) {
+        expect(issues).toContain(member);
+      }
+    });
+  });
 });
 
 describe('ListViewSchema', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1178,6 +1178,14 @@ export const GanttConfigSchema = lazySchema(() => strictObject({
   ])).optional().describe('Fields to surface in the hover tooltip, in display order'),
   quickFilters: z.array(GanttQuickFilterSchema).optional().describe('Multi-select filter dropdowns rendered above the chart'),
   autoZoomToFilter: z.boolean().optional().describe('When true (default), filtering zooms the range to the filtered tasks'),
+  // Timeline granularity. The member list is measured from the renderer
+  // (objectui plugin-gantt GanttView.tsx: GanttViewMode / VIEW_MODES), not
+  // invented here. No spec-side `.default()` on purpose: the renderer's
+  // absence behaviour is not a constant — an omitted `viewMode` lets a
+  // persisted layout seed the granularity before falling back to 'day', so a
+  // materialized default would read as an explicit author choice and defeat
+  // that seeding (same reasoning as the map block's defaultless `zoom`/`center`).
+  viewMode: z.enum(['day', 'week', 'month', 'quarter', 'year']).optional().describe("Timeline granularity — one column per day/week/month/quarter/year (also the resource-view column granularity; renderer default 'day')"),
 // Forward-compatible: the gantt renderer (objectui plugin-gantt) keeps adding
 // config knobs (e.g. lockField / defaultCollapsedDepth) ahead of this schema.
 // Passthrough lets those extra fields reach the renderer instead of being


### PR DESCRIPTION
Fixes #9463

Spec half of the objectui#5074 maintainer ruling (2026-08-18, verbatim 「同意」: declare `viewMode` and wire BOTH branches). This PR declares the key on `GanttConfigSchema`; the objectui half (objectui#5074, `pm:blocked` on this card) declares it on `ObjectGanttSchema` and wires the timeline branch after this lands. objectui#5074 is not addressed here and remains open; the PM posts the unlock there after landing.

## Measurement receipts (enum from the renderer, not invented)

Measured on objectui `origin/main` @ `68d9e282c83af26f639180fc22dacba4c26dc201` (fetched 2026-08-18):

- `packages/plugin-gantt/src/GanttView.tsx:197` — `export type GanttViewMode = 'day' | 'week' | 'month' | 'quarter' | 'year'`
- `packages/plugin-gantt/src/GanttView.tsx:199` — `const VIEW_MODES: GanttViewMode[] = ['day', 'week', 'month', 'quarter', 'year']` (the runtime membership guard actually applied to the prop at :645, :803, :808)
- `packages/plugin-gantt/src/GanttView.tsx:207-213` — `NOMINAL_DAYS` maps all five members (each granularity really renders; `year` included, despite the stale JSDoc at :195 that names only four — filed as objectui#5132)
- **Default:** `packages/plugin-gantt/src/GanttView.tsx:802-805` — `viewModeProp && VIEW_MODES.includes(viewModeProp) ? viewModeProp : restoredLayout?.viewMode ?? 'day'`; same `'day'` default in the resource branch (`ResourceWorkload.tsx:63`) and at the existing cast read (`ObjectGantt.tsx:1445`, `(schema as any).viewMode … || 'day'`)

So the declared enum is exactly the measured set: `day | week | month | quarter | year`.

**Why optional with no spec-side `.default('day')`:** the renderer's absence behaviour is not a constant — an omitted `viewMode` lets a persisted layout (`persistLayoutKey`, GanttView.tsx:784-805) seed the granularity before falling back to `'day'`. A materialized default would arrive at the renderer as an explicit author choice and defeat that seeding — the same reasoning the map block records for its defaultless `zoom`/`center`. This also mirrors the gantt block's own sibling convention (`autoZoomToFilter`, `effortField`: optional + default documented in prose).

## What landed

- `packages/spec/src/ui/view.zod.ts` — `viewMode: z.enum(['day','week','month','quarter','year']).optional().describe(…)` on `GanttConfigSchema`. The block's deliberate `.passthrough()` posture is unchanged (renderer-ahead knobs still flow); declaring the key means an out-of-vocabulary **value** is now refused at authoring instead of silently falling back to `'day'`.
- `packages/spec/src/ui/view.test.ts` — accept pin per measured member (`it.each`), an absence pin (omitted `viewMode` stays absent — no materialized default), and a refusal pin (`viewMode: 'hour'` — a real granularity on the timeline block's `scale`, deliberately not in the gantt vocabulary — rejected with `invalid_value` naming the full member list).
- `packages/spec/liveness/view.json` — the `view/list/gantt` blanket note now records `viewMode` at PLANNED strength (mirroring the #9340 map precedent one level down): today only the resourceView branch reads it (objectui `ObjectGantt.tsx:1445`, an `as any` cast); flips to plain live when objectui#5074 wires both branches.
- `packages/spec/authorable-surface/ui.json` + `content/docs/references/ui/view.mdx` — regenerated (`check:generated --fix`; only the artifacts it proved stale).
- `.changeset/gantt-viewmode-declared.md` — `@objectstack/spec` minor (widens the accept set; not breaking, no ADR-0087 disposition required).

Out of scope, untouched: the component's other undeclared `as any` reads (`readOnly`, `markers`, `holidays`, …) — objectui#5043's family track.

## Verification

All at head `84a5f2185`, run after the final commit (the working tree was byte-identical to HEAD for every run; `git status --porcelain` empty):

- `pnpm --filter @objectstack/spec test` — **409 files / 10922 tests passed**; `pnpm --filter @objectstack/spec typecheck` — green (incl. `check:test-typecheck`: spec test layer compiles, debt ledger untouched)
- `pnpm --filter @objectstack/spec build` + `check:generated` — 1 artifact proved stale (`content/docs/references/**`), regenerated with `--fix`; `authorable-surface/ui.json` picked up exactly `ui/GanttConfig:viewMode`
- Full derived gate union (`node scripts/pm/dispatch-gates.mjs` over the changed paths, 24 families + `check:nul-bytes`): all green — incl. `check:liveness`, `check:strictness-ledger`, `check:empty-state`, `check:variant-docs`, `check:authorable-surface` (via `check:generated`), `check:merge-driver`, `check:adr-0087-registration`, `check:changeset-no-major`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, and — after building the workspace closure exactly as lint.yml does — `check:dev-prereqs`, lint `check:doc-formula-expressions`, and `check:type-check-debt --re-measure` (33 entries re-measured, none above its recorded number)

## Reverse verification

From the committed state, `git restore --source=origin/main -- packages/spec/src/ui/view.zod.ts` (schema alone reverted, tests kept). Direction predicted before running: **exactly 1 of the 7 new pins red** — the refusal pin — because the deliberately-passthrough parent already tolerated the key's presence, so declaring it changes value judgment only. Observed exactly that: `1 failed | 266 passed`, the failure being the refusal pin (view.test.ts:304 — `viewMode: 'hour'` parses successfully once the key is undeclared). Restored with `git checkout HEAD -- ...`, re-run: `267 passed (267)`, tree clean at `84a5f2185`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_