### PR TITLE
fix(service-settings): tell operators where @objectstack/knowledge-turso comes from instead of naming a package this repo does not build

### DIFF
--- a/.changeset/knowledge-manifest-turso-origin.md
+++ b/.changeset/knowledge-manifest-turso-origin.md
@@ -1,0 +1,36 @@
+---
+'@objectstack/service-settings': patch
+---
+
+Tell the operator where `@objectstack/knowledge-turso` comes from instead of
+naming a package this repo does not build
+
+An operator who selects the `turso` knowledge adapter in **Settings → AI &
+Embedder** and runs the connection test was told: "Mount
+`@objectstack/knowledge-turso` to exercise live calls." That package is in no
+directory of this repo (0 path hits on `main`; `knowledge-memory` and
+`knowledge-ragflow` return 8 each under the identical command, so the zero is
+real), and the message said nothing about where it does come from — leaving the
+instruction un-followable at exactly the moment it is read.
+
+The prior question the card turned on — *is it published anywhere?* — is now
+measured rather than assumed. Against the public npm registry on 2026-08-23,
+with `@objectstack/spec` and `@objectstack/cli` as positive controls and
+`@objectstack/security-enterprise` as a known-private negative control:
+`@objectstack/knowledge-turso` **is published**, `latest` 6.9.0 (2026-05-27),
+nine versions from 6.4.0. So the option stays — dropping it would have deleted a
+working adapter.
+
+What it is *not* is co-installable with this platform version: 6.9.0 exact-pins
+`@objectstack/spec@6.9.0` while this repo ships 17.2.0, so mounting it resolves a
+second spec rather than reusing this one. The runtime message now names the
+package, says this platform does not ship it, points at the ObjectStack Cloud
+monorepo where it is built, and tells the operator to check for a release
+matching their platform version — the framework#3366 discipline that an install
+hint must carry its own edition/version boundary.
+
+The manifest's adapter-list comment loses the undated "mirrors the plugin
+packages currently published" claim that stopped being true with nothing to
+catch it, and gains the measurement with its date and method so the next reader
+can re-run it. No behaviour change: `ok` and `severity` are untouched on every
+branch of the test action.

--- a/packages/services/service-settings/src/manifests/knowledge.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/knowledge.manifest.test.ts
@@ -97,6 +97,40 @@ describe('knowledgeTestActionHandler', () => {
     expect(r.ok).toBe(true);
   });
 
