### PR TITLE
docs(qa): state the console boot flag per command in RUNNER.md

### DIFF
--- a/docs/qa/platform-checklist/RUNNER.md
+++ b/docs/qa/platform-checklist/RUNNER.md
@@ -202,6 +202,54 @@ contradicts it, and correct it here when it does.
   gets the diagnostic and the fix; the cryptic `command dev not found` only appears when
   the bare binary is invoked directly.
 
+- **`--no-ui` is a flag of `serve` and `start`, NOT of `dev` — boot flags are not portable
+  between the three, in either direction.** Measured on `main` at `736cfb14` by reading
+  each command's own `--help` FLAGS block:
+
+  | boot command | console flag | `--artifact` |
+  |---|---|---|
+  | `os dev` | `--ui` — **no negation**, so `--no-ui` is a parse error | `-a, --artifact` |
+  | `os serve` | `--[no-]ui` | ⛔ not a flag here |
+  | `os start` | `--[no-]ui` | `-a, --artifact` |
+
+  `dev` is the odd one out on `ui`, which is why the flag gets carried across to it:
+  `objectstack dev --no-ui` never runs — `Error: Nonexistent flag: --no-ui`, exit **2**.
+  The absence is real and not a help-rendering artifact: `dev` *does* render
+  `--[no-]compile`, `--[no-]restart` and `--[no-]seed-admin`, and in a single
+  `dev --no-restart --no-ui` run the parser names only `--no-ui`. It cuts the other way
+  too — `serve --no-ui --artifact <path>` rejects only **`--artifact`**. **Check:**
+  `<cmd> --help`; the `--[no-]x` spelling in FLAGS is the only proof that `--no-x`
+  parses. ⛔ Never copy a flag from a sibling command's line.
+
+  **The canonical checklist boot is one invocation, and it makes no `ui` decision to get
+  wrong** (the same line dogfood skill §0 prescribes — a checklist run wants the console):
+
+  ```
+  pnpm -C <abs>/examples/app-showcase exec objectstack dev --ui --seed-admin -p <port> -d file:/tmp/<run>/data.db
+  ```
+
+  `--ui` on `dev` is a no-op forwarder onto `serve`'s `default: true` (`dev` forwards
+  `--ui` only when set, and never forwards a negation), so it is written out for intent,
+  not effect. Use the line as-is and the off switch never comes up.
+
+  ⚠️ **Why this is briefed rather than left to the error message: backgrounded — which is
+  how a runner boots a server — a rejected flag looks exactly like a server that booted
+  and died.** The process is gone, nothing is listening, and the usage dump scrolls past
+  in a log nobody reads until the first request times out — at which point the reader
+  starts debugging the **application**, which was never started. Since #10181 the CLI
+  says so in its own first line, ahead of the usage dump:
+
+  ```
+  objectstack: INVOCATION ERROR — Nonexistent flag: --no-ui. The command never ran: nothing was started and nothing is listening. Invoked as: objectstack dev --no-ui
+  ```
+
+  **So: when a backgrounded boot never answers, read the FIRST line of its log before
+  touching the app** — `INVOCATION ERROR` means the parse failed and no application code
+  ran. The same commit gave the other boot-lookalike a voice:
+  `node packages/cli/dist/index.js` (the package `main`, a re-export barrel) now refuses
+  by name and exits **1**, where it used to exit **0** in silence — the entry point is
+  `packages/cli/bin/run.js`.
+
 ### Trap vocabulary (`traps` field)
 
 | trap | what it fakes | counter |
@@ -216,7 +264,7 @@ contradicts it, and correct it here when it does.
 | `dispatcher-vs-hono-route` | route exists in unit tests, 404s on the real server | oracle = live server trace, never simulated dispatch |
 | `wrong-panel` | feature looks missing on a sibling surface | item's `steps` name the exact surface; check it |
 | `wrong-persona` | admin privileges mask a guard | run guard checks as the non-privileged persona |
-| `absence-inference` | a missing flag/key/script read as a missing capability | follow the forwarding chain to where the default is actually decided, before writing the finding down. A scaffold's bare `objectstack dev` still serves the console: `serve`'s `ui` flag is `default: true, allowNo: true`, so `--no-ui` is the off switch and absence means on |
+| `absence-inference` | a missing flag/key/script read as a missing capability | follow the forwarding chain to where the default is actually decided, before writing the finding down. A scaffold's bare `objectstack dev` still serves the console: `dev` forwards `--ui` only when set and never forwards a negation, and the default is decided one hop downstream by `serve`'s own `ui` flag (`default: true, allowNo: true`) — so absence means ON. ⛔ The off switch `--no-ui` is `serve`'s and `start`'s; `dev` has no such flag and rejects it (environment facts above) |
 
 ## Run records — the GitHub issue is the report
 


