### PR TITLE
fix(core): only a backend fault populates the localization failure memo (#11877)

### DIFF
--- a/.changeset/localization-failure-memo-backend-leg-only.md
+++ b/.changeset/localization-failure-memo-backend-leg-only.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/core": patch
+---
+
+fix(core): only a backend fault populates `resolveLocalizationContext`'s failure memo (#11877)
+
+`resolveLocalizationContext` memoizes an outcome for 30s whenever the read
+"failed" (#10221 — so a repeatedly-failing `sys_setting` query does not re-run,
+and the driver does not re-log it, on every request). The write condition was
+wider than the cache's own docblock: six legs set the flag and only **one** of
+them is the backend fault the docblock describes (the direct `ql.find` throw).
+The other five are the **settings service refusing** — a thrown `getMany`, each
+of the three older per-key `get`s, and the whole-block "service unavailable"
+handler.
+
+Those five legs are reachable inside the settings engine's **bind window**
+(`SettingsService.getMany` refuses all-or-nothing for a `localization`
+namespace whose manifest is not yet registered), so:
+
+- A caller that deliberately re-reads **after** the bind — the #11580 stdio
+  repair re-resolves at `kernel:bootstrapped` for exactly this reason — was
+  answered from the memo taken **inside** the window for up to 30s. The
+  correction silently did not happen, with nothing in the output saying so.
+- A settings refusal standing alongside a perfectly **successful** direct read
+  memoized that successful value — the staleness the docblock forbids outright
+  and that `analytics-timezone.dogfood.test.ts` (#1982/#2018) exists to catch.
+
+The memo is now written only for the direct-read fault. **#10221's protection
+is unchanged for the legs it was built for**: its environment (table not
+migrated yet) still memoizes, because the direct read throws there whether or
+not a settings refusal stands in front of it — pinned in both directions. And
+nothing is lost on the narrowed legs: those refusals throw out of an in-memory
+registry check *before* any query and *before* any log line, so memoizing them
+suppressed neither.
+
+No signature, export or accepted-input change — the flag is internal to the
+module.

--- a/packages/core/src/security/resolve-authz-context.test.ts
+++ b/packages/core/src/security/resolve-authz-context.test.ts
@@ -374,6 +374,22 @@ describe('resolveLocalizationContext — batched fallback read (#2409)', () => {
   });
 });
 
+// Simulates a fresh environment: `sys_setting` not migrated/written yet, so
+// every read rejects the way the real sql-driver's "no such table" does.
+// Shared by the #10221 cache block below and the #11877 leg-narrowing block
+// after it, which needs the same backend fault standing BEHIND a settings
+// refusal.
+function makeMissingTableQl() {
+  const counts = { sys_setting: 0 };
+  return {
+    counts,
+    async find(_object: string) {
+      counts.sys_setting += 1;
+      throw new Error('no such table: sys_setting');
+    },
+  };
+}
+
 // #10221: a fresh environment's `sys_setting` table doesn't exist yet, so
 // EVERY request's read used to fail and the sql-driver's `[sql-driver]
 // DATABASE_ERROR` warning repeated once per request, burying real errors.
