### PR TITLE
fix(console,cli): stop printing install instructions for packages nobody can install

### DIFF
--- a/.changeset/out-of-repo-package-names.md
+++ b/.changeset/out-of-repo-package-names.md
@@ -1,0 +1,48 @@
+---
+'@objectstack/console': patch
+'@objectstack/cli': patch
+---
+
+Stop naming a package nobody can install: `@objectstack/framework` is not a real
+package, and the multi-org remedy now says it is not publicly obtainable
+
+Four `@objectstack/` names appear in this repo's published docs and runtime text
+without this repo building any of them. Measured against the public npm registry
+(unauthenticated `GET https://registry.npmjs.org/@objectstack%2F<name>`, with
+`@objectstack/spec` and `@objectstack/cli` as positive controls so a 404 is a
+fact about the name and not about access), they are **not one population but
+three**:
+
+- `@objectstack/framework` — **404, and fabricated.** Unlike the others, nothing
+  in this tree describes it as enterprise, cloud, or private; it is presented as
+  the *default public* install. There is no umbrella package and there never was.
+- `@objectstack/security-enterprise` (404) and `@objectstack/organizations`
+  (404) — **real, and deliberately not public.** This tree calls them
+  "closed-source" and "cloud-private" in a dozen places, and
+  `PLATFORM_CAPABILITY_PROVIDERS` declares `security-enterprise` with
+  `edition: 'enterprise'`. Their 404 is the caveat npm's API carries for any
+  private package, not evidence of fabrication.
+- `@objectstack/service-tenant` — **published, at 4.1.0**, exactly as
+  `platform-object-names.ts` describes it. Untouched.
+
+What changes:
+
+- **`@objectstack/console`'s README** no longer opens with
+  `pnpm add @objectstack/framework`. The mechanism it described is real, just
+  misnamed: `@objectstack/cli` declares `@objectstack/console` as a dependency
+  and both ship at one version from the Changesets `fixed` group, so any app
+  that installs the CLI — every `npx create-objectstack` scaffold does — already
+  gets a version-matched Console. The instruction is corrected rather than
+  deleted, so the reader is left with something they can run.
+- **`serve`'s multi-org fail-fast** kept telling an operator to add
+  `@objectstack/organizations` to their app without saying the runtime ships
+  only with an enterprise/cloud subscription. That is the un-followable "add it
+  to your dependencies" that framework#3366 exists to make legible. The remedy
+  now states it, so an operator without a licence can see that the two bullets
+  below it are their actual path. The declared-but-unresolvable branch is
+  unchanged — that operator does have the package.
+
+No behaviour changes: boot outcomes, exit codes and the posture wall are
+untouched, and `@objectstack/security-enterprise`'s install hint is deliberately
+left alone — it already names its edition boundary, and the test pinning it is
+strengthened to assert that it keeps doing so.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2658,7 +2658,10 @@ export default class Serve extends Command {
                         "        — declare it in the app's package.json and install; the CLI resolves it from the\n" +
                         '          app, not from the framework it is linked out of. Being merely reachable\n' +
                         '          through NODE_PATH / a hoisted workspace store is deliberately not enough\n' +
-                        '          (#4719) — that made this wall depend on how the process was launched — or\n';
+                        '          (#4719) — that made this wall depend on how the process was launched.\n' +
+                        '          NOTE: this runtime is closed-source and is NOT on the public npm registry —\n' +
+                        '          it is distributed with an enterprise / cloud subscription. Without one this\n' +
+                        '          bullet is not followable, and one of the two below is your path — or\n';
                   console.error(
                     chalk.red(
                       `\n  ✖ FATAL: tenancy posture '${tenancyPosture}' was requested but ` +

--- a/packages/cli/src/utils/console.ts
+++ b/packages/cli/src/utils/console.ts
@@ -14,7 +14,9 @@
  *   1. `@objectstack/console` — the framework-vendored, version-locked
  *      build. Shipped as a dist-only npm package frozen at the objectui
  *      SHA recorded in `<framework>/.objectui-sha`. This is what a
- *      fresh `pnpm add @objectstack/framework` install gets. Cloud /
+ *      fresh `@objectstack/cli` install gets: the CLI declares this
+ *      package as a dependency and both ship at one version from the
+ *      Changesets `fixed` group, so no app installs it by hand. Cloud /
  *      objectos Docker builds overlay their own `cloud/.objectui-sha`
  *      build into this package's `dist/` so the same package name
  *      always wins regardless of who built the image.

--- a/packages/cli/test/capability-preflight.test.ts
+++ b/packages/cli/test/capability-preflight.test.ts
@@ -5,7 +5,10 @@ import {
   missingProviderMessage,
   makeProviderResolver,
 } from '../src/utils/capability-preflight.js';
-import { classifyRequiredCapability } from '@objectstack/spec/kernel';
+import {
+  classifyRequiredCapability,
+  PLATFORM_CAPABILITY_PROVIDERS,
+} from '@objectstack/spec/kernel';
 
 // framework#3366 — the CLI-side resolution + message layer over the spec-owned
 // classifier. Resolution is injected so the classification is deterministic.
@@ -69,10 +72,20 @@ describe('renderCapabilityMessage (#3366)', () => {
     expect(m).toContain('pnpm add @objectstack/service-automation');
   });
 
-  it('enterprise provider hint points at plugins[] wiring', () => {
+  it('enterprise provider hint names plugins[] wiring AND carries the edition boundary', () => {
     const m = msgFor('hierarchy-security', () => false);
     expect(m).toContain('pnpm add @objectstack/security-enterprise');
     expect(m).toContain('plugins[]');
+    // #10921 — this `pnpm add` names a package this repo does not build and that
+    // is not publicly resolvable; it is followable only by a licensee. What keeps
+    // it from reading as an ordinary open-edition install is the roster's edition
+    // note, so assert the message carries that note VERBATIM instead of a literal
+    // copied into this file — the note is spec-owned, and a copy here would let
+    // the two drift apart with both still green. Strip the note from the roster
+    // entry, or stop interpolating it, and this fails.
+    const note = PLATFORM_CAPABILITY_PROVIDERS['hierarchy-security'].note;
+    expect(note, 'the enterprise roster entry must carry an edition note').toBeTruthy();
+    expect(m).toContain(note!);
   });
 
   it('unknown token reads as a typo hint', () => {

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,20 +1,24 @@
 # @objectstack/console
 
-**Prebuilt Console SPA, version-locked to `@objectstack/framework`.**
+**Prebuilt Console SPA, version-locked to the framework release that ships it.**
 
 This package contains nothing but a prebuilt `dist/` directory: the static
 assets of the ObjectStack runtime Console, baked at the commit of
 [`objectstack-ai/objectui`](https://github.com/objectstack-ai/objectui)
 recorded in [`.objectui-sha`](../../.objectui-sha) of this framework release.
 
-It exists so that a single
+You never install it directly. `@objectstack/cli` declares it as a
+dependency, and both ship at the same version from the Changesets `fixed`
+group (see [`.changeset/config.json`](../../.changeset/config.json)), so
+scaffolding an app
 
 ```sh
-pnpm add @objectstack/framework
+npx create-objectstack
 ```
 
-always pulls in a Console build matched to the framework version — no
-second npm dependency to keep in sync.
+— or adding `@objectstack/cli` to an existing one — always pulls in a Console
+build matched to the framework version, with no second npm dependency to keep
+in sync.
 
 ## Relationship to `@object-ui/console`
 
@@ -22,7 +26,7 @@ second npm dependency to keep in sync.
 |---|---|---|
 | Repo | [`objectstack-ai/objectui`](https://github.com/objectstack-ai/objectui) | [`objectstack-ai/objectstack`](https://github.com/objectstack-ai/objectstack) |
 | Role | Standalone Console SPA on its own release cadence | Prebuilt SPA frozen at the SHA this framework release was tested against |
-| Use | Cloud overlays, advanced users, anyone consuming Console directly | Default install for `@objectstack/framework` consumers |
+| Use | Cloud overlays, advanced users, anyone consuming Console directly | What every `@objectstack/cli` install gets by default |
 
 The framework CLI's `resolveConsolePath()` (in
 `packages/cli/src/utils/console.ts`) prefers `@objectstack/console` and


### PR DESCRIPTION
Fixes #10921

## The measurement was re-taken, and it splits the four names 1 / 3 — not 3 / 1

The ruling of 2026-08-22 made this card's first step a measurement. That measurement was re-run here (unauthenticated `GET https://registry.npmjs.org/@objectstack%2FPKGNAME`), and the registry half reproduces exactly:

| name | HTTP | `dist-tags.latest` |
| :--- | :--- | :--- |
| `@objectstack/framework` | 404 | — |
| `@objectstack/security-enterprise` | 404 | — |
| `@objectstack/organizations` | 404 | — |
| `@objectstack/service-tenant` | 200 | `4.1.0` |
| `@objectstack/spec` *(positive control)* | 200 | `17.1.0` |
| `@objectstack/cli` *(positive control)* | 200 | `17.1.0` |

⚠️ The strict claim a 404 supports is **"not publicly resolvable"**, never "does not exist" — npm answers 404 for a private package too, and this probe is unauthenticated.

**What changes is the reading, not the numbers.** The dispatching analysis took the three 404s as three fabricated names. Measured against this tree, they are not one population:

- **`@objectstack/framework` — fabricated.** Nothing in this tree calls it enterprise, cloud, or private. The opposite: `packages/console/README.md` presents it as the *default public* install (`| Use | … | Default install for @objectstack/framework consumers |`). There is no umbrella package, and the real public onboarding path — `npx create-objectstack`, whose template is `packages/create-objectstack/src/templates/blank/package.json` — never mentions one.
- **`@objectstack/organizations` and `@objectstack/security-enterprise` — real, and deliberately not public.** This tree calls them "closed-source" (`serve.ts:2576`) and "cloud-private" (`serve.ts:229`, `packages/verify/src/harness.ts:44`) in roughly a dozen places, one citing `cloud#1013`. `security-enterprise` is declared *with provenance* in `PLATFORM_CAPABILITY_PROVIDERS` (`packages/spec/src/kernel/platform-capabilities.ts`) as `edition: 'enterprise'`. Their 404 is the private-package caveat above, not evidence of fabrication.
- **`@objectstack/service-tenant` — published at 4.1.0**, exactly as `platform-object-names.ts` describes it. Untouched, as instructed.

## On the A/B fork: a roster already exists, so this adds none

The card's option A was "a declared roster, one row per out-of-repo package, with where it ships". That roster is **`PLATFORM_CAPABILITY_PROVIDERS`** in `packages/spec/src/kernel/platform-capabilities.ts`: `package` + `edition` (`open` / `enterprise` / `cloud`) + a prose `note`, drift-tested 1:1 against the capability vocabulary and read by both the CLI preflight and cloud's objectos-runtime. Three out-of-repo packages already have rows.

Adding a second one would be the exact failure that file's header warns about — *"A second description nobody checks is how that happens; one exported list is how it stops."* So this PR adds no roster, no gate script and no `check:` alias.

The one real gap — `@objectstack/organizations` has no row, because the map is keyed by `requires` token and that package is `plugins[]`-wired off the tenancy posture — needs a `packages/spec/**` edit, which was fenced out of this card. Routed to #11263 for the spec seat rather than done here.

## What actually changed

**`packages/console/README.md`** no longer opens with `pnpm add @objectstack/framework`. The mechanism it described is real and just misnamed: `@objectstack/cli` declares `@objectstack/console` as a dependency (`packages/cli/package.json`), and both sit in the Changesets `fixed` group, so any app that installs the CLI already gets a version-matched Console. Corrected rather than deleted — a reader is left with something runnable (`npx create-objectstack`).

**`packages/cli/src/utils/console.ts`** carried the same fabricated name in the resolution-strategy docblock; same correction.

**`packages/cli/src/commands/serve.ts`** — the multi-org fail-fast told an operator to add `@objectstack/organizations` to their app and never said the runtime ships only with an enterprise/cloud subscription. That is the un-followable *"add it to your dependencies"* that framework#3366 exists to make legible — the boundary `platform-capabilities.ts` states in its own words. The remedy now says so, so an operator without a licence can see that the two bullets below it are their actual path. The `declared-unresolvable` branch is untouched (that operator does have the package), and the strings the e2e suite pins — `to THIS APP` and `NODE_PATH` — are both preserved verbatim.

## What deliberately did NOT change

- **`@objectstack/security-enterprise`'s install hint.** It is a real enterprise package and the message *already* names its edition boundary, because `renderCapabilityMessage` interpolates the roster's `note` on the `enterprise` branch. "Fixing" it would have been the vacuity risk this card flagged.
- **`packages/plugins/plugin-audit/README.md`** (`:365`) and **`packages/plugins/plugin-security/README.md`** (`:42,48`) — both in the declared surface, both re-read, both already correct: prose, not install commands, and each already states that the open edition ships no such runtime. No edit, which also keeps this PR clear of #11211 / #11183 in that package.

## The test pin at `capability-preflight.test.ts` is strengthened, not loosened

The card flagged this assertion as the interesting one — it *guaranteed* we keep printing an install hint for an out-of-repo package. It stays, because the hint is correct; what it lacked was any proof that the hint carries its edition context. It now asserts the message contains the roster's `note` **verbatim, read from `PLATFORM_CAPABILITY_PROVIDERS`** rather than copied as a literal — a copy here could drift from spec with both sides green.

**Ablation, both legs rebuilt-or-argued and confirmed on disk.** The subject is imported *relatively* (`../src/utils/capability-preflight.js`), and `packages/cli/vitest.config.ts` aliases only `@objectstack/service-cache` and `create-objectstack` — so no `exports`/`dist` resolution is involved and the mutation takes effect without a rebuild. (`@objectstack/spec/kernel`, where the `note` is read from, *does* resolve through `dist`, and was built first.) Replacing `const note = p!.note ? …` with an empty string:

```
MUTATION CONFIRMED ON DISK: removed-anchor count 0, injected marker count 1
MUTANT:   FAIL  enterprise provider hint names plugins[] wiring AND carries the edition boundary
          AssertionError: expected 'Capability "hierarchy-security" is pr…' to contain 'ADR-0057 hierarchy scopes ship in the…'
          Tests  1 failed | 14 passed (15)
RESTORE CONFIRMED ON DISK: restored-anchor count 1, marker count 0
RESTORED: Tests  15 passed (15)
```

Predicted direction was RED on that assertion alone; observed exactly that. The script carried a `trap … EXIT INT TERM` restore.

## Verification — all on the final commit `ce44f6057`

`pnpm --filter @objectstack/cli exec vitest run test/capability-preflight.test.ts` → **15 passed (15)**; `pnpm --filter @objectstack/cli typecheck` → clean.

Gate families re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths passed — the script reads its own change set), which added four the dispatch lead did not name, via its convention-triggered bucket. All 21 green, each exit code captured before any pipe:

`check:nul-bytes` · `check:changeset-gate-self-tests` · `check:objectui-changeset` · `check:published-files` · `check:route-envelope` · `check:slot-lookup` · `check:test-source-alias` · `check:type-check-coverage` · `check:type-source-resolution` · `check:cross-package-test-inputs` · `check:query-options-erasure` · `check:engine-double-contract` · `check:where-matcher` · `check:type-check-debt` · `check-adr-0087-registration` · `check-changeset-no-major` · `check-empty-changeset` · `check-ci-filter-parity` · `check-plugin-teardown-shape` · `check-affected-docs` · `check-published-readme-exports`

Quoting each gate's own verdict rather than a bare exit code:

```
✓ check:published-readme-exports — 60 published document(s) across 78 workspace package(s);
  212 import statement(s), 51 workspace type entr(ies), 197/197 @objectstack/ specifier(s)
  naming a workspace member.
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 225.2s,
  1897 raw tsc error(s) total, none above its recorded number.
✓ check:published-files — 69 publishable package(s) of 78 workspace member(s) …
✓ No empty-frontmatter changeset introduced by this diff (0 declaring changeset(s) added).
✓ This diff introduces no `major` bump.
```

`check:type-check-debt` was run against the **built** workspace closure (`turbo run build --filter=./packages/* --filter=./packages/*/*` → 70/70 successful), so its verdict is a measurement, not a refusal.

**Repo-wide `pnpm lint` was narrowed, and the narrowing is measured rather than assumed** — three pieces of evidence, all read from the tooling rather than guessed:

1. The population came from ESLint's own resolution, not from my judgement of "which files count": run over all 5 changed paths, it reported 3 linted and 2 (`.md`) as *"File ignored because no matching configuration was supplied."*
2. Counts read from `--format json`: **5 results, 0 errors, 0 real warnings.**
3. Invariance for untouched files: `eslint.config.mjs` states, with its own recorded positive control, that this repo *"runs one `eslint.config.mjs`, which never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file"* — so nothing in this diff can move the verdict on a file it does not touch.

## Findings filed, not fixed

- #11261 — `packages/console/package.json`'s npm `description` still names `@objectstack/framework`. Outside the declared file surface, and it is the most *visible* remaining site (it renders on the npm page). One-line change.
- #11262 — `packages/console/README.md:27-31` describes an `@object-ui/console` fallback that `resolveConsolePath()` no longer performs, contradicting `console.ts:26-31` in the same repo. Which side is stale depends on cloud's real Docker overlay target, which is not readable from here — so it was not guessed at.
- #11263 — the `PLATFORM_CAPABILITY_PROVIDERS` gap described above (spec-seat territory).

Note for triage: per the ruling's standing execution note, #10920 waits on this same prior fact and is unblocked by what lands here.

ℹ️ Read-path note, corrected: the probe URL above is spelled `PKGNAME` rather than with an angle-bracket placeholder because an earlier read of this body appeared truncated there. Measured afterwards against the REST API, that was **not** GitHub's sanitizer — raw storage keeps such fragments intact, and the dispatch comment on #10921 still holds its own angle-bracket placeholders verbatim. What drops them is the MCP issue/PR *read* path used to review the body. Nothing was lost on write; the plain placeholder is kept only so the URL reads correctly through either path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPBxLsqQGCVL5z5UXvgipH)_


---
_Generated by [Claude Code](https://claude.ai/code)_