### PR TITLE
pm-dispatch: anchor instruction-architecture and governed-surface enforcement files to domain:skills

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -186,8 +186,8 @@ references);② 创建后手动 fire 一轮烟测,判据取**GitHub 上的产出
 | `domain:drivers` | `packages/drivers/driver-*`(维护者 2026-08-05 对 `driver-memory` / `driver-mongodb` 族有投入冻结指令;`formula` / `driver-sql` 不受影响) |
 | `domain:services` | `packages/services/*`、`packages/connectors/*`、`packages/triggers/*`、`plugin-approvals`、`plugin-webhooks`、`plugin-email`、`plugin-reports`、`embedder-openai`、`knowledge-*` |
 | `domain:identity` | `plugin-auth`、`plugin-security`、`plugin-sharing`、`plugin-audit` |
-| `domain:devx` | `packages/lint`、`packages/sdui-parser`、`content/docs/**`、`apps/docs`、`scripts/`(门禁类)—— 与 `domain:spec` 相交的三面按「是否围着 spec 契约转」切分 |
-| `domain:skills` | 两个技能根:`.claude/skills/**`(含本文件)+ `skills/**`(维护者 2026-08-11 裁定单设座位,与维护者走专题讨论;skills 更新 ADR-class,见 Guardrails) |
+| `domain:devx` | `packages/lint`、`packages/sdui-parser`、`content/docs/**`、`apps/docs`、`scripts/`(门禁类;与 `domain:skills` 的分界按门禁的 SUBJECT:治理 agent 指令面/governed 面的归 skills,治理代码/文档质量的归本域)—— 与 `domain:spec` 相交的三面按「是否围着 spec 契约转」切分 |
+| `domain:skills` | 两个技能根:`.claude/skills/**`(含本文件)+ `skills/**`(维护者 2026-08-11 裁定单设座位,与维护者走专题讨论;skills 更新 ADR-class,见 Guardrails);指令架构文件:根 `AGENTS.md` + 根 `CLAUDE.md`(所有面向 agent 的宪法文本);governed 面(统一定义见 ACCEPT 路径分叉)的治理执行文件:`.github/CODEOWNERS`(治理路由半边)+ SUBJECT 是 governed 面本身的门禁/审计(现为 `scripts/pm/check-governed-merges.mjs`,一句话见守卫索引;未来同类同判)—— 维护者 2026-08-18 裁决:「skills 相关的应该都归你管,为什么派给了 devx」 |
 | `domain:spec` | `packages/spec` 整包唯一契约,语义/文本/机器三面同席:schema 形状、`contracts/**`、退役行为半边、strictness 台账;describe/JSDoc/墓碑散文/错误 guidance 与 alias 表;`packages/spec/scripts/**`、`packages/spec/docs/**` 及围着 spec 契约转的工具链(门禁/生成器/lint 规则/报错散文/references 管线)—— 一般开发工具面留 `devx`(维护者 2026-08-09 裁决);席内分派判据见下文「spec 席内分派参考」 |
 | `domain:cli` | `packages/cli`、`runtime`、`verify`、`qa`、`types`、`packages/rest`、`packages/mcp`、`packages/observability`、`packages/client*`、`cloud-connection`、`create-objectstack`、`packages/adapters/*`、`plugin-hono-server`、`plugin-dev` |
 | (无固定归属,按落点分诊) | `packages/apps/*`、`packages/console`(dist 由脚本生成 ⛔ 手改;UI 缺陷走 `repo:objectui`,pin/刷新脚本归 `scripts/` 行)、`examples/*`(归它演练的子系统) |


### PR DESCRIPTION
Fixes #9528

## What

Two in-row amendments to the 域车道 table in `.claude/skills/pm-dispatch/SKILL.md`, per the maintainer ruling (2026-08-18, verbatim, untranslated): 「skills 相关的应该都归你管,为什么派给了 devx」

- **`domain:skills` row** now also carries: instruction-architecture files (root `AGENTS.md` + root `CLAUDE.md` — all agent-facing constitution text); the governance-routing half of the governed surface (`.github/CODEOWNERS`); and governance-enforcement gates/audits whose SUBJECT is the governed surface itself — currently `scripts/pm/check-governed-merges.mjs`, referenced by pointing at the existing guards-index row rather than duplicating it, with future same-subject gates judged the same way. The row cites the governed-surface unified definition already stated in the ACCEPT path-fork section rather than restating it.
- **`domain:devx` row** now states the boundary inline in its `scripts/`(门禁类) entry: the divider is the gate's SUBJECT — a gate governing agent-instruction surfaces (the governed surface) routes to `domain:skills`; a gate governing code/docs quality stays `domain:devx`.

## Ratchet payment table

| item | lines |
|:--|:--|
| SKILL.md before | 682 (ceiling 682, headroom 0) |
| SKILL.md after | 682 |
| lines added | 0 |
| lines cut as payment | 0 (none owed) |

Both amendments extend existing single-line table rows in place — the diff is 2 lines changed, 0 lines added, so no payment cut is owed and no re-wrap/line-merge was used. References files untouched. `pnpm check:pm-skill-ratchet` green at head `53b34c8`.

## Verification (all at head `53b34c8`, clean tree, after the final commit)

Gate union re-derived from the actual diff via `node scripts/pm/dispatch-gates.mjs` (no paths passed; change set = 1 file vs merge base `02ebb6f5b`) — the six derived families are exactly the six the dispatch named, nothing new:

- `pnpm check:pm-skill-ratchet` — exit 0
- `pnpm check:pm-skill-id-lint` — exit 0 (no issue-number citations in operational text)
- `pnpm check:pm-governed-merges` — exit 0
- `pnpm check:skill-frame-sync` — exit 0
- `pnpm check:doc-authoring` — exit 0
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — exit 0 (after building the lint dependency closure)

Also `node scripts/check-nul-bytes.mjs` — exit 0.

## Governed surface — human merge only

This PR edits `.claude/skills/**`, so it is itself on the governed surface: it stays a **draft** awaiting a human merge. Never flip it ready, never enqueue, never arm auto-merge.

`.claude/`-only diff publishes nothing ⇒ `skip-changeset` applies.

Out of scope by design: `AGENTS.md` untouched (devx PR rewriting PD#14 is in flight — disjoint file surfaces), `docs/adr/**` untouched, references files untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WswfK2yNYT9hNnMH6TzAwL)_