### PR TITLE
docs(check-console-injection): record why packages/spec is not in ci.yml's console filter

### DIFF
--- a/scripts/check-console-injection.mjs
+++ b/scripts/check-console-injection.mjs
@@ -48,6 +48,50 @@
  * the stamped detector is STILL ABSENT from this tree's spec. Once the published
  * spec catches up, the stamp is expired and says so instead of passing.
  *
+ * ## Why packages/spec is NOT in ci.yml's console filter (objectstack#9710)
+ *
+ * That filter lists the pin, the build script and this gate's own sources — not
+ * packages/spec — so a spec-only PR never schedules Console Pin Gate and never
+ * reaches this check. Adding it is the obvious next thought; it was measured and
+ * DECLINED, and the reason is not cost, which is why it is recorded here rather
+ * than left on a card: the job it would schedule is vacuous, not expensive.
+ *
+ * Count what this gate can fail on. Of its six failure verdicts, FIVE are pure
+ * functions of the RESTORED DIST and its stamp — a missing dist, unreadable
+ * assets or a malformed stamp, a missing stamp, the published-only detector
+ * present in the bundle, the stamp's own fresh witness missing from it. A
+ * spec-only diff cannot move any of those: the cache key is the one spelled at
+ * the top of this header — the pin and the build script, nothing else — and
+ * entries under it are IMMUTABLE, so all five replay what the last
+ * console-filtered run already saw. Exactly ONE verdict reads this tree, the
+ * expiry re-check, and it needs packages/spec/dist because readSpecBlob resolves
+ * the package's exports map. So the restore-only job proposed there — no
+ * install, no turbo build — would start the gate 15 more times per 100 commits
+ * (6/100 today, 21/100 with packages/spec added, measured over real first-parent
+ * history) and skip the only tree-sensitive assertion on every one of them.
+ *
+ * Paying for the build instead does not rescue it, because the headline scenario
+ * is one this gate deliberately does not test. With the dist and stamp held
+ * fixed and only the tree varying: spec unbuilt PASSES (expiry not re-checked),
+ * spec unchanged PASSES, spec MOVED FORWARD PASSES, and only a spec that has
+ * caught up to the published text FAILS. "Spec moved forward since the dist was
+ * built" is precisely what a spec trigger would be bought for, and PR
+ * objectstack#9706 already ruled it "not a failure — the ruled cache design
+ * accepts lag". The lag is the trade-off objectstack#9667 accepted when it
+ * rejected the cache-key option, not a defect a trigger change can catch. What
+ * remains has a low ceiling: only 5 of those 15 commits add any `describe()`
+ * text under packages/spec — the only text the probes read — and expiry is a
+ * tree STATE, not an event, so once it is true today's 6/100 console runs still
+ * catch it. Widening the filter buys latency, not coverage.
+ *
+ * The exit, for whoever asks a third time: objectstack#10428 proposes deriving
+ * the expiry probe from packages/spec SOURCE text — `describe()` arguments are
+ * plain string literals — which would make that one assertion BUILDLESS. The
+ * light job is worthless only because its single meaningful assertion needs a
+ * build; remove the build and this question reopens on entirely different terms.
+ * Full working — the paths-filter replay under both picomatch versions, the
+ * per-commit attribution — is on objectstack#9710's ruling comment.
+ *
  * ## Failure response: FAIL, deliberately, rather than rebuild
  *
  * GitHub Actions cache keys are IMMUTABLE. A gate that reacted to a bad restore


### PR DESCRIPTION
Header-only. One file, 44 added lines, zero deletions, no behaviour change.

This lands the PM's ruling on **#9710**'s open question — *where to record the
measurement* — which was answered **C**: put it in
`scripts/check-console-injection.mjs`'s header, where **#9667**'s cache-key cost
model already lives, rather than in `ci.yml`.

`Refs: #9710` deliberately, **not a closing keyword**. That card's ruled outcome
is *keep B — do not widen the filter, do not build the light job*; this commit
implements none of what the card asked for, so it must not auto-close it. The
PM closes it with the ruling recorded.

## What the new section records

A sibling of the existing "Adding `packages/spec` to the cache key was
considered and REJECTED" paragraph, placed after the EXPIRY section and before
the failure-response one:

- the gap is real — `packages/spec` is absent from `ci.yml`'s `console` paths
  filter, so a spec-only PR never schedules Console Pin Gate;
- **the reason it stays that way is not cost.** Of this gate's **six** failure
  verdicts, **five** are pure functions of the restored dist plus its stamp —
  which a spec-only diff cannot move, the cache key being the pin and the build
  script and cache entries immutable — and **exactly one** reads this tree, the
  probe-expiry re-check, which needs `packages/spec/dist` because
  `readSpecBlob` resolves the package's `exports` map;
- so the proposed restore-only job would start the gate **15 more times per 100
  commits** (6/100 today, 21/100 with `packages/spec` added) and skip the only
  tree-sensitive assertion on every one of them;
- and the fully built variant still **passes** on *"spec moved forward since the
  dist was built"* — the headline scenario — which PR **#9706**'s ruling table
  already calls *"not a failure — the ruled cache design accepts lag"*;
- **#10428** is named as the exit: derive the expiry probe from `packages/spec`
  source text, making that assertion buildless, which reopens the trigger
  question on different terms.

Full working (paths-filter replay under both picomatch versions, per-commit
attribution) stays on #9710's ruling comment; the header carries the conclusion
plus the numbers that make it checkable.

## Verification — all at `c84898aeb` (the final commit)

`node scripts/pm/dispatch-gates.mjs` derived three families for this diff, all
green at head:

| gate | verdict line |
|---|---|
| `pnpm check:console-injection` | `✓ check-console-injection --self-test: 21 assertions over real fixture trees (real evaluate() path)` (exit 0) |
| `node scripts/check-cross-package-test-inputs.mjs` | `OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check:nul-bytes` (standing, any edit) | `check-nul-bytes: OK (scanned 6124 text file(s) … no raw ASCII control bytes).` |

`pnpm lint` — `os-verify-lock: VERDICT command-exit 0 · held the lock 58s ·
waited 171s`, ESLint silent. It ran on byte-identical content: the commit
changed no bytes (`git status --porcelain` = 0 lines, `git diff HEAD` empty at
`c84898aeb`). Relevant because PR #10429's
`comment-swallow/no-code-inside-block-comment` targets exactly this shape —
every added line carries the `*` prose marker, blank ones included, and the
block contains no `*/` sequence (`packages/spec` is written unglobbed for that
reason).

Independently reproduced the ruling's price numbers here before writing them
down, by literal-path replay over the same window (all seven `console` filter
entries are literal paths, so no matcher is needed): 100 first-parent commits
ending `e502a6a8e` → baseline **6/100**, `+ packages/spec` **21/100** (+15),
`+ packages/spec/src` **16/100**, and **5 of the 15** add `.describe(` text
under `packages/spec`. The five-vs-one verdict split was re-derived from the
current source, not inherited from the brief — it matches.

## Not in this diff

- ⛔ `.github/workflows/ci.yml` — that was option A and it is ruled out.
- No new flag, no new assertion, no test change, no behaviour change.
- Changeset: `scripts/**` publishes nothing (the root package is `private`), so
  `skip-changeset`. Re-derived at diff time by publish surface.

Refs: #9710 (the card and its ruling) · #9667 (the cost model already in this
header) · #9706 (the ruling table) · #10428 (the exit)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_