### PR TITLE
fix(objectql): hydrate a tombstoned sys_file that still has a live holder

### DIFF
--- a/.changeset/file-hydration-tombstone-agreement.md
+++ b/.changeset/file-hydration-tombstone-agreement.md
@@ -1,5 +1,5 @@
 ---
-"@objectstack/objectql": patch
+"@objectstack/objectql": minor
 "@objectstack/service-storage": patch
 ---
 

--- a/.changeset/file-hydration-tombstone-agreement.md
+++ b/.changeset/file-hydration-tombstone-agreement.md
@@ -1,0 +1,10 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/service-storage": patch
+---
+
+Record file-field hydration now answers the same question about a `sys_file` tombstone that the download path answers (#11427). `#10246` stopped `GET /api/v1/storage/files/:id` treating a tombstone (`status: 'deleted'` + `deleted_at`) as the last word — it asks the reap guard's own `findFileHolder` and serves the row for as long as something still holds it — but the record read kept the older `status === 'committed'` rule. One `sys_file` row therefore answered `200` at the download endpoint and a bare id inside a record payload, which UI and export render as "this record has no attachment".
+
+The population is narrow and unchanged in every other respect: `claimFile` already un-tombstones a field file synchronously when a record re-points at it, and attachments-scope files are never reached by field hydration, so what this closes is the residual the reap guard's sweep-time re-verification names — hook races, direct-driver writes, and future trash restore. A tombstone nothing holds still hydrates as a bare id, and a `pending` upload is untouched.
+
+The predicate is not re-derived in the engine. `ObjectQL` gains `registerHeldFileResolver` (type `HeldFileResolver`), which the storage plugin fills with `findHeldFiles` — the batched form of `findFileHolder`, asking the same union of `sys_attachment` join rows and the `ref_*` ownership columns. Batched because hydration runs over many rows per read: a read with no tombstone costs nothing, and the residual case costs one extra query for the whole read rather than one per file. Engines with no storage plugin keep tombstones un-hydrated exactly as before.

--- a/content/docs/permissions/attachments-access.mdx
+++ b/content/docs/permissions/attachments-access.mdx
@@ -109,13 +109,17 @@ can be shared across records). Reclamation is handled by the platform LifecycleS
   attachments-scope file is deleted, the file is tombstoned; a reap guard
   re-verifies zero references at sweep time and deletes the storage bytes
   before the row is reaped (abandoned `pending` uploads are reaped too).
