### PR TITLE
fix(ci): a refused cross-repo close fails the job instead of passing as a warning

### DIFF
--- a/.github/workflows/cross-repo-issue-closer.yml
+++ b/.github/workflows/cross-repo-issue-closer.yml
@@ -29,9 +29,21 @@
 # attempted, and a refusal that outlives the retries writes the notice into the
 # run's job summary and then FAILS the job.
 #
-# Failing is deliberate, and it is the opposite of what docs-drift-check.yml
-# (#9373) chose for its advisory comment. The difference is a property of this
-# job, measured rather than inherited:
+# The OTHER exit — the per-target close loop, the branch that runs when the
+# token IS present — reached the same rule one card later (#9595). Its `catch`
+# is unchanged and must stay so: it buys ISOLATION, and one unreachable target
+# taking the rest down with it would be a worse failure than the one being
+# fixed. What it did NOT buy is a verdict. `core.warning` leaves the job green,
+# so a refused close left the foreign issue open, put nothing on the PR, and
+# produced a conclusion identical to the ~2270 runs where there was nothing to
+# do at all — while the catch's own comment said "a failure here must not read
+# as success". Isolation and outcome are now separate: the loop records the
+# keys it could not close, runs to the end, and the verdict is passed after it.
+#
+# Failing is deliberate on BOTH exits, and it is the opposite of what
+# docs-drift-check.yml (#9373) chose for its advisory comment. The difference is
+# a property of this job, measured rather than inherited — and re-measured for
+# the loop on 2026-08-18 rather than carried over from the notice (#9595):
 #
 #   - its conclusion is in no required set — the context name `Close issues
 #     referenced in other repositories` is absent from the registry in
@@ -44,10 +56,21 @@
 #   - no `workflow_run:` listener in this repo watches it (the only two listen
 #     for `CI` and `Release`), so a red starts no fan-out.
 #
+# The first of those three was re-derived on 2026-08-18 against the LIVE ruleset
+# rather than against the repo-side pin alone: `GET /repos/.../rulesets/12119582`
+# lists six required contexts (`Lint & Repo Gates`, `TypeScript Type Check`,
+# `Test Core`, `Dogfood Regression Gate`, `Build Core`, `Temporal Conformance
+# (live PG + MySQL)`) and this job's name is not among them.
+#
 # A red therefore costs one X on an already-merged PR. A green that delivered
 # nothing costs the foreign issues this workflow exists to stop losing — and
 # looks exactly like the 2000+ green runs where there was simply nothing to
-# report. Same trade merge-queue-triage.yml (#9424) made, for the same reason;
+# report. That a red here is READ, meanwhile, is not an assumption either: this
+# job's only two script-level failures (2026-08-02, a `SyntaxError` that stopped
+# it running at all) were diagnosed and fixed 39 minutes after the first one,
+# and the second of them landed on an unrelated author's merge.
+#
+# Same trade merge-queue-triage.yml (#9424) made, for the same reason;
 # docs-drift-check.yml's opposite choice is right THERE because its conclusion
 # is a check on a live PR and its comment is a courtesy, neither of which is
 # true here.
@@ -120,6 +143,20 @@ jobs:
             const body = context.payload.pull_request.body || '';
             const prUrl = context.payload.pull_request.html_url;
             const thisRepo = `${context.repo.owner}/${context.repo.repo}`;
+
+            // ONE vocabulary for a refusal, used by both exits below: `HTTP 503`
+            // or `ECONNRESET` is what lets a reader separate platform weather
+            // from a 403/404 that means the credential is wrong. Hoisted rather
+            // than copied per call site — merge-queue-triage.yml declares the
+            // identical helper once, and a second hand-written copy here is the
+            // shape #9576 records as the thing to stop doing.
+            const describe = (error) => {
+              const kind = typeof error?.status === 'number'
+                ? `HTTP ${error.status}`
+                : (error?.code || 'error');
+              // Octokit messages usually end in a full stop; ours supplies its own.
+              return `${kind}: ${String(error?.message || '').replace(/\s*\.\s*$/, '')}`;
+            };
 
             // GitHub's own keyword set, restricted to the qualified
             // `owner/repo#N` form — the bare `#N` form already works natively
