### PR TITLE
fix(plugin-auth): answer a registered ADR-0112 code from the SSO domain-verification routes

### DIFF
--- a/.changeset/sso-domain-verification-error-code-casing.md
+++ b/.changeset/sso-domain-verification-error-code-casing.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+The two SSO domain-verification admin routes now answer a registered ADR-0112
+error code. `POST /admin/sso/request-domain-verification` and
+`POST /admin/sso/verify-domain` shape their failure as
+`code: parsed?.code || <our default>`, and the default half — the code
+ObjectStack itself authors when @better-auth/sso returns none — was lowercase
+(#10716, found by #10658):
+
+| route | wrote | writes instead |
+| --- | --- | --- |
+| `POST /admin/sso/request-domain-verification` | `request_domain_verification_failed` | `DOMAIN_VERIFICATION_FAILED` |
+| `POST /admin/sso/verify-domain` | `verify_domain_failed` | `DOMAIN_VERIFICATION_FAILED` |
+
+If you match on either lowercase spelling, match on `DOMAIN_VERIFICATION_FAILED`
+instead — the two routes are distinguished by their path, as they already were
+for every other failure they can answer.
+
+`DOMAIN_VERIFICATION_FAILED` is reused, not invented: it is already registered
+for `@objectstack/plugin-auth` in the error-code ledger, so this PR adds nothing
+to `packages/spec` and the emitted vocabulary gets no new member. A new spelling
+(`VERIFY_DOMAIN_FAILED`) would have needed a ledger registration to be a legal
+`error.code` at all, and — measured while fixing this — an unregistered code in
+an `||` fallback slot is currently invisible to BOTH error-code gates, so it
+would have shipped as exactly the silent fourth state ADR-0112 D3 exists to
+prevent.
+
+**The vendor pass-through arm is unchanged.** `parsed?.code` still reaches the
+caller verbatim, so @better-auth/sso's own diagnosis (`NO_PENDING_VERIFICATION`,
+`DOMAIN_VERIFICATION_FAILED`) is never overwritten by ours — the half that would
+be silently lost by a handler that stamped our code unconditionally, and it is
+pinned in both directions by
+`packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts`.
+Statuses and messages are untouched on every path.
+
+ADR-0087 disposition, in prose because the marker vocabulary has no slot for
+this shape: nothing is registered and nothing needs to be. The declared wire
+contract is `error.code ∈ StandardErrorCode ∪ ERROR_CODE_LEDGER`, and neither
+lowercase spelling was ever a member of it — they were undeclared values a
+blind gate let through, so this brings the implementation onto the published
+contract rather than changing that contract. There is no metadata surface for
+`objectstack migrate meta` to rewrite: error codes live in responses, not in
+stored metadata. The table above is here for anyone who matched the undeclared
+spelling anyway, which is why this ships as `minor` rather than `patch`.

--- a/packages/plugins/plugin-auth/src/register-sso-provider.ts
+++ b/packages/plugins/plugin-auth/src/register-sso-provider.ts
@@ -408,7 +408,11 @@ export async function runRequestDomainVerification(
     if (resp.status === 404 && !parsed?.code) {
       return { status: 400, body: { success: false, error: { code: 'DOMAIN_VERIFICATION_DISABLED', message: 'Domain verification is not enabled for this environment (set OS_SSO_DOMAIN_VERIFICATION).' } } };
     }
-    return { status: resp.status, body: { success: false, error: { code: parsed?.code || 'request_domain_verification_failed', message: parsed?.message || 'Failed to request domain verification' } } };
+    // ADR-0112: `parsed?.code` is better-auth's own code passing through — never
+    // overwritten. The DEFAULT is ours, so it is the registered SCREAMING ledger
+    // entry for this feature (`DOMAIN_VERIFICATION_FAILED`, @objectstack/plugin-auth)
+    // rather than a bespoke lowercase spelling (#10716).
+    return { status: resp.status, body: { success: false, error: { code: parsed?.code || 'DOMAIN_VERIFICATION_FAILED', message: parsed?.message || 'Failed to request domain verification' } } };
   }
 
   const token = str(parsed?.domainVerificationToken);
