### PR TITLE
fix(driver-sql): scope the Postgres introspectForeignKeys catalog read to the session's own schemas

### DIFF
--- a/.changeset/driver-sql-introspect-fk-schema-scope.md
+++ b/.changeset/driver-sql-introspect-fk-schema-scope.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+fix(driver-sql): scope the Postgres `introspectForeignKeys` catalog read to the session's own schemas (#11201)
+
+The Postgres arm queried `information_schema.table_constraints` with
+`tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = ?` and **no `table_schema`
+predicate at all**. Those views span every schema the session has privilege on,
+independently of `search_path`, so a table name that exists in more than one schema had
+all of their foreign keys merged into a single answer — including foreign keys from
+schemas the session can never reach unqualified.
+
+That is a wrong answer rather than a missing one, and it is consumed as fact:
+`introspectSchema` hangs the result on the table it just listed, and from there it reaches
+federated-object codegen, the persisted `external_catalog` (ADR-0015) and schema-drift
+comparison. A phantom foreign key makes a drafted federated object reference a table it
+does not reference.
+
+The fix is the pin the rest of the family already carries —
+`AND tc.table_schema = ANY (current_schemas(false))` — spelled and placed exactly as
+`introspectUniqueConstraints` spells it, which in turn follows `introspectSchema`'s own
+table listing. `introspectForeignKeys` was the last unscoped introspection arm; the two
+`pg_index`-based arms (`introspectIndexes`, `introspectPrimaryKeys`) reach the same scoping
+from the other side by resolving the name to an OID through `regclass`. No interface shape
+and no accepted input changes: a same-named table in another schema simply stops
+contributing foreign keys it never should have contributed.
+
+Measured on a live PostgreSQL 16.13. The regression pin
+(`sql-driver-11201-introspect-fk-schema-scope.test.ts`) builds the collision the repo's own
+live-PG isolation (#9350, one schema per test file in one database) already makes routine:
+two same-named tables in two schemas, each with a different foreign key. It first asserts
+the pre-fix predicate really sees both constraints — so the interesting assertion, an
+absence, cannot go green on a fixture that never collided — then requires the arm and
+`introspectSchema` to return only the current schema's. Reverse-verified: with the
+predicate reverted the pin fails with the neighbour's foreign key present in the answer.
+
+The MySQL arm of the same method was checked and is not affected: it already pins
+`TABLE_SCHEMA = DATABASE()`. SQLite has no schemas.

--- a/packages/drivers/driver-sql/src/sql-driver-11201-introspect-fk-schema-scope.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-11201-introspect-fk-schema-scope.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11201] `introspectForeignKeys` must answer for the table the SESSION
+ * resolves — not for every same-named table in the database.
+ *
+ * The Postgres arm filtered `information_schema.table_constraints` on
+ * `tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = ?` with no
+ * `table_schema` predicate at all. Those views span every schema the session
+ * has privilege on, `search_path` notwithstanding, so a table name that exists
+ * in more than one schema had all of their foreign keys merged into one answer.
+ *
+ * That is a WRONG answer, not a missing one, and it is consumed as fact:
+ * `introspectSchema` hangs it on the table it just listed, and from there it
+ * reaches federated-object codegen, the persisted `external_catalog`
+ * (ADR-0015) and schema-drift comparison. The fix is the family's existing
+ * pin — `AND tc.table_schema = ANY (current_schemas(false))`, the same one
+ * `introspectSchema`'s table listing and `introspectUniqueConstraints` carry.
+ *
+ * ## Why the collision is realistic rather than contrived
+ *
+ * The live-dialect isolation (#9350) gives every test FILE in this package its
+ * own schema inside ONE database. Same-named tables in sibling schemas are
+ * therefore the normal state of a live-PG run here, not an edge case someone
+ * has to construct — this file just makes the collision explicit so it can be
+ * asserted on.
+ *
+ * ## Why this file is PG-only
+ *
+ * SQLite has no schemas, and the MySQL arm of this same method already pins
+ * `TABLE_SCHEMA = DATABASE()` — the defect is not expressible on either, so
+ * the cell list is exactly `pg`, declared through `declareDialectCell` so an
+ * unprovisioned run is a NAMED skip (and a red under
+ * `OS_EXPECT_LIVE_DIALECT_MATRIX=1`), never a silent pass.
+ *
+ * ## Why the fixture pins the catalog fact first
+ *
+ * The interesting assertion here is an ABSENCE — "the other schema's foreign
+ * key is not in the answer" — and an absence goes green for free if the
+ * fixture never created the collision (a `create schema` that silently landed
+ * somewhere else, a DDL statement that did not run). So the first case
+ * re-issues the pre-fix predicate verbatim and requires it to see BOTH
+ * constraints. If that case ever goes green with one row, the rest of this
+ * file is measuring nothing and says so.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+import {
+  PG_CELL,
+  currentLiveSchema,
+  declareDialectCell,
+  type DialectCell,
+} from './live-dialect-matrix.testkit.js';
+
+const MATRIX = 'introspectForeignKeys schema scoping';
+
+/** The COLLIDING name — one in this file's own schema, one next door. */
+const TABLE = 'os11201_orders';
+
+/** The referenced table each side points at. Distinct, so the answer is attributable. */
+const REF_HERE = 'os11201_ref_here';
+const REF_THERE = 'os11201_ref_there';
+
+/** Constraint names, likewise distinct — a PG constraint name is per-schema. */
+const FK_HERE = 'os11201_fk_here';
+const FK_THERE = 'os11201_fk_there';
+
+/** `introspectForeignKeys` is `protected`; this is the narrowest way to reach it. */
+class ForeignKeyProbeDriver extends SqlDriver {
+  foreignKeys(table: string) {
+    return this.introspectForeignKeys(table);
+  }
+}
+
+function declareForeignKeyScopeSuite(cell: DialectCell): void {
+  describe(`introspectForeignKeys schema scoping — ${cell.label} (#11201)`, () => {
+    let driver: ForeignKeyProbeDriver;
+    /** This file's own schema (#9350) — the only one on `search_path`. */
+    let here: string;
+    /** The neighbour. Created by this file, so it is dropped by this file. */
+    let there: string;
+
+    beforeAll(async () => {
+      driver = new ForeignKeyProbeDriver(cell.config());
+      here = currentLiveSchema();
+      there = `${here}_alt`;
+      // Postgres TRUNCATES an over-long identifier silently, which would fold
+      // the neighbour back onto this file's own schema and quietly delete the
+      // collision this suite exists to measure.
+      expect(
+        there.length,
+        `the neighbour schema name ${there} exceeds Postgres' 63-byte identifier limit and would ` +
+          `be silently truncated — shorten the suffix`,
+      ).toBeLessThanOrEqual(63);
+
+      await driver.execute(`drop schema if exists "${there}" cascade`);
+      await driver.execute(`create schema "${there}"`);
+
+      // This file's own schema: unqualified DDL lands here, because the cell's
+      // config puts exactly this schema on `search_path`.
+      await driver.execute(`drop table if exists ${TABLE} cascade`);
+      await driver.execute(`drop table if exists ${REF_HERE} cascade`);
+      await driver.execute(`create table ${REF_HERE} (id varchar(64) primary key)`);
+      await driver.execute(
+        `create table ${TABLE} (
+           id varchar(64) primary key,
+           here_ref varchar(64),
+           constraint ${FK_HERE} foreign key (here_ref) references ${REF_HERE} (id)
+         )`,
+      );
+
+      // The neighbour: same TABLE name, a different foreign key, and NOT on
+      // `search_path`. Every name is schema-qualified so nothing depends on the
+      // session's resolution while building it.
+      await driver.execute(`create table "${there}".${REF_THERE} (id varchar(64) primary key)`);
+      await driver.execute(
+        `create table "${there}".${TABLE} (
+           id varchar(64) primary key,
+           there_ref varchar(64),
+           constraint ${FK_THERE} foreign key (there_ref) references "${there}".${REF_THERE} (id)
+         )`,
+      );
+    });
+
+    afterAll(async () => {
+      await driver.execute(`drop schema if exists "${there}" cascade`).catch(() => {});
+      await driver.execute(`drop table if exists ${TABLE} cascade`).catch(() => {});
+      await driver.execute(`drop table if exists ${REF_HERE} cascade`).catch(() => {});
+      await driver.disconnect().catch(() => {});
+    });
+
+    it('the fixture really collides: `search_path` sees one table, the catalog sees two', async () => {
+      // Non-vacuity, part one — the session resolves the bare name to THIS
+      // schema's table, so a scoped read has exactly one right answer.
+      const resolved: any = await driver.execute(
+        `select nspname from pg_class c join pg_namespace n on n.oid = c.relnamespace
+          where c.oid = to_regclass(?)`,
+        [TABLE],
+      );
+      expect(resolved.rows[0].nspname).toBe(here);
+
+      // Non-vacuity, part two — the PRE-FIX predicate, re-issued verbatim.
+      // Both constraints are visible to it, which is the whole defect.
+      const unscoped: any = await driver.execute(
+        `select tc.table_schema, tc.constraint_name
+           from information_schema.table_constraints as tc
+          where tc.constraint_type = 'FOREIGN KEY'
+            and tc.table_name = ?
+          order by tc.constraint_name`,
+        [TABLE],
+      );
+      expect(
+        unscoped.rows.map((r: any) => `${r.table_schema}.${r.constraint_name}`),
+        'the neighbour schema did not get its own colliding table — this suite would be ' +
+          'asserting an absence that the fixture, not the fix, produced',
+      ).toEqual([`${here}.${FK_HERE}`, `${there}.${FK_THERE}`]);
+    });
+
+    it('reports ONLY the current schema’s foreign keys', async () => {
+      const foreignKeys = await driver.foreignKeys(TABLE);
+
+      // The exact array, not a `toContain`: the defect ADDS a row, so any
+      // assertion satisfied by a superset is satisfied by the defect too.
+      expect(
+        foreignKeys,
+        `${cell.label}: a same-named table in ${there} must contribute nothing to ${here}'s answer`,
+      ).toEqual([
+        {
+          columnName: 'here_ref',
+          referencedTable: REF_HERE,
+          referencedColumn: 'id',
+          constraintName: FK_HERE,
+        },
+      ]);
+
+      // The pre-fix answer, named — so a future reader can see what red looked
+      // like without re-deriving it.
+      expect(foreignKeys.map((fk) => fk.constraintName)).not.toContain(FK_THERE);
+      expect(foreignKeys.map((fk) => fk.referencedTable)).not.toContain(REF_THERE);
+    });
+
+    it('carries the scoping through `introspectSchema`, the in-tree consumer', async () => {
+      // The call site at the top of this defect's blast radius: the whole-schema
+      // read hangs these keys on the table it listed, and every downstream
+      // consumer (federated codegen, `external_catalog`, drift comparison)
+      // reads them from there rather than calling the arm directly.
+      const schema = await driver.introspectSchema();
+
+      expect(Object.keys(schema.tables)).toContain(TABLE);
+      expect(schema.tables[TABLE].foreignKeys).toEqual([
+        {
+          columnName: 'here_ref',
+          referencedTable: REF_HERE,
+          referencedColumn: 'id',
+          constraintName: FK_HERE,
+        },
+      ]);
+    });
+  });
+}
+
+declareDialectCell(PG_CELL, MATRIX, declareForeignKeyScopeSuite);

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -13149,6 +13149,25 @@ export class SqlDriver implements IDataDriver {
 
     try {
       if (this.isPostgres) {
+        // `information_schema.table_constraints` spans EVERY schema the session
+        // can read, so `tc.table_name = ?` on its own merges a same-named
+        // table's foreign keys from schemas `search_path` never reaches — a
+        // wrong answer, not a missing one, and downstream (federated-object
+        // codegen, the persisted `external_catalog` under ADR-0015,
+        // schema-drift comparison) acts on it. Not theoretical here: the
+        // live-dialect isolation (#9350) gives every test FILE its own schema
+        // inside one database, so colliding table names are the normal state of
+        // a run.
+        //
+        // The pin is the family's existing one, kept spelled and placed exactly
+        // as `introspectUniqueConstraints` spells it, which in turn follows
+        // `introspectSchema`'s own table listing: `current_schemas(false)` is
+        // the session's `search_path` minus the implicit `pg_catalog`, so a
+        // bare name is scoped the way every other statement in the session
+        // resolves it. (`introspectIndexes` and `introspectPrimaryKeys` reach
+        // the same scoping from the other side — they resolve the name to an
+        // OID through `regclass` — because `pg_index` takes a relation, not a
+        // schema name.)
         const result = await this.knex.raw(
           `
           SELECT
@@ -13165,6 +13184,7 @@ export class SqlDriver implements IDataDriver {
             AND ccu.table_schema = tc.table_schema
           WHERE tc.constraint_type = 'FOREIGN KEY'
             AND tc.table_name = ?
+            AND tc.table_schema = ANY (current_schemas(false))
         `,
           [tableName],
         );


### PR DESCRIPTION
Fixes #11201

The Postgres arm of `SqlDriver.introspectForeignKeys` filtered `information_schema.table_constraints` on `tc.constraint_type = 'FOREIGN KEY' AND tc.table_name = ?` with **no `table_schema` predicate at all**. Those views span every schema the session has privilege on, independently of `search_path`, so a table name existing in more than one schema had all of their foreign keys merged into one answer.

That is a wrong answer rather than a missing one, and it is consumed as fact: `introspectSchema` hangs the result on the table it just listed, and from there it reaches federated-object codegen, the persisted `external_catalog` (ADR-0015) and schema-drift comparison.

## The change

One predicate, plus the comment explaining it:

```sql
AND tc.table_schema = ANY (current_schemas(false))
```

No interface shape changes, and the accepted input set is not widened — a same-named table in another schema simply stops contributing foreign keys it never should have contributed.

## Sibling-arm comparison, since the point is ONE resolution rule across the family

I compared every Postgres introspection arm in `sql-driver.ts` before writing, rather than copying the predicate from the issue:

| arm | how it scopes the Postgres read | agrees? |
|---|---|---|
| `introspectSchema` (table listing, ~10293) | `WHERE table_schema = ANY (current_schemas(false))` | yes — carries the pin |
| `introspectUniqueConstraints` (~13416) | `AND tc.table_schema = ANY (current_schemas(false))` | yes — carries the pin |
| `introspectIndexes` (~9965) | `WHERE ix.indrelid = to_regclass(?)` | consistent, other side |
| `introspectPrimaryKeys` (~13294) | `WHERE i.indrelid = ?::regclass` | consistent, other side |
| `introspectColumnOrder` (~13049) | `AND table_schema = current_schema()` | deliberate, documented |
| **`introspectForeignKeys` (~13151)** | **nothing — this PR** | — |

The two arms that carry *this* predicate agree with each other exactly, so there was no winner to pick: same spelling, same `ANY (...)` form, and the same placement as the last predicate in the `WHERE`, after `tc.table_name = ?`. This PR matches both. The existing `JOIN` correlations on `kcu.table_schema` / `ccu.table_schema` are left untouched.

The two `pg_index` arms are not a disagreement — `pg_index` takes a relation, not a schema name, so they reach the same session scoping by resolving the name to an OID through `regclass`. `introspectColumnOrder` uses `current_schema()` on purpose and says so in its docblock: it mirrors the scoping knex itself applies in `columnInfo()`, which is the catalog read it exists to re-order.

## MySQL arm: checked, not affected

The MySQL arm of this same method already pins `TABLE_SCHEMA = DATABASE()` and reads `KEY_COLUMN_USAGE` directly. The defect is not expressible there, so nothing was widened into this PR. SQLite has no schemas (`PRAGMA foreign_key_list` is relation-scoped by construction).

## Test — measured on a live PostgreSQL 16.13

New pin: `packages/drivers/driver-sql/src/sql-driver-11201-introspect-fk-schema-scope.test.ts`, PG-only, declared through `declareDialectCell(PG_CELL, ...)` so an unprovisioned run is a **named skip** and a red under `OS_EXPECT_LIVE_DIALECT_MATRIX=1` — never a silent pass. The required `Temporal Conformance (live PG + MySQL)` job runs this cell against its real `postgres:16` service container.

The fixture builds the collision the repo's own live-PG isolation (#9350 — one schema per test file inside one database) already makes routine: two same-named `os11201_orders` tables in two schemas, each with a different foreign key to a differently-named parent, only one schema on `search_path`.

The interesting assertion is an **absence**, which goes green for free on a fixture that never collided — so the first case is a non-vacuity pin: it re-issues the pre-fix predicate verbatim and requires it to see **both** constraints, and separately confirms `to_regclass` resolves the bare name to this file's own schema. The remaining two cases assert the exact array (not `toContain`: the defect *adds* a row, so any assertion satisfied by a superset is satisfied by the defect), through the arm and through `introspectSchema`, the in-tree consumer.

### Reverse verification, predicted before each leg

Legs 1 and 3 ran with the tree byte-identical to the committed blob; leg 2 reverted only `sql-driver.ts` to its parent commit, proven on disk before running (new-predicate occurrences 2 to 1, comment marker absent, `git diff --stat` showing 20 deletions).

| leg | predicted | observed |
|---|---|---|
| fix applied | 3 passed | 3 passed |
| fix reverted | cases 2+3 RED with the neighbour's FK present; case 1 stays green (it issues the pre-fix predicate itself) | exactly that — 1 passed, 2 failed |
| restored | 3 passed | 3 passed |

The red diff named the defect precisely, the extra row being the neighbour schema's:

```
+   {
+     "columnName": "there_ref",
+     "constraintName": "os11201_fk_there",
+     "referencedColumn": "id",
+     "referencedTable": "os11201_ref_there",
+   },
```

No rebuild happened between the legs and the behaviour still flipped, which is the positive evidence that this pin reads **source**, not a stale `dist/` — so no dist preflight applies to it.

## Verification

All gates below were run on the tree at `5c2897943`, which is this PR's head commit, with a clean working tree. The gate union was derived from the actual diff via `node scripts/pm/dispatch-gates.mjs` with no paths passed. Each exit status was captured before any pipe.

Path-derived: `check:changeset-gate-self-tests` 0 · `check:driver-conformance` 0 · `check:objectui-changeset` 0 · `check:published-files` 0 · `check:slot-lookup` 0 · `check:test-source-alias` 0 · `check:type-source-resolution` 0 · `check-adr-0087-registration.mjs` 0 · `check-changeset-no-major.mjs` 0 · `check-ci-filter-parity.mjs` 0 · `check-empty-changeset.mjs` 0 · `check-plugin-teardown-shape.mjs` 0 · `docs-audit/check-affected-docs.mjs` 0

Convention-triggered (adds a test file): `check:query-options-erasure` 0 · `check:type-check-coverage` 0 · `check:type-check-debt` 0 · `check:engine-double-contract` 0 · `check:cross-package-test-inputs` 0 · `check:where-matcher` 0. `check:type-check-debt` was run after `turbo run build --filter='./packages/*' --filter='./packages/*/*'`, exactly as `lint.yml` sequences it, so it measured rather than refused; it reported `33 ledger entries re-measured, 1897 raw tsc errors, none above its recorded number`.

Also run: `check:nul-bytes` 0, `pnpm --filter @objectstack/driver-sql typecheck` 0, and the full package suite against the live server — **120 files passed, 1 skipped; 2153 tests passed, 45 skipped, 0 failed** under `TZ=America/New_York` with `OS_TEST_POSTGRES_URL` set.

Live **MySQL was not exercised locally** and is not claimed: the diff does not touch the MySQL branch, and CI's `Temporal Conformance (live PG + MySQL)` job covers that cell.

## Deliberately not done

Two further defects in this same query's `JOIN` correlations were measured on the live server and are **filed as #11324** rather than fixed here — they are a different class from this card's unscoped read, each needs its own fixture, and the likely repair is a `pg_constraint` rewrite that would cross into the interface region another PR owns. Both were confirmed present *after* this change, so this PR neither causes nor repairs them:

- a foreign key whose target table lives in another schema returns **zero rows** and vanishes from the answer (`ccu.table_schema = tc.table_schema` demands parent and child share a schema);
- a 2-column composite foreign key returns **4 rows**, the cartesian product of child columns by parent columns (no ordinal correlation between `kcu` and `ccu`).

Region discipline held: both hunks land at ~13151 and ~13167, inside the query body. The `Introspected*` interface declarations (3673-3729, 12925-12934) that PR #11270 owns are untouched, `IntrospectedForeignKey`'s shape is unchanged, and #11224's write-door stamp region is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_