### PR TITLE
fix(service-messaging): stop the delivery dispatchers on the kernel's own teardown hook (#9371)

### DIFF
--- a/.changeset/messaging-dispatchers-stop-on-shutdown.md
+++ b/.changeset/messaging-dispatchers-stop-on-shutdown.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/service-messaging": patch
+---
+
+**Fix:** `MessagingServicePlugin` now releases its delivery dispatchers on `kernel.shutdown()`. Previously they kept running after shutdown had resolved (#9371).
+
+The plugin starts two `setInterval` dispatchers at `kernel:ready` — `NotificationDispatcher` over `sys_notification_delivery` and `HttpDispatcher` over `sys_http_delivery` — and released them from a method named `stop()`. The kernel's plugin teardown hook is `destroy()` (`Plugin.destroy?()` in `@objectstack/core`; the only teardown `ObjectKernel.performShutdown()` and `LiteKernel.destroy()` invoke), and `stop()` is not on that interface, so **nothing ever called it**. Both dispatchers went on claiming and updating delivery rows after `await kernel.shutdown()` returned. Measured on the new pin: 48 further delivery reads/writes in the 80 ms following a resolved shutdown.
+
+The teardown body now lives on `destroy()`. `stop()` is **retained as an alias** — it is public API of an exported class, and an embedder may well have learned to call it directly precisely because the kernel never did. No call site has to change, and no accept/reject behaviour of any contract moves.
+
+**Why it was invisible in production, and where the bill landed.** `start()` `unref()`s both timers, so a long-lived host process still exits and the leak is silent. Under vitest the worker process is alive throughout teardown, so a tick fires *after* a test file is over, reads a delivery table through a driver the suite already disconnected, and `SqlDriver`'s console fallback warns. `console.*` inside a vitest worker is an RPC to the main process (`onUserConsoleLog`); one issued after `rpcDone()` has snapshotted the pending set is rejected by `$rejectPendingCalls` as `EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending`. Nothing awaits that promise, so it lands as an unhandled rejection and fails a run in which every test passed — twice measured on `examples/app-showcase` (334/334 and 337/337 green, exit 1, a merge-queue eviction each time). The width of the window is the duration of `rpcDone()`, which is why it only ever fired on a loaded queue runner and never on the PR-side run of the identical diff.
+
+Suites that boot a kernel with this plugin get quieter and finish cleaner as a result: over 48 loaded runs of the affected showcase file, console output emitted after the file's own `afterAll` went 3 → 0, and console RPC round-trips per run roughly halved (6574 → 3456 in aggregate).

--- a/packages/services/service-messaging/src/messaging-service-plugin.ts
+++ b/packages/services/service-messaging/src/messaging-service-plugin.ts
@@ -378,11 +378,52 @@ export class MessagingServicePlugin implements Plugin {
         }
     }
 
-    /** Stop the dispatcher loop + retention sweep on shutdown. */
-    async stop(): Promise<void> {
+    /**
+     * The kernel's teardown hook (`Plugin.destroy`, core `types.ts`) — the ONLY
+     * teardown entry point `ObjectKernel.performShutdown()` and
+     * `LiteKernel.destroy()` invoke.
+     *
+     * [#9371] IT USED TO BE `stop()`, WHICH NOTHING CALLED. The method below
+     * carried the docblock "Stop the dispatcher loop … on shutdown" and was
+     * correct in every respect except its NAME: `Plugin` declares `destroy?()`
+     * and no `stop()`, so the kernel walked past this plugin at shutdown and
+     * both `setInterval` dispatchers went on ticking after `await
+     * kernel.shutdown()` resolved. `start()` `unref()`s the timers, so a
+     * long-lived process still EXITS — which is exactly why this stayed
+     * invisible in production and surfaced somewhere else entirely.
+     *
+     * WHERE IT SURFACED. Under vitest the worker process is very much alive
+     * during teardown, so a tick fires after the test file is over, reads
+     * `sys_notification_delivery` / `sys_http_delivery` through a driver the
+     * suite already disconnected, and `SqlDriver`'s console fallback warns.
+     * `console.*` inside a worker is an RPC to the main process
+     * (`onUserConsoleLog`); one created after `rpcDone()` has taken its
+     * snapshot is rejected by vitest's `$rejectPendingCalls` as
+     * `EnvironmentTeardownError: [vitest-worker]: Closing rpc while
+     * "onUserConsoleLog" was pending`. Nobody awaits that promise, so it lands
+     * as an UNHANDLED REJECTION and fails the run — with every test passing.
+     * That is #9371: `examples/app-showcase` green at 334/334 and 337/337, exit
+     * 1, a merge-queue eviction each time. The window is the duration of
+     * `rpcDone()`, which is why it only ever fired on a loaded queue runner and
+     * never on the PR-side run of the identical diff.
+     *
+     * So this is a teardown-contract fix, not a test fix: a plugin that owns
+     * timers must release them on the hook the kernel actually calls.
+     */
+    async destroy(): Promise<void> {
         await this.dispatcher?.stop();
         this.dispatcher = undefined;
         await this.httpDispatcher?.stop();
         this.httpDispatcher = undefined;
+    }
+
+    /**
+     * Retained alias for {@link destroy}. Kept because it is public API of an
+     * exported class and removing it would break any embedder that learned to
+     * call it precisely BECAUSE the kernel never did. Callers should prefer
+     * kernel shutdown; direct callers keep working.
+     */
+    async stop(): Promise<void> {
+        await this.destroy();
     }
 }

