### PR TITLE
fix(driver-sql): declared booleans answer JSON booleans on MySQL's row-read doors (find/distinct/group keys)

### DIFF
--- a/.changeset/mysql-boolean-row-read-presentation.md
+++ b/.changeset/mysql-boolean-row-read-presentation.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+fix(driver-sql): a declared `Field.boolean` answers JSON booleans on MySQL's row-read doors (#11782)
+
+`formatOutput`'s boolean read coercion — and its per-column mirror
+`readPresentationKind`, which `distinct()` and the aggregate group-key /
+`min`/`max` tracking consume — was gated `isSqlite`-only. On MySQL the storage
+is `tinyint(1)` and mysql2 hands back a JS number, so a declared boolean
+answered `1`/`0` through `find()`, `distinct()` and aggregate group keys while
+SQLite and Postgres answered `true`/`false` — and, after #11635 presented
+aggregate `min`/`max` on every dialect, `max(flag) === true` and
+`row.flag === 1` disagreed on the same column over the same MySQL connection.
+
+Measured on live MySQL 8.0.46 before the fix: `find().flag` → `1` (`typeof
+number`), `distinct('flag')` → `[0, 1]`, aggregate group keys → `1`/`0`. The
+boolean presentation now runs on the two dialects whose stored boolean is a
+number (SQLite `INTEGER` 0/1, MySQL `tinyint(1)`); Postgres stores a real
+`boolean` node-pg already parses, so it deliberately stays outside the gate and
+its answers are byte-identical. A `NULL` boolean stays `null` on every door
+(absence is not `false`), and declared `number`/`string` columns are untouched.

