### PR TITLE
docs(spec): front-door and branded-types examples compile against the real exports map (+os:check markers)

### DIFF
--- a/.changeset/front-door-examples-compile.md
+++ b/.changeset/front-door-examples-compile.md
@@ -1,0 +1,24 @@
+---
+'@objectstack/spec': patch
+---
+
+Fix four self-contained TSDoc `@example` blocks in `packages/spec/src` that did
+not compile against the package's own built declarations, and add `os:check`
+markers so `check:skill-examples` keeps them honest going forward.
+
+The package's front-door header (`src/index.ts`) taught a root namespace-import
+style (`import { Data, UI, System, Auth, AI, API } from '@objectstack/spec'`)
+the root has never exported, and two subpath-import styles that named
+`@objectstack/spec/auth` — a subpath that does not exist (the real one is
+`@objectstack/spec/identity`). The header now documents three styles that
+actually compile: root-level `defineX` factory imports (`defineStack`,
+`defineView`, `defineApp`, `defineFlow`, `defineAgent`, `defineTool`,
+`defineSkill`, …, which the root really does export), namespace imports via
+subpath, and direct subpath imports — all against `@objectstack/spec/identity`
+instead of the non-existent `/auth`.
+
+`src/shared/branded-types.zod.ts`'s `@example` imported `ObjectNameSchema` /
+`FieldNameSchema` from the package root; both are exported only from
+`@objectstack/spec/shared`. Fixed the specifier.
+
+No behavior change — TSDoc examples only.

--- a/content/docs/references/shared/branded-types.mdx
+++ b/content/docs/references/shared/branded-types.mdx
@@ -13,7 +13,7 @@ where a FieldName is expected, even though both are strings at runtime.
 
 @example
 ```ts
-import { ObjectNameSchema, FieldNameSchema } from '@objectstack/spec';
+import { ObjectNameSchema, FieldNameSchema } from '@objectstack/spec/shared';
 
 const objName = ObjectNameSchema.parse('project_task');   // ObjectName
 const fieldName = FieldNameSchema.parse('task_name');     // FieldName

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -5,37 +5,61 @@
  * 
  * ObjectStack Protocol & Specification
  * 
- * This package does NOT export types at the root level to prevent naming conflicts.
- * Please use namespaced imports or subpath imports.
- * 
+ * This package does NOT export type namespaces at the root level, to prevent
+ * naming conflicts — `import { Data, UI, System } from '@objectstack/spec'`
+ * names nothing the root exports. The root DOES export a curated set of
+ * authoring `defineX` factory functions (`defineStack`, `defineView`,
+ * `defineApp`, `defineFlow`, `defineAgent`, `defineTool`, `defineSkill`, …)
+ * for direct top-level use. Every domain's TYPES, and its `*Schema` values,
+ * are reached through that domain's own subpath instead
+ * (`@objectstack/spec/data`, `@objectstack/spec/identity`, …).
+ *
  * ## Import Styles
- * 
- * ### Style 1: Namespace Imports from Root
+ *
+ * ### Style 1: Root-Level Factory Imports
+ * <!-- os:check -->
  * ```typescript
- * import { Data, UI, System, Auth, AI, API } from '@objectstack/spec';
- * 
- * const field: Data.Field = { name: 'task_name', type: 'text' };
- * const user: Auth.User = { id: 'u1', email: 'user@example.com' };
+ * import { defineSkill } from '@objectstack/spec';
+ *
+ * const skill = defineSkill({
+ *   name: 'case_management',
+ *   label: 'Case Management',
+ *   description: 'Handles support case lifecycle',
+ *   instructions: 'Use these tools to create, update, and resolve support cases.',
+ *   tools: ['create_case', 'update_case', 'resolve_case'],
+ * });
  * ```
- * 
+ *
  * ### Style 2: Namespace Imports via Subpath
+ * <!-- os:check -->
  * ```typescript
  * import * as Data from '@objectstack/spec/data';
  * import * as UI from '@objectstack/spec/ui';
  * import * as System from '@objectstack/spec/system';
