### PR TITLE
feat(security): REST 401 anonymous-deny body carries code UNAUTHENTICATED alongside error/message (#9487)

### DIFF
--- a/.changeset/anonymous-deny-401-code-key.md
+++ b/.changeset/anonymous-deny-401-code-key.md
@@ -1,0 +1,20 @@
+---
+"@objectstack/core": minor
+---
+
+feat(security): the REST 401 anonymous-deny body carries `code: "UNAUTHENTICATED"` alongside the existing `error` / `message` keys (#9487)
+
+Every other REST error family answers `{ error, code }`, with the machine code
+in `code` — the 401 family was the one outlier, answering
+`{ error: "UNAUTHENTICATED", message }` with no `code` key at all. A client
+keying on `body.code` (the shape the other families teach, and the first read
+of `@objectstack/client`'s `err.code`) read `undefined` for every
+authentication failure.
+
+`ANONYMOUS_DENY_BODY` now carries `code: "UNAUTHENTICATED"` as well.
+**Additive only** (maintainer-ruled): no key is removed or moved — `error`
+keeps holding the same code value it always has, so every existing reader
+keeps working. The wire effect surfaces through `@objectstack/rest`'s
+`enforceAuth`, which writes this constant verbatim on every `/data`, `/meta`
+and `/reports` 401. This does not settle ADR-0112 D5 (flat vs nested envelope
+convergence); both declared envelope families are unchanged in kind.

--- a/packages/core/src/security/anonymous-deny.test.ts
+++ b/packages/core/src/security/anonymous-deny.test.ts
@@ -49,6 +49,13 @@ describe('shouldDenyAnonymous — the shared HTTP anonymous-deny decision (#2567
 
   it('exposes a stable 401 body + status for seams to return', () => {
     expect(ANONYMOUS_DENY_STATUS).toBe(401);
-    expect(ANONYMOUS_DENY_BODY).toEqual({ error: 'UNAUTHENTICATED', message: expect.any(String) });
+    // [#9487] `code` carries the machine code — the documented key every other
+    // REST error family answers. ADDITIVE by maintainer ruling: `error` keeps
+    // holding the same code value it always has, so no existing reader breaks.
+    expect(ANONYMOUS_DENY_BODY).toEqual({
+      error: 'UNAUTHENTICATED',
+      code: 'UNAUTHENTICATED',
+      message: expect.any(String),
+    });
   });
 });

--- a/packages/core/src/security/anonymous-deny.ts
+++ b/packages/core/src/security/anonymous-deny.ts
@@ -40,8 +40,9 @@ export const ANONYMOUS_DENY_CODE = 'UNAUTHENTICATED' as const;
 /** Human-facing message. */
 export const ANONYMOUS_DENY_MESSAGE = 'Authentication is required to access this endpoint.';
 /**
- * The **REST seam's** 401 body — flat `{ error, message }`. NOT the platform's
- * only one; see the two-envelope table below before you reuse this shape.
+ * The **REST seam's** 401 body — flat `{ error, code, message }`. NOT the
+ * platform's only one; see the two-envelope table below before you reuse this
+ * shape.
  *
  * Exactly one consumer writes it: `@objectstack/rest`'s `enforceAuth`
  * (`rest-server.ts` — `res.status(ANONYMOUS_DENY_STATUS).json(ANONYMOUS_DENY_BODY)`),
@@ -54,8 +55,11 @@ export const ANONYMOUS_DENY_MESSAGE = 'Authentication is required to access this
  * {@link ANONYMOUS_DENY_MESSAGE}). What differs is the **wrapper**:
  *
  *  - **REST seam** — `@objectstack/rest` `enforceAuth`, this constant, verbatim:
- *    `{ error: 'UNAUTHENTICATED', message: '…' }`. The code is the value of the
- *    top-level `error` key; there is no `success` key and no nesting.
+ *    `{ error: 'UNAUTHENTICATED', code: 'UNAUTHENTICATED', message: '…' }`.
+ *    The machine code lives in the top-level `code` key — the same documented
+ *    key every other REST error family answers (#9487, maintainer-ruled
+ *    ADDITIVE: `error` keeps carrying the code value it always has, so no
+ *    existing reader breaks). There is no `success` key and no nesting.
  *  - **Dispatcher seams** — the five runtime domains `domains/ai.ts`,
  *    `domains/meta.ts`, `domains/security.ts`, `domains/actions.ts` and
  *    `domains/automation.ts` do NOT use this constant. Each calls
@@ -67,7 +71,10 @@ export const ANONYMOUS_DENY_MESSAGE = 'Authentication is required to access this
  * (#4007) records the flat and wrapped envelopes as the two live ones, and
  * assigns retiring one of them to the envelope-convergence line (#3843 family).
  * Converging them is a breaking wire change; it is not this module's to make,
- * and this constant must not be read as if it had already happened.
+ * and this constant must not be read as if it had already happened. The #9487
+ * `code` key does NOT settle that question either way (ADR-0112 D5 stays
+ * open): it aligns the flat family to the `{ error, code }` shape the other
+ * flat REST error families already answer, without moving or removing a key.
  *
  * ## Reading this from a consumer (human or AI author)
  *
@@ -84,6 +91,7 @@ export const ANONYMOUS_DENY_MESSAGE = 'Authentication is required to access this
  */
 export const ANONYMOUS_DENY_BODY = {
   error: ANONYMOUS_DENY_CODE,
+  code: ANONYMOUS_DENY_CODE,
   message: ANONYMOUS_DENY_MESSAGE,
 } as const;
 

--- a/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts
@@ -107,7 +107,10 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
 /**
  * The REST seam's envelope — `@objectstack/rest` `enforceAuth` writing
  * `ANONYMOUS_DENY_BODY` verbatim. The machine code IS the top-level `error`
- * value; there is no wrapper around it and no `success` flag.
+ * value — and, since #9487, also the top-level `code` key (additive); there is
+ * no wrapper around it and no `success` flag. The predicate deliberately does
+ * not require `code`: family membership is judged on the discriminating keys,
+ * and the exact body is pinned strictly elsewhere in this file.
  */
 const isRestFlatDeny = (body: unknown): boolean =>
   isRecord(body)
@@ -369,11 +372,14 @@ describe('showcase: anonymous posture is uniform across surfaces (#2567)', () =>
     // Each family is read in ITS OWN declared shape — no `??` chain across the
     // two, because a tolerant reader here would hide the day one of them
     // changes. `@objectstack/rest` returns the flat `ANONYMOUS_DENY_BODY`
-    // (`{ error: <CODE>, message }`); the dispatcher returns its standard
+    // (`{ error: <CODE>, code: <CODE>, message }` — `code` added by #9487,
+    // additive, aligning the 401 family to the `{ error, code }` shape every
+    // other REST error family answers); the dispatcher returns its standard
     // wrapper (`{ success: false, error: { code, message, httpStatus } }`).
     for (const body of rest) {
       expect(body).toEqual({
         error: 'UNAUTHENTICATED',
+        code: 'UNAUTHENTICATED',
         message: 'Authentication is required to access this endpoint.',
       });
     }


### PR DESCRIPTION
Part of #9487 — delivers the maintainer-ruled additive fix for the dispatched surface. One additional producer was found outside that surface and is filed as sub-issue #9823, so this PR deliberately uses no closing keyword: the PM decides whether the parent closes on this landing or on #9823.

## What changed (ruling: additive only — no key removed, no key moved)

- `packages/core/src/security/anonymous-deny.ts` — `ANONYMOUS_DENY_BODY` gains `code: ANONYMOUS_DENY_CODE`. The wire effect surfaces through `@objectstack/rest`'s `enforceAuth`, which writes this constant verbatim on every `/data`, `/meta` and `/reports` 401 (all 69 call sites). `error` keeps carrying the same code value it always has; docstring updated to match, including an explicit note that this does NOT settle ADR-0112 D5 (#9559 stays open — both envelope families unchanged in kind).
- `packages/core/src/security/anonymous-deny.test.ts` — the strict pin updated to the new exact three-key shape (strict `toEqual`, not loosened).
- `packages/qa/dogfood/test/showcase-anonymous-deny-surfaces.dogfood.test.ts` — the strict wire pin updated to the exact three-key shape. The two-family classifier (`isRestFlatDeny` / `isDispatcherWrapperDeny`) is byte-untouched: it judges family on the discriminating keys and tolerates the additive key — verified on the wire, not assumed (below). The `toEqual(ANONYMOUS_DENY_BODY)` verbatim pin follows the constant by construction and needed no edit.
- `.changeset/anonymous-deny-401-code-key.md` — `@objectstack/core` minor. Not breaking; no ADR-0087 marker required (`check:adr-0087-registration` green).

## The ledger half of the ruling — measured already satisfied, no spec edit needed

The ruling asks that the 401 family be declared like every other family. Measured on `main`: `UNAUTHENTICATED` is already a tier-1 `StandardErrorCode` member (`packages/spec/src/api/errors.zod.ts:69`) with `HttpStatusErrorCodeMap` 401 mapped to it (`:174`) — the same tier as `PERMISSION_DENIED` / `OBJECT_NOT_FOUND` / `RECORD_NOT_FOUND`; the card's other named codes (`VALIDATION_FAILED`, `BATCH_NOT_ATOMIC`, `UNSUPPORTED_QUERY_PARAM`) are tier-2 ledger rows only because they are not standard members. A tier-2 ledger row for `UNAUTHENTICATED` would be refused by the ledger's own admission gate ("no registered code shadows the standard catalog", `packages/spec/src/api/error-code-ledger.test.ts:38-42`). So `packages/spec/**` is untouched and the `domain:spec` boundary was never breached.

## Measured benefit (the card's cost, removed)

`packages/client/src/index.ts:4958-4961` reads `asSemanticCode(errorBody?.code) ?? asSemanticCode(errorBody?.error?.code)`. Harness against built dist (stub server answering the built constant; client resolved via package `exports`): before — `err.code === undefined`; after — `err.code === 'UNAUTHENTICATED'`, `err.httpStatus === 401`, with **no SDK change**. objectui's four `UNAUTHENTICATED` readers (`error-message.ts:212`, `MarketplacePackagePage.tsx:338`, tests) all key on `code` and start receiving it; none asserts absence.

## Verification (all at `b0d5633c5`, the head this PR ships)

- `@objectstack/core` tests: 35 files / 857 passed. `@objectstack/rest` full suite: 129 files / 2105 passed. `@objectstack/dogfood` full suite: 118 files passed / 1 skipped, 866 tests passed / 3 skipped; the anonymous-deny file alone re-run: 1 file / 25 passed against a real booted showcase — the additive body classified `rest-flat`, no third dialect, wire-verbatim pin green. `@objectstack/dogfood` typecheck green.
- Reverse verification from the committed state, both legs rebuilt and dist-proven (`scripts/ablation-dist-preflight.mjs`, value-unique markers, `--absent` on the ablation leg): reverting the constant turns the core pin RED (1 failed / 7 passed, missing `code`) and the SDK harness back to `err.code === undefined`; restore leg returns 8/8 and PASS. First marker attempt was rejected by the preflight itself (the marker also matched a pre-existing docstring surviving in `.d.ts`) — remeasured with value-unique markers.
- Gate union derived by `node scripts/pm/dispatch-gates.mjs` from the real changeset (15 path-matched + 5 convention-triggered), all green, plus the tool's known gaps run explicitly: `pnpm lint` and `pnpm check:slot-lookup` green, `check:nul-bytes` green, `check:type-check-debt` re-measure green on the built closure (turbo 70/70).

## Scope discipline

- Consumer sweep (with controls; intolerant count beside tolerant): exactly 2 strict whole-body pins existed and both are updated here; 1 verbatim pin follows the constant; the 2 tolerant top-level `body.error` readers (`rest-meta-auth.test.ts:49`, `security-routes.test.ts:99`) stay green by construction; all nested `error.code` readers are unaffected.
- Producer sweep: the deny message has exactly two non-test spellings repo-wide. This PR fixes the constant; the inline copy in `packages/runtime/src/dispatcher-plugin.ts:213-221` (service-declared endpoint routes) is #9823 — out of the dispatched surface, reported rather than silently expanded into.
- `packages/rest`, `packages/client`, `packages/spec`: zero edits needed, zero made.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeN7F6jQFpcqW2BN56RdPa)_