### PR TITLE
fix(lint): lintLivenessProperties skips malformed collection items instead of throwing

### DIFF
--- a/.changeset/liveness-lint-null-collection-item-guard.md
+++ b/.changeset/liveness-lint-null-collection-item-guard.md
@@ -1,0 +1,14 @@
+---
+"@objectstack/lint": patch
+---
+
+`lintLivenessProperties` now honours its own docblock contract ("Advisory only
+— returns findings, never throws") when a collection item is `null` or
+otherwise not an object. The object walk, the field walk nested under it, and
+the flat `TYPE_COLLECTIONS` loop that covers every other governed type (flow,
+action, agent, tool, …) each read `item.name`/`item.object` straight off every
+element with no record guard, throwing `TypeError: Cannot read properties of
+null (reading 'name')` on a malformed item instead of skipping it — reachable
+via the exported `stack: AnyRec` signature on an unparsed or hand-built stack.
+The translation bundle walk already guarded its two levels (#11383); this
+closes the same hole on the three walks that did not (#11385).

--- a/packages/lint/src/lint-liveness-properties.test.ts
+++ b/packages/lint/src/lint-liveness-properties.test.ts
@@ -755,6 +755,51 @@ describe('lintLivenessProperties', () => {
       expect(findings.map((f) => f.where)).toEqual(["translation bundle #2 · locale 'en'"]);
     });
   });
+
+  // ── #11385: the "never throws" contract also covers object/field items and
+  // every flat TYPE_COLLECTIONS entry ─────────────────────────────────────────
+  //
+  // The translation bundle walk above guards its two levels (#11383,
+  // `isRecord(bundle)` / `isRecord(data)`). Three other walks read
+  // `item.name` (or `item.object`) straight off every collection element with
+  // no such guard: the object walk, the field walk nested under it, and the
+  // flat loop that covers every OTHER governed type in TYPE_COLLECTIONS
+  // (flow/action/agent/tool/…). A `null` element — a malformed hand-built or
+  // unparsed stack, which the exported `stack: AnyRec` signature permits —
+  // threw `TypeError: Cannot read properties of null (reading 'name')`
+  // instead of being skipped, breaking the docblock's own "Advisory only —
+  // returns findings, never throws" promise. Each case below pairs the
+  // malformed element with a well-formed one carrying a REAL still-`authorWarn`
+  // ledger row, so the assertion proves two things at once: no throw, and the
+  // walk kept going past the bad element instead of aborting silently.
+  describe('never throws on a malformed collection item (#11385)', () => {
+    it('flat TYPE_COLLECTIONS loop: skips a null item and keeps walking past it', () => {
+      const findings = lintLivenessProperties({
+        // agent.memory is a real, currently-`experimental` ledger row (see
+        // "warns on an experimental prop" above) — a real ledger witness,
+        // not a synthetic one.
+        agents: [null, { name: 'ag1', memory: { kind: 'buffer' } }],
+      });
+      expect(paths(findings).some((m) => m.includes('`memory`'))).toBe(true);
+    });
+
+    it('object walk: skips a null item and keeps walking past it', () => {
+      const findings = lintLivenessProperties({
+        objects: [null, { name: 'widget', externalSharingModel: 'read' }],
+      });
+      expect(paths(findings).some((m) => m.includes('externalSharingModel'))).toBe(true);
+    });
+
+    it('field walk: skips a null item (nested under a well-formed object) and keeps walking past it', () => {
+      const findings = lintLivenessProperties({
+        objects: [{
+          name: 'widget',
+          fields: [null, { name: 'related_orders', type: 'text', relatedListFilter: { field: 'account_id' } }],
+        }],
+      });
+      expect(paths(findings).some((m) => m.includes('relatedListFilter'))).toBe(true);
+    });
+  });
 });
 
 // ── #10262: the array fan-out, tested at the WALKER's own level ──────────────

