### PR TITLE
fix(devx): cap `pnpm test` concurrency at 50% of the host's own cores

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:crm": "node scripts/check-dev-prereqs.mjs && pnpm check:console-sha && pnpm --filter @objectstack/example-crm dev",
     "dev:todo": "node scripts/check-dev-prereqs.mjs && pnpm check:console-sha && pnpm --filter @objectstack/example-todo dev",
     "spec:rebuild": "turbo run build --filter=...@objectstack/spec",
-    "test": "turbo run test --concurrency=100%",
+    "test": "turbo run test --concurrency=50%",
     "test:e2e": "turbo run test:e2e",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:crm": "node scripts/check-dev-prereqs.mjs && pnpm check:console-sha && pnpm --filter @objectstack/example-crm dev",
     "dev:todo": "node scripts/check-dev-prereqs.mjs && pnpm check:console-sha && pnpm --filter @objectstack/example-todo dev",
     "spec:rebuild": "turbo run build --filter=...@objectstack/spec",
-    "test": "turbo run test",
+    "test": "turbo run test --concurrency=100%",
     "test:e2e": "turbo run test:e2e",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf dist",


### PR DESCRIPTION
Fixes #11938

## What

`pnpm test` (`turbo run test`, no `--concurrency`) falls through to turbo's
built-in default of **10** parallel tasks. On this container (4 CPU / ~15 GB,
confirmed via `nproc`/`free -h`; the cgroup carries no lower limit than the
host's own memory), that fan-out — each `test` task additionally forking its
own vitest worker pool, since only 1 of 41 `vitest.config.ts` files in the
repo declares `poolOptions`/`maxWorkers` — gets the process killed by the
kernel OOM killer (exit 137) before 16 of 91 tasks ever run (the card's own
measurement, reproduced twice with `dmesg` confirmation).

Fix: the root `test` script now runs `turbo run test --concurrency=50%`.
`50%` is turbo's own percentage syntax (`--concurrency=<N>%`, resolved
against `available_parallelism()` **at invocation time**, confirmed by
reading the turbo binary's own validation strings) — environment-derived,
not a hard low constant: it scales with whatever box actually runs it.

**This changes zero CI behaviour.** Every `turbo run test` invocation in
`.github/workflows/*.yml` already passes an explicit `--concurrency=4` (a
CLI flag always wins over the script default) and nothing calls the root
`pnpm test` script directly (grepped every workflow). The only invocation
this changes is the bare `pnpm test` / `turbo run test` with no flag — the
local / agent-container path #11938 is about.

## Why `50%`, not `100%` (revised mid-PR — see commit history)

The first commit on this branch shipped `--concurrency=100%` (→ 4 on this
box), reasoned from real production evidence: `ci.yml`'s Test Core job and
`rerun-safety-nightly.yml`'s full-suite double pass both already run at a
literal `--concurrency=4` on this repo's only CI shape (`ubuntu-latest`,
confirmed 4 vCPU/16GB via every `runs-on:` in every workflow — there is no
"larger CI shape" in this repo today, so the two-runtime ask collapses to
"this container" + "the identical shape CI already proves" for the repo as
it stands). Sampled several `rerun-safety-nightly` runs via the GitHub API:
2026-08-21 both passes green (26m44s + 26m30s, 136/136 twice); 2026-08-23/24
"failed" but not from OOM — 135/136, 45-47min, same pre-existing unrelated
`envelope-unwrap.test.ts` hook-timeout flake, no exit 137 anywhere.

