### PR TITLE
docs(service-automation): See Also names the two docs pages it lands on (#9668)

### DIFF
--- a/.changeset/automation-readme-link-labels.md
+++ b/.changeset/automation-readme-link-labels.md
@@ -1,0 +1,27 @@
+---
+"@objectstack/service-automation": patch
+---
+
+`service-automation`'s README labels its two docs links with the pages they land on (#9668)
+
+Two entries in the README's See Also list named artifacts that are not what the link
+resolves to. `Flow Builder Guide` lands on the Automation **section index**
+(`content/docs/automation/index.mdx`, `title: Automation`); `Trigger Reference` lands on
+the automation **schema** reference index (`content/docs/references/automation/index.mdx`,
+`title: Automation Protocol`), which lists every automation schema — approval, flow,
+state-machine, webhook and eleven more — not triggers. Both destinations resolve and both
+are the right section-level target for a package README, so the mismatch is on the label
+axis, not the destination axis, and only the labels changed.
+
+Each new label is the destination page's own `title` frontmatter, with a gloss compressed
+from that page's own `description`, so the label is checkable against the page rather than
+invented. **No URL changed**, and in particular the plausible-looking
+`references/studio/flow-builder` was not adopted: it is a **Studio** reference, not the
+automation service's.
+
+The third docs link in this README — `Flows`, at the end of the flow-node section — was
+verified and left alone. It points at a specific page (`content/docs/automation/flows.mdx`,
+`title: Flow Metadata`), and that page does carry the per-node `config` reference, loop and
+parallel containers, subflows, waits and error handling that the sentence promises.
+
+Documentation only: no API, behaviour or type surface changes.

--- a/packages/services/service-automation/README.md
+++ b/packages/services/service-automation/README.md
@@ -456,5 +456,7 @@ Apache-2.0. See [LICENSING.md](../../../LICENSING.md).
 ## See Also
 
 - [@objectstack/spec/automation](../../spec/src/automation/)
-- [Flow Builder Guide](https://docs.objectstack.ai/docs/automation)
-- [Trigger Reference](https://docs.objectstack.ai/docs/references/automation)
+- [Automation](https://docs.objectstack.ai/docs/automation) — the automation docs section: hooks, flows,
+  workflows, approvals, webhooks, connectors
+- [Automation Protocol](https://docs.objectstack.ai/docs/references/automation) — the complete schema
+  reference for the automation protocol


### PR DESCRIPTION
Fixes #9668

Shape **B** as ruled: the two labels change, **neither URL does**.

## The relabel, derived from the destination pages

Each new label is the destination page's own `title` frontmatter — checkable against the
page rather than invented — with a gloss compressed from that same page's `description`.

| was | now | destination | page `title` |
|---|---|---|---|
| `Flow Builder Guide` | `Automation` | `/docs/automation` | **Automation** (`content/docs/automation/index.mdx`) |
| `Trigger Reference` | `Automation Protocol` | `/docs/references/automation` | **Automation Protocol** (`content/docs/references/automation/index.mdx`) |

The second index lists thirteen schema cards — approval, bpmn-interop, builtin-node-config,
control-flow, execution, flow, flow-function, io-node-config, node-executor,
schemaless-node-config, state-machine, time-relative-trigger, webhook — so `Trigger
Reference` named one card out of thirteen. `Automation Protocol` names the page.

`content/docs/references/studio/flow-builder.mdx` was **not** adopted for the first link.
It is a Studio reference; a `service-automation` README pointing there would send the reader
to a different product surface. PR #9662's dev declined it and I read both pages and agree.

## Sweep: is this the only label/destination mismatch in the published READMEs? (issue H2)

Swept all **150 outbound links across the 60 published markdown files** — the same
population `check:published-readme-links` reads, via its own exported `publishedDocs`
helper, so the census matches the gate's own output link-for-link. Twelve are
`docs.objectstack.ai` links, i.e. the ones whose destination title can be read:

| README | label | lands on | page title | verdict |
|---|---|---|---|---|
| `create-objectstack:90` | `Your First Project` | `getting-started/your-first-project` | Your First Project | exact |
| `knowledge-ragflow:5` | `Knowledge Protocol` | `protocol/knowledge` | Knowledge Protocol | exact |
| `service-knowledge:8` | `Knowledge Protocol` | `protocol/knowledge` | Knowledge Protocol | exact |
| `plugin-audit:343` | `Access depth` | `permissions/permission-sets#access-depth...` | Permission Sets | honest — the label names the **anchored heading**, not the page |
| `plugin-audit:397` | `` `services.audit` reference `` | `kernel/runtime-services/audit-service` | services.audit | honest — label contains the title verbatim |
| `service-analytics:194` | `Analytics Guide` | `data-modeling/analytics` | Analytics Datasets | honest — a page, not an index, and it is the analytics guide in `data-modeling` |
| `service-cache:151` | `Cache Service` | `kernel/contracts/cache-service` | ICacheService Contract | honest — the page's own opening sentence is "The Cache Service provides…" |
| `service-i18n:196` | `I18n Standard` | `protocol/kernel/i18n-standard` | Internationalization Standard | honest — same words |
| `service-job:186` | `Queue Service` | `kernel/runtime-services/queue-service` | services.queue | honest — human name for the same slot |
| `service-automation:178` | `Flows` | `automation/flows` | Flow Metadata | honest — see below |
| `service-automation:459` | `Flow Builder Guide` | `automation` (**index**) | Automation | **the defect — fixed here** |
| `service-automation:460` | `Trigger Reference` | `references/automation` (**index**) | Automation Protocol | **the defect — fixed here** |

**These two are the only ones of this class in the whole published corpus, and they are the
only two docs links in it that resolve to a section `index.mdx` at all.** Nothing folded in,
nothing carded: every other label describes what it lands on.

The other 138 links were classified too: 94 relative, 34 external, 10 bare fragments. The 18
relative links whose label claims a package name were checked mechanically against the target
directory's `package.json` `name` — **18 checked, 0 mismatched**; the remaining seven of that
shape point into `packages/spec/src/...` subpaths, which `check:published-readme-exports`
already owns.

## The third link is good (issue H4)

`service-automation/README.md:178` — "see the maintained reference — **[Flows]**" — points at
`content/docs/automation/flows.mdx` (`title: Flow Metadata`), a **page, not an index**. The
sentence promises "every other node's `config`, and … loops, parallel blocks, subflows, waits
and error handling"; the page carries `### Node Types`, `### Node Structure`, `### Node
Examples`, `### Loop container`, `### Parallel block`, `### Try / catch / retry`, `## Durable
pause and resume`, `### Nested pause — pausing inside a subflow` and `## Error Handling`.
Label and destination agree. Left alone deliberately.

## No gate for this class, and here is the measurement (issue H3)

The approximate check — flag a link whose text shares no significant token with the
destination page's `title` — was run over the twelve rows above. It flags
`plugin-audit:343`, `plugin-audit:397`, `service-cache:151`, `service-job:186` and
`service-automation:178`, of which **all five are correct link text**, and catches the two
real defects: **five false positives to two true positives on the only population it has.**
Two further reasons it is the wrong instrument here:

1. The gate's document reader strips code spans (shared with `check:adr-links` and
   `check:doc-anchors`, deliberately, so all three read a document the same way). Link labels
   routinely *contain* code spans — `plugin-audit:397`'s label is `` `services.audit` reference ``
   and reads as the bare word "reference" after stripping. A label checker would need its own
   second reading of every document, which is exactly the duplicated-derivation that
   `check:published-readme-links` was careful to avoid.
2. The tightest variant that scores 2/2 here — "a docs link resolving to an `index.mdx` must
   carry that index's `title`" — has a population of **two links in the entire corpus**, both
   fixed by this PR, and it would fire on any deliberate section-level label
   (`the Automation docs`) that a human would call correct.

So: **no gate.** The honesty of link *text* is a judgement, and the corpus is small enough
(150 links, 12 of them checkable this way) that a re-sweep is cheap — the script that produced
the table above is thirty lines on top of the gate's own exports. Recorded on the card so the
next person does not re-derive it.

## Changeset

`.changeset/automation-readme-link-labels.md`, `patch` on `@objectstack/service-automation`
— `private` unset and `README.md` in `files`, so this text renders on the npm package page.
Same precedent as #9531, #9541, #9636, #9662.

## Verification

All at `16722a7c5` (the final commit):

```
✓ check:published-readme-links — 150 outbound link(s) across 60 published markdown file(s):
    0 root-relative, 12 docs.objectstack.ai page(s) resolved (0 via redirect), 1 anchor(s) verified
✓ check:nul-bytes — 6237 text files, no raw ASCII control bytes
✓ check:changeset-gate-self-tests · check:objectui-changeset
✓ check-empty-changeset (1 declaring changeset added) · check-changeset-no-major · check-adr-0087-registration
✓ check:test-source-alias · check:type-source-resolution
✓ scripts/docs-audit/check-affected-docs.mjs (242 cases)
```

Gate family derived from the changed paths with
`node scripts/pm/dispatch-gates.mjs .changeset/automation-readme-link-labels.md packages/services/service-automation/README.md`
after the edit, not recalled; `check:published-readme-links` added on top because it is the
gate that governs this file.

One gate **not** green locally: `check:published-readme-exports` fails in a fresh worktree
because it reads every package's built `dist/*.d.ts` and none exist before a full workspace
build — it names `packages/types/README.md` and `packages/verify/README.md`, files this PR
does not touch. It reads **fenced code blocks only**; this diff adds and edits **zero** fenced
blocks, so its verdict cannot move on this change. CI builds first and will run it.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_