### PR TITLE
docs(metadata-protocol): name each decline list's remit and add the JSDoc's missing flow-conflict bullet

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -856,7 +856,12 @@ is `migrate-stored`, so a later diff shows which changes were an upgrade and
 which were somebody's edit.
 
 What it deliberately declines, and names in the report rather than
-counting as done:
+counting as done. This table is the **operator-observable** surface — what a
+run can actually report, from the command above or the route below. The
+function's own JSDoc in `packages/metadata-protocol/src/protocol.ts` documents
+its full internal surface instead, and so lists one decline more: flow rows
+skipped for want of a reachable automation engine, which neither operator door
+can produce, because both supply a live one.
 
 | Not rewritten | Why |
 | :--- | :--- |

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -13183,13 +13183,15 @@ export class ObjectStackProtocolImplementation implements
      *
      * ## What it declines to touch, and says so
      *
-     * This section documents the function's internal surface, which is not
-     * always identical to what an operator running the CLI can observe:
+     * This section documents the function's FULL internal surface, which is
+     * not always identical to what an operator running the CLI can observe:
      * `os migrate meta --stored` always passes its own automation engine
      * (see `canonicalizeFlow` above), so the first bullet below is never
-     * observed from that door. That does not by itself account for every
-     * difference between this list and `content/docs/deployment/cli.mdx`'s
-     * decline table — see #9271.
+     * observed from that door. That is now the only difference between this
+     * list and `content/docs/deployment/cli.mdx`'s decline table, which
+     * documents the operator-observable surface and so carries the other
+     * four. #9271 ruled that split intentional: keep each list correct for
+     * its own audience rather than reconciling them.
      *
      * - **`flow` rows with no reachable automation engine.** Flow-node
      *   conversions carry ADR-0078's open-namespace conflict guard, which