--- a/packages/services/service-messaging/src/plugin-shutdown-stops-dispatchers.test.ts
+++ b/packages/services/service-messaging/src/plugin-shutdown-stops-dispatchers.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#9371] `await kernel.shutdown()` must leave NOTHING of this plugin still
+ * touching the database.
+ *
+ * THE DEFECT. `MessagingServicePlugin` starts two `setInterval` dispatchers at
+ * `kernel:ready` — `NotificationDispatcher` over `sys_notification_delivery`
+ * and `HttpDispatcher` over `sys_http_delivery`. The teardown that stops them
+ * was spelled `stop()`. The kernel's plugin teardown hook is `destroy()`
+ * (`Plugin.destroy?()` in `@objectstack/core`'s `types.ts`; the only teardown
+ * `ObjectKernel.performShutdown()` and `LiteKernel.destroy()` invoke), and
+ * `stop()` is not part of that interface — so nothing in the repo ever called
+ * it and both dispatchers went on ticking after shutdown had resolved.
+ *
+ * WHY IT WENT UNNOTICED, AND WHERE THE BILL LANDED. `start()` `unref()`s both
+ * timers, so a long-lived host process still exits and the leak is silent in
+ * production. Under vitest the worker process is alive throughout teardown, so
+ * a tick fires AFTER the test file is over, reads a delivery table through a
+ * driver the suite has already disconnected, and `SqlDriver`'s console
+ * fallback warns. `console.*` inside a worker is an RPC to the main process
+ * (`onUserConsoleLog`); one issued after `rpcDone()` has snapshotted the
+ * pending set is rejected by `$rejectPendingCalls` as `EnvironmentTeardownError:
+ * [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending`. Nothing
+ * awaits that promise, so it surfaces as an unhandled rejection and fails a run
+ * in which every test passed — twice measured on `examples/app-showcase`
+ * (334/334 and 337/337 green, exit 1, a merge-queue eviction each time).
+ *
+ * WHAT THIS PINS, AND WHY IN THIS SHAPE. The assertion is behavioural — "after
+ * shutdown the plugin issues no further delivery reads/writes" — and not
+ * `expect(plugin.destroy).toBeDefined()`, because the hook merely EXISTING is
+ * not the property that was missing; being reached by the kernel is. The
+ * counter is installed on the very `IDataEngine` the dispatchers captured, so
+ * it observes the production call path (`outbox.claim()` → `engine.update()` /
+ * `engine.find()`) rather than a stand-in.
+ *
+ * The pre-shutdown leg is a POSITIVE CONTROL and load-bearing: without it a
+ * dispatcher that never started would satisfy the post-shutdown assertion
+ * vacuously, and this test would pass on a plugin that does nothing at all.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { SqlDriver } from '@objectstack/driver-sql';
+import { MessagingServicePlugin } from './messaging-service-plugin.js';
+
+/** Fast enough that a handful of ticks fit in a short window; still real time. */
+const TICK_MS = 10;
+/** ~8 ticks. Wide enough that "no reads" cannot be a scheduling coincidence. */
+const OBSERVE_MS = 80;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const openKernels: ObjectKernel[] = [];
+const openDrivers: Array<{ disconnect?: () => Promise<void> }> = [];
+
+afterEach(async () => {
+    // Kernels first, drivers second: the kernel's own teardown still wants a
+    // live driver to drain against. (Reversing these is what makes a suite
+    // shout DATABASE_ERROR at teardown time.)
+    while (openKernels.length) {
+        try { await openKernels.pop()?.shutdown(); } catch { /* already stopped */ }
+    }
+    while (openDrivers.length) {
+        try { await openDrivers.pop()?.disconnect?.(); } catch { /* noop */ }
+    }
+});
+
+interface Booted {
+    kernel: ObjectKernel;
+    /** Reads/writes the dispatchers have made against the delivery tables. */
+    deliveryCalls: () => number;
+}
+
+async function bootMessagingKernel(): Promise<Booted> {
+    const kernel = new ObjectKernel({ logger: { level: 'silent' } } as any);
+    openKernels.push(kernel);
+
+    await kernel.use(new ObjectQLPlugin());
+    await kernel.use(
+        new MessagingServicePlugin({ dispatchIntervalMs: TICK_MS, partitionCount: 1 }),
+    );
+    await kernel.bootstrap();
+
+    const objectql: any = kernel.getService('objectql');
+    const driver: any = new SqlDriver({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+    });
+    await driver.connect();
+    objectql.registerDriver(driver, true);
+    openDrivers.push(driver);
+    await objectql.syncSchemas();
+
+    // Count on the engine instance the dispatchers captured at `kernel:ready`
+    // (`getData()` resolves the `data` service, which is this same object), so
+    // the tally is of real `outbox.claim()` traffic.
+    const engine: any = kernel.getService('data');
+    let calls = 0;
+    for (const method of ['find', 'findOne', 'update'] as const) {
+        const orig = engine[method].bind(engine);
+        engine[method] = (name: string, ...rest: unknown[]) => {
+            if (String(name).includes('_delivery')) calls++;
+            return orig(name, ...rest);
+        };
+    }
+
+    return { kernel, deliveryCalls: () => calls };
+}
+
+describe('#9371 MessagingServicePlugin releases its dispatchers on kernel shutdown', () => {
+    it('stops touching the delivery tables once shutdown() has resolved', async () => {
+        const { kernel, deliveryCalls } = await bootMessagingKernel();
+
+        // POSITIVE CONTROL — the dispatchers really are running, so the
+        // post-shutdown assertion below is measuring silence and not absence.
+        await sleep(OBSERVE_MS);
+        expect(deliveryCalls()).toBeGreaterThan(0);
+
+        await kernel.shutdown();
+
+        const atShutdown = deliveryCalls();
+        await sleep(OBSERVE_MS);
+
+        // The contract: shutdown() resolving means the plugin is done with the
+        // database. Before the fix both dispatchers kept ticking here and this
+        // count kept climbing.
+        expect(deliveryCalls()).toBe(atShutdown);
+    });
+
+    it('a second shutdown is a no-op rather than a throw', async () => {
+        const { kernel } = await bootMessagingKernel();
+        await sleep(TICK_MS * 2);
+        await kernel.shutdown();
+        // Idempotence matters because `destroy()` nulls the handles it stopped;
+        // a teardown that only works once is a teardown that fails in a suite.
+        const plugin = new MessagingServicePlugin();
+        await expect(plugin.destroy()).resolves.toBeUndefined();
+    });
+});

