### PR TITLE
docs(pm): add pm:retriage — the awaiting-regrade label coexisting with the standing pm:* state

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -71,13 +71,14 @@ references);② 创建后手动 fire 一轮烟测,判据取**GitHub 上的产出
 
 | issue 上的信号 | 含义 |
 |---|---|
-| open + 队列标签 + **无 assignee** | 可派发 |
+| open + 队列标签 + **无 assignee** | 可派发(同卡带 `pm:retriage` 的除外 —— 异议未决不派) |
 | **assignee 已设** | 已认领/在飞 —— 不是你的就永不碰 |
 | `pm:dispatched` | 已派发(派发评论记轮次);与摘 `pm:queue` **同一次标签写入**成对落地 |
 | `needs-user-decision` | 决定**待做** —— 永不派发、除已裁代裁通道外永不代答;维护者的收件箱 |
 | `pm:on-hold` | 决定**已做**且答案是「不是现在」—— 不派发也不催;**仅当正文带机器可读行 `Restart-when: closed <owner/repo>#N`(由 `Blocked-by:` 的同一遍解锁扫描点火、同一正文单通道)或 `Restart-when: <一行可执行判据>` 时才合法**;hold 评论带日期、理由、出处(维护者裁或座位定级,⛔ 不设第二个标签区分);机会主义重启的触发文件走同族正典行 **`Restart-touch: <仓内相对路径>`**(一行一路径,大小写敏感、行锚定,与 `Blocked-by:`/`Restart-when:` 同一正文单通道;反引号/bullet 可容忍、值须为 tracked 文件)—— 喂半状态巡查 H17 的 on-hold 触发文件索引,抽取器已随巡查落地、采用即零代码;存量 hold ⛔ 不迁移、不产 finding,散文锚词抽取兜底旧卡;**放行双查(两查皆机械、零判断)**:① 只对**最近一次** `pm:on-hold`/`pm:blocked` 转换评论所载条件放行,⛔ 永不对线程里更早的 blocker —— 已放行过的条件是花掉的,再点火就把过期前提立成现行;② 该转换评论之后卡上有**更新的 merged PR** ⇒ 拒绝放行 —— 那是条件写下后卡已前进的信号(引用的事实可以为真而不再是现行条件) |
 | `pm:blocked` + 正文行 `Blocked-by: #N` | 等上游 —— 选择期跳过,#N 关闭时由解锁扫描放回。**工已完、PR 被外部门禁缺陷卡住的卡同用本态,⛔ 不设新标签**:`Blocked-by:` 指向门禁缺陷卡,正文另加机器可读行 `Unlock-action: re-check PR #M` —— 解锁扫描读到它就把解锁动作从「回队重派」换成「重查该 PR 的落地」(回队前提检查见到已完工的 open PR 即按落地工作处理,⛔ 永不给完工卡重派 dev);停放的 PR 正文必须点名门禁卡,让链路从任一端可读、不依赖会被整篇改写的座位贴 |
 | `pm:blocking` | 有 open 下游依赖者(分诊 sweep 自 `Blocked-by:` 索引推导的缓存,⛔ 不手工挂);进选择优先级全序 |
+| `pm:retriage` | 等分诊改判(维护者 2026-08-19/20 裁定:「同意 并存」)—— 与现行 `pm:*` 标签**并存,⛔ 不摘原标**:原定级在改判前仍是权威,并存让「排队但有异议」在列表上可见;挂标者 = 提出异议的席位,挂标与**异议评论同笔**(证据 + 建议定级),无证据评论的裸挂标不合法;摘标者 = 分诊 Routine,每 fire 高优先重判、重判后摘标 —— 挂/摘分属两方、各自的转换不相交,这是本行的安全性;带本标签的 `pm:queue` 卡**跳过派发**(异议未决不派,即可派发行的除外项);标签须四仓存在(分诊四仓统一职责,首次应用时创建);老化兜底归半状态巡查(年龄谓词随巡查另行落地) |
 | `finding` | 观察类记录,恒 = **待首次定级**(定级即离标:晋级换 `pm:queue` / 关闭 / hold 换 `pm:on-hold`;裸标签数即健康读数)—— 不占队列不进收件箱 |
 | `target:<major>` | 发版阻塞 —— 每个 backlog 恰好一个生产者,见「发版板」 |
 | `pm:epic`(父单) | 子树已委托 epic PM(会话与领地在父单正文;`label:pm:epic` 即全量索引)—— 其它 PM 不把其 sub-issue 当候选 |
