### PR TITLE
fix(plugin-auth): run the break-glass last-local-credential guard after authentication

### DIFF
--- a/.changeset/break-glass-guard-after-auth.md
+++ b/.changeset/break-glass-guard-after-auth.md
@@ -1,0 +1,17 @@
+---
+'@objectstack/plugin-auth': patch
+---
+
+Run the break-glass last-local-credential guard after authentication
+
+The guard that refuses removal of the last local-password login was registered
+as a better-auth `before` hook, which runs ahead of the endpoint middleware that
+establishes identity. It therefore decided — and answered — a question about a
+named user for a caller who had not been authenticated, while every neighbouring
+route on the same lane answers with the ordinary "please log in" refusal.
+
+The guard now runs only once the acting user is resolved. An unauthenticated
+caller falls through to the ordinary refusal and learns nothing about the named
+user. For an authenticated caller nothing changes: the same lookup runs and the
+same `LAST_LOCAL_CREDENTIAL` conflict is returned, so the lockout protection is
+unaffected.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1643,22 +1643,49 @@ export class AuthManager {
             // the mount is conditional on the admin plugin, and because the
             // guard itself now lives in ONE module both call sites share —
             // `last-local-credential.ts`, whose header records this trap.
+            // ── [#10776] AUTHENTICATE FIRST ────────────────────────────
+            // A `hooks.before` runs AHEAD of the endpoint's own
+            // `use: [adminMiddleware]`, and that middleware is the only layer
+            // establishing identity on this lane. So this guard used to read an
+            // unauthenticated request's body, ask the database a question about
+            // the named user, and answer it — a per-record answer to a caller
+            // nobody had authenticated, where every sibling `/admin/` route
+            // answers 401. Resolving the actor first makes the guard's decision
+            // (and its distinctive refusal) reachable only once the caller has
+            // an identity; an anonymous caller falls through to the vendor's own
+            // `sessionMiddleware`/`adminMiddleware` and hears the ordinary 401.
+            //
+            // Maintainer ruling 2026-08-22 (decision-inbox digest, accepted
+            // verbatim 「接受所有」): option A, authentication before the guard.
+            //
+            // ⚠️ This changes WHEN the guard decides, never WHAT it decides:
+            // an authenticated caller reaches exactly the same lookup and the
+            // same `CONFLICT`. `break-glass-guard-authentication-order.test.ts`
+            // pins both halves — the disclosure closing AND the invariant
+            // surviving — because closing the first by deleting the guard would
+            // satisfy a disclosure-only suite.
+            //
+            // Same shape as the `/oauth2/authorize` gate above: unauthenticated
+            // → fall through, never a refusal invented here.
+            const breakGlassActor = await this.resolveActor(ctx);
+
             let isLastLocalCredential = false;
-            try {
-              let targetId: string | undefined = ctx?.body?.userId ?? ctx?.body?.user_id;
-              if (!targetId && ctx.path === '/delete-user') {
-                const { getSessionFromCtx } = await import('better-auth/api');
-                const s: any = await getSessionFromCtx(ctx as any).catch(() => null);
-                targetId = s?.user?.id ?? s?.session?.userId;
+            if (breakGlassActor?.userId) {
+              try {
+                // `/delete-user` names no target in the vendor's own contract:
+                // the subject IS the authenticated caller, which is now already
+                // resolved rather than looked up a second time.
+                let targetId: string | undefined = ctx?.body?.userId ?? ctx?.body?.user_id;
+                if (!targetId && ctx.path === '/delete-user') targetId = breakGlassActor.userId;
+                if (targetId) {
+                  isLastLocalCredential = await isLastLocalCredentialHolder(
+                    ctx.context.adapter,
+                    targetId,
+                  );
+                }
+              } catch {
+                // Fail-open — never block a legitimate op on a lookup error.
               }
-              if (targetId) {
-                isLastLocalCredential = await isLastLocalCredentialHolder(
-                  ctx.context.adapter,
-                  targetId,
-                );
-              }
-            } catch {
-              // Fail-open — never block a legitimate op on a lookup error.
             }
             if (isLastLocalCredential) {
               const { APIError } = await import('better-auth/api');

--- a/packages/plugins/plugin-auth/src/break-glass-guard-authentication-order.test.ts
+++ b/packages/plugins/plugin-auth/src/break-glass-guard-authentication-order.test.ts
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #10776 — the break-glass last-local-credential guard must run AFTER identity
+// is established, not before it.
+//
+// The guard is registered as a better-auth `hooks.before` keyed on `ctx.path`.
+// A `before` hook runs ahead of the endpoint's own `use: [adminMiddleware]`,
+// which is the only layer that establishes identity on that lane. The guard
+// therefore decided — and answered — a per-record question for a caller nobody
+// had authenticated. Maintainer ruling 2026-08-22 (decision-inbox digest,
+// accepted verbatim 「接受所有」): **Option A, authentication before the
+// guard**, so an unauthenticated caller hears only the ordinary refusal that
+// every other route on this lane gives. Option B (keep the guard early and
+// disguise its answer) was the fallback and is not taken; option C (accept the
+// disclosure) is not taken.
+//
+// ── Why this file drives the REAL seam ──────────────────────────────────────
+//
+// `break-glass-local-credential.test.ts` drives the before-hook directly with a
+// synthetic `ctx`. That is the right shape for the guard's own predicate, and
+// it is structurally blind to the defect this file pins: hook ORDER relative to
+// endpoint middleware does not exist in a synthetic call. So every assertion
+// here goes through `AuthManager.handleRequest` on the installed better-auth
+// 1.7.1, where the vendor's own middleware really runs, and reads a status and
+// a code off a real `Response`.
+//
+// ── The load-bearing half ───────────────────────────────────────────────────
+//
+// ⛔ An implementation that simply DELETED the guard would satisfy every
+// disclosure assertion below while destroying the protection the guard exists
+// for. Two describe-blocks exist to make that impossible to pass vacuously:
+// the still-refused leg (an AUTHENTICATED admin removing the genuine last
+// local credential still gets 409 `LAST_LOCAL_CREDENTIAL`) and the admission
+// leg (the same admin removing an ordinary user still succeeds, so the
+// still-refused leg cannot be satisfied by refusing everyone).
+//
+// ADR-0112 is `code` AND `status`; every refusal assertion below carries both.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthManager } from './auth-manager';
+import { createMemoryEngine } from './impersonation-bearer-rotation.test';
+import { LAST_LOCAL_CREDENTIAL_CODE } from './last-local-credential';
+
+const SECRET = 'test-secret-at-least-32-chars-long!!';
+const PASSWORD = 'S3cure!Passw0rd-10776';
+const BASE = 'http://localhost:3000/api/v1/auth';
+
+const makeManager = (engine: any) =>
+  new AuthManager({
+    secret: SECRET,
+    baseUrl: 'http://localhost:3000',
+    dataEngine: engine,
+    plugins: { admin: true },
+  } as any);
+
+const post = (manager: AuthManager, path: string, body: unknown, bearer?: string) =>
+  manager.handleRequest(
+    new Request(`${BASE}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(bearer ? { authorization: `Bearer ${bearer}` } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+
+/** Status + whatever error code the body carries, in either envelope shape. */
+async function verdict(res: Response): Promise<{ status: number; code?: string; text: string }> {
+  const text = await res.text();
+  let code: string | undefined;
+  try {
+    const parsed = JSON.parse(text);
+    // ObjectStack's ADR-0112 envelope nests it; better-auth's flat shape does not.
+    code = parsed?.error?.code ?? parsed?.code;
+  } catch {
+    /* non-JSON body → no code */
+  }
+  return { status: res.status, code, text };
+}
+
+/**
+ * One deployment, staged to the exact posture the guard exists to protect:
+ *
+ *  - `owner` holds the ONLY local-password (`credential`) account — the
+ *    break-glass escape hatch itself.
+ *  - `admin` is an IdP-managed platform admin holding NO local credential
+ *    (their credential row is removed after they sign in, which is what
+ *    enforced SSO looks like: a managed team with a live session and no
+ *    password). Their session keeps working, so they can act as the
+ *    authenticated caller.
+ *  - `ordinary` is a second credential-less managed user — the removable one,
+ *    so the admission direction is testable on the same fixture.
+ *
+ * `/admin/remove-user` is better-auth's own endpoint and still authorizes on
+ * the legacy `role` scalar (only `/admin/impersonate-user` was re-pointed at
+ * ObjectStack's predicate, see `auth-manager.ts`), so the scalar is what is
+ * set here.
+ */
+async function seedDeployment() {
+  const engine = createMemoryEngine();
+  const manager = makeManager(engine);
+
+  for (const [email, name] of [
+    ['owner.10776@example.com', 'Break Glass Owner'],
+    ['admin.10776@example.com', 'Managed Admin'],
+    ['ordinary.10776@example.com', 'Ordinary User'],
+  ]) {
+    const res = await post(manager, '/sign-up/email', { email, password: PASSWORD, name });
+    expect(res.status, `sign-up ${email}: ${await res.clone().text()}`).toBe(200);
+  }
+
+  const users = (engine.tables.get('sys_user') ?? []) as any[];
+  const idFor = (email: string) => String(users.find((r) => r.email === email)!.id);
+  const ownerId = idFor('owner.10776@example.com');
+  const adminId = idFor('admin.10776@example.com');
+  const ordinaryId = idFor('ordinary.10776@example.com');
+
+  // The vendor `/admin/` lane's own authorization scalar.
+  users.find((r) => String(r.id) === adminId)!.role = 'admin';
+
+  const signIn = await post(manager, '/sign-in/email', {
+    email: 'admin.10776@example.com',
+    password: PASSWORD,
+  });
+  const bearer = signIn.headers.get('set-auth-token');
+  expect(bearer, 'sign-in must mint a bearer or the authenticated legs prove nothing').toBeTruthy();
+
+  const ownerSignIn = await post(manager, '/sign-in/email', {
+    email: 'owner.10776@example.com',
+    password: PASSWORD,
+  });
+  const ownerBearer = ownerSignIn.headers.get('set-auth-token');
+  expect(ownerBearer, 'the self-service leg needs the owner signed in').toBeTruthy();
+
+  // Strip the local password from everyone except `owner`, leaving exactly one
+  // credential holder. This is the state the guard guards.
+  const accounts = (engine.tables.get('sys_account') ?? []) as any[];
+  engine.tables.set(
+    'sys_account',
+    accounts.filter(
+      (r) => !(r.provider_id === 'credential' && String(r.user_id ?? '') !== ownerId),
+    ),
+  );
+  const remaining = (engine.tables.get('sys_account') ?? []).filter(
+    (r: any) => r.provider_id === 'credential',
+  );
+  expect(
+    remaining.map((r: any) => String(r.user_id)),
+    'fixture invariant: `owner` must be the SOLE local-credential holder',
+  ).toEqual([ownerId]);
+
+  return { engine, manager, ownerId, adminId, ordinaryId, bearer: bearer!, ownerBearer: ownerBearer! };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+// ───────────────────────────────────────────────────────────────────────────
+// The disclosure: an unauthenticated caller learns nothing per-record
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10776 — an anonymous caller gets the ordinary refusal, never a per-record answer', () => {
+  it('arm 1: naming the break-glass holder answers 401 UNAUTHENTICATED, not the guard‘s 409', async () => {
+    const { manager, ownerId } = await seedDeployment();
+
+    const v = await verdict(await post(manager, '/admin/remove-user', { userId: ownerId }));
+
+    // Status AND code (ADR-0112). The status alone was the whole defect: a 409
+    // where every sibling route answers 401 IS the per-record answer.
+    expect(v.status, v.text).toBe(401);
+    expect(v.code, v.text).toBe('UNAUTHENTICATED');
+    expect(v.code, 'the guard‘s code must not reach an unauthenticated caller').not.toBe(
+      LAST_LOCAL_CREDENTIAL_CODE,
+    );
+    expect(v.status, 'the guard‘s status must not reach an unauthenticated caller').not.toBe(409);
+  }, 60_000);
+
+  it('arm 2: naming an ordinary user answers 401 UNAUTHENTICATED — measured, not read off the source', async () => {
+    // The card filed this arm as an unmeasured reading. It is measured here so
+    // the before/after is a real comparison: if this arm did NOT already land
+    // on 401, the disclosure would be wider than the card states.
+    const { manager, ordinaryId } = await seedDeployment();
+
+    const v = await verdict(await post(manager, '/admin/remove-user', { userId: ordinaryId }));
+
+    expect(v.status, v.text).toBe(401);
+    expect(v.code, v.text).toBe('UNAUTHENTICATED');
+  }, 60_000);
+
+  it('arm 2b: a userId nobody holds answers the same 401 — no existence oracle either', async () => {
+    const { manager } = await seedDeployment();
+
+    const v = await verdict(await post(manager, '/admin/remove-user', { userId: 'usr_no_such_user' }));
+
+    expect(v.status, v.text).toBe(401);
+    expect(v.code, v.text).toBe('UNAUTHENTICATED');
+  }, 60_000);
+
+  it('the two arms are INDISTINGUISHABLE to the anonymous caller', async () => {
+    // The substance of the card asserted directly rather than inferred from two
+    // assertions that merely happen to agree today: whatever the platform says,
+    // it must say the SAME thing for the break-glass holder and for anyone else.
+    const { manager, ownerId, ordinaryId } = await seedDeployment();
+
+    const holder = await verdict(await post(manager, '/admin/remove-user', { userId: ownerId }));
+    const other = await verdict(await post(manager, '/admin/remove-user', { userId: ordinaryId }));
+
+    expect(holder.status).toBe(other.status);
+    expect(holder.text).toBe(other.text);
+  }, 60_000);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// The load-bearing half: the invariant survives the move
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10776 — the break-glass invariant is unchanged for an AUTHENTICATED admin', () => {
+  it('still-refused: removing the genuine last local credential is still 409 LAST_LOCAL_CREDENTIAL', async () => {
+    // ⛔ The leg that fails on an implementation that "fixed" the disclosure by
+    // deleting the guard. Everything in the block above stays green there.
+    const { manager, ownerId, bearer } = await seedDeployment();
+
+    const v = await verdict(
+      await post(manager, '/admin/remove-user', { userId: ownerId }, bearer),
+    );
+
+    expect(v.status, v.text).toBe(409);
+    expect(v.code, v.text).toBe(LAST_LOCAL_CREDENTIAL_CODE);
+  }, 60_000);
+
+  it('admission: the same admin removing an ordinary user still succeeds', async () => {
+    // Without this, the still-refused leg above is satisfiable by refusing
+    // every caller — the failure mode this lane has already paid for twice.
+    const { manager, ordinaryId, bearer } = await seedDeployment();
+
+    const res = await post(manager, '/admin/remove-user', { userId: ordinaryId }, bearer);
+    const v = await verdict(res);
+
+    expect(v.status, v.text).toBe(200);
+    expect(v.code, v.text).not.toBe(LAST_LOCAL_CREDENTIAL_CODE);
+  }, 60_000);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// The self-service path, whose TIMING moves with the guard
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10776 — /delete-user sits under the same guard and is covered here', () => {
+  it('anonymous: no per-record answer, and specifically not the guard‘s 409', async () => {
+    const { manager, ownerId } = await seedDeployment();
+
+    const v = await verdict(await post(manager, '/delete-user', { userId: ownerId }));
+
+    // The route is a DISABLED one on this platform (`user.deleteUser` is
+    // deliberately unconfigured — see the `disabled` row in
+    // `auth-route-ledger.ts`), so what an unauthenticated caller must hear is
+    // whatever that route says to everyone. The binding assertion is that the
+    // guard is not what answers.
+    expect(v.code, v.text).not.toBe(LAST_LOCAL_CREDENTIAL_CODE);
+    expect(v.status, v.text).not.toBe(409);
+  }, 60_000);
+
+  it('anonymous: the self-service path is INDISTINGUISHABLE across the two arms too', async () => {
+    const { manager, ownerId, ordinaryId } = await seedDeployment();
+
+    const holder = await verdict(await post(manager, '/delete-user', { userId: ownerId }));
+    const other = await verdict(await post(manager, '/delete-user', { userId: ordinaryId }));
+
+    expect(holder.status).toBe(other.status);
+    expect(holder.text).toBe(other.text);
+  }, 60_000);
+
+  it('authenticated: the OUTCOME for the break-glass holder is unchanged — still 409', async () => {
+    // Triage asked whether the ordering change alters this path's outcome or
+    // only its timing. This is that question, pinned.
+    const { manager, ownerId, ownerBearer } = await seedDeployment();
+
+    const v = await verdict(await post(manager, '/delete-user', { userId: ownerId }, ownerBearer));
+
+    expect(v.status, v.text).toBe(409);
+    expect(v.code, v.text).toBe(LAST_LOCAL_CREDENTIAL_CODE);
+  }, 60_000);
+});

--- a/packages/plugins/plugin-auth/src/break-glass-guard-authentication-order.test.ts
+++ b/packages/plugins/plugin-auth/src/break-glass-guard-authentication-order.test.ts
@@ -255,11 +255,14 @@ describe('#10776 — /delete-user sits under the same guard and is covered here'
 
     const v = await verdict(await post(manager, '/delete-user', { userId: ownerId }));
 
-    // The route is a DISABLED one on this platform (`user.deleteUser` is
-    // deliberately unconfigured — see the `disabled` row in
-    // `auth-route-ledger.ts`), so what an unauthenticated caller must hear is
-    // whatever that route says to everyone. The binding assertion is that the
-    // guard is not what answers.
+    // Measured: the vendor's own session middleware refuses first, in
+    // better-auth's flat envelope. That is deliberate and is NOT the #10349
+    // envelope's business — `/delete-user` is not an `/admin/` path, and that
+    // card's normalizer is scoped to `/admin/` on purpose. What matters here is
+    // that the answer is an AUTHENTICATION refusal and carries nothing about
+    // the named user.
+    expect(v.status, v.text).toBe(401);
+    expect(v.code, v.text).toBe('UNAUTHORIZED');
     expect(v.code, v.text).not.toBe(LAST_LOCAL_CREDENTIAL_CODE);
     expect(v.status, v.text).not.toBe(409);
   }, 60_000);

--- a/packages/plugins/plugin-auth/src/break-glass-local-credential.test.ts
+++ b/packages/plugins/plugin-auth/src/break-glass-local-credential.test.ts
@@ -24,6 +24,12 @@
  *     (`LAST_LOCAL_CREDENTIAL`). Under enforced SSO the managed team has no
  *     local credential at all, so that one account IS the escape hatch.
  *
+ *     [#10776] The guard now runs only once the caller's identity is
+ *     established. That moved WHEN it decides, not WHAT it decides, so the
+ *     cases below still pin the same verdicts — they just have to present a
+ *     resolvable credential to reach the guard at all, and the last case pins
+ *     that an anonymous caller never reaches it.
+ *
  * The middleware is driven directly with a synthetic `ctx` — the same shape
  * better-auth passes it (`path`, `body`, `context.adapter`) — because the
  * decision under test is entirely a function of those three, and standing up
@@ -73,16 +79,44 @@ async function buildConfig(
 /**
  * The `account` rows a deployment holds. `findOne` answers the target's own
  * credential lookup; `findMany` answers "who else holds one".
+ *
+ * [#10776] It also answers the `session` lookup the hook now makes BEFORE the
+ * guard: the guard runs only for a caller whose identity is established, so a
+ * synthetic ctx that wants to reach the guard has to carry one. Anything the
+ * fake is not asked about answers `null`, which is exactly what an anonymous
+ * caller's session lookup finds.
  */
+const CALLER_TOKEN = 'tok_admin_caller';
+
 function adapterWithCredentials(holders: string[]) {
   const rows = holders.map((userId) => ({ userId, providerId: 'credential' }));
   return {
-    findOne: vi.fn(async ({ where }: { where: Array<{ field: string; value: unknown }> }) => {
+    findOne: vi.fn(async ({ model, where }: { model?: string; where: Array<{ field: string; value: unknown }> }) => {
+      if (model === 'session') {
+        const token = where.find((w) => w.field === 'token')?.value;
+        return token === CALLER_TOKEN
+          ? { token, userId: 'usr_admin_caller', expiresAt: new Date(Date.now() + 3_600_000) }
+          : null;
+      }
       const userId = where.find((w) => w.field === 'userId')?.value;
       return rows.find((r) => r.userId === userId) ?? null;
     }),
     findMany: vi.fn(async () => rows),
   };
+}
+
+/**
+ * A ctx the way better-auth hands it to the global before-hook, carrying a
+ * resolvable credential. `signedIn: false` is the anonymous caller.
+ */
+function hookCtx(
+  path: string,
+  body: Record<string, unknown>,
+  adapter: unknown,
+  { signedIn = true }: { signedIn?: boolean } = {},
+) {
+  const headers = new Headers(signedIn ? { authorization: `Bearer ${CALLER_TOKEN}` } : {});
+  return { path, body, headers, context: { adapter } };
 }
 
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -168,7 +202,7 @@ describe('[#5892] the last local password login survives ban / remove / delete',
       const adapter = adapterWithCredentials(['usr_owner']);
       let caught: unknown;
       try {
-        await before!({ path, body: { userId: 'usr_owner' }, context: { adapter } });
+        await before!(hookCtx(path, { userId: 'usr_owner' }, adapter));
       } catch (e) {
         caught = e;
       }
@@ -184,11 +218,7 @@ describe('[#5892] the last local password login survives ban / remove / delete',
     const adapter = adapterWithCredentials(['usr_owner', 'usr_second_admin']);
 
     await expect(
-      config.hooks!.before!({
-        path: '/admin/ban-user',
-        body: { userId: 'usr_owner' },
-        context: { adapter },
-      }),
+      config.hooks!.before!(hookCtx('/admin/ban-user', { userId: 'usr_owner' }, adapter)),
     ).resolves.toBeUndefined();
   });
 
@@ -199,11 +229,7 @@ describe('[#5892] the last local password login survives ban / remove / delete',
     const adapter = adapterWithCredentials(['usr_owner']);
 
     await expect(
-      config.hooks!.before!({
-        path: '/admin/ban-user',
-        body: { userId: 'usr_managed' },
-        context: { adapter },
-      }),
+      config.hooks!.before!(hookCtx('/admin/ban-user', { userId: 'usr_managed' }, adapter)),
     ).resolves.toBeUndefined();
     // Only the target's own lookup ran — the whole-table scan is skipped.
     expect(adapter.findMany).not.toHaveBeenCalled();
@@ -211,8 +237,17 @@ describe('[#5892] the last local password login survives ban / remove / delete',
 
   it('fails OPEN on a lookup error — the opposite direction from the ban guard, on purpose', async () => {
     const { config } = await buildConfig({ ssoOnlyMode: true });
+    // The session lookup succeeds — the identity is established — and it is the
+    // GUARD's own lookup that fails. Otherwise this would be measuring the
+    // #10776 fall-through instead of the fail-open direction.
     const adapter = {
-      findOne: vi.fn(async () => {
+      findOne: vi.fn(async ({ model, where }: { model?: string; where: Array<{ field: string; value: unknown }> }) => {
+        if (model === 'session') {
+          const token = where.find((w) => w.field === 'token')?.value;
+          return token === CALLER_TOKEN
+            ? { token, userId: 'usr_admin_caller', expiresAt: new Date(Date.now() + 3_600_000) }
+            : null;
+        }
         throw new Error('account table unreadable');
       }),
       findMany: vi.fn(async () => []),
@@ -222,11 +257,34 @@ describe('[#5892] the last local password login survives ban / remove / delete',
     // is the cost in `last-admin-ban-guard.ts`. Different failure modes,
     // different directions — see that file's header.
     await expect(
-      config.hooks!.before!({
-        path: '/admin/ban-user',
-        body: { userId: 'usr_owner' },
-        context: { adapter },
-      }),
+      config.hooks!.before!(hookCtx('/admin/ban-user', { userId: 'usr_owner' }, adapter)),
     ).resolves.toBeUndefined();
+  });
+
+  // ── [#10776] the guard is now downstream of authentication ───────────────
+
+  it('does not run AT ALL for an unauthenticated caller — no throw, and no lookup', async () => {
+    // The disclosure this closes is not only the 409: it is that the guard
+    // queried the database about a user named by a caller nobody had
+    // authenticated. So the absence of the lookup is asserted, not just the
+    // absence of the refusal. The status-level half is pinned end-to-end in
+    // `break-glass-guard-authentication-order.test.ts`.
+    const { config } = await buildConfig({ ssoOnlyMode: true });
+
+    for (const path of BAN_PATHS) {
+      const adapter = adapterWithCredentials(['usr_owner']);
+
+      await expect(
+        config.hooks!.before!(hookCtx(path, { userId: 'usr_owner' }, adapter, { signedIn: false })),
+      ).resolves.toBeUndefined();
+
+      const askedAboutAccounts = adapter.findOne.mock.calls.some(
+        ([q]: [{ model?: string }]) => q?.model === 'account',
+      );
+      expect(askedAboutAccounts, `${path}: the guard must not query for an anonymous caller`).toBe(
+        false,
+      );
+      expect(adapter.findMany).not.toHaveBeenCalled();
+    }
   });
 });


### PR DESCRIPTION
Fixes #10776

## What was wrong

The break-glass last-local-credential guard was registered as a better-auth
`hooks.before`. A `before` hook runs ahead of the endpoint's own
`use: [adminMiddleware]`, and that middleware is the only layer establishing
identity on the vendor `/admin/` lane. The guard therefore evaluated — and
answered — a per-record question for a caller whose identity had never been
established, while every neighbouring route on the same lane answers with the
ordinary authentication refusal. The guard's refusal is distinctive, so the
refusal itself was the answer.

Mechanism only, per the card. No request shapes, seeding steps or values appear
in this PR, in its commits, or in the card.

## What changed

`packages/plugins/plugin-auth/src/auth-manager.ts` resolves the acting user
before the guard and runs the guard only for a caller who has an identity. An
unauthenticated caller falls through to the vendor's own session middleware and
receives the ordinary refusal — the same shape as every neighbour. This is the
pattern the `/oauth2/authorize` gate a few lines above already uses.

This moves **when** the guard decides, never **what** it decides. An
authenticated caller reaches the same lookup and the same `CONFLICT`.

Maintainer ruling, 2026-08-22 decision-inbox digest, accepted verbatim
「接受所有」: **option A — authentication before the guard.** Option B (keep the
guard early and disguise the pre-auth answer) was the fallback and is not taken;
nothing in the measurement establishes that the guard must run first. Option C
is not taken.

The guard's other production call site is the raw `/admin/ban-user` mount in
`auth-plugin.ts`, which already runs `gateAdmin(c)` before invoking
`runAdminBanUser`. It was already authentication-first and is unchanged.

## Execution order

Triage made the order part of the ruling, so the hermetic cases landed **first**,
in their own commit (`08ac2e7`), and were measured on the pre-fix tree before
anything was changed. The fix is the second commit (`07f1a57`).

## Measured verdicts — `code` AND `status` (ADR-0112)

All through `AuthManager.handleRequest` on the installed better-auth 1.7.1.

| leg | before | after |
|:---|:---|:---|
| anonymous, names the break-glass holder, `/admin/remove-user` | 409 `LAST_LOCAL_CREDENTIAL` | **401 `UNAUTHENTICATED`** |
| anonymous, names an ordinary user, `/admin/remove-user` | 401 `UNAUTHENTICATED` | 401 `UNAUTHENTICATED` |
| anonymous, names a user id nobody holds | 401 `UNAUTHENTICATED` | 401 `UNAUTHENTICATED` |
| **authenticated admin, genuine last local credential** | **409 `LAST_LOCAL_CREDENTIAL`** | **409 `LAST_LOCAL_CREDENTIAL`** |
| authenticated admin, ordinary user (admission) | 200 | 200 |
| anonymous, `/delete-user`, break-glass holder | 409 `LAST_LOCAL_CREDENTIAL` | **401 `UNAUTHORIZED`** |
| anonymous, `/delete-user`, ordinary user | 401 `UNAUTHORIZED` | 401 `UNAUTHORIZED` |
| authenticated holder, `/delete-user` (self-service) | 409 `LAST_LOCAL_CREDENTIAL` | 409 `LAST_LOCAL_CREDENTIAL` |

**The card's second arm was an unmeasured reading and is now measured: it
already landed on 401.** The disclosure is therefore exactly as wide as the card
states, not wider — the severity does not move.

**The self-service path's outcome is unchanged; only its timing moved.** For an
authenticated holder it is still the same conflict. For an anonymous caller it
is now the vendor's own flat 401, which is correct: `/delete-user` is not an
`/admin/` path, so #10349's envelope normalizer deliberately leaves it alone.

Two legs are load-bearing and exist so the disclosure fix cannot be satisfied
vacuously: an implementation that simply deleted the guard would score green on
every disclosure assertion, and fails the still-refused leg; one that refused
every caller would pass the still-refused leg, and fails the admission leg.

## Proof

**Ablation**, signature predicted in writing before mutating. Mutation: restore
the pre-fix ordering in `auth-manager.ts`, both test files untouched.

- **Predicted:** exactly 5 failures across exactly 2 files — arm 1, the
  indistinguishability pin, and the two anonymous `/delete-user` pins, each
  `expected 409 to be 401`; plus the unit-level "does not run at all for an
  unauthenticated caller" case rejecting instead of resolving. The legs that
  were green pre-fix predicted to stay green.
- **Observed:** exactly that. `Tests 5 failed | 22 passed (27)`, in
  `break-glass-guard-authentication-order.test.ts` (4) and
  `break-glass-local-credential.test.ts` (1), with the predicted messages.
- **Restore:** `git hash-object` before `2e63bcada18a628de4e120572a65364122df7b61`,
  after `2e63bcada18a628de4e120572a65364122df7b61` — byte-identical. The restore
  leg was re-run to a real verdict: `Tests 27 passed (27)`.

**`src` vs `dist` resolution, argued from the files** (re-measured on this tree
rather than inherited): `packages/plugins/plugin-auth` had **no `dist/` at all**
at ablation time, even after a full dependency-closure build; `vitest.config.ts`
declares no `resolve`/`alias` key and there is no root vitest workspace file;
and both test files sit inside `src/` and import the subject by **relative
specifier**, which bypasses `package.json#exports` entirely. So the subject
under test is `src/auth-manager.ts` and the mutation took effect without a
rebuild. The `KNOWN_UNALIASED_TEST_IMPORTS` entry for this package concerns its
**dependencies**, which do resolve through their own `dist/` — that is why the
closure build was required, and it does not apply to the subject.

**Zero-hit counter-check, positive control run first.** The control: searching
`isLastLocalCredentialHolder(` and `LAST_LOCAL_CREDENTIAL` over
`packages apps examples` names the expected files, so the instrument speaks on
this corpus. The silence: the same instrument, excluding the defining module,
the two known call sites and test files, returns nothing — the guard has exactly
the two production call sites already known, and the other one is
authentication-first already.

## Gates

Union derived on the final commit **`f3a8f0022`** with a clean tree, via
`node scripts/pm/dispatch-gates.mjs` with **no path arguments** (it took the
change set from the merge base itself). Every exit code captured before any
pipe; every verdict below is the gate's own printed line, not a bare `$?`.

Derived (11): `check:changeset-gate-self-tests`, `check:objectui-changeset`,
`check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`,
`check-adr-0087-registration`, `check-changeset-no-major`,
`check-ci-filter-parity`, `check-empty-changeset`, `check-plugin-teardown-shape`,
`check-affected-docs` — all green.

Convention-triggered by the new test file (5): `check:query-options-erasure`,
`check:type-check-coverage`, `check:type-check-debt`,
`check:engine-double-contract`, `check:where-matcher` — all green. The ratchet
ran on a **built** workspace closure and reached a real verdict, not a refusal:
`check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in
252.4s, 1908 raw tsc error(s) total, none above its recorded number.`

Class #10309, run explicitly: **the derivation named none of
`check:route-envelope`, `check:dispatcher-error-vocabulary` or
`check:error-code-casing` this time either** — the same silence reported on the
last three plugin-auth PRs. Run by hand, all three green:
`✓ check-route-envelope self-test passed`;
`check-dispatcher-error-vocabulary: OK — 21 unregistered code-stamping site(s), all classified`;
`✓ no unlisted lowercase error codes in 4429 scanned file(s) (ADR-0112).`

Also `check:nul-bytes`: `OK (scanned 6391 text file(s) … no raw ASCII control
bytes)`, plus a direct control-byte scan over the four changed files.

Package suite and typecheck on `f3a8f0022`:
`Test Files 69 passed (69)`, `Tests 1440 passed (1440)`; `pnpm typecheck` exit 0
for both of its `tsc` invocations.

## Posture

Clause-② is **yes** — anonymous-caller accept/reject behaviour changes. This PR
stays **draft**, `needs:contract-review` stays on the card, and this seat does
not clear it, mark it ready, arm auto-merge or merge.

## Scope

No `packages/spec` edit was needed; no `content/docs/releases/**` touched.
Changeset included. No files belonging to the two open sibling PRs in this
package were touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_