### PR TITLE
fix(devx): stop the scim follow-up note from restating the model count

### DIFF
--- a/scripts/check-prerelease-pin-watch.mjs
+++ b/scripts/check-prerelease-pin-watch.mjs
@@ -145,6 +145,33 @@ export class RegistryUnreadable extends Error {}
 // Unmapped is legal and is itself reported: a prerelease pin with no recorded
 // revert plan is the #5024 shape again, and saying so is cheaper than
 // discovering it later.
+//
+// THE RULE FOR A NOTE: carry the ACTION, point at the PIN for the MEASUREMENT.
+// -----------------------------------------------------------------------------
+// A note's job is to tell its reader what to DO. It must not restate a fact
+// that is measured and written down somewhere else -- above all not a COUNT.
+// The SCIM model set is measured in the `@better-auth/scim` block of
+// `pnpm-workspace.yaml`; this note used to carry its own typed copy of that
+// measurement ("all six new models present"), which is a second copy with
+// nothing holding it to the first.
+//
+// It rotted exactly the way a second copy rots. The measurement was re-taken
+// and corrected in the pin comment (#11372, #11764) and the copy here went on
+// printing the old number on every nightly run -- to the single reader this
+// probe exists to inform, at the moment they have the least context. #11761
+// deleted the copy rather than correcting it a second time: a correction would
+// have left a third copy waiting to rot.
+//
+// Deriving the number here instead was considered and measured as impractical:
+// the count lives in a `#` comment, which `readOverrides` skips by design, and
+// that block states three different counts (the core set, what
+// `managedConnections` adds, and the total). A regex over wrapped English prose
+// would have to GUESS which one a note meant -- a tolerant reader of an
+// unspecified producer, which is the shape this repo removes rather than adds.
+// So the note points, and the pin comment stays the single source.
+//
+// `restatedModelCounts()` mechanizes the COUNT half of this rule -- the half
+// that has demonstrably rotted -- and the self-test proves it can still fail.
 // ---------------------------------------------------------------------------
 
 /** @type {Array<{ match: RegExp, issues: string[], note: string }>} */
