### PR TITLE
fix(rest): GET /meta/_drafts reads in the caller's org scope — closes the write-org/read-null split (#11087 layer 2)

### DIFF
--- a/.changeset/drafts-route-org-scope-11087.md
+++ b/.changeset/drafts-route-org-scope-11087.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/rest': patch
+---
+
+`GET /meta/_drafts` threads the caller's org into `listDrafts` (#11087) — read scope symmetric with the save route, so org-scoped drafts (saved by sessions carrying an active organization) appear in the pending-changes list alongside env-wide ones instead of being invisible to every package/pending surface.

--- a/packages/rest/src/rest-server-meta-org-scope-url-spelling.test.ts
+++ b/packages/rest/src/rest-server-meta-org-scope-url-spelling.test.ts
@@ -273,6 +273,19 @@ describe('#10340 the /meta doors decide org scope on the FOLDED type, not the ra
             });
             expect(requestFrom(b.listDrafts).type).toBe('translations');
         });
+
+        it('threads the CALLER org into GET /meta/_drafts — read scope symmetric with the save route (#11087)', async () => {
+            // A draft saved by a session carrying an active org lands in that
+            // org's overlay scope (`saveMetaItem`'s `organizationId:
+            // ctx?.tenantId`). Reading with NO org sees only env-wide rows
+            // (`getOverlayRepo(null)` → `organization_id IS NULL`), so every
+            // org-scoped draft was invisible to the pending-changes surfaces —
+            // the write-org/read-null split behind cloud#1593. The repository's
+            // own `$or` contract surfaces BOTH scopes once the org is threaded.
+            const b = boot(AUTHORIZED);
+            await b.drive('GET', `${META}/_drafts`, {});
+            expect(requestFrom(b.listDrafts).organizationId).toBe(ORG);
+        });
     });
 
     describe('what the fold deliberately does NOT touch', () => {

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -3950,9 +3950,24 @@ export class RestServer {
                         // [#6877] Both narrow the draft list to one package /
                         // one type; an array reached `listDrafts` untouched.
                         if (refuseRepeatedQueryParams(req, res, ['packageId', 'type'])) return;
+                        // [#11087] Read in the CALLER'S org scope, symmetric with
+                        // the save route (`saveMetaItem`'s `organizationId:
+                        // ctx?.tenantId`, below): a draft saved by a session
+                        // carrying an active org lands in that org's overlay
+                        // scope, and this route used to read with NO org —
+                        // `getOverlayRepo(null)` sees only env-wide
+                        // (`organization_id IS NULL`) rows, so every org-scoped
+                        // draft was invisible to the pending-changes surfaces
+                        // while single reads (which thread the ctx) and the
+                        // publisher (which resolves each draft's own scope)
+                        // saw it fine — the write-org/read-null split behind
+                        // cloud#1593. With the org threaded, the repository's
+                        // own `$or` contract surfaces BOTH the caller's org
+                        // overlay and env-wide drafts.
                         const result = await (p as any).listDrafts({
                             packageId: (req.query?.packageId as string | undefined) || undefined,
                             type: (req.query?.type as string | undefined) || undefined,
+                            organizationId: ctx?.tenantId ?? undefined,
                         });
                         res.json(result);
                     } catch (error: any) {


### PR DESCRIPTION
## What

The `_drafts` route threads `ctx?.tenantId` into `protocol.listDrafts` — symmetric with the save route's `organizationId: ctx?.tenantId`. `SysMetadataRepository.listDrafts`'s existing `$or` contract then surfaces BOTH the caller's org overlay and env-wide drafts.

## Why (live staging measurement, cloud#1593)

A view draft saved through the console landed `org=org_mt42…` (the session carries an active org), while `GET /meta/_drafts` read with NO org — `getOverlayRepo(null)` matches only `organization_id IS NULL` — so the draft was invisible to every pending-changes surface while the single read and the publisher (each threading its own scope) saw it fine. This is the second, orthogonal layer of #11087: layer 1 (merged, #11139) fixed the `package_id NULL` orphan; this fixes org-scope invisibility. Both are required before the pending-changes bar can count what a console session actually drafts.

## Tests

New pin in `rest-server-meta-org-scope-url-spelling.test.ts` (drafts read carries the caller org); suite file 12/12. Full `rest` package: 1681/1681 executed tests pass locally (39 file-level load failures are unbuilt-sibling-dist noise on the local rig — service-analytics/service-package dists absent — CI builds the graph).

Part of #11087 / cloud#1593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)