### PR TITLE
fix(engine): set_null on a multiple:true reference removes the deleted member; emptied set stored as [], never null; drop the #9437 interim 409 hold

### DIFF
--- a/.changeset/cascade-set-null-multivalue-member-removal.md
+++ b/.changeset/cascade-set-null-multivalue-member-removal.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(engine): `deleteBehavior: 'set_null'` on a `multiple: true` reference field removes the deleted MEMBER from the stored array instead of nulling the whole slot, and the temporary 409 hold shipped with #9437 is removed (#9438)
+
+On a set-valued foreign key, "set null" now means what it has to mean: the
+reference to the deleted record is filtered out of the stored array and the
+remaining members are written back untouched. Before the interim hold, this
+limb wrote `null` over the WHOLE array — a row holding `["acc_a","acc_b"]`
+re-read as `null` after `acc_a` was deleted, silently dropping the live
+reference to `acc_b`.
+
+**The residual shape is the ruled one, consumed rather than decided here.**
+When the last member is removed, the field is written as **`[]`, never
+`null`** — the representation `FieldSchema` pins as verbatim contract
+(`packages/spec/src/data/field.zod.ts`, the `multiple` and `required` doc
+blocks; #9447, maintainer ruling 2026-08-18, binding for every writer). The
+open question that kept this limb held back was exactly that shape; it is
+now answered at the spec, and this write consumes the answer.
+
+**The temporary holding position is removed in the same stroke — it was
+built to be removed.** #9437 shipped an explicit interim: any delete that
+would take the `set_null` limb on a multi-value reference was refused
+`DELETE_RESTRICTED` / 409, with a `developerMessage` naming the refusal
+TEMPORARY and citing the tracking issue literally. Those deletes now
+succeed and remove the member. The refusal envelope for a genuinely
+configured `restrict` is unchanged, and the interim's extra sentence is gone
+with the interim.
+
+Removal compares whole members (`String(v) !== String(id)`), the same
+reading the dependents narrowing already applies — the probe's `$contains`
+pushdown is a substring superset, so an id that is a prefix of another
+neither loses its own member nor takes its neighbor's. Every other
+disposition is untouched: `cascade` still deletes dependents, a
+single-valued `set_null` still clears its foreign key to `null`, an
+explicit `restrict` still refuses with its own sentence, and the required-FK
+escalation stays exactly as it was.
+
+Pinned against the driver double that models the JSON TEXT column and
+against a real `SqlDriver` on better-sqlite3 through the real data-plane
+delete: member removal with a surviving sibling that still resolves, the
+emptying case asserted literally as `[]` and not `null` on a re-read of the
+database, and the controls beside them.
+
+Note: `required` on a multi-value lookup now *documents* non-empty-array
+semantics (same ruling), but the validator does not yet enforce it — that
+enforcement gap is tracked separately in #9476 and is not changed here.

--- a/packages/objectql/src/engine-cascade-delete-multivalue-probe.test.ts
+++ b/packages/objectql/src/engine-cascade-delete-multivalue-probe.test.ts
@@ -89,9 +89,9 @@ const guard: ServiceObject = {
 };
 
 /** Multi-value, `set_null` spelled OUT — `||` collapses it with the default. */
-const holdExplicit: ServiceObject = {
-  name: 'mv_hold_explicit',
-  label: 'Hold (explicit set_null)',
+const explicitSetNull: ServiceObject = {
+  name: 'mv_explicit_set_null',
+  label: 'Explicit set_null',
   fields: {
     id: { name: 'id', label: 'ID', type: 'text' as const },
     accounts: {
@@ -145,7 +145,7 @@ const opp: ServiceObject = {
 const JSON_COLUMNS: Record<string, readonly string[]> = {
   mv_zoo: ['f_lookups'],
   mv_guard: ['accounts'],
-  mv_hold_explicit: ['accounts'],
+  mv_explicit_set_null: ['accounts'],
   mv_cascade_multi: ['accounts'],
 };
 
@@ -309,7 +309,7 @@ describe('[#9362] the dependents probe reads a multi-value reference field the w
     probes = stub.probes;
     engine.registerDriver(stub.driver, true);
     await engine.init();
-    for (const o of [acct, zoo, guard, opp, holdExplicit, cascadeMulti, singleSetNull]) {
+    for (const o of [acct, zoo, guard, opp, explicitSetNull, cascadeMulti, singleSetNull]) {
       engine.registry.registerObject(o, OWNER_PACKAGE);
     }
   });
@@ -459,22 +459,27 @@ describe('[#9362] the dependents probe reads a multi-value reference field the w
 });
 
 /**
- * [#9362 -> #9438] The holding position: a `set_null` limb aimed at a
- * SET-valued foreign key refuses instead of writing.
+ * [#9438] `set_null` on a SET-valued foreign key removes the deleted MEMBER
+ * and writes what remains; the emptied set is written as `[]`, never `null`.
  *
- * Maintainer-ruled (option B) as a temporary measure to ship alongside the
- * probe repair above. The limb it holds back writes `null` over the whole
- * array, dropping every other member; the correct semantics is #9438's to
- * decide. Refusing decides nothing and is reversible; writing decides it by
- * accident and is not.
+ * The residual-shape sentence is NOT this suite's finding: `FieldSchema` pins
+ * it (`packages/spec/src/data/field.zod.ts`, the `multiple` and `required`
+ * doc blocks — #9447, maintainer ruling 2026-08-18, binding for every
+ * writer). This suite pins that the cascade repair CONSUMES that contract.
  *
- * The suite is written OVER-FIRE FIRST, because that is the way this guard can
- * re-break what the probe repair just fixed: every disposition it must NOT
- * touch — single-valued `set_null`, multi-value `cascade`, an already-declared
- * `restrict`, and a relation with no dependents at all — is asserted here
- * beside the two it must catch.
+ * The #9437 holding position — refusing these deletes 409 while the residual
+ * shape was undecided — is REMOVED by the same change, so the success pins
+ * here are also the revert's pins: under the hold every one of them was a
+ * `DELETE_RESTRICTED` refusal.
+ *
+ * Controls stay OVER-FIRE FIRST, as the hold's suite had them: single-valued
+ * `set_null`, multi-value `cascade`, an already-declared `restrict`, and a
+ * relation with no dependents are asserted beside the member-removal pins.
+ * The single-valued control is non-vacuous in the WIDEN direction (treat
+ * every field as multi-valued and it goes red on the array write), not under
+ * a removal ablation.
  */
-describe('[#9362 -> #9438] set_null on a multi-value reference refuses instead of nulling the array', () => {
+describe('[#9438] set_null on a multi-value reference removes the deleted member', () => {
   let engine: ObjectQL;
   let stores: Map<string, Map<string, Record<string, unknown>>>;
 
@@ -484,60 +489,99 @@ describe('[#9362 -> #9438] set_null on a multi-value reference refuses instead o
     stores = stub.stores;
     engine.registerDriver(stub.driver, true);
     await engine.init();
-    for (const o of [acct, zoo, guard, opp, holdExplicit, cascadeMulti, singleSetNull]) {
+    for (const o of [acct, zoo, guard, opp, explicitSetNull, cascadeMulti, singleSetNull]) {
       engine.registry.registerObject(o, OWNER_PACKAGE);
     }
   });
 
-  // ── FIRES — and the array is still intact afterwards.
+  // ── The write: member removal, on both spellings of set_null.
 
-  it('a DEFAULTED set_null on a multi-value field refuses, and writes nothing', async () => {
+  it('a DEFAULTED set_null removes the deleted member and keeps the rest', async () => {
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
     await engine.insert('mv_acct', { id: 'acc_b', name: 'B' });
     await engine.insert('mv_zoo', { id: 'z1', name: 'z', f_lookups: ['acc_a', 'acc_b'] });
 
-    const err: any = await engine.delete('mv_acct', { where: { id: a.id } } as any).catch((e) => e);
-    expect(err.code).toBe('DELETE_RESTRICTED');
-    expect(err.status).toBe(409);
-    expect(err.dependentObject).toBe('mv_zoo');
-    expect(err.dependentCount).toBe(1);
-    // The whole point: the sibling reference is still there.
-    expect(stores.get('mv_zoo')?.get('z1')?.f_lookups).toEqual(['acc_a', 'acc_b']);
-    expect(stores.get('mv_acct')?.has('acc_a')).toBe(true);
+    await engine.delete('mv_acct', { where: { id: a.id } } as any);
+
+    expect(stores.get('mv_acct')?.has('acc_a')).toBe(false);
+    // The whole point of the card: the sibling reference SURVIVES, and the
+    // record it points at is still there to resolve.
+    expect(stores.get('mv_zoo')?.get('z1')?.f_lookups).toEqual(['acc_b']);
+    expect(stores.get('mv_acct')?.has('acc_b')).toBe(true);
   });
 
-  it('an EXPLICITLY authored set_null on a multi-value field refuses too', async () => {
+  it('an EXPLICITLY authored set_null takes the same member removal', async () => {
     // `fdef.deleteBehavior || 'set_null'` collapses the absent declaration and
-    // this one into the same value, which is why one `if` covers both — the
-    // same reason the required-FK escalation beside it covers both.
+    // this one into the same value — both spellings take the same write.
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
-    await engine.insert('mv_hold_explicit', { id: 'h1', accounts: ['acc_a'] });
+    await engine.insert('mv_acct', { id: 'acc_b', name: 'B' });
+    await engine.insert('mv_explicit_set_null', { id: 'h1', accounts: ['acc_a', 'acc_b'] });
 
-    const err: any = await engine.delete('mv_acct', { where: { id: a.id } } as any).catch((e) => e);
-    expect(err.code).toBe('DELETE_RESTRICTED');
-    expect(err.status).toBe(409);
-    expect(err.dependentObject).toBe('mv_hold_explicit');
-    expect(stores.get('mv_hold_explicit')?.get('h1')?.accounts).toEqual(['acc_a']);
+    await engine.delete('mv_acct', { where: { id: a.id } } as any);
+
+    expect(stores.get('mv_explicit_set_null')?.get('h1')?.accounts).toEqual(['acc_b']);
   });
 
-  it('the refusal names the hold as TEMPORARY and points at #9438, on the developer half only', async () => {
+  it('removing the LAST member writes `[]`, never `null` — the ruled representation', async () => {
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
     await engine.insert('mv_zoo', { id: 'z1', name: 'z', f_lookups: ['acc_a'] });
 
-    const err: any = await engine.delete('mv_acct', { where: { id: a.id } } as any).catch((e) => e);
-    expect(err.developerMessage).toContain('TEMPORARY');
-    expect(err.developerMessage).toContain('objectstack#9438');
-    expect(err.developerMessage).toContain('multiple: true');
-    // The BUSINESS sentence is the ordinary one — the user's action is the
-    // same, and #7307 keeps the machine detail off this half.
-    expect(err.message).not.toContain('9438');
-    // And the wire code does not split (operation-message.ts's own rule).
-    expect(err.code).toBe('DELETE_RESTRICTED');
+    await engine.delete('mv_acct', { where: { id: a.id } } as any);
+
+    const stored = stores.get('mv_zoo')?.get('z1')?.f_lookups;
+    // Assert the literal shape, both ways: the contract sentence is exactly
+    // "`[]`, never `null`" (field.zod.ts, `multiple` doc block).
+    expect(stored).toEqual([]);
+    expect(stored).not.toBeNull();
+    expect(Array.isArray(stored)).toBe(true);
   });
 
-  // ── DOES NOT FIRE — four dispositions the hold must leave alone.
+  it('removal compares WHOLE members — an id keeps a member it is only a prefix of', async () => {
+    // The probe pushdown is a substring superset; the write must not be.
+    const a = await engine.insert('mv_acct', { id: 'acc_1', name: 'one' });
+    await engine.insert('mv_acct', { id: 'acc_10', name: 'ten' });
+    await engine.insert('mv_zoo', { id: 'z1', name: 'z', f_lookups: ['acc_1', 'acc_10'] });
 
-  it('a SINGLE-valued set_null still clears the foreign key, exactly as before', async () => {
+    await engine.delete('mv_acct', { where: { id: a.id } } as any);
+
+    expect(stores.get('mv_zoo')?.get('z1')?.f_lookups).toEqual(['acc_10']);
+  });
+
+  it('every dependent row loses the member, each keeping its own others', async () => {
+    const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
+    await engine.insert('mv_acct', { id: 'acc_b', name: 'B' });
+    await engine.insert('mv_zoo', { id: 'z1', name: 'z1', f_lookups: ['acc_a', 'acc_b'] });
+    await engine.insert('mv_zoo', { id: 'z2', name: 'z2', f_lookups: ['acc_a'] });
+    await engine.insert('mv_zoo', { id: 'z3', name: 'z3', f_lookups: ['acc_b'] });
+
+    await engine.delete('mv_acct', { where: { id: a.id } } as any);
+
+    expect(stores.get('mv_zoo')?.get('z1')?.f_lookups).toEqual(['acc_b']);
+    expect(stores.get('mv_zoo')?.get('z2')?.f_lookups).toEqual([]);
+    // A row that never referenced the deleted record is not touched.
+    expect(stores.get('mv_zoo')?.get('z3')?.f_lookups).toEqual(['acc_b']);
+  });
+
+  // ── The refusal channel: plain policy again, no interim sentence.
+
+  it("an already-declared multi-value restrict refuses with its OWN sentence — the interim's is gone", async () => {
+    const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
+    await engine.insert('mv_guard', { id: 'g1', name: 'g', accounts: ['acc_a'] });
+
+    const err: any = await engine.delete('mv_acct', { where: { id: a.id } } as any).catch((e) => e);
+    expect(err.code).toBe('DELETE_RESTRICTED');
+    expect(err.status).toBe(409);
+    expect(err.dependentObject).toBe('mv_guard');
+    // Configured policy only: the holding-position wording must not outlive
+    // the hold (it cited its card literally so that this grep is possible).
+    expect(err.developerMessage).not.toContain('TEMPORARY');
+    expect(err.developerMessage).not.toContain('9438');
+    expect(stores.get('mv_guard')?.get('g1')?.accounts).toEqual(['acc_a']);
+  });
+
+  // ── Controls the removal must leave alone.
+
+  it('a SINGLE-valued set_null still clears the foreign key to null, exactly as before', async () => {
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
     await engine.insert('mv_single', { id: 's1', account: 'acc_a' });
 
@@ -547,7 +591,7 @@ describe('[#9362 -> #9438] set_null on a multi-value reference refuses instead o
     expect(stores.get('mv_single')?.get('s1')?.account).toBeNull();
   });
 
-  it('a multi-value CASCADE still deletes the dependents (the P0 closes for this path)', async () => {
+  it('a multi-value CASCADE still deletes the dependents', async () => {
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
     await engine.insert('mv_cascade_multi', { id: 'c1', accounts: ['acc_a'] });
 
@@ -557,23 +601,10 @@ describe('[#9362 -> #9438] set_null on a multi-value reference refuses instead o
     expect(stores.get('mv_cascade_multi')?.has('c1')).toBe(false);
   });
 
-  it('an already-declared multi-value restrict refuses with its OWN sentence, not the hold\'s', async () => {
-    const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
-    await engine.insert('mv_guard', { id: 'g1', name: 'g', accounts: ['acc_a'] });
-
-    const err: any = await engine.delete('mv_acct', { where: { id: a.id } } as any).catch((e) => e);
-    expect(err.code).toBe('DELETE_RESTRICTED');
-    expect(err.dependentObject).toBe('mv_guard');
-    // Configured policy, not a holding position — the two must stay tellable
-    // apart, which is the whole reason the sentence splits.
-    expect(err.developerMessage).not.toContain('9438');
-    expect(err.developerMessage).not.toContain('TEMPORARY');
-  });
-
-  it('a multi-value set_null relation with NO dependent rows still deletes (the card\'s P0 repro)', async () => {
+  it('a multi-value set_null relation with NO dependent rows still deletes', async () => {
     const a = await engine.insert('mv_acct', { id: 'acc_a', name: 'A' });
     expect(stores.get('mv_zoo')?.size ?? 0).toBe(0);
-    expect(stores.get('mv_hold_explicit')?.size ?? 0).toBe(0);
+    expect(stores.get('mv_explicit_set_null')?.size ?? 0).toBe(0);
 
     await engine.delete('mv_acct', { where: { id: a.id } } as any);
 

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -10204,7 +10204,12 @@ export class ObjectQL implements IObjectQLEngine {
    * or `lookup` field referencing `object`, honor the field's `deleteBehavior`:
    *   - `cascade`  → delete the dependent rows (recursively, so grandchildren
    *                  are handled by each child's own delete),
-   *   - `set_null` → clear the foreign key,
+   *   - `set_null` → clear the foreign key. On a `multiple: true` field the
+   *                  FK is a SET, so "clear" means remove the deleted MEMBER
+   *                  and keep the rest; an emptied set is written as `[]`,
+   *                  never `null` — the representation `FieldSchema` pins
+   *                  (`packages/spec/src/data/field.zod.ts`, the `multiple`
+   *                  doc block, #9447 maintainer ruling 2026-08-18),
    *   - `restrict` → refuse the delete when dependents exist.
    * `master_detail` defaults to `cascade` (the parent owns the child
    * lifecycle); `lookup` defaults to `set_null` — except a `set_null` default
@@ -10276,52 +10281,8 @@ export class ObjectQL implements IObjectQLEngine {
         }
 
         // [#9362] Declared here rather than at the probe because BOTH the
-        // escalation below and the probe's filter spelling turn on it.
+        // set_null write below and the probe's filter spelling turn on it.
         const multiValued = fdef.multiple === true;
-
-        // [#9362 -> #9438] TEMPORARY HOLDING POSITION. Delete this block, and
-        // the `multiValueHold` limb of the refusal below, when #9438 lands.
-        //
-        // `set_null` on a SET-valued foreign key has no settled meaning yet.
-        // The limb it would run writes `null` over the WHOLE array, discarding
-        // every other member — references that have nothing to do with the
-        // record being deleted. Measured on the real stack: a row holding
-        // `["acc_a","acc_b"]` re-reads as `null` after `acc_a` is deleted.
-        //
-        // That limb has never executed in this codebase: before #8895 the
-        // dependents probe swallowed its own failure and skipped the relation,
-        // after #8895 it raised `INVALID_FILTER` and aborted the delete. The
-        // probe repair one method over is what would make it run, so this is
-        // not a behaviour being taken away — it is one being held back.
-        //
-        // The RIGHT semantics is "remove the deleted member", but the residual
-        // shape when the array empties (`[]` or `null`) is observable — on the
-        // read path and to a required multi-value validator — and nothing in
-        // `FieldSchema` pins it. #9438 answers that; until it does, refusing
-        // LOUDLY decides nothing, while writing decides it by accident. A
-        // delete that is refused can still be performed by clearing the
-        // references first; data dropped by a successful 200 cannot be undone.
-        //
-        // Shaped as the required-FK escalation directly above, deliberately
-        // rather than as a new mechanism: same `behavior` reassignment, same
-        // one `if`. It reads `behavior === 'set_null'`, which is exactly what
-        // that escalation reads — `fdef.deleteBehavior || 'set_null'` collapses
-        // an ABSENT declaration and an explicitly authored `set_null` into one
-        // value, so both are covered here for the same reason both are covered
-        // there. Distinguishing them would be new machinery, and would leave
-        // the explicit spelling running the very write this holds back — the
-        // author of `set_null` on a set-valued field cannot have chosen "clear
-        // the whole set", because that semantic has never existed to choose.
-        //
-        // An explicit `cascade` or `restrict` is untouched, and a relation with
-        // no dependent rows still deletes: this only changes the DISPOSITION,
-        // so the `restrict` branch below is still reached only when the probe
-        // actually found referencing rows.
-        let multiValueHold = false;
-        if (behavior === 'set_null' && multiValued) {
-          behavior = 'restrict';
-          multiValueHold = true;
-        }
 
         let dependents: any[];
         try {
@@ -10422,29 +10383,10 @@ export class ObjectQL implements IObjectQLEngine {
               { locale: msgCtx.locale, translate: msgCtx.translate },
             ),
           );
-          // [#9362 -> #9438] The hold's reason is DEVELOPER-facing and rides
-          // `developerMessage` alone — the split #7307 already made on this
-          // envelope, applied to a third reason. The business `message` is
-          // unchanged because the USER's action is unchanged: clear or reassign
-          // the referencing records. Why the wire code does not split either:
-          // `operation-message.ts` states the rule for this exact envelope —
-          // "one wire code with two sentences ... splitting the SENTENCE, never
-          // the code ... `DELETE_RESTRICTED` stays one member of the ADR-0112
-          // vocabulary that clients match on". A code minted for a holding
-          // position would also have to be RETIRED under ADR-0087 when #9438
-          // lands, which is the opposite of reverting in one line. `#9438` is
-          // spelled literally so removing this is one grep.
-          err.developerMessage = multiValueHold
-            ? `Cannot delete ${object} (${id}): ${dependents.length} dependent ${childName} record(s) reference it via ` +
-              `${fieldName}, which is a multi-value reference (multiple: true) taking the default/declared ` +
-              `deleteBehavior:'set_null'. This refusal is TEMPORARY and is not a policy you configured: clearing ` +
-              `that field would null the WHOLE array and drop the other references it holds, and the correct ` +
-              `semantics ("remove just this member", and what the field holds once empty) is still open — ` +
-              `objectstack#9438. Until it lands: delete or reassign the referencing records first, or set ` +
-              `deleteBehavior:'cascade' on ${childName}.${fieldName} if the dependents should go with the parent.`
-            : `Cannot delete ${object} (${id}): ${dependents.length} dependent ${childName} record(s) reference it via ${fieldName}` +
-              `${required ? ` (${fieldName} is required, so it cannot be cleared)` : ''}. ` +
-              `Delete or reassign them first, or set deleteBehavior:'cascade' on ${childName}.${fieldName}.`;
+          err.developerMessage =
+            `Cannot delete ${object} (${id}): ${dependents.length} dependent ${childName} record(s) reference it via ${fieldName}` +
+            `${required ? ` (${fieldName} is required, so it cannot be cleared)` : ''}. ` +
+            `Delete or reassign them first, or set deleteBehavior:'cascade' on ${childName}.${fieldName}.`;
           err.code = 'DELETE_RESTRICTED';
           err.status = 409;
           err.object = object;
@@ -10470,7 +10412,35 @@ export class ObjectQL implements IObjectQLEngine {
             // — same trust model as `__expandRead`), so it cannot be forged from
             // a request to bypass the guard on an ordinary write.
             const referentialCtx = { ...(context ?? {}), __referentialFieldClear: true } as ExecutionContext;
-            await this.update(childName, { id: depId, [fieldName]: null }, { context: referentialCtx } as any);
+            if (multiValued) {
+              // The FK is a SET, so `set_null` clears the deleted MEMBER, not
+              // the slot: filter the stored array and write what remains.
+              // Nulling the slot instead discarded every other live reference
+              // (measured: `["acc_a","acc_b"]` re-read as `null` after
+              // `acc_a` was deleted).
+              //
+              // The residual shape when the last member goes is not this
+              // engine's call to make: `FieldSchema` pins it —
+              // `packages/spec/src/data/field.zod.ts`, the `multiple` and
+              // `required` doc blocks (#9447, maintainer ruling 2026-08-18) —
+              // and this write consumes that contract: the emptied set is
+              // written as `[]`, which `Array.prototype.filter` already
+              // yields, never `null`.
+              //
+              // `String(v) !== String(id)` is the same reading
+              // `storedReferenceIncludes` applies when narrowing `dependents`
+              // above, so the member removed here is exactly the member that
+              // made this row a dependent. An off-shape bare scalar in a
+              // `multiple: true` slot is normalized to the array spelling by
+              // this write, for the same reason the narrowing compares it
+              // rather than dismissing it.
+              const stored = dep?.[fieldName];
+              const current: unknown[] = Array.isArray(stored) ? stored : [stored];
+              const next = current.filter((v) => String(v) !== String(id));
+              await this.update(childName, { id: depId, [fieldName]: next }, { context: referentialCtx } as any);
+            } else {
+              await this.update(childName, { id: depId, [fieldName]: null }, { context: referentialCtx } as any);
+            }
           }
         }
       }

--- a/packages/runtime/src/cascade-delete-multivalue-lookup-real-driver.integration.test.ts
+++ b/packages/runtime/src/cascade-delete-multivalue-lookup-real-driver.integration.test.ts
@@ -157,26 +157,47 @@ describe('[#9362] REST DELETE on an object targeted by a multiple:true lookup �
         expect(err.status).toBe(409);
     });
 
-    // ── [#9362 -> #9438] The holding position, on the real stack.
+    // ── [#9438] Member removal on the real stack. The residual-shape
+    //    sentence these tests consume is `FieldSchema`'s, not theirs:
+    //    `packages/spec/src/data/field.zod.ts`, the `multiple` and `required`
+    //    doc blocks (#9447, maintainer ruling 2026-08-18). Under the #9437
+    //    holding position each of these deletes was a 409, so the 200s below
+    //    also pin the interim escalation's removal.
 
-    it('a multi-value set_null refuses instead of nulling the array, and the array survives', async () => {
+    it('a multi-value set_null removes the deleted member and the sibling reference survives', async () => {
         const { protocol, real } = await rig([ACCOUNT, FIELD_ZOO]);
         const a: any = await engine!.insert('zz_account', { id: 'acc_a', name: 'A' });
         await engine!.insert('zz_account', { id: 'acc_b', name: 'B' });
         await engine!.insert('zz_field_zoo', { id: 'z1', name: 'z', f_lookups: ['acc_a', 'acc_b'] });
 
-        const err: any = await protocol
-            .deleteData({ object: 'zz_account', id: a.id })
-            .catch((e: any) => e);
-        expect(err.code).toBe('DELETE_RESTRICTED');
-        expect(err.status).toBe(409);
-        expect(err.developerMessage).toContain('objectstack#9438');
+        const res = await protocol.deleteData({ object: 'zz_account', id: a.id });
+        expect(res).toMatchObject({ object: 'zz_account', id: a.id, success: true });
 
-        // Read the stored array back out of the DATABASE. Before the hold this
-        // re-read as `null`, taking `acc_b` with it.
+        // Read the stored array back out of the DATABASE, on the driver's own
+        // connection. Before the fix this slot re-read as `null`, taking
+        // `acc_b` with it; under the interim hold the delete was a 409.
         const [row]: any[] = await real.find('zz_field_zoo', { where: { id: 'z1' } });
-        expect(row.f_lookups).toEqual(['acc_a', 'acc_b']);
-        expect(await real.count('zz_account')).toBe(2);
+        expect(row.f_lookups).toEqual(['acc_b']);
+        // …and the surviving member still resolves to a live record.
+        expect(await real.count('zz_account', { where: { id: 'acc_b' } })).toBe(1);
+        expect(await real.count('zz_account')).toBe(1);
+    });
+
+    it('removing the LAST member stores `[]`, never `null` — the ruled representation, in the database', async () => {
+        const { protocol, real } = await rig([ACCOUNT, FIELD_ZOO]);
+        const a: any = await engine!.insert('zz_account', { id: 'acc_a', name: 'A' });
+        await engine!.insert('zz_field_zoo', { id: 'z1', name: 'z', f_lookups: ['acc_a'] });
+
+        const res = await protocol.deleteData({ object: 'zz_account', id: a.id });
+        expect(res).toMatchObject({ id: 'acc_a', success: true });
+
+        const [row]: any[] = await real.find('zz_field_zoo', { where: { id: 'z1' } });
+        // The literal shape, asserted both ways: `[]`, not `null` — this is
+        // the observable half of the #9447 ruling, proved against what the
+        // real driver actually stored and read back.
+        expect(row.f_lookups).toEqual([]);
+        expect(row.f_lookups).not.toBeNull();
+        expect(Array.isArray(row.f_lookups)).toBe(true);
     });
 
     it('a multi-value CASCADE still deletes end to end — the P0 closes for that path', async () => {


### PR DESCRIPTION
Fixes #9438

## What this does

`deleteBehavior: 'set_null'` on a `multiple: true` reference field now removes the deleted **member** from the stored array and writes what remains, instead of nulling the whole slot (which discarded every other live reference). The interim `restrict` escalation shipped with #9437 as an explicit holding position is removed in the same stroke — it was built to be removed, and the ruling that unblocked this card has landed.

- **Member removal**: `next = current.filter(v => String(v) !== String(id))`, then write `next`. Whole-member comparison — the same reading the dependents narrowing already applies — so an id that is a prefix of another neither loses its own member nor takes its neighbor's.
- **Residual shape is consumed, not decided here**: an emptied set is written as `[]`, never `null` — the representation `FieldSchema` pins as verbatim contract (`packages/spec/src/data/field.zod.ts`, the `multiple` and `required` doc blocks; #9447, maintainer ruling 2026-08-18, binding for every writer). The engine comment cites that file rather than restating the sentence.
- **Interim revert**: the escalation `if`, its `multiValueHold` flag, and the TEMPORARY `developerMessage` limb are gone. Completion check from the dispatch: `grep -c` for `multiValueHold`, `TEMPORARY`, and `9438` in `packages/objectql/src/engine.ts` — all three are **0**.
- Untouched, deliberately: the #9437 probe repair (`$contains` + exact element-wise narrowing), the required-FK escalation, `cascade`, explicit `restrict`, and the single-valued `set_null` limb.

Out of scope, still open: **#9476 is not addressed here** (the validator still passes `[]` on a `required` + `multiple: true` lookup; the ruled non-empty semantics remain documented-but-unenforced). This change neither helps nor hinders it mechanically — the member-removal write goes through the ordinary update path, so when #9476 lands its enforcement, an emptying cascade repair on a required multi-value lookup will surface that contradiction loudly, which is the #9438 issue's own "required FK cannot be honestly cleared" reasoning one level up. Worth a sentence on that card, left to its implementer.

## Tests

Union run at `18c20564a5` (the head of this branch; working tree clean at every run quoted below).

- `packages/objectql/src/engine-cascade-delete-multivalue-probe.test.ts` — the hold suite is rewritten into the member-removal suite: defaulted and explicit `set_null` member removal, the emptying case asserted literally (`toEqual([])`, `not.toBeNull()`, `Array.isArray`), whole-member prefix safety, multi-row independence, restrict-with-its-own-sentence (no TEMPORARY / no card citation outliving the hold), plus the four controls. **17/17 green**. Full package suite: **3828/3828 green**.
- `packages/runtime/src/cascade-delete-multivalue-lookup-real-driver.integration.test.ts` — on a real `SqlDriver` (better-sqlite3) through the real data-plane delete, asserting on the **database** via the driver's own connection: `["acc_a","acc_b"]` minus deleted `acc_a` re-reads as `["acc_b"]` and `acc_b` still resolves; the emptying case re-reads as `[]`, explicitly not `null`. **7/7 green**. Full package suite: **2510/2510 green**.
- Typecheck: `@objectstack/objectql` and `@objectstack/runtime` both clean.

## Reverse verification (all three legs; runtime resolves objectql from `dist`, so each ablation leg was rebuilt and proved live via `scripts/ablation-dist-preflight.mjs` before its colour was trusted; the restore leg proved all markers **absent** from `dist`)

- **Leg 1 — member-removal write ablated alone** (null write restored, hold still removed): the member-removal pins went RED in the expected direction — `expected null to deeply equal [ 'acc_b' ]` and `expected null to deeply equal []` — 5 unit + 2 integration failures, everything else green.
- **Leg 2 — escalation-revert ablated alone** (hold re-added, member removal kept): the old 409 behaviour returned — the same 7 success pins went RED on `DELETE_RESTRICTED` refusals.
- **Leg 3 — widen direction** for the "guard does not fire" control: `multiValued` forced true made the single-valued `set_null` control go RED (`expected [] to be null`), proving it non-vacuous. Run at the unit layer (src-resolved, no dist involved). This is the direction used, per the over-fire caution in the dispatch: removal-direction ablations cannot exercise that control.

## Gates

Derived via `node scripts/pm/dispatch-gates.mjs` over the changed paths; all derived families run locally and green at this tree: changeset-gate-self-tests, cross-package-test-inputs (pnpm + node forms), durability-log-level, objectui-changeset, stack-collection-maps, adr-0087-registration, changeset-no-major, empty-changeset, engine-split-ratio, affected-docs, query-options-erasure, where-matcher, engine-double-contract, type-check-coverage, type-check-debt (`--re-measure`, after the full packages closure build), nul-bytes. The ratchet families (query-options-erasure, where-matcher, engine-double-contract, nul-bytes) were re-run at the committed head `18c20564a5`; type-check-debt ran on the byte-identical tree the commit was created from.

Changeset: `.changeset/cascade-set-null-multivalue-member-removal.md` (patch, `@objectstack/objectql`) — user-visible: deletes that returned 409 under the interim now succeed and remove the member.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKPDRoynY8i3HmdSFUxFj)_