### PR TITLE
fix(service-datasource): refuse an importObject name override that violates the namespace prefix

### DIFF
--- a/.changeset/import-object-name-override-namespace-prefix.md
+++ b/.changeset/import-object-name-override-namespace-prefix.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/service-datasource": patch
+---
+
+`importObject` now refuses an explicit `opts.name` that violates the ADR-0028
+namespace-prefix rule (#11061). The override used to be taken verbatim
+(`opts.name ?? draft.name`) and persisted through `metadata.register('object',
+…)` — the one runtime write path no namespace gate looks at — so
+`POST /api/v1/datasources/:name/external/tables/:remote/import` with
+`{"name": "customers"}` minted an unprefixed federated object that
+`defineStack()` and the publish pre-flight would both have refused.
+
+The refusal answers `400 EXTERNAL_IMPORT_ERROR` (the family's registered
+ADR-0112 code, in the #8016 thrown-refusal shape) carrying
+`validateObjectNamespacePrefix`'s own actionable message — the same text the
+publish gate serves for the identical violation, e.g. `Object 'customers' is
+missing the package namespace prefix. Rename it to 'wh_customers' (namespace =
+'wh').` A compliant override (`wh_customers`), a `sys_*` platform-reserved
+name, and any override on a datasource whose package resolves no namespace are
+accepted exactly as before; the derived-name path (no `name` in the body) is
+unchanged.

--- a/packages/services/service-datasource/src/__tests__/external-datasource-service.test.ts
+++ b/packages/services/service-datasource/src/__tests__/external-datasource-service.test.ts
@@ -2,6 +2,10 @@
 
 import { describe, it, expect } from 'vitest';
 import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+// The prefix rule's ONE authored message source — refusal pins below compute
+// their expected text from it rather than copying strings, so the assertion
+// can never drift from the rule (#11061).
+import { validateObjectNamespacePrefix } from '@objectstack/spec/kernel';
 import {
   ExternalDatasourceService,
   type DatasourceLike,
@@ -216,6 +220,106 @@ describe('importObject', () => {
     const { svc, persisted } = makeImporter();
     await expect(svc.importObject('warehouse', 'ghost')).rejects.toThrow(/not found/);
     expect(persisted).toHaveLength(0);
+  });
+});
+
+/**
+ * ADR-0028 namespace prefix on the `opts.name` OVERRIDE path (#11061).
+ *
+ * The derived path resolves the datasource's package namespace and prefixes
+ * the generated name; `opts.name` used to be taken verbatim, so a caller could
+ * persist an unprefixed federated object through `metadata.register` — the one
+ * runtime write path with no namespace gate. The override now answers to the
+ * SAME rule (loud refusal — the publish pre-flight's treatment of the
+ * identical violation — never a silent rewrite).
+ *
+ * Refusal pins assert the ADR-0112 envelope declaration (`status` + `code`,
+ * the #8016 thrown-refusal shape) AND that nothing was persisted or
+ * introspected; the message is asserted byte-equal to
+ * `validateObjectNamespacePrefix`'s own return, computed — not copied — so the
+ * rule keeps exactly one authored message everywhere it fires.
+ */
+describe('importObject — namespace prefix on the name override (#11061)', () => {
+  function makeNamespacedImporter(namespace?: string) {
+    const persisted: Array<{ name: string; def: Record<string, unknown> }> = [];
+    let introspectCalls = 0;
+    const svc = new ExternalDatasourceService({
+      introspect: async () => {
+        introspectCalls += 1;
+        return warehouseSchema();
+      },
+      getDatasource: async () => ({ name: 'warehouse', schemaMode: 'external' }),
+      getObject: async () => undefined,
+      listObjects: async () => [],
+      persistObject: async (name, def) => { persisted.push({ name, def }); },
+      getNamespace: async () => namespace,
+    });
+    return { svc, persisted, introspectCalls: () => introspectCalls };
+  }
+
+  it('refuses an unprefixed override with the rule\'s own message — 400 EXTERNAL_IMPORT_ERROR, nothing persisted, nothing introspected', async () => {
+    const { svc, persisted, introspectCalls } = makeNamespacedImporter('wh');
+    const err = await svc.importObject('warehouse', 'fact_orders', { name: 'orders' }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { status?: number }).status).toBe(400);
+    expect((err as { code?: string }).code).toBe('EXTERNAL_IMPORT_ERROR');
+    // Byte-equal to the validator's own authored prescription — one rule, one
+    // message, at this gate and the publish gate alike.
+    expect((err as Error).message).toBe(validateObjectNamespacePrefix('orders', 'wh'));
+    expect((err as Error).message).toContain("Rename it to 'wh_orders'");
+    // The service was never persuaded: no persist, and no remote round trip —
+    // the verdict needs only the injected namespace read.
+    expect(persisted).toHaveLength(0);
+    expect(introspectCalls()).toBe(0);
+  });
+
+  it('refuses the legacy FQN form (ns__short) with the validator\'s legacy-form message', async () => {
+    const { svc, persisted } = makeNamespacedImporter('wh');
+    const err = await svc.importObject('warehouse', 'fact_orders', { name: 'wh__orders' }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { status?: number }).status).toBe(400);
+    expect((err as { code?: string }).code).toBe('EXTERNAL_IMPORT_ERROR');
+    expect((err as Error).message).toBe(validateObjectNamespacePrefix('wh__orders', 'wh'));
+    expect(persisted).toHaveLength(0);
+  });
+
+  it('accepts a compliant override verbatim — no double prefixing, persisted as asked', async () => {
+    const { svc, persisted } = makeNamespacedImporter('wh');
+    const result = await svc.importObject('warehouse', 'fact_orders', { name: 'wh_orders' });
+    expect(result.name).toBe('wh_orders');
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].name).toBe('wh_orders');
+  });
+
+  it('accepts a sys_* override — the platform-reserved carve-out every gate on this rule shares', async () => {
+    const { svc, persisted } = makeNamespacedImporter('wh');
+    const result = await svc.importObject('warehouse', 'fact_orders', { name: 'sys_orders' });
+    expect(result.name).toBe('sys_orders');
+    expect(persisted).toHaveLength(1);
+  });
+
+  it('skips the rule when no namespace resolves — an unprefixed override stays accepted (mirrors defineStack)', async () => {
+    const { svc, persisted } = makeNamespacedImporter(undefined);
+    const result = await svc.importObject('warehouse', 'fact_orders', { name: 'orders' });
+    expect(result.name).toBe('orders');
+    expect(persisted).toHaveLength(1);
+  });
+
+  it('treats a blank namespace as absent — same normalisation as the derived path', async () => {
+    const { svc, persisted } = makeNamespacedImporter('   ');
+    const result = await svc.importObject('warehouse', 'fact_orders', { name: 'orders' });
+    expect(result.name).toBe('orders');
+    expect(persisted).toHaveLength(1);
+  });
+
+  it('still prefixes the DERIVED name under a namespace when no override is passed', async () => {
+    const { svc, persisted } = makeNamespacedImporter('wh');
+    const result = await svc.importObject('warehouse', 'fact_orders');
+    expect(result.name).toBe('wh_fact_orders');
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].name).toBe('wh_fact_orders');
   });
 });
 

