### PR TITLE
fix(hooks): guard-main-checkout-bash reads shell comments as text, not commands

### DIFF
--- a/.claude/hooks/guard-main-checkout-bash.selftest.sh
+++ b/.claude/hooks/guard-main-checkout-bash.selftest.sh
@@ -170,6 +170,35 @@ expect allow 'grep -rn "he said \"sed -i\" once" .claude/'
 expect block 'node -e "console.log(\"hi\")" > pkg/out.json'
 expect block 'sed -i "s/\"a\"/\"b\"/" pkg/x.ts'
 
+echo "== a shell COMMENT is text, not a command (#10570) =="
+CWD="$MAIN"
+# The measured false blocks: prose in a comment put a real `>` in operator position and the
+# next word was named as a write target. Nothing in either command writes anything.
+expect allow "$(printf '# rename foo -> bar\necho hello\n')"
+expect allow "$(printf '# sitting 1 landed; card stays open for sitting 2 -> pm:dispatched goes, pm:queue returns\ncurl -s https://example.com/a\ncurl -s https://example.com/b\n')"
+expect allow 'echo hi   # then; tee pkg/x.ts would write it down'
+expect allow "$(printf '# step one; then a -> b\n# 2> is not a redirect here either\ngit status\n')"
+# Recall is untouched: a real redirect on a LATER line still blocks, and so does one on the
+# SAME line ahead of an inline comment.
+expect block "$(printf '# rename foo -> bar\necho x > pkg/x.ts\n')"
+expect block 'echo x > pkg/x.ts   # write it down'
+expect block "$(printf '# a comment; with a separator\nsed -i s/a/b/ pkg/x.ts\n')"
+# Word start is the whole rule: these `#`s are not comments and must not change a verdict.
+expect block 'touch foo#bar'
+expect block 'rm -rf pkg/x.ts#old'
+expect allow 'curl -s "https://example.com/docs#frag"'
+expect allow "curl -s https://example.com/docs#a-real-redirect-would-be > /dev/null"
+expect allow "grep -n '#' README.md"
+expect allow "sed 's/#//' README.md"
+expect allow 'echo "# not a comment > pkg/x.ts"'
+# `${x#y}` / `${#arr[@]}` — a parameter expansion, not a comment. Swallowing the line here
+# would drop the redirect behind it, so the negative twin is the load-bearing case.
+expect allow 'echo ${x#pkg/} '
+expect block 'echo ${#TOK[@]} > pkg/x.ts'
+expect block 'echo ${x#a} > pkg/x.ts'
+# an escaped `\#` outside quotes is a literal, not a comment opener
+expect allow 'echo \# not a comment'
+
 echo "== shapes this guard deliberately does NOT claim (documented fail-open) =="
 CWD="$MAIN"
 expect allow "bash -c \"sed -i s/a/b/ $MAIN/pkg/x.ts\""

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -61,6 +61,15 @@
 #      in that tail put a REAL ASCII `>` in operator position, so the guard named the
 #      following JS fragment as a write "target" and blocked a pure-read command (#10247).
 #      Single quotes take no escapes: inside '…' a backslash is literal, as in a real shell.
+#   4. shell COMMENTS are text, not commands — both quote-aware passes stop at an unquoted
+#      `#` that starts a WORD and resume at the next newline (#10570). A comment cannot
+#      write anything, so reading one as a command is a false BLOCK: prose arrows (`->`,
+#      `=>`) put a real `>` in operator position and the word after it was named as a write
+#      target, while a `;` in the same comment first split it into its own "segment".
+#      The word-start condition is the whole rule — `foo#bar`, `${x#y}`, `curl 'url/#frag'`,
+#      `sed 's/#//'` and `grep '#'` are NOT comments and are left exactly as they were. A
+#      comment never begins inside '…' or "…" (layer 1 owns those) nor inside a heredoc body
+#      (layer 2 has already dropped those lines before this pass runs).
 #
 # Redirection is recognised on ASCII operators ONLY — `>` `>>` `<` `<<` and their fd-prefixed
 # forms. No non-ASCII codepoint is ever an operator or an operator boundary, and this is
