### PR TITLE
feat(plugin-auth): mount admin-gated POST /organization/add-member wrapping better-auth's server-only addMember

### DIFF
--- a/.changeset/organization-add-member-mounted.md
+++ b/.changeset/organization-add-member-mounted.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+feat(plugin-auth): mount `POST /api/v1/auth/organization/add-member` — platform-admin-gated wrapper over better-auth's server-only `auth.api.addMember` (#9941)
+
+better-auth (1.7.1 installed; already true on 1.7.0-rc.2) declares `addMember`
+with **no HTTP path** — server-only — so the catch-all never mounted
+`POST /organization/add-member`, yet the `sys_member` **Add Member** toolbar
+action has always targeted exactly that URL and answered 404. On a multi-org
+posture that 404 was a hard blocker: `admin/create-user`'s reconciler resolves
+no target org under the org wall by design, generic `sys_member` CRUD is
+suppressed (ADR-0010 full lock), and the invite flow needs an email round-trip
+phone-number-only users cannot complete — leaving **no UI path at all** to
+attach an existing user to an organization.
+
+What ships:
+
+- `auth-plugin.ts` now mounts the route ahead of the catch-all, wrapping the
+  vendor's own `auth.api.addMember` (its already-a-member pre-check, membership
+  limit, team resolution and hooks all stay the vendor's — nothing is
+  re-adjudicated, and no `sys_member` row is written directly).
+- **Admit set: platform admin only** (the shared ADR-0068 gate,
+  `platform-admin-gate.ts`). Anonymous → `401 UNAUTHENTICATED`; any signed-in
+  non-platform-admin — including org owners/admins — → `403 PERMISSION_DENIED`
+  (ADR-0112 envelope). The vendor endpoint performs no authorization of its own
+  (server-only = trusted caller), which is why the gate is not negotiable.
+- Request headers are forwarded, so an omitted `organizationId` defaults to the
+  caller's active organization — the behaviour the action metadata documents.
+- The route is ledgered in `auth-route-ledger.ts` (`source: 'objectstack'`,
+  `disposition: 'server-only'` — no SDK method builds this URL; the metadata
+  action posts it directly), and the stale `adopt-membership.ts` claim that
+  named the vendor path as mounted now describes the real shape.
+
+The `sys_member` action metadata itself is untouched: its target was correct
+all along — the route underneath it now exists.

--- a/packages/plugins/plugin-auth/src/admin-user-endpoints.ts
+++ b/packages/plugins/plugin-auth/src/admin-user-endpoints.ts
@@ -395,7 +395,7 @@ async function writeAdminAudit(
   }
 }
 
