### PR TITLE
docs: retarget the general-rule `ADR-0057 D10` citations to `ADR-0124 D1`

### DIFF
--- a/.claude/skills/dogfood-verification/SKILL.md
+++ b/.claude/skills/dogfood-verification/SKILL.md
@@ -110,7 +110,7 @@ dev 工作树、dev-server 端口、preview 浏览器全是**共享的**:并行�
 - [ ] 确认页面渲染完成*之后*(先截图,再查 selector),DOM dump 没问题。
 - [ ] **门的两侧都要测**:`requiresService`/`requiresObject`/权限门要在依赖存在*与*
       缺席两种状态下各验一次。
-- [ ] 服务端是权威可见性门(ADR-0057 D10)—— 客户端过滤只是「礼貌」。元数据开关不改
+- [ ] 服务端是权威可见性门(ADR-0124 D1)—— 客户端过滤只是「礼貌」。元数据开关不改
       UI 时,先查强制在服务端(框架,可在本仓修)还是客户端(objectui console,另一
       个仓)。
 - [ ] 用 `preview_screenshot`(API 改动用 `preview_network`)向用户证明;loading

--- a/docs/audits/2026-07-studio-package-create-ux-dogfood.md
+++ b/docs/audits/2026-07-studio-package-create-ux-dogfood.md
@@ -6,7 +6,7 @@ object with fields, enter a record, create an app with navigation, publish, and
 use the result as an end user — driving a real Chromium against `/_console`
 (vendored console build `7782698`, matching the `.objectui-sha` pin, so findings
 are not stale-bundle artifacts). Both sides of the read-only gate were exercised
-per ADR-0057 D10.
+per ADR-0124 D5.
 
 Run: `objectstack dev --ui --seed-admin` on the showcase example, fresh SQLite DB,
 `admin@objectos.ai` seeded admin, headless Chromium via CDP with screenshots at

--- a/docs/qa/platform-checklist/RUNNER.md
+++ b/docs/qa/platform-checklist/RUNNER.md
@@ -75,9 +75,9 @@ test-run output the clause's `evidence` field names.
 4. **Both sides of every gate.** For any permission/visibility/feature gate, verify
    presence for the entitled persona AND absence (or server-side rejection) for the
    unentitled one. UI absence alone is a client courtesy; the server is the authority.
-   (That rule is cited across the framework as `ADR-0057 D10`; treat it as an
-   attribution — D10 itself decides Setup-nav capability surfacing, and recording the
-   general rule is tracked in #9628. The rule is not in doubt, only its anchor.)
+   (That rule is `ADR-0124 D1`, and this rule is its verification half — `ADR-0124 D5`
+   states it directly: a test that asserts only that the interface hides something has
+   tested the courtesy layer and left the enforcement point unobserved.)
    Where feasible, prove denial with a direct forged request.
 5. **Severe findings are hypotheses.** "The whole surface is unreachable" gets
    disproven-or-confirmed via screenshot + the server's own metadata before it is

--- a/docs/qa/platform-checklist/areas/access-security.json
+++ b/docs/qa/platform-checklist/areas/access-security.json
@@ -51,7 +51,7 @@
           "evidence": "PATCH response + admin re-read"
         },
         {
-          "clause": "admin (platform posture) reads the full set — the entitled side of the same gate (both sides, RUNNER rule 4 / ADR-0057 D10)",
+          "clause": "admin (platform posture) reads the full set — the entitled side of the same gate (both sides, RUNNER rule 4 / ADR-0124 D5)",
           "oracle": "api",
           "verify": "admin GET list contains every id created in this run",
           "evidence": "admin listing"
@@ -83,7 +83,7 @@
       },
       "source": [
         "packages/verify/src/rls.ts",
-        "ADR-0057 D10",
+        "ADR-0124 D1",
         "packages/qa/dogfood/test/showcase-private-owd.dogfood.test.ts",
         "authz-conformance.matrix.ts rows rls-read / rls-by-id-write",
         "#7637 (run record) — the by-id spot-check on a skipped object is where the private D11 defect surfaced",
@@ -335,7 +335,7 @@
           "evidence": "screenshot + disabled-state DOM read"
         },
         {
-          "clause": "the SERVER refuses the same write: direct PUT /api/v1/meta/object/<name> on the read-only package answers 4xx with a ledgered metadata-protocol code (WRITABLE_PACKAGE_REQUIRED, or ITEM_LOCKED for _lock'd items) — UI absence never suffices (ADR-0057 D10)",
+          "clause": "the SERVER refuses the same write: direct PUT /api/v1/meta/object/<name> on the read-only package answers 4xx with a ledgered metadata-protocol code (WRITABLE_PACKAGE_REQUIRED, or ITEM_LOCKED for _lock'd items) — UI absence never suffices (ADR-0124 D1)",
           "oracle": "api",
           "verify": "PUT response status >=400 and error.code ∈ {WRITABLE_PACKAGE_REQUIRED, ITEM_LOCKED} (packages/spec/src/api/error-code-ledger.zod.ts, @objectstack/metadata-protocol entry)",
           "evidence": "PUT trace"
@@ -421,7 +421,7 @@
           "evidence": "the verdict matrix + spot re-reads"
         },
         {
-          "clause": "every withheld cell is DENIED SERVER-SIDE with the ledgered code: verbs marked false answer 403 with error.code PERMISSION_DENIED (rest-server maps explicit security denials to 403 PERMISSION_DENIED) — UI absence never counts (ADR-0057 D10)",
+          "clause": "every withheld cell is DENIED SERVER-SIDE with the ledgered code: verbs marked false answer 403 with error.code PERMISSION_DENIED (rest-server maps explicit security denials to 403 PERMISSION_DENIED) — UI absence never counts (ADR-0124 D1)",
           "oracle": "api",
           "verify": "per-cell status 403 and body code PERMISSION_DENIED; capture any cell answering a different code for triage",
           "evidence": "the verdict matrix"
@@ -1293,7 +1293,7 @@
         }
       ],
       "negative": [
-        "a Studio panel that greys the save while a direct meta PUT widens is a FAIL — the server gate is the authority (ADR-0057 D10 both-sides)",
+        "a Studio panel that greys the save while a direct meta PUT widens is a FAIL — the server gate is the authority (ADR-0124 D1 both-sides)",
         "a stock-deploy packaged-object widening PUT that answers 2xx (or leaves the object widened) is a FAIL",
         "do NOT tick external-principal read/write enforcement: that evaluation is liveness `planned` (#2696) — this item is the save/authoring gate only"
       ],
