### PR TITLE
docs(lint): record that the Template version-time rewriter comment's scheduling gap closed, and correct its picomatch version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -533,29 +533,52 @@ jobs:
       - name: Docs image-tag version-time rewriter self-test
         run: pnpm check:docs-image-tag-sync
 
-      # #9348 — the same treatment for the OTHER version-time rewriter, and the
-      # scheduling gap that made it necessary after #9648 already added a vitest
-      # file which runs the CLI. `create-objectstack#test` is reachable only from
-      # ci.yml's `test` job, which is gated on the `core` paths-filter; `core` is
-      # `packages/**`, `examples/**`, `apps/!(docs)/**`, `package.json`,
-      # `pnpm-lock.yaml`, `tsconfig.json`, `.github/workflows/ci.yml` and matches
-      # no path under `scripts/`. Measured with picomatch 4.0.5 (the matcher
-      # dorny/paths-filter uses): a diff confined to
-      # scripts/sync-template-versions.mjs yields core=false, so Test Core is
-      # skipped ENTIRELY on the PR that changes the rewriter, and with it the
-      # vitest. The two layers that look like they cover it do not: `turbo ls
-      # --affected` returns ZERO packages for that diff (a package-local edit
-      # returns 1, so the probe is live) — turbo.json's `$TURBO_ROOT$` entry
-      # moves the task HASH, which is what stops a cached green on the merge
-      # queue, not what schedules the job — and the `--union-into` step that DOES
-      # pull create-objectstack back in is a step inside the skipped job. The
-      # queue build catches it, one merge late, as batch collateral; that is the
-      # failure shape check-cross-package-test-inputs.mjs's own ledger records
-      # twice.
+      # #9348 — the same treatment for the OTHER version-time rewriter, argued
+      # there from two measured gaps after #9648 had already added a vitest file
+      # which runs the CLI. GAP 1 has since closed; it is recorded here rather
+      # than deleted, so the next reader does not re-derive a conclusion the
+      # workflow no longer supports.
       #
-      # This workflow carries no paths filter and no filter job, so this step
-      # runs on every pull request, push and merge-queue build. That is the whole
-      # reason the flag exists rather than more cases in the vitest file.
+      # GAP 1 — SCHEDULING. CLOSED by #9829 / #10014. The original claim:
+      # `create-objectstack#test` is reachable, at PR time, only from ci.yml's
+      # `test` job; that job was gated on the `core` paths-filter ALONE; and
+      # `core` — `packages/**`, `examples/**`, `apps/!(docs)/**`,
+      # `package.json`, `pnpm-lock.yaml`, `tsconfig.json`,
+      # `.github/workflows/ci.yml` — matches no path under `scripts/`, so a diff
+      # confined to scripts/sync-template-versions.mjs skipped Test Core
+      # ENTIRELY, and the vitest with it. `core` is still false on that diff — it
+      # was never widened — but the `test` job now ORs in a SECOND filter output,
+      # `scripts: ['scripts/**']`, which matches, so
+      # `if: ... (core != 'false' || scripts != 'false')` resolves to RUN.
+      # Re-measured against the merged filter with picomatch 2.3.1 — the version
+      # dorny/paths-filter@v4's own package-lock.json resolves, NOT this repo's
+      # 4.0.5, which is what the old text cited; the two agree on these globs, so
+      # the wrong figure never produced a wrong verdict — `core=false`,
+      # `scripts=true`. With the job running the rest of the chain follows:
+      # `--union-into` is a step inside it, so it runs and unions
+      # create-objectstack back in off its declared globs; `create-objectstack#test`
+      # declares
+      # `$TURBO_ROOT$/scripts/sync-template-versions.mjs` in turbo.json, so the
+      # task hash moves and no cached green is replayed. PR CI is the first
+      # signal now, not the queue build one merge later.
+      #
+      # Two halves of that argument are UNCHANGED, and they are why `--union-into`
+      # has to exist at all: `turbo ls --affected` returns ZERO packages for that
+      # diff (a package-local edit returns 1, so the probe is live), and the
+      # `$TURBO_ROOT$` entry moves the task HASH, which is what stops a cached
+      # green — a different thing from scheduling the job. Unchanged too is the
+      # failure SHAPE the retired sentence pointed at — the merge queue as first
+      # signal, one merge late, as batch collateral — which
+      # check-cross-package-test-inputs.mjs's own ledger records twice. It is
+      # simply no longer what happens to a diff confined to this rewriter.
+      #
+      # GAP 2 — THE RED PATHS. Open, and it carries this step alone now. This
+      # workflow still carries no paths filter and no filter job, so the step
+      # runs on every pull request, push and merge-queue build, unconditionally,
+      # where the vitest's scheduling now rides a chain (filter output, then the
+      # union's declaration, then the task hash). That is robustness; it is no
+      # longer the reason the flag exists. The reason is that the cases below are
+      # executed nowhere else.
       #
       # Only the --self-test runs here, for the same reason as the step above:
       # the rewriter has nothing to do on a green corpus. The cases are scoped to


