### PR TITLE
chore(claude): allowlist the claude-code-remote trigger/session self-management tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,14 @@
       "mcp__Claude_in_Chrome__find",
       "mcp__Claude_in_Chrome__read_console_messages",
       "mcp__Claude_in_Chrome__list_connected_browsers",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__fire_trigger",
+      "mcp__Claude_Code_Remote__update_trigger",
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__get_session",
+      "mcp__Claude_Code_Remote__list_sessions",
+      "mcp__Claude_Code_Remote__create_trigger",
       "Bash(agent-browser snapshot *)",
       "Bash(agent-browser skills *)"
     ]


### PR DESCRIPTION
Fixes #10973

## What changed

Eight `permissions.allow` entries added to `.claude/settings.json` — the claude-code-remote
**trigger/session self-management family**, in the order the card names it:

```
mcp__Claude_Code_Remote__delete_trigger
mcp__Claude_Code_Remote__fire_trigger
mcp__Claude_Code_Remote__update_trigger
mcp__Claude_Code_Remote__send_later
mcp__Claude_Code_Remote__list_triggers
mcp__Claude_Code_Remote__get_session
mcp__Claude_Code_Remote__list_sessions
mcp__Claude_Code_Remote__create_trigger
```

They are inserted after the existing MCP entries and before the two `Bash(...)` entries,
keeping the file's MCP-then-Bash grouping. No other key, no reformatting: the file
round-trips byte-for-byte through `JSON.stringify(parsed, null, 2)` plus a trailing
newline, so indentation, key order and style are unchanged.

Nothing else in the repo is touched. File surface: `.claude/settings.json` only.

## Deliberately NOT allowlisted

`create_session`, `archive_session`, `unarchive_session`, `interrupt_session`,
`set_session_title`, `set_session_tags`, `add_repo`, `subscribe_pr_activity`,
`unsubscribe_pr_activity`, `list_repos`, `list_environments`, `register_repo_root`.

Those are fleet-shape, spend and scope actions — they stay behind a confirmation prompt.
The eight above act only on the account's own Routines and on reading its own sessions;
none of them reaches a repo or a code surface, which is the risk argument for the allow.

## Evidence that fixed the prefix spelling

The card flagged two candidate spellings for the server segment
(`Claude_Code_Remote` vs a lowercase `claude-code-remote`). Only one spelling is
attested by a harness record; the lowercase one is not attested anywhere:

1. **Live tool schemas in this session** name the tools
   `mcp__Claude_Code_Remote__get_session`, `mcp__Claude_Code_Remote__create_trigger`,
   `mcp__Claude_Code_Remote__send_later`, etc. — this is the name the tool is invoked by,
   and permission matching is against exactly that invocation name.
2. **The session transcript's accepted `tool_use` blocks** carry that spelling verbatim:
   `"name":"mcp__Claude_Code_Remote__get_session"` (12 occurrences),
   `__send_later` (4), `__list_triggers` (1), `__create_trigger` (1) — all successful
   calls, i.e. names the harness itself resolved.
3. **The harness tool registry echoes it**: a `ToolSearch` `select:` query resolved
   `mcp__Claude_Code_Remote__get_session` back as a match.
4. **The lowercase spelling has exactly one occurrence in the whole record**, and it is
   not a harness record — it is prose inside a chat message written by the PM seat
   itself, proposing `mcp__claude-code-remote__*` as a hypothesis and asking the dev to
   verify it against a real prompt record. That is the speculation this card asked to
   resolve, not evidence for it.

So a single spelling is used. A second, lowercase copy would have matched nothing and
would only have made the file read as if two things were verified when one was.

The file's existing 16 MCP entries use the same convention
(`mcp__Claude_Preview__preview_screenshot`, `mcp__Claude_in_Chrome__find`) — server
segment spelled exactly as the live tool name spells it.

Correction to one dispatch assumption, for the record: the file carried **18**
`permissions.allow` entries, but they are **16 MCP entries plus 2 `Bash(...)` entries**,
not 18 MCP entries. The spelling precedent is unaffected.

JSON carries no comments, so this evidence lives here rather than in the file.

## Verification

All commands below were run in a dedicated worktree at head `13c648be3` — the final
commit — on an otherwise clean tree.

Strict JSON parse:

```
node -e "JSON.parse(fs.readFileSync('.claude/settings.json','utf8'))"
PARSE_OK allow_entries=26
ccr=8
trailing_newline=true
roundtrip_identical=true
JSON_EXIT=0
```

Gate families derived from the real change set with `node scripts/pm/dispatch-gates.mjs`
(no path args — the script derives the change set itself; it reported
`change set derived from git — 1 path(s) vs merge base 81845c65a`). Four families
matched, all run, each exit code captured before any pipe:

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 389 files clean — no bare metadata literals.` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 416 files / 1444 TS blocks judged clean by @objectstack/formula.` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 90 assertions ...` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `pnpm check:nul-bytes` (run for any edit) | 0 | `check-nul-bytes: OK (scanned 6329 text file(s) ... no raw ASCII control bytes).` |

Every heavy command ran through `scripts/pm/os-verify-lock.sh`; each printed
`VERDICT command-exit 0`. `check:doc-formula-expressions` first failed on a missing
dependency closure in the fresh worktree (`ERR_MODULE_NOT_FOUND: @objectstack/formula`),
and was green after `pnpm --filter '@objectstack/lint^...' build` — recorded so the first
red is not mistaken for a finding.

**Declared narrowing (repo-wide `pnpm lint`).** Not run here; run targeted instead, with
the three pieces of evidence that make the narrowing a measurement rather than a skip:
(1) the population is read from eslint's own configuration, not guessed — eslint reports
`File ignored because no matching configuration was supplied.` for `.claude/settings.json`,
so this path is outside the linted population by eslint's own account; (2) the file count
comes from `--format json`: 1 file inspected, `errorCount: 0`, `fatalErrorCount: 0`;
(3) invariance for untouched files — the diff adds eight string literals to one JSON file
and changes no source, no eslint config and no tsconfig, so no untouched file's verdict
can move. CI runs the full farm regardless.

The reported symptom itself (no more `{"trigger_id": ...}` confirm dialogs on unattended
auto-mode seats) can only be confirmed after merge, in a live session — that is the
maintainer's observation to report, as the card states.

## Housekeeping

- Draft PR against `main`, governed face (`.claude/**`) — human merge only.
- `skip-changeset`: this PR publishes nothing (harness permission config only).
- One unrelated file shows as modified in the worktree and was deliberately left alone:
  `pnpm install` flipped the file mode of `packages/create-objectstack/bin/create-objectstack.js`
  from 100644 to 100755. It is not staged and not in this branch's commit, which contains
  exactly one file and eight added lines.

Ref: #10686 — permission classifier misjudgments, same lane; that card is not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ApyDuQY2fkunMCqXiqvBhR)_