### PR TITLE
feat(security): explain reports a deactivated permission set/position via the shared held-state vocabulary (#8714)

### DIFF
--- a/.changeset/explain-deactivated-held-state.md
+++ b/.changeset/explain-deactivated-held-state.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/spec": patch
+"@objectstack/plugin-security": patch
+---
+
+feat(security): the explain engine reports a DEACTIVATED permission set / position as a held-but-not-resolving contributor state, sharing one vocabulary with the ADR-0091 expired state (#8714)
+
+ADR-0091 validity windows and the ADR-0049 `active` switch are structural
+siblings — both resolution-time, fail-closed filters that can make a grant a
+user visibly held yesterday stop resolving today. The explain engine narrated
+only one of them: an expired grant reported "held until … — expired", while a
+deactivated permission set or position simply vanished from
+`layers[].contributors[]`, answering exactly like a grant that never existed.
+Deactivation is an incident-response, installation-wide control with no date on
+the user's own grant row, so the silence hit precisely where attribution
+matters most.
+
+Per the 2026-08-18 maintainer ruling, the two lifecycle controls now share ONE
+"held but not resolving, because X" vocabulary:
+
+- `@objectstack/spec`: `ExplainLayerSchema.contributors[].state` widens from
+  `['active', 'expired']` to `['active', 'expired', 'deactivated']` — a closed
+  enumeration of reasons, extended only deliberately (an unknown state such as
+  `'suspended'` is still refused, and stays pinned as refused). Widening only:
+  every payload that parsed before parses unchanged.
+- `@objectstack/plugin-security`: the explain-only provenance pass re-reads the
+  grant rows it already walks (`sys_user_position`, direct
+  `sys_user_permission_set` grants at the existing by-id `sys_permission_set`
+  read) and reports a held row whose catalogue entry is switched off as
+  `{ state: 'deactivated', via: 'held — deactivated' }`, judged by the same
+  shared `isRowActive` predicate the resolver enforces with. The resolver's
+  fail-closed dropping is untouched — this is presentation, never aggregation.
+  A row both expired and deactivated reports `expired` (one reason per row,
+  resolver drop order).
+
+Internal (not a public contract): `buildContextForUser`'s context annotation
+`expiredGrants` is replaced by `droppedGrants`, one array whose entries carry
+the same closed reason enumeration (`state: 'expired' | 'deactivated'`) instead
+of a per-cause sibling array.

--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -337,7 +337,11 @@ unscoped `admin_full_access` grant no longer derives `platform_admin`.
 
 The explain engine reports an expired-but-present row as a dedicated
 contributor state ("held until 2026-08-01 — expired"), so "why did access
-disappear" is self-answering. Two authoring lint rules cover seed grants: one
+disappear" is self-answering. The state member is one shared "held but not
+resolving, because X" vocabulary: a closed enumeration of reasons (`expired`
+here; `deactivated` for the ADR-0049 `active` switch below), extended only
+deliberately — every lifecycle control that silently drops a held grant
+answers through the same member rather than growing its own shape. Two authoring lint rules cover seed grants: one
 mirrors D2 — a seed grant whose `valid_until` is already past (or unparseable)
 is dead on arrival (error) — and one mirrors the D3 dual audit: a delegation
 row (`delegated_from`) without `reason` is an error. The first runs on **both**
@@ -386,6 +390,18 @@ place, by the same discipline: **resolution-time filtering, fail-closed**, in
 - Assignments are untouched. `sys_user_position` and
   `sys_user_permission_set` rows stay exactly as they were, and re-activating
   the catalogue row restores every grant it carried, at the next resolution.
+
+The explain engine reports a deactivated-but-held row with the same dedicated
+contributor state the expired case gets (`state: 'deactivated'`, "held —
+deactivated") — the shared vocabulary above. This matters more here than for
+an expiry: deactivation is an incident-response control, installation-wide,
+and there is no date on the user's own grant row to notice — without the
+state, the admin diagnosing "why did access disappear" would get the same
+answer as for a user who never held the grant, with no pointer to the
+catalogue row somebody switched off. Reported for the grant rows explain
+already walks: `sys_user_position` rows and direct `sys_user_permission_set`
+grants (a deactivated set reached only through an active position's linkage is
+not re-derived — that would replicate the resolver's aggregation).
 
 **Absent is ACTIVE.** Only a stored value that really reads false takes a grant
 away, so a row that predates the column keeps granting. The same predicate

--- a/content/docs/references/security/explain.mdx
+++ b/content/docs/references/security/explain.mdx
@@ -123,7 +123,7 @@ ADR-0095 D2 posture rung — PLATFORM_ADMIN crosses the tenant wall where object
 | **kernelTier** | `Enum<'layer_0_tenant' \| 'layer_1_business'>` | optional | ADR-0095 kernel layer: layer_0_tenant = the always-first org wall; layer_1_business = business RLS/sharing/ownership. |
 | **verdict** | `Enum<'grants' \| 'denies' \| 'narrows' \| 'widens' \| 'neutral' \| 'not_applicable'>` | ✅ |  |
 | **detail** | `string` | ✅ |  |
-| **contributors** | `{ kind: Enum<'permission_set' \| 'position' \| 'system'>; name: string; via?: string; state?: Enum<'active' \| 'expired'> }[]` | optional (default: `[]`) |  |
+| **contributors** | `{ kind: Enum<'permission_set' \| 'position' \| 'system'>; name: string; via?: string; state?: Enum<'active' \| 'expired' \| 'deactivated'> }[]` | optional (default: `[]`) |  |
 | **record** | `{ outcome: Enum<'admitted' \| 'excluded' \| 'not_evaluated'>; rowFilter?: any; matchesRecord?: boolean; rules: object[]; … }` | optional | Row-level determination for the specific record under explanation; set only for record-grained requests. |
 
 

--- a/packages/plugins/plugin-security/src/explain-engine.test.ts
+++ b/packages/plugins/plugin-security/src/explain-engine.test.ts
@@ -186,7 +186,9 @@ describe('explainAccess (ADR-0090 D6)', () => {
       },
     });
     const principal = d.layers.find((l) => l.layer === 'principal')!;
-    const dropped = principal.contributors.filter((c: any) => c.state === 'expired' || c.state === 'deactivated');
+    // `contributors` is the z.input type (defaulted, so optional pre-parse) —
+    // normalize rather than dereference, keeping the test-layer TEST_DEBT flat.
+    const dropped = (principal.contributors ?? []).filter((c) => c.state === 'expired' || c.state === 'deactivated');
     expect(dropped).toEqual([
       { kind: 'permission_set', name: 'quarter_close_admin', via: 'held until 2026-06-01T00:00:00Z — expired', state: 'expired' },
       { kind: 'permission_set', name: 'crm_full', via: 'held — deactivated', state: 'deactivated' },

--- a/packages/plugins/plugin-security/src/explain-engine.test.ts
+++ b/packages/plugins/plugin-security/src/explain-engine.test.ts
@@ -126,7 +126,7 @@ describe('explainAccess (ADR-0090 D6)', () => {
       object: 'leave_request', operation: 'read',
       context: {
         ...CTX,
-        expiredGrants: [{ kind: 'position', name: 'payroll_approver', until: '2026-07-01T00:00:00Z' }],
+        droppedGrants: [{ kind: 'position', name: 'payroll_approver', state: 'expired', until: '2026-07-01T00:00:00Z' }],
       },
     });
     const principal = d.layers.find((l) => l.layer === 'principal')!;
@@ -140,6 +140,59 @@ describe('explainAccess (ADR-0090 D6)', () => {
     });
     // Expired grants contribute nothing to the resolved principal itself.
     expect(d.principal.positions).not.toContain('payroll_approver');
+  });
+
+  it('surfaces deactivated grants in the principal layer with the shared held-state vocabulary (ADR-0049 / #8714)', async () => {
+    const d = await explainAccess(makeDeps(), {
+      object: 'leave_request', operation: 'read',
+      context: {
+        ...CTX,
+        droppedGrants: [
+          { kind: 'permission_set', name: 'crm_full', state: 'deactivated' },
+          { kind: 'position', name: 'field_auditor', state: 'deactivated' },
+        ],
+      },
+    });
+    const principal = d.layers.find((l) => l.layer === 'principal')!;
+    expect(principal.detail).toContain('DEACTIVATED');
+    expect(principal.detail).toContain('crm_full');
+    expect(principal.detail).toContain('field_auditor');
+    expect(principal.contributors).toContainEqual({
+      kind: 'permission_set',
+      name: 'crm_full',
+      via: 'held — deactivated',
+      state: 'deactivated',
+    });
+    expect(principal.contributors).toContainEqual({
+      kind: 'position',
+      name: 'field_auditor',
+      via: 'held — deactivated',
+      state: 'deactivated',
+    });
+    // Deactivated grants contribute nothing to the resolved principal itself.
+    expect(d.principal.permissionSets).not.toContain('crm_full');
+    expect(d.principal.positions).not.toContain('field_auditor');
+  });
+
+  it('expired and deactivated rows share ONE vocabulary — both states appear side by side in one principal layer (#8714)', async () => {
+    const d = await explainAccess(makeDeps(), {
+      object: 'leave_request', operation: 'read',
+      context: {
+        ...CTX,
+        droppedGrants: [
+          { kind: 'permission_set', name: 'quarter_close_admin', state: 'expired', until: '2026-06-01T00:00:00Z' },
+          { kind: 'permission_set', name: 'crm_full', state: 'deactivated' },
+        ],
+      },
+    });
+    const principal = d.layers.find((l) => l.layer === 'principal')!;
+    const dropped = principal.contributors.filter((c: any) => c.state === 'expired' || c.state === 'deactivated');
+    expect(dropped).toEqual([
+      { kind: 'permission_set', name: 'quarter_close_admin', via: 'held until 2026-06-01T00:00:00Z — expired', state: 'expired' },
+      { kind: 'permission_set', name: 'crm_full', via: 'held — deactivated', state: 'deactivated' },
+    ]);
+    expect(principal.detail).toContain('EXPIRED');
+    expect(principal.detail).toContain('DEACTIVATED');
   });
 
   it('attributes a delegated position "via delegation from X until Y" in the principal layer (ADR-0091 D3)', async () => {
@@ -659,7 +712,7 @@ describe('buildContextForUser', () => {
       // memberships. This fixture serves no `sys_member` rows, so it is empty,
       // which fails the `group` wall closed.
       accessible_org_ids: [],
-      expiredGrants: [],
+      droppedGrants: [],
       delegatedPositions: [],
       hasPlatformAdminGrant: false,
     });
@@ -699,10 +752,80 @@ describe('buildContextForUser', () => {
     const ctx = await buildContextForUser(qlWindowed, 'u2', NOW);
     expect(ctx.positions).toEqual(['hr_specialist', 'everyone']);
     expect(ctx.permissions).toEqual(['payroll_reader']);
-    expect(ctx.expiredGrants).toEqual([
-      { kind: 'position', name: 'payroll_approver', until: '2026-07-01T00:00:00Z' },
-      { kind: 'permission_set', name: 'quarter_close_admin', until: '2026-06-01T00:00:00Z' },
+    expect(ctx.droppedGrants).toEqual([
+      { kind: 'position', name: 'payroll_approver', state: 'expired', until: '2026-07-01T00:00:00Z' },
+      { kind: 'permission_set', name: 'quarter_close_admin', state: 'expired', until: '2026-06-01T00:00:00Z' },
     ]);
+  });
+
+  // [#8714 / ADR-0049] The second reason of the shared held-state vocabulary:
+  // the catalogue row's `active` switch. The resolver drops these rows
+  // fail-closed (#8613); the provenance pass re-reads them so the panel can say
+  // "held — deactivated" instead of answering like the grant never existed.
+  it('reports a directly-granted permission set whose catalogue row is deactivated (ADR-0049 / #8714)', async () => {
+    const qlDeactivated = makeGrantQl({
+      sys_user_permission_set: [
+        { user_id: 'u2', permission_set_id: 'ps1' },
+        { user_id: 'u2', permission_set_id: 'psOff' },
+      ],
+      sys_permission_set: [
+        { id: 'ps1', name: 'payroll_reader' },
+        { id: 'psOff', name: 'crm_full', active: false },
+      ],
+    });
+    const ctx = await buildContextForUser(qlDeactivated, 'u2', NOW);
+    // The resolver's fail-closed dropping is untouched…
+    expect(ctx.permissions).toEqual(['payroll_reader']);
+    // …and the dropped row is REPORTED, with the deactivated reason.
+    expect(ctx.droppedGrants).toEqual([
+      { kind: 'permission_set', name: 'crm_full', state: 'deactivated' },
+    ]);
+  });
+
+  it('reports a held position whose sys_position row is deactivated — including the 0/1 storage shape (ADR-0049 / #8714)', async () => {
+    const qlDeactivated = makeGrantQl({
+      sys_user_position: [
+        { user_id: 'u2', position: 'hr_specialist' },
+        { user_id: 'u2', position: 'field_auditor' },
+      ],
+      // 0 is what the primary driver hands back for a stored false — the
+      // shared isRowActive predicate reads it as deactivated (#8613).
+      sys_position: [
+        { id: 'pos_hr', name: 'hr_specialist' },
+        { id: 'pos_fa', name: 'field_auditor', active: 0 },
+      ],
+    });
+    const ctx = await buildContextForUser(qlDeactivated, 'u2', NOW);
+    expect(ctx.positions).toEqual(['hr_specialist', 'everyone']);
+    expect(ctx.droppedGrants).toEqual([
+      { kind: 'position', name: 'field_auditor', state: 'deactivated' },
+    ]);
+  });
+
+  it('a row both expired AND deactivated reports expired — one reason per row, resolver drop order (#8714)', async () => {
+    const qlBoth = makeGrantQl({
+      sys_user_permission_set: [
+        { user_id: 'u2', permission_set_id: 'psOff', valid_until: '2026-06-01T00:00:00Z' },
+      ],
+      sys_permission_set: [{ id: 'psOff', name: 'crm_full', active: false }],
+    });
+    const ctx = await buildContextForUser(qlBoth, 'u2', NOW);
+    expect(ctx.droppedGrants).toEqual([
+      { kind: 'permission_set', name: 'crm_full', state: 'expired', until: '2026-06-01T00:00:00Z' },
+    ]);
+  });
+
+  it('an absent `active` column keeps granting and is NOT reported — absent is ACTIVE (ADR-0049)', async () => {
+    const qlAbsent = makeGrantQl({
+      sys_user_position: [{ user_id: 'u2', position: 'hr_specialist' }],
+      sys_position: [{ id: 'pos_hr', name: 'hr_specialist' }],
+      sys_user_permission_set: [{ user_id: 'u2', permission_set_id: 'ps1' }],
+      sys_permission_set: [{ id: 'ps1', name: 'payroll_reader' }],
+    });
+    const ctx = await buildContextForUser(qlAbsent, 'u2', NOW);
+    expect(ctx.positions).toEqual(['hr_specialist', 'everyone']);
+    expect(ctx.permissions).toEqual(['payroll_reader']);
+    expect(ctx.droppedGrants).toEqual([]);
   });
 });
 
@@ -895,9 +1018,19 @@ describe('buildContextForUser ↔ resolveUserAuthzGrants parity (#6352)', () => 
         { user_id: 'u2', position: 'hr_specialist' },
         { user_id: 'u2', position: 'approver', delegated_from: 'u_boss', valid_until: '2026-07-20T00:00:00Z' },
         { user_id: 'u2', position: 'payroll_approver', valid_until: '2026-07-01T00:00:00Z' },
+        // [#8714] a held position whose catalogue row is switched off
+        { user_id: 'u2', position: 'field_auditor' },
       ],
-      sys_user_permission_set: [{ user_id: 'u2', permission_set_id: 'ps2', valid_until: '2026-06-01T00:00:00Z' }],
-      sys_permission_set: [{ id: 'ps2', name: 'quarter_close_admin' }],
+      sys_position: [{ id: 'pos_fa', name: 'field_auditor', active: false }],
+      sys_user_permission_set: [
+        { user_id: 'u2', permission_set_id: 'ps2', valid_until: '2026-06-01T00:00:00Z' },
+        // [#8714] a held direct grant whose SET's catalogue row is switched off
+        { user_id: 'u2', permission_set_id: 'psOff' },
+      ],
+      sys_permission_set: [
+        { id: 'ps2', name: 'quarter_close_admin' },
+        { id: 'psOff', name: 'crm_full', active: false },
+      ],
     };
     const grants = await resolveUserAuthzGrants(makeGrantQl(tables), 'u2', { nowMs: NOW });
     const ctx = await buildContextForUser(makeGrantQl(tables), 'u2', NOW);
@@ -906,16 +1039,20 @@ describe('buildContextForUser ↔ resolveUserAuthzGrants parity (#6352)', () => 
     expect(ctx.delegatedPositions).toEqual([
       { name: 'approver', from: 'u_boss', until: '2026-07-20T00:00:00Z' },
     ]);
-    expect(ctx.expiredGrants).toEqual([
-      { kind: 'position', name: 'payroll_approver', until: '2026-07-01T00:00:00Z' },
-      { kind: 'permission_set', name: 'quarter_close_admin', until: '2026-06-01T00:00:00Z' },
+    expect(ctx.droppedGrants).toEqual([
+      { kind: 'position', name: 'payroll_approver', state: 'expired', until: '2026-07-01T00:00:00Z' },
+      { kind: 'position', name: 'field_auditor', state: 'deactivated' },
+      { kind: 'permission_set', name: 'quarter_close_admin', state: 'expired', until: '2026-06-01T00:00:00Z' },
+      { kind: 'permission_set', name: 'crm_full', state: 'deactivated' },
     ]);
-    // …and the aggregation is still byte-identical to enforcement's. An expired
-    // grant is REPORTED, never RESOLVED.
+    // …and the aggregation is still byte-identical to enforcement's. A dropped
+    // grant (expired OR deactivated) is REPORTED, never RESOLVED.
     expect(ctx.positions).toEqual(grants.positions);
     expect(ctx.permissions).toEqual(grants.permissions);
     expect(ctx.positions).not.toContain('payroll_approver');
+    expect(ctx.positions).not.toContain('field_auditor');
     expect(ctx.permissions).not.toContain('quarter_close_admin');
+    expect(ctx.permissions).not.toContain('crm_full');
   });
 });
 

--- a/packages/plugins/plugin-security/src/explain-engine.ts
+++ b/packages/plugins/plugin-security/src/explain-engine.ts
@@ -22,6 +22,7 @@
 import {
   isGrantActive,
   isGrantExpired,
+  isRowActive,
   derivePosture as deriveAdminPosture,
   resolveUserAuthzGrants,
 } from '@objectstack/core';
@@ -278,13 +279,31 @@ function untilOfGrantRow(r: any): string | undefined {
 }
 
 /**
- * [#6352 / ADR-0091 D2/D3] The explain-ONLY provenance pass: the two annotations
- * the panel prints that the authorization resolver, correctly, throws away.
+ * [#8714] One entry of the shared "held but not resolving, because X"
+ * vocabulary (the internal counterpart of the spec contract's
+ * `contributors[].state`): a grant row the principal HOLDS that the resolver
+ * fail-closed DROPPED, with the closed reason enumeration naming why —
+ * `expired` (ADR-0091 D2 validity window) or `deactivated` (ADR-0049 / #8613
+ * catalogue `active` switch). `until` is the window bound, present only for
+ * the expired reason. One array, one reason discriminant — deliberately NOT a
+ * sibling array per cause (maintainer ruling 2026-08-18).
+ */
+export interface DroppedGrant {
+  kind: 'position' | 'permission_set';
+  name: string;
+  state: 'expired' | 'deactivated';
+  until?: string;
+}
+
+/**
+ * [#6352 / ADR-0091 D2/D3 / #8714] The explain-ONLY provenance pass: the
+ * annotations the panel prints that the authorization resolver, correctly,
+ * throws away.
  *
  * This is presentation, not aggregation. It decides nothing about who is
  * authorized — `resolveUserAuthzGrants` has already decided that, and this pass
  * never feeds `positions` / `permissions` / the `platform_admin` derivation. It
- * only re-reads the same rows to answer two questions the resolver's output
+ * only re-reads the same rows to answer questions the resolver's output
  * cannot express, because the resolver's output is by construction the set of
  * grants that DID resolve:
  *
@@ -292,30 +311,54 @@ function untilOfGrantRow(r: any): string | undefined {
  *    "held until … — expired" instead of silently omitting a grant the admin
  *    knows they granted. This is "why did access DISAPPEAR", and only a dropped
  *    row can answer it.
+ *  - **deactivated** (#8714) — a row whose CATALOGUE entry
+ *    (`sys_permission_set.active` / `sys_position.active`) is switched off
+ *    (ADR-0049 / #8613), so the grant stopped resolving for everyone holding
+ *    it. Deactivation is an incident-response control with no date on the
+ *    user's own grant row, so without this state the set is simply ABSENT and
+ *    explain answers like the grant never existed — the exact silence the
+ *    contributor-attribution feature exists to prevent.
  *  - **delegated** — the `delegated_from` provenance of a row that DID resolve,
  *    so a position can be attributed "via delegation from X, until Y".
  *
- * Both verdicts come from the SAME shared ADR-0091 predicate module the resolver
- * uses (`isGrantActive` / `isGrantExpired`, `@objectstack/core`) — one
- * implementation of the window rule, consulted twice, never re-derived here.
+ * All verdicts come from the SAME shared predicate modules the resolver uses
+ * (`isGrantActive` / `isGrantExpired` for the ADR-0091 window, `isRowActive`
+ * for the ADR-0049 switch — all `@objectstack/core`) — one implementation of
+ * each rule, consulted twice, never re-derived here.
+ *
+ * A row that is BOTH expired and deactivated reports `expired`: the window
+ * verdict is judged on the user's own grant row, the same order the resolver
+ * drops in, and each dropped row carries exactly one reason (closed enum).
+ *
+ * Boundary (the ruling's cheaper sketch, deliberately): deactivation is
+ * re-read for the grants this pass already walks — `sys_user_position` rows
+ * and direct `sys_user_permission_set` grants. A deactivated position held via
+ * role projection, or a deactivated SET reached only through an active
+ * position's `sys_position_permission_set` linkage, is not re-derived here —
+ * that would replicate the resolver's aggregation, which is the design this
+ * pass exists to avoid.
  */
 async function collectGrantProvenance(
   ql: any,
   userId: string,
   nowMs: number,
 ): Promise<{
-  expiredGrants: Array<{ kind: 'position' | 'permission_set'; name: string; until?: string }>;
+  droppedGrants: DroppedGrant[];
   delegatedPositions: Array<{ name: string; from: string; until?: string }>;
 }> {
-  const expiredGrants: Array<{ kind: 'position' | 'permission_set'; name: string; until?: string }> = [];
+  const droppedGrants: DroppedGrant[] = [];
   const delegatedPositions: Array<{ name: string; from: string; until?: string }> = [];
 
   try {
     const rows = await ql.find('sys_user_position', { where: { user_id: userId }, limit: 500, context: SYSTEM_CTX });
+    // Window-ACTIVE position names — held now, so the only thing that can
+    // still drop them is the catalogue `active` switch, checked below.
+    const heldPositionNames = new Set<string>();
     for (const r of Array.isArray(rows) ? rows : []) {
       const p = String((r as any)?.position ?? '');
       if (!p) continue;
       if (isGrantActive(r, nowMs)) {
+        heldPositionNames.add(p);
         const from = (r as any)?.delegated_from;
         if (from != null && from !== '') {
           delegatedPositions.push({ name: p, from: String(from), until: untilOfGrantRow(r) });
@@ -323,33 +366,66 @@ async function collectGrantProvenance(
       } else if (isGrantExpired(r, nowMs)) {
         // Pending (future `valid_from`) rows are inactive but NOT expired — they
         // are not reported, because nothing was lost yet.
-        expiredGrants.push({ kind: 'position', name: p, until: untilOfGrantRow(r) });
+        droppedGrants.push({ kind: 'position', name: p, state: 'expired', until: untilOfGrantRow(r) });
+      }
+    }
+    // [#8714 / ADR-0049] A held position whose `sys_position` catalogue row is
+    // explicitly deactivated was dropped by the resolver (step 6a) — report it
+    // instead of letting it vanish. A name with no row has no flag to read and
+    // is untouched, matching the resolver.
+    if (heldPositionNames.size > 0) {
+      const posRows = await ql.find('sys_position', {
+        where: { name: { $in: Array.from(heldPositionNames) } },
+        limit: heldPositionNames.size,
+        context: SYSTEM_CTX,
+      });
+      for (const row of Array.isArray(posRows) ? posRows : []) {
+        const n = String((row as any)?.name ?? '');
+        if (n && heldPositionNames.has(n) && !isRowActive(row)) {
+          droppedGrants.push({ kind: 'position', name: n, state: 'deactivated' });
+        }
       }
     }
   } catch { /* table unavailable → no provenance to report */ }
 
   try {
     const rows = await ql.find('sys_user_permission_set', { where: { user_id: userId }, limit: 500, context: SYSTEM_CTX });
-    const expiredRows = (Array.isArray(rows) ? rows : []).filter(
-      (g: any) => !isGrantActive(g, nowMs) && isGrantExpired(g, nowMs),
-    );
-    const ids = expiredRows
-      .map((g: any) => g?.permission_set_id ?? g?.permissionSetId)
-      .filter(Boolean);
+    const grantRows = Array.isArray(rows) ? rows : [];
+    const idOf = (g: any) => g?.permission_set_id ?? g?.permissionSetId;
+    const expiredRows = grantRows.filter((g: any) => !isGrantActive(g, nowMs) && isGrantExpired(g, nowMs));
+    // Window-ACTIVE direct grants: resolvable unless the SET's catalogue row is
+    // deactivated — the one remaining reason the resolver drops them (step 6b).
+    const activeRows = grantRows.filter((g: any) => isGrantActive(g, nowMs));
+    const ids = Array.from(new Set([...expiredRows, ...activeRows].map(idOf).filter(Boolean)));
     if (ids.length > 0) {
+      // [#8714] The existing by-id `sys_permission_set` read now serves both
+      // reasons: names for the expired rows, and the ADR-0049 `active` flag for
+      // the held ones — one read, no second query shape.
       const sets = await ql.find('sys_permission_set', { where: { id: { $in: ids } }, limit: ids.length, context: SYSTEM_CTX });
-      const nameById = new Map<string, string>();
+      const rowById = new Map<string, any>();
       for (const s of Array.isArray(sets) ? sets : []) {
-        if ((s as any)?.id && (s as any)?.name) nameById.set(String((s as any).id), String((s as any).name));
+        if ((s as any)?.id) rowById.set(String((s as any).id), s);
       }
       for (const g of expiredRows) {
-        const n = nameById.get(String((g as any)?.permission_set_id ?? (g as any)?.permissionSetId ?? ''));
-        if (n) expiredGrants.push({ kind: 'permission_set', name: n, until: untilOfGrantRow(g) });
+        const s = rowById.get(String(idOf(g) ?? ''));
+        const n = (s as any)?.name;
+        if (n) droppedGrants.push({ kind: 'permission_set', name: String(n), state: 'expired', until: untilOfGrantRow(g) });
+      }
+      const deactivatedNames = new Set<string>();
+      for (const g of activeRows) {
+        const s = rowById.get(String(idOf(g) ?? ''));
+        const n = (s as any)?.name;
+        // Dedupe: several grant rows can point at one deactivated set; the
+        // catalogue-row fact is reported once.
+        if (n && !isRowActive(s)) deactivatedNames.add(String(n));
+      }
+      for (const n of deactivatedNames) {
+        droppedGrants.push({ kind: 'permission_set', name: n, state: 'deactivated' });
       }
     }
   } catch { /* table unavailable → no provenance to report */ }
 
-  return { expiredGrants, delegatedPositions };
+  return { droppedGrants, delegatedPositions };
 }
 
 /**
@@ -376,14 +452,15 @@ async function collectGrantProvenance(
  * did not make. That is the failure mode the panel exists to prevent, so the
  * mirror is gone rather than pinned.
  *
- * What stays explain-side is presentation only, and additive: the expired /
- * delegated row annotations ({@link collectGrantProvenance}), and
- * `hasPlatformAdminGrant`, which is now READ OFF the resolver's own posture
- * verdict instead of being recomputed from the grant rows.
+ * What stays explain-side is presentation only, and additive: the dropped-grant
+ * (expired / deactivated) and delegated row annotations
+ * ({@link collectGrantProvenance}), and `hasPlatformAdminGrant`, which is now
+ * READ OFF the resolver's own posture verdict instead of being recomputed from
+ * the grant rows.
  */
 export async function buildContextForUser(ql: any, userId: string, nowMs: number = Date.now()): Promise<any> {
   const grants = await resolveUserAuthzGrants(ql, userId, { nowMs });
-  const { expiredGrants, delegatedPositions } = await collectGrantProvenance(ql, userId, nowMs);
+  const { droppedGrants, delegatedPositions } = await collectGrantProvenance(ql, userId, nowMs);
   return {
     userId,
     positions: grants.positions,
@@ -394,7 +471,7 @@ export async function buildContextForUser(ql: any, userId: string, nowMs: number
     ...(grants.tabPermissions ? { tabPermissions: grants.tabPermissions } : {}),
     ...(grants.email != null ? { email: grants.email } : {}),
     ...(grants.posture ? { posture: grants.posture } : {}),
-    expiredGrants,
+    droppedGrants,
     delegatedPositions,
     // [ADR-0068 D2] Not a second derivation: `derivePosture` returns
     // PLATFORM_ADMIN if and only if the resolver saw the unscoped
@@ -914,11 +991,15 @@ export async function explainAccess(deps: ExplainEngineDeps, input: ExplainInput
     if ((context?.permissions ?? []).includes(name)) return 'direct grant';
     return 'resolved';
   };
-  // [ADR-0091 D2] Expired-but-present grant rows (populated by
-  // buildContextForUser when explaining by userId). They contributed nothing —
-  // reported so "why did access disappear" is self-answering.
-  const expiredGrants: Array<{ kind: 'position' | 'permission_set'; name: string; until?: string }> =
-    Array.isArray(context?.expiredGrants) ? context.expiredGrants : [];
+  // [ADR-0091 D2 / ADR-0049 / #8714] Held-but-dropped grant rows (populated by
+  // buildContextForUser when explaining by userId): present, but contributing
+  // nothing, each carrying the closed reason enumeration (`expired` |
+  // `deactivated`) — reported so "why did access disappear" is self-answering
+  // for BOTH lifecycle controls, in ONE shared vocabulary.
+  const droppedGrants: DroppedGrant[] =
+    Array.isArray(context?.droppedGrants) ? context.droppedGrants : [];
+  const expiredGrants = droppedGrants.filter((g) => g.state === 'expired');
+  const deactivatedGrants = droppedGrants.filter((g) => g.state === 'deactivated');
   // [ADR-0091 D3] Positions held via delegation — attributed "via delegation
   // from X, until Y" so a delegated hat is visible in the report.
   const delegatedPositions: Array<{ name: string; from: string; until?: string }> =
@@ -945,6 +1026,11 @@ export async function explainAccess(deps: ExplainEngineDeps, input: ExplainInput
         ? ` ${expiredGrants.length} grant(s) present but EXPIRED (ADR-0091): [${expiredGrants
             .map((g) => `${g.name}${g.until ? ` until ${g.until}` : ''}`)
             .join(', ')}] — contributing nothing.`
+        : '') +
+      (deactivatedGrants.length > 0
+        ? ` ${deactivatedGrants.length} grant(s) present but DEACTIVATED (ADR-0049): [${deactivatedGrants
+            .map((g) => g.name)
+            .join(', ')}] — the catalogue row is switched off, contributing nothing until re-activated.`
         : ''),
     contributors: [
       ...positions.map((p) => {
@@ -954,11 +1040,15 @@ export async function explainAccess(deps: ExplainEngineDeps, input: ExplainInput
           : { kind: 'position' as const, name: p };
       }),
       ...setNames.map((n) => ({ kind: 'permission_set' as const, name: n, via: viaOf(n) })),
-      ...expiredGrants.map((g) => ({
+      // [#8714] One shared "held but not resolving, because X" vocabulary for
+      // every dropped row — the state member IS the reason, closed enum.
+      ...droppedGrants.map((g) => ({
         kind: g.kind,
         name: g.name,
-        via: g.until ? `held until ${g.until} — expired` : 'expired',
-        state: 'expired' as const,
+        via: g.state === 'expired'
+          ? (g.until ? `held until ${g.until} — expired` : 'expired')
+          : 'held — deactivated',
+        state: g.state,
       })),
     ],
   });

--- a/packages/spec/src/security/explain.test.ts
+++ b/packages/spec/src/security/explain.test.ts
@@ -74,12 +74,17 @@ describe('ExplainLayerSchema — the ten-layer pipeline + contributor shape', ()
         { kind: 'position', name: 'approver', via: 'delegation from u_boss until 2026-08-01', state: 'active' },
         { kind: 'permission_set', name: 'approve_set', via: 'position:approver' },
         { kind: 'position', name: 'payroll_approver', via: 'held until 2026-07-01 — expired', state: 'expired' },
+        // [#8714 / ADR-0049] the second member of the shared held-state
+        // vocabulary: the catalogue row is switched off.
+        { kind: 'permission_set', name: 'crm_full', via: 'held — deactivated', state: 'deactivated' },
         { kind: 'system', name: 'platform_admin' },
       ],
     });
-    expect(full.contributors.map((c) => c.kind)).toEqual(['position', 'permission_set', 'position', 'system']);
+    expect(full.contributors.map((c) => c.kind)).toEqual(['position', 'permission_set', 'position', 'permission_set', 'system']);
     // [ADR-0091 D2] the lifecycle state member L3 reads for the "expired" report
     expect(full.contributors[2].state).toBe('expired');
+    // [#8714 / ADR-0049] the shared vocabulary's deactivated member
+    expect(full.contributors[3].state).toBe('deactivated');
     expect(full.contributors[1].state).toBeUndefined();
   });
 
@@ -88,6 +93,10 @@ describe('ExplainLayerSchema — the ten-layer pipeline + contributor shape', ()
       layer: 'principal', verdict: 'neutral', detail: 'x',
       contributors: [{ kind: 'role', name: 'x' }],
     })).toThrow();
+    // [#8714] `suspended` is deliberately a STILL-UNKNOWN value: it proves the
+    // reason enumeration stays CLOSED (extended only deliberately), not merely
+    // widened. If a future lifecycle control legitimately adds `suspended`,
+    // replace this pin with another unknown value in the same edit.
     expect(() => ExplainLayerSchema.parse({
       layer: 'principal', verdict: 'neutral', detail: 'x',
       contributors: [{ kind: 'position', name: 'x', state: 'suspended' }],

--- a/packages/spec/src/security/explain.zod.ts
+++ b/packages/spec/src/security/explain.zod.ts
@@ -196,12 +196,23 @@ export const ExplainLayerSchema = lazySchema(() => z.object({
     /** How the contributor reached the principal (e.g. `position:sales_rep`, `baseline`, `everyone`). */
     via: z.string().optional(),
     /**
-     * [ADR-0091 D2] Grant-lifecycle state. Omitted/`active` = contributing
-     * normally; `expired` = the grant row exists but is OUTSIDE its
-     * `[valid_from, valid_until)` window, so it contributed NOTHING — reported
-     * so "why did access disappear" is self-answering ("held until … — expired").
+     * Grant-lifecycle state — ONE shared "held but not resolving, because X"
+     * vocabulary for every lifecycle control that can silently take a held
+     * grant out of resolution (#8714). Omitted/`active` = contributing
+     * normally; the other members mean the row EXISTS but contributed
+     * NOTHING, and name why, so "why did access disappear" is self-answering:
+     *
+     *  - `expired` — [ADR-0091 D2] the grant row is OUTSIDE its
+     *    `[valid_from, valid_until)` window ("held until … — expired").
+     *  - `deactivated` — [ADR-0049 / #8613] the catalogue row itself
+     *    (`sys_permission_set.active` / `sys_position.active`) is switched
+     *    off, so the grant stopped resolving for EVERYONE holding it.
+     *
+     * This is a CLOSED enumeration of reasons, extended only deliberately
+     * (maintainer ruling 2026-08-18) — a new lifecycle control joins this
+     * enum rather than growing a second per-cause shape or a sibling array.
      */
-    state: z.enum(['active', 'expired']).optional(),
+    state: z.enum(['active', 'expired', 'deactivated']).optional(),
   })).default([]),
   /**
    * [C2] Per-record attribution — present only when the request carried a


### PR DESCRIPTION
Fixes #8714

## What

Implements the 2026-08-18 maintainer ruling (「其他接受你的建议」, comment 5334876108): the explain engine gains a contributor state for a **deactivated permission set / position**, sharing ONE "held but not resolving, because X" vocabulary with the ADR-0091 expired state — a closed enumeration of reasons (`expired`, `deactivated`), extended only deliberately, not a second per-cause shape and not a sibling array. One atomic PR spanning spec + plugin-security per the triage designation (comment 5345619143), so the contract never carries a producer-less enum member.

## Contract (`packages/spec`)

- `ExplainLayerSchema.contributors[].state` widens from two members (`active`, `expired`) to three (`active`, `expired`, `deactivated`), with the doc comment rewritten as the shared held-state vocabulary (ADR-0091 D2 for `expired`, ADR-0049 / #8613 for `deactivated`).
- `explain.test.ts`: the accept pin gains a `deactivated` contributor; the reject pin **keeps `'suspended'` as a still-unknown value** (the triage-designated closure condition), so the enumeration stays provably closed rather than merely widened.
- Accept-set widening only: every payload that parsed before parses unchanged.
- `content/docs/references/security/explain.mdx` regenerated (`check:generated` proved exactly this artifact stale; `--fix` regenerated only it).

## Producer (`packages/plugins/plugin-security`)

The ruling's cheaper sketch: the explain-only provenance pass (`collectGrantProvenance`) re-reads the grant rows it already walks, and the resolver's fail-closed dropping stays untouched.

- Direct `sys_user_permission_set` grants: the existing by-id `sys_permission_set` read now serves both reasons — names for expired rows, the ADR-0049 `active` flag for held rows. A held grant whose set row is explicitly deactivated is reported `state: 'deactivated'`, `via: 'held — deactivated'`.
- `sys_user_position` rows: window-active position names are checked against their `sys_position` catalogue rows (one additional read in the explain-by-userId path); an explicitly deactivated one is reported the same way. Both cases the ruling covers — sets and positions — are produced.
- Deactivation is judged by the same shared `isRowActive` predicate the resolver enforces with (`@objectstack/core`) — one implementation, consulted twice, never re-derived.
- A row both expired and deactivated reports `expired` — one reason per row, matching the resolver's drop order (window filter first).
- The principal layer's `detail` gains a DEACTIVATED sentence beside the existing EXPIRED one.
- Internal plumbing: the context annotation `expiredGrants` is replaced by `droppedGrants` — one array whose entries carry the closed reason enum instead of growing a per-cause sibling array. Consumer sweep (repo-wide grep): all consumers live in `explain-engine.ts` + its test; the objectui explain panel imports the spec types and renders contributors without discriminating `state`, so it degrades gracefully until the pin moves.

**Deliberate boundary (documented in code + docs):** deactivation is re-read for the grants the provenance pass already walks. A deactivated position held only via role projection, or a deactivated SET reached only through an active position's `sys_position_permission_set` linkage, is not re-derived — that would replicate the resolver's aggregation, which is the design the ruling's sketch avoids.

## Docs

`content/docs/permissions/authorization.mdx`: the expired-state paragraph now names the shared closed vocabulary; the ADR-0049 `active`-switch section gains the deactivated-reporting paragraph, including the boundary above.

## Verification

- **@objectstack/spec**: full suite green — 414 files / 11036 tests. Typecheck green.
- **@objectstack/plugin-security**: full suite green — 66 files / 1301 tests, including new cases (deactivated direct-grant set; deactivated position incl. the 0/1 storage shape; expired+deactivated precedence; absent-`active`-is-ACTIVE non-report; both states side by side). Typecheck green.
- **qa/dogfood**: full suite green — 121 files passed, 1 skipped / 880 tests passed, 3 skipped — includes the ADR-0056 D10 authz-conformance ledger (its `permission-set-active` / `position-active` rows cite enforcement sites only; no fixture consumes the new state).
- **Reverse verification** (fix committed first, direction predicted in advance): restoring the two-member enum from origin/main and rebuilding spec turned the producer arm RED (TS2322 at explain-engine.ts, `state` not assignable) and the spec accept pin RED (1 failed / 28 passed); restoring the fix and rebuilding returned both green (tsc exit 0; 29/29) — proving the rebuilt `.d.ts` is what was read.
- 30+ gate families run locally, all green — including `check:generated` (after the one proved-stale regen), `check:dev-prereqs` (after a full build), `check:i18n`, `check:authz-resolver`, `check:cross-package-test-inputs`, docs-audit, spec-liveness family, engine-double-contract, where-matcher, changeset gates.

The `needs:contract-review` gate is expected to fire on the `packages/spec/src/**` path limb — that is correct behavior for this clause-② card.

_Generated by [Claude Code](https://claude.ai/code/session_01URCaKuNTuK3BKJvwqM74QU)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01URCaKuNTuK3BKJvwqM74QU)_