### PR TITLE
docs(spec): FlowSchema terminal messages are every-terminal-run, not screen-flow-only (#9512)

### DIFF
--- a/.changeset/flow-terminal-messages-every-run-doc.md
+++ b/.changeset/flow-terminal-messages-every-run-doc.md
@@ -1,0 +1,16 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `FlowSchema.successMessage`/`errorMessage` describe themselves as carried on every terminal flow run, not screen-flow-only (#9512)
+
+Since #9414, the pair is set on `AutomationResult` for every terminal run —
+`execute()`'s exit, both `retryExecution()` exits, and the resume exit — not
+only on `screen`-flow runs. The JSDoc and `describe()` text above
+`successMessage`/`errorMessage` in `packages/spec/src/automation/flow.zod.ts`
+previously said "Terminal messages for `screen`-flow runs", which stayed the
+premise of a route considered and rejected at #9414's triage (narrowing the
+contract to screen-flow-only). Text-only: no schema shape, validation, or
+`authorable-surface.base.json` change. The two mirrored reference pages
+(`content/docs/references/automation/flow.mdx`,
+`content/docs/references/api/automation-api.mdx`) are regenerated to match.

--- a/content/docs/references/api/automation-api.mdx
+++ b/content/docs/references/api/automation-api.mdx
@@ -88,8 +88,8 @@ const result = AutomationApiErrorCode.parse(data);
 | **name** | `string` | ✅ | Machine name |
 | **label** | `string` | ✅ | Flow label |
 | **description** | `string` | optional |  |
-| **successMessage** | `string` | optional | Toast shown when a screen flow completes (defaults to a generic "Done"). |
-| **errorMessage** | `string` | optional | Toast shown when a screen flow fails (defaults to the raw error). |
+| **successMessage** | `string` | optional | Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of a generic "Done". |
+| **errorMessage** | `string` | optional | Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of the raw error. |
 | **version** | `integer` | optional (default: `1`) | Version number |
 | **status** | `Enum<'draft' \| 'active' \| 'obsolete' \| 'invalid'>` | optional (default: `"draft"`) | Deployment status |
 | **template** | `never` | optional | [REMOVED] `flow.template` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — no designer or engine path ever read it, so flagging a flow as a template/subflow did nothing. Delete the key. Shared logic is invoked via a subflow NODE referencing the flow by name. Run `os migrate meta --from 16` to rewrite existing sources automatically. |

--- a/content/docs/references/automation/flow.mdx
+++ b/content/docs/references/automation/flow.mdx
@@ -42,8 +42,8 @@ const result = FlowSchema.parse(data);
 | **name** | `string` | ✅ | Machine name |
 | **label** | `string` | ✅ | Flow label |
 | **description** | `string` | optional |  |
-| **successMessage** | `string` | optional | Toast shown when a screen flow completes (defaults to a generic "Done"). |
-| **errorMessage** | `string` | optional | Toast shown when a screen flow fails (defaults to the raw error). |
+| **successMessage** | `string` | optional | Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of a generic "Done". |
+| **errorMessage** | `string` | optional | Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of the raw error. |
 | **version** | `integer` | optional (default: `1`) | Version number |
 | **status** | `Enum<'draft' \| 'active' \| 'obsolete' \| 'invalid'>` | optional (default: `"draft"`) | Deployment status |
 | **template** | `never` | optional | [REMOVED] `flow.template` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — no designer or engine path ever read it, so flagging a flow as a template/subflow did nothing. Delete the key. Shared logic is invoked via a subflow NODE referencing the flow by name. Run `os migrate meta --from 16` to rewrite existing sources automatically. |

--- a/packages/spec/src/automation/flow.zod.ts
+++ b/packages/spec/src/automation/flow.zod.ts
@@ -616,14 +616,23 @@ export const FlowSchema = lazySchema(() => strictObject(
   description: z.string().optional(),
 
   /**
-   * Terminal messages for `screen`-flow runs. When the run reaches a terminal
-   * state, the UI flow-runner shows `successMessage` instead of a generic
-   * "Done" toast, and `errorMessage` instead of the raw error. Both are
-   * surfaced on the terminal {@link AutomationResult} (`successMessage` /
-   * `errorMessage`). Plain strings; `{var}` is NOT interpolated here.
+   * Terminal messages for the flow. Since #9414, carried on EVERY terminal
+   * run — `execute()`'s exit, both `retryExecution()` exits, and the resume
+   * exit — not only on `screen`-flow runs. The pair is set on the terminal
+   * {@link AutomationResult} (`successMessage` on success, `errorMessage` on
+   * failure) returned by any trigger route (e.g.
+   * `POST /api/v1/automation/:name/trigger`), whether or not a UI is
+   * listening; a `screen`-flow run additionally has the UI flow-runner show
+   * `successMessage` as a toast instead of a generic "Done", and
+   * `errorMessage` instead of the raw error. Reading this pair as
+   * screen-flow-only was the alternative considered and rejected at #9414's
+   * triage — narrowing the text would delete a declared, documented,
+   * console-consumed capability to make a bug disappear — so treat the
+   * screen-flow toast as one consumer, not the whole contract. Plain
+   * strings; `{var}` is NOT interpolated here.
    */
-  successMessage: z.string().optional().describe('Toast shown when a screen flow completes (defaults to a generic "Done").'),
-  errorMessage: z.string().optional().describe('Toast shown when a screen flow fails (defaults to the raw error).'),
+  successMessage: z.string().optional().describe('Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of a generic "Done".'),
+  errorMessage: z.string().optional().describe('Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of the raw error.'),
 
   /** Metadata & Versioning */
   version: z.number().int().default(1).describe('Version number'),


### PR DESCRIPTION
Fixes #9512

## What

`FlowSchema.successMessage`/`errorMessage` (`packages/spec/src/automation/flow.zod.ts`)
still described themselves as screen-flow-only text, but #9414 (merged as PR #9514,
`5aadce374`) made the engine carry the pair on every terminal flow run, not just resumed
screen flows. This PR rewrites the JSDoc and both `describe()` strings to state that
reality and to explicitly kill the screen-flow-only reading — that reading is the exact
premise of a route considered and **rejected** at #9414's triage ("narrow the contract
text to say these are screen-flow / resume-only"), and leaving the text phrased that way
kept the rejected route's premise alive and reachable.

## Before / after

`packages/spec/src/automation/flow.zod.ts:618-635`

```diff
   /**
-   * Terminal messages for `screen`-flow runs. When the run reaches a terminal
-   * state, the UI flow-runner shows `successMessage` instead of a generic
-   * "Done" toast, and `errorMessage` instead of the raw error. Both are
-   * surfaced on the terminal {@link AutomationResult} (`successMessage` /
-   * `errorMessage`). Plain strings; `{var}` is NOT interpolated here.
+   * Terminal messages for the flow. Since #9414, carried on EVERY terminal
+   * run — `execute()`'s exit, both `retryExecution()` exits, and the resume
+   * exit — not only on `screen`-flow runs. The pair is set on the terminal
+   * {@link AutomationResult} (`successMessage` on success, `errorMessage` on
+   * failure) returned by any trigger route (e.g.
+   * `POST /api/v1/automation/:name/trigger`), whether or not a UI is
+   * listening; a `screen`-flow run additionally has the UI flow-runner show
+   * `successMessage` as a toast instead of a generic "Done", and
+   * `errorMessage` instead of the raw error. Reading this pair as
+   * screen-flow-only was the alternative considered and rejected at #9414's
+   * triage — narrowing the text would delete a declared, documented,
+   * console-consumed capability to make a bug disappear — so treat the
+   * screen-flow toast as one consumer, not the whole contract. Plain
+   * strings; `{var}` is NOT interpolated here.
    */
-  successMessage: z.string().optional().describe('Toast shown when a screen flow completes (defaults to a generic "Done").'),
-  errorMessage: z.string().optional().describe('Toast shown when a screen flow fails (defaults to the raw error).'),
+  successMessage: z.string().optional().describe('Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of a generic "Done".'),
+  errorMessage: z.string().optional().describe('Message carried on AutomationResult for every terminal run (not only screen flows); the screen-flow UI shows it as a toast instead of the raw error.'),
```

Wording mirrors the general phrasing `contracts/automation-service.ts`'s `AutomationResult`
has always used ("`successMessage` is set on terminal success, `errorMessage` on
failure") — that file is untouched by this PR.

The two mirrored reference pages were regenerated via `pnpm --filter @objectstack/spec
gen:docs` and committed as the generator produced them, no hand edits:

- `content/docs/references/automation/flow.mdx`
- `content/docs/references/api/automation-api.mdx`

Both diffs are the identical two-line `describe()` text swap (table row for
`successMessage` / `errorMessage`), nothing else moved.

## Engine-site verification (re-verified on current `main`, not inherited)

`git rev-parse HEAD` at worktree creation: `02ebb6f5b` (current `main`, ancestor of the
unlock comment's `5aadce374`). `grep -n successMessage packages/services/service-automation/src/engine.ts`
→ 5 sites, matching the unlock comment's measurement:

- `engine.ts:3245` — explanatory comment (`execute()`'s terminal-success exit)
- `engine.ts:3263` — `execute()`'s terminal-success return: `successMessage: flow.successMessage,`
- `engine.ts:4104` — the resume/bubble-up terminal exit: `successMessage: flow.successMessage,`
- `engine.ts:6350` — explanatory comment (`retryExecution()`'s success exit)
- `engine.ts:6352` — `retryExecution()`'s success return: `successMessage: flow.successMessage, …`

Three real assignment sites (`execute()`, the resume exit, `retryExecution()`'s success
exit) plus two explanatory comments = the 5 grep hits. Confirms the pair is carried on
every terminal exit, not only the two `resumeInternal` sites that existed pre-#9414.

## authorable-surface re-verification (measured here, not inherited)

Re-ran `pnpm --filter @objectstack/spec check:generated` after the edit:

```
✓ check:authorable-surface   authorable-surface/ + authorable-defaults/ (+ its .base.json anchor) + JSON schemas
```

`git status --porcelain` shows **no** change under `packages/spec/authorable-surface/` or
`packages/spec/authorable-surface.base.json` — the filer's claim holds: the `describe()`
text is not part of that generated artifact. This stays a text change, not a spec-surface
change.

## Tests / gates

Head verified: `e89d5c48b` (this PR's tip; the gate run below is on this exact tree).

- `pnpm --filter @objectstack/spec build` — clean.
- `pnpm --filter @objectstack/spec check:generated` — 13/13 green (docs regenerated once,
  then clean; authorable-surface untouched — see above).
- `pnpm --filter @objectstack/spec test` — 409 test files / 10937 tests passed.
- `pnpm --filter @objectstack/spec typecheck` — clean (`tsc --noEmit`, `check:scripts-typecheck`,
  `check:test-typecheck`).
- `node scripts/check-nul-bytes.mjs` — OK, 6150 files scanned.
- Named gates from `node scripts/pm/dispatch-gates.mjs packages/spec/src/automation/flow.zod.ts`,
  all green: `check:cross-package-test-inputs`, `check:doc-formula-expressions`,
  `check:empty-state`, `check:liveness`, `check:merge-driver`, `check:spec-parsed-alias`,
  `check:strictness-ledger`, `check:type-source-resolution`, `check:variant-docs`,
  `scripts/check-cross-package-test-inputs.mjs`, `scripts/docs-audit/check-affected-docs.mjs`.
- `node scripts/check-dev-prereqs.mjs` — **not run to green**: it requires the full
  monorepo `dist/` (64 of 67 packages unbuilt in this fresh worktree), which is unrelated
  to this text-only diff and out of scope for targeted local verification. CI's lint.yml
  pipeline builds the full workspace before this step runs.

## Scope

Text only: `packages/spec/src/automation/flow.zod.ts`'s JSDoc + two `describe()` strings,
the two generated reference pages, and a patch changeset for `@objectstack/spec`. No
engine edits, no `contracts/automation-service.ts` edits, no schema/shape change, no
`content/docs/releases/` edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_