### PR TITLE
chore(lint): repoint check-route-envelope.mjs's ratchet owner to #9559

### DIFF
--- a/scripts/check-route-envelope.mjs
+++ b/scripts/check-route-envelope.mjs
@@ -242,7 +242,7 @@ const MODULES = {
   'packages/rest/src/rest-server.ts': {
     dialectOnly:
       'the repo\'s hottest response file (208 write sites, edited several times a day) — a `responses` ratchet would go red for edits that are not envelope drift',
-    ratchet: '#7035 (option 1: convert onto the shared sendOk/sendError)',
+    ratchet: '#9559 (option 1: convert onto the shared sendOk/sendError)',
     stringError: 44,
     // 77 → 75 (#7981): registerSecurityEndpoints' two `handleError` arms moved
     // off the `{ code, error }` sibling-code literal onto the shared
@@ -306,7 +306,7 @@ const MODULES = {
     responses: 2,
     ok: 0,
     err: 0,
-    ratchet: '#7035 (option 1: convert onto the shared sendOk/sendError)',
+    ratchet: '#9559 (option 1: convert onto the shared sendOk/sendError)',
   },
 };
 


### PR DESCRIPTION
Fixes #9461

Repoints `scripts/check-route-envelope.mjs`'s two `ratchet:` fields (`rest-server.ts`
`:245`, `error-response.ts` `:309`) from the closed `#7035` to the live tracking card
`#9559`, preserving the option-1 prose verbatim. Nothing else moves.

## Why

`#7035` reached `completed` on 2026-08-10 (PR #7293, three `/meta` 501 handlers) and was
never the owner of "convert this file onto the shared sendOk/sendError." Triage on
#9461 executed option 1 at the triage layer: `#9559` is a `tracking` card that stays
open while any `ratchet:` field names it, with both legal exits written into it (a
dedicated envelope card, or the ADR-0112 D5 permanently-accepted path).

## Scope check (Zone 2 of the dispatch card)

Measured `ratchet: '#7035` on `origin/main` before editing: **exactly 2** occurrences,
at `:245` (`rest-server.ts`) and `:309` (`error-response.ts`) — matches the card's
assumption exactly. A control query (`dialectOnly`, 15 hits; a made-up string, 0 hits)
confirmed the grep itself works before trusting the zero/two counts.

The file's other **eleven** `#7035` mentions are historical prose (comments describing
what #7035 did, past tense) — left untouched per Zone 1 rule 2.

## What did not move

```diff
-  ⚠ ratchet #7035 (option 1: convert onto the shared sendOk/sendError): packages/rest/src/rest-server.ts (dialect facts only — stringError 44, siblingCode 69; ticks down only, write sites NOT pinned)
-  ⚠ ratchet #7035 (option 1: convert onto the shared sendOk/sendError): packages/rest/src/error-response.ts (pinned at current drift, not conformant)
+  ⚠ ratchet #9559 (option 1: convert onto the shared sendOk/sendError): packages/rest/src/rest-server.ts (dialect facts only — stringError 44, siblingCode 69; ticks down only, write sites NOT pinned)
+  ⚠ ratchet #9559 (option 1: convert onto the shared sendOk/sendError): packages/rest/src/error-response.ts (pinned at current drift, not conformant)
```

That is the entire diff in the gate's own output — captured by running `pnpm
check:route-envelope` before and after the edit and diffing the two runs. Every other
line (`10 route module(s) audited: 7 conformant, 2 ratcheted, 1 exempt`, `stringError
44, siblingCode 69`, `responses: 2` pinned-at-current-drift, the dispatcher/plugin-route
sections) is byte-identical. No counter, threshold, or exempt entry changed.

## Verification

Run at `d22bc2ecb` (final commit; `git status --porcelain` empty):

- `check:route-envelope` — self-test ✓ (`✓ check-route-envelope self-test passed`),
  audit ✓ exit 0: `10 route module(s) audited: 7 conformant, 2 ratcheted, 1 exempt`.
- `node scripts/pm/dispatch-gates.mjs scripts/check-route-envelope.mjs` — names exactly
  one family: `pnpm check:route-envelope [lint.yml]`.
- `check:nul-bytes` — clean (6157 tracked text files, no raw control bytes), plus a
  targeted self-scan of the changed file.

No package build or test was run, and none is owed: the diff touches no package
source (`scripts/check-route-envelope.mjs` is a repo-root dev-tooling script, not
inside any `packages/*`), so there is no affected package to build a closure for.

## skip-changeset

The diff releases nothing — one lint script, no package source, matching the identical
precedent on this same file (#9455, `chore(lint): record the ruled pre-auth exemption
in the route-envelope gate`, which used this exact label for this exact reason). Label
applied on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_