### PR TITLE
fix(driver-sql): a PRIMARY KEY is not a unique constraint on the SQLite introspection arm (#11654)

### DIFF
--- a/.changeset/sqlite-primary-key-not-unique-introspection.md
+++ b/.changeset/sqlite-primary-key-not-unique-introspection.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+`introspectUniqueConstraints` no longer reports a PRIMARY KEY column as unique on SQLite, so all three dialects now answer the same question (#11654). The SQLite arm read `PRAGMA index_list` keyed only on `unique === 1`, and SQLite materialises a non-INTEGER primary key as a unique auto-index — so a `varchar` key was reported while the Postgres and MySQL arms, which filter on `CONSTRAINT_TYPE = 'UNIQUE'`, never see a primary key at all. It also disagreed with itself: an `INTEGER PRIMARY KEY` is a rowid alias with no auto-index, so the same logical schema produced a different `isUnique` flag depending only on the declared type of its key. The arm now skips `origin: 'pk'` index rows, which closes both gaps at once (`WITHOUT ROWID` keys included).
+
+This continues #11202's convention: `isUnique` means a *declared single-column UNIQUE constraint*. Nothing is lost — primary-key membership is still reported losslessly through `IntrospectedTable.primaryKeys` and `IntrospectedColumn.primaryKey`. The filter is on the index's `origin`, not on whether the column is in the key, so a key column that separately carries its own unique index stays flagged.
+
+Consumer-visible effect: `introspectedSchemaToObjects` in `@objectstack/objectql` turns this flag into a drafted field's `unique: true`, so a federated-object draft (ADR-0015) taken from a SQLite table no longer gains a redundant `unique: true` on its key column that the same table drafted through Postgres or MySQL never had. Drivers extending `SqlDriver` (`driver-turso`, `driver-sqlite-wasm`) inherit the change.

--- a/packages/drivers/driver-sql/src/sql-driver-11654-primary-key-not-unique.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-11654-primary-key-not-unique.test.ts
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11654] A PRIMARY KEY is not a UNIQUE constraint to
+ * `introspectUniqueConstraints` — on any dialect, and for any key type.
+ *
+ * This is the residual cell of the family #11202 opened. That change unified
+ * the three arms on *single-column* uniqueness; it deliberately left the
+ * primary-key question alone, because the flag it produced was not false, only
+ * inconsistent — and its fixture carries no primary key at all, precisely so it
+ * measured the composite-vs-single question and nothing else.
+ *
+ * ## The convention this inherits, and its reason
+ *
+ * `isUnique` means **a declared single-column UNIQUE constraint**. Primary-key
+ * membership is already reported losslessly through a face of its own —
+ * `IntrospectedTable.primaryKeys` and `IntrospectedColumn.primaryKey` — so
+ * excluding keys from `isUnique` loses no information and leaves the two flags
+ * non-overlapping. That is #11202's convention applied one cell over, not a new
+ * decision, which is why this file pins the `primaryKeys` face as well: it is
+ * the half that makes the exclusion lossless rather than merely narrower.
+ *
+ * ## What was measured before the fix (2026-08-24, embedded better-sqlite3)
+ *
+ * The catalogs disagreed. Postgres and MySQL filter on
+ * `CONSTRAINT_TYPE = 'UNIQUE'`, which excludes primary keys outright. SQLite
+ * iterated `PRAGMA index_list` keyed only on `idx.unique === 1`, never on
+ * `origin` — and SQLite materialises a non-INTEGER primary key as a unique
+ * auto-index:
+ *
+ * ```text
+ * create table t_text (id varchar(64) primary key, email varchar(64) unique)
+ *   PRAGMA index_list(t_text) ->
+ *     { name: 'sqlite_autoindex_t_text_2', unique: 1, origin: 'u'  }
+ *     { name: 'sqlite_autoindex_t_text_1', unique: 1, origin: 'pk' }
+ *   introspectUniqueConstraints -> ['email', 'id']     <-- 'id' is the PRIMARY KEY
+ *
+ * create table t_int (id integer primary key, note varchar(64))
+ *   PRAGMA index_list(t_int) -> []
+ *   introspectUniqueConstraints -> []
+ * ```
+ *
+ * So SQLite disagreed with the other two dialects AND with itself: an
+ * `INTEGER PRIMARY KEY` is a rowid alias with no auto-index and was never
+ * flagged, while a `varchar` key was — the same logical schema producing
+ * different `isUnique` flags from the declared type of its key alone.
+ *
+ * ## The fix filters the INDEX by origin, not the COLUMN by key membership
+ *
+ * Those are different changes and only one is correct. A column that is the
+ * primary key AND separately carries its own unique index really does have a
+ * declared single-column unique constraint, and must stay flagged; dropping
+ * every primary-key *column* would lose it. `t_pk_and_idx` below is that
+ * distinction as a pin — it fails under the wrong sibling implementation and
+ * passes under this one.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SqlDriver } from './sql-driver.js';
+import { DIALECT_CELLS, declareDialectCell, type DialectCell } from './live-dialect-matrix.testkit.js';
+
+const MATRIX = 'primary key is not a unique constraint';
+
+/** A varchar primary key plus a real single-column `UNIQUE (email)`. */
+const TABLE = 'os11654_pk';
+
+/** `introspectUniqueConstraints` is `protected`; this is the narrowest reach. */
+class UniqueProbeDriver extends SqlDriver {
+  uniqueConstraints(table: string) {
+    return this.introspectUniqueConstraints(table);
+  }
+}
+
+// ── Half 1: every provisioned dialect answers the same ──────────────────────
+
+function declarePrimaryKeyUniqueSuite(cell: DialectCell): void {
+  describe(`introspectUniqueConstraints — a PRIMARY KEY is not unique — ${cell.label} (#11654)`, () => {
+    let driver: UniqueProbeDriver;
+
+    beforeAll(async () => {
+      driver = new UniqueProbeDriver(cell.config());
+      await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+      // A NON-INTEGER key on purpose: this is the shape SQLite materialises as
+      // a unique auto-index, and therefore the only shape on which the three
+      // dialects ever disagreed.
+      await driver.execute(
+        `create table ${TABLE} (
+           id varchar(64) not null primary key,
+           email varchar(64) not null unique,
+           note varchar(64)
+         )`,
+      );
+    });
+
+    afterAll(async () => {
+      await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+      await driver.disconnect().catch(() => {});
+    });
+
+    it('the fixture is real: the key IS enforced and so is the UNIQUE column', async () => {
+      // Non-vacuity, asserted against the server rather than the catalog. The
+      // interesting assertion below is an ABSENCE, which goes green for free on
+      // a table whose key never landed — so prove both constraints exist and
+      // are enforced first. Note what this establishes: `id` really is unique
+      // in the database. The flag's absence is a statement about what KIND of
+      // constraint makes it so, not a claim that duplicates are allowed.
+      await driver.execute(`insert into ${TABLE} (id, email) values ('k1', 'e1@example.com')`);
+
+      // The key repeated — REJECTED, so the PRIMARY KEY is enforced.
+      await expect(
+        driver.execute(`insert into ${TABLE} (id, email) values ('k1', 'e2@example.com')`),
+      ).rejects.toThrow();
+
+      // `email` repeated — REJECTED, so the single-column UNIQUE exists too.
+      await expect(
+        driver.execute(`insert into ${TABLE} (id, email) values ('k2', 'e1@example.com')`),
+      ).rejects.toThrow();
+    });
+
+    it('reports the UNIQUE column and NOT the primary-key column', async () => {
+      const columns = await driver.uniqueConstraints(TABLE);
+
+      expect(columns).toContain('email');
+      expect(columns).not.toContain('id');
+      expect(columns).not.toContain('note');
+      // Exact, so a dialect that starts reporting something extra is caught
+      // rather than absorbed by the `not.toContain`s above.
+      expect(columns).toEqual(['email']);
+    });
+
+    it('`introspectSchema` folds that into `isUnique` — the consumer-visible half', async () => {
+      const schema = await driver.introspectSchema();
+      const table = schema.tables[TABLE];
+      expect(table, `${TABLE} missing from the introspected schema`).toBeDefined();
+
+      const byName = Object.fromEntries(table.columns.map((col) => [col.name, col]));
+      expect(byName.email?.isUnique).toBe(true);
+      // Falsy, not `false`: `isUnique` is only ever SET to `true`, so asserting
+      // `false` would pin a shape the producer does not promise (#11202).
+      expect(byName.id?.isUnique).toBeFalsy();
+      expect(byName.note?.isUnique).toBeFalsy();
+    });
+
+    it('nothing is lost: the `primaryKeys` face still reports the key', async () => {
+      // This is what makes the exclusion lossless rather than a narrowing that
+      // drops information. A consumer asking "is this column the key?" has an
+      // answer that did not move, on both faces.
+      const schema = await driver.introspectSchema();
+      const table = schema.tables[TABLE];
+      expect(table.primaryKeys).toEqual(['id']);
+
+      const byName = Object.fromEntries(table.columns.map((col) => [col.name, col]));
+      expect(byName.id?.primaryKey).toBe(true);
+      expect(byName.email?.primaryKey).toBeFalsy();
+    });
+  });
+}
+
+for (const cell of DIALECT_CELLS) {
+  declareDialectCell(cell, MATRIX, declarePrimaryKeyUniqueSuite);
+}
+
+// ── Half 2: the SQLite key shapes no other dialect can produce ──────────────
+
+describe('SQLite key materialisation — every key shape answers the same (#11654)', () => {
+  let driver: UniqueProbeDriver;
+
+  beforeAll(async () => {
+    driver = new UniqueProbeDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    // The card's two tables, verbatim.
+    await driver.execute(`create table t_text (id varchar(64) primary key, email varchar(64) unique)`);
+    await driver.execute(`create table t_int (id integer primary key, note varchar(64))`);
+    // A WITHOUT ROWID table still materialises its key as a `pk`-origin index.
+    await driver.execute(
+      `create table t_worid (id varchar(64) primary key, email varchar(64) unique) without rowid`,
+    );
+    // Composite key: two members, so the #11202 width filter already dropped
+    // it. Pinned so the origin filter is not credited with it, and so it stays
+    // dropped if the width filter is ever reworked.
+    await driver.execute(
+      `create table t_comp (a varchar(64), b varchar(64), email varchar(64) unique, primary key (a, b))`,
+    );
+    // The key column ALSO carrying its own unique index (`origin: 'c'`).
+    await driver.execute(`create table t_pk_and_idx (id varchar(64) primary key, note varchar(64))`);
+    await driver.execute(`create unique index t_pk_and_idx_id_u on t_pk_and_idx (id)`);
+  });
+
+  afterAll(async () => {
+    await driver.disconnect().catch(() => {});
+  });
+
+  it('PRAGMA index_list really reports origin `pk` for a varchar key', async () => {
+    // Pins the premise the filter rests on. If SQLite ever stopped tagging the
+    // auto-index, the filter would be dead code and should be re-read.
+    const rows: any = await driver.execute(`PRAGMA index_list(t_text)`);
+    const byOrigin = Object.fromEntries((rows as any[]).map((r) => [r.origin, r]));
+    expect(byOrigin.pk, 'no pk-origin auto-index — the premise moved').toBeDefined();
+    expect(byOrigin.pk.unique).toBe(1);
+    expect(byOrigin.u, 'no u-origin index for UNIQUE(email)').toBeDefined();
+  });
+
+  it('an INTEGER key and a varchar key now agree — neither is flagged', async () => {
+    // The self-inconsistency this card names: an INTEGER PRIMARY KEY is a rowid
+    // alias with no auto-index and was never flagged, while a varchar key was.
+    // The same logical schema must not answer differently by key type.
+    expect(await driver.uniqueConstraints('t_text')).toEqual(['email']);
+    expect(await driver.uniqueConstraints('t_int')).toEqual([]);
+  });
+
+  it('a WITHOUT ROWID key is not flagged either', async () => {
+    expect(await driver.uniqueConstraints('t_worid')).toEqual(['email']);
+  });
+
+  it('a composite key contributes nothing, and its UNIQUE sibling survives', async () => {
+    const columns = await driver.uniqueConstraints('t_comp');
+    expect(columns).toEqual(['email']);
+    expect(columns).not.toContain('a');
+    expect(columns).not.toContain('b');
+  });
+
+  it('a key column with its OWN unique index stays flagged', async () => {
+    // The filter drops pk-ORIGIN INDEXES, not primary-key COLUMNS. `id` here
+    // carries a separately declared single-column unique constraint, which is
+    // exactly what `isUnique` means — dropping it would be a different, wrong
+    // change wearing the same description.
+    expect(await driver.uniqueConstraints('t_pk_and_idx')).toEqual(['id']);
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -3698,6 +3698,16 @@ export interface IntrospectedColumn extends SpecIntrospectedColumn {
    * option B and waits for demand; until it exists, an absent flag on a
    * composite member means "not single-column unique", never "no constraint".
    *
+   * A PRIMARY KEY is NOT a unique constraint to this flag (#11654), on any
+   * dialect and for any key type. `isUnique` means a *declared* single-column
+   * UNIQUE constraint; key membership has a lossless face of its own
+   * ({@link IntrospectedTable.primaryKeys} and `primaryKey` below), so
+   * excluding keys keeps the two flags non-overlapping and drops no fact. Note
+   * this is a statement about what KIND of constraint the flag reports, never
+   * a claim that a key column admits duplicates. A key column that separately
+   * carries its own single-column unique constraint is still flagged — the
+   * constraint is what is being reported, not the column.
+   *
    * All three dialect arms of {@link SqlDriver.introspectUniqueConstraints}
    * produce it through one predicate — see {@link singleColumnUniqueColumns}.
    */
@@ -14762,6 +14772,23 @@ export class SqlDriver implements IDataDriver {
    * All three now normalise their rows to {@link UniqueConstraintMember} and
    * decide through {@link singleColumnUniqueColumns} — one predicate, so a
    * fourth dialect cannot quietly acquire a fourth meaning.
+   *
+   * ## A PRIMARY KEY is not one of them (#11654)
+   *
+   * The residual cell of the same family, and the same convention applied one
+   * step over: a column appears here iff a *declared UNIQUE constraint* covers
+   * it alone. Postgres and MySQL got this for free — `CONSTRAINT_TYPE =
+   * 'UNIQUE'` never matches a primary key. SQLite did not: it keys on
+   * `PRAGMA index_list`, which reports the unique auto-index SQLite
+   * materialises for a non-INTEGER key, so a `varchar` key was flagged while
+   * an `INTEGER PRIMARY KEY` — a rowid alias with no auto-index at all — was
+   * not. Three dialects, four answers, from the declared type of a key.
+   *
+   * The SQLite arm now skips `origin: 'pk'` rows. Unlike the composite case
+   * above the excluded flag was not FALSE, only inconsistent — a key column
+   * really is unique — which is why the exclusion has to be paid for by the
+   * face that keeps the fact: `introspectPrimaryKeys` reports it through
+   * `primaryKeys` and `IntrospectedColumn.primaryKey`, both unmoved by this.
    */
   protected async introspectUniqueConstraints(
     tableName: string,
@@ -14857,7 +14884,31 @@ export class SqlDriver implements IDataDriver {
         const indexes = await this.knex.raw(`PRAGMA index_list(${safeTableName})`);
 
         for (const idx of indexes) {
-          if (idx.unique === 1) {
+          // `origin: 'pk'` is the auto-index SQLite materialises for a
+          // non-INTEGER PRIMARY KEY — not a declared UNIQUE constraint, and so
+          // not what this method reports (#11654). Skipping it is what makes
+          // SQLite agree with the other two arms, whose
+          // `CONSTRAINT_TYPE = 'UNIQUE'` filter never sees a primary key at
+          // all, AND what makes SQLite agree with ITSELF: an `INTEGER PRIMARY
+          // KEY` is a rowid alias for which SQLite creates no auto-index, so
+          // `index_list` is empty and the key was never flagged — the same
+          // logical schema answering differently by the declared type of its
+          // key alone. Nothing is lost by the exclusion: primary-key
+          // membership is reported losslessly by `introspectPrimaryKeys`,
+          // through `IntrospectedTable.primaryKeys` and
+          // `IntrospectedColumn.primaryKey`.
+          //
+          // The test is on the INDEX's origin, never on whether the COLUMN is
+          // in the key: a key column that separately carries its own unique
+          // index (`origin: 'c'`) really does have a declared single-column
+          // unique constraint and stays flagged.
+          //
+          // `origin` has been reported by this pragma since SQLite 3.8.9, so
+          // an absent value is not a case that arises here; were it ever
+          // absent this reads as the pre-#11654 behaviour rather than
+          // silently dropping real constraints, and the pin on
+          // `index_list`'s own origin values turns red.
+          if (idx.unique === 1 && idx.origin !== 'pk') {
             // `PRAGMA index_info` reports one row per index MEMBER, and a
             // member is not always a column: an expression term
             // (`CREATE UNIQUE INDEX … ON t (lower(a))`) arrives with


### PR DESCRIPTION
Fixes #11654

`SqlDriver.introspectUniqueConstraints` reached its answer from a different catalog per dialect, and the catalogs disagreed about primary keys. Postgres and MySQL filter on `CONSTRAINT_TYPE = 'UNIQUE'`, which never matches a primary key. The SQLite arm iterated `PRAGMA index_list` keyed only on `idx.unique === 1`, never on `origin` — and SQLite materialises a non-INTEGER primary key as a unique auto-index, so the key column was reported as unique.

SQLite also disagreed with **itself**: an `INTEGER PRIMARY KEY` is a rowid alias for which SQLite creates no auto-index at all, so `index_list` is empty and such a key was never flagged. The same logical schema produced a different `isUnique` from the declared type of its key alone.

The SQLite arm now skips `origin: 'pk'` rows, which closes both gaps in one stroke.

## The convention this inherits, and its reason

This is **not** a new decision — it is the convention #11202 landed (PR #11657), applied one cell over. `isUnique` means **a declared single-column UNIQUE constraint**. Primary-key membership already has a lossless face of its own — `IntrospectedTable.primaryKeys` and `IntrospectedColumn.primaryKey` — so excluding keys from `isUnique` drops no fact and leaves the two flags non-overlapping.

Note the direction, because it differs from #11202: the flag being removed here was not *false* — a primary-key column really is unique — only inconsistent. That is exactly why the exclusion has to be paid for by the face that keeps the fact, and why this PR pins `primaryKeys` and `primaryKey` as part of the change rather than only asserting the absence.

**The filter is on the INDEX's `origin`, not on whether the COLUMN is in the key.** Those are different changes and only one is correct: a key column that *separately* carries its own unique index really does have a declared single-column unique constraint and must stay flagged. `t_pk_and_idx` is that distinction as a pin — it fails under the wrong sibling implementation and passes under this one.

## Premise re-measure against `origin/main`

The card is a lead, not a spec, and the triage fence asked for a re-measure on the post-#11202 ref specifically because PR #11657 touched this exact producer the same day. Re-measured at merge base `dce6a019f` on embedded better-sqlite3, through the driver itself. **The cell was not absorbed; all of the card's readings reproduce.**

```text
PRAGMA index_list(t_text) ->
    { name: 'sqlite_autoindex_t_text_2', unique: 1, origin: 'u',  partial: 0 }
    { name: 'sqlite_autoindex_t_text_1', unique: 1, origin: 'pk', partial: 0 }
PRAGMA index_list(t_int) -> []

introspectUniqueConstraints(t_text) = ["email","id"]     <- 'id' is the PRIMARY KEY
introspectUniqueConstraints(t_int)  = []

introspectSchema().tables['t_text']: primaryKeys = ["id"]
    column id:    primaryKey=true  isUnique=true         <- the defect
    column email: primaryKey=false isUnique=true
introspectSchema().tables['t_int']:  primaryKeys = ["id"]
    column id:    primaryKey=true  isUnique=false        <- same schema, different answer
```

`premise_still_valid: true`. The PG/MySQL half is read from the arms' own SQL (`CONSTRAINT_TYPE = 'UNIQUE'`); live PG and MySQL are not provisioned in this container, so those cells are named skips locally and run in the `Temporal Conformance (live PG + MySQL)` job — the same posture #11657 recorded.

**Two shapes were measured that the card does not name**, and both changed the test design rather than merely confirming it:

- A `WITHOUT ROWID` table still materialises its key as a `pk`-origin index, so it carried the identical defect. Covered by the same filter, and pinned.
- A **composite** primary key was already dropped — but only incidentally, by #11202's width filter, since its auto-index has two members. Pinned so this change is not credited with it and so it stays dropped if the width filter is ever reworked.

## Reverse verification

Pinned first against unfixed source, as dispatched. Both legs measured on the full `@objectstack/driver-sql` suite.

**RED** (new pins, unmodified arm) — 4 failed / 1972 passed / 112 skipped, quoting the assertions:

```text
× reports the UNIQUE column and NOT the primary-key column
    AssertionError: expected [ 'email', 'id' ] to not include 'id'
× `introspectSchema` folds that into `isUnique` — the consumer-visible half
    AssertionError: expected true to be falsy
× an INTEGER key and a varchar key now agree — neither is flagged
    AssertionError: expected [ 'email', 'id' ] to deeply equal [ 'email' ]
× a WITHOUT ROWID key is not flagged either
    AssertionError: expected [ 'email', 'id' ] to deeply equal [ 'email' ]
```

**GREEN** (after the filter) — `Test Files 127 passed | 8 skipped (135)`, `Tests 1976 passed | 112 skipped (2088)`.

The four pins that must hold in *both* directions were green in the RED leg too, which is what makes the red meaningful rather than a broken fixture: the non-vacuity case, the `primaryKeys` face, the composite key, and the key-column-with-its-own-index case. Exactly 4 tests moved, 1972 → 1976 passed, nothing else.

The fixtures assert the absence is real before asserting it. `"a PK column is not flagged"` goes green for free on a table whose key never landed, so every cell first makes the database its own witness: a repeated key is **rejected** and a repeated `email` is **rejected**. That also states plainly what the flag's absence does and does not mean — the key column really is unique; what changed is which *kind* of constraint the flag reports.

## Verification

Gate union re-run at the final commit `66d9634df`, after the commit, from the worktree. Derivation quoted from the script itself:

```text
dispatch-gates: gate list derived from the tree of 'objectstack-ai/objectstack' at commit 66d9634df
  --repo 'objectstack-ai/objectstack' checked against this checkout's 'origin' remote — it holds.
dispatch-gates: change set derived from git — 3 path(s) vs merge base dce6a019f of 'origin/main' and HEAD
```

14 path-derived families plus 6 convention-triggered (this adds a test file). **All 20 exit 0**, each captured before any pipe. Selected verdict lines, quoted from the gates themselves:

- `check-driver-conformance: OK — 45 covered cell(s), 0 in the DEBT ledger, 0 exempt.`
- `check-engine-double-contract: OK — 401 pinned, 133 in the DEBT ledger, 2 exempt.`
- `OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `check-nul-bytes: OK (scanned 6593 text file(s) ... no raw ASCII control bytes).`
- `check-where-matcher: 0 silently-wrong and 0 unjudged matcher(s) ... none new.`
- `check-changeset-no-major: ✓ This diff introduces no 'major' bump.`

Per-package readings, both at `66d9634df` (working tree clean at commit time, so the tested tree is the committed tree):

- `@objectstack/driver-sql` — 127 files passed, 8 skipped; 1976 tests passed, 112 skipped. `typecheck` exit 0 (`tsc --noEmit` echoed, so not a zero-match silent pass).
- `@objectstack/objectql` — the consumer check: `src/util.test.ts`, 1 file / 22 tests passed. This is the suite covering `introspectedSchemaToObjects`, the flag's one real consumer.

**Supporting evidence from the consumer's own fixture**, which was not part of the dispatch and is worth a reviewer's eye: `packages/objectql/src/util.test.ts` already models a key column as `{ primaryKey: true }` with **no** `isUnique`, and `email` as `isUnique: true`. The consumer's test data has always encoded option A. Nothing in it needed changing, and no fixture triage was required.

### Two declared narrowings

Both are declared rather than silently skipped, and CI runs the full farm regardless.

1. **`check:type-check-debt --re-measure` was not run locally.** It re-runs tsc per *ledger entry* and needs the whole workspace closure built. Its population is read from the gate's own model, not guessed: `driver-sql` carries no `test-typecheck-debt.json` and appears nowhere in the gate's `DEBT` / `TEST_DEBT` / `EXEMPT` / `UNCHECKED_SOURCE_DEBT` / `PHANTOM_PIN_DEBT` literals (only in its header's history prose, as debt already paid). The structural half, `check:type-check-coverage`, passed, and the package's own `tsc --noEmit` is green. The diff adds no file to any ledgered package.

2. **Repo-wide `pnpm lint` was narrowed to the changed files**, and the narrowing is a measurement rather than a skip — all three pieces:
   - **Population, read from eslint's own config** (`ESLint#isPathIgnored` / `calculateConfigForFile`), not from an assumption about which files count: of the 3 changed paths, exactly 2 are in the linted population (6 and 5 rules); the changeset `.md` is not linted at all.
   - **Count, from `--format json`**: 2 files linted, **0 errors, 0 warnings**, exit 0.
   - **Invariance for untouched files**: `eslint.config.mjs` states in its own text that this repo "never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file". With no cross-file type information in play, this diff cannot move the verdict on any file it does not touch.

   The container was saturated at measurement time (load 4.41 on 4 cores, three waiters queued behind an active build), where a repo-wide scan reliably meets the foreground cap and yields nothing.

## Scope

Declared surface, unchanged from the claim: `packages/drivers/driver-sql/src/sql-driver.ts` (the SQLite arm of `introspectUniqueConstraints` plus the two TSDoc contract sentences in the same file), one new sibling test file, and the changeset. Nothing else.

**H17 fence** — both holds name `sql-driver.ts` as a trigger file, and the diff stays clear of both regions. Neither `sqliteCanonicalDatetimeSql`, `backfillCanonicalDatetimes` (#6009) nor `insertOnlyUpsertColumns` / the upsert region (#8740) appears anywhere in the diff; those symbols live at lines 4007–9630 and 6529 / 7023, while the three hunks are at 3701, 14775 and 14887.

**Clause-②: no — driver introspection behaviour, no `packages/spec` path in the diff.**

Drivers extending `SqlDriver` (`driver-turso`, `driver-sqlite-wasm`) inherit the change; both are covered by the package suite above.

## One out-of-scope finding, filed unassigned

- **#11826** — the consumer-side copy of this contract sentence in `packages/objectql/src/util.ts` now under-specifies it. That declaration says in its own text that it "must not drift from" the producer's, and #11655 was filed and fixed for exactly this drift one round ago. Not fixed here: it fails the bounded in-place exemption's fourth condition — `packages/objectql/src` pulls in gate families this diff otherwise never matches (`check:durability-log-level`, `check-engine-split-ratio`, as PR #11657 measured when it amended that same file), so it is a new verification surface rather than a free ride. Documentation only; no behaviour depends on it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_