### PR TITLE
ci: adopt the setup-pnpm composite action at all 16 remaining Corepack sites

### DIFF
--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/cut-rc.yml
+++ b/.github/workflows/cut-rc.yml
@@ -339,11 +339,8 @@ jobs:
           # hotcrm@v1.2.0, whose manifest pins engines.node >=22.
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,8 +56,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash
@@ -2496,11 +2496,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash
@@ -3072,11 +3069,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash
@@ -3249,11 +3243,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash
@@ -3443,11 +3434,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -423,11 +423,11 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
+      - name: Setup pnpm
         if: >-
           steps.labels.outputs.skip != 'true'
           && steps.diffbase.outputs.base_error == ''
-        run: corepack enable
+        uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         if: >-

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -191,8 +191,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,11 +274,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash
@@ -507,9 +504,9 @@ jobs:
 
       # Everything below is skipped on the overwhelmingly common path (nothing to
       # repair), which is why the install is here rather than at the top of the job.
-      - name: Enable Corepack
+      - name: Setup pnpm
         if: steps.audit.outputs.releases-missing == 'true'
-        run: corepack enable
+        uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         if: steps.audit.outputs.releases-missing == 'true'
@@ -670,11 +667,8 @@ jobs:
             echo "  see the run's deployment history for the reviewer and timestamp"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/rerun-safety-nightly.yml
+++ b/.github/workflows/rerun-safety-nightly.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/spec-liveness-check.yml
+++ b/.github/workflows/spec-liveness-check.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/validate-deps.yml
+++ b/.github/workflows/validate-deps.yml
@@ -39,11 +39,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
Fixes #11369

`corepack enable` only writes shims — the pnpm tarball is fetched from
`registry.npmjs.org` on the **first** `pnpm` invocation in the job. Every such site is
an independent chance for a network flake to fail a job for a reason unrelated to the
code under test. The `setup-pnpm` composite action removes that call by restoring the
Corepack store from the actions cache; #11300 introduced it and cleared `ci.yml`. This
PR applies it to the ten workflows that still carried a Corepack site.

## Scope: widened from the card's 2 files to the full population of 10

The card names `lint.yml` + `spec-liveness-check.yml`, correctly, for **queue-ejection**
exposure (7 of the 24 jobs in a merge-queue build). The remaining eight workflows carry
the identical per-job download outside that frame, and three of them change the *risk
class* rather than the count: `release.yml` and `cut-rc.yml` fail a **release** rather
than ejecting a re-queueable PR, and `publish-smoke.yml` turns a network flake into
"the release candidate is bad". Widening was the dispatching PM's call, made explicitly.

## Non-vacuity: counts across `.github/workflows/`, both directions

| pin | before (`2a6122bd9`) | after (`5796ff6a3`) | delta |
|---|---|---|---|
| `corepack enable` occurrences | 16 | **0** | −16 |
| files containing `corepack enable` | 10 | **0** | −10 |
| `uses: ./.github/actions/setup-pnpm` | 7 | **23** | **+16** (matching) |
| `name: Verify pnpm version` steps | 8 | 0 | −8 (folded into the composite) |
| `uses: actions/setup-node@` steps | 32 | **32** | **0 — invariant** |

The −16 and the +16 are the same 16 sites, which is what makes the count a measurement
rather than an artefact of one probe. Controls, each zero paired with a positive:
`corepack enable` in `ci.yml` = 0 while `Setup pnpm` in `ci.yml` = 14 (the grep is live
and #11300's removal is complete); `corepack disable` across all workflows = 0 (the probe
is not indiscriminate).

## Per-site classification — all 16 sites, in 16 distinct jobs

Every site was read individually rather than assumed uniform. All 16 sit in a job that
runs `checkout` → `setup-node` → Corepack, on `ubuntu-latest`, with no `container:`, no
checkout `path:`/`repository:`, and no `corepack prepare`/explicit version activation
anywhere in the tree.

**Class A — plain mechanical swap (14 sites).** Identical to the shape `ci.yml` already
landed.

