### PR TITLE
fix(metadata-protocol): warn at load time when a seed defers a required column, and document the ordering constraint at the four pointer-pair sites (#11674)

### DIFF
--- a/.changeset/seed-required-deferral-early-signal.md
+++ b/.changeset/seed-required-deferral-early-signal.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): warn at load time when a seed defers a `required` column, before the engine rejects the row (#11674)
+
+The seed loader defers an unresolvable reference to pass 2 by **deleting the
+column** from the pass-1 row. On a `required: true` column that turns the insert
+into one the write contract rejects (ADR-0113), so the row never lands and pass
+2 has no row to back-fill — measured against the real `ObjectQL` engine in
+`packages/objectql/src/engine-seed-required-deferral.test.ts`. It is the second,
+independent road to the same loud failure that the pass-2 internal-id write-back
+could not clear, and it is why a `required` id half stays **order-dependent**
+even though a declared pointer pair contributes no static ordering edge.
+
+Nothing about that failure was quiet — it is a write error naming the column, a
+dropped-deferral error, and `success: false`. What was missing is **when** the
+author learns: only after the engine rejected the row, from a driver-level
+message that does not mention seeding order. The loader now says it first.
+
+- **Load-time warning, scoped to the required subset.** When a dataset defers a
+  reference on a column the write contract requires on insert, the loader logs
+  one `warn` naming the object, the field, the target object that is not seeded
+  yet, what deferring did to the row, and the fix — order the target dataset
+  first. Emitted before the row reaches the engine, once per dataset and field
+  rather than once per row.
+- **⛔ The accept set is unchanged.** Nothing is counted, nothing reaches
+  `result.errors`, `success` is untouched, and every existing loud failure and
+  its tests are preserved verbatim. Only the log gains a line.
+- **The predicate mirrors the write contract instead of approximating it**
+  (`required && !readonly && !system`, and only on rows headed for an INSERT).
+  Two configurations were measured on the real engine where a deferral on a
+  `required` column is accepted today — an upsert replay taking the UPDATE arm
+  (an omitted column is not a cleared one) and a `readonly` required column
+  (required-validation skips it on insert) — and the warning correctly stays
+  silent on both. They are pinned as controls.
+
+The constraint is also now documented at the four pointer-pair declaration
+sites: `sys_approval_request`, `sys_record_share` and `sys_share_link` must seed
+the target dataset first; `sys_audit_log` (optional id half) is genuinely
+order-independent and says why it differs.

--- a/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
@@ -909,9 +909,11 @@ describe('required-deferral early signal (#11674)', () => {
    * the deferral was taken: pass 1 deleted the column, so only pass 2 can put
    * it back, and its payload is the only `update` carrying that field.
    */
-  function passTwoBackfills(engine: { update: { mock: { calls: unknown[][] } } }, object: string, field: string): number {
-    return engine.update.mock.calls.filter(
-      ([obj, data]) => obj === object && Object.prototype.hasOwnProperty.call((data ?? {}) as object, field),
+  function passTwoBackfills(engine: ReturnType<typeof newService>['engine'], object: string, field: string): number {
+    // Same `as any` reach into the mock the rest of this file uses — the
+    // engine is typed as `IDataEngine`, whose `update` carries no mock.
+    return (engine.update as any).mock.calls.filter(
+      (call: any[]) => call[0] === object && Object.prototype.hasOwnProperty.call(call[1] ?? {}, field),
     ).length;
   }
 

--- a/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts
@@ -865,3 +865,201 @@ describe('pointer-pair adoption per object (#11386)', () => {
     expect(store.sys_automation_run[0].trigger_record_id).toBe('Lisa Thompson');
   });
 });
+
+/**
+ * The load-time EARLY SIGNAL for a deferral on a `required` column — #11674's
+ * B half, ruled by triage on 2026-08-24 as "warn (loud) by default", scoped to
+ * the required subset, and ⛔ NOT allowed to change the accept set.
+ *
+ * The failure it announces was already loud: PR #11830 measured against the
+ * REAL engine (`packages/objectql/src/engine-seed-required-deferral.test.ts`)
+ * that pass 1 defers by DELETING the column, so a `required: true` id half is
+ * rejected at insert and pass-2 write-back can never reach the row. What this
+ * signal changes is WHEN the author learns — the loader now says it before the
+ * write that provokes the rejection, instead of leaving the author to read a
+ * driver-level error after the fact.
+ *
+ * Two failure modes are pinned against, because both look green:
+ *  - a signal that NEVER fires  → the FIRES cases below;
+ *  - a signal that fires on EVERYTHING → the DOES-NOT-FIRE cases, which are
+ *    the ones that give it meaning: an optional id half (`sys_audit_log`,
+ *    genuinely order-independent since #11830), a pointer that resolves in
+ *    pass 1, and the UPDATE arm, where the deleted column is an omitted field
+ *    the write contract never checks.
+ *
+ * The message wording is pinned in ONE case only; the rest match on the
+ * signal's identifying parts (`required`, the field, the target object) so a
+ * reworded line does not fail six tests for one change.
+ */
+describe('required-deferral early signal (#11674)', () => {
+  /** The load-time signal, isolated from every other line the loader logs. */
+  function requiredDeferralWarnings(logger: ReturnType<typeof createLogger>): string[] {
+    return logger.warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => /is `required: true`, but record #/.test(message));
+  }
+
+  /**
+   * Non-vacuity probe: how many pass-2 back-fill writes landed for `field`.
+   *
+   * ⛔ NOT `referencesDeferred` — a successful back-fill GIVES THAT COUNTER
+   * BACK (the loader decrements it when pass 2 heals the row), so a healed
+   * deferral reads as zero and a case asserting `> 0` on it would be asserting
+   * that healing FAILED. The pass-2 write itself is the durable evidence that
+   * the deferral was taken: pass 1 deleted the column, so only pass 2 can put
+   * it back, and its payload is the only `update` carrying that field.
+   */
+  function passTwoBackfills(engine: { update: { mock: { calls: unknown[][] } } }, object: string, field: string): number {
+    return engine.update.mock.calls.filter(
+      ([obj, data]) => obj === object && Object.prototype.hasOwnProperty.call((data ?? {}) as object, field),
+    ).length;
+  }
+
+  it('FIRES when a keyless required id half defers — before the row is written, naming the fix', async () => {
+    const { service, logger, engine, store } = newService(ADOPTER_SCHEMAS);
+
+    const result = await service.load({
+      seeds: [
+        // Approval request BEFORE its target: `record_id` cannot resolve in
+        // pass 1, so the loader defers it by deleting the required column.
+        insertSeed('sys_approval_request', [
+          { process_name: 'flow:discount', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ]),
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // The scenario really deferred — without this the assertion below could
+    // pass against a load that never took the deferral branch at all.
+    const approvalResult = result.results.find((r) => r.object === 'sys_approval_request')!;
+    expect(passTwoBackfills(engine, 'sys_approval_request', 'record_id'), 'no deferral was taken — the signal case is vacuous').toBe(1);
+
+    const warnings = requiredDeferralWarnings(logger);
+    expect(warnings).toHaveLength(1);
+    // The line owes the author three things: WHICH declaration makes this
+    // order-dependent, WHAT the deferral did to the row, and the fix.
+    expect(warnings[0]).toContain('sys_approval_request.record_id is `required: true`');
+    expect(warnings[0]).toContain('REMOVES the column from the pass-1 insert');
+    expect(warnings[0]).toContain('Order the `crm_lead` dataset BEFORE `sys_approval_request`');
+
+    // ⛔ ACCEPT SET UNCHANGED. This engine double does not validate, so the
+    // deferred insert lands and #11830's write-back heals it — exactly as it
+    // did before this signal existed. The warning is a log line and nothing
+    // more: no counter moved, nothing reached `errors`, `success` is untouched.
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(approvalResult.errored).toBe(0);
+    expect(approvalResult.referencesDropped).toBe(0);
+    expect(store.sys_approval_request[0].record_id).toBe(store.crm_lead[0].id);
+  });
+
+  it('DOES NOT FIRE for an OPTIONAL id half deferring the very same way — sys_audit_log stays order-independent', async () => {
+    const { service, logger, store, engine } = newService(ADOPTER_SCHEMAS);
+
+    const result = await service.load({
+      seeds: [
+        insertSeed('sys_audit_log', [
+          { action: 'view', actor: 'admin', object_name: 'crm_lead', record_id: 'Lisa Thompson' },
+        ]),
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // Same shape, same order, same deferral — the ONLY difference from the
+    // case above is that this id half is not `required`.
+    expect(passTwoBackfills(engine, 'sys_audit_log', 'record_id'), 'no deferral was taken — the control is vacuous').toBe(1);
+    expect(requiredDeferralWarnings(logger)).toHaveLength(0);
+
+    // …and it heals, which is why warning here would be a false alarm.
+    expect(result.success).toBe(true);
+    const leadId = store.crm_lead.find((r) => r.name === 'Lisa Thompson')!.id;
+    expect(store.sys_audit_log[0].record_id).toBe(leadId);
+  });
+
+  it('DOES NOT FIRE when the target is seeded first — the constraint is the deferral, not the declaration', async () => {
+    const { service, logger } = newService(ADOPTER_SCHEMAS);
+
+    const result = await service.load({
+      seeds: [
+        LEAD_SEED,
+        insertSeed('sys_approval_request', [
+          { process_name: 'flow:discount', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ]),
+      ] as any,
+      config: CONFIG,
+    });
+
+    // Resolved in pass 1: nothing was deferred, so there is nothing to warn
+    // about. A signal keyed on the `required` DECLARATION rather than on the
+    // deferral would fire here — and then fire on every correctly ordered
+    // seed in the repo.
+    const approvalResult = result.results.find((r) => r.object === 'sys_approval_request')!;
+    expect(approvalResult.referencesDeferred).toBe(0);
+    expect(approvalResult.referencesResolved).toBeGreaterThan(0);
+    expect(requiredDeferralWarnings(logger)).toHaveLength(0);
+    expect(result.success).toBe(true);
+  });
+
+  it('DOES NOT FIRE on the UPDATE arm: an omitted column is not a cleared one, so the replay succeeds today', async () => {
+    const { service, logger, store, engine } = newService(ADOPTER_SCHEMAS);
+    // A row this dataset will MATCH on replay — the dev-server-restart shape.
+    store.sys_approval_request = [
+      { id: 'ar-existing', process_name: 'flow:discount', object_name: 'crm_lead', record_id: 'lead-from-a-previous-run', status: 'pending' },
+    ];
+
+    const result = await service.load({
+      seeds: [
+        {
+          object: 'sys_approval_request',
+          externalId: 'process_name',
+          mode: 'upsert',
+          env: ['prod', 'dev', 'test'],
+          records: [
+            { process_name: 'flow:discount', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'approved' },
+          ],
+        },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // The deferral IS taken (the target is not seeded yet) …
+    const approvalResult = result.results.find((r) => r.object === 'sys_approval_request')!;
+    expect(passTwoBackfills(engine, 'sys_approval_request', 'record_id'), 'no deferral was taken — the control is vacuous').toBe(1);
+    expect(approvalResult.updated).toBe(1);
+    // … but it lands on an UPDATE, where the deleted column is simply omitted
+    // and the write contract never checks it. Warning here would announce a
+    // rejection that does not happen — measured on the REAL engine in
+    // `packages/objectql/src/engine-seed-required-deferral.test.ts`.
+    expect(requiredDeferralWarnings(logger)).toHaveLength(0);
+    expect(result.success).toBe(true);
+    const leadId = store.crm_lead.find((r) => r.name === 'Lisa Thompson')!.id;
+    expect(store.sys_approval_request[0].record_id).toBe(leadId);
+  });
+
+  it('says it ONCE per dataset and field, not once per row', async () => {
+    const { service, logger, engine } = newService(ADOPTER_SCHEMAS);
+
+    const result = await service.load({
+      seeds: [
+        insertSeed('sys_approval_request', [
+          { process_name: 'flow:a', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'pending' },
+          { process_name: 'flow:b', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'pending' },
+          { process_name: 'flow:c', object_name: 'crm_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ]),
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    expect(result.success).toBe(true);
+    expect(passTwoBackfills(engine, 'sys_approval_request', 'record_id')).toBe(3);
+    // Three rows, one ordering mistake, one line. The author's fix is the same
+    // single change for all three — repeating it per row is the noise that
+    // trains readers to skim `warn`.
+    expect(requiredDeferralWarnings(logger)).toHaveLength(1);
+  });
+
+});

--- a/packages/metadata-protocol/src/seed-loader.ts
+++ b/packages/metadata-protocol/src/seed-loader.ts
@@ -302,6 +302,32 @@ export class SeedLoaderService implements ISeedLoaderService {
    * target. Reset per `load`.
    */
   private seedExternalIdByObject = new Map<string, string | string[]>();
+  /**
+   * [#11674] Per seeded object, the fields the WRITE CONTRACT requires a value
+   * for **on insert** — the subset a pass-1 deferral cannot survive.
+   *
+   * Pass 1 defers an unresolvable reference by DELETING the column from the
+   * row (see the deferral branch in {@link loadDataset}). On a `required: true`
+   * column that turns the insert into one ADR-0113 rejects, so the row never
+   * lands and pass 2 has nothing to write back onto — a second, independent
+   * road to the same loud failure that pass-2 write-back cannot clear. This
+   * map is what lets the loader say so BEFORE the engine does, at the moment
+   * the deferral is taken (the early signal, this card's B half).
+   *
+   * The set MIRRORS the write contract's own insert-time predicate rather than
+   * approximating it: `required && !readonly && !system`. A `readonly`/`system`
+   * field is skipped by required-validation on insert, so a deferral on one is
+   * accepted today — signalling there would be a false alarm, and a warning
+   * that fires where nothing fails is how readers are trained to skim `warn`
+   * (AGENTS.md → "Degradation log levels", "Do not over-apply it").
+   *
+   * An instance field for the same reason {@link pointerRefsByObject} is one:
+   * the consumer sits several parameters deep and the map is a per-load
+   * constant. Built in {@link load} step 4.5; reset per `load`. An object whose
+   * definition cannot be resolved gets NO entry — the loader then knows
+   * nothing about `required` there and stays silent rather than guessing.
+   */
+  private requiredOnInsertByObject = new Map<string, Set<string>>();
 
   constructor(engine: IDataEngine, metadata: IMetadataService, logger: Logger) {
     this.engine = engine;
@@ -384,20 +410,40 @@ export class SeedLoaderService implements ISeedLoaderService {
     // is per record anyway. Only `text` fields participate: the spec refuses
     // `referenceVia` on other types at authoring, and metadata at rest that
     // predates that check must not have non-text columns resolved as ids.
+    //
+    // [#11674] The same pass also records which fields the write contract
+    // requires on insert — the subset a deferral cannot survive. One
+    // definition read answers both questions, so the early signal costs no
+    // extra metadata round-trip. See {@link requiredOnInsertByObject}.
     this.pointerRefsByObject.clear();
+    this.requiredOnInsertByObject.clear();
     this.seedExternalIdByObject = externalIdByObject;
+    const definitionScanned = new Set<string>();
     for (const dataset of orderedDatasets) {
-      if (this.pointerRefsByObject.has(dataset.object)) continue;
+      if (definitionScanned.has(dataset.object)) continue;
+      definitionScanned.add(dataset.object);
       const objDef = await this.resolveObjectDefinition(dataset.object);
-      const fields = objDef?.fields as Record<string, { type?: string; referenceVia?: unknown }> | undefined;
+      const fields = objDef?.fields as
+        | Record<string, { type?: string; referenceVia?: unknown; required?: unknown; readonly?: unknown; system?: unknown }>
+        | undefined;
       if (!fields) continue;
       const pairs: Array<{ field: string; objectField: string }> = [];
+      const requiredOnInsert = new Set<string>();
       for (const [fieldName, fieldDef] of Object.entries(fields)) {
         if (fieldDef?.type === 'text' && typeof fieldDef.referenceVia === 'string' && fieldDef.referenceVia.length > 0) {
           pairs.push({ field: fieldName, objectField: fieldDef.referenceVia });
         }
+        // Mirror of the write contract's insert-time predicate, not an
+        // approximation of it — see `requiredOnInsertByObject`.
+        if (fieldDef?.required === true && fieldDef.readonly !== true && fieldDef.system !== true) {
+          requiredOnInsert.add(fieldName);
+        }
       }
       if (pairs.length > 0) this.pointerRefsByObject.set(dataset.object, pairs);
+      // Set unconditionally (even empty): "this object declares no required
+      // field" and "this object's definition never resolved" are different
+      // facts, and only the second may make the loader stay silent.
+      this.requiredOnInsertByObject.set(dataset.object, requiredOnInsert);
     }
 
     // 5. Pass 1: Insert/upsert records, resolving references
@@ -559,6 +605,21 @@ export class SeedLoaderService implements ISeedLoaderService {
      */
     const summariesStaleAtStart = this.summariesStale;
     const errors: ReferenceResolutionError[] = [];
+    /**
+     * [#11674] The early signal's state, for this dataset only.
+     *
+     * `requiredOnInsert` is what the write contract requires a value for on
+     * insert (see {@link SeedLoaderService.requiredOnInsertByObject}); an
+     * object whose definition never resolved has NO entry, and an absent entry
+     * means "unknown", which stays silent. `earlySignalledFields` keeps the
+     * warning to ONE line per dataset+field: a 500-row dataset deferring the
+     * same column defers it for the same reason 500 times, and the author's
+     * fix is the same single ordering change — repeating it per row is the
+     * noise AGENTS.md → "Degradation log levels" says to say once, at the
+     * first degradation.
+     */
+    const requiredOnInsert = this.requiredOnInsertByObject.get(objectName);
+    const earlySignalledFields = new Set<string>();
 
     // Ensure the object's record map exists
     if (!insertedRecords.has(objectName)) {
@@ -789,6 +850,14 @@ export class SeedLoaderService implements ISeedLoaderService {
         continue;
       }
       const record = { ...(seedResult.value as Record<string, unknown>) };
+      /**
+       * [#11674] Deferrals this row took on a column the write contract
+       * requires on insert. Collected during resolution, reported once the
+       * write ACTION for this row is known (below) — the deferral itself is
+       * harmless on an update, where the deleted column is simply an omitted
+       * field the contract never checks.
+       */
+      const requiredDeferrals: Array<{ field: string; targetObject: string; attemptedValue: unknown }> = [];
 
       // Per-tenant tagging: stamp every seeded row with the target org — the
       // caller's explicit `config.organizationId`, or (when none was pinned) the
@@ -1056,6 +1125,16 @@ export class SeedLoaderService implements ISeedLoaderService {
               recordIndex: i,
             });
             referencesDeferred++;
+            // [#11674] Deferring DELETED a column the write contract requires
+            // on insert. Note it now; the signal is emitted once this row's
+            // write action is known — see `signalRequiredDeferrals` below.
+            if (requiredOnInsert?.has(ref.field)) {
+              requiredDeferrals.push({
+                field: ref.field,
+                targetObject: ref.targetObject,
+                attemptedValue: unresolvedItem,
+              });
+            }
           } else {
             // Cannot resolve and no pass 2 will run — skip the whole record.
             // Writing it anyway would either carry the raw natural-key string
@@ -1109,6 +1188,49 @@ export class SeedLoaderService implements ISeedLoaderService {
       if (unresolvedRefError && !config.dryRun) {
         errored++;
         continue;
+      }
+
+      // [#11674] EARLY SIGNAL — emitted here, before this row reaches the
+      // engine, for the deferrals it took on columns the write contract
+      // requires on INSERT.
+      //
+      // Why the row's write ACTION gates it: `decideWriteAction` mirrors
+      // `writeRecord`'s mode/existing logic exactly and is side-effect free,
+      // so it answers "is this an insert?" without writing. On an UPDATE the
+      // deferral's deleted column is an omitted field, which required-
+      // validation never checks (ADR-0113: "a PATCH may not null OUT a
+      // required field", but an omission is not a clear-out) — so an upsert
+      // replay over an existing row succeeds today and must not be warned
+      // about. On a SKIP nothing is written at all.
+      //
+      // ⛔ This changes NO accept behaviour: nothing is counted, nothing
+      // reaches `errors`, `success` is untouched. The load proceeds exactly as
+      // before and the existing loud failure (the engine's write error naming
+      // the column, plus pass 2's dropped-deferral error) is preserved
+      // verbatim — this line only moves WHEN the author learns, from after the
+      // engine's rejection to before the write that provokes it.
+      if (!config.dryRun && requiredDeferrals.length > 0) {
+        if (this.decideWriteAction(record, mode, externalId, existingRecords).action === 'insert') {
+          for (const deferral of requiredDeferrals) {
+            if (earlySignalledFields.has(deferral.field)) continue;
+            earlySignalledFields.add(deferral.field);
+            this.logger.warn(
+              `[SeedLoader] ${objectName}.${deferral.field} is \`required: true\`, but record #${i} defers it to ` +
+                `pass 2: '${String(deferral.attemptedValue)}' names no ${deferral.targetObject} that exists yet. ` +
+                `Deferring REMOVES the column from the pass-1 insert, so an engine that enforces \`required\` ` +
+                `rejects this row and pass 2 has no row left to back-fill — a failure that is reported loudly ` +
+                `either way, just later. Order the \`${deferral.targetObject}\` dataset BEFORE \`${objectName}\` ` +
+                `so the reference resolves in pass 1 (a \`required\` id half is order-dependent; pass-2 healing ` +
+                `only covers optional ones). Reported once per field per dataset.`,
+              {
+                object: objectName,
+                field: deferral.field,
+                target: deferral.targetObject,
+                recordIndex: i,
+              },
+            );
+          }
+        }
       }
 
       // Insert/upsert the record

--- a/packages/objectql/src/engine-seed-required-deferral.test.ts
+++ b/packages/objectql/src/engine-seed-required-deferral.test.ts
@@ -133,14 +133,22 @@ function emptyMetadata(): IMetadataService {
 
 function silentLogger() {
   const calls: Record<string, unknown[][]> = { info: [], warn: [], error: [], debug: [] };
-  return {
-    calls,
-    info: (...a: unknown[]) => { calls.info.push(a); },
-    warn: (...a: unknown[]) => { calls.warn.push(a); },
-    error: (...a: unknown[]) => { calls.error.push(a); },
-    debug: (...a: unknown[]) => { calls.debug.push(a); },
-  } as any;
+  /**
+   * Every line in the ORDER it was emitted, across levels — which is how the
+   * author reads a seed run, and the only shape in which "the loader said it
+   * BEFORE the engine did" (#11674's B half) is a measurable claim rather than
+   * an assertion about two unrelated arrays.
+   */
+  const lines: Array<{ level: string; message: string }> = [];
+  const at = (level: string) => (...a: unknown[]) => {
+    calls[level].push(a);
+    lines.push({ level, message: String(a[0]) });
+  };
+  return { calls, lines, info: at('info'), warn: at('warn'), error: at('error'), debug: at('debug') };
 }
+
+/** The load-time early signal, isolated from every other line the loader logs. */
+const EARLY_SIGNAL = /is `required: true`, but record #/;
 
 const CONFIG = {
   dryRun: false,
@@ -186,6 +194,17 @@ describe('seed deferral vs required:true, on the real engine (#11674)', () => {
         status: { type: 'select', options: [{ value: 'pending' }, { value: 'approved' }] },
       },
     } as any, 'test-package');
+    // NOT a shape any adopted object has — the boundary of the early signal's
+    // predicate. `required` AND `readonly`: required-validation skips readonly
+    // fields on insert, so a deferral here is accepted by this very engine.
+    engine.registry.registerObject({
+      name: 'rq_approval_ro',
+      fields: {
+        process_name: { type: 'text', required: true },
+        object_name: { type: 'text', required: true },
+        record_id: { type: 'text', required: true, readonly: true, referenceVia: 'object_name' },
+      },
+    } as any, 'test-package');
     // The sys_audit_log shape: pointer pair declared, id half OPTIONAL.
     engine.registry.registerObject({
       name: 'rq_ledger',
@@ -203,9 +222,13 @@ describe('seed deferral vs required:true, on the real engine (#11674)', () => {
     expect(approval?.referenceVia, 'registry dropped referenceVia — cases below would not defer at all').toBe('object_name');
     expect(approval?.required, 'registry dropped required — case 1 would measure nothing').toBe(true);
     expect((engine.getSchema('rq_ledger') as any)?.fields?.record_id?.referenceVia).toBe('object_name');
+    const approvalRo = (engine.getSchema('rq_approval_ro') as any)?.fields?.record_id;
+    expect(approvalRo?.required, 'registry dropped required on the readonly variant').toBe(true);
+    expect(approvalRo?.readonly, 'registry dropped readonly — the boundary case would measure the ordinary one').toBe(true);
   });
 
-  const loader = () => new SeedLoaderService(engine as unknown as IDataEngine, emptyMetadata(), silentLogger());
+  const loader = (logger: ReturnType<typeof silentLogger> = silentLogger()) =>
+    new SeedLoaderService(engine as unknown as IDataEngine, emptyMetadata(), logger as any);
 
   it('MEASURED: the real engine REJECTS the deferred insert of a required id half — pass-2 write-back cannot save it', async () => {
     // Keyless approval dataset BEFORE its target: the pointer cannot resolve
@@ -284,5 +307,132 @@ describe('seed deferral vs required:true, on the real engine (#11674)', () => {
     expect(ledgerResult.referencesDeferred).toBe(0);
     // Never the verbatim natural key.
     expect(ledger.record_id).not.toBe('Lisa Thompson');
+  });
+  it('EARLY SIGNAL: the loader names the required deferral BEFORE the engine rejects the row (#11674 B)', async () => {
+    const logger = silentLogger();
+    // Exactly case 1's scenario. The measured failure below is UNCHANGED — the
+    // signal moves when the author learns, it does not move the verdict.
+    const result = await loader(logger).load({
+      seeds: [
+        { object: 'rq_approval', mode: 'insert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ] },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // ⛔ ACCEPT SET UNCHANGED: same rejection, same counters, same success.
+    expect(storeFor('rq_approval').size).toBe(0);
+    expect(result.success).toBe(false);
+
+    const signalAt = logger.lines.findIndex((l) => l.level === 'warn' && EARLY_SIGNAL.test(l.message));
+    const rejectionAt = logger.lines.findIndex((l) => l.level === 'error' && /record_id/.test(l.message));
+    expect(signalAt, 'the early signal never fired against the real engine').toBeGreaterThanOrEqual(0);
+    expect(rejectionAt, 'the engine did not reject — the ordering claim would be vacuous').toBeGreaterThanOrEqual(0);
+    // THE claim of this half of the card, measured rather than argued: the
+    // loader says it first, on the engine that really does the rejecting.
+    expect(signalAt).toBeLessThan(rejectionAt);
+
+    const signal = logger.lines[signalAt].message;
+    expect(signal).toContain('rq_approval.record_id is `required: true`');
+    expect(signal).toContain('Order the `rq_lead` dataset BEFORE `rq_approval`');
+  });
+
+  it('DOES NOT FIRE for the optional id half — the case the write-back really did make order-independent', async () => {
+    const logger = silentLogger();
+    const result = await loader(logger).load({
+      seeds: [
+        { object: 'rq_ledger', mode: 'insert', env: ENV, records: [
+          { action: 'read', object_name: 'rq_lead', record_id: 'Lisa Thompson' },
+        ] },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // Same deferral, same order, same engine — only `required` differs, and
+    // this one heals. A signal that fired here would be a false alarm on every
+    // correctly-authored optional pointer in the repo.
+    expect(result.success).toBe(true);
+    expect(logger.lines.some((l) => EARLY_SIGNAL.test(l.message))).toBe(false);
+  });
+
+  /**
+   * ⛔ THE REFUSAL FORK, measured — triage's 2026-08-24 ruling admits a
+   * load-time REFUSAL "only on an arm where the pass-1 insert is measured to be
+   * rejected by the real engine anyway", and says that any reachable
+   * configuration where a refusal would reject a load that succeeds today is a
+   * fork on which the refusal arm must NOT ship.
+   *
+   * The two cases below are that measurement, against the real engine, on the
+   * same predicate a refusal would have to key on ("this dataset defers a
+   * reference on a `required` column"). Both SUCCEED today. They are pinned
+   * because they are the reason the shipped diagnostic is warn-only, and
+   * because they are exactly the boundary the warning's predicate must keep
+   * honouring — the same fixtures answer both questions.
+   */
+  it('REFUSAL FORK 1: a required deferral on the UPDATE arm succeeds today — an omitted column is not a cleared one', async () => {
+    // Round 1: the row exists, seeded in the correct order.
+    await loader().load({
+      seeds: [
+        LEAD_SEED,
+        { object: 'rq_approval', externalId: 'process_name', mode: 'upsert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Lisa Thompson', status: 'pending' },
+        ] },
+      ] as any,
+      config: CONFIG,
+    });
+    expect(storeFor('rq_approval').size, 'round 1 did not seed — round 2 would measure an insert').toBe(1);
+
+    // Round 2 — the dev-server-restart shape: the same row is replayed, now
+    // pointing at a lead THIS load seeds later. The pointer cannot resolve in
+    // pass 1, so the loader defers by deleting required `record_id` — the
+    // identical predicate case 1 fails on.
+    const logger = silentLogger();
+    const result = await loader(logger).load({
+      seeds: [
+        { object: 'rq_approval', externalId: 'process_name', mode: 'upsert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Marco Diaz', status: 'approved' },
+        ] },
+        { object: 'rq_lead', externalId: 'name', mode: 'upsert', env: ENV, records: [{ name: 'Marco Diaz' }] },
+      ] as any,
+      config: CONFIG,
+    });
+
+    // MEASURED: it SUCCEEDS. Update-mode validation checks only the fields the
+    // write supplies, and the deferral removed the key rather than nulling it
+    // — so the required check never runs, and pass 2 back-fills the resolved
+    // id afterwards. A load-time refusal keyed on the deferral would have
+    // rejected this load. ⇒ refusal arm not shipped.
+    expect(result.success).toBe(true);
+    const marcoId = [...storeFor('rq_lead').values()].find((r) => r.name === 'Marco Diaz')!.id;
+    expect([...storeFor('rq_approval').values()][0].record_id).toBe(marcoId);
+    // …and the warning correctly stays silent here, for the same reason.
+    expect(logger.lines.some((l) => EARLY_SIGNAL.test(l.message))).toBe(false);
+  });
+
+  it('REFUSAL FORK 2: a required READONLY column deferring on INSERT is accepted today — required-validation skips it', async () => {
+    const logger = silentLogger();
+    const result = await loader(logger).load({
+      seeds: [
+        { object: 'rq_approval_ro', mode: 'insert', env: ENV, records: [
+          { process_name: 'flow:discount', object_name: 'rq_lead', record_id: 'Lisa Thompson' },
+        ] },
+        LEAD_SEED,
+      ] as any,
+      config: CONFIG,
+    });
+
+    // MEASURED: the row LANDS. Same deferral, same `required: true`, same
+    // engine as case 1 — the only difference is `readonly`, which
+    // required-validation skips on insert. A load-time refusal keyed on
+    // `required` alone would have rejected a row this engine accepts.
+    expect(storeFor('rq_approval_ro').size, 'the deferred insert was rejected — the fork claim would be wrong').toBe(1);
+    expect(result.success).toBe(true);
+    // The warning's predicate MIRRORS the contract's rather than approximating
+    // it, so it stays silent here too. If this ever flips, the predicate and
+    // the write contract have drifted apart.
+    expect(logger.lines.some((l) => EARLY_SIGNAL.test(l.message))).toBe(false);
   });
 });

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -167,6 +167,19 @@ export const SysApprovalRequest = ObjectSchema.create({
       // `required: true`, so the un-addressable case (id half authored, type
       // half empty) is already unreachable on this object.
       group: 'Target',
+      //
+      // ⚠️ ORDERING CONSTRAINT — this id half is `required: true`, and that
+      // makes it ORDER-DEPENDENT in seeds even though a pointer pair
+      // contributes no static ordering edge (#11674, measured against the real
+      // engine in `packages/objectql/src/engine-seed-required-deferral.test.ts`):
+      // the seed loader defers an unresolvable reference by DELETING the column
+      // from the pass-1 insert, required-validation rejects that row, and pass 2
+      // is then left with no row to back-fill. So the pass-2 healing that makes
+      // an OPTIONAL id half order-independent (`sys_audit_log`) does not reach
+      // this one. ⇒ SEED THE TARGET DATASET FIRST. The failure if you do not is
+      // loud in three places — a write error naming this column, a
+      // dropped-deferral error, and `success: false` — and since #11674 the
+      // loader also WARNS at load time, before the engine rejects the row.
       referenceVia: 'object_name',
     }),
 

--- a/packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
+++ b/packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
@@ -252,6 +252,19 @@ export const SysAuditLog = ObjectSchema.create({
       // A DELETED RECORD (an `action: 'delete'` row, whose target must NOT
       // exist) stays authorable through the landed escape hatch: an
       // internal-id-shaped value passes through untouched.
+      //
+      // ⚠️ ORDERING, and why this object differs from its three siblings
+      // (#11674): this id half is OPTIONAL, so a seed that names a target
+      // loaded later is genuinely order-independent — pass 1 inserts without
+      // the column and pass 2 back-fills it through the internal id captured at
+      // insert time, measured end-to-end against the real engine in
+      // `packages/objectql/src/engine-seed-required-deferral.test.ts`. ⛔ Do not
+      // carry that property over to `sys_approval_request`, `sys_record_share`
+      // or `sys_share_link`: their id half is `required: true`, deferring
+      // DELETES the column from the pass-1 insert, and required-validation
+      // rejects the row before pass 2 can help. Those three must seed the
+      // target dataset first; this one need not. Making this column `required`
+      // would therefore also make its seeds order-dependent.
       referenceVia: 'object_name',
       group: 'Target',
     }),

--- a/packages/plugins/plugin-sharing/src/objects/sys-record-share.object.ts
+++ b/packages/plugins/plugin-sharing/src/objects/sys-record-share.object.ts
@@ -150,6 +150,19 @@ export const SysRecordShare = ObjectSchema.create({
       // exist. Loud seed-time refusal replaces a grant that silently meant
       // nothing and then silently disappeared.
       group: 'Target',
+      //
+      // ⚠️ ORDERING CONSTRAINT — this id half is `required: true`, and that
+      // makes it ORDER-DEPENDENT in seeds even though a pointer pair
+      // contributes no static ordering edge (#11674, measured against the real
+      // engine in `packages/objectql/src/engine-seed-required-deferral.test.ts`):
+      // the seed loader defers an unresolvable reference by DELETING the column
+      // from the pass-1 insert, required-validation rejects that row, and pass 2
+      // is then left with no row to back-fill. So the pass-2 healing that makes
+      // an OPTIONAL id half order-independent (`sys_audit_log`) does not reach
+      // this one. ⇒ SEED THE TARGET DATASET FIRST. The failure if you do not is
+      // loud in three places — a write error naming this column, a
+      // dropped-deferral error, and `success: false` — and since #11674 the
+      // loader also WARNS at load time, before the engine rejects the row.
       referenceVia: 'object_name',
     }),
 

--- a/packages/plugins/plugin-sharing/src/objects/sys-share-link.object.ts
+++ b/packages/plugins/plugin-sharing/src/objects/sys-share-link.object.ts
@@ -141,6 +141,19 @@ export const SysShareLink = ObjectSchema.create({
       // failure is silent at seed time and indistinguishable from a
       // revocation at use time. Declared, the seed is refused loudly instead.
       group: 'Target',
+      //
+      // ⚠️ ORDERING CONSTRAINT — this id half is `required: true`, and that
+      // makes it ORDER-DEPENDENT in seeds even though a pointer pair
+      // contributes no static ordering edge (#11674, measured against the real
+      // engine in `packages/objectql/src/engine-seed-required-deferral.test.ts`):
+      // the seed loader defers an unresolvable reference by DELETING the column
+      // from the pass-1 insert, required-validation rejects that row, and pass 2
+      // is then left with no row to back-fill. So the pass-2 healing that makes
+      // an OPTIONAL id half order-independent (`sys_audit_log`) does not reach
+      // this one. ⇒ SEED THE TARGET DATASET FIRST. The failure if you do not is
+      // loud in three places — a write error naming this column, a
+      // dropped-deferral error, and `success: false` — and since #11674 the
+      // loader also WARNS at load time, before the engine rejects the row.
       referenceVia: 'object_name',
     }),
 


### PR DESCRIPTION
Part of #11674

The remainder of the card, as re-graded by triage on 2026-08-24 (comment
`5400822253`): **A + B folded into one PR**. The keyless write-back half landed
separately in PR #11830 and is untouched here.

⛔ **This is not a correctness hole and not data loss.** The failure it addresses
is already loud in three registers — a write error naming the column, a
dropped-deferral error, and `success: false`. The only thing this PR moves is
**when the author learns**.

## The mechanism, restated once

Pass 1 defers an unresolvable reference by **deleting the column** from the row.
On a `required: true` column that turns the insert into one the write contract
rejects (ADR-0113), so the row never lands and pass 2 has no row to back-fill.
That is the second, independent road to the same loud failure — the one the
pass-2 internal-id write-back cannot clear — and it is why a `required` id half
stays **order-dependent** even though a declared pointer pair contributes no
static ordering edge.

## A — the constraint, documented at the declaration sites

Added at the four pointer-pair declaration sites, next to `referenceVia`:

| Object | Note |
|---|---|
| `sys_approval_request`, `sys_record_share`, `sys_share_link` | id half is `required: true` ⇒ **seed the target dataset first**; pass-2 healing does not reach them |
| `sys_audit_log` | id half is **optional** ⇒ genuinely order-independent, with an explicit ⛔ against carrying that property over to its three siblings |

The fourth note is the one the card's body specifically warns about ("a reader
who carried its order-independence over to these four would be wrong"), so it
states the contrast rather than repeating the constraint.

⛔ **Nothing under `packages/spec/src/**`.** The constraint is a property of the
*seeding order* of these four objects, not of the `referenceVia` schema, so the
object declaration sites are where it belongs on the merits — which also keeps
the diff clear of the enqueue gate's path limb.

## B — the load-time early signal, warn-only

When a dataset defers a reference on a column the write contract requires **on
insert**, the loader now logs one `warn` before the row reaches the engine,
naming the object, the field, the target object that is not seeded yet, what
deferring did to the row, and the fix.

⛔ **The accept set is unchanged.** Nothing is counted, nothing reaches
`result.errors`, `success` is untouched, and every existing loud failure and its
tests are preserved verbatim. Only the log gains a line.

**The predicate mirrors the write contract instead of approximating it** —
`required && !readonly && !system`, and only for rows `decideWriteAction` says
are headed for an INSERT. Both halves of that are measured, not assumed (below).
It is emitted once per dataset and field: three rows deferring the same column
are one ordering mistake with one fix, and repeating it per row is exactly the
noise AGENTS.md → "Degradation log levels" says to say once.

`warn`, not `error`, by the same section's one question: at the moment it fires
nothing has been lost — it is a prediction, and the loss (if the engine does
reject) is already reported at `error` by the write site.

## ⛔ The refusal arm is NOT shipped — the fork, measured

Triage admitted a load-time **refusal** "only on an arm where the pass-1 insert
is measured to be rejected by the real engine anyway", and ruled that any
reachable configuration where a refusal would reject a load that succeeds today
is a fork on which the refusal arm must not ship.

**Two such configurations were measured against the real `ObjectQL` engine**, on
the same predicate a refusal would have to key on. Both are pinned as tests in
`packages/objectql/src/engine-seed-required-deferral.test.ts`:

1. **The UPDATE arm.** An upsert replay over an existing row defers the required
   column; update-mode validation checks only the fields the write supplies, and
   the deferral *removes* the key rather than nulling it, so the required check
   never runs. The load **succeeds today** and pass 2 back-fills afterwards.
2. **A `readonly` required column.** Required-validation skips `readonly` and
   `system` fields on insert, so the deferred insert is **accepted today** — same
   deferral, same `required: true`, same engine; only `readonly` differs.

⇒ Reported as a fork, refusal arm not built. The warning correctly stays silent
on both, which is why the same two cases double as the boundary controls for its
predicate: if either ever starts warning, the predicate and the write contract
have drifted apart.

⛔ **Option C is not taken and not escalated**, per the ruling. Nothing measured
here argues for it.

## Non-vacuity

A signal that never fires and one that fires on everything both look green, so
both are pinned. In `packages/metadata-protocol/src/seed-loader-pointer-pair.test.ts`:

| Case | Expectation |
|---|---|
| keyless required id half defers | **FIRES** — exactly one line, naming the declaration, what deferring did, and the fix |
| optional id half, same shape and order | **silent** — and heals, which is why warning would be a false alarm |
| target seeded first | **silent** — a signal keyed on the `required` *declaration* rather than on the deferral would fire on every correctly ordered seed in the repo |
| UPDATE arm | **silent** — measured on the real engine, see above |
| three rows, one ordering mistake | **one** line, not three |

The existing positive control that isolates keylessness as the original cause
(same seeds, same order, `externalId` declared → heals) is untouched, as are the
loud-failure pins on both key shapes.

⚠️ One trap worth recording: the obvious non-vacuity probe, `referencesDeferred > 0`,
is **wrong** here — a successful pass-2 back-fill *gives that counter back*, so a
healed deferral reads as zero and the assertion would be asserting that healing
failed. The probe counts the pass-2 back-fill write instead, which is the only
`update` carrying the deleted column.

## Ablation

Mutation: gate the signal's emission behind a condition that can never hold.
Direction predicted **in advance** and recorded in the driver's output before any
result was read.

- **Mutation proven on disk first**: anchor `1 → 0`, marker `0 → 1`, single exact
  replacement with a hit-count assert.
- **Leg 1** — `packages/metadata-protocol` resolves `./seed-loader.js` from src,
  so no build sits in the path. Predicted 2 RED; **got exactly 2** (the two FIRES
  cases), 23 green. ⚠️ The three DOES-NOT-FIRE controls stayed green **by
  construction** — they assert zero warnings, and a removed signal also yields
  zero. Controls cannot detect removal; that is what the FIRES cases are for.
- **Leg 2** — `packages/objectql` resolves `@objectstack/metadata-protocol`
  through `exports` → `dist/`, so the mutation was rebuilt and proven in the
  artifact: `ablation-dist-preflight` PASS, marker in 2 built files. Predicted
  1 RED; **got exactly 1** (the ordering test), 6 green.
  The marker was **executable from the start** (a `globalThis` read, not a
  comment) precisely because a comment marker is stripped by esbuild — the
  VOID-leg lesson from this card's first round. No leg was void.
- **Restore under `trap … EXIT INT TERM`**: marker `0`, anchor `1`, rebuild,
  preflight `--absent` PASS (absent from all 24 built files),
  `git status --porcelain` empty.

## Verification

All at final commit `c42a5a3a0f`; heavy runs serialised through
`scripts/pm/os-verify-lock.sh`, exits captured before any pipe, results read from
each gate's own verdict line.

- `@objectstack/metadata-protocol` suite: `Test Files 139 passed | 2 skipped`,
  `Tests 1919 passed | 10 skipped`.
- `@objectstack/objectql` suite: `Test Files 232 passed`, `Tests 4117 passed`.
- `typecheck` green for `objectql`, `plugin-approvals`, `plugin-sharing`,
  `plugin-audit` (each echoed its script name — `@objectstack/metadata-protocol`
  has no `typecheck` script and is ledgered).
- Repo-wide `eslint . --no-inline-config`: **5407 files linted, 0 findings**, so
  no narrowing was needed or claimed.
- Gate union **derived** by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
  at `c42a5a3a0f` (identical to the derivation at the first commit), every family
  run and green: `changeset-gate-self-tests`, `cross-package-test-inputs`,
  `durability-log-level`, `objectui-changeset`, `published-files`, `slot-lookup`,
  `test-source-alias`, `type-source-resolution`, `adr-0087-registration`,
  `changeset-no-major`, `ci-filter-parity`, `empty-changeset`,
  `engine-split-ratio` (shallow-clone refusal → deepened per its own remedy →
  97.6%), `plugin-teardown-shape`, `affected-docs`, `drift-comment`,
  `release-rehearsal --self-test`, `query-options-erasure`, `type-check-coverage`,
  `type-check-debt` (`--re-measure`, after the full workspace build),
  `engine-double-contract`, `where-matcher`, `i18n`, `nul-bytes`.

⚠️ **The `type-check-debt` ratchet caught a real regression mid-round** and is
worth reading rather than skimming: the first version of the new pass-2 probe
declared a structural parameter type the engine double does not satisfy, adding
4 raw tsc errors and drifting `@objectstack/metadata-protocol` from 63 to 67.
Repaired at the **author's** remedy — the probe now reaches the mock the way the
rest of that file does — bringing the raw count back to the frozen 63 with none
of them in this file. ⛔ The ledger entry was not raised.

_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_