### PR TITLE
docs(permissions,protocol): owner-type sharing rules are rejected at parse, not skipped

### DIFF
--- a/content/docs/permissions/permissions-matrix.mdx
+++ b/content/docs/permissions/permissions-matrix.mdx
@@ -149,15 +149,14 @@ Field-level security controls visibility and editability of individual fields pe
 
 ## 4. Sharing Rule Types
 
-Sharing rules extend access beyond ownership and the depth axis. The declarative `SharingRule` schema is a discriminated union with two `type` values — `owner` and `criteria`. Manual and territory sharing are separate mechanisms (see notes below the table).
+Sharing rules extend access beyond ownership and the depth axis. The declarative `SharingRule` schema carries a single enforced `type` value — `criteria`. (`SharingRuleType` in `packages/spec/src/security/sharing.zod.ts` is a one-member enum, and `SharingRuleSchema` *is* `CriteriaSharingRuleSchema`; it is kept discriminated so a future enforced rule type can rejoin as a union member.) Manual and territory sharing are separate mechanisms (see notes below the table).
 
 | Mechanism | `type` | Description | Example |
 |:---|:---|:---|:---|
-| **Owner-Based** | `owner` | Share records owned by a specific group/position with another recipient — **[experimental — not enforced]**: owner rules are skipped at seed time and materialize no shares yet | All accounts owned by "West Region" team are shared with "Sales Directors" |
 | **Criteria-Based** | `criteria` | Share records matching a CEL predicate over field values | All opportunities where `record.amount > 100000` are shared with "VP Sales" |
 
 <Callout type="warn">
