### PR TITLE
fix(metadata-protocol): derive discovery `version` instead of the hardcoded `'1.0'` literal

### DIFF
--- a/.changeset/discovery-version-third-producer.md
+++ b/.changeset/discovery-version-third-producer.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `getDiscovery()` serves a derived `version`, not the hardcoded `'1.0'` literal (#11235)
+
+`ObjectStackProtocolImplementation.getDiscovery()` filled `DiscoverySchema`'s "System
+Identity" `version` field with the constant `'1.0'`. The other `DiscoverySchema` producer
+— `HttpDispatcher.getDiscoveryInfo()` in `@objectstack/runtime` — filled the *same* field
+with its own constant `'1.0.0'` until #10993 derived it. Two producers of one field
+disagreeing with each other is what proves neither literal was ever a contract value: if
+`version` were a contract, two producers would not each invent their own constant; if it
+is not, it should not be hardcoded. That argument needs no opinion about what `version`
+"should" be.
+
+It now resolves the same way its sibling does: an injected `OS_RUNTIME_VERSION` build
+stamp, falling back to this package's own installed version, and `'unknown'` only if both
+are unavailable — honest about not knowing rather than a plausible-looking constant. One
+stamp, one meaning: a deployment that sets `OS_RUNTIME_VERSION` now gets the same answer
+from both discovery producers and from `GET /health`, so the two can no longer drift.
+
+The resolver is a package-local ~10-line copy of `packages/runtime/src/runtime-version.ts`
+rather than a shared import: `@objectstack/runtime` depends on
+`@objectstack/metadata-protocol`, not the reverse, so importing it would invert the
+dependency direction, and hoisting a helper into `@objectstack/types`/`@objectstack/core`
+would widen two packages' published surface for two call sites (declined at #11235
+triage). `tsup.config.ts` gains `shims: true` for the same reason
+`packages/runtime/tsup.config.ts` carries it — esbuild empties `import.meta` in a CJS
+bundle, so without the shim `require('@objectstack/metadata-protocol')` would have fallen
+through to `'unknown'` on every consumer.
+
+No schema shape changed, no field was added, and no export was widened — only where one
+field's value comes from. Patch, matching the sibling fix.

