### PR TITLE
fix(service-datasource): read the introspected primary key at the isPrimary/primaryKey seam

### DIFF
--- a/.changeset/external-catalog-introspected-primary-key.md
+++ b/.changeset/external-catalog-introspected-primary-key.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/service-datasource": patch
+---
+
+Restore the introspected primary key in the persisted `external_catalog`
+(#10676). `ExternalDatasourceService` reads `column.primaryKey` — the
+`packages/spec` `IntrospectedColumn` spelling — but `plugin.ts` hands it the
+driver's `introspectSchema()` result unmodified, and `SqlDriver` (and
+`SqliteWasmDriver`, which extends it) speaks the other `IntrospectedColumn`
+contract, from `packages/objectql/src/util.ts`: it sets `column.isPrimary` and
+fills `table.primaryKeys`, never `column.primaryKey`.
+
+Measured against a live SQLite database: for a table declared
+`primary key (id)`, the driver's `id` column carries `isPrimary: true` and the
+table carries `primaryKeys: ['id']`, while `primaryKey` is `undefined`. Because
+`ExternalCatalogSchema` defaults `primaryKey` to `false`, `refreshCatalog`
+persisted a catalog in which **every** column of **every** remote table claimed
+not to be part of the remote key — so Studio's schema browser and the boot gate
+read a catalog that shows no primary keys at all.
+
+The seam now reads the union of all three signals (`primaryKey`, `isPrimary`,
+`table.primaryKeys`) rather than any one of them. No in-tree producer uses a
+`false` to negate a key another signal asserts, and taking the union means a
+producer that fills only the table-level list — or only the per-column flag —
+cannot lose half a composite key. No response or record shape changes: a field
+that should always have carried the introspected value starts carrying it.
+
+The regression pin drives the service off a **real** `SqlDriver.introspectSchema()`
+result rather than a hand-written fixture. The pre-existing suite could not see
+this defect precisely because it hand-wrote its fixture in the spec spelling, so
+no test ever fed the service what a driver actually emits.
+
+Not fixed here: `generateObjectDraft` still drops the key from the generated
+object definition. Its destination is an open contract question rather than a
+missing read — `fields.<name>.primaryKey` is **not** an authorable spec field
+key (an object literal carrying it fails `tsc` against `ServiceObject` with
+TS2353, and `ObjectSchema.safeParse` with `unrecognized_keys`), and there is no
+key on `ObjectExternalBindingSchema` to hold a remote primary key either. See
+#10676 for the routing decision.

