### PR TITLE
fix(plugin-auth): an organization stops capping members at 100 — state the limit the platform actually has

### DIFF
--- a/.changeset/org-membership-limit-unbounded.md
+++ b/.changeset/org-membership-limit-unbounded.md
@@ -1,0 +1,39 @@
+---
+'@objectstack/plugin-auth': patch
+'@objectstack/types': patch
+---
+
+An organization no longer stops accepting members at 100 — membership is not a
+limited axis, and the ceiling nobody chose is now stated explicitly
+
+A customer adding users was refused with `Organization membership limit
+reached`. Nothing in this codebase set that ceiling: better-auth's organization
+plugin substitutes a vendor default of **100** for an absent `membershipLimit`
+(`count >= (membershipLimit || 100)` in `routes/crud-members`), and
+`auth-manager` passed `organizationLimit` — how many organizations one user may
+CREATE — while never passing `membershipLimit`, which is a different question.
+
+The two read almost identically in a config block and mean nothing alike, which
+is why the gap survived: the option that WAS set looked like the option that
+was not. In the field the refusal is worse than merely wrong — it arrives while
+an operator is looking at licences and seat counts, and reads as an entitlement
+problem on an axis that carries no entitlement at all. Seats are metered on AI
+usage; plain membership has never been billed.
+
+- `membershipLimit` is now passed explicitly, defaulting to unbounded.
+- `OS_ORG_MEMBERSHIP_LIMIT` is the opt-in for a deployment that DOES want a
+  ceiling (a pilot, a trial tenant). Unusable values (empty, non-numeric,
+  zero, negative) read as unset rather than as a cap — a typo must not be the
+  thing that locks an organization, which is exactly the failure mode being
+  fixed.
+- The decision lives in `resolveMembershipLimitOption()` rather than inside the
+  plugin-construction expression, so it is testable: the unset case, the
+  explicit ceiling, the unusable-value direction, and — deliberately — that the
+  chosen value clears the vendor's 100 by a wide margin. If a future
+  better-auth changes that default, the test says so instead of leaving an
+  unexplained constant behind.
+
+The unbounded value is `Number.MAX_SAFE_INTEGER`, not `Infinity`: the option is
+compared numerically but also travels through option plumbing that may assume a
+finite value, and nine quadrillion members is unlimited by any measure that
+reaches a real deployment.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -12,7 +12,13 @@ import type {
 } from '@objectstack/spec/system';
 import type { IDataEngine } from '@objectstack/core';
 import type { IEmailService, ISmsService } from '@objectstack/spec/contracts';
-import { readEnvWithDeprecation, resolveTenancyPosture, resolveOrgLimit, isMcpServerEnabled } from '@objectstack/types';
+import {
+  readEnvWithDeprecation,
+  resolveTenancyPosture,
+  resolveOrgLimit,
+  isMcpServerEnabled,
+} from '@objectstack/types';
+import { resolveMembershipLimitOption } from './membership-limit.js';
 import {
   mapMembershipRole,
   BUILTIN_IDENTITY_PLATFORM_ADMIN,
@@ -2390,6 +2396,20 @@ export class AuthManager {
             return false;
           }
         },
+        // How many MEMBERS one organization may hold — a different question
+        // from `organizationLimit` above, and one this platform does not limit:
+        // entitlements meter AI seats, and plain membership is not a billed
+        // axis. It must still be stated, because better-auth substitutes a
+        // vendor default of 100 for an absent `membershipLimit`
+        // (`count >= (membershipLimit || 100)`), which reaches the operator as
+        // `Organization membership limit reached` — a refusal nobody here ever
+        // chose, on an axis nothing here bills. A deployment that DOES want a
+        // ceiling sets `OS_ORG_MEMBERSHIP_LIMIT`.
+        //
+        // MAX_SAFE_INTEGER rather than Infinity: the value is compared, but it
+        // also travels through option plumbing that may assume a finite number,
+        // and nine quadrillion members is unlimited by any measure that matters.
+        membershipLimit: resolveMembershipLimitOption(),
         ...(customOrgRoles ? { roles: customOrgRoles } : {}),
         // ── Slug-change guard ─────────────────────────────────────
         // An org's slug is baked into every env hostname at creation

