### PR TITLE
fix(plugin-audit): the NULL-tenant audit guard reads the session key the engine emits

### DIFF
--- a/.changeset/audit-tenant-fallback-reads-organization-id.md
+++ b/.changeset/audit-tenant-fallback-reads-organization-id.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+fix(audit): the NULL-tenant guard on audit rows reads the session key the engine actually emits (#9516)
+
+`writeAudit`'s organization fallback read `sess.tenantId`. That key does not
+exist on the hook session: `ObjectQL.buildSession` constructs it as an object
+literal with a fixed key set (`userId`, `organizationId`, `positions`,
+`accessToken`, plus conditional flags) and no spread, and the deprecated
+`session.tenantId` alias (#3280) was removed repo-wide in the v11 major
+(#3290). The arm therefore resolved to `undefined`, which made the guard it
+belongs to unable to fire.
+
+That guard is load-bearing. Its own comment states the consequence: an audit
+row must never be written with `organization_id = NULL`, or the SecurityPlugin's
+RLS predicate hides it from everyone forever while the write reports success.
+The two cases the fallback covers are exactly the ones where the record cannot
+supply an organization — an object with no organization column at all
+(single-tenant stacks, ADR-0066 platform-global objects) and a row whose
+organization column is NULL or empty. On both, the row was stamped
+`organization_id: null` and became permanently invisible in the audit log UI.
+Nothing reported it: every `sys_audit_log` field is `readonly: true` so
+`validateRecord` skips it, and the write path is wrapped in swallow-and-report.
+
+Both readers of the removed alias in this package now read
+`sess.organizationId`. Precedence is unchanged at both sites: the audited
+record's own organization still wins over the acting session (#8707, honouring
+the ruling on #8287), and the `@mention` notification scope stays session-first
+— #8707's reasoning is about an audit row read through the record's tenant
+wall, which a notification is not, so only the key changed there.
+
+Deployments on a single-tenant stack, and any multi-tenant deployment auditing
+a platform-global object or a row with an empty organization column, stop
+accumulating audit rows that no one can read. Rows already written with a NULL
+organization are not repaired by this change.

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -126,7 +126,7 @@ describe('audit writers — organization_id stamping (#1532)', () => {
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: 'org-9' },
-      session: { tenantId: 'org-9', userId: 'user-1' },
+      session: { organizationId: 'org-9', userId: 'user-1' },
     });
 
     const audit = created.find((c) => c.object === 'sys_audit_log');
@@ -919,7 +919,7 @@ describe('audit writers — localized activity summaries (framework#3039)', () =
     object,
     input: { id: 'q-1' },
     result: { id: 'q-1', name: 'OC-00001' },
-    session: { tenantId: 'org-1', userId: 'user-1' },
+    session: { organizationId: 'org-1', userId: 'user-1' },
   });
 
   it('localizes verb + object label to the workspace locale (zh-CN)', async () => {
@@ -1017,7 +1017,7 @@ describe('audit writers — localized activity summaries (framework#3039)', () =
         body: 'hello',
         mentions: '["user-2"]',
       },
-      session: { tenantId: 'org-1', userId: 'user-1' },
+      session: { organizationId: 'org-1', userId: 'user-1' },
     });
     const mention = emits.find((e) => e.topic === 'collab.mention');
     expect(mention).toBeDefined();
@@ -1039,7 +1039,7 @@ describe('audit writers — localized activity summaries (framework#3039)', () =
       object: 'crm_lead',
       input: { id: 'l-1' },
       result: { id: 'l-1', name: 'Acme', owner_id: 'user-2' },
-      session: { tenantId: 'org-1', userId: 'user-1' },
+      session: { organizationId: 'org-1', userId: 'user-1' },
     });
     expect(emits.find((e) => e.topic === 'collab.assignment')).toBeUndefined();
   });
