### PR TITLE
fix(auth): gate the localhost trusted-origin substitution to non-production

### DIFF
--- a/.changeset/csrf-localhost-trio-dev-only.md
+++ b/.changeset/csrf-localhost-trio-dev-only.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+Gate the localhost trusted-origin substitution to non-production (#10366).
+
+`AuthManager`'s `trustedOrigins` block substituted a localhost wildcard trio
+(`http://localhost:*`, `http://*.localhost:*`, `https://*.localhost:*`) whenever
+the resolved trusted-origin list came out empty and `OS_CORS_ORIGIN` was unset
+or `*`. Its own comment described this as a development convenience, but the
+condition tested only emptiness — it carried no `NODE_ENV` term, no dev-mode
+term, nothing. A production deployment that reached it with an empty list
+CSRF-trusted every `localhost` and `*.localhost` origin. The declared boundary
+and the enforced boundary disagreed, and only the declared one was visible in
+the file.
+
+The substitution is now gated on `NODE_ENV !== 'production'`, the same dev
+signal already used by the fallback auth secret and by the dev `Origin`
+synthesis in the same file. The property enforced: **a development convenience
+exists only outside production.**
+
+**What production receives instead.** With the trio gated off and the list
+empty, the block's tail omits `trustedOrigins` from the better-auth config
+entirely. That is not an absent policy. Measured against the installed
+better-auth 1.7.1: `getTrustedOrigins`
+(`dist/context/helpers.mjs`) unconditionally seeds the trusted set from the
+resolved `baseURL` origin and treats `options.trustedOrigins` as purely
+**additive**, so an omitted key and an empty array are equivalent — both leave
+exactly the deployment's own origin trusted, and `validateOrigin`
+(`dist/api/middlewares/origin-check.mjs`) refuses everything else with
+`403 INVALID_ORIGIN`.
+
+**Who is affected.** Deployments with an explicitly configured `trustedOrigins`,
+or one derived from `OS_CORS_ORIGIN`, are unchanged in production — the
+substitution never fired for them. Non-production behaviour is unchanged,
+including under `NODE_ENV=test` and when `NODE_ENV` is unset. A production
+deployment that was relying on the substitution to reach its own login page
+now receives a loud `403` rather than silent over-trust; the remedy is to set
+`OS_TRUSTED_ORIGINS`, or to fix the base URL that resolved unusable (PR #10369's
+boot diagnostic already names that condition at startup).
+
+Both existing pins keep their dev-only assertions verbatim; new pins cover the
+production omission, the non-production legs, the SSO per-request-function
+shape, and — load-bearing — that explicitly configured and `OS_CORS_ORIGIN`-derived
+trust survives in production.

--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -1315,6 +1315,146 @@ describe('AuthManager', () => {
     });
   });
 
