### PR TITLE
test(cli): pin the conversions-only exit-code cell of `os validate --json --strict`

### DIFF
--- a/packages/cli/src/commands/validate-json-strict-exit.e2e.test.ts
+++ b/packages/cli/src/commands/validate-json-strict-exit.e2e.test.ts
@@ -44,6 +44,36 @@
  * "fails whenever `--json` sees a warning" — two fixes that pass the matrix
  * above identically, only one of which is the one asked for.
  *
+ * ## The conversions-only cell (#11301)
+ *
+ * `--strict` gates on the TEXT face's warning list, and that list folds in the
+ * ADR-0087 D2 load-time conversion notices. The payload carries those notices
+ * separately, under `conversions`; its own `warnings` field is the five-way
+ * spread WITHOUT them. So a config whose only advisories are conversion notices
+ * exits 1 carrying `{ valid: true, warnings: [], conversions: [...] }` — the one
+ * cell where the exit code is decided by a collection absent from the payload
+ * field a reader reaches for first. Every fixture above raises zero conversions,
+ * so a regression narrowing the gate back to `payload.warnings` would restore
+ * the original divergence for exactly these configs with all of them green.
+ *
+ * The two fixtures below are a MINIMAL PAIR from one template, differing in a
+ * single key on one page-header component: `description`, the alias
+ * `page-header-subtitle-alias` rewrites at load, against `subtitle`, the
+ * canonical spelling that converts nothing. So the pin discriminates on the
+ * CONVERSION and not on "a page is present" — measured on the pair before it
+ * was written: `description` → text `--strict` 1, `--json --strict` 1, `--json`
+ * 0, `warnings: []`, one notice; `subtitle` → 0 on every face, no notices.
+ *
+ * The non-empty `conversions` assertion is the anti-vacuity guard, and it is
+ * load-bearing rather than decorative. `page-header-subtitle-alias` is a LIVE
+ * window that retires from the load path at protocol 18; the day it retires,
+ * this fixture raises nothing and, without that assertion, the file would keep
+ * passing while pinning an empty cell — precisely the failure this test exists
+ * to remove. It goes red instead, and whoever retires the entry re-points the
+ * fixture at another live conversion. (The obvious candidate for this fixture,
+ * `object-compactLayout-to-highlightFields`, is already `retiredFromLoadPath`:
+ * the schema tombstones the key, so it raises a validation ERROR, not a notice.)
+ *
  * ## Why a real child process
  *
  * `process.exitCode` set inside a vitest worker is not an exit status: the
