### PR TITLE
docs(cli): the unknown-hostname-guard's install-order rationale names Phase 1 init() (#9745)

### DIFF
--- a/packages/cli/src/commands/serve-unknown-hostname-guard.test.ts
+++ b/packages/cli/src/commands/serve-unknown-hostname-guard.test.ts
@@ -391,3 +391,81 @@ describe('createUnknownHostnameGuardPlugin — install is soft, never fatal', ()
     expect(h.infos.join('\n')).toContain('installed');
   });
 });
+
+/**
+ * The install-order property the guard's rationale in `serve.ts` names.
+ *
+ * That rationale used to say the middleware intercepts everything "as long as
+ * it is added before kernel:listening fires". Measured false (#9745): Hono
+ * composes the handlers a request matched in REGISTRATION order, and
+ * `kernel:ready` / `kernel:bootstrapped` / `kernel:listening` all fire after
+ * Phase 2 `start()` — i.e. after every route on the platform is registered — so
+ * a guard installed from any of those hooks sits behind all of them and refuses
+ * nothing, with no error and no log.
+ *
+ * Nothing else in this file can fail when that claim comes back: every other
+ * test mounts the guard FIRST via `mountGuard`, which is precisely the case
+ * that works. So this pins the ordering itself, both directions on ONE app —
+ * neither direction can be satisfied by the middleware simply never installing:
+ *
+ *   - `/before` is registered BEFORE the guard's `init()` → guard never runs
+ *   - `/after`  is registered AFTER  the guard's `init()` → guard refuses
+ */
+describe('createUnknownHostnameGuardPlugin — install order is the contract', () => {
+  it('gates only what is registered after it, which is why init() is the requirement', async () => {
+    const server = new HonoHttpServer(0);
+    const rawApp = server.getRawApp();
+    const asked: string[] = [];
+
+    // A route that already exists when the guard installs. This is the shape a
+    // guard installed from a lifecycle hook would face for EVERY platform
+    // route, not an exotic one.
+    rawApp.get('/before', (c: { text: (body: string, status: number) => Response }) =>
+      c.text('BEFORE', 200));
+
+    const ctx = {
+      getService: (name: string) =>
+        name === 'http.server'
+          ? { getRawApp: () => rawApp }
+          : name === 'env-registry'
+            ? {
+              resolveByHostname: async (host: string) => { asked.push(host); return null; },
+            }
+            : undefined,
+      logger: { warn: () => {}, info: () => {} },
+    };
+
+    await createUnknownHostnameGuardPlugin({
+      rootDomain: ROOT_DOMAIN,
+      readCloudUrl: () => '',
+    }).init(ctx);
+
+    // Production's order: route-registering plugins run in Phase 2 `start()`,
+    // after every plugin's `init()`.
+    rawApp.get('/after', (c: { text: (body: string, status: number) => Response }) =>
+      c.text('AFTER', 200));
+
+    const call = (path: string) =>
+      rawApp.fetch(new Request(`http://placeholder${path}`, {
+        headers: { host: 'nobody.objectos.ai', accept: 'application/json' },
+      }));
+
+    // Registered first: it answers and never calls `next()`, so the guard is
+    // never reached — an unmapped hostname sails straight through, and the
+    // registry is not even consulted.
+    const before = await call('/before');
+    expect(before.status).toBe(200);
+    expect(await before.text()).toBe('BEFORE');
+
+    // Registered after: the guard is ahead of it in the composed chain and
+    // refuses. Same app, same host, same unmapped environment — registration
+    // order is the only difference between these two requests.
+    const after = await call('/after');
+    expect(after.status).toBe(404);
+    expect((await after.json() as RefusalBody).error?.code).toBe('ENVIRONMENT_NOT_FOUND');
+
+    // The registry was asked exactly once, for the request the guard actually
+    // saw — the direct evidence that the `/before` hit never reached it.
+    expect(asked).toEqual(['nobody.objectos.ai']);
+  });
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -3427,10 +3427,27 @@ export const UNKNOWN_HOSTNAME_GUARD_HEALTH_PATHS: readonly string[] = [
  *
  * Implemented as a Plugin so the middleware is wired during init (when
  * `http.server` is available) and BEFORE start() runs on the Console static
- * plugin / route-registering plugins. Hono's `app.use('*')` is order-independent
- * for matching, so as long as the middleware is added before kernel:listening
- * fires, it intercepts every request regardless of which plugin registered its
- * handler. The env-registry is resolved lazily per request on purpose: it is
+ * plugin / route-registering plugins. Phase 1 `init()` is the REQUIREMENT, not
+ * a convenience: Hono composes the handlers a request matched in REGISTRATION
+ * order, so a route registered ahead of this middleware answers and never calls
+ * `next()`, and the guard never runs for that path. Route registration starts
+ * in Phase 2 `start()` (createConsoleStaticPlugin mounts the Console there) and
+ * continues in the `kernel:ready` hooks registered from it (HonoServerPlugin's
+ * current-user endpoints, plugin-auth's terminal `/api/v1/auth/*`), while both
+ * kernels run every plugin's `init()` before the first `start()`
+ * (`LiteKernel.bootstrap`, `ObjectKernel.bootstrap`) — so an install from
+ * `init()` is ahead of all of it.
+ *
+ * ⛔ "Added before kernel:listening" is NOT the condition, however natural it
+ * reads. `kernel:ready`, `kernel:bootstrapped` and `kernel:listening` all fire
+ * strictly AFTER Phase 2, so a guard installed from one of those hooks is
+ * registered behind every route and observes NOTHING — no error, no log, no
+ * refusal (#9745, measured across three install points). A refusal surface that
+ * gates nothing is the failure this guard exists to prevent, so anything
+ * modelled on it installs during `init()`. Both directions are pinned in
+ * `serve-unknown-hostname-guard.test.ts`.
+ *
+ * The env-registry is resolved lazily per request on purpose: it is
  * registered by ObjectOSEnvironmentPlugin's init, and the guard must not depend
  * on plugin ordering to work.
  *


### PR DESCRIPTION
Fixes #9745

The guard is installed correctly and this PR changes nothing it accepts or refuses. What was wrong is the **rationale** in its doc comment — the part the next author copies:

> Hono's `app.use('*')` is order-independent for matching, so as long as the middleware is added before kernel:listening fires, it intercepts every request regardless of which plugin registered its handler.

## Premise re-verified on this ref, not inherited

- The comment block is still present in `packages/cli/src/commands/serve.ts` and still says what the card quotes. The card cites `:3429-3435`; on `origin/main` at 5cc8a3b08 it sits at `:3428-3435` — located by text, never by line number.
- `LiteKernel.bootstrap` (`packages/core/src/lite-kernel.ts`) and `ObjectKernel.bootstrap` (`packages/core/src/kernel.ts`) each run Phase 1 `init()` for every plugin, then Phase 2 `start()` for every plugin, and only then trigger `kernel:ready` → `kernel:bootstrapped` → `kernel:listening`. All three hooks fire strictly after Phase 2.
- Route registration begins in Phase 2 and continues past it: `createConsoleStaticPlugin` mounts the Console in `start()` (`packages/cli/src/utils/console.ts`), `HonoServerPlugin` registers the current-user endpoints from a `kernel:ready` hook, and `plugin-auth` defers its terminal `/api/v1/auth/*` mount to `kernel:ready` as well. Phase 1 `init()` is ahead of all of it — which is what the code already does.

Verdict: the premise holds and the emphasised sentence is false. "Before `kernel:listening`" admits install points that sit behind every route.

## What changed

**1. `packages/cli/src/commands/serve.ts` — comment only.** Names Phase 1 `init()` as the requirement, states the true mechanism (Hono composes the handlers a request matched in registration order, so a route registered ahead of the middleware answers and never calls `next()`), and drops the "order-independent for matching" clause — the phrase that made the false generalisation sound principled. The correct first sentence is kept; the bypass matrix and the inline-object-literal note are untouched.

**2. `packages/cli/src/commands/serve-unknown-hostname-guard.test.ts` — one new test** pinning the corrected sentence. Every other test in that file mounts the guard first via `mountGuard`, which is precisely the case that works, so none of them can fail when the false claim comes back.

The new test registers `/before` **ahead of** the guard's `init()` and `/after` **behind** it, on one real `HonoHttpServer`, then drives one unmapped hostname at both: `/before` answers 200 and the env-registry is never consulted; `/after` is refused with 404 and `ENVIRONMENT_NOT_FOUND`. Registration order is the only difference between those two requests.

## Reverse verification

Prediction stated before running: moving `/before`'s registration to after `init()` turns the test red on the pass-through leg. Measured, from the committed state:

```
- 200
+ 404
 ❯ src/commands/serve-unknown-hostname-guard.test.ts:456:27
 Tests  1 failed | 34 passed (35)
```

Restored with `git checkout HEAD -- ...`, re-run: `Tests 35 passed (35)`. No rebuild is involved on either leg — the subject is imported from `./serve.js`, a same-package source specifier vitest resolves out of `src/`, and the mutation lived inside the test file itself.

## Scope boundary

`packages/runtime/src/http-metrics-inbound-coverage.hono.integration.test.ts` — the card's evidence table — was **read, never written**. The pin above needed no part of that harness: `packages/cli` already boots a real Hono adapter in its own guard suite. No `Blocked-by:` was wired, per triage.

## Changeset: deliberately none — `skip-changeset` instead

A judgment call, not an assumption. The `serve.ts` diff is prose inside a JSDoc block: nothing that executes changes, no public surface moves, and there is no user-visible behaviour for a release note to describe. The test file never reaches the published tarball at all — `packages/cli/tsconfig.build.json` carries `"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/__tests__/**"]`, so it is not compiled and `files: ["dist"]` cannot ship it. Precedent landed on `main` today: #9802 corrected prose inside `@objectstack/lint`'s published `src/**` and merged with no changeset.

## Gates run, all at 218e2be7b

Derived with `node scripts/pm/dispatch-gates.mjs` (no paths passed — the script took the change set from the merge base 5cc8a3b08 itself), then run:

| gate | result |
|---|---|
| `pnpm --filter '@objectstack/cli^...' build` | dependency closure built first, in this fresh worktree |
| `pnpm lint` | clean, no findings (run regardless — the deriver does not name it) |
| `pnpm --filter @objectstack/cli test` | `Test Files 134 passed (134)`, `Tests 1462 passed (1462)` |
| `pnpm --filter @objectstack/cli typecheck` | `tsc --noEmit`, clean |
| `pnpm check:route-envelope` | 11 modules audited, 7 conformant / 1 ratcheted / 3 exempt — unchanged |
| `pnpm check:cross-package-test-inputs` | 33 self-test cases pass; 12 packages read outside themselves, all declared |
| `pnpm check:engine-double-contract` | OK — 321 pinned, 133 ledgered, 2 exempt |
| `pnpm check:where-matcher` | 257 matchers, 0 silently-wrong, 0 new |
| `pnpm check:query-options-erasure` | ratchet holds, none new |
| `pnpm check:nul-bytes` | OK, 6265 text files, no raw control bytes |
| `node scripts/docs-audit/check-affected-docs.mjs` | self-test 242 cases pass |

`check:type-check-coverage` / `check:type-check-debt` were not run locally, and the reason is the measurement rather than the cost: `packages/cli` declares a `typecheck` script and its `tsconfig.json` includes `src` — only `tsconfig.build.json` excludes tests — so the new test file already sits inside a tsc program and the package carries no TEST_DEBT entry to re-measure. The ratchet half needs the whole workspace closure built; CI runs that farm. `tsc --noEmit` over the package is the local half.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeN7F6jQFpcqW2BN56RdPa)_