### PR TITLE
ci(lint): run the .claude/hooks self-test matrices in the required job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -784,6 +784,106 @@ jobs:
       - name: PM ci-failure self-test
         run: node scripts/pm/ci-failure.mjs --self-test
 
+      # Claude hook guard self-tests (#11514, objectstack half of
+      # objectstack-ai/objectui#5754). `.claude/hooks/` holds the enforcement
+      # behind the two rules whose violation is most expensive in this repo —
+      # worktree-first and the stash ban — and each guard ships a hermetic
+      # matrix asserting its block/allow verdict case by case, with a header
+      # telling you to re-run it after touching the hook. Nothing ran them:
+      # `grep -rn 'selftest' .github/workflows/` returned no match when this
+      # card was filed, so those headers WERE the enforcement. A guard that has
+      # silently stopped guarding is worse than no guard, because everyone keeps
+      # behaving as though it works — the stash ban's own receipt is two
+      # parallel agents losing their in-flight changes to a shared LIFO stack.
+      #
+      # Baseline on `main` before this step existed, measured rather than
+      # assumed: `guard-main-checkout-bash` 121 cases pass, `guard-shared-stash`
+      # 32 cases pass. Both guards were healthy; this wires the alarm, it does
+      # not fix an outage.
+      #
+      # ⭐ DISCOVERED at run time, never listed. A hard-coded list is this
+      # card's own defect one level up: add a hook with a matrix tomorrow and it
+      # silently is not run, and nothing goes red. The glob is the contract, so
+      # a new `.claude/hooks/**/*.selftest.sh` is picked up with no edit here.
+      # `find`, not a flat glob, so a matrix in a subdirectory is not a silent
+      # miss either.
+      #
+      # ...and an EMPTY discovery is RED, not green (#4690). A renamed or moved
+      # directory would otherwise make this step pass by running nothing, which
+      # is the identical green line the whole self-test family above exists to
+      # distrust. The count is printed on success so a SHRINKING set is visible
+      # in the log rather than inferred.
+      #
+      # ⭐ Collected rather than sequenced, for the reason spelled out at the
+      # `Shallow-history guard self-tests` step above (#10814): a `run:` block
+      # is executed as `bash -e`, so a bare loop would abort at the FIRST red
+      # matrix and leave the rest unrun — neither green nor red, and nothing in
+      # the log tells those apart. The matrices are independent by construction
+      # (each builds its own throwaway fixture), so collecting loses nothing.
+      # ⚠️ `check:step-collectors` CANNOT see this block — its population is
+      # `scripts/`|`packages/` paths carrying `--self-test`, and these are
+      # `.claude/hooks/*.selftest.sh` — so the collector shape here is held by
+      # review, not by that gate. Do not "simplify" it into a bare loop.
+      #
+      # ⛔ This step RUNS the matrices; it does not modify any hook. `.claude/**`
+      # is governed surface and this workflow is not — that separation is what
+      # keeps the wiring on the ordinary merge path.
+      #
+      # Home: a STEP of this job rather than a job of its own, deliberately.
+      # `Lint & Repo Gates` is a required status context (pinned by
+      # `check:required-contexts`); a new job would publish a context that is in
+      # no ruleset, so a red guard would be advisory and the merge queue would
+      # not stop for it — #5617 verbatim, which is the exact shape this card
+      # exists to close.
+      #
+      # Hermetic by construction, and measured that way: each matrix builds its
+      # own git repo and linked worktree under $TMPDIR, and both were re-run
+      # from a primary checkout, a detached HEAD and a non-repo cwd with
+      # identical results, so neither this checkout's depth nor its branch is an
+      # input. Needs `jq` and `git` and nothing else — no pnpm, no node, no
+      # build, no network (`jq` is in the runner image and is already relied on
+      # bare by cut-rc.yml and release.yml). ~2 s measured.
+      - name: Claude hook guard self-tests (worktree-first · stash ban)
+        run: |
+          # Tolerate-and-collect (#10814) — see the note above this step. Each
+          # matrix runs unconditionally and prints its own verdict; the step
+          # still FAILS when any of them does, naming every one that failed.
+          # ⛔ Never let the collector swallow the exit code — a green step over
+          # a red self-test looks identical to success.
+          mapfile -t selftests < <(find .claude/hooks -type f -name '*.selftest.sh' | sort)
+          if [ "${#selftests[@]}" -eq 0 ]; then
+            echo "Claude hook guard self-tests — DISCOVERED NOTHING under .claude/hooks/."
+            echo "This step verified nothing, which is a failure and not a pass (#4690):"
+            echo "the matrices were moved, renamed or deleted. Re-point the search above"
+            echo "rather than deleting the step."
+            exit 1
+          fi
+          echo "discovered ${#selftests[@]} hook self-test(s):"
+          printf '  %s\n' "${selftests[@]}"
+          echo ""
+          failed=""
+          run_self_test() {
+            echo "-- $*"
+            if "$@"; then
+              echo "PASS  $*"
+            else
+              echo "FAIL  $*"
+              failed="${failed}  $*"$'\n'
+            fi
+            return 0
+          }
+          for selftest in "${selftests[@]}"; do
+            run_self_test "$selftest"
+          done
+          if [ -n "$failed" ]; then
+            echo ""
+            echo "Claude hook guard self-tests — the following FAILED:"
+            printf "%s" "$failed"
+            exit 1
+          fi
+          echo ""
+          echo "Claude hook guard self-tests — all ${#selftests[@]} ran and passed"
+
       # Docs/skills authoring guard (#2035 / ADR-0059): TS code blocks in
       # Markdown/MDX are not type-checked or ESLinted, so skills/ and
       # content/docs/ can drift back to teaching the bare `: Page = {}` literal


