### PR TITLE
chore(release): migrate the release toolchain to @changesets/cli v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": [
     "@changesets/cli/changelog",
     {
@@ -84,7 +84,5 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
-  }
+  "privatePackages": { "version": true, "tag": false }
 }

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -486,17 +486,39 @@ jobs:
       # cut: the pin bump and the version output are one atomic unit, and there is
       # never a main commit carrying a bumped pin but an unversioned tree.
       #
-      # WHAT MAY BE IN IT — re-measured on the 17.0.0 -> 18.0.0-rc.0 train (a full
-      # local `pnpm run version` in a throwaway clone over 199 pending changesets),
-      # not assumed. 160 paths:
-      #   77 modified package.json, 76 modified CHANGELOG.md,
-      #   .changeset/pre.json, the 3 major-boundary paths below, and the 3 doc
-      #   surfaces below. Zero deletions. `.changeset/pre.json` is UNTRACKED on the
-      #   first cut of a train (`changeset pre enter` just created it) and modified
-      #   on later ones; `git add -A` covers both. In PRE mode `changeset version`
-      #   does NOT delete the consumed changesets — it records them in pre.json and
-      #   they are removed at `changeset pre exit` — so a cut never races a lane PR
-      #   over a `.changeset/*.md` file it wants to keep.
+      # WHAT MAY BE IN IT — re-measured under @changesets/cli v3 on the
+      # 17.0.0 -> 17.1.0-rc.0 train (a full local `pnpm run version` in a throwaway
+      # clone over 209 pending changesets), not assumed. 365 staged paths:
+      #   76 modified package.json, 76 modified CHANGELOG.md, 209 changesets MOVED
+      #   into `.changeset/pre/`, `.changeset/pre.json`, and the 3 doc surfaces
+      #   below. `.changeset/pre.json` is UNTRACKED on the first cut of a train
+      #   (`changeset pre enter` just created it) and modified on later ones;
+      #   `git add -A` covers both.
+      #   The 3 major-boundary paths below did NOT appear on this train and are
+      #   allowed for the train that does move the major — as is the blank
+      #   template's own package.json, which is why the v2 measurement this block
+      #   used to carry counted 77 package.json against this one's 76: that train
+      #   was 17.0.0 -> 18.0.0-rc.0, so `sync-template-versions.mjs` had to rewrite
+      #   the template's `^17.0.0` pins. On a minor train it logs "already pins" and
+      #   writes nothing. The counts move with the SHAPE of the train; the
+      #   allowlist below is what does not have to.
+      #
+      #   THE CONSUMED CHANGESETS MOVE — new in v3 (changesets#2190), and the one
+      #   thing about a cut that this file's prose used to get wrong. v2 left every
+      #   consumed `.changeset/*.md` on disk and recorded it in `pre.json`; v3 moves
+      #   it to `.changeset/pre/NAME.md` VERBATIM (measured: a moved file diffs
+      #   identical to its original, and git reports all 209 as `R100` renames), and
+      #   `pre.json` is `{"mode","tag"}` only — `changeset version` never rewrites
+      #   it. So in the worktree a cut is 209 deletions plus a new untracked
+      #   `.changeset/pre/` directory, and the claim this block used to make — "a
+      #   cut never races a lane PR over a `.changeset/*.md` file it wants to keep"
+      #   — is FALSE under v3. The cut moves tracked changeset paths, so a lane PR
+      #   that edits or deletes one of them conflicts; the rebase guard further down
+      #   is what catches it, and it already names `.changeset` in its conflict
+      #   surface. What does NOT change is this allowlist: `^\.changeset/` covers
+      #   `.changeset/pre/…` and `git add -A -- … .changeset …` stages the deletions
+      #   and the new directory together (measured: all 365 staged paths accepted,
+      #   nothing tracked left unstaged).
       # Three more paths can appear at a major boundary and are allowed for that
       # reason, all written by `sync-protocol-version.mjs` /
       # `sync-template-versions.mjs`: packages/spec/src/kernel/protocol-version.ts
@@ -848,7 +870,7 @@ jobs:
             echo "### Two things that are expected, not defects"
             echo
             echo "1. **The standing \`chore: version packages (rc)\` PR (#6208) may look stale.**"
-            echo "   Its changesets were consumed by this cut and are recorded in \`.changeset/pre.json\`."
+            echo "   Its changesets were consumed by this cut and moved to \`.changeset/pre/\` (v3)."
             echo "   Whether it refreshes now depends on the push credential: pushes made with the"
             echo "   Actions \`GITHUB_TOKEN\` trigger no workflow runs (GitHub's recursion guard), so"
             echo "   \`version-pr\` does not fire until some later push to main; with a"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -383,12 +383,25 @@ jobs:
           fi
           # Count changesets THIS PR adds (diff against the base commit), NOT
           # the whole .changeset directory. A global `find | wc -l` is unsound:
-          # in pre-release (RC) mode `changeset version` RETAINS every consumed
-          # .md file, so the directory is permanently non-empty and the gate can
-          # never go red. #3373 merged a real spec/api-surface fix with no
-          # changeset while this step happily reported "Found 104 changeset(s)".
-          # Diffing against the merge base ignores that residue and sees only
-          # what the PR itself introduced. It has to be the MERGE BASE and not
+          # it counts main's pending stock, which has nothing to do with what this
+          # PR wrote. #3373 merged a real spec/api-surface fix with no changeset
+          # while this step happily reported "Found 104 changeset(s)".
+          # Diffing against the merge base ignores that stock and sees only what
+          # the PR itself introduced.
+          #
+          # That argument used to be stated in terms of pre-mode RESIDUE — under
+          # @changesets/cli v2, `changeset version` in pre mode retained every
+          # consumed .md file, so `.changeset/` was permanently non-empty for the
+          # whole RC window. v3 moves consumed changesets into `.changeset/pre/`
+          # instead (changesets#2190), so the root directory is no longer
+          # permanently non-empty. The unsoundness is unchanged and so is this
+          # step: a stock count is the wrong question in EVERY repo phase, not just
+          # a polluted one. What the migration did have to be checked against is
+          # the counter itself, because a cut now MOVES 209 tracked changeset
+          # paths: measured on a real v3 cut commit, git reports them as `R100`
+          # renames, so `--diff-filter=A` credits this PR with 0 of them (still 0
+          # with `diff.renameLimit=1` forced; only `--no-renames` turns them into
+          # 209 `A` rows, and nothing here passes it). It has to be the MERGE BASE and not
           # the payload's frozen `base.sha` -- see the base-resolution step above
           # (#6129); with the frozen sha this count silently included every
           # changeset main gained while the PR was open.
@@ -827,12 +840,19 @@ jobs:
         # same #6129 reason one defect along (#7005). This script used to read
         # the whole `.changeset` directory with no branch point, so its verdict
         # was a function of what main carried rather than of what the author
-        # wrote. That was invisible while pre-mode held and would have become
-        # visible all at once at `changeset pre exit`: 171 consumed-but-undeleted
-        # major changesets sit on main until the post-exit `changeset version`
-        # removes them, so every unlabelled PR open in that window would have
-        # gone red listing files it never touched, with `allow-major` -- a label
-        # meaning "a whole-stack major is intended HERE" -- as its only way out.
+        # wrote. Under @changesets/cli v2 that was invisible while pre-mode held
+        # and would have become visible all at once at `changeset pre exit`: 171
+        # consumed-but-undeleted major changesets sat on main until the post-exit
+        # `changeset version` removed them, so every unlabelled PR open in that
+        # window would have gone red listing files it never touched, with
+        # `allow-major` -- a label meaning "a whole-stack major is intended HERE"
+        # -- as its only way out. v3 retires that particular detonation: each cut
+        # moves its consumed changesets into `.changeset/pre/`, which the gate's
+        # root-only reader does not enumerate, so the root stock stays bounded to
+        # the unconsumed residue. It retires no line of the fix. `--base` is
+        # correct because a verdict about what a PR INTRODUCED cannot be computed
+        # without the fork -- #6129's argument, which never depended on how big
+        # the stock was.
         if: >-
           steps.labels.outputs.skip != 'true'
           && steps.labels_settled.outputs.skip != 'true'

