### PR TITLE
fix(publish-smoke): derive the tarball pin set from the publishable population, not a by-name exclusion

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -416,6 +416,16 @@ jobs:
       - name: Part-of closing-keyword guard self-test
         run: pnpm check:partof-closing-keyword
 
+      # Publish-smoke tarball pin-set self-test. The assertion it pins lives on
+      # the RELEASE path (scripts/publish-smoke-pack.mjs runs only inside the
+      # packed-tarball smoke), so without this step a regression in it would be
+      # discovered by a release candidate — which is exactly how the unscoped
+      # `create-objectstack` hole surfaced: as a red on the operator's own
+      # release run, not on the PR that opened it. Pure functions, synthetic
+      # fixtures, no pnpm/workspace/network; ~0.05s.
+      - name: Publish-smoke pin-set self-test
+        run: pnpm check:publish-smoke-pin
+
       # Single-claim path guard self-test (#9402). Same split as the step above
       # and for the same reason: the guard is a PR-scoped blocking check in its
       # own workflow, because its question is about OTHER open PRs and needs a

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -13,8 +13,9 @@
 #
 #   pack-smoke      SMOKE_MODE=pack — `pnpm pack` every publishable package
 #                   (pack applies the same manifest rewrites as publish),
-#                   scaffold a fresh project OUTSIDE the workspace, pin
-#                   @objectstack/* to the tarballs via the project's own pnpm
+#                   scaffold a fresh project OUTSIDE the workspace, pin every
+#                   publishable package — scoped and unscoped alike — to the
+#                   tarballs via the project's own pnpm
 #                   overrides, and smoke it. This is "what 15.1.0 would have
 #                   failed": the release-candidate combination, no workspace
 #                   overrides in sight.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "check:pm-half-states": "node scripts/pm/check-half-states.mjs --self-test",
     "check:pm-governed-merges": "node scripts/pm/check-governed-merges.mjs --self-test",
     "check:pm-governed-prose": "node scripts/pm/check-governed-prose.mjs --self-test && node scripts/pm/check-governed-prose.mjs",
+    "check:publish-smoke-pin": "node scripts/publish-smoke-pack.mjs --self-test",
     "check:partof-closing-keyword": "node scripts/check-partof-closing-keyword.mjs --self-test",
     "check:single-claim-paths": "node scripts/check-single-claim-paths.mjs --self-test",
     "check:pnpm-filter-targets": "node scripts/pnpm-filter-targets.mjs --self-test && node scripts/check-pnpm-filter-targets.mjs --self-test && node scripts/check-pnpm-filter-targets.mjs",

--- a/scripts/publish-smoke-pack.mjs
+++ b/scripts/publish-smoke-pack.mjs
@@ -16,6 +16,28 @@
  * Packing everything keeps the overrides map total — a package missing from
  * it would make the smoke project resolve that name from the npm registry,
  * silently testing a published version instead of the candidate one.
+ *
+ * THE SET IS THE PUBLISHABLE POPULATION — never a scope glob, never a hand
+ * list, never an exclusion. This script used to carve `create-objectstack`
+ * out by name, on the rationale that "no @objectstack/* manifest depends on
+ * it". That rationale expired the day `@objectstack/cli` took a dependency on
+ * the scaffolder: cli@17.2.0 declared `create-objectstack@17.2.0`, the name
+ * was neither packed nor pinned, pnpm fell back to the registry, and the
+ * release candidate's own smoke died on ERR_PNPM_NO_MATCHING_VERSION for a
+ * version that by definition does not exist yet — a chicken-and-egg red on
+ * every release candidate from that day on. The general shape of that bill:
+ * whether a workspace package is *reachable* from some other manifest is a
+ * fact about the dependency graph AT ONE MOMENT, and it is not the question
+ * this script gets to ask. Publishable is the question, `private !== true`
+ * is the answer, and `assertPinSetTotal` below re-checks it on every run so
+ * a future exclusion cannot re-open the hole silently.
+ *
+ * Source of truth: the workspace itself. The Changesets `fixed` group in
+ * .changeset/config.json enumerates the same 69 names, but it is a DERIVED
+ * declaration validated against the workspace by scripts/check-changeset-fixed.mjs
+ * (which reddens both when a public package is missing from the group and
+ * when a group name no longer exists) — deriving from the group would mean
+ * reading a copy that a gate keeps honest, rather than the thing itself.
  */
 
 import { execFile } from 'node:child_process';