### PR DESCRIPTION
Fixes #11514

`.claude/hooks/` holds the enforcement behind the two rules whose violation is most expensive in this repo — worktree-first and the stash ban — and each guard ships a hermetic self-test matrix whose header tells you to re-run it after touching the hook. Nothing ran them: `grep -rn 'selftest' .github/workflows/` matched nothing. So those headers *were* the enforcement, and a guard that had silently stopped guarding landed green — the worse half of a broken guard, because everyone keeps behaving as though it works.

One step is added to the `lint` job. **No hook is modified** — `.claude/**` is governed surface, this workflow is not.

## Baseline on `main` — measured before wiring anything

The first time anything measured these. Both healthy, so this wires an alarm rather than fixing an outage:

| self-test | cases | exit |
|---|---|---|
| `.claude/hooks/guard-main-checkout-bash.selftest.sh` | `121 passed, 0 failed` | 0 |
| `.claude/hooks/guard-shared-stash.selftest.sh` | `32 passed, 0 failed` | 0 |

Measured set, rather than the card's description: `.claude/hooks/` holds **two** self-tests, not three. `guard-main-checkout.sh` — the `Edit`/`Write` half of the pair — ships **no** self-test at all; only the Bash half does. That gap is reported, not closed here (authoring one is a `.claude/**` change).

## Non-vacuity — the step goes RED when a guard breaks

The deliverable, both directions, driving the real block extracted from this file under a real `bash -e`, the way Actions runs it. `guard-main-checkout-bash.sh`'s sole BLOCK verdict was mutated `exit 2` → `exit 0` — the guard stops guarding — as a scratch mutation under `trap … EXIT INT TERM`, never committed, proven on disk by anchor counts in both directions (`exit 2` 1→0, `exit 0` 0→1, sha moved) and restored byte-identical (sha `5db89551c9090bdb` before and after; `git diff` on `.claude/` empty).

| run | step exit | what the log says |
|---|---|---|
| unmutated tree | **0** | `discovered 2` · both `PASS` · `all 2 ran and passed` |
| guard mutated | **1** | `FAIL .claude/hooks/guard-main-checkout-bash.selftest.sh` (`70 passed, 51 failed`, every one `want=block got=allow`) |

