### PR TITLE
fix(console): npm description no longer names the fabricated @objectstack/framework (#11261)

### DIFF
--- a/.changeset/console-description-drop-fabricated-framework.md
+++ b/.changeset/console-description-drop-fabricated-framework.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/console': patch
+---
+
+npm `description` no longer names the fabricated `@objectstack/framework`
+
+`@objectstack/console`'s manifest `description` is what npm renders on the
+package page, so it was the most-read of the three sites that named a package
+nobody can install. The earlier pass corrected the other two — this package's
+README and `packages/cli/src/utils/console.ts` — but left the manifest alone
+because a published manifest was outside that change's declared file surface.
+This is the third and last live site.
+
+The correction is the same one the README took: the mechanism is real and only
+the name was wrong. There is no umbrella `@objectstack/framework` package (404
+on the public registry, and fabricated — nothing in this tree presents it as
+enterprise or private, it is presented as the *default public* install). What
+actually pins the two together is that `@objectstack/cli` declares
+`@objectstack/console` as a dependency and both ship at one version from the
+Changesets `fixed` group.
+
+```diff
+-Prebuilt Console SPA pinned to this @objectstack/framework release. Source of truth: …
++Prebuilt Console SPA pinned to this framework release, installed as a dependency of @objectstack/cli. Source of truth: …
+```
+
+"framework release" survives as the common noun the README already uses; what
+is dropped is the `@objectstack/` scope that turned it into a package name. The
+`@object-ui/console` source-of-truth half is unchanged — it was accurate.
+
+Text only: no code, no exports, no behaviour change. It carries a changeset
+rather than the publish-nothing exemption because the manifest `description`
+ships inside the npm tarball and is a published artifact.

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@objectstack/console",
   "version": "17.2.0",
-  "description": "Prebuilt Console SPA pinned to this @objectstack/framework release. Source of truth: @object-ui/console (https://github.com/objectstack-ai/objectui).",
+  "description": "Prebuilt Console SPA pinned to this framework release, installed as a dependency of @objectstack/cli. Source of truth: @object-ui/console (https://github.com/objectstack-ai/objectui).",
   "license": "Apache-2.0",
   "homepage": "https://github.com/objectstack-ai/objectstack/tree/main/packages/console",
   "repository": {


### PR DESCRIPTION
Fixes #11261

`@objectstack/console`'s manifest `description` is what npm renders on the package page, which made it the most-read of the three sites naming a package nobody can install. The earlier pass (#10921) corrected the other two — this package's README and `packages/cli/src/utils/console.ts` — and deliberately left the manifest alone, because a published manifest sat outside that card's declared file surface. This is the third and last live site.

```diff
-"Prebuilt Console SPA pinned to this @objectstack/framework release. Source of truth: @object-ui/console (…)"
+"Prebuilt Console SPA pinned to this framework release, installed as a dependency of @objectstack/cli. Source of truth: @object-ui/console (…)"
```

The mechanism was real and only the name was wrong, so the correction states the true thing rather than deleting the sentence. Both halves re-verified against `origin/main` before writing:

- `packages/cli/package.json` declares `"@objectstack/console": "workspace:*"` — the dependency relationship is real.
- `.changeset/config.json`'s `fixed` group lists both `@objectstack/cli` and `@objectstack/console` — the one-version claim is real.
- `"framework release"` survives as the common noun `packages/console/README.md` already uses ("version-locked to the framework release that ships it"). What is dropped is only the `@objectstack/` scope that turned a true common noun into a fabricated package name.
- The `@object-ui/console` source-of-truth half is unchanged — it was accurate, and rewriting the whole sentence around the one broken word was not needed.

## Positive control: is there a fourth site?

`git grep` over `origin/main` for `@objectstack/framework`, then widened to the case-insensitive `objectstack[/-]framework`. Outside CHANGELOGs the sweep returns three hits, and after this diff **zero live sites remain**:

| Site | Disposition |
|---|---|
| `packages/console/package.json:4` | **This diff.** The last live site. |
| `.changeset/out-of-repo-package-names.md` | Legitimate — that is the earlier pass's own changeset, which names the fabricated package in order to record that it is fabricated. |
| `scripts/check-published-readme-exports.mjs:857` | Legitimate by construction — a header comment enumerating the out-of-repo `@objectstack/` names measured under the wider fence. The file itself calls it "the umbrella install name" in a passage explaining why prose may name a package this repo does not build. |
| `packages/*/CHANGELOG.md` (9 files) | Immutable published release history, generated by Changesets. Not hand-edited. |

No fourth live site exists, so this PR is not widened.

## Changeset: REQUIRED — decided on the rule, not by habit

`scripts/pr-labels.mjs` states the exemption's own test: "`skip-changeset` is the exemption for a PR that **publishes nothing**". This diff publishes something — the manifest `description` is packed into the npm tarball and is exactly what renders on the package page for `@objectstack/console`. It therefore fails that test, and **no `skip-changeset` label is applied**. `.changeset/console-description-drop-fabricated-framework.md` carries a `patch` bump for `@objectstack/console` only, matching the earlier pass's precedent. It declares no `major`/breaking bump, so no ADR-0087 disposition marker is required (`check-adr-0087-registration` confirms: "this PR adds no declared-breaking changeset").

## Verification

Gate set derived, not recalled: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (re-derived after the commit; the set was identical both times). All 15 derived families plus `check:nul-bytes` were run at **`c7d37014`**, the head of this branch, and all are green.

`check:published-files` — named on the card as the acceptance check, because editing a published manifest widens its surface. Its own verdict lines:

```
✓ check:published-files --self-test — 21 pattern case(s), 12 classification case(s) and 4 population-declaration case(s) over 11 live workspace glob(s).
✓ check:published-files — 69 publishable package(s) of 78 workspace member(s) declare a `files` whitelist that covers every entry point plus CHANGELOG.md and admits no test, test-harness config or build script; 1 publish more than dist/ + README.md + CHANGELOG.md, each with a registered reason.
```

Worth recording for the next author: the gate's five invariants (DECLARED, COMPLETE, SUFFICIENT, MINIMAL, REGISTERED) are all about the `files` whitelist, so a `description` edit moves none of them. That is a measured result, not an assumption — the gate was run rather than reasoned about.

Other verdict lines:

```
✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.
✓ This diff introduces no `major` bump.
✓ No empty-frontmatter changeset introduced by this diff (0 declaring changeset(s) added).
✓ 8 published-manifest declaration(s) covered by pnpm-workspace.yaml overrides all resolve to their override targets.
✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new, and every file in the population parsed.
✓ check:plugin-teardown-shape: 63 Plugin implementation(s) across 4564 source(s) under packages/**; 0 known-unreached, baseline fully burned down.
check-nul-bytes: OK (scanned 6456 text file(s); no raw ASCII control bytes).
```

No `pnpm test` / `pnpm typecheck` was run for the affected package because `packages/console` declares neither — it is a prebuilt-`dist/` package whose only script is `prepublishOnly`. The diff contains no code.

**`pnpm lint` narrowing, declared with its three pieces of evidence.** The population is read from eslint's own config rather than guessed: `npx eslint --no-inline-config --format json` on both changed paths reports `"File ignored because no matching configuration was supplied."` for each, with `errorCount: 0`. Every `files` glob in `eslint.config.mjs` is restricted to `{ts,tsx,mts,cts,js,jsx,mjs,cjs}`; this diff touches one `.json` and one `.md`. And the invariance half holds mechanically: the config never enables type-aware linting for any file (no `parserOptions.project`, no typed rules — the config documents this at line 328, measured there with a positive control), so this diff cannot move any untouched file's verdict. The intersection of the diff with eslint's population is empty, so this is a measurement rather than a skipped run.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_