@@ -23,22 +45,65 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 
+import { isEntrypoint } from './invoked-as.mjs';
+
 const execFileP = promisify(execFile);
 
-// Not consumed as npm dependencies by a scaffolded project:
-//   create-objectstack — the scaffolder itself; the smoke runs it straight
-//     from the repo's built bin, and no @objectstack/* manifest depends on it.
-const EXCLUDE = new Set(['create-objectstack']);
-
 const CONCURRENCY = 8;
+
+/**
+ * The publishable population: every workspace member npm would receive.
+ * No scope filter — `create-objectstack` is unscoped and publishable, and
+ * the next unscoped public package must land in the set on its own.
+ *
+ * @param {{name?: string, private?: boolean}[]} all workspace members
+ * @returns {{name: string}[]}
+ */
+export function selectPublishable(all) {
+  return all.filter((p) => p.name && p.private !== true);
+}
+
+/**
+ * The pin set MUST equal the publishable set, both directions. A hole in
+ * either direction makes the smoke test something other than the candidate:
+ * a missing pin resolves that name from the registry (the bill above), and a
+ * surplus pin points the smoke project at a tarball for a name npm will never
+ * publish. Both are reported BY NAME — "the map is incomplete" without the
+ * name is the diagnostic the release operator had to reverse-engineer.
+ *
+ * @param {string[]} pinned names present in the overrides map
+ * @param {string[]} publishable names of the publishable population
+ */
+export function assertPinSetTotal(pinned, publishable) {
+  const pinnedSet = new Set(pinned);
+  const publishableSet = new Set(publishable);
+  const missing = publishable.filter((n) => !pinnedSet.has(n)).sort();
+  const surplus = pinned.filter((n) => !publishableSet.has(n)).sort();
+  if (missing.length === 0 && surplus.length === 0) return;
+  const lines = ['tarball pin set != publishable set'];
+  if (missing.length > 0) {
+    lines.push(
+      `  publishable but NOT pinned (${missing.length}): ${missing.join(', ')}`,
+      '    → the smoke project would resolve these from the npm registry, so it',
+      '      would test PUBLISHED code, or die on a version not published yet.',
+    );
+  }
+  if (surplus.length > 0) {
+    lines.push(
+      `  pinned but NOT publishable (${surplus.length}): ${surplus.join(', ')}`,
+      '    → pinning a name npm will never publish; the smoke would pass on a',
+      '      resolution no real user can reproduce.',
+    );
+  }
+  throw new Error(lines.join('\n'));
+}
 
 async function listPublicPackages(repoRoot) {
   const { stdout } = await execFileP('pnpm', ['-r', 'list', '--depth', '-1', '--json'], {
     cwd: repoRoot,
     maxBuffer: 64 * 1024 * 1024,
   });
-  const all = JSON.parse(stdout);
-  return all.filter((p) => p.name && p.private !== true && !EXCLUDE.has(p.name));
+  return selectPublishable(JSON.parse(stdout));
 }
 
 async function packOne(pkg, destDir) {
@@ -89,6 +154,11 @@ async function main() {
   });
   await Promise.all(workers);
 
+  assertPinSetTotal(
+    Object.keys(overrides),
+    packages.map((p) => p.name),
+  );
+
   const sorted = Object.fromEntries(
     Object.entries(overrides).sort(([a], [b]) => a.localeCompare(b)),
   );