@@ -197,11 +234,7 @@ jobs:
                   `Reported ${targets.size} unclosed cross-repo issue(s) on this pull request.`,
                 );
               } catch (error) {
-                const kind = typeof error?.status === 'number'
-                  ? `HTTP ${error.status}`
-                  : (error?.code || 'error');
-                // Octokit messages usually end in a full stop; ours supplies its own.
-                const reason = `${kind}: ${String(error?.message || '').replace(/\s*\.\s*$/, '')}`;
+                const reason = describe(error);
                 try {
                   await core.summary.addRaw([
                     '## ⚠️ 跨仓库关闭提示没能发到 PR 上',
@@ -234,6 +267,17 @@ jobs:
               return;
             }
 
+            // ISOLATION and OUTCOME are separable, and the loop owns only the
+            // first (#9595). The `catch` below must keep swallowing — one
+            // unreachable target must not take the rest down — so the verdict
+            // is passed AFTER the loop, over the keys it collected. Until this
+            // split existed the two were fused into `core.warning` alone: a
+            // refused close left the foreign issue open, put no notice on the
+            // PR, and handed the run the same green conclusion as the ~2270
+            // runs that had nothing to do at all. The catch's own comment
+            // already stated the requirement; only the code was missing.
+            const failures = [];
+
             for (const [key, t] of targets) {
               try {
                 const { data: issue } = await github.rest.issues.get({
@@ -257,7 +301,49 @@ jobs:
                 core.info(`Closed ${key}.`);
               } catch (error) {
                 // One unreachable target must not swallow the rest, and a
-                // failure here must not read as success.
-                core.warning(`Could not close ${key}: ${error.message}`);
+                // failure here must not read as success. This half buys the
+                // first: the loop continues. The failure is RECORDED instead of
+                // dropped, and the second half is passed below.
+                const reason = describe(error);
+                failures.push({ key, reason });
+                core.warning(`Could not close ${key}: ${reason}`, {
+                  title: 'Cross-repo issue left open',
+                });
               }
             }
+
+            if (failures.length === 0) {
+              core.info(`All ${targets.size} cross-repo target(s) closed or already closed.`);
+              return;
+            }
+
+            // A spent failure IS the report. Announce it in both channels the
+            // notice branch uses, for the same reasons: the summary carries the
+            // full list a human needs, `setFailed` carries the conclusion that
+            // makes anyone open the run at all.
+            const failedKeys = failures.map((f) => f.key).join(', ');
+            const failedList = failures.map((f) => `- \`${f.key}\` —— ${f.reason}`).join('\n');
+            try {
+              await core.summary.addRaw([
+                '## ⚠️ 跨仓库 issue 没能自动关闭',
+                '',
+                `本次合并声明了 ${targets.size} 个跨仓库关闭目标，其中 ${failures.length} 个被拒绝，仍是 open：`,
+                '',
+                failedList,
+                '',
+                `- 修复它们的是 ${prUrl} —— 需要手工关闭，并把这条链接留在目标 issue 上。`,
+                '- 原因排除后可以直接 re-run 本 job：已经关闭的目标会被跳过，不会重复评论。',
+                '- 401/404 通常意味着 `CROSS_REPO_ISSUE_TOKEN` 对目标仓库没有 `issues: write`，而不是目标不存在 —— GitHub 对无权访问的仓库回 404。',
+                '',
+              ].join('\n')).write();
+            } catch (summaryError) {
+              // Same asymmetry as the notice branch: the summary is the richer
+              // channel, the conclusion the reliable one. Losing the richer one
+              // must not restore the silence.
+              core.info(`Could not write the job summary: ${summaryError.message}`);
+            }
+            core.setFailed(
+              `${failures.length} of ${targets.size} cross-repo issue(s) could NOT be closed by this merge and `
+              + `are still open: ${failedKeys}. Close them by hand (fixed by ${prUrl}), or re-run this job once `
+              + `the cause is cleared. The full list with reasons is in this run's job summary.`,
+            );

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -785,6 +785,44 @@ jobs:
       - name: Workflow status-function guard
         run: pnpm check:workflow-status-functions
 
+      # Cross-repo closer outcome contract (#9595, and #9575 before it).
+      # `cross-repo-issue-closer.yml` carries ~150 lines of inline
+      # github-script, and it is code nobody has ever seen run: over the 1176
+      # most recently merged PRs, ZERO bodies carry a qualified cross-repo
+      # closing keyword, so the branch that closes foreign issues has had no
+      # target in that whole window. Its defects are therefore found by reading
+      # — one card per silent exit — and each fix lands as more unexercised
+      # code. This step is the exercise: the shipped script is extracted from
+      # the YAML with a real parser (never retyped) and run under doubles the
+      # way actions/github-script runs it, as one AsyncFunction body. Ten
+      # scenarios pin the target parse and the outcome of EVERY exit — which of
+      # setFailed / warning / job summary fires, and which API calls were made.
+      #
+      # Assertion 0 is the compile, and it is not theoretical: this job failed
+      # twice on 2026-08-02 with `SyntaxError: Identifier 'octokit' has already
+      # been declared`, i.e. a script that never ran at all, on a post-merge
+      # workflow whose red nothing else in CI can see.
+      #
+      # Its --self-test runs first and is the half that stops the battery
+      # rotting into decoration: it mutates the shipped script seven ways —
+      # downgrade the verdict to a warning, stop collecting failed keys, break
+      # out of the loop instead of isolating, drop the same-repo skip, narrow
+      # the keyword set, drop the already-closed skip, downgrade the notice
+      # path's verdict — and requires the battery to go RED for each, naming the
+      # scenario that catches it. A mutation whose anchor no longer exists is a
+      # failure too, so a rewrite of the workflow cannot leave the mutations
+      # silently matching nothing.
+      #
+      # Invoked as `node` rather than through a `pnpm check:*` alias: that alias
+      # belongs in root package.json, declared territory of the @changesets/cli
+      # v3 migration lane (#9465) while it runs. Same shape as the
+      # release-rehearsal step above; dispatch-gates.mjs derives gate families
+      # from either spelling. No network, no build; ~0.2 s.
+      - name: Cross-repo closer outcome contract
+        run: |
+          node scripts/check-cross-repo-closer-outcome.mjs --self-test
+          node scripts/check-cross-repo-closer-outcome.mjs
+
       # Shard positive-attestation gate (#6082). ci.yml's two aggregate gates
       # used to decide from one `needs.<matrix>.result` word, which cannot carry
       # three shards' verdicts: run 31120902911 read the undocumented

--- a/scripts/check-cross-repo-closer-outcome.mjs
+++ b/scripts/check-cross-repo-closer-outcome.mjs
@@ -1,0 +1,694 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// check-cross-repo-closer-outcome -- run the SHIPPED cross-repo-issue-closer
+// script under doubles and hold its OUTCOMES to contract.
+//
+//   node scripts/check-cross-repo-closer-outcome.mjs             # judge the shipped script
+//   node scripts/check-cross-repo-closer-outcome.mjs --self-test # prove the battery can go red
+//   node scripts/check-cross-repo-closer-outcome.mjs --list      # the scenario table
+//
+// ## Why this file exists (#9595, and #9575 before it)
+//
+// `.github/workflows/cross-repo-issue-closer.yml` carries ~150 lines of inline
+// `actions/github-script`, and that script is CODE NOBODY HAS EVER SEEN RUN.
+// Measured 2026-08-18 over the 1176 most recently merged pull requests (12
+// pages of the closed-PR listing, the workflow's own regex applied to each
+// body): **zero** carry a qualified cross-repo closing keyword. Twenty-five
+// carry the qualified SAME-repo spelling, which the loop skips. So the branch
+// this repo maintains for the occasion it exists for has, in that window,
+// never once had a target to close.
+//
+// Two consequences, and this file answers both:
+//
+//   1. The defects in it are found by reading, one card at a time -- #9575 for
+//      the notice, #9595 for the loop's verdict -- and each fix lands as more
+//      unexercised code. PR #9594 validated its half by extracting the script
+//      and driving it under stubs, which was the right method and was thrown
+//      away with the session. This makes that harness a repo artifact.
+//   2. Nothing catches a script that does not even COMPILE. It has happened:
+//      on 2026-08-02 the job failed twice with `SyntaxError: Identifier
+//      'octokit' has already been declared`, because github-script compiles the
+//      whole block as one `AsyncFunction` body. Assertion 0 below is that
+//      compile, on the real text.
+//
+// ## The method: the shipped bytes, never a copy
+//
+// The script is read out of the YAML with a real parser (`jobs ->
+// close-foreign-issues -> steps[github-script] -> with.script`) and executed
+// the way the action executes it:
+//
+//     new AsyncFunction('github', 'context', 'core', ..., source)
+//
+// A copy of the script pasted into this file would be a test of the copy. The
+// extraction is therefore load-bearing, and every failure to extract is a
+// FAILURE rather than a skip (#4690): a workflow that has been renamed, a step
+// that no longer uses github-script, an empty `script:` -- all of them exit
+// non-zero here, because a harness that could not find its subject has verified
+// nothing at all.
+//
+// ## What is asserted, and what is deliberately not
+//
+// Asserted: the target parse (which keyword spellings qualify, which forms do
+// not, that a same-repo reference is skipped), and the OUTCOME of every exit --
+// which of `core.setFailed` / `core.warning` / a job summary fires, and which
+// API calls were made. Those are the properties both cards are about.
+//
+// NOT asserted: the step's `retries:` / `retry-exempt-status-codes:` inputs.
+// They are consumed by the ACTION, not by the script, so no stub of `github`
+// can exercise them; their acceptance on the pinned action version is evidenced
+// by the action echoing its own defaults into every run of this job.
+//
+// NOT asserted either: that GitHub's own keyword parser agrees with the regex.
+// That is a property of GitHub, and the only honest evidence for it is the
+// 25 same-repo qualified references measured above, which GitHub did close.
+//
+// ## The self-test, and why it is not optional
+//
+// A battery of assertions over a script that is already correct is green on day
+// one and green forever, including the day someone deletes the thing it
+// guards. `--self-test` mutates the extracted source -- drop the `setFailed`,
+// stop collecting failed keys, `break` out of the loop instead of isolating,
+// disable the same-repo skip, narrow the keyword set, disable the
+// already-closed skip -- and requires the battery to go RED for each, naming
+// the scenario it expects. Each mutation also asserts its own anchor was
+// PRESENT before substituting: a mutation that silently matched nothing would
+// leave the battery green and read exactly like a passing self-test.
+
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isMap, isSeq, parseDocument } from 'yaml';
+
+const WORKFLOW = '.github/workflows/cross-repo-issue-closer.yml';
+const JOB = 'close-foreign-issues';
+const SELF = 'scripts/check-cross-repo-closer-outcome.mjs';
+const THIS_REPO = { owner: 'objectstack-ai', repo: 'objectstack' };
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+function repoRoot() {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+// ── Extraction ──────────────────────────────────────────────────────────────
+
+/**
+ * The inline github-script source, read out of the shipped workflow.
+ *
+ * @param {string} root repository root
+ * @returns {{ source: string|null, problems: string[] }}
+ */
+export function extractScript(root) {
+  const problems = [];
+  const path = join(root, WORKFLOW);
+  if (!existsSync(path)) {
+    problems.push(`${WORKFLOW} does not exist -- nothing was extracted, so nothing was verified.`);
+    return { source: null, problems };
+  }
+  const doc = parseDocument(readFileSync(path, 'utf8'));
+  if (doc.errors.length > 0) {
+    problems.push(`${WORKFLOW}: YAML parse error -- ${doc.errors[0].message}`);
+    return { source: null, problems };
+  }
+  const steps = doc.getIn(['jobs', JOB, 'steps']);
+  if (!isSeq(steps)) {
+    problems.push(`${WORKFLOW}: job \`${JOB}\` has no \`steps:\` sequence -- the subject of this check is gone.`);
+    return { source: null, problems };
+  }
+  const scripted = steps.items.filter((step) => {
+    if (!isMap(step)) return false;
+    const uses = String(step.get('uses') ?? '');
+    return uses.startsWith('actions/github-script@');
+  });
+  if (scripted.length !== 1) {
+    problems.push(
+      `${WORKFLOW}: expected exactly one \`actions/github-script@*\` step in \`${JOB}\`, found ${scripted.length}. ` +
+        'This harness drives one script; a second one would be unverified while this still reported OK.',
+    );
+    return { source: null, problems };
+  }
+  const source = scripted[0].getIn(['with', 'script']);
+  if (typeof source !== 'string' || source.trim() === '') {
+    problems.push(`${WORKFLOW}: the github-script step has no non-empty \`with.script\` -- nothing to run.`);
+    return { source: null, problems };
+  }
+  return { source, problems };
+}
+
+// ── Doubles ─────────────────────────────────────────────────────────────────
+
+/** An octokit-shaped rejection: `status` is what the script's `describe` reads. */
+function httpError(status, message) {
+  return Object.assign(new Error(message), { status });
+}
+
+/**
+ * `github` / `context` / `core` doubles plus a call log.
+ *
+ * `issues` maps `owner/repo#number` to `{ state }` or to a `{ throwOn }`
+ * instruction, so a scenario can refuse one specific target and leave the rest
+ * reachable -- which is the whole point of the isolation the loop must keep.
+ */
+function makeDoubles({ body, token, issues = {}, prCommentError = null, summaryError = null }) {
+  const calls = { get: [], comment: [], update: [], prComment: [] };
+  const log = { info: [], warning: [], failed: [], summary: [] };
+  let summaryBuffer = [];
+
+  const target = (o, r, n) => issues[`${o}/${r}#${n}`] ?? {};
+
+  const github = {
+    rest: {
+      issues: {
+        async get({ owner, repo, issue_number: n }) {
+          calls.get.push(`${owner}/${repo}#${n}`);
+          const t = target(owner, repo, n);
+          if (t.getError) throw t.getError;
+          return { data: { state: t.state ?? 'open' } };
+        },
+        async createComment({ owner, repo, issue_number: n, body: text }) {
+          const key = `${owner}/${repo}#${n}`;
+          const isThisPr = owner === THIS_REPO.owner && repo === THIS_REPO.repo;
+          if (isThisPr && prCommentError) {
+            calls.prComment.push({ key, attempted: true, delivered: false });
+            throw prCommentError;
+          }
+          if (isThisPr) {
+            calls.prComment.push({ key, attempted: true, delivered: true, body: text });
+            return { data: {} };
+          }
+          const t = target(owner, repo, n);
+          if (t.commentError) throw t.commentError;
+          calls.comment.push({ key, body: text });
+          return { data: {} };
+        },
+        async update({ owner, repo, issue_number: n, state, state_reason: reason }) {
+          const key = `${owner}/${repo}#${n}`;
+          const t = target(owner, repo, n);
+          if (t.updateError) throw t.updateError;
+          calls.update.push({ key, state, reason });
+          return { data: {} };
+        },
+      },
+    },
+  };
+
+  const summary = {
+    addRaw(text) {
+      summaryBuffer.push(text);
+      return summary;
+    },
+    async write() {
+      if (summaryError) throw summaryError;
+      log.summary.push(summaryBuffer.join(''));
+      summaryBuffer = [];
+      return summary;
+    },
+  };
+
+  const core = {
+    info: (m) => log.info.push(String(m)),
+    warning: (m, props) => log.warning.push({ message: String(m), props: props ?? null }),
+    setFailed: (m) => log.failed.push(String(m)),
+    summary,
+  };
+
+  const context = {
+    repo: { ...THIS_REPO },
+    payload: {
+      pull_request: {
+        body,
+        html_url: 'https://github.com/objectstack-ai/objectstack/pull/1234',
+        number: 1234,
+      },
+    },
+  };
+
+  return { github, context, core, calls, log, token };
+}
+
+/** Anything github-script hands the script that this harness does not model. */
+function unstubbed(name) {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(
+          `${SELF}: the shipped script now uses \`${name}\`, which this harness does not stub. ` +
+            'Model it here rather than deleting the assertion that found it.',
+        );
+      },
+    },
+  );
+}
+
+/**
+ * Run the script exactly as `actions/github-script` does: as the body of an
+ * AsyncFunction whose scope carries the action's argument set.
+ */
+async function runScript(source, scenario) {
+  const doubles = makeDoubles(scenario);
+  const args = {
+    github: doubles.github,
+    context: doubles.context,
+    core: doubles.core,
+    exec: unstubbed('exec'),
+    glob: unstubbed('glob'),
+    io: unstubbed('io'),
+    fetch: unstubbed('fetch'),
+    require: createRequire(import.meta.url),
+    __original_require__: createRequire(import.meta.url),
+  };
+  const fn = new AsyncFunction(...Object.keys(args), source);
+
+  const before = Object.hasOwn(process.env, 'CROSS_REPO_TOKEN')
+    ? { present: true, value: process.env.CROSS_REPO_TOKEN }
+    : { present: false };
+  if (scenario.token === undefined) delete process.env.CROSS_REPO_TOKEN;
+  else process.env.CROSS_REPO_TOKEN = scenario.token;
+
+  let threw = null;
+  try {
+    await fn(...Object.values(args));
+  } catch (err) {
+    // github-script routes a throw to `main().catch(handleError)` -> setFailed,
+    // so an escape is not automatically wrong -- but it IS a different outcome
+    // from a deliberate verdict, and scenarios say which one they expect.
+    threw = err;
+  } finally {
+    if (before.present) process.env.CROSS_REPO_TOKEN = before.value;
+    else delete process.env.CROSS_REPO_TOKEN;
+  }
+
+  return { ...doubles, threw };
+}
+
+// ── Scenarios ───────────────────────────────────────────────────────────────
+
+const FIXED = httpError(503, 'No server is currently available to service your request.');
+const DENIED = httpError(404, 'Not Found');
+const UNAUTHORIZED = httpError(401, 'Bad credentials');
+
+/** A body carrying the three keyword shapes plus three that must NOT qualify. */
+const MIXED_BODY = [
+  'Fixes objectstack-ai/objectui#456',
+  'CLOSES my-org/some.repo#22',
+  'resolved third/party#7',
+  '',
+  'Part of objectstack-ai/objectui#999 -- a reference, not a close.',
+  'Fixes #321 -- bare form, GitHub already handles it.',
+  'Fixes objectstack-ai/objectstack#5 -- same repo, GitHub already closed it.',
+].join('\n');
+
+const FOREIGN = ['objectstack-ai/objectui#456', 'my-org/some.repo#22', 'third/party#7'];
+
+/**
+ * Each scenario names the exit path it walks and asserts the OUTCOME of it.
+ * `check` returns an array of failure strings.
+ */
+export const SCENARIOS = [
+  {
+    id: 'P0',
+    name: 'no cross-repo keywords -- nothing to do, and nothing said about it',
+    scenario: () => ({ body: 'Fixes #12\n\nRefs objectstack-ai/objectui#9 (not a keyword).', token: 'pat' }),
+    check: (r, t) => [
+      t(r.log.failed.length === 0, `P0 stays green, got setFailed: ${r.log.failed[0]}`),
+      t(r.calls.get.length === 0, `P0 calls no API, got ${r.calls.get.length} get(s)`),
+      t(r.log.info.some((m) => /No cross-repository closing keywords/.test(m)), 'P0 says why it did nothing'),
+    ],
+  },
+  {
+    id: 'P1',
+    name: 'the target parse: which spellings qualify, and which must not',
+    scenario: () => ({ body: MIXED_BODY, token: 'pat' }),
+    check: (r, t) => {
+      const line = r.log.info.find((m) => m.startsWith('Cross-repo targets:')) ?? '';
+      const listed = line.replace('Cross-repo targets: ', '').split(', ').filter(Boolean);
+      return [
+        t(listed.length === 3, `P1 finds exactly the three qualified foreign targets, got ${listed.length}: ${line}`),
+        ...FOREIGN.map((k) => t(listed.includes(k), `P1 recognises ${k}`)),
+        t(!line.includes('#999'), 'P1 does not treat `Part of` as a closing keyword'),
+        t(!line.includes('#321'), 'P1 does not act on the bare `#N` form GitHub already handles'),
+        t(!line.includes('objectstack-ai/objectstack#5'), 'P1 skips the qualified SAME-repo reference'),
+        t(!r.calls.get.includes('objectstack-ai/objectstack#5'), 'P1 never calls the API for the same-repo reference'),
+      ];
+    },
+  },
+  {
+    id: 'N1',
+    name: 'token absent, notice delivered -- green, and the PR carries the work order',
+    scenario: () => ({ body: MIXED_BODY, token: undefined }),
+    check: (r, t) => [
+      t(r.log.failed.length === 0, `N1 stays green, got setFailed: ${r.log.failed[0]}`),
+      t(r.calls.prComment.length === 1 && r.calls.prComment[0].delivered, 'N1 posts the notice on this PR'),
+      t(FOREIGN.every((k) => (r.calls.prComment[0]?.body ?? '').includes(k)), 'N1 notice lists every target'),
+      t(
+        r.log.warning.some((w) => FOREIGN.every((k) => w.message.includes(k))),
+        'N1 announces the work order as an annotation too (#9575)',
+      ),
+      t(r.calls.update.length === 0, 'N1 closes nothing -- it has no credential to close with'),
+    ],
+  },
+  {
+    id: 'N2',
+    name: 'token absent, notice refused -- summary keeps it, job goes red (#9594)',
+    scenario: () => ({ body: MIXED_BODY, token: undefined, prCommentError: FIXED }),
+    check: (r, t) => [
+      t(r.log.failed.length === 1, `N2 fails the job exactly once, got ${r.log.failed.length}`),
+      t(FOREIGN.every((k) => (r.log.failed[0] ?? '').includes(k)), 'N2 setFailed names every unclosed target'),
+      t(/HTTP 503/.test(r.log.failed[0] ?? ''), 'N2 setFailed names the refusal'),
+      t(r.log.summary.length === 1, 'N2 reproduces the whole notice in the job summary'),
+      t(r.threw === null, 'N2 does not let the throw escape the script'),
+    ],
+  },
+  {
+    id: 'N3',
+    name: 'token absent, notice refused AND the summary unwritable -- still red',
+    scenario: () => ({ body: MIXED_BODY, token: undefined, prCommentError: FIXED, summaryError: new Error('EACCES') }),
+    check: (r, t) => [
+      t(r.log.failed.length === 1, 'N3 still fails the job when the richer channel is gone'),
+      t(FOREIGN.every((k) => (r.log.failed[0] ?? '').includes(k)), 'N3 setFailed still names every target'),
+      t(r.threw === null, 'N3 does not let the summary failure escape'),
+    ],
+  },
+  {
+    id: 'L1',
+    name: 'token present, every target closed -- comment then close, and green',
+    scenario: () => ({ body: MIXED_BODY, token: 'pat' }),
+    check: (r, t) => [
+      t(r.log.failed.length === 0, `L1 stays green, got setFailed: ${r.log.failed[0]}`),
+      t(r.calls.get.length === 3, `L1 reads all three targets, got ${r.calls.get.length}`),
+      t(r.calls.comment.length === 3, `L1 leaves the PR link on all three, got ${r.calls.comment.length}`),
+      t(r.calls.update.length === 3, `L1 closes all three, got ${r.calls.update.length}`),
+      t(
+        r.calls.update.every((u) => u.state === 'closed' && u.reason === 'completed'),
+        'L1 closes as `completed`, not as `not_planned`',
+      ),
+      t(
+        r.calls.comment.every((c) => c.body.includes('https://github.com/objectstack-ai/objectstack/pull/1234')),
+        'L1 comment carries the PR link -- the backlink is half the point of the workflow',
+      ),
+      t(r.log.warning.length === 0, 'L1 warns about nothing'),
+    ],
+  },
+  {
+    id: 'L2',
+    name: 'a target that is already closed is skipped, not re-commented (re-run safety)',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'pat',
+      issues: { 'objectstack-ai/objectui#456': { state: 'closed' } },
+    }),
+    check: (r, t) => [
+      t(r.log.failed.length === 0, 'L2 stays green'),
+      t(!r.calls.comment.some((c) => c.key === 'objectstack-ai/objectui#456'), 'L2 does not re-comment on a closed issue'),
+      t(!r.calls.update.some((u) => u.key === 'objectstack-ai/objectui#456'), 'L2 does not re-close a closed issue'),
+      t(r.calls.update.length === 2, `L2 still closes the other two, got ${r.calls.update.length}`),
+    ],
+  },
+  {
+    id: 'L3',
+    name: 'ONE target refused -- the rest still close (isolation) AND the job goes red (#9595)',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'pat',
+      issues: { 'objectstack-ai/objectui#456': { getError: DENIED } },
+    }),
+    check: (r, t) => [
+      t(r.calls.get.length === 3, `L3 still visits every target after the refusal, got ${r.calls.get.length}`),
+      t(r.calls.update.length === 2, `L3 still closes the two reachable targets, got ${r.calls.update.length}`),
+      t(
+        r.log.warning.some((w) => w.message.includes('objectstack-ai/objectui#456') && /HTTP 404/.test(w.message)),
+        'L3 warns naming the target and the refusal',
+      ),
+      t(r.log.failed.length === 1, `L3 FAILS the job -- the defect this card is about; got ${r.log.failed.length}`),
+      t((r.log.failed[0] ?? '').includes('objectstack-ai/objectui#456'), 'L3 setFailed names the target left open'),
+      t(
+        !(r.log.failed[0] ?? '').includes('my-org/some.repo#22'),
+        'L3 setFailed names ONLY what failed -- a verdict that lists the successes teaches nobody',
+      ),
+      t(r.log.summary.length === 1, 'L3 writes the list into the job summary'),
+      t(r.threw === null, 'L3 does not let the refusal escape the script'),
+    ],
+  },
+  {
+    id: 'L4',
+    name: 'every target refused (an expired credential) -- all named, none lost',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'expired-pat',
+      issues: Object.fromEntries(FOREIGN.map((k) => [k, { getError: UNAUTHORIZED }])),
+    }),
+    check: (r, t) => [
+      t(r.calls.get.length === 3, `L4 attempts every target, got ${r.calls.get.length}`),
+      t(r.log.failed.length === 1, 'L4 fails the job once, after the loop -- not once per target'),
+      t(FOREIGN.every((k) => (r.log.failed[0] ?? '').includes(k)), 'L4 setFailed names every target left open'),
+      t(/HTTP 401/.test(r.log.summary[0] ?? ''), 'L4 summary carries the reason, so the credential is the obvious suspect'),
+    ],
+  },
+  {
+    id: 'L5',
+    name: 'a target refused AND the summary unwritable -- still red',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'pat',
+      issues: { 'third/party#7': { updateError: DENIED } },
+      summaryError: new Error('EACCES'),
+    }),
+    check: (r, t) => [
+      t(r.log.failed.length === 1, 'L5 still fails the job when the richer channel is gone'),
+      t((r.log.failed[0] ?? '').includes('third/party#7'), 'L5 setFailed still names the target'),
+      t(r.threw === null, 'L5 does not let the summary failure escape'),
+      t(
+        r.calls.comment.some((c) => c.key === 'third/party#7'),
+        'L5 fixture is honest: the comment landed and only the close was refused',
+      ),
+    ],
+  },
+];
+
+// ── The battery ─────────────────────────────────────────────────────────────
+
+/**
+ * Run every scenario against `source`.
+ *
+ * @returns {Promise<{ failures: {id: string, message: string}[], checked: number }>}
+ */
+export async function judge(source) {
+  const failures = [];
+  let checked = 0;
+
+  try {
+    new AsyncFunction('github', 'context', 'core', source);
+  } catch (err) {
+    // Assertion 0. github-script compiles the whole block as one function body;
+    // this is the 2026-08-02 failure class, and no scenario can run past it.
+    checked++;
+    failures.push({ id: 'C0', message: `the shipped script does not compile as an AsyncFunction body -- ${err.message}` });
+    return { failures, checked };
+  }
+  checked++;
+
+  for (const s of SCENARIOS) {
+    const t = (cond, message) => {
+      checked++;
+      return cond ? null : { id: s.id, message };
+    };
+    let result;
+    try {
+      result = await runScript(source, s.scenario());
+    } catch (err) {
+      failures.push({ id: s.id, message: `the harness itself threw -- ${err.message}` });
+      continue;
+    }
+    for (const f of s.check(result, t)) if (f) failures.push(f);
+  }
+
+  return { failures, checked };
+}
+
+// ── Reporting ───────────────────────────────────────────────────────────────
+
+function reportProblems(problems) {
+  console.error(`check-cross-repo-closer-outcome: ${problems.length} input problem(s) -- the run is NOT a pass\n`);
+  for (const p of problems) console.error(`  • ${p}`);
+  console.error(`
+A harness that could not find its subject has verified nothing, so this exits
+non-zero rather than reporting OK (#4690). Either ${WORKFLOW}
+moved and this file must follow it, or the step it guards is gone -- and if it
+is gone, deleting this check is the honest edit, not letting it pass.`);
+}
+
+async function main() {
+  const root = repoRoot();
+  const { source, problems } = extractScript(root);
+  if (problems.length > 0) {
+    reportProblems(problems);
+    process.exit(1);
+  }
+
+  const { failures, checked } = await judge(source);
+  if (failures.length === 0) {
+    console.log(
+      `check-cross-repo-closer-outcome: OK (${checked} assertions over ${SCENARIOS.length} scenarios, ` +
+        `driving the ${source.length}-char script extracted from ${WORKFLOW}).`,
+    );
+    process.exit(0);
+  }
+
+  console.error(`check-cross-repo-closer-outcome: ${failures.length} failed assertion(s) over the SHIPPED script\n`);
+  for (const f of failures) console.error(`  • [${f.id}] ${f.message}`);
+  console.error(`
+The subject is the inline script in ${WORKFLOW}, run
+under doubles exactly as actions/github-script runs it. Fix the workflow, or --
+if the contract genuinely changed -- change the scenario here and say so in the
+PR body. Scenario table: node ${SELF} --list`);
+  process.exit(1);
+}
+
+function list() {
+  for (const s of SCENARIOS) console.log(`${s.id.padEnd(4)} ${s.name}`);
+  console.log(`\n${SCENARIOS.length} scenarios over ${WORKFLOW}`);
+}
+
+// ── Self-test ────────────────────────────────────────────────────────────────
+//
+// Each mutation states the anchor it needs. A mutation whose anchor is absent
+// is a FAILURE here, not a skip: the substitution would then be a no-op, the
+// battery would stay green, and the self-test would report a detector it never
+// exercised. That is the same #4690 shape the extraction guards against, one
+// level in.
+
+const MUTATIONS = [
+  {
+    id: 'M1',
+    what: 'the post-loop verdict is downgraded back to a warning (the #9595 defect, restored)',
+    from: 'core.setFailed(\n  `${failures.length} of ${targets.size}',
+    to: 'core.warning(\n  `${failures.length} of ${targets.size}',
+    expect: ['L3', 'L4', 'L5'],
+  },
+  {
+    id: 'M2',
+    what: 'the loop stops collecting the keys it could not close',
+    from: 'failures.push({ key, reason });',
+    to: '',
+    expect: ['L3', 'L4', 'L5'],
+  },
+  {
+    id: 'M3',
+    what: 'the loop stops isolating and breaks out on the first refusal',
+    from: 'failures.push({ key, reason });',
+    to: 'failures.push({ key, reason }); break;',
+    expect: ['L3'],
+  },
+  {
+    id: 'M4',
+    what: 'the same-repo reference is no longer skipped',
+    from: "if (`${owner}/${repo}`.toLowerCase() === thisRepo.toLowerCase()) continue;",
+    to: '',
+    expect: ['P1'],
+  },
+  {
+    id: 'M5',
+    what: 'the keyword set is narrowed, so `Fixes` and `resolved` stop qualifying',
+    from: "const KEYWORDS = 'close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved';",
+    to: "const KEYWORDS = 'close';",
+    expect: ['P1'],
+  },
+  {
+    id: 'M6',
+    what: 'the already-closed skip is removed, so a re-run re-comments',
+    from: "if (issue.state === 'closed') {",
+    to: 'if (false) {',
+    expect: ['L2'],
+  },
+  {
+    id: 'M7',
+    what: 'the notice path loses its verdict (the #9594 half, restored to its defect)',
+    from: 'core.setFailed(\n      `${targets.size} cross-repo issue(s) were left open',
+    to: 'core.warning(\n      `${targets.size} cross-repo issue(s) were left open',
+    expect: ['N2', 'N3'],
+  },
+];
+
+async function selfTest() {
+  const root = repoRoot();
+  const { source, problems } = extractScript(root);
+  if (problems.length > 0) {
+    reportProblems(problems);
+    process.exit(1);
+  }
+
+  const failures = [];
+  let checked = 0;
+  const assert = (cond, msg) => {
+    checked++;
+    if (!cond) failures.push(msg);
+  };
+
+  // 1. The unmutated shipped script must be green -- otherwise every red below
+  //    proves nothing about the mutation.
+  const clean = await judge(source);
+  assert(
+    clean.failures.length === 0,
+    `the shipped script is green before any mutation, got: ${clean.failures.map((f) => `[${f.id}] ${f.message}`).join(' | ')}`,
+  );
+
+  // 2. Every mutation must be REACHED and must turn the battery red, in the
+  //    scenarios it names.
+  for (const m of MUTATIONS) {
+    assert(source.includes(m.from), `${m.id}: its anchor is present in the shipped script (a no-op mutation proves nothing)`);
+    if (!source.includes(m.from)) continue;
+    const mutated = source.replace(m.from, m.to);
+    assert(mutated !== source, `${m.id}: the substitution changed the source`);
+    const red = await judge(mutated);
+    assert(red.failures.length > 0, `${m.id}: ${m.what} -- the battery goes RED`);
+    for (const id of m.expect) {
+      assert(
+        red.failures.some((f) => f.id === id),
+        `${m.id}: scenario ${id} is the one that catches it, got [${red.failures.map((f) => f.id).join(', ')}]`,
+      );
+    }
+  }
+
+  // 3. A script that does not compile is caught before any scenario runs -- the
+  //    2026-08-02 failure class, which no outcome assertion could ever see.
+  const broken = await judge(`${source}\nconst github = 1;`);
+  assert(broken.failures.length === 1 && broken.failures[0].id === 'C0', 'a non-compiling script is reported as C0, once');
+
+  // 4. Missing input is a failure, never a pass (#4690).
+  const gone = extractScript(join(root, 'scripts'));
+  assert(gone.source === null && gone.problems.length === 1, 'a missing workflow file is an input problem, not a pass');
+
+  // 5. Wiring. A check nobody runs is the #4449 shape this repo keeps paying
+  //    for, so the step that invokes it is pinned here.
+  const lint = join(root, '.github', 'workflows', 'lint.yml');
+  assert(existsSync(lint), 'wiring: .github/workflows/lint.yml exists -- it is where this check runs');
+  if (existsSync(lint)) {
+    const body = readFileSync(lint, 'utf8');
+    assert(body.includes(SELF), `wiring: lint.yml still invokes ${SELF}`);
+    assert(body.includes(`${SELF} --self-test`), 'wiring: lint.yml runs the --self-test half too');
+  }
+
+  if (failures.length) {
+    console.error(`✗ check-cross-repo-closer-outcome --self-test -- ${failures.length} failure(s)\n`);
+    for (const f of failures) console.error(`  • ${f}`);
+    process.exit(1);
+  }
+  console.log(
+    `✓ check-cross-repo-closer-outcome --self-test: ${checked} assertions, ` +
+      `${MUTATIONS.length} mutations of the shipped script each driven to red.`,
+  );
+}
+
+// The CLI dispatch is guarded so that IMPORTING this module is inert. The
+// reverse-verification route needs `extractScript` / `judge` pointed at another
+// tree (a pre-fix checkout), and a module that runs its gate on import would
+// silently judge THIS repo instead and print a pass about the wrong subject.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  if (process.argv.includes('--self-test')) await selfTest();
+  else if (process.argv.includes('--list')) list();
+  else await main();
+}


