### PR TITLE
Surface declared≠enforced permission-set drift + sanctioned overlay discard

### DIFF
--- a/.changeset/declared-vs-enforced-permission-set-drift.md
+++ b/.changeset/declared-vs-enforced-permission-set-drift.md
@@ -1,0 +1,38 @@
+---
+'@objectstack/plugin-security': minor
+'@objectstack/rest': minor
+---
+
+Surface "declared ≠ enforced" on package-declared permission sets, and give
+operators a sanctioned, audited way to discard a stale environment overlay.
+
+Field report: an rc→GA upgraded environment can freeze a package's
+permission set at a stale snapshot while the shipped artifact keeps
+shipping grant changes — silently, with only a boot log counter as a
+signal. Two independent mechanisms can cause this, and either (or both
+together) can be live on one row:
+
+- **overlay shadow** — a Studio permission-matrix save on a package-declared
+  set materializes a `sys_metadata` overlay that shadows every later package
+  edit to that set, forever, surviving redeploys and restarts;
+- **provenance skip** — a `sys_permission_set` row whose `managed_by` column
+  predates package provenance tracking is treated as environment-authored
+  and never reconciled with the package.
+
+`sys_permission_set` now carries `drift_status` / `drift_detail`, recomputed
+every boot, naming the set and the cause — a new "Needs Attention" Setup
+list view surfaces only sets that actually differ from their shipped
+artifact (an in-sync set is never flagged; `drift_status` stays `null`).
+
+A new "Discard Overlay" Setup action (`POST
+/api/v1/security/permission-sets/:id/discard-overlay`) removes a stale
+overlay and resyncs the record to the current artifact synchronously — the
+supported, audited counterpart to the raw-SQL remediation the field report
+had to use. It targets package-declared sets only: a set with no current
+package declaration is refused, so a genuinely environment-authored set can
+never be discarded by name collision.
+
+Boot-time auto-adoption of legacy rows and a bulk `os meta
+adopt-permission-sets` command remain out of scope (2026-08-20 maintainer
+ruling) — the manual SQL adoption recipe stays documented for the rc→GA
+provenance-skip case; see the ops runbook.

--- a/content/docs/permissions/permission-sets.mdx
+++ b/content/docs/permissions/permission-sets.mdx
@@ -295,6 +295,49 @@ A cross-package job function needs no hand-authored cross-package set: bind
 each package's own sets to one **position** (the union model adds), and use an
 overlay where a packaged set must be narrowed.
 
+### Declared ≠ enforced — diagnosing a frozen package set
+
+A package-declared set's *enforced* grants (what `sys_permission_set` stores
+and what the evaluator resolves) can diverge from its shipped *artifact*
+(what the package currently declares) through two independent mechanisms —
+either can be live on one row, and they need different remedies:
+
+- **Overlay shadow.** An active `sys_metadata` overlay for the set's name
+  (from a Studio save made while overlaying was still permitted, or through
+  the `OS_METADATA_WRITABLE` escape hatch) is re-projected onto the record on
+  every boot, unconditionally — the overlay wins forever, regardless of what
+  the package ships next. **Remedy:** the record's **Discard Overlay** Setup
+  action (`POST /api/v1/security/permission-sets/:id/discard-overlay`,
+  tenant-admin only) removes the stale overlay and resyncs the record to the
+  current artifact immediately. It refuses on any set that is not currently
+  package-declared, so it can never destroy a genuinely environment-authored
+  set.
+- **Provenance skip.** The record's `managed_by` column predates package
+  provenance tracking (a legacy insert without `managed_by: 'package'` —
+  typically a database first initialized on an older release line), so boot
+  seeding treats it as environment-authored and never reconciles it with the
+  package — permanently. There is currently no automated adoption path for
+  this case (boot-time auto-adoption and a bulk `os meta
+  adopt-permission-sets` command were both deliberately deferred as migration
+  machinery for a customer population that does not yet exist — see the
+  discussion on the tracking issue for this section). The manual recovery is
+  the same one-time SQL a field remediation used, run against the
+  environment's database with a backup first:
+
+  ```sql
+  UPDATE sys_permission_set
+  SET managed_by = 'package', package_id = '<owning package id>'
+  WHERE name = '<permission set name>';
+  ```
+
+  Restart the environment afterward so boot seeding re-adopts the row as
+  package-owned and reconciles its grants to the shipped artifact.
+
+Both mechanisms are surfaced on the record itself: `drift_status`
+(`'overlay_shadow'` / `'provenance_skip'`) and `drift_detail` name the cause,
+recomputed every boot, and the **Needs Attention** list view collects every
+currently drifted set — an in-sync set is never listed there.
+
 ---
 
 ## See also

--- a/packages/plugins/plugin-security/src/index.ts
+++ b/packages/plugins/plugin-security/src/index.ts
@@ -94,3 +94,25 @@ export type {
   SuggestionReconcileOutcome,
   SuggestionReconcileScope,
 } from './suggested-audience-bindings.js';
+// [field report — rc→GA declared≠enforced surfacing] "declared ≠ enforced"
+// per-set diagnostics (overlay_shadow / provenance_skip) + the sanctioned
+// operator discard action.
+export {
+  computePermissionSetDriftDiagnostics,
+  persistPermissionSetDriftDiagnostics,
+  runPermissionSetDriftDiagnostics,
+} from './permission-set-drift.js';
+export type {
+  PermissionSetDriftStatus,
+  PermissionSetDriftDiagnostic,
+  DriftDiagnosticsOptions,
+} from './permission-set-drift.js';
+export {
+  discardPermissionSetOverlay,
+  PermissionSetNotFoundError,
+  PermissionSetOverlayStateError,
+} from './permission-set-overlay-discard.js';
+export type {
+  PermissionSetOverlayDiscardDeps,
+  PermissionSetOverlayDiscardResult,
+} from './permission-set-overlay-discard.js';

--- a/packages/plugins/plugin-security/src/objects/rbac-objects.test.ts
+++ b/packages/plugins/plugin-security/src/objects/rbac-objects.test.ts
@@ -174,9 +174,28 @@ describe('RBAC object canonical names + row actions', () => {
     expect(names).toEqual(['activate_position', 'clone_position', 'deactivate_position', 'set_default_position']);
   });
 
