### PR TITLE
refactor(rest): compile the non-door getMetaItems request literals against the declared contract (#9805)

### DIFF
--- a/.changeset/getmetaitems-helper-request-literals-typed.md
+++ b/.changeset/getmetaitems-helper-request-literals-typed.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/rest": patch
+---
+
+refactor(rest): the non-door `getMetaItems` request literals are compiled against the declared contract (#9805)
+
+Nine `getMetaItems` call sites in `packages/rest/src/rest-server.ts` outside the
+four meta-read doors still passed their request through `as any` (or through a
+`p: any` parameter), so the compiler checked nothing about them. Every member
+they thread has been expressible in declared types since #9741 landed
+`previewDrafts` on `GetMetaItemsRequest` and the `TransportScopedMetaRequest`
+envelope for the transport-level `environmentId` — the casts were pure
+blindness, and an un-typed request literal is exactly the class that lets a
+future key drift silently.
+
+Each literal is now a named const typed
+`TransportScopedMetaRequest<GetMetaItemsRequest>` (or plain
+`GetMetaItemsRequest` where the site threads no `environmentId`), the same shape
+#9741 gave the doors: the object-metadata read behind the API-exposure gate, the
+audience book fetch, the book-tree book and doc listings, the doc corpus behind
+the audience resolver, the public-form view lookup, the public-form object
+schema, the public-lookup reference resolution, and the dataset listing.
+
+**No behaviour change of any kind, and nothing about the wire moves.** The
+outgoing payloads are byte-identical (same keys, same conditional spreads); the
+edit hoists each literal into a const and drops a type-level cast. Two spellings
+at these sites deliberately SURVIVE, because retiring either would change
+behaviour rather than typing, and both are now documented on the envelope alias:
+
+- the optional call (`getMetaItems?.(…)`) and the `typeof … === 'function'`
+  guards — `getMetaItems` is a required `MetadataProtocol` member, so these are
+  not feature detection in the type sense, but a host may occupy the protocol
+  slot with an object that does not implement the whole surface (the reason
+  `metaTypeIsLive` documents the same spelling for `getMetaTypes`). Retiring one
+  turns a tolerated absence into a `TypeError`;
+- the result handling — the verb is declared to return `{ type, items }` while
+  these sites also tolerate the bare-array shape older hosts and stubs return,
+  so the response stays runtime-shaped on purpose.
+
+Genuinely feature-detected server-only verbs (`getMetaDiagnostics`,
+`listDrafts`, `migrateStoredMetadata`, …) are untouched — runtime casts are the
+documented convention there, and tightening one would turn optional capability
+detection into a hard dependency.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -134,6 +134,28 @@ export type RestProtocol = DataProtocol & MetadataProtocol;
  * is now checked against the spec contract — an undeclared member is a compile
  * error at the call site, not a cast-and-hope. Never add protocol members
  * here; a key that belongs to the request belongs in the spec schema.
+ *
+ * [#9805] The same typing now covers the NON-door `getMetaItems` helper call
+ * sites in this file (the object, book, doc, view and dataset listings). Two
+ * spellings those sites carry deliberately SURVIVE the tightening, because
+ * retiring either would change behaviour rather than typing:
+ *
+ *   - The OPTIONAL CALL (`getMetaItems?.(…)`) and the
+ *     `typeof … === 'function'` guards. `getMetaItems` is a REQUIRED
+ *     `MetadataProtocol` member, so these are not feature detection in the
+ *     type sense — but a host may occupy the protocol slot with an object
+ *     that does not implement the whole surface, which is the measured reason
+ *     they exist (`metaTypeIsLive` documents the same deliberate spelling for
+ *     `getMetaTypes`). Retiring one turns a tolerated absence into a
+ *     `TypeError`.
+ *   - The RESULT handling. `getMetaItems` is declared to return
+ *     `{ type, items }`, while these sites also tolerate the bare-array shape
+ *     older hosts and stubs return (see `metaItemsArray`), so the response
+ *     stays runtime-shaped on purpose.
+ *
+ * The REQUEST is what is fully typeable today, and the request is what is
+ * typed — which is the whole point: an undeclared key in one of these
+ * literals is now a compile error instead of a cast-and-hope.
  */
 type TransportScopedMetaRequest<R> = R & { environmentId?: string };
 import {
@@ -1329,10 +1351,11 @@ export class RestServer {
      */
     private async loadObjectItems(p: RestProtocol, environmentId: string | undefined): Promise<any[]> {
         try {
-            const r: any = await (p as any).getMetaItems?.({
+            const objectsRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                 type: 'object',
                 ...(environmentId ? { environmentId } : {}),
-            });
+            };
+            const r: any = await p.getMetaItems?.(objectsRequest);
             return Array.isArray(r?.items) ? r.items : Array.isArray(r) ? r : [];
         } catch (err) {
             // [#3545] The API-exposure gate fails OPEN when object metadata can't
@@ -1711,11 +1734,12 @@ export class RestServer {
     }
 
     /** Fetch every book of the environment, shaped for the audience resolver. */
-    private async fetchAudienceBooks(p: any, environmentId: string | undefined): Promise<any[]> {
-        const raw = await p.getMetaItems({
+    private async fetchAudienceBooks(p: RestProtocol, environmentId: string | undefined): Promise<any[]> {
+        const booksRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
             type: 'book',
             ...(environmentId ? { environmentId } : {}),
-        } as any).catch(() => []);
+        };
+        const raw = await p.getMetaItems(booksRequest).catch(() => []);
         return RestServer.metaItemsArray(raw).map((b: any) =>
             b && typeof b === 'object' ? { ...b, packageId: b._packageId } : b,
         );
@@ -4554,11 +4578,12 @@ export class RestServer {
                         const norm = (raw: any): any[] =>
                             Array.isArray(raw) ? raw : (raw && Array.isArray(raw.items) ? raw.items : []);
 
-                        const books = norm(await prot.getMetaItems({
+                        const booksRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                             type: 'book',
                             ...(packageId ? { packageId } : {}),
                             ...(environmentId ? { environmentId } : {}),
-                        } as any));
+                        };
+                        const books = norm(await prot.getMetaItems(booksRequest));
                         let book = books.find((b: any) => b && b.name === req.params.name);
                         if (!book) {
                             // Unknown name → the implicit per-package book (§6.4).
@@ -4583,11 +4608,12 @@ export class RestServer {
                             return;
                         }
 
-                        const docs = norm(await prot.getMetaItems({
+                        const docsRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                             type: 'doc',
                             ...(packageId ? { packageId } : {}),
                             ...(environmentId ? { environmentId } : {}),
-                        } as any))
+                        };
+                        const docs = norm(await prot.getMetaItems(docsRequest))
                             .map((d: any) => (d && typeof d === 'object' ? resolveDocLocale(d, locale) : d))
                             .map((d: any) => ({
                                 name: d.name,
@@ -5135,10 +5161,12 @@ export class RestServer {
                                     if (caller.authenticated && !RestServer.anyPermissionSetAudience(books)) {
                                         allowed = true; // no gated book anywhere → org suffices
                                     } else {
-                                        const corpus = RestServer.metaItemsArray(await p.getMetaItems({
+                                        const docCorpusRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                                             type: 'doc',
                                             ...(environmentId ? { environmentId } : {}),
-                                        } as any).catch(() => []))
+                                        };
+                                        const corpus = RestServer.metaItemsArray(
+                                            await p.getMetaItems(docCorpusRequest).catch(() => []))
                                             .filter((d: any) => d && typeof d === 'object')
                                             .map((d: any) => ({
                                                 name: d.name,
@@ -8028,10 +8056,11 @@ export class RestServer {
         ): Promise<{ view: any; form: any; object: string } | null> => {
             const p = await this.resolveProtocol(environmentId, req);
             if (typeof (p as any).getMetaItems !== 'function') return null;
-            const result: any = await (p as any).getMetaItems({
+            const viewsRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                 type: 'view',
                 ...(environmentId ? { environmentId } : {}),
-            });
+            };
+            const result: any = await p.getMetaItems(viewsRequest);
             const items: any[] = Array.isArray(result?.items)
                 ? result.items
                 : Array.isArray(result)
@@ -8092,10 +8121,11 @@ export class RestServer {
                     try {
                         const p = await this.resolveProtocol(environmentId, req);
                         if (typeof (p as any).getMetaItems === 'function') {
-                            const r: any = await (p as any).getMetaItems({
+                            const objectsRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                                 type: 'object',
                                 ...(environmentId ? { environmentId } : {}),
-                            });
+                            };
+                            const r: any = await p.getMetaItems(objectsRequest);
                             const items: any[] = Array.isArray(r?.items) ? r.items : Array.isArray(r) ? r : [];
                             const obj = items.find((o: any) => o?.name === match.object);
                             if (obj && obj.fields && typeof obj.fields === 'object') {
@@ -8408,10 +8438,11 @@ export class RestServer {
                     let referenceTo: string | undefined = picker.object;
                     if (!referenceTo && typeof (p as any).getMetaItems === 'function') {
                         try {
-                            const r: any = await (p as any).getMetaItems({
+                            const objectsRequest: TransportScopedMetaRequest<GetMetaItemsRequest> = {
                                 type: 'object',
                                 ...(environmentId ? { environmentId } : {}),
-                            });
+                            };
+                            const r: any = await p.getMetaItems(objectsRequest);
                             const items: any[] = Array.isArray(r?.items) ? r.items : Array.isArray(r) ? r : [];
                             const obj = items.find((o: any) => o?.name === match.object);
                             const def = obj?.fields?.[fieldName];
@@ -8611,7 +8642,8 @@ export class RestServer {
                     let dataset = body.dataset;
                     if (!dataset && body.datasetName) {
                         const p = await this.resolveProtocol(environmentId, req);
-                        const items = await (p as any).getMetaItems?.({ type: 'dataset', previewDrafts }).catch(() => null);
+                        const datasetRequest: GetMetaItemsRequest = { type: 'dataset', previewDrafts };
+                        const items: any = await p.getMetaItems?.(datasetRequest).catch(() => null);
                         const list = Array.isArray(items?.items) ? items.items : (Array.isArray(items) ? items : []);
                         dataset = list.find((d: any) => d?.name === body.datasetName);
                         if (!dataset) {


### PR DESCRIPTION
Fixes #9805

Behaviour-preserving type-tightening in `packages/rest/src/rest-server.ts`: the non-door `getMetaItems` call sites now compile their request literal against the declared spec contract instead of smuggling it past the compiler with `as any`.

The value is not tidiness. An un-typed request literal is exactly the blindness class that lets a future key drift silently — restoring compiler coverage over a request that is *fully typeable today* is the invariant being restored.

## The residue, re-derived on the merged ref (not read off the card)

#9741 (PR #9804, merged `2a29caa532`) landed after the card was written, so the card's list is a clue. Re-derived at `origin/main` `152bff8fcd`. **Population: 25 `getMetaItems` mentions in the file**, placed exhaustively:

| bucket | count | disposition |
|---|---|---|
| comment / prose mentions | 10 | not code |
| `typeof … === 'function'` feature-detect reads | 3 | untouched — see "what survives" |
| call expressions | 12 | ↓ |
| — the #9741 list door (`:4022`) | 1 | ⛔ out of scope by ruling — untouched |
| — already request-typed (`:3438`, `:3479`) | 2 | no residue — measured below |
| — **tightened here** | **9** | this PR |

The three other #9741 doors (`getMetaItem` / `Cached` / `Layered`) are different verbs and sit outside this population entirely. They are untouched.

## The nine sites

Each request literal became a named const typed `TransportScopedMetaRequest< GetMetaItemsRequest >` — #9741's envelope, which declares the transport-level `environmentId` on top of the spec shape — or plain `GetMetaItemsRequest` at the one site that threads no `environmentId` (the same split #9741 used for its uncached door).

| site | helper | request keys |
|---|---|---|
| `:1332` | `loadObjectItems` (API-exposure gate) | `type`, `environmentId?` |
| `:1715` | `fetchAudienceBooks` — also `p: any` → `RestProtocol` | `type`, `environmentId?` |
| `:4557` | book-tree book listing | `type`, `packageId?`, `environmentId?` |
| `:4586` | book-tree doc listing | `type`, `packageId?`, `environmentId?` |
| `:5138` | doc corpus behind the audience resolver | `type`, `environmentId?` |
| `:8031` | `resolveFormBySlug` view listing | `type`, `environmentId?` |
| `:8095` | public-form object schema | `type`, `environmentId?` |
| `:8411` | public-lookup reference resolution | `type`, `environmentId?` |
| `:8614` | dataset listing | `type`, `previewDrafts` |

Every member is declared: `type` / `packageId` / `organizationId` / `previewDrafts` on `GetMetaItemsRequest` (the last one is #9741's), plus the envelope's `environmentId`. **`packages/spec` needed no change** — no new or widened declared key was required at any site.

## Two card-named sites delivered no diff, and the measurement is why

`:3438` (discovery `{object}` expansion) and `:3479` (the `api` listing) are `protocol?.getMetaItems?.({ … })` where `protocol` is typed `RestProtocol | undefined`. **Their request literals are already compiler-checked** — the card read the visible `as any` there, but that cast is on the *result*, not the request. There is no request blindness left to retire, and the only remaining `any` at those sites is the response-shape tolerance described below. Delivering a diff there would remove a visible `any` while the shape stayed untypeable — the case the dispatch brief said to name rather than do.

Conversely six sites the card did not name (`:4557`, `:4586`, `:5138`, `:8031`, `:8095`, `:8411`) carried the same defect and are fixed here.

## What deliberately survives, and why each would be a behaviour change

Documented on the `TransportScopedMetaRequest` alias so the next reader does not "finish the job":

- **The optional call** (`getMetaItems?.(…)`) **and the `typeof … === 'function'` guards.** `getMetaItems` is a required `MetadataProtocol` member, so the card is right that these are not feature detection *in the type sense* — but `metaTypeIsLive`'s own comment records the measured reason they exist: a host may occupy the protocol slot with an object that does not implement the whole surface. Retiring one converts a tolerated absence into a `TypeError` at runtime.
- **The result handling.** The verb is declared to return `{ type, items }` while these sites also tolerate the bare-array shape older hosts and stubs return (`metaItemsArray`). The response stays runtime-shaped on purpose; only the request is typeable today, and only the request is typed.
- **Genuinely feature-detected server-only verbs** (`getMetaDiagnostics`, `listDrafts`, `migrateStoredMetadata`, …) — untouched. Runtime casts are the documented convention there, and tightening one would turn optional capability detection into a hard dependency, silently at compile time.

**Zero runtime change.** Each edit hoists a literal into a const and drops a type-level cast; outgoing payloads are byte-identical (same keys, same conditional spreads), and `as any` erases at emit.

## Verification — all at head `a98b6834e3`

- `pnpm --filter @objectstack/rest typecheck` (`tsc --noEmit`) — clean, real exit 0.
- `pnpm --filter @objectstack/rest test` (`vitest run`) — **129 files / 2105 tests passed**, real exit 0 read unpiped (a redirect, not a pipe, so no masked teardown code).
- **Reverse verification, direction predicted then observed: red.** Injecting `bogusKey: 1` into the `loadObjectItems` literal → `TS2353`, and the printed type resolves the declared shape out of the rebuilt `.d.ts`: `TransportScopedMetaRequest< { type: string; packageId?: string | undefined; organizationId?: string | undefined; previewDrafts?: boolean | undefined; } >` — `previewDrafts` present proves it is reading #9741's landed declaration, not a stale build. Injecting `previewDrafts: 'yes'` into the dataset literal → `TS2322: Type 'string' is not assignable to type 'boolean | undefined'`. Restored from the commit (never from `origin/main`), re-typechecked green.
- Dependency closure built first in the fresh worktree: `pnpm --filter '@objectstack/rest^...' build` — green.
- Gates re-derived from the actual diff (`node scripts/pm/dispatch-gates.mjs`, no hand-fed paths) at the final head: all **11** path-matched families green — `check:authz-resolver`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:dispatcher-error-vocabulary`, `check:objectui-changeset`, `check:route-envelope`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-cross-package-test-inputs`, `check-empty-changeset`, `check-affected-docs`. Plus the three the derivation is known not to name: `pnpm lint` (`eslint . --no-inline-config`) green, `check:slot-lookup` green, `check:nul-bytes` green — and `check:meta-type-normalized`, which scans this file, green.
- `check:route-envelope` is a ratchet on this file and its count is unmoved: no envelope call site is added or removed.

## Changeset

`@objectstack/rest` **patch**, stated rather than assumed. `skip-changeset` would be wrong here: that label is for a PR that publishes nothing (tests / workflow / `.claude/` only), and this one edits production source in a published package, so the package does republish — even though there is no behaviour, no wire and no public-type change. `TransportScopedMetaRequest` is a module-local type and `fetchAudienceBooks` is private, so no exported surface moves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeN7F6jQFpcqW2BN56RdPa)_