@@ -107,8 +108,6 @@ references);② 创建后手动 fire 一轮烟测,判据取**GitHub 上的产出
   分,会被兄弟席当误扫重开;同理适用于摘标签、回收认领等不可反推理由的动作。
 - **写后回读按风险定向;标签写恒为硬步骤 read-modify-write + 回读**(维护者 2026-08-18 裁定):① 先取现集 → ② 只增删目标标签 → ③ 写合并集 → ④ 写后回读核验 —— 整组 PUT 写的是本席快照,并发席落在你读与写之间的标签被静默剥掉,受害者常是你没打算碰的那枚;**承载闸门语义的标签**(如 `needs:contract-review`)挂与清两向同此四步,闸门被剥不是红灯是放行,「被剥」与「从未挂过」在证据上不可区分,回读是唯一察觉手段;
   多席可写面恒读回(防竞态覆盖,不只防 sanitizer);正文/评论仅当含尖括号/HTML 注释才读回;「API 返回 200」≠「落地内容正确」。
-
-**一次性建标签**:`bash scripts/pm/ensure-pm-labels.sh`(幂等;退役车道刻意不在脚本里 ⛔ 不加回,理由与对象清理以脚本头为权威)。
 
 ## 平台读数纪律
 
@@ -291,6 +290,7 @@ hold 评论纪律见状态模型,hold 重验只在 `Restart-when:` 命中时发�
 / hold;**判级发生在这里,不在立单时**。车道座位可附证据/前提重验,⛔ 不定级不改标(唯一例外:skills 车
 道 finding 由该席自分诊,全仓轮跳过)。**自动集中轮**(常设授权,维护者 2026-08-13):`finding` >15 ⇒ 下
 一 fire 跑域分批集中轮,sweep 打包晋级五条照用;原话、批量参数与五条细则见 `references/dispatch-runbook.md`。
+**`pm:retriage` 重判每 fire 高优先处理**:按异议评论的证据与建议定级重裁,维持或改判皆由本座位同笔摘标(挂标归异议席,见状态模型)。
 
 **发版板(`target:<major>`;鲜度节奏、清板三选一、pin 前置等运维细则见
 `references/seat-post-protocol.md`)。** 判据二元(⛔ 不做优先级渐变 —— 渐变没人维护):「不修它,
@@ -324,7 +324,7 @@ hold 评论纪律见状态模型,hold 重验只在 `Restart-when:` 命中时发�
 
 **整车道一次读全,本地求交**(维护者 2026-08-11 接受):`list_issues` 带 `labels: [domain:X]` +
 最小字段一次拿回全车道 open 集,各状态本地求交 —— 按单一 pm 状态切片的查询看不见其它状态,是结
-构性盲区。候选 = open、未 assign、无`needs-user-decision`;已排队父单的 open sub-issue 自动是
+构性盲区。候选 = open、未 assign、无`needs-user-decision`、无 `pm:retriage`;已排队父单的 open sub-issue 自动是
 候选(`pm:epic` 父单的子树除外)。**每张候选读全文 + 全部评论**(裁决落在评论区,跳过评论就是跳
 过裁决;评论还可能记着一半工作已交付);**派发前做前提过时检查(stale-premise check)—— 裁决同
 罪**(裁决描述的也是当时的仓,写得权威、日期又近,恰恰更容易被当成现成事实),两半都查:**动作
