### PR TITLE
fix(scripts): keep turbo's packages.count true across --union-into, and assert the agreement on read

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1079,6 +1079,26 @@ jobs:
       - name: Cross-package test inputs
         run: pnpm check:cross-package-test-inputs
 
+      # The READING half of the gate above (#10046). `--union-into` appends the
+      # cross-package scans to the `turbo ls` document ci.yml is about to shard,
+      # and `scripts/partition-test-shards.mjs` is the only thing that reads it.
+      # That script asserts the payload shape loudly on purpose — an
+      # experimental-command upgrade should become a red step naming the cause
+      # rather than a silently empty shard — but it had carried a `--self-test`
+      # that NOTHING ran since it was written, so every assertion in it, the
+      # partitioner's determinism and coverage pins included, evaluated never.
+      # A pin nobody runs is not a weaker pin, it is no pin: `--union-into` wrote
+      # a `count: 0` document alongside two items for as long as nobody looked,
+      # and the reader-side refusal that now catches that needs a live pin of its
+      # own or it rots the same way.
+      # Invoked as `node` rather than through a `pnpm check:*` alias for the same
+      # reason as the release-rehearsal self-test above: that alias belongs in
+      # root package.json, declared territory of the @changesets/cli v3 lane
+      # (#9465) while it runs. dispatch-gates.mjs derives gate families from
+      # either spelling. Pure functions, no IO, milliseconds.
+      - name: Shard partitioner self-test
+        run: node scripts/partition-test-shards.mjs --self-test
+
       # The inventory of `packages/**` tests coupled to `examples/**` (#8754).
       # Sibling of the gate above, on the axis it cannot see: that one detects
       # tests whose FILESYSTEM READS escape their package, this one detects

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -1010,6 +1010,27 @@ function expectedInputs(globs) {
 }
 
 /**
+ * `turbo ls --output=json` emits `packages.count` beside `packages.items`, and
+ * keeps the two equal -- measured on turbo 2.10.10, all of the bare, `--filter`
+ * and `--affected` forms agree. So `count` is TURBO's field, not this script's
+ * invention, and a document we have appended to is a valid `turbo ls` payload
+ * only while the count moves with the array.
+ *
+ * Nothing reads `count` today, which is exactly what makes it cheap to keep
+ * true and expensive to leave stale: the consumer is partition-test-shards.mjs,
+ * whose stated posture is to assert this payload's shape LOUDLY so an
+ * experimental-command upgrade becomes a red step naming the cause rather than
+ * a silently empty shard. A hand-mutated document that contradicts itself about
+ * its own size is the input to that assertion. The reader now checks the
+ * agreement (`readPackageItems()` there), so this is a checked invariant across
+ * the two scripts rather than a convention someone has to remember.
+ */
+function reconcilePackageCount(packages) {
+  packages.count = packages.items.length;
+  return packages;
+}
+
+/**
  * Layer A. Adds any declaring package whose globs the diff touches to the
  * package list ci.yml is about to shard, so the scan runs on the PR that
  * actually changed its inputs.
@@ -1045,6 +1066,11 @@ function unionInto(listPath, changedPath) {
     items.push({ name, path: join(REPO_ROOT, dir) });
     added.push(`${name}  (declared glob matched ${hit})`);
   }
+  // The push above changed the list's size, so the size the document DECLARES
+  // has to move with it -- see reconcilePackageCount(). Unconditional rather
+  // than `if (added.length)`: the invariant is a property of the document we
+  // write, not of whether this particular run had anything to add.
+  reconcilePackageCount(parsed.packages);
   writeFileSync(listPath, JSON.stringify(parsed));
   if (added.length) {
     console.log('Cross-package scans pulled into this run because the diff touched their declared inputs:');
@@ -1370,6 +1396,16 @@ function selfTest() {
   ok('but it DOES cover that directory as a listing', coversDirectory('packages/lint/src', ['packages/lint/src/**']));
   ok('a single-file glob does not cover the directory it sits in', !coversDirectory('scripts', ['scripts/check-nul-bytes.mjs']));
   ok('a directory that does not exist is covered by nothing', !coversDirectory('scripts/no-such-dir-9763', ['**']));
+
+  // `--union-into`'s output document. `packages.count` is turbo's field and the
+  // append changes the size it describes, so the two are one operation -- these
+  // pin the half of the cross-script invariant this side owns (the reader's
+  // half is partition-test-shards.mjs `--self-test`).
+  const counted = (packages) => reconcilePackageCount(packages).count;
+  ok('count follows an appended item', counted({ count: 0, items: [{ name: 'a', path: 'p' }, { name: 'b', path: 'q' }] }) === 2);
+  ok('a correct count is left correct', counted({ count: 1, items: [{ name: 'a', path: 'p' }] }) === 1);
+  ok('count follows an empty list down', counted({ count: 7, items: [] }) === 0);
+  ok('the reconciliation never invents items', reconcilePackageCount({ count: 0, items: [] }).items.length === 0);
 
   const failed = cases.filter((c) => !c.cond);
   for (const c of cases) console.log(`${c.cond ? 'ok  ' : 'FAIL'} ${c.label}`);

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -1024,10 +1024,17 @@ function expectedInputs(globs) {
  * its own size is the input to that assertion. The reader now checks the
  * agreement (`readPackageItems()` there), so this is a checked invariant across
  * the two scripts rather than a convention someone has to remember.
+ *
+ * Reconciling inside the SERIALIZER rather than as a statement beside the write
+ * is the point: `unionInto()` has exactly one `writeFileSync`, and it has no
+ * other source of bytes, so "appended to `items` but forgot to move `count`" is
+ * not a state this script can reach. A separate `reconcile(); write();` pair
+ * would have re-created the original defect the first time someone added a
+ * second write path.
  */
