### PR TITLE
docs: retire the /graphql endpoint contract and its protocol-page residue

### DIFF
--- a/content/docs/api/declarative-endpoints.mdx
+++ b/content/docs/api/declarative-endpoints.mdx
@@ -12,8 +12,8 @@ publish gates serves real traffic as soon as the package is published.
 
 <Callout type="warn">
 **This is not [Plugin Endpoints](/docs/api/plugin-endpoints).** That page is a *catalog of
-built-in routes* the platform serves when a plugin is installed (`/auth`, `/automation`,
-`/graphql`, …) — you call those, you do not write them. This page is about the endpoints
+built-in routes* the platform serves when a plugin is installed (`/auth`, `/automation`, …)
+— you call those, you do not write them. This page is about the endpoints
 **you declare**, which live under your own namespace and never overlap with that catalog.
 </Callout>
 

--- a/content/docs/api/declarative-endpoints.mdx
+++ b/content/docs/api/declarative-endpoints.mdx
@@ -12,9 +12,9 @@ publish gates serves real traffic as soon as the package is published.
 
 <Callout type="warn">
 **This is not [Plugin Endpoints](/docs/api/plugin-endpoints).** That page is a *catalog of
-built-in routes* the platform serves when a plugin is installed (`/auth`, `/automation`, …)
-— you call those, you do not write them. This page is about the endpoints
-**you declare**, which live under your own namespace and never overlap with that catalog.
+built-in routes* the platform serves when a plugin is installed (`/auth`, `/automation`, …) —
+you call those, you do not write them. This page is about the endpoints **you declare**,
+which live under your own namespace and never overlap with that catalog.
 </Callout>
 
 ## Which channel: `actions` or `apis`?

--- a/content/docs/api/plugin-endpoints.mdx
+++ b/content/docs/api/plugin-endpoints.mdx
@@ -1,6 +1,6 @@
 ---
 title: Plugin Endpoints
-description: REST endpoints that become available when the corresponding plugin is installed — auth, workflow, automation, views, realtime, notifications, AI, i18n, GraphQL, and file storage.
+description: REST endpoints that become available when the corresponding plugin is installed — auth, workflow, automation, views, realtime, notifications, AI, i18n, and file storage.
 ---
 
 # Plugin Endpoints
@@ -141,12 +141,6 @@ protocol `ai.chatStream` parses and owns message state for you.
 | GET | `/i18n/locales` | List available locales |
 | GET | `/i18n/translations/:locale` | Get translation bundle |
 | GET | `/i18n/labels/:object/:locale` | Get field labels |
-
-### GraphQL (`/graphql`) — Plugin Required
-
-| Method | Endpoint | Description |
-|:-------|:---------|:------------|
-| POST | `/graphql` | Execute GraphQL query/mutation |
 
 ### File Storage (`/storage`) — Plugin Required
 

--- a/content/docs/protocol/diagram.mdx
+++ b/content/docs/protocol/diagram.mdx
@@ -22,7 +22,7 @@ ObjectStack is composed of seven protocol layers that work together to form a co
 | **System (Kernel)** | `src/kernel/` | Manifest, Datasources, Plugins, Kernel |
 | **Automation** | `src/automation/` | Flows, Workflows, Triggers, Approvals |
 | **AI** | `src/ai/` | Agents, RAG Pipelines, Model Registry |
-| **API** | `src/api/` | REST, GraphQL, WebSocket, Realtime |
+| **API** | `src/api/` | REST, WebSocket, Realtime |
 | **Security** | `src/security/` | Permissions, Roles, Sharing, RLS |
 
 ---
@@ -39,7 +39,6 @@ graph TB
 
     subgraph "API Layer"
         REST[REST Endpoints]
-        GQL[GraphQL]
         WS[WebSocket / Realtime]
     end
 
@@ -92,12 +91,10 @@ graph TB
 
     %% Client to API
     CLIENT --> REST
-    CLIENT --> GQL
     CLIENT --> WS
 
     %% API references Data
     REST --> KERNEL
-    GQL --> KERNEL
     WS --> KERNEL
 
     %% Security enforced at Kernel