-  it('SysPermissionSet exposes activate/deactivate/clone row actions', () => {
+  it('SysPermissionSet exposes activate/deactivate/clone/discard-overlay row actions', () => {
     const names = (SysPermissionSet.actions ?? []).map((a) => a.name).sort();
-    expect(names).toEqual(['activate_permission_set', 'clone_permission_set', 'deactivate_permission_set']);
+    // [field report — rc→GA declared≠enforced surfacing] `discard_permission_set_overlay`
+    // is the sanctioned counterpart to the field remediation's raw SQL.
+    expect(names).toEqual([
+      'activate_permission_set', 'clone_permission_set', 'deactivate_permission_set',
+      'discard_permission_set_overlay',
+    ]);
+  });
+
+  it('[field report — rc→GA declared≠enforced surfacing] SysPermissionSet.drift_status is a select naming the two detected causes, and appears in the "Needs Attention" list view', () => {
+    const f: any = (SysPermissionSet.fields as any).drift_status;
+    expect(f, 'drift_status field exists').toBeDefined();
+    expect(f.type).toBe('select');
+    expect(f.readonly).toBe(true);
+    const opts = (f.options ?? []).map((o: any) => o.value).sort();
+    expect(opts).toEqual(['other', 'overlay_shadow', 'provenance_skip']);
+
+    const views: any = SysPermissionSet.listViews;
+    expect(views.drifted, 'drifted list view exists').toBeDefined();
+    expect(views.drifted.columns).toContain('drift_status');
+    expect(views.all_permsets.columns).toContain('drift_status');
   });
 
   it('[A4 #2920] SysPermissionSet.managed_by is a select on the unified platform/package/admin vocab', () => {

--- a/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
@@ -69,6 +69,29 @@ export const SysPermissionSet = ObjectSchema.create({
       refreshAfter: true,
     },
     {
+      // [field report — rc→GA declared≠enforced surfacing] The sanctioned,
+      // audited counterpart to the field remediation's raw
+      // `DELETE FROM sys_metadata WHERE type='permission' AND name='…'` — see
+      // `permission-set-overlay-discard.ts`. Refuses (403) on any set that is
+      // not currently package-declared, so it can never destroy a genuinely
+      // environment-authored set's work.
+      name: 'discard_permission_set_overlay',
+      label: 'Discard Overlay',
+      icon: 'refresh-ccw',
+      variant: 'danger',
+      mode: 'custom',
+      locations: ['list_item', 'record_header'],
+      type: 'api',
+      method: 'POST',
+      target: '/api/v1/security/permission-sets/{id}/discard-overlay',
+      confirmText:
+        'Discard the environment overlay shadowing this package-declared set and resync it to the shipped ' +
+        'artifact? This only removes the customization overlay — it never touches an environment-authored set.',
+      successMessage: 'Overlay discarded — the set is resynced to the shipped artifact',
+      refreshAfter: true,
+      visible: "has(record.drift_status) && record.drift_status == 'overlay_shadow'",
+    },
+    {
       name: 'clone_permission_set',
       label: 'Clone',
       icon: 'copy',
@@ -122,8 +145,30 @@ export const SysPermissionSet = ObjectSchema.create({
       data: { provider: 'object', object: 'sys_permission_set' },
       // [ADR-0094] Surface provenance + the customized flag so admins can tell
       // a packaged set (and whether they've overlaid it) from an env set.
-      columns: ['label', 'name', 'managed_by', 'customized', 'active', 'updated_at'],
+      // [field report — rc→GA declared≠enforced surfacing] `drift_status`
+      // alongside them: `customized` alone stays `0` on a row whose
+      // `managed_by` is itself wrong (the provenance-skip + overlay-shadow
+      // confound), so it is not a substitute for this column.
+      columns: ['label', 'name', 'managed_by', 'customized', 'drift_status', 'active', 'updated_at'],
       sort: [{ field: 'label', order: 'asc' }],
+      pagination: { pageSize: 50 },
+    },
+    // [field report — rc→GA declared≠enforced surfacing] The LOUD surface:
+    // every package-declared set whose enforced grants differ from the
+    // shipped artifact, naming the set AND the cause (`drift_status`),
+    // updated every boot by `runPermissionSetDriftDiagnostics`. An in-sync
+    // set is never in this view — `drift_status` is written `null`, not
+    // `'in_sync'` (see `permission-set-drift.ts`), so this filter is a data
+    // fact, not merely a display choice: noise here is what would make the
+    // next real drift easy to ignore.
+    drifted: {
+      type: 'grid',
+      name: 'drifted',
+      label: 'Needs Attention',
+      data: { provider: 'object', object: 'sys_permission_set' },
+      columns: ['label', 'name', 'managed_by', 'drift_status', 'drift_detail', 'updated_at'],
+      filter: [{ field: 'drift_status', operator: 'is_not_null' }],
+      sort: [{ field: 'updated_at', order: 'desc' }],
       pagination: { pageSize: 50 },
     },
   },
@@ -267,6 +312,45 @@ export const SysPermissionSet = ObjectSchema.create({
       description:
         'This packaged permission set has an environment customization overlay (ADR-0094). ' +
         'Reset it (delete through the data door) to return to the shipped baseline.',
+      group: 'Provenance',
+    }),
+
+    // [field report — rc→GA declared≠enforced surfacing] Set when this
+    // package-declared set's ENFORCED grants differ from the shipped
+    // artifact — `runPermissionSetDriftDiagnostics` (permission-set-drift.ts)
+    // recomputes it every boot. Absent (null) means enforced == declared, OR
+    // this set is not currently package-declared — an in-sync set is never
+    // given a value here, on purpose (a badge that fires on every packaged
+    // set is noise, and noise is how the next real one gets ignored).
+    // ⚠️ NOT a substitute for, and not derived from, `customized`: that flag
+    // is forced `false` on a row whose `managed_by` is itself wrong (the
+    // provenance-skip + overlay-shadow confound measured on the field-
+    // reported environment), which is exactly the case this field still
+    // needs to catch.
+    drift_status: Field.select({
+      label: 'Declaration Drift',
+      required: false,
+      readonly: true,
+      description:
+        "Cause of a declared≠enforced mismatch for this package-declared set. 'overlay_shadow' = a Studio-" +
+        "authored environment overlay is shadowing the packaged declaration — resync it with the Discard " +
+        "Overlay action. 'provenance_skip' = this row predates package provenance tracking, so boot sync " +
+        "treats it as environment-authored and never reconciles it with the package (no automated fix — file " +
+        "an issue / see the ops runbook for the manual adoption recipe). Absent = enforced grants match the " +
+        "shipped artifact, or this set is not currently package-declared.",
+      options: [
+        { value: 'overlay_shadow', label: 'Overlay shadow' },
+        { value: 'provenance_skip', label: 'Provenance skip' },
+        { value: 'other', label: 'Drift (other)' },
+      ],
+      group: 'Provenance',
+    }),
+
+    drift_detail: Field.textarea({
+      label: 'Drift Detail',
+      required: false,
+      readonly: true,
+      description: 'Human-readable detail for `drift_status` — names the grant-count mismatch and its cause.',
       group: 'Provenance',
     }),
 

--- a/packages/plugins/plugin-security/src/permission-set-drift.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-drift.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import {
   computePermissionSetDriftDiagnostics,
   persistPermissionSetDriftDiagnostics,
@@ -46,10 +47,17 @@ function makeQl(declared: any[] = []) {
       const rows = tableFor(object);
       return rows ? rows.filter((r) => matches(r, q?.where)) : [];
     },
-    async update(object: string, data: any) {
+    // Routed through the real dispatch predicate (#4434 / check:engine-double-contract):
+    // a fake looser than ObjectQL.update would let persistPermissionSetDriftDiagnostics
+    // drift to a call shape the real engine refuses while this suite stayed green.
+    async update(object: string, data: any, options?: any) {
       const rows = tableFor(object);
-      const r = rows?.find((x) => x.id === data.id);
-      if (r) Object.assign(r, data);
+      const dispatch = assertEngineUpdateDispatch(data, options);
+      const targets = dispatch.kind === 'by-id'
+        ? (rows ?? []).filter((r: any) => r.id === dispatch.id)
+        : (rows ?? []).filter((r: any) => matches(r, options?.where));
+      for (const r of targets) Object.assign(r, data);
+      return dispatch.kind === 'by-id' ? (targets[0] ?? null) : targets.length;
     },
   };
 }

--- a/packages/plugins/plugin-security/src/permission-set-drift.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-drift.test.ts
@@ -32,6 +32,16 @@ function makeQl(declared: any[] = []) {
     object === 'sys_permission_set' ? permRows : object === 'sys_metadata' ? metaRows : null;
   const matches = (r: any, where: any) =>
     Object.entries(where ?? {}).every(([k, v]) => {
+      // REFUSE the combinators this double does not implement rather than
+      // reading `$and`/`$or` as a column name (check:where-matcher /
+      // #8494) -- neither code path under test here (drift detection reads
+      // sys_permission_set/sys_metadata by id/name/type/state, batched by
+      // `$in` via `buildExistingByName`) ever issues one; a matcher that
+      // silently treated a combinator as a field name would let a future
+      // combinator query pass this suite while answering the wrong rows.
+      if (k.startsWith('$')) {
+        throw new Error(`fake driver: unsupported combinator ${k}`);
+      }
       if (v && typeof v === 'object' && !Array.isArray(v)) {
         const inList = (v as any).$in;
         if (Array.isArray(inList)) return inList.includes(r[k]);

--- a/packages/plugins/plugin-security/src/permission-set-drift.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-drift.test.ts
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * "declared ≠ enforced" surfacing (field report: rc→GA upgraded envs freeze
+ * a package-declared permission set's grants, silently). Pins, one per test
+ * group:
+ *
+ *  1. a set whose enforced grants differ from the artifact is surfaced,
+ *     naming the set AND the cause;
+ *  2. ⭐ the counter-direction — an in-sync set is NOT surfaced (`in_sync` is
+ *     persisted as `null`, never a value that reads as a badge);
+ *  3. both mechanisms are detected AND correctly attributed, including the
+ *     CONFOUNDED case where `managed_by` is wrong AND an overlay exists
+ *     (the exact field-reported shape) — a detector that finds drift but
+ *     mislabels the cause sends the operator to the wrong remedy.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computePermissionSetDriftDiagnostics,
+  persistPermissionSetDriftDiagnostics,
+  runPermissionSetDriftDiagnostics,
+} from './permission-set-drift.js';
+import { permissionSetRowFields } from './permission-set-projection.js';
+
+/** Minimal in-memory ql: sys_permission_set + sys_metadata + $in support. */
+function makeQl(declared: any[] = []) {
+  const permRows: any[] = [];
+  const metaRows: any[] = [];
+  const tableFor = (object: string) =>
+    object === 'sys_permission_set' ? permRows : object === 'sys_metadata' ? metaRows : null;
+  const matches = (r: any, where: any) =>
+    Object.entries(where ?? {}).every(([k, v]) => {
+      if (v && typeof v === 'object' && !Array.isArray(v)) {
+        const inList = (v as any).$in;
+        if (Array.isArray(inList)) return inList.includes(r[k]);
+        throw new Error(`fake driver: unsupported operator ${Object.keys(v).join(',')}`);
+      }
+      return r[k] === v;
+    });
+  return {
+    permRows,
+    metaRows,
+    registry: { listItems: (type: string) => (type === 'permission' ? declared : []) },
+    async find(object: string, q: any) {
+      const rows = tableFor(object);
+      return rows ? rows.filter((r) => matches(r, q?.where)) : [];
+    },
+    async update(object: string, data: any) {
+      const rows = tableFor(object);
+      const r = rows?.find((x) => x.id === data.id);
+      if (r) Object.assign(r, data);
+    },
+  };
+}
+
+const declaredSet = (over: Record<string, any> = {}) => ({
+  name: 'ehr_quality_inspector',
+  label: 'Quality Inspector',
+  objects: {
+    obj_a: { allowRead: true }, obj_b: { allowRead: true }, obj_c: { allowRead: true },
+  }, // 3 objects — "the artifact" (stands in for the field report's 49)
+  _packageId: 'com.example.ehr',
+  ...over,
+});
+
+/**
+ * A row whose stored facets equal `declaredSet()`'s — built from the SAME
+ * `permissionSetRowFields` projection the real boot seeders write, so this
+ * fixture cannot drift from what `recordDiffersFromBody` actually compares
+ * (label / description / all five JSON facet columns).
+ */
+const inSyncRow = (over: Record<string, any> = {}) => ({
+  id: 'ps_1',
+  name: 'ehr_quality_inspector',
+  managed_by: 'package',
+  package_id: 'com.example.ehr',
+  ...permissionSetRowFields(declaredSet()),
+  ...over,
+});
+
+describe('computePermissionSetDriftDiagnostics — pin 2 (quiet case): an in-sync set is NOT surfaced', () => {
+  it('a package-owned row whose content matches the artifact reports in_sync (persisted as null)', async () => {
+    const ql = makeQl([declaredSet()]);
+    ql.permRows.push(inSyncRow());
+    const diagnostics = await computePermissionSetDriftDiagnostics(ql);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].status).toBe('in_sync');
+    expect(diagnostics[0].detail).toBeNull();
+
+    const { updated } = await persistPermissionSetDriftDiagnostics(ql, diagnostics);
+    expect(updated).toBe(0); // row already had no drift_status — nothing to write
+    expect(ql.permRows[0].drift_status).toBeUndefined();
+  });
+
+  it('a steady-state re-run issues ZERO writes once drift_status already reflects the truth (#10946 discipline)', async () => {
+    const ql = makeQl([declaredSet()]);
+    ql.permRows.push(inSyncRow({ drift_status: null, drift_detail: null }));
+    const { updated } = await runPermissionSetDriftDiagnostics(ql);
+    expect(updated).toBe(0);
+  });
+});
+
+describe('computePermissionSetDriftDiagnostics — pin 1 & 3: both mechanisms detected AND correctly attributed', () => {
+  it("overlay_shadow: an active sys_metadata overlay shadows a managed_by:'package' row", async () => {
+    const artifact = declaredSet(); // 3-object artifact
+    const ql = makeQl([artifact]);
+    // row currently enforces only 2 objects (the overlay's stale content)
+    ql.permRows.push(inSyncRow({
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true }, obj_b: { allowRead: true } }),
+    }));
+    ql.metaRows.push({
+      id: 'meta_1', type: 'permission', name: 'ehr_quality_inspector', state: 'active',
+      organization_id: null,
+      metadata: JSON.stringify({ name: 'ehr_quality_inspector', objects: { obj_a: {}, obj_b: {} } }),
+    });
+
+    const [d] = await computePermissionSetDriftDiagnostics(ql);
+    expect(d.status).toBe('overlay_shadow');
+    expect(d.detail).toContain('overlay');
+    expect(d.detail).toContain('Discard');
+  });
+
+  it("provenance_skip: managed_by is NOT 'package' (legacy row), no overlay present", async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    ql.permRows.push(inSyncRow({
+      managed_by: 'admin', // legacy / pre-provenance insert
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true } }), // frozen at an old, smaller snapshot
+    }));
+    // no sys_metadata overlay row at all
+
+    const [d] = await computePermissionSetDriftDiagnostics(ql);
+    expect(d.status).toBe('provenance_skip');
+    expect(d.detail).toContain('managed_by');
+    expect(d.detail).not.toContain('overlay is shadowing'); // never conflate the two causes' wording
+  });
+
+  it('CONFOUNDED case (the exact field-reported shape): managed_by is wrong AND an overlay exists — attributed as overlay_shadow, not provenance_skip', async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    // The row's managed_by is wrong (provenance-skip candidate) …
+    ql.permRows.push(inSyncRow({
+      managed_by: 'admin',
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true }, obj_b: { allowRead: true } }),
+    }));
+    // … AND an active overlay is ALSO present for the same name — the
+    // decisive stale source per the field follow-up. Detection must not be
+    // fooled by the wrong managed_by into calling this provenance_skip.
+    ql.metaRows.push({
+      id: 'meta_1', type: 'permission', name: 'ehr_quality_inspector', state: 'active',
+      organization_id: null,
+      metadata: JSON.stringify({ name: 'ehr_quality_inspector', objects: { obj_a: {}, obj_b: {} } }),
+    });
+
+    const [d] = await computePermissionSetDriftDiagnostics(ql);
+    expect(d.status).toBe('overlay_shadow'); // correctly attributed despite the confound
+  });
+
+  it('a set with no owning package is never diagnosed (nothing to compare against)', async () => {
+    const ql = makeQl([declaredSet({ _packageId: undefined, packageId: undefined })]);
+    ql.permRows.push(inSyncRow({ managed_by: 'admin', object_permissions: '{}' }));
+    const diagnostics = await computePermissionSetDriftDiagnostics(ql);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('a name with no materialized row yet is skipped (boot seeding will create it, nothing to diagnose)', async () => {
+    const ql = makeQl([declaredSet()]);
+    const diagnostics = await computePermissionSetDriftDiagnostics(ql);
+    expect(diagnostics).toHaveLength(0);
+  });
+});
+
+describe('persistPermissionSetDriftDiagnostics — writes are equality-gated', () => {
+  it('writes drift_status/drift_detail once, then issues zero further writes on an unchanged re-run', async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    ql.permRows.push(inSyncRow({
+      managed_by: 'admin',
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true } }),
+    }));
+
+    const first = await runPermissionSetDriftDiagnostics(ql);
+    expect(first.updated).toBe(1);
+    expect(ql.permRows[0].drift_status).toBe('provenance_skip');
+    expect(typeof ql.permRows[0].drift_detail).toBe('string');
+
+    const second = await runPermissionSetDriftDiagnostics(ql);
+    expect(second.updated).toBe(0); // nothing changed — no round trip
+  });
+});