-function reconcilePackageCount(packages) {
-  packages.count = packages.items.length;
-  return packages;
+function serializePackageList(parsed) {
+  parsed.packages.count = parsed.packages.items.length;
+  return JSON.stringify(parsed);
 }
 
 /**
@@ -1067,11 +1074,9 @@ function unionInto(listPath, changedPath) {
     added.push(`${name}  (declared glob matched ${hit})`);
   }
   // The push above changed the list's size, so the size the document DECLARES
-  // has to move with it -- see reconcilePackageCount(). Unconditional rather
-  // than `if (added.length)`: the invariant is a property of the document we
-  // write, not of whether this particular run had anything to add.
-  reconcilePackageCount(parsed.packages);
-  writeFileSync(listPath, JSON.stringify(parsed));
+  // moves with it -- serializePackageList() is the only way this function turns
+  // `parsed` into bytes, precisely so that cannot be skipped.
+  writeFileSync(listPath, serializePackageList(parsed));
   if (added.length) {
     console.log('Cross-package scans pulled into this run because the diff touched their declared inputs:');
     for (const a of added) console.log(`  + ${a}`);
@@ -1401,11 +1406,15 @@ function selfTest() {
   // append changes the size it describes, so the two are one operation -- these
   // pin the half of the cross-script invariant this side owns (the reader's
   // half is partition-test-shards.mjs `--self-test`).
-  const counted = (packages) => reconcilePackageCount(packages).count;
-  ok('count follows an appended item', counted({ count: 0, items: [{ name: 'a', path: 'p' }, { name: 'b', path: 'q' }] }) === 2);
-  ok('a correct count is left correct', counted({ count: 1, items: [{ name: 'a', path: 'p' }] }) === 1);
-  ok('count follows an empty list down', counted({ count: 7, items: [] }) === 0);
-  ok('the reconciliation never invents items', reconcilePackageCount({ count: 0, items: [] }).items.length === 0);
+  // These run the real serializer -- the one and only source of the bytes
+  // `unionInto()` writes -- and assert on the parsed-back document, so they pin
+  // what lands on disk rather than an intermediate object.
+  const written = (packages) => JSON.parse(serializePackageList({ packageManager: 'pnpm9', packages })).packages;
+  ok('count follows an appended item', written({ count: 0, items: [{ name: 'a', path: 'p' }, { name: 'b', path: 'q' }] }).count === 2);
+  ok('a correct count is left correct', written({ count: 1, items: [{ name: 'a', path: 'p' }] }).count === 1);
+  ok('count follows an empty list down', written({ count: 7, items: [] }).count === 0);
+  ok('the write never invents items', written({ count: 0, items: [] }).items.length === 0);
+  ok('the write leaves turbo\'s other fields alone', JSON.parse(serializePackageList({ packageManager: 'pnpm9', packages: { count: 0, items: [] } })).packageManager === 'pnpm9');
 
   const failed = cases.filter((c) => !c.cond);
   for (const c of cases) console.log(`${c.cond ? 'ok  ' : 'FAIL'} ${c.label}`);

--- a/scripts/partition-test-shards.mjs
+++ b/scripts/partition-test-shards.mjs
@@ -28,8 +28,9 @@
 //   node scripts/partition-test-shards.mjs --self-test
 //
 // <turbo-ls.json> is the output of `turbo ls [--affected] --output=json`
-// (shape: {packages:{items:[{name,path}]}}; `turbo ls` is marked experimental,
-// so the shape is asserted loudly below rather than defaulted around).
+// (shape: {packages:{count,items:[{name,path}]}}; `turbo ls` is marked
+// experimental, so the payload is asserted loudly in readPackageItems() below
+// rather than defaulted around).
 // Prints the selected shard's package names, one per line -- possibly zero
 // lines, which the caller must treat as "nothing to run", NOT as "no filter":
 // a `turbo run test` with no --filter args runs the entire workspace.
@@ -78,6 +79,51 @@ export function partition(items, shardCount) {
   return bins;
 }
 
+// Reads the package list out of a `turbo ls --output=json` payload, asserting
+// two independent properties. They fail for different reasons and both are
+// loud, because the failure this whole file guards against is the quiet one --
+// a shard that tested nothing and went green.
+//
+//   SHAPE -- `packages.items` must be an array. `turbo ls` is experimental, so
+//            an upgrade that renames or restructures this becomes a red step
+//            naming the cause rather than an empty shard.
+//   SIZE  -- when the payload carries turbo's own `packages.count`, it must
+//            equal `items.length`. turbo never breaks this itself (measured on
+//            2.10.10: the bare, `--filter` and `--affected` forms all agree),
+//            so a payload that DOES has been hand-mutated or truncated between
+//            turbo and here and is not trustworthy about how many packages
+//            this shard is meant to see. There is exactly one such mutator in
+//            this repo -- `--union-into` in check-cross-package-test-inputs.mjs,
+//            which appends the cross-package scans the dependency graph cannot
+//            reach -- and it maintains `count`. This assertion is what makes
+//            that a checked fact instead of a convention: it wrote a `count: 0`
+//            document alongside two items for as long as nobody looked.
+//
+// A payload carrying NO `count` is accepted on purpose. The field is redundant
+// with the array, so its ABSENCE cannot mis-shard anything, while its
+// DISAGREEMENT can; requiring it would turn a turbo upgrade that merely dropped
+// a field nobody reads into a red Test Core on every PR. Note this is a
+// redundancy check, not lenient parsing -- a `count` that is present and wrong
+// is rejected, never repaired.
+export function readPackageItems(parsed, listPath) {
+  const items = parsed?.packages?.items;
+  if (!Array.isArray(items)) {
+    throw new Error(
+      `${listPath}: expected \`turbo ls --output=json\` shape {packages:{items:[...]}} -- ` +
+        'did an experimental-command upgrade change the output?'
+    );
+  }
+  const count = parsed.packages.count;
+  if (count !== undefined && count !== items.length) {
+    throw new Error(
+      `${listPath}: packages.count is ${JSON.stringify(count)} but packages.items holds ` +
+        `${items.length} -- the payload contradicts itself about its own size, so it has ` +
+        'been hand-mutated or truncated since `turbo ls` wrote it. Refusing to shard it.'
+    );
+  }
+  return items;
+}
+
 function selfTest() {
   const mk = (name, weight) => ({ name, weight });
   // Coverage + determinism: every package lands in exactly one bin, and two
@@ -101,6 +147,32 @@ function selfTest() {
   if (empty.some((bin) => bin.names.length > 0)) throw new Error('empty input produced packages');
   const sparse = partition([mk('only', 5)], 3);
   if (sparse.flatMap((bin) => bin.names).join() !== 'only') throw new Error('sparse input lost the package');
+
+  // Payload assertions. The document reaching this script has two writers --
+  // `turbo ls` and `--union-into` in check-cross-package-test-inputs.mjs -- so
+  // "count agrees with items" is a cross-script invariant; this is its reading
+  // half (the writing half is that script's own `--self-test`).
+  const threw = (fn) => {
+    try {
+      fn();
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  const doc = (packages) => ({ packageManager: 'pnpm9', packages });
+  const two = [{ name: 'a', path: 'p' }, { name: 'b', path: 'q' }];
+  if (readPackageItems(doc({ count: 2, items: two }), 'f').length !== 2) throw new Error('payload: a consistent list was rejected');
+  if (readPackageItems(doc({ items: two }), 'f').length !== 2) throw new Error('payload: a list with no count was rejected');
+  if (readPackageItems(doc({ count: 0, items: [] }), 'f').length !== 0) throw new Error('payload: a legitimately empty list was rejected');
+  // The exact document `--union-into` used to write: two items, count still 0.
+  if (!threw(() => readPackageItems(doc({ count: 0, items: two }), 'f'))) throw new Error('payload: count 0 beside 2 items was accepted');
+  if (!threw(() => readPackageItems(doc({ count: 3, items: two }), 'f'))) throw new Error('payload: an over-count was accepted');
+  if (!threw(() => readPackageItems(doc({ count: '2', items: two }), 'f'))) throw new Error('payload: a non-numeric count was accepted');
+  if (!threw(() => readPackageItems(doc({ count: 2 }), 'f'))) throw new Error('payload: a missing items array was accepted');
+  if (!threw(() => readPackageItems(doc({ count: 0, items: {} }), 'f'))) throw new Error('payload: a non-array items was accepted');
+  if (!threw(() => readPackageItems({}, 'f'))) throw new Error('payload: a document with no packages key was accepted');
+
   console.log('partition-test-shards: self-test OK');
 }
 
@@ -131,13 +203,7 @@ function main() {
   if (shardIndex > shardCount) throw new Error(`--shard ${shardSpec}: index exceeds count`);
 
   const parsed = JSON.parse(readFileSync(listPath, 'utf8'));
-  const items = parsed?.packages?.items;
-  if (!Array.isArray(items)) {
-    throw new Error(
-      `${listPath}: expected \`turbo ls --output=json\` shape {packages:{items:[...]}} -- ` +
-        'did an experimental-command upgrade change the output?'
-    );
-  }
+  const items = readPackageItems(parsed, listPath);
   const weighted = [];
   for (const it of items) {
     if (typeof it?.name !== 'string' || typeof it?.path !== 'string') {


### PR DESCRIPTION
Fixes #10046

`check-cross-package-test-inputs.mjs --union-into` appended to `packages.items` and never touched `packages.count`, so the document it handed to `partition-test-shards.mjs` said `count: 0` while carrying two entries. Reproduced on `20b9a9ce1b` with a changed-file list of exactly `scripts/sync-template-versions.mjs`:

```
packages.count = 0
items.length  = 2
```

Inert today because nothing reads `count` — but the consumer's stated job is to assert this payload's shape *loudly*, so a `turbo ls` upgrade becomes a red step naming the cause rather than a silently empty shard, and it was being fed a document that contradicts itself about its own size.

## Decision: `count` is MAINTAINED, not removed — because it is turbo's field

The card left maintain-vs-remove open, conditional on whose schema `count` belongs to. Measured, not assumed. `turbo ls --output=json` on turbo **2.10.10** emits it, and turbo keeps `count === items.length` in every form:

| invocation | count | items | agree |
|---|---|---|---|
| `turbo ls` | 77 | 77 | yes |
| `turbo ls --filter=@objectstack/spec` | 1 | 1 | yes |
| `turbo ls --affected` | 77 | 77 | yes |

So `count` is not this script's invention and is not ours to delete. Removing it would make our hand-mutated document stop being a valid `turbo ls` payload — the opposite of what the partitioner's assert-the-upstream-shape-loudly posture is for, and it would diverge our documents from real `turbo ls` output on a second axis. The "delete it so a future consumer fails loudly" option assumes the field is ours; it is not.

## Both halves ship together

**Writer** — `serializePackageList()` reconciles `count` with `items.length`, and is the *only* thing that turns the parsed document into bytes. Reconciling inside the serializer rather than as a statement beside the write is deliberate: `unionInto()` has exactly one `writeFileSync` and no other source of bytes, so "appended to `items` but forgot to move `count`" is not a state this script can reach. A `reconcile(); write();` pair would re-create the original defect the first time someone added a second write path.

**Reader** — `readPackageItems()` in `partition-test-shards.mjs` now refuses a payload whose `count` disagrees with `items.length`, naming the contradiction:

```
packages.count is 0 but packages.items holds 2 -- the payload contradicts itself
about its own size, so it has been hand-mutated or truncated since `turbo ls`
wrote it. Refusing to shard it.
```

This is what makes the invariant a *checked* fact across the two scripts rather than a convention someone has to remember. A payload carrying **no** `count` is accepted on purpose: a redundant field's absence cannot mis-shard anything, while its disagreement can, and requiring its presence would turn a turbo upgrade that merely dropped an unread field into a red `Test Core` on every PR. A `count` that is present and wrong is rejected, never repaired.

## The partitioner's `--self-test` was wired to nothing

Called out because it is the one change here beyond the minimal diff, and it is load-bearing for the card's second ruling (a future disagreement must be *caught*, not merely unlikely).

`scripts/partition-test-shards.mjs --self-test` existed but **nothing invoked it** — not `package.json`, not any workflow. Every assertion in it evaluated never, the partitioner's pre-existing determinism, coverage and balance pins included. Adding reader-side pins to an unrun self-test would have been adding dead code, and the issue explicitly asked for a pin that "would keep it from rotting back" — which an unrun pin cannot do.

It is now a step in `Lint & Repo Gates`, invoked as `node …  --self-test` rather than through a `pnpm check:*` alias, matching the release-rehearsal self-test step directly above it and for the same stated reason: that alias would belong in root `package.json`, which is declared territory of the @changesets/cli v3 lane (#9465) while it runs. Pure functions, no IO, milliseconds.

## Verification

Gate union re-derived from the real change set with `node scripts/pm/dispatch-gates.mjs` (no paths passed — it reads the merge base itself), run at **`a0b947783d`**, the final commit:

| gate | exit | verdict line |
|---|---|---|
| `check:cross-package-test-inputs` | 0 | `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check:node-version` | 0 | `OK (30 setup-node step(s) across 27 workflow(s), all on Node 22).` |
| `check:required-contexts` | 0 | — |
| `check:shard-attestation` | 0 | — |
| `check:type-check-coverage` | 0 | `OK — 64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger` |
| `check:workflow-status-functions` | 0 | `OK (scanned 27 workflow file(s), 46 job(s), 24 job-level if: expression(s))` |
| `check:nul-bytes` | 0 | `OK (scanned 6358 text file(s) … 0 untracked-not-ignored; skipped 5 binary)` |
| `partition-test-shards.mjs --self-test` | 0 | `partition-test-shards: self-test OK` |
| `check-cross-package-test-inputs.mjs --self-test` | 0 | `All 57 self-test cases passed.` |

Six of those families were **not** in the dispatch list — the `.github/workflows/lint.yml` edit pulled them in, which is why the union was re-derived from the actual diff rather than the brief.

**One declared narrowing:** `check:type-check-debt` exits 1 in this worktree, refusing to `--re-measure` because 55 workspace dependencies have no built `dist/*.d.ts`. It is **not** caused by this branch — the identical refusal reproduces on the unmodified shared `origin/main` checkout with none of this diff present, and this diff touches **zero** TypeScript files (3 files: 2 `.mjs`, 1 workflow YAML). The half of that gate which actually reads `lint.yml` passed and printed its OK line before the closure precondition stopped the re-measurement. Building the full 77-package closure would hold the container's shared heavy-verify lock for ~10 minutes to re-measure a TypeScript debt ledger this change cannot move; CI builds the closure before that step and will run it properly.

### Reverse verification

Both halves ablated from the committed state, each with its direction predicted first, then restored (`git checkout HEAD -- …`, working tree and index confirmed clean via `git status --porcelain`, not `git diff HEAD`). No rebuild leg applies and that is checked rather than assumed: both scripts import only `node:` builtins, run directly as source, are absent from the test-source-alias ledger, and are reached through no package build — there is no `dist/` between the edit and the measurement.

- **Writer ablated** (reconciliation removed): predicted red on exactly 2 of the 5 new cases — the 3 whose count is already correct cannot see a missing assignment. Observed exactly that: `2/57 self-test case(s) failed`, `count follows an appended item` and `count follows an empty list down`. End to end, the document regressed to `count 0 / items 2` and the **reader refused it** (exit 1, 0 packages emitted) — the cross-script guard catching the original defect.
- **Reader ablated** (agreement check removed): predicted red at the first must-throw case, since `selfTest()` throws rather than collecting. Observed `Error: payload: count 0 beside 2 items was accepted`, and the contradictory document was silently accepted again — exit 0, `@objectstack/spec` selected. The pre-fix behaviour, reproduced on demand.

### No package moves between shards

The card fenced this: the change is comment/data-shape only. Old and new partitioner run against the same real 77-package document, all three shards, `--exclude @objectstack/dogfood`:

```
shard 1 OLD/NEW: 23/76 packages, weight 781 (all bins: 781/780/780)  -> IDENTICAL (23 packages)
shard 2 OLD/NEW: 29/76 packages, weight 780 (all bins: 781/780/780)  -> IDENTICAL (29 packages)
shard 3 OLD/NEW: 24/76 packages, weight 780 (all bins: 781/780/780)  -> IDENTICAL (24 packages)
```

All 76 placed packages land on identical shards with identical weights and bin totals. The unioned-document path is likewise unchanged: same shard output before and after the fix (`shard 1/3: 1/2 packages, weight 414`, `@objectstack/spec`).

## Full field audit of the document

Every field, exhaustively (all 77 items share one key set), and whether the union step keeps it true:

| field | writer | union keeps it true? |
|---|---|---|
| `packageManager` | turbo | **yes** — a workspace-level fact, unaffected by appending items (pinned by a self-test case) |
| `packages.count` | turbo | **was NO** — this PR |
| `packages.items` | turbo, appended by union | yes — the append is the intended mutation |
| `packages.items[].name` | turbo, union | yes — same convention |
| `packages.items[].path` | turbo (repo-relative), union (**absolute**) | **no** — filed as #10056 |

No timestamp, no filter echo, no `packageCount` — the document has exactly these five fields.

## Out of scope, filed

- **#10056** — the second field the union writer leaves untrue: it pushes an **absolute** `path` while turbo emits repo-relative ones (0 of 77 turbo entries are absolute). Inert today (identical weights measured from the repo root) but deliberately **not** fixed here: `path` feeds `countTestFiles()` feeds the package weight feeds shard placement, so touching it could move packages between shards — exactly what this card's claim declared it would not do. The correct normalisation is also a genuine judgment call, not a mechanical fix.
- **#10057** — nothing distinguishes "zero packages affected" from "the affected-set computation silently produced nothing": `ci.yml` checks the exit status of `git diff --name-only "$SCM_BASE" HEAD` but never its **emptiness**, and an empty changed-file list on a `pull_request` event is a decidable "selection failed" signal. Reported rather than fixed, per the card. Note the partitioner cannot fix this at its own layer — zero is frequently the correct answer there (a docs-only PR; any run with fewer packages than shards).

Neither is addressed by this PR; #10056 and #10057 both remain open.

## Notes

No changeset: this is `scripts/` and CI tooling and publishes nothing, and `.changeset/**` sits inside the #9465 fence. `skip-changeset` applied accordingly. No governed surface is touched — nothing under `docs/adr/`, `.claude/`, `skills/`, `AGENTS.md` or `CLAUDE.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_