@@ -394,19 +410,6 @@ describe('resolveLocalizationContext — failure-only cross-request cache (#1022
   afterEach(() => {
     vi.useRealTimers();
   });
-
-  // Simulates a fresh environment: `sys_setting` not migrated/written yet, so
-  // every read rejects the way the real sql-driver's "no such table" does.
-  function makeMissingTableQl() {
-    const counts = { sys_setting: 0 };
-    return {
-      counts,
-      async find(_object: string) {
-        counts.sys_setting += 1;
-        throw new Error('no such table: sys_setting');
-      },
-    };
-  }
 
   it('does not re-query on a second call within the TTL window when the read fails (same tenant)', async () => {
     const ql = makeMissingTableQl();
@@ -481,6 +484,193 @@ describe('resolveLocalizationContext — failure-only cross-request cache (#1022
     const second = await resolveLocalizationContext({ ql, tenantId: 'o1' });
     expect(second.timezone).toBe('Asia/Tokyo');
     expect(ql.counts.sys_setting).toBe(2);
+  });
+});
+
+// ── #11877 — a SETTINGS-SERVICE refusal must not populate the failure memo ──
+//
+// The memo above exists for one thing (#10221): a `sys_setting` query that
+// actively FAILS must not re-run — and re-log the driver's line — on every
+// request. Its write condition was wider than that. `failed` was set by SIX
+// legs and only ONE of them is the backend fault the cache's own docblock
+// describes:
+//
+//   settings.getMany(...) threw            — the grouped read (settings leg)
+//   settings.get(...) threw          × 3   — the older per-key arm (settings)
+//   the settings block threw               — "service unavailable" (settings)
+//   ql.find('sys_setting', ...) threw      — THE backend fault
+//
+// The five settings legs are reachable INSIDE the settings engine's bind
+// window: `SettingsService.getMany` refuses all-or-nothing for a
+// `localization` namespace whose manifest is not (yet) registered. So a
+// caller that deliberately re-reads AFTER the bind — the #11580 repair does
+// exactly that, re-resolving at `kernel:bootstrapped` — could be answered
+// from the memo taken inside the window, within the 30s TTL, with nothing in
+// the output saying the correction did not happen.
+//
+// And directly against this cache's own docblock ("a successful read is NEVER
+// cached"): a settings refusal standing alongside a perfectly SUCCESSFUL
+// direct read memoized that successful value for 30s — the exact staleness
+// `analytics-timezone.dogfood.test.ts` (#1982/#2018) exists to forbid.
+//
+// So the memo is written only for the backend-fault leg now. #10221's
+// protection is untouched, and BOTH directions are pinned below: a genuine
+// backend fault still memoizes — including with a settings refusal standing
+// in front of it — while a settings refusal alone no longer does.
+describe('resolveLocalizationContext — only a backend fault populates the memo (#11877)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** What the workspace has PERSISTED — answerable only once the engine binds. */
+  const CONFIGURED = { timezone: 'Asia/Shanghai', locale: 'zh-CN', currency: 'CNY' };
+
+  // The all-or-nothing refusal `SettingsService.getMany` gives for a namespace
+  // whose manifest is not (yet) registered. It throws out of an in-memory
+  // registry check — before any query, before any log line — which is why
+  // memoizing THIS leg never suppressed a query or a log line to begin with.
+  function makeBindWindowSettings() {
+    const state = { bound: false, getManyCalls: 0 };
+    return {
+      state,
+      get: async () => {
+        throw new Error('per-key get must not be called on the batched arm');
+      },
+      getMany: async () => {
+        state.getManyCalls += 1;
+        if (!state.bound) throw new Error("unknown settings namespace 'localization'");
+        return {
+          timezone: { value: CONFIGURED.timezone },
+          locale: { value: CONFIGURED.locale },
+          currency: { value: CONFIGURED.currency },
+        };
+      },
+    };
+  }
+
+  // ── the reproduction this card was filed without ────────────────────────
+  //
+  // Pre-bind read inside the window (settings refuses, `sys_setting` answers
+  // an ordinary empty result) → deliberate post-bind re-read 1s later, well
+  // inside the 30s TTL. The clock is FAKE and advanced explicitly; nothing
+  // here sleeps on the wall clock.
+  it('a post-bind re-read inside the TTL is answered by the now-bound service, not by the pre-bind memo', async () => {
+    const settings = makeBindWindowSettings();
+    const ql = makeCountingQl({ sys_setting: [] });
+
+    const preBind = await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    expect(preBind).toEqual({ timezone: 'UTC', locale: 'en-US', currency: undefined });
+    expect(settings.state.getManyCalls).toBe(1);
+
+    settings.state.bound = true; // the settings engine binds
+    await vi.advanceTimersByTimeAsync(1_000); // still deep inside the 30s window
+
+    const postBind = await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    // The re-read must REACH the service (a memo hit would never call it) and
+    // must carry the configured values, which exist only behind the bind.
+    expect(settings.state.getManyCalls).toBe(2);
+    expect(postBind).toEqual({ timezone: 'Asia/Shanghai', locale: 'zh-CN', currency: 'CNY' });
+  });
+
+  // The same refusal, but the direct read SUCCEEDS with rows. The memoized
+  // value here was a correct, successful answer — frozen for 30s by a leg that
+  // has nothing to do with the backend.
+  it('a settings refusal never freezes a SUCCESSFUL direct read: a row change is visible on the very next call', async () => {
+    const settings = makeBindWindowSettings(); // stays unbound → refuses every call
+    const rows = [{ namespace: 'localization', key: 'timezone', scope: 'tenant', value: 'UTC' }];
+    const ql = makeCountingQl({ sys_setting: rows });
+
+    const first = await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    expect(first.timezone).toBe('UTC');
+
+    rows[0].value = 'America/Los_Angeles'; // a settings write lands, no TTL advance
+    const second = await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    expect(second.timezone).toBe('America/Los_Angeles');
+    expect(ql.counts.sys_setting).toBe(2);
+  });
+
+  // The older per-key arm (a service with no `getMany`): three `get` legs,
+  // same rule.
+  it('the per-key get legs do not populate the memo either', async () => {
+    const state = { bound: false, gets: 0 };
+    const settings = {
+      get: async (_ns: string, key: string) => {
+        state.gets += 1;
+        if (!state.bound) throw new Error("unknown settings namespace 'localization'");
+        return { value: (CONFIGURED as Record<string, string>)[key] };
+      },
+    };
+    const ql = makeCountingQl({ sys_setting: [] });
+
+    expect(await resolveLocalizationContext({ ql, settings, tenantId: 'o1' })).toEqual({
+      timezone: 'UTC',
+      locale: 'en-US',
+      currency: undefined,
+    });
+    expect(state.gets).toBe(3);
+
+    state.bound = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await resolveLocalizationContext({ ql, settings, tenantId: 'o1' })).toEqual({
+      timezone: 'Asia/Shanghai',
+      locale: 'zh-CN',
+      currency: 'CNY',
+    });
+    expect(state.gets).toBe(6);
+  });
+
+  // The whole-block leg: a `get` that throws SYNCHRONOUSLY never attaches its
+  // `.catch`, so the throw escapes `Promise.all` into the outer
+  // "settings service unavailable → direct read" handler. Same rule.
+  it('the outer "settings service unavailable" leg does not populate the memo either', async () => {
+    const state = { bound: false, gets: 0 };
+    const settings = {
+      // Deliberately NOT async: this throws before a promise exists.
+      get: (_ns: string, key: string) => {
+        state.gets += 1;
+        if (!state.bound) throw new Error('settings service unavailable');
+        return Promise.resolve({ value: (CONFIGURED as Record<string, string>)[key] });
+      },
+    };
+    const ql = makeCountingQl({ sys_setting: [] });
+
+    expect(await resolveLocalizationContext({ ql, settings, tenantId: 'o1' })).toEqual({
+      timezone: 'UTC',
+      locale: 'en-US',
+      currency: undefined,
+    });
+
+    state.bound = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect((await resolveLocalizationContext({ ql, settings, tenantId: 'o1' })).timezone).toBe('Asia/Shanghai');
+  });
+
+  // ── the half that must be PRESERVED (#10221) ────────────────────────────
+  //
+  // Narrowing the write condition must not narrow it to nothing. A settings
+  // refusal standing in FRONT of a genuinely failing `sys_setting` read is the
+  // real #10221 environment (fresh deployment: no manifest registered yet AND
+  // no table yet) — the failing query must still be memoized there.
+  it('still memoizes when a settings refusal stands in front of a genuine backend fault', async () => {
+    const settings = makeBindWindowSettings(); // unbound → refuses
+    const ql = makeMissingTableQl(); // and the direct read throws
+
+    await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    expect(ql.counts.sys_setting).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    // Memo hit: the failing query — and the driver's log line for it — did not
+    // repeat. The settings refusal is re-attempted (it is free), but that is
+    // not what #10221 was protecting.
+    expect(ql.counts.sys_setting).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+    await resolveLocalizationContext({ ql, settings, tenantId: 'o1' });
+    expect(ql.counts.sys_setting).toBe(2); // and it still self-heals on expiry
   });
 });
 

