### PR TITLE
docs(protocol): document the real checkMethod health-check contract

### DIFF
--- a/content/docs/protocol/kernel/lifecycle.mdx
+++ b/content/docs/protocol/kernel/lifecycle.mdx
@@ -665,34 +665,59 @@ health-monitor model below, not to this body.
 
 ### Custom Health Checks
 
-Plugins can register custom health checks:
+A plugin can expose **one** custom health check, and it takes two halves: the
+plugin defines an ordinary method, and whoever runs the monitor names that
+method in the plugin's `PluginHealthCheck` config. There is no `healthChecks`
+field to declare — the monitor resolves the method dynamically off the plugin
+object (`plugin[checkMethod]`), so it is not a member of the `Plugin` interface
+either.
 
 ```typescript
-// Plugin registers a custom health check (internal health-monitor model)
-export default {
+import { PluginHealthMonitor } from '@objectstack/core';
+import { PluginHealthCheckSchema } from '@objectstack/spec/kernel';
+
+// 1. The plugin side — a plain method, invoked with NO arguments.
+export const salesforcePlugin = {
   name: '@vendor/salesforce',
 
-  healthChecks: {
-    salesforce_connection: async ({ context }) => {
-      try {
-        // Test Salesforce API
-        const response = await salesforce.query('SELECT Id FROM Account LIMIT 1');
-        
-        return {
-          status: 'healthy',
-          latency_ms: response.duration,
-          records_synced_last_hour: await getSyncCount(),
-        };
-      } catch (error) {
-        return {
-          status: 'unhealthy',
-          error: error.message,
-        };
-      }
-    },
+  // The name is free; `checkMethod` below is what points at it.
+  async healthCheck() {
+    try {
+      await salesforce.query('SELECT Id FROM Account LIMIT 1');
+      return true;
+    } catch (error) {
+      return { status: 'unhealthy', message: error.message };
+    }
   },
 };
+
+// 2. The host side — the embedding application owns the monitor.
+const monitor = new PluginHealthMonitor(kernel.logger);
+
+// `registerPlugin` takes the PARSED config, so parse it: the schema fills in
+// interval 30000, timeout 5000, failureThreshold 3, successThreshold 1,
+// autoRestart false, maxRestartAttempts 3, restartBackoff 'exponential'.
+monitor.registerPlugin(
+  salesforcePlugin.name,
+  PluginHealthCheckSchema.parse({ checkMethod: 'healthCheck' }),
+);
+
+monitor.startMonitoring(salesforcePlugin.name, salesforcePlugin);
 ```
