### PR TITLE
fix(metadata-protocol): the sys_setting degradation report prints a duplicate probe MySQL can run (#9434)

### DIFF
--- a/.changeset/sys-setting-probe-mysql-spelling.md
+++ b/.changeset/sys-setting-probe-mysql-spelling.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): the sys_setting degradation report hands MySQL operators a duplicate-probe statement MySQL can actually run (#9434)
+
+When `sys_setting`'s NULL-safe row-identity index cannot be built, the migration
+degrades and prints a query so the operator can list the duplicate rows
+themselves. The `unsupported` arm is reached specifically on MySQL/MariaDB — no
+functional key parts, no `CREATE INDEX IF NOT EXISTS` — so that arm's audience is
+exactly one dialect, and the statement it printed used bare identifiers. `key` is
+a RESERVED word on MySQL, so the one remedy offered to a MySQL operator came back
+as `ERROR 1064 (42000)`, measured on a live MySQL 8.0.46. Nothing in the platform
+executes the statement, so no boot path was affected — what failed was the
+operator's copy-paste, in the arm that has no other remedy to offer.
+
+That arm now prints the MySQL spelling: every identifier quoted with backticks,
+the convention `seed-tenancy-backfill.ts` adopted for the same reason in #9381.
+Both spellings are generated from one body over one key-part array, so the
+operator's list and the index's own key cannot drift apart, and the ANSI
+statement `buildSysSettingDuplicateProbeSql()` returns is unchanged byte for byte
+— the `conflict` arm still prints it, because a conflict means real rows blocked
+a build the server was willing to attempt, which only SQLite and PostgreSQL ever
+are.
+
+Identifiers are quoted uniformly rather than only where a word looks reserved:
+MySQL's reserved-word list grows across point releases, and #9381's `last_value`
+is the recorded case of quoting the table while leaving a reserved column bare.
+
+The `CREATE UNIQUE INDEX` statement is deliberately untouched and still bare.
+MySQL refuses it for reasons quoting does not reach — unparenthesized `COALESCE`
+key parts — and that verdict is now checked on a live server rather than
+asserted, in both its quoted and unquoted spellings.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -745,8 +745,21 @@ jobs:
       # into a warning, so the symptom was a skipped repair in the log.
       #
       # This rides this job rather than getting its own because this is where a
-      # live MySQL already exists. Only the live file runs: the rest of the
+      # live MySQL already exists. Only the live files run: the rest of the
       # package's suite has no server axis and runs in Test Core.
+      #
+      # The argument is a FILTER, not the one path it started as (#9434). A
+      # second migration in this family needed the same server — `sys_setting`'s
+      # degradation report prints an operator query in which `key` is a MySQL
+      # reserved word — and a named-path list is the shape where the next such
+      # file is added, is green locally because it SKIPS without a server, and is
+      # never run here at all. A test that cannot fail reports success.
+      #
+      # `live-mysql` and not `src/migrations/*.live-mysql.test.ts`: vitest's
+      # positional arguments are SUBSTRING filters against the resolved test
+      # paths, not shell globs — measured, the glob form matches zero files
+      # ("No test files found", exit 1). Loud rather than silent, but still
+      # wrong; the substring is the form that actually selects both.
       - name: Build metadata-protocol and its dependencies
         run: pnpm exec turbo run build --filter=@objectstack/metadata-protocol... --concurrency=4
 
@@ -758,8 +771,7 @@ jobs:
           # and must be a red rather than a skip.
           OS_EXPECT_LIVE_DIALECT_MATRIX: '1'
         run: |
-          pnpm --filter @objectstack/metadata-protocol exec vitest run \
-            src/migrations/seed-tenancy-backfill.live-mysql.test.ts
+          pnpm --filter @objectstack/metadata-protocol exec vitest run live-mysql
 
   dogfood:
     # Sharded 3-way: the suite is ~60 independent test files, each booting its

--- a/packages/metadata-protocol/src/migrations/sys-setting-identity-index.live-mysql.test.ts
+++ b/packages/metadata-protocol/src/migrations/sys-setting-identity-index.live-mysql.test.ts
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #9434 — the `sys_setting` degradation report's duplicate probe, RUN on a live
+ * MySQL.
+ *
+ * ## Why this file exists rather than one more text pin
+ *
+ * The defect is invisible on the two dialects the rest of the suite runs on.
+ * `key` is non-reserved on PostgreSQL and not a keyword at all on SQLite, so the
+ * bare statement is perfectly good SQL there — a SQLite-only test passes with
+ * the bug fully present, which is exactly what happened: the sibling suite even
+ * EXECUTES the bare probe against a real SQLite and stayed green while MySQL
+ * operators were being handed `ERROR 1064`.
+ *
+ * And the obvious cheap test is worse than none. Asserting that the message
+ * "contains a backtick" would pass over any misquoted statement — a backtick in
+ * the wrong place, a half-quoted projection, a `GROUP BY` that no longer matches
+ * the projection under `ONLY_FULL_GROUP_BY`. Only a server can answer "does this
+ * parse", so a server answers it.
+ *
+ * ## What is proved here, and in which direction
+ *
+ * Both directions, because one alone is not evidence:
+ *
+ *   - the MySQL-spelled statement RUNS, and returns the duplicate rows; and
+ *   - the bare statement — the one the module printed before this fix — is
+ *     REJECTED by the same server in the same session, with `ER_PARSE_ERROR`.
+ *
+ * Without the second, a server that had somehow accepted the bare form would
+ * give a green run that means nothing. It is the card's own measurement, kept
+ * live rather than quoted.
+ *
+ * The end-to-end leg goes further and takes the statement out of the LOG MESSAGE
+ * `ensureSysSettingIdentityIndex` actually emits, rather than calling the builder
+ * — because what is on trial is the operator's copy-paste, and a builder that is
+ * right while the message interpolates the other one is the whole defect.
+ *
+ * ## The CREATE INDEX is deliberately proved to STAY refused
+ *
+ * `buildSysSettingIdentityIndexSql` is NOT quoted by this card, and the module's
+ * header says quoting would not change MySQL's verdict on it. That claim is
+ * checked here rather than trusted: the statement is refused by this server for
+ * reasons quoting does not touch (unparenthesized functional key parts). It
+ * guards the reasoning in both directions — if MySQL ever accepts it, the
+ * `unsupported` arm this whole card is about stops being the arm MySQL reaches.
+ *
+ * ## Non-vacuity
+ *
+ * The suite ASSERTS the server is not running with `ANSI_QUOTES` and IS running
+ * with `ONLY_FULL_GROUP_BY` before it asserts anything else — the first because
+ * a server with it would parse quotes differently, the second because it is what
+ * makes the `GROUP BY`/projection pairing a real constraint rather than a
+ * formality. Same vacuous-pass guard as the sibling `#9381` file.
+ *
+ * ## Provisioning
+ *
+ * Needs `OS_TEST_MYSQL_URL` (the variable the driver-sql live matrix uses) and
+ * reports a named SKIP without one — never a silent pass. A runner that knows it
+ * provisioned the server sets `OS_EXPECT_LIVE_DIALECT_MATRIX=1`, which turns a
+ * missing URL into a failure so a dropped `env:` line cannot quietly return this
+ * seam to no coverage.
+ *
+ * Everything runs in its OWN database (`os_metadata_protocol_9434`), created on
+ * the spot, because `sys_setting` is a fixed platform table name that other live
+ * suites also use.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import mysql from 'mysql2/promise';
+
+import {
+    buildSysSettingDuplicateProbeSql,
+    buildSysSettingDuplicateProbeSqlMysql,
+    buildSysSettingIdentityIndexSql,
+    ensureSysSettingIdentityIndex,
+    SYS_SETTING_IDENTITY_INDEX_NAME,
+    SYS_SETTING_TABLE,
+} from './sys-setting-identity-index.js';
+import type { IndexExec } from './partial-index-probe.js';
+
+const MYSQL_URL = process.env.OS_TEST_MYSQL_URL;
+const EXPECT_LIVE = process.env.OS_EXPECT_LIVE_DIALECT_MATRIX === '1';
+const DB = 'os_metadata_protocol_9434';
+
+/**
+ * The sentence the `unsupported` arm ends with, immediately before the
+ * statement. Pinned here so the extraction below cannot silently start reading
+ * the wrong half of the message — if the wording moves, this leg goes red rather
+ * than running an empty string and passing.
+ */
+const STATEMENT_LEAD_IN = 'watch for duplicates with this MySQL statement: ';
+
+if (!MYSQL_URL && EXPECT_LIVE) {
+    describe('#9434 live MySQL', () => {
+        it('OS_TEST_MYSQL_URL must be set — this runner declared it provisioned a server', () => {
+            throw new Error(
+                'OS_EXPECT_LIVE_DIALECT_MATRIX=1 without OS_TEST_MYSQL_URL: the live MySQL cell for ' +
+                    "the sys_setting degradation report would have been skipped, returning #9434 to zero " +
+                    'coverage on the only dialect that can exhibit it.',
+            );
+        });
+    });
+}
+
+describe.skipIf(!MYSQL_URL)('#9434 the sys_setting duplicate probe on a LIVE MySQL', () => {
+    let conn: mysql.Connection;
+
+    beforeAll(async () => {
+        const bootstrap = await mysql.createConnection(MYSQL_URL!);
+        await bootstrap.query(`CREATE DATABASE IF NOT EXISTS \`${DB}\``);
+        await bootstrap.end();
+
+        conn = await mysql.createConnection(`${MYSQL_URL}`);
+        await conn.query(`USE \`${DB}\``);
+        // The one session SET `SqlDriver` itself performs on a mysql connection.
+        await conn.query(`SET time_zone = '+00:00'`);
+
+        // The table as `platform-objects` declares it, in MySQL's own spelling —
+        // the fixture has to quote `key` for the same reason the probe does.
+        await conn.query(`DROP TABLE IF EXISTS \`${SYS_SETTING_TABLE}\``);
+        await conn.query(
+            `CREATE TABLE \`${SYS_SETTING_TABLE}\` (` +
+                '`id` VARCHAR(64) PRIMARY KEY, `organization_id` VARCHAR(64) NULL, ' +
+                '`namespace` VARCHAR(128) NOT NULL, `key` VARCHAR(128) NOT NULL, ' +
+                '`scope` VARCHAR(32) NOT NULL, `user_id` VARCHAR(64) NULL, `value` TEXT)',
+        );
+        // Two tenant-scope rows for ONE (organization, namespace, key) with the
+        // NULL `user_id` that makes the declared index void — the exact shape the
+        // operator is being asked to go looking for.
+        await conn.query(
+            `INSERT INTO \`${SYS_SETTING_TABLE}\` ` +
+                '(`id`, `organization_id`, `namespace`, `key`, `scope`, `user_id`, `value`) VALUES ' +
+                "('d1','org_jia','lifecycle','retention_overrides','tenant',NULL,'\"v1\"')," +
+                "('d2','org_jia','lifecycle','retention_overrides','tenant',NULL,'\"v2\"')," +
+                "('u1','org_jia','lifecycle','retention_overrides','user','usr_1','\"v3\"')",
+        );
+    });
+
+    afterAll(async () => {
+        if (!conn) return;
+        await conn.query(`DROP DATABASE IF EXISTS \`${DB}\``);
+        await conn.end();
+    });
+
+    it('the server is NOT on ANSI_QUOTES and IS on ONLY_FULL_GROUP_BY — without this the run proves nothing', async () => {
+        const [rows] = await conn.query('SELECT @@session.sql_mode AS sql_mode, VERSION() AS version');
+        const mode = String((rows as Array<{ sql_mode: string }>)[0]!.sql_mode);
+        // Printed so the CI log carries the measurement, not just the verdict.
+        // eslint-disable-next-line no-console
+        console.log(
+            `[#9434] live MySQL ${(rows as Array<{ version: string }>)[0]!.version} sql_mode=${mode}`,
+        );
+        expect(mode).not.toContain('ANSI_QUOTES');
+        expect(mode).toContain('ONLY_FULL_GROUP_BY');
+    });
+
+    it('CONTROL: the bare statement this module used to print is REJECTED — ER_PARSE_ERROR', async () => {
+        // The card's measurement, kept live. Without this the green above could
+        // mean "MySQL accepts both spellings" rather than "the fix was needed".
+        await expect(conn.query(buildSysSettingDuplicateProbeSql())).rejects.toMatchObject({
+            code: 'ER_PARSE_ERROR',
+        });
+    });
+
+    it('the MySQL-spelled statement PARSES, and lists exactly the duplicate group', async () => {
+        const [rows] = await conn.query(buildSysSettingDuplicateProbeSqlMysql());
+        expect(rows).toEqual([
+            {
+                organization_id_key: 'org_jia',
+                namespace: 'lifecycle',
+                key: 'retention_overrides',
+                scope: 'tenant',
+                user_id_key: '',
+                duplicate_rows: 2,
+            },
+        ]);
+    });
+
+    it('END TO END: the statement an operator copies OUT OF THE LOG runs on this server', async () => {
+        // What is on trial is the copy-paste, not the builder. A correct builder
+        // whose output never reaches the message is the defect itself.
+        const messages: string[] = [];
+        const logger = { error: (m: string) => messages.push(m), warn: () => {}, info: () => {} };
+        // A seam that answers the presence probe and refuses the DDL the way this
+        // MySQL does — the module's own `unsupported` classification path.
+        const refusing: IndexExec = async (sql: string) => {
+            if (/^CREATE UNIQUE INDEX/i.test(sql)) {
+                throw new Error("You have an error in your SQL syntax near '(COALESCE'");
+            }
+            return conn.query(sql) as unknown as Promise<unknown>;
+        };
+
+        const result = await ensureSysSettingIdentityIndex(refusing, logger as never);
+        expect(result.status).toBe('unsupported');
+
+        const [message] = messages;
+        expect(message).toContain(STATEMENT_LEAD_IN);
+        const copied = message!.slice(message!.indexOf(STATEMENT_LEAD_IN) + STATEMENT_LEAD_IN.length);
+        expect(copied.length).toBeGreaterThan(0);
+
+        // The whole point of the card, measured: paste it, and it runs.
+        const [rows] = await conn.query(copied);
+        expect((rows as unknown[]).length).toBe(1);
+    });
+
+    it('the CREATE INDEX stays refused whatever the quoting — the header verdict this card did NOT touch', async () => {
+        // Quoting rescues the SELECT and nothing about the CREATE: MySQL refuses
+        // the unparenthesized functional key parts. Measured, so the reasoning
+        // left standing in the module header is not merely asserted.
+        await expect(
+            conn.query(buildSysSettingIdentityIndexSql(SYS_SETTING_IDENTITY_INDEX_NAME)),
+        ).rejects.toMatchObject({ code: 'ER_PARSE_ERROR' });
+
+        // …and not because of `key`: the same statement with every identifier
+        // quoted MySQL's way is refused too. This is what makes "quoting would
+        // not change that verdict" a measurement rather than a guess.
+        const quoted = buildSysSettingIdentityIndexSql(SYS_SETTING_IDENTITY_INDEX_NAME)
+            .replace(/\bkey\b(?=,)/, '`key`')
+            .replace(new RegExp(`\\b${SYS_SETTING_TABLE}\\b(?= \\()`), `\`${SYS_SETTING_TABLE}\``);
+        await expect(conn.query(quoted)).rejects.toMatchObject({ code: 'ER_PARSE_ERROR' });
+    });
+});

--- a/packages/metadata-protocol/src/migrations/sys-setting-identity-index.test.ts
+++ b/packages/metadata-protocol/src/migrations/sys-setting-identity-index.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
     buildSysSettingDuplicateProbeSql,
+    buildSysSettingDuplicateProbeSqlMysql,
     buildSysSettingIdentityIndexSql,
     buildSysSettingPresenceSql,
     ensureSysSettingIdentityIndex,
@@ -292,6 +293,12 @@ describe('sys_setting row-identity uniqueness (#8629)', () => {
             expect(message).toContain('no row is discarded automatically');
             expect(message).toContain(buildSysSettingDuplicateProbeSql());
             expect(message).toContain('os migrate plan');
+            // #9434 stays out of THIS arm: a conflict means real rows blocked a
+            // build the server was willing to attempt, which only SQLite and
+            // PostgreSQL ever are. MySQL refuses the statement outright and
+            // lands in `unsupported`, so backticks here would be wrong for
+            // every reader who can actually reach this line.
+            expect(message).not.toContain(buildSysSettingDuplicateProbeSqlMysql());
         });
 
         it('the shipped query lists the offending rows, on the folded key', () => {
@@ -386,6 +393,78 @@ describe('sys_setting row-identity uniqueness (#8629)', () => {
             expect(sql).toContain("COALESCE(user_id, '') AS user_id_key");
             expect(sql).not.toMatch(/SELECT organization_id,/);
         });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // #9434 — the MySQL spelling of that same query.
+        //
+        // ⚠️ Nothing in THIS file can prove the statement parses on MySQL: the
+        // suite runs on SQLite, which accepts backticks (MySQL compatibility)
+        // and also accepted the broken bare form, so a green run here is
+        // compatible with the defect being fully present. That proof lives in
+        // `sys-setting-identity-index.live-mysql.test.ts`, which runs the
+        // statement on a real server. What these assertions add is the half a
+        // live server cannot check — that the two spellings describe the SAME
+        // key — plus a byte pin a reviewer can read against MySQL's manual.
+        // ─────────────────────────────────────────────────────────────────────
+        it('the MySQL spelling quotes EVERY identifier, and leaves the bare one untouched', () => {
+            expect(buildSysSettingDuplicateProbeSqlMysql()).toBe(
+                'SELECT COALESCE(`organization_id`, \'__global__\') AS `organization_id_key`, ' +
+                    '`namespace`, `key`, `scope`, COALESCE(`user_id`, \'\') AS `user_id_key`, ' +
+                    'COUNT(*) AS `duplicate_rows` FROM `sys_setting` ' +
+                    'GROUP BY COALESCE(`organization_id`, \'__global__\'), `namespace`, `key`, ' +
+                    '`scope`, COALESCE(`user_id`, \'\') HAVING COUNT(*) > 1',
+            );
+            // The bare builder is the package's existing surface and several
+            // callers execute it on SQLite/PostgreSQL — adding a variant must
+            // not have moved it.
+            expect(buildSysSettingDuplicateProbeSql()).toBe(
+                "SELECT COALESCE(organization_id, '__global__') AS organization_id_key, " +
+                    "namespace, key, scope, COALESCE(user_id, '') AS user_id_key, " +
+                    'COUNT(*) AS duplicate_rows FROM sys_setting ' +
+                    "GROUP BY COALESCE(organization_id, '__global__'), namespace, key, scope, " +
+                    "COALESCE(user_id, '') HAVING COUNT(*) > 1",
+            );
+            // No identifier left bare — not a list of MySQL's reserved words,
+            // which is version-dependent, but the rule that makes such a list
+            // unnecessary (#9381's lesson, carried forward).
+            expect(buildSysSettingDuplicateProbeSqlMysql()).not.toMatch(/[ ,(]key\b/);
+            expect(buildSysSettingDuplicateProbeSqlMysql()).not.toMatch(/FROM sys_setting/);
+        });
+
+        it('differs from the bare spelling ONLY in the quoting — same key, same query', () => {
+            // Strip the backticks and the MySQL statement must be the bare one,
+            // character for character. This is the invariant a hand-written
+            // second statement would break: the two would drift into grouping by
+            // different keys and the operator's list would stop matching what
+            // the index rejects.
+            expect(buildSysSettingDuplicateProbeSqlMysql().replace(/`/g, '')).toBe(
+                buildSysSettingDuplicateProbeSql(),
+            );
+        });
+
+        it('and returns the same rows — the folded key survives the re-spelling', () => {
+            // SQLite takes backticks too, so it can answer the EQUIVALENCE
+            // question (do both spellings select the same thing?) even though it
+            // cannot answer the parse question for MySQL.
+            const dup = { namespace: 'lifecycle', key: 'retention_overrides', scope: 'tenant' };
+            insert('m1', { ...dup, organization_id: 'org_jia' });
+            insert('m2', { ...dup, organization_id: 'org_jia' });
+
+            const bare = db.prepare(buildSysSettingDuplicateProbeSql()).all();
+            const mysql = db.prepare(buildSysSettingDuplicateProbeSqlMysql()).all();
+
+            expect(mysql).toEqual(bare);
+            expect(bare).toEqual([
+                {
+                    organization_id_key: 'org_jia',
+                    namespace: 'lifecycle',
+                    key: 'retention_overrides',
+                    scope: 'tenant',
+                    user_id_key: '',
+                    duplicate_rows: 2,
+                },
+            ]);
+        });
     });
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -443,7 +522,13 @@ describe('sys_setting row-identity uniqueness (#8629)', () => {
             expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(DECLARED_INDEX_DDL);
             const [message] = logger.error.mock.calls[0]!;
             expect(message).toContain('stays NULL-distinct on user_id');
-            expect(message).toContain(buildSysSettingDuplicateProbeSql());
+            // #9434: this arm is reached on MySQL/MariaDB by construction, so the
+            // one remedy it offers has to be spelled for MySQL — `key` is
+            // reserved there and the bare form is ERROR 1064, i.e. no remedy at
+            // all. The negative is the half that would have caught the defect:
+            // the old message contained the bare statement and read fine.
+            expect(message).toContain(buildSysSettingDuplicateProbeSqlMysql());
+            expect(message).not.toContain(buildSysSettingDuplicateProbeSql());
         });
 
         it('an unclassifiable failure is still reported at error, with the previous index kept', async () => {

--- a/packages/metadata-protocol/src/migrations/sys-setting-identity-index.ts
+++ b/packages/metadata-protocol/src/migrations/sys-setting-identity-index.ts
@@ -208,17 +208,57 @@ export const SYS_SETTING_NULL_SENTINELS: Readonly<Record<string, string>> = {
 };
 
 /**
+ * How ONE identifier is spelled.
+ *
+ * Every statement this module *executes* uses {@link BARE} — the platform's own
+ * spelling, which SQLite and PostgreSQL take verbatim. {@link MYSQL_IDENT} is
+ * the single dialect-specific alternative, and it is used only where the reader
+ * is known to be MySQL: the `unsupported` arm's operator query (#9434).
+ */
+type IdentifierQuote = (name: string) => string;
+
+/** Identifiers exactly as declared. What every executed statement here emits. */
+const BARE: IdentifierQuote = (name) => name;
+
+/**
+ * MySQL's identifier quote — backticks, with an embedded backtick doubled.
+ *
+ * Deliberately NOT the ANSI `"name"`: MySQL does not run with `ANSI_QUOTES`, so
+ * `"name"` there is a STRING LITERAL and not an identifier at all. Measured on
+ * a live MySQL 8.0.46 by #9381, whose `quoteIdent` in `seed-tenancy-backfill.ts`
+ * this mirrors on purpose — that sibling shipped the ANSI spelling and every one
+ * of its statements came back `ER_PARSE_ERROR`.
+ *
+ * ⚠️ It quotes EVERY identifier handed to it, never only the ones that look
+ * reserved. That is #9381's other recorded lesson (its `last_value` was reserved
+ * and unquoted while the table beside it was quoted), and it is why this module
+ * carries no list of MySQL's reserved words: such a list is version-dependent —
+ * MySQL adds reserved words in point releases — and being wrong about a single
+ * entry reinstates the whole defect. Quoting everything cannot be wrong about a
+ * word, and costs the operator nothing but backticks.
+ */
+const MYSQL_IDENT: IdentifierQuote = (name) => `\`${name.replace(/`/g, '``')}\``;
+
+/** {@link sysSettingIdentityKeyParts}, in a chosen identifier spelling. */
+function keyPartsIn(quote: IdentifierQuote): string[] {
+    return SYS_SETTING_IDENTITY_INDEX_COLUMNS.map((column) => {
+        const sentinel = SYS_SETTING_NULL_SENTINELS[column];
+        const ident = quote(column);
+        return sentinel === undefined ? ident : `COALESCE(${ident}, '${sentinel}')`;
+    });
+}
+
+/**
  * The index's key parts, in key order: a bare column, or its NULL-safe
  * `COALESCE` form when {@link SYS_SETTING_NULL_SENTINELS} names one.
  *
  * One builder so the CREATE, the duplicate-listing query the conflict report
- * ships, and the degradation messages can never describe different keys.
+ * ships, and the degradation messages can never describe different keys — and,
+ * since #9434, so the MySQL-spelled operator query cannot describe a different
+ * key either: it is this same array under a different quote.
  */
 export function sysSettingIdentityKeyParts(): string[] {
-    return SYS_SETTING_IDENTITY_INDEX_COLUMNS.map((column) => {
-        const sentinel = SYS_SETTING_NULL_SENTINELS[column];
-        return sentinel === undefined ? column : `COALESCE(${column}, '${sentinel}')`;
-    });
+    return keyPartsIn(BARE);
 }
 
 /**
@@ -274,14 +314,67 @@ export function buildSysSettingPresenceSql(): string {
  * `user_id_key = ''` as "user_id IS NULL".
  */
 export function buildSysSettingDuplicateProbeSql(): string {
-    const keyParts = sysSettingIdentityKeyParts();
+    return duplicateProbeSqlIn(BARE);
+}
+
+/**
+ * The SAME query, spelled for MySQL — for the one arm whose reader is a MySQL
+ * operator and whose server rejects the bare form (#9434).
+ *
+ * ## Why a second spelling exists at all
+ *
+ * `key` is a RESERVED word on MySQL, so the bare statement above is not a
+ * degraded-but-usable query there — it is `ERROR 1064`, measured on MySQL
+ * 8.0.46. The `unsupported` arm is reached *specifically* on MySQL/MariaDB —
+ * `classifyIndexFailure`'s dialect arm in `partial-index-probe.ts` stands for
+ * exactly the two refusals MySQL raises — so the one remedy that arm offered was
+ * a statement its only audience could not run: the operator is told to watch for
+ * duplicates and handed a parse error to do it with.
+ *
+ * ## Why a variant, and not a dialect threaded through the migration
+ *
+ * Because nothing executes this string. `ensureSysSettingIdentityIndex` takes a
+ * bare {@link IndexExec} and has no dialect in hand; giving it one — the route
+ * the sibling `seed-tenancy-backfill.ts` had to take, because its statements
+ * really do run — would be a new seam through a boot hook, paid for a piece of
+ * text the platform prints. The `unsupported` arm already knows its dialect by
+ * construction, which is what makes the cheap answer the correct one here
+ * (triage adjudication, 2026-08-18).
+ *
+ * ⚠️ This does NOT extend to {@link buildSysSettingIdentityIndexSql}. That
+ * statement's verdict — MySQL refuses it whatever the quoting, for the
+ * unparenthesized functional key parts — is unchanged and still stated at its
+ * own definition. Quoting rescues the `SELECT`, which MySQL can otherwise run;
+ * it rescues nothing about the `CREATE`.
+ *
+ * ## What stays in the platform's own spelling
+ *
+ * Only the copy-pasteable STATEMENT is compiled for MySQL. The prose around it
+ * keeps naming the table, the columns and the key parts the way the platform
+ * declares them — that text is a description of the schema, not something an
+ * operator pastes into a client, and re-spelling it per dialect would make the
+ * four degradation messages in this module disagree about what the table is
+ * called. Executable text is dialect-compiled; prose naming things is not.
+ */
+export function buildSysSettingDuplicateProbeSqlMysql(): string {
+    return duplicateProbeSqlIn(MYSQL_IDENT);
+}
+
+/**
+ * The duplicate-listing query in a chosen identifier spelling.
+ *
+ * ONE body, so the two spellings cannot drift into describing different keys —
+ * the same reason the projection and the `GROUP BY` are built from one array.
+ */
+function duplicateProbeSqlIn(quote: IdentifierQuote): string {
+    const keyParts = keyPartsIn(quote);
     const projected = SYS_SETTING_IDENTITY_INDEX_COLUMNS.map((column, i) => {
         const keyPart = keyParts[i]!;
-        return keyPart === column ? column : `${keyPart} AS ${column}_key`;
+        return keyPart === quote(column) ? keyPart : `${keyPart} AS ${quote(`${column}_key`)}`;
     });
     return (
-        `SELECT ${projected.join(', ')}, COUNT(*) AS duplicate_rows ` +
-        `FROM ${SYS_SETTING_TABLE} ` +
+        `SELECT ${projected.join(', ')}, COUNT(*) AS ${quote('duplicate_rows')} ` +
+        `FROM ${quote(SYS_SETTING_TABLE)} ` +
         `GROUP BY ${keyParts.join(', ')} HAVING COUNT(*) > 1`
     );
 }
@@ -396,6 +489,11 @@ function reportDegradation(
 ): void {
     const columns = SYS_SETTING_IDENTITY_INDEX_COLUMNS.join(', ');
     const keyParts = sysSettingIdentityKeyParts().join(', ');
+    // The bare spelling, for the arms whose reader is NOT known to be MySQL.
+    // `conflict` is the live one: it means real rows blocked a build that the
+    // server was willing to attempt, which only SQLite and PostgreSQL ever are —
+    // MySQL never gets that far, it refuses the statement and lands in
+    // `unsupported` above, which prints the MySQL spelling instead (#9434).
     const duplicateQuery = buildSysSettingDuplicateProbeSql();
 
     if (status === 'unsupported') {
@@ -405,6 +503,12 @@ function reportDegradation(
         // ADR-0120 D3's degradation — the previous index stays in force —
         // reached by keeping it rather than by rebuilding it, which is also
         // `createNullSafeUniqueIndex`'s handling of the same refusal.
+        //
+        // The remedy query is the MySQL-spelled one (#9434). This arm's reader
+        // is a MySQL/MariaDB operator by construction, and the bare form is not
+        // merely unidiomatic there — `key` is reserved, so it is ERROR 1064.
+        // Handing that operator a statement their server cannot parse is handing
+        // them nothing, in the one arm that has no other remedy to offer.
         logProblem(
             logger,
             `[metadata-protocol] this database cannot build the NULL-safe row-identity index — ` +
@@ -414,7 +518,8 @@ function reportDegradation(
             `(namespace, key) in ONE organization, or two platform defaults on the global layer, can coexist ` +
             `and SettingsService has no defined answer for which one wins (#8629). MySQL/MariaDB before ` +
             `8.0.13 has no functional key parts, so there is no in-dialect fix: run this platform on ` +
-            `SQLite/PostgreSQL for the guarantee, and meanwhile watch for duplicates with: ${duplicateQuery}`,
+            `SQLite/PostgreSQL for the guarantee, and meanwhile watch for duplicates with this MySQL ` +
+            `statement: ${buildSysSettingDuplicateProbeSqlMysql()}`,
             detail,
         );
         return;


### PR DESCRIPTION
Fixes #9434

## What was wrong

`sys-setting-identity-index.ts` degrades when it cannot build the NULL-safe
row-identity index, and prints a duplicate-listing query so the operator can find
the offending rows. The `unsupported` arm is reached **specifically** on
MySQL/MariaDB — no functional key parts, no `CREATE INDEX IF NOT EXISTS` — so its
audience is exactly one dialect, and the statement it printed used bare
identifiers. `key` is a RESERVED word on MySQL, so the one remedy that arm had to
offer came back as `ERROR 1064 (42000)`.

Nothing in the platform executes the statement, so no boot path was affected.
What failed was the operator's copy-paste, in the arm with no other remedy.

## The change

Triage adjudicated the card's **option 2** (comment 5322230525): print a
MySQL-spelled variant in the arm that is already MySQL-specific by construction,
rather than threading a dialect through the ensure-function for a string the
platform never runs. That is what this does.

- `buildSysSettingDuplicateProbeSqlMysql()` — the same query with every
  identifier backtick-quoted. The `unsupported` arm prints it.
- `buildSysSettingDuplicateProbeSql()` is **unchanged, byte for byte**. It stays
  the package's exported surface and the `conflict` arm keeps printing it: a
  conflict means real rows blocked a build the server was willing to attempt,
  which only SQLite and PostgreSQL ever are.
- Both come from one body over one key-part array, so the operator's list and the
  index's own key cannot drift into describing different keys.

**Identifiers are quoted uniformly, not just where a word looks reserved.**
MySQL's reserved-word list grows across point releases, and being wrong about one
entry reinstates the whole defect. This is also #9381's recorded lesson, where
`last_value` was reserved and left bare while the table beside it was quoted.

**No public surface change.** The new builder is exported from the module for its
test, deliberately **not** re-exported from `src/index.ts`: the ruling scopes this
to a log string, and there is no measured consumer for a second spelling.

## The `CREATE UNIQUE INDEX` verdict is untouched — and now measured

The module header says quoting would not change MySQL's verdict on the INDEX
statement. That is true and out of scope here, so it is left exactly as written.
The live test now **measures** it rather than trusting it: the statement is
rejected by a real MySQL both as-is and with every identifier backtick-quoted. If
MySQL ever accepts it, the arm this card is about stops being the arm MySQL
reaches, and that leg goes red.

## Why a live-MySQL test

A test asserting the message "contains a backtick" would pass over any misquoted
statement, and the rest of the suite runs on SQLite — which accepts backticks
**and** accepted the broken bare form. The sibling suite even executes the bare
probe against a real SQLite and stayed green throughout. Only a server can answer
"does this parse", so `sys-setting-identity-index.live-mysql.test.ts` follows the
house style established by `ad217b1`:

- the MySQL statement runs and returns the duplicate group;
- **control:** the pre-fix bare statement is rejected by the same server in the
  same session with `ER_PARSE_ERROR` — without this the green means nothing;
- **end to end:** the statement is extracted from the log message
  `ensureSysSettingIdentityIndex` actually emits and run — what is on trial is the
  operator's copy-paste, and a correct builder whose output never reaches the
  message is the defect itself;
- non-vacuity: the server is asserted to be off `ANSI_QUOTES` and on
  `ONLY_FULL_GROUP_BY` before anything else.

## Deviations from the dispatched file surface — declared

Two files beyond the declared surface, both required for the test to be real:

1. `packages/metadata-protocol/src/migrations/sys-setting-identity-index.live-mysql.test.ts`
   — the proof-of-parse the dispatch requires cannot live in the SQLite suite.
2. `.github/workflows/ci.yml` — the live-MySQL step named one file by path, so a
   new live file would **never run in CI** while skipping green locally. The
   argument is now the filter `live-mysql`, which selects both.

   Measured, and worth recording: vitest positional arguments are **substring
   filters against resolved test paths, not shell globs**. The natural
   `src/migrations/*.live-mysql.test.ts` matches zero files ("No test files
   found", exit 1) — loud rather than silent, but still wrong.

## Verification

Union re-derived with `node scripts/pm/dispatch-gates.mjs` (no paths — it takes
its own change set from the merge base) against the actual diff, and run at
`fcc5cfd`:

```
pnpm --filter @objectstack/metadata-protocol test
  → 121 passed | 2 skipped (123 files); 1669 passed | 10 skipped
    (the 10 skips are the two live-MySQL files without a server)

check:cross-package-test-inputs   PASS      check:node-version               PASS
check:durability-log-level        PASS      check:required-contexts          PASS
check:query-options-erasure       PASS      check:shard-attestation          PASS
check:engine-double-contract      PASS      check:workflow-status-functions  PASS
check:where-matcher               PASS      check:changeset-gate-self-tests  PASS
check:type-check-coverage         PASS      check:objectui-changeset         PASS
check:type-check-debt --re-measure PASS     check:nul-bytes                  PASS
docs-audit/check-affected-docs    PASS
```

`check:type-check-debt --re-measure` ran on the built workspace closure: 33 ledger
entries, *"surplus: none — every entry sits exactly at its measurement"*, so the
new test file contributes zero new tsc errors to `@objectstack/metadata-protocol`'s
63-error entry.

Four gates were **not** in the dispatched lead and were added by the
re-derivation, all pulled in by the workflow edit: `check:node-version`,
`check:required-contexts`, `check:shard-attestation`,
`check:workflow-status-functions`.

**Affected-docs is a real negative:** the mapper derived 10 anchors from this diff
and matched **0** pages. Confirmed independently by grep — no page under
`content/docs/` names this module, this builder, or the index.

### Reverse verification

Reverting only the `unsupported` arm to the bare form, from the committed fix,
turns the arm's test red:

```
FAIL  sys-setting-identity-index.test.ts > composition and dialect >
      a dialect that rejects functional key parts
AssertionError: expected '[metadata-protocol] this database can…'
                to contain 'SELECT COALESCE(`organization_id`, …'
Tests  1 failed | 31 passed (32)
```

Direction: **red**, as expected. One failure and not two — the paired
`not.toContain(bare)` assertion never executes, since vitest stops the test at the
first failed expectation. No rebuild was needed on either leg: the suite imports
the module by relative sibling path, so vitest compiles `src/` directly and no
`dist/` is in the resolution path.


---
_Generated by [Claude Code](https://claude.ai/code/session_017qYPmkKEsfbWY1yVg83p8F)_