### PR TITLE
fix(example-showcase): make the react rollups use the adapter's query contract

### DIFF
--- a/.changeset/showcase-react-page-adapter-query-contract.md
+++ b/.changeset/showcase-react-page-adapter-query-contract.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/example-showcase": patch
+---
+
+Fix the showcase react pages' `useAdapter()` query contract, and pin it (#10288)
+
+`renewals-pipeline` passed `top: 500` and `crm-workbench` passed `limit: 200` to
+`adapter.find`. Neither is a query option: `QueryParams` declares only `$`-prefixed keys
+and `ObjectStackAdapter.convertQueryParams` copies exactly those, so the key reached no
+branch and was dropped with no error. The consequence is the opposite of a truncated
+read — the GET list route has **no default page size**, so an absent `top` returns the
+ENTIRE match set, and the cap the author wrote never happened.
+
+The same effect then read its rows off `.records`. `find()` resolves to a normalized
+`QueryResult` (`data` + `total`), never the REST envelope, so `pr.records` was
+`undefined` on every call and the renewals KPI strip sat at `0 / 0 / 0` while the
+`<ListView>` beside it showed the same rows correctly. Measured on a 640-row account with
+the real page source driven against a contract-faithful adapter double: before,
+`$top` arrives `undefined` and the strip reads `{projects: 0, invoices: 0, openInvoices: 0}`;
+after, the cap is applied and it reads `{projects: 640, invoices: 640, openInvoices: 100,
+capped: true}`.
+
+Applying the cap is only half a fix, because `data.length` under a `$top` is exactly the
+silently-capped count the card was filed about — so both pages now count the envelope's
+`total` (the server's real count over the same `$filter` whenever a limit was applied).
+The one number a cap genuinely bounds, "Open AR", is a per-row verdict over the fetched
+window; it renders as `100+` rather than passing for a total.
+
+`test/react-page-adapter-query-contract.test.ts` executes the page's real rollup effect
+and then sweeps every `kind:'react'` page in the app for both contracts, with an
+extraction control, a census control, and a positive control on the scanners.

--- a/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
+++ b/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
@@ -36,9 +36,19 @@ function Page() {
       // a "records" array. Reading .records here always missed, so the KPI cards
       // silently stuck at 0 even though the ListView beside them showed the same
       // rows. Read .data first, with .records/array fallbacks for robustness.
-      const all = await adapter.find('showcase_project', { limit: 200 });
+      //
+      // The cap is $top, not 'limit': QueryParams declares only $-prefixed keys
+      // and the adapter copies only those, so a bare 'limit' is dropped without
+      // an error and the read runs unbounded. And once a cap IS applied, the
+      // headline count has to come from the envelope's 'total' (the server's
+      // real count over the same filter) — rows.length would report 200 for
+      // every workspace with more than 200 projects, and look right doing it.
+      // "Active" stays a per-row verdict over the 200 rows actually fetched;
+      // an exact one would need its own filtered count query.
+      const all = await adapter.find('showcase_project', { $top: 200 });
       const rows = Array.isArray(all) ? all : (all && (all.data || all.records)) || [];
-      setStats({ total: rows.length, active: rows.filter((r) => r.status === 'active').length });
+      const total = typeof (all && all.total) === 'number' ? all.total : rows.length;
+      setStats({ total, active: rows.filter((r) => r.status === 'active').length });
     } catch (e) { console.warn('[CRM Workbench] failed to refresh stats', e); }
   }, [adapter]);
   React.useEffect(() => { refreshStats(); }, [refreshStats, reloadKey]);

--- a/examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts
+++ b/examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts
@@ -13,7 +13,9 @@ import { definePage } from '@objectstack/spec/ui';
  *
  * The 360 panel deliberately shows BOTH rollup styles side by side:
  *   • hand-rolled — a `useAdapter()` effect counts related projects/invoices
- *     into a KPI strip (full control, you own loading/refresh), vs
+ *     into a KPI strip (full control, you own loading/refresh, and you own the
+ *     adapter's `$`-prefixed option contract and its `QueryResult` shape — see
+ *     the numbered note on the effect), vs
  *   • framework blocks — `<ObjectChart>`/`<ListView>` do the same cross-object
  *     reads declaratively (zero data code).
  * (This comparison absorbed the former Account Cockpit page.)