--- a/packages/plugins/plugin-security/src/permission-set-drift.ts
+++ b/packages/plugins/plugin-security/src/permission-set-drift.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * "declared ≠ enforced" surfacing for package-declared `sys_permission_set`
+ * rows (field report: rc→GA upgraded envs freeze a package's permission set
+ * at a first-boot/overlay snapshot while the shipped artifact keeps moving —
+ * grants stay frozen for weeks, silently, and the only signal was a boot log
+ * counter).
+ *
+ * TWO INDEPENDENT MECHANISMS can make a package-declared set's ENFORCED
+ * grants (what `sys_permission_set` actually stores, and what the evaluator
+ * resolves) diverge from its shipped ARTIFACT (what `readDeclared` reads from
+ * the engine's SchemaRegistry, the same source `bootstrapDeclaredPermissions`
+ * seeds from) — and neither may be assumed to be the only one live on a given
+ * environment:
+ *
+ *  - **`overlay_shadow`** — an active `sys_metadata` overlay row exists for
+ *    the set's name (a Studio permission-matrix save materialized one, back
+ *    when `permission` still allowed org overrides, or through the
+ *    `OS_METADATA_WRITABLE` hatch since). `reconcilePermissionSetProjection`
+ *    re-projects that overlay's content onto the record on EVERY boot
+ *    (ADR-0094 D4 step 1, unconditionally, keyed only on overlay presence),
+ *    so the overlay wins forever regardless of what the package ships next.
+ *  - **`provenance_skip`** — the row's `managed_by` is not `'package'` (a
+ *    legacy/pre-provenance insert — see `bootstrap-declared-permissions.ts`),
+ *    so `upsertPackagePermissionSet`'s package door refuses to touch it
+ *    (`skippedEnvAuthored`) on every boot, forever.
+ *
+ * ⚠️ THE TWO MECHANISMS CONFOUND EACH OTHER. When BOTH are present on one row
+ * — the exact field-report shape — `upsertEnvPermissionSet`'s `customized`
+ * flag (`existing.managed_by === 'package' ? !!customized : false`) is
+ * FORCED FALSE, because the row's `managed_by` is wrong (provenance_skip),
+ * even though an overlay genuinely IS shadowing it. That is measurably why
+ * `customized` stayed `0` on the field-reported environment — the ADR-0094
+ * surface an admin would check said "not customized" while an overlay had
+ * frozen the set for two weeks. So detection here does NOT trust
+ * `managed_by` to decide whether an overlay is shadowing a row — overlay
+ * presence is checked directly against `sys_metadata`, independent of the
+ * row's (possibly wrong) provenance column, exactly so this confounded case
+ * is still attributed correctly (`overlay_shadow`, not silently missed).
+ *
+ * WHAT THIS MODULE DOES NOT DO: it never guesses which mechanism explains a
+ * mismatch — it re-derives the fact each boot from the current `sys_metadata`
+ * / `sys_permission_set` state, the same sources the two write-doors read.
+ * It also never adopts/migrates a row (out of scope by 2026-08-20 maintainer
+ * ruling — "新项目还没上线，不需要清理旧数据，也没有老客户升级"; the
+ * `sanctioned discard` counterpart lives in `permission-set-overlay-discard.ts`
+ * and only ever touches the `sys_metadata` overlay row, never `managed_by` /
+ * `package_id`).
+ *
+ * ⚠️ Scope note shared with `reconcilePermissionSetProjection`: only
+ * ENV-WIDE overlays (`sys_metadata.organization_id IS NULL`) are considered
+ * — the per-organization overlay residue the projection file's header already
+ * documents as deliberately out of scope (#10103) stays out of scope here
+ * too, for the same reason (this module answers the identical "is there an
+ * overlay" question the reconciler already answers, from the same rows).
+ */
+
+import {
+  recordDiffersFromBody,
+  tryFind,
+  tryUpdate,
+  type ProjectionLogger,
+} from './permission-set-projection.js';
+import { readDeclared } from './bootstrap-declared-permissions.js';
+import { buildExistingByName } from './seed-name-lookup.js';
+
+/**
+ * Cause a package-declared set's enforced grants can diverge from its shipped
+ * artifact. `in_sync` and `other` are internal/testing values only —
+ * {@link persistPermissionSetDriftDiagnostics} writes `null` for `in_sync`
+ * (pin: an in-sync set must not be surfaced at all, not even as a quiet
+ * "ok" badge) and keeps `other` as a truthful catch-all for the one case
+ * neither named mechanism explains (a package-owned row whose own boot-seed
+ * write failed — `unreadable` — so its content is stale for a reason that is
+ * neither an overlay nor a provenance skip).
+ */
+export type PermissionSetDriftStatus = 'in_sync' | 'overlay_shadow' | 'provenance_skip' | 'other';
+
+export interface PermissionSetDriftDiagnostic {
+  id: string;
+  name: string;
+  packageId: string;
+  status: PermissionSetDriftStatus;
+  /** Human-readable detail naming the grant-count mismatch and the cause. `null` when in sync. */
+  detail: string | null;
+  /** The row's stored `drift_status` before this pass (already normalized: `'in_sync'` read back as `null`). */
+  priorStatus: string | null;
+  priorDetail: string | null;
+}
+
+export interface DriftDiagnosticsOptions {
+  logger?: ProjectionLogger;
+  organizationId?: string;
+}
+
+function countGrantedObjects(objects: any): number {
+  return objects && typeof objects === 'object' ? Object.keys(objects).length : 0;
+}
+
+/** True when `row` carries an ACTIVE env-wide `sys_metadata` overlay for `name` (independent of `managed_by`). */
+function buildOverlayNameSet(rows: any[]): Set<string> {
+  const out = new Set<string>();
+  for (const r of rows) {
+    if ((r?.organization_id ?? null) !== null || !r?.name) continue; // env-wide overlays only — see module header
+    out.add(String(r.name));
+  }
+  return out;
+}
+
+/**
+ * Compute (never write) the drift diagnostic for every currently package-
+ * declared permission set. Pure function over the passed `ql` — a boot pass
+ * and a test both call this the same way; {@link persistPermissionSetDriftDiagnostics}
+ * is the only thing that writes.
+ */
+export async function computePermissionSetDriftDiagnostics(
+  ql: any,
+  opts: DriftDiagnosticsOptions = {},
+): Promise<PermissionSetDriftDiagnostic[]> {
+  const out: PermissionSetDriftDiagnostic[] = [];
+  if (!ql || typeof ql.find !== 'function') return out;
+
+  const declared = readDeclared(ql, 'permission').filter((ps) => ps?.name && (ps._packageId ?? ps.packageId));
+  if (declared.length === 0) return out;
+
+  const organizationId = opts.organizationId;
+  const existingByName = await buildExistingByName(
+    ql,
+    'sys_permission_set',
+    declared.map((ps) => ps.name),
+    opts.logger,
+    organizationId,
+  );
+
+  // Same bulk overlay read `reconcilePermissionSetProjection` performs (ADR-0094
+  // D4 step 1) — both `permission` and its legacy plural spelling.
+  const overlayRows: any[] = [];
+  for (const type of ['permission', 'permissions']) {
+    overlayRows.push(...(await tryFind(ql, 'sys_metadata', { type, state: 'active' }, 1000)));
+  }
+  const overlayNames = buildOverlayNameSet(overlayRows);
+
+  for (const ps of declared) {
+    const name = String(ps.name);
+    const packageId = String(ps._packageId ?? ps.packageId);
+    const lookup = await existingByName.get(name);
+    if (lookup.status !== 'present') continue; // not yet materialized — nothing to diagnose (boot seeding creates it)
+    const row = lookup.row;
+    const priorStatus: string | null = row?.drift_status ?? null;
+    const priorDetail: string | null = row?.drift_detail ?? null;
+
+    const differs = recordDiffersFromBody(row, ps);
+    if (!differs) {
+      out.push({ id: row.id, name, packageId, status: 'in_sync', detail: null, priorStatus, priorDetail });
+      continue;
+    }
+
+    const declaredCount = countGrantedObjects(ps.objects);
+    const enforcedCount = countGrantedObjects(
+      (() => { try { return JSON.parse(row.object_permissions ?? '{}'); } catch { return {}; } })(),
+    );
+    const hasOverlay = overlayNames.has(name);
+
+    let status: PermissionSetDriftStatus;
+    let detail: string;
+    if (hasOverlay) {
+      status = 'overlay_shadow';
+      detail =
+        `An environment customization overlay (sys_metadata, type:'permission', name:'${name}') is shadowing ` +
+        `this package-declared set — enforced grants (${enforcedCount} object(s)) come from the overlay, not ` +
+        `the shipped artifact (${declaredCount} object(s)). Discard the overlay (Discard Overlay action) to resync.`;
+    } else if (row.managed_by !== 'package') {
+      status = 'provenance_skip';
+      detail =
+        `This row's managed_by ('${row.managed_by ?? 'none'}') predates package provenance tracking, so boot ` +
+        `sync treats it as environment-authored and never reconciles it with the package — enforced grants ` +
+        `(${enforcedCount} object(s)) are frozen at an old snapshot vs. the shipped artifact's ` +
+        `${declaredCount} object(s).`;
+    } else {
+      status = 'other';
+      detail =
+        `Enforced grants (${enforcedCount} object(s)) differ from the shipped artifact (${declaredCount} ` +
+        `object(s)) for a reason that is neither an overlay nor a provenance skip — check boot logs for ` +
+        `'[security] declared permission sets left untouched'.`;
+    }
+    out.push({ id: row.id, name, packageId, status, detail, priorStatus, priorDetail });
+  }
+  return out;
+}
+
+/**
+ * Write the computed diagnostics onto their `sys_permission_set` rows.
+ * EQUALITY-GATED (#10946 discipline): a row whose stored `drift_status` /
+ * `drift_detail` already match is left untouched — a steady-state boot pays
+ * zero writes, matching the round-trip contract every other pass in this file
+ * keeps.
+ *
+ * `in_sync` is written as `null` — the "not surfaced" pin is a data-level
+ * fact, not merely a filtered view: a quiet set carries no `drift_status`
+ * value at all, so a client reading the raw record (not only the Setup
+ * "Needs Attention" view) sees nothing to worry about either.
+ */
+export async function persistPermissionSetDriftDiagnostics(
+  ql: any,
+  diagnostics: readonly PermissionSetDriftDiagnostic[],
+  opts: DriftDiagnosticsOptions = {},
+): Promise<{ updated: number }> {
+  let updated = 0;
+  for (const d of diagnostics) {
+    const status: string | null = d.status === 'in_sync' ? null : d.status;
+    const detail: string | null = d.status === 'in_sync' ? null : d.detail;
+    if (d.priorStatus === status && d.priorDetail === detail) continue;
+    if (await tryUpdate(ql, 'sys_permission_set', { id: d.id, drift_status: status, drift_detail: detail }, opts.organizationId)) {
+      updated += 1;
+    }
+  }
+  return { updated };
+}
+
+/** Compute + persist in one call — what boot wiring uses. */
+export async function runPermissionSetDriftDiagnostics(
+  ql: any,
+  opts: DriftDiagnosticsOptions = {},
+): Promise<{ diagnostics: PermissionSetDriftDiagnostic[]; updated: number }> {
+  const diagnostics = await computePermissionSetDriftDiagnostics(ql, opts);
+  const { updated } = await persistPermissionSetDriftDiagnostics(ql, diagnostics, opts);
+  if (updated > 0) {
+    opts.logger?.warn?.(
+      '[security] package-declared permission set(s) enforcing grants that differ from the shipped artifact',
+      {
+        updated,
+        drifted: diagnostics.filter((d) => d.status !== 'in_sync').map((d) => ({ name: d.name, status: d.status })),
+        ...(opts.organizationId ? { organization: opts.organizationId } : {}),
+      },
+    );
+  }
+  return { diagnostics, updated };
+}

--- a/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
@@ -31,7 +31,18 @@ function makeQl(declared: any[] = []) {
   const tableFor = (object: string) =>
     object === 'sys_permission_set' ? permRows : object === 'sys_metadata' ? metaRows : null;
   const matches = (r: any, where: any) =>
-    Object.entries(where ?? {}).every(([k, v]) => r[k] === v);
+    Object.entries(where ?? {}).every(([k, v]) => {
+      // REFUSE the combinators this double does not implement rather than
+      // reading `$and`/`$or` as a column name (check:where-matcher /
+      // #8494) -- discardPermissionSetOverlay's ql.find/update/delete calls
+      // (by id, or by type+name+state) never issue one; a matcher that
+      // silently treated a combinator as a field name would let a future
+      // combinator query pass this suite while answering the wrong rows.
+      if (k.startsWith('$')) {
+        throw new Error(`fake driver: unsupported combinator ${k}`);
+      }
+      return r[k] === v;
+    });
   return {
     permRows,
     metaRows,

--- a/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import {
   discardPermissionSetOverlay,
   PermissionSetNotFoundError,
@@ -39,18 +40,31 @@ function makeQl(declared: any[] = []) {
       const rows = tableFor(object);
       return rows ? rows.filter((r) => matches(r, q?.where)) : [];
     },
-    async update(object: string, data: any) {
+    // Routed through the real dispatch predicate (#4434 / check:engine-double-contract):
+    // a fake looser than ObjectQL.update would let discardPermissionSetOverlay's
+    // fallback (degraded-kernel) path drift to a call shape the real engine refuses.
+    async update(object: string, data: any, options?: any) {
       const rows = tableFor(object);
-      const r = rows?.find((x) => x.id === data.id);
-      if (r) Object.assign(r, data);
+      const dispatch = assertEngineUpdateDispatch(data, options);
+      const targets = dispatch.kind === 'by-id'
+        ? (rows ?? []).filter((r: any) => r.id === dispatch.id)
+        : (rows ?? []).filter((r: any) => matches(r, options?.where));
+      for (const r of targets) Object.assign(r, data);
+      return dispatch.kind === 'by-id' ? (targets[0] ?? null) : targets.length;
     },
+    // Same reason, delete half: this is the exact mouth `discardPermissionSetOverlay`
+    // uses to remove the stale `sys_metadata` overlay row.
     async delete(object: string, opts: any) {
       const rows = tableFor(object);
-      if (!rows) return false;
-      const id = opts?.where?.id;
-      const i = rows.findIndex((x: any) => x.id === id);
-      if (i >= 0) { rows.splice(i, 1); return true; }
-      return false;
+      const dispatch = assertEngineDeleteDispatch(opts);
+      if (!rows) return dispatch.kind === 'by-id' ? false : 0;
+      const targets = dispatch.kind === 'by-id'
+        ? rows.filter((r: any) => r.id === dispatch.id)
+        : rows.filter((r: any) => matches(r, opts?.where));
+      const remaining = rows.filter((r: any) => !targets.includes(r));
+      rows.length = 0;
+      rows.push(...remaining);
+      return dispatch.kind === 'by-id' ? targets.length > 0 : targets.length;
     },
   };
 }

--- a/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
+++ b/packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The sanctioned, audited discard action (field report ask #2 — the field
+ * remediation had to delete a `sys_metadata` row by raw SQL; this is that
+ * same operation as a supported code path). Pins:
+ *
+ *  4. the discard action actually restores sync — the healed GRANT SET is
+ *     asserted, not just "the action returned ok";
+ *  5. ⭐ the discard action refuses what it must — it targets package-
+ *     declared sets only, so a genuinely environment-authored set (no
+ *     current package declaration under that name) is refused, with no
+ *     mutation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  discardPermissionSetOverlay,
+  PermissionSetNotFoundError,
+  PermissionSetOverlayStateError,
+  type PermissionSetOverlayDiscardDeps,
+} from './permission-set-overlay-discard.js';
+import { PermissionDeniedError } from './errors.js';
+import { permissionSetRowFields } from './permission-set-projection.js';
+
+/** Minimal in-memory ql: sys_permission_set + sys_metadata + delete support. */
+function makeQl(declared: any[] = []) {
+  const permRows: any[] = [];
+  const metaRows: any[] = [];
+  const tableFor = (object: string) =>
+    object === 'sys_permission_set' ? permRows : object === 'sys_metadata' ? metaRows : null;
+  const matches = (r: any, where: any) =>
+    Object.entries(where ?? {}).every(([k, v]) => r[k] === v);
+  return {
+    permRows,
+    metaRows,
+    registry: { listItems: (type: string) => (type === 'permission' ? declared : []) },
+    async find(object: string, q: any) {
+      const rows = tableFor(object);
+      return rows ? rows.filter((r) => matches(r, q?.where)) : [];
+    },
+    async update(object: string, data: any) {
+      const rows = tableFor(object);
+      const r = rows?.find((x) => x.id === data.id);
+      if (r) Object.assign(r, data);
+    },
+    async delete(object: string, opts: any) {
+      const rows = tableFor(object);
+      if (!rows) return false;
+      const id = opts?.where?.id;
+      const i = rows.findIndex((x: any) => x.id === id);
+      if (i >= 0) { rows.splice(i, 1); return true; }
+      return false;
+    },
+  };
+}
+
+/** Fake metadata protocol: `getMetaItemLayered` reads the overlay straight off `ql.metaRows`. */
+function makeProtocol(ql: ReturnType<typeof makeQl>) {
+  return {
+    async getMetaItemLayered({ name }: { type: string; name: string }) {
+      const overlayRow = ql.metaRows.find(
+        (r: any) => r.type === 'permission' && r.name === name && r.state === 'active' && (r.organization_id ?? null) === null,
+      );
+      const overlay = overlayRow ? JSON.parse(overlayRow.metadata) : null;
+      return { type: 'permission', name, code: null, overlay, effective: overlay };
+    },
+  };
+}
+
+const declaredSet = (over: Record<string, any> = {}) => ({
+  name: 'ehr_quality_inspector',
+  label: 'Quality Inspector',
+  objects: { obj_a: { allowRead: true }, obj_b: { allowRead: true }, obj_c: { allowRead: true } }, // 3-object artifact
+  _packageId: 'com.example.ehr',
+  ...over,
+});
+
+const overlayRow = (staleObjects: Record<string, any>) => ({
+  id: 'meta_1', type: 'permission', name: 'ehr_quality_inspector', state: 'active', organization_id: null,
+  metadata: JSON.stringify({ name: 'ehr_quality_inspector', objects: staleObjects }),
+});
+
+const tenantAdminCtx = { userId: 'u_admin', isSystem: false };
+
+function deps(ql: ReturnType<typeof makeQl>, protocol: any = makeProtocol(ql)): PermissionSetOverlayDiscardDeps {
+  return {
+    ql,
+    metadata: { registerInMemory() {}, get: async () => undefined, unregister() {} },
+    // `isTenantAdmin` (delegated-admin-gate.ts) keys on a resolved set's `'*'`
+    // wildcard `modifyAllRecords: true` — NOT `systemPermissions` — so the
+    // fixture representing "caller is a tenant admin" has to carry that.
+    resolveSets: async () => [{ name: 'platform_admin', objects: { '*': { modifyAllRecords: true } }, fields: {}, systemPermissions: [] } as any],
+    getProtocol: () => protocol,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+}
+
+describe('discardPermissionSetOverlay — pin 4: actually restores sync', () => {
+  it('discards the stale overlay and heals the row to the CURRENT declared artifact (asserts the healed grant set)', async () => {
+    const artifact = declaredSet(); // ships 3 objects
+    const ql = makeQl([artifact]);
+    ql.permRows.push({
+      id: 'ps_1', name: 'ehr_quality_inspector', managed_by: 'package', package_id: 'com.example.ehr',
+      ...permissionSetRowFields(artifact),
+      // enforced content overridden below to the STALE overlay's 2-object shape
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true }, obj_b: { allowRead: true } }),
+    });
+    ql.metaRows.push(overlayRow({ obj_a: {}, obj_b: {} })); // the stale overlay (2 objects, missing obj_c)
+
+    const result = await discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'ps_1');
+
+    expect(result.overlaysDiscarded).toBe(1);
+    expect(ql.metaRows).toHaveLength(0); // the overlay row is gone
+    // The healed row now enforces the ARTIFACT's full 3-object grant set —
+    // not merely "an update happened".
+    expect(result.healedObjectGrantCount).toBe(3);
+    const healedObjects = JSON.parse(result.permissionSet.object_permissions);
+    expect(Object.keys(healedObjects).sort()).toEqual(['obj_a', 'obj_b', 'obj_c']);
+    expect(result.permissionSet.customized).toBe(false); // no overlay left to badge
+  });
+
+  it('the CONFOUNDED field-reported shape (managed_by wrong AND overlay present) still discards and heals — eligibility is NOT gated on managed_by', async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    ql.permRows.push({
+      id: 'ps_1', name: 'ehr_quality_inspector', managed_by: 'admin', // wrong provenance — the confound
+      ...permissionSetRowFields(artifact),
+      object_permissions: JSON.stringify({ obj_a: { allowRead: true } }),
+    });
+    ql.metaRows.push(overlayRow({ obj_a: {} }));
+
+    const result = await discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'ps_1');
+    expect(result.healedObjectGrantCount).toBe(3);
+    expect(ql.metaRows).toHaveLength(0);
+  });
+});
+
+describe('discardPermissionSetOverlay — pin 5: refuses what it must', () => {
+  it('refuses a set with NO current package declaration (genuinely environment-authored) — no mutation', async () => {
+    const ql = makeQl([]); // nothing declared by any package
+    ql.permRows.push({
+      id: 'ps_env', name: 'sales_readonly', managed_by: 'admin',
+      object_permissions: JSON.stringify({ crm_lead: { allowRead: true } }),
+    });
+    ql.metaRows.push({
+      id: 'meta_env', type: 'permission', name: 'sales_readonly', state: 'active', organization_id: null,
+      metadata: JSON.stringify({ name: 'sales_readonly', objects: { crm_lead: { allowRead: true } } }),
+    });
+
+    await expect(discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'ps_env'))
+      .rejects.toBeInstanceOf(PermissionDeniedError);
+
+    // No mutation: the overlay is still there, the row is untouched.
+    expect(ql.metaRows).toHaveLength(1);
+    expect(JSON.parse(ql.permRows[0].object_permissions)).toEqual({ crm_lead: { allowRead: true } });
+  });
+
+  it('a NAME COLLISION with a genuinely env-authored set is refused even though a DIFFERENT package declares an unrelated set (name match against the declared registry only)', async () => {
+    // `readDeclared` returns items for OTHER names too — eligibility must
+    // match on the TARGET row's own name, not "some package declares
+    // something".
+    const ql = makeQl([declaredSet({ name: 'crm_admin' })]);
+    ql.permRows.push({ id: 'ps_env', name: 'sales_readonly', managed_by: 'admin', object_permissions: '{}' });
+    ql.metaRows.push({
+      id: 'meta_env', type: 'permission', name: 'sales_readonly', state: 'active', organization_id: null,
+      metadata: JSON.stringify({ name: 'sales_readonly', objects: {} }),
+    });
+    await expect(discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'ps_env'))
+      .rejects.toBeInstanceOf(PermissionDeniedError);
+  });
+
+  it('404s on an unknown id', async () => {
+    const ql = makeQl([declaredSet()]);
+    await expect(discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'nope'))
+      .rejects.toBeInstanceOf(PermissionSetNotFoundError);
+  });
+
+  it('409s when the package-declared set has no active overlay to discard', async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    ql.permRows.push({
+      id: 'ps_1', name: 'ehr_quality_inspector', managed_by: 'package', package_id: 'com.example.ehr',
+      ...permissionSetRowFields(artifact),
+    });
+    // no overlay row
+    await expect(discardPermissionSetOverlay(deps(ql), tenantAdminCtx, 'ps_1'))
+      .rejects.toBeInstanceOf(PermissionSetOverlayStateError);
+  });
+
+  it('refuses an unauthenticated / non-admin caller before touching anything', async () => {
+    const artifact = declaredSet();
+    const ql = makeQl([artifact]);
+    ql.permRows.push({
+      id: 'ps_1', name: 'ehr_quality_inspector', managed_by: 'package', package_id: 'com.example.ehr',
+      ...permissionSetRowFields(artifact),
+    });
+    ql.metaRows.push(overlayRow({ obj_a: {} }));
+    const nonAdminDeps: PermissionSetOverlayDiscardDeps = {
+      ...deps(ql),
+      resolveSets: async () => [], // not a tenant admin
+    };
+    await expect(discardPermissionSetOverlay(nonAdminDeps, tenantAdminCtx, 'ps_1'))
+      .rejects.toBeInstanceOf(PermissionDeniedError);
+    expect(ql.metaRows).toHaveLength(1); // untouched
+  });
+});