@@ -462,5 +466,8 @@ export async function runVerifyDomain(
   } else if (parsed?.code === 'DOMAIN_VERIFICATION_FAILED') {
     message = 'DNS TXT record not found yet. Add the record shown when you requested verification, allow time for DNS to propagate, then retry.';
   }
-  return { status: resp.status, body: { success: false, error: { code: parsed?.code || 'verify_domain_failed', message } } };
+  // ADR-0112, as above: the vendor's code passes through untouched; our default
+  // is the registered ledger entry (#10716). The `message` above still carries
+  // the specific diagnosis for each expected failure mode.
+  return { status: resp.status, body: { success: false, error: { code: parsed?.code || 'DOMAIN_VERIFICATION_FAILED', message } } };
 }

--- a/packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts
+++ b/packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #10716 — the two SSO domain-verification routes answer an ADR-0112 error code.
+ *
+ * Both handlers shape their failure as `code: parsed?.code || <our default>`,
+ * and the two halves of that expression have DIFFERENT owners:
+ *
+ *   - `parsed?.code` is @better-auth/sso's own code passing through. It is the
+ *     vendor's diagnosis and must reach the caller unchanged.
+ *   - the default is OURS, so ADR-0112 applies to it: SCREAMING_SNAKE, drawn
+ *     from the registered vocabulary rather than invented at the call site.
+ *
+ * Both directions are pinned below, and that pairing is the point. Pinning only
+ * "our code appears" would go green against a handler that overwrites the
+ * vendor's code unconditionally — which would swallow exactly the diagnosis the
+ * caller needs (`NO_PENDING_VERIFICATION` tells them to request the DNS record
+ * first; a blanket "verification failed" does not). Statuses are pinned in both
+ * directions too: the inner status passes through untouched.
+ *
+ * Rejection cases assert `code` AND `status` per ADR-0112 — a bare "it threw"
+ * would pass against a handler that refuses everyone.
+ */
+
+import { describe, it, expect } from 'vitest';
+// The `/api` subpath is where the built package exposes the ledger VALUE — the
+// root entry re-exports the schemas only. Reading it through the published
+// exports map (i.e. `dist`) is deliberate: this asserts against the surface a
+// consumer actually gets, not against a source file this test could reach.
+import { ERROR_CODE_LEDGER } from '@objectstack/spec/api';
+import { runRequestDomainVerification, runVerifyDomain, type AuthRequestHandler } from './register-sso-provider.js';
+
+/** The default this package authors for both routes when the vendor gives no code. */
+const OUR_DEFAULT = 'DOMAIN_VERIFICATION_FAILED';
+/** A vendor code with its own meaning — the one an overwrite would destroy. */
+const VENDOR_CODE = 'NO_PENDING_VERIFICATION';
+
+const REQUEST_URL = 'https://app.example/api/v1/auth/admin/sso/request-domain-verification';
+const VERIFY_URL = 'https://app.example/api/v1/auth/admin/sso/verify-domain';
+
+/** A fake inner @better-auth/sso endpoint that answers one canned response. */
+function fakeHandle(status: number, body: unknown): AuthRequestHandler {
+  return async () =>
+    new Response(body === undefined ? '' : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+const post = (url: string) =>
+  new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ providerId: 'p1', domain: 'acme.example' }),
+  });
+
+describe('#10716 SSO domain verification — our default is a registered ADR-0112 code', () => {
+  it('request-domain-verification: an uncoded vendor failure answers our SCREAMING default, status passed through', async () => {
+    const res = await runRequestDomainVerification(fakeHandle(502, { message: 'upstream exploded' }), post(REQUEST_URL));
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error?.code).toBe(OUR_DEFAULT);
+    expect(res.status).toBe(502);
+  });
+
+  it('verify-domain: an uncoded vendor failure answers our SCREAMING default, status passed through', async () => {
+    // The 404-without-a-code shape: SSO domain verification is off for this env.
+    // This is the response the dogfood admin-route probe observes.
+    const res = await runVerifyDomain(fakeHandle(404, undefined), post(VERIFY_URL));
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error?.code).toBe(OUR_DEFAULT);
+    expect(res.status).toBe(404);
+  });
+
+  it('both defaults are SCREAMING_SNAKE and registered for this package — reused, not invented', () => {
+    expect(OUR_DEFAULT).toMatch(/^[A-Z][A-Z0-9_]*$/);
+    // The mechanical half of "we reused a ledger entry": if this code were a new
+    // spelling it would need a `packages/spec` registration, and an unregistered
+    // code in a fallback slot is invisible to BOTH error-code gates — a silent
+    // fourth state, which is precisely what ADR-0112 D3 exists to prevent.
+    expect(ERROR_CODE_LEDGER['@objectstack/plugin-auth']).toContain(OUR_DEFAULT);
+  });
+});
+
+describe('#10716 the vendor pass-through arm is untouched', () => {
+  it('request-domain-verification: the vendor code and status reach the caller unchanged', async () => {
+    const res = await runRequestDomainVerification(
+      fakeHandle(400, { code: VENDOR_CODE, message: 'vendor copy' }),
+      post(REQUEST_URL),
+    );
+
+    expect(res.body.error?.code).toBe(VENDOR_CODE);
+    expect(res.body.error?.code).not.toBe(OUR_DEFAULT);
+    expect(res.status).toBe(400);
+    expect(res.body.error?.message).toBe('vendor copy');
+  });
+
+  it('verify-domain: the vendor code and status reach the caller unchanged', async () => {
+    const res = await runVerifyDomain(fakeHandle(400, { code: VENDOR_CODE, message: 'vendor copy' }), post(VERIFY_URL));
+
+    expect(res.body.error?.code).toBe(VENDOR_CODE);
+    expect(res.body.error?.code).not.toBe(OUR_DEFAULT);
+    expect(res.status).toBe(400);
+    // This route substitutes friendlier COPY for known vendor codes — the code
+    // itself still passes through, which is the half that matters on the wire.
+    expect(res.body.error?.message).toContain('Request Domain Verification');
+  });
+
+  it('request-domain-verification: the disabled branch keeps its own dedicated code', async () => {
+    // Unchanged by #10716 and pinned so the rename cannot have blurred the two:
+    // "the feature is off" is a different answer from "verification failed".
+    const res = await runRequestDomainVerification(fakeHandle(404, undefined), post(REQUEST_URL));
+
+    expect(res.body.error?.code).toBe('DOMAIN_VERIFICATION_DISABLED');
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/qa/dogfood/test/admin-route-nonadmin-refusal.dogfood.test.ts
+++ b/packages/qa/dogfood/test/admin-route-nonadmin-refusal.dogfood.test.ts
@@ -249,7 +249,7 @@ function expectationsFor(targetUserId: string): Record<string, RouteExpectation>
     'POST /api/v1/auth/admin/sso/verify-domain': {
       bucket: 'objectstack-gate',
       body: { providerId: 'refusal-probe-oidc' },
-      note: 'admin passes the gate and lands on 404 verify_domain_failed while SSO is off',
+      note: 'admin passes the gate and lands on 404 DOMAIN_VERIFICATION_FAILED while SSO is off',
     },
 
     // ── #9652: ban / unban moved from the vendor to an ObjectStack mount ────

--- a/scripts/check-error-code-casing.mjs
+++ b/scripts/check-error-code-casing.mjs
@@ -162,27 +162,28 @@ const CODE_POSITION_PATTERNS = [
  * an allowlist nobody re-reads. A NEW lowercase code never joins it: the gate
  * refuses that, and the remedy for a fresh finding is a registered SCREAMING
  * code, never a line here.
+ *
+ * [#10716] It is now EMPTY, and that is this list reaching its designed end
+ * rather than a list that never had a use: both entries it was created for
+ * (`request_domain_verification_failed`, `verify_domain_failed`) were renamed
+ * onto the registered ledger code `DOMAIN_VERIFICATION_FAILED` by the services
+ * lane, and the owning PR deleted them here — the coordination #10658 asked
+ * for, so the gate ends up green with zero exceptions. Emptiness costs no
+ * coverage: --self-test drives the shrink-only semantics against a FIXTURE
+ * registry, and pins the live one AT zero so a future exception cannot be
+ * added quietly.
  */
-const KNOWN_LOWERCASE_CODES = new Map([
-  [
-    'packages/plugins/plugin-auth/src/register-sso-provider.ts::request_domain_verification_failed',
-    'wire-visible; rename owned by #10716 (services lane)',
-  ],
-  [
-    'packages/plugins/plugin-auth/src/register-sso-provider.ts::verify_domain_failed',
-    'wire-visible; rename owned by #10716 (services lane); pinned by name in the dogfood suite',
-  ],
-]);
+const KNOWN_LOWERCASE_CODES = new Map([]);
 
 /** Split findings into the two the wire already carries and everything else. */
-export function partitionKnown(violations) {
+export function partitionKnown(violations, registry = KNOWN_LOWERCASE_CODES) {
   const known = [];
   const fresh = [];
   for (const v of violations) {
-    (KNOWN_LOWERCASE_CODES.has(`${v.file}::${v.literal}`) ? known : fresh).push(v);
+    (registry.has(`${v.file}::${v.literal}`) ? known : fresh).push(v);
   }
   const reached = new Set(known.map((v) => `${v.file}::${v.literal}`));
-  const stale = [...KNOWN_LOWERCASE_CODES.keys()].filter((k) => !reached.has(k)).sort();
+  const stale = [...registry.keys()].filter((k) => !reached.has(k)).sort();
   return { known, fresh, stale };
 }
 
@@ -302,8 +303,19 @@ function selfTest() {
   // [#10658] The shrink-only registry, in both directions. The second one is
   // the load-bearing half: when the owning card's rename lands, a stale line
   // must FAIL rather than sit there as a quiet allowlist entry.
+  //
+  // [#10716] These drive a FIXTURE registry rather than the live one, which is
+  // now empty. The semantics being pinned belong to the MECHANISM (an entry
+  // that stops matching is stale and fails; a new code is never absorbed), and
+  // they have to survive the live list reaching zero — otherwise emptying it
+  // would have silently taken the coverage with it. The live list gets its own
+  // assertion below.
   const SSO = 'packages/plugins/plugin-auth/src/register-sso-provider.ts';
   const row = (literal) => ({ file: SSO, line: 1, literal, form: 'fallback' });
+  const fixtureRegistry = new Map([
+    [`${SSO}::request_domain_verification_failed`, 'fixture — the shape the live list had before #10716'],
+    [`${SSO}::verify_domain_failed`, 'fixture — the shape the live list had before #10716'],
+  ]);
   const partitionCases = [
     [[row('request_domain_verification_failed'), row('verify_domain_failed')], { known: 2, fresh: 0, stale: 0 }, 'both known rows still present'],
     [
@@ -315,7 +327,7 @@ function selfTest() {
     [[], { known: 0, fresh: 0, stale: 2 }, 'an empty tree makes every entry stale'],
   ];
   for (const [input, want, label] of partitionCases) {
-    const got = partitionKnown(input);
+    const got = partitionKnown(input, fixtureRegistry);
     const shape = { known: got.known.length, fresh: got.fresh.length, stale: got.stale.length };
     if (shape.known !== want.known || shape.fresh !== want.fresh || shape.stale !== want.stale) {
       console.error(`  ✗ self-test "${label}": expected ${JSON.stringify(want)}, got ${JSON.stringify(shape)}`);
@@ -323,12 +335,24 @@ function selfTest() {
     }
   }
 
+  // [#10716] The live registry, at zero. It is closed to new entries by the rule
+  // above, so "closed" is checked rather than merely written down: a wire-visible
+  // code that genuinely needs deferring is a call for the ADR-0112 owner to make
+  // in the open, not a line someone adds back here on the way past.
+  if (KNOWN_LOWERCASE_CODES.size !== 0) {
+    console.error(
+      `  ✗ self-test "the live registry stays empty": KNOWN_LOWERCASE_CODES holds ${KNOWN_LOWERCASE_CODES.size} entry/entries — ` +
+        `this list is closed (#10658/#10716); a new deferral is an ADR-0112 decision, not a line here.`,
+    );
+    failed++;
+  }
+
   if (failed) {
     console.error(`\n✗ check-error-code-casing self-test failed (${failed} case(s)).`);
     process.exit(1);
   }
   console.log(
-    `✓ check-error-code-casing self-test: ${cases.length} recognizer case(s) + ${partitionCases.length} registry case(s) pass.`,
+    `✓ check-error-code-casing self-test: ${cases.length} recognizer case(s) + ${partitionCases.length + 1} registry case(s) pass.`,
   );
 }
 


### PR DESCRIPTION
Fixes #10716

## What

`packages/plugins/plugin-auth/src/register-sso-provider.ts` shapes both SSO
domain-verification failures as `code: parsed?.code || OUR_DEFAULT`. The two
halves have different owners, and only one of them is ours:

- `parsed?.code` — @better-auth/sso's own code, passing through. **Untouched by this PR.**
- the default — authored by ObjectStack, so ADR-0112 D1 applies to it. Both were lowercase.

Reproduced on this branch at base `5f2e54cc6` before editing (the card measured them at `47aff0938`):

| line | was | is |
| --- | --- | --- |
| 411 | `parsed?.code \|\| 'request_domain_verification_failed'` | `parsed?.code \|\| 'DOMAIN_VERIFICATION_FAILED'` |
| 465 | `parsed?.code \|\| 'verify_domain_failed'` | `parsed?.code \|\| 'DOMAIN_VERIFICATION_FAILED'` |

## The ledger question: reused, not registered — and `packages/spec` is untouched

`DOMAIN_VERIFICATION_FAILED` is **already registered** for `@objectstack/plugin-auth`
in `packages/spec/src/api/error-code-ledger.zod.ts:341`. Nothing is added to the
vocabulary and this PR touches no spec file.

The alternative — registering `REQUEST_DOMAIN_VERIFICATION_FAILED` /
`VERIFY_DOMAIN_FAILED`, a pure casing rename preserving every current
distinction — needs a `packages/spec` ledger entry, which is outside this lane.
It is written up as an open question below rather than decided here, because a
wire value should break **once**: this PR is draft and `needs:contract-review`
precisely so that choice can be redirected before it lands.

**Measured, not assumed** — why an unregistered SCREAMING spelling was not an option:

```
probe: both literals renamed to REQUEST_DOMAIN_VERIFICATION_FAILED / VERIFY_DOMAIN_FAILED
  check-dispatcher-error-vocabulary  -> exit 0, "21 unregistered code-stamping site(s)" (baseline: 21)
positive control: ONE DIRECT unregistered code in the same file
  check-dispatcher-error-vocabulary  -> exit 1, "[unclassified-site] ... stamps unregistered code
                                        'ZZ_POSITIVE_CONTROL_UNREGISTERED' (objlit)", 22 sites found
```

The file is in scan; the gate simply cannot see the fallback slot — the same
blindness #10658 just fixed in the casing gate, filed already as #10762 (I added
this positive control there). So an unregistered code in that slot would have
shipped invisible to **both** error-code gates: the silent fourth state ADR-0112
D3 exists to prevent. Trading a visible casing violation for an invisible
registration violation is not a fix.

## Pins — both directions, because one direction is not a pin

New: `packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts` (6 tests).

| # | direction | assertion |
| --- | --- | --- |
| ① | our default reaches the wire | uncoded vendor failure ⇒ `DOMAIN_VERIFICATION_FAILED`, both routes |
| ② | **vendor pass-through preserved** | vendor `NO_PENDING_VERIFICATION` ⇒ returned unchanged, both routes |
| ③ | statuses unchanged | `resp.status` passes through on every path (502, 404, 400) |
| ④ | reuse is mechanical | the emitted code is `toContain`-ed in `ERROR_CODE_LEDGER['@objectstack/plugin-auth']`, read through the published `@objectstack/spec/api` exports |
| ⑤ | the sibling code is not blurred | request-domain-verification's disabled branch still answers `DOMAIN_VERIFICATION_DISABLED` / 400 |

② is the load-bearing one: a handler that stamped our code unconditionally would
pass ① while destroying the vendor's diagnosis. Proven by ablation, not asserted.

## Ablation

Predictions written before mutating (`ablation-prediction.txt`), both legs run with
**no rebuild**, both restores `git hash-object`-identical to `62e381c3ab93f937281828cc0df1e6bed922b697`:

| leg | mutation | predicted | observed |
| --- | --- | --- | --- |
| A | default reverted to `verify_domain_failed` | 1 fail: "answers our SCREAMING default" | ✅ `expected 'verify_domain_failed' to be 'DOMAIN_VERIFICATION_FAILED'`, 1 failed / 5 passed |
| B | vendor arm dropped (unconditional overwrite) | 1 fail: "vendor code reaches the caller unchanged" | ✅ `expected 'DOMAIN_VERIFICATION_FAILED' to be 'NO_PENDING_VERIFICATION'`, 1 failed / 5 passed |

Both restore legs re-ran 6/6 green. **Resolution is proven, not asserted**: a
`src/`-only edit flipped the result in both directions with no build step, so the
suite reads `src/register-sso-provider.ts`. The ledger half resolves through
`dist` — measured separately: `ERROR_CODE_LEDGER` imported from the package root
`@objectstack/spec` is `undefined`, from `@objectstack/spec/api` it is an object
with 22 owner keys.

## Coordination with #10658 — I landed second

#10658 is **closed**; its gate PR #10760 is **merged**. Its `KNOWN_LOWERCASE_CODES`
registry carried both of my codes, shrink-only, and its own self-test pins that a
landed rename goes STALE and **fails**. Measured on the probe above:

```
✗ 2 stale KNOWN_LOWERCASE_CODES entry/entries:  ... — no longer present
```

So this PR deletes both entries, per the "whichever lands second" agreement. The
gate now reports **zero** exceptions:

```
before: · 2 known lowercase code(s) deferred to their owning card (KNOWN_LOWERCASE_CODES)
after:  · 0 known lowercase code(s) deferred to their owning card (KNOWN_LOWERCASE_CODES)
```

Emptying the list would have taken its self-test coverage with it (all four registry
cases key on the two entries), so the registry is now **injectable** and those cases
drive a fixture map — the shrink-only semantics outlive the live list reaching zero —
plus one new case pinning the live list **at** zero, since the list is closed to new
entries by its own documented rule. Reviewers who consider that pin over-reach for
this lane: say so and I will drop it.

## Dogfood pin (`admin-route-nonadmin-refusal.dogfood.test.ts:252`)

Updated to `DOMAIN_VERIFICATION_FAILED`; expected value only, no refactor.

⚠️ Correction to a premise the card inherited from #10658: that line is a `note:`
string — **documentation, not an assertion**. The bucket loop asserts
`admin.code).not.toBe('PERMISSION_DENIED')` and never reads `note`. So the rename
would not have reddened it; it would have gone quietly wrong. Updating it in this
PR is still right, for the reason the card gave.

⚠️ Known textual overlap with **PR #10800** (card #10349), which holds the
better-auth-gate bucket in this same file. Different region, deliberate on both
sides, whichever lands second resolves it. Not semantic: my edit changes one
string in a route the other PR does not touch.

## Changeset

`minor` for `@objectstack/plugin-auth`, with the FROM → TO table an upgrading
client greps for. **It does not carry a breaking declaration**, and that is a
judgement worth a reviewer's eye — the gate records it in the open:

```
✓ check-adr-0087-registration: this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).
```

Reasoning: the declared wire contract is `error.code ∈ StandardErrorCode ∪ ERROR_CODE_LEDGER`,
and neither lowercase spelling was ever a member — they were undeclared values a
blind gate let through, so this brings the implementation onto the published
contract rather than changing it. Measured support: **zero consumers** of either
spelling anywhere in `objectstack`, `objectui` or `objectos` (outside the emitter,
the gate's own fixtures and that dogfood note).

The honest alternative is not available in this lane, and that is the real reason
to look: declaring breaking obliges exactly one ADR-0087 disposition marker, and
every category is either false here (`unpublished` — plugin-auth is published;
`already-registered` — no such id; `no-migration-prescription` and
`runtime-interface-only` — both refused, since the body carries a FROM → TO
prescription) or requires the `registered` marker naming a migration id, i.e. a
new entry in `packages/spec/src/migrations/registry.ts`. **If contract review
reads this as breaking, this PR cannot carry that alone** — it needs a spec-lane
follow-up before merge. The disposition is written out in prose in the changeset
body meanwhile, so the question is answered in writing even where the marker
vocabulary has no slot for it.

## Verification

Union derived after the final commit on a clean tree, `node scripts/pm/dispatch-gates.mjs`
with no path arguments, at **`d4005cec7`**. Exit codes captured before any pipe.

| gate | verdict line |
| --- | --- |
| `check:error-code-casing` | `✓ no unlisted lowercase error codes in 4369 scanned file(s) (ADR-0112).` + `29 recognizer case(s) + 5 registry case(s) pass` |
| `check:route-envelope` (#10309) | `✓ Plugin-mounted Hono routes — 12 module(s) audited … 8 conformant, 0 ratcheted, 3 exempt, 1 vendor-wire` |
| `check:dispatcher-error-vocabulary` (#10309) | `OK — 21 unregistered code-stamping site(s), all classified; 1 awaiting a ledger entry (#8846).` |
| `check-adr-0087-registration` | `✓ … no declared-breaking changeset (1 non-breaking changeset(s) seen).` |
| `check-changeset-no-major` | ``✓ This diff introduces no `major` bump.`` |
| `check-empty-changeset` | `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check:changeset-gate-self-tests` | `✓ 212 assertions over real temp git repos` + `✓ 116 assertions` |
| `check:cross-package-test-inputs` | `OK: 13 package(s) read outside themselves, all declared` |
| `check:objectui-changeset` | `✓ objectui-changeset-digest --self-test: all checks passed` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) … none new` |
| `check:test-source-alias` | `OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `OK — 76 packages with a tsconfig.json scanned` |
| `check-plugin-teardown-shape` | `✓ 54 Plugin implementation(s) across 4384 source(s)` |
| `check-affected-docs` | `✓ affected-docs self-test: 308 cases pass.` |
| `check:query-options-erasure` | `✓ ratchet holds: 67 unswept non-test site(s) … none new` |
| `check:engine-double-contract` | `OK — 371 pinned, 133 in the DEBT ledger, 2 exempt.` |
| `check:where-matcher` | `✓ conformance holds: 272 matcher(s) discovered` |
| `check:type-check-coverage` | `OK — 64/77 workspace packages type-checked … 13 in the DEBT ledger` |
| `@objectstack/plugin-auth` `test` | `Test Files 64 passed (64) · Tests 1357 passed (1357)` |
| `@objectstack/plugin-auth` `typecheck` | exit 0 |

`check:route-envelope` and `check:dispatcher-error-vocabulary` were **not named by
the derivation** — they were run because the card named the #10309 class, and they
are the two most relevant gates to an error-vocabulary change.

Two **declared narrowings**, both re-run by CI regardless:

- `check:type-check-debt --re-measure` needs the whole workspace built. Instead I
  measured the only thing that could move it: plugin-auth's TEST_DEBT program with
  the `**/*.test.ts` exclusion lifted reports **0** errors naming the new test file,
  so the ratchet cannot drift up. The ledger entry (109) is untouched and `--lower`
  was not run.
- `@objectstack/dogfood` `typecheck` exits 2 with 227 `TS2307 Cannot find module`
  from an unbuilt dependency closure (`@objectstack/verify`, `plugin-audit`,
  `plugin-webhooks`, …) — none at line 252, and a one-word change inside a string
  literal cannot produce TS2307.

## Not decided here

- Reuse vs. registering two codes (above) — a `packages/spec` call.
- The ledger annotates `DOMAIN_VERIFICATION_FAILED` as "pass-through from
  better-auth"; after this PR we author it too. Comment only, `packages/spec`, not
  touched — filed as a finding.
- `verify-domain` answers a *failure* code when the feature is **disabled**, while
  its sibling answers `DOMAIN_VERIFICATION_DISABLED` for the same condition. That
  incoherence predates this PR (the old bespoke code said "failed" too) and fixing
  it is a behaviour change, not a casing fix — filed separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
