### PR TITLE
refactor(plugin-sharing): collapse the two byte-identical MinimalLogger shapes

### DIFF
--- a/.changeset/sharing-logger-shape-dedup.md
+++ b/.changeset/sharing-logger-shape-dedup.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/plugin-sharing": patch
+---
+
+Collapse the two byte-identical `MinimalLogger` declarations in `plugin-sharing`
+onto one shared `OptionalSharingLogger` (#10692). Internal types only — none of
+the seven local `MinimalLogger` interfaces was exported, so no published surface
+and no runtime behaviour changes.
+
+`plugin-sharing/src` declared **seven** module-local interfaces all named
+`MinimalLogger`. The duplication was not the defect; divergence under one name
+was. When #10556 made `bulk-recompute.ts`'s `warn` non-optional, `tsc` reported
+the forwarding modules as:
+
+```
+Type 'MinimalLogger' is not assignable to type 'MinimalLogger'.
+  Two different types with this name exist, but they are unrelated.
+```
+
+`bu-tree-recompute.ts` and `primary-bu-projection.ts` were byte-identical, so
+they now share one declaration in `logger-shapes.ts`. The new type is
+deliberately given a DIFFERENT name: the next forwarding edge added between it
+and a module that still declares its own `MinimalLogger` produces a diagnostic
+naming two different types, instead of the same name twice.
+
+The other five declarations are left alone, each for a stated reason recorded in
+`logger-shapes.ts`. Three are genuinely different contracts (`bulk-recompute.ts`
+is the guaranteed sink; `rule-hooks.ts` and `record-share-cascade.ts` require
+`warn` because they forward into it). Two are *not* the cheap unification the
+card assumed:
+
+- `sharing-rule-provenance.ts` is `{ info?, warn? }` by optionality but carries a
+  stricter member signature, `(msg: string, meta?: Record<string, any>)`.
+  Folding it onto the `(msg: any, ...rest: any[])` spelling would delete real
+  checking; folding the others onto its spelling would tighten two modules.
+- `record-orphan-cleanup.ts`'s bare `Function` members **cannot** be tightened
+  here: `Function` is not assignable to any concrete signature ("Type 'Function'
+  provides no match for the signature"), and the two loggers handed to it —
+  `SharingServiceOptions['logger']` and `ShareLinkServiceOptions['logger']` —
+  are themselves spelled with bare `Function`.
+
+`check:optional-error-sink` (#9754) membership is unchanged and was verified
+before and after: 37 sinks declare `error`, 2 permit silence, 2 baselined. The
+shared shape declares no `error` and must not grow one — that would enrol every
+module using it into that gate's population, which is a contract decision for
+the #10556 family rather than a side effect of de-duplication.

--- a/packages/plugins/plugin-sharing/src/bu-tree-recompute.ts
+++ b/packages/plugins/plugin-sharing/src/bu-tree-recompute.ts
@@ -91,6 +91,7 @@
 
 import type { SharingRuleRow, SharingRuleRecipientType } from '@objectstack/spec/contracts';
 import { ruleRegrantQueue } from './rule-hooks.js';
+import type { OptionalSharingLogger } from './logger-shapes.js';
 
 const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
 
@@ -149,11 +150,6 @@ interface MinimalEngine {
     options?: { object?: string | string[]; priority?: number; packageId?: string },
   ): void;
   unregisterHooksByPackage(packageId: string): number;
-}
-
-interface MinimalLogger {
-  info?: (msg: any, ...rest: any[]) => void;
-  warn?: (msg: any, ...rest: any[]) => void;
 }
 
 /** The slice of {@link SharingRuleService} this module drives. */
@@ -220,7 +216,7 @@ export function writeCanChangeExpansion(objectName: string, event: string, hookC
 export function bindBusinessUnitTreeRecompute(
   engine: MinimalEngine,
   service: BuTreeRecomputeRuleService,
-  logger?: MinimalLogger,
+  logger?: OptionalSharingLogger,
 ): void {
   if (typeof engine.registerHook !== 'function') return;
   if (typeof engine.unregisterHooksByPackage === 'function') {

--- a/packages/plugins/plugin-sharing/src/logger-shapes.ts
+++ b/packages/plugins/plugin-sharing/src/logger-shapes.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The one `{ info?, warn? }` logger shape this package's fire-and-forget
+ * projection modules share (#10692).
+ *
+ * ## Why this file exists
+ *
+ * `plugin-sharing` declared SEVEN module-local interfaces all named
+ * `MinimalLogger`. Duplication was not the defect; DIVERGENCE under one name
+ * was. When #10556 made `bulk-recompute.ts`'s `warn` non-optional, `tsc`
+ * reported the two modules that forward into it with the unreadable form:
+ *
+ *     Type 'MinimalLogger' is not assignable to type 'MinimalLogger'.
+ *       Two different types with this name exist, but they are unrelated.
+ *
+ * A shared declaration removes that seam for the modules that can share one,
+ * and the DISTINCT NAME is deliberate: when a future forwarding edge is added
+ * between this shape and a module that still declares its own, the diagnostic
+ * names two different types instead of the same one twice.
+ *
+ * ## ⛔ Why this shape declares no `error`, and must not grow one
+ *
+ * `check:optional-error-sink` (#9754) draws its population STRUCTURALLY: a sink
+ * is in scope only if it DECLARES an `error` member. A shape with no `error` is
+ * out of the population — there is no optional fallback for the rule to
+ * guarantee. Adding `error?` here would enrol every module that uses this type
+ * into that gate's scope at once, and that ledger is being paid DOWN
+ * deliberately (#10556: 15 → 3 → 2, shrink-only). Enlarging it is a contract
+ * decision for the #10556 family, never a side effect of de-duplication.
+ *
+ * ## ⛔ Why the other four modules do NOT use this type
+ *
+ * They are not the same contract, and collapsing them would change meaning:
+ *
+ * - `bulk-recompute.ts` — `{ info?, warn, error? }`. It IS the guaranteed sink;
+ *   its `warn` is required and it declares `error?`, so it is in the gate's
+ *   population by design.
+ * - `rule-hooks.ts`, `record-share-cascade.ts` — `{ info?, warn }`. Their `warn`
+ *   is required because they FORWARD into `bulk-recompute.ts`'s guaranteed sink;
+ *   a `warn?` there re-opens the silence one module downstream of where #10556
+ *   closed it.
+ * - `record-orphan-cleanup.ts` — `{ info?: Function, warn?: Function }`. Bare
+ *   `Function` documents nothing, but it cannot be tightened to this shape:
+ *   `Function` is NOT assignable to a concrete signature ("Type 'Function'
+ *   provides no match for the signature"), and the two loggers handed to it —
+ *   `SharingServiceOptions['logger']` and `ShareLinkServiceOptions['logger']` —
+ *   are themselves spelled with bare `Function`. Tightening it requires
+ *   tightening those producers first, which is a gate-population change, not a
+ *   refactor. Recorded on #10692 rather than done quietly here.
+ * - `sharing-rule-provenance.ts` — `{ info?, warn? }` by OPTIONALITY but with a
+ *   stricter member signature, `(msg: string, meta?: Record<string, any>)`.
+ *   Folding it onto the `(msg: any, ...rest: any[])` spelling below would DELETE
+ *   real checking at its call sites; folding the others onto ITS spelling would
+ *   tighten two modules. Either direction changes meaning, so neither is a
+ *   de-duplication — see #10692 for the open contract question.
+ */
+export interface OptionalSharingLogger {
+  info?: (msg: any, ...rest: any[]) => void;
+  warn?: (msg: any, ...rest: any[]) => void;
+}

--- a/packages/plugins/plugin-sharing/src/primary-bu-projection.ts
+++ b/packages/plugins/plugin-sharing/src/primary-bu-projection.ts
@@ -23,6 +23,8 @@
  * membership is usable single-tenant too).
  */
 
+import type { OptionalSharingLogger } from './logger-shapes.js';
+
 const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
 
 export const PRIMARY_BU_HOOK_PACKAGE = 'plugin-sharing:primary-bu';
@@ -42,14 +44,9 @@ interface MinimalEngine {
   update(object: string, data: any, options?: any): Promise<any>;
 }
 
-interface MinimalLogger {
-  info?: (msg: any, ...rest: any[]) => void;
-  warn?: (msg: any, ...rest: any[]) => void;
-}
-
 /** Recompute one user's primary_business_unit_id from their `is_primary` member
  * row (null when they have none). Idempotent. */
-async function recompute(engine: MinimalEngine, userId: string, logger?: MinimalLogger): Promise<void> {
+async function recompute(engine: MinimalEngine, userId: string, logger?: OptionalSharingLogger): Promise<void> {
   if (!userId) return;
   let buId: string | null = null;
   try {
@@ -94,7 +91,7 @@ function collectUserIds(ctx: any): string[] {
  * projection must stay correct regardless of who mutates membership (seeds,
  * HRIS sync, admin UI).
  */
-export function bindPrimaryBuHooks(engine: MinimalEngine, logger?: MinimalLogger): void {
+export function bindPrimaryBuHooks(engine: MinimalEngine, logger?: OptionalSharingLogger): void {
   if (typeof engine.registerHook !== 'function') return;
   if (typeof engine.unregisterHooksByPackage === 'function') {
     engine.unregisterHooksByPackage(PRIMARY_BU_HOOK_PACKAGE);
@@ -131,7 +128,7 @@ export function bindPrimaryBuHooks(engine: MinimalEngine, logger?: MinimalLogger
  * `is_primary` member row, so pre-existing memberships (seeds, prior data)
  * project even though their inserts pre-dated the hooks. Idempotent.
  */
-export async function backfillPrimaryBu(engine: MinimalEngine, logger?: MinimalLogger): Promise<{ updated: number }> {
+export async function backfillPrimaryBu(engine: MinimalEngine, logger?: OptionalSharingLogger): Promise<{ updated: number }> {
   let rows: any[] = [];
   try {
     rows = await engine.find('sys_business_unit_member', {


### PR DESCRIPTION
Part of #10692

Collapses the two genuinely byte-identical `MinimalLogger` declarations in
`plugin-sharing` onto one shared internal type. Internal types only — none of the
seven local `MinimalLogger` interfaces was exported, so no published surface and no
runtime behaviour changes.

This is `Part of`, not a closing keyword, and deliberately so: the divergence the card
is about is **not** fully closed by this subset. Five declarations remain, and two of
them turn out to sit behind a contract decision that is the PM's to make, not a
refactor. The measurement is below.

## The count: it is SEVEN, not six

Derived by **enclosing declaration**, not by grep hit: every `interface MinimalLogger`
/ `type MinimalLogger =` in the package, then each one's members read off the
declaration itself.

`packages/plugins/plugin-sharing/src` declares **seven** interfaces named
`MinimalLogger`, one per file — all seven spell the same name. The card's title says
six and its body says *"Seven rows, six of which spell the same name"*; both are off by
one against the tree at `072d072d2`. Nineteen textual `MinimalLogger` hits resolve to
7 declarations + 12 type annotations.

Normalising away doc comments, there are **5 distinct structural shapes**:

| shape | files | in `check:optional-error-sink` population? |
|---|---|---|
| `{ info?, warn, error? }` — all `(msg: any, ...rest: any[]) => void` | `bulk-recompute.ts` | **yes** — it *is* the guaranteed sink |
| `{ info?, warn }` — same signatures | `rule-hooks.ts`, `record-share-cascade.ts` | no (`error` absent) |
| `{ info?, warn? }` — same signatures | `bu-tree-recompute.ts`, `primary-bu-projection.ts` | no |
| `{ info?, warn? }` — but a **string message + Record meta** signature (see below) | `sharing-rule-provenance.ts` | no |
| `{ info?: Function, warn?: Function }` | `record-orphan-cleanup.ts` | no (and invisible — see below) |

## ⚠️ The card's "three already-identical shapes" is really two

The card groups three files as `{ info?, warn? }`. That grouping normalises away the
**member signatures**, and they differ: `sharing-rule-provenance.ts` spells its members
a **string message plus a Record meta object**, while `bu-tree-recompute.ts` and
`primary-bu-projection.ts` spell theirs with an `any` message and a rest parameter:

```ts
// sharing-rule-provenance.ts — precise: catches a non-string message and a bad meta
info?: (msg: string, meta?: Record<string, any>) => void;

// bu-tree-recompute.ts / primary-bu-projection.ts — loose: catches nothing
info?: (msg: any, ...rest: any[]) => void;
```

Only the latter two are byte-identical, so only those two are unified here. Folding
`sharing-rule-provenance.ts` in would go one of two ways, and **both change meaning**,
so neither is a de-duplication:

- onto the `any` spelling → **deletes** real checking at its call sites;
- the others onto its spelling → **tightens** two modules.

## What is unified

`bu-tree-recompute.ts` and `primary-bu-projection.ts` now share
`OptionalSharingLogger` in the new `src/logger-shapes.ts`.

The shared type is given a **different name** on purpose. The card's complaint is the
diagnostic `Two different types with this name exist, but they are unrelated.` A future
forwarding edge between this shape and a module still declaring its own `MinimalLogger`
now names two different types instead of the same name twice. (`OptionalLogger` was
not reused — `plugin-webhooks/src/auto-enqueuer.ts` already declares a *different* type
under that name, which is the same hazard.)

## ⛔ `record-orphan-cleanup.ts` was left alone — it is blocked, not skipped

The card asks for its bare `Function` members to be replaced with real signatures.
**That is not possible without a contract decision**, and the reason is measured, not
argued:

```
Type 'Function' is not assignable to type '(msg: any, ...rest: any[]) => void'.
  Type 'Function' provides no match for the signature '(msg: any, ...rest: any[]): void'.
```

`Function` is assignable to no concrete signature. The two loggers actually handed to
`sweepOrphanedRowsByRecordExistence` are `SharingServiceOptions['logger']`
(`sharing-service.ts:1381`) and `ShareLinkServiceOptions['logger']`
(`share-link-service.ts:704`), and **both are themselves spelled with bare
`Function`** — uncast, unlike every other logger entry point in this package, which
arrives as `ctx.logger as any`. So tightening the consumer requires tightening those
two producers first.

I measured what that costs, then reverted it byte-identically:

| | population declaring `error` | permit silence (RED) | gate |
|---|---|---|---|
| today | 37 | 2 (2 baselined) | ✓ passes |
| producers tightened | **39** | **4** | ✗ **fails** |

Tightening them costs **0 compile errors** — and enrols two new RED sinks:

```
✗ 2 sink type(s) declare an optional `error` with no guaranteed fallback channel
  packages/plugins/plugin-sharing/src/share-link-service.ts:345
    sink : inline type logger@ShareLinkServiceOptions  { info? warn? error? debug? }
  packages/plugins/plugin-sharing/src/sharing-service.ts:280
    sink : inline type logger@SharingServiceOptions  { info? warn? error? debug? }
```

Both shapes are **latently red today**: they declare `error?` beside an optional `warn`,
which is exactly what #9754 forbids. They escape the gate only because bare `Function`
is not a `FunctionTypeNode`, so the gate's structural matcher never sees them. And the
gate's own prescribed repair — dropping the `?` from `warn` — lands on
`SharingServiceOptions` and `ShareLinkServiceOptions`, **both publicly exported** from
`src/index.ts`, so it is a breaking change for any host passing `{ info, error }`.

That is a contract decision for the #10556 family. Recorded on #10692 for the PM rather
than done quietly here.

## `check:optional-error-sink` — the load-bearing check, before and after

Population unchanged, quoting the gate's own verdict lines:

**Before**
```
SINK CENSUS [optional-error-sink-contract] (#9754): 37 sink type(s) declaring `error` in
packages/** — 12 declare it REQUIRED, 23 declare it optional beside a REQUIRED `warn`,
2 permit silence (2 optional-fallback, 0 no-fallback).
✓ optional-error sink contract: every sink declaring an optional `error` guarantees a
`warn` channel (2 baselined, shrink-only).
```

**After** — the two enforced numbers and the verdict line are **identical**:
```
SINK CENSUS [optional-error-sink-contract] (#9754): 37 sink type(s) declaring `error` in
packages/** — 12 declare it REQUIRED, 23 declare it optional beside a REQUIRED `warn`,
2 permit silence (2 optional-fallback, 0 no-fallback).
✓ optional-error sink contract: every sink declaring an optional `error` guarantees a
`warn` channel (2 baselined, shrink-only).
```

**One informational number did move, and it is not a membership change**: the
`narrowings:` line's tally of pure sinks declaring no `error` went `56 → 54`. I
predicted `55` and was wrong by one; the miss is explained rather than waved at. Two
declarations were removed and one added, so `-2 +1 = -1` was the prediction. The new
declaration is **not counted at all**, because the gate prefilters files by text before
parsing:

```js
if (!/\berror\s*\??\s*[:(]/.test(text)) continue;
```

`logger-shapes.ts` never spells `error` followed by `:` or `(`, so it is skipped before
the parser sees it. The two files it replaced matched that regex only because their call
sites pass `{ error: err?.message }` — a literal `error:`. Verified directly: deleting
`logger-shapes.ts` leaves the tally at 54, unchanged.

This is sound for what the gate **enforces** (a sink declaring `error` necessarily
matches the regex), but it means the advertised "cost of the narrowing" tally
undercounts. Filed separately as #11069; no behaviour here depends on it.

## Proof that `tsc` would have failed

A type change has no runtime behaviour to assert, so the compiler is the instrument —
and an instrument not shown to be live is not a measurement. Signature predicted
**before** running:

**Predicted** — mutate the shared type's `warn` to `(msg: string, code: number) => void`;
expect 6 × `TS2345` "not assignable to parameter of type 'number'", 3 in each file,
exit 2; errors in **both** files being the load-bearing part, since that is what proves
both modules really consume the single shared declaration.

**Observed** — exactly that:
```
src/bu-tree-recompute.ts(249,11): error TS2345: Argument of type '{ rule: string; error: any; }' is not assignable to parameter of type 'number'.
src/bu-tree-recompute.ts(279,13): error TS2345: Argument of type '{ rule: string; object: string; error: any; }' is not assignable to parameter of type 'number'.
src/bu-tree-recompute.ts(287,71): error TS2345: Argument of type '{ object: string; event: string; error: any; }' is not assignable to parameter of type 'number'.
src/primary-bu-projection.ts(61,57): error TS2345: Argument of type '{ userId: string; error: any; }' is not assignable to parameter of type 'number'.
src/primary-bu-projection.ts(67,59): error TS2345: Argument of type '{ userId: string; error: any; }' is not assignable to parameter of type 'number'.
src/primary-bu-projection.ts(141,57): error TS2345: Argument of type '{ error: any; }' is not assignable to parameter of type 'number'.
```
6 errors, 3 per file, exit 2 — prediction and observation agree on count, code, shape
and distribution.

**Restore** proved byte-identical by `git hash-object`
(`2533d6dad5348f3728a6db38edb0eafad3b56a61` before the mutation and after the restore),
and the restore leg re-run to a real verdict rather than trusted on the hash: `tsc`
exit 0, 0 errors, `git status --porcelain` empty.

The two call sites the card names still compile and their `warn` requirement is
unchanged — `rule-hooks.ts` and `record-share-cascade.ts` are untouched by this PR.

## Gates

Union derived on the **final commit** `5eb6636f2`, clean tree,
`node scripts/pm/dispatch-gates.mjs` with **no path arguments** (it takes the change set
from the merge base itself: 4 paths vs `072d072d2`). It named 11 families plus one
convention-triggered. It did **not** name `check:optional-error-sink` — that gate
computes its own population and scores `silent` for every card — which is exactly why
the card mandated it by hand.

All verdicts below are the gates' own printed lines; exit codes were captured before any
pipe.

| gate | verdict |
|---|---|
| `check:optional-error-sink` | `✓ optional-error sink contract … (2 baselined, shrink-only)` |
| `plugin-sharing typecheck` | exit 0, 0 errors |
| `plugin-sharing test` | `Test Files 25 passed (25)` · `Tests 624 passed (624)` |
| `check:changeset-gate-self-tests` | `✓ check-empty-changeset --self-test: 118 assertions over real temp git repos` |
| `check:objectui-changeset` | `✓ objectui-changeset-digest: 70058c167c14..a90fbe836c37 walks completely` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 77 packages with a tsconfig.json scanned` |
| `check-adr-0087-registration` | `✓ this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)` |
| `check-changeset-no-major` | `✓ This diff introduces no \`major\` bump.` |
| `check-ci-filter-parity` | `OK: all 83 declared cross-package glob(s) (72 unique) are covered` |
| `check-empty-changeset` | `✓ No empty-frontmatter changeset introduced by this diff` |
| `check-plugin-teardown-shape` | `✓ 63 Plugin implementation(s) across 4446 source(s); baseline fully burned down` |
| `check-affected-docs` | `✓ affected-docs self-test: 339 cases pass.` |
| `check:nul-bytes` | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo` |
| `check:i18n` | `check-i18n-bundles: OK (9 package(s) — all bundles in sync)` · `plugins/plugin-sharing in sync (4 bundle(s))` |

`check:i18n` first returned `PREREQUISITE NOT MET — the workspace CLI is not built …
Nothing was checked` at exit 1. That is **not measured**, never a pass, so the CLI was
built (`turbo run build --filter=@objectstack/cli`) and the gate re-run to the real
verdict quoted above.

## Open question for the PM — not decided here

What *should* this package's logger contract be? Three candidates, with cost:

1. **Leave the five as they are** (this PR). Cost: the seam stays open; the next
   forwarding edge re-opens the same diagnostic.
2. **One `{ info?, warn? }` contract with a precise signature**
   (a **string message plus a Record meta object**), absorbing `sharing-rule-provenance.ts`,
   `bu-tree-recompute.ts` and `primary-bu-projection.ts`. Cost: **0 at every caller** —
   all three receive `ctx.logger as any` or `undefined`, so no caller constrains them —
   and it *gains* arity/type checking at ~12 in-module call sites, which is precisely
   what the card says bare `Function` fails to provide. This is my recommendation for
   the `{ info?, warn? }` family, but it tightens two modules, so it is a contract call,
   not a refactor.
3. **One contract for the whole package, including `error`.** ⛔ Not recommended. It
   enrols four modules into `check:optional-error-sink`'s population — a ledger being
   paid *down* deliberately (#10556: 15 → 3 → 2, shrink-only) — and the repair it then
   demands is a breaking change to two exported option types.

The `record-orphan-cleanup.ts` producer question above is the sharper one, and it is
live whether or not this card proceeds: two shapes are red under #9754's rule today and
are hidden only by a spelling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_