--- a/packages/plugins/plugin-security/src/permission-set-overlay-discard.ts
+++ b/packages/plugins/plugin-security/src/permission-set-overlay-discard.ts
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Sanctioned, audited operator action: discard a stale `sys_metadata`
+ * overlay shadowing a PACKAGE-DECLARED `sys_permission_set` (the
+ * `overlay_shadow` mechanism {@link ../permission-set-drift.ts} detects).
+ *
+ * Field report: the only remediation available was raw SQL against
+ * `sys_metadata` (`DELETE … WHERE type='permission' AND name='…'`), run by
+ * hand against production. This module is that same operation — the SAME
+ * physical row, the SAME table — as a supported, gated, audited code path
+ * instead. Maintainer ruling 2026-08-20 (「新项目还没上线，不需要清理旧数据，
+ * 也没有老客户升级」) scoped this DELIBERATELY NARROWLY: this is an
+ * operator-invoked, one-set-at-a-time, explicit mutation — never boot-time
+ * auto-adoption and never a bulk `os meta adopt-permission-sets` command
+ * (both stay out of scope). It never touches `managed_by` / `package_id`:
+ * once the overlay is gone, the EXISTING env-door reconciler
+ * (`reconcilePermissionSetProjection` step 2/3, ADR-0094 D4) keeps the row in
+ * sync with the artifact on every subsequent boot, on its own — no adoption
+ * needed for grant CONTENT to stay current, only for the row's provenance
+ * columns (out of scope, unaffected by this action).
+ *
+ * ## Why this bypasses `deleteMetaItem`, not calls it
+ *
+ * `permission` is `allowOrgOverride: false` since #6483/#6608 (ADR-0094
+ * D5-R), so the protocol's ADR-0005 tier gate refuses `deleteMetaItem` on an
+ * artifact-backed name with 403 `NOT_OVERRIDABLE` — see
+ * `permission-set-projection.ts`'s header, "leaving the operator hatch
+ * (`OS_METADATA_WRITABLE=permission`) as the only documented removal." That
+ * hatch is a blunt, environment-wide, undocumented-to-Setup escape valve —
+ * exactly what ask #2 exists to replace. This module deletes the
+ * `sys_metadata` overlay row DIRECTLY (SYSTEM context), never through
+ * `deleteMetaItem`, because the tier gate's refusal is correct in general
+ * (a data-door write must not silently re-fork a packaged set) and the
+ * discard action is a DIFFERENT, narrower operation the gate has no seat for:
+ * "remove a stale overlay and let the row re-converge to its declared
+ * artifact", never "write a new customization".
+ *
+ * ## Eligibility — pin: refuses what it must
+ *
+ * "Package-declared" is decided by asking the SAME source
+ * `bootstrapDeclaredPermissions` reads — `readDeclared(ql, 'permission')` —
+ * for an item whose `name` matches AND carries a resolvable owning package
+ * (`_packageId ?? packageId`), never by trusting the row's `managed_by`
+ * column. This is deliberate: `managed_by` is exactly the column the
+ * `provenance_skip` mechanism gets wrong, so gating on it would refuse the
+ * one case this action most needs to fix (a genuinely package-declared set
+ * whose row's `managed_by` was never 'package' to begin with — the
+ * field-reported shape, where BOTH mechanisms compounded on one row). A name
+ * with no current package declaration is treated as genuinely
+ * environment-authored and refused — the maintainer's cited hazard verbatim:
+ * "a name collision with a genuinely env-authored set would be destroyed
+ * without a trace".
+ */
+
+import type { PermissionSet } from '@objectstack/spec/security';
+import {
+  SYSTEM_CTX,
+  permissionSetRowFields,
+  projectPermissionMutation,
+  tryFind,
+  tryUpdate,
+  type ProjectionDeps,
+  type ProjectionLogger,
+} from './permission-set-projection.js';
+import { readDeclared } from './bootstrap-declared-permissions.js';
+import { PermissionDeniedError } from './errors.js';
+import { isTenantAdmin } from './delegated-admin-gate.js';
+
+/** Thrown when the referenced `sys_permission_set` row does not exist → HTTP 404. */
+export class PermissionSetNotFoundError extends Error {
+  readonly code = 'NOT_FOUND';
+  readonly statusCode = 404;
+  constructor(id: string) {
+    super(`Permission set '${id}' not found`);
+    this.name = 'PermissionSetNotFoundError';
+  }
+}
+
+/** Thrown when there is no active overlay to discard → HTTP 409. */
+export class PermissionSetOverlayStateError extends Error {
+  readonly code = 'INVALID_STATE';
+  readonly statusCode = 409;
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermissionSetOverlayStateError';
+  }
+}
+
+export interface PermissionSetOverlayDiscardDeps {
+  ql: any;
+  metadata?: any;
+  /** Same tenant-admin resolution the confirm/dismiss suggestion flow uses. */
+  resolveSets: (context: any) => Promise<PermissionSet[]>;
+  /** Lazy protocol handle — mirrors `WriteThroughDeps.getProtocol` (the protocol service may register after start()). */
+  getProtocol: () => any;
+  logger?: ProjectionLogger;
+}
+
+export interface PermissionSetOverlayDiscardResult {
+  permissionSet: any;
+  /** Object grants the row now carries (post-reconcile) — the "healed" number, for callers to assert on. */
+  healedObjectGrantCount: number;
+  overlaysDiscarded: number;
+}
+
+function callerOrganizationId(callerCtx: any): string | undefined {
+  const id = callerCtx?.tenantId;
+  return typeof id === 'string' && id !== '' ? id : undefined;
+}
+
+async function assertTenantAdmin(deps: PermissionSetOverlayDiscardDeps, callerCtx: any): Promise<void> {
+  if (callerCtx?.isSystem) return;
+  if (!callerCtx?.userId) {
+    throw new PermissionDeniedError(
+      "[Security] Access denied: discarding a permission set's overlay requires an authenticated tenant administrator.",
+    );
+  }
+  let sets: PermissionSet[] = [];
+  try { sets = await deps.resolveSets(callerCtx); } catch { sets = []; }
+  if (!isTenantAdmin(sets)) {
+    throw new PermissionDeniedError(
+      "[Security] Access denied: discarding a permission set's overlay requires a tenant-level administrator.",
+      { userId: callerCtx.userId },
+    );
+  }
+}
+
+/** Every ACTIVE env-wide `sys_metadata` overlay row for `name` (both `permission`/`permissions` type spellings). */
+async function findActiveOverlayRows(ql: any, name: string): Promise<any[]> {
+  const rows: any[] = [];
+  for (const type of ['permission', 'permissions']) {
+    const page = await tryFind(ql, 'sys_metadata', { type, name, state: 'active' }, 10);
+    for (const r of page) {
+      if ((r?.organization_id ?? null) !== null) continue; // env-wide overlays only (see permission-set-drift.ts)
+      rows.push(r);
+    }
+  }
+  return rows;
+}
+
+function countGrantedObjects(row: any): number {
+  try {
+    const parsed = JSON.parse(row?.object_permissions ?? '{}');
+    return parsed && typeof parsed === 'object' ? Object.keys(parsed).length : 0;
+  } catch { return 0; }
+}
+
+/**
+ * Discard the stale overlay shadowing a package-declared permission set,
+ * then RESTORE SYNC synchronously — the row is re-projected to the current
+ * declared artifact before this returns (never "wait for the next boot").
+ */
+export async function discardPermissionSetOverlay(
+  deps: PermissionSetOverlayDiscardDeps,
+  callerCtx: any,
+  id: string,
+): Promise<PermissionSetOverlayDiscardResult> {
+  const { ql, logger } = deps;
+  await assertTenantAdmin(deps, callerCtx);
+  const organizationId = callerOrganizationId(callerCtx);
+
+  const row = (await tryFind(ql, 'sys_permission_set', { id }, 1, organizationId))[0];
+  if (!row) throw new PermissionSetNotFoundError(id);
+
+  // Eligibility: package-declared, decided from the ARTIFACT registry — never
+  // from `row.managed_by`, which is exactly the column the confounded
+  // provenance-skip + overlay-shadow case gets wrong. See module header.
+  const declaredItem = readDeclared(ql, 'permission').find(
+    (item: any) => item?.name === row.name && (item?._packageId ?? item?.packageId),
+  );
+  if (!declaredItem) {
+    throw new PermissionDeniedError(
+      `[Security] Access denied: '${String(row.name)}' is not currently declared by any installed package — ` +
+        `discarding its overlay would destroy environment-authored work with no trace and no recovery path. ` +
+        `This action targets package-declared sets only.`,
+      { id, name: row.name },
+    );
+  }
+
+  const overlays = await findActiveOverlayRows(ql, String(row.name));
+  if (overlays.length === 0) {
+    throw new PermissionSetOverlayStateError(
+      `Permission set '${row.name}' has no active environment overlay to discard — its enforced grants are not ` +
+        `currently shadowed (if they still differ from the shipped artifact, this is the 'provenance_skip' ` +
+        `mechanism, which this action does not target).`,
+    );
+  }
+
+  const beforeCount = countGrantedObjects(row);
+  for (const overlay of overlays) {
+    try {
+      await ql.delete('sys_metadata', { where: { id: overlay.id }, context: SYSTEM_CTX });
+    } catch (e) {
+      logger?.error?.(
+        '[security] failed to delete stale permission-set overlay row during sanctioned discard',
+        e as Error,
+        { name: row.name, overlayId: overlay.id },
+      );
+      throw e;
+    }
+  }
+
+  // Restore sync NOW, not on next boot: re-run the SAME projector the env
+  // door awaits on every save (ADR-0094) — with the overlay gone,
+  // `getMetaItemLayered` now yields the declared artifact body, so this both
+  // re-projects the record's facets and heals the evaluator's in-memory
+  // registry echo (`syncEvaluatorRegistry`'s "overlay gone" branch).
+  const protocol = deps.getProtocol?.();
+  const projectionDeps: ProjectionDeps = { ql, metadata: deps.metadata, logger };
+  let healedRow: any;
+  if (protocol && typeof protocol.getMetaItemLayered === 'function') {
+    await projectPermissionMutation(protocol, projectionDeps, {
+      type: 'permission', name: String(row.name), state: 'active', organizationId: organizationId ?? null,
+    });
+    healedRow = (await tryFind(ql, 'sys_permission_set', { id }, 1, organizationId))[0] ?? row;
+  } else {
+    // Degraded kernel with no metadata protocol: project the declared
+    // artifact's facets directly, same shape `upsertEnvPermissionSet` writes,
+    // clearing `customized` (there is no overlay left to badge).
+    await tryUpdate(
+      ql,
+      'sys_permission_set',
+      { id, ...permissionSetRowFields(declaredItem), customized: false },
+      organizationId,
+    );
+    healedRow = (await tryFind(ql, 'sys_permission_set', { id }, 1, organizationId))[0] ?? row;
+  }
+
+  const afterCount = countGrantedObjects(healedRow);
+  // Audited: who, what, before/after — the "supported, audited action" ask.
+  logger?.info?.('[security] package-declared permission set overlay discarded (sanctioned operator action)', {
+    id, name: row.name, packageId: declaredItem._packageId ?? declaredItem.packageId,
+    by: callerCtx?.userId, organization: organizationId,
+    overlaysDiscarded: overlays.length,
+    objectGrantsBefore: beforeCount, objectGrantsAfter: afterCount,
+  });
+
+  return { permissionSet: healedRow, healedObjectGrantCount: afterCount, overlaysDiscarded: overlays.length };
+}

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -35,6 +35,8 @@ import {
   registerPermissionSetProjection,
   reconcilePermissionSetProjection,
 } from './permission-set-projection.js';