--- a/packages/services/service-datasource/src/__tests__/external-introspection-seam.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-introspection-seam.test.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The pin the original suite could not be: this service driven off a REAL
+ * `SqlDriver.introspectSchema()` result, not a hand-written fake.
+ *
+ * `external-datasource-service.test.ts` hand-writes its fixture with
+ * `primaryKey: true` — the `packages/spec` contract spelling
+ * (`contracts/schema-diff-service.ts`). The driver emits the OTHER spelling:
+ * `SqlDriver.introspectSchema` sets `col.isPrimary` and fills
+ * `table.primaryKeys` (the `packages/objectql/src/util.ts` shape). `plugin.ts`
+ * hands the driver's result to this service unmodified, so the two contracts
+ * meet — and disagree — exactly here. A fixture written in EITHER spelling is
+ * blind to that; only a live introspection can see it, so every case below
+ * introspects a real in-memory SQLite database rather than describing one.
+ *
+ * Both directions are pinned deliberately: an implementation that stamped the
+ * key onto the first column would satisfy a positive-only suite.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { SqlDriver } from '@objectstack/driver-sql';
+import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+import {
+  ExternalDatasourceService,
+  type DatasourceLike,
+} from '../external-datasource-service.js';
+
+const opened: SqlDriver[] = [];
+
+afterEach(async () => {
+  while (opened.length) {
+    const d = opened.pop()!;
+    try {
+      await (d as unknown as { knex?: { destroy(): Promise<void> } }).knex?.destroy();
+    } catch {
+      /* the pool may never have opened */
+    }
+  }
+});
+
+/**
+ * A live in-memory SQLite database, introspected by the real driver. Returns
+ * the driver's own result, deliberately NOT reshaped — anything this service
+ * needs, it must read from the bytes the driver actually produces.
+ */
+async function introspectReal(ddl: (knex: never) => Promise<void>): Promise<unknown> {
+  const driver = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  } as never);
+  opened.push(driver);
+  await ddl((driver as unknown as { knex: never }).knex);
+  return driver.introspectSchema();
+}
+
+/** Wire the service to a fixed introspection result, exactly as `plugin.ts` does. */
+function serviceOver(schema: unknown): ExternalDatasourceService {
+  return new ExternalDatasourceService({
+    introspect: async () => schema as IntrospectedSchema,
+    getDatasource: async (name): Promise<DatasourceLike> => ({ name, schemaMode: 'external' }),
+    getObject: async () => undefined,
+    listObjects: async () => [],
+  });
+}
+
+/** The catalog columns for one remote table, keyed by column name. */
+async function catalogColumns(
+  schema: unknown,
+  remoteName: string,
+): Promise<Record<string, { primaryKey: boolean; nullable: boolean; sqlType: string }>> {
+  const catalog = await serviceOver(schema).refreshCatalog('showcase_external');
+  const table = catalog.tables.find((t) => t.remoteName === remoteName);
+  expect(table, `no '${remoteName}' in the refreshed catalog`).toBeDefined();
+  return Object.fromEntries(table!.columns.map((c) => [c.name, c])) as never;
+}
+
+describe('the introspection seam, as a real SqlDriver actually spells it', () => {
+  it('the driver speaks isPrimary/primaryKeys and never the spec spelling', async () => {
+    const schema = (await introspectReal(async (knex: never) => {
+      await (knex as { schema: { createTable(n: string, cb: (t: never) => void): Promise<void> } }).schema.createTable(
+        'customers',
+        (t: never) => {
+          const b = t as unknown as { string(n: string): { primary(): void }; integer(n: string): void };
+          b.string('id').primary();
+          b.string('name');
+          b.integer('age');
+        },
+      );
+    })) as { tables: Record<string, { primaryKeys: string[]; columns: Record<string, unknown>[] }> };
+
+    const table = schema.tables.customers;
+    const id = table.columns.find((c) => c.name === 'id')!;
+
+    // This is the whole defect, stated as an assertion on the producer's own
+    // output. If it ever flips — the driver starting to emit the spec
+    // spelling, or the two contracts being reconciled upstream — the union
+    // read in `primaryKeyReader` stops being load-bearing and should be
+    // re-derived rather than quietly relaxed.
+    expect(table.primaryKeys).toEqual(['id']);
+    expect(id.isPrimary).toBe(true);
+    expect(id.primaryKey).toBeUndefined();
+  });
+
+  it('refreshCatalog carries the introspected key onto the right column only', async () => {
+    const schema = await introspectReal(async (knex: never) => {
+      await (knex as { schema: { createTable(n: string, cb: (t: never) => void): Promise<void> } }).schema.createTable(
+        'customers',
+        (t: never) => {
+          const b = t as unknown as { string(n: string): { primary(): void }; integer(n: string): void };
+          b.string('id').primary();
+          b.string('name');
+          b.integer('age');
+        },
+      );
+    });
+
+    const cols = await catalogColumns(schema, 'customers');
+    expect(cols.id.primaryKey).toBe(true);
+    // …and nothing else was promoted.
+    expect(cols.name.primaryKey).toBe(false);
+    expect(cols.age.primaryKey).toBe(false);
+  });
+
+  it('refreshCatalog invents no key for a table that declares none', async () => {
+    const schema = await introspectReal(async (knex: never) => {
+      await (knex as { schema: { createTable(n: string, cb: (t: never) => void): Promise<void> } }).schema.createTable(
+        'events',
+        (t: never) => {
+          const b = t as unknown as { string(n: string): unknown };
+          b.string('label');
+          b.string('payload');
+        },
+      );
+    });
+
+    const cols = await catalogColumns(schema, 'events');
+    // Still a usable catalog entry…
+    expect(Object.keys(cols)).toEqual(['label', 'payload']);
+    // …and no column was promoted, least of all the first one.
+    expect(cols.label.primaryKey).toBe(false);
+    expect(cols.payload.primaryKey).toBe(false);
+  });
+});
+
+describe('the seam read, where the two spellings disagree', () => {
+  /**
+   * No in-tree driver produces a disagreement — `SqlDriver` derives
+   * `isPrimary` FROM `primaryKeys`, so the two always agree. This case is
+   * therefore hand-built ON PURPOSE, and it is the one place in this file
+   * where that is the right instrument: it fixes the behaviour under a
+   * disagreement no live database can currently stage, so a future producer
+   * that fills only one of the two signals cannot silently lose half a
+   * composite key. The spelling seam itself is pinned above, against a real
+   * driver, where a fake would have been blind.
+   */
+  function serviceOverRaw(table: unknown): ExternalDatasourceService {
+    return serviceOver({ tables: { order_lines: table } });
+  }
+
+  const cols = [
+    { name: 'order_id', type: 'varchar', nullable: false },
+    { name: 'line_no', type: 'varchar', nullable: false },
+    { name: 'sku', type: 'varchar', nullable: true },
+  ];
+
+  it('takes the union when the table-level list is wider than the per-column flag', async () => {
+    const catalog = await serviceOverRaw({
+      name: 'order_lines',
+      primaryKeys: ['order_id', 'line_no'],
+      columns: cols.map((c) => ({ ...c, isPrimary: c.name === 'order_id' })),
+    }).refreshCatalog('showcase_external');
+
+    const byName = Object.fromEntries(catalog.tables[0].columns.map((c) => [c.name, c]));
+    expect(byName.order_id.primaryKey).toBe(true);
+    expect(byName.line_no.primaryKey).toBe(true);
+    expect(byName.sku.primaryKey).toBe(false);
+  });
+
+  it('takes the union when the per-column flag is wider than the table-level list', async () => {
+    const catalog = await serviceOverRaw({
+      name: 'order_lines',
+      primaryKeys: ['order_id'],
+      columns: cols.map((c) => ({ ...c, isPrimary: c.name !== 'sku' })),
+    }).refreshCatalog('showcase_external');
+
+    const byName = Object.fromEntries(catalog.tables[0].columns.map((c) => [c.name, c]));
+    expect(byName.order_id.primaryKey).toBe(true);
+    expect(byName.line_no.primaryKey).toBe(true);
+    expect(byName.sku.primaryKey).toBe(false);
+  });
+
+  it('still honours the spec spelling on its own — the pre-existing fixtures keep working', async () => {
+    const catalog = await serviceOverRaw({
+      name: 'order_lines',
+      // No `primaryKeys`, no `isPrimary` — the hand-written shape the rest of
+      // this package's suite feeds in.
+      columns: cols.map((c) => ({ ...c, primaryKey: c.name === 'order_id' })),
+    }).refreshCatalog('showcase_external');
+
+    const byName = Object.fromEntries(catalog.tables[0].columns.map((c) => [c.name, c]));
+    expect(byName.order_id.primaryKey).toBe(true);
+    expect(byName.line_no.primaryKey).toBe(false);
+  });
+});

