### PR TITLE
fix(plugin-auth): seed managed-extension-fields' source scan from `__dirname`, retiring the package's only TS1470 (TEST_DEBT 110 -> 109)

### DIFF
--- a/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
+++ b/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
@@ -100,8 +100,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, resolve } from 'node:path';
 import { getAuthTables } from 'better-auth/db';
 import { jwt } from 'better-auth/plugins';
 import { admin } from 'better-auth/plugins/admin';
@@ -278,7 +277,36 @@ const COVERED_OBJECTS: readonly string[] = [
   'sys_device_code',
 ];
 
-const HERE = dirname(fileURLToPath(import.meta.url));
+/**
+ * Seeded from `__dirname`, not from `dirname(fileURLToPath(import.meta.url))`,
+ * and both halves of that choice are load-bearing — the same pair
+ * `platform-objects/src/managed-api-method-affordance-sweep.test.ts` states for
+ * the sibling repo-wide walk:
+ *
+ *  - `import.meta` is a TS1470 here. This package is CJS-typed (no
+ *    `"type": "module"`, it publishes `dist/index.js` as CommonJS), so under
+ *    `module: NodeNext` the meta-property is an error however well it runs
+ *    under vitest — and this package's test layer IS in front of tsc, through
+ *    the `@objectstack/plugin-auth` TEST_DEBT entry
+ *    in `check-type-check-coverage.mjs` under `scripts/`, a ledger that may
+ *    only shrink.
+ *    `__dirname` type-checks under the package's own config and is defined at
+ *    runtime by vitest's transform (verified, not assumed).
+ *  - `check:cross-package-test-inputs` recognises exactly two seeds —
+ *    `dirname(fileURLToPath(import.meta.url))` and `__dirname` — when it
+ *    detects statically that a test escapes its package. This file's walk of
+ *    `PACKAGES_DIR` below is the ONLY escaping read the gate can see in
+ *    plugin-auth, so it is what holds the package's declared radius
+ *    (`packages/**\/*.object.ts`) and the matching `turbo.json` inputs.
+ *    Deriving the root any other way — the `findUp` walk from `process.cwd()`
+ *    that `rate-limit-storage-isolation.test.ts` and
+ *    `member-role-canonical.test.ts` use — makes this radius INVISIBLE to that
+ *    gate, which then reports the declaration as stale and asks for its
+ *    removal. Losing it would put this sweep back in #7802's blind spot:
+ *    turbo would replay a cached green for a diff that changed another
+ *    package's object file. Measured both ways.
+ */
+const HERE = __dirname;
 /** …/packages/plugins/plugin-auth/src → repo root */
 const REPO_ROOT = resolve(HERE, '../../../..');
 const PACKAGES_DIR = join(REPO_ROOT, 'packages');

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -729,18 +729,32 @@ const TEST_DEBT = {
       + '(#5278 option A).',
   },
   '@objectstack/plugin-auth': {
-    errors: 110,
-    note: 'TS2493 x42 (tuple index out of range), TS18048 x24, TS2740 x19, TS2322 x11, TS2532 x9, '
-      + 'TS2339 x8, TS2741 x8. Lowered 131 -> 111 at b16dcb45 (#7888); the intermediate 108 in this PR\'s '
-      + 'first commit was measured at b5e09b21 and was already stale when the merge queue built it -- the '
-      + 'package took +3 inside the hour, which is the same "a ledger number is a number about a moment" '
-      + 'race that kicked #5278 three times, and 111 is the merge-queue run\'s own re-measure on the ref '
-      + 'this PR actually lands on. Composition below predates both and is NOT re-tallied at 111. '
-      + 'Measured 124 -> 129 (5ab08428, composition unchanged in shape) -> 131 (e8db1a230). Half of the '
-      + 'latest +2 is a TS2554 in src/last-admin-guard.test.ts, a file added by #5941 / PR #5993 '
-      + '(the break-glass delete guard); the other 1 landed in a file that already existed and is not '
-      + 'attributed further. 64 of the 131 sit in src/auth-manager.test.ts, 22 in '
-      + 'src/admin-import-users.test.ts and 18 in src/admin-user-endpoints.test.ts.',
+    errors: 109,
+    note: 'RE-TALLIED from tsc at the 109 below (measured on this branch over base e717ba111), so the '
+      + 'composition, the per-file split and the total are one measurement rather than a rescale: '
+      + 'TS2493 x42 (tuple index out of range), TS18048 x24, TS2322 x11, TS2532 x9, TS2339 x8, '
+      + 'TS2345 x5, TS2554 x3, TS2741 x3, TS7006 x2, TS2769 x1, TS6133 x1. 44 of the 109 sit in '
+      + 'src/auth-manager.test.ts, 22 in src/admin-import-users.test.ts, 18 in '
+      + 'src/admin-user-endpoints.test.ts and 12 in src/auth-plugin.test.ts. What this replaces is '
+      + 'worth one sentence, because it is the #7038 shape and not an arithmetic slip: the old tally '
+      + 'was taken at 131, said so, and named TS2740 x19 and TS2741 x8 -- TS2740 has since gone to '
+      + 'zero outright and TS2741 stands at 3, so no rescale of it could have been right. '
+      + 'History, still true: measured 124 -> 129 (5ab08428, composition unchanged in shape) -> 131 '
+      + '(e8db1a230). Lowered 131 -> 111 at b16dcb45 (#7888); the intermediate 108 in that PR\'s first '
+      + 'commit was measured at b5e09b21 and was already stale when the merge queue built it -- the '
+      + 'package took +3 inside the hour, the same "a ledger number is a number about a moment" race '
+      + 'that kicked #5278 three times, so 111 was the merge-queue run\'s own re-measure on the ref '
+      + 'that PR actually landed on. Of the +2 that had made 131, half is a TS2554 in '
+      + 'src/last-admin-guard.test.ts, a file added by #5941 / PR #5993 (the break-glass delete '
+      + 'guard); the other 1 landed in a file that already existed and is not attributed further. '
+      + 'Then 111 -> 110 in PR #10013 -- the number moved and this note did not, which is how a '
+      + 'composition written at 131 was still sitting over an entry reading 110. '
+      + '110 -> 109 here (#9694): src/managed-extension-fields.test.ts held the package\'s only '
+      + 'TS1470 -- an `import.meta.url` seed in a package that is CJS-typed and therefore forbids '
+      + 'the meta-property under module: NodeNext -- and now seeds from `__dirname`, which '
+      + 'type-checks here AND is one of the two seeds check:cross-package-test-inputs recognises, so '
+      + 'that file\'s repo-wide *.object.ts walk stays visible to the gate holding plugin-auth\'s '
+      + 'declared input radius. It contributes nothing to this pile any more.',
   },
   '@objectstack/mcp': {
     errors: 53,


### PR DESCRIPTION
Fixes #9694

`packages/plugins/plugin-auth/src/managed-extension-fields.test.ts` seeded its
repo-wide `*.object.ts` scan from `dirname(fileURLToPath(import.meta.url))`.
plugin-auth is CJS-typed (no `"type": "module"`; it publishes `dist/index.js` as
CommonJS), so under `module: NodeNext` that line is a TS1470 — the package's only
one, frozen in a shrink-only `TEST_DEBT` ledger entry.

All numbers below were measured on this branch; none were copied from the card.

## The seed: `__dirname`, not the card's `findUp` idiom — and why

The card and its triage both prescribe the package's `findUp` idiom
(`member-role-canonical.test.ts:65-80`). **That would have broken
`check:cross-package-test-inputs`, and this PR does not do it.** The evidence,
measured rather than argued:

`check:cross-package-test-inputs` finds escaping tests by scanning source text,
and recognises exactly two directory seeds: `dirname(fileURLToPath(import.meta.url))`
and `__dirname`. A `findUp` walk from `process.cwd()` is not one of them, so a
file seeded that way has no statically-visible radius at all. Enumerated on the
base ref, **`managed-extension-fields.test.ts` is the ONLY test in plugin-auth
the gate can see escaping** — it alone holds the package's declared radius
(`packages/**` object files + `packages/core/src/security/**`) and the matching
`turbo.json#test` inputs.

Counterfactual, run with the card's prescribed `findUp` idiom in place:

```
FAIL: cross-package test inputs are not declared consistently.

  - @objectstack/plugin-auth declares a cross-package input radius, but no test in it reads outside
    the package any more. Delete the entry (and its turbo.json inputs) — a stale
    declaration invalidates that package's test cache for nothing.
```

Deleting that entry is exactly the wrong repair: the file really does walk every
`*.object.ts` in the monorepo, so dropping the turbo inputs would put the sweep
back in #7802's blind spot — turbo replaying a cached green for a diff that
changed another package's object file.

`__dirname` satisfies both constraints at once: it is TS1470-free under this
package's own CJS config, it is defined at runtime by vitest's transform, and it
is one of the two seeds the gate recognises. This is not a new invention — it is
the choice `packages/platform-objects/src/managed-api-method-affordance-sweep.test.ts:95-113`
already made for the sibling repo-wide object walk, for these same two reasons,
written out there in full. The comment added here points at it.

After the change the gate still sees the file, and stays green:

```
OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.
```

with `findEscapingPackages()` still reporting
`packages/plugins/plugin-auth/src/managed-extension-fields.test.ts` for
`@objectstack/plugin-auth` — the same single entry as before the change.

The now-unused `fileURLToPath` and `dirname` imports are removed (`noUnusedLocals`
is on, so leaving them would have traded one error for another).

## The ledger: 110 → 109, measured twice on this branch

The card prescribes `111 → 110`. **That was already stale**: PR #10013 lowered
this entry to 110 before this branch was cut. The recorded value at base
`e717ba111` reads `errors: 110`, and the pre-fix measurement on this branch
returns exactly 110 — so the recorded number was correct, and the card's target
was the number that had already been consumed.

The measurement reproduces `check-type-check-coverage.mjs`'s own
`measureTestDebt()`: the same generated project (the package's `tsconfig.json`
with the `**/*.test.ts` exclusion lifted, paths absolutised, `typeRoots`
reconstructed), the same `tsc --noEmit --pretty false`, the same
`TSC_ERROR_LINE` counter, against a built dependency closure.

| | measured | TS1470 |
|---|---|---|
| before (base `e717ba111`, recorded 110) | **110** | 1 — `managed-extension-fields.test.ts(281,36)` |
| after | **109** | none |

The delta is exactly the one error, and no other diagnostic moved: every other
code and per-file count is identical across the two runs.

The adjudicating gate agrees, at `1252262be`:

```
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 354.3s, 1924 raw tsc error(s) total, none above its recorded number.
  surplus: none — every entry sits exactly at its measurement, so any new error is red.
```

`surplus: none` is the load-bearing half: had 110 been left in place, the entry
would have printed its own `can be lowered` line instead.

## The note: re-tallied, not rescaled

The entry's composition note was written at 131, said so openly, and had since
survived two number changes (131 → 111 → 110) without being touched — the #7038
shape. It is re-tallied from the same run that produced 109:

- old, at 131: `TS2493 x42, TS18048 x24, TS2740 x19, TS2322 x11, TS2532 x9, TS2339 x8, TS2741 x8`
- new, at 109: `TS2493 x42, TS18048 x24, TS2322 x11, TS2532 x9, TS2339 x8, TS2345 x5, TS2554 x3, TS2741 x3, TS7006 x2, TS2769 x1, TS6133 x1`

A rescale could not have produced this: **TS2740 has gone to zero outright** and
TS2741 is 3, not 8. The per-file split is re-measured too (44/22/18/12, was
64/22/18). The historical provenance sentences that are still true are kept, and
the 111 → 110 move that this note had missed is now recorded in it.

`check-type-check-coverage.mjs:2766` — `{ ledger: 'TEST_DEBT', name: 'plugin-auth',
recorded: 111, actual: 112 }` — is the #8435 ratchet-offer detector's self-test
fixture, not the ledger, and is deliberately untouched.

## Ablations

Both predicted first, then run, then restored byte-identically
(`git hash-object` = `9c57a17d7b005fbb4536ccf30bc8fb9038db96ae` before and after
each). Neither ablation resolves through a dependency's `dist/`: one is a pure
source scan of the repo, the other mutates the test file vitest loads from
source, so no rebuild is interposed in either leg.

1. **`findUp` counterfactual** — predicted: the cross-package gate reports the
   declaration stale. Observed: exactly that, quoted above.
2. **Vacuous-seed guard** — predicted: a seed pointing at a wrong directory makes
   the scan find nothing and the file goes red. Observed, with
   `const HERE = join(__dirname, 'no-such-dir')`:

   ```
   AssertionError: expected 0 to be greater than 15
   Error: ENOENT: no such file or directory, open '…/plugin-auth/src/no-such-dir/auth-manager.ts'
    Test Files  1 failed (1)
         Tests  3 failed | 22 passed (25)
   ```

   So `HERE` is load-bearing in both of its uses, and the seed cannot silently
   resolve elsewhere: the file's own `guards a silently empty sweep` floor
   (`> 15`, and `sys_api_key` present) refuses a vacuous scan.

## Gates run locally, at `1252262be`

Families re-derived from the real diff with `node scripts/pm/dispatch-gates.mjs`
(no path list passed), then run to completion. Verdict lines as each gate printed
them:

- `check:type-check-debt` — `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 354.3s, 1924 raw tsc error(s) total, none above its recorded number.` / `surplus: none — every entry sits exactly at its measurement, so any new error is red.`
- `check:type-check-coverage` — `check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger (436 frozen raw errors, …), 1 exempt.`
- `check:cross-package-test-inputs` — `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` (+ `All 52 self-test cases passed.`)
- `check:nul-bytes` — `check-nul-bytes: OK (scanned 6349 text file(s) …; no raw ASCII control bytes).`
- `check:slot-lookup` — `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new.`
- `check:test-source-alias` — `check-test-source-alias OK — 72 packages with tests scanned; …`
- `check:type-source-resolution` — `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; …`
- `check:query-options-erasure` — `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new.`
- `check:engine-double-contract` — `check-engine-double-contract: OK — 321 pinned, 133 in the DEBT ledger, 2 exempt.`
- `check:where-matcher` — `✓ where-matcher conformance holds: 260 matcher(s) discovered, 260 answer the combinator battery correctly or refuse it loudly (155 refuse).`
- `scripts/docs-audit/check-affected-docs.mjs` — exit 0.
- `pnpm --filter @objectstack/plugin-auth typecheck` — `tsc --noEmit`, exit 0.
- `pnpm --filter @objectstack/plugin-auth test` — `Test Files 57 passed (57) · Tests 1301 passed (1301)`.

## Changeset

`skip-changeset`. The diff is one test file and one CI-internal gate script; the
package's published artifact is unchanged (`tsconfig.json` and the build both
exclude `*.test.ts`), so this PR releases nothing — the case lint.yml names in
its own words as "the textbook `skip-changeset` case".


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_