+import { runPermissionSetDriftDiagnostics } from './permission-set-drift.js';
+import { discardPermissionSetOverlay, type PermissionSetOverlayDiscardDeps } from './permission-set-overlay-discard.js';
 import { registerObjectPostureGate } from './object-posture-gate.js';
 import {
   reconcileAudienceBindingSuggestions,
@@ -1177,6 +1179,20 @@ export class SecurityPlugin implements Plugin {
         resolveSets: (context: any) => this.resolvePermissionSetsForContext(context),
         logger: ctx.logger,
       };
+      // [field report — rc→GA declared≠enforced surfacing] Sanctioned overlay-
+      // discard deps — same tenant-admin resolution as the suggestion surface
+      // above. `getProtocol` is lazy (mirrors `createPermissionSetWriteThrough`'s
+      // own resolver further down): the protocol service may register after
+      // this plugin's `start()` runs.
+      const overlayDiscardDeps: PermissionSetOverlayDiscardDeps = {
+        ql,
+        metadata,
+        resolveSets: (context: any) => this.resolvePermissionSetsForContext(context),
+        getProtocol: () => {
+          try { return (ctx as any).getService?.('protocol') ?? null; } catch { return null; }
+        },
+        logger: ctx.logger,
+      };
       // Typed against the published contract so the registered surface cannot
       // drift from what cross-package consumers are promised: a renamed method,
       // a dropped one, or a changed return type fails THIS build rather than
@@ -1334,9 +1350,15 @@ export class SecurityPlugin implements Plugin {
       const registeredSecurityService = Object.assign(securityService, {
         getMetadataReadableFields: (object: string, context?: any) =>
           this.getMetadataReadableFields(object, context),
+        // [field report — rc→GA declared≠enforced surfacing] Same extension
+        // pattern as `getMetadataReadableFields` above, same reason:
+        // `ISecurityService` lives in `packages/spec` and this seat there is a
+        // separate change. Consumers feature-detect.
+        discardPermissionSetOverlay: (callerContext: any, id: string) =>
+          discardPermissionSetOverlay(overlayDiscardDeps, callerContext, id),
       });
       ctx.registerService('security', registeredSecurityService);
-      ctx.logger.info('[security] registered "security" service (getReadFilter, getReadableFields, getMetadataReadableFields, canExport, checkAuthoredRowWrite, resolvePermissionSetNames, resolvePermissionSetsForContext, explain, audience-binding suggestions) — ADR-0021 D-C / ADR-0090 D5/D6/D9 / ADR-0106 D7 / #3544 / #3547 / #5493 / #7616');
+      ctx.logger.info('[security] registered "security" service (getReadFilter, getReadableFields, getMetadataReadableFields, canExport, checkAuthoredRowWrite, resolvePermissionSetNames, resolvePermissionSetsForContext, explain, audience-binding suggestions, discardPermissionSetOverlay) — ADR-0021 D-C / ADR-0090 D5/D6/D9 / ADR-0094 / ADR-0106 D7 / #3544 / #3547 / #5493 / #7616');
     } catch (e) {
       ctx.logger.warn?.('[security] failed to register "security" service', {
         error: (e as Error).message,
@@ -3138,6 +3160,18 @@ export class SecurityPlugin implements Plugin {
             });
           } catch (e) {
             ctx.logger.warn('[security] permission-set projection reconciliation failed (ADR-0094)', { error: (e as Error).message });
+          }
+          // [field report — rc→GA declared≠enforced surfacing] Recompute
+          // "declared ≠ enforced" per package-declared set AFTER both doors
+          // have settled for this boot (the package door above, and the env
+          // door's reconciliation just above this line) — so `drift_status`
+          // reflects the boot's TRUE final state, not a mid-boot snapshot.
+          // Own try/catch: a failure here must never take down boot, and must
+          // never be read as "reconciliation also failed" in the log above.
+          try {
+            await runPermissionSetDriftDiagnostics(ql, { logger: ctx.logger });
+          } catch (e) {
+            ctx.logger.warn('[security] permission-set drift diagnostics failed', { error: (e as Error).message });
           }
         } catch (e) {
           ctx.logger.warn('[security] permission publish-materializer registration failed', { error: (e as Error).message });

--- a/packages/plugins/plugin-security/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/en.objects.generated.ts
@@ -236,6 +236,19 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
         label: "Customized",
         help: "This packaged permission set has an environment customization overlay (ADR-0094). Reset it (delete through the data door) to return to the shipped baseline."
       },
+      drift_status: {
+        label: "Declaration Drift",
+        help: "Cause of a declared≠enforced mismatch for this package-declared set. 'overlay_shadow' = a Studio-authored environment overlay is shadowing the packaged declaration — resync it with the Discard Overlay action. 'provenance_skip' = this row predates package provenance tracking, so boot sync treats it as environment-authored and never reconciles it with the package (no automated fix — file an issue / see the ops runbook for the manual adoption recipe). Absent = enforced grants match the shipped artifact, or this set is not currently package-declared.",
+        options: {
+          overlay_shadow: "Overlay shadow",
+          provenance_skip: "Provenance skip",
+          other: "Drift (other)"
+        }
+      },
+      drift_detail: {
+        label: "Drift Detail",
+        help: "Human-readable detail for `drift_status` — names the grant-count mismatch and its cause."
+      },
       id: {
         label: "Permission Set ID"
       },
@@ -255,6 +268,9 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       all_permsets: {
         label: "All"
+      },
+      drifted: {
+        label: "Needs Attention"
       }
     },
     _actions: {
@@ -266,6 +282,11 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
         label: "Deactivate",
         confirmText: "Deactivate this permission set? Existing assignments stay in place but stop granting access until re-activated.",
         successMessage: "Permission set deactivated"
+      },
+      discard_permission_set_overlay: {
+        label: "Discard Overlay",
+        confirmText: "Discard the environment overlay shadowing this package-declared set and resync it to the shipped artifact? This only removes the customization overlay — it never touches an environment-authored set.",
+        successMessage: "Overlay discarded — the set is resynced to the shipped artifact"
       },
       clone_permission_set: {
         label: "Clone",

--- a/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
@@ -236,6 +236,19 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         label: "Personalizado",
         help: "Este conjunto de permisos empaquetado tiene una superposición de personalización del entorno (ADR-0094). Reinícialo (elimínalo por la puerta de datos) para volver a la línea base distribuida."
       },
