### PR TITLE
fix(services): two published `.d.ts` JSDoc comments stop describing behaviour their code does not have

### DIFF
--- a/.changeset/service-jsdoc-declared-equals-actual.md
+++ b/.changeset/service-jsdoc-declared-equals-actual.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/service-cache": patch
+"@objectstack/service-job": patch
+---
+
+fix(services): two published `.d.ts` JSDoc comments stop describing behaviour their code does not have — `MemoryCacheAdapter` eviction is FIFO, not LRU, and `recordRuns` is an on/off switch, not a retention cap (#9611)
+
+Both comments are emitted by `tsup` into each package's built `index.d.ts`, so they
+are **the editor tooltip an npm consumer sees** — the same "published documentation
+asserting behaviour the runtime does not have" class as #9517 and #9532, in a third
+channel that no gate reads. No runtime behaviour changes in either package; this is a
+patch because the corrected text only reaches consumers through a release.
+
+**1. `MemoryCacheAdapter` — "LRU-style eviction" was never LRU.**
+
+The class comment advertised `TTL-based expiry and LRU-style eviction`. The eviction
+path takes `this.store.keys().next().value` — the first key in `Map` insertion order —
+and `get()` returns `entry.value` without ever deleting and re-setting the key, so a
+read does not move an entry back. Nor does an overwrite: `Map.set` on a key already
+present keeps its original insertion slot. Eviction has therefore always been
+**oldest-inserted (FIFO)**, which is a materially different hit-rate profile from the
+one the tooltip promised anyone sizing a cache.
+
+The comment was corrected rather than the code, deliberately: `maxSize` defaults to `0`
+(unlimited), so the eviction path is off by default and nothing shipped is getting FIFO
+where it expected LRU, and there is no measured pull for LRU. Minting a real behaviour
+change to make a stale sentence true inverts the fix — the defect is that the
+documentation lies, not that the cache is wrong. (A real LRU already exists in the repo,
+`packages/metadata/src/utils/lru-cache.ts`, for the callers that need one.)
+
+Four tests now pin the corrected sentence so it stops being an unenforced claim. Each is
+written as a **discriminator against LRU**: it reads (or overwrites) the oldest entry
+before overflowing the cache and then asserts that entry was evicted anyway — a hot key
+dies on age, an untouched newer key survives. The pre-existing eviction tests could not
+tell the two policies apart, which is how the wrong comment sat green.
+
+**2. `DbJobAdapterOptions.recordRuns` — the comment described a different field.**
+
+`/** Soft cap on sys_job_run rows recorded per job (defaults to none — handled by
+retention jobs) */` made three claims and the code contradicts all three: the field is a
+`boolean`, not a count; it defaults to `true`, not "none" (`args.options?.recordRuns ??
+true`); and it gates whether a `sys_job_run` row is written at all, rather than being
+trimmed later by retention. The sentence reads as if it belongs to the numeric
+`JobRunRetention` knob that ADR-0057 retired — a copy-paste that outlived its source.
+
+The consequence the new wording keeps in sight: **a reader who sets `recordRuns: false`
+expecting "no cap" gets run history switched off.** The replacement states the real
+meaning (one row per attempt, inserted at start and updated on settle, default `true`)
+and both things that are *not* affected by the flag — the `sys_job` row's own
+`last_status` / `run_count` / `failure_count` counters, which `bumpJob` updates
+regardless, and `replay()`, which writes its synthetic `trigger: 'replay'` row without
+consulting the flag at all.

--- a/packages/services/service-cache/src/memory-cache-adapter.test.ts
+++ b/packages/services/service-cache/src/memory-cache-adapter.test.ts
@@ -105,3 +105,87 @@ describe('MemoryCacheAdapter', () => {
     expect(await cache.has('expiring')).toBe(false);
   });
 });
