### PR TITLE
fix(driver-sql): report an un-run MySQL widening ALTER at `error`, naming the fix

### DIFF
--- a/.changeset/olive-donkeys-brake.md
+++ b/.changeset/olive-donkeys-brake.md
@@ -1,0 +1,27 @@
+---
+'@objectstack/driver-sql': patch
+---
+
+Report an un-run MySQL widening ALTER at `error`, naming the fix
+
+Boot schema-sync widens legacy MySQL `TIMESTAMP` columns to `DATETIME(3)` and
+zero-precision `TIME` columns to `TIME(3)`. When that DDL cannot run — most
+often another session holding the table's metadata lock — the failure is
+swallowed on purpose so a migration never takes boot down. It was reported at
+`warn`.
+
+That is the case AGENTS.md's degradation rule names for `error` by name: after
+the swallow the platform boots, serves traffic and looks entirely normal, while
+the DDL that was supposed to run did not. An un-widened `TIMESTAMP` keeps
+truncating milliseconds and an un-widened `TIME` keeps rounding fractional
+seconds to whole ones, against a canonical storage form that promises the
+milliseconds are kept, and nothing else reports the column as outstanding.
+
+Both lines now report at `error` and say what to do about it — identify the
+metadata-lock holder, end it, then re-run `os migrate apply` or restart, the
+widening being idempotent. Control flow is unchanged: the swallow stays, and
+the deferred-DDL flush keeps its loud refusal.
+
+`scripts/check-durability-degradation-log-level.mjs` gains `runWideningAlters`
+in its durability vocabulary, so the class stays fixed rather than these two
+sites.

