### PR TITLE
Move both `record:alert` gates onto the `has()`-guarded node `visibleWhen`, as a CEL envelope (#9167)

### DIFF
--- a/.changeset/record-alert-visiblewhen-migration.md
+++ b/.changeset/record-alert-visiblewhen-migration.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+Move both authored `record:alert` gates off `properties.visible` onto the
+component-node `visibleWhen`, `has()`-guarded (#9167) — the `sys_user` detail
+page's "Email not verified" banner, and the showcase Task Detail page's
+"Awaiting review" banner.
+
+`record:alert` is the one record component that declares a props-level
+`visible` predicate, but `PageComponentSchema.properties` is an opaque record:
+the bag is served verbatim, so a bare string in `visible` never reaches
+`ExpressionInputSchema` and is evaluated by the console's **legacy JS**
+evaluator. The node-level `visibleWhen` declared at `page.zod.ts:189` *is* an
+`ExpressionInputSchema`, so it normalizes to `{ dialect: 'cel', source }`
+before it is served and runs on CEL — the same engine, and the same `has()`
+semantics, every other predicate face was migrated to.
+
+Two properties of that move were measured in a real console at the pinned
+objectui SHA rather than reasoned about, and both are load-bearing:
+
+- The `visible` key is **deleted**, not left beside the new gate. A node
+  `visibleWhen` and `properties.visible` compose as **AND**, so keeping both
+  would leave the legacy predicate load-bearing and make the migration
+  cosmetic.
+- The `has()` guards are **mandatory**. On the CEL face an absent key is a
+  *fault*, and that face is fail-soft: unguarded, a stripped gate key logs
+  `[runtime] No such key: …` and leaves the banner permanently VISIBLE. The
+  guards are what make the migration safe rather than a regression.
+
+Behaviour for real users is unchanged in every polarity — a `todo` task hides
+the banner and an `in_review` task shows it; a verified user hides "Email not
+verified" and an unverified user viewing their own profile shows it. What
+changes is that a genuine fault is now **loud** (CEL names the missing key)
+instead of silently answering `false`, and that the two predicates now sit on
+the declared slot the platform teaches everywhere else.

--- a/.changeset/record-alert-visiblewhen-migration.md
+++ b/.changeset/record-alert-visiblewhen-migration.md
@@ -3,34 +3,42 @@
 ---
 
 Move both authored `record:alert` gates off `properties.visible` onto the
-component-node `visibleWhen`, `has()`-guarded (#9167) — the `sys_user` detail
-page's "Email not verified" banner, and the showcase Task Detail page's
-"Awaiting review" banner.
+component-node `visibleWhen`, `has()`-guarded and served as a CEL envelope
+(#9167) — the `sys_user` detail page's "Email not verified" banner, and the
+showcase Task Detail page's "Awaiting review" banner.
 
 `record:alert` is the one record component that declares a props-level
 `visible` predicate, but `PageComponentSchema.properties` is an opaque record:
 the bag is served verbatim, so a bare string in `visible` never reaches
 `ExpressionInputSchema` and is evaluated by the console's **legacy JS**
-evaluator. The node-level `visibleWhen` declared at `page.zod.ts:189` *is* an
-`ExpressionInputSchema`, so it normalizes to `{ dialect: 'cel', source }`
-before it is served and runs on CEL — the same engine, and the same `has()`
-semantics, every other predicate face was migrated to.
+evaluator, which has no `has()`. The node-level `visibleWhen` declared at
+`page.zod.ts:189` *is* an `ExpressionInputSchema`, so a page that goes through
+the spec's transform serves `{ dialect: 'cel', source }` and runs on CEL — the
+same engine, and the same `has()` semantics, every other predicate face was
+migrated to.
 
-Two properties of that move were measured in a real console at the pinned
-objectui SHA rather than reasoned about, and both are load-bearing:
+Three properties of that move were measured in a real console at the pinned
+objectui SHA rather than reasoned about, and all three are load-bearing:
 
 - The `visible` key is **deleted**, not left beside the new gate. A node
   `visibleWhen` and `properties.visible` compose as **AND**, so keeping both
   would leave the legacy predicate load-bearing and make the migration
   cosmetic.
 - The `has()` guards are **mandatory**. On the CEL face an absent key is a
-  *fault*, and that face is fail-soft: unguarded, a stripped gate key logs
-  `[runtime] No such key: …` and leaves the banner permanently VISIBLE. The
-  guards are what make the migration safe rather than a regression.
+  *fault*, and that face is fail-soft: measured, an unguarded gate with its key
+  stripped from the read left the banner VISIBLE, where the guarded gate hid
+  it.
+- On `sys_user` the predicate is authored through `P` so it reaches the wire as
+  a CEL **envelope**. `SysUserDetailPage` is a raw `Page` object literal, so —
+  unlike a page built with `definePage()` — nothing normalizes it, and the
+  renderer keeps bare strings on the legacy path by design. Measured: the bare
+  form left "Email not verified" showing on *every* profile, including other
+  people's; the envelope restores every polarity.
 
-Behaviour for real users is unchanged in every polarity — a `todo` task hides
-the banner and an `in_review` task shows it; a verified user hides "Email not
-verified" and an unverified user viewing their own profile shows it. What
-changes is that a genuine fault is now **loud** (CEL names the missing key)
-instead of silently answering `false`, and that the two predicates now sit on
-the declared slot the platform teaches everywhere else.
+Behaviour for real users is unchanged in every polarity measured — a `todo`
+task hides the banner and an `in_review` task shows it; a verified user hides
+"Email not verified", an unverified user viewing their own profile shows it,
+and another user's profile shows nothing. What changes is that a genuine fault
+is now **loud** (CEL names the missing key) instead of silently answering
+`false`, and that both predicates sit on the declared slot the platform teaches
+everywhere else.

--- a/examples/app-showcase/src/ui/pages/task-detail.page.ts
+++ b/examples/app-showcase/src/ui/pages/task-detail.page.ts
@@ -8,7 +8,8 @@ import { definePage } from '@objectstack/spec/ui';
  *   • `record:path`        — Salesforce-style status stepper across the task
  *                            lifecycle (Backlog → … → Done).
  *   • `record:alert`       — a conditional banner shown only while the task is
- *                            In Review (demonstrates `visible` expressions).
+ *                            In Review (demonstrates the ADR-0089 component-node
+ *                            `visibleWhen` predicate, `has()`-guarded).
  *   • `record:quick_actions` — object Actions surfaced as inline buttons.
  *   • `record:highlights` + `record:details` — the standard compact + section
  *                            layout.
@@ -41,14 +42,27 @@ export const TaskDetailPage = definePage({
             ],
           },
         },
+        // The banner's gate is the ADR-0089 canonical, component-NODE
+        // `visibleWhen` — a sibling of `properties`, never a key inside it.
+        // `properties.visible` is declared on `record:alert` too, but the page
+        // metadata serves that bag verbatim (`properties` is an opaque record
+        // on `PageComponentSchema`), so a bare string there reaches the
+        // renderer's LEGACY JS evaluator, which has no `has()`. The node key is
+        // `ExpressionInputSchema`, normalized to `{ dialect: 'cel', source }`
+        // before it is served, so it runs on CEL — where an absent key is a
+        // FAULT and the surface is fail-soft, i.e. an unguarded predicate would
+        // leave this banner permanently shown. Hence the `has()` guard, and
+        // hence no `visible` beside it: a node `visibleWhen` and
+        // `properties.visible` compose as AND, so leaving both would keep the
+        // legacy predicate load-bearing.
         {
           type: 'record:alert',
+          visibleWhen: "has(record.status) && record.status == 'in_review'",
           properties: {
             severity: 'warning',
             icon: 'eye',
             title: 'Awaiting review',
             body: 'This task is in review — confirm the work before marking it done.',
-            visible: "record.status == 'in_review'",
             dismissible: true,
           },
         },

--- a/packages/platform-objects/src/pages/sys-user.page.ts
+++ b/packages/platform-objects/src/pages/sys-user.page.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+import { P } from '@objectstack/spec/shared';
 import type { Page } from '@objectstack/spec/ui';
 
 /**
@@ -59,23 +60,32 @@ export const SysUserDetailPage: Page = {
     alerts: [
       // The gate is the ADR-0089 canonical, component-NODE `visibleWhen` — a
       // sibling of `properties`, never a key inside it. `record:alert` also
-      // DECLARES `properties.visible`, but the page metadata serves that bag
-      // verbatim (`properties` is an opaque record on `PageComponentSchema`),
-      // so a bare string there reaches the renderer's LEGACY JS evaluator,
-      // which has no `has()`. The node key is `ExpressionInputSchema`,
-      // normalized to `{ dialect: 'cel', source }` before it is served, so it
-      // runs on CEL — where an absent key is a FAULT and the surface is
-      // fail-soft, i.e. an unguarded predicate would leave "Email not verified"
-      // permanently shown, even beside the page's own "Email Verified: Yes"
-      // chip. Hence the `has()` guards (the same shape the sibling
-      // `resend_verification_email` action predicate already carries), and
+      // DECLARES `properties.visible`, but `PageComponentSchema.properties` is
+      // an opaque record served verbatim, so a predicate there never reaches
+      // `ExpressionInputSchema` and is evaluated by the console's LEGACY JS
+      // evaluator, which has no `has()`.
+      //
+      // ⚠️ The envelope is load-bearing, and `P` is not decoration. This page is
+      // authored as a RAW `Page` object literal, so — unlike a page built with
+      // `definePage()` — nothing runs `ExpressionInputSchema`'s transform over
+      // it and whatever is written here reaches the wire verbatim. Measured in
+      // the real console at the pinned objectui SHA: a BARE string in
+      // `visibleWhen` also stays on that legacy evaluator ("bare strings and
+      // `${…}` templates stay on the legacy path … only an explicit
+      // `{ dialect: 'cel' }` envelope is rerouted"), so `has()` throws, the
+      // surface is fail-soft, and the banner shows on EVERY user — including
+      // other people's profiles. `P` emits the `{ dialect: 'cel', source }`
+      // envelope that routes to CEL, where `has()` is a real function.
+      //
+      // On CEL an absent key is a FAULT and that face is fail-soft too, hence
+      // the `has()` guards (the same shape the sibling
+      // `resend_verification_email` action predicate already carries). And
       // hence no `visible` beside it: a node `visibleWhen` and
       // `properties.visible` compose as AND, so leaving both would keep the
       // legacy predicate load-bearing.
       {
         type: 'record:alert',
-        visibleWhen:
-          'has(record.id) && has(record.email_verified) && record.id == ctx.user.id && record.email_verified == false',
+        visibleWhen: P`has(record.id) && has(record.email_verified) && record.id == ctx.user.id && record.email_verified == false`,
         properties: {
           severity: 'warning',
           icon: 'mail',

--- a/packages/platform-objects/src/pages/sys-user.page.ts
+++ b/packages/platform-objects/src/pages/sys-user.page.ts
@@ -57,8 +57,25 @@ export const SysUserDetailPage: Page = {
     // current user viewing their own profile (admins looking at other
     // users see nothing — they can use Setup actions instead).
     alerts: [
+      // The gate is the ADR-0089 canonical, component-NODE `visibleWhen` — a
+      // sibling of `properties`, never a key inside it. `record:alert` also
+      // DECLARES `properties.visible`, but the page metadata serves that bag
+      // verbatim (`properties` is an opaque record on `PageComponentSchema`),
+      // so a bare string there reaches the renderer's LEGACY JS evaluator,
+      // which has no `has()`. The node key is `ExpressionInputSchema`,
+      // normalized to `{ dialect: 'cel', source }` before it is served, so it
+      // runs on CEL — where an absent key is a FAULT and the surface is
+      // fail-soft, i.e. an unguarded predicate would leave "Email not verified"
+      // permanently shown, even beside the page's own "Email Verified: Yes"
+      // chip. Hence the `has()` guards (the same shape the sibling
+      // `resend_verification_email` action predicate already carries), and
+      // hence no `visible` beside it: a node `visibleWhen` and
+      // `properties.visible` compose as AND, so leaving both would keep the
+      // legacy predicate load-bearing.
       {
         type: 'record:alert',
+        visibleWhen:
+          'has(record.id) && has(record.email_verified) && record.id == ctx.user.id && record.email_verified == false',
         properties: {
           severity: 'warning',
           icon: 'mail',
@@ -76,7 +93,6 @@ export const SysUserDetailPage: Page = {
             'ja-JP': 'パスワードリセットや重要なシステム通知を受け取るには、メールアドレスを認証してください。',
             'es-ES': 'Verifica tu correo para recibir restablecimientos de contraseña y notificaciones importantes del sistema.',
           },
-          visible: 'record.id == ctx.user.id && record.email_verified == false',
           dismissible: false,
           action: {
             actionName: 'resend_verification_email',


### PR DESCRIPTION
Fixes #9167

Round 2 of #9167 — the implementation the [2026-08-23 measurement round](https://github.com/objectstack-ai/objectstack/issues/9167#issuecomment-5384484500) and the [PM ruling](https://github.com/objectstack-ai/objectstack/issues/9167#issuecomment-5384494104) below it produced. Steps 2–3 of the card's "What is owed" stay **retired**: they name `properties.visible`, whose evaluator has no `has()` and never will. This is the replacement remedy.

## What changed

On both `record:alert` pages, the predicate moves off `properties.visible` onto the component-node `visibleWhen`, `has()`-guarded, with the `visible` key **deleted in the same edit**:

| page | gate |
|:--|:--|
| `examples/app-showcase/src/ui/pages/task-detail.page.ts` | `visibleWhen: "has(record.status) && record.status == 'in_review'"` |
| `packages/platform-objects/src/pages/sys-user.page.ts` | ``visibleWhen: P`has(record.id) && has(record.email_verified) && record.id == ctx.user.id && record.email_verified == false` `` |

Both ruled conditions hold in the landed diff, and both are verifiable on the wire rather than only in the source: across the 34 pages this app serves, the two `record:alert` nodes carry `['properties','type','visibleWhen']` and **no** `properties.visible`; repo-wide, `properties.visible` now appears on **0** served nodes.

## ⚠️ The `P` on the platform page is not decoration — the first draft of it shipped the exact defect this card exists to prevent

The ruled string was authored literally, as a bare string, on both pages. **Measured, that broke the `sys_user` banner outright** — and the wire said why before the browser did:

| page | authoring form | `visibleWhen` on the wire |
|:--|:--|:--|
| `showcase_task_detail` | `definePage({…})` | `{"dialect":"cel","source":"has(record.status) && …"}` |
| `sys_user_detail` | raw `Page` object literal | `"has(record.id) && …"` — **bare** |

`SysUserDetailPage` is a raw typed object literal, so nothing runs `ExpressionInputSchema`'s transform over it and whatever is authored reaches the wire verbatim. And the console keeps bare strings on the **legacy JS evaluator** by design — `ExpressionEvaluator.evaluateCondition`, at the pin: *"Bare strings and `${…}` templates stay on the legacy path (back-compat deprecation window); only an explicit `{ dialect: 'cel' }` envelope is rerouted."* That evaluator has no `has()`, the surface is fail-soft, so the gate stopped gating.

Measured on the bare-string draft, in the real console:

| run | probe | verdict | expected |
|:--|:--|:--|:--|
| B2 | `sys_user` self, `email_verified` forced `true` (15 keys set) | **VISIBLE** | hidden ❌ |
| B3 | **another user's** record (control: that page's own title, `Ada Auditor`) | **VISIBLE** | hidden ❌ |

B3 is the decisive one: on someone else's profile `record.id == ctx.user.id` is plainly false, and the banner showed anyway — the predicate was not being consulted at all.

Isolated to the dialect envelope alone, on **one page, one predicate, one rewrite path** (`metaPatched=1` in both):

| run | probe | verdict |
|:--|:--|:--|
| P1 | `todo` task, node `visibleWhen` rewritten to the **bare string** | **VISIBLE** ❌ |
| P2 | `todo` task, node `visibleWhen` rewritten to the **envelope**, same source | hidden ✅ |

`P` (`@objectstack/spec/shared`) emits the `{ dialect: 'cel', source }` envelope. After the fix, **8 of 8** served `visibleWhen` values are envelopes and **0** are bare.

## After-state, measured in a real console

Framework built from this branch (`Tasks: 71 successful, 71 total`), console rebuilt from the repo's pin (`✓ @objectstack/console dist ready (49388 KB) from objectui@190fbd01d061`, bundle canary + spec-injection checks passed), `objectstack dev --ui --seed-admin -p 39167`, Playwright 1.62.1 driving `chromium-1194` from `PLAYWRIGHT_BROWSERS_PATH` via an `executablePath` override (⛔ `playwright install` not run). Every mutation is a **network-response rewrite** against the shipped bundle; the authored source is only ever what the server already serves.

**Both banners, both polarities, all correct**

| run | page / row | verdict | expected |
|:--|:--|:--|:--|
| A1 | task `in_review` | **VISIBLE** | VISIBLE ✅ |
| A2 | task `todo` | hidden | hidden ✅ |
| B1 | `sys_user` self, `email_verified=false` | **VISIBLE** | VISIBLE ✅ |
| B2 | `sys_user` self, `email_verified` forced `true` | hidden | hidden ✅ |
| B3 | another user's record | hidden | hidden ✅ |

**The guard actually holds — and is load-bearing**

| run | probe | verdict |
|:--|:--|:--|
| G1 | task `in_review`, `status` **stripped** from the read (6 keys removed), landed guarded gate | hidden ✅ |
| G2 | same run, gate swapped for the **unguarded** envelope (5 keys removed) | **VISIBLE** — the fault, fail-soft |
| G3 | `sys_user` self, `email_verified` **stripped** (2 keys removed), landed guarded gate | hidden ✅ |
| G4 | same run, **unguarded** envelope (2 keys removed) | **VISIBLE** |

G1↔G2 and G3↔G4 are the same page, the same record, the same strip — only the `has()` guard differs. That is condition (b) measured on the landed gate rather than inherited.

**No flash during load**

| run | probe | verdict |
|:--|:--|:--|
| I1 | `todo` task, landed gate, polled every 150 ms for 8 s (52 samples) | never visible — **no flash** |
| I2 | polling control: unmodified `in_review` task, same poll | hidden → VISIBLE at **1458 ms** — the poller does see banners |

## The census the measurement round could not do

The round-1 confidence gap: *whether any **other** page-block renderer also ignores or mis-binds `visibleWhen`.* Read at the pin, then cross-checked in the browser.

**Finding: `visibleWhen` is not a per-block concern at all.** It is enforced once, generically, in `packages/react/src/SchemaRenderer.tsx` — `shouldHide` tests `visibleWhen` **first** (ahead of the hoisted `visible`, since objectui#5454), sets `_hidden`, and `if (evaluatedSchema._hidden) return null` fires **before** the registry dispatches to any renderer. A block renderer cannot ignore the gate: it never sees the node. Every path that places an authored page-component node reaches it — `RegionContent` and `FlatContent` (`renderers/layout/page.tsx`), the slot→region synthesizer for record pages (`plugin-detail/src/synth/buildDefaultPageSchema.ts`, which folds `slots.alerts` / `highlights` / `details` / `tabs` / `discussion` into `components`), and every `page:*` container's children via `renderChildren` → `SchemaRenderer`. `toRenderableSchema` is a pass-through, so no key is lost on the way.

Cross-checked behaviourally on block types this card does not touch, each with a paired mount:

| run | block | gate | verdict |
|:--|:--|:--|:--|
| X1 / X2 | `record:path` (showcase task page) | `{cel,'false'}` / `{cel,'true'}` | vanishes / present ✅ |
| X3 / X4 | `record:highlights` (showcase task page) | `{cel,'false'}` / `{cel,'true'}` | vanishes / present ✅ |
| X5b / X6b | `record:highlights` (**platform** `sys_user` page) | `{cel,'false'}` / `{cel,'true'}` | vanishes / present ✅ |

⛔ Nothing was migrated on the strength of this census — a wider migration is a separate card.

**What the census did turn up, reported and not acted on:**

1. **One authored-node render path bypasses the gate.** `renderers/complex/data-table.tsx:1974` renders the `emptyAction` slot by resolving the registry directly — it calls `ComponentRegistry.get(node.type)` and renders the returned component with the node as its `schema` prop, never through `SchemaRenderer` — so a `visibleWhen` on that node is never evaluated. It is the only such bypass for authored nodes in the tree; the other direct-registry render (`action-bar.tsx:300`) is the ADR-0089 **action** face, which gates on `visible` inside `action-button`/`action-icon` by design.
2. **`page:tabs` item-level `visibleWhen` is a second evaluator, with a wider binding and no diagnostic.** `containers.tsx:449` builds its own `ExpressionEvaluator` that spreads the row flat **and** binds `data` to the row, where the node-level gate binds `data` to the data-source **adapter** — same key, opposite meanings — and it calls `evaluateCondition` without the dev `throwOnError` probe, so a faulting tab predicate is silent where a faulting node predicate warns.
3. **In a production console bundle the node gate's fault is entirely silent.** `evaluateVisibilityPredicate` short-circuits on `if (!__DEV__)`, so the bare-string breakage above produced **no console line at all** — unlike the `properties.visible` face, which logs from `record-alert.tsx`'s `useCondition` path regardless. Round 1's `"has" is not a function` lines came from that other face.
4. **The declared root list under-states what binds.** `page.zod.ts:189` names `record`, `current_user` and the page-variable root; `app-shell/src/providers/ExpressionProvider.tsx` puts `{ current_user, user, ctx: { user }, os: { user }, app, data, features }` into the scope — the ADR-0068 aliases. `ctx.user.id` in the ruled predicate is therefore a first-class binding, matching the sibling `resend_verification_email` action predicate on the same object, and measured working (B1/B2/B3).

## Verification

- `pnpm --filter @objectstack/platform-objects --filter @objectstack/example-showcase run test` → `Test Files 27 passed (27)` / `Tests 432 passed (432)` and `Test Files 25 passed (25)` / `Tests 367 passed (367)`.
- Same filter, `run typecheck` → `packages/platform-objects typecheck: Done`, `examples/app-showcase typecheck: Done`.
- `node scripts/pm/dispatch-gates.mjs` (no paths passed — it derives the change set itself) named 15 path-matched families plus the convention-triggered `pnpm check:i18n`. All 16 run, plus `pnpm check:nul-bytes`; **all exit 0**, verdict lines quoted in the report on the card.
- `pnpm lint` (repo-wide, `eslint . --no-inline-config`) reports `89 errors`, **all 89 inside `.cache/objectui-190fbd01d061/`** — the objectui clone `pnpm objectui:build` creates locally, gitignored at `.gitignore:42` and absent from a CI checkout. Measured rather than argued: `pnpm exec eslint . --no-inline-config --ignore-pattern '.cache/**'` exits **0 with no output**.
- Gate union run at the final commit, `3d812516a`.

## Notes for review

- **Both pages ship together.** They are one case, identical on every dimension the card measured; the correction "one case, not two" is on the card twice.
- **The showcase page is left on `definePage()`'s normalization rather than given an explicit `P`.** That transform is the contract, and it is measured working here (its node serves the envelope, A1/A2 correct). The platform page needs `P` precisely because it is *not* built that way.
- **Real-user behaviour is unchanged in every polarity measured.** The only difference is that a genuine fault becomes loud (CEL names the missing key) instead of silently answering `false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_