### PR TITLE
docs(spec): correct the withdrawn `os migrate meta` claim in the published 17.0.0 app-area retirement entry

### DIFF
--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -5001,9 +5001,19 @@ configured` without it. Check `discovery.services` before calling, exactly as
   The retired alias spellings `visibleWhen` / `visibleOn` / `permissions` carry the
   same prescriptions rather than renaming onto keys that are themselves gone.
 
-  Run `os migrate meta --from 16` to rewrite existing sources automatically
-  (ADR-0087 D2 conversion `app-area-fail-open-gates-removed`, wired into the
-  protocol-17 D3 chain step).
+  Run `os migrate meta --from 16` to list the mechanical edits for existing
+  sources; apply them by hand (ADR-0087 D2 conversion
+  `app-area-fail-open-gates-removed`, wired into the protocol-17 D3 chain step).
+
+  > **Correction (#9734):** as published, this entry closed with "Run
+  > `os migrate meta --from 16` to rewrite existing sources automatically". The
+  > command has never rewritten an authored source file: it replays the
+  > conversion chain over the loaded stack **in memory** and prints the
+  > attributed mechanical change list, and there is no `--write` / `--fix` flag.
+  > The sentence was withdrawn class-wide in #9529, and the prescription above is
+  > the one `areas[].visible` / `areas[].requiredPermissions` carry today.
+  > Corrected post-publication — the released 17.0.0 artifact shipped the
+  > original wording.
 
   **Why they read alive — and why that made them worse than dead.** The _same key
   names_ are genuinely enforced one level up and one level down:


### PR DESCRIPTION
Fixes #9734

Corrects one shipped false claim in the published `@objectstack/spec` CHANGELOG, under explicit maintainer authorization. **One entry, one sentence, plus an inline correction note.**

## The authorization, quoted verbatim

Maintainer ruling, 2026-08-22, decision-inbox digest — accepted verbatim as 「接受所有」 — recorded in [comment 5377372330](https://github.com/objectstack-ai/objectstack/issues/9734#issuecomment-5377372330):

> **Ruled:** Option B — the authorized single-line fix at `packages/spec/CHANGELOG.md:3948`: correct the live false claim ("Run `os migrate meta --from 16` to rewrite existing sources automatically") in place, with an inline note that it was corrected post-publication. This is explicit maintainer authorization for the one-line edit to a published changelog that the seat correctly declined to make without it. Explicitly ruled NOT the line-2735 variant: `packages/spec/CHANGELOG.md:2735` quotes the withdrawn sentence in order to retract it and must not be touched, and the same protection extends to the descriptive quote in `packages/cli/src/utils/config.ts:133` — no blanket sweep.

Re-triage on 2026-08-24 ([comment 5389636842](https://github.com/objectstack-ai/objectstack/issues/9734#issuecomment-5389636842)) moved the card `domain:devx` → `domain:spec` with the ruling transferred verbatim and no re-adjudication.

## Locating the ruled line by CONTENT, not by number

The ruled line numbers are from 2026-08-21 and have since drifted, so the target was identified from history rather than trusted:

1. The clone here is shallow, which answers windowed history questions wrongly at exit 0. Deepened with `git fetch --shallow-since=2026-08-12` (51 → 1568 commits) so the window is genuinely covered.
2. Last commit touching `packages/spec/CHANGELOG.md` **before** the ruling timestamp (2026-08-22T02:28Z): **`47d1ae89`**, 2026-08-20T09:41Z (`chore: version packages`). That blob is what the ruling read.
3. At `47d1ae89`, `:3948` is the flat prescription inside entry **`ad047d2` — "retire the two fail-open app-area gates" (#4651)** under `## 17.0.0`, and `:2735` is the #9529 retraction quote. Both matched the ruling's description exactly.
4. That same entry sits at **`4981–5049`** today (drift **+1056**), and the ruled sentence at **`5004`**. The entry is **byte-identical** to its state at the ruling — `sha256 8e78a641…312a5` on both extractions — so this is the same entry, not a diverged one.

⚠️ The `ad047d2` entry appears **twice** in the file (`## 17.0.0` and `## 17.0.0-rc.2`). The ruled `:3948` maps only to the `## 17.0.0` copy. The rc.2 copy is a *different, older* text and is **not** touched here.

## What changed

The sentence now carries the post-#9529 house sentence — the one `areas[].visible` / `areas[].requiredPermissions` actually ship today (`packages/spec/src/ui/app.zod.ts:862-863`) — followed by a correction blockquote.

The note deliberately reuses the **house form this same file already uses** for a post-publication correction: the `**Correction (#5809):**` blockquote at `packages/spec/CHANGELOG.md:51632`, introduced by #5809 for this very entry's rc.2 copy.

