### PR TITLE
test(spec): let the sdui collision harness own the port it calls busy

### DIFF
--- a/packages/spec/scripts/gen-sdui-manifest-collision.test.ts
+++ b/packages/spec/scripts/gen-sdui-manifest-collision.test.ts
@@ -69,6 +69,50 @@
 // BUSY_HELD is asserted before PICKED_WITH_BUSY is believed: a precondition
 // that can evaporate silently is a test that accuses the wrong function.
 //
+// ## The precondition needed an OWNED port, not a picked one — measured
+//
+// That paragraph was still only half of it, and the other half reddened three
+// unrelated PRs in one afternoon, byte-identical every time:
+//
+//     BUSY_HELD=no
+//     BUSY_PORT=5180
+//     PICKED_WITH_BUSY=5181
+//
+// `PICKED_WITH_BUSY=5181` is the picker answering CORRECTLY — asked to avoid
+// 5180 it returned 5181. `BUSY_HELD=no` alone is the failure, and the thief was
+// this file. The occupier used to bind the port `sdui_pick_free_port` had just
+// handed it, and a RESERVATION IS NOT A BIND: the port stays takeable in the gap
+// between the pick returning and the occupier binding. `port_held` below binds
+// and closes that exact port, and it is spawned within milliseconds of the
+// occupier. Measured, 80 trials on an idle container:
+//
+//     probe won the bind 39/80        # the two genuinely race
+//     occupier died      1/80         # its bind landed inside the probe's hold
+//
+// Nothing outside this file has to hold 5180 for that to fire, which is why no
+// one could name the process that did. So the occupier binds `:0` and reports
+// back the port the kernel gave it: it is already holding that port when it
+// names it, which is the property BUSY_HELD asserts, and no gap is left.
+//
+// ## Why `set +e` follows the `source`, and why the harness ends `exit 0`
+//
+// `scripts/gen-sdui-manifest.sh` is `set -euo pipefail` at its top, so SOURCING
+// it turns errexit back ON here, overriding the `set -uo pipefail` written one
+// line earlier. Measured rather than read: `case "$-" in *e*)` after the source
+// reports `e` set. That is what truncated the three captures above. When the
+// occupier had already exited, the cleanup `kill` returned 1, errexit aborted
+// the harness on that line, `execFileSync` threw in the `describe` body, and
+// vitest reported `0 test` and a bare `Error: Command failed: bash
+// /tmp/sdui-collision-*/harness.sh` — every assertion that would have named the
+// problem pre-empted, the diagnosis surviving only because stdout rides along
+// on the serialized error. Reproduced here: forcing the occupier to lose its
+// bind stopped the harness dead after `PICKED_WITH_BUSY`, exit 1, exactly the
+// captured shape. So errexit is turned off again AFTER the source, and the
+// harness exits 0 unconditionally: its exit status is not a measurement. Every
+// measurement is a printed KEY=VALUE line and the assertions below grade those,
+// so a precondition that fails now fails AS AN ASSERTION, printing the whole
+// `seen` map with it.
+//
 // No vite and no console build: the contract under test is one the shell script
 // owns, and the ports are picked at run time by the script's own helper so this
 // test cannot collide with a concurrent agent — which would be a poor look here.
@@ -103,24 +147,31 @@ const HTTP_STUB = [
   'const s = http.createServer((_q, r) => { r.writeHead(200); r.end("SERVER"); });',
   // Losing the bind must EXIT, not throw: an unhandled 'error' event kills the
   // harness with a stack trace where a vacuity guard would have named the
-  // problem. See RAW_LISTENER below for the same reasoning.
+  // problem. See OWNED_LISTENER below for the same reasoning.
   's.once("error", () => process.exit(1));',
   's.listen(Number(process.env.SDUI_TEST_PORT), "127.0.0.1");',
 ].join('');
 
 /**
- * A bare TCP listener on $SDUI_TEST_PORT that reports a lost bind by exiting.
+ * A bare TCP listener that binds an EPHEMERAL port and prints the one it got.
  *
- * The unguarded form of this line is what made the merge-queue failure this
- * file now pins so hard to read: when a concurrent scanner took the port
- * first, node threw `Unhandled 'error' event ... EADDRINUSE 127.0.0.1:5180`,
- * the harness died mid-measurement, and the report was a stack trace instead
- * of "the port this test meant to occupy was never occupied".
+ * Bind first, name second. Asking the picker for a port and binding it
+ * afterwards leaves a window in which anything at all — including `port_held`
+ * below, measured — can take it, and losing there evaporates the precondition
+ * the BUSY/STEAL assertions rest on. Port 0 closes the window by construction:
+ * the number is written from inside the `listening` callback, so by the time
+ * the harness can read it the socket is already held.
+ *
+ * The error guard stays. It is near-unreachable on `:0`, but the unguarded form
+ * of this line is what made the merge-queue failure this file pins so hard to
+ * read: node threw `Unhandled 'error' event ... EADDRINUSE 127.0.0.1:5180`, the
+ * harness died mid-measurement, and the report was a stack trace instead of
+ * "the port this test meant to occupy was never occupied".
  */
