### PR TITLE
docs(adr): ADR-0120 D4 amendment — the duplicate pre-flight is per index class

### DIFF
--- a/docs/adr/0120-unique-scope-vocabulary-and-null-safe-tenant-uniqueness.md
+++ b/docs/adr/0120-unique-scope-vocabulary-and-null-safe-tenant-uniqueness.md
@@ -35,7 +35,7 @@ the per-organization meaning **NULL-safe**:
 | D1 | Scope is said, not inferred | `unique: 'global' \| 'organization'` on **both** spellings; bare `true` on a *declared index* is deprecated (17.x warn → protocol 18 reject) |
 | D2 | Stored metadata converts losslessly | ADR-0087 D2 entry rewrites declared-index `unique: true → 'global'` — byte-identical physical shape, **zero drift** |
 | D3 | Per-organization unique survives NULL | organization key part materializes as `COALESCE(organization_id, '__global__')` — fixes #5030 for field-level and new `'organization'` indexes alike; ships in 17.x |
-| D4 | Tightening migrates through ceremony | `recreate_index` drift + duplicate pre-flight in `os migrate plan`; auto-apply only on a clean probe |
+| D4 | Tightening migrates through ceremony | `recreate_index` drift + duplicate pre-flight, routed **per index class** — declared/differ-visible through `os migrate plan`, runtime-managed/differ-excluded through `os migrate duplicates` (2026-08-22 amendment); auto-apply only on a clean probe |
 | D5 | Authoring gates carry the contract | new lint rule for unscoped declared uniques (authoring-time checkable, no tenancy guessing); R10 rewritten in the new vocabulary |
 | D6 | Written surfaces tell one truth | the five #3696 surfaces, the pin tests, and the false single-tenant claim in `UniqueScopeSchema` are updated in the same wave |
 | D7 | Staged over 17.x → 18 | additive in 17.x, rejection + conversion at protocol 18 |
@@ -352,6 +352,46 @@ with pre-existing duplicate NULL-row data — data the old index wrongly admitte
 
 No constraint-*relaxing* rebuild exists under this ADR by construction; the migration
 planner asserts that invariant.
