### PR TITLE
docs(spec): widen DELIVERY_NOT_ELIGIBLE's ledger gloss to both delivery surfaces

### DIFF
--- a/.changeset/delivery-not-eligible-gloss-both-surfaces.md
+++ b/.changeset/delivery-not-eligible-gloss-both-surfaces.md
@@ -1,0 +1,36 @@
+---
+'@objectstack/spec': patch
+---
+
+`DELIVERY_NOT_ELIGIBLE`'s ledger gloss now describes every surface that raises it, not just `redeliver`
+
+The `ERROR_CODE_LEDGER` entry for `DELIVERY_NOT_ELIGIBLE` glossed the code as
+*"delivery row is in a non-terminal state"*. That named one refusal on one
+surface, and the code has since been reused on a second: `INotificationOutbox.ack`
+refuses any row that is not `in_flight`, which covers an unclaimed `pending` row
+**and** an already-terminal one. So the old wording was not merely incomplete —
+it was backwards for half the code's uses, describing terminal rows as the
+acceptable ones when `ack` refuses exactly those.
+
+The reuse itself is the ruled shape, not a defect: one concept — *this delivery
+row's state does not permit the requested operation* — on two delivery surfaces,
+with a second near-synonym code rejected for the vocabulary sprawl ADR-0112
+exists to prevent. Only the comment lagged.
+
+The gloss is now stated per surface, because the two refuse opposite halves of
+the state space and no single status predicate covers both:
+
+- **`IHttpOutbox.redeliver`** (`HttpRedeliverError`) refuses a row that is NOT
+  terminal — `redeliver` means send this again, so it wants
+  `success`/`failed`/`dead`. It also raises the same code when the producer's
+  `RedeliverGuard` refuses or itself throws (fail-closed: "we could not check"
+  must never read as "allowed"), and when the terminal re-check at the write
+  misses because a dispatcher tick re-claimed the row mid-call.
+- **`INotificationOutbox.ack`** (`NotificationAckError`) refuses a row that is
+  not `in_flight` — both the unclaimed `pending` row (the ack-as-cancel trap)
+  and the already-terminal one — plus the `SqlNotificationOutbox` compare-and-set
+  read-back that shows the claim was lost mid-ack.
+
+Comment only. No code is registered or removed, no wire value changes, and no
+acceptance or refusal behaviour moves — `packages/spec` publishes
+`src/**/*.zod.ts`, so the corrected gloss ships to consumers reading the ledger.

