### PR TITLE
docs(protocol): name the exception path's "health-check" check entry

### DIFF
--- a/content/docs/protocol/kernel/lifecycle.mdx
+++ b/content/docs/protocol/kernel/lifecycle.mdx
@@ -741,9 +741,15 @@ this shape over HTTP — it is an in-process model, not a wire body.
 `checks` is an **array**, and a check's `status` is `"passed" | "failed" |
 "warning"` — the six-value `"healthy" | "degraded" | "unhealthy" | "failed" |
 "recovering" | "unknown"` vocabulary belongs to the report's own top-level
-`status`, never to an entry inside `checks`. Each entry is named after the
-plugin's configured `checkMethod`, or `"plugin-loaded"` when a plugin configures
-none. `metrics.uptime` is in **milliseconds** (`Date.now() - startTime`), unlike
+`status`, never to an entry inside `checks`. An entry's `name` is one of three:
+
+| Entry `name` | Pushed when |
+| :--- | :--- |
+| the plugin's configured `checkMethod` | the custom check ran and returned — `"passed"`, or `"failed"` for the two failing shapes above |
+| `"plugin-loaded"` | no `checkMethod` is configured, **or** the configured name does not resolve to a function on the plugin |
+| `"health-check"` | the check **threw** — a `timeout` overrun included, since the race surfaces it as a rejection. A fixed name, neither the method's nor the default's, and always `status: "failed"` |
+
+`metrics.uptime` is in **milliseconds** (`Date.now() - startTime`), unlike
 the seconds-valued `uptime` of `GET /health` above, and the report carries no
 `version` field — it identifies its plugin by the key it is stored under. The
 optional `message` is set only when a check fails; the schema's remaining


### PR DESCRIPTION
Fixes #11823

## What changed

`content/docs/protocol/kernel/lifecycle.mdx` — the `checks[].name` enumeration below the
`PluginHealthReport` JSON block. It named two of the three names `PluginHealthMonitor` can push
and read as exhaustive, so a reader debugging the most alarming report the monitor emits found an
entry name the page said could not occur.

The two-clause sentence becomes a three-row table. The file already uses `| Declaration | Semantics |`
tables for exactly this name-to-meaning shape (4 tables, 19 rows), and the reader's task here is
reverse lookup — "I see `health-check`, what produced it?" — which a table serves better than a
third clause in an already dense paragraph.

The `PluginHealthReport` JSON block above is **untouched** — proven, not asserted: the block at
lines 728-740 is byte-identical between `a1c804bc9` and this branch (`diff` of the two extractions
is empty).

## Re-derivation on `origin/main` (`a1c804bc9`), not the card's line numbers

The card's cited lines were re-derived rather than trusted, since three PRs moved this area
(#11789, #11812, #11822 — the last landed as `f7eff23ed`). All three of its claims hold:

| Claim | Verdict on current `main` |
| :--- | :--- |
| Three push sites | Confirmed. `grep -rn "checks\.push"` over `packages/ apps/ examples/ scripts/` returns **4 hits, all in `health-monitor.ts`** (`:119`, `:121`, `:125`, `:172`) yielding **3 distinct names**. Line numbers unmoved. |
| `'health-check'` is the only literal on the catch path | Confirmed. The `catch (error)` at `:166` contains exactly one `checks.push`, `name: 'health-check'` at `:173`. |
| `raceCheckTimeout` surfaces a timeout as a **throw** | Confirmed. `:340-344` **rejects** with `new Error(message)`; `Promise.race` at `:347` propagates it out of the `await` at `:110`, inside the `try`. A timeout therefore lands in the same `catch`. |
| No fourth entry name exists | Confirmed. `PluginHealthMonitor` is the only producer of a `PluginHealthReport` in the repo; the other references are the spec schema and its tests. |

**One card claim needed correcting, and the doc reflects the corrected version.** The card says the
exception entry carries `status: 'failed'` with "**no** `failureThreshold` accumulation". The counter
*is* still incremented on the catch path (`:169`); what is skipped is the threshold **comparison** —
`:170` sets `failed` directly, where the returned-failure path reads `config.failureThreshold` at
`:150-151` and lands on `degraded` at `:163` until it is met. The asymmetry the card relies on is
real; its wording overstates it, so the table does not repeat that wording.

The table also does **not** re-explain the status asymmetry, because the paragraph above the JSON
block already states it correctly ("Consecutive returned failures move the plugin to `degraded`
first... A check that **throws** — including one that exceeds `timeout` — is the separate `failed`
status, applied immediately with no threshold"). Restating it in the table would create two
statements of one fact, free to drift apart.

## One bounded in-place correction, named rather than slipped in

While rewriting the clause, the `"plugin-loaded"` condition was corrected in the same sentence:
the doc said it applies "when a plugin configures none", but `:109` guards on
`config.checkMethod && typeof (plugin as any)[config.checkMethod] === 'function'` — so the default
entry is **also** pushed when a `checkMethod` is configured but does not resolve to a function on the
plugin. That is the same defect class as the card's (a reader seeing an entry name the page says
cannot occur), in the same clause being rewritten, mechanically pinned by the source, and it adds no
verification surface. The card's own measured table states the same fuller condition.

## Verification

Gate union re-run **after** the final commit, at `bd5de01b6` — 17/17 green. The set was derived
with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path
list) against this repo's tree at `a1c804bc9`. Each gate's own verdict line, not a bare `$?`:

- `check:doc-authoring` — `✓ doc authoring guard: 389 files clean — no bare metadata literals.`
- `check:doc-anchors` — `✅ 278 internal #fragment link(s) across 408 source file(s) all resolve to a real heading`
- `check:role-word` — `OK, no new occurrences of the reserved word.` (225 files across 2 roots)
- `check:nul-bytes` — `OK (scanned 6598 text file(s) ... no raw ASCII control bytes)`
- `check:liveness`, `check:empty-state`, `check:strictness-ledger`, `check:variant-docs` — green
- `check:doc-formula-expressions`, `check:doc-security-posture`, `check:docs-audit-scope`,
  `check:docs-redirects`, `check:published-readme-links`, `check:react-page-adapter-contract`,
  `check:doc-frontmatter`, `check:section-landing-index`, `check:cross-package-test-inputs` — green

`check:doc-formula-expressions` and `check:doc-security-posture` first exited 1 with
`PREREQUISITE NOT MET — the workspace package is not built`. That measured nothing; both are green
above after `turbo run build --filter=@objectstack/lint --filter=@objectstack/formula`.

MDX compiles with the new table: `pnpm exec fumadocs-mdx` in `apps/docs` → rc 0.

**Repo-wide `pnpm lint` narrowing, declared and measured** — eslint governs **zero** files in this
diff. Read from eslint's own config resolution, not assumed:
`eslint --no-inline-config --format json content/docs/protocol/kernel/lifecycle.mdx` returns 1 result
entry, `errorCount: 0`, whose only message is `File ignored because no matching configuration was
supplied` — the flat config supplies no configuration for `.mdx`. The diff is exactly 1 file and
touches no eslint config, so no untouched file's verdict can move.

## No changeset

Docs-only, and `dispatch-gates.mjs` says as much ("write one unless this card is docs-only"). This
matches all three sibling PRs on this same file — #11789, #11812 and #11822 each landed as a
single-file `content/docs/**` commit with no `.changeset/` entry. `skip-changeset` applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_