### PR TITLE
docs(plugin-approvals): correct what the approval snapshot column is FOR — audit evidence served redacted per reader, not a notification source

### DIFF
--- a/.changeset/approval-snapshot-docstring-audit-evidence.md
+++ b/.changeset/approval-snapshot-docstring-audit-evidence.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+Correct what `sys_approval_request.payload_json` is documented to be FOR — it is audit evidence served redacted per reader, not a notification source
+
+The object's module docstring — which ships to consumers in the package's type
+declarations — justified the snapshot column with: *"used by notifications so
+they can render before the record is locked or changed."* That consumer does
+not exist. Measured against every `this.notify(...)` call site in
+`approval-service.ts`, all **12** of them, each passes a payload of
+`{ title, message, actionUrl }` (two also carry `actions`), built from
+`object_name` / `record_id` and the caller's own comment. **None** reads
+`payload_json` or the parsed `payload`.
+
+This is more than tidiness: that sentence was the only documented
+justification for the column holding a *full* row, and it was cited as such
+during the #10749 consumer inventory before anyone checked it. The docstring
+now states the real reason — the snapshot is retained as **audit evidence of
+what was actually submitted**, so the column stays whole at rest, and is served
+**redacted per reader** by the subject object's field-level read controls via
+`getReadableFields`, on the approvals-inbox door and the generic data door
+alike (#11039).
+
+The field's own `description` is deliberately unchanged: `Record snapshot at
+submission time` is accurate, and it — unlike the JSDoc — is the string
+extracted into the four generated i18n bundles, so no translation leaf moves
+and no locale is left holding an English seed.
+
+Also carried in the same pass, the residual documentation the #10749 closure
+assigned to the next docs touch in this lane: `payload-redaction.ts` recorded
+`hidden`-vs-serialization as an **open** `packages/spec` question, and it has
+since been ruled (maintainer, 2026-08-24, applying the 2026-08-12 lineage).
+That paragraph now states the ruling — **`hidden: true` stays UI-only;
+`internal: true` is the serialization primitive** — so an author who needs a
+field kept out of read results is pointed at `internal: true` (#7728,
+ADR-0049) rather than at `hidden`, which never governed serialization.
+
+Documentation only: no runtime behaviour, no schema field, and no public type
+signature changes.

--- a/packages/plugins/plugin-approvals/src/payload-redaction.ts
+++ b/packages/plugins/plugin-approvals/src/payload-redaction.ts
@@ -44,8 +44,22 @@
  *   it. Making it govern serialization here alone would make the approval path
  *   stricter than a direct read of the very same row (so it would close no
  *   leak — the approver can just read the record), while breaking every drawer
- *   that renders a `hidden` business column. That is a `packages/spec`
- *   semantics question, and it is left open rather than decided here.
+ *   that renders a `hidden` business column.
+ *
+ *   That `packages/spec` semantics question was left open here when this seam
+ *   landed. **It has since been ruled** (maintainer, 2026-08-24, applying the
+ *   2026-08-12 lineage rather than making a new rule): **`hidden: true` stays
+ *   UI-only; `internal: true` is the serialization primitive.** `hidden`
+ *   gains no serialization semantic — it says "Hidden from default UI" and
+ *   nothing more. The read-side omission primitive is `internal: true`
+ *   (#7728, ADR-0049): the engine OMITS the key from `find`/`findOne` results,
+ *   the 201 create body and the by-id update body, on the default projection
+ *   AND when a client names the field in `?select=`. `internal` exists
+ *   PRECISELY BECAUSE `hidden` is not that, so an author who needs a field
+ *   kept out of read results declares `internal: true`; declaring `hidden`
+ *   and expecting omission is the mistake this paragraph exists to stop.
+ *   Per-caller field visibility — what this seam applies — remains
+ *   `requiredPermissions` / permission sets / `maskingRule`.
  */
 
 /** The slice of the security service this seam consumes. */

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -17,9 +17,16 @@ import { APPROVAL_STATUSES, APPROVAL_STATUS_LABELS } from '@objectstack/spec/con
  * snapshots the Approval node config (approvers / behaviour) the request was
  * opened with.
  *
- * `payload_json` captures a snapshot of the target record at submission
- * time — used by notifications so they can render before the record is
- * locked or changed.
+ * `payload_json` captures a snapshot of the target record at submission time.
+ * It is retained as **audit evidence of what was actually submitted**, so the
+ * column stays whole AT REST; it is served **redacted per reader** — the
+ * SUBJECT object's field-level read controls are applied at serve time from
+ * the security service's `getReadableFields`, on the approvals-inbox door and
+ * on the generic data door alike (#11039).
+ *
+ * ⛔ Notifications are NOT a consumer of this snapshot, and the audit-evidence
+ * sentence above — not "notifications need it" — is why the column holds a
+ * full row. See the note on the field itself.
  *
  * @namespace sys
  */
@@ -214,6 +221,22 @@ export const SysApprovalRequest = ObjectSchema.create({
       group: 'State',
     }),
 
+    // The module docstring above used to justify this column with "used by
+    // notifications so they can render before the record is locked or
+    // changed". That consumer does not exist, and the claim was cited as the
+    // reason the column holds a FULL row before anyone checked it. Measured
+    // against every `this.notify(...)` call site in `approval-service.ts` —
+    // all 12 of them: each passes `{ title, message, actionUrl }` (two also
+    // `actions`), built from `object_name` / `record_id` and the caller's
+    // comment. None reads this column or the parsed `payload`. The real
+    // readers are the serve path (`rowFromRequest` -> `payload`, redacted per
+    // reader), the decide-time approver re-resolution and the org backfill,
+    // both under SYSTEM_CTX, and the free-text predicate.
+    //
+    // The `description` below is deliberately UNCHANGED: it is accurate, and
+    // it is extracted into the four generated i18n bundles as `help`. The
+    // false sentence lived only in the JSDoc above, which is not extracted —
+    // so this correction moves no translation leaf.
     payload_json: Field.textarea({
       label: 'Snapshot',
       required: false,


### PR DESCRIPTION
Fixes #11041

## What was wrong

`sys_approval_request`'s module docstring justified the snapshot column with:

> `payload_json` captures a snapshot of the target record at submission time — **used by notifications so they can render before the record is locked or changed.**

That consumer does not exist. Re-measured on this branch rather than inherited from the card — every `this.notify(...)` call site in `approval-service.ts`, all **12** of them (lines 2137, 2148, 2868, 2910, 3158, 3217, 3240, 3387, 3430, 3792, 3811, 3825), passes a payload of `{ title, message, actionUrl }`; two also carry `actions` with action-link URLs. Every message is built from `raw.object_name` / `raw.record_id` and the caller's comment. **None reads `payload_json` or the parsed `payload`.**

This matters beyond tidiness: that sentence was **the only documented justification for the column holding a full row**, and it was cited as exactly that during #10749's consumer inventory before anyone checked it.

## What it says now

The docstring states the real reason, settled by the #10749 closure rather than re-derived here: the snapshot is retained as **audit evidence of what was actually submitted** — so the column stays whole **at rest** — and is served **redacted per reader**, the subject object's field-level read controls applied at serve time from `getReadableFields`, on the approvals-inbox door and the generic data door alike (#11039).

It does **not** claim `hidden`-based redaction (ruled out), and it does not resurrect the falsified notifications claim — a short line plus a field-level note record the measurement so the claim is not re-derived by the next reader. That note follows the file's own precedent: `organization_id` carries the same shape of "was X, measured false, reworded" comment from #10101.

## The rider from #10749's closure, carried here

#10749 closed with a residue assigned to *"the next docs touch in the services lane"*: the sentence clarifying `hidden` is not serialization. **This is that touch.**

`payload-redaction.ts` recorded the question as **open** — *"That is a `packages/spec` semantics question, and it is left open rather than decided here."* It has since been ruled (maintainer, 2026-08-24, applying the 2026-08-12 lineage rather than making a new rule), and leaving the paragraph as-is now states an open question that is closed. It now carries the ruling — **`hidden: true` stays UI-only; `internal: true` is the serialization primitive** — and points an author who needs a field kept out of read results at `internal: true` (#7728, ADR-0049, enforced at `Engine.maskSecretFields`) rather than at `hidden`, which never governed serialization.

## The card's "why this is filed rather than fixed" premise is falsified

The card, and triage after it, held that rewording this string is a **translation-regeneration change across four locales** rather than a comment edit. **It is not**, and the difference is measured, not argued:

- The false sentence lives **only** in the JSDoc block. `git grep "used by notifications"` returns **exactly 1 hit** repo-wide, in `sys-approval-request.object.ts`.
- The string that *is* extracted for this column is the **field `description`** — `Record snapshot at submission time` becomes `help:` in the bundles. Structurally so: `scripts/i18n-extract.config.ts` imports the **schema objects** and extracts their declared `label`/`description`; JSDoc is never read.
- So the field `description` is **deliberately left alone** — it is accurate, and touching it is what would have forced four locales.

Proven with the documented command, not asserted:

| step | result |
|---|---|
| `node scripts/check-i18n-bundles.mjs --write --filter=approvals` | `plugins/plugin-approvals  regenerated`, exit 0 |
| all four bundle blobs, before vs after | **byte-identical** (`en 3e64d45`, `es-ES 890c99a`, `ja-JP 6a608a9`, `zh-CN 537a51a`) |

⚠️ **That zero needed an instrument check before it could be read as evidence** — this gate's own header documents the false-green shape (on an unbuilt workspace `--write` prints "regenerated" and exits 0 having written nothing). **Positive control:** mutating the one string that *is* extracted (the field `description`, to `POSITIVE_CONTROL_MARKER_11041`), with the mutation confirmed on disk first (anchor occurrences 1 to 0, injected marker 1) rather than trusted to the editor's exit code, moved the `en` leaf and its blob (`3e64d45` to `958a99f`). The instrument works on this corpus, so the zero is a real zero. Restore proved byte-identical on all four blobs; the control script carried a `trap ... EXIT INT TERM` so a foreground-cap SIGTERM could not leave the tree mutated.

The control also measured the second hazard directly: with `--fill=default` the non-`en` leaves did **not** follow the mutated source (`zh-CN 提交时的记录快照`, `ja-JP 送信時のレコードスナップショット`, `es-ES Instantánea del registro en el momento del envío.` — all unchanged). Fill-only drift is real and sticky, and it is precisely why the accurate `description` was left where it is: no locale is left holding an English seed, because no leaf moved at all.

## Scope

Documentation only. No runtime behaviour, no schema field, no public type signature changes. The corrected JSDoc **does** ship to consumers — `dist/index.d.ts` on this branch contains the new sentence and no longer contains the old one — which is why this carries a **patch** changeset rather than none.

**Clause-② assessment: NO.** Verified against the tree rather than inherited: the diff is comments plus one changeset, moves no accept/reject behaviour, widens no public surface, and touches no `packages/spec`. The only consumer-facing artifact that changes is documentation text inside a `.d.ts`.

## Verification

Gate union derived on the **final** commit `f828ba9625`, clean tree, `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` with **no path arguments** (3 paths, 157 families discovered, `DERIVE_EXIT=0`). Every exit code captured **before** any pipe; each verdict below is the gate's **own** line.

| gate | exit | its own verdict line |
|---|---|---|
| `check:i18n` *(convention-triggered)* | 0 | `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).` |
| `check:i18n-coverage` *(judgment)* | 0 | `check-i18n-coverage: OK (12 config(s), 657 baselined untranslated string(s), none new).` |
| `check:published-files` | 0 | `69 publishable package(s) of 78 workspace member(s) declare a files whitelist ...` |
| `check:slot-lookup` | 0 | `slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new ...` |
| `check:test-source-alias` | 0 | `OK — 72 packages with tests scanned; 61 registered ...` |
| `check:type-source-resolution` | 0 | `OK — 77 packages with a tsconfig.json scanned; 51 registered ...` |
| `check-plugin-teardown-shape` | 0 | `63 Plugin implementation(s) across 4621 source(s) under packages/**; every teardown-shaped method sits beside a real destroy()` |
| `check-adr-0087-registration` | 0 | `this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).` |
| `check-changeset-no-major` | 0 | `This diff introduces no major bump.` |
| `check-empty-changeset` | 0 | `No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check:changeset-gate-self-tests` | 0 | `118 / 212 / 116 assertions over real temp git repos` |
| `check:objectui-changeset` | 0 | `objectui-range --self-test: all checks passed` |
| `check-affected-docs` | 0 | `affected-docs self-test: 417 cases pass.` |
| `check-drift-comment` | 0 | `check-drift-comment: 39 cases pass across 5 fixture diff(s).` |
| `release-rehearsal-clone --self-test` | 0 | `self-test passed` |
| `check:nul-bytes` *(judgment, class #10309 — the derivation named it nowhere)* | 0 | `OK (scanned 6592 text file(s) ... no raw ASCII control bytes).` |

⚠️ **`check:i18n-coverage` refused twice before it was measured** and neither refusal is reported as a pass. It first answered `COULD NOT MEASURE — 1 of 12 config(s) failed to lint`, naming `examples/app-showcase/objectstack.config.ts` and an unbuilt `@objectstack/connector-mcp`, and it says so itself: *"Nothing was compared ... this result says NOTHING about whether any declared label went untranslated."* Building that connector advanced the cause to `@objectstack/connector-openapi` — a chain — so the showcase's whole dependency closure was built (`--filter '@objectstack/example-showcase^...'`, exit 0) and the gate re-run to the real `OK` above. The cause was an environment prerequisite in an unrelated example app, never this diff.

`pnpm --filter @objectstack/plugin-approvals typecheck` exit **0** (the script name is echoed in the output, so this is not a zero-match `--filter` scoring a silent green). `pnpm --filter @objectstack/plugin-approvals test` exit **0** — `Test Files 33 passed (33)`, `Tests 610 passed (610)`.

**Lint, narrowed and declared.** `pnpm lint` is a repo-wide scan CI owns. Run here instead: `eslint --no-inline-config --format json` over the diff's own paths — **3 files enumerated, 0 errors**, the single warning being eslint's own `File ignored because no matching configuration was supplied` for the changeset `.md`, i.e. eslint reporting that file is outside its configured population. The narrowing is a measurement rather than a skip because this repo's `eslint.config.mjs` states in its own header that it *"never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file"* — measured there with its own positive control — so no rule reads across files and this diff cannot move the verdict of a file it does not touch.

All heavy verification ran through `scripts/pm/os-verify-lock.sh`; each run's conclusion is read from its `VERDICT` line, never a bare `$?`.

---

_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_