### PR TITLE
fix(docs-audit): widen the ledger key anchor past the word boundary (#11630)

### DIFF
--- a/scripts/docs-audit/affected-docs.mjs
+++ b/scripts/docs-audit/affected-docs.mjs
@@ -1391,24 +1391,65 @@ function typeDeclRegions(code) {
  * explicitly for their own population moves, and it is made explicitly here for the same
  * reason: the alternative is moving a reported number quietly.
  *
- * ⛔ THE RESIDUE THIS DOES NOT CLOSE, named rather than left to be discovered. `\b` fails only
- * against a preceding WORD character, so `$route:` — a legal JS identifier — is still read as
- * a declaration. It is no longer a DIVERGENCE (all eight now agree on it), which is what this
- * card was about, but it is still a phantom, and tightening to `(?<![\w$])` would move
- * `declarationsIn` as well — the one scan this card's before/after was priced to leave
- * byte-identical — so it is a SECOND population move with its own before/after to price.
- * Filed as #11630 rather than folded in, for the reason this card was filed rather than
- * folded into #11494, and pinned in `--self-test` so that card MOVES a pin rather than
- * finding none.
+ * ⛔ THE ANCHOR IS A LOOKBEHIND, NOT `\b` (#11630) — and the SET is the load-bearing half.
+ * `\b` fails only against a preceding WORD character (`[A-Za-z0-9_]`), so `$route:` — a legal
+ * JS identifier — was read as a declaration by all eight scans. They agreed, and they agreed
+ * by being wrong together, which is the shape #11542's own card rejected on sight when
+ * "make `declarationsIn` match the other seven" was proposed as the other direction.
+ *
+ * The set is `[\w$.]` — `symbolRe`'s, NOT `dottedRe`'s. Three lookbehind idioms already live
+ * in this file and they exclude THREE DIFFERENT classes, so copying the nearest one is how a
+ * fix comes out right about the mechanism and wrong about the class:
+ *   • `symbolRe`      `(?<![\w$.])`   a BARE token — not a longer identifier, not a member
+ *   • `dottedRe`      `(?<![\w$])`    a DOTTED token, which must tolerate its own dots
+ *   • `rulePatternFor`/`commandPatternFor` `(?<![\w$.-])`  a doc-side PROSE span, where `-`
+ *     glues tokens in English
+ * `declLead`'s key is a BARE token, so `symbolRe`'s set is the analogue: `$` continues an
+ * identifier (`$route`), and `.` makes the token a MEMBER ACCESS whose colon belongs to a
+ * ternary and never to a key (`cond ? obj.route : x`). Both mint the same phantom, and a
+ * character class closes the class rather than enumerating the escapees.
+ *
+ * ⛔ `-` IS DELIBERATELY NOT IN THE SET, which is the one place this departs from
+ * `rulePatternFor`. `a-route` is two tokens (`a - route`), so the `route` there IS the whole
+ * token `route` — it is not a declaration for a DIFFERENT reason (expression position), and
+ * that reason is shared with the bare `cond ? route : x` that NO lookbehind can exclude.
+ * Excluding `-` would close one spelling of that class while leaving its plainest spelling
+ * open, which is enumerating escapees wearing a character class.
+ *
+ * ⛔ THE RESIDUE THIS STILL DOES NOT CLOSE, named rather than left to be discovered. `\w` is
+ * ASCII-only, so a Unicode identifier character still passes: `éroute:` is admitted by the
+ * lookbehind exactly as it was by `\b` (measured — both admit it). Closing it means a
+ * `\p{L}`-class lookbehind under the `u` flag, which changes the escape semantics of every
+ * source these leads are COMPOSED with at the eight call sites. 0 occurrences across the
+ * seven live ledgers, and pinned in `--self-test` as deliberately unmoved so the next card
+ * of this shape MOVES a pin rather than finding none.
+ *
+ * ⛔ THIS IS THE SECOND POPULATION MOVE, and unlike #11542's it moves `declarationsIn` too —
+ * the one scan #11542's before/after was priced to leave byte-identical. It is priced with
+ * its OWN before/after against the header of `--bridge-coverage`, at ROW IDENTITY rather
+ * than counter equality: `--bridge-coverage --json` carries all 177 `unreachableRows` by
+ * `{file, route, client}`, and it hashes `d04a5cedfb613370e5b46ac4725db1d941e5dc88` on the
+ * base tree, on the ablated tree and on the fixed tree alike. Counters agreeing is consistent
+ * with two rows swapping places; row identity is not. Provably free for the direct reason:
+ * across the seven live ledgers, all 499 `route:`/`client:` leads are preceded by a SPACE —
+ * 0 preceded by `$`, 0 by `.`, 0 by any non-word character at all (positive control: the same
+ * scan reports both classes when a fixture carries them).
+ *
+ * ⛔ AND IT CAN ONLY EVER REMOVE. The key alternation always opens with a word character, so
+ * `\b` there fails exactly when the previous character is a word character — making
+ * `(?<![\w$.])` a STRICT SUBSET of `\b`. Swept over code points 0..0x2FFF: `\b` admits 12225,
+ * the lookbehind admits 12223, and the lookbehind admits 0 that `\b` does not. The move is
+ * exactly the 2 characters named above.
  *
  * @param {string} keys  the key alternation ONLY — `(route|client)`, `route`,
  *   `(?:route|client)`. The capture groups are the call site's question; the ANCHOR, the
  *   colon and the run between the colon and the value are this function's. ⛔ A call site must
- *   NOT restate the `\b`: a second copy is a second spelling, which is the entire defect this
- *   closes, and `--self-test` pins that no argument carries one.
+ *   NOT restate the anchor — neither the old `\b` nor a lookbehind of its own: a second copy
+ *   is a second spelling, which is the entire defect this closes, and `--self-test` pins that
+ *   no argument carries either form.
  */
 function declLead(keys) {
-  return String.raw`\b${keys}\s*:\s*`;
+  return String.raw`(?<![\w$.])${keys}\s*:\s*`;
 }
 
 /**
@@ -1441,6 +1482,10 @@ function declarationsIn(text) {
   const out = [];
   // The `\b` this used to carry is now `declLead`'s (#11542) — it was the LAST spelling the
   // eight scans decided for themselves, and this was the one scan that decided it correctly.
+  // #11630 then widened that one anchor past `\b` to `(?<![\w$.])`, which moves THIS scan as
+  // well: a `$route:` or a `cond ? obj.route : x` no longer reaches `unreadableIn` (line
+  // 1478) to be billed as a declaration the recognizer could not read. #11542's before/after
+  // was priced to leave this scan byte-identical; #11630's is priced INCLUDING it.
   const re = new RegExp(declLead('(route|client)'), 'g');
   let m;
   while ((m = re.exec(code)) !== null) {
@@ -2913,26 +2958,167 @@ function selfTest() {
     'declared', '1 row / 1 route / 0 declined',
     `${keyUnreadable.rows.length} row / ${keyUnreadable.routesDeclared} route / ${keyUnreadable.declined.length} declined`);
 
-  // ⛔ THE BOUNDARY THIS CARD DOES NOT CROSS. `\b` fails only against a preceding WORD
-  // character, so `$route:` — a legal JS identifier — is still read as a declaration. It is no
-  // longer a DIVERGENCE, which is what this card was about: all eight scans agree on it now,
-  // and they agree by reading the spelling `declarationsIn` already had. It is still a phantom
-  // row, and closing it means tightening to `(?<![\w$])`, which moves `declarationsIn` as well
-  // — a SECOND population move, with its own before/after to price against the header of
-  // `--bridge-coverage`. Filed as #11630 rather than folded in, for the reason this card was
-  // filed rather than folded into #11494, and pinned so that card MOVES this pin rather than
-  // finding none.
+  // ⛔ THE BOUNDARY #11542 LEFT — CROSSED HERE (#11630). The two pins this block used to hold
+  // read "`$route:` still mints a phantom row — deliberately unmoved" and "and it is still
+  // SILENT"; they are MOVED, not deleted, which is the same treatment #11542 gave the pin
+  // #11584 left it. `\b` fails only against a preceding WORD character, so `$route:` — a legal
+  // JS identifier — was a declaration to all eight scans. They agreed, and they agreed by
+  // being wrong together: exactly the "agreed-and-wrong" end state #11542's card rejected on
+  // sight when it was proposed as the OTHER direction for the key.
+  //
+  // The anchor is now `(?<![\w$.])` — `symbolRe`'s set, NOT `dottedRe`'s. See `declLead`'s
+  // docblock for why the set is the load-bearing half and why `-` is deliberately outside it.
+  //
+  // MEASURED ON THIS EXACT FIXTURE with the anchor back at `\b`:
+  //   ⇒ rows 2 · routesDeclared 2 · clientsDeclared 1 · declined 0 · outsideCode 0 ·
+  //     brokenScan 0   — a file declaring ONE `route:` produced TWO rows, exit 0.
+  //
+  // ⛔ AND THIS ONE MOVES `declarationsIn` TOO — the eighth scan, the one #11542's
+  // before/after was priced to leave byte-identical. Its own fixture is (D6) below.
   const dollarKey = parseLedgerSource([
     'export const L = [',
     "  { $route: 'GET /api/v1/gone', family: 'metadata', disposition: 'sdk' },",
     "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
     '];',
   ].join('\n'));
-  check('parseLedgerSource', 'a `$route:` still mints a phantom row — #11630, deliberately unmoved',
-    'row count', 2, dollarKey.rows.length);
-  check('parseLedgerSource', 'and it is still SILENT — all eight scans agree on it, so both terms move together',
-    'declared', '2 route / 0 declined',
-    `${dollarKey.routesDeclared} route / ${dollarKey.declined.length} declined`);
+  check('parseLedgerSource', 'a `$route:` mints NO row — the anchor excludes identifier CONTINUATION (#11630)',
+    'row count', 1, dollarKey.rows.length);
+  check('parseLedgerSource', 'and the row that survives is the REAL one, carrying its binding',
+    'row', 'GET /api/v1/meta → meta.getTypes',
+    `${dollarKey.rows[0]?.route} → ${dollarKey.rows[0]?.client}`);
+  check('parseLedgerSource', 'and the DENOMINATOR drops it too, so no phantom gap opens', 'declared',
+    '1 route / 1 client / 0 declined',
+    `${dollarKey.routesDeclared} route / ${dollarKey.clientsDeclared} client / ${dollarKey.declined.length} declined`);
+  check('bridgeCoverageFrom', 'and the widened read carries no verdict on an accurate ledger',
+    'brokenScan', 0,
+    bridgeCoverageFrom([{ file: 'p-route-ledger.ts', ...dollarKey }], ['/api/v1/meta']).brokenScan.length);
+  // …and in CODE position it is not reported as PROSE either — the `codeLeads`/`outsideCode`
+  // pair must anchor TOGETHER, the same way #11542 pinned it for the word-prefixed class.
+  check('parseLedgerSource', 'and a `$route:` in CODE position is not reported as a prose-quoted lead',
+    'outsideCode', 0, dollarKey.outsideCode.length);
+
+  // (D2) THE WINDOW DELIMITER (`nextRouteRe`) — the worst of the eight for the same reason it
+  // was for #11542: a `$route:` between a real `route:` and its `client:` CLOSED the real
+  // row's window, handing the binding to the phantom on a path no registrar mounts.
+  const dollarWindow = parseLedgerSource([
+    'export const L = [',
+    "  { route: 'GET /api/v1/meta', family: 'metadata',",
+    "    $route: 'GET /api/v1/gone',",
+    "    disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a `$route:` does not CLOSE the real row window (#11630)', 'rows',
+    '1 row · GET /api/v1/meta → meta.getTypes',
+    `${dollarWindow.rows.length} row · ${dollarWindow.rows.map((r) => `${r.route} → ${r.client}`).join(' | ')}`);
+
+  // (D3) THE IN-WINDOW `client:` MATCH (`windowClientRe`). `window.match()` takes the FIRST
+  // hit, so a `$client:` ahead of the real `client:` BECAME the binding, and the real one fell
+  // through to #10636's unclaimed sweep and was named as a value no row read.
+  const dollarClient = parseLedgerSource([
+    'export const L = [',
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk',",
+    "    $client: 'wrong.binding', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a `$client:` does not become the row BINDING (#11630)', 'binding',
+    'meta.getTypes', dollarClient.rows[0]?.client);
+  check('parseLedgerSource', 'and the real `client:` is bound, not swept up as unclaimed', 'declared',
+    '1 client / 0 declined',
+    `${dollarClient.clientsDeclared} client / ${dollarClient.declined.length} declined`);
+
+  // (D4) THE DECLINED SWEEP (`declinedIn`), the LOUD direction: a double-quoted `$route:` was
+  // billed as a `route:` value the parse FAILED to read — entering the denominator, named with
+  // its line, and firing a PARTIAL-read verdict with exit 1 on a wholly accurate ledger.
+  const dollarDeclined = parseLedgerSource([
+    'export const L = [',
+    '  { $route: "GET /api/v1/gone", family: \'metadata\', disposition: \'sdk\' },',
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a double-quoted `$route:` is not billed as a DECLINED row (#11630)',
+    'declared', '1 row / 1 route / 0 declined',
+    `${dollarDeclined.rows.length} row / ${dollarDeclined.routesDeclared} route / ${dollarDeclined.declined.length} declined`);
+  check('bridgeCoverageFrom', 'so no PARTIAL-read verdict fires on an accurate ledger', 'brokenScan',
+    0, bridgeCoverageFrom([{ file: 'q-route-ledger.ts', ...dollarDeclined }], ['/api/v1/meta']).brokenScan.length);
+
+  // (D5) THE RAW SWEEP behind `outsideCode` — a `$route:` in a COMMENT was printed to the
+  // reader on every `--bridge-coverage` run as a lead sitting where the mask says code is not.
+  const dollarProse = parseLedgerSource([
+    "// The retired row read $route: 'GET /api/v1/gone' before #1234.",
+    'export const L = [',
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a `$route:` in PROSE is not reported as a prose-quoted lead (#11630)',
+    'outsideCode', 0, dollarProse.outsideCode.length);
+
+  // (D6) ⛔ THE EIGHTH SCAN — `declarationsIn`, via `unreadableIn`. THIS is what makes #11630 a
+  // SECOND population move rather than a re-run of #11542's: #11542 left this scan
+  // byte-identical on purpose and priced its before/after that way. A `$route:` whose value is
+  // not a string literal at all was billed here as a declaration the recognizer could not
+  // read — `1 row / 2 route / 1 declined` with a PARTIAL-read verdict, on an accurate ledger.
+  // Compare `--self-test`'s `subroute:` twin above, which reads `1 row / 1 route / 0 declined`
+  // on BOTH trees because the anchored scan always agreed about the word-prefixed class.
+  const dollarUnreadable = parseLedgerSource([
+    'export const L = [',
+    "  { $route: ROUTES.gone, family: 'metadata', disposition: 'sdk' },",
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a non-literal `$route:` is billed to nothing — the EIGHTH scan moved too (#11630)',
+    'declared', '1 row / 1 route / 0 declined',
+    `${dollarUnreadable.rows.length} row / ${dollarUnreadable.routesDeclared} route / ${dollarUnreadable.declined.length} declined`);
+  check('bridgeCoverageFrom', 'and `declarationsIn` moving fires no PARTIAL-read verdict either',
+    'brokenScan', 0,
+    bridgeCoverageFrom([{ file: 'r-route-ledger.ts', ...dollarUnreadable }], ['/api/v1/meta']).brokenScan.length);
+
+  // (D7) ⛔ THE SECOND CLASS THE CHARACTER CLASS CLOSES, found by MEASUREMENT rather than
+  // assumed from the card, which named only `$`. A `.` before the key makes the token a MEMBER
+  // ACCESS, and the colon then belongs to a TERNARY and never to a key — `cond ? obj.route :
+  // 'GET /api/v1/gone'` minted a phantom row on a path nobody declares. This is why the set is
+  // `symbolRe`'s `[\w$.]` and not `dottedRe`'s `[\w$]`: `declLead`'s key is a BARE token.
+  const dottedKey = parseLedgerSource([
+    'export const L = [',
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+    "const fallback = cond ? defaults.route : 'GET /api/v1/gone';",
+  ].join('\n'));
+  check('parseLedgerSource', 'a member-access `.route :` in a TERNARY mints NO row (#11630)',
+    'row count', 1, dottedKey.rows.length);
+  check('parseLedgerSource', 'and the real row keeps its binding across it', 'row',
+    'GET /api/v1/meta → meta.getTypes',
+    `${dottedKey.rows[0]?.route} → ${dottedKey.rows[0]?.client}`);
+  check('parseLedgerSource', 'and it leaves the denominator alone as well', 'declared',
+    '1 route / 1 client / 0 declined',
+    `${dottedKey.routesDeclared} route / ${dottedKey.clientsDeclared} client / ${dottedKey.declined.length} declined`);
+
+  // ⛔ THE BOUNDARY THIS CARD DOES NOT CROSS, in its turn — both halves pinned so the next
+  // card of this shape MOVES a pin rather than finding none, exactly as this one did.
+  //
+  // (a) `-` is NOT in the set. `a-route` is two tokens, so that `route` IS the whole token —
+  // not a declaration for a DIFFERENT reason (expression position), one it shares with the
+  // bare `cond ? route : x` no lookbehind can reach. Excluding `-` would close one spelling of
+  // that class and leave its plainest spelling open.
+  const minusKey = parseLedgerSource([
+    'export const L = [',
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+    "const n = cond ? a-route : 'GET /api/v1/gone';",
+  ].join('\n'));
+  check('parseLedgerSource', 'a `-`-prefixed lead still mints a row — deliberately outside the set (#11630)',
+    'row count', 2, minusKey.rows.length);
+  // (b) `\w` is ASCII-only, so a UNICODE identifier character still passes — `éroute:` is
+  // admitted by the lookbehind exactly as it was by `\b`. Closing it means a `\p{L}` class
+  // under the `u` flag, which changes escape semantics for every source these leads are
+  // COMPOSED with at the eight call sites. 0 occurrences across the seven live ledgers.
+  const unicodeKey = parseLedgerSource([
+    'export const L = [',
+    "  { éroute: 'GET /api/v1/gone', family: 'metadata', disposition: 'sdk' },",
+    "  { route: 'GET /api/v1/meta', family: 'metadata', disposition: 'sdk', client: 'meta.getTypes' },",
+    '];',
+  ].join('\n'));
+  check('parseLedgerSource', 'a UNICODE-prefixed lead still mints a phantom row — residue, deliberately unmoved',
+    'row count', 2, unicodeKey.rows.length);
 
   // ⛔ REPORTED, NEVER A VERDICT. A comment explaining a retired row by quoting its old path
   // is legitimate prose; reddening CI over it is the false red the #9747 family declines.
@@ -3568,24 +3754,57 @@ function selfTest() {
   // copy is the same hole re-opening, and only a source pin can see it: every behavioural
   // fixture above would keep passing while the new scan drifted on its own.
   check('declLead', 'the run between a `route:`/`client:` colon and its value is spelled ONCE', 'affected-docs.mjs',
-    1, (ownSource.match(/String\.raw`\\b\$\{keys\}\\s\*:\\s\*`/g) || []).length);
+    1, (ownSource.match(/String\.raw`\(\?<!\[\\w\$\.\]\)\$\{keys\}\\s\*:\\s\*`/g) || []).length);
   check('declLead', 'and all eight lead scans are built from it, none inline', 'affected-docs.mjs',
     8, (ownSource.match(/new RegExp\(declLead\(/g) || []).length);
   // …AND THE KEY ANCHOR IS SPELLED ONCE TOO (#11542), which is the same pin one field over.
   // It was the LAST part of the lead each call site decided for itself: `declarationsIn`
   // passed `\b(route|client)` and the other seven passed the key bare, so seven agreeing and
   // one differing looked exactly like eight agreeing — and the one that differed was the one
-  // that was right. A call site that restates the `\b` is that hole re-opening from the other
-  // side, and only a source pin can see it: every behavioural fixture above stays green while
-  // the argument drifts.
+  // that was right. A call site that restates the anchor is that hole re-opening from the
+  // other side, and only a source pin can see it: every behavioural fixture above stays green
+  // while the argument drifts. #11630 widened the anchor past `\b` to a LOOKBEHIND, so the pin
+  // now rejects BOTH spellings — a call site that restated the old `\b` and one that grew a
+  // lookbehind of its own are the same defect, and pinning only the form we just moved away
+  // from would leave the pin watching a door nobody uses any more.
   check('declLead', 'and the KEY anchor is spelled once too — no call site restates it', 'affected-docs.mjs',
-    0, (ownSource.match(/declLead\([^\n]*?\\b/g) || []).length);
+    0, (ownSource.match(/declLead\([^\n]*?(?:\\b|\(\?<!)/g) || []).length);
   // BEHAVIOURAL, not merely textual: the three key spellings the eight call sites pass all
   // come back anchored, from the one place that spells the anchor. This is what "all eight
   // read the same anchored spelling" means when checked rather than asserted.
   check('declLead', 'every key spelling a call site passes comes back ANCHORED', 'declLead',
-    String.raw`\b(route|client)\s*:\s* | \broute\s*:\s* | \b(?:route|client)\s*:\s*`,
+    String.raw`(?<![\w$.])(route|client)\s*:\s* | (?<![\w$.])route\s*:\s* | (?<![\w$.])(?:route|client)\s*:\s*`,
     ['(route|client)', 'route', '(?:route|client)'].map((k) => declLead(k)).join(' | '));
+  // …and BEHAVIOURALLY the anchor is a strict TIGHTENING of the `\b` it replaced, which is the
+  // invariant the population pricing rests on: the key alternation always opens with a word
+  // character, so `\b` there fails exactly when the previous character is a word character,
+  // making `(?<![\w$.])` a strict SUBSET. Swept rather than argued — over code points
+  // 0..0x2FFF the lookbehind admits nothing `\b` does not, and exactly 2 characters move.
+  {
+    const bAnchor = new RegExp(String.raw`\b(route|client)\s*:\s*`);
+    // Built through a NAMED intermediate on purpose: the pin above counts the eight
+    // production lead SCANS by the way each one compiles `declLead` directly, and this probe
+    // is a behavioural check rather than a ninth scan. Inflating that count to 9 would blunt
+    // the pin that exists to catch a real ninth. Same convention the key-spelling check below
+    // already uses (`.map((k) => declLead(k))`). ⛔ That pin reads this file as TEXT, so even
+    // naming the compiled spelling in a comment here would count — it is described, not
+    // quoted, for the same reason.
+    const leadSource = declLead('(route|client)');
+    const lead = new RegExp(leadSource);
+    let admitsMore = 0;
+    let moved = 0;
+    for (let c = 0; c < 0x3000; c++) {
+      const s = String.fromCodePoint(c) + "route: 'x'";
+      const b = bAnchor.test(s);
+      const l = lead.test(s);
+      if (l && !b) admitsMore++;
+      if (b && !l) moved++;
+    }
+    check('declLead', 'the anchor only ever REMOVES — it admits nothing `\\b` did not', 'code points 0..0x2FFF',
+      0, admitsMore);
+    check('declLead', 'and the characters it moves are exactly `$` and `.`', 'code points 0..0x2FFF',
+      2, moved);
+  }
 
 
   if (failed) {


### PR DESCRIPTION
Fixes #11630

`declLead` in `scripts/docs-audit/affected-docs.mjs` anchored the ledger `route:` / `client:` key with a word boundary. A word boundary fails only against a preceding **word** character (`[A-Za-z0-9_]`). `$` is not one, and `$route` is a legal JS identifier, so `$route:` was read as a declaration by **all eight** lead scans — they agreed, and they agreed by being wrong together. That is exactly the "agreed-and-wrong" end state #11542's card rejected on sight when it was proposed as the *other* direction for the key.

The anchor is now a **negative lookbehind**, still spelled once, in `declLead`. It is spelled verbatim in `declLead`'s docblock and in the `--self-test` boundary comment, and deliberately **not** here: GitHub's body sanitizer strips the less-than + bang digraph out of an issue or PR body — inside code spans and fenced blocks alike — and silently leaves a different, valid-looking regex behind. Measured twice on #11634.

## The character SET is the load-bearing half — and it is not the one the card named

The card and the old docblock both named the excluded set as word characters plus `$`. **That is `dottedRe`'s set, and it is the wrong analogue.** Three lookbehind idioms already live in this file and they exclude **three different classes**:

| idiom | excludes | because its token is |
| --- | --- | --- |
| `symbolRe` | word chars, `$`, `.` | a **bare** token — not a longer identifier, not a member |
| `dottedRe` | word chars, `$` | a **dotted** token, which must tolerate its own dots |
| `rulePatternFor` / `commandPatternFor` | word chars, `$`, `.`, `-` | a doc-side **prose** span, where `-` glues tokens in English |

`declLead`'s key is a **bare** token, so `symbolRe`'s set is the analogue and the shipped set is word characters, `$` **and `.`**. Copying the nearest idiom blindly is how a fix comes out right about the mechanism and wrong about the class.

`.` was **found by measurement, not assumed from the card**: a `.` before the key makes the token a member access, and the colon then belongs to a **ternary** and never to a key. `cond ? defaults.route : 'GET /api/v1/gone'` minted a phantom row on a path nobody declares. Pinned as its own fixture.

**`-` is deliberately left out**, which is the one place this departs from `rulePatternFor`. `a-route` is two tokens (`a - route`), so that `route` **is** the whole token `route` — it is not a declaration for a *different* reason (expression position), and that reason is shared with the bare `cond ? route : x` that no lookbehind can reach. Excluding `-` would close one spelling of that class while leaving its plainest spelling open: enumerating escapees wearing a character class. Pinned as still-admitted, deliberately.

## It can only ever REMOVE — swept, not argued

The key alternation always opens with a word character, so the old word boundary failed exactly when the previous character was a word character, which makes the new anchor a **strict subset**. Swept over code points `0..0x2FFF`:

| | admits |
| --- | --- |
| old word-boundary anchor | 12225 |
| this branch's anchor | 12223 |
| admitted by this branch but **not** by the old anchor | **0** |

Exactly **2** characters move: `$` and `.`. Both numbers are pinned in `--self-test`, so a future widening that admits something the old anchor did not fails there.

## TWO populations priced, not one — this is the harder move

⚠️ #11634's before/after was priced **specifically** to leave `declarationsIn` byte-identical. Widening past the word boundary **moves `declarationsIn` too**. That is a second population with its own before/after, and it is priced separately below. This is not the same measurement as #11634's and is not reported as such.

Both are priced at **row identity**, not counter equality — counters agreeing is consistent with two rows swapping places.

### Population 1 — the ledger rows (`--bridge-coverage`)

| | base `ffbb7a100` | ablated (anchor reverted) | this branch `6de837d30` |
| --- | --- | --- | --- |
| `rowsParsed` / `routesDeclared` | 269 of 269 | 269 of 269 | **269 of 269** |
| `clientRows` / `clientsDeclared` | 222 of 222 | 222 of 222 | **222 of 222** |
| `reachable` / `unreachable` | 45 / 177 | 45 / 177 | **45 / 177** |
| `leadsOutsideCode` | 0 | 0 | **0** |
| `brokenScan` | 0 (exit 0) | 0 (exit 0) | **0 (exit 0)** |
| tails / ledger files / registrar files | 43 / 7 / 12 | 43 / 7 / 12 | **43 / 7 / 12** |

**Which rows move: none.** `--bridge-coverage --json` carries all 177 `unreachableRows` by `{file, route, client}`, and `git hash-object` gives `d04a5cedfb613370e5b46ac4725db1d941e5dc88` on **all three** trees — base, ablated and fixed. Set difference over `{file, route, client}` is **0 in each direction**. The human-rendered output diffs empty. That is the same hash #11634 reported, so this ledger population has not moved since it merged.

### Population 2 — `declarationsIn`, the eighth scan (NEW to this card)

Measured by slicing `declarationsIn` and its dependency closure (`codeOnly`, `typeDeclRegions`, `declLead` — walked, not hand-listed) out of the file and running the file's **own** bodies over the seven live ledgers:

| tree | ledgers | declarations | `git hash-object` |
| --- | --- | --- | --- |
| base `ffbb7a100` | 7 | 491 | `7f89c810a6060a3a2755f16a00295f42774749e3` |
| ablated | 7 | 491 | `7f89c810a6060a3a2755f16a00295f42774749e3` |
| this branch `6de837d30` | 7 | 491 | `7f89c810a6060a3a2755f16a00295f42774749e3` |

**Positive control — the instrument is sensitive, and proven so before the zero was believed.** Run over a synthetic ledger carrying both escapees, the same harness reports **5** declarations on the base tree and **3** on this branch, and the diff names exactly the two that disappear:

```
< "index": 43,  "key": "route", "quote": "'", "text": "route: 'GET /api/v1/dollar'"
< "index": 183, "key": "route", "quote": "'", "text": "route: 'GET /api/v1/dotted'"
```

### Why both are free on today's tree — re-derived, not inherited from #11634

Across the seven live ledgers there are **499** `route:` / `client:` lead occurrences, and **every one of them is preceded by a space**: 0 preceded by `$`, 0 by `.`, 0 by any non-word character at all. Positive control: the same tally reports `$` and `.` correctly (and a word character as blocked) the moment a fixture carries them, so the zero is a reading and not a blind scan.

## The pin is FLIPPED, not deleted

`--self-test` pinned `$route:`'s behaviour as *deliberately unmoved* so this card would flip an existing pin. Both pinned assertions are **moved**, and the boundary comment above them is rewritten to record what moved — the same treatment #11542 gave the pin #11584 left it.

| pinned assertion | before | after |
| --- | --- | --- |
| `` a `$route:` still mints a phantom row — deliberately unmoved `` | 2 rows | **flipped** → `` a `$route:` mints NO row `` , 1 row |
| `and it is still SILENT — all eight scans agree, so both terms move together` | `2 route / 0 declined` | **flipped** → `and the DENOMINATOR drops it too`, `1 route / 1 client / 0 declined` |
| `the run between a colon and its value is spelled ONCE` | matched the word-boundary spelling | **updated** to the new anchor's spelling |
| `and the KEY anchor is spelled once too — no call site restates it` | rejected a restated word boundary | **widened** to reject a restated word boundary **or** a call site's own lookbehind |
| `every key spelling a call site passes comes back ANCHORED` | three word-boundary spellings | **updated** to the three new spellings |

Two **new** boundary pins are added in the same shape, so the next card of this family moves a pin rather than finding none: `-` still admits, and a **Unicode** identifier character still admits (`\w` is ASCII-only, so `éroute:` passes exactly as it did before — closing it means a `\p{L}` class under the `u` flag, which changes escape semantics for every source these leads are composed with at the eight call sites). 0 occurrences of either across the seven live ledgers.

## Reverse verification (ablation) — mutation proven on disk, restore under a trap

The one line the fix moved was reverted to its exact pre-fix spelling, under `trap … EXIT INT TERM` armed **before** the mutation. `affected-docs.mjs` is run directly from source by `node` — there is no `dist/` in its path, so no rebuild leg is involved and none is claimed. Mutation confirmed on disk by counting the injected and the removed text **separately**, anchored on the exact text meant to move (a bare `diff --stat` goes green on any same-round edit), plus hashes:

```
CLEAN_HASH=15da4f14a5971922e38c2f60874b60c220f07c85
  ON DISK: injected=1 (want 1)   removed=0 (want 0)     # declLead anchor
MUTATED_HASH=e6b954a887cff518da2190e8b286e84a298b2188
RESTORED_HASH=15da4f14a5971922e38c2f60874b60c220f07c85   (byte-identical)
```

**Direction predicted before running: turn red on the new pins, and a named set of controls stay green.** Observed exactly that — `ABLATED_SELFTEST_EXIT=1`, **16 checks fail**, and each `got` value is the before state:

```
✗ "a `$route:` mints NO row — the anchor excludes identifier CONTINUATION"  expected 1, got 2
✗ "and the row that survives is the REAL one, carrying its binding"         got "GET /api/v1/gone → null"
✗ "and the DENOMINATOR drops it too, so no phantom gap opens"               got "2 route / 1 client / 0 declined"
✗ "a `$route:` does not CLOSE the real row window"                          got "2 row · GET /api/v1/meta → null | GET /api/v1/gone → meta.getTypes"
✗ "a `$client:` does not become the row BINDING"                            got "wrong.binding"
✗ "and the real `client:` is bound, not swept up as unclaimed"              got "2 client / 1 declined"
✗ "a double-quoted `$route:` is not billed as a DECLINED row"               got "1 row / 2 route / 1 declined"
✗ "so no PARTIAL-read verdict fires on an accurate ledger"                  got brokenScan 1
✗ "a `$route:` in PROSE is not reported as a prose-quoted lead"             got outsideCode 1
✗ "a non-literal `$route:` is billed to nothing — the EIGHTH scan moved"    got "1 row / 2 route / 1 declined"
✗ "and `declarationsIn` moving fires no PARTIAL-read verdict either"        got brokenScan 1
✗ "a member-access `.route :` in a TERNARY mints NO row"                    expected 1, got 2
✗ "and it leaves the denominator alone as well"                             got "2 route / 1 client / 0 declined"
✗ "the run between a colon and its value is spelled ONCE"                   expected 1, got 0
✗ "every key spelling a call site passes comes back ANCHORED"               got the three word-boundary spellings
✗ "and the characters it moves are exactly `$` and `.`"                     expected 2, got 0
```

**The controls that stayed green are the point, not an omission** — each is a fixture that must be green both ways, and a red one would mean the fixture, not the fix, was doing the work:

- `` a `-`-prefixed lead still mints a row `` and `a UNICODE-prefixed lead still mints a phantom row` — the two boundaries this card deliberately does not cross.
- `` and the widened read carries no verdict on an accurate ledger `` (brokenScan 0) and `` and a `$route:` in CODE position is not reported as a prose-quoted lead `` — this is the **silence** the card is about: both terms move together, so no verdict ever fired.
- `and the KEY anchor is spelled once too` — 0 restatements on both trees.
- `the anchor only ever REMOVES` — 0 on both trees, since the ablated anchor is the one being compared against.
- `and the real row keeps its binding across it` (the `.` fixture) — the real row is ahead of the phantom there, so it keeps its binding either way.

Non-vacuity in the other direction is carried by the same fixtures: the genuine `route: 'GET /api/v1/meta'` is still read, still carries `meta.getTypes`, and the 269 live rows are unchanged.

Ablated row identity is also reported: both populations hash **identically** to base and fixed under ablation (`d04a5ced…` and `7f89c810…`), which is what makes the "free on today's tree" claim a three-way measurement rather than a two-way one.

## Verification

Base `origin/main` `ffbb7a100`; measured and re-measured on final commit **`6de837d30`**.

Gate union **derived**, not recalled — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths; the script takes the change set from the merge base itself), 9 families, plus `check:nul-bytes` and the self-test directly. The derivation is fresh for this card: it names `check:agent-test-spelling`, which #11634's run did not carry. Exit codes captured **before** any pipe; each verdict below is the line the gate itself printed.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 351 file(s) · 3319 bare -- token(s)…` |
| `pnpm check:cross-package-test-inputs` | 0 | `OK: 16 package(s) read outside themselves, all declared…` |
| `pnpm check:docs-audit-scope` | 0 | `✓ docs-accuracy-audit scope is in sync with content/docs/: 189 hand-written doc(s).` |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 143 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `pnpm check:parse-guard` | 0 | `✓ check:parse-guard: 142 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 129 assertions` |
| `pnpm check:pnpm-filter-targets` | 0 | `✓ check:pnpm-filter-targets: 134/167 --filter occurrence(s)… resolve` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 16 package(s) read outside themselves, all declared…` |
| `node scripts/docs-audit/check-affected-docs.mjs` | 0 | `✓ affected-docs self-test: 413 cases pass.` |
| `pnpm check:nul-bytes` | 0 | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo` |
| `affected-docs.mjs --self-test` | 0 | `✓ affected-docs self-test: 413 cases pass.` (base: 395 — **+18**) |

**Lint — the full repo-wide run, not a narrowing.** `pnpm lint` (`eslint . --no-inline-config`) was run in full on `6de837d30`: **exit 0**, no findings, 54s under the shared verify lock. No narrowing is claimed and none is needed.

**No changeset — checked against the actual rule, not inherited.** `changeset-check` in `.github/workflows/pr-automation.yml` has **no path exemption**; the `skip-changeset` label (or the changesets release PR) is the only route. This diff is one file under `scripts/`, which publishes nothing: the root package is `private: true` with no `files` field, `scripts/` is not inside any `pnpm-workspace.yaml` glob, and it has no `package.json` of its own. `skip-changeset` applied and read back.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_