### PR TITLE
fix(devx): reserve the port smoke_pick_free_port hands out, instead of probing and letting go

### DIFF
--- a/packages/spec/scripts/publish-smoke-port-collision.test.ts
+++ b/packages/spec/scripts/publish-smoke-port-collision.test.ts
@@ -53,6 +53,25 @@
 // server. Without those a green "retargeted" could mean nothing was listening
 // and nothing was turned down.
 //
+// ## What the "skips one that is already held" test can and cannot see (#10212)
+//
+// The sibling collision test lost a round to a vacuity hole: its `PICKED_WITH_BUSY`
+// assertion stayed green on the broken picker because its occupier could lose its
+// own bind and die, making the next pick return the occupied number legitimately.
+// That hole is NOT present here — `HOLDER_REACHABLE` curls the occupier and is the
+// precondition guard the sibling was missing, and it was re-measured against the
+// pre-fix script rather than assumed.
+//
+// The blind spot here is a different one, and worth naming because a green run is
+// what hid it: that test draws its two ports SEQUENTIALLY, and the TOCTOU defect
+// is about CONCURRENT callers. It is sound but silent on the defect — measured
+// green on the unfixed picker, exactly as designed, because a second pick taken
+// after the first port is already held really does skip it. Detecting a
+// check-then-use race needs callers that overlap in time, which is what
+// `CONCURRENT_DISTINCT` below adds. `TRIPLE_DISTINCT` covers the same defect from
+// the cheap direction: before the fix, two picks in one run with nothing bound in
+// between both returned the base.
+//
 // No `objectstack dev` boot and no scaffold: the contract under test belongs to
 // the shell script, and the ports are picked at run time by the script's own
 // helper so this test cannot collide with a concurrent agent — which would be a
@@ -149,6 +168,9 @@ describe.skipIf(!RUNNABLE)('[#9647] publish-smoke.sh smoke-tests its OWN dev ser
     expect(r.SCAFFOLDED).toBe('no');
   });
 
