### PR TITLE
fix(core,hono): retire /graphql residue — stale anonymous-deny surface list and inert test doubles

### DIFF
--- a/packages/adapters/hono/src/__mocks__/runtime.ts
+++ b/packages/adapters/hono/src/__mocks__/runtime.ts
@@ -1,9 +1,18 @@
 // Stub for @objectstack/runtime - resolved via vitest alias
+//
+// [#10835] Every method here must exist on the REAL `HttpDispatcher`
+// (`packages/runtime/src/http-dispatcher.ts`). A stub method the subject does
+// not have can never diverge from it — it is green by construction — and it
+// reads to the next author grepping the name as evidence the runtime still has
+// the method. `handleGraphQL` sat here for exactly that reason after `/graphql`
+// was removed (#2462 follow-on) and was the last non-CHANGELOG hit for the name
+// in `packages/**`. Declaring MORE than this adapter calls is fine (it calls
+// only `getDiscoveryInfo`, `handleAuth` and `dispatch`); declaring something the
+// dispatcher does not implement is not.
 import { vi } from 'vitest';
 
 export class HttpDispatcher {
   getDiscoveryInfo = vi.fn().mockReturnValue({ version: '1.0', routes: {} });
-  handleGraphQL = vi.fn().mockResolvedValue({ data: {} });
   handleAuth = vi.fn().mockResolvedValue({ handled: true, response: { status: 200, body: { ok: true } } });
   handleMetadata = vi.fn().mockResolvedValue({ handled: true, response: { status: 200, body: { objects: [] } } });
   handleData = vi.fn().mockResolvedValue({ handled: true, response: { status: 200, body: { records: [] } } });

--- a/packages/adapters/hono/src/hono-wildcard-fallthrough.test.ts
+++ b/packages/adapters/hono/src/hono-wildcard-fallthrough.test.ts
@@ -34,7 +34,6 @@ import type { Hono } from 'hono';
 const mockDispatcher = {
   getDiscoveryInfo: vi.fn().mockReturnValue({ version: '1.0', routes: {} }),
   handleAuth: vi.fn(),
-  handleGraphQL: vi.fn(),
   dispatch: vi.fn(),
 };
 

--- a/packages/adapters/hono/src/hono.test.ts
+++ b/packages/adapters/hono/src/hono.test.ts
@@ -7,7 +7,6 @@ import { Hono } from 'hono';
 const mockDispatcher = {
   getDiscoveryInfo: vi.fn().mockReturnValue({ version: '1.0', routes: {} }),
   handleAuth: vi.fn().mockResolvedValue({ handled: true, response: { body: { ok: true }, status: 200 } }),
-  handleGraphQL: vi.fn().mockResolvedValue({ data: {} }),
   dispatch: vi.fn().mockResolvedValue({ handled: true, response: { body: { success: true }, status: 200 } }),
 };
 
@@ -507,6 +506,37 @@ describe('createHonoApp', () => {
         'POST',
         '/storage/upload/presigned',
         { filename: 'a.txt' },
+        expect.any(Object),
+        expect.objectContaining({ request: expect.anything() }),
+        '/api',
+      );
+    });
+
+    // [#10835] `/graphql` is NOT a routed domain: it was removed along with the
+    // GraphQL surface itself (`runtime/http-dispatcher.ts` — "/graphql removed
+    // — GraphQL is not in the product plan", #2462 follow-on), so it is ordinary
+    // catch-all traffic, exactly like the retired `/storage` mount above.
+    //
+    // This REPLACES a `handleGraphQL` double that used to sit on
+    // `mockDispatcher` and proved nothing. The adapter calls exactly three
+    // dispatcher methods — `getDiscoveryInfo`, `handleAuth`, `dispatch` — so an
+    // extra key on the mock was unreachable from `index.ts`: it could never
+    // diverge from the real dispatcher, stayed green by construction, and read
+    // to anyone grepping the name as evidence the runtime still had the method.
+    // A double for an unrouted method is not how fall-through is demonstrated;
+    // a request that lands on `dispatch()` is, which is why the `/storage` test
+    // above needs no `handleStorage` double either.
+    it('POST /api/graphql reaches the catch-all — GraphQL is not a routed domain', async () => {
+      const res = await app.request('/api/graphql', {
+        method: 'POST',
+        body: JSON.stringify({ query: '{ __typename }' }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status).toBe(200);
+      expect(mockDispatcher.dispatch).toHaveBeenCalledWith(
+        'POST',
+        '/graphql',
+        { query: '{ __typename }' },
         expect.any(Object),
         expect.objectContaining({ request: expect.anything() }),
         '/api',

--- a/packages/core/src/security/anonymous-deny.ts
+++ b/packages/core/src/security/anonymous-deny.ts
@@ -4,11 +4,40 @@
  * #2567 — the single anonymous-deny decision, shared by every HTTP seam.
  *
  * ADR-0056 D2 made the platform deny anonymous callers by default. Phase 1 gated
- * each surface (REST `/data`, dispatcher `/graphql` + `/meta`, raw-hono `/data`)
- * but every seam hand-rolled the same `!userId && !isSystem → 401` check. This
- * centralises that DECISION into one pure, tested function — the exact pattern
- * {@link ./auth-gate.ts} established for the ADR-0069 auth-policy gate: keeping
- * the decision in one function means the seams can never drift on who is denied.
+ * each surface separately, with every seam hand-rolling the same
+ * `!userId && !isSystem → 401` check. This centralises that DECISION into one
+ * pure, tested function — the exact pattern {@link ./auth-gate.ts} established
+ * for the ADR-0069 auth-policy gate: keeping the decision in one function means
+ * the seams can never drift on who is denied.
+ *
+ * ## Do NOT keep a route list here (#10835)
+ *
+ * This paragraph used to name the Phase-1 surfaces inline — "REST `/data`,
+ * dispatcher `/graphql` + `/meta`, raw-hono `/data`" — and TWO of those three
+ * outlived the routes they named:
+ *
+ *  - **`/graphql` is gone.** Removed with the GraphQL surface itself
+ *    (`packages/runtime/src/http-dispatcher.ts`: "/graphql removed — GraphQL is
+ *    not in the product plan", #2462 follow-on). No `handleGraphQL` survives
+ *    anywhere in `packages/runtime`, and `/graphql` is now ordinary catch-all
+ *    traffic.
+ *  - **raw-hono `/data` is gone.** Those routes were deleted as a duplicate
+ *    surface in v17 (#4073); `packages/adapters/hono` mounts only `/discovery`,
+ *    `/auth/*` and the terminal `${prefix}/*` catch-all.
+ *
+ * A stale list here is worse than no list, because the seams it names are the
+ * thing a reader opens this file to learn: a dead route reads as a live surface.
+ * That is not hypothetical — the `handleGraphQL` test doubles removed alongside
+ * this edit had become the only non-CHANGELOG hits in `packages/**`, and so read
+ * to the next author grepping the name as evidence the runtime still had the
+ * method.
+ *
+ * The live enumeration is mechanical, so defer to it rather than restating it:
+ * `packages/qa/dogfood/test/authz-conformance.matrix.ts` and its companion
+ * `authz-conformance.test.ts` ratchet a CURATED table of HTTP/transport entry
+ * points out of source — deleting a `shouldDenyAnonymous` call makes its row
+ * STALE, a new ungated route in one of those files is UNCLASSIFIED, and either
+ * breaks CI. Read the ratchet, or read the call sites.
  *
  * ## The `requireAuth` opt-out is gone (#3963)
  *


### PR DESCRIPTION
Fixes #10835

Two halves that are **not the same kind of task**, handled differently and reported separately.

## Half 1 — the stale comment (unambiguous)

`packages/core/src/security/anonymous-deny.ts` described the anonymous-deny surfaces as
*"each surface (REST `/data`, dispatcher `/graphql` + `/meta`, raw-hono `/data`)"*. Both
facts re-derived against `origin/main` rather than taken from the card:

| Claim | Evidence at source |
|---|---|
| `/graphql` is gone | `packages/runtime/src/http-dispatcher.ts:2026` — `// /graphql removed — GraphQL is not in the product plan (#2462 follow-on)`. No `handleGraphQL` anywhere in `packages/runtime`; the real `HttpDispatcher` exposes `handleMcp`, `handleKeys`, `getDiscoveryInfo`, `handleAuth`, `handleMetadata`, `handleData`, `handleAnalytics`, `handleNotification`, `handleSecurity`, `handlePackages`, `handleUi`, `handleAutomation`, `handleActions`, `handleAI`, `handleShareLinks`, `dispatch` — and no GraphQL member |
| raw-hono `/data` is gone | `packages/adapters/hono/src/index.ts` mounts only `prefix`, `${prefix}/discovery`, `/.well-known/objectstack`, `${prefix}/auth/*` and the terminal `${prefix}/*` catch-all. No `/data` route. Matches `content/docs/permissions/authorization.mdx:53` (deleted as a duplicate surface in v17, #4073) |

Rather than swap in a fresh route list that will rot the same way, the comment now records
both corrections and **defers to the mechanical enumeration** — the `authz-conformance`
ratchet, which reads entry points out of source and fails CI on a STALE row or an
UNCLASSIFIED route. Comment-only: every changed line in that file is a comment line.

## Half 2 — the three `handleGraphQL` doubles (a real question)

**Decision: all three were inert residue. Removed — and replaced with an assertion that
actually pins the behaviour they gestured at.**

The card's counter-argument was that a wildcard fall-through test may legitimately want a
method the dispatcher does *not* route. That was tested against the code, not assumed:

- **The adapter cannot observe the property.** `index.ts` calls exactly three dispatcher
  methods — `getDiscoveryInfo` (l.300/304), `handleAuth` (l.413), `dispatch` (l.463).
- **Nothing asserts on it.** `handleGraphQL` was never invoked or asserted in either test
  file, and no test requests a `/graphql` path. Fall-through in
  `hono-wildcard-fallthrough.test.ts` is driven entirely by `handled: false` returns from
  `handleAuth`/`dispatch` on `/auth/*` paths.
- **The repo already shows the correct shape.** `/storage` is a genuinely retired mount
  (#4087) whose fall-through *is* pinned — by `POST /api/storage/upload/presigned reaches
  the catch-all, not a storage mount`, a request-level test that needs **no `handleStorage`
  double**. That is the in-repo precedent for how an unrouted domain is demonstrated.

So `/graphql` had the opposite of what it needed: an inert double and no test. This PR adds
`POST /api/graphql reaches the catch-all — GraphQL is not a routed domain`, modelled on the
`/storage` case.

`handleMetadata` and `handleData` stay in `src/__mocks__/runtime.ts` — both still exist on
the real dispatcher (`http-dispatcher.ts:1677`, `:1682`), so they are not residue. A stub may
declare more than this adapter calls; it may not declare what the subject lacks. That
invariant is now written at the top of the stub.

## Reverse verification — both directions, on a rebuild-free path

These tests import the subject as **source** (`from './index'`) and alias `@objectstack/runtime`
to a source stub; the package has **no `dist/` at all**, so the mutation on disk is what runs
and no rebuild can hide a leg. Every mutation was confirmed on disk by grep count, never by an
editor's exit code.

**1. The new test fails for the right reason.** Ablation: re-introduce a `/graphql` mount
ahead of the catch-all (`app.all(&#96;${prefix}/graphql&#96;, …)`) — the exact regression it guards.

```
baseline                     EXIT=0   Tests  74 passed (74)
+ /graphql mount             EXIT=1   Tests  1 failed | 73 passed (74)
                                      × POST /api/graphql reaches the catch-all — GraphQL is not a routed domain
restored (marker count 0)    EXIT=0   Tests  74 passed (74)
```

Exactly one failure, and it is the new test.

**2. The removed doubles really were unreachable** — proved positively, not by absence of
evidence. `mockDispatcher` was wrapped in a `Proxy` that throws on any string property outside
the allowed set:

```
Probe A  allow {getDiscoveryInfo, handleAuth, dispatch}   EXIT=0  74 passed   probe trips: 0
Probe B  CONTROL: same guard, 'dispatch' removed          EXIT=1  41 failed   probe trips: 14
```

Probe A green with zero trips ⇒ nothing ever reads a fourth property, so `handleGraphQL` could
never have been observed. Probe B is the control proving the instrument can detect a read — a
green Probe A would otherwise be indistinguishable from a dead probe.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs` (no paths passed — it takes its own change
set from the merge base) at `d2375ea9c1`, which is the final commit. All green:

| Gate | Its own verdict line |
|---|---|
| `check:cross-package-test-inputs` | `OK: 13 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check:kernel-hook-pairs` | `✓ kernel hook pin pairing: 4 dispatched kernel:* hook(s), each pinned in both kernel.test.ts and lite-kernel.test.ts` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned` |
| `check-ci-filter-parity.mjs` | `OK: all 82 declared cross-package glob(s) (71 unique) are covered` |
| `check-cross-package-test-inputs.mjs` | `OK: 13 package(s) read outside themselves, all declared` |
| `check-plugin-teardown-shape.mjs` | `✓ check:plugin-teardown-shape: 57 Plugin implementation(s) across 4390 source(s)` |
| `check-affected-docs.mjs` | exit 0 |
| `check:query-options-erasure` | `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new` |
| `check:engine-double-contract` | `check-engine-double-contract: OK — 371 pinned, 133 in the DEBT ledger, 2 exempt.` |
| `check:where-matcher` | `✓ where-matcher conformance holds: 272 matcher(s) discovered, 272 answer the combinator battery correctly or refuse it loudly` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 64/77 workspace packages type-checked` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6266 text file(s) … no raw ASCII control bytes)` |

Suite: `pnpm --filter @objectstack/hono test --maxWorkers=2` → `Test Files 2 passed (2)`,
`Tests 74 passed (74)`, `EXIT=0`.

**One declared narrowing.** `check:type-check-debt --re-measure` wants the whole workspace
closure built. Instead of that full build I measured the only two ledger entries this diff can
reach. `@objectstack/hono` (`errors: 3`, *"all code-tier (TS2769/TS18046)"*) — its tsconfig is
`include: ["src/**/*"]`, so test files really are in the program:

```
with this change      3 errors   (1 × TS18046, 2 × TS2769)
origin/main baseline  3 errors   (1 × TS18046, 2 × TS2769)
```

Unmoved, same composition as the ledger records. `@objectstack/core`'s entry cannot move
either — that change is comment-only, and comments do not participate in type checking. CI
runs the full re-measure regardless.

## No changeset

Real file list: three test/mock files under `packages/adapters/hono/src/` and one
**comment-only** change in `packages/core/src/security/anonymous-deny.ts`. No behavioural or
API change in either published package, so there is nothing to describe in release notes;
`skip-changeset` applied.

## Serial constraints

**PR #10824** (`perf(security,protocol)`) does **not** hold `anonymous-deny.ts` — checked
against its actual file list, which is `.changeset/count-opt-out-and-permission-set-memo.md`,
`packages/metadata-protocol/src/{protocol.ts, protocol.count-opt-out.test.ts}` and
`packages/plugins/plugin-security/src/{security-plugin.ts, permission-set-resolution-memo.test.ts}`.
Disjoint. **PR #10828** is `content/docs/**` only — also disjoint. Rebased onto `37ba31a4b8`;
the five commits main gained mid-run touch none of my four files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_