### PR TITLE
fix(plugin-auth): /admin/revoke-user-session refuses (404 RESOURCE_NOT_FOUND) when the token identifies no session

### DIFF
--- a/.changeset/spotty-planes-repeat.md
+++ b/.changeset/spotty-planes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/plugin-auth': patch
+---
+
+`POST /api/v1/auth/admin/revoke-user-session` no longer reports success when it revoked nothing. When the supplied `sessionToken` does not identify any live session — including a session that was already revoked — the endpoint now answers `404` with error code `RESOURCE_NOT_FOUND` (ADR-0112 envelope) instead of `200 { "success": true }` over a delete that removed no record. The refusal is only ever given to callers who pass the admin plugin's own `session: ["revoke"]` permission check; unauthenticated and unauthorized callers keep the previous `401`/`403` answers byte-for-byte, so no session-existence information is exposed below the permission line. A revoke that does identify a live session still answers `200 { "success": true }` and tombstones the session with reason `admin`, unchanged.

--- a/packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.test.ts
+++ b/packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.test.ts
@@ -1,0 +1,391 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #10069 — `POST /admin/revoke-user-session` must not answer success over a
+// delete that dispatched nothing. better-auth 1.7.1's handler calls
+// `deleteSession(ctx.body.sessionToken)` blindly and answers
+// `200 { success: true }` unconditionally — measured on this exact pipeline
+// before the guard existed: a zero-match token AND an already-revoked
+// (tombstoned) token both answered `200 {"success":true}`. The guard in
+// `admin-revoke-user-session-match-guard.ts` refuses those requests with 404
+// `RESOURCE_NOT_FOUND` (ADR-0112: code AND status, never one alone) — but
+// ONLY for callers the vendor's own permission check would admit; everyone
+// else keeps the vendor's exact 401/403 and gains no existence oracle.
+//
+// Real better-auth pipeline throughout, following
+// `revoke-session-match-guard.test.ts`: requests go in as `Request` objects
+// through `AuthManager.handleRequest`, the cookie is the one better-auth
+// minted, and the revoke path is better-auth's own. A stub of our adapter
+// would prove nothing — the whole question is what answer leaves the library.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/objectql';
+import { defaultRoles } from 'better-auth/plugins/admin/access';
+import { AuthManager } from './auth-manager';
+import {
+  ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE,
+  ADMIN_REVOKE_USER_SESSION_NOT_FOUND_MESSAGE,
+  ADMIN_REVOKE_USER_SESSION_PERMISSION,
+  adminMayRevokeUserSessions,
+  anySessionCarriesToken,
+} from './admin-revoke-user-session-match-guard';
+
+/**
+ * In-memory IDataEngine — the `session-tombstone.test.ts` harness, unchanged,
+ * because these tests assert against the same table through the same library
+ * and a second, more forgiving fake would be able to disagree with it. Both
+ * write paths stay pinned to ObjectQL's own dispatch predicates
+ * ({@link assertEngineDeleteDispatch} / {@link assertEngineUpdateDispatch}).
+ */
+const createMemoryEngine = () => {
+  const tables = new Map<string, any[]>();
+  const rows = (name: string) => {
+    if (!tables.has(name)) tables.set(name, []);
+    return tables.get(name)!;
+  };
+  const eq = (a: any, b: any) =>
+    a instanceof Date || b instanceof Date
+      ? new Date(a as any).getTime() === new Date(b as any).getTime()
+      : a === b;
+  const matches = (row: any, where: Record<string, any> = {}) =>
+    Object.entries(where).every(([k, v]) => {
+      if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+      const actual = row[k];
+      if (v && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date)) {
+        if ('$ne' in v) return !eq(actual, v.$ne);
+        if ('$in' in v) return (v.$in as any[]).some((x) => eq(actual, x));
+        if ('$gt' in v) return actual > v.$gt;
+        if ('$gte' in v) return actual >= v.$gte;
+        if ('$lt' in v) return actual < v.$lt;
+        if ('$lte' in v) return actual <= v.$lte;
+        if ('$regex' in v) return new RegExp(String(v.$regex)).test(String(actual ?? ''));
+      }
+      return eq(actual, v);
+    });
+  /** `fields` projection — `id` always survives, as it does in ObjectQL. */
+  const project = (row: any, fields?: string[]) => {
+    if (!Array.isArray(fields) || fields.length === 0) return { ...row };
+    const out: any = {};
+    for (const f of ['id', ...fields]) if (f in row) out[f] = row[f];
+    return out;
+  };
+  let seq = 0;
+  return {
+    tables,
+    async insert(name: string, data: any) {
+      const row = { id: data.id ?? `row_${++seq}`, ...data };
+      rows(name).push(row);
+      return { ...row };
+    },
+    async findOne(name: string, q: any = {}) {
+      const row = rows(name).find((r) => matches(r, q.where));
+      return row ? project(row, q.fields) : null;
+    },
+    async find(name: string, q: any = {}) {
+      let out = rows(name).filter((r) => matches(r, q.where));
+      const order = q.orderBy?.[0];
+      if (order) {
+        out = [...out].sort(
+          (a, b) => (a[order.field] > b[order.field] ? 1 : -1) * (order.order === 'desc' ? -1 : 1),
+        );
+      }
+      if (q.offset) out = out.slice(q.offset);
+      if (q.limit) out = out.slice(0, q.limit);
+      return out.map((r) => project(r, q.fields));
+    },
+    async count(name: string, q: any = {}) {
+      return rows(name).filter((r) => matches(r, q.where)).length;
+    },
+    async update(name: string, patch: any, options?: any) {
+      const dispatch = assertEngineUpdateDispatch(patch, options);
+      if (dispatch.kind === 'multi') {
+        const hit = rows(name).filter((r) => matches(r, options?.where));
+        for (const row of hit) Object.assign(row, patch);
+        return hit.length;
+      }
+      const row = rows(name).find((r) => r.id === dispatch.id);
+      if (!row) return null;
+      Object.assign(row, patch);
+      return { ...row };
+    },
+    async delete(name: string, q: any = {}) {
+      assertEngineDeleteDispatch(q);
+      const table = rows(name);
+      const keep = table.filter((r) => !matches(r, q.where));
+      tables.set(name, keep);
+      return table.length - keep.length;
+    },
+  };
+};
+
+const SECRET = 'test-secret-at-least-32-chars-long!!';
+const PASSWORD = 'S3cure!Passw0rd-10069';
+const BASE = 'http://localhost:3000/api/v1/auth';
+
+const makeManager = (engine: any) =>
+  new AuthManager({
+    secret: SECRET,
+    baseUrl: 'http://localhost:3000',
+    dataEngine: engine,
+    // The route under test lives on better-auth's `admin` plugin (opt-in here).
+    plugins: { admin: true },
+  } as any);
+
+const post = (manager: AuthManager, path: string, cookie?: string, body?: unknown) =>
+  manager.handleRequest(
+    new Request(`${BASE}/${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(cookie ? { cookie } : {}),
+      },
+      body: JSON.stringify(body ?? {}),
+    }),
+  );
+
+const signUp = (manager: AuthManager, email: string) =>
+  post(manager, 'sign-up/email', undefined, { email, password: PASSWORD, name: 'AdminRevoke' });
+
+const signIn = (manager: AuthManager, email: string) =>
+  post(manager, 'sign-in/email', undefined, { email, password: PASSWORD });
+
+const getSession = (manager: AuthManager, cookie: string) =>
+  manager.handleRequest(
+    new Request('http://localhost:3000/api/v1/auth/get-session', { headers: { cookie } }),
+  );
+
+const cookieFrom = (response: Response): string =>
+  (response.headers.getSetCookie?.() ?? [response.headers.get('set-cookie') ?? ''])
+    .map((c) => c.split(';')[0])
+    .filter(Boolean)
+    .join('; ');
+
+/**
+ * Is this cookie still authenticated? better-auth answers `/get-session` with
+ * HTTP 200 and a JSON `null` body when the session is gone — NOT a 401 — so a
+ * status-only assertion would pass against a fully revoked session.
+ */
+const isAuthenticated = async (manager: AuthManager, cookie: string): Promise<boolean> => {
+  const res = await getSession(manager, cookie);
+  if (res.status !== 200) return false;
+  const body = await res.json().catch(() => null);
+  return Boolean((body as any)?.user?.id);
+};
+
+const userRows = (engine: any) => (engine.tables.get('sys_user') ?? []) as any[];
+const sessionRows = (engine: any) => (engine.tables.get('sys_session') ?? []) as any[];
+
+/**
+ * better-auth's admin plugin authorizes on the `user.role` scalar (vendor
+ * default `adminRoles: ['admin']`). Written straight onto the seeded row, the
+ * way `impersonation-bearer-rotation.test.ts` does — sign in AFTER promotion
+ * so the authoritative session read sees it.
+ */
+const makeRoleAdmin = (engine: any, email: string) => {
+  const row = userRows(engine).find((r) => r.email === email);
+  if (!row) throw new Error(`no sys_user row for ${email}`);
+  row.role = 'admin';
+};
+
+const revoke = (manager: AuthManager, cookie: string | undefined, sessionToken: unknown) =>
+  post(manager, 'admin/revoke-user-session', cookie, { sessionToken });
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+/** One env: a target user with a live session, and a role-admin caller. */
+const seed = async () => {
+  const engine = createMemoryEngine();
+  const manager = makeManager(engine);
+  const targetCookie = cookieFrom(await signUp(manager, 'target@example.com'));
+  const targetRow = sessionRows(engine)[0]!;
+  await signUp(manager, 'admin@example.com');
+  makeRoleAdmin(engine, 'admin@example.com');
+  const adminCookie = cookieFrom(await signIn(manager, 'admin@example.com'));
+  return { engine, manager, targetCookie, targetRow, adminCookie };
+};
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#10069 — /admin/revoke-user-session refuses when the token identifies no record', () => {
+  it('a token matching ZERO rows answers 404 with code AND status — never { success: true }', async () => {
+    const { engine, manager, targetRow, adminCookie } = await seed();
+
+    const res = await revoke(manager, adminCookie, 'no-such-token-anywhere');
+    const body: any = await res.json();
+
+    // ADR-0112: code AND status, never one alone.
+    expect(res.status).toBe(404);
+    expect(body?.code).toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+    expect(body?.message).toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_MESSAGE);
+    // The defect's exact shape must be gone, not merely accompanied.
+    expect(body?.success).not.toBe(true);
+    // Nobody's session was touched by the failed revoke.
+    const target = sessionRows(engine).find((r) => r.id === targetRow.id);
+    expect(target?.revoked_at).toBeUndefined();
+    expect(await isAuthenticated(manager, adminCookie)).toBe(true);
+  });
+
+  it("an admitted revoke still succeeds end to end — an admin revoking an arbitrary user's session", async () => {
+    const { engine, manager, targetCookie, targetRow, adminCookie } = await seed();
+
+    const res = await revoke(manager, adminCookie, targetRow.token);
+    const body: any = await res.json();
+
+    // The vendor's success answer, now true when given.
+    expect(res.status).toBe(200);
+    expect(body).toHaveProperty('success', true);
+    // The revoke really happened, as a #7732 tombstone with reason `admin`.
+    const row = sessionRows(engine).find((r) => r.id === targetRow.id);
+    expect(row?.revoke_reason).toBe('admin');
+    expect(row?.revoked_at).toBeInstanceOf(Date);
+    expect(await isAuthenticated(manager, targetCookie)).toBe(false);
+    expect(await isAuthenticated(manager, adminCookie)).toBe(true);
+  });
+
+  it('revoking an ALREADY-REVOKED token answers 404 — a revoked session is not a session (#7732)', async () => {
+    const { engine, manager, targetRow, adminCookie } = await seed();
+
+    expect((await revoke(manager, adminCookie, targetRow.token)).status).toBe(200);
+    const tombstonedAt = sessionRows(engine).find((r) => r.id === targetRow.id)?.revoked_at;
+
+    const again = await revoke(manager, adminCookie, targetRow.token);
+    const body: any = await again.json();
+    expect(again.status).toBe(404);
+    expect(body?.code).toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+    // The tombstone itself is untouched by the refused second revoke.
+    const row = sessionRows(engine).find((r) => r.id === targetRow.id);
+    expect(row?.revoke_reason).toBe('admin');
+    expect(row?.revoked_at).toEqual(tombstonedAt);
+  });
+
+  it('an EMPTY-string token answers 404 — previously the quietest false success of all', async () => {
+    const { manager, adminCookie } = await seed();
+
+    const res = await revoke(manager, adminCookie, '');
+    // better-auth's zod body schema accepts an empty string (`z.string()`), so
+    // this reaches the guard, matches zero rows, and must refuse.
+    const body: any = await res.json();
+    expect(res.status).toBe(404);
+    expect(body?.code).toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+  });
+
+  it('a NON-ADMIN caller keeps the vendor 403 for missing and live tokens alike — no oracle below the permission line', async () => {
+    const { engine, manager, targetRow } = await seed();
+    const plainCookie = cookieFrom(await signUp(manager, 'plain@example.com'));
+
+    const missing = await revoke(manager, plainCookie, 'no-such-token-anywhere');
+    const missingBody = await missing.text();
+    const live = await revoke(manager, plainCookie, targetRow.token);
+    const liveBody = await live.text();
+
+    // The vendor's own permission refusal, both times, byte-identically: a
+    // caller below the permission line learns nothing about token existence.
+    expect(missing.status).toBe(403);
+    expect(live.status).toBe(403);
+    expect(missingBody).toBe(liveBody);
+    expect(JSON.parse(missingBody)?.code).toBe('YOU_ARE_NOT_ALLOWED_TO_REVOKE_USERS_SESSIONS');
+    expect(JSON.parse(missingBody)?.code).not.toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+    // And the live target row is untouched: not deleted, not tombstoned.
+    const row = sessionRows(engine).find((r) => r.id === targetRow.id);
+    expect(row).toBeDefined();
+    expect(row?.revoked_at).toBeUndefined();
+  });
+
+  it('an UNAUTHENTICATED caller still gets the vendor 401, never this 404', async () => {
+    const { manager, targetRow } = await seed();
+
+    // A real token, no credentials: the guard must stay silent and let the
+    // vendor's adminMiddleware answer the authentication question — a 404
+    // here would grade an anonymous probe's existence question.
+    const res = await revoke(manager, undefined, targetRow.token);
+    expect(res.status).toBe(401);
+    const body: any = await res.json().catch(() => null);
+    expect(body?.code).not.toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+  });
+
+  it('a NON-STRING token falls through to the vendor 400 — the body schema owns that refusal', async () => {
+    const { manager, adminCookie } = await seed();
+
+    const res = await revoke(manager, adminCookie, 12345);
+    expect(res.status).toBe(400);
+    const body: any = await res.json().catch(() => null);
+    expect(body?.code).not.toBe(ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('adminMayRevokeUserSessions — the vendor permission question, vendor inputs', () => {
+  const admin = { id: 'u_1', role: 'admin' };
+  const user = { id: 'u_2', role: 'user' };
+
+  it('admits the default admin role and refuses the default user role (real vendor defaultRoles)', () => {
+    expect(adminMayRevokeUserSessions(admin, {}, defaultRoles as any)).toBe(true);
+    expect(adminMayRevokeUserSessions(user, {}, defaultRoles as any)).toBe(false);
+    // Sanity that the imported vendor role really grants the permission the
+    // handler demands — the mirror and the vendor share this exact object.
+    expect(
+      (defaultRoles as any).admin.authorize(ADMIN_REVOKE_USER_SESSION_PERMISSION)?.success,
+    ).toBe(true);
+  });
+
+  it('splits a comma-separated role list, the way the vendor does', () => {
+    expect(adminMayRevokeUserSessions({ id: 'u', role: 'user,admin' }, {}, defaultRoles as any)).toBe(true);
+    expect(adminMayRevokeUserSessions({ id: 'u', role: 'user,editor' }, {}, defaultRoles as any)).toBe(false);
+  });
+
+  it('admits an adminUserIds member regardless of role', () => {
+    expect(
+      adminMayRevokeUserSessions(user, { adminUserIds: ['u_2'] }, defaultRoles as any),
+    ).toBe(true);
+    expect(
+      adminMayRevokeUserSessions(user, { adminUserIds: ['someone-else'] }, defaultRoles as any),
+    ).toBe(false);
+  });
+
+  it('falls back to options.defaultRole when the user carries no role scalar', () => {
+    expect(
+      adminMayRevokeUserSessions({ id: 'u' }, { defaultRole: 'admin' }, defaultRoles as any),
+    ).toBe(true);
+    expect(adminMayRevokeUserSessions({ id: 'u' }, {}, defaultRoles as any)).toBe(false);
+  });
+
+  it('a custom roles map REPLACES the fallback — an admin the operator did not authorize is refused', () => {
+    // Drift pin, strict direction: were the live options to carry a roles map
+    // without session:revoke on `admin`, the mirror must refuse (fall through
+    // to the vendor, which would refuse the same way).
+    const roles = { admin: { authorize: () => ({ success: false }) } };
+    expect(adminMayRevokeUserSessions(admin, { roles }, defaultRoles as any)).toBe(false);
+    const granting = { admin: { authorize: () => ({ success: true }) } };
+    expect(adminMayRevokeUserSessions(admin, { roles: granting }, {} as any)).toBe(true);
+  });
+
+  it('grades an unreadable input as not-permitted (fall through), never as admitted', () => {
+    expect(adminMayRevokeUserSessions(null, {}, defaultRoles as any)).toBe(false);
+    expect(adminMayRevokeUserSessions({}, null, defaultRoles as any)).toBe(false);
+    expect(
+      adminMayRevokeUserSessions(
+        admin,
+        { roles: { admin: { authorize: () => { throw new Error('boom'); } } } },
+        defaultRoles as any,
+      ),
+    ).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('anySessionCarriesToken — the admission predicate, no ownership dimension', () => {
+  it('admits any found session, whoever owns it', () => {
+    expect(anySessionCarriesToken({ session: { userId: 'u_1', token: 't' } })).toBe(true);
+    expect(anySessionCarriesToken({ session: {} })).toBe(true);
+  });
+
+  it('refuses null / undefined / shapeless results', () => {
+    expect(anySessionCarriesToken(null)).toBe(false);
+    expect(anySessionCarriesToken(undefined)).toBe(false);
+    expect(anySessionCarriesToken({})).toBe(false);
+    expect(anySessionCarriesToken({ session: null })).toBe(false);
+    expect(anySessionCarriesToken({ session: 'not-an-object' })).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.ts
+++ b/packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#10069] `POST /admin/revoke-user-session` — a revoke that identifies NO
+ * record must not report success.
+ *
+ * ## The defect, and where it is minted
+ *
+ * Not here: the wrong answer comes out of the pinned vendor. better-auth
+ * `1.7.1` (the installed line, re-read for this card),
+ * `dist/plugins/admin/routes.mjs`, `revokeUserSession` runs, after its
+ * `session: ["revoke"]` permission check:
+ *
+ * ```js
+ * await ctx.context.internalAdapter.deleteSession(ctx.body.sessionToken);
+ * return ctx.json({ success: true });
+ * ```
+ *
+ * There is no match check at all — `deleteSession` on a token matching zero
+ * rows deletes nothing and the endpoint answers `200 { success: true }`
+ * unconditionally. Measured behaviourally on this repo's real pipeline
+ * (AuthManager.handleRequest → better-auth 1.7.1 → ObjectQL adapter) before
+ * the guard existed: a zero-match token answered `200 {"success":true}`, and
+ * an ALREADY-REVOKED (tombstoned, #7732) token answered `200 {"success":true}`
+ * as well. Same "security control no-ops while reporting success" class as the
+ * `/revoke-session` guard (`revoke-session-match-guard.ts`), on the surface
+ * where a false success matters most: an administrator revoking someone
+ * else's session and being told it worked.
+ *
+ * ## NOT the sibling's predicate
+ *
+ * `/revoke-session` skips on an ownership mismatch, so its guard reproduces an
+ * ownership predicate ("a session of YOURS carries this token"). This admin
+ * route deletes blindly — the caller is an admin acting on arbitrary users, so
+ * there is no ownership dimension. The admission predicate here is simply:
+ * **does any session carry this token** ({@link anySessionCarriesToken}),
+ * asked through the same `ctx.context.internalAdapter.findSession` seam the
+ * sibling uses. Copying the sibling's ownership predicate would wrongly narrow
+ * an admin's legitimate reach to their own sessions.
+ *
+ * ## Permission is graded BEFORE existence — the vendor's own question first
+ *
+ * The guard runs in the global `hooks.before`, AHEAD of the vendor's
+ * `adminMiddleware` and its `hasPermission` check. Refusing 404 on a
+ * zero-match token without first grading the caller would hand every
+ * authenticated NON-admin an existence oracle the vendor never gave them
+ * (guard-404 for a missing token vs vendor-403 for a live one). So the guard
+ * asks the vendor's own permission question first, with the vendor's own
+ * inputs, and falls through (to the vendor's 401/403) for any caller the
+ * vendor would refuse:
+ *
+ *  - the caller's session is resolved via `getAuthoritativeSessionFromCtx` —
+ *    the exact call the vendor's `adminMiddleware` makes (authoritative on
+ *    purpose: never grade a role off the cookie cache);
+ *  - the permission predicate ({@link adminMayRevokeUserSessions}) is
+ *    better-auth's `has-permission.mjs` `hasPermission`, reproduced line for
+ *    line because the vendor does not export it — but asked with the LIVE
+ *    admin-plugin options read off `ctx.context.options.plugins` (the object
+ *    the vendor itself retains) and with the vendor's own exported
+ *    `defaultRoles` from `better-auth/plugins/admin/access` as the fallback,
+ *    so `adminUserIds` / `defaultRole` / custom `roles` configured on the
+ *    plugin are honoured without a second source of truth. (This repo's
+ *    composition passes none of the three — `auth-manager.ts` constructs
+ *    `admin({ schema })` only — and the integration tests pin both drift
+ *    directions: a mirror gone loose answers this guard's 404 where the
+ *    vendor's 403 belongs, a mirror gone strict resurfaces the vendor's false
+ *    success.)
+ *
+ * ## The refusal shape
+ *
+ * **404 `RESOURCE_NOT_FOUND`** (ADR-0112: code AND status), for the same three
+ * reasons recorded in `revoke-session-match-guard.ts`: `res.ok` callers,
+ * DELETE-like semantics on an unidentifiable resource, and the standard
+ * catalog member over a synonym extension.
+ *
+ * ## The existence-oracle question, RE-DECIDED for this surface
+ *
+ * The sibling made zero-match and foreign-token answers byte-identical to
+ * avoid an existence oracle, because its caller is an arbitrary user. Here the
+ * refusal is deliberately allowed to reveal "no session carries this token" —
+ * but ONLY to callers who pass the vendor's own `session: ["revoke"]`
+ * permission check. That caller class is already entitled to session
+ * existence knowledge: the same default `admin` role statement grants
+ * `session: ["list"]`, i.e. `/admin/list-user-sessions` over arbitrary users,
+ * so the 404 tells an entitled admin nothing they cannot already query
+ * directly. For everyone else the guard is silent by construction (permission
+ * graded first), so the unauthenticated and unauthorized surfaces keep the
+ * vendor's exact refusals (401 / 403) with no existence dimension. There is
+ * no foreign-vs-missing pair to collapse on this route — any live session is
+ * legitimately deletable by an entitled admin; only "no session at all" is
+ * refused.
+ *
+ * ## What the guard deliberately does NOT decide
+ *
+ *  - **Unauthenticated / unresolvable callers fall through** — the vendor's
+ *    `adminMiddleware` owns the 401.
+ *  - **Callers its permission mirror refuses fall through** — the vendor's
+ *    `hasPermission` owns the 403 (including the seeded platform admin whose
+ *    `role` scalar is not `admin`, #9482 — this guard must not change that
+ *    surface's recorded behaviour).
+ *  - **A non-string `sessionToken` falls through** — the endpoint's zod body
+ *    schema answers the 400.
+ *  - **An adapter read failure falls through** — never convert "I could not
+ *    look" into "it does not exist".
+ *
+ * ## Interaction with session tombstones (#7732)
+ *
+ * This route is in `INTERACTIVE_REVOKE_REASON` with reason `admin`, and
+ * `hideRevokedSessionRow` makes a tombstoned row invisible to
+ * `internalAdapter.findSession`. So revoking an ALREADY-REVOKED token now
+ * answers 404 — consistent with the tombstone module's doctrine ("a revoked
+ * session is not a session") and with the sibling guard; previously it was a
+ * silent `{ success: true }` no-op (measured, see above). The admitted path
+ * still tombstones with reason `admin`, untouched.
+ *
+ * ## Scope
+ *
+ * The SINGULAR route only. `/admin/revoke-user-sessions` (plural) matches by
+ * user id and cannot mis-identify a single record — zero sessions to sweep is
+ * genuinely "nothing to do", exactly the reason the sibling left its own
+ * plural routes untouched.
+ */
+
+/** The refusal's wire code — standard catalog (ADR-0112), see header. */
+export const ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE = 'RESOURCE_NOT_FOUND';
+
+/**
+ * The refusal's message. Deliberately NOT the sibling's "of yours" wording —
+ * this route has no ownership dimension (see header).
+ */
+export const ADMIN_REVOKE_USER_SESSION_NOT_FOUND_MESSAGE =
+  'No session matches the supplied token.';
+
+/**
+ * The permission the vendor's handler demands — `revokeUserSession` calls
+ * `hasPermission({ …, permissions: { session: ["revoke"] } })`.
+ */
+export const ADMIN_REVOKE_USER_SESSION_PERMISSION: Readonly<Record<string, readonly string[]>> = {
+  session: ['revoke'],
+};
+
+/** The vendor's `AccessControl` role shape, as much of it as the mirror reads. */
+type AuthorizingRole = {
+  authorize?: (permissions: unknown) => { success?: boolean } | undefined;
+};
+
+/**
+ * better-auth's admin-plugin `hasPermission` (dist/plugins/admin/
+ * has-permission.mjs), reproduced because the vendor does not export it. The
+ * inputs are the vendor's own: `user` is the authoritative session's user,
+ * `adminOptions` is the LIVE options object retained on the mounted admin
+ * plugin, `fallbackRoles` is the vendor's exported `defaultRoles`. Anything
+ * unreadable grades as not-permitted, which only ever means "fall through to
+ * the vendor's own refusal" — never a refusal minted here.
+ */
+export function adminMayRevokeUserSessions(
+  user: unknown,
+  adminOptions: unknown,
+  fallbackRoles: Record<string, AuthorizingRole | undefined>,
+): boolean {
+  const u = (user ?? {}) as { id?: unknown; role?: unknown };
+  const opts = (adminOptions ?? {}) as {
+    adminUserIds?: unknown;
+    defaultRole?: unknown;
+    roles?: unknown;
+  };
+  const userId = u.id == null ? '' : String(u.id);
+  if (
+    userId &&
+    Array.isArray(opts.adminUserIds) &&
+    opts.adminUserIds.some((x) => String(x) === userId)
+  ) {
+    return true;
+  }
+  const roleSource =
+    (typeof u.role === 'string' && u.role) ||
+    (typeof opts.defaultRole === 'string' && opts.defaultRole) ||
+    'user';
+  const acRoles: Record<string, AuthorizingRole | undefined> =
+    opts.roles && typeof opts.roles === 'object'
+      ? (opts.roles as Record<string, AuthorizingRole | undefined>)
+      : fallbackRoles;
+  for (const role of roleSource.split(',')) {
+    try {
+      if (acRoles[role]?.authorize?.(ADMIN_REVOKE_USER_SESSION_PERMISSION)?.success) return true;
+    } catch {
+      // an authorizer that throws grades as not-permitted — the vendor's own
+      // call would throw the same way one moment later, on its own path.
+    }
+  }
+  return false;
+}
+
+/**
+ * The admission predicate: does `found` (the `internalAdapter.findSession`
+ * result) name ANY session? Shape-tolerant like the sibling's — `findSession`
+ * answers `{ session, user }` or `null`, and anything without a readable
+ * `session` is "no match", which is also what the vendor's `deleteSession`
+ * would have made of it (deletes nothing).
+ */
+export function anySessionCarriesToken(found: unknown): boolean {
+  const session = (found as { session?: unknown } | null | undefined)?.session;
+  return session != null && typeof session === 'object';
+}

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -55,6 +55,12 @@ import {
   revokeTargetsCallerSession,
 } from './revoke-session-match-guard.js';
 import {
+  ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE,
+  ADMIN_REVOKE_USER_SESSION_NOT_FOUND_MESSAGE,
+  adminMayRevokeUserSessions,
+  anySessionCarriesToken,
+} from './admin-revoke-user-session-match-guard.js';
+import {
   reconcileMembership,
   type MembershipPolicy,
   type ReconcileOutcome,
@@ -1484,6 +1490,24 @@ export class AuthManager {
           // no-existence-oracle property.
           if (ctx?.path === '/revoke-session') {
             await this.assertRevokeSessionIdentifiesRecord(ctx);
+            // fall through — the vendor still performs the revoke itself
+          }
+
+          // ── #10069: the ADMIN revoke that identifies NO record must not ──
+          // report success either. better-auth 1.7.1's `admin/revoke-user-
+          // session` handler calls `deleteSession(ctx.body.sessionToken)`
+          // blindly and answers `200 { success: true }` unconditionally —
+          // measured on this pipeline: zero-match AND already-revoked tokens
+          // both answered success. NOT the #9714 predicate: no ownership
+          // dimension here (the caller is an admin acting on arbitrary
+          // users) — the question is only "does any session carry this
+          // token", and it is asked AFTER the vendor's own permission
+          // question so non-admins keep the vendor's 401/403 and gain no
+          // existence oracle. Before-hook on purpose: an after-hook cannot
+          // change the status. `admin-revoke-user-session-match-guard.ts`
+          // carries the full reading.
+          if (ctx?.path === '/admin/revoke-user-session') {
+            await this.assertAdminRevokeUserSessionIdentifiesRecord(ctx);
             // fall through — the vendor still performs the revoke itself
           }
 
@@ -4508,6 +4532,65 @@ export class AuthManager {
       throw new APIError('NOT_FOUND', {
         message: REVOKE_SESSION_NOT_FOUND_MESSAGE,
         code: REVOKE_SESSION_NOT_FOUND_CODE,
+      });
+    }
+  }
+
+  /**
+   * [#10069] `/admin/revoke-user-session` admission gate — refuse (404,
+   * standard `RESOURCE_NOT_FOUND`) when the supplied token identifies no
+   * session at all, instead of letting the vendor's unconditional success
+   * line answer `{ success: true }` over a delete that dispatched nothing.
+   *
+   * NOT the #9714 predicate: this route has no ownership dimension — the
+   * caller is an admin acting on arbitrary users, so the question is only
+   * "does any session carry this token". And it is asked strictly AFTER the
+   * vendor's own permission question ({@link adminMayRevokeUserSessions},
+   * the vendor's `hasPermission` with the LIVE mounted-plugin options), so
+   * every caller the vendor would refuse falls through to the vendor's own
+   * 401/403 and never learns whether the token exists. Everything else the
+   * guard cannot decide falls through too: a non-string token (the vendor's
+   * zod body schema answers 400), an adapter read failure (never convert
+   * "could not look" into "does not exist"). Full reading:
+   * `admin-revoke-user-session-match-guard.ts`.
+   */
+  private async assertAdminRevokeUserSessionIdentifiesRecord(ctx: any): Promise<void> {
+    const token = ctx?.body?.sessionToken;
+    if (typeof token !== 'string') return; // vendor's body schema answers 400
+
+    let admitted: boolean;
+    try {
+      // The vendor's own session resolution — the exact call adminMiddleware
+      // makes (authoritative: a role graded off the cookie cache could admit
+      // a demoted caller the vendor is about to refuse).
+      const { getAuthoritativeSessionFromCtx } = await import('better-auth/api');
+      const s: any = await getAuthoritativeSessionFromCtx(ctx).catch(() => null);
+      // No resolvable caller → the vendor's adminMiddleware issues the 401.
+      if (!s?.user?.id) return;
+
+      // The vendor's own permission question, with the vendor's own inputs:
+      // the LIVE admin-plugin options (the object the mounted plugin retains)
+      // and its exported defaultRoles as the fallback. A caller this refuses
+      // gets the vendor's 403 — never this guard's 404.
+      const adminOptions = ((ctx?.context?.options?.plugins ?? []) as any[]).find(
+        (p: any) => p?.id === 'admin',
+      )?.options;
+      const { defaultRoles } = await import('better-auth/plugins/admin/access');
+      if (!adminMayRevokeUserSessions(s.user, adminOptions, defaultRoles as any)) return;
+
+      const found = await ctx.context.internalAdapter.findSession(token);
+      admitted = anySessionCarriesToken(found);
+    } catch {
+      // A lookup that did not complete hands the request back to the vendor
+      // unchanged — an engine hiccup must not invent a "not found".
+      return;
+    }
+
+    if (!admitted) {
+      const { APIError } = await import('better-auth/api');
+      throw new APIError('NOT_FOUND', {
+        message: ADMIN_REVOKE_USER_SESSION_NOT_FOUND_MESSAGE,
+        code: ADMIN_REVOKE_USER_SESSION_NOT_FOUND_CODE,
       });
     }
   }

--- a/packages/plugins/plugin-auth/src/better-auth-schema-parity.test.ts
+++ b/packages/plugins/plugin-auth/src/better-auth-schema-parity.test.ts
@@ -270,6 +270,18 @@ const AUTH_MANAGER_PLUGINS: Record<string, { construct: () => unknown } | { skip
   hasPermission: {
     skip: 'permission predicate exported by the organization plugin — declares no schema',
   },
+  // [#10069] NOT a plugin factory either — same scanner shape as
+  // `hasPermission` above. `defaultRoles` is the admin plugin's exported
+  // role→AccessControl map (`better-auth/plugins/admin/access`); it declares no
+  // schema, so it contributes no model and no column for this gate to compare.
+  // `assertAdminRevokeUserSessionIdentifiesRecord` reads it so the
+  // admin-revoke-user-session gate asks the vendor's own permission question
+  // (its `hasPermission` fallback roles) rather than keeping a second spelling
+  // of it. The `stale` assertion below removes this entry's licence the moment
+  // that import goes away.
+  defaultRoles: {
+    skip: 'role→AccessControl map exported by the admin plugin — declares no schema',
+  },
 };
 
 /** The plugin set the auth manager actually assembles (`buildPluginList()`). */

--- a/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
+++ b/packages/plugins/plugin-auth/src/managed-extension-fields.test.ts
@@ -453,6 +453,18 @@ const AUTH_MANAGER_PLUGINS: Record<string, { construct: () => unknown } | { skip
   hasPermission: {
     skip: 'permission predicate exported by the organization plugin — declares no schema',
   },
+  // [#10069] NOT a plugin factory either — same scanner shape as
+  // `hasPermission` above. `defaultRoles` is the admin plugin's exported
+  // role→AccessControl map (`better-auth/plugins/admin/access`); it declares no
+  // schema, contributes no model and no column, so there is nothing here for
+  // the collision loop to compare. `assertAdminRevokeUserSessionIdentifiesRecord`
+  // reads it so the admin-revoke-user-session gate asks the vendor's own
+  // permission question (its `hasPermission` fallback roles) rather than keeping
+  // a second spelling of it. The `stale` assertion below removes this entry's
+  // licence the moment that import goes away.
+  defaultRoles: {
+    skip: 'role→AccessControl map exported by the admin plugin — declares no schema',
+  },
 };
 
 /** The plugin set the auth manager actually assembles (`buildPluginList()`). */

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -1027,6 +1027,16 @@
       "pinned": 1
     },
     {
+      "file": "packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-auth/src/admin-revoke-user-session-match-guard.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/plugins/plugin-auth/src/auth-manager.jwt-eddsa-fallback.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Fixes #10069

## The measurement first (the card's premise, re-established behaviourally)

The card's reading was from the installed dist only; this PR re-measured it end to end before changing anything. On the installed vendor **better-auth 1.7.1** (read from this branch's `node_modules`, not from the card), through the real pipeline (`AuthManager.handleRequest` → better-auth → ObjectQL adapter, network-free), `POST /admin/revoke-user-session`:

