### PR TITLE
docs(service-messaging): mark the `sys_notification_subscription` expansion not-yet-wired and align `principal` with the resolver

### DIFF
--- a/.changeset/notification-subscription-expansion-not-wired.md
+++ b/.changeset/notification-subscription-expansion-not-wired.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/service-messaging": patch
+---
+
+docs(service-messaging): mark the `sys_notification_subscription` expansion not-yet-wired and align the `principal` description with the resolver (#9807)
+
+The object header described a live routing control that does not exist: "where a
+producer emits with `audience: 'subscribers'` … the resolver expands the topic's
+subscriptions into recipients". Nothing implements that. `AudienceSpec`
+(`messaging-service.ts`) has no `'subscribers'` member, `EmitInput.audience` is
+required, and `RecipientResolver` has no branch that reads
+`sys_notification_subscription` — the literal `'subscribers'` occurs exactly once
+in the repo, in that sentence. Every delivery today comes from the explicit
+`audience` a producer passes to `emit()`, so the Setup "Notification
+Subscriptions" grid is admin-authored data, not a live routing control. The
+header now says so, per the maintainer ruling on #9807 (annotate now; the
+ADR-0030 Layer-3 expansion stays future work, deferred on measured zero pull).
+
+The `principal` field description shipped a four-form list (`'role:x'` |
+`'team:x'` | `'user:id'` | bare user id) narrower than what
+`RecipientResolver.resolveOne()` accepts for the same string shape; it now also
+names `'owner_of:object:id'` and the email form (matched against `sys_user`).
+This is a user-visible string: it ships into `dist/` and into the generated `en`
+translation bundle as the field's help text in the Setup grid.

--- a/packages/services/service-messaging/src/objects/notification-subscription.object.ts
+++ b/packages/services/service-messaging/src/objects/notification-subscription.object.ts
@@ -6,11 +6,18 @@ import { ObjectSchema, Field } from '@objectstack/spec/data';
  * `sys_notification_subscription` — who is subscribed to a topic (ADR-0030
  * Layer 3).
  *
