### PR TITLE
feat(spec): declare introspectSchema on IDataDriver and type IDataEngine.introspectDatasource — the engine-registration seam meets the compiler

### DIFF
--- a/.changeset/eleven-introspect-contract.md
+++ b/.changeset/eleven-introspect-contract.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/spec': minor
+---
+
+The engine-registration road into datasource introspection now meets the compiler (#11493, extending the #11123 ruling from the `DatasourceDriverHandle` seam): `IDataDriver` gains an optional `introspectSchema?(): Promise<IntrospectedSchema>` member, and `IDataEngine` gains an optional `introspectDatasource?(datasource: string): Promise<IntrospectedSchema>` member. Both are typed with the spec's one introspection shape (`IntrospectedSchema`, `@objectstack/spec/contracts`). Drivers and engines without introspection stay conformant — the members are optional — while a driver that DOES implement `introspectSchema` with a mis-shaped result (a column flag spelled `isPrimary`, a bare `{ tables }` with no `dialect`/`introspectedAt`) now fails compile at the offending field instead of surfacing at runtime as a federated table whose records cannot be located.

--- a/.changeset/eleven-introspect-engine.md
+++ b/.changeset/eleven-introspect-engine.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/objectql': patch
+---
+
+`ObjectQL.introspectDatasource()` declares its real return type — the spec's `IntrospectedSchema` (the new `IDataEngine.introspectDatasource?` contract member) — instead of an untyped `Promise<unknown>`, and the driver lookup inside it drops its `as any` now that `IDataDriver` declares `introspectSchema?`. Type-level only; runtime behaviour is byte-identical (#11493).

--- a/.changeset/eleven-introspect-plugin.md
+++ b/.changeset/eleven-introspect-plugin.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/service-datasource': patch
+---
+
+`ExternalDatasourceServicePlugin` types the `'data'` service with the real engine contract (`IDataEngine`, `@objectstack/spec/contracts`) and deletes its private structural `DataEngineLike` re-declaration — the workaround the untyped `IDataEngine.introspectDatasource()` forced (#11493). The introspection fallback branch now probes `getDriverByName?` (the registry member the contract declares) instead of `getDatasourceDriver?`, a spelling no engine in either repository ever had, so the degradation path is reachable for the first time.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -58,7 +58,7 @@ import type { FlowFunctionEffect } from '@objectstack/spec/automation';
 // Imported from spec directly rather than through `@objectstack/core`'s
 // re-export block: that block is labelled backward-compatibility, and this
 // contract is new (#5945).
-import type { IScopedContext, IScopedObjectRepository } from '@objectstack/spec/contracts';
+import type { IScopedContext, IScopedObjectRepository, IntrospectedSchema as SpecIntrospectedSchema } from '@objectstack/spec/contracts';
 import {
   IDataDriver,
   IDataEngine,
@@ -12239,9 +12239,18 @@ export class ObjectQL implements IObjectQLEngine {
    *
    * @throws if the datasource has no registered driver, or the driver does
    *   not support introspection.
+   *
+   * [#11493] The return is the spec's ONE introspection shape — the
+   * `IDataEngine.introspectDatasource?` contract member this method
+   * implements — not the untyped `Promise<unknown>` it declared while
+   * `IDataDriver` was silent about `introspectSchema`. The `as any` on the
+   * driver lookup went in the same stroke: the member is on the driver
+   * contract now, so the duck-typed probe below is a typed read. Runtime is
+   * deliberately byte-identical — both throws and the delegation are
+   * unchanged.
    */
-  async introspectDatasource(datasource: string): Promise<unknown> {
-    const driver = this.drivers.get(datasource) as any;
+  async introspectDatasource(datasource: string): Promise<SpecIntrospectedSchema> {
+    const driver = this.drivers.get(datasource);
     if (!driver) {
       throw new Error(`[ObjectQL] Datasource '${datasource}' has no registered driver to introspect.`);
     }

--- a/packages/services/service-datasource/src/plugin.ts
+++ b/packages/services/service-datasource/src/plugin.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { Plugin, PluginContext } from '@objectstack/core';
-import type { IntrospectedSchema } from '@objectstack/spec/contracts';
+import type { IDataEngine, IntrospectedSchema } from '@objectstack/spec/contracts';
 import {
   ExternalDatasourceService,
   type ExternalDatasourceServiceConfig,
@@ -10,15 +10,17 @@ import {
   type Logger,
 } from './external-datasource-service.js';
 
-/**
- * Minimal surfaces the plugin needs from the data engine + metadata service.
- * Kept structural so the plugin doesn't hard-depend on concrete classes.
- */
-interface DataEngineLike {
-  /** Resolve a driver by datasource name and introspect its live schema. */
-  introspectDatasource?: (datasource: string) => Promise<IntrospectedSchema>;
-  getDatasourceDriver?: (datasource: string) => { introspectSchema?: () => Promise<IntrospectedSchema> } | undefined;
-}
+// The structural `DataEngineLike` re-declaration that used to live here is
+// DELETED (#11493, part of the fix by the maintainer ruling): the `'data'`
+// service's real contract (`IDataEngine`, `@objectstack/spec/contracts`) now
+// declares `introspectDatasource?` with the spec return type, so this plugin
+// no longer needs a private engine type to recover `IntrospectedSchema` from
+// an untyped `Promise`. Its second member, `getDatasourceDriver?`, matched NO
+// engine in either repository (measured 2026-08-24: zero references outside
+// this file) — the fallback branch below probed it and could never fire. The
+// probe is respelled to the member the contract actually declares
+// (`getDriverByName?`, [#4251]), which makes the degradation reachable for
+// the first time instead of silently dead.
 
 interface MetadataServiceLike {
   get: (type: string, name: string) => Promise<unknown>;
@@ -61,14 +63,14 @@ export class ExternalDatasourceServicePlugin implements Plugin {
   }
 
   async init(ctx: PluginContext): Promise<void> {
-    const engine = safeGetService<DataEngineLike>(ctx, 'data');
+    const engine = safeGetService<IDataEngine>(ctx, 'data');
     const metadata = safeGetService<MetadataServiceLike>(ctx, 'metadata');
 
     const introspect: ExternalDatasourceServiceConfig['introspect'] =
       this.options.introspect ??
       (async (datasource: string) => {
         if (engine?.introspectDatasource) return engine.introspectDatasource(datasource);
-        const driver = engine?.getDatasourceDriver?.(datasource);
+        const driver = engine?.getDriverByName?.(datasource);
         if (driver?.introspectSchema) return driver.introspectSchema();
         throw new Error(
           `Cannot introspect datasource '${datasource}': no driver introspection available.`,

--- a/packages/spec/src/contracts/data-driver.test.ts
+++ b/packages/spec/src/contracts/data-driver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { DriverQuery, IDataDriver } from './data-driver';
+import type { IntrospectedSchema } from './schema-diff-service';
 import type { QueryAST } from '../data/query.zod';
 import type { DriverOptions } from '../data/driver.zod';
 
@@ -268,6 +269,133 @@ describe('IDataDriver', () => {
       // was not in the protocol.
       const unknownOperator: DriverQuery = { where: { name: { $sounds_like: 'acme%' } } };
       expect(unknownOperator.where).toBeTruthy();
+    });
+  });
+
+  // ===========================================================================
+  // introspectSchema — the engine-registration road meets the compiler (#11493)
+  // ===========================================================================
+  //
+  // #11381 typed the host-factory road (`DatasourceDriverHandle.introspectSchema`,
+  // option C of the #11123 ruling). This block pins the OTHER documented road: a
+  // driver implementing `IDataDriver` and handed to `IDataEngine.registerDriver()`.
+  // Reverse-verified against the pre-#11493 contract (measured 2026-08-24): with
+  // the interface silent about `introspectSchema`, the mis-shapes below compiled
+  // GREEN — an extra member rides along unchecked — which is the gap #11493
+  // closes. As with the DriverQuery pins above, every directive here is resolved
+  // by tsc: reverting the member makes each `@ts-expect-error` unused, and an
+  // unused directive is itself an error, so `pnpm --filter @objectstack/spec
+  // typecheck` goes red on regression in either direction.
+
+  describe('introspectSchema (#11493)', () => {
+    /** The declared return type, read off the CONTRACT rather than re-spelled. */
+    type DriverIntrospection = Awaited<ReturnType<NonNullable<IDataDriver['introspectSchema']>>>;
+
+    const base: IDataDriver = {
+      name: 'introspecting',
+      version: '1.0.0',
+      supports: {},
+      connect: async () => {},
+      disconnect: async () => {},
+      checkHealth: async () => true,
+      execute: async () => ({}),
+      find: async () => [],
+      findOne: async () => null,
+      create: async () => ({ id: '1' }),
+      update: async () => ({ id: '1' }),
+      upsert: async () => ({ id: '1' }),
+      delete: async () => true,
+      count: async () => 0,
+      bulkCreate: async () => [],
+      bulkUpdate: async () => [],
+      bulkDelete: async () => {},
+      beginTransaction: async () => ({}),
+      commit: async () => {},
+      rollback: async () => {},
+      syncSchema: async () => {},
+      dropTable: async () => {},
+    };
+
+    it('is optional — a driver without introspection stays conformant', () => {
+      // `base` above declares no `introspectSchema` and satisfies `IDataDriver`
+      // at its declaration; introspection is a capability, not an obligation.
+      expect(base.introspectSchema).toBeUndefined();
+    });
+
+    it('declares exactly the spec introspection shape, not a lookalike', () => {
+      // Mutual extends: the member's return IS `IntrospectedSchema` — a revert
+      // to `unknown` (or a drift to a private re-spelling) resolves `Exact` to
+      // `never` and this line goes red naming the contract.
+      type Exact = DriverIntrospection extends IntrospectedSchema
+        ? (IntrospectedSchema extends DriverIntrospection ? 'exact' : never)
+        : never;
+      const exact: Exact = 'exact';
+      expect(exact).toBe('exact');
+    });
+
+    it('accepts the spec shape, and a shape that EXTENDS it (the driver-sql pattern)', () => {
+      const conforming: IDataDriver = {
+        ...base,
+        introspectSchema: async () => ({
+          dialect: 'postgres',
+          introspectedAt: '2026-08-24T00:00:00.000Z',
+          tables: {
+            wh_order: {
+              name: 'wh_order',
+              columns: [{ name: 'id', type: 'uuid', nullable: false, primaryKey: true }],
+            },
+          },
+        }),
+      };
+      // Extra facts ride along: driver-sql's table-level `primaryKeys` /
+      // `foreignKeys` and per-column `isUnique` / `maxLength` live on declared
+      // types that EXTEND the spec contract, and assignability admits them on
+      // any non-literal value. What the contract refuses is a wrong spelling
+      // of a DECLARED key, never a richer driver.
+      const extendedResult = {
+        dialect: 'postgres',
+        introspectedAt: '2026-08-24T00:00:00.000Z',
+        tables: {
+          wh_order: {
+            name: 'wh_order',
+            columns: [{ name: 'id', type: 'uuid', nullable: false, primaryKey: true, isUnique: true, maxLength: 36 }],
+            primaryKeys: ['id'],
+            foreignKeys: [],
+          },
+        },
+      };
+      const extended: IDataDriver = { ...base, introspectSchema: async () => extendedResult };
+      expect(typeof conforming.introspectSchema).toBe('function');
+      expect(typeof extended.introspectSchema).toBe('function');
+    });
+
+    it('refuses the retired isPrimary spelling at the offending field', () => {
+      // The defect class this seam actually shipped: primary-key membership
+      // spelled `isPrimary`, which no consumer reads — the federated table's
+      // records silently could not be located or updated.
+      // @ts-expect-error - primary-key membership is spelled `primaryKey`, never `isPrimary`
+      const misSpelled: DriverIntrospection = { dialect: 'postgres', introspectedAt: 'now', tables: { t: { name: 't', columns: [{ name: 'id', type: 'uuid', nullable: false, isPrimary: true }] } } };
+      expect(misSpelled).toBeTruthy();
+    });
+
+    it('refuses a bare { tables } with no dialect / introspectedAt envelope', () => {
+      // @ts-expect-error - `dialect` and `introspectedAt` are REQUIRED on the spec schema
+      const bareTables: DriverIntrospection = { tables: {} };
+      expect(bareTables).toBeTruthy();
+    });
+
+    it('refuses a mis-shaped implementation where it is OFFERED, on the registerDriver road', () => {
+      // Exactly what a pre-#11493 driver author shipped: the whole driver value,
+      // with an `introspectSchema` answering the pre-spec shape. Against the
+      // silent contract this assignment compiled green (the measured gap);
+      // declared, tsc refuses it at the member.
+      const preFixResult = { tables: { t: { name: 't', columns: [{ name: 'id', type: 'uuid', nullable: false, isPrimary: true }] } } };
+      const author: IDataDriver = {
+        ...base,
+        // @ts-expect-error - the pre-spec result shape no longer satisfies the declared member
+        introspectSchema: async () => preFixResult,
+      };
+      expect(author).toBeTruthy();
     });
   });
 });

--- a/packages/spec/src/contracts/data-driver.ts
+++ b/packages/spec/src/contracts/data-driver.ts
@@ -2,6 +2,7 @@
 
 import type { DriverOptions, DriverCapabilities } from '../data/driver.zod.js';
 import type { QueryAST } from '../data/query.zod.js';
+import type { IntrospectedSchema } from './schema-diff-service.js';
 
 /**
  * DriverQuery — the query AST as a **driver** receives it: {@link QueryAST}
@@ -362,6 +363,36 @@ export interface IDataDriver {
    * vouch for a store's newness.
    */
   getSchemaSyncStats?(): { created: number; existing: number };
+
+  /**
+   * Introspect the live physical schema this driver is connected to
+   * (ADR-0015): table names, columns, and primary-key membership, as the
+   * spec's ONE introspection shape — {@link IntrospectedSchema}.
+   *
+   * The return type is CONTRACTUAL, and it is declared here for the same
+   * reason `DatasourceDriverHandle.introspectSchema` was typed by #11381
+   * (option C of the #11123 ruling): a custom driver has TWO documented roads
+   * into the same runtime read — the host-factory handle, and direct
+   * `IDataEngine.registerDriver()` — and until #11493 only the first was
+   * reachable by a compiler. A driver author implementing THIS interface had
+   * no signature to mis-match against, so a column flag spelled `isPrimary`,
+   * or a bare `{ tables }` with no `dialect`/`introspectedAt`, compiled clean
+   * and surfaced only as a federated table whose records silently could not
+   * be located or updated (absorbed by the PR #11001 runtime shim). Declared
+   * here, `tsc` refuses the mis-shape at the offending field on either road.
+   *
+   * Extra facts a richer driver carries stay legal — driver-sql's table-level
+   * `primaryKeys` / `foreignKeys`, per-column `isUnique` / `maxLength` ride
+   * on declared types that EXTEND the spec contract, and assignability
+   * admits them. What is refused is a WRONG spelling of a declared key,
+   * which is the defect class this seam has actually shipped.
+   *
+   * Optional: introspection is a capability, not an obligation — drivers
+   * without it (memory, mongodb today) simply omit the member and stay
+   * conformant. The engine's `introspectDatasource()` answers their absence
+   * with a named error rather than a guess.
+   */
+  introspectSchema?(): Promise<IntrospectedSchema>;
 
   /** Drop the underlying table or collection (destructive) */
   dropTable(object: string, options?: DriverOptions): Promise<void>;

--- a/packages/spec/src/contracts/data-engine.test.ts
+++ b/packages/spec/src/contracts/data-engine.test.ts
@@ -367,23 +367,24 @@ describe('Data Engine Contract', () => {
   // Every directive below is resolved by tsc; reverting the member makes it
   // unused, and an unused directive is itself an error.
 
+  // Deliberately NO new engine double in this block: every pin below reads the
+  // MEMBER type off the contract instead of standing up another `IDataEngine`
+  // literal (this file's doubles are counted by `check:engine-double-contract`
+  // against a shrink-only baseline, and a pin block is not a reason to grow
+  // it). The value-level optionality evidence already exists above: every
+  // pre-existing minimal `IDataEngine` literal in this file omits
+  // `introspectDatasource` and compiles.
   describe('introspectDatasource (#11493)', () => {
-    type EngineIntrospection = Awaited<ReturnType<NonNullable<IDataEngine['introspectDatasource']>>>;
-
-    const minimalEngine: IDataEngine = {
-      find: async () => [],
-      findOne: async () => null,
-      insert: async (_obj, data) => data,
-      update: async (_obj, data) => data,
-      delete: async () => ({ deleted: 0 }),
-      count: async () => 0,
-      aggregate: async () => [],
-    };
+    type Member = IDataEngine['introspectDatasource'];
+    type EngineIntrospection = Awaited<ReturnType<NonNullable<Member>>>;
 
     it('is optional — an engine without a named-driver registry stays conformant', () => {
-      // `minimalEngine` satisfies `IDataEngine` at its declaration with no
-      // registry members at all — same posture as `getDriverByName?` ([#4251]).
-      expect(minimalEngine.introspectDatasource).toBeUndefined();
+      // Same posture as `getDriverByName?` ([#4251]): the member's type admits
+      // `undefined`, so the minimal literals above satisfy the contract without
+      // it. A revert to a REQUIRED member resolves `Optional` to `never`.
+      type Optional = undefined extends Member ? 'optional' : never;
+      const optional: Optional = 'optional';
+      expect(optional).toBe('optional');
     });
 
     it('declares exactly the spec introspection shape', () => {
@@ -396,27 +397,21 @@ describe('Data Engine Contract', () => {
       expect(exact).toBe('exact');
     });
 
-    it('accepts an engine that answers the spec shape', () => {
-      const introspecting: IDataEngine = {
-        ...minimalEngine,
-        introspectDatasource: async (_datasource) => ({
-          dialect: 'postgres',
-          introspectedAt: '2026-08-24T00:00:00.000Z',
-          tables: {},
-        }),
-      };
-      expect(typeof introspecting.introspectDatasource).toBe('function');
+    it('accepts an implementation that answers the spec shape', () => {
+      const introspect: NonNullable<Member> = async (_datasource: string) => ({
+        dialect: 'postgres',
+        introspectedAt: '2026-08-24T00:00:00.000Z',
+        tables: {},
+      });
+      expect(typeof introspect).toBe('function');
     });
 
-    it('refuses an engine that answers a non-spec shape at the member', () => {
+    it('refuses an implementation that answers a non-spec shape', () => {
       // The pre-#11493 posture: `{ tables }` alone, no envelope — absorbed at
       // runtime by the consumer-side shim, invisible to every compiler.
       const bareTables = { tables: {} };
-      const misShapen: IDataEngine = {
-        ...minimalEngine,
-        // @ts-expect-error - the untyped pre-#11493 result no longer satisfies the declared member
-        introspectDatasource: async (_datasource: string) => bareTables,
-      };
+      // @ts-expect-error - the untyped pre-#11493 result no longer satisfies the declared member
+      const misShapen: NonNullable<Member> = async (_datasource: string) => bareTables;
       expect(misShapen).toBeTruthy();
     });
   });

--- a/packages/spec/src/contracts/data-engine.test.ts
+++ b/packages/spec/src/contracts/data-engine.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { IDataEngine, WriteObservabilityOptions } from './data-engine';
 import type { IDataDriver } from './data-driver';
+import type { IntrospectedSchema } from './schema-diff-service';
 import {
   EngineUpdateOptionsSchema,
   DataEngineInsertOptionsSchema,
@@ -352,5 +353,71 @@ describe('Data Engine Contract', () => {
     // The `findStream` case that stood here was removed with the contract method
     // in 17.0.0 (#4484) — it built an IDataDriver whose only job was to satisfy a
     // required method no production code ever called.
+  });
+
+  // ===========================================================================
+  // introspectDatasource — typed on the contract, not re-declared by consumers
+  // (#11493, extending the #11123 ruling to the engine-registration seam)
+  // ===========================================================================
+  //
+  // Reverse-verified against the pre-#11493 contract (measured 2026-08-24):
+  // with the member undeclared, an engine answering a non-spec shape compiled
+  // green, and the one in-tree consumer (service-datasource's plugin) carried
+  // a private structural `DataEngineLike` to recover the spec return type.
+  // Every directive below is resolved by tsc; reverting the member makes it
+  // unused, and an unused directive is itself an error.
+
+  describe('introspectDatasource (#11493)', () => {
+    type EngineIntrospection = Awaited<ReturnType<NonNullable<IDataEngine['introspectDatasource']>>>;
+
+    const minimalEngine: IDataEngine = {
+      find: async () => [],
+      findOne: async () => null,
+      insert: async (_obj, data) => data,
+      update: async (_obj, data) => data,
+      delete: async () => ({ deleted: 0 }),
+      count: async () => 0,
+      aggregate: async () => [],
+    };
+
+    it('is optional — an engine without a named-driver registry stays conformant', () => {
+      // `minimalEngine` satisfies `IDataEngine` at its declaration with no
+      // registry members at all — same posture as `getDriverByName?` ([#4251]).
+      expect(minimalEngine.introspectDatasource).toBeUndefined();
+    });
+
+    it('declares exactly the spec introspection shape', () => {
+      // Mutual extends: a revert to `Promise<unknown>` — the shape that forced
+      // the consumer-side re-declaration — resolves `Exact` to `never`.
+      type Exact = EngineIntrospection extends IntrospectedSchema
+        ? (IntrospectedSchema extends EngineIntrospection ? 'exact' : never)
+        : never;
+      const exact: Exact = 'exact';
+      expect(exact).toBe('exact');
+    });
+
+    it('accepts an engine that answers the spec shape', () => {
+      const introspecting: IDataEngine = {
+        ...minimalEngine,
+        introspectDatasource: async (_datasource) => ({
+          dialect: 'postgres',
+          introspectedAt: '2026-08-24T00:00:00.000Z',
+          tables: {},
+        }),
+      };
+      expect(typeof introspecting.introspectDatasource).toBe('function');
+    });
+
+    it('refuses an engine that answers a non-spec shape at the member', () => {
+      // The pre-#11493 posture: `{ tables }` alone, no envelope — absorbed at
+      // runtime by the consumer-side shim, invisible to every compiler.
+      const bareTables = { tables: {} };
+      const misShapen: IDataEngine = {
+        ...minimalEngine,
+        // @ts-expect-error - the untyped pre-#11493 result no longer satisfies the declared member
+        introspectDatasource: async (_datasource: string) => bareTables,
+      };
+      expect(misShapen).toBeTruthy();
+    });
   });
 });

--- a/packages/spec/src/contracts/data-engine.ts
+++ b/packages/spec/src/contracts/data-engine.ts
@@ -11,6 +11,7 @@ import {
   DroppedFieldsEvent,
 } from '../data/index.js';
 import type { IDataDriver } from './data-driver.js';
+import type { IntrospectedSchema } from './schema-diff-service.js';
 
 /**
  * In-process write-observability hooks for `insert`/`update` (#3407).
@@ -262,4 +263,29 @@ export interface IDataEngine {
    */
   getDefaultDriverName?(): string | undefined;
   getDriverByName?(name: string): IDataDriver | undefined;
+
+  /**
+   * Introspect a datasource's live remote schema (ADR-0015): resolve the
+   * driver registered under `datasource` and delegate to its
+   * `introspectSchema()` capability. Implementations throw when the
+   * datasource has no registered driver, or its driver does not offer
+   * introspection — absence is answered with a named error, never a guess.
+   *
+   * Optional for the same reason as the registry pair above: only an engine
+   * that owns a named-driver registry can resolve a datasource to a driver;
+   * test fakes and remote/virtual engines simply omit it.
+   *
+   * [#11493] Declared because the binding is evidenced, exactly as [#4251]
+   * asks: ObjectQL has implemented this method since ADR-0015, and the
+   * external-datasource service reads it off the `'data'` service — while
+   * this contract stayed silent, that consumer had to re-declare a private
+   * structural engine type to recover the spec return type from the
+   * implementation's untyped `Promise`. The return type is the spec's ONE
+   * introspection shape ({@link IntrospectedSchema}), the same contract
+   * #11381 put on `DatasourceDriverHandle.introspectSchema` — this member
+   * extends that ruling (#11123's population/channel argument) to the
+   * engine-registration seam, so both roads into the runtime read now meet
+   * a compiler.
+   */
+  introspectDatasource?(datasource: string): Promise<IntrospectedSchema>;
 }

--- a/skills/objectstack-data/references/_index.md
+++ b/skills/objectstack-data/references/_index.md
@@ -21,6 +21,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 
 - `node_modules/@objectstack/spec/src/api/errors.zod.ts` — Standardized Error Codes Protocol
 - `node_modules/@objectstack/spec/src/automation/flow-function.zod.ts` — The contract for a **named handler function a `script` node invokes** —
+- `node_modules/@objectstack/spec/src/data/driver-sql.zod.ts` — SQL Dialect Enumeration
 - `node_modules/@objectstack/spec/src/data/driver.zod.ts` — Common Driver Options
 - `node_modules/@objectstack/spec/src/data/driver/common.zod.ts` — Shared building blocks for the per-driver `datasource.config` shapes (#4410).
 - `node_modules/@objectstack/spec/src/data/driver/config-registry.zod.ts` — The driver-id → `datasource.config` shape registry (#4410).
@@ -42,6 +43,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
 - `node_modules/@objectstack/spec/src/shared/suggestions.zod.ts` — "Did you mean?" Suggestion Utilities
+- `node_modules/@objectstack/spec/src/system/deploy-bundle.zod.ts` — Deploy Bundle Protocol
 - `node_modules/@objectstack/spec/src/ui/action-params.zod.ts` — The action DISPATCH contract: what the platform validates on the way in, and
 - `node_modules/@objectstack/spec/src/ui/action.zod.ts` — Action Parameter Schema
 - `node_modules/@objectstack/spec/src/ui/bulk-action.zod.ts` — Bulk Action Schemas


### PR DESCRIPTION
Fixes #11493

## What this does

Extends the #11123 ruling to the engine-registration seam, per the maintainer ruling on the card (comment 5394014425), quoted verbatim and untranslated:

> 「接受你的建议。」

(maintainer, 2026-08-24, live PM chat, on the aligned four-facet analysis — both steps approved as the extension of the #11123 ruling to the engine-registration seam.)

1. **`IDataDriver` (spec contract) gains an OPTIONAL `introspectSchema?()` member returning the spec type `IntrospectedSchema`** (`packages/spec/src/contracts/data-driver.ts`), so drivers without introspection stay conformant. A driver implementing it with a wrong shape now fails compile at the offending field, on the `registerDriver()` road that #11492 could not reach.
2. **`IDataEngine` gains an OPTIONAL `introspectDatasource?(datasource: string)` member with the same spec return type** (`packages/spec/src/contracts/data-engine.ts`, the same evidenced-binding posture as the [#4251] registry pair beside it), and **`ObjectQL.introspectDatasource()` tightens** its return from the untyped Promise to the spec type, dropping the `as any` driver probe (`packages/objectql/src/engine.ts`).
3. **`service-datasource/plugin.ts` DELETES its structural `DataEngineLike` re-declaration** — part of the fix per the ruling, not follow-up. The plugin now types the `'data'` service with the real `IDataEngine` contract. Forced by the deletion: the workaround's second member, `getDatasourceDriver?`, matched **no engine in either repository, ever** (measured 2026-08-24: zero references outside this file), so its fallback branch could never fire; the probe is respelled to the member the contract actually declares (`getDriverByName?`, [#4251]), making the degradation reachable for the first time. This is the one deliberate runtime-visible edit in the PR (see "Runtime" below).

The interface member on `IDataEngine` is the mechanism step ② requires: without it, deleting `DataEngineLike` leaves the plugin nothing typed to compile against — the ruling's own wording (`IDataEngine.introspectDatasource()`) names the member on the contract.

## In-tree driver audit (required by the ruling — readings)

| Driver | `introspectSchema` | Declared return | Verdict |
|---|---|---|---|
| `@objectstack/driver-sql` (`SqlDriver`) | yes (`sql-driver.ts`) | local `IntrospectedSchema extends SpecIntrospectedSchema` (derive-not-redeclare, post-#11124/#11270; extras: per-column `isUnique`/`maxLength`, per-table `primaryKeys`/`foreignKeys`) | **aligned** — assignable to the new member; package `tsc --noEmit` green against the new contract |
| `@objectstack/driver-turso` (`TursoDriver extends SqlDriver`) | inherited | inherits driver-sql's | **aligned** |
| `@objectstack/driver-sqlite-wasm` (`SqliteWasmDriver extends SqlDriver`) | inherited | inherits driver-sql's | **aligned** |
| `@objectstack/driver-memory` (`InMemoryDriver`) | absent | — | **conformant via optionality** |
| `@objectstack/driver-mongodb` (`MongoDBDriver`) | absent | — | **conformant via optionality** |
| `@objectstack/objectql` consumer types (`util.ts`) | n/a (consumer) | `IntrospectedSchema extends SpecIntrospectedSchema` | **aligned** |

No drift found ⇒ no driver touch-ups needed. Deliberately NOT widened: the Zod mirror `DriverInterfaceSchema` (`data/driver.zod.ts`) — its coverage of optional TS members is already partial by existing practice (`updateMany`/`syncSchemasBatch`/`explain` declared; `temporalFilterValue`/`registerExternalObject`/`getSchemaSyncStats`/`reclaimSpace` not), and the ruling names the TS contract; widening the mirror is a separate decision.

## Out-of-tree driver risk (the accepted face)

An out-of-tree driver with a same-named, differently-shaped `introspectSchema` gets a **loud compile error on upgrade** — carried from the four-facet block as the accepted face of this change. The runtime is untouched: plain-JS drivers and stale builds are reached by no compiler, and the PR #11001 runtime shim keeps absorbing them exactly as before.

## Reverse verification (the required inversion, both legs recorded)

One fixture (a driver class whose `introspectSchema` answers `{ tables }` with the retired `isPrimary` column spelling, plus an engine whose `introspectDatasource` answers `{ tables: {} }`), **no** suppression directives, compiled by `tsc --noEmit` in `packages/spec`:

- **Leg A — contracts at BASE `e43b18fd9` (pre-fix):** exit **0**, zero diagnostics. The mis-shapes compile GREEN — the gap the card describes, measured.
- **Leg B — contracts at the fix (same fixture):** exit **2** —
  - `TS2416: Property 'introspectSchema' in type 'MisShapenDriver' is not assignable to the same property in base type 'IDataDriver'. … Type '{ tables: … isPrimary … }' is missing the following properties from type 'IntrospectedSchema': dialect, introspectedAt`
  - `TS2322 … The types returned by 'introspectDatasource(...)' are incompatible … Type '{ tables: {}; }' is missing the following properties from type 'IntrospectedSchema': dialect, introspectedAt`

The fixture was never committed; the committed pins carry the same inversion as `@ts-expect-error` directives (an unused directive is itself an error, so a revert reds `pnpm --filter @objectstack/spec typecheck` in either direction).

## Pins

- **Wrong shape fails compile**: `@ts-expect-error` pins in `data-driver.test.ts` (retired `isPrimary` spelling; bare `{ tables }`; a mis-shaped member offered on the driver value) and `data-engine.test.ts` (non-spec engine answer) — the repo's existing type-test idiom (tsc-resolved, vitest-hosted, zero entries in `test-typecheck-debt.json`).
- **Optionality**: type-level `undefined extends` pins on both members; value-level, the file's pre-existing minimal literals already omit both members and compile.
- **Exactness**: mutual-`extends` pins that the members' return type IS `IntrospectedSchema` (a revert to the untyped Promise resolves the pin type to `never`).
- **Engine-side pins are deliberately type-level** — no new `IDataEngine` literal, so `check:engine-double-contract`'s shrink-only double census is untouched.
- **plugin.ts compiles against the real engine type**: `@objectstack/service-datasource` `tsc --noEmit` green with the workaround deleted.

## Runtime

**Zero runtime change in spec and objectql, verified at the artifact**: the spec edits are interface members (type-only imports + declarations — no JS is emitted for them), and the compiled `ObjectQL.introspectDatasource` body in `packages/objectql/dist/index.js` after the change is the identical three-step function (lookup → two named throws → delegate); the `as any` and the return annotation never reached JS. The **one deliberate JS change** is `service-datasource/plugin.ts`'s fallback probe respelling (`getDatasourceDriver` → `getDriverByName`), declared above: the old spelling was dead against every engine that has ever existed in-tree, so no behaviour that ever executed changes; the branch becomes reachable, which is the point.

H17-adjacent note: `service-datasource/sqlite-driver-fallback.ts` and `tsup.config.ts` (hold #10062 trigger files) are untouched — the diff in this package is `src/plugin.ts` only.

## skills/** readings (required)

`check:skill-refs` regenerated `skills/objectstack-data/references/_index.md`: the new type-only `IntrospectedSchema` import pulls `driver-sql.zod.ts` + `deploy-bundle.zod.ts` into the skill's reference closure (generated artifact; gate red without it).

- Changed file, whole-file: **63 → 65 lines** (+2, both generated index rows).
- Whole published package (sum of all `skills/**/SKILL.md`): **10505 → 10505 lines** (no SKILL.md touched).

This path also makes the diff touch a **governed surface** (`skills/**`, Prime Directive #14): this PR is human-merge only — it stays DRAFT, is never queued, and auto-merge is never armed. Clause-②: **yes — public contract member addition; the PR stays draft, the contract-review chain runs before enqueue.**

## Verification (all readings at head `eab6d131b` unless noted)

- `@objectstack/spec`: `pnpm typecheck` → exit 0 (`tsc --noEmit` + scripts + `check:test-typecheck` OK, debt ledger unchanged at 55 files / 263 errors); full `vitest run --maxWorkers=2` → **420 files / 11228 tests passed** (verify-lock verdict `command-exit 0`; suite ran at 0acd55c3c — the follow-up commit touches only `data-engine.test.ts`, whose file-scoped rerun at head is below).
- `@objectstack/objectql`: `pnpm typecheck` → exit 0; full `vitest run --maxWorkers=2` → **231 files / 4106 tests passed** (verify-lock verdict `command-exit 0`).
- `@objectstack/service-datasource`: `pnpm typecheck` → exit 0; `vitest run --maxWorkers=2` → **27 files / 585 tests passed** (verify-lock verdict `command-exit 0`).
- `@objectstack/driver-sql`: `pnpm typecheck` → exit 0 (audit leg).
- Contract test files at head: `data-driver.test.ts` + `data-engine.test.ts` → **2 files / 35 tests passed**.
- Full workspace: `turbo run build` over `./packages/*` + `./packages/*/*` → exit 0 (70/70 tasks); `turbo run typecheck --concurrency=2` → **exit 0, "Tasks: 129 successful, 129 total"** (verify-lock verdict `command-exit 0`) — the return-type tightening surfaced no latent consumer.
- `pnpm --filter @objectstack/spec check:generated` → after regenerating the one proved-stale artifact (`gen:skill-refs`), exit 0; `check:api-surface` and `check:docs` green without regeneration.
- Derived gate families (`node scripts/pm/dispatch-gates.mjs`, no paths — change set derived by the script from the merge base; derivation line: "gate list derived from the tree of 'objectstack-ai/objectstack' at commit …"): all 32 path-matched famil(ies) + the 5 convention-triggered test-file famil(ies) + `check:nul-bytes` run locally, every gate exit 0 at head (per-gate exits captured pipe-free; `check:engine-double-contract` prints `OK — 401 pinned, 133 in the DEBT ledger, 2 exempt`; `check:type-check-debt --re-measure` and `check:dev-prereqs` run after the full workspace build).

CI is expected to re-run the full farm; per the dispatch contract this PR is reported at draft time with CI possibly still in progress.

Out-of-scope finding filed: #11833 (two more consumer-local structural `DataEngineLike` declarations, observation-class).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_