--- a/packages/services/service-datasource/src/external-datasource-service.ts
+++ b/packages/services/service-datasource/src/external-datasource-service.ts
@@ -298,6 +298,37 @@ function applyNamespacePrefix(objectName: string, namespace: string | undefined)
     : `${namespace}_${objectName}`;
 }
 
+/**
+ * The refusal `importObject` answers when an explicit `opts.name` violates the
+ * ADR-0028 namespace-prefix rule.
+ *
+ * REFUSED, never silently rewritten: the derived path above may prefix its own
+ * invention (`applyNamespacePrefix` adjusts a name the service itself derived),
+ * but an override is the caller's explicit input, and every other gate on this
+ * rule — `defineStack()` at compile time, the publish pre-flight at runtime
+ * (`NAMESPACE_PREFIX`) — refuses a violating name rather than editing it.
+ * Persisting a rewritten name behind a 201 would leave the caller holding a
+ * name that does not exist, which is worse than the 400 (and exactly the
+ * tolerant-consumer accommodation Prime Directive #12 forbids).
+ *
+ * `message` is `validateObjectNamespacePrefix`'s own authored text, verbatim —
+ * the same prescription the publish gate serves for the identical violation,
+ * so one rule keeps one message everywhere it fires.
+ *
+ * The throw carries its own `status`/`code` — the #8016 declaration shape
+ * (`resolveThrownHttpError` reads them): this is a *refusal*, not a fault.
+ * `EXTERNAL_IMPORT_ERROR` is the ledger's registered code for a refused
+ * federated import, and 400 + that code is also exactly what the REST import
+ * route answers for any `importObject` throw, so the declaration and the
+ * served envelope agree by construction.
+ */
+function importNameRefusedError(message: string): Error {
+  const err = new Error(message) as Error & { code?: string; status?: number };
+  err.code = 'EXTERNAL_IMPORT_ERROR';
+  err.status = 400;
+  return err;
+}
+
 /** snake_case → Title Case label. */
 function toLabel(name: string): string {
   return name
@@ -469,6 +500,24 @@ export class ExternalDatasourceService implements IExternalDatasourceService {
           `(datasource '${datasource}'). This deployment may be GitOps-only — ` +
           `use 'os datasource introspect' and commit the generated *.object.ts instead.`,
       );
+    }
+
+    // ADR-0028 invariant on the OVERRIDE path. The derived path below resolves
+    // the datasource's package namespace and prefixes the name it generates;
+    // `opts.name` used to be taken verbatim, so a caller could persist an
+    // unprefixed federated object through the one runtime write path no gate
+    // looks at (`metadata.register` applies no namespace check — the checks
+    // live at `defineStack()` and the publish pre-flight, and an imported
+    // object passes through neither). Same normalisation, same validator, so
+    // the override answers to exactly the rule the derived name already obeys;
+    // when no namespace resolves the rule is skipped, mirroring `defineStack`.
+    // Checked BEFORE the draft on purpose: the verdict needs only the injected
+    // namespace read, and a doomed request should not cost a live remote
+    // introspection round trip.
+    if (opts.name !== undefined) {
+      const namespace = normaliseNamespace(await this.config.getNamespace?.(datasource));
+      const violation = validateObjectNamespacePrefix(opts.name, namespace);
+      if (violation) throw importNameRefusedError(violation);
     }
 
     // Reuse the draft pipeline (type mapping, review notes, external binding).


