### PR TITLE
docs(skills): drop the dead `target` key from the objectstack-api object_operation example

### DIFF
--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -142,7 +142,7 @@ export const CEILING_BASIS = {
  */
 export const CEILINGS = new Map([
   ['skills/objectstack-ai/SKILL.md', 6824],
-  ['skills/objectstack-api/SKILL.md', 6348],
+  ['skills/objectstack-api/SKILL.md', 6342],
   ['skills/objectstack-automation/SKILL.md', 12543],
   // basis 7228d6c25 (PR #10402 head), not main — see CEILING_BASIS.
   // +20 (13797→13817): maintainer ruling 2026-08-23 on PR #11141 — the three

--- a/skills/objectstack-api/SKILL.md
+++ b/skills/objectstack-api/SKILL.md
@@ -178,7 +178,6 @@ export const leadFeed: ApiEndpoint = {
   method: 'GET',
   summary: 'Lead feed',
   type: 'object_operation',
-  target: 'acme_lead',
   objectParams: { object: 'acme_lead', operation: 'find' },
   // `authRequired` omitted → defaults to `true`. Omission is SAFE.
   cacheTtl: 30,                          // seconds; GET-only; success answers only


### PR DESCRIPTION
Fixes #11291

The published `objectstack-api` skill still taught `target` on an `object_operation` endpoint — a key that has been dead since #10338 (landed as #11290, commit `d2619fd0`).

## Premise re-verified on current `origin/main`

The card's premise holds. `packages/spec/src/api/endpoint.zod.ts:171` now reads:

> `target: z.string().optional()` — "REQUIRED at publish for `type: 'flow'` … and UNREAD for `type: 'object_operation'`, so do not write it there: that endpoint is addressed by `objectParams.object` / `.operation`, and a `target` beside them is a dead string nothing checks against `objectParams.object`"

#11290 swept the in-tree examples (`examples/app-showcase`) and the protocol / getting-started docs. `skills/**` was outside that card's file surface and is a governed surface, so the dead spelling survived only here.

**Not generated.** `skills/objectstack-api/SKILL.md` carries no GENERATED header and no generator writes it — `build-skill-docs.ts` writes `skills/README.md` and `content/docs/ai/skills-reference.mdx` from frontmatter, and `build-skill-references.ts` writes `skills/*/references/_index.md`. Neither owns the body, so this is a hand edit of a hand-written file, and both gates stay green (frontmatter untouched).

## What changed

- `skills/objectstack-api/SKILL.md` — the `leadFeed` example drops `target: 'acme_lead'`. The example is inside an `<!-- os:check -->` fence, so it is type-checked: it compiles with the key absent, which is itself the proof that the vocabulary really made it optional.
- `scripts/check-skills-token-ratchet.mjs` — lowers this file's ceiling `6348 → 6342` to lock in the saving, per the ratchet's own documented discipline: *"A ceiling may be LOWERED by any PR that shrinks its file. Lowering is always legitimate and encouraged."*

**No explanatory note was added, deliberately.** The card made the one-line "omit `target` on `object_operation`" note conditional on budget, and the budget is spent: the token ratchet had **zero headroom** on this file (ceiling 6348, file 6348). A first attempt that replaced the key with a one-line comment measured **+16 tokens** and drove the ratchet red — the gate refusing to let a small correction pay for prose. The per-type rule is already stated in the file's gate description (~lines 212-214, unchanged): *"an `object_operation` needs both `objectParams.object` and `.operation`; a `flow` needs a `target`"*. So the corpus still teaches the contract; it just stops demonstrating the dead spelling.

Only the `leadFeed` example spelled the dead key. The other `target` occurrences in the package are unrelated English or the `inputMapping` dot-path sense, and no other skill in `skills/` teaches `target` on an `object_operation`.

## Size discipline (maintainer ruling 2026-08-21)

Both readings, lines and tokens (ratchet convention `ceil(utf8 bytes / 4)`):

| Reading | Before | After | Net |
|:---|---:|---:|---:|
| `skills/objectstack-api/SKILL.md` (whole file) — lines | 610 | 609 | **−1** |
| `skills/objectstack-api/SKILL.md` (whole file) — tokens | 6348 | 6342 | **−6** |
| Whole package (all 11 published `SKILL.md`) — lines | 10506 | 10505 | **−1** |
| Whole package (all 11 published `SKILL.md`) — tokens | 117922 | 117916 | **−6** |

Net growth is negative in every reading — nothing was expanded to fix a small thing.

## Changeset: none, `skip-changeset` applied

Judged from the diff. Nothing published moves: `skills/` has no `package.json` of its own, no published workspace package's `files[]` covers `skills/` or `scripts/`, and the repo root is `private: true`. Both touched paths are repo-internal — a published-catalog source file and a CI gate script — so no npm artifact changes.

## Gates — all run locally at `0e5ea8cb`, each quoting its own verdict line

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no path args) against the real change set, re-derived after `scripts/check-skills-token-ratchet.mjs` joined the diff (8 families → 13). Exit codes captured before any pipe.

| Gate | Verdict line |
|:---|:---|
| `check:agent-test-spelling` | `✓ 0 violations — 351 file(s)` |
| `check:cross-package-test-inputs` | exit 0 |
| `check:doc-authoring` | `✓ doc authoring guard: 389 files clean` |
| `check:doc-formula-expressions` | exit 0 |
| `check:entry-guard` | exit 0 |
| `check:parse-guard` | exit 0 |
| `check:pm-governed-merges` | exit 0 |
| `check:pnpm-filter-targets` | exit 0 |
| `check:role-word` | `check-role-word: OK, no new occurrences` |
| `check:skill-compatibility` | `✓ 11 SKILL.md file(s) reconciled against 78 workspace packages` |
| `check:skill-frame-sync` | `✓ 4 copies of the decision frame are structurally isomorphic` |
| `check-cross-package-test-inputs.mjs` | exit 0 |
| `check-skills-token-ratchet.mjs` | `✓ 11 published SKILL.md within their ceilings.` |

Plus the families AGENTS.md names for a `SKILL.md` edit, which the path derivation did not list — run because the derivation is a clue, not a spec:

| Gate | Verdict line |
|:---|:---|
| `check:skill-docs` | exit 0 |
| `check:skill-refs` | exit 0 |
| `check:skill-examples` | `✅ 257 prose examples type-check across 3 surface(s)` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6553 text file(s) … no raw ASCII control bytes)` |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`) | exit 0 — full run, not a narrowed scan |

Two gates initially **refused rather than measured**, both for missing builds, and neither was a finding: `check:doc-formula-expressions` could not resolve `@objectstack/formula/dist` and `check:skill-examples` refused on an unbuilt `packages/client-react/dist` (it fails loudly rather than returning a false green). Both were re-run to a real verdict after building the dependency closures; the greens above are the post-build runs.

## Landing

⛔ **Governed surface** (`skills/**`, Prime Directive #14) — this PR stays **draft**, is never queued, never armed for auto-merge, and never flipped ready. Human merge only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RMTpSRF5CjMmQBFfPtPCwJ)_