### PR TITLE
docs(scripts): narrow check-org-identifier's stated reason for excluding tests, and pin what it cannot see

### DIFF
--- a/scripts/check-org-identifier.mjs
+++ b/scripts/check-org-identifier.mjs
@@ -29,9 +29,15 @@
 //     database-per-tenant kernels) do not trip it. For the rare genuine
 //     driver-layer `session.tenantId`, add an `os-allow-tenant-id` comment on
 //     the same line.
-//   • Test/spec files are EXCLUDED: they legitimately reference the removed
-//     token to assert its ABSENCE (`expect(session.tenantId).toBeUndefined()`),
-//     and are not reference bodies an author copies a hook from.
+//   • Test/spec files are EXCLUDED, and the exclusion is WHOLESALE: it drops
+//     the FILE, not a shape inside it. The population it is written for is
+//     real -- a body naming the removed token to assert its ABSENCE
+//     (`expect(session.tenantId).toBeUndefined()`) is not a reference body an
+//     author copies a hook from. But "asserts its absence" is narrower than
+//     the exclusion, which also drops fixtures that CONSTRUCT the removed
+//     dialect as INPUT. That second population is not a reference body either,
+//     and it is invisible to the DETECTOR as well -- so this filter is not what
+//     hides it. Measured under "What the test exclusion covers" below (#9809).
 //   • Comments are SKIPPED -- a migration note that NAMES the removed alias to
 //     explain its removal is documentation, not an executable read. Which spans
 //     ARE comments is decided by the ONE shared string-, template- and regex-
@@ -152,8 +158,74 @@
 //   • The BINDING rule reads code, not strings: an aliased read taught inside a
 //     template literal is seen by neither rule (the TEXT rule catches only the
 //     literal spelling there).
+//   • A `session` OBJECT LITERAL is not a read, so no rule scores it. Both
+//     rules resolve a session-valued RECEIVER and grade a `.tenantId` READ off
+//     it; `session: { tenantId: … }` CONSTRUCTS the removed dialect instead and
+//     scores zero in test and non-test files alike (#9809, below).
 // These are the shapes to widen to if one ever goes live. They are named here
 // so a future green is read as "clean where this gate can see", never as proof.
+//
+// ## What the test exclusion covers, and what it does not (#9809)
+//
+// The bullet above used to justify the exclusion as "tests assert the alias is
+// GONE". That is true of one population and silent about a second: a fixture
+// can also CONSTRUCT the removed dialect, handing the code under test a
+// `session: { …, tenantId: … }` literal that `HookContextSchema` strips and
+// `ObjectQLEngine.buildSession` never emits. The second shape is the one that
+// can hold a production defect green, because the fixture supplies the very key
+// production cannot -- which is how the pre-#9691 attachment fixture kept
+// `callerContext()` reading a dead name for two majors.
+//
+// ⚠️ But the exclusion is NOT what hides that shape, and this is the correction
+// worth carrying. Both rules grade a `.tenantId` READ off a receiver shown to
+// be a session. An object literal whose KEY is `tenantId` under a `session:`
+// property is a CONSTRUCTION, not a read, so no rule scores it -- and it scores
+// zero in the scanned population too. Measured by running `findOffenders` over
+// each shape under a NON-test filename, i.e. with the exclusion bypassed:
+//
+//   `expect(session.tenantId).toBeUndefined()`  (assertion side) ........ 1
+//   `session: { userId, tenantId, positions }`  (input side) ............ 0
+//   the verbatim pre-#9691 phantom-green, input + echoed expectation .... 0
+//
+// So deleting the test exclusion would not surface a single construction site.
+// Reaching them is a NEW recognizer on a new axis (literal construction), not a
+// loosening of this filter -- which is what makes it a judgement call rather
+// than a repair, and the census says it is not earned yet.
+//
+// CENSUS on 83f8267f5 (2026-08-19), over the 2449 test/spec files the exclusion
+// drops -- 2058 files remain scanned. Reproduce with:
+//
+//   rg -l --multiline --multiline-dotall 'session\s*:\s*\{[^{}]*\btenantId\b' \
+//     -g '*.test.ts' -g '*.spec.ts' examples apps packages
+//
+//   `session: { … tenantId … }` literals in EXCLUDED test files ......... 4
+//   ... of them wrong today ............................................ 0
+//   the same literal in the SCANNED (non-test) population ............... 0
+//
+//     packages/spec/src/data/hook.test.ts:619                   #3290 absence pin
+//     packages/plugins/plugin-audit/src/audit-writers.test.ts:1666  absence pin
+//     packages/plugins/plugin-audit/src/comment-access-hooks.test.ts:529  #9691
+//     packages/services/service-storage/src/attachment-access-hooks.test.ts:750
+//
+// (The recipe reports 5 matches across those 4 files: `hook.test.ts` carries a
+// second one whose `tenantId` sits inside a COMMENT in the literal's body.)
+//
+// ⛔ The distinguishing signal is NOT "input side vs assertion side". All four
+// deliberate pins put the removed key on the INPUT side -- constructing the
+// dialect on purpose is HOW you pin that it gets stripped. What separates them
+// from a phantom-green is whether the fixture asserts the key's FATE (absent,
+// or inert downstream) or echoes its VALUE back as expected output. Even that
+// does not reduce to a text rule: `attachment-access-hooks.test.ts` legitimately
+// asserts `toEqual({ …, tenantId: 'org_1', … })` one test earlier, because
+// `tenantId` on the way OUT is `ExecutionContext`'s driver-layer name for the
+// same value -- byte-identical to what a phantom-green would write. A recognizer
+// on this axis has to tell those two apart, and today it would ship catching
+// nothing: 4 sites, 0 wrong.
+//
+// Both shapes are pinned in `--self-test`, so this stays executable rather than
+// remembered. An author who later builds the construction-axis recognizer will
+// see the input-shape cases flip from 0 to 1: that is the contract moving on
+// purpose, not a regression.
 //
 // ## The population invariant -- zero is a broken scan, not a clean repo
 //
