### PR TITLE
feat(spec): refuse authored radio + multiple:true at the schema layer (ruled Option C, objectui#4015)

### DIFF
--- a/.changeset/radio-multiple-refused-at-schema.md
+++ b/.changeset/radio-multiple-refused-at-schema.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): refuse an authored `radio` + `multiple: true` at the schema layer (#11437, maintainer ruling 2026-08-22 on objectui#4015, Option C)
+
+**BREAKING** accept-set narrowing, shipped as `minor` under the repo's
+launch-window convention for breaking changes.
+
+An author could declare `{ type: 'radio', multiple: true }` and the producer
+honoured it everywhere the widget could not: the data layer stored an array,
+validated it as multi, split it on import and inferred multi arity for action
+params, while the one renderer `radio` has draws a single-value radio group
+with zero diagnostics. Declared multi, rendered single — the contradiction sat
+inside `packages/spec` itself, where `SINGLE_OPTION_TYPES` calls `radio`
+single-choice on one line and `MULTI_CAPABLE_TYPES` carries it on another
+because it "shares the select branch".
+
+Per the maintainer ruling recorded 2026-08-22 on objectui#4015 (Option C,
+「接受所有」), `FieldSchema` now refuses the authored combination at parse
+time — the seam every publish crosses, both for a standalone `field` document
+and for fields embedded in an `ObjectSchema` — with a diagnostic that names
+the field, names the illegal pair, and prescribes the correctly-named
+multi-choice types: `checkboxes` (all options visible, radio-like layout),
+`multiselect` (dropdown) and `tags` (free-form values).
+
+**What stays accepted, byte-identically:** `radio` without `multiple`
+(including its materialized `multiple: false`), `radio` with an authored
+`multiple: false`, `select`/`lookup`/`user`/`file`/`image` with
+`multiple: true`, and the inherently-multi types with or without the redundant
+flag. Because `multiple` materializes `.default(false)`, the refusal can only
+ever fire on an authored `true` — a defaulted value never trips it, and
+`parse(parse(x))` stays stable (pinned).
+
+**What is deliberately untouched, per the same ruling:** `MULTI_CAPABLE_TYPES`
+and `isMultiValueField` in `field-value.zod.ts` keep `radio`, so data at rest
+that was written under the old contract keeps its read path and no
+stored-shape migration is paid — that is the whole reason Option C was
+preferred over narrowing the sets themselves. A test pins `radio`'s membership
+so a future cleanup trips loudly. `packages/objectql`'s record-validator
+select/radio branch likewise stays, as a data-safety fallback for stock.
+
+Measured before landing (both repos, examples/docs/fixtures/tests included):
+21 `type: 'radio'` declarations, none carrying `multiple: true` — the refused
+combination has zero occurrences, so no existing metadata is invalidated. The
+ruling attaches an explicit flip condition: if deployed tenant metadata
+carrying the combination with stored data is ever found, entrance rejection
+alone would strand it and the set-narrowing option becomes required.
+
+<!-- adr-0087: not-required (no-migration-prescription) The ruling explicitly declines a migration: at-rest data keeps its read path via the untouched MULTI_CAPABLE_TYPES / isMultiValueField, and re-measurement at the merge base found zero occurrences of the refused combination in either repo, so there is no existing author to migrate and nothing objectstack migrate meta is authorized to rewrite — a conversion rewriting the pair would itself be the stored-shape migration Option C was chosen to avoid. Guidance for future authors lives in the refusal diagnostic itself. -->

--- a/packages/spec/src/data/field.test.ts
+++ b/packages/spec/src/data/field.test.ts
@@ -12,6 +12,7 @@ import {
   type CurrencyValue,
 } from './field.zod';
 import { ObjectSchema } from './object.zod';
