### PR TITLE
fix(docs): migrate apps/docs to the Next 16 `proxy` file convention

### DIFF
--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -45,9 +45,10 @@ function getPreferredLanguage(request: NextRequest): string {
 }
 
 /**
- * Middleware for automatic language detection and redirection
+ * Proxy (Next `proxy` file convention) for automatic language detection and
+ * redirection
  * 
- * This middleware:
+ * This proxy:
  * - Detects the user's preferred language from browser settings or cookies
  * - Redirects users to the appropriate localized version
  * - For the default language (en): keeps URL as "/" (with internal rewrite)
@@ -56,7 +57,7 @@ function getPreferredLanguage(request: NextRequest): string {
  * The docs are English-only by decision (2026-07); the i18n plumbing stays so a
  * future language only needs entries in lib/i18n.ts and content, not new routing.
  */
-export default function middleware(request: NextRequest) {
+export default function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Check if the pathname already has a locale


### PR DESCRIPTION
Fixes #10782

Migrates `apps/docs` from the Next 16 deprecated `middleware` file convention to
`proxy`. Every `pnpm docs:dev` boot on Next `16.3.1` printed the migration
warning; the runtime had **already renamed the slot** — request timing lines read
`proxy.ts: 6ms` while the file was still spelled `middleware.ts` — so this only
aligns the repo with the name Next already uses.

> Body note: an earlier revision of this description used literal HTML `title`
> tags to quote page titles. GitHub's body sanitizer swallowed each one *and the
> span between the opening and closing tag*, which silently ate a table header and
> two rows. Rewritten below without angle brackets.

## The change

Produced by the vendor codemod, scoped to the docs app:

```
npx @next/codemod@canary middleware-to-proxy apps/docs
```

Its entire output is two paths, both under `apps/docs/`:

```
 apps/docs/{middleware.ts => proxy.ts} | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

— the file rename plus `export default function middleware` becoming
`export default function proxy`. I scoped it to `apps/docs` rather than running it
at the repo root on purpose: the unrelated `packages/runtime/src/middleware.ts` is
not a Next file-convention file, yet it matches the codemod's
`/(^|[/\\])middleware\./` path test. It is untouched here.

On top of the codemod, one doc-comment fix in the same file so it no longer
describes itself as middleware. No other file in the repo changes.

## ⭐ Verification — the rename is the easy half

A file-convention rename that silently stops being invoked is the failure this
change's shape invites, and it would be **invisible**: the deprecation warning
disappearing is what success looks like either way — deleting the file achieves it
too. So the evidence below is behavioural, from real requests against a real
`next dev` boot, with ablations.

Four boots on port 43782, each with a cold `.next`. Full probe matrix:
`/en/docs`, `/docs` (with and without `FD_LOCALE`), `/zz/docs`, `/en`,
`/api/search`.

### 1. The warning is gone

Baseline boot (`middleware.ts`) printed:

```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

After the rename, grepping the boot log for `deprecat` / `middleware-to-proxy`
returned `GREP_EXIT=1` (absent). Boot output is otherwise identical.

### 2. The locale negotiation still fires — behaviour is byte-identical

Diffing the baseline and post-rename response matrices (status line, `location`,
`set-cookie`, `x-middleware-rewrite`, page title) gave `DIFF_EXIT=0` — identical:

| probe | result |
|---|---|
| `GET /en/docs` | `307`, `location: /docs`, `set-cookie: FD_LOCALE=en; Path=/; SameSite=lax` |
| `GET /docs` (`Accept-Language: zh-CN`, no cookie) | `200`, `x-middleware-rewrite: /en/docs`, title `Documentation \| ObjectStack` |
| `GET /docs` (`Cookie: FD_LOCALE=en`) | `200`, `x-middleware-rewrite: /en/docs` |
| `GET /zz/docs` | `404`, `x-middleware-rewrite: /en/zz/docs` |
| `GET /en` | `307`, `location: /`, `set-cookie: FD_LOCALE=en` |
| `GET /api/search` | `200`, no rewrite, **no `proxy.ts:` timing segment** (matcher-excluded) |

That covers the whole negotiator: the `FD_LOCALE` cookie is **written**
(`/en/docs`, `/en`), `i18n.languages` membership is **consulted** (`/en/docs`
strips the prefix, `/zz/docs` does not and is rewritten instead — the two paths
diverge on exactly `i18n.languages.some(...)`), and `hideLocale: 'default-locale'`
drives the redirect-vs-rewrite split.

### 3. It is the new file doing the work — two ablations

The timing line alone proves nothing here: **`proxy.ts: 6ms` was already printed
while the file was named `middleware.ts`.** So it needed ablating.

**Ablation A — park `proxy.ts` outside the app.** Mutation confirmed on disk:
`grep -rl FD_LOCALE apps/docs --include=*.ts` returned 0 files. The entire matrix
collapses — `/en/docs` goes `307` to `200` with **no `Set-Cookie`**; `/docs` loses
`x-middleware-rewrite` and renders the *landing page* (title
`ObjectStack — Apps small enough for AI to hold whole.`) instead of the docs index,
because `[lang]` captures `"docs"`; `/zz/docs` goes `404` to `500`; `/en` goes
`307` to `200`. And the `proxy.ts:` timing-segment count per boot log:

```
baseline: 3    after: 3    ablationA: 0
```

Restored; `git diff --quiet HEAD` confirmed byte-identical.

**Ablation B — `throw new Error('OS_ABLATION_NEGOTIATOR')` injected immediately
after `const negotiator = new Negotiator({ headers: negotiatorHeaders });`.**
Mutation confirmed on disk (injected marker count 1, anchor count 1, `git diff`
dirty). One boot, three-way discrimination:

- `GET /docs` **without** the cookie gave `500`, and the dev server names the file
  and the renamed function directly:
  ```
  ⨯ Error: OS_ABLATION_NEGOTIATOR
      at getPreferredLanguage (proxy.ts:35:9)
      at proxy (proxy.ts:87:29)
  ```
  So the `Negotiator` construction is on the live request path **in `proxy.ts`**.
- `GET /docs` **with** `Cookie: FD_LOCALE=en` gave `200` + `x-middleware-rewrite`,
  never reaching the throw — positive proof the `FD_LOCALE` cookie is **read** and
  short-circuits ahead of the negotiator.
- `/en/docs` and `/en` still gave `307` + `Set-Cookie` — the pathname-locale branch
  never calls `getPreferredLanguage`, as written.

Restored via `git checkout HEAD --`; marker count `0`, anchor intact, `git status`
clean.

> Honest limitation: `i18n.languages` is `['en']` alone, so no Accept-Language or
> cookie *value* can produce a different negotiated result. Ablation B is what
> discriminates the cookie-read and `Negotiator` code paths, instead of a value
> difference.

## Gates

Union re-derived with `node scripts/pm/dispatch-gates.mjs` (no paths — it takes
its own change set from the merge base) and run on final HEAD `353cb948e0`, tree
clean. Each gate's own verdict line:

```
check-nul-bytes: OK (scanned 6271 text file(s) -- 6271 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).
check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through `dist/`; 44 published subpath(s) resolved through every alias table.
check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; 51 registered as still resolving a workspace dep's types through `dist/`.
```

Dependency closure built first (`pnpm --filter '@objectstack/docs^...' build`,
exit 0), then `pnpm --filter @objectstack/docs typecheck` (`tsc --noEmit`), exit 0.
The filter was probed rather than trusted — `pnpm --filter @objectstack/docs exec
pwd` printed `/home/user/objectstack-issue-10782/apps/docs`, so it matched a real
project rather than printing `No projects matched the filters` and exiting 0.

## Changeset

`skip-changeset`. `apps/docs` is `private: true` and `.changeset/config.json` sets
`privatePackages: { version: true, tag: false }`, so `@objectstack/docs` is never
published. The docs site's HTTP behaviour is byte-identical (matrix above), so
nothing a reader or a package consumer can observe changes — the only delta is
that a dev-boot warning stops printing. That is this repo's own stated case for
the label: *"such a PR releases nothing, so by the workflow's own prescription it
takes the label"* (`.github/workflows/lint.yml`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_