### PR TITLE
feat(lint): give `validate-translation-references` a `flows` leg

### DIFF
--- a/.changeset/translation-refs-flows-leg.md
+++ b/.changeset/translation-refs-flows-leg.md
@@ -1,0 +1,35 @@
+---
+'@objectstack/lint': patch
+---
+
+`validate-translation-references` now checks the `flows` group — an authored key naming a
+flow, screen node or screen field that does not exist warns instead of resolving to nothing
+
+The rule walked `objects`, `globalActions`, `apps` and `dashboards`; an unrecognised
+top-level namespace is skipped and never reported, and `flows` was one of them. So a
+bundle keyed to `flows.<name>.screens.<node_id>.fields.<field_name>` parsed, shipped, and
+silently resolved to nothing — the wizard rendering its source-locale string while every
+other label on the screen was translated, which is the exact failure this rule exists for,
+one namespace over.
+
+All three levels are exact-match identifiers with an enumerable universe, so the leg
+mirrors the `dashboards` → `widgets` leg one level further: flow → `Flow.name`, screen →
+`FlowNode.id` on `type: 'screen'` nodes, field → `ScreenFieldConfig.name`. Findings are
+`warning`, like every other finding in this rule (ADR-0072 D1 — an orphan key is inert,
+not broken), and each names the declared universe it resolved against.
+
+Two shape facts the collector respects, both measured against the schemas rather than
+assumed — either one read the obvious way would have made the leg a false-positive
+generator:
+
+- **Screen nodes nest.** A screen inside an ADR-0031 region (`loop.config.body`,
+  `parallel.config.branches[].nodes`, `try_catch.config.try`/`.catch`) is a real screen the
+  runner pauses on, so the universe is collected through `walkFlowNodes` rather than the
+  flat `flow.nodes`.
+- **`ScreenConfigSchema` has two mutually exclusive shapes.** An object-form screen
+  (`config.objectName`) renders that object's own create/edit form and declares no
+  `config.fields`; its input labels resolve through `objects.<objectName>.fields.*`, so a
+  field key there is reported with that redirect rather than a bare "not declared".
+
+A key naming a node that exists but is not a `screen` is diagnosed as the wrong node type,
+not as a missing node.

--- a/packages/lint/src/validate-translation-references.test.ts
+++ b/packages/lint/src/validate-translation-references.test.ts
@@ -373,6 +373,223 @@ describe('validateTranslationReferences — apps, dashboards, global actions', (
   });
 });
 