+  // #10366 — the localhost-wildcard trio is a DEVELOPMENT convenience and is
+  // gated on `NODE_ENV !== 'production'`. Before the gate the condition tested
+  // only emptiness, so a production deployment whose trusted-origin list
+  // resolved empty silently CSRF-trusted every `localhost` / `*.localhost`
+  // origin. These pins enforce the boundary in BOTH directions: production
+  // must not substitute, and non-production must still substitute.
+  describe('trustedOrigins localhost substitution is non-production only (#10366)', () => {
+    const TRIO = ['http://localhost:*', 'http://*.localhost:*', 'https://*.localhost:*'];
+
+    const ENV_KEYS = ['NODE_ENV', 'OS_CORS_ORIGIN', 'CORS_ORIGIN', 'OS_SSO_ENABLED'] as const;
+    let saved: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      saved = Object.fromEntries(ENV_KEYS.map(k => [k, process.env[k]]));
+      for (const k of ENV_KEYS) delete process.env[k];
+    });
+
+    afterEach(() => {
+      for (const k of ENV_KEYS) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k]!;
+      }
+    });
+
+    async function captureConfig(config: Record<string, unknown>): Promise<any> {
+      let capturedConfig: any;
+      (betterAuth as any).mockImplementation((c: any) => {
+        capturedConfig = c;
+        return { handler: vi.fn(), api: {} };
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const manager = new AuthManager({
+        secret: 'test-secret-at-least-32-chars-long',
+        baseUrl: 'https://app.example.com',
+        ...config,
+      } as any);
+      await manager.getAuthInstance();
+      warnSpy.mockRestore();
+      return capturedConfig;
+    }
+
+    describe('production does not substitute', () => {
+      it('omits the trustedOrigins key entirely when none is provided', async () => {
+        process.env.NODE_ENV = 'production';
+        const cfg = await captureConfig({});
+
+        expect(cfg.trustedOrigins).toBeUndefined();
+        // Absent, not merely empty — the key must not appear at all, which is
+        // the shape better-auth receives.
+        expect('trustedOrigins' in cfg).toBe(false);
+      });
+
+      it('omits the trustedOrigins key entirely when an empty array is provided', async () => {
+        process.env.NODE_ENV = 'production';
+        const cfg = await captureConfig({ trustedOrigins: [] });
+
+        expect(cfg.trustedOrigins).toBeUndefined();
+        expect('trustedOrigins' in cfg).toBe(false);
+      });
+    });
+
+    describe('non-production still substitutes', () => {
+      it("substitutes the trio under NODE_ENV='development'", async () => {
+        process.env.NODE_ENV = 'development';
+        const cfg = await captureConfig({});
+
+        expect(cfg.trustedOrigins).toEqual(TRIO);
+      });
+
+      // Guards against "hardening" the predicate to `=== 'development'`, which
+      // would be a STRICTER boundary than ruled and would break `test` and
+      // unset-NODE_ENV development flows.
+      it("substitutes the trio under NODE_ENV='test'", async () => {
+        process.env.NODE_ENV = 'test';
+        const cfg = await captureConfig({});
+
+        expect(cfg.trustedOrigins).toEqual(TRIO);
+      });
+
+      it('substitutes the trio when NODE_ENV is unset', async () => {
+        delete process.env.NODE_ENV;
+        const cfg = await captureConfig({});
+
+        expect(cfg.trustedOrigins).toEqual(TRIO);
+      });
+    });
+
+    // LOAD-BEARING: without these two legs, a change that broke ALL origin
+    // trust in production would still pass a substitution-only suite.
+    describe('production leaves real configured trust intact', () => {
+      it('forwards an explicitly configured trustedOrigins list unchanged', async () => {
+        process.env.NODE_ENV = 'production';
+        const cfg = await captureConfig({
+          trustedOrigins: ['https://app.example.com', 'https://*.example.com'],
+        });
+
+        expect(cfg.trustedOrigins).toEqual([
+          'https://app.example.com',
+          'https://*.example.com',
+        ]);
+      });
+
+      it('forwards an OS_CORS_ORIGIN-derived list unchanged', async () => {
+        process.env.NODE_ENV = 'production';
+        process.env.OS_CORS_ORIGIN = 'https://app.example.com,https://admin.example.com';
+        const cfg = await captureConfig({});
+
+        expect(cfg.trustedOrigins).toEqual([
+          'https://app.example.com',
+          'https://admin.example.com',
+        ]);
+      });
+    });
+
+    // The SSO branch returns `trustedOrigins` as a per-request FUNCTION built
+    // from a copy of the same `origins` array, so gating the push at the source
+    // covers this shape too. That is true today and is exactly the kind of
+    // coupling a future refactor breaks silently — pin it.
+    describe('SSO per-request function shape', () => {
+      it('production: the resolved list contains no localhost wildcard', async () => {
+        process.env.NODE_ENV = 'production';
+        const cfg = await captureConfig({ plugins: { sso: true } });
+
+        expect(typeof cfg.trustedOrigins).toBe('function');
+        const resolved: string[] = await cfg.trustedOrigins(undefined);
+        for (const entry of TRIO) expect(resolved).not.toContain(entry);
+        expect(resolved.some(o => o.includes('localhost'))).toBe(false);
+      });
+
+      it('non-production: the resolved list still contains the trio', async () => {
+        process.env.NODE_ENV = 'development';
+        const cfg = await captureConfig({ plugins: { sso: true } });
+
+        expect(typeof cfg.trustedOrigins).toBe('function');
+        const resolved: string[] = await cfg.trustedOrigins(undefined);
+        for (const entry of TRIO) expect(resolved).toContain(entry);
+      });
+    });
+  });
+
   describe('setRuntimeBaseUrl', () => {
     it('should update baseURL before auth instance is created', async () => {
       let capturedConfig: any;

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -1905,7 +1905,28 @@ export class AuthManager {
         // `*.localhost` subdomains so per-project tenant subdomains (the dev
         // default root domain — see project-provisioning.ts) pass CSRF checks
         // without operators having to configure trustedOrigins manually.
-        if (!origins.length && (!corsOrigin || corsOrigin === '*')) {
+        //
+        // NON-PRODUCTION ONLY (#10366). This substitution is a development
+        // convenience and is now gated on the same `NODE_ENV` dev signal used
+        // by the fallback auth secret and the dev Origin synthesis below, so
+        // the boundary this comment claims is the boundary that is enforced.
+        // Previously the condition tested only emptiness, so a production
+        // deployment whose trusted-origin list resolved empty silently
+        // CSRF-trusted every `localhost` / `*.localhost` origin.
+        //
+        // What production gets instead: `trustedOrigins` is omitted from the
+        // better-auth config entirely (see the tail of this block). That is
+        // NOT an absent policy — better-auth seeds its trusted set from the
+        // resolved `baseURL` origin and treats `trustedOrigins` as purely
+        // ADDITIVE, so an empty list and an omitted key are equivalent and
+        // both leave exactly the deployment's own origin trusted; every other
+        // origin is refused with `403 INVALID_ORIGIN`. Measured against
+        // better-auth 1.7.1 (`getTrustedOrigins` in `dist/context/helpers.mjs`,
+        // `validateOrigin` in `dist/api/middlewares/origin-check.mjs`).
+        if (
+          process.env.NODE_ENV !== 'production' &&
+          !origins.length && (!corsOrigin || corsOrigin === '*')
+        ) {
           origins.push('http://localhost:*');
           origins.push('http://*.localhost:*');
           origins.push('https://*.localhost:*');


### PR DESCRIPTION
Fixes #10366

Implements the maintainer ruling of 2026-08-22 (Option A — non-production only), verbatim.

## What changed

`packages/plugins/plugin-auth/src/auth-manager.ts` — the `trustedOrigins` block substituted a localhost wildcard trio whenever the resolved origin list came out empty and `OS_CORS_ORIGIN` was unset or `*`. Its own comment called this a development convenience, but the condition carried no `NODE_ENV` term, no dev-mode term, nothing — it tested only emptiness. The declared boundary and the enforced boundary disagreed, and only the declared one was visible in the file.

The substitution is now gated on the ruling's literal predicate, `NODE_ENV !== 'production'`.

**Property enforced: a development convenience exists only outside production.**

### Predicate spelling — chosen, not invented

This file already contains several spellings of the environment test: `!== 'production'`, `=== 'production'`, `=== 'development'`, and a `!== 'production'` living inside an unrelated method rather than a reusable predicate. I enumerated them and added none. The form used here is the file's existing sibling-CSRF-gate spelling (the dev `Origin` synthesis), which is also the form used by the fallback-auth-secret gate on the same config-build path — proving `process` is available there without a `globalThis` guard.

Not hardened to `=== 'development'`: that is a **stricter** boundary than ruled and would break `test` and unset-`NODE_ENV` development flows. A pin now holds that line in both directions.

## Measured, not assumed: what production actually receives

The block's tail returns `trustedOrigins` **only when the computed list is non-empty**, and otherwise returns an object with no `trustedOrigins` key at all. So in production, once the trio is gated off and the list is empty, better-auth receives **no `trustedOrigins` key** — not an empty array. Those are different inputs, and the ruling's premise depended on the answer. It was unmeasured on the card. It is measured now.

Measured against the installed **better-auth 1.7.1**, by reading the resolver and by booting real instances:

- `getTrustedOrigins` (`dist/context/helpers.mjs`) **unconditionally seeds** the trusted set from the resolved `baseURL` origin, then treats `options.trustedOrigins` as purely **additive** (`trustedOrigins.push(...)`).
- Therefore an **omitted key and an empty array are equivalent** — confirmed by boot, identical outcomes on every probe.
- `validateOrigin` (`dist/api/middlewares/origin-check.mjs`) refuses anything unmatched with `403 INVALID_ORIGIN`.

Booted probe results (`500` = the origin check passed and reached the credential path against a schema-less memory adapter; `403` = refused):

| baseURL handed to better-auth | key | `tenant.localhost` | `evil.example.net` | own origin |
| --- | --- | --- | --- | --- |
| `https://app.example.com` | absent | 403 | 403 | 500 (trusted) |
| `https://app.example.com` | `[]` | 403 | 403 | 500 (trusted) |
| `https://app.example.com` | trio (today) | **500 (trusted)** | 403 | 500 (trusted) |

**The absent-key default is a refusal, not a permissive fallback.** It leaves exactly the deployment's own origin trusted. The ruling's assumption holds, and no sentinel value, synthesized origin or forced empty array was needed — each of those would have been a different trust surface and a different decision.

### A correction to the card's reachability read

The severity read predicted that in the bare-host shape (`OS_AUTH_URL` set to a host with no scheme) the deployment's real origin would still be refused. Measured, it is not: `getCanonicalOrigin` repairs the bare host by prepending the scheme, and that repaired value is what `auth-manager.ts` hands better-auth as `baseURL`, which better-auth then seeds into its trusted set. So in the bare-host shape the real origin is **already** trusted today; the defect there is only the *extra* trio. This change removes the extra without touching the real origin.

The two empty-list causes compose as follows in production after this change:

- bare host — accept set becomes the deployment's real origin. Strictly better than today.
- empty string — `getCanonicalOrigin` falls back to its `http://localhost:3000` default, so the accept set becomes that. Still a refusal for the trio and for the real origin; the operator's remedy is to set `OS_TRUSTED_ORIGINS` or fix the base URL. PR #10369's boot diagnostic already names that condition at startup for both causes, and is not duplicated here.

## Pins

Both existing tests keep their dev-only assertions **verbatim** — untouched. New pins added alongside:

- production, no key provided ⇒ `trustedOrigins` absent from the config (asserted as key-absent, not merely `undefined`)
- production, empty array provided ⇒ same
- non-production still substitutes, under `development`, under `test`, and with `NODE_ENV` unset
- **load-bearing:** in production an explicitly configured `trustedOrigins` and an `OS_CORS_ORIGIN`-derived list are forwarded **unchanged**. Without these two legs, a change that broke all origin trust in production would pass a substitution-only suite.
- **SSO shape:** when the SSO RP is wired the block returns `trustedOrigins` as a per-request async function built from a copy of the same `origins` array, so gating the push at the source covers both shapes. That is true today and is exactly what a future refactor breaks silently — pinned in both directions (production: trio absent from what the function returns; non-production: trio present).

## Verification

Ablation with the signature predicted **in writing before running**: removing the gate reddens exactly three cases — the two production-omission pins and the SSO production pin — while both load-bearing legs and every non-production leg stay green. Observed: exactly those three, `3 failed | 6 passed`. Restore proved byte-identical by `git hash-object` (`d6bdba96…` before and after) and re-run to a real green verdict.

The ablation also settles `src` vs `dist`: the test imports `AuthManager` by **relative path** with no vitest alias, so it resolves package source. Held falsifiable — a src-only edit with **no rebuild** flipped the verdict, which could not happen if the suite read `dist`.

Gate union derived on the final commit `26a89671`, clean tree, `dispatch-gates.mjs` with **no path arguments** (exit 0, 3 paths vs merge base `24043c290`). All 11 path-matched and 5 convention-triggered gates run to real verdicts, exit 0, each read from the gate's own printed verdict line rather than a pipe status. `check:type-check-debt --re-measure` was run against a **built** workspace closure — plugin-auth's TEST_DEBT ceiling is 109 and tsc now reports 97, so the new test code adds zero type errors. That 12-error surplus is pre-existing and already tracked in #6376; not touched here, and no baseline was written.

Note: this package's `tsconfig.json` excludes `**/*.test.ts`, so the new pins are invisible to its own `typecheck`. They were typechecked explicitly via a test-inclusive tsc program — zero errors in the added range.

## Scope

Out of scope and deliberately untouched: the `''`-coalescing question (parked), PR #10369's boot diagnostic (not duplicated), and `cloud` (outside this session's repo scope — triage already recorded that its per-project factory builds the list explicitly and passes `undefined` rather than relying on this fallback, so the cloud production path does not depend on the trio). No `packages/spec` change was needed.

**Declared residual, filed not fixed:** with `NODE_ENV` unset, `undefined !== 'production'` is true, so an `os serve` deployment that never sets it still receives the trio. The ruling's literal text governs, so it is implemented as ruled and the gap is recorded in #11113 rather than silently tightened. Measured while filing: `os start` already forces `NODE_ENV=production` when unset (`start.ts:347`); `os serve` does not.

Every line number in this PR was re-derived in the worktree; the ones on the card and its comments are stale.

## Review state

⚠️ This changes the runtime **accept set** (Clause-② confirmed). `needs:contract-review` remains on #10366. This PR **stays draft** — not marked ready, auto-merge not armed, not merged, and the label not cleared by me.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnJHU45vPJj5UQrxe946Bx)_