### PR TITLE
docs(pm): state the skill line-ratchet's coverage boundary in its header

### DIFF
--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -25,6 +25,39 @@
  * see check-skill-id-lint.mjs). Without a gate that intent erodes one
  * well-meaning paragraph at a time.
  *
+ * ## What is covered — and the published catalog, which deliberately is not
+ *
+ * "The whole surface" above means the CEILINGS map below, which is an
+ * ENUMERATION, never a root glob: the pm-dispatch surface (SKILL.md, its
+ * references/, the per-lane job descriptions), the four other
+ * `.claude/skills/` playbook SKILL.md files, the dev-agent definition
+ * `.claude/agents/os-dev.md`, and the root `AGENTS.md`. Read a file's absence
+ * from the map as a fact to check, not an oversight to infer — `.claude/hooks/`,
+ * `.claude/settings.json` and `CLAUDE.md` carry no ceiling either.
+ *
+ * The **published** `skills/` catalog — the one that ships to customer projects
+ * — is deliberately OUTSIDE the ceiling. It is the omission worth stating
+ * because it is by far the larger surface: eleven published SKILL.md totalling
+ * ~10,400 lines, against ~3,700 covered here. Two reasons, both about the cost
+ * curve the ratchet prices rather than about size (#9923):
+ *
+ *   - What the ratchet prices is a full-file token read paid PER SEAT SESSION
+ *     and PER ROUTINE FIRE, which is what every covered file above costs. The
+ *     published catalog is read by customer projects, not by this repo's seats
+ *     — a different cost curve, and not the one this gate was built against.
+ *   - The published catalog is already a governed, human-merge-only surface
+ *     (Prime Directive #14), so growth there passes a human eye by
+ *     construction — a control a ratchet would merely duplicate. Note this
+ *     reason does not separate the two roots by itself: the covered files are
+ *     governed at merge too. What no reviewer prices THERE is the recurring
+ *     per-session read of reason one, which is why they still carry ceilings
+ *     and the published catalog does not.
+ *
+ * Extending coverage to the published root is therefore a POLICY CHANGE, not a
+ * maintenance edit: it needs its own card and a maintainer's ruling, not a
+ * CEILINGS row added in passing. The self-test pins this boundary, because
+ * enforcement cannot — a published-root entry would run perfectly green.
+ *
  * ## The ratchet discipline (shrink-only, per file)
  *
  *   - A ceiling may be LOWERED by any PR that shrinks its file — lowering is
@@ -142,6 +175,12 @@ function selfTest() {
     ['all six lane job descriptions are covered', ['engine', 'services', 'cli', 'devx', 'skills', 'spec'].every((n) => CEILINGS.has(`.claude/skills/pm-dispatch/references/lanes/${n}.md`)), true],
     ['the other four skills are covered (#9473)', ['checklist-test', 'checklist-author', 'dogfood-verification', 'spec-property-retirement'].every((n) => CEILINGS.has(`.claude/skills/${n}/SKILL.md`)), true],
     ['root AGENTS.md is covered (#9792)', CEILINGS.has('AGENTS.md'), true],
+    // The boundary the header states, pinned (#9923). Enforcement cannot hold
+    // it: a ceiling on a real published SKILL.md runs green like any other row,
+    // so without this case the header paragraph could drift from the map
+    // silently. Extending coverage to the published catalog is a policy change
+    // — it lands with a maintainer ruling that also deletes this case.
+    ['the published skills/ catalog is deliberately uncovered', [...CEILINGS.keys()].some((k) => k.startsWith('skills/')), false],
   ];
   let failed = 0;
   for (const [name, actual, expected] of cases) {


### PR DESCRIPTION
Fixes #9923

Header honesty only. **No `CEILINGS` entry added; no enforcement behaviour changed.**

## The gap

`scripts/pm/check-skill-line-ratchet.mjs` ends its "Why ceilings" section with "the ceiling now covers the whole surface, per file" — which reads as a claim about the instruction surface **as a category**. Re-measured on `origin/main` at merge base `5989b0de9`:

| | |
|---|---|
| `CEILINGS` entries | **18** |
| under `.claude/` | 17 |
| other | `AGENTS.md` |
| under the published `skills/` root | **0** |

The published catalog is eleven `SKILL.md` totalling **10,443** lines, against **3,664** lines of ceiling covered here. A reader could not see the published root was outside the boundary without diffing the map against the filesystem.

Note the card said 16 entries; its own enumeration (6 + 6 + 4 + 1 + 1) sums to 18, and 18 is what the map holds. The load-bearing measurement — zero published-root entries — is unaffected.

## The fix, per the ruling on the card

Deliberately uncovered stays uncovered. The header now states:

1. The covered set is an **enumeration**, never a root glob, and names it. It also names what else carries no ceiling (`.claude/hooks/`, `.claude/settings.json`, `CLAUDE.md`) so absence reads as a fact to check rather than an oversight to infer.
2. The published `skills/` catalog is **deliberately outside**, with both reasons: the ratchet prices a full-file token read paid per seat session and per Routine fire, and the published catalog is read by customer projects rather than this repo's seats — a different cost curve; and the published catalog is already a governed, human-merge-only surface (Prime Directive #14), so growth there passes a human eye by construction.
3. Extending coverage to the published root is a **policy change** needing its own card and a maintainer's ruling, not a `CEILINGS` row added in passing.

One precision added while writing reason 2, because the header must not itself state something false: the governed-surface reason **does not separate the two roots on its own** — the covered files are human-merge-only too (Prime Directive #14 names `.claude/**` and `AGENTS.md`), so taken alone that reason would argue against the `AGENTS.md` ceiling that already exists. The header now says so and points at the recurring per-session read as the property that actually does the separating.

## The boundary is pinned, because enforcement cannot hold it

One self-test case in the file's existing idiom asserts no `CEILINGS` key starts with the published root. This is not decoration — see the reverse verification below: a ceiling on a **real** published `SKILL.md` runs perfectly green through the enforcement path, so without the pin the header paragraph could drift from the map silently.

## Reverse verification (direction predicted in writing before running)

**RV-1 — the pin catches a published-root ceiling.** Mutation: add `['skills/objectstack-formula/SKILL.md', 556]`, a real path at its true line count, chosen so enforcement stays green. Predicted: enforcement GREEN, self-test RED. Observed exactly that:

```
RUN_EXIT=0
  check-skill-line-ratchet: skills/objectstack-formula/SKILL.md is 556 lines (ceiling 556; headroom 0).
SELFTEST_EXIT=1
  the published skills/ catalog is deliberately uncovered      [failing case]
  check-skill-line-ratchet self-test: 1 of 15 case(s) failed.
```

Restored with `git checkout HEAD -- ...` from the committed state; `git status --porcelain` clean afterwards (no `MM`), mutation absent.

**RV-2 — header prose must not change derived watch hints.** `scripts/pm/dispatch-gates.mjs` machine-reads this file via `extractWatchHints`, which masks comments first. Predicted: hint set byte-identical before and after, since any change would silently widen the ratchet family's watch set — an enforcement/derivation change this card forbids.

**This leg falsified its prediction on the first run, and the failure was real.** The initial header spelled a glob whose asterisk and slash form a **comment terminator**, closing the docblock early. Node reported `SyntaxError: Unexpected identifier 'AGENTS'`, and the orphaned prose — now parsed as module body — leaked seven phantom hints (`.claude`, `.claude/hooks`, `.claude/settings.json`, `.claude/skills`, `origin/main`, `references`, `skills`). Rewritten without the terminator; `node --check` passes and the hint set is identical to the base (17 hints, unchanged) at final head. The three `dispatch-gates` self-test cases that pin this file's hints stay green.

The generalisable trap: a path glob containing an asterisk followed by a slash cannot be written literally inside a block comment.

## Gates

`node scripts/pm/dispatch-gates.mjs` with no args, deriving from the real diff, re-run on final commit `021dfbcbb`; `scripts/**` adds `check:nul-bytes` per the dispatch. Each gate's own verdict line, from that head:

- `pnpm check:pm-skill-ratchet` — `check-skill-line-ratchet self-test: 15 cases pass.` and `check-skill-line-ratchet: AGENTS.md is 958 lines (ceiling 958; headroom 0).` (whole tree still passes)
- `pnpm check:cross-package-test-inputs` — `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `pnpm check:nul-bytes` — `check-nul-bytes: OK (scanned 6314 text file(s) -- 6314 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).`
- `pnpm check:pm-dispatch-gates` (not derived; run because it pins this file's hints) — `dispatch-gates self-test: 310 cases pass.`

`skip-changeset`: internal PM tooling, nothing user-visible ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_