+      drift_status: {
+        label: "Declaration Drift",
+        help: "Cause of a declared≠enforced mismatch for this package-declared set. 'overlay_shadow' = a Studio-authored environment overlay is shadowing the packaged declaration — resync it with the Discard Overlay action. 'provenance_skip' = this row predates package provenance tracking, so boot sync treats it as environment-authored and never reconciles it with the package (no automated fix — file an issue / see the ops runbook for the manual adoption recipe). Absent = enforced grants match the shipped artifact, or this set is not currently package-declared.",
+        options: {
+          overlay_shadow: "Overlay shadow",
+          provenance_skip: "Provenance skip",
+          other: "Drift (other)"
+        }
+      },
+      drift_detail: {
+        label: "Drift Detail",
+        help: "Human-readable detail for `drift_status` — names the grant-count mismatch and its cause."
+      },
       id: {
         label: "ID de conjunto de permisos"
       },
@@ -255,6 +268,9 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       all_permsets: {
         label: "Todos"
+      },
+      drifted: {
+        label: "Needs Attention"
       }
     },
     _actions: {
@@ -266,6 +282,11 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         label: "Desactivar",
         confirmText: "¿Desactivar este conjunto de permisos? Las asignaciones existentes se mantienen, pero dejan de otorgar acceso hasta que se vuelva a activar.",
         successMessage: "Conjunto de permisos desactivado"
+      },
+      discard_permission_set_overlay: {
+        label: "Discard Overlay",
+        confirmText: "Discard the environment overlay shadowing this package-declared set and resync it to the shipped artifact? This only removes the customization overlay — it never touches an environment-authored set.",
+        successMessage: "Overlay discarded — the set is resynced to the shipped artifact"
       },
       clone_permission_set: {
         label: "Clonar",

--- a/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
@@ -236,6 +236,19 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
         label: "カスタマイズ済み",
         help: "このパッケージ権限セットには環境カスタマイズのオーバーレイがあります（ADR-0094）。リセット（データドア経由で削除）すると出荷時のベースラインに戻ります。"
       },
