### PR TITLE
ci(lint): run scripts/pm/ci-failure.mjs --self-test in Lint & Repo Gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -388,6 +388,53 @@ jobs:
       - name: Verify-lock entry-point self-test
         run: bash scripts/pm/os-verify-lock.sh --self-test
 
+      # ci-failure self-test (#9898). Fifth member of the PM self-test family
+      # above, and until now the odd one out: `scripts/pm/ci-failure.mjs` — the
+      # one command from "a check is red" to "here is the failing assertion" —
+      # shipped a `--self-test` that NO job ran, so it executed only when a
+      # human or an agent typed it.
+      #
+      # This tool is worth the second because the rot it would hide is the exact
+      # defect its own card was about. The file was found near-complete but
+      # NEVER RUN LIVE: node 22's `fetch` ignores HTTPS_PROXY, so behind an agent
+      # container's proxy every read answered 401 and the tool's own transport
+      # probe reported PREREQUISITE NOT MET (exit 3) — and looked right doing it.
+      # ⇒ A retrieval tool that has stopped working presents as a tool correctly
+      # declining to work. Nothing about that shape reads as broken, which is
+      # what makes an unrun self-test the wrong economy here specifically.
+      #
+      # The self-test is also materially larger than when the card was filed:
+      # #9966/PR #10157 corrected the transport probe (a healthy `/rate_limit`
+      # was greening containers whose repo-scoped reads are refused — the fourth
+      # measured container class) and added nine cases, which is why this step
+      # was deliberately ordered AFTER that fix. Wiring a false green into a
+      # required job would have pinned it as CI-enforced truth.
+      #
+      # Beyond the pure predicates it pins the LIVE WIRING: `resolveStep` is run
+      # against the real `.github/workflows/` tree, so reshaping the workflows
+      # until no step name resolves to a `run:` block reddens here rather than
+      # silently degrading every gate failure from "here is the command" into
+      # "no substitute available".
+      #
+      # Unconditional and un-`if:`-ed, like every self-test above it — an
+      # exemption is precisely what a self-test must not have, or the gap moves.
+      #
+      # NO NETWORK, measured rather than assumed (#9898), because a self-test
+      # that reached GitHub would put this required context at the mercy of API
+      # availability — a far worse trade than the rot it prevents. Under
+      # `strace -f` with full egress available the run makes ZERO `socket()` and
+      # ZERO `connect()` calls (the live walk, traced identically, makes 3 and
+      # 3), and it exits 0 inside an empty network namespace where the live walk
+      # exits 3. The `--self-test` branch is chosen before the transport probe
+      # and never re-execs, and its two readers are injected. ~0.14 s.
+      #
+      # Invoked as `node` rather than through a `pnpm check:*` alias, same as
+      # the release-rehearsal step above: this card's declared file surface is
+      # this workflow alone, and dispatch-gates.mjs derives gate families from
+      # either spelling.
+      - name: PM ci-failure self-test
+        run: node scripts/pm/ci-failure.mjs --self-test
+
       # Docs/skills authoring guard (#2035 / ADR-0059): TS code blocks in
       # Markdown/MDX are not type-checked or ESLinted, so skills/ and
       # content/docs/ can drift back to teaching the bare `: Page = {}` literal


### PR DESCRIPTION
Fixes #9898

`scripts/pm/ci-failure.mjs` shipped a `--self-test` that **no job ran**. Its four
sibling PM tools all run theirs as unconditional steps in the existing
`Lint & Repo Gates` job; this one was the odd one out, so it could rot until an
agent reached for it mid-round and found it broken.

This adds **one step** to the existing `lint:` job. No new job, no new check
name, no new required context.

## Why this tool specifically

The rot it prevents is the exact defect the tool's own card was about. The file
was found near-complete but **never run live**: node 22's `fetch` ignores
`HTTPS_PROXY`, so behind an agent container's proxy every read answered 401 and
the tool's own transport probe reported `PREREQUISITE NOT MET` (exit 3) — and
looked right doing it. A retrieval tool that has stopped working presents as a
tool correctly declining to work.

The self-test is also materially larger than when the card was filed: #9966 /
PR #10157 (merged today) corrected the transport probe and added nine cases,
including the fourth measured container class. This card was deliberately
ordered *after* that fix — wiring a false green into a required job would have
pinned it as CI-enforced truth.

## Falsification 1 — the step is in the right job (job key + line)

