### PR TITLE
fix(service-automation): a triggered run carries the flow author's successMessage / errorMessage — execute() and both retry exits (#9414)

### DIFF
--- a/.changeset/automation-execute-terminal-messages.md
+++ b/.changeset/automation-execute-terminal-messages.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/service-automation": patch
+---
+
+fix(service-automation): a triggered run carries the flow author's `successMessage` / `errorMessage` — `execute()` and both retry exits, symmetric with `resume()` (#9414)
+
+`AutomationResult` declares `successMessage` / `errorMessage` as a general
+terminal-result feature — *"Friendly terminal messages copied from the flow
+definition (`flow.successMessage` / `flow.errorMessage`) … `successMessage` is
+set on terminal success, `errorMessage` on failure."* One producer honoured it.
+`resumeInternal` set both on its terminal returns; `execute()` set neither, on
+either exit, and neither did `executeWithoutRetry` or `retryExecution`.
+
+So a flow's own words reached a caller **only if the run happened to pause and
+be resumed**. A flow dispatched straight through
+`POST /api/v1/automation/:name/trigger` — or the legacy `trigger/:name` that
+`client.automation.trigger()` calls — carried nothing, though the flow declared
+the text and the contract said it was set. One declaration, two behaviours
+decided by *route* rather than by authoring.
+
+**The consumer was already there and already reading.** The trigger route
+carries `errorMessage` into `error.details.errorMessage` (#9413), which is the
+one place the console reads it from (objectui `flowResponse.ts`, #4899) — and on
+the trigger path it was **always absent at the source**, so every non-screen flow
+showed the raw node error instead of the sentence its author wrote.
+
+Four terminal exits now produce the pair, which is every exit a triggered run can
+leave through:
+
+- `execute()` terminal success → `successMessage`; terminal failure →
+  `errorMessage`, **beside** the raw `error` rather than instead of it (the
+  transport folds `error` into the ADR-0112 message and carries the author's text
+  in `details`).
+- `executeWithoutRetry()` — both exits. `retryExecution` returns this result
+  verbatim when a later attempt succeeds, so without it `successMessage` would
+  depend on *which attempt* happened to work.
+- `retryExecution()`'s **exhausted** exit, which is a different exit from
+  `execute()`'s own failure return — a flow under `errorHandling.strategy:
+  'retry'` never reaches that one. A repair stopping at `execute()` would have
+  left the message missing for exactly the runs most likely to need it.
+
+**Nothing else gained a message, deliberately.** The paused return is not
+terminal; the skip exits (`condition_not_met`, `reentrancy_loop_guard`) return
+`success: true` for a run that executed no node; the never-dispatched exits
+(flow not found / disabled / no start node) have no lifecycle verdict at all and
+must not acquire a second channel implying one. Those boundaries are pinned, not
+just described.
+
+No new keys and no contract edit — the pair was declared, documented and
+consumed already; this is the production half catching up (ADR-0049
+enforce-or-remove, restoration direction).

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3239,6 +3239,28 @@ export class AutomationEngine implements IAutomationService {
                 success: true,
                 output,
                 durationMs,
+                // [#9414] The flow author's own completion text, on the exit
+                // every TRIGGERED run leaves through. `AutomationResult`
+                // declares this pair as a general terminal-result feature —
+                // "`successMessage` is set on terminal success, `errorMessage`
+                // on failure" — but `resumeInternal` was the only producer, so
+                // the author's words reached a caller only when the run
+                // happened to pause and be resumed. A flow dispatched straight
+                // through `POST /api/v1/automation/:name/trigger` (or the
+                // legacy `trigger/:name` the SDK calls) carried nothing. Same
+                // declaration, two behaviours decided by ROUTE rather than by
+                // authoring — the shape ADR-0049's enforce-or-remove exists to
+                // stop, and this is the restoration half of it, not a new key.
+                //
+                // ⚠️ TERMINAL exits only, which is the whole boundary. The
+                // paused return below carries neither (the run has not
+                // finished; `resumeInternal` stamps the message when it later
+                // ends). Neither do the SKIP exits above — `condition_not_met`
+                // and `reentrancy_loop_guard` return `success: true` for a run
+                // that executed no node, so stamping "Opportunity created!" on
+                // one would be a toast about work nobody did. They carry no
+                // `summary` for exactly the same reason.
+                successMessage: flow.successMessage,
                 // #4354 — hand the counts back synchronously so a caller
                 // (a `subflow` roll-up, a runtime test asserting the sweep wrote
                 // something) never has to re-read the run to learn what it did.
@@ -3309,7 +3331,7 @@ export class AutomationEngine implements IAutomationService {
 
             // Error handling strategy
             if (flow.errorHandling?.strategy === 'retry') {
-                return this.retryExecution(flowName, context, startTime, flow.errorHandling);
+                return this.retryExecution(flowName, context, startTime, flow.errorHandling, flow.errorMessage);
             }
             return {
                 success: false,
@@ -3350,6 +3372,16 @@ export class AutomationEngine implements IAutomationService {
                 // documented as the run's lifecycle verdict, and already the
                 // value recorded in the log.
                 status: 'failed',
+                // [#9414] The author's failure text, BESIDE the raw `error`
+                // rather than instead of it. The transport folds `error` into
+                // the ADR-0112 message and carries this one in
+                // `error.details.errorMessage` — the single place the console
+                // reads it from (objectui `flowResponse.ts`, PR #4899). The
+                // envelope has no `data`, so a producer that leaves this absent
+                // does not degrade to a plainer toast: the consumer falls back
+                // to the raw node error text, which is what every non-screen
+                // flow showed until now.
+                errorMessage: flow.errorMessage,
                 // A failed run's counts matter MORE, not less: they say how far
                 // it got before dying — how many rows it had already written.
                 summary: logged.summary,
@@ -6117,12 +6149,20 @@ export class AutomationEngine implements IAutomationService {
      * the parameter as the parsed shape is what keeps a second set of defaults
      * from growing back here: a knob the spec stops defaulting becomes a
      * compile error, not a silent engine-side guess.
+     *
+     * `flowErrorMessage` is the author's terminal failure text
+     * (`flow.errorMessage`), passed for the same reason `errorHandling` is
+     * passed rather than re-read: `execute()` already holds the parsed flow,
+     * and the exhausted exit below must report the definition THIS dispatch
+     * started under — not whatever a hot-reload re-registered under the same
+     * name while the loop slept between attempts (#9414).
      */
     private async retryExecution(
         flowName: string,
         context: AutomationContext | undefined,
         startTime: number,
         errorHandling: NonNullable<FlowParsed['errorHandling']>,
+        flowErrorMessage: string | undefined,
     ): Promise<AutomationResult> {
         // `maxRetries >= 1` is guaranteed under `strategy: 'retry'` — the schema
         // refuses the zero-attempt spelling of "retry" (#4247), so reaching this
@@ -6159,7 +6199,20 @@ export class AutomationEngine implements IAutomationService {
         // same lifecycle verdict, and a transport answers it the same way.
         // Without it, a flow whose author chose `errorHandling.strategy:
         // 'retry'` would be the ONE failure shape that still rode HTTP 200.
-        return { success: false, error: lastError, durationMs: Date.now() - startTime, status: 'failed' };
+        //
+        // [#9414] `errorMessage` for the same structural reason: this is a
+        // DIFFERENT terminal exit from `execute()`'s own failure return — a
+        // flow under `strategy: 'retry'` is handed off above and never reaches
+        // that one — so a repair that stopped at `execute()` would leave the
+        // author's message missing for precisely the runs most likely to need
+        // it, the ones that failed over and over.
+        return {
+            success: false,
+            error: lastError,
+            durationMs: Date.now() - startTime,
+            status: 'failed',
+            errorMessage: flowErrorMessage,
+        };
     }
 
     /**
@@ -6290,7 +6343,13 @@ export class AutomationEngine implements IAutomationService {
 
             // #4354 — a retried run reports its own attempt's counts, not the
             // failed one's: `retryExecution` returns THIS result on success.
-            return { success: true, output, durationMs, summary: logged.summary };
+            //
+            // [#9414] …and because `retryExecution` returns THIS result, this
+            // is the exit a run that succeeded on attempt 2+ leaves through.
+            // The author's completion text has to be produced here as well, or
+            // `successMessage` would be a function of which attempt happened to
+            // work — the same route-dependent shape the fix is removing.
+            return { success: true, output, durationMs, successMessage: flow.successMessage, summary: logged.summary };
         } catch (err: unknown) {
             const errorMessage = err instanceof Error ? err.message : String(err);
             const durationMs = Date.now() - startTime;
@@ -6311,7 +6370,19 @@ export class AutomationEngine implements IAutomationService {
             // same ran-and-failed exit as the two above and is classified the
             // same: a selective classification is the one a later reader
             // mistakes for a rule.
-            return { success: false, error: errorMessage, durationMs, status: 'failed', summary: logged.summary };
+            //
+            // [#9414] `errorMessage: flow.errorMessage` rides along on the same
+            // argument, and note the two names are NOT the same thing here:
+            // the local `errorMessage` is the raw thrown text, `flow.errorMessage`
+            // is what the author wrote for a human to read.
+            return {
+                success: false,
+                error: errorMessage,
+                durationMs,
+                status: 'failed',
+                errorMessage: flow.errorMessage,
+                summary: logged.summary,
+            };
         }
     }
 }

--- a/packages/services/service-automation/src/flow-terminal-messages.test.ts
+++ b/packages/services/service-automation/src/flow-terminal-messages.test.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #9414 — a TRIGGERED run carries the flow author's terminal messages.
+ *
+ * `AutomationResult` declares `successMessage` / `errorMessage` as a general
+ * terminal-result feature (`packages/spec/src/contracts/automation-service.ts`):
+ * "Friendly terminal messages copied from the flow definition … `successMessage`
+ * is set on terminal success, `errorMessage` on failure."
+ *
+ * One producer honoured it. `resumeInternal` set both on its terminal returns;
+ * `execute()` set neither, on either exit, and neither did `executeWithoutRetry`
+ * or `retryExecution`. So the author's own words reached a caller ONLY when the
+ * run happened to pause and be resumed. A flow dispatched straight through
+ * `POST /api/v1/automation/:name/trigger` — or the legacy `trigger/:name` that
+ * `client.automation.trigger()` calls — carried nothing, though the flow
+ * declared the text and the contract says it is set. One declaration, two
+ * behaviours chosen by ROUTE rather than by authoring.
+ *
+ * The consumer was already there and already reading: the trigger route carries
+ * `errorMessage` into `error.details.errorMessage` (#9413), which is the one
+ * place the console reads it from (objectui `flowResponse.ts`, PR #4899) — and
+ * on the trigger path it was ALWAYS absent at the source, so every non-screen
+ * flow fell back to the raw node error.
+ *
+ * **What is pinned here, and what deliberately is not.**
+ *
+ * The producer half lives in this package; the wire half is pinned one package
+ * over, in `packages/runtime/src/domains/automation-trigger-route-status.test.ts`
+ * (`carries the flow author's errorMessage in details, not folded into the
+ * message`), which drives the route with a scripted `AutomationResult` because
+ * `@objectstack/runtime` does not depend on this engine. The two meet on the
+ * result shape, so these tests assert the fields that test scripts —
+ * `success`/`status`/`error`/`errorMessage` — rather than only the message.
+ *
+ * ⚠️ Direction, predicted before running (the #9085 lesson: a pin that is green
+ * both before and after the fix is measuring the wrong thing). The four tests
+ * under "the defect" FAIL against an unfixed `engine.ts` — `undefined` where the
+ * author's text is expected. The three under "the boundary" and the one under
+ * "the symmetry anchor" are green either way ON PURPOSE: they are not evidence
+ * of the repair, they fence it, and each says which side it guards.
+ *
+ * ⚠️ A test that exercised `resume()` alone would prove nothing at all here:
+ * that path already worked, and the asymmetry between the two paths IS the
+ * defect. The single resume test below exists only to state the behaviour the
+ * execute path is being aligned to, so a later one-sided edit breaks something.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AutomationEngine } from './engine.js';
+import { InMemorySuspendedRunStore } from './suspended-run-store.js';
+import type { AutomationContext } from '@objectstack/spec/contracts';
+import { defineActionDescriptor } from '@objectstack/spec/automation';
+
+function createTestLogger(): any {
+    return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, child: () => createTestLogger() };
+}
+
+const SUCCESS_TEXT = 'Opportunity created — the owner has been notified.';
+const ERROR_TEXT = 'We could not create the opportunity — check the amount and try again.';
+
+/** The raw node failure. Deliberately unlike ERROR_TEXT: the two must not be confusable. */
+const RAW_FAILURE = 'downstream 503';
+
+/**
+ * A one-node flow the author gave both terminal messages. `startCondition`
+ * seeds the skip fixture; `errorHandling` seeds the retry fixtures.
+ */
+function messageFlow(
+    name: string,
+    opts: { errorHandling?: unknown; startCondition?: string; withMessages?: boolean } = {},
+) {
+    const withMessages = opts.withMessages ?? true;
+    return {
+        name,
+        label: name,
+        type: 'autolaunched',
+        ...(withMessages ? { successMessage: SUCCESS_TEXT, errorMessage: ERROR_TEXT } : {}),
+        ...(opts.errorHandling ? { errorHandling: opts.errorHandling } : {}),
+        nodes: [
+            {
+                id: 'start',
+                type: 'start',
+                label: 'Start',
+                ...(opts.startCondition ? { config: { condition: opts.startCondition } } : {}),
+            },
+            { id: 'work', type: 'script', label: 'Work' },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e0', source: 'start', target: 'work' },
+            { id: 'e1', source: 'work', target: 'end' },
+        ],
+    };
+}
+
+/**
+ * An engine whose single `script` node behaves as `outcome` says. `'fail_then_pass'`
+ * fails the first attempt and passes afterwards — the retry-succeeds fixture, which
+ * leaves through `executeWithoutRetry`'s success exit rather than `execute()`'s.
+ */
+function engineWith(outcome: 'pass' | 'fail' | 'fail_then_pass') {
+    const engine = new AutomationEngine(createTestLogger());
+    const runs = { count: 0 };
+    engine.registerNodeExecutor({
+        type: 'script',
+        async execute() {
+            runs.count++;
+            const fails = outcome === 'fail' || (outcome === 'fail_then_pass' && runs.count === 1);
+            return fails ? { success: false, error: RAW_FAILURE } : { success: true, output: { ok: true } };
+        },
+    } as never);
+    return { engine, runs };
+}
+
+/** `maxRetries: 1` is the smallest count the schema allows under `'retry'` (#4247). */
+const RETRY_ONCE = { strategy: 'retry', maxRetries: 1, backoffMs: 0 };
+
+describe('#9414 — the defect: execute() drops the author\'s terminal messages', () => {
+    it('terminal SUCCESS on the trigger path carries successMessage', async () => {
+        const { engine } = engineWith('pass');
+        engine.registerFlow('notify_owner', messageFlow('notify_owner') as never);
+
+        const result = await engine.execute('notify_owner');
+
+        expect(result.success).toBe(true);
+        // The defect: `undefined` here, on every run that did not pause.
+        expect(result.successMessage).toBe(SUCCESS_TEXT);
+        // Still a terminal result in every other respect — the message is
+        // added to the exit, it does not replace what the exit already said.
+        expect(result.summary).toBeDefined();
+        expect(typeof result.durationMs).toBe('number');
+    });
+
+    it('terminal FAILURE on the trigger path carries errorMessage BESIDE the raw error', async () => {
+        const { engine } = engineWith('fail');
+        engine.registerFlow('notify_owner', messageFlow('notify_owner') as never);
+
+        const result = await engine.execute('notify_owner');
+
+        expect(result.success).toBe(false);
+        // The defect: `undefined`, so `error.details.errorMessage` was never
+        // populated on this route and the console showed RAW_FAILURE instead.
+        expect(result.errorMessage).toBe(ERROR_TEXT);
+        // Beside, not instead of: the raw text stays in `error` for logs and
+        // diagnostics, and the transport folds THAT into the envelope message.
+        expect(result.error).toContain(RAW_FAILURE);
+        expect(result.error).not.toContain(ERROR_TEXT);
+        // The classification the route reads to answer 400 `FLOW_FAILED`
+        // (#9378) is untouched — this is the same exit, with one more field.
+        expect(result.status).toBe('failed');
+    });
+
+    it('the retry-EXHAUSTED exit carries errorMessage — a different exit from execute()\'s own', async () => {
+        // `strategy: 'retry'` hands off to `retryExecution`, so `execute()`'s
+        // failure return is never reached. Fixing only that one would leave the
+        // author's message missing for the runs most likely to need it.
+        const { engine, runs } = engineWith('fail');
+        engine.registerFlow('notify_owner', messageFlow('notify_owner', { errorHandling: RETRY_ONCE }) as never);
+
+        const result = await engine.execute('notify_owner');
+
+        expect(runs.count).toBe(2); // initial attempt + 1 retry: the loop really ran
+        expect(result.success).toBe(false);
+        expect(result.status).toBe('failed');
+        expect(result.errorMessage).toBe(ERROR_TEXT);
+    });
+
+    it('a run that succeeds on a LATER attempt carries successMessage', async () => {
+        // This result comes out of `executeWithoutRetry` — `retryExecution`
+        // returns it verbatim — so `successMessage` must be produced there too,
+        // or the message becomes a function of which attempt happened to work.
+        const { engine, runs } = engineWith('fail_then_pass');
+        engine.registerFlow('notify_owner', messageFlow('notify_owner', { errorHandling: RETRY_ONCE }) as never);
+
+        const result = await engine.execute('notify_owner');
+
+        expect(runs.count).toBe(2);
+        expect(result.success).toBe(true);
+        expect(result.successMessage).toBe(SUCCESS_TEXT);
+    });
+});
+
+describe('#9414 — the boundary: which exits must NOT carry a message', () => {
+    // ⚠️ Green before and after the repair, deliberately. These fence the fix
+    // rather than demonstrate it: each one is an exit a later "for consistency"
+    // tidy-up would be tempted to stamp, and stamping it would be wrong.
+
+    it('a SKIPPED run carries neither — nothing ran, so there is nothing to toast', async () => {
+        const { engine, runs } = engineWith('pass');
+        engine.registerFlow(
+            'notify_owner',
+            messageFlow('notify_owner', { startCondition: 'amount > 1000' }) as never,
+        );
+
+        const result = await engine.execute('notify_owner', {
+            event: 'test',
+            record: { id: 'opp_1', amount: 5 },
+        } as unknown as AutomationContext);
+
+        expect(runs.count).toBe(0);
+        expect((result.output as Record<string, unknown>)?.reason).toBe('condition_not_met');
+        // `success: true` here means "the trigger was handled", not "the flow
+        // finished". Showing "Opportunity created!" would be a toast about work
+        // nobody did — the same reason this exit carries no `summary`.
+        expect(result.successMessage).toBeUndefined();
+        expect(result.summary).toBeUndefined();
+    });
+
+    it('a NEVER-DISPATCHED exit carries neither — a disabled flow has no terminal state', async () => {
+        const { engine } = engineWith('pass');
+        engine.registerFlow('notify_owner', messageFlow('notify_owner') as never);
+        engine.toggleFlow('notify_owner', false);
+
+        const result = await engine.execute('notify_owner');
+
+        expect(result.success).toBe(false);
+        expect(result.code).toBe('FLOW_DISABLED');
+        // `status` absent is what proves the transport reads a verdict rather
+        // than guessing (#9378/#9415); `errorMessage` must not become a second
+        // channel that says "this run failed" for a run that never started.
+        expect(result.status).toBeUndefined();
+        expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('a flow that declares no messages gets no invented text', async () => {
+        const { engine } = engineWith('fail');
+        engine.registerFlow('quiet_flow', messageFlow('quiet_flow', { withMessages: false }) as never);
+
+        const result = await engine.execute('quiet_flow');
+
+        expect(result.success).toBe(false);
+        // Copied from the definition or absent — the engine never synthesizes a
+        // friendly message, so a caller can tell "the author wrote one" from
+        // "the author did not" and fall back on its own terms.
+        expect(result.errorMessage).toBeUndefined();
+        expect(result.error).toContain(RAW_FAILURE);
+    });
+});
+
+describe('#9414 — the symmetry anchor: resume() already did this', () => {
+    // ⚠️ Green before and after, on purpose. `resumeInternal` was the ONE
+    // producer honouring the declaration, and the repair above is defined as
+    // "symmetric with it". Pinning it keeps a later one-sided edit — narrowing
+    // this path instead of widening that one — from passing silently.
+
+    it('a resumed run still carries successMessage on its terminal exit', async () => {
+        const engine = new AutomationEngine(createTestLogger(), new InMemorySuspendedRunStore());
+        engine.registerNodeExecutor({
+            type: 'approval_pause',
+            descriptor: defineActionDescriptor({
+                type: 'approval_pause',
+                version: '1.0.0',
+                name: 'approval_pause',
+                supportsPause: true,
+                resumeAuthority: 'any',
+            }),
+            async execute() {
+                return { success: true, suspend: true, correlation: 'approval:req' };
+            },
+        } as never);
+        engine.registerFlow('approve_it', {
+            name: 'approve_it',
+            label: 'approve_it',
+            type: 'autolaunched',
+            successMessage: SUCCESS_TEXT,
+            errorMessage: ERROR_TEXT,
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'gate', type: 'approval_pause', label: 'Gate' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e0', source: 'start', target: 'gate' },
+                { id: 'e1', source: 'gate', target: 'end' },
+            ],
+        } as never);
+
+        const paused = await engine.execute('approve_it');
+        expect(paused.status).toBe('paused');
+        // The pause is NOT terminal, so it carries no message of its own —
+        // the run has not finished doing anything to report.
+        expect(paused.successMessage).toBeUndefined();
+
+        const done = await engine.resume(paused.runId as string, { output: { verdict: 'approved' } } as never);
+
+        expect(done.success).toBe(true);
+        expect(done.successMessage).toBe(SUCCESS_TEXT);
+    });
+});

--- a/packages/verify/src/automation-trigger-terminal-messages.test.ts
+++ b/packages/verify/src/automation-trigger-terminal-messages.test.ts
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #9414 — the flow author's terminal messages reach THE WIRE on a triggered run.
+ *
+ * This is the end-to-end half of the repair, and it lives here because
+ * `@objectstack/verify` is the one package that already depends on BOTH
+ * `@objectstack/runtime` (the trigger route) and `@objectstack/service-automation`
+ * (the engine that produces the result). The engine-side pins live in
+ * `packages/services/service-automation/src/flow-terminal-messages.test.ts`; the
+ * route-side pins, driven with a scripted `AutomationResult`, live in
+ * `packages/runtime/src/domains/automation-trigger-route-status.test.ts`. Neither
+ * of those, alone or together, asserts the sentence the documentation actually
+ * makes — so this file drives a REAL engine through the REAL dispatcher and reads
+ * the response body.
+ *
+ * **The documented promise is the acceptance criterion.**
+ * `content/docs/automation/flows.mdx` says, in prose, of the trigger route:
+ *
+ *   > A `400` additionally carries the flow author's own `errorMessage` (when the
+ *   > flow declares one) at `error.details.errorMessage`
+ *
+ * That sentence was FALSE before this change, and not by a little: the field was
+ * *always* absent at the source on the trigger path, because only `resumeInternal`
+ * ever produced it. The docs described the declaration; the implementation never
+ * honoured it, and three published pages plus two consumers (the trigger route
+ * itself, and objectui's `flowResponse.ts`) were written against the description.
+ * The repair does not invalidate the documentation — it makes the documentation
+ * true. So the assertions below are written against the doc's exact PATH and KEY
+ * (`error.details.errorMessage` on a 400, `data.successMessage` on a 200), never
+ * against the engine's internal result object: a pin that stops at
+ * `AutomationResult` cannot fail when the wire mapping is the half that breaks.
+ *
+ * **Verbatim is contract too.** `flows.mdx` documents both fields as plain
+ * author-declared strings with `{var}` explicitly NOT interpolated. Anything this
+ * path did to them on the way out — templating, trimming, HTML-escaping — would
+ * contradict the shipped contract, so one case drives a deliberately
+ * hostile string and asserts byte identity rather than a substring match.
+ *
+ * ⚠️ This suite resolves both packages through their BUILT `dist/`, as every
+ * dependent of theirs in this workspace does. Rebuild `@objectstack/service-automation`
+ * before trusting a run of this file — and especially before trusting an ABLATED
+ * one, where a stale `dist` would run the pre-mutation code and report green over
+ * a mutation that never reached the artifact.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { HttpDispatcher } from '@objectstack/runtime';
+import { AutomationEngine } from '@objectstack/service-automation';
+
+const SUCCESS_TEXT = 'Opportunity created — the owner has been notified.';
+const ERROR_TEXT = 'We could not create the opportunity — check the amount and try again.';
+
+/** The raw node failure. Deliberately unlike ERROR_TEXT: the two must not be confusable. */
+const RAW_FAILURE = 'downstream 503';
+
+/**
+ * Braces (a templating probe), padding (a trimming probe), and `&`/quotes/`>`
+ * (an escaping probe) in one string. `{amount}` is supplied as a real trigger
+ * param below, so an interpolating producer would visibly substitute it.
+ */
+const HOSTILE = '  {amount} items — "R&D" & 5 > 3, kept verbatim  ';
+
+const CTX = { request: {}, executionContext: { userId: 'user_1' } } as never;
+
+function createTestLogger(): never {
+    const logger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, child: () => logger };
+    return logger as never;
+}
+
+/** A one-node flow whose single `script` node passes or fails as asked. */
+function bootFlow(opts: { fails: boolean; successMessage?: string; errorMessage?: string }): HttpDispatcher {
+    const engine = new AutomationEngine(createTestLogger());
+    engine.registerNodeExecutor({
+        type: 'script',
+        async execute() {
+            return opts.fails ? { success: false, error: RAW_FAILURE } : { success: true, output: { ok: true } };
+        },
+    } as never);
+    engine.registerFlow('notify_owner', {
+        name: 'notify_owner',
+        label: 'notify_owner',
+        type: 'autolaunched',
+        ...(opts.successMessage !== undefined ? { successMessage: opts.successMessage } : {}),
+        ...(opts.errorMessage !== undefined ? { errorMessage: opts.errorMessage } : {}),
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start' },
+            { id: 'work', type: 'script', label: 'Work' },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e0', source: 'start', target: 'work' },
+            { id: 'e1', source: 'work', target: 'end' },
+        ],
+    });
+
+    const services: Record<string, unknown> = { automation: engine };
+    const resolve = (name: string): unknown => services[name];
+    const kernel = {
+        getService: resolve,
+        getServiceAsync: async (name: string): Promise<unknown> => resolve(name),
+        context: { getService: resolve },
+    };
+    return new HttpDispatcher(kernel as never);
+}
+
+/** `POST /api/v1/automation/notify_owner/trigger`, as the SDK and console reach it. */
+function trigger(dispatcher: HttpDispatcher, body: Record<string, unknown> = {}) {
+    return dispatcher.handleAutomation('/notify_owner/trigger', 'POST', body, CTX);
+}
+
+describe('#9414 — a triggered run reaches the wire with the author\'s terminal messages', () => {
+    it('400: the author\'s errorMessage arrives at error.details.errorMessage — the documented path', async () => {
+        const dispatcher = bootFlow({ fails: true, successMessage: SUCCESS_TEXT, errorMessage: ERROR_TEXT });
+
+        const result = await trigger(dispatcher);
+
+        expect(result.response?.status).toBe(400);
+        expect(result.response?.body?.error?.code).toBe('FLOW_FAILED');
+        // THE documented sentence, asserted at the documented key. Before the
+        // repair this was `undefined` for every non-screen flow ever triggered.
+        expect(result.response?.body?.error?.details?.errorMessage).toBe(ERROR_TEXT);
+        // Beside, not instead of: the raw node failure stays the envelope's
+        // human-readable message, so diagnostics do not lose the real cause…
+        expect(result.response?.body?.error?.message).toContain(RAW_FAILURE);
+        // …and the author's text is NOT folded into it (objectui reads the two
+        // from different places and shows them differently).
+        expect(result.response?.body?.error?.message).not.toContain(ERROR_TEXT);
+        // ADR-0112: no inner envelope for a status-blind caller to misread.
+        expect(result.response?.body?.data).toBeUndefined();
+    });
+
+    it('200: the author\'s successMessage arrives on the response data', async () => {
+        const dispatcher = bootFlow({ fails: false, successMessage: SUCCESS_TEXT, errorMessage: ERROR_TEXT });
+
+        const result = await trigger(dispatcher);
+
+        expect(result.response?.status).toBe(200);
+        expect(result.response?.body?.success).toBe(true);
+        expect(result.response?.body?.data?.successMessage).toBe(SUCCESS_TEXT);
+    });
+
+    it('carries both VERBATIM — no templating, no trimming, no escaping', async () => {
+        // `flows.mdx` documents these as plain strings with `{var}` explicitly
+        // NOT interpolated. `amount` is a real trigger param here, so an
+        // interpolating producer would substitute it and this would fail loudly.
+        const failing = bootFlow({ fails: true, errorMessage: HOSTILE });
+        const passing = bootFlow({ fails: false, successMessage: HOSTILE });
+
+        const failed = await trigger(failing, { amount: 42 });
+        const passed = await trigger(passing, { amount: 42 });
+
+        expect(failed.response?.body?.error?.details?.errorMessage).toBe(HOSTILE);
+        expect(passed.response?.body?.data?.successMessage).toBe(HOSTILE);
+        // Spelled out, because `toBe` on a constant can be read as tautological:
+        // the padding survives, and the brace was never a template.
+        expect(failed.response?.body?.error?.details?.errorMessage).not.toContain('42');
+        expect(failed.response?.body?.error?.details?.errorMessage).toMatch(/^ {2}\{amount\}/);
+        expect(failed.response?.body?.error?.details?.errorMessage).toMatch(/verbatim {2}$/);
+    });
+
+    it('a flow declaring NO messages gets no invented key — the doc\'s "when the flow declares one" half', async () => {
+        // ⚠️ Green before and after the repair, deliberately: it fences the fix
+        // rather than demonstrating it. The route omits the key entirely when
+        // the engine has nothing to give, so a consumer can still tell "the
+        // author wrote one" from "the author did not".
+        const dispatcher = bootFlow({ fails: true });
+
+        const result = await trigger(dispatcher);
+
+        expect(result.response?.status).toBe(400);
+        expect(result.response?.body?.error?.details?.errorMessage).toBeUndefined();
+        expect(result.response?.body?.error?.message).toContain(RAW_FAILURE);
+    });
+});


