### PR TITLE
fix(core,rest): declare the `getMany` the localization resolver actually calls, and pin its leg count

### DIFF
--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -255,6 +255,123 @@ describe('resolveLocalizationContext — batched fallback read (#2409)', () => {
     expect(loc.timezone).toBe('Europe/Paris');
     expect(ql.counts.sys_setting).toBe(1); // the batched $in fallback ran once
   });
+
+  // ── [#11222 items 2 + 3] LEGS, and the resolution context ────────────────
+  //
+  // The pins above count CALLS (`getMany.calls`, `gets === 3`). #10826's whole
+  // calibration is that the three reads it collapsed already ran in ONE leg —
+  // "a query-count fix, not a latency fix" (cloud#1539). Nothing pinned that.
+  // A future edit turning the per-key fallback's `Promise.all` into a
+  // sequential `for` loop takes legs 1 -> 3 while every call-count assertion
+  // above stays green; legs are the latency multiplier, so that regression is
+  // exactly the one the existing pins cannot see.
+  //
+  // And the `getMany` double above is declared with TWO parameters, so it is
+  // structurally unable to observe the third argument: drop `sctx` from the
+  // production call and all three pins stay green. The rig's double takes it.
+
+  /**
+   * A settings-service double that MEASURES what the resolver asks for.
+   *
+   *  - `queries` — every row load. `loadRows` stands in for the real service's
+   *    namespace row load, so one call is one `sys_setting` query.
+   *  - `legs` — every row load that STARTS while nothing else is in flight,
+   *    i.e. the number of sequential round-trip WAVES. Three loads issued
+   *    inside one `Promise.all` all increment `inFlight` synchronously before
+   *    any of them resumes past its first `await`, so they count as ONE leg;
+   *    three awaited in sequence count as three. That is the leg definition
+   *    cloud#1539 used, and it is what makes "3 queries, 1 leg" measurable
+   *    rather than asserted.
+   *
+   * `batched: false` reproduces the pre-#10826 occupant (only `get`), which is
+   * also the shape the resolver still falls back to for a host-provided
+   * settings service that predates `getMany`.
+   */
+  function makeSettingsRig(
+    values: Record<string, unknown>,
+    { batched }: { batched: boolean },
+  ) {
+    const stats = { queries: 0, legs: 0 };
+    const calls: Array<{ method: string; args: any[] }> = [];
+    let inFlight = 0;
+    const loadRows = async () => {
+      stats.queries += 1;
+      if (inFlight === 0) stats.legs += 1; // nothing else in flight -> a new wave
+      inFlight += 1;
+      try {
+        await Promise.resolve();
+        return values;
+      } finally {
+        inFlight -= 1;
+      }
+    };
+    const pick = (loaded: Record<string, unknown>, key: string) =>
+      key in loaded
+        ? { value: loaded[key], source: 'tenant' }
+        : { value: undefined, source: 'default' };
+    const rig: any = {
+      stats,
+      calls,
+      async get(namespace: string, key: string, ctx: any) {
+        calls.push({ method: 'get', args: [namespace, key, ctx] });
+        return pick(await loadRows(), key);
+      },
+    };
+    if (batched) {
+      // NOTE the THIRD parameter — this is item 3's fix, not a detail: the
+      // double must accept `ctx` to be able to assert it was forwarded.
+      rig.getMany = async (namespace: string, keys: readonly string[], ctx: any) => {
+        calls.push({ method: 'getMany', args: [namespace, [...keys], ctx] });
+        const loaded = await loadRows();
+        const out: Record<string, unknown> = {};
+        for (const key of keys) out[key] = pick(loaded, key);
+        return out;
+      };
+    }
+    return rig;
+  }
+
+  const VALUES = { timezone: 'Asia/Tokyo', locale: 'ja-JP', currency: 'JPY' };
+  const EXPECTED = { timezone: 'Asia/Tokyo', locale: 'ja-JP', currency: 'JPY' };
+
+  it('a per-key occupant issues three namespace reads in ONE leg (the pre-#10826 cost)', async () => {
+    const settings = makeSettingsRig(VALUES, { batched: false });
+    const ql = makeCountingQl({ sys_setting: [] });
+    const loc = await resolveLocalizationContext({ ql, settings, tenantId: 'o1', userId: 'u1' });
+    expect(loc).toEqual(EXPECTED);
+    expect(settings.stats).toEqual({ queries: 3, legs: 1 });
+    // The settings path answered, so the direct `sys_setting` fallback is not
+    // reached — the three reads above are the whole cost.
+    expect(ql.counts.sys_setting ?? 0).toBe(0);
+  });
+
+  it('the batched occupant issues ONE namespace read, in the same ONE leg', async () => {
+    const settings = makeSettingsRig(VALUES, { batched: true });
+    const ql = makeCountingQl({ sys_setting: [] });
+    const loc = await resolveLocalizationContext({ ql, settings, tenantId: 'o1', userId: 'u1' });
+    expect(loc).toEqual(EXPECTED);
+    // queries 3 -> 1, legs 1 -> 1. #10826 was correctly scheduled as a
+    // query-count fix; the `legs` half is what a sequential-loop regression
+    // would move, and it is now pinned in both directions.
+    expect(settings.stats).toEqual({ queries: 1, legs: 1 });
+    expect(ql.counts.sys_setting ?? 0).toBe(0);
+  });
+
+  it('asks for all three keys of the one namespace in a single call, with the resolution context', async () => {
+    const settings = makeSettingsRig(VALUES, { batched: true });
+    await resolveLocalizationContext({
+      ql: makeCountingQl({ sys_setting: [] }),
+      settings,
+      tenantId: 'o1',
+      userId: 'u1',
+    });
+    expect(settings.calls).toEqual([
+      {
+        method: 'getMany',
+        args: ['localization', ['timezone', 'locale', 'currency'], { tenantId: 'o1', userId: 'u1' }],
+      },
+    ]);
+  });
 });
 
 // #10221: a fresh environment's `sys_setting` table doesn't exist yet, so