--- a/packages/metadata-protocol/src/discovery-version.test.ts
+++ b/packages/metadata-protocol/src/discovery-version.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #11235 — the `version` field `getDiscovery()` serves must be DERIVED: an
+ * injected `OS_RUNTIME_VERSION` stamp, falling back to the resolved
+ * `@objectstack/metadata-protocol` package version — never the `'1.0'` literal
+ * this producer hardcoded before the fix, and never any other constant.
+ *
+ * ## What these cases are built to catch, and why they are shaped this way
+ *
+ * The regression this file exists to prevent is a literal creeping back into
+ * the producer. A test that asserts one specific expected string is weak
+ * against exactly that: whoever restores a literal only has to restore the
+ * string the test names. So the load-bearing case here
+ * ("tracks the stamp across two distinct values") asserts a PROPERTY no
+ * constant can satisfy — that two different injected stamps produce two
+ * different served values — and it names no expected string at all. The
+ * value-level cases sit beside it for the more ordinary failure (the stamp is
+ * read but mangled), not in place of it.
+ *
+ * Every assertion drives the REAL `ObjectStackProtocolImplementation
+ * .getDiscovery()` path, never `resolveDiscoveryVersion()` in isolation and
+ * never the source text: a fix that stops being wired into the producer has to
+ * fail here. That is the same anti-vacuity requirement #10993's sibling test
+ * (`packages/runtime/src/http-dispatcher.runtime-version.test.ts`) states, and
+ * this file is deliberately its counterpart one package over.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { ObjectStackProtocolImplementation } from './index.js';
+
+/**
+ * The real fallback value, read the same way `resolveDiscoveryVersion()` reads
+ * it — so this assertion tracks the production code instead of independently
+ * guessing a version string that would drift from it at the next release.
+ */
+const PACKAGE_VERSION = (
+    createRequire(import.meta.url)('../package.json') as { version: string }
+).version;
+
+/**
+ * A protocol impl over a minimal engine — the harness
+ * `discovery-schema-conformance.test.ts` already uses in this package.
+ * `getDiscovery()` reads `engine.registry`, `engine.transaction` and the
+ * services registry; nothing here touches `version`, which is the point.
+ */
+function makeImpl() {
+    const engine = {
+        registry: {
+            getObject: (_name: string) => undefined,
+            getRegisteredTypes: () => [],
+        },
+    };
+    return new ObjectStackProtocolImplementation(engine as any, () => new Map());
+}
+
+async function servedVersion(): Promise<unknown> {
+    const discovery: any = await makeImpl().getDiscovery();
+    return discovery.version;
+}
+
+describe('[#11235] getDiscovery() serves a DERIVED `version`, not a literal', () => {
+    const ORIGINAL_STAMP = process.env.OS_RUNTIME_VERSION;
+
+    afterEach(() => {
+        if (ORIGINAL_STAMP === undefined) delete process.env.OS_RUNTIME_VERSION;
+        else process.env.OS_RUNTIME_VERSION = ORIGINAL_STAMP;
+    });
+
+    // Values with no plausible relationship to '1.0', '1.0.0' or the package
+    // version — anything else served back would prove the producer is not
+    // actually reading the injected stamp.
+    const STAMP_A = 'stamp-a-6d1e0b4-issue11235-could-not-be-a-coincidence';
+    const STAMP_B = 'stamp-b-c72f593-issue11235-could-not-be-a-coincidence';
+
+    it('serves the injected OS_RUNTIME_VERSION stamp verbatim', async () => {
+        process.env.OS_RUNTIME_VERSION = STAMP_A;
+
+        expect(await servedVersion()).toBe(STAMP_A);
+    });
+
+    it('TRACKS the stamp across two distinct values — a constant cannot do this', async () => {
+        // The anti-literal pin. It names no expected string: it asserts only
+        // that the served value FOLLOWS its source. Restoring `version: '1.0'`
+        // — or any other hardcode — fails this case no matter which string the
+        // hardcode picks, which is precisely what a specific-string assertion
+        // cannot promise.
+        process.env.OS_RUNTIME_VERSION = STAMP_A;
+        const first = await servedVersion();
+
+        process.env.OS_RUNTIME_VERSION = STAMP_B;
+        const second = await servedVersion();
+
+        expect(first).not.toBe(second);
+        expect(first).toBe(STAMP_A);
+        expect(second).toBe(STAMP_B);
+    });
+
+    it('falls back to the resolved package version — not a literal, not undefined — when no stamp is injected', async () => {
+        delete process.env.OS_RUNTIME_VERSION;
+
+        const version = await servedVersion();
+
+        expect(version).toBe(PACKAGE_VERSION);
+        expect(version).not.toBeUndefined();
+        // The two literals this defect family produced, named so a restoration
+        // of EITHER is caught here as well as by the tracking case above:
+        // `'1.0'` was this producer's, `'1.0.0'` the runtime dispatcher's
+        // (#10993). Their disagreement is the evidence neither was a contract
+        // value.
+        expect(version).not.toBe('1.0');
+        expect(version).not.toBe('1.0.0');
+    });
+
+    it('reports the fallback as a real, non-empty identity string', async () => {
+        delete process.env.OS_RUNTIME_VERSION;
+
+        const version = await servedVersion();
+
+        expect(typeof version).toBe('string');
+        expect((version as string).length).toBeGreaterThan(0);
+        // `'unknown'` is the honest last resort when the package's own
+        // `package.json` cannot be read. In this repo it always can be, so
+        // seeing it here would mean the resolver's read path is broken —
+        // failing loudly instead of passing on a plausible-looking string.
+        expect(version).not.toBe('unknown');
+    });
+});

