### PR TITLE
docs(gate): stop check-engine-double-contract restating its own ledger size in prose

### DIFF
--- a/scripts/check-engine-double-contract.mjs
+++ b/scripts/check-engine-double-contract.mjs
@@ -203,17 +203,21 @@
 //
 // Method, stated so this can be redone rather than trusted: membership is
 // proxied by `assertEngine…Dispatch(` call sites in test files under the scan
-// roots, calibrated against this gate's own ledger at HEAD -- 0 false negatives
-// on the file sets, and 309 of 310 (file, verb) rows agreeing on the exact
-// count. Anyone re-running it must first prove their clone actually covers the
-// window; a shallow one silently answers for its own depth, which is the whole
-// reason this paragraph had to be rewritten.
+// roots, calibrated on 2026-08-19 against this gate's own ledger as it then
+// stood -- 0 false negatives on the file sets, and every (file, verb) row but
+// ONE agreeing on the exact count. That calibration is a dated measurement, not
+// a standing property; anyone re-running it must first prove their clone covers
+// the window; a shallow one silently answers for its own depth, which is the
+// whole reason this paragraph had to be rewritten.
 //
 // So the additions the ratchet does redden on are already in conversation with
 // this gate (they are new fakes that had to write `assert…Dispatch` because
-// PINNED demanded it). 310 entries today against the 135 the DEBT ledger
-// already carries: same file format, same order of magnitude, same
-// reconciliation shape.
+// PINNED demanded it). Set against the DEBT ledger this gate already carries,
+// the pinned ledger is the same file format, the same order of magnitude and
+// the same reconciliation shape -- so it is the maintenance cost already being
+// paid for the other ledger, not a new one. Both sizes are printed by a run and
+// countable in the artifacts; they are deliberately not copied into this prose,
+// because `--write` moves one of them and nothing here would notice.
 //
 // ## How a LEGITIMATE decrease is expressed (the anti-nuisance half)
 //
