### PR TITLE
fix(plugin-approvals): require warn on ApprovalServiceOptions logger sink

### DIFF
--- a/.changeset/approval-service-logger-warn-required.md
+++ b/.changeset/approval-service-logger-warn-required.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-approvals": minor
+---
+
+**BREAKING** (compile-time only): `ApprovalServiceOptions['logger']` now
+declares a **non-optional** `warn`, so a durability report always has
+somewhere to land (#9754, #10556). This is the thirteenth of the thirteen
+mechanical repairs the card names — held out of #10691 to serialize against
+PR #10547, which owned `approval-service.ts` while it was open; that fence
+has since cleared.
+
+`minor`, not `major`: during the launch window this stack ships breaking
+changes as `minor` — every publishable package versions in lockstep, so a
+`major` would promote the whole release. `patch` would be wrong in the other
+direction, because this *can* break a consumer's build. This is the same
+reasoning #10691 used for the twelve sibling repairs; no exemption for a
+types-only break was found there either, and none applies here.
+
+`error` stays optional — hosts legitimately inject reduced sinks, and
+requiring `error` was measured and rejected as #9754 option C. What changes
+is that its *absence* now has a declared, guaranteed destination. Call sites
+keep the `logger?.warn?.(…)` spelling as the backstop for hosts the type
+cannot reach, so **no runtime behaviour changes**: nothing that printed
+before stops printing, and nothing silent starts printing.
+
+### Who has to change, and what to do
+
+Only a caller that constructs `ApprovalService` (or an `ApprovalServiceOptions`
+value) with a `logger` object that has **no `warn` method** — for example
+`{ error }` alone. Add a `warn` member; there is no rename, no removal, and no
+stored value or metadata key to rewrite. The only non-test construction site
+in this repo (`ApprovalsServicePlugin.start`, in this same package) passes the
+kernel `ctx.logger`, whose `warn` is already required, so the in-repo cost is
+zero.
+
+<!-- adr-0087: not-required (runtime-interface-only packages/plugins/plugin-approvals/src/approval-service.ts#ApprovalServiceOptions) the tightened type is a plain TypeScript logger interface -- no Zod projection, no metadata surface, and it is referenced by none -- so `objectstack migrate meta` has nothing to rewrite. Nothing is removed or renamed and no stored value moves; the only consumer action is adding a `warn` member at a construction site the compiler names. -->

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -536,7 +536,7 @@ function rowFromAction(row: any): ApprovalActionRow {
 export interface ApprovalServiceOptions {
   engine: ApprovalEngine;
   clock?: ApprovalClock;
-  logger?: { info?: (msg: any, ...rest: any[]) => void; warn?: (msg: any, ...rest: any[]) => void; error?: (msg: any, ...rest: any[]) => void; debug?: (msg: any, ...rest: any[]) => void };
+  logger?: { info?: (msg: any, ...rest: any[]) => void; warn: (msg: any, ...rest: any[]) => void; error?: (msg: any, ...rest: any[]) => void; debug?: (msg: any, ...rest: any[]) => void };
   /**
    * Optional automation surface used to resume a suspended flow run when a
    * decision finalises a request. Usually attached after construction via

--- a/scripts/optional-error-sink-contract.baseline.json
+++ b/scripts/optional-error-sink-contract.baseline.json
@@ -21,19 +21,17 @@
     "           metadata-protocol, plugin-approvals/lifecycle-hooks, both plugin-audit sinks,",
     "           both plugin-auth sinks, plugin-email/attachment-reclaim, plugin-reports,",
     "           plugin-sharing, plugin-webhooks and service-knowledge.",
-    "  = 3    — what is left, and NONE of the three is left for lack of effort:",
-    "           one is a serialisation leftover whose reason has expired (approval-service.ts),",
-    "           and two are DESIGN calls escalated to the maintainer rather than answered by a",
-    "           dev to make this checker green (security-plugin.ts, settings-service.types.ts)."
+    "  = 3    — what was left after #10556's first PR, and NONE of the three was left for lack",
+    "           of effort: one was a serialisation leftover whose reason had expired",
+    "           (approval-service.ts), and two are DESIGN calls escalated to the maintainer",
+    "           rather than answered by a dev to make this checker green (security-plugin.ts,",
+    "           settings-service.types.ts).",
+    "  -1     — #10556's follow-up dispatch repaired the serialisation leftover once its",
+    "           fence (PR #10547/#10739) cleared: `logger@ApprovalServiceOptions` dropped the",
+    "           `?` from `warn`, mechanically identical to the twelve already paid down.",
+    "  = 2    — both remaining rows are the escalated DESIGN calls; neither is a `?` deletion."
   ],
   "entries": [
-    {
-      "file": "packages/plugins/plugin-approvals/src/approval-service.ts",
-      "sink": "logger@ApprovalServiceOptions",
-      "verdict": "optional-fallback",
-      "members": "{ info? warn? error? debug? }",
-      "note": "Approval-service options bag. Mechanically identical to the twelve repaired in #10556 — drop the `?` from `warn`. Held out of that PR to serialize against PR #10546, which owned this file while it was open. #10546 has since MERGED (2026-08-21), so the reason this row is still here has expired: it is a one-line repair awaiting a dispatch, not a design call and not an exemption."
-    },
     {
       "file": "packages/plugins/plugin-security/src/security-plugin.ts",
       "sink": "logger@SecurityPlugin",


### PR DESCRIPTION
Part of #10556

## What

Drops the `?` from `warn` on `ApprovalServiceOptions['logger']` so a sink
declaring an optional `error` always has a guaranteed durability-report
channel (#9754). `error` stays optional. This is the last of the card's
thirteen mechanical repairs — held out of #10691 to serialize against
PR #10547, which owned `approval-service.ts` while it was open; that fence
cleared when #10739 merged (2026-08-21T14:40Z).

Deletes the now-stale `logger@ApprovalServiceOptions` row from the
shrink-only `scripts/optional-error-sink-contract.baseline.json`, identified
by running `pnpm check:optional-error-sink` after the type fix and using its
own "1 stale entry(ies)" verdict as the deletion criterion (not by line
number). The other two rows — `plugin-security`'s default-sink design call
and `service-settings`'s no-fallback design call — are untouched; both
remain escalated to the maintainer per #10556's re-triage
(issuecomment-5368213444). Baselined count after this PR: **2** (as
expected).

⛔ Not `Fixes #10556` — the card still carries two unruled design
decisions; a closing keyword would silently close their only tracking
artifact.

## Construction-site re-check

The sole non-test construction site (`ApprovalsServicePlugin.start`, same
package) passes `ctx.logger` (`PluginContext['logger']`), whose `Logger`
contract already requires `warn` — zero widening needed. `pnpm --filter
'@objectstack/plugin-approvals' typecheck` is clean (echoed `tsc --noEmit`
then done — not a zero-match pass). Test-file loggers (`noopLogger`,
`capturing`, inline `{ warn: ... }` spies) already declare `warn`; none
needed a change.

## Ablation (both directions, predicted before mutating)

- **Leg A** (un-repair, ledger row stays deleted): predicted the gate reds
  with "no guaranteed fallback channel". Observed exactly:
  `✗ 1 sink type(s) declare an optional `error` with no guaranteed fallback
  channel ... sink: inline type logger@ApprovalServiceOptions { info? warn?
  error? debug? }`. Restored via `git checkout HEAD --
  packages/plugins/plugin-approvals/src/approval-service.ts` (fix was
  already committed) — `git hash-object` confirms byte-identical restore
  (`20083b9a4ab5ef6e3d3cff46bfcf12701d968df8`).
- **Leg B** (repair kept, ledger row restored): predicted `stale entry`.
  Observed exactly: `✗ 1 stale entry(ies) in
  scripts/optional-error-sink-contract.baseline.json ...
  packages/plugins/plugin-approvals/src/approval-service.ts::logger@ApprovalServiceOptions`
  — proves the row deletion is a required part of this fix, not tidying.
  Restored via `git checkout HEAD -- scripts/optional-error-sink-contract.baseline.json`,
  byte-identical (`1a933af08d6aa911b7377d63effc352c8116d80a`).

## Tests

All at final head `1a9baa986`, exit codes captured before any pipe.

- `pnpm check:optional-error-sink`: exit 0 — `✓ optional-error sink
  contract: every sink declaring an optional `error` guarantees a `warn`
  channel (**2** baselined, shrink-only).`
- `pnpm --filter '@objectstack/plugin-approvals^...' build`: exit 0 (dependency
  closure — upstream direction, `^...`).
- `pnpm --filter '@objectstack/plugin-approvals' typecheck`: exit 0.
- `pnpm --filter '@objectstack/plugin-approvals' test -- --maxWorkers=2`: exit
  0 — 536 tests / 28 files passed.
- `pnpm check:route-envelope -- --self-test` and `pnpm
  check:dispatcher-error-vocabulary -- --self-test`: both exit 0. The
  gate-union derivation (`node scripts/pm/dispatch-gates.mjs`, no path args)
  did **not** name either — this diff touches no `packages/plugins/plugin-auth/**`
  path, so class #10309 does not apply to this PR's surface; run anyway per
  dispatch item 7 and both green.
- Changeset gates: `check:empty-changeset`, `check:adr-0087-registration`,
  `check:changeset-no-major` (and the bundled `check:changeset-gate-self-tests`)
  all exit 0 on the **committed** tree. `check-adr-0087-registration` verdict:
  `[BREAKING] not-required (runtime-interface-only) -- verified:
  packages/plugins/plugin-approvals/src/approval-service.ts#ApprovalServiceOptions
  (interface)`.
- Full named-gate sweep from `node scripts/pm/dispatch-gates.mjs` (no path
  args, run after the final commit, clean tree): all 15 path-matched
  families green, plus the one convention-triggered gate (`pnpm check:i18n`,
  triggered because this package owns an `i18n-extract.config.ts`) green
  after building the CLI (`check:i18n`'s own prerequisite — it exits 1 with
  "PREREQUISITE NOT MET" and checks nothing until the CLI is built).

## Bump / ADR-0087 reasoning (read #10691's changeset first, per dispatch)

`minor`, matching #10691's twelve sibling repairs: `major` is banned by
`check-changeset-no-major.mjs` during the launch window (lockstep
versioning), and `patch` would be wrong because this can break a consumer's
build (compile-time only, no runtime change). No exemption for a types-only
break was found, matching #10691's own search.

`not-required (runtime-interface-only)`: `ApprovalServiceOptions` is a plain
TypeScript interface — no Zod projection, no metadata surface, not
referenced by one — so `objectstack migrate meta` has nothing to rewrite.
Nothing is removed or renamed (AGENTS.md's FROM→TO prescription requirement
is scoped to removal/rename) and no stored value moves.

⭐ Instrument note (confirmed again on this PR):
`check-adr-0087-registration` reads changeset content from **git**, not the
working tree — it must be re-run after committing the changeset to carry
any information.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_