| workflow | job | paired `Verify pnpm version`? |
|---|---|---|
| `lint.yml` | `lint` | no |
| `lint.yml` | `typecheck-source-gates` | yes |
| `lint.yml` | `typecheck-workspace` | yes |
| `lint.yml` | `typecheck-debt` | yes |
| `lint.yml` | `typecheck-consumers` | yes |
| `spec-liveness-check.yml` | `liveness` | no |
| `cut-rc.yml` | `cut` | yes |
| `release.yml` | `version-pr` | yes |
| `release.yml` | `publish` | yes |
| `validate-deps.yml` | `validate` | yes |
| `publish-smoke.yml` | `pack-smoke` | no |
| `coverage-nightly.yml` | `coverage` | no |
| `rerun-safety-nightly.yml` | `rerun-safety` | no |
| `scaffold-e2e.yml` | `scaffold-local` | no |

**Class B — mechanical, but only with the caller's `if:` carried verbatim (2 sites).**
These were the two sites that were *not* a blind swap:

| workflow | job | condition carried |
|---|---|---|
| `pr-automation.yml` | `changeset-check` | `steps.labels.outputs.skip != 'true' && steps.diffbase.outputs.base_error == ''` (a folded `>-` scalar, kept verbatim) |
| `release.yml` | `release-integrity` | `steps.audit.outputs.releases-missing == 'true'` |

Both gate a following `pnpm install` on the *same* condition, so the composite inherits
exactly the reachability the `corepack enable` step had. `release-integrity`'s Corepack
step is deliberately deferred to the repair path rather than sitting at the top of the
job; the composite stays in that position and the comment explaining the deferral is
untouched.

**Zero sites were left unconverted.** Nothing in the population pinned a different pnpm
version, passed different flags, or ran Corepack at a point the composite changes.

## Two preconditions checked rather than assumed

- **`publish-smoke.yml` / `pack-smoke` checks out a non-default ref**
  (`needs.resolve.outputs.ref`), and `uses: ./…` resolves from the *checked-out tree* —
  so a ref without the composite would hard-fail. It cannot arise: on `workflow_run` the
  ref is the open `changeset-release/main` head, a descendant of `main`; on
  `workflow_dispatch` the ref is `github.ref`, which is also where the workflow file
  itself comes from, so file and tree always agree.
- **`coverage-nightly.yml` / `rerun-safety-nightly.yml` use `actions/cache/restore@v6`
  (restore-only) for their pnpm *store*.** The composite embeds a save-capable
  `actions/cache@v6` for the *Corepack* store. Naming it rather than hiding it: the
  restore-only comment is attached to the pnpm-store step and is about that cache, and
  the Corepack entry is keyed on the `packageManager` pin alone (one small entry
  repo-wide, saved only on a miss — which `ci.yml` on `main` will already have filled).

## The census constraint the card states, held

Each caller keeps its own `actions/setup-node` with its literal `node-version` pin.
`scripts/check-node-version.mjs` scans `.github/workflows/*.yml` only and reports how many
setup-node steps it audited; folding those steps into the composite would drop them from
its census while it still printed `OK`. It still reports **32 setup-node steps across 26
workflows**, byte-identical to the pre-change census.

## Verification — gate union at `5796ff6a3`, 18/18 green

Gate families derived from the real changeset via
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (10 paths vs merge
base `2a6122bd9`), not from a hand-written list. Quoting each gate's own verdict line:

```
check-node-version: OK (32 setup-node step(s) across 26 workflow(s), all on Node 22).
check-workflow-status-functions: OK (scanned 26 workflow file(s), 49 job(s), 25 job-level
  if: expression(s); 10 read needs.*.outputs.*, all naming a status function).
check-step-collectors: 327 `run:` steps across 26 workflow(s) ...
check-aggregator-roster: 3 aggregator(s) across 2 workflow(s); roster == needs: in both
  directions, and all 3 required-context aggregate(s) declared.
check-required-contexts: 6 required context name(s) pinned across 2 workflow(s) ...
check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) ...
check-nul-bytes: OK (scanned 6568 text file(s) ... no raw ASCII control bytes).
```

Those gates parse the workflow files themselves, so their green is a real measurement
over the edited files rather than a bystander pass. All 10 files additionally re-parse as
valid YAML with the expected composite-step count per job.

One family in the derived set, `check:type-check-debt` (`--re-measure`), **declined to
run** rather than failing: it refuses without a built TypeScript closure, because a number
measured from an unbuilt tree would silently record a different world. This diff contains
zero TypeScript, and its non-`--re-measure` sibling `check:type-check-coverage` is green.

No changeset: this PR is `.github/workflows/**` only and releases nothing, so it takes the
`skip-changeset` route.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_