### PR TITLE
docs(adr): repair ADR-0082's golden-page citation — the moved path, and an `os validate` output that never renders

### DIFF
--- a/docs/adr/0082-react-component-contract-governance.md
+++ b/docs/adr/0082-react-component-contract-governance.md
@@ -96,7 +96,7 @@ spec zod schema  ──gen──►  react-blocks.md      (AI reads it — decis
                            (hard: missing-required / typo)
 ```
 
-`examples/app-showcase/src/pages/renewals-pipeline.page.ts` is the **golden page**: authored straight from the contract (five server-connected blocks), it passes `os validate`; injecting a missing required `objectName` and an `onSucces` typo makes the gate fail with an error + a warning (captured in `docs/audits/2026-06-react-tier-authoring-dogfood.md`). The chain demonstrably closes.
+`examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts` is the **golden page**: authored straight from the contract (five server-connected blocks), it passes `os validate`; injecting a missing required `objectName` makes the gate fail, and an `onSucces` typo is a separate, non-fatal advisory — the error gate exits before advisories are printed, so no one run shows both (each output is captured in `docs/audits/2026-06-react-tier-authoring-dogfood.md`). The chain demonstrably closes. *(#10808: this cited the page's pre-move path — it sits one directory deeper now — and said the two mistakes make the gate fail "with an error + a warning", which reads as one run rendering both. The severity split is real; the single run showing both never was.)*
 
 ---
 


### PR DESCRIPTION
Fixes #10808

`docs/adr/0082-react-component-contract-governance.md` decision 6 cites the react-tier golden page. Two pieces of that citation had rotted. Both were **re-measured against current `main` (`fd50e59e7`)** before the edit — the card measured at `b05a543654` and warned of same-day churn, so nothing here is inherited from it.

The ADR's ruling and its conclusion ("the chain demonstrably closes") are **untouched**. This repairs an illustration, not a decision.

## 1. The path moved

`examples/app-showcase/src/pages/renewals-pipeline.page.ts` does not exist; the page sits one directory deeper, at `examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts`.

The zero is reported beside positive controls, so it carries information:

| grep (tree, excluding `node_modules`/`.git`) | hits |
|---|---|
| `app-showcase/src/pages/` — the old prefix | 5 |
| `app-showcase/src/ui/pages/` — the new prefix (positive control) | 20 |
| `renewals-pipeline.page.ts` — bare filename (positive control) | 11 |

Of the 5 old-prefix hits, 4 are in `docs/audits/2026-06-react-tier-authoring-dogfood.md` and every one of them is **deliberate**: its 2026-08-21 superseded header quotes the old path as the thing that moved, and its body is left as written on purpose ("An audit is a dated record of what someone actually observed"). The 5th was ADR-0082 line 99. So the card's claim holds — that line was the tree's only *uncorrected* citation of the old path. No adjacent citation needed fixing, and none was touched.

## 2. "an error + a warning" describes an output the CLI never renders

This is the load-bearing half, so it was measured, not read. The CLI and the showcase app's dependency closure were built in this worktree (`pnpm --filter '@objectstack/cli...' build`, `pnpm --filter '@objectstack/example-showcase^...' build`, both under the shared verify lock), then the two mistakes were injected into the golden page by a script holding `trap restore EXIT INT TERM`. Each mutation was confirmed **on disk** by an anchored `grep -c` over both the injected and the deleted text — never by the editor's exit code.

| run | injected | exit | what printed |
|---|---|---|---|
| 0 | nothing (baseline) | 0 | `✓ Validation passed (1007ms)`, 31 advisories, none of them the typo |
| 1 | missing required `objectName` **and** the `onSucces` typo | 1 | `✗ Author-time rules failed (1 issue)` — the error only. **`onSucces` occurs 0 times in the entire output.** |
| 2 | the `onSucces` typo alone | 0 | `✓ Validation passed (1031ms)` plus the `⚠ … has prop "onSucces" — did you mean "onSuccess"?` advisory (advisory count 31 → 32: exactly the one added) |

Run 1, verbatim:

```
  → Running author-time rules (41)...

  ✗ Author-time rules failed (1 issue)
  • page "showcase_renewals_pipeline" › <ObjectChart>: <ObjectChart> is missing the required prop "objectName".
      Pass objectName={…}. See the react-tier component contract.
      rule: react-prop-missing-required  at pages[27].source
                                                 # exit 1
```

Run 2, the advisory that run 1 never reaches:

```
  ✓ Validation passed (1031ms)
  …
  ⚠ page "showcase_renewals_pipeline" › <ObjectForm>: <ObjectForm> has prop "onSucces" — did you mean "onSuccess"?
                                                 # exit 0
```

The early exit the card names is still where it says: `packages/cli/src/commands/validate.ts` splits the author-time findings by severity and, on `ruleErrors.length > 0`, prints the errors and calls `this.exit(1)` — the advisory rendering (`console.log(chalk.yellow(...))`) sits far below that return point.

So the **severity split is real and intact**, and the new wording preserves it: a missing required binding is fatal, a near-miss prop name is a non-fatal advisory. Only "one run shows both" was wrong.

After the runs, `git status --porcelain` was empty — the injected file restored byte-for-byte by the trap.

## The edit

One line, `docs/adr/0082-react-component-contract-governance.md:99`. The path is corrected, the parenthetical is reworded to keep the severity split while dropping the impossible interleaving, and an in-place correction note follows the ADR's own house style (compare the `#4472` / `#5960` notes elsewhere in the file). No counts, no shas, no line numbers are baked into the prose — the citation stays the audit, whose dated header carries the measured output and cannot rot the way a number does.

## Gates

Derived live at the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list), then run at `f9637fd79` with a clean working tree. Verdict lines as each gate printed them:

```
check-adr-anchors: OK (52 anchored file(s), every governing ADR still referenced; 123 decision number(s), each naming one decision or an allowlisted pair; 27972 citation(s) across 3511 file(s) resolve).
✓ doc authoring guard: 389 files clean — no bare metadata literals.
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 421 files / 1448 TS blocks judged clean by @objectstack/formula.
✓ check-governed-merges --self-test: 129 assertions (…)
✅ check-adr-links: 551 relative link destination(s) under docs/adr/ resolve
check-nul-bytes: OK (scanned 6631 text file(s) -- 6631 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).
```

`check:nul-bytes` is not path-derived for this card; it was run anyway because the diff was edited by hand.

## Deliberately not done

- **Stays a draft.** `docs/adr/**` is a governed surface (Prime Directive #14): never flipped ready, never queued, never auto-merged. Review requested from `os-zhuang`; the maintainer's hand-merge is the review record.
- **No changeset** — docs-only, publishes nothing; `skip-changeset` applied instead.
- **No sweep.** Other ADRs were not read for similar rot, and the audit's deliberate old-path quotations were left exactly as they are.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_

---
_Generated by [Claude Code](https://claude.ai/code)_