@@ -1476,10 +1480,12 @@ function readBaseline() {
  * The RETAINED ledger (#9680) — the enumerated pinned population.
  *
  * Deliberately a SEPARATE artifact from `engine-double-contract.baseline.json`
- * rather than more rows in it. The baseline is 135 hand-written MEASURED
+ * rather than more rows in it. The baseline is a set of hand-written MEASURED
  * justifications whose readability this file's header calls the gate's whole
- * value ("shrink-only, hand reviewed"); folding 308 generated rows in would
- * bury the reasons under the census and blur which rows a human must agree to.
+ * value ("shrink-only, hand reviewed"); folding the generated rows in would
+ * bury the reasons under a census that ALREADY OUTNUMBERS them -- and, by the
+ * opposite polarities below, can only outnumber them further -- blurring which
+ * rows a human must agree to.
  * These two ledgers also answer to opposite polarities — the baseline records
  * debt and may only SHRINK, this one records coverage and may only GROW — so a
  * reader who conflates them reads every ratchet in this file backwards.
@@ -1497,10 +1503,11 @@ function readPinnedLedger() {
  * diff.
  *
  * Counted per FILE and not merely as membership, because a file may hold more
- * than one pinned double for a verb — measured on this branch: 319 pinned
- * doubles across 308 (file, verb) pairs, so 11 pairs carry more than one. A
- * membership-only ledger would let a file that pins two deletes drop to one in
- * silence, which is this card's defect at a finer grain.
+ * than one pinned double for a verb — the rows reading `"pinned"` above 1 in
+ * `engine-double-contract.pinned.json` are the live list, and the ledger is
+ * where to read how many there are rather than here. A membership-only ledger
+ * would let a file that pins two deletes drop to one in silence, which is this
+ * card's defect at a finer grain.
  */
 function censusPinned(slices) {
   const rows = [];
@@ -1537,7 +1544,8 @@ const pairKey = (file, verb) => JSON.stringify([file, verb]);
  * remedy attached to the wrong story.
  *
  * Counted rather than a membership Set, because a file may pin several doubles
- * for one verb (measured: 10 of 308 rows do). Membership alone cannot separate
+ * for one verb (the ledger rows reading `"pinned"` above 1 are the live list,
+ * as above). Membership alone cannot separate
  * "the file pinned two deletes and now pins one because a MEMBER WAS DELETED"
  * from "...because a member stopped calling the predicate", and those two want
  * opposite remedies: restore the member vs re-pin it.
@@ -1578,8 +1586,9 @@ const REGEN = 'node scripts/check-engine-double-contract.mjs --write';
 function retainedErrors(census, ledger, ledgerExists, declared, onDisk) {
   const errors = [];
 
-  // Bootstrap. Without this a missing artifact reports 308 separate "not in the
-  // ledger" errors, which reads as a catastrophe and buries the one-line fix.
+  // Bootstrap. Without this a missing artifact reports one "not in the ledger"
+  // error per census row -- hundreds of them, and growing, since this ledger is
+  // grow-only -- which reads as a catastrophe and buries the one-line fix.
   if (!ledgerExists) {
     return [
       `RETAINED: ${relative(ROOT, PINNED_LEDGER_PATH)} is missing. That file IS the pinned `
@@ -2915,7 +2924,8 @@ class Svc {
     grewMore.length === 1 && anyOf(grewMore, 'Coverage grew'));
 
   // ── Bootstrap: a missing ledger is ONE error, not one per row. The failure
-  // this guards is a fresh checkout reporting 308 problems for one missing file.
+  // this guards is a fresh checkout reporting one problem per census row for a
+  // single missing file.
   const missing = retainedErrors(
     [{ file: 'a.test.ts', verb: 'delete', pinned: 1 }, { file: 'b.test.ts', verb: 'update', pinned: 1 }],
     { entries: [] }, false, dcount([]), onDisk);


### PR DESCRIPTION
Fixes #9915

`scripts/engine-double-contract.pinned.json` is generated: `--write` — the action this
gate's own failure messages instruct authors to take — moves its row count. Prose in
`scripts/check-engine-double-contract.mjs` had copied that count beside it, so a routine,
sanctioned action silently falsified the comment block whose stated job is to justify a
merge-blocking ratchet to the next reader.

**Comment-only.** No invariant, criterion, exit code, population or output string is
touched — proof below.

## Re-derived count: 7 sites, 13 figure occurrences, not 5

The card said 5 and warned the live number might differ either way (PR #9712 landed since
filing). It is higher. Method: extract every numeric literal in the file's comment lines,
then classify each by whether it describes a population the script itself loads. A
mechanical cross-check — comparing every array length in the pinned ledger against the
file's prose — independently flags the sites whose figure *currently* equals a live
ledger size, catching the two the card missed.

The table below groups the 13 occurrences by the sentence they sit in.

Measured at merge base: the ledger holds **310 rows / 321 doubles / 176 files**, and
**10** rows pin more than one double.

| site | figure | was | disposition |
|---|---|---|---|
| L206 | `309 of 310 (file, verb) rows` | accurate | **must stay literal** → anchored as dated |
| L214 | `310 entries today` / `135` DEBT | accurate | **deleted** → ratchet-guaranteed claim |
| L1481 | `folding 308 generated rows` | stale (310) | **deleted** → ratchet-guaranteed claim |
| L1500 | `319 pinned doubles` | stale (321) | **deleted** → points at the ledger |
| L1501 | `across 308 (file, verb) pairs` | stale (310) | **deleted** → points at the ledger |
| L1501 | `so 11 pairs carry more than one` | **wrong** | **deleted** |
| L1540 | `10 of 308 rows do` | stale (308) | **deleted** → points at the ledger |
| L1581 | `308 separate "not in the ledger" errors` | stale (310) | **deleted** → "one per row" |
| L2918 | `308 problems for one missing file` | stale (310) | **deleted** → "one per row" |

All five sites the card listed were still stale — the count did not go down. Two more
(L206, L214) are the same defect **latent**: correct today, wrong on the next `--write`.
L214 is the site PR #9712 refreshed; refreshing is what left it still able to rot.

### One figure was never right

`319 pinned doubles across 308 (file, verb) pairs, so 11 pairs carry more than one` — 11
is the **excess of doubles over rows**, not the count of rows pinning more than one. That
count is **10** (9 rows pin 2, one pins 3), which is what the paragraph 40 lines below
already said: `measured: 10 of 308 rows do`. Two sentences in one file gave different
values for the same quantity, and the arithmetic that made the claim look self-consistent
(321 − 310 = 11) is the coincidence the card flagged.

## Approach: removed or ratchet-guaranteed, never re-measured

Per the #9803 / PR #9909 lesson, a refreshed constant reproduces the defect with a fresher
value. And these are **comments** — nothing renders them, so "derived at run time" is not
available without making `--write` rewrite this file's own source, which would be a
behaviour change. So each figure is instead removed, or replaced by a claim the ratchets
already guarantee:

- The pinned ledger **may only GROW** and the baseline **may only SHRINK** — both stated
  in the paragraph being edited. So "a census that ALREADY OUTNUMBERS them and can only
  outnumber them further" and "hundreds of them, and growing" are monotone-true by
  construction, not by measurement.
- Where the magnitude was incidental (the bootstrap error explosion), the point is "one
  error per census row", which needs no number and reads better without one.
- Where the live number matters, the prose now points at the artifact that holds it
  rather than copying it.
- L206's `309` is genuinely underivable — it is a calibration agreement rate against a
  past HEAD, not a ledger size. It stays literal but is anchored as a dated measurement,
  matching the idiom the paragraph above it already uses (`in the month to 2026-08-18`).

Removing `135` also corrected a second inaccuracy: the gate reports `133 in the DEBT
ledger, 2 exempt` — 135 is the baseline file's total entries, not what the DEBT ledger
carries.

## Verification (all at `e7ebebd66`, the final commit)

**Comment-only proof.** Both revisions emitted through the TypeScript compiler with
`removeComments: true`, compared byte-for-byte:

```
emitted bytes: base=80651 head=80651
IDENTICAL — the change is comment-only
```

(A raw-scanner token diff was tried first and desynced on regex-literal ambiguity; the
full-parser emit is the trustworthy instrument.)

**Gates**, re-derived from the actual changeset with
`node scripts/pm/dispatch-gates.mjs` (no paths passed — it takes the change set from the
merge base itself), which placed 3 families:

```
pnpm check:engine-double-contract
  OK  self-test: separates engine doubles from driver doubles ...
  check-engine-double-contract: OK — 321 pinned, 133 in the DEBT ledger, 2 exempt.
  check-engine-double-contract: 310 (file, verb) row(s) held by the RETAINED ledger

pnpm check:cross-package-test-inputs
  All 33 self-test cases passed.
  OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.

pnpm check:nul-bytes
  check-nul-bytes: OK (scanned 6312 text file(s) ... no raw ASCII control bytes).
```

`dispatch-gates` also reported `Model tier — no path-derived mandate` for this surface.

## Not in this PR

No changeset: this is a `scripts/` gate and nothing published changes.

A second population of self-describing figures in the same file is filed separately as
issue #9943 and is deliberately untouched here — the prose stating the **DISCOVERED** and
**PINNED** sizes (`250 doubles this gate discovers` reads 487 today; `82 PINNED` reads
321). Those are not invalidated by `--write`, and correcting them requires re-running a
measurement whose conclusion could change, which is a decision rather than a prose edit.
That issue stays open and is out of scope here.

Sibling sweep for the same shape elsewhere in `scripts/`: of the ten other scripts with a
regenerator mode, exactly one hardcodes its own regenerated baseline's size in prose —
`scripts/check-role-word.mjs`, at two sites (`43 baselined file(s)` and `43 problem(s)`),
currently accurate and therefore latent. Left alone for the PM to card; it is not
addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_

---
_Generated by [Claude Code](https://claude.ai/code)_