@@ -201,7 +273,10 @@ import { maskComments } from './js-comment-mask.mjs';
 const ROOTS = ['examples', 'apps', 'packages'];
 const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.cts', '.mts'];
 const EXCLUDED = /(^|\/)(node_modules|dist|build|\.next|\.turbo)\//;
-// Tests assert the alias is GONE, so they reference the token on purpose.
+// Dropped WHOLESALE: absence pins and fixtures that CONSTRUCT the removed
+// dialect alike. Neither is a reference body an author copies -- and the
+// construction shape is invisible to both rules anyway, so this filter is not
+// what hides it (#9809, header).
 const TEST_FILE = /(\.(test|spec)\.[cm]?[jt]sx?$)|((^|\/)__tests__\/)/;
 
 // `ctx.session.tenantId`, `session?.tenantId`, `this.session . tenantId`, … --
@@ -566,6 +641,18 @@ function selfTest() {
       'a comment naming an ALIASED read is documentation -- the tree never sees it'],
     ['function h(ctx) {\n  const execCtx = ctx.input.options.context;\n  return execCtx.tenantId;\n}', 0,
       'NO FALSE RED: the driver-layer envelope is not reached through `.session`'],
+
+    // ── #9809: what the test exclusion covers, and what it does not ─────
+    // These run through the DETECTOR under a non-test filename, so they state
+    // what the RULES do independently of the TEST_FILE filter. An author who
+    // builds the construction-axis recognizer flips the two 0s to 1s: that is
+    // the contract moving on purpose, not a regression.
+    ['expect(session.tenantId).toBeUndefined();', 1,
+      'ABSENCE PIN: the shape the test exclusion is written for -- a finding but for the filter'],
+    ["await hook({\n  object: 'sys_attachment',\n  session: { userId: 'u1', tenantId: 'stale_org', positions: ['p1'] },\n});", 0,
+      'CONSTRUCTION: a `session:` literal spelling the removed key is not a READ, so no rule scores it -- deleting the exclusion would not reach it'],
+    ["await hook({\n  session: { userId: 'u1', tenantId: 'org_1' },\n});\nexpect(canEdit.mock.calls[0][2]).toEqual({ userId: 'u1', tenantId: 'org_1' });", 0,
+      'CONSTRUCTION: the verbatim pre-#9691 phantom-green -- input literal plus echoed expectation, invisible to both rules'],
   ];
 
   let failed = 0;


### PR DESCRIPTION
Fixes #9809

Option (1) from the card, as ruled: leave the exclusion as-is, narrow the header's stated reason to match what the exclusion actually does, and record the measurement in the script so the next reader sees measurement rather than assertion. No recognizer is added — the gate's accept/reject behaviour is unchanged (verified: same corpus, same verdict, same 2058 files).

## What the card asked, and what measuring it changed

The card's framing is that the wholesale test exclusion is blind to fixtures that CONSTRUCT the removed session dialect, as opposed to those asserting its absence. That is true. But running the gate's own `findOffenders` over each shape under a NON-test filename — i.e. with the exclusion bypassed — says the exclusion is **not what hides the construction shape**:

```
`expect(session.tenantId).toBeUndefined()`  (assertion side) ........ 1
`session: { userId, tenantId, positions }`  (input side) ............ 0
the verbatim pre-#9691 phantom-green, input + echoed expectation .... 0
```