```
-  Run `os migrate meta --from 16` to rewrite existing sources automatically
-  (ADR-0087 D2 conversion `app-area-fail-open-gates-removed`, wired into the
-  protocol-17 D3 chain step).
+  Run `os migrate meta --from 16` to list the mechanical edits for existing
+  sources; apply them by hand (ADR-0087 D2 conversion
+  `app-area-fail-open-gates-removed`, wired into the protocol-17 D3 chain step).
+
+  > **Correction (#9734):** as published, this entry ended with "Run
+  > `os migrate meta --from 16` to rewrite existing sources automatically". The
+  > command has never rewritten an authored source file: …
```

One hunk, 13 insertions / 3 deletions, one file.

## The excluded sites, proven excluded

| Protected site | Proof |
|:---|:---|
| `packages/spec/CHANGELOG.md:3791` (the #9529 retraction, was `:2735`) | The diff has exactly one hunk, `@@ -5004,3 +5004,13 @@` — the retraction is above it and unmodified |
| `packages/cli/src/utils/config.ts:133` | Not in `git diff --name-only`; the PR touches one file |
| `## 17.0.0-rc.2` copy of the same entry | Extracted before and after; **byte-identical** |

## Remaining sites are recorded, not swept — #11636

A full classified census found **9 more flat occurrences** of the withdrawn sentence across three published changelogs (`packages/spec` ×5, `packages/platform-objects` ×2, `examples/app-todo` ×2). Per "no blanket sweep" they are **not** touched here; they are recorded in **#11636** (unassigned, `finding`, no `pm:queue`) so they cannot be auto-dispatched without the same kind of authorization this card received. That card also lists the sites that merely *quote* the sentence in order to retract or describe it — the trap a regex sweep would fall into.

## Verification — gate union re-run at `c79ec814`

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (change set derived by the script itself from the merge base, not from a hand-built list) matched **16 families**. All runnable ones are green:

`check:release-notes` · `check:release-page-status` · `check-release-section-coverage` · `check:published-files` · `check:merge-driver` · `check:empty-state` · `check:liveness` · `check:variant-docs` · `check:strictness-ledger` · `check:slot-lookup` · `check:test-source-alias` · `check:type-source-resolution` · `check-ci-filter-parity` · `check-plugin-teardown-shape` · `docs-audit/check-affected-docs` — **all EXIT=0**, plus `check-nul-bytes` (0 control bytes, 6506 files).

`check-release-section-coverage` prints an **advisory** finding about `content/docs/releases/index.mdx` naming 17.1.0 while 17.2.0 is current. It is pre-existing, unrelated to this diff, and advisory by design ("Findings are ADVISORY: they never fail this run").

**One declared narrowing — `check-dev-prereqs`, proven irrelevant rather than skipped.** It reds locally only because this fresh worktree has no `packages/spec/dist`. Its input set, read from its own source and from `turbo.json`, is: every file under the package's own `src/`, its `package.json`, its `tsconfig.json`, its `tsup.config.ts`, plus turbo's `globalDependencies` (`["tsconfig.json","tsup.config.ts"]`). `CHANGELOG.md` is in none of them and the script never names it (`grep -c CHANGELOG` = 0), so this diff cannot move its verdict. `--self-test` passes (16 cases). CI builds and runs it for real.

**`pnpm lint` narrowed the same way:** eslint reports the changed file as `"File ignored because no matching configuration was supplied"` (`--format json`, errorCount 0) — read from eslint's own config resolution. 1 file in the diff, 0 in eslint's population, and no type-aware linting is enabled, so no untouched file's verdict can move.

## Merge notes

- **Not a governed surface.** `GOVERNED_SURFACES` printed from `scripts/pm/check-governed-merges.mjs` is `docs/adr/**`, `.claude/**`, `skills/**`, `AGENTS.md`, `CLAUDE.md` — this diff hits none, so Prime Directive 14's human-merge-only fence does not apply.
- **No changeset.** This corrects release history; a changeset would append a *new* release entry to the very file being corrected. `skip-changeset` applied (whole-set write unioned onto the bot-applied `documentation` / `size/s`, because the additive labels endpoint returned HTTP 403 for this session) and read back below.
- ⚠️ Version Packages PR #11336 was still open at push time — re-verified after the final commit: `main` had moved 5 commits but `packages/spec/CHANGELOG.md` was unchanged, so the target still holds. If #11336 lands first this file gains sections at the top; the target must then be re-located by content (entry `ad047d2` under `## 17.0.0`), never by line number.

---

_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_
