### PR TITLE
fix(service-messaging): correct sys_notification_subscription index comment to name sys_member/sys_team_member

### DIFF
--- a/packages/services/service-messaging/src/objects/notification-subscription.object.ts
+++ b/packages/services/service-messaging/src/objects/notification-subscription.object.ts
@@ -72,13 +72,24 @@ export const NotificationSubscription = ObjectSchema.create({
         // org_yi (billing.invoice, user:u1) 201 / org_yi's own GET on the
         // colliding pair 0 rows.
         //
-        // ⚠️ `principal` names are per-organization: `role:x` and `team:x`
-        // resolve against `sys_permission_set` / `sys_position` rows that
-        // #8461 and #8556 already scoped per organization, so `role:sales_manager`
-        // denoted a DIFFERENT principal in each organization while colliding on
-        // one installation-wide key. And a user who belongs to two
-        // organizations could not subscribe to the same topic in both — the
-        // symptom #8323 measured on `sys_user_preference`.
+        // ⚠️ [#9722, correcting this note] `principal` names are per-organization:
+        // `role:x` resolves against `sys_member` (tenant-scoped org-membership
+        // rows — the org-administration tier that is the sole ADR-0090 D3
+        // "role" exception) and `team:x` against `sys_team_member` (tenant-scoped
+        // via its `team_id` lookup into `sys_team`, itself per-organization) —
+        // per `RecipientResolver.resolveRole` / `.resolveTeam`
+        // (`recipient-resolver.ts`, the sole reader of this selector). NOT
+        // `sys_permission_set` / `sys_position` as an earlier version of this
+        // note claimed — this selector has no `permission_set:` or
+        // `position:` spelling at all; `sys_position` names business roles
+        // like `sales_manager` elsewhere on the platform, unrelated to
+        // `role:`/`team:` here. So `role:admin` denotes a DIFFERENT set of
+        // members in each organization (`sys_member.role` is the closed
+        // owner/admin/delegated_admin/member vocabulary — see
+        // `BUILTIN_MEMBERSHIP_ROLE_OPTIONS`) while colliding on one
+        // installation-wide key. And a user who belongs to two organizations
+        // could not subscribe to the same topic in both — the symptom #8323
+        // measured on `sys_user_preference`.
         //
         // ⚠️ `managedBy: 'system-data'` is NOT a reason to exempt this object;
         // the already-ruled `sys_user_preference` is `system-data` too. The


### PR DESCRIPTION
Fixes #9722

## What was wrong

`packages/services/service-messaging/src/objects/notification-subscription.object.ts`'s
`(topic, principal)` index comment justified the per-organization scope by claiming
`role:x` / `team:x` resolve against `sys_permission_set` / `sys_position` (citing #8461
and #8556). Those two PRs scope `sys_user_preference`/`sys_capability`/`sys_position`'s
own uniqueness per organization — the general index-scoping precedent this object's
index also follows — but say nothing about what a notification `role:`/`team:` selector
resolves against.

`RecipientResolver` (`recipient-resolver.ts`, the sole reader of this selector)
disagrees on both halves: `resolveRole` reads `sys_member` (tenant-scoped via
`organization_id`) and `resolveTeam` reads `sys_team_member` (tenant-scoped via its
`team_id` lookup into `sys_team`) — pinned by `recipient-resolver.test.ts`'s
`"expands role: via sys_member (tenant-scoped) and de-dups"` case. The comment's own
worked example (`role:sales_manager`) is not even a reachable `sys_member.role` value —
that field's closed vocabulary is `owner`/`admin`/`delegated_admin`/`member`
(`BUILTIN_MEMBERSHIP_ROLE_OPTIONS`); `sales_manager` is `sys_position`'s canonical
example name, a different object this selector does not read at all.

## Stop-condition check (before editing)

Per the card's hard stop-condition, searched for evidence the comment recorded a
RULED/intended semantics (role: → positions) rather than being simply wrong: grepped
`docs/adr/` for `sys_permission_set`/`sys_position`/notification-principal language and
read #8461 and #8556 in full. Both are exclusively about scoping *other* objects' own
declared-index uniqueness per organization (the `unique: 'organization'` pattern this
object's own index already follows) — neither states or implies anything about what a
notification principal selector resolves against. ADR-0090 D3 independently confirms
`sys_member.role` (the org-administration tier) is the *sole* permitted "role" spelling
platform-wide — consistent with, not contradicting, what the resolver actually reads.
No ruling found → stop-condition cleared, proceeded with the comment fix.

## What changed

Rewrote the flagged comment (`notification-subscription.object.ts:75-92`) to name
`sys_member` / `sys_team_member` as the objects `RecipientResolver` actually reads,
kept the tenancy argument load-bearing (both objects are tenant-scoped, so `role:x` /
`team:x` still denote different rows per organization — the same reason the
`(topic, principal)` index has to be `unique: 'organization'`), and replaced the
unreachable `role:sales_manager` example with the reachable `role:admin`. Comment-only —
no schema field, index declaration, or runtime behavior changed. Declared file surface
only; `recipient-resolver.ts` and its test were read-only references, untouched.

## Gates (comment-only change; local scope per AGENTS.md; final HEAD `99521a51c`)

- `pnpm check:slot-lookup` — PASS (107 unswept sites in 25 files, none new; baseline
  key set unchanged vs `b030055`)
- `pnpm check:test-source-alias` — PASS (72 packages with tests scanned)
- `pnpm check:type-source-resolution` (`--self-test` + full) — PASS (76 packages
  scanned)
- `node scripts/docs-audit/check-affected-docs.mjs` — PASS (262 self-test cases)
- `pnpm check:nul-bytes` (`--self-test` + full) — PASS (6298 text files scanned, no raw
  control bytes)
- `node scripts/pm/dispatch-gates.mjs` (no paths — self-derived from the actual diff, 1
  changed path) — same 4 named families, plus one convention-triggered addition:
  `pnpm check:i18n`, because the package owns an `i18n-extract.config.ts`. Diff review
  confirmed no `label`/`description`/authorable string changed (comment-only), so the
  extractor had nothing to pick up — ran it to completion anyway (built the CLI per its
  own PREREQUISITE-NOT-MET message): **PASS**, 9 packages, all bundles in sync, no
  undeclared authoring keys.
- `pnpm --filter @objectstack/service-messaging test -- --maxWorkers=2` — unchanged
  from `main`, as expected for a comment-only diff: **242 passed / 22 files, 0
  failed.**

All gates run against the committed tree at `99521a51c` (working tree was clean before
and after commit — no drift between the runs above and the final diff).

## Changeset

`skip-changeset` applied (this repo's real mechanism — confirmed against
`.github/workflows/pr-automation.yml`'s `changeset-check` job and the repo-conditional
convention `pm-dispatch`/`os-dev` PR #9100 settled: this repo uses the label, objectui
uses an empty-frontmatter changeset instead). Rationale: comment-only prose change, zero
user-visible or runtime behavior change, nothing to release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_