### PR TITLE
fix(spec): dist-freshness refusal derives package label and build remedy from pkgDir

### DIFF
--- a/.changeset/dist-freshness-refusal-derives-package-label.md
+++ b/.changeset/dist-freshness-refusal-derives-package-label.md
@@ -1,0 +1,19 @@
+---
+'@objectstack/spec': patch
+---
+
+fix(spec): the dist-freshness refusal derives its package label and build remedy from `pkgDir` (#11250)
+
+`inspectDistFreshness()` / `inspectBundleFreshness()` in `packages/spec/scripts/lib/dist-freshness.ts`
+already take an arbitrary `pkgDir`, but their refusal `cause` strings and the `pnpm --filter <pkg> build`
+remedy line hardcoded `packages/spec` / `@objectstack/spec` regardless of it. Every real caller passed
+`SPEC_DIR` until #10969 gave `check:skill-examples` a second surface (`packages/client-react` /
+`packages/client`) — confirmed live: a stale-dist refusal on that surface named `packages/spec` while
+`packages/spec` was freshly built and `client`/`client-react` were the actually-unbuilt packages, so
+following the printed remedy verbatim rebuilt an already-fresh package and re-red identically.
+
+Both cause strings now interpolate a `packages/<name>` label derived from `pkgDir`'s own path (falling
+back to the raw path when the shape doesn't match), and the build-remedy line now reads
+`package.json#name` from `pkgDir` (falling back to the same label when it's missing or unparsable). The
+freshness verdict itself, and every caller's own `rerun` argument, are unchanged — this is diagnostic
+text only.

--- a/packages/spec/scripts/dist-freshness.test.ts
+++ b/packages/spec/scripts/dist-freshness.test.ts
@@ -31,7 +31,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { inspectDistFreshness } from './lib/dist-freshness';
+import { inspectDistFreshness, packageDirLabel } from './lib/dist-freshness';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PKG = path.resolve(HERE, '..');
@@ -84,7 +84,12 @@ describe('inspectDistFreshness — the dist precondition gen:api-surface never e
     expect(verdict.fresh).toBe(false);
     if (verdict.fresh) return;
     expect(verdict.state).toBe('stale');
-    expect(verdict.message).toContain('OLDER than packages/spec/src');
+    // The label is DERIVED from `sandbox`, not a hardcoded `packages/spec` —
+    // `sandbox` is a bare tmpdir with no `packages` path segment, so this
+    // exercises the fallback-to-raw-path branch of `packageDirLabel` (#11250).
+    // The `packages/<name>`-shaped branch is covered by its own case below.
+    expect(verdict.message).toContain(`OLDER than ${packageDirLabel(sandbox)}/src`);
+    expect(verdict.message).not.toContain('packages/spec');
   });
 
   it('refuses in --check mode too, so CI cannot pass against a stale dist either', () => {
@@ -107,6 +112,12 @@ describe('inspectDistFreshness — the dist precondition gen:api-surface never e
   });
 
   it('names the writing damage in generate mode, and prescribes the build', () => {
+    // The build-remedy line now reads `package.json#name` (#11250) rather than
+    // hardcoding `@objectstack/spec`, so THIS case seeds one — matching
+    // `sandbox`'s own docblock, "a throwaway `packages/spec`-SHAPED directory" —
+    // to keep asserting the spec-shaped remedy line. The non-spec-shaped case
+    // below is what proves that name is genuinely read, not assumed.
+    write('package.json', JSON.stringify({ name: '@objectstack/spec' }), NEW);
     write('dist/contracts/index.d.ts', 'export {};', OLD);
     write('src/contracts/job-service.ts', 'export interface JobRunOutcome { ok: boolean }', NEW);
 
@@ -116,6 +127,45 @@ describe('inspectDistFreshness — the dist precondition gen:api-surface never e
     expect(verdict.message).toContain('BREAKING');
     expect(verdict.message).toContain('pnpm --filter @objectstack/spec build');
     expect(verdict.message).toContain('gen:api-surface');
+  });
+
+  it('derives BOTH the cause label and the build-remedy package name from a NON-spec-shaped pkgDir (#11250)', () => {
+    // Every case above runs against `sandbox` directly, which (bare tmpdir, no
+    // `packages` path segment) already proves the label is not hardcoded — but
+    // it never exercises the `packages/<name>` MATCHING branch of
+    // `packageDirLabel`, and none of them give `pkgDir` a `package.json` naming
+    // anything other than `@objectstack/spec`. So a build that quietly special-
+    // cased "packages/spec" back in, or that only ever prints the one name
+    // every other case's fixture happens to share, would still pass all of
+    // them. This case is shaped like neither: a real `packages/widgets` path
+    // segment, with its OWN unrelated `package.json#name`.
+    const pkgDir = path.join(sandbox, 'packages', 'widgets');
+    write('packages/widgets/package.json', JSON.stringify({ name: '@acme/widgets' }), NEW);
+    write('packages/widgets/dist/index.d.ts', 'export {};', OLD);
+    write('packages/widgets/src/index.ts', 'export const live = 1;', NEW);
+
+    const verdict = inspectDistFreshness(pkgDir, 'generate', 'pnpm --filter @acme/widgets check:something');
+    expect(verdict.fresh).toBe(false);
+    if (verdict.fresh) return;
+    expect(verdict.state).toBe('stale');
+    expect(verdict.message).toContain('OLDER than packages/widgets/src');
+    expect(verdict.message).toContain('pnpm --filter @acme/widgets build');
+    expect(verdict.message).not.toContain('packages/spec');
+    expect(verdict.message).not.toContain('@objectstack/spec');
+  });
+
+  it('falls back to the raw pkgDir for the build-remedy name when package.json is unreadable', () => {
+    // `packageName`'s OTHER branch (#11250): a `pkgDir` with no `package.json`
+    // at all (or one that fails to parse) must not throw out of a diagnostic
+    // path. `sandbox` itself has none, so this reuses it directly rather than
+    // constructing a second fixture.
+    write('dist/contracts/index.d.ts', 'export {};', OLD);
+    write('src/contracts/job-service.ts', 'export interface JobRunOutcome { ok: boolean }', NEW);
+
+    const verdict = inspectDistFreshness(sandbox, 'generate', GEN_RERUN);
+    expect(verdict.fresh).toBe(false);
+    if (verdict.fresh) return;
+    expect(verdict.message).toContain(`pnpm --filter ${packageDirLabel(sandbox)} build`);
   });
 
   it('reads a MISSING dist as its own condition, not as staleness', () => {
@@ -130,7 +180,10 @@ describe('inspectDistFreshness — the dist precondition gen:api-surface never e
     expect(verdict.fresh).toBe(false);
     if (verdict.fresh) return;
     expect(verdict.state).toBe('missing');
-    expect(verdict.message).toContain('no .d.ts declarations');
+    // Same fallback branch as above: `sandbox` has no `packages` segment, so
+    // the label in the cause string is the raw sandbox path, not `packages/spec`.
+    expect(verdict.message).toContain(`${packageDirLabel(sandbox)}/dist holds no .d.ts declarations`);
+    expect(verdict.message).not.toContain('packages/spec');
   });
 
   it('reads a JS-only dist as missing — the OS_SKIP_DTS=1 shape on a virgin tree', () => {

--- a/packages/spec/scripts/lib/dist-freshness.ts
+++ b/packages/spec/scripts/lib/dist-freshness.ts
@@ -94,13 +94,67 @@
  * command string rather than an npm script name — that path is not reachable
  * through one.
  */
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { bundlesAreStale, distIsStale } from '../../../../scripts/check-regen-pending.mjs';
 
 /** What the generator is about to do, so the refusal can name the real damage. */
 export type DistReadMode = 'generate' | 'check';
+
+/**
+ * A `packages/<name>` display label for `pkgDir`, derived from the path
+ * itself rather than assumed — the refusal text used to hardcode
+ * `packages/spec` unconditionally, which misnamed the stale package for
+ * every non-spec caller (#11250; `check:skill-examples` became the first
+ * real one, adopting this for `packages/client` / `packages/client-react`
+ * in #10969).
+ *
+ * Finds the LAST `packages` path segment and takes the one right after it.
+ * Every real caller today passes an absolute path with a single `packages`
+ * segment, so "last" and "first" coincide; "last" is chosen so a
+ * hypothetical path with an ancestor directory also named `packages`
+ * (`.../packages/foo/packages/bar`) still names the package itself (`bar`)
+ * rather than the misleading earlier match.
+ *
+ * Falls back to the raw `pkgDir` when the shape doesn't match at all (no
+ * `packages` segment, or nothing after it) — a raw path is uglier than a
+ * clean label, but it is still the TRUE location, whereas a hardcoded
+ * `packages/spec` from a `pkgDir` this rule failed to parse would be a wrong
+ * one dressed as a right one.
+ */
+export function packageDirLabel(pkgDir: string): string {
+  const segments = pkgDir.split(/[\\/]+/).filter(Boolean);
+  const idx = segments.lastIndexOf('packages');
+  if (idx === -1 || idx === segments.length - 1) return pkgDir;
+  return `packages/${segments[idx + 1]}`;
+}
+
+/**
+ * The package's own declared `package.json#name` — what `pnpm --filter`
+ * actually resolves against, which is why the build-remedy line needs THIS
+ * and not `packageDirLabel` above (a directory label like `packages/client`
+ * is not a valid `--filter` argument; the published name is
+ * `@objectstack/client`).
+ *
+ * Read defensively: a missing or unparsable `package.json` falls back to the
+ * directory label. That fallback command will not resolve either, but it is
+ * no worse than the pre-fix behaviour (which unconditionally printed
+ * `@objectstack/spec` regardless of `pkgDir`) and it stays legible rather
+ * than throwing out of a diagnostic path.
+ */
+function packageName(pkgDir: string): string {
+  try {
+    const parsed = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')) as {
+      name?: unknown;
+    };
+    if (typeof parsed.name === 'string' && parsed.name.length > 0) return parsed.name;
+  } catch {
+    // Falls through to the directory-label fallback below — unreadable or
+    // unparsable package.json is not fatal to a diagnostic message.
+  }
+  return packageDirLabel(pkgDir);
+}
 
 export type DistFreshness =
   | { fresh: true }
@@ -164,11 +218,12 @@ export function inspectDistFreshness(
         `   check would reach its conclusion without ever reading the declarations under test —\n` +
         `   a FALSE GREEN on exactly the change it exists to catch (#7122).`;
 
+  const label = packageDirLabel(pkgDir);
   const cause =
     state === 'missing'
-      ? `packages/spec/dist holds no .d.ts declarations — the package is not built (or was built\n` +
+      ? `${label}/dist holds no .d.ts declarations — the package is not built (or was built\n` +
         `   with OS_SKIP_DTS=1, which emits JS and skips exactly the artifact this reads).`
-      : `packages/spec/dist/**/*.d.ts is OLDER than packages/spec/src — the declarations on disk\n` +
+      : `${label}/dist/**/*.d.ts is OLDER than ${label}/src — the declarations on disk\n` +
         `   predate the sources. If you built with OS_SKIP_DTS=1, that build did not rebuild them.`;
 
   return {
@@ -178,7 +233,7 @@ export function inspectDistFreshness(
       `\n❌ ${cause}\n\n` +
       `   ${damage}\n\n` +
       `   Build first, then re-run:\n\n` +
-      `     pnpm --filter @objectstack/spec build\n` +
+      `     pnpm --filter ${packageName(pkgDir)} build\n` +
       `     ${rerun}\n\n` +
       `   (Do NOT use OS_SKIP_DTS=1 for this one — AGENTS.md §9 names it as the flag that emits JS\n` +
       `   and skips exactly the declarations this reads.)`,
@@ -239,11 +294,12 @@ export function inspectBundleFreshness(
         `   check would reach its conclusion without ever reading the module graph under test —\n` +
         `   NOT MEASURED reported as if it were measured and clean (#4690).`;
 
+  const label = packageDirLabel(pkgDir);
   const cause =
     state === 'missing'
-      ? `packages/spec/dist holds no .mjs/.js bundles — the package is not built. This gate reads\n` +
+      ? `${label}/dist holds no .mjs/.js bundles — the package is not built. This gate reads\n` +
         `   the module a consumer's import actually loads, so there is nothing here to read.`
-      : `packages/spec/dist's .mjs/.js bundles are OLDER than packages/spec/src (or than\n` +
+      : `${label}/dist's .mjs/.js bundles are OLDER than ${label}/src (or than\n` +
         `   tsup.config.ts, which decides the entries, the externals and whether entries are\n` +
         `   self-contained). The bundles on disk predate the sources.`;
 
@@ -254,7 +310,7 @@ export function inspectBundleFreshness(
       `\n❌ ${cause}\n\n` +
       `   ${damage}\n\n` +
       `   Build first, then re-run:\n\n` +
-      `     pnpm --filter @objectstack/spec build\n` +
+      `     pnpm --filter ${packageName(pkgDir)} build\n` +
       `     ${rerun}\n\n` +
       `   (OS_SKIP_DTS=1 is fine for THIS gate — it still emits every bundle this reads. It is\n` +
       `   the .d.ts-reading gates next door that it blinds.)`,


### PR DESCRIPTION
Fixes #11250

## What

`inspectDistFreshness()` / `inspectBundleFreshness()` (`packages/spec/scripts/lib/dist-freshness.ts`)
take an arbitrary `pkgDir`, but their refusal `cause` strings and the printed
`pnpm --filter PKG build` remedy line hardcoded `packages/spec` / `@objectstack/spec`
regardless of it.

- Both `cause` strings now interpolate a `packages/NAME` display label derived from
  `pkgDir`'s own path (`packageDirLabel` — finds the last `packages` path segment and
  takes the one after it; falls back to the raw `pkgDir` when the shape doesn't match).
- The build-remedy line now reads `pkgDir/package.json#name` (`packageName` — falls back
  to the same directory label when the file is missing or unparsable), since that's what
  `pnpm --filter` actually resolves against, not the directory label.
- The `rerun` line (the caller's own re-run command) is **unchanged** — see "Decisions"
  below.

## Why

Every real caller passed `SPEC_DIR` until #10969 gave `check:skill-examples` a second
surface (`packages/client-react` / `packages/client`), so a stale-dist refusal on that
surface printed a wrong package name in both diagnostic lines.

**Live confirmation** (issue comment, 2026-08-23 15:29Z): while working #11026, the
refusal printed

```
❌ packages/spec/dist holds no .d.ts declarations — the package is not built …
```

with `packages/spec/dist` holding 44 fresh `.d.ts` files — the actually-unbuilt packages
were `client` and `client-react` (`dts=0` each). Following the printed remedy
(`pnpm --filter @objectstack/spec build`) verbatim rebuilds an already-fresh package and
reds again identically — the message was not merely mislabelled, it was non-actionable
for the surface it fired on.

## Decisions

- **Cause label + build-remedy line: derived from `pkgDir`.** Both now trace to the real
  stale package, whichever surface fired.
- **`rerun` line at the `check-skill-examples.ts` call site: left as-is.** The issue asked
  me to weigh per-surfacing it. `check-skill-examples.ts` passes one fixed
  `'pnpm --filter @objectstack/spec check:skill-examples'` for every surface it loops
  over — but that command is *correct* for every surface: `check:skill-examples` itself
  is a `packages/spec` script that type-checks all three surfaces (skills+docs,
  `packages/spec/src`, and the client SDK) in one run, so re-running it is the right fix
  regardless of which surface's dist was stale. Per-surfacing it would print a command
  that doesn't exist (there is no `check:skill-examples` that runs only the client-SDK
  surface). So the printed remedy is actionable as shipped: build the named package, then
  re-run the one real gate command.

## Tests

- `dist-freshness.test.ts`: updated the two pinned-literal assertions that hardcoded
  `packages/spec` text against the (non-`packages/spec`-shaped) `sandbox` fixture to
  assert against the dynamically-derived label instead, and added a package.json seed to
  the one case that needs the build-remedy line to keep naming `@objectstack/spec`.
  Added two new cases:
  - a non-spec-shaped `pkgDir` (`packages/widgets`, `package.json#name` = `@acme/widgets`)
    proving both the cause label and the build-remedy line are genuinely derived, not a
    surviving `packages/spec` hardcode with different test data;
  - the `packageName` fallback branch (no `package.json` at all) falls back to the
    directory label rather than throwing.
- `dist-freshness-adoption.test.ts` (the end-to-end suite covering
  `check:dual-source-exports` / `check:exported-any` / `check:skill-examples` against real
  spawned gate runs) is unaffected — every one of its cases exercises `tree.spec`, a
  genuinely `packages/spec`-shaped sandbox with a real `@objectstack/spec` `package.json`,
  so the dynamically-derived label there is *correctly* `packages/spec` before and after
  this change.

### Verification transcript (at `ca8116159855bc936c3b443666bd73caa3653b6e`)

- `pnpm --filter @objectstack/spec build` — exit 0.
- `pnpm --filter @objectstack/spec exec vitest run scripts/dist-freshness.test.ts scripts/dist-freshness-adoption.test.ts --reporter=verbose --maxWorkers=2` — **25/25 passed** (15 + 10). Also ran the full `pnpm --filter @objectstack/spec test` once (419 files / 11163 tests, all green) — an accidental over-broad run (a stray `--` defeated the vitest path filter), kept only as extra confirmation, not the intended scope.
- **Reverse verification**: with `packages/spec/scripts/lib/dist-freshness.ts` checked out from `origin/main` (pre-patch) and the new/updated test bodies unchanged, 4 tests fail as expected — most tellingly, the non-spec-shaped case fails with `expected '\n❌ packages/spec/dist/**/*.d.ts is O…' to contain 'OLDER than packages/widgets/src'`, i.e. the pre-patch code reproduces the exact live-confirmed bug (prints `packages/spec` for a `packages/widgets` `pkgDir`). Restored the fix from `HEAD` afterward and confirmed byte-identity (`git hash-object` on the working-tree file equalled `git rev-parse HEAD:` plus the path) before re-running the suite green (25/25).
- `node scripts/check-cross-package-test-inputs.mjs --self-test && node scripts/check-cross-package-test-inputs.mjs` — both exit 0 (104/104 self-test cases; `OK: 14 package(s) … all declared`).
- `eslint` on both touched files (`--no-inline-config --format json`) — 0 problems.
- Gate list **derived at HEAD** via `node scripts/pm/dispatch-gates.mjs` (not hand-picked) — 18 path-derived + 4 convention-triggered (test-file-add) local gates identified. Ran all of them: **21 green** (`check:changeset-gate-self-tests`, spec `check:empty-state`/`check:liveness`/`check:strictness-ledger`/`check:variant-docs`, `check:merge-driver`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-empty-changeset`, `check-plugin-teardown-shape`, `check-affected-docs`, `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`). **2 red for the same declared reason**: `check-dev-prereqs` and `check:type-check-debt --re-measure` both refuse outright ("NOT MEASURED", not a false verdict) because this worktree has only `@objectstack/spec` built, not the full 67-package closure their measurement needs — `check:type-check-debt` names the exact remedy itself: `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`. That full-workspace build is a `lint.yml`-CI-side precondition, not something this diagnostic-text-and-tests-only diff can affect either way; declared here rather than silently skipped.

Clause-② confirmed not triggered: diff touches only `packages/spec/scripts/lib/dist-freshness.ts`
and `packages/spec/scripts/dist-freshness.test.ts` — no `packages/spec/src/**`, no accept/reject
contract change, diagnostic text + tests only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_