+
+`startMonitoring` runs one check immediately, then repeats every `interval`
+milliseconds; each run is raced against `timeout`, and the method may be
+synchronous or return a promise.
+
+Only two returned shapes count as a failure: `false`, and an object whose
+`status` is exactly `'unhealthy'` (whose `message`, if any, becomes the
+report's). **Everything else passes** — `true`, `undefined`,
+`{ status: 'healthy' }` and a rich object of metrics alike, so a check has
+nowhere to publish latency or row counts: no key beyond `status` and `message`
+is read. Consecutive returned failures move the plugin to `degraded` first, and
+to `unhealthy` only once `failureThreshold` of them accumulate. A check that
+**throws** — including one that exceeds `timeout` — is the separate `failed`
+status, applied immediately with no threshold.
 
 The monitor keeps one report per plugin rather than one aggregate document. Each
 round of checks builds a `PluginHealthReport` (`@objectstack/spec/kernel`,


### PR DESCRIPTION
Fixes #11811

The TypeScript example under `### Custom Health Checks` in
`content/docs/protocol/kernel/lifecycle.mdx` declared `healthChecks` — a map of
named async functions taking `({ context })` — on the plugin default export.
No such field exists anywhere in the runtime.

## Route taken: rewrite against `checkMethod` (route A), with one correction

The card offered two routes and ruled neither. I took **A (rewrite against the
real contract)**, but not in the form the card sketched, because reading the
callout first changed what "the real contract" is.

**The callout, quoted in full** (it sits immediately above the section and is
**unchanged** by this PR):

> `GET /health` returns a compact liveness body (`status`, `timestamp`, `version`,
> `uptime`) and `GET /ready` returns readiness. The per-plugin health report
> and the plugin-declared custom checks below describe the internal health-monitor model
> (`PluginHealthMonitor`), which covers **plugins, not driver connections** — they
> are **not yet** exposed as a dedicated HTTP endpoint or as a declarative plugin
> field.

That callout is **correct**, and I verified it rather than assuming it. It is
also what made the page self-contradictory: it says there is no declarative
plugin field, and the block underneath it then demonstrated one, under the
present-tense lead-in "Plugins can register custom health checks:". A reader
following the example writes a key that nothing reads and nothing rejects.

So the defect is not "the example names the wrong field". It is that the example
showed a **declarative plugin field of any kind**. Route A as sketched — "a
`healthCheck()` method plus the `PluginHealthCheckSchema` config that names it" —
would have reproduced that error one field over if the config were shown sitting
on the manifest, because **nothing in the kernel reads that config either**:

- `AdvancedPluginLifecycleConfigSchema.health` (`plugin-lifecycle-advanced.zod.ts:435`)
  is the only container for `PluginHealthCheckSchema`, and its only references
  repo-wide are the schema file and its own tests — no runtime consumer.
- `packages/core/src/kernel.ts` never mentions the health monitor; `PluginHealthMonitor`
  is constructed in exactly one place, `packages/core/examples/phase2-integration.ts:53`.

`PluginHealthMonitor` **is** exported from `@objectstack/core` (`src/index.ts:76`),
so the capability is real — it is just **host-driven**, not declarative. The
example now shows those two halves and no manifest field, which is what keeps
the callout true.

Route B was rejected on evidence, not taste: `healthChecks` has **no design
record anywhere** — zero hits in `packages/spec`, the ADRs, the roadmap, or any
other doc. A repo audit note already classed it with the fictional
`definePlugin()` (`docs/audits/2026-06-handwritten-docs-accuracy-followups.md:319`:
"the documented manifest fields ... and top-level `healthChecks` are not on the
real Plugin interface"). There is no published intention for B to preserve, and
keeping one would be the `declared != enforced` shape Prime Directive #10 names.

## Measurement, each zero with its positive control

| probe | count | what the hits are |
|---|---|---|
| `healthChecks` as an author-writable field | **0** | 4 hits are `PluginHealthMonitor`'s own private `Map` (`health-monitor.ts:19,35,51,301`); 1 reads that private map (`examples/phase2-integration.ts:151`); 1 was this doc block; 1 is the audit note above |
| `checkMethod` (positive control) | **8** in `packages/` | schema `:64`, spec test `:52`, consumer `:109,111,119,121`, its TSDoc `:329`, core test `:108` — reproduces the filer's count exactly |

## Every element of the new example traces to a source

| element in the example | traced to |
|---|---|
| method named `healthCheck`, `checkMethod: 'healthCheck'` | `health-monitor.test.ts:108` + `plugin-lifecycle-advanced.test.ts:52` |
| plugin object carrying that method, returning `true` | the repo's own fixture, `health-monitor.test.ts:113-122` |
| "not a member of the `Plugin` interface" | `Plugin` (`core/src/types.ts:99-171`) has no index signature; the monitor uses `(plugin as any)[...]` and the fixture casts `as unknown as Plugin` |
| invoked with NO arguments | `health-monitor.ts:111` — `(plugin as any)[config.checkMethod]()` |
| may be sync or async; raced against `timeout` | `raceCheckTimeout` + its TSDoc, `health-monitor.ts:329-350` |
| only `false` / `{ status: 'unhealthy' }` fail; `message` is read | `health-monitor.ts:116-117` |
| `degraded` first, `unhealthy` only at `failureThreshold` | `health-monitor.ts:150-164` |
| a throw (or timeout) is `failed`, immediately, no threshold | `health-monitor.ts:165-170` |
| the seven default values quoted in the code comment | pinned green by `plugin-lifecycle-advanced.test.ts:32-41` |
| `PluginHealthCheckSchema.parse(...)` before `registerPlugin` | `registerPlugin` takes `PluginHealthCheckParsed` (`health-monitor.ts:34`) |

The example does **not** have the author build a `PluginHealthReport` — the
monitor builds it and the author reads it back via `getHealthReport()`, exactly
as established while accepting PR #11812.

## Controls

Both proven by checksum over the final tree, not by inspection:

- **The `PluginHealthReport` block is byte-identical.** Everything from "The monitor
  keeps one report per plugin" to EOF: `sha256 83a4432f7644ccb7e65f1b49dfec8b8a3485d6f1030b6d40d346a2b74dd3112f`
  before and after, 5121 bytes. PR #11812's field-by-field work is untouched.
- **An adjacent already-correct claim left untouched.** Everything from the start of
  the file through the `### Custom Health Checks` heading:
  `sha256 5217096945515f3226fe6479e21ec66198fb106171b8a2e11e48ea565d004fd3` before and
  after, 25607 bytes — which is the callout quoted above, plus the `GET /health`
  response prose.
- **Hunk boundaries agree:** `git diff -U0` reports no changed line beyond old line 696
  (the blank line before the report paragraph).
- The one surviving `healthChecks` mention in the page is the explicit denial,
  "There is no `healthChecks` field to declare".

## Verification

Gate families derived mechanically (`node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack`, no hand-built path list), re-run at the shipping
commit **e98175b1a** — 17 derived + `check:nul-bytes`, all exit 0. Their own
verdict lines, not a bare exit status:

```
✓ doc authoring guard: 389 files clean — no bare metadata literals.
✅ check-doc-anchors: 278 internal #fragment link(s) across 408 source file(s) all resolve to a real heading
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 421 files / 1448 TS blocks judged clean by @objectstack/formula.
✅ 26 ObjectSchema.create example(s) in 227 marked block(s) across 237 prose file(s) in 2 root(s) carry an os validate-clean security posture
✓ docs-accuracy-audit scope is in sync with content/docs/: 189 hand-written doc(s).
```

`check:doc-formula-expressions` and `check:doc-security-posture` were red on the
first pass purely because `packages/lint/dist` and `@objectstack/formula/dist` did
not exist yet in a fresh worktree; both are green after
`pnpm --filter '@objectstack/lint...' build`.

**Repo-wide `pnpm lint` narrowed, and the narrowing is measured rather than
assumed.** `eslint --format json` on the changed file returns 1 result, 0 errors,
and the single message `File ignored because no matching configuration was
supplied.` — eslint's own config resolution, not my reading of it. The broadest
`files` entry in `eslint.config.mjs` is line 891, `**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}`,
which no `.mdx` path can match, so the linted population of this changeset is
**zero files**. No type-aware linting applies, and the diff touches no eslint
config, so no untouched file's verdict can move either.

Docs-only, so no changeset; carries `skip-changeset` instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_