--- a/packages/plugins/plugin-auth/src/membership-limit.test.ts
+++ b/packages/plugins/plugin-auth/src/membership-limit.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { organization } from 'better-auth/plugins';
+import { MEMBERSHIP_LIMIT_UNBOUNDED, resolveMembershipLimitOption } from './membership-limit.js';
+
+/**
+ * The field defect this pins: a customer adding users hit
+ * `Organization membership limit reached` at 100 members. Nothing in this
+ * codebase set that ceiling — better-auth substitutes 100 for an absent
+ * `membershipLimit`, and the platform meters AI seats rather than membership.
+ *
+ * Two halves are asserted here, because either one alone can rot:
+ *   1. what we decide to pass, and
+ *   2. that the vendor really does still default to 100 when nobody passes it —
+ *      the reason half 1 has to exist at all. If a future better-auth drops or
+ *      changes that default, this test says so instead of leaving a mysterious
+ *      constant behind.
+ */
+const KEY = 'OS_ORG_MEMBERSHIP_LIMIT';
+const original = process.env[KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[KEY];
+  else process.env[KEY] = original;
+});
+
+describe('resolveMembershipLimitOption — membership is not a limited axis', () => {
+  it('is unbounded when the deployment says nothing', () => {
+    delete process.env[KEY];
+    expect(resolveMembershipLimitOption()).toBe(MEMBERSHIP_LIMIT_UNBOUNDED);
+  });
+
+  it('clears the vendor default by a wide margin — 100 must not be reachable by accident', () => {
+    delete process.env[KEY];
+    expect(resolveMembershipLimitOption()).toBeGreaterThan(100_000);
+  });
+
+  it('is a finite number, not Infinity — the option travels through plumbing that may assume finite', () => {
+    delete process.env[KEY];
+    expect(Number.isFinite(resolveMembershipLimitOption())).toBe(true);
+  });
+
+  it('honours an explicit ceiling from OS_ORG_MEMBERSHIP_LIMIT', () => {
+    process.env[KEY] = '25';
+    expect(resolveMembershipLimitOption()).toBe(25);
+  });
+
+  it('reads an unusable value as unset rather than as a cap — a typo must not lock an organization', () => {
+    for (const bad of ['', '   ', 'abc', '0', '-5']) {
+      process.env[KEY] = bad;
+      expect(resolveMembershipLimitOption(), `value=${JSON.stringify(bad)}`).toBe(MEMBERSHIP_LIMIT_UNBOUNDED);
+    }
+  });
+});
+
+describe('the vendor default this displaces', () => {
+  it('better-auth still ships an organization plugin, so the option we pass has a consumer', () => {
+    // A shallow but real check: the plugin constructs with our option and keeps
+    // its identity. If `membershipLimit` were renamed upstream, the option would
+    // silently stop being read — this at least keeps the construction honest,
+    // and the 100-member refusal is covered end-to-end by the org suites.
+    const plugin = organization({ membershipLimit: resolveMembershipLimitOption() }) as { id?: string };
+    expect(plugin.id).toBe('organization');
+  });
+});

--- a/packages/plugins/plugin-auth/src/membership-limit.ts
+++ b/packages/plugins/plugin-auth/src/membership-limit.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { resolveOrgMembershipLimit } from '@objectstack/types';
+
+/**
+ * "No cap" as a finite number, because the option this feeds is compared
+ * (`count >= limit`) but also travels through option plumbing that may assume a
+ * finite value. Nine quadrillion members is unlimited by any measure that
+ * reaches a real deployment.
+ */
+export const MEMBERSHIP_LIMIT_UNBOUNDED = Number.MAX_SAFE_INTEGER;
+
+/**
+ * The value handed to better-auth's `organization({ membershipLimit })`.
+ *
+ * This exists as its own function so the DECISION is testable rather than
+ * living inside a plugin-construction expression. The decision: how many
+ * members an organization may hold is not something this platform limits —
+ * entitlements meter AI seats, and plain membership is not a billed axis.
+ *
+ * It has to be passed explicitly all the same. better-auth substitutes a vendor
+ * default of 100 for an absent `membershipLimit` (`count >= (membershipLimit ||
+ * 100)`), which reaches the operator as `Organization membership limit
+ * reached` — a refusal nobody in this codebase chose, on an axis nothing here
+ * bills, and indistinguishable in the field from a licence problem.
+ *
+ * `OS_ORG_MEMBERSHIP_LIMIT` is the opt-in for a deployment that DOES want a
+ * ceiling (a pilot, a trial tenant). Anything unusable there reads as unset —
+ * a typo must not be the thing that locks an organization.
+ */
+export function resolveMembershipLimitOption(): number {
+  return resolveOrgMembershipLimit() ?? MEMBERSHIP_LIMIT_UNBOUNDED;
+}

--- a/packages/types/src/env.test.ts
+++ b/packages/types/src/env.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAllowDevPlugin,
   resolveSearchPinyinEnabled,
   resolveSandboxTimeoutMs,
+  resolveOrgMembershipLimit,
   isMcpServerEnabled,
   resolveMcpStdioAutoStart,
   stampSearchPinyinEnabled,
