### PR TITLE
fix(tooling): error-status gate names the real cause when a code leaves the ungraded set (#9563)

### DIFF
--- a/scripts/check-error-status-conformance.mjs
+++ b/scripts/check-error-status-conformance.mjs
@@ -606,6 +606,34 @@ export function reconcile({ vocabulary, emitted, claimed, covered, documented })
   return { emittedNotDocumented, documentedNotReachable, unpinned: unpinned.sort(), reconciledCodes, reconciledPairs };
 }
 
+/**
+ * The two causes a BASELINED-as-unpinned code can leave the `unpinned` census
+ * on a later run — split at the same `documented.has(code)` juncture
+ * `reconcile()` branches on, rather than assuming the first cause for a
+ * subtraction that has two:
+ *
+ *   'producer'    a producer now declares a status for it (`runtime.size > 0`
+ *                 in `reconcile()`), while the code is still documented.
+ *   'doc-removed' its doc entry was removed — nothing documents the code any
+ *                 more (`!documented.has(code)`), and no producer appeared
+ *                 either, or `reconcile()` would already have counted it as a
+ *                 reconciled code, not an unpinned one.
+ *
+ * A code cannot leave `unpinned` for any OTHER reason: `reconcile()` only
+ * ever adds a code to `unpinned` when `runtime.size === 0 && documented.has
+ * (code)`, so losing that membership means one of those two flipped.
+ *
+ * @param {string[]} baselined codes recorded unpinned in the baseline file
+ * @param {{ unpinned: string[], vocabulary: string[], documented: Set<string> }} input
+ * @returns {{ code: string, reason: 'producer' | 'doc-removed' }[]}
+ */
+export function nowPinned({ baselined, unpinned, vocabulary, documented }) {
+  return baselined
+    .filter((c) => !unpinned.includes(c) && vocabulary.includes(c))
+    .sort()
+    .map((code) => ({ code, reason: documented.has(code) ? 'producer' : 'doc-removed' }));
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // Messages — named and pure, so the self-test can assert the exact text
 // ───────────────────────────────────────────────────────────────────────────
@@ -649,8 +677,15 @@ export function unreadableHeadingMessage(u) {
   );
 }
 
