### PR TITLE
fix(app-showcase): author the task-done email at a locale the send ladder can reach

### DIFF
--- a/examples/app-showcase/package.json
+++ b/examples/app-showcase/package.json
@@ -40,6 +40,7 @@
     "@objectstack/formula": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@objectstack/plugin-approvals": "workspace:*",
+    "@objectstack/plugin-email": "workspace:*",
     "@objectstack/service-automation": "workspace:*",
     "@objectstack/service-messaging": "workspace:*",
     "@playwright/test": "^1.62.1",

--- a/examples/app-showcase/src/system/emails/index.ts
+++ b/examples/app-showcase/src/system/emails/index.ts
@@ -1,20 +1,49 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
-/** Email template fired by the Task Completed flow. */
-export const TaskDoneEmail = {
+import { defineEmailTemplateDefinition } from '@objectstack/spec';
+
+/**
+ * Email template declared for the Task Completed flow.
+ *
+ * ## Why `locale` is `en-US`, and why it is spelled out
+ *
+ * `sendTemplate`'s ladder is **exact match → `en-US` → (no-locale calls only)
+ * the bundle's lowest tag**, with deliberately no language-prefix matching:
+ * `en` does not satisfy `en-US`. Because `en-US` is the ladder's own second
+ * rung, a row authored at `en-US` is reachable from *every* call shape — an
+ * explicit `en-US`, this app's `defaultLocale: 'en'` (which the notify path
+ * passes as the recipient locale), and a call naming no locale at all. Any
+ * other tag is reachable from strictly fewer: this row used to say `en`, which
+ * made `sendTemplate({ locale: 'en-US' })` fail with `TEMPLATE_NOT_FOUND`.
+ *
+ * The key is written out rather than left to the schema default because the
+ * example corpus is what gets copied: the tag is the bundle key a second
+ * language row has to match, and `content/docs/automation/email-templates.mdx`
+ * teaches authoring the tags your callers actually pass.
+ *
+ * ## Not wired to the flow yet
+ *
+ * `showcase_task_completed`'s notify node demonstrates the inline
+ * `title`/`message` path, which the node schema makes mutually exclusive with
+ * `template` — so referencing this template there is a substitution, not an
+ * addition: it would cost the script node's `{summary}` its only consumer, and
+ * that consumption is what the flow exists to demonstrate. Tracked as its own
+ * decision in #10394 rather than smuggled in here.
+ */
+export const TaskDoneEmail = defineEmailTemplateDefinition({
   name: 'showcase_task_done_email',
   label: 'Task Done Notification',
-  category: 'workflow' as const,
-  locale: 'en',
+  category: 'workflow',
+  locale: 'en-US',
   subject: '✅ Task done: {{title}}',
   bodyHtml: '<p>The task <strong>{{title}}</strong> on project {{project}} was marked done.</p>',
   bodyText: 'The task {{title}} on project {{project}} was marked done.',
   variables: [
-    { name: 'title', type: 'string' as const, required: true, description: 'Task title' },
-    { name: 'project', type: 'string' as const, required: false, description: 'Project name' },
+    { name: 'title', type: 'string', required: true, description: 'Task title' },
+    { name: 'project', type: 'string', required: false, description: 'Project name' },
   ],
   active: true,
   isSystem: false,
-};
+});
 
 export const allEmails = [TaskDoneEmail];