@@ -1111,7 +1111,7 @@ describe('audit writers — a lost audit row is reported at error (#5226)', () =
     object: 'crm_lead',
     input: { id },
     result: { id, name: 'Acme' },
-    session: { tenantId: 'org-1', userId: 'user-1' },
+    session: { organizationId: 'org-1', userId: 'user-1' },
   });
 
   it('logs at error — never warn — when the audit row cannot be written', async () => {
@@ -1176,7 +1176,7 @@ describe('audit writers — a lost audit row is reported at error (#5226)', () =
  * [#8707] Which organization an audit row is stamped with — the RECORD'S own,
  * honouring the maintainer's ruling on #8287.
  *
- * The precedence these cases pin is `recordOrgId ?? sess.tenantId`. Read the
+ * The precedence these cases pin is `recordOrgId ?? sess.organizationId`. Read the
  * pair together: the first four cases are the flip itself, the next three are
  * the RLS fallback the flip must not weaken (it is why the fallback exists at
  * all — an audit row with a NULL organization is hidden from everyone forever),
@@ -1211,7 +1211,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     const { audit, activity } = stampOf(created);
@@ -1233,7 +1233,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'lead-1' },
       result: true,
       previous: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-A');
@@ -1249,7 +1249,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'lead-1' },
       previous: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
       result: { id: 'lead-1', name: 'Acme Corp', organization_id: 'org-A' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-A');
@@ -1268,7 +1268,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
-      session: { tenantId: 'org-A', userId: 'user-1' },
+      session: { organizationId: 'org-A', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-A');
@@ -1287,7 +1287,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: null },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-B');
@@ -1302,7 +1302,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-B');
@@ -1314,7 +1314,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
     installAuditWriters(engine as any, 'test.audit');
 
     // The two cases the fallback was originally written for — a background job
-    // or sudo path with no `tenantId`, and better-auth's `activeOrganizationId`
+    // or sudo path with no active organization, and better-auth's `activeOrganizationId`
     // cache miss right after sign-in. Behaviour here is byte-identical to
     // before the flip: those sessions carry no tenant either way.
     await fire('afterInsert', {
@@ -1345,7 +1345,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-B');
@@ -1362,7 +1362,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', workspace_id: 'ws-1' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
     expect(stampOf(created).audit?.organization_id).toBe('ws-1');
 
@@ -1378,7 +1378,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
-      session: { tenantId: 'org-B', userId: 'user-1' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
     });
     expect(stampOf(missing.created).audit?.organization_id).toBe('org-A');
   });
@@ -1404,7 +1404,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'org-self' },
       previous: { id: 'org-self', name: 'Sub', parent_organization_id: 'org-parent' },
       result: { id: 'org-self', name: 'Subsidiary', parent_organization_id: 'org-parent' },
-      session: { tenantId: 'org-self', userId: 'user-1' },
+      session: { organizationId: 'org-self', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-self');
@@ -1448,7 +1448,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'key-1' },
       previous: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: false },
       result: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: true },
-      session: { tenantId: 'org-actor', userId: 'user-1' },
+      session: { organizationId: 'org-actor', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-key');
@@ -1473,7 +1473,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'key-1' },
       previous: { id: 'key-1', name: 'ci', revoked: false },
       result: { id: 'key-1', name: 'ci', revoked: true },
-      session: { tenantId: 'org-actor', userId: 'user-1' },
+      session: { organizationId: 'org-actor', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-actor');
@@ -1497,7 +1497,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       object: 'crm_lead',
       input: { id: 'lead-1' },
       result: { id: 'lead-1', name: 'Acme', workspace_id: 'ws-1', about_org_id: 'org-about' },
-      session: { tenantId: 'org-actor', userId: 'user-1' },
+      session: { organizationId: 'org-actor', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-about');
@@ -1518,9 +1518,192 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
       input: { id: 'key-1' },
       previous: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: false },
       result: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: true },
