### PR TITLE
fix(spec): stop offering a master_detail the deleteBehavior its schema refuses

### DIFF
--- a/.changeset/field-designer-master-detail-delete-behavior-options.md
+++ b/.changeset/field-designer-master-detail-delete-behavior-options.md
@@ -1,0 +1,51 @@
+---
+'@objectstack/spec': patch
+---
+
+The field designer no longer offers a `master_detail` a `deleteBehavior` the schema refuses
+
+#9689 made `deleteBehavior: 'set_null'` authored on a `master_detail` field a
+named parse-time rejection. The two shipped metadata forms that let a Studio
+author pick that value did not move with it, so the designer kept offering
+"Set null" for a `master_detail` — the author picked it and learned only at
+publish, from a 422, that the choice was never legal. Declared-vs-enforced, one
+seam earlier than the parse door.
+
+Both forms failed the same way through **different option sources**, which is
+why the repair is not one edit twice:
+
+- `object.form.ts` declared an inline `options` array carrying all three values
+  behind a single `visibleWhen` that named both `lookup` and `master_detail`.
+- `field.form.ts` declared **no** `options` at all. That is not a narrower
+  offer — it is the renderer's derived source: with no inline list the
+  metadata-admin form falls through to the JSON Schema `enum`, which is
+  `['set_null','cascade','restrict']` and additionally advertises
+  `default: 'set_null'`. A Zod enum has no per-type narrowing to give, so the
+  derived path re-offers the refused value by construction, and `master_detail`
+  can only be served by an explicit list.
+
+Both now declare the control **twice, with disjoint `visibleWhen`** — `lookup`
+keeps all three outcomes, `master_detail` is offered `cascade` and `restrict`
+only. Nothing is taken away from `lookup`, where all three remain legal:
+`object.form.ts` keeps its three-value list unchanged, and `field.form.ts`'s
+`lookup` branch keeps deriving from the enum exactly as before, so its labels
+and their translation are untouched. The two branches are mutually exclusive, so
+no author ever sees both.
+
+**Per-option `visibleWhen` was the tighter-looking spelling and was measured and
+rejected.** `SelectOptionSchema` does declare it (ADR-0068), so it reads as
+existing vocabulary, but it is not reachable from a metadata form in either
+direction: the metadata-admin renderer maps `fieldSpec.options` straight to
+select items and never consults it, so writing one would ship an ADR-0049
+declared-but-unenforced key; and on the runtime surface that *does* honor it,
+the per-option evaluator binds `record` and never `data`, so a `data.`-rooted
+predicate there is an unbound identifier whose visibility fails **open**,
+keeping the option. Either way the author would still have been offered
+"Set null" — a fix that silently does nothing. Field-level `visibleWhen` is the
+predicate the renderer already evaluates for every other type-conditional
+control in these files, so the split uses it and the form DSL is unchanged.
+
+The pinning test asserts more than the absent value: it requires **exactly one**
+visible control per type, because two declarations of one key can fail by
+overlapping (two selects writing one key) as well as by leaving a gap (the
+control vanishes for that type).

--- a/packages/lint/src/validate-predicate-path-refs.test.ts
+++ b/packages/lint/src/validate-predicate-path-refs.test.ts
@@ -9,7 +9,9 @@
  * metadata forms this repo actually SHIPS (`METADATA_FORM_REGISTRY`), which is
  * both the corpus count the widening discipline requires before an `error`-level
  * gate may land, and the reverse verification — restoring #6254's pre-fix
