### PR TITLE
fix(devx): give affected-docs' route walk a PATH, not a basename (#11866)

### DIFF
--- a/scripts/docs-audit/affected-docs.mjs
+++ b/scripts/docs-audit/affected-docs.mjs
@@ -1371,11 +1371,47 @@ function bridgeCoverageFrom(ledgers, tails, maximalTails) {
 }
 
 /**
- * Walk `packages/**` for the two declared tables the `sdk` bridge rides on. Split out of
- * PHASE 2 so `--bridge-coverage` can measure the same surface the bridge uses, from the
- * same walk — a second walk here is exactly the drift #4851 billed us for.
+ * The walk itself, split out of `scanRouteSurface` so `--self-test` can pin the one
+ * decision that broke here — WHICH FILES THE WALK ADMITS — against a fake tree.
+ * `readDir` is injectable for exactly the reason `packageRootOf`'s `hasPackageJson` is:
+ * the pin needs no repo state, and a pin that re-asks the predicate instead of walking
+ * would re-pin the half that was already right.
+ *
+ * ⛔ `isTestFile` IS DEFINED OVER A PATH AND MUST BE GIVEN ONE (#11866). This call site
+ * used to pass `e.name` — a BASENAME — so the `__tests__` / `__mocks__` / `__fixtures__`
+ * arm, which requires a `/`, could never match: only the `*.test.*` / `*.spec.*` arm did
+ * any work here, and the directory exclusion the function documents was not happening.
+ * The self-test did not catch it because it pins `isTestFile` with paths, and the
+ * function was never the broken half — its CALLER was. That is why the pin walks a fake
+ * tree through this function rather than calling the predicate a fourth time.
+ *
+ * A STRICT TIGHTENING, measured rather than assumed: on `d63b01436`, of the 4625 `.ts`
+ * files under `packages/**`, exactly 3 were admitted by the basename test and are
+ * excluded by the path test, and ZERO go the other way — the file arms are anchored
+ * `(^|\/)`, so a basename they match is matched inside a path too. Reordering `rel`
+ * ahead of the test therefore cannot admit anything the old order excluded.
+ *
+ * ⭐ AND THE EXCLUSION IS RIGHT FOR THE CEILING TOO, which is the question this walk's
+ * two consumers make live. `sourceFiles` is the #11178 ceiling population and
+ * `registrarFiles` is the bridge's own discovery — one walk, both. It is tempting to
+ * argue the ceiling wants the WIDEST possible population and so should keep test
+ * directories; it does not, because of what the ceiling's verdict MEANS. A row counted
+ * `remediable by discovery` is a claim that widening the FILENAME CONVENTION would reach
+ * it, and no widening of that convention may legitimately admit a test double — so a
+ * witness under `__tests__/` would move a row into `remediable` against a remedy that
+ * cannot be taken, i.e. exactly the misreading `bridgeCoverageFrom`'s split exists to
+ * end ("it aimed a whole card at widening a recognizer that was never the constraint").
+ * The superset invariant survives either way — both populations come off this one walk,
+ * so they narrow together and `reachable` still cannot exceed the ceiling. And no gate
+ * ratchets these counts: `check-affected-docs.mjs` fails on `brokenScan` alone, so
+ * nothing here moves a shrink-only number down.
+ *
+ * @param {string} root  the tree to walk (`packages/**` under it); paths come back
+ *   relative to it, which is what `isTestFile` and both file regexes are defined over.
+ * @param {(dir: string, opts: {withFileTypes: true}) => Array<{name: string, isFile(): boolean, isDirectory(): boolean}>} [readDir]
+ * @returns {{registrarFiles: string[], sourceFiles: string[]}}
  */
