### PR TITLE
fix(tests): make plugin-auth's rate-limit isolation radius visible to the gate and hashed by turbo

### DIFF
--- a/packages/plugins/plugin-auth/src/rate-limit-storage-isolation.test.ts
+++ b/packages/plugins/plugin-auth/src/rate-limit-storage-isolation.test.ts
@@ -41,37 +41,52 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 /**
- * This package is CJS-typed (no `"type": "module"` — it publishes
- * `dist/index.js` as CommonJS), so `module: NodeNext` forbids `import.meta`
- * here. Walk up from the CWD instead, which works wherever vitest is invoked
- * from.
+ * Seeded from `__dirname`, not from a `findUp` walk of `process.cwd()`, and not
+ * from `dirname(fileURLToPath(import.meta.url))`. Both halves of that choice are
+ * load-bearing — the same pair `managed-extension-fields.test.ts` and
+ * `platform-objects/src/managed-api-method-affordance-sweep.test.ts` state for
+ * their sibling repo-wide walks:
+ *
+ *  - `import.meta` is a TS1470 here. This package is CJS-typed (no
+ *    `"type": "module"` — it publishes `dist/index.js` as CommonJS), so under
+ *    `module: NodeNext` the meta-property is an error however well it runs under
+ *    vitest, and this package's test layer IS in front of tsc through the
+ *    `@objectstack/plugin-auth` TEST_DEBT entry in `check-type-check-coverage.mjs`.
+ *    `__dirname` type-checks under the package's own config and is defined at
+ *    runtime by vitest's transform.
+ *  - `check:cross-package-test-inputs` detects an escaping read STATICALLY, by
+ *    resolving the seed expression. A `findUp` walk from `process.cwd()` is not a
+ *    spelling it resolves — `process.cwd()` appears nowhere in that detector — so
+ *    the two cross-package directory reads at the bottom of this file yielded no
+ *    flag and therefore no declaration, SILENTLY. Measured before this change:
+ *    `--list-escapes` named only `managed-extension-fields.test.ts` for
+ *    plugin-auth, and `@objectstack/plugin-auth#test`'s turbo input hash
+ *    (`1bf3935543ab055b`) did not move when `packages/runtime/src` changed — so a
+ *    runtime-only diff that reinstated the package-root import replayed a cached
+ *    green over the very scan that catches it (#7802's shape, #10029).
+ *
+ * Deriving the roots any other way puts this file back in that blind spot.
  */
-function findUp(predicate: (dir: string) => boolean, what: string): string {
-  let dir = process.cwd();
-  for (;;) {
-    if (predicate(dir)) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) throw new Error(`could not locate ${what}`);
-    dir = parent;
-  }
-}
+const HERE = __dirname;
+/** …/packages/plugins/plugin-auth/src → the package root, then the repo root. */
+const PKG = resolve(HERE, '..');
+const REPO = resolve(HERE, '../../../..');
 
-const PKG = findUp((dir) => {
-  const manifest = join(dir, 'package.json');
-  if (!existsSync(manifest)) return false;
-  const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };
-  return name === '@objectstack/plugin-auth';
-}, 'the @objectstack/plugin-auth package root');
+const SRC = HERE;
 
