### PR TITLE
feat(platform-objects): declare a sourced maxLength on sys_import_job.created_by (#11374 route A, last column)

### DIFF
--- a/.changeset/import-job-created-by-bound.md
+++ b/.changeset/import-job-created-by-bound.md
@@ -1,0 +1,39 @@
+---
+'@objectstack/platform-objects': minor
+---
+
+Declare a sourced `maxLength` on `sys_import_job.created_by`, so its declared
+index can exist on MySQL — route A's last column
+
+`driver-sql` (since #11430) honours a keyed text-family field's declared
+`maxLength`, emitting `varchar(maxLength)` instead of `TEXT`, and #11699
+declared bounds on thirteen keyed identity columns. `sys_import_job.created_by`
+is keyed by `(created_by, created_at)` and declared no bound at all, so on MySQL
+that index was refused (`ER_BLOB_KEY_WITHOUT_LENGTH`: a TEXT/BLOB column cannot
+be a key without a prefix length) and the object landed registered-but-broken.
+It was the only remaining such object outside the >768-character class that
+#11627 tracks.
+
+The bound is **255**, derived by referenced-column transitivity rather than
+chosen: the column holds a `sys_user.id` stamped by the rest-server import route
+from `context.userId`, and `driver-sql` creates every table's primary key as
+`table.string('id').primary()` — knex's `varchar(255)` — so no id this column
+can receive exceeds 255. It agrees with what the column would get if declared
+like its siblings (`Field.lookup('sys_user')` emits
+`DEFAULT_STRING_VARCHAR_CHARS` = 255) and with the landed declarations for the
+same value class (`sys_metadata_audit.actor`, `sys_metadata_commit.actor`,
+`sys_view_definition.owner`, all 255). A minted platform id is 26 characters, so
+the bound clears the floor with 229 characters of headroom.
+
+This is behaviour-narrowing on a published object: on a strict MySQL server a
+`created_by` longer than 255 is now **refused** (`ER_DATA_TOO_LONG`, 0 rows)
+rather than stored, where previously the column was unbounded `TEXT`. No value
+the producing contract can emit is affected, because the id it copies is itself
+capped at 255 by its own column.
+
+The route-A pin moves from `identity/identity-keyed-text-bounds.test.ts` to
+`platform-keyed-text-bounds.test.ts` and now enumerates **every** platform
+object the package exports, not just `identity/`. That directory scoping is
+exactly how this column escaped the first pass — the pin could not see it — and
+a new control asserts the enumeration reaches columns in `audit/`, `metadata/`
+and `system/` so the narrowing cannot silently return.

--- a/packages/platform-objects/src/audit/sys-import-job.object.ts
+++ b/packages/platform-objects/src/audit/sys-import-job.object.ts
@@ -92,7 +92,35 @@ export const SysImportJob = ObjectSchema.create({
     // ── lifecycle timestamps ──
     started_at: Field.datetime({ label: 'Started At', required: false, group: 'State' }),
     completed_at: Field.datetime({ label: 'Completed At', required: false, group: 'State' }),
-    created_by: Field.text({ label: 'Created By', required: false, readonly: true, group: 'System' }),
+    // [#11374 route A] The value is `context.userId`, stamped by the rest-server
+    // import route (`String(context?.userId ?? context?.user?.id ?? '')` in
+    // `rest-server.ts`) — i.e. a `sys_user.id`. The bound is derived by
+    // referenced-column transitivity from three converging in-repo producers,
+    // never guessed:
+    //   - the physical column the id itself lives in: driver-sql creates every
+    //     table's primary key as `table.string('id').primary()`, which is knex's
+    //     `varchar(255)`, so no id this column can ever receive exceeds 255;
+    //   - what this column would be if it were declared like its siblings: every
+    //     other actor column on a platform object is `Field.lookup('sys_user')`,
+    //     which driver-sql emits at `DEFAULT_STRING_VARCHAR_CHARS` = 255;
+    //   - the landed text declarations for the same value class:
+    //     `sys_metadata_audit.actor`, `sys_metadata_commit.actor` and
+    //     `sys_view_definition.owner` all declare `maxLength: 255`.
+    // The floor is cleared with room to spare: a minted platform id is 26
+    // characters (measured on #11431, where honouring a bound below that made a
+    // column structurally unable to hold any id at all).
+    // 255 is also <= the 768-character utf8mb4 key ceiling, so the
+    // `(created_by, created_at)` index below is expressible on MySQL — which is
+    // the whole point: unbounded, this column was emitted TEXT and MySQL refused
+    // the index with `ER_BLOB_KEY_WITHOUT_LENGTH`, landing the object
+    // registered-but-broken.
+    created_by: Field.text({
+      label: 'Created By',
+      required: false,
+      readonly: true,
+      maxLength: 255,
+      group: 'System',
+    }),
     created_at: Field.datetime({
       label: 'Created At',
       required: true,

--- a/packages/platform-objects/src/platform-keyed-text-bounds.test.ts
+++ b/packages/platform-objects/src/platform-keyed-text-bounds.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
-import * as Identity from './index';
+import * as PlatformObjects from './index';
 
 /**
  * #11374 — every text-family column a declared index keys on must declare a
@@ -26,6 +26,18 @@ import * as Identity from './index';
  * has to live HERE, in the field declaration (maintainer ruling on #11374,
  * 2026-08-24: route A).
  *
+ * ## Why this file enumerates the WHOLE package, not just `identity/`
+ *
+ * It used to be `identity/identity-keyed-text-bounds.test.ts`, importing
+ * `./index` from `identity/`. That scoping is precisely how
+ * `sys_import_job.created_by` — a keyed, unbounded text column in `audit/` —
+ * survived route A's first pass: the pin could not see it, so nothing failed by
+ * name and the column was left for a follow-up card to find by hand. A pin that
+ * polices one directory does not police the defect class; it polices a
+ * directory. The enumeration now walks every object the package exports, and
+ * the vacuity control below asserts a column from OUTSIDE `identity/` is in
+ * the enumerated set, so the same narrowing cannot silently come back.
+ *
  * ## What a red on this file means
  *
  * A new keyed text-family field arrived without a `maxLength`. Do not silence
@@ -47,7 +59,7 @@ const TEXT_FAMILY = new Set(['text', 'textarea', 'html', 'markdown']);
 /**
  * Keyed text-family columns with NO defensible bound. Every entry must name
  * why. Entries that stop matching a real keyed unbounded column fail the
- * second test, so the list cannot rot.
+ * third test, so the list cannot rot.
  */
 const UNBOUNDABLE: ReadonlySet<string> = new Set([
   // better-auth's oauth-provider stores OIDC authorization-code payloads in
@@ -65,7 +77,7 @@ type AnyObject = {
   indexes?: Array<{ fields?: string[]; unique?: boolean }>;
 };
 
-const identityObjects: AnyObject[] = Object.values(Identity)
+const platformObjects: AnyObject[] = Object.values(PlatformObjects)
   .map((v) => v as unknown as AnyObject)
   .filter(
     (v) =>
@@ -84,19 +96,32 @@ function keyedTextColumns(o: AnyObject): Array<{ column: string; maxLength: unkn
     .map(([column, def]) => ({ column: `${o.name}.${column}`, maxLength: def.maxLength }));
 }
 
-describe('identity keyed text-family columns declare their bound (#11374)', () => {
+describe('platform keyed text-family columns declare their bound (#11374)', () => {
   it('enumerates a real surface — the probe itself is not vacuous', () => {
     // Positive control: if the export shape or field/index spelling changes so
     // this file stops seeing columns, fail loudly instead of passing empty.
-    const all = identityObjects.flatMap(keyedTextColumns);
-    expect(identityObjects.length).toBeGreaterThanOrEqual(20);
-    expect(all.length).toBeGreaterThanOrEqual(30);
+    const all = platformObjects.flatMap(keyedTextColumns);
+    expect(platformObjects.length).toBeGreaterThanOrEqual(40);
+    expect(all.length).toBeGreaterThanOrEqual(70);
     expect(all.map((c) => c.column)).toContain('sys_session.token');
+  });
+
+  it('reaches beyond identity/ — the scoping that let a keyed column escape', () => {
+    // The specific regression control for this file's own history: while it
+    // lived in `identity/` it enumerated only that directory, and
+    // `sys_import_job.created_by` (audit/) went unbounded through route A's
+    // first pass. These two names are in DIFFERENT source directories, so a
+    // future re-narrowing of the import fails here by name rather than by
+    // quietly enumerating less.
+    const columns = platformObjects.flatMap(keyedTextColumns).map((c) => c.column);
+    expect(columns).toContain('sys_import_job.created_by'); // audit/
+    expect(columns).toContain('sys_metadata.name'); // metadata/
+    expect(columns).toContain('sys_setting.key'); // system/
   });
 
   it('every keyed text-family column declares a positive integer maxLength, or is allowlisted by name', () => {
     const offenders: string[] = [];
-    for (const o of identityObjects) {
+    for (const o of platformObjects) {
       for (const { column, maxLength } of keyedTextColumns(o)) {
         if (UNBOUNDABLE.has(column)) continue;
         const bounded =
@@ -115,7 +140,7 @@ describe('identity keyed text-family columns declare their bound (#11374)', () =
 
   it('the UNBOUNDABLE allowlist matches only real, still-unbounded keyed columns', () => {
     const real = new Map(
-      identityObjects.flatMap(keyedTextColumns).map((c) => [c.column, c.maxLength]),
+      platformObjects.flatMap(keyedTextColumns).map((c) => [c.column, c.maxLength]),
     );
     for (const entry of UNBOUNDABLE) {
       expect(real.has(entry), `allowlist entry ${entry} is not a keyed text column any more — remove it`).toBe(true);


### PR DESCRIPTION
Part of #11374 — route A's **last column**.

Not a closing keyword by choice: #11374 also carries the C-half remainder (the
>768-character key class, tracked on #11627 and its sub-issue #11701), so
whether this card closes is the PM's call, not this PR's. #11699 landed route A
for 13 keyed identity columns; `sys_import_job.created_by` sat in `audit/`,
outside that dispatch's declared file surface, and was left for this card.

## The defect

`sys_import_job.created_by` is keyed by `(created_by, created_at)` and declared
no `maxLength`, so `driver-sql` emitted it `TEXT` and MySQL refused the index.
Per #11699's own measurement it was the only remaining
`ER_BLOB_KEY_WITHOUT_LENGTH` object outside the >768 class. Measured live, not
recalled — the driver's own message from the BEFORE leg:

```
[sql-driver] cannot create index 'idx_sys_import_job_created_by_created_at'
on "sys_import_job" — MySQL refuses a TEXT/BLOB column in a key without a key length
```

## The bound and where it comes from — the veto surface

Route A's method is that every bound is derived from a **named producer** and
stated so a reviewer can veto the row. One column, one row:

| Column | Bound | Source (named producer) |
|---|---|---|
| `sys_import_job.created_by` | **255** | Referenced-column transitivity from the value's actual producer. The rest-server import route stamps `String(context?.userId ?? context?.user?.id ?? '')` (`packages/rest/src/rest-server.ts`), i.e. a `sys_user.id`. `driver-sql` creates every table's primary key as `table.string('id').primary()` — knex's `varchar(255)` — so **no id this column can ever receive exceeds 255**. Confirmed physically in the same run: `sys_import_job.id` reads back `varchar(255)` from `information_schema`. |

Two independent in-repo corroborations, both already landed, neither used as the
primary source:

- **What this column would get if declared like its siblings.** Every *other*
  actor column on a platform object is `Field.lookup('sys_user', …)`, which
  `driver-sql` emits at `DEFAULT_STRING_VARCHAR_CHARS` = 255.
- **Landed text declarations for the same value class.**
  `sys_metadata_audit.actor` ("Acting principal — user id, system id, or
  'system'"), `sys_metadata_commit.actor` and `sys_view_definition.owner` all
  declare `maxLength: 255`.

**Floor cleared with headroom.** A minted platform id is 26 characters (measured
on #11431, where honouring a bound below that made a column structurally unable
to hold any id at all). 255 leaves 229 characters of headroom.

**Ceiling respected.** 255 is well inside the 768-character utf8mb4 key ceiling
(`MAX_KEYABLE_VARCHAR_CHARS`), so this stays out of the C class rather than
quietly merging the two ruled halves.

## Measured on live servers — physical read-back, never the emitted DDL

MySQL 8.0.46 (`@@global.time_zone = '+08:00'`, `STRICT_TRANS_TABLES`, utf8mb4)
and PostgreSQL 16.13, process `TZ=America/New_York`. All 44 distinct exported
platform objects through `syncSchema`, both legs at the same tree apart from the
one declaration.

| | BEFORE (unbounded) | AFTER (this PR) |
|---|---|---|
| MySQL `syncSchema` failures | **8 / 44** (7 `ER_BLOB_KEY_WITHOUT_LENGTH` + 1 `ER_TOO_LONG_KEY`) | **7 / 44** (6 + 1) |
| `sys_import_job` itself | FAILED, `ER_BLOB_KEY_WITHOUT_LENGTH` | clean |
| `created_by` physical column | `text`, `CHARACTER_MAXIMUM_LENGTH` 65535 | `varchar(255)` |
| `idx_sys_import_job_created_by_created_at` | **absent** | **present** |
| Postgres 16.13 control | 0 / 44 | 0 / 44 |

Column shapes are read from `information_schema.COLUMNS` and the index list from
`information_schema.STATISTICS` — the physical catalog, not the DDL the driver
emitted.

### The accept/reject flip

On the strict MySQL server, against the physical column:

| Value length | BEFORE | AFTER |
|---|---|---|
| 255 (boundary) | accepted, stored 255 | **accepted, stored 255** |
| 256 | accepted, stored 256 | **refused — `ER_DATA_TOO_LONG`, rows 0** |
| 300 | accepted, stored 300 | **refused — `ER_DATA_TOO_LONG`, rows 0** |

Refused, not truncated — which is why the changeset grades this `minor`
(behaviour-narrowing on a published object), matching #11699's tier. No value
the producing contract can emit is affected: the id being copied is itself
capped at 255 by its own column.

## The pin: why this column escaped, and the fix for the class

⚠️ Answering the dispatch's question explicitly: **route A's pin did NOT cover
`audit/`.** It lived at `identity/identity-keyed-text-bounds.test.ts` and
imported `./index` from `identity/`, so its enumeration could only ever see
identity objects. That is exactly how a keyed unbounded column in `audit/`
survived a pin whose stated job is to fail by name on keyed unbounded columns —
it policed a *directory*, not the defect class.

Extended rather than patched with a one-off assertion: the file moves to
`packages/platform-objects/src/platform-keyed-text-bounds.test.ts` and
enumerates **every object the package exports**. Measured effect on the
enumeration:

- objects walked: 20+ (identity only) → **45**
- keyed text-family columns enumerated: 30+ → **78**
- unbounded offenders surfaced by the widening: **exactly two** —
  `sys_verification.value` (already allowlisted, better-auth JSON blob) and
  `sys_import_job.created_by` (this PR). **The widening drags in no new debt.**

A new vacuity control asserts the enumeration reaches
`sys_import_job.created_by` (`audit/`), `sys_metadata.name` (`metadata/`) and
`sys_setting.key` (`system/`) — three different source directories — so a future
re-narrowing of the import fails by name instead of quietly enumerating less.
The `UNBOUNDABLE` allowlist and its anti-rot test are unchanged.

## Ablation — mutation proven on disk before any result was read

Direction predicted **in advance** in both legs; every prediction held.

**Leg A (pin discrimination, source level).** Removed only `maxLength: 255,`
from the `created_by` block. Anchor was proven unique before writing
(`ANCHOR HITS: 1`) and the mutation proven on disk after
(`created_by` bound-block count 1 → 0; `git diff --stat` = 1 deletion). Green
baseline 4 passed → red `Tests 1 failed | 3 passed (4)`, the failure naming
exactly:

```
sys_import_job.created_by (maxLength: undefined)
```

The red appeared with **no build step between mutation and run**, which is the
proof the suite read the mutated source rather than a stale artifact.

**Leg B (physical level, the BEFORE measurement above).** Same mutation, then
`pnpm --filter @objectstack/platform-objects build`, then
`ablation-dist-preflight.mjs … --absent` confirmed the bound was gone from all
**66 built files** — only then was the probe's result read.

**Restore verified, not trusted.** Both legs restored from a
`trap … EXIT INT TERM` using `git checkout HEAD -- ` with an **absolute** path
(never `git checkout -- FILE`, which restores from the index the mutation step
itself wrote). Verified after each leg: `git hash-object` of the working file
equals `git rev-parse HEAD:path` (`75930e4af21ade22f4b21f0996b4265ce14a781c`),
and `git status --porcelain` empty. The restore leg was then rebuilt and
re-proven with the preflight in **present** mode — marker back in 4 built files,
so no mutated artifact is left behind to poison later runs in this worktree.

## Gates

Union **derived, not recalled**:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` with no
paths passed (the script derives its own change set from the merge base). Its
stderr stamped the answer to this repo's tree. Every family run against the
final commit `59897f5e49`, exit captured **before any pipe**.

13 path-matched + `check:nul-bytes`, all `0`:
`check:nul-bytes`, `check:changeset-gate-self-tests`, `check:objectui-changeset`,
`check:published-files`, `check:slot-lookup`, `check:test-source-alias`,
`check:type-source-resolution`, `check-adr-0087-registration.mjs`,
`check-changeset-no-major.mjs`, `check-empty-changeset.mjs`,
`check-plugin-teardown-shape.mjs`, `docs-audit/check-affected-docs.mjs`,
`docs-audit/check-drift-comment.mjs`,
`release-rehearsal-clone.mjs --self-test`.

Convention-triggered, all `0`: `check:query-options-erasure`,
`check:type-check-coverage`, `check:engine-double-contract`,
`check:where-matcher`, `check:cross-package-test-inputs`, `check:i18n`.

Suites and ratchets, at `59897f5e49`:

- `pnpm --filter @objectstack/platform-objects test` → `Test Files 30 passed (30) / Tests 475 passed (475)`
- `pnpm --filter @objectstack/platform-objects typecheck` → exit 0, script name echoed (`tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json`), so not a zero-match
- `pnpm lint` (full repo, `eslint . --no-inline-config`) → exit 0 in 2m23s. A **full** run; no narrowing claimed.
- `pnpm check:type-check-debt --re-measure`, its own verdict line:
  `check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured in 360.3s, 1898 raw tsc error(s) total, none above its recorded number.`
- `check:i18n` first run exited 1 as a **measured refusal** (`PREREQUISITE NOT MET — the workspace CLI is not built`; nothing was checked), then green after building the CLI:
  `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).`

## Out of scope, deliberately

- `sys_verification.value` — better-auth stores OIDC authorization-code payloads
  there as a JSON blob; no bound provably admits every value. Stays allowlisted
  by name with its reason (#11627).
- `sys_account.issuer` and the `(issuer, account_id)` composite — 2048 exceeds
  the 768 key ceiling; that is the C class (#11627 / #11701).
- The hash-shadow-key route itself — #11627.

## Found while doing this, filed separately, NOT fixed here

The same defect class exists in sibling packages my pin cannot reach: four
keyed, unbounded `Field.text` columns in `plugin-audit` and `plugin-security`
(`sys_activity.record_id`, `sys_audit_log.record_id`,
`sys_audience_binding_suggestion.package_id` / `.permission_set_name`). Filed
unassigned rather than fixed — out of this card's declared surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_