### PR TITLE
fix(metadata-protocol): seed pass 2 writes back by the internal id captured at insert time, healing keyless datasets

### DIFF
--- a/.changeset/seed-pass2-keyless-writeback.md
+++ b/.changeset/seed-pass2-keyless-writeback.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+Seed pass 2 now writes a deferred reference back through the internal id captured at insert time, so a keyless dataset (`mode: 'insert'`, no `externalId` — the honest authoring for an engine-owned object with no natural key) heals an out-of-order reference exactly like a keyed one. Previously pass 2 re-resolved the source row through its `externalId`, so a keyless (or empty-keyed) row's resolved reference was dropped loudly and the load reported `success: false`; the same load now succeeds with the reference healed. The loud drop remains for the one case where it is true — the source row's pass-1 write failed, so there is nothing to write back onto. Unchanged and now measured against the real engine: a deferred column that is `required: true` is still rejected at pass-1 insert (the deferral deletes the column), so such datasets must still seed their target first.

--- a/packages/metadata-protocol/src/seed-loader-deferred-dropped.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-deferred-dropped.test.ts
@@ -6,30 +6,30 @@ import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts'
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 
 /**
- * #5127 — pass 2 RESOLVES the target and then has no record to write it onto.
+ * #5127 / #11674 — pass 2 RESOLVES the target; does it have a record to write
+ * it onto?
  *
- * `resolveDeferredUpdates()` looked the source record's internal id up in
- * `insertedRecords` and, when it wasn't there, ran off the end of an `if`
- * with no `else`: no write, no `errors`/`allErrors` entry (so `success` stayed
- * `true`), no `errored`, not one log line. The single trace left behind was the
- * `referencesDeferred` the record booked in pass 1 and never gave back — only a
- * SUCCESSFUL back-fill decrements it — i.e. a result object carrying a dangling
- * number with nothing in it that explains the number.
+ * #5127's finding: `resolveDeferredUpdates()` looked the source record's
+ * internal id up in `insertedRecords` (a natural-key map) and, when it wasn't
+ * there, ran off the end of an `if` with no `else`: no write, no error entry
+ * (so `success` stayed `true`), not one log line — only a dangling
+ * `referencesDeferred` nothing explained. #5127 made both roads to that state
+ * loud.
  *
- * It is the deeper cousin of the two branches on either side of it: #4729 fixed
- * "counted, but logged at `warn`"; #4997 fixed "counted, never logged"; this one
- * was "never counted, never logged".
+ * #11674 then removed one of the roads at the root. Pass 2 now writes back
+ * through the internal id CAPTURED AT INSERT TIME, so a row this load actually
+ * wrote can always be written back to — a natural key is no longer required.
+ * What used to be the "PURE SILENT LOSS" (row written fine, composite
+ * externalId evaluated to `''`, so the natural-key map had no handle) is not a
+ * loss at all any more: it HEALS, and the first describe below pins that.
  *
- * The two ways to reach it are NOT the same failure and are pinned separately:
- *
- *  - PURE SILENT LOSS — the row wrote perfectly, but its natural key was never
- *    registered because `externalIdKey` returned `''` (any component of a
- *    composite externalId absent or blank). NOTHING else in the load reports
- *    anything: this is the only signal that will ever exist. Mandatory coverage.
- *  - SOURCE ROW NEVER LANDED — its pass-1 write failed, which the write site
- *    already reported at `error` (#4729). Still recorded here under the same
- *    objective criterion, but as exactly ONE line that points AT that error
- *    rather than a second flood over the same root cause.
+ * The road that remains — and stays pinned loud — is SOURCE ROW NEVER LANDED:
+ * the pass-1 write failed (already reported at `error` by the write site,
+ * #4729) or returned no id, so there is genuinely nothing to write onto. It is
+ * recorded under the same objective criterion, as exactly ONE line that points
+ * AT the pass-1 error rather than a second flood over the same root cause —
+ * spelled by natural key when the record has one, by record index when it does
+ * not (the keyless / empty-key spelling, pinned in the last describe).
  */
 
 function createLogger() {
@@ -149,18 +149,23 @@ const compositeSeeds = (region: string) => [
 const deferredDropLines = (logger: ReturnType<typeof createLogger>) =>
   logger.error.mock.calls.filter((c: unknown[]) => String(c[0]).includes('Deferred reference DROPPED'));
 
-describe('pass 2 resolves the target but the source record has no id (#5127)', () => {
+describe('pass 2 heals a row whose natural key evaluated empty (#5127 → #11674)', () => {
   /**
-   * (c) THE PURE SILENT LOSS — the case that must be covered.
+   * What #5127 pinned here as "THE PURE SILENT LOSS" — row written fine,
+   * composite externalId ['name', 'region'] evaluating to `''` because
+   * `region` is blank, pass 2 resolving 'Alice' perfectly and then having no
+   * handle to write her id onto — is exactly the structural defect #11674
+   * removed: pass 2 no longer re-resolves the source row through its
+   * externalId at all. The id the row got when it was INSERTED is captured
+   * then and written back through now, so the empty key costs nothing.
    *
-   * The department row is written successfully and sits in the database. Its
-   * composite externalId ['name', 'region'] evaluates to `''` because `region`
-   * is blank, so `externalIdKey` returns the empty key and nothing registers it
-   * in `insertedRecords`. Pass 2 then resolves 'Alice' perfectly and finds no id
-   * to write onto. No other site in the loader says a word about this: before
-   * the fix the entire outcome was one un-explained `referencesDeferred: 1`.
+   * These pins flip #5127's loud-drop pins into healing pins on the SAME
+   * scenario, so the two fixes cannot regress each other: if the write-back
+   * handle is ever lost again, this load either drops loudly (#5127's
+   * branches, still live for a row that never landed) or heals — silence over
+   * a written row with a missing link has no branch left to come back through.
    */
-  it('reports the back-fill it had to drop, with the row itself seeded fine', async () => {
+  it('back-fills the reference by the internal id captured at insert — the empty key costs nothing', async () => {
     const { engine, store } = createFaithfulEngine();
     const logger = createLogger();
 
@@ -169,35 +174,27 @@ describe('pass 2 resolves the target but the source record has no id (#5127)', (
       config: CONFIG,
     });
 
-    // The row IS there — this is not a write failure. That is the whole point:
-    // every row counter reads healthy.
+    // The row is there AND carries its association.
     const engineering = store.drop_department.find((r) => r.name === 'Engineering');
     expect(engineering, 'the department row was not seeded — wrong scenario').toBeDefined();
-    const deptResult = result.results.find((r: { object: string }) => r.object === 'drop_department')!;
-    expect(deptResult.inserted).toBe(1);
-    expect(deptResult.errored).toBe(1);
-
-    // …while the association it declared is permanently absent.
-    expect(engineering!.head_id == null).toBe(true);
-    // Nothing was even attempted against the department (no id to update).
+    const aliceId = store.drop_worker.find((r) => r.name === 'Alice')!.id;
+    expect(engineering!.head_id).toBe(aliceId);
+    // It went through the pass-2 back-fill write, by a REAL record id.
     expect(
       (engine.update as any).mock.calls.some(([obj]: [string]) => obj === 'drop_department'),
-      'a back-fill write was attempted without a record id',
-    ).toBe(false);
+      'no back-fill write reached the department',
+    ).toBe(true);
 
-    // So the load must NOT report clean success — it used to.
-    expect(result.success).toBe(false);
-    expect(result.summary.totalErrored).toBe(1);
-    const dropped = result.errors.find((e: { field: string }) => e.field === 'head_id')!;
-    expect(dropped, 'the dropped back-fill was not recorded as an error').toBeDefined();
-    expect(dropped.sourceObject).toBe('drop_department');
-    expect(dropped.targetObject).toBe('drop_worker');
-    expect(dropped.recordIndex).toBe(0);
-    expect(dropped.message).toContain('Deferred reference dropped');
-    expect(dropped.message).toContain('name+region');
+    // A healed load is a clean load.
+    const deptResult = result.results.find((r: { object: string }) => r.object === 'drop_department')!;
+    expect(deptResult.inserted).toBe(1);
+    expect(deptResult.errored).toBe(0);
+    expect(result.success).toBe(true);
+    expect(result.summary.totalErrored).toBe(0);
+    expect(result.errors).toHaveLength(0);
   });
 
-  it('logs it exactly once at ERROR, naming the empty key, the consequence and the fix (#4632)', async () => {
+  it('says nothing at error OR warn — a healed deferral is not a degradation (#4632)', async () => {
     const { engine } = createFaithfulEngine();
     const logger = createLogger();
 
@@ -206,49 +203,19 @@ describe('pass 2 resolves the target but the source record has no id (#5127)', (
       config: CONFIG,
     });
 
-    // ONE line — and, since nothing else in this load fails, the ONLY error line.
-    const lines = deferredDropLines(logger);
-    expect(lines.length, 'the dropped back-fill was not logged exactly once at error').toBe(1);
-    expect(logger.error.mock.calls.length).toBe(1);
-
-    const [message, err, meta] = lines[0];
-    // Locating info: object, field, target, and which record.
-    expect(String(message)).toContain('drop_department.head_id');
-    expect(String(message)).toContain('drop_worker.name');
-    // The consequence, concretely.
-    expect(String(message)).toContain('stays NULL');
-    expect(String(message)).toContain('The row itself WAS seeded');
-    // WHY there is no id — the empty composite key, named.
-    expect(String(message)).toContain('`name+region`');
-    expect(String(message)).toContain('EMPTY key');
-    // The fix.
-    expect(String(message)).toMatch(/non-empty value/);
-    expect(String(message)).toMatch(/re-run the seed/);
-    // Logger contract is `(message, error, meta)`; there is no thrown error here.
-    expect(err).toBeUndefined();
-    expect(meta).toMatchObject({
-      object: 'drop_department',
-      field: 'head_id',
-      target: 'drop_worker.name',
-      recordIndex: 0,
-      recordExternalId: '',
-    });
-
-    // NOT downgraded to warn — the level the count has to agree with.
-    expect(
-      logger.warn.mock.calls.some((c: unknown[]) => String(c[0]).includes('DROPPED')),
-      'the dropped back-fill is being reported at warn',
-    ).toBe(false);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   /**
-   * The result object may no longer carry a `referencesDeferred` that nothing
-   * explains. The counter itself keeps its meaning — "deferred references that
-   * never landed", decremented only by a SUCCESSFUL back-fill, exactly as the
-   * two sibling failure branches leave it — so what this pins is the pairing:
-   * a leftover count now always has a matching entry in `errors`.
+   * #5127's pairing invariant, unchanged in meaning: `referencesDeferred`
+   * means "deferred references that never landed", only a SUCCESSFUL
+   * back-fill decrements it, and a leftover count must have a matching entry
+   * in `errors`. Here the back-fill SUCCEEDS, so the counter is given back —
+   * zero left over, zero to explain — and the invariant loop still holds for
+   * every result entry.
    */
-  it('leaves no dangling referencesDeferred without an error explaining it', async () => {
+  it('gives referencesDeferred back on the successful back-fill, leaving nothing dangling', async () => {
     const { engine } = createFaithfulEngine();
 
     const result = await new SeedLoaderService(engine, createMetadata(), createLogger()).load({
@@ -257,9 +224,9 @@ describe('pass 2 resolves the target but the source record has no id (#5127)', (
     });
 
     const deptResult = result.results.find((r: { object: string }) => r.object === 'drop_department')!;
-    expect(deptResult.referencesDeferred).toBe(1); // booked in pass 1, never landed
-    expect(deptResult.errors.length).toBe(1); // …and now explained
-    expect(deptResult.errors[0].field).toBe('head_id');
+    expect(deptResult.referencesDeferred).toBe(0); // booked in pass 1, given back in pass 2
+    expect(deptResult.referencesResolved).toBe(1);
+    expect(deptResult.errors).toHaveLength(0);
 
     for (const entry of result.results) {
       if (entry.referencesDeferred > 0) {
@@ -269,13 +236,15 @@ describe('pass 2 resolves the target but the source record has no id (#5127)', (
         ).toBeGreaterThan(0);
       }
     }
-    expect(result.summary.totalReferencesDeferred).toBe(1);
+    expect(result.summary.totalReferencesDeferred).toBe(0);
   });
 
   /**
-   * (b) The control: same composite key, `region` filled in. The key registers,
-   * pass 2 back-fills normally, and the new branch stays out of the way — which
-   * proves the failure above is caused by the EMPTY key, not by composite keys.
+   * The keyed sibling: same composite key, `region` filled in. The key
+   * registers AND the internal id is captured, and the outcome is identical to
+   * the empty-key case above — which is the point of #11674: keyedness no
+   * longer decides whether a deferral can land, so the two paths are pinned to
+   * the same healed outcome and cannot drift apart.
    */
   it('a composite key whose components are all present back-fills normally and says nothing', async () => {
     const { engine, store } = createFaithfulEngine();
@@ -393,5 +362,77 @@ describe('pass 2 finds no id because the source row failed in pass 1 (#5127)', (
     const [message] = deferredDropLines(logger)[0];
     expect(String(message)).not.toContain('EMPTY key');
     expect(String(message)).not.toContain('stays NULL');
+  });
+});
+
+/**
+ * The same "source row never landed" failure on a record with NO usable
+ * natural key (#11674) — the composite key evaluates to `''` AND the pass-1
+ * insert fails, so neither the captured-internal-id channel nor the
+ * natural-key fallback can name a row. This is the one way left to reach the
+ * empty-key drop branch: before #11674 that branch claimed "The row itself WAS
+ * seeded" and prescribed fixing the externalId components, both of which would
+ * be lies now (a row that seeds heals; the key is not the problem). The
+ * rewritten line names the record by INDEX — the only handle a keyless record
+ * has — and points at the pass-1 write error, exactly like its keyed sibling
+ * above.
+ */
+describe('pass 2 finds no id because a KEYLESS record failed in pass 1 (#11674)', () => {
+  function loadWithFailingKeylessDepartment() {
+    const { engine, store } = createFaithfulEngine();
+    const logger = createLogger();
+    const realInsert = (engine.insert as any).getMockImplementation();
+    (engine.insert as any).mockImplementation(async (obj: string, data: any, opts: any) => {
+      if (obj === 'drop_department') throw new Error('CHECK constraint failed: drop_department');
+      return realInsert(obj, data, opts);
+    });
+    return { engine, store, logger };
+  }
+
+  it('records the drop, naming the record by index and pointing at the pass-1 error', async () => {
+    const { engine, store, logger } = loadWithFailingKeylessDepartment();
+
+    const result = await new SeedLoaderService(engine, createMetadata(), logger).load({
+      seeds: compositeSeeds(''), // region '' → externalIdKey '' → no natural key
+      config: CONFIG,
+    });
+
+    // The row really is absent — nothing to back-fill onto.
+    expect(store.drop_department ?? []).toHaveLength(0);
+    expect(result.success).toBe(false);
+
+    // Recorded: the row loss (pass 1) AND the link it would have carried.
+    const dropped = result.errors.find(
+      (e: { field: string; message?: string }) => e.field === 'head_id' && String(e.message).includes('Deferred reference dropped'),
+    )!;
+    expect(dropped, 'the dropped back-fill was not recorded as an error').toBeDefined();
+    expect(dropped.message).toContain('no internal id was captured for drop_department record #0');
+    expect(result.errors.length).toBeGreaterThan(1); // the pass-1 write error is still there too
+
+    // Exactly ONE extra line, spelled by index (the only handle), pointing at
+    // the pass-1 failure — not the old "fix your externalId" prescription.
+    const lines = deferredDropLines(logger);
+    expect(lines.length).toBe(1);
+    const [message, err, meta] = lines[0];
+    expect(String(message)).toContain('drop_department.head_id');
+    expect(String(message)).toContain('record #0');
+    expect(String(message)).toContain('pass-1 write FAILED');
+    expect(String(message)).not.toContain('The row itself WAS seeded');
+    expect(String(message)).not.toMatch(/non-empty value/);
+    expect(String(message)).toMatch(/re-run the seed/);
+    expect(err).toBeUndefined();
+    expect(meta).toMatchObject({
+      object: 'drop_department',
+      field: 'head_id',
+      target: 'drop_worker.name',
+      recordIndex: 0,
+      recordExternalId: '',
+    });
+
+    // The pass-1 write error is untouched — one line each, no flood.
+    expect(
+      logger.error.mock.calls.some((c: unknown[]) => String(c[0]).includes('CHECK constraint failed')),
+      'the pass-1 write error stopped being reported',
+    ).toBe(true);
   });
 });

--- a/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
@@ -439,30 +439,33 @@ describe('seed pointer-pair resolution (#11339 — referenceVia)', () => {
  * and therefore has no case here; the verdict and its reasons are recorded at
  * the declaration site (`sys-automation-run.object.ts`, `trigger_record_id`).
  *
- * ## Why every case below seeds its TARGET FIRST
+ * ## Ordering: what heals, what still requires the target first (#11674)
  *
  * `sys_activity` heals an out-of-order pointer in pass 2 (the
- * order-independence case above). None of these four inherits that, and the
- * reason was measured here rather than assumed — twice over:
+ * order-independence case above). Whether these four inherit that was
+ * measured rather than assumed, and the answer SPLIT — by dataset keyedness
+ * first, then by the `required` flag on the id half:
  *
- *  - MEASURED, and the load-bearing one: all four are engine-owned rows with
- *    no natural key, so an honest seed dataset for them declares no
- *    `externalId`. Pass 2 back-fills by looking the row up BY its externalId,
- *    so it resolves the target and then has nowhere to write it ("Deferred
- *    reference DROPPED … has an empty externalId"). Pinned by the keyless
- *    case and its positive control in the `sys_audit_log` block.
- *  - NOT MEASURED here, and stated as such: on `sys_approval_request`,
- *    `sys_record_share` and `sys_share_link` the id half is also
- *    `required: true`, and pass 1 defers a reference by DELETING the column
- *    from the row (`seed-loader.ts`: "REMOVE the field rather than writing
- *    null … NOT NULL columns turned this into a loud constraint error"). A
- *    real engine enforces `required` on seed writes, so the deferred insert
- *    would fail there too — but this file's engine double does not validate,
- *    so no case here may claim it either way.
- *
- * Both roads end at the ruled family direction (loud, never silently wrong)
- * and at the same one-line author fix: order the target dataset first. What
- * they are NOT is order-independence, so no case below claims it.
+ *  - MEASURED, healed by #11674: all four are engine-owned rows with no
+ *    natural key, so an honest seed dataset for them declares no
+ *    `externalId`. Pass 2 used to back-fill by looking the row up BY its
+ *    externalId, so a keyless deferral resolved the target and then had
+ *    nowhere to write it ("Deferred reference DROPPED … empty externalId").
+ *    Pass 2 now writes back through the internal id captured at insert time,
+ *    so keylessness no longer costs the deferral — pinned by the keyless
+ *    case (healing) and its keyed sibling control in the `sys_audit_log`
+ *    block below.
+ *  - MEASURED against the REAL engine (in `packages/objectql/src/`
+ *    `engine-seed-required-deferral.test.ts` — this file's engine double
+ *    does not validate, so no case HERE may claim it): on
+ *    `sys_approval_request`, `sys_record_share` and `sys_share_link` the id
+ *    half is also `required: true`, and pass 1 defers a reference by
+ *    DELETING the column from the row. The real engine enforces `required`
+ *    on seed inserts (SEED_OPTIONS skips only state_machine), so the
+ *    deferred insert is rejected before pass 2 can help — an independent,
+ *    equally LOUD road that #11674's write-back does NOT clear. For those
+ *    three, order the target dataset first; `sys_audit_log` (optional id
+ *    half) is genuinely order-independent now.
  */
 
 /** The four adopted objects, mirroring their real declarations field-for-field
@@ -549,32 +552,33 @@ describe('pointer-pair adoption per object (#11386)', () => {
     });
 
     /**
-     * MEASURED, and not what this case was first written to assert.
+     * MEASURED — and this case has now flipped TWICE, deliberately both times.
      *
-     * The prediction going in was that an out-of-order pointer would heal in
-     * pass 2 here, because `sys_audit_log.record_id` is optional and so defers
-     * cleanly (that is what `sys_activity` does in the order-independence case
-     * above). It does not, and the reason is a property of the DATASET rather
-     * than of the pair: an engine-owned ledger has no natural key, so its seed
-     * dataset declares no `externalId` — and pass 2 back-fills by looking the
-     * row up by its externalId. It resolves the target and then has nowhere to
-     * write it ("Deferred reference DROPPED … has an empty externalId, so no
-     * internal id").
+     * As first written it asserted the healing this title now claims, on the
+     * prediction that an optional `record_id` defers cleanly the way
+     * `sys_activity`'s does. Measurement said no: pass 2 back-filled by
+     * looking the row up BY its externalId, and a keyless dataset (the honest
+     * authoring for an engine-owned ledger — no natural key) had no such
+     * handle, so the deferral resolved the target and then dropped the link
+     * LOUDLY ("Deferred reference DROPPED … empty externalId"). That
+     * order-dependence is the defect #11674 names: the declared deferral
+     * property ("a pointer pair contributes no static ordering edge, pass 2
+     * heals it") did not hold for exactly the datasets the four adopted
+     * objects ship.
      *
-     * That is the ruled family direction, not a regression: the load fails
-     * LOUDLY, and the author's fix is one line (order the target dataset
-     * first, or declare an externalId on the ledger dataset — the positive
-     * control below). It is asserted here rather than glossed because it is
-     * the measured difference between adopting the pair on `sys_activity` and
-     * adopting it on the four keyless system objects, and a reader who assumed
-     * order-independence carried over would be wrong.
+     * #11674's fix makes pass 2 write back through the internal id captured
+     * at insert time, so the property now holds without requiring a key.
+     * This case pins the healed behaviour; the keyed sibling below pins that
+     * the pre-existing keyed path still heals identically (it was the
+     * positive control that isolated keylessness as the cause while the
+     * failure existed).
      */
-    it('does NOT silently heal an out-of-order pointer on a KEYLESS dataset — pass 2 has nowhere to write back, and says so', async () => {
-      const { service, store } = newService(ADOPTER_SCHEMAS);
+    it('DOES heal an out-of-order pointer on a KEYLESS dataset — pass 2 writes back by the internal id captured at insert (#11674)', async () => {
+      const { service, store, engine } = newService(ADOPTER_SCHEMAS);
 
       // Ledger dataset BEFORE its target. A pointer pair contributes no static
       // dependency edge (the target is a per-row fact), so nothing but pass 2
-      // could save this — and pass 2 cannot, on a dataset with no externalId.
+      // can save this — and pass 2 now can, with no externalId declared.
       const result = await service.load({
         seeds: [
           insertSeed('sys_audit_log', [
@@ -585,22 +589,31 @@ describe('pointer-pair adoption per object (#11386)', () => {
         config: CONFIG,
       });
 
-      expect(result.success).toBe(false);
-      const err = result.errors.find((e: any) => e.field === 'record_id');
-      expect(err).toBeDefined();
-      // The message names the cause (the empty externalId), not just the miss —
-      // the author needs to know ordering/keying is the fix, not the value.
-      expect(String(err!.message)).toMatch(/externalId/);
+      expect(result.success).toBe(true);
+      const leadId = store.crm_lead.find((r) => r.name === 'Lisa Thompson')!.id;
+      // Healed to the REAL id — the `{object_name, record_id}` index query the
+      // ledger exists to answer now matches.
+      expect(store.sys_audit_log[0].record_id).toBe(leadId);
+      // It really went through the pass-2 back-fill write, not luck of order.
+      expect(
+        (engine.update as any).mock.calls.some(([obj]: [string]) => obj === 'sys_audit_log'),
+      ).toBe(true);
+      const ledgerResult = result.results.find((r: any) => r.object === 'sys_audit_log')!;
+      expect(ledgerResult.referencesResolved).toBeGreaterThan(0);
+      expect(ledgerResult.referencesDeferred).toBe(0); // given back by the successful back-fill
       // Never the silent verbatim store this family exists to kill.
       expect(store.sys_audit_log.filter((r) => r.record_id === 'Lisa Thompson')).toHaveLength(0);
     });
 
-    it('POSITIVE CONTROL — the same out-of-order load DOES heal once the ledger dataset declares an externalId', async () => {
+    it('KEYED SIBLING CONTROL — the same out-of-order load heals identically with an externalId declared', async () => {
       const { service, store } = newService(ADOPTER_SCHEMAS);
 
-      // Same seeds, same order, one difference: the ledger rows are
-      // addressable. This is what isolates the cause above to keylessness
-      // rather than to the pointer pair or to the deferral machinery.
+      // Same seeds, same order, one difference: the ledger rows are also
+      // addressable by natural key. While the keyless failure existed this was
+      // the positive control that isolated its cause to keylessness (same
+      // seeds, same order, key declared → healed); it stays pinned so the two
+      // paths — internal-id write-back and the pre-existing keyed lookup —
+      // cannot drift apart again.
       const result = await service.load({
         seeds: [
           {

--- a/packages/metadata-protocol/src/seed-loader.ts
+++ b/packages/metadata-protocol/src/seed-loader.ts
@@ -225,7 +225,10 @@ function isEnvScopedDataset(dataset: Seed): boolean {
  *   `object_name`), by the same externalId rules — and an unresolvable or
  *   un-addressable pointer is refused loudly, never stored verbatim
  * - Topological dependency ordering (parents before children)
- * - Multi-pass loading for circular references
+ * - Multi-pass loading for circular references — pass 2 writes a deferred
+ *   reference back through the source row's INTERNAL id captured at insert
+ *   time (#11674), so it heals KEYLESS datasets (`mode: 'insert'`, no
+ *   `externalId`) the same as keyed ones
  * - Dry-run validation mode
  * - Upsert support honoring SeedSchema mode
  * - Idempotent replay: an upsert/update whose declared fields already match
@@ -598,6 +601,19 @@ export class SeedLoaderService implements ISeedLoaderService {
     // logical/validation failure. See framework#2678.
     const pendingInserts: Array<{ recordIndex: number; externalIdValue: string; record: Record<string, unknown> }> = [];
     const opts = SeedLoaderService.SEED_OPTIONS as any;
+    // [#11674] Internal ids captured at write time, keyed by record index.
+    // Every write site below records the id it learned here — unconditionally,
+    // unlike the `insertedRecords` registrations, which need a non-empty
+    // natural key. Once the dataset has fully written, the deferred updates it
+    // pushed are annotated from this map (see the loop after the final flush),
+    // so pass 2 back-fills BY INTERNAL ID and a KEYLESS dataset (`mode:
+    // 'insert'`, no `externalId` — the honest authoring for an engine-owned
+    // object with no natural key) heals exactly like a keyed one. Before this,
+    // pass 2 re-resolved the source row through its externalId and a keyless
+    // deferral was structurally unreachable: it resolved the target, then
+    // dropped the link ("empty externalId, so no internal id").
+    const deferredStart = deferredUpdates.length;
+    const internalIdByRecordIndex = new Map<number, string>();
     const extIdOf = (rec: Record<string, unknown>) => this.externalIdKey(rec, externalId);
     // bulkWrite is at-least-once: a retry (or a mismatch-driven degradation)
     // may re-run a write whose prior attempt already committed. Guard against
@@ -687,6 +703,7 @@ export class SeedLoaderService implements ISeedLoaderService {
         if (res.ok) {
           inserted++;
           const internalId = this.extractId(res.record);
+          if (internalId) internalIdByRecordIndex.set(recordIndex, internalId); // [#11674]
           if (externalIdValue && internalId) {
             insertedRecords.get(objectName)!.set(externalIdValue, internalId);
           }
@@ -1111,6 +1128,7 @@ export class SeedLoaderService implements ISeedLoaderService {
 
             const externalIdValue = this.externalIdKey(record, externalId);
             const internalId = result.id;
+            if (internalId) internalIdByRecordIndex.set(i, String(internalId)); // [#11674]
             if (externalIdValue && internalId) {
               insertedRecords.get(objectName)!.set(externalIdValue, String(internalId));
             }
@@ -1121,6 +1139,7 @@ export class SeedLoaderService implements ISeedLoaderService {
             // mapping alive for downstream reference resolution.
             const externalIdValue = this.externalIdKey(record, externalId);
             const existingId = this.extractId(existingRecords?.get(externalIdValue));
+            if (existingId) internalIdByRecordIndex.set(i, existingId); // [#11674]
             if (externalIdValue && existingId) {
               insertedRecords.get(objectName)!.set(externalIdValue, existingId);
             }
@@ -1143,6 +1162,7 @@ export class SeedLoaderService implements ISeedLoaderService {
 
           if (decision.action === 'skip') {
             skipped++;
+            if (decision.id) internalIdByRecordIndex.set(i, decision.id); // [#11674]
             if (decision.id && externalIdValue) {
               insertedRecords.get(objectName)!.set(externalIdValue, decision.id);
             }
@@ -1154,6 +1174,7 @@ export class SeedLoaderService implements ISeedLoaderService {
             // sever downstream natural-key resolution — that cascade is what
             // turned one legitimate validation error into NULLed-out child
             // references on every dev-server restart.
+            if (decision.id) internalIdByRecordIndex.set(i, decision.id); // [#11674] same rationale
             if (externalIdValue) {
               insertedRecords.get(objectName)!.set(externalIdValue, decision.id);
             }
@@ -1196,6 +1217,19 @@ export class SeedLoaderService implements ISeedLoaderService {
 
     if (!config.dryRun) {
       await flushPendingInserts();
+    }
+
+    // [#11674] Annotate this dataset's deferred updates with the internal id
+    // their source row got when it was written — the id pass 2 writes the
+    // resolved reference back through. Runs after the final flush so batched
+    // inserts have reported their ids; datasets load sequentially, so the
+    // slice from `deferredStart` is exactly this dataset's deferrals. An entry
+    // that gets no id here is a row this dataset never landed (its write
+    // failed, or returned no id) — pass 2 reports that as the drop it is.
+    for (let d = deferredStart; d < deferredUpdates.length; d++) {
+      const entry = deferredUpdates[d];
+      const internalId = internalIdByRecordIndex.get(entry.recordIndex);
+      if (internalId) entry.internalId = internalId;
     }
 
     return {
@@ -1442,9 +1476,16 @@ export class SeedLoaderService implements ISeedLoaderService {
       const resolvedValue: unknown = deferred.multiple ? resolvedItems : resolvedItems[0];
 
       if (!stillUnresolved && resolvedItems.length > 0) {
-        // Find the record and update the reference
-        const objectRecordMap = insertedRecords.get(deferred.objectName);
-        const recordId = objectRecordMap?.get(deferred.recordExternalId);
+        // [#11674] Write back through the internal id captured at insert time
+        // — the handle that exists for every row this load actually wrote,
+        // keyed or KEYLESS, so the declared deferral property ("pass 2 heals
+        // an out-of-order reference") holds without requiring the dataset to
+        // declare an externalId. The natural-key map is the FALLBACK, not the
+        // primary: it can still name a row when this record's own pass-1 write
+        // failed but another dataset in the same load upserted the same
+        // natural key (same key = same logical row).
+        const recordId = deferred.internalId
+          ?? insertedRecords.get(deferred.objectName)?.get(deferred.recordExternalId);
 
         if (recordId) {
           try {
@@ -1502,57 +1543,45 @@ export class SeedLoaderService implements ISeedLoaderService {
               `Failed to write deferred reference: ${deferred.objectName}.${deferred.field} = '${this.formatAttempted(deferred.attemptedValue)}' → ${deferred.targetObject}.${deferred.targetField}: ${quotableSeedFailureDetail(err) ?? WITHHELD_WRITE_REASON}`);
           }
         } else {
-          // THE TARGET RESOLVED BUT THE SOURCE ROW HAS NO ID (#5127).
+          // THE TARGET RESOLVED BUT THE SOURCE ROW HAS NO ID (#5127, #11674).
           //
           // Pass 2 did its job — `resolvedValue` is a real internal id — and
-          // then found no internal id to write it ONTO: this load never
-          // registered `deferred.recordExternalId` in `insertedRecords`. Until
-          // now this branch did not exist, so the back-fill simply evaporated:
-          // no write, no `errors`/`allErrors` entry (so `success` stayed true),
-          // no `errored`, no log. The ONLY trace left was the `referencesDeferred`
-          // this record booked in pass 1 and never gave back — a number with
-          // nothing in the result explaining it.
+          // then found no internal id to write it ONTO. Since #11674 captures
+          // the internal id AT INSERT TIME for every row this load writes
+          // (keyed or keyless), the one way left to get here is that the
+          // source row NEVER LANDED: its pass-1 write failed (already
+          // reported at `error` by the write site, #4729) or returned no id.
+          // The pre-#11674 "pure silent loss" — row written fine but its key
+          // evaluated empty, so pass 2's externalId re-resolution had no
+          // handle — no longer exists: such a row now heals through its
+          // captured internal id.
           //
-          // It is the deeper cousin of the two branches around it: #4729 fixed
-          // "counted but logged at `warn`", #4997 fixed "counted, never logged",
-          // this one was "never counted, never logged". Same objective criterion
-          // as both (does the outcome enter `errors`/`allErrors`?) — so it is
-          // recorded AND logged at `error` per AGENTS.md → "Degradation log
-          // levels" (#4632): the row is in the database, every row counter reads
-          // healthy, and the association it declares is permanently absent.
-          //
-          // `referencesDeferred` deliberately stays booked, exactly as the two
+          // The outcome enters `errors`/`allErrors` (recorded AND logged at
+          // `error` per AGENTS.md → "Degradation log levels", #4632), and
+          // `referencesDeferred` deliberately stays booked, exactly as the
           // sibling failure branches leave it: the counter means "deferred
           // references that never landed", and only a SUCCESSFUL back-fill
-          // decrements it. What was missing was never the arithmetic — it was
-          // the error that explains the leftover, which `recordDeferredError`
-          // now supplies (the load reports `success: false`, `errored` counts
-          // the loss, and the dangling count has a matching entry in `errors`).
+          // decrements it — the leftover count always has a matching entry in
+          // `errors` explaining it.
           //
-          // The two ways to get here are NOT the same failure, so they do not
-          // get the same line. An EMPTY `recordExternalId` is the pure silent
-          // loss: `externalIdKey` returns `''` when any component of a composite
-          // key is blank, the row itself wrote fine, and nothing anywhere else
-          // reports it — this line is the only one a reader will ever see. A
-          // NON-empty key that is simply absent from the map means the source
-          // row did not land (or its write returned no id); that failure was
-          // already reported at `error` by the pass-1 write site (#4729), so
-          // this line points AT that error instead of restating it — one line,
-          // not a second flood over the same root cause.
+          // Two spellings of one failure, split on how the record can be
+          // NAMED: a record with a natural key is called by it; a keyless (or
+          // empty-keyed) record can only be called by its index. Both lines
+          // point AT the pass-1 write error instead of restating it — one
+          // line, not a second flood over the same root cause.
           const missedTarget = this.formatAttempted(deferred.attemptedValue);
           const where = `${deferred.targetObject}.${deferred.targetField} = '${missedTarget}'`;
           if (deferred.recordExternalId === '') {
             this.logger.error(
-              `[SeedLoader] Deferred reference DROPPED — ${deferred.objectName}.${deferred.field} stays NULL ` +
-                `FOREVER on record #${deferred.recordIndex}. Pass 2 RESOLVED the target (${where}) and then had ` +
-                `nowhere to write it: that record's externalId (\`${deferred.externalIdLabel}\`) evaluated to the ` +
-                `EMPTY key, which is what \`externalIdKey\` returns when the key field is absent or blank — or, ` +
-                `for a composite key, when ANY one of its components is — so no internal id was ever registered ` +
-                `for it in this load. The row itself WAS ` +
-                `seeded, so every row counter looks healthy while the relationship is MISSING, and nothing ` +
-                `retries this: pass 2 is the last one. Give every \`${deferred.externalIdLabel}\` component a ` +
-                `non-empty value in the ${deferred.objectName} seed data (or declare an externalId whose parts ` +
-                `are always present) and re-run the seed to complete the link.`,
+              `[SeedLoader] Deferred reference DROPPED — ${deferred.objectName}.${deferred.field} is never written ` +
+                `on record #${deferred.recordIndex}. Pass 2 RESOLVED the target (${where}) and then had ` +
+                `nowhere to write it: this load captured no internal id for that ${deferred.objectName} record, ` +
+                `because its pass-1 write FAILED (reported as its own \`error\` above) or returned no id — and its ` +
+                `externalId (\`${deferred.externalIdLabel}\`) evaluated to the empty key, so no natural-key ` +
+                `fallback can name a row either. Nothing retries this: pass 2 back-fills only rows this load ` +
+                `actually seeded, and it is the last pass. Fix the pass-1 write error reported for ` +
+                `${deferred.objectName} record #${deferred.recordIndex} and re-run the seed — the row and this ` +
+                `link land together or not at all.`,
               undefined,
               {
                 object: deferred.objectName,
@@ -1564,9 +1593,9 @@ export class SeedLoaderService implements ISeedLoaderService {
             );
             this.recordDeferredError(deferred, allResults, allErrors,
               `Deferred reference dropped: ${deferred.objectName}.${deferred.field} = '${missedTarget}' → ` +
-                `${deferred.targetObject}.${deferred.targetField} resolved, but ${deferred.objectName} record ` +
-                `#${deferred.recordIndex} has an empty \`${deferred.externalIdLabel}\` externalId, so no internal ` +
-                `id was registered for it and the back-fill could not be written`);
+                `${deferred.targetObject}.${deferred.targetField} resolved, but no internal id was captured for ` +
+                `${deferred.objectName} record #${deferred.recordIndex} in this load (its pass-1 write failed), ` +
+                `so the back-fill could not be written`);
           } else {
             this.logger.error(
               `[SeedLoader] Deferred reference DROPPED — ${deferred.objectName}.${deferred.field} is never written ` +
@@ -2446,17 +2475,35 @@ interface SummaryRecomputeLike {
 interface DeferredUpdate {
   objectName: string;
   /**
+   * The source record's INTERNAL id, captured at the moment its pass-1 write
+   * landed (#11674). This is the handle pass 2 writes the resolved reference
+   * back through: it exists for every row this load actually wrote —
+   * including rows of a KEYLESS dataset (`mode: 'insert'`, no `externalId`)
+   * and rows whose composite key evaluated to the empty string — so the
+   * "pass 2 resolved the target and had nowhere to write it" loss (#5127) is
+   * reduced to the one case where it is true: the source row never landed.
+   *
+   * `undefined` exactly when pass 1 registered no id for this record — its
+   * write failed (already reported at `error` by the write site) or returned
+   * no id. Pass 2 then falls back to the `insertedRecords` natural-key map,
+   * which can still name a row when ANOTHER dataset in the same load upserted
+   * the same natural key.
+   */
+  internalId?: string;
+  /**
    * The source record's natural key, as {@link SeedLoaderService.externalIdKey}
-   * computed it in pass 1 — the key pass 2 looks the record's internal id up by.
+   * computed it in pass 1 — pass 2's FALLBACK lookup into `insertedRecords`
+   * when {@link internalId} is absent, and the name error messages call the
+   * record by.
    *
    * May legitimately be `''`: `externalIdKey` returns the empty string when the
-   * key field is absent or blank, and — the case that actually bites — when ANY
-   * ONE component of a composite externalId is. An empty key is
-   * never registered in `insertedRecords`, so a deferred update carrying one can
-   * never find its record in pass 2 — which is precisely the "wrote the row,
-   * dropped the link" case #5127 exists to report. Carried verbatim (not
-   * normalised to `undefined`) so pass 2 can tell that case apart from a real
-   * key whose record simply failed to write.
+   * dataset declares no `externalId` and the row carries no `name`, when the
+   * key field is absent or blank, and when ANY ONE component of a composite
+   * externalId is. An empty key is never registered in `insertedRecords`, so
+   * it can never find a record — since #11674 that only matters when
+   * `internalId` is ALSO absent (the row never landed). Carried verbatim (not
+   * normalised to `undefined`) so pass 2 can address the record by index
+   * rather than by a key it does not have.
    */
   recordExternalId: string;
   /**

--- a/packages/objectql/src/engine-seed-required-deferral.test.ts
+++ b/packages/objectql/src/engine-seed-required-deferral.test.ts
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectQL } from './engine.js';
+import { SeedLoaderService } from '@objectstack/metadata-protocol';
+import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
+
+/**
+ * Seed deferral vs `required: true` — measured against the REAL engine
+ * (#11674, the card's "Second, NOT measured" question).
+ *
+ * The seed loader defers an unresolvable reference to pass 2 by DELETING the
+ * column from the row. The seed-loader suite's engine double does not
+ * validate, so it accepts that insert either way and nothing in
+ * `packages/metadata-protocol` may claim what a real engine does. This suite
+ * closes the question with the real `ObjectQL` engine, whose record validator
+ * enforces `required` on insert (ADR-0113; `SEED_OPTIONS.seedReplay` skips
+ * only the `state_machine` rule — "All OTHER validation … still runs").
+ *
+ * Measured answers, each pinned below:
+ *
+ *  1. REQUIRED id half (`sys_approval_request` / `sys_record_share` /
+ *     `sys_share_link` shape): the deferred insert — its required `record_id`
+ *     deleted — is REJECTED by required-validation. Loud, counted, the row
+ *     never lands, and pass 2 has nothing to write back onto. So #11674's
+ *     internal-id write-back does NOT make these three objects
+ *     order-independent: their datasets must still seed the target first.
+ *  2. Same object, target seeded FIRST: the pointer resolves in pass 1, the
+ *     insert carries the real id, the same engine accepts it. This isolates
+ *     case 1's rejection to the deferral-deletion, not the object shape, the
+ *     pointer pair, or the engine.
+ *  3. OPTIONAL id half (`sys_audit_log` shape), keyless dataset, target
+ *     seeded after: pass 1 inserts without the column (nothing requires it),
+ *     and pass 2 back-fills through the internal id captured at insert time —
+ *     #11674's fix, holding end-to-end against the engine that really
+ *     validates. This is what makes `sys_audit_log` genuinely
+ *     order-independent while its three required-half siblings are not.
+ */
+
+function makeDriver() {
+  const stores = new Map<string, Map<string, any>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  const checkOp = (value: any, cond: any): boolean => {
+    if (cond === null || typeof cond !== 'object' || Array.isArray(cond) || cond instanceof Date) {
+      return value === cond;
+    }
+    return Object.entries(cond).every(([op, target]: [string, any]) => {
+      switch (op) {
+        case '$eq': return value === target;
+        case '$ne': return value !== target;
+        case '$in': return Array.isArray(target) && target.includes(value);
+        default: return true;
+      }
+    });
+  };
+  const matches = (row: any, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    return Object.entries(where).every(([k, v]: [string, any]) => {
+      if (k === '$and') return (v as any[]).every((w) => matches(row, w));
+      if (k === '$or') return (v as any[]).some((w) => matches(row, w));
+      if (k === '$not') return !matches(row, v);
+      return checkOp(row?.[k], v);
+    });
+  };
+  let n = 0;
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matches(r, ast?.where));
+    },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matches(r, ast?.where)) return r;
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      n += 1;
+      const id = (data.id as string) ?? `r_${n}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return row;
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const row = { ...s.get(id), ...data, id };
+      s.set(id, row);
+      return row;
+    },
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      let count = 0;
+      for (const row of [...s.values()]) {
+        if (!matches(row, ast?.where)) continue;
+        s.set(row.id, { ...row, ...data, id: row.id });
+        count += 1;
+      }
+      return count;
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count() { return 0; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { __trx: true, commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, storeFor };
+}
+
+/** The loader falls back to `engine.getSchema` when the metadata service has
+ *  nothing — the marketplace-install shape. All schemas live in the REAL
+ *  engine registry here; the stub only has to answer "not mine". */
+function emptyMetadata(): IMetadataService {
+  return {
+    getObject: async () => undefined,
+    listObjects: async () => [],
+    register: async () => {},
+    get: async () => undefined,
+    list: async () => [],
+    unregister: async () => {},
+    exists: async () => false,
+    listNames: async () => [],
+  } as unknown as IMetadataService;
+}
+
+function silentLogger() {
+  const calls: Record<string, unknown[][]> = { info: [], warn: [], error: [], debug: [] };
+  return {
+    calls,
+    info: (...a: unknown[]) => { calls.info.push(a); },
+    warn: (...a: unknown[]) => { calls.warn.push(a); },
+    error: (...a: unknown[]) => { calls.error.push(a); },
+    debug: (...a: unknown[]) => { calls.debug.push(a); },
+  } as any;
+}
+
+const CONFIG = {
+  dryRun: false,
+  haltOnError: false,
+  multiPass: true,
+  defaultMode: 'insert',
+  batchSize: 1000,
+  transaction: false,
+} as any;
+
+const ENV = ['prod', 'dev', 'test'];
+
+const LEAD_SEED = {
+  object: 'rq_lead',
+  externalId: 'name',
+  mode: 'upsert',
+  env: ENV,
+  records: [{ name: 'Lisa Thompson' }],
+};
+
+describe('seed deferral vs required:true, on the real engine (#11674)', () => {
+  let engine: ObjectQL;
+  let storeFor: ReturnType<typeof makeDriver>['storeFor'];
+
+  beforeEach(async () => {
+    engine = new ObjectQL();
+    const d = makeDriver();
+    storeFor = d.storeFor;
+    engine.registerDriver(d.driver, true);
+    await engine.init();
+    engine.registry.registerObject({
+      name: 'rq_lead',
+      fields: { name: { type: 'text', required: true } },
+    } as any, 'test-package');
+    // The sys_approval_request / sys_record_share / sys_share_link shape:
+    // BOTH halves required, id half a declared pointer pair.
+    engine.registry.registerObject({
+      name: 'rq_approval',
+      fields: {
+        process_name: { type: 'text', required: true },
+        object_name: { type: 'text', required: true },
+        record_id: { type: 'text', required: true, referenceVia: 'object_name' },
+        status: { type: 'select', options: [{ value: 'pending' }, { value: 'approved' }] },
+      },
+    } as any, 'test-package');
+    // The sys_audit_log shape: pointer pair declared, id half OPTIONAL.
+    engine.registry.registerObject({
+      name: 'rq_ledger',
+      fields: {
+        action: { type: 'text' },
+        object_name: { type: 'text' },
+        record_id: { type: 'text', referenceVia: 'object_name' },
+      },
+    } as any, 'test-package');
+
+    // Harness sanity: the declarations the loader reads really survived
+    // registry normalization. If either strips, every case below would pass a
+    // different (vacuous) scenario — fail here instead, naming the reason.
+    const approval = (engine.getSchema('rq_approval') as any)?.fields?.record_id;
+    expect(approval?.referenceVia, 'registry dropped referenceVia — cases below would not defer at all').toBe('object_name');
+    expect(approval?.required, 'registry dropped required — case 1 would measure nothing').toBe(true);
+    expect((engine.getSchema('rq_ledger') as any)?.fields?.record_id?.referenceVia).toBe('object_name');
+  });
+
+  const loader = () => new SeedLoaderService(engine as unknown as IDataEngine, emptyMetadata(), silentLogger());
+
+  it('MEASURED: the real engine REJECTS the deferred insert of a required id half — pass-2 write-back cannot save it', async () => {
+    // Keyless approval dataset BEFORE its target: the pointer cannot resolve
+    // in pass 1, so the loader defers by DELETING required `record_id`.
+    const result = await loader().load({
+      seeds: [
+        { object: 'rq_approval', mode: 'insert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ] },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // The row never landed: required-validation refused the column-less insert.
+    expect(storeFor('rq_approval').size).toBe(0);
+    expect(result.success).toBe(false);
+
+    // The rejection is the REQUIRED check on the deleted column, reported as
+    // this row's write error — not a resolution error and not silence.
+    const writeError = result.errors.find(
+      (e: any) => /record_id/.test(String(e.message)) && /required/i.test(String(e.message)),
+    );
+    expect(writeError, 'no write error names the required record_id — the engine did not reject the deferred insert').toBeDefined();
+
+    // The load really did DEFER (this is what deleted the column): pass 2 then
+    // resolved the target and reported it had no row to write back onto.
+    const approvalResult = result.results.find((r: any) => r.object === 'rq_approval')!;
+    expect(approvalResult.referencesDeferred).toBeGreaterThan(0);
+    expect(
+      result.errors.some((e: any) => String(e.message).includes('Deferred reference dropped')),
+    ).toBe(true);
+
+    // The target itself seeded fine — the failure is confined to the deferral.
+    expect(storeFor('rq_lead').size).toBe(1);
+  });
+
+  it('CONTROL: the same object accepts the same row when the target seeds FIRST — the rejection is the deferral, not the shape', async () => {
+    const result = await loader().load({
+      seeds: [
+        LEAD_SEED,
+        { object: 'rq_approval', mode: 'insert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ] },
+      ] as any,
+      config: CONFIG,
+    });
+
+    expect(result.success).toBe(true);
+    const leadId = [...storeFor('rq_lead').values()][0].id;
+    const approval = [...storeFor('rq_approval').values()][0];
+    expect(approval.record_id).toBe(leadId);
+    expect(approval.process_name).toBe('flow:discount');
+  });
+
+  it('MEASURED: an OPTIONAL id half on a KEYLESS dataset heals out-of-order through the real engine (#11674 end-to-end)', async () => {
+    const result = await loader().load({
+      seeds: [
+        { object: 'rq_ledger', mode: 'insert', env: ENV, records: [
+          { action: 'read', object_name: 'rq_lead', record_id: 'Lisa Thompson' },
+        ] },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    expect(result.success).toBe(true);
+    const leadId = [...storeFor('rq_lead').values()][0].id;
+    const ledger = [...storeFor('rq_ledger').values()][0];
+    // Healed to the REAL id by the pass-2 back-fill — on an engine that
+    // validates every write, with no externalId declared anywhere on the
+    // ledger dataset.
+    expect(ledger.record_id).toBe(leadId);
+    const ledgerResult = result.results.find((r: any) => r.object === 'rq_ledger')!;
+    expect(ledgerResult.referencesResolved).toBeGreaterThan(0);
+    expect(ledgerResult.referencesDeferred).toBe(0);
+    // Never the verbatim natural key.
+    expect(ledger.record_id).not.toBe('Lisa Thompson');
+  });
+});

--- a/packages/objectql/src/engine-seed-required-deferral.test.ts
+++ b/packages/objectql/src/engine-seed-required-deferral.test.ts
@@ -53,7 +53,9 @@ function makeDriver() {
         case '$eq': return value === target;
         case '$ne': return value !== target;
         case '$in': return Array.isArray(target) && target.includes(value);
-        default: return true;
+        // REFUSE, never silently match — an unsupported operator answered
+        // `true` reads as a hit for every row (the where-matcher gate's class).
+        default: throw new Error(`fake driver: unsupported operator ${op}`);
       }
     });
   };
@@ -63,6 +65,7 @@ function makeDriver() {
       if (k === '$and') return (v as any[]).every((w) => matches(row, w));
       if (k === '$or') return (v as any[]).some((w) => matches(row, w));
       if (k === '$not') return !matches(row, v);
+      if (k.startsWith('$')) throw new Error(`fake driver: unsupported combinator ${k}`);
       return checkOp(row?.[k], v);
     });
   };


### PR DESCRIPTION
Part of #11674 — the KEYLESS write-back half is closed here; the card's "Second, NOT measured" question was measured, it HOLDS, and what it leaves open is stated at the bottom. #11674 remains open on that remainder.

## What was measured

**Before-state (the card's pinned red).** A keyless dataset (`mode: 'insert'`, no `externalId`) seeded before its pointer target reported `success: false` with the empty-externalId drop — pass 2 resolved the target, then had no handle to write it back through, because it re-resolved the source row via `externalId`. Pinned in `seed-loader-pointer-pair.test.ts` with its positive control (same seeds, same order, `externalId` declared → heals), which isolated keylessness as the cause.

**The card's "Second, NOT measured" section — now measured, against the real engine.** New suite `packages/objectql/src/engine-seed-required-deferral.test.ts` drives `SeedLoaderService` against the real `ObjectQL` engine (which enforces `required` on insert; `SEED_OPTIONS.seedReplay` skips only `state_machine`) with an in-memory driver:

- an object shaped like `sys_approval_request` (`record_id` `required: true` + `referenceVia`), keyless, seeded before its target: pass 1 defers by **deleting the required column** and the engine **rejects the insert** (write error naming `record_id` + required; row never lands; `referencesDeferred > 0`; pass 2 reports the dropped back-fill). The prediction in the card holds.
- control: the same object, target seeded first → accepted, pointer carries the real id. The rejection is the deferral-deletion, not the shape, the pair, or the engine.
- an object shaped like `sys_audit_log` (optional id half), keyless, out of order → **heals end-to-end through the real validating engine** with this PR's fix.

So a pass-2 write-back fix alone does **not** clear the out-of-order failure for `sys_approval_request`, `sys_record_share`, `sys_share_link` — exactly as the card suspected.

## What changed

`packages/metadata-protocol/src/seed-loader.ts`:

- `DeferredUpdate` gains `internalId` — the source row's internal id captured when its pass-1 write lands.
- `loadDataset` captures the id at every write site (batched insert outcomes, self-ref sequential writes incl. the rejected-update cascade guard, upsert `skip`/`update` decisions), keyed by record index, and annotates the dataset's deferred updates after the final flush.
- Pass 2 writes back through `deferred.internalId` first; the natural-key map stays as the fallback for the one case it can still answer (another dataset in the same load upserted the same natural key).
- The empty-externalId drop branch is rewritten for its one remaining reachable meaning: the source row never landed (pass-1 write failed / returned no id), named by record index since a keyless record has no key to be named by. The keyed drop branch is unchanged.

Tests: the keyless pin flips to a healing pin (with back-fill-write and counter assertions); the #5127 "pure silent loss" trio (row written, composite key evaluated empty) flips to healing pins — that loss no longer exists structurally; a new pin covers the keyless row whose pass-1 write failed (the drop that remains); the keyed drop pins and all controls are untouched. Plus the new real-engine suite above.

Changeset: patch on `@objectstack/metadata-protocol`.

## What deliberately did not change

- Pass-1 deferral still defers by deleting the column (the upsert-replay corruption rationale stands); no relaxation of `required` at seed time — that would be a design decision this card does not carry.
- No spec/Zod change, no new authorable keys, no consumer-side leniency. Options 1 and 3 from the card (document / refuse at load time) were not taken: option 2 was reachable and is the only one that makes the deferral property honest.
- The loud-drop family direction: a row that never landed still drops its deferred reference loudly, one line, pointing at the pass-1 error.

**Accept-surface note for the enqueue gate:** this diff flips loads that previously reported `success: false` (keyless out-of-order, and the empty-composite-key #5127 scenario) into successful, healed loads — the accept-behaviour change the card predicted for option 2. It does not widen any authorable or API surface beyond that.

## Ablation (mutation proven on disk before any result was read; direction predicted in advance)

Mutation: remove the internal-id channel in pass 2 (`const recordId = deferred.internalId ?? map…` → map-only). Predicted: the 4 healing pins in metadata-protocol go red, the real-engine optional-half case goes red, all controls and drop pins stay green.

- Src proof: anchor `const recordId = deferred.internalId` count 1 → 0; marker count 0 → 1 (single exact replacement, node string-replace with hit-count assert).
- Leg 1 (metadata-protocol, resolves src): **4 failed | 23 passed** — exactly the predicted four.
- Leg 2 first attempt was **VOID** and is reported as such: the marker was a comment, esbuild stripped it, and `ablation-dist-preflight` refused ("marker only in sourcemaps"). Re-run with the marker in executable code: rebuild → preflight PASS (marker in 2 built files) → objectql suite **1 failed | 2 passed** — exactly the predicted case 3.
- Restore under `trap … EXIT INT TERM`: src marker count 0, rebuild, preflight `--absent` PASS (marker absent from all 24 built files), `git status --porcelain` clean.

## Verification (all on the tree of final commit `2654222fd3`; gate union derived by `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at that commit)

- `@objectstack/metadata-protocol` full suite: **139 passed | 2 skipped (1910 tests passed | 10 skipped)**.
- `@objectstack/objectql` full suite: **232 files, 4109 tests, all passed**; `typecheck` green (metadata-protocol has no `typecheck` script — ledgered, governed by `check:type-check-coverage`, which is green).
- Gate union, every gate exit captured before any pipe, all green: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:durability-log-level`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-engine-split-ratio` (refused on the shallow clone, deepened per its remedy, then green at 97.6%), `check-plugin-teardown-shape`, `docs-audit/check-affected-docs`, `release-rehearsal-clone --self-test`, plus convention-triggered `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:type-check-debt` (`--re-measure`, closure built via turbo first), and `check:nul-bytes`.

## What remains on #11674

The three required-id-half objects (`sys_approval_request`, `sys_record_share`, `sys_share_link`) stay order-dependent through the second, now-measured road: pass 1 defers by deleting a `required` column and a validating engine rejects that insert before pass 2 can help. Failure stays loud (write error + dropped-deferral error). Resolving that half means deciding how a deferral should coexist with `required` (or adopting the card's option 1/3 for that subset only) — a design decision left on the card for triage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VK8rFDtg8eREaxBGX99Csn)_