--- a/packages/services/service-messaging/src/plugin-shutdown-stops-dispatchers.test.ts
+++ b/packages/services/service-messaging/src/plugin-shutdown-stops-dispatchers.test.ts
@@ -43,6 +43,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { ObjectKernel } from '@objectstack/core';
 import { ObjectQLPlugin } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
+import type { ObjectQL } from '@objectstack/objectql';
+import type { IDataEngine } from '@objectstack/spec/contracts';
 import { MessagingServicePlugin } from './messaging-service-plugin.js';
 
 /** Fast enough that a handful of ticks fit in a short window; still real time. */
@@ -83,7 +85,7 @@ async function bootMessagingKernel(): Promise<Booted> {
     );
     await kernel.bootstrap();
 
-    const objectql: any = kernel.getService('objectql');
+    const objectql = kernel.getService<ObjectQL>('objectql');
     const driver: any = new SqlDriver({
         client: 'better-sqlite3',
         connection: { filename: ':memory:' },
@@ -97,7 +99,9 @@ async function bootMessagingKernel(): Promise<Booted> {
     // Count on the engine instance the dispatchers captured at `kernel:ready`
     // (`getData()` resolves the `data` service, which is this same object), so
     // the tally is of real `outbox.claim()` traffic.
-    const engine: any = kernel.getService('data');
+    type EngineCall = (name: string, ...rest: unknown[]) => unknown;
+    const engine = kernel.getService<IDataEngine>('data') as unknown as
+        Record<'find' | 'findOne' | 'update', EngineCall>;
     let calls = 0;
     for (const method of ['find', 'findOne', 'update'] as const) {
         const orig = engine[method].bind(engine);

--- a/packages/services/service-messaging/vitest.config.ts
+++ b/packages/services/service-messaging/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+/**
+ * [#9371] `plugin-shutdown-stops-dispatchers.test.ts` asserts a property of the
+ * KERNEL's teardown contract — that `ObjectKernel.performShutdown()` reaches
+ * this plugin's `destroy()` — so the `@objectstack/core` it runs against has to
+ * be the source in this checkout. Unaliased, the workspace link resolves it to
+ * `dist/`, and the verdict becomes a function of build state: a `dist` merely
+ * BEHIND would run that test GREEN against a `performShutdown` that no longer
+ * matches the one shipping, which is precisely the reading it exists to pin.
+ * `pnpm check:test-source-alias` is the gate.
+ *
+ * ANCHORED regex, array form, deliberately: a bare string `find` matches by
+ * PREFIX, so with a FILE replacement it would also swallow any subpath and
+ * resolve it to `…/core/src/index.ts/<sub>` — `ENOTDIR` at run time, from a
+ * config that reads as correct. Mirrors the identical rule in
+ * `examples/app-showcase/vitest.config.ts`.
+ */
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^@objectstack\/core$/, replacement: path.resolve(__dirname, '../../core/src/index.ts') },
+    ],
+  },
+});