--- a/packages/services/service-datasource/src/external-datasource-service.ts
+++ b/packages/services/service-datasource/src/external-datasource-service.ts
@@ -22,6 +22,7 @@ import type {
   SchemaValidationReport,
   IntrospectedSchema,
   IntrospectedTable,
+  IntrospectedColumn,
 } from '@objectstack/spec/contracts';
 import type { SchemaDiffEntry } from '@objectstack/spec/shared';
 import {
@@ -92,6 +93,63 @@ export interface ExternalDatasourceServiceConfig {
 
 /** Columns ObjectStack manages itself — never validated against the remote. */
 const BUILTIN_COLUMNS = new Set(['id', 'created_at', 'updated_at']);
+
+/**
+ * Read "is this column part of the remote primary key" across the TWO
+ * introspection contracts that meet at this service.
+ *
+ * `plugin.ts` hands the driver's `introspectSchema()` result to this service
+ * unmodified, and the driver does not speak the contract this file is typed
+ * against:
+ *
+ * | producer                                       | per-column     | table-level    |
+ * | ---------------------------------------------- | -------------- | -------------- |
+ * | `SqlDriver` (+ `SqliteWasmDriver`, which extends it) | `isPrimary`    | `primaryKeys`  |
+ * | `packages/spec` `IntrospectedColumn` (what this file's types say) | `primaryKey`   | —              |
+ *
+ * Measured against a live SQLite database at `368e7a06f`: the driver's column
+ * for a `primary key (id)` table carries `isPrimary: true` and the table
+ * carries `primaryKeys: ['id']`, while `primaryKey` is `undefined`. Reading
+ * only `col.primaryKey` therefore reads a key no in-tree driver ever sets, and
+ * the remote key is silently lost.
+ *
+ * This reads the UNION of all three signals rather than picking one:
+ *
+ *  - No in-tree producer uses `primaryKey: false` / `isPrimary: false` to
+ *    NEGATE a key another signal asserts — the falses are just "not a key",
+ *    written by producers that fill exactly one of the three. A precedence
+ *    chain would therefore drop a real key whenever the winning signal is the
+ *    one its producer left blank, which is the defect being repaired here.
+ *  - A producer that fills only `table.primaryKeys` (the shape a table-level
+ *    reader would naturally emit) is covered without needing a per-column flag,
+ *    and vice versa.
+ *
+ * When the per-column flag and the table-level list DISAGREE, the union takes
+ * both. That is deliberate: for a federated table, under-reporting the key
+ * costs the caller its addressing key, and no in-tree consumer treats a
+ * column's PK-ness as an exclusive claim. Note that no in-tree driver produces
+ * such a disagreement today — `SqlDriver` derives `isPrimary` FROM
+ * `primaryKeys`, so the two always agree, including where both are wrong (a
+ * SQLite composite key reports only its first column, because
+ * `introspectPrimaryKeys` filters `PRAGMA table_info` on `pk === 1` while
+ * SQLite numbers composite members `1, 2, ...`). That truncation is upstream
+ * of this seam and is not repaired here.
+ *
+ * Deliberately structural: the extra spellings are read off the value without
+ * widening any declared contract, because reconciling
+ * `packages/objectql/src/util.ts` with
+ * `packages/spec/src/contracts/schema-diff-service.ts` is a spec-owned change.
+ */
+function primaryKeyReader(table: IntrospectedTable): (col: IntrospectedColumn) => boolean {
+  const declared = (table as unknown as { primaryKeys?: unknown }).primaryKeys;
+  const listed = new Set(
+    Array.isArray(declared) ? declared.filter((n): n is string => typeof n === 'string') : [],
+  );
+  return (col) =>
+    col.primaryKey === true ||
+    (col as { isPrimary?: unknown }).isPrimary === true ||
+    listed.has(col.name);
+}
 
 /** Split a possibly schema-qualified name (`mart.fact_orders`). */
 function parseQualified(raw: string): { schema?: string; name: string } {
@@ -302,6 +360,12 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
       dialect: schema.dialect,
       tables: Object.values(schema.tables).map((t) => {
         const { schema: s, name } = parseQualified(t.name);
+        // The introspection seam: a real driver spells this `isPrimary` /
+        // `primaryKeys`, never `primaryKey`. `ExternalCatalogSchema` defaults
+        // the key to `false`, so reading only `c.primaryKey` persisted a
+        // catalog in which EVERY column claimed not to be part of the remote
+        // key — including the ones that are.
+        const isPk = primaryKeyReader(t);
         return {
           remoteSchema: s,
           remoteName: name,
@@ -309,7 +373,7 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
             name: c.name,
             sqlType: c.type,
             nullable: c.nullable,
-            primaryKey: c.primaryKey,
+            primaryKey: isPk(c),
             suggestedFieldType: suggestFieldTypeForSqlType(c.type, schema.dialect as SqlDialect),
           })),
         };


### PR DESCRIPTION
**Part of #10676.** The seam read is repaired and pinned; the object-draft half of that card is
*not* discharged here, because measurement turned it into a contract question rather than a
missing read. What remains, and why, is in "Not fixed here" below.

## The defect

`ExternalDatasourceService` is typed against the `packages/spec` `IntrospectedColumn`
(`contracts/schema-diff-service.ts`), which spells the flag `primaryKey`. But `plugin.ts` hands it
the driver's `introspectSchema()` result **unmodified**, and `SqlDriver` implements the *other*
`IntrospectedColumn` — the one in `packages/objectql/src/util.ts` — which spells it `isPrimary` and
additionally fills `table.primaryKeys`.

So the service reads a key no in-tree driver ever sets.

Measured on current `origin/main` (`368e7a06f`), against a live in-memory SQLite database declared
`primary key (id)` — the driver's own output, not a description of it:

```json
{ "name": "id", "type": "varchar", "isPrimary": true, ... }     // primaryKey: undefined
{ "name": "customers", "primaryKeys": ["id"], ... }
```

`refreshCatalog` fed that `undefined` into `ExternalCatalogSchema`, whose `primaryKey` key is
`z.boolean().default(false)`. The default absorbed it silently, so the persisted `external_catalog`
recorded **every column of every remote table** as not being part of the remote key — including the
ones that are. Studio's schema browser and the boot gate read that record.

## The repair

One module-local helper, `primaryKeyReader(table)`, reading the **union** of the three signals
(`col.primaryKey`, `col.isPrimary`, `table.primaryKeys`) rather than picking one, wired into
`refreshCatalog`.

Union rather than a precedence chain, deliberately: no in-tree producer uses a `false` to *negate* a
key another signal asserts — the falses are just "not a key", written by producers that fill exactly
one of the three. A precedence chain would drop a real key whenever the winning signal is the one
its producer left blank, which is the defect being repaired. **Where the per-column flag and the
table-level list disagree, the union takes both**; under-reporting a federated table's key costs the
caller its addressing key, and no in-tree consumer treats a column's PK-ness as an exclusive claim.

The extra spellings are read structurally off the value. Nothing in `packages/spec` or
`packages/objectql/src/util.ts` is touched — reconciling those two declarations is spec-owned and is
not this PR.

Note that no in-tree driver produces a disagreement *today*: `SqlDriver` derives `isPrimary` **from**
`primaryKeys`, so the two always agree — including where both are wrong together. See "composite
keys" below.

## Clause ②

The response and record *shapes* do not change. A field that should always have carried the
introspected value starts carrying it: `external_catalog` columns already declare `primaryKey`, and
already emit it on every column — only ever as `false`. This PR makes the `true`s true.

⚠️ The dispatch asked me to stop if any consumer keys on the **absence** of `primaryKey`. On the
catalog path, none does — the key is non-optional in `ExternalCatalogSchema` and is always present.
**On the object-draft path one does**, which is exactly why that half is not shipped here; see below.

## Composite keys

The union handles a disagreement, but on SQLite the two signals agree *and are both short*: a
composite key is truncated **upstream in the driver**, before this seam ever sees it.
`introspectPrimaryKeys` filters `PRAGMA table_info` on `row.pk === 1`, while SQLite numbers
composite members `1, 2, 3…`. Measured on `t.primary(['order_id','line_no'])`: PRAGMA reports
`line_no` with `pk: 2`, and the driver returns `primaryKeys: ["order_id"]`. Filed as **#10997**;
not repaired here (different package, different lane).

## Not fixed here — and why it is a decision, not an omission

`generateObjectDraft` still drops the key. Restoring it there is blocked on a contract question that
this lane cannot answer, so it is escalated rather than guessed:

A field-level `primaryKey` — i.e. `fields.FIELDNAME.primaryKey`, the exact key this generator
renders — is **not an authorable spec field key**. Measured, with a positive control in the same
tsc program:

- rendered draft → `error TS2353: ... 'primaryKey' does not exist in type ...` against the
  `ServiceObject` annotation the generator itself writes; the identical file with the key removed
  produced no diagnostic.
- `ObjectSchema.safeParse` → `unrecognized_keys` at `["fields","id"]`; identical definition without
  the key → `success: true`.

That strict schema *is* a consumer keying on the absence of `primaryKey`, so shipping the draft half
under the Clause-② reading above would have been wrong. And there is no other authorable home for it:
`ObjectExternalBindingSchema` is a `strictObject` with no key for a remote primary key either.

Filed as **#11000** with the three candidate repairs (emit it anyway / reuse `externalId` /
add an authorable spelling) and the measurements behind each. Reported as `needs_decision` on
#10676. Note #11000 is reachable today without this PR: the `opts.primaryKey` path already emits
that key and the existing suite pins it.

Adjacent, untouched: **#10712** (the same draft also fails `os build` on the missing namespace
prefix and absent `sharingModel`) and **#10998** (`introspectSchema` also omits the contract's
`dialect` and required `introspectedAt`).

