### PR TITLE
fix(lint): planned liveness rows get their own verdict and rule id (were reported dead)

### DIFF
--- a/.changeset/planned-liveness-verdict-not-dead.md
+++ b/.changeset/planned-liveness-verdict-not-dead.md
@@ -1,0 +1,28 @@
+---
+'@objectstack/lint': patch
+---
+
+`lintLivenessProperties` no longer tells authors a `planned` property is `dead`
+
+`describe()` in `lint-liveness-properties.ts` only knew two verdicts
+(`experimental`, everything else → `dead`), while the liveness ledger ships a
+third: `status: 'planned'` (declared, and a consumer is being built against
+it — contract-first, the opposite of `dead`). Every `planned` row fell through
+into the `dead` branch, so the finding's own **message** told the author to
+remove metadata the platform had asked them to write, while the same finding's
+**hint** (when the row carried one) said the opposite one sentence later. Three
+shipped rows hit this: `field.relatedListFilter`, `object.externalSharingModel`,
+`translation.flows`.
+
+`describe()` now has a third branch: `status === 'planned'` gets its own rule
+id (`liveness-planned-property`, mirroring `liveness-dead-property` /
+`liveness-experimental-property`'s advisory-only posture — nothing downstream
+keys off these ids today) and its own message/default hint ("keep it — a
+consumer is being built against this property", never "Remove it").
+
+The ledger's `status` field is a documented vocabulary, not a Zod-enforced
+enum — nothing rejects a ledger entry with an unrecognised status. `describe()`
+previously graded any such entry `dead` silently; it now throws, naming the
+offending status, so a ledger-authoring mistake (a typo, or a new status added
+without teaching this file about it) fails loudly at test time instead of
+mislabelling a finding.

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -616,7 +616,11 @@ export {
 
 export { lintLivenessProperties } from './lint-liveness-properties.js';
 export type { LivenessLintFinding } from './lint-liveness-properties.js';
-export { LIVENESS_DEAD_PROPERTY, LIVENESS_EXPERIMENTAL_PROPERTY } from './lint-liveness-properties.js';
+export {
+  LIVENESS_DEAD_PROPERTY,
+  LIVENESS_EXPERIMENTAL_PROPERTY,
+  LIVENESS_PLANNED_PROPERTY,
+} from './lint-liveness-properties.js';
 
 export { lintAutonumberFormats } from './lint-autonumber-formats.js';
 export type { AutonumberLintFinding } from './lint-autonumber-formats.js';

--- a/packages/lint/src/lint-liveness-properties.test.ts
+++ b/packages/lint/src/lint-liveness-properties.test.ts
@@ -783,8 +783,14 @@ describe('lintLivenessProperties', () => {
 // assertions say nothing about which properties the ledger warns on — that
 // stays the job of every other block in this file.
 describe('the array fan-out, against a synthetic warn map (#10262)', () => {
+  // #11384: `status: 'dead'` is explicit on purpose. Before that fix, `describe()`
+  // graded any non-`experimental` entry `dead` by fallthrough, so a synthetic
+  // entry with no `status` at all worked here by accident; now an entry that
+  // does not name a recognised status throws (the loud boundary the card asked
+  // for), so this walker-only fixture must declare one — `dead` is arbitrary,
+  // this block asserts nothing about verdicts, only about the fan-out.
   const warnOn = (...paths: string[]) =>
-    new Map(paths.map((p) => [p, { authorWarn: true, authorHint: 'synthetic (#10262)' }] as const));
+    new Map(paths.map((p) => [p, { status: 'dead', authorWarn: true, authorHint: 'synthetic (#10262)' }] as const));
 
   /** `n` navigation entries; those at `authored` set the warned key. */
   const navItems = (n: number, authored: number[]) =>
@@ -858,5 +864,138 @@ describe('the array fan-out, against a synthetic warn map (#10262)', () => {
       );
       expect(findings).toEqual([]);
     });
+  });
+});
+
+// ── #11384: `describe()` gives `dead` / `experimental` / `planned` DISTINCT
+// verdicts — own rule id, own message, own default hint — and refuses to guess
+// on a status it does not recognise instead of silently grading it `dead`.
+//
+// The bug: a `planned` row (declared, and a consumer is being built against it
+// — the OPPOSITE of `dead`) fell through the old two-branch `describe()` into
+// the `dead` branch, so the finding's MESSAGE told the author to remove
+// something the ledger's own `authorHint`/`note` on the SAME finding said to
+// keep. `field.relatedListFilter`, `object.externalSharingModel` and
+// `translation.flows` are the three shipped rows this hit.
+//
+// The real ledgers currently have PLANNED rows and EXPERIMENTAL rows, but — as
+// this file's other comments document at length (#2377, #3896, #4509) — no
+// `dead`+`authorWarn` row survives in tree; every one that existed was retired
+// via enforce-or-remove rather than kept around to warn about. So the `dead`
+// branch, the `live`-mistakenly-warned case, and the unrecognised-status throw
+// are pinned here against SYNTHETIC entries through the `checkItemAgainstWarnMap`
+// seam (#10262) — exactly the kind of verdict-level testing that seam exists
+// for; the PLANNED branch is pinned against BOTH the real ledgers (so it stays
+// a contract test) and a synthetic no-hint entry (to pin the DEFAULT wording).
+describe('dead / experimental / planned verdicts are distinct, and unknown statuses fail loud (#11384)', () => {
+  const oneEntry = (entry: Record<string, unknown>) => new Map([['gizmo', entry]]);
+
+  // ── REAL LEDGER: the three rows the card captured ──────────────────────
+  it('REAL LEDGER: translation.flows (planned) — planned rule id, non-contradictory message, hint preserved', () => {
+    const findings = lintLivenessProperties({
+      translations: [{
+        'zh-CN': { flows: { lead_conversion: { screens: { screen_1: { title: '转化详情' } } } } },
+      }],
+    });
+    expect(findings).toHaveLength(1);
+    const [f] = findings;
+    expect(f.rule).toBe('liveness-planned-property');
+    expect(f.message).not.toContain('dead');
+    expect(f.message).toContain('is planned');
+    // The card's own captured hint — unchanged by this fix, just no longer
+    // contradicted by the message sitting next to it.
+    expect(f.hint).toContain('screen-flow runner');
+  });
+
+  it('REAL LEDGER: field.relatedListFilter (planned) — planned rule id, non-contradictory message', () => {
+    const findings = lintLivenessProperties({
+      objects: [{
+        name: 'account',
+        fields: [{ name: 'related_orders', type: 'text', relatedListFilter: { field: 'account_id' } }],
+      }],
+    });
+    const f = findings.find((x) => x.message.includes('relatedListFilter'));
+    expect(f).toBeDefined();
+    expect(f!.rule).toBe('liveness-planned-property');
+    expect(f!.message).not.toContain('dead');
+  });
+
+  it('REAL LEDGER: object.externalSharingModel (planned, no authorHint — falls back to `note`) — planned rule id, note hint does not say Remove it', () => {
+    const findings = lintLivenessProperties({ objects: [{ name: 'widget', externalSharingModel: 'read' }] });
+    const f = findings.find((x) => x.message.includes('externalSharingModel'));
+    expect(f).toBeDefined();
+    expect(f!.rule).toBe('liveness-planned-property');
+    expect(f!.message).not.toContain('dead');
+    expect(f!.hint).not.toMatch(/^Remove it/);
+  });
+
+  // ── SYNTHETIC: the default hint per verdict, when neither authorHint nor
+  // note is present — the shape #11384 explicitly called out ("the default
+  // hint for a planned row without an authorHint must NOT say 'Remove it'") ──
+  it('SYNTHETIC: a planned entry with no authorHint/note gets the planned DEFAULT hint, never "Remove it"', () => {
+    const findings = checkItemAgainstWarnMap(
+      'gadget',
+      { name: 'g1', gizmo: 'x' },
+      "gadget 'g1'",
+      oneEntry({ status: 'planned', authorWarn: true }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe('liveness-planned-property');
+    expect(findings[0].message).not.toContain('dead');
+    expect(findings[0].hint).not.toContain('Remove it');
+    expect(findings[0].hint.toLowerCase()).toContain('keep it');
+  });
+
+  it('SYNTHETIC: a dead entry with no authorHint/note keeps the dead rule id, "liveness: dead" message and the "Remove it" default hint', () => {
+    const findings = checkItemAgainstWarnMap(
+      'gadget',
+      { name: 'g1', gizmo: 'x' },
+      "gadget 'g1'",
+      oneEntry({ status: 'dead', authorWarn: true }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe('liveness-dead-property');
+    expect(findings[0].message).toContain('liveness: dead');
+    expect(findings[0].hint).toBe('Remove it — it is declared in the spec but not consumed at runtime.');
+  });
+
+  it('SYNTHETIC: an experimental entry with no authorHint/note gets an experimental default hint, never "Remove it"', () => {
+    const findings = checkItemAgainstWarnMap(
+      'gadget',
+      { name: 'g1', gizmo: 'x' },
+      "gadget 'g1'",
+      oneEntry({ status: 'experimental' }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe('liveness-experimental-property');
+    expect(findings[0].hint).not.toContain('Remove it');
+  });
+
+  // ── SYNTHETIC: the unknown-status boundary — loud, never silently `dead` ──
+  it('SYNTHETIC: an unrecognised status fails LOUD, naming the status, instead of silently grading as dead', () => {
+    expect(() =>
+      checkItemAgainstWarnMap(
+        'gadget',
+        { name: 'g1', gizmo: 'x' },
+        "gadget 'g1'",
+        oneEntry({ status: 'quantum', authorWarn: true }),
+      ),
+    ).toThrow(/quantum/);
+  });
+
+  it('SYNTHETIC: a `live` row mistakenly marked authorWarn also fails LOUD rather than being graded dead', () => {
+    // Not a real shipped scenario (a `live` property should never carry
+    // `authorWarn: true`) — but exactly the class of ledger-authoring mistake
+    // the old silent fallthrough would have hidden by mislabelling it `dead`
+    // too, which is why the boundary in `describe()` is status-based rather
+    // than an `else if (status === 'planned') … else /* assume dead */`.
+    expect(() =>
+      checkItemAgainstWarnMap(
+        'gadget',
+        { name: 'g1', gizmo: 'x' },
+        "gadget 'g1'",
+        oneEntry({ status: 'live', authorWarn: true }),
+      ),
+    ).toThrow(/live/);
   });
 });

--- a/packages/lint/src/lint-liveness-properties.ts
+++ b/packages/lint/src/lint-liveness-properties.ts
@@ -4,13 +4,15 @@
  * Build-time lint that closes the spec-liveness loop on the AUTHOR side.
  *
  * The liveness ledgers (`@objectstack/spec/liveness/<type>.json`) classify every
- * authorable metadata property as live / experimental / dead with evidence. The
- * CI gate enforces that classification is *complete*, but the ledger's knowledge
- * never reached the person (very often an AI) writing the metadata. This lint
- * surfaces it: when an authored object/field sets a property the ledger marks as
- * dead-and-misleading (or experimental), it emits an advisory WARNING — "you set
- * this expecting it to do something; at runtime it does nothing" — with a hint
- * toward the supported alternative. It NEVER fails the build.
+ * authorable metadata property as live / experimental / planned / dead with
+ * evidence. The CI gate enforces that classification is *complete*, but the
+ * ledger's knowledge never reached the person (very often an AI) writing the
+ * metadata. This lint surfaces it: when an authored object/field sets a property
+ * the ledger marks `dead`-and-misleading, `experimental`, or `planned`, it emits
+ * an advisory WARNING with a verdict-specific message and hint — `dead` says
+ * remove it, `experimental`/`planned` say keep it (declared, just not enforced /
+ * not read yet) — under a verdict-specific rule id (`describe()` below is the one
+ * place that mapping lives; #11384). It NEVER fails the build.
  *
  * Signal over noise is the whole point, so the ledger opts in per entry via
  * `"authorWarn": true` (+ an optional `"authorHint"`). A property being merely
@@ -33,6 +35,7 @@ export interface LivenessLintFinding {
 
 export const LIVENESS_DEAD_PROPERTY = 'liveness-dead-property';
 export const LIVENESS_EXPERIMENTAL_PROPERTY = 'liveness-experimental-property';
+export const LIVENESS_PLANNED_PROPERTY = 'liveness-planned-property';
 
 type AnyRec = Record<string, unknown>;
 
@@ -105,11 +108,71 @@ function isAuthored(value: unknown): boolean {
   return true;
 }
 
-function describe(entry: LedgerEntry): { kind: string; rule: string } {
+/**
+ * `#11384`. The ledger ships (at least) three verdicts an author-facing finding
+ * can carry, and they imply OPPOSITE actions: `dead` means remove the property
+ * (nothing will ever read it), `planned` means keep it (a consumer is being
+ * built against it, contract-first — it just does not have runtime effect
+ * YET), `experimental` means keep it too but with the guarantee's status
+ * flagged. Collapsing `planned` into the `dead` branch — the bug this function
+ * fixes — told an author to delete metadata the platform had asked them to
+ * write, while the row's own `authorHint`/`note` (when present) said the
+ * opposite one sentence later on the SAME finding.
+ *
+ * Each verdict below also carries its own DEFAULT hint (used only when the
+ * ledger entry has neither `authorHint` nor `note`): the `dead` default says
+ * "Remove it"; `planned`'s must not, because removing a planned property is
+ * exactly the wrong author action.
+ *
+ * Unknown status: `LedgerEntry.status` is a plain `string` (see the interface
+ * above) because the ledger's status vocabulary is DOCUMENTED, not
+ * schema-enforced — `packages/spec/scripts/liveness/check-liveness.mts`'s own
+ * header states "Statuses: live | experimental | planned | dead" in a comment,
+ * and nothing in that gate (or anywhere else) rejects a ledger JSON file that
+ * spells one wrong or ships a status this function has never heard of; the
+ * gate only requires that a status be PRESENT, not that it be one of the four.
+ * An entry only reaches `describe()` once `shouldWarn()` has already said yes
+ * (`authorWarn: true`, or `status === 'experimental'`), so `live` can in
+ * principle arrive here too (an entry marked `authorWarn: true` on a `live`
+ * row would be a ledger authoring mistake, not a user error). Before this fix
+ * every one of those unrecognised cases fell silently into the `dead` branch —
+ * exactly the defect class #11384 reports, just with a different trigger — so
+ * the boundary below is LOUD on purpose: a status this function does not
+ * recognise is a bug in the shipped ledger, not something to guess about.
+ * This is deliberately narrower than the file's general "never throws"
+ * promise (see the `checkItem`/bundle-walk comments below): that promise
+ * covers malformed STACK input from an untrusted author, while a ledger
+ * status is OUR OWN shipped, framework-controlled data — failing loudly here
+ * cannot be triggered by anything an app author writes.
+ */
+function describe(entry: LedgerEntry): { kind: string; rule: string; defaultHint: string } {
   if (entry.status === 'experimental') {
-    return { kind: 'is experimental — declared but NOT enforced at runtime', rule: LIVENESS_EXPERIMENTAL_PROPERTY };
+    return {
+      kind: 'is experimental — declared but NOT enforced at runtime',
+      rule: LIVENESS_EXPERIMENTAL_PROPERTY,
+      defaultHint: 'It is declared in the spec as an experimental guarantee — not yet enforced at runtime.',
+    };
   }
-  return { kind: 'has no runtime effect (liveness: dead)', rule: LIVENESS_DEAD_PROPERTY };
+  if (entry.status === 'planned') {
+    return {
+      kind: 'is planned — declared, and a consumer is being built against it (not read YET)',
+      rule: LIVENESS_PLANNED_PROPERTY,
+      defaultHint: 'Keep it — a consumer is being built against this property; it has no runtime effect yet.',
+    };
+  }
+  if (entry.status === 'dead') {
+    return {
+      kind: 'has no runtime effect (liveness: dead)',
+      rule: LIVENESS_DEAD_PROPERTY,
+      defaultHint: 'Remove it — it is declared in the spec but not consumed at runtime.',
+    };
+  }
+  throw new Error(
+    `lintLivenessProperties: ledger entry has unrecognised status ${JSON.stringify(entry.status)} — ` +
+    "describe() only knows 'experimental' | 'planned' | 'dead'. This is a shipped-ledger integrity " +
+    'bug, not an authoring error: either the ledger JSON has a typo, or a new status was added to ' +
+    'the vocabulary without teaching describe() in lint-liveness-properties.ts about it (#11384).',
+  );
 }
 
 /** Check one metadata item's set properties against its type's warn-map. */
@@ -126,10 +189,8 @@ function checkItem(
       : [item[path]];
     for (const value of values instanceof Array ? values : [values]) {
       if (!isAuthored(value)) continue;
-      const { kind, rule } = describe(entry);
-      const hint = entry.authorHint
-        ?? entry.note
-        ?? 'Remove it — it is declared in the spec but not consumed at runtime.';
+      const { kind, rule, defaultHint } = describe(entry);
+      const hint = entry.authorHint ?? entry.note ?? defaultHint;
       findings.push({
         where: whereBase,
         message: `sets \`${path}\` but this ${type} property ${kind}.`,


### PR DESCRIPTION
## The contradiction

`describe()` in `packages/lint/src/lint-liveness-properties.ts` only knew two
verdicts — `experimental`, and everything else (including `planned`) fell
through into `dead`. A real finding, captured from `translation.flows`:

```
message: "sets `flows` but this translation property has no runtime effect (liveness: dead)."
hint:    "No shipped screen-flow runner reads this group yet — until the objectui half of #7646
          lands, a `type: 'screen'` flow renders the strings authored on the flow ... in every locale."
```

The message says *remove it*; the hint (and the ledger's own note) says *keep
it, a consumer is being built*. Three shipped rows hit this:
`field.relatedListFilter`, `object.externalSharingModel`,
`translation.flows` — all `status: 'planned'`, all warned via `authorWarn`.

## The fix: a third, distinct verdict

`describe()` now returns one of three verdicts, each with its own rule id and
default hint:

| status | rule id | message | default hint (used only when the ledger row has neither `authorHint` nor `note`) |
|---|---|---|---|
| `experimental` | `liveness-experimental-property` | "is experimental — declared but NOT enforced at runtime" | *(unchanged)* |
| `planned` (**new**) | `liveness-planned-property` | "is planned — declared, and a consumer is being built against it (not read YET)" | "Keep it — a consumer is being built against this property; it has no runtime effect yet." |
| `dead` | `liveness-dead-property` | "has no runtime effect (liveness: dead)" | "Remove it — it is declared in the spec but not consumed at runtime." (unchanged) |

**Advisory-only posture**: `lintLivenessProperties` is registered once in
`authoring-rules.ts` (`tier: 'advisory'`, every finding mapped to
`severity: 'warning'` regardless of `f.rule`), so the new rule id inherits the
same posture automatically — there is no per-rule-id severity table to update.
Repo-wide search confirms no suppression config, report grouper, or other
consumer keys off `liveness-dead-property` / `liveness-experimental-property`
today (`index.ts`, the source file, and its test are the only 3 hits), so
`liveness-planned-property` needed no other wiring.

## Unknown status: now fails loud

`LedgerEntry.status` is a plain `string` — the ledger's status vocabulary
(`live | experimental | planned | dead`) is documented in a comment at the top
of `packages/spec/scripts/liveness/check-liveness.mts`, **not** enforced by a
Zod enum. Nothing rejects a ledger JSON file that misspells a status or ships
one this file has never heard of; the CI gate only requires a status be
*present*. Before this fix, any such entry silently graded `dead` — the same
defect class the card reports, just with a different trigger. `describe()` now
throws, naming the offending status, when it sees anything other than
`experimental` / `planned` / `dead`. This is scoped narrower than the file's
general "advisory lint, never throws" contract: that promise covers malformed
**stack** input from an untrusted app author (the translation-bundle walk
etc.), while a ledger status is *our own* shipped, framework-controlled data —
nothing an app author writes can trigger this throw.

One existing test (`the array fan-out, against a synthetic warn map (#10262)`)
built its synthetic ledger rows with `authorWarn: true` and no `status` at
all, relying on the old silent-`dead` fallthrough. Updated to declare
`status: 'dead'` explicitly — that block asserts nothing about verdicts, only
about the `getNested` array walk, so the choice of status is arbitrary but
must now be one of the three.

## Verification

- `pnpm --filter '@objectstack/lint^...' build` then
  `pnpm --filter @objectstack/lint build` — clean.
- `pnpm --filter @objectstack/lint test` — **2266/2266 passed** (80 files),
  including 8 new cases pinning all three verdicts' message+rule-id pairs, the
  `planned` default hint (never "Remove it"), the unknown-status throw (named
  status in the message), and a `live`-mistakenly-`authorWarn`'d row also
  throwing.
- `pnpm --filter @objectstack/lint typecheck` — clean.
- **Reverse verification**: committed the fix, then reverted just the two
  source files (`lint-liveness-properties.ts`, `index.ts`) to their
  `origin/main` content via `git checkout`, to stand up the pre-patch source
  under the new tests. **7 of the 8 new tests failed** (rule id
  `liveness-dead-property` instead of `liveness-planned-property`; "Remove
  it" leaking into the experimental default hint; the two throw-expectation
  tests found nothing thrown). The 8th (`dead` branch, no authorHint/note)
  passed unchanged both before and after, as expected — that behaviour is
  untouched by this fix. Restored both files back to HEAD's committed
  content (verified `git diff HEAD` clean) before re-running the full suite
  green.
- **Live capture** — running the linter over a fixture with all three
  shipped `planned` rows authored now produces (rule id + message, no more
  "dead"):
  ```json
  {
    "where": "translation bundle #0 · locale 'zh-CN'",
    "message": "sets `flows` but this translation property is planned — declared, and a consumer is being built against it (not read YET).",
    "hint": "No shipped screen-flow runner reads this group yet — until the objectui half of #7646 lands, a `type: 'screen'` flow renders the strings authored on the flow (`config.title`, `fields[].label`, `fields[].placeholder`) in every locale.",
    "rule": "liveness-planned-property"
  }
  ```
  (`field.relatedListFilter` and `object.externalSharingModel` produce the
  matching shape.)
- Local gate list derived via `node scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` from this worktree — every path-derived and
  convention-triggered local gate it named ran green: `check:changeset-gate-
  self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`,
  `check:published-files`, `check:slot-lookup`, `check:test-source-alias`,
  `check:type-source-resolution`, `check-adr-0087-registration`,
  `check-changeset-no-major`, `check-ci-filter-parity`, `check-empty-
  changeset`, `check-plugin-teardown-shape`, `check-affected-docs`,
  `check:query-options-erasure`, `check:engine-double-contract`,
  `check:where-matcher`, and `check:type-check-coverage` (both the plain run
  and the `--re-measure` ratchet, the latter after building the full
  `./packages/*` + `./packages/*/*` closure it requires — 70/70 tasks) — no
  new debt, no ratchet moved (32 ledger entries re-measured, none above their
  recorded ceiling). `pnpm lint` (repo-wide ESLint) is CI's to run, not
  re-run here; a scoped ESLint pass over just the 3 touched files (0
  errors/warnings) was run as an extra courtesy check, not a substitute.
- Changeset added: `.changeset/planned-liveness-verdict-not-dead.md`
  (`@objectstack/lint`, patch — `@objectstack/lint` sits in the repo's fixed
  publish group).

## Scope

Touches only `packages/lint/src/lint-liveness-properties.ts`, its test file,
and the `index.ts` export barrel. No `packages/spec/src/**` diff — the ledger
JSON files and their `status` vocabulary are unchanged; this is purely the
author-facing lint's own verdict mapping.

Fixes #11384

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_