--- a/docs/releases-maintenance.md
+++ b/docs/releases-maintenance.md
@@ -303,11 +303,14 @@ rediscovered at 2am:
   by itself.
 
 **A stale #6208 after an rc cut is EXPECTED AND HARMLESS — do not "fix" it by hand.**
-Its changesets were consumed by the cut and are recorded in `.changeset/pre.json`; the
-PR is bookkeeping, it carries no publish capability by construction (`release.yml`
-passes the changesets action no `publish:` script), and it regenerates correctly at
-the next push to `main` or the next GA cut. Editing or force-refreshing it manually
-only risks putting a version commit somewhere the publish lane can reach.
+Its changesets were consumed by the cut and MOVED into `.changeset/pre/` — under
+`@changesets/cli` v3 that move is what "consumed" looks like on disk, and
+`.changeset/pre.json` carries `{"mode","tag"}` and nothing else, so it is not a
+record of what was consumed (it was, under v2). The PR is bookkeeping, it carries no
+publish capability by construction (`release.yml` passes the changesets action no
+`publish:` script), and it regenerates correctly at the next push to `main` or the
+next GA cut. Editing or force-refreshing it manually only risks putting a version
+commit somewhere the publish lane can reach.
 
 **The runtime image is not built here.** `release.yml`'s `release-integrity` lane runs
 on every push to `main` and requests the image once the version is on npm, so it

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "author": "ObjectStack",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@changesets/cli": "^2.31.1",
+    "@changesets/cli": "^3.0.0",
     "@types/node": "^26.1.2",
     "@typescript-eslint/parser": "^8.65.0",
     "eslint": "^10.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.31.1
-        version: 2.31.1(@types/node@26.1.2)
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -3070,63 +3070,77 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@changesets/apply-release-plan@7.1.1':
-    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+  '@changesets/apply-release-plan@8.0.0':
+    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/assemble-release-plan@6.0.10':
-    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+  '@changesets/assemble-release-plan@7.0.0':
+    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/changelog-git@0.2.1':
-    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+  '@changesets/changelog-git@1.0.0':
+    resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/cli@2.31.1':
-    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
+  '@changesets/cli@3.0.0':
+    resolution: {integrity: sha512-V7Gm+GP5OT3mJinMI2YcJD/JyO/a4WChnaMCCzTRhWHgu1zhtsyY7zCjP6n5W6zsgSjJKs+yPmvtREvE0F2g8A==}
+    engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
     hasBin: true
 
