### PR TITLE
feat(spec): type-check packages/spec/src TSDoc examples as a third surface

### DIFF
--- a/.changeset/spec-src-tsdoc-example-surface.md
+++ b/.changeset/spec-src-tsdoc-example-surface.md
@@ -1,0 +1,22 @@
+---
+'@objectstack/spec': patch
+---
+
+Type-check the TSDoc code examples in `packages/spec/src` — the ADR-0033 authoring channel
+
+`check:skill-examples` now scans a third surface: `packages/spec/src/**` TSDoc blocks,
+alongside `skills/` + `content/docs` and the client SDK sources. A schema's `@example`
+is what an AI author copies, and it sits inches from the tombstone written for that same
+reader — but nothing compiled it, so an example could name a retired key, a renamed
+export or a tightened union and stay green indefinitely. (`check:doc-formula-expressions`
+walks the same blocks but judges *formula expressions*, never TypeScript.)
+
+This is a new `SURFACES` entry, not a second extractor: the existing marker/tsc pipeline
+was already surface-parameterised. Compilation stays **opt-in** via the `os:check`
+marker, which matters more on this root than anywhere else — of its 146 fenced ts blocks,
+128 carry no imports of their own and three more are ellipsis-placeholder prose
+(`defineStack({ ... })`) that is correct as documentation and can never compile. Six
+self-contained blocks are marked and now compile against the built declarations.
+
+The marker is an inert HTML comment, as on the other surfaces, and is stripped from
+generated reference pages rather than published to them.

--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,10 @@ packages/spec/json-schema/
 # Generated bundle size reports
 packages/spec/bundle-size-report.json
 
-# Throwaway build dir for `check:skill-examples` (extracted skill code blocks)
+# Throwaway build dirs for `check:skill-examples` — one per surface (a surface
+# is wiped when written, so surfaces sharing a resolution dir need their own).
 packages/spec/.examples-build/
+packages/spec/.examples-build-src/
 
 # Generated SBOM (rebuilt during release)
 sbom.json

--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -42,6 +42,18 @@
  * `content/docs` (a FAQ recommending `FieldSchema.extend()`, impossible since
  * FieldSchema became a ZodPipe); everything else was fragments.
  *