+      drift_status: {
+        label: "Declaration Drift",
+        help: "Cause of a declared≠enforced mismatch for this package-declared set. 'overlay_shadow' = a Studio-authored environment overlay is shadowing the packaged declaration — resync it with the Discard Overlay action. 'provenance_skip' = this row predates package provenance tracking, so boot sync treats it as environment-authored and never reconciles it with the package (no automated fix — file an issue / see the ops runbook for the manual adoption recipe). Absent = enforced grants match the shipped artifact, or this set is not currently package-declared.",
+        options: {
+          overlay_shadow: "Overlay shadow",
+          provenance_skip: "Provenance skip",
+          other: "Drift (other)"
+        }
+      },
+      drift_detail: {
+        label: "Drift Detail",
+        help: "Human-readable detail for `drift_status` — names the grant-count mismatch and its cause."
+      },
       id: {
         label: "権限セット ID"
       },
@@ -255,6 +268,9 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       all_permsets: {
         label: "すべて"
+      },
+      drifted: {
+        label: "Needs Attention"
       }
     },
     _actions: {
@@ -266,6 +282,11 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
         label: "無効化",
         confirmText: "この権限セットを無効化しますか？既存の割り当ては維持されますが、再度有効化するまでアクセスの付与は停止されます。",
         successMessage: "権限セットが無効化されました"
+      },
+      discard_permission_set_overlay: {
+        label: "Discard Overlay",
+        confirmText: "Discard the environment overlay shadowing this package-declared set and resync it to the shipped artifact? This only removes the customization overlay — it never touches an environment-authored set.",
+        successMessage: "Overlay discarded — the set is resynced to the shipped artifact"
       },
       clone_permission_set: {
         label: "複製",

--- a/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
@@ -236,6 +236,19 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
         label: "已定制",
         help: "该打包权限集存在环境定制覆盖层（ADR-0094）。重置它（通过数据入口删除）即可回到随包发布的基线。"
       },
+      drift_status: {
+        label: "Declaration Drift",
+        help: "Cause of a declared≠enforced mismatch for this package-declared set. 'overlay_shadow' = a Studio-authored environment overlay is shadowing the packaged declaration — resync it with the Discard Overlay action. 'provenance_skip' = this row predates package provenance tracking, so boot sync treats it as environment-authored and never reconciles it with the package (no automated fix — file an issue / see the ops runbook for the manual adoption recipe). Absent = enforced grants match the shipped artifact, or this set is not currently package-declared.",
+        options: {
+          overlay_shadow: "Overlay shadow",
+          provenance_skip: "Provenance skip",
+          other: "Drift (other)"
+        }
+      },
+      drift_detail: {
+        label: "Drift Detail",
+        help: "Human-readable detail for `drift_status` — names the grant-count mismatch and its cause."
+      },
       id: {
         label: "权限集 ID"
       },
@@ -255,6 +268,9 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       all_permsets: {
         label: "全部"
+      },
+      drifted: {
+        label: "Needs Attention"
       }
     },
     _actions: {
@@ -266,6 +282,11 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
         label: "停用",
         confirmText: "确定要停用此权限集吗？现有分配仍将保留，但在重新激活之前将不再授予访问权限。",
         successMessage: "权限集已停用"
+      },
+      discard_permission_set_overlay: {
+        label: "Discard Overlay",
+        confirmText: "Discard the environment overlay shadowing this package-declared set and resync it to the shipped artifact? This only removes the customization overlay — it never touches an environment-authored set.",
+        successMessage: "Overlay discarded — the set is resynced to the shipped artifact"
       },
       clone_permission_set: {
         label: "克隆",

--- a/packages/rest/src/rest-route-ledger.ts
+++ b/packages/rest/src/rest-route-ledger.ts
@@ -309,6 +309,13 @@ export const REST_ROUTE_LEDGER: readonly RestRouteLedgerEntry[] = [
     note: 'duplicate mount with the dispatcher /security domain' },
   { route: 'POST /api/v1/security/suggested-bindings/:id/dismiss', family: 'security', source: 'route-manager', disposition: 'sdk', client: 'security.suggestedBindings.dismiss',
     note: 'duplicate mount with the dispatcher /security domain' },
+  // [field report — rc→GA declared≠enforced surfacing] REST-only (no
+  // dispatcher twin, unlike the suggested-bindings family above): invoked by
+  // `sys_permission_set`'s "Discard Overlay" Setup action via a plain fetch
+  // to `target`, not through the typed SDK — see
+  // `permission-set-overlay-discard.ts`.
+  { route: 'POST /api/v1/security/permission-sets/:id/discard-overlay', family: 'security', source: 'route-manager', disposition: 'server-only',
+    note: 'Setup admin action only (sys_permission_set "Discard Overlay") — invoked via the declarative action target, not the SDK' },
 
   // ── reports ───────────────────────────────────────────────────────────────
   { route: 'GET /api/v1/reports', family: 'reports', source: 'route-manager', disposition: 'sdk', client: 'reports.list' },

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -9852,6 +9852,45 @@ export class RestServer {
             },
             metadata: { summary: 'Dismiss a suggested audience binding', tags: ['security'] },
         });