@@ -138,10 +147,19 @@ strip_heredocs() {
 
 # --- split the command into shell segments, honouring quotes ---------------------------
 # A separator inside '…' or "…" does NOT split, so writing *about* the ban is never caught
-# by the ban.
+# by the ban. The same goes for a separator inside a COMMENT: `word` tracks whether the
+# next character would open a new WORD, which is the only position where an unquoted `#`
+# begins a comment — the comment then runs to the next newline and never splits, tokenises
+# or contributes a target (#10570).
+#
+# What resets `word` is exactly what delimits a word in the shell: start of input, blank,
+# and the metacharacters `; | & ( ) newline > <`. `{` and `}` do NOT — they are reserved
+# words rather than metacharacters, so `#` right after one continues the word. That is not
+# cosmetic: this pass splits on `{`/`}` anyway, and treating the `#` of `${#arr[@]}` as a
+# comment would swallow the rest of the line — including a real redirect behind it.
 segments=()
 split_segments() {
-  local s="$1" seg="" q="" ch i n=${#1}
+  local s="$1" seg="" q="" ch i n=${#1} word=0
   for ((i = 0; i < n; i++)); do
     ch="${s:i:1}"
     if [ -n "$q" ]; then
@@ -156,9 +174,20 @@ split_segments() {
       continue
     fi
     case "$ch" in
-      "'" | '"') q="$ch" ; seg+="$ch" ;;
-      ';' | '|' | '&' | '(' | ')' | '{' | '}' | $'\n') segments+=("$seg") ; seg="" ;;
-      *) seg+="$ch" ;;
+      '#')
+        if [ "$word" = 0 ]; then
+          # comment: skip to (not past) the newline, which still separates as usual
+          while [ $((i + 1)) -lt "$n" ] && [ "${s:i+1:1}" != $'\n' ]; do i=$((i + 1)); done
+          continue
+        fi
+        seg+="$ch"                                   # foo#bar, ${x#y}, url/#frag
+        ;;
+      "'" | '"') q="$ch" ; seg+="$ch" ; word=1 ;;
+      ';' | '|' | '&' | '(' | ')' | $'\n') segments+=("$seg") ; seg="" ; word=0 ;;
+      '{' | '}') segments+=("$seg") ; seg="" ; word=1 ;;
+      ' ' | $'\t') seg+="$ch" ; word=0 ;;
+      '>' | '<') seg+="$ch" ; word=0 ;;
+      *) seg+="$ch" ; word=1 ;;
     esac
   done
   segments+=("$seg")