--- a/examples/app-showcase/test/email-template-locale.test.ts
+++ b/examples/app-showcase/test/email-template-locale.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// The showcase's declared email templates have to be REACHABLE, and the only
+// way to know that is to resolve them.
+//
+// The bug this pins: `showcase_task_done_email` declared `locale: 'en'`.
+// `sendTemplate`'s ladder is exact match → `en-US` → (no-locale calls only) the
+// bundle's lowest tag, with deliberately no language-prefix matching, so `en`
+// never satisfies `en-US`. Measured against the old declaration, through the
+// same loader used below: `load(name, 'en-US')` answered `null`, and a
+// `sendTemplate({ locale: 'en-US' })` threw
+// `TEMPLATE_NOT_FOUND: showcase_task_done_email (locale=en-US)`. A no-locale
+// send still worked — by falling through to rung 3, the arbitrary-looking
+// "lowest tag in the bundle" — which is exactly why the defect was latent.
+//
+// So these assertions run the DECLARED templates through the real boot path:
+// the canonical schema parse, the real `mapTemplateToRow` projection into
+// `sys_email_template` columns, and the real `createSysEmailTemplateLoader`.
+// Nothing here inspects the source literal's strings; every verdict is a
+// resolution. The composition of rungs 1-3 itself is plugin-email's own
+// contract and is pinned there (`template-locale-resolution.test.ts`).
+
+import { describe, it, expect } from 'vitest';
+import { EmailTemplateDefinitionSchema } from '@objectstack/spec/system';
+import {
+  createSysEmailTemplateLoader,
+  mapTemplateToRow,
+  EMAIL_TEMPLATE_OBJECT,
+  DEFAULT_TEMPLATE_LOCALE,
+} from '@objectstack/plugin-email';
+import { allEmails, TaskDoneEmail } from '../src/system/emails/index.js';
+
+type Row = Record<string, unknown> & { id: string };
+
+/** What the boot seeder writes: schema parse, then the shared column mapping. */
+function materialize(templates: readonly unknown[]): Row[] {
+  return templates.map((t, i) => ({
+    id: `row-${i}`,
+    ...mapTemplateToRow(EmailTemplateDefinitionSchema.parse(t) as never),
+  }));
+}
+
+/**
+ * A driver-ish engine over the materialized rows — filters by `where`, honours
+ * `orderBy`, then `limit`. Mirrors the fake plugin-email's own resolution
+ * suite uses, so the loader is exercised the way a real store exercises it.
+ */
+function engine(rows: Row[]) {
+  return {
+    async find(object: string, query: Record<string, unknown>) {
+      expect(object).toBe(EMAIL_TEMPLATE_OBJECT);
+      const where = (query.where ?? {}) as Record<string, unknown>;
+      let out = rows.filter((r) => Object.entries(where).every(([k, v]) => r[k] === v));
+      const orderBy = query.orderBy as Array<{ field: string; order?: string }> | undefined;
+      if (Array.isArray(orderBy)) {
+        out = [...out].sort((a, b) => {
+          for (const { field, order } of orderBy) {
+            const av = String(a[field] ?? '');
+            const bv = String(b[field] ?? '');
+            if (av !== bv) return (av < bv ? -1 : 1) * (order === 'desc' ? -1 : 1);
+          }
+          return 0;
+        });
+      }
+      return typeof query.limit === 'number' ? out.slice(0, query.limit) : out;
+    },
+  };
+}
+
+const loader = () => createSysEmailTemplateLoader(engine(materialize(allEmails)) as never);
+
+describe('showcase email templates — declared tags the send ladder can actually reach', () => {
+  it('resolves `showcase_task_done_email` for an explicit en-US send', async () => {
+    const found = await loader().load('showcase_task_done_email', DEFAULT_TEMPLATE_LOCALE);
+
+    // The regression, stated as the send that used to fail. For an explicit
+    // `en-US` the loader IS the whole ladder: rung 1 and rung 2 name the same
+    // tag, so a null here is a `TEMPLATE_NOT_FOUND` throw at the service.
+    expect(found).not.toBeNull();
+    expect(found?.locale).toBe('en-US');
+  });
+
+  it('resolves THIS template, not some other row of the bundle', async () => {
+    const found = await loader().load('showcase_task_done_email', DEFAULT_TEMPLATE_LOCALE);
+
+    // A resolution that answers the wrong row is the failure mode a bare
+    // "not null" assertion cannot see, so pin the identity of what came back.
+    expect(found?.name).toBe('showcase_task_done_email');
+    expect(found?.subject).toBe(TaskDoneEmail.subject);
+    expect(found?.body_html).toBe(TaskDoneEmail.bodyHtml);
+  });
+
+  it('answers a no-locale send from the default rung, not from the lowest-tag rung', async () => {
+    // Rung 3 ("no en-US row at all ⇒ the bundle's lowest tag") is a
+    // keep-the-tenant-working fallback, not a place an authored corpus should
+    // be living. With the row at en-US this send is answered by rung 2.
+    const found = await loader().load('showcase_task_done_email', undefined);
+    expect(found?.locale).toBe(DEFAULT_TEMPLATE_LOCALE);
+  });
+
+  it('does NOT answer the language-only tag `en` — and does not need to', async () => {
+    // Pinned in the true direction: there is no prefix matching in either
+    // direction, so an `en` lookup misses rung 1 by design. It still delivers,
+    // because rung 2 of the service ladder is `en-US` — which is precisely why
+    // `en-US` is the tag reachable from every call shape and `en` is not.
+    expect(await loader().load('showcase_task_done_email', 'en')).toBeNull();
+  });
+
+  it('every declared template in the corpus is reachable at the default locale', async () => {
+    // The class guard: a template added later cannot reintroduce the defect
+    // by picking a tag the ladder's default rung does not name.
+    for (const template of allEmails) {
+      const name = EmailTemplateDefinitionSchema.parse(template).name;
+      const found = await loader().load(name, DEFAULT_TEMPLATE_LOCALE);
+      expect(found, `${name} is unreachable at ${DEFAULT_TEMPLATE_LOCALE}`).not.toBeNull();
+    }
+  });
+
+  it('every declared template went through `defineEmailTemplateDefinition`', async () => {
+    // The second half of the card: the literal used to be exported bare, so
+    // `EmailTemplateDefinitionSchema.parse()` never ran at authoring time. A
+    // definition that has been through the factory is a FIXED POINT of the
+    // parse (every default already applied); a bare literal is not.
+    for (const template of allEmails) {
+      expect(EmailTemplateDefinitionSchema.parse(template)).toEqual(template);
+    }
+  });
+});

