### PR TITLE
fix(driver-sql): give the SQLite builtin audit columns the canonical ISO-8601 DEFAULT

### DIFF
--- a/.changeset/sqlite-audit-column-canonical-default.md
+++ b/.changeset/sqlite-audit-column-canonical-default.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+**Fix:** on SQLite the builtin `created_at`/`updated_at` audit columns now take the same canonical ISO-8601 `DEFAULT` a declared `Field.datetime` NOW() column in the same table already gets (#11321).
+
+`createAuditTimestampColumn`'s non-MySQL branch was `table.timestamp(name).defaultTo(this.knex.fn.now())`. On SQLite `knex.fn.now()` compiles to an unqualified `CURRENT_TIMESTAMP`, which renders a zone-**naive**, space-separated, second-precision `'YYYY-MM-DD HH:MM:SS'`. A declared `defaultValue: 'NOW()'` field in the **same table** already got `(strftime('%Y-%m-%dT%H:%M:%fZ','now'))` from `nowColumnDefault`, so one table carried two spellings of one conceptual value:
+
+```
+created_at  "2026-08-23 14:54:17"          <- builtin audit  (naive)
+when        "2026-08-23T14:54:17.796Z"     <- declared field (canonical)
+```
+
+That naive spelling is the one `updatedAtStamp()`'s own docblock condemns: `Date.parse` reads a zone-less string as LOCAL time, silently shifting the instant by the host offset on a non-UTC runtime. It is also the pre-canonical storage form `backfillCanonicalDatetimes` exists to converge — reached here by a path writing it *today*, not by legacy data.
+
+The SQLite branch is now routed through `nowColumnDefault('datetime')` — the existing single source for "what does NOW() mean in DDL on this dialect" — rather than restating the expression, so the two cannot drift apart again. **Postgres and MySQL are untouched**: `knex.fn.now()` on Postgres is a real zone-aware `TIMESTAMP` that never had the ambiguity, and MySQL keeps the `now(3)` precision match from #11224.
+
+`rebuildSqliteTablePatched` — the whole-table rebuild SQLite drift reconciliation uses — re-emitted the audit default itself as `knex.fn.now()`. That method is SQLite-only, so leaving it would have silently **reverted** a canonically-created table the moment any unrelated drift (a relaxed NOT NULL, an orphaned column) triggered a rebuild. Fixed in the same change: a rebuild hands back the column `initObjects` would have built.
+
+**Graded `patch`, not `minor`, on a measurement rather than a judgement.** The change alters emitted DDL, so the question that decides the grade is what it does to databases that already exist:
+
+- **Existing tables are not altered.** Both call sites are `CREATE TABLE` only; `initObjects`' `alterTable` branch adds declared fields and never the audit columns. A table already on disk keeps `default CURRENT_TIMESTAMP`.
+- **They do not start reporting drift.** Measured on live in-memory SQLite through the real `detectManagedDrift` entry point against a table carrying the old default: **zero** entries. Two independent guards — `BUILTIN_COLUMNS` skips `created_at`/`updated_at` in both of `diffManagedTable`'s loops, and the only `default_mismatch` producer is the #4560 runtime-token check, for which `isAppResolvedDefaultToken('NOW()')` is pinned `false`. The measurement carries a positive control: in the same call on the same table, drift reports `unmapped_column` **and** `default_mismatch` for a `current_user` column, so the default-reading dimension is demonstrably live and still says nothing about the audit columns.
+- **Rows already written naive keep reading correctly.** `formatOutput`'s `repairNaiveUtcAuditTimestamp` folds them to canonical on read — the same disposition `nowColumnDefault` already documents for declared fields.
+
+So no deployment changes behaviour on upgrade; only newly-created tables get the corrected default.
+
+The population this actually repairs is wider than "writes that bypass the driver". `stampInsertTimestamps` fills both columns app-side, but it gates on `tablesWithTimestamps`, which only DDL-running paths populate. On the documented `skipSchemaSync` / `OS_SKIP_SCHEMA_SYNC=1` posture, `registerObjectMetadata` (the DDL-free registration door) deliberately does not touch that set — so the set is empty, the stamp returns early, and **the driver's own `create()` door reaches the column DEFAULT**. Measured, one table, one row per boot posture: `created_at "2026-08-23T14:54:17.791Z"` on a normal boot versus `"2026-08-23 14:54:17"` on a `skipSchemaSync` boot, with the declared NOW() sibling canonical in both — because its canonical shape lives in the column DEFAULT rather than in an app-side stamp. That asymmetry is the argument for fixing this in DDL, and it is now closed.

--- a/packages/drivers/driver-sql/src/sql-driver-11321-sqlite-audit-default-canonical.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-11321-sqlite-audit-default-canonical.test.ts
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11321] On SQLite the builtin audit columns must take the SAME canonical
+ * ISO-8601 DEFAULT a declared `Field.datetime` NOW() column in the same table
+ * gets — not the zone-naive `CURRENT_TIMESTAMP`.
+ *
+ * ## The defect
+ *
+ * `createAuditTimestampColumn`'s non-MySQL branch was
+ * `table.timestamp(name).defaultTo(this.knex.fn.now())`. On SQLite
+ * `knex.fn.now()` compiles to an unqualified `CURRENT_TIMESTAMP`, which renders
+ * a zone-NAIVE, space-separated, second-precision `'YYYY-MM-DD HH:MM:SS'`.
+ * `nowColumnDefault` — what a DECLARED `defaultValue: 'NOW()'` field gets —
+ * already emitted `(strftime('%Y-%m-%dT%H:%M:%fZ','now'))`. Measured on
+ * better-sqlite3 before the fix, one table, one defaulted insert:
+ *
+ * ```
+ * created_at  "2026-08-23 14:54:17"          <- builtin audit  (naive)
+ * updated_at  "2026-08-23 14:54:17"          <- builtin audit  (naive)
+ * when        "2026-08-23T14:54:17.796Z"     <- declared field (canonical)
+ * ```
+ *
+ * `updatedAtStamp()`'s own docblock condemns exactly that spelling: `Date.parse`
+ * reads a zone-less string as LOCAL time, silently shifting the instant by the
+ * host offset on a non-UTC runtime.
+ *
+ * ## Why this is asserted as AGREEMENT, not as a string
+ *
+ * The property that matters is that one table cannot carry two shapes for one
+ * conceptual value. So §1 and §2 compare the audit columns to a declared NOW()
+ * sibling *in the same table* rather than to a hard-coded literal: if
+ * `nowColumnDefault` ever changes its canonical spelling, this suite must keep
+ * passing (both sides move together) and must still fail if only one side moves.
+ *
+ * ## §3 exists because this changes emitted DDL
+ *
+ * Every SQLite table already on disk keeps `default CURRENT_TIMESTAMP`. If
+ * schema-drift compared column defaults, this fix would make every existing
+ * deployment report drift on `created_at`/`updated_at` — a narrow correctness
+ * fix turned into a broad false alarm. It does not, by two independent guards
+ * (`BUILTIN_COLUMNS` skips the audit columns outright; the only
+ * `default_mismatch` producer is the #4560 runtime-token check, and `NOW()` is
+ * not an app-resolved token). §3 pins that, WITH a positive control — a bare
+ * "drift is empty" assertion would pass just as well against an inert harness.
+ *
+ * ## §4: the second site
+ *
+ * `rebuildSqliteTablePatched` re-materializes a whole table when SQLite drift is
+ * reconciled, and it re-emitted the audit default itself. That method is
+ * SQLite-only, so leaving it as `knex.fn.now()` would have silently REVERTED a
+ * canonically-created table on the first unrelated drift rebuild. §4 pins that a
+ * rebuild hands back the column `initObjects` would have built.
+ *
+ * ## §5: the reachability this actually repairs
+ *
+ * `stampInsertTimestamps` fills both audit columns app-side, so on an ordinary
+ * boot the DEFAULT never fires. It gates on `tablesWithTimestamps`, which only
+ * DDL-running paths populate — so on the documented `skipSchemaSync` /
+ * `OS_SKIP_SCHEMA_SYNC=1` posture (`registerObjectMetadata`, the DDL-free
+ * registration door) the set is EMPTY and the driver's own `create()` door hits
+ * the column DEFAULT. That is the population this fix repairs, and it is wider
+ * than "writes that bypass the driver".
+ *
+ * ## Reverse verification (direction predicted BEFORE each leg)
+ *
+ * Restoring `main`'s `createAuditTimestampColumn` body turns §1, §2 and §5 red
+ * (audit columns naive, declared sibling canonical — the defect itself as the
+ * received value) and leaves §3 GREEN, because §3's subject is drift's
+ * indifference to the default, which the fix never changed. Restoring `main`'s
+ * `rebuildSqliteTablePatched` line turns §4 red ONLY.
+ */
+
+import { describe, it, expect } from 'vitest';
+import knexFactory from 'knex';
+import { SqlDriver } from '../src/index.js';
+
+/** Canonical instant: ISO-8601, explicit `Z`, milliseconds. */
+const ISO_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+/** The pre-canonical shape this card removes: zone-naive, space-separated. */
+const NAIVE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+const OPTS = { bypassTenantAudit: true } as any;
+
+/** An object carrying a declared `Field.datetime` NOW() sibling of the audit columns. */
+const FIELDS = {
+  title: { type: 'string' },
+  when: { type: 'datetime', defaultValue: 'NOW()' },
+} as Record<string, any>;
+
+function sqliteDriver(filename = ':memory:'): SqlDriver {
+  return new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename },
+    useNullAsDefault: true,
+  } as any);
+}
+
+/** The `CREATE TABLE` text SQLite itself recorded for `table`. */
+async function emittedDdl(driver: SqlDriver, table: string): Promise<string> {
+  const raw = (driver as any).knex;
+  const rows = await raw.raw(`select sql from sqlite_master where type='table' and name=?`, [table]);
+  const sql = (Array.isArray(rows) ? rows[0]?.sql : rows?.sql) ?? '';
+  expect(sql, `no CREATE TABLE recorded for ${table}`).toBeTruthy();
+  return String(sql);
+}
+
+/** The `default …` clause SQLite recorded for one column, normalized to one line. */
+function defaultClauseOf(ddl: string, column: string): string {
+  // `\`col\` <type> default <expr>` up to whatever ends the column definition:
+  // the next quoted column, the table-level `primary key (…)` clause, or the
+  // close of the CREATE TABLE. Without the `primary key` alternative the LAST
+  // column's clause swallows it and no two columns ever compare equal.
+  const m = new RegExp(
+    '`' + column + '`\\s+\\w+\\s+default\\s+(.+?)(?:,\\s*`|,\\s*primary key|\\s*\\)\\s*$)',
+    'i',
+  ).exec(ddl);
+  expect(m, `no DEFAULT clause for ${column} in: ${ddl}`).not.toBeNull();
+  return m![1].trim().replace(/\s+/g, ' ');
+}
+
+describe('#11321 SQLite builtin audit columns take the canonical NOW() default', () => {
+  // ── §1 emitted DDL ────────────────────────────────────────────────────────
+  it('§1 the audit columns and a declared Field.datetime NOW() sibling get the SAME default expression', async () => {
+    const driver = sqliteDriver();
+    try {
+      await driver.initObjects([{ name: 'audit_ddl_t', fields: FIELDS } as any]);
+      const ddl = await emittedDdl(driver, 'audit_ddl_t');
+
+      const declared = defaultClauseOf(ddl, 'when');
+      const createdAt = defaultClauseOf(ddl, 'created_at');
+      const updatedAt = defaultClauseOf(ddl, 'updated_at');
+
+      // The property: one table, ONE default shape. Compared to the declared
+      // sibling rather than to a literal, so a future respelling of the
+      // canonical expression moves both sides together.
+      expect(createdAt).toBe(declared);
+      expect(updatedAt).toBe(declared);
+
+      // And the shape is the canonical one, not the naive fallback — otherwise
+      // "they agree" would also be satisfied by both being CURRENT_TIMESTAMP.
+      expect(createdAt.toUpperCase()).not.toBe('CURRENT_TIMESTAMP');
+      expect(createdAt).toContain('strftime');
+      expect(createdAt).toContain('%Y-%m-%dT%H:%M:%fZ');
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  // ── §2 stored value on a DEFAULT-firing write ─────────────────────────────
+  it('§2 a write that lets the DEFAULTs fire stores a canonical instant in every column', async () => {
+    const driver = sqliteDriver();
+    try {
+      await driver.initObjects([{ name: 'audit_val_t', fields: FIELDS } as any]);
+      const raw = (driver as any).knex;
+
+      // Deliberately NOT driver.create(): this is the door that reaches the
+      // column DEFAULT — raw SQL that names neither audit column.
+      await raw.raw(`insert into "audit_val_t" ("id","title") values ('x','y')`);
+      const rows = await raw.raw(`select created_at, updated_at, "when" from "audit_val_t"`);
+      const row = (Array.isArray(rows) ? rows[0] : rows) as Record<string, string>;
+
+      for (const col of ['created_at', 'updated_at', 'when']) {
+        expect(row[col], `${col} = ${row[col]}`).toMatch(ISO_Z);
+        expect(row[col], `${col} is still the naive shape`).not.toMatch(NAIVE);
+      }
+      // Same statement, same SQLite `'now'` — the instants agree to the second,
+      // which is what "one conceptual value" means here.
+      expect(row.created_at.slice(0, 19)).toBe(row.when.slice(0, 19));
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  // ── §3 the blast-radius question: does drift read this default? ───────────
+  it('§3 a table still carrying the OLD CURRENT_TIMESTAMP default reports NO drift (with a positive control)', async () => {
+    const driver = sqliteDriver();
+    try {
+      const raw = (driver as any).knex;
+      // A table exactly as an already-deployed database holds it: audit columns
+      // defaulted the OLD way, created before this fix.
+      await raw.raw(
+        `create table "legacy_t" (` +
+          `"id" varchar(255), ` +
+          `"created_at" datetime default CURRENT_TIMESTAMP, ` +
+          `"updated_at" datetime default CURRENT_TIMESTAMP, ` +
+          `"title" varchar(255), ` +
+          `"when" datetime default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), ` +
+          `primary key ("id"))`,
+      );
+
+      // Introspection DOES surface the legacy default — so a green below is
+      // drift declining to compare it, not drift failing to see it.
+      const cols = await (driver as any).introspectColumns('legacy_t');
+      const createdAtCol = cols.find((c: any) => c.name === 'created_at');
+      expect(String(createdAtCol.defaultValue).toUpperCase()).toContain('CURRENT_TIMESTAMP');
+
+      const drift = await driver.detectManagedDrift([{ name: 'legacy_t', fields: FIELDS } as any]);
+      expect(drift.filter((d: any) => d.column === 'created_at' || d.column === 'updated_at')).toEqual([]);
+      expect(drift).toEqual([]);
+
+      // POSITIVE CONTROL — same table, same call. Without this, the empty array
+      // above is satisfied by a drift path that reports nothing at all.
+      await raw.raw(`alter table "legacy_t" add column "orphan_col" varchar(255)`);
+      await raw.raw(`alter table "legacy_t" add column "owner" varchar(255) default 'current_user'`);
+      const controlled = await driver.detectManagedDrift([
+        { name: 'legacy_t', fields: { ...FIELDS, owner: { type: 'lookup', defaultValue: 'current_user' } } } as any,
+      ]);
+      const kinds = controlled.map((d: any) => `${d.kind}:${d.column}`);
+      expect(kinds).toContain('unmapped_column:orphan_col');
+      // The default-READING dimension is demonstrably live in the same call …
+      expect(kinds).toContain('default_mismatch:owner');
+      // … and still says nothing about the audit columns.
+      expect(controlled.filter((d: any) => d.column === 'created_at' || d.column === 'updated_at')).toEqual([]);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  // ── §4 the SQLite rebuild must not revert the default ─────────────────────
+  it('§4 a drift-triggered SQLite table rebuild hands back the canonical default, not CURRENT_TIMESTAMP', async () => {
+    const driver = sqliteDriver();
+    try {
+      await driver.initObjects([{ name: 'rebuild_t', fields: FIELDS } as any]);
+      const before = defaultClauseOf(await emittedDdl(driver, 'rebuild_t'), 'created_at');
+
+      // An UNRELATED drift on the same table — an orphaned column — is what
+      // triggers the whole-table rebuild. The audit columns are not the subject.
+      const raw = (driver as any).knex;
+      await raw.raw(`alter table "rebuild_t" add column "orphan_col" varchar(255)`);
+      const drift = await driver.detectManagedDrift([{ name: 'rebuild_t', fields: FIELDS } as any]);
+      expect(drift.map((d: any) => d.op.type)).toContain('drop_column');
+
+      await (driver as any).applyMigrationEntries(drift, { allowDestructive: true });
+
+      const after = defaultClauseOf(await emittedDdl(driver, 'rebuild_t'), 'created_at');
+      expect(after).toBe(before);
+      expect(after.toUpperCase()).not.toBe('CURRENT_TIMESTAMP');
+      expect(after).toContain('%Y-%m-%dT%H:%M:%fZ');
+
+      // And it still behaves: a defaulted insert into the rebuilt table.
+      await raw.raw(`insert into "rebuild_t" ("id","title") values ('r','y')`);
+      const rows = await raw.raw(`select created_at from "rebuild_t" where id='r'`);
+      const row = (Array.isArray(rows) ? rows[0] : rows) as Record<string, string>;
+      expect(row.created_at).toMatch(ISO_Z);
+    } finally {
+      await driver.disconnect();
+    }
+  });
+
+  // ── §5 the reachability the fix actually repairs ──────────────────────────
+  it('§5 on a skipSchemaSync boot the driver own create() door now stores a canonical created_at', async () => {
+    const { mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const filename = join(mkdtempSync(join(tmpdir(), 'os11321-')), 'probe.sqlite');
+
+    // Boot 1 — an ordinary boot. initObjects runs the DDL and records the table
+    // in `tablesWithTimestamps`, so the app-side stamp fires.
+    const a = sqliteDriver(filename);
+    await a.initObjects([{ name: 'reach_t', fields: FIELDS } as any]);
+    await a.create('reach_t', { id: 'ddl-boot', title: 'a' } as any, OPTS);
+    expect([...(a as any).tablesWithTimestamps]).toContain('reach_t');
+    await a.disconnect();
+
+    // Boot 2 — the documented out-of-band posture: metadata registered, DDL
+    // skipped. `tablesWithTimestamps` stays EMPTY, so `stampInsertTimestamps`
+    // returns early and `create()` reaches the column DEFAULT.
+    const b = sqliteDriver(filename);
+    (b as any).registerObjectMetadata([{ name: 'reach_t', fields: FIELDS }]);
+    expect([...(b as any).tablesWithTimestamps]).toEqual([]);
+    await b.create('reach_t', { id: 'skip-boot', title: 'b' } as any, OPTS);
+
+    try {
+      const raw = (b as any).knex;
+      const rows = await raw.raw(`select id, created_at, "when" from "reach_t" order by id`);
+      const byId = Object.fromEntries(
+        (Array.isArray(rows) ? rows : [rows]).map((r: any) => [r.id, r]),
+      );
+      // The row written on the posture where the app-side stamp does NOT run —
+      // the one that used to be naive.
+      expect(byId['skip-boot'].created_at, 'skipSchemaSync boot created_at').toMatch(ISO_Z);
+      expect(byId['skip-boot'].created_at).not.toMatch(NAIVE);
+      // Both boot postures now agree, and both agree with the declared sibling.
+      expect(byId['ddl-boot'].created_at).toMatch(ISO_Z);
+      expect(byId['skip-boot'].when).toMatch(ISO_Z);
+    } finally {
+      await b.disconnect();
+    }
+  });
+
+  // ── §6 dialect gate — Postgres and MySQL are untouched ────────────────────
+  it('§6 Postgres keeps native now() and MySQL keeps now(3) — compiled without a connection', () => {
+    for (const [client, expected] of [
+      ['pg', 'CURRENT_TIMESTAMP'],
+      ['mysql2', 'CURRENT_TIMESTAMP(3)'],
+    ] as const) {
+      const k = knexFactory({ client } as any);
+      const driver = new SqlDriver({ client, connection: {} } as any);
+      (driver as any).knex = k;
+
+      const ddl = k.schema
+        .createTable('t', (table: any) => {
+          (driver as any).createAuditTimestampColumn(table, 'created_at');
+        })
+        .toString();
+
+      expect(ddl.toUpperCase()).toContain(expected);
+      // The SQLite-only canonical expression must not have leaked across.
+      expect(ddl).not.toContain('strftime');
+      k.destroy();
+    }
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -9794,7 +9794,16 @@ export class SqlDriver implements IDataDriver {
             const nullable = relax.has(c.name) ? true : tighten.has(c.name) ? false : c.nullable;
             if (!nullable && c.name !== 'id') col.notNullable();
             if (c.name === 'created_at' || c.name === 'updated_at') {
-              col.defaultTo(this.knex.fn.now());
+              // #11321: the SAME canonical default {@link createAuditTimestampColumn}
+              // emits, not `knex.fn.now()`. This method is SQLite-only (see the
+              // `isSqlite` branch in `applyMigrationEntries`), where
+              // `knex.fn.now()` is the zone-naive `CURRENT_TIMESTAMP` — so
+              // re-emitting it here would silently REVERT a table that was
+              // created with the canonical default the moment any unrelated
+              // drift (a relaxed NOT NULL, a dropped column) triggered a
+              // rebuild. A rebuild must hand back the column `initObjects`
+              // would have built.
+              col.defaultTo(this.nowColumnDefault('datetime'));
             } else if (!dropDefault.has(c.name)) {
               // Re-emit the METADATA-declared default. The rebuild dropped the
               // original table, so a column whose default is not restated here
@@ -12448,10 +12457,50 @@ export class SqlDriver implements IDataDriver {
    * `TIMESTAMP` problems on MySQL: no milliseconds, and a 2038 ceiling on the
    * column every list view sorts by (#3942). `CURRENT_TIMESTAMP` has to carry
    * matching precision for a `DATETIME(3)` default, hence `now(3)`.
+   *
+   * ## SQLite takes the SAME canonical default a declared field gets (#11321)
+   *
+   * "Must take the same physical type as a declared `Field.datetime`" is the
+   * paragraph above; the DEFAULT is the other half of that sentence, and on
+   * SQLite it used to diverge. `knex.fn.now()` compiles to an unqualified
+   * `CURRENT_TIMESTAMP`, which SQLite renders as a zone-NAIVE, space-separated,
+   * second-precision `'YYYY-MM-DD HH:MM:SS'` — the exact string
+   * {@link updatedAtStamp}'s docblock condemns, because `Date.parse` reads a
+   * zone-less string as LOCAL time and silently shifts the instant by the host
+   * offset. A declared `defaultValue: 'NOW()'` field in the SAME table already
+   * gets the canonical ISO-8601 form from {@link nowColumnDefault}, so one table
+   * carried two spellings of one conceptual value:
+   *
+   * ```
+   * created_at  "2026-08-23 14:54:17"          <- builtin audit (naive)
+   * when        "2026-08-23T14:54:17.796Z"     <- declared Field.datetime NOW()
+   * ```
+   *
+   * Routed through {@link nowColumnDefault} rather than restating the
+   * expression, so the two can never drift apart again — one source for "what
+   * does NOW() mean in DDL on this dialect".
+   *
+   * Postgres is deliberately untouched: `knex.fn.now()` there is a real
+   * zone-aware `TIMESTAMP` that never had the ambiguity. MySQL keeps `now(3)`
+   * (#11224) — a `DATETIME(3)` default must carry matching precision.
+   *
+   * ⚠️ Scope: a DDL default governs only NEWLY-created tables. A table already
+   * on disk keeps its legacy `CURRENT_TIMESTAMP` default; `formatOutput`'s read
+   * repair (`repairNaiveUtcAuditTimestamp`) folds those rows to canonical on
+   * read, which is why this needs no migration — the same disposition
+   * {@link nowColumnDefault} already documents for declared fields. Measured:
+   * schema-drift never compares this default, so an existing deployment does
+   * NOT start reporting drift on `created_at`/`updated_at` — the audit columns
+   * are skipped outright ({@link BUILTIN_COLUMNS}), and the only
+   * `default_mismatch` producer is the #4560 runtime-token check.
    */
   protected createAuditTimestampColumn(table: Knex.CreateTableBuilder, name: string): void {
     if (this.isMysql) {
       table.datetime(name, { precision: 3 }).defaultTo(this.knex.fn.now(3));
+      return;
+    }
+    if (this.isSqlite) {
+      table.timestamp(name).defaultTo(this.nowColumnDefault('datetime'));
       return;
     }
     table.timestamp(name).defaultTo(this.knex.fn.now());


### PR DESCRIPTION
Fixes #11321

On SQLite the builtin `created_at`/`updated_at` audit columns defaulted to an unqualified `CURRENT_TIMESTAMP` — zone-naive, space-separated, second-precision — while a declared `Field.datetime` with `defaultValue: 'NOW()'` **in the same table** already got the canonical ISO-8601 form. One table, two spellings of one conceptual value.

The SQLite branch of `createAuditTimestampColumn` now routes through `nowColumnDefault('datetime')`, the existing single source for "what does NOW() mean in DDL on this dialect", rather than restating the expression — so the two cannot drift apart again. Postgres and MySQL are untouched (`knex.fn.now()` on Postgres is a real zone-aware `TIMESTAMP`; MySQL keeps the `now(3)` precision match from #11224).

## The question that gates this card: does schema-drift read column defaults?

Answered **no**, by reading the code *and* by measuring on live in-memory SQLite (better-sqlite3) through the real `detectManagedDrift` entry point, against a table carrying the OLD default — i.e. exactly what every already-deployed SQLite database holds.

```
introspected  created_at.defaultValue = "CURRENT_TIMESTAMP"        <- drift CAN see it
              when.defaultValue       = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
detectManagedDrift(...)                = []                        <- and reports nothing
```

The zero is **positive-controlled**, because a bare empty array is equally satisfied by an inert harness. Same table, same call, after adding an orphan column and a `current_user` default:

```
drift kinds = ["unmapped_column:orphan_col", "default_mismatch:owner"]
entries naming created_at / updated_at = []
```

`default_mismatch` — the drift kind that *does* read column defaults — fires in the same call, and still says nothing about the audit columns. Two independent guards explain it: `BUILTIN_COLUMNS` skips `created_at`/`updated_at` in both of `diffManagedTable`'s loops, and the only `default_mismatch` producer is the #4560 runtime-token check, for which `isAppResolvedDefaultToken('NOW()')` is pinned `false` in `packages/spec`. `applyDeclaredColumnDefault`'s own docblock states the same invariant independently: *"there is no general declared-literal-vs-physical comparison"*.

**So no existing SQLite deployment starts reporting drift on its audit columns.** Both call sites are `CREATE TABLE` only — `initObjects`' `alterTable` branch adds declared fields and never the audit columns — so existing tables keep their old default, and `formatOutput`'s `repairNaiveUtcAuditTimestamp` folds already-written naive rows to canonical on read. That is the same disposition `nowColumnDefault` already documents for declared fields.

## A second site, named here because it is not in the card

`rebuildSqliteTablePatched` — the whole-table rebuild SQLite drift reconciliation uses — re-emitted the audit default **itself**, as `knex.fn.now()`:

```ts
if (c.name === 'created_at' || c.name === 'updated_at') {
  col.defaultTo(this.knex.fn.now());
}
```

That method runs only under `if (this.isSqlite)` in `applyMigrationEntries`. Fixing only `createAuditTimestampColumn` would therefore have shipped a fix that **silently reverts itself**: a canonically-created table would fall back to `CURRENT_TIMESTAMP` the first time any *unrelated* drift (a relaxed NOT NULL, an orphaned column) triggered a rebuild. Fixed in the same change, and pinned by §4 — whose reverse-verification leg (below) turns red **alone**, so it is a real guard and not an untested rider. This extends the card's declared region beyond `createAuditTimestampColumn` (~12452) and its call sites; it is disjoint from #11324's `introspectForeignKeys` region and from both `pm:on-hold` symbol sets.

## Reachability — measured, and wider than the card states

The card says the DEFAULT only fires on writes that bypass the driver. Measured, that is not the whole population: **the driver's own `create()` door reaches it** on a documented deployment posture.

`stampInsertTimestamps` gates on `tablesWithTimestamps`, which only DDL-running paths populate. On `skipSchemaSync` / `OS_SKIP_SCHEMA_SYNC=1`, `registerObjectMetadata` (the DDL-free registration door) deliberately sets `updatedAtColumnState='presumed'` and never touches that set — so it is empty, the stamp returns early, and the insert falls through to the column DEFAULT. One table, one row per boot posture, before the fix:

```
boot 1 (initObjects ran)      created_at "2026-08-23T14:54:17.791Z"   canonical
boot 2 (skipSchemaSync)       created_at "2026-08-23 14:54:17"        NAIVE
both rows                     when       "…T14:54:17.79…Z"            canonical
```

The declared NOW() sibling is canonical on **both** postures — because its canonical shape lives in the column DEFAULT rather than in an app-side stamp. That asymmetry is the argument for fixing this in DDL, and §5 pins it closed.

## Existing pins on the old DDL

**None.** A repo-wide sweep for `CURRENT_TIMESTAMP` found no test asserting the SQLite audit-column DDL. The one dialect-gate assertion (`sql-driver-user-datetime-default-format.test.ts:202`) covers Postgres/MySQL only. Nothing was rewritten to match new behaviour.

The opposite is true and worth stating: two live-matrix suites already spell the SQLite audit default as `strftime('%Y-%m-%dT%H:%M:%fZ','now')` in their hand-written-migration fixtures, each with a docblock claiming those columns take *"the SAME physical types `createAuditTimestampColumn` produces"* — `sql-driver-11176-bulk-and-merge-updated-at.test.ts` and `sql-driver-timestamps-without-ddl.test.ts`. That claim held on MySQL and was false on SQLite; the fixtures modelled a **more correct** table than the driver built. This change makes the driver agree with them.

## Tests

`packages/drivers/driver-sql/src/sql-driver-11321-sqlite-audit-default-canonical.test.ts` — six legs on real better-sqlite3 through the driver's own `initObjects`. §1 and §2 assert the audit columns **agree with the declared NOW() sibling in the same table** rather than matching a hard-coded literal, so a future respelling of the canonical expression moves both sides together and still fails if only one moves.

### Reverse verification — direction predicted before each leg, then observed

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | remove the SQLite branch from `createAuditTimestampColumn` | §1 §2 §5 red; §4 red for an **inverted** reason (`before` becomes `CURRENT_TIMESTAMP` while the still-fixed rebuild returns canonical, so `after === before` fails); §3 §6 green | exactly that — 4 failed, 2 passed |
| B | restore `knex.fn.now()` in `rebuildSqliteTablePatched` only | §4 red **alone**; all others green | exactly that — 1 failed, 5 passed |

§3 staying green under leg A is the point of that prediction: its subject is drift's *indifference* to the default, which the fix never changed.

Each leg proved the mutation on disk at the text it meant to change (`createAuditTimestampColumn` canonical line 1→0, 119 bytes removed for A; rebuild canonical 1→0 and `knex.fn.now` 0→1 for B), and each restore was proved **byte-identical** by `git hash-object` against the HEAD blob, not by an insertion count. Both mutation scripts installed a bash `trap` on EXIT, INT and TERM whose action was the `git checkout HEAD --` restore, so a foreground-cap SIGTERM landing mid-mutation cannot leave the tree mutated. No build/dist step is involved: the suite imports `../src/index.js`, a relative path vitest compiles from source, so the mutation is in the code under test with nothing to rebuild.

## Gates

Union derived from the actual diff via `node scripts/pm/dispatch-gates.mjs` with no paths passed, re-derived unchanged at the final commit `1bf96b8a6`. All 20 green, each exit status captured before any pipe:

`changeset-gate-self-tests` 0 · `driver-conformance` 0 · `objectui-changeset` 0 · `published-files` 0 · `slot-lookup` 0 · `test-source-alias` 0 · `type-source-resolution` 0 · `adr-0087-registration` 0 · `changeset-no-major` 0 · `ci-filter-parity` 0 · `empty-changeset` 0 · `plugin-teardown-shape` 0 · `affected-docs` 0 · `query-options-erasure` 0 · `type-check-coverage` 0 · `type-check-debt` 0 · `engine-double-contract` 0 · `cross-package-test-inputs` 0 · `where-matcher` 0 · `nul-bytes` 0

`check:type-check-debt` ran against a built workspace closure and printed its own verdict: *"--re-measure: OK — 33 ledger entr(ies) re-measured in 278.4s, 1897 raw tsc error(s) total, none above its recorded number."*

Package-level, at the same commit: `pnpm --filter @objectstack/driver-sql typecheck` clean (`tsc --noEmit`, script name echoed), and the full suite **116 files passed | 7 skipped, 1854 tests passed | 92 skipped** — the skips are the live-dialect PG/MySQL cells, which CI runs.

Repo-wide `pnpm lint` (`eslint . --no-inline-config`) run in full — exit 0 in 99s. Not a narrowing.

## Deliberately not done

- **No migration and no drift exemption.** Existing tables keep the old default. The measurement above says nothing reports it and reads are repaired, so neither is warranted; inventing one would have widened the card.
- **`backfillCanonicalDatetimes` / `sqliteCanonicalDatetimeSql` untouched** — the `pm:on-hold` #6009 symbols. Measured over my changed lines rather than asserted: 0 occurrences of all three on-hold symbols (#6009's two plus #8740's `insertOnlyUpsertColumns`) across 50 added lines. Positive-controlled both ways — the same literals appear 2/10/7 times in the whole file, and a synthetic added line fed to the same filter is caught 1/1/1. The first version of that filter was **broken**: its exclusion pattern for diff headers was written in basic regex, where an escaped plus is a repetition operator rather than a literal, so it stripped every added line and reported a false 0. The controls caught it, and the numbers above are from the repaired instrument.
- **`Fixes`, not `Part of`** — the card's acceptance criterion is fully met, including the second site that would have undone it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfyXxZ2WPjcjhuXpiQQc3y)_
