### PR TITLE
feat(spec,plugin-email,service-messaging,plugin-auth): widen SendEmailInput with optional organizationId, threaded from org-holding producers

### DIFF
--- a/.changeset/sendemail-organization-id.md
+++ b/.changeset/sendemail-organization-id.md
@@ -1,0 +1,15 @@
+---
+'@objectstack/spec': minor
+'@objectstack/plugin-email': minor
+'@objectstack/service-messaging': minor
+'@objectstack/plugin-auth': minor
+---
+
+Widen `SendEmailInput` / `SendTemplateInput` with an optional `organizationId`, threaded from producers that already hold an organization, so `plugin-email`'s writer stamps `sys_email.organization_id` at the source (#11741, Decision 2 of #11303).
+
+- `@objectstack/spec`: `SendEmailInput.organizationId?` and `SendTemplateInput.organizationId?` — optional, pass-through only; absent stays legal (auth verification / password-reset mail carries none).
+- `@objectstack/plugin-email`: `EmailService.send()` stamps the value verbatim onto the persisted `sys_email` row; `sendTemplate()` forwards it to `send()`. No in-adapter resolution or fabrication — the writer runs under a constant system context and only passes through what the input carries.
+- `@objectstack/service-messaging`: the email channel threads `delivery.notification.organizationId` on both of its arms (plain `send` and the `sendTemplate` template path).
+- `@objectstack/plugin-auth`: `sendInvitationEmail` threads the invitation's own `organizationId`; org-less auth mail (reset / verification / magic link / email-change notice) is unchanged.
+
+Forward-stamping only: existing org-less `sys_email` rows are not backfilled.

--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -2394,7 +2394,8 @@ describe('AuthManager', () => {
         inviter: { user: { email: 'admin@example.com' } },
       });
       expect(emailService.sendTemplate).toHaveBeenCalledTimes(1);
