### PR TITLE
fix(security): make clone_permission_set carry all five copied facets

### DIFF
--- a/.changeset/clone-permission-set-carries-all-facets.md
+++ b/.changeset/clone-permission-set-carries-all-facets.md
@@ -1,0 +1,41 @@
+---
+'@objectstack/plugin-security': patch
+---
+
+Make `clone_permission_set` carry the system permissions, row-level security
+and tab permissions it was silently dropping
+
+The Clone action POSTs its `params` values to `/api/v1/data/sys_permission_set`,
+so the params list *is* the payload. It named two of the six definition facets a
+`sys_permission_set` row carries — `object_permissions` and `field_permissions`
+— leaving `system_permissions`, `row_level_security` and `tab_permissions`
+absent from the body. `permissionSetBodyFromRow()` then read each one through
+`parseMaybeJson(undefined, …)` and filled the empty default, so cloning a set
+that grants `setup.access`, or one carrying row-level security policies,
+produced a clone with none of them: record created, success toast fired, and the
+missing half discoverable only by diffing the two records.
+
+The three now travel, in the same JSON-string shape the two listed columns
+already used. Nothing about what the door ACCEPTS changed — `permissionSetBodyFromRow()`
+already read all six columns; what changed is what the action SENDS.
+
+This became urgent one commit ago. The save door now refuses an in-place edit of
+a package-declared permission set **and its refusal message tells the admin to
+clone**, which made this action the platform's own recommended remedy while it
+was still dropping three facets — an admin following that instruction lost
+grants quietly. The failure direction was fail-closed (fewer grants), which is
+why it was quiet.
+
+`admin_scope` is **deliberately not copied** (maintainer ruling 2026-08-24).
+Putting an ADR-0090 D12 delegated-admin authority onto a brand-new
+organization-owned set on the admin's behalf is a privilege decision, not a
+field copy. The Clone dialog now says so in its description, so the omission
+reads to the admin as a decision rather than as the same silent drop — grant a
+scope deliberately on the new set if it needs one.
+
+Pinned by `packaged-permission-set-lock.test.ts` pin 6, which assembles the
+clone payload by READING the action's params list rather than restating it, and
+asserts each facet by identity against a non-empty value — the empty default
+(`[]` / `{}`) is exactly what a "present" assertion would have accepted. Its
+control proves the exclusion is live: the base fixture carries a real
+`admin_scope`, and the clone still has none.

