### PR TITLE
fix(spec): make check:skill-examples's orphan scan fence-aware

### DIFF
--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -153,6 +153,18 @@
  * real consumer would, rather than relying on a same-package self-import
  * trick that may or may not resolve.
  *
+ * ── Fence-awareness in the orphan scan ────────────────────────────────────
+ * The orphan-marker guard (`extractFromFile`) is fence-aware: a marker
+ * spelling shown as example text INSIDE some other fenced block (e.g. a
+ * ```md illustration showing what `<!-- os:check -->` looks like) is not
+ * adjacent, at top level, to a real fence, so it claims nothing and must not
+ * be reported as a misplaced marker either — otherwise this gate's own
+ * convention could never be documented in the roots it governs. `fenceSpans()`
+ * tracks every top-level fence of ANY language (lifted from the #10533
+ * fence-awareness shape in `scripts/check-role-word.mjs`); a marker at true
+ * top level that is merely not adjacent to its fence is unaffected and still
+ * fails loudly.
+ *
  * Usage:
  *   tsx scripts/check-skill-examples.ts            # extract + type-check (CI)
  *   tsx scripts/check-skill-examples.ts --self-test  # pin the `any` detector, both directions
@@ -371,6 +383,43 @@ const FENCE_CLOSE_RE = /^```\s*$/;
 const JSDOC_GUTTER_RE = /^\s*\*\s?/;
 
 /**
+ * ANY CommonMark-shaped opening code fence — every language, not just the
+ * ts/tsx/typescript ones `FENCE_OPEN_RE` recognises for compilation: up to
+ * three spaces of indent, a run of three or more backticks, and an info
+ * string that cannot itself contain a backtick. Lifted from the #10533
+ * fence-awareness shape in `scripts/check-role-word.mjs`.
+ */
+const ANY_FENCE_OPEN_RE = /^ {0,3}(`{3,})([^`]*)$/;
+
+/**
+ * Every line index that lies INSIDE some top-level fenced block — of ANY
+ * language, spanning both its opening and closing fence line. This gate's own
+ * `os:check` convention has to be documentable in the very roots it governs
+ * (e.g. a ```` ```md ```` illustration showing the marker's exact spelling),
+ * and a marker shown as example text inside such a fence claims nothing — it
+ * is not adjacent to a real fence the author intends to check, so it must not
+ * be flagged as a misplaced (orphan) marker either. The closing run length
+ * must match or exceed the opener's (a `````` fence wrapping a ```ts example
+ * closes on ITS OWN fence, not the inner one), and an unclosed fence runs to
+ * the end of the document (CommonMark), so it consumes the rest of the file
+ * rather than leaving the tail ambiguous.
+ */
+function fenceSpans(lines: string[]): boolean[] {
+  const inFence = new Array<boolean>(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i++) {
+    const open = ANY_FENCE_OPEN_RE.exec(lines[i]);
+    if (!open) continue;
+    const run = open[1].length;
+    const closeFence = new RegExp(`^ {0,3}\`{${run},}[ \\t]*$`);
+    let end = i + 1;
+    while (end < lines.length && !closeFence.test(lines[end])) end++;
+    for (let s = i; s < Math.min(end + 1, lines.length); s++) inFence[s] = true;
+    i = end;
+  }
+  return inFence;
+}
+
+/**
  * The lines a root's regexes actually match against. Identical to the raw
  * file lines for markdown roots; for a `commentPrefixed` root, the JSDoc
  * gutter is stripped from every line first — so a marker, a fence, and a
@@ -390,10 +439,14 @@ function logicalLines(rawLines: string[], root: SourceRoot): string[] {
  * fence is exactly the MARKER (ignoring surrounding whitespace) — after
  * gutter-stripping, for a `commentPrefixed` root.
  *
- * Also reports `orphans`: MARKER lines that are NOT directly above a ts fence.
- * A misplaced marker (a blank line slipped in between, or it precedes a bash /
- * json block) silently checks nothing — exactly the failure mode this gate
- * exists to prevent — so the caller treats an orphan as an error, not a no-op.
+ * Also reports `orphans`: top-level MARKER lines that are NOT directly above
+ * a ts fence. A misplaced marker (a blank line slipped in between, or it
+ * precedes a bash / json block) silently checks nothing — exactly the
+ * failure mode this gate exists to prevent — so the caller treats an orphan
+ * as an error, not a no-op. A marker occurrence INSIDE some other fenced
+ * block (`fenceSpans()`) is example text illustrating the convention, not a
+ * claim, and is excluded from this scan for the same reason it is excluded
+ * from extraction above: it is not adjacent, at top level, to a real fence.
  */
 function extractFromFile(source: string, root: SourceRoot): { examples: Example[]; orphans: number[] } {
   const rawLines = fs.readFileSync(source, 'utf-8').split('\n');
@@ -424,8 +477,13 @@ function extractFromFile(source: string, root: SourceRoot): { examples: Example[
     i = close; // skip to the close fence
   }
 
+  const inFence = fenceSpans(lines);
   const orphans: number[] = [];
   for (let i = 0; i < lines.length; i++) {
+    // Top level only. A marker shown INSIDE some other fenced block (e.g. a
+    // ```md illustration of this very convention) is example text, not a
+    // claim — see `fenceSpans()`.
+    if (inFence[i]) continue;
     // Any marker spelling counts as an orphan claim — a wrong-format marker
     // checks nothing, which is precisely what this guard exists to catch.
     if (ALL_MARKERS.includes(lines[i].trim()) && !claimed.has(i)) orphans.push(i + 1); // 1-based
@@ -917,6 +975,52 @@ function selfTest(): never {
       `orphan fixture: reported ${orphanTsx.orphans.length} orphan marker(s), expected 1 — a misplaced gutter-wrapped ` +
         `marker must not be silently ignored`,
     );
+
+    // ── Fence-awareness (fenceSpans): the os:check convention has to be
+    //    documentable in the very roots it governs. A marker shown as example
+    //    text INSIDE some other fenced block (here a ```md illustration of
+    //    the marker's exact spelling) must not be reported as an orphan —
+    //    but a REAL misplaced marker at top level (not inside any fence,
+    //    just not adjacent to its fence) must still be an error: this gate's
+    //    hard-error posture must not weaken. Both live in one fixture so a
+    //    fix that over-widens the exemption (e.g. treating every marker as
+    //    "documented") is caught by the same run that proves the narrow case.
+    const fenceFixture = path.join(dir, 'fence-aware.md');
+    fs.writeFileSync(
+      fenceFixture,
+      [
+        '# Fence-awareness fixture', // 1
+        '', // 2
+        'Documenting the marker syntax itself, inside a wrapping fence:', // 3
+        '', // 4
+        '```md', // 5
+        '<!-- os:check -->', // 6  ← INSIDE the fence: example text, not a claim
+        '```', // 7
+        '', // 8
+        'A genuine misplaced marker (blank line breaks adjacency) must still fail:', // 9
+        '', // 10
+        '<!-- os:check -->', // 11 ← top-level, but NOT adjacent to the fence below
+        '', // 12
+        '```ts', // 13
+        'const x = 1;', // 14
+        '```', // 15
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const fenceAware = extractFromFile(fenceFixture, skillsRoot);
+    check(
+      fenceAware.examples.length === 0,
+      `fence-awareness fixture: extracted ${fenceAware.examples.length} block(s), expected 0 — neither marker is ` +
+        `adjacent to a real ts fence`,
+    );
+    check(
+      JSON.stringify(fenceAware.orphans) === JSON.stringify([11]),
+      `fence-awareness fixture: reported orphan line(s) ${JSON.stringify(fenceAware.orphans)}, expected [11] — line 6 ` +
+        "(inside the ```md fence) must NOT be an orphan, and line 11 (a genuine top-level misplaced marker) must " +
+        'STILL be one — a false orphan there is exactly the defect that makes this convention undocumentable, and a ' +
+        "silenced real orphan would weaken the gate's hard-error posture",
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -930,7 +1034,9 @@ function selfTest(): never {
     '✅  self-test: flags a bare `any` parameter / variable / property / return / alias / cast in a\n' +
       '    marked block at the right page line, and flags nothing in an honestly typed one; a\n' +
       '    JSDoc-gutter-wrapped ```tsx block (client SDK surface) extracts, strips and maps lines\n' +
-      '    identically, and a misplaced gutter-wrapped marker is still caught as an orphan.',
+      '    identically, and a misplaced gutter-wrapped marker is still caught as an orphan; a marker\n' +
+      '    shown as example text inside another fenced block is not an orphan, while a genuine\n' +
+      '    top-level misplaced marker still is.',
   );
   process.exit(0);
 }


### PR DESCRIPTION
Fixes #10791

## The defect

`packages/spec/scripts/check-skill-examples.ts`'s orphan-marker scan had no fence
awareness. `extractFromFile` walks every line looking for `os:check` marker text; the
"is this claimed by a real block" check only looks one line up (is the *previous* line a
ts/tsx/typescript fence-open), but the *orphan* scan afterwards runs over **every** line
in the file with no notion of being inside some other fence. A marker shown as example
text inside a `` ```md `` illustration of the convention (e.g. "put this exact line above
your fence: `<!-- os:check -->`") is not adjacent to any real fence, so it was never
`claimed` — and the orphan scan flagged it as a misplaced marker, failing the gate. The
`os:check` convention could not be documented in the very roots it governs (`skills/`,
`content/docs/`).

## Confirming run — premise re-measurement

The card's premise is source-derived and was latent: today's corpus has all 192 (now 246,
after the #10969 SDK surface landed) markers at top level, so the gate is green on `main`
with nothing exercising this path.

Reproduced against `origin/main`'s script by adding a temporary fixture
(`skills/tmp-fence-repro.md`, not part of this PR) with two markers:
1. a marker shown literally inside a `` ```md `` fence, illustrating the convention
2. a genuine top-level misplaced marker (blank line breaks adjacency)

```
✗ Found an os:check marker not directly above a ```ts / ```tsx / ```typescript fence
  - skills/tmp-fence-repro.md:8    ← the FALSE orphan (marker shown as doc text)
  - skills/tmp-fence-repro.md:13   ← the REAL orphan (genuinely misplaced)
EXIT=1
```

Both were reported — the false orphan confirms the defect exactly as described.

## The fix

Lifted the fence-awareness shape from `scripts/check-role-word.mjs`'s #10533 fix (the
maintainer-accepted precedent for the same "this gate's own convention must be
documentable in the roots it governs" problem): a new `fenceSpans()` walks every line
once, recognizing **any** CommonMark-shaped opening fence (any language, backtick run
length 3+, with a run-length-aware matching closer — a `````` fence wrapping a ` ```ts `
example closes on its own fence, not the inner one; an unclosed fence runs to EOF per
CommonMark). The orphan scan in `extractFromFile` now skips any line inside such a span.

The real marked-block extraction loop is untouched — it still only recognizes bare
` ```ts `/` ```tsx `/` ```typescript ` fences for compilation, so this fix is scoped
exactly to the orphan-scan defect the card describes, not to a broader "nested fence"
extraction concern.

Re-running the same repro with the fix:

```
✗ Found an os:check marker not directly above a ```ts / ```tsx / ```typescript fence
  - skills/tmp-fence-repro.md:13   ← ONLY the real orphan — line 8 no longer flagged
EXIT=1
```

The false orphan (line 8) is gone; the genuine orphan (line 13) still fails — the gate's
hard-error posture is unweakened. The temporary fixture was then deleted (not part of
this PR).

## Self-test coverage

Added a new fixture to the existing `--self-test` suite in the same file, asserting both
directions in one run: a marker shown inside a `` ```md `` illustration must extract 0
blocks and report 0 orphans for that line, while a genuine top-level misplaced marker in
the same fixture must still be reported. Composing both in one fixture catches an
over-wide fix (treating every marker as "documented") as readily as an under-wide one.

## Changeset

None — `packages/spec/scripts/**` is dev/CI tooling, not published (`packages/spec`'s
`files` allowlist is `dist`, `json-schema`, `liveness`, `prompts`, `llms.txt`,
`README.md`, `src/**/*.zod.ts`, `CHANGELOG.md`, `api-surface`, `spec-changes.json` — no
`scripts/`). Matches the precedent for this exact shape of fix, #10787
(`fix(gate): let check:role-word exempt marked vendor-wire fences`), merged with the
`skip-changeset` label and no changeset. `skip-changeset` label applied to this PR via the
additive labels endpoint per repo convention, and read back after size-labeler settled.

## Gates

Derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` against
the actual diff (`packages/spec/scripts/check-skill-examples.ts` only).

| gate | verdict |
|---|---|
| `pnpm --filter @objectstack/spec check:skill-examples` (self-test + full run) | ✅ `246 prose examples type-check across 2 surface(s)` |
| `pnpm --filter @objectstack/spec typecheck` | ✅ |
| `pnpm --filter @objectstack/spec run check:empty-state` | ✅ |
| `pnpm --filter @objectstack/spec run check:liveness` | ✅ |
| `pnpm --filter @objectstack/spec run check:strictness-ledger` | ✅ |
| `pnpm --filter @objectstack/spec run check:variant-docs` | ✅ |
| `pnpm check:merge-driver` | ✅ |
| `pnpm check:published-files` | ✅ |
| `pnpm check:slot-lookup` | ✅ |
| `pnpm check:test-source-alias` | ✅ |
| `pnpm check:type-source-resolution` | ✅ |
| `node scripts/check-ci-filter-parity.mjs` | ✅ |
| `node scripts/check-dev-prereqs.mjs` (needed a full `pnpm build` first — 67/67 package artifacts) | ✅ |
| `node scripts/check-plugin-teardown-shape.mjs` | ✅ `0 known-unreached` |
| `node scripts/docs-audit/check-affected-docs.mjs` | ✅ (pre-existing `UNREACHABLE` sdk-route-bridge rows are unrelated to this diff) |
| `node scripts/check-nul-bytes.mjs` | ✅ |

Exit codes captured before any pipe (`cmd > file 2>&1; EXIT=$?`); each command run through
`scripts/pm/os-verify-lock.sh`, verdict read from its own printed `VERDICT command-exit N` line.

Union re-run at final HEAD `01ade5594` (clean tree) — every family above re-run and green at
that exact commit.

⛔ Not enabled for auto-merge and not marked ready — CI convergence and merge are the PM's.

_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RadETjNRLALFLhFA3xehZP)_