--- a/packages/lint/src/lint-liveness-properties.ts
+++ b/packages/lint/src/lint-liveness-properties.ts
@@ -355,10 +355,14 @@ export function lintLivenessProperties(stack: AnyRec): LivenessLintFinding[] {
   const objectWarn = loadWarnMap(dir, 'object');
   const fieldWarn = loadWarnMap(dir, 'field');
   for (const obj of asArray(stack.objects)) {
+    // Malformed collection item — same "never throws" contract as the flat
+    // TYPE_COLLECTIONS loop and the translation bundle walk below (#11385).
+    if (!isRecord(obj)) continue;
     const objName = typeof obj.name === 'string' ? obj.name : '(unnamed object)';
     if (objectWarn.size > 0) checkItem('object', obj, `object '${objName}'`, objectWarn, findings);
     if (fieldWarn.size > 0) {
       for (const field of asArray(obj.fields)) {
+        if (!isRecord(field)) continue;
         const fieldName = typeof field.name === 'string' ? field.name : '(unnamed field)';
         checkItem('field', field, `object '${objName}' · field '${fieldName}'`, fieldWarn, findings);
       }
@@ -402,6 +406,8 @@ export function lintLivenessProperties(stack: AnyRec): LivenessLintFinding[] {
     const warnMap = loadWarnMap(dir, type);
     if (warnMap.size === 0) continue;
     for (const item of asArray(stack[key])) {
+      // Malformed collection item — "never throws" contract (#11385).
+      if (!isRecord(item)) continue;
       // view containers bind via `object`, not `name`
       const name = typeof item.name === 'string' ? item.name
         : typeof item.object === 'string' ? item.object


### PR DESCRIPTION
Fixes #11385

## The contradiction

`lintLivenessProperties`'s docblock states its contract plainly: "Advisory
only — returns findings, never throws." Three of its four walks did not hold
it — each read `item.name` (or `item.object`) straight off every collection
element with no check that the element is actually a record:

- the flat `TYPE_COLLECTIONS` loop (covers every OTHER governed type: flow,
  action, agent, tool, skill, dataset, permission, hook, page, view, webhook,
  datasource, app, book, job, email_template, mapping, dashboard)
- the `object` walk
- the `field` walk nested under it

A `null` element in any of those collections threw `TypeError: Cannot read
properties of null (reading 'name')` instead of being skipped — reachable via
the exported `stack: AnyRec` signature on an unparsed or hand-built stack,
which the docblock's "never throws" promise invites a caller to hand this
function without validating first. The translation bundle walk already
guards its two levels this way (`isRecord(bundle)` / `isRecord(data)`,
#11383); these three did not.

## The fix

One `if (!isRecord(item)) continue;` guard in each of the three walks,
mirroring the existing idiom from the translation bundle walk and using the
`isRecord` helper already defined in the file. No new helper, no behavior
change for well-formed input — a malformed element is now skipped and the
walk continues over the rest of the collection, exactly like the translation
walk already does.

## Measurement

The card's own reachability note asked only about the flat loop; it flagged
the object/field walk above it as "the same one-line question" without
measuring it. Measured on `origin/main` before this fix, all three throw:

```
lintLivenessProperties({ agents: [null] })                                    -> throws TypeError
lintLivenessProperties({ objects: [null] })                                   -> throws TypeError
lintLivenessProperties({ objects: [{ name: 'w', fields: [null] }] })          -> throws TypeError
```

So the object/field walk needed the same guard as the flat loop — this PR
guards all three, not just the one the card's suggested shape named.

## Tests

Three new regression tests in `lint-liveness-properties.test.ts`, one per
guarded walk, each pairing the malformed element with a real still-warning
ledger row from the shipped ledgers (not a synthetic one) so the assertion
proves two things at once: no throw, and the walk kept going past the bad
element instead of aborting silently —

- flat loop: `agents: [null, { name: 'ag1', memory: { kind: 'buffer' } }]` →
  still warns on `memory` (real `experimental` row)
- object walk: `objects: [null, { name: 'widget', externalSharingModel: 'read' }]`
  → still warns on `externalSharingModel` (real `planned` row)
- field walk: a `null` field entry alongside a real `field.relatedListFilter`
  (real `planned` row)

**Reverse verification**: ran these three tests against the unguarded
`origin/main` source first (before writing the guards) — all three failed
with the TypeError above, not the assertion they were written for. Added the
three guards, reran — all three pass.

## Verification

- `pnpm --filter '@objectstack/lint^...' build` (dependency closure), then
  `pnpm --filter @objectstack/lint build` — clean.
- `pnpm --filter @objectstack/lint test -- --maxWorkers=2` — **2274/2274
  passed** (81 files), including the 3 new regression tests.
- `pnpm --filter @objectstack/lint typecheck` — clean.
- Scoped ESLint (`eslint packages/lint/src/lint-liveness-properties.ts
  packages/lint/src/lint-liveness-properties.test.ts --no-inline-config
  --format json`) — 2 files linted (matches this diff exactly), 0
  errors/warnings. Repo-wide `pnpm lint` is CI's to run; the collapse to
  these 2 files is sound because this repo's single `eslint.config.mjs`
  never enables type-aware linting for any file (`no parserOptions.project,
  no typed @typescript-eslint rules` — the file's own header, `eslint.config.mjs:326-328`),
  so no untouched file's lint verdict can move from this diff.
- Local gate list derived via `node scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` from this worktree — every path-derived and
  convention-triggered local gate it named ran green: `check:changeset-gate-
  self-tests`, `check:cross-package-test-inputs`, `check:objectui-changeset`,
  `check:published-files`, `check:slot-lookup`, `check:test-source-alias`,
  `check:type-source-resolution`, `check-adr-0087-registration`,
  `check-changeset-no-major`, `check-empty-changeset`,
  `check-plugin-teardown-shape`, `check-affected-docs`,
  `check:query-options-erasure`, `check:engine-double-contract`,
  `check:where-matcher`, `release-rehearsal-clone --self-test`. (Two path-
  derived entries — `check:cross-package-test-inputs` and
  `check-cross-package-test-inputs.mjs` — are the same script; ran once.)
  `check:type-check-debt`'s `--re-measure` ratchet needs the full
  `./packages/*` + `./packages/*/*` closure built; not run locally given the
  shared-container resource discipline (this diff adds no cross-package
  import and no new type surface outside the touched file, so it is very
  unlikely to move that ratchet) — flagged for CI to confirm.
- Changeset added: `.changeset/liveness-lint-null-collection-item-guard.md`
  (`@objectstack/lint`, patch).

## Scope

Touches only `packages/lint/src/lint-liveness-properties.ts`, its test file,
and the changeset. No other file in the package or repo is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_