### PR TITLE
fix(service-datasource): generate an object draft that `os build` accepts

### DIFF
--- a/.changeset/external-object-draft-passes-os-build.md
+++ b/.changeset/external-object-draft-passes-os-build.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/service-datasource": patch
+---
+
+`os datasource introspect` now generates an object draft that `os build`
+accepts (#10712). The review-before-commit flow was handing the user a
+`*.object.ts` the platform's own validator refuses, on two independent counts:
+
+- **The object name carried no `${namespace}_` prefix**, so `defineStack()`
+  refused it outright (ADR-0028) — measured as
+  `Object 'customers' is missing the package namespace prefix.` The prefix is
+  now derived from the datasource's OWN owning package (`_packageId` →
+  that package's `manifest.namespace`), and applied through
+  `validateObjectNamespacePrefix` — the same function `defineStack()` and the
+  runtime publish gate call, so an already-prefixed remote table
+  (`wh_accounts` under namespace `wh`) is not double-prefixed.
+- **No `sharingModel` was emitted**, so the author-time rule set refused it
+  (`security-owd-unset`, ADR-0090 D1) — the same rule family #9666 hit for the
+  `os init` template. The draft now declares `sharingModel: 'private'`
+  explicitly, following the shape #9666 settled on for generated scaffolds:
+  the rule's own recommended default, rendered with the reason attached.
+
+When no namespace can be resolved (a datasource with no package provenance, or
+a package that declares none) the draft keeps the bare remote-table name and
+the rendered source carries a loud `TODO(namespace)`. It does not invent a
+prefix — mirroring `defineStack`, which skips the check entirely rather than
+inventing one, and avoiding an `_customers` that would trade one invalid draft
+for another.
+
+Note the `opts.primaryKey` path still does not build: it emits
+`fields.<f>.primaryKey`, which is not an authorable spec field key. That is
+#11000, a separate open contract question, untouched here.

--- a/packages/services/service-datasource/src/__tests__/external-object-draft-os-build.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-object-draft-os-build.test.ts
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The generated object draft has to survive the platform's OWN validator.
+ *
+ * `generateObjectDraft` renders a `*.object.ts` a human is meant to review and
+ * commit. Two things in that output made it un-committable:
+ *
+ *  1. the object name carried no `${namespace}_` prefix, so `defineStack()`
+ *     refused it outright (ADR-0028) — measured on the pre-fix tree as
+ *     `Object 'customers' is missing the package namespace prefix.`;
+ *  2. no `sharingModel` was emitted, so the author-time rule set `os build`
+ *     runs refused it (`security-owd-unset` at `objects[0].sharingModel`,
+ *     ADR-0090 D1) — the same rule family #9666 hit for the `os init` template.
+ *
+ * ## Why the two are pinned SEPARATELY
+ *
+ * A single "the draft builds now" assertion cannot say which of the two it is
+ * measuring, and cannot fail informatively when one of them regresses on its
+ * own. Each defect therefore gets its own case, asserting its own signal.
+ *
+ * ## Why `still-generates` is here at all
+ *
+ * Both defects above are satisfiable by emitting LESS. An implementation that
+ * returned a minimal valid stub — right name, right OWD, no fields — would go
+ * green on a validator-only suite while destroying the only thing this
+ * generator exists to do. The `still-generates` block is the counterweight:
+ * the introspected columns, the remote table name and the `external` binding
+ * are asserted to survive the fix.
+ *
+ * ## The instrument
+ *
+ * The prefix assertion calls `validateObjectNamespacePrefix` — the same
+ * function `defineStack()` and the runtime publish gate call — rather than
+ * re-spelling `startsWith`. A hand-rolled check here could pass while the real
+ * gate refuses, which is precisely the drift that produced defect (1).
+ * The OWD assertion runs a full `ObjectSchema.safeParse`, because what is
+ * being guarded is a VALUE's verdict, not merely a key's presence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+import { validateObjectNamespacePrefix } from '@objectstack/spec/kernel';
+import { ObjectSchema } from '@objectstack/spec/data';
+import {
+  ExternalDatasourceService,
+  type DatasourceLike,
+  type ExternalDatasourceServiceConfig,
+} from '../external-datasource-service.js';
+
+/**
+ * A remote schema with an ALREADY-prefixed table alongside a bare one, so the
+ * double-prefix case (`wh_wh_accounts`) is reachable from the same fixture.
+ *
+ * Hand-written rather than driven off a live `SqlDriver` — deliberately, and
+ * for a different reason than the blindness `external-introspection-seam.test.ts`
+ * exists to close. Neither defect pinned here reads a column's PK-ness at all:
+ * the object NAME comes from the table name and the OWD is a constant, so a
+ * real introspection would add cost and no coverage.
+ *
+ * Every column is spelled `primaryKey: false` on purpose. That keeps the whole
+ * file on the `opts.primaryKey`-unset path, where the generator emits no
+ * `fields.<f>.primaryKey` — the key that is NOT authorable (#11000, an open
+ * contract question in `packages/spec`, deliberately untouched here). Pinning
+ * these two repairs on a draft that also carries #11000's key would produce
+ * cases that cannot go green until a card this lane does not own is decided.
+ */
+function remoteSchema(): IntrospectedSchema {
+  return {
+    dialect: 'postgres',
+    introspectedAt: '2026-08-22T00:00:00.000Z',
+    tables: {
+      'mart.customers': {
+        name: 'mart.customers',
+        indexes: [],
+        columns: [
+          { name: 'id', type: 'text', nullable: false, primaryKey: false },
+          { name: 'name', type: 'varchar(255)', nullable: true, primaryKey: false },
+          { name: 'signed_up_at', type: 'timestamptz', nullable: true, primaryKey: false },
+        ],
+      },
+      'mart.wh_accounts': {
+        name: 'mart.wh_accounts',
+        indexes: [],
+        columns: [{ name: 'id', type: 'text', nullable: false, primaryKey: false }],
+      },
+    },
+  };
+}
+
+/**
+ * The service wired exactly as `plugin.ts` wires it, with the namespace
+ * resolution the plugin injects made explicit per-test.
+ *
+ * `namespace: undefined` is NOT the same as omitting `getNamespace`: the first
+ * is "a resolver ran and found nothing", the second is "no resolver at all".
+ * Both must land on the bare name, and both are exercised below.
+ */
+function serviceWith(
+  namespace?: string | undefined,
+  opts: { wireResolver?: boolean } = {},
+): ExternalDatasourceService {
+  const config: ExternalDatasourceServiceConfig = {
+    introspect: async () => remoteSchema(),
+    getDatasource: async (name): Promise<DatasourceLike> => ({ name, schemaMode: 'external' }),
+    getObject: async () => undefined,
+    listObjects: async () => [],
+    ...(opts.wireResolver === false ? {} : { getNamespace: () => namespace }),
+  };
+  return new ExternalDatasourceService(config);
+}
+
+/** The canonical OWD values, read off the live schema rather than restated. */
+const CANONICAL_OWD: readonly string[] = (
+  ObjectSchema.shape.sharingModel as unknown as { def: { innerType: { options: string[] } } }
+).def.innerType.options;
+
+describe('defect 1 — the generated object name carries the package namespace prefix', () => {
+  it('prefixes the derived name, and the SINGLE-SOURCE rule accepts it', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+
+    expect(draft.name).toBe('wh_customers');
+    // The instrument that matters: the very function `defineStack()` calls.
+    expect(validateObjectNamespacePrefix(draft.name, 'wh')).toBeNull();
+    // …and the rendered file agrees with the structured definition.
+    expect(draft.definition.name).toBe('wh_customers');
+    expect(draft.source).toContain("name: 'wh_customers'");
+    expect(draft.source).toContain('const wh_customers: ServiceObject = {');
+  });
+
+  it('does NOT double-prefix a remote table that already carries the namespace', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'wh_accounts');
+
+    expect(draft.name).toBe('wh_accounts');
+    expect(draft.name).not.toContain('wh_wh_');
+    expect(validateObjectNamespacePrefix(draft.name, 'wh')).toBeNull();
+  });
+
+  it('keeps the LABEL derived from the short name — the prefix is addressing, not display', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+    expect(draft.definition.label).toBe('Customers');
+  });
+});
+
+describe('defect 2 — the generated draft declares an explicit sharingModel', () => {
+  it('emits the OWD the #9666 precedent settled on, and the spec accepts the VALUE', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+
+    expect(draft.definition.sharingModel).toBe('private');
+    // Not just "some string": a value the canonical enum still declares. If
+    // ADR-0090's four ever change, this reddens instead of drifting.
+    expect(CANONICAL_OWD).toContain(draft.definition.sharingModel);
+
+    // A value verdict needs a full parse, not an absence-of-unknown-keys check.
+    const parsed = ObjectSchema.safeParse(draft.definition);
+    expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('renders the OWD into the committed source, with the reason attached', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+
+    expect(draft.source).toContain("sharingModel: 'private'");
+    expect(draft.source).toContain('security-owd-unset');
+  });
+
+  it('emits the OWD even when no namespace resolves — the two defects are independent', async () => {
+    const draft = await serviceWith(undefined).generateObjectDraft('warehouse', 'customers');
+    expect(draft.definition.sharingModel).toBe('private');
+    expect(draft.source).toContain("sharingModel: 'private'");
+  });
+});
+
+describe('still-generates — the fix must not be satisfied by emitting a valid stub', () => {
+  it('keeps every introspected column, its mapped type, and the review notes', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+    const fields = draft.definition.fields as Record<string, { type: string }>;
+
+    expect(Object.keys(fields)).toEqual(['id', 'name', 'signed_up_at']);
+    expect(fields.id.type).toBe('text');
+    expect(fields.name.type).toBe('text');
+    expect(fields.signed_up_at.type).toBe('datetime');
+
+    expect(draft.source).toContain("id: { type: 'text' }");
+    expect(draft.source).toContain("signed_up_at: { type: 'datetime' }");
+  });
+
+  it('keeps the external binding pointed at the REMOTE table, not the renamed object', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+    const external = draft.definition.external as { remoteName?: string; remoteSchema?: string };
+
+    // The object was renamed to `wh_customers`; the remote table was not.
+    expect(external.remoteName).toBe('customers');
+    expect(external.remoteSchema).toBe('mart');
+    expect(draft.definition.datasource).toBe('warehouse');
+    expect(draft.source).toContain("remoteSchema: 'mart', remoteName: 'customers'");
+  });
+});
+
+describe('an absent or blank namespace must not trade one invalid draft for another', () => {
+  /**
+   * `_customers` is the failure mode this block exists to forbid: a name that
+   * satisfies "has a prefix" while being neither valid nor meaningful. The
+   * bare name is the defensible outcome — `defineStack()` skips the prefix
+   * check entirely for a stack with no `manifest.namespace`, and deliberately
+   * does not invent one on the author's behalf, so the draft stays committable
+   * exactly where an unprefixed name is legal.
+   */
+  it.each([
+    ['no resolver wired at all', undefined, false],
+    ['a resolver that finds nothing', undefined, true],
+    ['an empty string', '', true],
+    ['whitespace only', '   ', true],
+  ])('%s → the bare name, never a leading underscore', async (_label, ns, wired) => {
+    const draft = await serviceWith(ns as string | undefined, {
+      wireResolver: wired as boolean,
+    }).generateObjectDraft('warehouse', 'customers');
+
+    expect(draft.name).toBe('customers');
+    expect(draft.name.startsWith('_')).toBe(false);
+    expect(draft.source).not.toContain('_customers:');
+    expect(ObjectSchema.safeParse(draft.definition).success).toBe(true);
+  });
+
+  it('says so loudly in the rendered file rather than failing silently', async () => {
+    const draft = await serviceWith(undefined).generateObjectDraft('warehouse', 'customers');
+
+    expect(draft.source).toContain('TODO(namespace)');
+    expect(draft.source).toContain('ADR-0028');
+  });
+
+  it('carries NO namespace TODO once a namespace did resolve', async () => {
+    const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
+    expect(draft.source).not.toContain('TODO(namespace)');
+  });
+});
+
+describe('importObject inherits both repairs from the draft pipeline', () => {
+  it('persists the prefixed name and the explicit OWD', async () => {
+    const persisted: Array<{ name: string; def: Record<string, unknown> }> = [];
+    const svc = new ExternalDatasourceService({
+      introspect: async () => remoteSchema(),
+      getDatasource: async (name): Promise<DatasourceLike> => ({ name, schemaMode: 'external' }),
+      getObject: async () => undefined,
+      listObjects: async () => [],
+      getNamespace: () => 'wh',
+      persistObject: async (name, def) => {
+        persisted.push({ name, def });
+      },
+    });
+
+    const result = await svc.importObject('warehouse', 'customers');
+
+    expect(result.name).toBe('wh_customers');
+    expect(persisted[0]?.name).toBe('wh_customers');
+    expect(persisted[0]?.def.sharingModel).toBe('private');
+    expect(ObjectSchema.safeParse(persisted[0]?.def).success).toBe(true);
+  });
+});