-function mapAuthApiError(error: unknown, fallback: string): EndpointResult {
+export function mapAuthApiError(error: unknown, fallback: string): EndpointResult {
   const e = error as {
     statusCode?: number;
     status?: number | string;

--- a/packages/plugins/plugin-auth/src/adopt-membership.ts
+++ b/packages/plugins/plugin-auth/src/adopt-membership.ts
@@ -66,10 +66,14 @@
  * membership**, so a `create` naming an (org, user) pair that already exists is
  * not a second membership — it is that membership.
  *
- * Blast radius, measured against better-auth 1.7.0-rc.2 rather than assumed —
- * accept-invitation is the ONLY `member` create that can reach an existing pair:
+ * Blast radius, measured against the installed better-auth (re-measured on
+ * 1.7.1) rather than assumed — accept-invitation is the ONLY `member` create
+ * that can reach an existing pair:
  *
- *  - `POST /organization/add-member` pre-checks and refuses first
+ *  - The vendor's `addMember` is SERVER-ONLY (declared with no HTTP path;
+ *    reachable over HTTP only through ObjectStack's platform-admin-gated
+ *    `POST /organization/add-member` mount, #9941 — see
+ *    organization-add-member.ts), and it pre-checks and refuses first
  *    (`crud-members.mjs`: `findMemberByEmail` →
  *    `USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION`, a 400).
  *  - `POST /organization/create-organization` mints a fresh organization id, so

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -2108,6 +2108,38 @@ export class AuthPlugin implements Plugin {
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // #9941 — organization/add-member. better-auth declares `addMember`
+    // WITHOUT an HTTP path (server-only `auth.api.addMember`; measured on the
+    // installed 1.7.1), so the catch-all never mounts it — yet the
+    // `sys_member` `add_member` toolbar action has always targeted this URL,
+    // and on a multi-org posture it is the only UI path that can attach an
+    // existing user to an organization. This mount restores that declared
+    // surface behind the shared ADR-0068 platform-admin gate (attaching a
+    // user without their consent is a platform-operator action, and the
+    // vendor endpoint does no authorization of its own). Ledgered as
+    // `server-only` in auth-route-ledger.ts; logic in
+    // organization-add-member.ts.
+    rawApp.post(`${basePath}/organization/add-member`, async (c: any) => {
+      try {
+        const actor = await gateAdmin(c);
+        if (actor instanceof Response) return actor;
+        const { runOrganizationAddMember } = await import('./organization-add-member.js');
+        // [#4586] Same seam as create-user: the write is driven server-side
+        // and never passes through `AuthManager.handleRequest`, so open the
+        // attribution seam here — the `sys_member` row this creates is
+        // credited to the admin instead of recorded as the system.
+        const { status, body } = await runAttributedToUser(actor.id, () =>
+          runOrganizationAddMember({ getAuthApi: () => this.authManager!.getApi() as any }, c.req.raw),
+        );
+        return c.json(body, status as any);
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        ctx.logger.error('[AuthPlugin] organization/add-member failed', err);
+        return c.json({ success: false, error: { code: 'INTERNAL_ERROR', message: err.message } }, 500);
+      }
+    });
+
+    // ────────────────────────────────────────────────────────────────────
     // ADR-0069 P3 — register a SAML 2.0 IdP. Mirrors the OIDC bridge above:
     // the metadata `register_saml_provider` action posts FLAT fields; the shared
     // helper reshapes them into better-auth's nested `samlConfig` (deriving the

--- a/packages/plugins/plugin-auth/src/auth-route-ledger.conformance.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-route-ledger.conformance.test.ts
@@ -168,15 +168,18 @@ describe('auth route ledger hygiene', () => {
     expect(stray, `rows outside ${BASE_PATH}: ${stray.join(', ')}`).toEqual([]);
   });
 
-  it('the two objectstack-mounted rows are the ones auth-plugin.ts serves itself', () => {
-    // /config and /bootstrap-status are mounted on the raw app AHEAD of the
-    // catch-all, so they are absent from `auth.api` by construction. Pinned so
+  it('the objectstack-mounted rows are the ones auth-plugin.ts serves itself', () => {
+    // These are mounted on the raw app AHEAD of the catch-all, so they are
+    // absent from `auth.api`'s wire table by construction (organization/
+    // add-member exists on `auth.api` but carries NO path — server-only — so
+    // the enumeration, which reads `.path`, never sees it either). Pinned so
     // the `source` split stays honest rather than becoming a place to park a
     // row that failed the upstream check.
     const own = AUTH_ROUTE_LEDGER.filter((e) => e.source === 'objectstack').map((e) => e.route).sort();
     expect(own).toEqual([
       'GET /api/v1/auth/bootstrap-status',
       'GET /api/v1/auth/config',
+      'POST /api/v1/auth/organization/add-member',
     ]);
     for (const route of own) {
       expect(live.has(route), `${route} should NOT come from better-auth`).toBe(false);

--- a/packages/plugins/plugin-auth/src/auth-route-ledger.ts
+++ b/packages/plugins/plugin-auth/src/auth-route-ledger.ts
@@ -179,6 +179,14 @@ export const AUTH_ROUTE_LEDGER: readonly AuthRouteLedgerEntry[] = [
   { route: 'GET /api/v1/auth/bootstrap-status', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.bootstrapStatus' },
   { route: 'GET /api/v1/auth/config', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.getConfig' },
   { route: 'POST /api/v1/auth/organization/accept-invitation', family: 'organization', source: 'better-auth', disposition: 'sdk', client: 'organizations.invitations.accept', requires: 'organization' },
+  // #9941 — better-auth declares `addMember` with NO HTTP path (server-only
+  // `auth.api.addMember`; measured on the installed 1.7.1), so the catch-all
+  // never publishes it and it is correctly ABSENT from
+  // BETTER_AUTH_MOUNTED_SURFACE. auth-plugin.ts mounts this wrapper itself,
+  // ahead of the catch-all, behind the ADR-0068 platform-admin gate — it
+  // restores the URL the `sys_member` `add_member` toolbar action has always
+  // targeted (on multi-org the only UI path to attach an existing user).
+  { route: 'POST /api/v1/auth/organization/add-member', family: 'organization', source: 'objectstack', disposition: 'server-only', requires: 'organization', note: 'no SDK method builds this URL — the sys_member add_member action posts it directly; ObjectStack mount wrapping the vendor server-only auth.api.addMember, platform-admin gated (ADR-0068), #9941' },
   { route: 'POST /api/v1/auth/organization/add-team-member', family: 'organization', source: 'better-auth', disposition: 'sdk', client: 'organizations.teams.addMember', requires: 'organization' },
   { route: 'POST /api/v1/auth/organization/cancel-invitation', family: 'organization', source: 'better-auth', disposition: 'sdk', client: 'organizations.invitations.cancel', requires: 'organization' },
   { route: 'POST /api/v1/auth/organization/create', family: 'organization', source: 'better-auth', disposition: 'sdk', client: 'organizations.create', requires: 'organization' },

--- a/packages/plugins/plugin-auth/src/organization-add-member.test.ts
+++ b/packages/plugins/plugin-auth/src/organization-add-member.test.ts
@@ -400,7 +400,12 @@ describe('#9941 runOrganizationAddMember — capability ordering on a degraded d
   });
 
   it('forwards userId/role/organizationId (accepting snake_case spellings) and the request headers to the vendor', async () => {
-    const addMember = vi.fn(async () => ({ id: 'mem_new', userId: 'usr_1', organizationId: 'org_1', role: 'member' }));
+    const addMember = vi.fn(async (_opts: { body: Record<string, unknown>; headers?: Headers }) => ({
+      id: 'mem_new',
+      userId: 'usr_1',
+      organizationId: 'org_1',
+      role: 'member',
+    }));
     const req = post({ user_id: 'usr_1', role: ['member'], organization_id: 'org_1' });
     const res = await runOrganizationAddMember({ getAuthApi: async () => ({ addMember }) }, req);
     expect(res.status).toBe(200);

--- a/packages/plugins/plugin-auth/src/organization-add-member.test.ts
+++ b/packages/plugins/plugin-auth/src/organization-add-member.test.ts
@@ -1,0 +1,415 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #9941 — `POST /organization/add-member` is MOUNTED (better-auth declares
+ * `addMember` server-only, with no HTTP path), admin-gated, and actually
+ * clears the card's blocker: on a multi-org fixture an existing user with
+ * zero memberships gets a `sys_member` row through this route and no longer
+ * meets the "create a workspace" bootstrap condition.
+ *
+ * Two layers, deliberately:
+ *
+ *  1. The MOUNTED route on the plugin's real route registration, driven by
+ *     REAL better-auth sessions over a real `AuthManager` + in-memory engine
+ *     (the remove-member-permission-guard.test.ts harness) — so the ADR-0068
+ *     gate pins (anon 401 / member 403 / org owner 403 / platform admin
+ *     admitted) are pinned on the WIRING, not on a fake session shape, and
+ *     the admitted path is proven to reach the real vendor `addMember`
+ *     (the row lands in `sys_member` through the objectql adapter).
+ *  2. The handler module alone, for the orderings that need a degraded
+ *     deployment (organization plugin off → 501 before body validation).
+ *
+ * Every rejection asserts `code` AND `status` (ADR-0112) — a bare "it threw"
+ * would pass against a handler that refuses everyone.
+ *
+ * The platform admin here is REAL: `sys_permission_set`(`admin_full_access`)
+ * + an org-less `sys_user_permission_set` link — the exact rows the
+ * customSession override derives `positions[]`/`isPlatformAdmin` from. No
+ * `role = 'admin'` scalar is patched anywhere (re-synthesizing it is
+ * permanently vetoed, maintainer ruling 2026-08-18).
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { Hono } from 'hono';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/objectql';
+import { AuthManager } from './auth-manager';
+import { AuthPlugin } from './auth-plugin';
+import { runOrganizationAddMember } from './organization-add-member.js';
+import type { PluginContext } from '@objectstack/core';
+
+const SECRET = 'test-secret-at-least-32-chars-long!!';
+const BASE = 'http://localhost:3000';
+const BASE_PATH = '/api/v1/auth';
+const ORG_ACME = 'org_acme';
+const ORG_BETA = 'org_beta';
+const PASSWORD = 'S3cure!Passw0rd-9941';
+
+/**
+ * The in-memory `IDataEngine` double the other end-to-end auth-manager suites
+ * use (copied from remove-member-permission-guard.test.ts), deliberately NO
+ * more forgiving than the real engine: `delete`/`update` route through the
+ * shared dispatch asserts, and `sys_member`'s declared
+ * `{ organization_id, user_id }` UNIQUE index is ENFORCED — this suite's whole
+ * point is which calls create membership rows, so a fake that tolerated a
+ * duplicate would let a wrong write read as a right one.
+ */
+const createMemoryEngine = () => {
+  const tables = new Map<string, any[]>();
+  const rows = (name: string) => {
+    if (!tables.has(name)) tables.set(name, []);
+    return tables.get(name)!;
+  };
+  const assertMemberUnique = (name: string, row: any, ignoreId?: string) => {
+    if (name !== 'sys_member') return;
+    const clash = rows(name).some(
+      (r) =>
+        r.id !== ignoreId &&
+        r.organization_id === row.organization_id &&
+        r.user_id === row.user_id,
+    );
+    if (clash) {
+      throw new Error(
+        'insert into sys_member … UNIQUE constraint failed: ' +
+          'sys_member.organization_id, sys_member.user_id',
+      );
+    }
+  };
+  const eq = (a: any, b: any) =>
+    a instanceof Date || b instanceof Date
+      ? new Date(a as any).getTime() === new Date(b as any).getTime()
+      : a === b;
+  const matches = (row: any, where: Record<string, any> = {}) =>
+    Object.entries(where).every(([k, v]) => {
+      if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+      const actual = row[k];
+      if (v && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date)) {
+        if ('$ne' in v) return !eq(actual, v.$ne);
+        if ('$in' in v) return (v.$in as any[]).some((x) => eq(actual, x));
+      }
+      return eq(actual, v);
+    });
+  const project = (row: any, fields?: string[]) => {
+    if (!Array.isArray(fields) || fields.length === 0) return { ...row };
+    const out: any = {};
+    for (const f of ['id', ...fields]) if (f in row) out[f] = row[f];
+    return out;
+  };
+  let seq = 0;
+  return {
+    tables,
+    async insert(name: string, data: any) {
+      const row = { id: data.id ?? `row_${++seq}`, ...data };
+      assertMemberUnique(name, row);
+      rows(name).push(row);
+      return { ...row };
+    },
+    async findOne(name: string, q: any = {}) {
+      const row = rows(name).find((r) => matches(r, q.where));
+      return row ? project(row, q.fields) : null;
+    },
+    async find(name: string, q: any = {}) {
+      let out = rows(name).filter((r) => matches(r, q.where));
+      if (q.offset) out = out.slice(q.offset);
+      if (q.limit) out = out.slice(0, q.limit);
+      return out.map((r) => project(r, q.fields));
+    },
+    async count(name: string, q: any = {}) {
+      return rows(name).filter((r) => matches(r, q.where)).length;
+    },
+    async update(name: string, patch: any, options?: any) {
+      assertEngineUpdateDispatch(patch, options);
+      const row = rows(name).find((r) => r.id === patch.id);
+      if (!row) return null;
+      assertMemberUnique(name, { ...row, ...patch }, row.id);
+      Object.assign(row, patch);
+      return { ...row };
+    },
+    async delete(name: string, q: any = {}) {
+      assertEngineDeleteDispatch(q);
+      const table = rows(name);
+      const keep = table.filter((r) => !matches(r, q.where));
+      tables.set(name, keep);
+      return table.length - keep.length;
+    },
+  };
+};
+
+type MemoryEngine = ReturnType<typeof createMemoryEngine>;
+
+const mockCtx = (): PluginContext =>
+  ({
+    registerService: vi.fn(),
+    getService: vi.fn((name: string) => (name === 'manifest' ? { register: vi.fn() } : undefined)),
+    getServices: vi.fn(() => new Map()),
+    hook: vi.fn(),
+    trigger: vi.fn(),
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    getKernel: vi.fn(),
+  }) as any;
+
+const cookieFrom = (response: Response): string =>
+  (response.headers.getSetCookie?.() ?? [response.headers.get('set-cookie') ?? ''])
+    .map((c) => c.split(';')[0])
+    .filter(Boolean)
+    .join('; ');
+
+/** POST through the real better-auth pipeline (sign-up, organization/list …). */
+const viaManager = (manager: AuthManager, path: string, init: RequestInit, cookie?: string) =>
+  manager.handleRequest(
+    new Request(`${BASE}${BASE_PATH}${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookie ? { cookie } : {}),
+        ...(init.headers ?? {}),
+      },
+    }),
+  );
+
+const signUp = async (manager: AuthManager, engine: MemoryEngine, email: string) => {
+  const res = await viaManager(manager, '/sign-up/email', {
+    method: 'POST',
+    body: JSON.stringify({ email, password: PASSWORD, name: email }),
+  });
+  expect(res.status, await res.clone().text()).toBe(200);
+  const user = (engine.tables.get('sys_user') ?? []).find((u) => u.email === email);
+  expect(user, `sign-up did not create ${email}`).toBeDefined();
+  return { cookie: cookieFrom(res), userId: String(user!.id), email };
+};
+
+const memberRows = (engine: MemoryEngine, userId: string) =>
+  (engine.tables.get('sys_member') ?? []).filter((m) => m.user_id === userId);
+
+/** The orgs a user's own session can see — the "create a workspace" signal. */
+const orgListFor = async (manager: AuthManager, cookie: string): Promise<any[]> => {
+  const res = await viaManager(manager, '/organization/list', { method: 'GET' }, cookie);
+  expect(res.status, await res.clone().text()).toBe(200);
+  return (await res.json()) as any[];
+};
+
+/** Fire the MOUNTED route, exactly as the sys_member action posts it. */
+const fireAddMember = (app: Hono, body: unknown, cookie?: string) =>
+  app.request(`${BASE}${BASE_PATH}/organization/add-member`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: BASE,
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+describe('#9941 POST /organization/add-member — mounted, gated, and it clears the blocker (real multi-org fixture)', () => {
+  let engine: MemoryEngine;
+  let manager: AuthManager;
+  let app: Hono;
+  let admin: { cookie: string; userId: string };
+  let member: { cookie: string; userId: string };
+  let orgOwner: { cookie: string; userId: string };
+  let target: { cookie: string; userId: string };
+
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  afterAll(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  beforeAll(async () => {
+    engine = createMemoryEngine();
+    manager = new AuthManager({
+      secret: SECRET,
+      baseUrl: BASE,
+      dataEngine: engine as any,
+      plugins: { organization: true },
+    } as any);
+
+    // TWO organizations — a genuinely multi-org deployment, so nothing can
+    // resolve a "sole organization" to auto-bind anyone to.
+    await engine.insert('sys_organization', { id: ORG_ACME, name: 'Acme', slug: 'acme' });
+    await engine.insert('sys_organization', { id: ORG_BETA, name: 'Beta', slug: 'beta' });
+
+    admin = await signUp(manager, engine, 'platform.admin@example.com');
+    member = await signUp(manager, engine, 'plain.member@example.com');
+    orgOwner = await signUp(manager, engine, 'org.owner@example.com');
+    target = await signUp(manager, engine, 'existing.user@example.com');
+
+    // The REAL ADR-0068 platform-admin signal: admin_full_access held with
+    // organization_id = null — the rows customSession derives positions[]
+    // from. NOT the legacy role scalar.
+    await engine.insert('sys_permission_set', { id: 'ps_admin', name: 'admin_full_access' });
+    await engine.insert('sys_user_permission_set', {
+      id: 'ups_admin',
+      user_id: admin.userId,
+      permission_set_id: 'ps_admin',
+      organization_id: null,
+    });
+
+    // Org-scoped actors on Acme: a plain member and an org OWNER — the owner
+    // is the seat #10009 is open about; here it must stay refused.
+    await engine.insert('sys_member', {
+      id: 'mem_plain',
+      organization_id: ORG_ACME,
+      user_id: member.userId,
+      role: 'member',
+      created_at: new Date(),
+    });
+    await engine.insert('sys_member', {
+      id: 'mem_owner',
+      organization_id: ORG_ACME,
+      user_id: orgOwner.userId,
+      role: 'owner',
+      created_at: new Date(),
+    });
+
+    // The plugin's REAL route registration on a real Hono app (the
+    // admin-sso-bridge-gate.test.ts harness), with the REAL AuthManager
+    // behind it — gate, mount, and vendor call are all the shipped wiring.
+    app = new Hono();
+    const plugin = new AuthPlugin({ secret: SECRET });
+    await plugin.init(mockCtx());
+    (plugin as any).authManager = manager;
+    (plugin as any).registerAuthRoutes({ getRawApp: () => app, getPort: () => 0 }, mockCtx());
+  }, 120_000);
+
+  const answer = async (res: Response) => {
+    const body: any = await res.clone().json().catch(() => null);
+    return { status: res.status, code: body?.error?.code ?? null, success: body?.success ?? null };
+  };
+
+  // ── The card's premise, kept measured ────────────────────────────────────
+  it('premise: on multi-org, a fresh user has ZERO memberships and an empty org list (the "create a workspace" bootstrap condition)', async () => {
+    expect(memberRows(engine, target.userId)).toHaveLength(0);
+    expect(await orgListFor(manager, target.cookie)).toEqual([]);
+  });
+
+  // ── ADR-0068 gate pins, anonymous-first ordering ─────────────────────────
+  it('anonymous → 401 UNAUTHENTICATED even with an invalid body (identity error before body validation), and nothing is written', async () => {
+    const before = memberRows(engine, target.userId).length;
+    const res = await fireAddMember(app, {}); // no userId, no role, no session
+    expect(await answer(res)).toEqual({ status: 401, code: 'UNAUTHENTICATED', success: false });
+    expect(memberRows(engine, target.userId)).toHaveLength(before);
+  });
+
+  it('a signed-in plain member → 403 PERMISSION_DENIED, and nothing is written', async () => {
+    const res = await fireAddMember(
+      app,
+      { userId: target.userId, role: 'member', organizationId: ORG_ACME },
+      member.cookie,
+    );
+    expect(await answer(res)).toEqual({ status: 403, code: 'PERMISSION_DENIED', success: false });
+    expect(memberRows(engine, target.userId)).toHaveLength(0);
+  });
+
+  it('an org OWNER is not a platform admin → 403 PERMISSION_DENIED (the admit set is platform-admin only)', async () => {
+    const res = await fireAddMember(
+      app,
+      { userId: target.userId, role: 'member', organizationId: ORG_ACME },
+      orgOwner.cookie,
+    );
+    expect(await answer(res)).toEqual({ status: 403, code: 'PERMISSION_DENIED', success: false });
+    expect(memberRows(engine, target.userId)).toHaveLength(0);
+  });
+
+  // ── The card's actual blocker, end to end ────────────────────────────────
+  it('a platform admin attaches the zero-membership user: the vendor addMember runs, the sys_member row lands, and the bootstrap condition clears', async () => {
+    const res = await fireAddMember(
+      app,
+      { userId: target.userId, role: 'member', organizationId: ORG_BETA },
+      admin.cookie,
+    );
+    const body: any = await res.clone().json();
+    expect(res.status, JSON.stringify(body)).toBe(200);
+    expect(body.success).toBe(true);
+    // The vendor's created member row is returned to the action's caller.
+    expect(body.data?.member?.userId ?? body.data?.member?.user_id).toBe(target.userId);
+
+    // The row is real — written through the objectql adapter by the REAL
+    // vendor endpoint, not by any direct sys_member write in this repo.
+    const rows = memberRows(engine, target.userId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].organization_id).toBe(ORG_BETA);
+    expect(rows[0].role).toBe('member');
+
+    // …and the user no longer lands on "create a workspace": their own
+    // session now sees the org.
+    const orgs = await orgListFor(manager, target.cookie);
+    expect(orgs.map((o: any) => o.id)).toEqual([ORG_BETA]);
+  });
+
+  // ── The vendor's own verdicts are forwarded, not re-adjudicated ──────────
+  it("repeating the attach is refused by the VENDOR's pre-check: 400 USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION", async () => {
+    // This is also the claim adopt-membership.ts documents — kept live here.
+    const res = await fireAddMember(
+      app,
+      { userId: target.userId, role: 'member', organizationId: ORG_BETA },
+      admin.cookie,
+    );
+    expect(await answer(res)).toEqual({
+      status: 400,
+      code: 'USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION',
+      success: false,
+    });
+    expect(memberRows(engine, target.userId)).toHaveLength(1);
+  });
+
+  it('an unknown userId → the vendor 400 USER_NOT_FOUND', async () => {
+    const res = await fireAddMember(
+      app,
+      { userId: 'usr_nobody', role: 'member', organizationId: ORG_ACME },
+      admin.cookie,
+    );
+    expect(await answer(res)).toEqual({ status: 400, code: 'USER_NOT_FOUND', success: false });
+  });
+
+  it('omitted organizationId with no active organization on the admin session → the vendor 400 NO_ACTIVE_ORGANIZATION', async () => {
+    // The admin holds no membership (platform admin ≠ org member) and never
+    // set an active org, so the documented "defaults to the caller's active
+    // org" fallback has nothing to fall back to — the vendor says so.
+    const res = await fireAddMember(app, { userId: member.userId, role: 'member' }, admin.cookie);
+    expect(await answer(res)).toEqual({ status: 400, code: 'NO_ACTIVE_ORGANIZATION', success: false });
+  });
+
+  // ── Body validation (after the gate — the admin seat sees these) ─────────
+  it('missing userId → 400 INVALID_REQUEST; missing role → 400 INVALID_REQUEST', async () => {
+    expect(await answer(await fireAddMember(app, { role: 'member' }, admin.cookie))).toEqual({
+      status: 400,
+      code: 'INVALID_REQUEST',
+      success: false,
+    });
+    expect(
+      await answer(await fireAddMember(app, { userId: member.userId }, admin.cookie)),
+    ).toEqual({ status: 400, code: 'INVALID_REQUEST', success: false });
+  });
+});
+
+describe('#9941 runOrganizationAddMember — capability ordering on a degraded deployment', () => {
+  const post = (body: unknown) =>
+    new Request(`${BASE}${BASE_PATH}/organization/add-member`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('organization plugin off → 501 NOT_IMPLEMENTED, even before body validation (capability error before body error)', async () => {
+    // `getAuthApi` yields an api with NO addMember — the organization plugin
+    // is not enabled. The body is ALSO invalid; the capability answer wins.
+    const res = await runOrganizationAddMember({ getAuthApi: async () => ({}) }, post({}));
+    expect(res.status).toBe(501);
+    expect(res.body.error?.code).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('forwards userId/role/organizationId (accepting snake_case spellings) and the request headers to the vendor', async () => {
+    const addMember = vi.fn(async () => ({ id: 'mem_new', userId: 'usr_1', organizationId: 'org_1', role: 'member' }));
+    const req = post({ user_id: 'usr_1', role: ['member'], organization_id: 'org_1' });
+    const res = await runOrganizationAddMember({ getAuthApi: async () => ({ addMember }) }, req);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(addMember).toHaveBeenCalledTimes(1);
+    const call = addMember.mock.calls[0][0] as any;
+    expect(call.body).toEqual({ userId: 'usr_1', role: ['member'], organizationId: 'org_1' });
+    // Headers forwarded so an omitted organizationId can default to the
+    // caller's ACTIVE org — the action metadata's documented behaviour.
+    expect(call.headers).toBe(req.headers);
+  });
+});

--- a/packages/plugins/plugin-auth/src/organization-add-member.ts
+++ b/packages/plugins/plugin-auth/src/organization-add-member.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `POST /api/v1/auth/organization/add-member` — ObjectStack's admin-gated
+ * mount over better-auth's SERVER-ONLY `auth.api.addMember` (#9941).
+ *
+ * ── Why this mount exists (the measurement) ─────────────────────────────────
+ *
+ * better-auth declares `addMember` WITHOUT an HTTP path — measured on the
+ * installed 1.7.1, `dist/plugins/organization/routes/crud-members.mjs`:
+ * `addMember` returns `createAuthEndpoint({ method: "POST", ... })` (no path
+ * argument), while its siblings keep theirs
+ * (`createAuthEndpoint("/organization/remove-member", …)`,
+ * `"/organization/update-member-role"`). The vendor's own doc comment says so:
+ * "**Server-only:** callable as `auth.api.addMember` from trusted server"
+ * (`dist/plugins/organization/organization.mjs`). So the catch-all never
+ * mounts it and `POST /organization/add-member` answered 404 — yet the
+ * `sys_member` `add_member` toolbar action ships targeting exactly that URL,
+ * and on a multi-org posture it was the ONLY remaining UI path to attach an
+ * existing user to an organization (create-user's reconciler resolves no
+ * target org under the org wall by design; generic `sys_member` CRUD is
+ * suppressed under the ADR-0010 full lock; the invite flow needs an email
+ * round-trip phone-number-only users cannot complete).
+ *
+ * This mount RESTORES that declared surface rather than widening it: same
+ * URL the action metadata has always targeted, wrapped around the vendor's
+ * own server-only endpoint — no reimplementation of its checks (already-a-
+ * member, membership limit, team resolution, hooks all stay the vendor's).
+ *
+ * ── Authorization ───────────────────────────────────────────────────────────
+ *
+ * The HTTP mount in auth-plugin.ts runs the shared ADR-0068 platform-admin
+ * gate (`platform-admin-gate.ts`, via the hoisted `gateAdmin`) BEFORE this
+ * handler is reached — anonymous 401 `UNAUTHENTICATED`, signed-in non-admin
+ * (including org owners/admins — they are NOT platform admins, ADR-0068) 403
+ * `PERMISSION_DENIED`. Directly attaching a user to an organization without
+ * their consent is a platform-operator action; the vendor endpoint itself
+ * performs NO authorization (server-only = trusted caller), which is exactly
+ * why the admit set here must stay platform-admin only.
+ *
+ * Ordering (ADR-0112, anonymous-first): identity error (gate, at the mount) →
+ * capability error (501 when the organization plugin is off) → body
+ * validation (400) → the vendor's own verdicts, forwarded verbatim.
+ *
+ * ── organizationId default ──────────────────────────────────────────────────
+ *
+ * The request headers are forwarded into `auth.api.addMember`, so an omitted
+ * `organizationId` defaults to the CALLER's active organization — the
+ * behaviour the `sys_member` action metadata documents ("organizationId/teamId
+ * default to the caller's active org/team when omitted"). An admin with no
+ * active organization gets the vendor's 400 `NO_ACTIVE_ORGANIZATION`.
+ */
+
+import { mapAuthApiError, type EndpointResult } from './admin-user-endpoints.js';
+
+/** Minimal better-auth server-api surface this route drives. */
+export interface AddMemberCapableApi {
+  addMember(opts: {
+    body: {
+      userId: string;
+      role: string | string[];
+      organizationId?: string;
+      teamId?: string;
+    };
+    headers?: Headers;
+  }): Promise<Record<string, unknown> | null>;
+}
+
+export interface OrganizationAddMemberDeps {
+  getAuthApi(): Promise<AddMemberCapableApi | Record<string, unknown>>;
+}
+
+const badRequest = (message: string): EndpointResult => ({
+  status: 400,
+  body: { success: false, error: { code: 'INVALID_REQUEST', message } },
+});
+
+async function parseJson(request: Request): Promise<Record<string, unknown>> {
+  try {
+    const parsed = await request.json();
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Both spellings accepted, like the sibling mounts (`unlock-user` reads
+ * `userId ?? user_id`): the `sys_member` action params send camelCase, but the
+ * snake_case column names are what an operator pasting from the grid has.
+ */
+function readString(body: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const raw = body[key];
+    if (typeof raw === 'string' && raw.length > 0) return raw;
+  }
+  return undefined;
+}
+
+/** `role` is the vendor's `string | string[]` — validated, never widened. */
+function readRole(body: Record<string, unknown>): string | string[] | undefined {
+  const raw = body.role;
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  if (Array.isArray(raw) && raw.length > 0 && raw.every((r) => typeof r === 'string' && r.length > 0)) {
+    return raw as string[];
+  }
+  return undefined;
+}
+
+/**
+ * `POST /api/v1/auth/organization/add-member` — the caller is already gated
+ * (platform admin only; see the module header and the mount in auth-plugin.ts).
+ */
+export async function runOrganizationAddMember(
+  deps: OrganizationAddMemberDeps,
+  request: Request,
+): Promise<EndpointResult> {
+  // Capability before body validation (ADR-0112 ordering): without the
+  // organization plugin there is no member model at all, and reporting a
+  // body nit first would send the caller fixing a payload for a capability
+  // the deployment does not have.
+  const authApi = (await deps.getAuthApi()) as Partial<AddMemberCapableApi>;
+  if (typeof authApi.addMember !== 'function') {
+    return {
+      status: 501,
+      body: {
+        success: false,
+        error: {
+          code: 'NOT_IMPLEMENTED',
+          message: 'The better-auth organization plugin is not enabled (auth.plugins.organization)',
+        },
+      },
+    };
+  }
+
+  const body = await parseJson(request);
+  const userId = readString(body, 'userId', 'user_id');
+  if (!userId) return badRequest('userId is required');
+  const role = readRole(body);
+  if (!role) return badRequest('role is required (a role name, or an array of role names)');
+  const organizationId = readString(body, 'organizationId', 'organization_id');
+  const teamId = readString(body, 'teamId', 'team_id');
+
+  try {
+    // Headers forwarded on purpose: an omitted organizationId defaults to the
+    // admin's ACTIVE organization (the action metadata's documented
+    // behaviour). The vendor endpoint is server-only and does no
+    // authorization of its own — the mount's platform-admin gate already ran.
+    const member = await authApi.addMember({
+      body: {
+        userId,
+        role,
+        ...(organizationId ? { organizationId } : {}),
+        ...(teamId ? { teamId } : {}),
+      },
+      headers: request.headers,
+    });
+    return { status: 200, body: { success: true, data: { member: member ?? null } } };
+  } catch (error) {
+    // The vendor's own verdicts, forwarded verbatim — NO_ACTIVE_ORGANIZATION,
+    // USER_NOT_FOUND, USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION,
+    // ORGANIZATION_MEMBERSHIP_LIMIT_REACHED, … (400s; limit is 403). Their
+    // checks are not duplicated here: duplicated security checks are where
+    // bypasses live (see adopt-membership.ts).
+    return mapAuthApiError(error, 'organization/add-member failed');
+  }
+}

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -1072,6 +1072,16 @@
       "pinned": 1
     },
     {
+      "file": "packages/plugins/plugin-auth/src/organization-add-member.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-auth/src/organization-add-member.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/plugins/plugin-auth/src/remove-member-permission-guard.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Fixes #9941

## Premise re-verified — on the INSTALLED vendor, which is 1.7.1, not the card's 1.7.0-rc.2

The installed `better-auth` in this tree is **1.7.1** (`packages/plugins/plugin-auth/node_modules/better-auth/package.json`). The card cited `1.7.0-rc.2`; the vendor bump did **not** change the fact:

- `dist/plugins/organization/routes/crud-members.mjs:20-25` — `addMember` returns `createAuthEndpoint({ method: "POST", ... })` with **no path argument** → server-only, never mounted by the catch-all.
- Same file `:139` — `removeMember` keeps `"/organization/remove-member"`; `:236` — `updateMemberRole` keeps `"/organization/update-member-role"`.
- `dist/plugins/organization/organization.mjs:326` — the vendor's own doc: "**Server-only:** callable as `auth.api.addMember` from trusted server".

The three contradicting sites named by the card were all intact on `origin/main@09b880b0c`: `sys-member.object.ts:54` (the `add_member` action target), `adopt-membership.ts:72` (the stale "`POST /organization/add-member` pre-checks and refuses first" claim), and the ledger listing only `add-team-member` (`:182`, `:333`) with the `'server-only'` arm at `:60` unused.

## What ships (triage's preferred shape — restores a declared surface, widens nothing)

- **`organization-add-member.ts`** (new): `runOrganizationAddMember(deps, request)` wraps `auth.api.addMember` server-side. Ordering per ADR-0112, anonymous-first: identity (gate, at the mount) → capability (501 `NOT_IMPLEMENTED` when the organization plugin is off) → body validation (400 `INVALID_REQUEST`) → the vendor's own verdicts forwarded verbatim (`USER_NOT_FOUND`, `NO_ACTIVE_ORGANIZATION`, `USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION`, …). Request headers are forwarded so an omitted `organizationId` defaults to the caller's active org — the behaviour the action metadata documents. **No `sys_member` row is written directly** (ADR-0010 lock respected): the row lands through the vendor's own `createMember` via the objectql adapter.
- **`auth-plugin.ts`**: mounts `POST ${basePath}/organization/add-member` ahead of the catch-all, gated by the **shared** `gateAdmin` → `judgePlatformAdmin` (`platform-admin-gate.ts`; no new predicate copy — same hoist PR #10013 landed for the `/admin/sso/*` bridges). Admitted writes run under `runAttributedToUser(actor.id, …)` so the membership is credited to the admin. **Admit set: platform admin only** — org owners/admins are refused 403 (#10009 remains open about a sibling's wider admit set; this route does not repeat that shape).
- **`auth-route-ledger.ts`**: new row `POST /api/v1/auth/organization/add-member`, `source: 'objectstack'`, **`disposition: 'server-only'`** (the previously-unused arm — it fits: the route is deliberately not SDK surface; no client method builds this URL, the `sys_member` action posts it directly), `requires: 'organization'`, with a rationale note. `BETTER_AUTH_MOUNTED_SURFACE` is deliberately untouched: the vendor endpoint has no path, so the live enumeration (which reads `.path`) never sees it, and the exact-equality pin stays honest.
- **`auth-route-ledger.conformance.test.ts`**: the pinned `source: 'objectstack'` set grows to three rows; the "should NOT come from better-auth" live-check holds for the new row by construction.
- **`adopt-membership.ts`**: the stale contract sentence now says the vendor endpoint is server-only, reachable over HTTP only through this admin-gated mount, re-measured on 1.7.1 — the pre-check claim itself (`findMemberByEmail` → 400) is still true and is now pinned live by a test.
- **`admin-user-endpoints.ts`**: `mapAuthApiError` exported (reused, not copied).
- **`sys-member.object.ts` is untouched**: its target was correct all along — the route underneath it now exists. No metadata string changed ⇒ no dist/i18n/example-showcase consumer surface moved (the #9807 sweep clause is satisfied by construction; verified no diff outside `plugin-auth` + changeset + the double-contract ledger).
- Changeset: `.changeset/organization-add-member-mounted.md` (patch, states route + admit set in release-notes terms).

## Pins (`organization-add-member.test.ts`, 11 tests — real multi-org fixture)

Real `AuthManager` + in-memory engine (the remove-member-guard harness: dispatch-asserted double, `sys_member` UNIQUE enforced), **two** organizations, the plugin's real route registration on a real Hono app, REAL better-auth sessions. The platform admin is real ADR-0068 signal (`admin_full_access` + org-less `sys_user_permission_set` link) — no `role='admin'` scalar patched anywhere.

- premise kept measured: fresh user on multi-org has zero memberships and an empty `organization/list` (the "create a workspace" bootstrap condition);
- anon → **401 `UNAUTHENTICATED`** even with an invalid body (identity before body validation), nothing written;
- signed-in member → **403 `PERMISSION_DENIED`**, nothing written;
- org **owner** → **403 `PERMISSION_DENIED`** (admit set is platform-admin only);
- platform admin → **200**, the vendor `addMember` runs, the `sys_member` row lands (org, user, role asserted), and the user's own session now sees the org — **the card's blocker, pinned end to end**;
- repeat → **400 `USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION`** (vendor pre-check, kept live for adopt-membership's doc);
- unknown user → **400 `USER_NOT_FOUND`**; omitted org + no active org → **400 `NO_ACTIVE_ORGANIZATION`**; missing userId/role → **400 `INVALID_REQUEST`**;
- module-level: organization plugin off → **501 `NOT_IMPLEMENTED`** before body validation; body/headers forwarding pinned.

All rejection pins assert `code` AND `status`.

## Ablation (gate neutered in the mount, predictions stated first)

Predicted: anon 401→400 `INVALID_REQUEST`; member 403→200 with the unauthorized `sys_member` write landing; org-owner 403→vendor 400 already-a-member (poisoned by the member pin's write); blocker test poisoned (2 rows). Observed: **exactly that** — 5 failed / 6 passed, each red for the predicted reason (`expected 401, received 400`; `expected 403, received 200`; `expected 403, received 400`; `length 1 but got 2` ×2). **No rebuild was required for the mutation to be observable**: the suite imports `./auth-plugin` by same-package relative path, which vitest resolves to source; the ablation marker was verified absent from `dist/` on both legs. Restored byte-identically: `git hash-object` = `56c783b059d81e058c540079db786c204bc8351f` before and after; restored leg re-run green (11/11).

## Gates — union run at final commit `918435096`

`node scripts/pm/dispatch-gates.mjs` re-derived from the actual diff (no hand-fed paths), re-run after the last commit:

- `pnpm --filter @objectstack/plugin-auth test` — `Test Files 58 passed (58) · Tests 1312 passed (1312)` (includes the ledger conformance suite)
- `pnpm --filter @objectstack/plugin-auth typecheck` — `tsc --noEmit`, exit 0
- `check:route-envelope` — "✓ IHttpServer express-style modules — 1 module(s) audited … 1 conformant, 0 ratcheted"
- `check:engine-double-contract` — "OK — 323 pinned, 133 in the DEBT ledger, 2 exempt" (new double registered via the gate's own `--write`; ledger artifact committed)
- `check:type-check-debt` — "OK — 33 ledger entr(ies) re-measured … none above its recorded number" (an untyped `vi.fn()` had moved plugin-auth's TEST_DEBT 109→110; fixed by typing the mock, back to exactly 109)
- `check:type-check-coverage`, `check:cross-package-test-inputs` ("OK: 12 package(s) read outside themselves, all declared"), `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:where-matcher`, `check:nul-bytes` ("no raw ASCII control bytes"), `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration` ("no declared-breaking changeset"), `check-changeset-no-major`, `check-empty-changeset`, `docs-audit/check-affected-docs` — all exit 0, verdict lines captured from each gate's own output (exit codes captured before any pipe).

Downstream: with this route mounted, the field report steedos-labs/os-project-titanwind-ehr#1615's blocker is cleared at the platform layer — a platform admin can attach an existing (including phone-number-only) user to an org from the `sys_member` list toolbar, and the attached user no longer lands on the "create a workspace" bootstrap.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_