--- a/examples/app-showcase/tsconfig.json
+++ b/examples/app-showcase/tsconfig.json
@@ -27,8 +27,19 @@
     // `dist` typechecks green over an engine contract that has since moved.
     // `pnpm check:type-source-resolution` is the gate; it wants the `paths`
     // rule, not a registry entry.
+    //
+    // Same rule, same reason, for the email plugin: `test/email-template-locale.test.ts`
+    // resolves this app's declared email templates through plugin-email's real
+    // `sys_email_template` loader and its real column mapping. Unaliased, its TYPES
+    // come from `packages/plugins/plugin-email/dist/*.d.ts`, so `tsc --noEmit` would
+    // grade those declarations against whatever was last built rather than against the
+    // locale ladder in this checkout. Bare key, no `*`: a tsconfig `paths` key without
+    // a star is an EXACT match, and the `@objectstack/plugin-email*` spelling would
+    // fold every subpath onto this one target and type-check green against the wrong
+    // module.
     "paths": {
-      "@objectstack/formula": ["../../packages/formula/src/index.ts"]
+      "@objectstack/formula": ["../../packages/formula/src/index.ts"],
+      "@objectstack/plugin-email": ["../../packages/plugins/plugin-email/src/index.ts"]
     }
   },
   // This package took the widened-`include` route rather than a sibling

