### PR TITLE
docs(scripts): drop the stale sync-template-versions.mjs cross-reference from the spec entry's serve.ts rationale

### DIFF
--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -139,11 +139,11 @@ const CROSS_PACKAGE_TEST_INPUTS = {
       // scripts/dist-freshness.test.ts stages a fixture around the root scripts dir
       'scripts/**',
       // `serve.ts` is named in a comment rather than read, the same shape as
-      // `check-nul-bytes.mjs` / `sync-template-versions.mjs` / the realtime
-      // protocol page below, and settled the same way: the literal collector
-      // takes quoted paths without parsing, so a mention forces a declaration,
-      // and declaring the file is cheaper than rewording prose to dodge the
-      // scanner. scripts/publish-smoke-port-collision.test.ts cites it for the
+      // `check-nul-bytes.mjs` / the realtime protocol page below, and settled
+      // the same way: the literal collector takes quoted paths without parsing,
+      // so a mention forces a declaration, and declaring the file is cheaper
+      // than rewording prose to dodge the scanner.
+      // scripts/publish-smoke-port-collision.test.ts cites it for the
       // measurement that justifies its whole existence — `serve.ts` auto-shifts
       // off a busy port whenever `flags.dev` is set, which is the only reason
       // publish-smoke.sh cannot trust the port it asked for. One file, not the


### PR DESCRIPTION
Fixes #9977

Comment prose only, in one entry of `scripts/check-cross-package-test-inputs.mjs`. No verdict, exit code, glob or declared population moves.

## What was stale, re-derived rather than taken on trust

The `@objectstack/spec` entry's rationale for the `packages/cli/src/commands/serve.ts` glob offered three examples of the "named in a comment rather than read" shape. One of them stopped being true:

`packages/create-objectstack/src/template-version-stamps.test.ts` really READS the script — line 47 builds the path as `path.join(repoRoot, 'scripts', 'sync-template-versions.mjs')` and line 97 does `fs.readFileSync(SYNC_SCRIPT, 'utf8')` to seed its two-template fixture, on top of loading it by URL and running it with `execFileSync`. Since the collector reconstructs split-segment `join`/`resolve` paths, that read is what holds the radius, and the `create-objectstack` entry lower in this same file already says so in as many words. Two entries in one file disagreeing about one path.

The card proposed the same deletion; it was checked against the tree line by line and matched, so what landed is the same content with the paragraph rewrapped (the proposed diff left a 43-column orphan line mid-paragraph).

## The other examples in the clause were re-checked, and both still hold

A patch that repairs one half of a cross-reference and leaves a newly-false other half is the same defect, so each surviving example was verified against `origin/main`:

| path | status today | evidence |
| --- | --- | --- |
| `scripts/check-nul-bytes.mjs` | still mention-only — a correct example | every reference in the tree is a comment; `packages/cli/test/login-json-noninteractive.e2e.test.ts:143` carries the quoted mention that forces the `@objectstack/cli` declaration. No test reads it. |
| `content/docs/protocol/kernel/realtime-protocol.mdx` | still mention-only — a correct example | named in two comments in `packages/qa/dogfood/test/authz-conformance.test.ts` (lines 175, 260) and read by nothing. |
| `packages/cli/src/commands/serve.ts` (the subject) | still mention-held | `packages/spec/scripts/publish-smoke-port-collision.test.ts:11` quotes the whole repo-relative path in a comment; the test's only repo read is `scripts/publish-smoke.sh` (line 69), reached through `execFileSync('bash', [harness])`. |

The paragraph's remaining factual claims were checked too and stand: `serve.ts:861` still gates the port shift on `portAutoShiftAllowed = flags.dev || process.env.NODE_ENV === 'development'`, and the test still reads `publish-smoke.sh` and nothing else.

## Nothing mechanical keys on the distinction the sentence draws

The one consumer that reads this gate's own source text is `scripts/pm/dispatch-gates.mjs`, and its `extractWatchHints` runs `maskSelfTests(maskComments(scriptSource))` before extracting anything — its header (lines 503-512) states the reason outright: *"naming a path is not reading it."* The gate's own literal collector scans package test files, which this script is not. Measured: `node scripts/pm/dispatch-gates.mjs scripts/check-cross-package-test-inputs.mjs` prints byte-identical output before and after this commit.

## Gates

Run on the final commit `44dfb28457`, working tree clean, after `node scripts/pm/dispatch-gates.mjs` derived the union from the merge base:

- `node scripts/check-cross-package-test-inputs.mjs --self-test` — `All 52 self-test cases passed.`
- `node scripts/check-cross-package-test-inputs.mjs` — `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `node scripts/check-nul-bytes.mjs` — `check-nul-bytes: OK (scanned 6345 text file(s) ... no raw ASCII control bytes).`
- `node scripts/pm/dispatch-gates.mjs --self-test` — `314 cases pass` (run because that self-test reads this file live as a fixture, not because the derivation named it)

Declared narrowing: no `pnpm install` and no local `eslint` run in this worktree. The diff is five comment lines in a dependency-free root `scripts/` gate that belongs to no package, the derived union named only the two invocations above, and the root eslint config has no line-length rule. CI runs the farm regardless.

No changeset: a comment in a `scripts/` gate publishes nothing. `skip-changeset` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_