### PR TITLE
fix(service-package): refuse `get()` / `list()` over a seam that never answered

### DIFF
--- a/.changeset/olive-pandas-repeat.md
+++ b/.changeset/olive-pandas-repeat.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/service-package": patch
+---
+
+`get()` and `list()` no longer report "not installed" / "nothing installed" over a storage seam they never queried.
+
+A driver that cannot run raw SQL returns no result set rather than throwing (`InMemoryDriver.execute()` logs `Raw execution not supported in InMemory driver` and returns `null`), and the service's row flattener mapped that to `[]` — the same value a working driver returns when a package genuinely is not installed. Both read paths then handed that back as a product answer, and the boot-time `sys_packages` rehydration skipped silently because of it.
+
+Reads now establish that the seam ANSWERED before reading emptiness as a fact. A seam that returns no result set is refused with `SERVICE_UNAVAILABLE` / 503 and a message saying the answer is unknown; boot logs the skipped rehydration at `warn` instead of passing over it. A seam that answers with genuinely zero rows is unchanged: `get()` still returns `null` and `list()` still returns `[]`.

--- a/packages/runtime/src/package-service.null-seam.test.ts
+++ b/packages/runtime/src/package-service.null-seam.test.ts
@@ -9,13 +9,43 @@
  * is that measurement, kept as a pin.
  *
  * It lives in `packages/runtime` because that is where the pieces already are:
- * `@objectstack/driver-memory` is a dependency, `@objectstack/service-package`
- * a devDependency, and this package's `vitest.config.ts` already aliases the
- * latter to its `src/` for exactly this reason (the `#5047` rehydration pin
- * next door). `service-package` itself depends on neither the engine nor a
- * driver, so the same boot cannot be written inside it.
+ * `@objectstack/service-package` is a devDependency and this package's
+ * `vitest.config.ts` already aliases it to `src/` for exactly this reason (the
+ * `#5047` rehydration pin next door). `service-package` itself depends on
+ * neither the engine nor a driver, so the same boot cannot be written inside it.
  *