--- a/packages/core/src/security/resolve-authz-context.ts
+++ b/packages/core/src/security/resolve-authz-context.ts
@@ -647,7 +647,23 @@ function coerceCurrency(value: unknown): string | undefined {
 
 export interface ResolveLocalizationInput {
   ql: any;
-  /** Settings service exposing `get(namespace, key, { tenantId, userId })`. */
+  /**
+   * Settings service occupant. Two methods are consumed, in this order:
+   *
+   *  - `getMany(namespace, keys, { tenantId, userId })` — PREFERRED since
+   *    #10826, and what this resolver calls for all three localization keys in
+   *    ONE grouped read.
+   *  - `get(namespace, key, { tenantId, userId })` — the per-key fallback,
+   *    taken only when the occupant does not expose `getMany` (three parallel
+   *    reads; see the feature-detect below).
+   *
+   * `getMany` is OPTIONAL for an occupant: the branch is feature-detected, so
+   * a service that predates it still resolves — at three reads instead of one.
+   * Typed `any` deliberately (the occupant's shape varies by host); the
+   * declaration above is the contract this resolver actually relies on, and it
+   * is prose precisely because nothing type-checks it — `getService` is a cast
+   * and `rest-server.ts` widens the provider's return to a bare promise.
+   */
   settings?: any;
   tenantId?: string;
   userId?: string;
@@ -757,6 +773,19 @@ async function resolveLocalizationContextUncached(
       // A thrown `getMany` lands in the same place a thrown `get` did —
       // `failed = true` and the direct `$in` fallback below, which reads the
       // exact same three keys.
+      //
+      // [#11222 item 4] ONE non-equivalence, inherent to batching and recorded
+      // here because it is this CALLER's degradation, not the service's:
+      // `getMany` validates every requested key up front and throws for the
+      // WHOLE call, so a host that registered a PARTIAL `localization`
+      // manifest (missing any of the three keys) loses all three at once,
+      // where the per-key path would still have resolved the declared ones.
+      // The `$in` fallback below then answers from tenant-scoped rows only —
+      // it has no `global` scope layer and no `OS_LOCALIZATION_*` env
+      // override. Degradation, never a wrong answer, and unreachable against
+      // the in-repo `localizationSettingsManifest`, which declares all three.
+      // The all-or-nothing rule itself is `SettingsService.getMany`'s own
+      // contract and is documented there, not here.
       let tzRes: any; let localeRes: any; let currencyRes: any;
       if (typeof settings.getMany === 'function') {
         try {

--- a/packages/rest/src/rest-api-plugin.ts
+++ b/packages/rest/src/rest-api-plugin.ts
@@ -51,11 +51,29 @@ interface DefaultEnvironmentSurface {
  * [#4251 B4] Named surface rather than a ledger entry, following the B2
  * decision for this slot: `service-settings` is OPTIONAL, so the REST layer
  * must not acquire a runtime dependency on it, and its `SettingsService`
- * declares no `implements` — there is no contract to name. The one method the
- * platform consumes is `get`, through `resolveLocalizationContext`'s 4-tier
- * timezone/locale/currency cascade; its return type is the PUBLIC
+ * declares no `implements` — there is no contract to name. Both methods below
+ * are consumed through `resolveLocalizationContext`'s 4-tier
+ * timezone/locale/currency cascade; their return types are the PUBLIC
  * `ResolvedSettingValue` from `@objectstack/spec/system`, so only the context
  * argument is described structurally (`SettingsContext` is service-local).
+ *
+ * ## What an occupant must implement
+ *
+ * `get` is REQUIRED; `getMany` is OPTIONAL and worth implementing. Since
+ * #10826 the resolver feature-detects `getMany` and, when present, reads all
+ * three localization keys in ONE grouped call; an occupant without it takes
+ * the three-parallel-`get` path and still answers correctly — the cost is
+ * three namespace reads instead of one, not a wrong result. That is why
+ * `getMany` is declared optional rather than required: making it required
+ * would over-state the contract, and omitting it (as this interface did until
+ * #11222) under-states what the platform actually calls.
+ *
+ * ⚠️ Neither member is type-checked at the call site. `ctx.getService` is a
+ * cast, `rest-server.ts` widens this provider's return to a bare promise, and
+ * `resolveLocalizationContext` receives `settings?: any` — so this interface
+ * is documentation for host authors, not enforcement. `check:slot-lookup`
+ * (#4251) only bans erasing the lookup to `any`; it never checks the named
+ * type is COMPLETE, which is how the missing `getMany` stayed invisible.
  */
 interface SettingsReadSurface {
     get<T = unknown>(
@@ -63,6 +81,15 @@ interface SettingsReadSurface {
         key: string,
         ctx?: { tenantId?: string; userId?: string },
     ): Promise<ResolvedSettingValue<T>>;
+    /**
+     * Resolve several keys of ONE namespace in a single grouped read.
+     * Optional — feature-detected by `resolveLocalizationContext`.
+     */
+    getMany?<T = unknown>(
+        namespace: string,
+        keys: readonly string[],
+        ctx?: { tenantId?: string; userId?: string },
+    ): Promise<Record<string, ResolvedSettingValue<T>>>;
 }
 
 export interface RestApiPluginConfig {


### PR DESCRIPTION
Fixes #11222

The #10826 switch from three `settings.get()` calls to one `settings.getMany()`
left two declarations describing the *old* consumer, left the metric that switch
was calibrated on unmeasured, and left the resolution context unobservable by
any pin. Three items, one PR, spanning `core` + `rest` as triage designated.

## 1. Two declarations now say what the consumer actually calls

`resolveLocalizationContext` has called `getMany` since #10826. Two declarations
still said `get` was the one method consumed:

- `packages/core/src/security/resolve-authz-context.ts` — the param JSDoc on
  `ResolveLocalizationInput.settings`.
- `packages/rest/src/rest-api-plugin.ts` — `interface SettingsReadSurface`, whose
  prose read *"The one method the platform consumes is `get`"*.

`getMany` is declared **OPTIONAL**, not required, and that is the load-bearing
choice: the branch is feature-detected, so an occupant without `getMany` still
answers correctly at three reads instead of one. Declaring it required would
over-state the contract as badly as omitting it under-stated it.

Nothing was broken and the reason is itself worth writing down, so both sites now
say it: the type is erased three times before the call site — `ctx.getService` is
a cast, `rest-server.ts` widens the provider's return to a bare promise, and the
resolver receives `settings?: any` — so `settings.getMany` is type-checked
nowhere. That is why CI was green without the declaration, and why these
interfaces are documentation for host authors rather than enforcement.

**No fourth site.** Verified: `runtime`'s own lookup
(`resolve-execution-context.ts`) calls `opts.getService('settings')` untyped, and
`plugin-auth` / `plugin-email` name their own `SettingsReadSurface` but call no
`getMany` (grep: zero hits in both) — their narrower declarations are accurate
and deliberately untouched.

## 2. Legs, not calls — the card's own metric, now pinned

#10826's calibration is *"a query-count fix, not a latency fix"*, because
cloud#1539 measured the three reads running in parallel: 3 queries but **1 leg**,
and legs are the latency multiplier. Every pin in this file counts **calls**
(`getMany.calls`, `gets === 3`), so the leg count was pinned by nothing.

`makeSettingsRig` measures a **leg**: a row load that starts while nothing else
is in flight — the number of sequential round-trip waves. Three loads issued
inside one `Promise.all` all increment before any resumes past its first `await`,
so they count as one; three sequential awaits count as three.

**Reverse-verified in both directions** — a leg pin that has never been seen red
is not a pin:

- Feature-detect disabled (`if (false && typeof settings.getMany === 'function')`)
  — the batched occupant falls to the per-key path:
  ```text
  AssertionError: expected { queries: 3, legs: 1 } to deeply equal { queries: 1, legs: 1 }
  Tests  3 failed | 67 passed (70)
  ```
  That is the salvaged rig's original failure line, reproduced against the landed
  source: **queries 3 -> 1, legs 1 -> 1.**

- The per-key `Promise.all` replaced with a sequential `for` loop — the exact
  regression class item 2 exists to catch:
  ```text
  AssertionError: expected { queries: 3, legs: 3 } to deeply equal { queries: 3, legs: 1 }
  Tests  1 failed | 69 passed (70)
  ```
  **69 of 70 stayed green.** Every pre-existing call-count assertion — including
  `gets === 3` and `getMany.calls === 1` — passed while legs went 1 -> 3. The new
  leg pin is the only assertion in the file that can see it, which is precisely
  the gap being closed.

Both ablations restored via an `EXIT INT TERM` trap and confirmed on disk by
anchor grep counts before and after each mutation (`Promise.all` 2 -> 1,
marker 0 -> 1, and back). No rebuild leg applies: the test imports the resolver
by relative specifier (`./resolve-authz-context.js`), so vitest resolves source,
never `dist/`.

## 3. The resolution context, observable for the first time

The existing `getMany` double is declared `(ns, keys)` — **two** parameters — so
it structurally cannot see the third argument. Drop `sctx` from the production
call today and all three pins stay green. The rig's double takes `ctx`, and the
new pin asserts the whole call shape: namespace, key list, and
`{ tenantId: 'o1', userId: 'u1' }`. It went red under ablation 1 alongside the
leg pin.

## 4. Partial-manifest all-or-nothing — split producer/consumer, not widened

Judgement called as the card invited. The all-or-nothing rule is
`SettingsService.getMany`'s **own** contract (it validates every key up front and
throws `UnknownKeyError` for the whole call), so documenting the rule belongs on
the producer, in `packages/services/service-settings` — a `domain:services` card,
filed separately rather than silently widened into this PR's package set.

What *is* this caller's own and is recorded here: when `getMany` throws, this
resolver drops to the direct tenant-scoped `$in` read, which has **no `global`
scope layer and no `OS_LOCALIZATION_*` env override**. The existing comment said
the fallback "reads the exact same three keys" without saying it reads them
through a shorter cascade. Degradation, never a wrong answer, and unreachable
against the in-repo `localizationSettingsManifest`, which declares all three keys.

## Verification

`pnpm --filter @objectstack/core exec vitest run src/security/resolve-authz-context.test.ts`
— **Test Files 1 passed (1) · Tests 70 passed (70)**.
`pnpm --filter @objectstack/rest typecheck` — exit 0, script name echoed
(`> @objectstack/rest@17.2.0 typecheck`), so it is not the zero-match no-op.

Gates run at final HEAD `266eb589`, each read from its own printed verdict line:
`check:authz-resolver` · `check:cross-package-test-inputs` ·
`check:dispatcher-error-vocabulary` · `check:kernel-hook-pairs` ·
`check:published-files` · `check:slot-lookup` · `check:test-source-alias` ·
`check:type-source-resolution` · `check:query-options-erasure` ·
`check:engine-double-contract` · `check:where-matcher` · `check:nul-bytes` ·
`check:type-check-coverage` · `check-plugin-teardown-shape` ·
`docs-audit/check-affected-docs` — all exit 0.

`@objectstack/core`'s tsconfig is `include: ["src/**/*"], exclude: []`, so its
`*.test.ts` files **are** inside the tsc program the 98-error DEBT ratchet
freezes. Measured directly rather than assumed: `tsc --noEmit -p` on this branch
reports **98 errors, unchanged**, and zero of them in
`resolve-authz-context.test.ts`.

**Declared narrowing** (repo-wide `pnpm lint` left to CI): eslint run with
`--no-inline-config` over the three changed files, `--format json` reporting
**3 files linted, 0 errors, 0 warnings**. The narrowing excludes nothing,
because this repo's `eslint.config.mjs` never enables type-aware linting — no
`parserOptions.project`, no typed `@typescript-eslint` rules, for any file
(stated and measured in the config's own comment) — so this diff cannot move the
verdict on a file it does not touch.

## No changeset

Nothing here releases: no runtime path moves, no exported type changes,
`SettingsReadSurface` is not exported, and the rest is JSDoc, a code comment and
tests. `skip-changeset` applied per the workflow's own prescription for a PR that
declares no release of its own. Say the word and a patch changeset goes in
instead.

## Scope

Three files exactly, as claimed. `packages/plugins/plugin-auth` and
`plugin-email` declare their own `SettingsReadSurface` and were deliberately left
alone. `packages/core/src/security/auth-gate.ts` (hold #7898's indexed path) was
not touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK8rFDtg8eREaxBGX99Csn)_