--- a/packages/drivers/driver-sql/src/sql-driver-11782-boolean-row-read-presentation.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-11782-boolean-row-read-presentation.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11782] A declared `Field.boolean` answers JSON booleans on EVERY read door,
+ * on every dialect this driver speaks — one column, one answer set, whichever
+ * door it is read through.
+ *
+ * ## The measured gap this suite exists to keep closed
+ *
+ * Measured 2026-08-25 on live MySQL 8.0.46 through the driver boundary, on
+ * `main` @ `d63b014360`, before the fix (the same instrument as the card:
+ * `driver.create(...)` + the read doors, over `flag` declared
+ * `type: 'boolean'`, stored as `tinyint(1)`):
+ *
+ * - `find().flag`                → `1` / `0`   (`typeof number`)
+ * - `distinct('flag')`           → `[0, 1]`    (`typeof number`)
+ * - `aggregate` groupBy(`flag`)  → keys `1`/`0` (`typeof number`)
+ * - `aggregate` `min`/`max`      → `false`/`true` (correct since #11635/#11785)
+ *
+ * while SQLite and Postgres answered `true`/`false` on all four. The boolean
+ * read coercion in `formatOutput` — and its per-column mirror
+ * `readPresentationKind`, which `distinct()` and the aggregate group-key /
+ * `min`/`max` tracking consume — was gated `isSqlite`-only, so MySQL's storage
+ * form leaked. Worse than a one-dialect leak: after #11635 presented the
+ * aggregate door everywhere, `max(flag)` answered `true` while `find()` on the
+ * SAME column over the SAME connection answered `1` — two doors, opposite
+ * answers, in one request cycle. The fix runs the boolean presentation on the
+ * two dialects whose stored boolean is a number (SQLite INTEGER 0/1, MySQL
+ * `tinyint(1)`); Postgres stores a real `boolean` node-pg parses, so its
+ * stored form already IS the presented form and it stays ungated.
+ *
+ * ## Assertion conventions
+ *
+ * Booleans are asserted STRICTLY (`toBe(true)` / `toBe(false)`, `toEqual` on
+ * exact values): the before-state is a WRONG VALUE, not an absence — `1` is
+ * truthy, so a `toBeTruthy()` pin would have passed on the defect this suite
+ * went red on. The cross-door test asserts the doors against EACH OTHER on the
+ * same column (per the triage note on the card: a one-door pin passes on an
+ * implementation where the doors still disagree).
+ *
+ * ## Controls
+ *
+ * A declared `number` and a declared `string` column ride the same fixture and
+ * must come back untouched — the presentation is per declared-boolean column,
+ * never per row. A NULL boolean stays `null` on every door: absence is not
+ * `false`, and `Boolean(null)` would manufacture one.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { SqlDriver } from './sql-driver.js';
+import { DIALECT_CELLS, declareDialectCell, type DialectCell } from './live-dialect-matrix.testkit.js';
+
+const TABLE = 'bool_row_read_presentation';
+
+/** 1 true / 2 false / 1 null — asymmetric so a sticky constant shows. */
+const ROWS = [
+  { label: 'a', flag: true, score: 10 },
+  { label: 'b', flag: false, score: 20 },
+  { label: 'c', flag: false, score: 30 },
+  { label: 'd', flag: null, score: 40 },
+] as const;
+
+function declarePresentation(cell: DialectCell): void {
+describe(`[#11782] driver-sql — boolean row reads answer JSON booleans (${cell.label})`, () => {
+  let driver: SqlDriver;
+
+  beforeAll(async () => {
+    driver = new SqlDriver(cell.config());
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.initObjects([
+      {
+        name: TABLE,
+        fields: {
+          label: { type: 'string' },
+          flag: { type: 'boolean' },
+          score: { type: 'number' },
+        },
+      },
+    ]);
+    for (const row of ROWS) {
+      await driver.create(TABLE, { ...row }, { bypassTenantAudit: true });
+    }
+  });
+
+  afterAll(async () => {
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.disconnect();
+  });
+
+  // The fixture read back rather than trusted: four rows under their labels —
+  // a seed that dropped or folded a row would turn every assertion below into
+  // a test of the wrong table.
+  it('the fixture is four rows: T, F, F, NULL', async () => {
+    const rows = (await driver.find(TABLE, {})) as Array<{ label: string }>;
+    expect(rows.map((r) => r.label).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  // ─── The row-read door (`find()`) — the card's own surface ───────────────
+
+  it('find() answers the JSON boolean true — not 1', async () => {
+    const rows = (await driver.find(TABLE, { where: { label: 'a' } } as DriverQuery)) as any[];
+    expect(rows).toHaveLength(1);
+    // STRICT: `1` — the exact value this suite went red on — is truthy.
+    expect(rows[0].flag).toBe(true);
+  });
+
+  it('find() answers the JSON boolean false — not 0', async () => {
+    const rows = (await driver.find(TABLE, { where: { label: 'b' } } as DriverQuery)) as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].flag).toBe(false);
+  });
+
+  it('find() passes a NULL boolean through — absence is not false', async () => {
+    const rows = (await driver.find(TABLE, { where: { label: 'd' } } as DriverQuery)) as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].flag).toBeNull();
+  });
+
+  it('CONTROL find() leaves declared number and string columns untouched', async () => {
+    const rows = (await driver.find(TABLE, { where: { label: 'a' } } as DriverQuery)) as any[];
+    expect(rows[0].score).toBe(10);
+    expect(rows[0].label).toBe('a');
+  });
+
+  // ─── The values door (`distinct()`) — measured here, shares the gate ─────
+
+  it('distinct(flag) answers JSON booleans — not 0/1', async () => {
+    const values = await driver.distinct(TABLE, 'flag');
+    // Set-compare: order is the dialect's; membership is the contract.
+    // `toEqual` does not coerce, so a `Set {0, 1, null}` fails here.
+    expect(new Set(values)).toEqual(new Set([true, false, null]));
+  });
+
+  it('CONTROL distinct(score) still answers numbers', async () => {
+    const values = await driver.distinct(TABLE, 'score');
+    expect(new Set(values)).toEqual(new Set([10, 20, 30, 40]));
+  });
+
+  // ─── Cross-door agreement — the assertion the triage note asked for ──────
+
+  it('find(), distinct() and aggregate() answer the SAME JSON booleans for the same column', async () => {
+    const found = new Set(
+      ((await driver.find(TABLE, {})) as any[]).map((r) => r.flag),
+    );
+    const listed = new Set(await driver.distinct(TABLE, 'flag'));
+    const grouped = (await driver.aggregate(TABLE, {
+      groupBy: ['flag'],
+      aggregations: [{ function: 'count', field: 'score', alias: 'n' }],
+    } as DriverQuery)) as any[];
+    const groupKeys = new Set(grouped.map((g) => g.flag));
+    const agg = (await driver.aggregate(TABLE, {
+      aggregations: [
+        { function: 'min', field: 'flag', alias: 'lo' },
+        { function: 'max', field: 'flag', alias: 'hi' },
+      ],
+    } as DriverQuery)) as any[];
+
+    const domain = new Set([true, false, null]);
+    expect(found, 'find()').toEqual(domain);
+    expect(listed, 'distinct()').toEqual(domain);
+    expect(groupKeys, 'aggregate group keys').toEqual(domain);
+    expect(agg[0].lo, 'min(flag)').toBe(false);
+    expect(agg[0].hi, 'max(flag)').toBe(true);
+  });
+
+  it('aggregate group keys carry per-group counts under the presented key', async () => {
+    const grouped = (await driver.aggregate(TABLE, {
+      groupBy: ['flag'],
+      aggregations: [{ function: 'count', field: 'score', alias: 'n' }],
+    } as DriverQuery)) as any[];
+    const byKey = new Map(grouped.map((g) => [g.flag, Number(g.n)]));
+    expect(byKey.get(true), 'count under key true').toBe(1);
+    expect(byKey.get(false), 'count under key false').toBe(2);
+    expect(byKey.get(null), 'count under key null').toBe(1);
+  });
+});
+}
+
+// A matrix that silently finds zero cells reports OK — assert the axis is real
+// before iterating it (the #11455 suite's own guard, kept in force here).
+describe('[#11782] the dialect axis this suite runs', () => {
+  it('runs every dialect this driver speaks', () => {
+    expect(DIALECT_CELLS.map((c) => c.id)).toEqual(['sqlite', 'pg', 'mysql']);
+  });
+});
+
+for (const cell of DIALECT_CELLS) {
+  declareDialectCell(cell, 'boolean row-read presentation', declarePresentation);
+}

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -7987,13 +7987,15 @@ export class SqlDriver implements IDataDriver {
           // only, so it is deliberately not tracked.
           if ((funcName === 'min' || funcName === 'max') && agg.field) {
             // [#11249/#11635] A boolean aggregand presents on EVERY dialect,
-            // not only under `readPresentationKind`'s SQLite gate. That gate
-            // mirrors `formatOutput`'s ROW reads, where the native dialects
-            // hand storage back as-is — but on this door the backend answers
-            // `min`/`max` as 1/0 on MySQL (`tinyint(1)`) and on Postgres (the
-            // `cast(?? as int)` above), and the ruled contract is `false` /
-            // `true` in JSON: order statistics return a member of the input
-            // domain, and SQL drivers convert at the driver boundary.
+            // not only under `readPresentationKind`'s dialect gate. That gate
+            // mirrors `formatOutput`'s ROW reads (SQLite + MySQL since #11782;
+            // SQLite-only when this landed), where the storage-form dialects
+            // hand back a number — but on this door the backend ALSO answers
+            // `min`/`max` as 1/0 on Postgres (the `cast(?? as int)` above,
+            // over a column whose row reads need no presentation), and the
+            // ruled contract is `false` / `true` in JSON: order statistics
+            // return a member of the input domain, and SQL drivers convert at
+            // the driver boundary. The `??` fallback is what carries Postgres.
             // `presentReadValue('boolean', …)` leaves `null` (no rows / all
             // NULL) untouched and is idempotent on a value already boolean.
             const kind =
@@ -11590,9 +11592,13 @@ export class SqlDriver implements IDataDriver {
    * row, asked one field at a time so the paths that return raw builder output
    * can ask it too. `null` means the stored form already IS the presented form.
    *
-   * The boolean / numeric rules are SQLite-only because `formatOutput` gates
-   * them that way: SQLite is the dialect without a native boolean, and the
-   * numeric repair only exists for legacy TEXT-affinity columns.
+   * The boolean rule runs on SQLite AND MySQL — the two dialects that store a
+   * declared boolean as a number (INTEGER 0/1, `tinyint(1)`) — because
+   * `formatOutput` gates its row reads that way (#11782; SQLite-only before,
+   * which is how a declared boolean answered `1`/`0` on MySQL). Postgres
+   * stores a real `boolean` node-pg parses, so there the stored form already
+   * IS the presented form. The numeric repair stays SQLite-only: it exists
+   * for legacy TEXT-affinity columns, which no other dialect has.
    */
   protected readPresentationKind(
     table: string | null | undefined,
@@ -11601,8 +11607,10 @@ export class SqlDriver implements IDataDriver {
     if (!table) return null;
     const temporal = this.temporalFieldKind(table, field);
     if (temporal) return temporal;
+    if ((this.isSqlite || this.isMysql) && this.booleanFields[table]?.includes(field)) {
+      return 'boolean';
+    }
     if (!this.isSqlite) return null;
-    if (this.booleanFields[table]?.includes(field)) return 'boolean';
     if (this.numericFields[table]?.includes(field)) return 'number';
     return null;
   }
@@ -11613,10 +11621,11 @@ export class SqlDriver implements IDataDriver {
    * (`aggregate`, `distinct` — #3797 for instants, #3849 for scalars).
    *
    * The dialect gating mirrors `formatOutput`: the `Field.datetime` repair and
-   * the boolean / numeric coercions are SQLite-only (it is the one dialect where
-   * storage ≠ presentation), while the `Field.date` → `YYYY-MM-DD` collapse runs
-   * everywhere. {@link readPresentationKind} does the SQLite gating for the
-   * scalar kinds, so by the time one arrives here the dialect is settled.
+   * the numeric coercion are SQLite-only, the boolean coercion runs on SQLite
+   * and MySQL (#11782 — the two dialects whose stored boolean is a number),
+   * and the `Field.date` → `YYYY-MM-DD` collapse runs everywhere.
+   * {@link readPresentationKind} does the dialect gating for the scalar kinds,
+   * so by the time one arrives here the dialect is settled.
    */
   protected presentReadValue(kind: ReadPresentationKind, value: any): any {
     if (value == null) return value;
@@ -14309,15 +14318,6 @@ export class SqlDriver implements IDataDriver {
         }
       }
 
-      const booleanFields = this.booleanFields[object];
-      if (booleanFields && booleanFields.length > 0) {
-        for (const field of booleanFields) {
-          if (data[field] !== undefined && data[field] !== null) {
-            data[field] = Boolean(data[field]);
-          }
-        }
-      }
-
       // Numeric scalars stored on a legacy TEXT-affinity column come back as
       // strings ('4'); coerce numeric-looking strings back to numbers so the
       // declared type wins regardless of when the column was created. Only
@@ -14360,6 +14360,29 @@ export class SqlDriver implements IDataDriver {
         for (const field of datetimeFields) {
           if (data[field] !== undefined) {
             data[field] = normalizeSqliteDatetimeOutput(data[field]);
+          }
+        }
+      }
+    }
+
+    // [#11782] Present a declared `Field.boolean` as a JSON boolean on the
+    // dialects whose STORAGE form is a number: SQLite (INTEGER 0/1) and MySQL
+    // (`tinyint(1)`, which mysql2 hands back as a JS number). Postgres stores a
+    // real `boolean` and node-pg already parses it, so its stored form IS the
+    // presented form and it deliberately stays outside the gate — the same
+    // per-dialect posture {@link readPresentationKind} takes for the read doors
+    // that return raw builder output (`distinct`; `aggregate` tracks its own
+    // result columns per #11635). Before this, the gate was SQLite-only and a
+    // declared boolean answered `1`/`0` on MySQL's row-read door while
+    // answering `true`/`false` on the other two dialects — and, once #11635
+    // presented `min`/`max` everywhere, `find()` and `aggregate()` gave
+    // OPPOSITE answers for the same column on the same MySQL connection.
+    if (this.isSqlite || this.isMysql) {
+      const booleanFields = this.booleanFields[object];
+      if (booleanFields && booleanFields.length > 0) {
+        for (const field of booleanFields) {
+          if (data[field] !== undefined && data[field] !== null) {
+            data[field] = Boolean(data[field]);
           }
         }
       }


### PR DESCRIPTION
Fixes #11782

## What this changes

`formatOutput`'s boolean read coercion and `readPresentationKind`'s boolean arm were gated `isSqlite`-only, so a declared `Field.boolean` leaked its storage form on MySQL: `tinyint(1)` reaches mysql2 as a JS number, and nothing downstream converted. The boolean presentation now runs on the two dialects whose stored boolean is a number — SQLite (`INTEGER` 0/1) and MySQL (`tinyint(1)`). Postgres stores a real `boolean` that node-pg parses, so its stored form already IS the presented form and it deliberately stays outside the gate: its answers are byte-identical before and after.

## Contract surface — answer set per door, per dialect (dispatched at tier; stated explicitly)

Measured live before (`main` @ `d63b014360`) and after (this branch), on MySQL 8.0.46, PostgreSQL 16.13, embedded SQLite, through the driver boundary (`driver.create(...)` + each read door — the card's own instrument):

| Door | sqlite before → after | pg before → after | mysql before → after |
|---|---|---|---|
| `find()` row value | `true`/`false` → unchanged | `true`/`false` → unchanged | **`1`/`0` (number) → `true`/`false` (boolean)** |
| `distinct()` values | `[true,false]` → unchanged | `[true,false]` → unchanged | **`[0,1]` (number) → `[true,false]` (boolean)** |
| `aggregate()` group keys | `true`/`false` → unchanged | `true`/`false` → unchanged | **`1`/`0` (number) → `true`/`false` (boolean)** |
| `aggregate()` `min`/`max` | `false`/`true` → unchanged | `false`/`true` → unchanged | `false`/`true` → unchanged (#11635 already presented this door; it now short-circuits on `readPresentationKind` instead of the call-site fallback — same answers) |
| `NULL` boolean, every door | `null` → unchanged | `null` → unchanged | `null` → unchanged (absence is not `false`) |
| Controls: declared `number` / `string` columns, every door | unchanged | unchanged | unchanged |

The aggregate `min`/`max` row is the cross-door disagreement this card exists to close: since #11635, `max(flag)` answered `true` on MySQL while `find()` on the same column over the same connection answered `1`. The group-key cells are the same gate consumed through the groupBy tracking sites — before this fix MySQL was also the one dialect whose group keys disagreed with SQLite/Postgres. `distinct()` was recorded on the card as UNMEASURED; it is measured here (before: `[0,1]` on MySQL) and decided alongside `find()`, through the shared gate.

Scope fence honoured: `aggregate()`'s lowering and its #11635 call-site fallback are behaviourally untouched (one comment updated to stay accurate). The fallback is NOT dead code after this change — it is what carries Postgres, where `cast(?? as int)` makes the backend answer 1/0 while row reads need no presentation.

## Regions (declared by symbol — serial constraint vs #11876)

- `formatOutput` — the `booleanFields` read coercion, moved out of the SQLite-only block behind an `isSqlite || isMysql` gate.
- `readPresentationKind` — the boolean arm now applies on SQLite and MySQL; the numeric arm stays SQLite-only (it exists for legacy TEXT-affinity columns, which only SQLite has).
- The `distinct()` seam consumes the re-gated `readPresentationKind`; no code in `distinct()` itself changed.
- Comment-only accuracy updates in `presentReadValue`'s doc and at the #11635 aggregate `min`/`max` tracking site (its prose described a "SQLite gate" that no longer exists as stated; no behaviour touched).

Disjoint from #11876's regions (`createColumn` / varchar width mirror). `origin/main` merged before opening this PR (merge commit `0091979a8e`); no upstream `driver-sql` movement between base and merge (path-filtered log empty). A `mariadb` client spelling stays outside `MYSQL_EMIT_CLIENTS` and therefore outside this gate — that is the standing #11756 support-scope decision, not this card's.

## Evidence

- **Pin**: `sql-driver-11782-boolean-row-read-presentation.test.ts` — 9 tests per dialect cell over the live matrix + the axis guard (28 total). Asserts cross-door agreement on the same column (find + distinct + group keys + min/max), per the triage note — a one-door pin passes on an implementation where the doors still disagree. Booleans asserted strictly (`toBe(true)`; `1` is truthy and would pass a `toBeTruthy` pin). Negative controls: declared `number`/`string` columns and `NULL` passthrough.
- **Ablation** (fix reverted to the SQLite-only gate, from the committed state): direction predicted in advance per cell — sqlite 9 green, pg 9 green, mysql 5 red / 4 green with named failure modes. Observed exactly that: 23 pass / 5 fail, all five in the live mysql cell (`expected 1 to be true // Object.is equality`; `Set{1, null, +0}` ≠ `Set{true, false, null}`; group count under key `true` undefined). Mutation proven on disk before any result was read (anchored greps: union-gate spelling 2→0, `#11782` tags 4→0), restore under `trap … EXIT INT TERM`, post-restore anchors 2/4 and clean `git status --porcelain`. No build leg owed: the suite imports `./sql-driver.js` relative from `src`, so the subject never resolves through a dependency `exports` map — no dist is involved in the measurement.
- **Full package suite** at `0091979a8e` under CI-parity skew (PG `Asia/Shanghai`, MySQL `+08:00`, process `America/New_York`, `OS_EXPECT_LIVE_DIALECT_MATRIX=1`, both live servers attached): **138 files, 2778 passed, 1 skipped, 0 failed**.
- **Downstream live-MySQL consumers** (`@objectstack/metadata-protocol` migration suites): 10/10 green.
- **Driver-conformance census** before (BASE tree) and after: identical — 5 drivers × 9 case-sets, 45 covered cells, 0 debt, 0 exempt.
- **Typecheck**: `pnpm --filter @objectstack/driver-sql typecheck` green at `0091979a8e` (script echo verified).
- **Gate union** derived (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`; the script derives the changeset itself from the merge-base; its stderr attribution line names this repo at this checkout): 14 path-matched + 6 convention-triggered (new test file) + `check:nul-bytes`. **All 21 ran at `0091979a8e` (this PR's head), every exit captured before any pipe, all `EXIT=0`.** Verdict lines from the gates' own output include: `check-driver-conformance: OK — 45 covered cell(s), 0 in the DEBT ledger, 0 exempt`; `check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured in 346.6s, 1898 raw tsc error(s) total, none above its recorded number` (the debt gate, run on the freshly built `./packages/*` closure); `check-engine-double-contract: OK — 405 pinned, 133 in the DEBT ledger, 2 exempt`; `where-matcher conformance holds: 297 matcher(s) discovered, 297 answer the combinator battery correctly or refuse it loudly`; `check-nul-bytes: OK (scanned 6664 text file(s) … no raw ASCII control bytes)`; `OK: 16 package(s) read outside themselves, all declared` (cross-package-test-inputs); `query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new`.
- **ESLint** (repo scan is CI's; declared narrowing with its three-part proof): the diff's lintable population is exactly the two `.ts` files — the changeset `.md` returns eslint's own "File ignored because no matching configuration was supplied"; `--format json` counts 2 files linted, 0 errors, 0 warnings; and this repo's `eslint.config.mjs` states in its own docblock that type-aware linting is never enabled for any file, so a diff cannot move an untouched file's lint verdict.
- **Upstream re-checked after the union ran**: `origin/main` gained 3 commits past this branch's merge point (spec `maxLength`, release CI, a showcase test) — none touch `packages/drivers/driver-sql/` or any file in this diff, and #11876 has not landed, so the serial trigger ("merge again if #11876 lands first") has not fired. The full package suite and typecheck above were re-run at `0091979a8e` after that check.

## Changeset

`@objectstack/driver-sql` patch — user-visible presentation change on MySQL row-read doors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_