### PR TITLE
docs(ci): state the launch-window major guard's arming condition, not today's phase

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -780,14 +780,22 @@ jobs:
       #      `rerun_failed_jobs` after labelling converges to green. Removing the
       #      permanent red is the whole of what #5620 records.
       #
-      # DORMANT TODAY, and the dormancy is deliberately not load-bearing.
-      # `check-changeset-no-major.mjs` stands aside for the whole pre-release
-      # window (its RC EXEMPTION note) and `.changeset/pre.json` currently says
-      # `"mode": "pre"`, so the guard below cannot fail and the label is never
-      # needed. It re-arms by itself at `changeset pre exit` -- precisely the day
-      # whole-stack majors are under discussion and `allow-major` is most likely to
-      # be applied by hand, seconds after `gh pr create`. Nothing here leans on the
-      # dormancy, and it must not become a reason to weaken the read.
+      # WHETHER THE GUARD BELOW CAN FAIL AT ALL IS PHASE-DEPENDENT, and nothing
+      # in this read may lean on the phase either way. `check-changeset-no-major.mjs`
+      # stands aside for a diff that introduces a `major` for exactly as long as
+      # `.changeset/pre.json` parses with `"mode": "pre"` (its RC EXEMPTION note);
+      # in every other state -- absent, `"exit"`, unreadable -- it enforces, and
+      # the label read below is the only way past it. That flips with no edit
+      # here: `changeset pre enter` stands the guard down, `changeset pre exit`
+      # re-arms it. Read the phase from `.changeset/pre.json` or from the guard
+      # step's own output, never from this comment -- a comment that named
+      # today's phase is what this paragraph replaces.
+      #
+      # The re-arming edge is the one this read is built for: it is precisely the
+      # day whole-stack majors are under discussion and `allow-major` is most
+      # likely to be applied by hand, seconds after `gh pr create`. So a phase in
+      # which the guard cannot fail must never become a reason to weaken the read
+      # -- the exemption ends on the day the read matters most.
       - name: Re-read this PR's allow-major label live (the event payload can predate it)
         id: allow_major
         # Both skip-changeset reads, for the same reason the guard below names

--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -181,25 +181,60 @@
  * rather than 0 (#4690): a gate that cannot read its input has verified nothing,
  * and exiting 0 there reads as "no violations" in every checks list.
  *
- * ## What `--self-test` covers, and what it does NOT (#6923, still true)
+ * ## What `--self-test` covers, and what a green tick from this file means (#6923)
  *
- * Read this before trusting a green tick from this file. The enforcing half it
- * fixtures is still, on CI, unexecuted — and #7005 did not change that.
+ * Read this before trusting a green tick. Both halves below are stated as a
+ * condition rather than as a reading of the release phase the repo happens to be
+ * in — the wording they replace was the latter, and `changeset pre exit`
+ * falsified it without touching a line of code (see RE-DERIVED at the end).
  *
- *   COVERED — every decision this file makes: the frontmatter dialects, the
- *   pre-mode/exit-mode switch in BOTH directions, the diff scoping driven
- *   through real temp git repositories (including a real `refs/pull/N/merge`
- *   shape with a base branch that keeps moving), and the rendered text of the
- *   offenders report.
+ *   COVERED, IN EVERY REPO PHASE — every decision this file makes: the
+ *   frontmatter dialects, the pre-mode/exit-mode switch in BOTH directions, the
+ *   diff scoping driven through real temp git repositories (including a real
+ *   `refs/pull/N/merge` shape with a base branch that keeps moving), and the
+ *   rendered text of the offenders report. None of it can move with the release
+ *   train: the fixtures pass `judge()` its `pre` argument directly and build
+ *   their own throwaway repos, and the assertions that did read the real
+ *   `.changeset/` for its PHASE were removed at #8654 (see the reader block in
+ *   `--self-test`). They run in a job with no label exemption —
+ *   `check:changeset-gate-self-tests`, lint.yml's ESLint job (#6509/PR #6917) —
+ *   so they execute on every PR.
  *