+
+// ─── eviction is insertion-order (FIFO), and the class JSDoc says so ─────────
+//
+// The class comment used to advertise "LRU-style eviction" while `get()` has
+// never re-inserted the key it reads, so eviction has always been oldest-
+// INSERTED, not least-recently-USED. The comment was corrected rather than the
+// code; these tests are what stops that corrected sentence from being another
+// unenforced claim.
+//
+// Every case below is written to be a DISCRIMINATOR: each one passes under the
+// shipped FIFO store and fails under an LRU store, because each performs a
+// read (or an overwrite) on the oldest entry and then asserts that the entry
+// was evicted anyway. A test that merely fills the cache past `maxSize` without
+// touching anything first cannot tell the two policies apart, which is how the
+// pre-existing eviction tests above sat green over a comment they contradicted.
+describe('MemoryCacheAdapter — insertion-order (FIFO) eviction', () => {
+  it('a read does NOT refresh eviction order — the read-hot oldest entry is still evicted', async () => {
+    const cache = new MemoryCacheAdapter({ maxSize: 2 });
+    await cache.set('a', 1);
+    await cache.set('b', 2);
+
+    // Read 'a' repeatedly: under LRU this promotes it to most-recently-used and
+    // makes 'b' the eviction candidate. Under FIFO it changes nothing at all.
+    expect(await cache.get('a')).toBe(1);
+    expect(await cache.get('a')).toBe(1);
+    expect(await cache.has('a')).toBe(true);
+
+    await cache.set('c', 3);
+
+    expect(await cache.has('a')).toBe(false); // oldest-inserted, evicted despite being hot
+    expect(await cache.get('b')).toBe(2);     // untouched, survives — the inverse of LRU
+    expect(await cache.get('c')).toBe(3);
+  });
+
+  it('an overwrite does NOT refresh eviction order either — Map.set keeps the original slot', async () => {
+    const cache = new MemoryCacheAdapter({ maxSize: 2 });
+    await cache.set('a', 1);
+    await cache.set('b', 2);
+
+    // Overwriting an existing key never evicts (it is not a new key) and never
+    // moves the entry: `Map.set` on a present key keeps its insertion position.
+    await cache.set('a', 10);
+    expect(await cache.get('a')).toBe(10);
+
+    await cache.set('c', 3);
+
+    expect(await cache.has('a')).toBe(false); // freshly written, still the oldest slot
+    expect(await cache.get('b')).toBe(2);
+    expect(await cache.get('c')).toBe(3);
+  });
+
+  it('evicts strictly in insertion order across a longer run, reads notwithstanding', async () => {
+    const cache = new MemoryCacheAdapter({ maxSize: 3 });
+    await cache.set('a', 1);
+    await cache.set('b', 2);
+    await cache.set('c', 3);
+
+    // Make 'a' the hottest key in the cache and 'c' the coldest.
+    await cache.get('a');
+    await cache.get('a');
+    await cache.get('a');
+
+    await cache.set('d', 4); // evicts 'a' (first in), not 'c' (least recently used)
+    expect(await cache.has('a')).toBe(false);
+    expect(await cache.has('c')).toBe(true);
+
+    await cache.set('e', 5); // evicts 'b' — the queue keeps advancing by age
+    expect(await cache.has('b')).toBe(false);
+
+    expect(await cache.get('c')).toBe(3);
+    expect(await cache.get('d')).toBe(4);
+    expect(await cache.get('e')).toBe(5);
+    expect((await cache.stats()).keyCount).toBe(3);
+  });
+
+  it('leaves the eviction path off entirely at the default maxSize of 0 (unlimited)', async () => {
+    const cache = new MemoryCacheAdapter(); // maxSize defaults to 0
+    for (let i = 0; i < 50; i++) await cache.set(`k${i}`, i);
+
+    expect(await cache.get('k0')).toBe(0); // the very first key is still there
+    expect(await cache.get('k49')).toBe(49);
+    expect((await cache.stats()).keyCount).toBe(50);
+  });
+});