@@ -1310,7 +1310,7 @@
         "packages/lint/src/validate-security-posture.ts (OWD_WIDTH + SECURITY_EXTERNAL_WIDER lint parity)",
         "objectui packages/app-shell/src/views/studio-design/owd-sharing.ts (isExternalWider) + PackageOwdOverviewPanel.tsx + ObjectSettingsPanel.tsx",
         "examples/app-showcase/src/data/objects/announcement.object.ts + account.object.ts (externalSharingModel declarations)",
-        "ADR-0090 D11, ADR-0086 D1, ADR-0057 D10, #3050, objectui#2508"
+        "ADR-0090 D11, ADR-0086 D1, ADR-0124 D1, #3050, objectui#2508"
       ],
       "history": [
         {

--- a/docs/qa/platform-checklist/areas/approvals.json
+++ b/docs/qa/platform-checklist/areas/approvals.json
@@ -280,7 +280,7 @@
           "evidence": "request read"
         },
         {
-          "clause": "the gate is server-side: a forged direct POST of the decision route as the submitter is rejected (ADR-0057 D10 — UI absence alone is a client courtesy)",
+          "clause": "the gate is server-side: a forged direct POST of the decision route as the submitter is rejected (ADR-0124 D1 — UI absence alone is a client courtesy)",
           "oracle": "api",
           "verify": "the forged approve answers FORBIDDEN (403-mapped); test BOTH sides — the entitled approver's decision on the same request succeeds",
           "evidence": "the rejected call + the entitled approver's accepted call"
@@ -298,7 +298,7 @@
       "traps": ["hydration-race", "wrong-persona"],
       "source": [
         "#3358 §1",
-        "ADR-0057 D10 (server is the authoritative visibility gate)",
+        "ADR-0124 D1 (server is the authoritative visibility gate)",
         "examples/app-showcase/src/security/seed-approval-demo.ts (Mei Phone: 'a clean submitter — a requester who is never also one of her own approvers')"
       ],
       "history": [

--- a/docs/qa/platform-checklist/areas/attachments-storage.json
+++ b/docs/qa/platform-checklist/areas/attachments-storage.json
@@ -233,7 +233,7 @@
         }
       ],
       "negative": [
-        "a gated file downloadable anonymously (silent success) is a FAIL — UI absence of a download button is a client courtesy; the route is the authority (ADR-0057 D10)",
+        "a gated file downloadable anonymously (silent success) is a FAIL — UI absence of a download button is a client courtesy; the route is the authority (ADR-0124 D1)",
         "a deny that surfaces in the panel as 'Download failed (403)' instead of the mapped copy means the error-envelope dialect broke (#3689 note in the panel) — file it against objectui, not storage"
       ],
       "traps": ["wrong-persona", "dispatcher-vs-hono-route", "stale-console-bundle"],

--- a/docs/qa/platform-checklist/areas/identity-auth.json
+++ b/docs/qa/platform-checklist/areas/identity-auth.json
@@ -211,7 +211,7 @@
           "evidence": "the screenshot set"
         },
         {
-          "clause": "a disabled method is refused SERVER-SIDE, not merely hidden — UI absence is a client courtesy; the server is the authority (ADR-0057 D10)",
+          "clause": "a disabled method is refused SERVER-SIDE, not merely hidden — UI absence is a client courtesy; the server is the authority (ADR-0124 D1)",
           "oracle": "api",
           "verify": "firing each disabled method's endpoint returns a non-2xx (the plugin's routes are absent or refuse)",
           "evidence": "the forged-request responses"
@@ -347,7 +347,7 @@
       ],
       "negative": [
         "an admin-role invitation that returns success, or that leaves ANY row behind, is a FAIL of privilege-escalation severity — file immediately, P0-verify per RUNNER rule 7",
-        "UI-only enforcement (affordance hidden but the forged request succeeds) is a FAIL — the server is the authority (ADR-0057 D10)",
+        "UI-only enforcement (affordance hidden but the forged request succeeds) is a FAIL — the server is the authority (ADR-0124 D1)",
         "my-delegable-scope OVER-reporting is a FAIL — a position, permission set or BU subtree the caller cannot actually delegate, or (were the shape ever to grow one) a role the caller cannot mint: a client that trusts the scope would offer what the endpoint then refuses. UNDER-reporting is NOT a FAIL and must not be filed as one: the endpoint answering an empty scope while the delegate can still mint a member invitation is the safe direction and the expected state on stock fixtures (run #7663 — DelegableScope has no invitation-role field at all)"
       ],
       "automated": { "kind": "e2e", "ref": "packages/qa/dogfood/test/delegated-admin-invite.dogfood.test.ts" },
