### PR TITLE
fix(scripts): anchor check-i18n-bundles' population at the repo root

### DIFF
--- a/scripts/check-i18n-bundles.mjs
+++ b/scripts/check-i18n-bundles.mjs
@@ -238,6 +238,147 @@ function passthroughStderrLines(text) {
 }
 
 // ---------------------------------------------------------------------------
+// The POPULATION: what this gate is going to grade, and the two ways that
+// question can fail before a single bundle is compared (#11647).
+// ---------------------------------------------------------------------------
+
+/**
+ * The directory the population is walked from. Repo-relative ON PURPOSE — it is
+ * the spelling every message here is written in, exactly as `CLI` and the
+ * documented `--out=` are, and `atRepoRoot` is the one seam that turns it into a
+ * path on disk. The same division cli-build-prerequisite.mjs states for its own
+ * vocabulary (#11394), and check-i18n-coverage.mjs for its `at()` (#10907).
+ */
+const PACKAGES_DIR = 'packages';
+
+/**
+ * The repo root as a cwd for the child extractor. Taken from the SHARED seam
+ * rather than derived again from `import.meta.url`: this file already imports
+ * `atRepoRoot`, and a second derivation two lines from the first is the
+ * duplication #11394 removed when it exported this one.
+ */
+const REPO_ROOT = atRepoRoot('.');
+
+/**
+ * A population problem is never fixed by building the CLI, so it must not
+ * inherit `reportPrerequisiteNotMet`'s default `fix`. Prescribing a rebuild for
+ * a missing `packages/` is the confident-wrong-diagnosis shape #5862 removed.
+ */
+const POPULATION_FIX = `check out this repository — this gate reads ${PACKAGES_DIR}/ from its own location, not from the cwd`;
+
+/**
+ * Every extract config in the repo, repo-relative and sorted — from ANY cwd.
+ *
+ * `findExtractConfigs`'s first parameter is its ABSOLUTE walk root; its own
+ * docstring says so ("Every extract config under `absDir`"), and the module's
+ * other consumer — scripts/pm/dispatch-gates.mjs — has always passed one
+ * (`findExtractConfigs(join(ROOT, 'packages'), 'packages')`). This gate passed
+ * the repo-relative vocabulary word for BOTH parameters, so the walk landed on
+ * `<cwd>/packages`: at the repo root that is the right directory by
+ * coincidence, and from anywhere else `readdirSync` threw an uncaught
+ * `ENOENT … scandir 'packages'` with a `node:fs` stack (#11647).
+ *
+ * The anchor goes HERE and not in the shared module: the module's contract is
+ * already correct and already honoured by its other caller, so moving the
+ * anchor into it would silently re-root a second consumer's population — the
+ * defect this gate family keeps paying for, in reverse.
+ *
+ * Note the direction, because it is not #10907's: that stack is LOUD. The cost
+ * was a wrong first diagnosis (a reader sent to node's filesystem module), not
+ * a false pass. What makes it worth fixing anyway is that it bypassed every
+ * worded channel this gate owns — #5217, #7681 and `reportPrerequisiteNotMet`
+ * exist precisely so an environment fact never reaches the reader as a content
+ * verdict, and an uncaught throw reaches them as neither.
+ */
+function discoverExtractConfigs() {
+  return findExtractConfigs(atRepoRoot(PACKAGES_DIR), PACKAGES_DIR)
+    .map((c) => c.rel)
+    .sort();
+}
+
+/**
+ * The detail for a walk that threw. Pure, so `--self-test` can pin the one
+ * property that matters: it says the checkout is broken, NOT that the reader
+ * stood in the wrong place — post-#11647 the cwd cannot cause this.
+ */
+function unreadablePopulationDetail(err) {
+  const message = String(err?.message ?? err);
+  return [
+    `Walking for extract configs failed before any bundle was compared:`,
+    ``,
+    `  ${message.length > 160 ? `${message.slice(0, 160)}…` : message}`,
+    ``,
+    `This gate resolves \`${PACKAGES_DIR}/\` against its OWN location rather than the cwd, so`,
+    `this is not a "run it from the repo root" problem — the directory is missing or`,
+    `unreadable in the checkout this script lives in:`,
+    ``,
+    `  ${atRepoRoot(PACKAGES_DIR)}`,
+  ];
+}
+
+/**
+ * Why the population is unusable, or `null`. Pure over an already-walked list,
+ * so `--self-test` drives both directions — the shape every other classifier in
+ * this file has.
+ *
+ * TWO causes, and only ONE of them is a prerequisite. Keeping them apart is the
+ * whole of this function:
+ *
+ *   - an EMPTY POPULATION is an environment fact, and refusing it is #4690's
+ *     rule: a scan that found nothing must never render as a pass. #10907 had
+ *     to re-learn that one file over, where an unanchored walk came back empty
+ *     and the gate printed `OK (0 config(s))` and exited 0. This gate has
+ *     always exited 1 here, so anchoring the walk did not introduce the guard —
+ *     but anchoring it WITHOUT this check would have converted #11647's loud
+ *     crash into exactly that silent green, which is strictly worse than the
+ *     bug being fixed.
+ *
+ *     No legitimate tree of this repo has zero: `lint.yml` runs this gate
+ *     because packages here ship translation bundles, and a checkout with none
+ *     is not one this gate can grade. So the condition is the plain `=== 0`,
+ *     and it is stated here rather than assumed.
+ *
+ *   - a FILTER that matched nothing is a typo in an argument the developer just
+ *     typed. It is not an environment fact: it must not borrow the "nothing was
+ *     checked" apparatus, must not prescribe a rebuild, and must not describe a
+ *     repository that is fine as broken. Before #11647 both causes shared one
+ *     sentence, so `--filter=platform_objects` for `platform-objects` read as a
+ *     repo with no i18n configs at all.
+ */
+function populationVerdict(population, activeFilter) {
+  if (population.length === 0) {
+    return {
+      prerequisite: true,
+      headline: `this gate has no population — no extract config exists under \`${PACKAGES_DIR}/\``,
+      detail: [
+        `The walk reached \`${PACKAGES_DIR}/\` and came back empty, so there is nothing to compare.`,
+        `Every package that ships a translation bundle documents its extract in`,
+        `\`${PACKAGES_DIR}/<pkg>/scripts/i18n-extract.config.ts\`, and CI runs this gate because some do.`,
+        ``,
+        `Walked: ${atRepoRoot(PACKAGES_DIR)}`,
+        ``,
+        `Reported as a prerequisite rather than as a pass on purpose (#4690): an empty`,
+        `scan rendered as OK is a gate that has stopped grading without saying so.`,
+      ],
+    };
+  }
+  if (activeFilter && !population.some((c) => c.includes(activeFilter))) {
+    return {
+      prerequisite: false,
+      headline: `--filter=${activeFilter} matched none of the ${population.length} extract config(s)`,
+      detail: [
+        `The repository is fine and the population was found — this is the filter, not`,
+        `the tree. \`--filter\` is a plain substring test against these repo-relative`,
+        `paths, and none of them contain that text:`,
+        ``,
+        ...population.map((c) => `  ${c}`),
+      ],
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Self-test — the proof that each classifier can go red, and that the two
 // verdicts do not contaminate each other.
 // ---------------------------------------------------------------------------
@@ -592,14 +733,128 @@ function selfTest() {
   ).join('\n');
   expect('#7681 long evidence is truncated', longSentence.includes(`${'S'.repeat(160)}…`), 'a 400-char sentence must not be pasted whole');
 
+  // -------------------------------------------------------------------------
+  // Fifth classifier (#11647): the POPULATION — is there anything to grade, and
+  // did the walk for it land on this repo or on the caller's cwd?
+  //
+  // These are the only assertions here that can fail over a CORRECT tree in a
+  // WRONG place, which is exactly why they are worth their cost: every other
+  // classifier in this file is proven red against a recorded string, but "did
+  // this gate look at anything at all?" can only be proven by looking.
+  // -------------------------------------------------------------------------
+
+  const popCwdBefore = process.cwd();
+  let offRootPopulation;
+  let bareWalkOffRoot;
+  try {
+    process.chdir(tmpdir());
+    offRootPopulation = discoverExtractConfigs();
+    // POSITIVE CONTROL for the assertion below. Without it, "the anchored walk
+    // works off-root" is compatible with a cwd that happened to contain a
+    // `packages/` — and on a tree where the bare spelling ALSO resolved, the
+    // anchoring assertion would be proving nothing. This records what the
+    // pre-#11647 line 748 did from here: throw.
+    try {
+      findExtractConfigs(PACKAGES_DIR, PACKAGES_DIR);
+      bareWalkOffRoot = 'resolved';
+    } catch (err) {
+      bareWalkOffRoot = err.code ?? 'threw';
+    }
+  } finally {
+    process.chdir(popCwdBefore);
+  }
+  const onRootPopulation = discoverExtractConfigs();
+
+  expect(
+    '#11647 the population is CWD-independent',
+    offRootPopulation.length > 0,
+    `the walk from ${tmpdir()} found ${offRootPopulation.length} config(s) — the population is still ` +
+      "resolved CWD-relatively, which is the defect: off-root the gate cannot start at all",
+  );
+  expect(
+    '#11647 …and finds exactly the population the root does',
+    offRootPopulation.join('\n') === onRootPopulation.join('\n'),
+    `off-root found ${offRootPopulation.length} config(s), on-root ${onRootPopulation.length} — ` +
+      'anchoring must not change WHAT is scanned',
+  );
+  expect(
+    '#11647 …spelled repo-relative, as every message and the child argv are',
+    offRootPopulation.every((c) => !c.startsWith('/') && !c.includes(REPO_ROOT)),
+    `absolute paths would leak into the rerun command and the extractor argv; got ${JSON.stringify(offRootPopulation.slice(0, 2))}`,
+  );
+  expect(
+    '#11647 …and the bare spelling demonstrably would not have',
+    bareWalkOffRoot === 'ENOENT',
+    `the pre-fix spelling did not fail from ${tmpdir()} (got ${bareWalkOffRoot}), so the assertions above ` +
+      'prove nothing about anchoring',
+  );
+
+  // #4690, carried over from #10907: an empty population is a REFUSAL. Anchoring
+  // a scan without this trades a loud crash for a silent green.
+  const emptyVerdict = populationVerdict([], '');
+  expect('#4690 an empty population is refused', !!emptyVerdict && emptyVerdict.prerequisite === true, `got ${JSON.stringify(emptyVerdict)}`);
+  expect(
+    '#4690 …through the WORDED channel, not as a pass',
+    !!emptyVerdict && /no population|came back empty/.test(`${emptyVerdict.headline}\n${emptyVerdict.detail.join('\n')}`),
+    'the refusal has to say in words that nothing was gradeable',
+  );
+  expect(
+    '#4690 …and does not prescribe the CLI build, which would change nothing',
+    POPULATION_FIX !== CLI_BUILD_FIX,
+    'a population problem is not fixed by rebuilding the CLI',
+  );
+
+  // The other cause, and the reason `=== 0` alone is not the whole condition: a
+  // filter that matched nothing is a typo, not an environment fact.
+  const filterVerdict = populationVerdict(onRootPopulation, 'no-such-package');
+  expect('#11647 an unmatched --filter is refused', !!filterVerdict, 'a filter matching nothing must not render as OK (0 package(s))');
+  expect(
+    '#11647 …but NOT as a prerequisite',
+    !!filterVerdict && filterVerdict.prerequisite === false,
+    'a typo in an argument the developer just typed is not an environment fact, and must not print "nothing was checked"',
+  );
+  expect(
+    '#11647 …and the two population verdicts do not contaminate each other',
+    !!emptyVerdict &&
+      !!filterVerdict &&
+      !emptyVerdict.headline.includes('--filter') &&
+      !filterVerdict.detail.join('\n').includes('came back empty') &&
+      filterVerdict.detail.join('\n').includes('The repository is fine'),
+    'each cause must name itself: a broken checkout and a mistyped filter send the reader to different places',
+  );
+  expect(
+    '#11647 a healthy population yields no verdict at all',
+    populationVerdict(onRootPopulation, '') === null && populationVerdict(onRootPopulation, 'platform-objects') === null,
+    'the classifier must be silent over the tree CI actually runs on',
+  );
+
+  // The walk-threw path: it must blame the CHECKOUT, never the caller's cwd —
+  // post-#11647 the cwd cannot cause it, so a message that says "run from the
+  // repo root" would send the reader somewhere that changes nothing.
+  const unreadable = unreadablePopulationDetail(Object.assign(new Error("ENOENT: no such file or directory, scandir 'packages'"), { code: 'ENOENT' })).join('\n');
+  expect('#11647 the unreadable-walk detail carries the evidence', unreadable.includes("scandir 'packages'"), `a conclusion with no reading under it is not auditable; got ${JSON.stringify(unreadable)}`);
+  expect(
+    '#11647 …names the tree it actually walked',
+    unreadable.includes(atRepoRoot(PACKAGES_DIR)),
+    'the reader has to be told WHICH packages/ was missing, not merely that one was',
+  );
+  expect(
+    '#11647 …and does not blame the cwd',
+    /not a "run it from the repo root" problem/.test(unreadable),
+    'after the anchor the cwd cannot cause this, and a wrong remedy costs the reader the diagnosis again',
+  );
+  const longWalkError = unreadablePopulationDetail(new Error('E'.repeat(400))).join('\n');
+  expect('#11647 long walk errors are truncated', longWalkError.includes(`${'E'.repeat(160)}…`), 'a 400-char message must not be pasted whole');
+
   if (failures.length) {
     console.error(`✗ check:i18n --self-test — ${failures.length} failure(s)\n`);
     for (const f of failures) console.error(`  ${f}`);
     process.exit(1);
   }
   console.log(
-    '✓ check:i18n --self-test — bundle-drift, undeclared-authoring-key, missing-CLI-build and ' +
-      'stale-workspace-dist classifiers all go red, and stay distinct.',
+    '✓ check:i18n --self-test — bundle-drift, undeclared-authoring-key, missing-CLI-build, ' +
+      'stale-workspace-dist and empty-population classifiers all go red, and stay distinct; ' +
+      'the population walk is CWD-independent.',
   );
 }
 
@@ -745,14 +1000,31 @@ function checkCliBuildPrerequisite() {
 
 checkCliBuildPrerequisite();
 
-const configs = findExtractConfigs('packages', 'packages')
-  .map((c) => c.rel)
-  .sort()
-  .filter((c) => !filter || c.includes(filter));
-if (configs.length === 0) {
-  console.error(`check-i18n-bundles: no extract configs matched${filter ? ` --filter=${filter}` : ''}`);
+let population;
+try {
+  population = discoverExtractConfigs();
+} catch (err) {
+  // Before #11647 this threw straight out of the module and printed a `node:fs`
+  // stack. It is a worded verdict now, through the same channel the other two
+  // prerequisites already use.
+  reportPrerequisiteNotMet(`this gate's population could not be enumerated`, unreadablePopulationDetail(err), {
+    fix: POPULATION_FIX,
+  });
+}
+
+const populationProblem = populationVerdict(population, filter);
+if (populationProblem?.prerequisite) {
+  reportPrerequisiteNotMet(populationProblem.headline, populationProblem.detail, { fix: POPULATION_FIX });
+}
+if (populationProblem) {
+  // NOT a prerequisite: the repo is fine and the population was found, so this
+  // must not borrow the "nothing was checked" apparatus or prescribe a rebuild.
+  console.error(`\ncheck-i18n-bundles: ${populationProblem.headline}\n`);
+  for (const line of populationProblem.detail) console.error(line ? `  ${line}` : '');
   process.exit(1);
 }
+
+const configs = population.filter((c) => !filter || c.includes(filter));
 
 const drifted = [];
 const broken = [];
@@ -760,14 +1032,19 @@ const broken = [];
 const undeclared = [];
 for (const [index, config] of configs.entries()) {
   const pkg = config.replace(/^packages\//, '').replace(/\/scripts\/i18n-extract\.config\.ts$/, '');
-  const flags = flagsFromDocstring(config);
+  // `config` is repo-relative VOCABULARY — it is what every message below and the
+  // rerun command print, and what the child is handed as argv. The READ of it
+  // goes through the one seam (#11647).
+  const flags = flagsFromDocstring(atRepoRoot(config));
   const out = flags.find((f) => f.startsWith('--out='));
   if (!out) {
     broken.push(`${pkg}: its docstring documents no --out=<dir>, so the gate cannot tell where the bundles live`);
     continue;
   }
   const outDir = out.slice('--out='.length);
-  if (!existsSync(outDir)) {
+  // Same seam: `--out=` is documented repo-relative (`--out=packages/<pkg>/src/...`),
+  // so asking the filesystem about it unanchored asks about the cwd (#11647).
+  if (!existsSync(atRepoRoot(outDir))) {
     broken.push(`${pkg}: documented --out directory does not exist: ${outDir}`);
     continue;
   }
@@ -782,6 +1059,13 @@ for (const [index, config] of configs.entries()) {
   const run = spawnSync(process.execPath, args, {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
+    // `CLI`, `config` and the documented `--out=` are ALL repo-relative, so the
+    // child's cwd is what resolves them — anchoring it is what makes an off-root
+    // run extract the real bundles instead of failing nine times with an
+    // environment fact dressed as `N bundle problem(s)` (#11647). The same line,
+    // for the same reason, that check-i18n-coverage.mjs carries over its own
+    // spawn (#10907).
+    cwd: REPO_ROOT,
   });
   if (run.error) {
     broken.push(`${pkg}: could not run the extractor — ${run.error.message}`);

--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -219,6 +219,22 @@ const TRIAGE = new Map([
       + 'for #10907 gave the literal a population-constant name, so this row records a population '
       + 'that was previously unnameable rather than one the fix introduced',
   }],
+  ['check:i18n PACKAGES_DIR packages', {
+    verdict: 'REFUSE-UNSPELLABLE',
+    why: 'files named i18n-extract.config.ts beneath a scripts segment — 9 of 5093 (0.18%), tying '
+      + 'its check:i18n-coverage sibling above for the narrowest row on this list. The two gates '
+      + 'select the same nine configs by the same filename-and-segment test, so they are refused '
+      + 'alike: a subtree hint would name this gate for 5093 files to reach 9. Nothing narrower is '
+      + 'spellable, measured rather than assumed — every glob spelling of the real population '
+      + 'collapses to a malformed double-separator prefix that hintCovers matches against NOTHING, '
+      + 'so a narrow declaration would not be a precise hint but a live hint covering zero files. '
+      + 'The miss is also smaller than the row: this gate already reaches the cards that can '
+      + 'actually move a bundle through the convention triggers (a package that owns an extract '
+      + 'config, and a metadata form module), both verified live, and a wholesale root declaration '
+      + 'would drown that precision rather than add to it. The root reached the sweep only once the '
+      + 'fix for #11647 gave the literal a population-constant name, so this row records a '
+      + 'population that was previously unnameable rather than one the fix introduced',
+  }],
   ['scripts/check-skills-token-ratchet.mjs SKILLS_DIR skills', {
     verdict: 'REFUSE-UNSPELLABLE',
     why: 'one named file per child directory, 11 of 50 (22%). It already reaches its own cards '


### PR DESCRIPTION
Fixes #11647

`scripts/check-i18n-bundles.mjs` enumerated its population with two bare relative
literals, so from any cwd but the repo root it died with an uncaught
`ENOENT ... scandir 'packages'` and a `node:fs` stack. This anchors the walk,
routes its failure through the gate's existing worded channel, and refuses an
empty population.

## Re-measured at today's `main` before starting

The card's own `Unlock-action:`. Re-measured at `c251ef421` (the report was
written at `3637731e2`), with an on-root positive control so the off-root
reading is not a zero-hit that proves nothing:

```
CONTROL on-root: 9 config(s); first=packages/platform-objects/scripts/i18n-extract.config.ts
off-root THREW: Error: ENOENT: no such file or directory, scandir 'packages'
  first frame: at readdirSync (node:fs:1590:26)
  code=ENOENT syscall=scandir path="packages"
```

The premise holds. One correction to how it reproduces: running the **gate** from
`/tmp` on a fresh worktree stops earlier, at the unbuilt-CLI prerequisite, so the
population stack is only reachable on a **built** tree. It was measured both ways.

## Where the anchor goes, and why not in the shared module

`findExtractConfigs(absDir, rel)`'s first parameter is its **absolute** walk root
— its own docstring says so ("Every extract config under `absDir`"), and the
module's other consumer already passes one:

| caller | spelling | correct today |
| --- | --- | --- |
| `scripts/pm/dispatch-gates.mjs:2097` | `findExtractConfigs(join(ROOT, 'packages'), 'packages')` | yes |
| `scripts/check-i18n-bundles.mjs:748` | `findExtractConfigs('packages', 'packages')` | no — this PR |

So the shared module's contract was never wrong; only this call site was. Route B
from the card (anchor inside `i18n-bundle-surface.mjs`) is therefore rejected:
it would silently re-root `dispatch-gates.mjs`'s population, which is the
mistake this gate family keeps paying for, in reverse.

## The direction is LOUD, not silently green

Stated because the opposite claim would be wrong: an uncaught throw naming
`node:fs` costs a **wrong first diagnosis**, not a false pass. This PR did not
prevent a false green. What makes it worth fixing is that the throw bypassed
every worded channel this gate owns — #5217, #7681 and `reportPrerequisiteNotMet`
exist precisely so an environment fact never reaches the reader as a content
verdict, and an uncaught stack reaches them as neither.

## An empty population is REFUSED, not reported OK

Anchoring the scan without this would trade the loud crash for a silent green,
which is strictly worse than the bug. `populationVerdict()` is a pure classifier
(the shape every other classifier in this file has, so `--self-test` drives it)
splitting two causes that previously shared one sentence:

- **empty population** — an environment fact, so it goes through
  `reportPrerequisiteNotMet` with its "Nothing was checked" statement, and a
  `fix:` that is deliberately **not** the CLI build.
- **`--filter` matched nothing** — a typo in an argument the developer just
  typed. Not a prerequisite: it must not borrow "nothing was checked", must not
  prescribe a rebuild, and must not describe a healthy repository as broken.

On the question of whether `=== 0` is the right condition: no legitimate tree of
this repo has zero — `lint.yml` runs this gate because packages here ship
translation bundles. The narrower condition needed was not on the count, it was
on the **cause**, which is the split above.

### The failure now arrives worded

Same synthetic root that previously produced the bare stack:

```
check-i18n-bundles: PREREQUISITE NOT MET — this gate's population could not be enumerated

  Walking for extract configs failed before any bundle was compared:

    ENOENT: no such file or directory, scandir '.../fakeroot/packages'

  This gate resolves `packages/` against its OWN location rather than the cwd, so
  this is not a "run it from the repo root" problem — the directory is missing or
  unreadable in the checkout this script lives in:

    .../fakeroot/packages

  Fix:  check out this repository — this gate reads packages/ from its own location, not from the cwd

  Nothing was checked: no bundle was compared and no config was parsed, so this
  result says NOTHING about whether the committed translation bundles are in sync.
```

## Scope beyond the walk, and why it is not creep

Anchoring only the walk moves the crash one line down: `flagsFromDocstring`,
the documented `--out=` existence check and the child extractor's argv are all
repo-relative too. Left unanchored, an off-root run would have reported an
environment fact as `N bundle problem(s)` — the exact shape ruling #7681 removed.
So the seam is applied to all four, and the spawn takes `cwd: REPO_ROOT`, the
same line `check-i18n-coverage.mjs` already carries for the same reason (#10907).

`REPO_ROOT` is taken from the **shared** `atRepoRoot` seam rather than derived
again from `import.meta.url` — a second derivation two lines from the first is
the duplication #11394 removed when it exported that one.

## What #11650 had already done here

Verified rather than assumed: it anchored **line 736's existence check**
(`existsSync(atRepoRoot(resolved.file))`) and added the `#11394` self-test block
— 61 insertions, 1 deletion, population untouched. Nothing in this PR redoes it.

## Verification — all at `9d41b11e0`

Gate union **derived**, not recalled:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(provenance line asserts the repo matches this checkout's `origin`).

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm check:i18n` | 0 | `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).` |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 142 scripts/ file(s) …` |
| `pnpm check:parse-guard` | 0 | `✓ check:parse-guard: 141 scripts/ file(s) …` |
| `pnpm check:pnpm-filter-targets` | 0 | `✓ check:pnpm-filter-targets: 120/148 \`--filter\` occurrence(s) …` |
| `pnpm check:cross-package-test-inputs` | 0 | `OK: 16 package(s) read outside themselves …` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 6519 text file(s) …)` |
| `pnpm lint` (whole repo, not narrowed) | 0 | clean |

Exit codes captured **before** any pipe.

### End-to-end, on a built tree

The claim this card is about, measured rather than argued — the gate's full
output from `/tmp` and from the repo root:

```
$ diff gate-onroot.txt gate-offroot.txt
IDENTICAL — the gate reports the same verdict from both cwds
```

Both exit 0, both `OK (9 package(s) …)`. That single comparison is what proves
the whole chain moved, not just the walk: had any one of the four sites stayed
cwd-relative, the off-root run would have diverged.

### Non-vacuity, both directions

Each mutation was proven on disk by **marker counts and the file's sha**, and each
restore proven **byte-identical**; both ran under `trap … EXIT INT TERM`.

**A — revert the anchor to the pre-fix spelling.** Predicted before running: an
*uncaught ENOENT*, not a worded assertion failure, because the walk throws before
the assertion evaluates. Observed exactly that:

```
anchored spelling 1 -> 0   sha 5e3f435f -> 777a12e5
ABLATION_A_EXIT=1
Error: ENOENT: no such file or directory, scandir 'packages'
    at discoverExtractConfigs (.../scripts/check-i18n-bundles.mjs:294:10)
```

**B — delete the empty-population refusal.** Predicted a worded `✗`. Observed:

```
'population.length === 0' 1 -> 0   sha 5e3f435f -> ea55766b
ABLATION_B_EXIT=1
✗ check:i18n --self-test — 3 failure(s)
  #4690 an empty population is refused — got null
  #4690 …through the WORDED channel, not as a pass — …
  #11647 …and the two population verdicts do not contaminate each other — …
```

Both restored to `5e3f435f`, byte-identical.

The new self-test also carries its **own positive control**: it records that the
pre-fix spelling throws `ENOENT` from `tmpdir()`, so "the anchored walk works
off-root" cannot pass on a tree where the bare spelling would have resolved too.

`check:i18n` runs `--self-test` and then the real run, so CI runs all of this on every PR.

## No changeset

`pnpm changeset` is not required: AGENTS.md §942 — "Pure bug fixes do **not**
require a changeset" — and nothing here is released. The change is confined to
`scripts/`, the root package is `private: true`, and the file appears in no
published package's `files`; its only referent is the root `check:i18n` script.
Per `pr-automation.yml`, the `skip-changeset` label is the author's explicit
opt-out and is applied to this PR.


---

---

## Follow-up: the bare-root verdict this fix owed (`d741c991d`)

`Lint & Repo Gates` went red on `scripts/pm/bare-root-worklist.mjs --self-test`.
In scope and correct: anchoring the population gave the bare literal a
**population-constant name** (`PACKAGES_DIR`), and a bare single-segment word
builds no watch hint, so `check:i18n` newly joined the invisible bare-root
species and owed a recorded verdict.

### Verdict: REFUSE-UNSPELLABLE — not REFUSE-WIDE

The refusal direction was right, the specific verdict was not, and the table's
own definitions make the difference load-bearing:

- **REFUSE-WIDE** — "the population really IS the whole top-level root. A
  declaration would be **TRUE**, and is refused anyway."
- **REFUSE-UNSPELLABLE** — "the population is a file-KIND or FILENAME filter
  inside the root."

This gate opens nine named config files. A `packages/**` declaration would be
**false**, not merely wide, which is the second row, not the first.

Measured on the tree at `d741c991d`, numerator from the gate's own walk filter,
denominator from `trackedFiles()`:

| | |
| --- | --- |
| files the walk admits | **9** |
| tracked files under the root | **5093** |
| ratio | **0.18%** |

### The narrow-declaration hypothesis: falsified, measured

Checked what the vocabulary can actually express before concluding the choice
was binary. `collapseHint` **deletes** glob segments (`hint.replace(/\*\*?/g, '')`),
so every narrower spelling collapses to a malformed double-separator prefix:

| candidate | collapses to | covers the config | covers an unrelated package file |
| --- | --- | --- | --- |
| `packages/**` | `packages` | yes | **yes** — and all 5093 |
| `packages/*/scripts/i18n-extract.config.ts` | `packages//scripts/…` | **no** | no |
| `packages/**/scripts/i18n-extract.config.ts` | `packages//scripts/…` | **no** | no |
| `packages/*/scripts/**` | `packages//scripts` | **no** | no |

Worse than useless: each narrow spelling **does** survive `extractWatchHints`
into a live hint, and then covers **nothing at all** — a declaration that names
the gate for zero files. So the choice really is binary, and the honest half of
it is refusal.

### Precedent — the identical row already exists

`check:i18n-coverage PACKAGES_DIR packages` is already recorded
**REFUSE-UNSPELLABLE** at "9 of 5035 (0.18%)". That is not an analogy: the
sibling selects the population with the same filename-and-segment test
(`e.name === 'i18n-extract.config.ts' && p.includes('/scripts/')`), so both
gates walk the **same nine files** under the **same constant name** at the
**same root**. Refusing them alike is consistency, not novelty.

### The positive assertion, adapted to a refusal

The declaration route asks you to prove the derivation actually changes. A
refusal owes the converse, proven the same way — that refusing loses nothing,
because the gate already reaches the right cards by a better route. Verified
live against the derivation, both directions:

```
$ dispatch-gates packages/platform-objects/src/index.ts     # package OWNS an extract config
  - pnpm check:i18n   — it re-extracts every owning package's translation bundles …

$ dispatch-gates packages/core/src/index.ts                 # package owns NO extract config
  (check:i18n correctly absent — editing it cannot move a bundle)

$ dispatch-gates packages/spec/src/ai/agent.form.ts         # metadata form module
  - pnpm check:i18n   — the metadataForms half of the bundles is registry-driven …
```

`check:i18n` is therefore **not** unreachable for package cards. The convention
triggers already name it for exactly the cards that can move a bundle, with a
precision a `packages/**` subtree hint would destroy rather than add to.

### What was edited, and what was not

`scripts/pm/bare-root-worklist.mjs`: **16 insertions, 0 deletions**, entirely
inside the `TRIAGE` data ledger. The recogniser (`POPULATION_CONSTANT`), the
sweep and the self-test are untouched — verified by filtering the diff for those
anchors. Recording a verdict is the remedy the gate's own failure text
prescribes, and `REFUSE-*` verdicts are recordable **only** there.

`scripts/check-agent-test-spelling.mjs` was not touched.

### Non-vacuity

Ablation C — delete the row just recorded. Mutation proven on disk (row key
1 → 0, sha `09b8d6a3` → `02576657`), restore proven byte-identical back to
`09b8d6a3`, under `trap … EXIT INT TERM`.

```
ABLATION_C_EXIT=1
  x self-test: no gate has NEWLY joined the invisible bare-root species —
    FRESH: check:i18n PACKAGES_DIR packages
```

### Gates at `d741c991d`

Union re-derived (`--repo objectstack-ai/objectstack`); the change set is now 2
paths and the derivation added exactly one family, the one that fired.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `bare-root-worklist --self-test` | 0 | `OK  self-test: 38 live row(s), 35 unreachable as spelled, 35 recorded verdict(s) — none stale, none missing.` |
| `check:i18n --self-test` | 0 | `✓ check:i18n --self-test — … all go red, and stay distinct` |
| `check:entry-guard` | 0 | `✓ 142 scripts/ file(s)` |
| `check:parse-guard` | 0 | `✓ 141 scripts/ file(s)` |
| `check:pnpm-filter-targets` | 0 | `✓ 120/148 --filter occurrence(s)` |
| `check:cross-package-test-inputs` | 0 | `OK: 16 package(s) read outside themselves` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 6519 text file(s))` |
| `pnpm lint` (whole repo) | 0 | clean |

**One declared narrowing:** the full `check:i18n` run (the nine-package extract,
which needs a built CLI) was **not** re-run at `d741c991d`. It ran green at
`9d41b11e0`, and `scripts/check-i18n-bundles.mjs` is **byte-identical** across
the two commits — blob `5e3f435f` at both — with `bare-root-worklist.mjs` the
only file that changed between them. So that green still describes this tree;
re-running would have cost an 11.5-minute shared CLI rebuild for no new
information. Stated rather than silently skipped.


---

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_


---
_Generated by [Claude Code](https://claude.ai/code)_