### PR DESCRIPTION
Fixes #9414

`AutomationResult` declares `successMessage` / `errorMessage` as a general terminal-result
feature (`packages/spec/src/contracts/automation-service.ts`):

> Friendly terminal messages copied from the flow definition (`flow.successMessage` /
> `flow.errorMessage`) so a screen-flow runner can show a meaningful toast instead of a
> generic "Done" / the raw error. `successMessage` is set on terminal success,
> `errorMessage` on failure.

One producer honoured it. `resumeInternal` set both on its terminal returns; `execute()`
set neither, on either exit, and neither did `executeWithoutRetry` or `retryExecution`. So
a flow's own words reached a caller **only if the run happened to pause and be resumed**. A
flow dispatched straight through `POST /api/v1/automation/:name/trigger` — or the legacy
`trigger/:name` that `client.automation.trigger()` calls — carried nothing, though the flow
declared the text and the contract said it was set. One declaration, two behaviours decided
by ROUTE rather than by authoring.

## This is a declared-vs-enforced pair three docs pages and two consumers were already written against

The strongest argument for the route triage chose is that **nothing here was speculative**.
Everything downstream of the engine had already been built against the declaration:

- **The published documentation already promises the wire shape.**
  `content/docs/automation/flows.mdx:1322` says, of the trigger route:

  > A `400` additionally carries the flow author's own `errorMessage` (when the flow
  > declares one) at `error.details.errorMessage`

  **That sentence was false on `main`.** The card's own measurement is that `errorMessage`
  is *always absent on the trigger path*, because only `resumeInternal` ever produced it.
  The documentation described the declaration; the implementation never honoured it. This
  PR does not invalidate the doc — **it makes the doc true**, which is why the docs-drift
  advisory on this PR (`flows.mdx`, `ui/actions.mdx`, `protocol/kernel/http-protocol.mdx`,
  all reached through the `/api/v1/automation/:name/trigger` route anchor) is a **true
  positive that resolves to no doc edit**. Nothing in those pages is now wrong; the prose
  is the acceptance criterion, and the pins below are written against it.