@@ -158,10 +185,12 @@ const FOLLOW_UPS = [
     note:
       'SCIM is a MIGRATION, not a bump (#3653): rc.2 replaced the model set and moved ' +
       'connections from runtime rows to boot config, and the STABLE 1.7 releases ship that ' +
-      'same rewrite (measured on the 1.7.1 tarball: no scimProvider model, no generate-token ' +
-      'endpoint, all six new models present). Do the migration against the stable models — ' +
-      'do not "align" this pin with the family first. #3002 moved the REST of the family to ' +
-      'stable ^1.7.1 and left this pin behind deliberately, so #3653 is the only card left.',
+      'same rewrite. That rewrite is measured against the published tarball and written ' +
+      'down ONCE, in the `@better-auth/scim` block of pnpm-workspace.yaml — read it there ' +
+      'for which models the stable line ships, what it dropped, and what `managedConnections` ' +
+      'adds. Do the migration against the stable models — do not "align" this pin with the ' +
+      'family first. #3002 moved the REST of the family to stable ^1.7.1 and left this pin ' +
+      'behind deliberately, so #3653 is the only card left.',
   },
   {
     match: /^(better-auth|@better-auth\/.+)$/,
@@ -178,6 +207,28 @@ const FOLLOW_UPS = [
 /** @returns {{ issues: string[], note: string } | null} */
 export function followUpFor(pkg) {
   return FOLLOW_UPS.find((f) => f.match.test(pkg)) ?? null;
+}
+
+/**
+ * The ledger rule above, mechanized for the half that rots: a note may not
+ * state a COUNT of upstream models. Version numbers and issue refs are stripped
+ * first — `1.7.1` and `#3653` are identifiers, not counts of anything, and a
+ * guard that reddens on them would be turned off rather than obeyed.
+ *
+ * @returns {string[]} every offending fragment; empty means the note obeys.
+ */
+export function restatedModelCounts(note) {
+  const prose = String(note)
+    .replace(/#\d+/g, '')
+    .replace(/\brc\.\d+\b/gi, '')
+    .replace(/\b\d+(?:\.\d+)+(?:-[0-9A-Za-z.]+)?\b/g, '');
+  const CARDINAL =
+    '(?:\\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)';
+  const re = new RegExp(
+    `\\b${CARDINAL}\\b[^.]{0,40}?\\bmodels?\\b|\\bmodels?\\b[^.]{0,40}?\\b${CARDINAL}\\b`,
+    'gi',
+  );
+  return prose.match(re) ?? [];
 }
 
 // ---------------------------------------------------------------------------
@@ -635,6 +686,41 @@ function selfTest() {
   check(
     'the rest of the family carries a follow-up card too',
     watch.find((w) => w.name === 'better-auth').followUp.issues.join() === '#3653',
+  );
+
+  // --- 1b. the ledger rule: a note points at the pin, it does not restate it -
+  // Two correction rounds found one copy each and left the other (#11372 fixed
+  // the pin comment, #11761 the note). What forbids a third copy is this check,
+  // not the memory of those rounds.
+  const restated = FOLLOW_UPS.flatMap((f) =>
+    restatedModelCounts(f.note).map((m) => `${f.match.source} -> "${m.trim()}"`),
+  );
+  check(
+    'no follow-up note restates a model COUNT (the pin comment is the single source)',
+    restated.length === 0,
+    restated.join(' | '),
+  );
+  check(
+    'the scim note routes its reader to that single source BY NAME',
+    followUpFor('@better-auth/scim').note.includes('pnpm-workspace.yaml'),
+    followUpFor('@better-auth/scim').note,
+  );
+  // Positive control. A guard that cannot fail is not a guard, and the zero
+  // above is only worth reading next to this one: the exact wording #11761
+  // deleted, kept here verbatim so the check can never quietly become a no-op.
+  check(
+    'the count guard FIRES on the exact wording this ledger used to print',
+    restatedModelCounts(
+      'the STABLE 1.7 releases ship that same rewrite (measured on the 1.7.1 tarball: no ' +
+        'scimProvider model, no generate-token endpoint, all six new models present).',
+    ).length > 0,
+  );
+  // Negative control: a version is an identifier, not a count. A guard that
+  // reddened on `1.7.1` next to `models` would be switched off, not obeyed.
+  check(
+    'the count guard does NOT fire on version numbers or issue refs',
+    restatedModelCounts('the models changed in 1.7.1, again in rc.2, tracked by #3653')
+      .length === 0,
   );
   check(
     'a prerelease pin with no declared follow-up is watched anyway (unmapped is legal)',


### PR DESCRIPTION
Fixes #11761

The `@better-auth/scim` entry in this probe's `FOLLOW_UPS` ledger carried its own
typed copy of a measurement that is taken and written down in
`pnpm-workspace.yaml`'s pin comment. The copy read `all six new models present`;
the pin comment, re-measured and corrected in #11764 (`589eae250`), reads
`seven` / `all seven present`. Because the note is printed **verbatim** by the
nightly probe, the stale number was emitted on every run — to the single reader
the gate exists to inform.

The defect class is **one measurement written down twice with nothing holding the
copies together**. A correction round already found one copy and left this one
(#11372), so this PR does not re-type the number.

## What the reader actually sees

Same command both ways — the real CLI, offline, against the repo's own
`pnpm-workspace.yaml`, with a fixture that publishes a stable release:

```
node scripts/check-prerelease-pin-watch.mjs --fixture scim-stable.json
```

**Before** (`origin/main`, exit 1):

```
      action list: #3653
      SCIM is a MIGRATION, not a bump (#3653): rc.2 replaced the model set and moved
      connections from runtime rows to boot config, and the STABLE 1.7 releases ship
      that same rewrite (measured on the 1.7.1 tarball: no scimProvider model, no
      generate-token endpoint, all six new models present). Do the migration against
      the stable models — do not "align" this pin with the family first. #3002 moved
      the REST of the family to stable ^1.7.1 and left this pin behind deliberately,
      so #3653 is the only card left.
```

**After** (this branch, exit 1):

```
      action list: #3653
      SCIM is a MIGRATION, not a bump (#3653): rc.2 replaced the model set and moved
      connections from runtime rows to boot config, and the STABLE 1.7 releases ship
      that same rewrite. That rewrite is measured against the published tarball and
      written down ONCE, in the `@better-auth/scim` block of pnpm-workspace.yaml —
      read it there for which models the stable line ships, what it dropped, and what
      `managedConnections` adds. Do the migration against the stable models — do not
      "align" this pin with the family first. #3002 moved the REST of the family to
      stable ^1.7.1 and left this pin behind deliberately, so #3653 is the only card
      left.
```

`diff` over the two captured reports: **exactly one of the 16 printed lines
changed** — the note. The verdict, the pin, the remedy and the error annotation
are byte-identical, including `pinned: 1.7.0-rc.1`, `STABLE in the pinned line:
1.7.0, 1.7.1  → revert the pin to ^1.7.x`, `action list: #3653`, the dist-tag
context line, and `::error::A stable release retires a prerelease pin`.

## Why point rather than derive

Both halves were measured, not assumed:

- **The file is present at run time.** `prerelease-pin-watch.yml` runs
  `actions/checkout@v7` before the probe, and the probe already reads
  `pnpm-workspace.yaml`. So a pointer points at something the nightly reader has.
- **The number is not machine-readable there.** It lives in a `#` comment, which
  `readOverrides` skips by design, and that block states **three** different
  counts — `seven new models` (core), `three MORE models` (`managedConnections`),
  `ten in total`. A regex over wrapped English prose would have to *guess* which
  one a note meant. That is a tolerant reader of an unspecified producer, which is
  the shape this repo removes rather than adds.

So the note points, the pin comment stays the single source, and the note states
no count at all. The sibling `FOLLOW_UPS` entry already used this shape (`read the
pin's own comment in pnpm-workspace.yaml for why`), so this conforms to a form the
ledger had already declared rather than inventing one.

## What stops a third copy

`restatedModelCounts()` mechanizes the count half of the rule: no `FOLLOW_UPS`
note may state a count of models. Version numbers and issue refs are stripped
first — `1.7.1` and `#3653` are identifiers, not counts, and a guard that reddened
on them would be switched off rather than obeyed.

The ledger's header now records the rule itself, why deriving was rejected, and
that the guard covers the count half rather than all of it.

**Non-vacuity, measured live rather than asserted.** Putting the deleted wording
back into the real ledger entry drives the self-test red:

```
  ✗ no follow-up note restates a model COUNT (the pin comment is the single source)
      — ^@better-auth\/scim$ -> "six new models"
⛔ check-prerelease-pin-watch --self-test: 1 failure(s)
```

exit `1`. The mutation was confirmed on disk before the run (`grep -c` in both
directions), the restore was confirmed **byte-identical** with `cmp`, and the
self-test returned to exit `0` afterwards. The script is plain ESM run directly by
node — there is no `dist/`, so no rebuild leg applies to either side.

The self-test also carries that positive control permanently (the exact deleted
wording, which must keep tripping the guard) plus a negative control (`the models
changed in 1.7.1, again in rc.2, tracked by #3653` must **not** trip it), so the
green above can never quietly become a no-op.

## Scope

The pin is untouched — moving it is still the ADR-0071 migration on #3653, out of
scope here. `pnpm-workspace.yaml` is not in this diff; the only file changed is
`scripts/check-prerelease-pin-watch.mjs`. Both copies of this fact still retire
together when the pin leaves the watch list (#11632).

## Gates

Union re-run at final head `13d03ab92`, working tree clean, each read from the
gate's own printed verdict line (redirect-then-capture, never `| tail` then `$?`):

| gate | exit |
| --- | --- |
| `node scripts/check-prerelease-pin-watch.mjs --self-test` (50 checks) | 0 |
| `check:agent-test-spelling` | 0 |
| `check:cross-package-test-inputs` | 0 |
| `check:entry-guard` | 0 |
| `check:parse-guard` | 0 |
| `check:pnpm-filter-targets` | 0 |
| `check:nul-bytes` | 0 |

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
from the working tree (1 path) — it named exactly the seven families above, matching
the forecast recorded on the card. The guard added **no** new verification surface.

`pnpm lint` was **not** run locally and this is a non-run, not a declared
narrowing: the worktree has no `node_modules` and the measurement a narrowing owes
(population read from eslint's own config, file count from `--format json`) is not
obtainable without it. CI owns that scan. As a sanity signal only, the longest line
this diff adds is 97 chars against a pre-existing file maximum of 229.

No changeset: `scripts/` publishes nothing, so this takes the `skip-changeset`
label (route 2).


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_