-      session: { tenantId: 'org-actor', userId: 'user-1' },
+      session: { organizationId: 'org-actor', userId: 'user-1' },
     });
 
     expect(stampOf(created).audit?.organization_id).toBe('org-actor');
+  });
+});
+
+/**
+ * [#9516] The detector this file was missing: the writer must read the session
+ * key the ENGINE ACTUALLY EMITS.
+ *
+ * `ObjectQL.buildSession` (`packages/objectql/src/engine.ts`) builds the hook
+ * session as an object literal with a fixed key set — `userId`,
+ * `organizationId`, `positions`, `accessToken`, plus the conditional
+ * `isSystem` / `actor` / `skipTriggers` / `skipAutomations` / `preserveAudit`.
+ * There is no spread, so no other key can arrive. `session.tenantId` was a
+ * deprecated alias (#3280) REMOVED repo-wide in the v11 major (#3290).
+ *
+ * The writer nevertheless read `sess.tenantId` for the RLS fallback, so the
+ * fallback could never fire: on an object with no organization column, or a
+ * row whose organization column is NULL, the audit row was stamped
+ * `organization_id: null` — and the SecurityPlugin's RLS predicate then hides
+ * it from everyone, permanently, while the write itself succeeds.
+ *
+ * Nothing went red for two reasons, and BOTH are closed here:
+ *   • every `sys_audit_log` field is `readonly: true`, so `validateRecord`
+ *     skips it and a null tenant is accepted silently; the write path is
+ *     additionally wrapped in swallow-and-report;
+ *   • every fixture in this file hand-built its session with `tenantId`, a
+ *     dialect the engine cannot produce. The fallback cases passed because the
+ *     TEST spoke the removed alias, not because the code worked. Those
+ *     fixtures now spell `organizationId`, so they exercise the real shape.
+ *
+ * Read the two halves together: the non-null pins are the guard the card is
+ * about, and the "alias is not resolved" pin is what goes red the day someone
+ * reintroduces `sess.tenantId` as a belt-and-braces fallback — a phantom read
+ * that would silently mask a genuinely broken caller.
+ */
+describe('audit writers — the writer reads the session key the engine emits (#9516, #3290)', () => {
+  const AUDITED = {
+    ...MULTI_TENANT,
+    // No organization column of its own: a single-tenant stack, or an
+    // ADR-0066 platform-global object. `resolveRecordOrganizationField`
+    // returns null for both, so `recordOrgId` is undefined and the SESSION
+    // arm is the only thing standing between this row and a null stamp.
+    crm_lead: ['id', 'name'],
+  };
+
+  it('stamps a non-null organization on an object with NO organization column', async () => {
+    const { engine, fire, created } = makeEngine(AUDITED);
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      // Exactly what `buildSession` emits for an org-bearing caller.
+      session: { organizationId: 'org-B', userId: 'user-1' },
+    });
+
+    const audit = created.find((c) => c.object === 'sys_audit_log')?.row;
+    // The assertion the card is about, stated as the consequence rather than
+    // the mechanism: a null here is the permanently-invisible ledger row.
+    expect(audit?.organization_id).not.toBeNull();
+    expect(audit?.organization_id).toBe('org-B');
+    expect(audit?.tenant_id).toBe('org-B');
+    // The activity mirror is read through the same wall and must agree.
+    expect(created.find((c) => c.object === 'sys_activity')?.row.organization_id).toBe('org-B');
+  });
+
+  it('stamps a non-null organization when the record\'s organization column is NULL', async () => {
+    const { engine, fire, created } = makeEngine({
+      ...MULTI_TENANT,
+      crm_lead: ['id', 'name', 'organization_id'],
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: null },
+      session: { organizationId: 'org-B', userId: 'user-1' },
+    });
+
+    const audit = created.find((c) => c.object === 'sys_audit_log')?.row;
+    expect(audit?.organization_id).not.toBeNull();
+    expect(audit?.organization_id).toBe('org-B');
+  });
+
+  it('keeps #8707\'s precedence — the record\'s own organization still wins', async () => {
+    const { engine, fire, created } = makeEngine({
+      ...MULTI_TENANT,
+      crm_lead: ['id', 'name', 'organization_id'],
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    // This case is GREEN before and after the #9516 fix on purpose: it pins
+    // that fixing WHICH KEY the fallback arm reads did not disturb the ORDER
+    // the #8707 ruling set (honouring the maintainer's ruling on #8287).
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { organizationId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(created.find((c) => c.object === 'sys_audit_log')?.row.organization_id).toBe('org-A');
+  });
+
+  it('⛔ does not resolve the v11-removed `tenantId` alias', async () => {
+    const { engine, fire, created } = makeEngine(AUDITED);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // A session in the REMOVED dialect. The engine cannot produce one, so the
+    // only way this shape reaches the writer is a caller that is itself broken
+    // — and honouring it here would hide that. This pin goes red the day
+    // `sess.tenantId` is reintroduced as a fallback arm; `pnpm check:org-identifier`
+    // cannot see that reintroduction when the receiver is spelled `sess`.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      session: { tenantId: 'org-B', userId: 'user-1' } as any,
+    });
+
+    expect(created.find((c) => c.object === 'sys_audit_log')?.row.organization_id).toBeNull();
+  });
+
+  // ── the second site: the @mention notification scope ──────────────────
+  //
+  // Lower stakes than the audit stamp — it feeds `resolveWriteLocale` and the
+  // emitted envelope's `organizationId` rather than a row behind an RLS wall —
+  // but the same removed key, dead the same way. Note the ORDER here is
+  // session-first and stays that way: #8707's ruling reasons about an AUDIT
+  // ROW read through the record's own tenant wall, which is not what a mention
+  // notification is. Only the key changes at this site.
+  const setupMentions = (schemas: Record<string, string[] | Record<string, any>> = SINGLE_TENANT) => {
+    const { engine, fire } = makeEngine(schemas);
+    const emits: any[] = [];
+    installAuditWriters(engine as any, 'test.audit', {
+      getMessaging: () => ({
+        emit: async (e: any) => {
+          emits.push(e);
+          return {};
+        },
+      }),
+    });
+    return { fire, emits };
+  };
+
+  const aComment = (extra: Record<string, any> = {}) => ({
+    object: 'sys_comment',
+    input: {},
+    result: {
+      id: 'c-1',
+      thread_id: 'crm_lead:l-1',
+      author_id: 'user-1',
+      author_name: 'Alice',
+      body: 'hello',
+      mentions: '["user-2"]',
+      ...extra,
+    },
+  });
+
+  it('scopes the @mention notification to the session\'s organization', async () => {
+    const { fire, emits } = setupMentions();
+
+    await fire('afterInsert', {
+      ...aComment(),
+      session: { organizationId: 'org-1', userId: 'user-1' },
+    });
+
+    const mention = emits.find((e) => e.topic === 'collab.mention');
+    expect(mention).toBeDefined();
+    expect(mention.organizationId).toBe('org-1');
+  });
+
+  it('falls back to the comment row\'s organization when the session carries none', async () => {
+    const { fire, emits } = setupMentions();
+
+    // GREEN before and after — the fallback limb's order is unchanged.
+    await fire('afterInsert', {
+      ...aComment({ organization_id: 'org-2' }),
+      session: {},
+    });
+
+    expect(emits.find((e) => e.topic === 'collab.mention')?.organizationId).toBe('org-2');
   });
 });

