### PR TITLE
fix(service-datasource): stop rendering the unauthorable `fields.*.primaryKey` in object drafts

### DIFF
--- a/.changeset/external-object-draft-drops-unauthorable-primary-key.md
+++ b/.changeset/external-object-draft-drops-unauthorable-primary-key.md
@@ -1,0 +1,38 @@
+---
+"@objectstack/service-datasource": patch
+---
+
+`os datasource introspect --primary-key` (and `POST /object-draft` with
+`primaryKey`) now generates an object draft that compiles and parses (#11000).
+
+The generator emitted a field-level `primaryKey: true` — into the definition
+and onto the rendered field line. `primaryKey` is **not a key of the spec field
+schema**, so the `*.object.ts` the review-before-commit flow handed the user was
+refused by both instruments the file is annotated for:
+
+- `tsc --noEmit` against `ServiceObject` — `TS2353: Object literal may only
+  specify known properties, and 'primaryKey' does not exist in type …`;
+- `ObjectSchema.safeParse` — `unrecognized_keys` at `["fields","<f>"]`.
+
+This was the last reason the `opts.primaryKey` path did not build. With #10712's
+namespace/`sharingModel` repairs already landed, **both** paths — `primaryKey`
+set and unset — now clear `defineStack()`'s namespace check, the
+`authoringRulesFor('build')` rule set, and `tsc --noEmit` over the rendered
+source.
+
+The introspected key is not discarded: it is preserved as a comment above the
+`fields` block, naming the column(s) the draft was given as the key —
+
+```ts
+  // Remote primary key: order_id, line_no
+```
+
+— with the reason it is a comment rather than a field key, and an explicit
+caveat that for a composite key some drivers report only the first column
+(#10997), so the list is a lower bound rather than a verified complete key. A
+table with no reported key gets no comment at all.
+
+Per the maintainer ruling of 2026-08-22, an authorable spelling for a federated
+object's remote key (`external.primaryKey: string[]` on the binding schema) is
+**deferred, not rejected** — it returns as its own `packages/spec` change when
+federated upsert has a live runtime consumer to justify the surface.

--- a/.changeset/external-object-draft-passes-os-build.md
+++ b/.changeset/external-object-draft-passes-os-build.md
@@ -27,6 +27,7 @@ prefix — mirroring `defineStack`, which skips the check entirely rather than
 inventing one, and avoiding an `_customers` that would trade one invalid draft
 for another.
 
-Note the `opts.primaryKey` path still does not build: it emits
-`fields.<f>.primaryKey`, which is not an authorable spec field key. That is
-#11000, a separate open contract question, untouched here.
+At the time this landed, the `opts.primaryKey` path still did not build: it
+emitted `fields.<f>.primaryKey`, which is not an authorable spec field key.
+That was #11000, and it is fixed separately in this same release — both paths
+build now. See that changeset for what replaced the key.

--- a/packages/services/service-datasource/src/__tests__/external-datasource-service.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-datasource-service.test.ts
@@ -89,7 +89,23 @@ describe('generateObjectDraft', () => {
     expect(draft.name).toBe('fact_orders');
     expect(draft.datasource).toBe('warehouse');
     const fields = draft.definition.fields as Record<string, { type: string; primaryKey?: boolean }>;
-    expect(fields.order_id).toEqual({ type: 'text', primaryKey: true });
+    /**
+     * `order_id` is the table's primary key, and the field carries NOTHING
+     * about that.
+     *
+     * This assertion used to read `{ type: 'text', primaryKey: true }`. It was
+     * flipped by the maintainer ruling of 2026-08-22 (「同意所有」, item 8 = D,
+     * recorded on #11000): `fields.<f>.primaryKey` is not a key of the spec
+     * field schema, so the draft it pinned was one `tsc --noEmit` refused
+     * (`TS2353`) and `ObjectSchema.safeParse` refused (`unrecognized_keys`).
+     * The pin is kept, not deleted — inverted, it is now the guard that the
+     * unauthorable key does not come back. `toEqual` (not `toMatchObject`) is
+     * load-bearing here: it is what makes the assertion fail on an EXTRA key.
+     *
+     * Where the key went instead is pinned in
+     * `external-object-draft-primary-key.test.ts`.
+     */
+    expect(fields.order_id).toEqual({ type: 'text' });
     expect(fields.amount.type).toBe('number');
     expect(fields.ordered_at.type).toBe('datetime');
     expect(fields.metadata.type).toBe('json');
@@ -101,7 +117,11 @@ describe('generateObjectDraft', () => {
     expect(draft.source).toContain("remoteName: 'fact_orders'");
     expect(draft.source).toContain("remoteSchema: 'mart'");
     expect(draft.source).toContain('REVIEW:');
-    expect(draft.source).toContain("order_id: { type: 'text', primaryKey: true }");
+    // Same flip, source side: the rendered field line no longer carries the
+    // key, and the introspected key survives as the comment ruling D requires.
+    expect(draft.source).toContain("order_id: { type: 'text' },");
+    expect(draft.source).not.toContain('primaryKey: true');
+    expect(draft.source).toContain('// Remote primary key: order_id');
   });
 
   it('honours include/exclude/rename/primaryKey options', async () => {
@@ -113,6 +133,10 @@ describe('generateObjectDraft', () => {
     });
     const fields = draft.definition.fields as Record<string, unknown>;
     expect(Object.keys(fields)).toEqual(['order_id', 'total']);
+    // `opts.primaryKey` still HAS an effect after ruling D — it moved from the
+    // definition to the comment. An implementation that dropped the option
+    // entirely would pass every other assertion in this file.
+    expect(draft.source).toContain('// Remote primary key: order_id');
   });
 
   it('throws when the remote table is missing', async () => {

--- a/packages/services/service-datasource/src/__tests__/external-object-draft-os-build.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-object-draft-os-build.test.ts
@@ -58,12 +58,22 @@ import {
  * the object NAME comes from the table name and the OWD is a constant, so a
  * real introspection would add cost and no coverage.
  *
- * Every column is spelled `primaryKey: false` on purpose. That keeps the whole
- * file on the `opts.primaryKey`-unset path, where the generator emits no
- * `fields.<f>.primaryKey` — the key that is NOT authorable (#11000, an open
- * contract question in `packages/spec`, deliberately untouched here). Pinning
- * these two repairs on a draft that also carries #11000's key would produce
- * cases that cannot go green until a card this lane does not own is decided.
+ * Every column is spelled `primaryKey: false`, so the cases above run on the
+ * `opts.primaryKey`-UNSET path. That was originally a workaround: #11000's
+ * unauthorable `fields.<f>.primaryKey` made the key-set path un-buildable, and
+ * pinning these two repairs on top of it would have produced cases that could
+ * not go green until a card this lane did not own was decided.
+ *
+ * #11000 is now decided (maintainer, 2026-08-22, 「同意所有」 item 8 = D) and
+ * fixed: the generator no longer emits that key. The fixture keeps the unset
+ * spelling because these two defects genuinely do not read a column's PK-ness
+ * — but the path split is no longer a limitation, and the block at the bottom
+ * of this file re-runs the same three checks with `opts.primaryKey` SET.
+ * ⭐ Keep them separate anyway: before the namespace/OWD repairs landed, the
+ * key-set path failed on `unrecognized_keys` BEFORE the namespace check ran,
+ * so on that path the namespace defect was masked rather than absent. Error
+ * ordering hides defects in this pipeline; one path's verdict never covers the
+ * other's.
  */
 function remoteSchema(): IntrospectedSchema {
   return {
@@ -231,6 +241,48 @@ describe('an absent or blank namespace must not trade one invalid draft for anot
   it('carries NO namespace TODO once a namespace did resolve', async () => {
     const draft = await serviceWith('wh').generateObjectDraft('warehouse', 'customers');
     expect(draft.source).not.toContain('TODO(namespace)');
+  });
+});
+
+/**
+ * The `opts.primaryKey`-SET path, which #11000 removed the last blocker from.
+ *
+ * Until ruling D, this path produced a draft that failed
+ * `ObjectSchema.safeParse` on `unrecognized_keys` — and failed it EARLY ENOUGH
+ * that the namespace and OWD repairs pinned above were never reached on it.
+ * Re-running all three checks here is what makes "both paths build" a measured
+ * claim rather than an inference from the unset path.
+ */
+describe('both paths build — the key-set path is no longer the exception', () => {
+  /** The same service, driven with an explicit remote key. */
+  const withKey = (ns: string | undefined = 'wh') =>
+    serviceWith(ns).generateObjectDraft('warehouse', 'customers', { primaryKey: ['id'] });
+
+  it('stage 1 — the namespace prefix rule accepts the name on the key-set path too', async () => {
+    const draft = await withKey();
+    expect(draft.name).toBe('wh_customers');
+    expect(validateObjectNamespacePrefix(draft.name, 'wh')).toBeNull();
+  });
+
+  it('stage 2 — the definition PARSES, and carries the declared OWD', async () => {
+    const draft = await withKey();
+    const parsed = ObjectSchema.safeParse(draft.definition);
+    expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true);
+    expect(draft.definition.sharingModel).toBe('private');
+    expect(CANONICAL_OWD).toContain(draft.definition.sharingModel);
+  });
+
+  it('still-generates — every field, the binding and the remote name survive the key path', async () => {
+    const draft = await withKey();
+    const fields = draft.definition.fields as Record<string, { type: string }>;
+    const external = draft.definition.external as { remoteName?: string; remoteSchema?: string };
+
+    expect(Object.keys(fields)).toEqual(['id', 'name', 'signed_up_at']);
+    expect(fields.signed_up_at.type).toBe('datetime');
+    expect(external.remoteName).toBe('customers');
+    expect(external.remoteSchema).toBe('mart');
+    expect(draft.source).toContain("remoteSchema: 'mart', remoteName: 'customers'");
+    expect(draft.source).toContain("sharingModel: 'private'");
   });
 });
 

--- a/packages/services/service-datasource/src/__tests__/external-object-draft-primary-key.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-object-draft-primary-key.test.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The introspected remote primary key: absent from the definition, present as
+ * a comment in the rendered source.
+ *
+ * ## The defect this pins closed (#11000)
+ *
+ * `generateObjectDraft` emitted `fields.<f>.primaryKey: true` and
+ * `renderObjectSource` rendered `, primaryKey: true` onto the field line.
+ * `primaryKey` is **not a key of the spec field schema**, so the generator had
+ * a pinned path producing a draft the platform's own toolchain refused on both
+ * instruments the rendered file is annotated for:
+ *
+ *  - `tsc --noEmit` against `ServiceObject` — `TS2353: Object literal may only
+ *    specify known properties, and 'primaryKey' does not exist in type …`;
+ *  - `ObjectSchema.safeParse` — `unrecognized_keys` at `["fields","<f>"]`.
+ *
+ * ## The ruling
+ *
+ * Maintainer, 2026-08-22 live session (「同意所有」, item 8) — **D**:
+ * stop emitting the key; the introspected key survives **as a comment** in the
+ * generated source (information preserved for the reader, zero contract face).
+ * The alternative of an authorable spelling on the binding
+ * (`external.primaryKey: string[]`) is **deferred, not rejected** — it returns
+ * as its own `packages/spec` card when federated upsert has a live runtime
+ * consumer.
+ *
+ * ## Why FOUR directions and not one
+ *
+ * "The draft parses now" is satisfiable by an implementation that simply drops
+ * `opts.primaryKey` on the floor — it would go green on a parse-only suite
+ * while discarding exactly what the ruling said to preserve. So the
+ * information-preservation direction is pinned as its own case, and is the one
+ * that reddens under ablation of the comment renderer.
+ *
+ * ## The instruments
+ *
+ * `ObjectSchema.safeParse` is asserted in full (`success === true`), not merely
+ * "no `unrecognized_keys`": what the field-drop has to buy is the whole
+ * definition's verdict, and #11059's `sharingModel` repair is part of that same
+ * verdict. The `tsc --noEmit` half of the acceptance runs against the built
+ * artifact in the PR's harness rather than in-process here — this file imports
+ * the service through a RELATIVE specifier (`../external-datasource-service.js`),
+ * which cannot route through the package's `exports`, so these cases measure
+ * `src/` and are correct without a build.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+import { ObjectSchema } from '@objectstack/spec/data';
+import {
+  ExternalDatasourceService,
+  type DatasourceLike,
+} from '../external-datasource-service.js';
+
+/**
+ * A remote schema with three shapes of key in one fixture: a single-column key
+ * (`orders.order_id`), a COMPOSITE key (`order_lines.order_id + line_no`) and a
+ * table with NO key at all (`events`).
+ *
+ * The composite table spells BOTH members `primaryKey: true`. That is what a
+ * complete introspection reports; #10997 (SQLite returns only the first column
+ * of a composite key) is a separate, unfixed defect in the engine lane, and
+ * pinning this generator against the truncated shape would bake that defect in
+ * as if it were the contract. What this file does owe #10997 is that the
+ * rendered comment must not CLAIM completeness — asserted below.
+ */
+function remoteSchema(): IntrospectedSchema {
+  return {
+    dialect: 'postgres',
+    introspectedAt: '2026-08-22T00:00:00.000Z',
+    tables: {
+      'mart.orders': {
+        name: 'mart.orders',
+        indexes: [],
+        columns: [
+          { name: 'order_id', type: 'text', nullable: false, primaryKey: true },
+          { name: 'amount', type: 'numeric(10,2)', nullable: true, primaryKey: false },
+        ],
+      },
+      'mart.order_lines': {
+        name: 'mart.order_lines',
+        indexes: [],
+        columns: [
+          { name: 'order_id', type: 'text', nullable: false, primaryKey: true },
+          { name: 'line_no', type: 'integer', nullable: false, primaryKey: true },
+          { name: 'sku', type: 'text', nullable: true, primaryKey: false },
+        ],
+      },
+      'mart.events': {
+        name: 'mart.events',
+        indexes: [],
+        columns: [
+          { name: 'payload', type: 'jsonb', nullable: true, primaryKey: false },
+          { name: 'at', type: 'timestamptz', nullable: true, primaryKey: false },
+        ],
+      },
+    },
+  };
+}
+
+function svc(): ExternalDatasourceService {
+  return new ExternalDatasourceService({
+    introspect: async () => remoteSchema(),
+    getDatasource: async (name): Promise<DatasourceLike> => ({ name, schemaMode: 'external' }),
+    getObject: async () => undefined,
+    listObjects: async () => [],
+    getNamespace: () => 'wh',
+  });
+}
+
+/** Every field record in a draft definition, flattened for key inspection. */
+function fieldRecords(draft: { definition: Record<string, unknown> }): Array<[string, object]> {
+  return Object.entries(draft.definition.fields as Record<string, object>);
+}
+
+describe('direction 1 — the unauthorable key is ABSENT from the definition', () => {
+  it('drops it on the option-supplied path', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+
+    for (const [name, record] of fieldRecords(draft)) {
+      expect(Object.keys(record), `field '${name}'`).toEqual(['type']);
+    }
+    // Spelled twice on purpose: the loop above forbids ANY extra key, this
+    // line names the one the defect was about, so a regression reports it.
+    expect(JSON.stringify(draft.definition)).not.toContain('primaryKey');
+  });
+
+  it('drops it on the introspection-supplied path', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders');
+
+    const fields = draft.definition.fields as Record<string, object>;
+    expect(Object.keys(fields.order_id)).toEqual(['type']);
+    expect(JSON.stringify(draft.definition)).not.toContain('primaryKey');
+  });
+
+  it('renders no `primaryKey:` onto the field LINE either', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+    expect(draft.source).toContain("order_id: { type: 'text' },");
+    expect(draft.source).not.toContain('primaryKey: true');
+  });
+});
+
+describe('direction 2 — the draft PARSES, which it could not before', () => {
+  it('accepts the whole definition on the key-set path', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+
+    const parsed = ObjectSchema.safeParse(draft.definition);
+    expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('accepts it on the composite-key path too', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'order_lines', {
+      primaryKey: ['order_id', 'line_no'],
+    });
+    const parsed = ObjectSchema.safeParse(draft.definition);
+    expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true);
+  });
+
+  it('POSITIVE CONTROL — the same definition with the key put BACK is refused', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+    const fields = draft.definition.fields as Record<string, Record<string, unknown>>;
+    const poisoned = {
+      ...draft.definition,
+      fields: { ...fields, order_id: { ...fields.order_id, primaryKey: true } },
+    };
+
+    const parsed = ObjectSchema.safeParse(poisoned);
+    expect(parsed.success).toBe(false);
+    // The instrument is live and refusing for THE reason #11000 measured, not
+    // for some incidental one. Without this, the green above could be a schema
+    // that stopped refusing anything at all.
+    expect(JSON.stringify((parsed as { error: unknown }).error)).toContain('unrecognized_keys');
+  });
+});
+
+describe('direction 3 — the information is PRESERVED as a comment (load-bearing)', () => {
+  it('names the single key column', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+    expect(draft.source).toContain('// Remote primary key: order_id');
+  });
+
+  it('names EVERY member of a composite key, in order', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'order_lines', {
+      primaryKey: ['order_id', 'line_no'],
+    });
+    expect(draft.source).toContain('// Remote primary key: order_id, line_no');
+  });
+
+  it('names the field name, not the remote column, when the field was renamed', async () => {
+    // The comment sits directly above the `fields:` block, so it has to speak
+    // that block's vocabulary — otherwise it points at a line that is not there.
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+      rename: { order_id: 'remote_order_id' },
+    });
+    expect(draft.source).toContain('// Remote primary key: remote_order_id');
+  });
+
+  it('does NOT overclaim completeness — #10997 is unfixed and in another lane', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'order_lines', {
+      primaryKey: ['order_id', 'line_no'],
+    });
+    // The caveat, not merely "some comment exists": a reader who trusts this
+    // list as the complete key can be wrong today, through no fault of this
+    // generator, and the file has to say so.
+    expect(draft.source).toContain('#10997');
+    expect(draft.source).toContain('lower bound');
+  });
+
+  it('says WHY the key is a comment rather than a field key', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+    // A bare column list would read as an oversight to the next person to touch
+    // this generator — exactly the shape that put the key on the field in the
+    // first place.
+    expect(draft.source).toContain('#11000');
+    expect(draft.source).toContain('no authorable key');
+  });
+
+  it('emits NO comment at all when no key was reported', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'events');
+    expect(draft.source).not.toContain('Remote primary key');
+    // …and the keyless draft is still a valid one.
+    expect(ObjectSchema.safeParse(draft.definition).success).toBe(true);
+  });
+
+  it('the comment survives INTO the source only — never into the definition', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders', {
+      primaryKey: ['order_id'],
+    });
+    expect(JSON.stringify(draft.definition)).not.toContain('Remote primary key');
+  });
+});
+
+describe('direction 4 — the `opts.primaryKey`-UNSET path is unchanged from #11059', () => {
+  it('still builds, still carries the namespace prefix and the declared OWD', async () => {
+    const draft = await svc().generateObjectDraft('warehouse', 'orders');
+
+    expect(draft.name).toBe('wh_orders');
+    expect(draft.definition.sharingModel).toBe('private');
+    expect(ObjectSchema.safeParse(draft.definition).success).toBe(true);
+  });
+
+  it('reports the introspected key in the comment without being asked', async () => {
+    // `opts.primaryKey` unset → the key comes from `col.primaryKey`. Pinned so
+    // that the fix cannot be read as "the option is ignored now".
+    const draft = await svc().generateObjectDraft('warehouse', 'orders');
+    expect(draft.source).toContain('// Remote primary key: order_id');
+  });
+});
+
+describe('importObject persists the parseable definition', () => {
+  it('never writes the unauthorable key into the metadata store', async () => {
+    const persisted: Array<{ name: string; def: Record<string, unknown> }> = [];
+    const service = new ExternalDatasourceService({
+      introspect: async () => remoteSchema(),
+      getDatasource: async (name): Promise<DatasourceLike> => ({ name, schemaMode: 'external' }),
+      getObject: async () => undefined,
+      listObjects: async () => [],
+      getNamespace: () => 'wh',
+      persistObject: async (name, def) => {
+        persisted.push({ name, def });
+      },
+    });
+
+    await service.importObject('warehouse', 'orders', { primaryKey: ['order_id'] });
+
+    expect(persisted).toHaveLength(1);
+    expect(JSON.stringify(persisted[0]?.def)).not.toContain('primaryKey');
+    expect(ObjectSchema.safeParse(persisted[0]?.def).success).toBe(true);
+  });
+});