### PR DESCRIPTION
Fixes #9595

The per-target loop in `.github/workflows/cross-repo-issue-closer.yml` caught every failure into `core.warning` and ran on. The isolation that buys is correct and is **kept exactly as it is** — one unreachable target must not take the rest down. What was fused to it, and should not have been, is the job's OUTCOME: a refused close left the foreign issue open, put no notice on the PR, and produced a conclusion identical to the ~2270 runs where there was nothing to do at all. The catch's own comment stated the requirement the code did not meet — "a failure here must not read as success".

## What changed

1. **The loop collects the keys it could not close and still runs to the end.** Isolation and outcome are now separate concerns: the `catch` keeps swallowing, and the verdict is passed after the loop over what it recorded.
2. **After the loop, a job summary lists the failed targets with reasons and `core.setFailed` names them** — the shape `merge-queue-triage.yml` has used since #9424, and the same two-channel arrangement PR #9594 gave the notice path (summary is the richer channel, the conclusion the reliable one; an unwritable summary must not restore the silence).
3. **`describe(error)` is hoisted once** instead of a second hand-written copy of the same four lines. Both exits now report `HTTP 404` / `ECONNRESET` in one vocabulary. This is the only edit that touches PR #9594's lines, and it is a deletion of duplication rather than an addition: a second copy of the classifier is precisely the shape #9576 records as the thing to stop doing, and this file's own header cites it. Named here because a hunk in someone else's just-merged code should not be found by reading the diff.
4. **`scripts/check-cross-repo-closer-outcome.mjs`** — new, and wired into `lint.yml`. See "How this is exercised".

