### PR TITLE
feat(messaging): scope the plugin-facing inbox writes to the authenticated caller

### DIFF
--- a/.changeset/messaging-inbox-authenticated-caller-scope.md
+++ b/.changeset/messaging-inbox-authenticated-caller-scope.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/service-messaging": minor
+---
+
+**Feature:** `MessagingService` gains a plugin-facing inbox write door scoped to the **authenticated caller** — `markReadAsCaller(caller, ids)` and `markAllReadAsCaller(caller)` (#10753).
+
+A plugin that pushes an "…awaiting your approval" message through `emit()` had no legitimate way to close it out again once the work was done, so the Console bell's unread badge stayed lit through a full page reload until the user hit "mark all read". The reporting project carries 30+ business hooks in that shape.
+
+What it was reaching for instead is the shape this closes. `markRead(userId, ids)` is the REST door's contract method (`INotificationService.markRead?`), and on that path its `userId` is trustworthy because `runtime/src/domains/notifications.ts` binds it to an already-authenticated session and answers 401 when there is none. But the service is also a kernel service, and the kernel hands every plugin ONE shared `PluginContext` whose `getService` carries no caller identity — so for an in-process caller that same parameter is a free string. **Any plugin could mark any user's inbox messages read**, and the receipt lands context-lessly on an `engine-owned` object (ADR-0103), so no engine permission check saw it either. This release is therefore both an API widening and the first tightening of in-process power on that path.
+
+The new pair takes **no target user at all**. The recipient is derived from the caller's `ExecutionContext.userId`, so "mark someone else's inbox read" has no spelling on this surface — it is unrepresentable rather than discouraged. That fits the case it was asked for exactly: the approver who clears a request *is* the recipient whose badge is stuck.
+
+`userId` is read, and nothing that merely resembles one:
+
+- `attributedUserId` is **attribution only** — its own contract states that nothing in the authorization path reads it, and a context carrying only it authorizes as anonymous (ADR-0118 D2). A `userId ?? attributedUserId` fallback would read as working and clear the wrong person's badge.
+- `actor` is a service-principal label (`svc:<name>`), not a `sys_user` id.
+- `isSystem: true` with no user is refused rather than elevated: the system has no inbox to be the recipient of.
+
+Each refusal throws `InboxCallerError` carrying the ADR-0112 envelope pair a boundary reads — `status: 401` and the registered `code: 'UNAUTHENTICATED'` — and the refusal is evaluated **before** the empty-`ids` and no-data-engine short-circuits, which return `{ success: true, readCount: 0 }`. Reaching one of those with no authenticated caller would report success for a write that was never authorized, which is the silent-success shape this door exists to replace.
+
+Honest about what it is: a **discipline** boundary, not a security boundary. An in-process plugin already holds the data engine and can write `sys_notification_receipt` directly; nothing at this layer stops trusted code that means to. What changes is that the correct pattern is the only one the plugin-facing surface expresses, and the incorrect one now fails loudly at the call site.
+
+Nothing existing changes behaviour: `markRead` / `markAllRead` / `listInbox` keep their signatures (they are the published `INotificationService` contract the REST door needs), and no schema, column or object declaration moves.

--- a/packages/services/service-messaging/src/inbox-caller.ts
+++ b/packages/services/service-messaging/src/inbox-caller.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Authenticated-caller scoping for the plugin-facing inbox write surface
+ * (ADR-0030 Layer 5).
+ *
+ * ## The shape this closes
+ *
+ * `MessagingService.markRead(userId, ids)` is the REST door's contract method:
+ * `INotificationService.markRead?(userId, ids)`, called by
+ * `packages/runtime/src/domains/notifications.ts`, which binds `userId` to
+ * `context.executionContext.userId` — the session user the HTTP door already
+ * authenticated. On that path the parameter is trustworthy because the door
+ * filled it.
+ *
+ * The service is also registered as a kernel service (`registerService('messaging', service)`
+ * in `messaging-service-plugin.ts`), and the kernel hands every plugin ONE
+ * shared `PluginContext` whose `getService` carries no caller identity. So for
+ * an in-process caller that same `userId` is a FREE PARAMETER: any plugin can
+ * mark ANY user's inbox messages read, and the receipt write lands
+ * context-lessly on an `engine-owned` object (ADR-0103), so no engine-level
+ * permission check sees it either. Unconstrained and undeclared, in both
+ * directions.
+ *
+ * The verbs here are the plugin-facing door, and the whole design is that they
+ * take NO target user. The recipient is DERIVED from the caller's
+ * {@link ExecutionContext}, so "mark someone else's inbox read" has no
+ * spelling on this surface — it is unrepresentable rather than merely
+ * discouraged. A plugin closing out a notification it pushed (the
+ * emit-in-a-hook → close-out-in-a-later-hook pattern) is acting inside the
+ * recipient's own request, and this is exactly the identity that request
+ * carries.
+ *
+ * ## Why `userId` ONLY, and nothing that looks like it
+ *
+ * `ExecutionContext` carries three principal-shaped fields and only one of
+ * them is an authorization subject:
+ *
+ *  - `userId` — "the subject the engine authorizes AS". The only one read here.
+ *  - `attributedUserId` — ATTRIBUTION ONLY. Its own contract states the
+ *    invariant: "nothing in the authorization path reads this", and a context
+ *    carrying only it "authorizes exactly like a context carrying nothing —
+ *    ANONYMOUS, per ADR-0118 D2". Promoting it here would open the second
+ *    adjudication track ADR-0095 D3 closed, and it would do so on a write that
+ *    clears someone's unread badge.
+ *  - `actor` — a service-principal LABEL (`svc:<name>`), not a `sys_user` id.
+ *    There is no inbox to clear for `svc:flow`.
+ *
+ * A tolerant `caller.userId ?? caller.attributedUserId ?? caller.actor` chain
+ * is precisely the consumer-side widening contract-first exists to refuse: it
+ * would read as working, and it would silently authorize the wrong principal.
+ * There is no fallback and there must not be one.
+ *
+ * `isSystem: true` without a `userId` is refused for the same reason rather
+ * than elevated: the system has no inbox, so there is no receipt it could be
+ * the recipient of. A system caller that genuinely means "sweep this user"
+ * still has `markRead(userId, ids)` — the door where naming a target user is
+ * the declared contract.
+ *
+ * ## What this is, and what it is honestly NOT
+ *
+ * It is a DISCIPLINE boundary, not a security boundary, and the difference is
+ * worth stating where the code is rather than discovering later. An in-process
+ * plugin already holds the data engine and can write `sys_notification_receipt`
+ * rows directly; nothing at this layer can stop trusted code that means to.
+ * What this does is make the CORRECT pattern the only one the plugin-facing
+ * surface expresses, and make the incorrect one fail loudly at the call site
+ * instead of silently succeeding — which is the failure mode measured on the
+ * existing path, where an absent caller returns `{ success: true, readCount: 0 }`.
+ */
+
+import type { ExecutionContext } from '@objectstack/spec/kernel';
+
+/**
+ * The authenticated caller a plugin-facing inbox write acts as — the
+ * `ExecutionContext` the caller was handed, passed through whole.
+ *
+ * Passed WHOLE, deliberately: the measured defect family behind
+ * `assembleExecutionContext` (#6071, #6206, #6551) is "a field exists on
+ * `ExecutionContext`, one copy carries it, another silently does not". A
+ * hand-picked `{ userId }` slice here would be one more such copy.
+ */
+export type InboxCaller = ExecutionContext;
+
+/**
+ * The plugin-facing inbox write refusal. Carries the ADR-0112 envelope pair a
+ * boundary reads — `status` + a registered `code` — so a caller that surfaces
+ * it over HTTP answers `401 UNAUTHENTICATED` rather than the `500
+ * INTERNAL_ERROR` a bare `Error` demotes to (`resolveThrownHttpError`,
+ * `@objectstack/types`).
+ *
+ * `UNAUTHENTICATED` rather than `PERMISSION_DENIED`, and the distinction is
+ * the point of the whole axis: there is no second identity for the caller to
+ * disagree with, so there is no forbidden-target case to answer 403 for. The
+ * only thing that can go wrong is having no authenticated principal at all.
+ */
+export class InboxCallerError extends Error {
+    /** Registered `StandardErrorCode` — 401's standard member. */
+    readonly code = 'UNAUTHENTICATED';
+    /** HTTP answer this refusal declares (ADR-0112). */
+    readonly status = 401;
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'InboxCallerError';
+    }
+}
+
+/**
+ * The recipient a plugin-facing inbox write acts on: the caller's
+ * authenticated `userId`, or a refusal.
+ *
+ * Never returns a guess. Never falls back to `attributedUserId` / `actor` /
+ * `isSystem` — see this module's header for why each of those is a wrong
+ * answer rather than a missing feature.
+ *
+ * @param caller The caller's execution context (`undefined` is a refusal).
+ * @param verb   The plugin-facing method name, so the refusal names the call.
+ * @throws {InboxCallerError} when no authenticated user can be resolved.
+ */
+export function resolveInboxRecipient(caller: InboxCaller | undefined, verb: string): string {
+    const userId = typeof caller?.userId === 'string' ? caller.userId.trim() : '';
+    if (userId) return userId;
+
+    // Name what WAS present, so the caller can tell "I passed nothing" from "I
+    // passed a context whose principal is not an authorization subject" — the
+    // second is the mistake that otherwise reads as a platform bug.
+    const carried: string[] = [];
+    if (caller?.attributedUserId) carried.push('attributedUserId');
+    if (caller?.actor) carried.push('actor');
+    if (caller?.isSystem) carried.push('isSystem');
+    const detail = carried.length
+        ? ` The context carries ${carried.join(' + ')}, which is attribution/privilege, never an authorization subject`
+        : '';
+
+    throw new InboxCallerError(
+        `messaging: ${verb} requires an authenticated caller — no 'userId' on the execution context.${detail}. `
+        + `This surface acts only on the CALLER'S OWN inbox and takes no target user; `
+        + `a system/background sweep that must name one uses markRead(userId, ids).`,
+    );
+}