## The pin

The card's own diagnosis of why the suite was blind:

> `external-datasource-service.test.ts` hand-writes its fake schema with `primaryKey: true` (the
> spec-contract spelling), so no test ever feeds it a real driver's `isPrimary` output.

A pin that hand-wrote the *fixed* spelling would reproduce that blindness exactly. So
`external-introspection-seam.test.ts` drives the service off a **real** `SqlDriver.introspectSchema()`
against a live in-memory SQLite database, and asserts the producer's spelling directly — if the
driver ever starts emitting the spec spelling, that case reddens and the union read gets re-derived
rather than quietly relaxed.

Both directions are pinned: a table **with** a declared key marks that column and no other; a table
**without** one still yields a usable catalog entry and promotes nothing, least of all the first
column. Three further cases cover the seam read under a staged disagreement — hand-built on purpose,
and labelled as such in the file, because no live database can currently produce one.

## Verification

`5cdd4e41f`, clean tree.

**Ablation** — signature predicted in writing *before* mutating: reduce `primaryKeyReader` to the
pre-fix read (`col.primaryKey === true` only) ⇒ exactly 3 failures, all in the new file
(`refreshCatalog carries the introspected key…`, and both union cases), all `expected false to be
true`; the file's other 3 cases and all 22 other files stay green; totals 522/525.

