### PR TITLE
fix(service-analytics): lower per-measure filters onto engine.aggregate (#10413 phase 2)

### DIFF
--- a/.changeset/objectql-per-measure-aggregate-filter.md
+++ b/.changeset/objectql-per-measure-aggregate-filter.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+**Fix:** `/api/v1/analytics/query` on the ObjectQL door (MongoDB, the memory driver, or any deployment whose driver reports `objectqlAggregate` but not `nativeSql`) now honours a measure's own scoped `filter` — `won_count` and `won_amount`-style conditional measures answer the same numbers the dashboard door and the native-SQL door already did (#10413 phase 2).
+
+`ObjectQLStrategy.execute` lowers each measure's `filter` into the ONE aggregation it belongs to, via the per-aggregation `filter` field #10576 added to `engine.aggregate`'s contract (SQL `FILTER (WHERE …)` semantics) — not into the whole-call filter, which would have narrowed every measure (a fix shaped that way would make a conditional measure right while making every unconditional sibling measure in the same query wrong). An aggregation with no measure filter is unchanged and keeps the native-pushdown-eligible shape.
+
+`ObjectQLStrategy.generateSql` (the `/analytics/sql` echo) renders the same conditional aggregate — `COUNT(CASE WHEN … THEN … END)`-style — so the preview stays an honest description of what `execute()` now actually runs, matching the native-SQL strategy's existing echo for the same class of measure.
+
+Phase 1 (PR #10758) already ANDed a dataset's definition-level `filter` into the whole-call filter on this door; this closes the remaining half of the two-door disagreement #10413 reported. `NativeSQLStrategy` (#10298 / PR #10411) is unaffected by this change.

--- a/packages/services/service-analytics/src/__tests__/execution-context-bridge.test.ts
+++ b/packages/services/service-analytics/src/__tests__/execution-context-bridge.test.ts
@@ -177,6 +177,60 @@ describe('plugin auto-bridge → engine.aggregate (#3602)', () => {
   });
 });
 
