### PR TITLE
docs(tooling): record the fifth casing-gate recognizer, and who owns a runtime-limbed chain

### DIFF
--- a/scripts/check-dispatcher-error-vocabulary.mjs
+++ b/scripts/check-dispatcher-error-vocabulary.mjs
@@ -89,7 +89,14 @@
  *     is WHICH gate reports it. `check:error-code-casing` owns the lowercase
  *     sweep, and every pattern it has needs a QUOTED lowercase literal beside
  *     the token `code` — `code: 'x'`, `.code = 'x'`, `code === 'x'`,
- *     `code?: 'x' | 'y'`. In those positions (`objlit`, `assign`) the
+ *     `code?: 'x' | 'y'`, and [#10760] `code: parsed?.code || 'x'` /
+ *     `.code = e?.code ?? 'x'` — the OUR-DEFAULT slot of a `||`/`??`
+ *     fallback chain, that gate's `fallback` pattern. It still captures only
+ *     a string literal, and a literal in our source is by construction the
+ *     default WE author. That fifth one is a position this gate has NO shape
+ *     for rather than one it hands over: an intervening expression leaves
+ *     `objlit` and `assign` with no quote to match.
+ *     In those positions (`objlit`, `assign`) the
  *     delegation is real: that gate reads the same characters and carries the
  *     D6/D6b/D6c discrimination — field-addressed catalogs, persisted audit
  *     columns, diagnostics payloads, Zod's own issue codes — that decides which
@@ -126,6 +133,22 @@
  *     Reduction is ALL-OR-NOTHING — a chain with one runtime limb reduces to
  *     nothing rather than to its literal half, since half an expression's
  *     values is a finding that is wrong in both directions at once.
+ *     [#10762] WHO owns a runtime-limbed chain then depends on WHERE it sits,
+ *     and the two answers differ — measured against both gates' recognizers,
+ *     not inferred from either one's prose. At the STAMP SITE
+ *     (`{ code: parsed?.code || 'lit' }`, `err.code = e?.code ?? 'lit'`) no
+ *     reduction is involved at all: `objlit`/`assign` need the quote
+ *     immediately, so this gate never had a shape there — and since #10760
+ *     `check:error-code-casing`'s `fallback` pattern reads that literal, so
+ *     the shape is DELEGATED, not dropped. That is the position the two live
+ *     SSO codes in `register-sso-provider.ts` shipped through. In a LOCAL'S
+ *     INITIALIZER (`const code = parsed?.code || 'lit'; err.code = code`) it
+ *     is neither: the ALL-OR-NOTHING rule above declines it here, and that
+ *     gate's `fallback` pattern anchors on `code:`/`code?:`/`.code =`, so a
+ *     `const code =` is out of ITS reach too. That one is still owned by
+ *     NOBODY — deliberately on this side, filed as #10897 for the other.
+ *     Stated so the next reader does not re-derive the hole and close it in
+ *     the wrong gate.
  *   - A constant this gate cannot resolve is REPORTED as unresolved, never
  *     dropped: a deriver that goes quietly blind is the same failure one layer
  *     down. [#9223] A constant imported from a WORKSPACE package is resolved
@@ -801,7 +824,11 @@ export function deriveSites({ registered, files, readFile, packageDirs = new Map
    *
    * `check:error-code-casing` owns the lowercase sweep, and every pattern it
    * has requires a QUOTED lowercase literal sitting next to the token `code`:
-   * `code: 'x'`, `.code = 'x'`, `code === 'x'`, `code?: 'x' | 'y'`. Where this
+   * `code: 'x'`, `.code = 'x'`, `code === 'x'`, `code?: 'x' | 'y'`, and
+   * [#10760] `code: parsed?.code || 'x'` / `.code = e?.code ?? 'x'`, the
+   * OUR-DEFAULT slot of a `||`/`??` fallback chain (that gate's `fallback`
+   * pattern; it still captures only a literal, which in our source is the
+   * default we author). Where this
    * gate finds a lowercase code in one of those same positions — `objlit`,
    * `assign` — the delegation is real: that gate sees the identical text, and
    * it carries the D6/D6b/D6c discrimination (field-addressed catalogs,


### PR DESCRIPTION
Fixes #10762. Verified at `278c9c6856`; base `origin/main` = `9faa9bc51d`.

One file, comment-only: `scripts/check-dispatcher-error-vocabulary.mjs`. No changeset — CI-internal gate tooling, publishes nothing (`skip-changeset`, by `pr-automation.yml`'s own prescription: "this PR edits a CI-internal script" is the textbook case).

## The card's falsification test, run first and last

The card's acceptance criterion is that nothing moves. Captured before the edit and again after, redirect-then-capture so no pipe eats the exit code:

```
$ node scripts/check-dispatcher-error-vocabulary.mjs --self-test        EXIT=0
check-dispatcher-error-vocabulary --self-test: 8 shapes + 102 assertions OK (vocabulary + #9098 door typing)

$ node scripts/check-dispatcher-error-vocabulary.mjs                    EXIT=0
check-dispatcher-error-vocabulary: OK — 21 unregistered code-stamping site(s), all classified; 1 awaiting a ledger entry (#8846).
  scope: 1883 non-test source files under packages/; 291 registered codes (241 ledger + 50 standard); 21 unregistered code-stamping site(s) found; 21 classified.
```

`diff` of the captured before/after files is **empty for both** — not "the same numbers", byte-identical output. No self-test case moved, so the delegation is what the comments claim.

Comment-only proven two ways rather than asserted: no added or removed line in the diff is a non-comment line, and the file's non-comment byte stream is md5-identical to `HEAD` (`2e9cfa29e4d03764361b277839eff427` both sides).

## The enumerations were TWO, not three

The card says three. Swept for them rather than trusting the count — `QUOTED`, `code === 'x'`, `code?: 'x'`, `.code = 'x'`, and every `delegat`/`owns` mention in the file. There are exactly **two** verbatim enumerations of that gate's recognizers:

| line | site |
| --- | --- |
| 90–92 | the header's `[#9460]` declared bound |
| 802–804 | the jsdoc on `keep()` — the card calls it `isMine`; the function is named `keep` |

Both now carry the fifth. Nothing else in the file enumerates the recognizer set: the neighbouring delegation notes (628, 1323) speak about anchoring on the token `code` and stay accurate after #10760, since the new pattern anchors on the token too.

## The fifth spelling, in the owning gate's words

Read off `check-error-code-casing.mjs` rather than from the card, per the card's own instruction that the owning gate is the truth:

```js
// [#10658] the OUR-DEFAULT slot of a fallback chain:
//   code: parsed?.code || 'verify_domain_failed'
//   err.code = e?.code ?? 'lookup_failed'
{ name: 'fallback',
  re: /(?:\bcode\s*\??\s*:|\.code\s*=(?!=))\s*(?['"`])[\w$.?!()[\]|&\s]{0,80}?(?:\|\||\?\?)\s*'([a-z][a-z0-9_]*)'/g }
```

So it is written into both enumerations as `code: parsed?.code || 'x'` / `.code = e?.code ?? 'x'` — both positions and both operators, which the card's one-form paraphrase (`code: parsed?.code || 'x'`) leaves half-stated.

## One discrepancy with the card, resolved in the gates' favour

The card asks for a clause saying a runtime-limbed chain "reduces to nothing here and is therefore delegated, not dropped — owned by `check:error-code-casing` rather than by nobody". Measured against both gates' own exported entry points (`findViolations`, `deriveSites`), that is true at one position and false at the other, so writing it unqualified would install into the delegation map the exact "two gates, each assuming the other" error the map exists to prevent:

| shape | this gate | `check:error-code-casing` |
| --- | --- | --- |
| stamp site `{ code: p?.code \|\| 'stamp_lower_failed' }` | no site | **1** (`fallback`) |
| stamp site `err.code = p?.code \|\| 'stamp_lower_failed'` | no site | **1** (`fallback`) |
| local init `const code = p?.code \|\| 'local_lower_failed'` | no site, no unresolved | **0** |
| control — local init `const code = flag ? 'TERN_A' : 'TERN_B'` | **2 sites** (`assignconst`) | n/a |

The control row is what makes the zeros readable rather than a broken probe: this gate does reduce and report a local initializer when every limb is a literal (#9568), and rows 1–2 are the matching live control on the casing side.

Two facts follow, and the clause now states both:

- **At the stamp site there is no reduction at all.** `objlit`/`assign` need the quote immediately, so this gate never had a shape there — nothing was "reduced to nothing". Since #10760 that literal is read by the casing gate, so the shape is genuinely delegated. This is the position the two live SSO codes in `register-sso-provider.ts` occupy (checked on disk: `{ code: parsed?.code || 'request_domain_verification_failed', … }`, no local, no `resolveConstant`), so the card's exemplar belongs to this row, not to the all-or-nothing rule it is filed under.
- **In a local's initializer it is owned by nobody.** The all-or-nothing rule declines it here — correctly, and this PR does not touch that, per the card — and the casing gate's `fallback` pattern anchors on `code:`/`code?:`/`.code =`, so `const code =` is out of its reach too. A typed local does not escape either: `const code: string =` puts an `=` in the gap class, which the class refuses.

The second row is a behaviour question in a different gate, so it is **not addressed here**: filed unassigned as #10897, with the measurements above and a tree sweep putting its live extent at **0** (1885 non-test files under `packages/`, comments masked with the gates' own `maskComments`). Like this card, it understates coverage and has no victim today.

## The edit, proven on disk

Anchored marker counts, each asserted to hit exactly once before writing (the script aborts on any other count rather than making a partial write) and re-counted after:

| marker | before | after |
| --- | --- | --- |
| header enumeration anchor | 1 | 0 (replaced) |
| `keep()` enumeration anchor | 1 | 0 (replaced) |
| `[#10760] code: parsed?.code \|\| 'x'` | 0 | **2** |
| `[#10762] WHO owns a runtime-limbed chain` | 0 | **1** |
| the #9568 ALL-OR-NOTHING line (must survive) | 1 | **1** |

## Gates

`node scripts/pm/dispatch-gates.mjs` with no paths, at `278c9c6856`, clean tree — it derived the change set from the merge base as **1 path** and named six families. All six run green:

| gate | verdict line | exit |
| --- | --- | --- |
| `check:dispatcher-error-vocabulary` | `8 shapes + 102 assertions OK` · `OK — 21 unregistered code-stamping site(s), all classified` | 0 |
| `check:cross-package-test-inputs` | `All 104 self-test cases passed.` · `OK: 13 package(s) read outside themselves, all declared` | 0 |
| `check:entry-guard` | `129 scripts/ file(s) — every entry guard goes through invoked-as.mjs; 87 export bindings, 77 of them inert on import` | 0 |
| `check:parse-guard` | self-test + sweep clean | 0 |
| `check:nul-bytes` | `OK (scanned 6298 text file(s) -- … no raw ASCII control bytes)` | 0 |
| `check-ci-filter-parity.mjs` | `OK: all 82 declared cross-package glob(s) (71 unique) are covered` | 0 |

Declared narrowing, so the report is not read as more than it is: no `pnpm install` was run in this worktree. Both gates this card concerns import only node builtins plus two local `.mjs`, so they need none. The one derived family that does need a dependency (`check-ci-filter-parity` wants `yaml`) was run against a single temporary symlink to an already-resolved `yaml@2.9.0`, removed immediately after; a broken link would have errored loudly rather than passing quietly, so its green is a real run.

_Generated by [Claude Code](https://claude.ai/code/session_c970724d-303c-5614-9d20-a3f92205cfad)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdCnBGcHeufjrq7drTD3wt)_