- * Declares standing interest in a `topic` by a `principal` (`role:x`, `team:x`,
- * `user:id`, or a bare user id). Where a producer emits with `audience:
- * 'subscribers'` (or no explicit audience), the resolver expands the topic's
- * subscriptions into recipients — the opt-in counterpart to the explicit
- * audience most producers pass today.
+ * Declares standing interest in a `topic` by a `principal` (see that field for
+ * the accepted selector forms).
+ *
+ * ⚠️ [#9807] The subscription→recipient expansion is **NOT WIRED in this
+ * repo**: `AudienceSpec` (`messaging-service.ts`) has no `'subscribers'`
+ * member, `EmitInput.audience` is REQUIRED, and no `RecipientResolver` branch
+ * expands a topic's subscriptions — so nothing here reads these rows at
+ * runtime. Every delivery today comes from the explicit `audience` a producer
+ * passes to `emit()`, which makes the Setup "Notification Subscriptions" grid
+ * admin-authored data, NOT a live routing control. The ADR-0030 Layer-3
+ * expansion is future work, deferred on measured zero pull; ADR-0012/0030
+ * describe that target state, not today's behaviour.
  *
  * Distinct from `sys_notification_preference`: a subscription says "include me
  * for this topic"; a preference says "but mute it on this channel".
@@ -45,7 +52,13 @@ export const NotificationSubscription = ObjectSchema.create({
             label: 'Principal',
             required: true,
             searchable: true,
-            description: "Subscriber selector: 'role:x' | 'team:x' | 'user:id' | bare user id.",
+            // [#9807] Kept in step with what `RecipientResolver.resolveOne()` really
+            // accepts for a string spec, so this does not under-describe the day the
+            // expansion above is wired: an email-shaped value is matched against
+            // `sys_user` (kept verbatim when no user matches), and anything otherwise
+            // unrecognized falls through as a bare user id.
+            description:
+                "Subscriber selector: 'role:x' | 'team:x' | 'user:id' | 'owner_of:object:id' | an email | a bare user id.",
         }),
 
         enabled: Field.boolean({

--- a/packages/services/service-messaging/src/translations/en.objects.generated.ts
+++ b/packages/services/service-messaging/src/translations/en.objects.generated.ts
@@ -238,7 +238,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       principal: {
         label: "Principal",
-        help: "Subscriber selector: 'role:x' | 'team:x' | 'user:id' | bare user id."
+        help: "Subscriber selector: 'role:x' | 'team:x' | 'user:id' | 'owner_of:object:id' | an email | a bare user id."
       },
       enabled: {
         label: "Enabled",


### PR DESCRIPTION
Fixes #9807

Implements the maintainer ruling recorded in [comment 5339441800](https://github.com/objectstack-ai/objectstack/issues/9807#issuecomment-5339441800) — Option B, adopted verbatim. Option A (build the Layer-3 `'subscribers'` expansion) is **not** implemented here and nothing in this diff moves toward it.

## What changed

1. **Object header** — the sentence claiming that a producer emitting `audience: 'subscribers'` causes the resolver to expand a topic's subscriptions is replaced with a marker saying the expansion is **NOT WIRED in this repo**, naming the three facts a reader can re-derive it from, and stating that delivery today comes from the explicit `audience` passed to `emit()`. The genuinely-true content (what a subscription is; the contrast with `sys_notification_preference`) is kept.
2. **`principal` field description** — widened from four forms to the six `RecipientResolver.resolveOne()` really accepts for a string spec.
3. **`en` translation bundle** — regenerated (see *Declared surface widening* below).
4. **Changeset** — a real `patch`, not `skip-changeset` (see *Changeset decision*).

Plus a merge of today's `main` (see *CI investigation*). The three content commits are unchanged since first review.

## Premise re-verification (measured, not recalled)

- The aspirational sentence stood at `notification-subscription.object.ts:9-13`, wrapping across five lines.
- `git grep "'subscribers'" -- '*.ts'` → **exactly one** hit repo-wide, line 11 of that same header. Counter-checked against a term known present: `audience` hits 6 files in the package, so the search is live rather than silently matching nothing.
- `AudienceSpec` (`messaging-service.ts:50-52`) is `string | { ownerOf: { object, id } }` — no `'subscribers'` member; `EmitInput.audience` is required.
- `grep sys_notification_subscription` across the repo: outside `service-messaging/src` only ADR/design prose, a driver test, changelogs, `platform-object-names.ts`, and a comment in `object.zod.ts`. Inside the package: the declaration, its own tests, generated translations, and the Setup nav entry. **No runtime read.**

The `principal` forms were verified by reading `recipient-resolver.ts:129-146` directly rather than trusting the card: prefix branches `user:` / `role:` / `team:` / `owner_of:<object>:<id>`, then `looksLikeEmail()` → `resolveEmail()` (matched against `sys_user`, kept verbatim when no user matches), then bare user id as the fallback for anything unmatched.

## Confidence gap — what I measured and what I could not

- **`objectstack`** — zero runtime consumers (above).
- **`objectui`** — measured, **confirmed zero**. `git grep` for `sys_notification_subscription`, `notification_subscription`, `notificationSubscription`, `notification-subscription` all return nothing. Counter-checked live: `sys_inbox_message` returns 20+ files including the real inbox path, and reading `useHomeInbox.ts`, `sharedUserFeeds.ts` and `InboxPopover.tsx` shows the inbox UI reads exactly `sys_inbox_message`, `sys_notification_receipt` and `sys_activity`. So the inbox renders the *materialized delivery*, never subscription rows.
- **`cloud`** — ⚠️ **NOT measured; not in this session's repo scope.** I make no claim about it either way.

**Declared narrowing:** the wording is deliberately scoped — "NOT WIRED **in this repo**", "nothing **here** reads these rows at runtime" — so it stays true even if `cloud` turns out to read them.

## Declared surface widening — ONE file beyond the dispatched surface

The dispatched surface was `notification-subscription.object.ts` alone. `packages/services/service-messaging/src/translations/en.objects.generated.ts` was added because `check:i18n` **failed** on the annotation commit:

```
  services/service-messaging     DRIFTED (1)
  • services/service-messaging: 1 bundle(s) drifted from the schema
```

The `en` bundle is a copy of the source, rewritten on every run (#8543); the field description reaches it as the `principal.help` leaf. The file is **generator output** — `node scripts/check-i18n-bundles.mjs --write`, one line changed, no hand edits — same gate family, so it adds no verification surface.

**The patch round added no second widening.** The `Test Core` investigation below produced no code change: no test was edited, skipped, quarantined or loosened, and the only new commit is the merge of `main`.

## Changeset decision — on evidence

Not a pure comment diff, so `skip-changeset` would be wrong. Measured after building the package:

- `grep -rl "owner_of:object:id" packages/services/service-messaging/dist/` → `dist/index.js`, `dist/index.cjs` (+ both `.map`s). The description is a **runtime string in the shipped artifact**.
- It also ships as the field's help text via the `en` translation bundle, i.e. what an admin reads in the Setup "Notification Subscriptions" grid.

So: a real `patch` changeset for `@objectstack/service-messaging`.

## CI investigation — the red `Test Core (2/3)` on `980dec44e`

That shard reported `Failed: @objectstack/example-showcase#test`. Investigated as ours. **It did not reproduce, and no defect attributable to this diff was found.**

**CI captured no assertion to act on.** I pulled the complete failing job log (5083 lines) and searched it: `example-showcase` appears exactly twice, both in the error summary. No `Test Files` line, no `Tests` line, no `FAIL`, no `AssertionError`, and none of the showcase's test names appear anywhere. The task that failed produced **zero output**, while other packages on the same shard streamed theirs into the same log. `turbo.json` sets no output suppression on `test`.

**The guard that was supposed to disambiguate could not.** `ci.yml` states that a red suite plus a green completeness check means real test failures; the run printed `check-test-completeness: OK (11 package(s), 3617 test(s) declared and all 3617 accounted for)`. But `check-test-completeness.mjs` regexes summary lines *present in the log*, so a package that printed nothing contributes no row and is invisible to it. Its green never covered the showcase.

**What I measured instead:**

| measurement | result |
|:--|:--|
| showcase suite at the failing head `980dec44e`, dependency closure built | `Test Files 21 passed (21)` / `Tests 337 passed (337)` |
| showcase suite at that tree merged with today's `main` | `Test Files 21 passed (21)` / `Tests 337 passed (337)` |
| does any showcase test read messaging metadata? | no — the strings this PR moves appear nowhere in `examples/app-showcase` |
| is the showcase in this PR's affected set? | yes — it depends directly on `@objectstack/service-messaging`; reproduced `turbo ls --affected` + `partition-test-shards.mjs` locally |
| CI at the merged head `a0954815f` | **all three `Test Core` shards green, aggregate `Test Core` green** |

⚠️ One thing that would otherwise mislead re-review: once the merge base advanced, the showcase moved from shard 2/3 to **shard 3/3** (shard 2 now carries `service-messaging`). A green shard 2 alone would prove nothing about it; shard 3 is the one that carries it, and it is green.

⚠️ My own first local run reproduced a *false* red of the same shape — every failure was `Cannot find package '@objectstack/spec/data'`-class, i.e. an unbuilt dependency closure in a freshly recreated worktree, not an assertion. Recorded because it reads exactly like "this change broke imports". All numbers above are from runs with the closure built.

The underlying event was neither reproduced nor explained, and I did not manufacture a fix for it. The diagnostic hole it exposed is filed as **#10032**.

## Verification — re-run at the merge head `a0954815f`

Gate union re-derived with `node scripts/pm/dispatch-gates.mjs` (no path arguments) against the new merge base `899052acc` — still the same 3 paths and the same gate set.

| gate | verdict line |
|:--|:--|
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new.` · `baseline key set verified against 899052a: no files added.` ← **re-quoted: the ratchet baseline moved with the merge base** |
| `check:i18n` | `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned; …` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; …` |
| `check:changeset-gate-self-tests` | all three self-tests `✓` |
| `check:objectui-changeset` | `✓ objectui-range --self-test: all checks passed` |
| `check-adr-0087-registration.mjs` | `✓ … this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).` |
| `check-changeset-no-major.mjs` | `✓ This diff introduces no 'major' bump.` |
| `check-empty-changeset.mjs` | `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check-affected-docs.mjs` | `✓ affected-docs self-test: 262 cases pass.` (exit 0) |

**Tests / typecheck at the merge head** — `pnpm --filter @objectstack/service-messaging test` → `Test Files 22 passed (22)` / `Tests 242 passed (242)`; `typecheck` → exit 0 with `tsc --noEmit` echoed. Counts unchanged from `main` (measured both sides in the same worktree at first review: base also 22/242).

**Ablation: NOT APPLICABLE.** Nothing executable changed — a header comment, one description string, one generated bundle leaf, one changeset. There is no guard to remove and no behaviour to mutate, so an ablation here would be fabricated rather than informative.

All heavy commands ran through `scripts/pm/os-verify-lock.sh`.

## Out-of-scope findings filed

- **#10026** — a source label/description edit leaves the *translated* locale bundles stale, and neither `check:i18n` nor `check:i18n-coverage` can see it. Measured on this diff.
- **#10032** — a failing `turbo run test` task can land in `Test Core` with zero captured output, and the completeness guard's green does not cover a package that printed nothing. Filed out of this patch round.

## Not addressed here

`#9807` covers only the annotation. The Layer-3 expansion itself remains unbuilt and unclaimed — see the report's `open_questions` for the two judgement calls I did not want to make silently.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