The verdict names only what failed. A message that also lists the successes teaches nobody, and scenario `L3` asserts the exclusion.

## The red/green judgement, re-derived rather than inherited

All three facts re-checked against the tree at `0a7e6c32d` and against the ruleset as it stands today. All three still hold.

**1. The conclusion is in no required set.** Not asserted from the repo-side pin alone this time — the live ruleset was read: `GET /repos/objectstack-ai/objectstack/rulesets` returns exactly one active ruleset (`main`, id `12119582`, `updated_at 2026-08-18T03:26:48Z`, repository-sourced, so no organization ruleset is being missed), and its `required_status_checks` rule lists six contexts:

```
TypeScript Type Check
Test Core
Dogfood Regression Gate
Build Core
Temporal Conformance (live PG + MySQL)
Lint & Repo Gates
```

`Close issues referenced in other repositories` is not among them. It is also absent from `REQUIRED_CONTEXTS` in `scripts/check-required-contexts.mjs`, and could not be enrolled there anyway — that pin's assertions 6 and 7 want a `merge_group:` trigger and an unfiltered `pull_request:` trigger, and this file has neither.

> Side effect worth flagging: `check-required-contexts.mjs`'s header says no agent seat can read the ruleset (HTTP 403). That 403 is for the **classic branch-protection** endpoint, which this repo does not use; the rulesets endpoints answer 200. Filed as #9642, with the measurement also posted on #9533 — whose open question ("was the six-item reading partial?") the reading above answers.

