### PR TITLE
fix(plugin-auth): a 2FA verification echoes the session it installed, not the one it deleted

### DIFF
--- a/.changeset/two-factor-verify-echoes-installed-session.md
+++ b/.changeset/two-factor-verify-echoes-installed-session.md
@@ -1,0 +1,64 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): a 2FA verification echoes the session it INSTALLED, not the one it deleted (#10701)
+
+`POST /api/v1/auth/two-factor/verify-totp` answered `200` with two credentials
+that disagreed. The `Set-Cookie` named the caller's new session; the JSON
+`token` named a session row the same request had just deleted.
+
+The cause is upstream and mechanical. better-auth's `verifyTwoFactor` helper
+resolves the caller's session once, at entry, and closes over it:
+
+```js
+valid: async (ctx) => ctx.json({ token: session.session.token, ... })
+```
+
+On the enrolment lane — a signed-in user confirming a new TOTP factor — the
+route rotates that session before it answers: it mints a new session, installs
+it with `setSessionCookie`, and deletes the caller's original session row. Only
+then does it call `valid(ctx)`, which still holds the pre-rotation session and
+echoes the token of the row that no longer exists. (Measured on the installed
+better-auth 1.7.1: `dist/plugins/two-factor/verify-two-factor.mjs` and
+`dist/plugins/two-factor/totp/index.mjs`.)
+
+Every other auth response in this repo echoes `token` as the unsigned token of
+a live session, and `bearer()` accepts exactly that — presented without a
+signature it signs the value itself before verifying. Measured on
+`/sign-up/email`, the body's `token` resolves to the user as a bearer. So a
+client following that contract after enrolling in 2FA stored a revoked token.
+
+That did not merely fail to authenticate. `bearer()`'s before-hook OVERWRITES
+the request's session cookie with whatever the `Authorization` header carries,
+so a request presenting the still-valid rotated cookie *and* the dead token
+resolved to nobody. Measured before the fix, on one enrolment: the cookie alone
+resolved to the user (`get-totp-uri` `200`); the echoed token alone resolved to
+nobody (`get-session` `200` and empty, `get-totp-uri` `401`); and the two
+together also resolved to nobody (`401`). Fail-closed — no privilege was
+available to gain — but a legitimate user was locked out of a session they
+still held, which is the point of the report.
+
+The echoed value is now read back out of the response's own session cookie, so
+the `token` names the session the response actually installed. This restores
+the contract rather than changing it: the field keeps its shape (the unsigned
+session token) and its meaning ("the session you now hold"), and only the value
+moves, from a deleted row to the live one. Shipped as `patch` for that reason —
+no consumer expression has to be rewritten, and the previous value was not a
+usable credential for anything, so nothing could have depended on it.
+
+The repair is keyed on the mechanism, not on the enrolment branch: it applies
+only when the response staged a session cookie whose token differs from the one
+being echoed. On the sign-in-challenge lane, where the route mints the session
+it echoes, the two agree and this is a no-op — pinned, along with the cookie
+lane, so that fixing the broken lane could not quietly rewrite the others.
+`/two-factor/verify-otp` carries the byte-identical rotate-then-answer block and
+is covered by the same guard; `/two-factor/verify-backup-code` does not rotate
+and is unaffected.
+
+Resolver precedence is deliberately untouched. Having the resolver fall back to
+the cookie when a bearer is unusable was the other repair direction named in the
+report, and it was ruled out of scope: it would stop an invalid credential from
+failing loud. Two pins hold that line — anonymous is still refused, and a bogus
+bearer still overrides a valid cookie and still fails closed — so an attempt to
+loosen the resolver later reddens this suite instead of passing it.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -37,6 +37,7 @@ import {
   rotateCallerBearerOnImpersonation,
   withBearerAdminSessionRecovery,
 } from './impersonation-bearer-rotation.js';
+import { echoInstalledSessionToken } from './two-factor-rotated-token-echo.js';
 import {
   applyPlatformAdminImpersonation,
 } from './admin-impersonate-endpoint.js';
@@ -1703,6 +1704,17 @@ export class AuthManager {
           // the ADMIN's session cookie on every later request, so without
           // rotating that token, `/admin/impersonate-user` is a 200 no-op.
           await rotateCallerBearerOnImpersonation(ctx);
+
+          // ── #10701: a 2FA verification must echo the session it INSTALLED ─
+          // On the enrolment lane `/two-factor/verify-totp` rotates the
+          // caller's session and then echoes the PRE-rotation token — the row
+          // it just deleted. A client that stores it (the console's
+          // `auth-session-token` pattern) is holding a revoked credential, and
+          // because `bearer()` overwrites the request cookie with whatever the
+          // Authorization header carries, presenting it destroys the valid
+          // rotated cookie too. See `two-factor-rotated-token-echo.ts`. This
+          // corrects the echoed VALUE only; resolver precedence is untouched.
+          await echoInstalledSessionToken(ctx);
 
           // ── ADR-0069 D2: account lockout (counter) ──────────────────
           // better-auth catches an INVALID_EMAIL_OR_PASSWORD APIError and runs

--- a/packages/plugins/plugin-auth/src/two-factor-rotated-token-echo.test.ts
+++ b/packages/plugins/plugin-auth/src/two-factor-rotated-token-echo.test.ts
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #10701 — `/two-factor/verify-totp` echoed a session token it had just
+// DELETED, and presenting that token destroyed the caller's valid cookie.
+//
+// The shape of the defect dictates the shape of these tests. The endpoint
+// answered 200, rotated the session cookie correctly, and emitted a correct
+// `set-auth-token` — all of it right — and then echoed the PRE-rotation token
+// in the JSON body. So a test asserting "verify-totp returns 200", or "a
+// `token` came back", or "the response set a session cookie" would have been
+// GREEN against the bug.
+//
+// Every assertion below therefore ends at the same question the runtime asks:
+// WHICH PRINCIPAL does the next request resolve to, when the client presents
+// the credential this response handed it? And the three cases from the card
+// are measured side by side in ONE arrangement, because the finding is not
+// "the bearer is useless" — it is that a useless bearer DESTROYS an otherwise
+// valid cookie session.
+//
+// Real better-auth pipeline throughout (the precedent set by
+// `impersonation-bearer-rotation.test.ts`): requests go in as `Request`
+// objects through `AuthManager.handleRequest`, the tokens are the ones
+// better-auth minted, and the resolution path is the real one. Where a test
+// wants the seam the data routes actually use, it asks
+// `auth.api.getSession({ headers })` — literally what
+// `runtime/src/security/resolve-session-principal.ts` calls.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { AuthManager } from './auth-manager';
+// The SAME in-memory engine the #8243 harness drives, deliberately: a second
+// fake would be a second looseness risk and a new `check:engine-double-contract`
+// ledger entry, for no added fidelity.
+import { createMemoryEngine } from './impersonation-bearer-rotation.test';
+
+const SECRET = 'test-secret-at-least-32-chars-long!!';
+const PASSWORD = 'S3cure!Passw0rd-10701';
+const BASE = 'http://localhost:3000/api/v1/auth';
+
+// ── RFC 6238 TOTP ──────────────────────────────────────────────────────────
+// Hand-rolled rather than imported, for the reason the #3624 dogfood harness
+// gives: `@better-auth/utils/otp` is a transitive dependency, and taking a
+// direct dependency on it to generate six digits would tie this suite to an
+// internal package's resolution. better-auth's defaults are the RFC's
+// (SHA-1, 6 digits, 30s), asserted by `enable`'s own otpauth:// URI below.
+
+function base32Decode(input: string): Buffer {
+  const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const clean = input.replace(/=+$/, '').toUpperCase();
+  let bits = 0;
+  let value = 0;
+  const out: number[] = [];
+  for (const char of clean) {
+    const idx = ALPHABET.indexOf(char);
+    if (idx === -1) throw new Error(`invalid base32 character: ${char}`);
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      out.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(out);
+}
+
+/** The 6-digit TOTP for `secret` at the current 30-second step. */
+function totp(secret: Buffer): string {
+  const counter = Math.floor(Date.now() / 30_000);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+  const digest = createHmac('sha1', secret).update(buf).digest();
+  const offset = digest[digest.length - 1] & 0x0f;
+  const code =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+  return String(code % 1_000_000).padStart(6, '0');
+}
+
+/** Collect a response's Set-Cookie values into a single request Cookie header. */
+const cookieHeader = (res: Response): string =>
+  (res.headers.getSetCookie?.() ?? []).map((c) => c.split(';')[0]).join('; ');
+
+const makeManager = (engine: any) =>
+  new AuthManager({
+    secret: SECRET,
+    baseUrl: 'http://localhost:3000',
+    dataEngine: engine,
+    plugins: { twoFactor: true },
+  } as any);
+
+const post = (manager: AuthManager, path: string, body: unknown, headers: Record<string, string> = {}) =>
+  manager.handleRequest(
+    new Request(`${BASE}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body ?? {}),
+    }),
+  );
+
+const sessionRows = (engine: any) => (engine.tables.get('sys_session') ?? []) as any[];
+const userIdFor = (engine: any, email: string): string => {
+  const row = ((engine.tables.get('sys_user') ?? []) as any[]).find((r) => r.email === email);
+  if (!row) throw new Error(`no sys_user row for ${email}`);
+  return String(row.id);
+};
+
+/**
+ * WHO does this set of request headers resolve to, asked through the exact
+ * seam the framework's data routes use.
+ *
+ * `null` for anonymous. Never a status code — better-auth answers a dead
+ * session with a 200 and a JSON `null`, so a status assertion is blind here.
+ * That is precisely how this defect read in the field: `get-session` came back
+ * 200 and EMPTY.
+ */
+const principalFor = async (
+  manager: AuthManager,
+  headers: Record<string, string>,
+): Promise<string | null> => {
+  const auth: any = await manager.getAuthInstance();
+  const session = await auth.api.getSession({ headers: new Headers(headers) }).catch(() => null);
+  const id = session?.user?.id ?? session?.session?.userId;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+};
+
+/**
+ * A real protected 2FA route, driven with the given credentials. `get-session`
+ * alone is not enough evidence: it answers 200 for anonymous. This is the
+ * route the card names, and it is the one that tells 200 from 401.
+ */
+const getTotpUri = (manager: AuthManager, headers: Record<string, string>) =>
+  post(manager, '/two-factor/get-totp-uri', { password: PASSWORD }, headers);
+
+const EMAIL = 'enroller@example.com';
+
+/**
+ * A signed-in user who has just completed TOTP ENROLMENT — the lane the QA run
+ * surfaced, and the lane on which the vendor rotates the session mid-request.
+ *
+ * Returns everything the three cases need: the token the response echoed, the
+ * cookie it installed, and the token the caller was holding BEFORE enrolment
+ * (the value that used to be echoed, kept so the pins can name it exactly).
+ */
+const arrangeCompletedEnrolment = async () => {
+  const engine = createMemoryEngine();
+  const manager = makeManager(engine);
+
+  const signedUp = await post(manager, '/sign-up/email', {
+    email: EMAIL,
+    password: PASSWORD,
+    name: 'Enrolling User',
+  });
+  expect(signedUp.status).toBe(200);
+  const preEnrolmentCookie = cookieHeader(signedUp);
+  const preEnrolmentToken = String(((await signedUp.json()) as any).token);
+  const userId = userIdFor(engine, EMAIL);
+
+  // The premise: before enrolling, the echoed token IS an accepted bearer.
+  // Without this, a green suite could never tell "we fixed the echo" from
+  // "the bearer seam never worked here".
+  expect(await principalFor(manager, { authorization: `Bearer ${preEnrolmentToken}` })).toBe(userId);
+
+  const enabled = await post(manager, '/two-factor/enable', { password: PASSWORD }, { cookie: preEnrolmentCookie });
+  expect(enabled.status, `two-factor/enable: ${await enabled.clone().text()}`).toBe(200);
+  const { totpURI } = (await enabled.json()) as { totpURI: string };
+  const uriSecret = new URL(totpURI.replace('otpauth://', 'https://')).searchParams.get('secret');
+  expect(uriSecret, 'no secret in the otpauth URI').toBeTruthy();
+  const secret = base32Decode(String(uriSecret));
+
+  const verified = await post(manager, '/two-factor/verify-totp', { code: totp(secret) }, { cookie: preEnrolmentCookie });
+  expect(verified.status, `verify-totp (enrolment): ${await verified.clone().text()}`).toBe(200);
+
+  const echoedToken = String(((await verified.clone().json()) as any).token);
+  const rotatedCookie = cookieHeader(verified);
+  expect(rotatedCookie, 'verify-totp installed no session cookie').toContain('session_token=');
+
+  return { engine, manager, userId, secret, preEnrolmentToken, echoedToken, rotatedCookie };
+};
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#10701 — the three cases from the card, one arrangement', () => {
+  it('the echoed token, the cookie, and the two together all resolve to the user', async () => {
+    const { manager, userId, echoedToken, rotatedCookie } = await arrangeCompletedEnrolment();
+
+    const bearerOnly = { authorization: `Bearer ${echoedToken}` };
+    const cookieOnly = { cookie: rotatedCookie };
+    const both = { ...cookieOnly, ...bearerOnly };
+
+    // ① the client can keep authenticating with what the response handed it.
+    //    Against the unfixed route this was `null`.
+    expect(await principalFor(manager, bearerOnly)).toBe(userId);
+
+    // ② the arm that was already right stays right.
+    expect(await principalFor(manager, cookieOnly)).toBe(userId);
+
+    // ⭐ THE POINT OF THE CARD. Against the unfixed route this was `null`: the
+    //    dead bearer overwrote a perfectly valid cookie and dropped the
+    //    request to anonymous. A fix that only made the bearer work in
+    //    isolation would not be enough — real clients send both.
+    expect(await principalFor(manager, both)).toBe(userId);
+  }, 60_000);
+
+  it('the same three cases on a real protected route, not just `get-session`', async () => {
+    // `get-session` answers 200 for anonymous, so status codes there prove
+    // nothing. `get-totp-uri` is the route the card names, and against the
+    // unfixed endpoint it answered 401 for both bearer cases.
+    const { manager, echoedToken, rotatedCookie } = await arrangeCompletedEnrolment();
+
+    expect((await getTotpUri(manager, { authorization: `Bearer ${echoedToken}` })).status).toBe(200);
+    expect((await getTotpUri(manager, { cookie: rotatedCookie })).status).toBe(200);
+    expect(
+      (await getTotpUri(manager, { cookie: rotatedCookie, authorization: `Bearer ${echoedToken}` })).status,
+    ).toBe(200);
+  }, 60_000);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#10701 — the echoed token is the LIVE session, named exactly', () => {
+  it('it is the rotated session row, and not the deleted pre-enrolment one', async () => {
+    // Corroborates the resolution assertions at the storage layer, and pins
+    // the exact wrong value: asserting only "the echo changed" would be
+    // satisfied by echoing any other string.
+    const { engine, userId, preEnrolmentToken, echoedToken } = await arrangeCompletedEnrolment();
+
+    const live = sessionRows(engine).filter((r) => String(r.userId ?? r.user_id) === userId);
+    expect(live.map((r) => String(r.token))).toContain(echoedToken);
+
+    expect(echoedToken).not.toBe(preEnrolmentToken);
+    expect(sessionRows(engine).map((r) => String(r.token))).not.toContain(preEnrolmentToken);
+  }, 60_000);
+
+  it('it matches the session the response installed in its own cookie', async () => {
+    // The credential is READ BACK out of the response rather than minted, so
+    // this equality is the whole safety argument: the fix cannot hand a caller
+    // a session the request did not already grant it.
+    const { echoedToken, rotatedCookie } = await arrangeCompletedEnrolment();
+
+    const cookieValue = /session_token=([^;]+)/.exec(rotatedCookie)?.[1];
+    expect(cookieValue, 'no session cookie to compare against').toBeTruthy();
+    expect(decodeURIComponent(String(cookieValue)).split('.')[0]).toBe(echoedToken);
+  }, 60_000);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#10701 — nothing was loosened', () => {
+  // Direction (b) from the card — the resolver falling back to the cookie when
+  // the bearer is unusable — was ruled OUT of scope precisely because it stops
+  // an invalid credential from failing loud. These two pins are what would go
+  // red if someone later implemented it, so they are the guard on that ruling,
+  // not decoration.
+
+  it('anonymous is still refused', async () => {
+    // Pinning only the success direction goes green on a loosened
+    // implementation that authenticates everybody.
+    const { manager } = await arrangeCompletedEnrolment();
+
+    expect(await principalFor(manager, {})).toBeNull();
+    expect((await getTotpUri(manager, {})).status).toBe(401);
+  }, 60_000);
+
+  it('a bogus bearer still overrides a valid cookie and still fails loud', async () => {
+    // Bearer-over-cookie precedence is better-auth's, and this card does NOT
+    // change it. An invalid credential must keep failing closed even when the
+    // request also carries a good cookie.
+    const { manager, userId, rotatedCookie } = await arrangeCompletedEnrolment();
+
+    const bogus = { authorization: 'Bearer not-a-real-session-token' };
+    expect(await principalFor(manager, { cookie: rotatedCookie })).toBe(userId);
+    expect(await principalFor(manager, { cookie: rotatedCookie, ...bogus })).toBeNull();
+    expect((await getTotpUri(manager, { cookie: rotatedCookie, ...bogus })).status).toBe(401);
+  }, 60_000);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+describe('#10701 — the sign-in-challenge lane is untouched', () => {
+  it('completing a 2FA SIGN-IN still echoes a token that authenticates', async () => {
+    // The lane where the vendor mints the session it echoes: the two already
+    // agreed, so the repair is a no-op here. Pinned because "fix the broken
+    // lane" must not become "rewrite every lane".
+    const { manager, userId, secret, rotatedCookie } = await arrangeCompletedEnrolment();
+
+    // A fresh sign-in now stops at the 2FA challenge instead of returning a
+    // session — that is what having enrolled means.
+    const challenged = await post(manager, '/sign-in/email', { email: EMAIL, password: PASSWORD });
+    expect(challenged.status).toBe(200);
+    expect((await challenged.clone().json()) as any).toMatchObject({ twoFactorRedirect: true });
+
+    const completed = await post(
+      manager,
+      '/two-factor/verify-totp',
+      { code: totp(secret) },
+      { cookie: cookieHeader(challenged) },
+    );
+    expect(completed.status, `verify-totp (sign-in): ${await completed.clone().text()}`).toBe(200);
+
+    const signInToken = String(((await completed.clone().json()) as any).token);
+    expect(await principalFor(manager, { authorization: `Bearer ${signInToken}` })).toBe(userId);
+    expect((await getTotpUri(manager, { authorization: `Bearer ${signInToken}` })).status).toBe(200);
+
+    // And the enrolment session is a different, still-independent session.
+    expect(signInToken).not.toBe(rotatedCookie);
+  }, 60_000);
+});

--- a/packages/plugins/plugin-auth/src/two-factor-rotated-token-echo.ts
+++ b/packages/plugins/plugin-auth/src/two-factor-rotated-token-echo.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #10701 — a successful 2FA verification echoed a session token it had just
+ * DELETED, and a client that believed the echo locked itself out.
+ *
+ * ## The defect
+ *
+ * better-auth's `verifyTwoFactor` helper resolves the caller's session ONCE,
+ * at entry, and closes over it:
+ *
+ *     valid: async (ctx) => ctx.json({ token: session.session.token, ... })
+ *
+ * (`dist/plugins/two-factor/verify-two-factor.mjs`, measured 2026-08-21
+ * against the installed better-auth `1.7.1`.)
+ *
+ * On the ENROLMENT lane — a caller who is already signed in confirming a new
+ * TOTP factor — `/two-factor/verify-totp` rotates that session before it
+ * answers: it mints a new session, installs it with `setSessionCookie`, and
+ * then deletes the caller's original session row
+ * (`dist/plugins/two-factor/totp/index.mjs`). Only afterwards does it call
+ * `valid(ctx)` — which still holds the pre-rotation session and echoes the
+ * token of the row that was just deleted.
+ *
+ * So the 200 carries two credentials that disagree. The `Set-Cookie` names the
+ * live session; the JSON `token` names a session that no longer exists.
+ *
+ * ## Why a dead echo is worse than no echo
+ *
+ * Every other auth response in this repo echoes `token` as the UNSIGNED token
+ * of a LIVE session, and `bearer()` accepts exactly that: presented without a
+ * signature it signs the value itself before verifying
+ * (`dist/plugins/bearer/index.mjs` — the no-`.` branch). Measured on
+ * `/sign-up/email`: the body's `token` resolves to the user as a bearer.
+ *
+ * A client following that contract after enrolling in 2FA therefore stores a
+ * revoked token — and `bearer()`'s before-hook does not merely fail to
+ * authenticate it, it OVERWRITES the request's session cookie with it. A
+ * request carrying the still-valid rotated cookie AND the dead bearer resolves
+ * to nobody. The dead echo does not just fail; it destroys a working session.
+ * Fail-closed, no privilege gained — and a legitimate user locked out.
+ *
+ * ## The fix — echo the session the response actually installed
+ *
+ * This restores the contract; it does not change it. The field keeps its
+ * shape (the unsigned token) and its meaning ("the session you now hold").
+ * Only the value is corrected, from a deleted row to the live one — the very
+ * session the response staged in `Set-Cookie` a few lines earlier.
+ *
+ * Deliberately keyed on the MECHANISM rather than on the enrolment branch: the
+ * echo is repaired only when the response staged a session cookie whose token
+ * differs from the one being echoed. On the sign-in-challenge lane, where
+ * `valid()` mints the session it echoes, the two agree and this is a byte-for-
+ * byte no-op. Nothing is invented: the corrected value is read back out of the
+ * response's own cookie, so this cannot hand a caller a credential the request
+ * did not already grant it.
+ *
+ * ⚠️ NOT a resolver change. `bearer()`'s precedence over the cookie is
+ * untouched, and an invalid bearer still fails loud exactly as it does today —
+ * relaxing that rejection was considered and explicitly ruled out of scope for
+ * this card. The only thing that changes is which token we hand out.
+ *
+ * ## Scope
+ *
+ * `/two-factor/verify-otp` carries the byte-identical rotate-then-`valid(ctx)`
+ * block (same dist tree, `otp/index.mjs`), so it is the same defect and is
+ * covered by the same guard rather than left as a known-identical hole. The
+ * pins in `two-factor-rotated-token-echo.test.ts` drive the TOTP path, which is
+ * the one this repo's plugin wiring can exercise without OTP transport config.
+ * `/two-factor/verify-backup-code` does NOT rotate and is unaffected either
+ * way; it is listed for neither.
+ */
+
+/** The 2FA verification routes whose vendor implementation rotates the session. */
+export const ROTATING_TWO_FACTOR_VERIFY_PATHS: readonly string[] = [
+  '/two-factor/verify-totp',
+  '/two-factor/verify-otp',
+];
+
+/** Every `Set-Cookie` currently staged on the response, however the runtime spells it. */
+function stagedSetCookies(headers: Headers | undefined): string[] {
+  if (!headers) return [];
+  const viaGetter = (headers as any).getSetCookie?.();
+  if (Array.isArray(viaGetter)) return viaGetter;
+  const joined = headers.get('set-cookie');
+  return joined ? [joined] : [];
+}
+
+/**
+ * Percent-decode a cookie value the way `bearer()` does — and, like it, use the
+ * value verbatim when it turns out not to be percent-encoded after all.
+ */
+function tryDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * The UNSIGNED session token the response is installing, or `undefined` when it
+ * is not installing one.
+ *
+ * The cookie carries `<token>.<signature>`; `session.token` — the value every
+ * auth response body echoes — is the part before the signature. An expiring
+ * cookie (`max-age=0`) is a sign-OUT, not a rotation, and is ignored, matching
+ * the guard `bearer()`'s own after-hook uses before emitting `set-auth-token`.
+ */
+async function installedSessionToken(ctx: any): Promise<string | undefined> {
+  const headers: Headers | undefined = ctx?.context?.responseHeaders;
+  const staged = stagedSetCookies(headers);
+  if (staged.length === 0) return undefined;
+  const cookieName: unknown = ctx?.context?.authCookies?.sessionToken?.name;
+  if (typeof cookieName !== 'string' || !cookieName) return undefined;
+
+  const { parseSetCookieHeader } = await import('better-auth/cookies');
+  for (const cookie of staged) {
+    const parsed = parseSetCookieHeader(cookie).get(cookieName);
+    if (!parsed?.value) continue;
+    if (parsed['max-age'] === 0) continue;
+    const unsigned = tryDecode(parsed.value).split('.')[0];
+    if (unsigned) return unsigned;
+  }
+  return undefined;
+}
+
+/** Did the route succeed, and does its payload echo a token? */
+async function echoedTokenPayload(ctx: any): Promise<{ token: string } | undefined> {
+  const returned = ctx?.context?.returned;
+  if (!returned || typeof returned !== 'object') return undefined;
+  try {
+    const { isAPIError } = await import('better-auth/api');
+    if (isAPIError(returned)) return undefined;
+  } catch {
+    if (returned instanceof Error) return undefined;
+  }
+  return typeof (returned as any).token === 'string' && (returned as any).token
+    ? (returned as any)
+    : undefined;
+}
+
+/**
+ * Repair the `token` a 2FA verification echoes, so it names the session the
+ * same response installed rather than the one it deleted.
+ *
+ * A no-op for every other path, for a failed verification, for a response that
+ * installs no session cookie, and — the common case — whenever the echoed token
+ * already matches the installed one.
+ *
+ * Never throws. A verification that genuinely succeeded must not be turned into
+ * a failure because the response body could not be tidied; the caller's cookie
+ * is valid either way, and this repair only widens which credentials from the
+ * response work. Any unexpected shape therefore leaves the payload untouched.
+ */
+export async function echoInstalledSessionToken(ctx: any): Promise<void> {
+  try {
+    if (!ROTATING_TWO_FACTOR_VERIFY_PATHS.includes(ctx?.path)) return;
+    const payload = await echoedTokenPayload(ctx);
+    if (!payload) return;
+    const installed = await installedSessionToken(ctx);
+    if (!installed || installed === payload.token) return;
+    payload.token = installed;
+  } catch {
+    /* leave the payload exactly as the vendor route wrote it */
+  }
+}


### PR DESCRIPTION
Fixes #10701

A successful 2FA verification handed the caller a session token it had just
deleted, and a client that believed the echo locked itself out of a session it
still held.

## What was measured

`POST /api/v1/auth/two-factor/verify-totp` answers `200` carrying two
credentials that disagree. The `Set-Cookie` names the caller's rotated session;
the JSON `token` names the session row the same request deleted.

Reproduced from the mechanism description (the full reproduction is withheld
under the auth/authz disclosure carve-out and stays in the QA session). All
three cases from the report were measured side by side in one tree, one run,
one arrangement — before the fix:

| credentials presented | `get-session` | `get-totp-uri` |
|---|---|---|
| rotated cookie alone | resolves to the user | `200` |
| echoed `token` as bearer alone | `200` and **empty** | `401` |
| rotated cookie **+** echoed `token` | `200` and **empty** | `401` |
| `set-auth-token` bearer alone (control) | resolves to the user | `200` |

The third row is the finding. It is not that the bearer is useless — it is that
a useless bearer **destroys an otherwise valid cookie session**. The fourth row
is the control that says so: the bearer seam itself works fine, so nothing about
credential resolution is broken. Only the echoed value is wrong.

## What the `token` turned out to be

Not an internal identifier, and not a malformed credential: it is the caller's
**pre-rotation session token** — a credential that was valid until moments
earlier in the same request.

better-auth's `verifyTwoFactor` resolves the caller's session once, at entry,
and closes over it:

```js
valid: async (ctx) => ctx.json({ token: session.session.token, ... })
```

On the enrolment lane, `/two-factor/verify-totp` rotates that session before it
answers — mints a new session, installs it with `setSessionCookie`, then deletes
the caller's original row — and only afterwards calls `valid(ctx)`, which still
holds the pre-rotation session. Measured on the installed better-auth `1.7.1`
(`dist/plugins/two-factor/verify-two-factor.mjs`,
`dist/plugins/two-factor/totp/index.mjs`).

The reason a dead echo is worse than no echo is `bearer()`: its before-hook
**overwrites** the request's session cookie with whatever the `Authorization`
header carries, so presenting the dead token does not merely fail — it discards
the good cookie and drops the request to anonymous.

## The fix

Direction (a), the "make the echoed token an actually-accepted bearer" arm. The
value is now read back out of the response's own session cookie, so `token`
names the session the response actually installed.

The arm was chosen on measurement, not preference: every other auth response in
this repo echoes `token` as the **unsigned** token of a live session, and
`bearer()` accepts exactly that (presented without a signature it signs the
value itself before verifying). Measured on `/sign-up/email`, that body's
`token` resolves to the user as a bearer. So `verify-totp` is the only endpoint
breaking a contract the rest of the surface already keeps — which makes this a
restoration rather than a change, and made "stop echoing the token" the wrong
arm: the field is right, the value was wrong.

Keyed on the mechanism rather than the enrolment branch: the echo is repaired
only when the response staged a session cookie whose token differs from the one
being echoed. Nothing is invented — the corrected value comes out of the
response's own cookie, so this cannot hand a caller a credential the request did
not already grant it.

`/two-factor/verify-otp` carries the byte-identical rotate-then-answer block and
is covered by the same guard rather than left as a known-identical hole; it is
**not** pinned by a test here, because exercising it needs OTP transport
configuration this package's harness does not wire.
`/two-factor/verify-backup-code` does not rotate and is unaffected.

## Resolver precedence is untouched

Direction (b) from the report — the resolver falling back to the cookie when the
bearer is unusable — was ruled out of scope because it stops an invalid
credential from failing loud, and this change does not go near it. Two pins hold
that line so a later attempt to loosen it reddens this suite: anonymous is still
refused, and a bogus bearer still overrides a valid cookie and still fails
closed.

## Pins

| # | direction | pin |
|---|---|---|
| ① | works | the echoed `token` is an accepted bearer — resolves to the exact user id, and `get-totp-uri` answers `200` |
| ② | still works | the rotated cookie alone still authenticates |
| ⭐ | the card | cookie **+** echoed token together resolve to the user (was anonymous) |
| ③ | still refused | anonymous resolves to nobody and gets `401` |
| ③ | still refused | a bogus bearer still overrides a valid cookie and still `401`s |
| ④ | genuinely accepted | the echoed token is a **live session row**, is not the deleted pre-enrolment token, and equals the token in the response's own `Set-Cookie` |
| — | untouched | completing a 2FA **sign-in** still echoes a token that authenticates |

Assertions end at *which principal does the next request resolve to*, never at
status alone: `get-session` answers `200` for anonymous, which is exactly how
this defect read in the field.

## Ablation

Predicted signature written down before mutating; both directions run.
Neutralising the repair predicted 4 failed / 13 passed of 17, naming the four
tests and their first failing assertions. Measured: **4 failed / 13 passed**,
the same four, with the predicted messages — `AssertionError: expected null to
be` the user id, and `AssertionError: expected 401 to be 200`. The load-bearing
prediction held too: the sign-in lane test **passed** under ablation,
independently confirming the repair is a genuine no-op there rather than an
untested claim.

Restore proved byte-identical by `git hash-object`
(`6b352697eabe4b4320cd61c84696cf6cbfce98be` before and after), and the restored
tree re-ran 17/17 green.

Positive control for `src` vs `dist`, settled rather than asserted: the package
has **no `dist/` directory at all** and its vitest config declares no alias,
while the suite ran 1394 tests green — a suite resolving the subject through a
built `dist/` could not have run.

## Gates

Union derived after the final commit on a clean tree, with no path arguments
(`node scripts/pm/dispatch-gates.mjs`, 4 paths vs merge base `376b3dc0b`), at
`d5330290f`. Exit codes captured before any pipe. All 18 exit `0`; none returned
`254`, printed `Command not found`, or refused with `PREREQUISITE NOT MET`.

Selected verdict lines, as each gate printed them:

- `✓ check-adr-0087-registration: this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).`
- ✓ `check-changeset-no-major`: "This diff introduces no `major` bump."
- `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).`
- `check-engine-double-contract: OK — 376 pinned, 133 in the DEBT ledger, 2 exempt.`
- `✓ where-matcher conformance holds: 275 matcher(s) discovered, 275 answer the combinator battery correctly or refuse it loudly (165 refuse).`
- `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new, and every file in the population parsed.`
- `check-nul-bytes: OK (scanned 6316 text file(s) ... no raw ASCII control bytes).`
- `✓ check-route-envelope self-test passed`
- `check-dispatcher-error-vocabulary --self-test: 8 shapes + 102 assertions OK (vocabulary + #9098 door typing)`

The last two were **not** named by the path derivation; they were run explicitly
with `--self-test` because this change sits in the route/envelope class.

Package-scoped: `@objectstack/plugin-auth` `pnpm test` 66 files / 1394 tests
passed; `pnpm typecheck` (`tsc --noEmit`) clean.

**Declared narrowing.** `check:type-check-debt --re-measure` was not run — it
needs the whole workspace closure built. What matters for that ratchet was
measured directly instead: with the package's test files included in the tsc
program, the new test file contributes **0** raw errors, so it cannot drift the
frozen `TEST_DEBT` count. The ledger entry was not edited and `--lower` was not
run. CI runs the gate itself.

## Versioning note for review

Shipped as `patch`, deliberately, and this is the call most worth a second pair
of eyes. The dispatch expected `minor` on the assumption that the credential
semantics of a published endpoint change. What the measurement shows is a
contract **restoration**: the field keeps its shape (the unsigned session token)
and its meaning ("the session you now hold"), only the value moves from a
deleted row to the live one, and the previous value was not a usable credential
for anything — so no consumer expression has to be rewritten and nothing could
have depended on it. No breaking declaration is made, and consequently no
ADR-0087 disposition marker is required. If review reads it the other way, the
flip is a one-file edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
