### PR TITLE
docs(skills): make the objectstack-data ADR-0057 citations resolvable outside this repo

### DIFF
--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -81,7 +81,7 @@ database table and exposes automatic CRUD APIs.
 | `titleFormat` | — | **Retired (ADR-0079)** — a render-only template the server can't return or query. Use `nameField`; for a composite title, designate a `returnType: 'text'` formula field as `nameField` |
 | `enable` | — | Capability flags (trackHistory, searchable, apiEnabled, etc.) |
 | `fieldGroups` | — | Ordered list of logical field groups for forms/detail pages (see [Field Groups](#field-groups-mvp)) |
-| `lifecycle` | `record` semantics (permanent) | Data retention/rotation/archival contract (ADR-0057). **Required for append-only, high-write-rate objects** — a `telemetry`/`transient`/`event`/`audit` class must declare a bounding policy or parsing fails (see [Data Lifecycle & Retention](./rules/lifecycle.md)) |
+| `lifecycle` | `record` semantics (permanent) | Data retention/rotation/archival contract. **Required for append-only, high-write-rate objects** — a `telemetry`/`transient`/`event`/`audit` class must declare a bounding policy or parsing fails (see [Data Lifecycle & Retention](./rules/lifecycle.md)) |
 
 ### Object Capabilities (`enable`)
 
@@ -970,7 +970,7 @@ export const SetupApp = defineApp({
 | Feature | When to Consider |
 |:--------|:-----------------|
 | `tenancy` | Multi-tenant SaaS — `{ enabled: true, tenantField: 'tenant_id' }` row-level isolation (DB-per-tenant is an environment/deployment choice, not object metadata) |
-| `lifecycle` | Append-only / high-write-rate objects — retention / rotation / archival contract (ADR-0057); see [rules/lifecycle.md](./rules/lifecycle.md) |
+| `lifecycle` | Append-only / high-write-rate objects — retention / rotation / archival contract; see [rules/lifecycle.md](./rules/lifecycle.md) |
 | per-field `trackHistory` | Render a field's value changes as human-readable activity-timeline entries (pair with `enable.trackHistory`, ADR-0052 §5b) |
 
 > The former `softDelete` / `versioning` object keys were **removed** from the

--- a/skills/objectstack-data/rules/lifecycle.md
+++ b/skills/objectstack-data/rules/lifecycle.md
@@ -1,10 +1,10 @@
 # Data Lifecycle & Retention
 
 Guide for declaring how long an object's data lives and how its space is
-reclaimed (ADR-0057). Not to be confused with **lifecycle hooks**
-(`beforeInsert` / `afterUpdate` …) — those run business logic on data
-operations; *this* page is about retention, rotation, and archival of the
-rows themselves.
+reclaimed (ADR-0057 — system data lifecycle & retention). Not to be
+confused with **lifecycle hooks** (`beforeInsert` / `afterUpdate` …) —
+those run business logic on data operations; *this* page is about
+retention, rotation, and archival of the rows themselves.
 
 ## Why This Exists
 


### PR DESCRIPTION
Fixes #11781

`skills/**` is the published catalog: it ships into customer codebases that have
no `docs/adr/` to grep. A bare `ADR-0057` therefore resolves to **nothing** for
its actual audience — and in this repo the number is additionally one of the
three claimed by two unrelated records (the shrink-only
`KNOWN_NUMBER_COLLISIONS` in `check-adr-anchors.mjs`): system data lifecycle vs.
ERP authorization core.

## The measured constraint that shaped the fix

`skills/objectstack-data/SKILL.md` sits at **exactly** its published-skills token
ceiling — `13817 / 13817`, **zero headroom**. The ratchet's own remedy text says
new text is paid for by deleting text in the same file and that loosening a
ceiling is not the fix. Measured: even the shortest additive qualifier
(`(ADR-0057 lifecycle)`, +10 bytes per site) lands the file at 13822 tokens and
turns the gate red. So slug-qualifying **inside `SKILL.md` is not reachable**
without deleting other published text, which would be an unmeasured edit riding
on a measured card.

`rules/lifecycle.md` is unpriced — the ratchet enumerates `skills/*/SKILL.md`
only (`discoverSkillFiles`). That asymmetry is what makes a per-site answer both
possible and correct.

## Per-citation disposition

| Site | What it says | Which record | Load-bearing? | Action |
|:--|:--|:--|:--|:--|
| `SKILL.md:84` | "Data retention/rotation/archival contract (ADR-0057)" | system data lifecycle | **Decorative** — the row already states the contract in full and already links `./rules/lifecycle.md`, which *does* resolve for an external reader | Bare citation **dropped** (−11 bytes) |
| `SKILL.md:973` | "retention / rotation / archival contract (ADR-0057)" | system data lifecycle | **Decorative** — same, checklist row, same in-bundle link | Bare citation **dropped** (−11 bytes) |
| `rules/lifecycle.md:4` | "reclaimed (ADR-0057)" | system data lifecycle | **Decorative provenance**, but this is the page that *is* the substance — the right single anchor for the topic | **Slug-qualified**: `(ADR-0057 — system data lifecycle & retention)` |

Provenance is not lost at the two dropped sites: it survives one hop away, at
the destination both rows already point to.

## The form is not invented

Zone 2 asked whether a published skill can carry this. Findings:

- **ADRs are not published** — `content/docs/` has no ADR path, so no stable
  public URL exists to link. A URL form was not available.
- **Within the published catalog there is no disambiguating convention** — 175
  ADR citations across `skills/**`, essentially all bare.
- **Repo-wide the convention does exist**: `ADR-NNNN (short qualifier)` —
  `ADR-0010 (metadata protection)`, `ADR-0010 (NL → Flow authoring)`,
  `ADR-0019 (App as the consumer unit)`, `ADR-0057 (ERP auth)`. Most relevant,
  it is already used on a **published docs page**:
  `content/docs/permissions/attachments-access.mdx:139` writes
  `ADR-0057 (data lifecycle)`.
- It is also the maintainer-sanctioned route: the 2026-08-07 ruling recorded in
  `check-adr-anchors.mjs` ordered **C first, B to finish**, where B is
  "slug-qualified references for the three existing pairs … amortised as those
  files are touched". This is one of those files being touched.

## Non-vacuity, with controls

| Reading | Before | After |
|:--|--:|--:|
| bare `ADR-0057` in `skills/objectstack-data/` | 3 | **0** |
| slug-qualified `ADR-0057` in `skills/objectstack-data/` | 0 | **1** |
| **CONTROL** — `ADR-0057 D1` at `SKILL.md:651` | 1 | **1** (byte-identical) |
| **CONTROL** — `ADR-0010` in `SKILL.md` | 4 | **4** |
| **CONTROL** — `ADR-0052` in `SKILL.md` | 1 | **1** |
| **CONTROL** — all `ADR-NNNN` in `SKILL.md` | 32 | **30** (exactly the two dropped) |

`SKILL.md:651`'s `ADR-0057 D1` is deliberately untouched — the filer checked it
and it is correct (the ERP record's D1 really is scope-depth on object grants).

## Published-skill size readings

Lines are the primary reading; tokens reported too, per the sibling gate's
`ceil(utf8 bytes / 4)` convention.

| Surface | Lines | Tokens |
|:--|:--|:--|
| `skills/objectstack-data/SKILL.md` (whole file) | 1210 → 1210 (**0**) | 13817 → 13811 (**−6**) |
| `skills/objectstack-data/rules/lifecycle.md` (whole file) | 156 → 156 (**0**) | 1581 → 1590 (**+9**) |
| `skills/objectstack-data/` (whole published package) | 4934 → 4934 (**0**) | 46924 → 46928 (**+4**) |
| Ratchet-priced catalog surface (all `SKILL.md`) | — | 117916 → 117910 (**−6**) |

Line-neutral, and the surface the ratchet actually prices **shrinks**.

## Verification

All gate families derived from the real change set with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no
hand-written path list), then re-run at final commit `eaea14b08`. Each verdict
below is the gate's own printed line, not a shell `$?`.

- `node scripts/check-skills-token-ratchet.mjs` — `✓ check-skills-token-ratchet: skills/objectstack-data/SKILL.md is 13811 tokens (ceiling 13817; headroom 6).` (headroom was **0**)
- `pnpm check:doc-authoring` — `✓ doc authoring guard: 389 files clean — no bare metadata literals.`
- `pnpm check:skill-compatibility` — `✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 78 workspace packages`
- `pnpm check:skill-frame-sync` — `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files`
- `pnpm check:agent-test-spelling` — `✓ check-agent-test-spelling: 0 violations — 352 file(s) …`
- `pnpm check:role-word` — self-test + scan green
- `pnpm check:pm-governed-merges` — `✓ check-governed-merges --self-test: 129 assertions`
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — `✓ … 9 @example(s) judged clean across 997 packages/spec/src files`
- `pnpm check:nul-bytes` — self-test (75 assertions) + scan green

**Repo-wide `eslint . --no-inline-config` narrowed, and the narrowing is
measured rather than assumed** — three pieces:

1. Population read from eslint's own config, not guessed: run against both
   changed files, eslint reports `File ignored because no matching
   configuration was supplied` for each.
2. File count read from `--format json`: 2 paths submitted, **0 files actually
   linted**, 0 errors.
3. Invariance for untouched files: `eslint.config.*` declares no
   `parserOptions.project` and no `projectService` (its line 328 documents the
   absence explicitly), so linting is not type-aware — a markdown-only diff
   cannot move any verdict on any file it does not touch.

No changeset: markdown-only change to the published skill catalog, matching
repo precedent for `docs(skills):` commits.

## Governed surface

`skills/**` is governed (Prime Directive #14). This PR **stays draft**, review
requested from `os-zhuang`, and is not to be flipped ready, armed for
auto-merge, or enqueued by any agent seat. A human reviews governed changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_