### PR TITLE
fix(docs-audit): derive the declLead key-spelling pin's population from the source

### DIFF
--- a/scripts/docs-audit/affected-docs.mjs
+++ b/scripts/docs-audit/affected-docs.mjs
@@ -3814,12 +3814,35 @@ function selfTest() {
   // from would leave the pin watching a door nobody uses any more.
   check('declLead', 'and the KEY anchor is spelled once too — no call site restates it', 'affected-docs.mjs',
     0, (ownSource.match(/declLead\([^\n]*?(?:\\b|\(\?<!)/g) || []).length);
-  // BEHAVIOURAL, not merely textual: the three key spellings the eight call sites pass all
-  // come back anchored, from the one place that spells the anchor. This is what "all eight
-  // read the same anchored spelling" means when checked rather than asserted.
+  // BEHAVIOURAL, not merely textual: every key spelling the eight call sites pass comes back
+  // anchored, from the one place that spells the anchor. This is what "all eight read the same
+  // anchored spelling" means when checked rather than asserted.
+  //
+  // The spellings are READ FROM THE SOURCE, never restated here (#11737). A hand-kept list
+  // carried three of the FOUR the call sites actually pass — `client`, the one `windowClientRe`
+  // passes, was missing — so a pin labelled "every key spelling" checked three quarters of
+  // them, and nothing else could see the gap: this pin compares STRINGS, so `(route|client)`
+  // never exercises `client`, and the three pins above count call sites and spellings by TEXT
+  // without ever calling the function. A corrected list re-rots the same way the moment a
+  // ninth call site arrives, which is why it is derived rather than corrected.
+  //
+  // Measured rather than argued: a `client`-only TIGHTENING of the allowlist — `(?<![^\s{,])`
+  // narrowed to `(?<![^\s])` for that one key — leaves all of `--self-test` green against the
+  // hand-kept list and fails HERE against the derived one. No fixture defends the `{` and `,`
+  // members, and none can: the sweep below measured 0 leads preceded by either across all
+  // seven live ledgers, so they are exactly the part of the allowlist that only a string pin
+  // can hold. Widening drifts are caught either way (the #11542/#11630 `myclient:`/`$client:`
+  // fixtures see those), so tightening is the whole of what this pin adds — and it is the
+  // direction a `simplification` takes.
+  //
+  // ⛔ Only the INPUT population is derived; the EXPECTED stays a literal. Deriving both ends
+  // is what would make the comparison vacuous, for the reason the sweep below spells out.
+  const passedKeys = [...ownSource.matchAll(/new RegExp\(declLead\((['"])([^'"]*)\1\)/g)].map((m) => m[2]);
+  check('declLead', 'and all eight pass their key as a LITERAL — a computed one drops out of the list below unseen', 'affected-docs.mjs',
+    8, passedKeys.length);
   check('declLead', 'every key spelling a call site passes comes back ANCHORED', 'declLead',
-    String.raw`(?<![^\s{,])(route|client)\s*:\s* | (?<![^\s{,])route\s*:\s* | (?<![^\s{,])(?:route|client)\s*:\s*`,
-    ['(route|client)', 'route', '(?:route|client)'].map((k) => declLead(k)).join(' | '));
+    String.raw`(?<![^\s{,])(?:route|client)\s*:\s* | (?<![^\s{,])(route|client)\s*:\s* | (?<![^\s{,])client\s*:\s* | (?<![^\s{,])route\s*:\s*`,
+    [...new Set(passedKeys)].sort().map((k) => declLead(k)).join(' | '));
   // …and BEHAVIOURALLY the allowlist is a strict TIGHTENING of BOTH anchors it has replaced,
   // which is the invariant the population pricing rests on. Swept rather than argued, and
   // swept against the anchor it ACTUALLY replaces (#11710's lookbehind) as well as against the


### PR DESCRIPTION
Fixes #11737

The `--self-test` pin labelled *"every key spelling a call site passes comes back ANCHORED"* compared a **hand-kept three-element list** against a literal, while the eight `new RegExp(declLead(…))` call sites pass **four** distinct spellings. The card is accurate: `client` — the spelling `windowClientRe` passes — was absent, so a pin naming *every* spelling checked three quarters of them.

## Verdict: the array moves, not the label — and it moves to being *derived*

The population, enumerated from the tree rather than from the card (all eight arguments parse as string literals, so the enumeration is complete — nothing computed escapes it):

| spelling | call sites | lines |
| --- | --- | --- |
| `(route\|client)` | 3 | 1508, 1637, 1877 |
| `route` | 3 | 1775, 1776, 1860 |
| `(?:route\|client)` | 1 | 1876 |
| **`client`** | **1** | **1777 (`windowClientRe`)** |

`new RegExp(declLead(` total **8**, parsed as literals **8**, distinct **4**. **There is no fifth spelling.**

Rather than correcting the list to four, the pin now **reads the population out of the source**. A corrected list re-rots the moment a ninth call site arrives with a fifth spelling — which is the same failure this family exists to close ("seven agreeing and one differing looked exactly like eight agreeing"), one level up. Only the **input** is derived; the **expected stays a literal**, so the comparison is not vacuous. A second pin asserts all eight keys parse as literals, so a computed key fails loudly instead of dropping out of the derived list unseen.

## Non-vacuity — the whole deliverable on this card

Every reading below is from a mutation **confirmed on disk** by grepping the injected text (a zero-hit edit reports exit 0 and would read as a clean run). All mutation scripts carry `trap … EXIT INT TERM` restores.

| mutation | list = 3 (before) | list = derived (after) | which case fires |
| --- | --- | --- | --- |
| none — control | green (417) | green (417) | — |
| `client`-only **tightening**: allowlist `(?<[^\s{,])` narrowed to `(?<[^\s])` | **green, 0 failures** | **RED, 1 failure** | the pin, and only the pin |
| a call site passes a **computed** key | n/a | RED, 2 failures | the new literal-count pin + the pin |
| a call site **changes its spelling** (`(?:route\|client)` to `(?:client\|route)`) | n/a (frozen list cannot see it) | RED, 1 failure | the pin — derivation is live |
| no-op edit elsewhere — negative control | green | green | — |

Row 2 is the demonstration the card asked for: a real, `client`-only behavioural drift that **all 416 cases pass through today** and that exactly one case catches after this change.

## Correcting the card's stated rationale

The card and the triage comment both reason that the behavioural pin *"would not see a regression that reached only the `client`-only spelling"*. **That is too strong, and I could not sustain it.** Measured: a `client`-only **widening** (allowlist back to `\b`) is caught today, by two fixtures — `` a `$client:` does not become the row BINDING (#11630) `` and *"and the real `client:` is bound, not swept up as unclaimed"*. A gross `client`-only break (dropping the trailing `\s*`) trips 83 cases.

What survives is narrower and is the real gap: **tightening** drifts. No fixture defends the `{` and `,` members of the allowlist, and none can — the file's own sweep measured **0 leads preceded by `{` or by `,`** across all seven live ledgers, so those members are behaviourally silent on every fixture and every real ledger today. They are exactly the part of the anchor only a string pin can hold, and tightening is the direction a "simplification" takes. That is now stated in the comment block, replacing the over-broad claim.

## The three falsification paths, checked

1. **Do the neighbouring pins jointly constrain it?** No. Computed over a mutated source: `the run … spelled ONCE` stays **1**, `all eight lead scans` stays **8**, `no call site restates it` stays **0**. All three count *text* and never call the function, so a branch added inside `declLead` is invisible to every one of them. The array's job is not narrower than its label — the label was simply untrue.
2. **A fifth spelling?** No — 8 call sites, 8 literals, 4 distinct.
3. **Is `windowClientRe` comparable?** Yes. The missing `'g'` flag and `window.match()` are real but **orthogonal**: flags are a separate argument to `new RegExp(source, flags)` and cannot affect the source string this pin compares. If anything it argues the other way — `windowClientRe` is the only call site whose *value extraction* reads `client.index` and `client[0].length`, so lead drift there corrupts extracted client names rather than merely missing matches.

## Verification

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (9 families from the real changeset), all run at **`1253ea0e9`**, exit codes captured before any pipe:

```
check:agent-test-spelling          exit=0     check:parse-guard              exit=0
check:cross-package-test-inputs    exit=0     check:pm-governed-merges       exit=0
check:docs-audit-scope             exit=0     check:pnpm-filter-targets      exit=0
check:entry-guard                  exit=0     check-affected-docs            exit=0
check:nul-bytes                    exit=0
```

`affected-docs --self-test`: **417 cases pass** (416 before; one check became two). No changeset — this touches only internal CI tooling under `scripts/docs-audit/` and publishes nothing, so `skip-changeset` applies.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_