### PR TITLE
cli: every documented `os auth` / `os studio` invocation now names a command that resolves

### DIFF
--- a/.changeset/cli-auth-command-examples-resolve.md
+++ b/.changeset/cli-auth-command-examples-resolve.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): `register`/`whoami`/`logout` examples no longer spell `os auth <cmd>` in live `--help` output (#11221)
+
+`static override examples` is printed verbatim as part of oclif's `--help`. `register.ts`,
+`whoami.ts` and `logout.ts` live at the **root** of `packages/cli/src/commands/`, so oclif's
+pattern-strategy loader registers them as `register` / `whoami` / `logout` — but their
+`examples` spelled an `os auth <cmd>` shape that has never resolved. A user copy-pasting
+straight out of `--help` hit `Error: Command auth:whoami not found.` (exit 2), the same dead
+command #10927 fixed in `packages/cli/README.md` and #10967 fixed for the `environments`
+topic, this time on the root auth-family commands.
+
+Measured against the built CLI (`packages/cli/bin/run.js`) before the fix: `os auth whoami`,
+`os auth register` and `os auth logout` each exited 2 with `Error: Command auth:<cmd> not
+found.`, while the bare `os whoami` / `os register` / `os logout` each exited 0 and printed
+help — so the examples named the one spelling that could not work. All seven `examples`
+entries now say the bare, registered spelling.
+
+The exported default class on each file is renamed to match its real, file-path-derived
+command id (`AuthRegister` → `Register`, `AuthWhoami` → `Whoami`, `AuthLogout` → `Logout`).
+oclif derives a command's id purely from its file path, never from the class name, so this
+changes no runtime resolution — confirmed by rebuilding the CLI and re-running `--help` on
+all three. The rename also brings them onto this package's measured convention: every other
+root-level command class is exactly the PascalCase of its filename. `login.ts` keeps
+`AuthLogin` — its `examples` were already correct (`$ os login`), so it is outside this
+card's file surface; that lone remaining class-name holdout is reported, not swept.
+
+`environments.test.ts`'s `#10967` pin carried a deliberately self-retiring `EXCLUDED` entry
+for each of these three files, asserting the defect was *still present* so the exemption
+could not outlive its cause. This fix removed the last unresolved entry, that assertion went
+red exactly as designed, and the three entries are retired — the map is now empty and all
+three files are scanned by the main assertion like every other command source.

--- a/.changeset/cli-readme-drop-os-studio.md
+++ b/.changeset/cli-readme-drop-os-studio.md
@@ -1,0 +1,20 @@
+---
+"@objectstack/cli": patch
+---
+
+docs(cli): drop the `os studio` row from the README command table — the CLI ships no such command (#11180)
+
+`packages/cli/README.md`'s **Development** command table listed
+`` | `os studio [config]` | Launch Studio UI with development server | ``. The CLI has no
+`studio` command and has not had one: the oclif command set is pattern-derived from
+`packages/cli/src/commands/**`, and loading the built CLI's own `Config` enumerates 60
+registered ids with **zero** matching `studio` (control: `dev`, `serve`, `login`, `logout`,
+`register`, `whoami` are all present in the same enumeration, so the check is not vacuous).
+Running it confirms the same from the outside — `os studio --help` exits 2 with
+`Error: Command studio not found.`
+
+The row is deleted rather than rewritten. Studio is not reached by a CLI command at all —
+it is served by the console at `/_console/studio` after `os dev` or `os serve`, both of
+which the same table already lists — so a replacement row would reintroduce the category
+error that made this one wrong: a Commands table is a list of commands, and a browser route
+is not one.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,7 +42,6 @@ os compile
 | `os init [name]` | Initialize a new ObjectStack project in the current directory |
 | `os dev [package]` | Start development mode with hot reload |
 | `os serve [config]` | Start the ObjectStack server with plugin auto-detection |
-| `os studio [config]` | Launch Studio UI with development server |
 
 ### Build & Validate
 

--- a/packages/cli/src/commands/environments/environments.test.ts
+++ b/packages/cli/src/commands/environments/environments.test.ts
@@ -151,23 +151,27 @@ describe('os environments commands', () => {
  * back" (AGENTS.md, Route & surface ownership §3): a shape this pin cannot
  * parse is exactly the shape that could hide a stale command undetected.
  *
- * ## The one exclusion, and why it must self-retire
+ * ## The one exclusion, and why it self-retired
  *
  * `register.ts` / `whoami.ts` / `logout.ts` are root-level commands whose
- * `examples` say `os auth register` / `os auth whoami` / `os auth logout`,
- * though no `auth` topic has ever existed for them (confirmed via
+ * `examples` USED TO say `os auth register` / `os auth whoami` / `os auth
+ * logout`, though no `auth` topic has ever existed for them (confirmed via
  * `--help`: `Error: Command auth:whoami not found.`) — the same defect
  * class as #10967, found by scanning the whole tree, but not #10967's to
- * fix (outside its dispatched file surface). Filed as #11221. `EXCLUDED`
- * carves exactly those three files out of the main assertion below, but a
- * silent, permanent exemption is its own defect — a file excluded here
- * stops being checked by this pin forever, even after #11221 lands and the
- * excluded condition no longer holds. So a second `it.each` re-runs the
- * SAME predicate over the excluded files and asserts it still finds an
- * unresolved entry: when #11221's fix removes the last one, that assertion
- * goes red on purpose, and the failure message says to delete the entry.
- * The pattern (map-of-reason + filtered main assertion + a "still needs
- * its exclusion" retiring assertion) matches
+ * fix (outside its dispatched file surface). Filed as #11221 and fixed
+ * there, so `EXCLUDED` is now empty and all three are scanned by the main
+ * assertion like every other command source.
+ *
+ * The mechanism stays, because it is what made that handoff safe: a silent,
+ * permanent exemption is its own defect — a file excluded here stops being
+ * checked by this pin forever, even after the excluded condition no longer
+ * holds. So a second `it.each` re-runs the SAME predicate over the excluded
+ * files and asserts it still finds an unresolved entry. That is not
+ * hypothetical here: when #11221's fix removed the last unresolved entry,
+ * this assertion went red on purpose for all three files, and its message
+ * ("remove it from EXCLUDED above") is what retired them. The pattern
+ * (map-of-reason + filtered main assertion + a "still needs its exclusion"
+ * retiring assertion) matches
  * `packages/create-objectstack/src/starter-comments-self-contained.test.ts`'s
  * `EXCLUDED`, which has retired this same way before (#11022).
  */
@@ -287,15 +291,15 @@ describe('#10967 pin: examples resolve to a real command id', () => {
   }
 
   /**
-   * Files with a KNOWN, currently-live instance of this defect class this
-   * card does not own the fix for (#11221). The retiring assertion below
-   * proves each entry is still load-bearing, not decorative.
+   * Nothing is excluded — every command source is scanned. `register.ts` /
+   * `whoami.ts` / `logout.ts` each carried a self-retiring entry here while
+   * their `os auth …` examples were #11221's to fix; that fix landed, the
+   * retiring assertion below went red exactly as designed, and the map goes
+   * back to empty rather than staying around as a silent exemption over three
+   * root-level commands. The assertion stays, so the next entry added here is
+   * held to the same self-retirement.
    */
-  const EXCLUDED = new Map<string, string>([
-    ['register.ts', '#11221: examples say `os auth register`, no `auth` topic exists'],
-    ['whoami.ts', '#11221: examples say `os auth whoami`, no `auth` topic exists'],
-    ['logout.ts', '#11221: examples say `os auth logout`, no `auth` topic exists'],
-  ]);
+  const EXCLUDED = new Map<string, string>();
 
   const sourceFiles = commandSourceFiles();
   const registeredIds = registeredCommandIds();

--- a/packages/cli/src/commands/logout.ts
+++ b/packages/cli/src/commands/logout.ts
@@ -5,11 +5,11 @@ import { printHeader, printSuccess, printError, emitJson } from '../utils/format
 import { deleteAuthConfig, readAuthConfig } from '../utils/auth-config.js';
 import { ObjectStackClient } from '@objectstack/client';
 
-export default class AuthLogout extends Command {
+export default class Logout extends Command {
   static override description = 'Clear stored authentication credentials';
 
   static override examples = [
-    '$ os auth logout',
+    '$ os logout',
   ];
 
   static override flags = {
@@ -19,7 +19,7 @@ export default class AuthLogout extends Command {
   };
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(AuthLogout);
+    const { flags } = await this.parse(Logout);
 
     try {
       if (!flags.json) {

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -59,13 +59,13 @@ async function promptPassword(promptText: string): Promise<string> {
   });
 }
 
-export default class AuthRegister extends Command {
+export default class Register extends Command {
   static override description = 'Create a new account and store credentials';
 
   static override examples = [
-    '$ os auth register',
-    '$ os auth register --email user@example.com --name "Jane Doe" --password mypassword',
-    '$ os auth register --url https://api.example.com',
+    '$ os register',
+    '$ os register --email user@example.com --name "Jane Doe" --password mypassword',
+    '$ os register --url https://api.example.com',
   ];
 
   static override flags = {
@@ -93,7 +93,7 @@ export default class AuthRegister extends Command {
   };
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(AuthRegister);
+    const { flags } = await this.parse(Register);
 
     try {
       if (!flags.json) {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -5,13 +5,13 @@ import { printHeader, printError, printKV, emitJson } from '../utils/format.js';
 import { createApiClient, requireAuth } from '../utils/api-client.js';
 import { formatOutput } from '../utils/output-formatter.js';
 
-export default class AuthWhoami extends Command {
+export default class Whoami extends Command {
   static override description = 'Show current session information';
 
   static override examples = [
-    '$ os auth whoami',
-    '$ os auth whoami --format json',
-    '$ os auth whoami --url https://api.example.com --token <token>',
+    '$ os whoami',
+    '$ os whoami --format json',
+    '$ os whoami --url https://api.example.com --token <token>',
   ];
 
   static override flags = {
@@ -34,7 +34,7 @@ export default class AuthWhoami extends Command {
   };
 
   async run(): Promise<void> {
-    const { flags } = await this.parse(AuthWhoami);
+    const { flags } = await this.parse(Whoami);
 
     try {
       const { client, token } = await createApiClient({


### PR DESCRIPTION
Fixes #11221
Fixes #11180

A family fold: two cards, one defect form — **a documented CLI invocation that does not resolve** — corrected to the real spelling, or removed. One commit per card, plus a third for the pin retirement the first commit fires. Verified against the **built** CLI, not by reading source.

> **A note on spelling in this body.** The defect is about an `os auth …` prefix, where `…` stands for `register` / `whoami` / `logout`. GitHub's body sanitizer strips short angle-bracket fragments — including inside code fences — so the angle-bracket placeholders that appear in the real source and in real CLI output are spelled without brackets here. The first version of this body lost them silently; this is the repair, not the original wording.

## The two cards

### #11221 — `register` / `whoami` / `logout` examples said `os auth …`

These three live at the **root** of `packages/cli/src/commands/`, so oclif's pattern-strategy loader registers them as `register` / `whoami` / `logout`. Their `static override examples` — which oclif prints verbatim in `--help` — spelled an `os auth …` shape that has never resolved.

Pre-fix, against `packages/cli/bin/run.js`:

```
$ node packages/cli/bin/run.js auth whoami --help
 ›   Error: Command auth:whoami not found.       (exit 2)
$ node packages/cli/bin/run.js auth register --help
 ›   Error: Command auth:register not found.     (exit 2)
$ node packages/cli/bin/run.js auth logout --help
 ›   Error: Command auth:logout not found.       (exit 2)
```

…while the bare `os whoami` / `os register` / `os logout` each exited 0 and printed help. The examples named the one spelling that could not work.

All seven `examples` entries now use the bare, registered spelling. **The check that closes this card** extracts the example lines from the rebuilt binary's own `--help` output and resolves each against the rebuilt binary's own registry:

```
RESOLVES  os register
RESOLVES  os register --email user@example.com --name "Jane Doe" --password mypassword
RESOLVES  os register --url https://api.example.com
RESOLVES  os whoami
RESOLVES  os whoami --format json
RESOLVES  os whoami --url https://api.example.com --token TOKEN
RESOLVES  os logout
---
example lines checked: 7, unresolved: 0

anti-vacuity, the PRE-FIX spellings through this same check:
  DEAD (expected)  os auth register
  DEAD (expected)  os auth whoami
  DEAD (expected)  os auth logout
  DEAD (expected)  os studio
```

(`TOKEN` on the sixth line is an angle-bracket `token` placeholder in the real example string and in the real output — respelled here per the note above.)

The anti-vacuity block is the part that makes the seven `RESOLVES` mean something: the same predicate still rejects the spellings this PR removed.

**Class renames.** `AuthRegister` → `Register`, `AuthWhoami` → `Whoami`, `AuthLogout` → `Logout`. oclif derives a command's id purely from its file path, never from the class name, so this changes no runtime resolution — re-verified by rebuilding and re-running `--help` on all three. It also brings them onto this package's **measured** convention: surveying every root-level command source, each class is exactly the PascalCase of its filename, with the `Auth*` quartet the sole exception.

`login.ts` keeps `AuthLogin`. Its `examples` were already correct (`$ os login`), which puts it outside this card's file surface; that lone remaining holdout is reported, not swept.

### #11180 — the README listed `os studio`, a command the CLI does not ship

`packages/cli/README.md`'s Development table carried a row reading `os studio [config]` — "Launch Studio UI with development server". Two independent readings, because "confirmed absent from the command registry" deserves better than a grep:

1. **From inside** — loading the built CLI's own oclif `Config` enumerates **60** registered ids, of which **zero** match `studio` (and zero match `auth`, and there is no `auth` topic). Control, same enumeration: `dev`, `serve`, `login`, `logout`, `register`, `whoami` all present. The control is what makes the zero evidence rather than a broken probe.
2. **From outside** — `os studio --help` exits 2 with `Error: Command studio not found.`

The row is **deleted rather than rewritten**. Studio is not reached by a CLI command at all — the console serves it at `/_console/studio` after `os dev` or `os serve`, both of which this same table already lists. A replacement row would reintroduce the category error that made this one wrong: a Commands table lists commands, and a browser route is not one.

## The third commit: a pin that retired itself, exactly as designed

`packages/cli/src/commands/environments/environments.test.ts` (landed by #11227 for #10967) carries a deliberately **self-retiring** `EXCLUDED` map. Its header states the contract:

> when #11221's fix removes the last one, that assertion goes red on purpose, and the failure message says to delete the entry

That is measured here, not predicted. With **only** the first commit applied:

```
 × register.ts still needs its exclusion (owned by #11221)
 × whoami.ts  still needs its exclusion (owned by #11221)
 × logout.ts  still needs its exclusion (owned by #11221)
 Tests  3 failed | 68 passed (71)

 AssertionError: register.ts no longer has an unresolved examples entry --
 remove it from EXCLUDED above so it is scanned like every other command source.
```

So #11221 could not land green without this edit, and the failing test names this card as the owner of the remedy. After retiring: **71 passed (71)**, with all three files now covered by the **main** assertion instead of exempted — the pin got stronger, not weaker.

Retirement shape follows the precedent the file names as its own (`packages/create-objectstack/src/starter-comments-self-contained.test.ts`, retired the same way in #11022): the map goes back to empty, **the retiring assertion stays** so the next entry added is held to the same self-retirement, and the header records that it fired.

**On file ownership**, since this path was on the dispatch's read-only list: that fence was attributed to #10967, which is **closed** (`completed`, 2026-08-23T05:11:28Z) with PR #11227 **merged** at 04:58 — roughly 3.5h before dispatch. No open PR or branch touches the file. The one genuinely live hold, #11268, touches `serve.ts`, `test/serve-node-env-production-default.e2e.test.ts`, `vitest.config.ts` and its changeset — checked against its file list, zero overlap. Both genuinely-held surfaces (`serve.ts`, `packages/cli/test/**`) are untouched by this branch. Kept as its own commit so it can be dropped independently. Confirmed by the dispatching PM before this PR was opened.

## Out of scope, filed not swept

- **#11313** — `packages/cli/src/utils/auth-config.ts:60` throws "No stored credentials found. Please run `os auth login` first.", and `os auth login` is dead too (exit 2, measured). Deliberately **not** fixed here: it is a user-facing thrown error rather than an `examples` string, so it is a different surface and belongs to a graded card of its own rather than being slipped into this one. Worth noting the existing pin cannot see this class at all — it reads `examples` arrays via AST.

## Verification

All at final head `bc08f9bb`, each verdict quoted from what the gate itself printed.

- `pnpm --filter @objectstack/cli test` — **`Test Files 160 passed (160)` / `Tests 1822 passed (1822)`**, `VERDICT command-exit 0`. Includes `remote-api-commands.test.ts`, which default-imports two of the renamed classes (default imports are rename-proof, so that held file needed no edit and still passes) and `environments.test.ts`.
- `pnpm --filter @objectstack/cli typecheck` (`tsc --noEmit`) — `VERDICT command-exit 0`.
- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — `VERDICT command-exit 0` in 81s. Run in full; no narrowing taken.
- Gate families re-derived at this head with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (change set read by the script itself, three-dot, 7 paths). All 14 path-matched families run and green: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-cross-package-test-inputs`, `check-empty-changeset`, `check-plugin-teardown-shape`, `check-affected-docs`.
- Convention-triggered families (this edits a test file), all green: `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, plus `check:nul-bytes`.
- `check:type-check-debt` — first attempt **refused** (`--re-measure cannot run: 1 workspace dependenc(ies) … have no built type entry point on disk -- @objectstack/service-knowledge`), which means *not measured*, not *passed*. Built that closure and re-ran: **`OK — 33 ledger entr(ies) re-measured in 248.9s, 1897 raw tsc error(s) total, none above its recorded number`**. The `--lower` surplus it reports sits in `plugin-approvals` / `runtime` / `plugin-auth` / `trigger-record-change` — all pre-existing and untouched by this diff.

Two changesets, one per card, both `patch` on `@objectstack/cli`, matching the precedent of both sibling fixes (#11227 for the help-text class, #10968 for the README-prose class). No `skip-changeset`.

_Generated by [Claude Code](https://claude.ai/code/session_019siH5jDmk5hrayvfyojUqR)_