@@ -160,7 +157,7 @@ sequenceDiagram
     participant D as Driver
     participant DB as Database
 
-    C->>API: HTTP Request (REST / GraphQL)
+    C->>API: HTTP Request (REST)
     API->>K: Parsed Operation
 
     K->>SEC: Check Permissions

--- a/content/docs/protocol/kernel/error-handling.mdx
+++ b/content/docs/protocol/kernel/error-handling.mdx
@@ -7,7 +7,7 @@ import { AlertCircle, Bug, Shield, Info, AlertTriangle, XCircle, Radio, Zap } fr
 
 # Error Handling
 
-The **Error Handling Protocol** defines standardized error codes, response formats, and debugging strategies across all ObjectStack APIs (HTTP, WebSocket, GraphQL).
+The **Error Handling Protocol** defines standardized error codes, response formats, and debugging strategies across all ObjectStack APIs (HTTP, WebSocket).
 
 ## Why Standardized Errors Matter
 

--- a/content/docs/protocol/kernel/lifecycle.mdx
+++ b/content/docs/protocol/kernel/lifecycle.mdx
@@ -67,7 +67,7 @@ The ObjectStack boot process follows a **strict order** to ensure dependencies a
 │  └─ Start event bus                                             │
 │  └─ Start job scheduler                                         │
 │  └─ Start audit logger                                          │
-│  └─ Start HTTP/GraphQL servers                                  │
+│  └─ Start HTTP server                                           │
 └─────────────────────────────────────────────────────────────────┘
                           ↓
 ┌─────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
Fixes #10832

`content/docs/api/plugin-endpoints.mdx` handed the reader a **method, a path and a payload
contract** for a route that is not mounted. That is the same defect class as #10710, one
level worse: the earlier card advertised a *behaviour*, this one advertised an *endpoint*.

## The three facts, re-measured at this base (`origin/main` @ `5f2e54cc66`)

| Claim the pages make | What the tree says |
|:---|:---|
| `POST /graphql` is a servable route | **Not mounted.** `packages/runtime/src/http-dispatcher.ts:2026` is the whole of it: `// /graphql removed — GraphQL is not in the product plan (#2462 follow-on).` |
| the platform serves it when a plugin is installed | **No `createGraphQLDomain`** anywhere in `packages/*/src` (0 hits); the fifteen domains at `http-dispatcher.ts:556-574` do not include one. |
| `src/api/` contains a GraphQL module | **Zero graphql files** in `packages/spec/src/api/` (re-measured: 68 files, 0 named graphql). The one string hit is `protocol.zod.ts:105`, a docblock naming GraphQL as an industry *design style* — not a module. |

## Remove vs. rewrite — reasoned per site, not applied uniformly

`packages/runtime/src/domains/unavailable.ts` draws the line: **404** = "the route is not
there"; **501** = "the route is there, the implementation is not", and every 501 domain is
mounted *unconditionally*. `/graphql` is in **neither** state. So a construct whose job is to
*enumerate servable routes* must lose the entry entirely — rewriting it to "not available"
would still assert GraphQL was a surface worth listing. That is why #10710 deleted its
status-table row.

But the card is right that a mermaid node and a prose enumeration are not the same object,
so the sites split two ways:

**Deleted — the construct itself asserts a surface that does not exist:**

- `api/plugin-endpoints.mdx` — the entire `### GraphQL (/graphql) — Plugin Required` section
  and its `POST /graphql` method/path table, plus GraphQL from the frontmatter enumeration
  at `:3`. A table headed *Method | Endpoint | Description* is a promise that the row is callable.
- `api/declarative-endpoints.mdx` — `/graphql` from the exemplar list pointing at that
  catalog. The two survivors (`/auth`, `/automation`) are real mounted domains.
- `protocol/diagram.mdx` — the `GQL[GraphQL]` node **and both its edges** (`CLIENT --> GQL`,
  `GQL --> KERNEL`). Deleting only the declaration would not have been enough: **mermaid
  materialises an undeclared node from a dangling edge**, so the box would still render, now
  without its label.
- `protocol/diagram.mdx` — GraphQL from the `src/api/` layer-table cell.

**Rewritten — the surrounding claim is true; only the enumeration was wrong:**

