### PR TITLE
fix(plugin-security): bind the report sink above start()'s two bail-outs (#10706)

### DIFF
--- a/.changeset/security-plugin-start-logger-above-bailouts.md
+++ b/.changeset/security-plugin-start-logger-above-bailouts.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+`SecurityPlugin.start()` binds its report sink **above** the two bail-outs, so a
+degraded boot no longer leaves the plugin permanently unable to report (#10706).
+
+`private logger … = {}` is an empty object from construction, and
+`this.logger = ctx.logger` was its only assignment — sitting in the "capture
+handles" block, **below** the two `return`s that fire when `objectql`/`metadata`
+cannot be resolved, or when the engine carries no `registerMiddleware`. On
+either path the field stayed `{}` for the **lifetime of the instance**. Every
+report site is written `this.logger.warn?.(…)`, so an unbound sink is not a
+state any caller can notice: the reports simply do not happen. The assignment
+now runs immediately after the `Starting Security Plugin...` line, before either
+bail-out can be taken.
+
+Boot behaviour is otherwise unchanged, and that is pinned rather than asserted:
+both bail-outs still `return`, the middleware and the `security` service are
+still **not** registered on those paths, and both bail-outs still report through
+`ctx.logger` — which was always a real sink, so the bail-out itself was already
+loud. What was silent was the plugin's own field afterwards.
+
+Scope note: this is independent of the open design call on #10556 about what the
+default sink should be. Only the **placement** of the binding changes; the `= {}`
+default itself is untouched, and the fix is correct under every option there.
+
+Reachability, measured rather than assumed: every in-repo caller of the two
+public methods that report through the field (`checkAuthoredRowWrite`,
+`getReadFilter`) reaches them through the registered `security` service, and
+that service is registered *below* the bail-outs too — so on a bailed-out boot
+there is no live consumer. The defect was latent, not live. It is still a defect
+on its own terms: a sink that can never be bound after an early return is
+unrepresentable as a state the code can notice.
+
+New pin: `start-logger-binding.test.ts`.

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -866,6 +866,16 @@ export class SecurityPlugin implements Plugin {
   async start(ctx: PluginContext): Promise<void> {
     ctx.logger.info('Starting Security Plugin...');
 
+    // [#10706] Bind the report sink FIRST — above the two bail-outs below.
+    // Both of them `return` before the "capture handles" block, so binding the
+    // sink there left `this.logger` at its `= {}` construction default for the
+    // whole LIFETIME of the instance on a degraded boot: every report site is
+    // written `this.logger.warn?.(...)`, so an unbound sink is not a state any
+    // caller can notice — it silently reports nothing. Assigning here is
+    // correct under every option on #10556's open default-sink question, so it
+    // does not wait on that ruling; the `= {}` default itself is #10556's.
+    this.logger = ctx.logger;
+
     // Get required services
     let ql: IObjectQLEngine | undefined;
     let metadata: IMetadataService | undefined;
@@ -887,7 +897,6 @@ export class SecurityPlugin implements Plugin {
     // engine middleware AND the public getReadFilter service method.
     this.metadata = metadata;
     this.ql = ql;
-    this.logger = ctx.logger;
     this.rlsCompiler.setLogger?.(ctx.logger);
     // [C2 / ADR-0095] Late-bound resolver for the optional `sharing` service.
     this.resolveKernelService = (name: string) => {

--- a/packages/plugins/plugin-security/src/start-logger-binding.test.ts
+++ b/packages/plugins/plugin-security/src/start-logger-binding.test.ts
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#10706] `start()` binds `this.logger` ABOVE its two bail-outs.
+//
+// The mechanic this pins: `private logger … = {}` is an empty object from
+// construction, and `this.logger = ctx.logger` is its ONLY assignment. It used
+// to sit in the "capture handles" block, BELOW the two `return`s that fire when
+// `objectql`/`metadata` are missing or when the engine carries no
+// `registerMiddleware`. On either bail-out the field therefore stayed `{}` for
+// the LIFETIME of the instance — and because every report site is written
+// `this.logger.warn?.(…)`, an unbound sink is indistinguishable from a
+// configured one at every call site: it silently reports nothing.
+//
+// ⛔ This suite is deliberately INDEPENDENT of #10556's open design call on what
+// the `= {}` default should be. It asserts only WHERE the real sink is bound,
+// which is correct under every option on that question. Nothing here reads or
+// asserts the default value itself.
+//
+// Four directions are pinned, and the middle two are the load-bearing ones:
+//
+//   1. after either bail-out, `this.logger` IS `ctx.logger` — and RECEIVES a
+//      report. Identity alone is not enough, and "non-empty" would be no
+//      assertion at all: `{}` and a real logger both satisfy
+//      `typeof x === 'object'`.
+//   2. STILL BAILS. Both early returns still return, and the middleware is
+//      still NOT registered. An implementation that "fixed" this by deleting a
+//      bail-out would pass a logger-only suite while changing boot behaviour.
+//   3. the bail-out itself stays LOUD through `ctx.logger` — it already was,
+//      and that must not regress.
+//   4. the normal boot path is unchanged — same sink, registration still
+//      happens.
+
+import { describe, it, expect, vi } from 'vitest';
+// Relative specifier: resolves to THIS package's `src/security-plugin.ts`, never
+// to `dist/`. The only aliases in `vitest.config.ts` are anchored regexes for
+// `@objectstack/driver-sql` and `@objectstack/objectql`; neither can match a
+// relative path, so the subject here is the source in the checkout.
+import { SecurityPlugin } from './security-plugin.js';
+
+type Ctx = {
+  logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  registerService: ReturnType<typeof vi.fn>;
+  getService: ReturnType<typeof vi.fn>;
+  registerMiddleware: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * A boot context in one of three postures:
+ *
+ *  - `'throws'`   — `getService('objectql')` throws → the `:878` bail-out.
+ *  - `'no-mw'`    — objectql resolves but carries no `registerMiddleware`
+ *                   → the `:883` bail-out.
+ *  - `'healthy'`  — a normal boot that reaches registration.
+ */
+function makeCtx(posture: 'throws' | 'no-mw' | 'healthy'): Ctx {
+  const registerMiddleware = vi.fn();
+  const manifestService = { register: vi.fn() };
+  const ctx: any = {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerService: vi.fn(),
+    registerMiddleware,
+    getService: vi.fn().mockImplementation((name: string) => {
+      if (name === 'manifest') return manifestService;
+      if (posture === 'throws') throw new Error('service not available');
+      if (name === 'objectql') return posture === 'no-mw' ? {} : { registerMiddleware };
+      if (name === 'metadata') return { list: vi.fn().mockResolvedValue([]) };
+      return undefined;
+    }),
+  };
+  return ctx as Ctx;
+}
+
+/** The private field, read exactly as the mechanic describes it. */
+const sinkOf = (plugin: SecurityPlugin) => (plugin as any).logger;
+
+/**
+ * Drive a REAL report through `this.logger` and return whether it landed.
+ *
+ * `getReadFilter` is a public instance method whose on-behalf-of refusal
+ * (`this.logger.error?.(…)`, the ADR-0095/#2852 fail-closed branch) depends on
+ * NONE of the handles captured below the bail-outs — no `this.ql`, no
+ * `this.metadata`. That makes it the one report site that is genuinely
+ * reachable on a bailed-out instance, which is what makes it the right probe
+ * for "the sink RECEIVES something".
+ *
+ * Pre-fix this call is silent: `{}.error` is `undefined` and `?.()` no-ops.
+ */
+async function probeSinkReceives(plugin: SecurityPlugin, ctx: Ctx): Promise<boolean> {
+  ctx.logger.error.mockClear();
+  const verdict = await plugin.getReadFilter('crm_opportunity', {
+    userId: 'u_agent',
+    onBehalfOf: { userId: 'u_delegator' },
+  });
+  // The refusal itself must still be fail-closed, independent of the sink.
+  expect(verdict).toBeTruthy();
+  return ctx.logger.error.mock.calls.length > 0;
+}
+
+describe('[#10706] start() binds the report sink above both bail-outs', () => {
+  describe.each([
+    ['getService throws — the ObjectQL/metadata bail-out', 'throws' as const],
+    ['engine without registerMiddleware — the no-middleware bail-out', 'no-mw' as const],
+  ])('%s', (_label, posture) => {
+    it('binds `this.logger` to the real sink, and that sink RECEIVES a report', async () => {
+      const plugin = new SecurityPlugin();
+      const ctx = makeCtx(posture);
+
+      // Before `start()` the field is still the construction default — this is
+      // the state the fix makes unreachable AFTER a start, and asserting it
+      // here is what makes the post-start assertion a change and not a tautology.
+      expect(sinkOf(plugin)).not.toBe(ctx.logger);
+
+      await plugin.init(ctx as any);
+      await plugin.start(ctx as any);
+
+      // Direction 1a — identity: the field IS the context's logger.
+      expect(sinkOf(plugin)).toBe(ctx.logger);
+
+      // Direction 1b — the sink RECEIVES. `typeof sink === 'object'` would be
+      // satisfied by `{}` too, so the only honest assertion is a delivered call.
+      await expect(probeSinkReceives(plugin, ctx)).resolves.toBe(true);
+    });
+
+    it('STILL BAILS — no middleware and no `security` service are registered', async () => {
+      const plugin = new SecurityPlugin();
+      const ctx = makeCtx(posture);
+
+      await plugin.init(ctx as any);
+      await plugin.start(ctx as any);
+
+      // The bail-out is the POINT of these paths. A "fix" that moved the sink
+      // by deleting a return would satisfy the logger assertions above and
+      // silently change boot behaviour; these two assertions are what refuse it.
+      expect(ctx.registerMiddleware).not.toHaveBeenCalled();
+      const registeredNames = ctx.registerService.mock.calls.map((c) => c[0]);
+      expect(registeredNames).not.toContain('security');
+    });
+
+    it('the bail-out stays LOUD — it still reports through `ctx.logger`', async () => {
+      const plugin = new SecurityPlugin();
+      const ctx = makeCtx(posture);
+
+      await plugin.init(ctx as any);
+      await plugin.start(ctx as any);
+
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('security middleware not registered'),
+      );
+    });
+  });
+
+  it('normal boot is unchanged — same sink, and registration still happens', async () => {
+    const plugin = new SecurityPlugin();
+    const ctx = makeCtx('healthy');
+
+    await plugin.init(ctx as any);
+    await plugin.start(ctx as any);
+
+    expect(sinkOf(plugin)).toBe(ctx.logger);
+    expect(ctx.registerMiddleware).toHaveBeenCalledWith(expect.any(Function));
+    const registeredNames = ctx.registerService.mock.calls.map((c) => c[0]);
+    expect(registeredNames).toContain('security');
+    // The healthy path must NOT take either bail-out.
+    expect(ctx.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('security middleware not registered'),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #10706

`SecurityPlugin.start()` bound its report sink **below** the two bail-outs, so a degraded boot left `this.logger` at its `= {}` construction default for the lifetime of the instance. This moves the binding above both.

## The mechanic

`private logger … = {}` (`:776`) is an empty object from construction, and `this.logger = ctx.logger` was its **only** assignment — sitting in the "capture handles" block at `:890`, below the two `return`s at `:878` (ObjectQL/metadata unresolvable) and `:883` (engine without `registerMiddleware`). Every report site is written `this.logger.warn?.(…)`, so an unbound sink is not a state any caller can notice: the reports simply do not happen.

The assignment now runs immediately after the `Starting Security Plugin...` line. Independent of #10556's open design call on what the default sink should be — only the **placement** changes, the `= {}` default is untouched, and the fix is correct under every option there.

## Step 1 — the card's one undemonstrated row: REFUTED, on two independent grounds

The card flagged `checkAuthoredRowWrite` as *possibly* live and asked the next seat to settle it. Verdict: **latent, not live.**

**(a) No caller reaches it on the instance.** Positive control first — the instrument names the known path before its silence is read as evidence: the sweep finds the service literal delegation (`:1149`), the registration (`:1235`), and every service-mediated consumer. Against that working instrument, the instance-level reaches are:

| reach | receiver | verdict |
|---|---|---|
| `plugin-sharing/sharing-service.ts:841` | `probe = this.securityService?.()` → `ctx.getService('security')` | service-mediated |
| `service-analytics/plugin.ts:386` (`getReadFilter`) | `ctx.getService('security')` | service-mediated |
| `security-plugin.ts:5564` | `this.checkAuthoredRowWrite` inside `private assertControlledByParentWrite` | self-call, middleware-driven |
| `plugin-dev/dev-plugin.ts:759` | `childPlugins: Plugin[]`, driven only via `init`/`start`/`destroy` | not reachable without a cast |
| `controlled-by-parent-master-widener.test.ts:503,515` | `vi.spyOn(h.plugin as any, …)` | test only, after a healthy boot |

`registerService('security', …)` is at `:1235`, **inside `start()`** and below the bail-outs — so on a bailed-out boot the service is never registered and every one of those consumers gets `undefined` and fails closed to `abstain`.

**(b) Even a hypothetical direct instance caller cannot reach the report site.** `checkAuthoredRowWrite` guards `if (!this.ql) return 'abstain'` *before* its only `this.logger.warn?.()` at `:3647`. `this.ql` was assigned in the same straight-line block as the logger, with no branch between — so `this.ql` bound ⟹ logger bound. On exactly the boots where the sink is empty, the method short-circuits before reporting.

The defect is still real on its own terms: a sink that can never be bound after an early return is unrepresentable as a state the code can notice.

## ⚠️ The card's site count was short, and the omission hides a second public method

The card corrected itself from 6 to 11 `this.logger.*` sites. Re-derived by enclosing scope with the TypeScript AST — at `24ba050f3`, the card's own revision, where `:722`/`:836`/`:812–3084`/`:3501` all match it exactly — the true count is **18**. All 11 the card listed are real; it omitted 7, including **three in `getReadFilter` (`:3701`, `:3734`, `:3765`) — a public method in the same structural category as `checkAuthoredRowWrite`**.

That omission matters, because `getReadFilter` has **no `this.ql` guard**. Its on-behalf-of refusal (`:3735`) depends on none of the handles captured below the bail-outs, so it *is* reachable on a bailed-out instance — it is caller-gated only, not doubly unreachable. `getReadFilter`, not `checkAuthoredRowWrite`, was the structurally-live path. Still latent (all callers are service-mediated), but one ground instead of two.

A plain `grep -n 'this\.logger\.'` finds 17 of the 18 on `main`: `:5673` is written `this.logger?.warn?.(` — optional chain on the field itself — and no `this\.logger\.` pattern can see it. Reported as a derived count, not a grep hit count.

## What is pinned — `start-logger-binding.test.ts`, 7 tests

- **both bail-outs, pinned separately**: `this.logger` **is** `ctx.logger` (identity), **and the sink RECEIVES a report** — driven through `getReadFilter`'s on-behalf-of refusal, the one site reachable on a bailed-out instance. Asserting "non-empty" would assert nothing: `{}` and a real logger both satisfy `typeof x === 'object'`.
- **still-bails (load-bearing)**: both returns still return — `registerMiddleware` not called, `'security'` not among the registered names. A "fix" that deleted a bail-out would pass a logger-only suite while changing boot behaviour; these assertions refuse it.
- **bail-out stays loud**: both still report `security middleware not registered` through `ctx.logger`.
- **normal boot unchanged**: same sink, middleware registered, `'security'` registered, neither bail-out taken.

## Ablation — signature predicted before mutating

Prediction written to file before the mutation, then the fix hunk reverted in place:

| | predicted | observed |
|---|---|---|
| direction | RED | RED |
| tally | `2 failed \| 5 passed (7)` | `2 failed \| 5 passed (7)` |
| failing assertion | `expect(sinkOf(plugin)).toBe(ctx.logger)`, both postures | same, `:117`, both postures |
| message | `{}` received where ctx.logger expected | `AssertionError: expected {} to be { info: [Function Mock], …(2) }` |
| green controls | the 5 still-bails / loud / normal-boot tests unmoved | unmoved |

`probeSinkReceives` never executes in the mutated leg — the identity assertion throws first. That is why both halves are asserted.

**`src/` vs `dist/`, argued from the files and then falsified.** The subject is imported by the relative specifier `./security-plugin.js`; `vitest.config.ts` carries only two anchored aliases (`/^@objectstack\/driver-sql$/`, `/^@objectstack\/objectql$/`), neither of which can match a relative path — so the subject is transformed from `src/`. The falsifiable consequence: the ablation mutated `src/` and ran **no build**, and it reddened. Had the suite been reading `dist/`, an unbuilt `src` mutation would have stayed green.

**Restore.** `git hash-object` before ablation and after restore both `3a2ed20f24a1da854708d6d9c3e0b1adea44698a` — byte-identical. The restore leg was then **re-run to a real verdict** rather than trusted on the hash: `Test Files 1 passed (1) / Tests 7 passed (7)`.

## Verification — all on the final commit `518ef0855`, clean tree

Dependency closure built first; every exit code captured before any pipe (`cmd > file 2>&1; EXIT=$?`), and each gate quoted by **its own** verdict line.

- `pnpm --filter @objectstack/plugin-security test` — `Test Files 70 passed (70) / Tests 1355 passed (1355)`
- `pnpm --filter @objectstack/plugin-security typecheck` — exit 0, `> tsc --noEmit` echoed (the package does ship the script; a filter matching none would exit 0 having run nothing)

Gate union from `node scripts/pm/dispatch-gates.mjs` with **no path arguments** — 3 paths vs merge base `2866d5f97`, 136 families discovered:

| gate | verdict line |
|---|---|
| `check:changeset-gate-self-tests` | ✓ 118 + 212 + 116 assertions over real temp git repos |
| `check:cross-package-test-inputs` | `OK: 13 package(s) read outside themselves, all declared` |
| `check:objectui-changeset` | ✓ digest + range self-tests all passed |
| `check:slot-lookup` | ✓ ratchet holds: 107 unswept sites in 25 files, none new |
| `check:test-source-alias` | `OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `OK — 77 packages with a tsconfig.json scanned` |
| `check-adr-0087-registration.mjs` | ✓ no declared-breaking changeset (1 non-breaking seen) |
| `check-changeset-no-major.mjs` | ✓ no `major` bump |
| `check-ci-filter-parity.mjs` | `OK: all 83 declared cross-package glob(s)` covered |
| `check-cross-package-test-inputs.mjs` | `OK: 13 package(s)`, turbo.json hashes every glob |
| `check-empty-changeset.mjs` | ✓ 1 declaring changeset added |
| `check-plugin-teardown-shape.mjs` | ✓ 61 Plugin implementations, baseline fully burned down |
| `check-affected-docs.mjs` | ✓ 339 cases pass |

Convention-triggered (new test file · i18n-owning package):

| gate | verdict line |
|---|---|
| `check:query-options-erasure` | ✓ ratchet holds: 67 unswept sites, none new |
| `check:engine-double-contract` | `OK — 377 pinned, 133 in the DEBT ledger, 2 exempt` |
| `check:where-matcher` | ✓ 276 matchers, all answer or refuse loudly |
| `check:type-check-coverage` | `OK — 65/78 workspace packages type-checked` |
| `check:type-check-debt` | `--re-measure: OK — 33 ledger entr(ies) re-measured in 266.9s … none above its recorded number` |
| `check:i18n` | `OK (9 package(s) — all bundles in sync)` |
| `check:nul-bytes` | `OK (scanned 6391 text file(s) … no raw ASCII control bytes)` |

⚠️ `check:i18n` first returned `PREREQUISITE NOT MET — the workspace CLI is not built … Nothing was checked`. That is **not measured**, never a pass — the row above is the re-run after `turbo run build` over the workspace closure, which is also what let `check:type-check-debt --re-measure` run its ratchet instead of refusing.

**Class #10309** (dispatch lists short by the five `.changeset/**`-triggered families, because the changeset does not exist when the PM derives): my re-derivation ran *after* the changeset was committed and **did name all five** — `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`. All green.

## Not in scope

- #10556's design call and the `= {}` default itself — untouched.
- `this.rlsCompiler.setLogger?.(ctx.logger)` sits on the line the binding vacated and is **still below both bail-outs**, so the RLS compiler's ADR-0056 D4 dropped-policy warnings have no sink on a degraded boot. Same class, adjacent line, deliberately not moved: it is a different object's sink and its correct shape is not pinned by existing evidence. Filed separately rather than ridden along.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_