--- a/examples/app-showcase/vitest.config.ts
+++ b/examples/app-showcase/vitest.config.ts
@@ -24,8 +24,18 @@ export default defineConfig({
     // PREFIX, so with a FILE replacement it would also swallow any subpath and
     // resolve it to `…/formula/src/index.ts/<sub>` — `ENOTDIR` at run time,
     // from a config that reads as correct.
+    //
+    // `test/email-template-locale.test.ts` resolves this app's declared email
+    // templates through plugin-email's real `sys_email_template` loader and its
+    // real column mapping. Through the workspace link that package resolves to
+    // `dist/` — a build artifact — so a stale dist would grade the declarations
+    // against an OLD locale ladder, which is the one thing those assertions
+    // exist to measure. `pnpm check:test-source-alias` is the gate, and its
+    // registry is shrink-only: the alias is the sanctioned remedy, never a new
+    // registry entry.
     alias: [
       { find: /^@objectstack\/formula$/, replacement: path.resolve(__dirname, '../../packages/formula/src/index.ts') },
+      { find: /^@objectstack\/plugin-email$/, replacement: path.resolve(__dirname, '../../packages/plugins/plugin-email/src/index.ts') },
     ],
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       '@objectstack/plugin-approvals':
         specifier: workspace:*
         version: link:../../packages/plugins/plugin-approvals
+      '@objectstack/plugin-email':
+        specifier: workspace:*
+        version: link:../../packages/plugins/plugin-email
       '@objectstack/service-automation':
         specifier: workspace:*
         version: link:../../packages/services/service-automation


### PR DESCRIPTION
Fixes #10267

`examples/app-showcase/src/system/emails/index.ts` declared `locale: 'en'` on a bare object literal. `sendTemplate`'s ladder is **exact match → `en-US` → (no-locale calls only) the bundle's lowest tag**, with deliberately no language-prefix matching, so `en` never satisfies `en-US`.

## The premise, measured rather than inferred

The card's premise is behavioural, so it was exercised rather than read off the strings. The **unmodified** declaration was pushed through the real boot path — `EmailTemplateDefinitionSchema.parse()`, the real `mapTemplateToRow` projection into `sys_email_template` columns, the real `createSysEmailTemplateLoader`, and the real `EmailService.sendTemplate` ladder:

```
materialized row: { name: showcase_task_done_email, locale: "en", subject: "✅ Task done: {{title}}" }

loader.load(showcase_task_done_email, en-US)   -> null
loader.load(showcase_task_done_email, en)      -> row locale=en
loader.load(showcase_task_done_email, undefined) -> row locale=en

sendTemplate no locale        -> RESOLVED  "✅ Task done: Ship it"   (rung 3, the lowest-tag fallback)
sendTemplate locale='en-US'   -> THREW TEMPLATE_NOT_FOUND: showcase_task_done_email (locale=en-US)
sendTemplate locale='en'      -> RESOLVED  "✅ Task done: Ship it"
sendTemplate locale='zh-CN'   -> THREW TEMPLATE_NOT_FOUND: showcase_task_done_email (locale=zh-CN)
```

Premise confirmed: rows 1 and 2 of the card's table reproduce exactly.

**One row of the card's table does not hold as written, and it is worth recording.** The card says a notify delivery for an `en-US` recipient gets `TEMPLATE_NOT_FOUND`. On *this app* it does not, today: the notify path's recipient locale is `getDefaultTemplateLocale()` → `II18nService.getDefaultLocale()`, and `examples/app-showcase/objectstack.config.ts` declares `defaultLocale: 'en'`. So the showcase's own deliveries pass `'en'` and currently resolve. The defect is real and the first two rows are enough for it; the third is conditional on a deployment whose default tag is `en-US`. The fix is correct for both, as the next section shows.

## Which remedy, argued from the measurement

The card left the choice between `locale: 'en-US'` and dropping the key to take the schema default. Both candidates were run through the same real ladder:

```
A · explicit locale: "en-US"        row.locale="en-US"   send(en-US) OK · send(en) OK · send(no locale) OK
B · key dropped, factory default    row.locale="en-US"   send(en-US) OK · send(en) OK · send(no locale) OK
```

**The ladder cannot tell them apart** — `defineEmailTemplateDefinition` applies the `en-US` default, so both produce the identical materialized row. So the measurement settles the part it can and no more:

- It settles `en-US` **over `en`** decisively. `en-US` is the ladder's own second rung, so a row authored there is reachable from *every* call shape — an explicit `en-US`, this app's `defaultLocale: 'en'` (via rung 2), and a call naming no locale. Any other tag is reachable from strictly fewer. That is why the fix is right for the showcase even though the showcase's own callers pass `en`.
- It does **not** settle explicit-versus-default, because they are the same row. That was decided on the axis the measurement leaves open: the example corpus is what customers and AI authors copy, the tag is the bundle key a second language row must match, and the guide in #10211 writes it out in both of its samples under the rule "author the tags your callers actually pass." An omitted key teaches nothing about the key. **Chosen: explicit `locale: 'en-US'`.**

The literal is now wrapped in `defineEmailTemplateDefinition(...)` — the card's other half — so `EmailTemplateDefinitionSchema.parse()` runs at authoring time instead of first at boot.

## Does the shape this lands match what #10211 teaches?

Yes — read from the guide's own branch (`claude/issue-10211-jobs-email-templates`, PR #10273), not from memory. Its sample is `defineEmailTemplateDefinition({ … locale: 'en-US', … })` and its locale section names `en` → `en-US` as the anti-pattern in the same breath as `zh` → `zh-CN`. The one shape difference left standing is the template `name`: the guide recommends a dotted namespace (`crm.task_done`) and this row keeps `showcase_task_done_email`. That is schema-valid (the regex makes the dotted segments optional), it is already app-prefixed, and it is not the anti-pattern the guide warns about — renaming it would be unrelated churn on a key the flow wiring question (#10394) may want to settle anyway.

## The latent half — deliberately NOT taken, and why

The card scoped "wire the template into the Task Completed flow" as a separate call. **Out of scope**, because it is not an addition:

`NotifyConfigSchema`'s `superRefine` refuses `template` combined with inline `title`/`message` outright. `showcase_task_completed`'s notify node uses the inline path, and its `message: '{summary}'` is the **only** consumer of the `summarize` script node's `outputVariable` — which is exactly what that flow's docblock says the flow exists to demonstrate ("A flow function is PURE: it takes `inputs`, RETURNS a value, and a later declarative node uses or persists it"). Wiring the template would trade one deliberate demonstration for another, would additionally need `expand: ['project']` on the start node to feed the template's `project` variable, and would need `@objectstack/plugin-email` registered as a runtime plugin or the channel answers `TEMPLATE_UNSUPPORTED`.

That is a design decision with real options, not a mechanical edit, so it is filed unassigned as #10394 with the three options priced, and the template's docblock now says it is unwired instead of claiming it is "fired by the Task Completed flow".

## Direction pins

`examples/app-showcase/test/email-template-locale.test.ts` (6 tests) resolves the **declared** templates through the real loader and the real column mapping — nothing inspects the source literal's strings:

- the send that used to fail now resolves (for an explicit `en-US` the loader *is* the whole ladder: rungs 1 and 2 name the same tag, so a null there is a `TEMPLATE_NOT_FOUND` throw at the service);
- the resolved row is **this** template — name, subject and `body_html` identity, so a resolution answering the wrong row cannot pass as "not null";
- a no-locale send is now answered by rung 2 rather than by rung 3's lowest-tag fallback;
- `en` still resolves to nothing, pinned in the true direction — there is no prefix matching either way, and it does not need to, because rung 2 catches it;
- **class guard:** every template in `allEmails` is reachable at the default locale, so a template added later cannot reintroduce the defect;
- every declared template is a fixed point of the schema parse — the detectable consequence of going through the factory.

## Ablation

Predicted signature was written down **before** the mutation (the run log): 5 fail / 1 pass, including one failure in the *opposite* direction. Observed, exactly:

```
× resolves `showcase_task_done_email` for an explicit en-US send        expected null not to be null
× resolves THIS template, not some other row of the bundle              expected undefined to be 'showcase_task_done_email'
× answers a no-locale send from the default rung, not the lowest-tag    expected 'en' to be 'en-US'
× does NOT answer the language-only tag `en`                            expected { id: 'row-0', …(10) } to be null   ← reversed: it goes red by RESOLVING
× every declared template in the corpus is reachable at the default     showcase_task_done_email is unreachable at en-US
✓ every declared template went through `defineEmailTemplateDefinition`  (orthogonal — still wrapped)
Tests  5 failed | 1 passed (6)
```

Restore proven byte-identical, not merely re-run: mutated blob `32c86c89f05851c45e26be4a7d10900e2aeb3c02` → restored `c62a8abcd167dd47e46f112f8e6ffa0c47520921`, equal to `git rev-parse HEAD:examples/app-showcase/src/system/emails/index.ts`, worktree clean, 6/6 green again.

**Rebuild statement, corrected against a measurement rather than left as first written.** The first rationale said "app-showcase has no `dist/`". That was true of the worktree at the time and is *not* the load-bearing fact — `pnpm build` does produce `examples/app-showcase/dist` (gitignored). The fact that actually holds: the mutated file is reached through the **relative** specifier `../src/system/emails/index.js`, which vitest transforms from source, so no package resolution and no `dist/` is on that path; and the other package on the path, `@objectstack/plugin-email`, is aliased in `vitest.config.ts` to `packages/plugins/plugin-email/src/index.ts`, also source. Both legs were re-run with the dist present and behaved identically.

A second ablation measured whether the *factory-bypass* half is really guarded, and the honest answer is "partly": unwrapping `defineEmailTemplateDefinition` while spelling every defaulted key stays **green** (a complete literal is still a fixed point of the parse); unwrapping and omitting the defaulted keys — the realistic bypass, and the one that costs something — goes **red** on exactly the fixed-point assertion (`expected { …(10) } to deeply equal { …(8) }`). The guard is on the consequence, not on the wrapper. Recorded rather than claimed as full coverage.

## Why a vitest alias and not a registry entry

The test imports `@objectstack/plugin-email`, which resolves to `dist/` through the workspace link — a stale dist would grade these declarations against an *old* locale ladder, which is the one thing they exist to measure. `check:test-source-alias`'s registry is shrink-only and its header names the alias as the remedy ("Adding an entry, or widening one, is not how a red build gets fixed"), so `examples/app-showcase/vitest.config.ts` gains an **anchored-regex, array-form** entry (rule 5: a bare string key would swallow subpaths into an `ENOTDIR`). The `@objectstack/example-showcase` registry entry is unchanged, and the gate confirms it.

## Changeset

**None — followed the gate, not habit.** `examples/app-showcase` is `private: true` and is not in `.changeset/config.json`'s `fixed` release set; every file this PR touches is inside it plus the lockfile, so the PR releases nothing. That is this repo's textbook `skip-changeset` case (named as such in `lint.yml`'s own rationale), and the empty-frontmatter route used in `objectui` is explicitly rejected here by `check-empty-changeset.mjs`. The `skip-changeset` label is applied and read back.

## Gate union

Derived **after** the final commit on a clean worktree with `node scripts/pm/dispatch-gates.mjs` (no paths passed — the script takes its own change set from the merge base). Re-derived and **re-run in full at the new head `80a65cb0d`** after the follow-up commit below; every verdict below is from that run, and the ratchet families were re-read there rather than carried over. Exit codes captured before any pipe; each quoted from the gate's own verdict line.

| gate | exit | its own verdict line |
|:--|:--|:--|
| `check:type-source-resolution` | 0 | `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; 51 registered as still resolving a workspace dep's types through dist/.` |
| `check:cross-package-test-inputs` | 0 | `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check:override-consistency` | 0 | `✓ 8 published-manifest declaration(s) … all resolve to their override targets.` |
| `check-changeset-fixed.mjs` | 0 | `✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.` |
| `check-osv-exemptions.mjs` | 0 | `✓ osv-scanner.toml holds zero OSV exemptions (the intended steady state).` |
| `check:query-options-erasure` | 0 | `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new` |
| `check:type-check-coverage` | 0 | `✓ check:type-check-coverage --self-test — 23 semantic case(s) … hold.` |
| `check:engine-double-contract` | 0 | `OK  self-test: separates engine doubles from driver doubles …` |
| `check:where-matcher` | 0 | `✓ where-matcher conformance holds: 266 matcher(s) discovered, 266 answer the combinator battery correctly` |
| `check:test-source-alias` | 0 | `check-test-source-alias OK — 72 packages with tests scanned; 61 registered …` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 6115 text file(s) … no raw ASCII control bytes).` |
| `check:type-check-debt --re-measure` | 0 | `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 227.4s, 1924 raw tsc error(s) total, none above its recorded number.` |

Package-level verification on the built closure: `pnpm --filter @objectstack/example-showcase typecheck` (`tsc --noEmit`) clean, and the full suite `Test Files 22 passed (22) · Tests 348 passed (348)`. An earlier run of that suite had 10 files red with `Failed to resolve entry for package "@objectstack/connector-mcp"` — unbuilt dependency dist, not this diff; building the closure first turned all 22 green.

No ledger entry was raised anywhere: `check:type-check-coverage`'s counts are unchanged and `--re-measure` reports none above its recorded number.

`check:test-source-alias` was **added by me** — the derivation did not name it, and I edited exactly its subject. The union is a clue, not a spec.

Builds and the suite ran through `scripts/pm/os-verify-lock.sh`; each reported `VERDICT command-exit 0`.

## Follow-up — `check:type-source-resolution` (CI red on `7bfca1da4`, fixed in `80a65cb0d`)

The first push went red in `Lint & Repo Gates`, legitimately and on this PR's own change:

```
check-type-source-resolution FAILED

  ✗ @objectstack/example-showcase: NEW dist-resolved type import(s) since this entry was measured: @objectstack/plugin-email.
    Add the `paths` rules to the package's tsconfig.json — widening the registry entry is not the fix.
```

The vitest alias above closed the **runtime** half of the staleness exposure this new devDependency creates. It has a second one on the **type** path: unaliased, `@objectstack/plugin-email` contributes `packages/plugins/plugin-email/dist/*.d.ts` to this app's tsc program, so `tsc --noEmit` was grading the declarations against whatever was last built rather than against the locale ladder in this checkout — and the dangerous direction there is a typecheck that **passes**.

Reproduced before fixing rather than fixed on faith: `pnpm check:type-source-resolution` at `7bfca1da4` exits **1** with the message above, and at `80a65cb0d` exits **0** with `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; 51 registered as still resolving a workspace dep's types through 'dist/'.`

The remedy is the `paths` rule the gate asks for, in `examples/app-showcase/tsconfig.json`, mirroring the `@objectstack/formula` entry already there. The shrink-only `KNOWN_DIST_RESOLVED_TYPE_IMPORTS` registry is **untouched** — same discipline this PR already followed for `check:test-source-alias`. Bare key, no `*`: a tsconfig `paths` key without a star is an exact match, whereas the `@objectstack/plugin-email*` spelling (star not preceded by a slash) would fold every subpath onto one target and type-check green against the wrong module — the trap that gate's own header calls out.

Pulling plugin-email's source into the tsc program was the risk worth measuring, and it costs nothing: `pnpm --filter @objectstack/example-showcase typecheck` is clean and the suite is still `Test Files 22 passed (22) · Tests 348 passed (348)`.

**Why the derivation missed it, recorded as a data point rather than an excuse.** `check:type-source-resolution` is a real family (`lint.yml:1318`) and it is the tsconfig-`paths` sibling of the vitest-alias gate I did run. `node scripts/pm/dispatch-gates.mjs` does not name it — **still** does not, even now that `examples/app-showcase/tsconfig.json` is in the change set (zero mentions in the derivation output, against a control term present once). That is the class #10309 already tracks; no new card filed.

## A note on this package going red in CI

`@objectstack/example-showcase` has a tracked, non-reproducing CI failure (#10293, p1). If this PR reds there, that is the known signature and attribution needs a control holding the base fixed — without one the honest verdict is "not attributable", in either direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_