@@ -103,6 +133,35 @@ export default {
 };
 `;
 
+/**
+ * The conversions-only minimal pair (#11301) — `CLEAN_SOURCE`'s shape plus one
+ * `page:header` component, whose second line is authored under the key named.
+ *
+ * Nothing else here raises an advisory: the unknown-key lints run on the
+ * POST-conversion `normalized`, so what they see is the canonical `subtitle`
+ * either way, and both members are pinned to `warnings: []` below rather than
+ * assumed to be.
+ */
+const headerPageSource = (headerTextKey: 'description' | 'subtitle'): string => `
+export default {
+  manifest: { id: 'com.example.strictexit', name: 'strictexit', version: '1.0.0', type: 'app', namespace: 'strictexit' },
+  objects: [{
+    name: 'strictexit_ticket',
+    label: 'Ticket',
+    sharingModel: 'private',
+    fields: { title: { type: 'text', label: 'Title' } },
+  }],
+  apps: [{ name: 'strictexit_app', label: 'Strict Exit App' }],
+  pages: [{
+    name: 'strictexit_home',
+    label: 'Home',
+    regions: [{ name: 'main', components: [
+      { type: 'page:header', properties: { title: 'Tickets', ${headerTextKey}: 'All open tickets' } },
+    ] }],
+  }],
+};
+`;
+
 interface Run {
   code: number;
   stdout: string;
@@ -128,17 +187,25 @@ function runCli(args: string[], cwd: string): Promise<Run> {
 
 let warnsDir: string;
 let cleanDir: string;
+let conversionsDir: string;
+let conversionsCanonDir: string;
 
 beforeAll(() => {
   warnsDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-exit-warns-'));
   writeFileSync(join(warnsDir, 'objectstack.config.ts'), WARNS_SOURCE);
   cleanDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-exit-clean-'));
   writeFileSync(join(cleanDir, 'objectstack.config.ts'), CLEAN_SOURCE);
+  conversionsDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-exit-conversions-'));
+  writeFileSync(join(conversionsDir, 'objectstack.config.ts'), headerPageSource('description'));
+  conversionsCanonDir = mkdtempSync(join(tmpdir(), 'os-validate-strict-exit-conversions-canon-'));
+  writeFileSync(join(conversionsCanonDir, 'objectstack.config.ts'), headerPageSource('subtitle'));
 });
 
 afterAll(() => {
   rmSync(warnsDir, { recursive: true, force: true });
   rmSync(cleanDir, { recursive: true, force: true });
+  rmSync(conversionsDir, { recursive: true, force: true });
+  rmSync(conversionsCanonDir, { recursive: true, force: true });
 });
 
 describe('#11174 — --strict reaches the same exit status on both faces', () => {
@@ -184,6 +251,62 @@ describe('#11174 — --strict reaches the same exit status on both faces', () =>
 
     const json = await runCli(['validate', '--json', '--strict'], cleanDir);
     expect(json.code, `json --strict:\n${json.stdout}\n${json.stderr}`).toBe(0);
+  }, 120_000);
+
+  it('conversions-only: the cell where --strict is decided by a collection the payload keeps OUT of `warnings`', async () => {
+    const text = await runCli(['validate', '--strict'], conversionsDir);
+    const json = await runCli(['validate', '--json', '--strict'], conversionsDir);
+
+    // Same floor as the first case: equality is only worth asserting over a run
+    // that genuinely had something to fail on.
+    expect(
+      text.code,
+      `text --strict must fail on the conversions-only config:\n${text.stdout}\n${text.stderr}`,
+    ).not.toBe(0);
+
+    expect(
+      json.code,
+      `--json --strict exited ${json.code} where --strict exited ${text.code}, same config.\n` +
+        `json stdout:\n${json.stdout}\njson stderr:\n${json.stderr}`,
+    ).toBe(text.code);
+
+    const payload = JSON.parse(json.stdout) as {
+      valid?: unknown;
+      warnings?: unknown;
+      conversions?: unknown;
+    };
+
+    // The cell spelled out. `warnings: []` is asserted, not tolerated: it is the
+    // whole point — narrow the gate to this field and the run above drops to 0
+    // while the text face stays at 1.
+    expect(payload.valid).toBe(true);
+    expect(payload.warnings).toEqual([]);
+    expect(
+      Array.isArray(payload.conversions) && (payload.conversions as unknown[]).length,
+      'the fixture raised NO conversion — the alias has most likely retired from ' +
+        'the load path; re-point `headerPageSource` at a live entry in ' +
+        '`packages/spec/src/conversions/registry.ts` rather than deleting this line',
+    ).toBeGreaterThan(0);
+
+    // Separates "gates on --strict" from "fails whenever a conversion is seen".
+    // The warnings fixture's own without-strict control cannot cover this: it
+    // raises no conversions, so it passes under either behaviour.
+    const loose = await runCli(['validate', '--json'], conversionsDir);
+    expect(loose.code, `--json without --strict must stay 0:\n${loose.stdout}\n${loose.stderr}`).toBe(0);
+  }, 120_000);
+
+  it('control: the same page under the CANONICAL key converts nothing and exits 0 on both faces', async () => {
+    // The discriminator. Byte-identical to the fixture above but for one key,
+    // so a pin that passed here too would be pinning the presence of a page.
+    const text = await runCli(['validate', '--strict'], conversionsCanonDir);
+    expect(text.code, `text --strict:\n${text.stdout}\n${text.stderr}`).toBe(0);
+
+    const json = await runCli(['validate', '--json', '--strict'], conversionsCanonDir);
+    expect(json.code, `json --strict:\n${json.stdout}\n${json.stderr}`).toBe(0);
+
+    const payload = JSON.parse(json.stdout) as { warnings?: unknown; conversions?: unknown };
+    expect(payload.warnings).toEqual([]);
+    expect(payload.conversions).toEqual([]);
   }, 120_000);
 
   it('control: without --strict, the same advisory-raising config still exits 0 under --json', async () => {


### PR DESCRIPTION
Fixes #11301

Test-only. Pins the one documented exit-code cell of `os validate --json --strict` that no fixture exercised.

## The unpinned cell

`--strict` gates on the **text** face's warning list, which folds in the ADR-0087 D2 load-time conversion notices. The JSON payload carries those notices separately, under `conversions`, and its own `warnings` field is the five-way spread *without* them. So a config whose only advisories are conversion notices exits **1** carrying `{ valid: true, warnings: [], conversions: [...] }`.

That is deliberate, and `commands/validate.ts` states the reasoning at the `emitJson` call. It was also the one cell where the exit code is decided by a collection absent from the payload field a reader reaches for first — and every existing fixture raises **zero** conversions, so a regression narrowing the gate back to `payload.warnings` would have restored the original divergence with the whole suite green.

The behaviour was not on trial here and was not touched: no production file is in this diff.

## The fixture is a minimal pair, not a single input

Both members come from one template, `headerPageSource(key)`, and differ in a single key on one `page:header` component:

| fixture | `--json` | `--json --strict` | `--strict` (text) | `valid` | `warnings` | `conversions` |
|---|---|---|---|---|---|---|
| `description` (the live `page-header-subtitle-alias` window) | 0 | **1** | 1 | `true` | `[]` | 1 notice |
| `subtitle` (canonical spelling) | 0 | **0** | 0 | `true` | `[]` | `[]` |

So the pin discriminates on the **conversion**, not on "a page is present". Both rows were measured before the test was written.

The issue's suggested candidate, `object-compactLayout-to-highlightFields`, turned out to be unusable and the test comment records why: it is already `retiredFromLoadPath`, so the schema tombstones the key and it raises a validation **error**, not a notice. `page-header-subtitle-alias` was selected from the 17 entries that are still live on the load path, and measured to raise no other advisory.

## Anti-vacuity

`conversions` is asserted **non-empty**. `page-header-subtitle-alias` retires from the load path at protocol 18; on that day the fixture raises nothing, and without that assertion the file would keep passing while pinning an empty cell — exactly the failure this card exists to remove. It goes red instead, with a message naming the remedy.

**Discrimination ablation** (trap-restored, mutation proven on disk by grepping both the injected and the removed text, prediction recorded before the run):

- mutation: `headerPageSource('description')` → `headerPageSource('subtitle')` in `beforeAll`, making the fixture byte-identical to its canonical twin. Removed-text hits 1 → 0, injected-text hits 0 → 1, sha `7cde9871…` → `391ebbd5…`.
- predicted: 1 failed / 5 passed, failing on the **floor** assertion (`expect(text.code).not.toBe(0)`) rather than on the `conversions` guard, since the floor is asserted first in the body.
- observed, as predicted: `Tests  1 failed | 5 passed (6)`, `AssertionError: text --strict must fail on the conversions-only config: expected +0 not to be +0`. The canonical control stayed green.
- restore leg: sha back to `7cde9871…`, grep counts back to 1/0, `git status` clean.

## Verification — all at `32ecb986`

- `pnpm --filter @objectstack/cli exec vitest run src/commands/validate-json-strict-exit.e2e.test.ts` → `Test Files  1 passed (1)` / `Tests  6 passed (6)`
- `pnpm --filter @objectstack/cli typecheck` → `tsc --noEmit`, exit 0
- Gate set derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, not a hand-built list. All 11 matched + convention-triggered families green, including `check-i18n-bundles: OK (9 package(s) — all bundles in sync…)`, `check-i18n-coverage: OK (12 config(s), 602 baselined untranslated string(s), none new).` and `check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured…, none above its recorded number.`
- `check:i18n` and `check:i18n-coverage` first **refused** (`PREREQUISITE NOT MET — the workspace CLI is not built`, "Nothing was checked"). Recorded as not measured, then measured for real after `turbo run build`.

## No changeset

Nothing user-visible ships: the diff is one `packages/cli/src/**/*.test.ts` file, which `tsconfig.build.json` excludes from the published output. `skip-changeset` applied.

## Note on #11599

`check:cli-test-child-env` is not in this branch's base and does not reach this diff either way — the file lives in `packages/cli/src/commands/`, not `packages/cli/test/**`. No baseline entry was added and no existing violating file was touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_019siH5jDmk5hrayvfyojUqR)_