### PR TITLE
spec: withdraw the never-honored introspection `indexes` promise; widen `defaultValue`/`maxLength` to the measured emitted types

### DIFF
--- a/.changeset/introspection-contract-withdraw-indexes-widen-defaults.md
+++ b/.changeset/introspection-contract-withdraw-indexes-widen-defaults.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/spec": patch
+"@objectstack/driver-sql": patch
+"@objectstack/objectql": patch
+---
+
+Withdraw the never-honored `IntrospectedTable.indexes` promise and widen two
+introspection declarations to the measured emitted types (#11122, maintainer
+ruling 2026-08-23, option B — 「其他同意你的意见」).
+
+The spec's introspection contract (`schema-diff-service.ts`) declared
+`indexes: IntrospectedIndex[]` as REQUIRED, yet no producer has ever emitted
+it — a consumer typed against the promise read `undefined` with no compiler
+complaint. It also declared `defaultValue?: string` while the in-tree SQL
+driver passes `knex.columnInfo().defaultValue` through raw (measured on live
+SQLite: `null` for a column with no default, dialect-quoted strings such as
+`'abc'` otherwise; other producers report native values such as `true`).
+
+- `IntrospectedTable.indexes` is now **optional**, and absence is meaningful:
+  an absent key means the producer did not read indexes; an empty array is a
+  positive claim the table HAS none. Producers that did not look must omit
+  the key rather than emit `[]`. Wiring the index read into
+  `introspectSchema()` is explicitly NOT part of this change.
+- `IntrospectedColumn.defaultValue` is now `unknown` — consumers narrow
+  before use instead of trusting a string promise no producer kept.
+- The SQL layer's extra `maxLength` fact (driver-sql / objectql
+  `IntrospectedColumn`, driver-sql `PhysicalColumn`) widens from `number` to
+  `number | string` — SQLite reports the string `"255"` where other dialects
+  report a number.
+
+With the spec now telling the truth, the deliberate `Omit` workarounds in
+`@objectstack/driver-sql` and `@objectstack/objectql` (which carved
+`defaultValue` and `indexes` out of the spec types to keep the divergence
+visible) are retired: both packages' introspection types now extend the spec
+contract directly.
+
+Consumers that read `table.indexes` must guard for absence (none exist
+in-tree — the requirement was never honored, so today's readers would have
+crashed on `undefined` anyway); consumers of `defaultValue` must narrow from
+`unknown` before string operations.