+
+> **Amendment (2026-08-22, [#8725](https://github.com/objectstack-ai/objectstack/issues/8725) / [#11032](https://github.com/objectstack-ai/objectstack/issues/11032)) — the duplicate pre-flight is per index CLASS: `os migrate plan` for the declared, differ-visible indexes; `os migrate duplicates` for the runtime-managed ones the differ excludes by construction.**
+>
+> The sentence above — "`os migrate plan` gains a **duplicate pre-flight probe** per affected
+> index" — was written for the **declared** class, the `recreate_index` drift ops the
+> reconciler can see, and it is true there: `os migrate plan` reports a blocked tightening of
+> a declared organization-unique index in full, quoting the offending group and its row count.
+>
+> It cannot reach a second class. Three `kernel:ready` migrations in
+> `packages/metadata-protocol` tighten an index at runtime —
+> `ensureMetadataOverlayIndexes` (`sys_metadata`), `ensureViewDefinitionActiveIndex`
+> (`sys_view_definition`), `ensureSysSettingIdentityIndex` (`sys_setting`) — and every one of
+> them is invisible to the drift differ **by construction**. *After* the tightening,
+> `isRuntimeManagedIndex` excludes the index (`isSyncReproducibleIndex` is false for a partial
+> index and for a `COALESCE` key part over a non-tenant column), and that exclusion is
+> correct — without it a boot would propose rebuilding away the guarantee it just created.
+> *Before* it there is nothing to see either: each migration deliberately reuses the DECLARED
+> index's name, so the name-matched slot reads as filled whichever physical form is there. A
+> command that reports **drift** can therefore never report these rows — measured with a
+> matched control, one database carrying the same duplicate damage under both classes, where
+> `plan` named the declared index in full and said nothing about the runtime-managed one.
+>
+> **Ruled (maintainer, 2026-08-22, on #8725).** The pre-flight is per class:
+>
+> - **declared, differ-visible indexes** → reported through `os migrate plan`, exactly as
+>   decided above. Its drift contract is untouched by this amendment.
+> - **runtime-managed indexes the differ excludes by construction** → reported through
+>   `os migrate duplicates`, which boots read-only and owns the "inventory, never repair"
+>   contract.
+>
+> Everything else D4 decides is unchanged and holds for both classes: the previous index stays
+> in place, the report names the key that is not enforced and the rows that block it, and no
+> op is auto-applied on a dirty probe.
+>
+> **The split has an expiry.** It exists only because these three platform indexes are
+> tightened at runtime rather than declared. The route #8629's ruling parked to the
+> ADR-0120 / v18 train — NULL-safe uniqueness declared in the spec, so a declaration states
+> its own row identity and no runtime migration is needed — retires all three migrations, at
+> which point the class collapses back into the declared one and the pre-flight has a single
+> route again.
 
 ### D5 — Authoring gates
 


### PR DESCRIPTION
Fixes #11032

⛔ **Governed surface — `docs/adr/**`.** This PR stays **draft**. Review requested from `os-zhuang`; **the human merge IS the review** and the audit record. Never flipped ready, never enqueued, no auto-merge armed.

## What is wrong

ADR-0120 **D4** decides:

> `os migrate plan` gains a **duplicate pre-flight probe** per affected index

That was written for the **declared** index class — the `recreate_index` drift ops the reconciler can see — and it is true there. It cannot reach a second class. Three `kernel:ready` migrations in `packages/metadata-protocol` tighten an index at runtime (`ensureMetadataOverlayIndexes` on `sys_metadata`, `ensureViewDefinitionActiveIndex` on `sys_view_definition`, `ensureSysSettingIdentityIndex` on `sys_setting`), and each is invisible to the drift differ **by construction**: after the tightening `isRuntimeManagedIndex` excludes the index (`isSyncReproducibleIndex` is false for a partial index and for a `COALESCE` key part over a non-tenant column — correctly, or a boot would propose rebuilding away the guarantee it just created), and before it each migration deliberately reuses the DECLARED index's name, so the name-matched slot reads as filled either way.

PR #11031 shipped the behaviour for that class. D4's **text** did not move with it, so the three modules' doc comments cite D4 while naming `os migrate duplicates` — accurate about behaviour, inaccurate about D4's text, and the next author reads that as an error in the code rather than a split in the decision.

## The ruling this records — quoted verbatim

From the maintainer ruling recorded on #8725 (2026-08-22, decision-inbox digest; the maintainer accepted the batch, verbatim: 「接受所有」). Quoted rather than paraphrased, and the Chinese is kept untranslated:

> **Ruled:** Option B — the read-only reporting path that flags the duplicates: a probe on `os migrate duplicates` (which already boots read-only and owns the "inventory, never repair" contract) surfaces the three `kernel:ready` migrations' blocking duplicate rows before the operator restarts the server, keeping `os migrate plan`'s drift contract untouched. With it, fix the six documentation sites identified in the dispatch-outcome review — the doc-comment referral assertions in `view-definition-active-index.ts`, `sys-setting-identity-index.ts`, and `overlay-index.ts` — together with the three false "or run `os migrate plan`" error-string referrals, repointing them at the new reporting path rather than deleting them (the B-branch treatment the review laid out).

## The change

One file, 41 insertions / 1 deletion. The D4 summary row (line 38) and an amendment blockquote at the end of the D4 section — the ADR-0112 amendment convention: the original decision text is left standing, the amendment records what changed and why.

**Summary row, after:**

> | D4 | Tightening migrates through ceremony | `recreate_index` drift + duplicate pre-flight, routed **per index class** — declared/differ-visible through `os migrate plan`, runtime-managed/differ-excluded through `os migrate duplicates` (2026-08-22 amendment); auto-apply only on a clean probe |

**The amendment's operative wording:**

> **Ruled (maintainer, 2026-08-22, on #8725).** The pre-flight is per class:
>
> - **declared, differ-visible indexes** → reported through `os migrate plan`, exactly as decided above. Its drift contract is untouched by this amendment.
> - **runtime-managed indexes the differ excludes by construction** → reported through `os migrate duplicates`, which boots read-only and owns the "inventory, never repair" contract.
>
> Everything else D4 decides is unchanged and holds for both classes: the previous index stays in place, the report names the key that is not enforced and the rows that block it, and no op is auto-applied on a dirty probe.

The amendment also carries the by-construction invisibility argument and the matched-control measurement (one database carrying the same duplicate damage under both classes; `plan` named the declared index in full and said nothing about the runtime-managed one) — both already recorded in `runtime-index-preflight.ts` and `view-definition-active-index.ts`, now stated where the decision lives.

## Route 2 retires the split

The amendment says so in its own last paragraph, and it is worth stating here too: the split exists **only** because these three platform indexes are tightened at runtime rather than declared. **ADR-0120 Route 2** — NULL-safe uniqueness declared in the spec, so a declaration states its own row identity and no runtime migration is needed — was parked to the ADR-0120 / v18 train by #8629's ruling. If Route 2 lands, all three runtime migrations retire, the class collapses back into the declared one, and this per-class split goes with them. This amendment is therefore a record of a temporary shape, with its expiry named.

## No source file is touched — verified, not assumed

The claim under test: amending D4 makes the three migration modules' doc comments correct **where they already stand**. Every `ADR-0120 D4` and `os migrate` reference in `packages/metadata-protocol/src/migrations/` was read against the amended wording (read-only; nothing edited):

| Site | Says | Against amended D4 |
|---|---|---|
| `overlay-index.ts` L59-64 | "reports every failure the way ADR-0120 D4 requires: keep the previous index, name the key that is NOT enforced, ship the exact query …, point at `os migrate duplicates`, never block the boot" | **Correct.** D4 now routes this class to `os migrate duplicates`; the rest of the disposition is unchanged and explicitly held for both classes. |
| `overlay-index.ts` L66-73 | "The referral named `os migrate plan` until #8725, and it was FALSE for this class … ruling 2026-08-22 routes the class to `os migrate duplicates`" | **Correct.** Reads as history of the code's referral string, and D4's text now agrees with the outcome. |
| `overlay-index.ts` L98, L150 | a re-keying gets "its own ADR-0120 D4 ceremony" | **Unaffected.** The ceremony itself is untouched. |
| `overlay-index.ts` L194-201, L317, L377 | D4's "name the offending rows" / "wording contract"; error string points at `os migrate duplicates` | **Correct.** |
| `view-definition-active-index.ts` L114-117 | "handled the way ADR-0120 D4 requires: the PREVIOUS index stays in place, … points at `os migrate duplicates`, and the boot continues" | **Correct.** |
| `view-definition-active-index.ts` L119-128 | referral used to name `os migrate plan` and was FALSE; matched-control measurement; ruling routes the class | **Correct**, and the amendment now carries the same measurement. |
| `view-definition-active-index.ts` L235-241, L341-344, L393-396, L405 | D4's row-listing / wording contract; `os migrate duplicates` | **Correct.** |
| `sys-setting-identity-index.ts` L125-128 | "the operator then gets ADR-0120 D4's full disposition in one `error` line … without reaching for `os migrate duplicates` first" | **Correct.** |
| `sys-setting-identity-index.ts` L130-138 | referral named `os migrate plan` until #8725 and was FALSE; ruling routes the class, leaving `plan`'s drift contract untouched | **Correct**, verbatim the split D4 now states. |
| `sys-setting-identity-index.ts` L305-312, L487-490, L556-557 | D4's row-listing / wording contract; error string names `os migrate duplicates` and cites D4 | **Correct.** |
| `partial-index-probe.ts` L34 | "ADR-0120 D4 requires naming the key that is not enforced and the consequence" | **Unaffected** — the wording contract is unchanged. |
| `runtime-index-preflight.ts` L18-56 | D4 refusal disposition; "`os migrate plan` cannot carry it … by construction, twice over"; ruling routes to `os migrate duplicates` | **Correct**, and it is the closest prose match to the amendment's argument. |

**Result: zero comments remain inaccurate**, so no source file needs an edit and none was made. ⛔ `packages/metadata-protocol/**` was not touched — `protocol.ts` is held by in-flight #11095 under a hard file serial.

The two helpers the amendment names were verified in `packages/drivers/driver-sql/src/schema-drift.ts` (`isSyncReproducibleIndex` L895 returns `false` for `index.partial === true` and for a `COALESCE` part whose column is not the tenant field; `isRuntimeManagedIndex` L916 is true in that case, so the differ skips), and `os migrate duplicates` exists at `packages/cli/src/commands/migrate/duplicates.ts`, whose own header records the same 2026-08-22 ruling for its `runtimeIndexPreflight` section.

## Changeset: none, `skip-changeset` applies

Repo convention for an ADR-only change, checked rather than assumed: comparable merged ADR-only PRs — #10718, #10154, #9233 — each carry `documentation` + `skip-changeset` and add **no** `.changeset/*.md`. `pr-automation.yml`'s `changeset-check` has no path-based exemption, so the label is the mechanism. This PR publishes nothing, so it takes the same treatment: label applied additively, then read back.

## Verification — all five derived gate families green at `484ae001`

Gate set derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths passed; it took the changeset from the merge base itself: 1 path, `docs/adr/0120-…md`). Verdict lines are the gates' own:

- `check:adr-anchors` — `check-adr-anchors: OK (52 anchored file(s), every governing ADR still referenced; 123 decision number(s) …; 27580 citation(s) across 3415 file(s) resolve).` Self-test: `✓ … 74 assertions`.
- `check:doc-authoring` — `✓ doc authoring guard: 389 files clean — no bare metadata literals.` Self-test green.
- `check:doc-formula-expressions` — `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 418 files / 1447 TS blocks judged clean by @objectstack/formula.` Self-test: `✓ … 30 cases passed`. (Needed `pnpm --workspace-concurrency=2 --filter '@objectstack/lint^...' build` first — `@objectstack/formula`'s `dist/` is its input.)
- `check:pm-governed-merges` — `✓ check-governed-merges --self-test: 129 assertions …`.
- `check-adr-links.mjs` — `✅ check-adr-links: 551 relative link destination(s) under docs/adr/ resolve`.

Exit codes captured before any pipe (`cmd > file 2>&1; EXIT=$?`), never through `tail`.

**Repo-level `pnpm lint`: a proven narrowing to zero, not a skip.** The three pieces of evidence, all read from eslint itself rather than from the config globs:

1. **Population, from eslint's own resolution:** for `docs/adr/0120-…md`, `ESLint.isPathIgnored()` returns `true` and `calculateConfigForFile()` returns `undefined` — the file matches no configuration block at all.
2. **Count, from the run:** `lintFiles()` on the changed file yields 1 result with 0 errors and 1 warning, that warning being `File ignored because no matching configuration was supplied.` — i.e. **0 linted files** in this diff's reachable population.
3. **Invariance for untouched files:** type-aware linting is **not** enabled — for a TS file that *is* in the population, `parserOptions.project` and `parserOptions.projectService` both resolve to `null` — so no markdown edit can move any untouched file's verdict, and this diff touches no eslint config, baseline or ratchet file.

Control-byte self-scan on the changed file: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no match.

⛔ No behaviour, gate or test was changed. ⛔ `content/docs/releases/**` untouched. ⛔ No other ADR amended, and no neighbouring text in ADR-0120 tidied.

---
_Generated by [Claude Code](https://claude.ai/code/session_019siH5jDmk5hrayvfyojUqR)_


---
_Generated by [Claude Code](https://claude.ai/code)_