-const RAW_LISTENER = [
+const OWNED_LISTENER = [
   'const s = require("node:net").createServer();',
   's.once("error", () => process.exit(1));',
-  's.listen(Number(process.env.SDUI_TEST_PORT), "127.0.0.1");',
+  's.listen(0, "127.0.0.1", () => console.log(s.address().port));',
 ].join('');
 
 function runHarness(): Record<string, string> {
@@ -137,6 +188,11 @@ function runHarness(): Record<string, string> {
       // Sourcing runs no generation — the script returns right after defining
       // its helpers, so this exercises the REAL functions.
       `source ${JSON.stringify(SCRIPT)}`,
+      // …but the file just sourced opens with `set -euo pipefail`, so the source
+      // turns errexit back ON here and silently overrides the line above. That
+      // is what turned a failed precondition into a harness crash and a `0 test`
+      // report; see the header. Off again, after the source, where it sticks.
+      'set +e',
       `DIR=${JSON.stringify(dir)}`,
       'NODE_BIN="$(command -v node)"',
       // "is $1 held right now?" — the same probe shape the script uses, so a
@@ -150,21 +206,41 @@ function runHarness(): Record<string, string> {
       'printf "DEV_ARGV=%s\\n" "${ARGV[*]}"',
       '',
       '# ── 2. the free-port search skips a port that is taken right now ────',
-      'BUSY="$(sdui_pick_free_port 5180)"',
-      'export SDUI_TEST_PORT="$BUSY"',
-      `"$NODE_BIN" -e ${JSON.stringify(RAW_LISTENER)} &`,
+      // The busy port is the one the occupier BOUND, not one the picker handed
+      // it: a reservation is not a bind, and the gap between the two is what
+      // `port_held` walked through. See the header for the 80-trial count.
+      'BUSY_FILE="$DIR/busy.port"',
+      `"$NODE_BIN" -e ${JSON.stringify(OWNED_LISTENER)} > "$BUSY_FILE" &`,
       'BUSY_PID=$!',
       // disown: otherwise bash prints its own "Killed" job notice when this is
       // reaped below, which reads like a test failure in the vitest output.
       'disown "$BUSY_PID" 2>/dev/null || true',
-      'for _ in $(seq 1 40); do [ "$(port_held "$BUSY")" = yes ] && break; sleep 0.25; done',
+      // The port appears only once the socket is bound, so waiting for the
+      // number IS waiting for the hold — there is no second thing to wait for.
+      'BUSY=""',
+      'for _ in $(seq 1 40); do BUSY="$(tr -d "[:space:]" < "$BUSY_FILE" 2>/dev/null || true)"; [ -n "$BUSY" ] && break; sleep 0.25; done',
       // Vacuity guard, and the one this file was missing when it ejected a PR:
       // if the occupier never took the port, the pick below returns it and the
-      // green/red says nothing about the picker.
+      // green/red says nothing about the picker. Nothing can lose the port to a
+      // racer any more; the guard stays because it is what would make the next
+      // way of losing it legible instead of an accusation of the picker.
       'printf "BUSY_HELD=%s\\n" "$(port_held "$BUSY")"',
       'printf "BUSY_PORT=%s\\n" "$BUSY"',
+      // An ephemeral base does not risk scanning off the end of the port space:
+      // the first candidate is the port we hold, the second is free, and the
+      // scan returns there rather than walking its 200-port span upward.
       'printf "PICKED_WITH_BUSY=%s\\n" "$(sdui_pick_free_port "$BUSY")"',
       'kill -KILL "$BUSY_PID" 2>/dev/null',
+      '',
+      '# ── 2b. a third sequential pick from the shared base ────────────────',
+      // Case 2 used to contribute one of these as a by-product, back when its
+      // occupier took its port from the picker. It owns an ephemeral port now,
+      // so the third pick is taken explicitly: without it the "each pick within
+      // one run its own port" assertion compares two picked ports against one
+      // ephemeral one, and those differ whatever the registry does — a guard
+      // that would go green for a reason unrelated to what it guards.
+      'RPORT="$(sdui_pick_free_port 5180)"',
+      'printf "RPORT=%s\\n" "$RPORT"',
       '',
       '# ── 3. a NEIGHBOUR answering on our port is refused, not accepted ───',
       'NPORT="$(sdui_pick_free_port 5180)"',
@@ -232,15 +308,21 @@ function runHarness(): Record<string, string> {
       // the registry. Against everything else the probe is still the answer,
       // and losing there must not leak the claim — a hoarded claim would cost
       // a port on every future run in this container.
-      'SPORT="$(sdui_pick_free_port 5180)"',
-      'export SDUI_TEST_PORT="$SPORT"',
-      `"$NODE_BIN" -e ${JSON.stringify(RAW_LISTENER)} &`,
+      // Bound, then named — the same precondition case 2 needs, and the same
+      // way of guaranteeing it. STEAL_HELD is not a weaker assertion than
+      // BUSY_HELD and had no business resting on a weaker mechanism.
+      'STEAL_FILE="$DIR/steal.port"',
+      `"$NODE_BIN" -e ${JSON.stringify(OWNED_LISTENER)} > "$STEAL_FILE" &`,
       'STEAL_PID=$!',
       'disown "$STEAL_PID" 2>/dev/null || true',
-      'for _ in $(seq 1 40); do [ "$(port_held "$SPORT")" = yes ] && break; sleep 0.25; done',
+      'SPORT=""',
+      'for _ in $(seq 1 40); do SPORT="$(tr -d "[:space:]" < "$STEAL_FILE" 2>/dev/null || true)"; [ -n "$SPORT" ] && break; sleep 0.25; done',
       'printf "STEAL_HELD=%s\\n" "$(port_held "$SPORT")"',
-      // A registry of its own, so the listener above is genuinely foreign to
-      // it — the shared registry already knows this port is ours.
+      // A registry of its own, so the claim files the two lines below read are
+      // written by this leg and nothing else. The holder is foreign to that
+      // registry either way, and more plainly than before: a port bound
+      // directly from the ephemeral range was never claimed in any registry,
+      // which is exactly the non-participant this case exists to cover.
       'RESV="$DIR/resv"',
       'STEAL_PICK="$( (export SDUI_PORT_RESERVATION_DIR="$RESV"; sdui_pick_free_port "$SPORT") )"',
       'printf "STEAL_PORT=%s\\n" "$SPORT"',
@@ -253,6 +335,15 @@ function runHarness(): Record<string, string> {
       // half that can only be true when the registry is real.
       'printf "STEAL_CLAIM_ON_PICK=%s\\n" "$([ -e "$RESV/$STEAL_PICK" ] && echo yes || echo no)"',
       'kill -KILL "$STEAL_PID" 2>/dev/null',
+      '',
+      // Grading belongs to the assertions, not to whatever the last cleanup
+      // returned. Reaping an occupier that already exited fails, and under the
+      // errexit this file used to inherit that failure ended the harness where
+      // it stood; `execFileSync` then threw in the `describe` body and vitest
+      // reported `0 test` against a bare "Command failed". Exit 0 and let the
+      // KEY=VALUE lines above be the evidence — a red then names its assertion
+      // and prints the whole `seen` map beside it.
+      'exit 0',
     ].join('\n'),
     { mode: 0o755 },
   );
@@ -311,7 +402,11 @@ describe.skipIf(!RUNNABLE)('gen-sdui-manifest.sh concurrent-run contract', () =>
   });
 
   it('gives each pick within one run its own port', () => {
-    const picked = [seen.BUSY_PORT, seen.NPORT, seen.OPORT];
+    // Three ports the PICKER handed out, from one base, in one run. BUSY_PORT
+    // is deliberately not among them any more: the occupier binds an ephemeral
+    // port of its own, and an ephemeral port differs from the 5180 band however
+    // the registry behaves, so counting it here would be free.
+    const picked = [seen.NPORT, seen.OPORT, seen.RPORT];
     expect(picked.every((p) => /^\d+$/.test(p ?? '')), picked.join(',')).toBe(true);
     expect(new Set(picked).size, picked.join(',')).toBe(3);
   });


### PR DESCRIPTION
Fixes: #10370

## What actually broke

`BUSY_HELD=no` / `BUSY_PORT=5180` / `PICKED_WITH_BUSY=5181`, byte-identical on three
unrelated PRs in one afternoon (#10365 17:00Z, #10396 19:03Z — evicted from the merge
queue — #10441 19:22Z). `PICKED_WITH_BUSY=5181` is the picker answering **correctly**.
`BUSY_HELD=no` alone is the failure.

**The card's stated mechanism is not what happens, and the correction matters.** The card
says the harness "binds the fixed base port 5180". It does not — it calls
`sdui_pick_free_port 5180` and binds whatever that returns. `BUSY_PORT=5180` therefore
means the picker *probed 5180 and found it free*. An external holder of 5180 cannot
produce this signature at all: the picker would have skipped it and `BUSY_PORT` would read
5181. The port was taken in the window **between the pick returning and the occupier
binding** — a reservation is not a bind.

**The thief is this file.** `port_held` binds-and-closes the very port the occupier is
about to take, and it is spawned milliseconds later. Measured, 80 trials on an idle
container (`race-probe`, occupier + first probe launched exactly as the harness launches
them):

```
probe won the bind     39/80    # the two genuinely race, ~50/50
occupier died           1/80    # its bind landed inside the probe's hold window
```

Nothing outside this file has to hold 5180 for that to fire, which answers the card's
open question — *"nobody has identified what holds 5180"*. Nothing did.

## Why the failure arrived as `0 test` and a bare `Command failed`

Second, independent defect, and the PM's structural note was right about the effect but
not the cause. It is **not** "no `set -e`, so the exit status is the last command's":

```
$ bash -c 'set -uo pipefail; source scripts/gen-sdui-manifest.sh; echo "flags=$-"'
flags=ehuBc          # e — errexit is ON
```

`scripts/gen-sdui-manifest.sh` opens with `set -euo pipefail` (`:24`), so **sourcing it
turns errexit back on**, silently overriding the `set -uo pipefail` the harness writes one
line earlier — and contradicting that line's own comment. Once the occupier had exited,
the cleanup `kill` returned 1 and errexit ended the harness *on that line*. Reproduced by
forcing the occupier to lose its bind, `bash -x`:

```
+ printf 'PICKED_WITH_BUSY=%s\n' 5181
+ kill -KILL 1523                      # trace ends here; harness exit 1
```

That is why the captured output stops after `PICKED_WITH_BUSY` and why `execFileSync`
threw in the `describe` body.

## The fix

1. **Both occupiers bind `:0` and report back the port the kernel gave them** (case 2's
   `BUSY`, case 7's `SPORT`). The number is printed from inside the `listening` callback,
   so by the time the harness can read it the socket is already held — the property
   `BUSY_HELD` asserts, with no gap left to race through. This is the card's shape 1;
   shapes 2 and 3 were not needed. Shape 2 was additionally the one constraint 3 warns
   about, and shape 3 only shrinks a window that shape 1 removes.
2. **`set +e` after the `source`**, restoring the mode the harness declares for itself,
   and a final **`exit 0`**: the harness's exit status is not a measurement — every
   measurement is a printed `KEY=VALUE` and the assertions grade those. The sibling
   `publish-smoke-port-collision.test.ts` already does exactly this (`set +e +o pipefail`,
   `:135`) for exactly this reason; this file was the one that had not caught up. It keeps
   `pipefail`, which is what its own `set -uo pipefail` asked for.

## Evidence

**A/B on the same rig.** Widening the *measured* racer — `port_held` holds its socket
300 ms before closing, nothing else changed — six runs each:

| | nonzero exit | signature |
|---|---|---|
| pre-fix harness | **2/6** | one `BUSY_HELD=no` (byte-identical to CI), one `STEAL_HELD=no` |
| fixed harness | **0/6** | `BUSY_HELD=yes` and `STEAL_HELD=yes` every run |

**Positive control on the reject side — the guard still rejects.** Ablation: make the
occupier bind, close, *then* report, i.e. name a port it does not hold. Not a zero-hit:

```
❯ scripts/gen-sdui-manifest-collision.test.ts (8 tests | 2 failed)
  × picks a per-run port, skipping one that is already taken
  × skips a port held from outside the registry and releases the claim
AssertionError: {"DEV_ARGV":"…","BUSY_HELD":"no","BUSY_PORT":"34323","PICKED_WITH_BUSY":"34323",…}
  expected 'no' to be 'yes'
 ❯ scripts/gen-sdui-manifest-collision.test.ts:376:50
```

Note `PICKED_WITH_BUSY` **equals** `BUSY_PORT` there: without the guard this reads as *"the
picker ignores busy ports"*, which is precisely the misdiagnosis the file's header warns
about. The guard fires first and names the real problem.

**The same ablation against the pre-fix file**, for the reporting shape the second half
replaces — the frames match the card's capture exactly:

```
❯ scripts/gen-sdui-manifest-collision.test.ts (0 test)
Error: Command failed: bash /tmp/sdui-collision-Uk5QCr/harness.sh
 ❯ runHarness scripts/gen-sdui-manifest-collision.test.ts:260:15
```

No rebuild is involved in either leg: this test resolves nothing through a package
`exports`/`dist` — it imports `vitest` and node builtins only, and sources the shell script
by absolute path. Both ablations were confirmed on disk by grepping for the injected *and*
the removed spelling, and the restore leg was verified clean against `HEAD` and re-run
green.

## Constraints, each checked

- ⛔ **`expect(seen.BUSY_HELD, JSON.stringify(seen)).toBe('yes')` is untouched**, byte for
  byte (now `:376`). Its sibling `STEAL_HELD` too. The fix makes the precondition
  *satisfiable*, never optional.
- ⛔ **No probe address converged.** Every probe in this file still addresses `127.0.0.1`;
  nothing wildcard was introduced. #10261 is untouched.
- ⛔ **Case 7 still covers a non-participant in the registry** — more plainly than before:
  a port bound directly from the ephemeral range was never claimed in *any* registry. The
  private `RESV` stays, now justified by what it actually buys (claim files this leg alone
  writes) rather than by the shared registry knowing the port, which is no longer true.
- **Anti-vacuity, one that the fix would otherwise have caused.** `gives each pick within
  one run its own port` read `[BUSY_PORT, NPORT, OPORT]`. With `BUSY_PORT` ephemeral it
  would have compared one ephemeral port against the 5180 band and passed for free, so a
  third *sequential pick from the shared base* (`RPORT`) replaces it. Three picker outputs,
  one base, one run — the property is preserved at full strength, not quietly dropped to
  two.

## Changeset

**None owed, re-derived rather than assumed.** `@objectstack/spec` publishes
`files: ["dist", "json-schema", "liveness", "prompts", "llms.txt", "README.md",
"src/**/*.zod.ts", "CHANGELOG.md", "api-surface", "spec-changes.json"]` — `scripts/` is not
among them, so `packages/spec/scripts/gen-sdui-manifest-collision.test.ts` reaches no
published surface. `skip-changeset` applied.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs` against the real diff (it took the change
set from the merge base itself), at `38b1f88`:

```
check:nul-bytes 0 · check:merge-driver 0 · check:slot-lookup 0 · check:type-source-resolution 0
check:query-options-erasure 0 · check:type-check-coverage 0 · check:engine-double-contract 0
check:where-matcher 0 · docs-audit/check-affected-docs 0
spec: check:empty-state 0 · check:liveness 0 · check:strictness-ledger 0 · check:variant-docs 0
```

```
pnpm --filter @objectstack/spec run typecheck      -> VERDICT command-exit 0
  check:test-typecheck: OK — 55 file(s) / 263 error(s) held in test-typecheck-debt.json (unchanged)
pnpm --filter @objectstack/spec test               -> VERDICT command-exit 0
  Test Files 415 passed (415) · Tests 11076 passed (11076)
```

Two narrowings, declared: **`check:dev-prereqs`** and **`check:type-check-debt
--re-measure`** both demand a fully built 67-package workspace. `check:dev-prereqs` reds on
that alone here (`"The workspace is not built — 1 unmet precondition"`), unrelated to this
diff; `check:type-check-debt`'s per-package ratchet is the same ledger
`check:test-typecheck` just reported unchanged above. CI runs both against a built tree.

⚠️ `Lint & Repo Gates` may be red for #10122 (`packages/spec/src/migrations/registry.ts`,
`@typescript-eslint/parser` `Maximum call stack size exceeded`). Assigned elsewhere, not
this PR's.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_