### PR TITLE
fix(create-objectstack,cli): a clean first install no longer reports two unmet peers

### DIFF
--- a/.changeset/clean-first-install-peer-warnings.md
+++ b/.changeset/clean-first-install-peer-warnings.md
@@ -1,0 +1,30 @@
+---
+"create-objectstack": patch
+"@objectstack/cli": patch
+---
+
+**First-run polish:** a brand-new scaffold's very first `pnpm install` no longer reports two unmet peer dependencies (#10326).
+
+Reproduced on a clean scaffold from published `create-objectstack@17.1.0` — no lockfile, `node_modules` removed, nothing configured by the user — and again on the second scaffold path, `objectstack init`. Both printed the same two:
+
+```
+✕ unmet peer better-call
+  Installed: 1.4.0
+  Wanted:
+    1.3.7:
+      @better-auth/scim@1.7.0-rc.1
+
+✕ unmet peer better-sqlite3
+  Installed: 13.0.3
+  Wanted:
+    ^12.0.0:
+      better-auth@1.7.1
+```
+
+Nothing was broken — but it is the first screen a newcomer sees, and there is nothing they did to cause it or can do about it.
+
+**`better-sqlite3`: the pin is right and the upstream range is stale — so it is widened, not corrected.** better-auth 1.7.1 declares `better-sqlite3` as an **optional** peer at `^12.0.0`, and it governs exactly one configuration: a raw better-sqlite3 `Database` handed to better-auth's `database` option, which its Kysely dialect then drives. ObjectStack never takes that path — `AuthManager.createDatabaseConfig()` returns `createObjectQLAdapterFactory(dataEngine)`, and every `better-sqlite3` use under `plugin-auth` is knex's `client: 'better-sqlite3'` beneath ObjectQL. Measured anyway on the configuration the range *does* govern: better-auth 1.7.1 with `database: new Database(':memory:')`, running `getMigrations().runMigrations()`, `signUpEmail`, `signInEmail` and adapter `findOne`/`update`/`delete`, is green on **better-sqlite3 13.0.3** and byte-for-byte equivalent on **12.11.1**. The same probe with `Database.prototype.prepare` neutered fails, so that green is the driver's and not an unexercised path. Pinning our own `^13.0.3` declarations back to `^12` would downgrade a native module across the platform to satisfy a range measurement shows is simply behind.
+
+**`@better-auth/scim`: the rc pin stays, and one `better-call` copy is the correct tree.** `npm view @better-auth/scim dist-tags` reads `latest: '1.7.1'`, but stable 1.7.x ships the rc.2 whole-model rewrite, so adopting it is a separate migration rather than a version bump; the exact `1.7.0-rc.1` pin is deliberate. The rc peers an exact `better-call@1.3.7` while better-auth 1.7.1 depends on `1.4.0` — and a better-auth plugin has to share the **host's** better-call instance, so the single 1.4.0 copy every install already resolves is right, not a skew to repair. This declaration retires together with the rc pin.
+
+**What changed, and what deliberately did not.** Both remedies are pnpm `peerDependencyRules.allowedVersions` entries, scoped `<declaring package>><peer>` so each widens exactly one declaration. They ship *inside* the scaffold — the bundled `pnpm-workspace.yaml` template and the one `objectstack init` renders — because a block in this repo's own workspace file does not travel with published packages. `allowedVersions` changes what pnpm **reports**, never what it resolves: measured on both scaffold paths, the lockfile is byte-identical with and without it (0 lines of diff), and no dependency version, range or resolution moved anywhere. This repo's own resolutions are untouched.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -77,11 +77,53 @@ export function sanitizeNamespace(name: string): string {
 export const SCAFFOLD_BUILT_DEPENDENCIES = ['better-sqlite3', 'esbuild'];
 
 /**
- * Render the `pnpm-workspace.yaml` that allowlists native build scripts.
+ * Third-party peer ranges that resolve outside what their declaring package
+ * states, keyed `<declaring package>><peer>` — pnpm's scoped `allowedVersions`
+ * spelling, so each entry widens exactly one declaration and nothing else.
+ *
+ * Both are reported by `pnpm install` on a brand-new scaffold, and neither is a
+ * real incompatibility. They are declared here because that report is the first
+ * thing a newcomer sees, on the one screen where they are deciding whether this
+ * project is solid, and there is nothing they did to cause it.
+ *
+ *  - `better-auth>better-sqlite3` — better-auth 1.7.1 peers `^12.0.0` while the
+ *    tree resolves 13.x (`@objectstack/driver-sql`'s optional dependency). The
+ *    peer is OPTIONAL and governs one configuration only: a raw better-sqlite3
+ *    `Database` handed to better-auth's `database` option. ObjectStack never
+ *    does that — `AuthManager.createDatabaseConfig()` passes an ObjectQL
+ *    adapter factory. Measured on the configuration the range *does* govern
+ *    (better-auth's own Kysely dialect: migrations, sign-up, sign-in, adapter
+ *    find/update/delete), 1.7.1 behaves identically on better-sqlite3 13.0.3
+ *    and on 12.11.1. So the upstream range is stale and 13 is right — widening
+ *    is the correct remedy, not pinning our own declaration back to 12.
+ *
+ *  - `@better-auth/scim>better-call` — scim is held at `1.7.0-rc.1`
+ *    deliberately (stable 1.7.x ships a whole-model rewrite that is its own
+ *    migration), and the rc peers an exact `better-call@1.3.7` while
+ *    better-auth itself depends on 1.4.0. A better-auth plugin must share the
+ *    HOST's better-call instance, so the single 1.4.0 copy every install
+ *    already resolves is the correct tree, not a skew to repair.
+ *    ⚠️ This entry retires together with the SCIM rc pin — delete both at once.
+ *
+ * `allowedVersions` suppresses the report ONLY; it moves no resolution.
+ */
+export const SCAFFOLD_ALLOWED_PEER_VERSIONS: Record<string, string> = {
+  'better-auth>better-sqlite3': '13',
+  '@better-auth/scim>better-call': '1.4.0',
+};
+
+/**
+ * Render the `pnpm-workspace.yaml` that allowlists native build scripts and
+ * declares the two known-benign peer skews.
  * Kept minimal (no `packages:` key) so it acts purely as a settings file for
  * the single-package scaffold rather than declaring a workspace.
  */
-export function renderPnpmWorkspaceYaml(builtDeps: string[] = SCAFFOLD_BUILT_DEPENDENCIES): string {
+export function renderPnpmWorkspaceYaml(
+  builtDeps: string[] = SCAFFOLD_BUILT_DEPENDENCIES,
+  allowedPeerVersions: Record<string, string> = SCAFFOLD_ALLOWED_PEER_VERSIONS,
+): string {
+  const peerEntries = Object.entries(allowedPeerVersions);
+
   return [
     '# Allowlist native dependency build scripts so `pnpm install` compiles',
     '# them (pnpm 10+ blocks build scripts by default). Without this,',
@@ -89,6 +131,30 @@ export function renderPnpmWorkspaceYaml(builtDeps: string[] = SCAFFOLD_BUILT_DEP
     '# "Could not locate the bindings file".',
     'onlyBuiltDependencies:',
     ...builtDeps.map((d) => `  - ${d}`),
+    // No rules, no header: a bare `peerDependencyRules:` would advertise a
+    // declaration that is not there.
+    ...(peerEntries.length === 0 ? [] : [
+      '',
+      '# Two third-party peer ranges resolve outside what their declaring package',
+      '# states, and pnpm reports both on a first install. Neither is a real',
+      '# incompatibility:',
+      '#',
+      '#   better-auth peers better-sqlite3 ^12.0.0 while the tree resolves 13.x.',
+      '#   That peer is optional and covers handing better-auth a raw',
+      '#   better-sqlite3 `Database`; ObjectStack hands it an ObjectQL adapter',
+      '#   instead. Measured on the configuration the range does cover,',
+      '#   better-auth 1.7.1 behaves identically on 13.0.3 and on 12.11.1.',
+      '#',
+      '#   @better-auth/scim (held at a release candidate deliberately) peers an',
+      '#   exact better-call 1.3.7, while better-auth itself depends on 1.4.0. A',
+      '#   better-auth plugin has to share the host\'s better-call instance, so',
+      '#   the single 1.4.0 copy is the correct resolution.',
+      '#',
+      '# These suppress the report only — no resolution moves.',
+      'peerDependencyRules:',
+      '  allowedVersions:',
+      ...peerEntries.map(([k, v]) => `    '${k}': '${v}'`),
+    ]),
     '',
   ].join('\n');
 }

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { TEMPLATES, getCliVersion, detectPackageManager, sanitizeNamespace, SCAFFOLD_BUILT_DEPENDENCIES, renderPnpmWorkspaceYaml } from '../src/commands/init';
+import { TEMPLATES, getCliVersion, detectPackageManager, sanitizeNamespace, SCAFFOLD_BUILT_DEPENDENCIES, SCAFFOLD_ALLOWED_PEER_VERSIONS, renderPnpmWorkspaceYaml } from '../src/commands/init';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(
@@ -115,6 +115,60 @@ describe('native build allowlist (pnpm-workspace.yaml)', () => {
     expect(yaml).toMatch(/^ {2}- better-sqlite3$/m);
     // No `packages:` key — this is a settings file, not a workspace declaration.
     expect(yaml).not.toMatch(/^packages:/m);
+  });
+});
+
+// A brand-new scaffold's first `pnpm install` reported two unmet peers, on the
+// one screen where a newcomer decides whether this project is solid, with
+// nothing they did to cause it (#10326). Both ranges belong to third-party
+// packages we cannot edit, so the remedy is pnpm's scoped `allowedVersions` —
+// and it must travel INSIDE the scaffold, because a `peerDependencyRules` block
+// in this repo's own pnpm-workspace.yaml does not ship with published packages.
+describe('benign peer-skew declarations (#10326)', () => {
+  // Comments in the rendered YAML explain these keys; they must not be what
+  // satisfies an assertion about the keys themselves.
+  const settings = renderPnpmWorkspaceYaml().replace(/^\s*#.*$/gm, '');
+
+  it('widens better-auth\'s stale better-sqlite3 peer rather than pinning ours back', () => {
+    // better-auth 1.7.1 peers `^12.0.0` while the tree resolves 13.x. The peer
+    // is OPTIONAL and governs one configuration only — a raw better-sqlite3
+    // `Database` passed to better-auth's `database` option — which ObjectStack
+    // never does (AuthManager passes an ObjectQL adapter factory). Measured on
+    // the configuration it does govern, 1.7.1 behaves identically on 13.0.3 and
+    // 12.11.1, so 13 is right and the upstream range is stale.
+    expect(SCAFFOLD_ALLOWED_PEER_VERSIONS['better-auth>better-sqlite3']).toBe('13');
+    expect(settings).toMatch(/^ {4}'better-auth>better-sqlite3': '13'$/m);
+  });
+
+  it('accepts the single better-call copy @better-auth/scim resolves to', () => {
+    // scim is held at 1.7.0-rc.1 on purpose; the rc peers an EXACT
+    // `better-call@1.3.7` while better-auth depends on 1.4.0. A better-auth
+    // plugin must share the HOST's better-call instance, so one 1.4.0 copy is
+    // the correct tree. Retires with the scim rc pin.
+    expect(SCAFFOLD_ALLOWED_PEER_VERSIONS['@better-auth/scim>better-call']).toBe('1.4.0');
+    expect(settings).toMatch(/^ {4}'@better-auth\/scim>better-call': '1\.4\.0'$/m);
+  });
+
+  it('renders the rules under peerDependencyRules.allowedVersions', () => {
+    expect(settings).toMatch(/^peerDependencyRules:$/m);
+    expect(settings).toMatch(/^ {2}allowedVersions:$/m);
+  });
+
+  it('scopes every rule to one declaring package, never a bare peer name', () => {
+    // A bare `better-sqlite3: '13'` would silence that peer for every package
+    // declaring it — including one whose complaint would be real.
+    const keys = Object.keys(SCAFFOLD_ALLOWED_PEER_VERSIONS);
+    expect(keys.length).toBeGreaterThan(0);
+    for (const key of keys) {
+      expect(key, `"${key}" must be spelled <declaring package>><peer>`).toContain('>');
+    }
+  });
+
+  it('emits nothing at all when the caller supplies no rules', () => {
+    // The block is data-driven, so an empty map must not leave a dangling
+    // `allowedVersions:` header claiming a declaration that is not there.
+    const bare = renderPnpmWorkspaceYaml(SCAFFOLD_BUILT_DEPENDENCIES, {});
+    expect(bare).not.toMatch(/^peerDependencyRules:$/m);
   });
 });
 

--- a/packages/create-objectstack/src/template-consistency.test.ts
+++ b/packages/create-objectstack/src/template-consistency.test.ts
@@ -361,6 +361,55 @@ describe('blank template pnpm build approvals (#3119)', () => {
   });
 });
 
+// A brand-new scaffold's very first `pnpm install` reported two unmet peers —
+// on the one screen where a newcomer is deciding whether this project is solid,
+// with nothing they did to cause it and nothing they can do about it (#10326).
+// Both are third-party ranges we cannot edit, so the declaration is pnpm's
+// scoped `allowedVersions`, and it has to travel INSIDE the scaffold: a
+// `peerDependencyRules` block in this repo's own pnpm-workspace.yaml would not
+// ship with the published packages, exactly as the overrides note there says.
+describe('blank template peer-skew declarations (#10326)', () => {
+  const wsPath = path.join(pkgRoot, 'src', 'templates', 'blank', 'pnpm-workspace.yaml');
+  // Same comment-stripping as the block above: the prose explaining these keys
+  // must not be what satisfies an assertion about the keys.
+  const settings = fs.existsSync(wsPath)
+    ? fs.readFileSync(wsPath, 'utf8').replace(/^\s*#.*$/gm, '')
+    : '';
+  const allowed = /^ {2}allowedVersions:\n((?:[ \t]+.*\n?)*)/m.exec(settings)?.[1] ?? '';
+
+  it('declares the stale better-auth > better-sqlite3 peer', () => {
+    // better-auth 1.7.1 peers `^12.0.0`; @objectstack/driver-sql resolves 13.x.
+    // The peer is optional and governs only a raw better-sqlite3 `Database`
+    // handed to better-auth's `database` option — a path ObjectStack never
+    // takes (AuthManager passes an ObjectQL adapter factory). Measured on the
+    // path it does govern, 1.7.1 behaves identically on 13.0.3 and 12.11.1.
+    expect(
+      /^\s*'better-auth>better-sqlite3':\s*'13'\s*$/m.test(allowed),
+      "allowedVersions must widen better-auth's stale better-sqlite3 peer to 13",
+    ).toBe(true);
+  });
+
+  it('declares the frozen @better-auth/scim > better-call peer', () => {
+    // scim is held at 1.7.0-rc.1 deliberately; the rc peers an EXACT 1.3.7
+    // while better-auth depends on 1.4.0. A better-auth plugin must share the
+    // host's better-call instance, so the single 1.4.0 copy is correct.
+    expect(
+      /^\s*'@better-auth\/scim>better-call':\s*'1\.4\.0'\s*$/m.test(allowed),
+      'allowedVersions must accept the single better-call 1.4.0 copy scim resolves to',
+    ).toBe(true);
+  });
+
+  it('scopes every rule to one declaring package, never a bare peer name', () => {
+    // A bare `better-sqlite3: '13'` would silence that peer for EVERY package
+    // that declares it, including ones whose complaint would be real.
+    const entries = [...allowed.matchAll(/^\s*'([^']+)':/gm)].map((m) => m[1]);
+    expect(entries.length).toBeGreaterThan(0);
+    for (const key of entries) {
+      expect(key, `"${key}" must be spelled <declaring package>><peer>`).toContain('>');
+    }
+  });
+});
+
 describe('README template table', () => {
   it('lists exactly the templates in the TEMPLATES registry', () => {
     const readme = fs.readFileSync(path.join(pkgRoot, 'README.md'), 'utf8');

--- a/packages/create-objectstack/src/templates/blank/pnpm-workspace.yaml
+++ b/packages/create-objectstack/src/templates/blank/pnpm-workspace.yaml
@@ -21,3 +21,29 @@ onlyBuiltDependencies:
 allowBuilds:
   better-sqlite3: true
   esbuild: true
+
+# Two third-party peer ranges resolve outside what their declaring package
+# states. `pnpm install` reports both as unmet peers — which would be the first
+# thing a brand-new project shows you — and neither is a real incompatibility:
+#
+#   better-auth peers better-sqlite3 ^12.0.0 while the tree resolves 13.x. That
+#   peer is optional and covers handing better-auth a raw better-sqlite3
+#   `Database`; ObjectStack hands it an ObjectQL adapter instead, so nothing
+#   here goes down that path. Measured on the configuration the range does
+#   cover — better-auth's own Kysely dialect, running its migrations, sign-up,
+#   sign-in and adapter find/update/delete — 1.7.1 behaves identically on
+#   better-sqlite3 13.0.3 and on 12.11.1. The upstream range is stale.
+#
+#   @better-auth/scim (held at a release candidate deliberately, not by
+#   neglect) peers better-call at an exact 1.3.7, while better-auth itself
+#   depends on 1.4.0. A better-auth plugin has to share the host's better-call
+#   instance, so the single 1.4.0 copy is the correct resolution rather than a
+#   skew to repair. This entry retires when SCIM moves off the rc.
+#
+# These suppress the report only: no resolution moves, and the lockfile is
+# byte-identical with and without this block.
+
+peerDependencyRules:
+  allowedVersions:
+    'better-auth>better-sqlite3': '13'
+    '@better-auth/scim>better-call': '1.4.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,9 +96,26 @@ onlyBuiltDependencies:
 #     `@better-auth/core` at `^1.7.0-rc.1`) are satisfied by the stable 1.7.1
 #     the family now resolves to.
 #     KNOWN SKEW while this hold lasts: scim rc.1 peers `better-call@1.3.7`
-#     while better-auth 1.7.1 depends on `better-call@1.4.0`, so the tree
-#     carries two copies. Measured green on the plugin-auth suite; it retires
-#     with #3653.
+#     while better-auth 1.7.1 depends on `better-call@1.4.0`. CORRECTION
+#     (#10326, measured): the tree does NOT carry two copies — this lockfile
+#     holds exactly ONE better-call version, 1.4.0, and scim rc.1 resolves to
+#     it, in a scaffolded downstream install too. That is the correct tree
+#     rather than a skew to repair: a better-auth plugin has to share the
+#     HOST's better-call instance, and the exact `1.3.7` is just the rc's
+#     frozen stamp. What the skew does produce is an unmet-peer line on a
+#     newcomer's very first `pnpm install`, which the scaffold templates now
+#     declare away (see `peerDependencyRules` in
+#     `packages/create-objectstack/src/templates/blank/pnpm-workspace.yaml`
+#     and `renderPnpmWorkspaceYaml` in `packages/cli`). Measured green on the
+#     plugin-auth suite; the skew, and both template entries, retire with
+#     #3653.
+#     Its sibling line is better-auth's own stale `better-sqlite3@^12.0.0`
+#     peer against our `^13.0.3`. That one is NOT reported here, because
+#     `auto-install-peers=true` (.npmrc) quietly installs a second, unused
+#     better-sqlite3 12.11.1 to satisfy it — which is why CI never saw what a
+#     scaffolded project shows on its first screen. #10326 measured 1.7.1 as
+#     behaviourally identical on 13.0.3 and 12.11.1 and left this workspace's
+#     resolution untouched; only the scaffolds declare it.
 #     `scripts/check-prerelease-pin-watch.mjs` keeps watching this pin (it is
 #     now the only entry on its watch list) so #3653 has a producer.
 #   - @better-auth/oauth-provider: GHSA-p2fr-6hmx-4528 — same better-auth


### PR DESCRIPTION
Fixes #10326

A brand-new scaffold's very first `pnpm install` reported two unmet peer dependencies. Nothing was broken — but it is the one screen where a newcomer is deciding whether this project is solid, and there is nothing they did to cause it or can do about it.

## Premise: reproduced before anything changed

Clean install means: scaffolded fresh from **published** `create-objectstack@17.1.0`, then `rm -rf node_modules pnpm-lock.yaml` and `pnpm install` again — no lockfile, no `node_modules`, nothing configured by the user. The pnpm in this container is 11.22.0, which moved the per-package lines out of the install summary and behind `pnpm peers check`; the filing's inline `✕ unmet peer …` shape is pnpm 10's rendering of the same two facts.

```
Issues with peer dependencies found

✕ unmet peer better-call
  Installed: 1.4.0
  Wanted:
    1.3.7:
      @better-auth/scim@1.7.0-rc.1

✕ unmet peer better-sqlite3
  Installed: 13.0.3
  Wanted:
    ^12.0.0:
      better-auth@1.7.1
```

**A second scaffold path reproduces both, identically**, and the filing did not name it: `objectstack init` (`packages/cli`) renders its own `pnpm-workspace.yaml`. Same two lines, same versions.

## ① better-sqlite3 — the pin is right; the upstream range is stale, so it is **widened**

The question is behavioural, not textual, so it was measured rather than read off the range string.

**What the range actually governs.** better-auth 1.7.1 declares `better-sqlite3` as an **optional** peer (`peerDependenciesMeta.better-sqlite3.optional === true`) at `^12.0.0`. It governs exactly one configuration: a raw better-sqlite3 `Database` handed to better-auth's `database` option, which its Kysely dialect then drives. **ObjectStack never takes that path** — `AuthManager.createDatabaseConfig()` returns `createObjectQLAdapterFactory(this.config.dataEngine)`, and all 14 `better-sqlite3` mentions under `plugin-auth` are knex's `client: 'better-sqlite3'` underneath ObjectQL (the grep was controlled against a known-present neighbour term in the same files).

**Measured on the configuration it does govern.** A probe built better-auth 1.7.1 with `database: new Database(':memory:')` and drove it end to end:

```
MEASURED better-sqlite3 = 13.0.3 | better-auth = 1.7.1 | better-auth peer range = ^12.0.0
MIGRATIONS: ok — tables = account,session,user,verification
SIGNUP: ok — user id = c7lwqlSTpVX8MwoKHY8SyrsCO1fajorb email = probe@example.com
READBACK FROM better-sqlite3 13: {"id":"c7lwqlSTpVX8MwoKHY8SyrsCO1fajorb","email":"probe@example.com"}
SIGNIN: ok — token present = true
ADAPTER findOne: ok — probe@example.com
ADAPTER update: ok — name = Renamed
ADAPTER delete: ok — remaining users = 0
```

Two controls make that green mean something:

- **Falsification.** The same probe with `Database.prototype.prepare` neutered **fails**, in kysely's `SqliteIntrospector` — so the green is better-sqlite3 actually executing, not an unexercised path.
- **The version the range names.** The identical probe on **better-sqlite3 12.11.1** produces the identical transcript. 13 is not merely tolerated; it is indistinguishable from what the range asks for.

**Therefore: widen, do not correct the pin.** Pinning our own `^13.0.3` declarations (driver-sql, driver-turso, plugin-sharing, cli) back to `^12` would downgrade a native module across the whole platform to satisfy a range that measurement shows is simply behind. The remedy is pnpm's `peerDependencyRules.allowedVersions`, which is the only way to widen a third-party peer range we do not own.

## ② @better-auth/scim — the rc pin stays; this card stops at the reading

The `npm view` reading, verbatim, taken today:

```
$ npm view @better-auth/scim dist-tags
{
  'release-1.4': '1.4.22',
  beta: '1.7.0-beta.10',
  rc: '1.7.0-rc.6',
  latest: '1.7.1'
}
```

`latest` is a **stable, non-rc** version. **No migration is performed here.** Stable 1.7.x ships the rc.2 whole-model rewrite, so adopting it is an architecture card of its own, not a version bump — and the pin at `1.7.0-rc.1` is deliberate, not a decayed version stamp.

On the warning itself: the rc peers an **exact** `better-call@1.3.7` while better-auth 1.7.1 depends on `1.4.0`. A better-auth plugin has to share the **host's** better-call instance, so the single 1.4.0 copy every install already resolves is the correct tree rather than a skew to repair. Measured: exactly one `better-call` version in the lockfile (`better-call@1.4.0`), with scim's `node_modules/better-call` symlinked to it — in the scaffolded downstream tree and in this repo's own lockfile alike. The declaration retires together with the rc pin.

**A correction to the workspace prose, in scope because it is this half's own evidence.** `pnpm-workspace.yaml`'s scim note claimed "so the tree carries two copies". It does not, and never did in the tree as resolved. That sentence is corrected in place, with the measurement, so the next author doing the SCIM migration is not working from a false picture. The root file's diff is **comment-only** — verified by filtering the diff to non-`#` lines, which comes back empty; the pin line itself does not appear in the diff at all.

## What changed

Both remedies are `peerDependencyRules.allowedVersions` entries, keyed with pnpm's scoped spelling (the declaring package's name, then a greater-than sign, then the peer's name) so each widens exactly one declaration — a bare `better-sqlite3: '13'` would silence that peer for every package declaring it, including one whose complaint would be real. A test pins that scoping in both packages.

They ship **inside the scaffold**, not in this repo's workspace file, and that placement is load-bearing: a `peerDependencyRules` block here would not travel with published packages — the same limitation the `overrides` block already documents, and the reason `plugin-auth` restates its ranges. So the entries land in the two files a newcomer actually gets:

- `packages/create-objectstack/src/templates/blank/pnpm-workspace.yaml`
- `renderPnpmWorkspaceYaml()` in `packages/cli/src/commands/init.ts` (data-driven from an exported `SCAFFOLD_ALLOWED_PEER_VERSIONS`; an empty map emits no block at all, rather than a dangling header advertising a declaration that is not there)

**Verified gone on the same clean-install path that produced them.** Both scaffolds, both re-installed from zero:

```
$ pnpm peers check
No peer dependency issues found            # exit 0
```

and the install summary no longer carries `[WARN] Issues with peer dependencies found`.

### Lockfile blast radius: zero, measured both ways

`allowedVersions` changes what pnpm **reports**, never what it resolves. Rather than assert that, both scaffolds were installed from scratch with and without the block and the lockfiles diffed:

| scaffold | `diff` lines between baseline and fixed lockfile |
| --- | --- |
| `create-objectstack@17.1.0` | **0** |
| `objectstack init` | **0** |

Nothing moved beyond the two named packages because nothing moved at all — no version, no range, no resolution, in the scaffolds or in this repo (whose lockfile this PR does not touch).

### One thing deliberately not done

This repo's own `pnpm-workspace.yaml` gets **no** `peerDependencyRules` block. It does not show these warnings, because `auto-install-peers=true` in the root `.npmrc` quietly installs a second, entirely unused `better-sqlite3@12.11.1` to satisfy the stale peer — which is exactly why CI never saw what a scaffolded project shows on its first screen. Adding the rule here was tried and measured: it moves **0** lockfile lines today, so it would sit inert until some unrelated future re-resolve dropped the duplicate as unreviewed drift in this repo's hottest merge-conflict file. That masking is recorded in the workspace comment instead, where the next reader will find it.

## Verification

Reverse verification, run from the committed state. Both suites read **source**, not `dist` — `init.test.ts` imports `../src/commands/init` by relative path and the template test reads `src/templates/…` off disk, neither resolving through a package's `exports` — so no rebuild is involved and none was needed. Predicted direction before running: the declarations' removal reds the new assertions, **except** the "emits nothing when given no rules" test, which should stay green because an empty map genuinely should emit nothing. Observed, exactly:

| leg | `packages/cli` | `create-objectstack` |
| --- | --- | --- |
| declarations removed | **4 failed** \| 33 passed (37) | **3 failed** \| 21 passed (24) |
| restored from the commit | 37 passed (37) | 24 passed (24) |

Targeted suites and typechecks, script names echoed in the output (so no zero-match silent pass):

- `pnpm --filter create-objectstack test` — `Test Files 7 passed (7)`, `Tests 84 passed (84)`
- `pnpm --filter @objectstack/cli exec vitest run test/init.test.ts` — `Tests 37 passed (37)`
- `pnpm --filter @objectstack/cli typecheck` and `pnpm --filter create-objectstack typecheck` — both clean

### Gate union — `node scripts/pm/dispatch-gates.mjs`, no paths passed

Derived after the final commit on a clean worktree at **`83e1c328c`**, exit codes captured before any pipe. 20 families run, **19 exit 0**. The one non-zero is pre-existing and provably not mine:

```
EXIT=1 :: node scripts/check-prerelease-pin-watch.mjs
```

Its own verdict line reads `⛔ A STABLE release is available for 1 prerelease pin(s) — the trigger condition of #3653 has ARRIVED.` That is the standing SCIM watch firing on the `npm view` reading quoted above, and it is red on `main` for the same reason: this PR's only change to `pnpm-workspace.yaml` is comment text, and the scim pin line is not in the diff.

Green, each quoted from its own exit code: `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`, `check:override-consistency`, `check:slot-lookup`, `check:template-version-sync`, `check-adr-0087-registration.mjs`, `check-changeset-fixed.mjs`, `check-changeset-no-major.mjs`, `check-cross-package-test-inputs.mjs`, `check-empty-changeset.mjs`, `check-osv-exemptions.mjs`, `docs-audit/check-affected-docs.mjs`, plus the convention-triggered set the two edited test files move: `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, and `check:type-check-debt` — the last run against a fully built workspace closure (`turbo run build`, `70 successful, 70 total`), reporting `33 ledger entr(ies) re-measured in 236.8s, 1924 raw tsc error(s) total, none above its recorded number` and `surplus: none`. No ledger entry was raised or touched.

A note on where the CLI test edits are typechecked: `packages/cli/tsconfig.json` includes only `src`, so `test/**` sits outside that program — pre-existing, documented debt already carried in the type-check-coverage ledger (`packages/cli` is named in the script's own header). The additions were checked directly against the file anyway and introduce no error naming a line this PR wrote.

### Changeset

Shipped, and it is the gate's call rather than habit: `check-empty-changeset.mjs` / `check-changeset-fixed.mjs` are in this card's derived gate union, and the change is user-visible — it alters what published `create-objectstack` and `@objectstack/cli` write into a new project. `patch` on both.

## Out of scope, filed not fixed

`objectstack init`'s scaffold hard-fails `pnpm install` on pnpm 11 with `ERR_PNPM_IGNORED_BUILDS` (exit 1), because `renderPnpmWorkspaceYaml` emits only `onlyBuiltDependencies` and not the `allowBuilds` key that pnpm 11 reads — the same defect class the blank template already fixed for itself. It is a different defect from this card's (an install that fails outright, not a warning on an install that succeeds), so it is filed rather than ridden. See #10405; that issue is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