--- a/packages/services/service-datasource/src/external-datasource-service.ts
+++ b/packages/services/service-datasource/src/external-datasource-service.ts
@@ -33,6 +33,12 @@ import {
   type SqlDialect,
   type FieldType,
 } from '@objectstack/spec/data';
+// The SINGLE source of the ADR-0028 object-name prefix rule, shared verbatim
+// with `defineStack()` (compile time) and `MetadataManager.publishPackage`
+// (runtime). Imported rather than re-implemented: a generator that hand-rolled
+// its own `startsWith` would be free to drift from the check that refuses its
+// output, which is the shape of this whole defect.
+import { validateObjectNamespacePrefix } from '@objectstack/spec/kernel';
 
 /** Minimal datasource shape the service reads (subset of `Datasource`). */
 export interface DatasourceLike {
@@ -88,6 +94,23 @@ export interface ExternalDatasourceServiceConfig {
    * throws (the deployment is GitOps-only / has no writable metadata store).
    */
   persistObject?: (name: string, definition: Record<string, unknown>) => Promise<void>;
+  /**
+   * Resolve the package namespace that generated object names must be
+   * prefixed with — `${namespace}_${shortName}`, ADR-0028. Injected for the
+   * same reason every other read here is: the service stays kernel-free, and
+   * the plugin decides where a namespace comes from (it reads the
+   * datasource's own owning package — see `plugin.ts`).
+   *
+   * Optional, and allowed to resolve nothing. A deployment whose datasource
+   * carries no package provenance, or whose package declares no `namespace`,
+   * gets a draft with the BARE remote-table name plus a loud TODO in the
+   * rendered source. That is deliberate and mirrors `defineStack`, which
+   * skips the prefix check entirely when `manifest.namespace` is absent
+   * rather than inventing a prefix on the author's behalf. Emitting
+   * `_customers` on a blank namespace would trade one invalid draft for
+   * another, so a blank/whitespace value is treated as absent.
+   */
+  getNamespace?: (datasource: string) => Promise<string | undefined> | string | undefined;
   logger?: Logger;
 }
 
@@ -165,6 +188,53 @@ function toObjectName(remoteName: string): string {
     .replace(/[^a-zA-Z0-9_]/g, '_')
     .replace(/^[^a-z_]/, (c) => `_${c.toLowerCase()}`)
     .toLowerCase();
+}
+
+/**
+ * The org-wide default every generated federated object declares.
+ *
+ * NOT a judgement call made here — it is the shape #9666 settled for the
+ * CLI's own `os init` scaffolds (`packages/cli/src/commands/init.ts`), which
+ * hit this same rule family: declare the value explicitly, and pick the one
+ * `security-owd-unset`'s own hint calls the recommended default. It is also
+ * what ADR-0090 D1 already resolves an unset OWD to at runtime, so a draft
+ * carrying it describes the posture the platform would apply anyway — the
+ * change is that the baseline becomes an AUTHORED decision instead of an
+ * accident, which is the entire point of the rule.
+ *
+ * It is the most restrictive of the four canonical values, so a generated
+ * federated object can never be published wider than its author intended by
+ * this default alone; widening it is a one-line edit the review-before-commit
+ * flow exists to invite.
+ */
+const GENERATED_SHARING_MODEL = 'private';
+
+/**
+ * Normalise an injected namespace. Blank / whitespace-only reads as ABSENT:
+ * `validateObjectNamespacePrefix` skips a falsy namespace, but `'  '` is
+ * truthy and would render `  _customers` — one invalid draft traded for
+ * another, which is the failure this card is closing.
+ */
+function normaliseNamespace(raw: string | undefined): string | undefined {
+  const ns = raw?.trim();
+  return ns ? ns : undefined;
+}
+
+/**
+ * Apply the ADR-0028 package prefix to a derived object name.
+ *
+ * The decision is delegated to `validateObjectNamespacePrefix` — the same
+ * function `defineStack` and the runtime publish gate call — so "is this name
+ * already compliant?" has exactly one answer in the tree. `null` means the
+ * name is already acceptable (no namespace to apply, a `sys_*` reserved name,
+ * or a remote table that is ALREADY prefixed, e.g. `crm_accounts` under
+ * namespace `crm` — which must not become `crm_crm_accounts`).
+ */
+function applyNamespacePrefix(objectName: string, namespace: string | undefined): string {
+  if (!namespace) return objectName;
+  return validateObjectNamespacePrefix(objectName, namespace) === null
+    ? objectName
+    : `${namespace}_${objectName}`;
 }
 
 /** snake_case → Title Case label. */
@@ -289,23 +359,35 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
       fields[fieldName] = isPk ? { type: fieldType, primaryKey: true } : { type: fieldType };
     }
 
