### PR TITLE
docs(agents): name all six blocking contexts in the merge-queue rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,15 +349,15 @@ Even inside your own worktree, operate defensively:
 
    **Green means the gate-carrying jobs' `conclusion` is `success`** — not "no failure
    yet"; `in_progress` is not a pass. Arming a red PR does not queue it, it hides it:
-   every poll then misreads "not on `main` yet" as "queued". Always read *two* things
-   when checking a landing: the queue branch **and** `origin/main`. And **the queue
-   enforces only the required set** — **Lint & Repo Gates** (the whole `check:*` gate
-   family, formerly published under a name that described only one of its steps) and
-   **TypeScript Type Check** block by maintainer decision (2026-08-07); everything else
-   is advisory and rides through, and an advisory red that lands rides `main`'s merge ref
-   into every following PR until stanched. A required context is matched by check-run
-   name, so a job rename detaches its gate silently — treat those names as contract.
-   That is why "arm only on green" is a rule, not a formality.
+   every poll then misreads "not on `main` yet" as "queued". Always read *two* things:
+   the queue branch **and** `origin/main`. And **the queue enforces only the required
+   set** — six contexts block by maintainer decision (2026-08-07, extended 2026-08-09):
+   `Lint & Repo Gates` (all `check:*` gates), `TypeScript Type Check`, `Test Core`,
+   `Dogfood Regression Gate`, `Build Core` and `Temporal Conformance (live PG + MySQL)`.
+   A check outside those six is advisory and rides through, and an advisory red that
+   lands rides `main`'s merge ref into every later PR until stanched. A required context
+   is matched by check-run name, so a rename detaches its gate silently — treat those
+   six names as contract. That is why "arm only on green" is a rule, not a formality.
 
    **Re-arm awareness** — none of these is a reason to avoid the queue; all are reasons
    to confirm a PR is still *in* it: a red queue build **ejects** your entry and drops