+import { MULTI_CAPABLE_TYPES, isMultiValueField } from './field-value.zod';
 
 describe('FieldType', () => {
   it('should accept valid field types', () => {
@@ -1395,6 +1396,92 @@ describe('ADR-0113 — required is a write contract; storage.notNull is the colu
   });
   it('storage is strict — unknown storage keys reject', () => {
     expect(() => FieldSchema.parse({ type: 'text', storage: { collation: 'C' } })).toThrow();
+  });
+});
+
+describe('FieldSchema — authored `radio` + `multiple: true` is REFUSED (#11437, maintainer ruling 2026-08-22 on objectui#4015, Option C)', () => {
+  // Option C rejects the contradiction at the entrance: the data layer
+  // honoured the flag while the widget rendered a single-value radio group —
+  // declared multi, rendered single, zero diagnostics. The other half of the
+  // same ruling is that the field-value.zod.ts sets stay UNTOUCHED (at-rest
+  // data keeps its read path); the last pin below trips a future "cleanup".
+
+  it('REJECTS radio + multiple: true, naming the field and the illegal pair on the `multiple` path', () => {
+    const r = FieldSchema.safeParse({ name: 'severity', type: 'radio', multiple: true });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const issue = r.error.issues.find((i) => i.path.join('.') === 'multiple');
+      expect(issue).toBeDefined();
+      expect(issue!.message).toMatch(/"severity"/);
+      expect(issue!.message).toMatch(/'radio'/);
+      expect(issue!.message).toMatch(/multiple: true/);
+    }
+  });
+
+  it('the rejection carries the prescription — all three correctly-named multi-choice types', () => {
+    const r = FieldSchema.safeParse({ name: 'labels', type: 'radio', multiple: true });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const message = r.error.issues.map((i) => i.message).join('\n');
+      expect(message).toMatch(/`checkboxes`/);
+      expect(message).toMatch(/`multiselect`/);
+      expect(message).toMatch(/`tags`/);
+    }
+  });
+
+  it('fires through ObjectSchema too — the publish path an object document crosses', () => {
+    const r = ObjectSchema.safeParse({
+      name: 'crm_lead',
+      label: 'Lead',
+      fields: {
+        severity: { type: 'radio', multiple: true, options: [{ label: 'Low', value: 'low' }, { label: 'High', value: 'high' }] },
+      },
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      const messages = r.error.issues.map((i) => i.message).join('\n');
+      expect(messages).toMatch(/`checkboxes`/);
+    }
+  });
+
+  it('radio WITHOUT `multiple` stays accepted — and the key materializes its usual `false`', () => {
+    const f = FieldSchema.parse({ name: 'severity', type: 'radio', options: [{ label: 'Low', value: 'low' }, { label: 'High', value: 'high' }] });
+    expect(f.multiple).toBe(false);
+  });
+
+  it('radio + authored `multiple: false` stays accepted — the refusal reads only the authored `true`', () => {
+    const f = FieldSchema.parse({ name: 'severity', type: 'radio', multiple: false });
+    expect(f.multiple).toBe(false);
+  });
+
+  it('parse(parse(x)) is stable — the materialized `multiple: false` re-parses cleanly (#9689 class)', () => {
+    const once = FieldSchema.parse({ name: 'severity', label: 'Severity', type: 'radio', options: [{ label: 'Low', value: 'low' }, { label: 'High', value: 'high' }] });
+    const twice = FieldSchema.parse(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('the prescribed multi-choice types all still parse — with and without the redundant flag', () => {
+    for (const type of ['checkboxes', 'multiselect', 'tags']) {
+      expect(() => FieldSchema.parse({ name: 'labels', type, options: [{ label: 'Alpha', value: 'alpha' }, { label: 'Beta', value: 'beta' }] })).not.toThrow();
+      // Inherently-multi types tolerated a redundant `multiple: true` before
+      // this refusal and still do — the refusal is radio-scoped.
+      expect(() => FieldSchema.parse({ name: 'labels', type, options: [{ label: 'Alpha', value: 'alpha' }, { label: 'Beta', value: 'beta' }], multiple: true })).not.toThrow();
+    }
+  });
+
+  it('`select` + multiple: true — the multi-capable sibling on the same parse branch — stays accepted', () => {
+    const f = FieldSchema.parse({ name: 'labels', type: 'select', options: [{ label: 'Alpha', value: 'alpha' }, { label: 'Beta', value: 'beta' }], multiple: true });
+    expect(f.multiple).toBe(true);
+  });
+
+  it('UNTOUCHED-HALF PIN — `radio` stays in MULTI_CAPABLE_TYPES and isMultiValueField still promotes it', () => {
+    // The ruling's other half: at-rest data written under the old contract
+    // keeps its read path. A "cleanup" that drops `radio` from the set is
+    // Option B (spec-set narrowing + stored-shape migration), explicitly NOT
+    // taken — this pin makes that cleanup trip a test instead of landing
+    // silently.
+    expect(MULTI_CAPABLE_TYPES.has('radio')).toBe(true);
+    expect(isMultiValueField({ type: 'radio', multiple: true })).toBe(true);
   });
 });
 describe('FieldSchema — `placeholder` is a DECLARED key (#9019, ruled Option C on objectui#4676)', () => {

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -1510,6 +1510,33 @@ export const FieldSchema = lazySchema(() => strictObject({
     });
   }
 
+  // [#11437] (maintainer ruling 2026-08-22 on objectui#4015, Option C —
+  // reject at the entrance): an authored `radio` + `multiple: true` is
+  // refused at the schema/publish seam. The data layer honoured the flag
+  // (stored an array, validated as multi, split on import, inferred action
+  // -param arity) while the widget rendered a single-value radio group with
+  // zero diagnostics — declared multi, rendered single. Per the same ruling,
+  // `MULTI_CAPABLE_TYPES` / `isMultiValueField` (field-value.zod.ts) stay
+  // UNTOUCHED so at-rest data keeps its read path and no stored-shape
+  // migration is paid (why C beat B), and objectql record-validator's
+  // select/radio branch stays as a data-safety fallback. `multiple`
+  // materializes `.default(false)` above, so `true` here is always AUTHORED —
+  // this check can never fire on a defaulted value, and `parse(parse(x))`
+  // stays stable (#9689 class; pinned in field.test.ts).
+  if (field.type === 'radio' && field.multiple === true) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['multiple'],
+      message:
+        `Field "${field.name ?? '<unnamed>'}": \`type: 'radio'\` cannot be combined with \`multiple: true\` — ` +
+        'a radio group is single-choice by definition (its widget renders exactly one selected option ' +
+        'and has no multi arity), so the declaration would validate and store arrays no radio input can ' +
+        'ever produce: declared multi, rendered single. Use a multi-choice type instead: `checkboxes` ' +
+        '(all options visible, radio-like layout), `multiselect` (dropdown), or `tags` (free-form ' +
+        'values). For a single-choice field, drop `multiple`.',
+    });
+  }
+
   // #7918 (maintainer ruling 2026-08-12, Option A): the FIELD-level
   // `precision` key doubles as the currency display width — objectui's
   // CurrencyField reads it, and objectui#4361 pinned authored-precision-wins


### PR DESCRIPTION
## What this PR does

Implements the maintainer ruling recorded **2026-08-22** on objectui#4015 (decision-inbox digest, batch accepted verbatim: 「接受所有」):

> **Ruled:** Option C — reject at the entrance: refuse `radio + multiple: true` at the
> schema/publish layer with a diagnostic prescribing the correctly-named multi-choice
> types (`checkboxes`/`multiselect`/`tags`), while leaving `MULTI_CAPABLE_TYPES` and
> `isMultiValueField` untouched so at-rest data keeps its read path and no stored-shape
> migration is paid. Option A (rendering the combination as checkboxes) is explicitly not
> taken. […] The implementation lands on the spec side (objectstack, `domain:spec` lane).

objectui#4015 remains **open** as the decision record — nothing in this PR closes it.

## The defect being ruled on

An author could declare `{ type: 'radio', multiple: true }`. The data layer honoured it (stored an array, validated as multi, split on import, inferred action-param arity) while the widget rendered a single-value radio group with zero diagnostics — declared multi, rendered single. The producer contradicted itself about `radio` (re-verified at this branch's merge base `d10e214626`, matching the card's measurement at `5d163792c`):

| Site | Says |
|---|---|
| `packages/spec/src/data/field-value.zod.ts:79-81` | `SINGLE_OPTION_TYPES = ['select','radio']` — "Single-choice option types." |
| `packages/spec/src/data/field-value.zod.ts:204-206` | `MULTI_CAPABLE_TYPES` includes `radio`, its own comment conceding it "shares the select branch" |
| `packages/spec/src/data/field-value.zod.ts:224-226` | `isMultiValueField` promotes any `MULTI_CAPABLE_TYPES` member on `multiple: true` |
| `packages/spec/src/data/field.zod.ts:818` | `multiple`'s published description: "Applicable for select, lookup, file, image" — `radio` absent |
| `packages/spec/src/ui/action.zod.ts:453` | param arity inferred from `MULTI_CAPABLE_TYPES` |

Consumer side (objectui, read-only, verified at the local checkout): `RadioField.tsx` has 0 occurrences of `multiple` (control probe 23 for `RadioGroup|value`), and `paramValueShape.ts:142` pins `radio` as `cardinality: 'scalar'`.

**Occurrence re-measurement at the merge base:** both repos scanned; 18 `type: 'radio'` declarations found by this branch's scanner, **0** carrying `multiple: true` in a ±6-line window. The single window hit is the known `select + multiple` line adjacent to a `radio` entry in objectui `paramValueShape.test.ts:93` — the same false positive the card documents. The flip-to-B condition (deployed tenant metadata with stored data) has not been triggered by anything measurable from here.

## Where the refusal homes, and the diagnostic

`FieldSchema`'s `.superRefine` in `packages/spec/src/data/field.zod.ts` — the same seam that carries the module's sibling authored-combination refusals (`referenceVia` on a non-text type, `referenceVia` + `reference`, `storage.notNull` + `requiredWhen`, the #7918 currency-precision contradiction). This is the parse path every publish crosses, measured rather than assumed: `kernel/metadata-type-schemas.ts:91` registers `field: FieldSchema` for the standalone metadata type, and `ObjectSchema`'s `fields` record embeds `FieldSchema` directly (`object.zod.ts:1894`), so both publish shapes hit the refinement. No `.extend`/`.omit`/`.pick` derivative of `FieldSchema` exists that could strip it.

The diagnostic (issue `path: ['multiple']`, verified verbatim against the built dist):

```
Field "severity": `type: 'radio'` cannot be combined with `multiple: true` — a radio group is single-choice by definition (its widget renders exactly one selected option and has no multi arity), so the declaration would validate and store arrays no radio input can ever produce: declared multi, rendered single. Use a multi-choice type instead: `checkboxes` (all options visible, radio-like layout), `multiselect` (dropdown), or `tags` (free-form values). For a single-choice field, drop `multiple`.
```

It names the field, names the illegal pair, and prescribes all three correctly-named multi-choice types.

## Parse-idempotency (#9689 class — mandated check)

`multiple` is declared `.default(false)` (field.zod.ts:818), i.e. the default **materializes at parse** — but it materializes `false`, never `true`. The `.superRefine` runs over the parsed object, so a `multiple: true` it observes can only ever be **authored**; a defaulted value can never trip the refusal. Pinned by test: `parse(parse(validRadioField))` is deep-equal stable, and the materialized `multiple: false` re-parses cleanly as an authored `false`. No mainline parse path materializes `true`, so the refusal required no authored-vs-defaulted machinery (unlike the #7918 `.overwrite()` relocation one block below it).

## Untouched halves (binding constraints of the ruling)

- `MULTI_CAPABLE_TYPES` and `isMultiValueField` (`field-value.zod.ts`) — **untouched**. At-rest data keeps its read path; no stored-shape migration is paid. A new test pins `MULTI_CAPABLE_TYPES.has('radio')` and `isMultiValueField({ type: 'radio', multiple: true }) === true` so a future "cleanup" trips loudly instead of landing as Option B by accident.
- `packages/objectql/src/validation/record-validator.ts`'s `(t === 'select' || t === 'radio')` branch (line 656) — **untouched**, stays as a data-safety fallback for stock.
- objectui — **untouched** (Option A explicitly not taken). The objectui `field-type-alias.ts:28-37` prose correction the ruling assigns to the landing fork is deliberately **not** in this PR: it is objectui-side, and the PM relays it at ACCEPT per the dispatch brief.
- `multiple`'s published `.describe()` ("Applicable for select, lookup, file, image") — **untouched**: `radio` was already absent from it, consistent with the refusal; nothing in it is falsified by this change (confirmed by `check:docs` green with no regeneration needed).

## Changeset reasoning

`.changeset/radio-multiple-refused-at-schema.md` — `@objectstack/spec: minor` with an explicit **BREAKING** body, per the launch-window convention (mirroring the #11124/#11492 spelling). ADR-0087 disposition: `not-required (no-migration-prescription)` — the ruling explicitly declines a migration (that is why C beat B), re-measurement found zero occurrences of the refused combination in either repo, and a conversion rewriting the pair would itself be the stored-shape migration Option C was chosen to avoid. `node scripts/check-adr-0087-registration.mjs` accepts the disposition (exit 0). This follows the closest sibling precedent (#7918: a ruled contradiction-refusal in the same superRefine, registered nothing) rather than #8321 (which registered a conversion because it had stored rows to keep loading — the ruling here forbids exactly that move).

## Verification (all at commit `72b3d9c886`, via the shared verify lock)

- `pnpm --filter @objectstack/spec build` — VERDICT command-exit 0.
- `pnpm --filter @objectstack/spec test` — **420 files / 11213 tests passed**, VERDICT command-exit 0, run after the final commit.
- `pnpm --filter @objectstack/spec typecheck` — green (tsc + scripts + test programs; the check:test-typecheck self-test line printed its pass).
- `pnpm --filter @objectstack/spec check:generated` — "All 14 generated artifacts are up to date" (no artifact moved: the refusal adds no describe, no export, no authorable key).
- **Reverse verification** (fix committed first; source-only revert to origin/main proven on disk by marker grep 2 → 0): exactly the 3 refusal tests red pre-patch, the 6 accept-side controls green on both sides; restored byte-identically (`git checkout HEAD`, porcelain clean, marker 2, empty diff vs HEAD), re-run 9/9 green.
- **Acceptance probe on the built dist** via `@objectstack/spec/data` package exports from a consumer package: radio+multiple red with the verbatim prescriptive message on path `['multiple']`; radio-without-multiple green with `multiple: false` materialized; untouched-half probes true.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (derivation attested at `72b3d9c886`, `--repo` assertion held): 26 derived/convention gates run, 25 to verdict **green** — including `check:adr-0087-registration`, `check:changeset-no-major`, `check:empty-changeset`, `check:cross-package-test-inputs`, `check:engine-double-contract`, `check:where-matcher`, `check:test-source-alias`, `check:nul-bytes`, and `check:doc-formula-expressions` (after building `@objectstack/formula`, whose missing dist was worktree build state, not this diff).
- **Declared narrowings (2)**, both workspace-build-state preconditions no spec-only diff can move, both CI-covered on a fully built tree: `check:dev-prereqs` (wants all 67 package dists on disk; spec's own dist is built and content-fresh — its spec-freshness half is the only half this diff touches) and `check:type-check-debt --re-measure` (needs the full workspace closure built; the slice this diff can move — spec's own programs including the new test code — is proven green by spec's `typecheck`).

## Review status

**Draft, held for the PM's contract review (clause-②)** — this PR changes accept/reject behaviour on the contract surface and does not land until that review; please do not flip it ready or queue it.

Fixes #11437

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9cDbY2NBiVJWYx3BpWfH2)_