--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -510,7 +510,34 @@ export const ERROR_CODE_LEDGER = {
   ],
   '@objectstack/service-messaging': [
     'DELIVERY_NEVER_SENT',           // [#8069] terminal delivery row with 0 attempts — a PARKED record of a delivery that could never be prepared, not one that failed. Redelivering it would be a FIRST send, and the row carries no HMAC signature because the secret that would have produced one is exactly what went missing, so it would go out unsigned (#7799). Distinct from DELIVERY_NOT_ELIGIBLE: that one says "wrong state, try when it settles"; this one says "never, fix the configuration instead"
-    'DELIVERY_NOT_ELIGIBLE',         // delivery row is in a non-terminal state
+    // "this delivery row's state does not permit the requested operation" —
+    // ONE concept on TWO delivery surfaces of this package, deliberately
+    // sharing one spelling (PR #11858's contract-review PASS ruled option B;
+    // a second near-synonym code was rejected for the vocabulary sprawl
+    // ADR-0112 exists to prevent). Stated per-surface because the two refuse
+    // OPPOSITE halves of the state space — no single status predicate glosses
+    // both, and the older "non-terminal state" wording named only the first:
+    //   - `IHttpOutbox.redeliver` (`HttpRedeliverError`; the operator
+    //     redeliver button) refuses a row that is NOT terminal —
+    //     `redeliver` means send this AGAIN, so it wants `success`/`failed`/
+    //     `dead` (`assertHttpRedeliverable`). Also raised when the producer's
+    //     `RedeliverGuard` refuses, or itself throws (fail-closed on purpose:
+    //     "we could not check" must never read as "allowed"), and when the
+    //     terminal re-check AT THE WRITE misses because a dispatcher tick
+    //     re-claimed the row mid-call — both `SqlHttpOutbox` and
+    //     `MemoryHttpOutbox` report that miss instead of a false success
+    //     (#11009).
+    //   - `INotificationOutbox.ack` (`NotificationAckError`; #11453) refuses a
+    //     row that is not `in_flight` — which covers BOTH an unclaimed
+    //     `pending` row (the ack-as-cancel trap) and an already-terminal one,
+    //     because `ack` records the outcome of a delivery the caller CLAIMED.
+    //     Also raised by `SqlNotificationOutbox` when its compare-and-set
+    //     read-back shows the claim was lost mid-ack (a slow send outrunning
+    //     `claimTtlMs`), so nothing was written.
+    // Distinct from DELIVERY_NEVER_SENT: this one says "wrong state for THIS
+    // operation, try when it settles"; that one says "never, fix the
+    // configuration instead".
+    'DELIVERY_NOT_ELIGIBLE',
   ],
   '@objectstack/trigger-api': [
     'ENQUEUE_FAILED',                // queue accepted the call but publish threw


### PR DESCRIPTION
Fixes #11892

`ERROR_CODE_LEDGER`'s entry for `DELIVERY_NOT_ELIGIBLE` glossed the code as *"delivery row is in a non-terminal state"*. The code is now raised on two delivery surfaces, and they refuse **opposite halves** of the state space — so the old wording was not merely incomplete, it was **backwards for half the code's uses**: it describes terminal rows as the acceptable ones, while `INotificationOutbox.ack` refuses exactly those.

Comment only. No code is registered or removed, no wire value changes, and no acceptance or refusal behaviour moves. The reuse itself is the ruled shape (PR #11858's contract-review PASS ruled option B; a second near-synonym code was rejected for the vocabulary sprawl ADR-0112 exists to prevent) — only the comment lagged.

## What the gloss now says, and how the refusal set was derived

The card named two surfaces. A repo-wide `git grep -rn "DELIVERY_NOT_ELIGIBLE" -- 'packages/**/*.ts'` over the real throw sites found **six**, in two families — the gloss covers the measured set, not the card's reading:

| Surface | Refusal | Site |
| --- | --- | --- |
| `IHttpOutbox.redeliver` (`HttpRedeliverError`) | row is **not** terminal (`redeliver` wants `success`/`failed`/`dead`) | `http-outbox.ts` `assertHttpRedeliverable` |
| | producer's `RedeliverGuard` returned a refusal | `http-outbox.ts` `assertRedeliverAllowed` |
| | `RedeliverGuard` itself **threw** — fail-closed, "we could not check" must never read as "allowed" | `http-outbox.ts` `assertRedeliverAllowed` |
| | terminal re-check **at the write** missed: a dispatcher tick re-claimed the row mid-call | `sql-http-outbox.ts`, `memory-http-outbox.ts` |
| `INotificationOutbox.ack` (`NotificationAckError`) | row is not `in_flight` — covers an unclaimed `pending` row (the ack-as-cancel trap) **and** an already-terminal one | `sql-outbox.ts`, `memory-outbox.ts` |
| | compare-and-set read-back shows the claim was lost mid-ack (slow send outran `claimTtlMs`) | `sql-outbox.ts` |

The two guard-based redeliver refusals and the two compare-and-set misses are not state predicates at all, which is the second reason no single-clause gloss covers this code. The entry keeps the neighbouring `DELIVERY_NEVER_SENT` "Distinct from…" contrast, now pointed both ways.

## Premise check against `origin/main`

The card's premise holds; two details in the dispatch reading did not survive verification, and neither changes the fix:

- The card cites `error-code-ledger.zod.ts:511`; the entry is at **:513** on `f7b25c5` (line drift).
- The ledger has **one** gloss for this code, not two. The file's second textual occurrence is the cross-reference *inside* `DELIVERY_NEVER_SENT`'s gloss on the line above, and both sit in the same `@objectstack/service-messaging` section — so there is one place to write, not a per-section sweep.

## Generated ledger docs: correctly unchanged

`content/docs/references/api/error-code-ledger.mdx` is an auto-generated artifact, but the generator emits only the **code-name list** — it never carries the inline glosses (`grep` for the old wording in the page returns nothing). So this change produces no docs delta, and no generated file belongs in this PR. Proven rather than assumed, after `gen:schema` supplied the required `json-schema` tree:

```
pnpm --filter @objectstack/spec check:docs
  ✅ 229 generated files in sync with packages/spec
```

## Verification — union re-run on the final commit `285254d`

Gate families derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` against the real change set (26 families; broader than the dispatch list, which predated the changeset file). Re-run on the committed HEAD, quoting each gate's own verdict line:

- `check:error-code-casing` — `✓ no unlisted lowercase error codes in 4660 scanned file(s) (ADR-0112).`
- `check:dispatcher-error-vocabulary` — `OK — 21 unregistered code-stamping site(s), all classified; 1 awaiting a ledger entry (#8846).`
- `@objectstack/spec check:docs` — `✅ 229 generated files in sync with packages/spec`
- `@objectstack/spec check:liveness` — `✓ … the README state table carries a row for each of the 31 governed type(s) it claims to index.`
- `@objectstack/spec check:empty-state` — `✓ all classified (1 closed, 2 open, 4 output, 9 scope)`
- `@objectstack/spec check:strictness-ledger` — `✓ strictness ledger: 60 file(s) across 5 triaged director(ies) …`
- `@objectstack/spec typecheck` — `check:test-typecheck: OK — @objectstack/spec's test layer compiles …`
- `@objectstack/spec` ledger suite — `Test Files 1 passed (1) · Tests 17 passed (17)`

Green earlier in the same tree: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:merge-driver`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:spec-parsed-alias`, `check:test-source-alias`, `check:type-source-resolution`, `check:variant-docs`, `check:doc-formula-expressions` (`✓ … 22 record-scoped formula example(s) across 421 files / 1449 TS blocks judged clean`, after building `@objectstack/formula` and `@objectstack/lint`, whose absence had made it exit before measuring anything), plus `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-cross-package-test-inputs`, `check-empty-changeset`, `check-plugin-teardown-shape`, `check-affected-docs`, `check-drift-comment`, `release-rehearsal-clone --self-test`, `check-nul-bytes`.

### Declared narrowings

- **`check-dev-prereqs.mjs` was not run to a verdict.** Its precondition is a built workspace (it reported 67 of 67 packages missing their `dist/` entry point) and it measured nothing. A full `pnpm build` is a repo-scale run CI owns and performs before this gate.
- **Repo-wide `pnpm lint` narrowed to the changed files, and the narrowing is measured, not assumed.** ESLint's own config declines the changeset (`File ignored because no matching configuration was supplied.`), so the linted population of this diff is the single `.ts` file; `--format json` reports 2 entries / **0 errors, 0 real warnings**. The narrowing excludes nothing because this repo runs one `eslint.config.mjs` that **never enables type-aware linting for any file** (no `parserOptions.project`, no typed `@typescript-eslint` rules — stated in the config with a measured positive control), so a two-file comment diff cannot move the verdict of any untouched file.

## Scope

Clause ② is **no** — prose only; the set of legal metadata and every accept/reject decision is byte-for-byte identical before and after. The diff touches `packages/spec/src/**`, so it still routes through `needs:contract-review` before enqueue. Draft, and staying draft.