### PR TITLE
fix(service-analytics): refuse a cross-object dataset-level filter on both ObjectQL doors (#10861)

### DIFF
--- a/.changeset/objectql-dataset-scope-crossobject-refusal.md
+++ b/.changeset/objectql-dataset-scope-crossobject-refusal.md
@@ -1,0 +1,61 @@
+---
+"@objectstack/service-analytics": minor
+---
+
+**BREAKING**: on the ObjectQL path, a compiled dataset whose definition-level
+`filter` is itself cross-object is now refused by both analytics doors instead
+of reaching `engine.aggregate` with a predicate it cannot join (#10861).
+
+PR #10758 gave the dataset's own definition-level `filter` a route onto this
+door for the first time. That route was outside the member view the cross-object
+envelope check judges, so nothing ever saw it:
+
+```
+dataset: object 'opportunity', include: ['account'],
+         filter: { 'account.region': 'West' }
+
+before   /analytics/query   200, rows   -> engine.aggregate received
+                                           {"$and":[{"account.region":"West"}]}
+         /analytics/sql     200, SQL
+after    both               400 INVALID_FIELD, member "account.region",
+                            cube "<dataset>"; the engine is never reached
+```
+
+`engine.aggregate` cannot join. `account.region` is not a column of
+`opportunity`, so on any driver that evaluates the predicate honestly it matches
+nothing, and the widget answered a number that was neither the scoped number nor
+the unscoped one — with no error anywhere. That is the silent mis-bucket #3654's
+loud refusal exists to prevent, arriving through a producer #3654 predates.
+
+**Breaking, and argued rather than assumed.** A query that returns `200` with
+rows today starts answering `400`, on a *saved* dataset rather than on anything
+in the request — a dashboard that renders today can start showing an error. That
+is the strongest reading of "breaking" and it is why this is called out here
+rather than filed as a quiet fix. What is *not* lost is any correct answer: the
+rows that stop being served were already wrong, and wrong in the way that hides
+itself. The refusal names the member, names the dataset, and says the same
+definition is valid on a native-SQL deployment, so the operator has somewhere to
+go; the previous behaviour gave them a plausible number and nothing to notice.
+Rejecting the dataset at compile time in `dataset-compiler.ts` was considered and
+not taken (maintainer ruling, 2026-08-22): the compiler cannot see which driver
+will serve the dataset, and the same definition is legal on a native-SQL one.
+
+Who is affected: a deployment whose driver reports `objectqlAggregate` but not
+`nativeSql` (Mongo, the memory driver), serving a dataset whose definition-level
+`filter` names a field on a related object. Nothing an author writes changes
+shape, no stored document is rewritten, and an **ordinary** dataset scope
+(`filter: { is_deleted: false }`) still passes both doors and still reaches the
+engine carrying its predicate — that direction is pinned one character away from
+the new refusal in `crossobject-conjunct-refusal.test.ts`, because an
+implementation that refused *every* dataset scope would look identical from the
+refusal side alone and would break every scoped dataset shipping today.
+
+<!-- adr-0087: not-required (no-migration-prescription) No authorable surface is
+retired, renamed or re-shaped: `DatasetSchema`'s `filter` key stays exactly as it
+is, every stored dataset document stays valid as written, and the very same
+document remains correct on a native-SQL deployment. There is therefore nothing
+`objectstack migrate meta` could rewrite — a mechanical rewrite would have to
+know which driver will serve the dataset, which is precisely the capability the
+2026-08-22 ruling records as invisible to the compile-time placement. This is a
+query-time refusal on one driver family, not a surface retirement, so the ledger
+has no entry to carry and the upgrade guide has no prescription to print. -->

--- a/packages/services/service-analytics/src/__tests__/crossobject-conjunct-refusal.test.ts
+++ b/packages/services/service-analytics/src/__tests__/crossobject-conjunct-refusal.test.ts
@@ -31,12 +31,27 @@
  * stated the invariant it was breaking: *"`generateSql()` calls this too, so the
  * preview accepts/rejects the same set."*
  *
- * ## Why this file pins FOUR directions, not one
+ * ## [#10861] The second producer, and why this file now covers both
  *
- * Pinning only the new refusal would go green on an implementation that refuses
- * every combinator — which would break every legitimate `$or` query shipping
- * today. So the accepting neighbours are pinned in the same file, one character
- * away from the refused ones:
+ * The caller's `where` is not the only thing that puts a predicate in front of
+ * `engine.aggregate` here. PR #10758 gave the compiled dataset's OWN
+ * definition-level `filter` a route onto this door, and that route was outside
+ * both member views too — so a dataset declaring
+ * `filter: { 'account.region': 'West' }` was accepted by BOTH doors and the
+ * engine received a predicate it cannot join. #10759 was not that card: the two
+ * doors AGREED there, so there was no divergence to restore, and refusing it
+ * was a new decision about the refusal set. It was taken (maintainer,
+ * 2026-08-22: Option A, refuse at query time) and #10861 folds the scope's
+ * leaves into the same one member view. Both producers are now judged by one
+ * check, which is why they are pinned in one file.
+ *
+ * ## Why this file pins SIX directions, not one
+ *
+ * Pinning only the new refusals would go green on an implementation that
+ * refuses every combinator, or every dataset scope — which would break every
+ * legitimate `$or` query and every scoped dataset shipping today. So the
+ * accepting neighbours are pinned in the same file, one character away from the
+ * refused ones:
  *
  *   ① a cross-object member nested in `$or` / `$not` is REFUSED on both doors
  *   ② a combinator with NO cross-object member still passes both doors, and
@@ -47,14 +62,13 @@
  *      misread as a cross-object reference — an ordinary definition-level scope
  *      travels in `$and` exactly like a combinator does, and reads as a member
  *      of nothing
+ *   ⑤ a CROSS-OBJECT dataset-level `filter` is REFUSED on both doors, in the
+ *      ADR-0112 envelope, before `engine.aggregate` is reached (#10861)
+ *   ⑥ an ORDINARY dataset-level `filter` still reaches the engine CARRYING its
+ *      predicate — the load-bearing half of ⑤, and the pin a
+ *      "refuse every dataset scope" implementation fails
  *
- * ## The scope line this file also draws
- *
- * A dataset whose DEFINITION-LEVEL filter is itself cross-object is accepted by
- * BOTH doors, before and after this change — neither call site's view contains
- * the dataset scope. The doors AGREE there, so it is not the invariant this card
- * restores; it is a separate defect and is pinned here as measured-and-known
- * rather than left to be rediscovered. See the last block.
+ * ①–④ are #10759's and are re-run unchanged here; ⑤–⑥ are #10861's.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -65,7 +79,7 @@ import { AnalyticsService } from '../analytics-service.js';
 
 const ctxA = { tenantId: 'org_A', userId: 'u_a' } as ExecutionContext;
 
-interface Refusal extends Error { code?: string; status?: number; member?: string; param?: string }
+interface Refusal extends Error { code?: string; status?: number; member?: string; param?: string; cube?: string }
 interface AggCall { object: string; filter?: unknown }
 
 /** A cube with one base dimension, one cross-object dimension, one base measure. */
@@ -104,6 +118,21 @@ const XOBJ_SCOPED_SALES: Dataset = DatasetSchema.parse({
   object: 'opportunity',
   include: ['account'],
   filter: { 'account.region': 'West' },
+  dimensions: [{ name: 'stage', field: 'stage', type: 'string' }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+}) as Dataset;
+
+/**
+ * [#10861] A dataset scope with a base leaf AND a cross-object leaf. Serving is
+ * not a property of a scope containing a base leaf — the cross-object one
+ * decides, wherever it sits.
+ */
+const MIXED_SCOPED_SALES: Dataset = DatasetSchema.parse({
+  name: 'mixed_scoped_sales',
+  label: 'Mixed scoped sales',
+  object: 'opportunity',
+  include: ['account'],
+  filter: { is_deleted: false, 'account.region': 'West' },
   dimensions: [{ name: 'stage', field: 'stage', type: 'string' }],
   measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
 }) as Dataset;
@@ -150,6 +179,15 @@ async function bothDoors(cube: string, query: Omit<AnalyticsQuery, 'cube'>, defs
 }
 
 const CROSS_OBJECT_MESSAGE = /cannot evaluate a cross-object filter \("account\.region"\)/;
+/**
+ * [#10861] A DISTINCT message, deliberately: the four refusals that predate
+ * this card keep their wording (#5923's tests read it), and this one has to say
+ * a different thing — the member is in a saved document, not in the request.
+ * Matching on the substring that carries that distinction, so a rewording that
+ * dropped the provenance would go red.
+ */
+const DATASET_SCOPE_MESSAGE =
+  /cannot evaluate the cross-object filter \("account\.region"\) that dataset "[^"]+" declares at its definition level/;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ① the refusal that was missing on the execution door
@@ -281,29 +319,148 @@ describe('[#10759] the #10413-phase-1 dataset filter conjunct is not misread', (
     expect(calls).toEqual([]);
   });
 
-  /**
-   * MEASURED AND DELIBERATELY LEFT OPEN — not a latent pass.
-   *
-   * A cross-object DEFINITION-LEVEL filter is accepted by both doors, and
-   * `engine.aggregate` receives `{"$and":[{"account.region":"West"}]}`, which it
-   * cannot join. PR #10758 created this instance by giving the dataset scope a
-   * route onto the ObjectQL door at all; #10759 is not it, because the two doors
-   * AGREE here — neither call site's member view contains the dataset scope, so
-   * there is no preview/execution divergence to restore.
-   *
-   * Filed separately rather than widened into this PR: refusing it is a real
-   * decision (query-time refusal versus a compile-time rejection in
-   * `dataset-compiler.ts`, which is the contract-first placement), and it is not
-   * the invariant this file restores. The expectation below is written to the
-   * behaviour as it IS, so the day that decision lands this pin goes red and
-   * points at the paragraph explaining why.
-   */
-  it('a CROSS-OBJECT definition-level filter is still accepted by both doors (filed separately)', async () => {
-    const { execute, generateSql, calls } = await bothDoors('xobj_scoped_sales', {
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// ⑤ [#10861] the CROSS-OBJECT dataset scope — the second producer
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * THE REFUSAL IS INTENDED. This block replaces the as-is pin #10759 left here.
+ *
+ * What that pin recorded, and what it was for: a dataset whose DEFINITION-LEVEL
+ * `filter` is itself cross-object was accepted by BOTH doors, and
+ * `engine.aggregate` received `{"$and":[{"account.region":"West"}]}` — a
+ * predicate it cannot join, so it matches nothing on any driver that evaluates
+ * it honestly and the widget answers neither the scoped number nor the unscoped
+ * one. #10759 was not that card: the two doors AGREED in accepting it, so there
+ * was no preview/execution divergence to restore. It was written to the
+ * behaviour as it WAS, so that the day the decision landed it would go red and
+ * point at its own explanation. It did exactly that; this is the rewrite it
+ * asked for.
+ *
+ * The decision (maintainer, 2026-08-22 decision-inbox digest, accepted verbatim
+ * 「接受所有」): **Option A — refuse at query time.** The dataset scope's
+ * leaves are folded into the one member view `planCrossObject` judges, so both
+ * doors refuse at the moment the engine would otherwise be misled. Compile-time
+ * rejection in `dataset-compiler.ts` (Option B) was NOT taken — the compiler
+ * cannot see which driver will serve the dataset, and this same definition is
+ * legal on a native-SQL deployment — and serving the shape (Option C) is
+ * deferred until a real customer dataset is found to depend on it.
+ *
+ * Measured on the merged tree, one fixture, both doors in one run:
+ *
+ * ```
+ * BEFORE   execute()     ACCEPTED  -> engine.aggregate got
+ *                                     {"$and":[{"account.region":"West"}]}
+ *          generateSql() ACCEPTED
+ * AFTER    execute()     REFUSED   INVALID_FIELD / 400, member "account.region"
+ *          generateSql() REFUSED   same
+ *          engine.aggregate        never reached (0 calls)
+ * ```
+ *
+ * ## Why the still-served neighbour below is load-bearing
+ *
+ * "Refuse the dataset scope" has a trivially green wrong implementation:
+ * refuse EVERY dataset scope. It would pass a refusal-only suite and break
+ * every scoped dataset shipping today. The ordinary-scope case is therefore
+ * pinned one character away from the refused one, reaching the engine and
+ * CARRYING its predicate — dropping the scope silently widens the answer just
+ * as badly as refusing it wrongly narrows the product.
+ */
+describe('[#10861] a CROSS-OBJECT definition-level filter is refused on BOTH doors', () => {
+  it('execute() refuses with the ADR-0112 envelope, before the engine is asked', async () => {
+    const { execute, calls } = await bothDoors('xobj_scoped_sales', {
       dimensions: ['stage'], measures: ['revenue'],
     }, [XOBJ_SCOPED_SALES]);
-    expect(execute).toBeUndefined();
-    expect(generateSql).toBeUndefined();
-    expect(JSON.stringify(calls[0]?.filter)).toContain('account.region');
+
+    expect(execute, 'accepted — the dataset scope was invisible to the envelope check')
+      .toBeInstanceOf(Error);
+    // Read exactly as `rest-server.ts`'s catch reads them: a 4xx status AND a
+    // code, or the route falls through to 500 ANALYTICS_QUERY_FAILED. Asserting
+    // only that it throws would pass on a bare `Error` and report the platform
+    // broken for what is a dataset-authoring mistake on this deployment.
+    expect(execute?.code, 'no `code` ⇒ 500 ANALYTICS_QUERY_FAILED').toBe('INVALID_FIELD');
+    expect(execute?.status, 'no `status` ⇒ 500 ANALYTICS_QUERY_FAILED').toBe(400);
+    // The member as the DATASET spelled it, and the dataset named as the
+    // document to go and edit.
+    expect(execute?.member).toBe('account.region');
+    expect(execute?.cube).toBe('xobj_scoped_sales');
+    expect(String(execute?.message)).toMatch(DATASET_SCOPE_MESSAGE);
+    // `param` is ABSENT on purpose, and this assertion is the pin on that
+    // choice rather than an omission nobody noticed. `AnalyticsRequestKey` is
+    // the analytics REQUEST vocabulary; `AnalyticsQuerySchema` is strict and has
+    // no `filter` key, and this request carries no `where` at all. Both
+    // `param: 'where'` and a widened `param: 'filter'` would send the caller to
+    // a key that does not exist on what they sent. `cube` is the locator that
+    // does.
+    expect(execute?.param, '`param` must not name a key the request has no room for')
+      .toBeUndefined();
+    // Refused BEFORE the engine was asked, not after it mis-bucketed. This is
+    // the assertion the whole card is about: the BEFORE run reached it once,
+    // carrying `{"$and":[{"account.region":"West"}]}`.
+    expect(calls, 'engine.aggregate was reached — it cannot join').toEqual([]);
+  });
+
+  it('both doors agree', async () => {
+    const { execute, generateSql } = await bothDoors('xobj_scoped_sales', {
+      dimensions: ['stage'], measures: ['revenue'],
+    }, [XOBJ_SCOPED_SALES]);
+    // One fact about one query, not two independent expectations — the same
+    // shape ① uses. Two expectations that happen to coincide do not pin an
+    // invariant BETWEEN two call sites; this does.
+    expect(
+      [execute === undefined, generateSql === undefined],
+      'the preview and the execution door accept/reject the same set',
+    ).toEqual([false, false]);
+    expect(generateSql?.code).toBe('INVALID_FIELD');
+    expect(generateSql?.status).toBe(400);
+    expect(String(generateSql?.message)).toMatch(DATASET_SCOPE_MESSAGE);
+  });
+
+  it('the still-served neighbour: an ORDINARY dataset scope still reaches the engine carrying its predicate', async () => {
+    // LOAD-BEARING. An implementation that refused every dataset scope would go
+    // green on the two tests above and break every scoped dataset shipping
+    // today. `is_deleted: false` is one character away from `account.region`
+    // in the fixture and travels the identical `$and` conjunct route.
+    const { execute, generateSql, calls } = await bothDoors('scoped_sales', {
+      dimensions: ['stage'], measures: ['revenue'],
+    }, [SCOPED_SALES]);
+    expect(
+      [execute === undefined, generateSql === undefined],
+      'both doors must still SERVE an ordinary dataset scope',
+    ).toEqual([true, true]);
+    expect(calls, 'the engine was not reached at all — the scope was refused, not served')
+      .toHaveLength(1);
+    expect(
+      JSON.stringify(calls[0]?.filter),
+      'reached the engine with the scope DROPPED — silently wider, not refused',
+    ).toContain('is_deleted');
+  });
+
+  it('a base-object leaf beside a cross-object one in the SAME dataset scope is still refused', async () => {
+    // The counter-shape for the test above: refusing is not a property of the
+    // scope having more than one leaf, and serving is not a property of it
+    // having a base leaf anywhere in it. The cross-object leaf decides.
+    const { execute, generateSql, calls } = await bothDoors('mixed_scoped_sales', {
+      dimensions: ['stage'], measures: ['revenue'],
+    }, [MIXED_SCOPED_SALES]);
+    expect([execute === undefined, generateSql === undefined]).toEqual([false, false]);
+    expect(execute?.member).toBe('account.region');
+    expect(calls).toEqual([]);
+  });
+
+  it('the KNOWN-PRESENT control: a cross-object member in the CALLER\u2019s where keeps its own diagnostic', async () => {
+    // The counter-check for every "refused" above, and the pin that #10861 did
+    // not repaint the refusal #10759 restored. This shape was refused before
+    // this card and is refused after it, with the OTHER message and with
+    // `param: 'where'` — which is exactly what makes the absent `param` above a
+    // deliberate distinction rather than a field this file forgot to set.
+    const { execute, generateSql } = await bothDoors('sales_by_account', {
+      dimensions: ['stage'], measures: ['revenue'], where: { 'account.region': 'West' },
+    }, [SALES_BY_ACCOUNT]);
+    expect(String(execute?.message)).toMatch(CROSS_OBJECT_MESSAGE);
+    expect(String(generateSql?.message)).toMatch(CROSS_OBJECT_MESSAGE);
+    expect(execute?.param).toBe('where');
   });
 });

--- a/packages/services/service-analytics/src/strategies/objectql-strategy.ts
+++ b/packages/services/service-analytics/src/strategies/objectql-strategy.ts
@@ -28,6 +28,16 @@ import {
   type RecombinableMethod,
 } from './cross-object-rebucket.js';
 
+/**
+ * [#10861] Where a member in the cross-object envelope's inventory came from.
+ *
+ * Two producers put predicates in front of `engine.aggregate` on this path: the
+ * caller's own `where`, and — since PR #10758 — the compiled dataset's
+ * definition-level `filter`. Both are judged by the same envelope check; only
+ * the DIAGNOSTIC differs, because only one of them names a key the caller sent.
+ */
+type FilterMemberOrigin = 'where' | 'dataset-filter';
+
 /** Scalar analytics operators → their SQL spelling (display SQL only). */
 const SCALAR_SQL_OPS: Record<string, string> = {
   equals: '=', notEquals: '!=', gt: '>', gte: '>=', lt: '<', lte: '<=',
@@ -207,7 +217,7 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // differently for one query. `/analytics/query` reached `engine.aggregate`
     // with a predicate the engine cannot join and silently mis-bucketed it,
     // which is the exact outcome #3654's loud refusal exists to prevent.
-    const plan = this.planCrossObject(cube, query, this.filterMemberView(cube, query));
+    const plan = this.planCrossObject(cube, query, this.filterMemberView(cube, query, ctx));
     if (plan) {
       return this.executeCrossObject(cube, query, aggregations, filter, plan, ctx);
     }
@@ -359,7 +369,7 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // rather than two copies: "the preview accepts/rejects the same set" is an
     // invariant between two call sites, and two copies of a view can drift
     // apart while each stays individually correct — which is how they drifted.
-    const plan = this.planCrossObject(cube, query, this.filterMemberView(cube, query));
+    const plan = this.planCrossObject(cube, query, this.filterMemberView(cube, query, ctx));
     const crossByDim = new Map((plan?.crossDims ?? []).map((cd) => [cd.outputName, cd]));
     const joinClauses: string[] = [];
     const dimExpr = (dim: string): string => {
@@ -548,8 +558,9 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
 
   /**
    * The member view {@link planCrossObject} judges a filter by: EVERY member
-   * the query's `where` touches, structure discarded, keyed by RESOLVED field
-   * name (#10759).
+   * that will end up in the engine's predicate, structure discarded, keyed by
+   * RESOLVED field name (#10759), valued by WHERE THE MEMBER CAME FROM
+   * (#10861).
    *
    * Both call sites — `execute()` and `generateSql()` — are handed this and
    * nothing else, which is what makes the invariant `planCrossObject` states
@@ -562,10 +573,33 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
    * the members inside were unreadable from the outside and the envelope check
    * could not reject what it could not see.
    *
-   * `true` is a placeholder operand and never reaches a driver: `planCrossObject`
-   * reads `Object.keys` only. Structure is discarded on purpose — a member is
-   * cross-object or it is not, and which branch of a disjunction it sits in
-   * cannot make `engine.aggregate` able to join it.
+   * ## Two producers, one inventory (#10861)
+   *
+   * The caller's `where` is not the only thing that reaches `engine.aggregate`
+   * as a predicate. Since PR #10758 the compiled dataset's own definition-level
+   * `filter` is lowered onto `execute()`'s `conjuncts` and rendered by
+   * `generateSql()`, so a dataset declaring `filter: { 'account.region': 'West' }`
+   * sent `{"$and":[{"account.region":"West"}]}` to an engine that cannot join —
+   * measured on both doors, which AGREED in accepting it, so #10759's
+   * preview/execution symmetry had nothing to restore. Refusing it is a
+   * widening of the refusal set, ruled by the maintainer on 2026-08-22 (Option
+   * A, query-time refusal): fold the scope's leaves in HERE, where driver
+   * capability is known, rather than in `dataset-compiler.ts`, which cannot see
+   * which driver will serve the dataset and would refuse a dataset that is
+   * perfectly legal on a native-SQL deployment.
+   *
+   * Structure is discarded on purpose — a member is cross-object or it is not,
+   * and which branch of a disjunction it sits in cannot make
+   * `engine.aggregate` able to join it. PROVENANCE is not discarded, because it
+   * decides what the refusal can tell the caller to go fix: `AnalyticsRequestKey`
+   * is the analytics REQUEST vocabulary and a dataset's `filter` is not in it,
+   * so a scope-borne member must not be reported as `param: 'where'` — see
+   * `planCrossObject`. The value slot carries that and nothing else; it never
+   * reaches a driver.
+   *
+   * Dataset leaves are inserted FIRST so a member named by BOTH producers keeps
+   * the caller's provenance (last write wins on a duplicate key): if it is in
+   * the request too, the request is the actionable place to fix it.
    *
    * Time-dimension WINDOWS are deliberately absent (they live in
    * `dateRangeBounds`, not in `where`). They need no arm here: a cross-object
@@ -574,11 +608,24 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
    * rather than as the lowered predicate it becomes — which is the better
    * diagnostic and the reason that loop runs first.
    */
-  private filterMemberView(cube: Cube, query: AnalyticsQuery): Record<string, unknown> {
-    return Object.fromEntries(
-      collectFilterLeaves(normalizeAnalyticsFilterTree(query))
-        .map((f) => [this.resolveFieldName(cube, f.member, 'any'), true]),
-    );
+  private filterMemberView(
+    cube: Cube,
+    query: AnalyticsQuery,
+    ctx: StrategyContext,
+  ): Record<string, FilterMemberOrigin> {
+    // Read from the SAME channel both doors lower the scope from, so the view
+    // and the predicate cannot disagree about what the engine will receive.
+    const datasetFilter = (ctx as DatasetScopedStrategyContext).getDatasetScope?.(query.cube!)?.filter;
+    const leaves = (node: ReturnType<typeof normalizeAnalyticsFilterTree>, origin: FilterMemberOrigin) =>
+      collectFilterLeaves(node).map(
+        (f) => [this.resolveFieldName(cube, f.member, 'any'), origin] as const,
+      );
+    return Object.fromEntries([
+      ...(datasetFilter
+        ? leaves(normalizeAnalyticsFilterTree({ where: datasetFilter }), 'dataset-filter')
+        : []),
+      ...leaves(normalizeAnalyticsFilterTree(query), 'where'),
+    ]);
   }
 
   /**
@@ -591,7 +638,9 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
    * query (direct path), a plan for an in-envelope cross-object query.
    *
    * THROWS for anything outside the envelope — a cross-object MEASURE or FILTER
-   * (needs a real join to evaluate), a MULTI-HOP dimension (`a.b.c`), or a
+   * (needs a real join to evaluate), a cross-object leaf in the DATASET's own
+   * definition-level `filter` (#10861 — same join it does not have, arriving
+   * from the producer PR #10758 added), a MULTI-HOP dimension (`a.b.c`), or a
    * non-recombinable measure (`avg`/`count_distinct`, whose sub-bucket values
    * cannot be merged). A loud error beats the silent mis-bucket #3654 kills.
    * `generateSql()` calls this too, so the preview accepts/rejects the same set
@@ -599,16 +648,26 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
    * {@link filterMemberView}, so that sentence is enforced by construction
    * instead of restated at two call sites.
    *
-   * [#5716] All four refusals below are `invalidMemberError` — `INVALID_FIELD` /
-   * 400, naming the member — and the MESSAGES are unchanged (they are good
-   * diagnostics, and #5923's tests read them). Each is decided by two caller-side
-   * facts and nothing else: a member the query named, and whether that member
-   * resolves across a join. Neither is an internal invariant — a cube where the
-   * member exists and a driver that could serve it are both perfectly ordinary,
-   * which is exactly what the "run this on a native-SQL driver" half of each
-   * message says. They are member-level rather than dataset-level (hence not
-   * `datasetInvalidError`) because the fix is always to change or drop ONE named
-   * member, and because they fire on `/analytics/query` where no dataset exists.
+   * [#5716] All five refusals below are `invalidMemberError` — `INVALID_FIELD` /
+   * 400, naming the member — and the four that predate #10861 keep their
+   * MESSAGES unchanged (they are good diagnostics, and #5923's tests read
+   * them). Each is decided by two facts and nothing else: a member that will
+   * reach the engine's predicate, and whether that member resolves across a
+   * join. Neither is an internal invariant — a cube where the member exists and
+   * a driver that could serve it are both perfectly ordinary, which is exactly
+   * what the "run this on a native-SQL driver" half of every message says. They
+   * are member-level rather than dataset-level (hence not `datasetInvalidError`)
+   * because the fix is always to change or drop ONE named member, and because
+   * four of them fire on `/analytics/query` where no dataset exists.
+   *
+   * [#10861] The fifth is the exception that proves the rule and is written to
+   * it: it can only fire where a dataset DOES exist, and it is the one refusal
+   * here whose member no request key named — so it carries `cube` and no
+   * `param`, and says in its own words which document to go and edit. It stays
+   * `INVALID_FIELD` rather than becoming `DATASET_INVALID` because the verdict
+   * is the same physical one as its neighbour — this engine cannot join this
+   * member — and splitting the code by PROVENANCE would make a caller branch on
+   * two wire shapes for one capability limit.
    *
    * Detection is on RESOLVED field names, so a dotted dimension the cube
    * flattens to a real column is treated as base, not cross-object.
@@ -616,7 +675,7 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
   private planCrossObject(
     cube: Cube,
     query: AnalyticsQuery,
-    filter: Record<string, unknown>,
+    filter: Record<string, FilterMemberOrigin>,
   ): CrossObjectPlan | null {
     const baseObject = this.extractObjectName(cube);
 
@@ -644,7 +703,9 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       ...(query.measures ?? []).map((m) => ({
         where: 'measure', member: m, field: this.resolveMeasureAggregation(cube, m).field,
       })),
-      ...Object.keys(filter).map((f) => ({ where: 'filter', member: f, field: f })),
+      ...Object.entries(filter)
+        .filter(([, origin]) => origin === 'where')
+        .map(([f]) => ({ where: 'filter', member: f, field: f })),
     ].filter((r) => this.isCrossObjectField(cube, r.field, baseObject));
     if (nonDim.length > 0) {
       throw invalidMemberError(
@@ -658,6 +719,42 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
           param: nonDim[0].where === 'measure' ? 'measures' : 'where',
           cube: cube.name,
         },
+      );
+    }
+
+    // [#10861] The same verdict for a member the CALLER never named: a leaf of
+    // the compiled dataset's own definition-level `filter`. Checked after the
+    // caller's own members, so a request that names a cross-object member keeps
+    // the diagnostic it can act on directly, and so every shape that was
+    // refused before this card is refused with the identical message.
+    //
+    // Same family and same envelope as the arm above — `INVALID_FIELD` / 400 —
+    // because it is the same physical verdict about the same member: this
+    // engine has no join. A caller should not have to branch on two codes for
+    // one capability limit.
+    //
+    // `param` is deliberately ABSENT rather than `'where'`. `AnalyticsRequestKey`
+    // is the analytics REQUEST vocabulary, and `AnalyticsQuerySchema` is strict:
+    // there is no `filter` key on a query (its `guidance` sends `filters` to
+    // `where`), and the request's `where` may be empty or absent entirely. Both
+    // `param: 'where'` and a widened `param: 'filter'` would name a key the
+    // caller cannot go and edit — the exact "never suggest a key the schema
+    // cannot accept" trap `strict-object.ts` documents. `cube` carries the
+    // locator that IS actionable: the dataset whose definition holds the leaf.
+    const scopeCross = Object.entries(filter)
+      .filter(([field, origin]) =>
+        origin === 'dataset-filter' && this.isCrossObjectField(cube, field, baseObject))
+      .map(([field]) => field);
+    if (scopeCross.length > 0) {
+      throw invalidMemberError(
+        `[Analytics] ObjectQLStrategy cannot evaluate the cross-object filter ` +
+        `("${scopeCross[0]}") that dataset "${cube.name}" declares at its definition ` +
+        `level — the engine cannot join in an aggregate, so this predicate matches ` +
+        `nothing and the answer would be neither the scoped number nor the unscoped ` +
+        `one. Nothing in the request names it: remove the cross-object leaf from the ` +
+        `dataset's own \`filter\`, or serve this dataset on a native-SQL driver, ` +
+        `where the same definition is valid.`,
+        { member: scopeCross[0], cube: cube.name },
       );
     }
 


### PR DESCRIPTION
Fixes #10861

Parent card: #10413 — its phase-2 per-measure filter work is untouched here and stays where it is.

## What was wrong

PR #10758 (#10413 phase 1) gave a compiled dataset's **definition-level `filter`** a route onto the ObjectQL door for the first time. That route was outside the member view `ObjectQLStrategy.planCrossObject` judges — `execute()` lowers the scope onto `conjuncts` *after* the view is built, and `generateSql()` renders it from a separate `getDatasetScope(...)?.filter` read — so nothing ever saw it.

Reproduced on the merged tree (`072d072d2`, i.e. after PR #10862 landed), one fixture, both doors in one run. This is byte-for-byte the measurement the card recorded at `5f2e54cc6`, so the defect survived every move of the tree in between:

```
dataset: object 'opportunity', include: ['account'],
         filter: { 'account.region': 'West' }
capabilities: { nativeSql: false, objectqlAggregate: true, inMemory: false }

BEFORE  execute()      ACCEPTED
        generateSql()  ACCEPTED
        engine.aggregate calls: 1  filter: {"$and":[{"account.region":"West"}]}
```

`engine.aggregate` cannot join. `account.region` is not a column of `opportunity`, so on any driver that evaluates the predicate honestly it matches nothing, and the widget answered a number that was neither the scoped number nor the unscoped one — with no error anywhere. That is the silent mis-bucket #3654's loud refusal exists to prevent, arriving through a producer #3654 predates.

#10759 was not this card: both doors **agreed** in accepting it, so there was no preview/execution divergence to restore.

## What changed

Maintainer ruling, 2026-08-22 decision-inbox digest (46 cards, accepted verbatim 「接受所有」): **Option A — refuse at query time.**

`filterMemberView` now folds the dataset scope's leaves into the one member view both doors are judged on, so the refusal fires where driver capability is known. Compile-time rejection in `dataset-compiler.ts` (B) was not taken — the compiler cannot see which driver will serve the dataset, and the same definition is legal on a native-SQL deployment. Serving the shape (C) is deferred; no customer dataset depending on it was found in the course of this work.

```
AFTER   execute()      REFUSED  code=INVALID_FIELD status=400 member=account.region
        generateSql()  REFUSED  code=INVALID_FIELD status=400 member=account.region
        engine.aggregate calls: 0
```

The member view is re-derived on the merged tree rather than taken from the card's description of it (triage's note: whichever lands second re-checks the shape). As #10862 left it, it was `collectFilterLeaves(normalizeAnalyticsFilterTree(query))` keyed by `resolveFieldName(..., 'any')` and valued `true`. It is now keyed the same way and **valued by provenance** (`'where' | 'dataset-filter'`) — the value slot was already documented as a placeholder `planCrossObject` never read, and provenance is the only thing the refusal needs it for. Dataset leaves are inserted first so a member named by both producers keeps the caller's provenance, which is the actionable one.

## One deliberate envelope choice, flagged for contract review

The new refusal carries `code: INVALID_FIELD`, `status: 400`, `member`, `cube` — and **no `param`**. That is a decision, not an omission, and it is pinned as such:

- `AnalyticsRequestKey` is documented as *"which **request** key named the member"*. No request key named this one.
- `AnalyticsQuerySchema` is `strictObject` and has **no `filter` key** (its own `guidance` sends `filters` → `where`), so a widened `param: 'filter'` would name a key the schema rejects — the "never suggest a key the schema cannot accept" trap `strict-object.ts` documents.
- `param: 'where'` would send the caller to a `where` this request does not even carry.

`cube` is the locator that *is* actionable, and the message names the dataset and says the same definition is valid on a native-SQL deployment. It stays `INVALID_FIELD` rather than becoming `DATASET_INVALID` because it is the same physical verdict as its neighbour — this engine cannot join this member — and splitting the code by provenance would make a caller branch on two wire shapes for one capability limit. The four refusals that predate this card keep their messages byte-identical (#5923's tests read them); this one is a fifth, separately worded.

## The as-is pin

`crossobject-conjunct-refusal.test.ts`'s last test was written to the behaviour as it *was*, deliberately, so it would go red the day the decision landed. It did. It is **flipped, not deleted**, and the explanatory paragraph above it is rewritten so the next reader sees the refusal is intended rather than a leftover explanation of a defect that no longer exists. The file header's "FOUR directions" section is rewritten to six.

## Six pinned directions

| | direction |
|---|---|
| ①–④ | #10759's: nested cross-object member refused on both doors; clean combinators still served carrying their disjunction; `generateSql()` unchanged; the ordinary dataset conjunct not misread. **Re-run unchanged — 15 of the 18 tests, all green.** |
| ⑤ | a cross-object dataset-level `filter` is refused on **both** doors, with `code` **and** `status`, the member, the `cube`, the absent `param`, and `engine.aggregate` **never reached** |
| ⑥ | **load-bearing:** an *ordinary* dataset scope (`is_deleted: false`) still passes both doors and still reaches the engine **carrying its predicate** |

Two-door agreement is asserted **as agreement** over one query — `[execute === undefined, generateSql === undefined]` compared to `[false, false]` — not as two independent expectations, which is the shape #10862 used. A mixed scope (one base leaf + one cross-object leaf) is pinned refused, and the caller's-`where` case is kept as the known-present control that still carries `param: 'where'`.

## Proof

**Ablation, signature predicted in writing before mutating.** Mutation: drop the dataset-scope arm from `filterMemberView`, leaving the new refusal arm starved of input. Predicted `3 failed | 15 passed (18)`, naming the three tests and their first-failure assertions, with ⑥ and the known-present control staying **green** (that asymmetry is the point). Observed: exactly that — `expected undefined to be an instance of Error`, then `expected [true,true] to deeply equal [false,false]` twice. Restore proved byte-identical (`git hash-object` `dd7d329f…` both sides) **and re-run to a real verdict**: `18 passed (18)`.

**`src/` vs `dist/`, argued from the files and then measured.** The test imports `'../analytics-service.js'`, which imports `'./strategies/objectql-strategy.js'` — both relative, so the package `exports` map is never consulted for the subject. Re-verified rather than inherited from #10862's seat, in the stronger form: with a **built, correct `dist/index.js` present**, a `src`-only mutation flipped the verdict `18 passed` → `3 failed`, while `dist/index.js` stayed byte-identical (`md5 2ed2099a…` both sides) and never contained the mutation marker.

**Zero-hit counter-check, positive control first.** `filterMemberView(cube, query` → **2** hits, both the 3-arg form (the two doors: the pattern demonstrably matches). `filterMemberView(cube, query)` (the 2-arg form) → **0**. All four `conjuncts.push` sites were then *read*, not counted: two are the caller's `where` via `applyFilterNode`, one is the dataset scope (now in the view), one is the time-dimension window (refused by `planCrossObject`'s own `timeDimensions` loop, which runs first). The platform read scope is applied after the plan and is base-object by construction.

## Gates — derived on the final commit `d24441362`, clean tree

`node scripts/pm/dispatch-gates.mjs` with **no path arguments** (3 committed paths, 0 working tree, 0 untracked, three-dot vs merge base `072d072d2`). It named 11 path-derived families plus 5 convention-triggered ones. Re-derived after the amend; the list was identical. Exit codes captured before any pipe.

| gate | verdict |
|---|---|
| `check:changeset-gate-self-tests` | ✓ 118 + 212 assertions over real temp git repos |
| `check:objectui-changeset` | ✓ releasing list derived from changesets |
| `check:slot-lookup` | ✓ ratchet holds: 107 unswept sites, none new |
| `check:test-source-alias` | ✓ 72 packages scanned; 45 published subpaths resolved |
| `check:type-source-resolution` | ✓ 77 packages with a tsconfig scanned |
| `check-adr-0087-registration` | ✓ 1 declared-breaking changeset, carrying a disposition |
| `check-changeset-no-major` | ✓ no `major` bump |
| `check-ci-filter-parity` | ✓ all 83 declared cross-package globs covered |
| `check-empty-changeset` | ✓ no empty-frontmatter changeset |
| `check-plugin-teardown-shape` | ✓ 63 Plugin implementations, baseline fully burned down |
| `check-affected-docs` | ✓ self-test 339 cases pass |
| `check:query-options-erasure` | ✓ ratchet holds: 67 unswept sites, none new |
| `check:type-check-coverage` | ✓ self-test 47+59+29+28+19 cases hold |
| `check:type-check-debt` | ✓ **33 ledger entries re-measured in 248.9s, 1908 raw errors, none above its recorded number** |
| `check:engine-double-contract` | ✓ 377 pinned, 133 in DEBT, 2 exempt |
| `check:where-matcher` | ✓ 277 matchers, all conform |
| `check-nul-bytes` | ✓ 6394 files, no raw ASCII control bytes |

`check:type-check-debt` first **refused** (`--re-measure cannot run: 47 workspace dependencies … no built type entry point`). A refusal is NOT MEASURED, so the closure was built exactly as `lint.yml` does (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful) and it was re-run to the real verdict above. `check-adr-0087-registration` was genuinely **red** first — this changeset declares BREAKING and carried no disposition marker — and is green on the argued `not-required (no-migration-prescription)` line now in the changeset.

**Tests.** `@objectstack/service-analytics`: `80 files / 1766 tests passed`. Consumer door: `@objectstack/rest`'s 7 analytics suites, `85 tests passed`, run against a freshly built `dist` that demonstrably carried the new message.

## Breaking-vs-not, argued in the open

Called **breaking** in the changeset and `minor` in the bump. A query that returns `200` with rows today starts answering `400`, and it does so because of a *saved dataset* rather than anything in the request — a dashboard that renders today can start showing an error. That is the strongest reading of breaking and it is why it is stated rather than filed quietly. What is not lost is any correct answer: the rows that stop being served were already wrong, and wrong in the way that hides itself. An **ordinary** dataset scope is unaffected and pinned so.

## Posture

Stays **draft**. `needs:contract-review` is hung on #10861 and this seat does not clear it, mark ready, arm auto-merge, or merge. The absent-`param` choice above is the specific thing worth a reviewer's eye.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_