### PR DESCRIPTION
Fixes #9371

Root-causes the `EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending` teardown race that evicted #9365 and #9775 from the merge queue with **every test passing** (334/334, then 337/337).

The fault is **not** in `test/approval-resume-relation-expand.test.ts`, **not** a showcase fixture, and **not** vitest configuration. It is a plugin teardown that the kernel never reaches.

⛔ Nothing is skipped, quarantined, retry-wrapped or `--reporter`-silenced, and no assertion is weakened.

## The defect

`MessagingServicePlugin` starts two `setInterval` dispatchers at `kernel:ready` — `NotificationDispatcher` over `sys_notification_delivery` and `HttpDispatcher` over `sys_http_delivery` — and released them from a method named `stop()`:

```ts
/** Stop the dispatcher loop + retention sweep on shutdown. */
async stop() { ... }   // the body was right; only the NAME was wrong
```

The intent is explicit and the body was correct. Only the **name** was wrong. `Plugin` (`packages/core/src/types.ts:170`) declares exactly one teardown hook — the optional member `destroy?()`, returning a promise or nothing — and that is the only one `ObjectKernel.performShutdown()` and `LiteKernel.destroy()` invoke. `stop()` is not on the interface, so **nothing in the tree ever called it**. Both dispatchers went on claiming and updating delivery rows after `await kernel.shutdown()` had resolved.

`start()` `unref()`s both timers, so a long-lived host process still exits — which is why this stayed invisible in production and surfaced somewhere else entirely.

## How that becomes a red run on a green suite

Read out of the installed vitest (4.1.10), not assumed:

1. Under vitest the worker process is alive throughout teardown, so a dispatcher tick fires **after the test file is over**, reads a delivery table through a driver the suite already disconnected, and `SqlDriver`'s console fallback (`sql-driver.ts:3983`) warns.
2. `console.*` in a worker is an RPC to the main process. `sendLog` calls `state().rpc.onUserConsoleLog({...})` and **discards the returned promise**.
3. `execute()`'s `finally` does `await rpcDone()` — which awaits a *snapshot* of the pending set — and then `$rejectPendingCalls`, which rejects anything created after that snapshot with `EnvironmentTeardownError`.
4. Nobody holds that promise, so it lands as an **unhandled rejection**. Vitest fails a run on an unhandled error even when no assertion failed.

The width of the window is the duration of `rpcDone()`. That is the entire "load-dependence" recorded on the card: ~1 ms on an idle box, long enough on a saturated queue runner. It explains why the identical diff ran the identical suite clean PR-side and red queue-side.

## Reproduced before it was fixed

4-vCPU container (same profile as the CI runner under `turbo --concurrency=4`), 4 concurrent full `examples/app-showcase` suites × 3 rounds, with a probe wrapping `rpc.onUserConsoleLog`:

```
AFTERALL  30847 t=37655        ← the file's tests and hooks are done
RPCSTART  30847 t=37899 id=135 ← eight console RPCs begin AFTER that
RPCREJECT 30847 t=38057 id=137 err=EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
   … ×6, one $rejectPendingCalls sweep
PROCEXIT  30847 t=38099
```

Corroborating, from vitest's own leak detector on the unmodified suite — one file, and it is the file both sightings name:

```
⎯⎯⎯⎯⎯⎯⎯ Async Leaks 4 ⎯⎯⎯⎯⎯⎯⎯⎯
PROMISE leaking in test/approval-resume-relation-expand.test.ts   (×4)
 Test Files  21 passed (21)
      Tests  342 passed (342)
      Leaks  4 leaks
```

And the reason that file is the one named: instrumenting every `console.*` across the suite, it makes **294 of the 348** console calls in the whole showcase run — the loudest by an order of magnitude, so it is where the queue is deepest at teardown.

## Effect of the fix, measured paired

Identical harness, same box, same N — 48 loaded runs of the affected file each side; `dist` rebuilt between legs and the rebuild verified on disk.

| | before (pre-fix `dist`) | after (fixed `dist`) |
|---|---|---|
| console calls after the file's own `afterAll` | **3** | **0** |
| console RPC round-trips (`RPCSTART`) | 6574 | **3456** |
| RPCs never settled (`RPCSTART − RPCOK`) | **3** | **0** |
| total console calls | 14251 | 11136 |

Both halves of the race shrink: the late calls that arm it are gone, and the queue depth that widens the window roughly halves.

## The change

- `destroy()` now carries the teardown body — the hook the kernel actually calls.
- `stop()` is **retained as a delegating alias**. It is public API of an exported class, and an embedder may well have learned to call it directly precisely because the kernel never did. No accept/reject behaviour of any contract moves.
- New pin `packages/services/service-messaging/src/plugin-shutdown-stops-dispatchers.test.ts`: boots a real `ObjectKernel` + real ObjectQL + real sqlite, counts delivery traffic on the very `IDataEngine` the dispatchers captured, and asserts none of it happens after `shutdown()` resolves. The pre-shutdown leg is a load-bearing **positive control** — without it a dispatcher that never started would pass vacuously.
- New `packages/services/service-messaging/vitest.config.ts`: one anchored alias for `@objectstack/core`. The pin asserts a property of the *kernel's* teardown contract, so the `@objectstack/core` it runs against must be this checkout's source, not a `dist` artifact. Required by `pnpm check:test-source-alias`.

### Ablation (the pin can go red)

Renamed `destroy()` → `ABLATED_destroy()`; confirmed on disk by grep against the exact text (`async destroy(` 0 occurrences, `async ABLATED_destroy(` 1). No rebuild needed — the subject is imported by relative path, so it resolves to source, not `dist`. Result:

```
 FAIL  src/plugin-shutdown-stops-dispatchers.test.ts > … > stops touching the delivery tables once shutdown() has resolved
AssertionError: expected 94 to be 46
 Test Files  1 failed (1)
      Tests  2 failed (2)
```

