### PR TITLE
docs(gate): rest check-role-word's comment figures on invariants, not on the ledger's current size

### DIFF
--- a/scripts/check-role-word.mjs
+++ b/scripts/check-role-word.mjs
@@ -9,9 +9,14 @@
 // P1 rename wave (#2697 was identifier-driven).
 //
 // This is a RATCHET, not a ban-with-exceptions: existing occurrences are
-// frozen in scripts/role-word-baseline.json (many are legitimate — the
-// better-auth boundary, ARIA `role=` in samples, educational "formerly
-// roles" mentions — and untangling them file-by-file is incremental work).
+// frozen in scripts/role-word-baseline.json, and not all of them are bugs.
+// The legitimate KINDS — vocabulary owned upstream (better-auth's
+// `sys_member.role`), ARIA's `role=` attribute, quoted pre-rename history —
+// are named as KINDS and not as an inventory of the ledger: which of them it
+// actually holds changes with every `--update`, so the same list read as a
+// census goes wrong silently. Untangling the rest file-by-file is
+// incremental work.
+//
 // The check fails when:
 //   • a file NOT in the baseline contains the word, or
 //   • a baselined file's count INCREASES, or
@@ -130,7 +135,12 @@ function newUseMessage(file, count) {
 //
 // The green line used to be, in full:
 //
-//   check-role-word: OK (43 baselined file(s), no new occurrences).
+//   check-role-word: OK (N baselined file(s), no new occurrences).
+//
+// N is written generically because this line no longer exists in the program.
+// It can never print again, at any size, so no literal here would be checkable
+// against anything the gate does — and the next `--update` could only make one
+// wrong, never right again. The quote is carried for its SHAPE.
 //
 // Every number in it came from the LEDGER. `current` holds only the files that
 // still carry the word, and a green run is precisely the run where its key set
@@ -141,11 +151,21 @@ function newUseMessage(file, count) {
 // scan that reads nothing drops every baselined file out of `current`, and the
 // ratchet-DOWN branch below then reports one "clean/gone" problem per baselined
 // file. Measured on this tree — ROOTS pointed at two non-existent directories,
-// ledger untouched — `43 problem(s)`, exit 1. That protection is a side effect
-// of still owing debt, and it evaporates at the exact moment this ratchet
-// succeeds at its purpose: with the ledger empty, `current = {}` and
-// `baseline = {}` raise nothing in either direction, and the same ablation
-// printed
+// ledger untouched — exit 1, raising exactly one problem per baselined file.
+// The magnitude is deliberately not written down, and no bound stands in its
+// place: the ratchet-DOWN loop below walks `Object.entries(baseline)` and
+// raises one error for every entry missing from `current`, so a dead scan
+// raises as many problems as the ledger holds — an identity that survives
+// every `--update`, at any ledger size, including the empty one. A SHRINK-only
+// ledger admits no durable bound to state instead: a floor rots on the first
+// sanctioned ratchet-down (the very remedy this gate tells authors to run),
+// and a ceiling rots too, because the same `--update` is also the
+// baseline-EXPANDING path the #8435 marker above gates.
+//
+// That protection is a side effect of still owing debt, and it evaporates at
+// the exact moment this ratchet succeeds at its purpose: with the ledger
+// empty, `current = {}` and `baseline = {}` raise nothing in either direction,
+// and the same ablation printed
 //
 //   check-role-word: OK (0 baselined file(s), no new occurrences).   EXIT=0
 //
@@ -269,6 +289,12 @@ function selfTest() {
   //
   // Interpolated counts again, so the source proves nothing about the rendered
   // sentence — driven here instead, in the states that used to be identical.
+  //
+  // These counts are SYNTHETIC fixtures, not a reading of the tree: every
+  // assertion below closes over them, so they stay correct however the real
+  // corpus moves. ⛔ Do not "refresh" them to match a live scan — that would
+  // turn a closed fixture into a figure the tree can falsify, which is the
+  // very defect the comment sites above were cleaned of.
   const SCANNED = [{ root: 'content/docs', files: 179 }, { root: 'skills', files: 36 }];
   const DEAD_SCAN = [{ root: 'content/docs', files: 0 }, { root: 'skills', files: 0 }];
   const PAID_OFF = {};


### PR DESCRIPTION
Fixes #9947

Comment prose only. Gates verified on `163d8292d7` (the final commit).

## H1 — is 43 still 43?

**Yes.** `scripts/role-word-baseline.json` holds **43** entries (129 occurrences) on current `main`. The card's "accurate today" still stands, so this is **latent, not live** — severity unchanged.

## Is the sample output stale too? (the card's second axis) — **no, falsified**

The card warned that #9931 landed in this file the same morning and may have left the sample output stale in a second way. Measured, and it did not — for a reason visible only from #9931's diff: **both named sites were authored BY #9931**, as a deliberate before/after narrative.

- The two old-format quotes (`OK (N baselined file(s), …)` and the `EXIT=0` ablation line) are past-tense **by construction** — the block introduces the first with *"The green line used to be, in full"*. Verified the old line is genuinely gone from the program: the live gate prints no `OK (` at all.
- The one fragment quoting the **new** format is exact. Live output today:

```
check-role-word: OK, no new occurrences of the reserved word.
  Scanned: 216 .md/.mdx file(s) read across 2 root(s) — content/docs 180, skills 36.
  Ledger: 43 baselined file(s) still carrying it (129 occurrence(s)) in scripts/role-word-baseline.json.
```

Both quoted fragments — ``0 .md/.mdx file(s) read`` and ``0 baselined file(s)`` — are exact substrings of that format.

## Per-site verdict: what these two things ARE

They are **different kinds of thing**, and they get different fixes.

### Site 1 (was L133) — a FORMAT example

The quote exists to support the sentence that follows it: *"Every number in it came from the LEDGER."* That argument rests on the line's **shape** (`N baselined file(s)`), never on N's value.

Decisive: **this figure is unrefreshable.** #9931 deleted that line from the program, so it can never print again at any size — after the next `--update` there is no correct value, because a "corrected" number would be as fictional as the stale one. The number goes generic (`N`), with a note recording why a literal must not come back.

### Site 2 (was L144) — a MEASUREMENT

``43 problem(s)``, from a real ablation (ROOTS pointed at non-existent directories, ledger untouched), offered as evidence that a dead scan fails loudly rather than passing green. Load-bearing, and self-invalidated by `--update`. So it gets the #9944 treatment — not a refresh.

## H2 — the invariant, and the shrink-only polarity

#9944 rested on a **floor** over a grow-only ledger (*"already outnumbers them and can only outnumber them further"*). The naive mirror image here is a **ceiling**. **I am not using one, and the reason is the point of this card:**

**`check-role-word`'s "shrink-only" is a governance rule, not a mechanical monotone.** The very same `--update` flag is *also* the baseline-EXPANDING path — that is exactly what the #8435 `⛔ MAINTAINER-ONLY` marker in `newUseMessage()` gates. So the ledger *can* rise; it merely may not rise without a maintainer.

Therefore **no bound is durable in either direction**:

- a **floor** rots on the first sanctioned ratchet-down — the remedy this gate literally tells authors to run;
- a **ceiling** rots on the maintainer-approved expansion the gate explicitly provides for. A ceiling would be resting on a *policy*, which is the one thing a comment cannot verify.

So the sentence stops making a magnitude claim and rests on an **identity** the code enforces 220 lines below:

> the ratchet-DOWN loop walks `Object.entries(baseline)` and raises one error for every entry missing from `current`, so a dead scan raises as many problems as the ledger holds

That is stronger than a bound: true at 43, true at 1, true at 0 — and its value at zero is *precisely* the failure the next paragraph goes on to describe. The shrink-only direction stops being a threat to the sentence and becomes its subject.

## H4 census — one more self-invalidated claim, fixed

Total figures/claims audited in the file: **14**. Self-invalidated by `--update`: **3**. Changed: **3** (plus one preventive pin, below).

The third is the header, which listed the ledger's legitimate contents as an **inventory**:

> *(many are legitimate — the better-auth boundary, ARIA `role=` in samples, educational "formerly roles" mentions …)*

Measured against the live baseline:

| named example | live baselined files |
|---|---|
| better-auth boundary | 14 |
| **ARIA `role=` in samples** | **0** |
| "formerly roles" mentions | 3 |

**Already stale.** The only two `role=` hits in baselined files are ``sys_member.role = …`` — better-auth org-plugin vocabulary, not ARIA. Per the card's H4 (*"an example entry … belongs in this card's population"*), it is fixed here, and fixed the ruling-2 way: it now names the legitimate **KINDS** (a rule about what may be baselined, which `--update` cannot falsify) rather than taking a census.

## H3 — already-stale check, the sibling method's blind spot

The sweep could only find figures still **equal** to the live size. Checked this file by hand for the other kind, and there is a hit — but it is **not a defect**:

The self-test fixtures read `content/docs 179, skills 36` (⇒ 215); the live tree is `180 / 36` (⇒ **216**). These are **synthetic fixtures** — every assertion closes over them, so they stay correct however the corpus moves, and the `215` regex can never fail for a tree-related reason.

**Deliberately not "corrected."** Refreshing them would convert a closed fixture into a figure the tree *can* falsify — manufacturing the exact defect this card removes. Instead they are **pinned as synthetic**, with a ⛔ note against future refreshing. That is the only preventive change here.

## Scope declaration

The claim declared the file surface as *"the two prose sites."* This PR touches **four** sites in that same file — the two named, plus the H4 header inventory (which the card's H4 pre-authorised into the population) and the H3 fixture pin. Same file, same defect class, same gate family, no new verification surface. Flagging it explicitly rather than letting it pass as silent widening.

## Ruling 4 — no behaviour change, proven mechanically

- **Every changed line is a comment.** `git diff -U0 | grep -v '^[+-]\s*//'` over the added/removed lines returns **nothing**.
- **Gate output byte-identical** before and after (`diff` of the two captured runs: no output, exit 0).
- Baseline JSON untouched — `git status` lists only `scripts/check-role-word.mjs`.

No verdict, exit code, population or threshold moves. `Clause-②` stays **no**.

## Gates (all on `163d8292d7`, quoting each gate's own verdict line)

Derived with `node scripts/pm/dispatch-gates.mjs` (no paths — it takes the changeset from the merge base itself), which named 3 families for `scripts/**`; `check:nul-bytes` added as always-owed.

| gate | verdict line |
|---|---|
| `pnpm check:role-word` | `check-role-word: OK, no new occurrences of the reserved word.` + `OK  self-test: …` |
| `pnpm check:nul-bytes` | `check-nul-bytes: OK (scanned 6358 text file(s) … no raw ASCII control bytes).` |
| `node scripts/check-cross-package-test-inputs.mjs` | `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |

No changeset: a `scripts/` gate publishes nothing, and `.changeset/**` sits inside the #9465 epic fence.

## Out of scope

Filed #10042 — the header's *"`--update` expands the baseline, which is the shrink-only direction of this ratchet"* is backwards on either reading of the relative clause. Different defect class (garbled prose, not a self-invalidated figure), so it is not touched here and #10042 remains open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_