### PR TITLE
fix(plugin-auth): verify-domain answers DOMAIN_VERIFICATION_DISABLED for the disabled condition

### DIFF
--- a/.changeset/sso-verify-domain-disabled-answers-disabled-code.md
+++ b/.changeset/sso-verify-domain-disabled-answers-disabled-code.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+`POST /admin/sso/verify-domain` now answers the DISABLED condition the way its
+sibling always has. When SSO domain verification is off for an environment,
+`@better-auth/sso` never mounts the inner endpoint and answers `404` with no
+code. Both bridge routes recognise that shape, and they used to answer it
+differently (#10859):
+
+| route | answered | answers instead |
+| --- | --- | --- |
+| `POST /admin/sso/request-domain-verification` | `400` `DOMAIN_VERIFICATION_DISABLED` | unchanged |
+| `POST /admin/sso/verify-domain` | `404` `DOMAIN_VERIFICATION_FAILED` | `400` `DOMAIN_VERIFICATION_DISABLED` |
+
+`verify-domain` rewrote only the `message` for that branch and let the code fall
+through to its generic failure default, so the response carried "the feature is
+off" copy under a code that means "verification failed". A caller can only act
+on the machine-readable half, and the two halves disagreed. The status moves
+with the code: the inner `404` describes the INNER endpoint, which is unmounted,
+whereas this bridge route is mounted unconditionally — passing that status
+through said "no such endpoint" about a resource that exists.
+
+If you match on `DOMAIN_VERIFICATION_FAILED` (or on `404`) to detect the
+disabled case on `verify-domain`, match on `DOMAIN_VERIFICATION_DISABLED` (or on
+`400`) instead — the same pair `request-domain-verification` has always
+answered. The distinction is worth having: `DISABLED` means "turn on
+`OS_SSO_DOMAIN_VERIFICATION`", `FAILED` means "the DNS TXT record is not visible
+yet, retry".
+
+**No `packages/spec` change, and the emitted vocabulary gains no member.** Both
+codes are already registered for `@objectstack/plugin-auth` in the error-code
+ledger, with exactly these meanings (`DOMAIN_VERIFICATION_DISABLED` — "domain
+verification is off on this deployment"). This route was emitting a *declared*
+code whose registered meaning is a different condition, so this is
+declared-vs-enforced restoration rather than a new contract decision.
+
+**A genuine verification failure still answers the failure code, and the vendor
+pass-through arm is untouched on both routes.** The rewrite is keyed to the
+disabled shape specifically — `404` *without* a code. A `404` that carries
+`@better-auth/sso`'s own code is the vendor's diagnosis and reaches the caller
+verbatim, status included, as does every non-404 failure. That direction is the
+load-bearing one — an implementation keyed to "any 404", or to `!resp.ok`, would
+satisfy the disabled case while destroying the diagnosis a caller acts on — and
+it is pinned in both directions in
+`packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts`.
+
+Shipped as `minor`, following the same call the casing rename on these two
+routes made (#10716). The argument for it: the vocabulary is unchanged, and the
+old pairing was self-contradictory rather than a contract anyone could have
+relied on deliberately. The argument against it, stated here rather than
+settled: unlike that rename — whose old spellings were undeclared values no
+schema admitted — `DOMAIN_VERIFICATION_FAILED` *is* a declared, registered code,
+so a client keyed to it for this case was keyed to something the published
+contract admitted, and both halves of the answer change. A reviewer who reads
+that as `major` is not reading it wrong; this PR does not decide it silently.

--- a/packages/plugins/plugin-auth/src/register-sso-provider.ts
+++ b/packages/plugins/plugin-auth/src/register-sso-provider.ts
@@ -457,11 +457,21 @@ export async function runVerifyDomain(
   if (resp.ok) {
     return { status: 200, body: { success: true, data: { providerId, verified: true, message: 'Domain ownership verified — this provider can now sign users in.' } } };
   }
+  // The feature is OFF for this env: `@better-auth/sso` never mounted the inner
+  // endpoint, so its `404` describes the INNER route. THIS route is mounted
+  // unconditionally, so passing that status through says "no such endpoint"
+  // about a resource that exists. Answer the sibling's answer instead — same
+  // condition, same code, same status (#10859). Before this, the branch
+  // rewrote only the `message` and let the code fall through to the generic
+  // default below, so the machine-readable field said "verification failed"
+  // while the human-readable one said "the feature is off"; a caller can only
+  // act on the first.
+  if (resp.status === 404 && !parsed?.code) {
+    return { status: 400, body: { success: false, error: { code: 'DOMAIN_VERIFICATION_DISABLED', message: 'Domain verification is not enabled for this environment (set OS_SSO_DOMAIN_VERIFICATION).' } } };
+  }
   // Friendlier copy for the expected failure modes.
   let message = parsed?.message || 'Domain verification failed';
-  if (resp.status === 404 && !parsed?.code) {
-    message = 'Domain verification is not enabled for this environment (set OS_SSO_DOMAIN_VERIFICATION).';
-  } else if (parsed?.code === 'NO_PENDING_VERIFICATION') {
+  if (parsed?.code === 'NO_PENDING_VERIFICATION') {
     message = 'No pending verification — click “Request Domain Verification” first to get the DNS record.';
   } else if (parsed?.code === 'DOMAIN_VERIFICATION_FAILED') {
     message = 'DNS TXT record not found yet. Add the record shown when you requested verification, allow time for DNS to propagate, then retry.';

--- a/packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts
+++ b/packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts
@@ -64,13 +64,18 @@ describe('#10716 SSO domain verification — our default is a registered ADR-011
   });
 
   it('verify-domain: an uncoded vendor failure answers our SCREAMING default, status passed through', async () => {
-    // The 404-without-a-code shape: SSO domain verification is off for this env.
-    // This is the response the dogfood admin-route probe observes.
-    const res = await runVerifyDomain(fakeHandle(404, undefined), post(VERIFY_URL));
+    // RE-FIXTURED by #10859. This case used to be driven by `fakeHandle(404,
+    // undefined)` — which is the DISABLED shape, not a verification failure, and
+    // now answers `DOMAIN_VERIFICATION_DISABLED` (see the #10859 describe below).
+    // Pointing the generic-default leg at that shape would have left the default
+    // arm of `verify-domain` with no coverage at all once the disabled branch
+    // returned early, so it is driven by a real uncoded failure instead — the
+    // same `502` its sibling above uses.
+    const res = await runVerifyDomain(fakeHandle(502, { message: 'upstream exploded' }), post(VERIFY_URL));
 
     expect(res.body.success).toBe(false);
     expect(res.body.error?.code).toBe(OUR_DEFAULT);
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(502);
   });
 
   it('both defaults are SCREAMING_SNAKE and registered for this package — reused, not invented', () => {
@@ -114,5 +119,85 @@ describe('#10716 the vendor pass-through arm is untouched', () => {
 
     expect(res.body.error?.code).toBe('DOMAIN_VERIFICATION_DISABLED');
     expect(res.status).toBe(400);
+  });
+});
+
+describe('#10859 the DISABLED condition gets ONE answer across both routes', () => {
+  /**
+   * The feature being off is a different condition from a verification failing,
+   * and the two SSO domain-verification routes used to answer it differently:
+   * the sibling rewrote to `400 DOMAIN_VERIFICATION_DISABLED`, while
+   * `verify-domain` rewrote only the MESSAGE and let the code fall through to
+   * the generic failure default — so its machine-readable field said
+   * "verification failed" while its human-readable one said "the feature is
+   * off". A caller can only act on the first.
+   *
+   * Both halves are asserted per ADR-0112 (`code` AND `status`), and the
+   * counter-direction below is the load-bearing half: stamping `DISABLED` on
+   * every failure would pass a one-directional suite while destroying exactly
+   * the diagnosis the caller acts on.
+   */
+  const DISABLED = 'DOMAIN_VERIFICATION_DISABLED';
+  /** The inner endpoint is unmounted when the feature is off: 404, no code. */
+  const disabledInner = () => fakeHandle(404, undefined);
+
+  it('verify-domain: the disabled condition answers the dedicated code at the sibling’s status', async () => {
+    const res = await runVerifyDomain(disabledInner(), post(VERIFY_URL));
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error?.code).toBe(DISABLED);
+    expect(res.status).toBe(400);
+    expect(res.body.error?.message).toContain('OS_SSO_DOMAIN_VERIFICATION');
+  });
+
+  it('both routes answer the SAME code and the SAME status for the SAME condition', async () => {
+    // The card's governing invariant, asserted directly rather than inferred
+    // from the two per-route cases above: one answer for one condition.
+    const verify = await runVerifyDomain(disabledInner(), post(VERIFY_URL));
+    const request = await runRequestDomainVerification(disabledInner(), post(REQUEST_URL));
+
+    expect(verify.body.error?.code).toBe(request.body.error?.code);
+    expect(verify.status).toBe(request.status);
+    expect(verify.body.error?.code).toBe(DISABLED);
+    expect(verify.status).toBe(400);
+  });
+
+  it('DOMAIN_VERIFICATION_DISABLED is registered for this package — reused, not invented', () => {
+    expect(DISABLED).toMatch(/^[A-Z][A-Z0-9_]*$/);
+    expect(ERROR_CODE_LEDGER['@objectstack/plugin-auth']).toContain(DISABLED);
+  });
+
+  // ── the load-bearing direction: DISABLED is NOT stamped on every failure ──
+
+  it('verify-domain: a genuine verification failure still answers the FAILURE code', async () => {
+    // Uncoded, but not the disabled shape. An implementation that keyed on
+    // `!resp.ok` instead of the 404-without-a-code shape would answer DISABLED
+    // here and tell the admin to flip an env var that is already on.
+    const res = await runVerifyDomain(fakeHandle(502, { message: 'upstream exploded' }), post(VERIFY_URL));
+
+    expect(res.body.error?.code).toBe(OUR_DEFAULT);
+    expect(res.body.error?.code).not.toBe(DISABLED);
+    expect(res.status).toBe(502);
+  });
+
+  it('verify-domain: a 404 that CARRIES a vendor code is the vendor’s diagnosis, not DISABLED', async () => {
+    // The disabled shape is 404 *without* a code. A 404 that carries one is the
+    // vendor answering, and both its code and its status pass through untouched
+    // — the arm #10716 pinned, re-pinned here at the status this branch tests.
+    const res = await runVerifyDomain(fakeHandle(404, { code: VENDOR_CODE, message: 'vendor copy' }), post(VERIFY_URL));
+
+    expect(res.body.error?.code).toBe(VENDOR_CODE);
+    expect(res.body.error?.code).not.toBe(DISABLED);
+    expect(res.status).toBe(404);
+  });
+
+  it('request-domain-verification: a genuine failure still answers the FAILURE code', async () => {
+    // The sibling's counter-direction, so the parity assertion above cannot be
+    // satisfied by both routes collapsing onto DISABLED.
+    const res = await runRequestDomainVerification(fakeHandle(502, { message: 'upstream exploded' }), post(REQUEST_URL));
+
+    expect(res.body.error?.code).toBe(OUR_DEFAULT);
+    expect(res.body.error?.code).not.toBe(DISABLED);
+    expect(res.status).toBe(502);
   });
 });

--- a/packages/qa/dogfood/test/admin-route-nonadmin-refusal.dogfood.test.ts
+++ b/packages/qa/dogfood/test/admin-route-nonadmin-refusal.dogfood.test.ts
@@ -258,7 +258,7 @@ function expectationsFor(targetUserId: string): Record<string, RouteExpectation>
     'POST /api/v1/auth/admin/sso/verify-domain': {
       bucket: 'objectstack-gate',
       body: { providerId: 'refusal-probe-oidc' },
-      note: 'admin passes the gate and lands on 404 DOMAIN_VERIFICATION_FAILED while SSO is off',
+      note: 'admin passes the gate and lands on 400 DOMAIN_VERIFICATION_DISABLED while SSO is off (#10859 — it answered 404 DOMAIN_VERIFICATION_FAILED before, out of step with the sibling above)',
     },
 
     // ── #9652: ban / unban moved from the vendor to an ObjectStack mount ────


### PR DESCRIPTION
Fixes #10859

## What each route answered, before and after

Both SSO domain-verification bridge routes recognise the same condition — domain
verification is off for this environment, so `@better-auth/sso` never mounts the
inner endpoint and it answers `404` with no code — and they answered it
differently.

| route | condition | before | after |
| --- | --- | --- | --- |
| `POST /admin/sso/request-domain-verification` | disabled | `400` `DOMAIN_VERIFICATION_DISABLED` | unchanged |
| `POST /admin/sso/verify-domain` | disabled | **`404` `DOMAIN_VERIFICATION_FAILED`** | **`400` `DOMAIN_VERIFICATION_DISABLED`** |
| `POST /admin/sso/verify-domain` | genuine failure, uncoded | `<inner status>` `DOMAIN_VERIFICATION_FAILED` | unchanged |
| `POST /admin/sso/verify-domain` | vendor answered with a code | `<inner status>` `<vendor code>` | unchanged |

`runVerifyDomain`'s branch for the disabled condition rewrote only the `message`
and let the code fall through to the route's generic default, so the response
carried "the feature is off" copy under a code that means "verification failed".
A caller can only act on the machine-readable half, and the two halves
disagreed.

Premise re-derived on `origin/main` at `047ac86ee` before any edit: it holds
exactly as the card quotes it.

## The status question, and the measurement behind it

The card asks whether `verify-domain` should stay `404` while its sibling
rewrites to `400`. **Answer: `400`, parity with the sibling.** Four measurements,
in the order they moved the decision:

1. **The file's own stated design intent already required it.** The section
   header in `register-sso-provider.ts` says: *"A `404` from the inner endpoint
   means the feature is OFF for this env (endpoints unmounted) → surfaced as
   such, not a bare 'not found'."* The sibling implements that; `verify-domain`
   did not.
2. **The `404` was describing the wrong resource.** The outer bridge route is
   mounted unconditionally (`auth-plugin.ts`, `rawApp.post(.../admin/sso/verify-domain)`)
   — it is not behind the feature flag. Only the *inner* endpoint is unmounted,
   so passing its status through said "no such endpoint" about a resource that
   demonstrably exists.
3. **No repo-wide convention pointed the other way.** Surveyed how this tree
   answers "capability off": `403` (`FEEDS_DISABLED`), `409` (`FLOW_DISABLED`),
   `501` (`NOT_IMPLEMENTED`, admin plugin off), `503` (OIDC not enabled), `404`
   (MCP not enabled), `400` (the sibling). There is no house rule to appeal to,
   so nothing outweighed same-file, same-feature, same-condition parity.
4. **Nothing depends on the `404`.** The dogfood bucket loop asserts only that
   the admin's status is not in `[401,403]` and the code is not
   `PERMISSION_DENIED`; the console action runtime uses the HTTP status only as
   a *fallback label* when the envelope carries no error. Neither is disturbed
   by `400`.

The status moves *with* the code deliberately: answering the sibling's code at a
different status would have left "one condition, two answers" half-standing.

## Both directions are pinned

`packages/plugins/plugin-auth/src/sso-domain-verification-error-codes.test.ts`
(6 pre-existing tests from #10716, 6 added; all assert `code` **and** `status`
per ADR-0112):

- disabled ⇒ `DOMAIN_VERIFICATION_DISABLED` + `400`, on **both** routes, plus a
  direct parity assertion that the two routes answer the same code *and* the
  same status for the same condition.
- **the load-bearing direction — `DISABLED` is not stamped on every failure:** a
  genuine uncoded failure still answers `DOMAIN_VERIFICATION_FAILED` with the
  inner status passed through, and a `404` that *carries* a vendor code is the
  vendor's diagnosis, passed through untouched. The rewrite is keyed to the
  disabled shape specifically — `404` **without** a code.
- the vendor `parsed?.code` pass-through arm is untouched on both routes.

**One fixture was re-fixtured, not just re-spelled.** The #10716 test
`verify-domain: an uncoded vendor failure answers our SCREAMING default` was
driven by `fakeHandle(404, undefined)` — which is the *disabled* shape, not a
verification failure. Left pointing there it would have kept passing while
testing the wrong branch, and the generic-default arm of `verify-domain` would
have had no coverage at all. It now drives a real uncoded failure (`502`), the
same shape its sibling case uses.

## Ablation — prediction written before mutating, both legs

Predictions were recorded to a file before either mutation. `plugin-auth` has no
`dist/` and its `vitest.config.ts` declares no alias, and the test imports the
subject by the relative specifier `./register-sso-provider.js`, so the resolved
artifact **is** `src/` and no rebuild step can silently invalidate a leg. The
positive control for that claim: the suite runs and its result changes from a
`src/`-only edit, with no `dist/` present anywhere in the package.

| leg | predicted | observed |
| --- | --- | --- |
| **A** — remove the fix (message-only rewrite) | exactly 2 red: the disabled case, and the both-routes parity case; 10 green | exactly 2 red, those two; 10 green. `expected 'DOMAIN_VERIFICATION_FAILED' to be 'DOMAIN_VERIFICATION_DISABLED'` |
| **B** — over-broad guard `if (resp.status === 404)`, dropping `&& !parsed?.code` | exactly 1 red: the vendor-coded-404 case; 11 green | exactly 1 red, that one; 11 green. `expected 'DOMAIN_VERIFICATION_DISABLED' to be 'NO_PENDING_VERIFICATION'` |

Leg B is the hazard worth naming: an implementation that stamped `DISABLED` on
every `404` passes the disabled case *and* the pre-existing #10716 pass-through
test (which drives status `400`, not `404`). Only the newly added leg catches
it.

Restores proved byte-identical with `git hash-object`, and the ablation marker
was confirmed absent afterwards:

```
PRISTINE   429a1399ba1cf23ee5708de0e3aeb2ca1fbbfff2
A mutated  19e47f3a6bd7e704c3227de43bf6ca7410bf399d  → restored 429a1399… (marker count 0)
B mutated  b155a69cfa25d8678bd6490a7e80664a0ddff008  → restored 429a1399… (marker count 0)
FINAL      429a1399ba1cf23ee5708de0e3aeb2ca1fbbfff2
```

## The dogfood note

`admin-route-nonadmin-refusal.dogfood.test.ts:261` is a `note:` string —
documentation, not an assertion. The bucket loop never reads `note`, so nothing
here goes red on its own; it was updated deliberately rather than by being
forced to.

## Gates — union derived on the final commit `93c4f7c9b`, clean tree

`node scripts/pm/dispatch-gates.mjs` with **no path arguments** (derived 4 paths
vs merge base `047ac86ee`; committed 4, working tree 0, untracked 0). Every exit
code captured before any pipe. All 24 green:

15 derived — `check:changeset-gate-self-tests`, `spec:check:empty-state`,
`spec:check:liveness`, `check:objectui-changeset`, `check:slot-lookup`,
`spec:check:strictness-ledger`, `check:test-source-alias`,
`check:type-source-resolution`, `spec:check:variant-docs`,
`check-adr-0087-registration`, `check-changeset-no-major`,
`check-ci-filter-parity`, `check-empty-changeset`, `check-plugin-teardown-shape`,
`check-affected-docs`.

5 convention-triggered (this change adds test code) — `check:query-options-erasure`,
`check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`,
and `check:type-check-debt --re-measure` (run against the built workspace closure,
`turbo run build` exactly as `lint.yml` does: *"33 ledger entries re-measured,
1908 raw tsc errors total, none above its recorded number"*).

Plus `check:nul-bytes`, and **class #10309 run explicitly**:
`check:error-code-casing`, `check:dispatcher-error-vocabulary`,
`check:route-envelope`. **The path derivation did not name any of those three** —
they were run because the class is live, and all three are green on their own
verdict lines (`✓ no unlisted lowercase error codes in 4414 scanned file(s)`;
`OK — 21 unregistered code-stamping site(s), all classified`; `✓ 4 module(s)
discovered and audited`). No log contains a `PREREQUISITE NOT MET` / `Nothing was
checked` refusal or a zero-match no-op.

Package suites: `@objectstack/plugin-auth` typecheck exit 0; full suite **67
files / 1406 tests passed**. `@objectstack/dogfood` typecheck exit 0.

## Breaking or not — argued here, not settled here

Shipped as `minor`, matching the call the casing rename on these same two routes
made (#10716). **For:** the emitted vocabulary gains no member (both codes are
already registered for `@objectstack/plugin-auth`), and the old pairing was
self-contradictory — a code meaning "verification failed" under a message saying
"the feature is off" — rather than a contract anyone could have relied on
deliberately. **Against, stated rather than settled:** unlike that rename, whose
old spellings were undeclared values no schema admitted,
`DOMAIN_VERIFICATION_FAILED` *is* a declared, registered code, so a client keyed
to it for this case was keyed to something the published contract admitted — and
here *both* halves of the answer change, code and status. A reviewer who reads
that as `major` is not reading it wrong. This PR does not decide it silently.

## Scope

No `packages/spec` change — none was needed and this lane has none.
`content/docs/releases/**` untouched. `#10700` is in flight in the same package
on the two-factor surface and was not touched; we share only `.changeset/`, one
file each.

⚠️ **Draft, and staying draft.** Clause-② applies (the emitted error vocabulary
of a published endpoint changes), `needs:contract-review` is the compensating
control on #10859, and this seat does not clear it, mark ready, enable
auto-merge, or merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_