### PR TITLE
docs(skills): regenerated responsive.zod.ts reference line for the #11027 retirement (governed surface — human merge, lands after #11685)

### DIFF
--- a/skills/objectstack-ui/references/_index.md
+++ b/skills/objectstack-ui/references/_index.md
@@ -40,7 +40,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/ui/action-params.zod.ts` — The action DISPATCH contract: what the platform validates on the way in, and
 - `node_modules/@objectstack/spec/src/ui/bulk-action.zod.ts` — Bulk Action Schemas
 - `node_modules/@objectstack/spec/src/ui/i18n.zod.ts` — Display-label and ARIA-label primitives shared by every `ui/` shape.
-- `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Breakpoint Name Enum
+- `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Style Map Schema (ADR-0065)
 - `node_modules/@objectstack/spec/src/ui/sharing.zod.ts` — Sharing & Embedding Protocol
 
 ## How to read these


### PR DESCRIPTION
Part of #11027

**Governed surface — awaits human merge.** This PR's entire diff is one regenerated line in `skills/objectstack-ui/references/_index.md`, split out of #11685 under AGENTS.md Prime Directive #14: `skills/**` is a governed surface, a mixed diff forks on one path hit (no proportionality), and the named generated-artifact exception covers only `.claude/workflows/docs-accuracy-audit.js` — not skill reference indexes. No AI seat merges, queues, or flips this ready.

## The change

`gen:skill-refs` derives each reference line's one-line description from the source file's first schema headline. #11685 retires the `ResponsiveConfig` family out of `responsive.zod.ts`, so the file's headline becomes `Style Map Schema (ADR-0065)`:

```diff
-- `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Breakpoint Name Enum
+- `node_modules/@objectstack/spec/src/ui/responsive.zod.ts` — Style Map Schema (ADR-0065)
```

## Landing order — MUST land only AFTER #11685

The new description is true only post-retirement. `check:skill-refs` byte-compares the committed file against a fresh render of the tree's own sources, so the two PRs cannot both be green until they land back-to-back:

- **this PR** against a pre-retirement base: `check:skill-refs` renders the OLD line and reads this diff as drift → red **by design** until #11685 is in its base;
- **#11685** (which now touches no `skills/**` path): `check:skill-refs` renders the NEW line against the still-committed old one → red **by design** until this PR lands on top.

Sequence for whoever lands the train: #11685 lands via the queue (with `check:skill-refs` expected red there, if it is not in the required-context set — flagged to the PM in the #11027 amendment), then the maintainer hand-merges this one immediately after, restoring `check:skill-refs` green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Uia4VoGZrEQpskAy1Dq8j

---
_Generated by [Claude Code](https://claude.ai/code/session_013Uia4VoGZrEQpskAy1Dq8j)_