### PR TITLE
docs(scripts): check-role-word's --update moves the baseline in both directions

### DIFF
--- a/scripts/check-role-word.mjs
+++ b/scripts/check-role-word.mjs
@@ -26,9 +26,15 @@
 //   node scripts/check-role-word.mjs [--update]
 //   node scripts/check-role-word.mjs --self-test   # verify the checker's own rules
 //
-// `--update` expands the baseline, which is the shrink-only direction of this
-// ratchet — the NEW-use message marks that path `⛔ MAINTAINER-ONLY` per the
-// #8435 convention, and the self-test holds the marker in place.
+// `--update` rewrites the baseline from the current tree — it never reads the
+// old ledger (see the `update` branch at the bottom) — so it moves whichever
+// way the tree moved: shrinking where the word is gone, EXPANDING where it is
+// new. Only policy tells those apart. The baseline is shrink-only, so
+// ratcheting down is the author's own remedy, while expanding WEAKENS the gate
+// and is a maintainer's call: the NEW-use message marks that path
+// `⛔ MAINTAINER-ONLY` per the #8435 convention, and the self-test holds the
+// marker in place. Both pin the WORDING, not the act — the flag takes either
+// direction from whoever runs it.
 //
 // Scope: content/docs (hand-written; references/ is generated from spec and
 // excluded — the spec source is the fix site there) and skills/. File and


### PR DESCRIPTION
Fixes #10042

The header block of `scripts/check-role-word.mjs` said:

```
// `--update` expands the baseline, which is the shrink-only direction of this
// ratchet — ...
```

Backwards on either reading of the relative clause, but the deeper problem was the
concept: **`--update` has no direction at all.** Repairing only the grammar would have
restated a half-truth more fluently, so this rewrite separates the mechanical fact from
the policy fact.

## The mechanical fact (measured, not inherited)

`--update` rewrites the baseline from the current tree, and **never reads the old
ledger** — the read sits *after* the update branch exits:

```js
const update = process.argv.includes('--update');          // L45

if (update) {                                              // L374
  writeFileSync(BASELINE_PATH, JSON.stringify(current, null, 2) + '\n');
  console.log(updateSummary(scanned, current));
  process.exit(0);                                         // L377 — leaves here
}

const baseline = existsSync(BASELINE_PATH)                 // L380 — never reached
  ? JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
  : {};
```

`current` (L364-372) is a pure function of the tree walk. So the written ledger cannot be
"only add" or "only remove": with no knowledge of the previous contents, it moves
whichever way the tree moved — shrinking where the word is gone, **expanding** where it
is new, in one stroke. PR #10044's reading that this is *also* the baseline-EXPANDING
path is confirmed independently by the code path above.

## The policy fact

Only governance separates the two directions: the baseline is shrink-only, so ratcheting
down is the author's own remedy while expanding weakens the gate and is a maintainer's
call. The new text says that, and says explicitly that the `⛔ MAINTAINER-ONLY` marker is
pinned as **wording, not as an enforced act** — nothing gates running the flag.

## Converged on what this file already says correctly

Per the card's ruling, the new sentence reuses the vocabulary already at two sites here
rather than inventing a third phrasing (line numbers at `origin/main` 20b9a9ce1b):

| site | text |
| --- | --- |
| L64-66, the #8435 block | "`--update`, which expands the baseline. That is a shrink-only ratchet, so taking that path WEAKENS the gate" |
| L128-130, `newUseMessage()` | "The baseline is shrink-only, so this weakens a ratchet and needs a maintainer to agree the boundary is genuine first" |

They agree with each other, and with two further correct sites the card did not name —
the self-test label at L261-263 and the #9910 block at L156-163 ("the same `--update` is
also the baseline-EXPANDING path the #8435 marker above gates"). The header was the only
odd one out of five.

## Verification

Comment prose only — `git diff` contains **zero** changed non-comment lines. No verdict,
population, exit code or message text moves.

Gates re-derived from the real change set and run at **`f2ad79dba3`** (the final commit):

| gate | verdict line |
| --- | --- |
| `check:role-word` (self-test) | `OK  self-test: the NEW-use remedy marks baseline expansion as maintainer-only, ...` |
| `check:role-word` (run) | `check-role-word: OK, no new occurrences of the reserved word.` |
| `check:cross-package-test-inputs` | `OK: 12 package(s) read outside themselves, all declared, ...` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6358 text file(s) ... no raw ASCII control bytes)` |
| `check:ratchet-remedy-authority` (self-test + run) | `OK  check-ratchet-remedy-authority: 97 scripts swept ...; 6 mark the expanding remedy ⛔ MAINTAINER-ONLY` |

The last one is the load-bearing check for a prose edit to a *marked* gate: its `CONTROL`
corpus pins `check-role-word.mjs` as `marked` with set-equality audited both ways. Its
output is **byte-identical before and after** this edit, which is the reverse-verification
result: the sweep's classification does not read this sentence.

`skip-changeset`: this PR changes a comment in a root script. It publishes nothing, and
`.changeset/**` is inside the #9465 epic fence.

## Not touched

Everything PR #10044 settled in this file stays as it is — the `N` generalisation, the
cardinality-identity sentence, the header's legitimate-KINDS rule, and the synthetic
self-test fixtures. On that last point the live scan now reads **216** files
(`content/docs` 180, `skills` 36) while the fixture pins **215** (179 + 36). That gap is
the fixture working exactly as its comment at L295-297 says it should, not drift to
refresh.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_