- **The route already carries it.** `respondToFlowTrigger` maps `result.errorMessage` into
  `error.details.errorMessage` on the 400 (#9413) — the one place the console reads it
  from.
- **The console already reads it.** objectui `flowResponse.ts` (#4899) reads that exact
  key, and got nothing on every non-screen flow.

So this is the production half catching up with a declaration that was already documented
and already consumed (ADR-0049 enforce-or-remove, restoration direction) — no new keys, no
contract edit. The alternative, narrowing the contract text to "screen-flow only", was
considered and rejected at triage; note that it would have required *falsifying three
published pages* to make a bug disappear.

## What changed

`packages/services/service-automation/src/engine.ts` — every exit a triggered run can leave
through:

| exit | field |
|---|---|
| `execute()` terminal success | `successMessage` |
| `execute()` terminal failure | `errorMessage`, **beside** the raw `error`, not instead of it |
| `executeWithoutRetry()` success | `successMessage` |
| `executeWithoutRetry()` failure | `errorMessage` |
| `retryExecution()` exhausted exit | `errorMessage` |

Two of those are the reason "and its retry wrappers" is in the card:

- **`retryExecution`'s exhausted exit is a different exit from `execute()`'s own failure
  return.** A flow under `errorHandling.strategy: 'retry'` is handed off before that return
  and never reaches it, so a repair stopping at `execute()` would have left the author's
  message missing for exactly the runs most likely to need it — the ones that failed over
  and over. `retryExecution` takes the author's text as a parameter for the same reason it
  already takes `errorHandling` rather than re-reading it: `execute()` holds the parsed
  flow, and the exhausted exit should report the definition *this dispatch* started under,
  not whatever a hot-reload re-registered while the loop slept between attempts.
- **`executeWithoutRetry`'s success exit is what a run that succeeded on attempt 2+ leaves
  through** — `retryExecution` returns that result verbatim. Without it, `successMessage`
  would depend on which attempt happened to work.

**The strings pass through untouched.** `flows.mdx:82` documents both fields as plain
author-declared strings with `{var}` explicitly NOT interpolated, so templating, trimming or
HTML-escaping on the way out would contradict the shipped contract. Nothing on this path
touches them, and that is pinned with a deliberately hostile string rather than assumed.

**Nothing else gained a message, deliberately**, and the boundaries are pinned rather than
only described: the paused return is not terminal; the skip exits (`condition_not_met`,
`reentrancy_loop_guard`) return `success: true` for a run that executed no node, so a toast
there would be about work nobody did; the never-dispatched exits (flow not found / disabled
/ no start node) carry no `status` on purpose — that absence is what proves the transport
reads a verdict instead of guessing (#9378 / #9415) — and `errorMessage` must not become a
second channel implying a run failed when none started.

## Tests — the doc's own path and key, end to end

Two new files, and the split is deliberate:

1. `packages/services/service-automation/src/flow-terminal-messages.test.ts` (8 pins) — the
   PRODUCER half: every terminal exit of `execute()`, `executeWithoutRetry()` and
   `retryExecution()`, plus the boundaries that must stay empty.
2. `packages/verify/src/automation-trigger-terminal-messages.test.ts` (4 pins) — the WIRE
   half, **end to end**. A pin that stops at `AutomationResult` cannot fail when the route
   mapping is the half that breaks, and the documented sentence is about
   `error.details.errorMessage`, not about an engine result object. `@objectstack/verify` is
   the one package already depending on **both** `@objectstack/runtime` and
   `@objectstack/service-automation`, so a real `AutomationEngine` is driven through a real
   `HttpDispatcher` at `POST /notify_owner/trigger` and the **response body** is read at the
   doc's exact path:
   - `400` → `body.error.details.errorMessage` is the author's text, `body.error.message`
     still carries the raw node failure and does **not** contain the author's text, and
     `body.data` is absent (ADR-0112, no inner envelope);
   - `200` → `body.data.successMessage` is the author's text;
   - **verbatim**: a message of `'  {amount} items — "R&D" & 5 > 3, kept verbatim  '` comes
     back byte-identical on both exits, with `amount: 42` supplied as a real trigger param —
     so an interpolating, trimming or escaping producer fails loudly;
   - a flow declaring **no** messages produces no key at all — the doc's "when the flow
     declares one" half.

   The route-side pins driven with a *scripted* result stay where they are
   (`packages/runtime/src/domains/automation-trigger-route-status.test.ts`, 26 tests, green
   at this head); this file is what proves the two halves actually meet.

**Reverse verification, direction predicted before running** (the #9085 lesson: a pin green
both before and after is measuring the wrong thing). The fix was committed first, then
`engine.ts` alone was restored to `origin/main` and both files re-run:

```
service-automation   Tests  4 failed | 4 passed (8)
verify (end-to-end)  Tests  3 failed | 1 passed (4)

AssertionError: expected undefined to be 'We could not create the opportunity —…'
```

The reds are exactly the pins that assert the author's text — `undefined` where it belongs,
on both `execute()` exits, both retry exits, and both wire exits. The greens are fences that
are green either way **on purpose**, and each says so in place: three boundary pins, one
resume symmetry anchor, and the "declares no messages" case.

⚠️ **The end-to-end file resolves both packages through their built `dist/`**, as every
dependent of theirs in this workspace does. So the ablation leg was run properly rather than
assumed: `@objectstack/service-automation` was **rebuilt after the mutation**, and the
mutation was **proved to have reached the artifact** before the run — the two markers in
`dist/index.js` drop from 3 sites to 1 (only `resumeInternal`'s) and return to 3 after the
restore. Without that rebuild the ablation would have run the pre-mutation build and
reported green over an assertion that could never fail.

## Verification — all at `3fc129b77` (the final commit)

```
pnpm --filter '@objectstack/service-automation^...' build      → 0
pnpm --filter '@objectstack/verify^...' build                  → 0
pnpm --filter @objectstack/service-automation test             → 81 files, 982 tests passed
pnpm --filter @objectstack/verify test                         → 7 files, 32 tests passed
pnpm --filter @objectstack/verify typecheck                    → 0 (real script, output echoed)
npx vitest run src/automation-trigger-terminal-messages.test.ts → 4 passed
npx vitest run src/domains/automation-trigger-route-status.test.ts (runtime) → 26 passed
```

Gate union re-derived at the new head from the actual changed paths via
`node scripts/pm/dispatch-gates.mjs` (paths from `git merge-base origin/main HEAD`, not the
two-dot form), and every family it named was re-run after the second commit:

```
check:nul-bytes                                → OK (6133 files, no raw control bytes)
check:changeset-gate-self-tests                → OK
check:objectui-changeset                       → OK
check:test-source-alias                        → OK (72 packages)
check:type-source-resolution                   → OK (76 packages)
check:engine-double-contract                   → OK (319 pinned, none new)
check:where-matcher                            → OK (253 matchers, none new)
check:query-options-erasure                    → OK (ratchet holds, no files added)
check:type-check-coverage                      → OK (64/77 packages)
check:type-check-debt (--re-measure)           → OK (33 entries in 217.2s, none above its
                                                  recorded number; "surplus: none")
check-adr-0087-registration.mjs --base MERGE_BASE  → OK (no declared-breaking changeset)
check-changeset-no-major.mjs  --base MERGE_BASE    → OK
check-empty-changeset.mjs     --base MERGE_BASE    → OK (1 declaring changeset added)
check-cross-package-test-inputs.mjs                → OK (12 packages, all declared)
docs-audit/check-affected-docs.mjs                 → OK (212 self-test cases)
```

The ratchet was re-run against a freshly built workspace closure
(`turbo run build --filter=./packages/* --filter=./packages/*/*`, 70 tasks) at the new head,
as its own failure text requires — an unbuilt run refuses rather than measuring. Both new
test files add zero errors: the `@objectstack/service-automation` and `@objectstack/verify`
ledger entries each sit exactly at their recorded numbers, and the hidden-test file count
moves 937 → 938, which is the new verify file being seen.

Changeset: `.changeset/automation-execute-terminal-messages.md` (patch on
`@objectstack/service-automation`). A triggered run's response body gains a field authors
already declared, so it is user-visible.

## Filed, not fixed here

- #9510 — `executeWithoutRetry` has no `isSuspendSignal` arm, so a **retry attempt that
  pauses** is recorded as failed and its continuation is never persisted; the run becomes
  unresumable. Same three methods, different defect class (a lost durable pause, not a
  missing field), and the repair changes what a retrying flow *does*.
- #9512 — `FlowSchema.successMessage` / `errorMessage` still describe themselves as
  screen-flow-only. Once this merges the authoring surface is the only place still saying
  so, and that wording is the exact premise of the route triage rejected. Lands in
  `packages/spec` plus two generated reference pages — a different package and gate family.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_
