### PR TITLE
feat(adapters): envelope the hono adapter's two discovery bodies (#9436)

### DIFF
--- a/.changeset/hono-adapter-discovery-envelope.md
+++ b/.changeset/hono-adapter-discovery-envelope.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/hono": minor
+---
+
+feat(adapters): the hono adapter's two discovery bodies join the response envelope (#9436)
+
+<!-- adr-0087: not-required (no-migration-prescription) Additive wire change:
+`GET {prefix}` and `GET {prefix}/discovery` gain `success: true` beside the
+existing `data` key — nothing authorable and no key is renamed, retired or
+removed, so there is no conversion to register. Every measured reader
+(`@objectstack/client` `connect()`'s `body.data || body`, the QA http-adapter's
+`'routes' in body` discriminator, objectui's `typeof body.success === 'boolean'
+&& 'data' in body` unwrap) resolves the new shape to the same document. -->
+
+`GET {prefix}` and `GET {prefix}/discovery` answered `{ data: <discovery> }`
+with no `success` flag — one key short of the declared `BaseResponseSchema`
+envelope. They now answer `{ success: true, data: <discovery> }`.
+
+Maintainer ruling on #9436 (2026-08-18, option A), deliberately not inheriting
+#9389's pre-auth exemption: these bodies are read by SDKs, codegen and AI
+clients — the envelope's core constituency — rather than by our own shells,
+and the migration is one key. Readers that unwrapped `body.data` keep working
+unchanged; envelope-aware readers that discriminate on `success` now unwrap
+this mount correctly.

--- a/packages/adapters/hono/src/hono.test.ts
+++ b/packages/adapters/hono/src/hono.test.ts
@@ -91,6 +91,7 @@ describe('createHonoApp', () => {
       const res = await app.request('/api');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(json.data.version).toBe('1.0');
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/api');
@@ -100,6 +101,7 @@ describe('createHonoApp', () => {
       const res = await app.request('/api/discovery');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/api');
     });
@@ -109,6 +111,7 @@ describe('createHonoApp', () => {
       const res = await customApp.request('/v2');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/v2');
     });
@@ -118,6 +121,7 @@ describe('createHonoApp', () => {
       const res = await customApp.request('/v2/discovery');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/v2');
     });
@@ -620,6 +624,7 @@ describe('createHonoApp', () => {
       const res = await outerApp.request('/api/v1');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/api/v1');
     });
@@ -630,6 +635,7 @@ describe('createHonoApp', () => {
       const res = await outerApp.request('/api/v1/discovery');
       expect(res.status).toBe(200);
       const json = await res.json();
+      expect(json.success).toBe(true);
       expect(json.data).toBeDefined();
       expect(mockDispatcher.getDiscoveryInfo).toHaveBeenCalledWith('/api/v1');
     });

--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -290,12 +290,18 @@ export function createHonoApp(options: ObjectStackHonoOptions): Hono {
   // ─── Explicit routes (framework-specific handling required) ────────────────
 
   // --- Discovery ---
+  //
+  // Enveloped (`{ success: true, data }`) by maintainer ruling on #9436
+  // (2026-08-18, option A) — deliberately NOT inheriting #9389's pre-auth
+  // exemption: these bodies are read by SDKs, codegen and AI clients (the
+  // envelope's core constituency, not our own shells), and the migration was
+  // one key. The SDK's `connect()` unwraps `body.data || body` either way.
   app.get(prefix, async (c) => {
-    return c.json({ data: await dispatcher.getDiscoveryInfo(prefix) });
+    return c.json({ success: true, data: await dispatcher.getDiscoveryInfo(prefix) });
   });
 
   app.get(`${prefix}/discovery`, async (c) => {
-    return c.json({ data: await dispatcher.getDiscoveryInfo(prefix) });
+    return c.json({ success: true, data: await dispatcher.getDiscoveryInfo(prefix) });
   });
 
   // --- .well-known ---

--- a/scripts/check-route-envelope.mjs
+++ b/scripts/check-route-envelope.mjs
@@ -535,13 +535,17 @@ const DISPATCHER_DOMAINS = {
  * (`plugin-hono-server/src/adapter.ts`, `adapters/hono/src/index.ts`,
  * `cli/src/commands/serve.ts`) are ordinary refusals at ordinary doors, and the
  * ruling never reached them. #9364 converted them instead, which is what a
- * ratchet is FOR and the visible contrast with this block: the first two are
- * conformant above, and what survives in `adapters/hono/src/index.ts` is its two
- * `{ data }` discovery bodies — pre-auth like this block, but read by SDKs and
- * codegen rather than by our own shells, so #9389's closed three-file list does
- * not reach them either and #9436 carries that question. The rejected option
- * (A: envelope them, flip objectui's readers, carry a skew window on the least
- * versionable seam in the product) is on record in #9389 rather than lost.
+ * ratchet is FOR and the visible contrast with this block: all three are
+ * conformant above. `adapters/hono/src/index.ts`'s last two counters — its
+ * `{ data }` discovery bodies, pre-auth like this block but read by SDKs and
+ * codegen rather than by our own shells — carried the SAME fork on a different
+ * consumer population, and the maintainer ruled it the OTHER way (#9436,
+ * 2026-08-18, option A: envelope them). The two rulings are one boundary read
+ * from both sides: WHO reads the body decides. Our own shells, pre-auth, high
+ * migration cost → exempt (here); SDKs/codegen/AI clients, one-key migration →
+ * envelope (#9436). The option #9389 rejected (A: envelope the SPA surfaces,
+ * flip objectui's readers, carry a skew window on the least versionable seam
+ * in the product) is on record in #9389 rather than lost.
  *
  * The reason is the deliverable. The entry is only where it is written down.
  *
@@ -604,17 +608,25 @@ const PLUGIN_ROUTE_MODULES = {
   // slot and `hostname` under `error.details`.
   'packages/cli/src/commands/serve.ts': {},
 
+  // Converted by #9436 (maintainer ruling 2026-08-18, option A): the two
+  // `{ data }` discovery bodies gained `success: true`. This file's
+  // `errorCodeNotString 1` had already been removed by #9364 (the shared
+  // `errorJson` wrote the HTTP status into `error.code` and now derives the
+  // ADR-0112 member from it through `resolveThrownHttpError`), so this was the
+  // file's last counter. The ruling deliberately did NOT extend #9389's
+  // pre-auth exemption here: these bodies are read by SDKs and codegen, not by
+  // our own shells, and the migration was one key.
+  'packages/adapters/hono/src/index.ts': {},
+
   // ── Ratchet: real, tracked, NOT blessed ─────────────────────────────────
   //
   // Measured by #9267 when this surface was added, not chosen. Each entry names
   // the issue that will drive it to zero; every number ticks DOWN only. These
   // are the finding this surface was worth adding for — none of them was
-  // visible to any check in the repo before it.
-  'packages/adapters/hono/src/index.ts': {
-    unenveloped: 2,
-    ratchet: '#9436 (envelope the hono adapter discovery bodies; Blocked-by #9389)',
-    note: 'two `{ data }` discovery bodies with no `success`. #9364 removed this file\'s `errorCodeNotString 1` — the shared `errorJson` wrote the HTTP status into `error.code` and now derives the ADR-0112 member from it through `resolveThrownHttpError`. What is left is the same PRE-AUTH bare-payload fork #9389 rules on, but on a different consumer population (SDKs and codegen read this mount\'s discovery, not the Console SPA), so #9389\'s closed three-file list does not reach it',
-  },
+  // visible to any check in the repo before it. #9436 graduated the last
+  // ratcheted member (`adapters/hono`, above); the section stays because the
+  // next measured drift lands here. `trigger-api` below was measured clean
+  // when the surface was added and is a pinned zero, not a ratchet.
   'packages/triggers/trigger-api/src/plugin.ts': {},
 
   // ── Ruled exempt: the pre-auth bootstrap seam (#9389) ────────────────────


### PR DESCRIPTION
Fixes #9436

Maintainer ruling on that card (2026-08-18, option A, recorded 22:30:43Z): envelope both discovery bodies. `GET {prefix}` and `GET {prefix}/discovery` in `packages/adapters/hono/src/index.ts` now answer `{ success: true, data }` instead of bare `{ data }`. The ruling deliberately does not inherit #9389's pre-auth exemption — these bodies are read by SDKs, codegen and AI clients, and the migration is one key.

## Reader sweep (ruled to run first — it did)

Every reported search ran with a control; no zero was accepted without one.

- `@objectstack/client` `connect()` (`packages/client/src/index.ts` 531-532, 557-558): unwraps `body.data || body` on both the `/api/v1/discovery` probe and the `.well-known` fallback — bare, `{ data }`, and `{ success, data }` all resolve to the same document. Unaffected.
- QA http-adapter (`packages/core/src/qa/http-adapter.ts` `resolveDataMount()`): discriminates on `'routes' in body`, else reads `body.data`. The new shape falls to `body.data`. Unaffected.
- http-conformance integration test: `body.data?.routes ?? body.routes`. Unaffected.
- objectui (cross-repo, read-only sweep): `ConditionalAuthWrapper.tsx` and `data-objectstack/src/index.ts` unwrap only when `typeof body.success === 'boolean' && 'data' in body` — today's bare `{ data }` fails that test; the post-flip shape satisfies it, so those readers now unwrap this mount correctly. `ConnectAgentWidget.tsx` uses the tolerant `(json?.data ?? json)?.routes`. No intolerant reader; no cross-repo flip needed, so no Blocked-by split.
- Controls: `.well-known/objectstack` literal — 20 files subject, 20 on the intolerant spelling; objectui `fetch(` count 156 (nonzero harness); examples tree 197 ts files scanned, zero discovery readers (both hits were prose); cli 7 discovery mentions, all comments, against 17 `fetch(` sites.
- The adapter's own tests were the only exact-shape assertions found; they are updated and strengthened here (six `success: true` pins added).

## Gate table (`scripts/check-route-envelope.mjs`)

- This file's entry graduates to conformant `{}` with a conversion comment; its `ratchet`/`note` drop per the gate's own last-counter rule.
- The exempt-block header prose now records the #9436 ruling as the other side of #9389's boundary (who reads the body decides), replacing the text that carried the fork as open.
- **Premise delta (dispatch brief Zone 2b):** the card's "four `ratchet` entries name #9364" was already discharged on `main` before this PR — PR #9455 had converted the three #9389 files to `exempt` entries (no `ratchet` field) and had repointed this file's `ratchet` at #9436. No pointer edits remained beyond this file's entry graduating; zero counters moved by pointer work. The two `'#9364'` strings still in the file are self-test fixture literals, not table entries.

## Verification (all readings at head `c938eea`)

- `check:route-envelope` before: 11 modules, 161 bodies — 7 conformant, **1 ratcheted (this file, unenveloped 2)**, 3 exempt; exit 0. After: **8 conformant, 0 ratcheted**, 3 exempt; exit 0, self-test green. The `unenveloped` counter is what dropped, 2 → 0, confirming Zone 2a — `success: true` was the only key the gate needed.
- Reverse verification, from the committed state: de-enveloping one body turned the gate red (exit 1, "unenveloped: found 1, declared 0") and exactly the 3 test pins on that route red (70 passed / 3 failed); restore via checkout from the branch, gate green again. The vitest legs resolve `./index` relatively (source path, no dist in the chain), so no rebuild was involved in either leg — stated per ablation discipline.
- `pnpm --filter @objectstack/hono test`: 73/73 passed (2 files), exit 0. `tsc --noEmit` on the package: exit 0.
- Derived union (`node scripts/pm/dispatch-gates.mjs`, no hand-fed paths — 4 paths matched, exactly this PR's files): check:changeset-gate-self-tests, check:cross-package-test-inputs, check:objectui-changeset, check:route-envelope, check:test-source-alias, check:type-source-resolution, check-adr-0087-registration, check-changeset-no-major, check-empty-changeset, docs-audit/check-affected-docs, plus convention-triggered check:query-options-erasure, check:type-check-coverage, check:type-check-debt (full packages closure built first, 70 tasks; re-measure: no entry above its recorded number), check:engine-double-contract, check:where-matcher — all exit 0.
- `pnpm lint` (run regardless, per the brief — the derivation does not name it): exit 0. `check:nul-bytes`: green.

## Out of scope, filed

- #9813 remains open and is not addressed here: `packages/runtime/src/dispatcher-plugin.ts` serves the same `{ data }` discovery shape on `/.well-known/objectstack` and the REST-less `{prefix}/discovery` fallback, outside this ruling's named file and outside the envelope gate's scan populations.

Changeset: `minor` for `@objectstack/hono` (additive wire change; adr-0087 marker: not-required, no key renamed or removed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeN7F6jQFpcqW2BN56RdPa)_