### PR TITLE
docs(qa): RUNNER.md rule 2 carries the access-control disclosure carve-out at its source

### DIFF
--- a/docs/qa/platform-checklist/RUNNER.md
+++ b/docs/qa/platform-checklist/RUNNER.md
@@ -55,6 +55,18 @@ test-run output the clause's `evidence` field names.
      issue. A `fail` with no reproduction rule in its issue is not a completed verdict.
      (The screenshot that convinced you is a live judgment aid, not report content —
      describe what it showed in one line; never attach it.)
+   - **Carve-out — authentication and authorization findings only.** ⛔ Never publish a
+     reproduction for an authentication or authorization hole **anywhere on GitHub**: not
+     the run issue, not a tracking or extracted card, not a comment. Relocating it is not a
+     mitigation — a tracking card is a public issue in a public repo just the same. Such a
+     `fail` **is a completed verdict** when it records the item id, the clause, and `detail
+     withheld pending maintainer`; the reproduction stays in the runner session, and the
+     runner stops there and waits for the maintainer. Existence published, recipe withheld,
+     is a complete and actionable report — getting a defect fixed never requires handing
+     anyone a working exploit. (Maintainer disclosure ruling, 2026-08-18, recorded on
+     #9387; the `checklist-test` skill states the same guardrail in the same terms — one
+     rule written in both places, not a precedence claim by either.) **No other failure
+     class is softened by this**: everything else owes its reproduction rule in full.
 3. **Classify blockers honestly.** Missing seed/persona/fixture → `blocked(fixture)`,
    and *record the gap on the item* (`fixtures.knownGaps` or `blocked`) so the next
    sweep doesn't rediscover it. A defect in the fixture itself (seed silently failing,
@@ -213,7 +225,9 @@ in the repo** — not the JSON, not screenshots; `runs/` is git-ignored except i
 reach a verdict — never report artifacts. What the report carries for a defect is the
 **reproduction rule**: ordered steps / API calls (method · path · body) / the
 ref-targeted selector path + expected-vs-actual from the oracle, enough to re-hit it on a
-fresh boot with no picture. A clause whose oracle was a screenshot is recorded as a
+fresh boot with no picture — **except under rule 2's authentication/authorization
+carve-out**, where the report carries the item, the clause and `detail withheld pending
+maintainer`, and nothing else. A clause whose oracle was a screenshot is recorded as a
 one-line text description of what it showed, not a link.
 
 The in-environment JSON scratch (RUNNER shape, never committed):