### PR DESCRIPTION
Fixes #11061

## What

`ExternalDatasourceService.importObject` took `opts.name` verbatim (`opts.name ?? draft.name`) and persisted it through `metadata.register('object', ...)` — the one runtime write path no namespace gate looks at (`register` applies the register contract and the writability gate, nothing else; the prefix rule runs only at `defineStack()` and the publish pre-flight). A `POST /api/v1/datasources/:name/external/tables/:remote/import` body of `{"name": "customers"}` therefore minted an unprefixed federated object that the platform's own authoring and publish paths would both have refused. Reachability re-verified against this head: the route forwards the request body as opts unfiltered — now at `packages/rest/src/external-datasource-routes.ts:465` (the card's `:462` had drifted by three lines; same code).

Triage ruled (comment `5383472206`, binding): **invariant restore** — the prefix rule is the declared behavior; loud refusal or forced prefixing, implementer argues which in the PR. That argument follows.

## The choice: B (loud refusal), argued against A's cost

**A (force the prefix)** keeps every request succeeding, which is its whole appeal — no caller breaks today. But it succeeds by silently rewriting a name the caller explicitly asked for: the request says `customers`, the 201 says `wh_customers`, and nothing failed loudly. Every caller that recorded its requested name — an AI-authored script, a saved config, a follow-up read of `/api/v1/data/customers` — now holds a reference to an object that does not exist, and discovers it later, far from the cause. That is the tolerant-consumer accommodation Prime Directive #12 forbids: off-contract input accepted and adjusted downstream, fossilizing "any name works, the platform fixes it" into a de-facto second contract. It would also make this seam the only place in the tree where the prefix rule **edits** input rather than refusing it — `defineStack()` refuses at compile time, the publish pre-flight refuses at runtime — a third behavior for one rule. (The derived path's `applyNamespacePrefix` is not a precedent for A: it adjusts a name the service itself invented; no caller intent is overridden there.)

**B's cost, engaged honestly:** a request that succeeds today returns 400 tomorrow. It is bounded three ways, all measured rather than assumed: the refusal takes an explicit `name` in the body (in-tree callers pass none — objectui's ImportObjectDialog posts no name, `os datasource introspect` does not import; the exposure is the raw route body), **and** a datasource whose owning package resolves a namespace, **and** a name that violates the rule — i.e. exactly the requests that were minting objects the platform's authoring path refuses. The 400 carries the rule's own prescription ("Rename it to 'wh_customers' (namespace = 'wh')"), so a broken caller — human or AI — self-corrects in one round trip. A silent rewrite hides the mistake where AI-generated metadata errors propagate; a loud refusal with the exact fix is the structurally safe failure. B also matches what the publish gate already does with the identical violation, keeping one rule at one behavior with one message everywhere it fires.

## Shape