The mutated guard is the **first** discovered, and the second still ran and passed (`32 passed, 0 failed`) in that same red run — so the collector really does defeat the `bash -e` masking, rather than merely being written to.

## Discovery is the contract, not a list

A hard-coded list would be this card's own defect one level up: add a hook with a matrix tomorrow, it silently is not run, nothing goes red. Proven with a scratch fixture (uncommitted, removed; `git status` on `.claude/` clean afterwards):

| run | step exit | result |
|---|---|---|
| new passing self-test added, **workflow untouched** | 0 | `discovered 3` — picked up with no edit here |
| same file made to exit 1 | 1 | `FAIL … zz-scratch-fixture.selftest.sh` — it is really executed, not just listed |
| run where nothing is discovered | 1 | `DISCOVERED NOTHING … verified nothing, which is a failure and not a pass (#4690)` |

That last row is the direction a glob normally fails in: a renamed or moved directory would otherwise make the step pass by running nothing — the same green line this whole family exists to distrust.

## Three placement decisions, each on evidence

**A step of the `lint` job, not a job of its own.** `Lint & Repo Gates` is a required status context (registered in `check:required-contexts`). A new job publishes a context in no ruleset, so a red guard would be advisory and the merge queue would not stop for it — #5617 verbatim, the exact shape this card exists to close.

**Tolerate-and-collect, not a bare loop** (#10814). A `run:` block is `bash -e`, so a bare loop aborts at the first red matrix and leaves the rest unrun. ⚠️ `check:step-collectors` **cannot see this block** — its population is `scripts/`|`packages/` paths carrying `--self-test`, and these are `.claude/hooks/*.selftest.sh`. Confirmed empirically: with this step in the tree that gate still reports `2 step(s) run 2+ independent self-tests`. The collector shape here is held by review, so the step carries a ⛔ note against "simplifying" it.

**Dependencies verified on the runner's terms, not assumed.** Needs `jq` and `git` and nothing else — no pnpm, no node, no build, no network. `jq` is used bare on `ubuntu-latest` by `cut-rc.yml` and `release.yml` already. Hermeticity was measured rather than read off the headers: each matrix builds its own git repo and linked worktree under `$TMPDIR`, and both were re-run from a primary checkout, a detached HEAD, and a non-repo cwd — `121/0` and `32/0` in all three. So neither this checkout's depth nor its branch is an input. ~2 s.

## Gates

Union re-run after the final commit, at `a05a5f961`. The 13 families derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (which reads the change set itself), plus `check:nul-bytes`: all green — `check-step-collectors` `✓ 329 run: steps across 26 workflow(s)`, `check-workflow-status-functions` `OK (scanned 26 workflow file(s), 49 job(s))`, `check-nul-bytes` `OK (scanned 6573 text file(s))`, `check:required-contexts`, `check:aggregator-roster`, `check:shard-attestation`, `check:type-check-coverage`, `check:agent-test-spelling`, `check:node-version`, `check:pnpm-filter-targets`, `ci-failure --self-test` all exit 0.

**One declared narrowing.** `check:type-check-debt` (`--self-test && --re-measure`) did not complete locally: its `--re-measure` half refuses on an unbuilt dependency closure by design (#6376, "measuring now would not fail, it would silently measure a DIFFERENT WORLD"), which is a property of a fresh worktree, not of this diff. Its `--self-test` half passed (182 cases), and the half that reads `lint.yml` — `observed()` — is shared with `check:type-check-coverage`, which passed **with this edit in place**, so every assertion this gate makes about `lint.yml` holds. This diff changes 1 file and 0 TypeScript files, so no ledger number is reachable from it; CI builds the closure before that step and measures there.

No changeset: this PR edits one CI workflow and releases nothing — the textbook `skip-changeset` case by this file's own prescription.

Sequencing: #11779 also edits `.github/workflows/lint.yml`, at line ~1654 (after `Node-version drift guard`). This edit is at line ~787. Verified by content, not assumed — #11779 had not landed on `main` at branch time.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_