### PR TITLE
test(plugin-dev): pay the plugin-security transform at module load, out of every clocked window

### DIFF
--- a/packages/plugins/plugin-dev/src/dev-plugin-security-enforcement-warning.test.ts
+++ b/packages/plugins/plugin-dev/src/dev-plugin-security-enforcement-warning.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { DevPlugin } from './dev-plugin';
 
 // [#10036] The state under test is "SecurityPlugin LOADED but its start()
@@ -65,6 +65,38 @@ async function boot(ctx: any, options: Record<string, unknown> = {}) {
   await plugin.start(ctx);
   return plugin;
 }
+
+// [#10115] Pay the one-off module-graph cost HERE, before the first `it`.
+//
+// `DevPlugin.start()` reaches `@objectstack/plugin-security` through a dynamic
+// `await import()`, and this file deliberately leaves that chain unmocked (see
+// the header: the real plugin's `init()`/`start()` phase split IS the subject).
+// So whichever test ran first paid the plugin's cold vite transform inside its
+// own measured window. Measured on an idle 4-vCPU container, bail #1 cost
+// 3110 / 3351 / 3360 ms — ~70% of vitest's 5000ms default `testTimeout` — while
+// the other three tests cost 3-5 ms each. Under four concurrent tsup DTS builds
+// of plugin-dev dependents it crossed the budget on every run
+// (5006 / 5007 / 5006 ms, `Test timed out in 5000ms`), and bail #2 then
+// inherited the still-cold import (2203-2931 ms) and went red with it on the
+// busier CI shard. Because a PR that dirties a plugin-dev dependency both makes
+// this file re-run AND makes it run beside a cold rebuild, the failure was
+// intermittent and named neither the real cause nor the offending PR — it read
+// as "your change broke security enforcement" when nothing of the sort happened.
+//
+// Warming the import here moves that one-off transform off every test's clock
+// and onto vitest's separate `hookTimeout` (default 10000ms — twice the test
+// budget), so each `it` measures only the behaviour it is about. Same machine,
+// same load, after: bail #1 22-26 ms idle and 29-54 ms under the same four-build
+// load, all four tests green.
+//
+// ⛔ This must stay a REAL import of the REAL plugin — replacing it with a stub,
+// here or via `vi.mock`, deletes the subject exactly as the header warns.
+// ⛔ Do not answer a future recurrence by raising `testTimeout` instead: that
+// widens the window around the cost rather than moving the cost out of it, and
+// it re-hides the next in-test transform that lands in this file.
+beforeAll(async () => {
+  await import('@objectstack/plugin-security');
+});
 
 describe('[#10036] the "nothing is enforced" warning must fire when SecurityPlugin.start() bailed', () => {
   // ── The state the warning describes, constructed for real ───────────────

--- a/packages/plugins/plugin-dev/src/dev-plugin-security-enforcement-warning.test.ts
+++ b/packages/plugins/plugin-dev/src/dev-plugin-security-enforcement-warning.test.ts
@@ -1,5 +1,54 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { DevPlugin } from './dev-plugin';
+
+// [#10115] Pay the one-off `@objectstack/plugin-security` module-graph cost at
+// MODULE LOAD, not inside any hook and not inside any test.
+//
+// `DevPlugin.start()` reaches the plugin through a dynamic `await import()`, and
+// this file deliberately leaves that chain unmocked (see the header below: the
+// real plugin's `init()`/`start()` phase split IS the subject). Something has to
+// pay its cold vite transform; the only question is which clock is running when
+// it does. This file has now answered that question wrongly twice:
+//
+//   * paid inside whichever `it` ran first  -> `Test timed out in 5000ms`
+//     (idle 3110/3351/3360 ms; red on every run under four concurrent builds).
+//   * moved into a `beforeAll`              -> `Hook timed out in 10000ms`,
+//     which ejected this file from the merge queue four times in one night
+//     (runs 32334616926 / 32334642055 / 32334745861 / 32335141663, shard
+//     `Test Core (3/3)`, file duration 10024ms) while PR-side CI stayed green --
+//     the queue runs the FULL suite, PR-side CI only the affected subset, so the
+//     queue shard is far heavier than anything the PR checks measure.
+//
+// Neither move took the cost OUT of a clocked window; each only widened or
+// swapped the window around it, which relocates the cliff to the next heavier
+// shard instead of removing it. A top-level import is paid during collection,
+// and in vitest 4.1.10 collection is clocked against NOTHING. Verified against
+// the installed runner, not recalled: `@vitest/runner` wraps exactly hooks and
+// test bodies in `withTimeout(...)`, while `collectTests()` awaits
+// `runner.importFile(filepath, 'collect')` bare and merely RECORDS
+// `file.collectDuration` for reporters; and `vitest --help` on 4.1.10 offers
+// exactly three timeout knobs -- `testTimeout`, `hookTimeout`, `teardownTimeout`
+// -- none of which covers module loading.
+//
+// Measured on a 4-vCPU container with this run confined to a single core and a
+// spinner beside it (idle -> loaded): the old `beforeAll` cost 3.3s -> 7.2-7.4s,
+// i.e. 74% of its 10000ms budget on a machine that could not even reach the
+// load the queue applies. After this change the file has NO hook at all, its
+// four tests cost 2-70 ms each against the 5000ms `testTimeout`, and the run
+// stays green even under `--hookTimeout=1` -- there is no hook time left to clock.
+//
+// `vi.mock` is hoisted above every import in this file, this one included, so
+// the ten mocks below still register before this module is evaluated.
+//
+// This must stay a REAL, STATIC, side-effect import of the REAL plugin:
+//   - replacing it with a stub, here or via `vi.mock`, deletes the subject
+//     exactly as the header warns;
+//   - turning it back into a hook or a dynamic `await import()` puts the cost
+//     back inside a clocked window and re-arms the ejection;
+//   - answering a recurrence by raising `testTimeout` / `hookTimeout` widens the
+//     window around the cost rather than moving the cost out of it, and re-hides
+//     the next transform that lands in this file.
+import '@objectstack/plugin-security';
 
 // [#10036] The state under test is "SecurityPlugin LOADED but its start()
 // bailed", so `@objectstack/plugin-security` is deliberately NOT mocked here —
@@ -65,38 +114,6 @@ async function boot(ctx: any, options: Record<string, unknown> = {}) {
   await plugin.start(ctx);
   return plugin;
 }
-
-// [#10115] Pay the one-off module-graph cost HERE, before the first `it`.
-//
-// `DevPlugin.start()` reaches `@objectstack/plugin-security` through a dynamic
-// `await import()`, and this file deliberately leaves that chain unmocked (see
-// the header: the real plugin's `init()`/`start()` phase split IS the subject).
-// So whichever test ran first paid the plugin's cold vite transform inside its
-// own measured window. Measured on an idle 4-vCPU container, bail #1 cost
-// 3110 / 3351 / 3360 ms — ~70% of vitest's 5000ms default `testTimeout` — while
-// the other three tests cost 3-5 ms each. Under four concurrent tsup DTS builds
-// of plugin-dev dependents it crossed the budget on every run
-// (5006 / 5007 / 5006 ms, `Test timed out in 5000ms`), and bail #2 then
-// inherited the still-cold import (2203-2931 ms) and went red with it on the
-// busier CI shard. Because a PR that dirties a plugin-dev dependency both makes
-// this file re-run AND makes it run beside a cold rebuild, the failure was
-// intermittent and named neither the real cause nor the offending PR — it read
-// as "your change broke security enforcement" when nothing of the sort happened.
-//
-// Warming the import here moves that one-off transform off every test's clock
-// and onto vitest's separate `hookTimeout` (default 10000ms — twice the test
-// budget), so each `it` measures only the behaviour it is about. Same machine,
-// same load, after: bail #1 22-26 ms idle and 29-54 ms under the same four-build
-// load, all four tests green.
-//
-// ⛔ This must stay a REAL import of the REAL plugin — replacing it with a stub,
-// here or via `vi.mock`, deletes the subject exactly as the header warns.
-// ⛔ Do not answer a future recurrence by raising `testTimeout` instead: that
-// widens the window around the cost rather than moving the cost out of it, and
-// it re-hides the next in-test transform that lands in this file.
-beforeAll(async () => {
-  await import('@objectstack/plugin-security');
-});
 
 describe('[#10036] the "nothing is enforced" warning must fire when SecurityPlugin.start() bailed', () => {
   // ── The state the warning describes, constructed for real ───────────────


### PR DESCRIPTION
Fixes #10115

## Follow-up round: the `beforeAll` fix was insufficient, and this is why

The first commit moved the one-off `@objectstack/plugin-security` transform off each test's
5000ms `testTimeout` and onto vitest's 10000ms `hookTimeout`. That was accepted with a
recorded residual — "if a heavier shard ever makes the hook itself time out". The residual
materialised immediately: the merge queue runs the **full** suite where PR-side CI runs only
the **affected subset**, and on that heavier shard the hook blew its own budget, ejecting this
PR four times and jamming the queue for everyone.

### The failing signature, verbatim

Extracted from queue run `32335141663`, job `96323172298`, shard `Test Core (3/3)` (the three
sibling ejections `32334616926` / `32334642055` / `32334745861` carry the same block):

```
 ❯ src/dev-plugin-security-enforcement-warning.test.ts (4 tests | 4 skipped) 10024ms
⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/dev-plugin-security-enforcement-warning.test.ts [ src/dev-plugin-security-enforcement-warning.test.ts ]
Error: Hook timed out in 10000ms.
If this is a long-running hook, pass a timeout value as the last argument or configure it globally with "hookTimeout".
 ❯ src/dev-plugin-security-enforcement-warning.test.ts:97:1
     97| beforeAll(async () => {
       | ^
     98|   await import('@objectstack/plugin-security');
 Test Files  1 failed | 5 passed (6)
      Tests  54 passed | 4 skipped (58)
   Duration  21.78s (transform 24.44s, setup 0ms, import 29.92s, ...)
```

It is the **hook**, not a test body, not an assertion, not an OOM. The `beforeAll` at `:97:1`
consumed 10024ms of its 10000ms budget and the four bodies never ran (`4 skipped`).

## The fix: move the cost out of every clocked window, not into a bigger one

Any budget the cost is moved *into* can be exhausted by a heavier shard — that is the class,
and both previous shapes were instances of it. A top-level side-effect import is paid during
**collection**, and in vitest 4.1.10 collection is clocked against nothing.

Verified against the installed runner rather than recalled:

- `@vitest/runner@4.1.10` wraps exactly hooks and test bodies in `withTimeout(...)`. Every
  call site is a `beforeAll` / `afterAll` / `beforeEach` / `afterEach` / `onTestFailed` /
  `onTestFinished` handler or a test `result`.
- `collectTests()` awaits `runner.importFile(filepath, "collect")` **bare** — no wrapper — and
  merely records `file.collectDuration = now() - collectStart`. That value is only ever summed
  for reporters; it is never compared against a budget anywhere in the runner or in vitest.
- `vitest --help` on 4.1.10 offers exactly three timeout knobs: `--testTimeout` (test bodies),
  `--hookTimeout` (hooks), `--teardownTimeout` (teardown). None covers module loading.

`vi.mock` is hoisted above every import in the file, this one included, so the ten mocks still
register before the new import is evaluated — the same mechanism that already lets the
existing static `./dev-plugin` import see them.

**No assertion is skipped, weakened, quarantined or mocked; no timeout is raised; the real
plugin is still imported for real.** The four #10036 pins are untouched.

## Numbers, with margin

4-vCPU container. Load = the run confined to one core (`taskset -c 0`) with a spinner on that
same core, which reproduces the *share* a vitest process gets on a loaded shard. Each run is
cold (`node_modules/.vite` removed first).

| condition | `tests` phase | max test body | outcome |
|---|---|---|---|
| **before**, idle | 3.32s | 26 ms | pass |
| **before**, loaded | **7.22s** (72% of the 10000ms hookTimeout) | 69 ms | pass, 1.38x margin |
| **before**, queue (GitHub) | **10024ms** | — | ❌ ejected 4x |
| **after**, loaded | **67 ms** | 41 ms | pass |

The margin after this change is not a bigger number in the same budget — it is the absence of
the budget. The `tests` phase drops **7.22s to 67ms** (108x), the cost reappearing in the
unclocked `import` phase (5.3s to 12.8s). Against the 5000ms `testTimeout` the worst body now
sits at 41ms, a **122x** headroom. And the file has no hook at all, so it passes even under
`--hookTimeout=1`, which is the sharpest statement of the margin available: there is no hook
time left to clock.

### Reproduction honesty

I could **not** push the hook past 10000ms on this container. It plateaus hard at 7.2-7.4s
across 1, 2, 6 and 12 competing spinners, and adding a forced uncached full-repo test run
alongside did not move it either — past that point the residual is IO-bound, not CPU-bound.
So the local reproduction **relocates the cliff** with a CLI flag (`--hookTimeout=5000`)
rather than manufacturing the load, touching neither the file nor any committed config. That
yields the identical failure shape at the identical call site:

```
 FAIL  src/dev-plugin-security-enforcement-warning.test.ts [ src/dev-plugin-security-enforcement-warning.test.ts ]
Error: Hook timed out in 5000ms.
 ❯ src/dev-plugin-security-enforcement-warning.test.ts:97:1
 Test Files  1 failed (1)
      Tests  4 skipped (4)
```

## Ablation

Predicted before running: reverting the file to its `e0ac7ef34` content under the same load
with `--hookTimeout=5000` goes red with `Hook timed out in 5000ms` at `:97:1`, with **4
skipped and 0 failed** bodies, because a failing suite-level hook skips them rather than
running them. Observed exactly that; the restored leg is green at `tests 66ms`.

```
fixed / HEAD blob   = b6668b86bb66d1909d5a6edbf54f9be906083e93
mutated blob        = 02952e11a4852b0d4189d393113c1841ac25fa98  (== e0ac7ef34 blob for this path)  ✓
restored blob       = b6668b86bb66d1909d5a6edbf54f9be906083e93  ✓ byte-identical
plugin-security dist, both legs = eb0a6d768db316932680cbc181a46c63ab0d55bc  ✓ identical
```

**Rebuild statement.** The mutated artifact is the test file itself, which vitest loads from
`src/` with no package `exports` or `dist` indirection, so no build step can sit between the
edit and the run. The one dependency this file consumes through an `exports` map is
`@objectstack/plugin-security` (to `dist/`); it is untouched by both legs and its dist tree
hashes identically across them, so the two legs differ only in the test file.

## Gates

Union derived by `node scripts/pm/dispatch-gates.mjs` with no paths passed (it takes its own
change set from the merge base), run **after** the final commit, at `7ef8159b7`, on a clean
worktree. Exit codes captured before any pipe; each gate printed its own verdict line.

```
nul-bytes 0 · slot-lookup 0 · test-source-alias 0 · type-source-resolution 0
affected-docs 0 · query-options-erasure 0 · type-check-coverage 0
engine-double-contract 0 · where-matcher 0
plugin-dev typecheck 0 · plugin-dev test 0  (6 files, 58 tests, 58 passed)
```

One narrowing, declared: `check:type-check-debt --re-measure` was not run locally. It requires
a full workspace build and re-runs tsc **per ledger entry**; `plugin-dev` declares its own
`typecheck` script and carries no DEBT or TEST_DEBT entry, so this diff cannot move any count
it measures. The structural half, `check:type-check-coverage`, is green above. CI runs it
regardless.

A first pass reported `plugin-dev typecheck` EXIT=2 on `@objectstack/spec/security`. That was
damage from my own load harness, which killed `@objectstack/spec#build` mid-DTS and left
`dist/security/` with `.js` but no `.d.ts`. Rebuilding spec restored EXIT=0. Recorded because
a truncated `dist` reading lies in both directions and this one read as a real defect in a
file this PR never touches.

## Changeset

None, deliberately: test-only, publishes nothing. The `skip-changeset` label was already
applied to this PR and is still present, so the changeset gate is satisfied by the repo
mechanism rather than by an empty changeset (which `scripts/check-empty-changeset.mjs`
rejects).

## Queue note

#10003 and #10008 were ejected by this same timeout and are on repeat queue attempts; nothing
had merged to `main` repo-wide for about 2.5h. Those cards are not addressed here — this PR
only removes the jam they were caught in. I have deliberately **not** re-queued this PR, since
each ejection forces every PR behind it to rebuild; re-queueing is the reviewer's call now
that the fix is on the branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_