### PR TITLE
fix(metadata-protocol): drop the invented-empty-registry swallow in global search

### DIFF
--- a/.changeset/global-search-registry-propagate.md
+++ b/.changeset/global-search-registry-propagate.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+Global search (`searchAll`, the producer behind `GET /api/v1/search`) no longer invents an empty registry. The registry read was `registry?.getAllObjects?.() ?? []`, so a host whose registry does not implement `getAllObjects` — a structural omission that never throws — produced a successful "nothing matched" response with `objectsScanned: 0`. A registry that cannot enumerate its objects is never truthfully "no objects" (ADR-0110 D3): both halves of the swallow are removed and the omission now surfaces as the read's own failure, mapped by the REST door's standard error path. Unchanged neighbours: a registry that enumerates and truthfully answers "no objects" still yields the successful empty response, and a blank query still short-circuits before the registry is consulted.

--- a/packages/metadata-protocol/src/protocol.read-seam-empty-accumulator.test.ts
+++ b/packages/metadata-protocol/src/protocol.read-seam-empty-accumulator.test.ts
@@ -204,6 +204,105 @@ describe('[#8896] searchAll — an object that could not be READ is not an objec
     });
 });
 
+describe('[#11754] searchAll — a registry that cannot ENUMERATE is not a registry with no objects', () => {
+    const acct = objectFixture('acct');
+
+    /**
+     * The seam this pins: `searchAll` used to read the registry as
+     * `(engine as any).registry?.getAllObjects?.() ?? []`. Neither guard could
+     * ever fire on an outage — `SchemaRegistry.getAllObjects()` walks in-memory
+     * Maps and has no throwing path — so what they absorbed was only the
+     * STRUCTURAL omission: a host whose registry does not implement
+     * `getAllObjects` at all. That omission never throws, so pre-fix the whole
+     * sweep was a silent no-op: `{ hits: [], totalObjects: 0, totalHits: 0,
+     * truncated: false }` under a successful response, indistinguishable from
+     * a deployment with genuinely nothing registered (ADR-0110 D3).
+     *
+     * No new code and no new envelope are minted here on purpose — the ruled
+     * disposition (#9284, the engine's own registry sweeps) is to drop both
+     * halves of the swallow and let the omission surface as the read's own
+     * failure, which for a missing method is the runtime's TypeError.
+     */
+
+    it('a registry WITHOUT getAllObjects rejects instead of inventing an empty sweep', async () => {
+        const find = vi.fn(async () => [{ id: 'a1', name: 'Acme' }]);
+        const engine = {
+            // Everything a registry needs EXCEPT enumeration — the structural
+            // omission, not an error class.
+            registry: {
+                getObject: (n: string) => (n === 'acct' ? acct : undefined),
+                getItem: () => undefined,
+                listItems: () => [],
+            },
+            find,
+            findOne: vi.fn(async () => null),
+        };
+        const protocol = new ObjectStackProtocolImplementation(engine as never);
+
+        const caught = await rejection(() => protocol.searchAll({ q: 'Acme' }));
+
+        // The omission surfaces as itself — the runtime's own TypeError naming
+        // the missing member — never a minted code, never an invented answer.
+        expect(caught).toBeInstanceOf(TypeError);
+        expect(caught.message).toContain('getAllObjects');
+        // The sweep never ran: no data read was issued for an enumeration that
+        // did not happen.
+        expect(find).not.toHaveBeenCalled();
+        // Pre-fix this resolved with `{ query: 'Acme', hits: [],
+        // totalObjects: 0, totalHits: 0, truncated: false }` — "nothing
+        // matched", reported for a registry that was never asked.
+    });
+
+    it('an engine with NO registry rejects too (the other dropped `?.`)', async () => {
+        const engine = {
+            find: vi.fn(async () => []),
+            findOne: vi.fn(async () => null),
+        };
+        const protocol = new ObjectStackProtocolImplementation(engine as never);
+
+        const caught = await rejection(() => protocol.searchAll({ q: 'Acme' }));
+
+        expect(caught).toBeInstanceOf(TypeError);
+    });
+
+    it('control: a registry that truthfully answers "no objects" still resolves the empty response', async () => {
+        // The one benign emptiness: the registry ENUMERATED and the answer was
+        // empty. This is the neighbouring shape the fix must not move.
+        const engine = {
+            registry: { ...fixtureRegistry([]), getAllObjects: vi.fn(() => []) },
+            find: vi.fn(async () => []),
+            findOne: vi.fn(async () => null),
+        };
+        const protocol = new ObjectStackProtocolImplementation(engine as never);
+
+        const result = await protocol.searchAll({ q: 'Acme' });
+
+        expect(result).toEqual({ query: 'Acme', hits: [], totalObjects: 0, totalHits: 0, truncated: false });
+        // Proof the emptiness was SAID by the registry, not invented past it.
+        expect(engine.registry.getAllObjects).toHaveBeenCalledTimes(1);
+    });
+
+    it('control: a blank query still short-circuits BEFORE the registry is consulted', async () => {
+        // The early return for an empty `q` sits above the enumeration read.
+        // Pinned so the propagate change cannot drift it: a registry-less host
+        // asked nothing must keep getting the empty-query answer, not a throw.
+        const engine = {
+            registry: {
+                getObject: () => undefined,
+                getItem: () => undefined,
+                listItems: () => [],
+            },
+            find: vi.fn(async () => []),
+            findOne: vi.fn(async () => null),
+        };
+        const protocol = new ObjectStackProtocolImplementation(engine as never);
+
+        const result = await protocol.searchAll({ q: '   ' });
+
+        expect(result).toEqual({ query: '', hits: [], totalObjects: 0, totalHits: 0, truncated: false });
+    });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // findReferencesToMeta
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -9863,7 +9863,19 @@ export class ObjectStackProtocolImplementation implements
         // pre-tokenised channel is exactly the divergence this card closed.
         const terms = q.split(/\s+/).filter(Boolean).slice(0, 8);
 
-        const allObjects = (this.engine as any).registry?.getAllObjects?.() ?? [];
+        // [#11754] No `?.` and no `?? []` on this read. The invented empty
+        // list made the whole sweep a silent no-op — zero hits,
+        // `objectsScanned: 0`, and a successful response — for a host whose
+        // registry cannot enumerate at all. `SchemaRegistry.getAllObjects()`
+        // walks in-memory Maps and has no throwing path, so what the guards
+        // absorbed was only the STRUCTURAL omission (a registry without the
+        // method), which never throws and is therefore invisible by
+        // construction. A registry that cannot enumerate its objects is
+        // never truthfully "no objects" (ADR-0110 D3) — the omission
+        // propagates, the same disposition as the engine's own registry
+        // sweeps (#9284). `registry` is a declared member of
+        // `MetadataHostEngine`, so the cast went with the guards.
+        const allObjects = this.engine.registry.getAllObjects();
         const hits: Array<{ object: string; id: string; title: string; snippet?: string; record: any }> = [];
         let objectsScanned = 0;
 


### PR DESCRIPTION
Closes #11754

## What was measured

- The seam, located by symbol (line numbers rot): `searchAll` in `packages/metadata-protocol/src/protocol.ts` read the host registry as `(this.engine as any).registry?.getAllObjects?.() ?? []`. An invented empty list made the whole sweep a silent no-op: zero hits, `objectsScanned: 0`, and a successful response.
- The #9284 precedent re-verified on `origin/main` at `7e83932621` before leaning on it: `const objects: ServiceObject[] = this._registry.getAllObjects();` at `packages/objectql/src/engine.ts` 7448 / 10562 / 10805, and `grep -c 'objects = []'` over that file returns 0. The landed disposition is drop-both-halves-and-propagate.
- **Honest frame: this is a Task, not a Bug.** No live path is demonstrated reaching the seam and no test was shown vacuous. `SchemaRegistry.getAllObjects()` walks in-memory `Map`s with no throwing path, so the `?? []` could never fire on an outage — what the guards absorbed is the **structural omission** (a host registry that does not implement `getAllObjects` at all), which never throws and is invisible by construction. This closes the last unswept member of the invented-empty-registry family (#9002, #8896, #9285/PR #9682), on the ruled *discriminate or propagate* answer (#8895): a registry that cannot enumerate its objects is never truthfully "no objects" (ADR-0110 D3). No reproduction and no user-visible defect are claimed.

## What changed

- `packages/metadata-protocol/src/protocol.ts` — one hunk at the seam: `const allObjects = this.engine.registry.getAllObjects();`. Both `?.` and the `?? []` are gone; the `as any` cast went with them (`registry` is a declared member of `MetadataHostEngine`). No new error code and no new response field: at the REST door the omission surfaces through `GET /search`'s existing `catch` → `mapDataError` path. This is an accept→reject flip on a public door for the broken-composition case only — a call that answered HTTP 200 with zero hits over an unenumerable registry now fails. The diff widens no public surface beyond that predicted flip.
- `packages/metadata-protocol/src/protocol.read-seam-empty-accumulator.test.ts` — four pins added beside the family's existing [#8896] tests: the omission rejects (TypeError naming `getAllObjects`, and the data read was never issued), a registry-less engine rejects, a registry that truthfully enumerates "no objects" still resolves the successful empty response, and a blank query still short-circuits before the registry is consulted.
- `.changeset/global-search-registry-propagate.md` — patch, `@objectstack/metadata-protocol`.

## What was deliberately NOT changed

- The import block at the top of `protocol.ts` (~L75) — untouched by construction; the diff is one hunk at the seam, ~9,800 lines away from PR #11716's emitted-specifier pin region. No import was added or reordered.
- `packages/cli/src/utils/schema-migrate.ts:329` — same spelling, but its docblock declares the degradation and its consumer is one advisory; examined and cleared by the filer (`domain:cli`).
- `packages/objectql/src/plugin.ts:728` — the `objectsRegistered` start-log count, cleared explicitly by #9285. Neither of #9285 / #9284 / #8895 is addressed here; each remains as it was.
- No structured error is minted for the omission: the ruled disposition is propagation of the read's own failure, matching the engine-side precedent and the existing [#8896] catch commentary ("the caller receives the read's own failure, envelope intact").

## Test-double fallout, with counts

Predicted in advance from #9284's nine suites; **measured here: 0 suites went red.** All nine candidate suites referencing `searchAll` were enumerated and either run or read: metadata-protocol (4 suites — doubles all implement `getAllObjects`; the two `orderby-vocabulary` doubles without it feed only `auditMetaItem`), objectql (4 suites — real `ObjectQL` engines; the one minimal `noTxEngine` double calls only `getDiscovery`), rest (3 suites — either mock the protocol object itself or use a fake engine that implements `getAllObjects`), runtime (1 suite — mocks the protocol). No double was fixed because none was broken; no suite was skipped, disabled, or quarantined.

## Verification (all at `583b3ed268`, the branch head; exit codes captured before any pipe)

- `pnpm --filter @objectstack/metadata-protocol exec vitest run --maxWorkers=2` — **139 files / 1913 tests passed**, 0 failed (2 files / 10 tests pre-existing skips).
- Targeted downstream (after rebuilding `@objectstack/metadata-protocol` dist and confirming the fix reached it: `grep -c 'registry.getAllObjects()' dist/index.js` = 1, swallow spelling = 0): objectql 4 suites **78 passed**; rest 3 suites **64 passed**; runtime 1 suite **23 passed**.
- Derived gate union (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, change set taken by the script from merge base `7e8393262`, derivation stamped at `583b3ed268`): all 16 path-matched + 5 convention-triggered gates green by their own exit codes, including `check:durability-log-level` (its own verdict line: "66 read seam(s), none invents an unreported answer"), `check:engine-double-contract`, `check:where-matcher`, `check:cross-package-test-inputs`, `check:nul-bytes` ("scanned 6590 text file(s) … no raw ASCII control bytes").
- `pnpm check:type-check-debt --re-measure` after `turbo run build --filter='./packages/*' --filter='./packages/*/*'` (70/70 tasks): "32 ledger entr(ies) re-measured … none above its recorded number" — the new test code does not move metadata-protocol's frozen 63.
- `pnpm lint` (full repo eslint, not narrowed): exit 0.

## Ablation, with numbers

Fix committed first; mutation and restore both proven on disk by anchored `grep -cF` counts; restore ran under `trap … EXIT INT TERM`.

- Direction predicted in advance: the two omission pins go red with a resolved invented-empty response; the two controls and all [#8896] tests stay green.
- Mutation leg: swallow spelling restored (`swallow-count=1`, `fixed-count=0` on disk). `vitest run src/protocol.read-seam-empty-accumulator.test.ts` → exit 1, **2 failed / 12 passed**, both failures the exact pre-fix shape: `expected a rejection, but the call resolved with {"query":"Acme","hits":[],"totalObjects":0,"totalHits":0,"truncated":false}`.
- Restore leg: `swallow-count=0`, `fixed-count=1`, `git status --porcelain` empty.
- No rebuild was needed for either ablation leg, and that claim is itself measured: the suite imports `./protocol.js` relative (vitest resolves it to `src/protocol.ts`), and the package's full suite — new pins included — passed **before** `packages/metadata-protocol/dist` existed in this fresh worktree, which is only possible if the tests read `src`, not `dist`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK8rFDtg8eREaxBGX99Csn)_