### PR TITLE
docs(plugin-audit): the published README documents the record-view audit surface that shipped

### DIFF
--- a/.changeset/mighty-ducks-repeat.md
+++ b/.changeset/mighty-ducks-repeat.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+Published README documents the record-view audit surface that actually shipped
+
+The README was corrected against the shipped surface before record-view auditing landed,
+so it still told readers that "reads and views are not on the ledger" and that the plugin
+takes no configuration. Both became false when the `read` action, its writer and the
+`record_views` list view merged. This is a docs-only change; it needs a version bump
+because the README is in the package's published `files` array, and a correction with no
+release never reaches the npm package page at all.
+
+What the page now documents, each point verified against the source rather than against a
+description of it:
+
+- the `read` action and its writer, in the action table and in the shipped list views;
+- the per-object opt-in as what it is — an **install-time list** passed to the plugin
+  constructor (`new AuditPlugin({ readAudit: { objects: [...] } })`), explicitly **not** an
+  `enable.auditReads` object-metadata key. A declarable key can be set on an object in a
+  deployment that never installs the plugin, producing metadata that reads as audited and
+  writes nothing, which is the exact class of claim this page was corrected to remove;
+- the three settings the plugin forwards, and the one writer knob (`maxBufferedEvents`) it
+  does not, which is reachable only by calling `installReadAuditWriter` directly;
+- the record-detail discriminator that keeps list and search reads out of scope, including
+  the `$or` / `$not` refusal and the AND-composed predicate the security middleware leaves
+  behind;
+- batched writes off the request path, the view-instant `created_at`, and the two loud
+  once-only failure postures (buffer overflow, failed ledger write);
+- the two declared boundaries — a system-elevated read and a read with no principal both
+  write no row;
+- that no field values are recorded, and therefore that the ledger cannot answer what a
+  viewer actually saw;
+- that the shipped `record_views` view carries an `ip_address` column which is always empty
+  on a `read` row, because no read-path writer stamps it.
+
+Record-view auditing adds no enterprise dependency: this package's declared edition is
+`open`, and the opt-in is ordinary plugin configuration. The two enterprise-dependent
+behaviours already annotated on the page — the hierarchy resolver and the archive
+datasource — are unchanged.

--- a/packages/plugins/plugin-audit/README.md
+++ b/packages/plugins/plugin-audit/README.md
@@ -5,11 +5,14 @@ System audit-trail objects for ObjectStack: the immutable `sys_audit_log` ledger
 
 ## What this package actually does
 
-`AuditPlugin` does two things when the kernel starts it:
+`AuditPlugin` does three things when the kernel starts it:
 
 1. **Registers three system objects** — `sys_audit_log`, `sys_activity`, `sys_comment`.
 2. **Installs ObjectQL hook subscribers** that write ledger and activity rows on data
    mutations, plus record-level access gates for `sys_comment`.