- * `object.form.ts` spellings must turn the count from 0 to 16.
+ * `object.form.ts` spellings must turn the count from 0 to the number of
+ * `data.type`-rooted predicates that form ships today (17; #6254 itself
+ * measured 16, and #11410 added the second `deleteBehavior` declaration).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -474,7 +476,7 @@ describe('registry wiring', () => {
 // ────────────────────────────────────────────────────────────────────────────
 //
 // `METADATA_FORM_REGISTRY` is the whole population of `data.`-rooted predicates
-// this repo ships (17 forms; 46 predicates, all `visibleWhen`). Every entry is a
+// this repo ships (17 forms; 48 predicates, all `visibleWhen`). Every entry is a
 // `defineForm` output, i.e. exactly the bare FormView shape `formViewSites`
 // walks as its `self` rung — so the corpus is fed through the rule's PRODUCTION
 // entry point, not through a parallel walker written for the test.
@@ -498,7 +500,7 @@ describe('#7010 corpus — shipped METADATA_FORM_REGISTRY', () => {
     // this way. The obvious version — "resolve every form against an empty
     // schema, expect a finding per predicate" — is WRONG here and was measured
     // wrong: an empty schema also fails to resolve the `fields` repeater, so the
-    // walk stops before the 16 sub-field predicates and the count comes out
+    // walk stops before the 17 sub-field predicates and the count comes out
     // BELOW the corpus while looking like proof of reach.
     //
     // So keep the real schemas (descent works exactly as in production) and
@@ -529,7 +531,7 @@ describe('#7010 corpus — shipped METADATA_FORM_REGISTRY', () => {
       for (const value of Object.values(rec)) corrupt(value);
     };
     corrupt(corrupted.views);
-    expect(predicates, 'the shipped metadata forms carry no predicates at all').toBe(46);
+    expect(predicates, 'the shipped metadata forms carry no predicates at all').toBe(48);
 
     const findings = validatePredicatePathRefs(corrupted);
     expect(findings).toHaveLength(predicates);
@@ -596,7 +598,7 @@ describe('#7010 corpus — shipped METADATA_FORM_REGISTRY', () => {
       for (const value of Object.values(rec)) rewrite(value);
     };
     rewrite(corrupted.views);
-    expect(comparisons, 'no shipped predicate carries an `==`/`!=` literal comparison').toBe(45);
+    expect(comparisons, 'no shipped predicate carries an `==`/`!=` literal comparison').toBe(47);
 
     const rhsFindings = validatePredicatePathRefs(corrupted)
       .filter((f) => f.rule === PREDICATE_RHS_PATH_SHAPED);
@@ -607,9 +609,16 @@ describe('#7010 corpus — shipped METADATA_FORM_REGISTRY', () => {
   it('catches the pre-#6254 bare spellings when they are restored (reverse verification)', () => {
     // The reverse direction is RED-on-restore: #6254 rewrote 16 predicates in
     // `object.form.ts` from `type ...` to `data.type ...`. Restoring the bare
-    // spelling on a deep copy of the shipped `object` form must produce exactly
-    // 16 `predicate-path-unrooted` findings — the count the issue measured, and
-    // the count this rule exists to have caught before it shipped.
+    // spelling on a deep copy of the shipped `object` form must produce one
+    // `predicate-path-unrooted` finding per `data.type`-rooted predicate the
+    // form ships — the class the issue measured, and the class this rule exists
+    // to have caught before it shipped.
+    //
+    // The count tracks the CORPUS, not the issue: it is 17 today because
+    // #11410 split `deleteBehavior` into two declarations with disjoint
+    // `visibleWhen` (`lookup` / `master_detail`), so a `master_detail` author is
+    // no longer offered a `set_null` the schema refuses. #6254's own measurement
+    // was 16 and stays 16 — that number is history, this one is a census.
     const objectForm = structuredClone(METADATA_FORM_REGISTRY.object) as Record<string, unknown>;
     let restored = 0;
     const debare = (node: unknown): void => {
@@ -636,10 +645,13 @@ describe('#7010 corpus — shipped METADATA_FORM_REGISTRY', () => {
       for (const value of Object.values(rec)) debare(value);
     };
     debare(objectForm);
-    expect(restored, 'the 16 sites #6254 rewrote are no longer where this test looks').toBe(16);
+    expect(
+      restored,
+      "the object form's `data.type`-rooted predicates are no longer where this test looks",
+    ).toBe(17);
 
     const findings = validatePredicatePathRefs({ views: [objectForm] });
-    expect(findings).toHaveLength(16);
+    expect(findings).toHaveLength(17);
     expect(new Set(findings.map((f) => f.rule))).toEqual(new Set([PREDICATE_PATH_UNROOTED]));
     expect(findings[0].message).toContain('`type`');
   });

--- a/packages/spec/src/data/field.form.ts
+++ b/packages/spec/src/data/field.form.ts
@@ -46,7 +46,32 @@ export const fieldForm = defineForm({
         { field: 'options', type: 'repeater', visibleWhen: "data.type == 'select' || data.type == 'multiselect'", helpText: 'Available options (label/value pairs)' },
         // Reference field options
         { field: 'reference', widget: 'ref:object', visibleWhen: "data.type == 'lookup' || data.type == 'master_detail'", helpText: 'Referenced object name' },
-        { field: 'deleteBehavior', visibleWhen: "data.type == 'lookup' || data.type == 'master_detail'", helpText: 'What happens when referenced record is deleted' },
+        // Two declarations of one key, with disjoint `visibleWhen` (#11410) —
+        // the same split `object.form.ts` carries, and for the same reason:
+        // #9689 made `set_null` on a `master_detail` a parse-time rejection, so
+        // one shared control offered a choice publish refuses.
+        //
+        // This file reached that defect by the OTHER route. It declares no
+        // `options`, which is not a narrower offer but the renderer's DERIVED
+        // source: with no inline list the metadata-admin form falls through to
+        // the JSON Schema `enum` — `['set_null','cascade','restrict']`, which
+        // additionally advertises `default: 'set_null'`. A Zod enum has no
+        // per-type narrowing to give, so `master_detail` can only be served by
+        // an EXPLICIT list; omitting one re-offers the refused value.
+        //
+        // `lookup` keeps deriving from that enum, untouched: all three outcomes
+        // are legal there, and leaving the source alone keeps its labels and
+        // their translation exactly as they are today. The two branches are
+        // mutually exclusive, so no author ever sees both spellings at once.
+        //
+        // `helpText` is identical on both — they share one i18n key
+        // (`metadataForms.field.fields.deleteBehavior`), so divergent text would
+        // collide silently.
+        { field: 'deleteBehavior', visibleWhen: "data.type == 'lookup'", helpText: 'What happens when referenced record is deleted' },
+        { field: 'deleteBehavior', type: 'select', visibleWhen: "data.type == 'master_detail'", helpText: 'What happens when referenced record is deleted', options: [
+          { label: 'Cascade (delete children)', value: 'cascade' },
+          { label: 'Restrict (block the delete)', value: 'restrict' },
+        ] },
       ],
     },
     {

--- a/packages/spec/src/data/form-delete-behavior-options.test.ts
+++ b/packages/spec/src/data/form-delete-behavior-options.test.ts
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #11410 — the field designer must not OFFER a `deleteBehavior` the schema
+ * REFUSES.
+ *
+ * #9689 (PR #11406) made `deleteBehavior: 'set_null'` authored on a
+ * `master_detail` a named parse-time rejection. The two metadata forms that let
+ * a Studio author pick that value did not move with it: both declared ONE
+ * `deleteBehavior` control shared by `lookup` and `master_detail`, so a
+ * `master_detail` author was still offered "Set null", picked it, and learned
+ * only at publish (422) that the choice was never legal. Declared-vs-enforced,
+ * one seam earlier than the parse door.
+ *
+ * ## The two forms failed the same way through DIFFERENT option sources
+ *
+ * - `object.form.ts` declared an inline `options` array carrying all three
+ *   values, gated by one `visibleWhen` naming both types.
+ * - `field.form.ts` declared NO `options` at all. That is not a narrower
+ *   offer — it is the renderer's DERIVED source: with no `fieldSpec.options`
+ *   the metadata-admin form falls through to the JSON Schema `enum`, which is
+ *   `['set_null','cascade','restrict']` and additionally advertises
+ *   `default: 'set_null'`. A Zod enum has no per-type narrowing to give, so the
+ *   derived path re-offers the refused value by construction.
+ *
+ * Both are asserted below, and the derived-source half is asserted as a FACT
+ * about the enum rather than assumed — it is the reason the `master_detail`
+ * branch must carry an EXPLICIT list instead of simply omitting one.
+ *
+ * ## Why two selects with disjoint `visibleWhen`, and not per-option visibility
+ *
+ * `SelectOptionSchema` does declare a per-option `visibleWhen` (ADR-0068 /
+ * objectui#2284), so "hide just this option" looks like existing vocabulary.
+ * It is not reachable from a metadata form, measured twice:
+ *
+ *  1. The metadata-admin renderer (objectui `SchemaForm.tsx`) maps
+ *     `fieldSpec.options` straight to `<SelectItem>` and never consults
+ *     `opt.visibleWhen`. Writing one would ship an ADR-0049
+ *     declared-but-unenforced key — the author would still be offered
+ *     "Set null".
+ *  2. Where per-option visibility IS honored (the runtime form's
+ *     `resolveCascadingOptions` -> `evalFieldPredicate`), the predicate scope
+ *     binds `record` / `previous` / `extra` and has NO `data`. A metadata form
+ *     spells its predicates `data.*`, so a `data.`-rooted per-option predicate
+ *     is an unbound identifier, and visibility's fallback is TRUE — the option
+ *     would be KEPT. A fix that silently does nothing.
+ *
+ * Field-level `visibleWhen` has neither problem: it is the predicate the
+ * renderer already evaluates as `evaluatePredicate(visibility, { data })` for
+ * every other type-conditional control in these two files. So the shape is two
+ * declarations of the same key with disjoint predicates — the existing
+ * vocabulary the triage fence named.
+ *
+ * ## What each assertion is protecting
+ *
+ * `exactly one visible declaration per type` is not a tidiness check. Two
+ * declarations of one key have two ways to go wrong that a bare
+ * "set_null is absent" assertion would not see: predicates that OVERLAP (both
+ * controls render, two selects writing one key) and predicates that leave a
+ * GAP (neither renders, the control silently disappears for that type — the
+ * same fail-CLOSED disappearance objectstack#6936 was filed about).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+import { objectForm } from './object.form';
+import { fieldForm } from './field.form';
+import { FieldSchema } from './field.zod';
+import { FormViewSchema } from '../ui/view.zod';
+
+// ────────────────────────────────────────────────────────────────────────────
+// The derived option source — what a declaration with NO `options` offers.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** `deleteBehavior`'s JSON Schema node, as the renderer's fallback reads it. */
+function derivedDeleteBehaviorNode(): { enum?: unknown[]; default?: unknown } {
+  const js = z.toJSONSchema(FieldSchema as unknown as z.ZodType, {
+    unrepresentable: 'any',
+    io: 'input',
+  }) as { properties?: Record<string, { enum?: unknown[]; default?: unknown }> };
+  const node = js.properties?.deleteBehavior;
+  if (!node) throw new Error('FieldSchema no longer exposes a `deleteBehavior` JSON Schema node');
+  return node;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// A deliberately tiny mirror of the metadata-admin predicate subset.
+//
+// This evaluator understands ONLY the spellings these two forms use. Anything
+// else THROWS rather than defaulting to "visible": a test that quietly assumed
+// visibility for a predicate it could not read would go green on a form it
+// never actually evaluated. Fail-closed on drift is the whole point — note this
+// is the opposite of the RENDERER's fail-open default, and deliberately so. The
+// renderer must not hide a control it cannot parse; a gate must not bless one.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** `visibleWhen` survives the parse as `{ dialect, source }`; accept both forms. */
+function predicateSource(spec: Record<string, unknown>): string | undefined {
+  const raw = spec.visibleWhen;
+  if (raw == null) return undefined;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object' && typeof (raw as { source?: unknown }).source === 'string') {
+    return (raw as { source: string }).source;
+  }
+  throw new Error(`unreadable visibleWhen on '${String(spec.field)}': ${JSON.stringify(raw)}`);
+}
+
+/** Evaluate one `data.type`-rooted clause. Throws on any unrecognised spelling. */
+function evalClause(clause: string, type: string): boolean {
+  const src = clause.trim().replace(/^\(|\)$/g, '').trim();
+
+  const eq = /^data\.type\s*==\s*'([^']*)'$/.exec(src);
+  if (eq) return type === eq[1];
+
+  const ne = /^data\.type\s*!=\s*'([^']*)'$/.exec(src);
+  if (ne) return type !== ne[1];
+
+  const inList = /^data\.type\s+in\s+\[([^\]]*)\]$/.exec(src);
+  if (inList) {
+    const members = inList[1]
+      .split(',')
+      .map((m) => m.trim())
+      .filter((m) => m.length > 0)
+      .map((m) => {
+        const lit = /^'([^']*)'$/.exec(m);
+        if (!lit) throw new Error(`non-literal member in \`in\` list: ${m}`);
+        return lit[1];
+      });
+    return members.includes(type);
+  }
+
+  throw new Error(`predicate spelling not covered by this test's evaluator: ${JSON.stringify(src)}`);
+}
+
+/** Evaluate a whole predicate (a `||` chain of clauses) for a given `data.type`. */
+function isVisibleForType(spec: Record<string, unknown>, type: string): boolean {
+  const src = predicateSource(spec);
+  if (src === undefined) return true;
+  return src.split('||').some((clause) => evalClause(clause, type));
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Locating the declarations
+// ────────────────────────────────────────────────────────────────────────────
+
+type Decl = { path: string; spec: Record<string, unknown> };
+
+/** Every form-field spec named `key`, at any depth (sections, repeater rows). */
+function findDeclarations(node: unknown, key: string, path = '$', out: Decl[] = []): Decl[] {
+  if (!node || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    node.forEach((n, i) => findDeclarations(n, key, `${path}[${i}]`, out));
+    return out;
+  }
+  const rec = node as Record<string, unknown>;
+  if (rec.field === key) out.push({ path, spec: rec });
+  for (const child of ['sections', 'fields'] as const) {
+    if (rec[child]) findDeclarations(rec[child], key, `${path}.${child}`, out);
+  }
+  return out;
+}
+
+/** Declared option VALUES, or `undefined` when the spec has no inline list. */
+function declaredOptionValues(spec: Record<string, unknown>): string[] | undefined {
+  const opts = spec.options;
+  if (!Array.isArray(opts) || opts.length === 0) return undefined;
+  return opts.map((o) => String((o as { value?: unknown }).value));
+}
+
+const FORMS = [
+  { name: 'objectForm', form: objectForm as unknown },
+  { name: 'fieldForm', form: fieldForm as unknown },
+] as const;
+
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('#11410 — `deleteBehavior` is never offered a value the schema refuses', () => {
+  describe('the derived option source, which is why an explicit list is required', () => {
+    it('offers all three values, and defaults to the one a master_detail refuses', () => {
+      const node = derivedDeleteBehaviorNode();
+      // A declaration with no inline `options` inherits exactly this set. It
+      // carries no per-type narrowing, so `master_detail` cannot be served by
+      // omission — only by an explicit list.
+      expect(node.enum).toEqual(['set_null', 'cascade', 'restrict']);
+      expect(node.default).toBe('set_null');
+    });
+  });
+
+  for (const { name, form } of FORMS) {
+    describe(name, () => {
+      const decls = findDeclarations(form, 'deleteBehavior');
+
+      it('declares the control at all', () => {
+        expect(decls.length, 'no `deleteBehavior` control found').toBeGreaterThan(0);
+      });
+
+      it('offers exactly one control to a master_detail author — no overlap, no gap', () => {
+        const visible = decls.filter((d) => isVisibleForType(d.spec, 'master_detail'));
+        expect(visible.map((d) => d.path)).toHaveLength(1);
+      });
+
+      it('offers exactly one control to a lookup author — no overlap, no gap', () => {
+        const visible = decls.filter((d) => isVisibleForType(d.spec, 'lookup'));
+        expect(visible.map((d) => d.path)).toHaveLength(1);
+      });
+
+      // THE DEFECT. A master_detail author must never see "Set null".
+      it('does not offer set_null to a master_detail author', () => {
+        const visible = decls.filter((d) => isVisibleForType(d.spec, 'master_detail'));
+        for (const d of visible) {
+          const values = declaredOptionValues(d.spec);
+          // An absent list is NOT a pass: it resolves to the derived enum,
+          // which carries set_null. The master_detail branch must narrow
+          // explicitly.
+          expect(
+            values,
+            `${d.path} declares no inline options, so it falls through to the derived enum `
+              + `(which offers set_null). The master_detail branch must declare an explicit list.`,
+          ).toBeDefined();
+          expect(values).not.toContain('set_null');
+          expect(values).toEqual(['cascade', 'restrict']);
+        }
+      });
+
+      // The other half of the ruling: nothing is taken away from `lookup`,
+      // where all three outcomes remain legal.
+      it('still offers all three values to a lookup author', () => {
+        const visible = decls.filter((d) => isVisibleForType(d.spec, 'lookup'));
+        expect(visible).toHaveLength(1);
+        const values = declaredOptionValues(visible[0].spec);
+        // Either spelling is a full offer: an explicit three-value list, or no
+        // list at all (deriving the same three from the schema enum). Both are
+        // asserted against the same expected set so neither form can narrow
+        // `lookup` unnoticed.
+        const offered = values ?? (derivedDeleteBehaviorNode().enum as string[]);
+        expect(offered).toEqual(['set_null', 'cascade', 'restrict']);
+      });
+
+      it('is expressible in the form DSL as it stands — no schema extension', () => {
+        // `defineForm` already parses at module load; re-parsing makes the
+        // claim an assertion rather than an import side effect. If the fix had
+        // needed a key the DSL does not declare, this is where it would fail.
+        const parsed = (FormViewSchema as unknown as z.ZodType).safeParse(form);
+        expect(parsed.success, JSON.stringify((parsed as { error?: unknown }).error)).toBe(true);
+      });
+    });
+  }
+
+  it('the two forms agree on what a master_detail may be offered', () => {
+    const sets = FORMS.map(({ form }) =>
+      findDeclarations(form, 'deleteBehavior')
+        .filter((d) => isVisibleForType(d.spec, 'master_detail'))
+        .flatMap((d) => declaredOptionValues(d.spec) ?? ['<derived>']),
+    );
+    expect(sets[0]).toEqual(sets[1]);
+  });
+});

--- a/packages/spec/src/data/object.form.ts
+++ b/packages/spec/src/data/object.form.ts
@@ -153,8 +153,44 @@ export const objectForm = defineForm({
             { field: 'lookupFilters', widget: 'json', helpText: 'Filter rules applied to the picker ({field, operator, value})', visibleWhen: "data.type in ['lookup','master_detail']" },
             // `deleteBehavior`, not a `cascadeDelete` boolean: the schema models
             // three outcomes, and only one of them is "cascade".
-            { field: 'deleteBehavior', type: 'select', helpText: 'What happens when the referenced record is deleted', visibleWhen: "data.type in ['lookup','master_detail']", options: [
+            //
+            // TWO declarations of one key, with disjoint `visibleWhen` (#11410).
+            // #9689 made `set_null` on a `master_detail` a named parse-time
+            // rejection, so a single shared option list offered a choice the
+            // publish door refuses — the author found out at the 422. The split
+            // is the narrowest shape the form DSL already supports: field-level
+            // `visibleWhen` is what the metadata-admin renderer evaluates as
+            // `evaluatePredicate(visibility, { data: row })`, exactly as it does
+            // for every other type-conditional control in this repeater.
+            //
+            // Per-option `visibleWhen` (`SelectOptionSchema`, ADR-0068) would be
+            // the tighter-looking spelling and is deliberately NOT used: the
+            // metadata-admin renderer maps `fieldSpec.options` straight to select
+            // items and never reads it, so it would ship an ADR-0049
+            // declared-but-unenforced key. And on the runtime surface that DOES
+            // honor it, the per-option evaluator binds `record`, never `data` —
+            // a `data.`-rooted predicate there is an unbound identifier, and
+            // visibility fails OPEN, keeping the option. Either way the author
+            // would still be offered "Set null".
+            //
+            // ⚠️ The predicates must stay disjoint AND total over the two types:
+            // an overlap renders two selects writing one key, a gap makes the
+            // control vanish for that type. Both are pinned in
+            // `form-delete-behavior-options.test.ts`.
+            //
+            // `helpText` is deliberately IDENTICAL on both. The i18n bundle keys
+            // form fields by field PATH (`metadataForms.<type>.fields.<path>`),
+            // so these two declarations share one translation key — divergent
+            // text here would collide silently, last writer winning.
+            { field: 'deleteBehavior', type: 'select', helpText: 'What happens when the referenced record is deleted', visibleWhen: "data.type == 'lookup'", options: [
               { label: 'Set null', value: 'set_null' },
+              { label: 'Cascade (delete children)', value: 'cascade' },
+              { label: 'Restrict (block the delete)', value: 'restrict' },
+            ] },
+            // `master_detail`: no `set_null`. A detail row without its master is
+            // the orphan the master-detail relationship exists to prevent, so
+            // the schema refuses the combination outright (#9689).
+            { field: 'deleteBehavior', type: 'select', helpText: 'What happens when the referenced record is deleted', visibleWhen: "data.type == 'master_detail'", options: [
               { label: 'Cascade (delete children)', value: 'cascade' },
               { label: 'Restrict (block the delete)', value: 'restrict' },
             ] },


### PR DESCRIPTION
Fixes #11410

The field designer offered "Set null" as a `deleteBehavior` for a `master_detail`
field — a combination #9689 (PR #11406, merged `9086761ed`) turned into a named
parse-time rejection. The author picked it and learned only at publish, from a
422, that the choice was never legal. Declared-vs-enforced, one seam earlier than
the parse door.

## Dispatch fence (triage comment 5389685394, quoted verbatim)

> pick within the form DSL's **existing** vocabulary (two selects with disjoint
> `visibleWhen` works today); ⛔ do not extend the DSL for one field — if no
> existing-vocabulary shape works, stop and report a fork instead.

Honored: the DSL is unchanged. The shape used is field-level `visibleWhen`, the
predicate the metadata-admin renderer already evaluates for every other
type-conditional control in these two files.

## Survey — which existing-vocabulary shape, and why

The card named three candidates. Both alternatives to the chosen shape were ruled
out by measurement, not by taste.

| Candidate | Verdict | Evidence |
|---|---|---|
| Per-option `visibleWhen` | **Rejected** | Key exists (`SelectOptionSchema`, ADR-0068), but is unreachable from a metadata form — see below |
| Option-source hook | **Does not exist** | No option-source key in `FormFieldBaseSchema`; the only sources are inline `options` or the derived JSON Schema `enum` |
| Two selects, disjoint `visibleWhen` | **Chosen** | Uses the exact call the renderer already makes: `evaluatePredicate(visibility, { data })` |

Per-option `visibleWhen` is the tighter-looking spelling and reads as existing
vocabulary. It is inert here in **both** directions:

1. The metadata-admin renderer maps `fieldSpec.options` straight to select items
   and never consults `opt.visibleWhen`. It calls `evaluatePredicate` only for
   section / field / repeater-row visibility. Writing a per-option predicate
   would ship an ADR-0049 declared-but-unenforced key.
2. On the runtime surface that *does* honor per-option visibility
   (`resolveCascadingOptions` to `evalFieldPredicate`), the scope binds `record`,
   `previous` and `extra` — and never `data`. A metadata form spells its
   predicates `data.*`, so a `data.`-rooted per-option predicate is an unbound
   identifier, and visibility's fallback is TRUE: the option is **kept**.

Either way the author would still be offered "Set null" — a fix that silently
does nothing. Zero `*.form.ts` in the repo uses per-option `visibleWhen` today.
Filed as #11793 so the next author who reaches for the key does not have to
re-measure it.

## The card's NEEDS-CHECKING half is answered: yes, it shares the defect

The card flagged whether `field.form.ts`'s option source narrows per type. It
does not, and it fails through a **different** mechanism than its sibling:

- `object.form.ts` declared an inline three-value `options` list behind one
  `visibleWhen` naming both types.
- `field.form.ts` declared **no** `options` at all. That is not a narrower offer
  but the renderer's derived source: with no inline list it falls through to the
  JSON Schema `enum`. Measured:
  `{"default":"set_null","type":"string","enum":["set_null","cascade","restrict"]}`
  — all three values, and `set_null` is additionally the advertised **default**.

A Zod enum has no per-type narrowing to give, so `master_detail` can only be
served by an explicit list; omitting one re-offers the refused value by
construction. This is why the repair is not one edit applied twice.

## What changed

Both forms declare the control twice, with disjoint `visibleWhen`:

- `lookup` keeps all three outcomes. `object.form.ts` keeps its three-value list
  byte-identically; `field.form.ts`'s `lookup` branch keeps deriving from the
  enum, so its labels and their translation are untouched.
- `master_detail` is offered `cascade` and `restrict` only.

The two branches are mutually exclusive, so no author ever sees both.

`helpText` is deliberately identical on both declarations in each file: the i18n
bundle keys form fields by field PATH, so the two declarations share one
translation key and divergent text would collide silently. This is not a
theory — `check:i18n` reports all 9 packages' bundles **in sync** with no
regeneration needed, which is the reading that would have moved had the two
declarations disagreed.

## Reverse verification

Test written first, run against **unfixed** source. Both readings are from the
same test file, `packages/spec/src/data/form-delete-behavior-options.test.ts`.

**RED — unfixed source** (`Test Files 1 failed | 420 passed (421)`,
`Tests 3 failed | 11229 passed (11232)`) — it failed by finding the offered
option, not by an unrelated error:

```
FAIL objectForm > does not offer set_null to a master_detail author
AssertionError: expected [ 'set_null', 'cascade', 'restrict' ] to not include 'set_null'

FAIL fieldForm > does not offer set_null to a master_detail author
AssertionError: $.sections[1].fields[10] declares no inline options, so it falls
through to the derived enum (which offers set_null). The master_detail branch
must declare an explicit list.: expected undefined to be defined

FAIL the two forms agree on what a master_detail may be offered
AssertionError: expected [ 'set_null', 'cascade', 'restrict' ] to deeply equal
[ the derived-source sentinel ]
```

(The third message's sentinel is spelled with angle brackets in the test source;
it is written out here because the GitHub body sanitizer strips short
angle-bracket fragments, which would have made it read as an empty string.)

The rest of the spec suite was green in that same run (11229 passed), so the
three failures are the new assertions alone.

**GREEN — fixed source**: `Test Files 1 passed (1)` · `Tests 14 passed (14)`.

## What the test pins beyond the absent value

`exactly one visible control per type` is asserted for both `lookup` and
`master_detail`. Two declarations of one key have two failure modes a bare
"set_null is absent" assertion would miss: predicates that **overlap** (two
selects writing one key) and predicates that leave a **gap** (the control
vanishes for that type). The test's own predicate evaluator throws on any
spelling it does not recognise rather than assuming visible — fail-closed on
drift, deliberately the opposite of the renderer's fail-open default.

## The second commit: a consumer census, not a weakened assertion

`packages/lint`'s `#7010 corpus` block pins the size of the shipped
`METADATA_FORM_REGISTRY` predicate population as **equalities** (deliberately,
so a subset can never satisfy the anti-vacuity guard). Adding one predicate to
each form moves three counts: total predicates 46 to 48, `==`/`!=` literal
comparisons 45 to 47, and the object form's `data.type`-rooted sites 16 to 17.

Counts only — no assertion weakened, no rule changed. The
`reports NOTHING over the shipped forms (corpus count = 0)` case stayed green
throughout, which is the independent evidence that the two new predicates
**resolve against the real schemas** rather than merely being counted. The
reverse-verification prose now separates two numbers it had conflated: #6254's
own measurement stays 16 (history), while the restore count tracks the corpus.

## Clause-②

Clause-②: no on the declaration limb (spec parse contract untouched — this
narrows what the Studio form offers); the path limb fires, so the
contract-review chain runs before enqueue; the PR stays draft.

## Verification

All readings taken at head `172b19c28`, after the final commit. Verdicts are
quoted from each gate's own output line, never from a piped `$?`.

| Check | Reading |
|---|---|
| `pnpm --filter @objectstack/spec test` (full) | `Test Files 421 passed (421)` · `Tests 11232 passed (11232)` |
| `pnpm --filter @objectstack/spec typecheck` | pass — incl. `check:test-typecheck: OK` (test layer compiles) |
| `pnpm --filter @objectstack/lint test` (consumer) | `Test Files 81 passed (81)` · `Tests 2280 passed (2280)` |
| `pnpm --filter @objectstack/lint typecheck` | pass |
| `pnpm --filter @objectstack/spec check:generated` | pass — no generator names these forms, so no regenerated artifact rides this PR |
| `check:i18n` | `OK (9 package(s) — all bundles in sync, no undeclared authoring keys)` |
| spec liveness family | `check:empty-state`, `check:liveness`, `check:strictness-ledger`, `check:variant-docs` — all pass |
| `check:cross-package-test-inputs` | pass (both the pnpm and `scripts/` invocations) |
| changeset family | `check:changeset-gate-self-tests`, `check-changeset-no-major`, `check-empty-changeset`, `check-adr-0087-registration`, `check:objectui-changeset`, `release-rehearsal-clone --self-test` — all pass |
| convention-triggered (new test file) | `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:type-check-coverage` — all pass |
| others named by derivation | `check:published-files`, `check:slot-lookup`, `check:spec-parsed-alias`, `check:test-source-alias`, `check:type-source-resolution`, `check:merge-driver`, `check-plugin-teardown-shape`, `check-affected-docs`, `check-nul-bytes` — all pass |

Gate list derived, not recalled:

> dispatch-gates: gate list derived from the tree of 'objectstack-ai/objectstack' at commit `172b19c28`
> dispatch-gates: change set derived from git — 5 path(s) vs merge base `2a6122bd9` of 'origin/main' and HEAD

Two items deliberately **not** claimed as green, so the distinction stays honest:

- `check-dev-prereqs` — red locally for one reason it names itself: "The
  workspace is not built". An environment precondition of this worktree, not a
  finding about this diff; CI builds first.
- `check:type-check-debt --re-measure` — **not measured** here. It refuses
  without the whole workspace closure built, and a refusal means *not measured*,
  never *not applicable*. Its structural half (`check:type-check-coverage`) is
  green, and spec's own `check:test-typecheck` confirms the new test file
  compiles under `tsconfig.test.json`.

Landing is the PM's — this PR stays draft and carries no auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_