--- a/packages/services/service-messaging/src/index.ts
+++ b/packages/services/service-messaging/src/index.ts
@@ -52,6 +52,10 @@ export type {
     QuietHours,
 } from './preference-resolver.js';
 
+// Plugin-facing inbox writes scoped to the authenticated caller (ADR-0030 L5)
+export { InboxCallerError, resolveInboxRecipient } from './inbox-caller.js';
+export type { InboxCaller } from './inbox-caller.js';
+
 // Channel seam
 export { createInboxChannel, INBOX_OBJECT, RECEIPT_OBJECT } from './inbox-channel.js';
 export type { InboxChannelOptions } from './inbox-channel.js';

--- a/packages/services/service-messaging/src/messaging-service.test.ts
+++ b/packages/services/service-messaging/src/messaging-service.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MessagingService } from './messaging-service.js';
+import { InboxCallerError } from './inbox-caller.js';
 import { MemoryNotificationOutbox } from './memory-outbox.js';
 import type { Delivery, MessagingChannel, SendResult } from './channel.js';
 
@@ -1068,5 +1069,129 @@ describe('[#6436] markAllRead — sweeps the whole inbox, not one 200-row window
 
         const svc = new MessagingService({ logger, getData: () => inboxEngine({ inbox: seedInbox('u1', 3) }) });
         expect(await svc.markAllRead('')).toEqual({ success: true, readCount: 0 });
+    });
+});
+
+/**
+ * [#10753] The plugin-facing inbox write door.
+ *
+ * The measured BEFORE, and it is this card's real severity: the messaging
+ * service is registered as a kernel service and the kernel hands every plugin
+ * ONE shared `PluginContext` whose `getService` carries no caller identity, so
+ * `markRead(userId, ids)`'s first parameter is a free string for an in-process
+ * caller — any plugin could mark ANY user's inbox messages read, unconstrained
+ * and undeclared, with the receipt landing context-lessly on an `engine-owned`
+ * object so no engine permission check saw it either.
+ *
+ * `markReadAsCaller` / `markAllReadAsCaller` take no target user at all. These
+ * pin that the recipient comes from the caller's authenticated `userId` and
+ * from NOTHING that merely resembles one.
+ */
+describe('MessagingService — plugin-facing inbox writes scoped to the authenticated caller (#10753)', () => {
+    const logger = silentLogger();
+
+    /** u1 and u2 each hold one unread message, so cross-user reach is visible. */
+    function twoUserInbox() {
+        return inboxEngine({
+            inbox: [
+                { id: 'm1', user_id: 'u1', notification_id: 'n1', title: 'Approve me', created_at: '1' },
+                { id: 'm2', user_id: 'u2', notification_id: 'n2', title: 'Approve me too', created_at: '2' },
+            ],
+            receipts: [
+                { id: 'r1', notification_id: 'n1', user_id: 'u1', channel: 'inbox', state: 'delivered' },
+                { id: 'r2', notification_id: 'n2', user_id: 'u2', channel: 'inbox', state: 'delivered' },
+            ],
+        });
+    }
+
+    it("marks the caller's OWN message read", async () => {
+        const engine = twoUserInbox();
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        expect(await svc.markReadAsCaller({ userId: 'u1' }, ['n1'])).toEqual({ success: true, readCount: 1 });
+        expect((await svc.listInbox('u1')).unreadCount).toBe(0);
+    });
+
+    it("cannot reach another user's read-state even when handed their notification id", async () => {
+        // The id is not secret — `sys_notification` publishes get/list and every
+        // recipient's own `listInbox` hands them out — so "holding the id" was
+        // never a capability. What makes u2 unreachable is that the receipt is
+        // keyed `(notification_id, user_id, channel)` and the user half comes
+        // from the CALLER, which this surface does not let you name.
+        const engine = twoUserInbox();
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        await svc.markReadAsCaller({ userId: 'u1' }, ['n2']);
+
+        expect((await svc.listInbox('u2')).unreadCount).toBe(1);
+        expect(engine.store.sys_notification_receipt.find((r: any) => r.user_id === 'u2').state).toBe('delivered');
+    });
+
+    it("sweeps only the caller's own inbox on markAllReadAsCaller", async () => {
+        const engine = twoUserInbox();
+        const svc = new MessagingService({ logger, getData: () => engine });
+
+        expect(await svc.markAllReadAsCaller({ userId: 'u1' })).toEqual({ success: true, readCount: 1 });
+        expect((await svc.listInbox('u1')).unreadCount).toBe(0);
+        expect((await svc.listInbox('u2')).unreadCount).toBe(1);
+    });
+
+    describe('refusals — the ADR-0112 envelope, not a silent success', () => {
+        const svc = () => new MessagingService({ logger, getData: () => twoUserInbox() });
+
+        /** Assert the declared envelope pair a boundary reads: `status` + `code`. */
+        async function expectRefusal(run: () => Promise<unknown>): Promise<InboxCallerError> {
+            const err = await run().then(
+                () => { throw new Error('expected InboxCallerError, but the call resolved'); },
+                (e: unknown) => e as InboxCallerError,
+            );
+            expect(err).toBeInstanceOf(InboxCallerError);
+            expect(err.code).toBe('UNAUTHENTICATED');
+            expect(err.status).toBe(401);
+            return err;
+        }
+
+        it('refuses an absent context', async () => {
+            await expectRefusal(() => svc().markReadAsCaller(undefined, ['n1']));
+            await expectRefusal(() => svc().markAllReadAsCaller(undefined));
+        });
+
+        it('refuses a context with no userId, and a blank one', async () => {
+            await expectRefusal(() => svc().markReadAsCaller({}, ['n1']));
+            await expectRefusal(() => svc().markReadAsCaller({ userId: '   ' }, ['n1']));
+        });
+
+        it('refuses a context carrying only attributedUserId — attribution never becomes authorization', async () => {
+            // `attributedUserId` is the real human behind a write whose
+            // authorization subject is the SYSTEM (#4586). Its own contract
+            // states the invariant — "nothing in the authorization path reads
+            // this", and a context carrying only it authorizes ANONYMOUS
+            // (ADR-0118 D2). A `userId ?? attributedUserId` fallback here would
+            // read as working and clear the wrong person's badge.
+            const engine = twoUserInbox();
+            const service = new MessagingService({ logger, getData: () => engine });
+
+            const err = await expectRefusal(() => service.markReadAsCaller({ attributedUserId: 'u1' }, ['n1']));
+            expect(err.message).toContain('attributedUserId');
+
+            // The refusal is the point, but so is this: u1's message is still unread.
+            expect((await service.listInbox('u1')).unreadCount).toBe(1);
+        });
+
+        it('refuses a service-principal label and a system context — neither owns an inbox', async () => {
+            await expectRefusal(() => svc().markReadAsCaller({ actor: 'svc:flow:nightly' }, ['n1']));
+            await expectRefusal(() => svc().markAllReadAsCaller({ isSystem: true }));
+        });
+
+        it('refuses BEFORE the empty-ids and no-data-engine short-circuits', async () => {
+            // Both of those return `{ success: true, readCount: 0 }`. Reaching
+            // one with no authenticated caller would report success for a write
+            // that was never authorized — the silent-success shape this door
+            // exists to replace, and the reason the order is pinned rather than
+            // left to reading.
+            await expectRefusal(() => svc().markReadAsCaller(undefined, []));
+            await expectRefusal(() => new MessagingService({ logger }).markReadAsCaller(undefined, ['n1']));
+            await expectRefusal(() => new MessagingService({ logger }).markAllReadAsCaller({}));
+        });
     });
 });