- a token matching **zero rows** answered `200 {"success":true}` — the delete dispatched nothing and the endpoint reported success;
- an **already-revoked** (tombstoned, issue #7732's mechanism) token also answered `200 {"success":true}`;
- a live token answered `200 {"success":true}` and tombstoned the session with reason `admin` (the #7732 interaction works as pinned at `session-tombstone.test.ts`);
- a non-admin caller was refused `403 YOU_ARE_NOT_ALLOWED_TO_REVOKE_USERS_SESSIONS` (harness sanity: the permission surface is real).

Premise valid; the fix proceeded.

## The fix — a `hooks.before` admission gate, NOT the sibling's predicate

`admin-revoke-user-session-match-guard.ts` + wiring in `auth-manager.ts`, same seam as the `/revoke-session` guard from PR #10070, because an after-hook can replace a body but not a status.

The sibling route skips on an ownership mismatch, so its guard reproduces an ownership predicate. This route deletes blindly and the caller is an admin acting on arbitrary users — there is **no ownership dimension**. The admission predicate here is only *"does any session carry this token"*, asked through the vendor's own `internalAdapter.findSession`. When no session does, the guard refuses **404 `RESOURCE_NOT_FOUND`** (ADR-0112: code AND status), for the three reasons recorded in the sibling's header (`res.ok` callers, DELETE-like semantics, standard-catalog member over a synonym extension).

### Permission is graded before existence

The guard runs ahead of the vendor's `adminMiddleware` + `hasPermission`. Refusing 404 on zero-match without grading the caller first would hand every authenticated **non-admin** an existence oracle the vendor never gave them (guard-404 for a missing token vs vendor-403 for a live one). So the guard first asks the vendor's own permission question — the caller's session via `getAuthoritativeSessionFromCtx` (the exact call `adminMiddleware` makes), then the vendor's `hasPermission` logic with the vendor's own inputs: the **live** options object retained on the mounted admin plugin and the vendor's exported `defaultRoles` as fallback. Any caller the vendor would refuse falls through to the vendor's own 401/403 untouched — pinned byte-identically for missing and live tokens alike, so nothing below the permission line can distinguish them. This also leaves the recorded #9482 surface unchanged (a platform admin without the legacy `role` scalar still gets the vendor 403).

`hasPermission` itself is not exported by the vendor, so its ten lines are reproduced with the live options and the exported role map as inputs; both drift directions are pinned (a mirror gone loose answers this guard's 404 where the vendor's 403 belongs — integration test; a mirror gone strict is refused at unit level by the custom-roles pin).

### The existence-oracle question, re-decided rather than inherited

The sibling (#9714) made zero-match and foreign-token answers byte-identical because its caller is an arbitrary user. Here the refusal deliberately reveals "no session carries this token" — but **only** to callers who pass the vendor's own `session: ["revoke"]` check. That caller class is already entitled to session-existence knowledge: the same default admin role grants `session: ["list"]` (`/admin/list-user-sessions` over arbitrary users), so the 404 tells an entitled admin nothing they cannot already query. There is no foreign-vs-missing pair to collapse on this route — any live session is legitimately deletable by an entitled admin; only "no session at all" refuses.

### Tombstone interaction (issue #7732), re-verified behaviourally

This route carries reason `admin` in `INTERACTIVE_REVOKE_REASON`. `hideRevokedSessionRow` makes a tombstoned row invisible to `findSession`, so revoking an already-revoked token now answers 404 — consistent with the tombstone module's "a revoked session is not a session" doctrine and with the sibling guard; previously it was a silent false success (measured above). The admitted path still tombstones with reason `admin`, and the refused second revoke leaves the tombstone untouched (pinned).

## Scope

- The **singular** route only. `/admin/revoke-user-sessions` (plural) matches by user id and cannot mis-identify a single record — left untouched, same reasoning as the sibling's plural routes.
- Two parity-scanner test ledgers (`better-auth-schema-parity.test.ts`, `managed-extension-fields.test.ts`) gained a `defaultRoles` skip entry — it is a role map, not a plugin factory; it declares no schema. Same shape as their existing `hasPermission` entry.
- Repo-wide pin-sweep for assertions of the old `{ success: true }` shape on this route: **zero found**; counter-check — the same search located the route's ledger row, tombstone map entry, dogfood refusal probe, and checklist prose, so the net demonstrably works. The dogfood non-admin refusal suite (`admin-route-nonadmin-refusal.dogfood.test.ts`) probes this route only below the permission line, which this guard leaves byte-identical.

## Verification (all at `b293081c2`)

- `pnpm --filter @objectstack/plugin-auth test` — `Test Files 60 passed (60) · Tests 1335 passed (1335)`.
- New suite: 15 tests (7 pipeline + 8 unit) covering zero-match, admitted revoke, already-revoked, empty-string token, non-admin byte-identical 403s, anonymous 401, non-string 400 fall-through, and the permission-mirror and admission predicates.
- **Ablation** (guard neutered by an early return, prediction stated first): predicted exactly the three refusal pins failing "expected 404, received 200"; observed `3 failed | 12 passed`, each `AssertionError: expected 200 to be 404`. Restored from the commit and proven byte-identical (`git hash-object` = `8cffac5b…` both sides). **No rebuild was needed for the mutation to be observable** — the suite imports `./auth-manager` in-package from `src/` under vitest's transform; no dist is on the resolution path.
- `pnpm check:type-check-debt` — "33 ledger entr(ies) re-measured … none above its recorded number"; plugin-auth stays at its frozen count (109), not raised.
- Gate union from `node scripts/pm/dispatch-gates.mjs` (re-derived after the ledger commit, which added `check:cross-package-test-inputs`): `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract` ("316 (file, verb) row(s) held by the RETAINED ledger"), `check:where-matcher`, `check:nul-bytes`, `check:error-code-casing`, `check-adr-0087-registration` ("this PR adds no declared-breaking changeset"), `check-changeset-no-major`, `check-empty-changeset`, `check-affected-docs` — all exit 0 at `b293081c2`.

Changeset: patch for `@objectstack/plugin-auth`, stating the new answer plainly for a release-notes reader.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_