### PR TITLE
fix(pm): add per-file ceilings for the four uncovered skills

### DIFF
--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -57,6 +57,14 @@ export const CEILINGS = new Map([
   ['.claude/skills/pm-dispatch/references/landing-operations.md', 82],
   ['.claude/skills/pm-dispatch/references/seat-post-protocol.md', 101],
   ['.claude/agents/os-dev.md', 399],
+  // #9473: the other four `.claude/skills/` are read in full by the sessions
+  // that use them too — the erosion mechanism the ratchet exists to stop
+  // isn't specific to the pm-dispatch surface. Set at current counts on
+  // `origin/main` (headroom 0, same convention as the entries above).
+  ['.claude/skills/checklist-test/SKILL.md', 232],
+  ['.claude/skills/checklist-author/SKILL.md', 61],
+  ['.claude/skills/dogfood-verification/SKILL.md', 155],
+  ['.claude/skills/spec-property-retirement/SKILL.md', 328],
 ]);
 
 export function verdict(rel, lineCount, maxLines) {
@@ -117,6 +125,7 @@ function selfTest() {
     ['SKILL.md is covered', CEILINGS.has('.claude/skills/pm-dispatch/SKILL.md'), true],
     ['the dev-agent definition is covered', CEILINGS.has('.claude/agents/os-dev.md'), true],
     ['all five compressed references are covered', ['dispatch-runbook', 'platform-readings', 'review-checklist', 'landing-operations', 'seat-post-protocol'].every((n) => CEILINGS.has(`.claude/skills/pm-dispatch/references/${n}.md`)), true],
+    ['the other four skills are covered (#9473)', ['checklist-test', 'checklist-author', 'dogfood-verification', 'spec-property-retirement'].every((n) => CEILINGS.has(`.claude/skills/${n}/SKILL.md`)), true],
   ];
   let failed = 0;
   for (const [name, actual, expected] of cases) {


### PR DESCRIPTION
Fixes #9473

## What

`scripts/pm/check-skill-line-ratchet.mjs`'s header claims "the ceiling now covers the whole surface, per file", but the `CEILINGS` map only held the pm-dispatch surface (SKILL.md + 5 references + `os-dev.md`). Adds four entries at their current line counts on fetched `origin/main` (headroom 0, same shrink-only convention as the existing entries):

- `.claude/skills/checklist-test/SKILL.md` — 232
- `.claude/skills/checklist-author/SKILL.md` — 61
- `.claude/skills/dogfood-verification/SKILL.md` — 155
- `.claude/skills/spec-property-retirement/SKILL.md` — 328

No instruction-text changes; only `scripts/pm/check-skill-line-ratchet.mjs` touched, per the card's file-surface constraint.

This is a pure extension of an existing guard in its own declared direction (no ceiling raised or loosened), so the maintainer-ruling requirement for *raising* a ceiling does not apply here.

## Self-test

Extended the script's existing `--self-test` fixtures with one new case asserting the four files are covered, matching the convention already used for the pm-dispatch entries (`'SKILL.md is covered'`, `'all five compressed references are covered'`, etc.). No new test harness invented.

## Verification (head `79b0f2a`)

```
$ pnpm check:pm-skill-ratchet
✓ check-skill-line-ratchet self-test: 12 cases pass.
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md is 682 lines (ceiling 682; headroom 0).
...
✓ check-skill-line-ratchet: .claude/skills/checklist-test/SKILL.md is 232 lines (ceiling 232; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/checklist-author/SKILL.md is 61 lines (ceiling 61; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/dogfood-verification/SKILL.md is 155 lines (ceiling 155; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/spec-property-retirement/SKILL.md is 328 lines (ceiling 328; headroom 0).
exit=0
```

`node scripts/pm/dispatch-gates.mjs` (no path args, derived from merge-base `02ebb6f5b`) names exactly one local gate for this diff: `pnpm check:pm-skill-ratchet` — run above, exit 0. `node scripts/check-nul-bytes.mjs` also clean (edited file only).

This diff publishes nothing (internal PM guard tooling only) — `skip-changeset` label applied.

_Generated by [Claude Code](https://claude.ai/code/session_01WswfK2yNYT9hNnMH6TzAwL)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01WswfK2yNYT9hNnMH6TzAwL)_