--- a/packages/services/service-cache/src/memory-cache-adapter.ts
+++ b/packages/services/service-cache/src/memory-cache-adapter.ts
@@ -30,7 +30,13 @@ export interface MemoryCacheAdapterOptions {
 /**
  * In-memory cache adapter implementing ICacheService.
  *
- * Uses a Map-backed store with TTL-based expiry and LRU-style eviction.
+ * Uses a Map-backed store with TTL-based expiry and **insertion-order (FIFO)
+ * eviction**: once `maxSize` is reached, a new key evicts the oldest-inserted
+ * entry. This is deliberately **not** LRU — neither reading an entry nor
+ * overwriting its value moves it back in the queue, so a hot key is evicted on
+ * age like any other (pinned by the FIFO tests in `memory-cache-adapter.test.ts`).
+ * `maxSize` defaults to `0` (unlimited), which leaves the eviction path off.
+ *
  * Suitable for single-process environments, development, and testing.
  */
 export class MemoryCacheAdapter implements ICacheService {

--- a/packages/services/service-job/src/db-job-adapter.ts
+++ b/packages/services/service-job/src/db-job-adapter.ts
@@ -31,7 +31,19 @@ export interface JobLoggerLike {
 export interface DbJobAdapterOptions {
   /** Maximum executions kept in memory per job (default 100) */
   maxExecutions?: number;
-  /** Soft cap on sys_job_run rows recorded per job (defaults to none — handled by retention jobs) */
+  /**
+   * Record each scheduled or triggered execution as a `sys_job_run` row —
+   * inserted at the start of every attempt and updated to its terminal status
+   * when that attempt settles. Default **`true`**.
+   *
+   * This is an on/off switch for run history, NOT a retention cap: setting it to
+   * `false` means no per-attempt rows are written at all, so `sys_job_run` holds
+   * nothing for these executions and `listExecutionsByStatus` has nothing to
+   * read. Two things are unaffected either way — the `sys_job` row's own
+   * `last_status` / `run_count` / `failure_count` counters, and
+   * {@link DbJobAdapter.replay}, which writes its synthetic `trigger: 'replay'`
+   * row regardless of this flag.
+   */
   recordRuns?: boolean;
 }
 


### PR DESCRIPTION
Fixes #9611

Both comments are emitted by `tsup` into their package's built `index.d.ts`, so they are **the editor tooltip an npm consumer sees** — the same "published documentation asserting behaviour the runtime does not have" class as #9517 and #9532, in a third channel no gate reads. **Neither package's behaviour changes.**

## Premise verified before implementing

Both claims re-measured against `origin/main` (`ba0a84685`) rather than taken from the card:

- `MemoryCacheAdapter.get()` increments counters and returns `entry.value` — it does **not** delete-and-re-set the key, so a read does not move an entry back. The card's stop-condition ("if `get()` does re-insert on current `main`, the premise is false") did not fire.
- `set()`'s overflow path takes `this.store.keys().next().value` — the first key in `Map` insertion order.
- `this.recordRuns = args.options?.recordRuns ?? true` — boolean, default `true`, gating whether a `sys_job_run` row is written at all.

## 1. `MemoryCacheAdapter` — "LRU-style eviction" was never LRU

The class comment advertised `TTL-based expiry and LRU-style eviction`. Eviction has always been **oldest-inserted (FIFO)**: neither a read nor an overwrite moves an entry back, the latter because `Map.set` on a key already present keeps its original insertion slot. Under a `maxSize` cap that is a materially different hit-rate profile from the one the tooltip promised anyone sizing a cache.

The comment is corrected rather than the code, per the ruling on the card: `maxSize` defaults to `0` (unlimited) so the eviction path is off by default and nothing shipped is getting FIFO where it expected LRU; there is no measured pull for LRU; and minting a real behaviour change to make a stale sentence true inverts the fix — the defect is that the documentation lies, not that the cache is wrong. A real LRU already exists in the repo (`packages/metadata/src/utils/lru-cache.ts`) for callers that need one.

### The pin, and why each case discriminates

Four tests now pin the corrected sentence so it stops being an unenforced claim. Three of them are written to **fail against a hypothetical LRU implementation**: each reads or overwrites the oldest entry *before* overflowing the cache, then asserts that entry was evicted anyway while an untouched newer key survived. The fourth pins the `maxSize: 0` default the comment also asserts.

**Reverse verification — direction predicted before running, and observed:** with a real LRU spliced into the working tree (promote-on-read in `get()`, promote-on-write in `set()`), the three discriminators go **red** and the pre-existing eviction tests stay **green**:

```
 × a read does NOT refresh eviction order — the read-hot oldest entry is still evicted
 × an overwrite does NOT refresh eviction order either — Map.set keeps the original slot
 × evicts strictly in insertion order across a longer run, reads notwithstanding
 Tests  3 failed | 23 passed (26)
```

That second half is the load-bearing part: the two eviction tests that already existed pass under **both** policies, which is exactly how a comment contradicting them sat green. The ablation was applied to the committed state and restored with `git checkout claude/issue-9611-service-jsdoc-truth -- ...`; no ablation marker remains (`grep -c ABLATION` = 0) and the working tree is clean at the head below.

## 2. `DbJobAdapterOptions.recordRuns` — the comment described a different field

`/** Soft cap on sys_job_run rows recorded per job (defaults to none — handled by retention jobs) */` made three claims and the code contradicts all three: a `boolean` not a count, defaulting to `true` not "none", gating whether the row is written at all rather than being trimmed later. The wording reads as if it belongs to the numeric `JobRunRetention` knob that ADR-0057 retired.

The replacement keeps the sharp consequence in sight — **a reader who sets `recordRuns: false` expecting "no cap" gets run history switched off** — and names the two things the flag does *not* affect, both measured rather than assumed: the `sys_job` row's own `last_status` / `run_count` / `failure_count` counters (`bumpJob` is called unconditionally in `settle`), and `replay()`, which writes its synthetic `trigger: 'replay'` row without consulting the flag.

## Acceptance: checked in the emitted artifact, not the source

Rebuilt both packages and read the published declarations. In `service-job/dist/index.d.ts` and its `.d.cts` twin, `grep -c 'Soft cap'` = **0**. In `service-cache/dist/index.d.ts` and its twin, the single surviving occurrence of `LRU` is the corrected sentence's own negation:

```
21: * entry. This is deliberately **not** LRU — neither reading an entry nor
```

Neither comment survives in the built `.d.ts` in a form the code contradicts.

## Changeset: owed, and why

`.changeset/service-jsdoc-declared-equals-actual.md`, `patch` on both packages. AGENTS.md exempts pure bug fixes, but this fix's **entire deliverable is text inside two published packages' `.d.ts`** — with no version bump the corrected tooltip never reaches npm and the card's acceptance is unmet in the only channel it is about. Not breaking, so no ADR-0087 marker is required (`check-adr-0087-registration` confirms: "this PR adds no declared-breaking changeset").

## Verification — union run at `9b07a5e34`, the final commit

Derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths from `git merge-base` (`ba0a84685`), then re-derived after the last commit; the set was unchanged. All at the head above, working tree clean.

| gate | result |
|---|---|
| `pnpm --filter @objectstack/service-cache --filter @objectstack/service-job test` | 26 passed (3 files) · 75 passed (8 files) |
| `pnpm --filter ... typecheck` (both) | `tsc --noEmit` clean |
| `pnpm check:nul-bytes` | OK — 6174 files, no raw control bytes |
| `pnpm check:changeset-gate-self-tests` | OK |
| `pnpm check:objectui-changeset` | OK |
| `pnpm check:test-source-alias` | OK — 72 packages |
| `pnpm check:type-source-resolution` | OK — 76 packages |
| `node scripts/check-adr-0087-registration.mjs` | OK — no declared-breaking changeset |
| `node scripts/check-changeset-no-major.mjs` | OK |
| `node scripts/check-empty-changeset.mjs` | OK — 1 declaring changeset |
| `node scripts/docs-audit/check-affected-docs.mjs` | OK — 242 self-test cases |
| `pnpm check:query-options-erasure` | ratchet holds, none new |
| `pnpm check:engine-double-contract` | OK — 319 pinned, no new double |
| `pnpm check:where-matcher` | OK — 255 matchers, none new |
| `pnpm check:type-check-coverage` | OK — 64/77 packages |
| `pnpm check:type-check-debt --re-measure` | OK — 33 entries re-measured, none above its number |

The ratchet's re-measure needs the built workspace closure, so `turbo run build --filter=./packages/* --filter=./packages/*/*` was run first (70/70 successful). Every heavy step ran under `flock /tmp/os-heavy-verify.lock`.

## Out of scope, filed rather than absorbed

The card's scope fence is two comments and the pinning test. Two findings of the same class were left untouched and filed unassigned:

- **#9631** — the `DbJobAdapter` **class** JSDoc, in this same file and this same emitted `.d.ts`, still says "every execution writes a `sys_job_run` row", which `recordRuns: false` contradicts. It also records that nothing in the package's tests references `recordRuns` at all, so the corrected wording in item 2 is still an unenforced claim.
- **#9633** — `replay()` writes its synthetic run row regardless of `recordRuns`, so an operator who switched run history off still accumulates replay rows. A behavioural question needing a disposition, not a comment fix.

Neither is addressed by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_