### PR TITLE
fix(qa): declare @objectstack/spec in http-conformance, retiring the ledger ceiling it inflated

### DIFF
--- a/packages/qa/http-conformance/package.json
+++ b/packages/qa/http-conformance/package.json
@@ -17,6 +17,7 @@
     "@objectstack/objectql": "workspace:*",
     "@objectstack/plugin-hono-server": "workspace:*",
     "@objectstack/runtime": "workspace:*",
+    "@objectstack/spec": "workspace:*",
     "@types/node": "^26.2.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1967,6 +1967,9 @@ importers:
       '@objectstack/runtime':
         specifier: workspace:*
         version: link:../../runtime
+      '@objectstack/spec':
+        specifier: workspace:*
+        version: link:../../spec
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -1059,12 +1059,23 @@ const TEST_DEBT = {
   '@objectstack/connector-mcp': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
   '@objectstack/connector-openapi': { errors: 5, note: 'TS2339 x5. Re-measured 5 at 5ab08428, exact.' },
   '@objectstack/http-conformance': {
-    errors: 3,
-    note: 'TS2307 x2, TS2304 x1, TS2740 x1. Re-measured 4 at 5ab08428, up from 1. Worth knowing before '
-      + 'anyone tries to graduate it: 2 of the 4 are reported inside node_modules `.d.ts` files '
-      + '(@better-auth/core, @better-fetch/fetch), so this entry moves with the lockfile and not only with '
-      + 'this package\'s own code. Raw `tsc --noEmit` counts are what every number in these ledgers means, '
-      + 'so they are counted here rather than filtered out -- but they are not this package\'s debt to fix.',
+    errors: 2,
+    note: 'TS2307 x1, TS2304 x1, and BOTH are reported inside node_modules `.d.ts` files '
+      + '(@better-auth/core\'s `bun:sqlite` import, @better-fetch/fetch\'s `Timer`), so this entry now '
+      + 'moves with the lockfile and NOT with this package\'s own code at all -- every file this package '
+      + 'checks in is clean with the test exclusion lifted. Raw `tsc --noEmit` counts are what every '
+      + 'number in these ledgers means, so they are counted here rather than filtered out -- but they are '
+      + 'not this package\'s debt to fix, and this entry cannot graduate by fixing code. Re-measured 2 at '
+      + '3954fb7df, DOWN from 3 (#11788). The retired third diagnostic was a TS2307 on '
+      + '`@objectstack/spec/contracts` in conformance.integration.test.ts, which this package imported '
+      + 'without declaring @objectstack/spec: under pnpm\'s strict layout that specifier reached no '
+      + '@objectstack/spec anywhere on its resolution walk, so the old ceiling was a reading of the '
+      + 'INSTALL LAYOUT rather than of this package\'s types. Measured three ways on one tree at '
+      + '3954fb7df, same sources, same built closure: 3 as installed, 2 with @objectstack/spec merely '
+      + 'symlinked into the root node_modules and nothing else touched, 125 with packages/spec/dist moved '
+      + 'aside. #11788 declared the dependency, so the specifier now resolves through the closure this '
+      + 'gate refreshes and refuses on -- the number dropped because the program became well-defined, '
+      + 'not because anything was suppressed.',
   },
   '@objectstack/platform-objects': { errors: 3, note: 'TS2339 x2, TS7006 x1. Re-measured 3 at 5ab08428, exact.' },
   '@objectstack/plugin-sharing': { errors: 3, note: 'TS6133 x2, TS18048 x1. Re-measured 3 at 5ab08428, exact.' },


### PR DESCRIPTION
Fixes #11788

`packages/qa/http-conformance` imports `@objectstack/spec/contracts` from
`src/conformance.integration.test.ts` (line 25, `import type { IHttpServer }`) without
declaring `@objectstack/spec`. This declares it, and lowers the TEST_DEBT ceiling that the
undeclared import had inflated — measured, not assumed.

All measurements below are on one tree, at base `3954fb7df`, with the closure built exactly
as `lint.yml` does (`turbo run build --filter='./packages/*' --filter='./packages/*/*'` —
70/70 tasks successful). Final commit: **`52a8decfc`**.

## The two ledger measurements

Both are `check-type-check-coverage`'s own `--re-measure` path (its generated project, its
tsc, its counting rule), scoped to this one entry.

