### PR TITLE
docs: document POST /organization/add-member — the platform-admin-only path to attach an existing user

### DIFF
--- a/content/docs/deployment/tenancy-modes.mdx
+++ b/content/docs/deployment/tenancy-modes.mdx
@@ -167,6 +167,18 @@ wall and did not get one, and the safe reading of that is "I don't know which or
 this user belongs to", not "everyone belongs to the only org I can see". So
 `defaultOrgId()` returns `null` there too.
 
+<Callout type="info" title="`add-member` is a route — here it is">
+The `add-member` named above is `POST /api/v1/auth/organization/add-member`, an
+ObjectStack mount wrapping better-auth's server-only `addMember`. Under a walled
+posture it is the **only** way to attach an *existing* account to an
+organization: the reconciler declines to guess a target org, generic `sys_member`
+writes are suppressed under the ADR-0010 lock, and invitations need an email
+round-trip that phone-number-only accounts cannot complete. Its admit set is
+**platform admin only** — an organization owner or administrator is refused
+`403 PERMISSION_DENIED`. See [Attaching an existing user to an
+organization](/docs/permissions/authentication#attaching-an-existing-user-to-an-organization).
+</Callout>
+
 ### Membership policy
 
 | Policy | Behavior |

--- a/content/docs/permissions/authentication.mdx
+++ b/content/docs/permissions/authentication.mdx
@@ -756,6 +756,82 @@ more authority than the issuer has.** An issuer below `admin` grade may invite
 as plain `member` only, and no invitation may confer a tier above the issuer's
 own.
 
+#### Attaching an existing user to an organization
+
+`POST /api/v1/auth/organization/add-member` attaches an **existing** account to
+an organization directly — no invitation, no email round-trip.
+
+```http
+POST /api/v1/auth/organization/add-member
+{
+  "userId": "usr_01HZX…",
+  "organizationId": "org_beta"
+}
+```
+
+The body also carries the membership tier, under better-auth's own column name
+for it — the same field the invitation example above sends (see [Membership
+tiers are a closed list](#membership-tiers-are-a-closed-list)). It accepts a
+single tier name or an array of them. `snake_case` spellings are accepted
+alongside camelCase for the identifiers (`user_id`, `organization_id`,
+`team_id`), so a value pasted straight out of the record grid works.
+
+`organizationId` may be omitted, in which case the membership lands in the
+**calling admin's active organization**. `teamId` is optional and has no such
+fallback: omit it and the member simply joins no team.
+
+<Callout type="warn" title="This is an ObjectStack mount, not a better-auth route">
+better-auth declares `addMember` as a **server-only** API with no HTTP path of
+its own — measured on 1.7.1, where `addMember` builds its endpoint with no path
+argument while every sibling in the same module (`/organization/remove-member`,
+`/organization/list-members`, `/organization/leave`, …) passes one. So the
+vendor's documentation does not list this URL, and an audit that enumerates
+better-auth's mounted surface will not find it there either. ObjectStack mounts it ahead of the
+catch-all and wraps the vendor's server-only endpoint; the vendor's own checks
+(already-a-member, membership limit, team resolution, hooks) are not
+reimplemented.
+</Callout>
+
+**The admit set is platform admin only.** An organization owner or organization
+administrator is refused `403 PERMISSION_DENIED`, and that is deliberate under
+ADR-0068: standing inside an organization is not standing on the platform.
+Attaching someone to an organization without their consent is a
+platform-operator action, and the vendor endpoint performs no authorization of
+its own precisely because it was built to be called only from trusted server
+code.
+
+Refusals, with both halves of the ADR-0112 envelope:
+
+| Status | `code` | When |
+|---|---|---|
+| `401` | `UNAUTHENTICATED` | No session. Checked before the body, so an anonymous caller with a malformed body still gets `401`. |
+| `403` | `PERMISSION_DENIED` | Signed in, but not a platform admin — including organization owners and administrators. |
+| `501` | `NOT_IMPLEMENTED` | The organization plugin is off (`auth.plugins.organization`). Checked before the body: a payload nit is not worth reporting for a capability the deployment does not have. |
+| `400` | `INVALID_REQUEST` | Missing `userId`, or a missing/empty membership tier. |
+| `400` | `USER_NOT_FOUND` | No account with that `userId`. |
+| `400` | `USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION` | The account already holds a membership in that organization. |
+| `400` | `NO_ACTIVE_ORGANIZATION` | `organizationId` was omitted and the calling admin has no active organization to fall back to. |
+| `403` | `ORGANIZATION_MEMBERSHIP_LIMIT_REACHED` | The organization is at its membership limit (better-auth's `membershipLimit`, default 100). |
+
+The last five are the vendor's own verdicts, forwarded verbatim rather than
+re-adjudicated.
+
+<Callout type="info" title="On a walled deployment this is the only way to attach an existing user">
+Under a walled tenancy posture the other paths do not reach:
+
+- **Create User** binds a new account to an organization only when there is an
+  unambiguous one to bind to. Under the organization wall there is not, by
+  design, so no membership row is written — see [Membership: how new users join
+  an organization](/docs/deployment/tenancy-modes#membership-how-new-users-join-an-organization).
+- **Hand-writing the membership row** is not available: `sys_member` is managed
+  by better-auth and generic CRUD on it is suppressed under the ADR-0010 lock.
+- **Invitations** need an email round-trip, which phone-number-only accounts
+  cannot complete.
+
+That leaves this route. An administrator who does not know it exists reasonably
+concludes the platform cannot attach an existing user to an organization at all.
+</Callout>
+
 ### Admin User Management
 
 With `plugins: { admin: true }` (forced on when SCIM is enabled), platform
@@ -966,6 +1042,10 @@ All endpoints are available under `/api/v1/auth/*`:
 - `POST /api/v1/auth/admin/set-user-password` - Set/reset a user's password (also provisions a credential for SSO-onboarded users)
 - `POST /api/v1/auth/admin/import-users` - Bulk import users (CSV/JSON/XLSX; `auto` (default, per-row invite-or-temporary) / `invite` / `temporary` / `none` password policy; ≤500 rows, dry-run supported)
 - `POST /api/v1/auth/admin/unlock-user` - Clear a brute-force lockout early
+
+#### Organization Membership (requires `plugins.organization`; platform-admin gated)
+
+- `POST /api/v1/auth/organization/add-member` - Attach an **existing** account to an organization with no invitation ([details](#attaching-an-existing-user-to-an-organization)). An ObjectStack mount, not a better-auth route, and the only path that reaches this on a walled deployment.
 
 For complete API documentation, see the [Better-Auth API Reference](https://www.better-auth.com/docs).
 


### PR DESCRIPTION
Fixes: #10050

Documents `POST /api/v1/auth/organization/add-member`, mounted by #9941 / PR #10049 and never written up. Docs-only — two files under `content/docs`, no source changes.

## What the route actually does — verified, not inferred

Every claim below was read off the implementation (`packages/plugins/plugin-auth/src/organization-add-member.ts`, the mount at `auth-plugin.ts:2122`), its test (`organization-add-member.test.ts`), or the installed vendor source. The vendor legs were measured on **better-auth 1.7.1**, `dist/plugins/organization/routes/crud-members.mjs`.

- **It is an ObjectStack mount, not a better-auth route.** `addMember` is built with `createAuthEndpoint({ method: "POST", … })` — **no path argument** — while every sibling in the same module (`/organization/remove-member`, `/organization/list-members`, `/organization/leave`, …) passes one. So the catch-all never mounted it, the vendor's docs do not list it, and enumerating `BETTER_AUTH_MOUNTED_SURFACE` does not reach it. `auth-plugin.ts` mounts the URL ahead of the catch-all.
- **Admit set is platform admin only.** The shared ADR-0068 gate runs before the handler. Pinned in the test on the *real* wiring: anonymous → `401 UNAUTHENTICATED`, plain member → `403`, and an **organization owner** → `403 PERMISSION_DENIED`. The org-owner refusal is the surprising one and is now stated as deliberate.
- **Ordering** is identity → capability (`501` when the organization plugin is off) → body (`400`) → the vendor's verdicts. Both the anonymous-before-body and capability-before-body legs are pinned by tests.
- **Refusals** are documented with `code` **and** `status` per ADR-0112. The vendor's four are forwarded verbatim by `mapAuthApiError`, which preserves the vendor's status — so `USER_NOT_FOUND` / `USER_IS_ALREADY_A_MEMBER_OF_THIS_ORGANIZATION` / `NO_ACTIVE_ORGANIZATION` are `400` (`APIError.from("BAD_REQUEST", …)`) and `ORGANIZATION_MEMBERSHIP_LIMIT_REACHED` is `403` (`APIError.from("FORBIDDEN", …)`, default limit 100). The membership-limit row is read from vendor source, not from a test — no test exercises it.
- **`organizationId` omitted** falls back to the caller's active organization: `const orgId = ctx.body.organizationId || session?.session.activeOrganizationId`. Pinned by the `NO_ACTIVE_ORGANIZATION` test.
- ⚠️ **`teamId` does NOT fall back to an active team.** `const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0` — omitted means no team, full stop. Three source comments claim otherwise; the docs here state the asymmetry correctly and the comments are filed as **#10532**.

## Where it went, and why there

- `content/docs/permissions/authentication.mdx` — a new `#### Attaching an existing user to an organization` under the existing `### Organizations (Multi-Tenant)` section (beside the invitation flow it is the alternative to), plus a `#### Organization Membership` entry in the `## API Reference` endpoint list where the sibling admin routes are already listed.
- `content/docs/deployment/tenancy-modes.mdx` — a callout in `## Membership: how new users join an organization`. That page already named `add-member` **three times** without ever saying what URL it is, which is a good part of how the route stayed invisible while looking discussed.

Location was established from the tree: `authentication.mdx` is the only non-release page that documents `/api/v1/auth/admin/*` routes, and `tenancy-modes.mdx` is the only one that discusses attaching users under the org wall.

## ⚠️ One thing this PR could not do

The route's body carries better-auth's `role` field, and it has **no** snake_case alias — the wire name is `role` and nothing else. `check:role-word` is a per-file exact ratchet over `content/docs` with no exemption mechanism, so **no file in the corpus can gain that word**, and expanding the baseline is marked ⛔ MAINTAINER-ONLY by the checker itself.

So the field is documented indirectly — "the body also carries the membership tier, under better-auth's own column name for it" — linking to `#membership-tiers-are-a-closed-list`, whose invitation example already spends a baselined occurrence and shows the literal key. `authentication.mdx` stays at exactly its baselined 4.

Not wrong, but a reference page describing a **required** parameter without naming it is a real cost. Filed as **#10533** with three options and a recommendation; a maintainer's call.

## The card's other two asks

**Ledger.** The route **is** ledgered — `auth-route-ledger.ts:189`, `source: 'objectstack'`, `disposition: 'server-only'`, `requires: 'organization'`. It is **not** client-bound (no `client` field), correctly: no SDK method builds this URL; the `sys_member` `add_member` toolbar action posts it directly. So the `sdk` doc-nomination bridge cannot nominate docs for it — and it would not have anyway: `--bridge-coverage` reports **55 of 55** client-bound auth rows unreachable, because the bridge finds registrars by filename (`REGISTRAR_FILE_RE`) and `auth-plugin.ts` matches neither alternative.

**Census.** It was not the only one: **6 of 17** ObjectStack raw auth mounts had no wire path anywhere in the hand-written corpus (this PR takes it to 5), and **9 of 17** appear in neither half of the auth ledger. Both legs carry positive controls. Full census, method, and the "why nothing caught it" analysis: **#10534**.

⛔ Deliberately untouched: `scripts/docs-audit/affected-docs.mjs`, `scripts/docs-audit/README.md`, `.github/workflows/docs-drift-check.yml` — open PR #10501 owns those. Remedies implied by the bridge finding are written up in #10534, not ridden here.

## Gates

All run against the tree at **`379485124b`** (working tree clean — `git status --porcelain` empty, so the gated tree is byte-identical to HEAD). Family derived by `node scripts/pm/dispatch-gates.mjs` with no path arguments: 11 families matched.

| Gate | Verdict line it printed |
|---|---|
| `check:doc-anchors` | `✅ check-doc-anchors: 270 internal #fragment link(s) across 406 source file(s) all resolve to a real heading` |
| `check:docs-audit-scope` | `✓ docs-accuracy-audit scope is in sync with content/docs/: 187 hand-written doc(s).` |
| `check:docs-redirects` | `check-docs-redirects: OK (apps/docs/redirects.mjs: 92 entries …)` |
| `check:published-readme-links` | `✓ check:published-readme-links — 152 outbound link(s) across 60 published markdown file(s)` |
| `check:role-word` | `check-role-word: OK, no new occurrences of the reserved word.` |
| `check:cross-package-test-inputs` | `OK: 12 package(s) read outside themselves, all declared` |

The four `spec-liveness-check.yml` families, same tree:

| Gate | Verdict line it printed |
|---|---|
| `spec check:empty-state` | `✓ all classified (1 closed, 2 open, 4 output, 9 scope)` |
| `spec check:liveness` | `✓ packages/spec/liveness/state-counts.md is current — the same 30 row(s)` |
| `spec check:strictness-ledger` | `✓ strictness ledger: 61 file(s) across 5 triaged director(ies)` |
| `spec check:variant-docs` | `✓ variant/doc gate: 18 discriminated union(s) — 8 governed, 10 exempt` |

Both batches ran through `scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0` each). CI runs the full farm regardless.

## Changeset

None. `content/` is not in `pnpm-workspace.yaml`'s package globs, so this diff has no publish surface, and `check-empty-changeset.mjs` rejects an empty-frontmatter changeset in this repo. Declared with the `skip-changeset` label instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_