### PR TITLE
fix(pm): check-slot-lookup-ratchet declares the population it lints, so a source card derives it

### DIFF
--- a/scripts/check-slot-lookup-ratchet.mjs
+++ b/scripts/check-slot-lookup-ratchet.mjs
@@ -42,6 +42,64 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const BASELINE_PATH = 'scripts/slot-lookup-baseline.json';
 
+/**
+ * The POPULATION this gate re-measures, as the repo-relative subtree it really
+ * reads. Everything below is derived from it, so what the gate declares and
+ * what the gate scans cannot become two different facts.
+ *
+ * ## Why a gate declaring its own population is load-bearing (#9700, #9626)
+ *
+ * `scripts/pm/dispatch-gates.mjs` builds every dispatch's gate list by scanning
+ * each gate's own source for the path literals it operates on. Before this
+ * declaration, the only literals in this file were its OUTPUT
+ * (`scripts/slot-lookup-baseline.json`) and the ref the monotonicity check
+ * diffs against (`origin/main`) — neither of which is a file this gate reads.
+ * So the derivation scored this gate `silent` for every card in the tree: not
+ * "irrelevant", but "its sources name paths, none of which cover yours", which
+ * the residue summary calls its weakest claim and explicitly not a clearance.
+ *
+ * That cost real CI rounds on cards that could not have known to run it: #9391
+ * (a `priority:p0` auth guard that added five `getService` lookups typed `any`)
+ * and again PR #9695. Both went red in `Lint & Repo Gates` on a gate that
+ * appeared in NEITHER half of their dispatch's derivation.
+ *
+ * ## Why the subtree, and why it is the constant the target derives from
+ *
+ * The hint language `dispatch-gates` compares in is repo-relative paths with
+ * globs collapsed, so an extension glob carries no information there:
+ * `packages/**` + `/*.{ts,tsx,mts,cts}` is what ESLint needs, but that spelling
+ * is not even extractable as a hint (brace expansion is outside the scanner's
+ * accepted path charset) and collapses to something that matches no file. The
+ * declaration is therefore the SUBTREE, and the ESLint target is one
+ * concatenation away from it rather than a second literal — the same shape
+ * #9639 used for `check:doc-anchors` (`CONTENT_GLOB`, with its root derived),
+ * and for the same reason: a declaration that can drift from the scan is worse
+ * than none, because it replaces a silent gate with a lying one.
+ *
+ * ## The cost of declaring it, decided rather than assumed
+ *
+ * `packages/**` is broad: this gate is now named for every card whose surface
+ * is under `packages/`, and a card that edits a package README or manifest gets
+ * a lead it does not need. That trade is the one `CHANGE_KIND_GATES` already
+ * decided for the three structurally identical whole-tree ratchets in
+ * `dispatch-gates.mjs`, and it is decided the same way here — by what the gate
+ * costs to run needlessly. Measured on this tree: 46s, no build required, and a
+ * failure names the offending file and line. A seat that runs it needlessly
+ * loses seconds; a seat that is never prompted loses a CI round.
+ *
+ * Two things a seat prompted by this declaration needs to know, and neither is
+ * visible from a green `pnpm lint`:
+ *   • `pnpm lint` passing proves NOTHING for a file in the baseline — it is
+ *     grandfathered by `ignores`, so ESLint says nothing about new erasures
+ *     added to it. This ratchet is the only thing that sees them.
+ *   • the repair is to TYPE the lookup against its slot's contract. Never
+ *     `--update` the baseline upward; entries only ever go down.
+ */
+const POPULATION_GLOB = 'packages/**';
+
+/** What ESLint is asked to lint: every TS dialect inside the declared population. */
+const LINT_TARGET = `${POPULATION_GLOB}/*.{ts,tsx,mts,cts}`;
+
 const update = process.argv.includes('--update');
 const baseline = JSON.parse(readFileSync(resolve(repoRoot, BASELINE_PATH), 'utf8'));
 const baselinedFiles = new Set(Object.keys(baseline));
@@ -71,6 +129,28 @@ if (!eslintConfig.some(carriesRule)) {
   process.exit(2);
 }
 
