### PR TITLE
docs(platform-objects): re-measure the two better-auth 1.6.11 stamps outside #10188's plugin-auth carrier

### DIFF
--- a/packages/platform-objects/src/identity/sys-oauth-application.object.ts
+++ b/packages/platform-objects/src/identity/sys-oauth-application.object.ts
@@ -46,14 +46,19 @@ export const SysOauthApplication = ObjectSchema.create({
   // is intentionally dropped from `apiMethods` below so the only delete
   // path is the better-auth wrapper.
   //
-  // Upstream gap (better-auth 1.6.11): the stock `/admin/oauth2/update-client`
-  // endpoint's Zod body schema does NOT accept the `disabled` flag, even
-  // though the column exists and the runtime honours it. We bridge the
-  // gap with `POST /api/v1/auth/admin/oauth2/toggle-disabled`, registered
-  // by plugin-auth, which writes through better-auth's own adapter under
+  // Upstream gap (re-measured 2026-08-23 against the installed
+  // @better-auth/oauth-provider@1.7.1): `adminUpdateOAuthClient`
+  // (`dist/authorize-Crqw4_bR.mjs:2860`) declares the stock
+  // `/admin/oauth2/update-client` endpoint's Zod body schema at
+  // `:2862-2889`, and `disabled` occurs zero times in that block — while
+  // matching 35 other lines of the same file (`grep -c`), so the search
+  // reaches the text. The column exists and the runtime honours it, but
+  // no client-facing API can flip it there. We bridge the gap with
+  // `POST /api/v1/auth/admin/oauth2/toggle-disabled`, registered by
+  // plugin-auth, which writes through better-auth's own adapter under
   // the auth namespace (no generic data-layer bypass). When upstream
-  // ships `disabled` support, retarget the enable/disable actions and
-  // delete the bridge route.
+  // adds `disabled` to `adminUpdateOAuthClient`'s schema, retarget the
+  // enable/disable actions and delete the bridge route.
   //
   // The two toggle predicates are guarded for the SPARSE action face (#8990),
   // and this pair is where the guard actually changes what a user sees. Both

--- a/packages/platform-objects/src/platform-objects.test.ts
+++ b/packages/platform-objects/src/platform-objects.test.ts
@@ -182,10 +182,12 @@ describe('@objectstack/platform-objects', () => {
       expect(del?.mode).toBe('delete');
 
       // Enable/disable both hit the ObjectStack-added bridge route on
-      // /api/v1/auth (since better-auth 1.6.11's stock admin endpoint
-      // does not accept `disabled` in its update schema). They differ
-      // only in the static `disabled` body field and the visibility
-      // predicate, so exactly one is active at any time.
+      // /api/v1/auth. Re-measured 2026-08-23 against the installed
+      // @better-auth/oauth-provider@1.7.1: the stock admin endpoint's Zod
+      // body schema (`dist/authorize-Crqw4_bR.mjs:2862-2889`) still does
+      // not accept `disabled`, so the bridge route stays warranted. They
+      // differ only in the static `disabled` body field and the
+      // visibility predicate, so exactly one is active at any time.
       expect(disable?.target).toBe('/api/v1/auth/admin/oauth2/toggle-disabled');
       expect(disable?.bodyExtra).toEqual({ disabled: true });
       expect((disable?.visible as any)?.source).toBe('(has(record.disabled) && record.disabled != true) && features.oidcProvider != false');


### PR DESCRIPTION
Fixes #11362

Two `better-auth 1.6.11` stamps in `platform-objects` carried the same upstream-gap claim
as #10188's plugin-auth site 1 (the stock `/admin/oauth2/update-client` endpoint's Zod body
schema does not accept `disabled`), but sat outside that card's carrier and were recorded
separately per its own triage note. Nothing was broken: both claims are still **true** at
the version installed now; only the stamps and (for site 1) the anchor were stale.

## What each site now says, and how it was measured

Re-measured **in this worktree, against `node_modules` as installed on the current base**,
independently of the card body's own re-measurement — **2026-08-23**, against installed
`@better-auth/oauth-provider@1.7.1` (confirmed by reading `package.json` at the resolved
pnpm store path, not carried forward from #10188 or #11446):
`adminUpdateOAuthClient` (`dist/authorize-Crqw4_bR.mjs:2860`) declares its body schema at
`:2862-2889`, and `disabled` occurs **zero** times in that block — while matching 35 other
lines of the same file (`grep -c`; 38 whole-word, 42 substring), so the search reaches the
text. This agrees with #11446's independent re-measurement of the same file/version, and
with the card's own 2026-08-23 reading — but was read fresh here, not inherited.

### 1. `sys-oauth-application.object.ts:49` (comment on `SysOauthApplication`'s `actions`)

**Load-bearing, same as #11446's site 1**: this comment already carried its own
retirement trigger ("When upstream ships `disabled` support, retarget the enable/disable
actions and delete the bridge route") — and that retarget/delete is *this file's own*
`disable_oauth_application` / `enable_oauth_application` actions, a few lines below the
comment. If the claim had gone false, this PR would be retargeting those two actions to
the stock endpoint and deleting the plugin-auth bridge route, not re-stamping a comment.

Verified past the one block, for the same reason #11446 did:

- the non-admin sibling `/oauth2/update-client` handler (`updateClientEndpoint`,
  `:2379-2444`) destructures its `update` payload from `ctx.body.update`, which is bound
  by the *same* Zod schema shape (no `disabled` key) — so it can't accept the flag either;
- `resourceBodySchema` (`:3361`), the one `disabled: z.boolean().optional()` elsewhere in
  the file, belongs to OAuth **resources** — a different, unrelated model — confirmed a
  false friend;
- the DCR re-registration path sources `disabled` from the stored record
  (`disabled: existingClient.disabled`, `:1972`), never from client input.

Updated the comment to record the 2026-08-23 measurement, name `grep -c` as the
instrument, and correct the anchor to `:2862-2889` (not `:2896`, which is the closing
`});` of the whole `createAuthEndpoint(...)` call — includes `metadata` and the handler,
not the schema).

### 2. `platform-objects.test.ts:185` (comment inside a test)

No assertion in this test pins the `better-auth 1.6.11` string — it explains *why* the
test expects `disable?.target` / `enable?.target` to be the bridge route rather than the
stock endpoint. **Not independently load-bearing**: if the claim ever goes false, the
decision is made at site 1 (retarget the actions), and *that* change is what would force
this test's assertions — and this comment — to move together with it. Updated to record
the 2026-08-23 re-measurement and the anchor, dropping the version-number framing that
made it a fourth stamp.

## Not touched, and why

- `packages/plugins/plugin-auth` — its three sites were already swept and merged in
  #11446; re-touching it here would be exactly the widening the triage note forbids.
- The generalizable "dependency name adjacent to a version literal" gate #10188 sketches —
  that is its own card, not built here.

## Changeset: `skip-changeset`, judgement stated

`platform-objects` is a published package, so this is a judgement call, not an automatic
skip — same call #11446 made for `plugin-auth`. Both sites are comment text only:

- `sys-oauth-application.object.ts:49` — a `//` comment block inside the `actions`
  configuration passed to `ObjectSchema.create(...)`, not a JSDoc attached to an exported
  type or symbol. `tsup`'s `dts` generation reads type declarations, not comments sitting
  inside a runtime object-literal expression, so nothing here reaches `dist/*.d.ts`.
- `platform-objects.test.ts:185` — a test file, not published at all.

No exported symbol's documentation changes, no behaviour changes, no accept/reject
behaviour, no public surface moves. `skip-changeset` applied on that basis (label added
via the additive endpoint per AGENTS.md and read back — see report).

## Verification

Gate union derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
and **no path arguments** (2 paths vs merge base `8542bd457`), on the final commit
**`05bfc3eb34`**, clean tree, exit codes captured before any pipe.

Path-matched and convention-triggered families, all green:

| gate | verdict |
| --- | --- |
| `check:published-files` | 69 publishable packages, all covered |
| `check:slot-lookup` | ratchet holds, 107 unswept sites, none new |
| `check:test-source-alias` | OK — 72 packages scanned |
| `check:type-source-resolution` | OK — 77 packages scanned |
| `check-ci-filter-parity.mjs` | OK — 89 declared globs covered |
| `check-plugin-teardown-shape.mjs` | 63 Plugin implementations, baseline fully burned down |
| `docs-audit/check-affected-docs.mjs` | self-test 339 cases pass |
| `check:query-options-erasure` | ratchet holds, none new (via the shared lock) |
| `check:type-check-coverage` (structural) | OK — 65/78 packages type-checked |
| `check:engine-double-contract` | OK — 390 pinned |
| `check:cross-package-test-inputs` | OK — 14 packages, all declared |
| `check:where-matcher` | 288 matchers, 0 silently-wrong |

Package verification (foreground, filtered):

- `pnpm --filter @objectstack/platform-objects test -- --maxWorkers=2` — **27 test files,
  432 tests passed.**
- `pnpm --filter @objectstack/platform-objects typecheck` — exit 0, clean.

**Two gates are NOT MEASURED, reported as such rather than folded into the pass count:**

- `check:type-check-debt --re-measure` **refused**: `PREREQUISITE NOT MET — 50 workspace
  dependencies have no built type entry point on disk`. It needs the full workspace closure
  built exactly as `lint.yml` does (`turbo run build --filter='./packages/*'
  --filter='./packages/*/*'`) — a shared-lock verify contention lane (#11363) queued 5+ deep
  behind this attempt; abandoned rather than parking the session on it (its structural
  half, `check:type-check-coverage` without `--re-measure`, is measured above and green).
- `check:i18n` **refused**: `PREREQUISITE NOT MET — the workspace CLI is not built`
  (`packages/cli/dist/commands/i18n/extract.js` missing). Same shared-lock contention.

**Repo-wide `pnpm lint` — declared narrowing, not a gap**, for the same contention reason
(#11363 is live; a full-farm `pnpm lint` and the closure build above were both queued 5-6
deep behind other agents' work in the same window). In its place, the same three facts
#11446 used to make a narrowed run a measurement rather than an omission:

1. **Population from ESLint's own config**: `pnpm lint` is `eslint . --no-inline-config`
   over the single root `eslint.config.mjs`; both changed files return real result objects.
2. **Count read from `--format json`**: 2 files linted, 0 errors, 0 warnings.
3. **Invariance for untouched files**: this repo's one `eslint.config.mjs` never enables
   type-aware linting for any file (no `parserOptions.project`, no typed
   `@typescript-eslint` rules), so a comment-only edit inside two files cannot move any
   verdict on a file it does not touch.

CI runs the full farm regardless and its conclusion is authoritative over every narrowing
above.

## Scope

Comment text only, in exactly the two files this card names. No assertion, pin, schema,
route, or gate input is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_