### PR TITLE
docs(qa): point the two platform-checklist READMEs at RUNNER.md rule 2's carve-out

### DIFF
--- a/docs/qa/platform-checklist/README.md
+++ b/docs/qa/platform-checklist/README.md
@@ -280,11 +280,12 @@ over this ledger**: `since == vN` (the new capabilities) ∪ all `P0` (the stand
 smoke) ∪ any item whose `source` cites a PR in the release. The tracking issue for the
 sweep links here and hosts discussion; results stay OUT of the repo — every run files
 one `qa-run` GitHub issue as its record (text only: the verdict table + a reproduction
-rule per failure, never screenshots; `runs/` is git-ignored), and a run that finds a real
-regression extracts it into its own standalone card at close-out (RUNNER.md, extraction
-obligation — the run issue itself stays `qa-run`-only, excluded from triage). Item text,
-fixtures learned, and new traps discovered flow **back into the ledger** as revisions —
-that is the accumulation the one-off checklists never had.
+rule per failure — RUNNER.md rule 2's authentication/authorization carve-out excepted,
+and it binds the extracted card too — never screenshots; `runs/` is git-ignored), and a
+run that finds a real regression extracts it into its own standalone card at close-out
+(RUNNER.md, extraction obligation — the run issue itself stays `qa-run`-only, excluded
+from triage). Item text, fixtures learned, and new traps discovered flow **back into the
+ledger** as revisions — that is the accumulation the one-off checklists never had.
 
 ## Relationship to what already exists
 

--- a/docs/qa/platform-checklist/runs/README.md
+++ b/docs/qa/platform-checklist/runs/README.md
@@ -13,11 +13,19 @@ durable, **text-only** report (pass or fail alike):
 
 - the issue **body** hosts the per-clause verdict table (pass / partial / fail / blocked)
   and the scope — the selector that chose the items + the `revision` each ran against;
+  [../RUNNER.md](../RUNNER.md) carries the body contract in full, and this line
+  summarises only part of it;
 - **every `fail` carries a reproduction rule** in that same issue — ordered steps / API
   calls (method · path · body) / the ref-targeted selector path + expected-vs-actual;
   the run issue itself stays `qa-run`-only (protocol carrier, excluded from the triage
   sweep) — at close-out each product defect is extracted into its own standalone card
   (RUNNER.md, extraction obligation), and that card is what triages;
+  - **one exception — authentication and authorization findings.** Their reproduction is
+    **never published on GitHub**: not in this record, not in the extracted card, not in
+    a comment. Such a `fail` is still a completed verdict, and what it carries instead is
+    [../RUNNER.md](../RUNNER.md) rule 2's carve-out — read it there before you write the
+    record. This line is the flag that you are in that case; the rule itself is stated in
+    one place only;
 - **screenshots are never part of the report** — they are live judgment aids that die
   with the run environment, described in one line of text, never attached or linked.
 


### PR DESCRIPTION
Fixes #9507

Parent work: #9471 / PR #9506, which added the authentication/authorization carve-out to
RUNNER.md rule 2 and pointed RUNNER.md's own three restatements at it. The two sibling
READMEs were outside that card's declared file surface and kept stating the reproduction
obligation unconditionally.

## What changed

**`docs/qa/platform-checklist/runs/README.md`** — the `fail` bullet gains one nested
exception clause naming authentication and authorization findings, the never-publish
prohibition, and a link to RUNNER.md rule 2's carve-out for what the record carries
instead.

**`docs/qa/platform-checklist/README.md`** — the release-sweep paragraph's "a reproduction
rule per failure" now reads "RUNNER.md rule 2's authentication/authorization carve-out
excepted, and it binds the extracted card too". That file already used pointer style for
the extraction obligation, so this matches its own convention.

## Pointer, not a second copy — and where the line was drawn

The card and the parent card both argue that a hand-maintained second copy of a policy
goes stale silently; the carve-out landing in RUNNER.md without these two files is the
proof. So neither file restates the policy. But a pointer nobody knows to follow is not a
pointer, and the failure this guards is irreversible: a runner mid-record publishes a
working exploit once and cannot unpublish it.

The split applied, deliberately:

- **inline** — the trigger (authentication/authorization findings) and the prohibition
  (never published on GitHub: not the record, not the extracted card, not a comment).
  Both are the stable half; they are the maintainer ruling itself, and they are what a
  reader needs in order to stop before writing.
