### PR TITLE
docs(agents): show the targeted-vitest spelling and refuse the bare separator

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -75,8 +75,8 @@ JSON,所以终报消息就是 JSON 本身,别无其它。
    收尾打印本次持锁时长,过长自己喊出来。只包**命令本身**,不包你的阅读与判断;结论读它
    印的 VERDICT 行,不读裸 `$?`。排队是常态,不是挂死。
 2. **压住堆**:重命令前缀 `NODE_OPTIONS=--max-old-space-size=4096`(要抬需给理由)。
-3. **定向,不扫全**:只 build/test 受影响的包(`pnpm --filter <pkg> …`),vitest
-   `--maxWorkers=2`,turbo `--concurrency=2`。
+3. **定向,不扫全**:只 build/test 受影响的包 —— `pnpm --filter <pkg> exec vitest run --maxWorkers=2 <file>`,turbo `--concurrency=2`。
+   ⛔ 参数永不经裸 `--` 转交:`--` 之后的一切被 vitest 静默丢弃,文件模式与 `--maxWorkers` 一并失效,整包跑完、退出码 0、读起来像一次通过。
 4. **清理是任务的一步**:PR 开出后,
    `rm -rf <path>/node_modules && git worktree remove <path>` —— **不加 force**。⛔ 永不
    上来就 `--force`:node_modules 已删的情况下,拒绝移除说明里面有东西没提交 —— 你自己

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ pays its first load at module top; `pnpm check:test-source-alias` gates it.
 
 `--fresh`: ephemeral tempdir (auto-deleted on exit) + `--seed-admin` (POSTs sign-up, prints creds — default `admin@objectos.ai` / `admin123`, override via `--admin-email`/`--admin-password`). The seeded admin is auto-promoted to **platform admin** (the system seed identity `usr_system` is skipped), so Setup/Studio are reachable on first login.
 
-Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; **never kill a server you didn't start** (other agents/the user may be using it — see Multi-agent discipline §8); always use a `pnpm dev`/`dev:crm`/`dev:showcase` script (flags after `--` are forwarded), not raw `pnpm --filter`.
+Rules: never run two backends on port 3000; for backend tasks pick a random port and tear it down; **never kill a server you didn't start** (other agents/the user may be using it — see Multi-agent discipline §8); always use a `pnpm dev`/`dev:crm`/`dev:showcase` script, not raw `pnpm --filter` — but note what pnpm actually does with `--`: it forwards the **separator itself** into the child's argv, so this spelling only works where the receiving CLI tolerates a leading `--`. ⛔ Do not carry it over to test commands — vitest silently discards everything after a bare `--` (measured; see `.claude/agents/os-dev.md` → Toolchain traps).
 
 ```bash
 pnpm dev:crm -- --fresh -p 38421   # start; debug via curl


### PR DESCRIPTION
Part of #10166 — this lands triage's parts (1) and (2). It deliberately does **not** land the PreToolUse hook (A) or the `os-verify-lock.sh` refusal line (B) that the 2026-08-21 PM ruling adopted; triage's 2026-08-22 re-scope excluded tooling from this card, so those remain unimplemented and the card stays open for them.

### ⚠️ Governed surface — do not queue

Both files are governed (`.claude/**`, `AGENTS.md`). This PR stays **draft** and waits for a human merge: no ready flip, no auto-merge, no merge queue.

### The defect

`os-dev.md` rule 3 named `pnpm --filter <pkg>`, vitest `--maxWorkers=2` and turbo `--concurrency=2` **without ever showing how they join**. A gap that forces an invention is worse than a wrong statement, because every reader invents the same wrong thing — and npm semantics supply `--`.

### Measured, on `@objectstack/types` (13 test files, `test` script is exactly `vitest run`)

| spelling | result |
|---|---|
| `pnpm --filter <pkg> test -- --maxWorkers=2 src/keyset-walk.test.ts` | banner echoes `vitest run -- --maxWorkers=2 …` · **13 files / 362 tests** · exit 0 |
| whole suite, no pattern at all | **13 files / 362 tests** — byte-identical to the "targeted" run above |
| `pnpm --filter <pkg> test --maxWorkers=2 src/keyset-walk.test.ts` | **1 file / 12 tests / 285ms** |
| `pnpm --filter <pkg> exec vitest run --maxWorkers=2 src/keyset-walk.test.ts` | **1 file / 12 tests / 399ms** |
| `pnpm exec vitest run src/keyset-walk.test.ts` from the package cwd | **1 file / 12 tests / 269ms** |
| `pnpm exec vitest run -- src/keyset-walk.test.ts` (stray `--`, no package script) | **13 files / 362 tests** |

The last row matters: the `exec` route our own docs recommend is swallowed identically. Nothing about avoiding the package script protects you — the separator does.

### The card's unverified half: `--maxWorkers=2` was swallowed too

Probed against the exact parser (vitest 4.1.10 → **cac 7.0.0**, resolved from vitest's own tree; the earlier note on the card said 6.7.14):

```
["run","--maxWorkers=2","src/keyset-walk.test.ts"]   options.maxWorkers = 2         args = ["src/keyset-walk.test.ts"]  options['--'] = []
["run","--","--maxWorkers=2","src/keyset-walk.test.ts"]  options.maxWorkers = undefined  args = []  options['--'] = ["--maxWorkers=2","src/keyset-walk.test.ts"]
```

Both directions confirmed in vitest itself: an unknown flag **before** the separator throws ``CACError: Unknown option `--thisFlagDoesNotExist` `` (exit 1); the same flag **after** it exits 0 with no error, and a `--filesOnly` sitting after it is ignored as well (362 test lines listed instead of a file list).

⇒ **Every run that used the `--` spelling had no worker cap.** The concurrency discipline was inert in the same breath as the file filter.

### Net-zero, because both homes are at zero-headroom ratchets

`check:pm-skill-ratchet` sets each ceiling at the landed line count: `os-dev.md` 405/405, `AGENTS.md` 961/961. **Raising a ceiling requires a maintainer ruling quoted in the PR, and this PR has none** — so the fix is a rewrite, not an addition (`os-dev.md` stays at exactly 405, `AGENTS.md` at 961). That also follows the ratchet header's own instruction: *"provenance is one line, stories live on cards, not in operational text."* The measurements above therefore live here and on the card, not in the agent definition.

A first draft added a full `Toolchain traps` entry with the mechanism (+13 lines) and was rejected by the ratchet. The landed rule carries the spelling and the refusal; the mechanism stays on the card.

### Why this spelling and not the one triage named

Triage named `pnpm exec vitest run <file>` "from the right cwd". Verified — it works (row 5). The rule documents `pnpm --filter <pkg> exec vitest run --maxWorkers=2 <file>` instead, because it is the strict superset: it needs no `cd`, and agent bash calls in this container reset cwd between invocations, so a cwd-dependent spelling would reintroduce exactly the form-scoping defect this card is about. Both were measured; the more robust one is documented.

### Scope

- ⛔ No wrapper script and no lint rule (triage ruling 3).
- ⛔ #11419 (the unscoped `--workspace-concurrency` placement rule) is **not** addressed here and remains open — it is its own unassigned card. I did trip over it first-hand while setting up: `pnpm install --workspace-concurrency=2 --filter …` → `ERROR Unknown option: 'workspace-concurrency'`. One more datapoint for that card, fixed in neither file here.
- No changeset: nothing publishable changes (`skip-changeset`).

### Gates

All 12 families derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no path arguments) green at `685883f`. Repo-wide `pnpm lint` is CI's: both changed files report `isPathIgnored: true` from eslint's own flat config (2 files submitted, 0 linted, 0 rule results), so no untouched file's verdict can move.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_


---
_Generated by [Claude Code](https://claude.ai/code)_