### PR TITLE
fix(core): the pre-injected job fallback must not fake capability — take `job` off the pre-injection list so scheduled reports actually run on ObjectKernel

### DIFF
--- a/.changeset/job-fallback-must-not-fake-capability.md
+++ b/.changeset/job-fallback-must-not-fake-capability.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/core': minor
+---
+
+`ObjectKernel` no longer pre-injects the in-memory `job` fallback for the `job` core-service slot — a fallback must not fake capability (#10746, maintainer ruling 2026-08-22). `createMemoryJob()`'s `schedule()` records a job and never fires it (it owns no timer), so pre-injecting it made every "prefer the platform job service, else own a timer" consumer take the job-service branch on a kernel without `@objectstack/service-job` and then silently never run: `plugin-reports` logged `dispatcher registered with job service` and dispatched nothing, ever.
+
+Behavior change, FROM → TO: on an `ObjectKernel` without a registered `job` service, `getService('job')` FROM resolving a non-scheduling in-memory registry TO throwing `Service 'job' not found`. Consumers' documented no-job-service paths take over (`plugin-reports` falls through to its own `setInterval` and scheduled reports actually dispatch; schedule triggers and declarative jobs warn loudly instead of scheduling into the void), and the kernel says the absence out loud at boot: `Core service missing, functionality may be degraded: job`.
+
+One-line fix if you relied on the old behavior: install `@objectstack/service-job` for real scheduling, or — if you deliberately want the manual-trigger in-memory registry — register it explicitly: `kernel.registerService('job', createMemoryJob())` (the factory is still exported from `@objectstack/core`).

--- a/content/docs/kernel/services-checklist.mdx
+++ b/content/docs/kernel/services-checklist.mdx
@@ -16,7 +16,7 @@ package catalog.
 
 The ObjectStack protocol defines **15 kernel services** registered via the `CoreServiceName` enum (v17 removed the never-implemented `graphql` entry and retired the never-filled `workflow` slot, #4451). Each service maps to a set of protocol methods governed by its per-domain contract (`DataProtocol`, `MetadataProtocol`, ...) — the transitional `ObjectStackProtocol` composition alias was dissolved in v17 (ADR-0076 D9); capability availability comes from the runtime discovery `services` registry.
 
-**Key architecture principle**: the kernel guarantees only **data** and **metadata**, and even those are filled by packages (`@objectstack/objectql`, `@objectstack/metadata`) rather than baked in — the kernel's own contribution is an in-memory fallback for the `core` slots that have one (`metadata`, `cache`, `queue`, `job`, `i18n` — **not** `auth`). Everything else — including **auth** and **automation** — is delivered by plugins. `@objectstack/objectql` is an example kernel implementation to get the basic API running; production kernels will be rebuilt as separate plugins.
+**Key architecture principle**: the kernel guarantees only **data** and **metadata**, and even those are filled by packages (`@objectstack/objectql`, `@objectstack/metadata`) rather than baked in — the kernel's own contribution is an in-memory fallback for the `core` slots that have one (`metadata`, `cache`, `queue`, `i18n` — **not** `auth`, and not `job`: an in-memory registry cannot fire a `schedule()`d job on its own, so pre-injecting one advertised a scheduler that never ran, and a fallback must not fake capability — #10746. The `job` slot stays empty, loudly, until `@objectstack/service-job` or an explicitly registered scheduler fills it). Everything else — including **auth** and **automation** — is delivered by plugins. `@objectstack/objectql` is an example kernel implementation to get the basic API running; production kernels will be rebuilt as separate plugins.
 
 <Callout type="info">
 **Legend**
@@ -79,7 +79,7 @@ The ObjectStack protocol defines **15 kernel services** registered via the `Core
 | 12 | **search** | `optional` | — | ❌ Nothing ships | — |
 | 13 | **cache** | `core` | — | ✅ Built-in (in-memory fallback) | `@objectstack/service-cache` |
 | 14 | **queue** | `core` | — | ✅ Built-in (in-memory fallback) | `@objectstack/service-queue` |
-| 15 | **job** | `core` | — | ✅ Built-in (in-memory fallback) | `@objectstack/service-job` |
+| 15 | **job** | `core` | — | ❌ Plugin Required (no pre-injected fallback since #10746 — with no job plugin, `getService('job')` throws and the boot warns) | `@objectstack/service-job` |
 
 <Callout type="info">
 The Provider column mirrors `CORE_SERVICE_PROVIDER` in
@@ -480,7 +480,7 @@ AppPlugin will:
 
 ## 11–15. Infrastructure Services
 
-`cache`, `queue`, and `job` are `core` services: like `i18n`, the kernel auto-injects an in-memory fallback when no plugin registers them (see `CORE_FALLBACK_FACTORIES` in `packages/core/src/fallbacks/`). The `optional` services (`storage`, `search`) stay disabled until a plugin provides them.
+`cache`, `queue`, and `job` are `core` services. For `cache` and `queue` — like `i18n` — the kernel auto-injects an in-memory fallback when no plugin registers them (see `CORE_FALLBACK_FACTORIES` in `packages/core/src/fallbacks/`). `job` is deliberately **not** on that list (#10746): an in-memory registry cannot fire a `schedule()`d job on its own, and a fallback must not fake capability — so with no job plugin installed, `getService('job')` throws, consumers take their documented no-scheduler paths (e.g. the reports dispatcher's own `setInterval`), and the boot warns `Core service missing, functionality may be degraded: job`. The `core` criticality itself is unchanged — it is exactly what makes the absence loud. Fill the slot with `@objectstack/service-job`, or register `createMemoryJob()` explicitly if a manual-`trigger()` registry is genuinely wanted. The `optional` services (`storage`, `search`) stay disabled until a plugin provides them.
 
 | Service | Description |
 |:--------|:------------|
@@ -488,7 +488,7 @@ AppPlugin will:
 | **search** | **Nothing ships.** `ISearchService` and the engine enum (`elasticsearch`, `meilisearch`, …) exist in `@objectstack/spec`, but no package implements the contract or registers the `search` slot, so `CORE_SERVICE_PROVIDER.search` is `null`. |
 | **cache** | General-purpose cache. In-memory fallback; memory or Redis adapter via `@objectstack/service-cache`. |
 | **queue** | Message queue. In-memory fallback; durable DB-backed adapter (`sys_job_queue`) via `@objectstack/service-queue` (no BullMQ/Redis adapter is shipped). |
-| **job** | Scheduled task execution via `@objectstack/service-job`. In-memory fallback; interval, cron, and DB-backed adapters with concurrency policy. |
+| **job** | Scheduled task execution via `@objectstack/service-job` — interval, cron, and DB-backed adapters with concurrency policy. No pre-injected fallback (#10746): install the plugin, or the slot stays empty and the boot says so. |
 
 ---
 

--- a/packages/core/src/fallbacks/fallbacks.test.ts
+++ b/packages/core/src/fallbacks/fallbacks.test.ts
@@ -7,8 +7,14 @@ import { CORE_FALLBACK_FACTORIES } from './index';
 import { readServiceSelfInfo } from '@objectstack/spec/api';
 
 describe('CORE_FALLBACK_FACTORIES', () => {
-    it('should have exactly 5 entries: metadata, cache, queue, job, i18n', () => {
-        expect(Object.keys(CORE_FALLBACK_FACTORIES)).toEqual(['metadata', 'cache', 'queue', 'job', 'i18n']);
+    // [#10746] `job` is deliberately OFF this list — a fallback must not fake
+    // capability (maintainer ruling 2026-08-22). `createMemoryJob().schedule()`
+    // records a job and never fires it, so pre-injecting it made consumers
+    // treat "a `job` service resolves" as "a working scheduler" and silently
+    // never run. The factory stays exported for deliberate, explicit use; the
+    // kernel must not hand it out as if it honoured `schedule()`.
+    it('should have exactly 4 entries: metadata, cache, queue, i18n — job deliberately absent (#10746)', () => {
+        expect(Object.keys(CORE_FALLBACK_FACTORIES)).toEqual(['metadata', 'cache', 'queue', 'i18n']);
     });
 
     // [#4058] Every kernel fallback must be readable through the ONE standard

--- a/packages/core/src/fallbacks/index.ts
+++ b/packages/core/src/fallbacks/index.ts
@@ -2,7 +2,6 @@
 
 import { createMemoryCache } from './memory-cache.js';
 import { createMemoryQueue } from './memory-queue.js';
-import { createMemoryJob } from './memory-job.js';
 import { createMemoryI18n } from './memory-i18n.js';
 import { createMemoryMetadata } from './memory-metadata.js';
 
@@ -18,13 +17,30 @@ export {
 
 /**
  * Map of core-criticality service names to their in-memory fallback factories.
- * Used by ObjectKernel.validateSystemRequirements() to auto-inject fallbacks
- * when no real plugin provides the service.
+ * This IS the kernel's pre-injection list: `ObjectKernel.preInjectCoreFallbacks()`
+ * registers an entry for every unprovided `core` service before Phase 2, and
+ * `validateSystemRequirements()` consults the same map as its final check.
+ *
+ * [#10746] `job` is deliberately ABSENT — a fallback must not fake capability
+ * (maintainer ruling 2026-08-22). `createMemoryJob()`'s `schedule()` records a
+ * job and never fires it, so pre-injecting it made every "prefer the platform
+ * job service, else own a timer" consumer take the job-service branch and then
+ * silently never run: `plugin-reports` logged `dispatcher registered with job
+ * service` and dispatched nothing, ever (measured: 0 reads of
+ * `sys_report_schedule` in 5600 ms with the success line present). With no
+ * entry here, `getService('job')` throws when no job plugin is installed,
+ * every consumer's documented no-job-service path becomes reachable (they all
+ * already run on `LiteKernel`, which injects no fallbacks), and the kernel
+ * says the absence out loud at boot: `validateSystemRequirements()` warns
+ * "Core service missing, functionality may be degraded: job". Do NOT re-add
+ * the entry to quiet that warning — install `@objectstack/service-job`, or
+ * register a real scheduler, instead. `createMemoryJob` stays exported below
+ * for embedders who deliberately want a manual-trigger job registry and have
+ * read its docblock.
  */
 export const CORE_FALLBACK_FACTORIES: Record<string, () => Record<string, any>> = {
   metadata: createMemoryMetadata,
   cache: createMemoryCache,
   queue: createMemoryQueue,
-  job:   createMemoryJob,
   i18n:  createMemoryI18n,
 };

--- a/packages/core/src/fallbacks/memory-job.ts
+++ b/packages/core/src/fallbacks/memory-job.ts
@@ -1,11 +1,15 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * In-memory job scheduler fallback.
+ * In-memory job registry — schedule/cancel/trigger bookkeeping with NO timer.
  *
- * Implements the IJobService contract with basic schedule/cancel/trigger
- * operations.  Used by ObjectKernel as an automatic fallback when no real
- * job plugin (e.g. Agenda / BullMQ) is registered.
+ * [#10746] NOT pre-injected by ObjectKernel any more (it used to be, via
+ * `CORE_FALLBACK_FACTORIES`): a fallback must not fake capability (maintainer
+ * ruling 2026-08-22). Advertising a `schedule()` that records and never fires
+ * made every "prefer the platform job service, else own a timer" consumer
+ * take the job-service branch and then silently never run. The export remains
+ * for embedders who deliberately want a manual-trigger job registry — e.g. in
+ * tests that drive handlers via `trigger()` — and have read this docblock.
  *
  * [#4058] `degraded` (ADR-0076 D12), with the missing half named in the
  * message rather than left for a deployer to discover: `trigger()` really runs

--- a/packages/core/src/kernel.test.ts
+++ b/packages/core/src/kernel.test.ts
@@ -1155,4 +1155,43 @@ describe('ObjectKernel', () => {
             await kernel.shutdown();
         });
     });
+
+    describe('Core fallback pre-injection (#10746)', () => {
+        // The suite-level kernel sets `skipSystemValidation: true`, which skips
+        // pre-injection entirely — this pin needs the real path, so it boots
+        // its own kernel with validation ON (the production default).
+        it('pre-injects the honest core fallbacks but NOT job — a fallback must not fake capability', async () => {
+            const k = new ObjectKernel({
+                logger: { level: 'error' },
+                gracefulShutdown: false,
+            });
+            // `data` is `required` criticality; provide it so bootstrap
+            // survives validateSystemRequirements().
+            const dataProvider: Plugin = {
+                name: 'test.data-provider',
+                version: '1.0.0',
+                init: async (ctx: PluginContext) => {
+                    ctx.registerService('data', { find: async () => [] });
+                },
+            };
+            await k.use(dataProvider);
+            await k.bootstrap();
+            try {
+                // The remaining core slots still pre-inject before Phase 2.
+                for (const slot of ['metadata', 'cache', 'queue', 'i18n']) {
+                    expect(k.getService(slot), `fallback for '${slot}'`).toBeDefined();
+                }
+                // `job` must NOT resolve: `createMemoryJob()`'s `schedule()`
+                // records a job and never fires it, so handing it out made
+                // every "prefer the platform job service" consumer schedule
+                // into the void while logging success (maintainer ruling
+                // 2026-08-22: declare only what you enforce). Absence is the
+                // honest answer — consumers' documented no-job-service paths
+                // (setInterval fallbacks, loud warns) take over.
+                expect(() => k.getService('job')).toThrow(/Service 'job' not found/);
+            } finally {
+                await k.shutdown();
+            }
+        });
+    });
 });

--- a/packages/objectql/src/protocol-discovery.test.ts
+++ b/packages/objectql/src/protocol-discovery.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
-import { createMemoryMetadata, CORE_FALLBACK_FACTORIES } from '@objectstack/core';
+import { createMemoryMetadata, createMemoryJob, CORE_FALLBACK_FACTORIES } from '@objectstack/core';
 import { ObjectQL } from './engine.js';
 
 describe('ObjectStackProtocolImplementation - Dynamic Service Discovery', () => {
@@ -232,7 +232,12 @@ describe('ObjectStackProtocolImplementation - Dynamic Service Discovery', () => 
   it('reports every CORE_FALLBACK_FACTORIES product as degraded, never available (#3898)', async () => {
     expect(Object.keys(CORE_FALLBACK_FACTORIES).length).toBeGreaterThan(0);
 
-    for (const [slot, factory] of Object.entries(CORE_FALLBACK_FACTORIES)) {
+    // [#10746] `job` came OFF the pre-injection list (a fallback must not
+    // fake capability), but `createMemoryJob` stays exported for deliberate
+    // registration — so its product stays in this gate's inventory: however
+    // it reaches a slot, discovery must never call it `available`.
+    const inventory = { ...CORE_FALLBACK_FACTORIES, job: createMemoryJob };
+    for (const [slot, factory] of Object.entries(inventory)) {
       const mockServices = new Map<string, any>();
       mockServices.set(slot, factory());
 
@@ -382,9 +387,13 @@ describe('ObjectStackProtocolImplementation - Dynamic Service Discovery', () => 
   });
 
   it('never advertises a route for a cache/queue/job fallback either (#4318)', async () => {
+    // [#10746] `job` is off the pre-injection map but stays explicitly
+    // registrable, so the slot keeps its fallback-occupant coverage here.
+    const factoryFor = (slot: string) =>
+      slot === 'job' ? createMemoryJob : CORE_FALLBACK_FACTORIES[slot];
     for (const slot of ['cache', 'queue', 'job']) {
       const mockServices = new Map<string, any>();
-      mockServices.set(slot, CORE_FALLBACK_FACTORIES[slot]());
+      mockServices.set(slot, factoryFor(slot)());
 
       protocol = new ObjectStackProtocolImplementation(engine, () => mockServices);
       const reported = (await protocol.getDiscovery()).services[slot];

--- a/packages/plugins/plugin-reports/src/dispatcher-runs-on-object-kernel.test.ts
+++ b/packages/plugins/plugin-reports/src/dispatcher-runs-on-object-kernel.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#10746] Scheduled reports must actually RUN on `ObjectKernel` — the kernel
+ * real deployments use — when no job plugin is installed.
+ *
+ * THE DEFECT THIS PINS. `ReportsServicePlugin.start()` prefers the platform
+ * job service and only falls through to its own `setInterval` when
+ * `ctx.getService('job')` yields nothing with a `schedule` method.
+ * `ObjectKernel.preInjectCoreFallbacks()` used to register `createMemoryJob()`
+ * for every unprovided `core` service before Phase 2 — and `createMemoryJob()`
+ * is honest in its own docblock that a `schedule()`d job NEVER fires on its
+ * own (its `schedule()` is `jobs.set(...)` and nothing else). So on an
+ * `ObjectKernel` without `@objectstack/service-job` the plugin logged
+ * `dispatcher registered with job service` and then dispatched nothing, ever:
+ * measured as 0 reads of `sys_report_schedule` in 5600 ms with the success
+ * line present. The `setInterval` branch the plugin's docblock offers as the
+ * single-kernel answer was dead code on the kernel real deployments use.
+ *
+ * THE REPAIR (maintainer ruling 2026-08-22, Option A — a fallback must not
+ * fake capability). `job` came off the kernel's pre-injection list
+ * (`CORE_FALLBACK_FACTORIES` in `@objectstack/core`), so `getService('job')`
+ * now throws when no job plugin is installed, the plugin's existing catch
+ * falls through to `setInterval`, and single-kernel deployments actually
+ * dispatch scheduled reports.
+ *
+ * WHY THIS FILE EXISTS BESIDE `plugin-shutdown-releases-dispatcher.test.ts`.
+ * That file pins RELEASE at shutdown, and its running-dispatcher leg runs on
+ * `LiteKernel` — which injects no fallbacks, so it could never see this
+ * defect. Nothing pinned that the dispatcher RUNS on `ObjectKernel`; that gap
+ * is exactly why the defect shipped invisibly. This pin is the acceptance
+ * evidence for the fix: same composition a real single-kernel deployment
+ * boots, no job plugin anywhere, and the poll traffic itself is the assertion.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import type { ObjectQL } from '@objectstack/objectql';
+import { SqlDriver } from '@objectstack/driver-sql';
+import type { IDataEngine } from '@objectstack/spec/contracts';
+import { ReportsServicePlugin } from './reports-plugin.js';
+
+/**
+ * The plugin floors its own interval at 5s (`Math.max(5_000, …)`), so this is
+ * the fastest REAL clock the dispatcher can be driven at.
+ */
+const DISPATCH_INTERVAL_MS = 5_000;
+/** Comfortably past one tick boundary, so a window that sees zero is silence. */
+const OBSERVE_MS = 5_600;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const openKernels: Array<{ shutdown(): Promise<void> }> = [];
+const openDrivers: Array<{ disconnect?: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  // Kernels first, drivers second: the kernel's own teardown still wants a
+  // live driver to drain against.
+  while (openKernels.length) {
+    try { await openKernels.pop()?.shutdown(); } catch { /* already stopped */ }
+  }
+  while (openDrivers.length) {
+    try { await openDrivers.pop()?.disconnect?.(); } catch { /* noop */ }
+  }
+});
+
+/**
+ * Installs the read counter on the engine instance the dispatcher captured at
+ * `kernel:ready` (`ctx.getService('objectql')` resolves to this same object),
+ * so the tally is of real `ReportService.dispatchDue()` traffic, not a
+ * stand-in.
+ */
+function countScheduleReads(engineHolder: { getService: <T>(n: string) => T }): () => number {
+  type EngineCall = (name: string, ...rest: unknown[]) => unknown;
+  const engine = engineHolder.getService<IDataEngine>('objectql') as unknown as
+    Record<'find', EngineCall>;
+  let reads = 0;
+  const orig = engine.find.bind(engine);
+  engine.find = (name: string, ...rest: unknown[]) => {
+    if (String(name) === 'sys_report_schedule') reads++;
+    return orig(name, ...rest);
+  };
+  return () => reads;
+}
+
+/** A real in-memory SQL driver, connected and registered on `engine`. */
+async function attachSqlite(objectql: any): Promise<void> {
+  const driver: any = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  await driver.connect();
+  objectql.registerDriver(driver, true);
+  openDrivers.push(driver);
+  await objectql.syncSchemas();
+}
+
+describe('#10746 the dispatcher RUNS on ObjectKernel with no job plugin', () => {
+  it(
+    'polls sys_report_schedule — the setInterval fallback is reachable on the production kernel',
+    { timeout: 60_000 },
+    async () => {
+      // The composition a real single-kernel deployment boots: ObjectKernel
+      // (NOT LiteKernel), the engine, the reports plugin — and no job plugin.
+      const kernel = new ObjectKernel({ logger: { level: 'silent' } });
+      openKernels.push(kernel);
+
+      await kernel.use(new ObjectQLPlugin());
+      await kernel.use(new ReportsServicePlugin({ dispatchIntervalMs: DISPATCH_INTERVAL_MS }));
+      await kernel.bootstrap();
+
+      await attachSqlite(kernel.getService<ObjectQL>('objectql'));
+      const scheduleReads = countScheduleReads(kernel as any);
+
+      await sleep(OBSERVE_MS);
+
+      // THE PIN. Before the fix this was 0 — the kernel pre-injected a `job`
+      // fallback whose `schedule()` recorded the dispatcher and never fired
+      // it, while the plugin logged success. One tick boundary has passed, so
+      // silence here is the defect, not timing.
+      expect(scheduleReads()).toBeGreaterThan(0);
+    },
+  );
+});

--- a/packages/runtime/src/http-dispatcher.test.ts
+++ b/packages/runtime/src/http-dispatcher.test.ts
@@ -3120,10 +3120,16 @@ describe('HttpDispatcher', () => {
         // shape, was test-invisible.
 
         it('reports every CORE_FALLBACK_FACTORIES product as degraded, never available (#3898)', async () => {
-            const { CORE_FALLBACK_FACTORIES } = await import('@objectstack/core');
+            const { CORE_FALLBACK_FACTORIES, createMemoryJob } = await import('@objectstack/core');
             expect(Object.keys(CORE_FALLBACK_FACTORIES).length).toBeGreaterThan(0);
 
-            for (const [slot, factory] of Object.entries(CORE_FALLBACK_FACTORIES)) {
+            // [#10746] `job` came OFF the pre-injection list (a fallback must
+            // not fake capability), but `createMemoryJob` stays exported for
+            // deliberate registration — so its product stays in THIS gate's
+            // inventory: however it reaches a slot, discovery must never call
+            // it `available`.
+            const inventory = { ...CORE_FALLBACK_FACTORIES, job: createMemoryJob };
+            for (const [slot, factory] of Object.entries(inventory)) {
                 const fallback = factory();
                 (kernel as any).getService = vi.fn().mockImplementation((n: string) => (n === slot ? fallback : null));
                 (kernel as any).services = new Map([[slot, fallback]]);
@@ -3164,12 +3170,17 @@ describe('HttpDispatcher', () => {
 
         it('answers the cache/queue/job slots identically to the metadata-protocol builder (#4318)', async () => {
             const { ObjectStackProtocolImplementation } = await import('@objectstack/metadata-protocol');
-            const { CORE_FALLBACK_FACTORIES } = await import('@objectstack/core');
+            const { CORE_FALLBACK_FACTORIES, createMemoryJob } = await import('@objectstack/core');
 
+            // [#10746] `job` is no longer ON the pre-injection map, but its
+            // factory stays exported and explicitly registrable, so the slot
+            // keeps both occupant shapes here.
+            const factoryFor = (slot: string) =>
+                slot === 'job' ? createMemoryJob : CORE_FALLBACK_FACTORIES[slot];
             for (const slot of ['cache', 'queue', 'job']) {
                 // Both shapes an occupant can take: a real (unmarked) service
-                // and the kernel's self-describing in-memory fallback.
-                for (const svc of [{}, CORE_FALLBACK_FACTORIES[slot]()]) {
+                // and the self-describing in-memory fallback.
+                for (const svc of [{}, factoryFor(slot)()]) {
                     (kernel as any).getService = vi.fn().mockImplementation((n: string) => (n === slot ? svc : null));
                     (kernel as any).services = new Map([[slot, svc]]);
 


### PR DESCRIPTION
Fixes #10746

Implements the maintainer ruling of 2026-08-22 (decision-inbox batch, 「接受所有」, this card = Option A): **a fallback must not fake capability** — the "declare only what you enforce" layering rule, explicitly rather than asking every plugin to consult the degraded health flag (Option B, declined by name; the 12:31Z triage note describing B is superseded per the 00:49Z precedence resolution).

## Which of the two ruled shapes, and why

The ruling allowed either a **loud refusal** from the fallback's `schedule()` or **`job` off the pre-injection list**. This PR takes `job` off the pre-injection list (`CORE_FALLBACK_FACTORIES` in `packages/core/src/fallbacks/index.ts` — the one map both `preInjectCoreFallbacks()` and `validateSystemRequirements()` consult; `ServiceRequirementDef` itself lives in `packages/spec`, off limits, and is untouched — `job` stays `core` criticality, which is what routes it into the loud missing-core-services warn). Reasons, in order of weight:

1. **A throwing `schedule()` only half-honors the rule.** `getService('job')` would still resolve, and every consumer that probes `typeof job.schedule === 'function'` (all five in this tree do) would still see the capability declared, failing only at call time. Removal deletes the false declaration at its root.
2. **Refusal leaves a husk.** The fallback's only other real verb, `trigger()`, runs handlers that arrive only via `schedule()` — with `schedule()` refusing, every remaining member is pointless, but the service still occupies the slot.
3. **Absence is the already-tested state.** Every production consumer of `getService('job')` has a modeled, documented no-job-service path, because they all run on `LiteKernel`, which injects no fallbacks: plugin-reports falls to its own `setInterval`; plugin-approvals goes SLA display-only; runtime app-plugin warns and skips declarative jobs; trigger-schedule / time-relative warn loudly; `rearmSuspendedWaitTimers` takes `IJobService | undefined` by signature. Verified by suite runs below — no consumer legitimately depends on `job` always resolving (boundary 2 fork not reached).
4. **Boot loudness comes free and at the ruled-correct level**: `validateSystemRequirements()` already warns `Core service missing, functionality may be degraded: job` plus the degraded-capabilities summary — a functional degradation at `warn`, per the AGENTS.md log-level rule.

`createMemoryJob` stays exported (public API, honest docblock, real manual-trigger use) for embedders who register it deliberately; its docblock and the map's now say why it is not pre-injected.

## Before / after on ObjectKernel (the acceptance evidence)

New pin `packages/plugins/plugin-reports/src/dispatcher-runs-on-object-kernel.test.ts` boots `ObjectKernel` + `ObjectQLPlugin` + `ReportsServicePlugin({ dispatchIntervalMs: 5000 })` with **no job plugin** and counts `engine.find('sys_report_schedule', …)` on the engine instance the plugin captured at `kernel:ready`, over a 5600 ms window (one guaranteed tick boundary):

- **Before (origin/main + pin only):** `AssertionError: expected 0 to be greater than 0` — **0 reads in 5600 ms**, with `dispatcher registered with job service` logged. The issue's measurement, reproduced.
- **After (this fix):** the pin is green — the plugin falls through to its `setInterval` branch and `sys_report_schedule` is polled (read count is asserted greater than 0 over the same window). Full plugin-reports suite: 5 files, 76/76 tests pass.

The existing `LiteKernel` pin from the teardown work deliberately does not substitute — it pins release-at-shutdown on the kernel real deployments do not use; that gap is why this defect was invisible. A core-side mechanism pin was also added (`kernel.test.ts`): a validation-on `ObjectKernel` boot pre-injects `metadata`/`cache`/`queue`/`i18n` but refuses `getService('job')`.

## Census 1 — the other four pre-injected fallbacks (report only, per the ruling)

Question: does any other `CORE_FALLBACK_FACTORIES` entry declare a capability it cannot honour?

**Verdict: no — `job` was structurally unique.** Its contract is the only one requiring *autonomous future action* (a timer firing on its own later), which a passive in-memory object cannot honour at all. The other four honour every accepted call at call time, in-process; their degradation is *scope* (process-local, non-durable, no cross-instance fan-out), declared via `__serviceInfo` and visible to the caller:

| fallback | primary verbs | honoured at call time? | notes |
|---|---|---|---|
| `createMemoryMetadata` | register/get/list | yes — everything registered is listable and readable back | no persistence, declared |
| `createMemoryCache` | get/set/delete + TTL | yes — stores, expires, true stats | process-local, declared |
| `createMemoryQueue` | publish/subscribe | yes — synchronous real delivery to real subscribers | near-miss examined: `getQueueSize()` answering 0 is a TRUE answer — synchronous delivery means nothing is ever buffered |
| `createMemoryI18n` | t/loadTranslations/locales | yes — really translates from loaded bundles | in-memory only, declared |

No same-shape defect; the class does not widen within the pre-injection list, so no separate card is needed for it.

## Census 2 — the consumer class the root fix repairs (zero consumer edits)

The issue's question 2 asked how wide the "prefer the platform job service, else own a timer" class is. Wider than plugin-reports — and **all of it is repaired by this one root change**, because each consumer's absence path now actually engages instead of scheduling into the void while logging success:

- `plugin-reports` — dispatcher: now reaches its `setInterval` branch (pinned here).
- `plugin-approvals` — SLA escalation clock: previously scheduled into the void (escalations silently never swept); now takes its documented "No `job` service → SLA stays display-only" path.
- `packages/runtime` app-plugin — declarative bundle jobs: previously counted `ok` against the fake; now warns `job service not registered — skipping declarative jobs`.
- `trigger-schedule` / `time-relative` trigger plugins: their `job service not available` startup warnings were unreachable (the fake resolved); now they print, and `ScheduleTrigger`'s per-flow `job service unavailable — flow not scheduled` warn engages.
- `service-automation` wait-timer re-arm: `rearmSuspendedWaitTimers` receives `undefined` (modeled in its signature) instead of a scheduler that swallows one-shot wake-ups.

No consumer code was touched; their suites were run as verification (below).

## Docs correction (second commit, `973336d6b` — requested by the PM after the docs-drift flag)

`content/docs/kernel/services-checklist.mdx` asserted in **four** places that the kernel pre-injects an in-memory `job` fallback — all four made false by this PR, and left standing they would re-create the exact defect one layer up, in the page users meet first. Corrected, in the page's voice, with `job`'s **`core` criticality explicitly unchanged** (it is what makes the absence loud):

1. The key-architecture principle's slot list — `job` now named beside `auth` as deliberately without a kernel fallback, with the one-line reason.
2. Service Overview row 15 — `✅ Built-in (in-memory fallback)` → `❌ Plugin Required`, with the throw-and-warn behavior.
3. The Infrastructure Services intro — `cache`/`queue` keep the fallback claim; `job` is called out as deliberately off `CORE_FALLBACK_FACTORIES`, with the remedy (install `@objectstack/service-job`, or register `createMemoryJob()` explicitly).
4. The infrastructure table's `job` row — fallback claim removed.

Flagged lines judged **still true** and left alone: the ⚠️ Framework legend (~25: generic marker definition for slots that have a fallback, names no `job`), the `i18n` fallback note (~31) and the i18n implementations row (~429: `i18n` stays pre-injected), the plugin-layer ASCII diagram (~54: lists `job` as plugin-delivered and claims no fallback — more accurate now, not less), and the scheduled-tasks provider row (~516: names `service-job`, no fallback claim). Swept the rest of hand-written `content/docs` for equally specific pre-injection claims about `job`: none (`packages.mdx:272` is about the queue service's DB-backed `sys_job_queue` adapter — true and unrelated).

## Verification

First commit `857b214d1` (all package suites and gates ran on that tree, each under the shared verify lock with `VERDICT command-exit 0`):

- Dependency closures built first, then: `@objectstack/core` test **895/895** · `@objectstack/plugin-reports` **76/76** (incl. the new pin) · `@objectstack/runtime` **2706/2706** · `@objectstack/objectql` **4049/4049** · `@objectstack/plugin-approvals` **565/565** · `@objectstack/trigger-schedule` **57/57** · `typecheck` green for plugin-reports / runtime / objectql (core is a DEBT-ledger package; its tsup DTS build passed)
- Derived gate set (`node scripts/pm/dispatch-gates.mjs`, no hand-fed paths): all exit 0. Key verdict lines: `check-adr-0087-registration: this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)` · `This diff introduces no major bump` · `check-engine-double-contract: OK — 384 pinned, 133 in the DEBT ledger, 2 exempt` · `check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured … none above its recorded number` · `check-nul-bytes: OK`
- Repo-wide `pnpm lint` (`eslint . --no-inline-config`): exit 0.

Final commit `973336d6b` (docs-only delta; gate set re-derived — the docs file pulls in additional families) — all green at that head: the docs gates (`check:doc-anchors`, `check:doc-authoring`, `check:docs-audit-scope`, `check:docs-redirects`, `check:published-readme-links`, `check:role-word`, `check-doc-frontmatter`, `check-affected-docs`), the spec liveness family (`check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs`), the lint-package doc gates with their own verdict lines (`✓ check:doc-formula-expressions … 9 @example(s) judged clean` · `✅ 26 ObjectSchema.create example(s) … carry an os validate-clean security posture`), the full cheap union re-run (changeset gates, nul-bytes, slot-lookup, etc.), and repo-wide `pnpm lint` again (exit 0, 1m36s under the lock). Declared narrowing for the two heavy re-runs at `973336d6b`: the package test suites and the `check:type-check-debt --re-measure` ratchet were **not** re-run there — `git diff --stat 857b214d1..HEAD` is exactly `content/docs/kernel/services-checklist.mdx | 8 ++++----` (1 file), no tsc program or vitest suite takes `.mdx` as input, and the `packages/` subtree is byte-identical to the tree those runs measured green.

- Updated pins, intent preserved: the map-shape test now pins `job`'s deliberate absence; the discovery-honesty inventory gates (runtime + objectql) keep the memory-job product in their iteration via the still-exported factory, so however it reaches a slot, discovery must never call it `available`.

## Changeset

`minor` for `@objectstack/core` (behavioral contract change on a composition seam; nothing authorable and no export changed — not a declared-breaking changeset, confirmed by the gate above). States FROM → TO and the one-line fix: install `@objectstack/service-job`, or register `createMemoryJob()` explicitly if the manual-trigger registry is genuinely wanted.

Out-of-scope finding filed while running gates: #11204 (trigger-record-change TEST_DEBT graduation candidate) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_