The card's own warning: a gate added to `typecheck:` shows green ticks while
blocking nothing, reproducing this card's failure mode as its fix. Read from
`.github/workflows/lint.yml`, not from the card:

| | job key | line | `name:` (= check-run / required context) |
|---|---|---|---|
| target | `lint:` | **24** | `Lint & Repo Gates` (line **39**) |
| trap | `typecheck:` | 1509 (was 1462) | `TypeScript Type Check` |

Those are the only two jobs in the file. The trap is live: `typecheck:` really
does carry self-test steps of its own, so "this file has self-test steps" would
not have identified the right job.

Parsed rather than grepped — all five land in `lint` / `Lint & Repo Gates`, none
carries an `if:`:

| step | job key | job name | `if:` |
|---|---|---|---|
| `PM dispatch-gates self-test` | `lint` | Lint & Repo Gates | none |
| `Part-of closing-keyword guard self-test` | `lint` | Lint & Repo Gates | none |
| `Single-claim path guard self-test` | `lint` | Lint & Repo Gates | none |
| `PM half-state sweeper self-test` | `lint` | Lint & Repo Gates | none |
| **`PM ci-failure self-test`** (new) | `lint` | Lint & Repo Gates | none |

The new step is index 23 of 74 in `jobs.lint.steps`, keys `['name', 'run']`.

No required-context registry edit is needed, and none is possible by accident:
`scripts/check-required-contexts.mjs` assertion 10 explicitly forbids a registry
entry from embedding a step count, precisely so adding a step cannot desync it.

## Falsification 2 — it needs no network (measured, not inferred)

A self-test that reached GitHub would put this required context at the mercy of
API availability. "It worked here" is not that claim, so it was measured three
ways, each with its instrument falsified against this same file's **live** path:

| reading | `--self-test` | live walk (control) |
|---|---|---|
| `strace -f`, network available | **0** `socket()`, **0** `connect()` | 3 `socket(AF_INET)`, 3 `connect()` |
| empty network namespace (`unshare -rn`) | **exit 0** | exit 3, `GET /rate_limit did not complete: fetch failed` |
| in-process egress tripwire | 0 attempts | (see note) |

The `strace` reading is the load-bearing one: zero socket syscalls **with full
egress available**, following forks, so nothing is hidden in a subprocess.

Note on the tripwire, recorded because it nearly produced a false reading: its
`fetch` arm fires correctly, but its `child_process` arm is blind to a **named
ESM import binding**, which is exactly how this file imports `spawnSync`. Caught
by falsifying the instrument rather than trusting its "clean". `strace` and the
namespace have no such blind spot.

Structurally this is not accidental: the `--self-test` branch is selected before
the transport probe, it never re-execs, and its two readers are injected.

## Falsification 3 — the step runs, rather than no-opping

"I added the step and CI is green" does not distinguish a step that ran from one
that no-opped, so both no-op shapes were driven:

- **Broken self-test reddens.** Mutating `isNewer` in the shipped file
  (`return at > bt` → `at < bt`; confirmed on disk by grep count 1→0 / 0→1, not
  by an editor exit code) makes the step's exact command exit **1** with two
  named failures. Restored to byte-identity with `HEAD` and re-run green.
- **A wrong path reddens** (exit 1, `ERR_MODULE_NOT_FOUND`) rather than exiting
  0 the way a zero-match `pnpm --filter` would.

## Runtime

~65–170 ms, median ~0.10 s (8 runs), against a job that already runs ~70 gate
steps including a ~15 s one. It reads files and runs pure predicates.

## Gates

`node scripts/pm/dispatch-gates.mjs` with no path args, derived from the real
diff at `b3955be`: `check:node-version`, `check:required-contexts`,
`check:shard-attestation`, `check:workflow-status-functions`,
`check:type-check-coverage` — all green.

Extra, because editing `lint.yml` moves gates no path derivation names (found by
grepping for readers of the file): `check:changeset-gate-self-tests` (its
wiring half slices the `lint:` job out by anchors and asserts the slice is
non-empty — green, so the insertion did not stale those anchors),
`check:filter-alias-parity`, `check-merge-queue-triage-outcome --self-test`,
`check-cross-repo-closer-outcome --self-test`, `check:nul-bytes` — all green.

Declared narrowing: `check:type-check-debt` (`--re-measure`) was not run. It
re-runs `tsc` across the debt ledger to re-measure error counts; this diff
contains no TypeScript. CI runs it regardless.

`skip-changeset`: this diff is one workflow file and publishes nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_