### PR TITLE
docs: name both causes of `next: null` in the state-introspection prose

### DIFF
--- a/content/docs/protocol/objectql/state-machine.mdx
+++ b/content/docs/protocol/objectql/state-machine.mdx
@@ -124,7 +124,7 @@ A `state_machine` rule has no per-transition guard. To gate a transition on a pr
 Because the transition table is data, both UIs and Agents can ask "from this state, what's legal next?" instead of parsing a formula.
 
 - **In code**, `legalNextStates(objectSchema, field, currentState)` from `@objectstack/objectql` returns the declared next states, `[]` when the state has no outgoing edges (an explicit `[]` **or** a state the table never mentions — introspection does not distinguish the two, enforcement does), or `null` when no `state_machine` rule governs the field.
-- **Over HTTP**, `GET /api/v1/meta/object/:name/state/:field?from=:state` returns `{ object, field, from, next }`, where `next` is the legal-next list (or `null`).
+- **Over HTTP**, `GET /api/v1/meta/object/:name/state/:field?from=:state` returns `{ object, field, from, next }`, where `next` is the legal-next list, or `null` for **either** of two reasons: no `state_machine` rule governs the field, **or** `?from=` was omitted (no `from` ⇒ no transition table to answer with). A `null` from a call that passed no `from` is therefore not evidence that the field has no state machine — re-ask with `?from=`.
 
 <Callout type="info">
   When an AI Agent or Flow tries to update `status` to `approved` while the record is in `draft`, the write fails with a `ValidationError` (field error code `invalid_transition`) — the AI-mistake protection the rule exists for. There is no automatic injection of per-state AI instructions into the prompt; the guardrail is the enforced transition table.

--- a/skills/objectstack-automation/SKILL.md
+++ b/skills/objectstack-automation/SKILL.md
@@ -279,7 +279,8 @@ Notes:
   transition, e.g. `previous.status != 'escalated' && record.status == 'escalated'`.
 - **Introspection:** `GET /api/v1/meta/object/:name/state/:field?from=:state`
   returns the legal next states so UIs/agents can read the transition table
-  instead of hard-coding it (`next: null` when no FSM governs the field).
+  instead of hard-coding it (`next: null` = no FSM governs the field, **or**
+  `?from=` was omitted — always pass `from`).
 - Predicate conditions in sibling rules evaluate against the merged record in
   the **`record.<field>`** CEL scope (bare field names do not resolve).
 


### PR DESCRIPTION
Fixes #11049

## What

`next: null` on the state-introspection route has **two** causes; both published prose sites named only the first. This names both, at each site.

The dispatcher computes the answer as:

```ts
const next = from === undefined ? null : legalNextStates(schema, field, from);
```

(`packages/runtime/src/domains/meta.ts:245`, and the same line at `packages/rest/src/rest-server.ts:6279`.) So `null` means either *no `state_machine` rule governs the field* **or** *the caller omitted `?from=`*. A reader who calls without `from` got `null` and, from the docs, concluded the object declares no state machine. For the skill that misreading is the expensive one: it is the corpus an AI author works from, and the wrong conclusion is "this object has no lifecycle to respect".

**Oracle:** the repo already asserts the correct semantics on the QA side — `docs/qa/platform-checklist/areas/api-backend.json` (clause on the dispatcher meta state route): *"?from omitted returns next:null (no from ⇒ no transition table), a field with no FSM returns next:null"*. This PR is prose catching up to a fact the checklist already pins, not an open question.

## Scope refinement — the in-code bullet was already correct

The issue lists the `state-machine.mdx` **in-code** bullet as part of the defect. Verified against `main`: it is not. `legalNextStates` is declared

```ts
export function legalNextStates(
  objectSchema: { validations?: unknown[] } | undefined | null,
  field: string,
  currentState: string,
): string[] | null
```

`currentState` is **required**, and the function returns `null` only when no matching `state_machine` rule exists. The `from`-omitted cause is created by the HTTP dispatcher short-circuiting *before* it calls the function — it is not a property of the function. Adding "or when `?from=` is omitted" to the in-code bullet would have made that line newly wrong. Only the **Over HTTP** bullet is edited.

## Governed surface

This PR touches `skills/**` (the published skill catalog), so the whole PR is a **governed surface**: opened as draft, no auto-merge, human merge only. Review requested from @os-zhuang.

### Skill file size readings

Budget for the skill file was **≤3 net added lines**.

| Reading | Before | After | Delta |
|---|---|---|---|
| `skills/objectstack-automation/SKILL.md` whole file (lines) | 984 | 985 | **+1** |
| Published bundle, all 11 `SKILL.md` (lines) | 10505 | 10506 | **+1** |
| `skills/objectstack-automation/SKILL.md` (tokens) | 12528 | 12541 | **+13** |
| Published bundle (tokens) | 117907 | 117920 | **+13** |

The binding constraint here was **not** the line budget but `check-skills-token-ratchet` — the ceiling for this file is 12543 with only 60 bytes of headroom over the base. A first draft of the skill edit came in 66 bytes over and the ratchet failed it (`over by 17` tokens); the wording was tightened rather than the ceiling touched. Ceilings are shrink-only and maintainer-only to loosen — none was modified. Final verdict line:

```
✓ check-skills-token-ratchet: skills/objectstack-automation/SKILL.md is 12541 tokens (ceiling 12543; headroom 2).
✓ check-skills-token-ratchet: 11 published SKILL.md within their ceilings.
```

## Changeset

Docs/skills prose only — no package behavior changes, nothing to publish. Carried by the `skip-changeset` label per repo convention rather than a changeset file.

## Gates

Families derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` against the actual change set (2 paths) — **19 matched families**, all run locally plus `check:nul-bytes`. All 20 green, run **after** the final commit at `639babe` on a clean tree:

`cross-package-test-inputs` · `doc-anchors` · `doc-authoring` · `doc-formula-expressions` · `doc-security-posture` · `docs-audit-scope` · `docs-redirects` · `spec check:empty-state` · `spec check:liveness` · `pm-governed-merges` · `published-readme-links` · `role-word` · `skill-compatibility` · `skill-frame-sync` · `spec check:strictness-ledger` · `spec check:variant-docs` · `check-cross-package-test-inputs.mjs` · `check-doc-frontmatter.mjs` · `check-skills-token-ratchet.mjs` · `check:nul-bytes`

## Files changed

- `content/docs/protocol/objectql/state-machine.mdx` (+1/-1) — the **Over HTTP** bullet only
- `skills/objectstack-automation/SKILL.md` (+2/-1) — the existing Introspection parenthetical

_Generated by [Claude Code](https://claude.ai/code/session_01RMTpSRF5CjMmQBFfPtPCwJ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RMTpSRF5CjMmQBFfPtPCwJ)_