### PR TITLE
fix(scripts): bound objectui-range --help's self-read to the header prefix

### DIFF
--- a/scripts/objectui-range.mjs
+++ b/scripts/objectui-range.mjs
@@ -105,15 +105,27 @@ const SHOW_EXCLUDED = has('--all');
  * to its stdout and then `process.exit(0)` — its process ended mid-import
  * carrying a SUCCESS status, which no caller reading the status alone can
  * tell apart from a clean import.
+ *
+ * BOUNDED to the header, not every column-0 `//` line in the file (#11952).
+ * A bare `.filter(startsWith('//'))` has no notion of "the header": it took
+ * EVERY column-0 `//` line anywhere in the file, so an ordinary implementation
+ * comment written at column 0 later in the file — a helper's one-line
+ * rationale, a self-test section banner — silently became part of the usage
+ * text a reader pastes. The header IS a contiguous prefix of this file (right
+ * after the shebang), so this walks lines in order, skips the shebang before
+ * the block starts, and STOPS at the first line that is not a `//` line once
+ * the block has started — a `takeWhile`, not a `filter`. That makes "add a
+ * column-0 comment anywhere later" structurally unable to reach `--help`
+ * again, rather than merely detectable after the fact.
  */
 function printHelp() {
-  console.log(
-    readFileSync(fileURLToPath(import.meta.url), 'utf8')
-      .split('\n')
-      .filter((l) => l.startsWith('//'))
-      .map((l) => l.slice(3))
-      .join('\n'),
-  );
+  const lines = readFileSync(fileURLToPath(import.meta.url), 'utf8').split('\n');
+  const start = lines.findIndex((l) => l.startsWith('//'));
+  const header = [];
+  for (let i = start; i >= 0 && i < lines.length && lines[i].startsWith('//'); i++) {
+    header.push(lines[i].slice(3));
+  }
+  console.log(header.join('\n'));
   return 0;
 }
 
@@ -613,6 +625,31 @@ function selfTest() {
         cliJson.releasing.filter((r) => r.breakingSource === 'annotation').length === 1 &&
         cliJson.releasing.filter((r) => r.breaking).length === 2,
       JSON.stringify(cliJson.releasing.map((r) => r.breakingSource)),
+    );
+
+    // --- #11952: `--help`'s self-read is bound to the header, not every
+    // column-0 `//` line in the file. Pin the acceptance criterion literally:
+    // the header is still there, and none of the six measured stray lines —
+    // an internal helper's rationale (pinAt, mid-`main`) and this very
+    // self-test's own section banner — leak into the usage text.
+    const helpOut = run(['--help']);
+    check(
+      '--help still carries the real header (Usage/Env sections intact)',
+      helpOut.includes('Usage:') &&
+        helpOut.includes('node scripts/objectui-range.mjs <old-rev> [new-rev]') &&
+        helpOut.includes('OBJECTUI_ROOT=/path/to/objectui'),
+      helpOut,
+    );
+    const strayLines = [
+      'Resolve the objectui SHA pinned at a given framework rev',
+      'Self-test (#4843) — the repo idiom for a `scripts/` gate',
+      'git repo carrying the exact shapes measured on the real range',
+      'code over it, assert the ARTIFACT (the markdown a maintainer pastes)',
+    ];
+    check(
+      '--help does NOT leak mid-file implementation comments (#11952)',
+      strayLines.every((s) => !helpOut.includes(s)),
+      helpOut,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #11952

## What

`objectui-range --help` built its usage text from **every** column-0 `//`
line in `scripts/objectui-range.mjs`, not just the header block. Six
mid-file implementation comments (the `pinAt()` helper's one-line
rationale at old line 129, and this file's own self-test section banner
at old lines 333-337) leaked into the usage text a reader pastes.

Triage's acceptance pin (quoted verbatim in the issue): *"`--help`
output contains the header and none of the six measured stray lines."*

## Fix

The header **is** a contiguous prefix of the file (right after the
shebang) — measured on today's `origin/main` (`1e79aa4f8`), lines 2-74
are all column-0 `//`, then line 75 (`import { execFileSync } ...`)
breaks it, and no other column-0 `//` line appears again until 129. So
`printHelp()` now walks the file's lines in order and stops at the
**first** non-`//` line once the header block has started — a
`takeWhile`, not a `filter` — the repair triage's option 1 named as
cheapest and structurally closing the "add a comment anywhere later"
hazard. The self-read itself is kept (no-drift property preserved) —
only its boundary changed.

Total column-0 `//` line count is **unchanged at 79** (PR #11951's
byte-identity pin); the new rationale prose is a `/** */` JSDoc block on
`printHelp()`, matching #11951's own reason for choosing that comment
style on this file.

## Pin

Per the standing requirement to ship the acceptance criterion as a
mechanically-checkable test, not a PR-body claim: extended this file's
own self-test idiom (`--self-test`, cited from #4843) with two new
checks —

- `--help` still carries the real header (`Usage:`, the old-rev/new-rev
  line, `OBJECTUI_ROOT=...`).
- `--help` does **not** contain any of the six measured stray lines
  (the `pinAt()` rationale and the self-test banner text).

**Reverse-verified**: committed the fix, then mutated `printHelp()`
back to the old unbounded `.filter()` in place (confirmed the mutation
landed on disk via `grep -c` before running), re-ran `--self-test` —
the new stray-line check went **red** (`✗ --help does NOT leak
mid-file implementation comments`), confirming the pin actually detects
the regression it exists to catch. `git checkout -- ` with the target path (via a
`trap ... EXIT` in the mutation script) restored the fix; working tree
confirmed clean afterward.

## Byte diff

Captured `--help` output before/after into two files and diffed them —
exactly the six stray lines are gone, nothing else moved:

```
74,79d73
< Resolve the objectui SHA pinned at a given framework rev (or the working tree).
< ---------------------------------------------------------------------------
< Self-test (#4843) — the repo idiom for a `scripts/` gate: build a throwaway
< git repo carrying the exact shapes measured on the real range, run the real
< code over it, assert the ARTIFACT (the markdown a maintainer pastes).
< ---------------------------------------------------------------------------
```

`--help` byte length: 4693 → 4237 (content-asserted in the pin, not
byte-count-asserted, per the standing guidance that a byte-count
assertion rots).

## Scope

Only `scripts/objectui-range.mjs` touched. No reformatting/restructuring
elsewhere in the file — `git diff origin/main -- scripts/objectui-range.mjs`
is exactly two hunks: the `printHelp()` body + its doc-comment, and the
new self-test block.

## Gates (derived via `node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack` at final HEAD `05f5dec4b`)

All 8 matched local gate families green (exit 0, captured before any
pipe; verdict line quoted from each gate's own output):

- `pnpm check:agent-test-spelling` — `✓ check-agent-test-spelling: 0 violations — 367 file(s) · 3681 bare '--' token(s) · 1139 launcher-rooted run(s) · 9 separator(s) JUDGED · 5 vitest-backed script name(s) derived from 80 manifest(s)`
- `pnpm check:cross-package-test-inputs` — `OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `pnpm check:entry-guard` — `✓ check:entry-guard: 157 scripts/ file(s) — every entry guard goes through invoked-as.mjs; 113 export bindings, 111 of them inert on import (2 known-unsafe, ⛔ SHRINK-ONLY).`
- `pnpm check:objectui-changeset` (runs this file's own `--self-test`, including the two new checks) — `✓ objectui-range --self-test: all checks passed`
- `pnpm check:parse-guard` — `✓ check:parse-guard: 156 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.`
- `pnpm check:pnpm-filter-targets` — `✓ check:pnpm-filter-targets: 135/168 '--filter' occurrence(s) across 26 file(s) resolve against 78 workspace package(s); ...`
- `node scripts/check-ci-filter-parity.mjs` — `OK: all 96 declared cross-package glob(s) (81 unique) are covered by 'core' or 'crosspkg', ...`
- `node scripts/check-cross-package-test-inputs.mjs` — `OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`

Plus `pnpm check:nul-bytes` (any edit warrants it) — `check-nul-bytes: OK (scanned 6672 text file(s) ... no raw ASCII control bytes).`

`pnpm --stack-size=4000 eslint scripts/objectui-range.mjs --no-inline-config --format json` — 0 errors, 0 warnings, 1 file linted (scoped-run evidence: population read from `eslint`'s own JSON output, not a guess; this repo's `eslint.config.mjs` never enables type-aware linting for any file — measured with a positive control in the config's own header comment — so this scoped run cannot have missed a judgment on any untouched file).

No package's `typecheck`/`test` covers this file: root `tsconfig.json`
excludes `packages/`/`apps/`/`examples/` and has no `allowJs`, and
`scripts/` is not itself a workspace package, so `turbo run
typecheck`/`test` never touches it — the file's real correctness gate
is `check:objectui-changeset`'s `--self-test` above, which does.

## Changeset

Root `scripts/` tooling only, nothing published — `skip-changeset`
applies. Labeled and read back — confirmed present on this PR.

---

_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_