--- a/packages/services/service-messaging/src/messaging-service.ts
+++ b/packages/services/service-messaging/src/messaging-service.ts
@@ -19,6 +19,7 @@ import type {
     RedeliverOptions,
 } from './http-outbox.js';
 import { INBOX_OBJECT, RECEIPT_OBJECT } from './inbox-channel.js';
+import { type InboxCaller, resolveInboxRecipient } from './inbox-caller.js';
 
 /** The L2 event object every `emit()` writes one row to (ADR-0030). */
 export const NOTIFICATION_EVENT_OBJECT = 'sys_notification';
@@ -493,6 +494,20 @@ export class MessagingService {
      * `(notification_id, user_id, channel:'inbox')`); inserts one only when
      * absent. `ids` are notification (event) ids. Returns the REST contract
      * shape (`MarkNotificationsReadResponseSchema`): `{ success, readCount }`.
+     *
+     * **This is the REST door's method** — `INotificationService.markRead?`,
+     * called by `runtime/src/domains/notifications.ts`, which binds `userId`
+     * to `context.executionContext.userId` after answering 401 for a request
+     * that has none. The target user is a declared parameter here *because*
+     * that door has already authenticated it.
+     *
+     * An IN-PROCESS caller has no such door in front of it, and for that caller
+     * the parameter is simply a free string — the "any plugin can mark any
+     * user's messages read" shape. Plugins use {@link markReadAsCaller}, which
+     * derives the recipient from the caller's execution context and has no
+     * target-user parameter to get wrong. This signature stays as it is: it is
+     * the published `INotificationService` contract, and the REST door needs
+     * exactly it.
      */
     async markRead(userId: string, ids: readonly string[]): Promise<{ success: boolean; readCount: number }> {
         const data = this.ctx.getData?.();
@@ -558,6 +573,66 @@ export class MessagingService {
         const data = this.ctx.getData?.();
         if (!data || !userId) return { success: true, readCount: 0 };
         return this.markRead(userId, await this.unreadNotificationIds(data, userId));
+    }
+
+    /* ------------------------------------------------------------------ */
+    /*  Plugin-facing inbox writes — scoped to the AUTHENTICATED caller     */
+    /*                                                                     */
+    /*  The pair above is the REST door's contract surface                 */
+    /*  (`INotificationService.markRead?/markAllRead?`), whose `userId` is  */
+    /*  filled by the runtime from an already-authenticated session. The    */
+    /*  pair below is the door for IN-PROCESS callers, and it takes no      */
+    /*  target user at all: the recipient is derived from the caller's      */
+    /*  execution context, so acting on someone else's inbox has no         */
+    /*  spelling here. See `inbox-caller.ts` for the full rationale,        */
+    /*  including why `attributedUserId` / `actor` / `isSystem` are refused */
+    /*  rather than accepted as fallbacks.                                 */
+    /* ------------------------------------------------------------------ */
+
+    /**
+     * Mark notifications read **in the calling user's own inbox** — the
+     * plugin-facing counterpart to {@link markRead}.
+     *
+     * This is what a plugin closing out a notification it pushed should call:
+     * `emit()` returns the `notificationId`, the business record keeps it, and
+     * the hook that completes the work hands that id back here together with
+     * the context it is running under. The approval case the surface was asked
+     * for is exactly this shape — the approver who clears the request IS the
+     * recipient whose badge is stuck, so the authenticated caller and the
+     * receipt's owner are the same principal.
+     *
+     * Refuses (`InboxCallerError`, 401 `UNAUTHENTICATED`) when the context
+     * names no authenticated user. **The refusal is evaluated FIRST**, before
+     * the empty-`ids` and no-data-engine short-circuits {@link markRead}
+     * applies: those return a `{ success: true, readCount: 0 }` envelope, and
+     * letting an unauthenticated call reach one would report success for a
+     * write that was never authorized to happen — the silent-success shape
+     * this door exists to replace.
+     *
+     * @param caller The caller's execution context. The recipient is read from
+     *               its `userId` and from nothing else.
+     * @param ids    Notification (event) ids, as returned by `emit()`.
+     */
+    async markReadAsCaller(
+        caller: InboxCaller | undefined,
+        ids: readonly string[],
+    ): Promise<{ success: boolean; readCount: number }> {
+        return this.markRead(resolveInboxRecipient(caller, 'markReadAsCaller'), ids);
+    }
+
+    /**
+     * Mark the calling user's WHOLE inbox read — the plugin-facing counterpart
+     * to {@link markAllRead}, on the same authenticated-caller axis as
+     * {@link markReadAsCaller} (and with the same refusal, evaluated first).
+     *
+     * Deliberately still the caller's own inbox and not a sweep primitive: a
+     * background job that must clear someone else's inbox is naming a target
+     * user, which is {@link markAllRead}'s declared contract, not this one's.
+     */
+    async markAllReadAsCaller(
+        caller: InboxCaller | undefined,
+    ): Promise<{ success: boolean; readCount: number }> {
+        return this.markAllRead(resolveInboxRecipient(caller, 'markAllReadAsCaller'));
     }
 
     /**


### PR DESCRIPTION
Part of #10753

> ⚠️ **Deliberately `Part of`, not a closing keyword.** The dispatch asked for the closing form; this PR uses `Part of` instead — flagged here rather than silently switched. The ruling covers **two** verbs and this PR lands one of them: `recall()` hits the ruling's own fork clause (last section), so merging this must not close the card while that half is undecided. #10753 stays open. (The keyword is kept away from every issue number on purpose — GitHub's parser ignores any negation in front of it.)

## What this is

`MessagingService` gains a plugin-facing inbox write door scoped to the **authenticated caller**:

```ts
markReadAsCaller(caller: ExecutionContext | undefined, ids: readonly string[])
markAllReadAsCaller(caller: ExecutionContext | undefined)
```

Ruled 2026-08-23 (`5386675655`), maintainer, verbatim and untranslated: 「10950 不考虑存量，其他接受你的建议」 — recorded as **Q1 = A1 · Q2 = (a) hard recall · Q3 = implementation-first**, with two constraints the same ruling attaches:

> the implementation **must scope by AUTHENTICATED user** — `markRead`'s `userId` is a plain parameter, not auth context.
> ⛔ adding a provenance column to an engine-owned platform object is NOT approved by this ruling.

Everything here lands in `service-messaging` (Q3, implementation-first). **No `packages/spec` edit, no new column, no object declaration moved.**

## The measured BEFORE — where this card's severity actually lives

`markRead(userId, ids)` is the **REST door's** contract method (`INotificationService.markRead?`), and on that path the parameter is trustworthy: `runtime/src/domains/notifications.ts:198` binds it to `context.executionContext.userId` after answering 401 for a request that has none.

The same service is also a kernel service — `ctx.registerService('messaging', service)`, `messaging-service-plugin.ts:162` — and the kernel hands every plugin **one shared `PluginContext`** (`core/src/kernel.ts:65,:91`) whose `getService` carries no caller identity. For an in-process caller that first parameter is therefore a free string:

**Today any plugin can mark any user's inbox messages read — unconstrained and undeclared.** And the receipt write lands context-lessly on `sys_notification_receipt`, which is `managedBy: 'engine-owned'` with `apiMethods: ['get','list']` (ADR-0103), so no engine permission check sees it either.

So this PR is **both** an API widening (new plugin-facing methods) **and** the first tightening of in-process power on this path. That fact was not in front of the maintainer when Option A was first framed.

## Why the new door is a tightening and not just a convenience

The pair takes **no target user at all**. The recipient is derived from `caller.userId`, so *"mark someone else's inbox read"* has no spelling on this surface — unrepresentable rather than discouraged. It fits the case the card was filed for exactly: the approver who clears a request **is** the recipient whose badge is stuck, and the close-out hook runs inside that approver's own request.

`userId` is read, and nothing that merely resembles one:

| Field | Verdict | Why |
| --- | --- | --- |
| `userId` | the recipient | the subject the engine authorizes AS |
| `attributedUserId` | **refused** | attribution only; its own contract states *"nothing in the authorization path reads this"*, and a context carrying only it authorizes as anonymous (ADR-0118 D2). Promoting it opens the second adjudication track ADR-0095 D3 closed |
| `actor` | **refused** | a service-principal label (`svc:<name>`), not a `sys_user` id — `svc:flow` has no inbox |
| `isSystem: true`, no user | **refused** | the system has no inbox to be the recipient of. A sweep that must name a target still has `markRead(userId, ids)` |

A tolerant `userId ?? attributedUserId ?? actor` chain is exactly the consumer-side widening contract-first exists to refuse: it reads as working and silently clears the wrong person's badge.

Refusals throw `InboxCallerError` carrying the ADR-0112 envelope pair a boundary reads — `status: 401` + the registered `code: 'UNAUTHENTICATED'` — so an HTTP surface answers 401 rather than the 500 a bare `Error` demotes to. `UNAUTHENTICATED` and not `PERMISSION_DENIED` **is** the axis: there is no second identity to disagree with, so there is no forbidden-target case.

**Order is pinned, not left to reading:** the refusal is evaluated *before* the empty-`ids` and no-data-engine short-circuits, both of which return `{ success: true, readCount: 0 }`. Reaching one of those with no authenticated caller would report success for a write that was never authorized — the silent-success shape this door exists to replace.

## Honest about what it is NOT

A **discipline** boundary, not a security boundary, and that is stated in the module header rather than left to be discovered. An in-process plugin already holds the data engine and can write `sys_notification_receipt` directly; nothing at this layer stops trusted code that means to. And `markRead(userId, ids)` stays reachable — it is the published `INotificationService` contract the REST door needs, and this lane has zero ownership of `packages/spec`. What changes is that the correct pattern is the only one the plugin-facing surface expresses, and the wrong one now fails loudly at the call site. The `INotificationService` declaration of the new pair is the follow-up inside the contract-review chain.

## Verification

**Everything below was run against the final commit `1ce71df0e5`** — the same tree the gate union was derived from, with a clean working tree. Union derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` with **no hand-supplied paths** (the script takes its own change set from the merge base, three-dot; the run confirmed 5 committed paths / 0 working-tree / 0 untracked).

- **19 of the 19** path-matched + convention-triggered gates green, each read from its own verdict line with the exit code captured **before** any pipe. `check:i18n` first answered `PREREQUISITE NOT MET — the workspace CLI is not built`, which is **not measured, never a pass**; the CLI was built and it re-ran to its own verdict: `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys)`.
- `pnpm --filter @objectstack/service-messaging typecheck` (`tsc --noEmit`) — clean.
- `pnpm --filter @objectstack/service-messaging test` — **267 passed, 26 files**, including 8 new cases pinning the door.

**One declared narrowing:** `check:type-check-debt --re-measure` was *not* run — it refuses without the whole workspace closure built, and a repo-wide scan is CI's run. It is named here only by the *kind* "adds or edits a test file", and the three things that make this a measurement rather than a gap: (1) its population is its own ledger, whose single `service-messaging` entry is `packages/services/service-messaging/scripts` (the `i18n-extract.config.ts`); (2) none of this PR's 5 changed paths is under it; (3) the appended test code is inside the package's own tsc program — `tsconfig.json` is `include: ["src"]` with no test exclusion — and that program is green above. Its structural half, `check:type-check-coverage`, ran and passed.

### Ablation — the prediction was written down before the run

**Predicted, in writing, before mutating anything:** replacing the strict derivation with the forbidden fallback chain (`caller?.userId ?? caller?.attributedUserId`) turns the suite **RED** on exactly one test, named in advance — *"refuses a context carrying only attributedUserId — attribution never becomes authorization"* — with the absent / `{}` / blank / `actor` / `isSystem` refusals staying green, because the ablated chain never reaches those fields.

**Observed:** `Tests 1 failed | 266 passed (267)`, and the one failure is that test, by name. Direction RED as predicted.

- On-disk confirmation in **both** directions with `grep -F`, plus a reverse control taken *before* the mutation: injected literal `0 → 1`, deleted literal `1 → 0`.
- Restore verified byte-identical by `git hash-object`: `59883355018fe7b5fcbad947a3edaa0efb78786c` before and after. `trap … EXIT INT TERM` carried the restore.
- **No rebuild needed, and proven rather than assumed:** the suite imports `./inbox-caller.js` relatively, so vitest resolves `src`. A `dist`-resolved subject would have stayed green — and a green under ablation would have been *not measured*, never a pass.

### Documentation

Checked by reading the prose, not by trusting `docs-drift`'s green (which cannot see prose or table claims). Every page mentioning `markRead` / `sys_inbox_message` / `sys_notification_receipt` / `service-messaging` was read: `content/docs/api/client-sdk.mdx` (client SDK, REST path), `content/docs/kernel/services-checklist.mdx:395` (the three REST routes — all three keep their signatures), `content/docs/concepts/north-star.mdx:124`, and the package roster in `content/docs/plugins/packages.mdx:240`. **None enumerates who may mark read, and none is falsified by this change**, so there is nothing to repair in-PR. The package ships no README.

## ⚠️ `recall()` — the ruling's fork clause is triggered. NOT implemented here.

Q2 ruled **(a) hard recall**: delete the notification's `sys_inbox_message` rows and cancel its pending/unclaimed inbox deliveries. Writing that contract before its implementation — as instructed — is what surfaced that it cannot be built under this ruling's constraints. **Two independent blockers, both measured:**

**1. Authorization has no expressible predicate.** `recall` is an *emitter-side* verb — "retract what I sent, from everyone's inbox" — and emitter-scoped and authenticated-scoped are different axes. No emitter provenance exists on any row (`sys_notification` carries `topic`/`payload`/`severity`/`dedup_key`/`source_object`/`source_id`/`actor_id`/`created_at`; `actor_id` is *the user who caused the event*, not the emitting plugin; `sys_inbox_message` has none; `EmitInput` has no such field; the shared `PluginContext` mints no caller identity). On the authenticated axis the only expressible predicate is *"the caller is a recipient"* — which yields a **recipient-scoped retract**, not a hard recall across all recipients. Shipping that under the name `recall` would be the weaker approximation the dispatch forbids, so it is not shipped.

**2. The mechanism has no safe expression either — and this one is independent of the column.** `INotificationOutbox` declares exactly `enqueue | claim | ack | list | claimDigest` (`outbox.ts:115-129`). **There is no cancel.** Worse than absent: `ack(id, { success: false, suppressed: true })` *would appear to work* — neither `MemoryNotificationOutbox.ack` nor `SqlNotificationOutbox.ack` checks that the row is claimed, so both would flip a `pending` row to `suppressed`. It races the dispatcher (the row can be claimed between the `list` and the `ack`, sent, and acked back to `success`) and it increments `attempts` on a delivery that was never attempted. A real cancellation needs `INotificationOutbox` widened plus both implementations — a separate surface decision.

⇒ **Reported, not invented, and not approximated.** This is the PM seat's call, not a re-ruling request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_