### PR TITLE
fix(runtime-config): resolve OS_PRODUCT_STAGE into branding.stage so the documented preview-badge switch works (#9252)

### DIFF
--- a/.changeset/runtime-config-product-stage.md
+++ b/.changeset/runtime-config-product-stage.md
@@ -1,0 +1,57 @@
+---
+"@objectstack/cloud-connection": minor
+---
+
+fix(runtime-config): `OS_PRODUCT_STAGE` / `branding.stage` actually reaches `/api/v1/runtime/config`, so the documented preview-badge switch stops being a no-op (#9252)
+
+<!-- adr-0087: not-required (no-migration-prescription) One constructor option
+and one optional response key are ADDED; nothing authorable is renamed, retired
+or tombstoned, and no stored `sys_metadata` shape changes. There is no
+conversion to register. -->
+
+Running `examples/app-showcase` with `OS_PRODUCT_STAGE=ga objectstack dev` left
+the Console's "Preview" chip on screen. `RuntimeConfigPlugin` never emitted
+`branding.stage`, so objectui's `PreviewBadge` — which reads exactly that key —
+never saw the value, and the switch objectui's app-shell README presents as the
+operational way to hide the badge did nothing at all.
+
+**Nobody implemented it, in either distribution.** The card guessed the knob was
+"honored only by the cloud distribution"; measured with a control first, so the
+zeros are a reading rather than a broken search:
+
+| probe | result |
+|---|---|
+| `OS_PRODUCT_STAGE`, framework repo-wide | 0 hits |
+| `OS_PRODUCT_STAGE` / `branding.stage` / `PlatformStage`, cloud repo-wide | 0 hits |
+| control: `OS_PRODUCT_NAME`, cloud repo | 9 hits |
+| control: files mentioning `branding`, cloud repo | 18 files |
+
+So this is the declared-but-unenforced trap in its purest form: a documented
+operator knob with no producer anywhere. Emitting the key restores an
+already-declared contract rather than widening a surface — no request that is
+accepted today becomes rejected, or vice versa.
+
+**Resolved in the plugin, not threaded through the CLI.** Both halves of the
+documented interface name this plugin (`OS_PRODUCT_STAGE` **or**
+`new RuntimeConfigPlugin({ stage })`), every sibling branding key already
+resolves `config.X ?? OS_X` in the same constructor, and — decisively — the
+card's own repro constructs its **own** `RuntimeConfigPlugin` in
+`examples/app-showcase/objectstack.config.ts`, which wins over the CLI's by
+plugin name. A value threaded through `Serve.RUNTIME_CONFIG_OPTIONS` would have
+left the reported repro still broken. The cloud distribution inherits the fix
+for free: its `RuntimeConfigPlugin` extends this one and spreads its config into
+`super()`, so there is one mechanism answering this question, not two.
+
+**The value space is closed** — `'preview' | 'beta' | 'ga'`, mirroring the
+`PlatformStage` union the Console branches on (exported as `PlatformStage`). An
+unrecognised value is refused and named in a mount-time `warn` listing the
+accepted spellings, never forwarded: the SPA discards off-contract values
+anyway, so a passthrough would recreate this bug's exact shape — an operator
+sets the knob, nothing happens, nothing is said.
+
+**Unset stays absent.** No `stage` key at all, rather than an empty string or a
+default invented server-side, so the Console keeps applying its own documented
+`'preview'` default and nothing that works today changes. The regression proof
+asserts that direction on **key presence** (`hasOwnProperty`), not
+`toBeUndefined()` — `{ stage: undefined }` satisfies the latter while being a
+present property that survives `structuredClone` and shows up in `Object.keys`.

--- a/packages/cloud-connection/src/index.ts
+++ b/packages/cloud-connection/src/index.ts
@@ -54,7 +54,7 @@ export type {
 export { CloudConnectionPlugin, createCloudConnectionPlugin } from './cloud-connection-plugin.js';
 export type { CloudConnectionPluginConfig } from './cloud-connection-plugin.js';
 export { RuntimeConfigPlugin } from './runtime-config-plugin.js';
-export type { RuntimeConfigPluginConfig, RuntimeFeatureOverrides, RuntimeConfigPlanFeatures } from './runtime-config-plugin.js';
+export type { RuntimeConfigPluginConfig, RuntimeFeatureOverrides, RuntimeConfigPlanFeatures, PlatformStage } from './runtime-config-plugin.js';
 // ADR-0008 consumption side — the self-hosted credential ledger (bind
 // persists the oscc_ bearer here; forwards present it to the control plane).
 export { ConnectionCredentialStore, DEFAULT_CONNECTION_CREDENTIAL_PATH } from './connection-credential-store.js';

--- a/packages/cloud-connection/src/runtime-config-plugin.ts
+++ b/packages/cloud-connection/src/runtime-config-plugin.ts
@@ -15,8 +15,47 @@
  *     singleEnvironment: boolean,
  *     defaultOrgId?, defaultEnvironmentId?,   // multi-tenant, per-hostname
  *     features: { installLocal, marketplace, aiStudio, autoPublishAiBuilds, ... },
- *     branding: { productName, productShortName, logoUrl, faviconUrl, brandColor, pwaDescription, pwaThemeColor }
+ *     branding: { productName, productShortName, stage?, logoUrl, faviconUrl, brandColor, pwaDescription, pwaThemeColor }
  *   }
+ *
+ * ## `branding.stage` — a documented knob that this runtime never sent (#9252)
+ *
+ * The Console's `PreviewBadge` reads `branding.stage` to decide whether to show
+ * its "Preview" / "Beta" chip, and objectui's app-shell README states the
+ * operator interface in as many words: *"Operators set it with
+ * `OS_PRODUCT_STAGE` or `new RuntimeConfigPlugin({ stage })`"*. Neither half
+ * existed. Measured on `main` with a control before this change (the control is
+ * what makes the zeros a reading rather than a broken search):
+ *
+ *   OS_PRODUCT_STAGE, repo-wide                  0 hits
+ *   branding.stage / PlatformStage, cloud repo   0 hits
+ *   control: OS_PRODUCT_NAME, cloud repo         9 hits
+ *
+ * So `OS_PRODUCT_STAGE=ga objectstack dev` left the badge up, and the card's
+ * guess that "the knob is honored only by the cloud distribution" was wrong in
+ * the operator's favour: **no** distribution honoured it. Emitting the key is
+ * restoration of an already-declared contract, not a new surface.
+ *
+ * It is resolved HERE and not threaded in from the CLI, which is the one design
+ * choice in this fix worth stating. Both halves of the documented interface name
+ * this plugin, every sibling branding key already resolves `config.X ?? OS_X`
+ * in this constructor, and — decisively — the card's own repro
+ * (`examples/app-showcase`) constructs its **own** `RuntimeConfigPlugin` in
+ * `objectstack.config.ts`, which takes precedence over the CLI's by plugin name.
+ * A value threaded through `Serve.RUNTIME_CONFIG_OPTIONS` would therefore have
+ * left the reported repro still broken, and made every other host responsible
+ * for remembering one more passthrough — the every-host-must-remember failure
+ * `features.installLocal` above was already demoted for.
+ *
+ * The value space is CLOSED (`preview` | `beta` | `ga`), mirroring the
+ * `PlatformStage` union the Console branches on. An unrecognised value is
+ * refused and reported at mount time rather than forwarded: the SPA would
+ * discard it anyway (its own `isPlatformStage` guard keeps the current stage on
+ * a malformed payload), so a passthrough would recreate this bug's exact shape —
+ * an operator setting the knob, nothing happening, nothing said. Unset stays
+ * **absent**: no `stage` key at all, never an empty string or a guessed default,
+ * so the Console keeps applying its own documented `'preview'` default and
+ * nothing that works today changes.
  *
  * ## Feature seam (open-core boundary — cloud ADR-0012)
  *
@@ -254,6 +293,42 @@ function someRoutePattern(rawApp: unknown, matches: (pattern: string) => boolean
 
 
 /**
+ * Product lifecycle stage — drives the Console's top-bar preview/beta chip
+ * (#9252).
+ *
+ * A CLOSED set, not free text, because the consumer BRANCHES on the value:
+ * `PreviewBadge` renders "Preview" for `preview`, "Beta" for `beta`, and
+ * nothing at all for `ga`. This union is the server-side mirror of the
+ * `PlatformStage` union in objectui's `app-shell/src/runtime-config.ts`; the
+ * two are pinned together by the operator-facing documentation in its README
+ * rather than by an import, since neither repo depends on the other here.
+ *
+ * There is deliberately no `'preview'` default on this side — see
+ * {@link RuntimeConfigPluginConfig.stage}.
+ */
+export type PlatformStage = 'preview' | 'beta' | 'ga';
+
+/** The accepted spellings, in the order the diagnostic lists them. */
+const PLATFORM_STAGES: readonly PlatformStage[] = ['preview', 'beta', 'ga'];
+
+/**
+ * Narrow an operator-supplied string to the closed stage set.
+ *
+ * Exact match against the trimmed value — no case folding, no synonyms. A
+ * near-miss (`GA`, `general-availability`) is REFUSED and reported, not
+ * guessed: silently coercing it would fossilize a second spelling of a
+ * documented key, and this file's whole subject is a knob that appeared to work
+ * while doing nothing.
+ */
+function asPlatformStage(value: string | undefined): PlatformStage | undefined {
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    return (PLATFORM_STAGES as readonly string[]).includes(trimmed)
+        ? (trimmed as PlatformStage)
+        : undefined;
+}
+
+/**
  * Feature-flag overrides a host's distribution policy can derive per request.
  *
  * Open-ended on purpose: the framework's own flags (`aiStudio`,
@@ -326,6 +401,23 @@ export interface RuntimeConfigPluginConfig {
     productName?: string;
     /** Short product name (PWA shortName, compact spots). Defaults to productName. */
     productShortName?: string;
+    /**
+     * Product lifecycle stage driving the Console's preview/beta chip (#9252).
+     * Falls back to the `OS_PRODUCT_STAGE` env var; set `'ga'` to hide the
+     * badge. Both spellings are the ones objectui's app-shell README already
+     * documents to operators.
+     *
+     * ⛔ Unset means **unset**: the response then carries no `stage` key at all,
+     * rather than an empty string or a default invented here. The Console
+     * already owns the documented default (`'preview'` until a server says
+     * otherwise), so guessing one on this side would be this card's own defect
+     * pointing the other way — a consumer misreading a missing thing, except
+     * the server would be the one asserting it.
+     *
+     * An unrecognised value (env typo, or a JS host outside this type) is
+     * refused and warned about at mount time — never forwarded.
+     */
+    stage?: PlatformStage;
     /** Absolute or relative URL for the product logo. Falls back to OS_LOGO_URL env var. */
     logoUrl?: string;
     /** Absolute or relative URL for the favicon. Falls back to OS_FAVICON_URL env var. */
@@ -369,6 +461,16 @@ export class RuntimeConfigPlugin implements Plugin {
     private readonly singleEnvironment: boolean;
     private readonly productName: string;
     private readonly productShortName: string;
+    /** Resolved stage, or `undefined` for "send no key" (unset or refused). */
+    private readonly stage: PlatformStage | undefined;
+    /**
+     * The rejected spelling, kept only so `start()` can name it once. Holding
+     * it — rather than warning from the constructor — is what the route-ledger
+     * diagnostic below already does: the constructor has no logger, and a
+     * silently dropped operator knob is exactly the thing that must not be
+     * invisible from the SPA end.
+     */
+    private readonly refusedStage: string | undefined;
     private readonly logoUrl: string | undefined;
     private readonly faviconUrl: string | undefined;
     private readonly brandColor: string | undefined;
@@ -393,6 +495,15 @@ export class RuntimeConfigPlugin implements Plugin {
         const envShort = (typeof process !== 'undefined' ? process.env?.OS_PRODUCT_SHORT_NAME : undefined)?.trim();
         this.productName = (config.productName ?? envName ?? 'ObjectOS').trim() || 'ObjectOS';
         this.productShortName = (config.productShortName ?? envShort ?? this.productName).trim() || this.productName;
+        // Same precedence as every branding key above — the HOST's explicit
+        // option wins, the env var is the operator's fallback — but resolved
+        // through the closed set, so an unrecognised spelling from either door
+        // becomes "no key" plus one diagnostic rather than an out-of-contract
+        // value the Console would silently discard.
+        const envStage = (typeof process !== 'undefined' ? process.env?.OS_PRODUCT_STAGE : undefined)?.trim();
+        const requestedStage = config.stage ?? (envStage || undefined);
+        this.stage = asPlatformStage(requestedStage);
+        this.refusedStage = this.stage === undefined ? requestedStage : undefined;
         const envLogoUrl = (typeof process !== 'undefined' ? process.env?.OS_LOGO_URL : undefined)?.trim();
         const envFaviconUrl = (typeof process !== 'undefined' ? process.env?.OS_FAVICON_URL : undefined)?.trim();
         const envBrandColor = (typeof process !== 'undefined' ? process.env?.OS_BRAND_COLOR : undefined)?.trim();
@@ -438,6 +549,20 @@ export class RuntimeConfigPlugin implements Plugin {
                     '[RuntimeConfigPlugin] raw app exposes no route table — features.marketplace and '
                     + 'features.installLocal will report false (a mounted browse or install-local surface cannot '
                     + 'be observed here). Declare them via resolveFeatures if this runtime does serve them.',
+                );
+            }
+
+            // An operator who set OS_PRODUCT_STAGE (or a JS host that passed
+            // `stage`) to something outside the closed set gets told here,
+            // naming what was refused and what is accepted. `warn`, not
+            // `error`: this is a FUNCTIONAL degradation — the badge visibly
+            // stays up and the next person to look finds out — with nothing
+            // claimed-persisted going missing behind it.
+            if (this.refusedStage !== undefined) {
+                ctx.logger?.warn?.(
+                    `[RuntimeConfigPlugin] ignoring unrecognised product stage ${JSON.stringify(this.refusedStage)} `
+                    + `(OS_PRODUCT_STAGE / the \`stage\` option) — branding.stage will be omitted and the Console `
+                    + `keeps its default preview badge. Accepted values: ${PLATFORM_STAGES.join(', ')}.`,
                 );
             }
 
@@ -541,6 +666,13 @@ export class RuntimeConfigPlugin implements Plugin {
                     branding: {
                         productName: this.productName,
                         productShortName: this.productShortName,
+                        // Spread, not `stage: this.stage` — the sibling keys
+                        // below may serialize as `undefined` (JSON.stringify
+                        // drops them) but this one is asserted on by KEY
+                        // PRESENCE, so it must never exist as a
+                        // present-and-undefined property on the object handed
+                        // to a non-JSON consumer or a test.
+                        ...(this.stage !== undefined ? { stage: this.stage } : {}),
                         logoUrl: this.logoUrl,
                         faviconUrl: this.faviconUrl,
                         brandColor: this.brandColor,

--- a/packages/cloud-connection/src/runtime-config-stage.test.ts
+++ b/packages/cloud-connection/src/runtime-config-stage.test.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `branding.stage` — the documented preview-badge switch (#9252).
+ *
+ * objectui's app-shell README tells operators the badge is turned off with
+ * `OS_PRODUCT_STAGE` or `new RuntimeConfigPlugin({ stage })`. Neither half was
+ * implemented, so `OS_PRODUCT_STAGE=ga objectstack dev` left the "Preview" chip
+ * on screen and nothing said why.
+ *
+ * Both directions are pinned here, and the absent one is asserted on KEY
+ * PRESENCE rather than `toBeUndefined()` — the two are not the same claim, and
+ * only one of them is this card's contract. `{ stage: undefined }` satisfies
+ * `toBeUndefined()` while being a present property: it survives structuredClone,
+ * shows up in `Object.keys`, and reaches any consumer that does not round-trip
+ * the body through JSON. The contract is that the key is NOT THERE.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RuntimeConfigPlugin, type RuntimeConfigPluginConfig } from './runtime-config-plugin.js';
+
+interface Served {
+    body: any;
+    warnings: string[];
+}
+
+/**
+ * Mount the plugin on a Hono-shaped raw app and serve one request, keeping the
+ * warnings it emitted at mount time. Same harness shape as
+ * `runtime-config-plugin.test.ts`; it records `warn` because the refusal path
+ * is only observable there.
+ */
+async function serve(pluginConfig: RuntimeConfigPluginConfig = {}): Promise<Served> {
+    let handler: ((c: any) => Promise<any>) | undefined;
+    const rawApp = {
+        routes: [] as Array<{ method: string; path: string }>,
+        get(path: string, h: (c: any) => Promise<any>) {
+            this.routes.push({ method: 'GET', path });
+            if (path === '/api/v1/runtime/config') handler = h;
+        },
+    };
+    const warnings: string[] = [];
+    const ctx: any = {
+        logger: { info() {}, warn: (m: string) => { warnings.push(String(m)); } },
+        getService: (n: string) => {
+            if (n === 'http-server') return { getRawApp: () => rawApp };
+            throw new Error(`no ${n}`);
+        },
+        hooks: [] as Array<() => Promise<void>>,
+        hook(_e: string, cb: () => Promise<void>) { this.hooks.push(cb); },
+    };
+    const plugin = new RuntimeConfigPlugin({ controlPlaneUrl: '', singleEnvironment: true, ...pluginConfig });
+    await plugin.start(ctx);
+    for (const cb of ctx.hooks) await cb();
+    if (!handler) throw new Error('handler not mounted');
+    const body = await handler({
+        req: { header: () => undefined },
+        json: (b: any) => b,
+    });
+    return { body, warnings };
+}
+
+/** The assertion this card turns on: is the key THERE, whatever its value? */
+function hasStageKey(body: any): boolean {
+    return Object.prototype.hasOwnProperty.call(body.branding, 'stage');
+}
+
+describe('RuntimeConfigPlugin — branding.stage (#9252)', () => {
+    const saved = process.env.OS_PRODUCT_STAGE;
+
+    beforeEach(() => { delete process.env.OS_PRODUCT_STAGE; });
+    afterEach(() => {
+        if (saved === undefined) delete process.env.OS_PRODUCT_STAGE;
+        else process.env.OS_PRODUCT_STAGE = saved;
+    });
+
+    describe('direction 1 — the env var reaches the response', () => {
+        it('OS_PRODUCT_STAGE=ga is served as branding.stage (the reported repro)', async () => {
+            process.env.OS_PRODUCT_STAGE = 'ga';
+            const { body, warnings } = await serve();
+            expect(hasStageKey(body)).toBe(true);
+            expect(body.branding.stage).toBe('ga');
+            expect(warnings).toEqual([]);
+        });
+
+        it.each(['preview', 'beta', 'ga'] as const)('carries the whole closed set: %s', async (stage) => {
+            process.env.OS_PRODUCT_STAGE = stage;
+            const { body } = await serve();
+            expect(body.branding.stage).toBe(stage);
+        });
+
+        it('trims surrounding whitespace, like every sibling branding env read', async () => {
+            process.env.OS_PRODUCT_STAGE = '  ga  ';
+            const { body } = await serve();
+            expect(body.branding.stage).toBe('ga');
+        });
+
+        it('the host option wins over the env var — the host decides, env is its fallback', async () => {
+            process.env.OS_PRODUCT_STAGE = 'preview';
+            const { body } = await serve({ stage: 'ga' });
+            expect(body.branding.stage).toBe('ga');
+        });
+
+        it('the host option works with no env var set at all', async () => {
+            const { body } = await serve({ stage: 'beta' });
+            expect(body.branding.stage).toBe('beta');
+        });
+    });
+
+    describe('direction 2 — unset stays ABSENT, not empty and not guessed', () => {
+        it('omits the key entirely when nothing set it', async () => {
+            const { body, warnings } = await serve();
+            // The load-bearing assertion: absent, not present-and-undefined.
+            expect(hasStageKey(body)).toBe(false);
+            expect(Object.keys(body.branding)).not.toContain('stage');
+            // ...and no invented default in its place. The Console owns the
+            // documented 'preview' default; asserting a value here would be
+            // this card's own defect pointing the other way.
+            expect(body.branding.stage).toBeUndefined();
+            expect(warnings).toEqual([]);
+        });
+
+        it('survives a JSON round trip as an absent key', async () => {
+            const { body } = await serve();
+            const parsed = JSON.parse(JSON.stringify(body));
+            expect(Object.prototype.hasOwnProperty.call(parsed.branding, 'stage')).toBe(false);
+        });
+
+        it('an EMPTY env var reads as unset — absent, and silent (not a typo)', async () => {
+            process.env.OS_PRODUCT_STAGE = '   ';
+            const { body, warnings } = await serve();
+            expect(hasStageKey(body)).toBe(false);
+            expect(warnings).toEqual([]);
+        });
+
+        it('leaves the sibling branding keys exactly as they were', async () => {
+            const { body } = await serve();
+            expect(body.branding.productName).toBe('ObjectOS');
+            expect(body.branding.productShortName).toBe('ObjectOS');
+            expect(body.branding.pwaThemeColor).toBe('#4f46e5');
+        });
+    });
+
+    describe('the value space is closed — an unrecognised stage is refused, loudly', () => {
+        it('refuses a near-miss spelling rather than coercing it', async () => {
+            process.env.OS_PRODUCT_STAGE = 'GA';
+            const { body } = await serve();
+            expect(hasStageKey(body)).toBe(false);
+        });
+
+        it.each(['general-availability', 'production', 'stable', 'ga '.repeat(3)])(
+            'refuses %j',
+            async (value) => {
+                process.env.OS_PRODUCT_STAGE = value;
+                const { body } = await serve();
+                expect(hasStageKey(body)).toBe(false);
+            },
+        );
+
+        it('names the refused value AND the accepted set, so the operator can fix it', async () => {
+            process.env.OS_PRODUCT_STAGE = 'GA';
+            const { warnings } = await serve();
+            const warning = warnings.find((w) => w.includes('product stage'));
+            expect(warning).toBeDefined();
+            // What was refused, quoted, and where it came from.
+            expect(warning).toContain('"GA"');
+            expect(warning).toContain('OS_PRODUCT_STAGE');
+            // ...and every accepted spelling, so the fix needs no source dive.
+            for (const accepted of ['preview', 'beta', 'ga']) expect(warning).toContain(accepted);
+        });
+
+        it('refuses an off-contract value from a JS host too, not only from the env', async () => {
+            const { body, warnings } = await serve({ stage: 'launched' as any });
+            expect(hasStageKey(body)).toBe(false);
+            expect(warnings.some((w) => w.includes('"launched"'))).toBe(true);
+        });
+
+        it('a valid value emits no warning', async () => {
+            process.env.OS_PRODUCT_STAGE = 'ga';
+            const { warnings } = await serve();
+            expect(warnings.some((w) => w.includes('product stage'))).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #9252

`OS_PRODUCT_STAGE=ga objectstack dev` left the Console's "Preview" chip on
screen. `RuntimeConfigPlugin` never emitted `branding.stage`, so objectui's
`PreviewBadge` — which reads exactly that key — never saw the value.

## The premise, re-verified with controls

Triage asked for a re-check against a moved `main`, and one guess in the card
turned out to be wrong in the operator's favour.

| probe | result |
|---|---|
| `OS_PRODUCT_STAGE`, framework repo-wide | **0 hits** |
| `branding.stage` / `productStage` / `PreviewBadge`, `packages/` | **0 hits** |
| control: `OS_CLOUD_URL`/`OS_ALLOW`, `packages/` | **143 files** |
| `OS_PRODUCT_STAGE` / `branding.stage` / `PlatformStage`, **cloud** repo-wide | **0 hits** |
| control: `OS_PRODUCT_NAME`, cloud repo | **9 hits** |
| control: files mentioning `branding`, cloud repo | **18 files** |

The card supposed the knob was "honored only by the cloud distribution."
**It is honored by nobody** — the producer side does not exist in either
repository. The controls are what make those zeros a reading rather than a
broken search. So this is the declared-but-unenforced trap in its purest form:
objectui's app-shell README documents the operator interface in as many words
("Operators set it with `OS_PRODUCT_STAGE` or `new RuntimeConfigPlugin({ stage })`")
and no code anywhere answered it. Emitting the key restores an already-declared
contract; no request accepted today becomes rejected, or vice versa.

## Falsified: this is a one-file change, not the two-site change the card predicted

The dispatch expected a value threaded in from `Serve.RUNTIME_CONFIG_OPTIONS` in
`packages/cli/src/commands/serve.ts`. **`packages/cli` is not touched by this PR**,
for a reason that is checkable rather than stylistic:

- Both halves of the documented interface name **this plugin**, not the CLI.
- Every sibling branding key (`productName`, `logoUrl`, `faviconUrl`,
  `brandColor`, `pwaDescription`, `pwaThemeColor`) already resolves
  `config.X ?? OS_X` in this same constructor, host option winning. `stage`
  joins that rule instead of inventing a second one.
- Decisively: the card's own repro, `examples/app-showcase`, constructs its
  **own** `RuntimeConfigPlugin` in `objectstack.config.ts:163`, and a
  host-wired plugin wins over the CLI's by plugin name (the subject of
  `serve-marketplace-cloud-host-precedence.test.ts`). **A value threaded
  through `Serve.RUNTIME_CONFIG_OPTIONS` would have left the reported repro
  still broken**, and would have made every other host responsible for
  remembering one more passthrough — the every-host-must-remember failure
  `features.installLocal` was demoted to a ceiling for.

The cloud distribution inherits this for free: its `RuntimeConfigPlugin`
extends the open one and spreads its config into `super()`, so one mechanism
answers this question in both distributions rather than two that can drift.

## Value space: closed, and refusals are loud

`'preview' | 'beta' | 'ga'` — exported as `PlatformStage`, mirroring the union
the Console branches on. Not free text, because the consumer branches on the
value. An unrecognised value (`GA`, `general-availability`) is **refused** and
named in a mount-time `warn` listing the accepted spellings, never forwarded:
the SPA discards off-contract values anyway, so a passthrough would recreate
this bug's exact shape — an operator sets the knob, nothing happens, nothing is
said. `warn` and not `error` per the repo's log-level rule: this is a functional
degradation, with nothing claimed-persisted going missing behind it.

No `packages/spec` change is involved — the runtime-config response has no spec
schema (`runtime/config` in `packages/spec/src/`: 0 hits), and `pwaThemeColor`
proves the branding shape has exactly one declaration site in this repo.

## Unset stays absent

No `stage` key at all when nothing sets it — not an empty string, not a
server-invented default. The Console owns the documented `'preview'` default,
so nothing that works today changes. The response builds the key by conditional
spread, and the pin asserts that direction on **key presence**
(`hasOwnProperty`), not `toBeUndefined()`: `{ stage: undefined }` satisfies the
latter while being a present property that survives `structuredClone` and shows
up in `Object.keys`.

## Ablation: predicted, NOT executed — declared rather than implied

The two ablation legs were scripted and predicted in advance, then could not be
run: the shared heavy-verify lock (`/tmp/os-heavy-verify.lock`) starved this
session for **~77 minutes across 10 acquisition attempts**, every one returning
the queue-timeout code. The cause is measurable rather than mysterious — other
sessions in this container queue with `-w 2400` / `-w 3000` (40-50 minutes),
while a wait that must fit inside one foreground call caps out around 8
minutes, so the long waiters win every race. Load average was 6.16 with 5
vitest/tsc processes live. I stopped and reported instead of running unlocked.

Recorded so the PM (or a follow-up) can execute and compare rather than take my
word:

- **Leg A — revert the producer to `origin/main`, keep the pin.** Predicted
  **9 failed / 10 passed** of 19. The interesting half of that prediction is
  which tests *survive*: every absent-direction test **passes vacuously**
  pre-fix, because the key was already missing — that is the bug's own
  baseline, and it is exactly why direction 1 is the load-bearing half.
- **Leg B — keep the fix, swap the conditional spread for `stage: this.stage`.**
  Predicted **8 failed / 11 passed**. Every `hasOwnProperty` assertion fails on
  present-and-undefined, while the JSON-round-trip test still **passes**
  (`JSON.stringify` drops undefined) — which is the precise reason the pin
  asserts on the raw object rather than only after a round trip.

The script is kept at `scratchpad/issue-9252/ablate.sh` — it reverts, runs,
restores, and verifies byte-identity at each step. It expects a worktree at
`/home/user/objectstack-issue-9252`, which this session tore down per the
container cleanup rule, so recreate one from the pushed branch first:
`git worktree add ../objectstack-issue-9252 claude/issue-9252-product-stage-runtime-config`.

What *was* executed in this direction: the type reverse-verification below,
which is a real red-then-green against the rebuilt `.d.ts`.

## Evidence

All at `16b3fd1ef`.

- `pnpm --filter @objectstack/cloud-connection test` — **24 files, 210 tests passed**.
- The new pin alone, confirming it really executed (a zero-match run exits 0 and
  reads as a pass): **1 file, 19 tests passed**.
- Type reverse-verification against the **rebuilt** `.d.ts`: `stage: 'GA'` and
  `stage: 'general-availability'` are rejected (TS2820 / TS2322 — tsc even
  suggests `"ga"`), while all three valid members compile. Exactly 2 errors,
  both on the invalid lines.
- `pnpm check:nul-bytes` — OK, 6169 files; self-scan of my four files: 0
  control-byte lines, control query 745 lines.
- `pnpm check:route-envelope` — OK, and it names this file: *exempt, closed at
  unenveloped 1* (pre-auth discovery, 2026-08-17 ruling). This PR adds a key to
  that body, not a new body, so the ratchet is unmoved.
- `check-empty-changeset` / `check-adr-0087-registration` / `check-changeset-no-major`,
  each `--base origin/main` — OK.
- `pnpm check:engine-double-contract` · `check:where-matcher` ·
  `check:query-options-erasure` · `check:type-check-coverage` — OK, none newly
  ratcheted (these are convention-triggered by adding a test file; derived from
  my real changed paths via `scripts/pm/dispatch-gates.mjs`, not recalled).

CI owns the rest of the farm.

---

_Generated by [Claude Code](https://claude.ai/code/session_012WKSnqAaoqtW3QX7SSf1Vk)_