**2. It gates nothing already merged.** `on: pull_request_target: types: [closed]`, plus the job-level `if: github.event.pull_request.merged == true`. Confirmed unchanged in the current file; all 2281 recorded runs carry `event: pull_request_target`. The merge-queue rule in the ruleset (`grouping_strategy: ALLGREEN`, `check_response_timeout_minutes: 60`) concerns `merge_group` runs, which this workflow does not have a trigger for, so it publishes no check on a queue branch.

**3. No `workflow_run:` listener keys off it.** The repo has exactly two: `merge-queue-triage.yml` listens for `CI`, `publish-smoke.yml` listens for `Release`. Neither names this workflow, and `Close issues referenced in other repositories` appears nowhere in the tree outside the workflow's own `name:`.

## Does a red here actually reach anyone? (H4 — measured, and the answer is yes)

Worth answering, because a fix that swaps one invisible signal for another is not a fix. It is not invisible, and this workflow has already proved it:

- This job has **3 failures in 2281 runs**. Two of them, on 2026-08-02 at 07:56Z and 08:12Z, were `SyntaxError: Identifier 'octokit' has already been declared` — the script did not run at all. The fix (`fix(ci): 跨仓库客户端改名——github-script 本来就声明了 octokit`) merged at **08:35Z**, 39 minutes after the first red, and a second follow-up at 08:57Z. The second red landed on an unrelated author's merge, so the signal travelled beyond the author who was watching. The third failure (2026-08-06) was `Set up job` failing — runner infrastructure, before the script.
- The channels a red uses that a `core.warning` on a green run does not: the run's conclusion in the Actions list, a red check on the merged PR's Checks tab, and GitHub's default Actions failure notification to the run's triggering actor. That actor is a real person here — over the last 100 runs: `os-steve` (38), `os-zhuang` (30), `os-project-manager` (10), `os-support-ai` (8), `os-sam` (6), `hotlong` (5), plus bots.
- The honest caveat: no repo-side patrol sweeps failed workflow runs. Nothing in `scripts/pm/**` reads run conclusions, and no round report enumerates reds. So the signal is GitHub's own, not this repo's — which is enough (it demonstrably worked in 39 minutes) but is not a guarantee, and this is stated rather than assumed.