| | recorded | measured | direction |
|---|---|---|---|
| before | 3 | 3 | exact — `surplus: none` |
| after | 3 | **2** | **-1, the ceiling drops** |

The gate says it itself, unprompted, before the ledger was touched:

```
ℹ @objectstack/http-conformance: TEST_DEBT records 3, tsc now reports 2 (-1) -- the entry can be lowered.
check-type-check-coverage --re-measure: OK — 1 ledger entr(ies) re-measured in 113.8s, 2 raw tsc error(s) total, none above its recorded number.
  surplus: 1 raw error(s) across 1 entr(ies) sit BELOW their recorded ceiling
```

### Itemised, every diagnostic in both measurements

**Before — 3:**

```
node_modules/.pnpm/@better-auth+core@1.7.1_.../node_modules/@better-auth/core/dist/types/init-options.d.mts(15,26): error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
node_modules/.pnpm/@better-fetch+fetch@1.3.1/node_modules/@better-fetch/fetch/dist/index.d.ts(742,19): error TS2304: Cannot find name 'Timer'.
packages/qa/http-conformance/src/conformance.integration.test.ts(25,34): error TS2307: Cannot find module '@objectstack/spec/contracts' or its corresponding type declarations.
```

**After — 2:**

```
node_modules/.pnpm/@better-auth+core@1.7.1_.../node_modules/@better-auth/core/dist/types/init-options.d.mts(15,26): error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
node_modules/.pnpm/@better-fetch+fetch@1.3.1/node_modules/@better-fetch/fetch/dist/index.d.ts(742,19): error TS2304: Cannot find name 'Timer'.
```

The diff is exactly one line: the `@objectstack/spec/contracts` TS2307 is gone and **nothing
else moved**. Both survivors are third-party `.d.ts` diagnostics that this package cannot
fix; **no diagnostic in the new measurement was introduced by this PR**, and none was
absorbed.

Worth recording for whoever reads the entry next: after this, *every file this package checks
in is clean* with the test exclusion lifted. The entry cannot graduate (graduation needs 0)
because both remaining diagnostics live in `node_modules` and move with the lockfile.

## Why moving this ceiling is not a gate weakening

The recorded 3 was not a debt reading. It was a reading of **where the package manager
happened to put `@objectstack/spec`** — demonstrated, not asserted. Three legs, one tree, one
commit, identical sources and identical built closure, running the same generated project
through the same tsc; only the resolution environment differs:

| leg | manifest | `@objectstack/spec` placement | count |
|---|---|---|---|
| A | undeclared (base) | as pnpm installs it — reachable from nowhere on the walk | **3** |
| E | **undeclared, unchanged** | symlinked into the root `node_modules`, nothing else touched | **2** |
| B | undeclared (base) | `packages/spec/dist` moved aside | **125** |

Leg E is the load-bearing one: **the manifest is byte-identical to base**, and the count still
drops to 2 purely because `@objectstack/spec` became reachable. A number that changes with
install layout while the source does not is not a measurement of this package's types.

Leg B is the positive control, and it also answers the "both legs failed the same way, so the
diff is empty" trap — the legs are not identical (3 / 2 / 125), so the comparison carries
information. It reproduces exactly the mechanism this gate's own BUILT CLOSURE section
documents: an unresolved workspace import invents TS2307 and then an implicit-any cascade
(`packages/qa/http-conformance/src/*.test.ts` alone contributes ~40 fresh TS7006).

Note what leg B does **not** show: the `conformance.integration.test.ts` TS2307 is present in
both A and B. That specific diagnostic was insensitive to whether `@objectstack/spec` was
*built*, because the specifier never reached `@objectstack/spec` at all — it was sensitive to
*layout* only, which is what leg E isolates. After this PR the specifier resolves through the
declared closure, which is the closure `--re-measure` refreshes and refuses on, so the entry's
number is now governed by the gate instead of by ambient hoisting.

## devDependencies, not dependencies

The triage note said "dependencies"; the issue body allowed "or devDependency, matching how
the package consumes it". Measured, `devDependencies` is the match:

- the only import is `import type`, in a `*.test.ts`, erased at build time;
- every other workspace package this package uses **only from its tests** (`objectql`,
  `driver-sqlite-wasm`, `plugin-hono-server`, `runtime`) is already a devDependency;
  `@objectstack/core` sits in `dependencies` because `src/adapter.ts` and `src/node-plugin.ts`
  — non-test source — import it;