+ * #10924's sweep of `packages/spec/src` re-measured both traps on a fresh
+ * corpus and is worth recording, because the numbers argue the design: 146
+ * fenced ts blocks, of which 128 carry no import of their own (fragments by
+ * construction — a `columns: [...]` subtree, a `case 'in':` excerpt of a
+ * consumer's switch). Of the 18 self-contained ones, trap 1 fired immediately:
+ * three are ellipsis-placeholder prose (`defineStack({ ... })`, `{ ... }` in
+ * argument position) whose TS1109 syntax errors suppressed the semantic pass
+ * for the entire program — the first run reported 15 "clean" blocks that had
+ * simply never been type-checked. Excluding those three and re-running turned
+ * six of the remaining fifteen red on real semantics. So: mark deliberately,
+ * and never read a run containing TS1xxx codes as evidence about rot.
+ *
  * Each marked block is written verbatim to a throwaway build dir and type-checked
  * with `tsc --noEmit` against the built `@objectstack/spec` declarations — the
  * exact surface a consumer's `import { … } from '@objectstack/spec'` resolves to.
@@ -110,8 +122,9 @@
  * prose roots, its own throwaway build dir (which package's `node_modules`
  * a bare specifier like `react` or the surface's own package name resolves
  * against), and its own package(s) to derive a `paths` map from. Adding a
- * surface — #10924's `packages/spec/src/**` TSDoc `@example` channel is the
- * next candidate — is a new `SURFACES` entry, not a fork.
+ * surface is a new `SURFACES` entry, not a fork — #10924's
+ * `packages/spec/src/**` TSDoc channel was the next candidate and landed as
+ * exactly that: one root, one surface entry, zero new extraction code.
  *
  * TWO differences from the original skills/docs surface, both load-bearing:
  *
@@ -240,6 +253,39 @@ const SKILLS_DOCS_ROOTS: SourceRoot[] = [
 const isTestFile = (name: string): boolean => /\.(test|spec)\.tsx?$/.test(name);
 
 /**
+ * `packages/spec/src` — the schema package's OWN TSDoc code blocks (#10924).
+ *
+ * This is the ADR-0033 authoring channel: a schema's `@example` sits inches
+ * from the tombstone written for the same reader, and is the text an AI author
+ * copies. Until this root landed nothing compiled it — `check:doc-formula-
+ * expressions` walks the same `@example`s but judges *formula expressions*
+ * with `@objectstack/formula`, never TypeScript — so an example could name a
+ * retired key, a renamed export or a tightened union and stay green
+ * indefinitely. The measured specimen: `AgentSchema`'s own `@example` wrote
+ * `knowledge: { … }`, a key the same file declares `retiredKey()`
+ * (`z.never()`), which surfaces as `undefined` in `z.input` and so fails
+ * `tsc` with TS2322 — a compile-only gate catches this class with no runner.
+ *
+ * Same shape as the client SDK roots above (JSDoc gutter, `commentPrefixed`),
+ * and opt-in for the same reason, only more so: of the 146 fenced ts blocks in
+ * this root, 128 do not even carry their own imports, and among the 18 that do,
+ * three are ellipsis-placeholder fragments (`defineStack({ ... })`) that are
+ * correct as prose and can never compile. A blanket sweep here would misfire on
+ * every one of them; the marker is what separates "this is a claim" from "this
+ * illustrates".
+ */
+const SPEC_SRC_ROOTS: SourceRoot[] = [
+  {
+    dir: path.resolve(SPEC_DIR, 'src'),
+    ext: '.ts',
+    label: 'spec',
+    marker: '<!-- os:check -->',
+    commentPrefixed: true,
+    excludeFile: isTestFile,
+  },
+];
+
+/**
  * `packages/client-react/src` + `packages/client/src` — the SDK's own
  * hand-written TSDoc `@example` blocks (#10969). See the header comment's
  * "SURFACES" section for the two ways this root type differs from prose
@@ -278,16 +324,37 @@ interface Surface {
   /** Where the throwaway build dir + tsconfig.json live. Module resolution
    *  for bare specifiers (react, workspace packages) walks up from here. */
   resolutionDir: string;
+  /** Basename of the throwaway build dir inside `resolutionDir`. Two surfaces
+   *  MAY share a `resolutionDir` (spec's prose and its own source both resolve
+   *  against `packages/spec`) — they must NOT share a build dir: `writeBuildDir`
+   *  wipes it on entry, so the second surface would delete the first's blocks.
+   *  Sequential execution hides that today, but `--keep` would silently retain
+   *  only the last surface's dir. Defaults to `.examples-build`; every value
+   *  needs a `.gitignore` entry. `assertDistinctBuildDirs()` enforces it. */
+  buildDirName?: string;
   /** package.json dirs whose `exports` become explicit `paths` entries —
    *  what lets a block `import` its own surface's package by name. */
   selfPackages: string[];
 }
+
+/** @see Surface.buildDirName */
+const DEFAULT_BUILD_DIR = '.examples-build';
+const buildDirOf = (s: Surface): string => path.join(s.resolutionDir, s.buildDirName ?? DEFAULT_BUILD_DIR);
 
 const SURFACES: Surface[] = [
   {
     name: 'skills + docs (@objectstack/spec)',
     roots: SKILLS_DOCS_ROOTS,
     resolutionDir: SPEC_DIR,
+    selfPackages: [SPEC_DIR],
+  },
+  {
+    name: 'spec source TSDoc (@objectstack/spec)',
+    roots: SPEC_SRC_ROOTS,
+    // Same package as the prose surface above, so the same resolution env —
+    // but its OWN build dir (see `Surface.buildDirName`).
+    resolutionDir: SPEC_DIR,
+    buildDirName: '.examples-build-src',
     selfPackages: [SPEC_DIR],
   },
   {
@@ -976,6 +1043,84 @@ function selfTest(): never {
         `marker must not be silently ignored`,
     );
 
+    // ── commentPrefixed + a ```ts fence (#10924's spec-source surface). The
+    //    tsx fixture above pins gutter-stripping against a ```tsx fence; this
+    //    root is the other combination — a `.ts` source file whose docblock
+    //    fences plain ```ts — and it is the one #10924's entire corpus uses.
+    //    Without this, a regression that recognised a gutter-wrapped fence
+    //    ONLY when its language was `tsx` would leave the whole spec-source
+    //    surface extracting zero blocks, and the per-surface vacuous-green
+    //    guard in `main()` is the only thing that would notice — a hard error
+    //    a long way from its cause. Also pins that a marker sitting between
+    //    `@example` and the fence still counts as adjacent: that is where
+    //    every marker in the real spec corpus lives.
+    const specSrcRoot: SourceRoot = {
+      dir,
+      ext: '.ts',
+      label: 'spec',
+      marker: '<!-- os:check -->',
+      commentPrefixed: true,
+      excludeFile: isTestFile,
+    };
+    const specSrc = path.join(dir, 'schema.zod.ts');
+    fs.writeFileSync(
+      specSrc,
+      [
+        '// Copyright', //                                                  1
+        '', //                                                              2
+        '/**', //                                                           3
+        ' * A schema with a documented example.', //                        4
+        ' *', //                                                            5
+        ' * @example', //                                                   6
+        ' * <!-- os:check -->', //                                          7
+        ' * ```ts', //                                                      8
+        " * import { defineSkill } from '@objectstack/spec';", //           9
+        ' *', //                                                           10
+        " * const skill = defineSkill({ name: 'a' });", //                  11
+        ' * ```', //                                                       12
+        ' */', //                                                          13
+        'export const SchemaLike = 1;', //                                 14
+      ].join('\n'),
+      'utf8',
+    );
+    const specExtract = extractFromFile(specSrc, specSrcRoot);
+    check(
+      specExtract.examples.length === 1,
+      `spec-source fixture: extracted ${specExtract.examples.length} block(s), expected 1 — a gutter-wrapped ` +
+        '```ts fence is DORMANT, and every block in the spec-source corpus is exactly that shape',
+    );
+    check(
+      specExtract.orphans.length === 0,
+      `spec-source fixture: reported ${specExtract.orphans.length} orphan marker(s), expected 0 — a marker on the ` +
+        'line between `@example` and its fence IS adjacent',
+    );
+    if (specExtract.examples.length === 1) {
+      const ex = specExtract.examples[0];
+      check(
+        ex.fileName.endsWith('.ts') && !ex.fileName.endsWith('.tsx'),
+        `spec-source fixture: build file name "${ex.fileName}" should end in .ts for a \`\`\`ts fence`,
+      );
+      check(
+        ex.code.split('\n')[0] === "import { defineSkill } from '@objectstack/spec';",
+        `spec-source fixture: extracted body still carries a JSDoc gutter — ${JSON.stringify(ex.code.split('\n')[0])}`,
+      );
+      // body[0] is source line 9; `bodyStartLine` is what every diagnostic is
+      // remapped through, and an off-by-one here points authors at prose.
+      check(
+        ex.bodyStartLine === 9,
+        `spec-source fixture: bodyStartLine ${ex.bodyStartLine}, expected 9 — diagnostics would point at the wrong line`,
+      );
+    }
+    // A `.test.ts` sibling must be skipped by `excludeFile` even when it
+    // carries a perfectly good marked block: test fixtures are not the
+    // documented surface, and extracting them would type-check assertions.
+    const specTest = path.join(dir, 'schema.test.ts');
+    fs.writeFileSync(specTest, ['/**', ' * <!-- os:check -->', ' * ```ts', ' * const x = 1;', ' * ```', ' */'].join('\n'), 'utf8');
+    check(
+      sourceFiles([specSrcRoot]).every((f) => f.file !== specTest),
+      'spec-source fixture: a `.test.ts` file was scanned — `excludeFile` is not applied to this root',
+    );
+
     // ── Fence-awareness (fenceSpans): the os:check convention has to be
     //    documentable in the very roots it governs. A marker shown as example
     //    text INSIDE some other fenced block (here a ```md illustration of
@@ -1021,6 +1166,40 @@ function selfTest(): never {
         'STILL be one — a false orphan there is exactly the defect that makes this convention undocumentable, and a ' +
         "silenced real orphan would weaken the gate's hard-error posture",
     );
+
+    // ── Build-dir distinctness (#10924). The REAL surfaces are asserted on
+    //    every run by `assertDistinctBuildDirs()`; these two fixtures pin the
+    //    predicate underneath it in both directions, because a guard that can
+    //    only ever return null is indistinguishable from a correct config —
+    //    the dormant-checker failure this file's own docblocks keep naming.
+    const surfaceStub = (name: string, resolutionDir: string, buildDirName?: string): Surface => ({
+      name,
+      roots: [],
+      resolutionDir,
+      buildDirName,
+      selfPackages: [],
+    });
+    check(
+      findDuplicateBuildDir(SURFACES) === null,
+      'build-dir fixture: the REAL surfaces share a build dir — one of them would wipe the other',
+    );
+    const clash = findDuplicateBuildDir([
+      surfaceStub('alpha', SPEC_DIR),
+      surfaceStub('beta', SPEC_DIR), // same resolutionDir, both defaulting
+    ]);
+    check(
+      clash !== null && clash.first === 'alpha' && clash.second === 'beta',
+      `build-dir fixture: two surfaces defaulting into one resolution dir were NOT reported (got ${JSON.stringify(clash)}) ` +
+        '— that is the collision the guard exists to catch',
+    );
+    check(
+      findDuplicateBuildDir([
+        surfaceStub('alpha', SPEC_DIR),
+        surfaceStub('beta', SPEC_DIR, '.examples-build-src'),
+      ]) === null,
+      'build-dir fixture: a distinct `buildDirName` on a shared resolution dir was reported as a clash — ' +
+        'sharing a resolution dir is legitimate and must stay legal',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -1036,9 +1215,50 @@ function selfTest(): never {
       '    JSDoc-gutter-wrapped ```tsx block (client SDK surface) extracts, strips and maps lines\n' +
       '    identically, and a misplaced gutter-wrapped marker is still caught as an orphan; a marker\n' +
       '    shown as example text inside another fenced block is not an orphan, while a genuine\n' +
-      '    top-level misplaced marker still is.',
+      '    top-level misplaced marker still is; a gutter-wrapped ```ts block (spec-source\n' +
+      '    surface) extracts with the right build extension, body and line mapping, its\n' +
+      '    `.test.ts` sibling is skipped, and two surfaces sharing one build dir are caught.',
   );
   process.exit(0);
+}
+
+/**
+ * No two surfaces may write into the same throwaway build dir.
+ *
+ * `writeBuildDir()` wipes its target on entry, so a shared dir means the
+ * second surface deletes the first's extracted blocks. Sequential execution
+ * makes that invisible today — each surface's `tsc` has already run by then —
+ * which is exactly why it is asserted rather than left to be noticed: the
+ * first symptom would be `--keep` retaining only the last surface's dir, and
+ * the first *real* symptom would be a surface silently type-checking another
+ * surface's blocks the day this loop is reordered or parallelised. Sharing a
+ * `resolutionDir` is legitimate and stays legal (#10924's spec-source surface
+ * resolves against `packages/spec` just as the prose surface does); sharing
+ * the dir underneath it is not.
+ */
+function findDuplicateBuildDir(
+  surfaces: Surface[],
+): { dir: string; first: string; second: string } | null {
+  const seen = new Map<string, string>();
+  for (const surface of surfaces) {
+    const dir = buildDirOf(surface);
+    const first = seen.get(dir);
+    if (first) return { dir, first, second: surface.name };
+    seen.set(dir, surface.name);
+  }
+  return null;
+}
+
+function assertDistinctBuildDirs(): void {
+  const clash = findDuplicateBuildDir(SURFACES);
+  if (clash) {
+    fail(
+      `Surfaces "${clash.first}" and "${clash.second}" both use the build dir ${rel(clash.dir)}.\n\n` +
+        `  A build dir is wiped when it is written, so the second surface would delete the\n` +
+        `  first's extracted blocks. Give one of them a distinct \`buildDirName\` (and add it\n` +
+        `  to .gitignore).`,
+    );
+  }
 }
 
 /** A package.json's own `name` field — used to look its self-entry up in the
@@ -1049,6 +1269,8 @@ function pkgName(pkgDir: string): string {
 
 function main() {
   if (SELF_TEST) selfTest();
+
+  assertDistinctBuildDirs();
 
   console.log(`🧪 Type-checking prose TypeScript examples (${SURFACES.map((s) => s.name).join(' · ')})...\n`);
 
@@ -1191,7 +1413,7 @@ function main() {
       );
     }
 
-    const buildDir = path.join(surface.resolutionDir, '.examples-build');
+    const buildDir = buildDirOf(surface);
     buildDirs.push(buildDir);
     writeBuildDir(buildDir, examples, paths);
     const { code, output } = runTsc(buildDir);

--- a/packages/spec/scripts/dist-freshness-adoption.test.ts
+++ b/packages/spec/scripts/dist-freshness-adoption.test.ts
@@ -137,7 +137,33 @@ function declaredDts(spec: string): string[] {
  */
 function seed(spec: string, { distMtime, srcMtime }: { distMtime: number; srcMtime: number }): void {
   fs.mkdirSync(path.join(spec, 'src'), { recursive: true });
-  fs.writeFileSync(path.join(spec, 'src/index.ts'), 'export const live = 1;\n');
+  // #10924 added `packages/spec/src` as check-skill-examples's THIRD surface, so
+  // this seeded `src/` is now scanned for marked blocks too. Same reasoning as
+  // `seedClientSdkSurface()` above, and the same failure it prevents: without a
+  // marked block here that surface's zero-block guard fires on a directory this
+  // sandbox merely stubs, and it fires BEFORE the freshness check — so the
+  // staleness cases below would assert against "no marked examples found"
+  // instead of the refusal they exist to probe.
+  //
+  // It goes in the SAME file `srcMtime` already governs rather than a sibling:
+  // freshness compares dist against the newest source, so a second src file
+  // would be a second, ungoverned mtime knob. The block imports nothing, which
+  // is what lets it compile against the trivial `export {}` declarations
+  // `declaredDts()` seeds and keeps the fresh-dist positive control honest.
+  fs.writeFileSync(
+    path.join(spec, 'src/index.ts'),
+    [
+      '/**',
+      ' * @example',
+      ' * <!-- os:check -->',
+      ' * ```ts',
+      ' * export const ok = 1;',
+      ' * ```',
+      ' */',
+      'export const live = 1;',
+      '',
+    ].join('\n'),
+  );
   fs.utimesSync(path.join(spec, 'src/index.ts'), srcMtime, srcMtime);
 
   for (const dts of declaredDts(spec)) {
@@ -304,9 +330,13 @@ describe('check:skill-examples refuses a stale dist (#7181)', () => {
     const run = runGate(tree.spec, SKILL);
     expect(run.status).toBe(0);
     // #10969: the surface-parameterised success message names surface COUNT,
-    // not any one package -- it now covers this skills+docs surface AND the
-    // client-SDK one `seedClientSdkSurface` populates in every case in this file.
-    expect(run.stdout).toContain('prose examples type-check across 2 surface(s)');
+    // not any one package -- it now covers this skills+docs surface, the
+    // client-SDK one `seedClientSdkSurface` populates in every case in this
+    // file, and (#10924) the spec-source one `seed()` populates. The count is
+    // asserted literally, and moving it is the point: every surface added has
+    // to be seeded here deliberately, or its zero-block guard fires ahead of
+    // the refusal these cases probe.
+    expect(run.stdout).toContain('prose examples type-check across 3 surface(s)');
     expect(run.stderr).not.toContain('OLDER than');
   }, 60_000);
 

--- a/packages/spec/scripts/file-description.test.ts
+++ b/packages/spec/scripts/file-description.test.ts
@@ -245,6 +245,49 @@ describe('renderFileDescription', () => {
 });
 
 /**
+ * #10924 — the `check:skill-examples` opt-in marker never reaches the page.
+ *
+ * That gate marks a compilable docblock example with an HTML comment on the
+ * line above its fence. In a `.ts` source it must be the HTML form (the MDX
+ * wrapper form would close the JSDoc early), and it is a prose line, so the
+ * renderer emitted it verbatim into the generated MDX — measured on
+ * `studio/object-designer` and `studio/plugin`, whose marked examples live in
+ * the MODULE block rather than on a declaration. MDX has no HTML comments, so
+ * that both published an internal annotation to a customer-facing reference
+ * page and broke the docs build.
+ */
+describe('renderFileDescription — #10924: the os:check marker is machinery, not content', () => {
+  const ctx = { fromCategory: 'studio', sourcePathToDocsRoute: () => null };
+
+  const moduleBlock = (...body: string[]): string =>
+    ['/**', ...body.map(l => (l === '' ? ' *' : ` * ${l}`)), ' */', '', "import { z } from 'zod';", ''].join('\n');
+
+  it('drops a marker line above a fence, keeping the example itself', () => {
+    const out = renderFileDescription(
+      moduleBlock('Studio plugin manifest.', '', '@example', '<!-- os:check -->', '```ts', 'const x = 1;', '```'),
+      ctx,
+    );
+    expect(out).not.toContain('os:check');
+    // The block it marked is the content — dropping the marker must not take
+    // the example with it, nor detach the fence from its `@example` tag.
+    expect(out).toContain('```ts');
+    expect(out).toContain('const x = 1;');
+    expect(out).toContain('@example');
+  });
+
+  it('keeps a marker shown INSIDE a fence — there it is an author illustrating the convention', () => {
+    // The same text fenced is documentation ABOUT the gate, which several
+    // sources legitimately write. Stripping by text alone would silently edit
+    // an author's example; the strip is prose-only for exactly this reason.
+    const out = renderFileDescription(
+      moduleBlock('How to mark a block:', '', '```md', '<!-- os:check -->', '```ts', '```'),
+      ctx,
+    );
+    expect(out).toContain('<!-- os:check -->');
+  });
+});
+
+/**
  * #5553 — the block is rendered as the markdown it was written as.
  *
  * The renderer used to drop blank lines and join what was left with `\n\n`,

--- a/packages/spec/scripts/lib/file-description.ts
+++ b/packages/spec/scripts/lib/file-description.ts
@@ -255,6 +255,32 @@ function stripDocGutter(block: string): string[] {
   });
 }
 
+/**
+ * The `check:skill-examples` opt-in marker, which must never reach the page.
+ *
+ * That gate (`../check-skill-examples.ts`, which owns this spelling — it cannot
+ * be imported from here, it is a top-level script that runs on load) opts a
+ * docblock code block into type-checking with an HTML comment on the line
+ * directly above its fence. In a `.ts` source the marker HAS to be that HTML
+ * comment form, because the MDX roots' wrapper spelling ends in the two
+ * characters star-then-slash, which terminate a block comment — it would close
+ * the JSDoc early. (This comment avoids writing that pair out for the same
+ * reason.)
+ *
+ * The marker sits ABOVE the fence, so it is a prose line, and prose is emitted
+ * verbatim — which lands the marker in the generated MDX. MDX has no HTML
+ * comments; fumadocs-mdx fails the build outright on one ("Unexpected character
+ * `!`…"), directing the author at the wrapper form instead. So a marker on any
+ * MODULE-level doc block would both publish an internal annotation to a
+ * customer-facing reference page and break the docs build. Measured on
+ * `studio/object-designer` and `studio/plugin`, the two spec modules whose
+ * marked examples live in the module block rather than on a declaration.
+ *
+ * Dropped rather than escaped: it is machinery, not content, and the reader of
+ * the rendered page has no use for it.
+ */
+const SKILL_EXAMPLE_MARKER = '<!-- os:check -->';
+
 /** What a line is, which decides which transforms may touch it. */
 type LineKind = 'prose' | 'fenced' | 'indented';
 
@@ -480,7 +506,15 @@ export function renderFileDescription(source: string, ctx: FileDescriptionContex
   const block = findModuleDocBlock(source);
   if (block === null) return '';
 
-  const lines = withTagBlocksSeparated(stripDocGutter(block));
+  // Dropped BEFORE classification, so the marker never reaches the page and
+  // never separates a fence from the `@example` tag above it. Only at prose
+  // level: the same text inside a fenced block is an author illustrating the
+  // convention, which is content (see SKILL_EXAMPLE_MARKER).
+  const gutterless = stripDocGutter(block);
+  const markerKind = classifyLines(gutterless);
+  const lines = withTagBlocksSeparated(
+    gutterless.filter((line, i) => !(markerKind[i] === 'prose' && line.trim() === SKILL_EXAMPLE_MARKER)),
+  );
   const kind = classifyLines(lines);
 
   // Prose is rendered a RUN of lines at a time, never line by line: a sentence,

--- a/packages/spec/src/ai/skill.zod.ts
+++ b/packages/spec/src/ai/skill.zod.ts
@@ -246,6 +246,7 @@ export type SkillTriggerCondition = z.input<typeof SkillTriggerConditionSchema>;
  * Do not author one.
  *
  * @example
+ * <!-- os:check -->
  * ```ts
  * import { defineSkill } from '@objectstack/spec';
  *
@@ -441,6 +442,7 @@ export type SkillParsed = z.infer<typeof SkillSchema>;
  * routing in `triggerConditions`, natural-language intent in
  * `description` / `instructions`.
  *
+ * <!-- os:check -->
  * ```ts
  * import { defineSkill } from '@objectstack/spec';
  *

--- a/packages/spec/src/shared/expression.zod.ts
+++ b/packages/spec/src/shared/expression.zod.ts
@@ -146,6 +146,7 @@ export function expression(source: string, dialect: ExpressionDialect = 'cel', m
 /**
  * Tagged-template helpers for inline expression authoring.
  *
+ * <!-- os:check -->
  * ```ts
  * import { cel, F, P } from '@objectstack/spec';
  *

--- a/packages/spec/src/studio/object-designer.zod.ts
+++ b/packages/spec/src/studio/object-designer.zod.ts
@@ -37,6 +37,7 @@
  * ```
  *
  * @example
+ * <!-- os:check -->
  * ```typescript
  * import {
  *   ObjectDesignerConfigSchema,

--- a/packages/spec/src/studio/plugin.zod.ts
+++ b/packages/spec/src/studio/plugin.zod.ts
@@ -34,6 +34,7 @@
  * ```
  * 
  * @example
+ * <!-- os:check -->
  * ```typescript
  * import { StudioPluginManifestSchema } from '@objectstack/spec/studio';
  * 

--- a/packages/spec/src/system/metadata-form-registry.ts
+++ b/packages/spec/src/system/metadata-form-registry.ts
@@ -55,6 +55,7 @@ import { emailTemplateForm } from './email-template.form';
  * when no explicit ordering is supplied by the consumer).
  *
  * @example
+ * <!-- os:check -->
  * ```ts
  * import { METADATA_FORM_REGISTRY } from '@objectstack/spec/system';
  *


### PR DESCRIPTION
Fixes #10924

`check:skill-examples` gains a third surface: `packages/spec/src/**` TSDoc code blocks.
This is the ADR-0033 authoring channel — a schema's `@example` is what an AI author
copies, and it sits inches from the tombstone written for that same reader — and until
now nothing compiled it. `check:doc-formula-expressions` walks the same blocks but judges
*formula expressions* with `@objectstack/formula`, never TypeScript.

A new `SURFACES` entry, **not a second extractor**, as the card and triage required: the
marker/tsc pipeline was already surface-parameterised, `commentPrefixed: true` already
strips the JSDoc gutter, and `SourceRoot.ext` was already kept wide for this. Zero new
extraction code.

## Why opt-in marking, measured

Of the 146 fenced ts blocks in `packages/spec/src`, **128 carry no import of their own** —
fragments by construction. Of the 18 self-contained ones, both traps in the script's own
header fired on the first run:

- **Trap 1 (syntactic diagnostics suppress the semantic pass).** Three blocks are
  ellipsis-placeholder prose — `defineStack({ ... })`, `SystemObjectName.USER, { ... }` —
  whose TS1109 errors stopped `tsc` before it type-checked anything. The first run
  reported 15 "clean" blocks that had simply never been checked. Excluding those three and
  re-running turned **six of the remaining fifteen red on real semantics**.
- **Trap 2 (bare names / unresolvable imports).** `@oclif/core`, a relative
  `./realtime-shared.zod`, and undefined names (`data`, `engine`, `SomeSchema`) — all
  fragments, all correctly left unmarked.

A blanket sweep would have misfired on every one of them. The `:93` fragment in
`skill.zod.ts` flagged in the parent card (a `case 'in':` excerpt of the cloud consumer's
switch) is in the 128 — it carries no import and stays unmarked, as required.

## Marked-block census — 6 marked, 140 skipped

| Marked (compiles green) | |
|---|---|
| `ai/skill.zod.ts:249` | `SkillSchema` `@example` |
| `ai/skill.zod.ts:444` | `defineSkill` `@example` |
| `shared/expression.zod.ts:149` | tagged-template helpers (`cel`/`F`/`P`) |
| `studio/object-designer.zod.ts:40` | `@example` |
| `studio/plugin.zod.ts:37` | `@example` |
| `system/metadata-form-registry.ts:58` | `@example` |

`shared/expression.zod.ts:149` is a docblock fence not tagged `@example` — declared
deliberately: it is the same channel (a docblock example a reader copies), it is
self-contained, and it compiles. Everything else is unmarked: 128 no-import fragments,
3 ellipsis fragments, 5 unresolvable fragments, and 4 blocks that are **real rot**, filed
as #11436 rather than folded, per the triage clause.

## Two things the surface needed

**1. Surfaces sharing a resolution dir must not share a build dir.** Both spec surfaces
resolve against `packages/spec`, and `writeBuildDir()` wipes its target on entry — so the
second surface would delete the first's extracted blocks. Sequential execution hides that
today; `--keep` would already retain only the last dir, and a reordered loop would make a
surface type-check another's blocks. Added `Surface.buildDirName` +
`findDuplicateBuildDir()`, asserted on every run and pinned in both directions in the
self-test (a guard that can only ever return null is indistinguishable from a correct
config).

**2. The marker leaked into generated reference pages.** The marker sits *above* the
fence, so it is a prose line, and `renderFileDescription` emits prose verbatim — landing
`os:check` in `content/docs/references/studio/object-designer.mdx` and `.../plugin.mdx`,
the two spec modules whose marked examples live in the module block rather than on a
declaration. MDX has no HTML comments (fumadocs-mdx fails the build outright), so this
would have both published an internal annotation to a customer-facing page and broken the
docs build. The MDX wrapper spelling cannot be used in a `.ts` docblock — it ends in the
two characters that terminate a block comment — so the fix is to strip the marker during
generation, at **prose level only**: the same text inside a fence is an author
illustrating the convention, and is content. Pinned both ways in
`file-description.test.ts`. After the strip the generated tree is byte-identical to
`main` — **this PR touches no file under `content/docs/`**, and `check:generated` reports
all 14 artifacts up to date.

Second commit: adding a third surface made its per-surface zero-block guard fire on the
`dist-freshness-adoption` sandbox's stubbed `packages/spec/src`, ahead of the freshness
refusal those cases probe — the same interaction #10969 hit and solved with
`seedClientSdkSurface()`. Seeded into the file `srcMtime` already governs, so no second
ungoverned mtime knob; the surface-count assertion moves 2 → 3.

## Reverse verification — predicted RED, observed RED

Reintroducing `triggerPhrases` (a `retiredKey()` in that same file) into a marked block:

```
✗ [spec source TSDoc (@objectstack/spec)] examples do not compile:
  packages/spec/src/ai/skill.zod.ts:255:3
      error TS2322: Type 'string[]' is not assignable to type 'undefined'.
```

Gate exit 1, and `:255` is exactly the injected line — the block-line → source-line
remapping is correct. Both legs ran under a restore `trap` and proved themselves on disk
rather than trusting an editor's exit code: mutation leg `INJECTED_TEXT_COUNT=1` + present
in 2 built `.d.ts` files; restore leg count `0`, `--absent` over 209 built files, gate back
to exit 0. Both legs **rebuilt** `packages/spec` — editing `src/` makes `dist` stale, and
the gate's freshness guard would otherwise refuse with a message that is neither a pass nor
a real red.

This confirms the sibling card's finding that **compile-only is sufficient for this class**:
a retired key surfaces as `undefined` in `z.input`, so passing it is a type error, no
runner involved.

## Verification (all at final commit `e9c40a11fc`, tree clean vs HEAD)

- `check:skill-examples` — exit 0, `253 prose examples type-check across 3 surface(s)`
  (skills+docs 228 · **spec source 6** · client SDK 19)
- `check:generated` — exit 0, `All 14 generated artifacts are up to date`
- `pnpm --filter @objectstack/spec test` — exit 0, `419 passed (419)` / `11148 passed (11148)`
- `pnpm --filter @objectstack/spec exec tsc --noEmit` — exit 0
- 26 gate families derived from the actual diff via `dispatch-gates.mjs --repo` (no paths
  passed) — **26 pass / 0 fail**, re-run at the final head
- `check:type-check-coverage` — exit 0

## Changeset

`patch` for `@objectstack/spec`, measured not assumed: the marker lands in the published
`dist/skill.zod-*.d.ts` (2 occurrences) and spec's `files` also publishes
`src/**/*.zod.ts`, so it is consumer-visible text. Same precedent as the sibling card, and
the same inert-comment trade-off already accepted for the 228 markers shipping in
`skills/`. Not `skip-changeset` — this PR publishes bytes.

## Out of scope, filed not folded

- #11436 — four self-contained spec examples that do not compile. The headline one is the
  root `index.ts`, whose three documented import styles all name an
  `@objectstack/spec/auth` subpath the package does not export.
- #11440 — `packages/client-react/.examples-build/` has never been gitignored (pre-existing
  from #10969; this PR adds the entry only for the dir it introduces).

## #11355 interaction — not touched

The open finding on the extraction loop's fence-awareness is **not** required by this
surface and is not fixed here. The new root needs no nested-fence extraction, and the
marked-block census is closed, so no block reaches `tsc` through that path. Noted rather
than folded, per dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_
