### PR TITLE
fix(objectql): log a contributed kind by its declared `id`, and report that the `kind` bucket IS reachable via `GET /metadata/:type`

### DIFF
--- a/.changeset/kind-registration-log-declared-id.md
+++ b/.changeset/kind-registration-log-declared-id.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/objectql": patch
+---
+
+Log a contributed metadata kind by its declared `id` (#10729). `registerApp()`
+emits one `'Registered Kind'` debug line per entry in a manifest's
+`contributes.kinds`, and that line read `kind.name || kind.type`:
+
+```ts
+this.logger.debug('Registered Kind', { kind: kind.name || kind.type, from: id });
+```
+
+`contributes.kinds` items declare neither field. The schema
+(`packages/spec/src/kernel/manifest.zod.ts`) says `{ id, globs, description? }`,
+and `SchemaRegistry.registerKind` types its parameter `{ id: string, globs: string[] }`
+— so the expression evaluated `undefined || undefined` and every conforming
+manifest logged `kind: undefined`. The line now reads `kind.id`.
+
+`id` rather than any other declared field because `registerKind` files the
+descriptor with `registerItem('kind', kind, 'id')`: `id` is simultaneously the
+only identifying field the schema declares and the exact key the item is stored
+under, so a reader of the log line can look the item back up with it. Kept
+undeclared aliases OUT rather than adding `?? kind.name` for old manifests —
+reading an undeclared alias in a consumer is the tolerance Prime Directive #12
+rejects, and no manifest in this repo authors the older shape.
+
+Behaviour change is confined to the text of one `debug`-level line; nothing
+branches on it. It is pinned by `engine-kind-registration-log.test.ts`, which
+asserts the logged value equals the key `registry.listItems('kind')` files the
+descriptor under — a debug field that silently goes `undefined` is exactly the
+class of defect that survives forever because nothing asserts on it.

--- a/packages/objectql/src/engine-kind-registration-log.test.ts
+++ b/packages/objectql/src/engine-kind-registration-log.test.ts
@@ -1,0 +1,108 @@
+/**
+ * [#10729] `contributes.kinds` — the registration site's debug line must name
+ * fields that EXIST.
+ *
+ * `registerApp()` logs one `'Registered Kind'` line per contributed kind. It
+ * used to read `kind.name || kind.type`, and `contributes.kinds` items declare
+ * neither: the schema (`packages/spec/src/kernel/manifest.zod.ts`) says
+ * `{ id, globs, description? }` and `SchemaRegistry.registerKind` types its
+ * parameter `{ id: string, globs: string[] }`. So the line evaluated
+ * `undefined || undefined` and logged `kind: undefined` for every conforming
+ * manifest — a defect with no failing test anywhere, because a debug field
+ * that silently goes `undefined` is invisible to everything except a human
+ * reading the log at the moment it matters.
+ *
+ * That is the whole reason this file exists. The fix is two tokens wide; the
+ * pin is the part that keeps it fixed.
+ *
+ * Why `id` and not something else: `registerKind` stores the descriptor with
+ * `registerItem('kind', kind, 'id')`, so `id` is simultaneously (a) the only
+ * identifying field the schema declares and (b) the exact key the item is
+ * filed under — which makes the log line and the registry answer the same
+ * question the same way. The second test pins the direction as well as the
+ * value: an off-spec manifest that DOES carry `name`/`type` must still be
+ * logged by `id`, because reading an undeclared alias in a consumer is the
+ * tolerance Prime Directive #12 rejects.
+ *
+ * Real engine, real `SchemaRegistry` — no doubles. The assertion is about
+ * what the registration seam actually does with a manifest, so a mocked
+ * registry would be asserting on the mock.
+ */
+import { describe, it, expect } from 'vitest';
+import { ObjectQL } from './engine';
+
+interface DebugLine { msg: string; meta: Record<string, unknown> | undefined }
+
+function engineWithRecordedDebug(): { engine: ObjectQL; lines: DebugLine[] } {
+  const lines: DebugLine[] = [];
+  const logger = {
+    debug: (msg: string, meta?: Record<string, unknown>) => { lines.push({ msg, meta }); },
+    info() {}, warn() {}, error() {},
+  };
+  return { engine: new ObjectQL({ logger } as any), lines };
+}
+
+const registeredKindLines = (lines: DebugLine[]): DebugLine[] =>
+  lines.filter((l) => l.msg === 'Registered Kind');
+
+describe('[#10729] contributes.kinds registration logging', () => {
+  it('names a conforming kind by its declared `id`, not by undeclared fields', () => {
+    const { engine, lines } = engineWithRecordedDebug();
+
+    engine.registerApp({
+      id: 'com.example.bi',
+      contributes: {
+        // Exactly the schema's shape — and exactly its own documented example
+        // ("Registering a BI plugin to handle *.report.ts").
+        kinds: [{ id: 'sys.bi.report', globs: ['**/*.report.ts'] }],
+      },
+    });
+
+    const logged = registeredKindLines(lines);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]!.meta).toEqual({ kind: 'sys.bi.report', from: 'com.example.bi' });
+
+    // The regression this pins is specifically `undefined`, so say so: a
+    // future edit that reintroduces an undeclared read fails HERE with a
+    // readable message rather than at the deep-equal above.
+    expect(logged[0]!.meta!.kind).toBeDefined();
+  });
+
+  it('logs the same key the registry files the descriptor under', () => {
+    const { engine, lines } = engineWithRecordedDebug();
+
+    engine.registerApp({
+      id: 'com.example.bi',
+      contributes: { kinds: [{ id: 'sys.bi.report', globs: ['**/*.report.ts'] }] },
+    });
+
+    // `registerKind` → `registerItem('kind', kind, 'id')`. The value in the log
+    // is only useful if it is the value you can look the item back up by, so
+    // assert the round trip rather than the string twice.
+    const stored = engine.registry.listItems<{ id: string }>('kind');
+    expect(stored.map((k) => k.id)).toContain(registeredKindLines(lines)[0]!.meta!.kind);
+  });
+
+  it('still logs `id` when an off-spec manifest carries `name`/`type`', () => {
+    const { engine, lines } = engineWithRecordedDebug();
+
+    engine.registerApp({
+      id: 'com.legacy.bi',
+      contributes: {
+        kinds: [{
+          id: 'sys.bi.report',
+          globs: ['**/*.report.ts'],
+          // Neither key is declared by the schema. They are what the old line
+          // reached for, so an author who copied an ancient example could put
+          // them here — and the log must NOT start preferring them again.
+          name: 'Report (undeclared)',
+          type: 'report (undeclared)',
+        }],
+      },
+    });
+
+    const logged = registeredKindLines(lines);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]!.meta).toEqual({ kind: 'sys.bi.report', from: 'com.legacy.bi' });
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -4500,7 +4500,16 @@ export class ObjectQL implements IObjectQLEngine {
           this.logger.debug('Registering kinds from manifest', { id, kindCount: manifest.contributes.kinds.length });
           for (const kind of manifest.contributes.kinds) {
             this._registry.registerKind(kind);
-            this.logger.debug('Registered Kind', { kind: kind.name || kind.type, from: id });
+            // [#10729] Name the kind by its declared `id`. `contributes.kinds`
+            // items are `{ id, globs, description? }` (`manifest.zod.ts`) and
+            // `registerKind` keys the item on `id` (`registerItem('kind', kind, 'id')`),
+            // so `id` is BOTH the only identifying field the schema declares and the
+            // exact key the item is stored under — a reader of this line can look the
+            // item straight back up. The previous `kind.name || kind.type` reached for
+            // two fields NEITHER shape declares, so every conforming manifest logged
+            // `kind: undefined`. Do not re-add those as a fallback: reading undeclared
+            // aliases here is the consumer-side tolerance Prime Directive #12 rejects.
+            this.logger.debug('Registered Kind', { kind: kind.id, from: id });
           }
        }
 


### PR DESCRIPTION
Fixes #10729

Two halves were dispatched. **Half ② is implemented here. Half ① is an investigation whose answer is reported, not acted on** — and it landed on the *reachable* branch of the fork, so no spec change is proposed and `packages/spec` is untouched.

---

## Half ② — the log line (implemented)

`ObjectQL.registerApp()` emits one `'Registered Kind'` debug line per entry in a manifest's `contributes.kinds`. It read two fields that do not exist:

```ts
// packages/objectql/src/engine.ts (before)
this.logger.debug('Registered Kind', { kind: kind.name || kind.type, from: id });
```

`contributes.kinds` items are declared `{ id, globs, description? }` (`packages/spec/src/kernel/manifest.zod.ts:327-331`) and `SchemaRegistry.registerKind` types its parameter `{ id: string, globs: string[] }` (`packages/objectql/src/registry.ts:3748`). Neither shape declares `name` or `type`, so the expression evaluated `undefined || undefined` and **every conforming manifest logged `kind: undefined`**.

The line now reads `kind.id`.

**Why `id`, specifically.** I read both the declared shape and the registration site's actual input before choosing. `registerKind` files the descriptor with `registerItem('kind', kind, 'id')` — so `id` is simultaneously (a) the only identifying field the schema declares and (b) the exact key the item is stored under. That makes the log line and `registry.listItems('kind')` name the item the same way, so a reader of the log can look the item straight back up. `globs` and `description` are neither identifying nor keys; `description` is optional besides.

**No `?? kind.name` fallback for older manifests.** Reading an undeclared alias in a consumer is precisely the tolerance Prime Directive #12 rejects, and it would fossilize the drifted shape as a second de-facto contract. Nothing in this repo authors the older shape (see the census below), so there is nothing to accommodate.

### Pinned

New `packages/objectql/src/engine-kind-registration-log.test.ts` — real engine, real `SchemaRegistry`, no doubles (the assertion is about what the registration seam does with a manifest, so a mocked registry would be asserting on the mock). Three cases:

1. a conforming manifest is logged by its declared `id`;
2. the logged value equals the key `registry.listItems('kind')` files the descriptor under — the round trip, not the string twice;
3. an **off-spec** manifest that *does* carry `name`/`type` is still logged by `id`, which pins the direction as well as the value.

A debug field that silently goes `undefined` is exactly the class of defect that survives forever because nothing asserts on it — that is why the two-token fix ships with a pin.

**Reverse verification** (fix committed first, then `git restore --source=origin/main -- packages/objectql/src/engine.ts`, pin left in place): all 3 cases go red, in the predicted direction —

```
AssertionError: expected { kind: undefined, …(1) } to deeply equal { kind: 'sys.bi.report', …(1) }
-   "kind": "sys.bi.report",
+   "kind": undefined,
```

and case 3 reproduces the drift itself: `+ "kind": "Report (undeclared)"`. Restored with `git checkout HEAD -- ...`; `git status --porcelain` clean.

---

## Half ① — the terminal-bucket question (investigated, NOT acted on)

> Is the `kind` bucket reachable through the generic `GET /metadata/:type` passthrough?

### Answer: YES — reachable. The bucket is not terminal.

Measured end to end against a real engine and the real `ObjectStackProtocolImplementation`, with the metadata store answering as an empty healthy store (a *missing* store makes `getMetaItems` answer 503 for every type alike, which would have told me nothing about routing):

```
PROBE-1 spelling boundary for "kind":
  canonicalMetaUrlType("kind")      = "kind"      (no fold)
  metaUrlSpellingRefusal("kind")    = null        (not refused)
PROBE-2 registry bucket directly (the dispatcher's registry fallback door):
  registry.listItems("kind") = [{"id":"sys.bi.report","globs":["**/*.report.ts"]}]
PROBE-3 protocol.getMetaItems({ type: "kind" })  (the GET /metadata/:type door):
  RESULT = {"type":"kind","items":[{"id":"sys.bi.report","globs":["**/*.report.ts"]}]}
PROBE-4 negative control — an unregistered type through the same door:
  RESULT = {"type":"nonexistent_bucket","items":[]}
PROBE-5 positive control — a declared-type misspelling through the same door:
  THREW code=INVALID_REQUEST status=400 "'objectes' is not a recognised spelling of metadata type 'object'"
```

PROBE-4 shows PROBE-3's non-empty result is the registry bucket rather than an echo of the request; PROBE-5 shows the boundary gate is live and simply does not refuse `kind`. That last part is by construction, not by luck: `metaUrlSpellingRefusal` refuses only a spelling whose singular is a type the platform itself **declares**, and `kind` is not declared (it is absent from `DEFAULT_METADATA_TYPE_REGISTRY`, hence from the generated `meta-url-data.generated.ts`). Its own docblock states the intent — "a plugin kind can therefore never be refused by it".

**The route reaches both of those doors**, and neither drops the payload:

- `packages/runtime/src/domains/meta.ts:745-749` — `protocol.getMetaItems({ type: typeOrName, ... })`, which at `packages/metadata-protocol/src/protocol.ts:5939` does `this.engine.registry.listItems(request.type, packageId)`. That is the same bucket `registerKind` writes into.
- `packages/runtime/src/domains/meta.ts:805` — the dispatcher's own fallback, `qlService.registry.listItems?.(typeOrName, packageId)`, reached when no protocol service is resolvable.
- `maskObjectSchemaList` returns its input unchanged for any type whose singular is not `object` (`meta.ts:160`), and `slimDocList` is a no-op for anything that is not `doc` (`meta.ts:64`).

**So `getAllKinds()`' zero callers are explained.** I re-derived that reading rather than taking it on faith: `git grep getAllKinds` over the tree returns exactly one hit, its own definition, while the positive control `getAllObjects` returns hits across `cli`, `client`, `metadata-protocol` and `objectql` — the query style reaches callers when callers exist. The typed accessor is unused **because the generic route reads the same bucket through `listItems('kind')` and bypasses it**, not because the value is unreadable. The card's framing ("registers into a terminal bucket") needs revising on that point.

### The part that is genuinely inert is `globs`, not the bucket

Reported for triage, deliberately **not** acted on:

- **`globs` has zero consumers.** Tree-wide, the only non-comment occurrences are the schema declaration, `registerKind`'s parameter type and `getAllKinds`' return type. Nothing reads `kind.globs`.
- **The capability the schema advertises is implemented — from a different source.** The schema says `contributes.kinds` "enables the system to parse and validate new file types … Example: Registering a BI plugin to handle `*.report.ts`". Glob-driven artifact discovery does exist, and it globs `filePatterns` off the metadata type registry (`packages/metadata/src/plugin.ts:847`), which `contributes.kinds` does **not** extend — stated outright in `packages/spec/src/kernel/metadata-plugin.zod.ts:56-61`.
- **No in-repo manifest authors `contributes.kinds` at all** — the only two occurrences are test fixtures (`packages/objectql/src/engine.test.ts:180`, `packages/spec/src/kernel/manifest.test.ts:180`).

So the honest disposition is *not* "dead bucket": the storage and read paths are live and generic, while the **documented behaviour** is declared-but-unenforced. That is a materially different question from the one the card framed, and its answer is an ADR-0049 enforce-or-remove judgement over an authorable spec surface — which is the spec lane's, not this PR's. Filing it is left to the PM, which reserved this card's spec-lane routing; a search of open issues found no existing card for the `globs` gap.

### What this PR deliberately does not do

`contributes.kinds` and `getAllKinds` are **not** retired, deprecated or removed here, under either branch of the fork. Deleting an unused method resembles the tidy-up arm of Prime Directive #10 and here it is not: the thing it feeds is an authorable spec surface, and removing one goes through ADR-0049 enforce-or-remove with a liveness ledger, never a lane PR. `packages/spec/**` is untouched — see the file list.

---

## Verification

All of the below on the pushed tree, `061901a07` (`git rev-parse --short HEAD` from the run itself; this is also the final commit).

| Check | Result |
|:--|:--|
| `pnpm --filter @objectstack/objectql test` | `Test Files 229 passed (229)` · `Tests 4049 passed (4049)` |
| new pin, targeted + verbose | `Test Files 1 passed (1)` · `Tests 3 passed (3)`, all three named in the reporter output |
| `pnpm --filter @objectstack/objectql typecheck` | exit 0 — `tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json` echoed, so not a zero-match silent pass |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`) | exit 0 in 103s — the whole population, no narrowing claimed |
| `pnpm check:type-check-debt` | `--re-measure: OK — 33 ledger entries re-measured, 1895 raw tsc errors, none above its recorded number` (run with the full workspace closure built, as it demands) |
| `check:engine-double-contract` | exit 0 — this PR's new test declares no engine double (it drives the real engine) |

The 14 path-matched gates were derived by `node scripts/pm/dispatch-gates.mjs` from the change set rather than recalled, then re-derived after the final commit; all 14 plus the 5 convention-triggered ones (new test file) exit 0: `check:changeset-gate-self-tests`, `check:durability-log-level`, `check:objectui-changeset`, `check:slot-lookup`, `check:stack-collection-maps`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-empty-changeset`, `check-engine-split-ratio`, `check-plugin-teardown-shape`, `check-affected-docs`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:type-check-coverage`, `check:nul-bytes`.

Behaviour change is confined to the text of one `debug`-level line; nothing branches on it. Changeset: `patch` on `@objectstack/objectql`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_