### PR DESCRIPTION
Fixes #10045

`.github/workflows/lint.yml`'s comment above the `Template version-time rewriter self-test` step was the second near-verbatim carrier of the claim that a diff confined to `scripts/sync-template-versions.mjs` yields `core=false`, so `Test Core` is skipped entirely and the vitest never runs. The `test` job now ORs a second paths-filter output into its `if:`, so the scheduling half of that claim is retired. It is **recorded** here, with the mechanism attached, rather than deleted — a deleted paragraph leaves no trace that the question was settled.

**Comment prose only, and proved so mechanically.** Every changed line in the diff is a `#` comment:

```
$ git diff -U0 origin/main -- .github/workflows/lint.yml \
    | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -cvE '^[+-]      #'
0
```

## Structural proof that nothing but the comment moved

`lint.yml` carries every `check:*` gate, including the required context `Lint & Repo Gates` (job key `lint:`, whose `name:` is what the ruleset matches). Both versions were parsed with the `yaml` package (2.9.0, the repo's own) and compared on job ids, every job `name:`, `runs-on`, `needs`, `if`, `timeout-minutes`, `permissions`, `env`, `strategy`, step counts, and every step's `name`/`uses`/`run`/`if`/`with`/`env`/`id`/`shell`/`working-directory`/`continue-on-error`:

```
job ids   before: lint, typecheck
job ids   after : lint, typecheck
job lint      name="Lint & Repo Gates" -> "Lint & Repo Gates"  steps 70 -> 70  runs 67 -> 67  uses 3 -> 3
job typecheck name="TypeScript Type Check" -> "TypeScript Type Check"  steps 44 -> 44  runs 39 -> 39  uses 5 -> 5

parsed-shape sha256/16  before: 2d5048dd42a4bc45
parsed-shape sha256/16  after : 2d5048dd42a4bc45

PARSED SHAPES IDENTICAL: true
required context `Lint & Repo Gates` present in both: true
```

The parsed executable surface is byte-identical on both sides, so the required context is untouched. `pnpm check:required-contexts` agrees independently: `6 required context name(s) pinned across 2 workflow(s)`.

## The claim graded sentence by sentence

The two carriers are near-verbatim but not identical, so each sentence of *this* one was graded separately rather than rewritten as a block.

| sentence in the old comment | verdict | evidence |
| --- | --- | --- |
| ``create-objectstack#test`` is reachable only from ci.yml's `test` job | **true, narrowed** | true at PR time. `rerun-safety-nightly.yml` also runs `turbo run test` over everything, but it is `schedule` + `workflow_dispatch` only. The rewrite says "at PR time". |
| that job "is gated on the `core` paths-filter" | **newly false** | `if: ${{ !cancelled() && (needs.filter.outputs.core != 'false' \|\| needs.filter.outputs.scripts != 'false') }}` |
| `core` is `packages/**`, `examples/**`, `apps/!(docs)/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig.json`, `.github/workflows/ci.yml` and matches no path under `scripts/` | **still true** | measured below; `core` was never widened |
| "picomatch 4.0.5 (the matcher `dorny/paths-filter` uses)" | **false figure, correct verdict** | the action resolves **2.3.1**; see below |
| a diff confined to `scripts/sync-template-versions.mjs` yields `core=false` | **still true** | measured below |
| "so Test Core is skipped ENTIRELY … and with it the vitest" | **newly false** | `scripts` matches, so the `if:` resolves to RUN |
| `turbo ls --affected` returns ZERO packages for that diff (a package-local edit returns 1) | **still true** | re-measured below, both legs |
| `$TURBO_ROOT$` moves the task HASH, "not what schedules the job" | **still true** | re-measured below |
| "the `--union-into` step … is a step inside the skipped job" | **newly false** | the job is no longer skipped; the step runs and does pull `create-objectstack` back in |
| "The queue build catches it, one merge late, as batch collateral" | **newly false** | PR CI is the first signal now |
| "; that is the failure shape `check-cross-package-test-inputs.mjs`'s own ledger records twice" | **still true** | a historical record, unaffected: the ledger's two entries are PR #8742 (queue build 31825946401) and PR #8983, "dequeued the PR and took two unrelated PRs down as batch collateral" |

The last two are one sentence in the original, joined by a semicolon, and they grade differently. The consolation half is retired; the ledger citation is still right and is kept — a paragraph rewritten as a block would have lost it.

### The filter, re-measured

Filters parsed out of `.github/workflows/ci.yml` rather than transcribed, and matched the way `dorny/paths-filter@v4`'s `createRuleItem` does — `picomatch(pattern, {dot: true}, true)`, patterns OR-ed with `some()`:

```
uses: dorny/paths-filter@v4   id: changes

== picomatch 2.3.1 (dorny/paths-filter@v4 lockfile) · changed file: scripts/sync-template-versions.mjs ==
  docs     => false
  core     => false
  console  => false
  scripts  => true   (MATCH scripts/**)

== picomatch 4.0.5 (this repo tree) · changed file: scripts/sync-template-versions.mjs ==
  docs     => false
  core     => false
  console  => false
  scripts  => true   (MATCH scripts/**)
```

### The picomatch version

Read from the action's own committed lockfile at the `v4` ref, not taken on trust from the card or the sibling PR:

```
$ curl -sS https://raw.githubusercontent.com/dorny/paths-filter/v4/package-lock.json
lockfileVersion: 3 | name: paths-filter | version: 1.0.0
{"path":"node_modules/@types/picomatch","version":"2.3.3","dev":true,...}
{"path":"node_modules/picomatch","version":"2.3.1","dev":false,...}
dependencies.picomatch = ^2.3.1
devDependencies.picomatch = undefined
```

**2.3.1**, a runtime (non-`dev`) dependency; **4.0.5** is this repo's tree copy. The two agree on these globs — both tables above are identical — so the wrong figure never produced a wrong verdict, but the parenthetical asserted the action's behaviour while quoting a version the action does not carry.

### The rest of the chain, measured link by link

The job running is necessary, not sufficient, so the links between "job runs" and "the vitest executes" were measured rather than assumed (turbo 2.10.10):

```
$ TURBO_SCM_BASE=HEAD pnpm exec turbo ls --affected --output=json    # scripts/-only edit
affected packages: 0 []

$ TURBO_SCM_BASE=HEAD pnpm exec turbo ls --affected --output=json    # package-local edit (liveness control)
affected packages: 1 ["create-objectstack"]

$ node scripts/check-cross-package-test-inputs.mjs --union-into turbo-ls.json --changed changed-files.txt
Cross-package scans pulled into this run because the diff touched their declared inputs:
  + @objectstack/spec  (declared glob matched scripts/sync-template-versions.mjs)
  + create-objectstack  (declared glob matched scripts/sync-template-versions.mjs)

$ pnpm exec turbo run test --filter=create-objectstack --dry=json   # create-objectstack#test hash
HEAD hash:      fdb9dd70563b8fb5
edited hash:    2509c3c0a22a8f9d      # one line appended to scripts/sync-template-versions.mjs
restored hash:  fdb9dd70563b8fb5      # after `git checkout HEAD --` that path
```

`changed-files.txt` above holds exactly one line, `scripts/sync-template-versions.mjs`. The hash returning to its original value is also the byte-identity proof for the restore, so the tree these numbers describe is the committed one.

## What this means for the step (the question the card asked separately)

**The step's remaining justification is GAP 2, and it is intact — the scheduling argument no longer carries it.** Every input that can break this rewriter now schedules `Test Core`: the script itself matches `scripts/**`, and the template corpus lives under `packages/create-objectstack/`, which matches `core`'s `packages/**`. So GAP 1 is closed for this step exactly as it is for the sibling.

What is left is coverage, and it is real. The self-test's controls are executed nowhere else — its own pass line enumerates them:

```
$ pnpm check:template-version-sync
✓ sync-template-versions --self-test: 40 assertions over temp fixtures, running the real CLI. A CLEAN
corpus is observed REACHED, byte-identical and UNWRITTEN; a missing stamp, a missing file, an
unparseable package.json, a template with no @objectstack/* dependency and an empty templates
directory are each observed exiting 1 and naming the path; and one run is observed naming EVERY
unstamped surface. The STALE -> rewritten direction and the discovery walk belong to
packages/create-objectstack/src/template-version-stamps.test.ts and are deliberately not restated here.
```

`packages/create-objectstack/src/template-version-stamps.test.ts` asserts import-safety, the export surface, the throwing version read, the entry-point guard, and four `stampedPaths()` properties — none of the eight controls above. Deleting the step would delete coverage, so it stays; the comment now says *why* it stays. The one residual scheduling difference is stated as robustness rather than as the reason: this workflow has no paths filter at all, where the vitest's scheduling rides a chain (filter output → the union's declaration → the task hash).

