### PR TITLE
feat(client,plugin-auth): bind set-initial-password into the SDK and ledger it as an `sdk` mount

### DIFF
--- a/.changeset/client-auth-set-initial-password.md
+++ b/.changeset/client-auth-set-initial-password.md
@@ -1,5 +1,6 @@
 ---
 "@objectstack/client": minor
+"@objectstack/plugin-auth": patch
 ---
 
 **SDK:** `auth.setInitialPassword` binds the already-mounted `POST /api/v1/auth/set-initial-password` route, which had no client method.
@@ -10,4 +11,4 @@ The method is shaped exactly like its namespace siblings (`this.getRoute('auth')
 
 **Nothing about the route's behaviour moves.** Its accept/reject logic, its admit set and its server-side guards are untouched — this is a client binding to an existing mount, not a widening of what the mount allows.
 
-**Its `AUTH_ROUTE_LEDGER` row is deliberately not in this change**, and one consequence is visible in CI: with no exact row, `client-url-conformance.test.ts`'s final assertion sees this URL matched only by the dispatcher's `* /auth/**` wildcard family and fails, because that bound is ratcheted to zero on purpose. The row and this method have to arrive together — see the PR body.
+**Its `AUTH_ROUTE_LEDGER` row lands with it**, because the two halves are one statement and neither is true alone. `plugin-auth` gains `{ route: 'POST /api/v1/auth/set-initial-password', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.setInitialPassword' }` — the ninth mount of the #10534 census, whose disposition was escalated rather than guessed and which the maintainer ruled `sdk` (option C, 2026-08-22) and then ruled should land in one PR (2026-08-23). Without the row, the method's URL matched only the dispatcher's `* /auth/**` prefix family, and `client-url-conformance.test.ts` bounds wildcard-only matches at zero on purpose; with it, the same URL resolves to an enumerated route. The row also brings the `check:auth-mount-ledger` pending-disposition entry down — the exemption that carried this route while the question was open is deleted, which is that ratchet working rather than being relaxed.

--- a/.changeset/client-auth-set-initial-password.md
+++ b/.changeset/client-auth-set-initial-password.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/client": minor
+---
+
+**SDK:** `auth.setInitialPassword` binds the already-mounted `POST /api/v1/auth/set-initial-password` route, which had no client method.
+
+`AuthPlugin` has mounted this route on the raw Hono app for as long as the SSO-onboarding flow has existed, but `packages/client/src` built the URL nowhere — measured zero for both `setInitialPassword` and `set-initial-password`, against four sibling auth members returning non-zero on the same corpus, so the absence was an absence and not a broken search. Its only caller was `@object-ui/auth`'s `createAuthClient`, whose three other auth URLs (`/config`, `/get-session`, `/list-accounts`) are all expressed on `ObjectStackClient`, and whose sibling branch in the very same Console password card — `changePassword` — has been ledgered `sdk` throughout.
+
+The method is shaped exactly like its namespace siblings (`this.getRoute('auth')` + `this.fetch`, `POST` with a JSON body, returning the parsed envelope), because the difference between it and `changePassword` is a **server-side** one and belongs there: better-auth registers `setPassword` with no HTTP path of its own (server-only `auth.api.setPassword`), so ObjectStack wraps it in an authenticated mount that requires a session and refuses with 409 `PASSWORD_ALREADY_SET` when a credential already exists. Callers that already have a password use `changePassword`, which verifies the current one.
+
+**Nothing about the route's behaviour moves.** Its accept/reject logic, its admit set and its server-side guards are untouched — this is a client binding to an existing mount, not a widening of what the mount allows.
+
+**Its `AUTH_ROUTE_LEDGER` row is deliberately not in this change**, and one consequence is visible in CI: with no exact row, `client-url-conformance.test.ts`'s final assertion sees this URL matched only by the dispatcher's `* /auth/**` wildcard family and fails, because that bound is ratcheted to zero on purpose. The row and this method have to arrive together — see the PR body.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -2585,6 +2585,28 @@ export class ObjectStackClient {
     },
 
     /**
+     * Set a **first** local password for a signed-in user who has none yet —
+     * the SSO/social-onboarded account that has no `credential` row.
+     *
+     * This is NOT `changePassword`'s sibling-by-convenience: better-auth
+     * registers `setPassword` with no HTTP path of its own (server-only
+     * `auth.api.setPassword`), and ObjectStack's AuthPlugin mounts the wrapper
+     * this method targets. The route requires a valid session and REFUSES
+     * (409 `PASSWORD_ALREADY_SET`) when a credential already exists — in that
+     * case use `changePassword`, which verifies the current password.
+     *
+     * ObjectStack mount: POST /set-initial-password — `{ newPassword }`.
+     */
+    setInitialPassword: async (req: { newPassword: string }) => {
+      const route = this.getRoute('auth');
+      const res = await this.fetch(`${this.baseUrl}${route}/set-initial-password`, {
+        method: 'POST',
+        body: JSON.stringify(req),
+      });
+      return res.json();
+    },
+
+    /**
      * Begin a change-email flow. better-auth sends a verification mail to
      * the new address; the change only takes effect after the user clicks
      * the link.

--- a/packages/plugins/plugin-auth/src/auth-route-ledger.conformance.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-route-ledger.conformance.test.ts
@@ -176,7 +176,8 @@ describe('auth route ledger hygiene', () => {
     // the `source` split stays honest rather than becoming a place to park a
     // row that failed the upstream check.
     //
-    // [#10534] Grew from 3 to 11. A census of `auth-plugin.ts` found 17 such
+    // [#10534] Grew from 3 to 11, and to 12 with #10974/#10975. A census of
+    // `auth-plugin.ts` found 17 such
     // mounts, of which nine were in NEITHER half of the ledger; eight are
     // ledgered now. This pin is the thing that makes the enlarged set
     // reviewable: an ObjectStack mount added or removed without a matching
@@ -191,10 +192,17 @@ describe('auth route ledger hygiene', () => {
     // are complements rather than duplicates, and both are worth keeping: this
     // pin is a reviewed, hand-written statement of what the objectstack-sourced
     // set IS, and the gate is a reading of what the plugin actually serves.
-    // The ninth mount,
-    // `POST /api/v1/auth/set-initial-password`, is deliberately absent: its
-    // disposition is escalated on #10534 rather than guessed (see the ledger
-    // comment above these rows).
+    // The ninth mount, `POST /api/v1/auth/set-initial-password`, was
+    // deliberately absent while its disposition was escalated on #10534 rather
+    // than guessed. It is present now, and it got here by ADDITION on this
+    // pin's own terms — not by loosening the assertion, deleting the pin, or
+    // computing the list. Both terms hold for it: `auth-plugin.ts` mounts it
+    // itself (a `rawApp.post` on the `${basePath}/set-initial-password`
+    // template, ahead of the catch-all), and the `live.has(route)` loop below
+    // holds it to the same proof as the other eleven — better-auth does not
+    // publish it. Its `sdk` disposition names `auth.setInitialPassword`, which
+    // exists in the same change (#10974 / #10975, combined by the maintainer
+    // ruling of 2026-08-23).
     const own = AUTH_ROUTE_LEDGER.filter((e) => e.source === 'objectstack').map((e) => e.route).sort();
     expect(own).toEqual([
       'GET /api/v1/auth/bootstrap-status',
@@ -207,6 +215,7 @@ describe('auth route ledger hygiene', () => {
       'POST /api/v1/auth/admin/sso/verify-domain',
       'POST /api/v1/auth/admin/unlock-user',
       'POST /api/v1/auth/organization/add-member',
+      'POST /api/v1/auth/set-initial-password',
       'POST /api/v1/auth/sys-oauth-application/register',
     ]);
     for (const route of own) {

--- a/packages/plugins/plugin-auth/src/auth-route-ledger.ts
+++ b/packages/plugins/plugin-auth/src/auth-route-ledger.ts
@@ -178,6 +178,16 @@ export const AUTH_ROUTE_LEDGER: readonly AuthRouteLedgerEntry[] = [
   { route: 'GET /api/v1/auth/oauth2/public-client', family: 'oauth-provider', source: 'better-auth', disposition: 'sdk', client: 'oauth.applications.getPublic', requires: 'oidcProvider' },
   { route: 'GET /api/v1/auth/bootstrap-status', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.bootstrapStatus' },
   { route: 'GET /api/v1/auth/config', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.getConfig' },
+  // #10974 / #10975 — the ninth ObjectStack mount from the #10534 census,
+  // ledgered `sdk` on the maintainer's option-C ruling (2026-08-22) rather
+  // than on either word that was available before it. The two halves landed
+  // in ONE PR by the follow-up ruling of 2026-08-23: the row alone would have
+  // been the #3528 coverage lie, and the method alone matched its URL only
+  // through the dispatcher's `* /auth/**` family, which
+  // `client-url-conformance.test.ts` bounds at zero. Together they are one
+  // statement — the method exists, this row declares it, and the URL now
+  // resolves to an enumerated route.
+  { route: 'POST /api/v1/auth/set-initial-password', family: 'objectstack-mount', source: 'objectstack', disposition: 'sdk', client: 'auth.setInitialPassword' },
   // ─────────────────────────────────────────────────────────────────────
   // #10534 — the remaining ObjectStack raw-app mounts, ledgered.
   //
@@ -205,15 +215,18 @@ export const AUTH_ROUTE_LEDGER: readonly AuthRouteLedgerEntry[] = [
   // an accommodation written to make a row fit.
   //
   // ⚠️ `POST /api/v1/auth/set-initial-password` is the ninth mount and is
-  // DELIBERATELY NOT LEDGERED HERE. It fails the test above in a way none of
-  // these do: its caller is `@object-ui/auth`'s `createAuthClient`, whose
-  // three other auth URLs (`/config`, `/get-session`, `/list-accounts`) are
-  // ALL expressed on `ObjectStackClient` — and its own sibling branch in the
-  // same Console password card, `changePassword`, is ledgered `sdk`. That
-  // shape reads as `gap` ("should be in the SDK and is not"), not as
-  // `server-only`, and `gap` is ratcheted to zero by this file's conformance
-  // suite. Writing `server-only` there would be a false declaration of intent
-  // to dodge a ratchet. It is escalated on #10534 instead.
+  // NOT in this `server-only` batch — it is ledgered `sdk` with the other two
+  // ObjectStack mounts above (#10974 / #10975). It failed the test this batch
+  // passes: its caller is `@object-ui/auth`'s `createAuthClient`, whose three
+  // other auth URLs (`/config`, `/get-session`, `/list-accounts`) are ALL
+  // expressed on `ObjectStackClient` — and its own sibling branch in the same
+  // Console password card, `changePassword`, is ledgered `sdk`. That shape
+  // read as `gap` ("should be in the SDK and is not"), not as `server-only`,
+  // and `gap` is ratcheted to zero by this file's conformance suite; writing
+  // `server-only` there would have been a false declaration of intent to
+  // dodge a ratchet. It was escalated on #10534 rather than guessed, and the
+  // maintainer resolved the `gap` at its source instead of recording it:
+  // `auth.setInitialPassword` now exists, so `sdk` is the measurement.
   //
   // `requires` follows the add-member precedent: it names the better-auth
   // plugin the route's WORK needs, not whether the mount is conditional —

--- a/scripts/check-auth-mount-ledger.mjs
+++ b/scripts/check-auth-mount-ledger.mjs
@@ -139,16 +139,12 @@ export const EXIT_NOT_MEASURED = 2;
  * entry and the gate then fails if the entry is still here.
  */
 export const PENDING_DISPOSITION = [
-  {
-    route: 'POST /api/v1/auth/set-initial-password',
-    issue: '#10975',
-    why:
-      'Disposition escalated on #10534 rather than guessed: `server-only` would claim an intent ' +
-      "the route's own peer group contradicts (its three sibling URLs in the same createAuthClient " +
-      'are all ledgered `sdk`), and `gap` is ratcheted to <= 0. Maintainer ruling 2026-08-22: ' +
-      'option C -- add `auth.setInitialPassword` to ObjectStackClient (#10974), THEN ledger the ' +
-      'row as `sdk` (#10975, blocked-by #10974). This entry is deleted by #10975.',
-  },
+  // EMPTY, and that is the ratchet having come down rather than a list nobody
+  // uses. Its one entry -- `POST /api/v1/auth/set-initial-password`, granted by
+  // the maintainer ruling of 2026-08-22 -- was deleted when #10974/#10975
+  // landed its disposition: an `sdk` row naming `auth.setInitialPassword`. The
+  // gate would fail (`resolved-pending`) if the entry had been left behind, so
+  // this deletion is the landing half of that ruling, not tidying.
 ];
 
 /** Shrink-only. Raising it is a maintainer decision, not a repair. */
@@ -167,8 +163,8 @@ export const MIN_NOTE_CHARS = 60;
  * row in `AUTH_ROUTE_LEDGER`, which grows as routes are added and is no ratchet.
  * But both paths that touch PENDING_DISPOSITION expand a shrink-only exemption
  * list, and neither is the landing author's to take. Refusing them outright would
- * be the stronger shape and would also be FALSE: the list has a legitimate entry,
- * granted by a maintainer ruling. There is a real act here with a real owner, so
+ * be the stronger shape and would also be FALSE: the list HAS held a legitimate
+ * entry, granted by a maintainer ruling. There is a real act here with a real owner, so
  * the honest shape is to name the owner rather than to deny the act -- the same
  * reading `check-skills-token-ratchet.mjs` records for its published-catalog
  * ceiling (#10473).
@@ -391,8 +387,9 @@ function dispositionDemand(route) {
     '  a PENDING_DISPOSITION entry naming that issue, and stays printed on every clean run.',
     '',
     `  ${RATCHET_AUTHORITY} -- adding \`${route}\` to PENDING_DISPOSITION is an EXEMPTION from this`,
-    '  gate, and it is not yours to grant yourself. That list is shrink-only, its one entry exists',
-    '  because a maintainer ruled on it (#10534, 2026-08-22), and an author who quietly adds their',
+    '  gate, and it is not yours to grant yourself. That list is shrink-only and is EMPTY today; the',
+    '  one entry it has ever held was there because a maintainer ruled on it (#10534, 2026-08-22)',
+    '  and came off when that disposition landed. An author who quietly adds their',
     '  own route has done the single thing that turns this gate into a parking space: the mount is',
     '  then "accounted for" by a line recording that nobody decided. Escalating costs a round; a',
     '  self-granted exemption costs the gate. There IS a legitimate act here -- it just has an',


### PR DESCRIPTION
Fixes #10974
Fixes #10975

One statement in one PR: **the method exists · the ledger declares it · the URL resolves to an enumerated route.**

`POST /api/v1/auth/set-initial-password` has been mounted by `AuthPlugin` for as long as the SSO-onboarding flow has existed, with no SDK method and no ledger row. This binds it into `ObjectStackClient` as `auth.setInitialPassword` and records the exact `AUTH_ROUTE_LEDGER` row that names that method.

## The ruling this PR carries

Maintainer's **option C** (2026-08-22) settled the disposition: bind the route into the SDK, then ledger it `sdk`. It was filed as two cards, #10974 then #10975, and the SDK half landed here first — at which point the split turned out to be measurably unsatisfiable. `client-url-conformance.test.ts` bounds wildcard-only matches at zero (*"ZERO IS THE POINT: … Raising this bound reintroduces the one kind of evidence this audit family has caught being wrong"*), so the method matching through the dispatcher's `* /auth/**` row was a **hard failure**, not the weak pass #10974's body predicted. The only thing that turns it green is the exact row — which #10974's own fence excluded.

Maintainer ruling **A — combine** (2026-08-23): both halves land here. That changes the packaging, not the surface — option C had already authorised exactly one method and exactly one row.

⚠️ **Clause-② stands unchanged.** This widens published SDK surface. `needs:contract-review` stays hung, the PR stays **draft**, no ready-flip, no auto-merge, no merge-queue enqueue on the dispatching seat's authority, and the reviewing seat must not be the dispatching seat.

## The matched pattern, named before and after

A green suite either way would not show the displacement; the pattern name does. Both readings come from the conformance test's **own** `matches()`, via a temporary probe that was restored by trap after each run, so no probe is in the diff. Each probe's injection was confirmed on disk before its run (anchor and marker counts, byte delta) and the tree was verified clean again afterwards.

**BEFORE** — at `f9f809d2`, from the unmodified test's own failing assertion, no probe needed:

```
auth.setInitialPassword → POST /api/v1/auth/set-initial-password (via * /auth/**): expected 1 to be +0
```

and, naming the compiled pattern's source:

```
OSPROBE auth.setInitialPassword -> POST /api/v1/auth/set-initial-password (via * /auth/**) [pattern source: dispatcher]
```

**AFTER** — at `fbd9af2d`, printed by vitest itself from a probe assertion:

```
OSPROBE matched-pattern-name for auth.setInitialPassword POST /api/v1/auth/set-initial-password;
pattern source=auth: expected 'POST /api/v1/auth/set-initial-password' to be 'OSPROBE-SHOW-ME'
```

`* /auth/**` (compiled from the dispatcher ledger, `source: 'dispatcher'`) → `POST /api/v1/auth/set-initial-password` (compiled from `AUTH_ROUTE_LEDGER`, `source: 'auth'`). The sort at `client-url-conformance.test.ts:132` put the exact row ahead of the wildcard family exactly as its comment says it would. `wildcardOnly` is now empty and its bound is untouched at `toBe(0)`.

## The `:171` pin — extended by ADDITION, argued on its own terms

`the objectstack-mounted rows are the ones auth-plugin.ts serves itself` pins the `source: 'objectstack'` set to a hand-written literal list. **The card said 3 → 4; re-derived on this branch it is 11 → 12** — the pin grew through #10534's follow-ups after #10975 was written. The assertion, its shape and the `live.has(route)` loop are **unchanged**; one string literal was added, in the position `.sort()` puts it.

The pin's own two terms, both measured:

**1. `auth-plugin.ts` mounts it directly.** Re-derived rather than trusted — #10975 measured line 1716, it is now **1741**:

```ts
// packages/plugins/plugin-auth/src/auth-plugin.ts:1741
rawApp.post(`${basePath}/set-initial-password`, async (c: any) => {
```

A raw-app mount **ahead of the catch-all**, so better-auth's wire table cannot publish it and the enumeration (which reads `.path`) never sees it.

**2. `live.has(route)` is `false`.** The assertion's own reading, printed by vitest, with a positive control so a `false` from an empty set cannot pass for a measurement:

```
pin=12 · live.size=131 · live.has('POST /api/v1/auth/set-initial-password')=false
       · CONTROL live.has('POST /api/v1/auth/sign-in/email')=true
```

131 live routes enumerated, the control route present, ours absent. It does not come from better-auth.

⛔ Not reached by loosening the assertion, deleting the pin, or replacing the literal list with a computed one.

## The five gates, individually — all at `fbd9af2d`

| Gate | Result |
|---|---|
| `auth-route-ledger.conformance.test.ts:152` every `sdk` row names a client method | ✓ `every 'sdk' entry names its client method; every non-sdk entry carries a rationale` |
| `:160` no route ledgered twice, every row under the auth base path | ✓ `no route is ledgered twice, and every row is under the auth base path` |
| `:171` the objectstack pin | ✓ `the objectstack-mounted rows are the ones auth-plugin.ts serves itself` |
| `:189` `gap` and `mismatch` only shrink | ✓ `gap and mismatch counts only shrink` — **both still 0**; no `gap` row was added, and no ratchet moved |
| `client-url-conformance.test.ts:363` every client method classified | ✓ the method **drives**; not parked in `NON_HTTP`, no `DRIVE` override |
| `client-url-conformance.test.ts:373` every URL matches a mounted route | ✓ now green on the **exact** row (see above) |

Whole files: `auth-route-ledger.conformance.test.ts` **10 passed (10)**; `@objectstack/client` **23 files / 314 tests passed** (was 22/1-failed and 313/1-failed at `f9f809d2` — the one failure was `:373`).

## One file outside the two halves, and why it is not scope creep

`scripts/check-auth-mount-ledger.mjs` carried a `PENDING_DISPOSITION` entry for this exact route, whose own text reads *"This entry is deleted by #10975."* The gate reconciles that list in both directions and raises `resolved-pending` when an entry's route acquires a ledger row — so landing the row **without** deleting the entry is a red gate, by design. The entry is deleted; `PENDING_MAX` is **not** changed (it stays 1, and lowering it would break the gate's own self-test case that exercises a one-entry list). Two sentences of prose that the deletion made false were corrected in the same file. The ratchet coming down, in the gate's own words:

```
check-auth-mount-ledger --self-test: 42 assertions OK (right boundary, lane exclusion, rationale, pending ratchet).
check-auth-mount-ledger: OK -- 17 ObjectStack auth mount(s), all accounted for
  (13 by a reviewed ledger row, 4 shadowing a vendor-declared path, 0 pending a disposition).
```

## Nothing was weakened to get here

⛔ The `wildcardOnly` bound stays at `0` (option D was presented and **not** taken). ⛔ The method is not in `NON_HTTP`. ⛔ `gap` and `mismatch` stay at 0. ⛔ The route's accept/reject behaviour, its admit set and its server-side guards are untouched — this binds a client and records a row; it does not change what the mount allows. ⛔ Nothing else in `packages/plugins/plugin-auth/**` is touched.

## Verification — all at `fbd9af2d`, clean tree

Gate families derived from the real change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-built path list; the script read the merge-base change set of 5 paths and asserted the repo against this checkout's `origin`). 18 path-matched families plus the 6 convention-triggered ones for a touched test file, every exit code captured **before** any pipe:

- suites: `plugin-auth` `auth-route-ledger.conformance.test.ts` (10/10) · `@objectstack/client` full suite (23 files / 314 tests)
- typecheck: `@objectstack/client` (incl. `check:test-typecheck` — *"0 file(s) / 0 error(s)"*) · `@objectstack/plugin-auth`
- `check:auth-mount-ledger` · `check:engine-double-contract` · `check:where-matcher` · `check:query-options-erasure` · `check:type-check-coverage` · `check:nul-bytes` · `check:ratchet-remedy-authority` · `check:cross-package-test-inputs` · `check:test-source-alias` · `check:type-source-resolution` · `check:published-files` · `check:slot-lookup` · `check:entry-guard` · `check:parse-guard` · `check:pnpm-filter-targets` · `check:changeset-gate-self-tests` · `check:objectui-changeset`
- `check-adr-0087-registration` · `check-changeset-no-major` · `check-ci-filter-parity` · `check-cross-package-test-inputs` · `check-empty-changeset` · `check-plugin-teardown-shape` · `check-affected-docs`
- **repo-wide** `pnpm lint` (`eslint . --no-inline-config`) — run in full, not narrowed
- `check:type-check-debt --re-measure` on a fully built workspace closure: *"33 ledger entr(ies) re-measured … 1897 raw tsc error(s) total, none above its recorded number"* (its first invocation refused with NOT MEASURED on an unbuilt worktree — its designed refusal; the closure was built and it was re-run)

Changeset present and extended to both packages (`@objectstack/client` minor, `@objectstack/plugin-auth` patch).

## Refs

Part of #10534, which remains open until all 17 of its mounts are accounted for — its ledger leg for this route is now clear, and its docs leg is #10660's. Also #10050 · #3563 / #3642 (the conformance guards) · #3656 (the auth ledger's charter) · #9941 (the pin's `add-member` precedent) · #3528 (the coverage-lie failure the combined order avoids: the row and the method exist in the same commit).

Out-of-scope finding #11359 (the auth ledger's `client` names are never resolved against a real client, unlike every sibling ledger) is filed, unassigned, and is not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019siH5jDmk5hrayvfyojUqR)_