+// ── #10413 phase 2 / #10576 — the auto-bridge must forward the field, not
+//    just build it ────────────────────────────────────────────────────────
+
+/**
+ * `ObjectQLStrategy.execute` lowering a measure filter onto its own
+ * `aggregations[].filter` entry is necessary but not sufficient: that array
+ * still has to survive the auto-bridge in `plugin.ts`, which RECONSTRUCTS
+ * each aggregation object to rename `method` → the engine's own `function`
+ * key. A bridge that copies only `{ function, field, alias }` — the shape
+ * this repo actually shipped until this card — makes the strategy's lowering
+ * a NO-OP on every real deployment that boots through the default
+ * `new AnalyticsServicePlugin({ cubes })` wiring, while every test that stubs
+ * `executeAggregate` directly (as `objectql-dataset-filter.test.ts` does)
+ * stays green — the declared-≠-enforced shape Prime Directive #10 names,
+ * one layer below where #10413 itself was measured. This test goes through
+ * the REAL bridge, not a stub, so it is the one place a regression here
+ * would be caught.
+ */
+describe('plugin auto-bridge forwards aggregations[].filter (#10413 phase 2 / #10576)', () => {
+  it('the engine.aggregate call carries the per-measure filter the strategy lowered', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const engine = {
+      aggregate: async (_object: string, options: Record<string, unknown>) => {
+        calls.push(options);
+        return [{ opp_count: 24, won_count: 8 }];
+      },
+      getObject: () => undefined,
+    };
+    const { ctx, registered } = fakePluginContext({ data: engine });
+
+    await new AnalyticsServicePlugin({ queryCapabilities: objectqlOnly }).init(ctx as never);
+    const service = registered.analytics as AnalyticsService;
+    service.registerDataset(DatasetSchema.parse({
+      name: 'won_metrics', label: 'Won metrics', object: 'opportunity',
+      dimensions: [],
+      measures: [
+        { name: 'opp_count', label: 'Opportunities', aggregate: 'count' },
+        { name: 'won_count', label: 'Won', aggregate: 'count', filter: { stage: 'closed_won' } },
+      ],
+    }));
+
+    await service.query({ cube: 'won_metrics', measures: ['opp_count', 'won_count'] });
+
+    // The unfiltered measure keeps the EXACT pre-#10413-phase-2 shape — no
+    // `filter` key at all, not even `filter: undefined` — and the filtered
+    // one carries its own predicate, translated with the same `function`
+    // rename the rest of this bridge already applies.
+    expect(calls[0].aggregations).toEqual([
+      { function: 'count', field: '*', alias: 'opp_count' },
+      { function: 'count', field: '*', alias: 'won_count', filter: { stage: 'closed_won' } },
+    ]);
+  });
+});
+
 // ── Item 2: the record-label lookup rides the same bridge ────────────────────
 
 const labelDataset = DatasetSchema.parse({

--- a/packages/services/service-analytics/src/__tests__/objectql-dataset-filter.test.ts
+++ b/packages/services/service-analytics/src/__tests__/objectql-dataset-filter.test.ts
@@ -113,7 +113,7 @@ const UNSCOPED_METRICS: Dataset = DatasetSchema.parse({
 
 interface AggOptions {
   groupBy?: string[];
-  aggregations?: Array<{ field: string; method: string; alias: string }>;
+  aggregations?: Array<{ field: string; method: string; alias: string; filter?: Record<string, unknown> }>;
   filter?: Record<string, unknown>;
 }
 interface AggCall { object: string; options: AggOptions }
@@ -159,12 +159,19 @@ function runAggregate(rows: Row[], options: AggOptions): Row[] {
     const out: Row = {};
     for (const g of groupBy) out[g] = bucket[0]?.[g];
     for (const agg of options.aggregations ?? []) {
+      // [#10413 phase 2] `agg.filter` is a PER-AGGREGATION predicate over the
+      // rows already admitted by the whole-call `filter` above — SQL
+      // `FILTER (WHERE …)` semantics (#10576) — never a second whole-call
+      // narrowing. Evaluated with the SAME strict `matches`, so an operator
+      // this probe cannot evaluate throws rather than silently answering the
+      // unfiltered number.
+      const admitted = agg.filter ? bucket.filter((r) => matches(r, agg.filter)) : bucket;
       if (agg.method === 'count') {
         out[agg.alias] = agg.field === '*'
-          ? bucket.length
-          : bucket.filter((r) => r[agg.field] != null).length;
+          ? admitted.length
+          : admitted.filter((r) => r[agg.field] != null).length;
       } else if (agg.method === 'sum') {
-        out[agg.alias] = bucket.reduce((a, r) => a + Number(r[agg.field] ?? 0), 0);
+        out[agg.alias] = admitted.reduce((a, r) => a + Number(r[agg.field] ?? 0), 0);
       } else {
         throw new Error(`[probe engine] cannot compute "${agg.method}"`);
       }
@@ -238,60 +245,108 @@ describe('[#10413] the three doors on one dataset', () => {
     });
   });
 
-  it('the OBJECTQL door applies the dataset scope — phase 1 of the same repair', async () => {
+  it('the OBJECTQL door now agrees with the other two — phase 1 AND phase 2 combined', async () => {
     const { svc, calls } = objectqlService([OPPORTUNITY_METRICS]);
     const result = await svc.query({ cube: 'opportunity_metrics', measures: MEASURES });
 
-    // The engine call carries the dataset's own predicate...
+    // The engine call carries the dataset's own predicate (phase 1)...
     expect(calls).toHaveLength(1);
     expect(JSON.stringify(calls[0].options.filter)).toContain('is_deleted');
-    // ...so the soft-deleted rows are gone from the aggregate. 30 is the number
-    // this door answered before the fix.
-    expect(result.rows[0]?.opp_count).toBe(24);
+    // ...and every measure now answers the SAME numbers the dashboard door
+    // answers two tests above — phase 2 closes the remaining gap. 30 / 24 /
+    // 5,632,500 are the numbers this door answered before phase 1 and phase 2
+    // respectively; asserting `not.toBe` on each keeps the fix falsifiable.
+    expect(result.rows[0]).toMatchObject({ opp_count: 24, won_count: 8, won_amount: 1_290_000 });
     expect(result.rows[0]?.opp_count).not.toBe(30);
+    expect(result.rows[0]?.won_count).not.toBe(24);
+    expect(result.rows[0]?.won_amount).not.toBe(5_632_500);
   });
 });
 
-// -- 2. the phase-2 half, pinned WRONG on purpose --------------------------
+// -- 2. per-measure filters lower into their own aggregation — phase 2 -----
 
-describe('[#10413 phase 2 — NOT DONE] per-measure filters are still not lowered', () => {
+describe('[#10413 phase 2] per-measure filters lower into the aggregation they belong to', () => {
   /**
-   * These expectations are the CURRENT, WRONG numbers, held here on purpose so
-   * the gap cannot be mistaken for a green path.
-   *
-   * `engine.aggregate` types an aggregation as `{ field, method, alias }` —
-   * there is no per-aggregation `filter` to lower a measure filter into.
-   * Widening that contract is #10576; doing the lowering is phase 2 of #10413.
-   * When #10576 lands, `won_count` must become 8 and `won_amount` 1,290,000 —
-   * the numbers the dashboard door already answers three tests above — and
-   * these assertions must be FLIPPED, not deleted.
+   * FLIPPED from the pre-#10576 pin this block used to carry (`won_count: 24`,
+   * `won_amount: 5,632,500` — the CURRENT-WRONG numbers, held on purpose so the
+   * gap could not be mistaken for a green path; see the git history of this
+   * file / #10413's issue comments for the shape that pinned). Now pinned
+   * RIGHT, against the same dashboard-door baseline the section above uses:
+   * `opp_count: 24 / won_count: 8 / won_amount: 1,290,000`.
    */
-  it('sends aggregations with NO per-aggregation filter field (the #10576 contract gap)', async () => {
+  it('sends each filtered measure its OWN per-aggregation `filter` — the #10576 contract field', async () => {
     const { svc, calls } = objectqlService([OPPORTUNITY_METRICS]);
     await svc.query({ cube: 'opportunity_metrics', measures: MEASURES });
 
     const aggregations = calls[0].options.aggregations ?? [];
     expect(aggregations).toHaveLength(3);
-    for (const agg of aggregations) {
-      expect(Object.keys(agg).sort()).toEqual(['alias', 'field', 'method']);
-    }
-    // And the measure comparand reaches the engine NOWHERE — not on the
-    // aggregations, and not smuggled into the whole-call filter, which would
-    // narrow every measure at once, `opp_count` included.
-    expect(JSON.stringify(calls[0].options)).not.toContain('closed_won');
+    const byAlias = Object.fromEntries(aggregations.map((a) => [a.alias, a]));
+    // The unfiltered measure carries NO filter key at all — unchanged shape,
+    // still eligible for native pushdown on a driver that has one (#10576's
+    // own positive pin, `engine-aggregate-filter.test.ts`).
+    expect(Object.keys(byAlias.opp_count).sort()).toEqual(['alias', 'field', 'method']);
+    // The two conditional measures each carry their OWN filter — not a shared
+    // reference, and not the measure's `field`/`method` disturbed by it.
+    expect(byAlias.won_count).toMatchObject({ method: 'count', filter: { stage: 'closed_won' } });
+    expect(byAlias.won_amount).toMatchObject({
+      field: 'amount', method: 'sum', filter: { stage: 'closed_won' },
+    });
+    // And the comparand does NOT ALSO leak into the whole-call filter — that
+    // would be the "narrow every measure" failure mode ① below is about.
+    expect(JSON.stringify(calls[0].options.filter)).not.toContain('closed_won');
   });
 
-  it('therefore still answers the UNFILTERED number for a conditional measure', async () => {
+  it('① both directions in ONE result: won_count is right (8) and opp_count STAYS right (24)', async () => {
     const { svc } = objectqlService([OPPORTUNITY_METRICS]);
     const result = await svc.query({ cube: 'opportunity_metrics', measures: MEASURES });
-    // Every live row counted / summed, because the measure's own
-    // `{ stage: 'closed_won' }` has nowhere to go on this contract.
-    expect(result.rows[0]?.won_count).toBe(24);
-    expect(result.rows[0]?.won_amount).toBe(5_632_500);
-    // Phase 1 still moved these: the deleted rows are excluded from BOTH, so the
-    // measure is now wrong by exactly the measure filter and nothing else.
-    expect(result.rows[0]?.won_count).not.toBe(30);
-    expect(result.rows[0]?.won_amount).not.toBe(10_132_500);
+    // A fix that ANDed the measure filter into the WHOLE-CALL filter instead
+    // of the one aggregation it belongs to would make won_count right (8) and
+    // opp_count WRONG (8 instead of 24, since opp_count would inherit the
+    // stage narrowing too) — asserting both in one result catches that shape;
+    // pinning won_count alone would score it green.
+    expect(result.rows[0]).toEqual({ opp_count: 24, won_count: 8, won_amount: 1_290_000 });
+  });
+
+  it('② an aggregation without a filter is unchanged and answers the same as before phase 2', async () => {
+    const { svc, calls } = objectqlService([UNSCOPED_METRICS]);
+    const result = await svc.query({ cube: 'unscoped_metrics', measures: ['opp_count'] });
+    expect(calls[0].options.aggregations).toEqual([{ field: '*', method: 'count', alias: 'opp_count' }]);
+    expect(result.rows[0]?.opp_count).toBe(30);
+  });
+
+  it('③ the dataset-level filter from phase 1 still applies and is not displaced', async () => {
+    const { svc, calls } = objectqlService([OPPORTUNITY_METRICS]);
+    await svc.query({ cube: 'opportunity_metrics', measures: MEASURES });
+    // Phase 1's whole-call conjunct is untouched by phase 2's per-aggregation
+    // addition — still exactly one dataset-scope conjunct, nothing merged in.
+    expect(calls[0].options.filter).toEqual({ $and: [{ is_deleted: false }] });
+  });
+
+  it('④ the native-SQL path is untouched by this change (#10411 already fixed it)', async () => {
+    const svc = sqlService([OPPORTUNITY_METRICS]);
+    const { sql } = await svc.generateSql({ cube: 'opportunity_metrics', measures: MEASURES });
+    expect(sql).toContain('THEN 1 END) AS "won_count"');
+    expect(sql).toContain('THEN amount END) AS "won_amount"');
+  });
+});
+
+// -- 2b. the ObjectQL SQL echo renders the per-measure filter too ----------
+
+describe('[#10413 phase 2] the ObjectQL SQL echo renders the measure filter it executes', () => {
+  it('renders a conditional aggregate for a filtered measure, mirroring execution', async () => {
+    const { svc } = objectqlService([OPPORTUNITY_METRICS]);
+    const { sql } = await svc.generateSql({ cube: 'opportunity_metrics', measures: MEASURES });
+    // Same shape as the native-SQL echo (test ④ above): the two previews read
+    // alike. An echo showing an unconditional aggregate here would understate
+    // what `execute()` really runs now that phase 2 lowers the filter.
+    expect(sql).toContain('THEN 1 END) AS "won_count"');
+    expect(sql).toContain('THEN amount END) AS "won_amount"');
+  });
+
+  it('renders no conditional wrapping for the unfiltered measure', async () => {
+    const { svc } = objectqlService([OPPORTUNITY_METRICS]);
+    const { sql } = await svc.generateSql({ cube: 'opportunity_metrics', measures: MEASURES });
+    expect(sql).toContain('COUNT(*) AS "opp_count"');
   });
 });
 

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -378,7 +378,16 @@ export interface AnalyticsServiceConfig {
    */
   executeAggregate?: (objectName: string, options: {
     groupBy?: string[];
-    aggregations?: Array<{ field: string; method: string; alias: string }>;
+    /**
+     * Per-aggregation `filter` (#10576, the #10413 phase-2 contract field) —
+     * kept in lockstep with `StrategyContext.executeAggregate`
+     * (`packages/spec/src/contracts/analytics-service.ts`), which this local
+     * type otherwise mirrors. A bridge that reconstructs the aggregation
+     * entries (as `AnalyticsServicePlugin`'s auto-bridge does, to rename
+     * `method` → the engine's `function`) MUST forward this field or a
+     * measure-scoped filter `ObjectQLStrategy` lowers never reaches storage.
+     */
+    aggregations?: Array<{ field: string; method: string; alias: string; filter?: Record<string, unknown> }>;
     filter?: Record<string, unknown>;
     /** Reference timezone (IANA) for date bucketing — ADR-0053 Phase 2. */
     timezone?: string;

--- a/packages/services/service-analytics/src/plugin.ts
+++ b/packages/services/service-analytics/src/plugin.ts
@@ -20,7 +20,16 @@ interface DataEngineLike {
   aggregate(object: string, options: {
     where?: Record<string, unknown>;
     groupBy?: string[];
-    aggregations?: Array<{ function: string; field: string; alias: string }>;
+    /**
+     * `filter` (#10576, the contract half of #10413's ruling) is a
+     * per-aggregation predicate over the SOURCE rows — SQL
+     * `FILTER (WHERE …)` semantics — kept optional here in lockstep with
+     * `EngineAggregateOptions['aggregations'][number].filter` so the bridge
+     * below can forward a measure-scoped filter without widening this
+     * interface again the next time #10413's phase-2 lowering needs a place
+     * to put one.
+     */
+    aggregations?: Array<{ function: string; field: string; alias: string; filter?: Record<string, unknown> }>;
     /** Reference timezone (IANA) for date bucketing — ADR-0053 Phase 2. */
     timezone?: string;
     /**
@@ -120,7 +129,14 @@ export interface AnalyticsServicePluginOptions {
    */
   executeAggregate?: (objectName: string, options: {
     groupBy?: string[];
-    aggregations?: Array<{ field: string; method: string; alias: string }>;
+    /**
+     * Per-aggregation `filter` (#10576, the #10413 contract field) — a
+     * CUSTOM bridge (an app author's own `executeAggregate`, as opposed to
+     * the auto-bridge below) MUST forward it to the real engine the same way
+     * the auto-bridge does, or a measure-scoped filter this plugin lowers
+     * onto the aggregation silently never reaches storage.
+     */
+    aggregations?: Array<{ field: string; method: string; alias: string; filter?: Record<string, unknown> }>;
     filter?: Record<string, unknown>;
     /** Reference timezone (IANA) for date bucketing — ADR-0053 Phase 2. */
     timezone?: string;
@@ -270,10 +286,25 @@ export class AnalyticsServicePlugin implements Plugin {
         const rows = await engine.aggregate(objectName, {
           where: filter,
           groupBy,
+          // [#10413 phase 2 / #10576] `a.filter` is the per-aggregation
+          // predicate `ObjectQLStrategy` lowers a measure's own scoped
+          // `filter` into. This map already renames `method` → `function`
+          // for the engine's own vocabulary; dropping `filter` here — as this
+          // bridge did before this line existed — would have made the
+          // strategy's lowering a NO-OP on every real deployment that boots
+          // through this auto-bridge (the default path: `new
+          // AnalyticsServicePlugin({ cubes })` with no custom
+          // `executeAggregate`), passing every unit test that stubs
+          // `executeAggregate` directly while silently dropping the filter in
+          // production — the exact declared-≠-enforced shape Prime Directive
+          // #10 calls out. Omitted (not `filter: undefined`) when the
+          // aggregation carries none, matching the engine's own
+          // vacuous-filter convention.
           aggregations: aggregations?.map((a) => ({
             function: a.method,
             field: a.field,
             alias: a.alias,
+            ...(a.filter ? { filter: a.filter } : {}),
           })),
           // ADR-0053 Phase 2: thread the reference tz so date buckets resolve on
           // that zone's calendar days (engine buckets in-memory when non-UTC).

--- a/packages/services/service-analytics/src/strategies/objectql-strategy.ts
+++ b/packages/services/service-analytics/src/strategies/objectql-strategy.ts
@@ -135,12 +135,37 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       groupBy.push({ field: this.resolveFieldName(cube, dim, 'dimension'), dateGranularity: gran });
     }
 
-    // Build aggregations from measures
-    const aggregations: Array<{ field: string; method: string; alias: string }> = [];
+    // The compiled dataset's own scope (#10298 / PR #10758), read ONCE and
+    // reused below for both the per-measure aggregation filter (#10413 phase
+    // 2) and the whole-call dataset-level conjunct (#10413 phase 1).
+    // `undefined` for a cube that is not a compiled dataset, which is why an
+    // inferred or manifest cube compiles unchanged.
+    const datasetScope = (ctx as DatasetScopedStrategyContext).getDatasetScope?.(query.cube!);
+
+    // Build aggregations from measures.
+    //
+    // [#10413 phase 2] A measure's own `filter` (`stage: 'closed_won'`) lowers
+    // into the ONE aggregation it belongs to, via the per-aggregation `filter`
+    // #10576 added to the contract (SQL `FILTER (WHERE …)` semantics,
+    // `engine.aggregate`'s `aggregations[].filter`) — never into the whole-call
+    // filter below, which would narrow EVERY measure and trade a wrong
+    // `won_count` for a wrong `opp_count` as well. `filterNodeToCondition`
+    // returns `null` for a filter that constrains nothing (an empty object),
+    // matching the engine's own "empty filter is vacuous" convention — so a
+    // vacuous measure filter adds no `filter` key rather than an empty one.
+    const aggregations: Array<{ field: string; method: string; alias: string; filter?: Record<string, unknown> }> = [];
     if (query.measures && query.measures.length > 0) {
       for (const measure of query.measures) {
         const { field, method } = this.resolveMeasureAggregation(cube, measure);
-        aggregations.push({ field, method, alias: measure });
+        const measureFilter = datasetScope?.measureFilters?.[measure];
+        const filterCondition = measureFilter
+          ? this.filterNodeToCondition(normalizeAnalyticsFilterTree({ where: measureFilter }), cube)
+          : null;
+        aggregations.push(
+          filterCondition
+            ? { field, method, alias: measure, filter: filterCondition }
+            : { field, method, alias: measure },
+        );
       }
     }
 
@@ -170,6 +195,8 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // whole table, while the dashboard door — same cube, same measure names —
     // answered the scoped numbers. `undefined` for a cube that is not a compiled
     // dataset, which is why an inferred or manifest cube compiles unchanged.
+    // (`datasetScope` itself is computed once, above, and reused for the
+    // per-measure lowering the aggregations loop just did.)
     //
     // ANDed as its own conjunct rather than merged key by key, for the reason
     // `withReadScope` gives below: the caller's `where` and the dataset's scope
@@ -177,14 +204,12 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // other. Placed before the `$and` fold, so it travels on the cross-object
     // path (`executeCrossObject`) as well as the direct one.
     //
-    // PHASE 1 ONLY. `datasetScope.measureFilters` is deliberately NOT read here:
-    // an aggregation is `{ field, method, alias }`, so a per-measure predicate
-    // cannot be expressed on this contract at all, and folding one into this
-    // whole-call filter would narrow EVERY measure — trading a wrong `won_count`
-    // for a wrong `opp_count` as well. Widening the aggregate contract is
-    // #10576; lowering the measure filters into it is phase 2 of #10413, and
-    // `objectql-dataset-filter.test.ts` pins the gap open until then.
-    const datasetScope = (ctx as DatasetScopedStrategyContext).getDatasetScope?.(query.cube!);
+    // This is the WHOLE-CALL half only — `datasetScope.measureFilters` is
+    // handled separately, above, on the aggregations themselves (#10413 phase
+    // 2 / #10576): an aggregation is `{ field, method, alias, filter? }`, and
+    // folding a measure filter into THIS whole-call filter instead would
+    // narrow EVERY measure, trading a wrong `won_count` for a wrong
+    // `opp_count` as well.
     if (datasetScope?.filter) {
       // `null` = constrains nothing, which is the AND identity — nothing to add,
       // and nothing invented for a filter that says nothing.
@@ -370,6 +395,11 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // invariant between two call sites, and two copies of a view can drift
     // apart while each stays individually correct — which is how they drifted.
     const plan = this.planCrossObject(cube, query, this.filterMemberView(cube, query, ctx));
+    // Read once, reused below for both the per-measure conditional aggregate
+    // (#10413 phase 2) and the dataset-scope WHERE conjunct (#10413 phase 1) —
+    // the same channel `execute()` reads it from, so the echo cannot drift
+    // from what actually ran.
+    const datasetScope = (ctx as DatasetScopedStrategyContext).getDatasetScope?.(query.cube!);
     const crossByDim = new Map((plan?.crossDims ?? []).map((cd) => [cd.outputName, cd]));
     const joinClauses: string[] = [];
     const dimExpr = (dim: string): string => {
@@ -400,14 +430,25 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       selectParts.push(`${expr} AS "${dim}"`);
       groupByParts.push(expr);
     }
+    // [#10413 phase 2] A measure carrying its own `filter` renders as a
+    // conditional aggregate — `execute()` really lowers it into the
+    // aggregation's own `filter` field now (#10576), and an echo that shows
+    // the UNCONDITIONAL form would understate what actually ran, the same
+    // #3601/#3602/#3650 lie in the direction of narrowing that never shows.
     if (query.measures) {
       for (const m of query.measures) {
         const { field, method } = this.resolveMeasureAggregation(cube, m);
-        const aggSql = method === 'count'
-          ? 'COUNT(*)'
-          : method === 'count_distinct'
-            ? `COUNT(DISTINCT ${field})`
-            : `${method.toUpperCase()}(${field})`;
+        const measureFilter = datasetScope?.measureFilters?.[m];
+        const predicate = measureFilter
+          ? this.renderFilterNodeSql(normalizeAnalyticsFilterTree({ where: measureFilter }), cube, params)
+          : null;
+        const aggSql = predicate
+          ? this.conditionalAggregateSql(method, field, predicate)
+          : method === 'count'
+            ? 'COUNT(*)'
+            : method === 'count_distinct'
+              ? `COUNT(DISTINCT ${field})`
+              : `${method.toUpperCase()}(${field})`;
         selectParts.push(`${aggSql} AS "${m}"`);
       }
     }
@@ -446,13 +487,11 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
     // [#10413] The dataset's own scope renders too, for the reason the read
     // scope does further down: `execute()` really applies this predicate now, and
     // an echo that OMITS an applied predicate is the same lie as one that invents
-    // a predicate (#3601 / #3602 / #3650). Rendered from the same lowering
-    // `execute()` uses, so the two cannot drift.
-    const echoedDatasetFilter =
-      (ctx as DatasetScopedStrategyContext).getDatasetScope?.(query.cube!)?.filter;
-    if (echoedDatasetFilter) {
+    // a predicate (#3601 / #3602 / #3650). Read from `datasetScope` above — the
+    // same lowering `execute()` uses, so the two cannot drift.
+    if (datasetScope?.filter) {
       const scopeSql = this.renderFilterNodeSql(
-        normalizeAnalyticsFilterTree({ where: echoedDatasetFilter }),
+        normalizeAnalyticsFilterTree({ where: datasetScope.filter }),
         cube,
         params,
       );
@@ -801,7 +840,7 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
   private async executeCrossObject(
     cube: Cube,
     query: AnalyticsQuery,
-    aggregations: Array<{ field: string; method: string; alias: string }>,
+    aggregations: Array<{ field: string; method: string; alias: string; filter?: Record<string, unknown> }>,
     filter: Record<string, unknown>,
     plan: CrossObjectPlan,
     ctx: StrategyContext,
@@ -920,6 +959,39 @@ export class ObjectQLStrategy implements AnalyticsStrategy {
       if (r.id != null) map.set(r.id, r[attr]);
     }
     return map;
+  }
+
+  /**
+   * A measure's aggregate, restricted to the rows its own `filter` admits
+   * (#10413 phase 2) — the same six functions `generateSql`'s unconditional
+   * branch renders, wrapped in a `CASE WHEN`.
+   *
+   * Spelled `CASE WHEN` rather than SQL-standard `FILTER (WHERE …)`, mirroring
+   * `NativeSQLStrategy.CONDITIONAL_AGGREGATE_SQL`: this string is DOCUMENTATION
+   * of an execution that really goes through `engine.aggregate`'s per-driver
+   * `aggregations[].filter` lowering (#10576), not a statement this class runs
+   * itself, so there is no reason to pick a dialect-restricted spelling over
+   * the portable one the SQL-executing sibling already settled on.
+   *
+   * `count` over `*` counts a constant (`COUNT(CASE WHEN p THEN 1 END)`, since
+   * `COUNT(CASE WHEN p THEN * END)` is not valid SQL); over a real column it
+   * counts that column's non-null values among the admitted rows.
+   */
+  private conditionalAggregateSql(method: string, col: string, pred: string): string {
+    const target = col === '*' ? '1' : col;
+    switch (method) {
+      case 'count': return `COUNT(CASE WHEN ${pred} THEN ${target} END)`;
+      case 'count_distinct': return `COUNT(DISTINCT CASE WHEN ${pred} THEN ${col} END)`;
+      case 'sum': return `SUM(CASE WHEN ${pred} THEN ${col} END)`;
+      case 'avg': return `AVG(CASE WHEN ${pred} THEN ${col} END)`;
+      case 'min': return `MIN(CASE WHEN ${pred} THEN ${col} END)`;
+      case 'max': return `MAX(CASE WHEN ${pred} THEN ${col} END)`;
+      // Closed vocabulary, same posture as `resolveMeasureAggregation`'s
+      // callers: `method` comes only from that function, whose own aggTypes
+      // list is exactly these six, so this default is unreachable rather than
+      // a silent fallback for a method this table forgot.
+      default: return `${method.toUpperCase()}(CASE WHEN ${pred} THEN ${col} END)`;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #10413

## Phase 2 — per-measure filters lower into the aggregation they belong to

Phase 1 (PR #10758) ANDed a dataset's **definition-level** `filter` into the ObjectQL door's whole-call filter. This closes the remaining half: a measure's **own** `filter` (`won_count: { filter: { stage: 'closed_won' } }`) now lowers into the ONE aggregation it belongs to, via the per-aggregation `filter` field #10576 added to the contract (`engine.aggregate`'s `aggregations[].filter`, SQL `FILTER (WHERE …)` semantics) — never into the whole-call filter, which would narrow every measure in the query (a fix shaped that way makes `won_count` right and `opp_count` wrong).

### The three doors, one tree, one run (`objectql-dataset-filter.test.ts`)

| door | dataset-level filter | per-measure filter |
|---|---|---|
| native SQL (#10411) | done before this PR | done before this PR |
| dashboard (`DatasetExecutor`) | always correct | always correct |
| **ObjectQL** | done — Phase 1 / #10758 | **done here** |

`opp_count 24 / won_count 8 / won_amount 1,290,000` now agrees across all three doors — measured in `[#10413] the three doors on one dataset > the OBJECTQL door now agrees with the other two — phase 1 AND phase 2 combined`, alongside the sibling native-SQL and dashboard tests in the same file.

### ⚠️ The strategy-level fix alone would have been a silent no-op in production

`ObjectQLStrategy.execute` lowering a measure's filter onto `aggregations[].filter` is necessary but **not sufficient**: that array still has to survive `AnalyticsServicePlugin`'s auto-bridge in `plugin.ts`, which **reconstructs** each aggregation object to rename `method` → the engine's own `function` key:

```ts
aggregations: aggregations?.map((a) => ({ function: a.method, field: a.field, alias: a.alias })),
```

This is the shape the repo actually shipped until this PR — it copies exactly three keys and silently drops a fourth. Every unit test in `objectql-dataset-filter.test.ts` stubs `executeAggregate` directly (records `options.aggregations` verbatim), so it cannot see this: the strategy fix alone would have passed every one of those tests while being a complete no-op on every real deployment that boots through the default `new AnalyticsServicePlugin({ cubes })` wiring — the declared-≠-enforced shape Prime Directive #10 names, one layer below where #10413 itself was originally measured.

Fixed in `plugin.ts`: the map now forwards `filter` when present (`...(a.filter ? { filter: a.filter } : {})`), and the local `DataEngineLike` / `AnalyticsServicePluginOptions` / `AnalyticsServiceConfig` (`analytics-service.ts`) type declarations are widened in lockstep so a *custom* bridge an app author writes gets the field in its own type signature too, not just the default one. A dedicated regression pin (`execution-context-bridge.test.ts` → `plugin auto-bridge forwards aggregations[].filter (#10413 phase 2 / #10576)`) goes through the **real** `AnalyticsServicePlugin.init()` + a mocked `data` engine — not a stub `executeAggregate` — so a future regression here is caught.

### What changed

- **`packages/services/service-analytics/src/strategies/objectql-strategy.ts`** (the file surface this card names): `execute()` now reads `datasetScope` once, before both the aggregations loop and the whole-call filter block, and reuses it for both. Each measure's own `filter` (`datasetScope.measureFilters[measure]`) is lowered through the existing `filterNodeToCondition` helper (the same one Phase 1 uses for the dataset-level scope) into that measure's own `aggregations[].filter` entry. A measure with no filter, or a filter that constrains nothing (`{}`), keeps the exact `{ field, method, alias }` shape it had before — no key added, matching the engine's own "empty filter is vacuous" convention (pinned in `packages/objectql/src/engine-aggregate-filter.test.ts`) and preserving native-pushdown eligibility. `executeCrossObject`'s `aggregations` parameter type is widened to match (pure passthrough — the FK-expand base aggregate already forwards `aggregations` verbatim). `generateSql()` (the `/analytics/sql` echo) gets a new `conditionalAggregateSql` helper rendering a filtered measure as `CASE WHEN … THEN … END` (predicate, then column), mirroring `NativeSQLStrategy.CONDITIONAL_AGGREGATE_SQL`'s vocabulary — see "Bounded extension" below.
- **`packages/services/service-analytics/src/plugin.ts`** + **`analytics-service.ts`** (outside the dispatched file surface, corrected here — see below): the production auto-bridge fix described above, plus the three type-signature widenings.

### Bounded in-place extensions beyond the dispatched file surface

1. **The SQL echo** (`objectql-strategy.ts`'s `generateSql`) — same file, same defect class (execution/echo parity for measure filters), same gate family, own ablation leg (leg B below) and own pins (`[#10413 phase 2] the ObjectQL SQL echo renders the measure filter it executes`). Phase 1 already extended this same function for the dataset-level scope on the identical stated rule: *an echo that contradicts execution is worse than no echo* (#3601/#3602/#3650). Shipping the per-aggregation lowering without updating the echo would have left it UNDERSTATING what `execute()` now actually runs. One-block revert if you'd rather split it out.
2. **`plugin.ts` / `analytics-service.ts`** — not the file the dispatch named, but the production bridge the named file's fix passes through on every real deployment; see the callout above. This is not scope creep so much as the fix's own completion — the alternative was shipping a change that is correct in every unit test and inert in production, which is a worse outcome than not shipping it, because the unit tests would then read as proof it works.

### Both directions, pinned

1. **Both directions in one result** — `won_count: 8` AND `opp_count: 24` asserted together in one `toEqual` (`① both directions in ONE result`), so a fix that ANDed the measure filter into the whole-call filter instead of the one aggregation (which would make `opp_count` wrong too — 8, not 24) cannot pass.
2. An aggregation without a filter is byte-identical to before (`② an aggregation without a filter is unchanged`) — `[{ field: '*', method: 'count', alias: 'opp_count' }]`, no `filter` key.
3. Phase 1's dataset-level filter still applies and is not displaced (`③ the dataset-level filter from phase 1 still applies`) — `calls[0].options.filter` still equals `{ $and: [{ is_deleted: false }] }` exactly.
4. The native-SQL path is untouched (`④ the native-SQL path is untouched`).
5. Cross-object refusal set is **not** widened — #10759/#10861-style hazard for this *third* producer of a predicate reaching `engine.aggregate` (a per-measure filter naming a cross-object field) is filed separately as **#11461**, not fixed here (see "Out of scope" below).

### Merge semantics (read from the code, not assumed)

Same as Phase 1 — AND, never key-merge: `filter.$and = [...(Array.isArray(filter.$and) ? filter.$and : []), ...conjuncts]` (`objectql-strategy.ts`, unchanged by this PR). The per-measure addition is orthogonal to that fold entirely — it never touches the whole-call `filter`/`conjuncts`, it only adds an optional `filter` key on the aggregation object itself. Empty is absence, not `{}`: `filterNodeToCondition` returns `null` for a filter that constrains nothing, so a vacuous measure filter adds no `filter` key.

### Driver coverage — verified, not assumed

`packages/objectql/src/engine.ts`'s `hasAggregationFilter` gate (~line 11801) forces the in-memory lowering path for **every** driver whenever any aggregation carries a non-empty `filter` — an engine-level, driver-agnostic decision, not a per-driver pushdown implementation each driver could independently get wrong. Confirmed by `engine-aggregate-filter.test.ts`'s "a filtered aggregation forces the in-memory lowering even on a native-aggregate driver" pin (0 native calls, 1 `find()` call, correct filtered numbers even though the mock native driver's own `aggregate()` silently drops the filter). No driver in this codebase can silently ignore `aggregations[].filter` — the engine never asks a driver to honour it itself. (This is a *different* question from the `plugin.ts` bridge finding above — that one was about the filter never reaching `engine.aggregate` at all, not about a driver mishandling it once there.)

### Out of scope — filed, not fixed here

**#11461**: `filterMemberView`'s cross-object refusal envelope (`planCrossObject`, #10759/#10861) covers two producers of a predicate reaching `engine.aggregate` — the caller's `where` and the dataset's definition-level `filter` — but not this PR's third producer, a measure's own `filter`. A per-measure filter naming a cross-object field (e.g. `{ filter: { 'account.region': 'West' } }`) would lower onto `aggregations[].filter` unrefused and silently answer 0 rather than the loud `INVALID_FIELD`/400 the other two producers get. Widening a refusal set is a contract-behaviour change and this card was ruled a defect fix (matching how #10759 was treated as out-of-scope for Phase 1) — filed separately for triage rather than fixed here.

## Tests

All commands below ran at the final commit `0ee8782a99`, clean tree, `os-verify-lock` VERDICT lines quoted, exit codes captured before any pipe.

**Package suite** (`NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @objectstack/service-analytics exec vitest run --maxWorkers=2`): `Test Files 80 passed (80)` / `Tests 1772 passed (1772)`. `os-verify-lock: VERDICT command-exit 0`.

**Package build** (`pnpm --filter @objectstack/service-analytics build`): tsup ESM/CJS/DTS all succeed, no type errors from the widened `DataEngineLike`/`AnalyticsServicePluginOptions`/`AnalyticsServiceConfig` types. `VERDICT command-exit 0`.

**Ablation — predictions written before mutating, both legs, `src`/`dist` argued fresh (not inherited):**

`src`/`dist` resolution: both subject test files import the strategy relatively (`'../analytics-service.js'`, `'../plugin.js'`) from `src/__tests__/`. Relative specifiers are resolved by the filesystem, never through `package.json`'s `exports`/`main` (which point at `dist/` and govern only bare/self-referencing package-name imports) — and no `vitest.config.*` exists anywhere in this repo to alias otherwise. `dist/` *did* exist during this ablation (built earlier in this same session), which makes the point sharper than "no dist to resolve to": the argument is resolution-path, not artifact-absence, and the ablation runs are their own positive control regardless — see below.

- **Leg A** (remove the `execute()` per-measure lowering, `git hash-object` baseline `a65490a2b65e74722c488918f8f3d1b5680d3f57`): predicted 4 red (the plugin-bridge pin, the "doors agree" test, the "sends each filtered measure its OWN filter" test, and pin ①) — measured exactly those 4, 30 passed. Mutation confirmed on disk both directions (`grep -Fc` for the injected marker = 1, for the removed text = 0) before running; restore confirmed byte-identical (`git hash-object` matches baseline) after.
- **Leg B** (remove the `generateSql()` conditional-aggregate rendering, same baseline hash): predicted 1 red (the echo's "renders a conditional aggregate" test only — the sibling "renders no conditional wrapping for the unfiltered measure" test stays green because `opp_count` was never conditional) — measured exactly that 1, 33 passed. Mutation and restore confirmed the same way.

Both mutations used a `trap '...; git checkout HEAD -- the mutated file; ...' EXIT INT TERM` so a killed run could not leave the tree mutated.

**Zero-hit / bridge-coverage sweep** (production code only, positive control run first): `grep -rn "aggregations?\.map\|aggregations\.map" --include="*.ts" packages/ apps/` finds exactly 4 files — `plugin.ts` (fixed here) and 3 *test* files with their own local hand-rolled bridges (`cross-field-engine-fallback.test.ts`, `objectql-dataset-filter.test.ts`, `packages/runtime/src/cross-field-refusal-operand-withhold.test.ts`), none of which exercise measure-scoped filters, confirming the search term is live (non-zero, correctly explained) and that `plugin.ts` was the only *production* site reconstructing this array.

## Gates

`node scripts/pm/dispatch-gates.mjs` with **no path arguments**, final commit, clean tree — derived 6 committed path(s) vs merge base `8542bd457` (= current `origin/main`, no drift): 12 path-matched + 6 convention-triggered families (test file added/edited).

**Class #10309, as instructed**: the derivation did **not** name `check:route-envelope` or `check:dispatcher-error-vocabulary` (confirmed live again on this card). Ran both explicitly (each already chains `--self-test` internally): `check-route-envelope` — 4 Express-style response modules audited, `2 conformant, 2 ratcheted, 0 exempt` (pre-existing ratchet debt, untouched by this diff); `check-dispatcher-error-vocabulary --self-test: 8 shapes + 143 assertions OK`, main run `OK — 21 unregistered code-stamping site(s), all classified`.

All 20 gates green (`exit 0` each, verdict line quoted where the gate prints one):

- `check:changeset-gate-self-tests` — 3 self-tests, all pass
- `check:objectui-changeset` — `objectui-range --self-test: all checks passed`
- `check:published-files` — `69 publishable package(s) ... declare a files whitelist`
- `check:slot-lookup` — `ratchet holds: 107 unswept site(s) in 25 file(s), none new`
- `check:test-source-alias` — `OK — 72 packages with tests scanned`
- `check:type-source-resolution` — `OK — 77 packages with a tsconfig.json scanned`
- `check-adr-0087-registration` — `this PR adds no declared-breaking changeset`
- `check-changeset-no-major` — `This diff introduces no major bump`
- `check-ci-filter-parity` — `OK: all 89 declared cross-package glob(s) ... covered`
- `check-empty-changeset` — `No empty-frontmatter changeset introduced`
- `check-plugin-teardown-shape` — `63 Plugin implementation(s) ... 0 known-unreached`
- `check-affected-docs` — clean
- `check:query-options-erasure` — `ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new`
- `check:engine-double-contract` — `OK — 390 pinned, 133 in the DEBT ledger, 2 exempt`
- `check:cross-package-test-inputs` — `OK: 14 package(s) read outside themselves, all declared`
- `check:where-matcher` — `conformance holds: 288 matcher(s) discovered, 288 answer ... correctly or refuse it loudly`
- `check:route-envelope` — see class #10309 note above
- `check:dispatcher-error-vocabulary` — see class #10309 note above
- `check:type-check-coverage` — `OK — 65/78 workspace packages type-checked ... 13 in the DEBT ledger`
- `check:type-check-debt --re-measure` — required building the full workspace closure first (`pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 tasks, 55 cached) after an initial `PREREQUISITE NOT MET` on an unbuilt closure (not counted as measured — re-run after the build): `OK — 33 ledger entr(ies) re-measured in 353.6s, 1897 raw tsc error(s) total, none above its recorded number`. `@objectstack/plugin-auth` TEST_DEBT printed `109 recorded, tsc now reports 97 (-12)` — **not touched, `--lower` not run**, per standing instruction (#10615).

One prior gate-batch attempt hit `os-verify-lock: VERDICT queue-timeout (exit 99) · never acquired` — not folded into the pass count; re-ran and acquired on retry (all figures above are from the successful re-run).

---

_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_
