### PR TITLE
feat(service-datasource): external-datasource driver return contract fails compile-time on mis-shaped drivers (#11123 option C)

### DIFF
--- a/.changeset/datasource-driver-handle-introspection-contract.md
+++ b/.changeset/datasource-driver-handle-introspection-contract.md
@@ -1,0 +1,38 @@
+---
+"@objectstack/service-datasource": minor
+---
+
+feat(service-datasource): `DatasourceDriverHandle.introspectSchema` declares the spec introspection contract, so a mis-shaped custom driver fails to compile naming the wrong field (#11381, option C of the #11123 ruling)
+
+**BREAKING** for TypeScript hosts that build custom external-datasource
+drivers, shipped as `minor` under the repo's launch-window convention for
+breaking changes.
+
+`DatasourceDriverHandle.introspectSchema` — the seam every host-built driver
+crosses, since the framework deliberately ships no driver-by-id registry —
+was typed `Promise<unknown>`. The `isPrimary` → `primaryKey` retirement
+(#11124, shipped in 17.2.0) named the compiler as the channel that reaches
+every affected consumer, but against an `unknown` return that channel
+provably never fired: a host driver spelling the per-column primary-key flag
+`isPrimary`, or returning `{ tables }` with no `dialect`/`introspectedAt`,
+compiled clean, and the mis-shape surfaced only as a federated table whose
+records silently could not be located or updated.
+
+The member now declares `Promise<IntrospectedSchema>` — the one introspection
+contract in `packages/spec` (`contracts/schema-diff-service.ts`). A
+mis-shaped driver is refused at compile time, at the offending field:
+`Property 'primaryKey' is missing in type '…' but required in type
+'IntrospectedColumn'`, and on a fresh literal additionally `'isPrimary' does
+not exist in type 'IntrospectedColumn'`. A driver that already returns the
+spec shape — or a richer declared type extending it, the driver-sql /
+objectql pattern (table-level `primaryKeys`, per-column `maxLength`) —
+compiles unchanged.
+
+Runtime behaviour does not change. The `primaryKeyReader` compatibility belt
+in `ExternalDatasourceService` keeps absorbing the retired spelling from
+producers no compiler reaches (drivers already built against older versions,
+plain-JS drivers, casts). Removing that belt is #11123 option B — a later,
+separate step gated on this tightening being released and the retirement
+being published — and is not part of this change.
+
+<!-- adr-0087: not-required (runtime-interface-only packages/services/service-datasource/src/contracts/datasource-driver-factory.ts#DatasourceDriverHandle) the tightened member is a published runtime TypeScript interface describing a driver handle's capability surface — not a metadata surface. There is no Zod schema, no `packages/spec` declaration of the old `Promise<unknown>` signature, and no stored representation of a driver handle, so `objectstack migrate meta` has nothing to rewrite; the channel that reaches every affected consumer is the compiler, precisely and at every site. -->

--- a/packages/services/service-datasource/src/__tests__/datasource-driver-handle-contract.test.ts
+++ b/packages/services/service-datasource/src/__tests__/datasource-driver-handle-contract.test.ts
@@ -1,0 +1,199 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * DatasourceDriverHandle.introspectSchema — the return contract is the spec
+ * introspection shape, enforced by tsc (#11381, option C of the #11123
+ * ruling, recorded 2026-08-23).
+ *
+ * Until #11381 the member was typed `Promise<unknown>`, so the one channel
+ * the `isPrimary` → `primaryKey` retirement (#11124) named as its migration
+ * path — the compiler, "precisely and at every site" — provably never fired
+ * for the seam's OPEN producer population: host-built drivers
+ * (`datasource-driver-factory.ts` deliberately ships no driver registry). A
+ * driver spelling the primary-key flag wrong compiled clean and produced a
+ * federated table whose records silently could not be located or updated.
+ *
+ * Every mis-shape pin below is resolved by tsc, not by vitest: reverting the
+ * tightening (`introspectSchema?(): Promise<IntrospectedSchema>` back to
+ * `Promise<unknown>`) makes each `@ts-expect-error` directive unused, and an
+ * unused directive is itself an error, so
+ * `pnpm --filter @objectstack/service-datasource typecheck` goes red — and
+ * the first pin asserts the member's exact type, which reds directly on the
+ * same revert. This package carries no test-typecheck-debt ledger entry, so
+ * zero errors is the measured baseline these pins move away from. The
+ * `expect()` calls only give the assertions a home vitest will run.
+ *
+ * What these pins deliberately do NOT claim: any runtime behaviour change.
+ * The `primaryKeyReader` compatibility belt in
+ * `external-datasource-service.ts` still absorbs the retired spelling from
+ * producers no compiler reaches (already-built drivers, plain JS, casts);
+ * its own suite pins that. Removing the belt is #11123 option B, gated on
+ * this tightening being released AND the retirement being published.
+ */
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { DatasourceDriverHandle } from '../contracts/datasource-driver-factory.js';
+import type {
+  IntrospectedColumn,
+  IntrospectedSchema,
+  IntrospectedTable,
+} from '@objectstack/spec/contracts';
+
+/** A well-formed schema in the spec spelling, reused by the green cases. */
+function specShapedSchema(): IntrospectedSchema {
+  return {
+    tables: {
+      customers: {
+        name: 'customers',
+        columns: [
+          { name: 'id', type: 'varchar', nullable: false, primaryKey: true },
+          { name: 'email', type: 'varchar', nullable: true, primaryKey: false },
+        ],
+      },
+    },
+    dialect: 'sqlite',
+    introspectedAt: '2026-08-23T00:00:00.000Z',
+  };
+}
+
+describe('DatasourceDriverHandle.introspectSchema return contract (#11381)', () => {
+  it('declares exactly the spec introspection shape — not unknown', () => {
+    // The strongest pin in the file: this line reads the member's type off the
+    // CONTRACT and reds directly if the tightening is reverted to
+    // `Promise<unknown>` (or widened to any other spelling), independently of
+    // every `@ts-expect-error` below.
+    expectTypeOf<
+      ReturnType<NonNullable<DatasourceDriverHandle['introspectSchema']>>
+    >().toEqualTypeOf<Promise<IntrospectedSchema>>();
+  });
+
+  it('accepts a correctly-shaped driver, written in the spec spelling', async () => {
+    // A host-built handle authored fresh against this version: per-column
+    // `primaryKey`, schema-level `dialect` + `introspectedAt`. This literal
+    // failing to compile is the regression.
+    const handle: DatasourceDriverHandle = {
+      introspectSchema: async () => specShapedSchema(),
+    };
+    const schema = await handle.introspectSchema!();
+    expect(schema.tables.customers.columns[0].primaryKey).toBe(true);
+  });
+
+  it('gives the consumer a typed result — the probe read is no longer unknown', async () => {
+    const handle: DatasourceDriverHandle = {
+      introspectSchema: async () => specShapedSchema(),
+    };
+    // Before #11381 this expression was `unknown` and every consumer either
+    // cast or re-narrowed; now `dialect` reads straight off the declared type.
+    expectTypeOf(handle.introspectSchema!()).resolves.toEqualTypeOf<IntrospectedSchema>();
+    expect((await handle.introspectSchema!()).dialect).toBe('sqlite');
+  });
+
+  it('still accepts a RICHER driver whose declared type extends the spec contract', async () => {
+    // The in-tree pattern: driver-sql / objectql declare their introspection
+    // types as EXTENSIONS of the spec contract (table-level `primaryKeys`,
+    // per-column `maxLength`, …). Return-type covariance admits those extras
+    // on any non-literal value, so such a driver needs no edit — and the
+    // `primaryKeyReader` belt keeps reading `table.primaryKeys` as the one
+    // carrier of composite-key ORDER.
+    interface RicherColumn extends IntrospectedColumn {
+      maxLength?: number | string;
+    }
+    interface RicherTable extends IntrospectedTable {
+      columns: RicherColumn[];
+      primaryKeys: string[];
+    }
+    interface RicherSchema extends IntrospectedSchema {
+      tables: Record<string, RicherTable>;
+    }
+    const richer = async (): Promise<RicherSchema> => ({
+      tables: {
+        orders: {
+          name: 'orders',
+          columns: [
+            { name: 'order_id', type: 'varchar', nullable: false, primaryKey: true, maxLength: 36 },
+            { name: 'line_no', type: 'integer', nullable: false, primaryKey: true },
+          ],
+          primaryKeys: ['order_id', 'line_no'],
+        },
+      },
+      dialect: 'postgres',
+      introspectedAt: '2026-08-23T00:00:00.000Z',
+    });
+    const handle: DatasourceDriverHandle = { introspectSchema: richer };
+    const schema = await handle.introspectSchema!();
+    expect(schema.tables.orders.columns).toHaveLength(2);
+  });
+
+  it('refuses the retired `isPrimary` spelling, naming the field', () => {
+    // The founding defect (#10676 → #11001 → #11123): a driver spelling the
+    // per-column flag `isPrimary`. tsc's rejection names the field on both
+    // instruments — the missing required key ("Property 'primaryKey' is
+    // missing in type … but required in type 'IntrospectedColumn'") and, on a
+    // fresh literal, the excess key ("'isPrimary' does not exist in type
+    // 'IntrospectedColumn'").
+    const misSpelledColumn: IntrospectedColumn = {
+      name: 'id',
+      type: 'varchar',
+      nullable: false,
+      // @ts-expect-error - the spec spelling is `primaryKey`; `isPrimary` does not exist in type 'IntrospectedColumn'
+      isPrimary: true,
+    };
+    expect(misSpelledColumn).toBeTruthy();
+
+    // The same mistake a whole driver up: pre-#11381 this handle compiled
+    // clean and lost the remote key at runtime; now it does not compile.
+    const legacyDriver = async () => ({
+      tables: {
+        customers: {
+          name: 'customers',
+          columns: [{ name: 'id', type: 'varchar', nullable: false, isPrimary: true }],
+        },
+      },
+      dialect: 'sqlite',
+      introspectedAt: '2026-08-23T00:00:00.000Z',
+    });
+    // @ts-expect-error - a driver whose columns spell the flag `isPrimary` no longer satisfies the handle
+    const misSpelledHandle: DatasourceDriverHandle = { introspectSchema: legacyDriver };
+    expect(misSpelledHandle).toBeTruthy();
+  });
+
+  it('refuses the `{ tables }`-only schema the driver actually shipped (#10998)', () => {
+    // Measured on the pre-retirement driver: `Object.keys()` of the schema
+    // was `["tables"]` — no `dialect`, no `introspectedAt` — so type mapping
+    // ran dialect-blind across the whole federation path. tsc now names both
+    // missing fields.
+    const bareTables = async () => ({
+      tables: {
+        customers: {
+          name: 'customers',
+          columns: [{ name: 'id', type: 'varchar', nullable: false, primaryKey: true }],
+        },
+      },
+    });
+    // @ts-expect-error - `dialect` and `introspectedAt` are required by the spec introspection contract
+    const tablesOnlyHandle: DatasourceDriverHandle = { introspectSchema: bareTables };
+    expect(tablesOnlyHandle).toBeTruthy();
+  });
+
+  it('refuses a table-level `primaryKeys` list written fresh against the BARE spec shape', () => {
+    // On the spec contract the primary-key fact is per-column. A table-level
+    // list is a driver-sql EXTENSION — legal on a declared extending type
+    // (previous green case), refused as an excess key on a fresh literal of
+    // the bare contract, so an author who reaches for the extension is told
+    // to declare it rather than having half a spelling absorbed silently.
+    const listOnlyTable: IntrospectedTable = {
+      name: 'customers',
+      columns: [{ name: 'id', type: 'varchar', nullable: false, primaryKey: false }],
+      // @ts-expect-error - `primaryKeys` does not exist in type 'IntrospectedTable'; declare an extending type or spell the fact per-column
+      primaryKeys: ['id'],
+    };
+    expect(listOnlyTable).toBeTruthy();
+  });
+
+  it('refuses a driver that only promises `unknown` — the pre-#11381 signature itself', () => {
+    const opaque = async (): Promise<unknown> => JSON.parse('{}');
+    // @ts-expect-error - `Promise<unknown>` is exactly the contract this member no longer has
+    const opaqueHandle: DatasourceDriverHandle = { introspectSchema: opaque };
+    expect(opaqueHandle).toBeTruthy();
+  });
+});

--- a/packages/services/service-datasource/src/contracts/datasource-driver-factory.ts
+++ b/packages/services/service-datasource/src/contracts/datasource-driver-factory.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+
 /**
  * IDatasourceDriverFactory — host-provided capability that builds a live driver
  * from a connection spec (ADR-0015 Addendum §3.5).
@@ -76,6 +78,10 @@ export type DatasourceDriverOwnership = 'factory' | 'host';
  * A live (or lazily-connecting) driver handle. Intentionally structural and
  * fully optional so any concrete driver satisfies it — the admin service uses
  * whatever capabilities are present and skips the rest.
+ *
+ * "Fully optional" is about PRESENCE, not about shape: a member the driver
+ * does expose must honour that member's declared contract. The one place the
+ * distinction has already cost data is `introspectSchema` — see its own note.
  */
 export interface DatasourceDriverHandle {
   /** Open the connection / pool. */
@@ -86,8 +92,38 @@ export interface DatasourceDriverHandle {
   ownership?: DatasourceDriverOwnership;
   /** Cheap liveness round-trip (preferred for probes). */
   ping?(): Promise<unknown>;
-  /** Introspect the live schema (fallback probe when `ping` is absent). */
-  introspectSchema?(): Promise<unknown>;
+  /**
+   * Introspect the live schema (fallback probe when `ping` is absent, and the
+   * read the external-datasource federation path is built on).
+   *
+   * The return value is CONTRACTUAL: `packages/spec`'s one introspection
+   * shape — {@link IntrospectedSchema}, whose columns spell primary-key
+   * membership `primaryKey` and whose schema carries `dialect` and
+   * `introspectedAt`. This member was typed `Promise<unknown>` until #11381
+   * (option C of the #11123 ruling, 2026-08-23), which left the seam's OPEN
+   * producer population — host-built drivers, per this file's own header —
+   * unreachable by any compiler: a driver spelling the flag `isPrimary`, or
+   * emitting `{ tables }` alone, compiled clean, and the mis-shape surfaced
+   * only as a federated table whose records silently could not be located or
+   * updated. Typed against the spec contract, `tsc` now refuses a mis-shaped
+   * driver at the offending field (`Property 'primaryKey' is missing …` /
+   * `'isPrimary' does not exist in type 'IntrospectedColumn'`).
+   *
+   * Extra facts a richer driver carries stay legal — driver-sql's table-level
+   * `primaryKeys`, `foreignKeys`, per-column `maxLength` ride on declared
+   * types that EXTEND the spec contract, and assignability admits them on any
+   * non-literal value. What is refused is a WRONG spelling of a declared key,
+   * which is the defect class this seam has actually shipped.
+   *
+   * Runtime is deliberately untouched: the `primaryKeyReader` compatibility
+   * belt in `external-datasource-service.ts` keeps absorbing the retired
+   * `isPrimary` spelling from already-built drivers (plain-JS drivers and
+   * stale builds are reached by no compiler). Removing that belt is #11123
+   * option B — a later, separate step gated on this tightening being released
+   * AND the old spelling's retirement being published; it is not licensed by
+   * this type.
+   */
+  introspectSchema?(): Promise<IntrospectedSchema>;
   /** Liveness check on the underlying engine driver (probe fallback). */
   checkHealth?(): Promise<boolean>;
   /** Driver-reported server version, when available. */

--- a/packages/services/service-datasource/src/external-datasource-service.ts
+++ b/packages/services/service-datasource/src/external-datasource-service.ts
@@ -171,15 +171,21 @@ const BUILTIN_COLUMNS = new Set(['id', 'created_at', 'updated_at']);
  *  - It is still not dead code, because the producer population here is open
  *    by design. `contracts/datasource-driver-factory.ts` says the framework
  *    "ships no universal driver-by-id registry" — concrete drivers are built
- *    by the HOST — and types the handle as `introspectSchema?(): Promise<unknown>`.
- *    The retirement shipped as a BREAKING change whose stated migration
- *    channel is the compiler, "precisely and at every site"; against an
- *    `unknown` result that channel never fires, so a host-built driver still
- *    emitting the old spelling is reached by nothing and would silently lose
- *    its key here.
- *  - The belt's clock has not run either: the union (#11001) and the
- *    retirement (#11124) are BOTH still unconsumed changesets at `17.1.0`, so
- *    no released version has ever emitted `primaryKey` from this driver.
+ *    by the HOST. Since #11381 (option C of the #11123 ruling) the handle
+ *    types `introspectSchema?(): Promise<IntrospectedSchema>` — the spec
+ *    contract — so the retirement's stated migration channel, the compiler,
+ *    finally reaches a host-built TypeScript driver "precisely and at every
+ *    site" the moment it RECOMPILES against this version. Whom no compiler
+ *    reaches, ever: drivers already built against older versions, plain-JS
+ *    drivers, and casts. For that population the old spelling still arrives
+ *    here at runtime, and this belt is what absorbs it.
+ *  - The belt's clock HAS started: the union (#11001) and the retirement
+ *    (#11124) were consumed into `17.2.0` (version-packages commit
+ *    `e7d2cc67fd`, 2026-08-23), so the "unconsumed changesets at 17.1.0"
+ *    argument this bullet used to carry is expired. Whether option B's gate —
+ *    the retirement actually PUBLISHED — is met is a release-record question
+ *    (npm, not this tree); B also waits on the #11381 tightening being
+ *    released. Re-judge both there before touching the arm.
  *
  * Dropping the arm is therefore a NARROWING OF ACCEPTED INPUT rather than a
  * dead-code deletion, and wants the contract-review gate. Its only exercise is


### PR DESCRIPTION
Fixes #11381

Implements **option C of the #11123 maintainer ruling** (recorded 2026-08-23, 「10950 不考虑存量，其他接受你的建议」= A now + C as its own card): the custom external-datasource driver seam gets a declared return-shape contract, so a mis-written driver **fails to compile, naming the wrong field**, instead of being absorbed silently.

⛔ **This PR stays DRAFT — Clause-② contract-review tier.** The card carries `needs:contract-review`; the landing decision is the PM review's, not this seat's.

## Seam map (measured at merge base `b6d9432d1a`, not assumed)

The dispatch expected the seam "around `packages/spec` and/or the objectql driver interface"; measurement places it where #11123's recorded analysis names it:

| surface | role | state before this PR |
|---|---|---|
| `packages/services/service-datasource/src/contracts/datasource-driver-factory.ts` → `DatasourceDriverHandle.introspectSchema` | **THE seam** — the only typed crossing every host-built driver makes (the framework deliberately ships no driver-by-id registry) | `Promise<unknown>` — the compiler channel the #11124 retirement named as its migration path provably never fired here |
| `packages/spec/src/contracts/schema-diff-service.ts` → `IntrospectedSchema`/`IntrospectedTable`/`IntrospectedColumn` | the one introspection contract (per-column `primaryKey`, `dialect`, `introspectedAt`) | already truthful after #11270 (`indexes` optional, `defaultValue: unknown`); **not edited** |
| `packages/services/service-datasource/src/external-datasource-service.ts` → `primaryKeyReader` | the PR #11001 compatibility shim (three-signal union read) | **code untouched** — docblock truth update only, see below |
| `packages/objectql/src/engine.ts` → `introspectDatasource(): Promise<unknown>`; `packages/spec/src/contracts/data-driver.ts` → `IDataDriver` (declares no `introspectSchema`) | adjacent consumer-side facade / the engine-registration path | **deliberately not widened into** — see "Cascade boundary" |

In-tree fallout of the tightening: **zero implementers move.** Neither in-tree factory (`default-datasource-driver-factory`, `prebuilt-driver-factory`) nor the runtime Turso factory puts `introspectSchema` on its handle (they use the `driver` escape hatch + health probes); the consumer sites (`plugin.ts`, `datasource-admin-plugin.ts` probe) either already type the result as the spec `IntrospectedSchema` or discard it. `SqlDriver`-family drivers declare return types that **extend** the spec contract (post-#11124/#11270), so they satisfy the tightened member by covariance.

## What tightened

- `introspectSchema?(): Promise<unknown>` → `introspectSchema?(): Promise<IntrospectedSchema>` (spec contract, imported from `@objectstack/spec/contracts`), with a docblock recording the why, the named-field failure mode, the legality of richer extending types, and the shim's continued ownership of runtime.
- The `DatasourceDriverHandle` interface docblock now says what "fully optional" means: optional in **presence**, contractual in **shape**.

## Shim untouched — declaration

The PR #11001 `primaryKeyReader` union read is **byte-identical**: all three arms (`col.primaryKey` / `col.isPrimary` / `table.primaryKeys`) intact, its tests untouched and green (the staged-disagreement pair included). Per the ruling's ordering constraint, the tightening and the shim **coexist**: new/updated TS drivers are told by the compiler; already-built, plain-JS, or cast drivers are still absorbed at runtime. Option B (shim removal) remains a later, separate, gated step — this diff neither performs nor licenses it.

Two docblock bullets inside the shim's expiry-condition record are updated, both named here because that naming is the condition for taking them in place:

1. **Falsified by this diff**: the bullet stating the handle "types the handle as `introspectSchema?(): Promise<unknown>`" and that the compiler channel "never fires". Now records the tightened type and the exact population the compiler still cannot reach (stale builds, plain JS, casts) — the belt's remaining constituency.
2. **Falsified by the release record** (same defect class, mechanical, evidence pinned): "BOTH still unconsumed changesets at `17.1.0`" — the #11001 and #11124 changesets were consumed into **17.2.0** (version-packages commit `e7d2cc67fd`, 2026-08-23; `driver-sql/CHANGELOG.md` carries the retirement entry). The bullet now says the clock HAS started and that option B's "retirement published" gate is a release-record question (npm), not a tree measurement. ⚠️ PM note: with 17.2.0 versioned, B's second gate condition may already be met once the publish is confirmed — that re-judgment is the ruling's to make, flagged here only so it is not lost.

## Compile-fail demonstrations (real `tsc` output, measured on `b6583cd03e`)

New type-level suite `src/__tests__/datasource-driver-handle-contract.test.ts`, in the sibling-contract idiom (`data-driver.test.ts`): pins resolved by `tsc --noEmit` (the package's `typecheck`, which compiles `__tests__` — no test exclusion, no test-typecheck-debt entry, so zero errors is the measured baseline), `@ts-expect-error` directives with the expected text, `expectTypeOf` identity pin on the member itself.

With the directives stripped (mutation proven on disk: 7→0 occurrences; restore proven byte-identical by `git hash-object`), `tsc` names the field in every mis-shape the card/#11123 name:

- retired spelling, fresh literal: `error TS2353: … 'isPrimary' does not exist in type 'IntrospectedColumn'`
- retired spelling, whole driver: elaboration terminates at `Property 'primaryKey' is missing in type '{ name: string; type: string; nullable: boolean; isPrimary: boolean; }' but required in type 'IntrospectedColumn'`
- the `{ tables }`-only schema the pre-#11124 driver actually shipped (#10998): `… is missing the following properties from type 'IntrospectedSchema': dialect, introspectedAt`
- table-level `primaryKeys` written fresh against the bare spec shape: `error TS2353: … 'primaryKeys' does not exist in type 'IntrospectedTable'` (legal on a declared extending type — the green case beside it pins that)
- the pre-#11381 signature itself: `Type 'unknown' is not assignable to type 'IntrospectedSchema'`

**Reverse verification** (both legs from the committed state; predicted direction written before running, observed exactly): with the contract reverted to the merge-base `Promise<unknown>` (mutation proven on disk: `Promise<unknown>` 1 hit / tightened 0) and the new tests kept, `typecheck` reds with **3× TS2578 unused-directive** on the three handle-level pins — i.e. the mis-shaped drivers *compile* pre-patch, which is the defect — plus 5 consumer-side errors (`expectTypeOf` mismatches, property access on `unknown`). The two field-level pins stay consumed on both legs, as designed: they pin the spec contract itself, which #11270 already ships. Restore proven byte-identical (`git hash-object` = committed blob) both times.

## Cascade boundary (stopped, not widened)

Tightening this one member forces **no** public-surface change elsewhere — the diff stays inside `@objectstack/service-datasource`. Two adjacent `unknown` seams were found and deliberately left: `IDataEngine.introspectDatasource(): Promise<unknown>` (objectql consumer facade) and the `handle.driver: unknown` escape-hatch path into `registerDriver()`, where `IDataDriver` declares no `introspectSchema` at all — a driver entering the engine that way is still unreached by any compiler. Filed as a follow-up finding (see issue comment / report) rather than smuggled into this diff.

## Changeset level — reasoning

`minor` for `@objectstack/service-datasource`, with an explicit **BREAKING** declaration in the body. This is the repo's *documented, gate-enforced* convention, not a downgrade: `scripts/check-changeset-no-major.mjs`'s own header — "During the launch window we ship breaking changes as `minor`" — and the direct precedent, the #11124 retirement changeset ("**BREAKING** … shipped as `minor` under the repo's launch-window convention"). The dispatch's major-vs-gate conflict therefore does not arise: the convention itself dictates `minor`. ADR-0087 disposition: `not-required (runtime-interface-only …#DatasourceDriverHandle)` — verified mechanically by `check-adr-0087-registration.mjs` (green, notice emitted): a published runtime TS interface, no Zod schema, no stored representation, nothing for `objectstack migrate meta` to rewrite; the channel that reaches every affected consumer is the compiler.

## Verification summary — all on final commit `b6583cd03e`, clean tree; exit codes captured before any pipe; verdicts are the gates' own printed lines

- Build: deps closure `pnpm --workspace-concurrency=2 --filter '@objectstack/service-datasource^...' build` → `VERDICT command-exit 0`; full workspace closure `turbo run build --filter='./packages/*' --filter='./packages/*/*' --concurrency=2` → `Tasks: 70 successful, 70 total`.
- `pnpm --filter @objectstack/service-datasource typecheck` → exit 0 (script name echoed — not a zero-match no-op); `… test -- --maxWorkers=2` → `Test Files 27 passed (27)` · `Tests 585 passed (585)`.
- Gate union derived on the final commit with **no hand-supplied paths**: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (repo assertion held; 4 paths vs merge base `b6d9432d1`; 12 path-matched + 6 convention-triggered). All 18 ran locally, **all green, no declared narrowing**: `check:changeset-gate-self-tests` (116 assertions), `check:objectui-changeset`, `check-adr-0087-registration` (exemption notice emitted), `check-changeset-no-major` (`✓ This diff introduces no major bump.`), `check-empty-changeset` (1 declaring changeset), `check:published-files` (69 publishable), `check:slot-lookup` (`107 unswept … none new`), `check:test-source-alias` (72 packages), `check:type-source-resolution` (77 packages), `check-ci-filter-parity` (89 globs covered), `check-plugin-teardown-shape` (63 plugins), `check-affected-docs` (exit 0), `check:query-options-erasure` (`67 unswept … none new`), `check:type-check-coverage` (65/78), `check:type-check-debt --re-measure` (`33 ledger entr(ies) re-measured … none above its recorded number`), `check:engine-double-contract` (`390 pinned`), `check:cross-package-test-inputs` (14 declared), `check:where-matcher` (`288 matcher(s) … correctly`). Plus `check:nul-bytes` (`6443 text file(s) … no raw ASCII control bytes`).
- No runtime behaviour change is claimed, so no runtime ablation beyond the type-level legs above: the executable diff is one type annotation; the mutation whose removal reddens the suite IS the reverse-verification leg, and it was run in both directions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_