-**Enforcement status:** every authorable rule and recipient type is enforced. v17 reconciled the surface with the runtime (#1878): `owner`-type rules and `group` / `guest` recipients — previously declared but skipped at seed time — no longer parse; `group` became the enforced `team` and `business_unit` joined the enum. See [Sharing Rules](/docs/permissions/sharing-rules#recipient-types).
+**Enforcement status:** every authorable rule and recipient type is enforced. v17 reconciled the surface with the runtime (#1878): `owner`-type rules (`type: 'owner'`, `ownedBy`) and `group` / `guest` recipients — previously declared but skipped at seed time — **no longer parse**; `group` became the enforced `team` and `business_unit` joined the enum. That is a stronger statement than "declared but not enforced": a skipped rule is still authorable and is ignored, whereas a removed one is rejected by `SharingRuleSchema`, so a stale definition fails loudly at authoring time instead of silently doing nothing (ADR-0078). See [Sharing Rules](/docs/permissions/sharing-rules#recipient-types).
 </Callout>
 
 <Callout type="info">
@@ -171,7 +170,7 @@ Sharing rules extend access beyond ownership and the depth axis. The declarative
   sharingRules: [
     {
       name: 'high_value_opps_to_vp',
-      object: 'opportunity',
+      object: 'opportunity',          // sharingModel: 'private'
       type: 'criteria',
       // condition is a CEL predicate over the record
       condition: 'record.amount > 100000',
@@ -180,16 +179,30 @@ Sharing rules extend access beyond ownership and the depth axis. The declarative
     },
     {
       name: 'west_accounts_to_directors',
-      object: 'account',
-      type: 'owner',
-      // records owned by this group/position are the source set
-      ownedBy: { type: 'position', value: 'west_region_rep' },
+      object: 'account',              // sharingModel: 'public_read'
+      type: 'criteria',
+      // the source set is a field predicate — record ownership is not an
+      // authorable rule input; see the enforcement callout above
+      condition: 'record.region == "west"',
       sharedWith: { type: 'position', value: 'sales_director' },
       accessLevel: 'edit',
     },
   ],
 }
 ```
+
+<Callout type="warn">
+**Parsing is not granting — check the target object's OWD.** A sharing rule only
+widens what the baseline still withholds, so both rules above grant because of
+their objects' postures: `opportunity` is `private`, so both gates apply and the
+`read` rule widens the read filter; `account` is `public_read`, which is
+*read-open but write-owned*, so read is already universal there and it is the
+`edit` level that opens the write gate to non-owners. On a `public_read_write`
+or `controlled_by_parent` object both gates are already open, and a rule parses,
+materializes, and grants **nothing** — `effectiveSharingModel(schema) === 'public'`
+short-circuits `buildReadFilter` and `buildWriteFilter` to `null`
+(`packages/plugins/plugin-sharing/src/sharing-service.ts`).
+</Callout>
 
 ---
 

--- a/content/docs/protocol/objectql/security.mdx
+++ b/content/docs/protocol/objectql/security.mdx
@@ -372,30 +372,47 @@ object: account
 accessLevel: read           # read | edit
 condition: 'record.account_type == "Enterprise"'
 sharedWith:
-  type: position            # user | group | position | unit_and_subordinates | guest
+  type: position            # user | team | position | unit_and_subordinates | business_unit
   value: sales_rep
 ```
 
 `unit_and_subordinates` expands a **business-unit subtree**: the unit named by `value` plus every descendant unit's members (ADR-0057 D5 / ADR-0090 D3 — the former position-tree walk was re-homed onto the `sys_business_unit` tree).
 
-### Owner-Based Sharing
+### Owner-Based Sharing — removed in v17
 
-Share records owned by one group with another (`OwnerSharingRuleSchema`):
+Owner-based rules (`type: 'owner'`, `ownedBy`) were removed from the authoring
+surface in v17 (#1878), together with the `group` / `guest` recipients. They
+depended on live membership the static seeder cannot track, so they validated
+but never materialized a share. Use a criteria rule or a scope-depth grant
+instead; none of these shapes parses anymore, so a stale definition fails
+loudly at authoring time instead of silently doing nothing (ADR-0078).
+
+> **"Skipped" and "rejected" are different instructions to an author.** Before
+> v17 these rules were *declared but skipped at seed time*: you could write one,
+> it parsed, and the seeder ignored it. They are not skipped now — they **do not
+> parse**. `SharingRuleSchema` rejects the block above with three issues:
+> `type: 'owner'` fails the `criteria` literal, the required `condition` is
+> reported missing, and `ownedBy` comes back as an unrecognized key carrying its
+> own guidance message. There is also no `OwnerSharingRuleSchema` to point at —
+> `packages/spec/src/security/sharing.zod.ts` exports `CriteriaSharingRuleSchema`,
+> and `SharingRuleSchema` *is* that schema.
+
+The retired `share_west_region` rule — "West-region accounts reach the regional
+managers" — is expressed by predicating the field instead of the owner:
 
 ```yaml
+# share_west_region.sharing.yml
 name: share_west_region
-type: owner
-object: account
+type: criteria
+object: account             # sharingModel: private, declared above
 accessLevel: edit
-ownedBy:
-  type: position
-  value: west_region_reps
+condition: 'record.region == "west"'
 sharedWith:
   type: position
   value: west_region_managers
 ```
 
-> **Enforcement status.** Criteria rules with `user` / `position` / `unit_and_subordinates` recipients compile and enforce (the CEL condition lowers to a runtime filter that materializes `sys_record_share` grants, ADR-0058 D3). Owner-type rules and `group`/`guest` recipients are `[experimental — not enforced]`: the seed bootstrap skips them (logged) rather than seeding a permissive match-all (ADR-0049).
+> **Enforcement status.** Every authorable rule and recipient type is enforced. Criteria rules with `user` / `team` / `position` / `unit_and_subordinates` / `business_unit` recipients compile and enforce (the CEL condition lowers to a runtime filter that materializes `sys_record_share` grants, ADR-0058 D3). Owner-type rules and the `group` / `guest` recipients are **not** `[experimental — not enforced]` and are no longer skipped at seed time — v17 removed them from the schema, so they do not parse at all (see above). What is still skipped-and-logged is a `condition` the compiler cannot lower (functions, cross-object traversal): it is never seeded as a permissive match-all (ADR-0049).
 
 > `accessLevel` is one of `read` or `edit`. Sharing widens **which rows** a principal reaches, never **which verbs** they may use — an `edit` share opens *update*, not *delete*: delete comes from ownership, the ADR-0057 DEPTH scopes, or the `modifyAllRecords` bypass, enforced by the sharing layer's own `canDelete` gate (distinct from the `canEdit` update gate) on top of the object-level CRUD gate (ADR-0111 D3). A third level `full` ("Full Access — transfer/share/delete") was authorable through protocol 16 but never granted any of those verbs: both enforcement sites matched `edit`/`full` alike, so it was equivalent to `edit` while telling admins otherwise, and it was removed (#3865, ADR-0078). Stacks still authoring it are rewritten to `edit` at load by the `sharing-rule-access-level-full-to-edit` conversion.
 


### PR DESCRIPTION
Fixes #9891

Two docs pages taught `type: 'owner'` / `ownedBy` sharing rules as authorable. They were removed from `SharingRuleSchema` in v17 (#1878) rather than left declared-but-skipped, so they do not parse at all.

## H1 — the removal, measured before rewriting prose about it

The card's exact example block, fed to the built `SharingRuleSchema` from `packages/spec/dist/security/index.mjs`:

```text
success: false
---
code:    invalid_value
path:    ["type"]
message: Invalid input: expected "criteria"
---
code:    invalid_union
path:    ["condition"]
message: Invalid input
---
code:    unrecognized_keys
path:    []
message: Unrecognized key(s) on this sharing rule: `ownedBy`.
  - `ownedBy` belongs to the removed `owner`-type sharing rule - it depends on live team/position
    membership, which the static materialiser cannot track, so it was removed from the authoring
    surface (ADR-0078). Only `criteria` rules are authorable; express membership-shaped access via
    RLS dynamic membership (7.3.1) or business-unit depth scopes (ADR-0057).
```

Three issues, not one. Note the schema's own guidance message cites **ADR-0078**, while both docs pages and the v17 release note cite ADR-0049 — the ADR-0078 "validates but silently does nothing is an authoring trap" framing is the one the runtime actually prints, so the prose here cites it.

## Ruling 1 — "skipped" and "rejected" are different author instructions

Both pages now say which one applies, in as many words. The protocol page carried the pre-v17 state verbatim (*"the seed bootstrap skips them (logged)"*); it now states that a skipped rule is still authorable and is ignored, whereas a removed one is rejected by the schema. The `permissions-matrix` callout was already correct on "no longer parse" and gained the same contrast sentence.

The still-accurate half of the old ADR-0049 sentence is kept: a `condition` the compiler cannot lower **is** skipped and logged, never seeded as a permissive match-all. Only the owner-rule half was stale.

## H2 — `OwnerSharingRuleSchema` does not exist

Not "exists but unreachable" — the symbol is absent from the repo entirely.

- `grep -rn "OwnerSharingRuleSchema"` over `packages/ apps/ examples/ scripts/` returns **zero** hits; the only occurrence in the tree was the doc line this PR removes.
- It is absent from `packages/spec/api-surface/security.json`, which lists `CriteriaSharingRuleSchema (const)`, `SharingRuleSchema (const)`, `SharingRuleType (type)` and no owner variant.
- At runtime, `Object.keys(spec/security)` gives `CriteriaSharingRuleSchema, OWDModel, ShareRecipientType, SharingLevel, SharingRuleSchema, SharingRuleType, defineSharingRule`.

**Verdict: the protocol reference must stop naming it.** The section now points at `CriteriaSharingRuleSchema` and states that `SharingRuleSchema` *is* that schema. No finding to file — there is no live-but-unauthorable export here.

## H3 — the sweep found four spots, not two

Sweeping `content/docs/**` for `type: 'owner'`, `ownedBy`, `OwnerSharingRuleSchema` and pre-v17 "skipped (logged)" enforcement callouts: **7 occurrences across 4 files**, of which **6 across 2 files** were defects and are fixed here.

| Location | State | Action |
|:---|:---|:---|
| `permissions-matrix.mdx` intro | claimed "a discriminated union with two `type` values - `owner` and `criteria`" | fixed - `SharingRuleType.options` is `["criteria"]`, one member |
| `permissions-matrix.mdx` table row | "Owner-Based / **[experimental - not enforced]** / skipped at seed time" | row dropped - it contradicted the page's own callout four lines below |
| `permissions-matrix.mdx` example | the `type: 'owner'` block | rewritten in the `criteria` form |
| `protocol/objectql/security.mdx:375` | recipient comment `user \| group \| position \| unit_and_subordinates \| guest` | fixed - `group` and `guest` do not parse; `team` and `business_unit` were missing |
| `protocol/objectql/security.mdx` Owner-Based section | YAML example + `OwnerSharingRuleSchema` | replaced |
| `protocol/objectql/security.mdx` enforcement callout | pre-v17 "skipped (logged)" | repaired |
| `permissions/sharing-rules.mdx:234` | correct | untouched, and is the wording both pages converge on (ruling 2) |

The two extra spots (the intro's union claim and the `:375` recipient comment) are the same defect class as the card — docs teaching sharing vocabulary that no longer parses — and their correct form is pinned by the enum in `packages/spec/src/security/sharing.zod.ts`, measured directly:

```text
ShareRecipientType enum: ["user","team","position","unit_and_subordinates","business_unit"]
  group   parses: false      guest   parses: false
  team    parses: true       business_unit parses: true
```

`content/docs/releases/v17.mdx` is the fourth file; it is correct and is release-notes territory. Not touched.

## H4 — the replacement examples grant something

Every rule shipped in this PR was fed through `SharingRuleSchema.safeParse` and parses. Parsing was not the bar, though — the neighbouring card established that a rule on a `public_read_write` object parses and grants nothing. Checked at source rather than from the docs table: `effectiveSharingModel` in `packages/plugins/plugin-sharing/src/sharing-service.ts` maps `public_read_write` and `controlled_by_parent` to `'public'`, and `buildWriteFilter`'s own comment states the rule —

> applies to BOTH `private` and `read` (public_read) models - public_read is read-open but write-owned; only a fully `public` object is write-open.

So `buildReadFilter` returns `null` unless the model is `private`, and `buildWriteFilter` returns `null` only when it is `public`. Postures of the examples:

- `opportunity` is `private` (the page's own OWD table) - both gates apply, the `read` rule widens the read filter. **Grants.**
- `account` on `permissions-matrix.mdx` is `public_read` - read is already universal there, so the rule is `accessLevel: 'edit'`, which is what opens the write gate to non-owners. **Grants.**
- `account` on the protocol page is `private`, declared in that page's own preceding `account.object.yml` block. **Grants.**

Because the matrix example's second rule only grants by virtue of its `edit` level, the page gained a callout making the posture requirement explicit rather than leaving the reader to rediscover it.

## Scope

No changeset — docs-prose only, nothing user-visible ships. `check:docs-audit-scope` stayed at its existing count (179 hand-written docs); no `.claude/` regeneration was needed, so the #9866 collision was not reached. Nothing under `content/docs/releases/`, `docs/adr/`, `.claude/`, `skills/`, `AGENTS.md` or `CLAUDE.md` was touched. The adjacent in-flight pages `permissions/authorization.mdx` and `permissions/index.mdx` are out of scope here and were not edited.

## Gates

Run at `d237370527`, the final commit, after a full `pnpm --filter @objectstack/spec build`. Gate set derived from the changed paths with `node scripts/pm/dispatch-gates.mjs`, all 11 green:

```text
HEAD at union run: d237370527
check:docs-audit-scope                   exit=0
check:doc-anchors                        exit=0
check:docs-redirects                     exit=0
check:role-word                          exit=0
check:published-readme-links             exit=0
check:nul-bytes                          exit=0
check:cross-package-test-inputs          exit=0
spec:check:empty-state                   exit=0
spec:check:liveness                      exit=0
spec:check:strictness-ledger             exit=0
spec:check:variant-docs                  exit=0
UNION_ALL_GREEN=yes
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_