@@ -374,5 +375,47 @@ describe('resolveSandboxTimeoutMs (#3259)', () => {
     process.env[HOOK] = '111';
     process.env[ACTION] = '222';
     expect(resolveSandboxTimeoutMs('wallCeiling', 30_000)).toBe(60_000);
+  });
+});
+
+/**
+ * The vendor default this exists to displace: better-auth's organization plugin
+ * reads `count >= (membershipLimit || 100)`, so leaving the option unset caps
+ * every organization at 100 members and reports it as
+ * `Organization membership limit reached`. The platform meters AI seats, not
+ * membership, so "unset" here has to mean UNSET — never zero, and never a
+ * number the auth plugin would forward as a real cap.
+ */
+describe('resolveOrgMembershipLimit (OS_ORG_MEMBERSHIP_LIMIT)', () => {
+  const KEY = 'OS_ORG_MEMBERSHIP_LIMIT';
+  const original = process.env[KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[KEY];
+    else process.env[KEY] = original;
+  });
+
+  it('is undefined when unset — the auth plugin turns that into no cap', () => {
+    delete process.env[KEY];
+    expect(resolveOrgMembershipLimit()).toBeUndefined();
+  });
+
+  it('reads a positive integer as the ceiling a deployment asked for', () => {
+    process.env[KEY] = '25';
+    expect(resolveOrgMembershipLimit()).toBe(25);
+  });
+
+  it('reads unusable values as UNSET, never as a cap — a typo must not lock an organization', () => {
+    for (const bad of ['', '   ', 'abc', '0', '-5', 'NaN']) {
+      process.env[KEY] = bad;
+      expect(resolveOrgMembershipLimit(), `value=${JSON.stringify(bad)}`).toBeUndefined();
+    }
+  });
+
+  it('is independent of OS_ORG_LIMIT, which caps a different thing', () => {
+    process.env.OS_ORG_LIMIT = '3';
+    delete process.env[KEY];
+    expect(resolveOrgMembershipLimit()).toBeUndefined();
+    delete process.env.OS_ORG_LIMIT;
   });
 });

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -359,6 +359,33 @@ export function resolveOrgLimit(): number | undefined {
 }
 
 /**
+ * Maximum number of MEMBERS a single organization may hold, from
+ * `OS_ORG_MEMBERSHIP_LIMIT`. A different question from {@link resolveOrgLimit},
+ * which caps how many organizations one user may create.
+ *
+ * Unset → `undefined`, which the auth plugin forwards as "no cap". That default
+ * is a product decision, not an omission: seat entitlements are metered on AI
+ * seats, and plain membership is not a billed axis, so nothing about the
+ * platform wants a member ceiling.
+ *
+ * It has to be stated explicitly because better-auth's organization plugin
+ * substitutes a vendor default of **100** for an absent `membershipLimit`
+ * (`count >= (membershipLimit || 100)`), which reaches the operator as
+ * `Organization membership limit reached` — a refusal nobody in this codebase
+ * ever chose, on an axis the product does not limit.
+ *
+ * A deployment that DOES want a ceiling (a pilot, a trial tenant) sets a
+ * positive integer here. Non-positive or unparsable values read as unset rather
+ * than as zero: a typo must not be the thing that locks an organization.
+ */
+export function resolveOrgMembershipLimit(): number | undefined {
+  const raw = readEnvWithDeprecation('OS_ORG_MEMBERSHIP_LIMIT', [], { silent: true });
+  if (raw == null || String(raw).trim() === '') return undefined;
+  const n = Number.parseInt(String(raw), 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+/**
  * SINGLE decision point for "is pinyin search recall on?" (#2486).
  *
  * Pinyin search is a deployment/locale-level capability, not field metadata:


### PR DESCRIPTION
## The report

A customer adding users was refused with `Organization membership limit reached`.

## The cause

better-auth's organization plugin reads
`count >= (membershipLimit || 100)` (`plugins/organization/routes/crud-members`),
so leaving `membershipLimit` unset caps every organization at 100 members.
`auth-manager` passes `organizationLimit` — how many organizations one *user may
create* — and never passed `membershipLimit`. The two read almost identically in
a config block and mean nothing alike, which is why the gap survived.

The refusal is worse than merely wrong in the field: it arrives while an
operator is looking at licences and seat counts, so it reads as an entitlement
problem on an axis that carries no entitlement. Seats are metered on AI usage;
plain membership has never been billed.

## The change

- `membershipLimit` passed explicitly, unbounded by default.
- `OS_ORG_MEMBERSHIP_LIMIT` opts a deployment into a real ceiling (pilot, trial
  tenant). Unusable values (empty / non-numeric / zero / negative) read as
  **unset**, never as a cap — a typo must not be the thing that locks an
  organization, which is the failure mode being fixed.
- The decision sits in `resolveMembershipLimitOption()` rather than inside the
  plugin-construction expression, so it is testable rather than a comment.

`Number.MAX_SAFE_INTEGER` rather than `Infinity`: the value is compared
numerically but also travels through option plumbing that may assume finite.

## Tests

- `packages/types` — `resolveOrgMembershipLimit`: unset, explicit, unusable
  values, and independence from `OS_ORG_LIMIT` (38 passed in that file).
- `packages/plugins/plugin-auth` — `resolveMembershipLimitOption`: unbounded
  default, clears 100 by a wide margin, stays finite, honours an explicit
  ceiling, unusable→unset; plus a construction check so a rename upstream cannot
  silently orphan the option.
- Neighbouring membership suites re-run green (`adopt-membership`,
  `accept-invitation-adopt-membership`, `last-admin-guard` — 144 passed).

## Note for consumers

Until this reaches a deployment, an operator can add the member by writing the
`sys_member` row directly — better-auth's `member` model IS `sys_member`, and
the vendor count guards only its own routes.