### PR TITLE
docs(adr): ADR-0091 D1 — delegated_from is retired from sys_user_permission_set

### DIFF
--- a/docs/adr/0091-grant-lifecycle-and-recertification.md
+++ b/docs/adr/0091-grant-lifecycle-and-recertification.md
@@ -64,7 +64,10 @@ sells recertification campaigns on top of exactly this substrate.
 | `valid_until` | Grant is inactive **at and after** this instant (half-open `[from, until)`, UTC). Null = never expires. |
 
 Plus lifecycle-audit columns shared by D3/D4/D5: `reason` (free text, required
-for delegation/break-glass rows), `delegated_from` (user id, D3),
+for delegation/break-glass rows), `delegated_from` (user id, D3 — retired from
+`sys_user_permission_set` per the #9730 ruling, ADR-0049 enforce-or-remove;
+still declared and runtime-enforced on `sys_user_position` only — see the
+ADR-0087 semantic ledger entry `ups-delegated-from-column-retired`),
 `last_certified_at` / `certified_by` (D5).
 
 Deliberately **not** effective-dated: `sys_position_permission_set` (bindings


### PR DESCRIPTION
Fixes #9997

## What

ADR-0091 D1's declaration list still said `delegated_from` was a lifecycle-audit
column shared by both grant tables (`sys_user_position` and
`sys_user_permission_set`). That went stale on 2026-08-18 when the maintainer's
ruling on #9730 (ADR-0049 enforce-or-remove: REMOVE), landed via merged PR
#9998, retired `delegated_from` from `sys_user_permission_set` — the column
stays declared and runtime-enforced only on `sys_user_position`. No PR since
has amended `docs/adr/0091-grant-lifecycle-and-recertification.md`, so a
reader of D1 alone was still being told the pre-#9730 shape.

This PR amends the one sentence in D1's declaration list to record the
post-#9730 shape, and points the reader at the two places that carry the
actual decision: the #9730 ruling and the ADR-0087 semantic ledger entry
`ups-delegated-from-column-retired`.

## Scope

Exactly D1's declaration list (`docs/adr/0091-grant-lifecycle-and-recertification.md`,
one paragraph, ~4 lines). D3's delegation semantics and the
`sys_user_position` declaration are untouched — confirmed both were already
accurate (D3 already describes the delegation row as a `sys_user_position`
insert only).

## Verified on `origin/main` before editing

- `delegated_from` is gone from `sys_user_permission_set`
  (`packages/plugins/plugin-security/src/objects/sys-user-permission-set.object.ts`)
  — only retirement comments remain, no `Field.*` declaration; positive
  control: the sibling `reason` field is present as a real `Field.text(...)`
  declaration on the same object, ruling out a search-methodology false zero.
- `delegated_from` is still declared (`Field.lookup('sys_user', …)`) on
  `sys_user_position`
  (`packages/plugins/plugin-security/src/objects/sys-user-position.object.ts:112`).
- The ADR-0087 semantic ledger entry `ups-delegated-from-column-retired`
  exists, spelled exactly that way
  (`packages/spec/src/migrations/entries/semantic/17.ups-delegated-from-column-retired.ts`).
- ADR-0091 D1 had not been touched by any PR since acceptance (`git log` on
  the file shows nothing since the two 2026-07 accept/L1/L2 commits) — the
  premise was not self-resolved.

## Governed surface

`docs/adr/**` — this PR stays **draft**, is never armed for auto-merge or
queued, and the hand-merge is the review record (Prime Directive #14).
Requesting review from `os-zhuang` per the triage grading on the issue.

## Gates (at `7bc9cca2a`, the head commit — working tree matched it exactly when these ran)

Derived live via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`:

- `pnpm check:adr-anchors` — `check-adr-anchors: OK (52 anchored file(s), every governing ADR still referenced; 123 decision number(s), each naming one decision or an allowlisted pair; 27974 citation(s) across 3511 file(s) resolve).`
- `pnpm check:doc-authoring` — `✓ doc authoring guard: 389 files clean — no bare metadata literals.`
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 421 files / 1448 TS blocks judged clean` (plus the TSDoc and field-level `*When` sub-checks, all clean)
- `pnpm check:pm-governed-merges` — self-test: 129 assertions held
- `node scripts/check-adr-links.mjs` — `✅ check-adr-links: 551 relative link destination(s) under docs/adr/ resolve`

Also ran `node scripts/check-nul-bytes.mjs` (repo-wide gate, any edit) — clean.

## Changeset

None — docs-only, no user-facing/published change. `skip-changeset` label
applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_