- The gate runs in `importObject` **before** the draft is generated: it resolves the namespace through the same injected read and the same `normaliseNamespace` the derived path uses, and judges `opts.name` with `validateObjectNamespacePrefix` — the tree's single source of the rule. Fail-fast placement is deliberate: the verdict needs only the injected namespace read, so a doomed request does not cost a live remote introspection round trip (pinned: the refusal case asserts zero introspect calls).
- The refusal message is the validator's own authored text, **verbatim** — the same prescription the publish gate serves for this violation. No second dialect.
- The throw carries its own status and code — the #8016 thrown-refusal declaration shape, the same pattern as this package's `metadataIncompleteError`. Stated in prose because the body sanitizer eats short angle-bracket fragments: the helper returns a plain Error object whose `code` property is the string `EXTERNAL_IMPORT_ERROR` (the ADR-0112 ledger's registered code for a refused federated import) and whose `status` property is the number 400. The REST import route answers 400 + `EXTERNAL_IMPORT_ERROR` with the thrown message for every `importObject` throw (already pinned in `packages/rest/src/external-datasource-envelope.conformance.test.ts`, "an import the service refuses"), so the declared envelope and the served envelope agree by construction. Consequently `packages/rest/src/external-datasource-routes.ts` — permitted only if the shape required it — was **not touched**.
- No namespace resolvable, or a blank one: the rule is skipped and the override is accepted, exactly as the derived path and `defineStack()` behave. Nothing invents a prefix on the caller's behalf.
- `packages/spec` untouched (zero ownership in this lane; the fix did not need it — the validator was already exported). The `ImportObjectOpts.name` doc there still reads "Override the auto-derived object name (snake_case)", which remains true; the refusal semantics are documented at the service seam.

## Tests (7 new cases, both directions)

Refusal pins (ADR-0112: code + status, never a bare toThrow):
- unprefixed override under a namespace: rejects with status 400, code `EXTERNAL_IMPORT_ERROR`, message **byte-equal to the validator's own return** (computed via the imported validator, not a copied string), nothing persisted, nothing introspected;
- legacy FQN form (`wh__orders`): same envelope, the validator's legacy-form message.

Preservation pins:
- compliant override (`wh_orders`) accepted verbatim — no double prefixing;
- `sys_*` override accepted (the platform-reserved carve-out every gate on this rule shares);
- no namespace resolvable: unprefixed override stays accepted;
- blank namespace treated as absent (same normalisation as the derived path);
- derived path still prefixed under a namespace when no override is passed (`wh_fact_orders`).

**Reverse verification, from the committed state:** stood the base (`dd84ddd796`) service file up in the fixed tree (mutation confirmed on disk by anchored grep: zero hits of the new helper), re-ran the suite — exactly the two refusal pins went red (import succeeded instead of refusing), all 568 others stayed green; restored from the branch commit (disk-confirmed), 570/570 green. Predicted direction, observed direction: match.

## Gates — derived union, measured at head `4a86656751`, clean tree

`node scripts/pm/dispatch-gates.mjs` (no hand-supplied paths; derivation header names this repo at `4a86656751`). All to real verdicts, exit codes captured before any pipe:

- `pnpm --filter @objectstack/service-datasource test` — "Test Files 26 passed (26) · Tests 570 passed (570)"
- `pnpm --filter @objectstack/service-datasource typecheck` — command-exit 0
- path-matched (12): `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias` ("72 packages with tests scanned... OK"), `check:type-source-resolution`, `check-adr-0087-registration` ("adds no declared-breaking changeset"), `check-changeset-no-major`, `check-ci-filter-parity`, `check-empty-changeset` ("1 declaring changeset(s) added"), `check-plugin-teardown-shape`, `docs-audit/check-affected-docs` — all exit 0
- convention-triggered by the new test code (6): `check:query-options-erasure`, `check:type-check-coverage` ("OK — 65/78 workspace packages type-checked"), `check:type-check-debt` after building the workspace closure ("--re-measure: OK — 33 ledger entr(ies) re-measured, none above its recorded number"), `check:engine-double-contract` ("OK — 384 pinned"), `check:cross-package-test-inputs` ("OK: 13 package(s) read outside themselves, all declared"), `check:where-matcher` — all exit 0
- standard clause: `check:nul-bytes` ("OK — scanned 6511 text file(s)... no raw ASCII control bytes")

The full repo farm runs in CI; local scope is the derived union above (declared narrowing: repo-wide scans belong to CI per lane policy).

## Contract review (clause-②)

This PR **is draft and stays draft**: it changes contract accept/reject behavior on a request the API accepts today, so it waits on a contract-review seat at tier. No ready-flip, no auto-merge, and `needs:contract-review` stays on the card — this lane cannot clear any of those.

## Out of scope, recorded

- Filed as #11237: `metadata.register('object', ...)` applies **no** namespace check at all — the wider question the card flagged; deliberately not widened into this PR. #11237 remains open for its own grading.
- #10962 lands in this same file and holds its place in the queue; the diff here is kept tight for it (one gate block + one helper + tests + changeset — 3 files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_