-  '@changesets/config@3.1.4':
-    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+  '@changesets/config@4.0.0':
+    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/errors@0.2.0':
-    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+  '@changesets/errors@1.0.0':
+    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-dependents-graph@2.1.4':
-    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+  '@changesets/format@0.1.2':
+    resolution: {integrity: sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-release-plan@4.0.16':
-    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+  '@changesets/get-dependents-graph@3.0.0':
+    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-version-range-type@0.4.0':
-    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+  '@changesets/git@4.0.0':
+    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/git@3.0.4':
-    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+  '@changesets/parse@1.0.0':
+    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/logger@0.1.1':
-    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+  '@changesets/pre@3.0.0':
+    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/parse@0.4.3':
-    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+  '@changesets/read@1.0.0':
+    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/pre@2.0.2':
-    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+  '@changesets/should-skip-package@1.0.0':
+    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/read@0.6.7':
-    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+  '@changesets/types@7.0.0':
+    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/should-skip-package@0.1.2':
-    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
-
-  '@changesets/types@4.1.0':
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
-
-  '@changesets/types@6.1.0':
-    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
-
-  '@changesets/write@0.4.0':
-    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+  '@changesets/write@1.0.0':
+    resolution: {integrity: sha512-xCK3/4C7Z7muQB/wguE6HcbjtY9iOtaK9orZKE+7xi573cMGD8rLZz7qlo6IvK7s+SIUIKajzj1l+F1QuP97tw==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/workers-types@4.20260520.1':
     resolution: {integrity: sha512-wdmf9Fwabp06OgK9ZyCl8Q77GZ94k9J7OA9qA65FbgxZ/hd3hYRkVNiY7Bvsx4tKim+sWmKqGOblecZInAvoRg==}
@@ -3794,15 +3808,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/figures@2.0.7':
     resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
@@ -3916,11 +3921,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@manypkg/find-root@1.1.0':
-    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+  '@manypkg/find-root@3.1.0':
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
 
-  '@manypkg/get-packages@1.1.3':
-    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+  '@manypkg/get-packages@3.1.0':
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/tools@2.1.2':
+    resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
+    engines: {node: '>=20.0.0'}
 
   '@marcbachmann/cel-js@8.0.0':
     resolution: {integrity: sha512-oaTrAziGr3zDLFiMt/yLU3nZuRMawyWQB5X1a0I7s9eGy3JYzX9l8ZXXHyMd64nzbeVFZTewuUShwsZQdK6UCA==}
@@ -4030,18 +4041,6 @@ packages:
   '@nodable/entities@3.0.0':
     resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-
   '@oclif/core@4.13.3':
     resolution: {integrity: sha512-wBp2igI2KVwq2ZmpnfmGtOROo7aXZIr3OEtAS16g1wHFBqyEuswL+9K50NJWJvlpAmxd+4dVj/ycawXESU3wQQ==}
     engines: {node: '>=18.0.0'}
@@ -4081,6 +4080,10 @@ packages:
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@pnpm/deps.graph-sequencer@1100.0.1':
+    resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
+    engines: {node: '>=22.13'}
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -5060,9 +5063,6 @@ packages:
   '@types/negotiator@0.6.4':
     resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
@@ -5328,10 +5328,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
-
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -5370,9 +5366,6 @@ packages:
     resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
     engines: {node: '>= 10'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -5386,10 +5379,6 @@ packages:
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
-
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
 
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
@@ -5549,10 +5538,6 @@ packages:
       zod:
         optional: true
 
-  better-path-resolve@1.0.0:
-    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
-    engines: {node: '>=4'}
-
   better-sqlite3@12.11.1:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
@@ -5593,10 +5578,6 @@ packages:
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
 
   bson@7.3.1:
     resolution: {integrity: sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==}
@@ -5644,6 +5625,10 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -5684,9 +5669,6 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  chardet@2.2.0:
-    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -6084,10 +6066,6 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
@@ -6104,10 +6082,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -6154,10 +6128,6 @@ packages:
   enhanced-resolve@5.24.3:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
-
-  enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -6252,11 +6222,6 @@ packages:
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -6354,9 +6319,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extendable-error@0.1.7:
-    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
-
   fast-check@4.9.0:
     resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
     engines: {node: '>=12.17.0'}
@@ -6370,10 +6332,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -6399,9 +6357,6 @@ packages:
   fast-xml-parser@5.10.1:
     resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6429,10 +6384,6 @@ packages:
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -6490,14 +6441,6 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
-  fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
-
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -6668,10 +6611,6 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -6683,10 +6622,6 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -6908,10 +6843,6 @@ packages:
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -6928,16 +6859,8 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
-  is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
-    engines: {node: '>=4'}
-
   is-unsafe@2.0.0:
     resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
-
-  is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -6982,6 +6905,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
   jose@6.2.7:
     resolution: {integrity: sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==}
 
@@ -7003,14 +6929,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
-    hasBin: true
-
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
-    hasBin: true
 
   js-yaml@5.2.3:
     resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
@@ -7043,8 +6961,8 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -7106,6 +7024,9 @@ packages:
   kysely@0.29.4:
     resolution: {integrity: sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==}
     engines: {node: '>=22.0.0'}
+
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -7354,9 +7275,6 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
   lodash.union@4.6.0:
     resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
 
@@ -7487,10 +7405,6 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
   mermaid@11.16.1:
     resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
@@ -7599,10 +7513,6 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -7702,10 +7612,6 @@ packages:
         optional: true
       react-dom:
         optional: true
-
-  mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -7937,15 +7843,8 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  outdent@0.5.0:
-    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
-
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
-
-  p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -7963,19 +7862,15 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
-
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
-
   package-manager-detector@1.7.0:
     resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
@@ -8032,10 +7927,6 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -8082,17 +7973,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
-
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
 
   pinyin-pro@3.29.1:
     resolution: {integrity: sha512-GkdTguAt9JDAO7Xw71gyx3mtzgFXpmeigesM3XkcTcQdudg2v5k1ZFzWM30Oo4UkwZ9U8pE1pcLKKu8cx8icPg==}
@@ -8180,11 +8063,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -8223,12 +8101,6 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
-
-  quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
-
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quickjs-emscripten-core@0.32.0:
     resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
@@ -8290,10 +8162,6 @@ packages:
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
-
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -8396,10 +8264,6 @@ packages:
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
 
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -8431,9 +8295,6 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
@@ -8517,6 +8378,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
     engines: {node: '>=20'}
@@ -8550,9 +8415,8 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -8576,15 +8440,9 @@ packages:
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
-  spawndamnit@3.0.1:
-    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -8631,10 +8489,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -8724,10 +8578,6 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  term-size@2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
-
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -8774,10 +8624,6 @@ packages:
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
-
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -8916,10 +8762,6 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -9733,150 +9575,123 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@changesets/apply-release-plan@7.1.1':
+  '@changesets/apply-release-plan@8.0.0':
     dependencies:
-      '@changesets/config': 3.1.4
-      '@changesets/get-version-range-type': 0.4.0
-      '@changesets/git': 3.0.4
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      detect-indent: 6.1.0
-      fs-extra: 7.0.1
-      lodash.startcase: 4.4.0
-      outdent: 0.5.0
-      prettier: 2.8.8
-      resolve-from: 5.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/format': 0.1.2
+      '@changesets/git': 4.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      import-meta-resolve: 4.2.0
+      jsonc-parser: 3.3.1
       semver: 7.8.5
 
-  '@changesets/assemble-release-plan@6.0.10':
+  '@changesets/assemble-release-plan@7.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.4
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
       semver: 7.8.5
 
-  '@changesets/changelog-git@0.2.1':
+  '@changesets/changelog-git@1.0.0':
     dependencies:
-      '@changesets/types': 6.1.0
+      '@changesets/types': 7.0.0
 
-  '@changesets/cli@2.31.1(@types/node@26.1.2)':
+  '@changesets/cli@3.0.0':
     dependencies:
-      '@changesets/apply-release-plan': 7.1.1
-      '@changesets/assemble-release-plan': 6.0.10
-      '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.4
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.4
-      '@changesets/get-release-plan': 4.0.16
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.7
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@26.1.2)
-      '@manypkg/get-packages': 1.1.3
-      ansi-colors: 4.1.3
-      enquirer: 2.4.1
-      fs-extra: 7.0.1
-      mri: 1.2.0
-      package-manager-detector: 0.2.11
-      picocolors: 1.1.1
-      resolve-from: 5.0.0
+      '@changesets/apply-release-plan': 8.0.0
+      '@changesets/assemble-release-plan': 7.0.0
+      '@changesets/changelog-git': 1.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/git': 4.0.0
+      '@changesets/pre': 3.0.0
+      '@changesets/read': 1.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@changesets/write': 1.0.0
+      '@clack/prompts': 1.7.0
+      '@manypkg/get-packages': 3.1.0
+      '@pnpm/deps.graph-sequencer': 1100.0.1
+      cac: 7.0.0
+      import-meta-resolve: 4.2.0
+      launch-editor: 2.14.1
+      package-manager-detector: 1.7.0
       semver: 7.8.5
-      spawndamnit: 3.0.1
-      term-size: 2.2.1
-    transitivePeerDependencies:
-      - '@types/node'
+      tinyexec: 1.3.0
 
-  '@changesets/config@3.1.4':
+  '@changesets/config@4.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.4
-      '@changesets/logger': 0.1.1
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      fs-extra: 7.0.1
-      micromatch: 4.0.8
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
 
-  '@changesets/errors@0.2.0':
-    dependencies:
-      extendable-error: 0.1.7
+  '@changesets/errors@1.0.0': {}
 
-  '@changesets/get-dependents-graph@2.1.4':
+  '@changesets/format@0.1.2':
     dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      picocolors: 1.1.1
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
+  '@changesets/get-dependents-graph@3.0.0':
+    dependencies:
+      '@changesets/types': 7.0.0
       semver: 7.8.5
 
-  '@changesets/get-release-plan@4.0.16':
+  '@changesets/git@4.0.0':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.10
-      '@changesets/config': 3.1.4
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.7
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.5
+      tinyexec: 1.3.0
 
-  '@changesets/get-version-range-type@0.4.0': {}
-
-  '@changesets/git@3.0.4':
+  '@changesets/parse@1.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@manypkg/get-packages': 1.1.3
-      is-subdir: 1.2.0
-      micromatch: 4.0.8
-      spawndamnit: 3.0.1
+      '@changesets/types': 7.0.0
+      yaml: 2.9.0
 
-  '@changesets/logger@0.1.1':
+  '@changesets/pre@3.0.0':
     dependencies:
-      picocolors: 1.1.1
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
 
-  '@changesets/parse@0.4.3':
+  '@changesets/read@1.0.0':
     dependencies:
-      '@changesets/types': 6.1.0
-      js-yaml: 4.3.1
+      '@changesets/git': 4.0.0
+      '@changesets/parse': 1.0.0
+      '@changesets/types': 7.0.0
 
-  '@changesets/pre@2.0.2':
+  '@changesets/should-skip-package@1.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      fs-extra: 7.0.1
+      '@changesets/types': 7.0.0
 
-  '@changesets/read@0.6.7':
+  '@changesets/types@7.0.0': {}
+
+  '@changesets/write@1.0.0':
     dependencies:
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.3
-      '@changesets/types': 6.1.0
-      fs-extra: 7.0.1
-      p-filter: 2.1.0
-      picocolors: 1.1.1
-
-  '@changesets/should-skip-package@0.1.2':
-    dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-
-  '@changesets/types@4.1.0': {}
-
-  '@changesets/types@6.1.0': {}
-
-  '@changesets/write@0.4.0':
-    dependencies:
-      '@changesets/types': 6.1.0
-      fs-extra: 7.0.1
+      '@changesets/format': 0.1.2
+      '@changesets/types': 7.0.0
       human-id: 4.2.0
-      prettier: 2.8.8
 
   '@chevrotain/types@11.1.2': {}
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   '@cloudflare/workers-types@4.20260520.1':
     optional: true
@@ -10349,13 +10164,6 @@ snapshots:
       '@types/node': 26.2.0
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.1.2)':
-    dependencies:
-      chardet: 2.2.0
-      iconv-lite: 0.7.3
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/figures@2.0.7':
     optional: true
 
@@ -10472,21 +10280,20 @@ snapshots:
   '@libsql/win32-x64-msvc@0.5.29':
     optional: true
 
-  '@manypkg/find-root@1.1.0':
+  '@manypkg/find-root@3.1.0':
     dependencies:
-      '@babel/runtime': 7.29.7
-      '@types/node': 12.20.55
-      find-up: 4.1.0
-      fs-extra: 8.1.0
+      '@manypkg/tools': 2.1.2
 
-  '@manypkg/get-packages@1.1.3':
+  '@manypkg/get-packages@3.1.0':
     dependencies:
-      '@babel/runtime': 7.29.7
-      '@changesets/types': 4.1.0
-      '@manypkg/find-root': 1.1.0
-      fs-extra: 8.1.0
-      globby: 11.1.0
-      read-yaml-file: 1.1.0
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.2
+
+  '@manypkg/tools@2.1.2':
+    dependencies:
+      jju: 1.4.0
+      tinyglobby: 0.2.17
+      yaml: 2.9.0
 
   '@marcbachmann/cel-js@8.0.0': {}
 
@@ -10603,18 +10410,6 @@ snapshots:
 
   '@nodable/entities@3.0.0': {}
 
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
-
   '@oclif/core@4.13.3':
     dependencies:
       ansi-escapes: 4.3.2
@@ -10681,6 +10476,8 @@ snapshots:
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
+
+  '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@radix-ui/number@1.1.3': {}
 
@@ -11561,8 +11358,6 @@ snapshots:
 
   '@types/negotiator@0.6.4': {}
 
-  '@types/node@12.20.55': {}
-
   '@types/node@14.18.63': {}
 
   '@types/node@26.1.2':
@@ -11851,8 +11646,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-colors@4.1.3: {}
-
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -11907,10 +11700,6 @@ snapshots:
       tar-stream: 2.2.0
       zip-stream: 4.1.1
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -11922,8 +11711,6 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.1: {}
-
-  array-union@2.1.0: {}
 
   asn1@0.2.6:
     dependencies:
@@ -12030,10 +11817,6 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
-  better-path-resolve@1.0.0:
-    dependencies:
-      is-windows: 1.0.2
-
   better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
@@ -12095,10 +11878,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
   bson@7.3.1: {}
 
   buffer-crc32@0.2.13: {}
@@ -12142,6 +11921,8 @@ snapshots:
 
   cac@6.7.14: {}
 
+  cac@7.0.0: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -12173,8 +11954,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  chardet@2.2.0: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -12549,8 +12328,6 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-indent@6.1.0: {}
-
   detect-libc@2.0.2: {}
 
   detect-libc@2.1.2: {}
@@ -12562,10 +12339,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
 
   dom-accessibility-api@0.5.16: {}
 
@@ -12611,11 +12384,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  enquirer@2.4.1:
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
 
   entities@6.0.1: {}
 
@@ -12774,8 +12542,6 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
-  esprima@4.0.1: {}
-
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -12909,8 +12675,6 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extendable-error@0.1.7: {}
-
   fast-check@4.9.0:
     dependencies:
       pure-rand: 8.4.2
@@ -12924,32 +12688,21 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
-  fast-string-truncated-width@3.0.3:
-    optional: true
+  fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-    optional: true
 
   fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-    optional: true
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -12964,10 +12717,6 @@ snapshots:
       path-expression-matcher: 1.6.2
       strnum: 2.4.1
       xml-naming: 0.3.0
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -12993,10 +12742,6 @@ snapshots:
   filelist@1.0.6:
     dependencies:
       minimatch: 10.2.6
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -13056,18 +12801,6 @@ snapshots:
   fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
-
-  fs-extra@7.0.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
 
@@ -13226,10 +12959,6 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -13248,15 +12977,6 @@ snapshots:
       minimatch: 10.2.6
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   gopd@1.2.0: {}
 
@@ -13545,8 +13265,6 @@ snapshots:
   is-node-process@1.2.0:
     optional: true
 
-  is-number@7.0.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
@@ -13559,13 +13277,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  is-subdir@1.2.0:
-    dependencies:
-      better-path-resolve: 1.0.0
-
   is-unsafe@2.0.0: {}
-
-  is-windows@1.0.2: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -13605,6 +13317,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jju@1.4.0: {}
+
   jose@6.2.7: {}
 
   jose@6.2.8: {}
@@ -13618,15 +13332,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.15.1:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@5.2.3:
     dependencies:
@@ -13670,9 +13375,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
+  jsonc-parser@3.3.1: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -13740,6 +13443,11 @@ snapshots:
       - supports-color
 
   kysely@0.29.4: {}
+
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.10.0
 
   layout-base@1.0.2: {}
 
@@ -13922,8 +13630,6 @@ snapshots:
   lodash.isundefined@3.0.1: {}
 
   lodash.once@4.1.1: {}
-
-  lodash.startcase@4.4.0: {}
 
   lodash.union@4.6.0: {}
 
@@ -14147,8 +13853,6 @@ snapshots:
   memory-pager@1.5.0: {}
 
   merge-descriptors@2.0.0: {}
-
-  merge2@1.4.1: {}
 
   mermaid@11.16.1:
     dependencies:
@@ -14438,11 +14142,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
-
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -14554,8 +14253,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-
-  mri@1.2.0: {}
 
   ms@2.1.2: {}
 
@@ -14761,14 +14458,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  outdent@0.5.0: {}
-
   outvariant@1.4.3:
     optional: true
-
-  p-filter@2.1.0:
-    dependencies:
-      p-map: 2.1.0
 
   p-limit@2.3.0:
     dependencies:
@@ -14786,15 +14477,11 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  p-map@2.1.0: {}
-
   p-try@2.2.0: {}
 
-  package-manager-detector@0.2.11:
-    dependencies:
-      quansync: 0.2.11
-
   package-manager-detector@1.7.0: {}
+
+  package-manager-detector@1.8.0: {}
 
   pako@1.0.11: {}
 
@@ -14844,8 +14531,6 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
-  path-type@4.0.0: {}
-
   pathe@2.0.3: {}
 
   pend@1.2.0: {}
@@ -14889,11 +14574,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.5: {}
-
-  pify@4.0.1: {}
 
   pinyin-pro@3.29.1: {}
 
@@ -14975,8 +14656,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@2.8.8: {}
-
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -15012,10 +14691,6 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
-
-  quansync@0.2.11: {}
-
-  queue-microtask@1.2.3: {}
 
   quickjs-emscripten-core@0.32.0:
     dependencies:
@@ -15081,13 +14756,6 @@ snapshots:
       '@types/react': 19.2.18
 
   react@19.2.8: {}
-
-  read-yaml-file@1.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.15.1
-      pify: 4.0.1
-      strip-bom: 3.0.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -15249,8 +14917,6 @@ snapshots:
   rettime@0.11.11:
     optional: true
 
-  reusify@1.1.0: {}
-
   rimraf@2.7.1:
     dependencies:
       glob: 7.2.3
@@ -15329,10 +14995,6 @@ snapshots:
       - supports-color
 
   run-applescript@7.1.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   rw@1.3.3: {}
 
@@ -15449,6 +15111,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   shiki@4.4.3:
     dependencies:
       '@shikijs/core': 4.4.3
@@ -15490,7 +15154,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
+  signal-exit@4.1.0:
+    optional: true
 
   simple-concat@1.0.1:
     optional: true
@@ -15502,7 +15167,7 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
-  slash@3.0.0: {}
+  sisteransi@1.0.5: {}
 
   smart-buffer@4.2.0:
     optional: true
@@ -15523,14 +15188,7 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
 
-  spawndamnit@3.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   split2@4.2.0: {}
-
-  sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
 
@@ -15580,8 +15238,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-bom@3.0.0: {}
 
   strip-json-comments@2.0.1:
     optional: true
@@ -15708,8 +15364,6 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  term-size@2.2.1: {}
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
@@ -15748,10 +15402,6 @@ snapshots:
       tldts-core: 7.4.9
 
   tmp@0.2.7: {}
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
@@ -15906,8 +15556,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
-
-  universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
 

--- a/scripts/check-adr-0087-registration.mjs
+++ b/scripts/check-adr-0087-registration.mjs
@@ -348,6 +348,32 @@ const ADR_0087 = 'docs/adr/0087-metadata-protocol-upgrade-contract.md';
 const isChangesetFile = (p) => p.startsWith('.changeset/') && p.endsWith('.md') && !p.endsWith('/README.md');
 
 /**
+ * `.changeset/pre/NAME.md` is a CONSUMED prerelease changeset, not pending stock.
+ *
+ * New in `@changesets/cli` v3 (changesets#2190): a pre-mode `changeset version`
+ * MOVES every changeset it consumes out of `.changeset/` and into
+ * `.changeset/pre/`, verbatim, instead of leaving it in place and recording it in
+ * `pre.json` the way v2 did. Measured on a v3 cut of this repo (209 pending
+ * changesets, 17.0.0 -> 17.1.0-rc.0): all 209 move, git scores every one `R100`,
+ * and `git ls-tree -r ... -- .changeset` at the cut lists all 209 under `pre/`.
+ *
+ * That `-r` is why this predicate exists. `changesetDirAt` below lists the
+ * directory RECURSIVELY, so from the first v3 cut onwards the entire consumed
+ * stock of the open RC window would flow into `--list` and `--audit-stock` — two
+ * surfaces whose whole subject is the PENDING stock ("this gate judges diffs, not
+ * stock"), and whose numbers a reader takes as the size of the backlog. Every one
+ * of those changesets was judged by the diff scan on the PR that introduced it;
+ * re-listing them daily for the length of a window is noise that grows.
+ *
+ * WHERE THIS DELIBERATELY DOES NOT APPLY: the enforcing scan. It reads the diff
+ * through `isChangesetFile`, NOT through this predicate, so a changeset ADDED
+ * under `.changeset/pre/` in a PR is still judged like any other. Filtering the
+ * audit surfaces is a readability fix; filtering the verdict would be a bypass,
+ * and `PRE2` in the self-test pins the difference.
+ */
+const isConsumedPrerelease = (p) => p.startsWith('.changeset/pre/');
+
+/**
  * Split a changeset into its frontmatter bump entries and its body.
  *
  * The entry regex is deliberately the SAME shape `check-changeset-no-major.mjs`,
@@ -1376,12 +1402,18 @@ export function mergeBase(base, head, cwd) {
 
 /**
  * Everything under `.changeset/` at a rev, split into "any entry at all" and
- * "actual changesets", or `null` when the tree itself cannot be listed.
+ * "actual PENDING changesets", or `null` when the tree itself cannot be listed.
  *
  * The split is what lets `assertInputs` tell an EMPTY STOCK (zero pending
  * changesets — the legitimate state of main right after a release cut, #8658)
  * apart from a MISSING DIRECTORY (not even the tracked README.md/config.json
  * found — unreadable input, still a #4690 refusal).
+ *
+ * `entries` stays UNFILTERED on purpose: it answers "is this directory readable
+ * at all", and a tree whose changesets have all moved into `.changeset/pre/` is a
+ * perfectly readable one. Narrowing it would turn the ordinary post-cut state of
+ * main into a #4690 refusal — the exact confusion #8658 removed. `changesets` is
+ * the narrowed half (see `isConsumedPrerelease`).
  *
  * @returns {{ entries: string[], changesets: string[] } | null}
  */
@@ -1389,11 +1421,17 @@ function changesetDirAt(rev, cwd) {
   let out;
   try { out = git(['ls-tree', '-r', '--name-only', rev, '--', '.changeset'], cwd); } catch { return null; }
   const entries = out.split('\n').map((s) => s.trim()).filter(Boolean);
-  return { entries, changesets: entries.filter(isChangesetFile) };
+  return { entries, changesets: entries.filter((p) => isChangesetFile(p) && !isConsumedPrerelease(p)) };
 }
 
-/** Every changeset path present at a rev. */
-function changesetsAt(rev, cwd) {
+/**
+ * Every PENDING changeset path at a rev — the consumed prerelease stock under
+ * `.changeset/pre/` excluded (`isConsumedPrerelease`).
+ *
+ * Exported for `--self-test` S6/S8: the two consumers below print counts, and a
+ * count is the one thing an exit code cannot tell apart from "nothing ran".
+ */
+export function changesetsAt(rev, cwd) {
   return changesetDirAt(rev, cwd)?.changesets ?? [];
 }
 
@@ -3473,6 +3511,63 @@ function selfTest() {
     // same bypass: the worklist silently omitted them.
     const TABLE_PRESCRIPTION = '**BREAKING** x\n\n## Migration\n\n| Wrote | Write instead |\n| --- | --- |\n| `new HttpServer(p)` | register the `HonoHttpServer` |\n';
     assert(cls(CS({ body: TABLE_PRESCRIPTION })) === 'residue', 'S7: THE #6497 SHAPE -- published break + arrowless rewrite TABLE -- is RESIDUE');
+  }
+
+  // ---- PRE1-PRE3: `.changeset/pre/` is CONSUMED stock, not pending stock -----
+  //
+  // `@changesets/cli` v3 MOVES every changeset it consumes into `.changeset/pre/`
+  // at the cut that consumes it, and `changesetDirAt` lists `.changeset`
+  // RECURSIVELY (`ls-tree -r`). Without `isConsumedPrerelease` the entire consumed
+  // stock of an open RC window flows into `--list` and `--audit-stock`, two
+  // surfaces whose subject is the PENDING backlog. Measured on a real v3 cut of
+  // this repo's stock: 209 consumed changesets, every one of them returned by
+  // `git ls-tree -r --name-only <cut> -- .changeset`.
+  //
+  // PRE2 is the half that must NOT hold, and it is why the filter lives in
+  // `changesetsAt` rather than in `isChangesetFile`: the enforcing scan reads the
+  // diff through `isChangesetFile`, so a changeset ADDED under `.changeset/pre/`
+  // by a PR is judged like any other. Filter the verdict instead of the audit and
+  // `.changeset/pre/` becomes the place to put a breaking change you do not want
+  // read.
+  {
+    const { dir } = mk({
+      files: {
+        '.changeset/pre/consumed-one.md': CS({ body: 'consumed at the last cut\n\n**BREAKING** something\n' }),
+        '.changeset/pre/consumed-two.md': CS({ body: 'consumed at the last cut\n\n**BREAKING** something else\n' }),
+      },
+    });
+    const stock = changesetsAt('HEAD', dir);
+    assert(
+      stock.length === 1 && stock[0] === '.changeset/stock-breaking.md',
+      `PRE1: the audit surfaces read PENDING stock only -- two consumed changesets under .changeset/pre/ must not appear -- got ${JSON.stringify(stock)}`,
+    );
+  }
+
+  red('PRE2 a breaking changeset ADDED under .changeset/pre/ is still judged', run(mk({
+    files: { '.changeset/pre/smuggled.md': SIX048 },
+    pkgs: { '@objectstack/runtime': { dir: 'packages/runtime', private: false }, '@objectstack/spec': { dir: 'packages/spec', private: false } },
+  })), [/smuggled/, /no `adr-0087:` disposition marker/]);
+
+  {
+    // PRE3: `entries` stays UNFILTERED. A tree whose changesets have all moved
+    // into `.changeset/pre/` is the ordinary state of main mid-window; narrowing
+    // the readability probe as well would turn it into a #4690 refusal and undo
+    // #8658 by a different route. Pending stock is legitimately zero there.
+    const { dir } = mk({
+      files: {
+        '.changeset/stock-breaking.md': null,
+        '.changeset/pre/consumed.md': CS({ body: 'consumed\n\n**BREAKING** something\n' }),
+      },
+    });
+    const probs = assertInputs({ cwd: dir, head: 'HEAD' });
+    assert(
+      probs.length === 0,
+      `PRE3: a tree holding ONLY consumed changesets under .changeset/pre/ is readable input, not a #4690 refusal -- got: ${probs.join('|')}`,
+    );
+    assert(
+      changesetsAt('HEAD', dir).length === 0,
+      `PRE3: ...and its PENDING stock is legitimately zero -- got ${JSON.stringify(changesetsAt('HEAD', dir))}`,
+    );
   }
 
   assert(breakingDeclaration(parseChangeset(CS({ body: 'feat(spec)!: x\n' }))).breaking, 'P6: a conventional-commit bang is a declaration');

--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -58,25 +58,45 @@
  *
  * It went unnoticed because the enforcing half has never run: the RC exemption
  * above stands the guard down for the whole pre-release window. What made it
- * urgent is that the window ENDS. Measured on `origin/main` @ `d3e53f2d8`, with
- * `pre.json` still at `"mode": "pre"`:
+ * urgent is that the window ENDS. Measured on `origin/main` @ `d3e53f2d8`, under
+ * `@changesets/cli` v2, with `pre.json` still at `"mode": "pre"`:
  *
  *   total .changeset/*.md (excl README):  1552
  *   FILES declaring a major:               171
  *   total major package entries:           222
  *   pre.changesets recorded:              1279
  *
- * Those files are on disk because pre-mode `changeset version` does not delete
- * the changesets it consumes — it records them in `pre.json.changesets` so the
- * final release can re-apply them. Only the POST-EXIT `changeset version`
- * deletes them. So `changeset pre exit` rewrites the mode to `"exit"`
- * (@changesets/pre@2.0.2, `changesets-pre.cjs.js:117`), that commit lands on
- * main, and from that moment until the Version PR merges, the stock-scoped guard
- * would have failed EVERY unlabelled PR in the repo — each one listing 171 files
- * it never touched, with `allow-major` as the only route out. That label's own
- * error message says "a whole-stack major release is genuinely intended", which
- * is false for a PR fixing a typo, so the escape hatch would have meant
- * something different from what it says for the duration of the window.
+ * Those files were on disk because pre-mode `changeset version` under v2 did not
+ * delete the changesets it consumed — it recorded them in `pre.json.changesets`
+ * so the final release could re-apply them, and only the POST-EXIT
+ * `changeset version` deleted them. So `changeset pre exit` rewrote the mode to
+ * `"exit"`, that commit landed on main, and from that moment until the Version PR
+ * merged, the stock-scoped guard would have failed EVERY unlabelled PR in the
+ * repo — each one listing 171 files it never touched, with `allow-major` as the
+ * only route out. That label's own error message says "a whole-stack major
+ * release is genuinely intended", which is false for a PR fixing a typo, so the
+ * escape hatch would have meant something different from what it says for the
+ * duration of the window.
+ *
+ * ### What `@changesets/cli` v3 changes here, and what it does not
+ *
+ * v3 MOVES each consumed changeset into `.changeset/pre/NAME.md` at the cut that
+ * consumes it (changesets#2190) instead of leaving it in the root. Measured on a
+ * v3 cut of this repo's own stock — 209 pending changesets, 17.0.0 ->
+ * 17.1.0-rc.0, a full `pnpm run version` in a throwaway clone: afterwards the
+ * root holds only the UNCONSUMED residue, all 209 consumed files sit under
+ * `.changeset/pre/`, and `readChangesets` below — a root-only `readdirSync`
+ * filtered to `.md` — does not enumerate them (`pre` is a directory, not a
+ * `.md`). The 1552-file high-water mark and the single post-exit deletion event
+ * that made this urgent are both gone; the stock this guard could ever read is
+ * bounded now.
+ *
+ * NONE OF THAT RETIRES A LINE OF THE FIX BELOW, and this section is written to
+ * be unreadable as though it did. Stock size was the URGENCY; it was never the
+ * ARGUMENT. The argument is #6129's — "what this PR introduced" is a claim about
+ * one side of a fork and cannot be evaluated without the fork — and it is exactly
+ * as true at a stock of 2 as at 1552. What v3 does add is a new population of `R`
+ * rows on the ORDINARY path; see the diff-row table below.
  *
  * The fix is the sibling's, deliberately rather than coincidentally: judge only
  * what the diff INTRODUCES, starting at `merge-base(base, head)` and never at
@@ -120,15 +140,31 @@
  * `"@objectstack/spec": major` is reported for `@objectstack/cli` alone. The
  * report naming only what the PR introduced is the entire point of the card.
  *
- * `R` is where this file diverges from its two siblings by one letter:
- * `check-empty-changeset.mjs` and `check-adr-0087-registration.mjs` both use
- * `--diff-filter=AM`. Measured on git 2.43.0, renaming `.changeset/old.md` to
- * `.changeset/new.md` while flipping its bump to `major` reports as
- * `R075 .changeset/old.md .changeset/new.md` and is dropped entirely by `AM` —
- * a silent bypass. `AMR` plus reading the base side at the OLD path closes it
- * and costs nothing, because a pure rename compares equal and stays exempt. The
- * two siblings have the same hole in their own directions; filed separately
- * rather than fixed here, because their fixtures and messages are theirs.
+ * `R` is in the filter because of a bypass measured here first. On git 2.43.0,
+ * renaming `.changeset/old.md` to `.changeset/new.md` while flipping its bump to
+ * `major` reports as `R075 .changeset/old.md .changeset/new.md` and is dropped
+ * entirely by `--diff-filter=AM` — a silent bypass. `AMR` plus reading the base
+ * side at the OLD path closes it and costs nothing, because a pure rename
+ * compares equal and stays exempt.
+ *
+ * This paragraph used to say the two siblings `check-empty-changeset.mjs` and
+ * `check-adr-0087-registration.mjs` "both use `--diff-filter=AM`", i.e. that they
+ * still carried the hole. That stopped being true at #7045 and is corrected here
+ * rather than repeated: measured on the tree this line ships in, both siblings
+ * pass `AMR` today. A stale claim about a sibling's filter is worse than no
+ * claim — it is the kind a reader acts on.
+ *
+ * Under `@changesets/cli` v3 the `R` row also stops being a hand-crafted-bypass
+ * shape and becomes the ORDINARY one. A cut renames every consumed changeset into
+ * `.changeset/pre/`, and git's `.changeset/*.md` pathspec reaches into that
+ * directory (`*` crosses `/` in a pathspec). Measured on a real v3 cut commit of
+ * this repo: `git diff --name-status --diff-filter=AMR <cut>^ <cut> --
+ * '.changeset/*.md'` returns exactly 209 `R100` rows, every one under `pre/`. So
+ * any PR that merges main after a cut now carries a whole cut's worth of `R` rows
+ * through this gate. They are pure renames, so the base-side read at the OLD path
+ * compares equal and every one is exempt — but only because the filter says
+ * `AMR`. Dropping the `R` would no longer hide one crafted rename; it would hide
+ * a cut.
  *
  * ## The cost of the branch point, stated rather than slipped in
  *
@@ -1110,7 +1146,8 @@ function selfTest() {
     }
 
     // The rename rows. Measured on git 2.43.0: this reports as `R<score>` and is
-    // dropped entirely by the two siblings' `--diff-filter=AM`.
+    // dropped entirely by `--diff-filter=AM` (which is what this gate and both
+    // its siblings passed until #7045).
     {
       const long = '\n\nbody long enough for git to score this as a rename rather than an add plus a delete\n';
       const oldMinor = '---\n"@objectstack/spec": minor\n---' + long;


### PR DESCRIPTION
Fixes #9498

`@changesets/cli` 2.31.1 → 3.0.0, with every consequential change in the same PR — epic #9465's ruling 1: both half-states are broken, and each is broken *silently* until the next release. Sub-issue 2/4.

The scope is #9497's rehearsal. Every number below was **re-measured on this branch's tree** rather than inherited, because the stock has grown from the rehearsal's 165 changesets to 209 — and one of those new changesets turns out to matter (see "Where measurement diverged from the rehearsal").

---

## 1. The next train is 17.1.0 — shown, not asserted

Maintainer ruling on #9498, verbatim: 接受 17.1.0. Proof on the migrated tree, `@changesets/cli` 3.0.0:

```
$ changeset status --output=status-v3-ga.json      # non-pre, whole stock
releases by type: {"minor":69,"patch":7,"none":1}
changesets in plan: 209
  @objectstack/spec  17.0.0 -> 17.1.0 (minor)
  @objectstack/cli   17.0.0 -> 17.1.0 (minor)
  @objectstack/dogfood        0.0.40 -> 0.0.41 (patch)
  @objectstack/example-crm    4.0.92 -> 4.0.93 (patch)
  @objectstack/docs           4.2.1  -> 4.2.1  (none)
major releases: NONE
```

and in pre mode, which is the number the next cut dispatches:

```
$ changeset pre enter rc && changeset status --output=status-v3-rc.json
releases by type: {"minor":69,"patch":7,"none":1}
  @objectstack/spec  17.0.0 -> 17.1.0-rc.0 (minor)
```

Driven end to end through a full window in a throwaway clone (`pre enter` → RC1 → author a changeset → RC2 → `pre exit` → GA), all on this branch's tree:

| step | root `.changeset/*.md` | `.changeset/pre/` | `packages/cli` version |
|---|---|---|---|
| `pre enter rc` | 209 | – | 17.0.0 |
| `pnpm run version` (RC1) | **0** | **209** | **17.1.0-rc.0** |
| author one changeset | 1 | 209 | |
| `pnpm run version` (RC2) | **0** | **210** | **17.1.0-rc.1** |
| `changeset pre exit` | 0 | 210 | (`pre.json` `mode` → `"exit"`, one line, nothing else) |
| `pnpm run version` (GA) | 0 | 0 | **17.1.0** |

No changeset declares a major (`major releases: NONE`), and none was written to preserve 18.0.0 — explicitly rejected in the ruling. v2's 18.0.0 came from one optional peer edge (`@objectstack/cli` → `@objectstack/driver-turso`) crossed with "a prerelease never satisfies a non-prerelease range"; that is traced by ablation on #9465, not re-derived here.

## 2. What changed, and which unknown drove it

| file | change | driver |
|---|---|---|
| `package.json` + `pnpm-lock.yaml` | `@changesets/cli` `^2.31.1` → `^3.0.0` | the bump itself |
| `.changeset/config.json` | **add** `"privatePackages": {"version": true, "tag": false}` | **U4** |
| `.changeset/config.json` | **remove** `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` | **U2** |
| `.changeset/config.json` | `$schema` → `@changesets/config@4.0.0` (the version v3 resolves) | maintenance line |
| `.github/workflows/cut-rc.yml` | **prose only** — the measured file set, and the falsified "consumed changesets are recorded in pre.json / a cut never races a lane PR" claim | **U3** |
| `.github/workflows/pr-automation.yml` | **prose only** — two blocks resting on v2's "pre mode RETAINS every consumed .md" | **U3**, **U5** |
| `docs/releases-maintenance.md` | **prose only** — same falsified pre.json claim | **U3** |
| `scripts/check-changeset-no-major.mjs` | **header only** — the pollution narrative gets its v3 numbers; the stale claim that both siblings pass `--diff-filter=AM` is corrected | **U5** |
| `scripts/check-adr-0087-registration.mjs` | **code** — `.changeset/pre/` excluded from `--list` / `--audit-stock`, plus PRE1–PRE3 fixtures | rehearsal's scope verdict |

### `.changeset/config.json` — the toggle matrix, measured here

Same 209 changesets, v3, `changeset status`:

| config state | plan |
|---|---|
| **as shipped** (privatePackages set, experimental key removed) | `{"minor":69,"patch":7,"none":1}`, 77 packages, spec 17.1.0 |
| + experimental key restored (`true`) | identical |
| + experimental key `false` | identical |
| privatePackages **unset** (v3's default) | **exit 1** — see below |

The experimental key is measurably **inert under v3** (the peer-escalation branch is gone from `@changesets/assemble-release-plan@7`), so dropping it is a no-op here — and it may only be dropped *in this commit*, because under v2 it is load-bearing on the GA path (U2).

## 3. Where measurement diverged from the rehearsal — and the divergence matters

#9497 measured `privatePackages` unset as **lossy but survivable**: 8 private packages stop being versioned, 2 private-only changesets never get consumed. On today's stock it is **fatal**:

```
$ changeset status                       # privatePackages unset, v3.0.0
Error: Found mixed changeset default-timeout-margin-repair
Found ignored packages: @objectstack/dogfood
Found not ignored packages: @objectstack/types
Mixed changesets that contain both ignored and not ignored packages are not allowed
    at getRelevantChangesets (@changesets/assemble-release-plan@7.0.0/dist/index.mjs:326)
🦋 Exited with code 1
```

With `privatePackages.version === false`, v3 treats private packages as **ignored**, and a changeset naming one private and one public package becomes a "mixed changeset", which changesets refuses outright. Today's stock has exactly one — `.changeset/default-timeout-margin-repair.md` (`@objectstack/types` patch + `@objectstack/dogfood` patch), landed after the rehearsal's snapshot — plus 4 private-only changesets where the rehearsal saw 2.

So U4's recommendation is not a nicety about version numbers: without that key the bump alone takes the release lane from "wrong versions" to "will not run". It is more evidence for ruling 1, arriving from a direction nobody planned.

## 4. The measured v3 file set vs the enforced allowlist (U3)

`git status --porcelain` after `changeset pre enter rc` + `pnpm run version`, v3.0.0, 209 pending changesets — **366 lines**:

```
=== BY STATUS CODE ===          === BY PATH CLASS ===
    209  D                          209  D  .changeset/NAME.md
    155  M                           76  M  PKG/package.json
      2 ??                           76  M  PKG/CHANGELOG.md
                                      3  M  the 3 declared doc surfaces
                                      1 ??  .changeset/pre.json
                                      1 ??  .changeset/pre/
```

`.changeset/pre/account-oauth-tokens-internal.md` diffs **identical** to the original — the files are moved verbatim.

| the allowlist comment's claim (written under v2) | v3, measured |
|---|---|
| 77 modified `package.json` | **76** — the 77th was the blank template's, rewritten only at a major boundary; 17.0.0 → 17.1.0-rc.0 is not one |
| 76 modified `CHANGELOG.md` | 76 ✅ |
| `.changeset/pre.json` modified | **never modified** — v3's `pre.json` is `{"mode","tag"}` and stays that way |
| **zero deletions** | ❌ **209** |
| **zero untracked** | ❌ 1 new directory, `.changeset/pre/`, holding the 209 |
| "a cut never races a lane PR over a `.changeset/*.md` file" | ❌ false — the cut moves 209 tracked changeset paths |

**The enforcement itself needs no change**, replayed verbatim from the workflow against the v3 output:

```
doc surfaces declared by SURFACES (3): docker/README.md, content/docs/deployment/self-hosting.mdx, content/docs/upgrading.mdx
STAGED count: 365
RESULT: allowlist regex accepts every staged path
UNSTAGED ASSERTION: clean (nothing tracked left behind)
--- what got staged, by class ---
    209 .changeset/pre/NAME.md
      1 .changeset/pre.json
     76 PKG/CHANGELOG.md
     76 PKG/package.json
      3 the declared doc surfaces
```

`^\.changeset/` already covers `.changeset/pre/…`, and `git add -A -- … .changeset …` stages the deletions and the new directory together. **The `SURFACE_LIST` / `grep -vxF` block from 955ccf20d is untouched** — this PR changes prose in that file and one `echo` string, nothing else. Ruling 3 ("the allowlist follows the measurement") is satisfied by the allowlist needing no move.

## 5. Gate exposure, measured on a real v3 cut commit

`git ls-tree -r --name-only CUT -- .changeset` at the rehearsal cut:

```
      1 .changeset/*.md      (README.md)
      1 .changeset/config.json
      1 .changeset/pre.json
    209 .changeset/pre/*
```

`scripts/check-adr-0087-registration.mjs`'s `changesetDirAt` uses exactly that recursive `ls-tree`, so from the first v3 cut the entire consumed stock of an open window flows into `--list` and `--audit-stock` — surfaces whose subject is the *pending* backlog. Fixed by excluding the `pre/` prefix in `changesetsAt` **only**:

- the **enforcing** scan still reads the diff through `isChangesetFile`, so a breaking changeset *added* under `.changeset/pre/` is judged like any other. Filtering the verdict instead of the audit would make `.changeset/pre/` a hiding place;
- `entries` stays unfiltered, so a tree whose changesets have all moved into `pre/` is still readable input, not a #4690 refusal (that would undo #8658 by a new route).

Both halves are pinned and both ablations were run:

```
ablate the filter  (changesets: entries.filter(isChangesetFile))
  -> PRE1 RED  (got [".changeset/pre/consumed-one.md", ".changeset/pre/consumed-two.md", ".changeset/stock-breaking.md"])
  -> PRE3 RED  (pending stock got [".changeset/pre/consumed.md"], expected 0)
  -> PRE2 stays GREEN — it does not depend on the filter, by design

move the filter into isChangesetFile (i.e. into the VERDICT path)
  -> PRE2 RED  (the smuggled breaking changeset under .changeset/pre/ is no longer reported)
```

Other gates, measured on the same cut commit rather than reasoned about:

- `pr-automation.yml`'s changeset **counter** (`--diff-filter=A … '.changeset/*.md'`): the 209 moves report as `R100`, so it credits a PR with **0** — still 0 with `diff.renameLimit=1` forced; only `--no-renames` turns them into 209 `A` rows, and nothing passes it. **No change.**
- The `AMR` scan both gates use returns exactly **209 `R100`** rows over the cut. Pure renames compare equal at the old path, so every one is exempt — but only because the filter says `AMR`. That is now the *ordinary* path, not a crafted bypass, and the header says so.
- Root-only readers (`readdirSync` filtered to `.md`) see `pre` as a directory and ignore it: after the GA pass, `readdirSync('.changeset')` is `README.md, config.json, pre` and pending stock is 0. The post-exit mass deletion is **211 D, of which 210 are under `.changeset/pre/` and 0 in the root**.

## 6. What did NOT change — measured, not assumed

- **`scripts/check-empty-changeset.mjs` — untouched (U1), re-measured here on v3.0.0.** Three changesets with empty frontmatter: `changeset version` **exits 0**, deletes all three, bumps nothing — #4898 exactly, reproduced on v3. Zero changesets: exits 1. v3's exit-1 counts changeset *files*, not releases, so it covers a disjoint case; there is no coverage to trade. (v3 also reads `.changeset/pre/`, so inside a window the count is never 0 and the guard is disarmed for the whole window.)
- **`scripts/objectui-changeset-digest.mjs`** — re-read on current `main` (it moved in #9448). Its only `pre.json` contact is `inPreMode()` → `pre?.mode === 'pre'`, which survives v3's slimmed file. `check:objectui-changeset` green.
- **`.github/workflows/release.yml`** — its `pre.json` reference is a past-tense account of #3600's mechanism and is still accurate. #9499 owns the action question (U6 was not answerable from here).
- **`scripts/check-changeset-fixed.mjs`** — green: `fixed` group in sync with 69 public workspace packages.
- **`scripts/check-changeset-no-major.mjs`'s logic** — U5's verdict is "less than hoped": the exemption switch, the `mode: "exit"` re-arm and the merge-base/`AMR` scoping are all still load-bearing under v3. What v3 retires is the *urgency* the header was written in, not a line of code. The header now says that explicitly, so nobody reads shrinking stock as licence to drop the scoping.
- **Nothing reads `pre.json.changesets` or `pre.json.initialVersions`** — repo-wide, the only references were prose, all corrected here.

## 7. #9450 — decided, not folded in silently

**Not carried.** `cut-rc.yml:285`'s "range is walkable" preflight is a different defect in the same file: it is about objectui clone reachability, and nothing in this migration touches it. It is an ungraded `finding`, #9497 explicitly did not exercise the objectui pin-range path, and grading it would be fresh adjudication rather than execution against a measured spec. The two blocks are textually disjoint, so nothing is gained by bundling. It stays open and unassigned for its own dispatch.

## 8. Changeset decision — `skip-changeset`

This PR releases nothing. The diff is a root **devDependency** range plus release machinery: two gate scripts, two workflows' comments, an internal maintainer doc, and `.changeset/config.json`. No workspace package's published surface, runtime, or types are touched; `docs/` is not `content/docs/`. Naming a package in a changeset would put a false line in 69 CHANGELOGs. The label is the exemption designed for exactly this, so it is applied rather than an empty changeset written (#5471/#4898).

## 9. Gates — re-derived for this diff and run

`node scripts/pm/dispatch-gates.mjs` over the 8 changed paths named 13 families; all 13 run green on the final commit — `git rev-parse --short HEAD` at the time of the run: **`06e7ca712`**:

```
check:changeset-gate-self-tests   ✓ 212 + 116 + (check-empty-changeset) assertions
check:node-version                ✓ 27 setup-node steps, all Node 22
check:objectui-changeset          ✓ digest + range self-tests
check:override-consistency        ✓ 4 published-manifest declarations resolve
check:required-contexts           ✓
check:shard-attestation           ✓ 92 assertions
check:workflow-status-functions   ✓ 34 assertions, 24 workflows scanned
check:nul-bytes                   ✓ 75 assertions; 6157 files, no raw control bytes
check-adr-0087-registration.mjs --base MERGE_BASE   ✓
check-changeset-fixed.mjs                           ✓
check-changeset-no-major.mjs --base MERGE_BASE      ✓
check-empty-changeset.mjs --base MERGE_BASE         ✓
check-osv-exemptions.mjs                            ✓
eslint on both changed scripts                      ✓
```

## 10. For whoever dispatches the next cut

`cut-rc.yml` asserts computed == dispatched. From today's stock the computed number is **17.1.0-rc.0**, not 18.0.0-rc.0. Dispatch the new number, or the cut refuses before anything is pushed or published.

## Rehearsal rig — reproducible, and why it terminates

Per #9555: a local `pnpm run version` never terminates in this container, because `@changesets/git`'s `getCommitsThatAddFiles` deepens in a loop against a shallow clone with no reachable remote. The scaffold, inside a throwaway clone with its remote removed:

```
git rm -r --cached --quiet .changeset && git commit -q -m "replay scaffold: untrack .changeset"
git add .changeset                    && git commit -q -m "replay scaffold: re-add .changeset"
```

Tree hash verified identical before and after (`7c25e1c0f04822a9fd29f5718b9c1ec32a509fea`). A full `pnpm run version` then takes **7.7s**. **No release was performed**: no publish, no tag, no pre-mode transition on `origin`, no workflow dispatch, no Version Packages PR touched. `.changeset/pre.json` is absent on `main` and stays absent on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDA9nN6nXQngoQUAAzRdMb)_