### PR TITLE
fix(ci): published-README call sites assert the leading boundary instead of consuming it

### DIFF
--- a/scripts/check-published-readme-exports.mjs
+++ b/scripts/check-published-readme-exports.mjs
@@ -117,6 +117,11 @@
 //   count(...)` on a locally-bound variable is pseudo-code and is never read.
 //   Anything whose type is `any`, or which carries an index signature, is not
 //   reported -- absence of a property there is not evidence.
+//
+//   That fence is a CHARACTER CLASS, and #9610 measured what happens when it is
+//   spelled as a consuming alternation instead of a zero-width assertion: the
+//   receiver in `kernel.use(SomePlugin.configure(…))` became unreachable, because
+//   the outer call had already eaten the `(` in front of it. See extractMemberCalls.
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, posix, resolve } from 'node:path';
@@ -337,14 +342,31 @@ export function extractMemberCalls(markdown, localNames) {
     for (const { n, text } of fence.lines) {
       // Skip the import statements themselves and single-line comments.
       if (/^\s*(import\b|\/\/|\*|\/\*)/.test(text)) continue;
-      const rx = /(^|[^\w$.'"`])([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)\s*\(/g;
+      // ⛔ The leading boundary is ASSERTED, never consumed (#9610). The obvious
+      // spelling -- `(^|[^\w$.'"`])` -- eats the character in front of the receiver,
+      // and `rx` is global, so a receiver beginning at the very next character after
+      // a previous match has no boundary left to match against. A match always ends
+      // at its own `(`, which makes the swallowed position exactly `outer(Inner.m(`
+      // -- and `kernel.use(SomePlugin.configure({…}))` is the house spelling of every
+      // README this gate was built for, so the blind spot was the NORMAL position,
+      // not a corner. Measured on the published regex, one space apart:
+      //
+      //   kernel.use(CacheServicePlugin.configure({…}))   -> extracted: kernel.use
+      //   kernel.use( CacheServicePlugin.configure({…}))  -> extracted: both
+      //
+      // A negative lookbehind is zero-width, so nothing is consumed and the `^` arm
+      // folds in (a negative lookbehind is satisfied at position 0). The character
+      // class is byte-for-byte the old one, so the fence is unchanged: `a.b.c(` and
+      // `'str'.trim(` stay out -- now in the nested position too, which is the only
+      // position this change newly reaches.
+      const rx = /(?<![\w$.'"`])([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)\s*\(/g;
       let m;
       while ((m = rx.exec(text)) !== null) {
-        if (!wanted.has(m[2])) continue;
-        const key = `${m[2]}.${m[3]}`;
+        if (!wanted.has(m[1])) continue;
+        const key = `${m[1]}.${m[2]}`;
         if (seen.has(key)) continue;
         seen.add(key);
-        out.push({ line: n, object: m[2], member: m[3] });
+        out.push({ line: n, object: m[1], member: m[2] });
       }
     }
   }
@@ -954,6 +976,44 @@ function selfTest() {
     [],
   );
 
+  // -- the adversarial position (#9610), which the fixture above cannot reach ----
+  // Every case above puts the wanted receiver where no earlier match on the line
+  // has consumed anything in front of it. That is why a gate written with
+  // self-tests in BOTH directions still shipped blind to the shape below: the
+  // receiver starts at the character immediately after a DISCARDED `X.y(` match,
+  // with nothing separating them. It is also the house spelling of the six READMEs
+  // this gate exists for, so it is the likeliest wrong rewrite of any of them.
+  const nestedReceiver = [
+    '```typescript',
+    "import { CacheServicePlugin } from '@objectstack/service-cache';",
+    'await kernel.use(CacheServicePlugin.configure({ adapter: "memory" }));',
+    '```',
+  ].join('\n');
+  eq(
+    'extractMemberCalls — a receiver directly inside a discarded call is still read',
+    extractMemberCalls(nestedReceiver, ['CacheServicePlugin']).map((c) => `${c.object}.${c.member}`),
+    ['CacheServicePlugin.configure'],
+  );
+
+  // The other direction, in that SAME position: reaching it must not widen the
+  // fence. Property access, all three quote styles, and the CORRECT `new X(`
+  // spelling stay silent when nested exactly as above.
+  const nestedRejected = [
+    '```typescript',
+    "import { CacheServicePlugin } from '@objectstack/service-cache';",
+    'await kernel.use(wrapper.CacheServicePlugin.configure({}));',
+    "console.log('CacheServicePlugin.configure(');",
+    'console.log("CacheServicePlugin.configure(");',
+    'console.log(`CacheServicePlugin.configure(`);',
+    'await kernel.use(new CacheServicePlugin({ adapter: "memory" }));',
+    '```',
+  ].join('\n');
+  eq(
+    'extractMemberCalls — the nested position does not widen the fence',
+    extractMemberCalls(nestedRejected, ['CacheServicePlugin']),
+    [],
+  );
+
   // -- specifier splitting ------------------------------------------------------
   eq('splitSpecifier — scoped root', splitSpecifier('@objectstack/spec'), {
     name: '@objectstack/spec',
@@ -1062,6 +1122,25 @@ function selfTest() {
   eq(
     'analyzeDocument — a real class with an invented static is reported once',
     analyzeDocument(fabricatedStatic, resolveFake).map((f) => f.id),
+    ['@objectstack/kernel|packages/kernel/README.md|member|@objectstack/kernel|Kernel.configure'],
+  );
+
+  // ...and the same fabricated static written the way plugin registration is
+  // actually written: nested inside another call, no separator (#9610). This ran
+  // GREEN end to end on the real tree before the boundary became zero-width.
+  const fabricatedStaticNested = {
+    pkg: '@objectstack/kernel',
+    file: 'packages/kernel/README.md',
+    text: [
+      '```typescript',
+      "import { Kernel } from '@objectstack/kernel';",
+      'await app.use(Kernel.configure({}));',
+      '```',
+    ].join('\n'),
+  };
+  eq(
+    'analyzeDocument — a fabricated static nested inside another call is reported',
+    analyzeDocument(fabricatedStaticNested, resolveFake).map((f) => f.id),
     ['@objectstack/kernel|packages/kernel/README.md|member|@objectstack/kernel|Kernel.configure'],
   );
 


### PR DESCRIPTION
Fixes #9610

> ⚠️ **Reading note.** A negative-lookbehind literal cannot be carried in a GitHub body: the `!` in `(?` + less-than + `!` + `[` is deleted in storage (measured in #9621, with controls both ways). So wherever the real source has those two characters, this body writes `NLB`. **The genuine line is in the diff.**

## The defect, re-measured before fixing

`extractMemberCalls` found `Name.member(` with a leading alternation whose non-`^` arm **consumes** a character. The regex is global, so a receiver starting at the very next character after a previous match had no boundary left to match against. A match always ends at its own `(` — which makes the swallowed position exactly `outer(Inner.m(`.

Re-measured on the published regex, receiver set `{CacheServicePlugin}`:

```
await kernel.use(CacheServicePlugin.configure({ a: 1 }));
   all: ["kernel.use"]                                   kept: []                               MISSED
await kernel.use( CacheServicePlugin.configure({ a: 1 }));
   all: ["kernel.use","CacheServicePlugin.configure"]     kept: ["CacheServicePlugin.configure"]  caught
```

And end to end on the built tree, `service-cache`'s README given the genuine `CacheServicePlugin` with a fabricated static, one space apart:

| README line | pre-fix | post-fix |
|:---|:---|:---|
| `await kernel.use(CacheServicePlugin.configure({...}))` | **exit 0, green** | **exit 1**, `line 299: documents CacheServicePlugin.configure(...)` |
| `await kernel.use( CacheServicePlugin.configure({...}))` | exit 1 | exit 1, same finding, same key |

That nested position is not a corner — `kernel.use(new SomePlugin({...}))` is the house spelling of every README this gate polices, so the blind spot sat in the gate's most important position, and on the likeliest wrong rewrite of any of those pages.

## The fix

A negative lookbehind: the boundary is asserted zero-width, nothing is consumed, and the `^` arm folds in because a negative lookbehind is satisfied at position 0.

```js
// NLB stands for the two characters this body cannot carry; see the reading note.
const rx = /(?NLB[\w$.'"`])([A-Za-z_$][\w$]*)\s*\.\s*([A-Za-z_$][\w$]*)\s*\(/g;
```

The character class is byte-for-byte the old one, so the fence is unchanged. Group indices shift 2/3 to 1/2 with the capture gone.

### The card's proposal is sound — the missing `!` is a platform artifact, not an authoring error

The regex literal in #9610's "Suggested fix" reads back without its `!`, which is a `SyntaxError` — V8 reads a less-than right after `(?` as the opener of a **named group**. I did **not** file that as a defect in the card:

- The card's prose names "a **negative lookbehind**" and reasons from the property only the negative form has ("satisfied at position 0"), so the author wrote the `!`.
- The same deletion then hit this PR. My first body revision carried the real literal in three places; all three came back with the `!` gone.
- Probed with controls in #9621: `A` less-than `!B` **keeps** its `!`, while `(?` less-than `[\w$])` **loses** it. The destructive shape is the markup-declaration opener — less-than, `!`, `[` — which is exactly how a negative lookbehind over a character class is written.

⇒ Nothing in the card needs changing. Filed as **#9621**, because `AGENTS.md`'s sanitizer clause names only a less-than followed by a *letter* and so does not cover this, and because the same read path truncated a body at a doctype token (#9557's family).

## `--self-test`, in the same edit

The hole survived a gate written with self-tests in both directions because every existing fixture placed the wanted receiver where **no earlier match on the line had consumed anything in front of it**. Three cases added:

- `extractMemberCalls — a receiver directly inside a discarded call is still read` — fixture is `await kernel.use(CacheServicePlugin.configure({...}))`, receiver adjacent to a discarded `kernel.use(` match with **no separating character**.
- `analyzeDocument — a fabricated static nested inside another call is reported` — the same shape end to end.
- `extractMemberCalls — the nested position does not widen the fence` — the other direction **in that same position**: `wrapper.CacheServicePlugin.configure(`, all three quote styles, and the correct `new CacheServicePlugin(` spelling all stay silent.

### Reverse verification

Fix committed first, then the boundary reverted to the consuming form with the new fixtures left in place:

```
✗ check:published-readme-exports --self-test — 2 failure(s)

  extractMemberCalls — a receiver directly inside a discarded call is still read
      expected ["CacheServicePlugin.configure"]
      actual   []
  analyzeDocument — a fabricated static nested inside another call is reported
      expected ["...|member|@objectstack/kernel|Kernel.configure"]
      actual   []
```

Restored from the committed branch state; `git status` clean afterwards. Honest note on direction: the third case is green under **both** regexes by design — it is a fence-preservation pin (it reddens if someone widens the character class), not a regression detector for this change.

## No drift in what is detected

The fix changes **zero** known instances. Same numbers before and after, on the same built tree:

```
✓ check:published-readme-exports — 60 published document(s) across 77 workspace package(s);
  166 import statement(s), 47 workspace type entr(ies).
  16 known instance(s) still in scripts/published-readme-exports.baseline.json;
  2 of the findings are call sites.
```

### Cross-check against PR #9602 (not yet merged; this does not address it)

PR #9602 rewrites the five service READMEs and shrinks the baseline 16 to 10. Its head content was overlaid onto this branch and measured both ways:

| gate | over #9602's READMEs + baseline |
|:---|:---|
| this branch's fixed gate | green, **10** known instances, 2 call sites |
| `origin/main`'s pre-fix gate | green, **10** known instances, 2 call sites |

⇒ The fix newly detects **nothing** in #9602's rewritten content, and the numbers match #9602's own reported result exactly. No finding about that PR, and no baseline interaction in either landing order.

## Gates

The gate union derived by `node scripts/pm/dispatch-gates.mjs` from `git diff --name-only $(git merge-base origin/main HEAD)` (one changed path, `scripts/check-published-readme-exports.mjs`) is `check:published-readme-exports`; `check:nul-bytes` and `eslint` added for any-edit coverage. All run at **`a87e7f0bd`**, the final commit, with the working tree clean against it — all exit 0:

- `pnpm check:published-readme-exports` (self-test + full scan) — exit 0
- `pnpm check:nul-bytes` (self-test + scan of 6171 files) — exit 0
- `npx eslint scripts/check-published-readme-exports.mjs --no-inline-config` — exit 0

The full workspace was built first (`turbo run build`, 71 tasks, 71 successful): this gate hard-errors on a missing type entry rather than skipping, so on an unbuilt tree it refuses and measures nothing — a refusal is not a pass.

## No changeset

Repo tooling only — `scripts/` ships in no package's `files` array, so nothing user-visible changes. `skip-changeset` applied as a label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_
