### PR TITLE
fix(objectql): plugin registry reads discriminate unreadable from empty — schema sync no longer skips every object silently at boot (#9285)

### DIFF
--- a/.changeset/objectql-plugin-registry-read-seams.md
+++ b/.changeset/objectql-plugin-registry-read-seams.md
@@ -1,0 +1,61 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): `ObjectQLPlugin`'s three registry reads stop inventing an empty registry — one of them silently skipped schema sync for every object at boot (#9285)
+
+`ObjectQLPlugin` read the registered object set in three places, all spelled
+`this.ql.registry?.getAllObjects?.() ?? []`. That expression folds three
+different facts into one value:
+
+1. the registry answered, and holds no objects;
+2. the engine exposes no `registry` at all;
+3. the registry exposes no `getAllObjects` — a **structural** omission that
+   never throws, so it is invisible precisely when it is wrong.
+
+Only (1) is truthfully *"no objects"*. #8895 ruled this family **discriminate or
+propagate**; #9002 and #9154 applied it to the two delete-cascade seams and the
+roll-up summary index. This closes the same shape in the plugin, where the
+consequential seam is at **boot**.
+
+The three seams get three different answers, and the difference is the fix:
+
+- **`syncRegisteredSchemas` — propagates.** Its next line is
+  `if (allObjects.length === 0) return;`, so an invented empty answer meant **no
+  registered object's schema was synced to any driver** — no table created, no
+  column added — silently, at boot, with the plugin reporting a clean start.
+  Failing the boot is more truthful than starting against a store whose DDL
+  never ran. On the `metadata:reloaded` path the existing caller already catches
+  this and reports it at `error` (#4632), so propagation there is a loud
+  durability report rather than a dead kernel.
+- **`reconcileFederatedBindings` — reports at `error`, then degrades.** The pass
+  exists to *name* the federated objects it could not bind ("a boot with nothing
+  to report says nothing"), so an unreadable registry making it report nothing
+  was exactly the silence it was written to prevent. It stays exception-proof:
+  it is a post-hoc reconciliation run after every `start()`, deliberately not a
+  boot gate.
+- **`runGovernanceInventory` — reports at `warn`, then skips.** This seam
+  carried **two independent swallows** (`?.()` *and* a wrapping
+  `try { … } catch { return [] }`), so a *throwing* registry was
+  indistinguishable from an empty one. Feeding the audit an invented empty
+  object set is worse than silence: with no objects, every handler declared *on*
+  an object reconciles as an "undeclared handler … REFUSED at dispatch", so an
+  unreadable registry accused a healthy deployment. The inventory is warn-only
+  and exception-proof by contract, so it reports and skips instead of
+  propagating, and leaves its report fingerprint untouched so the next
+  successful run is not suppressed as "unchanged".
+
+All three now read through one shared helper that throws rather than inventing,
+naming the consequence; a registry that *throws* propagates its own error
+verbatim.
+
+This is a **structural** close, not a live defect — re-derived on this tree:
+`SchemaRegistry.getAllObjects()` is a walk over in-memory `Map`s calling
+`resolveObject()`, which returns `undefined` on every failure branch it models
+and never throws, and `ObjectQL.registry` is a getter over a field-initialized
+`SchemaRegistry`, so for a real engine neither optional link can short-circuit.
+The reach that is real is a duck-typed `ql` — an incomplete test double, which
+#9154 measured shipping in nine suites at once.
+
+The `objectsRegistered` count in the `ObjectQL engine started` info log is
+deliberately unchanged: a wrong `0` there costs one advisory line and no data.

--- a/packages/objectql/src/plugin-registry-read-failure.test.ts
+++ b/packages/objectql/src/plugin-registry-read-failure.test.ts
@@ -82,7 +82,14 @@ const remoteAcct: ServiceObject = {
 /** An object that DECLARES the action the engine has a handler for. */
 const acctWithAction: ServiceObject = {
   ...acct,
-  actions: [{ name: 'ping', label: 'Ping', type: 'script' as const, body: 'return 1;' }],
+  actions: [
+    {
+      name: 'ping',
+      label: 'Ping',
+      type: 'script' as const,
+      body: { language: 'js' as const, source: 'return 1;' },
+    },
+  ],
 };
 
 interface Recorded {

--- a/packages/objectql/src/plugin-registry-read-failure.test.ts
+++ b/packages/objectql/src/plugin-registry-read-failure.test.ts
@@ -45,6 +45,13 @@
  * these seams today. The reach that is real is a duck-typed `ql`: an
  * incomplete test double, which #9154 measured shipping in nine suites at once.
  *
+ * One case is labelled PRESERVED rather than fixed, because the ablation said
+ * so: a throwing registry already propagated out of `syncRegisteredSchemas`
+ * before #9285 (its `?.` chain short-circuits on ABSENCE, never on a throw, and
+ * that seam had no `catch`). Seam 2's defect was the structural half alone. The
+ * test is kept — relabelled — because it fails the day someone wraps this read
+ * in a `try/catch`, which is how seam 3 acquired its second swallow.
+ *
  * Every failure case is paired with a POSITIVE CONTROL in the same describe —
  * a genuinely empty registry, and a populated one that still does the work — so
  * a plugin that had stopped syncing/binding/auditing altogether could not pass
@@ -163,7 +170,19 @@ function makePlugin(objects: ServiceObject[], driver?: unknown) {
 // ───────────────────────────────────────────────────────────────────────────
 
 describe('#9285 seam 2 — syncRegisteredSchemas propagates a registry it could not read', () => {
-  it('hands a THROWING registry error to the caller, identity intact', async () => {
+  /**
+   * ⚠️ PRESERVED behaviour, not fixed behaviour — measured, and labelled as
+   * such because reverse verification proved it green in BOTH directions.
+   *
+   * Seam 2's swallow was the OPTIONAL-CHAIN half only: `?? []` never caught
+   * anything, because `?.` short-circuits on absence, not on a throw, and this
+   * seam had no `catch` (unlike seam 3). So a throwing registry propagated here
+   * before #9285 too. This test therefore pins nothing about the fix — its job
+   * is the opposite one, and a real one: it fails the day someone "hardens"
+   * this seam by wrapping the read in a `try/catch`, which is exactly how
+   * seam 3 acquired its second swallow.
+   */
+  it('a THROWING registry already propagated, and must keep propagating (preserved, not fixed)', async () => {
     const { plugin, engine, ctx, rec } = makePlugin([acct], recordingDriver().driver);
     injectRegistryFailure(engine, 'throws');
 

--- a/packages/objectql/src/plugin-registry-read-failure.test.ts
+++ b/packages/objectql/src/plugin-registry-read-failure.test.ts
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#9285] `ObjectQLPlugin`'s three registry reads must not answer a read that
+ * could not run with an invented *"the registry holds nothing"*.
+ *
+ * All three used to spell the read `this.ql.registry?.getAllObjects?.() ?? []`,
+ * which folds three different facts into one value: the registry answered and
+ * holds nothing; the engine exposes no `registry`; the registry exposes no
+ * `getAllObjects`. Only the first is truthfully "no objects". #8895 ruled this
+ * family *discriminate or propagate*, and #9002 / #9154 applied it to the two
+ * delete-cascade seams and the roll-up summary index; this closes the same
+ * shape in the plugin, where the consequential seam is at BOOT.
+ *
+ * The three seams get three different answers, and the difference is the point:
+ *
+ *  1. `syncRegisteredSchemas` — PROPAGATES. Its next line is
+ *     `if (allObjects.length === 0) return;`, so an invented empty answer means
+ *     NO registered object's schema is synced to any driver — no table created,
+ *     no column added — silently, at boot, with the plugin reporting a clean
+ *     start. Failing the boot is more truthful than starting against a store
+ *     whose DDL never ran.
+ *  2. `reconcileFederatedBindings` — REPORTS at `error`, then degrades. The
+ *     pass exists to NAME the federated objects it could not bind ("a boot with
+ *     nothing to report says nothing"), so an unreadable registry making it
+ *     report nothing is exactly the silence it was written to prevent. It is a
+ *     post-hoc reconciliation run after every `start()`, deliberately not a
+ *     boot gate, so it reports rather than throws.
+ *  3. `runGovernanceInventory` — REPORTS at `warn`, then skips. This seam
+ *     carried TWO independent swallows (`?.()` and a wrapping
+ *     `try { … } catch { return [] }`), and feeding the audit an invented empty
+ *     object set is worse than silence: with no objects, every handler declared
+ *     ON an object reconciles as an "undeclared handler … REFUSED at dispatch",
+ *     so an unreadable registry accused a healthy deployment. The inventory is
+ *     warn-only and exception-proof by contract, so it must not propagate.
+ *
+ * ⚠️ This pins a STRUCTURAL close, not a live defect — re-derived on this tree.
+ * `SchemaRegistry.getAllObjects()` is a walk over in-memory `Map`s calling
+ * `resolveObject()`, which returns `undefined` on every failure branch it
+ * models and never throws; the fold below it is spreads and comparisons, with
+ * no I/O and no driver. And `ObjectQL.registry` is a getter over a
+ * field-initialized `SchemaRegistry`, so for a real engine neither optional
+ * link can short-circuit either. The failure is therefore injected AT the
+ * registry — and the injection IS the statement that nothing shipped reaches
+ * these seams today. The reach that is real is a duck-typed `ql`: an
+ * incomplete test double, which #9154 measured shipping in nine suites at once.
+ *
+ * Every failure case is paired with a POSITIVE CONTROL in the same describe —
+ * a genuinely empty registry, and a populated one that still does the work — so
+ * a plugin that had stopped syncing/binding/auditing altogether could not pass
+ * any of this vacuously.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ServiceObject } from '@objectstack/spec/data';
+import { ObjectQL } from './engine.js';
+import { ObjectQLPlugin } from './plugin.js';
+
+/* Fixtures are typed as `ServiceObject` rather than left to inference, so this
+ * file adds nothing to `@objectstack/objectql`'s TEST_DEBT ledger (#5278). */
+const acct: ServiceObject = {
+  name: 'acct',
+  label: 'Account',
+  fields: { id: { name: 'id', label: 'ID', type: 'text' as const } },
+};
+
+/** A federated object — the input `reconcileFederatedBindings` exists for. */
+const remoteAcct: ServiceObject = {
+  name: 'remote_acct',
+  label: 'Remote account',
+  fields: { id: { name: 'id', label: 'ID', type: 'text' as const } },
+  external: { remoteName: 'acct_remote' },
+};
+
+/** An object that DECLARES the action the engine has a handler for. */
+const acctWithAction: ServiceObject = {
+  ...acct,
+  actions: [{ name: 'ping', label: 'Ping', type: 'script' as const, body: 'return 1;' }],
+};
+
+interface Recorded {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  args: unknown[];
+}
+
+function recordingLogger() {
+  const records: Recorded[] = [];
+  const push = (level: Recorded['level']) => (message: string, ...args: unknown[]) =>
+    void records.push({ level, message: String(message), args });
+  return {
+    records,
+    logger: { debug: push('debug'), info: push('info'), warn: push('warn'), error: push('error') },
+    at(level: Recorded['level']) {
+      return records.filter((r) => r.level === level);
+    },
+  };
+}
+
+/** The error object every "registry throws" test asserts the IDENTITY of. */
+const INJECTED = new Error('registry read exploded');
+
+/**
+ * The three shapes the old `?.()` / `?? []` spelling folded together, injected
+ * at the registry itself.
+ *
+ * `throws` shadows the prototype method with an own property; the other two
+ * shadow the `registry` GETTER with an own property, which is the only way to
+ * express "this engine's registry does not implement the method" / "this engine
+ * has no registry" against a real class. Both are exactly the duck-typed `ql`
+ * an incomplete test double produces.
+ */
+type Injection = 'throws' | 'no-method' | 'no-registry';
+
+function injectRegistryFailure(engine: ObjectQL, how: Injection): void {
+  if (how === 'throws') {
+    (engine.registry as any).getAllObjects = () => {
+      throw INJECTED;
+    };
+    return;
+  }
+  Object.defineProperty(engine, 'registry', {
+    value: how === 'no-registry' ? undefined : { getObject: () => undefined },
+    configurable: true,
+  });
+}
+
+/** A driver that records the DDL it was asked for. */
+function recordingDriver() {
+  const synced: string[] = [];
+  const bound: string[] = [];
+  return {
+    synced,
+    bound,
+    driver: {
+      name: 'default',
+      supports: {},
+      async syncSchema(tableName: string) {
+        synced.push(tableName);
+      },
+      async registerExternalObject(obj: { name: string }) {
+        bound.push(obj.name);
+      },
+      async find() {
+        return [];
+      },
+    },
+  };
+}
+
+function makePlugin(objects: ServiceObject[], driver?: unknown) {
+  const rec = recordingLogger();
+  const engine = new ObjectQL({ logger: rec.logger } as any);
+  if (driver) engine.registerDriver(driver as any);
+  for (const obj of objects) engine.registerObject(obj as any);
+  const plugin = new ObjectQLPlugin();
+  (plugin as any).ql = engine;
+  return { rec, engine, plugin, ctx: { logger: rec.logger } as any };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Seam 2 — syncRegisteredSchemas: PROPAGATE
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#9285 seam 2 — syncRegisteredSchemas propagates a registry it could not read', () => {
+  it('hands a THROWING registry error to the caller, identity intact', async () => {
+    const { plugin, engine, ctx, rec } = makePlugin([acct], recordingDriver().driver);
+    injectRegistryFailure(engine, 'throws');
+
+    await expect((plugin as any).syncRegisteredSchemas(ctx)).rejects.toBe(INJECTED);
+    // …and it did NOT quietly become "nothing to sync": no pass-complete line.
+    expect(rec.at('info').filter((r) => /complete/i.test(r.message))).toHaveLength(0);
+  });
+
+  it('fails on a registry that does not implement getAllObjects, naming the consequence', async () => {
+    const { plugin, engine, ctx } = makePlugin([acct], recordingDriver().driver);
+    injectRegistryFailure(engine, 'no-method');
+
+    // The `?.()` half of the swallow: a STRUCTURAL omission that never throws,
+    // so before #9285 this was byte-identical to an empty registry.
+    await expect((plugin as any).syncRegisteredSchemas(ctx)).rejects.toThrow(
+      /syncRegisteredSchemas: the object registry could not be read/,
+    );
+    await expect((plugin as any).syncRegisteredSchemas(ctx)).rejects.toThrow(
+      /NOT "no objects are registered"/,
+    );
+  });
+
+  it('fails when the engine exposes no registry at all', async () => {
+    const { plugin, engine, ctx } = makePlugin([acct], recordingDriver().driver);
+    injectRegistryFailure(engine, 'no-registry');
+
+    await expect((plugin as any).syncRegisteredSchemas(ctx)).rejects.toThrow(
+      /the engine exposes no `registry`/,
+    );
+  });
+
+  it('positive control — a genuinely EMPTY registry still returns quietly', async () => {
+    const { plugin, ctx, rec } = makePlugin([], recordingDriver().driver);
+
+    await expect((plugin as any).syncRegisteredSchemas(ctx)).resolves.toBeUndefined();
+    expect(rec.at('error')).toHaveLength(0);
+  });
+
+  it('positive control — a readable registry still syncs every object it holds', async () => {
+    const d = recordingDriver();
+    const { plugin, ctx, rec } = makePlugin([acct], d.driver);
+
+    await (plugin as any).syncRegisteredSchemas(ctx);
+
+    expect(d.synced).toHaveLength(1);
+    expect(rec.at('error')).toHaveLength(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Seam 1 — reconcileFederatedBindings: REPORT at error, then degrade
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#9285 seam 1 — reconcileFederatedBindings reports the unreadable registry instead of reporting nothing', () => {
+  for (const how of ['throws', 'no-method', 'no-registry'] as Injection[]) {
+    it(`reports at error and does not throw (registry ${how})`, async () => {
+      const { plugin, engine, ctx, rec } = makePlugin([remoteAcct], recordingDriver().driver);
+      injectRegistryFailure(engine, how);
+
+      // Exception-proof: this pass runs at `kernel:ready`, after every
+      // `start()`, and is deliberately not a boot gate.
+      await expect((plugin as any).reconcileFederatedBindings(ctx)).resolves.toBeUndefined();
+
+      const errors = rec.at('error');
+      expect(errors).toHaveLength(1);
+      // CONSEQUENCE — named, not merely "something failed".
+      expect(errors[0].message).toMatch(/reconciliation did NOT run/);
+      expect(errors[0].message).toMatch(/stays registered and served/);
+      expect(errors[0].message).toMatch(/no such table/);
+      // The invention itself, called out so the reader cannot read this as
+      // "there were none".
+      expect(errors[0].message).toMatch(/NOT "no federated objects to bind"/);
+      // FIX.
+      expect(errors[0].message).toMatch(/restart \(or trigger a metadata reload\)/);
+      // `Logger.error` is `(message, error?, meta?)` — the cause rides slot 2.
+      expect(errors[0].args[0]).toBeInstanceOf(Error);
+    });
+  }
+
+  it('preserves the injected error as the reported cause', async () => {
+    const { plugin, engine, ctx, rec } = makePlugin([remoteAcct], recordingDriver().driver);
+    injectRegistryFailure(engine, 'throws');
+
+    await (plugin as any).reconcileFederatedBindings(ctx);
+
+    expect(rec.at('error')[0].args[0]).toBe(INJECTED);
+  });
+
+  it('positive control — a readable registry with NO federated objects stays silent', async () => {
+    const { plugin, ctx, rec } = makePlugin([acct], recordingDriver().driver);
+
+    await (plugin as any).reconcileFederatedBindings(ctx);
+
+    expect(rec.at('error')).toHaveLength(0);
+  });
+
+  it('positive control — a readable registry still binds its federated objects', async () => {
+    const d = recordingDriver();
+    const { plugin, ctx, rec } = makePlugin([remoteAcct], d.driver);
+
+    await (plugin as any).reconcileFederatedBindings(ctx);
+
+    expect(d.bound).toEqual(['remote_acct']);
+    expect(rec.at('error')).toHaveLength(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Seam 3 — runGovernanceInventory: REPORT at warn, then skip (BOTH swallows)
+// ───────────────────────────────────────────────────────────────────────────
+
+/** The false accusation an invented empty object set produces. */
+const UNDECLARED_WARN = /registered handlers with NO declaration/;
+const SKIPPED_WARN = /inventory SKIPPED/;
+
+function governancePlugin(how?: Injection) {
+  const built = makePlugin([acctWithAction], recordingDriver().driver);
+  built.engine.registerAction('acct', 'ping', async () => 1);
+  if (how) injectRegistryFailure(built.engine, how);
+  // `runGovernanceInventory` probes a metadata service; a kernel without one
+  // is the ordinary case and the seam under test is downstream of it.
+  built.ctx.getService = () => undefined;
+  return built;
+}
+
+describe('#9285 seam 3 — runGovernanceInventory reports both swallows instead of auditing an invented empty set', () => {
+  for (const how of ['throws', 'no-method', 'no-registry'] as Injection[]) {
+    it(`warns that the audit was SKIPPED and accuses nobody (registry ${how})`, async () => {
+      const { plugin, ctx, rec } = governancePlugin(how);
+
+      // Warn-only and exception-proof BY CONTRACT: a diagnostic must never be
+      // the reason a kernel fails to boot.
+      await expect((plugin as any).runGovernanceInventory(ctx)).resolves.toBeUndefined();
+
+      const warns = rec.at('warn');
+      const skipped = warns.filter((r) => SKIPPED_WARN.test(r.message));
+      expect(skipped).toHaveLength(1);
+      expect(skipped[0].message).toMatch(/could not be read/);
+      // The whole point of seam 3: an empty object set does not merely audit
+      // nothing, it accuses every object-declared action of being undeclared.
+      expect(warns.filter((r) => UNDECLARED_WARN.test(r.message))).toHaveLength(0);
+      // `warn` is `(message, meta?)` — the cause rides slot 1, not slot 2.
+      expect(skipped[0].args[0]).toMatchObject({ error: expect.any(String) });
+    });
+  }
+
+  it('leaves the fingerprint untouched, so the NEXT successful run is not suppressed as unchanged', async () => {
+    const { plugin, engine, ctx, rec } = governancePlugin('throws');
+    (plugin as any).lastGovernanceFingerprint = 'previous-run';
+
+    await (plugin as any).runGovernanceInventory(ctx);
+    expect((plugin as any).lastGovernanceFingerprint).toBe('previous-run');
+
+    // Recover the registry, drop the declaration: the audit must now speak.
+    delete (engine.registry as any).getAllObjects;
+    engine.registerObject(acct as any);
+    engine.registry.invalidate('acct');
+    rec.records.length = 0;
+
+    await (plugin as any).runGovernanceInventory(ctx);
+    expect(rec.at('warn').filter((r) => UNDECLARED_WARN.test(r.message))).toHaveLength(1);
+  });
+
+  it('positive control — a readable registry audits, and a DECLARED handler is not accused', async () => {
+    const { plugin, ctx, rec } = governancePlugin();
+
+    await (plugin as any).runGovernanceInventory(ctx);
+
+    expect(rec.at('warn')).toHaveLength(0);
+    expect((plugin as any).lastGovernanceFingerprint).toBe('');
+  });
+
+  it('positive control — a readable registry DOES accuse a genuinely undeclared handler', async () => {
+    const built = makePlugin([acct], recordingDriver().driver);
+    built.engine.registerAction('acct', 'ping', async () => 1);
+    built.ctx.getService = () => undefined;
+
+    await (built.plugin as any).runGovernanceInventory(built.ctx);
+
+    expect(built.rec.at('warn').filter((r) => UNDECLARED_WARN.test(r.message))).toHaveLength(1);
+  });
+});

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -11,6 +11,7 @@ import { lifecycleSettingsManifest } from './lifecycle/lifecycle-settings.js';
 import type { DanglingReferenceAuditOptions } from './integrity/dangling-reference-audit.js';
 import { runActionGovernanceInventory } from './action-governance.js';
 import type { IMetadataService } from '@objectstack/spec/contracts';
+import type { ServiceObject } from '@objectstack/spec/data';
 
 export type { Plugin, PluginContext };
 
@@ -1094,6 +1095,61 @@ export class ObjectQLPlugin implements Plugin {
    */
 
   /**
+   * Read every registered object — or FAIL. The ONE registry read the three
+   * seams below share, and it exists so that none of them can answer a read
+   * that could not run with an invented *"the registry holds nothing"*.
+   *
+   * [#9285] All three used to spell the read
+   * `this.ql.registry?.getAllObjects?.() ?? []`, which folds three different
+   * facts into one value:
+   *
+   *   1. the registry answered, and holds no objects;
+   *   2. the engine exposes no `registry` at all;
+   *   3. the registry exposes no `getAllObjects` — a STRUCTURAL omission that
+   *      never throws, so it is invisible precisely when it is wrong.
+   *
+   * Only (1) is truthfully "no objects". #8895 ruled this family
+   * *discriminate or propagate*; #9002 and #9154 applied it to the two
+   * delete-cascade seams and the roll-up summary index. There is no benign
+   * failure class to discriminate here either, so (2) and (3) become a thrown
+   * error that names the consequence, and a registry that THROWS propagates
+   * its own error verbatim — this helper adds no `catch` of its own.
+   *
+   * What each caller DOES with that failure is the caller's decision, taken at
+   * the seam and justified there: {@link syncRegisteredSchemas} lets it
+   * propagate (a boot that could not read the registry must not report a clean
+   * start against a store whose DDL never ran), while the two diagnostic
+   * passes report it once, loudly, and degrade — an audit that did not run
+   * must never be spelled the same way as an audit that found nothing.
+   *
+   * ⚠️ A STRUCTURAL close, not a live defect — re-derived on this tree:
+   * `SchemaRegistry.getAllObjects()` is a walk over in-memory `Map`s calling
+   * `resolveObject()`, which returns `undefined` on every failure branch it
+   * models and never throws, and `ObjectQL.registry` is a getter over a
+   * field-initialized `SchemaRegistry`, so for a real engine neither optional
+   * link can short-circuit. The only reach is a duck-typed `ql` — which is
+   * exactly the incomplete test double #9154 measured.
+   *
+   * @param seam - the calling method, named in the thrown message.
+   */
+  private readRegisteredObjects(seam: string): ServiceObject[] {
+    const registry: any = (this.ql as any)?.registry;
+    const read: unknown = registry?.getAllObjects;
+    if (registry == null || typeof read !== 'function') {
+      throw new Error(
+        `[ObjectQLPlugin] ${seam}: the object registry could not be read — ` +
+          (registry == null
+            ? 'the engine exposes no `registry`.'
+            : '`registry.getAllObjects` is not a function.') +
+          ' This is NOT "no objects are registered": that answer was never obtained, and the two have opposite ' +
+          'consequences (nothing to sync vs. nothing synced). Give the engine a registry that implements ' +
+          '`getAllObjects()` — a duck-typed engine or an incomplete test double is the only way to reach this line.',
+      );
+    }
+    return (read as () => ServiceObject[]).call(registry);
+  }
+
+  /**
    * Bind every declared FEDERATED (external) object to its remote table —
    * once, at `kernel:ready`, when the boot has finished moving (#7737).
    *
@@ -1141,7 +1197,37 @@ export class ObjectQLPlugin implements Plugin {
   private async reconcileFederatedBindings(ctx: PluginContext): Promise<void> {
     if (!this.ql) return;
 
-    const allObjects = this.ql.registry?.getAllObjects?.() ?? [];
+    // [#9285] The read no longer invents an empty registry. This pass exists
+    // to NAME what it could not bind — "a boot with nothing to report says
+    // nothing" (above) — so a read that could not RUN must not be spelled as a
+    // boot with nothing to report; that is precisely the silence the pass was
+    // written to prevent. It is reported and the pass degrades rather than
+    // throwing: this is a post-hoc reconciliation, deliberately run after every
+    // `start()` has completed so that a late-connecting datasource is not a
+    // boot failure, and propagating here would turn a diagnostic into the hard
+    // stop it was written not to be. (By then {@link syncRegisteredSchemas} has
+    // already read the same registry successfully on every boot that does not
+    // set `skipSchemaSync`, so a failure at THIS line is a registry that became
+    // unreadable mid-boot, not the boot-wide condition seam 2 catches.)
+    // `error`, not `warn`, per the AGENTS.md degradation-log-level rule and for
+    // the same reason the report below it is: from the outside the deployment
+    // looks healthy while declared data is simply not reachable.
+    let allObjects: ServiceObject[];
+    try {
+      allObjects = this.readRegisteredObjects('reconcileFederatedBindings');
+    } catch (e: unknown) {
+      ctx.logger.error(
+        'Federated (external) object reconciliation did NOT run — the object registry could not be read, so this boot ' +
+          'never determined which declared external objects are bound to their remote tables, and never re-drove the ' +
+          'bindings this pass exists to install. Any object left unbound stays registered and served: it keeps its REST ' +
+          'routes and keeps rendering in the UI, while every read against it resolves to a table named after the OBJECT ' +
+          'instead of the remote table it declares — so those reads fail with "no such table", or answer from the wrong ' +
+          'table. This is NOT "no federated objects to bind": that answer was never obtained. Fix the registry error ' +
+          'below and restart (or trigger a metadata reload) to re-run this binding.',
+        e instanceof Error ? e : new Error(String(e)),
+      );
+      return;
+    }
     const federated = allObjects.filter((o: any) => o?.external != null);
     if (federated.length === 0) return;
 
@@ -1211,7 +1297,17 @@ export class ObjectQLPlugin implements Plugin {
   private async syncRegisteredSchemas(ctx: PluginContext) {
     if (!this.ql) return;
 
-    const allObjects = this.ql.registry?.getAllObjects?.() ?? [];
+    // [#9285] The read PROPAGATES — no `?.`, no `?? []`. The next line turns
+    // "no objects" into an early return, i.e. NO registered object's schema is
+    // synced to any driver: no table created, no column added, silently, at
+    // boot, with the plugin reporting a clean start. "The registry holds
+    // nothing" and "the registry could not be read" have opposite consequences
+    // here and only the first is a truthful reason to skip, so a read that
+    // could not run fails the boot instead — more truthful than starting
+    // against a store whose DDL was never run. On the `metadata:reloaded` path
+    // the caller already catches this and reports it at `error` (#4632), so
+    // propagation there is a loud durability report, not a dead kernel.
+    const allObjects = this.readRegisteredObjects('syncRegisteredSchemas');
     if (allObjects.length === 0) return;
 
     let synced = 0;
@@ -1997,9 +2093,39 @@ export class ObjectQLPlugin implements Plugin {
         loadStandaloneActions = () => loadMany.call(meta, 'action');
       }
     } catch { /* no metadata service — registry objects still audit */ }
+    // [#9285] BOTH swallows are gone. The old spelling —
+    // `(() => { try { return ql.registry?.getAllObjects?.() ?? []; } catch { return []; } })()`
+    // — carried two independent inventions on one expression (`?.()` for a
+    // registry that does not implement the method, `catch` for one that
+    // throws), and handed the result to an audit that then ran against an
+    // invented empty object set. That is worse than silence: with no objects
+    // every handler declared ON an object reconciles as an "undeclared handler
+    // … REFUSED at dispatch", so an unreadable registry produced a page of
+    // false accusations against a healthy deployment. This inventory is
+    // warn-only and exception-proof BY CONTRACT (above: a diagnostic must never
+    // be the reason a kernel fails to boot), so it does not propagate — it
+    // reports once and skips, leaving `lastGovernanceFingerprint` untouched so
+    // the next successful run reports in full rather than being suppressed as
+    // "unchanged". `warn`, not `error`, per the AGENTS.md degradation-log-level
+    // rule: an audit that did not run is a FUNCTIONAL degradation — nothing
+    // here claims to have been persisted.
+    let objects: ServiceObject[];
+    try {
+      objects = this.readRegisteredObjects('runGovernanceInventory');
+    } catch (e: unknown) {
+      ctx.logger.warn(
+        '[action-governance] inventory SKIPPED — the object registry could not be read, so this run audited nothing: ' +
+          'registered handlers with no declaration (REFUSED at dispatch, ADR-0110 D3) and declared actions with no ' +
+          'handler are neither found nor named. Deliberately NOT audited against an empty object set — that would ' +
+          'report every object-declared action as an undeclared handler. The audit re-runs at the next boot or on the ' +
+          'next `metadata:reloaded`; fix the registry error named here.',
+        { error: e instanceof Error ? e.message : String(e) },
+      );
+      return;
+    }
     this.lastGovernanceFingerprint = await runActionGovernanceInventory({
       registered: ql.listRegisteredActions(),
-      objects: (() => { try { return ql.registry?.getAllObjects?.() ?? []; } catch { return []; } })(),
+      objects,
       loadStandaloneActions,
       logger: ctx.logger,
       lastFingerprint: this.lastGovernanceFingerprint,


### PR DESCRIPTION
Fixes #9285

`ObjectQLPlugin` read the registered object set in three places, all spelled
`this.ql.registry?.getAllObjects?.() ?? []`. That expression folds three different
facts into one value:

1. the registry answered, and holds no objects;
2. the engine exposes no `registry` at all;
3. the registry exposes no `getAllObjects` — a **structural** omission that never
   throws, so it is invisible precisely when it is wrong.

Only (1) is truthfully *"no objects"*. This applies the inherited adjudication, it
does not re-argue it: #8895 ruled the family **discriminate or propagate**, #9002
applied it to the two delete-cascade seams, #9154 to the roll-up summary index
(PR #9284). Triage promoted this card straight to `pm:queue` for that reason.

## The ruling, per seam

All three seams now read through one shared private helper,
`ObjectQLPlugin.readRegisteredObjects(seam)`, which **throws** rather than
inventing — naming the consequence — and adds **no `catch` of its own**, so a
registry that *throws* propagates its own error verbatim. What each caller does
with that failure is decided at the seam, and the three answers differ:

| seam | method | disposition | why |
|---|---|---|---|
| 2 | `syncRegisteredSchemas` | **propagate** | its next line is `if (allObjects.length === 0) return;`, so an invented empty answer meant **no registered object's schema was synced to any driver** — no table created, no column added — silently, at boot, with the plugin reporting a clean start. Failing the boot is more truthful than starting against a store whose DDL never ran. |
| 1 | `reconcileFederatedBindings` | **report at `error`, then degrade** | the pass exists to *name* the federated objects it could not bind — its own docblock: *"a boot with nothing to report says nothing"* — so an unreadable registry making it report nothing is exactly the silence it was written to prevent. It stays exception-proof: it is a post-hoc reconciliation deliberately run after every `start()` so a late-connecting datasource is not a boot failure, and propagating would turn a diagnostic into the hard stop it was written not to be. `error`, not `warn`, matches the level its existing report already uses for the same consequence. |
| 3 | `runGovernanceInventory` | **report at `warn`, then skip** | warn-only and exception-proof **by contract** (*"a diagnostic must never be the reason a kernel fails to boot"*), so it must not propagate. |

Seam 1's degradation is proportionate rather than merely convenient: on every boot
that does not set `skipSchemaSync`, seam 2 has already read the same registry
successfully before `kernel:ready`, so a failure at seam 1 is a registry that
became unreadable *mid-boot*, not the boot-wide condition seam 2 now catches.

### Seam 3's double swallow — addressed explicitly

Seam 3 carried **two independent inventions on one expression**:
`?.()` for a registry that does not implement the method, **and** a wrapping
`try { … } catch { return [] }` for one that throws. A fix scoped to the `??`
class alone would have left a throwing registry indistinguishable from an empty
one. Both are gone.

The measurement that decided the disposition: feeding the audit an invented empty
object set is **worse than silence**. `collectEngineActionDeclarations` derives
declarations *from the objects*, so with none, every handler declared **on** an
object reconciles as an `"undeclared handler … REFUSED at dispatch"` — an
unreadable registry produced a page of **false accusations** against a healthy
deployment. So the seam does not audit a substitute set at all: it reports once and
returns, leaving `lastGovernanceFingerprint` untouched so the next successful run
reports in full rather than being suppressed as "unchanged". `warn` and not
`error` per the AGENTS.md degradation-log-level rule — an audit that did not run is
a **functional** degradation; nothing here claims to have been persisted.

### Deliberately untouched

The `objectsRegistered: … ?.length || 0` count in the `ObjectQL engine started`
info log, per the card and the dispatch. Judged benign, not left unexamined: a
wrong `0` there costs one advisory line and no data. It is the one executable
occurrence of the old shape the probe below still reports.

## ① Boot-time reachability — what was MEASURED

Triage deliberately did not establish this, and the fix direction does not hinge on
it. Re-derived on this tree rather than inherited, and it **still holds**:

- `SchemaRegistry.getAllObjects()` (`registry.ts`) is a walk over the in-memory
  `objectContributors` `Map`, calling `resolveObject(fqn)`. `resolveObject` returns
  `undefined` on every failure branch it models — no contributors, no owner (after
  a `console.warn`) — and never throws. Below it the fold is
  `foldExtenders` → `foldExtendersOntoDefinition` → `tenantAuthoredScalars` /
  `mergeObjectDefinitions` / `scalarOverridesPackagedBase`: spreads, `Set` adds and
  comparisons. **No I/O, no driver, no `throw` on the measured path.**
- The `?.` links are dead for a real engine too, which the card did not state:
  `ObjectQL.registry` is a plain getter returning `this._registry`, a
  **field-initialized** `SchemaRegistry`, and `getAllObjects` is a prototype method.
  Neither optional link can short-circuit for any engine constructed by
  `ObjectQLPlugin.init()` or handed in as `opts.ql` (typed `ObjectQL`).

**So: the seams are dormant against real data, and this is a structural close, not
a live-defect fix.** The reach that *is* real is a duck-typed `ql` — an incomplete
test double, which is the #9154 blind spot below. The tests therefore inject the
failure **at the registry itself**, and the injection is the statement that nothing
shipped reaches these seams today.

This does not change the verdict — *discriminate unreadable from empty* is right
either way — but it does mean the urgency is "keep the fail-open shape from coming
back", not "a boot is failing today".

## ② The `vi.mock` blind spot — classified, not blanket-patched

#9154 measured 83 reds across 9 suites when `?.()` came off `buildSummaryIndex`.
**Measured here: zero reds, in both directions.**

- `@objectstack/objectql` full suite, before: **217 files / 3836 tests, all green**.
  After: **218 / 3853, all green** (the +1 file and +17 tests are this PR's pin).
  No suite went red — so there is **nothing to classify as either "a double to
  complete" or "real coverage"**, and nothing was blanket-added to any double.
- Why the two cards differ, measured rather than assumed: the 12 suites carrying
  `vi.mock('./registry')` in this package drive `engine.ts` (which is where
  `buildSummaryIndex` lives), never `ObjectQLPlugin`'s three seams.
- The plugin's own reach was checked repo-wide: **every** construction of
  `ObjectQLPlugin` outside this package is `new ObjectQLPlugin()` or
  `new ObjectQLPlugin({ …options })` with **no `ql`**, so `init()` builds a real
  `ObjectQL` with a real `SchemaRegistry`. Not one consumer injects a duck-typed
  engine. Verified across `packages/runtime`, `packages/metadata`,
  `packages/metadata-protocol`, `packages/rest`, `packages/client`,
  `packages/services/*`, `packages/cli` and `packages/qa/*`.
- The consumer sweep ran anyway rather than resting on that reading — see below.

The one place a double now has to answer deliberately is this PR's **own** pin
file, and it answers by *failing*: two of its three injections install a registry
that cannot serve `getAllObjects`, which is the exact indistinguishability the card
is about, asserted rather than papered over.

## Reverse verification — predicted vs observed

Predictions were written before running. Resolution note: the pin imports
`./plugin.js`, a **same-package relative** specifier vitest resolves to
`src/plugin.ts` — no `exports`-mediated hop into `dist/`, so no rebuild leg applies
to this ablation. Each leg reverted **only** its own seam, leaving the tests and the
shared helper in place; the tree was then restored and `git diff HEAD` proved
**empty** before the restoration leg was re-run.

| leg | predicted | observed | match |
|---|---|---|---|
| **A** — seam 2 back to `?? []` | 3 red | **2 red**, 15 green | ⚠️ **partially falsified — see below** |
| **B** — seam 1 back to `?? []` | 4 red (with two *different* reasons by injection) | **4 red**, 13 green, both reasons exactly as predicted | ✅ |
| **C** — seam 3 back to the IIFE | 4 red | **4 red**, 13 green | ✅ |
| restoration | 17 green | **17 green** | ✅ |

Observed failure reasons, all as predicted:

- **A**: `AssertionError: promise resolved "undefined" instead of rejecting` (×2) —
  the read answers `[]`, the next line early-returns, the call resolves.
- **B**, `no-method` / `no-registry`: `expected [] to have a length of 1 but got +0`
  — the silent early return, zero error logs. **B**, `throws`:
  `promise rejected "Error: registry read exploded" instead of resolving` — a
  *different* reason, predicted in advance, because old seam 1 had no `catch`.
- **C**: `expected [] to have a length of 1 but got +0` (no SKIPPED warn) and
  `expected 'u:acct:ping' to be 'previous-run'` — the fingerprint overwritten with
  the **false accusation** against a declared action.

### The falsified prediction, and what was done about it

Leg A predicted 3 reds and produced 2. The test
*"hands a THROWING registry error to the caller, identity intact"* stayed **green
in both directions** — i.e. it pinned nothing about this change. The reason is a
real correction to how seam 2 was described: `?.` short-circuits on **absence**,
never on a throw, and seam 2 had **no `catch`** (unlike seam 3), so a throwing
registry already propagated there before this PR. **Seam 2's swallow was the
structural half alone.**

Rather than delete or quietly keep it, the test is **relabelled** as
*"a THROWING registry already propagated, and must keep propagating (preserved, not
fixed)"*, with the measurement recorded in the file header — because it still earns
its place: it fails the day someone "hardens" this read by wrapping it in a
`try/catch`, which is precisely how seam 3 acquired its second swallow.

## Gates — union derived on the final commit

`node scripts/pm/dispatch-gates.mjs` (no path arguments) against the **committed**
diff, re-derived on the final commit and **unchanged** from the first derivation.
All values below are from runs on `5da142ba7`, captured as `cmd > log 2>&1; EXIT=$?`
— never piped into `tail`, per #9552.

| gate | EXIT |
|---|---|
| `pnpm check:changeset-gate-self-tests` | 0 |
| `pnpm check:durability-log-level` | 0 |
| `pnpm check:objectui-changeset` | 0 |
| `node scripts/check-adr-0087-registration.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-empty-changeset.mjs` | 0 |
| `node scripts/check-engine-split-ratio.mjs` | 0 |
| `node scripts/docs-audit/check-affected-docs.mjs` | 0 |
| `pnpm check:query-options-erasure` | 0 |
| `pnpm check:type-check-coverage` | 0 |
| `pnpm check:type-check-debt --re-measure` | 0 |
| `pnpm check:engine-double-contract` | 0 |
| `pnpm check:where-matcher` | 0 |

`check:durability-log-level` stays green **and its census is unchanged** — neither
the read-invention baseline (`scripts/durability-read-invention.baseline.json`, no
`plugin.ts` entry before or after) nor the empty degradation baseline moved. That
is the #8845 blind spot re-confirmed across this fix, exactly as #9154 re-measured
it: this shape remains invisible to the gate, which is why the pin file exists.

**`check:type-check-debt --re-measure` caught a real regression and it was fixed at
the source, not at the ledger.** The new test file first added +1 raw tsc error to
`@objectstack/objectql`'s TEST_DEBT (355 → 356): an action's `body` is
`{ language, source }`, not a bare string. Re-measured after the fixture fix:
**355, with 0 errors attributable to this file** — the shrink-only ledger is
untouched, and raising it was never considered (maintainer-only).

## Suites

| package | result | EXIT |
|---|---|---|
| `@objectstack/objectql` (full, final commit) | 218 files / 3853 tests passed | 0 |
| `@objectstack/objectql` (baseline, before any edit) | 217 files / 3836 tests passed | 0 |
| pin file alone | 17 / 17 passed | 0 |
| `@objectstack/objectql typecheck` (`tsc --noEmit`, script name echoed) | pass | 0 |
| `@objectstack/runtime` | 170 files passed | 0 |
| `@objectstack/metadata` | 31 files / 603 tests passed | 0 |
| `@objectstack/metadata-protocol` | 121 passed + 2 skipped / 1669 passed | 0 |
| `@objectstack/rest` | 125 files / 2058 tests passed | 0 |
| `@objectstack/http-conformance` | 4 files / 72 tests passed | 0 |
| `@objectstack/client` | 23 files / 310 tests passed | 0 |

`@objectstack/http-conformance` failed once on
`Failed to resolve entry for package "@objectstack/runtime"` — that is the
**unbuilt-`dist/` prerequisite**, not a finding. It passed after building runtime.
The consumer suites resolve `@objectstack/objectql` through package `exports` into
`dist/`, so `dist/index.js` was confirmed to carry the fix (`readRegisteredObjects`
present) **before** those runs were read.

## Probe, with its positive control

A zero-hit grep is not a measurement, so the probe `getAllObjects\?\.\(\)` is shown
hitting the known sites first:

- **positive control**, same probe against `origin/main`'s `plugin.ts`: **4 hits** —
  `:664` (the deliberately-excluded log count), `:1144`, `:1214`, `:2002`.
- **after**, same probe against `HEAD`'s `plugin.ts`: **1 executable hit** — `:665`,
  the deliberately-excluded log count. The two other textual hits are **prose**:
  docblock/comment lines quoting the retired spelling so the next reader recognises
  it (the same thing `engine.ts:6946` does for #9154).
- **discriminator**: `plugin.ts` reports 6 total `getAllObjects` occurrences on
  `origin/main` against the 3 matching the fallback shape (10 on `HEAD` — the helper
  and its docblock), so the probe discriminates rather than matching everything.

## Scope

Clause ② was **not** reached and was not approached: no file under
`packages/spec/src/**` (only an `import type { ServiceObject }`, added so the seams
keep the exact element type they already inferred), no contract accept/reject
behaviour changed, no public surface widened. `syncRegisteredSchemas` propagating
instead of silently returning is a **boot** behaviour change, not a contract one.

Files changed: `packages/objectql/src/plugin.ts`,
`packages/objectql/src/plugin-registry-read-failure.test.ts` (new),
`.changeset/objectql-plugin-registry-read-seams.md` (new).


---
_Generated by [Claude Code](https://claude.ai/code/session_017qYPmkKEsfbWY1yVg83p8F)_