-  **A tombstone is recoverable state, not a delete — and downloads treat it that
-  way.** Re-attaching the file, or re-claiming it through a record field, makes
-  it downloadable again *immediately*, with no sweep in between: the download
-  endpoints ask the same "is anything still holding this file?" question the
-  reap guard asks before it reclaims anything. The row itself stays tombstoned
-  until a sweep tidies it, and a file with no holder left still answers
-  `FILE_NOT_FOUND` (404).
+  **A tombstone is recoverable state, not a delete — and every reader treats it
+  that way.** Re-attaching the file, or re-claiming it through a record field,
+  makes it readable again *immediately*, with no sweep in between: the download
+  endpoints **and record file-field hydration** ask the same "is anything still
+  holding this file?" question the reap guard asks before it reclaims anything.
+  Both reach it through that one predicate rather than each deciding for itself,
+  which is what stops the two surfaces answering differently about one row — a
+  file `GET /storage/files/:id` serves is a file a record read expands into
+  `{ id, name, size, mimeType, url }`. The row itself stays tombstoned until a
+  sweep tidies it, and a file with no holder left still answers
+  `FILE_NOT_FOUND` (404) and keeps its bare id in a record payload.
 - **`sys_upload_session`** — abandoned/terminal chunked-upload sessions are
   reaped, and a reap guard aborts the underlying backend multipart upload
   (S3 `AbortMultipartUpload` / local parts dir) first, so already-uploaded

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -1899,6 +1899,24 @@ export type EngineMiddleware = (
 ) => Promise<void>;
 
 /**
+ * "Which of these tombstoned `sys_file` rows is something still holding?"
+ * (#11427).
+ *
+ * Takes the whole tombstoned set from ONE record read and returns the subset
+ * still held, as a set of stringified ids. Batched rather than per-row on
+ * purpose: hydration runs over many rows per read, so asking per file would be
+ * N queries per read.
+ *
+ * The engine declares this shape but never implements it — "still held" has one
+ * definition (`findFileHolder`, the union of `sys_attachment` join rows and the
+ * `ref_*` ownership columns) and it lives in the storage package. See
+ * `ObjectQL.registerHeldFileResolver`.
+ */
+export type HeldFileResolver = (
+  rows: Array<Record<string, any>>,
+) => Promise<Set<string>>;
+
+/**
  * The stack collections the engine decomposes into individual registry items —
  * ONE list, read by the ONE body both registration seams run
  * (`registerMetadataCollections()`, called from the manifest seam in
@@ -3070,6 +3088,33 @@ export class ObjectQL implements IObjectQLEngine {
         this.actions.delete(key);
       }
     }
+  }
+
+  /**
+   * "Which of these tombstoned `sys_file` rows is something still holding?"
+   * (#11427) — supplied by the storage plugin, never derived here.
+   *
+   * File-field hydration must answer the same question the download path
+   * answers (#10246) or one row gets two answers. That question has exactly one
+   * definition, `findFileHolder`, and it lives in `@objectstack/service-storage`
+   * — a package this one does not and must not depend on. So the engine
+   * declares the seam and the storage plugin fills it, the same handover
+   * `resolveFileHolder` makes to the download routes.
+   *
+   * BATCHED on purpose: hydration runs over many rows per read, so a per-row
+   * holder check would be N queries per read. The resolver takes the whole
+   * tombstoned set and returns the ids still held.
+   */
+  private _heldFileResolver?: HeldFileResolver;
+
+  /**
+   * Wire the batched holder question (#11427). Last registration wins; leaving
+   * it unwired keeps tombstoned files un-hydrated, which is what this engine
+   * did before the seam existed.
+   */
+  registerHeldFileResolver(fn: HeldFileResolver): void {
+    this._heldFileResolver = fn;
+    this.logger.debug('Registered held-file resolver for sys_file hydration');
   }
 
   /**
@@ -8078,8 +8123,52 @@ export class ObjectQL implements IObjectQLEngine {
     }
 
     const fileMap = new Map<string, any>();
+    // [#11427] `committed` is servable and always was. A TOMBSTONE
+    // (`status: 'deleted'` + `deleted_at`) is recoverable state, not a delete:
+    // it is a claim about the future (this row is reapable once the grace
+    // window ends) that the sweep re-checks and often withdraws. #10246 already
+    // stopped the two download endpoints treating it as the last word — they
+    // ask the reap guard's own `findFileHolder` and serve the row for as long
+    // as something still holds it. This pass did not, so one `sys_file` row
+    // answered 200 at `/files/:id` and a bare id here: two read surfaces, two
+    // answers, and consumers render the bare id as "no attachment".
+    //
+    // ⛔ The predicate is NOT re-derived here. "Still held" has ONE definition
+    // (`findFileHolder`, a deliberate union of `sys_attachment` join rows AND
+    // the `ref_*` ownership columns) and it lives in the storage package, which
+    // this one cannot import. A copy narrower by a limb would hide files the
+    // sweep refuses to reap — the same defect one limb over — so the question
+    // arrives through {@link registerHeldFileResolver} instead, the same
+    // handover `resolveFileHolder` makes to the download routes. Unwired (bare
+    // kernel, no storage plugin, tests): tombstones stay hidden, exactly as
+    // before this existed.
+    const tombstoned: any[] = [];
     for (const row of fileRows) {
-      if (row?.id != null && row.status === 'committed') fileMap.set(String(row.id), row);
+      if (row?.id == null) continue;
+      if (row.status === 'committed') fileMap.set(String(row.id), row);
+      else if (row.status === 'deleted') tombstoned.push(row);
+    }
+    // Lazy by construction: a batch with no tombstone — every ordinary read —
+    // costs nothing at all, and the resolver is BATCHED, so the residual case
+    // costs one extra query for the whole read rather than one per row.
+    if (tombstoned.length > 0 && this._heldFileResolver) {
+      try {
+        const held = await this._heldFileResolver(tombstoned);
+        for (const row of tombstoned) {
+          if (held?.has(String(row.id))) fileMap.set(String(row.id), row);
+        }
+      } catch (error) {
+        // Unreadable evidence is not evidence of a holder. Keep the ids
+        // un-hydrated — the answer this pass gave before #11427, and the same
+        // direction the download path fails in (`isServableForDownload`) and
+        // the reap guard fails in (it vetoes rather than reaps when it cannot
+        // tell). Distinct from the #6116 catch above, which covers the
+        // `sys_file` read itself and is untouched.
+        this.logger.warn(
+          'sys_file holder check failed; tombstoned file fields keep their raw ids for this read',
+          { object: objectName, tombstonedIds: tombstoned.length, error: (error as Error)?.message },
+        );
+      }
     }
     if (fileMap.size === 0) return records;
 

--- a/packages/objectql/src/index.ts
+++ b/packages/objectql/src/index.ts
@@ -63,7 +63,7 @@ export type { CompanionFieldMeta, CompanionObjectMeta } from './search-companion
 
 // Export Engine
 export { ObjectQL, ObjectRepository, ScopedContext } from './engine.js';
-export type { HookHandler, HookEntry, OperationContext, EngineMiddleware } from './engine.js';
+export type { HookHandler, HookEntry, OperationContext, EngineMiddleware, HeldFileResolver } from './engine.js';
 export type { AdmittedValueShapeViolationTally } from './engine.js';
 export { SummaryRecomputeError } from './summary-errors.js';
 export type { SummaryRecomputeFailure } from './summary-errors.js';

--- a/packages/services/service-storage/package.json
+++ b/packages/services/service-storage/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@objectstack/objectql": "workspace:*",
-    "@objectstack/driver-memory": "workspace:*",
+    "@objectstack/driver-sql": "workspace:*",
     "@types/node": "^26.2.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-storage/package.json
+++ b/packages/services/service-storage/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@objectstack/objectql": "workspace:*",
+    "@objectstack/driver-memory": "workspace:*",
     "@types/node": "^26.2.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-storage/src/attachment-lifecycle.ts
+++ b/packages/services/service-storage/src/attachment-lifecycle.ts
@@ -366,6 +366,54 @@ export async function findFileHolder(
 }
 
 /**
+ * The BATCHED form of {@link findFileHolder} — "which of these files is still
+ * held?" — for callers holding many rows at once (#11427).
+ *
+ * Record file-field hydration is such a caller: it must reach the same verdict
+ * the download path reaches (#10246) or one `sys_file` row gets two answers,
+ * but it runs over many rows per read, so asking {@link findFileHolder} per
+ * file would be N queries per read. This asks the SAME union in at most one
+ * extra query for the whole batch.
+ *
+ * ⚠️ Same union, same limbs, deliberately in the cheaper order. {@link
+ * findFileHolder} asks the join-row limb first because it must NAME the
+ * surface; this one only needs "held or not", so it takes the free limb first:
+ * {@link hasFieldReferenceOwner} is a pure column test on rows the caller has
+ * already read, and every id it settles is an id the join-row query never has
+ * to carry. `||` commutes, so the verdict is identical either way — pinned as
+ * an equivalence in `tombstone-hydration-download-agreement.test.ts` rather
+ * than asserted here.
+ *
+ * Cost, stated rather than assumed:
+ *   - no rows, or every row settled by the columns → ZERO queries;
+ *   - otherwise → exactly ONE `$in` read of `sys_attachment`, whatever the
+ *     number of files or records involved.
+ */
+export async function findHeldFiles(
+  engine: Pick<AttachmentLifecycleEngine, 'find'>,
+  rows: Array<Record<string, unknown>>,
+): Promise<Set<string>> {
+  const held = new Set<string>();
+  const needJoinCheck: string[] = [];
+  for (const row of rows) {
+    if (row?.id == null) continue;
+    const id = String(row.id);
+    // The free limb first — a pure test on a row already in hand.
+    if (hasFieldReferenceOwner(row)) held.add(id);
+    else needJoinCheck.push(id);
+  }
+  if (needJoinCheck.length === 0) return held;
+  const refs = await engine.find('sys_attachment', {
+    where: { file_id: { $in: needJoinCheck } },
+    context: { ...SYSTEM_CTX },
+  });
+  for (const ref of refs ?? []) {
+    if (ref?.file_id != null) held.add(String(ref.file_id));
+  }
+  return held;
+}
+
+/**
  * The `sys_file` reap guard ({@link LifecycleReapGuard} shape from
  * `@objectstack/objectql`, duck-typed here to avoid the dependency).
  * Candidates arrive from the two declared policies — tombstones past the

--- a/packages/services/service-storage/src/storage-service-plugin.ts
+++ b/packages/services/service-storage/src/storage-service-plugin.ts
@@ -21,7 +21,7 @@ import { StorageMetadataStore } from './metadata-store.js';
 import type { FileRecord } from './metadata-store.js';
 import { registerStorageRoutes } from './storage-routes.js';
 import type { FileReadVerdict } from './storage-routes.js';
-import { installAttachmentLifecycleHooks, createSysFileReapGuard, createUploadSessionReapGuard, findFileHolder } from './attachment-lifecycle.js';
+import { installAttachmentLifecycleHooks, createSysFileReapGuard, createUploadSessionReapGuard, findFileHolder, findHeldFiles } from './attachment-lifecycle.js';
 import { installFileReferenceHooks } from './file-reference-lifecycle.js';
 import { installAttachmentAccessHooks, installAttachmentReadVisibility } from './attachment-access-hooks.js';
 import { SystemFile, SystemUploadSession } from './objects/index.js';
@@ -353,6 +353,22 @@ export class StorageServicePlugin implements Plugin {
         // guard below re-verifies the ownership columns — and re-reads the
         // deployment flag, fresh — before any byte is deleted.
         installFileReferenceHooks(engine as any, () => this.storage, ctx.logger);
+        // "Is anything still holding this tombstone?" for RECORD FILE-FIELD
+        // HYDRATION (#11427). The download path got this question in #10246;
+        // the record read kept the older `status === 'committed'` rule, so one
+        // `sys_file` row answered 200 at `/files/:id` and a bare id inside a
+        // record payload — which UI and export render as "no attachment".
+        //
+        // Handed over rather than re-derived, exactly like `resolveFileHolder`
+        // below, and BATCHED: hydration runs over many rows per read, so the
+        // engine passes the whole tombstoned set and `findHeldFiles` answers it
+        // in at most one extra query. Duck-typed so an older engine without the
+        // seam simply keeps tombstones un-hydrated.
+        if (typeof (engine as any).registerHeldFileResolver === 'function') {
+          (engine as any).registerHeldFileResolver(
+            (rows: Array<Record<string, unknown>>) => findHeldFiles(engine as any, rows),
+          );
+        }
         try {
           const lifecycle = ctx.getService<any>('lifecycle');
           if (lifecycle && typeof lifecycle.registerReapGuard === 'function') {

--- a/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
+++ b/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
@@ -54,9 +54,13 @@
  *
  * The download verdict and the hydration verdict must come from the SAME rows
  * or the pair proves nothing, so both surfaces are driven off one real
- * `ObjectQL` engine over `@objectstack/driver-memory` — a real driver that
- * really filters, including the `$in` the batched holder check issues. No
- * engine double is involved, so no write-verb dispatch contract applies.
+ * `ObjectQL` engine over sqlite `:memory:` — the project's ruled test backend
+ * (#5499 froze investment in the in-memory driver; #5704 migrated the test
+ * backends), and a real driver that really filters, including the `$in` the
+ * batched holder check issues. Nothing here turns on a driver's distinct
+ * semantics: what the fixture needs is shared state across two read surfaces,
+ * which sqlite carries identically. No engine double is involved, so no
+ * write-verb dispatch contract applies.
  *
  * The seam is reached by DUCK TYPING, exactly as `StorageServicePlugin` wires
  * it. That is deliberate: it lets this file state the divergence as a
@@ -70,7 +74,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { IHttpResponse, RouteHandler } from '@objectstack/spec/contracts';
 import { ObjectQL } from '@objectstack/objectql';
-import { InMemoryDriver } from '@objectstack/driver-memory';
+import { SqlDriver } from '@objectstack/driver-sql';
 import { LocalStorageAdapter } from './local-storage-adapter.js';
 import { StorageMetadataStore } from './metadata-store.js';
 import { registerStorageRoutes } from './storage-routes.js';
@@ -153,7 +157,11 @@ describe('#11427 — file-field hydration and the download path agree about one 
     adapter = new LocalStorageAdapter({ rootDir, signingSecret: 'test-secret' });
 
     engine = new ObjectQL({ logger: silentLogger() } as any);
-    engine.registerDriver(new InMemoryDriver() as any, true);
+    engine.registerDriver(new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    }) as any, true);
     await engine.init();
 
     engine.registry.registerObject({
@@ -175,6 +183,8 @@ describe('#11427 — file-field hydration and the download path agree about one 
       name: 'contract',
       fields: { title: { type: 'text' }, signed_pdf: { type: 'file' } },
     } as any, 'test-11427');
+    // Real DDL for all three tables before the first row is written.
+    await engine.syncSchemas();
 
     // ── The shared fixture: four sys_file rows in the residual state ──────
     const files = [
@@ -212,6 +222,8 @@ describe('#11427 — file-field hydration and the download path agree about one 
   });
 
   afterEach(async () => {
+    // Closes the `:memory:` database with the engine that owns it.
+    try { await engine?.destroy(); } catch { /* already torn down */ }
     if (rootDir) await fs.rm(rootDir, { recursive: true, force: true });
   });
 