- the placement costs nothing in gate coverage: `workspaceBuildGraph` reads `dependencies`,
  `devDependencies` and `peerDependencies` alike, so `@objectstack/spec` is inside the BUILT
  CLOSURE precondition either way;
- the package is `private: true` and never published, so no published manifest changes.

## Clause ②: no — re-affirmed against what was built

Declaring a dependency the code already imported changes no accept set and no public surface.
Re-affirmed rather than recalled: the diff is one manifest line, three lockfile lines, and one
tooling ledger entry; no `packages/spec` file is touched (it is read-only for this card); no
schema, route, error code or exported type changes; `pnpm --filter @objectstack/http-conformance test`
is 86/86 green with identical assertions before and after, because the import was type-only and
never existed at runtime.

## Changeset: `skip-changeset`, argued

Nothing publishable moves, so a changeset would describe a release that cannot happen:

- `@objectstack/http-conformance` is `"private": true` and is **not** one of the 69 public
  workspace packages — `check-changeset-fixed` prints
  `✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.`, and the
  package is absent from that group;
- `scripts/check-type-check-coverage.mjs` is repo tooling, never published;
- `pnpm-lock.yaml` is not published.

`check-empty-changeset` forbids the empty-changeset alternative, so the honest choice is the
label rather than a placeholder file.

## Checks — each gate's own verdict line, at `52a8decfc`

Gate family re-derived from the real change set with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, and again after the
commit; it did not grow (3 paths, 19 families, both times).

```
pnpm lint (eslint . --no-inline-config, full repo)  exit 0
check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger (436 frozen raw errors), 1 exempt.
  test layer: 19 package(s) still hide their own tests from tsc (1077 files hidden as counted by this run, 1462 frozen raw errors in TEST_DEBT).
✓ check:type-check-coverage --self-test — 47 semantic case(s) + 65 observation case(s) + 29 re-measure case(s) + 28 built-closure case(s) + 19 auto-lowering case(s) hold.
check-type-check-coverage --re-measure: OK — 1 ledger entr(ies) re-measured in 122.9s, 2 raw tsc error(s) total, none above its recorded number.
  surplus: none — every entry sits exactly at its measurement, so any new error is red.
✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.
OK: all 96 declared cross-package glob(s) (81 unique) are covered by `core` or `crosspkg`, ...
OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.
✓ osv-scanner.toml holds zero OSV exemptions (the intended steady state).
✓ check:plugin-teardown-shape: 63 Plugin implementation(s) across 4648 source(s) under packages/**; ...
check-nul-bytes: OK (scanned 6667 text file(s) -- 6667 tracked, 0 untracked-not-ignored; skipped 6 binary; no raw ASCII control bytes).
Test Files  5 passed (5) / Tests  86 passed (86)      # pnpm --filter @objectstack/http-conformance test
> @objectstack/http-conformance@0.1.2 typecheck ... tsc --noEmit      exit 0
```

The TEST_DEBT total moves 1463 → 1462, which is exactly this entry's -1 and no other entry.

Also exit 0 at `52a8decfc`: `check:agent-test-spelling`, `check:cross-package-test-inputs`,
`check:entry-guard`, `check:override-consistency`, `check:parse-guard`,
`check:pnpm-filter-targets`, `check:published-files`, `check:slot-lookup`,
`check:test-source-alias`, `check:type-source-resolution`, `check-ci-filter-parity.mjs`,
`check-affected-docs.mjs`, `check-drift-comment.mjs`.

### Declared narrowing

The `--re-measure` half was run **scoped to this one entry**, through the gate's own code path
(same generated project, same tsc, same counting rule, same BUILT CLOSURE refresh — its
`--self-test` passes unmodified). A full-ledger `--re-measure` is ~2 minutes per entry on this
contended container across 33 entries, which does not fit a foreground run and would hold the
shared verify lock for an hour. CI runs the full farm regardless; this is the cheap half, not a
substitute for it.

## Scope

Only this package's ledger entry is touched — the other four cards in flight were told to leave
the ledger alone, and this diff changes exactly one `errors:` field. The entry's `note` is
re-tallied onto what it now measures (its old itemisation described a 4-pile that has not been
true for some time), so no `compositionAt` declaration is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019siH5jDmk5hrayvfyojUqR)_