+  // Sequential by construction, and therefore blind to the TOCTOU race by
+  // construction — see the header. Kept because "does it skip a busy port" is a
+  // real property worth pinning; the concurrent cases below are what pin #10212.
   it('picks a per-run port and skips one that is already held', () => {
     const r = runHarness([
       'FIRST="$(smoke_pick_free_port 3210)"',
@@ -236,5 +258,77 @@ describe.skipIf(!RUNNABLE)('[#9647] publish-smoke.sh smoke-tests its OWN dev ser
     expect(r.OUR_LEADER_ALIVE).toBe('yes');
     expect(r.WAIT_RC).not.toBe('0');
     expect(r.WAIT_SAID_STATE_FILE).toBe('1');
+  });
+
+  // ── #10212: the port is RESERVED, not merely probed ──────────────────────
+  //
+  // These deliberately do NOT override SMOKE_PORT_RESERVATION_DIR: sharing one
+  // host registry is the fix, so the cases that measure contention have to run
+  // against the registry real callers use. Only the protocol test below, which
+  // needs to plant a specific registry state, points somewhere scratch.
+
+  it('hands concurrent callers scanning one base distinct ports', () => {
+    const r = runHarness([
+      // Eight at once from a single base. Before the fix every one of them was
+      // handed 3210 — not usually, but by construction, because the scan is
+      // deterministic and the probe socket was closed before the port was
+      // reported free.
+      'for i in 1 2 3 4 5 6 7 8; do ( smoke_pick_free_port 3210 > "$SMOKE_ROOT/pick.$i" ) & done',
+      'wait',
+      // The picker prints with NO trailing newline, so each file is read on its
+      // own; `cat`-ing them together concatenates eight numbers into one line
+      // and any distinct-count taken from that reads 1 whatever happened.
+      'for f in "$SMOKE_ROOT"/pick.*; do printf "%s\\n" "$(cat "$f")"; done > "$SMOKE_ROOT/picks.txt"',
+      'echo "CONCURRENT_TOTAL=$(grep -c "[0-9]" "$SMOKE_ROOT/picks.txt")"',
+      'echo "CONCURRENT_DISTINCT=$(sort -u "$SMOKE_ROOT/picks.txt" | grep -c "[0-9]")"',
+    ]);
+    // Vacuity guard: all eight callers actually produced a port. Without this a
+    // picker that failed outright would score a perfect distinct-count of 0.
+    expect(r.CONCURRENT_TOTAL).toBe('8');
+    expect(r.CONCURRENT_DISTINCT).toBe('8');
+  });
+
+  it('gives each pick within one run its own port', () => {
+    const r = runHarness([
+      // Nothing binds anything here: the only thing that can keep these apart is
+      // the claim outliving the call. Before the fix all three returned the base.
+      'A="$(smoke_pick_free_port 3210)"',
+      'B="$(smoke_pick_free_port 3210)"',
+      'C="$(smoke_pick_free_port 3210)"',
+      'echo "TRIPLE=$A,$B,$C"',
+      'echo "TRIPLE_DISTINCT=$(printf "%s\\n" "$A" "$B" "$C" | sort -u | grep -c "[0-9]")"',
+    ]);
+    expect(r.TRIPLE).toMatch(/^\d+,\d+,\d+$/);
+    expect(r.TRIPLE_DISTINCT).toBe('3');
+  });
+
+  it('skips a port held from outside the registry and hands the claim back', () => {
+    const r = runHarness([
+      'export SMOKE_PORT_RESERVATION_DIR="$SMOKE_ROOT/reg"',
+      // Take a port, then forget the claim — now the port is held by something
+      // the registry knows nothing about, which is the one case a claim cannot
+      // cover and the probe still has to.
+      'STEAL="$(smoke_pick_free_port 3210)"',
+      'rm -f "$SMOKE_PORT_RESERVATION_DIR/$STEAL"',
+      'STUB_PORT="$STEAL" STUB_NAME=THIEF node -e "$STUB" >/dev/null 2>&1 & THIEF=$!',
+      'sleep 1',
+      'echo "STEAL_BASE=$STEAL"',
+      'echo "STEAL_HELD=$(curl -sS "http://localhost:$STEAL/" | jq -r .iam)"',
+      'PICK="$(smoke_pick_free_port $STEAL)"',
+      'echo "STEAL_PICK=$PICK"',
+      'echo "STEAL_CLAIM_RELEASED=$([ -e "$SMOKE_PORT_RESERVATION_DIR/$STEAL" ] && echo no || echo yes)"',
+      'echo "STEAL_CLAIM_ON_PICK=$([ -e "$SMOKE_PORT_RESERVATION_DIR/$PICK" ] && echo yes || echo no)"',
+      'kill "$THIEF" 2>/dev/null',
+    ]);
+    // Vacuity guard: the thief really held the port.
+    expect(r.STEAL_HELD).toBe('THIEF');
+    expect(r.STEAL_PICK).not.toBe(r.STEAL_BASE);
+    // POSITIVE CONTROL, and it is not optional. "No claim file for the stolen
+    // port" is also what a registry that does not exist looks like, so
+    // STEAL_CLAIM_RELEASED is vacuously green on the unfixed script — measured,
+    // not assumed. STEAL_CLAIM_ON_PICK is what fails there, and it is what makes
+    // the release assertion mean anything.
+    expect(r.STEAL_CLAIM_ON_PICK).toBe('yes');
+    expect(r.STEAL_CLAIM_RELEASED).toBe('yes');
   });
 });

--- a/scripts/publish-smoke.sh
+++ b/scripts/publish-smoke.sh
@@ -175,22 +175,173 @@ cleanup() {
 # app-specific assertion available is the authenticated CRUD probe in section 3,
 # which lands after the auth probes have already run against the wrong app.
 
-# Print a TCP port that is free right now, searching upward from $1.
+# Print a TCP port that is free right now AND reserved for this caller,
+# searching upward from $1.
 #
-# ADVISORY ONLY. It reserves nothing, and `objectstack dev` binds a moment later,
-# so a concurrent run can still take the port in between. Closing that race is
-# not this helper's job — smoke_wait_for_own_server turns losing it into a
-# warning and a correctly retargeted BASE_URL instead of a silent wrong answer.
-# This only has to make losing it rare.
+# WHY A RESERVATION AND NOT JUST A PROBE.
+#
+# The probe below used to be the whole of this helper: bind a socket, CLOSE it,
+# and report the port free. Between that close and `objectstack dev`'s own bind
+# the port is unowned, and the scan is deterministic from $base upward, so every
+# concurrent caller starting at the same base was handed the same number — a
+# check-then-use race whose "use" is in another process, colliding by
+# construction rather than by bad luck. Measured on this tree with the
+# reservation removed, eight concurrent callers scanning from 3210:
+#
+#     DISTINCT_PORTS=1 of 8       # every one of them was handed 3210
+#     BIND_OK=1  BIND_ERR=7       # seven lost the follow-up bind:
+#                                 #   Error: listen EADDRINUSE :::3210
+#
+# The identical shape in scripts/gen-sdui-manifest.sh dequeued a PR from the
+# merge queue (#10167, fixed in #10217 — this is the port of that fix). The
+# contention here is not hypothetical either: the collision test beside this
+# script draws from 3210 four times and the real path below draws once more, in
+# a container several agents share.
+#
+# So a port is CLAIMED before it is probed, in a registry every caller on this
+# host shares, and the claim outlives this function — it is released when the
+# claiming process dies, not when this function returns. Two cooperating callers
+# can no longer be handed the same port at all. The probe stays, because a claim
+# says nothing about processes that never heard of this registry.
+#
+# STILL ADVISORY against those, and that half is deliberately unchanged: nothing
+# here stops a process outside the registry from taking the port between this
+# function and `objectstack dev`'s bind. smoke_wait_for_own_server is what turns
+# losing that race into a warning and a correctly retargeted BASE_URL instead of
+# a silent wrong answer — see the collision-safety block above, which is why
+# this script never needed the loud-failure half the sdui fix relies on. What
+# the claim removes is the collision this script's own callers cause each other,
+# which is every collision anyone has actually measured here.
 #
 # Probes the wildcard address with no host argument, the same spelling
 # serve.ts's own isPortAvailable() uses, so this sees a busy port exactly when
-# the CLI would.
+# the CLI would. (The sibling helper probes 127.0.0.1 because vite binds
+# loopback; that difference is load-bearing in both directions and is why these
+# two functions are ported rather than merged — see the registry note below.)
 smoke_pick_free_port() {
-  node - "${1:-3210}" "${2:-200}" <<'SMOKE_PICK_FREE_PORT'
+  local base="${1:-3210}" span="${2:-200}"
+  local dir="${SMOKE_PORT_RESERVATION_DIR:-${TMPDIR:-/tmp}/objectstack-port-reservations}"
+
+  # `O_EXCL` alone already gives exactly one winner per port, so the lock is not
+  # what makes a claim exclusive — it makes the SWEEP of abandoned claims safe,
+  # which is the one step that unlinks a file another scanner may be creating.
+  # Missing `flock` therefore degrades to "sound, minus the sweep's tie-break",
+  # never to a hard failure: this script runs on developer machines too.
+  #
+  # The descriptor is opened by a subshell that exits before the dev server is
+  # spawned, so nothing this script starts can inherit it. That matters more here
+  # than it looks: `objectstack dev` leaves a `serve` child that outlives its
+  # parent (see kill_tree above), and an inherited lock fd would keep the
+  # registry locked by that orphan for the whole run.
+  if command -v flock >/dev/null 2>&1; then
+    (
+      flock -w 30 9 2>/dev/null || true
+      smoke_scan_and_reserve_port "$base" "$span"
+    ) 9>"${dir}.lock"
+  else
+    smoke_scan_and_reserve_port "$base" "$span"
+  fi
+}
+
+# The scan itself: claim, then probe, then hand the port over. Split out from
+# `smoke_pick_free_port` only so the lock above wraps one named thing.
+smoke_scan_and_reserve_port() {
+  local base="$1" span="$2"
+  node - "$base" "$span" "$$" <<'SMOKE_PICK_FREE_PORT'
 const net = require('node:net');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
 const base = Number(process.argv[2]);
 const span = Number(process.argv[3]);
+// The CALLER's pid, not this node process's: the caller is what will hold the
+// port (it spawns `objectstack dev`), and its death is what makes the claim
+// collectable. `$$` survives the command substitution this helper is called in,
+// so it names the shell running the smoke, not a transient subshell.
+const owner = Number(process.argv[4]);
+
+// One registry per host, shared by every caller that sources this script —
+// sharing it IS the fix, so the tests that measure contention deliberately do
+// not override this. The override exists for tests of the protocol itself.
+//
+// The name is deliberately NOT script-specific. scripts/gen-sdui-manifest.sh
+// runs the same protocol against its own directory today; the two draw from
+// disjoint bases (3210 here, 5180 there), so they cannot collide with each
+// other and nothing is lost by that split right now. Converging both onto this
+// neutral default — and then onto one shared helper — is the follow-up, and it
+// is a pure rename on that side because the on-disk format is identical:
+// filename is the port, contents are the owner pid.
+const dir =
+  process.env.SMOKE_PORT_RESERVATION_DIR ||
+  path.join(process.env.TMPDIR || os.tmpdir(), 'objectstack-port-reservations');
+
+// A claim is collectable once its owner is gone. The floor keeps a claim
+// written moments ago out of the sweep whatever its pid says; the ceiling is a
+// backstop for the case pid liveness cannot see — a dead owner whose pid number
+// has since been reused by something unrelated.
+const SWEEP_FLOOR_MS = 10_000;
+const SWEEP_CEILING_MS = 12 * 60 * 60 * 1000;
+
+const alive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === 'EPERM'; // it exists, it is simply not ours to signal
+  }
+};
+
+const sweep = () => {
+  let names = [];
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  const now = Date.now();
+  for (const name of names) {
+    if (!/^\d+$/.test(name)) continue;
+    const file = path.join(dir, name);
+    let holder;
+    let age;
+    try {
+      holder = Number(String(fs.readFileSync(file, 'utf8')).trim());
+      age = now - fs.statSync(file).mtimeMs;
+    } catch {
+      continue; // vanished under us — someone else already collected it
+    }
+    if (age < SWEEP_FLOOR_MS) continue;
+    if (age < SWEEP_CEILING_MS && Number.isInteger(holder) && holder > 0 && alive(holder)) continue;
+    try {
+      fs.unlinkSync(file);
+    } catch {
+      /* already gone */
+    }
+  }
+};
+
+// `wx` is O_CREAT|O_EXCL: exactly one creator wins, and the losers are told so
+// HERE rather than discovering it at bind time in another process.
+const claim = (port) => {
+  try {
+    fs.writeFileSync(path.join(dir, String(port)), `${owner}\n`, { flag: 'wx' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const release = (port) => {
+  try {
+    fs.unlinkSync(path.join(dir, String(port)));
+  } catch {
+    /* already gone */
+  }
+};
+
+// No host argument: the wildcard bind is the spelling serve.ts's own
+// isPortAvailable() uses, so a port this rejects is a port the CLI would too.
 const isFree = (port) =>
   new Promise((resolve) => {
     const probe = net.createServer();
@@ -198,12 +349,21 @@ const isFree = (port) =>
     probe.once('listening', () => probe.close(() => resolve(true)));
     probe.listen(port);
   });
+
 (async () => {
+  fs.mkdirSync(dir, { recursive: true });
+  sweep();
   for (let port = base; port < base + span; port += 1) {
+    // Claimed by a live caller — including by an earlier call from THIS caller,
+    // which is why two picks in one run cannot return one port.
+    if (!claim(port)) continue;
     if (await isFree(port)) {
       process.stdout.write(String(port));
       return;
     }
+    // Held by something outside the registry. Hand the claim back rather than
+    // hoarding a port we never got, and keep scanning.
+    release(port);
   }
   process.stderr.write(`no free TCP port in [${base}, ${base + span})\n`);
   process.exitCode = 1;


### PR DESCRIPTION
Fixes #10212

## What was wrong, re-derived rather than taken from the card

`smoke_pick_free_port` bound a probe socket, **closed it**, and only then reported the
port free; `objectstack dev` bound it afterwards. The scan walks `base` upward
deterministically, so concurrent callers did not diverge — they were handed the same
port, and the first one every time. Check-then-use, with the "use" in another process.

Both of the PM's mechanism assumptions were measured and both hold: the probe closes
before reporting, and the collision test draws from base `3210` exactly four times
(`FIRST`, `SECOND`, and the two `REQUESTED`s).

Measured on this tree before the change, eight concurrent callers from base `3210`:

```
== phase 1: 8 concurrent callers scanning from base 3210 ==
         5 3210
         3 3211
   DISTINCT_PORTS=2 of 8
== phase 2: 8 concurrent callers pick-then-BIND ==
   BIND_OK_COUNT=2
   BIND_ERR_COUNT=6        # Error: listen EADDRINUSE 0.0.0.0:3210
```

After the change, the same construction:

```
   DISTINCT_PORTS=8 of 8       # 3210 3211 3212 3213 3214 3215 3216 3217
   BIND_OK_COUNT=8
   BIND_ERR_COUNT=0
```

The distinct-count moved between rounds on the unfixed script (1 of 8, then 2 of 8)
while `BIND_ERR_COUNT` stayed at 6 — the collision is by construction, its exact shape
varies with load. That is the property that let it survive: it is never absent, only
sometimes cheaper.

⚠️ **A correction to my own first measurement, because it nearly went into this PR.**
The first repro harness computed `DISTINCT_PORTS` by `cat`-ing the eight result files
together. The picker prints **without a trailing newline**, so all eight numbers landed
on one line and the count read `1 of 8` — for the fixed script too. The instrument, not
the picker, was reporting. It is fixed above and in the test (each file read separately),
and the same trap is commented at the assertion.

## The fix

Ported from #10217 (#10167), which landed on `main` at `318f96ae` while this card was in
flight. I read the **merged** source, not the card's summary — and to show the port is
faithful rather than approximate, here is a diff of the two `node` programs with the
`sdui`/`smoke` naming normalised away:

```
3c3   <  node - "$base" "$span" "$$" << 'PICK_PICK_FREE_PORT'      # heredoc spacing
      >  node - "$base" "$span" "$$" <<'PICK_PICK_FREE_PORT'
13c13 <  path.join(..., 'PICK-port-reservations');                  # registry dir
      >  path.join(..., 'objectstack-port-reservations');
72c72 <  probe.listen(port, '127.0.0.1');                           # probe address
      >  probe.listen(port);
```

Everything else — `O_EXCL` claim, release-on-probe-failure, the sweep with its floor and
ceiling, pid liveness, `flock` around the sweep only — is byte-identical. The three
differences are deliberate:

1. **Heredoc spacing** matches each file's own existing style.
2. **The probe stays on the wildcard address.** This is load-bearing and predates the
   card: it is the spelling `serve.ts`'s own `isPortAvailable()` uses, so this script
   sees a busy port exactly when the CLI would. Copying the sdui helper's `'127.0.0.1'`
   would have been the silent-divergence failure, not the faithful port.
3. **The registry directory is neutral, not `sdui-`prefixed.** Explained below.

So a port is **claimed before it is probed**, in a registry every caller on the host
shares (`${TMPDIR:-/tmp}/objectstack-port-reservations`, overridable via
`SMOKE_PORT_RESERVATION_DIR`), and the claim **outlives the function** — released when
the claiming process dies, not when the function returns. Verified that the claim file
records the *caller's* pid and not the `node` child's: `CLAIM_OWNER=16154` /
`MY_PID=16154`.

### The one design decision the card asked to be made deliberately: one registry or two

The card asked whether the two helpers should share a registry. They now run the same
protocol against two directories, and this PR chose **not** to converge them here:

- The ranges are **disjoint** — `[3210, 3410)` vs `[5180, 5380)` — so they cannot hand
  each other the same port. Sharing buys nothing measurable today.
- The probe-address difference above means a genuinely shared helper needs the address as
  a **parameter**, not a constant. That is a refactor, not a rename.
- Converging meant editing `scripts/gen-sdui-manifest.sh` and its collision test — both
  outside this card's declared file surface, hours after #10217 landed there.

This is **not a second incompatible registry**: the on-disk format is identical (filename
is the port, contents are the owner pid), and the directory name was chosen neutral
precisely so convergence is a pure rename on the sdui side with no migration. Recorded as
#10261 with the design sketch. `#10261 is not addressed here.`

## Tests

`publish-smoke-port-collision.test.ts` gains the race as executed assertions:

- `CONCURRENT_TOTAL` / `CONCURRENT_DISTINCT` — eight subshells, one base, at once.
  `CONCURRENT_TOTAL` is the vacuity guard: without it a picker that failed outright
  would score a perfect distinct-count of zero.
- `TRIPLE_DISTINCT` — three picks in one run, nothing bound in between, must differ.
- `STEAL_HELD` / `STEAL_PICK` / `STEAL_CLAIM_RELEASED`, with **`STEAL_CLAIM_ON_PICK` as
  its positive control**.

### ⭐ The blind-spot check the card asked for — and it is a *different* blind spot

The card asked whether this file's collision test carries the hole that made #10167's
`PICKED_WITH_BUSY` stay green on the broken picker. **It does not**, and that was
measured rather than assumed: `picks a per-run port and skips one that is already held`
already curls its occupier (`HOLDER_REACHABLE`), which is exactly the `BUSY_HELD`
precondition guard #10217 had to add. Nothing needed adding there.

**But it is still blind to this card's defect, for an unrelated reason: it draws its two
ports sequentially, and a TOCTOU race is about callers that overlap in time.** It stayed
green on the broken picker in *both* ablation rounds — correctly, because a second pick
taken after the first port is already held really does skip it. Sound, and silent on the
defect. That is why the new assertions use concurrency instead of strengthening it. Both
findings are written into the test file's header so the next reader does not have to
re-derive them.

### Ablation (fix reverted on disk, tests kept), re-run at the merged head

No rebuild leg is involved, and that is a property of the tests rather than an
assumption: `const SCRIPT = path.resolve(..., 'scripts', 'publish-smoke.sh')` — the
harness reads the shell script from the worktree at run time, so there is no `dist/` that
can go stale. Mutation confirmed on disk before reading any result, anchored on the text
each side owns: `smoke_scan_and_reserve_port=0`, `It reserves nothing=1`. Restoration
confirmed the same way (`=3` / `=0`, clean `git status` against HEAD).

```
× hands concurrent callers scanning one base distinct ports   expected '2' to be '8'
× gives each pick within one run its own port                 expected '1' to be '3'
× skips a port held from outside the registry ...             expected 'no' to be 'yes'
 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

**`STEAL_CLAIM_RELEASED` is vacuously green on the unfixed script — measured, not
argued.** The assertion at line 331 that fails is `STEAL_CLAIM_ON_PICK`, the positive
control; `STEAL_CLAIM_RELEASED` on line 332 never even runs. Driving the same harness
body directly against the unfixed script prints why:

```
STEAL_HELD=THIEF            STEAL_BASE=3210    STEAL_PICK=3211
STEAL_CLAIM_RELEASED=yes    ← green, and meaningless
STEAL_CLAIM_ON_PICK=no      ← the control, red
REGISTRY_DIR_EXISTS=no      ← the reason: no registry ⇒ no claim file either way
```

Note also that `STEAL_PICK != STEAL_BASE` passes on the unfixed script. It is a
regression guard, not a defect assertion, and is labelled as such.

### Green, at `0983862a`

All four port-drawing test files together at `--maxWorkers=4`, so the contention between
the two registries is real and not staged:

```
 Test Files  4 passed (4)
      Tests  22 passed (22)
os-verify-lock: VERDICT command-exit 0 · held the lock 9s · waited 0s
```

The collision test alone was also run three times back to back — `Tests 8 passed (8)`
each time — because a concurrency assertion that passes once proves less than most.

**One thing worth flagging that was NOT mine.** Before merging `main`, running those four
files together reproduced #10167 live on this branch: `gen-sdui-manifest-collision.test.ts`
died with `Error: Command failed: bash /tmp/sdui-collision-*/harness.sh` /
`Error: listen EADDRINUSE: address already in use 127.0.0.1:5180` under `runHarness` —
the merge-queue signature verbatim — and `gen-sdui-manifest-write-target.test.ts` lost
5180 beside it. Confirmed pre-existing by running the three sdui files **without** this
PR's test file in the run (same failures), and gone after merging #10217.

## Gates at `0983862a`

Union derived by `node scripts/pm/dispatch-gates.mjs` with no path args, re-derived after
the merge (2 paths, merge base `318f96ae`). Exit codes captured before any pipe; verdicts
quoted from what each gate printed, not from `$?`. All green:

`check:cross-package-test-inputs` · `check-cross-package-test-inputs.mjs` ·
`spec check:empty-state` · `spec check:liveness` · `check:merge-driver` ·
`check:slot-lookup` · `spec check:strictness-ledger` · `check:type-source-resolution` ·
`spec check:variant-docs` · `docs-audit/check-affected-docs.mjs` ·
`check:query-options-erasure` · `check:type-check-coverage` ·
`check:engine-double-contract` · `check:where-matcher` · `check:nul-bytes`

```
check-nul-bytes: OK (scanned 6088 text file(s) ... no raw ASCII control bytes).
check-engine-double-contract: OK — 331 pinned, 133 in the DEBT ledger, 2 exempt.
check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root) ...
✓ where-matcher conformance holds: 264 matcher(s) discovered ...
```

**Declared narrowing — two gates NOT MEASURED, and that is not a green.**
`check-dev-prereqs.mjs` and the `check:type-check-debt --re-measure` ratchet both refuse
on an unbuilt worktree; `check-dev-prereqs` reports `67 of 67 workspace packages` missing
their `dist/` entry point, a property of the worktree, not of a diff whose two files are a
root shell script and one test file importing nothing from the workspace. Building the
full closure would have held the container's shared verify lock against the other agents
in this round — the same shared-resource harm this card is about. The risk the ratchet
covers for this diff is that the new TS does not typecheck or grows the debt, and that was
measured directly instead:

```
check:test-typecheck: OK — @objectstack/spec's test layer compiles under
packages/spec/tsconfig.test.json; 55 file(s) / 263 error(s) held in
test-typecheck-debt.json (shrink-only)
```

263 is unchanged from what #10217 measured on the same ledger, so the new test code added
none. CI runs the whole farm regardless; this is the cheap half, not a substitute for it.

## Release fence

Untouched, and deliberately so. This PR changes only how a port is **picked**; it changes
nothing about what the smoke **publishes**. No `changeset publish`, no `pnpm run release`,
no tag push, no publish-capable `workflow_dispatch`. The diff is one shell function plus
its test.

## No changeset

Root `scripts/` plus one `packages/spec/scripts/*.test.ts`. Nothing published changes
behaviour, so this carries `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_