### PR TITLE
docs(qa): retarget rollup-summary-filter editor half at duplicate route

### DIFF
--- a/docs/qa/platform-checklist/areas/automation.json
+++ b/docs/qa/platform-checklist/areas/automation.json
@@ -254,7 +254,7 @@
       "title": "Filtered roll-up summaries recompute only through their own filter",
       "since": "v16",
       "status": "active",
-      "revision": 2,
+      "revision": 3,
       "priority": "P1",
       "surface": "mixed",
       "personas": [
@@ -263,10 +263,8 @@
       "fixtures": {
         "app": "showcase",
         "requires": [
-          "a parent with several filtered roll-ups in different filter shapes (showcase_expense_report: equality / boolean / operator / unfiltered)"
-        ],
-        "knownGaps": [
-          "the visual filter-editor half needs a summary field in a WRITABLE package — the showcase ships read-only, so Studio editing is not reachable on stock fixtures (#3358)"
+          "a parent with several filtered roll-ups in different filter shapes (showcase_expense_report: equality / boolean / operator / unfiltered)",
+          "the editor-half clause additionally needs a writable target package — obtained at runtime via POST /packages/:id/duplicate (ADR-0070 D4 'duplicate base'), not a stock fixture"
         ]
       },
       "steps": [
@@ -276,7 +274,7 @@
         "PATCH one line's status approved→rejected over /api/v1/data/showcase_expense_line/:id; re-read the parent and recompute again",
         "PATCH a different line's billable true→false; re-read the parent",
         "DELETE one line; re-read the parent — a delete must move every roll-up whose filter matched the deleted row, including the unfiltered total",
-        "(editor half, blocked) on a writable package: edit a summary field's child-row filter in Studio's visual filter editor, save, and re-read the persisted metadata"
+        "on a writable package: POST /packages/com.example.showcase/duplicate {targetPackageId: <scratch id>} (ADR-0070 D4 'duplicate base' — the platform's supported writable-base route) to clone the showcase base, then in Studio's visual filter editor edit the duplicated expense-report's summary field child-row filter, save, and re-read the persisted metadata over the meta API"
       ],
       "acceptance": [
         {
@@ -304,25 +302,23 @@
           "evidence": "before/after value table"
         },
         {
-          "clause": "the child-row filter is settable via the visual editor on a writable package",
+          "clause": "the child-row filter is settable via the visual editor on a writable package obtained through the platform's own duplicate-base route",
           "oracle": "screenshot",
-          "verify": "edit a summary field's filter in Studio on a writable package and confirm the persisted metadata via the meta API",
+          "verify": "POST /packages/com.example.showcase/duplicate to clone the showcase base into a writable target package (ADR-0070 D4), open the duplicated parent's summary field in Studio's visual filter editor, edit its child-row filter, save, and confirm the persisted metadata via the meta API",
           "evidence": "editor screenshot + saved metadata read"
         }
       ],
       "negative": [
         "an untouched-filter roll-up that moves on an edit outside its filter (e.g. rejected_count changing on the billable flip) is a FAIL even if every touched value is right"
       ],
-      "blocked": {
-        "by": "fixture",
-        "ref": "#3358 (editor half needs a writable-package summary field fixture)"
-      },
       "traps": [
         "seed-data-thin"
       ],
       "source": [
         "#3358 §2 (recompute half proven; editor half explicitly left unticked)",
-        "examples/app-showcase/src/data/objects/expense-report.object.ts (the six roll-up shapes and their filters)"
+        "examples/app-showcase/src/data/objects/expense-report.object.ts (the six roll-up shapes and their filters)",
+        "packages/runtime/src/domains/packages.ts (POST /packages/:id/duplicate — ADR-0070 D4 'duplicate base', the writable-target route)",
+        "docs/adr/0070-package-first-authoring.md §D4 ('clone a base into a new writable package')"
       ],
       "history": [
         {
@@ -336,6 +332,12 @@
           "date": "2026-08-07",
           "change": "expanded to deep-test contract: concrete steps, multi-clause acceptance, negatives, variants",
           "ref": "claude/platform-test-checklist-ocwugl"
+        },
+        {
+          "revision": 3,
+          "date": "2026-08-25",
+          "change": "retargeted clause 5 (the visual filter-editor half) at the platform's supported runtime path per the maintainer ruling on #9788 (2026-08-19, 「接受你的所有建议」): the stock showcase does NOT boot with a writable package, so the runner instead clones the showcase base via POST /packages/:id/duplicate (ADR-0070 D4 'duplicate base') to get a writable target for the visual editor. Removed the item-level blocked.by:fixture entry and the matching fixtures.knownGaps line — the clause is runnable on every boot now, not fixture-blocked. Oracle stays screenshot: the clause specifically tests the VISUAL editor, corroborated by a meta-API read of the persisted filter",
+          "ref": "#9788"
         }
       ]
     },


