### PR TITLE
docs(plugin-audit): restore the published README's `services.audit` pointer, in a form published readers can follow

### DIFF
--- a/.changeset/plugin-audit-readme-audit-service-link.md
+++ b/.changeset/plugin-audit-readme-audit-service-link.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+Published README points at the `services.audit` reference again, in the form a published reader can follow (#9589)
+
+PR #9531 dropped this README's "See Also" pointer to the runtime-services audit
+page because the page was measured wrong — it documented `record()` /
+`'set' | 'reset'` (the settings sink) as if that were the `audit` slot. PR #9587
+rewrote the page around the real slot, so the reason for the omission has stopped
+holding, and the link is restored.
+
+It is restored because the page carries three things this README deliberately
+does not, each verified against the page as it stands on `main` rather than
+against the PR title that rewrote it:
+
+- **the failure posture of the slot itself** — `recordAuthEvent` never throws; a
+  failed ledger insert is reported at `error` level once per process and then
+  drops to `debug`, the row is lost and nothing retries it, and the call silently
+  no-ops when no data engine resolves or when `userId` is absent. This README
+  documents the *record-view batcher's* two failure postures, which are a
+  different code path; it says nothing about this one.
+- **the event's field-by-field shape** — that `userId` must be a real `sys_user`
+  id, that `sessionId` lands on `record_id` with `object_name` fixed to
+  `sys_session`, that `organizationId` stamps the tenant columns and an unstamped
+  row is one non-administrator members can never see, and that `context` is
+  serialized into `metadata`. This README states the slot's interface and its
+  closed `'login' | 'logout'` action union, and deliberately stops there.
+- **the settings-sink disambiguation** — that `SettingsAuditSink.record()` is
+  never registered as or resolved from this slot, and that
+  `getService('audit').record({ ... })` therefore fails with a `TypeError`.
+
+The restored line is **not** the line #9531 removed. That one read
+`[Audit Logging Best Practices](/content/docs/kernel/runtime-services/audit-service.mdx)`
+— a label describing a best-practices guide the page has never been, and a
+repo-path-rooted URL that resolves for neither of this README's published
+audiences. A README in the package's `files` array is rendered on npm and on
+GitHub, where a root-relative href resolves against `npmjs.com` / `github.com`,
+not against the docs site. The replacement uses the absolute
+`https://docs.objectstack.ai/docs/...` form that `create-objectstack`'s published
+READMEs already use, and its annotation states what the page adds — so the next
+author weighing the same omission can check the justification instead of
+reconstructing it.
+
+The one pre-existing site-root-relative docs link in this same file
+(`/docs/permissions/permission-sets#access-depth...`, added by the same PR) is
+converted to the same absolute form. Its target page and heading anchor both
+exist; only the spelling was unfollowable off the docs site.

--- a/packages/plugins/plugin-audit/README.md
+++ b/packages/plugins/plugin-audit/README.md
@@ -340,7 +340,7 @@ Permission sets that use the **hierarchy-relative depth scopes** (`own_and_repor
 `@objectstack/security-enterprise`. The open edition ships no resolver, so those scopes
 **fail closed to `own`** — they never widen visibility without it. A grant written to let
 managers read their reports' audit rows will, on an open build, show them only their own.
-See [Access depth](/docs/permissions/permission-sets#access-depth--readscope--writescope-adr-0057-d1).
+See [Access depth](https://docs.objectstack.ai/docs/permissions/permission-sets#access-depth--readscope--writescope-adr-0057-d1).
 
 `sys_comment`'s record-level edit gates resolve the `sharing` service lazily; without it
 those checks degrade to parent-record read visibility. If the engine exposes no middleware
@@ -394,3 +394,6 @@ Apache-2.0. See [LICENSING.md](../../../LICENSING.md).
 
 - [@objectstack/plugin-security](../plugin-security/) — permissions, RLS and field-level security
 - [@objectstack/plugin-auth](../plugin-auth/) — the caller of the `audit` slot's auth-event ingress
+- [`services.audit` reference](https://docs.objectstack.ai/docs/kernel/runtime-services/audit-service) — the slot's
+  full event shape, its never-throws failure posture, and why `SettingsAuditSink.record()`
+  is not this slot


### PR DESCRIPTION
Fixes #9589

## Verdict: restore — but not the line that was removed

The card asked for a judgment, not a revert. Both conditions the card set are met, so the link goes back; the line that carries it is new, because the removed one was wrong in two ways that outlived the reason it was dropped.

## Condition 1 — the page's defect is gone (read as it stands on `main`)

Verified against `content/docs/kernel/runtime-services/audit-service.mdx` at `14935ab71`, not against the title of the PR that rewrote it:

- **Canonical source** line 9: `packages/plugins/plugin-audit/src/auth-event-audit.ts`.
- **Method** line 24: `services.audit.recordAuthEvent(event: { ... })`.
- **Action union** line 25: `action: 'login' | 'logout'`.
- The settings sink still appears, but only under an explicit **"Not this: the settings audit sink"** heading (line 84) which states it is never registered as or resolved from this slot, and that `getService('audit').record({ ... })` fails with a `TypeError`. That is disambiguation, which is the opposite of the defect PR #9531 measured — nothing on the page presents `record()` / `'set' | 'reset'` as the audit slot.

## Condition 2 — the page carries what the README deliberately does not

The card named three candidates and said a link is worth restoring only if at least one holds. All three do. The README's own "The `audit` service slot" section is lines 291-304 of `packages/plugins/plugin-audit/README.md`.

| Candidate | On the page | In the README |
|---|---|---|
| **Error posture** | "Typical Errors": `recordAuthEvent` never throws; a failed insert is `error` once per process then `debug`; the row is lost and nothing retries; silent no-op when no engine resolves or `userId` is absent | Absent. The README's two failure postures (lines 217-224) belong to the **record-view batcher** — a different code path — and its slot section states no posture at all |
| **`organizationId` visibility** | Line 45: it stamps the row's tenant columns, and an unstamped row is one non-administrator members can never see | The README's tenant note (lines 231-234) is about `read` rows written by the record-view writer. The slot section never enumerates the event's fields |
| **Settings-sink disambiguation** | The "Not this" section, with the `TypeError` consequence | The README names `config_change` as written by `service-settings`, but never distinguishes `SettingsAuditSink.record()` from the slot |

Plus the whole event shape — `userId` must be a real `sys_user` id, `sessionId` lands on `record_id` with `object_name` fixed to `sys_session`, `context` is serialized into `metadata`. The README's slot section stops at `interface AuthEventAuditSink` and the closed action union, so the page is the only place a reader learns what to put in the event. The link is not redundant.

## Why the restored line is a different line

PR #9531 removed:

```
- [Audit Logging Best Practices](/content/docs/kernel/runtime-services/audit-service.mdx)
```

Wrong twice, independently of the page defect:

1. **The label** describes a best-practices guide. The page is a service-slot reference and has never been anything else.
2. **The URL form** resolves for neither audience a published README has. This README is in the package's `files` array with `private` unset, so it renders on **npm** and on **GitHub**, where a root-relative href resolves against `npmjs.com` / `github.com`. It is not a docs-site route either: `apps/docs/lib/source.ts` mounts `loader({ baseUrl: '/docs' })` over `content/docs`, so the route is `/docs/kernel/runtime-services/audit-service`, and `apps/docs/redirects.mjs` has no `/content` source to rescue it.

The replacement uses the absolute form the repo already established, and its annotation states what the page adds — so the next author weighing the same omission can check the justification instead of reconstructing it.

## One in-place fix, declared

`packages/plugins/plugin-audit/README.md:343` carried the only site-root-relative docs link in the entire `packages/` tree — `](/docs/permissions/permission-sets#access-depth...)`, added by the same PR #9531 — and it is converted to the same absolute form. Its target page and heading anchor both exist (`content/docs/permissions/permission-sets.mdx:111`, slug `access-depth--readscope--writescope-adr-0057-d1`); only the spelling was unfollowable off the docs site.

Boundary scan behind that call: `grep -rn "](/docs" --include=README.md packages/` returned exactly one hit before this change and zero after. Same file, same defect class as the link being added, mechanically pinned by the convention below — leaving it would have shipped a README with one followable and one dead docs link, in a diff whose whole subject is which of the two forms is correct. The seven links in **other** packages are **not** touched here; they are filed as #9632.

## PM hypotheses

**H1 — does `check:published-readme-symbols` have anything to say about an outbound link? No. The expectation holds, and the gate's real name is `check:published-readme-exports`.** There is no script or package.json entry named `...-symbols`; PR #9546 added `scripts/check-published-readme-exports.mjs` (`pnpm check:published-readme-exports`, `lint.yml:1723`). It is explicitly "deliberately NOT a docs linter": it reads **fenced code blocks only** (typescript / ts / tsx / diff / untagged) and makes one claim per import line plus one per `Name.member(` call site, against the built `.d.ts`. Its only `](` occurrences are in its own header prose and self-test fixtures. Measured on this diff: all four changed lines (343, 395-397) sit **outside every fenced block** in the file — the six fences are at 24-26, 33-37, 43-49, 164-166, 296-300, 360-387. Also worth knowing for future cards: `scripts/published-readme-exports.baseline.json` names `@objectstack/plugin-audit` as the gate's deliberate **negative control** ("the PR that added this gate reports it clean"), so this file must stay clean rather than merely unbaselined.

**H2 — is there any gate that would catch a published README linking to a page or anchor that does not exist? No, and the gap is real.** Measured across every candidate: the lychee lane (`check-links.yml`) runs over exactly `content/**/*.md`, `content/**/*.mdx`, `README.md`, `ARCHITECTURE.md` — `packages/**/README.md` is not in scope; `check:doc-anchors` takes its sources from `content/**` plus `EXTRA_SOURCES = ['README.md', 'ARCHITECTURE.md']`, the root README only; `check:adr-links` is scoped to `docs/adr/`; `check:docs-redirects` to `apps/docs/redirects.mjs`; and `check:published-readme-exports` per H1. A published README can link anywhere, in any spelling, and ship to npm green. Filed as #9632 with a contained three-assertion proposal and sizing — the load-bearing one needs no filesystem lookup and cannot false-positive, and the other two reuse the resolvers `check-docs-redirects` and `check-doc-anchors` already have rather than growing a third.

**H3 — the card's shorthand was the wrong form, and the repo is inconsistent.** Four spellings coexist in published READMEs: the absolute `https://docs.objectstack.ai/docs/...` (`create-objectstack/README.md:90` and the blank template at 39, 70, 108 — the only form that works on all three surfaces, and the one adopted here); `/content/docs/...` (7 links, 5 packages — dead everywhere, filed as #9632); `/docs/...` (1 link, this file, converted above); and `../../../content/docs/...` (2 links, `service-knowledge` and `knowledge-ragflow` — these resolve on GitHub and npm but land the reader on raw MDX source rather than the rendered page). So the card's `/docs/kernel/runtime-services/audit-service` was the second-rarest form in the tree and unfollowable off the docs site.

**H4 — no other published README records this deliberate omission.** Swept all package READMEs for omission markers (`deliberately`, `intentionally`, `dropped`, `omitted`, `restore`, `once #`, `Blocked-by`) and read every `## See Also` section in the tree. The hits are all unrelated (`service-realtime`'s unimplemented `handleUpgrade`, `service-automation`'s deliberate non-duplication of the per-node reference, the spec liveness ledger's vocabulary). `plugin-audit` is the only README whose docs link was dropped for a wrong target page. The adjacent case — `runtime-services/index.mdx` pointing "Audit bridge" at the settings sink — is already open as #9588 and is a docs-site page, not a README, so it is not a duplicate of anything filed here.

## Verification

Local gate union, run **after** the final commit, at `a15cc19df`:

```
check:nul-bytes                              OK (6176 text files; no raw ASCII control bytes)
check:published-readme-exports --self-test   OK (both analysis directions pinned)
check-adr-0087-registration                  OK (1 non-breaking changeset seen)
check-empty-changeset                        OK (1 declaring changeset added)
check-changeset-no-major                     OK
check:test-source-alias                      OK (72 packages scanned)
check:type-source-resolution                 OK (76 packages scanned)
check-affected-docs                          OK (242 self-test cases)
```

Gate set derived from the actual changed paths with `node scripts/pm/dispatch-gates.mjs packages/plugins/plugin-audit/README.md .changeset/plugin-audit-readme-audit-service-link.md`, which added the four changeset families over the README-only derivation.

Two gates are reasoned rather than run, both build-dependent, both with the measurement behind the claim:

- **`check:published-readme-exports`** (full run) hard-errors without a built `dist/` for every workspace package any published README imports, i.e. a whole-workspace build; it runs in the CI job that has already built. Its `--self-test` passes, and the fence-range measurement in H1 shows this diff is outside its reading surface entirely.
- **`check:i18n`** is convention-triggered here because `plugin-audit` owns `scripts/i18n-extract.config.ts`, and it needs `@objectstack/cli` built. That config's input set is three object modules — `sys-audit-log.object.js`, `sys-activity.object.js`, `sys-comment.object.js` — plus the generated bundles. A markdown prose edit changes none of them.

No test pins this README's content: `grep -rn "README" --include="*.test.ts"` across `packages/` returns no plugin-audit hit, and the one structural reference (`packages/spec/src/kernel/plugin-structure.test.ts`) uses the literal string `'README.md'` as a schema fixture.

## Not addressed here

#9632 (the seven links in five other packages, and the missing gate) remains open, and #9588 remains open — neither is in this PR's scope.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_