### PR TITLE
docs(pm-dispatch): review checklist names the renamed Lint & Repo Gates check run (#9420)

### DIFF
--- a/.claude/skills/pm-dispatch/references/review-checklist.md
+++ b/.claude/skills/pm-dispatch/references/review-checklist.md
@@ -32,12 +32,12 @@
   布,看起来像修好了,比不合更糟。
 - **测试证据**要有真实命令与通过输出,不是一句 tests pass。**测量类交付先看阳性对
   照**:对照本身失败 ⇒ 该读数记 INCONCLUSIVE,⛔ 不把它的「绿」当被测风险的证据入账。
-- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点
-  交报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge /
-  入队前亲核 Lint & Repo Gates 与 TypeScript Type Check 两个 job 的 `conclusion` 已
-  为 `success`(必需检查认 check-run 名,改名前的 PR 仍列旧名 `ESLint`),⛔ 不因报告写
-  了「本地绿」跳过。收敛期转红走补丁轮(SendMessage 续派原 dev —— 那是这笔交换已付过
-  的价钱,不是 REWORK 的理由;红着合并才是)。重量级卡可在派发令显式写「本单等 CI」。
+- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点交
+  报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge
+  / 入队前亲核 Lint & Repo Gates 与 TypeScript Type Check 两个 job 的 `conclusion` 已为
+  `success`(门禁族跑在其内),⛔ 不因报告写了「本地绿」跳过。收敛期转红走补丁轮
+  (SendMessage 续派原 dev —— 那是这笔交换已付过的价钱,不是 REWORK 的理由;红着
+  合并才是)。重量级卡可在派发令显式写「本单等 CI」。
 - **每个门禁读数先钉到 PR 的当前 head**:先读 PR 的 `head.sha`,再比对 run 的
   `head_sha` —— 不一致的 run 是关于一个死提交的读数,绿与红**双向都不入账**(旧 head
   的绿把「新推送未验」读成「消费者干净」,旧 head 的红把已修掉的缺陷重新挂回 PR)。

--- a/.claude/skills/pm-dispatch/references/review-checklist.md
+++ b/.claude/skills/pm-dispatch/references/review-checklist.md
@@ -32,12 +32,12 @@
   布,看起来像修好了,比不合更糟。
 - **测试证据**要有真实命令与通过输出,不是一句 tests pass。**测量类交付先看阳性对
   照**:对照本身失败 ⇒ 该读数记 INCONCLUSIVE,⛔ 不把它的「绿」当被测风险的证据入账。
-- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点交
-  报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge
-  / 入队前亲核 ESLint 与 TypeScript Type Check 两个 job 的 `conclusion` 已为
-  `success`(门禁族跑在其内),⛔ 不因报告写了「本地绿」跳过。收敛期转红走补丁轮
-  (SendMessage 续派原 dev —— 那是这笔交换已付过的价钱,不是 REWORK 的理由;红着
-  合并才是)。重量级卡可在派发令显式写「本单等 CI」。
+- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点
+  交报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge /
+  入队前亲核 Lint & Repo Gates 与 TypeScript Type Check 两个 job 的 `conclusion` 已
+  为 `success`(必需检查认 check-run 名,改名前的 PR 仍列旧名 `ESLint`),⛔ 不因报告写
+  了「本地绿」跳过。收敛期转红走补丁轮(SendMessage 续派原 dev —— 那是这笔交换已付过
+  的价钱,不是 REWORK 的理由;红着合并才是)。重量级卡可在派发令显式写「本单等 CI」。
 - **每个门禁读数先钉到 PR 的当前 head**:先读 PR 的 `head.sha`,再比对 run 的
   `head_sha` —— 不一致的 run 是关于一个死提交的读数,绿与红**双向都不入账**(旧 head
   的绿把「新推送未验」读成「消费者干净」,旧 head 的红把已修掉的缺陷重新挂回 PR)。


### PR DESCRIPTION
Fixes #9420

## Merge posture — still DRAFT, and still human-merge only

**This PR stays DRAFT.** Do not mark it ready, do not enable auto-merge, do not enqueue it. This surface is human-merge only (Prime Directive #14, skills PRs). Nothing in this PR was armed, queued, or flipped.

**Ordering: satisfied.** This section originally read "do not merge before #9421" — that was correct when this PR opened and is now stale, so it is corrected rather than left standing. #9421 landed as `81316864b`, which is the commit immediately after this branch's base `ad217b192`. `main` now carries the rename:

```
$ git show origin/main:.github/workflows/lint.yml | grep -n "name: Lint & Repo Gates"
39:    name: Lint & Repo Gates
```

So the change in this PR is now correct rather than premature — the "wrong in the other direction" window the card warns about has closed.

**`mergeable_state: blocked` is expected and is not a defect.** This branch's head predates the rename by exactly one commit, so its own `lint.yml` still names the job `ESLint`. The standing remedy is one branch update, the same as for every open PR whose head predates the rename. **This seat deliberately did not perform it** — the dispatch forbade chasing the state — so that decision is left to the merging human. No other PR was touched.

## What changes

One line region in one file: `.claude/skills/pm-dispatch/references/review-checklist.md`.

The checklist tells the review seat, before flipping a PR ready / arming auto-merge / enqueuing it, to confirm the `conclusion` of two named jobs is `success`. One of those two is the job that carries the whole `check:*` gate family, and its check-run name moved to `Lint & Repo Gates`.

**Before** (lines 35-40):

```
- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点交
  报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge
  / 入队前亲核 ESLint 与 TypeScript Type Check 两个 job 的 `conclusion` 已为
  `success`(门禁族跑在其内),⛔ 不因报告写了「本地绿」跳过。收敛期转红走补丁轮
  (SendMessage 续派原 dev —— 那是这笔交换已付过的价钱,不是 REWORK 的理由;红着
  合并才是)。重量级卡可在派发令显式写「本单等 CI」。
```

**After** (lines 35-40):

```
- **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点
  交报,报告里 gate `in_progress` 是诚实读数、预期内常态):翻 ready / 挂 auto-merge /
  入队前亲核 Lint & Repo Gates 与 TypeScript Type Check 两个 job 的 `conclusion` 已
  为 `success`(必需检查认 check-run 名,改名前的 PR 仍列旧名 `ESLint`),⛔ 不因报告写
  了「本地绿」跳过。收敛期转红走补丁轮(SendMessage 续派原 dev —— 那是这笔交换已付过
  的价钱,不是 REWORK 的理由;红着合并才是)。重量级卡可在派发令显式写「本单等 CI」。
```

### What is preserved, checked mechanically

A whitespace-insensitive diff of the bullet reports **exactly three edits and nothing else**:

```
delete   OLD |ES|                     NEW ||
insert   OLD ||                       NEW |&RepoGates|
replace  OLD |门禁族跑在其内|
         NEW |必需检查认check-run名,改名前的PR仍列旧名`ESLint`|
```

Everything else is byte-identical modulo re-wrapping. Unchanged, deliberately:

- **the verb** — 亲核 ... 的 `conclusion` 已为 `success`, not "check", not "see green";
- **the timing** — 翻 ready / 挂 auto-merge / 入队前, all three, in that order;
- **which jobs are covered** — 两个 job, the gate-family one and `TypeScript Type Check`;
- the surrounding clauses (the 2026-08-10 ruling provenance, the "本地绿" prohibition, the patch-round rule, the 「本单等 CI」 escape).

Both job names are kept unbroken on a single line each, so a seat scanning for either literal finds it.

### Why the phrasing is not the card's proposed phrasing

The card proposes mirroring `**Lint & Repo Gates** (called ESLint until the #9325 rename)`. That exact sentence **cannot land here**: `check:pm-skill-id-lint` scans this file and forbids issue-ID citations in operative prose. Measured, not assumed — writing the card's parenthetical into this very line:

```
✗ check-skill-id-lint: .claude/skills/pm-dispatch/references/review-checklist.md: 1 issue-ID citation(s)
    review-checklist.md:38: 为 `success`(必需检查认 check-run 名,旧名 `ESLint`(#9325 改名)),⛔ 不因报告写
```

exit 1. Same gate that went red on #9421 for the same reason. The sentence that actually landed in `AGENTS.md` is not the card's proposal either — it was rewritten there for this gate, and this wording mirrors what landed rather than what was proposed.

So the fact is distilled in place instead of pointed at: **a required status check is matched by its check-run name**, which is exactly why a PR opened before the rename still lists the old spelling. That is the operative content the seat needs at the moment it is reading a stale PR's checks list, and it is self-contained.

### The one informational change, called out

The old gloss 「门禁族跑在其内」 is not carried over verbatim. It is folded into the new name, which now says it: the job is called `Lint & Repo Gates` precisely because the old name described one of its ~70 steps rather than the gate family it carries. `AGENTS.md` states the same gloss explicitly for the same required set.

This is not a stylistic preference — the file sits **exactly at its ratchet ceiling**: `review-checklist.md` is 82 lines against a ceiling of 82, headroom 0. The bullet had to absorb the longer job name plus the distilled fact inside its existing 6 lines. Wordings that kept the gloss too were measured and need a 7th line, which the ratchet rejects; raising a ceiling requires a maintainer ruling quoted in the raising PR, and there is none for this. Per the ratchet's own doctrine the change pays its way by compressing in place. The alternative considered and rejected was deleting rationale from the adjacent clauses of the same bullet — that would have cost instruction text rather than a gloss the new name now carries.

Line count after: 82. **The ratchet does not move in either direction**, and no ceiling is edited.

## Grep sweep

```
$ grep -rn "ESLint" .claude/skills/
.claude/skills/pm-dispatch/references/review-checklist.md:37: ...亲核 ESLint 与 TypeScript Type Check...
```

One occurrence in the whole skills tree, and it is the one this PR changes. Nothing was left behind, and nothing meaning the ESLint **tool** was touched (there is no such occurrence under `.claude/skills/`). For contrast, `lint.yml:81` on `main` is a step still legitimately named `ESLint` because it really is the ESLint tool — that one is the job's step, not the check-run name, and is correctly untouched by both PRs.

Adjacent references to the same job that do **not** spell the name were checked and correctly need no change — they already name the job by its role rather than its label:

- `references/platform-readings.md:23` — 门禁放行判据 = 承载门禁族 job 的 conclusion
- `references/landing-operations.md:32` — 承载门禁族的 job `completed: success`
- `SKILL.md:124` — 承载门禁族的 job 须 `completed: success`

Those are rename-proof by construction and are the reason the blast radius is one line.

## Gate union, derived not recalled

```
$ node scripts/pm/dispatch-gates.mjs .claude/skills/pm-dispatch/references/review-checklist.md
```

Six families derived from the changed path (the five the card names, plus `check-adr-merge-approval` via the `.claude/skills` gate source). Run at final commit `0ec6cfc64` (`git rev-parse --short HEAD` from that run), verbatim exit codes:

```
pnpm check:doc-authoring                                          -> exit 0
pnpm check:pm-skill-id-lint                                       -> exit 0
pnpm check:pm-skill-ratchet                                       -> exit 0
pnpm check:skill-frame-sync                                       -> exit 0
pnpm check:nul-bytes                                              -> exit 0
pnpm --filter @objectstack/lint run check:doc-formula-expressions -> exit 0
node scripts/check-adr-merge-approval.mjs                         -> exit 1  (environmental, below)
```

`check:nul-bytes` is not path-derived; it is run on every edit by contract. `0ec6cfc64` is still the head — the only change since is this body correction, which moves no tree.

Selected output:

```
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/review-checklist.md is 82 lines (ceiling 82; headroom 0).
✓ check-skill-id-lint: 9 file(s) clean (pattern /#[0-9]{3,}/g).
✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files
✓ doc authoring guard: 377 files clean — no bare metadata literals.
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 396 files / 1411 TS blocks judged clean
check-nul-bytes: OK (scanned 6130 text file(s); no raw ASCII control bytes).
```

`check-adr-merge-approval.mjs` is red for a reason independent of this diff — it needs GitHub credentials this seat does not have, and this PR touches no ADR:

```
❌  GET https://api.github.com/repos/objectstack-ai/objectstack/commits/0ec6cfc6.../pulls answered HTTP 401:
    { "message": "Bad credentials", ... }
    Missing input fails loud, never exit 0 (#4690, #4928).
```

CI runs it with a token. `check:doc-formula-expressions` also needed `pnpm --filter '@objectstack/lint^...' build` first (a fresh worktree has no built closure); it is green after that build, red before it for the same environmental reason.

## Reverse verification

**Predicted direction, stated before running: no gate notices this line's content at all.** For an instruction-file change the honest reverse check is whether any gate reads what the line says, and the derived families check line counts, issue-ID patterns, TypeScript fenced blocks and escalation-frame anchors. None of them parses a check-run name.

**Observed: exactly that.** Replacing the job name in the line with `Nonexistent Job Name` and re-running the whole union:

```
pnpm check:doc-authoring                                          -> exit 0
pnpm check:pm-skill-id-lint                                       -> exit 0
pnpm check:pm-skill-ratchet                                       -> exit 0
pnpm check:skill-frame-sync                                       -> exit 0
pnpm check:nul-bytes                                              -> exit 0
pnpm --filter @objectstack/lint run check:doc-formula-expressions -> exit 0
```

Green across the board. The tree was restored afterwards and `git status --porcelain` is empty.

This is a true reading about the surface rather than a manufactured green, and it is worth stating plainly: **nothing mechanically binds this checklist line to the workflow's `name:` or to the pinned registry in `scripts/check-required-contexts.mjs`.** That script's scan set is the workflow files; it does not read `.claude/` at all. The rename is caught in `lint.yml` and in the registry, and it is caught in `AGENTS.md` only by a human reading it. This line was found by the dev seat that did the rename, not by a gate — which is precisely why the card exists.

The positive control above (the id-lint run) is the complement: the gates **do** read this file, they just do not read the job name. So the scan set is not the gap; the assertion is.

Filed as #9491, an observation-class card, rather than widened into this PR.

## Changeset

`skip-changeset` per precedent: an agent instruction file publishes nothing. Same disposition as #9421 for its workflow and gate-script halves, and the same reasoning the checklist itself gives for tests/docs-only PRs in this repo (the label, not an empty changeset, which lingers in the release pipeline here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYgmGheCzM6NrHZN436Cxf)_