-      expect(emailService.sendTemplate.mock.calls[0][0].organizationId).toBe('org_apex');
+      const invitationInput = (emailService.sendTemplate.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]?.[0];
+      expect(invitationInput?.organizationId).toBe('org_apex');
     });
 
     it('sendResetPassword carries NO organizationId and is not refused — auth mail is genuinely org-less (#11741)', async () => {
@@ -2402,7 +2403,8 @@ describe('AuthManager', () => {
       const sendResetPassword = capturedConfig.emailAndPassword.sendResetPassword;
       await sendResetPassword({ user: { id: 'u1', email: 'real@example.com' }, url: 'http://x/reset', token: 't' });
       expect(emailService.sendTemplate).toHaveBeenCalledTimes(1);
-      expect(emailService.sendTemplate.mock.calls[0][0]).not.toHaveProperty('organizationId');
+      const resetInput = (emailService.sendTemplate.mock.calls as unknown as Array<[Record<string, unknown>]>)[0]?.[0];
+      expect(resetInput).not.toHaveProperty('organizationId');
     });
 
     it('sendInvitationEmail honours a custom uiBasePath (Console mounted elsewhere)', async () => {

--- a/packages/plugins/plugin-auth/src/auth-manager.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.test.ts
@@ -2379,6 +2379,32 @@ describe('AuthManager', () => {
       expect(data.acceptUrl).toBe('http://localhost:3000/_console/accept-invitation/tok456');
     });
 
+    // #11741 — the invitation producer HOLDS an organization (the invitation
+    // row's own organizationId), so it threads that exact value into
+    // SendTemplateInput for the sys_email.organization_id stamp. Auth mail
+    // that genuinely has no organization (password reset / verification /
+    // magic link) stays unstamped AND un-refused — the over-denial control.
+    it('sendInvitationEmail threads the invitation organizationId into sendTemplate (#11741)', async () => {
+      const { capturedConfig, emailService } = await boot();
+      const orgPlugin = capturedConfig.plugins.find((p: any) => p.id === 'organization');
+      await orgPlugin._opts.sendInvitationEmail({
+        email: 'invitee@example.com',
+        invitation: { id: 'inv42', organizationId: 'org_apex', role: 'member' },
+        organization: { name: 'Apex' },
+        inviter: { user: { email: 'admin@example.com' } },
+      });
+      expect(emailService.sendTemplate).toHaveBeenCalledTimes(1);
+      expect(emailService.sendTemplate.mock.calls[0][0].organizationId).toBe('org_apex');
+    });
+
+    it('sendResetPassword carries NO organizationId and is not refused — auth mail is genuinely org-less (#11741)', async () => {
+      const { capturedConfig, emailService } = await boot();
+      const sendResetPassword = capturedConfig.emailAndPassword.sendResetPassword;
+      await sendResetPassword({ user: { id: 'u1', email: 'real@example.com' }, url: 'http://x/reset', token: 't' });
+      expect(emailService.sendTemplate).toHaveBeenCalledTimes(1);
+      expect(emailService.sendTemplate.mock.calls[0][0]).not.toHaveProperty('organizationId');
+    });
+
     it('sendInvitationEmail honours a custom uiBasePath (Console mounted elsewhere)', async () => {
       const { capturedConfig, emailService } = await boot({
         baseUrl: 'https://acme.example.com',

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -2685,6 +2685,12 @@ export class AuthManager {
               },
               relatedObject: 'sys_invitation',
               relatedId: invitation.id,
+              // #11741 — the invitation HOLDS its organization; thread it so
+              // the sys_email row is stamped. Org-less auth mail (reset /
+              // verification / magic link) deliberately threads nothing.
+              ...(invitation.organizationId
+                ? { organizationId: String(invitation.organizationId) }
+                : {}),
             });
           } catch (err: any) {
             // Do NOT rethrow: the invitation row was already persisted by

--- a/packages/plugins/plugin-email/src/email-service.test.ts
+++ b/packages/plugins/plugin-email/src/email-service.test.ts
@@ -338,3 +338,46 @@ describe('rowToNormalized', () => {
     expect(() => rowToNormalized({ to_addresses: 'a@b.com', from_address: 'c@d.com', subject: 'x' })).toThrow(/body/);
   });
 });
+
+// ── #11741 — sys_email organization stamping ────────────────────────────────
+// The writer runs under a constant SYSTEM context, so the ONLY organization a
+// row can carry is the one the input carries: `SendEmailInput.organizationId`
+// is stamped onto `sys_email.organization_id` verbatim (pass-through), and its
+// absence writes nothing — never refused, never resolved, never fabricated
+// (a wrong organization is silently authoritative to every org-filtered
+// report/export, which is worse than a null).
+describe('sys_email organization stamping (#11741)', () => {
+  function makePersistence() {
+    const rows = new Map<string, Record<string, any>>();
+    const p: EmailPersistence = {
+      async insert(row) { rows.set(row.id, { ...row }); return { id: row.id }; },
+      async update(id, patch) {
+        const cur = rows.get(id);
+        if (cur) rows.set(id, { ...cur, ...patch });
+      },
+    };
+    return { p, rows };
+  }
+
+  it("send() stamps input.organizationId onto the row's organization_id (identity pin)", async () => {
+    const transport = { send: vi.fn(async () => ({ messageId: '<m1@x>' })) };
+    const { p, rows } = makePersistence();
+    const svc = new EmailService({ transport, defaultFrom: 'no@reply.com', persistence: p });
+    const res = await svc.send({ to: 'a@b.com', subject: 'Hi', text: 'x', organizationId: 'org_apex' });
+    expect(res.status).toBe('sent');
+    const row = rows.get(res.id);
+    expect(row?.organization_id).toBe('org_apex');
+    // The stamp survives the terminal update (sent_at/status patch does not
+    // rewrite it).
+    expect(row?.status).toBe('sent');
+  });
+
+  it('over-denial control: an org-less send writes NO organization_id and is not refused', async () => {
+    const transport = { send: vi.fn(async () => ({ messageId: '<m2@x>' })) };
+    const { p, rows } = makePersistence();
+    const svc = new EmailService({ transport, defaultFrom: 'no@reply.com', persistence: p });
+    const res = await svc.send({ to: 'a@b.com', subject: 'Hi', text: 'x' });
+    expect(res.status).toBe('sent');
+    expect(rows.get(res.id)).not.toHaveProperty('organization_id');
+  });
+});

--- a/packages/plugins/plugin-email/src/email-service.ts
+++ b/packages/plugins/plugin-email/src/email-service.ts
@@ -671,6 +671,11 @@ export class EmailService implements IEmailService {
       ...(input.relatedObject ? { related_object: input.relatedObject } : {}),
       ...(input.relatedId ? { related_id: input.relatedId } : {}),
       ...(input.sentBy ? { sent_by: input.sentBy } : {}),
+      // #11741 — pass-through ONLY. This writer runs under a constant system
+      // context, so the input's organization is the one fact it may stamp:
+      // no resolution, no default, no fabrication (a wrong organization_id is
+      // worse than a null). Absent ⇒ the column stays unwritten.
+      ...(input.organizationId ? { organization_id: input.organizationId } : {}),
       status: 'queued',
       attempt_count: 0,
     };
@@ -1294,6 +1299,9 @@ export class EmailService implements IEmailService {
       ...(input.relatedObject ? { relatedObject: input.relatedObject } : {}),
       ...(input.relatedId ? { relatedId: input.relatedId } : {}),
       ...(input.sentBy ? { sentBy: input.sentBy } : {}),
+      // #11741 — sendTemplate is itself a producer of send(): forward the
+      // caller's organization so the sys_email row it persists is stamped.
+      ...(input.organizationId ? { organizationId: input.organizationId } : {}),
     };
     return this.send(sendInput);
   }

--- a/packages/plugins/plugin-email/src/send-template.test.ts
+++ b/packages/plugins/plugin-email/src/send-template.test.ts
@@ -60,6 +60,51 @@ describe('EmailService.sendTemplate', () => {
     expect(msg.text).toContain('reset: https://x.com/r/abc');
   });
 
+  it('threads organizationId through to the sys_email row — sendTemplate is a producer of send() (#11741)', async () => {
+    const transport = new CaptureTransport();
+    const rows = new Map<string, Record<string, any>>();
+    const svc = new EmailService({
+      transport,
+      defaultFrom: { address: 'no-reply@x.com' },
+      templateLoader: makeLoader([sampleTemplate]),
+      persistence: {
+        async insert(row) { rows.set(row.id, { ...row }); return { id: row.id }; },
+        async update(id, patch) {
+          const cur = rows.get(id);
+          if (cur) rows.set(id, { ...cur, ...patch });
+        },
+      },
+    });
+    const res = await svc.sendTemplate({
+      template: 'auth.password_reset',
+      to: 'alice@x.com',
+      data: { user: { name: 'Alice' }, resetUrl: 'https://x.com/r/abc' },
+      organizationId: 'org_apex',
+    });
+    expect(res.status).toBe('sent');
+    expect(rows.get(res.id)?.organization_id).toBe('org_apex');
+  });
+
+  it('an org-less sendTemplate writes NO organization_id (over-denial control, #11741)', async () => {
+    const transport = new CaptureTransport();
+    const rows = new Map<string, Record<string, any>>();
+    const svc = new EmailService({
+      transport,
+      defaultFrom: { address: 'no-reply@x.com' },
+      templateLoader: makeLoader([sampleTemplate]),
+      persistence: {
+        async insert(row) { rows.set(row.id, { ...row }); return { id: row.id }; },
+      },
+    });
+    const res = await svc.sendTemplate({
+      template: 'auth.password_reset',
+      to: 'alice@x.com',
+      data: { user: { name: 'Alice' }, resetUrl: 'https://x.com/r/abc' },
+    });
+    expect(res.status).toBe('sent');
+    expect(rows.get(res.id)).not.toHaveProperty('organization_id');
+  });
+
   it('renders a datetime hole in the input reference timezone (ADR-0053 Phase 2)', async () => {
     const transport = new CaptureTransport();
     const tpl: EmailTemplateRow = {

--- a/packages/services/service-messaging/src/email-channel.test.ts
+++ b/packages/services/service-messaging/src/email-channel.test.ts
@@ -277,4 +277,94 @@ describe('email channel', () => {
             expect(email.sent[0]).toEqual({ to: 'ada@example.com', subject: 'Deal closed', text: 'Acme signed' });
         });
     });
+
+    // ── #11741 — organization threading. This channel is the producer the
+    // ruling names as HOLDING an organization (`delivery.notification
+    // .organizationId`, the tenant stamp the outbox snapshots per delivery),
+    // so it threads that value into the email service's input on BOTH of its
+    // arms; plugin-email's writer then stamps `sys_email.organization_id`
+    // verbatim. Identity pins, not counts: each pin asserts the exact value
+    // THIS producer stamped. The over-denial control pins the other half of
+    // the ruling: a delivery genuinely without an organization sends WITHOUT
+    // one — never refused, never given a fabricated stamp.
+    describe('organization threading (#11741)', () => {
+        /** Email service double recording both arms' inputs. */
+        function orgEmail() {
+            const sent: any[] = [];
+            const templated: any[] = [];
+            return {
+                sent,
+                templated,
+                service: {
+                    async send(input: any) { sent.push(input); return { id: 'email_row_1' }; },
+                    async sendTemplate(input: any) { templated.push(input); return { id: 'email_row_9', status: 'sent' }; },
+                },
+            };
+        }
+
+        it('the plain arm threads notification.organizationId into SendEmailInput (identity pin)', async () => {
+            const email = orgEmail();
+            const ch = channel(() => email.service, fakeData({ users: { user_1: 'ada@example.com' } }));
+            const r = await ch.send(silentCtx(), delivery({ organizationId: 'org_apex' }));
+            expect(r.ok).toBe(true);
+            expect(email.sent).toHaveLength(1);
+            // Exact shape: the stamp is the delivery's OWN organization, and
+            // nothing else about the input moved.
+            expect(email.sent[0]).toEqual({
+                to: 'ada@example.com',
+                subject: 'Deal closed',
+                text: 'Acme signed',
+                organizationId: 'org_apex',
+            });
+        });
+
+        it('the template arm threads notification.organizationId into sendTemplate (identity pin)', async () => {
+            const email = orgEmail();
+            const data = fakeData({ users: { user_1: 'ada@example.com' } });
+            const ch = createEmailChannel({
+                getEmail: () => email.service,
+                getData: () => data,
+                store: new NotificationTemplateStore({ getData: () => data }),
+                getDefaultTemplateLocale: () => 'ja-JP',
+            });
+            const r = await ch.send(silentCtx(), delivery({
+                organizationId: 'org_apex',
+                title: 'deal.won',
+                body: '',
+                payload: { template: 'crm.large_deal_won', templateData: { dealName: 'Acme' } },
+            }));
+            expect(r.ok).toBe(true);
+            expect(email.templated).toHaveLength(1);
+            expect(email.templated[0]).toEqual({
+                template: 'crm.large_deal_won',
+                to: 'ada@example.com',
+                data: { dealName: 'Acme' },
+                locale: 'ja-JP',
+                organizationId: 'org_apex',
+            });
+        });
+
+        it('over-denial control: an org-less delivery sends WITHOUT an organization and is not refused (both arms)', async () => {
+            const email = orgEmail();
+            const data = fakeData({ users: { user_1: 'ada@example.com' } });
+            const ch = createEmailChannel({
+                getEmail: () => email.service,
+                getData: () => data,
+                store: new NotificationTemplateStore({ getData: () => data }),
+            });
+            const plain = await ch.send(silentCtx(), delivery());
+            expect(plain.ok).toBe(true);
+            expect(email.sent).toHaveLength(1);
+            expect(email.sent[0]).not.toHaveProperty('organizationId');
+
+            const templated = await ch.send(silentCtx(), delivery({
+                title: 'deal.won',
+                body: '',
+                payload: { template: 'crm.large_deal_won' },
+            }));
+            expect(templated.ok).toBe(true);
+            expect(email.templated).toHaveLength(1);
+            expect(email.templated[0]).not.toHaveProperty('organizationId');
+        });
+    });
 });

--- a/packages/services/service-messaging/src/email-channel.ts
+++ b/packages/services/service-messaging/src/email-channel.ts
@@ -30,6 +30,13 @@ export interface EmailSenderSurface {
         subject: string;
         html?: string;
         text?: string;
+        /**
+         * Structural mirror of `SendEmailInput.organizationId` (#11741) —
+         * the tenant stamp for `sys_email.organization_id`, threaded from
+         * `delivery.notification.organizationId` when the delivery holds
+         * one. Optional: an org-less delivery sends without it.
+         */
+        organizationId?: string;
     }): Promise<{ id?: string } | unknown>;
     /**
      * Structural mirror of `IEmailService.sendTemplate` (#9205) — resolves a
@@ -45,6 +52,8 @@ export interface EmailSenderSurface {
         to: string | string[];
         data?: Record<string, unknown>;
         locale?: string;
+        /** Same tenant stamp as on `send` (#11741) — forwarded by the email service into the send it performs. */
+        organizationId?: string;
     }): Promise<{ id?: string; status?: string; error?: string } | unknown>;
     /**
      * Structural mirror of `IEmailService.renderTemplate` (#9225) — resolves a
@@ -190,6 +199,11 @@ export function createEmailChannel(opts: EmailChannelOptions): MessagingChannel 
                         to: address,
                         ...(data !== undefined ? { data } : {}),
                         ...(templateLocale ? { locale: templateLocale } : {}),
+                        // #11741 — this channel HOLDS the organization (the
+                        // tenant stamp the outbox snapshots per delivery), so
+                        // it threads it for the sys_email.organization_id
+                        // stamp. Absent stays absent — never fabricated.
+                        ...(n.organizationId ? { organizationId: n.organizationId } : {}),
                     })) as { id?: unknown; status?: unknown; error?: unknown } | undefined;
                     // `IEmailService.send` reports transport failure as
                     // `status: 'failed'` rather than throwing — surface it.
@@ -222,6 +236,8 @@ export function createEmailChannel(opts: EmailChannelOptions): MessagingChannel 
                     subject: rendered.subject,
                     ...(rendered.html !== undefined ? { html: rendered.html } : {}),
                     ...(rendered.text !== undefined ? { text: rendered.text } : {}),
+                    // #11741 — same threading as the template arm above.
+                    ...(n.organizationId ? { organizationId: n.organizationId } : {}),
                 });
                 const id = result?.id;
                 return { ok: true, externalId: id != null ? String(id) : undefined };

--- a/packages/spec/src/contracts/email-service.test.ts
+++ b/packages/spec/src/contracts/email-service.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import type { SendEmailInput, SendTemplateInput } from './email-service';
+
+/**
+ * #11741 (Decision 2 of #11303) — `SendEmailInput` is widened with an
+ * OPTIONAL `organizationId` so producers that already hold an organization
+ * can thread it to `plugin-email`'s writer, which stamps
+ * `sys_email.organization_id` verbatim.
+ *
+ * Two contract facts pinned here:
+ *  - the pre-widening shape stays legal byte-identically — a caller that has
+ *    no organization (auth verification / password-reset mail) passes the
+ *    same object it always passed and is not refused;
+ *  - the widened shape carries `organizationId` as a plain optional string on
+ *    BOTH `SendEmailInput` and `SendTemplateInput` (the template entry point
+ *    forwards it into the send it performs).
+ */
+describe('Email Service Contract — organization widening (#11741)', () => {
+  it('accepts the pre-widening SendEmailInput shape unchanged (organizationId optional, absent legal)', () => {
+    const legacy: SendEmailInput = { to: 'a@b.com', subject: 'Hi', text: 'x' };
+    expect(legacy).not.toHaveProperty('organizationId');
+    expect(legacy.organizationId).toBeUndefined();
+  });
+
+  it('accepts a SendEmailInput carrying organizationId (the sys_email.organization_id pass-through stamp)', () => {
+    const widened: SendEmailInput = {
+      to: 'a@b.com',
+      subject: 'Hi',
+      text: 'x',
+      organizationId: 'org_apex',
+    };
+    expect(widened.organizationId).toBe('org_apex');
+  });
+
+  it('accepts a SendTemplateInput carrying organizationId (forwarded to the underlying send)', () => {
+    const legacy: SendTemplateInput = { template: 'auth.password_reset', to: 'a@b.com' };
+    expect(legacy.organizationId).toBeUndefined();
+
+    const widened: SendTemplateInput = {
+      template: 'auth.password_reset',
+      to: 'a@b.com',
+      organizationId: 'org_apex',
+    };
+    expect(widened.organizationId).toBe('org_apex');
+  });
+});