@@ -97,7 +167,92 @@ async function main() {
   console.log(`Wrote ${Object.keys(sorted).length} override(s) → ${outPath}`);
 }
 
-main().catch((err) => {
-  console.error(err.stack ?? String(err));
-  process.exit(1);
-});
+/**
+ * Self-test — runs without pnpm, a workspace, or a network. It pins the two
+ * properties the release smoke depends on, and both are ABLATION-CHECKED
+ * (2026-08-23): restoring `EXCLUDE = new Set(['create-objectstack'])` and
+ * filtering it out of `selectPublishable` turns case 1 red by name; deleting
+ * the `missing`/`surplus` branch of `assertPinSetTotal` turns cases 2/3 red.
+ *
+ * Case 1 is not "some package survives the filter" — it is specifically that
+ * an UNSCOPED public package does, because every form this defect has taken
+ * (a `@objectstack/*` scope glob in the pinning prose, a by-name exclusion in
+ * the derivation) is invisible to any fixture whose names all start with `@`.
+ */
+function selfTest() {
+  const cases = [];
+  const check = (name, fn) => {
+    try {
+      fn();
+      cases.push(`  ok — ${name}`);
+    } catch (err) {
+      cases.push(`  FAIL — ${name}\n      ${(err.message ?? String(err)).split('\n').join('\n      ')}`);
+      process.exitCode = 1;
+    }
+  };
+  const assert = (cond, msg) => {
+    if (!cond) throw new Error(msg);
+  };
+
+  check('an unscoped public package is in the derived set', () => {
+    const picked = selectPublishable([
+      { name: '@objectstack/cli', private: false },
+      { name: 'create-objectstack' }, // no `private` key at all — the real manifest
+      { name: '@objectstack/internal-fixtures', private: true },
+      { name: undefined },
+    ]).map((p) => p.name);
+    assert(
+      picked.includes('create-objectstack'),
+      `unscoped public package dropped from the set: ${JSON.stringify(picked)}`,
+    );
+    assert(
+      !picked.includes('@objectstack/internal-fixtures'),
+      'a private package leaked into the publishable set',
+    );
+    assert(picked.length === 2, `expected 2 publishable, got ${picked.length}`);
+  });
+
+  check('set == publishable set is accepted', () => {
+    assertPinSetTotal(['create-objectstack', '@objectstack/cli'], ['@objectstack/cli', 'create-objectstack']);
+  });
+
+  check('a MISSING member reddens, by name', () => {
+    let msg = '';
+    try {
+      assertPinSetTotal(['@objectstack/cli'], ['@objectstack/cli', 'create-objectstack']);
+    } catch (err) {
+      msg = err.message;
+    }
+    assert(msg !== '', 'a pin set missing a publishable member was accepted');
+    assert(
+      msg.includes('create-objectstack'),
+      `the diagnostic does not name the missing package: ${msg}`,
+    );
+  });
+
+  check('a SURPLUS member reddens, by name', () => {
+    let msg = '';
+    try {
+      assertPinSetTotal(['@objectstack/cli', '@objectstack/gone'], ['@objectstack/cli']);
+    } catch (err) {
+      msg = err.message;
+    }
+    assert(msg !== '', 'a pin set with a non-publishable member was accepted');
+    assert(msg.includes('@objectstack/gone'), `the diagnostic does not name the surplus package: ${msg}`);
+  });
+
+  console.log('publish-smoke-pack self-test');
+  for (const line of cases) console.log(line);
+  console.log(process.exitCode === 1 ? 'SELF-TEST FAILED' : `SELF-TEST PASSED (${cases.length} cases)`);
+}
+
+if (isEntrypoint(import.meta.url)) {
+  if (process.argv.includes('--self-test')) {
+    selfTest();
+  } else {
+    main().catch((err) => {
+      console.error(err.stack ?? String(err));
+      process.exit(1);
+    });
+  }
+}