48 further delivery reads/writes in the 80 ms after a resolved `shutdown()` — the defect, quantified. Restored from the commit (`async destroy(` back to 1, `ABLATED` 0) and re-run: `Test Files 1 passed (1) · Tests 2 passed (2)`.

## Verification

All gates run at head `bd5293d83`, working tree byte-identical to HEAD (`git status --porcelain` empty). Gate set derived with `node scripts/pm/dispatch-gates.mjs` (no path args — it derives its own change set from the merge base), re-derived after the final commit; exit codes captured before any pipe.

Suites — `EXIT=0` each:

```
messaging-test       Test Files 23 passed (23) · Tests 244 passed (244)
messaging-typecheck  tsc --noEmit
showcase-test        Test Files 21 passed (21) · Tests 342 passed (342)
showcase-typecheck   tsc --noEmit
```

Gates, each quoting its own verdict line:

```
✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new … no files added.
check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through `dist/`
check-type-source-resolution OK — 76 packages with a tsconfig.json scanned
check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root)
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured … none above its recorded number.
check-engine-double-contract: OK — 331 pinned, 133 in the DEBT ledger, 2 exempt.
where-matcher: 0 silently-wrong and 0 unjudged matcher(s) … none new.
query-options-erasure: test surface 240 site(s) in 47 file(s) — at the ceiling … no files added.
check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).
check-nul-bytes: OK (scanned 6093 text file(s) … no raw ASCII control bytes).
✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).
✓ This diff introduces no `major` bump.
✓ check-adr-0087-registration: this PR adds no declared-breaking changeset
✓ objectui-range --self-test: all checks passed
✓ check-adr-0087-registration --self-test: 212 assertions over real temp git repos
check-affected-docs: OK
```

## Changeset

`@objectstack/service-messaging` is published, and this changes its runtime behaviour, so it carries a `patch` changeset — **not** `skip-changeset`. (`examples/app-showcase` is untouched by this PR.)

## Clause ② — declared

**Does not** change contract accept/reject behaviour, and **does not** widen public surface in any way a consumer can be broken by. It rests on: `destroy()` is an implementation of an already-declared optional hook on `Plugin`, not a new interface member; `stop()` is retained with identical semantics, so no existing call site changes meaning; no schema, validator, error code, or API shape is touched. The behavioural delta is confined to what happens *after* `kernel.shutdown()` resolves, where the previous behaviour was the defect.

## Out of scope — filed, not fixed here

- **#10371** — `plugin-reports` has the same defect (5 timer sites, `stop()`, no `destroy()`), plus five further plugins whose `stop()` the kernel never calls (no timers, so lower stakes).
- **#10373** — `approval-resume-relation-expand.test.ts` tears down driver-before-kernel, so the kernel drains against a disconnected driver.
- **#10374** — `finding`: the upstream amplifier is still live. Any late `console.*` in any package can fail a green suite; vitest's non-TTY default reporter (`MinimalReporter`, `silent: 'passed-only'`) never prints that output, so a suite pays the RPC round-trips for logs nobody reads. `--detectAsyncLeaks` is the tool that finds the exposed files.

## Flaky-signature ledger — PROPOSAL ONLY, ⛔ not self-added

Per the signature-ledger rule this promotion is a **human** action. Drafted for whoever takes it:

> **Signature:** `EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending`
> **Sightings:** 2 — run 32049971906 `Test Core (2/3)` (PR #9365, 1 error, 334/334 green); run 32196793380 `Test Core (3/3)` (PR #9775, 3 errors, 337/337 green). Both `examples/app-showcase`, both naming `test/approval-resume-relation-expand.test.ts`.
> **Status:** root-caused and fixed — #9371, this PR. Trigger was `MessagingServicePlugin` never being torn down by the kernel; dispatchers outlived the test file and logged into vitest's teardown window.
> **Residual risk:** the upstream amplifier is unfixed (#10374). Recurrence in a *different* package is a new instance of the class, not a regression of this fix; diagnose with `vitest --detectAsyncLeaks` on the named package.
> **Retire when:** no sighting for 30 days, or the upstream half lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_