+describe('validateTranslationReferences — flows (#7646 / #11287)', () => {
+  /**
+   * One stack, shared by every case below — the clean run and the three
+   * orphan runs differ ONLY in the bundle, so "no findings" is a verdict about
+   * this metadata rather than a rule that never reached it.
+   */
+  const flowStack = {
+    objects: [{ name: 'crm_lead', fields: { name: { type: 'text' }, owner: { type: 'lookup' } } }],
+    flows: [
+      {
+        name: 'lead_conversion',
+        type: 'screen',
+        nodes: [
+          { id: 'start', type: 'start', label: 'Start' },
+          { id: 'gate', type: 'decision', label: 'Qualified?' },
+          {
+            id: 'details',
+            type: 'screen',
+            label: 'Details',
+            config: {
+              title: 'Conversion Details',
+              fields: [
+                { name: 'opportunity_name', label: 'Opportunity Name' },
+                { name: 'close_date', label: 'Close Date' },
+              ],
+            },
+          },
+        ],
+        edges: [
+          { id: 'e1', source: 'start', target: 'gate' },
+          { id: 'e2', source: 'gate', target: 'details' },
+        ],
+      },
+    ],
+  };
+
+  const bundle = (flows: unknown) => ({ ...flowStack, translations: [{ 'zh-CN': { flows } }] });
+
+  /**
+   * The universe the collector actually reached, read back out of the rule's
+   * OWN hint — the tail `listNames()` prints.
+   *
+   * This is the assertion the leg exists for. A universe collector that
+   * silently reaches nothing reports nothing, which is indistinguishable from
+   * a leg that looked and found no orphans; here the collected names come back
+   * through the production code path, so a collector that reached nothing
+   * prints an empty tail and fails.
+   */
+  const enumeratedUniverse = (hint: string, lead: string): string[] => {
+    const matched = new RegExp(`${lead}: ([^.]*)\\.`).exec(hint);
+    return matched ? matched[1].split(', ').filter(Boolean) : [];
+  };
+
+  it('reports nothing when the flow, the screen node and the field all resolve', () => {
+    const findings = validateTranslationReferences(
+      bundle({
+        lead_conversion: {
+          label: '线索转换',
+          screens: {
+            details: {
+              title: '转换详情',
+              fields: {
+                opportunity_name: { label: '商机名称', placeholder: '请输入' },
+                close_date: { label: '预计成交日期' },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('fires on an orphan at level 1 — the flow name — and enumerates a non-empty flow universe', () => {
+    const findings = validateTranslationReferences(
+      bundle({ lead_conversions: { label: 'x', screens: { details: { title: 'y' } } } }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].rule).toBe(TRANSLATION_TARGET_UNKNOWN);
+    expect(findings[0].path).toBe('translations[0]["zh-CN"].flows.lead_conversions');
+    expect(findings[0].message).toContain('Did you mean "lead_conversion"?');
+    // ⭐ the collector reached a real flow, so the zero above is a reading.
+    expect(enumeratedUniverse(findings[0].hint, 'Defined flows')).toEqual(['lead_conversion']);
+  });
+
+  it('fires on an orphan at level 2 — the screen node id — and enumerates a non-empty screen universe', () => {
+    const findings = validateTranslationReferences(
+      bundle({ lead_conversion: { label: '线索转换', screens: { detail: { title: 'y' } } } }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].path).toBe('translations[0]["zh-CN"].flows.lead_conversion.screens.detail');
+    expect(findings[0].message).toContain('Did you mean "details"?');
+    expect(findings[0].hint).toContain('ScreenSpec.nodeId');
+    expect(enumeratedUniverse(findings[0].hint, 'Declared screen node ids')).toEqual(['details']);
+  });
+
+  it('fires on an orphan at level 3 — the screen field name — and enumerates a non-empty field universe', () => {
+    const findings = validateTranslationReferences(
+      bundle({
+        lead_conversion: {
+          screens: { details: { title: '转换详情', fields: { opportunity: { label: 'x' } } } },
+        },
+      }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].path).toBe(
+      'translations[0]["zh-CN"].flows.lead_conversion.screens.details.fields.opportunity',
+    );
+    expect(findings[0].message).toContain('Did you mean "opportunity_name"?');
+    expect(enumeratedUniverse(findings[0].hint, 'Declared screen field names')).toEqual([
+      'close_date',
+      'opportunity_name',
+    ]);
+  });
+
+  it('diagnoses a key on a real node of the wrong type as such, not as a missing node', () => {
+    const findings = validateTranslationReferences(
+      bundle({ lead_conversion: { screens: { gate: { title: 'x' } } } }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('declares as a `decision` node, not a `screen`');
+  });
+
+  it('resolves a screen nested in an ADR-0031 region — the runner pauses on it, so its keys are not orphans', () => {
+    const nestedStack = {
+      flows: [
+        {
+          name: 'lead_conversion',
+          type: 'screen',
+          nodes: [
+            {
+              id: 'per_lead',
+              type: 'loop',
+              label: 'Each Lead',
+              config: {
+                collection: '{leads}',
+                body: {
+                  nodes: [
+                    {
+                      id: 'nested_screen',
+                      type: 'screen',
+                      label: 'Confirm',
+                      config: { fields: [{ name: 'confirmed', label: 'Confirmed' }] },
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const nestedBundle = (screens: unknown) => ({
+      ...nestedStack,
+      translations: [{ 'zh-CN': { flows: { lead_conversion: { screens } } } }],
+    });
+
+    expect(
+      validateTranslationReferences(
+        nestedBundle({ nested_screen: { title: '确认', fields: { confirmed: { label: '已确认' } } } }),
+      ),
+    ).toEqual([]);
+
+    // …and the same nested universe still judges: one letter off and it fires,
+    // so the green above is a resolution rather than an unreached subtree.
+    const findings = validateTranslationReferences(
+      nestedBundle({ nested_screen: { fields: { confirme: { label: '已确认' } } } }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(enumeratedUniverse(findings[0].hint, 'Declared screen field names')).toEqual(['confirmed']);
+  });
+
+  it('redirects a field key on an object-form screen to the objects group', () => {
+    const findings = validateTranslationReferences({
+      ...flowStack,
+      flows: [
+        {
+          name: 'lead_conversion',
+          type: 'screen',
+          nodes: [
+            { id: 'edit_lead', type: 'screen', label: 'Edit', config: { objectName: 'crm_lead', mode: 'edit' } },
+          ],
+        },
+      ],
+      translations: [
+        {
+          'zh-CN': {
+            flows: { lead_conversion: { screens: { edit_lead: { title: '编辑', fields: { owner: { label: '负责人' } } } } } },
+          },
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('OBJECT-FORM screen');
+    expect(findings[0].hint).toContain('objects.crm_lead.fields.owner');
+  });
+
+  it('accepts a flow map keyed by name, the normalized stack shape', () => {
+    const findings = validateTranslationReferences({
+      flows: {
+        lead_conversion: {
+          type: 'screen',
+          nodes: [{ id: 'details', type: 'screen', label: 'D', config: { fields: [{ name: 'opportunity_name' }] } }],
+        },
+      },
+      translations: [
+        { 'zh-CN': { flows: { lead_conversion: { screens: { details: { fields: { opportunity_name: { label: 'x' } } } } } } } },
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
 describe('validateTranslationReferences — namespaces deliberately not judged', () => {
   it('ignores messages, validationMessages, settings, metadataForms and settingsCommon', () => {
     const findings = validateTranslationReferences({

--- a/packages/lint/src/validate-translation-references.ts
+++ b/packages/lint/src/validate-translation-references.ts
@@ -52,6 +52,39 @@
  *     (locale → `TranslationData`). Its keys are simply not visited here: an
  *     unrecognised top-level namespace is skipped, never reported.
  *
+ * ── Flows: what the three levels resolve against ─────────────────────────
+ *
+ * `flows.<name>.screens.<node_id>.fields.<field_name>` (#7646 / #11287) is
+ * three exact-match identifiers deep, and all three have an enumerable
+ * universe, so the leg mirrors `dashboards` → `widgets` one level further:
+ *
+ *   | level  | key                       | declared by                        |
+ *   |--------|---------------------------|------------------------------------|
+ *   | flow   | `Flow.name`               | `flow.zod.ts` (required machine name) |
+ *   | screen | `FlowNode.id`             | `flow.zod.ts`, `type: 'screen'` nodes |
+ *   | field  | `ScreenFieldConfig.name`  | `builtin-node-config.zod.ts` (`config.fields[]`) |
+ *
+ * Two shape facts the collector must respect, both measured rather than
+ * assumed — either one, read the obvious way, turns this leg into a
+ * false-positive generator:
+ *
+ *  1. **Screen nodes NEST.** `FlowNode.config` carries ADR-0031 regions
+ *     (`loop.config.body`, `parallel.config.branches[].nodes`,
+ *     `try_catch.config.try`/`.catch`), each holding a full node array. A
+ *     screen in one is a real screen — the runner pauses on it and the client
+ *     holds its `nodeId` — so the universe is collected with `walkFlowNodes`,
+ *     not off the flat `flow.nodes`.
+ *  2. **`ScreenConfigSchema` has two mutually exclusive shapes.** A FLAT
+ *     screen declares `config.fields[]`; an OBJECT-FORM screen
+ *     (`config.objectName`) renders that object's whole create/edit form and
+ *     declares no `fields` at all. Its input labels resolve through
+ *     `objects.<objectName>.fields.*`, so a field key on one is an orphan —
+ *     reported with that redirect rather than a bare "not declared".
+ *
+ * `flows.<name>.label` and `.screens.<id>.title` are leaf copy on a node that
+ * resolved, so they need no check of their own — the schema closes the leaf
+ * vocabulary (`.strict()`), which is a shape concern, not a reference.
+ *
  * ── Cross-package objects ────────────────────────────────────────────────
  *
  * A stack legitimately translates objects it does not define — `sys_user`'s
@@ -67,9 +100,21 @@
 
 import { expandViewContainer } from '@objectstack/spec';
 import { hasPlatformObjectPrefix, isPlatformProvidedObjectName } from '@objectstack/spec/system';
+import { walkFlowNodes } from './flow-walk.js';
 import { walkPageComponents } from './page-walk.js';
 import { SYSTEM_FIELDS } from './system-fields.js';
 import { viewObjectName } from './view-walk.js';
+
+/**
+ * The `FlowNode.type` a `flows.<name>.screens.*` key addresses.
+ *
+ * A local const, the same way `i18n-resolver.ts` keeps its own `SCREEN_NODE_TYPE`
+ * beside the resolver that reads it: `'screen'` is a member of the open
+ * `FlowNodeAction` seed set (ADR-0018 removed the enum gate on `FlowNode.type`),
+ * and neither that enum nor `FLOW_BUILTIN_NODE_TYPES` exposes "the screen one"
+ * by name to import.
+ */
+const SCREEN_NODE_TYPE = 'screen';
 
 export const TRANSLATION_TARGET_UNKNOWN = 'translation-target-unknown';
 export const TRANSLATION_OPTION_KEY_UNKNOWN = 'translation-option-key-unknown';
@@ -187,11 +232,38 @@ interface ObjectFacts {
   sections: Set<string>;
 }
 
+/** Everything a `flows.<name>.screens.<node_id>` key may legally name. */
+interface ScreenFacts {
+  /** `config.fields[].name` — the flat screen's declared inputs. */
+  fields: Set<string>;
+  /**
+   * `config.objectName` when this is an OBJECT-FORM screen. Its inputs are the
+   * object's own create/edit form, not `config.fields`, so a field key here is
+   * an orphan that belongs under `objects.<objectName>.fields.*` — the same
+   * "say where it belongs" redirect a misfiled `globalActions` key gets.
+   */
+  objectName?: string;
+}
+
+/** Everything a `flows.<name>.…` key may legally name under one flow. */
+interface FlowFacts {
+  /** Screen node id → that screen's facts. Keyed by `FlowNode.id`. */
+  screens: Map<string, ScreenFacts>;
+  /**
+   * Every NON-screen node id → its `type`. The `screens` group addresses screen
+   * nodes only, so a key naming a real `decision` node is still an orphan — but
+   * one whose diagnosis is "wrong node type", not "no such node".
+   */
+  otherNodes: Map<string, string>;
+}
+
 interface Universe {
   objects: Map<string, ObjectFacts>;
   /** App name → every navigation item id declared by that app. */
   apps: Map<string, Set<string>>;
   dashboards: Map<string, { widgets: Set<string>; actions: Set<string> }>;
+  /** Flow name (`Flow.name`) → its screen nodes and their declared fields. */
+  flows: Map<string, FlowFacts>;
   /** Object-less actions — the ones `globalActions.*` may name. */
   globalActions: Map<string, AnyRec>;
   /** Action name → owning object, so a misfiled `globalActions` key can say where it belongs. */
@@ -565,7 +637,42 @@ function buildUniverse(stack: AnyRec): Universe {
     dashboards.set(dashName, { widgets, actions });
   }
 
-  return { objects, apps, dashboards, globalActions, actionOwners };
+  // ── Flows: screen node ids + the field names each screen declares ──
+  //
+  // Nodes are collected through `walkFlowNodes`, NOT `flow.nodes` directly: a
+  // screen inside an ADR-0031 region (`loop.config.body`,
+  // `parallel.config.branches[].nodes`, `try_catch.config.try`/`.catch`) is a
+  // real screen the runner pauses on and hands the client a `ScreenSpec.nodeId`
+  // for, so its translation key resolves. Reading the flat array would leave
+  // every nested screen out of the universe and report each of its keys as an
+  // orphan — a warning-severity false positive, which is exactly the
+  // over-stating ADR-0072 D1 forbids.
+  const flows = new Map<string, FlowFacts>();
+  for (const flow of asArray(stack.flows)) {
+    const flowName = strName(flow.name);
+    if (!flowName) continue;
+    const screens = new Map<string, ScreenFacts>();
+    const otherNodes = new Map<string, string>();
+    for (const { node } of walkFlowNodes(flow, '')) {
+      const nodeId = strName(node.id);
+      if (!nodeId) continue;
+      const nodeType = strName(node.type);
+      if (nodeType !== SCREEN_NODE_TYPE) {
+        if (nodeType && !otherNodes.has(nodeId)) otherNodes.set(nodeId, nodeType);
+        continue;
+      }
+      const config = isRec(node.config) ? node.config : undefined;
+      const fields = new Set<string>();
+      for (const field of asArray(config?.fields)) {
+        const name = strName(field.name);
+        if (name) fields.add(name);
+      }
+      screens.set(nodeId, { fields, objectName: strName(config?.objectName) });
+    }
+    flows.set(flowName, { screens, otherNodes });
+  }
+
+  return { objects, apps, dashboards, flows, globalActions, actionOwners };
 }
 
 /** Quote a locale for the config path — BCP-47 tags carry `-`. */
@@ -825,6 +932,73 @@ export function validateTranslationReferences(stack: AnyRec): TranslationRefFind
             `Header-action translations are keyed by the action's \`actionUrl\`, not its label.` +
               (dash.actions.size > 0 ? ` Declared header actions: ${listNames(dash.actions)}.` : ''),
           );
+        }
+      }
+
+      // ── flows.<name>[.screens.<node_id>[.fields.<field_name>]] ────────
+      for (const [flowName, rawFlow] of Object.entries(asRecord(rawData.flows))) {
+        const flowPath = `${base}.flows.${flowName}`;
+        const flow = universe.flows.get(flowName);
+        if (!flow) {
+          orphan(
+            `${inLocale} · flow "${flowName}"`,
+            flowPath,
+            `Translations are keyed to flow "${flowName}", which this stack does not define. ` +
+              `The wizard renders its source-locale label and headings.` +
+              suggest(flowName, universe.flows.keys()),
+            `Match the key to a flow's \`name\` (the machine name, not its label), or drop it.` +
+              (universe.flows.size > 0 ? ` Defined flows: ${listNames(universe.flows.keys())}.` : ''),
+          );
+          continue;
+        }
+        if (!isRec(rawFlow)) continue;
+        for (const [nodeId, rawScreen] of Object.entries(asRecord(rawFlow.screens))) {
+          const screenPath = `${flowPath}.screens.${nodeId}`;
+          const screen = flow.screens.get(nodeId);
+          if (!screen) {
+            const otherType = flow.otherNodes.get(nodeId);
+            orphan(
+              `${inLocale} · flow "${flowName}" · screen "${nodeId}"`,
+              screenPath,
+              otherType
+                ? `Translations are keyed to screen "${nodeId}", which flow "${flowName}" ` +
+                  `declares as a \`${otherType}\` node, not a \`screen\`. Only screen nodes ` +
+                  `render a heading and fields for a user to read, so nothing resolves these keys.`
+                : `Translations are keyed to screen "${nodeId}", which flow "${flowName}" ` +
+                  `declares no screen node for. The wizard step keeps its source-locale heading.` +
+                  suggest(nodeId, flow.screens.keys()),
+              `Screen translations are keyed by the node's \`id\` (the client's ` +
+                `\`ScreenSpec.nodeId\`), not its \`label\`.` +
+                (flow.screens.size > 0
+                  ? ` Declared screen node ids: ${listNames(flow.screens.keys())}.`
+                  : ` Flow "${flowName}" declares no \`type: 'screen'\` node at all.`),
+            );
+            continue;
+          }
+          if (!isRec(rawScreen)) continue;
+          for (const fieldName of Object.keys(asRecord(rawScreen.fields))) {
+            if (screen.fields.has(fieldName)) continue;
+            const objectForm = screen.fields.size === 0 ? screen.objectName : undefined;
+            orphan(
+              `${inLocale} · flow "${flowName}" · screen "${nodeId}" · field "${fieldName}"`,
+              `${screenPath}.fields.${fieldName}`,
+              objectForm
+                ? `Translations are keyed to screen field "${fieldName}", but screen "${nodeId}" ` +
+                  `is an OBJECT-FORM screen (\`config.objectName: "${objectForm}"\`) — it renders ` +
+                  `that object's own create/edit form, so its input labels come from ` +
+                  `\`objects.${objectForm}.fields.*\` and nothing reads a field key here.`
+                : `Translations are keyed to screen field "${fieldName}", which screen "${nodeId}" ` +
+                  `of flow "${flowName}" does not declare. The input keeps its source-locale ` +
+                  `label while every neighbouring field on the same screen resolves.` +
+                  suggest(fieldName, screen.fields),
+              objectForm
+                ? `Move this copy under \`objects.${objectForm}.fields.${fieldName}\`, or drop it.`
+                : `Match the key to a \`config.fields[].name\` on that screen, or drop it.` +
+                  (screen.fields.size > 0
+                    ? ` Declared screen field names: ${listNames(screen.fields)}.`
+                    : ` Screen "${nodeId}" declares no \`config.fields\` at all.`),
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #11608

All measurements below are from the final commit, `172a28c9c`.

## Premise re-verified at my own base (`e170b0ae5`)

```
packages/lint/src/validate-translation-references.ts
  'dashboards' mentions  11   <- CTRL: the probe reaches the namespace list
  'widgets'    mentions  12   <- CTRL
  'flows'      mentions   0   <- the gap
```

And the skip really is silent: the walk reads exactly four namespaces
(`rawData.objects`, `.globalActions`, `.apps`, `.dashboards`) with no default
branch, no counter, no debug line. Nothing about `flows` was reported anywhere.

## The card's own probe, before and after

Same fixture the issue used, run through `validateTranslationReferences`:

| | findings | flows | dashboards (CTRL) | objects (CTRL) |
|:---|---:|---:|---:|---:|
| before | 2 | **0** | 1 | 1 |
| after | 3 | **1** | 1 | 1 |

The controls are unchanged, so the delta is the new leg and not a moved probe.

## What landed

A `flows` leg mirroring `dashboards` → `widgets` one level further, plus the
universe collector and the per-level `suggest()` / `listNames()` tables:

| level | key | declared by |
|:---|:---|:---|
| flow | `Flow.name` | `flow.zod.ts` (required machine name) |
| screen | `FlowNode.id` | `flow.zod.ts`, `type: 'screen'` nodes |
| field | `ScreenFieldConfig.name` | `builtin-node-config.zod.ts` (`config.fields[]`) |

Severity `warning` on every finding, like the rest of the rule (ADR-0072 D1).
No existing green tree turns red: the full `@objectstack/lint` suite is
2279 passed / 81 files.

### Two shape facts measured against the schemas, not taken from the card

The card's table was correct about the three keys; it did not mention either of
these, and each one read the obvious way turns this leg into a false-positive
generator.

1. **Screen nodes nest.** `FlowNode.config` carries ADR-0031 regions
   (`loop.config.body`, `parallel.config.branches[].nodes`,
   `try_catch.config.try`/`.catch`), each holding a full node array. A screen in
   one is a real screen — the executor pauses on it, the client gets its
   `ScreenSpec.nodeId` — so the universe is collected with `walkFlowNodes`
   rather than the flat `flow.nodes`. Reading the one-liner would report every
   nested screen's keys as orphans, which is the fourth-pass version of
   #4380 / #5383 / #4347.
2. **`ScreenConfigSchema` has two mutually exclusive shapes.** A flat screen
   declares `config.fields[]`; an **object-form** screen (`config.objectName`)
   renders that object's whole create/edit form and declares no `fields` at all.
   Its input labels resolve through `objects.<objectName>.fields.*`, so a field
   key there is an orphan — reported with that redirect rather than a bare "not
   declared", the same "say where it belongs" move a misfiled `globalActions`
   key already gets.

A key naming a node that exists but is not a `screen` is diagnosed as the wrong
node type, not as a missing node.

## The leg is shown firing, per level, and its universe is asserted non-zero

The failure this rule's new legs keep hitting is that a universe collector which
silently reaches nothing reports nothing, and reads exactly like a leg that
looked and found no orphans. Three things guard it here.

**One stack, four bundles.** The clean run and the three orphan runs share the
same `flowStack`, differing only in the bundle — so "no findings" is a verdict
about that metadata, not a rule that never reached it.

**Fires at each of the three levels separately**, with the other two levels
resolving, so no level is masked by another:

| test | planted orphan | asserted path |
|:---|:---|:---|
| level 1 | `flows.lead_conversions` | `…flows.lead_conversions` |
| level 2 | `…screens.detail` | `…flows.lead_conversion.screens.detail` |
| level 3 | `…fields.opportunity` | `…screens.details.fields.opportunity` |

**The collected universe is read back out of the rule's own hint** — the tail
`listNames()` prints — and asserted non-empty at every level. A collector that
reached nothing prints an empty tail and fails:

```
Defined flows            -> ['lead_conversion']
Declared screen node ids -> ['details']
Declared screen field names -> ['close_date', 'opportunity_name']
```

### Non-vacuity, both directions

Two ablations, each mutating the source under `trap … EXIT INT TERM`, each with
the mutation proven on disk by anchor count **and** sha256 before restoring
byte-identically. No rebuild step: the test imports the rule by relative
specifier (`./validate-translation-references.js`) inside its own package, so
vitest transforms the source — the mutations changed the result, which is itself
the proof that source is what ran.

| ablation | mutation | result |
|:---|:---|:---|
| A — collector never populates `flows` | `flows.set(...)` removed, anchor 1→0, marker 0→1, sha `c323b40e…`→`ddc86abe…` | **8 failed / 40 passed** — every new test |
| B — flat `flow.nodes` instead of `walkFlowNodes` | anchor 1→0, marker 0→1, sha `c323b40e…`→`1df13b72…` | **1 failed / 47 passed** — exactly the nested-region test |

Both restores verified back to sha `c323b40ed6aad88e7fc7b2a474ea4f49398a3e04fe6d64b40faee04c10f274c7`, zero markers left.

Ablation A is the direct answer to the failure mode: emptying the collector
reddens all eight tests, so none of them can pass on a universe of nothing.
Ablation B shows the nesting fact is load-bearing rather than decorative — it
reddens one test, precisely the one that asserts it.

## Gates

Union **derived**, not recalled:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which
confirmed its answer is about this repo at `172a28c9c` and its `--repo`
assertion holds. Exit codes captured before any pipe. All 14 matched families
plus the convention-triggered ones re-run at the final commit:

- `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`,
  `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`,
  `check:test-source-alias`, `check:type-source-resolution`,
  `check-adr-0087-registration`, `check-changeset-no-major`,
  `check-cross-package-test-inputs`, `check-empty-changeset`,
  `check-plugin-teardown-shape`, `check-affected-docs`,
  `release-rehearsal-clone --self-test` — all `EXIT=0`.
- convention (new test file): `check:query-options-erasure`
  (`ratchet holds: 67 unswept … none new`), `check:where-matcher`
  (`295 matcher(s) … none new`), `check:engine-double-contract`
  (`OK — 401 pinned`), `check:type-check-coverage`, `check:nul-bytes`
  (`no raw ASCII control bytes`).
- `check:type-check-debt` — the ratchet half — needed the workspace closure
  built (it refuses outright otherwise, #6376; that refusal is NOT MEASURED, not
  a red gate). Built via `turbo run build --filter='./packages/*'
  --filter='./packages/*/*'` (70/70 successful), then:
  `--re-measure: OK — 32 ledger entr(ies) re-measured in 235.3s, 1898 raw tsc
  error(s) total, none above its recorded number.`
- `pnpm lint` — the **full** repo-wide `eslint . --no-inline-config`, run whole
  rather than narrowed. `VERDICT command-exit 0 · held the lock 83s`. No
  narrowing to declare.
- `pnpm --filter @objectstack/lint test` — 2279 passed, 81 files.
  `pnpm --filter @objectstack/lint typecheck` — `tsc --noEmit`, exit 0 (script
  name echoed, so not a zero-match silent green).

Every heavy run went through `scripts/pm/os-verify-lock.sh`; verdicts read from
the printed `VERDICT` lines, never a bare `$?`.

## Scope

`packages/lint` only. #11485 is independent in code and is not touched here.

One adjacent finding filed rather than fixed: #11745 — `translateFlow` in
`packages/spec` walks `flow.nodes` flat, so a nested screen node is never
overlaid by the document-overlay path. That is `packages/spec`, out of scope
here, and #11745 is not addressed by this PR. It means the lint rule and
`translateFlow` currently disagree about which nested keys are live; this leg
takes the safe direction for a `warning` (resolve them, do not report them).

I did not hit the #11624 collision — nothing here touches the liveness rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_