--- a/packages/metadata-protocol/src/discovery-version.ts
+++ b/packages/metadata-protocol/src/discovery-version.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Resolves the value `ObjectStackProtocolImplementation.getDiscovery()` serves
+ * as the `DiscoverySchema` "System Identity" `version` field (`./protocol.ts`).
+ *
+ * ## #11235 — why the literal it replaces was provably not a contract value
+ *
+ * This producer hardcoded `version: '1.0'`. It is the SECOND
+ * `DiscoverySchema`-conforming producer; the first
+ * (`HttpDispatcher.getDiscoveryInfo()`, plus `GET /health`, both in
+ * `@objectstack/runtime`) hardcoded `'1.0.0'` until #10993 derived it. The two
+ * producers of the SAME `version: z.string()` field therefore disagreed with
+ * each other — and that, not anyone's opinion about what `version` "should"
+ * be, is the argument: if the field were a contract, two producers would not
+ * each invent their own constant; if it is not a contract, it should not be
+ * hardcoded at all.
+ *
+ * ## Why a package-local copy rather than an import
+ *
+ * `packages/runtime/src/runtime-version.ts` holds the identical resolver and
+ * CANNOT be imported here: `@objectstack/runtime` depends on
+ * `@objectstack/metadata-protocol`, not the reverse, so importing it would
+ * invert the dependency direction. Hoisting a shared helper into
+ * `@objectstack/types` or `@objectstack/core` (both already dependencies of
+ * this package) was considered and declined at #11235 triage: a hoist widens
+ * two packages' published surface for ~10 lines serving two call sites.
+ * Consolidation rides a later card if a third caller ever appears.
+ *
+ * ## Why `OS_RUNTIME_VERSION` — the SAME variable the first producer reads
+ *
+ * One stamp, one meaning. A deployment that injects `OS_RUNTIME_VERSION` now
+ * gets the same answer from both discovery producers and from `/health`, which
+ * is exactly the disagreement above, closed at its source: the two producers
+ * can no longer drift on a stamped host because there is nothing left for
+ * either of them to invent. The variable is not new — `cloud-connection-
+ * plugin.ts` already reads it, and #10993 made it `/health`'s source — and it
+ * matches AGENTS.md Prime Directive #9's `OS_{DOMAIN}_{NAME}` config-value
+ * shape (`RUNTIME` is the domain, `VERSION` the value; no `_ENABLED` /
+ * `_ALLOW_` / `_SKIP_` shape applies, this being a value rather than a flag or
+ * an escape hatch).
+ *
+ * The fallback is the one place this resolver differs from its sibling, and
+ * necessarily so: it resolves THIS package's own installed version, because
+ * `@objectstack/metadata-protocol` is the artifact whose identity this
+ * producer can honestly report when no stamp was injected.
+ */
+
+import { createRequire } from 'node:module';
+import { getEnv } from '@objectstack/core';
+
+/**
+ * `null` = not yet resolved. `undefined` is a legitimate resolved outcome (the
+ * read failed), so it cannot double as the "unset" sentinel.
+ */
+let cachedPackageVersion: string | undefined | null = null;
+
+/**
+ * `@objectstack/metadata-protocol`'s own installed version, read from its
+ * `package.json`.
+ *
+ * That file sits one directory above both `src/` (tests running against
+ * source) and the built `dist/` output, so `../package.json` resolves the same
+ * `package.json` from either shape. This package's `tsup.config.ts` uses
+ * `splitting: true`, which emits `dist/chunk-*.js` alongside `dist/index.js` —
+ * siblings at the same depth, so a chunked build resolves identically.
+ *
+ * `createRequire` (not a static `import … with { type: "json" }`) matches the
+ * resolution style already used for this exact kind of read elsewhere in the
+ * repo (`packages/runtime/src/runtime-version.ts`,
+ * `packages/cli/src/utils/spec-version.ts`) and needs no JSON-module-assertion
+ * support from the build target. Its CJS half depends on `shims: true` in this
+ * package's tsup config — see the comment there.
+ */
+function resolvePackageVersion(): string | undefined {
+    if (cachedPackageVersion !== null) return cachedPackageVersion;
+    try {
+        const require = createRequire(import.meta.url);
+        const pkg = require('../package.json') as { version?: unknown };
+        cachedPackageVersion = typeof pkg.version === 'string' && pkg.version.length > 0
+            ? pkg.version
+            : undefined;
+    } catch {
+        cachedPackageVersion = undefined;
+    }
+    return cachedPackageVersion;
+}
+
+/**
+ * The version this producer should report as the serving system's identity.
+ *
+ * 1. `OS_RUNTIME_VERSION` — an operator/build-pipeline-injected stamp (image
+ *    tag, git sha, release version). Read live, not memoized: `getDiscovery()`
+ *    builds a fresh document per call, so there is no construction moment to
+ *    freeze against, and tests that set/unset the variable around a call must
+ *    see it take effect without a stale cache.
+ * 2. The resolved `@objectstack/metadata-protocol` package version, when no
+ *    stamp was injected.
+ * 3. `'unknown'` — only if BOTH of the above are unavailable (the package's own
+ *    `package.json` is unreadable). Honest about not knowing, rather than a
+ *    plausible-looking literal a caller could mistake for real identity — the
+ *    exact failure mode #10993 and #11235 exist to close.
+ */
+export function resolveDiscoveryVersion(): string {
+    return getEnv('OS_RUNTIME_VERSION') || resolvePackageVersion() || 'unknown';
+}