- * import * as Auth from '@objectstack/spec/auth';
- * 
+ * import * as Identity from '@objectstack/spec/identity';
+ *
  * const field: Data.Field = { name: 'task_name', type: 'text' };
- * const user: Auth.User = { id: 'u1', email: 'user@example.com' };
+ * const user: Identity.User = {
+ *   id: 'u1',
+ *   email: 'user@example.com',
+ *   createdAt: '2026-01-01T00:00:00.000Z',
+ *   updatedAt: '2026-01-01T00:00:00.000Z',
+ * };
  * ```
- * 
+ *
  * ### Style 3: Direct Subpath Imports
+ * <!-- os:check -->
  * ```typescript
  * import { Field, FieldType } from '@objectstack/spec/data';
- * import { User, Session } from '@objectstack/spec/auth';
+ * import { User } from '@objectstack/spec/identity';
  *
  * const field: Field = { name: 'task_name', type: 'text' };
- * const user: User = { id: 'u1', email: 'user@example.com' };
+ * const user: User = {
+ *   id: 'u1',
+ *   email: 'user@example.com',
+ *   createdAt: '2026-01-01T00:00:00.000Z',
+ *   updatedAt: '2026-01-01T00:00:00.000Z',
+ * };
  * ```
  *
  * ## Standing principle for export surfaces (#10096, maintainer ruling 2026-08-20)

--- a/packages/spec/src/shared/branded-types.zod.ts
+++ b/packages/spec/src/shared/branded-types.zod.ts
@@ -11,8 +11,9 @@ import { SnakeCaseIdentifierSchema, SystemIdentifierSchema } from './identifiers
  * where a FieldName is expected, even though both are strings at runtime.
  *
  * @example
+ * <!-- os:check -->
  * ```ts
- * import { ObjectNameSchema, FieldNameSchema } from '@objectstack/spec';
+ * import { ObjectNameSchema, FieldNameSchema } from '@objectstack/spec/shared';
  *
  * const objName = ObjectNameSchema.parse('project_task');   // ObjectName
  * const fieldName = FieldNameSchema.parse('task_name');     // FieldName


### PR DESCRIPTION
Fixes #11436

**Status:** DRAFT — clause-② path limb (diff lives under `packages/spec/src/**`,
substantively no accept/reject or export-surface change). `needs:contract-review`
is on the card; this PR stays draft for the PM's review, per the dispatch
contract.

## Two defect classes

1. **`packages/spec/src/index.ts` — the front door's three import-style
   blocks.** Style 1 taught a root namespace-import style
   (`import { Data, UI, System, Auth, AI, API } from '@objectstack/spec'`) the
   root has never exported — the file's own preamble already conceded as much.
   Styles 2–3 both named `@objectstack/spec/auth`, a subpath the `exports` map
   has never declared (the real one is `@objectstack/spec/identity`).
2. **`packages/spec/src/shared/branded-types.zod.ts:14`** — named
   `ObjectNameSchema` / `FieldNameSchema` from the package root. Both symbols
   exist, but resolve from `@objectstack/spec/shared`, never the root.

## What each block teaches now

Measured against the package's real `exports` map (`packages/spec/package.json`)
and its built declarations — no new export, no widened surface, docblocks only:

- **Style 1 — Root-Level Factory Imports** *(reframed, not dropped)*. The root
  genuinely does export a curated set of authoring `defineX` factories
  (`defineStack`, `defineView`, `defineApp`, `defineFlow`, `defineAgent`,
  `defineTool`, `defineSkill`, …) for direct top-level use, even though it
  exports no type namespaces. The block now imports `defineSkill` from the
  root and calls it with a real, compiling config — teaching the true
  root-level surface instead of a fabricated one.
- **Style 2 — Namespace Imports via Subpath**: `import * as Identity from
  '@objectstack/spec/identity'` replaces the `/auth` import; `Auth.User` →
  `Identity.User`.