+// The declaration above states what this gate READS, and a dispatch pastes it
+// into a prompt as a lead. It is only true while it agrees with the scope the
+// RULE is configured for — the config block's own `files`. Copies in two files
+// drift silently, so the agreement is asserted rather than assumed: if the rule
+// is ever rescoped (another extension, another root, a second block), this
+// refuses to run instead of measuring a population that no longer matches
+// either what `pnpm lint` enforces or what `dispatch-gates` was told.
+const ruleScopes = eslintConfig.filter(carriesRule).flatMap((entry) => entry.files ?? []);
+if (ruleScopes.length !== 1 || ruleScopes[0] !== LINT_TARGET) {
+  console.error(
+    'check-slot-lookup-ratchet: the declared population no longer matches the\n' +
+    'scope the rule is configured for.\n' +
+    `  declared here: ${LINT_TARGET}\n` +
+    `  rule is scoped to: ${ruleScopes.join(', ') || '(nothing)'}\n` +
+    'Update POPULATION_GLOB/LINT_TARGET in this file to match eslint.config.mjs.\n' +
+    'This declaration is read by scripts/pm/dispatch-gates.mjs to decide which\n' +
+    'cards are told to run this gate, so a stale one is a wrong lead, not a\n' +
+    'cosmetic mismatch — refusing rather than measuring the wrong set.',
+  );
+  process.exit(2);
+}
+
 const eslint = new ESLint({
   cwd: repoRoot,
   overrideConfigFile: true,
@@ -80,7 +160,7 @@ const eslint = new ESLint({
   allowInlineConfig: false,
 });
 
-const results = await eslint.lintFiles(['packages/**/*.{ts,tsx,mts,cts}']);
+const results = await eslint.lintFiles([LINT_TARGET]);
 
 const current = {};
 for (const result of results) {

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -2306,6 +2306,23 @@ function selfTest() {
   t('the doc-anchors gate reaches the content page population it declares', anchorHints.some((h) => hintCovers(h, 'content/docs/deployment/cli.mdx')));
   t('and does not thereby claim a path outside that population', !anchorHints.some((h) => hintCovers(h, 'packages/spec/src/index.ts')));
 
+  // The second gate of that class (#9700): a whole-tree ESLint ratchet whose
+  // only literals were its own baseline artifact and the ref it diffs against,
+  // so it scored `silent` for every card in the tree while being REQUIRED in
+  // lint.yml — twice at the cost of a p0's CI round (#9391, PR #9695). It now
+  // declares the subtree it lints. Read from the real gate, not a fixture: what
+  // is being pinned is that the tree still HAS the declaration.
+  const slotHints = extractWatchHints(readFileSync(join(ROOT, 'scripts/check-slot-lookup-ratchet.mjs'), 'utf8'));
+  t('the slot-lookup ratchet reaches the package source population it declares', slotHints.some((h) => hintCovers(h, 'packages/services/service-datasource/src/admin-routes.ts')));
+  // The negative half is the load-bearing one for a declaration this broad: a
+  // gate named on EVERY card is the louder version of naming none. `packages/**`
+  // must reach nothing outside `packages/`, and these three roots are where a
+  // widened extractor would have leaked it (measured in hintCovers' docblock:
+  // the rejected alternative takes one card from 7 matched families to 34).
+  t('and claims nothing under apps/', !slotHints.some((h) => hintCovers(h, 'apps/console/src/main.tsx')));
+  t('nor under examples/', !slotHints.some((h) => hintCovers(h, 'examples/crm/objects/account.object.ts')));
+  t('nor a content page', !slotHints.some((h) => hintCovers(h, 'content/docs/deployment/cli.mdx')));
+
   // ── A trailing sentence period is not part of the path (#8534, half two) ──
   //
   // Coupled to the rule above: the raw-prefix comparison reached the real file


### PR DESCRIPTION
Fixes #9700

`check:slot-lookup` is REQUIRED in `lint.yml`, and `dispatch-gates` scored it `silent`
for every card in the tree — the derivation's weakest verdict, explicitly not a
clearance. Two `priority:p0` cards paid a CI round for that (#9391, and PR #9695 again).

## H1 first, because a "no" would have changed the shape

The dispatched question was whether `check-slot-lookup-ratchet.mjs` names any population
root as a string literal at all. **It does** — inline at the call site:

```js
const results = await eslint.lintFiles(['packages/**/*.{ts,tsx,mts,cts}']);
```

But it was unreadable to the deriver, for a reason worth recording: `extractWatchHints`
accepts a path literal only if it matches its path charset, and brace expansion
(`{ts,tsx,mts,cts}`) is outside it. Even if accepted, glob collapse turns that spelling
into `packages//.ts…`, which covers no file. So the mechanism PR #9639 built reached to
within one character class of this gate and stopped — the literal existed and named the
right tree, in a syntax the hint language cannot represent.

Measured, on `origin/main`, the gate's entire hint set:

```
check:slot-lookup   names: scripts/slot-lookup-baseline.json, origin/main
```

Its OUTPUT, and the ref its monotonicity check diffs against. Neither is a file it reads.

## The fix — the #9639 template, plus a guard against the drift it warns about

`check-slot-lookup-ratchet.mjs` now declares `POPULATION_GLOB = 'packages/**'` and derives
the ESLint target from it (`LINT_TARGET`), so what the gate declares and what it scans are
one fact, exactly as `CONTENT_GLOB` did for `check:doc-anchors`.

One addition beyond that template: the population is spelled twice in this repo — here and
as the `files` scope of the `eslint.config.mjs` block that carries the rule. A declaration
that drifts from the scan replaces a silent gate with a lying one, so the agreement is
asserted at run time rather than assumed. A drifted declaration refuses (exit 2) and names
both spellings.

No `CHANGE_KIND_GATES` entry was added. The table's own stated deletion criterion for the
three structurally identical ratchets is "when a gate grows a literal naming its
POPULATION, the ordinary derivation names it" — this is that, done directly. The card's
note about `--self-test` "names all five convention gates" therefore does not apply: the
convention section is untouched.

## H3 — the real population, and whether declaring it is honest

The scanned set is every TS dialect under `packages/` (tests included; `node_modules` and
`dist` excluded), and it is identical to the scope the ESLint rule is configured for —
both are `packages/**/*.{ts,tsx,mts,cts}`. So the declaration is the true population, not
a convenient approximation.

It is also broad, and that cost is stated rather than hidden. The hint language compares
collapsed paths, so extension precision cannot survive into it: of the reach this
declaration adds, **89.7% is TS files the gate really lints**; the remaining 10.3% is
`.json`, `.md` and extension-less files under `packages/`, which now get a lead they do not
need. That trade is the one `CHANGE_KIND_GATES` already decided for the three whole-tree
test-file ratchets, decided the same way here — by what the gate costs to run needlessly.
Measured on this tree: **53s, no build required**, and a failure prints the offending file
and line. A seat that runs it needlessly loses seconds; a seat never prompted loses a CI
round.

## H2 — both directions, measured over 110 families x 6249 tracked files

| | before | after |
|---|---|---|
| watch-hint (gate, file) pairs | 20988 | 25739 (+4751, **zero lost**) |
| families gaining coverage | — | exactly 1 |
| top-level roots of every gained pair | — | `packages/` only |

The negative direction is the load-bearing half: **every one of the 4751 gained pairs is
under `packages/`**. Across 22 probed card surfaces, the 10 under `packages/` each gain
exactly one family (3 to 4, 12 to 13, …) and the 12 outside it — `apps/`, `examples/`,
`content/`, `scripts/`, `.changeset`, `.github/workflows`, `docs/adr`, `skills/`,
`docker/` — gain nothing. For contrast, #9639's rejected alternative measured +139084 pairs
and took one card from 7 matched families to 34.

Acceptance test, on the file surface of the p0 that paid for this:

```
$ node scripts/pm/dispatch-gates.mjs packages/services/service-datasource/src/admin-routes.ts
  - pnpm check:slot-lookup   [lint.yml]   matched via …/admin-routes.ts ⇢ gate source 'packages/**'
```

## Reverse verification — both ablations, run from the committed state

- **the new self-test case pins the declaration**: reverting only the ratchet file and
  keeping the cases gives `✗ dispatch-gates self-test: 1 of 288 case(s) failed`, and the
  failing case is the positive one. (The three negative cases pass under ablation by
  construction — they are the "no false leads" half.)
- **the coupling guard is live**: mutating the declaration to `packages/core/**` makes the
  gate exit 2 naming both spellings, instead of silently measuring a smaller population.
- **the derived target scans the identical set**: `107 unswept site(s) in 25 file(s)`
  before and after, byte-identical verdict.

## Gates, all at 6c58cc46b

`pnpm check:slot-lookup` ✓ · `pnpm check:pm-dispatch-gates` ✓ (288 cases) ·
`pnpm check:cross-package-test-inputs` ✓ · `pnpm check:nul-bytes` ✓ ·
`pnpm check:ratchet-remedy-authority` ✓ · `eslint --no-inline-config` on both changed
files ✓. Union re-derived from the real diff with
`node scripts/pm/dispatch-gates.mjs scripts/check-slot-lookup-ratchet.mjs scripts/pm/dispatch-gates.mjs`.

`skip-changeset`: `scripts/` only, nothing published.

#9721 remains open and is the dedup partner recorded on the card; its class question is
routed to #9747, where the `silent` census this card produced has been posted as a comment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_