- **by reference** — the mechanics: that such a `fail` is still a completed verdict, the
  exact `detail withheld pending maintainer` wording, the rationale, and the ruling
  provenance. This is the drift-prone half, and it is stated in RUNNER.md only.

`runs/README.md` gets the fuller flag because it is what a runner reads while writing the
record; `README.md` is an overview whose reader is not in the act of publishing, so it
gets a bare pointer clause.

## Second finding in the same file, fixed in the same pass

Per the dispatch's instruction to diff the whole obligation rather than only the carve-out
sentence: `runs/README.md`'s first bullet describes the issue body as "the per-clause
verdict table and the scope", while RUNNER.md's enumeration (RUNNER.md lines 260-264) is
"env fingerprint · scope · per-clause verdict table · a reproduction rule per `fail` ·
derived item verdicts + fixture gaps". A runner reading only `runs/README.md` files a
record with no env fingerprint, in a document that argues a verdict is interpretable only
next to the build it names.

Same defect class, same file, same gate family, and the correct form is pinned by
RUNNER.md — so it is fixed here rather than filed: the bullet now says RUNNER.md carries
the body contract in full and that this line summarises only part of it. No enumeration is
copied, so there is no new drift surface.

## Sweep for other restatements

Repo-wide, excluding `node_modules`. English and Chinese phrasings both searched, since
the QA skills are written in Chinese and an English-only grep reads as a clean sweep while
missing them.

| location | state |
|---|---|
| `docs/qa/platform-checklist/RUNNER.md` | authority; carve-out plus three pointers, from PR #9506 |
| `docs/qa/platform-checklist/README.md` | was unconditional — fixed here |
| `docs/qa/platform-checklist/runs/README.md` | was unconditional — fixed here |
| `.claude/skills/checklist-test/SKILL.md` | governed surface — reported, not edited; see below |
| `.claude/skills/checklist-author/SKILL.md` | no restatement of the obligation; its one adjacent line ("security-sensitive findings are never filed publicly without the maintainer's decision") agrees with the carve-out |
| `docs/qa/platform-checklist/SWEEP.md`, `FOLLOW-UPS.md`, `.claude/skills/dogfood-verification/SKILL.md` | no restatement |

Zero-hit results carry a positive control: each file reporting no match was re-grepped for
a token known to be present, and every one returned a hit, so the misses are real rather
than a broken search.

`.claude/skills/checklist-test/SKILL.md` is a **governed surface and was not edited**. It
does carry the carve-out, at its Guardrails section, and that clause explicitly names what
it overrides. One residual asymmetry is reported rather than fixed: its extraction bullet
in section 4 tells the runner to itemize the reproduction and mechanism in the extracted
card with no pointer at the carve-out, whereas PR #9506 added exactly such a pointer to
RUNNER.md's extraction paragraph. The Guardrails clause does say "not into a tracking
card", so the substance is covered; the gap is that a reader landing on section 4 alone
does not see it. Maintainer's call, in a repo surface only a human merges.

## Verification

Docs-only. Gate families derived from the actual changed paths after the final commit, not
recalled:

```
node scripts/pm/dispatch-gates.mjs docs/qa/platform-checklist/README.md docs/qa/platform-checklist/runs/README.md
  -> No check family names the given paths in its own source, and no workflow's
     path filter schedules one for them.
```

That falsifies the dispatch's expectation that `check:platform-checklist` covers these
files. Reading `scripts/check-platform-checklist.mjs` confirms it: the READMEs appear
there only inside an error message, never as an input. It was run anyway, together with
the named doc-authoring family, at `6cc02e162` (the final commit):

```
check:nul-bytes          OK  (75 self-test assertions; 6170 text files scanned, no raw control bytes)
check:doc-authoring      OK  (self-test green; 377 files clean, no bare metadata literals)
check:platform-checklist OK  (checklist-select self-test 17 cases; 15 areas, 190 items, 0 waived)
```

`check:doc-anchors` is not applicable: its link-source scope is `content/` plus the
repo-root `README.md` and `ARCHITECTURE.md` (`EXTRA_SOURCES` in
`scripts/check-doc-anchors.mjs`), so nothing under `docs/qa/` is scanned. It also cannot
run in this worktree, which has no `node_modules` — reported as a fact rather than passed
off as green.

`skip-changeset`: this PR releases nothing — internal QA process docs, no package and no
published `content/docs/` page.

RUNNER.md is untouched. This PR does not re-decide the carve-out; it makes two
restatements agree with the authority.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_