--- a/packages/plugins/plugin-audit/src/audit-writers.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.ts
@@ -1295,7 +1295,7 @@ export function installAuditWriters(
       userId ?? (typeof sess.actor === 'string' && sess.actor.trim() ? sess.actor.trim() : null);
     // [#8707, honouring #8287's ruling] The audited RECORD'S OWN organization
     // wins; the acting session's active organization is the fallback. ⛔ Do not
-    // flip this back to `sess.tenantId ?? recordOrgId`.
+    // flip this back to `sess.organizationId ?? recordOrgId`.
     //
     // An audit row describes a change to a RECORD, and it is read through
     // `sys_audit_log`'s own tenant wall. Stamped with the ACTOR's active
@@ -1318,9 +1318,10 @@ export function installAuditWriters(
     //      `resolveRecordOrganizationField`, which returns null for both);
     //   2. a row whose organization column is NULL/empty;
     // and the record's own organization answers on the two cases the fallback
-    // was written for — background jobs / sudo paths with no `tenantId`, and
-    // better-auth's `activeOrganizationId` cache miss right after sign-in —
-    // exactly as it did before, since those sessions carry no tenant either way.
+    // was written for — background jobs / sudo paths with no active
+    // organization, and better-auth's `activeOrganizationId` cache miss right
+    // after sign-in — exactly as it did before, since those sessions carry no
+    // organization either way.
     //
     // What this does NOT change: the overwhelming majority of writes, where the
     // actor's active organization IS the record's. Under the `isolated` posture
@@ -1337,7 +1338,24 @@ export function installAuditWriters(
       return typeof v === 'string' && v.length > 0 ? v : undefined;
     };
     const recordOrgId: string | undefined = readRecordOrg(ctx.result) ?? readRecordOrg(before);
-    const tenantId: string | undefined = recordOrgId ?? sess.tenantId;
+    //
+    // [#9516] The fallback arm reads `organizationId` — the ONLY name the
+    // engine emits. `ObjectQL.buildSession` builds the hook session as a fixed
+    // key-set literal with no spread, and the `session.tenantId` alias (#3280)
+    // was removed repo-wide in the v11 major (#3290). This arm spelled the
+    // removed name, so it resolved to `undefined` and the guard above could
+    // never fire: every case it names — no organization column, NULL column —
+    // stamped `organization_id: null` and went permanently invisible behind the
+    // RLS predicate, silently, because `sys_audit_log`'s fields are all
+    // `readonly: true` (so `validateRecord` skips them) and this whole path is
+    // wrapped in swallow-and-report.
+    //
+    // It survived a careful review of exactly these lines because #8707
+    // reordered the two arms without evaluating either one: reordering two
+    // expressions does not tell you whether they resolve. The pins in
+    // `audit-writers.test.ts` (#9516 block) are what check this comment against
+    // the mechanism it describes — keep them if you touch this line.
+    const tenantId: string | undefined = recordOrgId ?? sess.organizationId;
 
     let oldValue: Record<string, any> | null = null;
     let newValue: Record<string, any> | null = null;
@@ -1626,7 +1644,7 @@ export function installAuditWriters(
     const actorName = row.author_name ?? null;
     const bodyPreview = String(row.body ?? '').slice(0, 240);
     const sess: any = (ctx as any).session ?? {};
-    const tenantId: string | null = sess.tenantId ?? row.organization_id ?? null;
+    const tenantId: string | null = sess.organizationId ?? row.organization_id ?? null;
     const commentId = row.id != null ? String(row.id) : null;
 
     for (const uid of userIds) {


### PR DESCRIPTION
Fixes #9516

`writeAudit`'s NULL-tenant guard read a session key the engine does not emit, so the guard could never fire. Both readers of the removed alias in this package now read `sess.organizationId`, and the drift is now pinned by tests instead of by prose.

## Verified on current `main` before editing

`ObjectQL.buildSession` (`packages/objectql/src/engine.ts`) builds the hook session as an object literal with a fixed key set and **no spread**, so no other key can arrive:

```ts
const session = {
  userId: execCtx.userId,
  organizationId: execCtx.tenantId,
  positions: execCtx.positions,
  accessToken: execCtx.accessToken,
  ...((execCtx as any).isSystem ? { isSystem: true } : {}),
  ...
};
```

Its own comment records the removal, and `packages/spec/src/data/hook.zod.ts` agrees (it declares `organizationId` and documents the alias as removed in the v11 major):

> The deprecated `session.tenantId` alias (#3280) was removed here in v11 (#3290) — the driver-layer `execCtx.tenantId` knob is a separate axis and stays.

The premise holds: `sess.tenantId` resolved to `undefined`, and the expression was exactly `recordOrgId`.

## What was broken

The block's own comment states the consequence it exists to prevent — an audit row must never be written with `organization_id = NULL`, or the SecurityPlugin's RLS predicate hides it forever while writes keep succeeding. The two cases it names are precisely the ones where the record cannot supply an organization: an object with no organization column at all (single-tenant stacks, ADR-0066 platform-global objects) and a row whose organization column is NULL or empty. On both, `recordOrgId` is `undefined`, the dead arm contributed nothing, and the row was stamped null.

Nothing went red: every `sys_audit_log` field is `readonly: true` so `validateRecord` skips it, and the write path is wrapped in swallow-and-report.

## The changes

**1. Both sites now read `sess.organizationId`.**

- `writeAudit` — `recordOrgId ?? sess.organizationId`. **#8707's precedence is unchanged**: the audited record's own organization still wins, honouring the ruling on #8287. Only which key the second arm reads has changed.
- `writeCommentMentions` — `sess.organizationId ?? row.organization_id ?? null`. **Order deliberately unchanged here too.** #8707's reasoning is about an audit row read through the record's own tenant wall; a mention notification is not that, so applying the flip to this site would be inventing a ruling for a different consumer. Only the key changed.

**2. The detector pin (`#9516` block in `audit-writers.test.ts`).**

The card's named assertion — an audit row on an object with no organization column, under a session that *has* an active organization, lands non-null — plus the NULL-column twin, a pin that the removed alias is **not** resolved, and the mention-path equivalent. Two further cases are green before and after on purpose, pinning that the fix did not disturb either site's precedence.

**3. Every fixture in the file was re-spelled to `organizationId`.**

This is the substantive half. All 19 session fixtures in `audit-writers.test.ts` hand-built their session as `{ tenantId: ... }` — a dialect `buildSession` cannot produce. The fallback cases passed **because the test spoke the removed alias**, not because the code worked. Re-spelled, they exercise the shape the engine actually emits.

## Reverse verification

Prediction was recorded before running anything.

| Step | Tree | Result |
|---|---|---|
| A — baseline | pristine `main`, original fixtures | **268 passed / 268**, 17 files |
| B — pins + re-spell, fix NOT applied | predicted 10 red | **11 red** / 263 passed |
| C — fix applied | all green | **274 passed / 274** |
| D — ablation (alias restored, both sites) | predicted same 11 | **exactly the same 11 red** |

**Step A is the measurement of why this drifted: 268 tests, every one green, with the dead arm live.** Not one could see it.

Prediction versus observation: I predicted 10 red at step B and observed 11. The extra one is instructive rather than noise — `stamps organization_id on multi-tenant tables when the column exists` (#1532) builds its engine from `MULTI_TENANT`, which declares only `sys_audit_log` and `sys_activity`. The audited object `crm_lead` is absent from the schema map, so `resolveRecordOrgField` returns null and `recordOrgId` is undefined no matter what the result row carries — the case rode entirely on the session arm despite putting `organization_id: 'org-9'` on the record. So **7** pre-existing tests, not 6, were silently held up by a fixture-only key.

Ablation markers removed and proved: `grep -c OS_ABLATION_9516` = 0, repo-wide `OS_ABLATION` = 0, tree clean at the final commit.

## The repo-wide sweep — census

`git grep -rn "session\.tenantId\|sess\.tenantId"` across the whole repo. Live **code readers** of the removed alias, all repos:

| Location | Verdict |
|---|---|
| `packages/plugins/plugin-audit/src/audit-writers.ts:1340, :1629` | **the two fixed here** — the only live readers in the repo |
| `packages/objectql/src/engine.test.ts:540, :553`; `packages/runtime/src/http-dispatcher.test.ts:3972` | correct usage — pins asserting the key is **absent** (`expect(session.tenantId).toBeUndefined()`) |
| `packages/objectql/src/engine.ts:2762`; `packages/objectql/src/plugin.ts:943`; `packages/runtime/src/action-execution.ts:853, :865`; `packages/spec/src/data/hook.zod.ts:617` | comments documenting the removal |
| `CHANGELOG.md`, `packages/*/CHANGELOG.md`, `content/docs/**`, `.changeset/audit-row-record-organization-stamp.md` | historical prose |
| `packages/plugins/plugin-audit/src/read-audit.test.ts`; `comment-access-hooks.test.ts` | **not this axis** — `ReadContext.tenantId` and the `ExecutionContext` principal envelope, the driver-layer knob that legitimately stays |
| `objectui` | zero occurrences |

So the two fixed here were the whole live population. No other dead reader to file.

## Out-of-scope finding, filed not ridden

**#9691** — `check-org-identifier` is a hard-fail gate scoped to `packages/` whose header asserts "the scanned surfaces carry ZERO occurrences today". Its detector anchors on the literal receiver name:

```js
const PATTERN = /\bsession\s*\??\.\s*tenantId\b/;
```

The shipped code binds the receiver to a local named `sess`, so the gate scored **0 hits on the unfixed file that contained 2 live dead-alias reads** (measured with the gate's own pattern over its own `maskComments` projection). It printed `OK (2053 author-facing source file(s), no removed session.tenantId alias)` on every PR for the entire period. Distinct from #9444/#9496, which fixed this gate's comment-masking hole. Not fixed here — it lives in `scripts/`, outside this card's scope.

## Why this survived, and why the pin is the point

The comment above the first site is unusually careful about precedence and even carries a directive written on the assumption that the arm is live — "⛔ Do not flip this back to `sess.tenantId ?? recordOrgId`". #8707 changed the **order** of the two arms and recorded its reasoning in full, but **reordering two expressions does not evaluate either of them**, so an arm that had already stopped resolving stayed invisible through a careful review of exactly this code.

That is the shape worth naming: prose sitting next to a mechanism with nothing checking that they agree. The one-line key change is the small half. The pins, and the fixture re-spell that stops the tests from speaking a dialect the engine cannot produce, are what make the declaration enforceable.

## Changeset

`.changeset/audit-tenant-fallback-reads-organization-id.md`, patch on `@objectstack/plugin-audit`. Owed because this changes behaviour on real deployments: single-tenant stacks, and any multi-tenant deployment auditing a platform-global object or a row with an empty organization column, stop accumulating unreadable audit rows. Rows already written with a NULL organization are not repaired by this change — noted explicitly in the changeset.

## Gates

Union re-derived after the final commit with `node scripts/pm/dispatch-gates.mjs` off `git merge-base` (c07d6e8b9), run at **`eb60bc99f`** with a clean tree.

Green: `check:nul-bytes`, `check:org-identifier`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-cross-package-test-inputs`, `check-affected-docs`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:type-check-debt --re-measure` (33 ledger entries, none above its recorded number), `check:i18n` (plugin-audit bundles in sync), plus `pnpm --filter @objectstack/plugin-audit test` and `typecheck`.

`check:i18n` first reported a **prerequisite failure**, not drift — a fresh worktree has no built CLI. Built `@objectstack/cli` and re-ran; green, exit code read directly rather than through a pipe, as that gate's own message warns.

Beyond the derived union I added `check:org-identifier` because this diff is precisely about the alias it guards, and `check:nul-bytes` per standing policy.

## Coordination

Untouched, per the dispatch note: `read-audit.ts`, and `sys-audit-log.object.ts`'s view definitions (#9539 awaits a maintainer privacy ruling).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y26DJEHSBhhAQ6wwfsHNza)_