### PR TITLE
fix(devx): teach the cross-package input detector the findUp anchor seeds

### DIFF
--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -148,6 +148,35 @@
 // and `@objectstack/rest`, the three services and `plugin-auth` are not even
 // dependencies of it -- so no graph edge reached them and no glob hashed them.
 //
+// ── The third way out: an ANCHOR the file cannot ask for (#10029) ───────────
+//
+// Every seed above answers "where am I?" from the module itself, so it resolves
+// in the depth coordinate with nothing but the source. A CJS-typed package
+// cannot ask that question at all: `packages/plugins/plugin-auth` publishes
+// `dist/index.js` as CommonJS, so under `module: NodeNext` `import.meta` is a
+// TS1470 there however well it runs under vitest. Four of its tests therefore
+// walk UP from `process.cwd()` to an anchor -- its own `package.json`, or the
+// workspace root -- and that walk resolved to nothing here. Nothing, in this
+// gate, does not mean "unknown": it means the reads built on it produced no
+// depth, no name and NO FLAG, which is the one failure mode this file exists
+// not to have.
+//
+// Measured on `19f98fa1f^`, not reasoned: `rate-limit-storage-isolation.test.ts`
+// read `packages/runtime/src` and `packages/services/service-sms/src` off such a
+// seed, appeared in no roster, and turbo replayed a cached green over the scan
+// it never re-ran -- #7802 exactly, by a fourth spelling. #10161 reseeded that
+// ONE file from `__dirname`. `findUpSeeds()` closes the CLASS it was an instance
+// of, so the next author who reaches for the idiom gets a red gate instead of
+// silence. Today's population is clean, which is the point: this lands with no
+// gate turning red and is pinned by `--self-test` cases that fail without it.
+//
+// What is new in kind: an anchor names an ABSOLUTE directory, where every other
+// spelling names a place relative to the file. So it is the first seed that
+// needs to know where the file SITS before it can be expressed as a depth, and
+// the first that can name a directory this scan cannot locate (another
+// package's manifest) -- which it answers with the trade `walkLiteral` already
+// makes for an unreadable argument: keep the escape verdict, invent no name.
+//
 // Usage:
 //   node scripts/check-cross-package-test-inputs.mjs --verify
 //   node scripts/check-cross-package-test-inputs.mjs --union-into <turbo-ls.json> --changed <file>
