### PR TITLE
fix(pm): add pm:retriage to the four-repo pm label vocabulary loop

### DIFF
--- a/scripts/pm/ensure-pm-labels.sh
+++ b/scripts/pm/ensure-pm-labels.sh
@@ -53,6 +53,17 @@ for R in objectstack-ai/objectstack objectstack-ai/objectui objectstack-ai/cloud
   # and list-page scans. A hand-set instance is mislabeling — the sweep
   # corrects it against the index.
   gh label create pm:blocking         -R "$R" -c 8250df -d "Derived cache from the Blocked-by reverse index: open card with open dependents — never hand-set" 2>/dev/null || true
+  # pm:retriage COEXISTS with the standing pm:* label and ⛔ never replaces it
+  # (maintainer ruling 2026-08-19/20, 「同意 并存」): the objecting seat sets it in
+  # the same write as its evidence comment, and the triage Routine is the only
+  # remover — hanging and removing belong to two different parties, which is
+  # what makes the state safe. Named consumers: the dispatchable-candidate
+  # query (a pm:queue card carrying it is skipped — objection undecided, no
+  # dispatch) and the triage round's high-priority re-judgement pass. It is in
+  # this four-repo loop because the state-model row requires the label to exist
+  # in all four; where a first application already auto-created the object,
+  # creation here is a no-op that leaves its colour and description untouched.
+  gh label create pm:retriage         -R "$R" -c d4c5f9 -d "Awaiting triage re-judgement — coexists with the standing pm:* label; queued cards skip dispatch" 2>/dev/null || true
   gh label create finding             -R "$R" -c c2e0c6 -d "Recorded observation — held, not dispatchable until the findings triage round grades it" 2>/dev/null || true
   gh label create pm:epic             -R "$R" -c 5319e7 -d "Parent delegated to a dedicated epic PM — other PMs never dispatch into its subtree" 2>/dev/null || true
 done


### PR DESCRIPTION
Fixes #10090

`scripts/pm/ensure-pm-labels.sh` claims in its header that "The label set IS the PM state machine (.claude/skills/pm-dispatch/SKILL.md, 'State model')". The `pm:retriage` row landed in that state model via #10089 without a matching entry here, so the identity claim drifted. One `gh label create` line inside the existing four-repo loop, following the file's idiom.

## The line

- **Placement** — inside the four-repo loop (objectstack, objectui, cloud, objectos), between `pm:blocking` and `finding`, which is where the row sits in SKILL.md's state-model table. The state-model row makes four-repo existence explicit: 「标签须四仓存在(分诊四仓统一职责,首次应用时创建)」.
- **Description** — 96 characters, inside the header's documented 100-character hard cap. The cap is the one thing in this file that fails *silently*: over-cap descriptions 422 and the idempotency `|| true` swallows it, so the label is never created and a rerun cannot repair it. Measured in characters, not bytes — `needs:contract-review` is 97 chars / 101 bytes and lives.
- **Colour `d4c5f9`** — unused by every other label in the file, and adjacent to `pm:blocking`'s purple. Distinctness is load-bearing rather than cosmetic here: the state-model row's stated purpose for coexistence is 「并存让「排队但有异议」在列表上可见」, and a grey label is the least visible choice available.
- **Comment block** — follows the `pm:blocking` / `needs:contract-review` idiom (why the label exists, who sets it, who removes it, its named consumers), citing the maintainer ruling verbatim and untranslated per AGENTS.md Communication.

## Idempotency over the label object that already exists

The `pm:retriage` object already exists on **objectstack** — auto-created when it was first applied (#9756 / #9705), colour `ededed`, empty description. Creation here is create-if-missing, exactly as the `target:` block documents for the same situation: running the script is a **no-op** on objectstack and leaves that object's colour and description exactly as they are. This PR's durable contribution is the other three repos, where the object does not exist yet and today's creation depends on the applying seat remembering to do it by hand.

⚠️ Consequence worth stating rather than hiding: the objectstack object therefore stays grey with no description until someone runs `gh label edit` by hand. Re-colouring an existing object is not this script's job — the file deliberately never calls `label edit` — so this is left as a visible PM landing step, not smuggled in.

## Verification

Gates re-derived from the **real diff** at the final commit `88abe7588`, via `node scripts/pm/dispatch-gates.mjs` with no path arguments (`change set derived from git — 1 path(s) vs merge base 907c11d2c`, `committed 1, working tree 0, untracked 0`). Verdict lines, exit codes captured before any pipe:

- `pnpm check:cross-package-test-inputs` — EXIT=0 — `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `pnpm check:nul-bytes` — EXIT=0 — `check-nul-bytes: OK (scanned 6367 text file(s) -- 6367 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).`
- `bash -n scripts/pm/ensure-pm-labels.sh` — EXIT=0.

**Dry-run harness.** The script has no dry-run or self-test mode, so verification used an out-of-tree harness that puts a fake `gh` on PATH recording every `label create` invocation. With the fix: 48 create calls, `pm:retriage d4c5f9 96c` present once per repo on all four; `DESC-CAP: PASS (every -d <= 100 chars)` across all 48.

**Reverse verification**, direction predicted in writing before running. Prediction: deleting the added line makes the listing lose exactly 4 rows, `TOTAL 48 → 44`, `DESC-CAP` stays PASS, and **no gate reddens** — the drift is silent. Observed exactly that; the diff of the two listings is the four `pm:retriage` rows plus the total. That silence is the point of the card: no mechanical check couples the SKILL.md state model to this script, which is why the drift could land unnoticed in the first place. Restored from the commit and confirmed byte-identical (`sha256 376359c1…`, matching the pre-ablation hash, clean `git diff --exit-code`), and the restored listing is identical to the pre-ablation one.

**What could NOT be verified from this container**, stated plainly: the script's live half. There is no `gh` CLI installed here and no label-write credentials for the four repos, so no label object was created, edited, or read-modified by this run — the only live read was confirming the existing objectstack object's colour and description through the GitHub API. Actually running the script remains a PM landing step, as the header already says for objectos.

## Scope

`scripts/**` only — no changeset (nothing published), hence `skip-changeset`. Not a governed surface.

Out-of-scope findings filed unassigned rather than ridden in here:

- #10098 — `pm:seat` and `priority:p0` are state-model rows with no entry in the loop. Same drift class, deliberately not fixed in this PR: the correct shape (which loop each belongs in, and whether the absence is deliberate) is a judgment no existing evidence pins.
- #10099 — the 100-character description cap is a documented silent-failure mode with no mechanical guard; live headroom is one character on `repo:objectui`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeA3nU1B5Q2pgxqxgUrexd)_