### PR TITLE
fix(pm): add a line ceiling for root AGENTS.md

### DIFF
--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -65,6 +65,11 @@ export const CEILINGS = new Map([
   ['.claude/skills/checklist-author/SKILL.md', 61],
   ['.claude/skills/dogfood-verification/SKILL.md', 155],
   ['.claude/skills/spec-property-retirement/SKILL.md', 328],
+  // #9792: root AGENTS.md is the largest, most-read, most binding instruction
+  // file in the repo and had no ceiling — the hole the oversized 39-line
+  // read-layer clause (compacted by #9715) entered through. Set at its line
+  // count on `origin/main` after #9715 landed (headroom 0, same convention).
+  ['AGENTS.md', 958],
 ]);
 
 export function verdict(rel, lineCount, maxLines) {
@@ -126,6 +131,7 @@ function selfTest() {
     ['the dev-agent definition is covered', CEILINGS.has('.claude/agents/os-dev.md'), true],
     ['all five compressed references are covered', ['dispatch-runbook', 'platform-readings', 'review-checklist', 'landing-operations', 'seat-post-protocol'].every((n) => CEILINGS.has(`.claude/skills/pm-dispatch/references/${n}.md`)), true],
     ['the other four skills are covered (#9473)', ['checklist-test', 'checklist-author', 'dogfood-verification', 'spec-property-retirement'].every((n) => CEILINGS.has(`.claude/skills/${n}/SKILL.md`)), true],
+    ['root AGENTS.md is covered (#9792)', CEILINGS.has('AGENTS.md'), true],
   ];
   let failed = 0;
   for (const [name, actual, expected] of cases) {


### PR DESCRIPTION
Fixes #9792

`scripts/pm/check-skill-line-ratchet.mjs` held per-file ceilings for every
`.claude/skills/**` instruction surface plus `.claude/agents/os-dev.md`, but root
`AGENTS.md` — the largest, most-read, most binding instruction file in the repo — had no
ceiling. That was the hole the oversized 39-line read-layer clause entered through before
it was compacted by #9715.

## Change

Added a `CEILINGS` entry for `AGENTS.md` at its line count measured on fetched
`origin/main` **after** #9715 (`e57524c`, 2026-08-19T01:13Z) landed, which is confirmed to
still be the tip commit touching `AGENTS.md`:

```
$ git show origin/main:AGENTS.md | wc -l
958
```

`958`, headroom 0 — the same shrink-only convention every other entry in the map already
uses (lower freely; raising later needs a maintainer ruling quoted in the PR, per the
script's own header comment). Extended `--self-test` with a coverage case pinning that
`AGENTS.md` is in the map.

File surface is exactly `scripts/pm/check-skill-line-ratchet.mjs`, per the card.

## Sequencing check (re-verified fresh, not taken from the card)

- `git show origin/main:AGENTS.md | wc -l` after a fresh `git fetch origin main` still
  shows `e57524c` as the newest commit touching `AGENTS.md` — no further AGENTS.md PR
  landed since the card was filed.
- Searched open PRs for `AGENTS.md` and for `check-skill-line-ratchet`: none open touch
  either file.

## Gates — all at `fac4602f3`

```
$ pnpm check:pm-skill-ratchet
✓ check-skill-line-ratchet self-test: 13 cases pass.
...
✓ check-skill-line-ratchet: AGENTS.md is 958 lines (ceiling 958; headroom 0).

$ pnpm check:cross-package-test-inputs
All 33 self-test cases passed.
OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.

$ pnpm check:nul-bytes
✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)
check-nul-bytes: OK (scanned 6278 text file(s) -- 6278 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).
```

Gate union re-derived from the real diff (`node scripts/pm/dispatch-gates.mjs`, no paths
passed — script derives the change set from merge-base itself):

```
Local gates for this card:
  - pnpm check:cross-package-test-inputs   [lint.yml]   matched via scripts/pm/check-skill-line-ratchet.mjs ⇢ gate source 'scripts/**'
  - pnpm check:pm-skill-ratchet   [lint.yml]   matched via scripts/pm/check-skill-line-ratchet.mjs ⇢ gate script 'scripts/pm/check-skill-line-ratchet.mjs'
  - node scripts/check-cross-package-test-inputs.mjs   [ci.yml]   matched via scripts/pm/check-skill-line-ratchet.mjs ⇢ gate source 'scripts/**'
```

Re-ran the full union again after the final commit (`fac4602f3`) — same three families,
all green, byte-identical set to the pre-commit run.

`scripts/` only, nothing published: no changeset.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_