--- a/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
+++ b/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
@@ -68,7 +68,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import type { IHttpRequest, IHttpResponse, RouteHandler } from '@objectstack/spec/contracts';
+import type { IHttpResponse, RouteHandler } from '@objectstack/spec/contracts';
 import { ObjectQL } from '@objectstack/objectql';
 import { InMemoryDriver } from '@objectstack/driver-memory';
 import { LocalStorageAdapter } from './local-storage-adapter.js';
@@ -164,17 +164,17 @@ describe('#11427 — file-field hydration and the download path agree about one 
         status: { type: 'text' }, deleted_at: { type: 'datetime' },
         ref_object: { type: 'text' }, ref_id: { type: 'text' }, ref_field: { type: 'text' },
       },
-    } as any);
+    } as any, 'test-11427');
     engine.registry.registerObject({
       name: 'sys_attachment',
       fields: {
         file_id: { type: 'text' }, parent_object: { type: 'text' }, parent_id: { type: 'text' },
       },
-    } as any);
+    } as any, 'test-11427');
     engine.registry.registerObject({
       name: 'contract',
       fields: { title: { type: 'text' }, signed_pdf: { type: 'file' } },
-    } as any);
+    } as any, 'test-11427');
 
     // ── The shared fixture: four sys_file rows in the residual state ──────
     const files = [
@@ -347,7 +347,7 @@ describe('#11427 — findHeldFiles is findFileHolder, batched', () => {
   });
 
   it('asks NOTHING when every row is settled by the ownership columns', async () => {
-    const find = vi.fn(async () => []);
+    const find = vi.fn(async (_object: string, _options: any) => [] as any[]);
     const held = await (lifecycle as any).findHeldFiles({ find } as any, [
       { id: 'f1', ref_object: 'p', ref_id: 'r1' },
       { id: 'f2', ref_object: 'p', ref_id: 'r2' },
@@ -360,7 +360,7 @@ describe('#11427 — findHeldFiles is findFileHolder, batched', () => {
   });
 
   it('asks ONCE for a whole batch, however many files are unsettled', async () => {
-    const find = vi.fn(async () => [{ id: 'att-1', file_id: 'f2' }]);
+    const find = vi.fn(async (_object: string, _options: any) => [{ id: 'att-1', file_id: 'f2' }]);
     const held = await (lifecycle as any).findHeldFiles({ find } as any, [
       { id: 'f1' }, { id: 'f2' }, { id: 'f3' }, { id: 'f4' },
     ]);

--- a/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
+++ b/packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts
@@ -1,0 +1,373 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #11427 — record file-field hydration and the download path must answer the
+ * SAME question about one `sys_file` row.
+ *
+ * ## The defect
+ *
+ * #10246 stopped the two download endpoints treating a `sys_file` tombstone as
+ * the last word: they ask the reap guard's own `findFileHolder` and serve a
+ * `status='deleted'` row for as long as something still holds it.
+ *
+ * The record read was not part of that ruling. `resolveFileReferences`
+ * (`packages/objectql/src/engine.ts`) — the pass that turns a stored `sys_file`
+ * id into `{ id, name, size, mimeType, url }` — kept the older, narrower rule,
+ * `row.status === 'committed'`. A file failing it keeps its bare id, which UI
+ * and export render as "this record has no attachment".
+ *
+ * So for ONE row, post-#10246: `GET /api/v1/storage/files/:id` answers 200
+ * while a record read hydrating that same id answers a bare id. Two read
+ * surfaces, two answers about one row.
+ *
+ * ## The population this pins — bounded, not a re-litigation of #10246
+ *
+ * Most field files never reach this state: `claimFile`
+ * (`file-reference-lifecycle.ts`) un-tombstones synchronously at re-point time,
+ * patching `status: 'committed'`, `deleted_at: null` — "a file re-referenced
+ * within its grace window comes back to life". Attachments-scope files are not
+ * involved either; that surface is `sys_attachment` join rows, not record file
+ * fields, so hydration never asks about them.
+ *
+ * What is left is exactly the residual the reap guard's sweep-time
+ * re-verification exists for and names: hook races, direct-driver writes, and
+ * future trash restore. Every fixture below is a row in that state.
+ *
+ * ## What is pinned — the PAIR and its counter-direction, never one side
+ *
+ * Asserting only "the held tombstone now hydrates" would score green for an
+ * implementation that hydrates everything, which would be a far worse defect
+ * than the one being fixed. So each case asks BOTH surfaces of ONE shared
+ * fixture, and the two directions are pinned together:
+ *
+ *   - tombstoned + a live holder ⇒ download serves it AND hydration enriches it;
+ *   - tombstoned + nothing holding it ⇒ download 404s AND hydration keeps the
+ *     bare id, exactly as before this change;
+ *   - `pending` ⇒ unchanged on both surfaces (only the `deleted` limb moved).
+ *
+ * Both limbs of the holder union get their own case, because `findFileHolder`
+ * is a deliberate union — `sys_attachment` join rows OR the `ref_*` ownership
+ * columns — and a hydration side that re-derived a narrower question would
+ * hide files the sweep refuses to reap: the same defect, one limb over.
+ *
+ * ## Why ONE engine and a real driver
+ *
+ * The download verdict and the hydration verdict must come from the SAME rows
+ * or the pair proves nothing, so both surfaces are driven off one real
+ * `ObjectQL` engine over `@objectstack/driver-memory` — a real driver that
+ * really filters, including the `$in` the batched holder check issues. No
+ * engine double is involved, so no write-verb dispatch contract applies.
+ *
+ * The seam is reached by DUCK TYPING, exactly as `StorageServicePlugin` wires
+ * it. That is deliberate: it lets this file state the divergence as a
+ * behavioural red on a tree where the seam does not exist yet, instead of
+ * failing at import and measuring nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { IHttpRequest, IHttpResponse, RouteHandler } from '@objectstack/spec/contracts';
+import { ObjectQL } from '@objectstack/objectql';
+import { InMemoryDriver } from '@objectstack/driver-memory';
+import { LocalStorageAdapter } from './local-storage-adapter.js';
+import { StorageMetadataStore } from './metadata-store.js';
+import { registerStorageRoutes } from './storage-routes.js';
+// Namespace import on purpose — a missing named export reads as `undefined`
+// here rather than exploding at module load, which is what keeps the pre-fix
+// run a MEASUREMENT of the divergence instead of an import crash.
+import * as lifecycle from './attachment-lifecycle.js';
+
+const URL_ROUTE = '/api/v1/storage/files/:fileId/url';
+const RAW_ROUTE = '/api/v1/storage/files/:fileId';
+
+/** Tombstoned, held through the `ref_*` ownership columns (field-owner limb). */
+const HELD_BY_COLUMNS = 'f_heldByColumns_7kQ2';
+/** Tombstoned, held through a live `sys_attachment` join row (attachment limb). */
+const HELD_BY_JOIN = 'f_heldByJoinRow_4mZ8';
+/** Tombstoned and genuinely unheld — the counter-direction control. */
+const UNHELD = 'f_unheld_9tRw3';
+/** Never completed. Only the `deleted` limb moved; this pins that. */
+const PENDING = 'f_pending_2bXy';
+
+const silentLogger = () => ({
+  info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(),
+  trace: vi.fn(), fatal: vi.fn(), child() { return this; },
+});
+
+function createMockHttpServer() {
+  const routes = new Map<string, RouteHandler>();
+  const put = (m: string) => vi.fn((path: string, handler: RouteHandler) => { routes.set(`${m}:${path}`, handler); });
+  return {
+    get: put('GET'), post: put('POST'), put: put('PUT'),
+    delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    _getHandler(method: string, path: string) { return routes.get(`${method}:${path}`); },
+  };
+}
+
+function createMockRes(): IHttpResponse & { _status: number; _json: any; _headers: Record<string, string> } {
+  const res: any = {
+    _status: 200, _json: null, _headers: {},
+    json(data: any) { res._json = data; },
+    send(data: any) { res._sent = data; },
+    status(code: number) { res._status = code; return res; },
+    header(name: string, value: string) { res._headers[name] = value; return res; },
+  };
+  return res;
+}
+
+const tombstone = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  key: `files/${id}.bin`,
+  name: 'signed.pdf',
+  size: 2048,
+  mime_type: 'application/pdf',
+  scope: 'field',
+  acl: 'private',
+  status: 'deleted',
+  deleted_at: new Date().toISOString(),
+  ...extra,
+});
+
+/** The enriched form `resolveFileReferences` owes a held file. */
+const hydrated = (id: string) => ({
+  id,
+  name: 'signed.pdf',
+  size: 2048,
+  mimeType: 'application/pdf',
+  url: `/api/v1/storage/files/${id}`,
+});
+
+describe('#11427 — file-field hydration and the download path agree about one sys_file row', () => {
+  let rootDir: string;
+  let adapter: LocalStorageAdapter;
+  let engine: ObjectQL;
+  let server: ReturnType<typeof createMockHttpServer>;
+
+  beforeEach(async () => {
+    rootDir = join(tmpdir(), `os-11427-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await fs.mkdir(rootDir, { recursive: true });
+    adapter = new LocalStorageAdapter({ rootDir, signingSecret: 'test-secret' });
+
+    engine = new ObjectQL({ logger: silentLogger() } as any);
+    engine.registerDriver(new InMemoryDriver() as any, true);
+    await engine.init();
+
+    engine.registry.registerObject({
+      name: 'sys_file',
+      fields: {
+        name: { type: 'text' }, size: { type: 'number' }, mime_type: { type: 'text' },
+        key: { type: 'text' }, scope: { type: 'text' }, acl: { type: 'text' },
+        status: { type: 'text' }, deleted_at: { type: 'datetime' },
+        ref_object: { type: 'text' }, ref_id: { type: 'text' }, ref_field: { type: 'text' },
+      },
+    } as any);
+    engine.registry.registerObject({
+      name: 'sys_attachment',
+      fields: {
+        file_id: { type: 'text' }, parent_object: { type: 'text' }, parent_id: { type: 'text' },
+      },
+    } as any);
+    engine.registry.registerObject({
+      name: 'contract',
+      fields: { title: { type: 'text' }, signed_pdf: { type: 'file' } },
+    } as any);
+
+    // ── The shared fixture: four sys_file rows in the residual state ──────
+    const files = [
+      tombstone(HELD_BY_COLUMNS, { ref_object: 'contract', ref_id: 'c1', ref_field: 'signed_pdf' }),
+      tombstone(HELD_BY_JOIN),
+      tombstone(UNHELD),
+      tombstone(PENDING, { status: 'pending', deleted_at: null }),
+    ];
+    for (const f of files) {
+      await engine.insert('sys_file', f as any);
+      await adapter.upload(String(f.key), Buffer.from(`bytes of ${f.id}`));
+    }
+    // Only HELD_BY_JOIN carries a join row.
+    await engine.insert('sys_attachment', {
+      id: 'att-1', file_id: HELD_BY_JOIN, parent_object: 'project', parent_id: 'p1',
+    } as any);
+
+    // One record per file, so hydration is asked about every case in ONE read.
+    await engine.insert('contract', { id: 'c1', title: 'MSA', signed_pdf: HELD_BY_COLUMNS } as any);
+    await engine.insert('contract', { id: 'c2', title: 'NDA', signed_pdf: HELD_BY_JOIN } as any);
+    await engine.insert('contract', { id: 'c3', title: 'SOW', signed_pdf: UNHELD } as any);
+    await engine.insert('contract', { id: 'c4', title: 'DPA', signed_pdf: PENDING } as any);
+
+    // ── The two read surfaces, both over the rows just seeded ─────────────
+    server = createMockHttpServer();
+    registerStorageRoutes(server as any, adapter, new StorageMetadataStore(engine as any), {
+      basePath: '/api/v1/storage',
+      resolveFileHolder: (f: any) => (lifecycle as any).findFileHolder(engine as any, f.id, f),
+    });
+
+    // The hydration seam, wired exactly as StorageServicePlugin wires it.
+    (engine as any).registerHeldFileResolver?.(
+      (rows: any[]) => (lifecycle as any).findHeldFiles(engine as any, rows),
+    );
+  });
+
+  afterEach(async () => {
+    if (rootDir) await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  /** What the download path says about one file id. */
+  const download = async (fileId: string) => {
+    const url = createMockRes();
+    await server._getHandler('GET', URL_ROUTE)!(
+      { params: { fileId }, query: {}, headers: {}, method: 'GET', path: URL_ROUTE } as any, url);
+    const raw = createMockRes();
+    await server._getHandler('GET', RAW_ROUTE)!(
+      { params: { fileId }, query: {}, headers: {}, method: 'GET', path: RAW_ROUTE } as any, raw);
+    return { url, raw };
+  };
+
+  /** What the record read says about the same file id — by record IDENTITY. */
+  const hydrationOf = async (recordId: string) => {
+    const rows = await engine.find('contract', { where: { id: recordId } });
+    return rows[0]?.signed_pdf;
+  };
+
+  it('the seam and its ONE batched implementation both exist', () => {
+    // Hydration cannot ask the holder question without a seam to ask through,
+    // and the answer must come from the storage package's single definition —
+    // never a copy re-derived inside the engine.
+    expect(typeof (engine as any).registerHeldFileResolver).toBe('function');
+    expect(typeof (lifecycle as any).findHeldFiles).toBe('function');
+  });
+
+  // ── The pair: a held tombstone, both limbs of the holder union ──────────
+
+  it('held through the ref_* columns — download and hydration AGREE it is there', async () => {
+    const { url, raw } = await download(HELD_BY_COLUMNS);
+
+    // The download path, post-#10246.
+    expect(url._status).toBe(200);
+    expect(url._json.data.url).toContain('/_local/raw/');
+    expect(raw._status).toBe(302);
+
+    // …and the record read must say the same thing about the same row.
+    expect(await hydrationOf('c1')).toEqual(hydrated(HELD_BY_COLUMNS));
+  });
+
+  it('held through a sys_attachment join row — download and hydration AGREE it is there', async () => {
+    const { url, raw } = await download(HELD_BY_JOIN);
+
+    expect(url._status).toBe(200);
+    expect(raw._status).toBe(302);
+
+    // The union's other limb. A hydration side that only read `ref_*` would
+    // hide this row while the download path serves it — the same divergence,
+    // one limb over.
+    expect(await hydrationOf('c2')).toEqual(hydrated(HELD_BY_JOIN));
+  });
+
+  // ── The counter-direction: nothing holds it, so BOTH surfaces hide it ───
+
+  it('a genuinely unheld tombstone stays absent on BOTH surfaces', async () => {
+    const { url, raw } = await download(UNHELD);
+
+    expect(url._status).toBe(404);
+    expect(url._json?.error?.code).toBe('FILE_NOT_FOUND');
+    expect(raw._status).toBe(404);
+    expect(raw._json?.error?.code).toBe('FILE_NOT_FOUND');
+
+    // The control that a widening cannot fake: still the BARE ID, by identity.
+    expect(await hydrationOf('c3')).toBe(UNHELD);
+  });
+
+  it('a pending upload stays absent on BOTH surfaces — only the deleted limb moved', async () => {
+    const { url, raw } = await download(PENDING);
+
+    expect(url._status).toBe(404);
+    expect(raw._status).toBe(404);
+    expect(await hydrationOf('c4')).toBe(PENDING);
+  });
+
+  // ── One read, every case at once: the agreement is per-row, not per-read ─
+
+  it('one read carrying all four files enriches exactly the held two, by identity', async () => {
+    const rows = await engine.find('contract');
+    const byId = new Map(rows.map((r: any) => [r.id, r.signed_pdf]));
+
+    expect(byId.get('c1')).toEqual(hydrated(HELD_BY_COLUMNS));
+    expect(byId.get('c2')).toEqual(hydrated(HELD_BY_JOIN));
+    expect(byId.get('c3')).toBe(UNHELD);
+    expect(byId.get('c4')).toBe(PENDING);
+  });
+});
+
+/**
+ * The batched question and the single-file question must be the SAME question.
+ *
+ * `findHeldFiles` exists only because asking `findFileHolder` per row would be
+ * N queries per read. The moment the two disagree, the divergence #11427 fixes
+ * reopens one layer down — hydration and the download path would once again be
+ * reading one row through two predicates. So the equivalence is pinned over a
+ * matrix that exercises both limbs and both of their absences, rather than
+ * asserted in a comment.
+ */
+describe('#11427 — findHeldFiles is findFileHolder, batched', () => {
+  /** A fake that honours the `$in` the batch form issues, and equality for the single form. */
+  const engineOver = (joinRows: Array<Record<string, unknown>>) => ({
+    async find(_object: string, options: any) {
+      const cond = options?.where?.file_id;
+      const wanted = cond && typeof cond === 'object' && '$in' in cond
+        ? (cond.$in as string[]).map(String)
+        : [String(cond)];
+      const hit = joinRows.filter((r) => wanted.includes(String(r.file_id)));
+      return typeof options?.limit === 'number' ? hit.slice(0, options.limit) : hit;
+    },
+  }) as any;
+
+  const MATRIX: Array<{ label: string; row: Record<string, unknown>; joined: boolean }> = [
+    { label: 'both limbs', row: { id: 'f1', ref_object: 'p', ref_id: 'r' }, joined: true },
+    { label: 'columns only', row: { id: 'f2', ref_object: 'p', ref_id: 'r' }, joined: false },
+    { label: 'join row only', row: { id: 'f3' }, joined: true },
+    { label: 'neither', row: { id: 'f4' }, joined: false },
+    { label: 'an EMPTY ref_id is not an owner', row: { id: 'f5', ref_object: 'p', ref_id: '' }, joined: false },
+  ];
+
+  it('agrees with findFileHolder on every combination, asked in ONE batch', async () => {
+    const joinRows = MATRIX.filter((c) => c.joined).map((c) => ({ id: `att-${c.row.id}`, file_id: c.row.id }));
+    const engine = engineOver(joinRows);
+
+    const held = await (lifecycle as any).findHeldFiles(engine, MATRIX.map((c) => c.row));
+
+    for (const { label, row } of MATRIX) {
+      const single = await (lifecycle as any).findFileHolder(engine, row.id, row);
+      expect(held.has(String(row.id)), label).toBe(single !== null);
+    }
+    // …and by identity, so a resolver that returned everything cannot pass.
+    expect([...held].sort()).toEqual(['f1', 'f2', 'f3']);
+  });
+
+  it('asks NOTHING when every row is settled by the ownership columns', async () => {
+    const find = vi.fn(async () => []);
+    const held = await (lifecycle as any).findHeldFiles({ find } as any, [
+      { id: 'f1', ref_object: 'p', ref_id: 'r1' },
+      { id: 'f2', ref_object: 'p', ref_id: 'r2' },
+    ]);
+
+    // The free limb settles both, so the join-row read is never issued: an
+    // ordinary read pays nothing for this feature.
+    expect(find).not.toHaveBeenCalled();
+    expect([...held].sort()).toEqual(['f1', 'f2']);
+  });
+
+  it('asks ONCE for a whole batch, however many files are unsettled', async () => {
+    const find = vi.fn(async () => [{ id: 'att-1', file_id: 'f2' }]);
+    const held = await (lifecycle as any).findHeldFiles({ find } as any, [
+      { id: 'f1' }, { id: 'f2' }, { id: 'f3' }, { id: 'f4' },
+    ]);
+
+    // ONE query, not one per file — the whole point of the batched form.
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(find.mock.calls[0][1].where.file_id.$in).toEqual(['f1', 'f2', 'f3', 'f4']);
+    expect([...held]).toEqual(['f2']);
+  });
+});

--- a/packages/services/service-storage/vitest.config.ts
+++ b/packages/services/service-storage/vitest.config.ts
@@ -42,6 +42,23 @@ export default defineConfig({
     // `@objectstack/core/logger` and resolve it to `core/src/index.ts/logger`
     // (ENOTDIR). Same reasoning, and same shape, as `service-knowledge`'s
     // config.
-    alias: [{ find: /^@objectstack\/core$/, replacement: path.resolve(__dirname, '../../core/src/index.ts') }],
+    // `@objectstack/driver-memory` joins it for the same reason (#11427): the
+    // hydration/download agreement pin drives a REAL engine over a real driver,
+    // and a driver read from `dist/` would make that pin a verdict about build
+    // state rather than about the source beside it.
+    //
+    // `@objectstack/objectql` is deliberately NOT aliased here — it is a
+    // registered entry in `KNOWN_UNALIASED_TEST_IMPORTS`
+    // (`scripts/check-test-source-alias.mjs`), so this package's tests resolve
+    // the engine through its `exports` to `dist/`. That is load-bearing rather
+    // than incidental: it is what lets an ablation of engine source, rebuilt,
+    // actually change what these tests observe.
+    //
+    // Anchored patterns in array form, per the note above: a bare key whose
+    // replacement is a FILE swallows the package's subpaths.
+    alias: [
+      { find: /^@objectstack\/core$/, replacement: path.resolve(__dirname, '../../core/src/index.ts') },
+      { find: /^@objectstack\/driver-memory$/, replacement: path.resolve(__dirname, '../../drivers/driver-memory/src/index.ts') },
+    ],
   },
 });

--- a/packages/services/service-storage/vitest.config.ts
+++ b/packages/services/service-storage/vitest.config.ts
@@ -42,8 +42,10 @@ export default defineConfig({
     // `@objectstack/core/logger` and resolve it to `core/src/index.ts/logger`
     // (ENOTDIR). Same reasoning, and same shape, as `service-knowledge`'s
     // config.
-    // `@objectstack/driver-memory` joins it for the same reason (#11427): the
-    // hydration/download agreement pin drives a REAL engine over a real driver,
+    // `@objectstack/driver-sql` joins it for the same reason (#11427): the
+    // hydration/download agreement pin drives a REAL engine over a real driver
+    // — sqlite `:memory:`, the project's ruled test backend (#5499 froze
+    // investment in the in-memory driver, #5704 migrated the test backends) —
     // and a driver read from `dist/` would make that pin a verdict about build
     // state rather than about the source beside it.
     //
@@ -58,7 +60,7 @@ export default defineConfig({
     // replacement is a FILE swallows the package's subpaths.
     alias: [
       { find: /^@objectstack\/core$/, replacement: path.resolve(__dirname, '../../core/src/index.ts') },
-      { find: /^@objectstack\/driver-memory$/, replacement: path.resolve(__dirname, '../../drivers/driver-memory/src/index.ts') },
+      { find: /^@objectstack\/driver-sql$/, replacement: path.resolve(__dirname, '../../drivers/driver-sql/src/index.ts') },
     ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2595,6 +2595,9 @@ importers:
         specifier: workspace:*
         version: link:../../types
     devDependencies:
+      '@objectstack/driver-memory':
+        specifier: workspace:*
+        version: link:../../drivers/driver-memory
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2595,9 +2595,9 @@ importers:
         specifier: workspace:*
         version: link:../../types
     devDependencies:
-      '@objectstack/driver-memory':
+      '@objectstack/driver-sql':
         specifier: workspace:*
-        version: link:../../drivers/driver-memory
+        version: link:../../drivers/driver-sql
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql


### PR DESCRIPTION
Fixes #11427

`Clause-②: yes` — see **Contract-review assessment** below. Draft on purpose; the dispatching seat lands it.

## Premise check first (dispatch constraint ①)

This card is hard-serial behind #10246 and re-parks if that predicate is not merged. Measured on `origin/main` before any edit:

- #10246 is **closed as completed** by **merged** PR #11428, commit `a41069ba37`, an ancestor of `origin/main`.
- The read-side predicate is live: `isServableForDownload` at `packages/services/service-storage/src/storage-routes.ts:192`, called by **both** download endpoints (`:675`, `:722`), wired to the reap guard's own `findFileHolder` in `storage-service-plugin.ts:422-425`.
- The narrower rule is still in place at `packages/objectql/src/engine.ts:8082`: `if (row?.id != null && row.status === 'committed')`.

The divergence is live. The card stands.

## The defect

For one `sys_file` row in the residual state, `GET /api/v1/storage/files/:id` answers **200** while a record read hydrating that same id answers **a bare id** — which UI and export render as "this record has no attachment". Two read surfaces, two answers about one row.

## Why this is not a mechanical widening (dispatch constraint ②)

Copying the download path's per-file `findFileHolder` call into hydration would be N queries per read, since hydration runs over many rows per read. It is not what this does.

`findFileHolder` is a union of two limbs, and **one of them is free**:

```ts
export function hasFieldReferenceOwner(row) {
  return row.ref_object != null && row.ref_id != null && row.ref_id !== '';
}
```

That is a pure column test on `sys_file` rows the hydration pass **has already fetched** in its existing single batched read. So `findHeldFiles` takes the whole tombstoned set, settles every row the ownership columns answer for at zero cost, and issues **at most one** `$in` read of `sys_attachment` for whatever is left.

Query shape, stated rather than asserted:

| batch | extra queries |
|---|---|
| no tombstoned row — **every ordinary read** | **0** |
| tombstones, all settled by the ownership columns | **0** |
| tombstones the columns do not settle | **1**, whatever the number of files or records |

The whole block is gated on `tombstoned.length > 0`, so the normal path does not even allocate. There is **no performance fork to report**: the batched union is +1 query worst case regardless of which layering choice is taken, so the design question below was decided on layering grounds, not cost.

`check:query-options-erasure` and `check:where-matcher` both stay green over the new `$in` call.

## Where the predicate lives, and why it is not re-derived

`objectql` does not depend on `service-storage` (that dependency exists only in the other direction, as a devDependency), so the engine cannot import `findFileHolder`. The engine already hard-codes one piece of storage semantics — `row.status === 'committed'` — and **that copy drifting from the download path is precisely this bug**. Adding a second copy would repeat the mechanism that produced it, against the explicit warning in `storage-routes.ts` ("a read side that re-derived a narrower question would refuse files the sweep refuses to reap: the same defect, one limb over") and `findFileHolder`'s own docblock ("the only way to make 'the same' a property of the code rather than a claim in a comment is for both callers to run this function").

So the engine **declares** the seam and the storage plugin **fills** it — the same handover `resolveFileHolder` makes to the download routes, and the same direction as `registerReapGuard`:

- `ObjectQL.registerHeldFileResolver(fn)` / `type HeldFileResolver` (batched: takes the tombstoned rows, returns the ids still held)
- `findHeldFiles` in `attachment-lifecycle.ts`, beside `findFileHolder` and sharing `hasFieldReferenceOwner`
- wired in `storage-service-plugin.ts`, duck-typed so an older engine simply keeps tombstones un-hydrated

Unwired (bare kernel, no storage plugin, tests that do not wire it) the behaviour is exactly what it was before this existed — symmetric with `resolveFileHolder` absent leaving tombstones refused.

## Scope is the residual population (dispatch constraint ③), measured

- **Attachments-scope files are not involved** — that surface is `sys_attachment` join rows, not record file fields, so hydration never asks. Confirmed against `system-file.object.ts`, whose `deleted_at` doc scopes tombstoning to "the last `sys_attachment` reference to an attachments-scope file".
- **Field files are un-tombstoned synchronously at re-point time** — `claimFile` (`file-reference-lifecycle.ts:475`) patches `status: 'committed'`, `deleted_at: null` **and** sets `ref_object`/`ref_id`/`ref_field`, so a normally-claimed field file is `committed` before anything reads it.

What remains is the reap guard's own named residual: **hook races, direct-driver writes, and future trash restore.** Nothing here re-opens the #10246 ruling — revival is still the sweep guard's alone and **nothing on this path writes to the row**; only the judgement moved.

## What is pinned

`packages/services/service-storage/src/tombstone-hydration-download-agreement.test.ts` — the only place both halves can be asked, since `objectql` cannot import `service-storage`. **One real `ObjectQL` engine over a real `@objectstack/driver-memory`**, with the download routes and the record read driven off the *same seeded rows*, because a pair proved over two separate fakes proves nothing.

- **the pair, both limbs** — held through `ref_*`, and held through a join row: download 200/302 **and** hydration enriched, asserted in the same test.
- **the counter-direction control** — a genuinely unheld tombstone: download 404 `FILE_NOT_FOUND` **and** hydration keeps the bare id. Without it, an implementation that hydrated everything would score green.
- **`pending` unchanged** — only the `deleted` limb moved.
- **one read carrying all four** — the agreement is per row, not per read.
- **`findHeldFiles` ≡ `findFileHolder`** over a five-case matrix covering both limbs and both absences, plus "asks nothing when the columns settle it" and "asks once for a whole batch". The batched form existing is only safe while it is the same question; that is pinned, not asserted.

All identities, never counts.

## Reverse verification

Run from the committed state, so the restore is a real restore (`git checkout <branch> -- <path>`), with a `trap … EXIT INT TERM` so a cap-kill mid-mutation cannot leave a mutated tree behind.

The mutation is `origin/main`'s `engine.ts` verbatim. Predicted in writing **before** the pin was written, and observed exactly:

```
× the seam and its ONE batched implementation both exist
    AssertionError: expected 'undefined' to be 'function'
× held through the ref_* columns — download and hydration AGREE it is there
    AssertionError: expected 'f_heldByColumns_7kQ2' to deeply equal { id: 'f_heldByColumns_7kQ2', …(4) }
× held through a sys_attachment join row — download and hydration AGREE it is there
    AssertionError: expected 'f_heldByJoinRow_4mZ8' to deeply equal { id: 'f_heldByJoinRow_4mZ8', …(4) }
× one read carrying all four files enriches exactly the held two, by identity
  Tests  4 failed | 440 passed (444)
```

The two counter-direction controls **stayed green through the ablation** — the reds are the divergence itself, not a broken fixture.

Ablation validity, since this package resolves `@objectstack/objectql` through `exports` to `dist/`: every leg rebuilt, and the mutation confirmed **in the artifact the suite consumes** — `node scripts/ablation-dist-preflight.mjs @objectstack/objectql 'registerHeldFileResolver' --absent` → *"marker absent from all 8 built files"*, and after restore the same check without `--absent` → *"marker present in 6 built files"*.

⚠️ Recorded rather than smoothed over: the mutation leg's build exited **1** — reverting `engine.ts` alone leaves `index.ts` re-exporting a now-missing type, so the **DTS** half failed. The JS the suite actually consumes was emitted and independently verified marker-absent, and the 4 reds are assertion failures inside a run where 440 tests passed, so the measurement stands. One `grep -c` line in the ablation script was mangled by shell quoting and printed a `grep:` error instead of its count; the mutation is confirmed by the *other* anchored observation (`seam present (expect 0): 0`) and by the dist preflight, so no measurement depends on the broken line.

## Contract-review assessment (Clause-②)

**Path limb: no.** Zero `packages/spec/**` in the diff — no contract schema, no error-code ledger.

**Declaration limb: yes**, on the content limb, declared rather than argued away:

- It changes what a record read **returns** for the residual population — a field that answered with a bare id now answers with the enriched object. Both are already declared-legal shapes for a file field (the fail-open path returns bare ids today), so no response schema widens and no request that was refused now succeeds — this is not the accept-set widening #10246 itself was graded on.
- But it **widens the public surface** of `@objectstack/objectql`: a new exported `registerHeldFileResolver` method and a new exported `HeldFileResolver` type.

That second bullet is sufficient on its own, so the honest call is `yes`. No authorization behaviour changes: hydration does not authorize (byte-download authorization stays at the `/files/:fileId` resolver, unchanged), and the file involved is one the reader's own record points at. `findHeldFiles` stays **internal** to `service-storage` — it is not added to that package's public index, matching the existing note that keeps `findFileHolder` internal.

## Out of scope

⛔ **#6116** — the fail-open `catch` around the `sys_file` read in the same function — is untouched. The new `catch` added here is a separate, narrow one around the holder resolver, mirroring `isServableForDownload`'s own, and it fails toward hiding: unreadable evidence is not evidence of a holder.

## Verification

Everything below was run in a dedicated worktree and, unless noted, on the final commit **`c956e46e9f`**. Exit codes captured before any pipe; each gate is quoted by its **own** verdict line.

| run | result |
|---|---|
| `pnpm --filter @objectstack/service-storage test` @ `c956e46e9f` | `Test Files 27 passed (27)` · `Tests 444 passed (444)` |
| `pnpm --filter @objectstack/objectql test` @ `2f0be8dda7` | `Test Files 231 passed (231)` · `Tests 4106 passed (4106)` |
| `pnpm --filter @objectstack/objectql typecheck` | exit 0 |
| `turbo run build --filter=./packages/* --filter=./packages/*/*` | `70 successful, 70 total` |

`@objectstack/objectql`'s suite is quoted at `2f0be8dda7` rather than the final commit: the only later change is `service-storage`'s own test file, so objectql's source and `dist/` are byte-identical between the two. The **ratchet family was re-run on the final head** after that push, which is the part that must not be quoted from an older tree.

Gates derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no path args, clean tree, after the final commit — provenance line confirms `objectstack-ai/objectstack` at the checkout's own `origin`). All green:

```
check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured, 1898 raw tsc error(s) total, none above its recorded number.
check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger
check-engine-double-contract: 383 (file, verb) row(s) held by the RETAINED ledger — a pin that leaves names itself.
check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through `dist/`
check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).
check:where-matcher — 0 silently-wrong and 0 unjudged matcher(s); none new. baseline key set verified against bb41868: no files added.
```

Also green, exit captured before any pipe: `check:nul-bytes`, `check:durability-log-level`, `check:query-options-erasure`, `check:cross-package-test-inputs`, `check:slot-lookup`, `check:type-source-resolution`, `check:stack-collection-maps`, `check:published-files`, `check:override-consistency`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-engine-split-ratio`, `check-plugin-teardown-shape`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-osv-exemptions`, `check-changeset-fixed`.

Two ratchets moved and were **repaired rather than widened**:

- `check:test-source-alias` — the new pin imported `@objectstack/driver-memory` unaliased. Fixed with an anchored alias in the package's `vitest.config.ts`, which is what the gate prescribes ("widening the registry entry is not the fix"). `@objectstack/objectql` stays ledgered-unaliased on purpose, and that is what makes the ablation above meaningful.
- `check:type-check-debt --re-measure` — the new test file pushed `service-storage` from its frozen 51 raw tsc errors to 57. All 6 were mine and are fixed; the package re-measures at exactly 51. The ledger was **not** raised.

⚠️ **Holder-side starvation, reported rather than hidden:** one verification run bundled a full workspace build with two complete test suites and held the shared verify lock for **19m09s**, with sibling agents queued behind it. The lock wrapper flagged it. The final round was deliberately narrowed to the ratchet family plus the affected package (6m59s). Worth noting on the card if this seat keeps bundling that way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_