@@ -246,10 +260,10 @@ The in-environment JSON scratch (RUNNER shape, never committed):
 ```
 
 The issue body is: env fingerprint · scope (selector + per-item `revision`) · the
-per-clause verdict table (text oracle evidence) · a reproduction rule per `fail` ·
-derived item verdicts + fixture gaps. The durable, version-controlled truth is still the
-checklist under `areas/`; a run is a dated assertion about one build, and it lives in its
-issue, not the tree.
+per-clause verdict table (text oracle evidence) · a reproduction rule per `fail` (rule 2's
+carve-out excepted) · derived item verdicts + fixture gaps. The durable,
+version-controlled truth is still the checklist under `areas/`; a run is a dated assertion
+about one build, and it lives in its issue, not the tree.
 
 ### Extraction obligation — the run record is a protocol carrier, not work
 
@@ -264,7 +278,9 @@ closing out the report includes the extraction, owed by the runner:
 - **Product defects found during the run**: at close-out, extract each one into its own
   standalone issue — self-contained title, reproduction and mechanism itemized in the
   card, a pointer back to the run record for the full evidence chain. A defect card does
-  not carry `qa-run`; it enters triage first-touch normally.
+  not carry `qa-run`; it enters triage first-touch normally. ⛔ An authentication or
+  authorization defect is extracted under rule 2's carve-out — item, clause, `detail
+  withheld pending maintainer`, no recipe. The extracted card is public too.
 - **Checklist-accuracy findings and fixture gaps** close out through the wave's anchor
   card (the sweep's tracking issue) — ⛔ not extracted.
 - **Environment blockers**: recorded in the run record is enough.


### PR DESCRIPTION
Fixes #9471

Docs-only, one file: `docs/qa/platform-checklist/RUNNER.md`.

## The conflict this removes

Rule 2's closing sentence defined a completed `fail` verdict unconditionally:

> A `fail` with no reproduction rule in its issue is not a completed verdict.

The `checklist-test` skill guardrail landed on `main` at `097fe96e1` (PR #9470) forbids
publishing a reproduction for an authentication or authorization hole anywhere on GitHub,
and states that it overrides this sentence. So a runner reading RUNNER.md on its own got
the unconditional rule with no hint a carve-out exists, and a runner reading both had to
choose between "complete verdict" and "do not publish an exploit" — resolved only by
precedence asserted from the skill side.

## What changed

**1. Rule 2 states the carve-out itself.** An auth/authz `fail` is a completed verdict
when it records the item id, the clause, and `detail withheld pending maintainer`, with
the reproduction held in the runner session and the runner stopping to wait for the
maintainer. The wording is the same rule the merged skill guardrail states — the two are
now consistent at the source, and the new text says so explicitly rather than claiming
precedence in the other direction. Rule 2's force for every other failure class is
untouched, and the carve-out says that too, in its last sentence.

Attribution follows the file's existing convention: maintainer disclosure ruling,
2026-08-18, recorded on #9387. No verbatim quote is given because I did not have the
maintainer's original wording — the ruling is cited by date and record, not paraphrased
into quotation marks.

**2. Bounded in-place fix, same defect class — three later restatements now point at the
carve-out instead of repeating the obligation unconditionally.** Naming them explicitly,
since they are beyond the letter of the card's scope paragraph (same file surface, no new
verification surface, no other claim on this file — no open PR touches
`docs/qa/platform-checklist/**`):

| line | text before | why it is the same defect |
|---|---|---|
| Run records, "the issue is text only" | "What the report carries for a defect is the **reproduction rule**" | a restatement of the exact sentence rule 2 carves out |
| issue-body composition | "a reproduction rule per `fail`" | same, in the report's field list |
| extraction obligation | "extract each one into its own standalone issue — reproduction and mechanism itemized in the card" | this is the public-card shape the original disclosure travelled through; left unconditional it re-instructs the incident |

Each is a **pointer** to rule 2, not a second copy of the rule — four copies of one policy
in one document is the drift this card exists to prevent.

## The card's "worth checking while in the file" sweep

Checked, no change needed, reporting the confirmation:

- **Trap vocabulary** — every row is about what a trap *fakes* and how to rule it out.
  Nothing in it assumes a finding is safe to publish.
- **Environment facts** (extended by #9427) — briefing facts about the stock environment.
  Their ⛔ markers all govern verdict accuracy ("do not file a whole-run red as a product
  defect before checking the browser resolved"), never disclosure.

The unconditional phrasing that does exist was the three restatements above, in other
sections.

## Out of file surface, filed separately

`docs/qa/platform-checklist/README.md` and `docs/qa/platform-checklist/runs/README.md`
carry the same unconditional obligation ("a reproduction rule per failure" / "**every
`fail` carries a reproduction rule**"). Both are outside this card's declared file
surface, so they are untouched here and filed as a separate finding.

## Gates

Re-derived against the actual diff rather than trusting the dispatch list:
`node scripts/pm/dispatch-gates.mjs docs/qa/platform-checklist/RUNNER.md` places zero
families on this path. The checklist's own validator is not path-derivable but names
RUNNER.md in its sources, so it was run anyway.

Union re-run at final HEAD `1c887f058`:

```
check-nul-bytes: OK (scanned 6136 text file(s) -- 6136 tracked, 0 untracked-not-ignored;
  skipped 5 binary; no raw ASCII control bytes).
checklist-select self-test: 17 cases pass.
check-platform-checklist: OK — 15 areas, 190 items (190 active); coverage: 30 kinds
  mapped, 0 waived.
```

Both checklist validators reference RUNNER.md only in prose/comments — neither parses its
content, so neither can assert on this change. Recording that rather than presenting a
green run as evidence the wording was verified.

No changeset: docs-only, nothing published — `skip-changeset` per repo convention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn7aaamsR99FXRqLcpL99q)_