### PR TITLE
docs(spec): drop stale GraphQL references and stale header provenance

### DIFF
--- a/.changeset/docs-graphql-stale-references.md
+++ b/.changeset/docs-graphql-stale-references.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/spec": patch
+---
+
+**Docs:** removes stale GraphQL references and stale hand-typed header provenance from generated and hand-kept protocol docs (#10834, #10833).
+
+GraphQL was retired as a product surface some time ago: `packages/spec/src/api/` has zero GraphQL sources, the `/graphql` HTTP route was removed from the dispatcher (out of the product plan, #2462 follow-on), and `graphql` was never actually a `CoreServiceName` — it only ever existed as a stray entry in this table and in metadata-protocol's discovery table (see the comment above `SERVICE_PROVIDER_TABLE` in `core-services.zod.ts`). Two places in the package still asserted otherwise:
+
+- The generated `content/docs/references/index.mdx` API Protocol blurb read "REST/GraphQL contracts, …". The source is `CATEGORY_BLURBS.api` in `packages/spec/scripts/build-docs.ts`; fixed there and regenerated with `gen:docs` — no hand-edit to the generated `.mdx`.
+- The hand-kept `packages/spec/llms.txt` (no generator; ships in the npm tarball per `files`) listed an `IGraphQLService` contract (execute, subscribe) under Service Contracts. `IGraphQLService` is declared nowhere in `packages/**/src` — verified before removal. Deleted the row rather than marking it `**DEPRECATED**` like the neighbouring `IUIService` row: that precedent fits a contract that has a replacement to point readers at; GraphQL has none — it's out of the product plan, not superseded by another contract — so a deprecation note would invent a migration path that doesn't exist.
+
+Also dropped this file's hand-typed `Schema Count` / `Last Updated` header lines (`171 Zod schemas, 191 test files, 5,157 tests`, `2026-02-12`) rather than refreshing them. Measured against the current tree: `packages/spec` now publishes 1,585 schemas (per the freshly generated `content/docs/references/index.mdx` root index) across 418 `*.test.ts` files — both roughly an order of magnitude past what the header claimed. Since this file has no generator (confirmed by the filer) and nothing re-verifies these numbers on change, a refreshed count would start drifting again on the very next PR that touches the package; removing the assertion is more honest than restating a number this file has no mechanism to keep true. Whether `llms.txt` should be generated at all is a larger follow-up left to the PM, not decided here.
+
+Graded rather than skipped: `llms.txt` ships in the `@objectstack/spec` npm tarball (`files`, enforced by `check:published-files`), so this prose change reaches consumers the same way the precedent in #10669 (`skill.tools` docblock) did.

--- a/content/docs/references/index.mdx
+++ b/content/docs/references/index.mdx
@@ -20,7 +20,7 @@ counts are sums of the rows they head. Regenerate with
 | Module | Pages | Schemas | Description |
 | :--- | ---: | ---: | :--- |
 | [AI Protocol](/docs/references/ai) | 11 | 66 | Agents, tools, skills, RAG and knowledge sources, model registry, conversations. |
-| [API Protocol](/docs/references/api) | 29 | 417 | REST/GraphQL contracts, endpoints, routing, realtime, batch, discovery. |
+| [API Protocol](/docs/references/api) | 29 | 417 | REST contracts, endpoints, routing, realtime, batch, discovery. |
 | [Automation Protocol](/docs/references/automation) | 13 | 68 | Flows and their nodes, approvals, ETL pipelines, webhooks, state machines, execution records. |
 | [Cloud Protocol](/docs/references/cloud) | 11 | 94 | Environments, packages and versions, marketplace, developer portal, tenancy. |
 | [Data Protocol](/docs/references/data) | 29 | 166 | Objects, fields, queries, filters, datasources and drivers — the ObjectQL layer. |
@@ -63,7 +63,7 @@ Agents, tools, skills, RAG and knowledge sources, model registry, conversations.
 
 **Source:** `packages/spec/src/api/` · **Import:** `@objectstack/spec/api` · **29 pages, 417 schemas**
 
-REST/GraphQL contracts, endpoints, routing, realtime, batch, discovery.
+REST contracts, endpoints, routing, realtime, batch, discovery.
 
 | File | Schemas |
 | :--- | :--- |

--- a/packages/spec/llms.txt
+++ b/packages/spec/llms.txt
@@ -2,8 +2,6 @@
 
 > **SYSTEM NOTE**: This file provides a high-level summary of the ObjectStack Protocol to help LLMs understand the codebase structure and intent.
 > **Version**: 3.0.0
-> **Schema Count**: 171 Zod schemas, 191 test files, 5,157 tests
-> **Last Updated**: 2026-02-12
 
 ## 1. Architecture Overview (The "Three-Layer Model")
 
@@ -168,7 +166,6 @@ function registerObject(rawConfig: unknown) {
 | `IAuthService` | authenticate, authorize, validateToken |
 | `IAutomationService` | executeFlow, triggerWorkflow |
 | `IUIService` | **DEPRECATED** — use IMetadataService.getView(), .listViews(), .getEffective('view', name, { userId }) |
-| `IGraphQLService` | execute, subscribe |
 
 ---
 

--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -621,7 +621,7 @@ const ROOT_INDEX_INTRO =
  */
 const CATEGORY_BLURBS: Record<string, string> = {
   ai: 'Agents, tools, skills, RAG and knowledge sources, model registry, conversations.',
-  api: 'REST/GraphQL contracts, endpoints, routing, realtime, batch, discovery.',
+  api: 'REST contracts, endpoints, routing, realtime, batch, discovery.',
   automation: 'Flows and their nodes, approvals, ETL pipelines, webhooks, state machines, execution records.',
   cloud: 'Environments, packages and versions, marketplace, developer portal, tenancy.',
   data: 'Objects, fields, queries, filters, datasources and drivers — the ObjectQL layer.',


### PR DESCRIPTION
Fixes #10834
Fixes #10833

## Summary

GraphQL was retired as a product surface some time ago: `packages/spec/src/api/` has zero GraphQL sources, the `/graphql` HTTP route was removed from the dispatcher (out of the product plan, per its own `#2462 follow-on` comment), and `graphql` was never actually a `CoreServiceName` — it only ever existed as a stray entry in the service-provider table and in metadata-protocol's discovery table (see the comment above `SERVICE_PROVIDER_TABLE` in `packages/spec/src/system/core-services.zod.ts`). Two places in `@objectstack/spec` still asserted GraphQL was live.

**#10834 — generated docs blurb**
- `CATEGORY_BLURBS.api` in `packages/spec/scripts/build-docs.ts` read `'REST/GraphQL contracts, endpoints, routing, realtime, batch, discovery.'`. Dropped `/GraphQL`.
- Regenerated with `pnpm --filter @objectstack/spec gen:docs`. The **only** file that blurb feeds is `content/docs/references/index.mdx` (two occurrences: the Quick Navigation table row and the API Protocol section body) — no other generated page changed, and nothing was hand-edited.
- Serial guard respected: `git status --porcelain` after the regen shows only `content/docs/references/index.mdx` touched — no overlap with PR #11327's `content/docs/references/api/dispatcher.mdx` or `content/docs/references/ui/app.mdx`.

**#10833 — hand-kept `llms.txt`**
- `packages/spec/llms.txt` (confirmed hand-kept — no generator produces it) listed an `IGraphQLService` contract row (`execute, subscribe`) under Service Contracts. Verified `IGraphQLService` is declared nowhere in `packages/**/src` (`grep -rn "IGraphQLService" packages/ --include="*.ts"` → no hits), then **deleted the row** rather than marking it `**DEPRECATED**` like the neighbouring `IUIService` row. That precedent fits a contract with a real replacement to point readers at (`IUIService` → `IMetadataService.getView()` etc.); `IGraphQLService` has none — GraphQL is out of the product plan, not superseded by another contract, so a deprecation note would invent a migration path that doesn't exist.
- Dropped the hand-typed header lines `**Schema Count**: 171 Zod schemas, 191 test files, 5,157 tests` and `**Last Updated**: 2026-02-12` rather than refreshing them. Measured against the current tree: `packages/spec` now publishes **1,585 schemas** (per the freshly regenerated `content/docs/references/index.mdx` root index, itself derived from the same JSON Schema output the reference pages are built from) across **418** `*.test.ts` files (`find packages/spec -iname "*.test.ts" -not -path "*/dist/*" -not -path "*/node_modules/*" | wc -l`) — both roughly an order of magnitude past the stale claim. Since this file has no generator and nothing re-verifies these numbers on change, a refreshed count would start drifting again on the very next PR that touches the package; removing the assertion is more honest than restating a number this file has no mechanism to keep true. The larger "should `llms.txt` be generated" question is left to the PM as a follow-up, not decided here. Left the `**Version**: 3.0.0` line untouched — out of the scope named for this card.
- `llms.txt` ships in the `@objectstack/spec` npm tarball (enforced by `check:published-files`), so per the #10669 precedent (`skill.tools` docblock, also prose shipped in the tarball) this change is graded with a changeset rather than skipped.

## Premise re-measurement (done before editing)

- `packages/spec/src/api/`: zero GraphQL files — confirmed.
- `/graphql` route: removed at `packages/runtime/src/http-dispatcher.ts` (comment at the removal site: `// /graphql removed — GraphQL is not in the product plan (#2462 follow-on).`, line 2087, matches the ~2026 pointer).
- `graphql` as `CoreServiceName`: confirmed absent; the table's own comment (`core-services.zod.ts` ~130-135) explains it "was never a `CoreServiceName`".
- `IGraphQLService`: confirmed declared nowhere in `packages/**/src`.

## Gates run (all local, none skipped)

Derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` on the actual diff (`.changeset/docs-graphql-stale-references.md`, `content/docs/references/index.mdx`, `packages/spec/llms.txt`, `packages/spec/scripts/build-docs.ts`). All ran through `scripts/pm/os-verify-lock.sh`, exit codes captured before any pipe.

- `pnpm --filter @objectstack/spec check:docs` → `✅ 229 generated files in sync with packages/spec`
- `pnpm check:changeset-gate-self-tests` → pass (3 self-test suites)
- `pnpm check:cross-package-test-inputs` → `OK: 14 package(s) read outside themselves, all declared`
- `pnpm check:doc-anchors` → pass
- `pnpm check:doc-authoring` → pass
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` → pass (after building `@objectstack/lint`'s dependency closure, which was not yet built in the fresh worktree)
- `pnpm --filter @objectstack/lint run check:doc-security-posture` → pass (same dependency-build note)
- `pnpm check:docs-audit-scope` → pass
- `pnpm check:docs-redirects` → pass
- `pnpm --filter @objectstack/spec run check:empty-state` → pass
- `pnpm --filter @objectstack/spec run check:liveness` → pass
- `pnpm check:merge-driver` → pass
- `pnpm check:objectui-changeset` → `✓ objectui-range --self-test: all checks passed`
- `pnpm check:published-files` → `✓ 69 publishable package(s) of 78 workspace member(s) declare a files whitelist…`
- `pnpm check:published-readme-links` → pass
- `pnpm check:quick-reference-counts` → pass
- `pnpm check:role-word` → pass
- `pnpm check:slot-lookup` → pass
- `pnpm --filter @objectstack/spec run check:strictness-ledger` → pass
- `pnpm check:test-source-alias` → pass
- `pnpm check:type-source-resolution` → pass
- `pnpm --filter @objectstack/spec run check:variant-docs` → pass
- `node scripts/check-adr-0087-registration.mjs` → `✓ this PR adds no declared-breaking changeset`
- `node scripts/check-changeset-no-major.mjs` → `✓ This diff introduces no major bump`
- `node scripts/check-ci-filter-parity.mjs` → pass
- `node scripts/check-cross-package-test-inputs.mjs` → pass
- `node scripts/check-dev-prereqs.mjs --self-test` → pass (CI only ever runs this script's `--self-test` per `lint.yml`; the unflagged form requires the full 67-package workspace built, out of scope for a docs-only diff and not what CI gates on)
- `node scripts/check-doc-frontmatter.mjs` → `✓ 403 page(s) under content/docs parse…`
- `node scripts/check-empty-changeset.mjs` → pass
- `node scripts/check-plugin-teardown-shape.mjs` → pass
- `node scripts/check-section-landing-index.mjs` → pass
- `node scripts/docs-audit/check-affected-docs.mjs` → pass
- `pnpm --filter @objectstack/spec typecheck` → pass

Union re-run at the final commit, clean tree, sha `f55523207`: `pnpm --filter @objectstack/spec check:docs` re-confirmed green (`✅ 229 generated files in sync with packages/spec`).

## Scope

`packages/spec/scripts/build-docs.ts`, the regenerated `content/docs/references/index.mdx` projection, `packages/spec/llms.txt`, and `.changeset/docs-graphql-stale-references.md`. No `packages/spec/src/**` touch, no `content/docs/releases/` touch.

_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_