**That evidence is real but incomplete on one axis: it only covers boxes
that are exactly this shape.** `--concurrency=100%` is turbo's OUTER
fan-out only. While the fix was being measured live, `ps` showed the actual
process count: 4 concurrent turbo test tasks were running **10 total
vitest worker processes** (~2.5 workers/task) — vitest's own default pool
sizing *also* scales with the host's detected core count, independently of
turbo's `--concurrency`. The two multiply. On a hypothetical bigger box that
compounds rather than staying proportional (outer fan-out grows *and* each
task's own inner fan-out grows), so `100%` is not a safe linear scale-up —
and since turbo's OLD flat default was 10 regardless of box size, `100%` on
any box with more than 10 cores is a real **increase** in outer fan-out over
today's behaviour, in the opposite direction from the defect this PR fixes.
No such box exists in this repo's CI to measure directly, so rather than
ship an unverified increase, the value was revised down. Filed the inner
lever itself as its own follow-up: #11958.

`50%` closes that gap without losing the "environment-derived, not a hard
low constant" property:

- On **this** box (4 cores) it resolves to **2** — the exact value the
  original card **itself already measured directly**: 135/136 tasks,
  30m39s, peak ~7.6 GB, real headroom. Not extrapolated — the small-box side
  of this change has direct prior proof.
- `50%` never exceeds turbo's old flat default of 10 until a box has **20+
  cores** — so on every runner shape this repo (or a typical contributor
  machine) actually has today, this change is a decrease or a wash relative
  to current behaviour, never an increase. That directly answers the
  compounding-fan-out risk above without needing a bigger box to prove it on.

## Measured (this container)

- **Build**: `pnpm build` under the shared verify lock — 71/71 tasks, 5m14s,
  clean.
- **`--concurrency=50%` (shipped value) on this container**: not freshly
  re-run by this session as a full suite — resting on the card's own prior
  direct measurement above (135/136, 30m39s, peak ~7.6GB), which is real
  evidence but pre-dates this PR. Disclosing this rather than implying a
  fresh run happened.
- **`--concurrency=100%` (the value this PR shipped, then walked back) on
  this container**: a fresh, real `pnpm test` run was executed live during
  this PR. As of this writing it has been running ~12 minutes, no failing
  test, no OOM signature (no `Killed process`, no exit 137), peak memory
  sampled every 5s topping out at **~8.25 GB** so far (~55% of the ~15GB
  ceiling) — still in progress, not yet at a terminal state. Included as
  **supplementary, monotonic evidence**: `50%` does strictly less concurrent
  work than `100%` on the same box (2 tasks in flight vs 4), so if `100%`
  clears this box without OOM, `50%` clearing it is the expected,
  lower-resource case, not a coincidence needing separate proof — the
  card's own direct measurement of `50%` already confirms it independently
  anyway.
- **Default (10), this container**: not re-triggered deliberately in this
  session. The card's own reproduction (twice, `dmesg`-confirmed cgroup OOM
  kill) already stands as evidence, and deliberately re-inducing an OOM on a
  container **shared with other parallel agents** risks killing an unrelated
  process — the kernel OOM killer doesn't limit itself to the invoking
  process. Flagging this decision rather than silently only running the safe
  side.
- **This container is shared with other agents' work throughout this
  session** (confirmed via `os-verify-lock.sh --status` — queued behind
  another agent's `sweep.sh` for part of the build step). All wall-clock
  numbers above are reported as observed on a shared box, not as clean,
  isolated benchmarks.

## Note: the inner lever (vitest's own worker pool) — filed as #11958

Only `packages/cli/vitest.config.ts` even mentions `poolOptions`/
`maxWorkers` (in a comment about a *rejected* lever) — the other 40 configs
run vitest's own default pool sizing. This is the mechanism behind the
`100%`→`50%` revision above, and it's the reason full-suite
`--concurrency=4` runs in the nightly CI logs (45-47 min) are slower than
the card's `--concurrency=2` run (30m39s) despite using more of the box:
outer fan-out × inner fan-out is oversubscribing a 4-core box, thrashing
rather than parallelizing cleanly. Bounding vitest's own pool directly would
close this more completely, but it's a 41-file change with its own
measurement, and out of the scope this card set ("the root test-concurrency
policy") — filed as #11958 rather than done here.

## Tests

- `pnpm build` — 71/71 tasks, 5m14s, under the shared verify lock.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` —
  0 check families matched `package.json`; nothing else to run for this diff.
- Full `pnpm test` at the shipped value (`50%`/2 on this box): see "Measured"
  above — resting on the card's own prior direct measurement, not a fresh
  run in this session.
- Full `pnpm test` at `100%`/4 on this box: fresh run executed live in this
  session, in progress as of this writing (~12 min elapsed, no OOM
  signature, peak ~8.25GB) — supplementary evidence, not the shipped value.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_