--- a/packages/core/src/security/resolve-authz-context.ts
+++ b/packages/core/src/security/resolve-authz-context.ts
@@ -771,6 +771,25 @@ type LocalizationResult = { timezone: string; locale: string; currency?: string 
  * where the read is actively failing — while never caching a value a caller
  * could observe going stale.
  *
+ * [#11877] "the underlying read itself THREW" means the DIRECT `sys_setting`
+ * read, and only it. The write condition used to be a single `failed` flag
+ * that five SETTINGS-SERVICE legs also set (a thrown `getMany`, each of the
+ * three older per-key `get`s, and the whole-block "service unavailable"
+ * handler). Those legs are reachable inside the settings engine's BIND
+ * WINDOW — `SettingsService.getMany` refuses all-or-nothing for a namespace
+ * whose manifest is not yet registered — so a caller that deliberately
+ * re-reads AFTER the bind (the #11580 repair re-resolves at
+ * `kernel:bootstrapped`) was answered from the in-window memo for up to 30s,
+ * silently keeping the very value the re-read existed to replace. And a
+ * settings refusal standing alongside a SUCCESSFUL direct read memoized that
+ * successful value — exactly the staleness the paragraph above forbids.
+ *
+ * Narrowing to the backend leg costs nothing #10221 bought: those refusals
+ * throw out of an in-memory registry check BEFORE any query and before any
+ * log line, so memoizing them suppressed neither — while #10221's own
+ * environment (table not migrated yet) still memoizes, because the direct
+ * read throws there whether or not a settings refusal stands in front of it.
+ *
  * Keyed on the `ql` instance (one entry-set per environment engine, so two
  * environments/tenants sharing a process never see each other's cached
  * outcome) and then `tenantId|userId` beneath it, matching the audit writer's
@@ -786,10 +805,12 @@ const localizationFailureCache = new WeakMap<object, Map<string, { value: Locali
  * platform default → global → tenant); falls back to direct tenant-scoped
  * `sys_setting` rows, then the built-ins `UTC` / `en-US`. Never throws.
  *
- * A read that fails outright (backend fault — table missing, connection
- * refused, etc.) is memoized for {@link LOCALIZATION_FAILURE_CACHE_TTL_MS}
- * per `(ql, tenantId, userId)` so the failing query — and the driver's log
- * line for it — does not repeat every request (#10221). A successful read,
+ * The DIRECT `sys_setting` read failing outright (backend fault — table
+ * missing, connection refused, etc.) is memoized for
+ * {@link LOCALIZATION_FAILURE_CACHE_TTL_MS} per `(ql, tenantId, userId)` so
+ * the failing query — and the driver's log line for it — does not repeat
+ * every request (#10221). Nothing else is: a settings-service refusal is not
+ * a backend fault and never populates the memo (#11877). A successful read,
  * including a legitimate "no settings configured yet" empty result, is NEVER
  * cached: the next call always re-reads, so a settings write takes effect
  * immediately (see the cache doc above for why — the dogfood analytics
@@ -803,8 +824,8 @@ export async function resolveLocalizationContext(input: ResolveLocalizationInput
     if (hit && hit.expiresAt > Date.now()) return hit.value;
   }
 
-  const { value, failed } = await resolveLocalizationContextUncached(input);
-  if (failed && ql && typeof ql === 'object') {
+  const { value, backendFailed } = await resolveLocalizationContextUncached(input);
+  if (backendFailed && ql && typeof ql === 'object') {
     const bucket = localizationFailureCache.get(ql) ?? new Map<string, { value: LocalizationResult; expiresAt: number }>();
     bucket.set(cacheKey, { value, expiresAt: Date.now() + LOCALIZATION_FAILURE_CACHE_TTL_MS });
     localizationFailureCache.set(ql, bucket);
@@ -814,9 +835,11 @@ export async function resolveLocalizationContext(input: ResolveLocalizationInput
 
 async function resolveLocalizationContextUncached(
   input: ResolveLocalizationInput,
-): Promise<{ value: LocalizationResult; failed: boolean }> {
+): Promise<{ value: LocalizationResult; backendFailed: boolean }> {
   const { ql, settings, tenantId, userId } = input;
-  let failed = false;
+  // ONLY the direct `sys_setting` read below sets this. The settings-service
+  // legs deliberately do not — see the cache doc above (#11877).
+  let backendFailed = false;
   try {
     if (settings && typeof settings.get === 'function') {
       const sctx = { tenantId, userId } as any;
@@ -826,9 +849,10 @@ async function resolveLocalizationContextUncached(
       // answers by the service's own equivalence contract. Feature-detected:
       // an older service without `getMany` keeps the three parallel `get`s
       // (still 1 leg — this is a query-count fix, per the card's calibration).
-      // A thrown `getMany` lands in the same place a thrown `get` did —
-      // `failed = true` and the direct `$in` fallback below, which reads the
-      // exact same three keys.
+      // A thrown `getMany` lands in the same place a thrown `get` did — the
+      // direct `$in` fallback below, which reads the exact same three keys.
+      // Neither populates the failure memo: a settings refusal is not the
+      // backend fault that memo is for (#11877; see the cache doc above).
       //
       // [#11222 item 4] ONE non-equivalence, inherent to batching and recorded
       // here because it is this CALLER's degradation, not the service's:
@@ -850,34 +874,28 @@ async function resolveLocalizationContextUncached(
           localeRes = many.locale;
           currencyRes = many.currency;
         } catch {
-          failed = true;
+          // Settings refusal → fall through to the direct `$in` read below.
+          // Not a backend fault, so it does not populate the memo (#11877).
         }
       } else {
+        // Same rule as the batched arm above: a refused key falls through to
+        // the direct `$in` read and does not populate the memo (#11877).
         [tzRes, localeRes, currencyRes] = await Promise.all([
-          settings.get('localization', 'timezone', sctx).catch(() => {
-            failed = true;
-            return undefined;
-          }),
-          settings.get('localization', 'locale', sctx).catch(() => {
-            failed = true;
-            return undefined;
-          }),
-          settings.get('localization', 'currency', sctx).catch(() => {
-            failed = true;
-            return undefined;
-          }),
+          settings.get('localization', 'timezone', sctx).catch(() => undefined),
+          settings.get('localization', 'locale', sctx).catch(() => undefined),
+          settings.get('localization', 'currency', sctx).catch(() => undefined),
         ]);
       }
       const tz = coerceTimeZone(tzRes?.value);
       const locale = coerceLocale(localeRes?.value);
       const currency = coerceCurrency(currencyRes?.value);
       if (tz || locale || currency) {
-        return { value: { timezone: tz ?? 'UTC', locale: locale ?? 'en-US', currency }, failed: false };
+        return { value: { timezone: tz ?? 'UTC', locale: locale ?? 'en-US', currency }, backendFailed: false };
       }
     }
   } catch {
-    // settings service unavailable → direct read
-    failed = true;
+    // Settings service unavailable → direct read. Still not a backend fault,
+    // so it does not populate the memo either (#11877).
   }
   // One read for all three keys instead of a query per key (`$in` on `key`).
   // Inlined (rather than the shared `tryFind`) so a genuine backend fault —
@@ -898,7 +916,8 @@ async function resolveLocalizationContextUncached(
       if (result && (result as any).value) result = (result as any).value;
       rows = Array.isArray(result) ? result : [];
     } catch {
-      failed = true;
+      // THE backend fault the failure memo exists for (#10221).
+      backendFailed = true;
     }
   }
   const valueOf = (k: string) => rows.find((r) => r.key === k)?.value;
@@ -908,6 +927,6 @@ async function resolveLocalizationContextUncached(
       locale: coerceLocale(valueOf('locale')) ?? 'en-US',
       currency: coerceCurrency(valueOf('currency')),
     },
-    failed,
+    backendFailed,
   };
 }


### PR DESCRIPTION
Fixes #11877

`resolveLocalizationContext` memoizes an outcome for 30s whenever the underlying
read "failed" (#10221 — so a repeatedly-failing `sys_setting` query does not
re-run, and the driver does not re-log it, on every request). The write
condition was wider than the cache's own docblock, and the memo could answer a
deliberate post-bind re-read with the pre-bind value.

## The leg split, re-enumerated on this branch

⚠️ The card says `failed` is set in **six** places and that "only two of them are
the backend fault". A raw `grep -c 'failed = true'` on `origin/main` returns
**seven** — but one of those is a **docblock mention**, not an assignment
(`resolve-authz-context.ts:830`, the `getMany` comment quoting the flag name).
So there are **six real legs**, unchanged from the card. No seventh leg landed;
the extra hit is prose.

The card's *classification* is what had moved — and it understates the defect.
Re-enumerated by hand on `origin/main` (`c804f0ca5f`):

| line | leg | kind |
|---|---|---|
| `:853` | `settings.getMany('localization', …)` threw | settings service |
| `:858` | `settings.get(…, 'timezone', …)` rejected | settings service |
| `:862` | `settings.get(…, 'locale', …)` rejected | settings service |
| `:866` | `settings.get(…, 'currency', …)` rejected | settings service |
| `:880` | the whole settings block threw — the handler's own comment reads `settings service unavailable → direct read` | settings service |
| `:901` | `ql.find('sys_setting', …)` threw | **backend fault** |

**Five of six are the settings service, and exactly ONE is the backend fault the
docblock describes** — not "four of six / two backend" as filed. `:880` is
classed by its own comment: it can only fire for a throw out of the settings
block. This changes nothing about the chosen route, but it is the number the
fix is built on, so it is stated rather than carried forward.

## The reproduction — this card was filed without one, and it reproduces

Built first, before any repair, and measured as the ablation leg below
(`packages/core/src/security/resolve-authz-context.test.ts`). The clock is
**fake and advanced explicitly** (`vi.useFakeTimers()` +
`advanceTimersByTimeAsync`) — nothing here sleeps on the wall clock.

Pre-bind read inside the window (settings refuses all-or-nothing for a
`localization` namespace whose manifest is not yet registered; `sys_setting`
answers an ordinary empty result) → the bind lands → deliberate re-read 1s
later, deep inside the 30s TTL. On unmodified `main`:

```
AssertionError: expected 1 to be 2        // settings.getMany call count —
                                          // the post-bind re-read never
                                          // reached the now-bound service
```

And the second, worse shape — a settings refusal standing alongside a perfectly
**successful** direct read froze that successful value, which the cache's own
docblock forbids outright ("a successful read … is NEVER cached"):

```
AssertionError: expected 'UTC' to be 'America/Los_Angeles'
```

`premise_still_valid: true`.

## The repair

The memo is written only for the direct-read fault. `resolveLocalizationContextUncached`'s
internal `failed` flag becomes `backendFailed`, set at `:901` and nowhere else;
the five settings legs keep their existing fall-through to the direct `$in`
read and no longer populate the memo.

**#10221's protection is intact for the legs it was built for.** Two independent
reasons, both measured:

1. #10221's environment (table not migrated yet) still memoizes — the direct
   read throws there whether or not a settings refusal stands in front of it.
   Pinned by a new case that puts a refusing settings service **in front of** a
   throwing `ql.find` and asserts the failing query still runs exactly once
   inside the TTL, and twice across it.
2. Nothing was lost on the narrowed legs anyway: `SettingsService.getMany`
   refuses out of an **in-memory registry check** (`UnknownNamespaceError` /
   `UnknownKeyError`, `settings-service.ts:1227-1230`) — thrown before any
   query and before any log line — so memoizing those legs suppressed neither a
   query nor a log line. The service's own pre-bind diagnostic is separately
   deduped by the service, per namespace (`reportPreBindRead`).

No signature, export, accepted-input or return-shape change reaches outside the
module: `resolveLocalizationContextUncached` is module-local, and
`resolveLocalizationContext`'s own signature is untouched. Clause-② stays **no**
— no contract accept/reject door moves and no public surface widens.

## Non-vacuity, both directions

| pin | direction | on `main` | on this branch |
|---|---|---|---|
| post-bind re-read inside the TTL reaches the bound service | the half that CHANGES | ✗ fail | ✓ |
| a settings refusal never freezes a SUCCESSFUL direct read | the half that CHANGES | ✗ fail | ✓ |
| the three per-key `get` legs do not populate the memo | the half that CHANGES | ✗ fail | ✓ |
| the outer "service unavailable" leg does not populate the memo | the half that CHANGES | ✗ fail | ✓ |
| a settings refusal in FRONT of a genuine backend fault still memoizes | the half that must be PRESERVED | ✓ | ✓ |
| the six existing #10221 cache cases | the half that must be PRESERVED | ✓ | ✓ |

The last two rows pass on **both** trees. That is the point of them — they guard
the half the fix must not move, so they are not evidence for the half it does.

## Ablation

Direction predicted in writing **before** the run: exactly 4 of the 5 new cases
fail on the un-narrowed source; the 5th and all pre-existing cases pass on both
trees.

- Mutation proven **on disk before any result was read**, by anchored counts of
  the text actually being changed (not `git diff --stat`, not an editor exit
  code): narrowed tree `'backendFailed = true' = 1`, `'failed = true' = 0`;
  ablated tree `'backendFailed = true' = 0`, `'failed = true' = 7`
  (6 legs + the 1 docblock mention).
- Restore under `trap restore EXIT INT TERM` with **absolute** paths (no
  repo-relative path after a `cd`), then **verified rather than trusted**:
  `cmp -s` reported `RESTORE_VERIFIED=byte-identical`, the post-restore anchored
  count returned to 1, and `git status` shows no stray file.
- Rebuild leg: **not applicable here, and that is a property of resolution, not
  of the suite's name.** The unit pin imports its subject as
  `./resolve-authz-context.js` — a relative, intra-package specifier vitest
  resolves to `src`, never through the package's `exports` → `dist`. Where the
  hazard *does* apply — `packages/qa/dogfood`, which consumes `dist`
  deliberately — the artifact was rebuilt and proved before its result was read
  (below).

Measured: `Tests 4 failed | 71 passed (75)`, failing exactly the four predicted
cases. On this branch: `Test Files 1 passed (1) · Tests 75 passed (75)`.

## The golden-regression pin was NOT touched

`packages/qa/dogfood/test/analytics-timezone.dogfood.test.ts` (#1982/#2018 — the
reason this cache was narrowed to failures in the first place) is **unmodified**
and green. Because that suite resolves `@objectstack/core` through `dist`, the
package was rebuilt and the change proved present in the built artifact before
the result was read:

```
ablation-dist-preflight: @objectstack/core -- expecting "backendFailed" in packages/core/dist
✓ marker present in 2 built files -- the ablation is live in the artifact the suite consumes.
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

This change only ever **removes** cache writes; it adds none. There is no
direction in which it can make a read staler than `main` already allows.

## Verification

Every run below is at **`5ce9ca42f4`** — the final commit on this branch — and
every exit code was captured **before any pipe** (`cmd > log 2>&1; EXIT=$?`),
never as `$?` after a `| tail`. Verdicts are quoted from what each gate printed
for itself.

**Gate union — derived, not recalled.** `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
against the actual diff (it reported `gate list derived from the tree of
'objectstack-ai/objectstack' at commit 5ce9ca42f4`, `3 path(s) vs merge base
c804f0ca5`, `--repo … checked against this checkout's 'origin' remote — it
holds`). All 18 path-matched families plus the 6 convention-triggered ones ran;
all exit 0:

```
check:authz-resolver                ✓ single shared authorization resolver intact; both entry points delegate.
check:type-check-debt               OK — 32 ledger entr(ies) re-measured in 360.1s, 1898 raw tsc error(s)
                                    total, none above its recorded number.
check:cross-package-test-inputs     OK: 16 package(s) read outside themselves, all declared, and turbo.json
                                    hashes every declared glob.
check:engine-double-contract        387 (file, verb) row(s) held by the RETAINED ledger  (exit 0)
check:where-matcher                 ✓ 297 matcher(s) discovered, 297 answer the combinator battery correctly
                                    or refuse it loudly; none new.
check:query-options-erasure         ✓ ratchet holds: 67 unswept non-test site(s), none new.
                                    baseline key set verified against c804f0c: no files added.
check:slot-lookup                   ✓ ratchet holds: 107 unswept site(s), none new.
check:nul-bytes                     OK (scanned 6666 text file(s); no raw ASCII control bytes).
check:kernel-hook-pairs             ✓ 4 dispatched kernel:* hook(s), each pinned in both kernel.test.ts and
                                    lite-kernel.test.ts
check:published-files               ✓ 69 publishable package(s) … declare a `files` whitelist
check:test-source-alias             OK — 72 packages with tests scanned; 61 registered
check:type-source-resolution        OK — 93 tsc program(s) across 77 packages scanned
check:type-check-coverage           (exit 0)
check:changeset-gate-self-tests     ✓ 118 + 212 + 116 assertions over real temp git repos
check:objectui-changeset            ✓ objectui-range --self-test: all checks passed
check-adr-0087-registration.mjs     ✓ this PR adds no declared-breaking changeset (1 non-breaking seen).
check-changeset-no-major.mjs        ✓ This diff introduces no `major` bump.
check-empty-changeset.mjs           ✓ No empty-frontmatter changeset introduced by this diff.
check-ci-filter-parity.mjs          OK: all 96 declared cross-package glob(s) … covered
check-cross-package-test-inputs.mjs OK: 16 package(s) read outside themselves, all declared
check-plugin-teardown-shape.mjs     ✓ 63 Plugin implementation(s) across 4647 source(s); baseline fully
                                    burned down
check-affected-docs.mjs             (exit 0)
check-drift-comment.mjs             ✓ 56 cases pass across 5 fixture diff(s).
release-rehearsal-clone.mjs --self-test   ✓ self-test passed
```

**Suites** — the owning package plus every in-repo caller of
`resolveLocalizationContext`, all exit 0:

```
@objectstack/core              Test Files  38 passed (38)   ·  Tests   949 passed (949)
@objectstack/mcp               Test Files  22 passed (22)   ·  Tests   242 passed (242)   ← the post-bind re-reader
@objectstack/runtime           Test Files 188 passed (188)  ·  Tests  2770 passed (2770)
@objectstack/service-settings  Test Files  29 passed (29)   ·  Tests   514 passed (514)
@objectstack/plugin-audit      Test Files  21 passed (21)   ·  Tests   321 passed (321)
@objectstack/rest (timezone)   Test Files   2 passed (2)    ·  Tests    39 passed (39)
@objectstack/dogfood (pin)     Test Files   1 passed (1)    ·  Tests     2 passed (2)
```

Note: `packages/core` declares **no `typecheck` script**, so none was run for it
— a `pnpm --filter @objectstack/core typecheck` would have matched zero scripts
and exited 0 while checking nothing. Its type coverage is asserted by the two
ledger gates above, both green, over a freshly built workspace closure
(`turbo run build --filter=./packages/* --filter=./packages/*/*` → `70
successful, 70 total`).

**`pnpm lint` (repo-wide `eslint . --no-inline-config`) was narrowed, and the
narrowing is declared and measured** — three pieces, not an omission:

1. *Population read from eslint's own config, not guessed.* Asked eslint
   directly (`ESLint#isPathIgnored` / `calculateConfigForFile`) about all three
   changed paths: the two `.ts` files are governed (`ignored=false`,
   rules present); the changeset `.md` is `ignored=true` by eslint's own config.
   So the eslint-governed population of this diff is exactly 2 files, and the
   narrowed run covered 100% of it.
2. *File count read from `--format json`, not from my summary:* `2` results,
   `errors=0 warnings=0` on both, exit 0.
3. *Invariance for untouched files:* this repo runs one `eslint.config.mjs` that
   **never enables type-aware linting for any file** — no `parserOptions.project`,
   no typed `@typescript-eslint` rules — stated and positively-controlled in the
   config itself (`eslint.config.mjs:326-335`). A verdict for an untouched file
   therefore cannot be a function of this diff.

CI runs the full farm regardless; the union above is the cheap half, owed and paid.

_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_