@@ -13197,6 +13199,15 @@ export class ObjectStackProtocolImplementation implements
      *   passed as `canonicalizeFlow`, or resolved from the services registry
      *   (#4498) — flows are migrated like anything else (#4454); when none is,
      *   they are reported `skipped` with that reason, never counted done.
+     * - **A flow whose rename that guard refused.** With an engine reachable,
+     *   the same open-namespace check can still find the old node-type token
+     *   is a LIVE name something else owns here. The conversion is refused and
+     *   the row reported `failed`, naming the token and its path: rewriting
+     *   would clobber that owner, and a quiet skip would hide it. Unlike the
+     *   bullet above this one IS reachable from every door — the CLI boots an
+     *   inert engine to hold the registry, and `POST /meta/_migrate-stored`
+     *   resolves a live one from the services registry — so
+     *   `content/docs/deployment/cli.mdx` carries it too.
      * - **Types with no repository write path** (neither `allowOrgOverride` nor
      *   `allowRuntimeCreate`). This pass declines them, and since #5086 it
      *   would have no choice: `saveMetaItem` refuses a code-only type with


### PR DESCRIPTION
Fixes #9271

Option A as ruled on 2026-08-17: the two decline lists describing
`migrateStoredMetadata` are an **intentional scope split**, now made explicit.
Two audiences, two documents, each self-describing — neither derived from nor
transcluded into the other.

Prose only. No behaviour change, no API change.

## The ruling's falsifiable premise: verified, NOT falsified

The ruling carried a hard stop: verify the flow-conflict path is reachable from
a **non-CLI** caller, and if it turns out CLI-only, report the fork rather than
force the bullet. **It is reachable**, so the bullet was genuinely owed. What
settled it:

- **Two non-CLI production callers, both HTTP doors**, and neither passes
  `canonicalizeFlow`:
  - `packages/rest/src/rest-server.ts` — `POST /meta/_migrate-stored`
  - `packages/runtime/src/domains/meta.ts` — `POST /metadata/_migrate-stored`
- With that argument omitted, the function resolves the engine itself —
  `request.canonicalizeFlow ?? this.resolveFlowCanonicalizer()` — and
  `resolveFlowCanonicalizer` reads the `automation` service off the services
  registry.
- The conflict branch is keyed on **only** two things: the row being a `flow`,
  and the canonicalization returning a non-empty `conflicts` array. Nothing in
  it discriminates on which caller supplied the engine.
- Both route comments already assert that a server always holds a live
  automation engine. A **live** executor registry is precisely the condition
  under which the guard can refuse a real rename; the CLI's deliberately inert
  engine is the weaker case, not the only one.

Positive control for the caller sweep: the same sweep independently surfaced the
expected CLI caller (`packages/cli/src/commands/migrate/meta.ts`) and 25 files
in total, so the non-CLI hits are a reading rather than an artefact of a query
that matches everything or nothing.

## What changed

**`packages/metadata-protocol/src/protocol.ts`** — the `migrateStoredMetadata`
JSDoc block only:

1. **Added the missing fifth bullet**, "a flow whose rename that guard refused".
   Placed immediately after the no-reachable-engine bullet so the two
   flow-related declines sit together — and so the remit sentence's existing
   "the first bullet below" reference keeps pointing at the bullet it always
   meant.
2. **Restated the remit sentence's final clause.** PR #9270 had already landed
   the remit sentence, ending "That does not by itself account for every
   difference between this list and cli.mdx's decline table — see #9271". Adding
   the bullet above makes that clause false: the difference is now fully
   accounted for. It now states the finished fact, and names the split as ruled
   rather than pointing at an open question. The sentence was **improved in
   place, never duplicated** — no second remit sentence was added.

**`content/docs/deployment/cli.mdx`** — one sentence naming the decline table's
remit: the **operator-observable** surface, plus which single member the JSDoc
carries that it does not, and why no operator door can reach it.

Per the ruling, `cli.mdx` deliberately does **not** grow a
"no reachable automation engine" row — an operator cannot reach that path, and
documenting it there would be its own small lie.

## End state

| | JSDoc | `cli.mdx` |
|---|---|---|
| `flow` rows with no reachable automation engine | yes | no, by stated remit |
| A flow whose rename the conflict guard refused | **yes (new)** | yes |
| Types with no repository write path | yes | yes |
| Rows that still fail the schema after conversion | yes | yes |
| Rows under a non-canonical metadata type spelling | yes | yes |

Five members against four, differing by exactly one member in exactly one
direction, for a reason each document now states itself — which is the end state
the ruling predicted.

Verified mechanically rather than by eye: parsing the file with the TypeScript
compiler API reports 0 parse diagnostics, attaches a 6481-char JSDoc to
`migrateStoredMetadata`, and counts **5** decline bullets in it.

## Changeset

None — the `skip-changeset` label is applied instead. This repo's
`check-empty-changeset.mjs` gate **rejects** a newly added empty-frontmatter
changeset, and AGENTS.md reserves changesets for feature or functional work. A
prose-only PR releases nothing, which is the label's textbook case as
`lint.yml` itself describes it.

## Gates

Re-derived against the actual diff with `node scripts/pm/dispatch-gates.mjs`
(no path argument, so the script takes its own change set) — it returned the
same 12 families the dispatch named, no additions. All 12 run green on the
pushed tree, commit `0d3ea23`, each exit status captured directly rather than
through a pipe:

`check:cross-package-test-inputs` · `check-cross-package-test-inputs.mjs` ·
`check:docs-audit-scope` · `check:docs-redirects` · `check:role-word` ·
`check:durability-log-level` · `check:filter-alias-parity` ·
spec `check:empty-state` · spec `check:liveness` ·
spec `check:strictness-ledger` · spec `check:variant-docs` ·
`docs-audit/check-affected-docs.mjs`

The affected-docs mapper flags three pages against this diff. Two are
`content/docs/releases/`, which is release-owned and untouched here. The third,
`content/docs/concepts/metadata-lifecycle.mdx`, is a **negative and stays
unedited**: it carries no decline list at all (zero occurrences of "decline"),
and its single mention of the function is one accurate clause about the
no-write-path skip, a decline this PR does not alter. So there is no third list
to fold into the split — the card's two-list framing is complete.


---
_Generated by [Claude Code](https://claude.ai/code/session_017qYPmkKEsfbWY1yVg83p8F)_