## Sweep for other carriers

Swept the whole tree for the claim rather than the filter: `picomatch`, `core=false`, `Test Core` outside ci.yml's own job names, `skipped ENTIRELY`/`skipped in full`, `reachable only from`/`reached only from`, `matches NONE`, `union-into`, `queue build catches`, `one merge late`, `batch collateral`, `first signal`, `outputs.core`, `outputs.scripts`.

**Two carriers, both stale; this PR repairs one:**

- `.github/workflows/lint.yml` — this PR.
- `scripts/sync-template-versions.mjs`'s `GAP 1 — SCHEDULING` header — still stale on `main`. PR #10047 is in flight for it — open, not merged as of this writing, and based on the same `main` sha `2ee7c453b5`. Not touched here: different declared file surface, and different PRs.

Checked and **not** stale, each for its own reason:

- `.github/workflows/ci.yml`'s `scripts:` filter comment — written by the change that closed the gap, phrased in the past tense, and its `picomatch` mention carries no version number.
- `scripts/check-cross-package-test-inputs.mjs`'s header and ledger — about the spec/platform-objects case and about two historical merge-queue incidents; unaffected.
- `.github/workflows/lint.yml` ~1085-1095 and `scripts/check-examples-live-imports.mjs`'s `invisible`-tier blurb — a *different* claim (a package coupled to `examples/**` that `turbo ls --affected` cannot reach), not this one; `examples/**` is inside `core`, so `Test Core` was never skipped for those diffs.
- `.github/workflows/lint.yml` ~1655 — about the `docs` paths-filter not covering `packages/spec/**`; still true (`docs` is `apps/docs/**`, `content/**`, `pnpm-lock.yaml`, `.github/workflows/ci.yml`).
- `packages/spec/scripts/protocol-map.test.ts` — claims only that `Test Core`'s `packages/**` filter has no blind spot for spec changes; true.