@@ -168,6 +197,9 @@ split_segments() {
 # The whole argument list matters here, and `read -r -a` would promote a QUOTED ">" or
 # "sed -i" to a real operator/command — exactly the false positive that makes a guard get
 # disabled. So: quotes are stripped and their contents are inert.
+# A comment is inert here too: `have` is already the "a word is open" flag, so an unquoted
+# `#` with have=0 is at word start and begins a comment (#10570). `foo#bar` and `${x#y}`
+# reach this point with have=1 and stay part of the token.
 # TOK[] = token values (unquoted); TOP[] = "op" for an unquoted redirection operator.
 TOK=(); TOP=()
 tokenize() {
@@ -187,6 +219,14 @@ tokenize() {
       continue
     fi
     case "$ch" in
+      '#')
+        if [ "$have" = 0 ]; then
+          # word-start `#`: comment, inert to the next newline
+          while [ $((i + 1)) -lt "$n" ] && [ "${s:i+1:1}" != $'\n' ]; do i=$((i + 1)); done
+          continue
+        fi
+        tok+="$ch"
+        ;;
       "'" | '"') q="$ch" ; have=1 ;;
       '\')
         i=$((i + 1))


### PR DESCRIPTION
Fixes #10570

Both quote-aware passes of `.claude/hooks/guard-main-checkout-bash.sh` now apply the shell's comment rule: outside quotes and heredoc bodies, an unquoted `#` that starts a WORD begins a comment that runs to the next newline.

Everything here is verified at `5f520708c`, the final commit on this branch.

## The defect, reproduced before the fix

A comment cannot write anything, so reading one as a command is a false BLOCK — the fail-closed direction. Prose arrows put a real ASCII `>` in operator position and the following word was named as a write target; a `;` in the same comment first cut it into its own "segment".

```
$ python3 -c "import json; print(json.dumps({'cwd':'/home/user/objectstack','tool_input':{'command':'# rename foo -> bar\necho hello'}}))" \
    | bash .claude/hooks/guard-main-checkout-bash.sh
⛔ Blocked: this Bash command WRITES into the shared PRIMARY checkout, not a worktree.
   command: # rename foo -> bar
   target:  bar
hook-exit=2
```

The control — the same command without the comment line — exits 0. The measured `#10720` shape (a comment carrying both `;` and `->` ahead of pure-`curl` calls) reproduced identically, naming `pm:dispatched` as its target.

## What changed

- `split_segments()` gains a `word` flag: an unquoted `#` at word start skips to (not past) the newline, so a separator inside a comment never splits. What resets `word` is exactly what delimits a word in the shell — start of input, blank, and the metacharacters `; | & ( ) newline > <`.
- `{` and `}` deliberately do NOT reset it. They are reserved words, not metacharacters, so a `#` right after one continues the word. That is load-bearing rather than cosmetic: this pass splits on `{`/`}` anyway, and treating the `#` of `${#arr[@]}` as a comment would swallow the rest of the line — **including a real redirect behind it**. The self-test pins that negative twin.
- `tokenize()` gains the same rule, keyed on its existing `have` flag, which already means "a word is open".
- Header docblock gains layer 4 alongside the quote and heredoc layers it joins.

**Nothing changes about what the hook blocks once it has a real command.** The word-start condition is the whole rule: `foo#bar`, `${x#y}`, `curl 'url/#frag'`, `sed 's/#//'` and `grep '#'` are not comments and keep every verdict they had. Precision over recall, the hook's own yardstick, is what the fix serves — a comment was a shape the hook did not model yet claimed with false confidence.

## Self-test — extended in both directions

`.claude/hooks/guard-main-checkout-bash.selftest.sh`, per the hook header's own discipline. **82 cases before, 100 after; `100 passed, 0 failed`.** The 18 new cases:

- the two measured false blocks, verbatim, plus an inline-comment shape and a two-comment-line shape carrying `2>`;
- recall guards: a real redirect on a line AFTER a comment still blocks; a real redirect on the SAME line ahead of an inline comment still blocks; a `sed -i` after a comment carrying a `;` still blocks;
- non-comment `#` shapes, in both verdict directions: `touch foo#bar` and `rm -rf pkg/x.ts#old` still BLOCK, while a quoted `#`, a URL fragment, `sed 's/#//'` and an escaped backslash-`#` still allow;
- `${#TOK[@]}` and `${x#a}` ahead of a real redirect still BLOCK — the case that would go quiet if word state were reset by `{`.

## Reverse-verification (ablation)

Run from the committed state by a script whose `trap ... EXIT INT TERM` owns the restore (the restore call is spelled inline in the script; angle-bracket placeholders do not survive this text field). No build step is involved: the hook file **is** the artefact the payload runs against, so reaching disk is the whole proof chain, and it was proven rather than inferred from an editor's exit code.

| step | on-disk proof |
| --- | --- |
| pre-ablation | marker occurrences 3, word-start guard lines 2 |
| mutated | marker occurrences 0, guard lines 0, 20702 bytes to 18156 (delta -2546) — asserted, not assumed |
| restored (trap) | marker occurrences 3, guard lines 2, `git status --porcelain` on the hook: 0 lines |

Against the ablated hook the card's exact repro JSON blocks again (`hook-exit=2`, both shapes, with the control still 0) and the self-test reports `96 passed, 4 failed`.

Direction, as observed rather than as templated: exactly the 4 allow-direction comment cases flip; the 14 recall and non-comment cases stay green in both states. That is the expected asymmetry — the ablation removes only the false-block fix, so a case that blocks for reasons the fix never touched cannot flip. It also means those 14 are pins against future regression, not discriminators for this one.

## Gates

`node scripts/pm/dispatch-gates.mjs` with no hand-fed paths, derived at the final commit; all four families it named were run, each verdict line quoted from the gate itself, exit codes captured before any pipe.

- `✓ doc authoring guard: 389 files clean — no bare metadata literals.`
- `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 416 files / 1447 TS blocks judged clean by @objectstack/formula.` (self-test: `30 cases passed`)
- `✓ check-governed-merges --self-test: 119 assertions` — `RC_pm_governed=0`
- `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files`
- plus `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)` — any-edit family; a direct control-character scan over both changed files also returned no matches.

Repo-wide `pnpm lint` is CI's run. The narrowing here is a measurement, not a skip: eslint's own config supplies the population, and for both changed paths it reports `File ignored because no matching configuration was supplied` — 2 files, read from `--format json`. Invariance for untouched files: every `files:` glob in the flat config is a TS/JS extension list and a scan of the config for any shell population returns nothing (exit 1), so a diff made only of `.sh` files cannot move any other file's verdict.

## Out of scope, filed separately

The two sibling fail-opens measured while in this function pair are NOT touched here — both are unadjudicated, and both are the opposite (fail-open) direction from this card:

- an unquoted backslash still makes the two passes disagree (a command whose escaped double quote is followed by `; sed -i s/a/b/ pkg/x.ts` exits 0, while the same `sed -i` alone exits 2);
- a heredoc introducer named inside a comment makes `strip_heredocs()` swallow the following real write — confirmed pre-existing at `origin/main`, unchanged by this PR.

Governed surface: draft PR, human merge. `skip-changeset` — `.claude/hooks/**` publishes nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01MsbKEG4LtERSLaDrbehM3e)_