### PR TITLE
feat(storage): report-only inventory for stranded sys_file orphans (#10950)

### DIFF
--- a/.changeset/sys-file-stranded-orphan-inventory.md
+++ b/.changeset/sys-file-stranded-orphan-inventory.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/service-storage": patch
+"@objectstack/cli": patch
+---
+
+feat(storage): report-only inventory for stranded `sys_file` orphans, plus `os storage orphans` (#10950)
+
+The tombstone repairs in #10171 (update verb) and #10240 (delete verb) are forward-only:
+they changed what the next write does and touched no row already written. Every
+attachments-scope file orphaned before them still sits at `status='committed'` with
+`deleted_at` NULL and no `sys_attachment` join row — and `sys_file`'s declared lifecycle
+nominates a sweep candidate only via `ttl { field: 'deleted_at' }` or
+`retention { onlyWhen: { status: 'pending' } }`, so such a row matches **neither**. It is
+never a candidate, the reap guard is never asked about it, and its bytes are never
+reclaimed. The leak is permanent rather than late.
+
+This ships the measurement half only, per the maintainer's ruling on #10950:
+
+- `inventoryStrandedFileOrphans()` — a read-only reconciliation pass that walks
+  attachments-scope committed `sys_file` rows and reports how many are stranded, their
+  byte magnitude, and why each excluded row was excluded. `formatStrandedOrphanInventory()`
+  renders it; both are exported from `@objectstack/service-storage`.
+- `os storage orphans` — the operator-invoked surface, with `--json` for a machine-readable
+  payload. There is no `--apply` and no write path, deliberately.
+
+**It writes nothing, tombstones nothing and deletes nothing.** Authorising the destructive
+backfill is a separate decision that these numbers exist to inform; a tombstone written
+here would start a 30-day clock ending in an irreversible byte delete.
+
+The ownership question is not reimplemented. `createSysFileReapGuard`'s "is anything still
+holding this file?" test — zero `sys_attachment` join rows **and** empty `ref_*` ownership
+columns — is extracted as `findFileHolder()` and called by both the guard and the
+inventory, so "the same question, never a weaker one" is a property of the code rather
+than a claim in a comment. A file with zero join rows that is `ref_*`-owned (ADR-0104 /
+#3459) is a live file and is excluded from the count.
+
+Behaviour of the reap guard is unchanged — the extraction is a pure refactor, and the
+guard's existing pins cover it. Both counts are labelled `attachments` scope: files in the
+other scopes are governed by the field-reference seam and are reconciled by
+`verifyFileReferences`, which skips attachments-scope files, so the two passes partition
+the population rather than overlapping.

--- a/.changeset/sys-file-stranded-orphan-inventory.md
+++ b/.changeset/sys-file-stranded-orphan-inventory.md
@@ -19,7 +19,9 @@ This ships the measurement half only, per the maintainer's ruling on #10950:
 - `inventoryStrandedFileOrphans()` — a read-only reconciliation pass that walks
   attachments-scope committed `sys_file` rows and reports how many are stranded, their
   byte magnitude, and why each excluded row was excluded. `formatStrandedOrphanInventory()`
-  renders it; both are exported from `@objectstack/service-storage`.
+  renders it; those two plus the inventory's result types are what
+  `@objectstack/service-storage` publishes — the shared ownership predicate stays internal,
+  since nothing outside the package pulls on it.
 - `os storage orphans` — the operator-invoked surface, with `--json` for a machine-readable
   payload. There is no `--apply` and no write path, deliberately.
 

--- a/packages/cli/src/commands/storage/orphans.ts
+++ b/packages/cli/src/commands/storage/orphans.ts
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { Command, Flags } from '@oclif/core';
+import chalk from 'chalk';
+import {
+  printHeader,
+  printSuccess,
+  printWarning,
+  printError,
+  printInfo,
+  printStep,
+  createTimer,
+  emitJson,
+  isExitSignal,
+} from '../../utils/format.js';
+import { bootSchemaStack } from '../../utils/schema-migrate.js';
+import { buildDataMigrationPlugins } from '../../utils/data-migration-plugins.js';
+
+/**
+ * `os storage orphans` — the read-only stranded-orphan inventory (#10950).
+ *
+ * Sizes the `sys_file` backlog that the forward-only tombstone fixes (#10171
+ * update verb, #10240 delete verb) could not reach: attachments-scope files
+ * left `status='committed'` with `deleted_at` NULL and no remaining
+ * `sys_attachment` join row. Those match neither lifecycle policy on
+ * `sys_file`, so the platform sweep never nominates them and their bytes are
+ * never reclaimed.
+ *
+ * ⛔ REPORT-ONLY BY CONSTRUCTION. There is no `--apply`, no `--fix`, and no
+ * write path in this command or in the pass it invokes — deliberately, not as
+ * an unimplemented default. Authorising the destructive backfill is a separate
+ * decision that this inventory's numbers exist to inform (#10950 step 2), and
+ * a tombstone written here would start a 30-day clock ending in an
+ * irreversible byte delete.
+ *
+ * ADR-0057 §3.3 forbids a bespoke SWEEPER — "detection and scheduling stay
+ * inside the single platform sweep". This command schedules nothing and
+ * registers nothing; it is an operator-invoked reconciliation read, the same
+ * shape as `os migrate files-to-references`'s verify pass.
+ */
+export default class StorageOrphans extends Command {
+  static override description =
+    'Report-only inventory of stranded sys_file orphans — attachments-scope files that no ' +
+    'sys_attachment join row and no ref_* owner holds, and that no lifecycle policy can ever ' +
+    'nominate for reaping. Writes nothing, tombstones nothing, deletes nothing.';
+
+  static override examples = [
+    '$ os storage orphans',
+    '$ os storage orphans --json',
+    '$ os storage orphans --max-candidates 50000',
+    '$ os storage orphans --samples 0',
+  ];
+
+  static override flags = {
+    'database-url': Flags.string({
+      description: 'Database URL to inspect (defaults to $OS_DATABASE_URL / the project DB)',
+      env: 'OS_DATABASE_URL',
+    }),
+    'max-candidates': Flags.integer({
+      description:
+        'Safety bound on sys_file rows read. Exceeding it truncates the walk and makes every ' +
+        'count a LOWER BOUND — omit it to size the population.',
+    }),
+    samples: Flags.integer({
+      description: 'Example stranded rows to list (default 20; 0 for counts only)',
+    }),
+    json: Flags.boolean({ description: 'Output as JSON' }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(StorageOrphans);
+    const timer = createTimer();
+
+    if (!flags.json) {
+      printHeader('Storage · stranded orphan inventory');
+    }
+
+    // No occupancy gate and no confirmation prompt, unlike the migration
+    // commands: this pass issues no write, so a concurrent writer can make the
+    // counts drift but can never be corrupted by us. The drift is warned about
+    // below instead of refused.
+    if (!flags.json) {
+      printStep('Booting data stack (read-only)…');
+    }
+
+    let stack;
+    try {
+      stack = await bootSchemaStack({
+        jsonOutput: flags.json,
+        databaseUrl: flags['database-url'],
+        extraPlugins: await buildDataMigrationPlugins({ storage: true }),
+      });
+    } catch (error: any) {
+      if (flags.json) {
+        await emitJson({ error: error.message }, 0, { compact: true });
+        this.exit(1);
+      }
+      printError(error.message || String(error));
+      this.exit(1);
+      return;
+    }
+
+    try {
+      const engine: any = stack.kernel.getService('objectql');
+      if (typeof engine?.getObject !== 'function' || !engine.getObject('sys_file')) {
+        throw new Error(
+          'sys_file is not registered on this stack — the storage service objects are required. ' +
+            'Ensure @objectstack/service-storage is installed, then re-run.',
+        );
+      }
+      // Unlike `os migrate files-to-references`, this pass reads only system
+      // objects (`sys_file`, `sys_attachment`), so a project with no app
+      // metadata loaded is not a reason to refuse: the scan's subject is
+      // present either way.
+      if (!engine.getObject('sys_attachment')) {
+        throw new Error(
+          'sys_attachment is not registered on this stack, so "does anything still reference this ' +
+            'file?" cannot be answered — and an unanswerable reference check must not be reported ' +
+            'as zero references. Ensure the storage service objects are loaded, then re-run.',
+        );
+      }
+
+      const { inventoryStrandedFileOrphans, formatStrandedOrphanInventory } = await import(
+        '@objectstack/service-storage'
+      );
+
+      const report = await inventoryStrandedFileOrphans(engine, {
+        maxCandidates: flags['max-candidates'],
+        sampleLimit: flags.samples,
+      });
+
+      if (flags.json) {
+        await emitJson({
+          database: stack.dbLabel,
+          readOnly: true,
+          ...report,
+          duration: timer.elapsed(),
+        });
+        return;
+      }
+
+      printInfo(`Database: ${chalk.white(stack.dbLabel)}`);
+      console.log('');
+      console.log(formatStrandedOrphanInventory(report));
+      console.log('');
+      if (report.truncated) {
+        printWarning(
+          'Truncated walk — the counts above are lower bounds, not the population size.',
+        );
+      } else if (report.stranded === 0) {
+        printSuccess('Nothing stranded on this deployment.');
+      } else {
+        printInfo(
+          'Reporting only. Reclaiming these bytes is a separate, deliberately deferred decision — ' +
+            'see issue #10950.',
+        );
+      }
+      console.log(chalk.dim(`  ${timer.display()}`));
+      console.log('');
+    } catch (error: any) {
+      if (isExitSignal(error)) throw error;
+      if (flags.json) {
+        await emitJson({ error: error.message }, 0, { compact: true });
+        this.exit(1);
+      }
+      printError(error.message || String(error));
+      this.exit(1);
+    } finally {
+      await stack.shutdown();
+    }
+  }
+}

--- a/packages/cli/src/commands/storage/orphans.ts
+++ b/packages/cli/src/commands/storage/orphans.ts
@@ -15,6 +15,20 @@ import {
 } from '../../utils/format.js';
 import { bootSchemaStack } from '../../utils/schema-migrate.js';
 import { buildDataMigrationPlugins } from '../../utils/data-migration-plugins.js';
+import type { IDataEngine } from '@objectstack/spec/contracts';
+import type { StrandedOrphanInventoryEngine } from '@objectstack/service-storage';
+
+/**
+ * The `objectql` slot's contract, plus the two structural bits this command
+ * uses: the inventory's read seam, and the registry probe. `getObject` is
+ * ObjectQL's own metadata surface rather than part of `IDataEngine`, so it is
+ * declared here — the lookup keeps its contract type instead of being erased
+ * to `any` (#4251).
+ */
+type OrphanInventoryEngine = IDataEngine &
+  StrandedOrphanInventoryEngine & {
+    getObject?(name: string): unknown;
+  };
 
 /**
  * `os storage orphans` — the read-only stranded-orphan inventory (#10950).
@@ -101,7 +115,11 @@ export default class StorageOrphans extends Command {
     }
 
     try {
-      const engine: any = stack.kernel.getService('objectql');
+      // Annotated rather than `getService<…>(…)`: `BootedSchemaStack.kernel` is
+      // itself untyped, so a type ARGUMENT on that call is a TS2347 error. The
+      // annotation types the binding just as tightly, which is what #4251 is
+      // after — the erasure it sweeps is an `any`-typed local, not this.
+      const engine: OrphanInventoryEngine = stack.kernel.getService('objectql');
       if (typeof engine?.getObject !== 'function' || !engine.getObject('sys_file')) {
         throw new Error(
           'sys_file is not registered on this stack — the storage service objects are required. ' +

--- a/packages/cli/test/json-stdout-purity.e2e.test.ts
+++ b/packages/cli/test/json-stdout-purity.e2e.test.ts
@@ -15,9 +15,9 @@
  *
  * ## Why the whole family, from one expectation
  *
- * The contract has one implementation face per command, and there are nine of
+ * The contract has one implementation face per command, and there are ten of
  * them. A file that pinned `migrate recorded-by` alone would go green while the
- * other eight stayed broken, and would say nothing at all about the tenth. So
+ * other nine stayed broken, and would say nothing at all about the eleventh. So
  * the family is DISCOVERED from the source tree — every command that calls
  * `bootSchemaStack` and declares a `--json` flag — and the discovered set is
  * reconciled against {@link FAMILY} below. Add a member and this file goes red
@@ -87,6 +87,7 @@ const FAMILY: Record<string, string[]> = {
   'migrate resume': [],
   'migrate summary-nulls': [],
   'migrate value-shapes': [],
+  'storage orphans': [],
 };
 
 /** Boot lines every member emits — the diagnostics that must survive on stderr. */

--- a/packages/services/service-storage/src/attachment-lifecycle.ts
+++ b/packages/services/service-storage/src/attachment-lifecycle.ts
@@ -315,6 +315,57 @@ export function installAttachmentLifecycleHooks(
 }
 
 /**
+ * Which surface still holds a file — `null` when nothing does.
+ *
+ * Two surfaces can hold one `sys_file`, and they are not interchangeable:
+ * `sys_attachment` join rows (the Attachments surface, #2727) and the
+ * `ref_*` ownership columns (field-file lineage, ADR-0104 / #3459 PR-5b).
+ * A file with ZERO join rows may still be owned through the columns.
+ */
+export type FileHolder = 'attachment' | 'field-owner' | null;
+
+/**
+ * The ownership half of the hold question: do the `ref_*` columns name an
+ * owner? Exactly the predicate the reap guard has always applied — `ref_field`
+ * is deliberately NOT consulted, because a slot is identified by (object,
+ * record) and a missing field name must not read as "unowned".
+ */
+export function hasFieldReferenceOwner(row: Record<string, unknown>): boolean {
+  return row.ref_object != null && row.ref_id != null && row.ref_id !== '';
+}
+
+/**
+ * "Is anything still holding this file?" — asked in ONE place because a second
+ * asker now exists (the stranded-orphan inventory, #10950).
+ *
+ * The reap guard asks it at sweep time before reclaiming bytes; the inventory
+ * asks it to decide whether a file with no join rows is genuinely stranded.
+ * The maintainer's ruling on #10950 requires the inventory to apply "the same
+ * `ref_*` ownership re-verification the reap guard uses — never a weaker
+ * question", and the only way to make "the same" a property of the code rather
+ * than a claim in a comment is for both callers to run this function. Two
+ * copies of an ownership test that authorises byte deletion is the drift
+ * #10171 was filed against, one seam over.
+ *
+ * ⚠️ Weakening this — dropping the `ref_*` limb, or asking only for a join-row
+ * count — makes live, field-owned files read as orphans. That is why the check
+ * is a union and not a choice.
+ */
+export async function findFileHolder(
+  engine: Pick<AttachmentLifecycleEngine, 'find'>,
+  fileId: string | number,
+  row: Record<string, unknown>,
+): Promise<FileHolder> {
+  const refs = await engine.find('sys_attachment', {
+    where: { file_id: String(fileId) },
+    limit: 1,
+    context: { ...SYSTEM_CTX },
+  });
+  if (refs?.length) return 'attachment';
+  return hasFieldReferenceOwner(row) ? 'field-owner' : null;
+}
+
+/**
  * The `sys_file` reap guard ({@link LifecycleReapGuard} shape from
  * `@objectstack/objectql`, duck-typed here to avoid the dependency).
  * Candidates arrive from the two declared policies — tombstones past the
@@ -388,20 +439,15 @@ export function createSysFileReapGuard(
 
       if (row.status === 'deleted') {
         try {
-          const refs = await engine.find('sys_attachment', {
-            where: { file_id: String(id) },
-            limit: 1,
-            context: { ...SYSTEM_CTX },
-          });
-          const owned = row.ref_object != null && row.ref_id != null && row.ref_id !== '';
-          if (refs?.length || owned) {
+          const holder = await findFileHolder(engine, id, row);
+          if (holder) {
             await engine.update(
               'sys_file',
               { id, status: 'committed', deleted_at: null },
               { context: { ...SYSTEM_CTX } },
             );
             logger.info(
-              `[storage] reap guard: sys_file ${id} regained ${refs?.length ? 'references' : 'an owner'} since tombstoning — un-tombstoned, not reaped`,
+              `[storage] reap guard: sys_file ${id} regained ${holder === 'attachment' ? 'references' : 'an owner'} since tombstoning — un-tombstoned, not reaped`,
             );
             continue;
           }

--- a/packages/services/service-storage/src/index.ts
+++ b/packages/services/service-storage/src/index.ts
@@ -16,18 +16,17 @@ export {
   installAttachmentLifecycleHooks,
   createSysFileReapGuard,
   createUploadSessionReapGuard,
-  findFileHolder,
-  hasFieldReferenceOwner,
 } from './attachment-lifecycle.js';
-export type {
-  AttachmentLifecycleEngine,
-  AttachmentLifecycleLogger,
-  FileHolder,
-} from './attachment-lifecycle.js';
+export type { AttachmentLifecycleEngine, AttachmentLifecycleLogger } from './attachment-lifecycle.js';
+// `findFileHolder` / `hasFieldReferenceOwner` / `FileHolder` stay INTERNAL: the
+// reap guard and the inventory both reach them by relative import, and nothing
+// outside this package pulls on them. Publishing an unpulled seam is surface
+// this project does not owe (implementation-first) — and the narrower the
+// ownership predicate's blast radius, the fewer places can drift weaker than
+// the guard. Export them the day a consumer exists.
 export {
   inventoryStrandedFileOrphans,
   formatStrandedOrphanInventory,
-  formatBytes,
 } from './stranded-orphan-inventory.js';
 export type {
   StrandedOrphanInventory,

--- a/packages/services/service-storage/src/index.ts
+++ b/packages/services/service-storage/src/index.ts
@@ -12,8 +12,29 @@ export type { FileRecord, UploadSessionRecord, StorageMetadataOperation } from '
 export { registerStorageRoutes } from './storage-routes.js';
 export type { StorageRoutesOptions, FileReadVerdict } from './storage-routes.js';
 export { SystemFile, SystemUploadSession } from './objects/index.js';
-export { installAttachmentLifecycleHooks, createSysFileReapGuard, createUploadSessionReapGuard } from './attachment-lifecycle.js';
-export type { AttachmentLifecycleEngine, AttachmentLifecycleLogger } from './attachment-lifecycle.js';
+export {
+  installAttachmentLifecycleHooks,
+  createSysFileReapGuard,
+  createUploadSessionReapGuard,
+  findFileHolder,
+  hasFieldReferenceOwner,
+} from './attachment-lifecycle.js';
+export type {
+  AttachmentLifecycleEngine,
+  AttachmentLifecycleLogger,
+  FileHolder,
+} from './attachment-lifecycle.js';
+export {
+  inventoryStrandedFileOrphans,
+  formatStrandedOrphanInventory,
+  formatBytes,
+} from './stranded-orphan-inventory.js';
+export type {
+  StrandedOrphanInventory,
+  StrandedOrphanInventoryEngine,
+  StrandedOrphanInventoryOptions,
+  StrandedOrphanSample,
+} from './stranded-orphan-inventory.js';
 export {
   installFileReferenceHooks,
   FileReferenceCopyError,

--- a/packages/services/service-storage/src/stranded-orphan-inventory.test.ts
+++ b/packages/services/service-storage/src/stranded-orphan-inventory.test.ts
@@ -1,0 +1,507 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, vi } from 'vitest';
+import { LifecycleService, assertEngineDeleteDispatch } from '@objectstack/objectql';
+import {
+  inventoryStrandedFileOrphans,
+  formatStrandedOrphanInventory,
+  formatBytes,
+} from './stranded-orphan-inventory.js';
+import { createSysFileReapGuard, findFileHolder } from './attachment-lifecycle.js';
+import { SystemFile } from './objects/system-file.object.js';
+
+const silentLogger = () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn() });
+
+/**
+ * WHERE matcher for the doubles below. It supports exactly the operators the
+ * code under test emits — equality, `$and`, `$gt` (the keyset cursor) and
+ * `$lt` (lifecycle cutoffs) — and THROWS on anything else, which is the
+ * conforming shape this repo asks of a driver double: a double that silently
+ * ignores an operator it does not know answers a narrower question with a
+ * wider row set, and the test still passes.
+ */
+function matches(row: Record<string, unknown>, where: unknown): boolean {
+  if (where == null) return true;
+  if (typeof where !== 'object') throw new Error(`double: unsupported where ${String(where)}`);
+  for (const [k, v] of Object.entries(where as Record<string, unknown>)) {
+    if (k === '$and') {
+      if (!Array.isArray(v)) throw new Error('double: $and expects an array');
+      if (!v.every((clause) => matches(row, clause))) return false;
+      continue;
+    }
+    if (k.startsWith('$')) throw new Error(`double: unsupported combinator ${k}`);
+    if (v !== null && typeof v === 'object') {
+      const ops = Object.entries(v as Record<string, unknown>);
+      for (const [op, operand] of ops) {
+        const cell = row[k];
+        if (op === '$gt') {
+          if (!(cell != null && String(cell) > String(operand))) return false;
+        } else if (op === '$lt') {
+          if (!(cell != null && String(cell) < String(operand))) return false;
+        } else {
+          throw new Error(`double: unsupported operator ${op} on ${k}`);
+        }
+      }
+      continue;
+    }
+    if ((row[k] ?? null) !== (v ?? null)) return false;
+  }
+  return true;
+}
+
+/** Engine members the inventory is allowed to touch. Everything else is a write. */
+const READ_ONLY_SURFACE = new Set(['find', 'tables', 'finds', 'then']);
+
+/**
+ * Read-only engine double.
+ *
+ * The double declares `find` and NOTHING else, and a Proxy throws on any other
+ * member access. That is deliberately stronger than stubbing the write verbs I
+ * happened to think of: `update`, `insert`, `delete`, `updateMany`,
+ * `deleteMany`, `execute` and anything added later all fail the same way, so
+ * the read-only claim is enforced against the whole engine surface rather than
+ * against a list. Every case in this file runs through it, so "this pass writes
+ * nothing" is a property the suite holds continuously, not one asserted once.
+ *
+ * (`then` is allowed through because awaiting a value probes it.)
+ */
+function inventoryEngine(seed: {
+  files?: Array<Record<string, unknown>>;
+  attachments?: Array<Record<string, unknown>>;
+}) {
+  const tables: Record<string, Array<Record<string, unknown>>> = {
+    sys_file: [...(seed.files ?? [])],
+    sys_attachment: [...(seed.attachments ?? [])],
+  };
+  const finds: Array<{ object: string; where: unknown }> = [];
+  const engine = {
+    tables,
+    finds,
+    async find(object: string, options: any) {
+      finds.push({ object, where: options?.where });
+      const table = tables[object];
+      if (!table) throw new Error(`double: unknown object ${object}`);
+      let rows = table.filter((r) => matches(r, options?.where));
+      const orderBy = options?.orderBy?.[0];
+      if (orderBy) {
+        rows = [...rows].sort((a, b) => String(a[orderBy.field]).localeCompare(String(b[orderBy.field])));
+      }
+      return typeof options?.limit === 'number' ? rows.slice(0, options.limit) : rows;
+    },
+  };
+  return new Proxy(engine, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string' && !READ_ONLY_SURFACE.has(prop)) {
+        throw new Error(
+          `READ-ONLY VIOLATION: the inventory reached for engine.${prop} — this pass may only read`,
+        );
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+/** An attachments-scope file in the pre-fix terminal state (the leak). */
+const strandedRow = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  key: `attachments/${id}.bin`,
+  name: `${id}.bin`,
+  size: 1024,
+  scope: 'attachments',
+  status: 'committed',
+  deleted_at: null,
+  ref_object: null,
+  ref_id: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  ...extra,
+});
+
+describe('inventoryStrandedFileOrphans — the population', () => {
+  it('counts an attachments-scope file with no join row and no ref_* owner', async () => {
+    const engine = inventoryEngine({ files: [strandedRow('f1')] });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.scope).toBe('attachments');
+    expect(report.stranded).toBe(1);
+    expect(report.strandedBytes).toBe(1024);
+    expect(report.bytesAreLowerBound).toBe(false);
+    expect(report.samples).toEqual([
+      {
+        fileId: 'f1',
+        key: 'attachments/f1.bin',
+        name: 'f1.bin',
+        size: 1024,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('⛔ EXCLUDES a file with ZERO join rows that is ref_*-owned — the case a weaker question gets wrong', async () => {
+    // This is the difference between an inventory that is safe to act on and a
+    // list of LIVE files to delete. The file has no `sys_attachment` row at
+    // all, so any count built on join rows alone reports it as an orphan; it
+    // is owned through the ADR-0104 ownership columns and is in active use.
+    const engine = inventoryEngine({
+      files: [
+        strandedRow('f_owned', { ref_object: 'product', ref_id: 'rec_1' }),
+        strandedRow('f_real'),
+      ],
+      attachments: [],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.heldByFieldOwner).toBe(1);
+    expect(report.stranded).toBe(1);
+    expect(report.samples.map((s) => s.fileId)).toEqual(['f_real']);
+    // …and its bytes are not in the magnitude a destructive step 2 would size.
+    expect(report.strandedBytes).toBe(1024);
+  });
+
+  it('excludes a file a join row still points at', async () => {
+    const engine = inventoryEngine({
+      files: [strandedRow('f_held'), strandedRow('f_free')],
+      attachments: [{ id: 'a1', file_id: 'f_held' }],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.heldByAttachment).toBe(1);
+    expect(report.stranded).toBe(1);
+    expect(report.samples.map((s) => s.fileId)).toEqual(['f_free']);
+  });
+
+  it('excludes rows outside the attachments scope and rows the sweep can already nominate', async () => {
+    const engine = inventoryEngine({
+      files: [
+        strandedRow('f_ok'),
+        // Other scopes: governed by the field-reference seam, not by join rows.
+        strandedRow('f_user', { scope: 'user' }),
+        strandedRow('f_tenant', { scope: 'tenant' }),
+        // Already tombstoned → the TTL nominates it; not stranded.
+        strandedRow('f_tomb', { status: 'deleted', deleted_at: '2026-02-01T00:00:00.000Z' }),
+        // A committed row carrying a stray deleted_at is STILL ttl-nominable,
+        // because the ttl policy keys on the field, not on the status.
+        strandedRow('f_halfstate', { deleted_at: '2026-02-01T00:00:00.000Z' }),
+        // Never-completed upload → the retention policy nominates it.
+        strandedRow('f_pending', { status: 'pending' }),
+      ],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.stranded).toBe(1);
+    expect(report.samples.map((s) => s.fileId)).toEqual(['f_ok']);
+    expect(report.alreadyOnTtlPath).toBe(1); // f_halfstate — f_tomb/f_pending never pass the status filter
+    expect(report.filesScanned).toBe(2); // f_ok + f_halfstate
+  });
+
+  it('counts BOTH legacy classes — they share one terminal state, so one predicate enumerates them', async () => {
+    // Pre-#10240 (delete verb): the join row was deleted and no tombstone was
+    // written. Pre-#10171 (update verb): a surviving join row was re-pointed
+    // at another file and the prior file was left behind. Both leave the SAME
+    // row shape, and the data records no provenance — so a complete count is a
+    // count of the terminal state, and the two cannot be split by verb.
+    const engine = inventoryEngine({
+      files: [
+        strandedRow('f_delete_verb'),
+        strandedRow('f_update_verb'),
+        // the file the surviving join row was re-pointed AT — still live
+        strandedRow('f_repointed_target'),
+      ],
+      attachments: [{ id: 'a_survivor', file_id: 'f_repointed_target' }],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.stranded).toBe(2);
+    expect(report.samples.map((s) => s.fileId).sort()).toEqual(['f_delete_verb', 'f_update_verb']);
+    expect(report.heldByAttachment).toBe(1);
+  });
+
+  it('every scanned row lands in exactly one bucket', async () => {
+    const engine = inventoryEngine({
+      files: [
+        strandedRow('f1'),
+        strandedRow('f2'),
+        strandedRow('f_owned', { ref_object: 'product', ref_id: 'r1' }),
+        strandedRow('f_held'),
+        strandedRow('f_halfstate', { deleted_at: '2026-02-01T00:00:00.000Z' }),
+      ],
+      attachments: [{ id: 'a1', file_id: 'f_held' }],
+    });
+
+    const r = await inventoryStrandedFileOrphans(engine);
+
+    expect(r.alreadyOnTtlPath + r.heldByAttachment + r.heldByFieldOwner + r.stranded).toBe(r.filesScanned);
+    expect(r.filesScanned).toBe(5);
+  });
+});
+
+describe('inventoryStrandedFileOrphans — byte magnitude', () => {
+  it('sums recorded sizes', async () => {
+    const engine = inventoryEngine({
+      files: [strandedRow('f1', { size: 1000 }), strandedRow('f2', { size: 2_500_000 })],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.strandedBytes).toBe(2_501_000);
+    expect(report.strandedRowsWithoutSize).toBe(0);
+    expect(report.bytesAreLowerBound).toBe(false);
+  });
+
+  it('flags the total as a LOWER BOUND when a stranded row carries no usable size', async () => {
+    // Silently treating a missing size as zero would under-report the leak and
+    // read as a precise figure.
+    const engine = inventoryEngine({
+      files: [
+        strandedRow('f1', { size: 512 }),
+        strandedRow('f_nosize', { size: null }),
+        strandedRow('f_bogus', { size: 'not-a-number' }),
+        strandedRow('f_negative', { size: -5 }),
+      ],
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.stranded).toBe(4);
+    expect(report.strandedBytes).toBe(512);
+    expect(report.strandedRowsWithoutSize).toBe(3);
+    expect(report.bytesAreLowerBound).toBe(true);
+    expect(formatStrandedOrphanInventory(report)).toContain('LOWER BOUND');
+  });
+
+  it('reads a numeric size that a driver handed back as a string', async () => {
+    const engine = inventoryEngine({ files: [strandedRow('f1', { size: '2048' })] });
+
+    const report = await inventoryStrandedFileOrphans(engine);
+
+    expect(report.strandedBytes).toBe(2048);
+    expect(report.bytesAreLowerBound).toBe(false);
+  });
+});
+
+describe('inventoryStrandedFileOrphans — bounds and honesty', () => {
+  it('reports a truncated walk rather than passing a partial count off as the population', async () => {
+    const engine = inventoryEngine({
+      files: Array.from({ length: 10 }, (_, i) => strandedRow(`f${String(i).padStart(2, '0')}`)),
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine, { maxCandidates: 4 });
+
+    expect(report.truncated).toBe(true);
+    expect(report.stranded).toBe(4);
+    expect(formatStrandedOrphanInventory(report)).toContain('LOWER BOUND');
+  });
+
+  it('does not report truncation when the walk read everything', async () => {
+    const engine = inventoryEngine({ files: [strandedRow('f1'), strandedRow('f2')] });
+
+    const report = await inventoryStrandedFileOrphans(engine, { maxCandidates: 500 });
+
+    expect(report.truncated).toBe(false);
+    expect(report.stranded).toBe(2);
+  });
+
+  it('honours the sample bound while still counting every row', async () => {
+    const engine = inventoryEngine({
+      files: Array.from({ length: 7 }, (_, i) => strandedRow(`f${i}`)),
+    });
+
+    const report = await inventoryStrandedFileOrphans(engine, { sampleLimit: 2 });
+
+    expect(report.stranded).toBe(7);
+    expect(report.samples).toHaveLength(2);
+  });
+
+  it('⛔ writes nothing — every write seam on the double throws', async () => {
+    const engine = inventoryEngine({
+      files: [strandedRow('f1'), strandedRow('f_owned', { ref_object: 'p', ref_id: 'r' })],
+      attachments: [{ id: 'a1', file_id: 'f_other' }],
+    });
+
+    await expect(inventoryStrandedFileOrphans(engine)).resolves.toMatchObject({ stranded: 1 });
+
+    // Only reads reached the engine, and only against the two system objects.
+    expect(new Set(engine.finds.map((f) => f.object))).toEqual(new Set(['sys_file', 'sys_attachment']));
+  });
+
+  it('an empty deployment reports zero without claiming anything else', async () => {
+    const report = await inventoryStrandedFileOrphans(inventoryEngine({}));
+
+    expect(report).toMatchObject({ filesScanned: 0, stranded: 0, strandedBytes: 0, truncated: false });
+    const text = formatStrandedOrphanInventory(report);
+    expect(text).toContain('No stranded attachments-scope orphans');
+    expect(text).toContain('READ-ONLY');
+  });
+
+  it('names its scope in the rendered report, so the total cannot be read as "all orphans"', async () => {
+    const report = await inventoryStrandedFileOrphans(inventoryEngine({ files: [strandedRow('f1')] }));
+
+    const text = formatStrandedOrphanInventory(report);
+    expect(text).toContain('attachments-scope');
+    expect(text).toContain('the other scopes');
+  });
+});
+
+describe('formatBytes', () => {
+  it('renders magnitudes an operator can act on', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(999)).toBe('999 B');
+    expect(formatBytes(1024)).toBe('1.0 KiB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MiB');
+    expect(formatBytes(3 * 1024 ** 3)).toBe('3.0 GiB');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * The ownership question is the reap guard's own — not a copy of it
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+describe('the inventory asks the reap guard question, at full strength', () => {
+  it('the guard and the inventory reach the same verdict on the same ref_*-owned row', async () => {
+    // One fact — "zero join rows, but the ref_* columns name an owner" — and
+    // two consumers. The guard must VETO (un-tombstone, reclaim nothing); the
+    // inventory must EXCLUDE (not an orphan). If these ever disagree, the
+    // inventory's number is sizing a delete the guard would refuse.
+    const owned = strandedRow('f_owned', { ref_object: 'product', ref_id: 'rec_1' });
+
+    const inventory = await inventoryStrandedFileOrphans(inventoryEngine({ files: [owned] }));
+    expect(inventory.stranded).toBe(0);
+    expect(inventory.heldByFieldOwner).toBe(1);
+
+    const guardEngine = {
+      async find() {
+        return [];
+      },
+      async findOne() {
+        return null;
+      },
+      update: vi.fn(async () => ({})),
+    } as any;
+    const storage = { delete: vi.fn(async () => {}) };
+    const guard = createSysFileReapGuard(guardEngine, () => storage as any, silentLogger(), async () => true);
+
+    const confirmed = await guard('sys_file', [{ ...owned, status: 'deleted', deleted_at: '2026-02-01T00:00:00.000Z' }]);
+
+    expect(confirmed).toEqual([]); // vetoed
+    expect(storage.delete).not.toHaveBeenCalled(); // no bytes reclaimed
+    expect(guardEngine.update).toHaveBeenCalledTimes(1); // un-tombstoned
+  });
+
+  it('findFileHolder names the surface, and a join row wins over the columns', async () => {
+    const engine = { async find() { return [{ id: 'a1' }]; } } as any;
+    expect(await findFileHolder(engine, 'f1', { ref_object: 'p', ref_id: 'r' })).toBe('attachment');
+
+    const empty = { async find() { return []; } } as any;
+    expect(await findFileHolder(empty, 'f1', { ref_object: 'p', ref_id: 'r' })).toBe('field-owner');
+    expect(await findFileHolder(empty, 'f1', {})).toBe(null);
+    // A recorded object with an EMPTY record id is not an owner — the guard's
+    // long-standing reading, preserved.
+    expect(await findFileHolder(empty, 'f1', { ref_object: 'p', ref_id: '' })).toBe(null);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * The premise, through the real LifecycleService
+ *
+ * The whole card rests on one claim: a stranded orphan matches NEITHER
+ * declared policy, so the platform sweep never nominates it and the reap guard
+ * is never asked about it. Asserting that against a fake would be circular, so
+ * these cases drive the real `LifecycleService` against the real `sys_file`
+ * lifecycle declaration and observe which rows a guard is actually handed.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const FIXED_NOW = Date.parse('2026-08-23T00:00:00.000Z');
+const daysAgo = (n: number) => new Date(FIXED_NOW - n * 86_400_000).toISOString();
+
+function sweepEngine(files: Array<Record<string, unknown>>) {
+  const store = new Map(files.map((f) => [String(f.id), { ...f }]));
+  const engine: any = {
+    registry: {
+      getAllObjects: () => [{ name: 'sys_file', lifecycle: (SystemFile as any).lifecycle }],
+    },
+    async find(_object: string, options: any) {
+      const rows = Array.from(store.values()).filter((r) => matches(r, options?.where));
+      return typeof options?.limit === 'number' ? rows.slice(0, options.limit) : rows;
+    },
+    async delete(_object: string, options: any) {
+      // Pinned to the real dispatch predicate: the reaper's per-id delete must
+      // be a shape `ObjectQL.delete` actually accepts, or this double would be
+      // proving nomination against a call the engine refuses.
+      assertEngineDeleteDispatch(options);
+      const id = String((options?.where as any)?.id);
+      const had = store.delete(id);
+      return { deletedCount: had ? 1 : 0 };
+    },
+    getDriverForObject: () => ({}),
+    datasource: () => ({}),
+  };
+  return { engine, store };
+}
+
+describe("[#10950] the sweep cannot nominate a stranded orphan — the card's premise", () => {
+  it('is the real lifecycle declaration under test', () => {
+    const lc = (SystemFile as any).lifecycle;
+    expect(lc.ttl).toEqual({ field: 'deleted_at', expireAfter: '30d' });
+    expect(lc.retention).toEqual({ maxAge: '7d', onlyWhen: { status: 'pending' } });
+  });
+
+  it('hands the guard the tombstoned and the pending rows, and NEVER the stranded orphan', async () => {
+    const { engine } = sweepEngine([
+      // The subject: orphaned before the forward-only fixes, never tombstoned.
+      strandedRow('f_stranded', { created_at: daysAgo(400) }),
+      // Tombstoned orphan, past the 30d TTL → ttl policy nominates it.
+      strandedRow('f_tomb', { status: 'deleted', deleted_at: daysAgo(60), created_at: daysAgo(400) }),
+      // Never-completed upload, past 7d → retention policy nominates it.
+      strandedRow('f_pending', { status: 'pending', created_at: daysAgo(400) }),
+    ]);
+
+    const seen: string[] = [];
+    const service = new LifecycleService({
+      getEngine: () => engine,
+      logger: silentLogger(),
+      now: () => FIXED_NOW,
+      initialDelayMs: 1,
+      sweepIntervalMs: 10,
+    } as any);
+    service.registerReapGuard('sys_file', async (_object, rows) => {
+      for (const r of rows) seen.push(String(r.id));
+      return []; // veto everything: this test observes nomination, not reaping
+    });
+
+    await service.sweep();
+
+    expect(seen.sort()).toEqual(['f_pending', 'f_tomb']);
+    expect(seen).not.toContain('f_stranded');
+  });
+
+  it('and age does not help it — a stranded orphan is still not a candidate years later', async () => {
+    const { engine } = sweepEngine([strandedRow('f_stranded', { created_at: daysAgo(3650) })]);
+
+    const seen: string[] = [];
+    const service = new LifecycleService({
+      getEngine: () => engine,
+      logger: silentLogger(),
+      now: () => FIXED_NOW,
+      initialDelayMs: 1,
+      sweepIntervalMs: 10,
+    } as any);
+    service.registerReapGuard('sys_file', async (_object, rows) => {
+      for (const r of rows) seen.push(String(r.id));
+      return [];
+    });
+
+    await service.sweep();
+
+    expect(seen).toEqual([]);
+    // …while the inventory finds exactly that row. The leak is real and the
+    // pass measures it.
+    const report = await inventoryStrandedFileOrphans(
+      inventoryEngine({ files: [strandedRow('f_stranded', { created_at: daysAgo(3650) })] }),
+    );
+    expect(report.stranded).toBe(1);
+  });
+});

--- a/packages/services/service-storage/src/stranded-orphan-inventory.ts
+++ b/packages/services/service-storage/src/stranded-orphan-inventory.ts
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { keysetWalk } from '@objectstack/types';
+import { findFileHolder, type AttachmentLifecycleEngine } from './attachment-lifecycle.js';
+
+/**
+ * Stranded `sys_file` orphan inventory (#10950) — READ-ONLY.
+ *
+ * ## What is stranded, and why it can never un-strand itself
+ *
+ * `sys_file` declares (`objects/system-file.object.ts`):
+ *
+ *     lifecycle: {
+ *       ttl:       { field: 'deleted_at', expireAfter: '30d' },
+ *       retention: { maxAge: '7d', onlyWhen: { status: 'pending' } },
+ *     }
+ *
+ * The LifecycleService turns those into the only two nomination filters that
+ * ever reach this object — `{ deleted_at: { $lt: cutoff } }` and
+ * `{ created_at: { $lt: cutoff }, status: 'pending' }` (`reap()` in objectql's
+ * `lifecycle/lifecycle-service.ts`). A file whose `deleted_at` is NULL and
+ * whose status is `committed` satisfies NEITHER. It is never a sweep
+ * candidate, so the reap guard is never asked about it, so its storage bytes
+ * are never reclaimed. The object's own comment says the same thing from the
+ * other side: "Committed rows carry neither trigger … so they are immortal."
+ *
+ * That is fine for a live file and permanent for an orphaned one. Two verbs
+ * used to produce orphans without writing the tombstone that would have put
+ * them on the TTL path:
+ *
+ *   - the DELETE verb, before #10240 — a predicate delete of `sys_attachment`
+ *     join rows dispatched per-row, the handler's stash died with the row, and
+ *     no tombstone was written.
+ *   - the UPDATE verb, before #10171 — an update re-pointing a join row's
+ *     `file_id` detached the prior file and nothing said so.
+ *
+ * ## Why ONE predicate enumerates BOTH legacy classes
+ *
+ * Both fixes are forward-only: they changed what the next write does and
+ * touched no already-written row. And both verbs leak into the SAME terminal
+ * state — `scope='attachments'`, `status='committed'`, `deleted_at` NULL, zero
+ * `sys_attachment` join rows — because in both cases the miss was simply that
+ * `tombstoneOrphanedFiles` never ran. Nothing in the data records WHICH verb
+ * stranded a given row: there is no provenance column, and the two classes are
+ * indistinguishable by construction, not merely by omission here. So the
+ * single predicate below is a COMPLETE enumeration of both classes, not a
+ * count of one of them. Splitting the total by verb is not possible from the
+ * data and this module does not pretend otherwise.
+ *
+ * ## The ownership question is the guard's, not a weaker one
+ *
+ * A file with zero join rows may still be owned through the `ref_*` columns
+ * (field-file lineage, ADR-0104 / #3459 PR-5b). Counting it as an orphan would
+ * put a LIVE file on a list whose whole purpose is to size a future byte
+ * delete. This module therefore calls {@link findFileHolder} — the very
+ * function the reap guard calls — rather than reimplementing the test. Per
+ * candidate, one query, exactly the guard's query. That costs one read per
+ * candidate instead of one per page; exactness wins here, because the number
+ * this produces is what a destructive step 2 would be authorised against.
+ *
+ * ## Scope
+ *
+ * `scope === 'attachments'` ONLY. Those are the files whose ownership is
+ * expressed as `sys_attachment` join rows, so they are the only ones a
+ * join-row count can speak about at all. Files in the other scopes are
+ * governed by the field-reference seam (`releaseOwnership` in
+ * `file-reference-lifecycle.ts`) and are reconciled by `verifyFileReferences`,
+ * which reports its own `unreferenced_file` advisory — and which deliberately
+ * skips attachments-scope files, so the two passes partition the population
+ * rather than overlapping. Every count here is labelled with its scope for
+ * that reason: a total that reads as "all orphans" but means "attachments-
+ * scope orphans" is the kind of number that gets acted on wrongly.
+ *
+ * ## ADR-0057 §3.3
+ *
+ * §3.3 forbids a bespoke SWEEPER: "detection and scheduling stay inside the
+ * single platform sweep … the guard is a domain callback, not a scheduler."
+ * This pass schedules nothing, registers nothing, and deletes nothing — it is
+ * an operator-invoked reconciliation read, the same shape (and the same file
+ * neighbourhood) as `verifyFileReferences`. It does not become a second
+ * detection-and-scheduling path, because it never acts on what it finds.
+ *
+ * ⛔ It writes nothing. It tombstones nothing. It deletes nothing. Authorising
+ * the destructive backfill is a separate, deferred decision (#10950 step 2)
+ * that this inventory exists to inform.
+ */
+
+/** Rows read per page while walking `sys_file`. */
+const SCAN_PAGE_SIZE = 500;
+
+/** Reads are system-context: an orphan by definition has no one to read it. */
+const SYSTEM_CTX = { isSystem: true } as const;
+
+/** Default number of example rows carried back with the counts. */
+const DEFAULT_SAMPLE_LIMIT = 20;
+
+/** An example stranded row, so an operator can spot-check the verdict. */
+export interface StrandedOrphanSample {
+  fileId: string;
+  /** Storage key — where the bytes are. */
+  key?: string;
+  name?: string;
+  /** Recorded size in bytes; absent when the row never carried one. */
+  size?: number;
+  createdAt?: string;
+}
+
+export interface StrandedOrphanInventory {
+  /**
+   * The population this inventory speaks about. Always `'attachments'` — see
+   * the module comment. Present in the payload so a consumer cannot read the
+   * totals as covering every scope.
+   */
+  scope: 'attachments';
+  /** `sys_file` rows examined (attachments-scope, `status='committed'`). */
+  filesScanned: number;
+  /**
+   * Examined rows carrying a `deleted_at`, so the TTL can already nominate
+   * them. Not stranded — they are on the reap path and the guard will be
+   * asked about them.
+   */
+  alreadyOnTtlPath: number;
+  /** Excluded: at least one `sys_attachment` join row still points at it. */
+  heldByAttachment: number;
+  /**
+   * Excluded: ZERO join rows, but the `ref_*` columns name an owner. These are
+   * the rows a weaker question would have miscounted as orphans — live,
+   * field-owned files.
+   */
+  heldByFieldOwner: number;
+  /** Stranded orphans: nothing holds them and no policy can nominate them. */
+  stranded: number;
+  /** Summed `sys_file.size` over the stranded rows. */
+  strandedBytes: number;
+  /**
+   * Stranded rows whose `size` was absent or unusable. Their bytes are real
+   * but uncounted.
+   */
+  strandedRowsWithoutSize: number;
+  /**
+   * True when at least one stranded row had no usable `size`, i.e.
+   * {@link strandedBytes} is a LOWER BOUND on the reclaimable bytes rather
+   * than the figure.
+   */
+  bytesAreLowerBound: boolean;
+  /** True when `maxCandidates` stopped the walk — the counts are partial. */
+  truncated: boolean;
+  samples: StrandedOrphanSample[];
+}
+
+export interface StrandedOrphanInventoryOptions {
+  /**
+   * Safety bound on `sys_file` rows read. Exceeding it sets `truncated`, which
+   * makes every count a lower bound. Omit for a complete walk — and prefer
+   * omitting it, since a truncated inventory cannot size the population.
+   */
+  maxCandidates?: number;
+  /** Example rows to carry back (default 20). */
+  sampleLimit?: number;
+}
+
+/** Engine surface this pass needs — duck-typed like the other storage seams. */
+export type StrandedOrphanInventoryEngine = Pick<AttachmentLifecycleEngine, 'find'>;
+
+function usableSize(value: unknown): number | undefined {
+  const n = typeof value === 'string' && value.trim() !== '' ? Number(value) : value;
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}
+
+/**
+ * Count the `sys_file` rows that the forward-only fixes (#10171, #10240) would
+ * have tombstoned had they existed when the rows were orphaned, and that the
+ * reap guard would then confirm.
+ *
+ * ⛔ Read-only: no write of any kind is issued, on any object.
+ */
+export async function inventoryStrandedFileOrphans(
+  engine: StrandedOrphanInventoryEngine,
+  options: StrandedOrphanInventoryOptions = {},
+): Promise<StrandedOrphanInventory> {
+  const sampleLimit = options.sampleLimit ?? DEFAULT_SAMPLE_LIMIT;
+  const report: StrandedOrphanInventory = {
+    scope: 'attachments',
+    filesScanned: 0,
+    alreadyOnTtlPath: 0,
+    heldByAttachment: 0,
+    heldByFieldOwner: 0,
+    stranded: 0,
+    strandedBytes: 0,
+    strandedRowsWithoutSize: 0,
+    bytesAreLowerBound: false,
+    truncated: false,
+    samples: [],
+  };
+
+  // Seek by `id` rather than counting from the start (#4363): a row an offset
+  // walk skips is a row silently missing from a population count, and the
+  // result still looks like a clean run.
+  const walk = keysetWalk<Record<string, unknown>>(
+    (q) =>
+      engine.find('sys_file', {
+        ...q,
+        fields: [
+          'id',
+          'key',
+          'name',
+          'size',
+          'scope',
+          'status',
+          'deleted_at',
+          'ref_object',
+          'ref_id',
+          'created_at',
+        ],
+        context: { ...SYSTEM_CTX },
+      }),
+    {
+      where: { scope: 'attachments', status: 'committed' },
+      pageSize: SCAN_PAGE_SIZE,
+      max: options.maxCandidates,
+    },
+  );
+
+  for await (const page of walk.pages()) {
+    for (const row of page) {
+      if (row?.id == null) continue;
+      // Re-apply the filter in process rather than trusting it round-tripped.
+      // A driver that dropped part of the `where` would otherwise WIDEN this
+      // population, and widening is the direction that puts live files on the
+      // list. (Same posture as `verifyFileReferences`, for the same reason.)
+      if (row.scope !== 'attachments' || row.status !== 'committed') continue;
+      report.filesScanned++;
+
+      // A `deleted_at` makes the row TTL-nominable, whatever else is true of
+      // it — so it is on the reap path and is not this card's subject.
+      if (row.deleted_at != null && row.deleted_at !== '') {
+        report.alreadyOnTtlPath++;
+        continue;
+      }
+
+      const id = String(row.id);
+      const holder = await findFileHolder(engine, id, row);
+      if (holder === 'attachment') {
+        report.heldByAttachment++;
+        continue;
+      }
+      if (holder === 'field-owner') {
+        report.heldByFieldOwner++;
+        continue;
+      }
+
+      report.stranded++;
+      const size = usableSize(row.size);
+      if (size === undefined) {
+        report.strandedRowsWithoutSize++;
+        report.bytesAreLowerBound = true;
+      } else {
+        report.strandedBytes += size;
+      }
+      if (report.samples.length < sampleLimit) {
+        report.samples.push({
+          fileId: id,
+          key: typeof row.key === 'string' ? row.key : undefined,
+          name: typeof row.name === 'string' ? row.name : undefined,
+          size,
+          createdAt: typeof row.created_at === 'string' ? row.created_at : undefined,
+        });
+      }
+    }
+  }
+
+  report.truncated = walk.truncated;
+  return report;
+}
+
+/** Human-readable bytes, for the report line an operator reads. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return 'unknown';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unit]}`;
+}
+
+/** Render an inventory as human-readable lines (CLI output). */
+export function formatStrandedOrphanInventory(report: StrandedOrphanInventory): string {
+  const lines: string[] = [];
+  lines.push(
+    `Scanned ${report.filesScanned} committed ${report.scope}-scope sys_file row(s).`,
+  );
+  if (report.truncated) {
+    lines.push(
+      '⚠ Walk was truncated by --max-candidates — every count below is a LOWER BOUND. ' +
+        'Re-run without the bound to size the population.',
+    );
+  }
+  lines.push(
+    `   held by a sys_attachment join row : ${report.heldByAttachment}`,
+    `   held via ref_* field ownership    : ${report.heldByFieldOwner}` +
+      (report.heldByFieldOwner > 0
+        ? '   ← live files a join-row-only question would have miscounted as orphans'
+        : ''),
+    `   already tombstoned (on the TTL)   : ${report.alreadyOnTtlPath}`,
+  );
+  lines.push('');
+  if (report.stranded === 0) {
+    lines.push(
+      `✅ No stranded ${report.scope}-scope orphans on this deployment. ` +
+        'Nothing here is unreachable by the platform sweep.',
+    );
+  } else {
+    lines.push(
+      `❗ ${report.stranded} stranded ${report.scope}-scope orphan(s), ` +
+        `${formatBytes(report.strandedBytes)} (${report.strandedBytes} bytes)` +
+        (report.bytesAreLowerBound
+          ? ` — LOWER BOUND: ${report.strandedRowsWithoutSize} row(s) carry no recorded size`
+          : ''),
+    );
+    lines.push(
+      '   These match neither lifecycle policy on sys_file, so the platform sweep can never',
+      '   nominate them and their bytes are never reclaimed.',
+    );
+    if (report.samples.length > 0) {
+      lines.push('', `   Examples (${report.samples.length} of ${report.stranded}):`);
+      for (const s of report.samples) {
+        const size = s.size === undefined ? 'size unrecorded' : formatBytes(s.size);
+        lines.push(`     ${s.fileId}  ${size}  ${s.key ?? '(no key)'}`);
+      }
+    }
+  }
+  lines.push(
+    '',
+    `Scope note: this pass covers ${report.scope}-scope files only — the files whose referrers are`,
+    '  sys_attachment join rows. Files in the other scopes are governed by the field-reference',
+    '  seam; run "os migrate files-to-references --include-unreferenced" to reconcile those.',
+    'This pass is READ-ONLY: nothing was written, tombstoned or deleted.',
+  );
+  return lines.join('\n');
+}

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -1830,6 +1830,11 @@
       "file": "packages/services/service-storage/src/storage-routes.metadata-outage.test.ts",
       "verb": "delete",
       "pinned": 1
+    },
+    {
+      "file": "packages/services/service-storage/src/stranded-orphan-inventory.test.ts",
+      "verb": "delete",
+      "pinned": 1
     }
   ]
 }


### PR DESCRIPTION
Part of #10950 — step 1 of the maintainer's 2026-08-22 ruling.

⛔ **Deliberately not a closing reference.** The ruling defers step 2 — authorising the destructive backfill — back onto that same card, to be re-adjudicated once these numbers land. Merging this must leave #10950 open.

## The ruling this implements

> **A: report-only inventory first; the tombstoning decision returns with the numbers**
>
> Scope: a read-only reconciliation pass (operator-invoked `os` subcommand or equivalent — dev picks the harness within ADR-0057 §3.3's no-bespoke-sweeper constraint, report-only is compatible) that enumerates candidate orphans across **both** legacy classes (pre-#10171 update-verb and pre-#10240 delete-verb), applying the same `ref_*` ownership re-verification the reap guard uses — never a weaker question — and reports count + byte magnitude **back onto this card**. ⛔ Writes nothing, tombstones nothing. Step 2 (authorizing the destructive backfill) is re-adjudicated here when the numbers land.

## The premise, re-verified on current `main`

The card's core claim holds, and it is now pinned executably rather than argued.

`sys_file`'s declared lifecycle (`objects/system-file.object.ts`) offers exactly two nomination routes, and `LifecycleService.reap()` turns them into exactly two filters:

- `ttl { field: 'deleted_at', expireAfter: '30d' }` becomes a filter on `deleted_at` being older than the cutoff.
- `retention { maxAge: '7d', onlyWhen: { status: 'pending' } }` becomes a filter on `created_at` older than the cutoff, narrowed to `status: 'pending'`.

A row with `deleted_at` NULL and `status='committed'` satisfies **neither**. The object's own comment already says so from the other side: *"Committed rows carry neither trigger … so they are immortal."* The row is never a candidate, the reap guard is never asked about it, and its bytes are never reclaimed.

New tests drive the **real** `LifecycleService` against the **real** `SystemFile.lifecycle` declaration and observe which rows a registered guard is actually handed: the tombstoned row and the `pending` row arrive, the stranded orphan never does — not at 400 days old, not at 3650.

**The population is fixed and finite**, and this PR confirms it rather than assuming it: both forward-only repairs have landed, and both write verbs now reach the orphan rule through the single shared `tombstoneOrphanedFiles` helper, so no verb is still minting members. The count does not decay while the maintainer looks at it.

## Both legacy classes, and why one predicate is the complete enumeration

The two verbs leak into the **same terminal state** — attachments-scope, `status='committed'`, `deleted_at` NULL, zero `sys_attachment` join rows — because in both cases the miss was simply that `tombstoneOrphanedFiles` never ran. Nothing in the data records which verb stranded a given row: there is no provenance column, so the classes are indistinguishable by construction, not merely by omission here.

So the single predicate is a **complete enumeration of both classes**, not a count of one of them — which is the failure the card was filed about. Splitting the total by verb is not possible from the data, and the module says so rather than implying a split it cannot make.

## The ownership question is the reap guard's own, not a copy of it

The ruling requires "the same `ref_*` ownership re-verification the reap guard uses — never a weaker question". The only way to make *"the same"* a property of the code rather than a claim in a comment is for both callers to run one function, so `createSysFileReapGuard`'s hold test is extracted as `findFileHolder`. It takes an engine, a file id and the row, and answers with the string `attachment`, the string `field-owner`, or `null` — join rows first, then the `ref_*` columns, exactly as the guard has always asked. `hasFieldReferenceOwner` is the ownership limb on its own: `ref_object` non-null and `ref_id` non-null and non-empty. `ref_field` is deliberately not consulted, preserving the guard's reading that a slot is identified by object plus record.

The guard's behaviour is unchanged — a pure refactor, and its existing pins cover it.

**Why this matters concretely:** a file with **zero** join rows may still be owned through the ADR-0104 / #3459 ownership columns. Any count built on join rows alone reports that live file as an orphan, and this inventory's whole purpose is to size a future byte delete. There is a dedicated test for exactly that row, and the ablation below shows what a weaker question would have cost.

## Harness choice — ADR-0057 §3.3

§3.3 forbids a bespoke **sweeper**: *"detection and scheduling stay inside the single platform sweep … the guard is a domain callback, not a scheduler."* Read from the clause itself rather than from the card's paraphrase, it governs **ongoing detection and scheduling**. This pass schedules nothing, registers nothing, and acts on nothing it finds — it is an operator-invoked reconciliation read, the same shape and the same file neighbourhood as `verifyFileReferences`, which already exists under the same constraint for the sibling seam. It cannot become a second detection-and-scheduling path because it never acts.

## What ships

- `inventoryStrandedFileOrphans()` in `@objectstack/service-storage` — walks attachments-scope committed `sys_file` rows by keyset (never by offset: a row an offset walk skips is silently missing from a population count), and buckets every scanned row into exactly one of *stranded*, *held by a join row*, *held via `ref_*`*, or *already on the TTL path*. That partition is asserted, so a row cannot go uncounted.
- `formatStrandedOrphanInventory()` for the operator-facing render. The package barrel publishes only that, `inventoryStrandedFileOrphans()` and the inventory result types — the shared ownership predicate stays internal, since nothing outside the package pulls on it.
- `os storage orphans` — the operator surface, with `--json`, `--max-candidates` and `--samples`.

⛔ **It writes nothing, tombstones nothing and deletes nothing.** There is no `--apply` and no write path — deliberately, not as an unimplemented default.

Three honesty properties the report carries, because each one is a way this number could be acted on wrongly:

- **Scope is in the payload.** Every count is labelled `attachments`. Only those files are reachable through a join-row count at all; the other scopes are governed by the field-reference seam and are reconciled by `verifyFileReferences`, which deliberately skips attachments-scope files — so the two passes partition the population rather than overlapping. A total that reads as "all orphans" but means "attachments-scope orphans" is exactly the number that gets acted on wrongly.
- **Byte magnitude declares when it is a lower bound.** `strandedBytes` sums the recorded `sys_file.size`; a stranded row with no usable size is counted in `strandedRowsWithoutSize` and sets `bytesAreLowerBound`. Treating a missing size as zero would under-report the leak while reading as a precise figure.
- **A bounded walk says so.** `--max-candidates` sets `truncated`, and the rendered report then calls every count a lower bound.

## The numbers

The ruling asks for count and byte magnitude reported back onto the card. **The production number has to come from an operator run against real tenant data — this PR ships the command that produces it.** What can be measured from this container is reported without dressing it up as more:

Running the real command end-to-end against a freshly provisioned deployment:

```
{ "readOnly": true, "scope": "attachments",
  "filesScanned": 0, "alreadyOnTtlPath": 0,
  "heldByAttachment": 0, "heldByFieldOwner": 0,
  "stranded": 0, "strandedBytes": 0,
  "strandedRowsWithoutSize": 0, "bytesAreLowerBound": false,
  "truncated": false, "samples": [] }
```

Zero here is a **confirmed-empty population, not an unmeasured one** — the boot log states the mechanism: *"new datastore attested at creation: adr-0104-file-references … no legacy data can exist here"*. A deployment with no attachment history has no pre-fix orphans by construction. The run exercises the whole operator path (boot, registry probe, keyset walk, render, clean JSON on stdout with logs on stderr), and it is not evidence about any deployment that has such a history.

The counting itself is pinned on non-empty populations by tests with exact expected counts and byte totals, including the `ref_*`-owned exclusion, against real ObjectQL and the real `LifecycleService`.

## Verification

Union re-derived with `node scripts/pm/dispatch-gates.mjs` (no hand-supplied paths) on the final commit with a clean tree; the per-gate verdict lines are in the report comment on #10950.

**Reverse verification.** `findFileHolder` was weakened to the join-row-only question — precisely the weaker question the ruling forbids — with the mutation proven on disk by anchor count before and after, and restored under an `EXIT`/`INT`/`TERM` trap. No rebuild leg is involved or needed: the tests import the module by relative path, so vitest resolves this package's own source and no `dist` hop can serve a stale artifact.

Five cases turned red, and the fifth is the one worth reading:

```
x  EXCLUDES a file with ZERO join rows that is ref_*-owned - the case a weaker question gets wrong
x  writes nothing - every write seam on the double throws
x  the guard and the inventory reach the same verdict on the same ref_*-owned row
x  findFileHolder names the surface, and a join row wins over the columns
x  vetoes and un-tombstones a field file that regained an owner (ownership re-verify)
```

That last one is `createSysFileReapGuard`'s **own pre-existing pin**, and it fails from the same one-line ablation. The two consumers really do share one predicate; the inventory cannot drift weaker than the guard without breaking the guard's own tests.

**Read-only is enforced, not asserted.** The engine double hands the pass a Proxy that throws on any member other than `find`, so `update`, `insert`, `delete`, `updateMany`, `deleteMany` and anything added later all fail identically. Every case in the file runs through it, so "this pass writes nothing" is a property the suite holds continuously rather than one checked once against a list of verbs someone thought of.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_

---
_Generated by [Claude Code](https://claude.ai/code)_