### PR TITLE
fix(auth): teamId on organization/add-member has no active-team fallback

### DIFF
--- a/.changeset/add-member-team-id-no-active-team-fallback.md
+++ b/.changeset/add-member-team-id-no-active-team-fallback.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/platform-objects": patch
+"@objectstack/plugin-auth": patch
+---
+
+Correct a false vendor claim in the `organization/add-member` source comments:
+`teamId` has **no** active-team fallback (#10532). Two comments — the
+`sys_member` `add_member` action metadata (the origin) and the
+`organization-add-member.ts` module header that cited it as authority — stated
+that "organizationId/teamId default to the caller's active org/team when
+omitted". Measured on the installed better-auth 1.7.1
+(`dist/plugins/organization/routes/crud-members.mjs`, inside `addMember`), only
+the organization half is true:
+
+```js
+const orgId = ctx.body.organizationId || session?.session.activeOrganizationId;
+const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0;
+```
+
+`activeOrganizationId` is read 8 times in that module; `activeTeamId`, never. An
+omitted `teamId` therefore stays `undefined` and the member joins no team — every
+`if (teamId)` branch (team lookup, `TEAM_NOT_FOUND`, per-team limit) is skipped.
+
+No runtime behaviour changes, and no deployment was ever misled: the `add_member`
+action's `params` list carries no `teamId`, so the toolbar never sent one and the
+claim was never exercised. What the comment did mislead was the next reader of
+the mount, which cited it as the justification for forwarding request headers —
+forwarding buys the organization default only. Forwarding `teamId` itself remains
+correct: pass it and it works.
+
+The asymmetry the docs now publish is held by a new pin,
+`organization-add-member-team-fallback.test.ts`, which reads the fact out of the
+installed vendor artifact (not out of our own comments) so that a future
+better-auth bump *adding* an active-team fallback reddens instead of silently
+putting the docs out of date.

--- a/packages/platform-objects/src/identity/sys-member.object.ts
+++ b/packages/platform-objects/src/identity/sys-member.object.ts
@@ -43,8 +43,18 @@ export const SysMember = ObjectSchema.create({
       // Admin-only: directly attach an existing user to the active org,
       // bypassing the invite-accept flow. Better-auth:
       // `organization/add-member { userId, role, organizationId?, teamId? }`.
-      // organizationId/teamId default to the caller's active org/team when
-      // omitted, so we leave them as optional params.
+      // The two optional fields are NOT symmetric. `organizationId` defaults
+      // to the caller's active organization when omitted; `teamId` has no such
+      // fallback — omit it and the member simply joins no team. Measured on the
+      // installed better-auth 1.7.1
+      // (`dist/plugins/organization/routes/crud-members.mjs`, `addMember`):
+      // `ctx.body.organizationId || session?.session.activeOrganizationId`
+      // against `"teamId" in ctx.body ? ctx.body.teamId : void 0`, and no
+      // `activeTeamId` read anywhere in that file. So `organizationId` is
+      // carried as an optional param below and `teamId` is not a param at all
+      // — this action never sends it, so it never exercises the team half.
+      // Pinned against a vendor bump that ADDS the fallback by
+      // plugin-auth's `organization-add-member-team-fallback.test.ts`.
       name: 'add_member',
       label: 'Add Member',
       icon: 'user-plus',

--- a/packages/plugins/plugin-auth/src/organization-add-member-team-fallback.test.ts
+++ b/packages/plugins/plugin-auth/src/organization-add-member-team-fallback.test.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#10532] `organization/add-member` — `organizationId` falls back to the
+ * caller's active organization; `teamId` does NOT.
+ *
+ * ## What this pin watches, and why it reads the VENDOR
+ *
+ * Three of our source comments used to assert the symmetric version of that
+ * sentence ("organizationId/teamId default to the caller's active org/team when
+ * omitted"). better-auth 1.7.1 implements only the org half. The comments are
+ * corrected, and the docs written for #10050 now state the asymmetry to users
+ * — so the standing risk is no longer a wrong comment but a **vendor bump that
+ * ADDS an active-team fallback**, which would make our (now correct) docs wrong
+ * with nothing watching.
+ *
+ * Therefore this pin asserts a fact about the INSTALLED vendor artifact, read
+ * out of `node_modules` at test time. It deliberately does NOT assert anything
+ * about our own comment text or our own constants: an assertion whose both
+ * sides derive from files in this repo proves only that we wrote what we wrote,
+ * and could not fail for the reason it exists.
+ *
+ * ## The zero-hit discipline
+ *
+ * "There is no active-team fallback" is a NEGATIVE finding, and a negative
+ * finding from a detector nobody proved is worthless — a typo'd matcher reports
+ * the same clean absence as a real one. So every negative leg below is paired
+ * with a POSITIVE control that runs the SAME matcher over a neighbouring fact
+ * known to be present:
+ *
+ *   - `SESSION_ACTIVE_FALLBACK` must MATCH the `orgId` binding (which really
+ *     does fall back) before its non-match on the `teamId` binding counts;
+ *   - `activeOrganizationId` must occur in the file before the zero count for
+ *     `activeTeam*` counts.
+ *
+ * Measured 2026-08-21 on the installed better-auth 1.7.1,
+ * `dist/plugins/organization/routes/crud-members.mjs`, inside `addMember`:
+ *
+ *     const orgId = ctx.body.organizationId || session?.session.activeOrganizationId;
+ *     const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0;
+ *
+ * `activeOrganizationId` occurs 8 times in that file; `activeTeamId`, 0.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+/**
+ * Locate this package by walking up from the CWD — the idiom
+ * `member-role-canonical.test.ts` / `rate-limit-storage-isolation.test.ts`
+ * established here and state the reason for: plugin-auth is CJS-typed (no
+ * `"type": "module"`, it publishes `dist/index.js` as CommonJS), so under
+ * `module: NodeNext` `import.meta` is a TS1470 in this package however well it
+ * runs under vitest.
+ */
+function findUp(predicate: (dir: string) => boolean, what: string): string {
+  let dir = process.cwd();
+  for (;;) {
+    if (predicate(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) throw new Error(`could not locate ${what}`);
+    dir = parent;
+  }
+}
+
+const PKG = findUp((dir) => {
+  const manifest = join(dir, 'package.json');
+  if (!existsSync(manifest)) return false;
+  const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };
+  return name === '@objectstack/plugin-auth';
+}, 'the @objectstack/plugin-auth package root');
+
+// Resolved from THIS package, so the file read is the better-auth this package
+// is pinned to — not whatever a hoist happens to put at the repo root. The read
+// goes through `node_modules` at test time; there is no checked-in copy of the
+// vendor text for it to fall back to, which is what the ablation in the PR body
+// demonstrates (mutate the file under `node_modules` and this suite reddens).
+const require_ = createRequire(join(PKG, 'probe.js'));
+/** `…/better-auth/dist/index.mjs` → `…/better-auth/dist`. */
+const VENDOR_DIST = dirname(require_.resolve('better-auth'));
+const CRUD_MEMBERS = join(VENDOR_DIST, 'plugins', 'organization', 'routes', 'crud-members.mjs');
+const VENDOR_SOURCE = readFileSync(CRUD_MEMBERS, 'utf8');
+
+/**
+ * The whole top-level `const <name> = …` declaration, up to the next top-level
+ * `const` (declarations inside the body are indented, so a line-start `const`
+ * marks the next sibling). Throws when the declaration is gone — the drift
+ * tripwire: a vendor upgrade that restructures the module fails loudly instead
+ * of leaving a pin that matches nothing and passes.
+ */
+function topLevelDecl(source: string, name: string): string {
+  const start = source.indexOf(`\nconst ${name} = `);
+  if (start < 0) {
+    throw new Error(
+      `[#10532] could not find the top-level \`${name}\` declaration in ${CRUD_MEMBERS}. ` +
+        `better-auth restructured this module — re-read \`addMember\` and re-decide whether ` +
+        `\`teamId\` still has no active-team fallback (our comments and the ` +
+        `content/docs/permissions/authentication.mdx "Attaching an existing user to an ` +
+        `organization" section both state that it does not).`,
+    );
+  }
+  const rest = source.slice(start + 1);
+  const next = rest.indexOf('\nconst ');
+  return next < 0 ? rest : rest.slice(0, next);
+}
+
+/**
+ * The initialiser of a single-line `const <name> = …;` binding inside a slice,
+ * returned as vendor BYTES. Throws when absent, for the same reason as above.
+ */
+function bindingInitializer(slice: string, name: string): string {
+  const match = new RegExp(`\\n\\s*const ${name} = ([^;\\n]+);`).exec(slice);
+  if (!match) {
+    throw new Error(
+      `[#10532] could not find the \`const ${name} = …;\` binding inside \`addMember\` in ` +
+        `${CRUD_MEMBERS}. better-auth rewrote the handler — re-read it and re-decide whether ` +
+        `\`teamId\` still has no active-team fallback.`,
+    );
+  }
+  return match[1]!;
+}
+
+/**
+ * "This binding falls back to something on the caller's session." One matcher,
+ * used on both bindings, so the negative leg is only ever read after the same
+ * matcher has been shown to fire on the positive one.
+ */
+const SESSION_ACTIVE_FALLBACK = /session[\s\S]*\bactive[A-Z]\w*/;
+
+const ADD_MEMBER = topLevelDecl(VENDOR_SOURCE, 'addMember');
+
+const occurrences = (needle: RegExp): number =>
+  VENDOR_SOURCE.match(new RegExp(needle.source, 'g'))?.length ?? 0;
+
+describe('[#10532] better-auth `addMember` — the org/team fallback asymmetry', () => {
+  it('CONTROL: the `orgId` binding really does fall back to the session active org', () => {
+    // Positive control for BOTH instruments used below: it proves the vendor
+    // file was located and sliced, and that `SESSION_ACTIVE_FALLBACK` fires on
+    // a binding that carries a session fallback. Without this leg passing, the
+    // non-match in the next test is not evidence of anything.
+    const orgId = bindingInitializer(ADD_MEMBER, 'orgId');
+    expect(orgId).toMatch(SESSION_ACTIVE_FALLBACK);
+    expect(orgId).toContain('activeOrganizationId');
+  });
+
+  it('the `teamId` binding has NO fallback — it reads the request body and nothing else', () => {
+    const teamId = bindingInitializer(ADD_MEMBER, 'teamId');
+    // Same matcher that just fired on `orgId`.
+    expect(teamId).not.toMatch(SESSION_ACTIVE_FALLBACK);
+    // …and positively: the only source of the value is the request body.
+    expect(teamId).toContain('ctx.body');
+    expect(teamId).not.toContain('session');
+  });
+
+  it('no active-team read anywhere in the module (with the neighbouring positive control)', () => {
+    // The control first: if this ever hits 0 the grep itself is broken and the
+    // zero below means nothing.
+    expect(occurrences(/activeOrganizationId/)).toBeGreaterThan(0);
+    expect(occurrences(/active[Tt]eam\w*/)).toBe(0);
+  });
+
+  it('the `if (teamId)` branches stay skipped when teamId is absent — no re-resolution later', () => {
+    // The remaining way the vendor could acquire an active team is to
+    // re-resolve it after the binding. Same control shape: the guard we expect
+    // to be there is asserted present, then the re-resolution is asserted
+    // absent across the whole handler.
+    expect(ADD_MEMBER).toMatch(/if \(teamId\)/);
+    expect(ADD_MEMBER).not.toMatch(/teamId\s*(?:\|\||\?\?)=?/);
+  });
+});

--- a/packages/plugins/plugin-auth/src/organization-add-member.ts
+++ b/packages/plugins/plugin-auth/src/organization-add-member.ts
@@ -42,13 +42,32 @@
  * capability error (501 when the organization plugin is off) → body
  * validation (400) → the vendor's own verdicts, forwarded verbatim.
  *
- * ── organizationId default ──────────────────────────────────────────────────
+ * ── organizationId defaults; teamId does NOT ────────────────────────────────
  *
- * The request headers are forwarded into `auth.api.addMember`, so an omitted
- * `organizationId` defaults to the CALLER's active organization — the
- * behaviour the `sys_member` action metadata documents ("organizationId/teamId
- * default to the caller's active org/team when omitted"). An admin with no
- * active organization gets the vendor's 400 `NO_ACTIVE_ORGANIZATION`.
+ * The two optional fields are NOT symmetric. `organizationId` defaults to the
+ * caller's active organization when omitted; `teamId` has no such fallback —
+ * omit it and the member simply joins no team. Measured on the installed
+ * better-auth 1.7.1 (`dist/plugins/organization/routes/crud-members.mjs`,
+ * inside `addMember`'s handler):
+ *
+ *     const orgId = ctx.body.organizationId || session?.session.activeOrganizationId;
+ *     const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0;
+ *
+ * and no `activeTeamId` read anywhere in that file (`activeOrganizationId`
+ * hits 8 times in the same grep, which is what proves the search works).
+ *
+ * So what header forwarding buys is the ORG default only: an admin with no
+ * active organization gets the vendor's 400 `NO_ACTIVE_ORGANIZATION`, while an
+ * omitted `teamId` stays `undefined` and every `if (teamId)` branch in the
+ * vendor handler (team lookup, `TEAM_NOT_FOUND`, per-team limit) is skipped.
+ * Forwarding `teamId` itself is still correct — pass it and it works.
+ *
+ * The `sys_member` `add_member` action metadata used to assert the symmetric
+ * version of this sentence; it was a wrong citation rather than a live defect,
+ * because that action's `params` list carries no `teamId` and so never sent
+ * one. Corrected at the origin in the same change, and pinned against a vendor
+ * bump that ADDS an active-team fallback by
+ * `organization-add-member-team-fallback.test.ts`.
  */
 
 import { mapAuthApiError, type EndpointResult } from './admin-user-endpoints.js';


### PR DESCRIPTION
Fixes #10532

## What was wrong

Two source comments asserted that better-auth's `organization/add-member`
defaults **both** `organizationId` and `teamId` to the caller's active
org/team. Only the organization half is true.

## Vendor re-measurement (done in this worktree, not taken from the card)

Installed version confirmed **better-auth 1.7.1** — resolved from
`packages/plugins/plugin-auth`, realpath
`node_modules/.pnpm/better-auth@1.7.1_…/node_modules/better-auth`, whose
`package.json` reports `1.7.1`. File:
`dist/plugins/organization/routes/crud-members.mjs`, inside `addMember`'s
handler (`:41`, `:43`):

```js
const orgId = ctx.body.organizationId || session?.session.activeOrganizationId;
if (!orgId) throw APIError.from("BAD_REQUEST", ORGANIZATION_ERROR_CODES.NO_ACTIVE_ORGANIZATION);
const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0;
```

The finding is a **zero-hit** judgement, so it is reported with the
neighbouring positive control that proves the search works — same `grep`,
same file:

| term | hits |
| --- | --- |
| `activeOrganizationId` (control — known present) | **8** |
| `activeTeamId` (the claim) | **0** |

An omitted `teamId` therefore stays `undefined`, and every `if (teamId)` branch
downstream (team lookup, `TEAM_NOT_FOUND`, the per-team limit) is skipped. The
card's reading reproduced exactly.

## Scope correction — the claim lives at TWO sites, not three

The card and the dispatch both name three sites. Measured here, the false
sentence exists at **two**:

1. `packages/platform-objects/src/identity/sys-member.object.ts` — the origin
   (the `add_member` action).
2. `packages/plugins/plugin-auth/src/organization-add-member.ts` — the module
   header, which cited the origin as *the* authority for forwarding headers.

`packages/plugins/plugin-auth/src/auth-plugin.ts` does cite the same action
metadata above the mount, but it cites it for a **different and correct** fact —
that the `sys_member` action has always targeted this URL, which is what
justifies restoring the route. It carries no claim about defaults, so there is
nothing false there to correct and it is left untouched. Verified by an
exhaustive scan rather than by reading the one comment: repo-wide greps for
`active org/team`, `default(s) to the caller` and `active[Tt]eam` return only
the two sites above (plus `sys-team.object.ts`, which asserts the
organization half **only** — that half is true — and one `plugin-auth` test
comment likewise quoting only the org half).

## The corrected sentence

Both sites now carry the same statement:

> `organizationId` defaults to the caller's active organization when omitted;
> `teamId` has no such fallback — omit it and the member simply joins no team.

which is also the wording the #10050 docs already publish in
`content/docs/permissions/authentication.mdx`.

## Nothing was misled at runtime

The `add_member` action's `params` list is `userId`, `role`, `organizationId` —
**no `teamId`** (checked in the file, not assumed from the card). The toolbar
therefore never sent one and the claim was never exercised. This is a **wrong
citation**, not a defect that reached a deployment. `teamId` forwarding itself
stays correct: pass it and it works. No runtime behaviour changes in this PR.

## The pin

`packages/plugins/plugin-auth/src/organization-add-member-team-fallback.test.ts`
reads the fact out of the **installed vendor artifact** — it resolves
`better-auth` with `createRequire` seeded from this package, reads
`crud-members.mjs`, slices the top-level `addMember` declaration, and extracts
the `orgId` / `teamId` binding initialisers as vendor **bytes**. It asserts
nothing about our own comments or our own constants: an assertion whose two
sides both derive from this repo would prove only that we wrote what we wrote.

Every negative leg is paired with a positive control running the **same**
instrument over a neighbouring known-present fact:

- one matcher, `SESSION_ACTIVE_FALLBACK`, must **match** the `orgId` binding
  before its non-match on the `teamId` binding is read as evidence;
- `activeOrganizationId` must occur in the module before the zero count for
  `active[Tt]eam*` counts.

A vendor upgrade that moves or renames the declaration throws with a message
naming the file and what to re-decide, rather than silently matching nothing
and passing.

### Ablation — predicted, then observed

Prediction written down **before** running (mutate the vendor fact into the
has-fallback shape):

```
const teamId = "teamId" in ctx.body ? ctx.body.teamId : void 0;
->  const teamId = "teamId" in ctx.body ? ctx.body.teamId : session?.session.activeTeamId;

predicted:  Test Files 1 failed (1) · Tests 2 failed | 2 passed (4)
  1 CONTROL orgId falls back .................. PASS (untouched)
  2 teamId binding has NO fallback ............ FAIL at not.toMatch(SESSION_ACTIVE_FALLBACK)
  3 no active-team read anywhere .............. FAIL, expected 0 received 1
  4 if (teamId) branches stay skipped ......... PASS (no `teamId ||` / `??` introduced)
```

Observed, exactly:

```
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)

AssertionError: expected '"teamId" in ctx.body ? ctx.body.teamI…' not to match /session[\s\S]*\bactive[A-Z]\w*/
AssertionError: expected 1 to be +0 // Object.is equality
```

**This also answers "where does the pin read from".** Nothing in this repo was
touched and nothing was rebuilt for the ablation — the only edit was to the file
under `node_modules`, and the suite went red. That is a positive control for
`node_modules`-at-runtime, not a cached or derived copy. (The usual
rebuild-each-leg rule does not apply here precisely because the mutated artifact
is the vendor's, not our `dist/`.) Green again on the unmutated vendor:
`Test Files 1 passed (1) · Tests 4 passed (4)`.

**Hardlink safety.** The vendor file had **6 hardlinks** into the shared pnpm
store, so an in-place edit would have corrupted every sibling agent's
`node_modules` and the store itself. The link was broken for this worktree only
(`rm` the directory entry, then write a fresh inode), leaving the store intact,
and restored by copy from a pre-mutation backup:

```
hardlinks before ......... 6
hardlinks during ......... 1   (store inode untouched)
ORIG_SHA     = 909fbfec01a59a0e36a12cb7ecc5ee7c8e9e5940
MUTATED_SHA  = 657e8c3b5864bfe1ea9fe7fe8e393f405d92098d
RESTORED_SHA = 909fbfec01a59a0e36a12cb7ecc5ee7c8e9e5940   ← byte-identical, `cmp` also clean
```

## Verification — all at `7064ec8ba`, clean tree

Gate union derived with `node scripts/pm/dispatch-gates.mjs` (no path
arguments) **after** the final commit on a clean tree; exit codes captured
before any pipe. Every line below is the gate's own verdict.

| gate | exit | verdict line |
| --- | --- | --- |
| `pnpm --filter @objectstack/plugin-auth typecheck` | 0 | (tsc silent) |
| `pnpm --filter @objectstack/platform-objects typecheck` | 0 | (tsc silent) |
| `pnpm --filter @objectstack/platform-objects test` | 0 | `Test Files 25 passed (25) · Tests 419 passed (419)` |
| `pnpm --filter @objectstack/plugin-auth test` | 0 | `Test Files 62 passed (62) · Tests 1363 passed (1363)` |
| `turbo run build --filter=./packages/* --filter=./packages/*/*` | 0 | `Tasks: 70 successful, 70 total` |
| `check:changeset-gate-self-tests` | 0 | |
| `check:objectui-changeset` | 0 | |
| `check:slot-lookup` | 0 | |
| `check:test-source-alias` | 0 | |
| `check:type-source-resolution` | 0 | |
| `check-adr-0087-registration.mjs` | 0 | |
| `check-changeset-no-major.mjs` | 0 | |
| `check-empty-changeset.mjs` | 0 | |
| `docs-audit/check-affected-docs.mjs` | 0 | |
| `check:query-options-erasure` | 0 | `query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new, and every file measured parsed.` |
| `check:engine-double-contract` | 0 | |
| `check:where-matcher` | 0 | |
| `check:i18n` | 0 | `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).` |
| `check:type-check-coverage` | 0 | `check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger …` |
| `check:type-check-debt --re-measure` | 0 | `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 391.3s, 1913 raw tsc error(s) total, none above its recorded number.` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 6214 text file(s) … no raw ASCII control bytes).` |

### #10449 is fixed — asserted, not merely absent

The dispatch carried a warning that `check-query-options-erasure-ratchet` might
be red on `packages/spec/src/migrations/registry.ts:0:0 — Parsing error:
Maximum call stack size exceeded`, and to attribute that to #10449 rather than
investigate. The PM withdrew the warning mid-task (#10449 closed 2026-08-20 by
PR #10464). Independently confirmed here, and more strongly than "it did not
reproduce": `pnpm check:query-options-erasure` is the exact command CI's *Engine
query-options erasure ratchet* step runs (`.github/workflows/lint.yml:109`), it
exits **0** on this branch, and its own self-test line names the withdrawn
failure directly —

> `…and packages/spec/src/migrations/registry.ts parses at --stack-size=4000 through this gate's own channel.`

The new test file also consumed no test-surface headroom
(`test surface: 240 site(s) in 47 file(s) — at the ceiling`).

**class #10309 — the derivation was short, as warned.** It did **not** name
`check:route-envelope` or `check:dispatcher-error-vocabulary` even though this
PR touches `plugin-auth` and `platform-objects`. Both were run explicitly,
including `--self-test`:

| gate | exit |
| --- | --- |
| `check:route-envelope` | 0 |
| `check:route-envelope --self-test` | 0 |
| `check:dispatcher-error-vocabulary` | 0 |
| `check:dispatcher-error-vocabulary --self-test` | 0 |

**Observation for #10615, deliberately NOT acted on here.** The ratchet's
informational line reads: *"@objectstack/plugin-auth: TEST_DEBT records 109, tsc
now reports 98 (-11) — the entry can be lowered."* The gate is green (a count
may sit below its ceiling); the dispatch fenced this entry off, so it was not
edited and `--lower` was never run. Flagging the −11 gap because it is a real
change to what #10615 records. The new test file contributes 0 errors — the
count moved **down**, not up.

## Single-claim paths

`scripts/check-single-claim-paths.mjs` cannot run here — it needs `PR_NUMBER` +
a `GITHUB_TOKEN`, and with only the former it fails `GitHub API 401`, which is a
wiring failure and not a verdict. CI runs it. Checked directly instead: of the
16 other open PRs, the two that could plausibly overlap were inspected file by
file — #10660 (`plugin-auth`) touches `auth-route-ledger.ts`,
`auth-route-ledger.conformance.test.ts` and docs; #10633 (`platform-objects`)
touches `sys-session.object.ts` and two new tests. **Neither touches any of this
PR's four files.** No conflicting claim.

## Not in scope

No `packages/spec` file is touched. `content/docs/releases/**` is untouched —
the release-notes input is the changeset,
`.changeset/add-member-team-id-no-active-team-fallback.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_