### PR TITLE
refactor(rest): drop the `(p as any)` cast at the `publishMetaItem` call site (#11145)

### DIFF
--- a/.changeset/rest-publish-meta-item-cast-retired.md
+++ b/.changeset/rest-publish-meta-item-cast-retired.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/rest": patch
+---
+
+refactor(rest): the `publishMetaItem` call site is compiled against the declared contract (#11145)
+
+The `POST /meta/:type/:name/publish` door in `packages/rest/src/rest-server.ts`
+reached its protocol method through `(p as any).publishMetaItem` — once for the
+501 feature-detection guard, once for the call — so the compiler checked nothing
+about the request literal it built. The cast was load-bearing on **member
+existence**, not on request shape: #10350 measured that deleting it answered
+`TS2339: Property 'publishMetaItem' does not exist on type 'RestProtocol'`, not
+a `TS2353` about an unknown key. `publishMetaItem` was an ADR-0076 D9
+server-only extension, so no amount of widening the implementation's own
+parameter type in `@objectstack/metadata-protocol` (which this package
+deliberately does not depend on) could have retired it.
+
+#11006 (maintainer ruling 2026-08-22, option B) declared the member on
+`MetadataProtocol` with a `PublishMetaItemRequest`, which is what removes the
+prop. The guard is now `if (!p.publishMetaItem)` and the request is a named
+const typed `TransportScopedMetaRequest<PublishMetaItemRequest>` — the same
+shape #9741 gave the meta-read doors and #9805 gave the non-door helpers.
+
+**No behaviour change of any kind, and nothing about the wire moves.** The
+outgoing payload is byte-identical (same keys, same conditional spreads); the
+edit hoists the literal into a const and drops a type-level cast. Two things
+deliberately survive:
+
+- the 501 feature-detection guard, because the declared member is **optional**
+  (a kernel may not implement the promotion door at all) — and it is also what
+  narrows the member to callable at the call site;
+- the transport-level `environmentId`, which stays layered on by the
+  `TransportScopedMetaRequest` envelope rather than becoming a protocol key, per
+  the #9741 ruling (2026-08-18).
+
+What the typing buys, measured rather than asserted: an undeclared key in this
+request literal is now `TS2353` at compile time instead of a payload member no
+contract has ever seen. The docblock that existed only to explain why the cast
+had to stay is replaced rather than left behind — a rationale for a prop that no
+longer exists is a declaration that outlived its subject.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -68,6 +68,7 @@ import type {
     GetMetaItemRequest,
     GetMetaItemCachedRequest,
     GetMetaItemLayeredRequest,
+    PublishMetaItemRequest,
 } from '@objectstack/spec/api';
 // [#8073] The closed ADR-0112 error vocabulary, so the explain family's single
 // refusal emitter types its `code` parameter as the vocabulary rather than as
@@ -5937,7 +5938,7 @@ export class RestServer {
                         return;
                     }
                     const p = await this.resolveProtocol(environmentId, req);
-                    if (!(p as any).publishMetaItem) {
+                    if (!p.publishMetaItem) {
                         res.status(501).json({
                             error: 'Publish operation not supported by protocol implementation',
                         });
@@ -6021,34 +6022,38 @@ export class RestServer {
                         // org-scope comment for the measurement.
                         canonicalMetaUrlType(req.params.type), ctx?.tenantId,
                     );
-                    // [#10350] The cast stays, and what it is load-bearing
-                    // FOR is worth stating so this is not re-filed as a missing
-                    // contract. It is NOT hiding the request shape: measured by
-                    // deleting it and running `pnpm --filter @objectstack/rest
-                    // typecheck`, the compiler answers
+                    // [#11145] The `(p as any)` cast this call carried came off
+                    // when `MetadataProtocol` declared `publishMetaItem` (#11006,
+                    // maintainer ruling 2026-08-22, option B). What the cast was
+                    // load-bearing FOR is recorded because it is counter-intuitive
+                    // and was measured, not assumed: deleting it while the member
+                    // was undeclared answered
                     //   `TS2339: Property 'publishMetaItem' does not exist on
                     //    type 'RestProtocol'`
-                    // — not a TS2353 about an unknown key. `publishMetaItem` is
-                    // an ADR-0076 D9 SERVER-ONLY extension: `RestProtocol` is
-                    // `DataProtocol & MetadataProtocol`, and `MetadataProtocol`
-                    // (`packages/spec`) declares no such member — only
-                    // `PublishMetaItemResponseSchema` (#7294) exists there, with
-                    // no request schema and no interface entry. So the cast is
-                    // feature detection, exactly like the `auditMetaItem` twin
-                    // a few hundred lines up, and the same measurement holds
-                    // AFTER #10350 declared `packageId` on the implementation's
-                    // request type: that type lives in
-                    // `@objectstack/metadata-protocol`, which `packages/rest`
-                    // deliberately does not depend on.
+                    // — NOT a `TS2353` about an unknown key. The cast was feature
+                    // detection for an ADR-0076 D9 server-only extension, so only
+                    // declaring the member could retire it; widening the
+                    // implementation's own request type in
+                    // `@objectstack/metadata-protocol` (which this package
+                    // deliberately does not depend on) never could, and #10350
+                    // measured exactly that.
                     //
-                    // Removing it therefore needs `MetadataProtocol` to declare
-                    // the member (plus a `PublishMetaItemRequest` to hang the
-                    // #9741 `TransportScopedMetaRequest` typing off) — a
-                    // `packages/spec` contract decision, promoting an undeclared
-                    // optional extension into a declared one, which is the same
-                    // call the 501 refusal above declines to pre-empt. Filed
-                    // rather than taken here.
-                    const result = await (p as any).publishMetaItem({
+                    // What replaces it is the point of the exercise, not a
+                    // side effect: the literal below is compiled against the spec
+                    // contract through the #9741 `TransportScopedMetaRequest`
+                    // wrapper, so an undeclared key here is a COMPILE ERROR
+                    // (`TS2353`, measured) instead of a payload member no contract
+                    // has ever seen. `environmentId` is the transport-level
+                    // routing key that wrapper layers on — ⛔ never a protocol
+                    // key; a key that belongs on the request belongs in the spec
+                    // schema.
+                    //
+                    // The 501 feature-detection guard above STAYS. The member is
+                    // declared OPTIONAL (ADR-0076 D9 promotion is additive to a
+                    // shipped contract, and a kernel may not implement the
+                    // promotion door at all), and that same guard is what narrows
+                    // it to callable here.
+                    const publishRequest: TransportScopedMetaRequest<PublishMetaItemRequest> = {
                         type: req.params.type,
                         name: req.params.name,
                         organizationId,
@@ -6056,7 +6061,8 @@ export class RestServer {
                         ...(actor ? { actor } : {}),
                         ...(message ? { message } : {}),
                         ...(packageId ? { packageId } : {}),
-                    });
+                    };
+                    const result = await p.publishMetaItem(publishRequest);
                     res.json(result);
                 } catch (error: any) {
                     handleRouteError(res, error);


### PR DESCRIPTION
Fixes #11145

The `POST /meta/:type/:name/publish` door reached its protocol method through
`(p as any).publishMetaItem` twice — once for the 501 feature-detection guard,
once for the call — so nothing checked the request literal it built. #11006
(maintainer ruling 2026-08-22, option B; landed as #11426) declared the member
on `MetadataProtocol` with a `PublishMetaItemRequest`, which is what takes the
prop out from under the cast. This is the consumer half the ruling routed to
this lane by name.

## The premise held, and it was measured rather than assumed

Verified on `origin/main` @ `c251ef4213` (the file took four commits on
2026-08-24, so line numbers were taken fresh):

- `packages/spec/src/api/protocol.zod.ts:2535` declares
  `publishMetaItem?(request: PublishMetaItemRequest): Promise<PublishMetaItemResponse>`
  — an optional member carrying the request type, not a narrowed variant.
- Both cast sites were still live, at 5940 (the guard) and 6051 (the call).
- `packages/spec` was rebuilt before any verdict was read: the emitted
  `packages/spec/dist/api/index.d.ts` carries the member at line 8987 and
  exports `type PublishMetaItemRequest`, so the readings below are against the
  rebuilt `.d.ts` and not a stale artifact. (`packages/rest` looks up
  `@objectstack/spec` through its `exports` map, i.e. `dist/`.)

## What the cast was load-bearing for — three measured legs

All three legs are `pnpm --filter @objectstack/rest typecheck` (`tsc --noEmit`),
run back to back at `a5d4f97b92` under the shared verify lock, with the mutation
confirmed on disk by grep between legs and restored from the commit under a
shell `trap`:

**Leg 1 — cast removed (this PR's tree): clean, exit 0.** On-disk before the
run: `(p as any).publishMetaItem` count `0`, typed-literal count `1`. No second,
independent reason for the cast surfaced. Had one, this PR would have been a
finding instead — re-casting in a different spelling to reach green would have
defeated the card.

**Leg 2 — undeclared key injected at the call site: `TS2353`, exit 2.** On-disk
before the run: injected probe count `1`.

```
src/rest-server.ts(6059,25): error TS2353: Object literal may only specify known
properties, and 'undeclaredKeyProbe' does not exist in type
'TransportScopedMetaRequest<{ type: string; name: string; organizationId?: string
| undefined; actor?: string | undefined; message?: string | undefined; packageId?:
string | null | undefined; }>'.
```

That diagnostic **is the deliverable**, not a side effect: it is the compile
error the card names as its acceptance signal, and the expanded type in the
message is the spec-declared surface the literal is now judged against.

**Leg 3 — restored: clean, exit 0.** On-disk after restore: probe count `0`,
typed-literal count `1`. The mutation left nothing behind.

The historical claim in the retired docblock is reproduced rather than
re-measured, and it is the counter-intuitive half worth keeping: deleting the
cast **while the member was undeclared** answered `TS2339: Property
'publishMetaItem' does not exist on type 'RestProtocol'` — *not* a `TS2353`
about an unknown key. The cast carried **member existence**, not request shape,
which is why widening the implementation's own parameter type in
`@objectstack/metadata-protocol` (a package `packages/rest` deliberately does
not depend on) could never have retired it, and why declaring the member did.

## What changed

- The guard is `if (!p.publishMetaItem)`. It **stays** — the declared member is
  optional (a kernel may not implement the promotion door), and it is also what
  narrows the member to callable at the call site.
- The request is a named const typed
  `TransportScopedMetaRequest<PublishMetaItemRequest>`, the same shape #9741
  gave the meta-read doors and #9805 gave the non-door helpers.
- The ~27-line docblock that existed **only** to explain why the cast had to
  stay is replaced, not left behind. It asserted `MetadataProtocol` "declares no
  such member", which #11006 falsified; a rationale for a prop that no longer
  exists is a declaration that outlived its subject.

**No behaviour change, and nothing about the wire moves.** The outgoing payload
is byte-identical — same keys, same conditional spreads. The edit hoists the
literal into a const and drops a type-level cast.

## No type-level pin, and the reason is measured

A `@ts-expect-error` pin in a `packages/rest` test would be **inert today**, so
it was deliberately not added rather than added for visibility.
`packages/rest/tsconfig.json` excludes `**/*.test.ts` / `**/*.spec.ts`, and the
repo runs no vitest `typecheck` mode — the package's tests sitting outside every
tsc program is a *ledgered* state, recorded as `TEST_DEBT` at 155 errors in
`scripts/check-type-check-coverage.mjs`. A pin nothing compiles is a phantom
check, which is worse than none. The guarantee is instead pinned where it is
actually compiled: the call-site literal in `src/`, which `typecheck` reads on
every run — that is what leg 2 exercised. The declaration side is already pinned
upstream by #11006 (`expectTypeOf<MetadataProtocol['publishMetaItem']>()` in
`packages/spec/src/api/protocol.test.ts:1760`).

## Verification, all at `a5d4f97b92`

- `pnpm --filter @objectstack/rest typecheck` — exit 0 (legs above).
- `pnpm --filter @objectstack/rest exec vitest run --maxWorkers=2` — the full
  package suite, `Test Files 142 passed (142)`, `Tests 2270 passed (2270)`.
- `pnpm lint` (`eslint . --no-inline-config`, repo-wide, **not** narrowed) —
  exit 0.
- All 17 gate families derived by `node scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` from the actual change set — exit 0 each. Plus
  `pnpm check:nul-bytes` — exit 0.

`packages/spec` was **not** touched: it is off limits from this lane, and the
cleanup needed nothing further there.

## Out of scope — filed, not touched here

Two sibling doors in this same file are in the state `publishMetaItem` just left,
both needing a `packages/spec` decision this lane cannot take. Filed rather than
touched; ⛔ neither is addressed here.

- filed as #11678 — `MetadataProtocol` declares no `auditMetaItem` member at
  all (0 occurrences in `protocol.zod.ts`), so that door's request literal at
  `rest-server.ts:5873` is compiled against nothing. The step *before* the state
  #11006 adjudicated: neither request nor member declared.
- filed as #11679 — `deleteMetaItem` **is** declared, but
  `DeleteMetaItemRequestSchema` declares 2 of the 8 members the reset door sends
  at `rest-server.ts:5704`. The opposite half of this card: `TS2339` is already
  gone there, and what is left is a genuine request-shape gap, so that cast
  cannot come off the way this one did.

Neither is in this diff. Both are `packages/spec` decisions; #11678 and #11679
remain open for triage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VK8rFDtg8eREaxBGX99Csn)_