@@ -807,7 +807,7 @@
         }
       ],
       "negative": [
-        "an org management surface where the affordance is hidden but the forged endpoint succeeds for a non-admin is a FAIL — the server is the authority (ADR-0057 D10)",
+        "an org management surface where the affordance is hidden but the forged endpoint succeeds for a non-admin is a FAIL — the server is the authority (ADR-0124 D1)",
         "remove-member that drops the roster row but leaves the ex-member's org-scoped access intact is a FAIL — removal must change authorization",
         "a role written outside the {owner, admin, delegated_admin, member} vocabulary is a FAIL — including a stored 'guest': the closed list is the write-side guardrail that makes an ungoverned capability grant unrepresentable (ADR-0108), so a 2xx that persists 'guest' is a regression of the closure, not a vocabulary difference. A role change that does not flip any gate is equally a FAIL",
         "the Organization nav landing on the raw sys_organization list because {current_org_id} did not resolve (when an active org exists) is a FAIL of the ADR-0081 wiring"

--- a/docs/qa/platform-checklist/areas/platform-core.json
+++ b/docs/qa/platform-checklist/areas/platform-core.json
@@ -518,7 +518,7 @@
           "evidence": "three screenshots"
         },
         {
-          "clause": "the app-level gate is server-side, not a client courtesy: a forged member GET /api/v1/meta/app?id=setup is denied/empty at the server, not merely hidden in the launcher (ADR-0057 D10 both-sides)",
+          "clause": "the app-level gate is server-side, not a client courtesy: a forged member GET /api/v1/meta/app?id=setup is denied/empty at the server, not merely hidden in the launcher (ADR-0124 D1 both-sides)",
           "oracle": "api",
           "verify": "the forged request's status/body proves server-side denial",
           "evidence": "the forged response"

--- a/docs/qa/platform-checklist/areas/records-forms.json
+++ b/docs/qa/platform-checklist/areas/records-forms.json
@@ -1120,7 +1120,7 @@
         {
           "clause": "related lists are READ-gated on BOTH ends: a persona WITHOUT read on the child object (showcase_contributor lacks showcase_contact read) sees NO Contacts section on the account detail (UI courtesy — deriveRelatedLists drops children the user cannot read, objectui#2359) AND a direct child query is refused server-side (403); a persona WITH child read (showcase_manager) sees the section AND the query 200s",
           "oracle": "api",
-          "verify": "as showcase_contributor: screenshot confirms the Contacts tab is absent, and the forged GET /api/v1/data/showcase_contact?$filter=[[\"account\",\"=\",\"<northwind id>\"]] returns 403; as showcase_manager: the tab renders and the identical query returns 200 with rows — the server is the authority (ADR-0057 D10, RUNNER rule 4), the UI drop is courtesy",
+          "verify": "as showcase_contributor: screenshot confirms the Contacts tab is absent, and the forged GET /api/v1/data/showcase_contact?$filter=[[\"account\",\"=\",\"<northwind id>\"]] returns 403; as showcase_manager: the tab renders and the identical query returns 200 with rows — the server is the authority (ADR-0124 D1, RUNNER rule 4), the UI drop is courtesy",
           "evidence": "both personas' detail screenshots + the 403 and the 200 child queries"
         }
       ],
@@ -2489,7 +2489,7 @@
         {
           "clause": "the SERVER is the boundary: a forged PUT /api/v1/meta/view/<name> by the non-admin is refused (4xx) — UI absence alone is courtesy",
           "oracle": "api",
-          "verify": "the direct non-admin PUT returns a 403-class refusal and no overlay view is created (RUNNER rule 4, ADR-0057 D10)",
+          "verify": "the direct non-admin PUT returns a 403-class refusal and no overlay view is created (RUNNER rule 4, ADR-0124 D5)",
           "evidence": "the forged-request refusal"
         }
       ],

