### PR TITLE
fix(spec): rewrite skill.zod.ts's two @example blocks off the retired `triggerPhrases`

### DIFF
--- a/.changeset/skill-zod-examples-drop-retired-trigger-phrases.md
+++ b/.changeset/skill-zod-examples-drop-retired-trigger-phrases.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": patch
+---
+
+**Docs:** `skill.zod.ts`'s two `@example` blocks stop handing the author a retired key that throws on parse (#11026).
+
+Both TSDoc examples in `packages/spec/src/ai/skill.zod.ts` — the one over `SkillSchema` and the one over `defineSkill` — passed `triggerPhrases`, removed in `@objectstack/spec` 17.0.0 (#3896 audit close-out) and carried as a `retiredKey()` tombstone ~120 lines below the first of them. `defineSkill` calls `SkillSchema.parse()`, so both documented blocks **threw** when run: `invalid_type` at path `triggerPhrases`, expected `never`. A reader copying either block got a refusal on their first move.
+
+The blocks now demonstrate the tombstone's own prescription instead of contradicting it. That prescription is a **split**, not a rename — routing intent belongs in `triggerConditions` (an AND of context field/operator/value), natural-language intent in `description` / `instructions`, the strings actually put in front of the model — and the `defineSkill` block shows both halves with each named. `tools` is required with no default, so both blocks carry it. Each block also opens with its own `import { defineSkill } from '@objectstack/spec';`, matching the convention the marked SDK examples in `packages/client-react/src` already use, so the block is self-contained as a consumer would resolve it.
+
+The tombstone and every line of its guidance prose are **unchanged**, verbatim — they were always correct, and they are what the repaired examples now agree with.
+
+Prose only: no schema shape, no `.describe()` text, no runtime behaviour, no authorable-surface movement, and `check:generated` moves nothing (the generated reference page `content/docs/references/ai/skill.mdx` renders the tombstoned row as `[REMOVED]` and carries neither example). It is graded rather than skipped because the text ships to consumers: the rewritten blocks are present in the built `dist/skill.zod-*.d.ts`, which is what an editor surfaces on hover, and `@objectstack/spec`'s `files` list publishes `src/**/*.zod.ts` so the docblock also travels in the npm tarball as source.

--- a/packages/spec/src/ai/skill.zod.ts
+++ b/packages/spec/src/ai/skill.zod.ts
@@ -247,13 +247,18 @@ export type SkillTriggerCondition = z.input<typeof SkillTriggerConditionSchema>;
  *
  * @example
  * ```ts
+ * import { defineSkill } from '@objectstack/spec';
+ *
  * const skill = defineSkill({
  *   name: 'case_management',
  *   label: 'Case Management',
  *   description: 'Handles support case lifecycle',
- *   instructions: 'Use these tools to create, update, and resolve support cases.',
+ *   // Natural-language intent lives in the strings actually put in front of
+ *   // the model. A skill is never activated by matching a phrase list.
+ *   instructions:
+ *     'Use these tools to create, update, and resolve support cases. Reach for this '
+ *     + 'skill when the user wants to open a ticket, chase an existing case, or close one out.',
  *   tools: ['create_case', 'update_case', 'resolve_case', 'query_cases'],
- *   triggerPhrases: ['create a case', 'open a ticket', 'resolve issue'],
  * });
  * ```
  */
@@ -432,14 +437,24 @@ export type SkillParsed = z.infer<typeof SkillSchema>;
  * Validates the config at creation time using Zod `.parse()`.
  *
  * @example
+ * Activation is a SPLIT, and this block shows both halves: programmatic
+ * routing in `triggerConditions`, natural-language intent in
+ * `description` / `instructions`.
+ *
  * ```ts
+ * import { defineSkill } from '@objectstack/spec';
+ *
  * const skill = defineSkill({
  *   name: 'order_management',
  *   label: 'Order Management',
  *   description: 'Handles order lifecycle operations',
- *   instructions: 'Use these tools to manage customer orders.',
+ *   // Half one — natural language, read by the LLM.
+ *   instructions:
+ *     'Use these tools to manage customer orders. Reach for this skill when the user '
+ *     + 'wants to place an order, change one, or cancel one.',
  *   tools: ['create_order', 'update_order', 'cancel_order'],
- *   triggerPhrases: ['place an order', 'cancel my order'],
+ *   // Half two — a programmatic AND of context field/operator/value,
+ *   // evaluated by the cloud agent runtime.
  *   triggerConditions: [
  *     { field: 'objectName', operator: 'eq', value: 'order' },
  *   ],


### PR DESCRIPTION
Fixes #11026

Sub-issue of #10924. Both TSDoc `@example` blocks in `packages/spec/src/ai/skill.zod.ts` passed `triggerPhrases` — removed in `@objectstack/spec` 17.0.0 (#3896 audit close-out) and carried as a `retiredKey()` tombstone ~120 lines below the first of them. `defineSkill` calls `SkillSchema.parse()`, so both documented blocks **threw** when run.

## Measured, before and after

Premise re-verified on `origin/main` @ `735f5c7` (the card said ~250/~436; the PM's re-check said :256/:442 @ `b863f01` — both blocks are where the PM placed them). Both blocks executed verbatim against the freshly built `packages/spec/dist`:

**Before** — `FAILING_BLOCKS=2`, exit 1:

```
BLOCK1(SkillSchema @example): THREW [ { "expected": "never", "code": "invalid_type",
  "path": [ "triggerPhrases" ], "message": "`skill.triggerPhrases` was removed in
  @objectstack/spec 17.0.0 (#3896 audit close-out) …
BLOCK2(defineSkill @example): THREW [ … same, path: [ "triggerPhrases" ] … ]
FAILING_BLOCKS=2
```

**After** — `FAILING_BLOCKS=0`, exit 0:

```
BLOCK1(SkillSchema @example): PARSED OK -> {"name":"case_management","surface":"ask",
  "active":true,"tools":["create_case","update_case","resolve_case","query_cases"]}
BLOCK2(defineSkill @example): PARSED OK -> {"name":"order_management","surface":"ask",
  "active":true,"tools":["create_order","update_order","cancel_order"],
  "triggerConditions":[{"field":"objectName","operator":"eq","value":"order"}]}
FAILING_BLOCKS=0
```

## What the blocks say now

The tombstone's prescription is a **split**, not a rename — routing intent to `triggerConditions`, natural-language intent to `description` / `instructions`, the strings actually put in front of the model. The blocks now demonstrate that instead of contradicting it:

- **`SkillSchema`** — the minimal skill. The intent the three deleted phrases were carrying moves into `instructions`, where the model actually reads it.
- **`defineSkill`** — shows **both halves**, each named in a comment: natural language in `instructions`, programmatic routing in `triggerConditions`.

`tools` is required with no default, so both blocks carry it. Each block now opens with its own `import { defineSkill } from '@objectstack/spec';`, matching the convention the marked SDK examples in `packages/client-react/src` already use — the block is self-contained the way a consumer resolves it.

**The `retiredKey()` tombstone and every line of its guidance prose are unchanged, verbatim** — they were always correct, and they are what the repaired examples now agree with. Verified mechanically: `git diff` against the base commit matches zero lines touching `retiredKey`, the `REMOVED` comment, `#3896`, or the `os migrate meta` line. The four surviving `triggerPhrases` mentions in the file are exactly the guidance prose (:276), the tombstone comment (:380), the declaration (:385) and its message (:386) — **zero in `@example` content**, so the card's own re-check command now reads clean.

## Reverse verification — would #10924's gate have caught this?

Yes, and this is the useful half for the parent card. Extracting the blocks the way `check-skill-examples.ts` does (JSDoc gutter stripped) and running `tsc --noEmit` against the built `dist`:

| blocks | result |
|:---|:---|
| the **original** two | `TS2322: Type 'string[]' is not assignable to type 'undefined'` — both, at exactly the `triggerPhrases` line |
| the **repaired** two | exit 0, no diagnostics |

So a compile-only gate does red on this defect class (the retired key surfaces as `undefined` in `z.input`), and the harness can produce red — the green on the repaired blocks is a real measurement, not a vacuous one.

## Verification

Union re-run **after** the final commit, at `63bc7746b2`:

- **23 of 24 derived gate families green.** Gates derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (22 families), plus `check:nul-bytes` and `check:skill-examples`.
- The one red is `check:dev-prereqs`, on its **scan** half: *"The workspace is not built — 34 of 67 workspace packages declare an entry point under dist/ that is not on disk"*. It names none of this PR's paths. `lint.yml` runs only `node scripts/check-dev-prereqs.mjs --self-test` — *"self-test half only, never the scan"* — and that half is green here (`exit 0`, 16 cases).
- `pnpm --filter @objectstack/spec exec tsc --noEmit` — exit 0, no output.
- `pnpm --filter @objectstack/spec test` — **419 test files, 11136 tests, all passed**.
- Regeneration discipline: `pnpm --filter @objectstack/spec build && pnpm --filter @objectstack/spec check:generated` — *"All 14 generated artifacts are up to date."* **Nothing moved**, confirming the card's reading that the generated reference page carries neither example.
- `check:skill-examples` — green over all 246 marked blocks across 2 surfaces.

## Changeset

Graded `patch`, not `skip-changeset`. The docblock ships to consumers: the rewritten blocks are present in the built `packages/spec/dist/skill.zod-CFjrFQj9.d.ts` (lines 442 and 525), which is what an editor surfaces on hover, and `@objectstack/spec`'s `files` list publishes `src/**/*.zod.ts` so the text also travels in the npm tarball as source. Same reasoning the repo already applies to docblock-prose changesets.

## Scope

`packages/spec/src/ai/skill.zod.ts` (the two `@example` blocks) plus the changeset — nothing else. No schema shape, no `.describe()` text, no runtime behaviour, no authorable-surface movement. `scripts/check-skill-examples.ts` is deliberately untouched: the gate extension is #10924's work, held behind this card, and #11355 has an open finding on that script's extraction loop.

Clause-② content limb is `no` (docblock prose; accept/reject behaviour unchanged). The path limb fires mechanically on `packages/spec/src/**`, so this is held for contract review — expected, not an error.

## Out-of-scope finding

While verifying, `check:skill-examples` refused the client SDK surface with *"packages/spec/dist holds no .d.ts declarations"* at a moment when `packages/spec/dist` held 44 of them — the unbuilt packages were `client` / `client-react`. That is already filed as #11250; rather than open a duplicate I added the live confirmation plus one addition that card had not recorded — the printed remedy is hardcoded to spec at the *call site* too, so following it verbatim does not clear the red. Not fixed here: #11250 is out of this card's scope and needs its pinned test assertions updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_