### PR TITLE
docs(adr): un-flatten ADR-0082's decision-6 chain diagram severity label

### DIFF
--- a/docs/adr/0082-react-component-contract-governance.md
+++ b/docs/adr/0082-react-component-contract-governance.md
@@ -93,7 +93,7 @@ spec zod schema  ──gen──►  react-blocks.md      (AI reads it — decis
                                 │
                                 ▼
                            prop gate                  (os validate — decision 5)
-                           (hard: missing-required / typo)
+                           (missing-required → error / typo → warning)
 ```
 
 `examples/app-showcase/src/pages/renewals-pipeline.page.ts` is the **golden page**: authored straight from the contract (five server-connected blocks), it passes `os validate`; injecting a missing required `objectName` and an `onSucces` typo makes the gate fail with an error + a warning (captured in `docs/audits/2026-06-react-tier-authoring-dogfood.md`). The chain demonstrably closes.


### PR DESCRIPTION
Fixes #11914

`docs/adr/0082-react-component-contract-governance.md` decision 6's chain diagram flattens the severity split that decision 5 of the same ADR records fifteen lines earlier. The prop-gate box read:

```
                           prop gate                  (os validate — decision 5)
                           (hard: missing-required / typo)
```

putting `missing-required` and `typo` on the same side of one word, `hard` — as if both fail the gate.

## Why it's wrong

Decision 5's own body splits the two by severity:

> - **missing a required binding** (e.g. `ObjectForm` with no `objectName`) → **error** (fails `os build`).
> - **a near-miss of a known prop** (edit distance ≤ 2, e.g. `onSucces` → `onSuccess`) → **warning**.

and the TL;DR line (decision 5) states it the same way: "a missing **required binding** is an error; a near-miss **prop typo** is a warning." The measured CLI behaviour (captured in #11914 and re-derived for #11912, a sibling repair on the adjacent line 99) agrees with decision 5, not with the diagram: a missing required `objectName` exits 1, an `onSucces` typo alone exits 0 with a `⚠` advisory.

## The edit

One line. The parenthetical now uses the same two words decision 5 uses for the two severities, so a reader following the arrow lands on the same distinction decision 5 makes:

```
                           prop gate                  (os validate — decision 5)
                           (missing-required → error / typo → warning)
```

No other line in the file changed — decision 5 itself and the golden-page citation on the line immediately below the diagram (already being repaired separately by #11912) are untouched.

## Scope

- Only the decision-6 diagram label. Decision 5's prose, the golden-page citation line, and everything else in the ADR are unchanged.
- No counts, shas, or line numbers are added to the ADR prose itself.

## Gates

Derived live at the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list), then run at HEAD `c93e1844d` with a clean working tree. Verdict lines as each gate printed them:

```
check-adr-anchors: OK (52 anchored file(s), every governing ADR still referenced; 123 decision number(s), each naming one decision or an allowlisted pair; 28016 citation(s) across 3518 file(s) resolve).
✓ doc authoring guard: 389 files clean — no bare metadata literals.
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 421 files / 1448 TS blocks judged clean by @objectstack/formula.
✓ check-governed-merges --self-test: 129 assertions (…)
✅ check-adr-links: 551 relative link destination(s) under docs/adr/ resolve
check-nul-bytes: OK (scanned 6658 text file(s) -- 6658 tracked, 0 untracked-not-ignored; skipped 6 binary; no raw ASCII control bytes).
```

`check:nul-bytes` is not path-derived for this card; it was run anyway because the diff was hand-edited.

## Deliberately not done

- **Stays draft.** `docs/adr/**` is a governed surface (Prime Directive #14): never flipped ready, never queued, never auto-merged. Review requested from `os-zhuang`; the maintainer's hand-merge is the review record.
- **No changeset** — docs-only, publishes nothing; `skip-changeset` applied instead.
- **No sweep.** Decision 5 and the rest of the ADR were not otherwise re-audited; only the one flattened label was in scope.

_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_