### PR TITLE
docs: correct two stale GraphQL residue sites in package source comments

### DIFF
--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -102,8 +102,8 @@ export function objectStackMiddleware(kernel: ObjectKernel) {
 /**
  * Creates a full-featured Hono app with all ObjectStack route dispatchers.
  *
- * Only routes that need framework-specific handling (auth service, GraphQL
- * raw result, discovery wrapper) are registered explicitly.
+ * Only routes that need framework-specific handling (auth service,
+ * discovery wrapper) are registered explicitly.
  * All other routes (meta, data, packages, analytics, automation, i18n, ui,
  * openapi, custom endpoints, and any future routes) are handled by a
  * catch-all that delegates to `HttpDispatcher.dispatch()`.

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -249,7 +249,7 @@ export const ObjectCapabilities = strictObject({
   /** Enable global search indexing */
   searchable: z.boolean().default(true).describe('Index records for global search'),
 
-  /** Enable REST/GraphQL API access */
+  /** Enable REST/MCP API access */
   apiEnabled: z.boolean().default(true).describe('Expose object via automatic APIs'),
 
   /**


### PR DESCRIPTION
Fixes #11140

Comment-only fix for two package-source comments that still asserted a `/graphql` surface the runtime does not mount — same defect class as #10846 / #10710 / #10832 / #10583 / #10835, one surface further in (package source comments rather than the published skill catalog).

## Sites fixed

| Site | Before | After |
|:---|:---|:---|
| `packages/spec/src/data/object.zod.ts:252` | `/** Enable REST/GraphQL API access */` | `/** Enable REST/MCP API access */` |
| `packages/adapters/hono/src/index.ts:105-106` | `Only routes that need framework-specific handling (auth service, GraphQL raw result, discovery wrapper) are registered explicitly.` | `Only routes that need framework-specific handling (auth service, discovery wrapper) are registered explicitly.` |

Neither site's `.describe()` (line below the `apiEnabled` JSDoc) was touched — it already read correctly ("Expose object via automatic APIs").

## Why

- `apiEnabled` gates the automatic REST and MCP surfaces, not GraphQL — `packages/mcp/src/stdio-data-bridge.ts:260` reads `enable.apiEnabled === false`. There is no automatic GraphQL API.
- `createHonoApp` registers auth (`app.all(prefix + '/auth/*')`) and discovery (`app.get(prefix)`, `/discovery`, `/.well-known/objectstack`) explicitly, then one catch-all — no GraphQL route is registered. `packages/runtime/src/http-dispatcher.ts:2087` carries the authoritative statement: `// /graphql removed — GraphQL is not in the product plan (#2462 follow-on).`

## Scope

Comment-only. No behavior change, no `.describe()` change, no schema shape change. Exactly the two files/sites named above — nothing else touched.

## Tests

Run on commit `07a05a7053` (current HEAD):

- Control probe (before edit): `git grep -n "GraphQL" -- packages/spec/src/data/object.zod.ts packages/adapters/hono/src/index.ts` → exactly the 2 expected hits.
- Control probe (after edit): same command → 0 hits (grep exit 1).
- `pnpm --filter '@objectstack/spec^...' build` → no workspace deps for spec; command-exit 0.
- `pnpm --filter @objectstack/spec build` → command-exit 0. Confirmed the rebuilt JS bundle (`packages/spec/dist/data/index.js`) carries the new JSDoc text (`Enable REST/MCP API access`) and no residual `GraphQL` text tied to `apiEnabled`; the `.d.ts` output does not inline this bare JSDoc at all (only `.describe()` strings do), so `check:api-surface`/`check:docs` are unaffected by this change — confirmed by `check:generated` below.
- `pnpm --filter @objectstack/spec check:generated` → `✓ All 14 generated artifacts are up to date` (command-exit 0).
- `pnpm --filter @objectstack/spec typecheck` → command-exit 0 (`tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck`, pre-existing test-layer debt count unchanged at 263/55 files).
- `pnpm --filter '@objectstack/hono^...' build` (deps closure: `@objectstack/rest`, `plugin-auth`, `@objectstack/runtime`, etc.) → command-exit 0.
- `pnpm --filter @objectstack/hono build` → command-exit 0.
- `pnpm --filter @objectstack/hono test -- --maxWorkers=2` → `Test Files 2 passed (2)` / `Tests 74 passed (74)`, command-exit 0.
- `node scripts/check-route-envelope.mjs` (matched by `node scripts/pm/dispatch-gates.mjs` specifically via `packages/adapters/hono/src/index.ts`) → pre-existing ratchet state unchanged, command-exit 0.
- `git grep -n "createGraphQLDomain" packages/*/src` → 0 hits (unchanged from filing-time verification).

Local scope followed the "定向门禁,全农场归 CI" discipline — the full lint farm is CI's to run.

## Deviations from the dispatch prompt

None. Both sites were still present on `origin/main` at task start (line numbers matched the prompt's re-verification: object.zod.ts:252 intact, hono sentence spanning :105-:106). `premise_still_valid: true`.

`skip-changeset`: comment-only diff, no changeset. Adding the `skip-changeset` label next via the additive endpoint per AGENTS.md, then reading it back to confirm it survived.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_