@@ -751,6 +780,15 @@ export const RECOGNISED_PATH_SPELLINGS = [
   "const P = new URL('<rel>', import.meta.url);",
   "readFileSync(resolve(HERE, '<rel>'))    // the same expressions in argument",
   "readFileSync(new URL('<rel>', import.meta.url))              // position",
+  '',
+  '// ANCHOR seeds -- a findUp walk, for a CJS-typed package where import.meta',
+  '// is a TS1470. Both compose with every expression above (#10029).',
+  "const PKG = findUp((dir) => JSON.parse(readFileSync(join(dir, 'package.json'))).name",
+  "                           === '<the name of THIS package>');   // -> package root",
+  "const REPO = findUp((dir) => existsSync(join(dir, 'pnpm-workspace.yaml')));",
+  '                                        // -> repo root',
+  '  ⛔ NOT a manifest name belonging to some OTHER package -- that root cannot',
+  '     be located from here, so the escape is flagged and the path is NOT named',
 ];
 
 /**
@@ -1081,23 +1119,130 @@ const DIR_ARG_READS = new Set(['readdirSync', 'opendirSync']);
 function* readArgumentLists(src) {
   const re = new RegExp(String.raw`\b(${PATH_ARG_READS.join('|')})\s*\(`, 'g');
   for (const m of src.matchAll(re)) {
-    const from = m.index + m[0].length;
-    let depth = 1;
-    let quote = null;
-    let i = from;
-    for (; i < src.length; i++) {
-      const c = src[i];
-      if (quote) {
-        if (c === '\\') i += 1;
-        else if (c === quote) quote = null;
-        continue;
-      }
-      if (c === "'" || c === '"' || c === '`') quote = c;
-      else if (c === '(') depth += 1;
-      else if (c === ')' && --depth === 0) break;
-    }
-    if (depth === 0) yield { fn: m[1], args: src.slice(from, i) };
+    const args = balancedArgs(src, m.index + m[0].length);
+    if (args !== null) yield { fn: m[1], args };
   }
+}
+
+/**
+ * The argument text of a call whose opening paren sits at `from - 1`, or `null`
+ * when the parens never close. Quote-aware, so a `(` inside a string literal --
+ * or the `)` inside a `` throw new Error(`could not locate ${what}`) `` -- does
+ * not move the depth.
+ *
+ * Extracted from `readArgumentLists` rather than written a second time beside
+ * the anchor seeds below, which need the same balanced read over a DIFFERENT
+ * callee. A mirrored helper is the shape #10628 already had to undo in this file
+ * once (a hand-copied `globToRegExp`); one balancer means a fix to it cannot
+ * land on one caller and miss the other.
+ */
+function balancedArgs(src, from) {
+  let depth = 1;
+  let quote = null;
+  let i = from;
+  for (; i < src.length; i++) {
+    const c = src[i];
+    if (quote) {
+      if (c === '\\') i += 1;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') quote = c;
+    else if (c === '(') depth += 1;
+    else if (c === ')' && --depth === 0) break;
+  }
+  return depth === 0 ? src.slice(from, i) : null;
+}
+
+/**
+ * The marker files that identify the WORKSPACE ROOT to a `findUp` walk. A
+ * predicate that tests for one of these resolves, statically, to the repo root
+ * -- there is exactly one directory in the tree that has it.
+ *
+ * Published and plural for the same reason `RECOGNISED_PATH_SPELLINGS` is: the
+ * set is what the gate can SEE, so a walk keyed on some other root marker
+ * (`turbo.json`, `.git`) yields no seed and the reads built on it go undeclared
+ * silently. Adding one here is a data change plus a `--self-test` case.
+ */
+export const WORKSPACE_ROOT_MARKERS = ['pnpm-workspace.yaml'];
+
+/** `const X = findUp(` / `let X = findUp(` — the binding the anchor seeds arrive as. */
+const FIND_UP_BINDING = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*string\s*)?=\s*findUp\s*\(/g;
+/** A manifest-name predicate, in either argument order. */
+const MANIFEST_NAME_TEST = /\bname\s*===\s*(['"`])([^'"`]+)\1|(['"`])([^'"`]+)\3\s*===\s*\bname\b/;
+
+/**
+ * The ANCHOR seeds: `findUp` walks that name an absolute directory in the tree
+ * rather than a place relative to the importing file (#10029).
+ *
+ * Every seed above this one answers "where am I?" -- `import.meta.url`,
+ * `__dirname`, `import.meta.dirname`. A CJS-typed package cannot ask that
+ * question: under `module: NodeNext` `import.meta` is a TS1470 there however
+ * well it runs under vitest, so `packages/plugins/plugin-auth` reaches for a
+ * walk up from `process.cwd()` instead, and four of its tests spell it. That
+ * walk resolved to NOTHING here, so every path built on it resolved to nothing
+ * too -- no depth, no name, no flag, which is this gate's one failure mode.
+ * Measured on `19f98fa1f^`: `rate-limit-storage-isolation.test.ts` read
+ * `packages/runtime/src` and `packages/services/service-sms/src` through such a
+ * seed and appeared in NO roster, while turbo replayed a cached green over the
+ * scan it never re-ran (#7802 exactly). #10161 reseeded that one file from
+ * `__dirname`; this closes the CLASS the file was an instance of.
+ *
+ * Two predicates are knowable without executing anything, and they are the two
+ * the idiom uses:
+ *
+ *   PACKAGE ROOT -- the predicate reads a `package.json` and compares its `name`
+ *     to a literal. When that literal is the scanned file's OWN package, the
+ *     answer is this package's root: depth 0, named.
+ *   REPO ROOT -- the predicate tests for a WORKSPACE_ROOT_MARKERS file. The
+ *     answer is the repo root, which sits `pkgSegs.length` levels ABOVE the
+ *     package root, so the binding escapes on its own -- exactly as the
+ *     `resolve(HERE, '../../../..')` spelling of the same anchor already does.
+ *
+ * ⚠️ Why these need repo context when no other seed does. Every other spelling
+ * is relative to the FILE, so it resolves in the depth coordinate on its own; an
+ * anchor names an absolute directory, and where that lands relative to the
+ * package root is not knowable until you know where the file sits. So both
+ * arrive only with `fileSegs`, and a caller with none (the depth-only
+ * `--self-test` shapes) gets no seed rather than a guessed one.
+ *
+ * ⛔ The boundary that keeps this from FABRICATING. A predicate naming some
+ * OTHER package's manifest resolves to that package's root, which this scan
+ * cannot locate without walking the tree -- so it takes the sound half of the
+ * trade `walkLiteral` already makes for an unreadable argument: the walk
+ * necessarily passed through the repo root, so `min` says so and the escape is
+ * flagged, while `segs` is `null` and no name is invented. A roster entry
+ * pointing at a file nobody reads is worse than a missing one.
+ *
+ * An unrecognised predicate yields no seed at all, which is the pre-#10029
+ * behaviour and is why the recognised set is published rather than implied.
+ */
+function findUpSeeds(src, hereDepth, fileSegs, ownPackageName) {
+  const seeds = new Map();
+  // An anchor is absolute; without the file's place in the tree there is no
+  // depth to express it in. Depth-only callers get nothing, deliberately.
+  if (!fileSegs) return seeds;
+  const pkgSegs = fileSegs.slice(0, fileSegs.length - 1 - hereDepth);
+  const repoRootDepth = -pkgSegs.length;
+  for (const m of src.matchAll(FIND_UP_BINDING)) {
+    const args = balancedArgs(src, m.index + m[0].length);
+    if (args === null) continue;
+    if (WORKSPACE_ROOT_MARKERS.some((f) => args.includes(f))) {
+      seeds.set(m[1], { end: repoRootDepth, min: repoRootDepth, vendored: false, segs: [] });
+      continue;
+    }
+    const named = args.includes('package.json') ? args.match(MANIFEST_NAME_TEST) : null;
+    if (!named) continue;
+    const wanted = named[2] ?? named[4];
+    if (ownPackageName && wanted === ownPackageName) {
+      seeds.set(m[1], { end: 0, min: 0, vendored: false, segs: pkgSegs });
+    } else {
+      // Another package's root: outside this one for certain, locatable only by
+      // walking the tree. Keep the verdict, drop the name.
+      seeds.set(m[1], { end: repoRootDepth, min: repoRootDepth, vendored: false, segs: null });
+    }
+  }
+  return seeds;
 }
 
 /**
@@ -1131,7 +1276,7 @@ function* readArgumentLists(src) {
  * `--self-test` pins the shapes that must keep flagging AND the shapes that must
  * not; an added spelling without an added case is the next silent regression.
  */
-function scanPathExpressions(src, hereDepth, fileSegs = null) {
+function scanPathExpressions(src, hereDepth, fileSegs = null, ownPackageName = null) {
   const known = new Map();
   const escapes = [];
   const files = new Set();
@@ -1154,6 +1299,19 @@ function scanPathExpressions(src, hereDepth, fileSegs = null) {
   const collect = (into, info) => {
     if (info?.segs?.length && !info.vendored) into.add(info.segs.join('/'));
   };
+
+  // The anchor seeds go in FIRST, and they are read by their own balanced pass
+  // rather than by `DECL` below, because `DECL` cannot reach them: it stops an
+  // initialiser at the first `;`, and a `findUp` predicate is a block with
+  // statements in it. Seeding `known` here is what lets every later spelling
+  // compose with an anchor exactly as it composes with an `import.meta.url`
+  // seed -- `join(REPO, 'packages', 'runtime', 'src')` is the ordinary literal
+  // walk once `REPO` has a depth.
+  for (const [name, info] of findUpSeeds(src, hereDepth, fileSegs, ownPackageName)) {
+    known.set(name, info);
+    collect(files, info);
+    report(name, info);
+  }
 
   const DECL = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;\n]+(?:\n\s*[^;\n]*)??)\s*;/g;
   for (const m of src.matchAll(DECL)) {
@@ -1200,8 +1358,8 @@ function scanPathExpressions(src, hereDepth, fileSegs = null) {
  * exported name the `--self-test` shapes and any future reader reach for; the
  * roster half of the same walk is internal to `findEscapingPackages()`.
  */
-export function escapingBindings(src, hereDepth, fileSegs = null) {
-  return scanPathExpressions(src, hereDepth, fileSegs).escapes;
+export function escapingBindings(src, hereDepth, fileSegs = null, ownPackageName = null) {
+  return scanPathExpressions(src, hereDepth, fileSegs, ownPackageName).escapes;
 }
 
 /**
@@ -1229,12 +1387,25 @@ export function repoRelativeLiterals(src) {
   return out;
 }
 
+/**
+ * Memoised, because the anchor seeds (#10029) need it BEFORE the scan rather
+ * than only after it: a `findUp` keyed on a manifest `name` is this package's
+ * root when the literal is this package's name, and some other package's root
+ * -- unnameable from here -- when it is not. Asking per test file re-read the
+ * same manifest once per test in the package; asking per package root does not.
+ */
+const packageNameCache = new Map();
+
 function packageNameOf(pkgRoot) {
+  if (packageNameCache.has(pkgRoot)) return packageNameCache.get(pkgRoot);
+  let name;
   try {
-    return JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).name ?? null;
+    name = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).name ?? null;
   } catch {
-    return null;
+    name = null;
   }
+  packageNameCache.set(pkgRoot, name);
+  return name;
 }
 
 /** Every package with at least one test that reads outside its own directory. */
@@ -1260,9 +1431,13 @@ export function findEscapingPackages() {
       // asserts on synthetic sources with no place in the tree, so it passes
       // none and gets depth-only answers, exactly as before.
       const fileSegs = relative(REPO_ROOT, file).split(sep).filter(Boolean);
-      const scan = scanPathExpressions(src, hereDepth, fileSegs);
-      if (!scan.escapes.length) continue;
+      // Read BEFORE the scan, not after: an anchor seed keyed on a manifest
+      // `name` is only this package's root while the literal is this package's
+      // name, so the scan needs the answer to avoid resolving another package's
+      // anchor to this one's directory (#10029).
       const name = packageNameOf(pkgRoot);
+      const scan = scanPathExpressions(src, hereDepth, fileSegs, name);
+      if (!scan.escapes.length) continue;
       if (!name) continue;
       if (!found.has(name))
         found.set(name, { dir: relative(REPO_ROOT, pkgRoot), tests: [], literals: new Map(), dirEntries: new Set() });
@@ -1343,10 +1518,19 @@ export function findEscapingPackages() {
  * `heldBy` names the escaping test that reads it, and that witness is checked --
  * the named test must still be one of this package's escaping tests. Which is
  * what makes the ablation this limb exists for fail: reseed
- * `managed-extension-fields.test.ts` from `process.cwd()` (a root walk this
- * detector deliberately does not resolve) and it stops being an escaping test at
- * all, so plugin-auth keeps its entry through its second test while
- * `packages/**\/*.object.ts` loses its only witness and is named here.
+ * `managed-extension-fields.test.ts` from a BARE `process.cwd()` and it stops
+ * being an escaping test at all, so plugin-auth keeps its entry through its
+ * second test while `packages/**\/*.object.ts` loses its only witness and is
+ * named here.
+ *
+ * ⚠️ "Bare" is load-bearing since #10029, and this sentence used to say
+ * `process.cwd()` was "a root walk this detector deliberately does not
+ * resolve". Half of that is now false: the `findUp` ANCHOR seeds -- which is
+ * how plugin-auth actually spells a cwd walk -- DO resolve, so reseeding that
+ * way leaves the test escaping and ablates nothing. It is the unadorned
+ * `process.cwd()` expression, with no recognised anchor predicate on it, that
+ * still resolves to nothing. Reach for the wrong one and this limb reads as
+ * healthy while nothing was measured.
  *
  * A rostered DIRECTORY is asked with `coversDirectory` against this glob ALONE,
  * the same predicate the coverage limb uses -- so two globs that only jointly
@@ -1767,6 +1951,157 @@ function selfTest() {
   ok(
     'does NOT flag the bare file expression itself (it names its own file)',
     !at("const SELF = fileURLToPath(import.meta.url);\nconst C = readFileSync(SELF, 'utf8');", 2),
+  );
+
+  // ── the ANCHOR seeds (#10029) ──────────────────────────────────────────────
+  //
+  // A `findUp` walk from `process.cwd()`, which is how a CJS-typed package
+  // reaches its own root when `import.meta` is a TS1470 there. Until these
+  // cases existed the walk resolved to nothing, so every path built on it
+  // resolved to nothing too and the reads went undeclared SILENTLY -- measured
+  // on `19f98fa1f^` against `rate-limit-storage-isolation.test.ts`, which read
+  // two other packages by directory and appeared in no roster while turbo
+  // replayed a cached green over it.
+  //
+  // ⚠️ Today's `findUp` population is CLEAN (the three surviving plugin-auth
+  // tests read in-package or vendored), so no gate turns red from this and none
+  // turns newly green either. That makes these cases the only proof there is:
+  // each one below fails on a detector without `findUpSeeds()`. The two that
+  // pin a NAME are the load-bearing pair -- a case asserting only "it does not
+  // flag" passes just as happily on a seed that resolved to NOTHING, which is
+  // precisely the bug.
+  const FIND_UP_FN =
+    'function findUp(predicate: (dir: string) => boolean, what: string): string {\n' +
+    '  let dir = process.cwd();\n' +
+    '  for (;;) {\n' +
+    '    if (predicate(dir)) return dir;\n' +
+    '    const parent = dirname(dir);\n' +
+    '    if (parent === dir) throw new Error(`could not locate ${what}`);\n' +
+    '    dir = parent;\n' +
+    '  }\n' +
+    '}\n';
+  // Verbatim from `packages/plugins/plugin-auth/src/*.test.ts` — a predicate
+  // BLOCK with statements in it, which is why `DECL` cannot read these and
+  // `findUpSeeds()` balances the parens itself.
+  const PKG_SEED =
+    'const PKG = findUp((dir) => {\n' +
+    "  const manifest = join(dir, 'package.json');\n" +
+    '  if (!existsSync(manifest)) return false;\n' +
+    "  const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };\n" +
+    "  return name === '@objectstack/plugin-auth';\n" +
+    "}, 'the @objectstack/plugin-auth package root');\n";
+  const REPO_SEED =
+    'const REPO = findUp(\n' +
+    "  (dir) => existsSync(join(dir, 'pnpm-workspace.yaml')),\n" +
+    "  'the workspace root (pnpm-workspace.yaml)',\n" +
+    ');\n';
+  // `packages/plugins/plugin-auth/src/x.test.ts` — one directory below its
+  // package root, whose own root is 3 segments below the repo root.
+  const PA = ['packages', 'plugins', 'plugin-auth', 'src', 'x.test.ts'];
+  const PA_NAME = '@objectstack/plugin-auth';
+  const anchorEscapes = (src) => escapingBindings(src, 1, PA, PA_NAME).length > 0;
+  const anchorFiles = (src) => [...scanPathExpressions(src, 1, PA, PA_NAME).files];
+  const anchorDirs = (src) => [...scanPathExpressions(src, 1, PA, PA_NAME).dirs];
+
+  // ⭐ The #10029 specimen, reconstructed: the exact read that was invisible.
+  const RATE_LIMIT_SHAPE =
+    FIND_UP_FN +
+    REPO_SEED +
+    "const abs = join(REPO, 'packages/runtime/src');\n" +
+    'for (const entry of readdirSync(abs, { recursive: true, withFileTypes: true })) {\n}\n';
+  ok('flags a directory read off a workspace-root anchor (the #10029 specimen)', anchorEscapes(RATE_LIMIT_SHAPE));
+  ok(
+    'and NAMES the directory it read, so a narrow glob can be checked against it',
+    anchorDirs(RATE_LIMIT_SHAPE).includes('packages/runtime/src'),
+  );
+  ok(
+    'the workspace-root anchor escapes on its own, like resolve(HERE, $DOTDOTS) already does',
+    anchorEscapes(FIND_UP_FN + REPO_SEED),
+  );
+  ok(
+    'a segment-by-segment join off the anchor resolves the same way',
+    anchorFiles(FIND_UP_FN + REPO_SEED + "const G = join(REPO, 'scripts', 'check-nul-bytes.mjs');").includes(
+      'scripts/check-nul-bytes.mjs',
+    ),
+  );
+
+  // The package-root anchor. Its whole point is that it does NOT escape, so the
+  // name is what proves it resolved at all — this is the `better-auth-schema-parity`
+  // shape, which triage measured in-package and which must stay quiet for the
+  // RIGHT reason.
+  const IN_PACKAGE_SHAPE = FIND_UP_FN + PKG_SEED + "const source = readFileSync(join(PKG, 'src', 'auth-manager.ts'), 'utf8');";
+  ok('does NOT flag a package-root anchor read that stays inside the package', !anchorEscapes(IN_PACKAGE_SHAPE));
+  ok(
+    '⭐ and resolves that anchor to THIS package root — the case a bare "does not flag" would pass without the seed',
+    anchorFiles(IN_PACKAGE_SHAPE).includes('packages/plugins/plugin-auth/src/auth-manager.ts'),
+  );
+  ok(
+    'flags a climb OUT of the package off the package-root anchor',
+    anchorEscapes(FIND_UP_FN + PKG_SEED + "const G = join(PKG, '..', '..', '..', 'scripts', 'check-nul-bytes.mjs');"),
+  );
+  ok(
+    'and names it',
+    anchorFiles(FIND_UP_FN + PKG_SEED + "const G = join(PKG, '..', '..', '..', 'scripts', 'check-nul-bytes.mjs');").includes(
+      'scripts/check-nul-bytes.mjs',
+    ),
+  );
+  ok(
+    'a vendored read off the anchor stays invisible (member-role-canonical: no glob can hash node_modules)',
+    !anchorEscapes(
+      FIND_UP_FN +
+        PKG_SEED +
+        "const require_ = createRequire(join(PKG, 'probe.js'));\n" +
+        "const VENDOR_DIST = dirname(require_.resolve('better-auth'));\n" +
+        "const SRC = readFileSync(join(VENDOR_DIST, 'plugins', 'organization', 'routes', 'crud-members.mjs'), 'utf8');",
+    ),
+  );
+
+  // ⛔ The boundary, pinned in both directions. A manifest name that is not this
+  // package's names a root this scan cannot locate, so it keeps the escape
+  // verdict and loses the name — the same trade an unreadable `join()` argument
+  // makes. Inventing this package's root for it would put a file nobody reads on
+  // the roster AND hide a real escape behind a depth of 0.
+  const FOREIGN_SEED =
+    'const OTHER = findUp((dir) => {\n' +
+    "  const manifest = join(dir, 'package.json');\n" +
+    '  if (!existsSync(manifest)) return false;\n' +
+    "  const { name } = JSON.parse(readFileSync(manifest, 'utf8')) as { name?: string };\n" +
+    "  return name === '@objectstack/core';\n" +
+    "}, 'the @objectstack/core package root');\n";
+  ok(
+    'flags an anchor keyed on ANOTHER package manifest',
+    anchorEscapes(FIND_UP_FN + FOREIGN_SEED + "const S = readFileSync(join(OTHER, 'src', 'x.ts'), 'utf8');"),
+  );
+  ok(
+    'but names nothing for it — no fabricated roster entry',
+    !anchorFiles(FIND_UP_FN + FOREIGN_SEED + "const S = readFileSync(join(OTHER, 'src', 'x.ts'), 'utf8');").some((p) =>
+      p.endsWith('x.ts'),
+    ),
+  );
+  // The published set is the whole claim: a predicate outside it yields NO seed,
+  // which is the pre-#10029 silence and is stated rather than discovered later.
+  ok(
+    'an unrecognised anchor predicate yields no seed (stated boundary, not a bug)',
+    !anchorEscapes(
+      FIND_UP_FN +
+        "const ROOT = findUp((dir) => existsSync(join(dir, 'turbo.json')), 'the turbo root');\n" +
+        "const G = join(ROOT, 'packages/runtime/src');\n" +
+        'const names = readdirSync(G);',
+    ),
+  );
+  // ⚠️ An anchor names an ABSOLUTE directory, so unlike every seed above it it
+  // cannot be placed in the depth coordinate without knowing where the file
+  // sits. A caller with no repo context gets no seed rather than a guessed one.
+  ok(
+    'an anchor yields nothing to a depth-only caller (no fileSegs, no guess)',
+    escapingBindings(FIND_UP_FN + REPO_SEED + "const G = join(REPO, 'packages/runtime/src');", 1).length === 0,
+  );
+  // A bare `process.cwd()` with no recognised predicate on it still resolves to
+  // nothing — the ablation `globHolderVerdict()` documents depends on it, and
+  // #10029 is the reason that sentence now says BARE.
+  ok(
+    'a bare process.cwd() walk is still unresolved',
+    !anchorEscapes("const ROOT = process.cwd();\nconst G = readFileSync(join(ROOT, 'packages/runtime/src/x.ts'), 'utf8');"),
   );
 
   // ── The radius roster, reconstructed rather than quoted (#9763) ────────────


### PR DESCRIPTION
Fixes #10029 — direction **B**, the residual scope the 2026-08-20 `pm:retriage` ruling retargeted this card to. Direction A landed separately as PR #10161 and is not revisited here.

## The class, not the instance

`check:cross-package-test-inputs` finds escaping tests by **scanning source text** — deliberately, so a dependency-free detector cannot itself fail to resolve in CI. The price is that it sees only the spellings it knows, and its own header states the consequence: *"A path written any other way yields no flag — which means no declaration, silently."*

Every seed it knew answers **"where am I?"** off the module itself: `import.meta.url`, `__dirname`, `import.meta.dirname`, `dirname(import.meta.filename)`, and the walked `import.meta.url`/`.filename` forms — five spellings, all file-relative.

A CJS-typed package cannot ask that question. `packages/plugins/plugin-auth` publishes `dist/index.js` as CommonJS, so under `module: NodeNext` `import.meta` is a TS1470 there however well it runs under vitest. Four of its tests therefore walk **up from `process.cwd()`** to an anchor instead — its own `package.json`, or the workspace root. That walk resolved to nothing, so every path built on it resolved to nothing too: no depth, no name, **no flag**.

Measured on `19f98fa1f^`, not reasoned: `rate-limit-storage-isolation.test.ts` read `packages/runtime/src` and `packages/services/service-sms/src` through such a seed, appeared in **no** roster, and turbo replayed a cached green over the scan it never re-ran — #7802 exactly, by a fourth spelling. PR #10161 reseeded that **one file** from `__dirname`. This closes the **class** it was an instance of.

## What `findUpSeeds()` resolves

Two predicates are knowable without executing anything, and they are the two the idiom uses:

| predicate | resolves to | escapes on its own? |
|---|---|---|
| manifest `name` === **this** package's name | the package root — depth 0, **named** | no |
| a `WORKSPACE_ROOT_MARKERS` file (`pnpm-workspace.yaml`) | the repo root, `pkgSegs.length` above the package root | **yes** — exactly as `resolve(HERE, '../../..')` already does |
| manifest `name` === some **other** package | outside this package for certain, locatable only by walking the tree | **yes**, and **no name is invented** |

That last row is the trade `walkLiteral` already makes for an unreadable `join()` argument: keep the escape verdict, drop the name. Resolving it to *this* package's root instead would do both kinds of damage at once — a roster entry pointing at a file nobody reads, and a real escape hidden behind a depth of 0.

Two things are new in kind, and both are stated in the header rather than left to be discovered:

- **An anchor names an ABSOLUTE directory.** Every other spelling is relative to the file, so it resolves in the depth coordinate on its own. An anchor cannot be placed there until you know where the file sits — so it arrives only with `fileSegs`, and a caller with none (the depth-only `--self-test` shapes) gets **no seed rather than a guessed one**.
- **`DECL` cannot read these.** It stops an initialiser at the first `;`, and a `findUp` predicate is a *block with statements in it*. So the seeds are read by their own balanced pass and injected into `known` **first**, after which every later spelling composes with an anchor exactly as it composes with an `import.meta.url` seed — `join(REPO, 'packages', 'runtime', 'src')` is the ordinary literal walk once `REPO` has a depth.

`balancedArgs()` is **extracted** from `readArgumentLists` rather than written a second time beside it. A mirrored helper is the shape #10628 already had to undo in this file once.

## ⭐ The evidence cannot be "a gate turned green"

Triage measured today's `findUp` population **clean**, and re-measurement on this branch's base confirms it. So this lands with **no gate turning red and none turning newly green** — which makes the `--self-test` the only proof there is.

Both real-tree outputs are **byte-identical** before and after the change (`diff` of the captured logs, exit 0):

```
node scripts/check-cross-package-test-inputs.mjs --list-escapes   ->  identical (61 test rows, 13 packages)
node scripts/check-cross-package-test-inputs.mjs --verify         ->  identical
```

### The ablation

`findUpSeeds()` was neutered with an early `return seeds;` — confirmed **on disk**, not by an editor's exit code: the injected marker went `0 -> 1` occurrences, the anchor text stayed at `1`, and `git hash-object` moved `529ca9d6…` -> `500566b5…`.

**Predicted before running:** the 8 presence-asserting cases fail; the 6 absence-asserting ones stay green; `--verify` stays exit 0 on both legs.

**Observed: 8 of 104 failed, and they are exactly the 8 enumerated** —

```
FAIL flags a directory read off a workspace-root anchor (the #10029 specimen)
FAIL and NAMES the directory it read, so a narrow glob can be checked against it
FAIL the workspace-root anchor escapes on its own, like resolve(HERE, $DOTDOTS) already does
FAIL a segment-by-segment join off the anchor resolves the same way
FAIL ⭐ and resolves that anchor to THIS package root — the case a bare "does not flag" would pass without the seed
FAIL flags a climb OUT of the package off the package-root anchor
FAIL and names it
FAIL flags an anchor keyed on ANOTHER package manifest
```

The second observation is the one worth keeping: **under the same ablation `--verify` over the real tree still printed `OK` and exited 0.** Today's population has nothing for it to catch, so the self-test is the only thing holding this rule — which is why the two cases that pin a **NAME** are load-bearing. A case asserting only *"it does not flag"* passes just as happily on a seed that resolved to **nothing**, which is precisely the bug.

**No rebuild was needed, and that is a property of the file rather than an assumption:** this gate is a dependency-free `.mjs` invoked as `node scripts/check-cross-package-test-inputs.mjs`, whose only import is the sibling `./invoked-as.mjs` by relative path. Nothing on its path resolves through any package's `exports` or `dist/`, so no stale build can mask either leg.

Restored and re-measured: marker `1 -> 0`, `git hash-object` back to `529ca9d64fe0405558b9fc9795388598a423670f` — **byte-identical** — worktree clean, self-test back to `All 104 self-test cases passed.` / exit 0.

## Verification

Gate union derived with `node scripts/pm/dispatch-gates.mjs` (no paths passed — it reads the merge-base changeset itself) **after** the final commit on a clean worktree, at `git rev-parse --short HEAD` = **`5157cf58fe`**. It named 3 families for this surface; every one was run. Each exit code captured **before** any pipe, and each row quotes the gate's **own** verdict line.

| command | exit | the gate's own verdict line |
|---|---|---|
| `node scripts/check-cross-package-test-inputs.mjs --self-test` | 0 | `All 104 self-test cases passed.` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 13 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `node scripts/check-ci-filter-parity.mjs --self-test` | 0 | `✓ check-ci-filter-parity --self-test: 36 assertions — …` |
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 82 declared cross-package glob(s) (71 unique) are covered by core or crosspkg, every crosspkg entry still covers one, and the test job's if: still names both filters.` |

Plus the two families `dispatch-gates` is structurally blind to — **run by hand, because this diff is exactly their file surface**:

| command | exit | the gate's own verdict line |
|---|---|---|
| `node scripts/check-entry-guard.mjs --self-test` | 0 | `✓ check-entry-guard self-test: 47 cases pass — …` |
| `node scripts/check-entry-guard.mjs` | 0 | `✓ check:entry-guard: 128 scripts/ file(s) — every entry guard goes through invoked-as.mjs; 86 export bindings, 76 of them inert on import (10 known-unsafe, ⛔ SHRINK-ONLY).` |
| `node scripts/check-parse-guard.mjs --self-test` | 0 | `✓ check:parse-guard self-test: 41 cases pass …` |
| `node scripts/check-parse-guard.mjs` | 0 | (clean) |
| `node scripts/check-nul-bytes.mjs --self-test` | 0 | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)` |
| `node scripts/check-nul-bytes.mjs` | 0 | `check-nul-bytes: OK (scanned 6266 text file(s) -- 6266 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes)` |

`dispatch-gates` names both blind spots itself and agrees on the reason: `check:parse-guard` is listed under *"unreachable BY CONSTRUCTION — `scripts`: the tree HAS it; the covering rule refuses the literal as too generic (no path separator)"*, and `check:entry-guard` never appears at all because it reads its population off `KNOWN_IMPORT_UNSAFE`, a roster of current violators.

Control bytes swept beyond the gate, **with its counter-check** so a zero is not a silent no-op: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the changed file yields **0**, while the same pattern over a deliberate BEL fixture yields **1**.

## Notes

- **No changeset:** gate tooling publishes nothing and this diff contains no TypeScript. `skip-changeset` applied additively (`POST /issues/N/labels`), following PR #10801's precedent on this same file.
- **`packages/plugins/plugin-auth/src/managed-extension-fields.test.ts` is untouched** — it is plugin-auth's only gate-visible escaping read and carries that package's declared radius by itself.
- **`CROSS_PACKAGE_TEST_INPUTS` and `turbo.json` are untouched.** No declaration changes; this is detector-only.
- **One prose correction inside this file, and it is load-bearing.** `globHolderVerdict()`'s docblock told the next reader to ablate that limb by reseeding from `process.cwd()`, calling it *"a root walk this detector deliberately does not resolve"*. Half of that is now false: the `findUp` anchor form — which is how plugin-auth actually spells a cwd walk — **does** resolve, so reseeding that way would leave the test escaping and ablate nothing, while the limb read as healthy. The sentence now says **bare** `process.cwd()`, and a `--self-test` case pins that the bare form is still unresolved.

_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_