### PR TITLE
fix(ci): a cross-repo closing keyword aimed at a foreign PULL REQUEST is refused, not honoured

### DIFF
--- a/.github/workflows/cross-repo-issue-closer.yml
+++ b/.github/workflows/cross-repo-issue-closer.yml
@@ -307,6 +307,13 @@ jobs:
             // already stated the requirement; only the code was missing.
             const failures = [];
 
+            // Targets that are not issues AT ALL. Kept apart from `failures`
+            // above because the two need opposite remedies: a failure is an API
+            // refusal a re-run can clear, this one is a defect in the merged
+            // PR's own body that no re-run will ever change. Fusing them would
+            // send the reader off to re-run a job that is going to refuse again.
+            const malformed = [];
+
             // The backlink this PR leaves, identified so a SECOND run can see
             // it. The marker is scoped to one pull request and is therefore
             // STABLE across runs — one PR leaves one backlink, however many
@@ -333,6 +340,47 @@ jobs:
                 const { data: issue } = await github.rest.issues.get({
                   owner: t.owner, repo: t.repo, issue_number: t.number,
                 });
+
+                // A pull request is ALSO an issue to this endpoint. Every PR
+                // answers `GET /repos/{owner}/{repo}/issues/{N}` with `state`,
+                // `state_reason` and the rest, plus a `pull_request` key that
+                // nothing here used to read (#9711) — the key is ABSENT on a
+                // real issue, present as an object on a PR, so its truthiness
+                // is the whole test. The target regex takes any `owner/repo#N`
+                // and PR and issue numbers share one sequence, so a body saying
+                // `Fixes owner/repo#4500` where 4500 is a pull request would
+                // have made this loop comment on that PR and CLOSE it.
+                //
+                // GitHub's own closing-keyword parser — the behaviour this
+                // workflow exists to carry across repository boundaries — never
+                // closes a pull request; `Fixes #N` aimed at a PR leaves a
+                // reference and nothing else. So the keyword is a MALFORMED
+                // instruction, and it is refused OUT LOUD rather than skipped:
+                // this file's ten exit paths were arrived at by fixing one
+                // quiet one after another, and a quiet `continue` would have
+                // been the eleventh. The refusal is also the conservative half
+                // of an asymmetry — closing a pull request drops its
+                // merge-queue membership and any armed auto-merge in the same
+                // step, and neither comes back by itself.
+                //
+                // Placed BEFORE the `state === 'closed'` branch on purpose: a
+                // merged pull request reads `state: 'closed'` with
+                // `state_reason: null` from this very endpoint (measured on
+                // objectstack-ai/objectstack#9143), which that branch reads as
+                // "no objection recorded" and answers with a backlink comment.
+                // A guard sitting after it would still write on somebody else's
+                // pull request.
+                if (issue.pull_request) {
+                  malformed.push({ key, url: issue.pull_request.html_url });
+                  core.warning(
+                    `${key} is a PULL REQUEST, not an issue — ${prUrl} declares it FIXED, but GitHub's own `
+                    + `closing-keyword parser never closes a pull request, so this workflow does not either. `
+                    + `Nothing was commented on and nothing was closed. Re-running cannot fix a keyword that `
+                    + `can never fire: point the reference at the issue it meant.`,
+                    { title: 'Cross-repo closing keyword names a pull request' },
+                  );
+                  continue;
+                }
 
                 // "Already closed" is NOT one situation, and the three causes
                 // that reach here do not deserve the same treatment (#9643).
@@ -433,7 +481,7 @@ jobs:
               }
             }
 
