### PR TITLE
docs(lint): correct the ./runtime subpath's "light entry" claim with measurements

### DIFF
--- a/packages/lint/src/authoring-rule-wiring.test.ts
+++ b/packages/lint/src/authoring-rule-wiring.test.ts
@@ -411,13 +411,17 @@ describe('authoring-rule registry wiring (#4409)', () => {
           `here rebuilds, on a fourth surface, the exact drift #3583 → #4409 took five repairs to end.`,
       ).toEqual([]);
 
-      // And it must not reach past the kernel-safe entry: `@objectstack/lint`'s
-      // root barrel pulls the react/jsx rules' module graph, which is the one
-      // thing the boot path may not name (`lazy-deps.test.ts`).
+      // And it must not reach past the narrow entry. What that pins is the
+      // EXPORT surface, not the module graph: measured, `./runtime` reaches 70
+      // of the root's 72 modules, so BOTH entries name the react/jsx rules'
+      // modules (`runtime-lazy-deps.test.ts` says so from the other side). What
+      // the root barrel adds is the 258 further NAMES, every CLI-only rule
+      // among them — and a kernel-path consumer that can name one can
+      // hand-call one, which is the drift #4463 closed.
       expect(
         source,
         `${RUNTIME_GATE_FILE} must import from '@objectstack/lint/runtime', not the root barrel — ` +
-          `the root entry reaches the typescript/sucrase rules the kernel boot path must not name.`,
+          `the root entry exports the CLI-only rules the kernel gate must never call directly.`,
       ).not.toMatch(/from\s*['"]@objectstack\/lint['"]/);
     });
 

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -658,8 +658,11 @@ export type {
 } from './authoring-rules.js';
 
 // The runtime publish gate over that registry. Also published as the
-// `@objectstack/lint/runtime` subpath — the entry the kernel boot path imports,
-// so a consumer there never names the graph that reaches the source parsers.
+// `@objectstack/lint/runtime` subpath — the entry the kernel boot path imports.
+// That subpath narrows the EXPORT surface to these five names, not the module
+// graph: measured, it reaches 70 of this entry's 72 modules and 93.8% of its
+// bundled bytes, and it does name the modules that reach the source parsers.
+// `runtime.ts`'s header carries the measurement and what the narrowing buys.
 export {
   buildRuntimeWriteSnapshots,
   runRuntimeAuthoringRules,

--- a/packages/lint/src/runtime.ts
+++ b/packages/lint/src/runtime.ts
@@ -1,19 +1,59 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * `@objectstack/lint/runtime` — the KERNEL-SAFE entry (#4463).
+ * `@objectstack/lint/runtime` — the NARROW entry. Not the light one (#4463).
  *
- * The metadata write path (`@objectstack/metadata-protocol`) sits on the kernel
- * boot path and must reach the shared rule core without dragging the lint
- * package's gate-only dependencies (`typescript` ~9 MB, `sucrase`) into it.
- * That constraint is real and it is guarded from both ends:
+ * ## What it is, measured
  *
- * - `lazy-deps.test.ts` pins that no `src/` file eagerly imports either dep, so
- *   importing this entry loads neither;
- * - `runtime-lazy-deps.test.ts` pins the stronger claim this entry needs — that
- *   RUNNING the gate on a real, gated body loads neither either, because the
- *   rules #4463 wired to `runtime-publish` (flow / approval / expression /
- *   reference) never parse authored source.
+ * This entry narrows the EXPORT SURFACE. It does not narrow the module graph,
+ * and reading it as a weight boundary is a trap that costs a console build to
+ * disprove. Measured by walking the static import graph of `src/` from each
+ * entry, and by `stat` on this package's own `tsup` output:
+ *
+ * |            | modules reached        | ESM bundle       | exported names |
+ * |------------|------------------------|------------------|----------------|
+ * | `.`        | 72                     | 552,936 B        | 263            |
+ * | `./runtime`| 71, 70 shared with `.` | 518,583 B (93.8%)| 5              |
+ *
+ * So: **93.8% of the bytes, 1.9% of the surface.** The one non-barrel module
+ * `.` reaches and this entry does not is `lint-startup-registry-verdict.ts`;
+ * that single module IS the whole graph delta, and it is not the reason the
+ * entry exists. (Re-derive rather than trust these: the numbers move with the
+ * rule set, the ratio has not.)
+ *
+ * The published `.d.ts` is the one place the narrowing shows as bytes —
+ * `dist/runtime.d.ts` is a 278 B re-export line against `dist/index.d.ts`'s
+ * ~158 KB — because types are erased, and code is not.
+ *
+ * ## What it does NOT carry
+ *
+ * `validateCapabilityReferences` is not exported here, and switching to this
+ * entry to get a cheaper capability check gets neither half: the rule's code is
+ * compiled INTO `dist/runtime.js` (it is a member of the one shared registry),
+ * it is only not named on the way out. You pay its bytes and cannot call it.
+ * The root entry is where that rule, and the other 257 names, are reachable.
+ *
+ * ## Why it exists anyway
+ *
+ * So the kernel boot path can name only the five gate functions below, and so a
+ * test can prove it named nothing else. `@objectstack/metadata-protocol`'s
+ * runtime gate must reach this package through this entry rather than the root
+ * barrel, and `authoring-rule-wiring.test.ts` fails if it ever does otherwise.
+ * That is an import-discipline boundary, machine-checked: it stops a
+ * kernel-path consumer from hand-calling a CLI-only rule, which is the drift
+ * #4463 closed. The value is the pin, not the payload.
+ *
+ * ## What is the PACKAGE's doing, not this entry's
+ *
+ * Lazy dependency loading. `lazy-deps.test.ts` pins that no `src/` file eagerly
+ * imports `typescript` (~9 MB), `sucrase` or `ajv` — so importing `.` loads
+ * none of them either, and this entry is not what buys that.
+ * `runtime-lazy-deps.test.ts` adds the claim this consumer actually needs: that
+ * RUNNING the gate on a real, gated body loads none of them, because the rules
+ * #4463 wired to `runtime-publish` (flow / approval / expression / reference)
+ * never parse authored source. Both are properties of which rules RUN. Neither
+ * is a property of which entry you import — the react/jsx rules' modules are
+ * present in this entry's graph, exactly as `runtime-lazy-deps.test.ts` states.
  *
  * The deliberate NON-goal: this is not a second, lighter rule set. It re-exports
  * a filtered view of the ONE registry in `authoring-rules.ts`. If the two ever

--- a/packages/lint/tsup.config.ts
+++ b/packages/lint/tsup.config.ts
@@ -5,9 +5,12 @@ import { defineConfig } from 'tsup';
  * cannot use the repo-root `tsup.config.ts` (single `src/index.ts`).
  *
  * - `index` — the full authoring surface, used by the CLI.
- * - `runtime` — the kernel-safe subset the metadata write path imports. Kept a
- *   separate entry so a consumer on the boot path never even names the module
- *   graph that reaches the react/jsx source parsers.
+ * - `runtime` — the narrowed subset the metadata write path imports. It is a
+ *   separate entry so that surface can be PINNED (`authoring-rule-wiring.test.ts`
+ *   fails if the kernel gate imports the root barrel instead), not because it is
+ *   lighter. `splitting: false` emits each entry self-contained, and measured
+ *   `dist/runtime.js` is 93.8% of `dist/index.js` and does name the react/jsx
+ *   rules' modules. `src/runtime.ts`'s header carries the measurement.
  */
 export default defineConfig({
   entry: ['src/index.ts', 'src/runtime.ts'],


### PR DESCRIPTION
Fixes #9772

Option C of #9707's disposition. **Prose only — nothing that executes changes.**

## H1 — re-measured, not quoted

Measured on this branch by walking the static import graph of `packages/lint/src`
from each entry, and by `stat` on this package's own `tsup` output. No console
build needed.

| | modules reached | `dist/index.js` / `dist/runtime.js` (ESM) | exported names | published `.d.ts` |
|---|---|---|---|---|
| `.` | 72 | 552,936 B | 263 | 157,976 B |
| `./runtime` | **71 — 70 shared with `.`** | **518,583 B (93.79%)** | **5** | 278 B |

The card's module counts (72 / 71 / 70 shared) reproduce **exactly**. The byte
figures moved because `main` has advanced since the card's SHA, and the card's
basis is the built ESM bundle: 532,262 / 498,225 (93.6%) then, 552,936 / 518,583
(**93.79%**) now. The ratio is unchanged. CJS is 570,928 / 520,268 (91.13%).

Two refinements the card did not have:

- The headline is sharper as a **pair**: `./runtime` carries **93.8% of the bytes
  and 1.9% of the export surface** (5 names of 263). Its export set is a strict
  subset of `.`'s — nothing is exclusive to it.
- `validateCapabilityReferences` is **compiled into `dist/runtime.js`** (it is a
  member of the one shared registry; the function body is at line 6435 of the
  bundle) and merely **not exported** from that entry. The card said "does not
  export it at all", which is true — but the consumer does not save its bytes
  either. You pay for the rule and cannot call it.

## H2 — the 2-module delta, named

The 72/71 delta decomposes into three files, two of which are the barrels
themselves. **The real delta is exactly one module:**

- only in `.`: `index.ts` (the barrel) and **`lint-startup-registry-verdict.ts`**
- only in `./runtime`: `runtime.ts` (the barrel)

So `lint-startup-registry-verdict.ts` is the entire graph difference — and it is
**not** why the entry exists. Both entries reach `validate-react-pages.ts`,
`validate-react-page-props.ts` and `validate-hook-body-writes.ts`, i.e. the
react/jsx source-parser rules.

**What `./runtime` is actually for, derived:** it is an **export-surface
boundary**, machine-checked — not a weight boundary. `@objectstack/metadata-protocol`'s
runtime gate must reach this package through it rather than the root barrel, and
`authoring-rule-wiring.test.ts`'s third invariant fails if it ever does
otherwise. That pin is what stops a kernel-path consumer from hand-calling a
CLI-only rule. The value is the pin, not the payload.

**What is NOT the entry's doing:** lazy loading of `typescript` / `sucrase` /
`ajv`. That is the **package's** property — `lazy-deps.test.ts` pins it over all
of `src/`, so importing `.` loads none of them either. All four of those deps are
`import type` only at every site; the values arrive via `createRequire` at call
time. Consistent with ruling 3, and the reason ruling 3's imports stay put.

## H3 — the sweep: five copies, four of them false

| file | verdict | action |
|---|---|---|
| `packages/lint/src/runtime.ts` header | "KERNEL-SAFE entry"; frames the entry's purpose as dep-avoidance, which is package-wide | rewritten with the measurement |
| `packages/lint/src/index.ts` (line ~660) | "never names the graph that reaches the source parsers" — **false** | corrected |
| `packages/lint/tsup.config.ts` | "never even names the module graph that reaches the react/jsx source parsers" — **false** | corrected |
| `packages/lint/src/authoring-rule-wiring.test.ts` | comment + **assertion failure message** repeat the same false claim | corrected (message **text** only; the assertion regex is untouched) |
| `packages/lint/src/runtime-lazy-deps.test.ts` | **already accurate** — "the registry statically names the react/jsx rules ... so the module graph is present" | left alone |

The package's own pin test was the witness the other four contradicted. That is
the whole finding: the check was right and the doc comments drifted off it.

Further copies deliberately **not** touched, reported rather than edited:

- `content/docs/releases/v17.mdx` line 2352 repeats the claim. `content/docs/releases/**`
  is off-limits in a code PR (ruling 5 and the repo's release-notes rule) — release
  notes are a historical record of what shipped, and that is what shipped.
- `packages/lint/CHANGELOG.md`, `packages/cli/CHANGELOG.md` and
  `packages/metadata-protocol/CHANGELOG.md` carry it in generated changeset
  history. Rewriting shipped history is not a doc fix.
- `packages/metadata-protocol/src/runtime-authoring-gate.ts` says the gate "may
  only reach that package through its kernel-safe `/runtime` entry (the wiring
  guard's third invariant)". That sentence states the **invariant**, which is
  true and enforced; it makes no weight claim, so it stands.

## H4 — other multi-entry packages: one candidate, and it needs judgement

Swept all 8 packages with a multi-entry `exports` map (`spec` 18, `platform-objects`
11, `metadata` 4, `types`, `objectql`, `metadata-core`, `lint`, `core` 2 each) for
"light" / "browser-safe" / "kernel-safe" / "minimal" / "never pulls" claims, then
measured every claim found. **`packages/lint`'s was the only unambiguously false
one.** The rest hold:

| entry | claim | measured | verdict |
|---|---|---|---|
| `@objectstack/types` `.` vs `./node` | root is "edge/browser-safe", node slice behind `./node` | 13 modules, **0** node builtins vs 2 modules, all 4 | **true**, and pinned by `node-isolation.test.ts` |
| `@objectstack/core` `./logger` | "deliberately browser-safe ... `fs`/`path` must never be imported statically" | 1 module, **0** static node builtins | **true** |
| `@objectstack/metadata` `./errors` | "a consumer that needs only the predicate does not load the manager, the loaders and their deps" | 2 modules, **5.6%** of `.`; reaches neither manager nor loaders | **true** — this is what a real light entry measures like, against `./runtime`'s 93.8% |
| `@objectstack/metadata` `./node`, `./migrations`; `@objectstack/metadata-core` `./testing` | no weight or safety claim made | — | nothing to check |
| `@objectstack/objectql` `./core` | "the 268KB metadata protocol is never pulled into their dependency graph" | structural half **true** (no value import of `@objectstack/metadata-protocol`; `.` has one, `./core` does not). The **268KB figure** is unverified at HEAD — `metadata-protocol/src` is 3.6 MB today and comparing published bundles needs a build | **filed as #9803**, not folded — the claim is sound, the number needs judgement |

## Changeset

`skip-changeset`, applied by additive POST and confirmed by read-back (the
labeler bot's `size/s` and `tests` both survived). Verified rather than asserted:
I hashed `packages/lint/dist/*` before and after the edit and rebuilt. **Exactly
two published files change, both sourcemaps** — `dist/index.cjs.map` and
`dist/runtime.cjs.map`, via embedded `sourcesContent`. No `.js`, no `.cjs`, no
`.d.ts`, no `.d.cts` differs; grepping the edited comment text finds it in none
of them. `tsup.config.ts` is not in `files` at all (`files` is `dist`,
`README.md`, `CHANGELOG.md`). Nothing a consumer can observe in behaviour or
types changes.

## Verification

At commit `44b0305`:

- `pnpm --filter @objectstack/lint test` — **74 files, 2088 tests, all passed**
- `pnpm --filter @objectstack/lint typecheck` — clean
- Gate families derived from the actual changed paths with
  `node scripts/pm/dispatch-gates.mjs` (the dispatch word named none), all exit 0:
  `check:nul-bytes`, `check:cross-package-test-inputs`, `check:engine-double-contract`,
  `check:where-matcher`, `check:query-options-erasure`, `check:type-check-coverage`,
  `scripts/docs-audit/check-affected-docs.mjs`
- Not run locally: `check:type-check-debt --re-measure`, which needs the whole
  workspace closure built. This diff adds no test file and no code — it edits
  comments and one assertion message inside an existing test — so it cannot move
  a tsc error count. CI runs it.

## Out of scope, honoured

No new subpath export (ruling 1). No shrinking, splitting or restructuring of `.`
or `./runtime` (ruling 2). The `module` / `fs` / `path` imports are untouched
(ruling 3). No governed surface touched (ruling 6).

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_