--- a/packages/metadata-protocol/src/discovery-version.ts
+++ b/packages/metadata-protocol/src/discovery-version.ts
@@ -70,7 +70,11 @@ let cachedPackageVersion: string | undefined | null = null;
  * repo (`packages/runtime/src/runtime-version.ts`,
  * `packages/cli/src/utils/spec-version.ts`) and needs no JSON-module-assertion
  * support from the build target. Its CJS half depends on `shims: true` in this
- * package's tsup config — see the comment there.
+ * package's tsup config, which is load-bearing rather than defensive: measured
+ * without it, `dist/index.cjs` carries `createRequire(import.meta.url)`
+ * verbatim and throws `SyntaxError: Cannot use 'import.meta' outside a module`
+ * at load, so `require('@objectstack/metadata-protocol')` fails outright — see
+ * the comment there.
  */
 function resolvePackageVersion(): string | undefined {
     if (cachedPackageVersion !== null) return cachedPackageVersion;

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -10,6 +10,9 @@ import { readEnvWithDeprecation, resolveTenancyPosture, resolveThrownHttpError }
 // this question with it is a bug (cloud#1020, #5233) — so the posture, and only
 // the posture, is what the runtime authoring gate is told.
 import { postureEnforcesWall } from '@objectstack/spec/security';
+// [#11235] The derived `version` this file's `getDiscovery()` serves as the
+// `DiscoverySchema` "System Identity" field — never a literal again.
+import { resolveDiscoveryVersion } from './discovery-version.js';
 import type { MetadataHostEngine } from './host-engine.js';
 import { omitInternalFieldsFromWriteResponse } from './write-response-internal-fields.js';
 import {
@@ -5092,7 +5095,18 @@ export class ObjectStackProtocolImplementation implements
         const name = 'ObjectStack API';
 
         return {
-            version: '1.0',
+            // [#11235] The serving system's identity, DERIVED — an injected
+            // `OS_RUNTIME_VERSION` stamp, falling back to this package's own
+            // resolved version. It was the literal `'1.0'` while the other
+            // `DiscoverySchema` producer (`HttpDispatcher.getDiscoveryInfo()`
+            // in `@objectstack/runtime`) carried its own literal `'1.0.0'` —
+            // two producers of the same field disagreeing with each other,
+            // which is what proves neither constant was ever a contract value.
+            // #10993 fixed that producer the same way; see
+            // {@link resolveDiscoveryVersion} for the derivation, the fallback,
+            // and why the resolver is a package-local copy rather than an
+            // import.
+            version: resolveDiscoveryVersion(),
             name,
             /** @deprecated Use `name`. Removed in protocol 18 (#4828). */
             apiName: name,

--- a/packages/metadata-protocol/tsup.config.ts
+++ b/packages/metadata-protocol/tsup.config.ts
@@ -10,18 +10,25 @@ export default defineConfig({
   dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
-  // [#11235] `discovery-version.ts` reads its own `package.json` via
-  // `createRequire(import.meta.url)` — correct as written for the ESM output,
-  // but esbuild EMPTIES `import.meta` in a CJS bundle, so `import.meta.url`
-  // would be `undefined` there and the read would fall through to the
-  // `'unknown'` last resort on every `require('@objectstack/metadata-protocol')`
-  // consumer. `shims: true` makes tsup rewrite `import.meta.url` in the CJS
-  // build to a real `__filename`-derived value instead (its
-  // `assets/cjs_shims.js`), so both formats resolve the SAME package.json.
-  // Identical need, identical remedy, identical wording as
-  // `packages/runtime/tsup.config.ts` carries for #10993's resolver.
-  // Need-based injection — nothing here references `__dirname`/`__filename`,
-  // so the ESM build's shim path is a no-op.
+  // [#11235] LOAD-BEARING, and measured rather than assumed. `discovery-
+  // version.ts` reads its own `package.json` via
+  // `createRequire(import.meta.url)` — correct as written for the ESM output.
+  // `shims: true` makes tsup rewrite `import.meta.url` in the CJS build to a
+  // real `__filename`-derived value (its `assets/cjs_shims.js`), so both
+  // formats resolve the SAME package.json; `packages/runtime/tsup.config.ts`
+  // carries it for #10993's resolver, the sibling of this one.
+  //
+  // What removing it does HERE was measured on this package, and it is worse
+  // than the degradation the sibling's comment anticipates: at this `target`
+  // esbuild does not empty `import.meta` in the CJS output, it emits
+  // `createRequire(import.meta.url)` verbatim — so `dist/index.cjs` throws
+  // `SyntaxError: Cannot use 'import.meta' outside a module` at LOAD time and
+  // `require('@objectstack/metadata-protocol')` fails outright. Not a version
+  // that degrades to `'unknown'`; a package a CJS consumer cannot import at
+  // all. Do not drop this line while `discovery-version.ts` exists.
+  //
+  // Need-based injection — nothing else here references
+  // `__dirname`/`__filename`, so the ESM build's shim path is a no-op.
   shims: true,
   external: ['vitest'],
 });

--- a/packages/metadata-protocol/tsup.config.ts
+++ b/packages/metadata-protocol/tsup.config.ts
@@ -10,5 +10,18 @@ export default defineConfig({
   dts: !process.env.OS_SKIP_DTS,
   format: ['esm', 'cjs'],
   target: 'es2020',
+  // [#11235] `discovery-version.ts` reads its own `package.json` via
+  // `createRequire(import.meta.url)` — correct as written for the ESM output,
+  // but esbuild EMPTIES `import.meta` in a CJS bundle, so `import.meta.url`
+  // would be `undefined` there and the read would fall through to the
+  // `'unknown'` last resort on every `require('@objectstack/metadata-protocol')`
+  // consumer. `shims: true` makes tsup rewrite `import.meta.url` in the CJS
+  // build to a real `__filename`-derived value instead (its
+  // `assets/cjs_shims.js`), so both formats resolve the SAME package.json.
+  // Identical need, identical remedy, identical wording as
+  // `packages/runtime/tsup.config.ts` carries for #10993's resolver.
+  // Need-based injection — nothing here references `__dirname`/`__filename`,
+  // so the ESM build's shim path is a no-op.
+  shims: true,
   external: ['vitest'],
 });


### PR DESCRIPTION
Fixes #11235

## Premise check

Confirmed at `origin/main` (`1fa05a69e`): `packages/metadata-protocol/src/protocol.ts:5095` carried `version: '1.0'` inside `getDiscovery()`'s return. Premise holds for the producer.

**One part of the card's framing does not survive the check, and it matters** — reported rather than quietly worked around. The card describes this producer as "served over REST by `packages/rest/src/rest-server.ts:3196`". It is *called* there, and its `version` is **overwritten on the next line**:

```ts
const discovery = await protocol.getDiscovery();

// Override discovery information with actual server configuration
discovery.version = this.config.api.version;   // rest-server.ts:3219
```

`config.api.version` defaults to `'v1'` (`normalizeConfig()`) and is the **API version identifier** that builds the mounted URL (`api.apiPath ?? \`${api.basePath}/${api.version}\``; spec declares it `z.string().default('v1').describe('API version identifier')`). So the `'1.0'` literal never reached the REST wire, and neither does its replacement.

That does **not** make this card moot, and it is deliberately not fixed here:

- `getDiscovery()` is a declared protocol method (`ObjectStackProtocol.getDiscovery()`, `packages/spec/src/api/protocol.zod.ts:2457`) — embedders calling it directly get the producer's own answer, and the schema-conformance gate in this package judges that answer.
- The card's evidence is about **producers**, not the wire, and it is untouched by the override.
- The REST seam is a different package with a real design question attached (the schema has no field meaning "API version"), so it fails the bounded in-place-fix test on both "mechanical" and "same gate family". Filed as **#11292**, with the options and a recommendation.

## The evidence, which needs no opinion about what `version` should be

`DiscoverySchema` has exactly two producers (the spec's own census, `packages/spec/src/api/discovery.zod.ts:421`). They filled the **same** `version: z.string()` "System Identity" field with **different** constants — `'1.0.0'` in `HttpDispatcher.getDiscoveryInfo()` (until #10993), `'1.0'` here. Both literals are therefore provably not meaningful contract values: if `version` were a contract, two producers would not each invent their own; if it is not, it should not be hardcoded.

## Chosen shape — matched to what #10993 actually landed, not to the card's wording

Read #11242 (the merged #10993 fix) rather than the card's wording, per dispatch. Same three-step resolution, same env var, same `'unknown'` last resort:

1. `OS_RUNTIME_VERSION` — the operator/build-pipeline stamp. **The same variable**, not a new one: `cloud-connection-plugin.ts` already read it and #10993 made it `/health`'s source. One stamp, one meaning — a stamped deployment now gets the same answer from both discovery producers and `/health`, which is the producer disagreement closed at its source. AGENTS.md #9's `OS_{DOMAIN}_{NAME}` config-value shape.
2. This package's own resolved `package.json` version, via `createRequire(import.meta.url)('../package.json')`.
3. `'unknown'` only if both are unavailable — honest about not knowing rather than a plausible-looking literal.

Two deliberate differences from the sibling, each forced:

- **Package-local resolver** (`packages/metadata-protocol/src/discovery-version.ts`, not exported from the package index). `@objectstack/runtime` depends on `@objectstack/metadata-protocol`, not the reverse, so `resolveRuntimeVersion()` cannot be imported here; hoisting a shared helper to `types`/`core` was declined at triage. Named `resolveDiscoveryVersion()` rather than duplicating `resolveRuntimeVersion` so it cannot be confused with the sibling or with `PROTOCOL_VERSION` (the unrelated wire-protocol number in `spec/kernel`).
- **Resolved per call, not memoized at construction.** #10993 resolves once in `HttpDispatcher`'s constructor because the dispatcher is long-lived; `getDiscovery()` builds a fresh document per call and has no construction moment to freeze against.

`tsup.config.ts` gains `shims: true`, exactly as `packages/runtime/tsup.config.ts` did for the sibling.

## Reverse verification — both legs, on-disk proof, restored by `trap`

Fix committed first (`88fb4b6ce`), so every restore is a `git checkout HEAD --` back to a known state. Each ablation script installs an `EXIT INT TERM` trap whose handler restores the mutated file (spelled without angle brackets here on purpose — GitHub's body sanitizer eats short bracketed placeholders, which is how the previous revision of this paragraph rendered as an EMPTY trap handler and read as though the restore were a no-op), and each mutation is proven on disk by **anchored counts of the specific text**, not by an editor's exit code or a bare `git diff --stat`.

**Ablation 1 — restore the `'1.0'` literal on the producer.** Predicted direction: red.

```
--- BEFORE mutation (anchored counts) ---   literal count: 0   derived count: 1
--- AFTER  mutation (anchored counts) ---   literal count: 1   derived count: 0
MUTATION_LANDED: YES
```

```
FAIL src/discovery-version.test.ts > serves the injected OS_RUNTIME_VERSION stamp verbatim
FAIL src/discovery-version.test.ts > TRACKS the stamp across two distinct values — a constant cannot do this
     AssertionError: expected '1.0' not to be '1.0'
FAIL src/discovery-version.test.ts > falls back to the resolved package version …
     AssertionError: expected '1.0' to be '17.2.0'
 Test Files  1 failed (1)      Tests  3 failed | 1 passed (4)
RESTORED (trap): injected=0 derived=1
```

The fourth case stayed green, correctly: `'1.0'` *is* a non-empty string that is not `'unknown'`, which is what that case asserts. It is not an anti-literal pin and does not pretend to be one. No build was needed for this leg — the test imports `./index.js`, a package-relative specifier vitest resolves to `src/`, so no `dist/` is in the path.

**Ablation 2 — drop `shims: true` and rebuild.** Predicted direction: the CJS consumer degrades to `'unknown'`. **Observed: worse than predicted, and reported as observed.**

```
--- AFTER mutation (anchored count) --- shims count: 0
MUTATION_LANDED: YES        MUTATION-LEG REBUILD exit=0
getImportMetaUrl occurrences in dist/*.cjs: 0        (the shim really left the built output)

DIST_PROBE_VERDICT: ERROR
  dist/index.cjs:20  const require2 = _module.createRequire.call(void 0, import.meta.url);
  SyntaxError: Cannot use 'import.meta' outside a module
```

At this target esbuild does not empty `import.meta` in the CJS output, it emits it verbatim — so without the shim `require('@objectstack/metadata-protocol')` throws at **load** time and the package is unimportable from CJS, not merely degraded. Both comments were rewritten to state the measured behaviour rather than the sibling's prediction (`23d2831b8`). Restore leg rebuilt too, and re-verified — no mutated `dist/` survived the ablation:

```
RESTORED (trap): shims count now 1   RESTORE-LEG REBUILD exit=0   shim back in dist/chunk-XJQEL33S.cjs
git status --short → (empty)   # byte-identical restore
```

## Both built formats verified against a real `getDiscovery()` call

Not a unit test: constructed `ObjectStackProtocolImplementation` from the **built** `dist/index.cjs` and `dist/index.js` and read the served field.

```
package.json version : 17.2.0
CJS  build, no stamp : 17.2.0
ESM  build, no stamp : 17.2.0
CJS  build, stamped  : dist-probe-stamp-11235
DIST_PROBE_VERDICT: PASS
```

## Pin design — a property, not a string

`packages/metadata-protocol/src/discovery-version.test.ts`, four cases, every one driving the real `getDiscovery()` (never the resolver in isolation, never source text) so a fix that stops being wired in fails here.

The load-bearing case names **no expected string at all**: it asserts that two *different* injected stamps produce two *different* served values. No constant can satisfy that, whichever constant someone picks — which is precisely what a specific-string assertion cannot promise. The value-level cases sit beside it for the ordinary failure (stamp read but mangled), not in place of it, and they name both `'1.0'` and `'1.0.0'` so a restoration of either literal is caught twice.

## Consumer-by-value survey — with the controls that prove the queries were live

Dispatch asked whether discovery's `version` is consumed **by value** (version comparison, feature gating, cache key), because that would make this more than a bug fix. **I found no such consumer** in `objectstack`, `objectui` or `cloud`.

Controls, because a zero-hit query is not a reading until a known-present one proves it ran:

| query | result | control |
|:---|:---|:---|
| `discovery(Info\|Result\|Data)?\.version` / `data.version` (repo) | 17 hits, none a comparison | same regex family on `apiName` → 5 hits |
| semver comparison against a discovery version (repo) | 0 | `semver` anywhere → 10+ files |
| cache key built from a version (repo) | 0 | `cacheKey` → 5+ files |
| org-wide `"version ==="` near `discovery` | 4 hits, none about this field | org-wide `x-objectstack-build-sha` → **10 hits across `objectstack` AND `cloud`**, so org search reaches both sibling repos |

What the by-value hits actually are: `packages/adapters/hono/src/hono.test.ts:95` pins `'1.0'` from **its own mock** of `getDiscoveryInfo` (the *other* producer — untouched here); `packages/client/tests/integration/01-discovery.test.ts:38` asserts `/^v?\d+/` against the **REST-served** value, which is `config.api.version` (`'v1'`) and unaffected; `packages/spec/src/api/discovery.test.ts:207` is a schema-parse fixture. `packages/metadata-core/src/protocol-handshake.ts` compares `PROTOCOL_VERSION` against a package manifest — a different field entirely.

**Stated at its real strength: "I found no consumer" is not "there is no consumer."** Embedder code outside these three repos is not visible from here.

## Tier

Default tier holds, on content: no schema shape change, no new field, no widened export (`discovery-version.ts` is package-internal — not re-exported from `src/index.ts`, mirroring `runtime-version.ts`). Only where one field's value comes from. `packages/spec` untouched.

## Gate verdicts — exit captured before any pipe, each quoted from the gate's own output

Run at `23d2831b8` (this PR's head, `git status --porcelain` empty at run time). The list was re-derived with `node scripts/pm/dispatch-gates.mjs` **after** the changeset existed, and every path-derived and convention-triggered family it named was run except the one noted at the end.

- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — **`LINT_EXIT=0`**. Full farm, no narrowing to declare.
- `pnpm --filter @objectstack/metadata-protocol test` — `Test Files 138 passed | 2 skipped (140)` / `Tests 1883 passed | 10 skipped (1893)`.
- `pnpm --filter @objectstack/metadata-protocol build` — `ESM ⚡️ Build success` / `DTS ⚡️ Build success`, both formats.
- `pnpm check:nul-bytes` — `check-nul-bytes: OK (scanned 6336 text file(s) …; no raw ASCII control bytes).`
- `pnpm check:cross-package-test-inputs` — `OK: 14 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `pnpm check:published-files` — `✓ 69 publishable package(s) of 78 workspace member(s) declare a \`files\` whitelist …`
- `pnpm check:test-source-alias` — `check-test-source-alias OK — 72 packages with tests scanned; …`
- `pnpm check:where-matcher` — `✓ where-matcher conformance holds: 282 matcher(s) discovered … baseline key set verified against 1fa05a6: no files added.`
- `pnpm check:query-options-erasure` — `✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new … no files added.`
- `pnpm check:engine-double-contract` — `OK — 384 pinned, 133 in the DEBT ledger, 2 exempt.`
- `pnpm check:type-check-coverage` — exit 0 (structural layer).
- `node scripts/check-empty-changeset.mjs` — `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).`
- `node scripts/check-changeset-no-major.mjs` — `✓ This diff introduces no \`major\` bump.`
- `node scripts/check-adr-0087-registration.mjs` — `✓ this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).`
- Also exit 0: `check:durability-log-level`, `check:filter-alias-parity`, `check:slot-lookup`, `check:type-source-resolution`, `check:objectui-changeset`, `check:changeset-gate-self-tests`, `scripts/check-ci-filter-parity.mjs`, `scripts/check-plugin-teardown-shape.mjs`, `scripts/docs-audit/check-affected-docs.mjs`.

**One declared narrowing.** `pnpm check:type-check-debt` (`--re-measure`) requires the whole workspace build closure and re-runs tsc across all 33 ledger entries; that is CI's run. What it would judge about *this* diff was measured directly instead: `tsc --noEmit -p packages/metadata-protocol/tsconfig.json` reports **63** errors — exactly this package's recorded ledger number (`errors: 63` in `scripts/check-type-check-coverage.mjs`) — with **0** attributed to `src/discovery-version.ts`, **0** to `src/discovery-version.test.ts` and **0** to `src/protocol.ts`. The count landing on the ledger figure *is* the before/after comparison; the ratchet cannot move.

## Out of scope, filed not fixed

- **#11292** — `@objectstack/rest` overwrites discovery `version` with `config.api.version` (`'v1'`), serving the URL path segment in the "System Identity" field and masking both producers on the wire. The wire-visible half of this defect family; carries the options and a recommendation.
- **#11295** — `content/docs/api/client-sdk.mdx:90` documents `discovery.version` as `"1.0.0"`, a value no producer has ever served.

No fourth `DiscoverySchema` producer exists: the spec's own census names exactly two, and the only non-test caller of `getDiscovery()` in the tree is `rest-server.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_