--- a/packages/spec/src/contracts/email-service.ts
+++ b/packages/spec/src/contracts/email-service.ts
@@ -67,6 +67,22 @@ export interface SendEmailInput {
   relatedId?: string;
   /** User id for `sent_by` audit linkage. */
   sentBy?: string;
+  /**
+   * Organization (tenant) id stamped verbatim onto the persisted
+   * `sys_email.organization_id` (#11741, Decision 2 of #11303).
+   *
+   * Pass-through only: the email service's writer runs under a constant
+   * system context and MUST NOT resolve or fabricate an organization — a
+   * wrong `organization_id` is silently authoritative to every report,
+   * export and cleanup script that filters by organization, which is worse
+   * than a null. Producers that already hold one (e.g. the messaging email
+   * channel's `delivery.notification.organizationId`) thread it here; omit
+   * it when the caller genuinely has none (auth verification /
+   * password-reset mail) — absent stays legal and the row is simply
+   * unstamped. Forward-stamping only; pre-existing org-less rows are not
+   * backfilled.
+   */
+  organizationId?: string;
 }
 
 /**
@@ -184,6 +200,16 @@ export interface SendTemplateInput {
   relatedId?: string;
   /** User id for `sent_by` audit linkage. */
   sentBy?: string;
+  /**
+   * Organization (tenant) id forwarded into the {@link SendEmailInput} this
+   * template send performs, and stamped from there onto
+   * `sys_email.organization_id` (#11741). Same contract as
+   * {@link SendEmailInput.organizationId}: pass-through only, optional,
+   * absent stays legal. Distinct from {@link SendTemplateInput.org}, which
+   * addresses template org-overlay *resolution*, not the delivery row's
+   * tenant stamp.
+   */
+  organizationId?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #11741