+
+        /**
+         * [field report — rc→GA declared≠enforced surfacing] The sanctioned,
+         * audited operator action: discard a stale `sys_metadata` overlay
+         * shadowing a package-declared `sys_permission_set` (the
+         * `overlay_shadow` diagnostic on the record — see
+         * `permission-set-drift.ts`). Bound to `sys_permission_set`'s
+         * "Discard Overlay" Setup action (`{id}` route param, same
+         * convention as `/data/sys_permission_set/{id}`). Refuses (403) on a
+         * set that is not currently package-declared — see
+         * `permission-set-overlay-discard.ts`'s eligibility note — and 409s
+         * when there is no active overlay to discard.
+         *
+         *   POST {basePath}/security/permission-sets/:id/discard-overlay
+         */
+        this.routeManager.register({
+            method: 'POST',
+            path: `${dataPath}/security/permission-sets/:id/discard-overlay`,
+            handler: async (req: any, res: any) => {
+                try {
+                    const environmentId = isScoped ? req.params?.environmentId : undefined;
+                    const context = await this.resolveExecCtx(environmentId, req);
+                    if (this.enforceAuth(req, res, context)) return;
+                    const svc = await resolveService(environmentId);
+                    if (!svc || typeof svc.discardPermissionSetOverlay !== 'function') return respond501(res);
+                    const result = await svc.discardPermissionSetOverlay(context ?? {}, String(req.params.id));
+                    res.json({ data: result });
+                // 'INTERNAL' (registered, generic — ADR-0112) is the default here
+                // deliberately, not a bespoke `..._FAILED` code: this route's typed
+                // errors (`PermissionSetNotFoundError` 404, `PermissionSetOverlayStateError`
+                // 409, `PermissionDeniedError` 403) already carry their own registered
+                // `code`, which `handleError`'s `status !== 500` arm reads ahead of this
+                // default — this string is reached only by a genuinely unexpected fault,
+                // and a NEW route-specific code for that arm is a `packages/spec` ledger
+                // entry this change deliberately does not make.
+                } catch (err: any) { handleError(err, res, 'INTERNAL'); }
+            },
+            metadata: { summary: 'Discard a stale environment overlay shadowing a package-declared permission set (ADR-0094)', tags: ['security'] },
+        });
     }
 
     /**

--- a/packages/rest/src/rest-write-response-internal-fields.tripwire.test.ts
+++ b/packages/rest/src/rest-write-response-internal-fields.tripwire.test.ts
@@ -372,6 +372,13 @@ const DISPOSITIONS: Record<string, Disposition> = {
   'POST /api/v1/security/suggested-bindings/:id/confirm': { kind: 'no-record-echo', why: 'Binding receipt.' },
   'POST /api/v1/security/suggested-bindings/:id/dismiss': { kind: 'no-record-echo', why: 'Dismissal receipt.' },
   'POST /api/v1/security/explain': { kind: 'no-record-echo', why: 'Permission explanation verdict.' },
+  // Discard-overlay receipt: `healedObjectGrantCount` / `overlaysDiscarded`
+  // plus the resynced `sys_permission_set` row for the caller's convenience.
+  // Same shape as confirm/dismiss above — the row travels through
+  // `permission-set-overlay-discard.ts`'s own `tryFind` (a `ql.find` READ,
+  // already engine-stripped), never a raw insert/update return, so there is
+  // no unstripped write mouth here to begin with.
+  'POST /api/v1/security/permission-sets/:id/discard-overlay': { kind: 'no-record-echo', why: 'Overlay-discard receipt; the row rides a post-write read (ql.find), not a raw write-mouth echo.' },
 
   // Import: per-row RECEIPTS (row number, action, id, warnings/errors) plus
   // counts — measured, the written row is never spread into a result.

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -1457,6 +1457,21 @@
       "pinned": 1
     },
     {
+      "file": "packages/plugins/plugin-security/src/permission-set-drift.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-security/src/permission-set-overlay-discard.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/plugins/plugin-security/src/row-write-widener-composition.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Fixes #9952

## Summary

An rc→GA upgraded environment can freeze a package's permission set at a
stale snapshot while the shipped artifact keeps moving — silently, with only
a boot log counter as a signal, until a real user hits a 403. Two independent
mechanisms can cause this (either, or both compounded on one row):

- **Overlay shadow** — an active `sys_metadata` overlay for a package-declared
  set's name (created by a Studio save, back when overlaying was still
  permitted, or via the `OS_METADATA_WRITABLE` hatch since) is re-projected
  onto the record on every boot, unconditionally — the overlay wins forever.
- **Provenance skip** — the record's `managed_by` column predates package
  provenance tracking, so `bootstrapDeclaredPermissions`'s package door
  refuses to touch it forever (`skippedEnvAuthored`).

The two mechanisms **confound each other**: on a row whose `managed_by` is
wrong, the existing `customized` flag is forced `false` even when an overlay
genuinely shadows it — measured on the field-reported environment, `customized`
stayed `0` for two weeks while the set was frozen.

## What this PR builds (the maintainer's 2026-08-20 ruling, both in-scope asks)

**1. "declared ≠ enforced" surfacing, covering BOTH mechanisms, naming the set
AND the cause.**

- `sys_permission_set` gets two new fields, `drift_status`
  (`overlay_shadow` / `provenance_skip` / `other`) and `drift_detail`,
  recomputed every boot by `runPermissionSetDriftDiagnostics`
  (`permission-set-drift.ts`). Detection is independent of `managed_by`'s
  correctness — an active `sys_metadata` overlay is checked directly, so the
  confounded case (the exact field-reported shape) is still attributed
  correctly.
- A new **"Needs Attention"** Setup list view (`drifted`) filters on
  `drift_status is_not_null` — the loud surface. An in-sync set is never
  flagged: `drift_status` is persisted as `null`, not `'in_sync'`, so quiet is
  a data fact, not merely a display choice.
- `all_permsets` gets a `drift_status` column alongside the pre-existing
  `managed_by` / `customized` columns.

**2. A sanctioned, audited operator path to discard a stale overlay on a
package-declared set.**

- New **"Discard Overlay"** Setup action → `POST
  /api/v1/security/permission-sets/:id/discard-overlay`
  (`permission-set-overlay-discard.ts`, tenant-admin gated). It deletes the
  stale `sys_metadata` overlay row directly (bypassing `deleteMetaItem`'s
  ADR-0005 tier-gate refusal deliberately — this is a narrower, sanctioned
  operation the gate has no seat for) and **synchronously** re-projects the
  record to the current declared artifact via the same awaited projector the
  env door uses — no waiting for the next boot.
- **Eligibility is decided from the artifact registry, never from
  `managed_by`** — exactly so the confounded case (a genuinely package-
  declared set whose row's `managed_by` was never `'package'`) is still
  reachable. A name with **no** current package declaration is refused (403),
  so a genuinely environment-authored set can never be discarded by name
  collision.

**Deliberately NOT built** (maintainer ruling, verbatim: 「新项目还没上线，
不需要清理旧数据，也没有老客户升级」): boot-time auto-adoption of legacy rows,
and a bulk `os meta adopt-permission-sets` operator command. The manual SQL
adoption recipe for the `provenance_skip` case stays documented — see
`content/docs/permissions/permission-sets.mdx`'s new "Declared ≠ enforced"
section.

## Where an admin actually looks

`sys_permission_set`'s existing `all_permsets` list view (`managed_by` +
`customized` columns) is the established ADR-0094 Setup surface — confirmed
by the field follow-up itself ("the ADR-0094 surface an admin would check").
The new `drifted` "Needs Attention" view and the `discard_permission_set_overlay`
row action live on the same object, so no new Setup surface or objectui
change is needed — the generic Setup grid picks up the new fields/action from
this object's declared schema
(`packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts`).

## Out-of-scope finding filed

The maintainer's ruling named a follow-up explicitly ("arguably the real
product defect the field report uncovered"): the overlay-shadow mechanism
itself — a Studio save of a package-declared set silently forking it, with
`customized` untouched. This PR's `drift_status` is an independent detector
that catches it even when `customized` lies, but does not fix the underlying
mechanism (nothing stops the fork from recurring, and `customized`'s own
computation is unchanged). Filed as #11513 (unassigned; PM labelled it
`finding` + `domain:services` after landing — a concrete defect for PM
triage, not an observation).

## Two CI fixes on top of the first push (head `3e5f38254e`)

**`rest-write-response-internal-fields.tripwire.test.ts` (#8497):** every
write-method REST route must declare a disposition. The new discard-overlay
route had none. **Which of the two cases applied:** the route is
*structurally exempt*, not leaking — classified `no-record-echo`, matching
the neighbouring `security/suggested-bindings/:id/confirm` /
`:id/dismiss` routes exactly: the `sys_permission_set` row in the body
travels through `permission-set-overlay-discard.ts`'s own `tryFind` (a
`ql.find` **READ**, already engine-stripped), never a raw insert/update
return — there is no unstripped write mouth to begin with. Added the entry
with that reasoning as a comment, no allowlist shortcut.

**`check:engine-double-contract`:** the fake engines in
`permission-set-drift.test.ts` / `permission-set-overlay-discard.test.ts`
had `update()`/`delete()` that didn't route through
`assertEngineUpdateDispatch` / `assertEngineDeleteDispatch`
(`@objectstack/metadata-core`). Pinned both, **then re-ran the 15 affected
tests against the real dispatch predicate before touching anything else** —
all 15 still pass, byte-identical outcome, no behavior change. Recorded the
new pinned coverage with `check-engine-double-contract.mjs --write`, which
touches only `scripts/engine-double-contract.pinned.json` (new coverage
recorded) — the shrink-only `engine-double-contract.baseline.json` is
untouched.

## A third CI fix — `check:where-matcher` at head `3e5f38254e`

The engine-double-contract pin let the run reach one gate deeper:
`check:where-matcher` (#8494) flagged both new fakes' `matches(row, where)`
as shape-(b) silently-wrong — `Object.entries(where).every(...)` with no
combinator branch, so a future `$and`/`$or` query would read as a field
named `$and`/`$or` and silently match the wrong rows instead of erroring.

**Which of the two fixes applied:** checked whether the code paths under
test (`computePermissionSetDriftDiagnostics`, `persistPermissionSetDriftDiagnostics`,
`discardPermissionSetOverlay`, and the `tryFind`/`tryUpdate` calls they make)
ever issue a combinator query — they do not; every `where` these modules
build is a flat object (`{ id }`, `{ type, name, state }`, `{ name: { $in } }`
via `buildExistingByName`'s batched read). So the correct fix is the
**refuse** case: both matchers now `throw` on any `$`-prefixed key, matching
the established idiom in `bootstrap-seed-round-trips.test.ts` (same
`#10946` module family). Confirmed directly via the gate's own
`discoverInSource`/`judge` functions that both matchers are now judged
`CONFORMING (refused)`.

**Did pinning change any assertion?** No — re-ran both suites after the
change: 15/15 pass, byte-identical outcome. Refusing a combinator that is
never issued changes nothing about what the tests were proving.

Head after this fix: `95e1b45c24`.

## Tests

- `permission-set-drift.test.ts` (8 tests) — pin 1 (surfaced, naming set +
  cause), pin 2 ⭐ (quiet case: in-sync set persists `drift_status: null`,
  zero writes on a steady-state re-run), pin 3 (both mechanisms constructed
  independently and via the CONFOUNDED case — attributed correctly, never
  mislabeled).
- `permission-set-overlay-discard.test.ts` (7 tests) — pin 4 (discard heals
  the row to the current artifact's actual grant set, asserted by content —
  including the confounded case), pin 5 ⭐ (refuses a set with no current
  package declaration, refuses a name collision against an unrelated
  package's declared set, 404/409 on bad input, refuses a non-tenant-admin
  caller — no mutation in every refusal branch).
- `rbac-objects.test.ts` updated: the pinned action-name list now includes
  `discard_permission_set_overlay`; a new pin on `drift_status`'s options and
  its presence in both list views.
- `rest-route-ledger.conformance.test.ts` (7/7), `rest-write-response-internal-fields.tripwire.test.ts` — both green with the new route registered.

Local: 137 new/regression tests green across the pushes (plus the two where-matcher suites re-run clean a third time at head `95e1b45c24`),
`@objectstack/plugin-security` and `@objectstack/rest` typecheck clean, i18n
bundles regenerated (additive only — 4 new keys × 4 locales), `packages/spec`
liveness/empty-state/strictness-ledger/variant-docs gates green (triggered by
the `content/docs/**` edit), 25+ targeted `check:*` lint/doc gates green
(route-envelope, authz-resolver, dispatcher-error-vocabulary, doc-anchors,
doc-authoring, published-files, role-word, and more — see the dev report),
`check:engine-double-contract` green. The `check:i18n` confirmatory
bundle-drift check stayed **NOT MEASURED** both attempts (workspace CLI not
built in this worktree; the extraction itself succeeded and the diff was
reviewed clean) — left to CI.

---

_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_
