### PR TITLE
docs(plugin-auth): sweep the stale "@better-auth/sso accepts no `schema` option" claim, re-measured against 1.7.1

### DIFF
--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -2761,10 +2761,11 @@ export class AuthManager {
       // AUTH_SSO_PROVIDER_SCHEMA).
       //
       // That bridge dates from 1.6.20, where @better-auth/sso hardcoded the
-      // model and read no `schema` option. Re-checked against the pinned
-      // 1.7.0-rc.2 (`node_modules/@better-auth/sso/dist`) on 2026-08-12: that is
-      // no longer true — `SSOOptions.schema.ssoProvider` now exists
-      // (index-D1yk91me.d.mts) and the runtime honours `modelName` plus a
+      // model and read no `schema` option. Re-measured against the installed
+      // 1.7.1 (`node_modules/@better-auth/sso/dist`) on 2026-08-19 — the pin
+      // moved off 1.7.0-rc.2, so the previous stamp here had itself expired
+      // (#8224): still no longer true — `SSOOptions.schema.ssoProvider` exists
+      // (index-CZytzKv6.d.mts) and the runtime honours `modelName` plus a
       // per-field `fieldName` map (index.mjs, the plugin's `schema:` block). The
       // adapter-level bridge is kept as-is here because it is what the rest of
       // the auth stack is wired to; whether to move it onto the plugin option is
@@ -2797,9 +2798,14 @@ export class AuthManager {
     // Provider; endpoints mount under /api/v1/auth/scim/v2/{Users,…} (SCIM 2.0)
     // and /api/v1/auth/scim/{generate-token,…} (management). `active:false` →
     // ban + session revoke (needs the admin plugin, forced on above); org-scoped
-    // tokens need the organization plugin. Like @better-auth/sso it hardcodes
-    // its `scimProvider` model (no schema option) — bridged to `sys_scim_provider`
-    // via AUTH_MODEL_TO_PROTOCOL. Toggle with `OS_SCIM_ENABLED`.
+    // tokens need the organization plugin. This plugin hardcodes its
+    // `scimProvider` model and accepts no `schema` option — still true of the
+    // installed 1.7.0-rc.1 (`SCIMOptions` declares no `schema` / `modelName` /
+    // `fields` member; measured 2026-08-19). NOT "like @better-auth/sso", as
+    // this line used to say: sso accepts one as of 1.7.1 (#8224), so scim is now
+    // the only one of the pair for which the adapter bridge is forced. Bridged
+    // to `sys_scim_provider` via AUTH_MODEL_TO_PROTOCOL. Toggle with
+    // `OS_SCIM_ENABLED`.
     //
     // storeSCIMToken: 'hashed' — never persist the bearer in cleartext; the
     // plaintext is returned exactly once from generate-token (for the IdP admin).

--- a/packages/plugins/plugin-auth/src/auth-schema-config.ts
+++ b/packages/plugins/plugin-auth/src/auth-schema-config.ts
@@ -942,11 +942,15 @@ export const AUTH_SSO_PROVIDER_SCHEMA = {
   },
 } as const;
 
-// NOTE: there is intentionally no `buildSsoPluginSchema()`. Unlike
-// `oauthProvider`, the @better-auth/sso plugin exposes NO `schema` option
-// (verified vs 1.6.20), so the mapping above cannot be handed to the plugin —
-// it must be consumed at the ADAPTER layer (AUTH_MODEL_TO_PROTOCOL + field
-// resolution in objectql-adapter.ts). See ADR-0024.
+// NOTE: there is intentionally no `buildSsoPluginSchema()`. The original reason
+// was that the plugin exposed NO `schema` option (true of 1.6.20) — that is no
+// longer why. Measured 2026-08-19 against the installed `@better-auth/sso@1.7.1`:
+// `SSOOptions.schema.ssoProvider.{modelName,fields,additionalFields}` exists and
+// the runtime honours it, so the mapping above COULD be handed to the plugin.
+// It is still consumed at the ADAPTER layer instead (AUTH_MODEL_TO_PROTOCOL +
+// field resolution in objectql-adapter.ts), which is now a deliberate choice
+// about where the bridge lives rather than a limitation of the dependency;
+// revisiting it is the open architecture question on #8224. See ADR-0024.
 
 // ---------------------------------------------------------------------------
 // SCIM plugin – scimProvider table (@better-auth/scim)
@@ -957,10 +961,15 @@ export const AUTH_SSO_PROVIDER_SCHEMA = {
  *
  * Each row is a SCIM connection: a bearer token an external IdP (Okta / Entra)
  * uses to auto-provision / deprovision THIS environment's users — the env is
- * the SCIM Service Provider (ADR-0071). Like `@better-auth/sso`, the plugin
- * hardcodes its model and exposes NO `schema` option, so the mapping is
- * consumed at the ADAPTER layer (AUTH_MODEL_TO_PROTOCOL + field resolution in
- * objectql-adapter.ts), NOT handed to the plugin.
+ * the SCIM Service Provider (ADR-0071). This plugin hardcodes its model and
+ * exposes NO `schema` option — still true of the installed
+ * `@better-auth/scim@1.7.0-rc.1` (`SCIMOptions` declares no `schema` /
+ * `modelName` / `fields` member at all; measured 2026-08-19). It is no longer
+ * true of `@better-auth/sso@1.7.1`, which this doc used to lean on for the
+ * comparison and which now accepts one (#8224). So for scim — and for scim
+ * alone — the ADAPTER layer (AUTH_MODEL_TO_PROTOCOL + field resolution in
+ * objectql-adapter.ts) is the only available route: the mapping cannot be
+ * handed to the plugin.
  *
  * | camelCase (better-auth) | snake_case (ObjectStack) |
  * |:------------------------|:-------------------------|

--- a/packages/plugins/plugin-auth/src/better-auth-schema-parity.test.ts
+++ b/packages/plugins/plugin-auth/src/better-auth-schema-parity.test.ts
@@ -46,8 +46,10 @@
  * `@better-auth/sso` / `@better-auth/scim` are excluded from the call above
  * for a narrower reason than this header used to give. The previous wording —
  * "accept no `schema` option, so `getAuthTables()` cannot see them" — was
- * measured false and is corrected here (#8224). Re-measured 2026-08-18 against
- * the pinned `@better-auth/sso@1.7.0-rc.2` / `@better-auth/scim@1.7.0-rc.1`:
+ * measured false and is corrected here (#8224). Re-measured 2026-08-19 against
+ * the installed `@better-auth/sso@1.7.1` / `@better-auth/scim@1.7.0-rc.1` (the
+ * 2026-08-18 stamp this block carried named `sso@1.7.0-rc.2`, a pin that has
+ * since moved — the very drift this card is about):
  *
  *  - Both DECLARE a schema `getAuthTables()` reads. Passing `sso()` yields the
  *    `ssoProvider` model; `scim({})` yields `scimProvider` plus the four
@@ -244,8 +246,8 @@ const AUTH_MANAGER_PLUGINS: Record<string, { construct: () => unknown } | { skip
       'the auth manager passes it no `schema` option, so getAuthTables() would report its model as '
       + '`ssoProvider` with camelCase columns while the adapter bridge writes `sys_sso_provider` in '
       + 'snake_case — covered by the dedicated sso/scim block below, which reproduces the adapter '
-      + 'rule that governs its writes. NOT because it accepts no schema option: it does, on '
-      + '1.7.0-rc.2 (#8224). See the file header.',
+      + 'rule that governs its writes. NOT because it accepts no schema option: it does, on the '
+      + 'installed 1.7.1 (measured 2026-08-19, #8224). See the file header.',
   },
   scim: {
     skip:

--- a/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
+++ b/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
@@ -173,8 +173,8 @@ interface UnmappedManagedObject {
  * coverage at all, so the reason has to say why that is the right answer for
  * this table rather than an oversight. `managedBy` alone does not mean
  * better-auth's core `getAuthTables()` surface owns the columns — a plugin may
- * be opt-in, ship in its own package, or (for sso/scim) expose no `schema`
- * option this call can read.
+ * be opt-in, ship in its own package, or (for sso/scim) be passed no `schema`
+ * option by the auth manager, leaving this call no mapping to key off.
  */
 const UNMAPPED_MANAGED_OBJECTS: Record<string, UnmappedManagedObject> = {
   sys_api_key: {
@@ -210,21 +210,32 @@ const UNMAPPED_MANAGED_OBJECTS: Record<string, UnmappedManagedObject> = {
   // ── Plugins getAuthTables() cannot ADDRESS as an ObjectStack object (#3653) ─
   // Both plugins are now in the call (#7820), so their models do appear in the
   // derived tables — under better-auth's own names (`ssoProvider`,
-  // `scimProvider`, …). What they accept no `schema` option for is the mapping:
-  // there is no way to tell getAuthTables() that `ssoProvider` materializes as
-  // `sys_sso_provider`, so MODEL_TO_OBJECT cannot key off anything the library
-  // reports and the derivation has nothing to compare against the object.
+  // `scimProvider`, …). The MAPPING is what this call cannot reach: the auth
+  // manager passes neither plugin a `schema` option, so nothing tells
+  // getAuthTables() that `ssoProvider` materializes as `sys_sso_provider`,
+  // MODEL_TO_OBJECT cannot key off anything the library reports, and the
+  // derivation has nothing to compare against the object.
+  //
+  // Note the reason above is about what the auth manager PASSES, not about what
+  // the plugins ACCEPT — the two were conflated here until #8224. Measured
+  // 2026-08-19: `@better-auth/sso@1.7.1` does accept a `schema` option
+  // (`SSOOptions.schema.ssoProvider`), so passing one is a live option rather
+  // than something the dependency forbids; `@better-auth/scim@1.7.0-rc.1` still
+  // accepts none.
   sys_sso_provider: {
     reason:
-      '@better-auth/sso accepts no `schema` option, so getAuthTables() reports its models only under '
-      + "better-auth's own names and they cannot be mapped onto this object (#3653). Its columns are "
+      'The auth manager passes @better-auth/sso no `schema` option, so getAuthTables() reports its '
+      + "models only under better-auth's own names and they cannot be mapped onto this object (#3653). "
+      + '(The plugin DOES accept one as of 1.7.1 — measured 2026-08-19, #8224; it is simply not passed.) '
+      + 'Its columns are '
       + 'bridged mechanically by objectql-adapter.ts and gated by the dedicated sso/scim block in '
       + 'better-auth-schema-parity.test.ts.',
   },
   sys_scim_provider: {
     reason:
-      '@better-auth/scim accepts no `schema` option, so getAuthTables() reports its models only under '
-      + "better-auth's own names and they cannot be mapped onto this object (#3653). Same bridge and "
+      '@better-auth/scim accepts no `schema` option at all (measured 2026-08-19 against the installed '
+      + '1.7.0-rc.1, and the auth manager passes none either), so getAuthTables() reports its models '
+      + "only under better-auth's own names and they cannot be mapped onto this object (#3653). Same bridge and "
       + 'same dedicated gate as sys_sso_provider.',
   },
 

--- a/packages/plugins/plugin-auth/src/objectql-adapter.test.ts
+++ b/packages/plugins/plugin-auth/src/objectql-adapter.test.ts
@@ -302,9 +302,13 @@ describe('createObjectQLAdapter – legacy model name mapping', () => {
   });
 });
 
-describe('createObjectQLAdapterFactory – schema-less plugin bridging (@better-auth/sso)', () => {
-  // The sso plugin exposes no `schema` option, so its `ssoProvider` table +
-  // camelCase fields are bridged at the adapter layer. Pass the plugin so
+describe('createObjectQLAdapterFactory – adapter-layer plugin bridging (@better-auth/sso)', () => {
+  // The auth manager passes the sso plugin no `schema` option, so its
+  // `ssoProvider` table + camelCase fields are bridged at the adapter layer
+  // instead. (Not because the plugin "exposes no `schema` option" — that was
+  // true of 1.6.20 and expired with the pin: measured 2026-08-19, the installed
+  // `@better-auth/sso@1.7.1` accepts `schema.ssoProvider.{modelName,fields,
+  // additionalFields}`. #8224.) Pass the plugin so
   // better-auth's wrapper recognises the model (it validates against the
   // merged schema before delegating to our adapter methods).
   const makeAdapter = (findOneRow: any = { id: '1', provider_id: 'okta', oidc_config: '{"clientId":"x"}', domain: 'acme.com' }) => {

--- a/packages/plugins/plugin-auth/src/objectql-adapter.ts
+++ b/packages/plugins/plugin-auth/src/objectql-adapter.ts
@@ -32,12 +32,26 @@ export const AUTH_MODEL_TO_PROTOCOL: Record<string, string> = {
   session: SystemObjectName.SESSION,
   account: SystemObjectName.ACCOUNT,
   verification: SystemObjectName.VERIFICATION,
-  // Plugin models. `@better-auth/sso` and `@better-auth/scim` both hardcode
-  // their model name and accept NO `schema` option (verified vs 1.6.2x — no
-  // mergeSchema, runtime never reads options.schema), so the table name is
-  // bridged here and `createObjectQLAdapterFactory` (below) auto-maps their
-  // camelCase fields to snake_case (oidcConfig→oidc_config, scimToken→
-  // scim_token, …) on every CRUD op via resolveProtocolName. Off by default
+  // Plugin models, bridged HERE rather than through a plugin `schema` option.
+  // This comment used to justify that with "both hardcode their model name and
+  // accept NO `schema` option (verified vs 1.6.2x)". That expired with the pin
+  // (#8224). Measured 2026-08-19 against the installed `@better-auth/sso@1.7.1`
+  // and `@better-auth/scim@1.7.0-rc.1`:
+  //   - sso DOES accept one now — `SSOOptions.schema.ssoProvider.{modelName,
+  //     fields,additionalFields}` (dist/index-CZytzKv6.d.mts), honoured at
+  //     runtime (dist/index.mjs, the plugin's own `schema:` block: `modelName:
+  //     options?.modelName ?? options?.schema?.ssoProvider?.modelName ??
+  //     'ssoProvider'`, plus a per-field `fieldName` fallback each).
+  //   - scim still accepts none — `SCIMOptions` declares no `schema` /
+  //     `modelName` / `fields` member at all.
+  // What holds for both is narrower and is the actual reason: the auth manager
+  // passes neither plugin a `schema` option, so their models arrive under
+  // better-auth's own names. The table name is bridged here and
+  // `createObjectQLAdapterFactory` (below) auto-maps their camelCase fields to
+  // snake_case (oidcConfig→oidc_config, scimToken→scim_token, …) on every CRUD
+  // op via resolveProtocolName. For scim that is the only available route; for
+  // sso it is now a CHOICE (see #8224 — moving it onto the plugin option is an
+  // open architecture question, deliberately not decided here). Off by default
   // (OS_SSO_ENABLED / OS_SCIM_ENABLED). See ADR-0024 / ADR-0071.
   ssoProvider: 'sys_sso_provider',
   scimProvider: 'sys_scim_provider',
@@ -713,8 +727,10 @@ export function createObjectQLAdapterFactory(rawDataEngine: IDataEngine) {
   // /refresh-token) see the row whole while the generic data API does not.
   // See `internal-field-readback.ts`.
   const internalFieldEngine = rawDataEngine as unknown as InternalFieldResolvingEngine;
-  // Field-name bridging for better-auth plugins that expose NO `schema` option
-  // (e.g. @better-auth/sso): when a model is remapped via AUTH_MODEL_TO_PROTOCOL,
+  // Field-name bridging for better-auth plugins the auth manager passes no
+  // `schema` option (@better-auth/sso, @better-auth/scim — NOT "plugins that
+  // expose no `schema` option": sso accepts one as of 1.7.1, #8224): when a
+  // model is remapped via AUTH_MODEL_TO_PROTOCOL,
   // its camelCase model fields are also converted to snake_case columns on the
   // way in and back to camelCase on the way out. SCOPED by `objectName !== model`
   // so core / schema-declared models are byte-for-byte untouched.


### PR DESCRIPTION
Fixes #8224

One dependency fact — "`@better-auth/sso` accepts NO `schema` option" — was copied into six files and went stale everywhere at once when the pin moved. This sweeps it. **The adapter-level bridge is deliberately untouched**; the architecture question the card also raises is left open (see the bottom of this description).

## Re-measured first, against the installed packages

⛔ No version number in this PR is copied from the issue, its comments, or the dispatch. Every one was read from `node_modules` in this worktree on **2026-08-19**:

| package | installed version |
|:---|:---|
| `better-auth` | **1.7.1** |
| `@better-auth/sso` | **1.7.1** |
| `@better-auth/scim` | **1.7.0-rc.1** |

Independently corroborated by a pnpm store path in the test run's own output: `node_modules/.pnpm/@better-auth+sso@1.7.1_.../node_modules/@better-auth/sso/dist/index.mjs`.

### Fact 1 — `sso` accepts a `schema` option; `scim` still does not

- `@better-auth/sso@1.7.1` declares `SSOOptions.schema.ssoProvider.{modelName,fields,additionalFields}` (`dist/index-CZytzKv6.d.mts` — note the chunk hash differs from the one the issue names, which is itself a reason not to quote it from memory). The runtime honours it in the plugin's own `schema:` block (`dist/index.mjs`): `modelName: options?.modelName ?? options?.schema?.ssoProvider?.modelName ?? "ssoProvider"`, plus a per-field `fieldName` fallback each and a spread of `additionalFields`.
- `@better-auth/scim@1.7.0-rc.1` accepts none. `SCIMOptions` declares no `schema`, `modelName` or `fields` member at all — its eight top-level members are `requiredRole`, `staticProviders`, `mapGroupToRoles`, `linkExistingUsers`, `beforeSCIMTokenGenerated`, `afterSCIMTokenGenerated`, `canGenerateToken`, `storeSCIMToken`.

So the correction is **per-plugin**, and every rewritten site now names the plugin it speaks about.

### Fact 2 — the sentence's second clause was false for BOTH

"so `getAuthTables()` cannot see them" — measured by calling it:

```
getAuthTables({ plugins: [sso()] })   -> ssoProvider
getAuthTables({ plugins: [scim({})] }) -> scimProvider, scimGroup, scimGroupMember,
                                          scimGroupRole, scimGroupRoleGrant
```

Both plugins DECLARE a schema the function reads. **Accepting a `schema` option and declaring a schema are different facts, and the old wording conflated them.** The real reason those models stay outside the parity gate's call is narrower: the auth manager passes them no `schema` option, so they come back under better-auth's own names with camelCase columns. Confirmed end-to-end that the option would change that — passing one flips both halves:

```
sso({ schema: { ssoProvider: { modelName: 'sys_sso_provider',
                               fields: { oidcConfig: 'oidc_config' } } } })
  -> model key=ssoProvider  modelName=sys_sso_provider  fields: oidcConfig->oidc_config
```

That measurement is evidence for the open question below — **it is not acted on in this diff.**

## What changed — 13 sites in 6 files, comments and messages only

`objectql-adapter.ts` ×2 · `auth-schema-config.ts` ×2 · `managed-extension-fields.test.ts` ×4 · `objectql-adapter.test.ts` ×1 · `auth-manager.ts` ×2 · `better-auth-schema-parity.test.ts` ×2.

Every replacement sentence names the version **and** the date it was measured against, so it fails loudly rather than expiring silently — the card's own lesson.

**No executable change in any shipped source file.** Verified mechanically: stripping comment lines from the diff of `auth-manager.ts`, `auth-schema-config.ts` and `objectql-adapter.ts` leaves nothing. The only non-comment change anywhere is one `describe()` title in a test file (`schema-less plugin bridging` is no longer an accurate name for the block, so it now reads `adapter-layer plugin bridging`).

### Three sites beyond the four files the dispatch enumerated — declared, not smuggled

1. **`auth-manager.ts`, sso block** — carried `Re-checked against the pinned 1.7.0-rc.2 … on 2026-08-12` and named `index-D1yk91me.d.mts`. The pin has moved to `^1.7.1` and that chunk file no longer exists, so the site the dispatch offered as *the model for the rest* had itself expired. Re-stamped to the measurement above. Substance unchanged.
2. **`better-auth-schema-parity.test.ts`** — two version stamps only (see the reviewer note below).
3. **⚠️ `auth-manager.ts`, scim block — this one contradicts an explicit instruction, please rule on it.** See below.

## ⚠️ Reviewer: the one place I did not follow the dispatch

The dispatch said, twice and with a ⛔: `auth-manager.ts:2790` is *"the scim-only site — leave it alone"*, because correcting it *"would introduce a new false claim while removing an old one"* — and also said **"re-verify this yourself before trusting it."** I did, and the premise does not hold: the line is not scim-only. It read:

> `// tokens need the organization plugin. Like @better-auth/sso it hardcodes`
> `// its scimProvider model (no schema option) — bridged to sys_scim_provider`

The scim half is **true and preserved** (and now carries the measured version and date). The clause `Like @better-auth/sso` is **false as of 1.7.1** — sso no longer hardcodes its model and no longer refuses a `schema` option. I corrected only that comparative and left the scim fact intact, so this removes a false claim without introducing one, which is what the ⛔'s stated rationale was protecting.

I am flagging rather than assuming: **if you disagree, this is one comment hunk in `auth-manager.ts` and reverts cleanly on its own.** My reasoning for acting is that leaving a live false statement about sso inside the very file offered as the corrected model is the half-swept outcome the card warns about — it would re-open this card.

## Reviewer note — `better-auth-schema-parity.test.ts` vs PR #9693

Confirming the distinction requested: **I did not rewrite or revert anything #9693 corrected.** Both hunks in that file are pure version-stamp refreshes (`2026-08-18` / `sso@1.7.0-rc.2` → `2026-08-19` / `sso@1.7.1`):

- the date+version line inside the file header paragraph — #9693's surrounding prose is untouched;
- the `AUTH_MANAGER_PLUGINS.sso.skip` string's trailing `it does, on 1.7.0-rc.2` stamp.

Left **completely untouched**: the header's three substantive bullets, the second describe block's doc comment, and every executable assertion in that block (`getAuthTables() DOES see them`, the `modelName` / `PLATFORM_OBJECTS` / `oidcConfig` vs `oidc_config` checks). `scim.skip` also untouched — it says `1.7.0-rc.1`, which is still the installed version.

## Verification — all at `c0fe12604`

`pnpm --filter @objectstack/plugin-auth test` → **`Test Files 59 passed (59)` / `Tests 1320 passed (1320)`**. Counts unchanged, as a comment-only sweep should be: mechanically confirmed that no `it(`/`test(` count moved in any changed file (12/12, 23/23, 40/40 vs `origin/main`).

`pnpm --filter @objectstack/plugin-auth typecheck` → `tsc --noEmit`, exit 0.

Gate union re-derived from the ACTUAL diff with `node scripts/pm/dispatch-gates.mjs` (no hand-built path list), then run to completion — quoting each gate's own verdict line:

- `check:slot-lookup` — `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new.`
- `check:test-source-alias` — `check-test-source-alias OK — 72 packages with tests scanned`
- `check:type-source-resolution` — `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned`
- `check-affected-docs.mjs` — exit 0
- `check:query-options-erasure` — `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new.`
- `check:type-check-coverage` — `check-type-check-coverage: OK — 64/77 workspace packages type-checked`
- `check:type-check-debt` — `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 269.0s, 1924 raw tsc error(s) total, none above its recorded number.` **`@objectstack/plugin-auth` holds at exactly 109** — the ledger file is not in this diff.
- `check:engine-double-contract` — `check-engine-double-contract: OK — 325 pinned, 133 in the DEBT ledger, 2 exempt.`
- `check:where-matcher` — `✓ where-matcher conformance holds: 263 matcher(s) discovered`
- `check:nul-bytes` — `check-nul-bytes: OK (scanned 6367 text file(s) … no raw ASCII control bytes).`

The ratchet family was re-run at the final head after the authorship amend; the tree is byte-identical to the pre-amend commit (`git diff` between them is empty).

**Ablation: NOT APPLICABLE.** Nothing executable changed, so there is no guard to mutate and no assertion whose failure could be demonstrated. Inventing one would be theatre.

**No changeset — `skip-changeset`.** The diff is comments, doc strings, assertion messages and one `describe()` title; nothing reaches `dist/` and nothing is user-visible.

## ⛔ Deliberately NOT done — the bridge rewire

Moving the `ssoProvider` → `sys_sso_provider` mapping off `AUTH_MODEL_TO_PROTOCOL` onto the plugin's `schema.ssoProvider` option is **not in this diff**. The card calls it *"a real architectural change"*; triage graded it zero-pull. The restart trigger unlocked re-measurement, not that decision. The measurement above shows the option now *works*, which is exactly why it deserves its own decision card rather than a silent ride-along here. My recommendation is recorded in the dev report on #8224 — briefly: **do not rewire.** It buys no capability (the bridge is exercised and tested), scim would still need the adapter path so the special case does not actually go away, and under startup-scope discipline a working seam is not worth re-plumbing to be prettier.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_