### PR TITLE
fix(scripts): move check-ci-filter-parity's self-test fixtures inside selfTest()

### DIFF
--- a/scripts/check-ci-filter-parity.mjs
+++ b/scripts/check-ci-filter-parity.mjs
@@ -382,35 +382,56 @@ function list(root = REPO_ROOT, table = CROSS_PACKAGE_TEST_INPUTS) {
 // is a different file and must be named), and a declaration under a root that
 // appears nowhere at all.
 
-/** A ci.yml source carrying the two scheduling lists, in the real shape. */
-const REAL_TEST_IF =
-  "${{ !cancelled() && (needs.filter.outputs.core != 'false' || needs.filter.outputs.crosspkg != 'false') }}";
-
-function fixtureWorkflow({ core, crosspkg, condition = REAL_TEST_IF } = {}) {
-  const list = (entries) => entries.map((e) => `              - '${e}'`).join('\n');
-  return [
-    'name: CI',
-    'jobs:',
-    '  filter:',
-    '    steps:',
-    '      - uses: dorny/paths-filter@v4',
-    '        id: changes',
-    '        with:',
-    '          filters: |',
-    '            core:',
-    list(core ?? ['packages/**', '.github/workflows/ci.yml']),
-    `            ${REMEDY_FILTER}:`,
-    list(crosspkg ?? ['scripts/**']),
-    '  test:',
-    `    if: ${JSON.stringify(condition)}`,
-    '    steps:',
-    '      - run: echo test',
-  ].join('\n');
-}
-
-const table = (globs) => ({ '@objectstack/probe': { globs } });
+// ⛔ The fixture builders below live INSIDE `selfTest()` and must stay there
+// (#10841). `scripts/pm/dispatch-gates.mjs` scans a gate's MODULE BODY for the
+// path literals it reads -- blanking comments and self-test BODIES first -- and
+// prints the gate as a local gate for every card those literals cover. A fixture
+// helper hoisted to module scope escapes that blanking, and its fixture globs are
+// then read as this gate's declared population.
+//
+// Measured on `3637731e2` before the move: this gate's hint set was
+// `.github/workflows/ci.yml` (real) plus the two subtree globs the `core`/
+// `crosspkg` defaults spell and the fixture table's package name (all three
+// fabricated), and the pair census put it in the MATCHED column for 5328 of 6511
+// tracked files. Its real population is ci.yml and its own source: 2. A
+// fabricated lead is pasted into a dispatch prompt and cannot be told apart from
+// an earned one, so the cost was paid by every card under two of the largest
+// directories in the tree.
+//
+// A fixture that must be module-scope for some other reason can still be spelled
+// safely -- assemble it from unslashed halves the way `DEFAULT_BASE_REF` does in
+// dispatch-gates.mjs, so only the joined value is pathy and it exists at runtime
+// alone.
 
 export async function selfTest() {
+  /** A ci.yml source carrying the two scheduling lists, in the real shape. */
+  const REAL_TEST_IF =
+    "${{ !cancelled() && (needs.filter.outputs.core != 'false' || needs.filter.outputs.crosspkg != 'false') }}";
+
+  function fixtureWorkflow({ core, crosspkg, condition = REAL_TEST_IF } = {}) {
+    const list = (entries) => entries.map((e) => `              - '${e}'`).join('\n');
+    return [
+      'name: CI',
+      'jobs:',
+      '  filter:',
+      '    steps:',
+      '      - uses: dorny/paths-filter@v4',
+      '        id: changes',
+      '        with:',
+      '          filters: |',
+      '            core:',
+      list(core ?? ['packages/**', '.github/workflows/ci.yml']),
+      `            ${REMEDY_FILTER}:`,
+      list(crosspkg ?? ['scripts/**']),
+      '  test:',
+      `    if: ${JSON.stringify(condition)}`,
+      '    steps:',
+      '      - run: echo test',
+    ].join('\n');
+  }
+
+  const table = (globs) => ({ '@objectstack/probe': { globs } });
+
   const failures = [];
   let checked = 0;
   const assert = (cond, label) => {


### PR DESCRIPTION
Fixes #10841

`scripts/check-ci-filter-parity.mjs` kept its self-test fixture apparatus at module
scope: the `REAL_TEST_IF` condition constant, the `fixtureWorkflow` builder, and the
`table` declaration-table helper. All three are used only by `selfTest()` — every
call site is inside it — but `dispatch-gates.mjs` blanks self-test *bodies* before
scanning a gate's module body for the path literals it reads, so a fixture helper
hoisted out of that body escapes the blanking and its fixture globs are read as the
gate's declared population.

This moves the three declarations inside `selfTest()`. No behaviour change: same
fixtures, same 39 assertions, same real run. Triage's remedy 1, taken at its widest
sensible boundary — the whole fixture apparatus rather than just the two defaults —
so the site is closed for the class and not only for the two instances. Remedy 3
(teaching `maskSelfTests` about module-scope self-test-only constants) is a
`scripts/pm/dispatch-gates.mjs` change and is untouched here.

## Premise re-verified on today's tree

The card was measured on 2026-08-21 at PR #10801's merged ref. Re-derived here on
`origin/main` `3637731e2` — 152 families today, up from the 150 quoted in dispatch,
after `dispatch-gates.mjs` gained import-following (#11512) and the `--self-test`
invocation matcher (#11554):

- Both literals are still present and still module-scope. Located by content, not by
  line number: they are the `core` / `crosspkg` defaults of `fixtureWorkflow`, which
  sat at column 0.
- The defect is live and unaltered by #11554. A `packages/**` card and a `scripts/**`
  card each derived `check-ci-filter-parity` as a MATCHED family before this change.

#11554's rule — a self-test family follows no import — does not reach this site. That
rule decides which *modules* a family inherits hints from; this leak is a literal in
the gate's own module body, which every family scans directly. Same species, one level
in.

## Price

Census over all 6511 tracked files against all 152 families, using the derivation's own
`coveringKey` per (family, file):

| | before | after |
|---|---|---|
| families discovered | 152 | 152 |
| families with at least one pair | 134 | 134 |
| total (gate, file) pairs | 66733 | 61407 |

- pairs **lost**: 5326 — every one of them this single family's
- pairs **gained**: 0
- pairs **re-attributed** (pair survives, covering key or via changes): **0**

Gain and re-attribution are counted separately, per the standard #11512 and #11554 were
held to. There is no re-attribution here at all.

### The genuine hints did not shrink

The family's hint set goes from four entries to one:

```
dropped: packages/**   scripts/**   @objectstack/probe
added:   (none)
```

All three are self-test fixtures. `@objectstack/probe` is the fixture declaration
table's package name; it was already inert for matching (no tracked path under it) and
contributed 0 of the 5326. It falls out of the same move and is reported for
completeness, not counted as gain.

The gate's real population is asserted rather than eyeballed — its surviving pairs are
exactly two, enumerated in full:

```
.github/workflows/ci.yml             ⇢ gate source '.github/workflows/ci.yml'
scripts/check-ci-filter-parity.mjs   ⇢ gate script (identity)
```

That is the whole of what the gate opens: `readFileSync(join(root, CI_WORKFLOW))` in
`main()` and `list()`, plus `CROSS_PACKAGE_TEST_INPUTS` imported from the sibling gate.
The census compared the hint set of **every** family, not just this one, precisely
because a lead that stops appearing looks exactly like a lead that was never earned: no
other family moved in either direction.

## Non-vacuity, both directions

Reverse-verified from the committed fix by restoring the pre-fix file out of
`origin/main`, under a `trap ... EXIT INT TERM` restore. The mutation was proven on
disk — sha256 changed, and the `fixtureWorkflow` declaration anchor moved from column 0
to column 2 and back — and the restore proven byte-identical (sha256 equal to the fixed
file, `git status` clean for the path):

| derivation input | mutated (pre-fix) | restored (fix) |
|---|---|---|
| `packages/core/src/index.ts` | MATCHED via gate source `packages/**` | absent |
| `scripts/check-nul-bytes.mjs` | MATCHED via gate source `scripts/**` | absent |
| `.github/workflows/ci.yml` | MATCHED via gate source `.github/workflows/ci.yml` | MATCHED, same key |

No rebuild leg applies here: `dispatch-gates.mjs` reads this gate with `readFileSync`
on the source path, never through a package `exports` map or a `dist/` artifact, so
there is no build step standing between the edit and the measurement.

## Gates

Derived union for this diff — `node scripts/pm/dispatch-gates.mjs` with no paths, so
the change set comes from the merge base rather than from a hand-written list — run at
head `f30da6d0e` (the final commit), exit codes captured before any pipe:

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm check:cross-package-test-inputs` | 0 | green |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 142 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `pnpm check:parse-guard` | 0 | green |
| `pnpm check:pnpm-filter-targets` | 0 | green |
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 95 declared cross-package glob(s) (80 unique) are covered by core or crosspkg` |
| `node scripts/check-ci-filter-parity.mjs --self-test` | 0 | `✓ check-ci-filter-parity --self-test: 39 assertions` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | green |

Plus the two standing families: `pnpm check:nul-bytes` (0 — `check-nul-bytes: OK
(scanned 6506 text file(s) ... no raw ASCII control bytes)`) and
`pnpm check:pm-dispatch-gates` (0 — `✓ dispatch-gates self-test: 579 cases pass.`),
the latter because this change is measured by that tool.

Run through `scripts/pm/os-verify-lock.sh`; its verdict line was
`VERDICT command-exit 0 · held the lock 66s · waited 0s`.

## No changeset

`scripts/` only — a dev-tooling gate that is not published and releases nothing, so this
PR carries the `skip-changeset` label instead of a changeset file.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_