### PR TITLE
feat(spec): ToolExecutionContext.surfaceContext — what the user is currently discussing (cloud#1610)

### DIFF
--- a/.changeset/surface-context-contract-1610.md
+++ b/.changeset/surface-context-contract-1610.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/spec': minor
+---
+
+`ToolExecutionContext.surfaceContext` (cloud#1610): an optional, advisory description of what the user is currently discussing — Studio pillar, the selected artifact WITH its type discriminator (page/object/dashboard/report), an optional finer selection, and the canvas mode. Strictly additive beside `currentObjectName`/`currentViewName`; consumers must treat every field as optional and never use it for access decisions.

--- a/packages/spec/src/contracts/ai-service.ts
+++ b/packages/spec/src/contracts/ai-service.ts
@@ -465,6 +465,28 @@ export interface ToolExecutionContext {
     /** View the user is currently viewing, if known. */
     currentViewName?: string;
     /**
+     * cloud#1610 — what the user is currently DISCUSSING, derived by the UI
+     * from its route and selection, sent fresh on every turn. Strictly richer
+     * than `currentObjectName`/`currentViewName` (which stay as their own
+     * fields for back-compat): the Studio pillar the user is on, the selected
+     * artifact WITH its type discriminator (an interfaces nav leaf may be a
+     * page, object view, dashboard or report — the type is what makes "改这个"
+     * unambiguous), an optional finer selection inside it, and the canvas mode.
+     * Consumers treat every field as optional and advisory: grounding for the
+     * agents ("当前正在讨论…"), default targets for authoring tools — never an
+     * access decision.
+     */
+    surfaceContext?: {
+        /** Studio pillar / console area, e.g. 'data' | 'automations' | 'interfaces' | 'access'. */
+        pillar?: string;
+        /** The artifact under discussion, with its metadata type (e.g. {type:'dashboard', name:'sales_overview'}). */
+        artifact?: { type: string; name: string };
+        /** Finer selection inside the artifact (e.g. {kind:'field', id:'priority'}). */
+        selection?: { kind: string; id: string };
+        /** Canvas mode where applicable: 'design' | 'run'. */
+        mode?: string;
+    };
+    /**
      * Text of the latest user message (neutral context, like currentObjectName).
      * Forwarded so a tool can detect intent — e.g. an explicit confirm/approval —
      * without re-deriving it from the transcript. Consumers own any semantics.


### PR DESCRIPTION
Contract half of cloud#1610 (the maintainer's 「AI 该知道我们在讨论什么」 design, 契约先行 per the epic's agreed order). Optional, advisory `surfaceContext` on `ToolExecutionContext`: Studio `pillar`, the selected `artifact` **with its metadata-type discriminator** (an interfaces nav leaf may be a page / object view / dashboard / report — the type is what makes 「改这个」 unambiguous), an optional finer `selection`, and the canvas `mode`. Strictly additive beside `currentObjectName`/`currentViewName`; never an access input.

Cloud's parse+inject half and the console's derive+send half follow in their own repos. spec suite: 415 files / 11122 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)