- *   NOT COVERED — the CI path. `.changeset/pre.json` says `"mode": "pre"`, so
- *   the real scan below still takes the exemption branch and exits 0 on every
- *   run; the `enforce` verdict has never been produced by a CI invocation of
- *   this script and still is not after #7005. What #6923 changed is that it is
- *   produced by fixtures on every PR, in a job with no label exemption
- *   (`check:changeset-gate-self-tests`, lint.yml's ESLint job — #6509/PR #6917).
- *   Fixtured is not the same as executed, and this note exists so the next
- *   reader does not read one as the other.
+ *   WHICH GREEN TICK — this file has two, they rule out different things, and
+ *   the text is what distinguishes them:
+ *
+ *     "introduces no `major` bump"      the `clean` verdict. Decided BEFORE
+ *                                       pre-mode is consulted — the verdict
+ *                                       ORDER in `judge` is contract, and pinned
+ *                                       by `--self-test` — so it means what it
+ *                                       says in every phase.
+ *
+ *     "in pre-release mode (tag: …)"    the `exempt` verdict. A `major` WAS
+ *                                       introduced and stood aside for the
+ *                                       window. Reachable ONLY while
+ *                                       `.changeset/pre.json` parses with
+ *                                       `"mode": "pre"`.
+ *
+ *   So the question a reader must answer is not "green or red" but WHICH green.
+ *   What the phase governs is only whether the real scan can reach `enforce` at
+ *   all: never inside a pre-release window, always outside one — absent, `"exit"`
+ *   and unreadable all enforce. `--list` prints the mode it read; an ordinary run
+ *   does not, which is exactly why the two ticks are worded apart.
+ *
+ *   Fixtured is still not the same as executed, and keeping those two apart is
+ *   what this note is for. The enforcing branch is reached by the real scan only
+ *   on a PR that introduces a `major` outside a pre-release window — rare by
+ *   construction, since the guard exists to make that PR rare — so `--self-test`
+ *   remains the only thing that exercises it on a routine basis.
+ *
+ *   RE-DERIVED, not re-worded. This paragraph used to read "`.changeset/pre.json`
+ *   says `"mode": "pre"`, so the real scan below still takes the exemption branch
+ *   and exits 0 on every run; the `enforce` verdict has never been produced by a
+ *   CI invocation of this script". That was a measurement of the RC window the
+ *   repo was in, not a property of this file, and it understated the gate in the
+ *   direction that flatters it. It is replaced by the condition above rather than
+ *   re-dated, because a dated reading of this paragraph goes stale again at the
+ *   next `changeset pre enter`.
  *
  * ## The frontmatter dialects, measured against the real parser
  *


### PR DESCRIPTION
Fixes #9561

Comment-only. No behaviour changes: `git diff` on this branch contains no non-comment line, and the guard's decision function is untouched.

## The premise, measured rather than accepted

The card asserts the guard is armed. Verified before editing anything:

- `.changeset/pre.json` is absent on `origin/main` @ `9ff11921a`.
- Provenance (recovered via the GitHub commit API — this checkout is shallow at 50 commits): `2c2afa544` (2026-08-14, PR #8643) ran `changeset pre exit`, moving the mode from `"pre"` to `"exit"`; `24c1b91e4` (the GA version-packages commit, same day) removed the file. Its own commit message says "`check-changeset-no-major.mjs` re-arms — its RC exemption reads pre.json."
- `readPre()` collapses absent / unreadable / malformed to `null`, and `judge()` grants the exemption only on `pre?.mode === 'pre'`.

Read-only evidence is not enough for a claim about a CI path, so the enforcing branch was **executed on the real scan**: a temporary commit adding a changeset declaring `"@objectstack/spec": major` made

```
node scripts/check-changeset-no-major.mjs --base origin/main
```

exit **1** with the offenders report. The probe commit was rolled back (`git reset --hard HEAD~1`); the branch carries no trace of it. So the premise holds, and the two comments are stale.

## H1 — the condition, and that it is windowed rather than permanent

The exemption condition is `pre?.mode === 'pre'`, i.e. `.changeset/pre.json` present, parsing, and in pre mode. That is **windowed, not permanent**: `changeset pre enter` re-creates it (cut-rc.yml refuses to run without `mode: pre`, `tag: rc`) and `changeset pre exit` clears it. So a comment saying "active" would be exactly as perishable as the "dormant" it replaces — it would rot at the next RC train instead of at the last GA.

Both comments therefore state the condition, and neither is re-dated.

**`.github/workflows/pr-automation.yml`** — the allow-major read. Now says that whether the guard below can fail at all is a function of the release phase, that the phase flips with no edit in that file, where to read the phase from, and — the load-bearing half, preserved — that a phase in which the guard cannot fail must never become a reason to weaken the live label read, because the exemption ends on precisely the day that read matters most.

**`scripts/check-changeset-no-major.mjs`** — the #6923 coverage note, **re-derived rather than re-worded** as the card requires. The old claim ("the `enforce` verdict has never been produced by a CI invocation of this script") understated the gate in the direction that flatters it. The replacement splits the note along the axis that actually holds:

- *Phase-independent*: what `--self-test` covers. The fixtures pass `judge()` its `pre` argument directly and build their own throwaway repos, and the assertions that read the real `.changeset/` for its phase were already removed at #8654.
- *Phase-dependent*: only whether the real scan can reach `enforce` at all — never inside a pre-release window, always outside one.
- And the part the original note was really reaching for: **which** green tick. `clean` is decided *before* pre-mode is consulted (the verdict order in `judge` is contract and is pinned by `--self-test`), so it means what it says in every phase; `exempt` names the window in its own text. A reader trusting a tick needs to read which one it is, not the repo's phase.

## H2 — the full sweep for other copies

Swept for the word `dormant`, for `pre.json`, for `stands aside` / `cannot fail` / `never been produced`, and for every file naming the guard. **The card's count of two is correct** — these are the only two stale present-tense claims about this guard.

Deliberately **not** edited, each checked and found already correct:

| surface | why it is not stale |
| --- | --- |
| `check-changeset-no-major.mjs` header "RC EXEMPTION" (~L34) | already conditional ("when Changesets is in pre-release mode") |
| same file, `judge()` docblock (~L472) | already conditional ("while the repo is in pre-mode") |
| same file, header measurement (~L62) | explicitly dated to `@changesets/cli` v2; reads as history |
| `cut-rc.yml` L52, L465 | states the lane's *requirement*, not the repo's state |
| `release.yml` L515 | narrates the #3600 → #8643 history in the past tense, already corrected |
| `.claude/**`, `skills/**` | zero hits — nothing governed mentions this guard |

One genuinely stale neighbour was found and filed rather than folded in — see below.

## H3 — does anything test the dormant claim?

No, and that is itself the finding: **#8654 already did this job on the fixture side.** It removed every phase-asserting assertion from this file's `--self-test` (the "majors pending NOW, pre.json present NOW" halves), replacing the real-directory reads with a two-branch `if (existsSync(pre.json))` that passes in both phases. There is no test named for the dormant state, no skipped case, no `--update` remedy line. The prose was simply left behind when the fixtures were fixed.

## H4 — how would this have been caught? A measured "no gate"

**No gate proposed.** Priced rather than waved off:

The mechanically checkable predicate here is "prose asserts a `pre.json` mode that disagrees with `readPre(REPO_ROOT)`". Grepping the repo for the literal `"mode": "pre"` outside `.changeset/` returns roughly four legitimate uses for every true positive — the RC EXEMPTION note's *definition* of the condition, cut-rc.yml's *requirement* error message, this file's *dated* v2 measurement, and the self-test fixtures that write the JSON themselves. Separating those from an assertion about today's repo is the natural-language read this lane rejected on #9668 and #9640.

The narrower variant — gate the phrase `pre.json currently says` — is worse, not better: it pins one English spelling of the mistake, so it is evaded by rewording while reporting green, which is the phantom-check shape the repo names explicitly elsewhere in this same file.

What actually closes the class is structural and is what this PR does: prose stated as a **condition** cannot go stale at a phase transition, so there is nothing left for a gate to detect. #8654 applied that same move to the assertions; this applies it to the prose. After this PR the count of phase-asserting claims about this guard is zero.

## Out of scope, filed separately

`.github/workflows/cut-rc.yml` L795 tells the reader to ship a migrated hotcrm release "before `changeset pre exit` re-arms that gate" — but `release.yml` L515-535 records (#8643) that pre-exit *did* re-arm it, the deadlock persisted, and the posture was re-keyed to shipping a migrated hotcrm release instead. Same defect class, **different guard**, and its correct replacement is a statement about release policy — so it is filed as its own unassigned card rather than ridden in here.

## Verification

Local gate union re-run on the final commit `b63a53bb9` (derived with `node scripts/pm/dispatch-gates.mjs .github/workflows/pr-automation.yml scripts/check-changeset-no-major.mjs`), all green:

```
check:changeset-gate-self-tests    exit 0   (116 + 118 + 212 assertions)
real scan, --base origin/main      exit 0   ✓ This diff introduces no `major` bump.
check:nul-bytes                    exit 0   6271 text files, no raw control bytes
check:node-version                 exit 0
check:required-contexts            exit 0
check:shard-attestation            exit 0
check:workflow-status-functions    exit 0   25 workflows parsed, 44 jobs
check:cross-package-test-inputs    exit 0
```

`check:workflow-status-functions` and `check:required-contexts` both parse `pr-automation.yml`, so the edited YAML is confirmed valid.

No changeset: comments only, nothing publishes. `skip-changeset` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_