Clause-②: yes — public contract widening; the PR stays draft, the contract-review chain runs before enqueue.

## The ruling this carries out (Decision 2 of #11303)

Maintainer, 2026-08-24, live PM chat: 「其他按照你的建议继续」, recorded on #11303 at `5396411781`, Decision 2 verbatim:

> **`sys_email`: separate card, ruled to file.** Widening `SendEmailInput` in `packages/spec/src/contracts/email-service.ts` is Clause-② work with spec ownership: thread from callers that hold an organization (the email channel's `delivery.notification.organizationId`), absent stays legal where the caller genuinely has none (auth verification/reset mail). The services seat files it with this provenance; ⛔ never smuggled into the merged PR #11698.

Parent ruling (#11303, `5393621706`): 「11303 sys_inbox_message/sys_notification/sys_email 应该写 organization_id。」 Backfill posture: forward-stamping only, no backfill of existing org-less rows (maintainer 2026-08-23 precedent 「10950 不考虑存量」). Nothing here touches merged PR #11698.

## What changed

- `packages/spec/src/contracts/email-service.ts` — `SendEmailInput.organizationId?: string` and `SendTemplateInput.organizationId?: string` (optional; pass-through only; TSDoc states the no-fabrication rule and the absent-stays-legal rule; the SendTemplateInput doc distinguishes it from the pre-existing `org` overlay key).
- `packages/plugins/plugin-email/src/email-service.ts` — `send()` stamps `input.organizationId` verbatim onto the persisted `sys_email` row (`organization_id`); absent writes nothing. `sendTemplate()` forwards the key into the `SendEmailInput` it builds. No in-adapter resolution: the writer runs under a constant SYSTEM context and only passes through what the input carries. The durable paths need no further change — queue/boot-sweep delivery re-reads the row, and the terminal status update never rewrites `organization_id`.
- `packages/services/service-messaging/src/email-channel.ts` — the named producer. Both arms thread `delivery.notification.organizationId`: the plain `send` arm and the `sendTemplate` template arm; the `EmailSenderSurface` structural mirrors declare the key.
- `packages/plugins/plugin-auth/src/auth-manager.ts` — `sendInvitationEmail` threads `invitation.organizationId` (the one auth producer that holds a real organization). All org-less auth mail is untouched.
- Changeset: `@objectstack/spec` minor + the three touched packages (launch-window convention: no major; additive, no ADR-0087 disposition owed — `node scripts/check-adr-0087-registration.mjs` exit 0).

## Caller census (the card marked it unmeasured)

Producers that HOLD an organization — now stamp:

| Producer | Evidence | Value threaded |
|---|---|---|
| service-messaging email channel, plain arm | `packages/services/service-messaging/src/email-channel.ts:229` (send call); org on `channel.ts:32` | `delivery.notification.organizationId` |
| service-messaging email channel, template arm | `packages/services/service-messaging/src/email-channel.ts:188` (sendTemplate call) | `delivery.notification.organizationId` |
| plugin-auth `sendInvitationEmail` | `packages/plugins/plugin-auth/src/auth-manager.ts:2672` | `invitation.organizationId` |
| plugin-email `sendTemplate` → `send()` (internal producer) | `packages/plugins/plugin-email/src/email-service.ts:1281` | forwarded `input.organizationId` |

Producers genuinely WITHOUT one — unchanged, absent stays legal (the ruling's named class):

- plugin-auth `sendResetPassword` (`auth-manager.ts:1254`), `sendVerificationEmail` (`:1311`), `sendMagicLink` (`:2833`), `sendChangeEmailNotice` (`:3391`) — user-scoped auth mail.
- plugin-email mail-test button (`email-plugin.ts:544`) — operator test message.
- plugin-email legacy queue subscriber (`email-plugin.ts:755`) — raw `SendEmailInput` pass-through; carries whatever its producer wrote, no change needed.
- plugin-reports `dispatchDue` (`report-service.ts:742,757`) — holds only `report.owner_id` (a user id); the owner-context resolver is wired `undefined` (`reports-plugin.ts:137`, scheduled runs fail closed), so no organization value is in hand at the send site, and deriving one would be the resolution the ruling forbids.
- REST `POST /email/send` (`rest-server.ts:8334`) — spreads the caller's body verbatim, so a body carrying `organizationId` now passes through with zero code change; whether the route should additionally stamp the execution context's tenant when the body omits one (the existing `sentBy` symmetry) is recorded as an open question in the dev report, not guessed at here.

Out-of-scope finding filed while sweeping: #11832 — `SendTemplateInput.org` ("org-overlay resolution (when supported)") has zero readers in the only IEmailService implementation.

## Pins

- Identity, not counts: each stamping pin asserts the exact org value the specific producer stamped (messaging both arms; plugin-email row `organization_id`; sendTemplate forwarding; plugin-auth invitation).
- Over-denial controls: org-less send/sendTemplate/delivery write no `organization_id` and are NOT refused (plugin-email, messaging both arms, plugin-auth reset mail).
- Contract pins: `packages/spec/src/contracts/email-service.test.ts` — the pre-widening shape stays legal byte-identically; the widened shape carries the optional key on both inputs. The pre-existing exact-shape `toEqual` pins in `email-channel.test.ts` double as byte-identity evidence for org-less callers.

## Reverse verification (pins written first, run against unfixed source)

RED (before the fix, value dropped/never carried — `expected undefined to be 'org_apex'`):
- service-messaging `email-channel.test.ts`: **2 failed** (both arms' identity pins) | 15 passed
- plugin-email `email-service.test.ts` + `send-template.test.ts`: **2 failed** (row stamp; sendTemplate forwarding) | 43 passed
- plugin-auth `auth-manager.test.ts`: **1 failed** (invitation threading) | 246 passed
- Over-denial controls were green on unfixed source in all three packages, as expected — the org-less path was already legal; only the stamping direction was red.

GREEN (after the fix, same commands): messaging 17/17 · plugin-email 45/45 · plugin-auth 247/247.

## Verification (all readings at head `5df550961` unless noted)

- `pnpm --filter @objectstack/spec test` — 421 files / **11221 passed**; `pnpm --filter @objectstack/spec typecheck` — OK (incl. check:test-typecheck).
- `pnpm --filter @objectstack/plugin-email test` — 27 files / **429 passed**; typecheck OK.
- `pnpm --filter @objectstack/service-messaging test` — 27 files / **279 passed**; typecheck OK.
- `pnpm --filter @objectstack/plugin-auth test` — **1519 passed** (suite) and 247/247 on the pinned file at head; typecheck OK (after building the package's own dist — the examples tsconfig resolves the package by name).
- Full workspace typecheck: `pnpm exec turbo run typecheck --concurrency=2` — **129/129 tasks successful** (covers every downstream consumer of the widened spec surface).
- `pnpm --filter @objectstack/spec check:generated` — "All 14 generated artifacts are up to date."
- `node scripts/pm/dispatch-gates.mjs` derivation line, quoted: "dispatch-gates: gate list derived from the tree of 'objectstack-ai/objectstack' at commit 5df550961 (/home/user/objectstack-11741)." Every derived family ran locally at that head, all exit 0: changeset-gate-self-tests, cross-package-test-inputs (both spellings), doc-formula-expressions, spec empty-state / liveness / strictness-ledger / variant-docs, merge-driver, objectui-changeset, published-files, slot-lookup, spec-parsed-alias, test-source-alias, type-source-resolution, adr-0087-registration, changeset-no-major, empty-changeset, dev-prereqs, plugin-teardown-shape, docs-audit affected-docs + drift-comment, release-rehearsal-clone --self-test; convention families: query-options-erasure, type-check-coverage, type-check-debt (--re-measure OK, none above recorded — the first run caught +3 in plugin-auth's frozen TEST_DEBT from this PR's own new tests; fixed by type-clean mock access, re-measured back to the recorded 97), engine-double-contract, where-matcher, check:i18n, check:nul-bytes.
- A first-run `check-dev-prereqs` red was the unbuilt fresh worktree (40/67 packages without dist), green after the full packages build — worktree state, not diff state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rxnd8cyFnoU8V5y21PaTsy)_