### PR TITLE
fix(lint): give the eslint parser stack headroom for migrations/registry.ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,68 @@ import tsParser from '@typescript-eslint/parser';
 // rules this config never registers ("Definition for rule … was not found").
 // Don't add such a script back — scope a local run from the root instead:
 // `pnpm exec eslint --no-inline-config packages/verify/src`.
+//
+// ## Why the root `lint` script runs eslint through `node --stack-size=4000`
+//
+// `@typescript-eslint/parser` builds the ESTree AST by recursion, so the stack
+// it needs is proportional to the AST's DEPTH — not to file size. One file in
+// this repo sits past V8's default ceiling: `packages/spec/src/migrations/
+// registry.ts`, whose `step17.rationale` is a single `+` concatenation of 970
+// string fragments, giving an AST depth of 976. Measured on Node 22.22.2:
+//
+//   • that file needs a minimum `--stack-size` of 1085 KB to parse;
+//   • V8's default main-thread stack is 984 KB.
+//
+// So it is already ~10% OVER budget: parsed on its own it fails every time.
+//
+// What makes it look "flaky" (#10030: success → failure → success on identical
+// bytes) is that the verdict depends on the OTHER files in the same eslint
+// invocation, not on this file. Measured here at the default stack, same bytes,
+// same command: linting `packages/spec/src/migrations` (205 files) REDS with
+// the parse error, while `packages/spec/src` (965 files) and `packages/spec`
+// (1063 files) both go green with registry.ts reporting zero messages — it is
+// linted in all three, and only the narrow scope crashes. So the trigger is a
+// property of the run, not of the content, which is why a re-run re-rolls it
+// and can lose twice. (Not JIT tiering, which was the obvious guess and is
+// falsified: the minimum stack is 1085 KB warm and 1084 KB under `--no-opt`,
+// so optimized and interpreted frames cost the same here.) The failure is
+// `registry.ts  0:0  error  Parsing error: Maximum call stack size exceeded`,
+// on PRs that never touched `packages/spec`, and `Lint & Repo Gates` is a
+// REQUIRED context — so each strike is an unbounded hold on an innocent PR.
+//
+// Raising the parser's headroom changes NO rule and NO accept/reject semantics:
+// it lets the parser finish where it currently crashes. It is the opposite of
+// an `ignores` entry — the file is now actually linted for the first time.
+//
+// Why 4000 KB specifically, both bounds measured rather than guessed:
+//   • need is 1085 KB, and each further `+ '…'` fragment appended to that
+//     rationale costs ~1.10 KB, so 4000 KB absorbs ~2650 more fragments —
+//     roughly 3.7x the current chain;
+//   • the hard ceiling is the OS thread stack (`ulimit -s`, 8192 KB on
+//     ubuntu-latest and locally). `--stack-size` at or above it makes V8 run
+//     off the real stack and SIGSEGV instead of throwing: measured clean
+//     `RangeError` up to 8000, `rc=139` at 8192 and above. 4000 keeps a 2x
+//     margin under that.
+//   • nothing else in the repo is close: across all 4659 linted files the
+//     runner-up AST depth is 71 (`entries/semantic/18.driver-sql-unresolvable-
+//     where-column-refused.ts`). Depth does not track size — the two largest
+//     linted files, 236 KB and 183 KB, sit at depth 44 and 40.
+//
+// ⚠️ The flag CANNOT be moved to `NODE_OPTIONS`: Node rejects it outright
+// (`--stack-size= is not allowed in NODE_OPTIONS`). It has to be an argv flag
+// on the `node` process that runs eslint, which is why this script spells out
+// `node_modules/eslint/bin/eslint.js` instead of the `eslint` bin shim — the
+// shim is a shell script, so `node` cannot execute it. Keeping the flag in the
+// root `lint` script (rather than in `.github/workflows/lint.yml`) is what
+// keeps local and CI identical: the workflow step is `pnpm lint`.
+//
+// ⚠️ A local run scoped past this file — `pnpm exec eslint …` on a path that
+// includes `packages/spec/src/migrations/` — bypasses this script and will
+// still hit the ceiling. Prefix it with `node --stack-size=4000` the same way.
+//
+// The permanent fix is to stop building that string with a 970-deep `+` chain
+// (a template literal or `.join('')` is depth ~4); it is a `packages/spec`
+// content change and is tracked separately.
 
 const SUBPATH_NAMES = [
   'Data', 'UI', 'System', 'AI', 'API', 'Automation',

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "objectui:bump": "bash scripts/bump-objectui.sh",
     "objectui:refresh": "bash scripts/bump-objectui.sh && bash scripts/build-console.sh",
     "objectui:clean": "rm -rf packages/console/dist .cache/objectui-*",
-    "lint": "eslint . --no-inline-config",
+    "lint": "node --stack-size=4000 node_modules/eslint/bin/eslint.js . --no-inline-config",
     "i18n:extract": "tsx packages/cli/bin/run-dev.js i18n extract packages/platform-objects/scripts/i18n-extract.config.ts --locales=zh-CN,ja-JP,es-ES --fill=default --out=packages/platform-objects/src/apps/translations",
     "check:i18n": "node scripts/check-i18n-bundles.mjs --self-test && node scripts/check-i18n-bundles.mjs",
     "check:i18n-coverage": "node scripts/check-i18n-coverage.mjs --self-test && node scripts/check-i18n-coverage.mjs",


### PR DESCRIPTION
Fixes #10030

`Lint & Repo Gates` is a **required** context and was ejecting innocent PRs with a parse error naming a file their diff never touched:

```
packages/spec/src/migrations/registry.ts
  0:0  error  Parsing error: Maximum call stack size exceeded
```

One line changes behaviour — the root `lint` script now runs eslint under `node --stack-size=4000`. Everything else in the diff is the measurement written down where the next person will look for it.

## The fix changes no rule and no accept/reject semantics

It is the **opposite** of an ignore entry: the parser now finishes where it crashed, so `registry.ts` is linted for the first time rather than skipped. It is clean — `node --stack-size=4000 … eslint --no-inline-config packages/spec/src/migrations/registry.ts` exits 0 with no findings, so nothing new is being accepted or reported.

## H1 — the crash is forced, not observed

Reproduced locally on the first attempt and deterministically thereafter, byte-identical to the CI signature. The card's "flaky" reading needed correcting: parsed on its own the file fails **every** time (5/5 through the parser directly, and through real eslint).

What actually flips is not the content and not luck — it is **the other files in the same eslint invocation**. Same bytes, same command, same default stack:

| scope | files linted | `registry.ts` verdict |
|---|---|---|
| `packages/spec/src/migrations` | 205 | ❌ `Parsing error: Maximum call stack size exceeded` |
| `packages/spec/src` | 965 | ✅ present in results, **0 messages** |
| `packages/spec` | 1063 | ✅ present in results, **0 messages** |

It is linted in all three (verified via `--format json`, not inferred from exit codes) and only the narrow scope crashes. That is a property of the run, not of the file — which is exactly why identical bytes gave ✅→❌→✅ on one card and ❌→❌ on another, and why a re-run re-rolls it and can lose twice.

⚠️ One obvious mechanism was **falsified**: JIT tiering (warm optimized frames being smaller). The minimum stack is 1085 KB warm and 1084 KB under `--no-opt` — optimized and interpreted frames cost the same here, so that is not the variable. I have left the honest version in the code comment rather than an appealing guess.

## H2 — the margin, and it is negative

| quantity | measured |
|---|---|
| minimum `--stack-size` to parse `registry.ts` | **1085 KB** |
| V8 default main-thread stack | **984 KB** |
| margin | **~10% OVER budget already** |
| cost of each additional `+ '…'` fragment | **~1.10 KB** (linear across 100→2000 operands) |
| headroom at the shipped 4000 KB | **~2650 more fragments**, ~3.7x the current chain |

Threshold located by bisection: fails at 1080, passes at 1090. The growth constant comes from synthetic chains of 100/300/500/700/970/1500/2000 operands needing 162/383/604/823/1122/1704/2255 KB.

## H3 — the supported mechanism, and local/CI agreement

- ⛔ **`NODE_OPTIONS` cannot carry it.** Node rejects the flag outright: `--stack-size= is not allowed in NODE_OPTIONS`. The direction suggested on the card is not available.
- It must be an argv flag on the `node` process running eslint. That is why the script spells out `node_modules/eslint/bin/eslint.js` rather than the `eslint` bin — the bin is a **shell shim**, so `node` cannot execute it (`SyntaxError: missing ) after argument list`).
- **Local and CI agree by construction.** The flag lives in the root `lint` script, and the workflow step is `pnpm lint`. `.github/workflows/lint.yml` is deliberately **not touched** — putting it there is what would let the two drift, and it would also have collided with #10116, which is open on that file.
- **Upper bound measured, not assumed.** The hard ceiling is the OS thread stack (`ulimit -s` = 8192 KB, locally and on `ubuntu-latest`). At or above it V8 runs off the real stack and **SIGSEGV**s instead of throwing: clean `RangeError` up to 8000, `rc=139` at 8192, 9000, 12000, 16000. 4000 keeps a 2x margin under that while giving 3.7x the current need.
- Worst case covered: `--stack-size=4000 --no-opt` (never-optimized frames) is still green.

## H4 — nothing else is close, and size is not the predictor

Across **all 4659 linted files**, ranked by max AST depth:

| AST depth | longest `+` chain | bytes | file |
|---:|---:|---:|---|
| **976** | **970** | 525,477 | `packages/spec/src/migrations/registry.ts` |
| 71 | 64 | 7,276 | `…/entries/semantic/18.driver-sql-unresolvable-where-column-refused.ts` |
| 61 | 2 | 15,191 | `packages/formula/src/stdlib.ts` |
| 56 | 49 | 6,306 | `…/entries/semantic/17.actor-user-roles-to-positions.ts` |
| 48 | 40 | 183,218 | `scripts/check-type-check-coverage.mjs` |
| 44 | 16 | 236,272 | `packages/cli/src/commands/serve.ts` |

The runner-up is **13.7x shallower**. And depth does not track size: the two largest linted files (236 KB, 183 KB) sit at depth 44 and 40.

## What this means for the card's framing

The depth is **not** the generated content. It is `step17.rationale` — a single `+` concatenation of 970 string fragments spanning lines 397–1367, while the nearest generated marker begins at line **1432**. The file's own header says `rationale` is hand-written and outside the markers.

So two of the three directions the card proposed would **not** have worked: splitting the generated output, and exempting the generated regions from parsing. The depth travels with `step17` and is not between the markers to begin with. The permanent fix is to re-spell that one string (a template literal is depth ~4) — a `packages/spec` content change, outside this card's declared file surface, filed as #10122.

## Reverse verification

Direction predicted in writing first, then observed. Decisive leg — identical `registry.ts` bytes (`git hash-object` = `5ff2ab96a0178a0ead8b72365b20d08469274edc` both legs), identical scope, **only the flag differs**:

| trial | default (984 KB) | `--stack-size=4000` |
|---|---|---|
| 1 | exit 1 | exit 0 |
| 2 | exit 1 | exit 0 |
| 3 | exit 1 | exit 0 |

The red leg reproduces the CI message verbatim. Per the card's own demand, this is evidence that the **stack ceiling moved** — not a green CI run, which would prove nothing here since the gate already passed intermittently.

⚠️ A whole-repo `pnpm lint` at the default stack was **green** on this machine, which is why the narrow-scope leg is the one that carries the proof. Reporting that rather than hiding it: a full-repo green is exactly the non-evidence the card warned about.

## Scope

Two files. `package.json` — one script line; the `@changesets/cli` range and the `version` script (the #9465 epic fence) are untouched. `eslint.config.mjs` — **comments only**, no config change; it is the file that already documents how linting is wired, and it was named as possible surface on the claim. `.github/workflows/lint.yml` deliberately untouched.

No changeset: a root script line and a comment block publish nothing.

## Gates

Union derived from the real diff by `node scripts/pm/dispatch-gates.mjs` (no paths — the script takes its own change set off the merge base), run **after** the final commit, at `8b4677b`:

> change set derived from git — 2 path(s) vs merge base 1800ffac2 · `eslint.config.mjs`, `package.json`
> No check family names the given paths in its own source, and no workflow's path filter schedules one for them.

Run anyway, all at `8b4677b`:

- `pnpm lint` — **exit 0**, no findings (the gate this PR changes);
- `check:nul-bytes` — `OK (scanned 6369 text file(s) … no raw ASCII control bytes)`, self-test 75 assertions;
- `check:slot-lookup` — `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new`;
- `check:query-options-erasure` — `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new`.

The last two import `eslint.config.mjs`, so they are the gates coupled to the edited file; both counts are unchanged from their `origin/main` readings. Control-byte scan of both edited files: clean. `package.json` re-parsed as JSON; `eslint.config.mjs` re-imported (6 config blocks).

Rebased state: `origin/main` was re-fetched immediately before pushing and had not moved from `1800ffac2` (0 commits behind), so #10116 had not landed and there was no conflict to resolve.

## Related cards

- #10071 and #10121 are duplicate reports of this same signature — #10121 is still open and worth closing as a duplicate by triage.
- #10122 — the permanent fix, filed from this work.
- #10123 — a separate silent hole found on the way: the two ESLint ratchet gates discard a fatal parse error as a non-matching message, so an unparseable file scores clean instead of red.

_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqDQYVU5smx29ts9pAErja)_