### PR TITLE
docs(api): record the os:check decision for client-sdk.mdx, and fence its JSX as tsx

### DIFF
--- a/content/docs/api/client-sdk.mdx
+++ b/content/docs/api/client-sdk.mdx
@@ -25,6 +25,41 @@ The `@objectstack/client` is the official TypeScript client for ObjectStack. It 
 pnpm add @objectstack/client
 ```
 
+{/*
+  CONTRIBUTOR NOTE — none of this page's TypeScript fences carries an
+  `os:check` marker, and that is a recorded decision rather than an omission.
+
+  `check:skill-examples` compiles marked blocks per SURFACE. `content/docs/**`
+  belongs to the "skills + docs" surface, whose resolution dir and `paths` map
+  are derived from `@objectstack/spec` alone — and `@objectstack/spec` does not
+  depend on `@objectstack/client`. So a marker on any fence that imports the SDK
+  reds with TS2307 "Cannot find module '@objectstack/client'" — a
+  surface-resolution gap, not doc-vs-SDK drift.
+
+  Every other fence is a deliberate continuation fragment: Quick Start
+  establishes `client` once and each later block continues that implied context,
+  so a marker there reds with TS2304 "Cannot find name 'client'". Making either
+  class compile would mean hand-declaring the SDK's own types, or injecting
+  casts into prose whose subject IS the real API — pinning each example to
+  itself and teaching worse code than the page teaches now.
+
+  Measured on this page (all 13 fences marked, then reverted): 128 diagnostics,
+  every one TS2307 / TS2304 / TS18004 / TS18046 / TS2591 / TS7006 / TS7026 /
+  TS2875. Not one was a doc-vs-SDK divergence.
+
+  The React Hooks block near the end is fenced tsx, not typescript, because it
+  IS JSX: the gate writes every block out with its fence's own extension, and
+  JSX in a .ts file is a syntax error. That reaches past this page — tsc stops
+  at syntax errors and never runs the semantic pass, so one such block would
+  suppress type-checking for every marked block across skills/ and
+  content/docs/ (measured here: 128 semantic diagnostics collapse to 0). Please
+  do not retag it back.
+
+  The marker becomes worth adding here the day the docs surface can resolve
+  `@objectstack/client` — the same condition recorded in
+  content/docs/kernel/runtime-services/data-service.mdx.
+*/}
+
 ## Quick Start
 
 ```typescript
@@ -636,7 +671,7 @@ For React applications, use `@objectstack/client-react`:
 pnpm add @objectstack/client-react
 ```
 
-```typescript
+```tsx
 import { ObjectStackProvider, useClient, useQuery } from '@objectstack/client-react';
 import { ObjectStackClient } from '@objectstack/client';
 


### PR DESCRIPTION
Part of #11942

## Why this is not "13 markers"

The card's scope was: opt the page's fences into `check:skill-examples`, compile, and repair
each red honestly, on the premise that *"each red is a real doc-vs-SDK divergence, not a marker
problem."*

**Measured, that premise does not hold: not one of the 13 reds is a doc-vs-SDK divergence.**
All 13 fences were marked, the gate run, and the tree reverted. Result: **128 diagnostics, zero
divergences**, in two structural classes neither of which this page can fix.

### Class 1 — the docs surface cannot resolve the SDK (3 fences)

`check:skill-examples` compiles per **surface**. `content/docs/**` belongs to the
`skills + docs (@objectstack/spec)` surface, whose `resolutionDir` and `paths` map derive from
`@objectstack/spec` alone — and `@objectstack/spec` does not depend on `@objectstack/client`
(confirmed: neither `packages/spec/node_modules/@objectstack/` nor the root
`node_modules/@objectstack/` exists).

Marking the single most self-contained fence on the page — a pure `createFilter()` builder chain
that is unambiguously correct SDK code — yields:

```
content/docs/api/client-sdk.mdx:485:30
    error TS2307: Cannot find module '@objectstack/client' or its corresponding type declarations.
```

That is a surface-resolution gap, not drift. The only real fix is adding `@objectstack/client` to
that surface's `selfPackages`, i.e. **editing the gate** — explicitly out of scope for this card.

This is not a new observation: `content/docs/kernel/runtime-services/data-service.mdx` already
records the identical constraint in prose, for the identical reason, and leaves its own SDK block
deliberately unmarked.

### Class 2 — deliberate continuation fragments (10 fences)

Quick Start establishes `const client = new ObjectStackClient(...)` once; every later fence
continues that implied context. Marking them reds with 93 x TS2304 `Cannot find name 'client'`,
plus TS18004 (`conversationId`, `messages`, `userId`, `orderId`, `recordId`), TS18046 (`error` is
`unknown` in a `catch`), TS2591 (`process`) and TS7006.

Making these compile means hand-declaring the SDK's own types or injecting casts into prose whose
subject *is* the real API — which pins each example to itself and teaches worse code than the page
teaches now. The card forbids editing a correct example into something that merely compiles.

## What this PR does deliver

**1. It records the decision.** The issue's actual claim is that *"nobody has decided, page by
page, which side of that line each block is on."* This PR decides it for this page and writes the
measurement down, as a contributor-facing MDX comment (renders to nothing), following the
`data-service.mdx` precedent. The next agent reads the answer instead of re-deriving it.

**2. It defuses a measured landmine.** The React Hooks block is JSX but was fenced as `typescript`.
The gate writes each block out with its **fence's own extension**, so a marker on it produced only
TS1xxx *syntax* errors — and `tsc` stops at syntax errors and never runs the semantic pass. Measured
consequence, on this page:

| fences marked | React Hooks fence | syntax errors | **semantic diagnostics** |
|---:|:---|---:|---:|
| 12 (JSX one excluded) | `typescript` | 0 | **118** |
| 13 (all) | `typescript` | 14 | **0** |
| 13 (all) | `tsx` | 0 | **128** |

One mis-tagged fence suppresses type-checking for **every marked block across `skills/` and
`content/docs/`** — 227 blocks — not just this page. Retagging it `tsx` is correct on its own terms
(the block *is* JSX) and converts a whole-surface blackout into honest per-block diagnostics.
`check:doc-authoring`'s `FENCE_OPEN` accepts `tsx`, so the block stays visible to it.

The marker becomes available here the day the docs surface can resolve `@objectstack/client`.

## Verification

Baseline and final are identical and unchanged, as intended — this PR adds no markers:

```
256 marked example(s) across 99 file(s), 3 surface(s)
256 prose examples type-check across 3 surface(s)
```

All 20 gate families derived at the final commit `c84df2983` by
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list),
plus `check:nul-bytes` and `check:skill-examples` — **22/22 green**, each exit code captured before
any pipe. MDX parse confirmed by compiling the page with the workspace's own `@mdx-js/mdx@3.1.1`.

Docs-only; no published package changes, so `skip-changeset` rather than a changeset.

Every mutation run above was performed under an `EXIT INT TERM` restore trap, with the marker count
on disk asserted before each run and the tree confirmed pristine after.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_