### PR TITLE
fix(docs): type-check apps/docs with `next typegen`, and delete the dead `types:check`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,9 +9,8 @@
     "build": "pnpm --filter @objectstack/spec gen:schema && pnpm --filter @objectstack/spec gen:docs && NODE_OPTIONS='--max-old-space-size=4096' next build",
     "start": "next start",
     "site:lint": "next lint",
-    "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "fumadocs-mdx && next typegen && tsc --noEmit"
   },
   "dependencies": {
     "fumadocs-core": "16.14.4",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -34,6 +34,30 @@
       ]
     }
   },
+  // `typecheck` runs `next typegen` before tsc on purpose, and these two
+  // `.next` globs are why. Next writes both of them itself
+  // (`writeConfigurationDefaults`) and re-adds either one on the next
+  // `next dev` / `next build` if you delete it -- measured by running that
+  // routine against a narrowed copy of this file: the `dev` glob came
+  // straight back and the file was rewritten. This array cannot be narrowed,
+  // so the honesty has to come from the script instead.
+  //
+  //   .next/types/**     produced by the `next typegen` that the `typecheck`
+  //                      script now runs itself, so the checked program is a
+  //                      function of source rather than of whatever `.next` an
+  //                      earlier build happened to leave behind. A bare
+  //                      `tsc --noEmit` here passed over a broken route
+  //                      signature precisely because these files were absent.
+  //   .next/dev/types/** written only by `next dev`. Next's own build-mode
+  //                      type check filters this directory OUT of the program
+  //                      (`getDevTypesPath`, lib/typescript/runTypeCheck.js)
+  //                      "to prevent stale dev types from causing errors when
+  //                      routes have been deleted since the last dev session".
+  //                      Plain tsc has no such filter, so a leftover dev
+  //                      session can only add a local false RED here, never a
+  //                      false green. Remedy: `rm -rf apps/docs/.next`.
+  //
+  // Do not reduce `typecheck` back to a bare `tsc --noEmit`.
   "include": [
     "next-env.d.ts",
     "**/*.ts",


### PR DESCRIPTION
Fixes #10871

`apps/docs` declared two near-identical type-check scripts, and the thorough one was dead:

```
"types:check": "fumadocs-mdx && next typegen && tsc --noEmit"   <- invoked by nothing
"typecheck":   "tsc --noEmit"                                   <- what CI runs
```

`git grep types:check` over `.github/`, `scripts/`, `turbo.json` and the root `package.json` returns only its own declaration. CI reaches the other one through `turbo run typecheck --filter='./apps/*'` (lint.yml, `Type Check · workspace`).

That mattered because `apps/docs/tsconfig.json` includes `.next/types/**/*.ts`, which only `next typegen` produces. The program CI type-checked was therefore set by whether some earlier, unrelated command had populated `.next` — and on a fresh CI checkout nothing had.

## The judgement: typegen materially changes coverage, so the thorough command wins

Measured on this branch's base, `.next` deleted, comparing `tsc --noEmit --listFiles` with and without typegen:

| | files in program | verdict |
|---|---|---|
| `tsc --noEmit` (what CI ran) | 1225 | exit 0 |
| `fumadocs-mdx && next typegen && tsc --noEmit` | 1231 | exit 0 |

The six added files are `.next/types/validator.ts` (160 lines validating **13 route entry points** — every page, layout and route handler against the route's real param map), `routes.d.ts`, `root-params.d.ts`, `cache-life.d.ts`, `next-env.d.ts`, and through that last one `next/image-types/global.d.ts`. So the bare run was also type-checking a Next app **without Next's own ambient declarations**.

Both were green, so the delta is coverage rather than a live bug. To show the added coverage is real rather than decorative, an ablation — giving `app/[lang]/docs/layout.tsx` a `params` object with one extra required key the route cannot supply, an edit that is internally consistent and so invisible to a plain compile:

| leg | result |
|---|---|
| mutation on disk | anchor count 1 -> 0, marker count 0 -> 1, `1 file changed, 1 insertion(+), 1 deletion(-)` |
| mutated + old script (bare `tsc`, empty `.next`) | **exit 0, 0 errors** — green over a broken route signature |
| mutated + new script | **exit 2, 1 error** — `TS2344` at `.next/types/validator.ts(139,31)`, naming the layout and the missing param |
| restored | marker count back to 0, `git status --porcelain` empty for the file, re-run exit 0 |

⛔ Both scripts are not left standing. `types:check` is deleted and its command becomes `typecheck` — the name `turbo run typecheck` and `check:type-check-coverage` already require, so no turbo or CI wiring moves.

## How the empty-`.next` case becomes honest

The check now **produces the generated inputs it reads**, from source, on every run: `fumadocs-mdx` writes `.source/`, `next typegen` writes `.next/types/**` and `next-env.d.ts`, and only then does `tsc` run. It can no longer pass because someone else populated `.next`, because it populates `.next` itself; and if typegen ever fails, `&&` short-circuits and `tsc` never runs, so the failure is loud rather than a quietly smaller program.

Proof, run on this commit with `.next` and `next-env.d.ts` deleted first:

```
next_dir_exists=no
next_env_exists=no
$ pnpm --filter @objectstack/docs typecheck
[MDX] generated files in 32.29ms
Generating route types...
✓ Types generated successfully
TYPECHECK_EXIT=0  SECONDS=4
next_types_dir=yes   next_env_now=yes
```

and the negative control on the same tree — the old command is still green over an empty `.next`, which is the trap being removed:

```
OLD_BARE_TSC_EXIT=0
```

## The cost of the trade, named rather than absorbed

**`next typegen` needs no build.** Measured at **~1 second**; it reads the `app/` directory and writes route types, it does not compile the app. The turbo `typecheck` task keeps `dependsOn: ["^build"]` exactly as before (that builds `@objectstack/spec`, not this app), and `pnpm build` still excludes docs. So this buys a whole class of route-signature checking for about a second, and does **not** turn the type check into something that requires a full build.

## Why `include` is left alone — the other option in the card is not available

The card floated narrowing `include` instead. Measured: that change is self-reverting. Next owns this array — `writeConfigurationDefaults` writes both `.next` globs and re-adds either one that is missing. Running Next's own routine against a narrowed copy of the file, exactly as `next build` and `next dev` call it:

```
PROBE_INCLUDE_NARROWED=["next-env.d.ts","**/*.ts","**/*.tsx",".next/types/**/*.ts"]
  - include was updated to add '.next/dev/types/**/*.ts'
DEV_GLOB_READDED_BY_NEXT=YES
```

So a hand-narrowed `include` comes back as an unrequested modification to a tracked file on the next `next dev` or `next build`. The rationale is recorded as a comment in `tsconfig.json`, at the spot where the next reader would try to tidy the glob away.

The residual is named there too, and it is the harmless direction: `.next/dev/types/**` is written only by `next dev`, and Next's **own** build-mode type check filters that directory out of the program (`getDevTypesPath`, `lib/typescript/runTypeCheck.js`) "to prevent stale dev types from causing errors when routes have been deleted since the last dev session". Plain `tsc` has no such filter, so a leftover dev session can only add a local false **red** — never a false green, which is the failure this card is about. Remedy: `rm -rf apps/docs/.next`.

## No changeset

`skip-changeset`. `apps/docs` is `private: true` and the diff is two files — a package script and a config comment. Nothing user-visible ships and no published package changes; `privatePackages.tag` is `false`, so there is no tag or release to describe either.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs` (2 paths vs merge base `7d483e1e5`), run at `8140f71b39` — the final commit — each quoting its own verdict line:

| gate | verdict line |
|---|---|
| `check:override-consistency` | `✓ 8 published-manifest declaration(s) covered by pnpm-workspace.yaml overrides all resolve to their override targets.` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 76 packages with a tsconfig.json scanned` |
| `scripts/check-changeset-fixed.mjs` | `✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.` |
| `scripts/check-osv-exemptions.mjs` | `✓ osv-scanner.toml holds zero OSV exemptions (the intended steady state).` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6294 text file(s) ... no raw ASCII control bytes).` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root)` |

`check:nul-bytes` is the any-edit gate; `check:type-check-coverage` is not path-derived but reads exactly the two files this diff changes (its `REAL` invariant is about whether a declared `typecheck` script means anything), so it was run deliberately.

Also run: `turbo run typecheck --filter='./apps/*' --force` — `Tasks: 2 successful, 2 total` — which is the CI lane's own command over this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_