### PR TITLE
feat(plugin-auth): warn at boot when a walled deployment declares an owner it can never verify

### DIFF
--- a/.changeset/walled-owner-no-verification-path-warning.md
+++ b/.changeset/walled-owner-no-verification-path-warning.md
@@ -1,0 +1,27 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+feat(plugin-auth): warn at boot when a walled deployment declares an owner it can never verify (#11640)
+
+A walled deployment (`OS_TENANCY_POSTURE=group|isolated`) that declares
+`OS_PLATFORM_OWNER_EMAIL` but wires **no verification path** — no email
+transport and no trusted federated sign-in — now emits a loud, named boot
+warning (`walled_owner_no_verification_path`) on `kernel:ready`.
+
+Since #11343, walled platform-admin elevation requires the declared owner's
+address to be **verified**, and verification can only arrive by an emailed
+link or by a federated sign-in that inserts the account already verified. With
+neither wired, the declared owner registers, is refused
+(`walled_owner_not_verified`), and has no in-product way to satisfy the
+condition — a dead end that previously surfaced only weeks later, at the
+owner's rejected registration. The warning names both missing inputs and the
+concrete wiring for either remedy (an email service, or SSO / a social
+provider), since either one alone clears it.
+
+⛔ **Boot proceeds — this is not a refusal**, and no accept/reject behaviour
+changes anywhere: the walled + undeclared-owner boot refusal (#11184) and the
+fail-closed elevation refusal (#11343) are untouched. Deployments already
+wiring either verification path see no new output, and neither does a
+dev/harness boot whose declared owner is the dev-admin the seed provisions and
+stamps verified.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -3353,6 +3353,21 @@ export class AuthManager {
   }
 
   /**
+   * [#11640] Whether an outbound email transport is wired RIGHT NOW.
+   *
+   * The one public read of the fact every verification link depends on: with
+   * no transport the `sendVerificationEmail` callback has nowhere to send, so
+   * an address can only ever become verified through a federated sign-in. The
+   * boot check in `walled-owner-verification-path.ts` asks this rather than
+   * re-deriving it from config, because the transport can arrive two ways —
+   * host-supplied at construction, or injected on `kernel:ready` once the
+   * kernel `email` service resolves — and only this object sees both.
+   */
+  public hasEmailTransport(): boolean {
+    return !!this.config.emailService;
+  }
+
+  /**
    * #8019 — mail the address a change-email request would move the account
    * AWAY from. Maintainer ruling 2026-08-12: 「notify the OLD address — do not
    * gate on it」.

--- a/packages/plugins/plugin-auth/src/auth-plugin-walled-owner-verification-path.test.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin-walled-owner-verification-path.test.ts
@@ -1,0 +1,302 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11640] The boot-time warning for a walled deployment that declares a
+ * platform owner it can never verify — maintainer ruling 2026-08-25 (option
+ * A, verbatim 「全部同意」).
+ *
+ * ⛔ Nothing here may become a refusal: boot proceeds in EVERY shape below,
+ * including the one that warns. The two refusals around this check
+ * (`walled_owner_email_undeclared` at boot, `walled_owner_not_verified` at
+ * elevation) are pinned by their own suites and are untouched.
+ *
+ * The load-bearing half of this file is the CONTROLS. A warning that fires on
+ * every boot satisfies "the dead-end shape warns" just as well as a correct
+ * one does, so each neighbouring shape — a transport wired, a federated
+ * sign-in wired, an unwalled posture, an undeclared owner, and the dev/harness
+ * boot that verifies its own seeded owner — is pinned SILENT.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AuthPlugin } from './auth-plugin';
+import {
+  WALLED_OWNER_NO_VERIFICATION_PATH,
+  resolveWalledOwnerVerificationPathWarning,
+  warnIfWalledOwnerCannotVerify,
+} from './walled-owner-verification-path';
+import type { PluginContext } from '@objectstack/core';
+
+const OWNER = 'operator@corp.example';
+const DEV_SEED_ADMIN = 'admin@objectos.ai';
+
+/** No transport, no federated sign-in — the shape the ruling is about. */
+const NOTHING_WIRED = { hasEmailTransport: false, hasFederatedSignIn: false } as const;
+
+const ENV_KEYS = [
+  'OS_TENANCY_POSTURE',
+  'OS_MULTI_ORG_ENABLED',
+  'OS_PLATFORM_OWNER_EMAIL',
+  'OS_SEED_ADMIN',
+  'OS_SEED_ADMIN_EMAIL',
+  'OS_SSO_ENABLED',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'NODE_ENV',
+] as const;
+
+const SAVED: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    SAVED[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (SAVED[k] === undefined) delete process.env[k];
+    else process.env[k] = SAVED[k];
+  }
+});
+
+/** The ruled dead end: walled posture, owner declared. */
+const walledWithDeclaredOwner = (posture = 'isolated', owner = OWNER) => {
+  process.env.OS_TENANCY_POSTURE = posture;
+  process.env.OS_PLATFORM_OWNER_EMAIL = owner;
+};
+
+describe('#11640 — the dead-end shape warns, by name and with the remedy', () => {
+  it('walled + owner declared + no transport + no federated sign-in produces the named warning', () => {
+    walledWithDeclaredOwner();
+    const msg = resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED);
+    expect(msg).toBeTruthy();
+    expect(msg).toContain(WALLED_OWNER_NO_VERIFICATION_PATH);
+    // Names the posture and the declared owner, so an operator reading one
+    // line knows which deployment and which address.
+    expect(msg).toContain("'isolated'");
+    expect(msg).toContain('OS_PLATFORM_OWNER_EMAIL');
+    expect(msg).toContain(OWNER);
+  });
+
+  it('the warning NAMES BOTH REMEDIES — the card is only closed if it is actionable', () => {
+    walledWithDeclaredOwner();
+    const msg = resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)!;
+    // (1) the email transport, named concretely enough to act on
+    expect(msg).toContain('EMAIL TRANSPORT');
+    expect(msg).toContain('OS_EMAIL_');
+    // (2) the federated sign-in, likewise
+    expect(msg).toContain('FEDERATED SIGN-IN');
+    expect(msg).toContain('OS_SSO_ENABLED');
+    expect(msg).toContain('GOOGLE_CLIENT_ID');
+    // Either input alone is enough, and the text says so — otherwise the
+    // operator wires both, or reads the docs to find out. C is subsumed by A
+    // exactly here.
+    expect(msg).toContain('Either one alone clears this');
+    // …and it says what goes wrong if nothing is wired, in the vocabulary of
+    // the refusal the owner will actually hit.
+    expect(msg).toContain('walled_owner_not_verified');
+  });
+
+  it('⛔ it is a WARNING, never a refusal — the text promises boot continues', () => {
+    walledWithDeclaredOwner();
+    const msg = resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)!;
+    expect(msg).toContain('Boot continues');
+    expect(msg).not.toContain('Refusing to boot');
+    expect(msg).not.toContain('REFUSING');
+  });
+
+  it('the other walled posture (`group`) is covered, and names itself', () => {
+    walledWithDeclaredOwner('group');
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toContain("'group'");
+  });
+
+  it('the legacy boolean spelling of a wall (OS_MULTI_ORG_ENABLED=true) is covered too', () => {
+    process.env.OS_MULTI_ORG_ENABLED = 'true';
+    process.env.OS_PLATFORM_OWNER_EMAIL = OWNER;
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toContain(
+      WALLED_OWNER_NO_VERIFICATION_PATH,
+    );
+  });
+});
+
+describe('#11640 — controls: every neighbouring shape stays SILENT', () => {
+  it('an email transport is wired ⇒ the verification link can be delivered ⇒ no warning', () => {
+    walledWithDeclaredOwner();
+    expect(
+      resolveWalledOwnerVerificationPathWarning({
+        hasEmailTransport: true,
+        hasFederatedSignIn: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('a federated sign-in is wired ⇒ the owner can arrive already verified ⇒ no warning', () => {
+    walledWithDeclaredOwner();
+    expect(
+      resolveWalledOwnerVerificationPathWarning({
+        hasEmailTransport: false,
+        hasFederatedSignIn: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('an UNWALLED posture never warns — `single` still promotes the first human user', () => {
+    process.env.OS_TENANCY_POSTURE = 'single';
+    process.env.OS_PLATFORM_OWNER_EMAIL = OWNER;
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toBeNull();
+  });
+
+  it('an UNDECLARED owner is not this check\'s business — `init()` already refused that boot', () => {
+    process.env.OS_TENANCY_POSTURE = 'isolated';
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toBeNull();
+    process.env.OS_PLATFORM_OWNER_EMAIL = '   ';
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toBeNull();
+  });
+
+  it('a dev/harness boot that seeds THIS owner verifies it at startup ⇒ no warning', () => {
+    // The dev-admin seed provisions the declared owner and stamps it
+    // `email_verified` (#11343), which is a verification path even with no
+    // mailbox anywhere — the verify harness boots exactly this shape.
+    process.env.NODE_ENV = 'development';
+    walledWithDeclaredOwner('isolated', DEV_SEED_ADMIN);
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toBeNull();
+
+    // …and it follows the seed's own address knob, not a hard-coded default.
+    process.env.OS_SEED_ADMIN_EMAIL = 'seeded-owner@corp.example';
+    process.env.OS_PLATFORM_OWNER_EMAIL = 'seeded-owner@corp.example';
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toBeNull();
+  });
+
+  it('…but a dev boot whose declared owner is NOT the seeded one is a real dead end', () => {
+    process.env.NODE_ENV = 'development';
+    walledWithDeclaredOwner('isolated', OWNER); // seed provisions admin@objectos.ai
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toContain(
+      WALLED_OWNER_NO_VERIFICATION_PATH,
+    );
+  });
+
+  it('…and a dev boot with the seed switched OFF gets no free pass either', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.OS_SEED_ADMIN = '0';
+    walledWithDeclaredOwner('isolated', DEV_SEED_ADMIN);
+    expect(resolveWalledOwnerVerificationPathWarning(NOTHING_WIRED)).toContain(
+      WALLED_OWNER_NO_VERIFICATION_PATH,
+    );
+  });
+});
+
+describe('#11640 — the emitter logs once, on the channel `serve` replays', () => {
+  it('warns exactly once and returns what it logged', () => {
+    walledWithDeclaredOwner();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    const returned = warnIfWalledOwnerCannotVerify(NOTHING_WIRED, logger);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(String(logger.warn.mock.calls[0][0])).toContain(WALLED_OWNER_NO_VERIFICATION_PATH);
+    expect(returned).toBe(logger.warn.mock.calls[0][0]);
+    // `warn`, not `error`: the ruling is a warning, and #4012's boot-log
+    // capture replays `warn` records into the startup banner.
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('a control shape logs nothing at all', () => {
+    walledWithDeclaredOwner();
+    const logger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    expect(
+      warnIfWalledOwnerCannotVerify({ hasEmailTransport: true, hasFederatedSignIn: false }, logger),
+    ).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('a logger that throws cannot break the boot', () => {
+    walledWithDeclaredOwner();
+    const logger = { warn: () => { throw new Error('sink is down'); } };
+    expect(() => warnIfWalledOwnerCannotVerify(NOTHING_WIRED, logger)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wired at boot, not merely written: the check has to run from the plugin's
+// own `kernel:ready` hook, or none of the above ever reaches an operator.
+// ---------------------------------------------------------------------------
+
+type Hooked = { event: string; handler: (...a: unknown[]) => unknown };
+
+const makeCtx = (services: Record<string, unknown> = {}) => {
+  const hooks: Hooked[] = [];
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+  const ctx = {
+    registerService: vi.fn(),
+    getService: vi.fn((name: string) => {
+      if (name === 'manifest') return { register: vi.fn() };
+      return services[name];
+    }),
+    getServices: vi.fn(() => new Map()),
+    hook: vi.fn((event: string, handler: (...a: unknown[]) => unknown) => {
+      hooks.push({ event, handler });
+    }),
+    trigger: vi.fn(),
+    logger,
+    getKernel: vi.fn(),
+  } as unknown as PluginContext;
+  return { ctx, hooks, logger };
+};
+
+const runKernelReady = async (hooks: Hooked[]) => {
+  for (const h of hooks.filter((x) => x.event === 'kernel:ready')) {
+    // Sibling hooks need services this fake context does not carry; their
+    // failures are not this suite's subject.
+    try { await h.handler(); } catch { /* not under test */ }
+  }
+};
+
+describe('#11640 — the check is wired into AuthPlugin boot', () => {
+  const plugin = () =>
+    new AuthPlugin({ secret: 'test-secret-at-least-32-chars-long', registerRoutes: false });
+
+  it('a walled boot with nothing wired emits the named warning from kernel:ready', async () => {
+    walledWithDeclaredOwner();
+    const { ctx, hooks, logger } = makeCtx();
+    const p = plugin();
+    await p.init(ctx);
+    await p.start(ctx);
+    await runKernelReady(hooks);
+    const warned = logger.warn.mock.calls.map((c) => String(c[0]));
+    expect(warned.filter((m) => m.includes(WALLED_OWNER_NO_VERIFICATION_PATH))).toHaveLength(1);
+  });
+
+  it('control — the same boot with an `email` service registered stays silent', async () => {
+    walledWithDeclaredOwner();
+    const { ctx, hooks, logger } = makeCtx({ email: { sendTemplate: vi.fn() } });
+    const p = plugin();
+    await p.init(ctx);
+    await p.start(ctx);
+    await runKernelReady(hooks);
+    const warned = logger.warn.mock.calls.map((c) => String(c[0]));
+    expect(warned.filter((m) => m.includes(WALLED_OWNER_NO_VERIFICATION_PATH))).toHaveLength(0);
+  });
+
+  it('control — the same boot with a social provider configured stays silent', async () => {
+    walledWithDeclaredOwner();
+    process.env.GOOGLE_CLIENT_ID = 'client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'client-secret';
+    const { ctx, hooks, logger } = makeCtx();
+    const p = plugin();
+    await p.init(ctx);
+    await p.start(ctx);
+    await runKernelReady(hooks);
+    const warned = logger.warn.mock.calls.map((c) => String(c[0]));
+    expect(warned.filter((m) => m.includes(WALLED_OWNER_NO_VERIFICATION_PATH))).toHaveLength(0);
+  });
+
+  it('control — an unwalled boot never warns, whatever is (not) wired', async () => {
+    process.env.OS_TENANCY_POSTURE = 'single';
+    process.env.OS_PLATFORM_OWNER_EMAIL = OWNER;
+    const { ctx, hooks, logger } = makeCtx();
+    const p = plugin();
+    await p.init(ctx);
+    await p.start(ctx);
+    await runKernelReady(hooks);
+    const warned = logger.warn.mock.calls.map((c) => String(c[0]));
+    expect(warned.filter((m) => m.includes(WALLED_OWNER_NO_VERIFICATION_PATH))).toHaveLength(0);
+  });
+});

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -57,6 +57,11 @@ import {
   authPluginManifestHeader,
 } from './manifest.js';
 import { scheduleLegacySsoSecretMigration } from './sso-client-secret.js';
+import {
+  devSeedAdminEmail,
+  isDevAdminSeedArmed,
+  warnIfWalledOwnerCannotVerify,
+} from './walled-owner-verification-path.js';
 import { judgePlatformAdmin, type PlatformAdminActor } from './platform-admin-gate.js';
 import {
   runAdminBanUser,
@@ -901,6 +906,36 @@ export class AuthPlugin implements Plugin {
       });
     }
 
+    // [#11640] The walled deployment that declares an owner it can never
+    // verify — maintainer ruling 2026-08-25 (option A): warn loudly, by name,
+    // at boot; NEVER refuse. The whole decision (and why it must run here
+    // rather than in `init()`, where no email transport is resolvable yet)
+    // lives in `walled-owner-verification-path.ts`; this hook only supplies
+    // the two live wiring facts. Registered independently of `registerRoutes`
+    // so an embedding that serves no auth routes still gets the diagnosis.
+    //
+    // ⚠️ #11663's re-anchor legs (L2 #11970 / L4 #11974) will rewrite this
+    // elevation surface: move THIS call, not the predicate — the message and
+    // its controls travel with the module.
+    ctx.hook('kernel:ready', async () => {
+      let emailSvc: IEmailService | undefined;
+      try { emailSvc = ctx.getService<IEmailService>('email'); } catch { emailSvc = undefined; }
+      // The auth manager's own view: a host can hand a transport straight to
+      // `AuthManager` without ever registering the kernel `email` service, and
+      // the sibling hook below injects the service into it. Reading BOTH makes
+      // this hook's answer independent of hook registration order.
+      let pub: { socialProviders?: unknown[]; features?: { sso?: boolean } } | undefined;
+      try { pub = this.authManager?.getPublicConfig(); } catch { pub = undefined; }
+      warnIfWalledOwnerCannotVerify(
+        {
+          hasEmailTransport: !!emailSvc || !!this.authManager?.hasEmailTransport(),
+          hasFederatedSignIn:
+            (pub?.socialProviders?.length ?? 0) > 0 || pub?.features?.sso === true,
+        },
+        ctx.logger,
+      );
+    });
+
     // Dev-only: provision a known, loginable platform admin on an empty DB.
     // Registered as its own kernel:ready hook (independent of registerRoutes)
     // so it runs whenever the runtime boots in development.
@@ -1541,11 +1576,15 @@ export class AuthPlugin implements Plugin {
    * OS_SEED_ADMIN=0 (or false/off/no).
    */
   private async maybeSeedDevAdmin(ctx: PluginContext): Promise<void> {
-    if (process.env.NODE_ENV !== 'development') return;
-    const flag = String(process.env.OS_SEED_ADMIN ?? '').trim().toLowerCase();
-    if (['0', 'false', 'off', 'no'].includes(flag)) return;
+    // [#11640] Both clauses (and the seeded address below) are resolved by
+    // `walled-owner-verification-path.ts`, because the boot check there treats
+    // this seed as a verification path — it stamps the seeded account
+    // `email_verified` (#11343). That is only true while the two agree on when
+    // the seed is armed and which address it provisions, so they read one
+    // resolution rather than two copies of the same env parsing.
+    if (!isDevAdminSeedArmed()) return;
 
-    const email = process.env.OS_SEED_ADMIN_EMAIL?.trim() || 'admin@objectos.ai';
+    const email = devSeedAdminEmail();
     const password = process.env.OS_SEED_ADMIN_PASSWORD?.trim() || 'admin123';
     const name = process.env.OS_SEED_ADMIN_NAME?.trim() || 'Dev Admin';
 

--- a/packages/plugins/plugin-auth/src/walled-owner-verification-path.ts
+++ b/packages/plugins/plugin-auth/src/walled-owner-verification-path.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11640] The walled deployment that declares an owner it can never verify.
+ *
+ * Maintainer ruling 2026-08-25 (decision-inbox batch 5, verbatim: 「全部同意」
+ * accepting option **A**): at boot, a walled deployment with
+ * `OS_PLATFORM_OWNER_EMAIL` **declared** but **no verification path** — no
+ * email transport wired, no trusted federated sign-in — emits a **loud, named
+ * warning**, so the operator sees the dead end at deploy time instead of at
+ * the owner's rejected registration weeks later.
+ *
+ * ⛔ **Boot PROCEEDS. This is not a refusal**, and it changes no accept/reject
+ * behaviour anywhere. The two fail-closed clauses around it are untouched:
+ *   - walled + owner UNDECLARED still REFUSES STARTUP (`auth-plugin.ts`
+ *     `init()`, #11184) — this check never runs in that shape, because boot
+ *     already aborted;
+ *   - walled + owner declared but the account unverified still REFUSES
+ *     ELEVATION (`bootstrapPlatformAdmin`, `walled_owner_not_verified`,
+ *     #11343) — this check is the *forecast* of that refusal, not a
+ *     replacement for it.
+ *
+ * ## Why the deployment is a dead end
+ *
+ * #11343 made walled platform-admin elevation require a VERIFIED owner-email
+ * match (the string alone proves nothing — anyone who knows the address could
+ * register it first). Verification can arrive two ways:
+ *
+ *   1. an **email transport**, which delivers the verification link, or
+ *   2. a **trusted federated sign-in** (enterprise SSO or a social/OIDC
+ *      provider), which inserts the account already verified — better-auth
+ *      writes `emailVerified: userInfo.emailVerified` straight off the IdP
+ *      profile when it creates the user (`better-auth/dist/oauth2/
+ *      link-account.mjs`, the new-user branch).
+ *
+ * With NEITHER wired, the declared owner registers, is refused, and has no
+ * in-product way to ever satisfy the condition. Nothing else in the boot path
+ * notices: the refusal is correct and the deployment looks healthy until the
+ * one account that matters tries to sign in.
+ *
+ * ## Why the message names the remedy
+ *
+ * The ruling folded the docs-only option (C) into A: a warning that says "the
+ * owner cannot be verified" and stops there sends the operator back to the
+ * docs, which is the state this card exists to end. So the text says which
+ * inputs are missing and what wiring EITHER of them looks like — one of the
+ * two is enough, and the warning says so.
+ *
+ * ## Why `kernel:ready`, and why `warn`
+ *
+ * The check runs on `kernel:ready`, not in `init()`, because the email
+ * transport is not knowable earlier: `EmailServicePlugin` registers the
+ * kernel `email` service after plugin-auth initialises, and plugin-auth wires
+ * it into `AuthManager` on its own `kernel:ready` hook. An `init()`-time read
+ * would report "no transport" for every deployment that has one — a warning
+ * that fires on every boot is the failure mode this check has controls
+ * against.
+ *
+ * `warn` is the loud channel here rather than a quieter one: `os serve`
+ * blanks stdout while the kernel boots, and #4012 makes that window a buffer
+ * rather than a drain — records at `warn` and above are captured and replayed
+ * into the startup banner's boot diagnostics (`collectBootDiagnostics`). A
+ * boot-phase `info` is dropped; a boot-phase `warn` reaches the operator's
+ * terminal.
+ *
+ * ## Scope — deliberately half the problem
+ *
+ * This covers the no-verification-path route only. Whether the *declared
+ * address itself* is already spoken for is a runtime state a boot check
+ * cannot see, and the ruling leaves it out on purpose; it stays an ungraded
+ * finding on the card's thread.
+ *
+ * ⚠️ **For whoever rewrites this surface** (the #11663 re-anchor legs L2
+ * #11970 / L4 #11974, both `pm:blocked` as of 2026-08-25): the decision lives
+ * entirely in this module and the call site is one `kernel:ready` hook in
+ * `AuthPlugin.start()`. Move the call; the predicate and its message travel
+ * with the file.
+ */
+
+import {
+  PLATFORM_OWNER_EMAIL_ENV,
+  resolvePlatformOwnerEmail,
+  resolveTenancyPosture,
+} from '@objectstack/types';
+import { postureEnforcesWall } from '@objectstack/spec/security';
+
+/**
+ * The stable NAME of this warning — the "named" half of the ruled "loud, named
+ * warning". It leads the message so an operator (or a support thread) can grep
+ * one token, the same way the elevation refusals are keyed by
+ * `walled_owner_email_undeclared` / `walled_owner_not_verified`.
+ */
+export const WALLED_OWNER_NO_VERIFICATION_PATH = 'walled_owner_no_verification_path';
+
+/** Default address the dev-admin seed provisions (see {@link devSeedAdminEmail}). */
+const DEV_SEED_ADMIN_EMAIL_DEFAULT = 'admin@objectos.ai';
+
+/** `OS_SEED_ADMIN` spellings that turn the dev-admin seed off. */
+const DEV_SEED_DISABLED_SPELLINGS = ['0', 'false', 'off', 'no'];
+
+const env = (): Record<string, string | undefined> =>
+  ((globalThis as { process?: { env?: Record<string, string | undefined> } })?.process?.env ?? {});
+
+/**
+ * The address `AuthPlugin.maybeSeedDevAdmin` provisions. Exported so the seed
+ * and this check read ONE resolution: the check treats the seed as a
+ * verification path (it stamps the seeded account `email_verified`, #11343),
+ * which is only true while both agree on which address gets stamped.
+ */
+export function devSeedAdminEmail(): string {
+  return env().OS_SEED_ADMIN_EMAIL?.trim() || DEV_SEED_ADMIN_EMAIL_DEFAULT;
+}
+
+/**
+ * Whether the dev-admin seed is armed for this process — HARD-gated to
+ * `NODE_ENV==='development'`, opt-out via `OS_SEED_ADMIN=0|false|off|no`.
+ * Same two clauses `maybeSeedDevAdmin` gates itself on, read from one place.
+ *
+ * "Armed" is a statement about CONFIGURATION, not about what the seed will do:
+ * it also requires an empty database, which is runtime state neither the seed
+ * nor this check can know at this point.
+ */
+export function isDevAdminSeedArmed(): boolean {
+  if (env().NODE_ENV !== 'development') return false;
+  const flag = String(env().OS_SEED_ADMIN ?? '').trim().toLowerCase();
+  return !DEV_SEED_DISABLED_SPELLINGS.includes(flag);
+}
+
+/**
+ * What this deployment has wired that could ever verify an address. Both
+ * members are resolved by the caller from the live runtime — the services and
+ * provider config as they stand at `kernel:ready` — because neither is an
+ * env-only fact.
+ */
+export interface VerificationPathWiring {
+  /**
+   * An outbound email transport (the kernel `email` service, or one handed to
+   * `AuthManager` directly). Without it the verification link has nowhere to
+   * go: the callback throws rather than faking a send.
+   */
+  hasEmailTransport: boolean;
+  /**
+   * At least one federated sign-in provider — enterprise SSO (`OS_SSO_ENABLED`
+   * / `plugins.sso`) or a configured social/OIDC provider. An account created
+   * through one is inserted already verified when the IdP says the address is.
+   */
+  hasFederatedSignIn: boolean;
+}
+
+/** The `warn` channel this check needs — every kernel logger satisfies it. */
+export interface WalledOwnerVerificationLogger {
+  warn?(message: string, ...rest: unknown[]): void;
+}
+
+/**
+ * The predicate and its message, with no I/O — the whole decision, testable
+ * shape by shape.
+ *
+ * Returns the warning text for the ONE dead-end shape (walled + owner declared
+ * + no transport + no federated sign-in), or `null` for every other shape.
+ * Each neighbouring shape is `null` for its own reason:
+ *
+ *   - **not walled** — `single` still promotes the first human user, so a
+ *     declared owner that cannot verify costs nothing;
+ *   - **owner undeclared** — a walled boot never reaches here (`init()`
+ *     refuses), and off the boot path the undeclared case has its own refusal;
+ *   - **a transport is wired** — the verification link can be delivered;
+ *   - **federated sign-in is wired** — the owner can arrive already verified;
+ *   - **the dev-admin seed will stamp this very address** — a dev/harness boot
+ *     verifies its own declared owner at startup (#11343's `email_verified`
+ *     stamp), which is a verification path even with no mailbox anywhere.
+ */
+export function resolveWalledOwnerVerificationPathWarning(
+  wiring: VerificationPathWiring,
+): string | null {
+  const posture = resolveTenancyPosture();
+  if (!postureEnforcesWall(posture)) return null;
+
+  const ownerEmail = resolvePlatformOwnerEmail();
+  if (!ownerEmail) return null;
+
+  if (wiring.hasEmailTransport || wiring.hasFederatedSignIn) return null;
+
+  // The dev-admin seed provisions the declared owner AND stamps it verified,
+  // so a dev/harness walled boot is not a dead end even with nothing wired.
+  // Address-matched on purpose: a dev boot that declares some OTHER owner is
+  // the dead end this warning is for.
+  if (
+    isDevAdminSeedArmed() &&
+    devSeedAdminEmail().toLowerCase() === ownerEmail.toLowerCase()
+  ) {
+    return null;
+  }
+
+  return (
+    `[auth] ${WALLED_OWNER_NO_VERIFICATION_PATH}: tenancy posture '${posture}' declares its ` +
+    `platform owner (${PLATFORM_OWNER_EMAIL_ENV}=${ownerEmail}) but this deployment has NO way ` +
+    'to verify that address — no email transport is wired AND no trusted federated sign-in ' +
+    '(enterprise SSO or a social/OIDC provider) is configured. Boot continues, but ' +
+    "platform-admin elevation requires the declared owner's address to be VERIFIED, so the " +
+    'owner will register, be refused (walled_owner_not_verified), and have no in-product way ' +
+    'to satisfy the condition. Wire EITHER path before the owner registers: (1) an EMAIL ' +
+    'TRANSPORT — register an email service (EmailServicePlugin + OS_EMAIL_*), which delivers ' +
+    'the verification link; or (2) a TRUSTED FEDERATED SIGN-IN — enterprise SSO ' +
+    '(OS_SSO_ENABLED=1 plus a sys_sso_provider row) or a social provider (e.g. ' +
+    'GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET), which inserts the owner already verified. ' +
+    'Either one alone clears this.'
+  );
+}
+
+/**
+ * Emit the warning when this deployment is in the dead-end shape. Returns the
+ * message that was logged, or `null` when nothing was wrong — the return value
+ * is what tests assert on, so a shape that must stay quiet is pinned by
+ * `null` rather than by the absence of a log call.
+ *
+ * Never throws: a diagnostic that can break a boot is worse than the gap it
+ * reports.
+ */
+export function warnIfWalledOwnerCannotVerify(
+  wiring: VerificationPathWiring,
+  logger?: WalledOwnerVerificationLogger,
+): string | null {
+  let message: string | null = null;
+  try {
+    message = resolveWalledOwnerVerificationPathWarning(wiring);
+  } catch {
+    return null;
+  }
+  if (!message) return null;
+  try {
+    logger?.warn?.(message);
+  } catch {
+    /* a logger that throws must not abort the boot */
+  }
+  return message;
+}


### PR DESCRIPTION
Fixes #11640

Maintainer ruling 2026-08-25 (decision-inbox batch 5, comment 5405067849), option **A**, verbatim: 「全部同意」.

At boot, a walled deployment with `OS_PLATFORM_OWNER_EMAIL` **declared** but **no verification path** — no email transport wired, no trusted federated sign-in — now emits a loud, named warning (`walled_owner_no_verification_path`). The operator sees the dead end at deploy time instead of at the owner's rejected registration weeks later.

⛔ **Boot proceeds. This is not a refusal**, and it changes no accept/reject behaviour anywhere: the walled + undeclared-owner boot refusal (#11184) and #11343's fail-closed elevation are untouched, byte for byte. B (an operator CLI verification command) is not built. C is subsumed: the warning text names the remedy, which is what makes A cover it.

## The exact site — for whoever claims #11663's L2 (#11970) / L4 (#11974)

Both legs are `pm:blocked` as of 2026-08-25 (measured at claim; nothing in that family is in flight), but they will rewrite this elevation surface, and the ruling notes the check may move sites. So the decision was deliberately kept in one place and the call kept to one line:

| what | where |
| --- | --- |
| the whole predicate + its message | `packages/plugins/plugin-auth/src/walled-owner-verification-path.ts` — `resolveWalledOwnerVerificationPathWarning()` (pure) and `warnIfWalledOwnerCannotVerify()` (emits) |
| the call site | `packages/plugins/plugin-auth/src/auth-plugin.ts`, `AuthPlugin.start()` — a dedicated `kernel:ready` hook registered immediately before the dev-admin-seed hook, independent of `registerRoutes` |
| the transport read | `AuthManager.hasEmailTransport()` (`auth-manager.ts`, beside `setEmailService`) |

**Move the call, not the predicate.** The module owns the decision, the message and every control; the hook only supplies two live wiring facts. Its docblock carries the same note.

**Why `kernel:ready` and not `init()`** (where the sibling #11184 refusal lives): the email transport is not knowable in `init()` — `EmailServicePlugin` registers the kernel `email` service after plugin-auth initialises, and plugin-auth injects it on its own `kernel:ready` hook. An `init()`-time read reports "no transport" for every deployment that has one, i.e. a warning that fires on every boot.

**Why `warn`**: `os serve` blanks stdout while the kernel boots, and #4012 made that window a buffer rather than a drain — records at `warn` and above are captured and replayed into the startup banner's boot diagnostics. A boot-phase `info` is dropped; a boot-phase `warn` reaches the operator's terminal.

## The warning is actionable, or it is not worth shipping

It names both missing inputs and the concrete wiring for either remedy, and says that either one alone clears it:

> `[auth] walled_owner_no_verification_path: tenancy posture 'isolated' declares its platform owner (OS_PLATFORM_OWNER_EMAIL=operator@corp.example) but this deployment has NO way to verify that address — no email transport is wired AND no trusted federated sign-in (enterprise SSO or a social/OIDC provider) is configured. Boot continues, but platform-admin elevation requires the declared owner's address to be VERIFIED, so the owner will register, be refused (walled_owner_not_verified), and have no in-product way to satisfy the condition. Wire EITHER path before the owner registers: (1) an EMAIL TRANSPORT — register an email service (EmailServicePlugin + OS_EMAIL_*), which delivers the verification link; or (2) a TRUSTED FEDERATED SIGN-IN — enterprise SSO (OS_SSO_ENABLED=1 plus a sys_sso_provider row) or a social provider (e.g. GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET), which inserts the owner already verified. Either one alone clears this.`

The federated half is not asserted from the docs: better-auth creates the user with `emailVerified: userInfo.emailVerified` straight off the IdP profile (`better-auth/dist/oauth2/link-account.mjs`, new-user branch), which is why one wired provider is a verification path.

## Controls — the load-bearing half

A warning that fires on every boot passes "the dead-end shape warns" just as well as a correct one does. `packages/plugins/plugin-auth/src/auth-plugin-walled-owner-verification-path.test.ts` (19 tests) pins the double-absent shape warning **and every neighbouring shape silent**:

- an email transport is wired → silent
- a federated sign-in is wired → silent
- an unwalled (`single`) posture → silent
- an undeclared owner → silent (that boot already refused in `init()`; not this check's business)
- a dev/harness boot whose declared owner **is** the dev-admin the seed provisions → silent, because that seed stamps the account `email_verified` (#11343). Without this input the verify harness — which boots walled and declares the seeded admin as owner — would warn on every fixture boot, which is exactly the every-boot failure mode.
- …but a dev boot declaring a *different* owner, or one with `OS_SEED_ADMIN=0`, is a real dead end and still warns.

Both walled spellings (`isolated`, `group`) and the legacy `OS_MULTI_ORG_ENABLED=true` boolean are covered. Four of the 19 drive the real `AuthPlugin.init()` + `start()` and fire the captured `kernel:ready` hooks, so the wiring is pinned, not just the predicate. One test asserts the text promises `Boot continues` and contains no refusal vocabulary — the ⛔ boundary is machine-checked, not just intended.

To keep the seed carve-out honest, `maybeSeedDevAdmin` now reads its two gate clauses and its address from the same exported `isDevAdminSeedArmed()` / `devSeedAdminEmail()` this check consults, instead of a second copy of the same env parsing. No behaviour change; the point is that the two cannot drift apart.

## Verification

All heavy steps ran through `scripts/pm/os-verify-lock.sh`; each verdict below is the gate's or the runner's own line, with the exit code captured before any pipe.

- `pnpm --filter @objectstack/plugin-auth test` at `03b4a880` (final commit, after both ablations were restored) — `Test Files 75 passed (75)` / `Tests 1538 passed (1538)`, `os-verify-lock: VERDICT command-exit 0`.
- `pnpm --filter @objectstack/plugin-auth build && … typecheck` — `VERDICT command-exit 0`, no `error TS` lines. (The `examples` half of `typecheck` needs the package's own `dist`; on an unbuilt worktree it fails on a missing `@objectstack/plugin-auth` module, unrelated to this change.)
- **Ablation, predictions written first** (leg 1 — an early `return null` before the message; leg 2 — the hook passing `undefined` instead of `ctx.logger`). Each mutation was proved on disk by grepping the injected marker *and* the text it replaced before the run, each ran under a `trap … EXIT INT TERM` restore, and each was restored with `git checkout HEAD -- <path>` followed by a disk == index == HEAD check (`git hash-object` == `git rev-parse HEAD:<path>`).
  - leg 1 predicted 9 failed / 10 passed, naming all nine → observed `Tests 9 failed | 10 passed (19)`, exactly those nine. The five silent-shape controls stay green under the ablation, as predicted — they cannot detect a warning that never fires, which is why the positive assertions carry the weight.
  - leg 2 predicted exactly one failure (`a walled boot with nothing wired emits the named warning from kernel:ready`) → observed `Tests 1 failed | 18 passed (19)`, that one.
  - No `dist` sits in either path: the suite imports the module and `AuthPlugin` from source inside the package, and leg 1 turning the suite red is the proof that the mutation reached the code under test.
- Gates derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at `03b4a880` (5 paths vs merge base `1620c1de2`; the `--repo` assertion holds against this checkout's `origin`). All 15 path-derived families plus the 6 test-kind convention families ran locally, each exiting 0:
  `check:nul-bytes` (`OK (scanned 6666 text file(s) … no raw ASCII control bytes)`), `check:published-files`, `check:slot-lookup`, `check:test-source-alias` (`OK — 72 packages with tests scanned`), `check:type-source-resolution`, `check:auth-mount-ledger`, `check:route-envelope`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-plugin-teardown-shape`, `release-rehearsal-clone --self-test`, `check:engine-double-contract`, `check:where-matcher` (`0 silently-wrong and 0 unjudged matcher(s) … none new`), `check:query-options-erasure`, `check:cross-package-test-inputs`, `check:type-check-coverage`.
- **The ratchet half, measured rather than assumed.** `check:type-check-debt` (`--re-measure`) re-runs tsc per ledger entry and needs the whole workspace closure built, which is CI's run — so the entry this PR can move was measured directly instead: a replica of `remeasureProject`'s generated project for `@objectstack/plugin-auth` (its tsconfig with the `**/*.test.ts` exclusion lifted) reports **97 raw tsc errors, exactly the recorded 97**, with **0** attributed to the new test file. Landing on the recorded number is also what shows the replica is the gate's program and not a lookalike.
- **ESLint, narrowed with proof rather than skipped.** `eslint --no-inline-config --format json` over the four changed files: **4 of 4 files linted** (eslint's own config ignored none), 0 errors, 0 warnings, exit 0. The narrowing excludes nothing, because this repo runs one `eslint.config.mjs` that **never enables type-aware linting for any file** (no `parserOptions.project`, no typed `@typescript-eslint` rules — stated and measured in the config itself, near `QUERY_OPTIONS_TEST_GLOBS`): with no cross-file type program, this diff cannot move the verdict on any file it does not touch. The repo-wide run stays CI's.

## Scope

Only the no-verification-path route is covered, per the ruling. The second route recorded on the issue thread is a runtime state a boot check cannot see; it stays there as an ungraded finding and nothing here widens toward it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01APWX2AwT3a4xDcjPCe8bk4)_