-            if (failures.length === 0) {
+            if (failures.length === 0 && malformed.length === 0) {
               core.info(`All ${targets.size} cross-repo target(s) handled: closed, or already closed and linked.`);
               return;
             }
@@ -442,10 +490,23 @@ jobs:
             // notice branch uses, for the same reasons: the summary carries the
             // full list a human needs, `setFailed` carries the conclusion that
             // makes anyone open the run at all.
+            //
+            // Both classes are red, and each says what to do about ITSELF: a
+            // refusal is retried, a malformed reference is rewritten. Green
+            // with an annotation was the alternative for the malformed class,
+            // and this file's own history rejects it — 2334 runs, every one of
+            // them `run_attempt` 1 and 99 of the last 100 green, so a green run
+            // of this job has never been opened by anybody. An annotation on a
+            // green post-merge run is the silent path with extra steps, and a
+            // declared close that can never happen is exactly what #9595 made
+            // red for.
             const failedKeys = failures.map((f) => f.key).join(', ');
             const failedList = failures.map((f) => `- \`${f.key}\` —— ${f.lost} 未完成：${f.reason}`).join('\n');
-            try {
-              await core.summary.addRaw([
+            const malformedKeys = malformed.map((m) => m.key).join(', ');
+            const malformedList = malformed.map((m) => `- \`${m.key}\` —— 这个编号是一个 pull request：${m.url}`).join('\n');
+            const summaryLines = [];
+            if (failures.length > 0) {
+              summaryLines.push(
                 '## ⚠️ 跨仓库 issue 没能收口',
                 '',
                 `本次合并声明了 ${targets.size} 个跨仓库关闭目标，其中 ${failures.length} 个没有完成：`,
@@ -456,16 +517,45 @@ jobs:
                 '- 原因排除后可以直接 re-run 本 job：已经关闭的目标不会被重复关闭，已经留下过本 PR 反链的目标也不会被重复评论。',
                 '- 401/404 通常意味着 `CROSS_REPO_ISSUE_TOKEN` 对目标仓库没有 `issues: write`，而不是目标不存在 —— GitHub 对无权访问的仓库回 404。',
                 '',
-              ].join('\n')).write();
+              );
+            }
+            if (malformed.length > 0) {
+              summaryLines.push(
+                '## ⛔ 关闭关键字指向的是 pull request，不是 issue',
+                '',
+                `本次合并声明的 ${targets.size} 个跨仓库关闭目标里，有 ${malformed.length} 个的编号是 pull request：`,
+                '',
+                malformedList,
+                '',
+                '- 它们没有被评论，也没有被关闭。GitHub 自己的关闭关键字解析器从不关闭 pull request，本工作流也不会 —— 关掉一个 PR 会在同一步里丢掉它的 merge queue 成员资格和已经武装的 auto-merge，两者都不会自己回来。',
+                `- 这不是 re-run 能解决的故障：写错的是 ${prUrl} 的正文。把引用改成它真正想关的那个 issue 编号，或者手工关掉那个 issue。`,
+                '',
+              );
+            }
+            try {
+              await core.summary.addRaw(summaryLines.join('\n')).write();
             } catch (summaryError) {
               // Same asymmetry as the notice branch: the summary is the richer
               // channel, the conclusion the reliable one. Losing the richer one
               // must not restore the silence.
               core.info(`Could not write the job summary: ${summaryError.message}`);
             }
-            core.setFailed(
-              `${failures.length} of ${targets.size} cross-repo target(s) were NOT finished by this merge: `
-              + `${failedKeys}. Finish them by hand (fixed by ${prUrl}) — an open one needs closing, an `
-              + `already-closed one needs this PR's link on it — or re-run this job once the cause is `
-              + `cleared. The full list, with what each one is missing, is in this run's job summary.`,
-            );
+            const verdict = [];
+            if (failures.length > 0) {
+              verdict.push(
+                `${failures.length} of ${targets.size} cross-repo target(s) were NOT finished by this merge: `
+                + `${failedKeys}. Finish them by hand (fixed by ${prUrl}) — an open one needs closing, an `
+                + `already-closed one needs this PR's link on it — or re-run this job once the cause is `
+                + `cleared. The full list, with what each one is missing, is in this run's job summary.`,
+              );
+            }
+            if (malformed.length > 0) {
+              verdict.push(
+                `${malformed.length} of ${targets.size} cross-repo closing keyword(s) in this merged pull `
+                + `request name a PULL REQUEST rather than an issue: ${malformedKeys}. GitHub's own keyword `
+                + `parser never closes a pull request and this workflow does not either, so nothing was `
+                + `commented on and nothing was closed. Re-running this job will refuse them again — what `
+                + `has to change is the reference in ${prUrl}'s body.`,
+              );
+            }
+            core.setFailed(verdict.join(' '));

--- a/scripts/check-cross-repo-closer-outcome.mjs
+++ b/scripts/check-cross-repo-closer-outcome.mjs
@@ -56,7 +56,12 @@
 // ## What is asserted, and what is deliberately not
 //
 // Asserted: the target parse (which keyword spellings qualify, which forms do
-// not, that a same-repo reference is skipped), and the OUTCOME of every exit --
+// not, that a same-repo reference is skipped), the target KIND (#9711: a pull
+// request is also an issue to `issues.get`, so `owner/repo#N` naming a PR
+// reaches the loop like anything else -- the scenarios pin that it is REFUSED
+// rather than closed, and that the refusal happens before the already-closed
+// branch can leave a comment on somebody else's pull request), and the OUTCOME
+// of every exit --
 // which of `core.setFailed` / `core.warning` / a job summary fires, and which
 // API calls were made. Those are the properties both cards are about.
 //
@@ -198,7 +203,21 @@ function makeDoubles({ body, token, issues = {}, prCommentError = null, summaryE
       // `state_reason` is nullable on a real closed issue -- objectui#4478
       // answers `null` from this very endpoint -- so the default models that
       // rather than inventing a value the API does not promise.
-      return { data: { state: t.state ?? 'open', state_reason: t.stateReason ?? null } };
+      //
+      // `pull_request` is how the same endpoint says the number is a PULL
+      // REQUEST, and it is modelled as ABSENCE rather than as `undefined`
+      // because that is what was measured: objectstack-ai/objectstack#9716 (a
+      // PR) answers `{ url, html_url, diff_url, patch_url, merged_at }`, and
+      // #9711 (an issue) carries no such key at all. A fixture that always
+      // spelled the key would let a truthiness test pass here that the real
+      // API would fail. (#9711)
+      return {
+        data: {
+          state: t.state ?? 'open',
+          state_reason: t.stateReason ?? null,
+          ...(t.pullRequest ? { pull_request: t.pullRequest } : {}),
+        },
+      };
     },
     async listComments({ owner, repo, issue_number: n }) {
       const key = `${owner}/${repo}#${n}`;
@@ -384,6 +403,27 @@ const FOREIGN = ['objectstack-ai/objectui#456', 'my-org/some.repo#22', 'third/pa
 
 /** The target the already-closed scenarios (L2, L6-L9) work on. */
 const CLOSED_TARGET = 'objectstack-ai/objectui#456';
+
+/** The target the PULL REQUEST scenarios (L12, L13) work on (#9711). */
+const PR_TARGET = 'my-org/some.repo#22';
+
+/**
+ * The `pull_request` key GitHub returns when an issue number is a pull request.
+ *
+ * Copied from a real response rather than invented: `GET /repos/
+ * objectstack-ai/objectstack/issues/9716` answers exactly these five fields,
+ * and `.../issues/9711` -- an issue -- answers with the key absent. The loop
+ * reads only its truthiness, but the shape is pinned so that a change in what
+ * the script reads out of it (`html_url` reaches the job summary) fails here
+ * instead of printing `undefined` into somebody's run.
+ */
+const PR_KEY = {
+  url: 'https://api.github.com/repos/my-org/some.repo/pulls/22',
+  html_url: 'https://github.com/my-org/some.repo/pull/22',
+  diff_url: 'https://github.com/my-org/some.repo/pull/22.diff',
+  patch_url: 'https://github.com/my-org/some.repo/pull/22.patch',
+  merged_at: null,
+};
 const PR_URL = 'https://github.com/objectstack-ai/objectstack/pull/1234';
 
 /**
@@ -730,6 +770,84 @@ export const SCENARIOS = [
       t(r.log.warning.length === 0, 'L11 run 2 warns about nothing -- an idempotent re-run is a normal outcome'),
     ],
   },
+  {
+    id: 'L12',
+    name: 'the target is an OPEN pull request -- refused out loud, never closed (#9711)',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'pat',
+      issues: { [PR_TARGET]: { state: 'open', pullRequest: PR_KEY } },
+    }),
+    check: (r, t) => [
+      t(r.calls.get.includes(PR_TARGET), 'L12 reads the target -- the kind is only knowable from the response'),
+      t(
+        !r.calls.update.some((u) => u.key === PR_TARGET),
+        "L12 does NOT close the pull request -- GitHub's own keyword parser never closes one, and this "
+          + 'workflow exists to carry that behaviour across repos, not to exceed it. A closed PR also loses '
+          + 'its merge-queue membership and any armed auto-merge in the same step, and neither returns by itself',
+      ),
+      t(!r.calls.comment.some((c) => c.key === PR_TARGET), 'L12 posts nothing on the foreign pull request either'),
+      t(
+        !r.calls.list.includes(PR_TARGET),
+        'L12 does not even list its comments -- the target KIND settles it before idempotency can matter',
+      ),
+      t(
+        r.log.warning.some((w) => w.message.includes(PR_TARGET) && /PULL REQUEST/.test(w.message)),
+        'L12 ANNOUNCES the refusal and names the target -- a quiet `continue` here would have been the '
+          + "eleventh silent exit in a file whose ten known ones were each found by somebody reading it",
+      ),
+      t(
+        r.log.failed.length === 1,
+        `L12 fails the job: the merged body declares a close that can never fire, and this run is the only `
+          + `thing that will ever know; got ${r.log.failed.length}`,
+      ),
+      t((r.log.failed[0] ?? '').includes(PR_TARGET), 'L12 setFailed names the malformed target'),
+      t(
+        !/re-run this job once the cause is cleared/.test(r.log.failed[0] ?? ''),
+        'L12 verdict does not send the reader to re-run -- unlike every other red path here the refusal is '
+          + 'deterministic, and only the PR body can change it',
+      ),
+      t((r.log.summary[0] ?? '').includes(PR_TARGET), 'L12 summary carries it too, with the PR url'),
+      t(r.calls.update.length === 2, `L12 still closes the other two targets -- isolation holds; got ${r.calls.update.length}`),
+      t(r.threw === null, 'L12 does not let anything escape the script'),
+    ],
+  },
+  {
+    id: 'L13',
+    name: 'the target is a MERGED pull request -- refused BEFORE the already-closed branch comments on it (#9711)',
+    scenario: () => ({
+      body: MIXED_BODY,
+      token: 'pat',
+      // A merged pull request answers `state: 'closed'` with
+      // `state_reason: null` from the issues endpoint -- measured on
+      // objectstack-ai/objectstack#9143. That is the very fixture L9 uses to
+      // prove a closed ISSUE gets its backlink, which makes this scenario the
+      // ORDERING test: a `pull_request` guard placed after the state branch
+      // would sail past it and comment on somebody else's pull request.
+      issues: {
+        [PR_TARGET]: {
+          state: 'closed',
+          stateReason: null,
+          comments: [],
+          pullRequest: { ...PR_KEY, merged_at: '2026-08-16T14:56:58Z' },
+        },
+      },
+    }),
+    check: (r, t) => [
+      t(
+        !r.calls.comment.some((c) => c.key === PR_TARGET),
+        'L13 leaves NO backlink on a merged pull request -- the path L9 pins for a closed issue must not be reached here',
+      ),
+      t(
+        !r.calls.list.includes(PR_TARGET),
+        'L13 never reaches the idempotency check, which is what proves the kind guard runs FIRST',
+      ),
+      t(!r.calls.update.some((u) => u.key === PR_TARGET), 'L13 does not touch its state'),
+      t(r.log.failed.length === 1, `L13 fails the job for the same reason L12 does, got ${r.log.failed.length}`),
+      t((r.log.failed[0] ?? '').includes(PR_TARGET), 'L13 setFailed names it'),
+      t(r.calls.update.length === 2, `L13 still closes the other two, got ${r.calls.update.length}`),
+    ],
+  },
 ];
 
 // ── The battery ─────────────────────────────────────────────────────────────
@@ -850,9 +968,11 @@ const MUTATIONS = [
   {
     id: 'M1',
     what: 'the post-loop verdict is downgraded back to a warning (the #9595 defect, restored)',
-    from: 'core.setFailed(\n  `${failures.length} of ${targets.size}',
-    to: 'core.warning(\n  `${failures.length} of ${targets.size}',
-    expect: ['L3', 'L4', 'L5'],
+    from: "core.setFailed(verdict.join(' '));",
+    to: "core.warning(verdict.join(' '));",
+    // Since #9711 the verdict carries both red classes, so this one mutation
+    // now has to be caught by an API refusal AND by a malformed target.
+    expect: ['L3', 'L4', 'L5', 'L12', 'L13'],
   },
   {
     id: 'M2',
@@ -921,6 +1041,27 @@ const MUTATIONS = [
     from: 'failures.push({ key, reason, lost });',
     to: 'failures.push({ key, reason });',
     expect: ['L10'],
+  },
+  {
+    id: 'M12',
+    what: 'the pull-request guard is dropped, so a keyword aimed at a foreign PR comments on it and CLOSES it (#9711)',
+    from: 'if (issue.pull_request) {',
+    to: 'if (false) {',
+    expect: ['L12', 'L13'],
+  },
+  {
+    id: 'M13',
+    what: 'a refused pull-request target stops being recorded, so the run refuses it and still reports green',
+    from: 'malformed.push({ key, url: issue.pull_request.html_url });',
+    to: '',
+    expect: ['L12', 'L13'],
+  },
+  {
+    id: 'M14',
+    what: 'the refusal is downgraded to an info line, so nothing annotates the run it happened in',
+    from: 'core.warning(\n        `${key} is a PULL REQUEST',
+    to: 'core.info(\n        `${key} is a PULL REQUEST',
+    expect: ['L12'],
   },
   {
     id: 'M7',


### PR DESCRIPTION
Fixes #9711

Branched after PR #9716 landed (squashed to `6f40ed736`), so its harness is the base this extends rather than something this collides with. Gate union re-run on the final commit `ab1084d93`, all green — see "Verification".

## H1 leads: the target is reachable, and the response already says what kind it is

Reachability first, severity second. The keyword has to qualify before anything else matters, and it does: the extraction regex is

```js
`\\b(?:${KEYWORDS})\\s+([\\w.-]+)\\/([\\w.-]+)#(\\d+)\\b`
```

so the target key is `owner/repo#N` where `N` is digits and nothing else. Pull requests and issues share **one** number sequence per repository, so every PR number is a well-formed target. Nothing downstream asked what kind of thing `N` was.

What `issues.get` returns was read from live responses on this repo, never by exercising a foreign PR — nothing was closed or commented on while testing:

| request | answer |
|---|---|
| `GET /repos/objectstack-ai/objectstack/issues/9716` (a pull request) | `state: open`, `state_reason: null`, **`pull_request: { url, html_url, diff_url, patch_url, merged_at }`** |
| `GET .../issues/9711` (an issue) | same fields, and the `pull_request` key is **absent** — not null |
| `GET .../issues/9143` (a **merged** pull request) | `state: closed`, `state_reason: null`, `pull_request.merged_at: 2026-08-16T14:56:58Z` |

The key is absent on an issue and an object on a PR, so its truthiness is the whole test — read out of the response the loop already has, no second API call (ruling 2), and therefore no new API surface for the harness to model (ruling 3).

Row three is why the guard sits **before** the already-closed branch, and it upgrades the card: since #9716 a merged foreign PR would not merely have been closed, it would have taken the `state_reason: null` path — read as "no objection recorded" — and had a backlink comment stranded on it. So the defect had two grades:

- target is an **open** PR → comment, then `issues.update({ state: 'closed' })`. The severe one: merge-queue membership and any armed auto-merge are gone in the same step, and neither returns by itself.
- target is a **merged or closed** PR → a permanent "fixed by this PR" comment on somebody else's pull request.

`L12` and `L13` pin one each, and `L13` is specifically the ordering test — a guard placed after the state branch passes `L12` and fails `L13`.

## H2: how loud — red, argued from this file's doctrine rather than from the PM's lean

Recorded as a failure and passed to `setFailed` after the loop. The three options were weighed on what the ten exit paths already do, and the deciding question is not "was something lost" but **"was a declared deliverable left undone, with this run the only thing that knows"**:

- Green rows are green because the declaration is *satisfied*: the close happened (rows 1, 6, 8), or the work order the run could still deliver was delivered (row 2, token absent), or — the closest counter-precedent — `not_planned` (`L7`), where the issue **is** closed, the author wanted it closed, and only the stated reason disagrees.
- Red rows are red because something the merge declared did not happen and no other channel reports it (rows 3, 4, 7, 9, 10).

A pull-request target is in the second class, not the `L7` class. Nothing about the declaration is satisfied: the merged body says it closes something, nothing was closed, nothing will ever be closed, and whatever real issue the author meant stays open. `L7`'s green rests on "the tracker already matches the author's belief"; here it never will.

The measured half of the argument, which is what makes green-with-an-annotation untenable rather than merely weaker: this job has **2334 runs, every one of them `run_attempt` 1**, and 99 of the last 100 concluded green (1 skipped). Nobody has ever re-run it and nobody opens its green runs. An annotation on a green post-merge run is the silent path with extra steps, and ruling 1 asks for a refusal the author actually learns about.

The third option — commenting on the foreign PR — is rejected on the workflow's own warrant: it exists to carry GitHub's in-repo behaviour across repository boundaries, and writing on another repo's pull request to complain about *our* authoring mistake is a new power, not that behaviour.

Red brings one obligation, and it is the mirror of the wording defect #9716 fixed: this red must not send the reader to the remedies that fit an API refusal. So the malformed targets are collected **apart** from `failures` and the post-loop verdict carries both classes, each stating its own remedy — retry a refusal, rewrite a bad reference. `L12` asserts the malformed verdict does not tell anyone to re-run the job.

Ruling 4 checked what red costs, re-derived live rather than inherited:

1. `GET /rulesets` → one active ruleset (12119582, `main`); its `required_status_checks` names six contexts (`TypeScript Type Check`, `Test Core`, `Dogfood Regression Gate`, `Build Core`, `Temporal Conformance (live PG + MySQL)`, `Lint and Repo Gates`) — this job is not among them. The rulesets endpoints do read from an agent seat (200), as PR #9679 corrected.
2. Trigger is `pull_request_target: [closed]` plus `if: github.event.pull_request.merged == true` — it runs only after a merge.
3. The repo's only two `workflow_run:` listeners are `publish-smoke.yml` (watches `Release`) and `merge-queue-triage.yml` (watches `CI`). Neither watches this workflow.

So red blocks nothing and wakes nothing; it is purely a conclusion a human reads, which is exactly the dial being set.

## H3: has it ever fired — no, in either spelling

Re-measured on a **third** independent window (the 1200 most recently *created* closed PRs, 1176 merged — #9595 used a created-desc window and #9643 an updated-desc one), with a port of the workflow's own regex self-tested against the harness fixture before being trusted:

- qualified **foreign** closing keywords: **0**
- qualified same-repo closing keywords (which the loop skips): 5 occurrences, none naming a pull request

Then the base rate of the underlying authoring mistake, in the spelling that *is* common — because "would anybody ever aim a closing keyword at a PR number" is the real question behind the branch:

- bare-form (`Fixes #N`) closing keywords in those same 1176 bodies: **1145 occurrences, 1129 distinct targets**, spanning `#4584`..`#9726`
- of those 1129 distinct targets, how many are pull requests: **0** (classified against 2400 enumerated PR numbers reaching down to `#4453`, so the enumeration covers the whole span)

Honest grading, then: **latent and never fired** — not active. Not once in three windows for the qualified form, and not once in 1129 chances for the form people actually write. The severity is carried entirely by the asymmetry of the outcome, not by its frequency.

## H4: is the same confusion anywhere else

Everything that reaches `issues.*` with a number taken from user-authored text was swept, in this repo and in `objectui`:

| consumer | number comes from | writes? | verdict |
|---|---|---|---|
| `cross-repo-issue-closer.yml` (this repo) | parsed from the merged PR body | comment + **close** | the defect — fixed here |
| `cross-repo-issue-closer.yml` (**objectui**) | same | comment + **close** | **same defect, and worse** — filed as objectstack-ai/objectui#5261 |
| `duplicate-fix-guard.yml` | parsed from PR bodies | no writes | inherits the confusion read-only: a PR number in a closing keyword would be compared as if it were a card. Worst case a spurious duplicate-claim red; 0 occurrences measured |
| `merge-queue-triage.yml` | `workflow_run` payload | comments on a PR | uses the issue/PR equivalence *deliberately* and correctly |
| `docs-drift-check.yml` | `context.issue.number` | comments on the event's own PR | not parsed from text |

The `objectui` finding is the substantive one: that repo carries a fork of this workflow from before the whole family landed — no `pull_request` guard, a bare `core.warning` where the failure verdict should be, the already-closed target skipped whole, and **no harness at all**. Its `thisRepo` is `objectui`, so its targets are in *this* repo: a merged PR there saying `Fixes objectstack-ai/objectstack#9716` would close that pull request here. Filed unassigned as objectstack-ai/objectui#5261 with the port route; not touched from this PR, since the fix has to land in the repo that owns the file.

One more divergence came out of the sweep and is filed as #9755, out of scope here: `duplicate-fix-guard.yml` accepts the optional colon (`Fixes: owner/repo#N`) and documents it as GitHub's syntax, while this workflow's regex requires whitespace immediately after the keyword — verified by running both regexes over the same bodies. That spelling takes exit path 1 here, whose green line is indistinguishable from a body with no cross-repo reference at all. Which parser is right is a question about GitHub, so it is a card rather than a rider.

## The change

```js
if (issue.pull_request) {
  malformed.push({ key, url: issue.pull_request.html_url });
  core.warning(`${key} is a PULL REQUEST, not an issue — ...`, {
    title: 'Cross-repo closing keyword names a pull request',
  });
  continue;
}
```

placed immediately after `issues.get` and before the `state === 'closed'` branch, plus the second list and a post-loop verdict that carries both classes. Exit paths 1 through 10 keep their behaviour byte for byte; this adds the eleventh, and it is loud:

| # | exit | verdict |
|---|---|---|
| 11 | target is a pull request | `core.warning` naming it, recorded, summary section, red after the loop — and the verdict says a re-run will refuse it again |

## Harness (ruling 3: extend it, do not work around it)

88 assertions over 16 scenarios → **105 over 18**; 11 mutations → **14**.

- `L12` — an **open** PR target: never closed, never commented on, not even listed (the kind settles it before idempotency can matter), announced, red, named in both the verdict and the summary, and the other two targets still close.
- `L13` — a **merged** PR target: the ordering test. Its fixture is exactly `L9`'s (closed, `state_reason: null`) plus the `pull_request` key, so `L9` proves that shape earns a backlink for an issue and `L13` proves it earns none for a pull request.
- The doubles model `pull_request` as **absence-or-object**, matching the measured API, so a fixture cannot pass a truthiness test the real response would fail. `PR_KEY` pins all five fields even though only truthiness is read, because `html_url` reaches the job summary.
- `M12` (guard removed), `M13` (the refusal stops being recorded, so the run refuses and still reports green), `M14` (the annotation downgraded to `core.info`) are new and each driven to red. `M1` follows the verdict's new shape and now has to be caught by an API refusal **and** by a malformed target: `['L3', 'L4', 'L5', 'L12', 'L13']`.

The self-test's anchor discipline earned its keep mid-change: rewriting the verdict made `M1`'s anchor a no-op, and the run failed with `M1: its anchor is present in the shipped script` while all 88 behaviour assertions were still green.

## Verification

Reverse verification, from the committed state, with the new battery pointed at **main's** pre-fix script through the module's documented `extractScript` / `judge` route: **11 failed assertions over exactly 2 scenarios** — the ordinary direction (red), and every failure names a new assertion rather than an incidental one. The two most telling lines are `L12 still closes the other two targets ... got 3` (the pre-fix script closes the pull request too) and `L13 leaves NO backlink on a merged pull request`.

Gate union derived from the actual changed paths with `node scripts/pm/dispatch-gates.mjs` rather than recalled, re-run on the final commit `ab1084d93` after the rebase:

```
check:cross-repo-closer-outcome               OK   (105 assertions / 18 scenarios)
check:cross-repo-closer-outcome --self-test   OK   (77 assertions / 14 mutations)
check:cross-package-test-inputs               OK
check:node-version                            OK
check:required-contexts                       OK
check:shard-attestation                       OK
check:workflow-status-functions               OK
check:nul-bytes                               OK
```

## Scope

`skip-changeset`: a workflow and its check script, nothing publishes — same as PRs #9594, #9645 and #9716 on this file.

Out-of-scope findings filed unassigned: objectstack-ai/objectui#5261 (the sibling repo's copy of this workflow) and #9755 (the colon divergence). Neither is addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_