### PR TITLE
feat(spec): add Field.time builder to close the temporal-field authoring gap

### DIFF
--- a/.changeset/field-time-builder.md
+++ b/.changeset/field-time-builder.md
@@ -1,0 +1,18 @@
+---
+"@objectstack/spec": patch
+---
+
+feat(spec): add `Field.time` builder to close the temporal-field authoring gap (#8656)
+
+The `Field` convenience object exposed `Field.date` and `Field.datetime` but no
+`Field.time`, even though `'time'` is a fully declared `FieldType` and is live
+end-to-end (validated by `field-value.zod.ts` as `HH:mm[:ss]`, stored, and
+rendered by the inline grid's time control). The gap split the three temporal
+types two-and-one, forcing authors reaching for `time` to fall back to the
+literal `{ type: 'time', ... }` form — the shape `examples/app-showcase`'s
+`field-zoo.object.ts` already carried, flagged `// no Field.time`.
+
+`Field.time` mirrors the adjacent `Field.datetime` builder exactly and produces
+the identical literal shape an author could already write — `{ type: 'time',
+...config }` — so nothing about what `FieldSchema` accepts changes; this is
+sugar over an already-declared field type, not a schema change.

--- a/examples/app-showcase/src/data/objects/field-zoo.object.ts
+++ b/examples/app-showcase/src/data/objects/field-zoo.object.ts
@@ -54,7 +54,7 @@ export const FieldZoo = ObjectSchema.create({
     // ── Date & time ──────────────────────────────────────────────────────
     f_date: Field.date({ label: 'Date' }),
     f_datetime: Field.datetime({ label: 'Date / Time' }),
-    f_time: { type: 'time', label: 'Time' },
+    f_time: Field.time({ label: 'Time' }),
 
     // ── Logic ────────────────────────────────────────────────────────────
     f_boolean: Field.boolean({ label: 'Boolean' }),

--- a/packages/spec/src/data/field.test.ts
+++ b/packages/spec/src/data/field.test.ts
@@ -795,9 +795,20 @@ describe('Field Factory Helpers', () => {
 
     it('should create email field', () => {
       const emailField = Field.email({ label: 'Email Address' });
-      
+
       expect(emailField.type).toBe('email');
       expect(emailField.label).toBe('Email Address');
+    });
+
+    it('should create time field (#8656)', () => {
+      const timeField = Field.time({ label: 'Time' });
+
+      expect(timeField.type).toBe('time');
+      expect(timeField.label).toBe('Time');
+      expect(() => FieldSchema.parse(timeField)).not.toThrow();
+      // Clause-2 pin: the builder must produce exactly the literal form an
+      // author could already write today — no accept-set change.
+      expect(timeField).toEqual({ type: 'time', label: 'Time' });
     });
   });
 

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -1548,6 +1548,7 @@ export const Field = {
   boolean: (config: FieldInput = {}) => ({ type: 'boolean', ...config } as const),
   date: (config: FieldInput = {}) => ({ type: 'date', ...config } as const),
   datetime: (config: FieldInput = {}) => ({ type: 'datetime', ...config } as const),
+  time: (config: FieldInput = {}) => ({ type: 'time', ...config } as const),
   currency: (config: FieldInput = {}) => ({ type: 'currency', ...config } as const),
   percent: (config: FieldInput = {}) => ({ type: 'percent', ...config } as const),
   url: (config: FieldInput = {}) => ({ type: 'url', ...config } as const),


### PR DESCRIPTION
Fixes #8656

## What

Adds `Field.time` to the `Field` convenience object in `packages/spec/src/data/field.zod.ts`, mirroring the adjacent `Field.datetime` builder exactly:

```ts
time: (config: FieldInput = {}) => ({ type: 'time', ...config } as const),
```

This is the minimal move pre-approved by the hold-release grading (issue comments 5294799408 and 5345587272): add `Field.time` alone, and only `time`, of the 13 field types the finding originally listed as missing a builder.

`time` was singled out because it is the one type the spec's own prose already names as existing — `Field.time` is referenced in doc comments at `packages/spec/src/contracts/data-driver.ts:234,256` and `packages/spec/src/data/calendar-day.ts:83`, which were false until this PR (the builder did not exist). No other builder is added; the other 12 types named in the original finding remain out of scope per the grading.

## Clause-2 honesty

`Field.time({ label })` produces exactly `{ type: 'time', label }` — the identical literal form an author could already write today. Nothing about what `FieldSchema` accepts or rejects changes; this is sugar over an already-declared field type. The accept pin in `field.test.ts` asserts this deep-equality directly.

## Changes

- `packages/spec/src/data/field.zod.ts` — add the `Field.time` builder (declared surface, one line).
- `packages/spec/src/data/field.test.ts` — accept pin: `Field.time({ label: 'Time' })` parses as a valid `time` field via `FieldSchema.parse`, and deep-equals the literal `{ type: 'time', label: 'Time' }` form.
- `.changeset/field-time-builder.md` — patch changeset for `@objectstack/spec`.
- `examples/app-showcase/src/data/objects/field-zoo.object.ts` — declared rider (optional PM suggestion): swap the showcase's `f_time` from the literal `{ type: 'time', label: 'Time' }` to `Field.time({ label: 'Time' })`. Example package builds clean with this change (verified via a full `pnpm exec turbo run build`).

## Tests

- `pnpm --filter @objectstack/spec exec vitest run src/data/field.test.ts` — 140/140 passed, including the new `Field.time` accept pin.
- `pnpm --filter @objectstack/spec test` (full suite) — 414 files / 11037 tests passed.
- `pnpm --filter @objectstack/spec typecheck` — green.
- Named gates + diff-derived gates — all green; see the structured report on the issue for the full list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01URCaKuNTuK3BKJvwqM74QU)_