### PR TITLE
docs(skills): state the ablation-on-dist hazard as a resolution property, not a dogfood one

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -190,14 +190,21 @@ dispatch prompt 只携带每单增量(裁决引文、裁决 / PM-机制假设分
   (删掉一个喂计数的读取,能让下游门禁*多出*一个发现);反转(canonical-first 的 `??`
   链:非法拼写落到 schema 的具名拒收 —— 规则绿、schema 红)。报告你实际观察到的方向;永
   不硬套模板的预设。
-- **dogfood ablation 跑在 `dist/` 上,所以要重建被 ablate 的包 —— 并在报告里说明你建
-  了。** `packages/qa/dogfood` 刻意从各包**构建产物 `dist/`** 解析被测代码,且两个方向
-  不对称:没 build 的修复是会被注意到的假红,没 build 的 **ablation** 跑的是变异前的构
-  建、保持**绿** —— 给一条可能永远失败不了的断言背书,对 CI 永久隐形。每一腿都是:变异
-  → `pnpm --filter <pkg> build` → **证明变异到达了产物** → 运行:
-  `node scripts/ablation-dist-preflight.mjs <pkg> '<marker>'`,ablation 删守卫时用
-  `--absent` —— 它同时是恢复腿,因为留在 `dist/` 里的 marker 会让变异代码在之后每次运行
-  里继续生效。
+- **ablation 的成立条件是解析路径,不是套件名 —— 变异腿与还原腿都要重建,并在报告里说
+  明你建了。** 条件:**被测主体经依赖的 `exports` 解析**(那指向该包的 `dist/`,不是
+  `src/`),且没有 vitest alias 把 specifier 拉回源码;这批 pair 有实测台账 ——
+  `scripts/check-test-source-alias.mjs` 的 `KNOWN_UNALIASED_TEST_IMPORTS`。
+  `packages/qa/dogfood` 是最眼熟的一例,不是定义:读成 dogfood 专属,普通单元套件里的
+  ablation 就会被当真(实测:plugin-email → platform-objects 消融后 375 试全绿,重建后
+  4 红;plugin-auth → core 那组「证明新门禁能红」的腿跑的是变异前产物)。两个方向不对
+  称:没 build 的修复是会被注意到的假红;没 build 的 **ablation** 保持**绿**,给一条可
+  能永远失败不了的断言背书,对 CI 永久隐形(CI 构建正确,那边永远绿)。⚠️ 消融本就为证
+  明**新门禁能失败**时,这份假绿不是空结果 —— 它读作「门禁没触发」,指向门禁坏了而不是
+  夹具坏了,于是有人去弱化一条本来正常的门禁。所以每一腿(变异**与**还原)都是:改动 →
+  `pnpm --filter <pkg> build` → **证明它到达了 `dist/`** → 才读运行结果:
+  `node scripts/ablation-dist-preflight.mjs <pkg> '<marker>'`(删守卫的消融、以及每个
+  **还原腿**,用 `--absent`)。⛔ 还原腿最常被跳过 —— 留在 `dist/` 里的 marker 会让变异
+  代码对该树之后的每次运行继续生效,后面的测量量的是错的树。
 
 ## Definition of done(按序)
 

--- a/.claude/skills/dogfood-verification/SKILL.md
+++ b/.claude/skills/dogfood-verification/SKILL.md
@@ -63,15 +63,22 @@ dev 工作树、dev-server 端口、preview 浏览器全是**共享的**:并行�
       watcher 只重编译示例应用自己的 `objectstack.config.ts` / `src`,不管工作区的包。
 - [ ] 所以:先做完**全部**源码编辑 → `pnpm --filter <pkg...> build` →
       `preview_stop` + `preview_start`。不要每修一处就编辑→构建→重启一遍。
-- [ ] ⚠️ **消融验证(predict-then-mutate)以最危险的方式继承这一条 —— mutate 与运行
-      之间要重建,并在报告里写明重建过。** 忘记重建*修复*是假红:费一圈,但会被发
-      现。忘记重建**消融**跑的是突变前的构建,套件保持**绿**,而这份绿会被记成「测试
-      已被证明有区分度」—— 给一条可能根本红不了的断言发了证书,之后任何 CI 都暴露不
-      了它(CI 构建正确,在那边永远绿)。每一腿都是 mutate →
-      `pnpm --filter <pkg> build` → **证明突变已到达 `dist/`** → 运行:
-      `node scripts/ablation-dist-preflight.mjs <pkg> '<marker>'` 只在被消费的
-      `dist/` 真带着突变时才退 0(消融删除守卫时用 `--absent`;restore 腿也要跑它 ——
-      留在 `dist/` 里的 marker 会让突变代码对该树之后的每次运行保持生效)。
+- [ ] ⚠️ **消融验证(predict-then-mutate)以最危险的方式继承这一条,而且它不是 dogfood
+      专属 —— mutate 腿与 restore 腿各自都要重建,并在报告里写明重建过。** 判据是解析
+      路径:任何主体经依赖的 `exports` 解析(→ 该包的 `dist/`,且没有 vitest alias
+      把 specifier 拉回源码)的测试都中招,普通单元套件一样(这批 pair 的台账是
+      `scripts/check-test-source-alias.mjs` 的 `KNOWN_UNALIASED_TEST_IMPORTS`)。忘记重
+      建*修复*是假红:费一圈,但会被发现。忘记重建**消融**跑的是突变前的构建,套件保持
+      **绿**,而这份绿会被记成「测试已被证明有区分度」—— 给一条可能根本红不了的断言发了
+      证书,之后任何 CI 都暴露不了它(CI 构建正确,在那边永远绿);消融本就为证明**新门
+      禁能失败**时更毒 —— 那份绿读作「门禁没触发」,指向门禁坏了而不是夹具坏了,会诱人
+      去弱化一条本来正常的门禁(实测:plugin-auth → core;plugin-email →
+      platform-objects 则是消融后 375 试假绿、重建后 4 红)。每一腿(mutate **与**
+      restore)都是:改动 → `pnpm --filter <pkg> build` → **证明它到达了 `dist/`** → 才
+      读运行结果:`node scripts/ablation-dist-preflight.mjs <pkg> '<marker>'` 只在被消费
+      的 `dist/` 真带着该状态时才退 0(消融删除守卫、以及每个 restore 腿,用
+      `--absent`)。⛔ restore 腿最常被跳过 —— 留在 `dist/` 里的 marker 会让突变代码对该
+      树之后的每次运行保持生效,后面的测量量的是错的树。
 - [ ] `dist/` 已 gitignore —— 安全;永不提交构建产物。
 - [ ] **`/_console` UI 是 *vendored objectui 构建*,与框架 `dist` 是两回事。** 它由
       `.objectui-sha` 钉住、按预构建 bundle 提供。已合并的 objectui 修复 —— *甚至


### PR DESCRIPTION
Fixes #8949

## What changed

Two `.claude/**` instruction files stated the "rebuild before you believe an ablation"
rule as a property of `packages/qa/dogfood`. Both now state it as a property of
**resolution**, which is what it actually is.

- `.claude/agents/os-dev.md` — the ablation clause in the standing-clauses section,
  generalized in place (no new section).
- `.claude/skills/dogfood-verification/SKILL.md` — the ablation bullet in section 2,
  generalized in place (no new section).

## The condition, as both copies now state it

Any test whose subject resolves through the dependency's `exports` — which point at
that package's built `dist/`, not `src/` — with no vitest alias redirecting the
specifier back to source. That set is enumerable and already enumerated:
`KNOWN_UNALIASED_TEST_IMPORTS` in `scripts/check-test-source-alias.mjs`.
`packages/qa/dogfood` is the most familiar instance, not the definition.

Two measured pairs are carried as the shortest possible provenance, as mechanism
illustration rather than as the rule body:

| pair | what happened |
|:--|:--|
| `plugin-email` to `platform-objects` | 375 passes on an ablated field; 4 went red once the dep was rebuilt |
| `plugin-auth` to `core` | legs meant to prove a new gate can fail ran the pre-mutation artifact and stayed green |

The second pair is the one both files are written around. An un-rebuilt ablation there
does not return a null result — it returns "the gate did not fire", which in that
context reads as evidence the **gate** is broken rather than the harness. The expensive
outcome is a dev weakening a working gate until it fires, destroying the thing the
ablation was written to certify.

## Both halves of the mechanical rule, now explicit in both copies

    mutate  -> rebuild -> prove the marker is IN dist/
    restore -> rebuild -> prove the marker is GONE   (--absent)

The restore half is the one that gets skipped: rebuilding after mutating is intuitive,
while remembering that *restoring* also needs a rebuild before the **next** measurement
is trustworthy is not. A marker left behind in `dist/` keeps mutated code live for every
later suite run in that worktree, so the runs that follow measure the wrong tree.

## Scope

- `scripts/ablation-dist-preflight.mjs` is deliberately **not** touched — that header is
  the authority and already carries this framing (landed via PR #8951); it is #8706's
  scope and out of bounds here. These two files were the lagging copies.
- `packages/qa/dogfood/README.md` step 4 is the third coupled location and is **out of
  scope on purpose** — it belongs to #8366 in the `domain:cli` lane. That card remains
  open and is not addressed here.
- Whether the preflight grows a per-symbol mode is a design question raised by #8706 and
  is untouched.

## Merge path

⛔ **Human merge only.** Standing maintainer ruling, 2026-08-11:
「所有 skills 的更新和 adr 类似,需要人工审核」. This PR is a draft; no AI seat should
mark it ready, add it to the merge queue, or arm auto-merge. It is *awaiting a human
merge*, which on GitHub looks identical to "forgotten".

## Verification

`.claude/**` prose only — no package source, no published surface, so no changeset
(`skip-changeset`).

Local gate union, all green at `2cfdd3bfb` (the final commit of this branch):

| gate | result |
|:--|:--|
| `pnpm check:doc-authoring` | 377 files clean |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 24 self-test cases; 396 files / 1411 TS blocks clean |
| `pnpm check:skill-frame-sync` | 4 copies structurally isomorphic across 3 files |
| `pnpm check:pm-skill-ratchet` | `os-dev.md` 341 lines, ceiling 399, headroom 58 |
| `pnpm check:pm-skill-id-lint` | 9 files clean; `os-dev.md` stays at zero issue-ID citations |
| `pnpm check:agent-model-declared` | `os-dev.md` declares `opus` |
| `pnpm check:nul-bytes` | 6136 text files, no raw control bytes |
| `node scripts/check-adr-merge-approval.mjs` | 401 Bad credentials locally (expected — needs CI credentials) |

`pnpm check:pm-skill-id-lint` was **not** in the dispatched gate list; it was picked up
by re-deriving the family from the actual diff
(`node scripts/pm/dispatch-gates.mjs` over the two changed paths) and is green. That
re-derivation placed 8 families for this surface and matched no others.

The id-lint gate is why neither file cites an issue number: maintainer ruling
2026-08-12 keeps operative agent-protocol text free of issue-ID dereferences, so the
two measured pairs are named by package pair only.

_Generated by [Claude Code](https://claude.ai/code/session_01Rn7aaamsR99FXRqLcpL99q)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rn7aaamsR99FXRqLcpL99q)_