### PR TITLE
fix(pm): close the block comment that swallowed dispatch-gates' maskComments re-export

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -500,6 +500,7 @@ export function resolveCheckToFiles(checkName, scriptsMap) {
  *
  * Re-exported because this tool's self-test drives the SAME masker the gates
  * run, not a copy of it.
+ */
 export { maskComments };
 
 /**
@@ -2181,6 +2182,24 @@ function selfTest() {
   t('a `//` inside a string does not start a comment', commentHints.includes('packages/metadata/src'));
   t('a quote inside a regex literal does not open a string', commentHints.includes('packages/client/src'));
   t('masking preserves every offset', maskComments(commented).length === commented.length);
+
+  // ...and the re-export of that masker is CODE, not comment text (#9640). The
+  // statement sits at the end of the longest docblock in this file, and a
+  // missing `*/` swallows it into prose that still parses: the module then has
+  // no `maskComments` export while its header says it has one, and nothing goes
+  // red — every gate stayed green over it until someone parsed for it. Asked of
+  // this file's own source with this file's own masker, which is what the
+  // docblock claims. Column 0 only, and a match the scan flags as literal is
+  // rejected, so no fixture spelling in this self-test can stand in for the
+  // statement.
+  const ownSource = readFileSync(new URL(import.meta.url), 'utf8');
+  const ownScan = scanSource(ownSource);
+  t(
+    'the maskComments re-export is code, not comment text',
+    [...ownSource.matchAll(/^export \{ maskComments \};$/gm)].some(
+      (m) => !ownScan.comment[m.index] && !ownScan.literal[m.index],
+    ),
+  );
 
   // The self-test boundary. The fixture puts a column-0 `}` inside a template
   // literal on purpose: that is the shape this tree really has (a check script


### PR DESCRIPTION
Fixes #9640

Shape 1 as ruled: the delimiter is restored and the re-export kept, plus a pin so the next edit to that docblock cannot swallow it again silently. Two hunks, no prose touched in the comment itself.

## What the runaway comment actually held

Parsed with the repo's own `scanSource`, not read. The span is lines 483-519 and holds exactly **one** code line:

```text
scripts/pm/dispatch-gates.mjs: block comment lines 483-519
   nested '/*' opener(s) inside it at line(s): 505
   SWALLOWED CODE  503: export { maskComments };
```

Line by line: 484-502 are the intended docblock; **503 is the casualty** — the re-export, which was comment text; 504 is blank; 505 is the `/**` that was meant to OPEN `SELF_TEST_DECL`'s docblock and is inert text instead (comments do not nest); 506-518 are that docblock's prose, still prose either way, so nothing there was lost; and 519's `*/`, written to close `SELF_TEST_DECL`'s docblock, is what actually closed the runaway span. `const SELF_TEST_DECL` at 520 and everything after it are live code, as the card said.

So `maskComments` is the sole casualty — shape 2 was available, and shape 1 is what landed.

## Before and after

```text
BEFORE   maskComments exported?  undefined      AFTER   maskComments exported?  function
         maskSelfTests exported? function               maskSelfTests exported? function
```

(Measured by importing the module with a path argument, so the CLI takes its `derive` branch instead of exiting — see the note at the bottom.)

## The self-test did not cover the guarantee its docblock states

It does now. Before this change the self-test passed **284 of 284 with the export absent**: every case drives the masker through the line-134 `import`, and nothing asked whether the module re-exports it. A re-export nothing tests breaks again the next time someone edits that comment, and #9639 edited that very comment last week.

The new case asks this file's own source with this file's own masker — matching at column 0 and rejecting any match the scan flags as literal, so no fixture spelling inside the self-test can stand in for the statement:

```text
✓ the maskComments re-export is code, not comment text
✓ dispatch-gates self-test: 285 cases pass.
```

Reverse-verified from the committed state by deleting the `*/` again — predicted direction, then observed:

```text
✗ the maskComments re-export is code, not comment text
✗ dispatch-gates self-test: 1 of 285 case(s) failed.     exit=1
maskComments exported?  undefined
```

Restored with `git checkout` to a clean tree.

## Gates

Derived from the changed path with the tool itself (`node scripts/pm/dispatch-gates.mjs scripts/pm/dispatch-gates.mjs`), run at `b557124c0`, the final commit:

```text
pnpm check:pm-dispatch-gates          ✓ dispatch-gates self-test: 285 cases pass.
pnpm check:cross-package-test-inputs  OK: 12 package(s) read outside themselves, all declared.
pnpm check:nul-bytes                  OK (scanned 6237 text file(s); no raw ASCII control bytes).
npx eslint scripts/pm/dispatch-gates.mjs --no-inline-config   exit 0
```

`skip-changeset`: `scripts/` publishes nothing.

## Two findings this turned up, filed not fixed

- **#9757** — the module dispatches its CLI at top level with no entry guard, so `import { maskComments } from './dispatch-gates.mjs'` still runs the tool and exits the importer. The card predicted this path would fail at call time as `undefined is not a function`; measured, it fails at import, before the consumer's first line. Left out of this PR deliberately: repairing it changes what `check:pm-dispatch-gates` measures (that gate spawns the CLI and holds the exit status only, so a mismatched guard reads as a silent pass), which is a second file and a second defect class. Precedent for the shape is #6566 → PR #6695.
- **#9758** — the H3 verdict. Swept all 4,595 JS/TS files with `scanSource`: this was the only instance on the tree, so the class does not earn a `check:*` family, but it is cheap and unambiguous as a local ESLint rule in the pattern `eslint.config.mjs` already uses three times. Recorded with the numbers rather than built here.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_