### PR TITLE
docs(ci): point the governed-merges step comment at the register, not a hand copy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -284,12 +284,22 @@ jobs:
 
       # Governed-merges audit self-test (#9495) — same family, same split as
       # the half-state sweeper above: the live sweep enumerates the governed
-      # merges (docs/adr/**, .claude/**, skills/**, AGENTS.md, CLAUDE.md)
-      # since a date/ref for the PM round report — report-only by design, the
-      # human-merge-is-the-review-record regime's detection half — while this
-      # step runs only the offline self-test (pure predicates + replay
-      # fixtures; no network, no token), so the predicates cannot rot unrun
-      # the way an uninvoked self-test does (#4690).
+      # merges since a date/ref for the PM round report — report-only by
+      # design, the human-merge-is-the-review-record regime's detection half
+      # — while this step runs only the offline self-test (pure predicates +
+      # replay fixtures; no network, no token), so the predicates cannot rot
+      # unrun the way an uninvoked self-test does (#4690).
+      #
+      # ⛔ WHICH surfaces are governed is deliberately NOT restated here
+      # (#9840). The register is `GOVERNED_SURFACES` in
+      # `scripts/pm/check-governed-merges.mjs`, and this comment used to spell
+      # the five out by hand — a copy nothing read. The register grew three
+      # times in two days, and the two hand copies a seat DOES act on went
+      # stale twice (#9395, #9511); those two are pinned by the step below,
+      # over backtick spans inside an anchored region. A bare YAML comment
+      # cannot present that shape, so this one points at the register rather
+      # than restating it: the copy that does not exist cannot go stale.
+      # ⛔ Do not helpfully re-add the list here.
       - name: Governed-merges audit self-test
         run: pnpm check:pm-governed-merges
 


### PR DESCRIPTION
Fixes #9840

The `Governed-merges audit self-test` step comment in `.github/workflows/lint.yml`
restated the five governed surfaces (`docs/adr/**`, `.claude/**`, `skills/**`,
`AGENTS.md`, `CLAUDE.md`) inline, by hand. Nothing read that copy. Triage graded the
card **direction 2** — delete the enumeration and point at the register — and that is
what this PR does.

## Reconciliation against the prose pin (PR #9841, from #9525) — it does NOT cover this

Checked first, because a card filed against a moving repo is a claim about a past
commit. `scripts/pm/check-governed-prose.mjs` is on `main` and its `PROSE_SURFACES`
register has **exactly two rows**: `AGENTS.md` and `.claude/skills/pm-dispatch/SKILL.md`.
`.github/workflows/lint.yml` is not among them, so the gate never opens this file. The
card is live, not stale.

The more useful half is *why* it misses, and the answer is not an oversight. Both
assertion halves operate over **backtick code spans inside an anchored region**; this
copy was bare, unquoted, comma-separated YAML prose. Registering it would have made
containment red on correct text (five spans it cannot see) unless the paths were
backticked first, and the over-claim half would still judge nothing. The gate's own
header states that boundary rather than implying it. So the pin's blind spot here is
declared, and the fix is to remove the copy rather than to widen the recogniser.

## Why delete rather than pin

The comment's reader is someone scanning `lint.yml` to understand why this step runs the
**self-test only** while the live sweep is report-only. That argument does not depend on
*which* five paths the sweep enumerates — the names were incidental colour, unlike
`AGENTS.md` Prime Directive #14, where at-a-glance readability was the point. The
sibling step comment directly above already names its script (`scripts/pm/check-half-states.mjs`)
instead of restating what it does, so pointing is the established shape in this block.

Pinning instead (a third `PROSE_SURFACES` row) would have cost: backticking the five,
plus two literal anchors inside a workflow file that churns heavily, in an
**unconditional** gate with no paths filter — an unrelated restructuring of this step
would turn `Lint & Repo Gates` red repo-wide. Detected drift is strictly worse than
impossible drift when the copy has no reader to serve. The replacement comment also says
why the list is not there, so the next author does not helpfully re-add it.

## Census of the governed-surface list across the tree

The card says "a third" copy. Measured over the whole tree, that is right about the
free-and-fixable population and undercounts the total statement count:

| Site | Kind | Held by a gate? |
| --- | --- | --- |
| `scripts/pm/check-governed-merges.mjs:274-280` `GOVERNED_SURFACES` | **the source** | n/a |
| `AGENTS.md:182` (Prime Directive #14) | prose | **pinned** — `PROSE_SURFACES` row 1 |
| `.claude/skills/pm-dispatch/SKILL.md:496-497` (ACCEPT path-fork) | prose | **pinned** — `PROSE_SURFACES` row 2 |
| `.github/workflows/lint.yml:287` | YAML comment | **free** — removed here |
| `scripts/pm/check-governed-merges.mjs:78-81` | dated verbatim maintainer quotation | free, structurally exempt |
| `scripts/pm/check-governed-prose.mjs:252-253` | self-test fixture | free **by design** |

**6 total / 2 pinned / 3 free**, of which two must stay free: rewriting a dated verbatim
ruling to satisfy a gate is rewriting the ruling, and the self-test fixture is
independent on purpose — `verdict()` takes the register as an argument precisely so the
test can vary it. **After this PR the count of unpinned, editable, non-quoted copies is
zero.**

Everything else that names these paths together is already a pointer, not a copy:
`AGENTS.md:344`, `.claude/skills/pm-dispatch/SKILL.md:194` and both PM lane files defer
to Prime Directive #14 / the ACCEPT fork by name. `scripts/check-required-contexts.mjs:419`
names similar paths for its **own** scan set, and `scripts/pm/dispatch-gates.mjs:710`
cites a single register row; neither is an enumeration.

## Latent, not live

The deleted copy named all five surfaces, correctly spelled, in register order — it
matched the register on the day it was removed. So the defect graded here is **latent**
(it rots on the next surface change), not an already-wrong statement. The register has
grown three times in two days, which is what makes a latent copy worth removing rather
than leaving.

## Verification — comment-only, mechanically proven

`1a8f380849`.

The parsed workflow is **structurally identical** to `origin/main`: same jobs, same
`Lint & Repo Gates` job name (the required context), same 70 steps in `lint:`, same
`run:` lines. No verdict, exit code or gate population changes.

```
parsed OK; structurally identical: true
lint job name: "Lint & Repo Gates"
lint step count: 70 vs 70
```

Gate union re-derived at `1a8f380849` with `node scripts/pm/dispatch-gates.mjs` (no path
arguments — the script takes its own change set from the merge base):

| Gate | Result |
| --- | --- |
| `check:node-version` | `check-node-version: OK (29 setup-node step(s) across 26 workflow(s), all on Node 22).` |
| `check:required-contexts` | OK — all six required contexts resolved |
| `check:shard-attestation` | `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root)` |
| `check:workflow-status-functions` | `check-workflow-status-functions: OK (scanned 26 workflow file(s), 45 job(s) …)` |
| `node scripts/check-shard-attestation.mjs` | `✓ check-shard-attestation: 2 aggregate gate(s) …` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6340 text file(s) … no raw ASCII control bytes).` |
| `check:pm-governed-prose` | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces … and claim no others.` |
| `check:pm-governed-merges` | `✓ check-governed-merges --self-test: 77 assertions` |

**One declared narrowing:** `check:type-check-debt` was not run to completion. Its
`--self-test` leg passes; its `--re-measure` leg refuses on an environment
precondition — *"55 workspace dependenc(ies) of the ledgered packages have no built type
entry point on disk … Build the closure first, exactly as lint.yml does before this
step"* — in a fresh worktree with nothing built. That leg reads `dist/*.d.ts` and the
ledgers, never this file. The only two facts the script derives from `lint.yml` live in
`observed()` (`scripts/check-type-check-coverage.mjs:2240-2255`) and are unchanged by
this diff, measured directly:

```
ciInvokesTask main= true  branch= true  unchanged= true
ciInvokesRoot main= false branch= false unchanged= true
```

and the sibling leg that actually evaluates `observed()` — `check:type-check-coverage` —
is green above. CI builds the closure before this step and runs the farm regardless.

**Reverse verification (no population change).** Predicted direction: identical output,
because watch hints are extracted from gate *script* sources with comments masked, so a
path named in a YAML comment cannot become one. Restored `origin/main`'s `lint.yml` into
the tree (the fix was committed first, so the restore point is a real commit), re-ran
`node scripts/pm/dispatch-gates.mjs --tier scripts/pm/check-governed-merges.mjs` — the
file this comment newly names — and diffed against the same command on this branch:
byte-identical, and `git status --porcelain` clean after `git checkout HEAD --`.

No changeset: a workflow comment publishes nothing. `skip-changeset` applied.

⛔ Draft on purpose — do not flip ready, queue or arm auto-merge; the maintainer arms
after review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_