### PR TITLE
test(dogfood): converge two-factor-lockout on the shared TOTP helper

### DIFF
--- a/packages/qa/dogfood/test/totp.ts
+++ b/packages/qa/dogfood/test/totp.ts
@@ -10,10 +10,11 @@
  * defaults are the RFC's (SHA-1, 6 digits, 30s), and `enable`'s own otpauth://
  * URI asserts them.
  *
- * ⚠️ `two-factor-lockout.dogfood.test.ts` still carries its own private copy of
- * these two functions — this module was extracted while adding a second caller
- * (#10681) and deliberately did NOT rewrite that file's internals, since it pins
- * an unrelated card. Consolidating it is filed separately.
+ * This is the package's SINGLE copy. It was extracted from
+ * `two-factor-lockout.dogfood.test.ts` while adding a second caller (#10681),
+ * which kept a private copy of its own until #11111 converged it here. Need a
+ * TOTP in a new fixture? Import it from this module — do not paste a third
+ * spelling of RFC 6238 into the package.
  */
 
 import { createHmac } from 'node:crypto';

--- a/packages/qa/dogfood/test/two-factor-lockout.dogfood.test.ts
+++ b/packages/qa/dogfood/test/two-factor-lockout.dogfood.test.ts
@@ -44,10 +44,10 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createHmac } from 'node:crypto';
 import showcaseStack from '@objectstack/example-showcase';
 import { bootStack, type VerifyStack } from '@objectstack/verify';
 import { assertArmed, authSettingArmed } from './armed.js';
+import { secretFromTotpUri, totp } from './totp.js';
 
 const SYS = { context: { isSystem: true } };
 const ADMIN_PASSWORD = 'admin123';
@@ -64,46 +64,6 @@ const LOCKOUT_THRESHOLD = 7;
 const LOCKOUT_DURATION_MINUTES = 40;
 /** better-auth's per-two-factor-cookie cap. Hardcoded upstream, not configurable. */
 const MAX_PER_CHALLENGE = 5;
-
-// ── RFC 6238 TOTP ──────────────────────────────────────────────────────────
-// Hand-rolled rather than imported: `@better-auth/utils/otp` is a transitive
-// dependency, and adding it as a direct one to generate six digits would tie
-// this test to an internal package's resolution. better-auth's defaults are
-// the RFC's (SHA-1, 6 digits, 30s), asserted by `enable`'s own otpauth:// URI.
-
-function base32Decode(input: string): Buffer {
-  const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-  const clean = input.replace(/=+$/, '').toUpperCase();
-  let bits = 0;
-  let value = 0;
-  const out: number[] = [];
-  for (const char of clean) {
-    const idx = ALPHABET.indexOf(char);
-    if (idx === -1) throw new Error(`invalid base32 character: ${char}`);
-    value = (value << 5) | idx;
-    bits += 5;
-    if (bits >= 8) {
-      out.push((value >>> (bits - 8)) & 0xff);
-      bits -= 8;
-    }
-  }
-  return Buffer.from(out);
-}
-
-/** The 6-digit TOTP for `secret` at the current 30-second step. */
-function totp(secret: Buffer): string {
-  const counter = Math.floor(Date.now() / 30_000);
-  const buf = Buffer.alloc(8);
-  buf.writeBigUInt64BE(BigInt(counter));
-  const digest = createHmac('sha1', secret).update(buf).digest();
-  const offset = digest[digest.length - 1] & 0x0f;
-  const code =
-    ((digest[offset] & 0x7f) << 24) |
-    ((digest[offset + 1] & 0xff) << 16) |
-    ((digest[offset + 2] & 0xff) << 8) |
-    (digest[offset + 3] & 0xff);
-  return String(code % 1_000_000).padStart(6, '0');
-}
 
 /** Collect a response's Set-Cookie values into a single request Cookie header. */
 function cookieHeader(res: Response): string {
@@ -180,9 +140,7 @@ describe('#3624 follow-up: better-auth 2FA lockout counts wrong codes', () => {
     });
     expect(enabled.status, `two-factor/enable: ${await enabled.clone().text()}`).toBe(200);
     const { totpURI } = (await enabled.json()) as { totpURI: string };
-    const uriSecret = new URL(totpURI.replace('otpauth://', 'https://')).searchParams.get('secret');
-    expect(uriSecret, 'no secret in the otpauth URI').toBeTruthy();
-    secret = base32Decode(uriSecret as string);
+    secret = secretFromTotpUri(totpURI);
 
     // better-auth enrols with `verified: false`, and the sign-in path refuses
     // an unverified enrolment (TOTP_NOT_ENABLED) before it ever reaches the


### PR DESCRIPTION
Fixes #11111

`two-factor-lockout.dogfood.test.ts` carried a private `base32Decode` / `totp` pair. The shared `packages/qa/dogfood/test/totp.ts` was extracted **from** that file while adding a second caller (#10681) and deliberately did not rewrite its internals, so the package held two spellings of RFC 6238. This converges them. Mechanical: no assertion, timeout or fixture-semantics changes.

## What changed

- The lockout test now imports `secretFromTotpUri, totp` from `./totp.js` — the same import its sibling `two-factor-backup-code-reveal.dogfood.test.ts` already uses.
- Its local `base32Decode` and `totp` are deleted, along with the `createHmac` import that only they used.
- The inline otpauth URI parsing collapses into `secretFromTotpUri`.
- The shared module's header carried a stale warning that the lockout file "still carries its own private copy". That stopped being true in this commit, so it is replaced with a note that this is now the package's single copy.

Net: 48 lines deleted, 7 added.

## Divergence check — the thing that could have made this unsafe

Both implementations were compared before anything was touched. Extracting the function bodies and diffing them yields exactly one difference each, the `export` keyword:

```
base32Decode:  1c1   export function base32Decode(...)   vs   function base32Decode(...)
totp:          1c1   export function totp(...)           vs   function totp(...)
```

No divergence. Nothing behavioural is being smuggled in under a dedupe.

## The one semantic nuance, stated rather than hidden

The collapsed block previously guarded the URI with `expect(uriSecret, 'no secret in the otpauth URI').toBeTruthy()`. `secretFromTotpUri` instead throws `Error('no secret in the otpauth URI')` — same message, same red/green outcome, a thrown error rather than an assertion. The card sanctions this collapse explicitly ("plus the `secret` param lookup and its `toBeTruthy` guard, so that block can collapse too").

## Why the green suite here is not a tautology

A dedupe PR's real risk is not that the suite goes red — it is that the suite never exercised the helper, so repointing it at a different implementation proves nothing. Predicted in writing **before** running: mutating the SHARED `totp()` must fail inside `beforeAll`, at the enrolment confirmation, because that is the first consumer of a TOTP in the file.

Measured, with the shared `totp()` mutated to return a fixed wrong code:

```
injected marker count : 1   (must be 1)
removed original count: 0   (must be 0)
FAIL |isolated| test/two-factor-lockout.dogfood.test.ts (beforeAll hook)
AssertionError: verify-totp (enrolment): {"message":"Invalid code","code":"INVALID_CODE"}: expected 401 to be 200
Test Files  1 failed (1)      Tests  5 skipped (5)
```

Restored byte-identically — `git hash-object` equal on both sides (`f5b906f55752e74ae4ba5c4be2d67891b621cbc9`), injected marker absent, original line back — and re-run to a real green: `Test Files 1 passed (1) / Tests 5 passed (5)`. The mutation ran under a `trap ... EXIT INT TERM` restore, so a cap kill mid-mutation could not have left the tree mutated.

Two honest deviations from the prediction: the rejection status is **401 INVALID_CODE**, not the 400 I guessed, and vitest accounts a `beforeAll` failure as *1 file failed / 5 skipped* rather than *5 failed*. Location and cause matched the prediction.

Pre-change the same mutation could not have moved this file at all — it referenced `./totp.js` nowhere, which is the contrast that makes the ablation a statement about the new wiring.

No dist preflight applies: `test/totp.ts` is a relative sibling module compiled from source by vitest, and `@objectstack/dogfood` declares no `build` script.

## Verification

Baseline on the same ref, before the change: `Test Files 1 passed (1) / Tests 5 passed (5)`. After the change: identical.

Gate union derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-supplied paths) and run at commit `3c6028f1b2`. 11 matched + 7 convention-triggered families, every one exit 0:

`check:empty-state` · `check:liveness` · `check:published-files` · `check:slot-lookup` · `check:strictness-ledger` · `check:test-source-alias` · `check:type-source-resolution` · `check:variant-docs` · `check-ci-filter-parity` · `check-plugin-teardown-shape` · `check-affected-docs` · `check:query-options-erasure` · `check:type-check-coverage` · `check:type-check-debt` · `check:engine-double-contract` · `check:cross-package-test-inputs` · `check:where-matcher` · `check:nul-bytes` · `@objectstack/dogfood typecheck`

`check:type-check-debt` first refused with `PREREQUISITE NOT MET` — `@objectstack/service-knowledge` had no built type entry point, and the gate is explicit that measuring from there measures a different world. That is NOT MEASURED, not a pass, so the closure was built and the gate re-run to its own verdict line:

```
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 449.8s,
1897 raw tsc error(s) total, none above its recorded number.
```

## Changeset

`skip-changeset`. `@objectstack/dogfood` is `"private": true` and this PR touches only two of its test files, so it publishes nothing — the textbook case the changeset workflow's own comments name.

_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_