@@ -676,6 +676,6 @@ grep <branch>`),复升级时逐条**跑**一遍,零命中/变形的就地改写�
 | `scripts/pm/check-governed-merges.mjs` | governed 面合并清单的 report-only 审计(事后防线;轮报载体,本地枚举零 API,仅归因走查询) |
 | `scripts/pm/dispatch-gates.mjs` | 文件面 → 该跑的门禁族(派发令取数) |
 | `scripts/pm/os-regen-merge.sh` | 碰生成物 PR 的 merge 四步序(防静默吞并与锚点倒退) |
-| `scripts/pm/ensure-pm-labels.sh` | pm 标签词表的幂等创建 |
+| `scripts/pm/ensure-pm-labels.sh` | pm 标签词表的幂等一次性创建;退役车道刻意不在 ⛔ 不加回,理由与对象清理以脚本头为权威 |
 | `check:skill-frame-sync` / `-freshness` | 四维决策框架四份拷贝的同构与新鲜度 |
 | `guard-main-checkout` / `guard-shared-stash` hooks | worktree-first 与 stash 禁令的机械面 |


### PR DESCRIPTION
Fixes #10081

## What

Adds the `pm:retriage` awaiting-regrade state to the PM dispatch skill's state model (maintainer ruling 2026-08-19/20, quoted verbatim in the row: 「同意 并存」), as one table row carrying the ruled four parts, plus the matching selection carve-outs and the triage-seat duty sentence.

- **State-model row `pm:retriage`** — the four parts, in the file's table idiom:
  1. Coexistence — carried alongside the standing `pm:*` label, never removes it; the standing grade stays authoritative until triage re-rules; coexistence is what makes "queued but contested" visible on a list.
  2. Producer — the objecting seat; the label write and the objection comment (evidence + proposed grade) are the same stroke; a bare label with no evidence comment is illegal.
  3. Reader + discharge — the triage Routine handles it as a high-priority item each fire and removes the label after re-ruling; producer and discharger are different parties on disjoint transitions (stated in the row as its safety property).
  4. Dispatch discipline — a `pm:queue` card also carrying `pm:retriage` is skipped by selection (contested grades are not dispatched).
- **Dispatchable-row carve-out**: the 「open + 队列标签 + 无 assignee ⇒ 可派发」 row now excepts cards carrying `pm:retriage`.
- **Candidate definition** in 候选与批次 gains the same exclusion (无 `pm:retriage`) — that line is the filter execution seats actually run.
- **分诊座位职责**: one sentence — `pm:retriage` re-ruling is high-priority each fire; the triage seat removes the label in the same stroke as the re-ruling.
- **Cross-repo clause** (in the row): the label must exist in all four repos, created on first application (triage's cross-repo duty). The companion age predicate is another card and is deliberately NOT implemented here; the row points at the half-state patrol generically (no issue numbers — id-lint).

## Line budget (ratchet)

Ceiling 682. Before: 681 (headroom 1). After: 681 (headroom 1) — net 0.

Payment audit: +2 lines (the new table row; the triage-duty sentence) paid by a genuine dedup of −2 lines: the standalone 「一次性建标签」 paragraph duplicated the 机械守卫索引 row for `scripts/pm/ensure-pm-labels.sh`. Each cut fact's surviving home: the script pointer and idempotence → the index row; "retired lanes deliberately absent, never re-add, rationale in the script header" → folded into that same index row. No re-wrap: no prose lines were merged to fund lines.

## Gates (all run at head 4c41ff27, after the final commit; exit codes captured via redirect-then-`$?`, never through a pipe)

- `node scripts/pm/dispatch-gates.mjs` (no args, real diff from merge base): 1 path, 7 local families derived; tier line "Model tier — MANDATORY: claude-fable-5" (clause ①, honored).
- `pnpm check:pm-skill-ratchet` — exit 0 — "✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md is 681 lines (ceiling 682; headroom 1)."
- `pnpm check:pm-skill-id-lint` — exit 0 — "✓ check-skill-id-lint: 15 file(s) clean (pattern /#[0-9]{3,}/g)."
- `pnpm check:pm-governed-prose` — exit 0 — "✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces (docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md) and claim no others."
- `pnpm check:pm-governed-merges` — exit 0 — "✓ check-governed-merges --self-test: 81 assertions …" (self-test + run).
- `pnpm check:skill-frame-sync` — exit 0 — "✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files".
- `pnpm check:doc-authoring` — exit 0 — "✓ doc authoring guard: 379 files clean — no bare metadata literals."
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — exit 0 — "✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 404 files / 1414 TS blocks judged clean by @objectstack/formula." (Required building the dependency closure first: `pnpm --workspace-concurrency=2 --filter '@objectstack/lint^...' build`.)
- `node scripts/check-nul-bytes.mjs` — exit 0 — "check-nul-bytes: OK (scanned 6367 text file(s) … no raw ASCII control bytes)."
- `node scripts/check-skill-compatibility-version.mjs` — exit 0 — "11 pinned major(s) all match the workspace" (named as-applicable; population unaffected by this diff).

## Reverse verification (direction predicted in writing before running)

Predicted: appending 2 filler lines (681 → 683, over ceiling 682) turns `check-skill-line-ratchet` RED with a verdict line naming this file; restoring from the committed branch is byte-identical and turns it green. Observed exactly that: "✗ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md is 683 lines; the ratchet ceiling is 682. …" (exit 1); sha256 identical before mutation and after restore (82b74df4a42b5966…); green at 681 (exit 0). `check:pm-skill-id-lint` stayed green throughout. The gate reads the .md directly via readFileSync — no dist/export resolution is involved, so no rebuild leg applies to this ablation.

## Housekeeping

Docs/protocol-only change to a `.claude/` internal skill — nothing user-visible is published, so `skip-changeset` is applied (union label write with read-back). GOVERNED surface: draft PR, review requested from os-zhuang, left visibly hanging for a human merge — never flipped ready, never queued, never auto-merged.

Known CI flake note: `Lint & Repo Gates` intermittently dies parsing packages/spec/src/migrations/registry.ts on unrelated PRs today; local dispatch-gates families do not run eslint over spec and are unaffected. If that job reds here with the same signature, it is the known flake, not this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_