### PR TITLE
test(core,runtime): authorization ObjectQL doubles enforce `limit`

### DIFF
--- a/packages/core/src/security/admin-standing-surface.test.ts
+++ b/packages/core/src/security/admin-standing-surface.test.ts
@@ -79,7 +79,7 @@ function makeRecordingQl(tables: Record<string, Array<Record<string, unknown>>>,
     key in row ? row[key] : row[camelOf(key)];
 
   return {
-    async find(object: string, opts: { where?: Record<string, unknown> } = {}) {
+    async find(object: string, opts: { where?: Record<string, unknown>; limit?: number } = {}) {
       if (!seen.has(object)) seen.set(object, new Set<string>());
       const where = opts?.where ?? {};
       for (const key of Object.keys(where)) {
@@ -96,7 +96,12 @@ function makeRecordingQl(tables: Record<string, Array<Record<string, unknown>>>,
           return raw(row, key) === cond;
         }),
       );
-      return rows.map(
+      // [#10978] Enforce the caller's bound — presence, not truthiness, so
+      // `limit: 0` returns nothing rather than everything. Bounding BEFORE the
+      // Proxy wrap keeps the column-observation ledger honest: a row the real
+      // read would never have returned must not record column reads either.
+      const page = typeof opts?.limit === 'number' ? rows.slice(0, opts.limit) : rows;
+      return page.map(
         (row) =>
           new Proxy(row, {
             get(target, prop, receiver) {

--- a/packages/core/src/security/api-key.test.ts
+++ b/packages/core/src/security/api-key.test.ts
@@ -13,13 +13,20 @@ import {
   effectiveTenancyPosture,
 } from './api-key.js';
 
-/** In-memory sys_api_key store exposing the `find` shape the verifier uses. */
+/**
+ * In-memory sys_api_key store exposing the `find` shape the verifier uses.
+ *
+ * [#10978] `limit` is ENFORCED — presence, not truthiness, so `limit: 0` returns
+ * nothing rather than everything. A double that drops the bound makes any limit
+ * change on this read green by construction; the verifier reads with `limit: 1`.
+ */
 function makeQl(rows: any[]) {
   return {
     find: async (object: string, opts: any) => {
       if (object !== 'sys_api_key') return [];
       const where = opts?.where ?? {};
-      return rows.filter((r) => Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`); return r[k] === v; }));
+      const matched = rows.filter((r) => Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`); return r[k] === v; }));
+      return typeof opts?.limit === 'number' ? matched.slice(0, opts.limit) : matched;
     },
   };
 }

--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -13,17 +13,44 @@ import type { AuthzPosture } from '@objectstack/spec/security';
  * sys_user_position / sys_position_permission_set / platform_admin / ai_seat).
  */
 
-// Minimal in-memory ObjectQL: find(object, { where }) with `===` + `$in` match.
+// Minimal in-memory ObjectQL: find(object, { where, limit }) with `===` + `$in`
+// match, and the caller's `limit` ENFORCED.
+//
+// [#10978] The bound is not decoration. A double that matches `where` and hands
+// back every row it matched cannot tell a read bounded at 200 from the same read
+// bounded at 1000, or from one carrying no bound at all — so raising a limit,
+// lowering it, or folding two reads that carry different ones is green BY
+// CONSTRUCTION, and the production symptom is a silently truncated result set
+// rather than an error. On this file's path that truncation is an authorization
+// input: `resolveUserAuthzGrants` reads `sys_member` twice, `{user_id}` at 200
+// and `{organization_id}` at 1000, and the obvious "same object, fold them"
+// cleanup silently caps the fellow-org peer list (`org_user_ids`, an RLS input)
+// at 200 for any organization with more members.
+//
+// PRESENCE, not truthiness — `limit: 0` means "return no records" and `0` is
+// falsy, so `opts.limit ? …` would answer a request for NOTHING with the WHOLE
+// table. That is a measured door in this repo, not a hypothetical: see the
+// `query.limit !== undefined` comment in `driver-memory`'s `memory-driver.ts`.
+// Bounding AFTER the filter matches the real read path (filter → sort → offset →
+// limit); these doubles implement no ordering, and no read on this path asks for
+// one.
+function bounded<T>(rows: T[], opts: any): T[] {
+  return typeof opts?.limit === 'number' ? rows.slice(0, opts.limit) : rows;
+}
+
 function makeQl(tables: Record<string, any[]>) {
   return {
     async find(object: string, opts: any) {
       const rows = tables[object] ?? [];
       const where = opts?.where ?? {};
-      return rows.filter((r) =>
-        Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`); 
-          if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(r[k]);
-          return r[k] === v;
-        }),
+      return bounded(
+        rows.filter((r) =>
+          Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+            if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(r[k]);
+            return r[k] === v;
+          }),
+        ),
+        opts,
       );
     },
   };
@@ -123,11 +150,14 @@ function makeCountingQl(tables: Record<string, any[]>) {
       counts[object] = (counts[object] ?? 0) + 1;
       const rows = tables[object] ?? [];
       const where = opts?.where ?? {};
-      return rows.filter((r) =>
-        Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`); 
-          if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(r[k]);
-          return r[k] === v;
-        }),
+      return bounded(
+        rows.filter((r) =>
+          Object.entries(where).every(([k, v]) => { if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+            if (v && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(r[k]);
+            return r[k] === v;
+          }),
+        ),
+        opts,
       );
     },
   };
@@ -1137,5 +1167,60 @@ describe('[#8613] the `active` flag on the grant catalogues (ADR-0049)', () => {
     const grants = await resolveUserAuthzGrants(makeQl(withActive(false)), 'u1');
     expect(grants.permissions).not.toContain('contributor_ps');
     expect(grants.positions).not.toContain('contributor');
+  });
+});
+
+/**
+ * [#10978] The instrument's own contract.
+ *
+ * Every assertion in this file stands on `makeQl`, and a double that drops
+ * `opts.limit` cannot fail a limit regression: raising a bound, lowering it, or
+ * folding two reads that carry different ones all produce identical rows. These
+ * cases pin the bound itself, so the blindness cannot come back unnoticed —
+ * without them the `slice` is unverified and deleting it fails nothing.
+ *
+ * The measured population when this landed: 49 limit-blind query-honouring
+ * doubles across 43 files, all 49 reached at runtime and 44 handed a real bound
+ * (values 1 … 10000). Teaching all 49 to honour it broke 0 of 1062 tests — the
+ * class was unobservable, not wrong.
+ */
+describe('the in-memory ObjectQL double honours `limit` (#10978)', () => {
+  const rows = (n: number, org: string) =>
+    Array.from({ length: n }, (_, i) => ({ user_id: `u${i}`, organization_id: org, role: 'member' }));
+
+  it('bounds a matched read at the caller\'s limit', async () => {
+    const ql = makeQl({ sys_member: rows(205, 'o1') });
+    expect(await ql.find('sys_member', { where: { organization_id: 'o1' }, limit: 200 })).toHaveLength(200);
+    expect(await ql.find('sys_member', { where: { organization_id: 'o1' } })).toHaveLength(205);
+  });
+
+  it('tells two bounds apart on the same read — the fold this card exists for', async () => {
+    // `resolveUserAuthzGrants` reads sys_member twice: `{user_id}` at 200 and
+    // `{organization_id}` at 1000. Folding them into one read would cap the
+    // fellow-org peer list (`org_user_ids`, an RLS input) at 200. Under a
+    // limit-blind double both bounds return 1005 rows and the fold is invisible.
+    const ql = makeQl({ sys_member: rows(1005, 'o1') });
+    const atOrgBound = await ql.find('sys_member', { where: { organization_id: 'o1' }, limit: 1000 });
+    const atUserBound = await ql.find('sys_member', { where: { organization_id: 'o1' }, limit: 200 });
+    expect(atOrgBound).toHaveLength(1000);
+    expect(atUserBound).toHaveLength(200);
+    expect(atOrgBound.length).not.toBe(atUserBound.length);
+  });
+
+  it('reads the bound by PRESENCE, not truthiness — `limit: 0` returns nothing', async () => {
+    // `0` is falsy, so `opts.limit ? …` answers a request for NOTHING with the
+    // WHOLE table. Measured door in this repo: `driver-memory` carries the same
+    // fix as `query.limit !== undefined`.
+    const ql = makeQl({ sys_member: rows(3, 'o1') });
+    expect(await ql.find('sys_member', { where: { organization_id: 'o1' }, limit: 0 })).toHaveLength(0);
+  });
+
+  it('applies the bound AFTER the filter, never before it', async () => {
+    // Bounding first would return rows the `where` excludes — a double that is
+    // silently WRONG rather than merely unbounded.
+    const ql = makeQl({ sys_member: [...rows(5, 'other'), ...rows(5, 'o1')] });
+    const found = await ql.find('sys_member', { where: { organization_id: 'o1' }, limit: 3 });
+    expect(found).toHaveLength(3);
+    expect(found.every((r: any) => r.organization_id === 'o1')).toBe(true);
   });
 });

--- a/packages/runtime/src/security/resolve-execution-context.test.ts
+++ b/packages/runtime/src/security/resolve-execution-context.test.ts
@@ -10,18 +10,35 @@ import { hashApiKey } from './api-key.js';
  * (sys_member, permission-set link tables, …) resolves to an empty set so the
  * tests isolate the API-key verify path.
  */
+/**
+ * [#10978] Enforce the caller's `limit`, the way a real driver does.
+ *
+ * A double that matches `where` and returns every matched row cannot tell a read
+ * bounded at 200 from the same read bounded at 1000, or from an unbounded one —
+ * so any limit change is green by construction, and the production symptom is a
+ * silently truncated result set rather than an error. The reads this file drives
+ * carry real bounds (1, 10, 100, 200, 500, 1000).
+ *
+ * PRESENCE, not truthiness: `limit: 0` means "return no records" and `0` is
+ * falsy, so `opts.limit ? …` would answer a request for NOTHING with the WHOLE
+ * table — the door `driver-memory` fixed for itself (`query.limit !== undefined`).
+ */
+function bounded<T>(rows: T[], opts: any): T[] {
+  return typeof opts?.limit === 'number' ? rows.slice(0, opts.limit) : rows;
+}
+
 function makeQl(apiKeyRows: any[]) {
   return {
     async find(object: string, opts: any) {
       const where = opts?.where ?? {};
       if (object !== 'sys_api_key') return [];
-      return apiKeyRows.filter((row) => {
+      return bounded(apiKeyRows.filter((row) => {
         for (const [k, v] of Object.entries(where)) {
           if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
           if (row[k] !== v) return false;
         }
         return true;
-      });
+      }), opts);
     },
   };
 }
@@ -192,13 +209,13 @@ describe('resolveExecutionContext — localization (timezone + locale)', () => {
       async find(object: string, opts: any) {
         const rows = tables[object] ?? [];
         const where = opts?.where ?? {};
-        return rows.filter((row) => {
+        return bounded(rows.filter((row) => {
           for (const [k, v] of Object.entries(where)) {
             if (v !== null && typeof v === 'object') continue; // skip $in/operators
             if (row[k] !== v) return false;
           }
           return true;
-        });
+        }), opts);
       },
     };
     return {
@@ -314,7 +331,7 @@ describe('resolveExecutionContext — platform-scoped (null-org) grants (ADR-006
       async find(object, opts) {
         const rows = tables[object] ?? [];
         const where = opts?.where ?? {};
-        return rows.filter((row) => {
+        return bounded(rows.filter((row) => {
           for (const [k, v] of Object.entries(where)) {
             if (v !== null && typeof v === 'object') {
               if (Array.isArray(v.$in) && !v.$in.includes(row[k])) return false;
@@ -323,7 +340,7 @@ describe('resolveExecutionContext — platform-scoped (null-org) grants (ADR-006
             if ((v ?? null) !== (row[k] ?? null)) return false;
           }
           return true;
-        });
+        }), opts);
       },
     };
   }
@@ -374,7 +391,7 @@ describe('resolveExecutionContext — posture plumbing (#2947)', () => {
       async find(object: string, opts: any) {
         const rows = tables[object] ?? [];
         const where = opts?.where ?? {};
-        return rows.filter((row) => {
+        return bounded(rows.filter((row) => {
           for (const [k, v] of Object.entries(where)) {
             if (v !== null && typeof v === 'object') {
               if (Array.isArray((v as any).$in) && !(v as any).$in.includes(row[k])) return false;
@@ -383,7 +400,7 @@ describe('resolveExecutionContext — posture plumbing (#2947)', () => {
             if ((v ?? null) !== (row[k] ?? null)) return false;
           }
           return true;
-        });
+        }), opts);
       },
     };
   }
@@ -488,13 +505,13 @@ describe('resolveExecutionContext — ADR-0090 D10 agent principal (OAuth on /mc
     };
     return {
       async find(object: string, opts: any) {
-        return (tables[object] ?? []).filter((row) =>
+        return bounded((tables[object] ?? []).filter((row) =>
           Object.entries(opts?.where ?? {}).every(([k, v]) =>
             v !== null && typeof v === 'object'
               ? (Array.isArray((v as any).$in) ? (v as any).$in.includes(row[k]) : true)
               : (v ?? null) === (row[k] ?? null),
           ),
-        );
+        ), opts);
       },
     };
   };


### PR DESCRIPTION
Part of #10978

⚠️ **Deliberately `Part of`, not a closing keyword** — the dispatch asked for a closing
keyword, but the census below changed the shape of the work: this PR converts **9 of the
49** limit-blind doubles. Closing the card would retire the remaining 40 silently. The
card should stay open and be closed by hand once the PM has triaged the remainder.

## What the card asked, and what the census found

The card proposed "teach the shared doubles to honour `limit` (a one-line `slice`)". The
dispatch flagged the word *shared* as an unmeasured guess. It is: **there is no shared
helper.** The doubles are N hand-rolled copies.

Measured on this tree (`919f3f6e`):

| | count |
|---|---|
| `find` implementations in test files | 83 |
| ... that take a query and read `where` (query-honouring doubles) | 62 |
| ... of those, already reading `limit` | 13 |
| ... of those, **limit-blind** | **49**, across **43 files** in **10 packages** |

Only one exported helper exists anywhere — `makeRecordingQl`, the probe #10825 had to
build for itself, which is precisely the rediscovery cost the card is about.

## The measurement — "let whatever breaks be the measurement"

Two instrumented runs over the 43 files, each a trap-guarded mutation restored on every
exit path, each with the mutation proven on disk before the run was believed.

**Run 1 — receipts (behaviour-neutral).** Records what each double is actually handed.
Without this, "nothing broke" is uninterpretable: it cannot tell *no test was vacuous*
from *no limit ever arrives*.

- **49 of 49** doubles are reached at runtime.
- **44 of 49** are handed a real bound — values `1, 2, 3, 4, 5, 6, 7, 10, 12, 20, 40, 50,
  100, 200, 500, 1000, 5000, 10000`.
- Baseline: all 43 files green before any change.

**Run 2 — all 49 doubles bounded.** Every one taught to honour the bound at once:

> **0 of 1062 tests broke.**

So the answer the card said "may well be zero today" **is zero**. The class was
unobservable, not wrong — no test in the tree is currently vacuous because of
limit-blindness, and nothing here is a suite being repaired.

## What actually changed

Nine doubles across four files — the **authorization-resolution seam**, where the card's
worked example lives and where a dropped bound is a privilege bug rather than a cosmetic
one (`org_user_ids` is an RLS input):

- `packages/core/src/security/resolve-authz-context.test.ts` (2 doubles)
- `packages/core/src/security/admin-standing-surface.test.ts`
- `packages/core/src/security/api-key.test.ts`
- `packages/runtime/src/security/resolve-execution-context.test.ts` (5 doubles)

Semantics were taken from the real read path, not invented — `driver-memory` applies
filter, sort, offset, then limit:

- **After the filter**, never before it. Bounding first returns rows the `where` excludes:
  a double that is silently *wrong* rather than merely unbounded.
- **By presence, not truthiness.** `limit: 0` means "return no records" and `0` is falsy,
  so `opts.limit ? …` answers a request for nothing with the whole table. That is a
  measured door in this repo, which `driver-memory` carries as `query.limit !== undefined`.
- No ordering is implemented and no read on these paths asks for one, so filter-then-slice
  matches production here rather than diverging from it.

Four cases pin the instrument itself, including the card's worked example (two `sys_member`
reads at 200 and 1000). Without them the bound is unverified and deleting it fails nothing.

**Reverse verification** (predicted direction stated first: red). Ablating the bound to the
identity, from the committed state, with the anchor proven present before (1) and absent
after (0): **4 failed, 63 passed** — exactly the four instrument cases, nothing else. No
rebuild is involved and none is owed: the ablated subject is the test file's own file-local
function, which vitest resolves from source, not through a package `exports` into `dist/`.

## What is deliberately NOT here

- **No `check:where-matcher`-family gate.** Ruled out for this round: #11190 is in flight
  measuring `dispatch-gates`' discovered-family universe, and adding a family concurrently
  would corrupt its baseline. The measurement above is also the input that decision wants —
  0 vacuous tests, but 44 live limit-carrying doubles.
- **No runtime change.** `resolveUserAuthzGrants` and every read's actual limit are
  untouched. Test instruments only, so no changeset (`skip-changeset`).
- **The other 40 limit-blind doubles.** Converting all 43 files would touch 10 packages at
  once — the maximum-conflict shape against every parallel dev — for zero broken tests and
  no shipped-behaviour risk. Left on the open card for the PM to schedule.

## Verification

All at the final commit `919f3f6e`; each gate quoted by its own printed verdict line, with
exit codes captured before any pipe.

- `pnpm --filter @objectstack/core --filter @objectstack/runtime test` — core **936 passed
  (936)**, runtime **2724 passed (2724)**, 0 failures.
- `pnpm --filter @objectstack/runtime typecheck` — clean (script name echoed, so not a
  zero-match). `@objectstack/core` declares no `typecheck` script; it is one of the 13
  DEBT-ledger packages, confirmed by the gate rather than assumed.
- `check:where-matcher` — "288 matcher(s) discovered, 288 answer the combinator battery
  correctly or refuse it loudly (176 refuse)."
- `check:engine-double-contract` — "OK — 390 pinned, 133 in the DEBT ledger, 2 exempt."
- `check:type-check-debt` — "32 ledger entr(ies) re-measured in 515.3s, 1897 raw tsc
  error(s) total, none above its recorded number." (First attempt refused with 27 deps
  unbuilt; that refusal was treated as NOT MEASURED, the closure was built, and it was
  re-run.)
- `check:cross-package-test-inputs`, `check:kernel-hook-pairs`, `check:published-files`,
  `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`,
  `check:query-options-erasure`, `check:type-check-coverage`, `check:nul-bytes`,
  `check-ci-filter-parity`, `check-plugin-teardown-shape`, `check-affected-docs` — all OK.

**Declared narrowing.** The two instrumented runs covered the 43 files carrying the doubles
rather than all ten packages' suites. The narrowing is sound by construction, not by
sampling: every edit is inside a test file, and each patched `find` is a file-local
function that nothing imports, so no behaviour outside its own file can change. The two
packages this PR actually edits were then run in full anyway (3660 tests). The gate set was
derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which
computes its own change set (4 paths vs merge base `63da5867e`) and confirmed the repo
assertion against this checkout's remote.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_