+3. **Installs the record-view writer** — an `afterFind` hook that records `read` rows for
+   the objects a deployment opted in, and is not installed at all when nothing is opted
+   in. See [Record-view auditing](#record-view-auditing--the-read-action).
 
 ⚠️ **There is no audit service you call to log a record change.** Record-level audit rows
 are produced by `afterInsert` / `afterUpdate` / `afterDelete` hooks, not by application
@@ -24,7 +27,8 @@ pnpm add @objectstack/plugin-audit
 
 ## Usage
 
-The plugin is a class, registered on the kernel. It takes no configuration:
+The plugin is a class, registered on the kernel. Write and activity auditing take no
+configuration at all:
 
 ```typescript
 import { AuditPlugin } from '@objectstack/plugin-audit';
@@ -32,8 +36,30 @@ import { AuditPlugin } from '@objectstack/plugin-audit';
 await kernel.use(new AuditPlugin());
 ```
 
-That is the whole setup surface. Coverage is not configured per object — see
-[Coverage](#coverage-subtraction-not-an-allow-list).
+Write coverage is not configured per object — see
+[Coverage](#coverage-subtraction-not-an-allow-list). The one thing that *is* configured is
+**record-view auditing**, which records nothing until objects are named:
+
+```typescript
+await kernel.use(
+  new AuditPlugin({
+    readAudit: { objects: ['contact', 'account'] },
+  }),
+);
+```
+
+`readAudit` is the only key `AuditPluginOptions` declares, and it accepts exactly three
+settings, no others:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `readAudit.objects` | `[]` | The closed per-object opt-in. Empty installs no hook |
+| `readAudit.maxBatchSize` | `50` | Flush once this many views are buffered |
+| `readAudit.flushIntervalMs` | `2000` | Flush this long after the first view of a batch |
+
+⚠️ The writer itself has one more knob — `maxBufferedEvents` (default `10000`) — that the
+plugin does **not** forward. Setting it requires calling `installReadAuditWriter` directly
+against the engine; there is no plugin-level spelling for it.
 
 The plugin depends on the ObjectQL engine (`com.objectstack.engine.objectql`) and resolves
 it at `kernel:ready`. If no engine is available it logs a warning and installs no writers.
@@ -46,6 +72,7 @@ these are the only values that are ever written:
 | `action` | Written by | On |
 |---|---|---|
 | `create` | `installAuditWriters` (this package) | `afterInsert` |
+| `read` | `installReadAuditWriter` (this package) | `afterFind`, on opted-in objects only, and only for record-detail views |
 | `update` | `installAuditWriters` (this package) | `afterUpdate`, only when the diff is non-empty |
 | `delete` | `installAuditWriters` (this package) | `afterDelete` |
 | `login` | `createAuthEventAuditSink` (this package), called by `@objectstack/plugin-auth` | session start |
@@ -65,7 +92,7 @@ written only by internal system hooks running under `sudo()`, never through UI f
 |---|---|---|
 | `id` | text | Audit log entry id |
 | `created_at` | datetime | When the action occurred (`NOW()` default) |
-| `action` | select | One of the seven values above |
+| `action` | select | One of the eight values above |
 | `user_id` | lookup → `sys_user` | Null for non-user / service actions |
 | `actor` | text | Principal label: a user id, `svc:<name>`, or null. Attributes service-token writes that `user_id` structurally cannot hold |
 | `object_name` | text | Target object, e.g. `sys_user` |
@@ -83,9 +110,15 @@ A credential *rotation* still produces a row — the raw values are compared for
 detection before masking is applied — so the audit trail of a secret change survives
 without the secret itself reaching the ledger.
 
-**`ip_address` / `user_agent` are populated on auth events only.** The record-level writer
-does not stamp them: a `create` / `update` / `delete` row records who and what, not from
-where. Do not read a null client fingerprint on a CRUD row as "the request had none".
+**`ip_address` / `user_agent` are populated on auth events only.** Neither the
+record-level writer nor the record-view writer stamps them: a `create` / `update` /
+`delete` / `read` row records who and what, not from where. Do not read a null client
+fingerprint on such a row as "the request had none". ⚠️ The shipped `record_views` list
+view carries an `ip_address` column, and on a `read` row that column is **always empty**
+for this reason.
+
+**`old_value` / `new_value` are null on every `read` row**, deliberately and not as an
+omission — see [Record-view auditing](#record-view-auditing--the-read-action).
 
 ## Coverage: subtraction, not an allow list
 
@@ -110,16 +143,131 @@ Excluded objects fall into two groups:
 The exclusion list is one definition consumed on both the registration face and inside the
 handlers, so the two cannot drift.
 
+⚠️ **Read coverage is the opposite shape** — a closed opt-in, not subtraction. The two are
+not inconsistent: for writes, an object nobody remembered to list is one whose changes go
+unrecorded, so the safe default is "audited"; for reads, the same default would record
+every record anyone opens on every object in the system, burying the views an auditor is
+actually looking for and charging every read for it. Read coverage is therefore
+enumerated, and the exclusion list applies on top of it — an excluded object cannot be
+opted in.
+
+## Record-view auditing — the `read` action
+
+Answers "who viewed this record, and when?". Nothing is recorded until a deployment names
+the objects it wants recorded.
+
+### The opt-in is an install-time list, not a metadata key
+
+⛔ There is no `enable.auditReads` object-metadata key and no global switch. The audited
+set is a constructor argument, given once at the place the plugin is installed:
+
+```typescript
+new AuditPlugin({ readAudit: { objects: ['contact', 'account'] } });
+```
+
+That shape is deliberate. A declarable metadata key can be set on an object in a
+deployment that never installs this plugin — producing a metadata file that *reads* as
+audited and writes nothing. A declaration a compliance reviewer mistakes for coverage is
+worse than an absent feature, and one input at the point of installation cannot make that
+claim.
+
+`installReadAuditWriter` filters the list before it registers anything:
+
+- names on the audit exclusion list above are **dropped with a warning** naming the object,
+  not silently accepted — the list is derived from the write-side exclusions rather than
+  re-typed, so the two cannot disagree;
+- duplicates and blanks are removed, and the returned handle reports `auditedObjects`,
+  i.e. what was actually registered rather than what was asked for;
+- an empty (or fully excluded) set registers **no hook at all**, so a deployment that opts
+  nothing in pays nothing on its read path.
+
+### Only record-detail views produce a row
+
+A read is recorded when **both** hold:
+
+1. it materialized exactly one record — `findOne` returning a record, not `find` returning
+   an array (an array, `null` or `undefined` result is never a detail view); and
+2. its predicate **pinned the primary key**. `GET /data/:object/:id` reaches the engine as
+   `findOne(object, { where: { id } })`, which is the record-detail surface. A `findOne`
+   carrying any other predicate is "give me *a* matching record" — an internal lookup, not
+   someone opening a record.
+
+The predicate walk tolerates what the security middleware leaves behind: an `id` equality
+AND-composed with an RLS/tenant clause still counts, and the explicit `{ id: { $eq: … } }`
+spelling is accepted. `$or` or `$not` anywhere on the path **disqualifies** the read — the
+row may have matched through the other arm, so the id equality no longer proves the read
+was for that record. Nesting is walked to a fixed depth of 8.
+
+⇒ **List and search reads are never recorded**, including a list read that happened to
+return exactly one record. List auditing is a deferred follow-up, and a deferral that
+leaked rows anyway would not be one.
+
+### Ledger writes happen off the request path
+
+The hook **enqueues and returns**; it awaits nothing. Rows are persisted on a later tick by
+a batcher, flushed whichever comes first — `maxBatchSize` views buffered (default 50) or
+`flushIntervalMs` since the batch's first view (default 2000ms) — and the plugin's
+`destroy()` drains the tail so a clean shutdown does not take the last batch with it.
+
+`created_at` on each row is the instant the record was **viewed**, not the instant its
+batch drained. Batching would otherwise stamp a whole batch with one flush timestamp, and a
+ledger that answers "when did they look?" with the time its own buffer emptied is wrong by
+up to the flush interval.
+
+Two failure postures, both loud once and never retried:
+
+- **Buffer overflow.** Past `maxBufferedEvents` (default 10000) the **oldest** buffered
+  views are dropped and a `warn` is logged once. The reads all still succeeded and returned
+  200, so nothing else reports the hole.
+- **A failed ledger write.** The batch is lost, an `error` is logged once, and the read is
+  unaffected — an audit write must never turn a valid read into an error, and retrying in a
+  loop against an unreachable table turns a degradation into an outage.
+
+### What the row contains — and what it deliberately does not
+
+A `read` row carries `action: 'read'`, the view instant on `created_at`, `user_id`,
+`actor`, `object_name`, `record_id`, and `tenant_id` — the viewed record's own
+organization, falling back to the viewer's session organization, so a row about an org-A
+record does not land behind org B's tenant wall. In multi-tenant mode, where the platform
+injects an `organization_id` column onto `sys_audit_log`, the same value is stamped there
+too: that column is what the row-level tenant wall gates on, and an unstamped row is one
+non-admin members can never see.
+
+⛔ **No field values are ever recorded.** `old_value` and `new_value` stay `null`. The
+`afterFind` hook runs *inside* the security middleware, ahead of its field masking, so the
+record it sees is pre-mask plaintext; copying values in would mint a plaintext copy of
+exactly what field-level security withholds, inside the one table compliance staff are
+granted broad access to. It follows that the ledger does not record *what the viewer
+actually saw* — only that they opened the record.
+
+Two boundaries are declared rather than left to be discovered:
+
+- **A system-elevated read writes no row.** Anything carrying `session.isSystem` — an
+  `api.sudo()` path, a formula recompute, a roll-up, a trigger — is the platform reading
+  for its own bookkeeping, not a person opening a record. Note `sudo()` keeps the caller's
+  user id, so this flag is the only thing separating the two.
+- **A read with no principal writes no row.** With neither a user id nor an actor there is
+  no answer to "who", and a row naming nobody only adds noise to the one query this
+  capability exists to serve.
+
+Rows surface in the shipped `record_views` list view.
+
 ## What the ledger does not record
 
 Stated explicitly, because a gap in an audit surface is easily mistaken for coverage:
 
-- **Reads and views are not on the ledger.** No writer emits a read action, and the record
-  writers subscribe only to `after*` write events. `sys_audit_log` answers "who changed
-  this record", not "who looked at it".
+- **Reads are on the ledger only where they were opted in, and only as record-detail
+  views.** An object absent from `readAudit.objects` produces no `read` row at all, and no
+  list or search read produces one on any object. See
+  [Record-view auditing](#record-view-auditing--the-read-action) for the full scope.
+- **What a viewer actually saw is not on the ledger.** A `read` row records who opened
+  which record; it carries no field values, so it cannot answer which fields were visible
+  to that viewer after masking.
 - **Failed operations are not on the ledger.** There is no success/failure column, and the
-  writers fire only on `after*` events — that is, only on operations that succeeded. A
-  failed write is not distinguishable from an absent one here.
+  write hooks fire only on `after*` events — that is, only on operations that succeeded. A
+  failed write is not distinguishable from an absent one here. The same holds for reads:
+  the `afterFind` hook is reached only by a read that succeeded, so a refused read leaves
+  no trace.
 - **Field-level read access is not on the ledger.**
 
 ## Reading audit rows
@@ -133,6 +281,7 @@ the standard object API or `services.data`, and through the shipped list views:
 | `recent` | Everything, newest first |
 | `writes_only` | `create` / `update` / `delete` |
 | `auth_events` | `login` / `logout` |
+| `record_views` | `read` — who opened which record |
 | `config_changes` | `config_change` / `import` |
 | `all_events` | Everything, larger page size |
 
@@ -198,6 +347,14 @@ those checks degrade to parent-record read visibility. If the engine exposes no 
 seam, `sys_comment` read visibility is not installed at all and the plugin logs a warning
 naming the consequence.
 
+**Record-view auditing adds no enterprise dependency.** The platform capability registry
+declares this package's edition as `open`; `read` rows are written by this package, and the
+opt-in is ordinary plugin configuration, so nothing about the capability degrades on an
+open build. The boundary above still applies to `read` rows the same way it applies to
+every other row — they are read through the same permission system, so a grant written with
+a hierarchy-relative scope shows a manager only their own record-view rows without the
+enterprise resolver.
+
 ## Exports
 
 ```typescript
@@ -206,6 +363,13 @@ export { AuditPlugin };
 
 // Writer installation + test probe
 export { installAuditWriters, createFieldPresenceProbe };
+
+// Record-view auditing (the `read` action)
+export { installReadAuditWriter, createReadAuditBatcher, extractDetailReadId, READ_AUDIT_ACTION };
+export type {
+  ReadAuditBatcher, ReadAuditBatcherOptions, ReadAuditEvent, ReadAuditLogger,
+  ReadAuditTimers, ReadAuditWriterHandle, ReadAuditWriterOptions,
+};
 
 // Auth-event ingress (the `audit` service slot)
 export { createAuthEventAuditSink };


### PR DESCRIPTION
Fixes #9517

This is the residual half of the card. PR #9531 (`53fc09922`) landed the urgent half — the SOC 2 / HIPAA / GDPR claim, the 12 fabricated `auditService` methods, the wrong row shape, the wrong object name and the 6 nonexistent REST routes are all gone from `main`, and two dependency boundaries were annotated. It correctly refused to document record-view auditing because that work was still an unmerged draft.

## Premise re-verified before editing anything

```
git merge-base --is-ancestor 5126e795d origin/main && echo landed
```

prints `landed`. `5126e795d` is `feat(plugin-audit): record-view auditing — who viewed which record (#8992) (#9515)`, so the blocker named in the previous round is cleared and the surface is now describable. Everything below was measured against `origin/main` at `53fc09922`, not against the card's description of it.

## What the README now documents

- **The `read` action**, in the action table with its writer and trigger, and the **`record_views`** list view in the views table.
- **The per-object opt-in as an install-time list**, with the constructor spelling and the three settings the plugin forwards.
- **Off-the-request-path batched writes** — enqueue-and-return, the size and timer flush thresholds, the `destroy()` tail drain, and why `created_at` holds the view instant rather than the flush instant.
- **The record-detail discriminator** — one materialized record plus a primary-key pin, the AND-composed predicate the security middleware leaves behind, the `$or` / `$not` refusal, and the depth bound. This is what keeps list and search reads out of scope, so it is stated as the scope rule rather than as trivia.
- **Both declared boundaries** — a system-elevated read and a read with no principal each write no row.
- **That no field values are recorded**, and the consequence: the ledger cannot answer what a viewer actually saw.

Two things only reading the code shows, both now on the page:

1. `maxBufferedEvents` (default 10000) is a **writer** knob the plugin does not forward. Documenting it as a plugin option would have been a small instance of exactly this card's defect.
2. The shipped `record_views` view carries an `ip_address` column that is **always empty** on a `read` row, because no read-path writer stamps it. Filed separately as #9539; documented here rather than left to surprise a reader.

## The opt-in is an install-time list, not a metadata key

The README says so explicitly, and says why. `enable.auditReads` appears on the page exactly once, in a sentence stating it does not exist — and the verification below asserts that, so a later edit cannot quietly turn the mention into a documented API.

## Scope 4 re-checked: record-view auditing introduces no enterprise boundary

`packages/spec/src/kernel/platform-capabilities.ts:143` declares `audit: { package: '@objectstack/plugin-audit', edition: 'open' }`. The `read` writer lives in this package, the opt-in is ordinary plugin configuration, and nothing about the capability degrades on an open build. ⇒ Nothing new is annotated under the `access-recipes.mdx` pattern; the page says so in one sentence rather than inventing a dependency. The two existing annotations (archive datasource fails closed to retention, hierarchy resolver fails closed to `own`) are untouched, and the second is noted as applying to `read` rows the same way it applies to every other row.

## Evidence: a set-equality check anyone can re-run

Matching the bar PR #9531 set. Save and run from the repo root:

```bash
cat > /tmp/check-audit-readme.mjs <<'EOF'
import { readFileSync } from 'node:fs';
const P = 'packages/plugins/plugin-audit/';
const readme = readFileSync(P + 'README.md', 'utf8');
const object = readFileSync(P + 'src/objects/sys-audit-log.object.ts', 'utf8');
const index  = readFileSync(P + 'src/index.ts', 'utf8');
const plugin = readFileSync(P + 'src/audit-plugin.ts', 'utf8');
const writer = readFileSync(P + 'src/read-audit.ts', 'utf8');
let bad = 0;
const eq = (label, doc, src) => {
  const d = [...new Set(doc)].sort(), s = [...new Set(src)].sort();
  const missing = s.filter((x) => !d.includes(x)), invented = d.filter((x) => !s.includes(x));
  const ok = !missing.length && !invented.length; if (!ok) bad++;
  console.log(`${ok ? 'OK  ' : 'FAIL'} ${label}: documented ${d.length} / declared ${s.length}` +
    (ok ? '' : `\n     omitted: ${JSON.stringify(missing)}\n     invented: ${JSON.stringify(invented)}`));
};
const section = (from, to) => {
  const a = readme.indexOf(from), b = to ? readme.indexOf(to, a + from.length) : readme.length;
  if (a < 0 || b < 0) throw new Error('section not found: ' + from);
  return readme.slice(a, b);
};
const firstCol = (text) => {
  const sep = text.search(/^\|[-\s|:]+\|\s*$/m);
  const body = sep < 0 ? text : text.slice(text.indexOf('\n', sep) + 1);
  return [...body.matchAll(/^\|\s*`([a-z_]+)`\s*\|/gm)].map((m) => m[1]);
};
eq('action enum', firstCol(section('## What lands on the ledger', '## `sys_audit_log` fields')),
  object.match(/action:\s*Field\.select\(\s*\[([^\]]*)\]/)[1]
    .split(',').map((s) => s.trim().replace(/^'|'$/g, '')).filter(Boolean));
eq('sys_audit_log fields', firstCol(section('## `sys_audit_log` fields', '**Secret masking.**')),
  [...object.matchAll(/^ {4}(\w+):\s*Field\./gm)].map((m) => m[1]));
eq('list views', firstCol(section('| View | Shows |', '\nIndexes are declared')),
  [...object.matchAll(/^ {4}(\w+):\s*\{\n\s*type: 'grid'/gm)].map((m) => m[1]));
const documented = [...section('## Exports', '## License').matchAll(/^export (?:type )?\{([^}]*)\}/gms)]
  .flatMap((m) => m[1].split(',').map((s) => s.trim()).filter(Boolean));
const unresolved = documented.filter((s) => !new RegExp(`(^|[\\s,{])${s}([\\s,}]|$)`, 'm').test(index));
if (unresolved.length) bad++;
console.log(`${unresolved.length ? 'FAIL' : 'OK  '} exports: ${documented.length} documented symbols` +
  (unresolved.length ? `\n     not exported by src/index.ts: ${JSON.stringify(unresolved)}` : ''));
const optRows = [...section('| Option | Default | Meaning |', '\n⚠️ The writer itself')
  .matchAll(/^\|\s*`readAudit\.(\w+)`\s*\|\s*`([^`]*)`\s*\|/gm)].map((m) => [m[1], m[2]]);
eq('readAudit options', optRows.map((r) => r[0]),
  [...plugin.slice(plugin.indexOf('interface AuditPluginReadAuditOptions'),
                   plugin.indexOf('interface AuditPluginOptions'))
    .matchAll(/^\s{2}(\w+)\??:/gm)].map((m) => m[1]));
const defs = Object.fromEntries([...writer.matchAll(
  /^\s{4}(maxBatchSize|flushIntervalMs|maxBufferedEvents) = ([\d_]+),/gm)]
  .map((m) => [m[1], m[2].replace(/_/g, '')]));
for (const [name, doc] of [...optRows, ['maxBufferedEvents', '10000']]) {
  if (!(name in defs)) continue;
  const ok = defs[name] === doc.replace(/[^\d]/g, ''); if (!ok) bad++;
  console.log(`${ok ? 'OK  ' : 'FAIL'} default ${name}: README ${doc} / source ${defs[name]}`);
}
const claimsKey = /`enable\.auditReads`/.test(readme) && !/There is no `enable\.auditReads`/.test(readme);
if (claimsKey) bad++;
console.log(`${claimsKey ? 'FAIL' : 'OK  '} enable.auditReads is named only to say it does not exist`);
console.log(bad === 0 ? '\nALL CHECKS PASSED' : `\n${bad} CHECK(S) FAILED`);
process.exit(bad === 0 ? 0 : 1);
EOF
node /tmp/check-audit-readme.mjs
```

Output at `4435acf66`:

```
OK   action enum: documented 8 / declared 8
OK   sys_audit_log fields: documented 13 / declared 13
OK   list views: documented 6 / declared 6
OK   exports: 28 documented symbols
OK   readAudit options: documented 3 / declared 3
OK   default maxBatchSize: README 50 / source 50
OK   default flushIntervalMs: README 2000 / source 2000
OK   default maxBufferedEvents: README 10000 / source 10000
OK   enable.auditReads is named only to say it does not exist

ALL CHECKS PASSED
```

Nothing is documented that the source does not declare, and nothing declared is left out: 8 of 8 action values, 13 of 13 fields, 6 of 6 list views, 28 of 28 export symbols resolving in `src/index.ts`, 3 of 3 plugin options with their defaults matching the writer's.

### The check is proven able to fail

A green check nobody has seen go red is an assurance, not evidence. Three ablations, each run against the committed tree and each restored to byte identity afterwards:

| Ablation | Result |
|---|---|
| delete the `read` row from the action table | `FAIL action enum: documented 7 / declared 8 — omitted: ["read"]` |
| delete the `record_views` row from the views table | `FAIL list views: documented 5 / declared 6 — omitted: ["record_views"]` |
| document `maxBatchSize` as 25 | `FAIL default maxBatchSize: README 25 / source 50` |

After restore, `git diff --stat HEAD` is empty and the check passes again.

## Gates

Derived from `git merge-base origin/main HEAD` (`53fc09922`) per #9320, not from a two-dot range: `node scripts/pm/dispatch-gates.mjs .changeset/mighty-ducks-repeat.md packages/plugins/plugin-audit/README.md` gives 8 path-derived plus 1 convention-triggered. All run at **`4435acf66`**, which is the branch tip and the tree every gate saw.

| Gate | Result |
|---|---|
| `check:changeset-gate-self-tests` | OK (118 + 206 + 116 assertions) |
| `check:objectui-changeset` | OK |
| `check:test-source-alias` | OK (72 packages) |
| `check:type-source-resolution` | OK (76 packages) |
| `check-adr-0087-registration.mjs` | OK (1 non-breaking changeset seen) |
| `check-changeset-no-major.mjs` | OK |
| `check-empty-changeset.mjs` | OK (1 declaring changeset added) |
| `check-affected-docs.mjs` | OK (220 self-test cases) |
| `check:i18n` (convention-triggered) | OK (9 packages, all bundles in sync) |
| `check:nul-bytes` (any edit) | OK (6151 files, 0 control bytes) |

`check:i18n` **refused the unbuilt tree first** (`PREREQUISITE NOT MET`, exit 1) and only went green after `turbo run build --filter=@objectstack/cli` (55 tasks). Reported green here is green, not skipped.

Package scope, after building the dependency closure (`pnpm --filter '@objectstack/plugin-audit^...' build`):

```
Test Files  17 passed (17)
     Tests  268 passed (268)
```

and `pnpm --filter @objectstack/plugin-audit typecheck` clean — the script name is echoed in the output, so this is not a zero-match silent pass. All heavy runs were serialized through `flock -E 99 -w 240 /tmp/os-heavy-verify.lock`; no queue timeouts.

⚠️ No dogfood ablation is claimed and none applies: the diff is one Markdown file plus a changeset, with zero executable code. The test and typecheck runs are a no-regression control, not evidence about README content — the set-equality check above is that evidence.

## Changeset

Owed, `patch`. PR #9531's reasoning is the precedent and it holds here: `README.md` is in this package's published `files` array with `private` unset, so **a docs-only correction with no version bump never reaches the npm package page at all**. The changeset is the mechanism that publishes the correction, not paperwork — which is why `skip-changeset` would be the wrong call.

## Findings filed, not fixed here

- **#9539** — `record_views` declares an `ip_address` column that no read-path writer stamps, so it is empty on every row that view can show. Same defect class as the #7675 / #8147 / #8315 enum retirements, one layer down. Not fixed here: it is a code change to a landed feature and does not meet the in-place bar for a docs-only PR.
- **#9540** (`finding`) — record-view auditing has no `content/docs` page; the only written scope is this README. Recorded, not claimed as a defect: `check:affected-docs` is green, and "the package README is the right home" is a legitimate disposition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_