+  // The turso adapter's plugin package is NOT built in this repo, so the live-call
+  // hint an operator reads in Settings -> AI & Embedder cannot be a bare "Mount
+  // @objectstack/knowledge-turso": that instruction was un-followable — it named a
+  // package with no directory here and no statement of where it comes from. Pinned
+  // as a property (names the package AND where it ships), not as a literal, so the
+  // wording can be improved without the guard going stale.
+  it('turso live-call hint says where the out-of-repo package comes from', async () => {
+    const r = await knowledgeTestActionHandler({
+      values: { adapter: 'turso', turso_url: 'file:./knowledge.db' },
+    } as any);
+    expect(r.ok).toBe(true);
+    const message = String(r.message);
+    expect(message).toContain('@objectstack/knowledge-turso');
+    expect(message).toMatch(/ObjectStack Cloud monorepo/);
+    // the un-followable form this card retired: named, with no origin stated
+    expect(message).not.toMatch(/Mount @objectstack\/knowledge-turso to exercise live calls/);
+  });
+
+  // Contrast, so the assertion above cannot be satisfied by blanket-rewording every
+  // hint: ragflow's plugin IS built here, and its hint stays the plain mount line.
+  it('ragflow live-call hint stays a plain mount line (its plugin is built here)', async () => {
+    const r = await knowledgeTestActionHandler({
+      values: {
+        adapter: 'ragflow',
+        ragflow_base_url: 'http://localhost:9380',
+        ragflow_api_key: 'k',
+      },
+    } as any);
+    expect(r.ok).toBe(true);
+    expect(String(r.message)).toContain(
+      'Mount @objectstack/knowledge-ragflow to exercise live calls',
+    );
+  });
+
   it('rejects ragflow without base URL', async () => {
     const r = await knowledgeTestActionHandler({
       values: { adapter: 'ragflow', ragflow_api_key: 'k' },

--- a/packages/services/service-settings/src/manifests/knowledge.manifest.ts
+++ b/packages/services/service-settings/src/manifests/knowledge.manifest.ts
@@ -10,12 +10,25 @@ import type { SettingsActionHandler } from '../settings-service.types.js';
  * knowledge sources and any future agent that needs to embed ad-hoc
  * inputs.
  *
- * Adapter list mirrors the plugin packages currently published:
- *   - memory    @objectstack/knowledge-memory   (dev / test reference)
- *   - turso     @objectstack/knowledge-turso    (libSQL native F32_BLOB —
- *                                                works for cloud Turso AND
- *                                                local file mode)
- *   - ragflow   @objectstack/knowledge-ragflow  (external RAGFlow service)
+ * Adapter list — two of these plugin packages are built in this repo and one
+ * is not, which is the difference that matters to an operator told to mount
+ * one of them:
+ *   - memory    @objectstack/knowledge-memory   built here (dev / test ref)
+ *   - ragflow   @objectstack/knowledge-ragflow  built here (external RAGFlow)
+ *   - turso     @objectstack/knowledge-turso    NOT built here — libSQL native
+ *                                               F32_BLOB, works for cloud
+ *                                               Turso AND local file mode
+ *
+ * Spelled out for `turso` because the undated claim that used to stand here —
+ * "mirrors the plugin packages currently published" — stopped being true and
+ * nothing caught it. The package IS published on the public npm registry, but
+ * on its own version track: `latest` was 6.9.0 (published 2026-05-27) while
+ * this repo shipped 17.2.0, and 6.9.0 exact-pins `@objectstack/spec@6.9.0`, so
+ * mounting it into an app on this platform version resolves a SECOND spec
+ * rather than reusing this one. Its source lives in the ObjectStack Cloud
+ * monorepo (see this repo's README). Measured against the registry on
+ * 2026-08-23 with `@objectstack/spec` + `@objectstack/cli` as positive
+ * controls; re-measure before treating those numbers as current.
  *
  * As with the AI manifest, the real adapter wiring happens in the
  * knowledge plugins; this manifest is the canonical settings surface
@@ -155,7 +168,11 @@ export const knowledgeTestActionHandler: SettingsActionHandler = async ({ values
     return {
       ok: true,
       severity: 'info',
-      message: `Turso adapter configured (${u}). Mount @objectstack/knowledge-turso to exercise live calls.`,
+      message:
+        `Turso adapter configured (${u}). Live calls need @objectstack/knowledge-turso, ` +
+        'which this platform does not ship: it is built in the ObjectStack Cloud monorepo ' +
+        'and published on its own version track, so check that it offers a release ' +
+        'compatible with your platform version before mounting it.',
     };
   }
 


### PR DESCRIPTION
Fixes #10920

## The prior question, answered by measurement rather than assumed

The card turned on one prior fact and said so in its own body — *is `@objectstack/knowledge-turso` published anywhere?* — so this branch begins with the measurement, not the edit.

**Absence in this repo, with a reverse control** (on `f24c90df3d`, the ref this branch was cut from):

```
git ls-tree -r --name-only HEAD | grep -c "/knowledge-turso/"    # -> 0
git ls-tree -r --name-only HEAD | grep -c "/knowledge-memory/"   # -> 8   (control)
git ls-tree -r --name-only HEAD | grep -c "/knowledge-ragflow/"  # -> 8   (control)
```

Identical command shape, so the zero is a fact about the package and not a broken pattern.

**Publication, against the public npm registry** (2026-08-23, unauthenticated `GET https://registry.npmjs.org/@objectstack%2F<name>` — the method PR #11266 established, with the same control discipline):

| package | HTTP | `latest` | role |
|---|---|---|---|
| `@objectstack/knowledge-turso` | 200 | **6.9.0** (2026-05-27, 9 versions from 6.4.0) | the subject |
| `@objectstack/spec` | 200 | — | positive control |
| `@objectstack/cli` | 200 | — | positive control |
| `@objectstack/security-enterprise` | 404 | — | known-private negative control |
| `@objectstack/knowledge-sqlite-vec` | 404 | — | negative control |

**The answer: it IS published.** So this PR takes the *record-where-it-ships* branch. Dropping the `turso` adapter option — the other branch the card offered — would have deleted a working adapter on the strength of a package not being in this directory tree, which is not the same claim.

One thing the measurement adds that neither branch anticipated: `knowledge-turso@6.9.0` exact-pins `@objectstack/spec@6.9.0` (also `core` and `service-knowledge` at 6.9.0) while this repo ships **17.2.0**. It is published, and it is *not* co-installable with this platform version — mounting it resolves a second `@objectstack/spec` rather than reusing this one. An operator told only "mount it" walks into that.

## What changed

Two sites in `packages/services/service-settings/src/manifests/knowledge.manifest.ts`, the two the card names.

**The runtime operator message (`:158`)** — the sharp one, spoken inside Settings → AI &amp; Embedder. Before:

> Turso adapter configured (…). Mount `@objectstack/knowledge-turso` to exercise live calls.

After, it names the package, says this platform does not ship it, points at where it is built, and gives the operator the check to perform — the framework#3366 discipline that an install hint must carry its own edition/version boundary, applied here the way PR #11266 applied it to `@objectstack/organizations`.

**The adapter-list comment (`:13-15`)** loses `Adapter list mirrors the plugin packages currently published:` — an undated, unowned claim that stopped being true with nothing to catch it — and gains the three-way split (built here / built here / NOT built here) plus the measurement above with its date and method, so the next reader can re-run it instead of inheriting it.

**No behaviour change.** `ok` and `severity` are untouched on every branch of the test action. Leaving `severity: 'info'` as-is is deliberate: changing it is a change to what the Settings UI renders, which is outside what this card was graded for. Flagging it here rather than doing it.

## Tests

Two added to `knowledge.manifest.test.ts`, pinned as **properties, not literals**, so the wording can improve without the guard going stale:

- the turso hint must name the package **and** where it ships, and must not be the retired bare-mount form;
- a contrast case — ragflow's plugin *is* built here, so its hint stays the plain mount line. Without it, the first assertion could be satisfied by blanket-rewording every hint in the file.

Verified green on `7372c21015`:

```
pnpm --filter @objectstack/service-settings test       -> Test Files 27 passed (27), Tests 483 passed (483)
pnpm --filter @objectstack/service-settings typecheck  -> tsc --noEmit, exit 0
```

(The package's `tsconfig.json` is `include: ["src"]` with no test exclusion, and the test file lives under `src/`, so `tsc --noEmit` really does read the new test code.)

Local gate union derived with `node scripts/pm/dispatch-gates.mjs` (no hand-supplied paths), run on `7372c21015`, exit codes captured before any pipe. All 18 green, each quoted from the gate's own verdict line — for example:

```
check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger …
check-engine-double-contract: OK — 384 pinned, 133 in the DEBT ledger, 2 exempt.
✓ check-changeset-no-major: This diff introduces no `major` bump.
OK: all 88 declared cross-package glob(s) (76 unique) are covered by `core` or `crosspkg` …
```

`check:type-check-debt` (the 19th, which needs the whole workspace closure built first) is running as this PR is opened; its verdict is reported on the card.

## Scope

The `packages/spec/src/contracts/embedder.ts` half of the original finding — the `IEmbedder` docblock naming `knowledge-turso` and `knowledge-sqlite-vec` — is **not touched here**, per the scope fence on the card. `#11318` is not addressed here either: it is the sibling case filed out of this work, where `ai.manifest.ts` prints the same un-followable mount instruction for `@objectstack/service-ai`, a package `PLATFORM_CAPABILITY_PROVIDERS` declares `edition: 'cloud'`.

A note for triage, since the unlock scan's condition pointed at it: `PLATFORM_CAPABILITY_PROVIDERS` is present on this ref (PR #11266 merged as `a2ec377078`), but it does **not** answer this question in either direction. It is keyed by `requires:` platform *service* capability tokens and contains no knowledge adapter at all — not `knowledge-turso`, and not the two this repo does build. Its silence here is category silence, so reading "absent from the roster" as "ships nowhere" would have produced the wrong repair. The registry measurement above is what actually answered it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_