- **Style 3 — Direct Subpath Imports**: `import { User } from
  '@objectstack/spec/identity'` replaces `import { User, Session } from
  '@objectstack/spec/auth'`. `Session` is dropped rather than mis-sourced —
  the bare `Session` type is deliberately not declared in `identity` (see the
  comment at `identity.zod.ts:164`); the wire shape lives in
  `@objectstack/spec/api` and pulling in a third subpath for one name did not
  earn its place in an already-two-subpath example.
- Both `User` literals gained the schema's two required timestamp fields
  (`createdAt`, `updatedAt`) — present in the type, silently never checked
  before because the broken import made every downstream usage unreachable to
  `tsc`.
- **`branded-types.zod.ts`**: `@objectstack/spec` → `@objectstack/spec/shared`.
  No other change.

### Front-door docs-shape decision

The card flagged this as worth deciding rather than guessing: whether
`index.ts`'s header should keep documenting a namespace-import style at all.
Went with the measurement-driven default stated in the dispatch — but chose
**"truthfully reframe" over "drop"** for Style 1, because the root really does
export something meaningful at that path (the `defineX` factories), and
dropping it down to two styles would have made the header thinner without
making it more honest. The header's opening prose was rewritten to state
plainly what the root does and does not export, rather than leaving the old
"this package does NOT export types at the root level" sentence to silently
disagree with a fixed Style 1 block the way it disagreed with the broken one.

Verified at `41ea937bc7` (this PR's head commit).

## Gate count

`pnpm --filter @objectstack/spec check:skill-examples` — spec-source surface
**6 → 10** marked blocks (4 new: 3 in `index.ts`, 1 in `branded-types.zod.ts`),
matching the card's acceptance count exactly (the reframed Style 1 counts as
the 4th new block, same as a literal one-for-one repair would have).

## Verification

- `pnpm --filter @objectstack/spec build`
- `pnpm --filter @objectstack/spec check:skill-examples` — green, `10` marked
  spec-source block(s) (was 6), `257 prose examples type-check across 3
  surface(s)` overall.
- **Reverse verification**: added the `os:check` marker to all four blocks
  against the OLD (broken) text first. Gate went red with exactly the card's
  diagnostics — TS2305 on `Data`/`UI`/`System`/`Auth`/`AI`/`API`, TS2307 on
  `@objectstack/spec/auth` (×2), TS2305 on `ObjectNameSchema`/`FieldNameSchema`.
  Rewrote to the real exports/declarations in place (still committed as the
  repair, no separate revert needed since the final state is the marked+fixed
  text) — gate went green.
- `pnpm --filter @objectstack/spec typecheck` — green (`tsc --noEmit` +
  `check:scripts-typecheck` + `check:test-typecheck`, test-layer debt ledger
  unchanged).
- `pnpm --filter @objectstack/spec test` — green: `Test Files 420 passed
  (420)`, `Tests 11204 passed (11204)`.
- `pnpm --filter @objectstack/spec check:generated` — 1 artifact proved stale
  (`check:docs`, because the fixed `@example` in `branded-types.zod.ts` feeds
  the generated reference page) → `pnpm --filter @objectstack/spec gen:docs`,
  re-ran clean (14/14). Regen diff audited: exactly the one-line specifier fix
  propagated into `content/docs/references/shared/branded-types.mdx`, nothing
  else moved.
- Targeted ESLint (`index.ts`, `branded-types.zod.ts`) — clean.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derived
  27 matched local gate families (+5 changeset-triggered once the changeset was
  added) for this diff; all ran green except `node scripts/check-dev-prereqs.mjs`,
  which failed on unrelated packages' missing `dist/` (this worktree never ran a
  full `pnpm build`) — an environment precondition, not a regression from this
  diff (spec's own `dist` is fresh and green everywhere else).
- Changeset added: `.changeset/front-door-examples-compile.md` (patch,
  `@objectstack/spec`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_