### PR TITLE
fix(pm): dispatch-gates names check:doc-anchors for a content card — the genericity refusal read the glob-collapsed hint

### DIFF
--- a/scripts/check-doc-anchors.mjs
+++ b/scripts/check-doc-anchors.mjs
@@ -124,9 +124,39 @@ import Slugger from 'github-slugger';
 
 import { stripCodeSpans, stripFencedBlocks } from './check-adr-links.mjs';
 
+/**
+ * The page population this gate sweeps, as the repo-relative glob it really
+ * reads — every `.md`/`.mdx` under the Fumadocs content root, `content/blog`
+ * and `content/docs` alike.
+ *
+ * ## Why the glob is the constant and the root is derived from it (#9626)
+ *
+ * `scripts/pm/dispatch-gates.mjs` builds every dispatch's gate list by scanning
+ * each gate's own source for the path literals it operates on, and a literal
+ * with no path separator is a WORD, not a path — it is refused as too generic,
+ * because `packages` and `apps` are path components dozens of gates join with
+ * something else. Spelled `'content'`, this gate's population therefore
+ * contributed no hint at all: `check:doc-anchors` scored `silent` for every
+ * card under `content/**`, while being REQUIRED in lint.yml and the only
+ * fragment coverage this repo has (`check-links.yml` sets
+ * `include_fragments = "none"` and says so in its own header — a link to a
+ * heading that does not exist is reported `[200] OK` there).
+ *
+ * Declaring the SUBTREE is what makes the declaration readable. The root is one
+ * substring of it rather than a second constant, so the two cannot drift apart
+ * — the failure that would otherwise replace a silent gate with a lying one.
+ *
+ * What this does NOT reach: `EXTRA_SOURCES` below. A top-level FILE name
+ * carries no separator either, and teaching the scanner to accept one would
+ * admit every `package.json` basename in the tree. A card editing only
+ * `README.md` or `ARCHITECTURE.md` still has to reach this gate by judgment;
+ * that residue is recorded in `hintCovers`' docblock as a decided loss.
+ */
+const CONTENT_GLOB = 'content/**';
+
 /** The Fumadocs content root — what `/` means in a site route, and what the
  *  lychee lane passes as `--root-dir`. */