-    const name = toObjectName(resolvedRemoteName);
+    // ADR-0028: every object a package defines must be named
+    // `${namespace}_${shortName}`. `defineStack()` refuses an unprefixed name
+    // outright, so a draft without the prefix cannot be committed into a
+    // namespaced stack — the generator has to resolve the namespace itself.
+    const namespace = normaliseNamespace(await this.config.getNamespace?.(datasource));
+    const shortName = toObjectName(resolvedRemoteName);
+    const name = applyNamespacePrefix(shortName, namespace);
     const definition: Record<string, unknown> = {
       name,
-      label: toLabel(name),
+      // Derived from the SHORT name on purpose: the prefix is an addressing
+      // requirement, not a display one, and keeping the label at 'Customers'
+      // rather than 'Wh Customers' leaves this draft's human-facing text
+      // exactly where it was before the prefix landed.
+      label: toLabel(shortName),
       datasource,
       external: {
         ...(remoteSchema ? { remoteSchema } : {}),
         remoteName: resolvedRemoteName,
       },
       fields,
+      // ADR-0090 D1 / `security-owd-unset` — see GENERATED_SHARING_MODEL.
+      sharingModel: GENERATED_SHARING_MODEL,
     };
 
     return {
       name,
       datasource,
       definition,
-      source: renderObjectSource(definition, fields, review),
+      source: renderObjectSource(definition, fields, review, namespace),
       review,
     };
   }