- `protocol/diagram.mdx:163` sequence label → `HTTP Request (REST)`. The request is real; the
  parenthetical listed one transport too many.
- `protocol/kernel/lifecycle.mdx:70` → `Start HTTP server`. Phase 6 genuinely starts a server.
  ASCII box width preserved (all Phase-6 rows remain byte-identical in length to their siblings).
- `protocol/kernel/error-handling.mdx:10` → `(HTTP, WebSocket)`. The error protocol does span
  the remaining surfaces.

Wording precedent followed: `content/docs/permissions/authorization.mdx:53`, which already
says `/graphql` now 404s and is left untouched.

## Sibling PR

**#10828's diff was read before editing** (its three files: `api/index.mdx`,
`data-modeling/fields.mdx`, `getting-started/quick-reference.mdx`). It is **disjoint by file**
from all five files here — no overlap, no shared hunk. One correction to the dispatch premise:
that PR is **still open and unmerged** (base `a7ea3289eb`, the previous `main`), so its changes
are *not* in `origin/main` @ `5f2e54cc66`; the three `api/index.mdx` GraphQL sites this branch
leaves alone are its work, not residue.

## Gates

`node scripts/pm/dispatch-gates.mjs` derived **15 families** from the changed paths — including
`check:error-status-conformance`, which the dispatch clue list did not name and which matches
only via `protocol/kernel/error-handling.mdx`. All 15 green at **`451fe92153`**, the head of
this branch. Exit codes captured by redirect before any pipe, never off a `tail`; each log
verified to carry real output, so no `pnpm --filter` zero-match could pass as green. Their own
verdict lines:

- `check:doc-anchors` — *"272 internal #fragment link(s) across 408 source file(s) all resolve to a real heading"* — the deleted `###` heading broke no anchor (independently confirmed: no `#graphql` fragment exists anywhere in `content/`).
- `check:error-status-conformance` — *"every derivable runtime status is documented, and every documented status is reachable."*
- `check:doc-authoring` — *"389 files clean — no bare metadata literals."*
- `check-doc-frontmatter` — *"403 page(s) under content/docs parse with yaml@2.9.0"*
- `check:docs-audit-scope` — *"scope is in sync with content/docs/: 189 hand-written doc(s)"*
- `check:docs-redirects` — *"OK (apps/docs/redirects.mjs: 92 entries ...)"*
- `check:doc-formula-expressions` — *"self-test: 30 cases passed"*, *"22 record-scoped formula example(s) ... judged clean"*
- `check:role-word` — *"OK, no new occurrences of the reserved word."*
- `check:published-readme-links` — *"165 outbound link(s) across 60 published markdown file(s)"*
- plus `check:cross-package-test-inputs` (×2, pnpm + direct node) and `spec/check:{empty-state,liveness,strictness-ledger,variant-docs}`.

`check:quick-reference-counts` is **not** in the derived set here — it keys on
`quick-reference.mdx`, which is #10828's file and not in this diff.

No ablation applies: this is a docs-only change with no guard under test.

**No changeset** — decided from the real file list, not defaulted. All five files are under
`content/`, which matches **no** glob in `pnpm-workspace.yaml` (`packages/*`, `apps/*`,
`examples/*`, …), and its only consumer `apps/docs` (`@objectstack/docs`) is `private: true`.
This publishes nothing ⇒ `skip-changeset`.

## Deliberately not touched

- `packages/**` — out of scope for this card. The code is correct; the docs were wrong.
- `content/docs/automation/webhooks.mdx:724` — a comparison to other ecosystems, not a claim
  about our surface.
- `content/docs/permissions/authorization.mdx:53` — already correct; it is the precedent.
- `content/docs/kernel/services-checklist.mdx:17,97` and `getting-started/index.mdx:99` —
  already correct: they state GraphQL was *removed*.
- `content/docs/references/**` — generated, filed against the generator during #10710's triage.
- `skills/**` and its mirror `content/docs/ai/skills-reference.mdx:156` — GraphQL residue found
  in five places, but the source of truth is `skills/**`, which is governed/human-merge-only.
  Filed separately rather than patching the consumer page into disagreement with the skill it
  catalogs.

_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_