--- a/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
+++ b/packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
@@ -92,6 +92,26 @@ export const SysPermissionSet = ObjectSchema.create({
       visible: "has(record.drift_status) && record.drift_status == 'overlay_shadow'",
     },
     {
+      // [#11703] ⭐ THIS PARAMS LIST *IS* THE PAYLOAD. Every definition facet a
+      // clone should carry has to be named below: the action POSTs its param
+      // VALUES to the generic data door, so a column that is not a param is
+      // simply absent from the body — `permissionSetBodyFromRow()` then reads
+      // it through `parseMaybeJson(undefined, …)` and fills the EMPTY default
+      // (`[]` / `{}`). An omission here is therefore not a missing input, it is
+      // a silent grant loss: the clone is created, the success toast fires, and
+      // the difference is discoverable only by diffing the two records.
+      //
+      // That was live until #11703 — three of the six facets
+      // (`system_permissions`, `row_level_security`, `tab_permissions`) were
+      // never listed, so cloning a set carrying system permissions or RLS
+      // produced a clone with none of them. Fail-closed, and therefore quiet.
+      // It became urgent the moment the save door started REFUSING in-place
+      // edits of package-declared sets and naming THIS action as the remedy
+      // (`packaged-permission-set-lock.ts`, maintainer ruling 2026-08-24).
+      //
+      // `packaged-permission-set-lock.test.ts` pin 6 READS this list rather
+      // than restating it, so adding a facet column to the object surfaces
+      // here rather than silently shipping a clone that drops it.
       name: 'clone_permission_set',
       label: 'Clone',
       icon: 'copy',
@@ -102,6 +122,16 @@ export const SysPermissionSet = ObjectSchema.create({
       method: 'POST',
       target: '/api/v1/data/sys_permission_set',
       bodyExtra: { active: true },
+      // The explanatory line under the clone dialog's title. Its second
+      // sentence is the RULED exclusion (2026-08-24): `admin_scope` — an
+      // ADR-0090 D12 delegated-admin authority — is deliberately NOT copied,
+      // because putting one on a brand-new set on the admin's behalf is a
+      // privilege decision, not a field copy. It is stated HERE, where the
+      // admin is standing when the clone happens, because an UNEXPLAINED
+      // omission is the same silent drop #11703 reports, merely ruled.
+      description:
+        'Copies this set\'s permissions into a new organization-owned set you can edit. '
+        + 'Delegated-admin scope is not copied — grant it deliberately on the new set if it needs one.',
       successMessage: 'Permission set cloned',
       refreshAfter: true,
       params: [
@@ -113,6 +143,14 @@ export const SysPermissionSet = ObjectSchema.create({
         { field: 'description', defaultFromRow: true },
         { field: 'object_permissions', defaultFromRow: true },
         { field: 'field_permissions', defaultFromRow: true },
+        // [#11703] The three facets the clone silently dropped. Same
+        // JSON-string shape as the two above: `permissionSetRowFields()`
+        // writes all five with `JSON.stringify`, and the data door parses all
+        // five back — the accept surface did not move, only what is SENT.
+        { field: 'system_permissions', defaultFromRow: true },
+        { field: 'row_level_security', defaultFromRow: true },
+        { field: 'tab_permissions', defaultFromRow: true },
+        // ⛔ `admin_scope` is deliberately absent — see `description` above.
       ],
     },
   ],

--- a/packages/plugins/plugin-security/src/packaged-permission-set-lock.test.ts
+++ b/packages/plugins/plugin-security/src/packaged-permission-set-lock.test.ts
@@ -613,8 +613,17 @@ const richSet = (over: Record<string, any> = {}) => ({
   ...over,
 });
 
-/** The row the package door materializes for {@link richSet}. */
-const richRow = (over: Record<string, any> = {}) => ({
+/**
+ * The row the package door materializes for {@link richSet}.
+ *
+ * The return annotation is load-bearing, not decoration: without it tsc infers
+ * the object-literal type and DROPS the index signature that
+ * `permissionSetRowFields()` spreads in, so reading `.admin_scope` off the
+ * result — which the exclusion control below does directly, rather than through
+ * the `any[]` of `ql.permRows` — is a TS2339. It costs no precision: every
+ * facet column arrives through that spread already typed `any`.
+ */
+const richRow = (over: Record<string, any> = {}): Record<string, any> => ({
   id: 'ps_rich',
   name: 'ops_console',
   managed_by: 'package',

--- a/packages/plugins/plugin-security/src/packaged-permission-set-lock.test.ts
+++ b/packages/plugins/plugin-security/src/packaged-permission-set-lock.test.ts
@@ -29,7 +29,11 @@
  *  3. the clone path works end to end — org-owned row, no upgrade linkage —
  *     and the package-declared base is untouched by it;
  *  5. fail-closed on ambiguity: a provenance read that cannot ANSWER refuses,
- *     never accepts.
+ *     never accepts;
+ *  6. ⭐ what the clone ACTION SENDS (#11703) — pin 3 drives the door with a
+ *     hand-written payload, so it could not see that the ACTION ITSELF listed
+ *     only two of the row's six definition facets. Pin 6 reads the payload out
+ *     of the action definition, so editing that params list is what moves it.
  *
  * (Pin 4 — the detection reading for overlays that already exist — lives in its
  * own suite at the bottom of this file, because it reads rather than writes.)
@@ -62,6 +66,7 @@
 import { describe, it, expect } from 'vitest';
 import { PermissionSetSchema } from '@objectstack/spec/security';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { SysPermissionSet } from './objects/sys-permission-set.object.js';
 import {
   createPermissionSetWriteThrough,
   permissionSetRowFields,
@@ -496,6 +501,242 @@ describe('pin 3 — the clone path yields an org-owned set with no upgrade linka
     });
     expect(nextCalled).toBe(false);
     expect(JSON.parse(ql.permRows.find((r: any) => r.id === clone.id).system_permissions)).toEqual(['local.only']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PIN 6 — what the CLONE ACTION SENDS: every copied facet, by identity (#11703)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Pin 3 above drives the data door with a HAND-WRITTEN clone payload. That is
+ * precisely why it stayed green while this defect was live: it pins what the
+ * SERVER does with a payload, never what the ACTION DEFINITION chooses to put
+ * in one. `clone_permission_set` listed two of the row's six definition facets
+ * on its `params`, so cloning a set carrying system permissions, row-level
+ * security or tab permissions produced a clone with NONE of them — no error, a
+ * success toast, and the loss discoverable only by diffing the two records
+ * (#11703). Fail-closed (fewer grants), and therefore quiet.
+ *
+ * It matters more since the ruling one commit above this one: the save door now
+ * refuses an in-place edit of a package-declared set AND its refusal names the
+ * clone path, so this action is the platform's own recommended remedy.
+ *
+ * So this suite reads the payload OUT OF THE ACTION instead of restating it.
+ * {@link clonePayload} is the clone dialog in miniature — the admin types the
+ * two inline params, every `defaultFromRow` param is seeded from the source row
+ * as objectui's `ActionParamDialog` seeds it, and `bodyExtra` rides along — so
+ * editing the params list is what moves this suite. That is the whole point:
+ * the class reopens the next time someone edits that list, unless a test is
+ * reading the list rather than a copy of it.
+ *
+ * ⭐ IDENTITIES, NOT COUNTS. "Five facets came across" holds constant while two
+ * of them swap, and asserting a facet is merely PRESENT passes on the empty
+ * default (`[]` / `{}`) that IS the bug. Every facet below is asserted against
+ * a NAMED, NON-EMPTY expected value.
+ */
+
+/** The shipped `clone_permission_set` action — read, never restated. */
+const cloneAction = (): any => {
+  const action = (SysPermissionSet.actions ?? []).find((a: any) => a.name === 'clone_permission_set');
+  if (!action) throw new Error('clone_permission_set is missing from SysPermissionSet.actions');
+  return action;
+};
+
+/**
+ * The body the clone dialog POSTs to `/api/v1/data/sys_permission_set`,
+ * assembled from the ACTION DEFINITION the way the dialog assembles it: a
+ * `defaultFromRow` param is seeded from the source row under its resolved field
+ * name and submitted verbatim when the admin does not touch it; an inline param
+ * carries what the admin typed; `bodyExtra` is merged in.
+ */
+function clonePayload(row: any, typed: Record<string, any>): Record<string, any> {
+  const action = cloneAction();
+  const body: Record<string, any> = { ...(action.bodyExtra ?? {}) };
+  for (const p of action.params ?? []) {
+    const key = p.field ?? p.name;
+    if (p.defaultFromRow) {
+      if (row[key] !== undefined) body[key] = row[key];
+    } else if (key in typed) {
+      body[key] = typed[key];
+    }
+  }
+  return body;
+}
+
+/**
+ * The base an admin clones: EVERY definition facet populated, so no assertion
+ * below can be satisfied by the empty default the defect produced.
+ *
+ * ⚠️ The card's repro sketch named `member_default` as "a set whose
+ * `system_permissions` is non-empty". Measured on this tree that is not so —
+ * the platform `member_default` carries a large `rowLevelSecurity` and NO
+ * system permissions, and `showcase_member_default` carries neither (the D7
+ * lint hard-blocks system permissions on an everyone-suggested set). The defect
+ * is real either way; the example was not. A fixture carrying all six facets at
+ * once is the shape that actually measures all three of the added ones, which a
+ * single real set would not.
+ */
+const richSet = (over: Record<string, any> = {}) => ({
+  name: 'ops_console',
+  label: 'Ops Console',
+  description: 'Runs the operations console.',
+  objects: {
+    showcase_task: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: false },
+    showcase_project: { allowRead: true },
+  },
+  fields: { 'showcase_project.budget': { readable: true, editable: false } },
+  // The three facets #11703 dropped, each non-empty and each named below.
+  systemPermissions: ['setup.access', 'ops.export_data'],
+  rowLevelSecurity: [
+    {
+      name: 'ops_own_rows',
+      label: 'Own Tasks Only',
+      description: 'Operators only select tasks assigned to them.',
+      object: 'showcase_task',
+      operation: 'select' as const,
+      using: 'assignee == current_user.email',
+      positions: ['ops'],
+      enabled: true,
+    },
+  ],
+  tabPermissions: { app_ops: 'default_on' as const, app_admin: 'hidden' as const },
+  // The RULED exclusion's positive control — see the last test.
+  adminScope: {
+    businessUnit: 'field_ops',
+    includeSubtree: true,
+    manageAssignments: true,
+    manageBindings: false,
+    authorEnvironmentSets: false,
+    assignablePermissionSets: ['ops_console'],
+  },
+  ...over,
+});
+
+/** The row the package door materializes for {@link richSet}. */
+const richRow = (over: Record<string, any> = {}) => ({
+  id: 'ps_rich',
+  name: 'ops_console',
+  managed_by: 'package',
+  package_id: 'com.example.ops',
+  active: true,
+  ...permissionSetRowFields(richSet()),
+  ...over,
+});
+
+describe('pin 6 — the clone action SENDS every facet it copies, and says what it deliberately does not (#11703)', () => {
+  it('declares a defaultFromRow param for every copied facet — the identities, not a count', () => {
+    const carried = (cloneAction().params ?? [])
+      .filter((p: any) => p.defaultFromRow)
+      .map((p: any) => p.field ?? p.name)
+      .sort();
+
+    // ⭐ A COUNT here (`toHaveLength(6)`) would hold while `system_permissions`
+    // was swapped for something else. The set is spelled out.
+    expect(carried, 'the params list is what the dialog sends — these are the facets it carries').toEqual([
+      'description',
+      'field_permissions',
+      'object_permissions',
+      'row_level_security',
+      'system_permissions',
+      'tab_permissions',
+    ]);
+    // `admin_scope` is the sixth definition column and is RULED out — pinned in
+    // its own test below so a future reader sees a decision, not an oversight.
+    expect(carried, 'admin_scope is excluded by ruling, not by accident').not.toContain('admin_scope');
+  });
+
+  it('cloning a fully-populated set carries all five copied facets end to end, by name', async () => {
+    const ql = makeQl([richSet()]);
+    const protocol = makeHatchOpenProtocol(ql, { ops_console: richSet() });
+    registerPermissionSetProjection(protocol, { ql });
+    ql.permRows.push(richRow());
+    const mw = makeMiddleware(ql, protocol);
+
+    // The payload comes from the ACTION, not from this test.
+    const payload = clonePayload(ql.permRows[0], {
+      label: 'Ops Console (local)',
+      name: 'ops_console_local',
+    });
+    await run(mw, {
+      object: 'sys_permission_set', operation: 'insert', context: userCtx, data: payload,
+    });
+
+    // (a) the DEFINITION that will be enforced — what `saveMetaItem` stored.
+    const body = protocol.saves.find((s: any) => s.name === 'ops_console_local')?.item;
+    expect(body, 'the clone was authored into the metadata store').toBeTruthy();
+    expect(body.name).toBe('ops_console_local');
+    expect(body.label, 'the admin-typed display name, not the base label').toBe('Ops Console (local)');
+    expect(body.description).toBe(richSet().description);
+    expect(body.objects, 'object permissions').toEqual(richSet().objects);
+    expect(body.fields, 'field permissions').toEqual(richSet().fields);
+    // ⭐ The three #11703 dropped. `[]` / `{}` here is the defect itself.
+    expect(body.systemPermissions, 'system permissions — [] here IS the #11703 silent drop').toEqual(
+      ['setup.access', 'ops.export_data'],
+    );
+    expect(
+      (body.rowLevelSecurity ?? []).map((p: any) => p.name),
+      'row-level security policies, by policy name',
+    ).toEqual(['ops_own_rows']);
+    expect(body.rowLevelSecurity, 'the RLS policy arrived whole, not as a name-only husk').toEqual(
+      richSet().rowLevelSecurity,
+    );
+    expect(body.tabPermissions, 'tab permissions, per tab').toEqual({
+      app_ops: 'default_on', app_admin: 'hidden',
+    });
+
+    // (b) the ROW the admin actually diffs the two records through.
+    const clone = ql.permRows.find((r: any) => r.name === 'ops_console_local');
+    expect(clone, 'the clone record exists').toBeTruthy();
+    expect(clone.managed_by, "this org's row").toBe('admin');
+    expect(clone.package_id ?? null, 'no upgrade linkage').toBeNull();
+    expect(JSON.parse(clone.system_permissions)).toEqual(['setup.access', 'ops.export_data']);
+    expect(JSON.parse(clone.row_level_security).map((p: any) => p.name)).toEqual(['ops_own_rows']);
+    expect(JSON.parse(clone.tab_permissions)).toEqual({ app_ops: 'default_on', app_admin: 'hidden' });
+
+    // The base is untouched by all of this (pin 3's invariant, re-checked on
+    // the richer shape — a payload that now carries five facets is a payload
+    // with five more chances to write to the wrong row).
+    const base = ql.permRows.find((r: any) => r.id === 'ps_rich');
+    expect(JSON.parse(base.system_permissions), 'the package-declared base still declares its own').toEqual(
+      ['setup.access', 'ops.export_data'],
+    );
+    expect(base.name).toBe('ops_console');
+  });
+
+  it('CONTROL — admin_scope is deliberately NOT carried (ADR-0090 D12), and the dialog says so', async () => {
+    // ⭐ POSITIVE CONTROL FIRST. Without it "the clone has no admin_scope" is
+    // satisfied by a base that never had one, and this test would pin nothing.
+    const baseRow = richRow();
+    expect(baseRow.admin_scope, 'the base carries a delegated-admin scope to lose').toBeTruthy();
+    expect(JSON.parse(baseRow.admin_scope).businessUnit).toBe('field_ops');
+
+    // It is not on the wire…
+    const payload = clonePayload(baseRow, { label: 'Ops Console (local)', name: 'ops_console_local' });
+    expect(Object.keys(payload), 'the clone dialog never sends admin_scope').not.toContain('admin_scope');
+
+    // …and it is not on the clone.
+    const ql = makeQl([richSet()]);
+    const protocol = makeHatchOpenProtocol(ql, { ops_console: richSet() });
+    registerPermissionSetProjection(protocol, { ql });
+    ql.permRows.push(baseRow);
+    const mw = makeMiddleware(ql, protocol);
+    await run(mw, {
+      object: 'sys_permission_set', operation: 'insert', context: userCtx, data: payload,
+    });
+
+    const body = protocol.saves.find((s: any) => s.name === 'ops_console_local')?.item;
+    expect(body, 'the clone was authored').toBeTruthy();
+    expect(body.adminScope, 'a delegated-admin authority is a privilege decision, never a field copy').toBeUndefined();
+    const clone = ql.permRows.find((r: any) => r.name === 'ops_console_local');
+    expect(clone.admin_scope ?? null, 'and the column stays empty on the clone').toBeNull();
+
+    // ⭐ The exclusion has to READ as a decision to the admin standing in the
+    // dialog — otherwise it is the same silent drop #11703 reports, merely
+    // ruled. The dialog's own explanatory line carries it.
+    const description = String(cloneAction().description ?? '');
+    expect(description, 'the clone dialog states the exclusion').toMatch(/delegated-admin scope/i);
+    expect(description, 'and states that it is not copied').toMatch(/not copied/i);
   });
 });
 

--- a/packages/plugins/plugin-security/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/en.objects.generated.ts
@@ -290,6 +290,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       clone_permission_set: {
         label: "Clone",
+        description: "Copies this set's permissions into a new organization-owned set you can edit. Delegated-admin scope is not copied — grant it deliberately on the new set if it needs one.",
         successMessage: "Permission set cloned",
         params: {
           label: {

--- a/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
@@ -290,6 +290,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       clone_permission_set: {
         label: "Clonar",
+        description: "Copia los permisos de este conjunto en un nuevo conjunto propiedad de la organización que puedes editar. El alcance de administración delegada no se copia: concédelo deliberadamente en el nuevo conjunto si lo necesita.",
         successMessage: "Conjunto de permisos clonado",
         params: {
           label: {

--- a/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
@@ -290,6 +290,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       clone_permission_set: {
         label: "複製",
+        description: "このセットの権限を、編集可能な組織所有の新しい権限セットにコピーします。委任管理スコープはコピーされません。新しいセットに必要な場合は、個別に付与してください。",
         successMessage: "権限セットを複製しました",
         params: {
           label: {

--- a/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
@@ -290,6 +290,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       clone_permission_set: {
         label: "克隆",
+        description: "将此权限集的权限复制到一个新的、由组织拥有且可编辑的权限集。委派管理范围不会被复制——如果新权限集需要，请单独在其上授予。",
         successMessage: "已克隆权限集",
         params: {
           label: {


### PR DESCRIPTION
Fixes #11703

## What changed

`clone_permission_set` POSTs its `params` **values** to `/api/v1/data/sys_permission_set`, so the params list *is* the payload. It named two of the six definition facets a `sys_permission_set` row carries — `object_permissions` and `field_permissions` — leaving `system_permissions`, `row_level_security` and `tab_permissions` absent from the body. `permissionSetBodyFromRow()` then read each one through `parseMaybeJson(undefined, …)` and filled the empty default, so cloning a set that granted `setup.access`, or one carrying row-level security policies, produced a clone with none of them: record created, success toast fired, and the missing half discoverable only by diffing the two records.

The three now travel, in the same JSON-string shape the two listed columns already used.

## Why this was urgent rather than tidy

PR #11702 landed one commit before this branch point. The save door now refuses an in-place edit of a package-declared permission set **and its refusal message tells the admin to clone** — so this action became the platform's own recommended remedy while it was still dropping three facets. An admin following that instruction lost grants quietly. The failure direction was fail-closed (fewer grants), which is exactly why nobody noticed.

## `admin_scope` — deliberately not copied

Ruled by the maintainer, 2026-08-24: putting an ADR-0090 D12 delegated-admin authority onto a brand-new organization-owned set on the admin's behalf is a **privilege decision, not a field copy**. The action's `description` now states the exclusion and why, so it reads to the admin standing in the dialog as a decision rather than as the same silent drop this card reports:

> Copies this set's permissions into a new organization-owned set you can edit. Delegated-admin scope is not copied — grant it deliberately on the new set if it needs one.

That is a new translatable leaf, so the four `plugin-security` bundles are regenerated with the documented `os i18n extract` command and the three non-English locales are translated by hand rather than left at the `--fill=default` English seed — `check:i18n-coverage` holds this package at **zero** untranslated strings, and an English sentence beside 克隆 / 複製 / Clonar would have been a visible regression regardless of the ratchet.

## The pin, and why it is shaped this way

`packaged-permission-set-lock.test.ts` gains **pin 6**. Its existing pin 3 already drives the data door through the clone path — and stayed green throughout this defect, because it hand-writes the payload. It pins what the *server* does with a payload, never what the *action definition* chooses to put in one.

So pin 6 assembles the payload by **reading the action's params list** (`clonePayload()` is the clone dialog in miniature: `defaultFromRow` params seeded from the source row, inline params carrying what the admin typed, `bodyExtra` merged in). Editing that params list is what moves this suite — which is the point, since editing that list is how the class got here.

Two deliberate choices:

- **Identities, not counts.** `toHaveLength(5)` holds constant while two facets swap, and asserting a facet is merely *present* passes on the `[]` / `{}` that **is** the bug. Every facet is asserted against a named, non-empty value, on both the metadata body that gets enforced and the row columns an admin diffs.
- **The exclusion carries a positive control.** The base fixture holds a real `admin_scope` (asserted first — otherwise "the clone has none" is satisfied by a base that never had one), and the clone still has none.

## Verification

All of the below on the final commit `9b7f93c` (union re-run after the last commit, not before it).

**Red → green, test-first on an otherwise unmodified tree.** The failing pin was written and the expected signature recorded in writing *before* any source edit — no ablation, so no restore could silently fail.

```
BEFORE (source unmodified):  Test Files 1 failed (1) · Tests 3 failed | 13 passed (16)
  AssertionError: the params list is what the dialog sends …:
      expected [ 'description', …(2) ] to deeply equal [ 'description', …(5) ]
  AssertionError: system permissions — [] here IS the #11703 silent drop:
      expected [] to deeply equal [ 'setup.access', 'ops.export_data' ]
  AssertionError: the clone dialog states the exclusion: expected '' to match /delegated-admin scope/i

AFTER:                       Test Files 1 passed (1) · Tests 16 passed (16)
```

The predicted signature matched the observed one on all three, including the *direction*: the payload **omits** columns and the door fills empty defaults, so this is a wrong-value failure, not a throw. A bare `toThrow()` would have been green in both states.

**Package suites** — `@objectstack/plugin-security`: `Test Files 79 passed (79) · Tests 1512 passed (1512)`; `typecheck` (`tsc --noEmit`) clean.

**Gates**, derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` on a clean tree after the final commit (no path arguments — the script takes its own change set from the merge base). Each exit code captured before any pipe; each line below is the gate's own verdict:

| gate | verdict |
| --- | --- |
| `check:changeset-gate-self-tests` | 118 + 212 + 116 assertions over real temp git repos |
| `check:cross-package-test-inputs` | `OK: 16 package(s) read outside themselves, all declared` |
| `check:engine-double-contract` | `OK — 401 pinned, 133 in the DEBT ledger, 2 exempt` |
| `check:where-matcher` | `295 matcher(s) discovered, 295 answer the combinator battery correctly or refuse it loudly` |
| `check:slot-lookup` | `ratchet holds: 107 unswept site(s) … none new` |
| `check:query-options-erasure` | `ratchet holds: 67 unswept non-test site(s) … none new` |
| `check:published-files` | `69 publishable package(s) of 78 workspace member(s)` |
| `check:test-source-alias` | `OK — 72 packages with tests scanned` |
| `check:type-source-resolution` | `OK — 77 packages with a tsconfig.json scanned` |
| `check:type-check-coverage` | `OK — 65/78 workspace packages type-checked` |
| `check:type-check-debt` | `--re-measure: OK — 32 ledger entr(ies) re-measured, 1898 raw tsc error(s) total, none above its recorded number` |
| `check:i18n` | `OK (9 package(s) — all bundles in sync)`; `plugins/plugin-security in sync (4 bundle(s))` |
| `check:i18n-coverage` | `OK (12 config(s), 657 baselined untranslated string(s), none new)` |
| `check:objectui-changeset` | `--self-test: all checks passed` |
| `check-adr-0087-registration` | `this PR adds no declared-breaking changeset` |
| `check-changeset-no-major` | `This diff introduces no major bump` |
| `check-empty-changeset` | `No empty-frontmatter changeset introduced by this diff` |
| `check-plugin-teardown-shape` | `63 Plugin implementation(s) … SHRINK-ONLY, baseline fully burned down` |
| `docs-audit/check-affected-docs` | exit 0 |
| `pm/release-rehearsal-clone --self-test` | `self-test passed` |

No ratchet artifact was rewritten — the tree is clean after the full union, and `engine-double-contract.baseline.json` (shrink-only) and `.pinned.json` are both untouched. The new pin introduces **no** new engine double: it reuses this file's existing `makeQl`, which already routes `update`/`delete` through `assertEngineUpdateDispatch` / `assertEngineDeleteDispatch`.

**One gate caught a real defect in this PR's own test code**, worth recording because the package's own typecheck could not see it. `check:type-check-debt --re-measure` measures `plugin-security` with its `**/*.test.ts` exclusion dropped, and there the first commit cost **+2** raw errors (11 → 13) on a shrink-only ledger: tsc infers `richRow()`'s object-literal type and drops the index signature `permissionSetRowFields()` spreads in, so the exclusion control's direct `.admin_scope` read is a `TS2339`. Fixed at the source (an explicit return annotation) — the ledger is untouched, and a re-measure reports **11**, matching the recorded entry exactly, with zero errors in this file.

## Scope notes

**Clause ② re-verified against the tree, not inherited: the accept surface does not move.** `permissionSetBodyFromRow()` already read all six columns before this change (`packages/plugins/plugin-security/src/permission-set-projection.ts`), and `PermissionSetSchema` already declared all six facets. What changed is the payload the action **emits**. No public surface widens; no `packages/spec` path is touched.

**One inaccuracy in the card, corrected rather than transcribed.** The repro sketch names `member_default` as "a set whose `system_permissions` is non-empty". Measured on this tree it is not: the platform `member_default` carries a large `rowLevelSecurity` (17+ policies) and **no** system permissions, and the showcase's `showcase_member_default` carries neither — the ADR-0090 D7 lint hard-blocks system permissions on any everyone-suggested set. The defect is real either way, and `member_default` is if anything a *better* repro than the card claimed, since it is the platform baseline set every member holds and a clone of it dropped all 17 policies. The pin therefore uses a fixture carrying all six facets at once, which is the only shape that measures all three added facets in one pass; the reasoning is recorded in the fixture's docblock so the next reader is not sent back to the wrong example.

**The dialog design question is filed, not fixed.** `defaultFromRow` params render as editable inputs, so this change takes the Clone dialog from two prefilled JSON blobs to five. Ruling clause ③ put that in the objectui lane and ruled it must not hold this deliverable; it is filed separately as #11753 with the three candidate shapes and the note that its failure direction — a hand-edited RLS blob that is valid JSON but wrong — is *not* fail-closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_