### PR DESCRIPTION
Fixes #10087

## What this changes

Docs only — `docs/qa/platform-checklist/RUNNER.md`. Two edits:

1. **New environment fact**: the console boot flag stated **per command**, plus the one
   canonical checklist boot invocation, plus the check that tells a rejected flag apart
   from a crashed boot.
2. **`absence-inference` trap row rewritten** so it stops carrying `--no-ui` across to
   `dev`. That row was the actual defect: its subject sentence is a bare
   `objectstack dev`, but it explained the default-ON console through **`serve`'s** `ui`
   flag and concluded "so `--no-ui` is the off switch" — which reads as a licence to type
   `dev --no-ui`. It now names `dev`'s forwarding behaviour, says the default is decided
   one hop downstream, and states that the off switch belongs to `serve` and `start`.

## Re-measured on current `main` before editing — this was the acceptance criterion

The card's own measurement is stamped at `4a7b3604c` and was **not** copied on trust.
Built `@objectstack/cli` and its dependency closure at `origin/main` = `736cfb14` and ran
the real binary. Verdicts are the commands' own output; exit codes were captured before
any pipe.

**The premise holds.** `dev` still rejects `--no-ui`:

```
$ node packages/cli/bin/run.js dev --no-ui        # EXIT=2
objectstack: INVOCATION ERROR — Nonexistent flag: --no-ui. The command never ran: nothing was started and nothing is listening. Invoked as: objectstack dev --no-ui
 ›   Error: Nonexistent flag: --no-ui
```

**Positive controls, because a zero-hit needs one.** Two paired probes, each with the
control inside the same invocation as the negative:

| probe | rejected | accepted (control) |
|---|---|---|
| `dev --no-restart --no-ui` | `--no-ui` | `--no-restart` — negation syntax works on `dev` |
| `serve --no-ui --artifact ./x.json` | `--artifact` | `--no-ui` — accepted by `serve` |

`--help` FLAGS blocks agree, and `dev` renders `--[no-]compile` / `--[no-]restart` /
`--[no-]seed-admin`, so the missing `--[no-]ui` is a real absence and not a rendering
artifact. Measured surface across all three boot commands:

| command | console flag | `--artifact` |
|---|---|---|
| `os dev` | `--ui` (no negation) | `-a, --artifact` |
| `os serve` | `--[no-]ui` | not a flag |
| `os start` | `--[no-]ui` | `-a, --artifact` |

`dev` is the odd one out, which is why the flag gets carried across to it. The asymmetry
runs both ways, so the doc says "flags are not portable between the three" rather than
just "serve has it".

## One thing HAS changed since the card was filed, and the doc reflects it

The card's sibling `domain:cli` half — issue #10111, now completed — landed as PR #10181,
after the card's stamp. Both lookalikes now announce themselves: the unknown-flag failure prints a
single loud first line ahead of the usage dump, and `node packages/cli/dist/index.js` now
refuses by name and exits **1** where it used to exit **0** in silence (measured, both).

That does not soften this card — the flag surface is unchanged, and #10181's own docblock
says so deliberately: *"Fixing (2) by teaching `dev` to accept `--no-ui` is deliberately
NOT what this module does."* It changes what good documentation looks like: the counter
to the backgrounded-boot failure mode is now actionable, so the new fact ends with **read
the FIRST line of the log before touching the app**, and quotes the literal line to
recognise.

## Deliberately not done

⛔ Making `dev` accept `--no-ui` is in neither card — it is a CLI surface question for the
decision inbox as a Feature. No CLI change here; nothing in this PR adds or removes an
accepted input — the diff is one markdown file.

## Verification

- `pnpm check:nul-bytes` — `check-nul-bytes: OK (scanned 6090 text file(s) ... no raw ASCII control bytes)`
- `pnpm check:platform-checklist` — `check-platform-checklist: OK — 15 areas, 204 items (204 active); coverage: 30 kinds mapped, 0 waived.`
- `node scripts/pm/dispatch-gates.mjs` re-run on the final commit `24b14c81`:
  `No check family names the given paths in its own source, and no workflow's path filter schedules one for them.` (`0 matched`)

**Clause-②: no** — docs-only diff; no contract accept/reject behaviour changes and no
public surface widens.

**Changeset:** none — `docs/qa/**` publishes nothing. Labelled `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_


---
_Generated by [Claude Code](https://claude.ai/code)_