### PR TITLE
Make the additive label POST the prescribed write and permit it for dev agents

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -269,12 +269,15 @@ dispatch prompt 只携带每单增量(裁决引文、裁决 / PM-机制假设分
   缺口,⛔ 不自行扩写、不自行抬预算 —— 预算是 PM 的,抬它是维护者裁决。
 - **`skip-changeset` 标签按仓库分流——先认清目标仓库有没有这个机制。** 仅含 tests/
   workflow/`.claude/` 的 PR 不发布任何东西,但「不发布」的声明方式因仓库而异。**本仓库**:
-  标签是真实机制,打标签是你的步骤、不是 CI 的,PR 一建立就打;**先读回、再写并集**——标
-  签写入是整组 PUT(裸集合会抹掉机器人刚打的标签,CI 的写入也可能抹掉你的;changeset 门的
-  首轮可能与你的写入竞态),等机器人稳定后读一次、把清单引进报告:关闭此步骤的是读回,不
-  是写入;口头声明不算打上。**objectui:该标签不存在**——tests/docs-only 的声明方式是空
-  frontmatter 的 changeset;⛔ 永不在那边创建或施加该标签——一次 label add 会静默铸出一
-  个仓库标签,被下一个 agent 读成真实机制。
+  标签是真实机制,打标签是你的步骤、不是 CI 的,PR 一建立就打;写入走**加法端点**——不碰
+  已有标签、无并集可算、无读写窗口(实测从 dev 座位可达;权限集已放行此拼写,别改写):
+  `curl -sS -X POST https://api.github.com/repos/objectstack-ai/objectstack/issues/<n>/labels -H "Authorization: Bearer $GITHUB_TOKEN" -d '{"labels":["skip-changeset"]}'`
+  加法写必要但**不充分**:实测 size-labeler 的整组 PUT 曾在 ~1 秒内抹掉一次正确的加法写。
+  所以收尾仍是**读回**,且在机器人稳定之后——读一次、把清单引进报告;标签消失读作被抹,
+  **重新加上**,不是你的错。仅当加法调用被拒才用回退:读→并集→整组写,**申报**用了回退
+  并报告其读回。关闭此步骤的是读回,不是写入;口头声明不算打上。**objectui:该标签不存
+  在**——tests/docs-only 的声明方式是空 frontmatter 的 changeset;⛔ 永不在那边创建或施
+  加该标签——一次 label add 会静默铸出一个仓库标签,被下一个 agent 读成真实机制。
 - **报告在 draft PR 时点交付 —— CI 收敛等待归 PM,不归你**(维护者 2026-08-10 拍板)。
   分支一推上、draft PR 一开出,立刻交报告;门禁状态如实记录 —— `in_progress` 是诚实
   值。⛔ draft PR 开出后永不 sleep、定时等待或空转轮询 CI(实测:空转轮询烧掉的恰是一个

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,9 @@
       "mcp__Claude_Code_Remote__list_sessions",
       "mcp__Claude_Code_Remote__create_trigger",
       "Bash(agent-browser snapshot *)",
-      "Bash(agent-browser skills *)"
+      "Bash(agent-browser skills *)",
+      "Bash(curl -sS -X POST https://api.github.com/repos/objectstack-ai/objectstack/issues/*/labels *)",
+      "Bash(curl -sS -X POST https://api.github.com/repos/objectstack-ai/objectui/issues/*/labels *)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Fixes #10902
Fixes #10686

One defect in two halves, one commit per member.

## Member 1 — `.claude/agents/os-dev.md` (commit 8c0a24c51)

The skip-changeset paragraph taught the whole-set read → union → write as what the label write *is*. Rewritten to the adjudicated four-point shape:

1. The additive `POST /repos/{owner}/{repo}/issues/{n}/labels` is THE mechanism, named executably — the exact `curl` line with `Authorization: Bearer $GITHUB_TOKEN` (measured working from an agent seat; "apply it additively" alone was demonstrably not actionable).
2. Read-back stays as the closing step — and the measured caveat is folded in: the additive POST is necessary but NOT sufficient. A bot's whole-set PUT was measured erasing a correct additive write within about 1 second, so the read-back happens AFTER the bots settle, and a vanished label is re-applied, not treated as the agent's own error.
3. The whole-set read → union → write is demoted to an explicitly declared fallback for a seat where the additive call is refused, with the requirement to report the read-back when used.
4. The objectui half (the label does not exist there; never create it) is untouched.

Line budget: os-dev.md 392 → 395 lines, ceiling 399 (`check:pm-skill-ratchet` verdict below). No ceiling raise. No issue numbers added (id-lint clean).

## Member 2 — `.claude/settings.json` (commit f6d61c9b7)

Direction A from the paired card: the auto-mode permission classifier was measured blocking a dev agent's additive label POST while permitting the whole-set `issue_write` labels array — the inversion that pushes agents into the clobbering shape. Two `permissions.allow` entries pre-approve exactly the additive POST spelling that os-dev.md now prescribes, for this repo and the objectui twin (the same settings file governs sessions that touch both):

- `Bash(curl -sS -X POST https://api.github.com/repos/objectstack-ai/objectstack/issues/*/labels *)`
- `Bash(curl -sS -X POST https://api.github.com/repos/objectstack-ai/objectui/issues/*/labels *)`

Strictly narrower than the whole-set write already permitted: the endpoint can only add. Documentation note: `settings.json` is strict JSON and cannot carry comments, so the rationale lives here and in the os-dev.md paragraph the entries serve (the doc pins the exact spelling the rules match — URL directly after `-X POST` — and says not to rewrite it). Failure direction if the harness does not support the mid-pattern wildcard on the issue number: the rule is inert and the classifier keeps deciding, i.e. no wider than today. This does not address the labeler's own whole-set PUT — that half remains open: #10703 remains open (devx lane).

Verified this session from a dev seat: the additive POST to this PR's own labels endpoint returned 200 and the read-back after the size-labeler settled shows the label intact (evidence in the report comment on the anchor card).

## Gates (all at head f6d61c9b7, run after the final commit)

`node scripts/pm/dispatch-gates.mjs` (no hand-fed paths) derived 8 families; all green:

- `check:pm-skill-ratchet` — "✓ check-skill-line-ratchet: .claude/agents/os-dev.md is 395 lines (ceiling 399; headroom 4)."
- `check:pm-skill-id-lint` — "✓ check-skill-id-lint: 17 file(s) clean (pattern /#[0-9]{3,}/g)."
- `check:doc-authoring` — "✓ doc authoring guard: 389 files clean — no bare metadata literals."
- `check:nul-bytes` — "check-nul-bytes: OK (scanned 6426 text file(s) … no raw ASCII control bytes)."
- `check:pm-governed-merges` — "✓ check-governed-merges --self-test: 119 assertions …"
- `check:agent-model-declared` — "✓ check-agent-model-declared: 1 agent definition(s) under .claude/agents/ all declare a model"
- `check:skill-frame-sync` — "✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files"
- `check:doc-formula-expressions` — "✓ … 22 record-scoped formula example(s) across 416 files / 1447 TS blocks judged clean"

`.claude/**` only — no publishable package changes, so no changeset; skip-changeset label applied. Governed surface (Prime Directive #14): draft PR, human merge only.

_Generated by [Claude Code](https://claude.ai/code/session_01MsbKEG4LtERSLaDrbehM3e)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsbKEG4LtERSLaDrbehM3e)_