--- a/docs/qa/platform-checklist/areas/studio-authoring.json
+++ b/docs/qa/platform-checklist/areas/studio-authoring.json
@@ -73,14 +73,14 @@
         }
       ],
       "negative": [
-        "silent acceptance of an authoring write into a read-only package is a FAIL (ADR-0057 D10 — the server is the authoritative gate; the client lock is courtesy)",
+        "silent acceptance of an authoring write into a read-only package is a FAIL (ADR-0124 D1 — the server is the authoritative gate; the client lock is courtesy)",
         "a 'published' app absent from the Home launcher, or an end-user list rendering raw picklist values instead of labels, is a FAIL"
       ],
       "traps": ["stale-console-bundle", "automation-input", "hydration-race"],
       "source": [
         "docs/audits/2026-07-studio-package-create-ux-dogfood.md ('The loop closes' — the canonical walk; findings 1/3/4/6 carried as knownGaps)",
         "ADR-0016 §9 (the MVP loop this proves)",
-        "ADR-0057 D10 (server-side gate authority)",
+        "ADR-0124 D1 (server-side gate authority)",
         "access-security.readonly-package-locks-studio (client-side lock — cross-referenced, not duplicated)"
       ],
       "history": [

--- a/packages/lint/src/validate-expressions.test.ts
+++ b/packages/lint/src/validate-expressions.test.ts
@@ -1146,8 +1146,8 @@ describe('validateStackExpressions (ADR-0032 build-time)', () => {
      *                `stripReadonlyWhenFields` deletes the value from the
      *                payload; client `fallback: false` ⇒ editable. The two ends
      *                fault in OPPOSITE directions and the "server enforces,
-     *                client is courtesy" rule (cited as ADR-0057 D10; an
-     *                attribution, #9628) gives it to the server. ⇒ the old sentence was BACKWARDS here.
+     *                client is courtesy" rule (ADR-0124 D1) gives it to the
+     *                server. ⇒ the old sentence was BACKWARDS here.
      *   requiredWhen server logs the unbound root and `continue`s (#4977 did not
      *                copy the carve-out); client `fallback: false`. Both ends
      *                fail open and neither is about visibility. ⇒ the old
@@ -1186,8 +1186,8 @@ describe('validateStackExpressions (ADR-0032 build-time)', () => {
       });
 
       it('`readonlyWhen` — names the client/server disagreement, not just the server verdict', () => {
-        // Server enforces, client is courtesy (cited as ADR-0057 D10, an
-        // attribution — #9628): the form renders the field editable
+        // Server enforces, client is courtesy (ADR-0124 D1): the form renders
+        // the field editable
         // (`fallback: false`)
         // while the server locks it. An author who only reads "LOCKED" cannot
         // reconcile that with the editable input in front of them.

--- a/packages/lint/src/validate-expressions.ts
+++ b/packages/lint/src/validate-expressions.ts
@@ -563,8 +563,7 @@ function rulePredicates(rule: AnyRec, path: string): Array<{ label: string; raw:
  *    payload and lets the rest of the write through. Client:
  *    `resolveFieldRuleState` passes `fallback: false`, so the form renders the
  *    field editable. The standing "server enforces, client is courtesy" rule
- *    — cited in this repo as ADR-0057 D10, an attribution rather than a
- *    resolvable anchor (#9628) — resolves the disagreement: the author edits
+ *    — ADR-0124 D1 — resolves the disagreement: the author edits
  *    the field, the save reports
  *    success, and the value silently never lands. The old sentence told this
  *    author the field would be VISIBLE TO EVERYONE — the opposite failure, and

--- a/packages/objectql/src/engine-readonly-when-parent.test.ts
+++ b/packages/objectql/src/engine-readonly-when-parent.test.ts
@@ -7,8 +7,7 @@
 // Paid, its lines are frozen". It was enforced only in the client grid: the
 // server-side strip bound `record` and `previous` and nothing else, so every
 // `parent.*` predicate faulted, took the fail-OPEN branch, and the write landed
-// with a 200 while the UI still drew the cell locked. The rule this repo cites
-// as ADR-0057 D10 (an attribution, not a resolvable anchor — #9628) puts
+// with a 200 while the UI still drew the cell locked. ADR-0124 D1 puts
 // enforcement on the SERVER and makes the client courtesy; this suite pins that
 // direction end-to-end through the real engine + a real driver, not through the
 // strip function in isolation (PD #10: a `case` label is not enforcement —

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -5391,9 +5391,8 @@ export class ObjectQL implements IObjectQLEngine {
    * `readonlyWhen` reads, or `null` when this write cannot resolve one.
    *
    * `readonlyWhen: parent.status == 'paid'` is a documented **server**
-   * guarantee (the rule this repo cites as ADR-0057 D10 puts enforcement here;
-   * the client grid is courtesy — an attribution, not a resolvable anchor,
-   * #9628), but the strip is a pure function over the payload and the prior
+   * guarantee (ADR-0124 D1 puts enforcement here; the client grid is
+   * courtesy), but the strip is a pure function over the payload and the prior
    * row — it has no driver and cannot fetch a header. So the engine resolves it
    * and passes it in.
    *

--- a/packages/objectql/src/validation/rule-validator.ts
+++ b/packages/objectql/src/validation/rule-validator.ts
@@ -113,10 +113,10 @@
  * and #4775 made at the two neighbouring write gates. Do not widen it back on
  * the grounds that it reads inconsistent with D5's table — the table is what
  * was amended, and the standing "server enforces, client is courtesy" rule is
- * why. This repo cites that rule as ADR-0057 D10 — an ATTRIBUTION, not a
- * resolvable anchor: D10 decides Setup-nav capability surfacing, and no ADR
- * records the general rule yet (#9628). The rule stands on its own; what is
- * missing is the decision record, not the discipline.
+ * why. That rule is ADR-0124 D1, recorded in its own right by #9628 after a
+ * corpus search found it universally practised and decided by no ADR at all.
+ * ADR-0124 D2 makes the scope general by construction: it may not be
+ * re-narrowed to a single surface by a later citer.
  *
  * ## `requiredWhen`: the SCOPE is bound, the SEMANTICS are not changed (#4977)
  *
@@ -661,10 +661,10 @@ export function stripReadonlyWhenFields(
  *    is unlocked — we simply could not ask. Waving it through inverts the
  *    guarantee: a field the author declared locked is written, the API answers
  *    200, and the client grid still draws the cell as read-only, so the UI and
- *    the database disagree with nobody told. The rule this repo cites as
- *    ADR-0057 D10 puts enforcement on the server; a lock that fails open leaves
- *    enforcement in the courtesy layer. (Attribution, not a resolvable anchor —
- *    see the module header and #9628.) So an unbound root resolves to LOCKED — conservative toward the
+ *    the database disagree with nobody told. ADR-0124 D1 puts enforcement on
+ *    the server; a lock that fails open leaves enforcement in the courtesy
+ *    layer, which ADR-0124 D3 names outright: the server may not hand an
+ *    undecided case to the client. So an unbound root resolves to LOCKED — conservative toward the
  *    author's declared intent, and the direction #4649 (validation predicates)
  *    and #4775 (hook conditions) already took for their own unevaluable case.
  *

--- a/packages/plugins/plugin-hono-server/src/current-user-endpoints.ts
+++ b/packages/plugins/plugin-hono-server/src/current-user-endpoints.ts
@@ -245,9 +245,10 @@ function allPathsMounted(rawApp: any, paths: readonly string[]): boolean {
  * (`admin_full_access` `'*': {modifyAllRecords}`) who ALSO holds
  * `organization_admin` (which denies writes on identity tables): the client
  * would see `sys_user.allowEdit:false` and disable a form the server accepts
- * (verified: `PATCH /data/sys_user {name}` → 200). The rule this repo cites as
- * ADR-0057 D10 — an attribution, not a resolvable anchor (#9628) — makes the
- * server the authoritative gate; the client must mirror it, never diverge.
+ * (verified: `PATCH /data/sys_user {name}` → 200). ADR-0124 D1 makes the
+ * server the authoritative gate, and D4 makes this direction explicit: what
+ * the client is told must be derived from the server's actual effective
+ * enforcement, never from an independent reading of the declarations.
  *
  * The super-user grant covers private/managed objects on the server, so folding
  * it here is exactly as broad as real enforcement — never broader.

--- a/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
+++ b/packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts
@@ -4,8 +4,8 @@ import { describe, it, expect } from 'vitest';
 import { foldWildcardSuperUser, clampManagedObjectWrites, type ManagedSchemaLike } from './current-user-endpoints.js';
 
 /**
- * Server enforces, client is courtesy (cited as ADR-0057 D10 — an attribution,
- * not a resolvable anchor, #9628) / ADR-0092 D5 — the `/me/permissions`
+ * Server enforces, client is courtesy (ADR-0124 D1; D4 for this direction
+ * specifically) / ADR-0092 D5 — the `/me/permissions`
  * per-object FLS map must
  * mirror the server's actual enforcement, which grants writes via a `'*'`
  * modifyAll super-user bypass regardless of another set's explicit per-object

--- a/packages/qa/dogfood/test/showcase-readonly-when-parent.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-readonly-when-parent.dogfood.test.ts
@@ -11,10 +11,8 @@
 // `previous` and had no `parent`, so every one of those predicates faulted, the
 // fail-OPEN branch let the write through, and a single PATCH rewrote the
 // quantity and unit price of a settled invoice's line — HTTP 200, value
-// persisted, while the grid still drew the cell locked. The rule this repo
-// cites as ADR-0057 D10 (an attribution, not a resolvable anchor — #9628)
-// makes the SERVER the enforcement point and the client courtesy; here it was
-// inverted.
+// persisted, while the grid still drew the cell locked. ADR-0124 D1 makes the
+// SERVER the enforcement point and the client courtesy; here it was inverted.
 //
 // This is the issue's own repro, run against the shipped metadata rather than a
 // hand-built fixture: the unit + engine suites in `@objectstack/objectql` pin

--- a/scripts/adr-anchors/packages__objectql__src__validation__rule-validator.ts.json
+++ b/scripts/adr-anchors/packages__objectql__src__validation__rule-validator.ts.json
@@ -1,8 +1,8 @@
 {
   "file": "packages/objectql/src/validation/rule-validator.ts",
   "adrs": [
-    "ADR-0057",
-    "ADR-0058"
+    "ADR-0058",
+    "ADR-0124"
   ],
-  "invariant": "A declared field lock is the SERVER's to enforce — the client grid is courtesy. This repo cites that rule as ADR-0057 D10; read it as an ATTRIBUTION, not as a resolvable anchor. D10 of `0057-erp-authorization-core-business-units-and-scope-depth.md` decides Setup-nav capability surfacing, and only its PS-2 implementation note carries the server-enforcement half — scoped to nav. The other ADR-0057 (system data lifecycle) has no D-numbered decisions at all. The rule itself is true and unchanged here; recording it as a decision is #9628. A `readonlyWhen` whose predicate names a scope root the write path could not bind resolves to LOCKED, not to \"not locked\": \"could not check\" must never read as \"allowed\" on a field the author declared frozen. This narrows ADR-0058 D5's fail-soft tier deliberately and only for that case — a merely BROKEN predicate (undeclared key, null overload, parse fault, throw) still fails open, and requiredWhen / option visibleWhen are untouched."
+  "invariant": "A declared field lock is the SERVER's to enforce — the client grid is courtesy. That rule is ADR-0124 D1, and it is general by construction: ADR-0124 D2 forbids re-narrowing it to one surface, and D3 forbids the specific move this file exists to prevent — resolving an undecided case permissively on the expectation that the courtesy layer will hide the result. This anchor previously carried the rule as an ATTRIBUTION rather than a resolvable anchor, because no ADR had recorded it; #9628 recorded it and the citation was retargeted. A `readonlyWhen` whose predicate names a scope root the write path could not bind resolves to LOCKED, not to \"not locked\": \"could not check\" must never read as \"allowed\" on a field the author declared frozen. This narrows ADR-0058 D5's fail-soft tier deliberately and only for that case — a merely BROKEN predicate (undeclared key, null overload, parse fault, throw) still fails open, and requiredWhen / option visibleWhen are untouched."
 }


### PR DESCRIPTION
Fixes #11501

## The classification criterion

Written first, so the calls below can be checked against it rather than against my judgement.

- **`ADR-0057 D10`** decides: *which Setup-nav entries are surfaced — they tier on capability/feature presence (`requiresService`, `multiOrgEnabled`) while the object itself stays registered open in every edition.* Its PS-2 implementation note (2026-06-22) records that this nav filtering happens server-side in `filterAppForUser`.
- **`ADR-0124 D1`** decides: *every access decision this platform declares is decided by the server before the answer leaves the process; a client-side check evaluating the same declaration is a usability courtesy and is never what makes the rule true.* D2 makes that scope general by construction and forbids re-narrowing it to one surface.

**The test applied to each citation:** does the sentence carrying the citation depend on a *capability/feature-gated nav or app surface*? If yes, D10 is its actual subject and it stays. If the sentence would be equally true with no capability gate anywhere in the picture — because it is asserting *where enforcement lives* or *what counts as verification* — it invokes the general rule and moves.

## Population — the card's number was the wrong end of it

| Measurement | Count | Note |
|:--|--:|:--|
| Files mentioning `ADR-0057` at all | 280 | the crude `grep -rl` figure; **not** the population |
| Files carrying the literal `ADR-0057 D10` | 42 | the card's ~42 |
| **Occurrences of `ADR-0057 D10`** | **98** | the real unit of work — a file carries up to 12 |
| Distinct spellings of a D10 citation | 1 | `git grep -oE 'ADR-0057[^A-Za-z0-9]{0,4}D10\|D10[^A-Za-z0-9]{0,6}(of )?ADR-0057'` → 98/98 are `ADR-0057 D10` |

⚠️ A bare-`D10` grep is useless here: `D10` is also a decision id in ADR-0056, 0058, 0076, 0079 and 0090 (345 non-`ADR-0057 D10` hits). Every citation of *this* D10 is spelled with the number adjacent, so the 98 is complete.

**Of 98 occurrences: 31 retargeted · 33 left on D10 (its real subject) · 34 are records not rewritten.**

## A · The 31 retargets

| # | Site | What the citing sentence claims | → | Why it moves |
|--:|:--|:--|:--|:--|
| 1 | `packages/objectql/src/validation/rule-validator.ts:116` | the standing "server enforces, client is courtesy" rule is why D5's fail-soft tier was narrowed | D1 | names the rule verbatim; no nav or capability in the picture |
| 2 | `packages/objectql/src/validation/rule-validator.ts:664` | a lock that fails open leaves enforcement in the courtesy layer | D1 | enforcement-location claim about a field lock; also now cites D3 (server may not delegate an undecided case) |
| 3 | `scripts/adr-anchors/packages__objectql__src__validation__rule-validator.ts.json:7` | anchor invariant: "a declared field lock is the SERVER's to enforce" | D1 | the anchor's invariant *is* the general rule — see the anchor note below |
| 4 | `packages/objectql/src/engine.ts:5394` | `readonlyWhen` is a documented **server** guarantee; the client grid is courtesy | D1 | enforcement-location claim about a field lock |
| 5 | `packages/objectql/src/engine-readonly-when-parent.test.ts:10` | the rule puts enforcement on the SERVER and makes the client courtesy | D1 | same, in the suite that pins the direction |
| 6 | `packages/qa/dogfood/test/showcase-readonly-when-parent.dogfood.test.ts:14` | makes the SERVER the enforcement point and the client courtesy; here it was inverted | D1 | same, dogfood-level |
| 7 | `packages/lint/src/validate-expressions.ts:566` | the rule resolves a client/server disagreement in the server's favour | D1 | enforcement-location claim; lint diagnostic docblock |
| 8 | `packages/lint/src/validate-expressions.test.ts:1149` | the rule "gives it to the server" when the two ends fault in opposite directions | D1 | same |
| 9 | `packages/lint/src/validate-expressions.test.ts:1189` | server enforces, client is courtesy | D1 | verbatim statement of the rule |
| 10 | `packages/plugins/plugin-hono-server/src/current-user-endpoints.ts:248` | the server is the authoritative gate; the client must mirror it, never diverge | D1 | FLS map; also now cites **D4** (what the client is told may not overstate enforcement) |
| 11 | `packages/plugins/plugin-hono-server/src/fold-wildcard-superuser.test.ts:7` | server enforces, client is courtesy | D1 | same, its test |
| 12 | `.claude/skills/dogfood-verification/SKILL.md:113` | 服务端是权威可见性门 —— 客户端过滤只是「礼貌」 | D1 | verbatim statement of the rule; citation swapped in place, prose untouched |
| 13 | `docs/qa/platform-checklist/RUNNER.md:78` | UI absence alone is a client courtesy; the server is the authority | D1 **+ D5** | "that rule" is D1; rule 4's own subject (both sides of every gate) is D5, so both are cited |
| 14 | `docs/audits/2026-07-studio-package-create-ux-dogfood.md:9` | "Both sides of the read-only gate were exercised" | **D5** | pure verification-method claim — see the D5 note |
| 15 | `.../areas/access-security.json:54` | "the entitled side of the same gate (both sides, RUNNER rule 4)" | **D5** | pure verification-method claim |
| 16 | `.../areas/access-security.json:86` | `source` entry for the RLS both-sides item | D1 | the source being cited is the rule itself |
| 17 | `.../areas/access-security.json:338` | the SERVER refuses the same write — UI absence never suffices | D1 | enforcement-location claim (read-only package meta PUT) |
| 18 | `.../areas/access-security.json:424` | every withheld cell is DENIED SERVER-SIDE — UI absence never counts | D1 | enforcement-location claim (FLS verbs) |
| 19 | `.../areas/access-security.json:1296` | a Studio panel greying the save while a direct meta PUT widens is a FAIL — the server gate is the authority | D1 | OWD authoring gate; no capability gate involved |
| 20 | `.../areas/access-security.json:1313` | `source` ADR list for the OWD item | D1 | same item as 19 |
| 21 | `.../areas/approvals.json:283` | the gate is server-side: a forged direct POST is rejected | D1 | enforcement-location claim (approval decision route) |
| 22 | `.../areas/approvals.json:301` | `source`: "server is the authoritative visibility gate" | D1 | same item |
| 23 | `.../areas/attachments-storage.json:236` | UI absence of a download button is a client courtesy; the route is the authority | D1 | enforcement-location claim (file route) |
| 24 | `.../areas/identity-auth.json:214` | a disabled method is refused SERVER-SIDE, not merely hidden | D1 | enforcement-location claim (auth methods) |
| 25 | `.../areas/identity-auth.json:350` | UI-only enforcement is a FAIL — the server is the authority | D1 | enforcement-location claim |
| 26 | `.../areas/identity-auth.json:810` | affordance hidden but the forged endpoint succeeds is a FAIL | D1 | enforcement-location claim (org management) |
| 27 | `.../areas/platform-core.json:521` | the app-level gate is server-side, not a client courtesy | D1 | ⚠️ closest call — the gate here is `App.requiredPermissions setup.access`, **not** a capability gate, so D10 is not its subject |
| 28 | `.../areas/records-forms.json:1123` | the server is the authority, the UI drop is courtesy | D1 | enforcement-location claim (RLS-scoped tab) |
| 29 | `.../areas/records-forms.json:2492` | "the direct non-admin PUT returns a 403-class refusal" | **D5** | pure verification-method claim |
| 30 | `.../areas/studio-authoring.json:76` | the server is the authoritative gate; the client lock is courtesy | D1 | enforcement-location claim (read-only package write) |
| 31 | `.../areas/studio-authoring.json:83` | `source`: "server-side gate authority" | D1 | same item |

### ⚠️ Declared deviation — 4 citations point at `ADR-0124 D5`, not D1

The card says "retarget to `ADR-0124 D1`". Four of the 31 (rows 13–15, 29) do not assert *where enforcement lives*; they assert *what counts as verification* — "both sides were exercised", "the forged PUT returns a refusal". `ADR-0124 D5` is that decision, exactly ("Verifying a gate means exercising the server; UI absence is not evidence"). Pointing a method claim at a location decision would be the same class of loose citation this card exists to close, so I sent them to D5 and am flagging it rather than doing it silently. Both targets satisfy the card's "Done means". **If you disagree, collapsing them is a 4-token edit** — they are the only D5 citations in the tree.

## B · The 33 left on `ADR-0057 D10` — D10 *is* their subject

| Site | × | Why it stays |
|:--|--:|:--|
| `packages/rest/src/rest-server.ts` | 12 | the `requiresService` capability gate itself — `filterAppForUser` / `filterDashboardForUser`, incl. the dashboard-widget gate |
| `packages/rest/src/rest.test.ts` | 7 | the tests of that gate (`describe('filterAppForUser — ADR-0057 D10 requiresService gate')`) |
| `packages/rest/src/meta-app-publish-gate.test.ts` | 3 | a published app gated by capability *presence* |
| `packages/rest/src/meta-app-area-nav-gate.test.ts` | 2 | a `requiresService` entry inside an area |
| `packages/rest/src/rest-api-plugin.ts` | 1 | wiring the capability probe |
| `packages/rest/src/rest-exec-ctx-principal-kind.test.ts` | 1 | the resolved kernel that probe reads |
| `packages/platform-objects/src/apps/account.app.ts` | 1 | the account app's own nav declaration — named in ADR-0124 as a "stays" case |
| `packages/platform-objects/src/apps/account-approvals-nav.test.ts` | 1 | that declaration's test |
| `packages/spec/liveness/README.md` | 2 | `requiresService` liveness — the "dead in the renderer, LIVE server-side" lesson |
| `packages/spec/liveness/app.json` · `dashboard.json` | 2 | the `requiresService` liveness rows |
| `scripts/check-meta-type-normalized.mjs` | 1 | "the ADR-0057 D10 widget gate never ran on the default path" |

### The third class exists, and it is left alone

Three of the 33 invoke **both** — D10's capability gate is the vehicle *and* the general rule is the reason: `account-approvals-nav.test.ts:94` ("`requiresService` is stripped server-side by `filterAppForUser`, so a gated-off entry never reaches the browser"), `meta-app-publish-gate.test.ts:125` and `rest-server.ts:2299` (both on the gate's fail-open-when-unprobeable behaviour). The subject test resolves them: the sentence's *subject* is the capability gate, which is what D10 decides, so the citation stays and the general rule is background rather than referent. Recording them here because they are the rows most worth a second opinion.

## C · The 34 not rewritten — these are records, not citing sites

| Site | × | Why |
|:--|--:|:--|
| 9 package `CHANGELOG.md` files | 29 | shipped release records, changeset-generated, published to npm. Retargeting them would rewrite what a past release said — a different act from moving a citation. |
| `docs/adr/0124-server-enforces-client-is-courtesy.md` | 4 | ⛔ out of scope by ruling. Its 4 mentions are the lineage argument (the "closest ancestor" table, the `2256e9369` commit history) and are *about* the old citations — they must survive for the record to make sense. |
| `docs/adr/0057-erp-authorization-core-business-units-and-scope-depth.md` | 1 | ⛔ out of scope by ruling; it is D10's own heading. |

## Non-vacuity — pins with named controls

Measured at `git rev-parse --short HEAD` = **584cff6b9**, base `5cb62d88b`. Every count is `git grep -o … | wc -l` (occurrences, not files).

| Pin | Before | After | Δ | Reads |
|:--|--:|--:|--:|:--|
| `ADR-0057 D10` | 98 | 67 | **−31** | exactly the retargets |
| `ADR-0124 D1` (word-bounded `D1\b`) | 1 | 29 | **+28** | 27 sites + RUNNER.md |
| `ADR-0124 D5` | 0 | 4 | **+4** | rows 13, 14, 15, 29 |
| **CONTROL** — total `ADR-0057` mentions | 789 | 756 | **−33** | see below |
| Diff ledger: `-` lines carrying `ADR-0057 D10` | — | — | **31** | |
| Diff ledger: `+` lines carrying `ADR-0057 D10` | — | — | **0** | nothing re-spelled the old citation |

**The control does not close at −31, and that is correct — it is −33.** The 2 extra are both in `scripts/adr-anchors/packages__objectql__src__validation__rule-validator.ts.json` and both are *required*, not collateral:

1. `"ADR-0057"` removed from the anchor's `adrs` array. `check:adr-anchors` asserts every listed ADR still appears in the anchored file; `rule-validator.ts` had **only** D10 mentions (2 of 2), so retargeting them left the file with no `ADR-0057` at all. Leaving the entry would have turned the gate red. `"ADR-0124"` replaces it.
2. The invariant's sentence "The other ADR-0057 (system data lifecycle) has no D-numbered decisions at all" — it existed to explain why the old citation was unresolvable, and is obsolete once the citation resolves.

28 + 4 = 32 citations across 31 sites because RUNNER.md row 13 carries both D1 and D5.

## Gates

Run on the final commit **584cff6b9**, each under `scripts/pm/os-verify-lock.sh`, exit captured before any pipe, verdict quoted from the gate's own output:

- `check:adr-anchors` — `OK (52 anchored file(s), every governing ADR still referenced; 123 decision number(s) …; 27918 citation(s) across 3497 file(s) resolve)`
- `check:platform-checklist` — `OK — 15 areas, 207 items (207 active)`
- `check:nul-bytes` — `OK (scanned 6572 text file(s) … no raw ASCII control bytes)`
- `check:doc-authoring` — `389 files clean — no bare metadata literals`
- `check:pm-skill-ratchet` — `dogfood-verification/SKILL.md is 155 lines (ceiling 155; headroom 0)` — the skill edit is byte-for-byte line-neutral
- `check:pm-governed-prose`, `check:skill-frame-sync`, `check:agent-test-spelling` — green

**Declared narrowing: no local `typecheck`/`test` run.** This worktree has no `node_modules` (the gates above are dependency-free node scripts), and installing a monorepo closure to typecheck a comments-only diff is not a good use of a shared container. The narrowing is *measured*, not assumed:
1. Population read from `git diff --name-only` — 8 `.ts` files, not a guess.
2. **0** changed lines in those files are non-comment lines (every `+`/`-` line begins `*`, `//` or `/**`), and `/*` ÷ `*/` counts are **identical before and after in all 8** — so no comment was opened or closed.
3. A change confined to comment interiors alters no type and no parse structure, so no untouched file's verdict can move either.

CI runs the full `TypeScript Type Check` job with no paths filter regardless.

## Scope notes

- **`skills/` (published) is not in this population at all.** `skills/objectstack-data/` cites `ADR-0057` four times, but all four are the *other* ADR-0057 (`0057-system-data-lifecycle-and-retention.md`, lifecycle/retention) and none is a D10 citation. The only skill file touched is `.claude/skills/dogfood-verification/SKILL.md` — internal agent tooling.
- **`content/docs/releases/` carries zero `ADR-0057 D10` citations** — verified, so the never-edit rule and this pass do not intersect.
- **Governed surface:** the diff touches `.claude/**`, so the whole PR is governed under Prime Directive #14. It stays **draft**, review requested from `os-zhuang`, and this seat will not flip it ready, arm auto-merge, or enqueue it. Without the one-line `.claude/` edit the diff would be ungoverned — say the word if you would rather split that line into its own PR so the other 18 files can land normally.
- **No changeset**, `skip-changeset` applied: every edit to a published package is inside a comment. The #9255 precedent in this family *did* ship one, but that change edited an author-visible lint diagnostic string; this one changes no runtime text.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_


---
_Generated by [Claude Code](https://claude.ai/code)_