## H1: this branch has never run, and the loop's happy path was checked rather than trusted

The card's corpus measurement was re-run and widened: **1176 merged PRs** (12 pages of the closed-PR listing, `merged_at` non-null), each body matched with the workflow's own regex.

| | count |
|---|---|
| merged PRs scanned | 1176 |
| bodies with a qualified **foreign** closing keyword | **0** |
| bodies with a qualified **same-repo** keyword (`objectstack-ai/objectstack#N`) | 25 |

So the loop has had nothing to do in that entire window, and the only part of the target collection with any live evidence is the same-repo skip — which fired 25 times, and GitHub did close those, so the skip's premise holds.

The happy path was therefore checked directly, by running it (scenarios `P1`, `L1`, `L2`): the keyword alternation backtracks correctly so `closes` / `fixes` / `resolved` all qualify rather than being shadowed by their shorter prefixes, `Part of owner/repo#N` and the bare `#N` form do not qualify, the same-repo form is dropped before any API call, the key format round-trips into the `get` / `createComment` / `update` triple, the close is `state_reason: 'completed'`, and the comment carries the PR link. **No second defect was found in the happy path.** One judgment-bearing gap was found on a neighbouring path and filed rather than folded in — see the audit below.

## H3: the full exit-path audit

Every exit of the script, not just the two under cards:

| # | exit | before | after | verdict |
|---|---|---|---|---|
| 1 | no qualified keywords | `core.info`, green | unchanged | correct — nothing to do |
| 2 | qualified same-repo reference | skipped silently | unchanged | correct — GitHub already closed it (25 live specimens) |
| 3 | token absent, notice delivered | warning + comment, green | unchanged | correct (#9575) — the comment is the deliverable |
| 4 | token absent, notice refused | summary + `setFailed` | unchanged | correct (#9594) |
| 5 | token absent, notice refused **and** summary unwritable | `core.info` + `setFailed` | unchanged | correct (#9594) |
| 6 | token present, all targets closed | green | unchanged | correct |
| 7 | token present, target already closed | skipped, green | unchanged | **judgment attached — filed as #9643** |
| 8 | token present, some target refused | `core.warning`, **green** | summary + `setFailed` | **this PR** |
| 9 | throw outside every `try` | github-script → `setFailed` | unchanged | correct, and unreachable given the trigger |

Row 7 is the third silent path neither #9575 nor #9595 names, and it is genuinely a silence of the same family: an already-closed foreign issue is skipped **whole**, so the PR backlink — which this workflow's header names as half the defect it exists to fix ("no reference to the PR on the issue's own page either") — is never left. Folding it in would have required choosing between three defensible behaviours, so it is #9643 rather than a rider here. Scenario `L2` pins today's behaviour so the change of mind is a visible edit.

Two things examined and rejected as this file's defect: the missing `timeout-minutes:` (a repo-wide pattern — 14 of 25 workflows declare none, so it is not this file's finding), and the absence of `concurrency:` (parallel merges producing parallel runs is correct here, since each run handles its own PR's targets).

One thing the audit reframes rather than fixes: a token that is present but **expired or under-scoped** takes exit 8, never exit 3, so before this change the run had no way at all to say the closes had not happened. GitHub answers a repository the credential cannot see with **404**, and `404` is on the step's retry-exempt list, so that is the likely real-world shape — one immediate throw per target, caught, and previously green. Scenario `L4` is exactly that case.

## How this is exercised (H2)

PR #9594 validated its half by extracting the shipped script and driving it under stubs. That was the right method and it was thrown away with the session, so the same defect class — code nobody has seen run — simply moved one line over. This PR makes the harness a repo artifact: `scripts/check-cross-repo-closer-outcome.mjs`, run by `lint.yml`.

- **The subject is the shipped bytes.** The script is read out of the YAML with a real parser (`jobs` ⇢ `close-foreign-issues` ⇢ the `actions/github-script@*` step ⇢ `with.script`) and executed as the body of an `AsyncFunction` carrying the action's own argument set. A copy pasted into the test file would test the copy. Every failure to extract exits non-zero rather than skipping (#4690).
- **Assertion 0 is the compile** — the 2026-08-02 `SyntaxError` class, which no outcome assertion could ever see, and which nothing in CI catches today.
- **Ten scenarios, 52 assertions** over the parse and every exit above: which of `setFailed` / `warning` / job summary fires, and which API calls were made.
- **A `--self-test` that mutates the shipped script seven ways** and requires the battery to go RED for each, naming the scenario that catches it: downgrade the post-loop verdict to a warning (the defect restored), stop collecting failed keys, `break` out of the loop instead of isolating, drop the same-repo skip, narrow the keyword set, drop the already-closed skip, and downgrade the notice path's verdict. Each mutation asserts its **anchor was present** first — a substitution that matched nothing would leave the battery green and read exactly like a pass.

**Reverse verification.** The identical battery, run against the pre-fix script taken from `origin/main` (nothing in the working tree touched), fails **9 of 52** assertions, all of them in `L3` / `L4` / `L5`:

```
[L3] L3 warns naming the target and the refusal
     L3 FAILS the job -- the defect this card is about; got 0
     L3 setFailed names the target left open
     L3 writes the list into the job summary
[L4] L4 fails the job once, after the loop -- not once per target
     L4 setFailed names every target left open
     L4 summary carries the reason, so the credential is the obvious suspect
[L5] L5 still fails the job when the richer channel is gone
     L5 setFailed still names the target
```

`P0` / `P1` / `N1` / `N2` / `N3` / `L1` / `L2` pass identically on both — which is what "the notice path is untouched and the isolation is preserved" means here, asserted rather than claimed. (`L3`'s first line also goes red because the warning text now routes through the hoisted `describe`, so it names `HTTP 404` where it previously named only the bare message. Reported because it is a real second reason that assertion flips, not only the missing verdict.)

**Not asserted, deliberately:** the step's `retries:` / `retry-exempt-status-codes:` inputs are consumed by the action, not the script, so no stub of `github` can reach them; and whether GitHub's own keyword parser agrees with the regex is a property of GitHub, evidenced only by the 25 same-repo references it did close.

`dispatch-gates.mjs` discovers the new gate automatically — the derivation now reports 108 families where it reported 107, and derives this one from the workflow path it guards.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs` over the three changed paths, plus `check:nul-bytes` for any edit. All run **after** the final commit, `0a7e6c32d`:

- `check:node-version` — OK (28 setup-node steps across 25 workflows)
- `check:required-contexts` — self-test + gate OK
- `check:shard-attestation` — self-test 92 assertions, gate OK
- `check:workflow-status-functions` — self-test 34 assertions, gate OK (25 workflows, 44 jobs, 24 job-level `if:`)
- `check:type-check-coverage` — self-test 109 cases, gate OK
- `check:nul-bytes` — self-test 75 assertions, gate OK (6174 files, no raw control bytes); plus a direct `grep -naP` over the three changed files
- `node scripts/check-cross-repo-closer-outcome.mjs --self-test` — 39 assertions, 7 mutations each driven to red
- `node scripts/check-cross-repo-closer-outcome.mjs` — OK, 52 assertions over 10 scenarios

`check:type-check-debt` is derived (its source names `lint.yml`) but was **not** run locally: it is the `--re-measure` variant that re-runs tsc across the 13 ledger packages, i.e. farm-scale, and the container's shared heavy-verify lock was held throughout by another agent's `@object-ui/console` build from `/home/user/objectstack-8134` with five more runs queued behind it. The non-re-measure half of the same script passed above, and this diff adds no TypeScript, touches no tsconfig and changes no package's `typecheck` script. CI owns it.

No changeset: this PR ships two workflow files and one gate script, and publishes nothing, so it carries `skip-changeset` — the same disposition as PR #9594. An empty-frontmatter changeset is not the alternative here; `check-empty-changeset.mjs` rejects newly added ones, and its header records why (an empty changeset is a real input to `changesets/action` and can stall a release, which the label cannot).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_