### PR TITLE
fix(service-automation): route every retry attempt through the node input-schema guard

### DIFF
--- a/.changeset/automation-input-schema-retry-parity.md
+++ b/.changeset/automation-input-schema-retry-parity.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/service-automation": patch
+---
+
+fix(service-automation): node input-schema validation now guards EVERY attempt of a retried flow, not only the first (#9889)
+
+Before this fix, `validateNodeInputSchemas` — the guard that refuses to run a
+flow whose node `config` violates its own declared `inputSchema` — was called
+only by `execute()` (attempt 1). Under `errorHandling.strategy: 'retry'`, the
+guard's throw routed into `retryExecution`, and every retry attempt ran
+through `executeWithoutRetry` with no guard at all: the nodes attempt 1
+refused to run were executed for real, with the config the guard rejected. A
+side-effecting node (a data write, an HTTP call, an email) behind a
+mis-declared `inputSchema` was reachable simply by declaring `retry`.
+
+Now both attempt paths call the same guard, so flows that were previously
+running on retry with a mis-declared `inputSchema` will be refused on every
+attempt (`success: false`, `status: 'failed'`, with the guard's message).
+Retry accounting is unchanged: each refused attempt still consumes retry
+budget, and valid flows retry exactly as before. If a flow of yours starts
+failing with `missing required input parameter` or `expected type ... but
+got ...` after this release, it was already being refused on its first
+attempt — fix the node's `config` to match its declared `inputSchema`.

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3184,7 +3184,10 @@ export class AutomationEngine implements IAutomationService {
                 reentryHeld = true;
             }
 
-            // Validate node input schemas before execution
+            // Validate node input schemas before execution. [#9889] The same
+            // call sits in `executeWithoutRetry` — every retry attempt must be
+            // refused by the same guard that refused attempt 1; see the guard's
+            // own doc for the chokepoint contract.
             this.validateNodeInputSchemas(flow, variables);
 
             // DAG traversal execution
@@ -5257,6 +5260,18 @@ export class AutomationEngine implements IAutomationService {
     /**
      * Validate node input schemas before execution.
      * Checks that node config matches declared inputSchema if present.
+     *
+     * [#9889] The ONE definition-level input-schema chokepoint, called by BOTH
+     * attempt paths — `execute()` (attempt 1) and `executeWithoutRetry` (every
+     * retry attempt) — the same chokepoint discipline `seedRunVariables`
+     * carries for the variable environment (#9704). Its verdict is a pure
+     * function of the flow definition (`_variables` is deliberately unused),
+     * so a refusal on attempt 1 must hold on every attempt: when only
+     * `execute()` called it, `errorHandling.strategy: 'retry'` ran the very
+     * nodes attempt 1 refused to run. ⛔ A repair to the validation rules
+     * belongs HERE, in the shared method — re-inlining either caller's copy
+     * re-opens the execute/executeWithoutRetry drift this file has now paid
+     * for six times (#9378, #9415, #9414, #9510, #9704, #9889).
      */
     private validateNodeInputSchemas(flow: FlowParsed, _variables: Map<string, unknown>): void {
         for (const node of flow.nodes) {
@@ -6432,6 +6447,29 @@ export class AutomationEngine implements IAutomationService {
                 // for the reason the disabled exit above states.
                 return { success: false, code: 'FLOW_NO_START_NODE', error: 'Flow has no start node' };
             }
+
+            // [#9889] The SAME definition-level guard attempt 1 runs under —
+            // the sixth instance of this method drifting from `execute()`
+            // (#9378, #9415, #9414, #9510, #9704 before it), and the first
+            // that skipped a GUARD rather than an exit or the environment.
+            // Without this call, a flow whose node config violates its own
+            // declared `inputSchema` under `errorHandling.strategy: 'retry'`
+            // was refused on attempt 1 (the guard throws before any node
+            // executes) and then RUN FOR REAL on attempts 2..N, because the
+            // retry handoff lives in `execute()`'s catch and every retry
+            // attempt comes back through here — a refusal that holds only
+            // until the flow is retried, i.e. `retry` as a way past
+            // authoring-time validation. The guard's verdict is a pure
+            // function of the flow definition (`_variables` is unused), so
+            // re-running it cannot refuse anything attempt 1 would have
+            // allowed; the throw lands in this method's generic failure arm
+            // below, so each refused attempt still consumes retry budget and
+            // retry accounting is unchanged. Same chokepoint discipline as
+            // `seedRunVariables` (#9704): ONE method holds the rules, both
+            // attempt paths call it — `input-schema-retry-parity.test.ts`
+            // pins the per-attempt refusal so this call cannot be dropped
+            // silently.
+            this.validateNodeInputSchemas(flow, variables);
 
             await this.executeNode(startNode, flow, variables, runContext, steps);
 

--- a/packages/services/service-automation/src/input-schema-retry-parity.test.ts
+++ b/packages/services/service-automation/src/input-schema-retry-parity.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from './engine.js';
+
+/**
+ * #9889 — node input-schema validation must hold on EVERY attempt, not only
+ * the first.
+ *
+ * `validateNodeInputSchemas` reports by throwing, and the retry handoff lives
+ * inside `execute()`'s catch. Before the repair, only `execute()` called the
+ * guard: for a flow whose node config violates its own declared `inputSchema`
+ * under `errorHandling.strategy: 'retry'`, attempt 1 threw in the guard before
+ * any node executed, the catch routed to `retryExecution`, and attempts 2..N
+ * ran through `executeWithoutRetry` — which never called the guard — so the
+ * nodes attempt 1 refused permission to run were executed for real, with the
+ * config the guard rejected. A `retry` strategy was a way past authoring-time
+ * validation.
+ *
+ * The pins here are written against the OBSERVABLE side effect (an executor
+ * spy counting real node executions), not only the thrown error: the defect's
+ * whole harm is a side-effecting node (a data write, an HTTP call, an email)
+ * running with rejected config, and an assertion on the returned error alone
+ * stays green while that node runs.
+ *
+ * On the envelope: the refusal is asserted as `success: false` +
+ * `status: 'failed'` + the guard's own message. There is no ADR-0112 `code`
+ * to assert — deliberately: #9378's classification gives `code` to the
+ * NEVER-DISPATCHED exits (`FLOW_DISABLED`, `FLOW_NO_START_NODE`) and `status:
+ * 'failed'` to the dispatched-and-failed exits, and the guard's throw rides
+ * the latter family on both attempt paths. Whether a definition-level refusal
+ * should instead be classified non-retryable (its verdict cannot change per
+ * attempt) is the open question #9889 leaves to a maintainer ruling; these
+ * pins assert the parity floor only.
+ */
+
+function createTestLogger(): any {
+    return { info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, child: () => createTestLogger() };
+}
+
+/**
+ * An engine holding one flow whose single work node counts every REAL
+ * execution — the observable the negative pins are written against.
+ */
+function countingFlowEngine(opts: {
+    config: Record<string, unknown>;
+    inputSchema: Record<string, { type: string; required?: boolean }>;
+    /** What the spy executor returns; defaults to success. */
+    executeResult?: (attempt: number) => { success: boolean; error?: string };
+}) {
+    const engine = new AutomationEngine(createTestLogger());
+    const runs = { count: 0 };
+
+    engine.registerNodeExecutor({
+        type: 'script',
+        async execute() {
+            runs.count++;
+            return opts.executeResult ? opts.executeResult(runs.count) : { success: true };
+        },
+    } as any);
+
+    engine.registerFlow('guarded', {
+        name: 'guarded',
+        label: 'Guarded',
+        type: 'autolaunched',
+        errorHandling: { strategy: 'retry', maxRetries: 2, backoffMs: 0 },
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start' },
+            {
+                id: 'work',
+                type: 'script' as any,
+                label: 'Work',
+                config: opts.config,
+                inputSchema: opts.inputSchema,
+            },
+            { id: 'end', type: 'end', label: 'End' },
+        ],
+        edges: [
+            { id: 'e0', source: 'start', target: 'work' },
+            { id: 'e1', source: 'work', target: 'end' },
+        ],
+    } as any);
+
+    return { engine, runs };
+}
+
+describe("#9889 — input-schema refusal holds on every attempt under strategy: 'retry'", () => {
+    it('never executes a node whose config mis-types its declared inputSchema — on ANY attempt', async () => {
+        const { engine, runs } = countingFlowEngine({
+            config: { count: 'not_a_number' },
+            inputSchema: { count: { type: 'number', required: true } },
+        });
+
+        const result = await engine.execute('guarded');
+
+        // The refusal, as the caller sees it (see header for why no `code`).
+        expect(result.success).toBe(false);
+        expect(result.status).toBe('failed');
+        expect(result.error).toContain("expected type 'number' but got 'string'");
+
+        // The point of the card: the side-effecting node ran ZERO times.
+        // Pre-repair this was 2 — refused on attempt 1, executed for real on
+        // attempts 2 and 3.
+        expect(runs.count).toBe(0);
+
+        // And the refusal happened PER ATTEMPT, not by short-circuiting the
+        // retry loop: every attempt still dispatched and consumed budget
+        // (retry accounting unchanged — the non-retryable classification is
+        // the open question, not this repair), so the run log holds one
+        // failed row per attempt (1 initial + maxRetries), each carrying the
+        // guard's own message.
+        const attemptRows = await engine.listRuns('guarded', { status: 'failed' });
+        expect(attemptRows).toHaveLength(3);
+        for (const row of attemptRows) {
+            expect(row.error).toContain("expected type 'number' but got 'string'");
+        }
+    });
+
+    it('never executes a node missing a required declared input — on ANY attempt', async () => {
+        const { engine, runs } = countingFlowEngine({
+            config: {},
+            inputSchema: { url: { type: 'string', required: true } },
+        });
+
+        const result = await engine.execute('guarded');
+
+        expect(result.success).toBe(false);
+        expect(result.status).toBe('failed');
+        expect(result.error).toContain("missing required input parameter 'url'");
+        expect(runs.count).toBe(0);
+    });
+
+    it('still retries a VALID flow normally — the guard refuses nothing attempt 1 allowed', async () => {
+        const { engine, runs } = countingFlowEngine({
+            config: { count: 42 },
+            inputSchema: { count: { type: 'number', required: true } },
+            // Attempt 1 fails downstream (a transient error, the case retry
+            // exists for); attempt 2 succeeds.
+            executeResult: attempt =>
+                attempt === 1 ? { success: false, error: 'downstream 503' } : { success: true },
+        });
+
+        const result = await engine.execute('guarded');
+
+        expect(result.success).toBe(true);
+        // Attempt 1 ran and failed, attempt 2 ran and succeeded — the fix must
+        // not turn a legitimate retry into a refusal.
+        expect(runs.count).toBe(2);
+    });
+});


### PR DESCRIPTION
Fixes #9889

## Defect

`validateNodeInputSchemas` — the guard that refuses to run a flow whose node `config` violates its own declared `inputSchema` — had exactly two sites in `packages/services/service-automation/src/engine.ts` at the branch point (`origin/main@1e050a5b1`, re-measured on this branch): the call at line 3188 inside `execute()`, and the definition at line 5261. `executeWithoutRetry` (line 6381) — the method `retryExecution` re-runs the flow through on **every** retry attempt — never called it.

Because the retry handoff lives inside `execute()`'s catch and the guard reports by throwing, a flow whose node config violates its declared `inputSchema` under `errorHandling.strategy: 'retry'` was refused on attempt 1 (before any node executed) and then **executed for real on attempts 2..N**, with the config the guard rejected. A side-effecting node (a data write, an HTTP call, an email) behind a mis-declared `inputSchema` was reachable simply by declaring `retry`.

## Fix — the parity floor only

`executeWithoutRetry` now calls the same `validateNodeInputSchemas` before dispatching the start node — the same chokepoint discipline `seedRunVariables` carries for the variable environment (#9704): **one method holds the rules, both attempt paths call it**. No second validation mechanism, no copy of the rules.

- The guard's verdict is a pure function of the flow definition (`_variables` is deliberately unused), so re-running it per attempt cannot refuse anything attempt 1 would have allowed.
- The throw lands in `executeWithoutRetry`'s generic failure arm, so each refused attempt still records a `failed` run-log row and still consumes retry budget — **retry accounting is unchanged**. The stronger alternative (classifying definition-level failure as non-retryable so `execute()` never hands off to `retryExecution` at all) changes retry accounting and is deliberately NOT implemented; it is raised as an open question on the issue for a maintainer ruling.
- The refusal envelope is `success: false` + `status: 'failed'` + the guard's message on both paths. It carries no ADR-0112 `code` — pre-existing and deliberate per the #9378 classification (codes mark the never-dispatched exits; `status: 'failed'` marks dispatched-and-failed, which is the family a guard-refused *attempt* rides today). Whether a definition-level refusal deserves its own code is part of the same non-retryable question.

## Why this makes a sixth drift harder (this is instance five: #9378, #9415, #9414, #9510, #9704)

Honestly: adding a call in `executeWithoutRetry` is a second call site, and a future edit could still delete it. What the PR changes about the *class*:

1. **The rules stay in one method.** `validateNodeInputSchemas`'s doc now states the chokepoint contract explicitly — both attempt paths call it, and a repair to the validation rules belongs in the shared method, never inlined into a caller. Diverging on the rules now requires actively re-inlining a copy against a written prohibition at the exact place a rule-editor reads.
2. **The call is pinned behaviorally, not textually.** `input-schema-retry-parity.test.ts` drives a mis-declared flow under `strategy: 'retry'` with a spy executor and asserts the side-effecting node runs **zero** times across all attempts, plus one `failed` run-log row per attempt each carrying the guard's message. Removing the `executeWithoutRetry` call flips the whole run to *success* (verified by ablation, below), so the deletion cannot pass the suite — a sixth drift on this guard now requires removing the call **and** deleting/weakening the pin in the same PR.
3. What it does **not** prevent: a brand-new guard added tomorrow to `execute()` alone. That is the class-level residue the chokepoint pattern can only shrink one guard at a time; stated rather than claimed away.

## Tests

- New `packages/services/service-automation/src/input-schema-retry-parity.test.ts`, 3 pins:
  - mis-typed config under retry → refused on every attempt, spy count 0, 3 `failed` rows (1 initial + `maxRetries: 2`), each with the guard's message — pre-fix this run *succeeded* with the node executing for real;
  - missing required param under retry → same refusal, spy count 0;
  - **valid** flow under retry → still retries normally (fails attempt 1 downstream, succeeds attempt 2, spy count 2) — the fix does not turn a legitimate retry into a refusal.
- Full package suite green at `194ab77db`: `Test Files 83 passed (83)`, `Tests 991 passed (991)` — `os-verify-lock: VERDICT command-exit 0`.

## Ablation (mandatory lane clause)

- Predicted first, in words: removing only the new guard call from `executeWithoutRetry` should fail both negative pins at their first assertion — `expect(result.success).toBe(false)` receiving `true` — because attempt 2 runs unguarded and succeeds, i.e. the refusal evaporates entirely; the valid-flow pin stays green.
- Observed: exactly that. `Tests 2 failed | 1 passed (3)`, both failures `AssertionError: expected true to be false` on the `result.success` assertion; valid-flow pin green. `os-verify-lock: VERDICT command-exit 1`.
- Restored byte-identically: `git hash-object` on `engine.ts` = `35d3e3f51e66626bf7adcdc7bee995e91843b801` both pre-ablation (at commit `194ab77db`) and post-restore; pins re-run green from the committed state (`Tests 3 passed (3)`).
- **Rebuild statement:** no rebuild was required on either leg — the test imports `./engine.js` relative from source and vitest transforms the TS source directly (no package-`exports`/dist resolution, no alias involved), so the mutation and its restoration were both observable immediately; `dist/` was never in the loop.

## Gates — union re-derived with `node scripts/pm/dispatch-gates.mjs` (no paths passed), run at final commit `194ab77db`

Dispatch-named, all green (each gate's own verdict line):
- `pnpm check:cross-package-test-inputs` / `node scripts/check-cross-package-test-inputs.mjs` — "OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob."
- `pnpm check:slot-lookup` — "baseline key set verified against 1e050a5: no files added."
- `pnpm check:test-source-alias` — "check-test-source-alias OK — 72 packages with tests scanned; …"
- `pnpm check:type-source-resolution` — "check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; …"
- `node scripts/docs-audit/check-affected-docs.mjs` — exit 0, "✓ affected-docs self-test: 262 cases pass." (unreachable-rows table is its standing informational report)

Added by re-derivation (changeset paths + new-test-file convention), all green:
- `pnpm check:changeset-gate-self-tests` — "✓ check-changeset-no-major --self-test: 116 assertions …"
- `pnpm check:objectui-changeset` — "✓ objectui-range --self-test: all checks passed"
- `node scripts/check-adr-0087-registration.mjs` — "✓ … this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)."
- `node scripts/check-changeset-no-major.mjs` — "✓ This diff introduces no `major` bump."
- `node scripts/check-empty-changeset.mjs` — "✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added)."
- `pnpm check:query-options-erasure` — "baseline key set verified against 1e050a5: no files added."
- `pnpm check:engine-double-contract` — "check-engine-double-contract: OK — 321 pinned, 133 in the DEBT ledger, 2 exempt."
- `pnpm check:where-matcher` — "baseline key set verified against 1e050a5: no files added."
- `pnpm check:type-check-coverage` — "check-type-check-coverage: OK — 64/77 workspace packages type-checked …"
- `pnpm check:type-check-debt` (after building the packages closure, VERDICT command-exit 0) — "check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 348.3s, 1925 raw tsc error(s) total, none above its recorded number."
- `pnpm check:nul-bytes` — "check-nul-bytes: OK (scanned 6348 text file(s) … no raw ASCII control bytes)."

The package declares no `typecheck` script; its type coverage rides the shared coverage/debt gates above, which re-measured green with the new test file in the tree.

## Changeset

`.changeset/automation-input-schema-retry-parity.md` — patch on `@objectstack/service-automation`, stating the new refusal plainly: flows that were running on retry with a mis-declared `inputSchema` are now refused on every attempt, and how an affected author repairs their flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_