### PR TITLE
docs(scripts): record that GAP 1's scheduling half closed, and that its coverage half closed with it

### DIFF
--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -380,25 +380,57 @@ function main() {
 // identical (empty) results. #9648 answered half of that by adding
 // `packages/create-objectstack/src/template-version-stamps.test.ts`, which runs
 // this CLI over a STALE two-template fixture and asserts the rewrites. Two
-// measured gaps survive it, and this flag is scoped to exactly those two —
+// measured gaps motivated this flag. GAP 1 — SCHEDULING — has since been
+// CLOSED in ci.yml; it is recorded below rather than deleted, so the next
+// reader does not re-derive a conclusion the workflow no longer supports.
+// GAP 2 is what the flag asserts, and it is scoped to exactly that —
 // re-asserting what that vitest file already owns would be worse than one
 // harness, not better.
 //
-// GAP 1 — SCHEDULING. `create-objectstack#test` is reached only from ci.yml's
-// `test` job, and that job is `if: ... needs.filter.outputs.core != 'false'`.
-// The `core` paths-filter is `packages/**`, `examples/**`, `apps/!(docs)/**`,
-// `package.json`, `pnpm-lock.yaml`, `tsconfig.json`, `.github/workflows/ci.yml`
-// — `scripts/**` matches NONE of them. Measured on this tree (picomatch 4.0.5,
-// the matcher dorny/paths-filter uses): a diff confined to this file yields
-// `core=false`, so Test Core is skipped in full and the vitest never runs, on
-// precisely the PR that changes the rewriter. Two further layers were measured
-// and neither rescues it: `turbo ls --affected` returns ZERO packages for that
-// diff (a package-local edit returns 1, so the probe is live) — the
-// `$TURBO_ROOT$` entry in `turbo.json` moves the task HASH, which is a
-// different thing — and the `--union-into` step that does pull
-// `create-objectstack` back in lives INSIDE the skipped job. lint.yml carries
-// no paths filter and no filter job, so a step there runs on every pull
-// request, push and merge-queue build. That is the whole of this flag's job.
+// GAP 1 — SCHEDULING, NOW CLOSED. The original argument: `create-objectstack#test`
+// is reached only from ci.yml's `test` job; that job was
+// `if: ... needs.filter.outputs.core != 'false'`; and the `core` paths-filter
+// (`packages/**`, `examples/**`, `apps/!(docs)/**`, `package.json`,
+// `pnpm-lock.yaml`, `tsconfig.json`, `.github/workflows/ci.yml`) matches NO path
+// under `scripts/` — so a diff confined to this file skipped Test Core in full,
+// and with it the vitest, on precisely the PR that changes the rewriter.
+//
+// `core` is still false for such a diff; `core` was never widened. What changed
+// is that the `test` job now ORs in a SECOND filter output — `scripts:` /
+// `'scripts/**'` — and skips only when BOTH say false (#9829).
+//
+// Re-measured against the merged workflow, with picomatch 2.3.1: that is the
+// version dorny/paths-filter@v4's own lockfile resolves and ncc-bundles, NOT the
+// 4.0.5 in this tree — the two agree on these globs, but the action is what
+// runs, so it is the one to quote. For a diff confined to this file:
+// `core=false`, `scripts=true`, so
+// `!cancelled() && (core != 'false' || scripts != 'false')` is TRUE. The job
+// runs.
+//
+// The job running is necessary, NOT sufficient — the shard tests a FILTERED
+// package set — so the rest of the chain was measured too, and the vitest does
+// now execute on such a diff. Each link, in order:
+//   - `turbo ls --affected` still returns ZERO packages for it (turbo 2.10.10),
+//     so the affected set alone would test nothing;
+//   - the `--union-into` step, which now runs because the job is no longer
+//     skipped, adds `@objectstack/spec` AND `create-objectstack` — both declare
+//     a glob matching this file in check-cross-package-test-inputs.mjs. On a
+//     push or merge-queue build the full package list is partitioned instead,
+//     which contains `create-objectstack` outright;
+//   - partition-test-shards.mjs places `create-objectstack` on a shard (2 of 3
+//     at this package set), so that shard's `turbo run test` names it;
+//   - `create-objectstack#test` declares
+//     `$TURBO_ROOT$/scripts/sync-template-versions.mjs` among its `inputs` in
+//     turbo.json, so editing this file MOVES the task hash — verified by
+//     comparing `turbo run test --filter=create-objectstack --dry=json` before
+//     and after a one-line edit — and turbo cannot replay a cached green;
+//   - `create-objectstack`'s `test` script is a bare `vitest run`, and its
+//     vitest config includes `src/**/*.test.ts`, which is that file.
+//
+// So GAP 1 no longer justifies this flag; GAP 2 carries it alone. What is
+// unchanged is WHERE the flag runs: lint.yml carries no paths filter and no
+// filter job, so a step there runs on every pull request, push and merge-queue
+// build whatever the diff touches, and GAP 2's cases need exactly that.
 //
 // GAP 2 — THE RED PATHS. Every failure contract this script's header argues for
 // is unexecuted. The vitest fixture is deliberately STALE and asserts the


### PR DESCRIPTION
Fixes #10016

`scripts/sync-template-versions.mjs`'s `--self-test` header argues the flag's existence from two measured gaps. GAP 1 claimed that a diff confined to this file yields `core=false`, so `Test Core` is skipped in full and `packages/create-objectstack/src/template-version-stamps.test.ts` never runs. The `test` job now ORs a second paths-filter output into its `if:`, so that half of the claim is stale.

Comment prose only: every changed line in the diff is a `//` comment, verified mechanically (`git diff -U0 | grep -vE '^[+-]// '` matches nothing). No behaviour change, no changeset — this is a `scripts/` comment.

## The gap had two halves and only one of them moved

The header's claim was compound: **(a) scheduling** — the job is skipped entirely — and **(b) coverage** — the vitest, and the `--union-into` step, sit inside that skipped job. Rewriting the header to say "this is covered now" on the strength of (a) alone would retire a real gap by assertion, so both halves were measured separately.

### (a) Scheduling — closed

Evaluated the merged `filter` job's globs against a changed-file set of exactly `scripts/sync-template-versions.mjs`, parsing the filter YAML out of `.github/workflows/ci.yml` rather than transcribing it, and matching the way `dorny/paths-filter@v4`'s `createRuleItem` does (`picomatch(pattern, {dot: true})`, SOME quantifier):

```
picomatch version used: 2.3.1
action: dorny/paths-filter@v4

filter core => false
   no      packages/**
   no      examples/**
   no      apps/!(docs)/**
   no      package.json
   no      pnpm-lock.yaml
   no      tsconfig.json
   no      .github/workflows/ci.yml

filter scripts => true
   MATCH   scripts/**
```

So `if: ${{ !cancelled() && (needs.filter.outputs.core != 'false' || needs.filter.outputs.scripts != 'false') }}` evaluates to `false || true` → **RUN**. `core` itself was never widened; it is still `false`.

**On the picomatch version:** the header said 4.0.5. `dorny/paths-filter@v4`'s own `package-lock.json` resolves `picomatch` — a runtime, non-`dev` dependency, ncc-bundled into `dist/index.js` — to **2.3.1**; 4.0.5 is what this repo has in its tree. I evaluated under both and got identical verdicts on these globs, so nothing downstream was wrong, but the header asserted the action's behaviour while quoting a version the action does not carry. Corrected in the same paragraph, with the distinction spelled out.

### (b) Coverage — also closed, and this is the part that had to be traced rather than assumed

The job running is necessary, not sufficient: `Test Core` tests a filtered package set. Each link, measured on this tree:

| link | measurement |
| --- | --- |
| `turbo ls --affected` | **0 packages** for this diff (turbo 2.10.10) — the affected set alone would still test nothing |
| `--union-into` | adds `@objectstack/spec` **and** `create-objectstack`, both from declared globs in `check-cross-package-test-inputs.mjs`. It runs now only because the job is no longer skipped |
| `partition-test-shards.mjs` | places `create-objectstack` on shard **2/3** (`shard 2/3: 1/2 packages, weight 7`) |
| turbo cache | `create-objectstack#test` declares `$TURBO_ROOT$/scripts/sync-template-versions.mjs` in `turbo.json`, so the hash moves on any edit to this file: `--dry=json` gave `fdb9dd70563b8fb5` at `HEAD` and `9fa6c426413e2f96` with a one-line edit |
| vitest | `create-objectstack`'s `test` script is a bare `vitest run`; its config includes `src/**/*.test.ts` |

End to end, running exactly what the shard runs, with this PR's diff in the tree:

```
$ pnpm turbo run test --filter=create-objectstack --concurrency=2
create-objectstack:test:  ✓ src/template-version-stamps.test.ts (8 tests) 338ms
create-objectstack:test:  Test Files  7 passed (7)
create-objectstack:test:       Tests  81 passed (81)
 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
```

`Cached: 0 cached` is the load-bearing line: the task really executed rather than replaying a cached green. So both halves are closed for this script, and the header now says so with the mechanism attached.

What that means for the flag: **GAP 1 no longer justifies it; GAP 2 (the red paths) carries it alone.** The header records GAP 1 rather than deleting it, so the next reader does not re-derive a conclusion the workflow no longer supports. Unchanged, and restated in place: lint.yml carries no paths filter and no filter job, which is still why the flag lives there.

## Sweep for other carriers of the same claim

Swept for the claim (not the filter) across the tree — `core=false`, `Test Core is skipped`/`skipped entirely`/`skipped in full`, `reached only from ci.yml`, `matches NONE`, `picomatch`, and every `Test Core` mention outside ci.yml's own job names. **Two carriers, both stale, one fixed here:**

- `scripts/sync-template-versions.mjs` GAP 1 — this PR.
- `.github/workflows/lint.yml` (~536-556), the comment above the `Template version-time rewriter self-test` step — a near-verbatim copy, carrying both the retired scheduling claim and the same wrong picomatch version. Filed as #10045 rather than edited: this card's declared file surface is `scripts/sync-template-versions.mjs`, and its ruling reserves the workflow/gate-wiring surface for the change that just landed there.

Checked and **not** stale: ci.yml's own `scripts:` filter comment (written by that change, and accurate); `check-cross-package-test-inputs.mjs`'s header (its scheduling note is about the spec/platform-objects case and is unaffected); `packages/spec/scripts/protocol-map.test.ts` (claims only that `packages/**` has no blind spot for spec changes — true).

Also filed as #10046, found while measuring the shard set: `--union-into` appends to `packages.items` but leaves `packages.count` stale, so the document it hands the partitioner contradicts itself. Inert today — `partition-test-shards.mjs` reads `items` and nothing anywhere reads `count`.

#10015 remains open and is a different question: it is about the *other* declared roots the filter still misses, not about this claim.

## Gates

Union re-derived from the real changeset at `bf46ce42` with `node scripts/pm/dispatch-gates.mjs` (no path arguments — the script takes the change set from the merge base itself), then each gate run at that same commit:

- `pnpm check:template-version-sync` → `✓ sync-template-versions --self-test: 40 assertions over temp fixtures, running the real CLI.`
- `pnpm check:cross-package-test-inputs` → `All 52 self-test cases passed.` / `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `node scripts/check-cross-package-test-inputs.mjs` (the bare form ci.yml spells) → `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `pnpm check:nul-bytes` → `check-nul-bytes: OK (scanned 6358 text file(s) -- 6358 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_