No carrier of this claim lives on a governed surface. `.claude/skills/pm-dispatch/references/lanes/cli.md` mentions `Test Core` only in a list of required contexts, which is not this claim.

## No changeset

Comment prose in a workflow file. Nothing user-visible, nothing published.

## Gates

Union re-derived from the real changeset with `node scripts/pm/dispatch-gates.mjs` (no path arguments — the script takes the change set from the merge base itself), then every gate run at the final commit `d169eda16d`:

- `pnpm check:nul-bytes` → `check-nul-bytes: OK (scanned 6358 text file(s) -- 6358 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).`
- `pnpm check:node-version` → `check-node-version: OK (30 setup-node step(s) across 27 workflow(s), all on Node 22).`
- `pnpm check:workflow-status-functions` → `check-workflow-status-functions: OK (scanned 27 workflow file(s), 46 job(s), 24 job-level if: expression(s); 9 read needs.*.outputs.*, all naming a status function).`
- `pnpm check:required-contexts` → `✓ check-required-contexts: 6 required context name(s) pinned across 2 workflow(s); 5 instruction surface(s) scanned against 2 retired name(s) (#9491).`
- `pnpm check:shard-attestation` → `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).`
- `pnpm check:type-check-coverage` → `check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger (436 frozen raw errors), 1 exempt.`
- `pnpm check:type-check-debt` → `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 238.6s, 1924 raw tsc error(s) total, none above its recorded number.` (run with the workspace closure built first, exactly as `lint.yml` does)
- `pnpm check:template-version-sync` → the step this comment sits above; pass line quoted in full above.
- `pnpm check:cross-package-test-inputs` → `All 52 self-test cases passed.` / `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`

Every verdict above is the gate's own printed judgment line, and each gate's exit status was captured before any pipe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_