### PR TITLE
security(service-datasource): require manage_platform_settings on the datasource-admin routes

### DIFF
--- a/.changeset/rare-donkeys-repeat.md
+++ b/.changeset/rare-donkeys-repeat.md
@@ -1,0 +1,23 @@
+---
+'@objectstack/service-datasource': patch
+---
+
+Datasource-admin HTTP routes now require the `manage_platform_settings` capability, not merely authentication.
+
+All eleven routes under `/api/v1/datasources` — list, read, driver catalog, remote-table
+introspection, connection probes, credential migration, create, patch and remove — answer
+`403 PERMISSION_DENIED` to a caller that resolves to an identity holding no
+`manage_platform_settings` grant. The anonymous floor is unchanged (`401 UNAUTHENTICATED`).
+
+The capability is matched to what the adjacent Setup-admin families already gate on, not
+minted: `@objectstack/service-settings`'s platform-infrastructure namespaces (`mail`,
+`storage`, `sms`, `auth`, `ai`, `knowledge`) declare it for reads and writes alike, and this
+service's own Setup nav entry already declared `requiredPermissions:
+['manage_platform_settings']` for the console door in front of these routes. There is no
+read/write split for the same reason those namespaces have none: a datasource read returns
+stored connection configuration and live remote-schema introspection.
+
+Impact: `admin_full_access` carries `manage_platform_settings`, so platform admins are
+unaffected. A deployment that granted non-admin users access to Setup → Datasources through
+some other capability must now grant `manage_platform_settings` (or bind those users to a
+permission set carrying it).

--- a/packages/rest/src/remote-tables-twin.equivalence.test.ts
+++ b/packages/rest/src/remote-tables-twin.equivalence.test.ts
@@ -94,14 +94,88 @@ const REMOTE: IntrospectedSchema = {
   },
 };
 
-/** The credential the admin spelling's authentication floor admits (#9391). */
+/**
+ * The credential every request-shape case presents: authenticated (#9391) AND
+ * holding `manage_platform_settings`, which the admin spelling requires as of
+ * #9593.
+ *
+ * The entitlement is not decoration. Before #9593 the admin spelling admitted
+ * any authenticated caller, so a bare session was enough to compare the two
+ * answers; now an unentitled session makes the admin spelling answer 403 and
+ * every case below would be comparing a 200 against a refusal — reading an
+ * ADMISSION difference as a request-shape divergence, the one thing this file
+ * exists not to confuse (the same reason #9391 made it wire `auth` at all).
+ */
 const SESSION = 'Bearer twin-session';
+
+/**
+ * [#9593] A second credential: authenticated, holding nothing. This is the
+ * posture on which the two spellings now genuinely DIVERGE, and the divergence
+ * gets its own pinned case at the bottom of this file rather than being
+ * papered over here.
+ */
+const UNENTITLED_SESSION = 'Bearer twin-session-unentitled';
+
+const USERS: Record<string, string> = {
+  [SESSION]: 'u_twin',
+  [UNENTITLED_SESSION]: 'u_twin_plain',
+};
+
 const authService = {
   api: {
-    getSession: async ({ headers }: { headers: Headers }) =>
-      headers?.get?.('authorization') === SESSION ? { user: { id: 'u_twin' } } : null,
+    getSession: async ({ headers }: { headers: Headers }) => {
+      const id = USERS[headers?.get?.('authorization') ?? ''];
+      return id ? { user: { id } } : null;
+    },
   },
 };
+
+/** The permission set carrying the grant `u_twin` holds and `u_twin_plain` does not. */
+const GRANT_SET_ID = 'ps_twin_datasource_operator';
+
+/**
+ * The RBAC tables `resolveAuthzContext` reads, as a fake data engine — the
+ * same idiom this package's other authz fixtures use
+ * (`rest-exec-ctx-principal-kind.test.ts`), and the same four-table shape the
+ * admin family's own pin builds in `@objectstack/service-datasource`.
+ *
+ * ONE engine serves BOTH spellings: it is wired into the plugin context the
+ * admin registrar resolves `objectql` from, and handed to the
+ * `resolveAuthzContext` call behind the federation registrar's
+ * `resolveExecutionContext`. That is deliberate and load-bearing — the two
+ * spellings must read one identity AND one grant aggregation, or this file
+ * could manufacture agreement (or disagreement) out of two different notions of
+ * who the caller is.
+ *
+ * The set is deliberately not `admin_full_access`: that platform set carries
+ * `manage_platform_settings` among six other capabilities, so a gate keyed on
+ * platform-admin posture rather than on the capability would pass unnoticed.
+ */
+const makeQl = () => ({
+  find: async (object: string, opts: any) => {
+    const where = opts?.where ?? {};
+    if (object === 'sys_user_permission_set') {
+      return where.user_id === 'u_twin'
+        ? [{ id: 'ups_twin', user_id: 'u_twin', permission_set_id: GRANT_SET_ID, organization_id: null }]
+        : [];
+    }
+    if (object === 'sys_permission_set') {
+      const ids: string[] = where.id?.$in ?? [];
+      return ids.includes(GRANT_SET_ID)
+        ? [{
+            id: GRANT_SET_ID,
+            name: 'twin_datasource_operator',
+            // JSON string — the spelling SQLite hands back, which the resolver
+            // parses. Pinning the stored shape keeps the fixture on the real
+            // read path.
+            system_permissions: JSON.stringify(['manage_platform_settings']),
+            object_permissions: '{}',
+          }]
+        : [];
+    }
+    return [];
+  },
+});
 
 /**
  * One server, one service, both registrars — the point of the fixture.
@@ -119,6 +193,7 @@ function mountBoth() {
     listObjects: async () => [],
   });
   const server = new HonoHttpServer(0);
+  const ql = makeQl();
   const ctx = {
     getService: (name: string) => {
       if (name === 'external-datasource') return service;
@@ -128,6 +203,12 @@ function mountBoth() {
       // compare a 200 against a 401 and read the difference as a request-shape
       // divergence — which is the one thing it exists NOT to confuse.
       if (name === 'auth') return authService;
+      // [#9593] …and the admin spelling now also requires a CAPABILITY, which
+      // the same resolver aggregates off the data engine. Same reasoning one
+      // step further: without a grant to read, the comparison would be a 200
+      // against a 403. `objectql` and `data` are one registration under two
+      // names, and the registrar tries them in that order.
+      if (name === 'objectql' || name === 'data') return ql;
       throw new Error(`no service: ${name}`);
     },
   } as any;
@@ -153,15 +234,24 @@ function mountBoth() {
       }
     }
     const authz = await resolveAuthzContext({
-      // No data engine here, stated rather than omitted: `ql` is a required
-      // member, and it is what the api-key admission path reads. This fixture
-      // wires only a session, so that path resolves nothing and the session
-      // path is the one under comparison.
-      ql: undefined,
+      // [#9593] The SAME engine the admin spelling resolves `objectql` to,
+      // stated rather than omitted. It used to be `undefined` here, which was
+      // right while only a session mattered; now that one spelling reads
+      // GRANTS, handing this side a different (or absent) engine would let the
+      // two spellings disagree about the caller for a reason that is the
+      // fixture's, not the code's. One identity function, and now one grant
+      // aggregation.
+      ql,
       headers,
       getSession: async (h: any) => authService.api.getSession({ headers: h }),
     });
-    return authz.userId ? { userId: authz.userId } : undefined;
+    // `systemPermissions` is carried through even though no route in this
+    // package reads it today: the federation spelling gates on authentication
+    // only (see the divergence case at the bottom of this file), and the day
+    // that changes, this resolver already supplies what such a gate would read.
+    return authz.userId
+      ? { userId: authz.userId, systemPermissions: authz.systemPermissions }
+      : undefined;
   };
 
   registerExternalDatasourceRoutes(server, ctx, '/api/v1', { resolveExecutionContext });
@@ -294,8 +384,30 @@ describe('listRemoteTables twins agree on the request shape (#7955)', () => {
  * answers, exactly as the request-shape cases compare table sets. A guard added
  * to one spelling and not the other now fails here, whichever side it is added
  * to — which is the property the equivalence is for.
+ *
+ * ## [#9593] The axis is no longer a single line, and this block says so
+ *
+ * #9593 raised the ADMIN spelling from "any authenticated caller" to
+ * `manage_platform_settings`; the federation spelling still gates on
+ * authentication alone, by its own registrar's stated decision (#9686 ruled
+ * the capability question out of its scope and pointed it here). So the
+ * spellings now agree at the two ends of the axis and diverge in the middle:
+ *
+ *  - anonymous — both refuse `401 UNAUTHENTICATED` (unchanged);
+ *  - unrecognised credential — both refuse `401 UNAUTHENTICATED` (unchanged);
+ *  - authenticated AND entitled — both serve, identically (unchanged);
+ *  - authenticated but UNENTITLED — the admin spelling refuses `403`, the
+ *    federation spelling serves.
+ *
+ * The last row is a real governance asymmetry — one operation, two doors, one
+ * gate — and it is FILED, not accepted: #9901. It is pinned here rather than left unasserted for the reason this
+ * whole block exists: an axis nothing drives is an axis that goes silently
+ * false, which is exactly how the pre-#9686 gap survived. ⚠️ When the
+ * federation spelling grows its own capability gate, that case is EXPECTED to
+ * fail — it is a record of a known gap, not a defence of it, and the correct
+ * response is to fold the row back into the agreement above.
  */
-describe('listRemoteTables twins agree on WHO may ask (#9686)', () => {
+describe('listRemoteTables twins agree on WHO may ask (#9686, #9593)', () => {
   it('an anonymous caller is refused identically on both spellings', async () => {
     const { federation, admin } = await readBoth('', {});
 
@@ -319,13 +431,44 @@ describe('listRemoteTables twins agree on WHO may ask (#9686)', () => {
     expect(admin.code).toBe(federation.code);
   });
 
-  it('the credential that clears one spelling clears the other — same identity, same answer', async () => {
+  it('an ENTITLED credential clears both spellings — same identity, same answer', async () => {
     // The other direction, and the one that makes the refusal cases mean
     // something: the two spellings do not agree merely by refusing everyone.
+    // "Entitled" is now two facts (authenticated, and holding
+    // `manage_platform_settings`), and the default credential carries both.
     const { federation, admin } = await readBoth('?schema=public');
 
     expect(federation.status).toBe(200);
     expect(admin.status).toBe(200);
     expect(qualified(admin)).toEqual(qualified(federation));
+  });
+
+  it('[#9593] an authenticated but UNENTITLED caller diverges: admin refuses 403, federation serves', async () => {
+    // ⚠️ A pinned RECORD OF A KNOWN GAP, not a contract worth keeping — see
+    // this block's header and the finding card #9901. The two
+    // halves are asserted separately and in full so that closing the gap
+    // fails this case loudly instead of drifting past it.
+    const { federation, admin } = await readBoth('', { authorization: UNENTITLED_SESSION });
+
+    // The admin spelling: the #9593 refusal, asserted by status AND
+    // machine-readable code (ADR-0112 envelope) — "not 200" would be satisfied
+    // by the 401 the anonymous case already covers, which would mean the
+    // credential was never read.
+    expect(admin.status).toBe(403);
+    expect(admin.code).toBe('PERMISSION_DENIED');
+    // …and it refused before serving anything.
+    expect(admin.tables).toEqual([]);
+
+    // The federation spelling: authentication was the whole gate here, so the
+    // same caller is served. This is the asymmetry, stated rather than implied.
+    expect(federation.status).toBe(200);
+    expect(qualified(federation)).toEqual([
+      'analytics.events',
+      'public.customers',
+      'public.orders',
+    ]);
+
+    // And it is genuinely a divergence — the point the equivalence axis makes.
+    expect(admin.status).not.toBe(federation.status);
   });
 });

--- a/packages/services/service-datasource/src/__tests__/admin-routes-auth-guard.test.ts
+++ b/packages/services/service-datasource/src/__tests__/admin-routes-auth-guard.test.ts
@@ -1,49 +1,61 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * The authentication pin for the datasource-admin HTTP family.
+ * The authorization pin for the datasource-admin HTTP family.
  *
- * ## Why both halves, and why on ONE boot
+ * ## Why all three postures, and why on ONE boot
  *
  * This family mounts straight onto `IHttpServer` from a plugin `init()`, which
- * is outside every seam that produces the platform's 401s — the REST server's
- * `enforceAuth` and the dispatcher domains' anonymous floor both sit on routes
- * this registrar never passes through. A guard added here is therefore the only
- * thing standing between an anonymous caller and datasource lifecycle
- * management, and a test that only asserts the refusal cannot tell "guarded"
- * apart from "broken": an unconditional 401 would pass it perfectly while
- * taking the Setup → Datasources console offline for everyone.
+ * is outside every seam that produces the platform's 401s and 403s — the REST
+ * server's `enforceAuth` and the dispatcher domains' anonymous floor both sit
+ * on routes this registrar never passes through. A guard added here is
+ * therefore the only thing standing between an unentitled caller and datasource
+ * lifecycle management, and a test that only asserts the refusals cannot tell
+ * "guarded" apart from "broken": an unconditional 401 (or 403) would pass a
+ * refusal-only suite perfectly while taking the Setup → Datasources console
+ * offline for everyone.
  *
- * So every route below is asserted TWICE against the SAME mounted app —
- * `family` is built once at module scope, so the anonymous refusal and the
- * entitled success are answers from one boot of one registrar, not from two
- * differently-wired fixtures that could disagree for reasons other than the
- * caller's identity.
+ * So every route below is asserted THREE times against the SAME mounted app —
+ * `family` is built once at module scope, so all three answers come from one
+ * boot of one registrar, not from differently-wired fixtures that could
+ * disagree for reasons other than the caller's identity and grants:
  *
- * The two halves are separate `it`s rather than one, deliberately: that is what
- * makes the red/green split countable when the guard is reverted — the
- * anonymous half must go red and the entitled half must stay green, and a
- * single combined case would hide the second fact behind the first failure.
+ *  1. **anonymous** → `401 UNAUTHENTICATED` (#9391's floor, unchanged);
+ *  2. **authenticated but unentitled** → `403 PERMISSION_DENIED` (#9593);
+ *  3. **entitled** → the route's own success status.
  *
- * ## What "entitled" means here, and what it does not
+ * The three are separate `it`s rather than one, deliberately: that is what
+ * makes the red/green split countable when either half of the guard is
+ * reverted — removing the capability check turns posture 2 red and leaves 1 and
+ * 3 green, which is a different signature from removing the whole guard — and a
+ * single combined case would hide every later fact behind the first failure.
  *
- * Exactly one thing: the caller is AUTHENTICATED. This family's guard is an
- * authentication floor, and nothing in this file asserts a capability — whether
- * these routes should further require something like `manage_platform_settings`
- * is a separate, separately-ruled question (#9593) and deliberately has no
- * scaffolding here.
+ * ## What "entitled" means here, and how it is granted
  *
- * Identity is resolved by the registrar through the platform's shared
- * `resolveAuthzContext`, so the fake `auth` service below is the real seam a
- * session arrives through, not a test-only bypass.
+ * Two things now: the caller is AUTHENTICATED **and** holds
+ * `manage_platform_settings` — the capability the sibling Setup-admin families
+ * gate on and the one this plugin's own Setup nav entry already declares
+ * (`DATASOURCE_ADMIN_CAPABILITY` in the registrar carries the measurement).
+ *
+ * The grant is delivered the way a deployment delivers it — a
+ * `sys_user_permission_set` row binding the user to a `sys_permission_set`
+ * whose `system_permissions` names the capability, read by the platform's
+ * shared `resolveAuthzContext` off the `objectql` engine — and it is delivered
+ * from `entitled-caller.fixture.ts`, which carries that chain once for the
+ * three suites in this package that need an entitled caller, and the reasoning
+ * behind each of its choices (including why the set is deliberately not
+ * `admin_full_access`).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HonoHttpServer } from '@objectstack/plugin-hono-server';
-import { registerDatasourceAdminRoutes } from '../admin-routes.js';
-
-/** The credential the fake `auth` service below admits. */
-const ENTITLED = 'Bearer entitled-session';
+import { registerDatasourceAdminRoutes, DATASOURCE_ADMIN_CAPABILITY } from '../admin-routes.js';
+import {
+  ENTITLED_CREDENTIAL as ENTITLED,
+  UNENTITLED_CREDENTIAL as UNENTITLED,
+  createSessionAuthService,
+  createGrantsEngine,
+} from './entitled-caller.fixture.js';
 
 /** Every service method the family dispatches to, as spies. */
 function createServiceDouble() {
@@ -64,23 +76,19 @@ function createServiceDouble() {
 }
 
 /**
- * Mount the family once, with a fake `auth` service that admits exactly one
- * credential. `objectql` resolves to `undefined` — the shared resolver reads it
- * only to aggregate permissions, and this pin asserts authentication, so an
- * absent engine must not change who is admitted.
+ * Mount the family once, with the shared `auth` service double — it admits two
+ * distinct credentials, one whose user holds the capability and one whose user
+ * holds nothing — and the shared grants engine as `objectql`, so the capability
+ * half of the guard resolves through the platform's own aggregation.
  */
 function mountFamily() {
   const service = createServiceDouble();
-  const auth = {
-    api: {
-      getSession: async ({ headers }: { headers: Headers }) =>
-        headers?.get?.('authorization') === ENTITLED ? { user: { id: 'u_entitled' } } : null,
-    },
-  };
+  const auth = createSessionAuthService();
+  const engine = createGrantsEngine();
   const ctx = {
     getService: vi.fn((name: string) => {
       if (name === 'auth') return auth;
-      if (name === 'objectql' || name === 'data') return undefined;
+      if (name === 'objectql' || name === 'data') return engine;
       return service;
     }),
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -168,9 +176,28 @@ describe('datasource-admin family — the anonymous caller is refused (read AND 
   }
 });
 
+describe('datasource-admin family — the authenticated caller WITHOUT the capability is refused', () => {
+  for (const c of ALL_CASES) {
+    it(`${c.name} answers 403 PERMISSION_DENIED without \`${DATASOURCE_ADMIN_CAPABILITY}\``, async () => {
+      const { status, body } = await drive(c, UNENTITLED);
+      // Status AND the machine-readable code (ADR-0112 envelope). "Not 200"
+      // would be satisfied by the 401 the anonymous half already covers and by
+      // the 503 an unwired service gives — neither of which is this refusal,
+      // and one of which would mean the credential was not read at all.
+      expect(status).toBe(403);
+      expect(body?.error?.code).toBe('PERMISSION_DENIED');
+      // The message names the grant to ask for, and nothing else.
+      expect(body?.error?.message).toContain(DATASOURCE_ADMIN_CAPABILITY);
+      // Refused BEFORE dispatch, for the reason the anonymous half gives: a
+      // DELETE refused after the service ran has already removed the row.
+      if (c.dispatches) expect(family.service[c.dispatches]).not.toHaveBeenCalled();
+    });
+  }
+});
+
 describe('datasource-admin family — the entitled caller still succeeds', () => {
   for (const c of ALL_CASES) {
-    it(`${c.name} answers ${c.okStatus} for an authenticated caller`, async () => {
+    it(`${c.name} answers ${c.okStatus} for a caller holding \`${DATASOURCE_ADMIN_CAPABILITY}\``, async () => {
       const { status } = await drive(c, ENTITLED);
       expect(status).toBe(c.okStatus);
       if (c.dispatches) expect(family.service[c.dispatches]).toHaveBeenCalled();

--- a/packages/services/service-datasource/src/__tests__/admin-routes.test.ts
+++ b/packages/services/service-datasource/src/__tests__/admin-routes.test.ts
@@ -3,6 +3,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { HonoHttpServer } from '@objectstack/plugin-hono-server';
 import { registerDatasourceAdminRoutes } from '../admin-routes.js';
+import {
+  ENTITLED_CREDENTIAL,
+  createSessionAuthService,
+  createGrantsEngine,
+} from './entitled-caller.fixture.js';
 
 /**
  * End-to-end routing test against the REAL `HonoHttpServer` adapter — the same
@@ -14,30 +19,41 @@ import { registerDatasourceAdminRoutes } from '../admin-routes.js';
  */
 
 /**
- * The credential every request in this file carries, and the fake `auth`
- * service that admits it.
+ * The credential every request in this file carries, and the fakes that admit
+ * it.
  *
- * This family requires authentication (#9391), so a fixture that presented no
- * identity would answer 401 to every case below — a suite measuring the guard
+ * This family requires authentication (#9391) AND the
+ * `manage_platform_settings` capability (#9593), so a fixture that presented no
+ * identity would answer 401 to every case below, and one that presented an
+ * unentitled identity would answer 403 — either way a suite measuring the guard
  * instead of the routing and failure-attribution it exists to measure. The
- * guard itself has its own both-sides pin, `admin-routes-auth-guard.test.ts`;
- * here an authenticated caller is the premise, not the subject.
+ * guard itself has its own three-posture pin,
+ * `admin-routes-auth-guard.test.ts`; here an ENTITLED caller is the premise,
+ * not the subject, and both halves of that entitlement come from the one
+ * `entitled-caller.fixture.ts` definition the pin uses.
  */
-const SESSION = 'Bearer test-session';
-const authService = {
-  api: {
-    getSession: async ({ headers }: { headers: Headers }) =>
-      headers?.get?.('authorization') === SESSION ? { user: { id: 'u_test' } } : null,
-  },
-};
+const SESSION = ENTITLED_CREDENTIAL;
+const authService = createSessionAuthService();
+const grantsEngine = createGrantsEngine();
 
 /**
- * Wrap a `getService` so `auth` resolves to the fake above and every other
- * lookup keeps the behaviour the case under test wired — including throwing,
- * which is what drives the resolver's catch arm.
+ * Wrap a `getService` so `auth` and the data engine resolve to the fakes above
+ * and every other lookup keeps the behaviour the case under test wired —
+ * including throwing, which is what drives the resolver's catch arm.
+ *
+ * The engine is intercepted rather than delegated for the same reason `auth`
+ * is: the guard resolves the caller's grants off `objectql`/`data`, and a case
+ * that deliberately wires a throwing or absent service to exercise a 503 would
+ * otherwise be answering 403 before it ever reached the arm it is testing.
  */
 const withAuth = (getService: (name: string) => unknown) =>
-  vi.fn((name: string) => (name === 'auth' ? authService : getService(name)));
+  vi.fn((name: string) =>
+    name === 'auth'
+      ? authService
+      : name === 'objectql' || name === 'data'
+        ? grantsEngine
+        : getService(name),
+  );
 
 const json = (path: string, init?: RequestInit) =>
   new Request(`http://local${path}`, {

--- a/packages/services/service-datasource/src/__tests__/entitled-caller.fixture.ts
+++ b/packages/services/service-datasource/src/__tests__/entitled-caller.fixture.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The one definition of "an entitled datasource-admin caller", shared by every
+ * suite in this package that drives the HTTP family.
+ *
+ * ## Why it is shared rather than copied
+ *
+ * The family's guard (#9391 authentication, #9593 capability) admits a caller
+ * only when the platform's shared `resolveAuthzContext` resolves an identity
+ * AND aggregates `manage_platform_settings` out of that identity's permission
+ * sets. That is a four-table read, and three suites in this package need a
+ * caller who survives it: the guard's own both-sides pin, which asserts the
+ * refusals and the success, and two suites — routing/failure-attribution and
+ * the envelope conformance — for which an entitled caller is the PREMISE, not
+ * the subject.
+ *
+ * Copied into three files, that chain drifts: a later change to the resolver
+ * would be met by three fixtures updated at three times, and the two premise
+ * suites would start failing for a reason that has nothing to do with what they
+ * measure. One definition, three importers.
+ *
+ * ## What it is NOT
+ *
+ * Not a bypass. Nothing here injects a permission list into the registrar —
+ * `sessionResolver` is the same `auth`-service shape a real deployment
+ * registers and `createGrantsEngine` answers the same `sys_*` reads the
+ * resolver issues against a real store. A guard that stopped consulting the
+ * platform's resolution would fail these fixtures, which is the property that
+ * makes them worth having.
+ */
+
+import { DATASOURCE_ADMIN_CAPABILITY } from '../admin-routes.js';
+
+/** The credential that resolves to a caller holding the capability. */
+export const ENTITLED_CREDENTIAL = 'Bearer entitled-session';
+
+/**
+ * A second credential resolving to a real, authenticated identity that holds
+ * NO capabilities — the posture this family used to serve in full, when
+ * authentication was the whole gate.
+ */
+export const UNENTITLED_CREDENTIAL = 'Bearer unentitled-session';
+
+/** The user ids the two credentials resolve to. */
+export const ENTITLED_USER = 'u_entitled';
+export const UNENTITLED_USER = 'u_plain';
+
+/** The permission set that carries the grant. */
+const GRANT_SET_ID = 'ps_datasource_operator';
+
+/**
+ * ⚠️ Deliberately NOT `admin_full_access`.
+ *
+ * That platform set carries `manage_platform_settings` among six other
+ * capabilities, so granting it would leave a gate keyed on platform-admin
+ * POSTURE — rather than on the capability — passing every suite here unchanged.
+ * A single-capability set named for nothing in particular can only pass a guard
+ * that reads the capability itself. It is also the honest shape: a deployment
+ * is free to grant this capability to an operator who is not a full admin.
+ */
+const GRANT_SET_NAME = 'datasource_operator';
+
+/**
+ * The `auth` service double: a `getSession` over the two credentials above,
+ * spelled on the legacy `api` member the contract still declares.
+ */
+export function createSessionAuthService() {
+  const sessions: Record<string, string> = {
+    [ENTITLED_CREDENTIAL]: ENTITLED_USER,
+    [UNENTITLED_CREDENTIAL]: UNENTITLED_USER,
+  };
+  return {
+    api: {
+      getSession: async ({ headers }: { headers: Headers }) => {
+        const id = sessions[headers?.get?.('authorization') ?? ''];
+        return id ? { user: { id } } : null;
+      },
+    },
+  };
+}
+
+/**
+ * The RBAC tables `resolveAuthzContext` reads, as a minimal engine double.
+ *
+ * Only the two objects carrying the grant answer rows; every other read — the
+ * memberships, positions and identity tables the resolver also consults —
+ * returns empty, which is what a deployment with no orgs and no custom roles
+ * really looks like. The rows carry no `active` flag and no validity window on
+ * purpose: absent means active/unbounded by the resolver's own predicates
+ * (`isRowActive` / `isGrantActive`), so these fixtures pin the CAPABILITY path
+ * rather than a validity edge case that belongs to `@objectstack/core`'s suite.
+ */
+export function createGrantsEngine() {
+  return {
+    find: async (object: string, opts: any) => {
+      if (object === 'sys_user_permission_set') {
+        return opts?.where?.user_id === ENTITLED_USER
+          ? [{
+              id: 'ups_datasource_operator',
+              user_id: ENTITLED_USER,
+              permission_set_id: GRANT_SET_ID,
+              // Unscoped (null org) — the grant is platform-scoped, matching
+              // `manage_platform_settings`'s own `scope: 'platform'`.
+              organization_id: null,
+            }]
+          : [];
+      }
+      if (object === 'sys_permission_set') {
+        const ids: unknown = opts?.where?.id?.$in;
+        return Array.isArray(ids) && ids.includes(GRANT_SET_ID)
+          ? [{
+              id: GRANT_SET_ID,
+              name: GRANT_SET_NAME,
+              // Stored as a JSON string — the spelling SQLite hands back, which
+              // the resolver parses. Pinning the stored shape keeps the fixture
+              // on the real read path rather than a convenient in-memory one.
+              system_permissions: JSON.stringify([DATASOURCE_ADMIN_CAPABILITY]),
+              object_permissions: '{}',
+            }]
+          : [];
+      }
+      return [];
+    },
+  };
+}

--- a/packages/services/service-datasource/src/__tests__/envelope.conformance.test.ts
+++ b/packages/services/service-datasource/src/__tests__/envelope.conformance.test.ts
@@ -38,22 +38,26 @@ import { describe, it, expect, vi } from 'vitest';
 import { BaseResponseSchema, envelopeViolations } from '@objectstack/spec/api';
 import { HonoHttpServer } from '@objectstack/plugin-hono-server';
 import { registerDatasourceAdminRoutes } from '../admin-routes.js';
+import {
+  ENTITLED_CREDENTIAL,
+  createSessionAuthService,
+  createGrantsEngine,
+} from './entitled-caller.fixture.js';
 
 /**
- * The family requires authentication (#9391), so every request below carries a
- * session and the mock context resolves an `auth` service that admits it. The
- * subject here is the ENVELOPE of the success and refusal bodies; an
- * unauthenticated fixture would replace all of them with the guard's 401 and
- * this file would stop covering what it exists to cover. The 401's own
- * envelope is asserted by `admin-routes-auth-guard.test.ts`.
+ * The family requires authentication (#9391) and the `manage_platform_settings`
+ * capability (#9593), so every request below carries an ENTITLED caller's
+ * session and the mock context resolves both the `auth` service that admits it
+ * and the data engine its grants resolve from. The subject here is the ENVELOPE
+ * of the success and refusal bodies; an unauthenticated fixture would replace
+ * all of them with the guard's 401 and an unentitled one with its 403, and this
+ * file would stop covering what it exists to cover. Both refusal envelopes are
+ * asserted by `admin-routes-auth-guard.test.ts`; the entitlement itself comes
+ * from the one `entitled-caller.fixture.ts` definition that pin uses.
  */
-const SESSION = 'Bearer test-session';
-const authService = {
-  api: {
-    getSession: async ({ headers }: { headers: Headers }) =>
-      headers?.get?.('authorization') === SESSION ? { user: { id: 'u_test' } } : null,
-  },
-};
+const SESSION = ENTITLED_CREDENTIAL;
+const authService = createSessionAuthService();
+const grantsEngine = createGrantsEngine();
 
 const req = (path: string, init?: RequestInit) =>
   new Request(`http://local${path}`, {
@@ -67,7 +71,15 @@ const req = (path: string, init?: RequestInit) =>
 
 function mount(svc: unknown) {
   const server = new HonoHttpServer(0);
-  const ctx = { getService: vi.fn((name: string) => (name === 'auth' ? authService : svc)) } as any;
+  const ctx = {
+    getService: vi.fn((name: string) =>
+      name === 'auth'
+        ? authService
+        : name === 'objectql' || name === 'data'
+          ? grantsEngine
+          : svc,
+    ),
+  } as any;
   registerDatasourceAdminRoutes(server, ctx, '/api/v1');
   return server.getRawApp();
 }

--- a/packages/services/service-datasource/src/admin-routes.ts
+++ b/packages/services/service-datasource/src/admin-routes.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { PluginContext } from '@objectstack/core';
-// The authentication floor: the platform's ONE anonymous-deny decision plus the
-// ONE identity resolution every other HTTP seam reads. Both are imported rather
-// than restated — see `requireAuthenticated` below for why a local check would
-// be the wrong shape even if it were written correctly.
+// The authorization floor: the platform's ONE anonymous-deny decision plus the
+// ONE identity-and-capability resolution every other HTTP seam reads. Both are
+// imported rather than restated — see `requireDatasourceAdmin` below for why a
+// local check would be the wrong shape even if it were written correctly.
 import {
   resolveAuthzContext,
   shouldDenyAnonymous,
@@ -82,13 +82,15 @@ const SERVICE_ERROR_CODE: Record<ServiceName, ErrorCode> = {
  *
  * `GET /datasources/drivers` is static metadata and needs neither service.
  *
- * ## Every route above requires authentication (#9391)
+ * ## Every route above requires the platform-settings capability (#9391, #9593)
  *
  * All eleven — reads, writes and the static catalog alike — answer `401`
- * `UNAUTHENTICATED` to a caller with no resolvable identity, before any service
- * is resolved and before any handler body runs. See `requireAuthenticated`
- * inside the registrar for how that decision is reached and why it has to be
- * made here rather than inherited from a seam.
+ * `UNAUTHENTICATED` to a caller with no resolvable identity and `403`
+ * `PERMISSION_DENIED` to a caller who resolves but holds no
+ * `manage_platform_settings`, before any service is resolved and before any
+ * handler body runs. See `requireDatasourceAdmin` inside the registrar for how
+ * both decisions are reached, why they have to be made here rather than
+ * inherited from a seam, and why the capability is neither minted nor split.
  *
  * The catalog route is included on purpose. It needs no service and reveals no
  * deployment data, but the family's own route ledger dispositions it
@@ -200,6 +202,64 @@ function buildGetSession(ctx: PluginContext): ((headers: Headers) => Promise<unk
   };
 }
 
+/**
+ * The capability every route in this family demands (#9593).
+ *
+ * ## Matched, never minted
+ *
+ * `manage_platform_settings` is the capability the adjacent Setup-admin
+ * families already gate on, and three independent measurements converge on it:
+ *
+ *  - **The sibling settings namespaces.** `@objectstack/service-settings`'s
+ *    manifests split into two cohorts. The tenant-facing, cosmetic ones —
+ *    `branding`, `company`, `localization`, `feature-flags` — declare
+ *    `readPermission: 'setup.access'` / `writePermission: 'setup.write'`. The
+ *    platform-infrastructure ones that carry connection configuration and
+ *    credentials — `mail`, `storage`, `sms`, `auth`, `ai`, `knowledge`, and
+ *    `packages/objectql`'s lifecycle namespace — declare
+ *    `manage_platform_settings` for BOTH. A datasource is a driver plus a DSN
+ *    plus a bound `sys_secret`; it belongs to the second cohort by
+ *    construction, not by analogy.
+ *  - **This plugin's own Setup nav entry.** `datasource-admin-plugin.ts`
+ *    contributes `nav_datasources` into the Setup app's `group_integrations`
+ *    slot with `requiredPermissions: ['manage_platform_settings']`. The
+ *    console door was already gated at this capability while the HTTP door
+ *    behind it took any authenticated caller — declared-but-unenforced (Prime
+ *    Directive #10) with the declaration and the gap in one package. Gating
+ *    here makes declared equal enforced and takes away no console anyone could
+ *    already reach.
+ *  - **The capability's own definition.** `PLATFORM_CAPABILITIES`
+ *    (`packages/spec/src/security/capabilities.ts`) describes it as
+ *    "Configure global platform settings (mail, storage, AI, licensing, …) and
+ *    platform-only Setup pages" — the class this family is in, named in the
+ *    registry rather than inferred here.
+ *
+ * ## Why there is no read/write split
+ *
+ * The card leaves the split to measurement, and the measurement says no. The
+ * cohort that splits is the cosmetic one; the credential-bearing cohort does
+ * not, and its reads are the reason. A read here is not a name list: `GET
+ * /datasources/:name` returns the stored connection config — host, port,
+ * database, user, `redactedConfigKeys` and the `hasSecret` handle flag — and
+ * `GET /:name/remote-tables` returns a live introspection of a remote schema.
+ * That is the same class of data `mail`, `storage` and `auth` gate their reads
+ * on, and a lower read capability would publish a deployment's connection
+ * topology to every authenticated tenant user, which is most of what the write
+ * gate is protecting. `GET /drivers` is static and could stand lower, and is
+ * held at the same line for the reason the authentication floor gave: a family
+ * whose floor has one hole has to be read route by route.
+ *
+ * ⚠️ Not a platform-admin gate. `admin_full_access` carries
+ * `manage_platform_settings` in its `systemPermissions`
+ * (`plugin-security/src/objects/default-permission-sets.ts`), so every platform
+ * admin holds it already and needs no bypass; a deployment can equally grant it
+ * to an operator set that is not a full admin. There is deliberately no
+ * `isPlatformAdmin` / posture arm here — that would be a SECOND policy beside
+ * the capability, and the sibling gate in `@objectstack/rest`'s
+ * `package-routes.ts` reads the held set only, for the same reason.
+ */
+export const DATASOURCE_ADMIN_CAPABILITY = 'manage_platform_settings';
+
 export function registerDatasourceAdminRoutes(
   server: IHttpServer,
   ctx: PluginContext,
@@ -208,9 +268,24 @@ export function registerDatasourceAdminRoutes(
   const root = `${basePath}/datasources`;
 
   /**
-   * The authentication floor for this whole family (#9391). Answers `401
-   * UNAUTHENTICATED` and returns `true` when the caller must be refused, so
-   * every handler opens with `if (await requireAuthenticated(req, res)) return;`.
+   * The authorization floor for this whole family (#9391 authentication, #9593
+   * capability). Answers `401 UNAUTHENTICATED` or `403 PERMISSION_DENIED` and
+   * returns `true` when the caller must be refused, so every handler opens with
+   * `if (await requireDatasourceAdmin(req, res)) return;`.
+   *
+   * ## One resolution, two decisions — deliberately not two guards
+   *
+   * The identity and the held capabilities come out of the SAME
+   * `resolveAuthzContext` call. Splitting this into an authentication guard
+   * followed by a capability guard would resolve the request twice, and two
+   * resolutions of one request can disagree — the second read is a fresh set of
+   * `sys_*` queries against a store another request may have written in
+   * between. One read, then both decisions off that one envelope.
+   *
+   * The order is fixed: anonymous first. A caller with no identity must be told
+   * it has no identity, not that its (empty) capability set is insufficient —
+   * the latter is both wrong and a hint that the credential was read and
+   * rejected on other grounds.
    *
    * ## Why this module needs its own line at all
    *
@@ -262,12 +337,30 @@ export function registerDatasourceAdminRoutes(
    * wrapper is this surface's, while the status, code and message are the
    * shared ones. Same reasoning, same shape, as `package-routes.ts`.
    *
-   * Authentication and nothing more: whether these routes should FURTHER
-   * require a platform-configuration capability is a separate, separately-ruled
-   * question (#9593) and is deliberately absent here.
+   * The capability refusal takes the STANDARD-catalog code for its status:
+   * `403` `PERMISSION_DENIED`, which `HttpStatusErrorCodeMap` names for 403 and
+   * `StandardErrorCode` describes as "User lacks required permission".
+   * Deliberately NOT `FORBIDDEN`, which the sibling `package-routes.ts` emits:
+   * that spelling is a grandfathered pre-gate synonym (ADR-0112 D3's
+   * `STANDARD_SYNONYM_WAIVERS`), waived for the three packages already putting
+   * it on the wire, and the waiver schema's own words are that it "keeps a WIRE
+   * VALUE registered; it does not endorse the spelling for new code". A
+   * standard member needs no per-package ledger registration either — the same
+   * reason `SERVICE_UNAVAILABLE` and `RESOURCE_NOT_FOUND` appear below while
+   * `@objectstack/service-datasource`'s ledger entry lists only its own two
+   * registered codes.
+   *
+   * ## What the message says, and what it withholds
+   *
+   * The capability's name and nothing else. A refused caller needs to know
+   * which grant to ask an administrator for; it must not learn whether the
+   * named datasource exists, which services this deployment wired, or anything
+   * else it was not entitled to read — which is also why this check, like the
+   * anonymous one, runs BEFORE `resolve()` and before any handler body.
    */
-  const requireAuthenticated = async (req: any, res: any): Promise<boolean> => {
+  const requireDatasourceAdmin = async (req: any, res: any): Promise<boolean> => {
     let userId: string | undefined;
+    let systemPermissions: string[] = [];
     try {
       const headers = toWebHeaders(req?.headers);
       if (headers) {
@@ -292,16 +385,33 @@ export function registerDatasourceAdminRoutes(
         }
         const authz = await resolveAuthzContext({ ql, headers, getSession });
         userId = authz.userId;
+        // The same envelope, read twice. `systemPermissions` is the resolver's
+        // aggregate of every permission set the caller holds (user-bound and
+        // position-bound alike) — the field `package-routes.ts` and the `/meta`
+        // gate read, so this family gates on the platform's capability
+        // resolution rather than a second reading of `sys_*`.
+        systemPermissions = Array.isArray(authz.systemPermissions) ? authz.systemPermissions : [];
       }
     } catch {
-      // Fail closed: an identity that could not be resolved is not an identity.
+      // Fail closed: an identity that could not be resolved is not an identity,
+      // and grants that could not be read are not grants.
       userId = undefined;
+      systemPermissions = [];
     }
     // `isSystem` is deliberately not read off anything the wire can reach —
     // `ResolvedAuthzContext` has no such field, and inbound HTTP never carries
     // one, so the only way past this line is a resolved caller.
     if (shouldDenyAnonymous({ userId, method: req?.method })) {
       sendError(res, ANONYMOUS_DENY_STATUS, ANONYMOUS_DENY_CODE, ANONYMOUS_DENY_MESSAGE);
+      return true;
+    }
+    if (!systemPermissions.includes(DATASOURCE_ADMIN_CAPABILITY)) {
+      sendError(
+        res,
+        403,
+        'PERMISSION_DENIED',
+        `Managing datasources requires the \`${DATASOURCE_ADMIN_CAPABILITY}\` capability.`,
+      );
       return true;
     }
     return false;
@@ -386,7 +496,7 @@ export function registerDatasourceAdminRoutes(
   // failure surfaced as the adapter's non-envelope 500 instead of the 400 its
   // eight siblings answer.
   server.get(root, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'listDatasources');
     if (!svc) return;
     try {
@@ -401,7 +511,7 @@ export function registerDatasourceAdminRoutes(
   // Studio connection form). Static metadata — no service dependency, so it
   // is always available even before any datasource-admin service is wired.
   server.get(`${root}/drivers`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     sendOk(res, { drivers: DRIVER_CATALOG });
   });
 
@@ -427,7 +537,7 @@ export function registerDatasourceAdminRoutes(
   // question #7606 owns globally; honouring it is correct under either answer,
   // so this route does not pre-empt it.
   server.get(`${root}/:name/remote-tables`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'external-datasource', 'listRemoteTables');
     if (!svc) return;
     try {
@@ -450,7 +560,7 @@ export function registerDatasourceAdminRoutes(
   // after the static `/drivers` route so that literal segment is never captured
   // as a name.
   server.get(`${root}/:name`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'getDatasource');
     if (!svc) return;
     try {
@@ -463,7 +573,7 @@ export function registerDatasourceAdminRoutes(
   });
 
   server.post(`${root}/:name/test`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'external-datasource', 'testConnection');
     if (!svc) return;
     try {
@@ -487,7 +597,7 @@ export function registerDatasourceAdminRoutes(
   // plainly. Genuine refusals — an unknown name, a throwing store — still take
   // the `badRequest` arm below.
   server.post(`${root}/:name/migrate-credential`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'migrateCredential');
     if (!svc) return;
     try {
@@ -499,7 +609,7 @@ export function registerDatasourceAdminRoutes(
   });
 
   server.post(`${root}/:name/object-draft`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'external-datasource', 'generateObjectDraft');
     if (!svc) return;
     const { table, ...opts } = (req.body as Record<string, unknown>) ?? {};
@@ -515,7 +625,7 @@ export function registerDatasourceAdminRoutes(
   // Probe a connection without persisting anything. Registered before the
   // `:name` routes so the literal `test` segment is never captured as a name.
   server.post(`${root}/test`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'testConnection');
     if (!svc) return;
     const { draft, secret } = splitSecret(req.body);
@@ -529,7 +639,7 @@ export function registerDatasourceAdminRoutes(
 
   // Create a runtime datasource.
   server.post(root, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'createDatasource');
     if (!svc) return;
     const { draft, secret } = splitSecret(req.body);
@@ -543,7 +653,7 @@ export function registerDatasourceAdminRoutes(
 
   // Patch a runtime datasource.
   server.patch(`${root}/:name`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'updateDatasource');
     if (!svc) return;
     const { draft, secret } = splitSecret(req.body);
@@ -557,7 +667,7 @@ export function registerDatasourceAdminRoutes(
 
   // Remove a runtime datasource.
   server.delete(`${root}/:name`, async (req: any, res: any) => {
-    if (await requireAuthenticated(req, res)) return;
+    if (await requireDatasourceAdmin(req, res)) return;
     const svc = resolve(res, 'datasource-admin', 'removeDatasource');
     if (!svc) return;
     try {


### PR DESCRIPTION
Fixes #9593

Tightens the datasource-admin HTTP family from "any authenticated user" to the
platform-configuration capability the adjacent Setup-admin families already gate on.
The authentication floor #9391 landed is unchanged; this adds the capability half its
body deliberately split out.

## ⚠️ Cross-package pin sweep — read this before the rest

This PR changes a **public admission semantic**, so the obligation that follows is
flipping every pin that asserted the old one. One consumer pin existed and it is in
another package: `packages/rest/src/remote-tables-twin.equivalence.test.ts`, the
`listRemoteTables` twin-equivalence suite (#4249 / #7955 / #9686). Its fixture caller was
authenticated but **unentitled**, so after the gate landed five request-shape cases were
comparing a 200 against the new 403 — reading an *admission* difference as a *request
shape* divergence, which is the one thing that file exists not to confuse. CI caught it
as `Test Core (3/3)` red; it is our coupling, not flake.

What changed there, and what deliberately did not:

- **The fixture is entitled through the platform's own RBAC chain** — one fake data
  engine wired into **both** spellings (the admin registrar's `objectql` lookup *and* the
  `resolveAuthzContext` call behind the federation registrar's `resolveExecutionContext`),
  so the twins still read one identity and now one grant aggregation. A fixture that
  hand-rolled a second notion of "entitled" on one side could make the twins agree by
  construction, which that file must never do.
- **The #9686 "WHO may ask" refusal cases are unchanged and still pass** — anonymous and
  unrecognised-credential callers are still refused identically on both spellings, because
  the capability check runs *after* the anonymous decision.
- **A new case pins what is now true rather than deleting the old one**: an authenticated
  but unentitled caller is refused `403 PERMISSION_DENIED` at the admin spelling and
  **served** at the federation spelling, which gates on authentication alone. Both halves
  are asserted in full.
- **No `packages/rest` runtime code is touched.** Whether the federation family should
  require a capability is a separate decision in a different lane — measurement at this
  head shows it deliberately does not, and its own guard doc says so. That asymmetry is
  **filed as #9901**, not accepted, and the new case is labelled a record of a known gap
  that is *expected to fail* when the gap closes.

Sweep scope, so the negative result is checkable: `registerDatasourceAdminRoutes` callers
repo-wide (the twin file, plus `packages/cli/src/commands/serve.ts`, which is production
wiring and not a pin), and every `*.test.ts` outside `service-datasource` matching the
admin family's route literals (`api/v1/datasources`, `datasources/drivers`,
`remote-tables`, `object-draft`, `migrate-credential`) — nine files. Eight of the nine are
untouched by this change and were verified as such rather than assumed: two assert a
metadata action's declared `target` string with no HTTP driven
(`metadata-service.test.ts`, `metadata-type-actions.test.ts`), three assert discovery /
route-table entries for the **federation** spelling
(`direct-mount-base-follows-apipath`, `discovery-advertised-direct-mounts.parity`,
`direct-mount-introspection`), two are the federation family's own guard and envelope
pins (a different registrar), one calls the `datasource-admin` **service method** directly
rather than the route (`runtime/src/datasource-visibility.test.ts`), and
`client/src/client.test.ts` asserts SDK URL construction with no server. The twin file is
the only consumer pin.

## Which capability, and why it was measured rather than chosen

`manage_platform_settings`, from three independent readings of the tree that agree:

1. **The sibling settings namespaces.** `@objectstack/service-settings`'s manifests fall
   into two cohorts. The tenant-facing, cosmetic ones — `branding`, `company`,
   `localization`, `feature-flags` — declare `readPermission: 'setup.access'` /
   `writePermission: 'setup.write'`. The platform-infrastructure ones carrying connection
   configuration and credentials — `mail`, `storage`, `sms`, `auth`, `ai`, `knowledge`,
   and `packages/objectql`'s lifecycle namespace — declare `manage_platform_settings` for
   both. A datasource is a driver plus a DSN plus a bound `sys_secret`; it is in the
   second cohort by construction.
2. **This service's own Setup nav entry.** `datasource-admin-plugin.ts` contributes
   `nav_datasources` with `requiredPermissions: ['manage_platform_settings']`. The console
   door was already gated at this capability while the HTTP door behind it took any
   authenticated caller — declared-but-unenforced (Prime Directive #10), with the
   declaration and the gap in one package. This makes declared equal enforced, and takes
   away no console anyone could already reach.
3. **The capability's own definition.** `PLATFORM_CAPABILITIES` describes it as
   "Configure global platform settings (mail, storage, AI, licensing, …) and platform-only
   Setup pages" — the class this family is in, named in the registry rather than inferred.

Nothing new is minted, and there is no platform-admin arm: `admin_full_access` carries
`manage_platform_settings` in its `systemPermissions`, so every platform admin already
holds it, and a deployment stays free to grant it to an operator who is not a full admin.

## No read/write split, and that is also a measurement

The card delegated the split to measurement and the measurement says no. The cohort that
splits is the cosmetic one; the credential-bearing cohort does not, and its reads are the
reason. A read here is not a name list: `GET /datasources/:name` returns stored connection
configuration — host, port, database, user, `redactedConfigKeys`, the `hasSecret` handle
flag — and `GET /:name/remote-tables` returns a live introspection of a remote schema. A
lower read capability would publish a deployment's connection topology to every
authenticated tenant user, which is most of what the write gate protects.
`GET /drivers` is static and could stand lower; it is held at the same line for the reason
the authentication floor gave — a family whose floor has one hole has to be read route by
route.

## The refusal code

`403` `PERMISSION_DENIED`, through the shared `sendError`, so
`check:route-envelope`'s zero-hand-written-bodies pin on this module is unchanged.

Deliberately **not** `FORBIDDEN`, which the closest sibling registrar
(`@objectstack/rest`'s `package-routes.ts`) emits: that spelling is a grandfathered
pre-gate synonym under ADR-0112 D3's `STANDARD_SYNONYM_WAIVERS`, waived for the three
packages already putting it on the wire, and the waiver schema's own words are that it
"keeps a WIRE VALUE registered; it does not endorse the spelling for new code".
`PERMISSION_DENIED` is the standard-catalog member `HttpStatusErrorCodeMap` names for 403
and needs no per-package ledger registration — the same reason `SERVICE_UNAVAILABLE` and
`RESOURCE_NOT_FOUND` already appear in this module while
`@objectstack/service-datasource`'s ledger entry lists only its own two registered codes.

## One guard, one resolution

The identity and the held capabilities come out of the same `resolveAuthzContext` call.
Splitting this into an authentication guard followed by a capability guard would resolve
one request twice, and two resolutions can disagree — the second is a fresh set of `sys_*`
reads against a store another request may have written in between. Order is fixed:
anonymous first, so a caller with no identity is told it has no identity rather than that
its empty capability set is insufficient.

## Pinning

`admin-routes-auth-guard.test.ts` — the #9391/#9695 both-sides-on-one-boot pin — grows a
third posture rather than gaining a parallel file. All eleven routes are now asserted
three times against the same mounted app: anonymous → `401 UNAUTHENTICATED`, authenticated
but unentitled → `403 PERMISSION_DENIED` (status **and** code **and** the capability named
in the message, per the ADR-0112 rejection-case rule), entitled → the route's own success
status. 33 cases, all green.

The entitlement is delivered the way a deployment delivers it — a
`sys_user_permission_set` row binding the user to a `sys_permission_set` whose
`system_permissions` names the capability, aggregated by the platform's own resolver off
the `objectql` engine. The set is deliberately **not** `admin_full_access`: that set
carries the capability among six others, so granting it would leave a gate keyed on
platform-admin posture passing this suite unchanged. The twin fixture one package over
makes the same choice for the same reason.

### Ablation, both legs

Removed the capability arm from the guard (fix committed first, so restoration had a real
restore point) and re-ran both pins:

- **service-datasource pin** — **11 failed | 22 passed (33)**:
  `AssertionError: expected 200 to be 403`, `expected 201 to be 403`, `expected 204 to be
  403`, one failure per route, with the anonymous and entitled postures staying green.
- **rest twin pin** — **1 failed | 8 passed (9)**: only the new divergence case goes red
  (`expected 200 to be 403`), which is what proves that case is driven by the gate rather
  than by some accident of the twin fixture's wiring.

Both signatures are the predicted ones for removing *only* the capability half, and both
are distinguishable from removing the whole guard. Restored with `git checkout HEAD --` on
the file; `git hash-object` reads back `164d3b00f9700a106548c11328ee1d674ebfe9cb`,
identical to the pre-ablation blob, and both pins return to green.

Neither leg needed a rebuild, and both resolution paths were checked rather than assumed:
the service-datasource pin imports the subject relatively (`../admin-routes.js` → `src/`),
and `packages/rest/vitest.config.ts` **aliases `@objectstack/service-datasource` to its
`src/index.ts`** — a deliberate alias whose own comment says a `dist` there "would report
the pre-fix admin route as agreeing". Both mutations reaching the runtime is demonstrated
by the reds themselves.

## Declared file surface, and its expansions

Landing is `packages/services/service-datasource/src/admin-routes.ts` plus the pinned
both-sides test, as dispatched. Everything else is a consequence of the semantic flip, not
a choice of scope:

- `src/__tests__/admin-routes.test.ts` and `src/__tests__/envelope.conformance.test.ts`
  each mount the family with an authenticated caller as their **premise** — routing and
  failure-attribution in one, envelope conformance in the other. Both would answer 403 on
  every case after this change, measuring the new guard instead of what they exist to
  measure. Their fixtures are entitled, and nothing else in them is touched.
- `src/__tests__/entitled-caller.fixture.ts` (new) holds the one definition of "an entitled
  datasource-admin caller" that the pin and those two suites share, rather than three
  copies of a four-table RBAC chain that would drift apart on the next resolver change.
- `packages/rest/src/remote-tables-twin.equivalence.test.ts` — the cross-package pin sweep
  above. Test-only; no runtime code in that package is touched.

No producer-side seam turned up outside `packages/services/**`: this registrar mounts
straight onto `IHttpServer` from a plugin `init()`, so — exactly as #9391 found for the
401 — there is no `@objectstack/rest` seam in front of it to fix instead.

## Verification

At `667c14711`:

- `pnpm --filter @objectstack/service-datasource test` — **22 files, 513 tests passed**;
  `typecheck` clean
- `pnpm --filter @objectstack/rest test` — **129 files, 2106 tests passed**; `typecheck`
  clean
- `pnpm check:route-envelope` — "11 module(s) audited … 8 conformant, 0 ratcheted, 3 exempt"
- `pnpm check:test-source-alias` — "OK — 72 packages with tests scanned"
- `pnpm check:type-source-resolution` — "OK — 76 packages with a tsconfig.json scanned"
- `node scripts/docs-audit/check-affected-docs.mjs` — "self-test: 242 cases pass"
- Union re-derived with `node scripts/pm/dispatch-gates.mjs` against the **expanded** diff.
  The rest file pulled in two gates the first derivation never named, and both were run:
  `check:cross-package-test-inputs` ("12 package(s) read outside themselves, all declared")
  and `check:dispatcher-error-vocabulary` ("290 registered codes … 17 classified").
  Also green: `check:changeset-gate-self-tests`, `check:objectui-changeset`,
  `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`
  (both re-run because the diff adds test code), `check:type-check-coverage`, and
  `check:type-check-debt` — the last matters here because **`@objectstack/rest` carries a
  TEST_DEBT ledger entry**, so a test edit in that package can move the ratchet: "33 ledger
  entr(ies) re-measured in 362.4s, 1926 raw tsc error(s) total, none above its recorded
  number", run on a closure built with `turbo run build` (the ratchet refuses outright on
  an unbuilt one). Plus `check-adr-0087-registration` / `check-changeset-no-major` /
  `check-empty-changeset`.
- **`@objectstack/cli` build**: the CI job log showed an `ELIFECYCLE` from `cli:build`
  while the turbo summary named only `@objectstack/rest#test` as failed. Confirmed rather
  than assumed — on a fresh worktree `cli:build` fails with `TS2307 Cannot find module`
  for `@objectstack/runtime`, `service-settings`, `service-storage` and `driver-turso`,
  the standard unbuilt-closure signature; after `pnpm --filter '@objectstack/cli^...'
  build` it exits **0**. Not reproduced by this patch and unrelated to it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_