-export function nowPinnedMessage(code) {
+export function nowPinnedProducerMessage(code) {
   return `${code}: baselined as unpinned, but a producer now declares its status — ratchet the baseline down with --update.`;
+}
+
+export function nowPinnedDocRemovedMessage(code) {
+  return (
+    `${code}: baselined as unpinned, but its doc entry was removed, so nothing claims a status for it any more `
+    + '— ratchet the baseline down with --update.'
+  );
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -725,6 +760,7 @@ function runFixture({ files, handling, catalog, members }) {
     ungraded: ungradedEntries(doc),
     unresolved: derived.unresolved,
     emitted: derived.emitted,
+    documented: doc.documented,
   };
 }
 
@@ -841,8 +877,9 @@ function selfTest() {
   // 11 — the ratchet-authority convention holds on the weakening remedy only.
   check('11 the baseline-expanding remedy is marked maintainer-only',
     RATCHET_EXPANSION_OFFER.test(newUnpinnedMessage('X')) && newUnpinnedMessage('X').includes(RATCHET_AUTHORITY_MARKER));
-  check('11b the ratchet-DOWN remedy stays the author\'s own',
-    !nowPinnedMessage('X').includes(RATCHET_AUTHORITY_MARKER));
+  check('11b both ratchet-DOWN remedies stay the author\'s own',
+    !nowPinnedProducerMessage('X').includes(RATCHET_AUTHORITY_MARKER)
+    && !nowPinnedDocRemovedMessage('X').includes(RATCHET_AUTHORITY_MARKER));
 
   // 12 — the vocabulary bound: a ledger code is derived but not reconciled.
   const ledger = runFixture({
@@ -992,7 +1029,42 @@ function selfTest() {
   check('20c an entry that DOES publish a graded status is not in the census',
     ungradedEntries({ entries: [{ code: 'TIMEOUT', where: 'x:1' }], claimed: new Map([['TIMEOUT', new Map([[504, []]])]]), covered: new Map() }).length === 0);
 
-  const CASES = 36;
+  // 21 — nowPinned, the PRODUCER branch: a baselined code that GAINS a
+  //      producer while remaining documented is named a producer, never a
+  //      doc removal.
+  const producerCase = runFixture({
+    files: { 'a/e.ts': "export class E extends Error {\n  readonly code = 'TRANSACTION_FAILED';\n  readonly status = 500;\n}" },
+    handling: '#### `TRANSACTION_FAILED`\n**HTTP Status:** 500  \n', catalog: '', members: ['TRANSACTION_FAILED'],
+  });
+  const producerFindings = nowPinned({
+    baselined: ['TRANSACTION_FAILED'], unpinned: producerCase.unpinned,
+    vocabulary: producerCase.vocabulary, documented: producerCase.documented,
+  });
+  check('21 nowPinned names the producer branch when the code stays documented',
+    producerFindings.length === 1 && producerFindings[0].code === 'TRANSACTION_FAILED' && producerFindings[0].reason === 'producer',
+    JSON.stringify(producerFindings));
+  check('21b the producer message names a producer, not a doc removal',
+    nowPinnedProducerMessage('TRANSACTION_FAILED').includes('a producer now declares its status')
+    && !nowPinnedProducerMessage('TRANSACTION_FAILED').includes('doc entry was removed'));
+
+  // 22 — nowPinned, the DOC-REMOVED branch: the #9266/#9563 counterfactual,
+  //      reduced to a fixture. No producer, and the catalog entry is gone —
+  //      the real cause the old single-cause message misdiagnosed as "a
+  //      producer now declares its status" when the `## Batch Operation
+  //      Errors` entries were deleted on `main`.
+  const docRemovedCase = runFixture({ files: {}, handling: '', catalog: '', members: ['TRANSACTION_FAILED'] });
+  const docRemovedFindings = nowPinned({
+    baselined: ['TRANSACTION_FAILED'], unpinned: docRemovedCase.unpinned,
+    vocabulary: docRemovedCase.vocabulary, documented: docRemovedCase.documented,
+  });
+  check('22 nowPinned names the doc-removed branch when nothing documents the code any more',
+    docRemovedFindings.length === 1 && docRemovedFindings[0].code === 'TRANSACTION_FAILED' && docRemovedFindings[0].reason === 'doc-removed',
+    JSON.stringify(docRemovedFindings));
+  check('22b the doc-removed message names a removed doc entry, not a producer',
+    nowPinnedDocRemovedMessage('TRANSACTION_FAILED').includes('doc entry was removed')
+    && !nowPinnedDocRemovedMessage('TRANSACTION_FAILED').includes('a producer now declares'));
+
+  const CASES = 40;
   if (failures.length) {
     for (const f of failures) console.error(`  x self-test: ${f}`);
     console.error(`\n✗ check-error-status-conformance --self-test: ${failures.length}/${CASES} case(s) failed.\n`);
@@ -1004,8 +1076,9 @@ function selfTest() {
     + '(positive control), both directions fire independently, section headings absolve but never demand, '
     + 'narrated envelopes in comments are not producers, unresolvable declarations are reported, a LEDGER code '
     + 'the docs publish a status for is reconciled in both directions while one no page publishes stays out of '
-    + 'the vocabulary, an entry heading in an unrecognised shape is reported instead of silently dropped, and '
-    + 'the baseline-expanding remedy stays maintainer-only.',
+    + 'the vocabulary, an entry heading in an unrecognised shape is reported instead of silently dropped, the '
+    + 'baseline-expanding remedy stays maintainer-only, and a baselined code leaving the unpinned census is '
+    + 'named a producer or a removed doc entry — never the wrong one of the two.',
   );
   process.exit(0);
 }
@@ -1058,7 +1131,9 @@ const baseline = existsSync(BASELINE_PATH)
   : { unpinned: [] };
 const baselined = new Set(baseline.unpinned ?? []);
 const newlyUnpinned = result.unpinned.filter((c) => !baselined.has(c));
-const nowPinned = [...baselined].filter((c) => !result.unpinned.includes(c) && vocabulary.includes(c)).sort();
+const nowPinnedFindings = nowPinned({
+  baselined: [...baselined], unpinned: result.unpinned, vocabulary, documented: doc.documented,
+});
 
 if (update) {
   writeFileSync(
@@ -1143,7 +1218,9 @@ for (const f of result.emittedNotDocumented) failures.push(emittedNotDocumentedM
 for (const f of result.documentedNotReachable) failures.push(documentedNotReachableMessage(f));
 for (const u of doc.unreadableHeadings) failures.push(unreadableHeadingMessage(u));
 for (const c of newlyUnpinned) failures.push(newUnpinnedMessage(c));
-for (const c of nowPinned) failures.push(nowPinnedMessage(c));
+for (const f of nowPinnedFindings) {
+  failures.push(f.reason === 'producer' ? nowPinnedProducerMessage(f.code) : nowPinnedDocRemovedMessage(f.code));
+}
 
 if (failures.length) {
   console.error('');


### PR DESCRIPTION
Fixes #9563

`check-error-status-conformance.mjs`'s `nowPinnedMessage()` computed the
ratchet-down trigger as a subtraction (`baselined \ result.unpinned`) but
hard-coded a single cause for it: "a producer now declares its status."
`result.unpinned` drops a code for either of two unrelated reasons —
`reconcile()`'s own branch at `documented.has(code)` shows why:

```js
if (runtime.size > 0) {
  reconciledCodes++;
  ...
} else if (documented.has(code)) {
  unpinned.push(code);
}
```

A baselined code leaves `unpinned` because **a producer appeared**
(`runtime.size > 0`), or because **its doc entry was removed**
(`!documented.has(code)`, with no producer either). Only the first cause had
a sentence.

## Before — the false diagnosis, reproduced

Per the issue's counterfactual: temporarily deleted the `## Batch Operation
Errors` section from `content/docs/api/error-catalog.mdx` (its three entries
— `BATCH_PARTIAL_FAILURE`, `BATCH_COMPLETE_FAILURE`, `TRANSACTION_FAILED` —
are all in `scripts/error-status-unpinned-baseline.json` and none has a real
producer) and ran the gate on `main`, before this fix:

```
$ node scripts/check-error-status-conformance.mjs
  unpinned: 34 documented code(s) with no derivable producer (baselined: 37).

  x BATCH_COMPLETE_FAILURE: baselined as unpinned, but a producer now declares its status — ratchet the baseline down with --update.
  x BATCH_PARTIAL_FAILURE: baselined as unpinned, but a producer now declares its status — ratchet the baseline down with --update.
  x TRANSACTION_FAILED: baselined as unpinned, but a producer now declares its status — ratchet the baseline down with --update.

x check:error-status-conformance — 3 finding(s).
```

No producer declares a status for any of the three (verified by grep across
`packages/`, `examples/`, `apps/` — the only hits outside the enum
declaration are two spec tests). The message is simply false on this route.
Restored the doc file (`git restore --source=HEAD`) before touching any code.

## After — the same counterfactual, this fix applied

```
$ node scripts/check-error-status-conformance.mjs
  unpinned: 34 documented code(s) with no derivable producer (baselined: 37).

  x BATCH_COMPLETE_FAILURE: baselined as unpinned, but its doc entry was removed, so nothing claims a status for it any more — ratchet the baseline down with --update.
  x BATCH_PARTIAL_FAILURE: baselined as unpinned, but its doc entry was removed, so nothing claims a status for it any more — ratchet the baseline down with --update.
  x TRANSACTION_FAILED: baselined as unpinned, but its doc entry was removed, so nothing claims a status for it any more — ratchet the baseline down with --update.

x check:error-status-conformance — 3 finding(s).
```

Truthful now, and `--update` is still the correct remedy either way — the
ratchet direction and remedy are unchanged, only the stated cause. Doc file
restored to a clean tree again afterward; `git status --porcelain` is empty
on `main` HEAD for that path throughout.

## What changed (`scripts/` only)

- `nowPinnedMessage()` -> split into `nowPinnedProducerMessage()` and
  `nowPinnedDocRemovedMessage()`, each naming its real cause.
- New pure `nowPinned({ baselined, unpinned, vocabulary, documented })`,
  placed beside `reconcile()`: derives `{ code, reason }[]` at the same
  `documented.has(code)` juncture `reconcile()` branches on, so the message
  selection isn't guessing — it reuses the same fact reconcile() already
  computed.
- `runFixture()` now also returns `documented` (the parsed doc-side set), so
  fixture-level self-tests can call `nowPinned()` directly.
- No baseline semantics change, no catalog change, no grading-model change —
  diagnosis text + self-tests only.

## Self-test — 2 new cases per branch (36 -> 40)

- **21 / 21b** — producer branch: a baselined code that gains a producer
  while remaining documented is named `reason: 'producer'`, and
  `nowPinnedProducerMessage()` names a producer, not a doc removal.
- **22 / 22b** — doc-removed branch: the #9266 / #9563 counterfactual
  reduced to a fixture (no producer, doc entry gone) is named
  `reason: 'doc-removed'`, and `nowPinnedDocRemovedMessage()` names a removed
  doc entry, not a producer.
- **11b** updated to assert the ratchet-authority convention on *both*
  ratchet-down messages (neither carries the MAINTAINER-ONLY marker).

```
check-error-status-conformance --self-test: 40 cases pass — …
```

## Reverse verification

Committed the fix, then temporarily forced `nowPinned()`'s branch to always
return `reason: 'producer'` (reverting only the causal split, keeping the new
self-test cases) and re-ran `--self-test`. Predicted: case 22 (doc-removed
branch) goes red, everything else stays green. Observed exactly that:

```
  x self-test: 22 nowPinned names the doc-removed branch when nothing documents the code any more — [{"code":"TRANSACTION_FAILED","reason":"producer"}]

x check-error-status-conformance --self-test: 1/40 case(s) failed.
```

Restored the fix from the branch (`git checkout claude/issue-9563-gate-diagnosis-split -- scripts/check-error-status-conformance.mjs`); re-ran `--self-test`, back to 40/40 green.

## Gates

- `node scripts/pm/dispatch-gates.mjs scripts/check-error-status-conformance.mjs`
  -> 1 matched family: `pnpm check:error-status-conformance` (`lint.yml`).
- `pnpm check:error-status-conformance` (self-test + real run) — green, at
  head `f173b99db`:
  ```
  check-error-status-conformance --self-test: 40 cases pass — …
  every derivable runtime status is documented, and every documented status is reachable.
  ```
- `pnpm check:nul-bytes` (self-test + real run, under the shared
  `/tmp/os-heavy-verify.lock`) — green: `check-nul-bytes: OK (scanned 6157
  text file(s) … no raw ASCII control bytes)`.
- No changeset: `git log --oneline -- scripts/check-error-status-conformance.mjs`
  shows the file's last two substantive commits (#9445, #9268) shipped
  without one — root-level `scripts/` tooling isn't part of any package in
  `.changeset/config.json`'s `fixed` list. Followed the house convention.

## Serial constraint (#9266)

#9266 (`needs-user-decision`, same file's subject matter) is still open with
no linked PR as of this branch's base — no re-run of the observation was
needed. No `content/docs/releases/` edits, no baseline rewrite, no catalog
edit landed by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs18A2DdXLVN2h8PaaFBcP)_