### PR TITLE
fix(spec): COMPONENT_NODE_VISIBILITY_GUIDANCE no longer claims a hoisted properties visibility key is evaluated by nothing

### DIFF
--- a/.changeset/component-node-visibility-guidance-post-5505.md
+++ b/.changeset/component-node-visibility-guidance-post-5505.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): `COMPONENT_NODE_VISIBILITY_GUIDANCE` no longer claims a hoisted `properties` visibility key is evaluated by nothing (#11033)
+
+The `COMPONENT_NODE_VISIBILITY_KEYS` key-set guard's `prescription` — the text
+emitted to an author when a visibility key (`visible` / `visibleWhen` / …) is
+written inside `properties` instead of on the component node — closed with:
+
+> Inside `properties` it is hoisted onto the node by the renderer but evaluated
+> by nothing — the component renders unconditionally, which is a visibility
+> gate that silently does not gate.
+
+That was true when it was written and is false since objectui#5505
+(`c86185eb5`, merged 2026-08-21): `SchemaRenderer`'s node-level `visibleWhen`
+evaluator now binds `record`, so the hoisted value IS evaluated by the
+node-level gate. Post-#5505 the props-level and node-level forms evaluate the
+same value over the same `RecordContext` and compose as an idempotent AND —
+there is no gate that silently fails to gate.
+
+The prescription now states that truth instead, and keeps its move-it-up
+advice resting on the reason that still holds: `visibleWhen` at the node,
+beside `type` and `id`, is the ADR-0089 canonical spelling — a layer-discipline
+argument, not an inertness one.
+
+Message text only. No accept/reject verdict changes, no schema shape changes,
+and no runtime behaviour changes — both gates already evaluated the value
+identically before and after this change.

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -275,9 +275,11 @@ const COMPONENT_NODE_VISIBILITY_GUIDANCE: KeySetGuidance =
     prescription:
       'Visibility is a COMPONENT-level predicate, not a prop: move it up one level to the '
       + 'component node\'s own `visibleWhen` (ADR-0089 canonical spelling), beside `type` and '
-      + '`id`. Inside `properties` it is hoisted onto the node by the renderer but evaluated by '
-      + 'nothing — the component renders unconditionally, which is a visibility gate that '
-      + 'silently does not gate.',
+      + '`id` — one canonical spelling per layer, not because the props-level form is inert. '
+      + 'Since objectui#5505 (`c86185eb5`, merged 2026-08-21) the hoisted form IS evaluated by '
+      + 'the node-level gate: the two gates evaluate the same value and compose as an '
+      + 'idempotent AND, so leaving it in `properties` duplicates the canonical key rather '
+      + 'than silently failing to gate.',
   };
 
 const COMPONENT_NODE_KEYS_GUIDANCE: KeySetGuidance =


### PR DESCRIPTION
Fixes #11033

## What was false, and why it mattered

`COMPONENT_NODE_VISIBILITY_GUIDANCE`'s `prescription` in
`packages/spec/src/ui/component.zod.ts` is not a docblock — it is the
user-facing text emitted to an author the moment the `COMPONENT_NODE_VISIBILITY_KEYS`
guard refuses a visibility key (`visible`/`visibleWhen`/…) written inside
`properties`. It said:

> Inside `properties` it is hoisted onto the node by the renderer but
> evaluated by nothing — the component renders unconditionally, which is a
> visibility gate that silently does not gate.

That was true when it was written and stopped being true when objectui#5505
(`c86185eb5`, merged 2026-08-21) bound `record` into `SchemaRenderer`'s
node-level `visibleWhen` evaluator. Post-#5505 the hoisted value **is**
evaluated by the node-level gate — both gates evaluate the same value over
the same `RecordContext` and compose as an idempotent AND. An author (or an
AI agent generating metadata) that trusted the old sentence would reason
about the wrong gate.

## The fix

Per the triage dispatch clause on #11033, this is a **prose-truth repair**,
not a guidance redesign:

1. The move-it-up advice **stays** — now resting on the ADR-0089
   canonical-spelling / layer-discipline reason (`visibleWhen` belongs on the
   node, beside `type` and `id`), not on the props-level form being inert.
2. The falsified "evaluated by nothing" sentence is replaced with the
   post-#5505 truth, in the card's own measured wording: the hoisted form IS
   evaluated by the node-level gate since objectui#5505; the two gates
   evaluate the same value and compose as an idempotent AND.
3. No schema shape change. No accept/reject verdict changes anywhere —
   `COMPONENT_NODE_VISIBILITY_KEYS`'s key set, and everything it refuses, is
   unchanged.

Diff is confined to the one `prescription` string (`packages/spec/src/ui/component.zod.ts`),
plus a patch changeset.

## Out of scope

`content/docs/protocol/objectui/layout-dsl.mdx`'s `hasRole` claim, named as a
separate adjacent finding in #11033 — not touched here.

## Verification (all at `819e30500e`)

- `pnpm --filter @objectstack/spec build && pnpm --filter @objectstack/spec check:generated`
  — all 14 generated artifacts still up to date; nothing extracts this
  `prescription` string into a generated artifact.
- No test in the repo pins the old prescription text (`git grep` for
  "evaluated by nothing" / "hoisted onto the node by the renderer" /
  `COMPONENT_NODE_VISIBILITY_GUIDANCE` finds only this one file before and
  after) — nothing to update.
- `pnpm --filter @objectstack/spec test` (full package suite) — 419/419 test
  files, 11136/11136 tests passed.
- `pnpm --filter @objectstack/spec typecheck` — `tsc --noEmit` +
  `check:scripts-typecheck` + `check:test-typecheck` all clean; the
  pre-existing shrink-only test-typecheck debt (55 files / 263 errors,
  #5286) is untouched by this diff.
- `node scripts/pm/dispatch-gates.mjs` on this diff names 22 local gate
  families (17 before the changeset existed, 5 more once it did — the
  changeset self-tests, `check:objectui-changeset`, ADR-0087 registration,
  no-major, and empty-changeset checks). All 22 ran green, with one
  worktree-environment caveat: `check:doc-formula-expressions`
  (`packages/lint`) failed once on a stale `@objectstack/formula/dist` in
  this fresh worktree, unrelated to this diff, and passed once that
  dependency was built. `check:dev-prereqs`'s EXISTENCE half needs the full
  67-package workspace built (a `pnpm dev` preflight, not a per-diff check)
  and stayed red in this partially-built worktree independent of any
  change; its FRESHNESS half (the part that reads `packages/spec/dist`) is
  satisfied by the `pnpm --filter @objectstack/spec build` above. Full
  commands and exit codes are in the dev report comment on #11033.
- `node scripts/check-adr-0087-registration.mjs` confirms this changeset is
  correctly non-breaking (no ADR-0087 disposition marker required).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_