- * ## Measured here, before the fix (framework `2866d5f97`)
+ * ## Why the driver here is a LOCAL DOUBLE, not `@objectstack/driver-memory`
+ *
+ * The first version of this file booted the real `InMemoryDriver`. That made it
+ * a THIRD consumer of a package whose investment is frozen (#5499), arriving
+ * after #5704 migrated the test backends and #6664 replaced the prose census
+ * with a ledger — and `check:driver-memory-census` refused it, correctly.
+ *
+ * The disposition taken was MIGRATE, not ledger. The two consumers a maintainer
+ * ruled permanent are both kept because nothing can stand in for them: one needs
+ * the SCHEMALESS arm of a divergence pin, the other needs a driver whose
+ * `supports = {}` hands autonumber seeding back to the engine. Neither shape is
+ * what this file needs. What it needs is a seam whose `execute()` RETURNS
+ * without answering — one return value, not a capability profile — and
+ * `packages/objectql/src/protocol-recorded-by-null.test.ts` already models
+ * exactly that with a local `makeStubDriver` carrying `async execute() { return
+ * null; }`. `makeStubDriver` is itself the convention #5704/#5784 established so
+ * that grepping for the driver lands on real consumers only.
+ *
+ * ⚠️ **What the double does NOT model.** It is not evidence about
+ * `@objectstack/driver-memory`'s behaviour. That the real driver logs
+ * `Raw execution not supported in InMemory driver` and returns `null` was
+ * measured on a real boot while triaging #10965, and it stays pinned on a real
+ * booted driver by `packages/cli/src/commands/migrate/duplicates.null-seam.test.ts`
+ * (#10677), which reaches it through the datasource factory rather than by
+ * importing it. Nothing about that fact is re-asserted here, and this file would
+ * not notice if that driver changed. What it models is the SHAPE — a seam that
+ * accepts a statement and returns no result set — which is the only property the
+ * guard under test keys on, and which the implementation deliberately judges by
+ * return value rather than by driver identity.
+ *
+ * ## Measured on a real booted `InMemoryDriver`, before the fix (framework
+ * `2866d5f97`) — the triage measurement this file is the regression pin for
  *
  *     typeof objectql.execute            -> 'function'   (the shape test passes)
  *     objectql.registry.installPackage   -> 'function'   (so hydration RUNS)
@@ -26,20 +56,19 @@
  *     list() -> []      ⇒ "no packages are installed"
  *     get()  -> null    ⇒ "this package is not installed"
  *
- * ⭐ What this pins is NOT "the memory driver is refused". It is the separation
+ * ⭐ What this pins is NOT "some named driver is refused". It is the separation
  * the guard keys on: **a seam that cannot ANSWER is absent, not empty.** No
  * driver is named by the implementation — the seam is judged by what it
- * returns, and this file asserts the real driver falls on the "cannot answer"
- * side of that line.
+ * returns — so the double below is judged by the same rule any real host is.
  *
- * The mongodb driver is deliberately NOT asserted anywhere here: it is not
- * loaded by this suite, and an assertion about it would be a false pin.
+ * No real driver is asserted anywhere in this file, by construction: every
+ * driver-specific claim would be a false pin over a backend this suite does not
+ * load.
  */
 
 import { describe, it, expect } from 'vitest';
 import { LiteKernel, type PluginContext } from '@objectstack/core';
 import { ObjectQLPlugin } from '@objectstack/objectql';
-import { InMemoryDriver } from '@objectstack/driver-memory';
 import {
   PackageServicePlugin,
   PACKAGE_SEAM_UNREADABLE_MESSAGE,
@@ -67,6 +96,40 @@ interface PackageSlot {
   list: () => Promise<unknown[]>;
 }
 
+/**
+ * A seam that ACCEPTS a statement and returns no result set.
+ *
+ * The whole double, and deliberately the smallest thing that can be one: the
+ * engine's `execute` delegates straight to `driver.execute(...)` after checking
+ * only that the method EXISTS (`packages/objectql/src/engine.ts:11687`), which
+ * is the half of the defect that made the conflation invisible — the shape test
+ * passes and the answer never arrives.
+ *
+ * `execute` returning `null` is the measured `InMemoryDriver` return, modelled
+ * here the way `protocol-recorded-by-null.test.ts`'s own `makeStubDriver` models
+ * it. The rest of the surface exists so `kernel.bootstrap()` completes; nothing
+ * below `execute` is asserted on.
+ */
+function makeNonAnsweringDriver() {
+  const driver = {
+    name: 'stub-non-answering',
+    version: '0.0.0',
+    supports: {},
+    async connect() {},
+    async disconnect() {},
+    async checkHealth() { return true; },
+    /** ⭐ The one behaviour under test: it RETURNS, and it does not answer. */
+    async execute() { return null; },
+    async find() { return []; },
+    async findOne() { return null; },
+    async count() { return 0; },
+    async create(_object: string, data: Record<string, unknown>) { return data; },
+    async update(_object: string, _id: unknown, data: Record<string, unknown>) { return data; },
+    async delete() { return true; },
+  };
+  return driver;
+}
+
 interface BootedStack {
   kernel: LiteKernel;
   engine: ObjectQlSlot;
@@ -76,11 +139,16 @@ interface BootedStack {
   service: PackageSlot;
 }
 
-/** The zero-install stack: real engine, real InMemoryDriver, real plugin. */
-async function bootMemoryStack(): Promise<BootedStack> {
+/**
+ * The zero-install stack: REAL kernel, REAL ObjectQL engine and registry, REAL
+ * `PackageServicePlugin.start()` — with the non-answering seam supplied by the
+ * double above. Everything the guard is judged against is real except the one
+ * property being modelled.
+ */
+async function bootNonAnsweringStack(): Promise<BootedStack> {
   const kernel = new LiteKernel({ logger: { level: 'error' } });
   kernel.use(new ObjectQLPlugin({}));
-  kernel.use(new DriverPlugin(new InMemoryDriver({ persistence: false }), 'memory'));
+  kernel.use(new DriverPlugin(makeNonAnsweringDriver()));
   await kernel.bootstrap();
 
   const engine = kernel.getService<ObjectQlSlot>('objectql');
@@ -116,9 +184,9 @@ async function bootMemoryStack(): Promise<BootedStack> {
   return { kernel, engine, statements, results, warnLogs, service: service! };
 }
 
-describe('#10965 service-package over a real booted InMemoryDriver', () => {
+describe('#10965 service-package over a booted engine whose seam never answers', () => {
   it('the seam has the SHAPE of a seam and answers nothing — the two the guard separates', async () => {
-    const stack = await bootMemoryStack();
+    const stack = await bootNonAnsweringStack();
     try {
       // The half that made the conflation invisible: `start()`'s own gate asks
       // whether `execute` is callable, and on this driver it is.
@@ -138,7 +206,7 @@ describe('#10965 service-package over a real booted InMemoryDriver', () => {
   }, 120_000);
 
   it('boot REACHES the list read — the card’s unverified half, measured', async () => {
-    const stack = await bootMemoryStack();
+    const stack = await bootNonAnsweringStack();
     try {
       const listStatement = stack.statements.find((s) => /^SELECT \* FROM sys_packages WHERE \(id, created_at\) IN/.test(s));
       expect(listStatement, 'start() issues the latest-per-id SELECT that backs list()').toBeDefined();
@@ -153,7 +221,7 @@ describe('#10965 service-package over a real booted InMemoryDriver', () => {
   }, 120_000);
 
   it('boot does not brick, and says the durable packages could not be read', async () => {
-    const stack = await bootMemoryStack();
+    const stack = await bootNonAnsweringStack();
     try {
       const skip = stack.warnLogs.find((l) => /hydration from sys_packages SKIPPED/i.test(l));
       expect(skip, 'the silent skip is now audible').toBeDefined();
@@ -164,7 +232,7 @@ describe('#10965 service-package over a real booted InMemoryDriver', () => {
   }, 120_000);
 
   it('get() and list() REFUSE with the ADR-0112 envelope instead of answering an absence', async () => {
-    const stack = await bootMemoryStack();
+    const stack = await bootNonAnsweringStack();
     try {
       for (const call of [
         () => stack.service.get('com.acme.crm', 'latest'),

--- a/packages/runtime/src/package-service.null-seam.test.ts
+++ b/packages/runtime/src/package-service.null-seam.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #10965 — the `service-package` seam guard, on a REAL booted driver.
+ *
+ * The card established the conflation by reading and named the boot path as
+ * unverified: *"Whether the DevPlugin zero-install stack (a real
+ * `InMemoryDriver`) reaches `get()`/`list()` at boot is unverified."* This file
+ * is that measurement, kept as a pin.
+ *
+ * It lives in `packages/runtime` because that is where the pieces already are:
+ * `@objectstack/driver-memory` is a dependency, `@objectstack/service-package`
+ * a devDependency, and this package's `vitest.config.ts` already aliases the
+ * latter to its `src/` for exactly this reason (the `#5047` rehydration pin
+ * next door). `service-package` itself depends on neither the engine nor a
+ * driver, so the same boot cannot be written inside it.
+ *
+ * ## Measured here, before the fix (framework `2866d5f97`)
+ *
+ *     typeof objectql.execute            -> 'function'   (the shape test passes)
+ *     objectql.registry.installPackage   -> 'function'   (so hydration RUNS)
+ *     start() issued three statements, each returning null:
+ *       CREATE TABLE IF NOT EXISTS sys_packages …         -> null
+ *       CREATE INDEX IF NOT EXISTS idx_packages_latest …  -> null
+ *       SELECT * FROM sys_packages … (the hydration list) -> null
+ *     list() -> []      ⇒ "no packages are installed"
+ *     get()  -> null    ⇒ "this package is not installed"
+ *
+ * ⭐ What this pins is NOT "the memory driver is refused". It is the separation
+ * the guard keys on: **a seam that cannot ANSWER is absent, not empty.** No
+ * driver is named by the implementation — the seam is judged by what it
+ * returns, and this file asserts the real driver falls on the "cannot answer"
+ * side of that line.
+ *
+ * The mongodb driver is deliberately NOT asserted anywhere here: it is not
+ * loaded by this suite, and an assertion about it would be a false pin.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LiteKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import {
+  PackageServicePlugin,
+  PACKAGE_SEAM_UNREADABLE_MESSAGE,
+} from '@objectstack/service-package';
+
+import { DriverPlugin } from './driver-plugin.js';
+
+interface BootedStack {
+  kernel: LiteKernel;
+  engine: any;
+  statements: string[];
+  results: unknown[];
+  warnLogs: string[];
+  service: any;
+}
+
+/** The zero-install stack: real engine, real InMemoryDriver, real plugin. */
+async function bootMemoryStack(): Promise<BootedStack> {
+  const kernel = new LiteKernel({ logger: { level: 'error' } });
+  kernel.use(new ObjectQLPlugin({}));
+  kernel.use(new DriverPlugin(new InMemoryDriver({ persistence: false }), 'memory'));
+  await kernel.bootstrap();
+
+  const engine = kernel.getService<any>('objectql');
+
+  // Record what `start()` actually asks the seam, and what the seam answers.
+  const statements: string[] = [];
+  const results: unknown[] = [];
+  const realExecute = engine.execute.bind(engine);
+  engine.execute = async (q: any) => {
+    const result = await realExecute(q);
+    statements.push(String(q.sql).replace(/\s+/g, ' ').trim());
+    results.push(result);
+    return result;
+  };
+
+  const warnLogs: string[] = [];
+  let service: any;
+  const services = new Map<string, unknown>([['objectql', engine]]);
+  const ctx: any = {
+    logger: {
+      debug: () => {}, info: () => {},
+      warn: (msg: string) => warnLogs.push(String(msg)),
+      error: () => {},
+    },
+    getService: (n: string) => services.get(n),
+    registerService: (n: string, s: unknown) => {
+      services.set(n, s);
+      if (n === 'package') service = s;
+    },
+  };
+
+  await new PackageServicePlugin().start(ctx);
+  return { kernel, engine, statements, results, warnLogs, service };
+}
+
+describe('#10965 service-package over a real booted InMemoryDriver', () => {
+  it('the seam has the SHAPE of a seam and answers nothing — the two the guard separates', async () => {
+    const stack = await bootMemoryStack();
+    try {
+      // The half that made the conflation invisible: `start()`'s own gate asks
+      // whether `execute` is callable, and on this driver it is.
+      expect(stack.engine.execute, 'the shape test still passes — that is the defect').toBeTypeOf('function');
+
+      // The half the guard now asks about: the driver accepts the statement
+      // and hands back no result set at all.
+      await expect(stack.engine.execute({ sql: 'select 1 as os_seam_probe' })).resolves.toBeNull();
+
+      // And the hydration gate it had to get past is genuinely open, so the
+      // boot loop below really does run.
+      expect(typeof stack.engine.registry?.installPackage).toBe('function');
+      expect(typeof stack.engine.registry?.getPackage).toBe('function');
+    } finally {
+      await stack.kernel.shutdown();
+    }
+  }, 120_000);
+
+  it('boot REACHES the list read — the card’s unverified half, measured', async () => {
+    const stack = await bootMemoryStack();
+    try {
+      const listStatement = stack.statements.find((s) => /^SELECT \* FROM sys_packages WHERE \(id, created_at\) IN/.test(s));
+      expect(listStatement, 'start() issues the latest-per-id SELECT that backs list()').toBeDefined();
+
+      // …and the driver answered every one of them with no result set, which
+      // is what `normalizeRows` used to flatten to "no packages installed".
+      expect(stack.results.length).toBeGreaterThan(0);
+      expect(stack.results.every((r) => r === null)).toBe(true);
+    } finally {
+      await stack.kernel.shutdown();
+    }
+  }, 120_000);
+
+  it('boot does not brick, and says the durable packages could not be read', async () => {
+    const stack = await bootMemoryStack();
+    try {
+      const skip = stack.warnLogs.find((l) => /hydration from sys_packages SKIPPED/i.test(l));
+      expect(skip, 'the silent skip is now audible').toBeDefined();
+      expect(skip).toMatch(/not "no packages installed"/);
+    } finally {
+      await stack.kernel.shutdown();
+    }
+  }, 120_000);
+
+  it('get() and list() REFUSE with the ADR-0112 envelope instead of answering an absence', async () => {
+    const stack = await bootMemoryStack();
+    try {
+      for (const call of [
+        () => stack.service.get('com.acme.crm', 'latest'),
+        () => stack.service.get('com.acme.crm', '1.0.0'),
+        () => stack.service.list(),
+      ]) {
+        let thrown: any;
+        try {
+          await call();
+          throw new Error('expected a refusal, but the call returned');
+        } catch (e) {
+          thrown = e;
+        }
+        // code AND status — never status alone, and never a bare toThrow().
+        expect(thrown.code).toBe('SERVICE_UNAVAILABLE');
+        expect(thrown.status).toBe(503);
+        expect(thrown.message).toBe(PACKAGE_SEAM_UNREADABLE_MESSAGE);
+      }
+    } finally {
+      await stack.kernel.shutdown();
+    }
+  }, 120_000);
+});

--- a/packages/runtime/src/package-service.null-seam.test.ts
+++ b/packages/runtime/src/package-service.null-seam.test.ts
@@ -37,7 +37,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { LiteKernel } from '@objectstack/core';
+import { LiteKernel, type PluginContext } from '@objectstack/core';
 import { ObjectQLPlugin } from '@objectstack/objectql';
 import { InMemoryDriver } from '@objectstack/driver-memory';
 import {
@@ -47,13 +47,33 @@ import {
 
 import { DriverPlugin } from './driver-plugin.js';
 
+/**
+ * The `objectql` slot, as this file reads it: the raw-SQL seam under test, plus
+ * the registry half whose presence is what lets `start()`'s hydration loop run
+ * at all. Spelled out rather than `any` so the slot's shape is a declaration
+ * (#4251 / `check:slot-lookup`).
+ */
+interface ObjectQlSlot {
+  execute: (query: { sql: string; args?: unknown[] }) => Promise<unknown>;
+  registry?: {
+    installPackage?: (manifest: unknown) => unknown;
+    getPackage?: (id: string) => unknown;
+  };
+}
+
+/** The two read methods this card is about, off the registered `package` slot. */
+interface PackageSlot {
+  get: (packageId: string, version?: string) => Promise<unknown>;
+  list: () => Promise<unknown[]>;
+}
+
 interface BootedStack {
   kernel: LiteKernel;
-  engine: any;
+  engine: ObjectQlSlot;
   statements: string[];
   results: unknown[];
   warnLogs: string[];
-  service: any;
+  service: PackageSlot;
 }
 
 /** The zero-install stack: real engine, real InMemoryDriver, real plugin. */
@@ -63,13 +83,13 @@ async function bootMemoryStack(): Promise<BootedStack> {
   kernel.use(new DriverPlugin(new InMemoryDriver({ persistence: false }), 'memory'));
   await kernel.bootstrap();
 
-  const engine = kernel.getService<any>('objectql');
+  const engine = kernel.getService<ObjectQlSlot>('objectql');
 
   // Record what `start()` actually asks the seam, and what the seam answers.
   const statements: string[] = [];
   const results: unknown[] = [];
   const realExecute = engine.execute.bind(engine);
-  engine.execute = async (q: any) => {
+  engine.execute = async (q: { sql: string; args?: unknown[] }) => {
     const result = await realExecute(q);
     statements.push(String(q.sql).replace(/\s+/g, ' ').trim());
     results.push(result);
@@ -77,9 +97,9 @@ async function bootMemoryStack(): Promise<BootedStack> {
   };
 
   const warnLogs: string[] = [];
-  let service: any;
+  let service: PackageSlot | undefined;
   const services = new Map<string, unknown>([['objectql', engine]]);
-  const ctx: any = {
+  const ctx = {
     logger: {
       debug: () => {}, info: () => {},
       warn: (msg: string) => warnLogs.push(String(msg)),
@@ -88,12 +108,12 @@ async function bootMemoryStack(): Promise<BootedStack> {
     getService: (n: string) => services.get(n),
     registerService: (n: string, s: unknown) => {
       services.set(n, s);
-      if (n === 'package') service = s;
+      if (n === 'package') service = s as PackageSlot;
     },
-  };
+  } as unknown as PluginContext;
 
   await new PackageServicePlugin().start(ctx);
-  return { kernel, engine, statements, results, warnLogs, service };
+  return { kernel, engine, statements, results, warnLogs, service: service! };
 }
 
 describe('#10965 service-package over a real booted InMemoryDriver', () => {
@@ -151,17 +171,17 @@ describe('#10965 service-package over a real booted InMemoryDriver', () => {
         () => stack.service.get('com.acme.crm', '1.0.0'),
         () => stack.service.list(),
       ]) {
-        let thrown: any;
+        let thrown: (Error & { code?: string; status?: number }) | undefined;
         try {
           await call();
           throw new Error('expected a refusal, but the call returned');
         } catch (e) {
-          thrown = e;
+          thrown = e as Error & { code?: string; status?: number };
         }
         // code AND status — never status alone, and never a bare toThrow().
-        expect(thrown.code).toBe('SERVICE_UNAVAILABLE');
-        expect(thrown.status).toBe(503);
-        expect(thrown.message).toBe(PACKAGE_SEAM_UNREADABLE_MESSAGE);
+        expect(thrown!.code).toBe('SERVICE_UNAVAILABLE');
+        expect(thrown!.status).toBe(503);
+        expect(thrown!.message).toBe(PACKAGE_SEAM_UNREADABLE_MESSAGE);
       }
     } finally {
       await stack.kernel.shutdown();

--- a/packages/services/service-package/src/index.ts
+++ b/packages/services/service-package/src/index.ts
@@ -173,11 +173,136 @@ function declaresHttpAnswer(error: unknown): boolean {
  *   - Some drivers may return `{ rows: [...] }` wrappers in other contexts.
  *
  * This helper accepts any of those shapes and always returns an array.
+ *
+ * ⚠️ [#10965] It returns `[]` for EVERYTHING else too, and that is the whole
+ * defect this file's seam guard exists for — see {@link isResultSet}. Flatten
+ * with this only AFTER the result has been established as an answer.
  */
 function normalizeRows(result: any): any[] {
   if (Array.isArray(result)) return result;
   if (result && Array.isArray(result.rows)) return result.rows;
   return [];
+}
+
+/**
+ * ── The seam that ACCEPTS a query but never ANSWERS one (#10965) ───────────
+ *
+ * {@link normalizeRows} flattens the result-set shapes a raw SELECT comes back
+ * as. A seam can hand back one more thing, and it means something else
+ * entirely: `null` — "I did not run your query". `InMemoryDriver.execute()` is
+ * the measured case; it logs `Raw execution not supported in InMemory driver`
+ * and returns `null`. It neither throws nor is absent, so `start()`'s
+ * `objectql.execute` shape test is satisfied, and `normalizeRows(null)` is `[]`
+ * — which is also what a real driver returns for a SELECT that matched nothing.
+ *
+ * Both read paths in this service then reported that emptiness as a fact about
+ * the data, and unlike its two siblings (#10677 / PR #10788 for
+ * `os migrate duplicates`, #10789 / PR #10964 for `backfillSeedTenancy`) what
+ * they hand back is a PRODUCT ANSWER a caller acts on:
+ *
+ *   - `get()` returned `null` ⇒ "this package is not installed".
+ *   - `list()` returned `[]`  ⇒ "no packages are installed".
+ *
+ * Measured on a real booted stack (LiteKernel + ObjectQLPlugin +
+ * `InMemoryDriver`), `start()`'s own rehydration reaches `list()`: the three
+ * statements it issues (CREATE TABLE, CREATE INDEX, the latest-per-id SELECT)
+ * each return `null`, `list()` answers `[]`, and the hydration loop iterates
+ * zero times — a SILENT skip, because its only log is behind `hydrated > 0`.
+ * Nothing downstream WRITES on that reading (the loop's only write is
+ * per-row; `installPackage`/`updatePackage`/`deletePackage` in
+ * `metadata-protocol` call `publish`/`delete` unconditionally, never gated on
+ * this read), so the blast radius is a silent hydration skip plus two false
+ * answers on the HTTP read doors — not a re-install.
+ *
+ * ⭐ **A seam that cannot ANSWER is absent, not empty.** The separation keys on
+ * the only thing that distinguishes them: a driver that answers returns a
+ * RESULT SET. Nothing here names a driver, so any host with the same no-op
+ * shape is covered without an allowlist to maintain.
+ */
+
+/**
+ * Is `result` one of the result-set shapes a raw SELECT can come back as?
+ *
+ * The shapes {@link normalizeRows} accepts, asked as a yes/no: a bare row array
+ * (better-sqlite3 through knex, and the mysql2 `[rows, fields]` tuple, which is
+ * an array too) and `{ rows }` (pg). An empty result set in any of those
+ * spellings is still a result set, and still `true` — that is what keeps a
+ * legitimately-empty install answering "not installed" / "nothing installed",
+ * and it is the half of this change that stops it being a rename.
+ *
+ * This cannot lose a row {@link normalizeRows} would have found: every shape it
+ * rejects is one that flattener already maps to `[]`, so the only change is
+ * "refused as unreadable" replacing "reported as zero rows".
+ *
+ * ⛔ A LOCAL copy, deliberately. `metadata-protocol` does not publish its own
+ * from the package index, the CLI keeps a third for its probes, and
+ * `@objectstack/metadata-protocol` is not a dependency of this package at all.
+ * Unifying the three is its own decision, not a rider on this fix.
+ */
+function isResultSet(result: unknown): boolean {
+  if (Array.isArray(result)) return true;
+  if (typeof result === 'object' && result !== null) {
+    return Array.isArray((result as { rows?: unknown }).rows);
+  }
+  return false;
+}
+
+/**
+ * [#10965] The caller-facing sentence a read over a non-answering seam gets.
+ *
+ * Like {@link PACKAGE_PUBLISH_DRIVER_FAULT_MESSAGE}, a CONSTANT that
+ * interpolates nothing: no driver text, no statement, no table name. It says
+ * the one thing a caller can act on — the answer is UNKNOWN, not "no".
+ *
+ * Exported so the doors and their pins assert the POSITIVE shape rather than
+ * the absence of the old empty answer (an absence assertion passes for any
+ * rewrite, including a worse one).
+ */
+export const PACKAGE_SEAM_UNREADABLE_MESSAGE =
+  'The package registry could not be read: the storage seam accepted the query but returned no '
+  + 'result set. Whether this package is installed is UNKNOWN — this is not an answer of "no".';
+
+/** Brand for the refusal below, so only IT is re-thrown out of the read catches. */
+const SEAM_UNREADABLE = Symbol.for('objectstack.service-package.seam-unreadable');
+
+/**
+ * [#10965] The refusal a read raises when the seam did not answer.
+ *
+ * ADR-0112 envelope: a `status` AND a `code`, both declared, so it leaves by
+ * the door's shared `errorFromThrown` mapping as the producer's own answer
+ * rather than a 500 catch-all. `SERVICE_UNAVAILABLE` / 503 is the standard
+ * catalog's own pairing and the spelling `metadata-protocol` already uses for
+ * exactly this condition (`metadataStoreUnavailableError`: the store is
+ * unreachable, so existence is unknown) — no new code is registered, and
+ * nothing in `packages/spec` is touched.
+ */
+function packageSeamUnreadableError(): Error {
+  const err = new Error(PACKAGE_SEAM_UNREADABLE_MESSAGE) as Error & {
+    code?: string;
+    status?: number;
+    [SEAM_UNREADABLE]?: true;
+  };
+  err.code = 'SERVICE_UNAVAILABLE';
+  err.status = 503;
+  err[SEAM_UNREADABLE] = true;
+  return err;
+}
+
+/**
+ * [#10965] Is this the seam refusal above?
+ *
+ * ⛔ Deliberately NOT {@link declaresHttpAnswer}. That predicate asks the much
+ * broader "did this throw declare an envelope?", and widening the two READ
+ * catches to re-throw every such error would change how this service answers
+ * driver faults it has always swallowed — a behaviour change this card did not
+ * measure and does not need. Only the refusal this file raises escapes.
+ */
+function isSeamUnreadable(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && (error as Record<symbol, unknown>)[SEAM_UNREADABLE] === true
+  );
 }
 
 /**
@@ -287,6 +412,15 @@ export class PackageServicePlugin implements Plugin {
 
           const args = version === 'latest' ? [packageId] : [packageId, version];
           const result = await objectql.execute!({ sql, args });
+
+          // [#10965] Before reading emptiness as a fact, establish that there
+          // was an answer to read. A seam that did not run the SELECT hands
+          // back no result set, and `normalizeRows` maps that to `[]` — the
+          // same value a real driver returns when the package genuinely is not
+          // installed. Refusing here is what makes those two distinguishable;
+          // a result set with zero rows still falls through to `null` below.
+          if (!isResultSet(result)) throw packageSeamUnreadableError();
+
           const rows = normalizeRows(result);
 
           if (rows.length === 0) {
@@ -304,6 +438,15 @@ export class PackageServicePlugin implements Plugin {
             updated_at: row.updated_at,
           };
         } catch (error) {
+          // [#10965] The seam refusal is the ONE throw this catch must not
+          // swallow: swallowing it would restore the exact `null` the refusal
+          // exists to replace, and the caller would be back to reading "not
+          // installed" off a query that never ran. Everything else keeps the
+          // behaviour it has always had.
+          if (isSeamUnreadable(error)) {
+            logger.error(`Cannot answer whether package '${packageId}' is installed`, error as Error);
+            throw error;
+          }
           logger.error(`Failed to get package: ${packageId}`, error as Error);
           return null;
         }
@@ -321,6 +464,11 @@ export class PackageServicePlugin implements Plugin {
             `,
           });
 
+          // [#10965] Same separation as `get()`: a seam that never ran this
+          // SELECT must not be reported as "no packages are installed". An
+          // answering seam with zero rows still returns `[]` below.
+          if (!isResultSet(result)) throw packageSeamUnreadableError();
+
           return normalizeRows(result).map((row: any) => ({
             id: row.id,
             version: row.version,
@@ -331,6 +479,13 @@ export class PackageServicePlugin implements Plugin {
             updated_at: row.updated_at,
           }));
         } catch (error) {
+          // [#10965] As in `get()`: only the seam refusal escapes, because
+          // swallowing it would answer "nothing installed" over a driver this
+          // method never queried.
+          if (isSeamUnreadable(error)) {
+            logger.error('Cannot answer which packages are installed', error as Error);
+            throw error;
+          }
           logger.error('Failed to list packages', error as Error);
           return [];
         }
@@ -433,7 +588,25 @@ export class PackageServicePlugin implements Plugin {
         }
       }
     } catch (error) {
-      logger.debug(`Package hydration from sys_packages skipped: ${(error as Error)?.message}`);
+      // [#10965] The measured consequence of the conflation, and the half that
+      // made it invisible. `list()` used to answer `[]` over a seam that never
+      // ran the SELECT, so this loop iterated zero times and said nothing —
+      // its only log sits behind `hydrated > 0`. A durable package was then
+      // absent from the registry for the whole process lifetime, with no line
+      // anywhere distinguishing that from an environment with no packages.
+      //
+      // Now `list()` refuses, and the refusal is reported at WARN naming what
+      // is unknown. Boot still continues: an unreadable seam must not brick the
+      // environment, exactly as a stale package does not (above).
+      if (isSeamUnreadable(error)) {
+        logger.warn(
+          'Package hydration from sys_packages SKIPPED — the storage seam accepted the query but '
+          + 'returned no result set, so durable packages could NOT be read. Any package persisted in '
+          + 'sys_packages is absent from the registry for this process. This is not "no packages installed".',
+        );
+      } else {
+        logger.debug(`Package hydration from sys_packages skipped: ${(error as Error)?.message}`);
+      }
     }
   }
 

--- a/packages/services/service-package/src/null-seam.test.ts
+++ b/packages/services/service-package/src/null-seam.test.ts
@@ -1,0 +1,329 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #10965 — `get()` / `list()` answered over a driver they never queried.
+ *
+ * ## What was measured before the fix
+ *
+ * The card established the conflation by READING, and said so; it named the
+ * boot path as unverified. It was booted for real before this change — a
+ * `LiteKernel` with the real `ObjectQLPlugin` and a real
+ * `InMemoryDriver({ persistence: false })`, with `PackageServicePlugin.start()`
+ * driven against that engine:
+ *
+ *     typeof objectql.execute            -> 'function'   (the shape test passes)
+ *     objectql.registry.installPackage   -> 'function'   (so hydration RUNS)
+ *     start() issues 3 statements, each returning null:
+ *       CREATE TABLE IF NOT EXISTS sys_packages …        -> null
+ *       CREATE INDEX IF NOT EXISTS idx_packages_latest … -> null
+ *       SELECT * FROM sys_packages … (the hydration list) -> null
+ *     list() -> []      ⇒ "no packages are installed"
+ *     get()  -> null    ⇒ "this package is not installed"
+ *
+ * So the boot path DOES reach `list()` on the zero-install stack, and the
+ * hydration loop iterated zero times without a word — its only log sits behind
+ * `hydrated > 0`. What nothing did was WRITE on that reading: the loop's only
+ * write is per-row, and `metadata-protocol`'s `installPackage` /
+ * `updatePackage` / `deletePackage` call `publish` / `delete` unconditionally,
+ * never gated on this read. No re-install; a silent hydration skip plus two
+ * false answers on the HTTP read doors.
+ *
+ * ## What these tests pin — BOTH directions
+ *
+ * The separation is not "stopped returning null/[]". It is that a seam which
+ * cannot ANSWER is now distinguishable from one that answered NO ROWS, and the
+ * second case must keep working: an implementation that treated every empty
+ * result as a broken seam would score green on the refusal cases alone and
+ * break every legitimately-empty deployment. The `node:sqlite` cases below are
+ * that leg, on a real driver running the real statements from `index.ts`.
+ *
+ * ## What is deliberately NOT asserted here
+ *
+ * This service's LOCAL `normalizeRows` implements TWO of the three dialect
+ * shapes — a bare row array and `{ rows }`. It does not unwrap the mysql2
+ * `[rows, fields]` tuple the way `metadata-protocol`'s copy does (that one
+ * tests `Array.isArray(result[0])`). So no populated-tuple result is asserted
+ * here: it would be a pin on behaviour this file does not have. What IS pinned
+ * is that a tuple-shaped result is still treated as an ANSWER, so the guard
+ * cannot misfire on a dialect it does not fully flatten. The gap itself is
+ * filed separately rather than fixed as a rider.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  PackageServicePlugin,
+  PACKAGE_SEAM_UNREADABLE_MESSAGE,
+  type PackageService,
+} from './index.js';
+
+const MANIFEST = { id: 'com.acme.crm', name: 'CRM', version: '1.0.0', type: 'application' } as any;
+
+interface Booted {
+  svc: PackageService;
+  warnLogs: string[];
+  errorLogs: string[];
+}
+
+/** Boot the real plugin over whatever `execute` the case supplies. */
+async function bootWith(
+  execute: (q: { sql: string; args?: unknown[] }) => Promise<unknown>,
+  registry?: { installPackage: (m: unknown) => void; getPackage: (id: string) => unknown },
+): Promise<Booted> {
+  const warnLogs: string[] = [];
+  const errorLogs: string[] = [];
+  const engine: any = { execute };
+  if (registry) engine.registry = registry;
+
+  let registered: PackageService | undefined;
+  const ctx: any = {
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: (msg: string) => warnLogs.push(String(msg)),
+      error: (msg: string) => errorLogs.push(String(msg)),
+    },
+    getService: (n: string) => (n === 'objectql' ? engine : undefined),
+    registerService: (_n: string, s: PackageService) => { registered = s; },
+  };
+
+  const plugin = new PackageServicePlugin();
+  await plugin.init(ctx);
+  await plugin.start(ctx);
+  return { svc: registered!, warnLogs, errorLogs };
+}
+
+/**
+ * A REAL SQLite database behind `objectql.execute` — an ANSWERING seam.
+ *
+ * `stmt.all()` returns a bare row array, dialect shape #1, and an empty SELECT
+ * returns `[]`. The `CREATE TABLE` / `CREATE INDEX` in `ensureTable` and the
+ * SELECTs in `get()` / `list()` are the statements from `index.ts`, run
+ * verbatim against a real engine.
+ */
+function realSqliteSeam() {
+  const db = new DatabaseSync(':memory:');
+  return {
+    db,
+    async execute({ sql, args }: { sql: string; args?: unknown[] }) {
+      const stmt = db.prepare(sql);
+      return /^\s*select/i.test(sql)
+        ? stmt.all(...((args ?? []) as any[]))
+        : stmt.run(...((args ?? []) as any[]));
+    },
+  };
+}
+
+/** The ADR-0112 envelope a seam refusal must declare: code AND status. */
+async function expectSeamRefusal(run: () => Promise<unknown>): Promise<void> {
+  let thrown: any;
+  try {
+    await run();
+    throw new Error('expected a refusal, but the call returned');
+  } catch (e) {
+    thrown = e;
+  }
+  // ⛔ Never `toThrow()` alone: an unfixed path throwing a bare Error would
+  // satisfy that and pin nothing. The envelope is the contract.
+  expect(thrown.code).toBe('SERVICE_UNAVAILABLE');
+  expect(thrown.status).toBe(503);
+  expect(thrown.message).toBe(PACKAGE_SEAM_UNREADABLE_MESSAGE);
+  // The wording is itself the contract: it says the answer is UNKNOWN.
+  expect(thrown.message).toMatch(/UNKNOWN/);
+  expect(thrown.message).not.toMatch(/sys_packages|SELECT/i);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. The seam that cannot answer — every spelling of "no result set"
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10965 a non-answering seam is REFUSED, not reported as absence', () => {
+  // `null` first: the measured `InMemoryDriver.execute()` return.
+  const nonAnswers: Array<[string, unknown]> = [
+    ['null — the measured InMemoryDriver return', null],
+    ['undefined', undefined],
+    ['a host that echoes the statement back', 'SELECT * FROM sys_packages'],
+    ['an object with no rows key', {}],
+    ['an object whose rows is not an array', { rows: 'not-an-array' }],
+    ['a number', 42],
+  ];
+
+  for (const [label, value] of nonAnswers) {
+    it(`get() refuses over ${label}`, async () => {
+      const { svc } = await bootWith(async () => value);
+      await expectSeamRefusal(() => svc.get('com.acme.crm', 'latest'));
+    });
+
+    it(`list() refuses over ${label}`, async () => {
+      const { svc } = await bootWith(async () => value);
+      await expectSeamRefusal(() => svc.list());
+    });
+  }
+
+  it('get() refuses for a pinned version too, not only "latest"', async () => {
+    const { svc } = await bootWith(async () => null);
+    await expectSeamRefusal(() => svc.get('com.acme.crm', '1.0.0'));
+  });
+
+  it('the refusal is logged as an inability, not as a miss', async () => {
+    const { svc, errorLogs } = await bootWith(async () => null);
+    await svc.get('com.acme.crm', 'latest').catch(() => {});
+    await svc.list().catch(() => {});
+    expect(errorLogs.some((l) => /Cannot answer whether package/.test(l))).toBe(true);
+    expect(errorLogs.some((l) => /Cannot answer which packages/.test(l))).toBe(true);
+    // The old lines claimed a failed read of something that exists.
+    expect(errorLogs.some((l) => /^Failed to get package/.test(l))).toBe(false);
+    expect(errorLogs.some((l) => /^Failed to list packages/.test(l))).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. STILL-EMPTY — the load-bearing leg, on a REAL driver
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10965 a seam that ANSWERS with zero rows still means "not installed"', () => {
+  it('real SQLite, empty sys_packages: get() -> null and list() -> []', async () => {
+    const seam = realSqliteSeam();
+    const { svc, warnLogs } = await bootWith(seam.execute);
+
+    // The table exists and is genuinely empty — proven against the real db,
+    // so "the query never ran" cannot explain the answers below.
+    expect(seam.db.prepare('SELECT COUNT(*) AS n FROM sys_packages').get()).toEqual({ n: 0 });
+
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toBeNull();
+    await expect(svc.get('com.acme.crm', '1.0.0')).resolves.toBeNull();
+    await expect(svc.list()).resolves.toEqual([]);
+    // A legitimately-empty install says nothing about an unreadable seam.
+    expect(warnLogs.filter((l) => /SKIPPED/.test(l))).toEqual([]);
+  });
+
+  it('real SQLite, populated: the rows still come back', async () => {
+    const seam = realSqliteSeam();
+    const { svc } = await bootWith(seam.execute);
+
+    await svc.publish({ manifest: MANIFEST, metadata: { objects: [] } });
+
+    const got = await svc.get('com.acme.crm', 'latest');
+    expect(got).toMatchObject({ id: 'com.acme.crm', version: '1.0.0' });
+    expect(got!.manifest).toMatchObject({ id: 'com.acme.crm' });
+
+    const listed = await svc.list();
+    expect(listed.map((p) => p.id)).toEqual(['com.acme.crm']);
+  });
+
+  it('a package that is genuinely absent is still `null`, beside one that is present', async () => {
+    const seam = realSqliteSeam();
+    const { svc } = await bootWith(seam.execute);
+    await svc.publish({ manifest: MANIFEST, metadata: {} });
+
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.not.toBeNull();
+    await expect(svc.get('com.acme.nothing', 'latest')).resolves.toBeNull();
+    await expect(svc.get('com.acme.crm', '9.9.9')).resolves.toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. The dialect shapes this flattener implements stay answers
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10965 the guard never turns a result set into a refusal', () => {
+  const row = {
+    id: 'com.acme.crm',
+    version: '1.0.0',
+    manifest: JSON.stringify(MANIFEST),
+    metadata: '{}',
+    hash: 'h',
+    created_at: 't',
+    updated_at: 't',
+  };
+
+  /** Only the SELECTs are shaped; DDL keeps the same spelling. */
+  function seamReturning(select: unknown) {
+    return async ({ sql }: { sql: string }) => (/^\s*select/i.test(sql.trim()) ? select : []);
+  }
+
+  it('bare row array (better-sqlite3 through knex) — rows come through', async () => {
+    const { svc } = await bootWith(seamReturning([row]));
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toMatchObject({ id: 'com.acme.crm' });
+    await expect(svc.list()).resolves.toHaveLength(1);
+  });
+
+  it('bare EMPTY array — an answer of no rows, not a refusal', async () => {
+    const { svc } = await bootWith(seamReturning([]));
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toBeNull();
+    await expect(svc.list()).resolves.toEqual([]);
+  });
+
+  it('`{ rows, rowCount }` (pg) — rows come through', async () => {
+    const { svc } = await bootWith(seamReturning({ rows: [row], rowCount: 1 }));
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toMatchObject({ id: 'com.acme.crm' });
+    await expect(svc.list()).resolves.toHaveLength(1);
+  });
+
+  it('`{ rows: [], rowCount: 0 }` (pg) — an answer of no rows, not a refusal', async () => {
+    const { svc } = await bootWith(seamReturning({ rows: [], rowCount: 0 }));
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toBeNull();
+    await expect(svc.list()).resolves.toEqual([]);
+  });
+
+  it('an `[rows, fields]`-shaped result is an ANSWER — the guard does not misfire', async () => {
+    // This local flattener does not UNWRAP the tuple (filed separately), so
+    // nothing is asserted about the rows it yields. What is asserted is the
+    // only thing this card owns: it is not mistaken for a seam that failed to
+    // answer, so no dialect gets a false 503.
+    const { svc } = await bootWith(seamReturning([[], []]));
+    await expect(svc.list()).resolves.toEqual([]);
+    await expect(svc.get('com.acme.crm', 'latest')).resolves.toBeNull();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 4. Boot hydration — the measured consequence, now audible
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('#10965 boot hydration over a non-answering seam', () => {
+  function fakeRegistry() {
+    const installed: any[] = [];
+    return {
+      installed,
+      installPackage: (m: any) => { installed.push(m); },
+      getPackage: (_id: string) => undefined,
+    };
+  }
+
+  it('does not brick boot, and SAYS the durable packages could not be read', async () => {
+    const registry = fakeRegistry();
+    const { warnLogs } = await bootWith(async () => null, registry);
+
+    // Boot completed (bootWith would have rejected otherwise) and installed
+    // nothing — but no longer silently.
+    expect(registry.installed).toEqual([]);
+    const skip = warnLogs.find((l) => /hydration from sys_packages SKIPPED/i.test(l));
+    expect(skip).toBeDefined();
+    expect(skip).toMatch(/no result set/);
+    expect(skip).toMatch(/not "no packages installed"/);
+  });
+
+  it('an ANSWERING seam with zero rows hydrates nothing and says nothing', async () => {
+    const registry = fakeRegistry();
+    const seam = realSqliteSeam();
+    const { warnLogs } = await bootWith(seam.execute, registry);
+
+    expect(registry.installed).toEqual([]);
+    expect(warnLogs.filter((l) => /SKIPPED/.test(l))).toEqual([]);
+  });
+
+  it('an ANSWERING seam with a durable row still hydrates it', async () => {
+    const registry = fakeRegistry();
+    const seam = realSqliteSeam();
+
+    // Seed the durable row through the service's own publish, then boot a
+    // second plugin instance over the same database — a restart.
+    const first = await bootWith(seam.execute);
+    await first.svc.publish({ manifest: MANIFEST, metadata: {} });
+
+    const { warnLogs } = await bootWith(seam.execute, registry);
+    expect(registry.installed.map((m: any) => m.id)).toEqual(['com.acme.crm']);
+    expect(warnLogs.filter((l) => /SKIPPED/.test(l))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #10965

`service-package` answered "this package is not installed" / "no packages are installed" over a storage seam it never queried. Its local `normalizeRows` maps a non-answering seam onto zero rows, and both read paths hand that back as a **product answer** a caller acts on.

Third instance of one settled class — #10677 / PR #10788 (`os migrate duplicates`), #10789 / PR #10964 (`backfillSeedTenancy`): **a seam that cannot ANSWER is absent, not empty.** The reasoning is reused; the code is a local copy (below).

---

## Step 1 — the measurement the card said it had not taken

The card established the conflation by reading, and named the boot path as unverified:

> Whether the DevPlugin zero-install stack (a real `InMemoryDriver`, `plugin-dev/src/dev-plugin.ts:473-482`) reaches `get()`/`list()` at boot is unverified — I only established the conflation by reading, not by booting.

It was booted before anything was changed: a `LiteKernel` with the real `ObjectQLPlugin` and a real `InMemoryDriver({ persistence: false })`, with `PackageServicePlugin.start()` driven against that engine, `execute` instrumented to record every statement and its return. Measured on `2866d5f97`:

```
typeof objectql.execute            -> 'function'    (the shape test passes)
objectql.registry.installPackage   -> 'function'    (so the hydration loop RUNS)
objectql.registry.getPackage       -> 'function'

start() issued three statements, each answered null:
  CREATE TABLE IF NOT EXISTS sys_packages …          -> null
  CREATE INDEX IF NOT EXISTS idx_packages_latest …   -> null
  SELECT * FROM sys_packages WHERE (id, created_at) IN ( … )  -> null   <-- list()

list() -> []      ⇒ "no packages are installed"
get()  -> null    ⇒ "this package is not installed"
```

**Answer: yes, the boot path reaches it.** `start()`'s own `sys_packages` rehydration calls `list()`, the seam returns no result set, and the loop iterated zero times — **silently**, because its only log sits behind `if (hydrated > 0)`.

### Does anything WRITE on that reading? No.

Every consumer of the two methods was enumerated:

| consumer | reads | effect of the false answer |
|---|---|---|
| `service-package/src/index.ts` `start()` boot rehydration | `list()` | hydration **skip**; the loop's only write (`registry.installPackage`) is per-row, so zero rows ⇒ zero writes |
| `rest/src/package-routes.ts:644` `GET /api/v1/packages` | `list()` | read-only merge — database packages silently missing from the listing |
| `rest/src/package-routes.ts:685` `GET /api/v1/packages/:id` | `get()` | read-only — falls through to the registry, then 404 |

The three protocol paths that *do* write (`metadata-protocol/src/protocol.ts` `installPackage` :19496, `updatePackage` :19542, `deletePackage` :16473) call `publish` / `delete` **unconditionally** — none is gated on this read, and `publish` is an `ON CONFLICT … DO UPDATE` upsert regardless.

**So: no re-install, no destructive write.** The blast radius is a silent boot hydration skip plus two false product answers on the HTTP read doors. That is above cosmetic — these are product values, and the skip was inaudible — and below the data-loss case the card flagged as the reason to triage. Reporting it plainly rather than leaving it implied: **the severity comes down.** The fix is still right; a method that reports an absence it never measured is wrong regardless.

## The fix

Both reads establish that the seam **answered** before reading emptiness as a fact:

```ts
if (!isResultSet(result)) throw packageSeamUnreadableError();
```

- **`isResultSet`** — the shapes `normalizeRows` accepts, asked as a yes/no. An empty result set in any spelling is still `true`.
- **The refusal** — ADR-0112 envelope, `code` **and** `status`: `SERVICE_UNAVAILABLE` / **503**, the standard catalog's own pairing and the spelling `metadata-protocol`'s `metadataStoreUnavailableError` already uses for exactly this condition (store unreachable ⇒ existence unknown). **No new code is registered and nothing in `packages/spec` is touched.** The message interpolates nothing — no driver text, no statement, no table name — and says the one thing a caller can act on: the answer is UNKNOWN, not "no".
- **The catches** — `get()`/`list()` each swallow into `null`/`[]`, so a bare throw would have been swallowed by the very catch the refusal exists to escape. Only the branded seam refusal is re-thrown. Deliberately **not** the existing `declaresHttpAnswer`: widening these two catches to re-throw every declared envelope would change how the service answers driver faults it has always swallowed — a behaviour change this card did not measure and does not need.
- **Boot hydration** — the skip is now logged at `warn`, naming what is unknown. Boot still continues: an unreadable seam must not brick the environment.

### The dialect shapes, enumerated FROM THE CODE

The card describes this as "the same three-dialect flattener `metadata-protocol` exports". Read against the source, that is **not** what this file has. Its local `normalizeRows` (`:177-181`) has exactly **two** accepting branches:

| # | shape | dialect | local `normalizeRows` |
|---|---|---|---|
| 1 | bare row array | better-sqlite3 through knex, Turso | `Array.isArray(result)` → `result` |
| 2 | `{ rows, rowCount, … }` | pg | `Array.isArray(result.rows)` → `result.rows` |
| 3 | `[rows, fields]` tuple | mysql2 | **not unwrapped** — no `Array.isArray(result[0])` branch |

`metadata-protocol`'s copy has all three. The doc comment's three bullets name only two distinct shapes (bullets 2 and 3 are both `{ rows }`). The missing tuple unwrap is a **separate defect of a different class** (a seam that *answered* being misread, not one that could not answer), so it is filed as #11062 rather than fixed as a rider here. What this PR does pin is that a tuple-shaped result is still treated as an **answer**, so the new guard cannot misfire on a dialect it does not fully flatten — no false 503.

The safety property holds against the **local** flattener: every shape `isResultSet` rejects is one `normalizeRows` already maps to `[]`, so no row can be lost. The only change is "refused as unreadable" replacing "reported as zero rows".

### Why the predicate is a local copy

`metadata-protocol` deliberately does not publish its `isResultSet` from the package index, the CLI keeps a third for its own probes — and `@objectstack/metadata-protocol` is **not a dependency of this package at all**. Unifying the three is its own decision, not a rider on this fix; raised as an open question for the maintainer instead.

## What is pinned — both directions

`packages/services/service-package/src/null-seam.test.ts` (28 cases) and `packages/runtime/src/package-service.null-seam.test.ts` (4 cases, on a real booted kernel + engine + plugin — see the census note below for why its *driver* is a local double):

1. **Non-answering seam is refused** — all six spellings (`null` first: the measured `InMemoryDriver` return; plus `undefined`, an echoed statement, `{}`, `{ rows: 'not-an-array' }`, a number) × `get()`/`list()`, asserting `code` **and** `status` **and** the message. Never a bare `toThrow()`: an unfixed path throwing a plain `Error` would satisfy that and pin nothing.
2. **⚠️ Still-empty, load-bearing** — a **real `node:sqlite` database** running the real statements from `index.ts`: with `SELECT COUNT(*) = 0` proven against the db itself, `get()` still returns `null` and `list()` still returns `[]`, and no warn is emitted. An implementation that treated every empty result as a broken seam would score green on the refusal cases alone and break every legitimately-empty deployment. Beside it: a populated database still returns its rows, and an absent package beside a present one is still `null`.
3. **The flattener still flattens what it implements** — bare array and `{ rows }`, populated and empty, driven end-to-end through `get()`/`list()`; plus the tuple-shaped non-misfire above.
4. **Boot hydration** — over a non-answering seam boot does not brick and now *says* the durable packages could not be read; over an answering seam with zero rows it hydrates nothing and says nothing; over an answering seam with a durable row (published, then a second plugin instance booted over the same database — a restart) it still hydrates it.

## Ablation — signature predicted in writing FIRST

Prediction, written before mutating: delete the two `if (!isResultSet(result)) throw packageSeamUnreadableError();` lines, leaving everything else. Direction: **turns red**.

| | predicted | observed |
|---|---|---|
| `service-package` suite | **15** red — the 13 refusal cases (6 shapes × get/list, + pinned version) with `expected a refusal, but the call returned`, the log-assertion case, and the boot "SAYS it could not read" case; describes 2 and 3 stay green | **15 failed \| 48 passed (63)** — exactly those 15, by name |
| `runtime` boot suite | **2 of 4** red — "boot … says the durable packages could not be read" and "get() and list() REFUSE"; the two cases asserting the *composition* stay green | **2 failed \| 2 passed (4)** — exactly those 2 |

Re-run after the census migration below, against the local double instead of the real driver: **the same 2 of 4, by name**. The double reproduces the failure the pin exists to catch.

Restored and proved byte-identical:

```
git hash-object … before ablation: 1314b679cff9af4fcb705cc88812b449c500994c
git hash-object … after restore:   1314b679cff9af4fcb705cc88812b449c500994c   BYTE-IDENTICAL
```

…and the restore leg was then **re-run to a real verdict** rather than trusted on the hash: `RESTORE-LEG service-package=0 runtime=0`, 63/63 and 4/4.

### `src` vs `dist` — argued from the files, and held falsifiable

Both suites read **`src`**, and this was not merely argued:

- `packages/services/service-package/src/null-seam.test.ts` imports `./index.js` — a **relative** import to its own sibling, which vitest resolves to `src/index.ts`. It never consults the package's `exports`.
- `packages/runtime/src/package-service.null-seam.test.ts` imports the bare specifier, and `packages/runtime/vitest.config.ts:110-112` declares an explicit **alias** to `../services/service-package/src/index.ts`.
- **The falsifiable half:** at the time both suites first ran green, `packages/services/service-package/dist/` was present but **stale** — built at 13:33, before the edits — and `grep -c PACKAGE_SEAM_UNREADABLE_MESSAGE dist/index.js` returned **0** while `src/index.ts` returned **2**. A suite reading `dist` would have imported `undefined` for that symbol and failed every message assertion; `isResultSet` would not have existed at all. Both suites passed against that stale `dist` on disk. `dist` was rebuilt afterwards, for the typechecks.

No `ablation-dist-preflight` run is claimed, and none applies: neither leg resolves the subject through `exports` → `dist/`, which is the condition that check exists for.

### `check:driver-memory-census` — the runtime pin was MIGRATED off the frozen driver, not ledgered

The first version of the runtime pin booted the real `InMemoryDriver`, which made it a **third** consumer of a package whose investment is frozen (#5499). `check:driver-memory-census` refused it — correctly, and it is the one gate the local derivation cannot reach (its declared population is the package specifier `@objectstack/driver-memory`, not a tracked path, so the script itself lists it under *unreachable by construction*: it scores the same quiet green for every card in the tree). CI caught what the derived union structurally could not.

**Disposition taken: migrate.** Adding a ledger entry was refused for the same reason the `check:slot-lookup` baseline was left alone earlier in this PR. The evidence that the real driver was not load-bearing, established before migrating:

- Both `ruled-permanent` entries are kept because **nothing can stand in** for them — one needs the *schemaless* arm of the #4271 divergence pin, the other a driver whose `supports = {}` hands autonumber seeding back to the engine (*"No SQL backend can stand in"*). That discriminator is a **capability profile**. This pin needs no capability profile — only a seam whose `execute()` returns without answering, which is one return value.
- The repo already models exactly that locally: `packages/objectql/src/protocol-recorded-by-null.test.ts` carries a `makeStubDriver` with `supports: {}` and `async execute() { return null; }`. `makeStubDriver` *is* the convention #5704/#5784 established so a grep for the driver lands on real consumers only.
- `engine.execute` delegates straight to `driver.execute(...)` after checking only that the method **exists** (`packages/objectql/src/engine.ts:11687`) — the very half of the defect that made the conflation invisible — so a double reaches the guard through the **real** engine path.
- Nothing is lost: the real driver's null-return stays pinned on a real boot by `packages/cli/src/commands/migrate/duplicates.null-seam.test.ts` (#10677), which reaches it through the datasource factory rather than by importing it.

The kernel, the ObjectQL engine and registry, and `PackageServicePlugin.start()` all stay **real**; only the seam's non-answer is doubled. ⚠️ **The bound, stated in the file itself:** this pin is not evidence about `@objectstack/driver-memory` and would not notice if that driver changed. It models the *shape* — a seam that accepts a statement and returns no result set — which is the only property the guard keys on, since the implementation judges by return value and never by driver identity.

Census verdict, before and after:

```
before:  13 module binding(s) in 13 file(s) — x LEDGERED: packages/runtime/src/package-service.null-seam.test.ts:42
         binds @objectstack/driver-memory (import) and the ledger does not cover it.        exit 1
after:   12 module binding(s) in 12 file(s), 2 ruled test consumer(s)                        exit 0
         "check-driver-memory-census: OK — every declaration is ledgered, every ledger entry is
          live, and every ruled file states \"#6664 census: 2 ruled consumers\"."
```

**The ledger is byte-unchanged and the ruled set is still 2.** Thirteen bindings became twelve — a migration, not bookkeeping.

### Zero-hit counter-check — positive control FIRST

Before reading any silence as evidence, the instrument was proved on the corpus. The consumer sweep `grep -rn "get('package')|getService('package')|getService<…>('package')" --include=*.ts packages/ apps/` was run and **did** return the known consumers (`rest/src/direct-mount-composition.ts:110`, `metadata-protocol/src/protocol.ts:16473, :19496, :19542`, `objectql/src/registry.ts`). Only then was the absence of any *write* gated on `get()`/`list()` read as a fact — and each surviving hit was opened and read rather than counted. **No grep hit count is reported here as a fact count**; the table above comes from reading all four call sites.

## Gates

Derived on the **final commit `5820d0922`, clean tree**, `node scripts/pm/dispatch-gates.mjs` with **no path arguments** (the script takes the change set from the merge base itself). **Class #10309 is live and was live here: the dispatch prompt named _no_ gate family for this card at all.** The derivation named 13 path-matched plus 5 convention-triggered; all 18 were run explicitly and each verdict below is the gate's **own** printed line, with exit codes captured before any pipe.

| gate | verdict |
|---|---|
| `check:changeset-gate-self-tests` | exit 0 |
| `check:cross-package-test-inputs` | exit 0 |
| `check:objectui-changeset` | exit 0 |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new` |
| `check:test-source-alias` | exit 0 |
| `check:type-source-resolution` | exit 0 |
| `check-adr-0087-registration.mjs` | exit 0 |
| `check-changeset-no-major.mjs` | exit 0 |
| `check-ci-filter-parity.mjs` | exit 0 |
| `check-cross-package-test-inputs.mjs` | exit 0 |
| `check-empty-changeset.mjs` | exit 0 |
| `check-plugin-teardown-shape.mjs` | exit 0 |
| `docs-audit/check-affected-docs.mjs` | exit 0 |
| `check:query-options-erasure` | `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new` |
| `check:engine-double-contract` | `OK — 377 pinned, 133 in the DEBT ledger, 2 exempt` |
| `check:where-matcher` | `✓ where-matcher conformance holds: 276 matcher(s) discovered … none new` |
| `check:type-check-coverage` | `OK — 65/78 workspace packages type-checked (plus the root)` |
| `check:type-check-debt` | `--re-measure: OK — 33 ledger entr(ies) re-measured in 246.7s, 1908 raw tsc error(s) total, none above its recorded number` |
| `check-nul-bytes.mjs` | `OK (scanned 6392 text file(s) … no raw ASCII control bytes)` |
| `check-driver-memory-census.mjs` | `OK — every declaration is ledgered, every ledger entry is live, and every ruled file states "#6664 census: 2 ruled consumers"` |

`check:slot-lookup` **failed first** — an `any` type parameter on the `getService` call in the new runtime pin was a NEW service-lookup erasure (#4251, the baseline never grows). Fixed by declaring the slot's contract shape, not by touching the baseline.

`check:type-check-debt` **first refused**: `--re-measure cannot run: 27 workspace dependenc(ies) … have no built type entry point on disk`. That refusal is **NOT MEASURED**, never a pass — the closure was built (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful) and the gate re-run to the real verdict above. Its `ℹ @objectstack/plugin-auth: TEST_DEBT records 109, tsc now reports 97 (-12)` surplus is pre-existing and in a package this PR does not touch; not lowered here.

Tests, same commit, exit codes captured before any pipe:

```
pnpm --filter @objectstack/service-package exec vitest run --maxWorkers=2   -> SP_TEST=0   Test Files 4 passed (4) · Tests 63 passed (63)
pnpm --filter @objectstack/runtime exec vitest run … null-seam.test.ts      -> RT_TEST=0   Test Files 1 passed (1) · Tests  4 passed (4)
pnpm --filter @objectstack/service-package typecheck                        -> SP_TC=0     (echoed `tsc --noEmit`)
pnpm --filter @objectstack/runtime typecheck                                -> RT_TC=0     (echoed `tsc --noEmit`)
```

### Declared narrowings

- **No repo-wide `pnpm test` / `pnpm typecheck`.** Only the two affected packages were run, plus the 18 derived gate families. CI runs the farm regardless.
- **No downstream consumer typecheck sweep** beyond `runtime`. This PR changes no exported type signature — it only *adds* one export (`PACKAGE_SEAM_UNREADABLE_MESSAGE`), which cannot break a consumer's types, and the behavioural change (a throw) is invisible to `tsc`. `rest` and `cli` were not typechecked locally.
- **No real driver is asserted anywhere**, deliberately — not the mongodb driver, and since the census migration not the in-memory one either: this suite loads neither, and an assertion about a backend it never loads would be a false pin.

### Scope

Two findings are filed and stay open — out of scope: #11062 (the mysql2 tuple gap) and #11063 (the door that swallows the new refusal). Neither is addressed here. Nothing under `content/docs/releases/**` or `packages/spec` is touched; the refusal reuses an existing standard-catalog code precisely so no spec edit is needed.

## Left for review, NOT decided here

- **Whether to unify the three `isResultSet` copies.** The card is explicit that a third consumer arriving is the *first real evidence* unification is worth doing — which makes it a proposal, not a licence. Implemented locally. `metadata-protocol`'s index comment says its copy is deliberately unpublished, and nothing here reaches into it. Measurement and recommendation are in the report; #11062 is a second data point for it.
- **`GET /api/v1/packages` swallows the new refusal.** `package-routes.ts:644` wraps `packageService.list()` in `catch { /* Database query failed — continue with registry-only packages */ }`, so the 503 does not reach the wire there and the door still answers 200 with registry-only packages. `GET /packages/:id` is unaffected — its `get()` throw reaches `sendThrownError` and the declared envelope goes out intact. That catch is a different file and a different consumer; filed as #11063, not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
