### PR TITLE
fix(objectql): sync IntrospectedColumn.isUnique consumer docblock to the producer's PRIMARY KEY exclusion

### DIFF
--- a/packages/objectql/src/util.ts
+++ b/packages/objectql/src/util.ts
@@ -42,6 +42,17 @@ export interface IntrospectedColumn extends SpecIntrospectedColumn {
    * — is the contract sentence; this is the consumer-side copy of the same
    * key and must not drift from it. An absent flag on a composite member
    * means "not single-column unique", never "no constraint".
+   *
+   * A PRIMARY KEY is NOT a unique constraint to this flag (#11654), on any
+   * dialect and for any key type. `isUnique` means a *declared*
+   * single-column UNIQUE constraint; key membership has a lossless face of
+   * its own ({@link IntrospectedTable.primaryKeys} and `primaryKey` below),
+   * so excluding keys keeps the two flags non-overlapping and drops no
+   * fact. Note this is a statement about what KIND of constraint the flag
+   * reports, never a claim that a key column admits duplicates. A key
+   * column that separately carries its own single-column unique constraint
+   * is still flagged — the constraint is what is being reported, not the
+   * column.
    */
   isUnique?: boolean;
   /**


### PR DESCRIPTION
Fixes #11826

Prose-only sync of the consumer-side `IntrospectedColumn.isUnique` docblock in `packages/objectql/src/util.ts` to the producer's current contract sentence in `packages/drivers/driver-sql/src/sql-driver.ts` (`SqlDriver`'s `IntrospectedColumn.isUnique`). No behaviour change, no export change, no test change.

## What the producer says now (added by #11654)

```
A PRIMARY KEY is NOT a unique constraint to this flag (#11654), on any
dialect and for any key type. `isUnique` means a *declared* single-column
UNIQUE constraint; key membership has a lossless face of its own
({@link IntrospectedTable.primaryKeys} and `primaryKey` below), so
excluding keys keeps the two flags non-overlapping and drops no fact. Note
this is a statement about what KIND of constraint the flag reports, never
a claim that a key column admits duplicates. A key column that separately
carries its own single-column unique constraint is still flagged — the
constraint is what is being reported, not the column.
```

## What the consumer copy said before (drift)

The consumer copy had no PRIMARY KEY clause at all — it still read as though `isUnique` could include a PK, which is exactly the reading #11654 retired on the producer side:

```
Whether this column ALONE carries a single-column unique constraint —
true iff some unique constraint covers this column and nothing else.

Membership of a COMPOSITE constraint is deliberately not represented
(#11202): `UNIQUE (a, b)` constrains the pair, and a per-column boolean
cannot say that. The producer's declaration —
`SqlDriver`'s `IntrospectedColumn.isUnique` in `@objectstack/driver-sql`
— is the contract sentence; this is the consumer-side copy of the same
key and must not drift from it. An absent flag on a composite member
means "not single-column unique", never "no constraint".
```

## The fix

Appended the producer's PRIMARY KEY paragraph (transfers essentially verbatim — `{@link IntrospectedTable.primaryKeys}` resolves to this same file's own `IntrospectedTable.primaryKeys` declaration, and `primaryKey` is inherited from the same spec contract on both sides) to the consumer's `isUnique` docblock, immediately after the still-accurate composite paragraph. The composite paragraph (#11202) was left untouched — it had not drifted.

**Deliberately NOT copied**: the producer's closing paragraph ("All three dialect arms of `{@link SqlDriver.introspectUniqueConstraints}` produce it through one predicate — see `{@link singleColumnUniqueColumns}`."). That paragraph is producer-internal implementation provenance (its `@link`s name `SqlDriver`-only symbols that do not exist in `@objectstack/objectql`), predates #11654 entirely (confirmed via `git show` on the #11654 commit — it was not touched), and was never part of the consumer's mirrored text before. It is not "the contract sentence."

## Second copy in the same docblock — checked, not touched

`IntrospectedForeignKey.referencedSchema` at `util.ts:70-86` carries the identical "must not drift" clause, mirroring `SqlDriver`'s `IntrospectedForeignKey.referencedSchema`. Compared both sides line by line: **not drifted**. Both landed together in #11906 and the producer side has had no edit since (`git log 0010797373..HEAD -- packages/drivers/driver-sql/src/sql-driver.ts` shows one unrelated commit, #11785, touching boolean aggregate casting — no `referencedSchema` lines). Negative reading, no action, no card filed.

## Tests

No behaviour change — `introspectedSchemaToObjects`/`convertIntrospectedSchemaToObjects` is unmodified, only a TSDoc comment moved. No ablation is owed for a prose-only change; the package suite is the regression check:

- `pnpm --filter '@objectstack/objectql^...' build` — dependency closure, exit 0.
- `pnpm --filter @objectstack/objectql test` — `Test Files 232 passed (232)`, `Tests 4117 passed (4117)`, exit 0.
- `pnpm --filter @objectstack/objectql typecheck` — `tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json`, exit 0.
- `node scripts/check-nul-bytes.mjs` — `OK (scanned 6665 text file(s) ... no raw ASCII control bytes)`, exit 0.

Gate union derived from the actual diff (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`), re-run at the final commit `8b58aa7304` — same single-path change set both times, same 9 matched families. All 9 run in the foreground, each `EXIT=0` captured before any pipe:

`check:durability-log-level`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-engine-split-ratio.mjs` (report-only, 97.6%), `check-plugin-teardown-shape.mjs`, `docs-audit/check-affected-docs.mjs`, `docs-audit/check-drift-comment.mjs`.

`skip-changeset` per triage grading — no behaviour, no export. `check:empty-changeset`'s own self-tests (GREEN 3) confirm a PR with no changeset and the `skip-changeset` label is exactly what that gate expects to see, so no changeset was written.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_