Both rules grade a `.tenantId` READ off a receiver shown to be a session. An object literal whose key is `tenantId` under a `session:` property is a construction, not a read, so no rule scores it — in the scanned population either. **Deleting the test exclusion would not surface a single construction site**, including the one instance that actually held a live defect green. Reaching them is a new recognizer on a new axis, not a loosening of this filter — which is what makes the card's option (2) a judgement call rather than a repair.

## Census (H1), re-measured on `83f8267f5`

The card measured on `11b779e0f` plus the #9691 branch. Re-run on current `main`:

```
tracked test/spec files the exclusion drops ......... 2449   (card: 2435)
files the gate actually scans ....................... 2058
`session: { … tenantId … }` literals in those tests .... 4
... of them wrong today ............................... 0
the same literal in the SCANNED (non-test) population . 0
```

Same 4 sites the card names, all still deliberate. **4 sites, 0 wrong — the census holds, so the ruling holds.** No live phantom-green found, so the card's stop-and-report condition was not triggered.

Reproduce the census:

```
rg -l --multiline --multiline-dotall 'session\s*:\s*\{[^{}]*\btenantId\b' \
  -g '*.test.ts' -g '*.spec.ts' examples apps packages
```

## The INPUT/ASSERTION distinction does not survive contact (H3)

Worth stating, because it is what a future author needs in order to price option (2): **all four deliberate pins put the removed key on the INPUT side.** Constructing the dialect on purpose is *how* you pin that it gets stripped, so "input side" does not mean "phantom-green".

What separates them is whether the fixture asserts the key's FATE or echoes its VALUE back as expected output — and even that does not reduce to a text rule. `attachment-access-hooks.test.ts` legitimately asserts `toEqual({ …, tenantId: 'org_1', … })` one test earlier, because `tenantId` on the way OUT is `ExecutionContext`'s driver-layer name for the same value. Byte-identical to what a phantom-green would write. A recognizer on this axis has to tell those two apart, and today it would ship catching nothing.

## Where the overclaim lived (H2)

Two copies, **both inside the gate script**, both narrowed here:

- `scripts/check-org-identifier.mjs` — the header bullet (the one the card quotes).
- `scripts/check-org-identifier.mjs` — a terser restatement above the `TEST_FILE` regex: "Tests assert the alias is GONE, so they reference the token on purpose."

Checked and clean, no edit needed:

- `.github/workflows/lint.yml` states the exclusion neutrally ("tests, comments, skills/ and docs/ are excluded") without claiming a reason — no overclaim to correct.
- `AGENTS.md`, `.claude/**` — no mention of this gate or the alias at all. **No governed-surface copy exists**, so nothing needed reporting-instead-of-editing on that axis.
- Sibling gates with a `TEST_FILE` regex (`check-test-source-alias`, `check-type-check-coverage`) exclude tests for unrelated reasons and did not copy this justification.

## Executable, not remembered (H4)

The script already had a `--self-test` harness, so the blind spot is pinned in it rather than described: 28 cases to 31. The absence-pin shape asserts 1 offender (a finding but for the filter); the two construction shapes assert 0 (invisible to both rules). An author who later builds the construction-axis recognizer sees those flip to 1 — the contract moving on purpose, labelled as such in the case comments.

Reverse-verified from the committed state: flipping all three expectations turns the harness red and names each case individually, so none of them passes vacuously.

## Scope notes

- **No changeset.** Comment prose plus self-test cases in a CI script; nothing user-visible is published. `.changeset/**` is inside the #9465 epic fence.
- **#9747 is not addressed here** and nothing was added to it — cross-referenced in prose only, per the ruling that its scope is visibility-only and does not cover this gate.
- Out-of-scope finding filed while sweeping H2: #9872 (roughly ten comments date the #3290 removal to "v11" when it shipped in v16, and there is no v11 release page at all). Not touched in this PR.

## Verification

All on the final commit `fab54d793`:

```
pnpm check:org-identifier
  ✓ check-org-identifier self-test: 31 cases pass.
  check-org-identifier: OK (2058 author-facing source file(s), 13 session
  binding(s) resolved, no removed session.tenantId alias).

pnpm check:cross-package-test-inputs
  All 33 self-test cases passed.
  OK: 12 package(s) read outside themselves, all declared.

node scripts/check-nul-bytes.mjs
  OK (scanned 6282 text file(s), no raw ASCII control bytes).
```

Gate family derived from the changed path with `node scripts/pm/dispatch-gates.mjs scripts/check-org-identifier.mjs`, which named exactly the first two; `check:nul-bytes` added because the diff is all prose.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_