@@ -56,19 +58,43 @@ function Page() {
   const [editing, setEditing] = React.useState(false);
   const [reload, setReload] = React.useState(0);
   const [stage, setStage] = React.useState('active');
-  const [related, setRelated] = React.useState({ projects: 0, invoices: 0, openInvoices: 0 });
+  const [related, setRelated] = React.useState({ projects: 0, invoices: 0, openInvoices: 0, capped: false });
 
   // Hand-rolled rollup: the imperative counterpart of the framework blocks
-  // below. You own the queries, loading, and refresh (reload bumps re-run it).
+  // below. You own the queries, loading, and refresh (reload bumps re-run it) --
+  // and, because you own them, you own the two adapter contracts the blocks hide:
+  //
+  //  1. QUERY OPTIONS ARE $-PREFIXED. QueryParams declares $select, $filter,
+  //     $orderby, $skip, $top, $expand, $search, $count, and the adapter copies
+  //     ONLY those. A bare 'top:' / 'limit:' reaches no branch and is dropped
+  //     with no error, so the cap you wrote is never applied -- and the list
+  //     route has no default page size, so the query comes back carrying EVERY
+  //     matching row.
+  //  2. THE RESULT IS A QueryResult, NOT THE REST ENVELOPE. Rows arrive under
+  //     'data' (never 'records'), beside 'total' -- which, whenever $top was
+  //     applied, is the server's real count over the same $filter rather than
+  //     the page length. Counting data.length under a cap is how a KPI starts
+  //     under-reporting in silence; count 'total' and the cap stays a fetch
+  //     bound instead of a lie about the business.
   React.useEffect(() => {
     let alive = true;
     (async () => {
-      if (!adapter || !sel) { setRelated({ projects: 0, invoices: 0, openInvoices: 0 }); return; }
-      const pr = await adapter.find('showcase_project', { $filter: ['account', '=', sel], top: 500 });
-      const iv = await adapter.find('showcase_invoice', { $filter: ['account', '=', sel], top: 500 });
-      const projects = Array.isArray(pr) ? pr : (pr && pr.records) || [];
-      const invoices = Array.isArray(iv) ? iv : (iv && iv.records) || [];
-      if (alive) setRelated({ projects: projects.length, invoices: invoices.length, openInvoices: invoices.filter((r) => r.status !== 'paid' && r.status !== 'void').length });
+      if (!adapter || !sel) { setRelated({ projects: 0, invoices: 0, openInvoices: 0, capped: false }); return; }
+      const pr = await adapter.find('showcase_project', { $filter: ['account', '=', sel], $top: 500 });
+      const iv = await adapter.find('showcase_invoice', { $filter: ['account', '=', sel], $top: 500 });
+      const rows = (res) => (Array.isArray(res) ? res : (res && res.data) || []);
+      const count = (res, list) => (typeof (res && res.total) === 'number' ? res.total : list.length);
+      const projects = rows(pr);
+      const invoices = rows(iv);
+      // Open AR is a per-row verdict, so it can only be read off the rows we
+      // actually fetched -- the one number here the cap genuinely bounds. The
+      // 'capped' flag says so on screen instead of letting it pass for a total.
+      if (alive) setRelated({
+        projects: count(pr, projects),
+        invoices: count(iv, invoices),
+        openInvoices: invoices.filter((r) => r.status !== 'paid' && r.status !== 'void').length,
+        capped: invoices.length < count(iv, invoices),
+      });
     })();
     return () => { alive = false; };
   }, [adapter, sel, reload]);
@@ -132,7 +158,7 @@ function Page() {
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
               <Stat label="Projects" value={related.projects} />
               <Stat label="Invoices" value={related.invoices} />
-              <Stat label="Open AR" value={related.openInvoices} accent="hsl(38 92% 50%)" />
+              <Stat label="Open AR" value={related.capped ? related.openInvoices + '+' : related.openInvoices} accent="hsl(38 92% 50%)" />
             </div>
 
             <ObjectChart objectName="showcase_invoice" type="bar" aggregate={{ field: 'total', function: 'sum', groupBy: 'status' }} xAxis={{ field: 'status' }} yAxis={[{ field: 'total', format: '$0,0' }]} series={[{ name: 'total', label: 'Invoice value' }]} title="Invoice value by status" showLegend={true} />

--- a/examples/app-showcase/test/react-page-adapter-query-contract.test.ts
+++ b/examples/app-showcase/test/react-page-adapter-query-contract.test.ts
@@ -1,0 +1,328 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+
+import * as pages from '../src/ui/pages/index.js';
+import { RenewalsPipelinePage } from '../src/ui/pages/index.js';
+
+/**
+ * The two `useAdapter()` contracts a hand-rolled rollup owns, pinned against the
+ * react pages this app ships.
+ *
+ * Both are DROP-SHAPED — nothing throws, nothing warns, and the page renders a
+ * plausible number either way, which is why neither `os validate` nor
+ * `tsc` nor a smoke test catches them:
+ *
+ *  1. `QueryParams` (objectui `packages/types/src/data.ts`) declares ONLY
+ *     `$`-prefixed keys, and `ObjectStackAdapter.convertQueryParams` (objectui
+ *     `packages/data-objectstack/src/index.ts`) builds its outgoing options by
+ *     copying exactly those. A bare `top:` / `limit:` reaches no branch and is
+ *     dropped. It does not fall back to a default page: the GET list route has
+ *     no default page size (`packages/client/src/index.ts`, and pinned in
+ *     `packages/client/src/client.test.ts`), so an absent `top` returns the
+ *     ENTIRE match set — the cap the author wrote simply never happens.
+ *  2. `find()` resolves to a normalized `QueryResult` — rows under `data`,
+ *     never the REST envelope's `records`, plus `total`. Reading `.records`
+ *     yields `undefined` on every call, so a KPI over it sticks at 0 forever
+ *     while the `<ListView>` beside it shows the same rows correctly.
+ *
+ * `total` is the third half of the same contract: with a `$top` applied the
+ * server runs a real count over the same filter
+ * (`ObjectStackProtocolImplementation.findData`), so a KPI that counts
+ * `data.length` under a cap under-reports silently. Fixing (1) without reading
+ * `total` therefore CREATES the capped-count defect it was meant to remove.
+ */
+
+// ---------------------------------------------------------------------------
+// A contract-faithful `ObjectStackAdapter` double
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+
+/**
+ * Mirrors the three behaviours above, and nothing else. Deliberately literal:
+ * it reads ONLY `$`-prefixed keys (so an unprefixed one is dropped exactly as
+ * the real adapter drops it) and returns the `QueryResult` shape.
+ */
+function makeAdapterDouble(store: Record<string, Row[]>) {
+  const seen: Array<{ resource: string; params: Record<string, unknown> }> = [];
+
+  const matches = (row: Row, filter: unknown): boolean => {
+    if (!Array.isArray(filter)) return true;
+    const [field, op, value] = filter as [string, string, unknown];
+    if (op !== '=') throw new Error(`double does not implement operator '${op}'`);
+    return row[field] === value;
+  };
+
+  return {
+    seen,
+    find(resource: string, params: Record<string, unknown> = {}) {
+      seen.push({ resource, params });
+      const all = (store[resource] ?? []).filter((r) => matches(r, params.$filter));
+      // ONLY the `$` spelling is read — this is the drop under test.
+      const limit = typeof params.$top === 'number' ? params.$top : undefined;
+      const data = limit === undefined ? all : all.slice(0, limit);
+      // No limit → the whole match set came back, so its length IS the total.
+      // With a limit → the server counts over the same filter.
+      const total = limit === undefined ? data.length : all.length;
+      return Promise.resolve({
+        data,
+        total,
+        page: 1,
+        pageSize: limit,
+        hasMore: data.length < total,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Running the page's REAL rollup effect
+// ---------------------------------------------------------------------------
+
+/** Slice the balanced `(...)` that starts at `from` (which must be `(`). */
+function balancedCall(src: string, from: number): string {
+  let depth = 0;
+  for (let i = from; i < src.length; i++) {
+    if (src[i] === '(') depth++;
+    else if (src[i] === ')') {
+      depth--;
+      if (depth === 0) return src.slice(from, i + 1);
+    }
+  }
+  throw new Error('unbalanced call expression');
+}
+
+/** Lift the `React.useEffect(...)` rollup out of the page source, verbatim. */
+function extractRollupEffect(source: string): string {
+  const anchor = 'React.useEffect(';
+  const at = source.indexOf(anchor);
+  if (at < 0) throw new Error('no React.useEffect in page source');
+  return `React.useEffect${balancedCall(source, at + anchor.length - 1)};`;
+}
+
+interface Rollup {
+  projects: number;
+  invoices: number;
+  openInvoices: number;
+  capped?: boolean;
+}
+
+/** Execute the extracted effect with a stub React and the adapter double. */
+async function runRollup(
+  effectSource: string,
+  adapter: ReturnType<typeof makeAdapterDouble>,
+  sel: string | null,
+): Promise<Rollup> {
+  let settle!: (v: Rollup) => void;
+  const done = new Promise<Rollup>((res) => { settle = res; });
+  const React = { useEffect: (cb: () => unknown) => { cb(); } };
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  const run = new Function('React', 'adapter', 'sel', 'reload', 'setRelated', effectSource) as (
+    React: unknown, adapter: unknown, sel: unknown, reload: unknown, setRelated: (v: Rollup) => void,
+  ) => void;
+  run(React, adapter, sel, 0, settle);
+  return done;
+}
+
+// ---------------------------------------------------------------------------
+
+describe('renewals-pipeline hand-rolled rollup — the adapter contract, executed', () => {
+  const effect = extractRollupEffect(RenewalsPipelinePage.source as string);
+
+  it('lifted the real effect out of the page source (extraction control)', () => {
+    // Guards the harness itself: if the anchor ever stops matching, every
+    // assertion below would pass over an empty string.
+    expect(effect).toContain("adapter.find('showcase_project'");
+    expect(effect).toContain("adapter.find('showcase_invoice'");
+    expect(effect).toContain('setRelated');
+  });
+
+  /** 640 projects and 640 invoices on one account — more than the page's cap. */
+  function bigAccount() {
+    const projects: Row[] = [];
+    const invoices: Row[] = [];
+    for (let i = 0; i < 640; i++) {
+      projects.push({ id: `p${i}`, account: 'acc_1' });
+      // 128 of the 640 invoices are open (every 5th).
+      invoices.push({ id: `i${i}`, account: 'acc_1', status: i % 5 === 0 ? 'open' : 'paid' });
+    }
+    // A second account that must never be counted into the first one's KPIs.
+    projects.push({ id: 'p_other', account: 'acc_2' });
+    invoices.push({ id: 'i_other', account: 'acc_2', status: 'open' });
+    return { showcase_project: projects, showcase_invoice: invoices };
+  }
+
+  it('applies a real cap — the $top the author wrote reaches the adapter', async () => {
+    const adapter = makeAdapterDouble(bigAccount());
+    await runRollup(effect, adapter, 'acc_1');
+
+    expect(adapter.seen).toHaveLength(2);
+    for (const call of adapter.seen) {
+      // The defect: an unprefixed key is silently ignored, so the read runs
+      // unbounded. Every key the page sends must be one the adapter reads.
+      expect(Object.keys(call.params).every((k) => k.startsWith('$'))).toBe(true);
+      expect(call.params.$top).toBe(500);
+    }
+  });
+
+  it('reports the account\'s true totals, not the page length under the cap', async () => {
+    const adapter = makeAdapterDouble(bigAccount());
+    const rollup = await runRollup(effect, adapter, 'acc_1');
+
+    // 640, not 500 (the cap) and not 0 (the `.records` read) and not 641
+    // (the other account's row leaking past `$filter`).
+    expect(rollup.projects).toBe(640);
+    expect(rollup.invoices).toBe(640);
+    // Open AR is a per-row verdict over the fetched window, so it IS bounded by
+    // the cap — 100 of the first 500, not the 128 that exist. The page must say
+    // so rather than presenting it as a total.
+    expect(rollup.openInvoices).toBe(100);
+    expect(rollup.capped).toBe(true);
+  });
+
+  it('is exact, and not capped, for an account inside the window', async () => {
+    const store = {
+      showcase_project: [
+        { id: 'p1', account: 'acc_1' },
+        { id: 'p2', account: 'acc_1' },
+        { id: 'p3', account: 'acc_2' },
+      ],
+      showcase_invoice: [
+        { id: 'i1', account: 'acc_1', status: 'open' },
+        { id: 'i2', account: 'acc_1', status: 'paid' },
+        { id: 'i3', account: 'acc_1', status: 'void' },
+      ],
+    };
+    const rollup = await runRollup(effect, makeAdapterDouble(store), 'acc_1');
+    expect(rollup).toMatchObject({ projects: 2, invoices: 3, openInvoices: 1, capped: false });
+  });
+
+  it('zeroes the strip when no account is selected', async () => {
+    const rollup = await runRollup(effect, makeAdapterDouble({}), null);
+    expect(rollup).toMatchObject({ projects: 0, invoices: 0, openInvoices: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The same two contracts, swept across every react page this app ships
+// ---------------------------------------------------------------------------
+
+const DECLARED_QUERY_PARAM_PREFIX = '$';
+
+/** Top-level keys of an object-literal source slice. */
+function topLevelKeys(objSrc: string): string[] {
+  const keys: string[] = [];
+  let depth = 0;
+  let i = 0;
+  let expectKey = true;
+  while (i < objSrc.length) {
+    const c = objSrc[i];
+    if (c === '{' || c === '[' || c === '(') { depth++; i++; continue; }
+    if (c === '}' || c === ']' || c === ')') { depth--; i++; continue; }
+    if (depth === 1) {
+      if (c === ',') { expectKey = true; i++; continue; }
+      if (c === ':') { expectKey = false; i++; continue; }
+      if (expectKey) {
+        const m = /^(['"]?)([A-Za-z_$][\w$]*)\1\s*:/.exec(objSrc.slice(i));
+        if (m) { keys.push(m[2]); i += m[0].length; expectKey = false; continue; }
+      }
+    }
+    i++;
+  }
+  return keys;
+}
+
+interface QueryFinding { key: string; snippet: string }
+
+/** Every unprefixed key handed to an `adapter.find`/`findOne` in one source. */
+function unprefixedQueryKeys(source: string): QueryFinding[] {
+  const found: QueryFinding[] = [];
+  const call = /\b(?:adapter|dataSource)\s*\.\s*(?:find|findOne)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = call.exec(source))) {
+    // Walk to the params object literal, staying inside this call's parens.
+    let i = m.index + m[0].length;
+    let depth = 1;
+    let objStart = -1;
+    while (i < source.length && depth > 0) {
+      const c = source[i];
+      if (c === '(') depth++;
+      else if (c === ')') { depth--; if (depth === 0) break; }
+      else if (c === '{' && depth === 1) { objStart = i; break; }
+      i++;
+    }
+    if (objStart < 0) continue;
+    let braces = 0;
+    let objEnd = -1;
+    for (let j = objStart; j < source.length; j++) {
+      if (source[j] === '{') braces++;
+      else if (source[j] === '}') { braces--; if (braces === 0) { objEnd = j; break; } }
+    }
+    if (objEnd < 0) continue;
+    const obj = source.slice(objStart, objEnd + 1);
+    for (const k of topLevelKeys(obj)) {
+      if (!k.startsWith(DECLARED_QUERY_PARAM_PREFIX)) {
+        found.push({ key: k, snippet: obj.replace(/\s+/g, ' ').slice(0, 100) });
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * A `.records` read with no `.data` beside it, off a find() result.
+ *
+ * Comment lines are skipped: a page that explains the trap in prose (and
+ * `crm-workbench` does, right above the call it once got wrong) is documenting
+ * the contract, not violating it. The read itself is what this looks for.
+ */
+function recordsOnlyReads(source: string): string[] {
+  const out: string[] = [];
+  for (const line of source.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue;
+    if (!trimmed.includes('.records')) continue;
+    if (trimmed.includes('.data')) continue;
+    out.push(trimmed);
+  }
+  return out;
+}
+
+const REACT_PAGES = Object.values(pages as Record<string, unknown>)
+  .filter((p): p is { name: string; kind?: string; source?: string } =>
+    !!p && typeof p === 'object' && (p as { kind?: string }).kind === 'react')
+  .filter((p) => typeof p.source === 'string');
+
+describe('every kind:"react" page in this app honours the useAdapter contracts', () => {
+  it('found the react pages to sweep (census control)', () => {
+    // A sweep over an empty list is vacuously green — this is what stops that.
+    expect(REACT_PAGES.length).toBeGreaterThanOrEqual(2);
+    expect(REACT_PAGES.map((p) => p.name)).toContain('showcase_renewals_pipeline');
+  });
+
+  it('the scanners fire on a known-bad source (positive control)', () => {
+    const bad = `
+      const a = await adapter.find('showcase_project', { $filter: ['account', '=', sel], top: 500 });
+      const b = await adapter.find('showcase_invoice', { limit: 200 });
+      // a comment mentioning .records must NOT count as a read
+      const rows = (a && a.records) || [];
+    `;
+    expect(unprefixedQueryKeys(bad).map((f) => f.key)).toEqual(['top', 'limit']);
+    expect(recordsOnlyReads(bad)).toEqual(['const rows = (a && a.records) || [];']);
+  });
+
+  it.each(REACT_PAGES.map((p) => [p.name, p.source as string] as const))(
+    '%s passes only $-prefixed query options',
+    (_name, source) => {
+      expect(unprefixedQueryKeys(source)).toEqual([]);
+    },
+  );
+
+  it.each(REACT_PAGES.map((p) => [p.name, p.source as string] as const))(
+    '%s reads rows off QueryResult.data',
+    (_name, source) => {
+      expect(recordsOnlyReads(source)).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Fixes #10288

## What the card asked for, and what turned out to be true

The card is right that `top` is not a query option: `QueryParams` (objectui
`packages/types/src/data.ts`) declares only `$`-prefixed keys, and
`ObjectStackAdapter.convertQueryParams` (objectui
`packages/data-objectstack/src/index.ts`) builds its outgoing options by copying exactly
those, so a bare `top:` reaches no branch and is dropped with no error.

Its **consequence** is the inverse of the filed one, and the correction is what shaped
this PR. The card says the queries "return the backend's default page size instead of up
to 500 rows", producing a silently capped KPI. There is no default page size. From this
repo's own sources:

- `packages/client/src/index.ts` — "The GET list route has no default page size, so an
  absent `top` returns the ENTIRE match set: the caller who asked for no records got
  every record, under a 200 with no warning." Pinned in `packages/client/src/client.test.ts`
  (#6485).
- `packages/objectql/src/protocol-unknown-query-param.test.ts` — `baseline — no params
  returns every row`, over a real `ObjectQL` engine and a real protocol: 10 rows seeded,
  `total: 10` with no params. Re-run on this branch, green.

So the dropped key did not truncate the read — it removed the cap. The page was fetching
every related row for the selected account, unbounded.

The KPI strip was wrong for a **second, separate reason** the card does not mention, and
it is the one a reader sees: the effect read its rows off `pr.records`. `find()` resolves
to a normalized `QueryResult` — `data`, `total`, `page`, `pageSize`, `hasMore`, never the
REST envelope's `records` — so `pr.records` was `undefined` on every call and the strip
read **0 / 0 / 0**, not a capped number. That defect was already found and fixed once on
the sibling page: `crm-workbench.page.ts` carries the diagnosis in a comment ("Reading
.records here always missed, so the KPI cards silently stuck at 0 even though the
ListView beside them showed the same rows") and was still live here.

## The harm, reproduced

The real page source, lifted out of the page file and executed against a
contract-faithful adapter double, over an account holding 640 projects and 640 invoices
(128 of them open):

```
── BEFORE (origin/main) ──
  find(showcase_project) params = {"$filter":["account","=","acc_1"],"top":500}
     -> $top seen by the adapter: UNDEFINED (no cap applied — the whole match set comes back)
  find(showcase_invoice) params = {"$filter":["account","=","acc_1"],"top":500}
     -> $top seen by the adapter: UNDEFINED (no cap applied — the whole match set comes back)
  KPI strip: {"projects":0,"invoices":0,"openInvoices":0}

── AFTER (this branch) ──
  find(showcase_project) params = {"$filter":["account","=","acc_1"],"$top":500}
     -> $top seen by the adapter: 500
  find(showcase_invoice) params = {"$filter":["account","=","acc_1"],"$top":500}
     -> $top seen by the adapter: 500
  KPI strip: {"projects":640,"invoices":640,"openInvoices":100,"capped":true}
```

## Why this is not a two-character edit

`$top: 500` alone would have **created** the defect the card describes. With a cap
applied, `data.length` is a page length, so the "Projects" and "Invoices" KPIs would have
silently reported 500 for every account above the cap — a capped count reading as a real
number, which is the card's own words for the harm. Both pages therefore count the
envelope's `total`, which with a limit present is the server's real count over the same
`$filter` (`ObjectStackProtocolImplementation.findData` runs `engine.count` on that
path).

"Open AR" is a per-row verdict and genuinely cannot be exact over a capped window — it is
the one number the cap really does bound. It renders as `100+` when the window was
truncated rather than passing for a total.

## Changed

- `examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts` — `$top` on both calls,
  rows off `.data`, counts off `total`, `capped` surfaced in the Open AR stat, and a
  numbered note on the effect stating both contracts (this page is the copy-paste
  surface, so the comment is load-bearing).
- `examples/app-showcase/src/ui/pages/crm-workbench.page.ts` — same class, found by the
  sweep: `{ limit: 200 }` → `{ $top: 200 }`, headline count off `total`.
- `examples/app-showcase/test/react-page-adapter-query-contract.test.ts` — new.

## Sweep census

`adapter.find` / `dataSource.find` call sites, params-object keys extracted by brace
matching, classified by whether the file's adapter comes from `useAdapter()` (the
objectui `DataAdapter`) or from something else.

**Positive control**: the scanner was run first against `origin/main` and reported the
known-present `renewals-pipeline.page.ts:67` and `:68` `top: 500` before it was used to
claim anything absent.

In this repo, **3 unprefixed-key sites in 2 files**, both under `examples/**`, both fixed
here:

| file | key |
|---|---|
| `examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts:67` | `top` |
| `examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts:68` | `top` |
| `examples/app-showcase/src/ui/pages/crm-workbench.page.ts:39` | `limit` |

21 further key hits across 5 files are a **different** `adapter`: `plugin-auth`'s
better-auth adapter (`findOne({ model, where })`, 4 files) and a `PostgresAdapter` in
`content/blog/protocol-first-development.mdx`. Neither is the objectui `DataAdapter`;
`model`/`where`/`field` are correct there.

`.records` reads off a `find()` result, same sweep: 4 sites — the two repaired here, one
benign (`crm-workbench` already read `.data` first), and `content/docs/ui/react-pages.mdx:147`,
which is reported separately (below).

Sweeping objectui at `c40f3b8` found **4 more unprefixed-key sites** plus two
`records`-only reads. Outside this repo's file surface — reported, not touched.

## The gate question: not built here, and the measurement

**Ruling: no new `os validate` rule or `check:*` gate in this repo. A scoped regression
pin instead.**

What a gate would have to cover, measured rather than guessed:

- **Exposure in this repo: 3 sites, 2 files, both in `examples/**`, 0 after this PR.**
  There are exactly 3 `kind:'react'` pages in `examples/**` and one `useAdapter` sample
  in `content/docs/**`. That is the entire population an objectstack-side checker could
  ever read, because a react page's `source` is a string — ESLint cannot see into it, and
  `tsc` cannot either.
- **Recurrence is real, and it is not in this repo.** The class has five measured
  instances by different authors: `object-timeline` (objectui#4009 / objectstack#7137),
  `object-kanban` (objectui#4025), `crm-workbench`'s `.records` (repaired in place,
  comment still there), `renewals-pipeline` (this card), and the four live objectui sites
  the sweep just found. Four of the five live in objectui.
- **objectui already gates the sibling half.** `eslint-rules/no-query-params-under-options.js`
  bans a `$`-prefixed key nested under `options`, and its header makes the case for
  mechanising this family: the mistake type-checks, it publishes, and "a review catches it
  once and then misses the next one." It does not look at a bare top-level key — that is
  the half with the live sites.
- **The decisive cost.** `QueryParams` is *objectui's* contract. A checker in objectstack
  would have to hard-code another repo's key list and become a second source of truth for
  it — the exact second-de-facto-contract shape Prime Directive #12 warns about, on a
  contract this repo does not own and cannot keep in step. The rule belongs beside the
  type it enforces, next to the rule that already gates the other half. Reported as
  #10470 with the census and a suggested rule shape.

What is built instead, at ~50 lines and no new infrastructure:
`test/react-page-adapter-query-contract.test.ts` sweeps **every** `kind:'react'` page this
app ships for both contracts. It needs no key table — the assertion is the prefix rule
itself ("every key the page sends starts with `$`") plus "rows come off `.data`" — so it
duplicates no contract and closes the whole class for this repo's file surface. It carries
three controls: an extraction control (the lifted effect really contains both `find`
calls), a census control (the page list is non-empty and contains the renewals page), and
a positive control (both scanners fire on a known-bad synthetic source, and the
comment-skip does not silence a real read).

## Reported separately, out of scope here

- **#10469** — `content/docs/ui/react-pages.mdx`: the live-data sample reads
  `result.records` (always `undefined`, so the documented sample renders an empty list),
  and its Callout claims a dropped `top:` yields "the default page size". Left alone here:
  `content/docs/**` pulls in a different gate family than this diff
  (`check:doc-anchors`, `check:docs-audit-scope`, `check:docs-redirects`,
  `check:published-readme-links`, `check:role-word`, plus the `{/* os:check */}`
  convention), and the Callout needs a wording decision.
- **#10470** — `[objectui]` the four live sites and the ESLint-rule extension.

## Ablations

The fix was committed first, then broken deliberately, each leg confirmed on disk by
counting the removed anchor and the injected text (a first attempt with `perl -0pi`
matched nothing and produced `$toptop:` — caught by that count, not by an exit code).

- **Leg A**, `$top: 500` → `top: 500` (anchor 2 → 0, injection 0 → 2): **3 tests red** —
  `expected false to be true` on the all-keys-`$`-prefixed assertion, `expected 128 to be
  100` on Open AR (the *unbounded* read returning all 128 open invoices instead of the
  honest 100 inside the window), and the page sweep reporting `{key: 'top', snippet: "{
  $filter: […], top: 500 }"}`. Note the direction: the ablation shows a **missing cap**,
  not a truncation.
- **Leg B**, `(res && res.data)` → `(res && res.records)` (anchor 1 → 0, injection 0 → 1):
  **3 tests red** — `expected +0 to be 100`, the in-window case losing `capped: false`,
  and the `reads rows off QueryResult.data` sweep firing.
- Restored: `git diff HEAD` empty, tree byte-identical to the fix commit.

## Verification

Gates re-derived from the real diff with `node scripts/pm/dispatch-gates.mjs` (no paths
passed — it takes its own change set from the merge base), run at `fde5f1e`:

| gate | verdict line |
|---|---|
| `check:nul-bytes` | `OK (scanned 6140 text file(s) … no raw ASCII control bytes)` |
| `check:changeset-gate-self-tests` | 118 + 212 + 116 self-test assertions pass |
| `check:objectui-changeset` | `objectui-range --self-test: all checks passed` |
| `check-adr-0087-registration.mjs` | `this PR adds no declared-breaking changeset` |
| `check-changeset-no-major.mjs` | `This diff introduces no 'major' bump` |
| `check-empty-changeset.mjs` | `No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added)` |
| `check:cross-package-test-inputs` | `OK: 12 package(s) read outside themselves, all declared` |
| `check:engine-double-contract` | `OK — 340 pinned, 133 in the DEBT ledger, 2 exempt` |
| `check:where-matcher` | `266 matcher(s) discovered … none new` |
| `check:query-options-erasure` | `ratchet holds: 67 unswept non-test site(s) … none new`; test surface `240 site(s) in 47 file(s) — at the ceiling` |
| `check:type-check-coverage` | `OK — 64/77 workspace packages type-checked` |
| `check:type-check-debt` | `--re-measure: OK — 33 ledger entr(ies) re-measured in 352.5s, 1924 raw tsc error(s) total, none above its recorded number` — full closure built first, exactly as `lint.yml` does |

Package-level, at the same commit:

- `pnpm --filter @objectstack/example-showcase test` — `Test Files 23 passed (23)`,
  `Tests 361 passed (361)`.
- `pnpm --filter @objectstack/example-showcase typecheck` — clean (this package's
  `tsconfig.json` includes `test/**/*`, so the new test file is in the program).
- `pnpm --filter @objectstack/example-showcase validate` — exit 0, no new findings,
  confirming the card's point that `os validate` cannot see this class.

## Changeset

`examples/app-showcase` is `private: true`, but this repo's `.changeset/config.json` sets
`privatePackages: { version: true, tag: false }`, so it is versioned and carries its own
`CHANGELOG.md` — and prior showcase-only PRs wrote real changesets for it. A changeset,
not the `skip-changeset` label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_