@@ -565,11 +647,22 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
   }
 }
 
-/** Render a reviewable `*.object.ts` source string for an object draft. */
+/**
+ * Render a reviewable `*.object.ts` source string for an object draft.
+ *
+ * The output is annotated `ServiceObject`, which makes `tsc` over this string
+ * a complete acceptance instrument for the draft's shape — use it that way.
+ *
+ * `namespace` is passed in rather than re-derived from `definition.name`,
+ * because the two absent cases are NOT the same file: a name that is already
+ * prefixed and a name that could not be prefixed both read as "starts with
+ * something" from here, and only the second one needs the TODO.
+ */
 function renderObjectSource(
   definition: Record<string, unknown>,
   fields: Record<string, { type: FieldType; primaryKey?: boolean }>,
   review: ObjectDraft['review'],
+  namespace?: string,
 ): string {
   const reviewByColumn = new Map(review.map((r) => [r.column, r.note]));
   const external = definition.external as { remoteSchema?: string; remoteName?: string };
@@ -585,8 +678,25 @@ function renderObjectSource(
     ? `  external: { remoteSchema: '${external.remoteSchema}', remoteName: '${external.remoteName}' },`
     : `  external: { remoteName: '${external.remoteName}' },`;
 
+  // No namespace resolved → the name is bare. That is legal in a stack whose
+  // manifest declares no `namespace` (`defineStack` skips the check), so the
+  // draft is emitted rather than refused — but it is NOT legal in a namespaced
+  // stack, and this generator cannot tell which one the author will paste it
+  // into. Say so loudly in the file instead of guessing: the same
+  // "emit it with a TODO the validator accepts" shape #9666 settled on.
+  const namespaceTodo = namespace
+    ? []
+    : [
+        `// TODO(namespace): no package namespace could be resolved for this`,
+        `// datasource, so this object name is UNPREFIXED. If the stack you commit`,
+        `// this into declares 'manifest.namespace', rename it to`,
+        `// '<namespace>_${definition.name as string}' — 'defineStack()' refuses an`,
+        `// unprefixed object name (ADR-0028).`,
+      ];
+
   return [
     `// Generated by \`os datasource introspect\` (ADR-0015). Review before committing.`,
+    ...namespaceTodo,
     `import type { ServiceObject } from '@objectstack/spec/data';`,
     ``,
     `const ${definition.name as string}: ServiceObject = {`,
@@ -597,6 +707,12 @@ function renderObjectSource(
     `  fields: {`,
     ...fieldLines,
     `  },`,
+    `  // Org-wide default (OWD): who can see records they do NOT own. ADR-0090 D1`,
+    `  // requires this to be an authored decision rather than an accident — the`,
+    `  // \`security-owd-unset\` author-time rule refuses an object without it, so a`,
+    `  // draft that omitted it could not compile. '${GENERATED_SHARING_MODEL}' is the rule's own`,
+    `  // recommended default: owner + explicit shares. Widen it deliberately.`,
+    `  sharingModel: '${definition.sharingModel as string}',`,
     `};`,
     ``,
     `export default ${definition.name as string};`,

--- a/packages/services/service-datasource/src/plugin.ts
+++ b/packages/services/service-datasource/src/plugin.ts
@@ -99,6 +99,51 @@ export class ExternalDatasourceServicePlugin implements Plugin {
             },
           }
         : {}),
+      /**
+       * Where a generated object's `${namespace}_` prefix comes from (ADR-0028).
+       *
+       * The datasource's OWN owning package — not an ambient "current package",
+       * which does not exist at this seam. A federated object is bound to one
+       * datasource (`definition.datasource`), so the package that declared that
+       * datasource is the package the object belongs in, and its
+       * `manifest.namespace` is the prefix `defineStack()` will demand.
+       *
+       * Both links are read, not assumed:
+       *  - `_packageId` is stamped onto every registered metadata item that has
+       *    package coords (`applyProtection`, `@objectstack/spec/shared`), by
+       *    both load paths — the artifact loader and `registry.registerItem`.
+       *    `'sys_metadata'` is the rehydration sentinel, not a real package, so
+       *    it is excluded exactly as the registry's own `isCodeArtifactBody`
+       *    excludes it.
+       *  - the package record is what `installPackage` stored under
+       *    `manifest.id`, i.e. the same `{ manifest }` shape the runtime publish
+       *    gate reads for this identical check.
+       *
+       * Every step is allowed to come up empty (a DB-only datasource, a
+       * GitOps deployment with no package registry, a legacy package that
+       * declares no namespace). Empty resolves to `undefined`, and the service
+       * then emits a bare name with a loud TODO rather than inventing a prefix.
+       */
+      getNamespace: async (datasource: string) => {
+        try {
+          const ds = (await metadata?.get('datasource', datasource)) as
+            | { _packageId?: unknown }
+            | undefined;
+          const pkgId = typeof ds?._packageId === 'string' ? ds._packageId : undefined;
+          if (!pkgId || pkgId === 'sys_metadata') return undefined;
+          const pkg = (await metadata?.get('package', pkgId)) as
+            | { manifest?: { namespace?: unknown } }
+            | undefined;
+          const ns = pkg?.manifest?.namespace;
+          return typeof ns === 'string' ? ns : undefined;
+        } catch {
+          // Namespace resolution is best-effort provenance, never a reason to
+          // fail a draft: an unresolvable namespace has a defined, documented
+          // outcome (bare name + TODO), so a throwing metadata store must land
+          // there too rather than taking the whole introspection down.
+          return undefined;
+        }
+      },
       logger: this.options.logger,
     };
 


### PR DESCRIPTION
**Fixes #10712.** The generated object draft now passes `os build` on the default
path. What the `opts.primaryKey` path still does — and why that is a different card —
is stated under "The acceptance boundary" below, measured rather than assumed.

## The two defects, reproduced first

Both reproduce on `2866d5f97` (the card measured at `79ebb37`; the tree has moved
several times since, so neither failure is inherited). The generator was driven off a
**real `SqlDriver.introspectSchema()`** against a live in-memory SQLite database, then
the rendered draft was held to the same three stages `os build` holds it to.

| stage | instrument | before |
| --- | --- | --- |
| 1 | `defineStack()` — namespace-prefix validation (ADR-0028) | ✗ `Object 'customers' is missing the package namespace prefix. Rename it to 'wh_customers' (namespace = 'wh').` |
| 2 | `authoringRulesFor('build')` — the 41 rules `os compile` runs | ✗ `security-owd-unset` at `objects[0].sharingModel` |
| 3 | `tsc --noEmit` over `draft.source` | ✓ (clean on the default path) |

Stage 3 is the instrument the #10676 seat left in PR #11001 — `renderObjectSource`
annotates its output `ServiceObject`, so `tsc` over the rendered file is a complete
check of the draft's *shape*. It is complete for shape and blind to the two defects
above, which is why stages 1 and 2 are here: neither an unprefixed name nor a missing
`sharingModel` is a type error.

## The namespace half — where the prefix comes from

**Derived from the datasource's own owning package.** A federated object is bound to
exactly one datasource (`definition.datasource`), so the package that declared that
datasource is the package the object belongs in. Both links are read, not assumed:

- `_packageId` is stamped onto every registered metadata item carrying package coords
  by `applyProtection` (`@objectstack/spec/shared`), on both load paths — the artifact
  loader and `registry.registerItem`. The `'sys_metadata'` rehydration sentinel is
  excluded, exactly as the registry's own `isCodeArtifactBody` excludes it.
- the package record is what `installPackage` stored under `manifest.id` — the same
  `{ manifest }` shape the runtime publish gate reads for this identical check.

Resolution is injected (`ExternalDatasourceServiceConfig.getNamespace`), keeping the
service kernel-free like every other read it makes; `plugin.ts` supplies the wiring.

The prefix itself is applied through **`validateObjectNamespacePrefix`** — the single
source of the rule, shared verbatim with `defineStack()` and
`MetadataManager.publishPackage`. Imported rather than re-spelled as `startsWith`: a
hand-rolled check here could pass while the real gate refuses, which is the drift that
produced this defect. It also gets the already-prefixed case right for free — a remote
table `wh_accounts` under namespace `wh` stays `wh_accounts`, not `wh_wh_accounts`.

### When the namespace is absent or empty

The draft keeps the **bare** remote-table name — today's output, unchanged — and the
rendered source carries a loud `TODO(namespace)` naming ADR-0028 and the rename to
make. It does **not** invent a prefix. That mirrors `defineStack`, which skips the
check entirely for a stack with no `manifest.namespace` and, in its own words, "does
not invent a prefix on the author's behalf because doing so would silently introduce a
second writing style". A bare name is legal exactly where that stack is legal.

A blank or whitespace-only namespace is normalised to absent. That case is asserted,
not assumed: `validateObjectNamespacePrefix` skips a *falsy* namespace, but `'   '` is
truthy and would have rendered `   _customers` — one invalid draft traded for another,
which is the failure this card exists to close.

## The `sharingModel` half — #9666's shape, not a new judgement

#9666 hit this same rule family for the `os init` template, and its resolution
(PR #9736, live in `packages/cli/src/commands/init.ts`) is: **declare the value
explicitly, and pick `'private'`** — the rule's own recommended default — with the
reason attached as a comment. This draft follows that verbatim, comment included.

It transfers for three reasons stated rather than assumed: `'private'` is what
ADR-0090 D1 already resolves an unset OWD to at runtime, so the draft describes the
posture the platform would apply anyway; it is the most restrictive of the four
canonical values, so this default can never publish a federated object wider than its
author intended; and the change is that the baseline becomes an **authored** decision
instead of an accident, which is the whole point of `security-owd-unset`. No new
security posture is being chosen here.

## The acceptance boundary — what the `opts.primaryKey` path still does

Measured on the final commit, both paths, same harness:

| `opts.primaryKey` | stage 1 `defineStack` | stage 2 rules | stage 3 `tsc` |
| --- | --- | --- | --- |
| **unset** (the default path) | ✓ PASS | ✓ PASS | ✓ PASS |
| **set** (the #11000 path) | ✗ `Unrecognized key(s) on this field: primaryKey` | not reached — schema parse failed | ✗ `TS2353 … 'primaryKey' does not exist` |

**The default draft now builds; the `opts.primaryKey` path still does not, pending
#11000.** Both of this card's own defects are visibly discharged on that failing path
too — it renders `name: 'wh_customers'` and `sharingModel: 'private'` — so what remains
is #11000's alone: `fields.FIELDNAME.primaryKey` is not an authorable spec field key.
Its likely fix is `packages/spec` surface and its routing is an open contract question,
so it is deliberately untouched here. #11000 remains open and is not addressed by this PR.

Before the fix, the `primaryKey`-set path failed on `unrecognized_keys` *before* the
namespace check ran — so on that path this card's first defect was masked, not absent.

## What is pinned — `src/__tests__/external-object-draft-os-build.test.ts`, 15 cases

The pre-existing 525 stay green **unchanged**, which is the finding in its own right:
that suite is blind to both defects, and stays blind because it wires no namespace.

- **the two defects pinned separately.** A single "it builds now" assertion cannot say
  which one it measures, nor fail informatively when one regresses alone. The prefix
  case asserts through `validateObjectNamespacePrefix` — the function `defineStack()`
  itself calls. The OWD case runs a **full `ObjectSchema.safeParse`**, because what is
  guarded is a value's verdict, not a key's presence.
- **still-generates (load-bearing).** Both defects are satisfiable by emitting *less*: a
  minimal valid stub would score green on a validator-only suite while destroying what
  the generator is for. So the introspected columns and their mapped types, the remote
  table name, `remoteSchema`, and the `external` binding are all asserted to survive —
  including that the object was renamed to `wh_customers` while `external.remoteName`
  stayed `customers`.
- **the absent/empty-namespace case**, four ways (no resolver wired, a resolver that
  finds nothing, `''`, `'   '`), each asserting the bare name and *never* a leading
  underscore, plus the TODO's presence and — the other direction — its absence once a
  namespace does resolve.
- **`importObject`** inherits both repairs through the draft pipeline.

## Verification — `14550cb58`, clean tree

`pnpm --filter @objectstack/service-datasource test` → `Test Files 24 passed (24)` ·
`Tests 540 passed (540)`. `typecheck` → exit 0, no `error TS`.

### Ablations — signatures predicted in writing BEFORE mutating, one per defect

Two ablations, because the card requires the two defects to be pinned separately and
separate ablations are what prove the separation.

**A — revert the prefix only** (`applyNamespacePrefix(shortName, ns)` → `shortName`).
Predicted: exactly 2 failures, both `AssertionError` on the name, in
*"prefixes the derived name…"* and *"persists the prefixed name and the explicit OWD"*;
totals `1 failed | 23 passed (24)`, `2 failed | 538 passed (540)`. Predicted **not** to
redden, with reasons: the double-prefix case (its table is already `wh_accounts`, so
dropping the step leaves the same correct name — it guards double-prefixing, not the
prefix being dropped), the label case, the whole absent-namespace block, the TODO-absence
case, and all of `still-generates`.
Observed: `2 failed | 538 passed (540)`, `1 failed | 23 passed (24)`, both
`AssertionError: expected 'customers' to be 'wh_customers'`, exactly those two cases.
**Prediction matched exactly.**

**B — revert the `sharingModel` emission only** (definition key + the six rendered lines).
Predicted: exactly 4 failures — the three `defect 2` cases and the `importObject` case;
totals `4 failed | 536 passed (540)`. Predicted **not** to redden: every
`ObjectSchema.safeParse(...).success` assertion, because `sharingModel` is *optional* in
`ObjectSchema` and `security-owd-unset` is a lint rule, not a schema refusal — which is
precisely why reproducing this half needed a lint-level instrument at all.
Observed: `4 failed | 536 passed (540)`, `1 failed | 23 passed (24)`, three
`expected undefined to be 'private'` plus the source `toContain` failure, exactly those
four cases, every `safeParse` assertion green. **Prediction matched exactly.**

Restores proved byte-identical by `git hash-object`:
`60cc5dfde720df630e9db485be1fd16aa7aa8134` before → mutated
`40893e6d1334d601888629ccf261fb576778400f` (A) / `a6e8e0327c6a83dad420146a8a6879645a4b741a` (B)
→ `60cc5dfde720df630e9db485be1fd16aa7aa8134` after, both times. Both **restore legs were
re-run to a real verdict** rather than trusted on the hash: `540 passed (540)` each.

### `src/` vs `dist/`, argued from the files — and re-verified, not inherited

Two conflicting claims existed: #11001's seat measured `service-datasource` as having
**no `dist/`**, while the card said the defect was "confirmed in the shipped `dist`".
Re-verified here, and both readings need retiring as stated:

- On a fresh worktree at `2866d5f97`, `packages/services/service-datasource/dist/` did
  **not** exist — `pnpm install` builds nothing. So #11001's observation reproduces, but
  it is a fact about a *fresh worktree*, not a property of the package.
- This worktree now **does** have a `dist/` (I built it deliberately). So the "no dist
  exists" argument is not available here, and a different one is needed.

The argument that survives: the pin imports its subject by the **relative** specifier
`../external-datasource-service.js`, which cannot route through package `exports` at
all — vitest resolves it to `src/external-datasource-service.ts`. That is proved
empirically, not just read: **both ablations reddened with no rebuild between edit and
run**, which is only possible if the suite is executing `src/`.

The **`os build` harness is the opposite case** and is treated as such: it drives the
generator through the package's built `dist/` (it must — it also needs `@objectstack/lint`,
which is not a dependency of this package). Every measurement through it is preceded by
a rebuild, and the fix was proved to have *reached* the artifact with
`node scripts/ablation-dist-preflight.mjs @objectstack/service-datasource GENERATED_SHARING_MODEL`
→ `✓ marker present in 2 built files`. The `@objectstack/spec` and `@objectstack/lint`
halves of that harness resolve through their own built `dist/`; neither is mutated.

### Zero-hit counter-check — positive control run FIRST

The dispatch's stop-condition: **the object NAME changes** (`customers` →
`wh_customers`), so a consumer depending on the unprefixed name would make this reading
wrong.

Positive control first, so the silence is readable: a sweep for `generateObjectDraft`
across both repos, excluding `dist/` and `node_modules`, returned **13 files** — and
surfaced a route surface not named in the card (`packages/rest/src/external-datasource-routes.ts`),
so the instrument is demonstrably reaching further than the assumption behind it.

Every one of those consumers, read individually, treats `draft.name` as **opaque server
output**: both route handlers (`service-datasource/admin-routes.ts`,
`rest/external-datasource-routes.ts`) pass the whole draft through untouched; the CLI
(`os datasource introspect`) writes `draft.source` and never derives a path from the
name; objectui uses it verbatim as a storage key
(`metaClient.save('object', draft.name, draft.definition)` — both halves move together,
so #7378's register contract still holds) and as display text. The two tests that assert
a bare name (`admin-routes.test.ts`, objectui's `external/api.test.ts`) are **stubs** —
`vi.fn().mockResolvedValue(...)` and a stubbed `fetch` — asserting transport, not
generator output; neither reaches the real generator. **No consumer depends on the name
being unprefixed.**

### Gates

Union derived on the **final commit** with a clean tree via
`node scripts/pm/dispatch-gates.mjs`, **no path arguments** (exit 0; 11 path-matched
families + 5 convention-triggered). Every exit code was captured **before** any pipe
(`cmd > file 2>&1; EXIT=$?`), and each row below quotes the gate's **own** printed
verdict line, never a bare `$?`.

| gate | verdict line |
| --- | --- |
| `check:changeset-gate-self-tests` | `✓ check-empty-changeset --self-test: 118 assertions over real temp git repos` |
| `check:objectui-changeset` | `✓ objectui-range --self-test: all checks passed` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 77 packages with a tsconfig.json scanned` |
| `check-adr-0087-registration.mjs` | `✓ … this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).` |
| `check-changeset-no-major.mjs` | `✓ This diff introduces no major bump.` |
| `check-ci-filter-parity.mjs` | `OK: all 83 declared cross-package glob(s) (72 unique) are covered` |
| `check-empty-changeset.mjs` | `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check-plugin-teardown-shape.mjs` | `✓ check:plugin-teardown-shape: 61 Plugin implementation(s) across 4444 source(s)` |
| `check-affected-docs.mjs` | `✓ affected-docs self-test: 339 cases pass.` |
| `check:query-options-erasure` | `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) … none new` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 65/78 workspace packages type-checked` |
| `check:engine-double-contract` | `check-engine-double-contract: OK — 377 pinned, 133 in the DEBT ledger, 2 exempt.` |
| `check:where-matcher` | `✓ where-matcher conformance holds: 276 matcher(s) discovered` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6391 text file(s) … no raw ASCII control bytes)` |
| `check:type-check-debt --re-measure` | `OK — 33 ledger entr(ies) re-measured in 250.0s, 1908 raw tsc error(s) total, none above its recorded number` |

Two notes on that table, both about not reading a green as more than it is:

- **`check:type-check-debt --re-measure` first REFUSED** — `--re-measure cannot run: 37
  workspace dependenc(ies) … have no built type entry point on disk`. A refusal is NOT
  MEASURED, never a pass, so the closure was built exactly as `lint.yml` does
  (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful)
  and the gate re-run to the real verdict quoted above. It reports a pre-existing
  `-12` surplus on `@objectstack/plugin-auth`; that package is untouched here.
- **`check:nul-bytes` is not in the derived union.** Class #10309 — the derivation has
  been short on every services PR measured today — so it was added on judgement (any
  edit can carry a control byte) and run explicitly. It is the only family added beyond
  the derived set; nothing else the derivation named was skipped.

**Declared narrowings**, on the record rather than implied:

1. Only the **SQLite** arm of `SqlDriver` was executed (better-sqlite3, in-memory) in
   the reproduction. Postgres and MySQL were not run — no server reachable. This is a
   weaker limitation here than it was for #10676: neither defect reads dialect-specific
   introspection output at all. The object name derives from the remote *table name* and
   the OWD is a constant, so no dialect can change either verdict.
2. `packages/create-objectstack/bin/create-objectstack.js` appears in the derived change
   set: `pnpm install` mode-flipped it (100644 → 100755) in this worktree. Not my edit,
   deliberately left unstaged and out of the commit; `git diff --stat` confirms
   `0 insertions, 0 deletions`. It only **widened** the derived gate set (`packages/**`
   families), never narrowed it.
3. The `os build` acceptance was driven through the harness described above rather than
   by spawning the real `os build` binary against a scaffolded project. The harness runs
   the same three stages the command runs — `defineStack()`, `authoringRulesFor('build')`
   (41 rules, the set `os compile` runs, reached the same way
   `packages/cli/src/utils/scaffold-validate.ts` reaches it), and `tsc` over the rendered
   source — but it is a reconstruction of that pipeline, not the binary.

## Not addressed here

**#11000** remains open, as covered above. Also untouched and out of scope: **#10997**
(SQLite composite-PK truncation in the driver) and **#10998** (`introspectSchema` omits
the contract's `dialect` / `introspectedAt`) — two further findings from the same
introspection seam, neither of which this change bears on.

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_