--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -427,9 +427,21 @@ export const REQUIRED_CONTEXTS = [
 export const INSTRUCTION_SURFACES = [
   {
     // The merge-queue rule ("the queue enforces only the required set"),
-    // naming both blocking contexts. States the required set ⇒ mustName.
+    // naming every blocking context. States the required set ⇒ mustName.
+    // Widened to all six by the #9677 ruling (2026-08-18): the sentence had
+    // named two and called the other four advisory-and-rides-through, which
+    // is the misclassification that puts a PR into the queue to be ejected.
+    // The full set is pinned here so the corrected sentence cannot rot back
+    // — a rename in ANY of the six now reddens this gate instead.
     file: 'AGENTS.md',
-    mustName: ['Lint & Repo Gates', 'TypeScript Type Check'],
+    mustName: [
+      'Lint & Repo Gates',
+      'TypeScript Type Check',
+      'Test Core',
+      'Dogfood Regression Gate',
+      'Build Core',
+      'Temporal Conformance (live PG + MySQL)',
+    ],
   },
   {
     // The review seat's gate-clearance step: confirm both jobs' `conclusion`


### PR DESCRIPTION
Fixes #9677

⛔ **Draft on purpose — do not flip ready, do not arm auto-merge.** `AGENTS.md` is a
governed surface (Prime Directive #14), so this lands by a maintainer's hand merge.

## What changed

**`AGENTS.md`, the auto-merge/queue rule (§9 rule 7).** The sentence named two required
contexts and said "everything else is advisory and rides through". Four contexts that
actually block were therefore described to every seat as optional — the misclassification
that puts a PR into the queue to be ejected, or leaves a seat waiting on a context it
believes advisory. Rewritten to name all six and to scope the advisory clause to what is
genuinely outside the set.

**`scripts/check-required-contexts.mjs`.** The AGENTS.md surface's `mustName` is widened
from two literals to all six, so the corrected sentence is lexicon-pinned: a rename in any
of the six now reddens `check:required-contexts` instead of rotting the prose. This is the
mechanical follow-on the card named, folded into the same PR because one governed hit
governs the whole diff anyway.

Authorized by the maintainer ruling recorded on the card, 2026-08-18 — 「其他接受你的建议」.

## ⚠️ The live required set could not be re-measured from this seat — read this

The dispatch required re-measuring the live set rather than copying the card's six. Both
named routes are shut to this session, measured rather than assumed:

| route | result |
| --- | --- |
| `node scripts/check-required-contexts.mjs --verify-required-set` | `NOT VERIFIED` — HTTP 401, exit 2 |
| same, with `NODE_OPTIONS=--use-env-proxy` (the script's own suggested retry) | `NOT VERIFIED` — HTTP 403, exit 2 |
| `curl https://api.github.com/repos/objectstack-ai/objectstack` | HTTP 403 — "GitHub access is not enabled for this session. An org admin must connect the Claude GitHub App for this organization." |

That is an **environment** classification, not a tree result — exactly the posture the
script documents for `NOT VERIFIED` (#4690). The session's egress policy answers 403 for
`api.github.com`, and the MCP GitHub surface available here exposes no ruleset or
branch-protection read, so no live route exists from a dev seat today.

**What the six were sourced from instead:** `REQUIRED_CONTEXTS` in
`scripts/check-required-contexts.mjs` at `origin/main` — the repo's machine-checked pin,
independently re-measured live on 2026-08-18 by the #9642 delivery, which the script's
header records as agreeing with the live set in both directions after the #9533 rows were
dropped. This is also the *mechanically required* source: `judgeInstructionSurfaces`
rejects a `mustName` literal that is not a registered context, so the widening could not
have been pinned to the card's text even if I had copied it.

**Observed delta: none.** The six literals in the registry match the card's reading
character-for-character. If the live set has moved since 2026-08-18, `--verify-required-set`
is the designed detector and this PR does not weaken it.

## Line budget

`AGENTS.md` is ratcheted at 958 with headroom 0, so the correction is net-zero: **958
before, 958 after, ceiling 958**, rewritten in place. Paying for four extra context names
inside that budget cost two things, both deliberate:

- the parenthetical recording that `Lint & Repo Gates` was formerly published under a name
  describing one of its steps — that history lives in `RETIRED_CONTEXT_NAMES`, which is
  where a seat can act on it;
- a pointer to `--verify-required-set` in the prose. The `mustName` widening in this same
  PR is the stronger guard against the same rot, and it is mechanical rather than
  aspirational.

The `check:*` gate-family note stayed: it is the only place in `AGENTS.md` that maps a red
`check:*` gate to its required context.

## Gates — run at `d5aa484`, after the final commit

| gate | verdict line |
| --- | --- |
| `check:required-contexts` | `✓ check-required-contexts: 6 required context name(s) pinned across 2 workflow(s); 5 instruction surface(s) scanned` (self-test: `115 assertions`) |
| `check:pm-skill-ratchet` | `✓ check-skill-line-ratchet: AGENTS.md is 958 lines (ceiling 958; headroom 0).` |
| `check:pm-governed-prose` | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces` (self-test: `24 cases pass`) |
| `check:cross-package-test-inputs` | `OK: 12 package(s) read outside themselves, all declared` (self-test: `All 33 self-test cases passed.`) |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6309 text file(s) ... no raw ASCII control bytes)` |

Families derived with `node scripts/pm/dispatch-gates.mjs` (no paths) against the real
change set — merge base `ae555f4`, 2 paths, no sibling contamination. It placed
`check:required-contexts` and `check:cross-package-test-inputs`; the ratchet, governed-prose
and NUL families are the dispatch-named and edit-implied additions.

## Reverse verification of the `mustName` widening

Direction predicted before running: dropping one newly-pinned literal from `AGENTS.md`
turns the check **red naming that literal**, and the `--self-test` half stays green because
it runs on its own fixtures.

Observed: `Test Core` occurs exactly once in `AGENTS.md` (the new sentence). Renaming it to
`Core Suite` made the run exit 1 with

> AGENTS.md no longer names the required context 'Test Core'. This file states the required
> set, and the literal IS the contract ...

Prediction half-right and recorded as such: the red surfaced **inside** `--self-test` (5 of
its cases read the real instruction files), so the standalone scan never ran. Restored with
`git checkout -- AGENTS.md` from the committed state; re-run green, working tree clean.

No rebuild leg exists for this ablation and none is claimed: `check:required-contexts` runs
`node scripts/check-required-contexts.mjs` from source, with no `dist/` in its resolution
path.

## Not a changeset case

Nothing here is published — an instruction file and a CI-internal gate script. Labelled
`skip-changeset`, which the `lint.yml` comment block calls the textbook case for exactly
this shape.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_