Observed, on the final bytes: **3 failed | 522 passed (525)**, `1 failed | 22 passed (23)` files,
the three named cases, all `AssertionError: expected false to be true`. Prediction matched exactly.

Restore proved byte-identical: `5707f16a98f62541e164a1dfe3ef09e28c3936c8` before, mutated
`282cb7dfbacf759655198eaf7f6f0fbe22e52b2d`, `5707f16a98f62541e164a1dfe3ef09e28c3936c8` after —
restore leg re-run green at 525/525.

**No rebuild sits between edit and run, argued from the files**: the pin imports the mutated subject
by the relative specifier `../external-datasource-service.js`, which vitest resolves to
`src/external-datasource-service.ts`; `packages/services/service-datasource/dist/` does not exist in
this worktree at all; and the package's only vitest alias is anchored on `@objectstack/core` alone,
which cannot capture the subject. The **driver** does resolve through its `dist/` — built, and
deliberately not mutated, so no leg depends on driver bytes.

| check | verdict line |
| --- | --- |
| `pnpm --filter @objectstack/service-datasource test` | `Test Files 23 passed (23)` · `Tests 525 passed (525)` |
| `pnpm --filter @objectstack/service-datasource typecheck` | exit 0, no `error TS` (and `--listFiles` confirms the new test file is inside that program) |
| `check:changeset-gate-self-tests` | `✓ check-empty-changeset --self-test: 118 assertions …` |
| `check:objectui-changeset` | `✓ objectui-range --self-test: all checks passed` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) … none new` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 76 packages … scanned` |
| `check:query-options-erasure` | `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) … none new` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 64/77 workspace packages type-checked` |
| `check:engine-double-contract` | `check-engine-double-contract: OK — 376 pinned, 133 in the DEBT ledger, 2 exempt` |
| `check:where-matcher` | `✓ where-matcher conformance holds: 275 matcher(s) … none new` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6340 text file(s) … no raw ASCII control bytes)` |
| `check-adr-0087-registration.mjs` | `✓ … this PR adds no declared-breaking changeset` |
| `check-changeset-no-major.mjs` | `✓ This diff introduces no major bump.` |
| `check-ci-filter-parity.mjs` | `OK: all 82 declared cross-package glob(s) … are covered` |
| `check-empty-changeset.mjs` | `✓ No empty-frontmatter changeset introduced by this diff` |
| `check-plugin-teardown-shape.mjs` | `✓ check:plugin-teardown-shape: 57 Plugin implementation(s) …` |
| `check-affected-docs.mjs` | exit 0 |

