### PR TITLE
docs(account): fix stale transitional wiring NOTE in index.ts

### DIFF
--- a/packages/apps/account/src/index.ts
+++ b/packages/apps/account/src/index.ts
@@ -14,9 +14,12 @@
  * account app.)
  *
  * NOTE (transitional): `ACCOUNT_APP` is still imported from
- * `@objectstack/platform-objects/apps`, and this package is NOT yet wired into
- * the dev/serve plugin set — that boot-path switch lands separately so it can
- * be verified against a live `os dev` boot.
+ * `@objectstack/platform-objects/apps`. The package IS wired into the
+ * dev/serve plugin set — `packages/cli/src/commands/serve.ts` loads it via
+ * the ADR-0048 platform-app loop (`['@objectstack/account',
+ * 'createAccountAppPlugin']`) — and that boot path has been verified against
+ * a live `os dev` boot (transcript: objectstack-ai/objectos#94, comment
+ * 5329804967).
  */
 
 import { ACCOUNT_APP } from '@objectstack/platform-objects/apps';


### PR DESCRIPTION
Fixes #9696

## What

`packages/apps/account/src/index.ts` carried a transitional header NOTE claiming
the package was "NOT yet wired into the dev/serve plugin set." That boot-path
switch has already landed — this PR rewrites the stale half of the NOTE to
match reality, comment-only.

## Evidence

- `packages/cli/src/commands/serve.ts:2293-2295` loads `@objectstack/account`
  in the ADR-0048 platform-app loop:
  ```ts
  for (const [appPkg, factory] of [
    ['@objectstack/setup', 'createSetupAppPlugin'],
    ['@objectstack/account', 'createAccountAppPlugin'],
  ] as const) {
  ```
- The boot path has been verified against a live `os dev` boot: a
  `@objectstack/cli@17.0.0` boot on a clean home lists `@objectstack/account`
  among the 30 loaded plugins — measured transcript in
  objectstack-ai/objectos#94, comment 5329804967.
- The other half of the NOTE — `ACCOUNT_APP` is still imported from
  `@objectstack/platform-objects/apps` — is still true and is kept verbatim.

## Scope

Comment-only diff, one file, no executable line changed:

```
 * NOTE (transitional): `ACCOUNT_APP` is still imported from
-* `@objectstack/platform-objects/apps`, and this package is NOT yet wired into
-* the dev/serve plugin set — that boot-path switch lands separately so it can
-* be verified against a live `os dev` boot.
+* `@objectstack/platform-objects/apps`. The package IS wired into the
+* dev/serve plugin set — `packages/cli/src/commands/serve.ts` loads it via
+* the ADR-0048 platform-app loop (`['@objectstack/account',
+* 'createAccountAppPlugin']`) — and that boot path has been verified against
+* a live `os dev` boot (transcript: objectstack-ai/objectos#94, comment
+* 5329804967).
```

## Changeset

Comment-only change in a published package — no user-visible behavior change.
Rationale for `skip-changeset` label (this repo's real mechanism; see PR #9918,
PR #10017 for worked examples), applied to this PR rather than an empty
changeset file.

## Tests

- `pnpm --filter @objectstack/account typecheck` — pass, unchanged from `main`
  (comment-only diff).
- `pnpm --filter @objectstack/account test` — package has no test script
  (`build`, `typecheck` only); nothing to run.
- Named gates re-derived via `node scripts/pm/dispatch-gates.mjs` against the
  actual diff (4 matched: `check:slot-lookup`, `check:test-source-alias`,
  `check:type-source-resolution`, `check-affected-docs.mjs`) — all pass, see
  dev report for verdict lines.
- Ablation: not applicable — nothing executable changed.

Commit under review: `2705d5f8a`.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_