### PR TITLE
fix(qa): correct rootDir comment that opens "No rootDir" above one that sets it

### DIFF
--- a/packages/qa/dogfood/tsconfig.json
+++ b/packages/qa/dogfood/tsconfig.json
@@ -8,13 +8,14 @@
     "skipLibCheck": true,
     "noEmit": true,
     "types": ["node"],
-    // No `rootDir`. This project emits nothing (`noEmit`), so `rootDir` never
-    // shaped an output layout here — its only effect was to forbid importing a
-    // sibling package's SOURCE file, and the route-ledger ↔ live-mount parity
-    // gate (#7526) must read the five ledgers exactly that way: each one is
-    // package-internal on purpose (the guard's data, not public API), so there
-    // is no entry point to import them from. Every other ledger guard in the
-    // repo compiles them as relative sources for the same reason.
+    // `rootDir` is set to the repo root — wide enough to be a no-op. This
+    // project emits nothing (`noEmit`), so `rootDir` never shaped an output
+    // layout here — its only effect was to forbid importing a sibling
+    // package's SOURCE file, and the route-ledger ↔ live-mount parity gate
+    // (#7526) must read the five ledgers exactly that way: each one is
+    // package-internal on purpose (the guard's data, not public API), so
+    // there is no entry point to import them from. Every other ledger guard
+    // in the repo compiles them as relative sources for the same reason.
     "rootDir": "../../.."
   },
   "include": ["test/**/*"],


### PR DESCRIPTION
Fixes #11476

## History (full clone, not the finder's shallow one)

`git log --follow` on `packages/qa/dogfood/tsconfig.json` shows three touches:

1. `10c2b854f` (2026-07-20, #3349, docs-only PR) — file **created** with
   `"rootDir": "."` and no comment.
2. `cc3555e78` (2026-08-11, #7526/#7584) — **the same commit** both (a) added
   the seven-line comment and (b) changed `rootDir` from `"."` to `"../../.."`.
   `git log -S` on the literal string `rootDir` on this path finds only these
   two commits (positive control: the same search technique reliably finds
   real hits — confirmed against `#7526` elsewhere in history — so the result
   here isn't a broken search).
3. `d41d99047` (2026-08-23, #11474, this same PM session) — dropped the dead
   `src/**/*` include glob and explicitly left `rootDir`/its comment
   "deliberately untouched", per #10899's scope fence on this file.

So `rootDir` was **not** added after the comment was written — the comment's
opening sentence was wrong from the moment it was introduced, in the same diff
that set the value it denies two lines below. There is no earlier form of
this file where "no `rootDir`" was true.

## Why disposition 1, not 2

Removing `rootDir` (disposition 2) would need evidence the file was *meant*
to have none. There isn't any — the opposite, if anything: `rootDir` has been
present since the file's creation (as `"."`, TS's own default), and the
commit that broadened it to `"../../.."` did so on purpose, to admit the
sibling-package ledger imports the parity gate needs (below). Nothing in the
history argues for removing it, so per triage's default this stays
disposition 1: fix the wording, keep the declaration.

## The comment's own argument still checks out

Verified the premise the comment relies on rather than inheriting it: the one
file in the package importing outside it,
`test/route-ledger-live-mount-parity.dogfood.test.ts`, resolves all five of
its relative imports (`../../../runtime/src/route-ledger.js`,
`../../../rest/src/rest-route-ledger.js`, and three more) to `packages/**` —
three `../` segments up from `packages/qa/dogfood/test/`, i.e. inside the
`../../..` (repo root) bound. No import anywhere in the package goes deeper.
So the declared `rootDir` never actually constrains anything here, exactly as
the comment's body (correctly) argues — only its opening sentence contradicted
the line beneath it.

## The fix

One-sentence correction; the rest of the comment is untouched content-wise
(only re-wrapped for line width by the change in opening-sentence length):

```diff
-    // No `rootDir`. This project emits nothing (`noEmit`), so `rootDir` never
-    // shaped an output layout here — its only effect was to forbid importing a
+    // `rootDir` is set to the repo root — wide enough to be a no-op. This
+    // project emits nothing (`noEmit`), so `rootDir` never shaped an output
+    // layout here — its only effect was to forbid importing a sibling
     ... (unchanged: parity-gate / five-ledgers reasoning, verbatim)
```

No behaviour change: `tsc --showConfig -p packages/qa/dogfood/tsconfig.json`
is byte-identical before/after this edit (`compilerOptions`, `include`,
`exclude`, `files` all unchanged — JSONC comments are stripped before
parsing), and `pnpm --filter @objectstack/dogfood typecheck` passes clean.

## Scope

Comment text only, in this one file — no other tidying, per #10899's standing
fence on this file.

## Gates

No changeset: comment-only edit inside a `tsconfig.json`, nothing publishable
changes. `skip-changeset` label applied.

Local gates (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
against `packages/qa/dogfood/tsconfig.json`), all green at `7b93b7521`:

- `pnpm --filter @objectstack/dogfood typecheck` — clean, 0 errors
- `pnpm check:published-files` — self-test (21+12+4 cases) + live, pass
- `pnpm check:slot-lookup` — ratchet holds, 0 new sites
- `pnpm check:test-source-alias` — self-test + live, 72 packages scanned, pass
- `pnpm check:type-source-resolution` — self-test + live, 77 packages scanned, pass
- `node scripts/check-plugin-teardown-shape.mjs` — 0 known-unreached, pass
- `node scripts/docs-audit/check-affected-docs.mjs` — pass
- `node scripts/docs-audit/check-drift-comment.mjs` — 56 cases pass
- `pnpm --filter @objectstack/spec run check:empty-state` — all classified, pass
- `pnpm --filter @objectstack/spec run check:liveness` — pass (one pre-existing,
  unrelated warning: an unregistered dogfood proof tag in
  `admin-platform-admin-standing.dogfood.test.ts`, a different file this PR
  never touches)
- `pnpm --filter @objectstack/spec run check:strictness-ledger` — pass
- `pnpm --filter @objectstack/spec run check:variant-docs` — 18 unions governed/exempt, pass

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_