-function scanRouteSurface() {
+function walkSourceFiles(root, readDir = readdirSync) {
   const registrarFiles = [];
   // EVERY candidate the convention CHOSE FROM, collected in the same walk (#11178). This
   // is not a second discovery route and nothing downstream of the bridge reads it: it is
@@ -1386,19 +1422,30 @@ function scanRouteSurface() {
   const sourceFiles = [];
   const walkSrc = (dir) => {
     let entries;
-    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    try { entries = readDir(dir, { withFileTypes: true }); } catch { return; }
     for (const e of entries) {
       if (e.name === 'node_modules' || e.name === 'dist' || e.name === '.turbo') continue;
       const p = join(dir, e.name);
-      if (e.isDirectory()) walkSrc(p);
-      else if (e.isFile() && e.name.endsWith('.ts') && !isTestFile(e.name)) {
-        const rel = relative(repoRoot, p);
-        sourceFiles.push(rel);
-        if (LEDGER_FILE_RE.test(rel) || REGISTRAR_FILE_RE.test(rel)) registrarFiles.push(rel);
-      }
+      if (e.isDirectory()) { walkSrc(p); continue; }
+      if (!e.isFile() || !e.name.endsWith('.ts')) continue;
+      // The PATH, never `e.name` — see above.
+      const rel = relative(root, p);
+      if (isTestFile(rel)) continue;
+      sourceFiles.push(rel);
+      if (LEDGER_FILE_RE.test(rel) || REGISTRAR_FILE_RE.test(rel)) registrarFiles.push(rel);
     }
   };
-  walkSrc(join(repoRoot, 'packages'));
+  walkSrc(join(root, 'packages'));
+  return { registrarFiles, sourceFiles };
+}
+
+/**
+ * Walk `packages/**` for the two declared tables the `sdk` bridge rides on. Split out of
+ * PHASE 2 so `--bridge-coverage` can measure the same surface the bridge uses, from the
+ * same walk — a second walk here is exactly the drift #4851 billed us for.
+ */
+function scanRouteSurface() {
+  const { registrarFiles, sourceFiles } = walkSourceFiles(repoRoot);
 
   const ledgers = [];
   const ledgerRows = [];
@@ -2095,6 +2142,81 @@ function selfTest() {
     ['packages/foo/src/tests-helper.ts', false, 'tests-helper is not __tests__'],
   ];
   for (const [path, want, label] of testFileCases) check('isTestFile', label, path, want, isTestFile(path));
+
+  // ── the WALK's admission decision, against a fake tree (#11866) ──────────────
+  //
+  // The cases above pin the PREDICATE, and the predicate was never wrong: every one of
+  // them passes a full path, which is what `isTestFile` is defined over. What was wrong
+  // was the CALL SITE — `scanRouteSurface`'s walk handed it `e.name`, a basename, so the
+  // three directory arms could not match. A green predicate beside a broken caller is the
+  // shape these cases could not see, so this block walks `walkSourceFiles` itself.
+  //
+  // ⛔ NON-VACUITY IS THE ENTIRE POINT OF THESE FIXTURES, and it is why none of them is a
+  // real repo path. The live population is ZERO — measured on `d63b01436`, the three files
+  // under a test directory that the old walk admitted match neither `REGISTRAR_FILE_RE`
+  // nor `LEDGER_FILE_RE` and declare no `path:`, so `--bridge-coverage` is byte-identical
+  // across this fix. A pin built from real paths would therefore have passed just as
+  // green with the bug in place and pinned NOTHING. Every fixture below is instead a file
+  // the BASENAME test admits and the PATH test excludes: `x-route.ts` carries no `.test.`
+  // / `.spec.` infix, so under the old call site it was walked, matched
+  // `REGISTRAR_FILE_RE`, and a test double contributed production route tails — the exact
+  // failure this is here to keep out. Verified RED against the pre-fix line: 4 registrar
+  // files and 6 source files, against the 1 and 2 asserted here.
+  const fakeSrcTree = [
+    'packages/foo/src/engine.ts',                        // plain implementation
+    'packages/foo/src/real-route.ts',                    // a genuine registrar — must survive
+    'packages/foo/src/engine.test.ts',                   // already excluded by the file arm
+    'packages/foo/src/__tests__/x-route.ts',             // ⭐ registrar-NAMED test double
+    'packages/foo/src/__tests__/helper.ts',              // ceiling population only
+    'packages/foo/src/__mocks__/fake-server.ts',         // the `-server` alternative
+    'packages/foo/src/__fixtures__/stub-route-ledger.ts',// LEDGER_FILE_RE
+    'packages/foo/node_modules/dep/route.ts',            // pruned directory
+    'packages/foo/dist/route.ts',                        // pruned directory
+    'packages/foo/README.md',                            // not a .ts file
+  ];
+  const fakeRoot = '/repo';
+  const fakeDirs = new Map();
+  for (const rel of fakeSrcTree) {
+    const segs = rel.split('/');
+    for (let i = 0; i < segs.length; i++) {
+      const dir = join(fakeRoot, ...segs.slice(0, i));
+      let kids = fakeDirs.get(dir);
+      if (!kids) fakeDirs.set(dir, (kids = new Map()));
+      kids.set(segs[i], i === segs.length - 1);
+    }
+  }
+  // Throws on an unknown directory exactly as `readdirSync` does, so the walk's own
+  // `try`/`catch` is exercised rather than bypassed by a forgiving fake.
+  const fakeReadDir = (dir) => {
+    const kids = fakeDirs.get(dir);
+    if (!kids) throw new Error(`ENOENT: no such fake directory, ${dir}`);
+    return [...kids].map(([name, isFile]) => ({ name, isFile: () => isFile, isDirectory: () => !isFile }));
+  };
+  const walked = walkSourceFiles(fakeRoot, fakeReadDir);
+  const sorted = (a) => [...a].sort().join(' | ');
+  check('walkSourceFiles', 'a registrar-NAMED file under __tests__/ is NOT a registrar — the walk tests the path',
+    'registrarFiles', 'packages/foo/src/real-route.ts', sorted(walked.registrarFiles));
+  check('walkSourceFiles', 'and the three test directories contribute nothing to the CEILING population either',
+    'sourceFiles', 'packages/foo/src/engine.ts | packages/foo/src/real-route.ts', sorted(walked.sourceFiles));
+  // Per-fixture, so a regression NAMES the arm that came back rather than only the totals.
+  const excludedFixtures = [
+    ['packages/foo/src/__tests__/x-route.ts', 'a __tests__/ file matching REGISTRAR_FILE_RE'],
+    ['packages/foo/src/__mocks__/fake-server.ts', 'a __mocks__/ file matching the `-server` alternative'],
+    ['packages/foo/src/__fixtures__/stub-route-ledger.ts', 'a __fixtures__/ file matching LEDGER_FILE_RE'],
+    ['packages/foo/src/__tests__/helper.ts', 'a __tests__/ helper with no registrar name'],
+  ];
+  for (const [rel, label] of excludedFixtures) {
+    check('walkSourceFiles', `${label} is walked at all`, rel, false, walked.sourceFiles.includes(rel));
+    check('walkSourceFiles', `${label} reaches the registrar list`, rel, false, walked.registrarFiles.includes(rel));
+  }
+  check('walkSourceFiles', 'a genuine registrar still survives the walk', 'packages/foo/src/real-route.ts',
+    true, walked.registrarFiles.includes('packages/foo/src/real-route.ts'));
+  check('walkSourceFiles', 'a .test.ts file is still excluded by the FILE arm', 'packages/foo/src/engine.test.ts',
+    false, walked.sourceFiles.includes('packages/foo/src/engine.test.ts'));
+  check('walkSourceFiles', 'node_modules/ and dist/ are still pruned', 'packages/foo/{node_modules,dist}/route.ts',
+    0, walked.sourceFiles.filter((f) => /(^|\/)(node_modules|dist)\//.test(f)).length);
+  check('walkSourceFiles', 'a non-.ts file is not walked', 'packages/foo/README.md',
+    false, walked.sourceFiles.includes('packages/foo/README.md'));
 
   // Package-root derivation, against a fake tree so the self-test stays hermetic.
   // One package.json per shape the repo has: a direct child package plus a nested


### PR DESCRIPTION
Fixes #11866

`scanRouteSurface`'s walk handed `isTestFile` `e.name` — a **basename** — so the
`__tests__` / `__mocks__` / `__fixtures__` arm, which requires a `/`, could never match
there. Only the `*.test.*` / `*.spec.*` arm did any work, and the directory exclusion the
function documents was not happening for **either** consumer of that walk: the bridge's
own registrar discovery, or the #11178 ceiling population filled in the same pass.

## The remedy, and the question the card declined to rule

The card explicitly left open *"whether the walk should exclude these directories at
all — the ceiling in PR #11865 arguably wants the widest possible population."*
**Resolved: exclude, from both consumers.** Not on taste — on what the ceiling's verdict
*means*. A row counted `remediable by discovery` is a claim that widening the **filename
convention** would reach it, and no widening of that convention may legitimately admit a
test double. A witness under `__tests__/` would therefore move a row into `remediable`
against a remedy nobody can take — precisely the conflation `bridgeCoverageFrom`'s split
exists to end (*"it aimed a whole card at widening a recognizer that was never the
constraint"*). Two supporting measurements:

- **The superset invariant survives.** Both populations come off this one walk, so they
  narrow together and `reachable` still cannot exceed the ceiling.
- **No ratchet moves.** `check-affected-docs.mjs` exits non-zero on `brokenScan` alone —
  the 45/221 ratio and the 82-tail ceiling are reported, never gated. There is no
  shrink-only number here to move down.

Route (a) from triage — pass the walk-relative path — over route (b) (basename against
the file arms, joined path against the directory arms): `isTestFile` is *defined* over a
path, its docblock says so, and all 14 of its existing self-test cases pass one. (b)
would enshrine a two-convention contract that nothing pins.

## Measurements

**The card's "0 live" claim, re-measured on `d63b01436`** (it was taken on `589758d22`,
before #11865 landed): still exactly 3 files, still **0** matching `REGISTRAR_FILE_RE` or
`LEDGER_FILE_RE` — `hono/src/__mocks__/runtime.ts`, `cli/src/utils/__tests__/server-body.ts`,
`service-datasource/src/__tests__/entitled-caller.fixture.ts`. Latent, not live: confirmed.

**And the half the card did not measure — the ceiling.** `sourceFiles` admits any file, not
just convention-matched ones, so a test-dir file declaring a `path:` would inflate the
ceiling without ever matching `REGISTRAR_FILE_RE`. Measured directly: `--bridge-coverage`
and `--bridge-coverage --json` are **byte-identical** across this change (12 registrar
files · 43 tails · 82-tail ceiling · 45/177 reach · 14/56/107 causes). The dormant-hole
framing holds for both halves.

**"Passing `rel` is safe" — falsified in the loose direction, and it holds.** Of the 4625
`.ts` files under `packages/**`: 3 excluded-by-path-but-not-by-basename, **0** the other
way. The file arms are anchored `(^|/)`, so a basename they match is matched inside a path
too — reordering `rel` ahead of the test is a strict tightening of this walk.

**The other callers of `isTestFile`, swept** (the card did not): it is module-local, never
exported, and the script is only ever spawned. Three call sites — the walk (basename,
**broken**), the `--self-test` cases (full paths, correct), and the changed-file loop over
`git diff --name-only` output (full paths, correct). Only the broken one is touched, so
the fix cannot break a caller that was already passing a path.

## The pin, and why it is not vacuous

⚠️ The live population is **zero**, so a pin built from real repo paths would pass just as
green with the bug in place and pin nothing. The fixtures are therefore chosen to be
files the basename test **admits** and the path test **excludes** — `__tests__/x-route.ts`
carries no `.test.` / `.spec.` infix, so under the old call site it was walked, matched
`REGISTRAR_FILE_RE`, and a test double contributed production route tails.

The walk is split out as `walkSourceFiles(root, readDir)` — `readDir` injectable for the
same reason `packageRootOf`'s `hasPackageJson` is — so the pin walks the **call site**
against a fake tree, not the predicate. That matters: the existing self-test pins
`isTestFile` with full paths and is green either way; the function was never the broken
half.

**Red before, green after, observed on disk in both directions.** The one call-site
argument was mutated back to `e.name` under a `trap … EXIT INT TERM`, with the mutation
confirmed by anchored `grep -c` on both the injected and the removed text (the first
attempt was a silent no-op — a `perl` `\Q…\E` anchor with pre-escaped parens matched
nothing and exited 0; the on-disk check caught it, and that reading was discarded):

| leg | anchored on-disk check | `--self-test` |
| --- | --- | --- |
| mutated (pre-fix argument) | fixed form 0 · buggy form 1 | **FAILED, 9 case(s)** — 4 registrar files and 6 source files against the 1 and 2 asserted |
| restored | fixed form 1 · buggy form 0 · `git status` clean | `✓ 451 cases pass.` |

`--bridge-coverage` under the mutation is identical to the pre-fix baseline, which is the
same zero-live fact from the other side.

## #11857 — checked for collision, and there is none

#11857 is the sibling gap in the same function (the *patterns*: `isTestFile` excludes
neither `test/fixtures/*.ts` nor `*.bench.ts`, plus a larger evidence-based admission
route). Not fixed here. The two are **disjoint on today's tree** — measured: all three
files #11857 enumerates are admitted both before and after this change. They are also
**complementary, in one direction**: `test/fixtures/*.ts` is itself a path-shaped pattern,
so adding it to `isTestFile` while this call site still passed a basename would produce
another dead arm — the identical failure. This PR is a prerequisite for #11857's cheaper
half, never a competitor to it. Textually, #11857 would edit the predicate body and may
extend `walkSourceFiles`; that is a rebase touch, not a semantic conflict.

## Verification

Run at `ad9307722`, the branch head.

- `node scripts/docs-audit/affected-docs.mjs --self-test` → `✓ affected-docs self-test: 451 cases pass.`
- All **12** gate families derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list — it reads the change set off the merge base itself), plus `check:nul-bytes`, green. Their own verdict lines, not bare exit codes:
  - `✓ check-affected-docs` → `451 cases pass.` · `✓ check-drift-comment: 56 cases pass across 5 fixture diff(s).`
  - `✓ check-self-test-wired: every one of the 127 script(s) CI runs that ship a --self-test has that self-test run by CI.`
  - `✓ check:entry-guard: 156 scripts/ file(s)` · `✓ check:parse-guard: 155 scripts/ file(s)`
  - `✓ check-governed-merges --self-test: 129 assertions` · `✓ check-pnpm-filter-targets --self-test: 40 assertions`
  - `✓ check-agent-test-spelling: 0 violations` · `✓ docs-accuracy-audit scope is in sync`
  - `OK: all 96 declared cross-package glob(s)…` · `OK: 16 package(s) read outside themselves…`
  - `check-nul-bytes: OK (scanned 6661 text file(s) … no raw ASCII control bytes)`
- **Repo-wide** `pnpm lint` (`eslint . --no-inline-config`) run in full, not narrowed — clean, 55s under the shared verify lock.

No changeset: this edits a CI-internal script and releases nothing — the case
`lint.yml` names as textbook `skip-changeset`. Label applied and read back.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ahemw8RcTgqtxrj15PEZx)_