### PR TITLE
fix(devx): reject an interpolating template literal in check-cross-package-test-inputs' PATH_LITERAL

### DIFF
--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -558,6 +558,27 @@ const PATH_LITERAL = /^(['"`])([^'"`]*)\1$/;
 const NEW_URL_LITERAL = /^new\s+URL\(\s*(['"`])([^'"`]*)\1\s*,\s*import\.meta\.url\s*,?\s*\)$/;
 
 /**
+ * `PATH_LITERAL`'s character class excludes only quote characters, so a
+ * BACKTICK-delimited argument containing no quotes matches it even when it is
+ * an interpolating template — `` `${someVar}` `` reads as the literal segment
+ * text `${someVar}`, which the walk below would count as ONE ordinary descent
+ * instead of routing it through the cannot-read branch that exists for exactly
+ * this case. That is not a lower bound: it biases the depth walk UPWARD and can
+ * hide an escape the unreadable-argument trade was written to still catch
+ * (#11487). A single- or double-quoted literal is unaffected — `${` inside one
+ * of those is ordinary text, never interpolation, so only the backtick
+ * delimiter needs the extra check. This is the ONE call site `PATH_LITERAL`
+ * has in this file (inside `pathExpression()`'s `resolve`/`join` argument
+ * walk), so narrowing it here does not move any other consumer's verdict.
+ */
+function readablePathLiteral(arg) {
+  const lit = arg.match(PATH_LITERAL);
+  if (!lit) return null;
+  if (lit[1] === '`' && lit[2].includes('${')) return null;
+  return lit;
+}
+
+/**
  * A formatter's TRAILING COMMA, dropped from an argument list before it is read.
  *
  * The other half of the line-spanning spelling (#11093), and the half that would
@@ -650,7 +671,7 @@ function pathExpression(expr, hereDepth, known, fileSegs = null) {
   if (!base) return undefined;
   let { end, min, vendored, segs } = base;
   for (const a of args.slice(1)) {
-    const lit = a.match(PATH_LITERAL);
+    const lit = readablePathLiteral(a);
     if (!lit) {
       // An argument this scan cannot read leaves the DEPTH walk where it was —
       // deliberately, since the escape verdict is a lower bound and has always
@@ -1939,6 +1960,36 @@ function selfTest() {
         "const P = join(ROOT, someVariable, 'x.ts');",
       1,
     ),
+  );
+  // ── the INTERPOLATING TEMPLATE argument (#11487) ──────────────────────────
+  //
+  // `PATH_LITERAL`'s character class excludes only quote characters, so a
+  // backtick argument holding no quotes matches it even when it is an
+  // interpolating template — `` `${someVar}` `` read as the literal segment
+  // text `${someVar}` and walked as ONE ordinary descent, biasing the depth
+  // walk UPWARD instead of taking the cannot-read path above. That is the
+  // exact inverse of the trade this file relies on everywhere else: an
+  // unreadable argument is safe, and a template read as readable was LESS
+  // safe than unreadable. Same climb, same file, only the middle argument
+  // differs from the unreadable-argument pair just above.
+  const TEMPLATE_SEED = 'const HERE = dirname(fileURLToPath(import.meta.url));\n';
+  const TEMPLATE_UNREADABLE = TEMPLATE_SEED + "const P = join(HERE, someVar, '../../other-pkg/src/y.ts');";
+  const TEMPLATE_INTERP = TEMPLATE_SEED + "const P = join(HERE, `${someVar}`, '../../other-pkg/src/y.ts');";
+  ok('(control) the unreadable-argument sibling of the pair below still flags at depth -1', at(TEMPLATE_UNREADABLE, 1));
+  ok(
+    'an interpolating template argument takes the SAME cannot-read path as an unreadable one — it flags too',
+    at(TEMPLATE_INTERP, 1),
+  );
+  ok(
+    'and — like any unreadable argument — yields no name for the path it builds (never a WRONG name)',
+    !named(TEMPLATE_INTERP, 1, CO).some((p) => p.endsWith('y.ts')),
+  );
+  ok(
+    'a non-interpolating backtick literal is NOT swept up by the narrowing — still read, still flags, still named',
+    (() => {
+      const src = TEMPLATE_SEED + "const P = join(HERE, `../../other-pkg/src/y.ts`);";
+      return at(src, 1) && named(src, 1, CO).includes('packages/other-pkg/src/y.ts');
+    })(),
   );
   ok(
     'a climb ABOVE the repo root yields no name (there is no repo-relative one)',


### PR DESCRIPTION
Fixes #11487

## What

`scripts/check-cross-package-test-inputs.mjs` states, twice, that an argument the scan cannot read leaves the DEPTH walk unchanged and only drops the NAME — the escape verdict is a lower bound. `PATH_LITERAL`'s character class (`[^'"`]*`) excludes only quote characters, so a backtick-delimited argument holding no quotes matched it even when it was an **interpolating template**: `` `${someVar}` `` read as the literal segment text `${someVar}` and `walkLiteral()` counted it as ONE ordinary descent — the exact inverse of the stated trade. An unreadable argument was safe; a template read as readable was **less** safe than unreadable.

Fix: `PATH_LITERAL` has exactly **one** call site in this file (inside `pathExpression()`'s `resolve`/`join` argument walk — verified by grep before touching it), so narrowing it moves no other consumer's verdict. That call is now routed through a small `readablePathLiteral()` wrapper that rejects a backtick literal containing `${` and falls back to the existing unreadable-argument branch (name dropped, depth preserved). A single/double-quoted literal is unaffected — `${` inside one of those is ordinary text, never interpolation.

**Resolver vs. filter (issue's Zone 2.3 question):** before this fix, "never a wrong name" held only because `findEscapingPackages()`'s downstream `statSync(...).isFile()` filter happened to drop the fabricated roster entry. After this fix, the resolver itself (`pathExpression()`) never produces a name for an interpolating template in the first place — the invariant is now true at the point the file's own comment makes the claim, not merely downstream of it.

## Tests

`--self-test` gains four cases at the site of the existing "unreadable join() argument" pair, using the issue's own fixture:

- a control repeating the existing unreadable-argument case (still flags, depth -1)
- the interpolating-template case (`` join(HERE, `${someVar}`, '../../other-pkg/src/y.ts') ``) — **now flags**, depth -1
- the same template case yields **no name** for the path it builds (never a wrong name)
- a **non-interpolating** backtick literal (`` `../../other-pkg/src/y.ts` ``) is unaffected — still flags AND is still correctly named `packages/other-pkg/src/y.ts`, proving the narrowing does not overshoot

Reverse-verified: reverting the call site to the raw `a.match(PATH_LITERAL)` (with the fix commit intact, so a real restore point exists) fails exactly the two new cases that assert the fix and none of the others — `2/113 self-test case(s) failed`. Restored and confirmed `git diff HEAD` clean before re-running.

```
$ node scripts/check-cross-package-test-inputs.mjs --self-test
...
All 113 self-test cases passed.
```

Derived gate list (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack scripts/check-cross-package-test-inputs.mjs`, re-run against HEAD `3a73f5644`) — all pass:

```
check:agent-test-spelling            exit=0
check:cross-package-test-inputs      exit=0  (self-test 113/113 + OK: 16 package(s) read outside themselves, all declared)
check:entry-guard                    exit=0
check:parse-guard                    exit=0
check:pnpm-filter-targets            exit=0
node scripts/check-ci-filter-parity.mjs  exit=0
```

`node scripts/pm/bare-root-worklist.mjs --self-test` — unaffected: no new scan-root population declared by this change (`none stale, none missing`).

## Scope

`NEW_URL_LITERAL` (three lines above `PATH_LITERAL`) has the identical character-class shape and the identical blind spot in a structurally different call path (`new URL(rel, import.meta.url)` seeds, not `resolve`/`join` arguments) — confirmed by direct regex test. Left untouched here per the issue's disposition and filed separately as #12085 for its own triage read, since an unmatched `NEW_URL_LITERAL` doesn't fall into the same "cannot read, keep depth" branch (the whole seed goes unrecognised instead), so the fix consequence isn't identical.

## Changeset

None — `skip-changeset`: this PR touches only `scripts/check-cross-package-test-inputs.mjs`, a repo gate script under `scripts/**`, nothing published.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_