-const REPO = findUp(
-  (dir) => existsSync(join(dir, 'pnpm-workspace.yaml')),
-  'the workspace root (pnpm-workspace.yaml)',
-);
-
-const SRC = join(PKG, 'src');
+/**
+ * The two consumer packages the root-import scan at the bottom of this file
+ * walks. Bound here, by name, so the gate can ROSTER them: these two paths are
+ * `@objectstack/plugin-auth`'s declared cross-package radius in
+ * `scripts/check-cross-package-test-inputs.mjs`, and the matching
+ * `$TURBO_ROOT$` entries under `@objectstack/plugin-auth#test` in `turbo.json`
+ * are what make this task's cache hash move when either directory changes.
+ */
+const RUNTIME_SRC = resolve(REPO, 'packages/runtime/src');
+const SERVICE_SMS_SRC = resolve(REPO, 'packages/services/service-sms/src');
 
 /**
  * Strip comments before scanning. The distinction this file turns on — a
@@ -280,12 +295,31 @@ describe('@objectstack/plugin-auth — ./rate-limit-storage stays free of better
     // that package. Scanned by directory rather than by filename so moving a
     // consumer file does not quietly retire the check.
     const COUNTER_SYMBOLS = /\b(incrementFixedWindow|createLazyCounterStore|InProcessCounterStore|CounterStore|FixedWindowCount|LazyCounterStoreOptions)\b/;
-    const roots = ['packages/runtime/src', 'packages/services/service-sms/src'];
+    // Each root is bound by NAME above and handed to `readdirSync` by that name,
+    // rather than looped over as `join(REPO, root)` with `root` an array element.
+    // That is not a style preference: `check:cross-package-test-inputs` learns a
+    // DIRECTORY input only when a directory-read consumes an expression it can
+    // resolve, and its own header lists "a directory read whose path is only a
+    // loop variable" among the shapes that yield no name. Written as a loop the
+    // two globs below would be declared but UNHELD — nothing would fail if a
+    // later edit deleted them, which is the #9763 failure mode (prose holding a
+    // radius) one level up. Written this way the gate rosters both directories
+    // and fails if the declaration stops covering them.
+    expect(
+      existsSync(RUNTIME_SRC),
+      'packages/runtime/src — consumer directory moved; re-point this check',
+    ).toBe(true);
+    expect(
+      existsSync(SERVICE_SMS_SRC),
+      'packages/services/service-sms/src — consumer directory moved; re-point this check',
+    ).toBe(true);
     const offenders: string[] = [];
-    for (const root of roots) {
-      const abs = join(REPO, root);
-      expect(existsSync(abs), `${root} — consumer directory moved; re-point this check`).toBe(true);
-      for (const entry of readdirSync(abs, { recursive: true, withFileTypes: true })) {
+    const trees = [
+      readdirSync(RUNTIME_SRC, { recursive: true, withFileTypes: true }),
+      readdirSync(SERVICE_SMS_SRC, { recursive: true, withFileTypes: true }),
+    ];
+    for (const entries of trees) {
+      for (const entry of entries) {
         if (!entry.isFile() || !entry.name.endsWith('.ts')) continue;
         const file = join(entry.parentPath, entry.name);
         for (const m of stripComments(readFileSync(file, 'utf8')).matchAll(FROM)) {

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -295,7 +295,33 @@ const CROSS_PACKAGE_TEST_INPUTS = {
   '@objectstack/plugin-auth': {
     // src/managed-extension-fields.test.ts walks every `*.object.ts`, and pins
     // core's api-key source alongside it.
-    globs: ['packages/**/*.object.ts', 'packages/core/src/security/**'],
+    globs: [
+      'packages/**/*.object.ts',
+      'packages/core/src/security/**',
+      // src/rate-limit-storage-isolation.test.ts (#6040) walks BOTH consumer
+      // packages of the `./rate-limit-storage` subpath by directory, checking
+      // that neither reaches the counter through the package ROOT — which would
+      // silently reinstate the whole better-auth load for them. The diff that
+      // breaks that invariant is a diff in one of these two directories, so
+      // without them declared the affected-subset filter never adds plugin-auth
+      // and turbo replays a cached green over the scan (#10029, the #7802
+      // shape). Measured: before this entry, `@objectstack/plugin-auth#test`
+      // hashed to `1bf3935543ab055b` both before and after a change under
+      // `packages/runtime/src`, and the re-run was `>>> FULL TURBO` in 135ms
+      // while the invariant was live-broken in the tree.
+      'packages/runtime/src/**',
+      'packages/services/service-sms/src/**',
+      // The three below are NAMED in that test's prose rather than read by it —
+      // the same shape as `serve.ts` on the @objectstack/spec entry above and
+      // `realtime-protocol.mdx` on @objectstack/dogfood, and settled the same
+      // way: the literal collector takes quoted paths without parsing, so a
+      // mention forces a declaration, and declaring the file is cheaper than
+      // rewording prose to dodge the scanner. All three are low-churn, so the
+      // added cache invalidation is nominal next to the two directories above.
+      'scripts/check-published-files.mjs',
+      'scripts/check-cross-package-test-inputs.mjs',
+      'packages/types/src/node-isolation.test.ts',
+    ],
   },
   '@objectstack/plugin-security': {
     // src/audience-anchor-set-claims.pin.test.ts pins against spec's

--- a/turbo.json
+++ b/turbo.json
@@ -112,7 +112,12 @@
         "!coverage/**",
         "!.turbo/**",
         "$TURBO_ROOT$/packages/**/*.object.ts",
-        "$TURBO_ROOT$/packages/core/src/security/**"
+        "$TURBO_ROOT$/packages/core/src/security/**",
+        "$TURBO_ROOT$/packages/runtime/src/**",
+        "$TURBO_ROOT$/packages/services/service-sms/src/**",
+        "$TURBO_ROOT$/scripts/check-published-files.mjs",
+        "$TURBO_ROOT$/scripts/check-cross-package-test-inputs.mjs",
+        "$TURBO_ROOT$/packages/types/src/node-isolation.test.ts"
       ]
     },
     "@objectstack/plugin-security#test": {


### PR DESCRIPTION
`Part of #10029` — the finding also lists directions B (teach the detector the `findUp` shape, repo-wide) and C (leave it recorded). This PR implements the graded direction A only, so the card should stay open for a decision on B.

## The defect, measured on the parent commit (`2d3860df9`)

`rate-limit-storage-isolation.test.ts` reads `packages/runtime/src` and `packages/services/service-sms/src` to check that neither consumer reaches the fixed-window counter through the package **root** — the #6040 invariant whose breach silently reinstates the whole better-auth load for `service-sms`. It derived its roots with a `findUp` walk from `process.cwd()`.

`check:cross-package-test-inputs` resolves seed expressions statically. `process.cwd` appears **nowhere** in that detector (`grep -c 'process\.cwd'` → `0`; counter-checked against `__dirname` → `8` and `import.meta.dirname` → `7`, so the zero is a measurement, not a broken search). The read therefore produced no flag, no declaration, and no turbo input:

```
$ node scripts/check-cross-package-test-inputs.mjs --list-escapes
@objectstack/plugin-auth  (packages/plugins/plugin-auth)
    packages/plugins/plugin-auth/src/managed-extension-fields.test.ts      <-- only this one
```

Turbo's `@objectstack/plugin-auth#test` input set (224 entries, package-relative) contained **0** paths under `../../runtime/src` and **0** under `../../services/service-sms/src`, against counter-checks of 35 for `../../core/src/security` and 11 for `../../services/service*` — the declared globs, present as expected.

### The cache replay, demonstrated rather than asserted

Reinstating the root import in `packages/runtime/src/security/inbound-rate-limit.ts` — the exact regression this test guards — and re-running the task:

```
@objectstack/plugin-auth:test: cache hit, replaying logs 1bf3935543ab055b
 Tasks:    26 successful, 26 total
  Time:    135ms >>> FULL TURBO          # exit 0
```

The same tree, run directly, is **red**:

```
FAIL  src/rate-limit-storage-isolation.test.ts > no cross-package consumer reaches the counter through the package ROOT
+   "packages/runtime/src/security/inbound-rate-limit.ts -> { createLazyCounterStore, type CounterStore } from the package root"
```

A green replayed over a live-broken invariant. That is #7802's shape, on the gate that exists to prevent it.

## What changed

1. **Reseed from `__dirname`.** TS1470-free under this CJS-typed package's `module: NodeNext`, and a spelling the detector resolves — the rationale `managed-extension-fields.test.ts` and `platform-objects/src/managed-api-method-affordance-sweep.test.ts` already state for their sibling walks.

2. **Bind each consumer root by name.** The gate rosters a *directory* only when a directory-read consumes an expression it can resolve; `join(REPO, root)` over an array element yields no name (its own header lists "a directory read whose path is only a loop variable" among the shapes that yield nothing). Written as a loop, the globs would have been **declared but unheld** — nothing would fail if a later edit deleted them, which is #9763's failure mode one level up. Now `readdirSync(RUNTIME_SRC, …)` / `readdirSync(SERVICE_SMS_SRC, …)` take named bindings.

3. **Declare the radius** in `CROSS_PACKAGE_TEST_INPUTS` and mirror it into `turbo.json`'s `@objectstack/plugin-auth#test` inputs.

Three of the declared entries (`scripts/check-published-files.mjs`, `scripts/check-cross-package-test-inputs.mjs`, `packages/types/src/node-isolation.test.ts`) are **named in the test's prose rather than read by it**. Declared rather than reworded, following the settled treatment of `serve.ts` on the `@objectstack/spec` entry and `realtime-protocol.mdx` on `@objectstack/dogfood`: the literal collector takes quoted paths without parsing, so a mention forces a declaration, and declaring is cheaper than rewording prose to dodge the scanner. All three are low-churn.

## Proof that the gate now SEES the radius (not merely exits 0)

The gate names both directories in its roster — the failure text before the globs were declared:

```
  - @objectstack/plugin-auth names path(s) no declared glob covers …
      packages/runtime/src/               (listed in …/rate-limit-storage-isolation.test.ts)
      packages/services/service-sms/src/  (listed in …/rate-limit-storage-isolation.test.ts)
```

It is *demanding* these globs, so they are held: delete them and the gate goes red. After declaring:

```
OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.
```

## Proof that turbo now HASHES the two packages

| | inputs | `#test` hash |
|---|---|---|
| before | 224 (runtime: **0**, service-sms: **0**) | `1bf3935543ab055b` |
| after | 489 (runtime: **250**, service-sms: **12**) | `844fad10458a8a2b` |

## Ablation — prediction stated first, then observed

**Predicted:** with the fix in place, the same runtime mutation must (a) move the hash off `844fad10458a8a2b`, (b) **miss** the cache and actually execute, and (c) fail with the same offender string.

**Observed** — all three:

```
@objectstack/plugin-auth:test: cache miss, executing ee3c9517b568ff5e
AssertionError: Import the counter from "@objectstack/plugin-auth/rate-limit-storage" …
+   "packages/runtime/src/security/inbound-rate-limit.ts -> { createLazyCounterStore, type CounterStore } from the package root"
 Test Files  1 failed | 59 passed (60)
      Tests  1 failed | 1334 passed (1335)      # 52.4s, exit 1 — not 135ms, not green
```

**Restore proven byte-identical**, both sides via `git hash-object`:

```
pristine  975b538b2744bc9b944ce12d7e529d91705da43f
mutated   6fc0564f417c77dc5f233553d7b5f02526fbdf68
restored  975b538b2744bc9b944ce12d7e529d91705da43f   ==  pristine
```

**No rebuild was needed for the mutation to be observable, and that is a property of the files involved, not an assumption.** The assertion reads `packages/runtime/src/**/*.ts` as raw source text through `fs.readFileSync`; nothing on its path resolves through `@objectstack/runtime`'s `exports` or `dist/`. The test's own header states this deliberately ("a SOURCE-level scan rather than a probe of `dist/`", because a gate reading build output passes or fails by local build state). Confirmed against the run: all 25 dependency `build` tasks stayed cached — no rebuild occurred — and the test still turned red. A stale `dist/` therefore cannot mask this ablation in either leg.

## Verification

Gate union derived with `node scripts/pm/dispatch-gates.mjs` (no paths passed) **after** the final commit, on a clean worktree, at `0a0019c93`. Exit codes captured before any pipe.

| gate | exit |
|---|---|
| `check:cross-package-test-inputs` (incl. 57 self-test cases) | 0 |
| `check:slot-lookup` | 0 |
| `check:test-source-alias` | 0 |
| `check:type-source-resolution` | 0 |
| `scripts/docs-audit/check-affected-docs.mjs` | 0 |
| `check:query-options-erasure` | 0 |
| `check:type-check-coverage` | 0 |
| `check:type-check-debt` (`--re-measure`, 33 entries, built closure) | 0 |
| `check:engine-double-contract` | 0 |
| `check:where-matcher` | 0 |
| `check:nul-bytes` | 0 |
| `pnpm --filter @objectstack/plugin-auth typecheck` | 0 |
| `turbo run test --filter=@objectstack/plugin-auth` | 0 — 60 files, 1335 tests |

`check:type-check-debt` reported *"33 ledger entr(ies) re-measured … none above its recorded number"*. **No ledger entry was raised**: `scripts/check-type-check-coverage.mjs` is untouched (empty diff), so `@objectstack/plugin-auth` stays at 109 and the self-test fixture at `:2766` is unmodified.

## Merge-queue cost, stated deliberately

This is direction A's known price and it is not small: `@objectstack/plugin-auth#test` now re-runs on **any** diff under `packages/runtime/src` (250 files) or `packages/services/service-sms/src` (12). That suite is ~50s / 1335 tests, and the queue runs the full suite under heavier load than the PR path. Buying that is the point — the gate's own header argues the radius is what the list buys over "just always run those packages" — but reviewers should expect runtime-touching PRs to newly schedule this suite where `main` has been serving a cached green.

## Not done, deliberately

- **`managed-extension-fields.test.ts` is untouched.** It is the only *other* escaping read the gate sees in this package and it alone holds the `packages/**/*.object.ts` radius; its `__dirname` seed is intact (its `findUp` occurrence is a prose mention, verified).
- **The detector is not extended** (direction B). Nothing here teaches it the `findUp` shape, so the class remains open repo-wide — that decision is still the card's.

## Release notes input

No changeset: this PR touches one test file, one CI gate script and `turbo.json`, and publishes nothing. Requesting the `skip-changeset` label per that mechanism rather than shipping an empty changeset. Following the gate, not habit — `content/docs/releases/` is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_