--- a/packages/drivers/driver-sql/src/sql-driver-deferred-ddl-lock-wait.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-deferred-ddl-lock-wait.test.ts
@@ -94,17 +94,27 @@ class FakeMysqlDriver extends SqlDriver {
 
   issued: Issued[] = [];
   /**
-   * [#9542] Every `logger.warn` the driver emitted.
+   * [#9542/#9609] Every log line the driver emitted, **with its level**.
    *
    * On the boot path this is the ONLY output a blocked widening produces — the
    * swallow eats the error itself — so "the bound fires and the operator is
    * told" and "the bound fires and nothing at all is printed" are the same
    * green suite without a sink to assert on.
+   *
+   * ⭐ #9609: the LEVEL is recorded, not just the text. The pins below assert
+   * `error`, because that is the observable that regresses: a future edit that
+   * puts this line back on `warn` keeps every message assertion green while
+   * removing it from the operator's alerting, which is the only signal there
+   * is. Recording the text alone cannot tell those two apart. The sink
+   * therefore also HAS an `error` channel — the previous fixture had only
+   * `warn`, which would have made an `error` call land nowhere and read as a
+   * missing line rather than as a level change.
    */
-  warnings: Array<{ msg: string; meta?: any }> = [];
+  logs: Array<{ level: 'warn' | 'error'; msg: string; meta?: any }> = [];
 
   protected override logger = {
-    warn: (msg: string, meta?: any) => { this.warnings.push({ msg, meta }); },
+    warn: (msg: string, meta?: any) => { this.logs.push({ level: 'warn', msg, meta }); },
+    error: (msg: string, meta?: any) => { this.logs.push({ level: 'error', msg, meta }); },
     info: () => {},
   };
 
@@ -168,6 +178,32 @@ class FakeMysqlDriver extends SqlDriver {
 
 function makeDriver(): FakeMysqlDriver {
   return new FakeMysqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+}
+
+/**
+ * [#9609] The same driver behind a sink that has NO `error` channel.
+ *
+ * `SqlDriver.logger.error` is optional by declaration, and a host that injects
+ * `{ warn }` is a supported composition. This twin exists so the fallback in
+ * `logDurabilityFailure` is pinned by a test rather than by a comment: the
+ * obvious way to make the durability gate see this call site is
+ * `this.logger.error?.(…)`, which against THIS sink prints nothing at all —
+ * strictly worse than the `warn` it replaced, and invisible to every assertion
+ * that only looks at the driver with a full sink.
+ */
+class NoErrorSinkDriver extends FakeMysqlDriver {
+  protected override logger = {
+    warn: (msg: string, meta?: any) => { this.logs.push({ level: 'warn' as const, msg, meta }); },
+    info: () => {},
+  };
+}
+
+function makeNoErrorSinkDriver(): NoErrorSinkDriver {
+  return new NoErrorSinkDriver({
     client: 'better-sqlite3',
     connection: { filename: ':memory:' },
     useNullAsDefault: true,
@@ -361,27 +397,109 @@ describe('[#9354/#9542] a blocked widening ALTER — bounded on both paths, refu
     // boot, and correctness never depended on the widening having run.
   });
 
-  it('finally reaches the boot `logger.warn` — a bound that printed nothing would deliver nothing', async () => {
+  it('finally reaches the boot durability log — a bound that printed nothing would deliver nothing', async () => {
     driver = makeDriver();
     await driver.initObjects([WIDGET]);
     driver.issued.length = 0;
-    driver.warnings.length = 0;
+    driver.logs.length = 0;
 
     await expect(driver.initObjects([WIDGET])).resolves.toBeUndefined();
 
-    // ⭐ The card's whole claim. This warn was already written and was
+    // ⭐ The card's whole claim. This line was already written and was
     // UNREACHABLE in this scenario: the unbounded ALTER never returned, so the
     // catch that logs it never ran. A bound whose only effect is a quieter hang
     // delivers nothing and looks identical in a green suite, so the delivery is
     // asserted on the sink rather than inferred from the bound being armed.
-    const warn = driver.warnings.find((w) => /could not widen MySQL datetime columns/.test(w.msg));
-    expect(warn).toBeDefined();
-    expect(warn!.msg).toContain(WIDGET.name);
+    const line = driver.logs.find((w) => /widen MySQL datetime columns/.test(w.msg));
+    expect(line).toBeDefined();
+    expect(line!.msg).toContain(WIDGET.name);
     // Carrying the server's own diagnosis, not a swallowed blank.
-    expect(String(warn!.meta?.error)).toMatch(/Lock wait timeout exceeded/);
+    expect(String(line!.meta?.error)).toMatch(/Lock wait timeout exceeded/);
     // And it is the SERVER error that was swallowed, not the ADR-0112 refusal:
     // that envelope stays flush-only, so its operator sentence is absent here.
-    expect(String(warn!.meta?.error)).not.toMatch(/PROCESSLIST|No schema change was made/);
+    expect(String(line!.meta?.error)).not.toMatch(/PROCESSLIST|No schema change was made/);
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // #9609 — the LEVEL of that line, which is a separate question
+  // ───────────────────────────────────────────────────────────────
+
+  it('reports the un-run datetime widening at `error`, not `warn`', async () => {
+    driver = makeDriver();
+    await driver.initObjects([WIDGET]);
+    driver.logs.length = 0;
+
+    await expect(driver.initObjects([WIDGET])).resolves.toBeUndefined();
+
+    // AGENTS.md → "Degradation log levels" decides this with one question:
+    // after the degradation, does the system still look normal from the outside
+    // while something it claims is persisted has not landed? Here: yes. Boot
+    // completed, traffic is served, and the `error` limb names this exact case
+    // — "DDL that was supposed to run did not". The swallow is unchanged and
+    // deliberately so (#9542); only the level moved.
+    const line = driver.logs.find((w) => /widen MySQL datetime columns/.test(w.msg));
+    expect(line?.level).toBe('error');
+    // ⭐ Asserted as an ABSENCE too, because `find` above would happily return
+    // an `error` line while a second `warn` copy of the same degradation kept
+    // being emitted somewhere else on the path.
+    expect(driver.logs.filter((w) => w.level === 'warn')).toHaveLength(0);
+  });
+
+  it('reports the un-run TIME widening at `error` too — the twins do not diverge', async () => {
+    driver = makeDriver();
+    driver.legacyDatetimeColumns = [];
+    driver.legacyTimeColumns = [{ name: 'at', nullable: true }];
+    await driver.initObjects([WIDGET]);
+    driver.logs.length = 0;
+
+    await expect(driver.initObjects([WIDGET])).resolves.toBeUndefined();
+
+    // The `Field.time` twin loses fractional seconds by ROUNDING, which changes
+    // the wall clock that was asked for — if anything the louder of the two. It
+    // is pinned separately because the two catches are separate code: fixing one
+    // and not the other is the likeliest way this half-regresses.
+    const line = driver.logs.find((w) => /widen MySQL time columns/.test(w.msg));
+    expect(line?.level).toBe('error');
+    expect(line!.msg).toContain(WIDGET.name);
+  });
+
+  it('names the FIX, not only the consequence — the second thing an `error` owes', async () => {
+    driver = makeDriver();
+    await driver.initObjects([WIDGET]);
+    driver.logs.length = 0;
+
+    await expect(driver.initObjects([WIDGET])).resolves.toBeUndefined();
+
+    const line = driver.logs.find((w) => /widen MySQL datetime columns/.test(w.msg));
+    // AGENTS.md: an `error` owes BOTH the consequence and the fix, in the first
+    // line it prints. An operator woken at `error` with no next step is a worse
+    // outcome than the `warn` this replaced, so the actionable half is pinned as
+    // hard as the level. Same three moves the flush's refusal names, because it
+    // is the same blocker: find the lock holder, end it, re-run.
+    expect(line!.msg).toMatch(/PROCESSLIST|metadata_locks/);
+    expect(line!.msg).toMatch(/os migrate apply|restart/);
+    expect(line!.msg).toMatch(/idempotent/);
+    // And the consequence stays concrete rather than becoming "degraded".
+    expect(line!.msg).toMatch(/millisecond/i);
+  });
+
+  it('still delivers the line at `warn` when the injected sink has no `error`', async () => {
+    const noErrorSink = makeNoErrorSinkDriver();
+    driver = noErrorSink;
+    await noErrorSink.initObjects([WIDGET]);
+    noErrorSink.logs.length = 0;
+
+    await expect(noErrorSink.initObjects([WIDGET])).resolves.toBeUndefined();
+
+    // ⛔ The regression this guards is `this.logger.error?.(…)`: it satisfies the
+    // durability gate's matcher and prints NOTHING against this sink, converting
+    // a loud degradation into a silent one to please a checker. `SqlDriver`
+    // declares `logger.error` optional, so this composition is supported and the
+    // fallback is part of the contract, not a nicety.
+    const line = noErrorSink.logs.find((w) => /widen MySQL datetime columns/.test(w.msg));
+    expect(line).toBeDefined();
+    expect(line!.level).toBe('warn');
+    expect(line!.msg).toMatch(/PROCESSLIST|metadata_locks/);
   });
 
   it('clears the flush flag after a refusal, so a later boot sync is unaffected', async () => {

--- a/packages/drivers/driver-sql/src/sql-driver-deferred-ddl-lock-wait.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-deferred-ddl-lock-wait.test.ts
@@ -56,6 +56,22 @@ const WIDGET = {
 interface Issued { session: number; sql: string; bindings: unknown[] }
 
 /**
+ * [#9609] The driver's logger shape, with `error` OPTIONAL exactly as
+ * `SqlDriver` declares it.
+ *
+ * Spelled out rather than inferred from each fixture's object literal: an
+ * inferred type makes `error` REQUIRED on whichever fixture happens to supply
+ * it, and then the no-error-sink twin below cannot extend it — which reads as a
+ * TypeScript puzzle when it is really the contract under test. `error?` is the
+ * whole reason `logDurabilityFailure` needs a fallback.
+ */
+type FakeLogSink = {
+  warn: (msg: string, meta?: any) => void;
+  info?: (msg: string, meta?: any) => void;
+  error?: (msg: string, meta?: any) => void;
+};
+
+/**
  * MySQL's lock-wait timeout as mysql2 raises it, wrapped the way knex re-throws
  * it — the wrapper is the point: a recognizer reading only the top-level error
  * goes blind here, and blind means back to the year-long hang.
@@ -112,7 +128,7 @@ class FakeMysqlDriver extends SqlDriver {
    */
   logs: Array<{ level: 'warn' | 'error'; msg: string; meta?: any }> = [];
 
-  protected override logger = {
+  protected override logger: FakeLogSink = {
     warn: (msg: string, meta?: any) => { this.logs.push({ level: 'warn', msg, meta }); },
     error: (msg: string, meta?: any) => { this.logs.push({ level: 'error', msg, meta }); },
     info: () => {},
@@ -196,8 +212,8 @@ function makeDriver(): FakeMysqlDriver {
  * that only looks at the driver with a full sink.
  */
 class NoErrorSinkDriver extends FakeMysqlDriver {
-  protected override logger = {
-    warn: (msg: string, meta?: any) => { this.logs.push({ level: 'warn' as const, msg, meta }); },
+  protected override logger: FakeLogSink = {
+    warn: (msg: string, meta?: any) => { this.logs.push({ level: 'warn', msg, meta }); },
     info: () => {},
   };
 }

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -887,7 +887,8 @@ function backendStatementFaultError(object: string, cause: unknown): Error {
  * one. Everything above is reasoning about how long a legitimate metadata-lock
  * holder can plausibly hold it — a property of the lock, not of who is waiting
  * on it. Boot's difference from the flush is what happens when the bound fires
- * (boot warns and carries on; the flush refuses), never how long it waits.
+ * (boot reports at `error` and carries on; the flush refuses), never how long
+ * it waits.
  *
  * ⛔ Deliberately NOT configurable, and deliberately NOT retried — the 2026-08-17
  * ruling's explicit minimality. Both wait for measured demand. A knob added now
@@ -3982,6 +3983,45 @@ export class SqlDriver implements IDataDriver {
     warn: (msg, meta) => console.warn(msg, meta ?? ''),
     error: (msg, meta) => console.error(msg, meta ?? ''),
   };
+
+  /**
+   * [#9609] Emit on the durability-degradation channel: `error` when the
+   * injected sink has one, `warn` when it does not.
+   *
+   * # Why a named method and not the inline `(this.logger.error ?? this.logger.warn)(…)`
+   *
+   * Two reasons, and the second is the load-bearing one.
+   *
+   * ① It names the AGENTS.md channel at the call site, so the level is read as
+   * a classification ("this is durability, not functionality") rather than as
+   * an adjective someone picked. The `error?` field above already documents
+   * that channel; this is its verb.
+   *
+   * ② `check-durability-degradation-log-level.mjs` cannot SEE the inline
+   * fallback. Its `loggerLevel()` matches the shape `<logger|log|console>.<level>(…)`
+   * — a call whose expression is a property access. `(a ?? b)(…)` is a call on
+   * a PARENTHESIZED expression, so the matcher returns nothing and the catch is
+   * reported as `catch swallows the failure with no log at all` — a false
+   * silent-swallow on code that is loud at runtime. Measured, not inferred:
+   * with `runWideningAlters` in the vocabulary, both widening catches reported
+   * exactly that while calling the fallback inline.
+   *
+   * ⛔ Deliberately NOT `this.logger.error?.(…)`, which the gate DOES recognise.
+   * That spelling drops the message entirely for a sink that has no `error` —
+   * turning a durability-critical failure into true silence in order to
+   * satisfy a matcher, which is the failure this whole rule exists to prevent. The gate follows
+   * same-file helpers transitively (its header says so, and the audit reports
+   * sites as `loud (error@… via <helper>())`), so routing through this method
+   * keeps the fallback AND is correctly classified.
+   *
+   * The pre-existing inline uses in this file (the ADR-0120 D4 index sites) are
+   * left alone on purpose — they are a separate change with a separate blast
+   * radius, and the matcher blind spot itself is filed rather than patched here.
+   */
+  protected logDurabilityFailure(msg: string, meta?: any): void {
+    if (this.logger.error) this.logger.error(msg, meta);
+    else this.logger.warn(msg, meta);
+  }
 
   /** Whether the underlying database is a SQLite variant (sqlite3 or better-sqlite3). */
   protected get isSqlite(): boolean {
@@ -8113,9 +8153,11 @@ export class SqlDriver implements IDataDriver {
    * better for boot than it is for an operator: a boot blocked on another
    * session's metadata lock waits 31,536,000 seconds having printed nothing,
    * and boot is the path nobody can retry from a prompt. Bounding it turns
-   * that into a bounded wait plus the widening's own `logger.warn` — which,
+   * that into a bounded wait plus the widening's own durability log — which,
    * until the bound reached here, could never fire at all: the ALTER never
-   * returned, so its catch never ran.
+   * returned, so its catch never ran. #9609 raised that line from `warn` to
+   * `error`; the level is the operator's only signal, and the swallow below is
+   * exactly what makes an un-run ALTER invisible without it.
    *
    * What stays gated on {@link flushDeferredSchemaDdl} is the REFUSAL, and
    * only it. Boot still swallows: correctness never depends on the widening
@@ -8150,8 +8192,8 @@ export class SqlDriver implements IDataDriver {
           } catch (err) {
             // #9542: the bound is armed on both callers, the ESCAPE is not.
             // Off the flush this rethrows the server's own error, which the
-            // widening's catch logs and swallows — boot's policy unchanged,
-            // now reached by a wait that ends.
+            // widening's catch reports and swallows — boot's policy
+            // unchanged, now reached by a wait that ends.
             if (this.flushingDeferredDdl && isMysqlLockWaitTimeout(err)) {
               throw deferredDdlLockWaitError(table, DEFERRED_DDL_LOCK_WAIT_TIMEOUT_SECONDS, err);
             }
@@ -8219,9 +8261,14 @@ export class SqlDriver implements IDataDriver {
       // lock wait that the flush bounded is the operator's answer to a command
       // they ran, and dropping it would report success for work not done.
       if (isDeferredDdlLockWaitRefusal(err)) throw err;
-      this.logger.warn(
-        `[sql-driver] could not widen MySQL datetime columns on ${table}; ` +
-        `writes stay correct, but the 2038 ceiling and millisecond truncation remain`,
+      this.logDurabilityFailure(
+        `[sql-driver] FAILED to widen MySQL datetime columns on ${table} — the DDL did not run and boot ` +
+        `continued: the columns are still legacy TIMESTAMP, so every write to them keeps truncating ` +
+        `milliseconds and keeps the 2038 ceiling, while reads return exactly what was stored and nothing ` +
+        `else reports the table as un-widened. Fix: identify the metadata-lock holder with ` +
+        '`SHOW PROCESSLIST` or `performance_schema.metadata_locks` (or resolve the error in this ' +
+        'record\'s meta), end it, then re-run `os migrate apply` or restart — the widening is ' +
+        're-detected from `information_schema` and is idempotent, so re-running is safe.',
         { error: err instanceof Error ? err.message : String(err) },
       );
     }
@@ -8269,9 +8316,21 @@ export class SqlDriver implements IDataDriver {
    * keeps the milliseconds instead, matching the canonical form's resolution
    * and the `DATETIME(3)` precedent (#3942).
    *
-   * Failures are logged and swallowed for the usual reason; the only cost of a
-   * `TIME(0)` column that could not be widened is second-rounding of fractional
-   * writes — which is today's behaviour.
+   * Failures are swallowed for the usual reason; the only cost of a `TIME(0)`
+   * column that could not be widened is second-rounding of fractional writes —
+   * which is today's behaviour.
+   *
+   * # The level is `error`, and that is a separate question from the swallow (#9609)
+   *
+   * Swallow-vs-throw was adjudicated (#9542) and is unchanged: boot must not go
+   * down over a migration. `warn`-vs-`error` was never separately decided, and
+   * AGENTS.md → "Degradation log levels" decides it with one question — after
+   * the degradation, does the system still look normal from the outside while
+   * something it claims is persisted has not landed? Both halves hold: boot
+   * completes and serves traffic, and its `error` limb names this case by name
+   * ("DDL that was supposed to run did not"). Nothing else reports the column
+   * as un-widened, so the level IS the signal. Same reasoning, same level, on
+   * {@link migrateMysqlDatetimeColumns}.
    */
   protected async migrateMysqlTimeColumns(
     table: string,
@@ -8307,9 +8366,15 @@ export class SqlDriver implements IDataDriver {
       // lock wait that the flush bounded is the operator's answer to a command
       // they ran, and dropping it would report success for work not done.
       if (isDeferredDdlLockWaitRefusal(err)) throw err;
-      this.logger.warn(
-        `[sql-driver] could not widen MySQL time columns on ${table}; ` +
-        `fractional-second writes keep rounding to whole seconds`,
+      this.logDurabilityFailure(
+        `[sql-driver] FAILED to widen MySQL time columns on ${table} — the DDL did not run and boot ` +
+        `continued: the columns are still zero-precision TIME, so every fractional-second write to them ` +
+        `keeps being ROUNDED to whole seconds — the stored wall clock is not the one that was asked for — ` +
+        `while reads return exactly what was stored and nothing else reports the table as un-widened. ` +
+        'Fix: identify the metadata-lock holder with `SHOW PROCESSLIST` or ' +
+        '`performance_schema.metadata_locks` (or resolve the error in this record\'s meta), end it, then ' +
+        're-run `os migrate apply` or restart — the widening is re-detected from `information_schema` ' +
+        'and is idempotent, so re-running is safe.',
         { error: err instanceof Error ? err.message : String(err) },
       );
     }

--- a/scripts/check-durability-degradation-log-level.mjs
+++ b/scripts/check-durability-degradation-log-level.mjs
@@ -203,6 +203,10 @@ const DURABILITY_CRITICAL_CALLEES = new Map([
         'persistPackageCommitRow',
         "The ADR-0067 commit row for a publish/revert turn was never written — the artifacts are LIVE and `publishPackageDrafts` answers `success: true` with `commitId` merely absent, so the API, the metadata and every counter read clean, while the only record of that turn's revert plan (`existedBefore`/`prevVersion` per artifact) does not exist: `revertCommit` and `rollbackToPackageCommit` have nothing to act on and the turn can never be undone. A commit store that is failing stays failing, so every later publish loses its plan the same way (#9066).",
     ],
+    [
+        'runWideningAlters',
+        "The widening ALTER never ran — the MySQL column keeps its legacy zero-precision type (`TIMESTAMP` for a `Field.datetime`, `TIME` for a `Field.time`) while the object stays registered and served, so every subsequent write silently drops the milliseconds the canonical storage form promises are always present: a `TIMESTAMP` truncates them, and a `TIME(0)` ROUNDS a fractional literal, changing the wall clock it was asked to store. Reads come back looking clean because the value that was stored is the value that is returned, and nothing else reports the column is still un-widened (#9609).",
+    ],
 ]);
 
 /**


### PR DESCRIPTION
Fixes #9609

Boot schema-sync's MySQL widening swallows a failed `ALTER … MODIFY COLUMN` on purpose, and that stays exactly as it was. Only the LEVEL and the message change.

## The judgment, applied rather than re-litigated

AGENTS.md's degradation rule decides the level with one question: after the degradation, does the system still look normal from the outside while something it claims is persisted has not landed? Both halves hold here — boot completes, serves traffic and looks entirely healthy, and the rule's `error` limb names this case verbatim: *"DDL that was supposed to run did not"*. An un-widened `TIMESTAMP` keeps truncating milliseconds; an un-widened zero-precision `TIME` keeps ROUNDING fractional seconds, so the stored wall clock is not the one that was asked for. Nothing else reports the column as outstanding, which makes the level the only signal there is.

Swallow-vs-throw was adjudicated on #9542 and is untouched: no control flow moved, the deferred-DDL flush keeps its loud `DATABASE_ERROR`/500 refusal, and boot still carries on.

## H2 — the catch really is newly reachable, with one refinement

Confirmed from the code, not from the card. Before #9542 (commit `8bbf45947`) the guard read `if (!this.flushingDeferredDdl || !this.isMysql)`, so boot took the early return and ran the ALTER through the pool at MySQL's default `lock_wait_timeout` of 31,536,000 seconds. A metadata-lock-blocked boot ALTER never returned, so its catch never ran.

The refinement, since the card's wording is slightly stronger than what holds: the catch was always reachable by NON-lock failures (a permission error, a dialect refusal, a failed `information_schema` probe). What #9542 made newly reachable is the metadata-lock-blocked path specifically — which is the path this level change matters most for.

## H1 resolved to (a), measured

The previous comment on the card established that `sql-driver.ts` IS in the log-level rule's scan population (a walk of all of `packages/`) and is NOT in `durability-degradation.baseline.json` (which is empty), but could not determine why the gate stayed silent. Running it settles it: the durability vocabulary had no entry reaching the widening's DDL path. Not (b) — the baseline is empty. Not (c) — the matcher resolves `runWideningAlters()` fine once it is declared.

So `DURABILITY_CRITICAL_CALLEES` gains `runWideningAlters`, which is what AGENTS.md asks for ("found a new one, add it to `DURABILITY_CRITICAL_CALLEES` in the same PR that fixes it"). Measured to be exactly contained — with the vocabulary entry added and the level still `warn`, the gate went red on precisely the two sites the card names and nothing else:

```
✗ 2 durability-critical catch(es) degrade quietly
  packages/drivers/driver-sql/src/sql-driver.ts:8216  guards runWideningAlters() at line 8211
    found   : catch logs warn@8222 and does not rethrow
  packages/drivers/driver-sql/src/sql-driver.ts:8304  guards runWideningAlters() at line 8299
    found   : catch logs warn@8310 and does not rethrow
```

Zero collateral sites, so no widening decision was deferred. After the fix: `29 durability-critical catch seam(s), all loud` — 27 before, plus these two.

## H3 — the messages named the consequence but not the fix

Correct, they did not. Both now carry the second thing an `error` owes, using the same three moves the flush's refusal already names because it is the same blocker: identify the metadata-lock holder with `SHOW PROCESSLIST` or `performance_schema.metadata_locks`, end it, then re-run `os migrate apply` or restart — the widening re-reads `information_schema` and is idempotent, so re-running is safe.

## The emission goes through a named helper, and that is load-bearing

The file's existing durability idiom is `(this.logger.error ?? this.logger.warn)(…)`, because `SqlDriver.logger.error` is optional by declaration. The gate's `loggerLevel()` matcher **cannot see that shape** — it requires a property-access callee, and a parenthesized `??` is not one. With the fallback inline, both catches reported `catch swallows the failure with no log at all`: a false silent-swallow on code that is loud at runtime.

The spelling the matcher DOES accept, `this.logger.error?.(…)`, is the trap: it clears the gate and prints **nothing at all** against a sink that has no `error`. Measured — with the helper body replaced by the optional call, the gate stays green while the delivery disappears. That converts a loud degradation into a genuinely silent one to satisfy a checker, which is the failure the whole rule exists to prevent.

So both sites call a named `logDurabilityFailure`, whose body branches explicitly. The gate follows same-file helpers transitively (documented in its header), so this is correctly classified rather than routed around: `loud (error@4021 via logDurabilityFailure())`.

The matcher blind spot itself is **not** patched here — choosing among the options is a policy call on a gate's classification surface. Filed as #9657, a sub-issue of #8897 (the receiver-name half of the same function's narrowness), whose restart-when trigger this PR fires. The 4 pre-existing inline uses in this file are left alone for the same reason.

## Tests

Four new pins in `sql-driver-deferred-ddl-lock-wait.test.ts`, asserting the LEVEL rather than the text, per the card. The fixture now records `{ level, msg, meta }` and carries an `error` channel — the old one had only `warn`, which would have made an `error` call land nowhere and read as a missing line rather than as a level change.

- the datetime widening reports at `error`, with zero `warn` lines left on the path
- the TIME twin does too — pinned separately, since fixing one catch and not the other is the likeliest half-regression
- the message names the fix (`PROCESSLIST`/`metadata_locks`, re-run, idempotent), not only the consequence
- a sink with **no** `error` still receives the line at `warn` — the pin that makes the `?.` regression impossible to land quietly

Reverse verification, all three predicted before running and all three landing as predicted:

| ablation | test | gate |
|---|---|---|
| datetime level back to `warn` | RED — `reports the un-run datetime widening at error, not warn` | RED — `catch logs warn@8264 and does not rethrow` |
| helper body to `this.logger.error?.(…)` | RED — `still delivers the line at warn when the injected sink has no error` | ⚠️ **GREEN** |
| fix clause stripped from the message | RED — `names the FIX` (and the no-error-sink pin, which asserts the clause too) | GREEN |

The middle row is the one worth reading: the gate alone would have accepted the harmful spelling. Only the test discriminates it. Each ablation was run from the committed state and restored with `git checkout branch -- path`, verified byte-identical by an empty `git status`. These are vitest runs against `src/`, so no `dist/` rebuild is involved.

Verification at `042f406fa` (the head this PR points at):

- `pnpm --filter '@objectstack/driver-sql' test` → `Test Files 101 passed | 5 skipped`, `Tests 1761 passed | 62 skipped`
- `pnpm --filter '@objectstack/driver-sql' typecheck` → clean
- the targeted suite, verbose → `Tests 15 passed (15)`, including all four new ones
- gate union derived from the actual changed paths via `scripts/pm/dispatch-gates.mjs`, all 15 PASS: `check:durability-log-level`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:type-source-resolution`, `check:nul-bytes`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-cross-package-test-inputs`, `docs-audit/check-affected-docs`
- `node scripts/check-durability-degradation-log-level.mjs --self-test` → 35 cases passed
- the two real `SqlDriver` subclasses typecheck clean against the new protected member (`driver-sqlite-wasm`, `driver-turso`), and `logDurabilityFailure` collides with no existing name repo-wide

`content/docs/releases/**` untouched; a `.changeset` carries the operator-visible change. No governed surface edited — where AGENTS.md is quoted it is quoted, never amended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_