Gate union derived on the final commit with a clean tree via `node scripts/pm/dispatch-gates.mjs`,
no path arguments (exit 0; 11 path-matched families + 5 convention-triggered). Every exit code above
was captured before any pipe.

**Declared narrowings**, so the gaps are on the record rather than implied:

1. `check:type-check-debt --re-measure` was **not run** — it requires the whole workspace build
   closure, which is the full-farm build this container's shared verify lock is meant to keep out of
   a per-card lane. Partial mitigation, not a substitute: the package's own `typecheck` is green and
   `tsc --listFiles` confirms the new test file is inside that program, which is the tsc run that
   gate re-measures for this package. CI runs the gate.
2. Only the **SQLite** arm of `SqlDriver` was executed (better-sqlite3, in-memory). Postgres and
   MySQL were read, not run — no server was reachable. The card claims the defect hits "every SQL
   driver"; that claim is *not* inherited. What is measured is stronger than a per-dialect sweep for
   this particular seam: the `isPrimary` assignment is a **single dialect-independent site** in
   `introspectSchema` (`if (primaryKeys.includes(col.name)) col.isPrimary = true`), downstream of the
   per-dialect `introspectPrimaryKeys`, so the *spelling* collision cannot vary by dialect. Only the
   composite-key truncation (#10997) is dialect-specific, and only SQLite's arm was measured for it.
3. The derived change set included `packages/create-objectstack/bin/create-objectstack.js`, which
   `pnpm install` mode-flipped (100644 → 100755) in this worktree. Not my edit, deliberately left
   unstaged and out of the commit. It only *widened* the derived gate set (`packages/**` families),
   never narrowed it.

#10676 remains open: the object-draft routing decision is still outstanding, so no closing
keyword is used anywhere in this body.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_