--- a/scripts/publish-smoke.sh
+++ b/scripts/publish-smoke.sh
@@ -460,7 +460,7 @@ if [ "$SMOKE_MODE" = "pack" ]; then
   # Anything NOT in the override map (transitive deps, better-auth, hono, …)
   # resolves from the registry exactly as it would for a real user; that
   # unpinned resolution is the thing under test.
-  log "Pinning @objectstack/* to local tarballs via project-local overrides"
+  log "Pinning every publishable package to local tarballs via project-local overrides"
   node - "$SMOKE_ROOT/tarballs/overrides.json" "$APP_DIR/pnpm-workspace.yaml" <<'EOF'
 const { existsSync, readFileSync, writeFileSync } = require('node:fs');
 const [overridesPath, wsPath] = process.argv.slice(2);
@@ -484,7 +484,8 @@ const lines = [
   base,
   '',
   '# ── appended by scripts/publish-smoke.sh ─────────────────────────────────',
-  '# @objectstack/* pinned to the about-to-publish tarballs; everything above',
+  '# every publishable package pinned to its about-to-publish tarball (scoped',
+  '# and unscoped alike); everything above',
   '# is what the template ships, everything else resolves from the registry.',
   'overrides:',
   ...Object.entries(overrides).map(([name, spec]) => `  '${name}': '${spec}'`),
@@ -518,17 +519,50 @@ EOF
   log "Installing (pnpm, tarball-pinned)"
   (cd "$APP_DIR" && pnpm install --no-frozen-lockfile)
 
-  # Belt-and-braces: if any @objectstack/* resolved from the REGISTRY the
+  # Belt-and-braces: if any package we PINNED resolved from the REGISTRY the
   # override map has a hole and the smoke would silently test published code.
-  # Registry-resolved lockfile keys read '@objectstack/<name>@<version>';
-  # tarball-pinned ones read '@objectstack/<name>@file:…' (with possible
-  # peer suffixes containing their own @<version>, hence the [^'@] name part).
-  log "Asserting no @objectstack/* leaked to the registry"
-  if grep -En "'@objectstack/[^'@]+@[0-9]" "$APP_DIR/pnpm-lock.yaml"; then
-    fail "some @objectstack/* packages resolved from the registry (see above) — publish-smoke-pack.mjs override map is incomplete"
-  fi
-  TARBALL_COUNT=$(grep -cE "'@objectstack/[^'@]+@file:" "$APP_DIR/pnpm-lock.yaml" || true)
-  echo "  ok — $TARBALL_COUNT tarball-resolved @objectstack/* lockfile entries"
+  # Registry-resolved lockfile keys read '<name>@<version>'; tarball-pinned
+  # ones read '<name>@file:…' (with possible peer suffixes containing their
+  # own @<version>, hence the name-anchored match).
+  #
+  # The names come from the override map, NOT from a `@objectstack/*` glob.
+  # This assertion used to grep the scope, which made it blind in exactly the
+  # case it existed to catch: `create-objectstack` is unscoped, so when it went
+  # unpinned and resolved from the registry, this guard reported "ok" and the
+  # smoke died 200 lines later inside pnpm with ERR_PNPM_NO_MATCHING_VERSION.
+  # A guard whose alphabet is narrower than the set it guards is not a guard.
+  log "Asserting no pinned package leaked to the registry"
+  node - "$SMOKE_ROOT/tarballs/overrides.json" "$APP_DIR/pnpm-lock.yaml" <<'EOF'
+const { readFileSync } = require('node:fs');
+const [overridesPath, lockPath] = process.argv.slice(2);
+const names = Object.keys(JSON.parse(readFileSync(overridesPath, 'utf8')));
+const lock = readFileSync(lockPath, 'utf8').split(/\r?\n/);
+
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const leaked = [];
+let pinnedCount = 0;
+for (const name of names) {
+  // Lockfile key lines: optional quote, the exact package name, '@', spec.
+  const key = new RegExp(`^\\s*'?${esc(name)}@([^']+?)'?:\\s*$`);
+  for (const line of lock) {
+    const m = key.exec(line);
+    if (!m) continue;
+    if (m[1].startsWith('file:')) pinnedCount += 1;
+    else if (/^[0-9]/.test(m[1])) leaked.push(`${name}@${m[1]}`);
+  }
+}
+
+if (leaked.length > 0) {
+  console.error('::error::these PINNED packages resolved from the npm registry:');
+  for (const l of leaked.sort()) console.error(`  ${l}`);
+  console.error(
+    'The publish-smoke-pack.mjs override map has a hole, so the smoke tested ' +
+      'PUBLISHED code instead of the release candidate.',
+  );
+  process.exit(1);
+}
+console.log(`  ok — ${pinnedCount} tarball-resolved lockfile entries, 0 registry leaks (${names.length} names checked)`);
+EOF
 else
   log "Scaffolding $APP_NAME with published create-objectstack@latest"
   (cd "$SMOKE_ROOT" && npx -y create-objectstack@latest "$APP_NAME" --skip-install --skip-skills)

--- a/scripts/publish-smoke.sh
+++ b/scripts/publish-smoke.sh
@@ -539,29 +539,33 @@ const names = Object.keys(JSON.parse(readFileSync(overridesPath, 'utf8')));
 const lock = readFileSync(lockPath, 'utf8').split(/\r?\n/);
 
 const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-const leaked = [];
-let pinnedCount = 0;
+// Sets, not arrays: a name is keyed in BOTH the `packages:` and `snapshots:`
+// sections, so counting lines would report every package twice.
+const leaked = new Set();
+const pinned = new Set();
 for (const name of names) {
   // Lockfile key lines: optional quote, the exact package name, '@', spec.
   const key = new RegExp(`^\\s*'?${esc(name)}@([^']+?)'?:\\s*$`);
   for (const line of lock) {
     const m = key.exec(line);
     if (!m) continue;
-    if (m[1].startsWith('file:')) pinnedCount += 1;
-    else if (/^[0-9]/.test(m[1])) leaked.push(`${name}@${m[1]}`);
+    if (m[1].startsWith('file:')) pinned.add(name);
+    else if (/^[0-9]/.test(m[1])) leaked.add(`${name}@${m[1]}`);
   }
 }
 
-if (leaked.length > 0) {
+if (leaked.size > 0) {
   console.error('::error::these PINNED packages resolved from the npm registry:');
-  for (const l of leaked.sort()) console.error(`  ${l}`);
+  for (const l of [...leaked].sort()) console.error(`  ${l}`);
   console.error(
     'The publish-smoke-pack.mjs override map has a hole, so the smoke tested ' +
       'PUBLISHED code instead of the release candidate.',
   );
   process.exit(1);
 }
-console.log(`  ok — ${pinnedCount} tarball-resolved lockfile entries, 0 registry leaks (${names.length} names checked)`);
+console.log(
+  `  ok — ${pinned.size}/${names.length} pinned packages resolved from tarballs, 0 registry leaks`,
+);
 EOF
 else
   log "Scaffolding $APP_NAME with published create-objectstack@latest"


### PR DESCRIPTION
Fixes #11253

The packed-tarball smoke never packed or pinned `create-objectstack`, so the 17.2.0 release candidate's own smoke died on a version that by definition does not exist yet. Failed run: [32622283383](https://github.com/objectstack-ai/objectstack/actions/runs/32622283383), job `Packed-tarball smoke (release candidate)`.

```
[ERR_PNPM_NO_MATCHING_VERSION] No matching version found for create-objectstack@17.2.0
This error happened while installing the dependencies of @objectstack/cli@17.2.0
The latest release of create-objectstack is "17.1.0".
```

## The mechanism — one correction to the card's reading

The card attributes the hole to an `@objectstack/*` **scope filter** in the pin-set construction. The pin set was not built from a scope glob: `publish-smoke-pack.mjs` already derived from `private !== true`. The hole was a **hand-written by-name exclusion** sitting on top of that derivation:

```js
// Not consumed as npm dependencies by a scaffolded project:
//   create-objectstack — the scaffolder itself; the smoke runs it straight
//     from the repo's built bin, and no @objectstack/* manifest depends on it.
const EXCLUDE = new Set(['create-objectstack']);
```

The rationale was true when written and expired when `@objectstack/cli` took a dependency on the scaffolder. Its general shape is the real bill: whether a workspace package is *reachable from some other manifest* is a fact about the dependency graph **at one moment**, and it is not a question this script gets to ask. Publishable is the question.

A scope filter **did** exist, in the second place the card told me to look — the registry-leak assertion in `publish-smoke.sh`, which drove off a `'@objectstack/[^'@]+@[0-9]` grep. That made the guard blind in exactly the case it existed to catch, so the run got `ok — 0 leaks` and then died 200 lines later inside pnpm. **A guard whose alphabet is narrower than the set it guards is not a guard.**

## Source of truth: the workspace, not the `fixed` group

Both candidates enumerate the same 69 names, and they are **provably equivalent right now** — measured on this branch:

```
publishable (private !== true): 69
.changeset/config.json fixed group: 69
set identical to fixed group: true
```

They are equivalent because `scripts/check-changeset-fixed.mjs` already asserts it in both directions (a public package missing from the group reddens; a group name that no longer exists in the workspace reddens). That is exactly why the **workspace** is the right source and the group is not: the group is a *derived declaration that a gate keeps honest*. Deriving the pin set from it would mean reading a copy — correct today, and correct only for as long as a second gate keeps it so. The workspace is the thing itself.

## Before / after

Same command, same tree, before and after the change:

| | pin set size | `create-objectstack` in set |
|---|---|---|
| before | 68 | **false** |
| after | **69** | **true** |

`create-objectstack` is the **only** unscoped publishable package in the workspace — which is why no fixture whose names all begin with `@` could have caught this.

## What changed

- **`scripts/publish-smoke-pack.mjs`** — the set is `private !== true`, full stop: no scope filter, no exclusion, no hand list. `assertPinSetTotal` re-checks *pin set == publishable set* in **both directions** at the derivation site and reports offenders **by name** (both halves matter: a missing pin silently tests published code, a surplus pin tests a resolution no real user can reproduce).
- **`scripts/publish-smoke.sh`** — the registry-leak assertion now drives off the override map's own names, scoped and unscoped alike, instead of a scope grep. De-duplicated across the lockfile's `packages:`/`snapshots:` sections.
- **`--self-test`** wired as `check:publish-smoke-pin` in `lint.yml`. The assertion it pins lives on the **release path**, which runs only during a release — without this step a regression in it would again be discovered by a release candidate rather than by the PR that caused it. Pure functions, synthetic fixtures, no pnpm/workspace/network, ~0.05s.
- Prose in `publish-smoke.yml` / `publish-smoke.sh` that described the pin set as `@objectstack/*` — the self-description the card quoted — corrected to match what the code does.

## Verification

**The full smoke ran locally, green, in pack mode** — CI does not have to take over any leg of it:

```
Packing 69 publishable package(s) → /tmp/objectstack-publish-smoke.sblLoc/tarballs
  wrote .../smoke-app/pnpm-workspace.yaml (69 overrides, template settings preserved)
      'create-objectstack': 'file:.../tarballs/create-objectstack-17.1.0.tgz'
== Asserting no pinned package leaked to the registry
  ok — 58/69 pinned packages resolved from tarballs, 0 registry leaks
  ok — POST /auth/sign-up/email → 200
  ok — POST /data/smoke_app_note (create) → 201
  ok — DELETE /data/smoke_app_note/IUZR2guTmyOFvXne (delete) → 200
== Publish smoke passed (pack mode)
```

**Isolated install leg — the defect and the fix, with the real tarballs.** Two throwaway projects outside the workspace, same tarball set, differing only in whether `create-objectstack` is pinned:

```
LEG OLD (68 overrides, create-objectstack pinned: false)
  create-objectstack@17.1.0:                                        ← npm REGISTRY
LEG NEW (69 overrides, create-objectstack pinned: true)
  create-objectstack@file:../tarballs/create-objectstack-17.1.0.tgz ← candidate tarball
```

At 17.1.0 that registry resolution *succeeds* and silently smokes published code; at 17.2.0 it is the hard `ERR_PNPM_NO_MATCHING_VERSION` above. Same hole, two faces. The packed `@objectstack/cli` manifest confirms the trigger — `pnpm pack` rewrites `workspace:*` to a concrete version, so the published manifest really does demand the unpublished one:

```
name/version: @objectstack/cli 17.1.0
create-objectstack dep: "17.1.0"
```

**The guard half**, both assertions run against that same leaking lockfile:

```
OLD guard (scope grep):  ok — no @objectstack/* leaked   ← BLIND; the install had leaked
NEW guard: EXIT=1
  ::error::these PINNED packages resolved from the npm registry:
    create-objectstack@17.1.0
```

**Self-test, ablation-checked.** Restoring the by-name exclusion turns case 1 red (`unscoped public package dropped from the set: ["@objectstack/cli"]`); neutering the equality branch turns cases 2 and 3 red. Each mutation was confirmed on disk by grepping for the injected *and* the removed text before running — and the restore leg was re-verified green (`SELF-TEST PASSED (4 cases)`) with the mutation proven absent. No build/`dist` is involved: the script is executed directly, not resolved through a package `exports`.

**Gates.** `node scripts/pm/dispatch-gates.mjs` derived 17 families from the real change set; all 17 run green at `c2fc2d9e` (the final commit — the union was run after it):

```
check:cross-package-test-inputs · check:entry-guard · check:node-version · check:parse-guard
check:pnpm-filter-targets · check:publish-smoke-pin · check:required-contexts
check:shard-attestation · check:type-check-coverage · check:type-check-debt
check:workflow-status-functions · check-aggregator-roster · check-ci-filter-parity
check-cross-package-test-inputs · check-required-contexts · check-shard-attestation
check-step-collectors
```

`check:type-check-debt` needs the built closure to `--re-measure`, so the closure was built first exactly as `lint.yml` does (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful) and it then reported `OK — 33 ledger entr(ies) re-measured, 1897 raw tsc error(s) total, none above its recorded number`. Its lowering hints are pre-existing and untouched by this diff. `check:nul-bytes` green. The new gate registers itself in the derivation (`check:publish-smoke-pin … matched via scripts/publish-smoke-pack.mjs ⇢ gate script`).

`node scripts/pm/check-governed-merges.mjs --test` on the final file list:

```
governed-surface predicate: 0 of 5 path(s) hit the register (5 surfaces, repo-agnostic).
  ✅  NOT governed — ordinary queue landing applies to a PR with exactly this file list.
```

**Changeset:** none — `skip-changeset`. Nothing here ships to npm: two scripts, two workflows, and one script entry in the private monorepo root manifest.

## For the release operator

**After this merges, re-run the smoke from the Actions UI:** open [publish-smoke.yml](https://github.com/objectstack-ai/objectstack/actions/workflows/publish-smoke.yml) → **Run workflow** → pick branch `main` → Run. `publish-smoke.yml` has no `push`/`pull_request` trigger (only `schedule` for the weekly registry canary, plus `workflow_dispatch`), so **merging alone does not start a run** — the dispatch is a manual step. `workflow_dispatch` runs the `pack-smoke` job (`if: github.event_name != 'schedule'`), which is the leg that was failing.

Then: green smoke → merge #10183 (17.2.0) → approve the release environment. #10183 needs no refresh; this PR is scripts-only and does not enter the publish set.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MsbKEG4LtERSLaDrbehM3e)_