### PR TITLE
docs(skills): state the published heavy-verify lock as properties, not a broken recipe

### DIFF
--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -752,18 +752,36 @@ most often get missed:
 Resource discipline — parallel agents share ONE container; unbounded build and
 test runs exhaust it. Binding:
 
-1. Serialize the heavy phase. Wrap every build and test run in a shared
-   container-wide lock so editing parallelizes but memory peaks never stack:
-     flock -w 7200 /tmp/heavy-verify.lock -c '<build/test command>'
-   (one lock file per container; waiting on it is normal, not a hang).
+1. Serialize the heavy phase. Editing parallelizes; build and test runs must
+   not — every one of them is wrapped in a lock the whole container shares, so
+   memory peaks never stack. The MECHANISM is the host project's (its wrapper,
+   its lock path, its budget — put it in the conventions file); the properties
+   that make any such wrapper correct are not negotiable:
+   - ONE shared heavy-verify lock per container, so every agent contends on
+     the same file. A path only one agent uses serializes nothing, and it
+     reports exactly like a lock that works.
+   - The acquisition budget fits inside a SINGLE foreground tool call: waiting
+     must never outlive the call carrying it, and backgrounding a wait to
+     escape that ceiling produces the stall the lock exists to avoid.
+   - A queue timeout is distinguishable from the wrapped command's own
+     failure — "I never got the lock" must not read as "the tests failed".
+   - Hold duration is observable, so a stuck holder names itself instead of
+     being inferred from everyone else's queueing.
+   Queueing is normal, not a hang. Queueing with no end in sight is a finding:
+   report it, naming the holder.
 2. Cap the heap: prefix heavy commands with
    NODE_OPTIONS=--max-old-space-size=4096 (raise only with a reason).
 3. Scope, don't sweep. Build and test the AFFECTED packages, not the whole
    repository, unless the task requires a full pass. Cap test parallelism
    (e.g. vitest --maxWorkers=2).
-4. Clean up: after the PR is up, remove your worktree
-   (git worktree remove <path> --force). Leftover dependency trees exhaust the
-   container's disk, which fails as confusingly as running out of memory.
+4. Clean up: after the PR is up, delete the worktree's dependency tree and
+   then remove the worktree. Leftover dependency trees exhaust the container's
+   disk, which fails as confusingly as running out of memory. Do NOT force the
+   removal as the opening move: with dependencies already deleted, a refusal
+   to remove means something in there is uncommitted — your own unpushed work,
+   or another agent's tree if the path was mistyped — and that refusal is the
+   container's only guard for it. Read the refusal first; force only after the
+   answer is genuinely "nothing".
 5. NEVER kill a process by name. A name-matched kill (pkill -f <tool>) can take
    down a parallel agent's run. Record the PID of what you start and operate on
    that PID only (kill $PID; liveness via kill -0 $PID). A pgrep pattern can
@@ -1040,6 +1058,7 @@ them into every dispatch:
 | Required release-note artifact (changeset, CHANGELOG entry, none) | conventions file |
 | Files owned by a release process that a code PR must never touch | conventions file |
 | Test / typecheck / lint commands per package | conventions file |
+| How the shared heavy-verify lock is taken (wrapper, lock path, acquisition budget) | conventions file |
 | Merge policy (merge queue, serial merge, maintainer-only) | conventions file |
 | Capability-expansion stance the business-need axis reads (tight by default, or permissive) | conventions file |
 | Which repositories exist and which is the backlog | `.claude/pm-dispatch.json` |


### PR DESCRIPTION
Fixes #9922

The published pm-dispatch catalog copy taught a copy-pasteable heavy-verify lock
recipe with two independent defects, and the serious one is silent: the lock path
it named carried no `os-` prefix, so it is a *different file* from the container's
shared lock. An agent following the recipe took an exclusive lock no sibling ever
contends on — it looks like serialization, reports like serialization, and
serializes nothing. The second: a `-w` budget 13x the declared acquisition cap and
12x the harness ceiling for a single foreground call, so a waiter that actually
spent it would be killed mid-wait.

## What changed

Exactly one file: `skills/objectstack-pm-dispatch/SKILL.md`, Resource discipline.

**Item 1 — recipe replaced by property statements.** The catalog ships into
customer codebases where neither this container's lock path nor this repo's
wrapper exists, so *any* copy-pasteable literal is wrong-by-construction
somewhere. The item now states the invariants and defers the mechanism:

- ONE shared heavy-verify lock per container, so every agent contends on the same
  file — with the naming of why a private path is the dangerous failure (it
  reports exactly like a lock that works).
- The acquisition budget fits inside a SINGLE foreground tool call: waiting must
  never outlive the call carrying it, and backgrounding a wait to escape that
  ceiling produces the stall the lock exists to avoid.
- A queue timeout is distinguishable from the wrapped command's own failure.
- Hold duration is observable, so a stuck holder names itself.

No literal lock path and no literal wait number survive anywhere in the file
(verified by rescan, below). The deferral is made structural rather than
prose-only by a new row in the "Adapting this loop to your project" table, which
is the file's existing idiom for everything the host project owns.

**Item 4 — the force-first worktree removal is gone.** With dependencies already
deleted, a refusal to remove means something in there is uncommitted, and that
refusal is the container's only guard for unpushed work. Force is now named as the
last resort after diagnosing, not the recipe.

## Deviation from the graded direction, with evidence

The adjudication permits citing this repo's `scripts/pm/os-verify-lock.sh` as *an
example of the shape*. I did not, because it does not exist on `main`:

```
$ ls -la scripts/pm/os-verify-lock.sh
ls: cannot access 'scripts/pm/os-verify-lock.sh': No such file or directory
```

It lands with #9921, which is still draft-awaiting-merge. Naming it now would ship
a dangling path in the published catalog — the precise failure mode this card
exists to remove. The permission was "may", not "must", so the shape is described
generically instead. If #9921 merges and the maintainer wants the example named, it
is a one-line follow-up.

## Verification at `c3cc548a7`

`node scripts/pm/dispatch-gates.mjs` (no paths — derived from the real diff vs
merge base `05864fb20`) matched three families, all run locally on the final
commit, each quoting the gate's own verdict line:

| Gate | Verdict line |
|:---|:---|
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6304 text file(s) ... no raw ASCII control bytes).` |
| `check:skill-frame-sync` | `check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `check:skill-compatibility` | `check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 77 workspace packages` |
| `check:pm-governed-merges` | `check-governed-merges --self-test: 77 assertions ...` |

Residue derivation placed all 114 discovered families (3 matched, 35 undetermined,
76 silent).

**A measured falsification of the dispatch's mechanism assumption:** the dispatch
asked whether `skills/**` is ratcheted. It is not. `check:pm-skill-ratchet`'s
`CEILINGS` map covers 16 entries, all under `.claude/` plus root `AGENTS.md`, and
zero under the published `skills/` root — so this PR pays no line budget. The file
goes 1,050 to 1,069 lines (+19: property statements are longer than the one broken
command they replace). That gap is recorded as an unassigned observation in #9923,
not repaired here.

## Notes

- Governed surface (`skills/**`) — this PR **opens draft and stays draft**. The
  maintainer merges; it is never queued, armed, or flipped ready.
- No changeset: `skills/` is in no package's published file list, so this PR
  releases nothing. `skip-changeset` applied.
- Related: #9661, #9921 (the internal mechanization this card's prose describes the
  shape of). Neither is addressed by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_