--- a/packages/services/service-datasource/src/external-datasource-service.ts
+++ b/packages/services/service-datasource/src/external-datasource-service.ts
@@ -210,6 +210,40 @@ function toObjectName(remoteName: string): string {
 const GENERATED_SHARING_MODEL = 'private';
 
 /**
+ * The lead-in of the comment that carries the introspected remote primary key
+ * into the generated source — and the one place the reason is written down.
+ *
+ * `fields.<f>.primaryKey` is **not a key of the spec field schema**. Emitting
+ * it produced a `*.object.ts` the platform's own toolchain refused on both
+ * instruments it is annotated for: `tsc --noEmit` against `ServiceObject`
+ * (`TS2353 … 'primaryKey' does not exist in type`) and
+ * `ObjectSchema.safeParse` (`unrecognized_keys` at `["fields","<f>"]`). So the
+ * generator had a pinned path that produced a draft neither the compiler nor
+ * the validator would take (#11000).
+ *
+ * Maintainer ruling, 2026-08-22 live session (「同意所有」, item 8) — **D**:
+ *
+ * > `generateObjectDraft`/`renderObjectSource` stop emitting
+ * > `fields.<f>.primaryKey`; the introspected key survives **as a comment** in
+ * > the generated source (information preserved for the reader, zero contract
+ * > face); the existing pin tests that assert the invalid emission are updated
+ * > as part of the fix.
+ *
+ * Both halves are load-bearing, and the second is the one an implementation
+ * can silently skip: simply dropping `opts.primaryKey` on the floor would make
+ * every parse-and-compile assertion green while discarding exactly what the
+ * ruling said to keep.
+ *
+ * The rejected alternatives, so they are not re-litigated from scratch:
+ * routing the key to `fields.<f>.externalId` was refused as semantically
+ * different and itself of unproven enforcement, and an authorable spelling on
+ * the binding (`external.primaryKey: string[]`) is **deferred, not rejected** —
+ * it returns as its own `packages/spec` card once federated upsert has a live
+ * runtime consumer to justify the surface.
+ */
+const REMOTE_PRIMARY_KEY_COMMENT = '// Remote primary key: ';
+
+/**
  * Normalise an injected namespace. Blank / whitespace-only reads as ABSENT:
  * `validateObjectNamespacePrefix` skips a falsy namespace, but `'  '` is
  * truthy and would render `  _customers` — one invalid draft traded for
@@ -331,7 +365,11 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
     const exclude = opts.excludeColumns ? new Set(opts.excludeColumns) : new Set<string>();
     const pkOverride = opts.primaryKey ? new Set(opts.primaryKey) : undefined;
 
-    const fields: Record<string, { type: FieldType; primaryKey?: boolean }> = {};
+    const fields: Record<string, { type: FieldType }> = {};
+    // The remote key is collected here rather than onto the field, because
+    // there is no authorable field key to put it on — see
+    // REMOTE_PRIMARY_KEY_COMMENT for the ruling and the measurements.
+    const primaryKeyFields: string[] = [];
     const review: ObjectDraft['review'] = [];
 
     for (const col of table.columns) {
@@ -356,7 +394,8 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
       }
 
       const isPk = pkOverride ? pkOverride.has(col.name) : col.primaryKey;
-      fields[fieldName] = isPk ? { type: fieldType, primaryKey: true } : { type: fieldType };
+      fields[fieldName] = { type: fieldType };
+      if (isPk) primaryKeyFields.push(fieldName);
     }
 
     // ADR-0028: every object a package defines must be named
@@ -387,7 +426,7 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
       name,
       datasource,
       definition,
-      source: renderObjectSource(definition, fields, review, namespace),
+      source: renderObjectSource(definition, fields, review, namespace, primaryKeyFields),
       review,
     };
   }
@@ -657,22 +696,45 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
  * because the two absent cases are NOT the same file: a name that is already
  * prefixed and a name that could not be prefixed both read as "starts with
  * something" from here, and only the second one needs the TODO.
+ *
+ * `primaryKeyFields` is rendered as a COMMENT and nowhere else — see
+ * {@link REMOTE_PRIMARY_KEY_COMMENT}. It is passed separately from `fields` on purpose:
+ * a field record that could carry the key at all is a field record something
+ * could accidentally serialise into the definition again.
  */
 function renderObjectSource(
   definition: Record<string, unknown>,
-  fields: Record<string, { type: FieldType; primaryKey?: boolean }>,
+  fields: Record<string, { type: FieldType }>,
   review: ObjectDraft['review'],
   namespace?: string,
+  primaryKeyFields: readonly string[] = [],
 ): string {
   const reviewByColumn = new Map(review.map((r) => [r.column, r.note]));
   const external = definition.external as { remoteSchema?: string; remoteName?: string };
 
   const fieldLines = Object.entries(fields).map(([fieldName, f]) => {
     const note = reviewByColumn.get(fieldName);
-    const pk = f.primaryKey ? ', primaryKey: true' : '';
     const comment = note ? ` // REVIEW: ${note}` : '';
-    return `    ${fieldName}: { type: '${f.type}'${pk} },${comment}`;
+    return `    ${fieldName}: { type: '${f.type}' },${comment}`;
   });
+
+  // The whole of ruling D's second half: information for the reader, zero
+  // contract face. Rendered only when a key was actually reported — with no
+  // key there is nothing to preserve, and an empty "none reported" banner would
+  // be noise in every draft of every keyless table.
+  const primaryKeyComment =
+    primaryKeyFields.length > 0
+      ? [
+          `  ${REMOTE_PRIMARY_KEY_COMMENT}${primaryKeyFields.join(', ')}`,
+          `  // Preserved as a COMMENT because 'ServiceObject' has no authorable key for a`,
+          `  // federated object's remote primary key (#11000): 'fields.<f>.primaryKey' is`,
+          `  // not part of the field schema, so emitting it produced a draft that neither`,
+          `  // 'tsc' nor 'ObjectSchema' accepted. Nothing below reads this line.`,
+          `  // It names the column(s) THIS DRAFT WAS GIVEN as the key. For a COMPOSITE key`,
+          `  // some drivers report only the first column (#10997), so treat the list as a`,
+          `  // lower bound and check it against the remote table before relying on it.`,
+        ]
+      : [];
 
   const externalLine = external.remoteSchema
     ? `  external: { remoteSchema: '${external.remoteSchema}', remoteName: '${external.remoteName}' },`
@@ -704,6 +766,7 @@ function renderObjectSource(
     `  label: '${definition.label as string}',`,
     `  datasource: '${definition.datasource as string}',`,
     externalLine,
+    ...primaryKeyComment,
     `  fields: {`,
     ...fieldLines,
     `  },`,


### PR DESCRIPTION
Fixes #11000

> **Note on spelling:** the real key is `fields.` + *fieldname* + `.primaryKey`, spelled in the source with angle brackets around the field placeholder. GitHub's body sanitizer strips short angle-bracket fragments — even inside backticks — so this description writes it `fields.*.primaryKey` throughout, including in the quoted generated source below. The committed files use the angle-bracket spelling.

`generateObjectDraft` emitted `fields.*.primaryKey: true` and `renderObjectSource` rendered `, primaryKey: true` onto the field line. `primaryKey` is **not a key of the spec field schema**, so the `*.object.ts` the review-before-commit flow handed the user was refused by both instruments the file is annotated for — `tsc --noEmit` against `ServiceObject` (`TS2353`) and `ObjectSchema.safeParse` (`unrecognized_keys`).

Per the maintainer ruling of 2026-08-22 (live session, 「同意所有」 item 8 = **D**): the key stops being emitted, and the introspected value survives **as a comment** in the generated source — information preserved for the reader, zero contract face. Option C (`external.primaryKey: string[]` on `ObjectExternalBindingSchema`) is **deferred, not rejected**; it returns as its own `packages/spec` card when federated upsert has a live runtime consumer. No `packages/spec` file is touched here.

## Acceptance — the `os build` pipeline, both paths, before and after

Three stages driven for real: `defineStack()` → `authoringRulesFor('build')` (41 rules) → `tsc --noEmit` over `draft.source`. Measured at `eb16902cc`.

| path | stage | BEFORE (`3e26359a7`) | AFTER (`eb16902cc`) |
|---|---|---|---|
| `opts.primaryKey` **unset** | 1 `defineStack()` | PASS | PASS |
| | 2 `authoringRulesFor('build')` | PASS (41 rules, 0 gating) | PASS (41 rules, 0 gating) |
| | 3 `tsc --noEmit` | PASS (0 diagnostics) | PASS (0 diagnostics) |
| `opts.primaryKey` **SET** | 1 `defineStack()` | **FAIL** — ``objects.0.fields.id: Unrecognized key(s) on this field: `primaryKey` `` | **PASS** |
| | 2 `authoringRulesFor('build')` | **FAIL (protocol schema; the rules were NEVER REACHED)** | **PASS (41 rules, 0 gating)** |
| | 3 `tsc --noEmit` | **FAIL** — `draft.ts(10,25): error TS2353: … 'primaryKey' does not exist in type` | **PASS (0 diagnostics)** |

The BEFORE column is a live re-measurement on this branch (pre-fix generator checked out, artifact rebuilt), not an inherited claim. It reproduces exactly what #11059's seat reported.

**#10712's acceptance** — "both paths build" — is only now fully discharged. #11059 landed the namespace/`sharingModel` half and left the `primaryKey`-set row red; this PR clears it. No closing keyword is added for that card: it is already closed by #11059.

⭐ The error-ordering hazard #11059 flagged is confirmed here rather than assumed: on the BEFORE/SET path stage 1 aborted on `unrecognized_keys`, so nothing downstream of it was measured on that path at all. One path's verdict never covers the other's.

## What the replacement comment renders

Single key (`opts.primaryKey: ['id']`, or introspection reporting one column):

```ts
  external: { remoteSchema: 'mart', remoteName: 'customers' },
  // Remote primary key: id
  // Preserved as a COMMENT because 'ServiceObject' has no authorable key for a
  // federated object's remote primary key (#11000): 'fields.*.primaryKey' is
  // not part of the field schema, so emitting it produced a draft that neither
  // 'tsc' nor 'ObjectSchema' accepted. Nothing below reads this line.
  // It names the column(s) THIS DRAFT WAS GIVEN as the key. For a COMPOSITE key
  // some drivers report only the first column (#10997), so treat the list as a
  // lower bound and check it against the remote table before relying on it.
  fields: {
    id: { type: 'text' },
```

- **composite key** → every member, in order: `// Remote primary key: order_id, line_no`
- **no key reported** → **no comment at all**. There is nothing to preserve, and a "none reported" banner would be noise in every draft of every keyless table.
- **renamed field** → the comment names the *field* name, not the remote column. It sits directly above the `fields` block, so it has to speak that block's vocabulary or it points at a line that is not there.

On #10997 (SQLite introspection returns only the first column of a composite key — unfixed, engine lane): the wording deliberately does not claim to name "the primary key". It says it names the column(s) *this draft was given*, and states outright that the list is a **lower bound**. That caveat is pinned, not just written.

## The pin flip

The existing suite pinned the invalid emission. It was **flipped, not deleted** — inverted, it is now the guard that the unauthorable key does not come back — and the explanatory text beside it was rewritten to cite this ruling (the #11046 stale-comment shape).

- `external-datasource-service.test.ts` — `expect(fields.order_id).toEqual({ type: 'text', primaryKey: true })` → `toEqual({ type: 'text' })`, plus source-side assertions that the key is gone and the comment is present. `toEqual` rather than `toMatchObject` is load-bearing and now says so: it is what makes the assertion fail on an *extra* key.
- `external-object-draft-os-build.test.ts` — its fixture docblock said #11000 was "an open contract question in `packages/spec`, deliberately untouched here". Now false; rewritten, with the error-ordering warning kept.
- **Bounded in-place fix, declared:** `.changeset/external-object-draft-passes-os-build.md` (#11059's, unreleased) ended with "the `opts.primaryKey` path still does not build … untouched here". That is a user-visible release note this PR falsifies, same defect class, mechanically corrected — one paragraph, no behaviour.

## What is pinned — four directions

New file `external-object-draft-primary-key.test.ts` (16 cases):

1. **absent from the definition** — every field record's keys are exactly `['type']`, on the option path *and* the introspection path, and nothing reaches `importObject`'s metadata store either.
2. **the draft parses** — full `ObjectSchema.safeParse` success (a value verdict, not an absence-of-unknown-keys check), single and composite. **Positive control**: the same definition with the key put back is refused, and refused *for `unrecognized_keys`* — without that, the green above could be a schema that stopped refusing anything.
3. **information preserved (load-bearing)** — the comment names the key, in order, under rename; carries the #10997 caveat; says why; and renders nothing when there is no key. An implementation that just dropped `opts.primaryKey` passes every other direction and fails these.
4. **the unset path is unchanged from #11059** — namespace prefix, `sharingModel`, and #11059's own still-generates cases all re-run green.

## Proof

**Ablation A — comment renderer removed.** Predicted in writing first: reddening (not diagnostics-increase, not inversion), `toContain` on `draft.source`, and — enumerated before running — exactly 8 named cases, with the absence-asserting cases staying green. Observed: exactly those 8, ``AssertionError: expected '// Generated by `os datasource intros…' to contain '// Remote primary key: order_id'``; 54 passed. (The coarser count written before the suite existed said 3; recorded, and wrong.)

**Ablation B — the key put back on the definition side only,** renderer untouched. Predicted 8 named cases red, with a **discriminator**: the field-line and comment cases must stay GREEN, because the renderer no longer reads `f.primaryKey`. Observed: exactly those 8; discriminator held. The two halves of ruling D are independently pinned.

Both restores proved byte-identical (`git hash-object` → `942f2c6ea223e42a173b9b9b8e4375eb50f25ded`, matching the pre-ablation hash) **and re-run to a real verdict** — 62/62 green each time, not trusted to the hash.

**Zero-hit counter-check, positive control run FIRST.** The same `grep -nE "primaryKey: true|, primaryKey: true|primaryKey\?: boolean"` matched the pre-fix file at 4 lines — read individually, they are the 4 sites this PR removes (two type annotations, one definition write, one render) — and matches nothing in the fixed file (exit 1). The zero is measured, not assumed.

**`src` vs `dist`, re-verified from the files rather than inherited — and it is two answers in one PR:**

- *unit pins* — the subject is imported as `'../external-datasource-service.js'`, a **relative** specifier that cannot route through `exports`, so it measures **`src/`**. This package's `vitest.config.ts` carries exactly one alias, anchored `/^@objectstack\/core$/`, which does not touch it. But the **instrument** (`ObjectSchema` from `@objectstack/spec/data`) is a bare specifier → the workspace link → `exports['./data']` → `packages/spec/dist/data/index.mjs`, so the schema half needs the closure built. Built and verified present (`ObjectSchema` in that artifact).
- *`os build` harness* — loads `ExternalDatasourceService` from `packages/services/service-datasource/dist/index.js`, so it measures the **artifact** and is rebuilt before every measurement. Each run fingerprints it: AFTER/RESTORE 126976 bytes with `Remote primary key` present and `, primaryKey: true` absent; BEFORE 126139 bytes with the inverse. Two instrument defects in the harness itself were caught and fixed before any verdict was believed — an incomplete manifest that failed stage 1 on both paths, and a `startsWith('draft.ts')` diagnostic classifier that reported 0 for *both* files (reading as a clean draft *and* a silent control at once). The tsc positive control was silent until the second was fixed; it now fires on every run.

## Gates — derived on the final commit, clean tree

`node scripts/pm/dispatch-gates.mjs` with **no path arguments**, on `eb16902cc` (6 paths vs merge base `3e26359a7`, working tree 0, untracked 0). It named the gates below; the dispatch carried no gate list, so this derivation *is* the list. Exit codes captured before any pipe; each verdict is the gate's own printed line.

| gate | verdict |
|---|---|
| `check:changeset-gate-self-tests` | ✓ 212 + 116 assertions over real temp git repos |
| `check:objectui-changeset` | ✓ all checks passed |
| `check:slot-lookup` | ✓ ratchet holds — 107 unswept sites in 25 files, **none new** |
| `check:test-source-alias` | OK — 72 packages with tests scanned |
| `check:type-source-resolution` | OK — 77 packages with a tsconfig scanned |
| `check-adr-0087-registration` | ✓ no declared-breaking changeset (2 non-breaking seen) |
| `check-changeset-no-major` | ✓ no `major` bump |
| `check-ci-filter-parity` | OK — all 83 declared cross-package globs covered |
| `check-empty-changeset` | ✓ no empty-frontmatter changeset (2 declaring added) |
| `check-plugin-teardown-shape` | ✓ 63 Plugin implementations, baseline fully burned down |
| `check-affected-docs` | ✓ 339 cases pass |
| `check:query-options-erasure` | ✓ ratchet holds — 67 sites, **none new** |
| `check:type-check-coverage` | OK — 65/78 packages type-checked |
| `check:type-check-debt --re-measure` | OK — 33 ledger entries re-measured in 248.1s, **none above its recorded number** |
| `check:engine-double-contract` | OK — self-test + 6 consumer seams, all refusing |
| `check:where-matcher` | ✓ 277 matchers, all conforming |
| `check:nul-bytes` | ✓ self-test, 75 assertions |

No gate returned a refusal (`PREREQUISITE NOT MET` / `cannot run` / `Nothing was checked`) — the full workspace closure (70 build tasks) was built first, exactly as `lint.yml` does, so the ratchet re-measured for real. **No baseline was touched.** `check:type-check-debt` reports a pre-existing 12-error *surplus* on `@objectstack/plugin-auth` that it explicitly calls "not an error"; unrelated to this diff and deliberately left alone.

Package tests: `pnpm --filter @objectstack/service-datasource test` → **25 files, 559 tests, all passing**.

## Declared narrowings

- **Local scope narrowed to the derived union**, not the whole `check:*` farm — CI runs the farm once regardless.
- `tsc --noEmit` over `draft.source` runs in the **PR harness, not the committed suite** — following #11059's precedent, which committed no tsc case either. The committed suite pins parse + shape + comment; the compile verdict is the measurement above.
- A caller who passes `primaryKey: ['x']` **and** `excludeColumns: ['x']` gets no mention of `x` at all — the column is not in the draft to name. A contradictory caller, left as-is rather than widened into. Noted, not filed.

## Not in scope

#10997 (SQLite composite-PK truncation) and #10998 (`introspectSchema` omits `dialect`/`introspectedAt`) are untouched — engine lane, #10676 ruling. This PR only makes sure the generated comment does not *overclaim* in the presence of #10997. #10676 itself remains open: `generateObjectDraft` still reads `col.primaryKey` directly rather than through this file's own `primaryKeyReader` union, which is that card's seam and not widened here.

---

_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_