### PR DESCRIPTION
Part of #9788.

## What

Retargets `automation.rollup-summary-filter` clause 5 (the visual filter-editor half, `docs/qa/platform-checklist/areas/automation.json`) at the platform's supported runtime path, per the maintainer ruling on #9788 (2026-08-19, verbatim: 「接受你的所有建议」): the stock showcase does **not** boot with a project-scoped writable package. The runner instead clones the showcase base into a writable target via `POST /packages/:id/duplicate` (ADR-0070 D4 "duplicate base") before exercising Studio's visual filter editor.

Changes to the item:
- `steps` — the editor-half step now names the duplicate-route call instead of "(editor half, blocked)".
- `acceptance` clause 5 — retargeted wording; **oracle stays `screenshot`**, since the clause specifically tests the *visual* editor (corroborated by a meta-API read of the persisted filter), not just the API.
- Removed the item-level `blocked: {by: "fixture", ref: "#3358 …"}` block and the matching `fixtures.knownGaps` entry — the clause is runnable on every boot now, not fixture-blocked.
- Added `fixtures.requires` and `source` entries citing the duplicate route (`packages/runtime/src/domains/packages.ts`) and ADR-0070 §D4.
- `revision` 2 → 3, with a `history` entry recording the retarget and its rationale.

## Verified before writing

- `POST /packages/:id/duplicate` exists (`packages/runtime/src/domains/packages.ts:819`) and really produces a writable package — its own `requireWritablePackage` refusal message names this exact route as the remedy ("duplicate this one into a writable base … and change that"), and `protocol.duplicatePackage` (`packages/metadata-protocol/src/protocol.ts:16807`) explicitly strips `scope` from the manifest copy because "the whole point of a duplicate is a WRITABLE base." ADR-0070 §D4 names the same gesture ("clone a base into a new writable package — the Airtable 'duplicate base' gesture").
- Re-read `automation.json` on `origin/main` first: clause 5, the `blocked.by:fixture` entry and its `ref: #3358` were all still present as the card described — premise held, nothing was retargeted already.

## Scope

Only `docs/qa/platform-checklist/areas/automation.json`. The sibling half named in the ruling — `docs/qa/platform-checklist/areas/access-security.json` → `access-security.readonly-package-locks-studio` — is out of scope: #11780 already has that file in its changed-file list, so this PR leaves it untouched.

## Local gates

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (run against the final commit `86c4a39b9`) names two matched families for this diff, both green:

- `pnpm check:doc-authoring` — "389 files clean — no bare metadata literals."
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — self-test 50/50, "22 record-scoped formula example(s) … judged clean," "9 @example(s) judged clean," "14 predicate(s) … judged clean; 6 skipped as undeterminable" (documented, unrelated to this diff).

`check:platform-checklist` is not CI-wired (manual cadence by maintainer decision — README), so `dispatch-gates.mjs` does not name it, but the area README asks for it "whenever you touch the checklist," so it was run anyway: `check-platform-checklist: OK — 15 areas, 207 items (207 active); coverage: 31 kinds mapped, 0 waived; traps: 19 documented, 19 in use; provisioning: 4 area recipes, 7 item references resolved (1 area-qualified), 4/4 recipes referenced.`

No changeset — QA-checklist-only change, nothing user-visible or published. `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_