-const CONTENT_ROOT = 'content';
+const CONTENT_ROOT = CONTENT_GLOB.slice(0, CONTENT_GLOB.indexOf('/'));
 
 /** Link sources outside `content/`, matching the lychee globs. */
 const EXTRA_SOURCES = ['README.md', 'ARCHITECTURE.md'];

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -2291,7 +2291,11 @@ function selfTest() {
   // the shape. If one of these gates stops declaring its root, re-point the
   // case at whatever gate then does; deleting one deletes the evidence.
   const crossPkgHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/check-cross-package-test-inputs.mjs'), 'utf8'));
-  t('the cross-package gate reaches the root scripts dir it declares', crossPkgHints.some((h) => hintCovers(h, 'scripts/check-nul-bytes.mjs')));
+  // NOT `scripts/check-nul-bytes.mjs`: that gate names that file explicitly
+  // too, so the case would pass with the declaration still refused — measured,
+  // it survived the ablation. Pick a scripts path reachable ONLY through the
+  // declared subtree, or the case pins nothing.
+  t('the cross-package gate reaches the root scripts dir it declares', crossPkgHints.some((h) => hintCovers(h, 'scripts/pm/dispatch-gates.mjs')));
   t('and the content tree it declares', crossPkgHints.some((h) => hintCovers(h, 'content/docs/getting-started/index.mdx')));
   const governedHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/pm/check-governed-merges.mjs'), 'utf8'));
   t('the governed-merge gate reaches the published skills catalog it declares', governedHints.some((h) => hintCovers(h, 'skills/objectstack-upgrade/SKILL.md')));

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -668,11 +668,59 @@ export function runnableInvocation({ check, filter, direct }) {
 
 /**
  * Does a watch hint cover an input path? Containment either way, compared on
- * PATH SEGMENT boundaries, with globs collapsed. A hint that collapses to a
- * bare top-level directory name (`packages`, `scripts` — no slash, not a dotted
- * dir) is rejected as too generic: it would match every file under the tree's
- * biggest directories and drown the signal the matched-via column exists to
- * carry.
+ * PATH SEGMENT boundaries, with globs collapsed. A hint that names a bare
+ * top-level directory (`packages`, `scripts` — a WORD, with no separator
+ * anywhere in it, and not a dotted dir) is rejected as too generic: it would
+ * match every file under the tree's biggest directories and drown the signal
+ * the matched-via column exists to carry.
+ *
+ * ## Why the refusal reads the hint AS WRITTEN, not the collapsed copy (#9626)
+ *
+ * That refusal used to be applied to `plain` — the hint AFTER globs were
+ * collapsed and trailing separators stripped. Collapsing is lossy in exactly
+ * the way the refusal is deciding on: `content/**` and `skills/**` collapse to
+ * `content` and `skills`, so a gate that declared a whole SUBTREE as its
+ * population was refused as though it had written a bare word. The two are not
+ * the same claim. A bare `packages` is a path component a script joins with
+ * something else; `packages/**` is an author stating what the gate reads, in
+ * the syntax the repo uses for exactly that everywhere else (`paths:` filters,
+ * turbo inputs, the `files` field).
+ *
+ * The blind spot was total for the class and it hid REQUIRED coverage. Measured
+ * on this tree, three live hints collapse to a bare root, and all three are
+ * genuine population declarations that reached nothing at all:
+ *
+ *   `scripts/**`, `content/**`  check-cross-package-test-inputs' declaration
+ *                               table, whose own header calls its entries "the
+ *                               repo-relative globs they really read"
+ *   `skills/**`                 check-governed-merges' GOVERNED_SURFACES row
+ *                               for the published skills catalog
+ *
+ * `check:doc-anchors` was the specimen that surfaced it: it spelled its root
+ * `'content'`, contributed no hint at all, and so scored `silent` for every
+ * card under `content/**` — while being the ONLY fragment coverage this repo
+ * has (`check-links.yml` sets `include_fragments = "none"`, and says so).
+ *
+ * Reading the hint as written closes the class without widening the scan.
+ * Measured over 107 discovered families against all 6181 tracked files:
+ *
+ *   watch-hint (gate, file) pairs   19024 -> 19834   (+810, and ZERO lost)
+ *   families gaining coverage       3, via those three hints and nothing else
+ *
+ * The alternative — teaching `extractWatchHints` to accept a bare single-segment
+ * literal that happens to name a real top-level directory — was measured on the
+ * same corpus and REFUSED: it takes those pairs to 158108 (+139084), because
+ * `packages`, `apps`, `examples` and `package.json` are path COMPONENTS in
+ * dozens of gates that never read the root. One card
+ * (`packages/spec/src/index.ts`) goes from 7 matched families to 34. That is
+ * the "22 leads is the same as none" failure in the header, bought wholesale.
+ *
+ * What stays out of reach, deliberately: a population that is a top-level FILE
+ * (`README.md`, `ARCHITECTURE.md` — the rest of `check-doc-anchors`' corpus).
+ * A bare filename carries no separator either, and accepting one would admit
+ * every `package.json` / `turbo.json` / `tsconfig.json` basename a gate joins
+ * with a package directory — the same explosion, one class over. A miss there
+ * costs one card one CI round; that is the side this file errs on.
  *
  * ## Why a segment boundary and not a raw string prefix (#8534)
  *
@@ -730,7 +778,9 @@ export function runnableInvocation({ check, filter, direct }) {
 export function hintCovers(hint, inputPath) {
   const plain = hint.replace(/\*\*?/g, '').replace(/\/+$/, '').replace(/\/$/, '');
   if (plain.length < 2) return false;
-  if (!plain.includes('/') && !plain.startsWith('.')) return false;
+  // `hint`, not `plain`: glob collapse destroys the separator this refusal is
+  // deciding on, and a declared subtree is not a bare word. See the docblock.
+  if (!hint.includes('/') && !plain.startsWith('.')) return false;
   return (
     inputPath === plain ||
     inputPath.startsWith(`${plain}/`) ||
@@ -1246,10 +1296,17 @@ export function reachesMetadataFormModule(path, modulePaths) {
  *   like any other literal — comment masking cannot reach it. The ratchet
  *   entry's remedy command therefore spells its `--filter` values unquoted (and
  *   says to quote them for the shell): measured, the shell-quoted spelling adds
- *   both of its glob filter values to THIS file's own hint set as hints, inert
- *   only because `hintCovers` rejects one that collapses to a bare top-level
- *   directory. A gate list that fabricates hints out of its own explanations is
- *   the failure this whole script is written against.
+ *   both of its glob filter values (the two `./packages` globs, one flat and
+ *   one nested) to THIS file's own hint set as hints. That spelling is now
+ *   LOAD-BEARING rather than
+ *   merely tidy: it used to be inert as well, because `hintCovers` refused a
+ *   hint that COLLAPSED to a bare top-level directory, and since #9626 that
+ *   refusal reads the hint as written — `packages/*` carries a separator, so
+ *   quoting it here would make this file's own prose match every card under
+ *   `packages/`. Leave the filter values unquoted. A gate list that fabricates
+ *   hints out of its own explanations is the failure this whole script is
+ *   written against, and this is the one place in the tree where the trade is
+ *   live rather than hypothetical.
  * - Every `name` here is checked against the LIVE workflows by the self-test,
  *   not only by the run that happens to print it. The STALE branch reports rot
  *   to whoever is looking at the output; the self-test case makes the same rot
@@ -1430,8 +1487,10 @@ export function residueLines({ discovered, matched, undetermined, silent, unfilt
     `Residue — all ${discovered} discovered famil(ies) placed, derived at runtime:`,
     `  ${matched} matched above · ${undetermined} undetermined (their sources name no path at all — NOT known irrelevant)` +
       ` · ${silent} silent (their sources name paths, none of which cover yours).`,
-    '  A `silent` verdict is this derivation\'s weakest claim, not a clearance: a gate that computes its own population and' +
-      ' names only its baseline artifact scores silent for every card in the tree.',
+    '  A `silent` verdict is this derivation\'s weakest claim, not a clearance, and there are two ways to earn it that have' +
+      ' nothing to do with your paths: a gate that computes its own population and names only its baseline artifact scores' +
+      ' silent for every card in the tree, and so does one whose population is a top-level FILE (`README.md`) — a literal' +
+      ' with no path separator is refused as too generic, so the gate reads your file while naming nothing that can match it.',
     `  ${unfiltered} of the ${discovered} sit only in workflows that declare no pull_request path filter — CI schedules those on` +
       ' EVERY pull request, so no path derivation can narrow them and their verdict above is about relevance, never schedule.',
     `  Convention-triggered gates cut ACROSS all three and are printed above when a kind hits (${kinds.map((k) => k.kind).join('; ')}).`,
@@ -2208,6 +2267,40 @@ function selfTest() {
   t('a collapsed partial-segment glob does NOT reach the sibling it would match as a glob', !hintCovers('packages/client*', 'packages/client-react/src/index.ts'));
   t('the same glob still covers the package it names', hintCovers('packages/client*', 'packages/client/src/index.ts'));
   t('a segment-boundary glob is untouched by the trade', hintCovers('packages/client/**', 'packages/client/src/index.ts'));
+
+  // ── A declared SUBTREE is not a bare word (#9626) ─────────────────────────
+  //
+  // The genericity refusal reads the hint as the author wrote it. Both
+  // directions, because the whole value of the rule is the pair: the word is
+  // still refused, the declaration is now honoured. Collapsing `content/**`
+  // yields the same `content` the bare word yields, which is precisely why the
+  // refusal cannot be decided on the collapsed copy.
+  t('a single-segment root declared as a subtree covers the tree it names', hintCovers('content/**', 'content/docs/any-page.mdx'));
+  t('the same declaration covers the OTHER subtree under that root', hintCovers('content/**', 'content/blog/a-post.mdx'));
+  t('a bare top-level directory WORD is still refused as too generic', !hintCovers('packages', 'packages/spec/src/index.ts'));
+  t('a bare root that lost its separator to the trailing trim is still refused', !hintCovers(extractWatchHints("const D = 'examples/';")[0] ?? 'examples', 'examples/app-showcase/src/x.ts'));
+  t('a declared subtree does not reach a sibling root', !hintCovers('content/**', 'contentious/x.md'));
+  // A top-level FILE stays out of reach on purpose: accepting a bare filename
+  // would admit every `package.json` basename a gate joins with a package dir.
+  // Pinned so the loss reads as a decision, not an oversight — it is the rest
+  // of check-doc-anchors' corpus (README.md, ARCHITECTURE.md).
+  t('a bare top-level FILE name is refused, the decided loss', !hintCovers('README.md', 'README.md'));
+
+  // The three live declarations the refusal used to swallow, read from the real
+  // gates rather than fixtures — a fixture cannot show that the tree still has
+  // the shape. If one of these gates stops declaring its root, re-point the
+  // case at whatever gate then does; deleting one deletes the evidence.
+  const crossPkgHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/check-cross-package-test-inputs.mjs'), 'utf8'));
+  t('the cross-package gate reaches the root scripts dir it declares', crossPkgHints.some((h) => hintCovers(h, 'scripts/check-nul-bytes.mjs')));
+  t('and the content tree it declares', crossPkgHints.some((h) => hintCovers(h, 'content/docs/getting-started/index.mdx')));
+  const governedHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/pm/check-governed-merges.mjs'), 'utf8'));
+  t('the governed-merge gate reaches the published skills catalog it declares', governedHints.some((h) => hintCovers(h, 'skills/objectstack-upgrade/SKILL.md')));
+
+  // The card this landed for: the ONLY fragment coverage in the repo, which
+  // scored `silent` for every content card while being REQUIRED in lint.yml.
+  const anchorHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/check-doc-anchors.mjs'), 'utf8'));
+  t('the doc-anchors gate reaches the content page population it declares', anchorHints.some((h) => hintCovers(h, 'content/docs/deployment/cli.mdx')));
+  t('and does not thereby claim a path outside that population', !anchorHints.some((h) => hintCovers(h, 'packages/spec/src/index.ts')));
 
   // ── A trailing sentence period is not part of the path (#8534, half two) ──
   //


### PR DESCRIPTION
Fixes #9626

`node scripts/pm/dispatch-gates.mjs content/docs/any-page.mdx` now lists
`pnpm check:doc-anchors`, matched via `gate source 'content/**'`.

## The root cause is one level deeper than the card states

The card locates the defect at the extraction site (`looksPathy` requires a
`/`). That is real but it is only half, and fixing only that half would have
changed nothing: **`hintCovers` independently refuses a single-segment hint**,
and it does so *after* collapsing globs.

```js
const plain = hint.replace(/\*\*?/g, '').replace(/\/+$/, '');
if (!plain.includes('/') && !plain.startsWith('.')) return false;   // reads the COLLAPSED copy
```

Glob collapse destroys the very separator that refusal is deciding on, so
`content/**` and `skills/**` arrive at the test spelled `content` and `skills`
and are rejected as though the author had written a bare word. Those are not
the same claim: a bare `packages` is a path component a script joins with
something else; `packages/**` is an author stating what the gate reads, in the
syntax this repo uses for exactly that everywhere else.

Two consequences the card did not predict:

* **Shape 2 verbatim does not work.** Spelling the root `'content/'` gets it
  past `looksPathy`, but `extractWatchHints` trims a trailing run of dots and
  slashes, so the hint arrives as `content` and `hintCovers` refuses it. The
  live proof was already in the tree before this PR: `check:examples-live-imports`
  spells `'examples/'`, its hint survives extraction as `examples`, and the gate
  scored `silent` for every `examples/**` card — including its own population.
* **The blind spot was already hiding declared coverage**, not just this gate's.

## H1 — the enumeration that decided the shape

Every gate family whose source names a single-segment top-level path, measured
across 107 discovered families and all 6181 tracked files.

**Raw count: 57 of 107 families** name such a literal. But that number is the
wrong instrument, because almost all of them are *path components*, not
declarations — `packages`, `apps`, `examples`, `package.json`, `turbo.json`
spelled as a join argument. Split by how the author wrote it:

| class | example | families | verdict |
|---|---|---|---|
| bare word, no separator | `'packages'`, `'apps'`, `'README.md'` | 54 | incidental — must stay refused |
| declared subtree glob | `'content/**'`, `'skills/**'`, `'scripts/**'` | 3 | genuine declaration — was refused, now honoured |
| bare trailing-slash prefix | `'examples/'`, `'scripts/'` | 2 | 50/50 (see below) — stays refused |

The three declarations the refusal was swallowing, all of them real:

* `scripts/**` and `content/**` in `check-cross-package-test-inputs`, whose own
  header calls its table entries "the repo-relative globs they really read";
* `skills/**` in `check-governed-merges`' `GOVERNED_SURFACES` row for the
  published skills catalog.

So the answer to "is it one gate, or six?" is: **one gate for the reported
symptom, three more families already silently miscounted for the same reason,
and 54 that must stay silent.**

### Why shape 1 was rejected on measurement

Shape 1 (accept a bare single-segment literal when a directory of that name
exists at the repo root) was implemented and measured on the same corpus:

| | (gate, file) matched pairs | one `packages/spec/src/index.ts` card |
|---|---|---|
| today | 19024 | 7 families |
| **shape 1** | **158108  (+139084)** | **34 families** |
| this PR | 19834  (+810, none lost) | 7 families |

Shape 1 is the "22 leads is the same as none" failure in the tool's own header,
bought wholesale — `packages` and `apps` are join arguments in dozens of gates
that never read the root. The card's fallback is therefore falsified, and I did
not take it.

### Why not the bare trailing-slash class either

Accepting `'examples/'`-shaped literals was also measured: +1227 pairs across 5
families, of which `check:published-files`' `rel.startsWith('scripts/')` is
**package-relative** — it would claim every repo-root `scripts/**` card, on the
surface where gate tooling itself lives. 1 true, 1 false is not high-signal
enough for the MATCHED column, so that class stays refused.

## The change

Two halves, each load-bearing (both ablated below):

1. **`scripts/pm/dispatch-gates.mjs`** — the genericity refusal reads the hint
   **as written** instead of the collapsed copy. One operand. The extractor is
   untouched, so no new heuristic is taught and the "widening the hint scan is
   where false leads come from" warning is respected.
2. **`scripts/check-doc-anchors.mjs`** — the gate declares the subtree it reads
   (`CONTENT_GLOB = 'content/**'`) and derives the join root from it, so the two
   cannot drift apart. This is shape 2's spirit — the declaration lives in the
   file that owns the fact — spelled so that it actually works.

## Reverse-verification, both directions

**Direction 1 — the gate is named.** Run through the real CLI against a
pristine worktree at the identical base commit (`f01c0ee2d`), 22 card surfaces:

```
content/docs/deployment/cli.mdx     base= 9 fix=10  GAINED pnpm check:doc-anchors
content/docs/any-page.mdx           base= 7 fix=10  GAINED check:doc-anchors, check:cross-package-test-inputs (x2 forms)
content/blog/some-post.mdx          base= 0 fix= 3
skills/objectstack-upgrade/SKILL.md base= 1 fix= 2  GAINED pnpm check:pm-governed-merges
```

`content/docs/deployment/cli.mdx` is the card's own ground truth — the PR #9624
surface where a dev reverse-verified that breaking a fragment turns the gate
red, and where the derived list was silent.

**Direction 2 — no card outside the link-source globs gains a false lead.**
Same battery: **13 leads gained, 0 lost**, and every gain lands on `content/**`,
`scripts/**` or `skills/**` — the three declared roots. Zero gains on:

```
packages/spec/src/data/filter.zod.ts   packages/objectql/src/engine.ts
packages/rest/src/server.ts            apps/web/src/app.tsx
examples/app-showcase/.../contact.view.ts   docs/adr/0112-error-envelope.md
.changeset/some-change.md              .github/workflows/lint.yml
.claude/skills/pm-dispatch/SKILL.md    docker/README.md
package.json   turbo.json   pnpm-workspace.yaml   README.md   ARCHITECTURE.md
```

**Ablations** (fix committed first, then reverted, then restored byte-identical):

* revert the `hintCovers` operand: **6 of 284 cases fail**, all six the new
  positive cases; every negative case still passes.
* revert the gate's declaration to the bare word: **1 of 284 fails**, and the
  CLI's doc-anchors MATCHED lines for the acceptance path drop to **0**.

## Fixtures added (H3)

The tool has a self-test and CI runs it unconditionally via
`check:pm-dispatch-gates` in lint.yml, so the fixture treatment was available.
11 cases added, pinned in both directions — the declared subtree covers its
tree and the other subtree under the same root; the bare word, the
separator-trimmed root, the sibling root and the bare top-level FILE are all
still refused; plus three cases reading the **real** gate sources so the tree
having this shape is asserted, not assumed.

One fixture had to be sharpened after the ablation caught it: the
cross-package case originally probed `scripts/check-nul-bytes.mjs`, which that
gate also names explicitly, so it passed with the fix reverted. A fixture that
survives its own ablation pins nothing. Re-pointed at a path only the
declaration reaches.

## H2 — re-verified, the card's claim holds

`lychee.toml` line 53 is `include_fragments = "none"`, and `check-links.yml`
states it in its own header: a link to a heading that does not exist is
reported `[200] OK` there, and "The fragment half is owned by
`pnpm check:doc-anchors` in `lint.yml`, which is REQUIRED where this lane is
advisory." No other job covers fragments. `check-links.yml` also declares no
`paths:` filter, so the CI-trigger authority could not have rescued the gate
either. The card understates nothing.

## H4 — the silent bucket really did read as a clearance

`--residue` prints one caveat for the whole bucket, and its only worked example
is the compute-your-own-population case, which invites the reader to generalise
to "this gate cannot be placed by paths." `check-doc-anchors` was not in that
category — it named its root, the comparison could not read it. The message now
names **both** ways to score silent, including the one that survives this PR (a
population that is a top-level FILE).

## Known residue, stated rather than hidden

* `README.md` / `ARCHITECTURE.md` — the rest of `check-doc-anchors`' corpus —
  remain unreachable. A bare filename carries no separator either, and
  accepting one would admit every `package.json` basename a gate joins with a
  package directory. Recorded as a decided loss in `hintCovers`' docblock and
  pinned by a negative fixture.
* `content/docs.site.json` now derives `check:doc-anchors`. The gate sweeps only
  `.md`/`.mdx`, so this is a mild over-reach *inside* the declared subtree —
  the same semantics every other directory hint in the tool already has.
* The `--filter` values in this file's own ratchet prose must stay **unquoted**.
  That was already the convention; it is now load-bearing rather than merely
  tidy, because a quoted `packages/*` would carry a separator. Documented at
  the site.

## Gates

Derived for the actual diff with the tool itself
(`node scripts/pm/dispatch-gates.mjs --changed`), all green at `11aed652e`:

```
pnpm check:pm-dispatch-gates          284 cases pass
pnpm check:doc-anchors                247 fragment links across 397 sources resolve
pnpm check:cross-package-test-inputs  33 self-test cases; 12 packages declared
pnpm check:nul-bytes                  6176 text files, no raw control bytes
```

`check:cross-package-test-inputs` appears in that union only *because of* this
change — the tool now derives its own gate from the `scripts/**` declaration it
previously threw away.

No changeset: this PR edits two CI-internal scripts and releases nothing, which
lint.yml calls the textbook `skip-changeset` case. Label applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_