--- a/packages/drivers/driver-sql/src/schema-drift.ts
+++ b/packages/drivers/driver-sql/src/schema-drift.ts
@@ -305,7 +305,12 @@ export interface PhysicalColumn {
   name: string;
   type: string;
   nullable: boolean;
-  maxLength?: number;
+  /**
+   * Raw as knex `columnInfo()` reports it — a number on some dialects, a
+   * STRING on SQLite (measured: `"255"`). The varchar differ below narrows
+   * via `typeof` before comparing, which is the pattern for any new reader.
+   */
+  maxLength?: number | string;
   /**
    * The column's raw DEFAULT as the dialect reports it (knex `columnInfo`), or
    * `null`/`undefined` when it has none. Dialect-decorated — SQLite and Postgres

--- a/packages/drivers/driver-sql/src/sql-driver-introspection-spec-contract.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-introspection-spec-contract.test.ts
@@ -23,6 +23,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { IntrospectedSchema as SpecIntrospectedSchema } from '@objectstack/spec/contracts';
 import { SqlDriver } from '../src/index.js';
 
 describe('SqlDriver.introspectSchema emits the spec introspection contract', () => {
@@ -101,5 +102,43 @@ describe('SqlDriver.introspectSchema emits the spec introspection contract', () 
     expect(Object.keys(id)).toEqual(
       expect.arrayContaining(['name', 'type', 'nullable', 'primaryKey']),
     );
+  });
+
+  it('OMITS `indexes` — never a false-empty `[]` (#11122)', async () => {
+    const schema = await driver.introspectSchema();
+
+    // This driver does not read indexes, and the spec key is optional with
+    // absence meaning exactly that. `indexes: []` would instead be a positive
+    // claim the table HAS none — the answer a drift differ acts on — so the
+    // pin is on key ABSENCE, `in`, not on emptiness.
+    expect('indexes' in schema.tables['customers']).toBe(false);
+
+    // And the emitted value now satisfies the spec declaration AS DECLARED —
+    // this assignment is the compile-time half of the pin, the seam that had
+    // no compiler across it while the `Omit` workarounds stood. Restoring the
+    // required `indexes` (or the `string` defaultValue) in the spec turns
+    // this file's `tsc` red at the driver's construction site.
+    const asSpec: SpecIntrospectedSchema = schema;
+    expect(asSpec.tables['customers'].indexes).toBeUndefined();
+  });
+
+  it('emits `defaultValue` / `maxLength` raw — the measured shapes the widened declarations promise (#11122)', async () => {
+    const schema = await driver.introspectSchema();
+    const byName = Object.fromEntries(
+      schema.tables['customers'].columns.map((c) => [c.name, c]),
+    );
+
+    // Measured on live in-memory SQLite (knex `columnInfo()` pass-through):
+    // a column with no default reports `null` — the value the old
+    // `defaultValue?: string` declaration could not even spell.
+    expect(byName.id.defaultValue).toBeNull();
+
+    // varchar maxLength arrives as the STRING "255" on SQLite while other
+    // dialects report a number — the measurement behind `number | string`.
+    // Asserted through Number() so a knex release normalising the spelling
+    // does not read as a contract break; typeof stays inside the declared
+    // union either way.
+    expect(['number', 'string']).toContain(typeof byName.name.maxLength);
+    expect(Number(byName.name.maxLength)).toBe(255);
   });
 });

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -3673,24 +3673,25 @@ function nullSafeNegationOperand(node: Record<string, unknown>): Record<string, 
  * a key added to the spec contract now fails this file's `tsc` until the
  * driver emits it, which is exactly the failure that was missing.
  *
- * Two divergences remain, deliberately, and neither is a second spelling of
- * something the spec declares:
- *
- *  - the SQL layer carries EXTRA per-column facts (`isUnique`, `maxLength`)
- *    and extra per-table facts (`foreignKeys`, `primaryKeys`) that the spec's
- *    diff-facing contract does not declare;
- *  - `defaultValue` is `unknown` here rather than the spec's `string`, because
- *    that is what Knex's `columnInfo()` actually returns (measured on live
- *    SQLite: `null`). Narrowing the declaration without normalising the value
- *    would move the lie rather than remove it.
+ * The `Omit` carve-outs that used to mark two remaining divergences
+ * (`defaultValue`, `indexes`) are RETIRED (#11122, maintainer ruling
+ * 2026-08-23 option B): the spec now declares `defaultValue` as the raw
+ * `unknown` this driver actually reports and `indexes` as optional, so both
+ * keys are inherited straight from the spec contract. What this layer still
+ * adds is EXTRA facts only — per-column `isUnique` / `maxLength`, per-table
+ * `foreignKeys` / `primaryKeys` — never a second spelling of a spec key.
  */
-export interface IntrospectedColumn extends Omit<SpecIntrospectedColumn, 'defaultValue'> {
-  /** Raw driver-reported default. See the note above on why this is not `string`. */
-  defaultValue?: unknown;
+export interface IntrospectedColumn extends SpecIntrospectedColumn {
   /** SQL-introspection extra: the column carries a UNIQUE constraint. */
   isUnique?: boolean;
-  /** SQL-introspection extra: declared maximum length for string types. */
-  maxLength?: number;
+  /**
+   * SQL-introspection extra: declared maximum length for string types — raw
+   * as knex `columnInfo()` reports it, which is a NUMBER on some dialects
+   * and a STRING on SQLite (measured live, 2026-08-23: `"255"` for a
+   * `t.string(…)` column). Consumers narrow via `typeof`, as
+   * `schema-drift.ts`'s varchar differ already does.
+   */
+  maxLength?: number | string;
 }
 
 /** No spec counterpart — foreign keys are a SQL-introspection extra. */
@@ -3702,13 +3703,15 @@ export interface IntrospectedForeignKey {
 }
 
 /**
- * `indexes` is `Omit`ted from the spec table rather than emitted empty: this
- * driver does not introspect indexes, and `indexes: []` would tell a schema
- * differ that a table HAS none when it merely was not asked — a worse answer
- * than an absent key. Emitting them for real is per-dialect work over arms
- * this container cannot execute, so it is filed rather than guessed.
+ * `indexes` is inherited from the spec contract, where it is OPTIONAL and
+ * absence is meaningful (#11122): this driver does not introspect indexes,
+ * so `introspectSchema` deliberately OMITS the key — `indexes: []` would
+ * tell a schema differ that a table HAS none when it merely was not asked,
+ * a worse answer than an absent key. Wiring the real read
+ * ({@link SqlDriver.introspectIndexes} exists) is explicitly a separate
+ * decision with its own `onFailure` ruling.
  */
-export interface IntrospectedTable extends Omit<SpecIntrospectedTable, 'columns' | 'indexes'> {
+export interface IntrospectedTable extends SpecIntrospectedTable {
   columns: IntrospectedColumn[];
   /** SQL-introspection extra: outbound foreign keys. */
   foreignKeys: IntrospectedForeignKey[];
@@ -3722,7 +3725,7 @@ export interface IntrospectedTable extends Omit<SpecIntrospectedTable, 'columns'
  * that omits them, which is the check that was missing while this type
  * declared `{ tables }` alone.
  */
-export interface IntrospectedSchema extends Omit<SpecIntrospectedSchema, 'tables'> {
+export interface IntrospectedSchema extends SpecIntrospectedSchema {
   tables: Record<string, IntrospectedTable>;
 }
 
@@ -12925,7 +12928,9 @@ export class SqlDriver implements IDataDriver {
     for (const colName of orderedNames) {
       const info = columnInfo[colName];
       let type = 'string';
-      let maxLength: number | undefined;
+      // Raw as knex reports it: a number on some dialects, a STRING on SQLite
+      // (measured: `"255"`) — see the `maxLength` note on IntrospectedColumn.
+      let maxLength: number | string | undefined;
 
       if (this.isSqlite) {
         type = info.type?.toLowerCase() || 'string';

--- a/packages/objectql/src/util.ts
+++ b/packages/objectql/src/util.ts
@@ -24,20 +24,20 @@ import type {
  * to it, and this local declaration converges on the spec import rather than
  * keeping a second contract.
  *
- * `defaultValue` stays `unknown` rather than the spec's `string`: SQL
- * introspection reports whatever the driver read (`null`, a number, a boolean
- * literal), and narrowing the declaration without normalising the value would
- * move the lie rather than remove it. `isUnique` / `maxLength` are extra facts
- * SQL introspection carries and the spec's diff-facing contract does not
- * declare.
+ * The `Omit` carve-out that used to keep `defaultValue` diverging from the
+ * spec's `string` is RETIRED (#11122): the spec itself now declares the raw
+ * `unknown` producers actually report, so the key is inherited. `isUnique` /
+ * `maxLength` are extra facts SQL introspection carries and the spec's
+ * diff-facing contract does not declare.
  */
-export interface IntrospectedColumn extends Omit<SpecIntrospectedColumn, 'defaultValue'> {
-  /** Default value if any — raw, as the driver reported it. */
-  defaultValue?: unknown;
+export interface IntrospectedColumn extends SpecIntrospectedColumn {
   /** Whether this column has a unique constraint */
   isUnique?: boolean;
-  /** Maximum length for string types */
-  maxLength?: number;
+  /**
+   * Maximum length for string types — raw as knex `columnInfo()` reports it:
+   * a number on some dialects, a STRING on SQLite (measured: `"255"`).
+   */
+  maxLength?: number | string;
 }
 
 /**
@@ -58,12 +58,13 @@ export interface IntrospectedForeignKey {
  * Table metadata from database introspection.
  *
  * DERIVED from the spec contract, like {@link IntrospectedColumn}. `indexes`
- * is `Omit`ted rather than required: SQL introspection here does not read
- * indexes, and an empty array would claim a table HAS none when it merely was
- * not asked. `foreignKeys` / `primaryKeys` are extras the spec's diff-facing
- * contract does not declare.
+ * is inherited as the spec's OPTIONAL key (#11122): a producer that did not
+ * read indexes omits the key, and an empty array is a positive claim that a
+ * table HAS none — so nothing here emits `[]` for "not asked".
+ * `foreignKeys` / `primaryKeys` are extras the spec's diff-facing contract
+ * does not declare.
  */
-export interface IntrospectedTable extends Omit<SpecIntrospectedTable, 'columns' | 'indexes'> {
+export interface IntrospectedTable extends SpecIntrospectedTable {
   /** List of columns */
   columns: IntrospectedColumn[];
   /** List of foreign key relationships */
@@ -80,7 +81,7 @@ export interface IntrospectedTable extends Omit<SpecIntrospectedTable, 'columns'
  * here and read downstream — which is how a producer shipped `{ tables }`
  * alone while consumers read two keys nobody set.
  */
-export interface IntrospectedSchema extends Omit<SpecIntrospectedSchema, 'tables'> {
+export interface IntrospectedSchema extends SpecIntrospectedSchema {
   /** Map of table name to table metadata */
   tables: Record<string, IntrospectedTable>;
 }

--- a/packages/spec/src/contracts/schema-diff-service.test.ts
+++ b/packages/spec/src/contracts/schema-diff-service.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pins for the two introspection-contract keys ruled in #11122 (maintainer
+ * ruling 2026-08-23, option B — 「其他同意你的意见」): `IntrospectedTable.indexes`
+ * is OPTIONAL (the required declaration was a promise no producer ever
+ * honoured), and `IntrospectedColumn.defaultValue` is the raw `unknown`
+ * producers actually report, not the `string` it used to promise.
+ *
+ * The load-bearing assertions here are COMPILE-TIME: the typed literals below
+ * are exactly what the old declarations refused or lied about. Restoring
+ * `indexes: IntrospectedIndex[]` (required) makes the no-indexes table literal
+ * fail `tsc`; restoring `defaultValue?: string` makes the `null` / `true`
+ * literals fail. The runtime expects only keep vitest honest about the same
+ * values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  IntrospectedColumn,
+  IntrospectedSchema,
+  IntrospectedTable,
+} from './schema-diff-service';
+
+const col = (name: string, extra: Partial<IntrospectedColumn> = {}): IntrospectedColumn => ({
+  name,
+  type: 'varchar',
+  nullable: true,
+  primaryKey: false,
+  ...extra,
+});
+
+describe('IntrospectedTable.indexes (#11122: optional, absence ≠ empty)', () => {
+  it('a table WITHOUT `indexes` typechecks — absence means "not read", and the in-tree producer emits exactly this', () => {
+    const table: IntrospectedTable = {
+      name: 'customers',
+      columns: [col('id', { primaryKey: true })],
+      // no `indexes` key: the producer did not read indexes. Under the old
+      // required declaration this literal did not compile, yet it is the only
+      // shape any producer ever emitted.
+    };
+    expect('indexes' in table).toBe(false);
+  });
+
+  it('an empty array stays a DISTINCT legal claim: the table was read and HAS no indexes', () => {
+    const none: IntrospectedTable = { name: 't_none', columns: [col('a')], indexes: [] };
+    const some: IntrospectedTable = {
+      name: 't_some',
+      columns: [col('a')],
+      indexes: [{ name: 'idx_a', columns: ['a'], unique: false }],
+    };
+    expect(none.indexes).toEqual([]);
+    expect(some.indexes).toHaveLength(1);
+  });
+
+  it('a whole schema built from index-less tables satisfies the contract', () => {
+    const schema: IntrospectedSchema = {
+      dialect: 'sqlite',
+      introspectedAt: new Date(0).toISOString(),
+      tables: { customers: { name: 'customers', columns: [col('id')] } },
+    };
+    expect(Object.keys(schema.tables)).toEqual(['customers']);
+  });
+});
+
+describe('IntrospectedColumn.defaultValue (#11122: raw `unknown`, not `string`)', () => {
+  it('accepts the measured emitted values — `null`, a dialect-quoted string, a native boolean', () => {
+    // Measured on live in-memory SQLite (knex `columnInfo()` pass-through,
+    // 2026-08-23): `null` for a column with no default; dialect-quoted
+    // strings such as `'abc'` when one exists. The boolean mirrors the
+    // in-tree fixture for producers that report native values.
+    const noDefault: IntrospectedColumn = col('id', { defaultValue: null });
+    const quoted: IntrospectedColumn = col('name', { defaultValue: "'abc'" });
+    const native: IntrospectedColumn = col('active', { defaultValue: true });
+    const absent: IntrospectedColumn = col('note');
+
+    expect(noDefault.defaultValue).toBeNull();
+    expect(quoted.defaultValue).toBe("'abc'");
+    expect(native.defaultValue).toBe(true);
+    expect('defaultValue' in absent).toBe(false);
+  });
+
+  it('is `unknown`, so a consumer MUST narrow before string operations — the old declaration invited exactly that crash', () => {
+    const c = col('x', { defaultValue: null });
+    // Compile-time half: `c.defaultValue.startsWith('a')` must NOT typecheck
+    // (that is the consumer bug the `string` promise produced at runtime).
+    // Spelled as a narrowing guard, the only legal read:
+    const asString = typeof c.defaultValue === 'string' ? c.defaultValue : undefined;
+    expect(asString).toBeUndefined();
+  });
+});

--- a/packages/spec/src/contracts/schema-diff-service.ts
+++ b/packages/spec/src/contracts/schema-diff-service.ts
@@ -39,8 +39,26 @@ export interface IntrospectedTable {
   name: string;
   /** Column definitions */
   columns: IntrospectedColumn[];
-  /** Index definitions */
-  indexes: IntrospectedIndex[];
+  /**
+   * Index definitions — OPTIONAL, and absence is meaningful.
+   *
+   * An ABSENT key means the producer did not read indexes (the in-tree SQL
+   * driver does not: wiring the read adds one index query per table to every
+   * `introspectSchema()` call — the whole-warehouse federation path included —
+   * and needs its own `onFailure` failure-policy ruling; see
+   * `SqlDriver.introspectIndexes`). An EMPTY ARRAY is a positive claim that
+   * the table HAS no indexes. A producer that did not look must OMIT the key
+   * rather than emit `[]`, so a schema differ can tell "not asked" from
+   * "none exist".
+   *
+   * History (#11122): declared required from the start yet emitted by no
+   * producer ever, so a consumer typed against the promise read `undefined`
+   * with no compiler complaint. Withdrawn to optional per maintainer ruling
+   * 2026-08-23 (option B — 「其他同意你的意见」); wiring the index read is
+   * explicitly NOT this change, and becomes a new card if real consumer
+   * demand appears.
+   */
+  indexes?: IntrospectedIndex[];
 }
 
 /**
@@ -53,8 +71,21 @@ export interface IntrospectedColumn {
   type: string;
   /** Whether the column is nullable */
   nullable: boolean;
-  /** Default value expression */
-  defaultValue?: string;
+  /**
+   * The column's default, RAW as the driver reported it — `unknown`, not the
+   * `string` this key used to promise (#11122).
+   *
+   * The in-tree SQL driver passes `knex.columnInfo().defaultValue` through
+   * unchanged. Measured on live in-memory SQLite (2026-08-23): `null` for a
+   * column with no default; a dialect-decorated STRING when one exists
+   * (SQLite quotes — `'abc'`, and spells a boolean default `'1'`; Postgres
+   * additionally appends a `::type` cast). Other producers report native
+   * values (an in-tree fixture carries `true` for a boolean column), and
+   * per-dialect CONTENT is deliberately not claimed here. Consumers must
+   * narrow before use — or compare through a helper such as driver-sql's
+   * `physicalDefaultIsToken` — never assume a string.
+   */
+  defaultValue?: unknown;
   /** Whether this column is a primary key */
   primaryKey: boolean;
 }


### PR DESCRIPTION
Fixes #11122

Implements the maintainer ruling recorded 2026-08-23 (comment 5383569868, verbatim 「其他同意你的意见」 adopting recommendation B): withdraw the never-honored promise. Wiring the index read (option A) is explicitly NOT done here; if real consumer demand appears, that is a new card with its own `onFailure` ruling.

## What changed

- `packages/spec/src/contracts/schema-diff-service.ts` — the two ruled keys only (kept tight for the #11166 serial handoff, which lands in this file after this PR):
  - `IntrospectedTable.indexes` is now **optional**, with TSDoc fixing the semantics: absent = "the producer did not read indexes"; empty array = a positive claim the table HAS none. Producers that did not look must omit the key — never emit a false-empty array.
  - `IntrospectedColumn.defaultValue` widens from the never-honored `string` to `unknown` — raw as the driver reported it, with the measurements in the TSDoc.
- `packages/drivers/driver-sql/src/sql-driver.ts` + `packages/objectql/src/util.ts` — the deliberate `Omit` workarounds and their explanatory notes are retired: both packages' `IntrospectedColumn`/`IntrospectedTable`/`IntrospectedSchema` now extend the spec contract directly (same PR, per the ruling). The SQL layer still adds only extra facts (`isUnique`, `maxLength`, `foreignKeys`, `primaryKeys`), never a second spelling of a spec key.
- `maxLength` (the noted same-class case) widens from `number` to `number | string` at all three SQL-layer sites: driver-sql `IntrospectedColumn`, `PhysicalColumn` in `schema-drift.ts` (fed directly from the same read; its varchar differ already narrows via typeof before comparing), and objectql `IntrospectedColumn`.
- No runtime behavior changes anywhere — producers emitted these shapes all along; the declarations now tell the truth.

## Premise check (re-verified on today's origin/main, base e5ea701b)

Both premises held: the spec still declared `indexes` required and `defaultValue` as optional string; the `Omit` workarounds still stood at driver-sql sql-driver.ts (formerly lines 3687/3711/3725) and objectql util.ts (formerly lines 34/66/83).

## Re-measurement (SQLite in-memory, knex `columnInfo()` pass-through — the driver's exact source, 2026-08-23)

| column | defaultValue | typeof | maxLength | typeof |
|---|---|---|---|---|
| `t.string('id').primary()` | `null` | null | `"255"` | **string** |
| `t.string('name').defaultTo('abc')` | `'abc'` (quoted) | string | `"255"` | **string** |
| `t.integer('n').defaultTo(5)` | `'5'` | string | `null` | null |
| `t.boolean('b').defaultTo(true)` | `'1'` | string | `null` | null |

Honest limit, as the card states: SQLite only — no PG/MySQL server is reachable from this container. Both keys are built at a single dialect-independent site (`introspectSchema`/`introspectColumns`), so the SHAPE cannot vary by dialect; per-dialect CONTENT is not claimed. `unknown` (not a closed union) is deliberate for `defaultValue`: a closed union would claim completeness across dialects nobody measured; `unknown` also forces consumers to narrow, which is the authoring-safety direction the four-axis analysis picked.

## Consumer readings (recorded per the ruling; a found consumer would have forked back to the card)

**(a) objectstack repo-wide — CLEAN.** Every typed consumer of the spec introspection types was enumerated (imports of the types across all packages): service-datasource (`external-datasource-service.ts` reads columns and `primaryKeys`; never `table.indexes`, never a string operation on `defaultValue` — its `PhysicalColumn.defaultValue` was already `unknown` and comparisons go through `physicalDefaultIsToken`), objectql `convertIntrospectedSchemaToObjects` (reads `columns`/`foreignKeys`; copies `defaultValue` opaquely behind a null-guard), and test fixtures. `IntrospectedIndex` has zero consumers outside the spec itself. The wire never carries the shape either: the REST family serves `RemoteTable` (name + columnCount only), so no UI can read `indexes` structurally. Fixtures in service-datasource/rest/runtime tests that carry `indexes: []` remain legal under the optional key (an empty array is still a valid positive claim) and were deliberately left untouched — outside this card's file surface, and service-datasource is H17-adjacent (neither H17 hold-trigger file is in this diff).

**(b) objectui — CLEAN, positive-controlled.** Read at fetched origin/main `3ddc8c261aa31ee85ce307330fb2ff4d246b15db`: `git grep -nE "Introspected(Schema|Table|Column|Index)|introspectSchema|introspectIndexes"` over all .ts/.tsx → **NO MATCHES**. Positive controls on the same SHA: `defaultValue` (matches — e.g. apps/console/dev/__tests__/setup/common-mocks.ts) and `@objectstack/spec` (matches — e.g. apps/console/src/__tests__/component-input-union-specimens.test.ts) both hit, so the empty result is a measurement, not a broken grep.

**(c) cloud — NOT this PR's reading to take.** Requested as seam card #11232 (which gates enqueue only). **This PR parks as draft until #11232's reading (a) posts clean.** #11232 remains open and is not addressed here.

## Tests

- New `packages/spec/src/contracts/schema-diff-service.test.ts`: compile-time pins (a table WITHOUT `indexes` typechecks; `indexes: []` and populated stay distinct legal claims; `defaultValue: null` / quoted-string / `true` accepted; a string operation on `defaultValue` without narrowing does not typecheck — spelled as the narrowing guard).
- `sql-driver-introspection-spec-contract.test.ts` gains three pins on live introspection bytes: `'indexes' in table === false` (absence, never a false-empty `[]`), the emitted schema assigned to the spec type (the compile-time seam pin), and the measured raw emissions (`defaultValue === null` for a no-default column; varchar `maxLength` within the declared `number | string` union, `Number(...) === 255`).

## Verification (all at HEAD 96b4153c, the final commit — quoted from the runs themselves)

- Suites: spec **419 files / 11114 tests passed**; driver-sql **112 passed / 6 skipped files, 1825 passed / 85 skipped tests**; objectql **229 files / 4049 tests passed**.
- Typechecks: spec (tsc + scripts + test-typecheck), driver-sql, objectql — all exit 0.
- `check:generated`: "All 14 generated artifacts are up to date." (No api-surface/docs churn — the surface records existence, and no export was added or removed.)
- Gate union re-derived from the ACTUAL diff by `node scripts/pm/dispatch-gates.mjs` (no paths passed; stderr line: "gate list derived from the tree of 'objectstack-ai/objectstack' at commit 96b4153c"; change set = exactly the 7 files of this PR). All 24 path-matched + 5 convention-triggered families run locally, every one exit 0 with its own OK line — including `check:type-check-debt` ("33 ledger entries re-measured … none above its recorded number", after the full turbo package build it requires), `check:type-check-coverage`, `check:cross-package-test-inputs`, `check:engine-double-contract`, `check:adr-0087-registration` (patch changeset — not declared-breaking, no marker owed), and `check:nul-bytes`. Two initial refusals were environment artifacts, each fixed by its own printed remedy and re-run green: `check:dev-prereqs` (fresh worktree, unbuilt sibling dists → full turbo build) and `check-engine-split-ratio` (shallow clone → deepened to 2026-05-18).

## Reverse verification (mutation proven on disk, both legs rebuilt)

Mutation = restore the OLD declarations (required `indexes`, string `defaultValue`) from base e5ea701b; proven on disk by grep (old lines present 1/1, new line absent 0) and in the rebuilt spec dist (old required-indexes line present in dist contracts d.ts). Predicted directions stated before running:

- spec `check:test-typecheck` → predicted RED, **observed RED** (exit 1: 5 type errors in the new pin file — exactly the literals the old declaration refuses).
- driver-sql `tsc` → predicted RED, **observed RED** (exit 2: `TS2741: Property 'indexes' is missing … but required in type 'IntrospectedTable'` at the `introspectSchema` construction site — the Omit-retirement failing to compile, as required).
- objectql `tsc` → predicted RED, **observed GREEN — prediction wrong, and the reason is worth recording**: objectql's tsconfig excludes all test files from tsc and the package has no test-typecheck program, so the `defaultValue: true` fixture in `util.test.ts` is compiled by no tsc program (vitest strips types) — a genuinely uncoupled compile surface, not a broken discriminator. objectql src itself only CONSUMES introspection values (no construction site), so its green under mutation is correct. This hidden test layer is a known, ledgered state — `@objectstack/objectql` carries a measured TEST_DEBT entry (354 frozen raw errors) in `check:type-check-coverage`, tracked under the standing coverage program (#4311 / #6376) — so no new issue is filed; recording the fact here instead. The compile-time pins for this card therefore live in spec and driver-sql, both proven able to fail.
- Restore leg: src restored from HEAD (git clean), spec rebuilt, dist proven restored (old marker 0, new marker 1), and all three checks re-run green (exit 0 / 0 / 0).
- Mutation-leg narrowings, declared: spec ran `check:test-typecheck` only (the program carrying the pins; spec src compiles under either declaration), objectql ran main tsc only (its scripts program does not touch introspection). The green-tree runs above were full.

## Notes for review

- Clause-② yes (declaration change = accepted-set change) — `needs:contract-review` is expected on this PR; the PM reviews it.
- Changeset: patch for @objectstack/spec, @objectstack/driver-sql, @objectstack/objectql, with the consumer prescription in the body. Not declared-breaking (the withdrawn promise was never honored — today's readers would have crashed on undefined already).
- The H17 hold-trigger files (service-datasource sqlite-driver-fallback / tsup config) are NOT in this diff; no skills/ files are touched.
- #11166 lands in the same contracts file after this PR; the edit here is confined to the two ruled keys plus their TSDoc. #11166 is not addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_