### PR TITLE
docs(comments): date the #3290 session.tenantId removal to v16, not v11

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -655,7 +655,7 @@ jobs:
 
       # #3280/#3290 org-identifier guard: `organizationId` is the blessed
       # developer-facing name for the caller's active org in hook/action bodies;
-      # the `session.tenantId` alias was REMOVED in v11 (#3290). Keeps our own
+      # the `session.tenantId` alias was REMOVED in v16 (#3290). Keeps our own
       # reference code (examples/, apps/, AND packages/) — which authors and AIs
       # copy from — off the removed name. Hard-fail (surfaces carry zero
       # occurrences today); tests, comments, skills/ and docs/ are excluded, and

--- a/content/docs/kernel/runtime-services/sharing-service.mdx
+++ b/content/docs/kernel/runtime-services/sharing-service.mdx
@@ -95,7 +95,7 @@ export async function mayEditContract(
     userId: session.userId,
     // The execution context names the org `tenantId`; a session exposes the
     // same value as `organizationId` (the `session.tenantId` alias was removed in
-    // v11, #3290).
+    // v16, #3290).
     tenantId: session.organizationId,
     positions: session.positions,
   });

--- a/packages/objectql/src/engine.test.ts
+++ b/packages/objectql/src/engine.test.ts
@@ -535,7 +535,7 @@ describe('ObjectQL Engine', () => {
             await engine.insert('task', { title: 'x' }, { context: { userId: 'u1', tenantId: 'org_1' } as any });
 
             // Blessed name carries the org; the deprecated `tenantId` alias was
-            // removed in v11 (#3290) and must no longer be emitted.
+            // removed in v16 (#3290) and must no longer be emitted.
             expect(session.organizationId).toBe('org_1');
             expect(session.tenantId).toBeUndefined();
             // `ctx.user` shortcut carries the same org for zero-relearning filtering.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -2906,7 +2906,7 @@ export class ObjectQL implements IObjectQLEngine {
       // active org (matches the `organization_id` column, `current_user`
       // RLS shape, and seed rows). It comes from `execCtx.tenantId`, which the
       // kernel resolves from `session.activeOrganizationId`. The deprecated
-      // `session.tenantId` alias (#3280) was removed here in v11 (#3290) — the
+      // `session.tenantId` alias (#3280) was removed here in v16 (#3290) — the
       // driver-layer `execCtx.tenantId` knob is a separate axis and stays.
       organizationId: execCtx.tenantId,
       positions: execCtx.positions,

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -942,7 +942,7 @@ export class ObjectQLPlugin implements Plugin {
       }
       // Stamp the driver-layer `tenant_id` column from the caller's active org.
       // The hook session exposes it as `organizationId` (the `session.tenantId`
-      // alias was removed in v11, #3290); the column name is a separate axis.
+      // alias was removed in v16, #3290); the column name is a separate axis.
       if (isInsert && session?.organizationId && hasField(objectName, 'tenant_id')) {
         record.tenant_id = record.tenant_id ?? session.organizationId;
       }

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -1557,7 +1557,7 @@ describe('audit writers — the record\'s own organization stamps the row (#8707
  * `organizationId`, `positions`, `accessToken`, plus the conditional
  * `isSystem` / `actor` / `skipTriggers` / `skipAutomations` / `preserveAudit`.
  * There is no spread, so no other key can arrive. `session.tenantId` was a
- * deprecated alias (#3280) REMOVED repo-wide in the v11 major (#3290).
+ * deprecated alias (#3280) REMOVED repo-wide in the v16 major (#3290).
  *
  * The writer nevertheless read `sess.tenantId` for the RLS fallback, so the
  * fallback could never fire: on an object with no organization column, or a

--- a/packages/plugins/plugin-audit/src/audit-writers.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.ts
@@ -1348,7 +1348,7 @@ export function installAuditWriters(
     // [#9516] The fallback arm reads `organizationId` — the ONLY name the
     // engine emits. `ObjectQL.buildSession` builds the hook session as a fixed
     // key-set literal with no spread, and the `session.tenantId` alias (#3280)
-    // was removed repo-wide in the v11 major (#3290). This arm spelled the
+    // was removed repo-wide in the v16 major (#3290). This arm spelled the
     // removed name, so it resolved to `undefined` and the guard above could
     // never fire: every case it names — no organization column, NULL column —
     // stamped `organization_id: null` and went permanently invisible behind the

--- a/packages/runtime/src/action-execution.ts
+++ b/packages/runtime/src/action-execution.ts
@@ -949,7 +949,7 @@ export function enforceActionParams(deps: ActionExecutionDeps,
  *
  * `organizationId` is the blessed name for the caller's active org — the
  * same value as the `organization_id` column and `current_user.organizationId`
- * (RLS). The deprecated `session.tenantId` alias (#3280) was removed in v11
+ * (RLS). The deprecated `session.tenantId` alias (#3280) was removed in v16
  * (#3290); the driver-layer `ExecutionContext.tenantId` it is sourced from is
  * a distinct, configurable axis and stays. Returns `undefined` — never `{}` —
  * for a genuinely context-less / self-invoked call, so a body can tell "no

--- a/packages/runtime/src/action-session-shape-contract.test.ts
+++ b/packages/runtime/src/action-session-shape-contract.test.ts
@@ -85,7 +85,7 @@ describe('#5697 — action `ctx.session` matches its declared contract', () => {
     it('translates `ExecutionContext.tenantId` to the blessed `organizationId`', () => {
         const built = build({ tenantId: 'org_acme' });
         expect(built).toEqual({ organizationId: 'org_acme' });
-        // The v11-removed alias (#3280 / #3290) must not reappear.
+        // The v16-removed alias (#3280 / #3290) must not reappear.
         expect('tenantId' in built!).toBe(false);
     });
 

--- a/packages/runtime/src/domains/actions.ts
+++ b/packages/runtime/src/domains/actions.ts
@@ -320,7 +320,7 @@ export async function handleActionsRequest(deps: DomainHandlerDeps, path: string
     // request (falling back to the id, quietly, when there is none).
     // `organizationId` remains the blessed developer-facing name for the
     // caller's active org (matches columns + `current_user.organizationId`);
-    // the deprecated `tenantId` alias (#3280) was removed in v11 (#3290).
+    // the deprecated `tenantId` alias (#3280) was removed in v16 (#3290).
     const ec: any = _context?.executionContext;
     const userFromAuth = actorUserFromExecutionContext(
         ec,

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -3965,7 +3965,7 @@ describe('HttpDispatcher — action body ctx.user identity (#2701)', () => {
     expect(user.permissions).toEqual(['convert_lead']);
     expect(user.email).toBe('rep@acme.test');
     // #3280 made `organizationId` the blessed name; the `tenantId` alias was
-    // removed in v11 (#3290) and must no longer be emitted on ctx.user.
+    // removed in v16 (#3290) and must no longer be emitted on ctx.user.
     expect(user.organizationId).toBe('org_acme');
     expect(user.tenantId).toBeUndefined();
   });

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -598,7 +598,7 @@ export type HierarchyScope = 'unit' | 'unit_and_below' | 'own_and_reports';
  * The name follows the repo-wide convention: #3280 made `organizationId` the
  * blessed developer-facing name for the caller's active org (matching the
  * `organization_id` column and `current_user.organizationId` in RLS) and #3290
- * removed the `session.tenantId` alias in v11; `scripts/check-org-identifier.mjs`
+ * removed the `session.tenantId` alias in v16; `scripts/check-org-identifier.mjs`
  * keeps it that way.
  */
 export interface HierarchyScopeContext {

--- a/packages/spec/src/data/hook.test.ts
+++ b/packages/spec/src/data/hook.test.ts
@@ -609,7 +609,7 @@ describe('HookContextSchema', () => {
     });
 
     // #3280 made `organizationId` the blessed developer-facing name; the
-    // `tenantId` alias was removed from this surface in v11 (#3290). A stray
+    // `tenantId` alias was removed from this surface in v16 (#3290). A stray
     // `tenantId` key is now stripped by the schema rather than surfaced.
     it('exposes session.organizationId and no longer carries the removed tenantId alias (#3290)', () => {
       const context = HookContextSchema.parse({
@@ -676,7 +676,7 @@ describe('HookContextSchema', () => {
         },
         session: {
           userId: 'user_123',
-          // `session.tenantId` was removed in v11 (#3280/#3290); the blessed
+          // `session.tenantId` was removed in v16 (#3280/#3290); the blessed
           // developer-facing name is `organizationId`. This fixture kept
           // spelling the retired alias for two majors because nothing
           // type-checked it — vitest only sees `HookContextSchema.parse`,

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -614,7 +614,7 @@ export const HookContextSchema = lazySchema(() => z.object({
      * `organization_id` column, `current_user.organizationId` (RLS/sharing),
      * and seed rows. `null`/`undefined` on unscoped (platform/community) calls.
      *
-     * The former `session.tenantId` alias (#3280) was removed in the v11 major
+     * The former `session.tenantId` alias (#3280) was removed in the v16 major
      * (#3290): read the org under this single blessed name. The generic
      * driver-layer isolation knob (`ExecutionContext.tenantId`,
      * `DriverOptions.tenantId`) is a distinct, configurable axis and is

--- a/packages/spec/src/ui/action-params.zod.ts
+++ b/packages/spec/src/ui/action-params.zod.ts
@@ -252,7 +252,7 @@ export interface ActionEngineFacade {
  * under two names. `positions` is canonical — it is the ADR-0090 D3 vocabulary
  * the rest of the platform already uses — and `roles` is the alias kept alive
  * only for the length of the window, then removed on the path
- * `session.tenantId` already walked (#3280 deprecate → #3290 removed in v11).
+ * `session.tenantId` already walked (#3280 deprecate → #3290 removed in v16).
  * The announcement a reader migrates from is the ADR-0087 semantic migration
  * `action-session-roles-to-positions`. Two live spellings is the MIGRATION,
  * not the destination; phase 1 withheld `positions` precisely so that the
@@ -331,7 +331,7 @@ export const ActionSessionSchema = lazySchema(() => z.object({
    * `current_user.organizationId` (RLS). Sourced from
    * `ExecutionContext.tenantId`, which is the distinct driver-level isolation
    * axis and keeps its own name; the deprecated `session.tenantId` alias
-   * (#3280) was removed in v11 (#3290) and must not come back.
+   * (#3280) was removed in v16 (#3290) and must not come back.
    */
   organizationId: z.string().optional().describe('Active organization id (blessed developer-facing name; absent when the call is org-less)'),
 
@@ -384,7 +384,7 @@ export const ActionSessionSchema = lazySchema(() => z.object({
    * one spelling ADR-0090 D3 forbids. Migration prescription and acceptance
    * criteria: the ADR-0087 semantic migration
    * `action-session-roles-to-positions`. Removal follows the `session.tenantId`
-   * alias precedent (#3280 deprecated → #3290 removed in v11), i.e. one
+   * alias precedent (#3280 deprecated → #3290 removed in v16), i.e. one
    * deprecation window after #5613's runtime half lands, not before.
    *
    * Why it is still declared at all: it is what the runtime produces today,

--- a/packages/triggers/trigger-record-change/src/record-change-trigger.ts
+++ b/packages/triggers/trigger-record-change/src/record-change-trigger.ts
@@ -448,7 +448,7 @@ export class RecordChangeTrigger implements FlowTrigger {
             // duplicate of what the engine now resolves authoritatively. The
             // engine elevates only for `runAs:'system'`. The hook session exposes
             // the active org as `organizationId` (the deprecated `session.tenantId`
-            // alias was removed in v11, #3290); it feeds the automation context's
+            // alias was removed in v16, #3290); it feeds the automation context's
             // driver-layer `tenantId` field unchanged.
             ...(session.organizationId ? { tenantId: session.organizationId } : {}),
             // Expose the record as params too, so flows with named `isInput`

--- a/scripts/check-org-identifier.mjs
+++ b/scripts/check-org-identifier.mjs
@@ -9,7 +9,8 @@
 // reads `ctx.user.organizationId` / `ctx.session.organizationId`, matching the
 // `organization_id` column and `current_user.organizationId` in RLS. The old
 // `ctx.session.tenantId` was a deprecated alias; #3290 REMOVED it from the
-// hook/action `ctx.session` surface entirely (v11 major), so any session-borne
+// hook/action `ctx.session` surface entirely (the v16 major — see
+// `content/docs/releases/v16.mdx`), so any session-borne
 // `tenantId` read in an authoring body now resolves to `undefined` and is
 // simply a bug.
 //


### PR DESCRIPTION
Part of #9872 — deliberately **not** a closing keyword: this lands the comment-only half. A
residue of 6 sites is out of scope under the card's rulings and needs PM triage, so merging
this must not close the card.

## The true version, established from the record before any comment was edited

The card asserted v16 on three legs. I verified all three, **falsified one of them**, and
replaced it with two stronger ones.

| Leg | Verdict | Evidence |
|---|---|---|
| Only `v16.mdx` mentions #3290 | ✅ holds | `content/docs/releases/v16.mdx:125,132,1046` — the only release page with a `#3290` hit |
| Its `Upgrade checklist → 16.0.0` lists the rename | ✅ holds | `v16.mdx:977` → "rename `ctx.session.tenantId` / `ctx.user.tenantId` → `organizationId` in every `*.hook.ts` / `*.action.ts` body" |
| "There is no `v11.mdx`, so v11 names a major that does not exist" | ❌ **falsified** | v11 is a real major: `CHANGELOG.md` `## [11.0.0] — 2026-06-27`, plus `docs/upgrading-to-11.md` and `@objectstack/*@11.0.0` in the example changelogs. The page is absent by *policy*, not because the major is: `scripts/check-release-notes.mjs` carries `const KNOWN_MISSING = new Set([10, 11]);` — "Curated release pages started at v9; v10/v11 were never backfilled" |

Absence of `v11.mdx` therefore proves nothing. Two replacement legs that do:

1. **The changelog record.** In `packages/spec`, `packages/runtime` and `packages/objectql`
   alike, the entry ``6c270a6: **BREAKING: remove the deprecated `ctx.session.tenantId` /
   `ctx.user.tenantId` alias…`` sits under `## 16.0.0` (and first under `## 16.0.0-rc.0`).
2. **The v11 guide's silence.** `docs/upgrading-to-11.md` is the complete 10.x → 11.x
   breaking-change guide — "This guide lists every breaking change from **10.x → 11.x**" —
   and contains no `tenantId`, no #3280 and no #3290.

`skills/objectstack-data/references/data-hooks.md:627` (governed; read, not edited) is the one
site that already said v16, and it corroborates.

## Why "v11" got written ~10 times — a single origin, and a cause worth recording

`git log -S` puts the origin at **`6c270a607c`** — *the removal PR itself*
(`feat(hooks)!: remove deprecated ctx.session.tenantId alias … (#3290) (#3305)`, 2026-07-20).
It introduced "v11" **15 times in one diff**. Every later site is a copy.

The cause is not carelessness, and it is still live:

> the repo's root `CHANGELOG.md` **still tops out at `## [11.10.0] — 2026-07-03`**.

It was never maintained past the 11 line while the packages moved on. At `6c270a607c`,
`packages/spec/package.json` read `15.1.1` — but an author sanity-checking "what major are we
on" against the repo's own root changelog reads **11**. That is the whole defect, once.

Hence the repair shape: the durable anchor is the **issue number**, not the major. Every edited
site already cites `#3290` next to the version, so the version is now redundant corroboration
rather than the load-bearing claim, and the single most-copied teaching site — the gate header
that the card notes "teaches the migration" — now names the checkable page:

```diff
-// hook/action `ctx.session` surface entirely (v11 major), so any session-borne
+// hook/action `ctx.session` surface entirely (the v16 major — see
+// `content/docs/releases/v16.mdx`), so any session-borne
```

## Population: 26 wrong sites found, 20 fixed here

Re-derived from scratch (every `v11` / `11.0.0` token and every `#3290` token in the tree), not
taken from the card's "~10".

**Fixed — 20 sites / 17 files, all pure comment text:** `packages/objectql/src/{engine.ts,
plugin.ts,engine.test.ts}` · `packages/runtime/src/{action-execution.ts,http-dispatcher.test.ts,
action-session-shape-contract.test.ts,domains/actions.ts}` · `packages/spec/src/{data/hook.zod.ts,
data/hook.test.ts ×2,ui/action-params.zod.ts ×3 (JSDoc only),contracts/sharing-service.ts}` ·
`packages/plugins/plugin-audit/src/{audit-writers.ts,audit-writers.test.ts}` ·
`packages/triggers/trigger-record-change/src/record-change-trigger.ts` ·
`scripts/check-org-identifier.mjs` · `.github/workflows/lint.yml` (YAML comment) ·
`content/docs/kernel/runtime-services/sharing-service.mdx` (comment inside a sample).

**Found wrong but deliberately NOT fixed — 6 sites, PM triage:**

| Site | Why untouched |
|---|---|
| `skills/objectstack-ui/SKILL.md:1934` | `skills/**` is a **governed surface**; a mixed diff forks the whole PR |
| `packages/spec/src/ui/action-params.zod.ts:376,409` | inside `.describe()` — runtime spec surface, regenerates the auto-generated `content/docs/references/ui/action-params.mdx:58,59`, and would owe a changeset (ruling 6) |
| `packages/spec/src/migrations/registry.ts:1555` + `entries/semantic/17.action-session-roles-to-positions.ts:23` | migration `rationale` — runtime data that regenerates `spec-changes.json` and `docs/protocol-upgrade-guide.md:317` |
| `packages/plugins/plugin-audit/src/audit-writers.test.ts:1653` | a **test title** string, not comment text |
| `scripts/check-org-identifier.mjs:596,600,602,640` | the gate's own **self-test fixture corpus** — ruling 4 says stop and report, not edit |

Also reported, not touched: `.changeset/{org-identifier-session-provenance,
audit-tenant-fallback-reads-organization-id}.md` (inside the #9465 fence) and the historical
`packages/{spec,runtime}/CHANGELOG.md` entries (published records).

**Correct `v11` citations — verified and deliberately left alone:**
`content/docs/kernel/contracts/metadata-service.mdx:311` (`IUIService` removed in v11) and
`docs/audits/2026-07-security-props-liveness-recheck.md:26` (`PolicySchema` removed in v11.0) —
both appear as their own items in `docs/upgrading-to-11.md` (lines 91 and 128). `objectui#3290`
(`packages/spec/src/ui/widget.zod.ts:123`, `content/docs/protocol/objectui/widget-contract.mdx:145`)
is a different repo's issue about the widget `required` state and is not in the population.

## Wider sweep — clean

Swept for a habit rather than one wrong digit: every release-version citation near #3290 and the
rename, plus the co-cited ids. #3280 is exactly what the comments claim it is ("add
`organizationId` as the blessed name", `session.tenantId` deprecated). ADR-0087/0090/0095/0099/0104
all resolve, and ADR-0090 **D3** really is the "role becomes a reserved-forbidden word" decision.
`v11` was the only wrong provenance found.

Nothing mechanical checks a version citation in a comment. `check-release-notes.mjs` verifies the
inverse — that every *released* major has a curated page — and reads nothing in source. That is why
this survived 20 times. Not carded here (a new gate is outside this card); flagged for PM judgement.

## Verification — `d9e01627ab`

Comment-only diff, so the local set was **deliberately narrowed** and is declared as such; CI runs
the full farm. Gate set re-derived mechanically with `node scripts/pm/dispatch-gates.mjs` (no paths
passed) on the committed head — 17 paths, 35 matched families.

```
✓ check-org-identifier self-test: 31 cases pass.
check-org-identifier: OK (2060 author-facing source file(s), 13 session binding(s) resolved,
                          no removed session.tenantId alias).
check-nul-bytes: OK (scanned 6322 text file(s) ... no raw ASCII control bytes).
✅ check-doc-anchors: 251 internal #fragment link(s) across 398 source file(s) all resolve
check-role-word: OK, no new occurrences of the reserved word.
```

`typecheck` green on all five touched packages (5 scripts echoed — not a zero-match silent pass).
Touched test files, all green: `hook.test.ts` + `action-params.test.ts` 102 · `engine.test.ts` 135 ·
`http-dispatcher.test.ts` + `action-session-shape-contract.test.ts` 257 · `audit-writers.test.ts` 67
— **561 tests**.

No changeset: this publishes nothing. Takes the `skip-changeset` label (route 2 in
`scripts/check-empty-changeset.mjs`), never an empty-frontmatter changeset.

⛔ Draft on purpose. Do not arm auto-merge; the maintainer arms after review.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_