### PR TITLE
docs(spec): strip the internal issue-ids projected into the published skill catalog, and drop the gate exemption that hid them

### DIFF
--- a/.changeset/skill-catalog-projected-issue-ids.md
+++ b/.changeset/skill-catalog-projected-issue-ids.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): strip the internal issue-id references that were projected into the published skill catalog
+
+The 2026-08-23 ruling stripped internal `#NNNN` citations from the published
+skill corpus, but 14 of them were not authored in `skills/**` at all — they were
+projected there from `.describe()` / TSDoc text in `packages/spec/src/**` by
+`gen:skill-refs` and `gen:react-blocks`, so a hand-edit of the corpus could not
+reach them and a regeneration would have put them straight back.
+
+Six source sites are rewritten to say the same thing without the citation, and
+the artifacts are regenerated: the module summaries of `data/driver/common`,
+`data/driver/config-registry`, `data/driver/turso`, `shared/retry-policy` and
+`system/translation`, plus the `ListView.objectName` / `ListView.viewType`
+deprecation notes and the `<Block>` summary in `ui/react-blocks`. The teaching in
+each is kept, per the standing ruling of 2026-08-12, verbatim and untranslated:
+「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」.
+
+Customer-facing text changes in three places from the one source edit: the
+published catalog (`skills/*/references/_index.md`,
+`skills/objectstack-ui/references/react-blocks.md` and its sibling
+`contracts/react-blocks.contract.json`), and the docs site
+(`content/docs/references/data/driver-common.mdx`, `driver-turso.mdx`). No
+schema shape, no `.describe()` used for validation, and no accept/reject
+behaviour changes — the edits are comment and documentation text only.
+
+The doc-authoring gate's path exemption for the generated artifacts is removed
+in the same change: it existed only because those files still carried projected
+ids, and an exemption over a surface that no longer needs one is where the next
+regeneration would smuggle one back in.

--- a/content/docs/references/data/driver-common.mdx
+++ b/content/docs/references/data/driver-common.mdx
@@ -5,7 +5,7 @@ description: Driver Common protocol schemas
 
 {/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs live in the module folders under content/docs/. */}
 
-Shared building blocks for the per-driver `datasource.config` shapes (#4410).
+Shared building blocks for the per-driver `datasource.config` shapes.
 
 Every schema under `data/driver/` describes ONE driver's `config` slot — the
 keys an author may write and the platform actually reads. They are the

--- a/content/docs/references/data/driver-turso.mdx
+++ b/content/docs/references/data/driver-turso.mdx
@@ -5,7 +5,7 @@ description: Driver Turso protocol schemas
 
 {/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs live in the module folders under content/docs/. */}
 
-Turso / libSQL Driver Protocol (#6345).
+Turso / libSQL Driver Protocol.
 
 ## Why this arrives late, and what it closes
 

--- a/packages/spec/src/data/driver/common.zod.ts
+++ b/packages/spec/src/data/driver/common.zod.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod';
 
 /**
- * Shared building blocks for the per-driver `datasource.config` shapes (#4410).
+ * Shared building blocks for the per-driver `datasource.config` shapes.
  *
  * Every schema under `data/driver/` describes ONE driver's `config` slot — the
  * keys an author may write and the platform actually reads. They are the

--- a/packages/spec/src/data/driver/config-registry.zod.ts
+++ b/packages/spec/src/data/driver/config-registry.zod.ts
@@ -15,7 +15,7 @@ import {
 import { getTursoConfigJsonSchema, TursoConfigSchema } from './turso.zod';
 
 /**
- * The driver-id → `datasource.config` shape registry (#4410).
+ * The driver-id → `datasource.config` shape registry.
  *
  * ## Why this exists
  *

--- a/packages/spec/src/data/driver/turso.zod.ts
+++ b/packages/spec/src/data/driver/turso.zod.ts
@@ -17,7 +17,7 @@ import {
 } from './common.zod';
 
 /**
- * Turso / libSQL Driver Protocol (#6345).
+ * Turso / libSQL Driver Protocol.
  *
  * ## Why this arrives late, and what it closes
  *

--- a/packages/spec/src/shared/retry-policy.zod.ts
+++ b/packages/spec/src/shared/retry-policy.zod.ts
@@ -3,9 +3,10 @@
 /**
  * @module shared/retry-policy
  *
- * The **single declaration** of the exponential-backoff retry policy (#4661,
- * the #4535 C8 dual-source cluster; completed for the anonymous inline blocks
- * by #4964 / #4962).
+ * The **single declaration** of the exponential-backoff retry policy.
+ *
+ * Converged in 17.0.0 in two passes: first the two same-named exports a
+ * dual-source scan could see, then the anonymous inline blocks it could not.
  *
  * Until 17 this shape existed twice — `automation/control-flow.zod.ts` (the
  * `try_catch` node's `retry` region) and `system/job.zod.ts` (`job.retryPolicy`)

--- a/packages/spec/src/system/translation.zod.ts
+++ b/packages/spec/src/system/translation.zod.ts
@@ -13,7 +13,7 @@ export const LocaleSchema = lazySchema(() => z.string().describe('BCP-47 Languag
 export type Locale = z.input<typeof LocaleSchema>;
 
 /**
- * Shared history sentence for every shape in this file (#4001).
+ * Shared history sentence for every shape in this file.
  *
  * Translation data has the most literal version of the silent-strip failure in
  * the whole spec: a misspelled group or key is dropped, the bundle saves or

--- a/packages/spec/src/ui/react-blocks.ts
+++ b/packages/spec/src/ui/react-blocks.ts
@@ -275,7 +275,7 @@ export const REACT_BLOCKS: ReactBlockDef[] = [
           replacedBy: 'data',
           note: "Write the metadata-tier data source instead: data={{ provider: 'object', object: '…' }} — the same spelling a metadata list view authors. objectName keeps working during the deprecation window.",
         },
-        description: "[DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling (#11284); this alias is removed after the deprecation window.",
+        description: "[DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling; this alias is removed after the deprecation window.",
       },
       {
         name: 'viewType',
@@ -285,7 +285,7 @@ export const REACT_BLOCKS: ReactBlockDef[] = [
           replacedBy: 'type',
           note: 'Write type="kanban" (ListViewSchema\'s own `type`, the metadata-tier view kind) instead. viewType keeps working during the deprecation window.',
         },
-        description: '[DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling (#11284): write `type`, the same key a metadata list view authors.',
+        description: '[DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling: write `type`, the same key a metadata list view authors.',
       },
       { name: 'filters', type: "FilterArray e.g. ['status','=','active']", kind: 'controlled', description: 'ObjectQL base filter; drive from React state for tabbed/searched lists. ([field, op, value]; ops =, !=, >, <, contains, in; compound: [\"and\", […], […]]).' },
       { name: 'navigation', type: "{ mode: 'page' | 'drawer' | 'modal' | 'split' | 'none' }", kind: 'binding', description: 'What a row click does. Use { mode: \"none\" } when you handle clicks via onRowClick.' },
@@ -344,7 +344,7 @@ export const REACT_BLOCKS: ReactBlockDef[] = [
   {
     tag: 'Block',
     schemaType: '(any)',
-    summary: 'Escape hatch — render any registered component by type. <Block type="object-kanban" objectName="task" /> etc. Not a way back to the record:* family: those need a record page\'s record context and are rejected here too (#4413).',
+    summary: 'Escape hatch — render any registered component by type. <Block type="object-kanban" objectName="task" /> etc. Not a way back to the record:* family: those need a record page\'s record context and are rejected here too.',
     interactions: [
       { name: 'type', type: 'string', kind: 'binding', required: true, description: 'The registered component type to render.' },
     ],

--- a/scripts/check-doc-authoring.mjs
+++ b/scripts/check-doc-authoring.mjs
@@ -263,17 +263,13 @@ const FENCE_CLOSE = /^```\s*$/;
 // guard: the exact failure this file's header opens with, one rule over.
 const PUBLISHED_SKILLS_ROOT = 'skills';
 
-// Generated artifacts under `skills/**`. Their ids are not authored here — they
-// are projected from `.describe()` / TSDoc in `packages/spec`, so the fix for
-// one is a spec-source edit plus a regeneration, on a surface with its own
-// gates. Flagging them here would red a file no author can legally hand-edit
-// ("do not edit" is in their own headers) and point the remedy at the wrong
-// repo layer. They are exempt from THIS rule, not absolved: the spec-side ids
-// are tracked separately.
-const GENERATED_SKILL_ARTIFACTS = [
-  /\/references\/_index\.md$/,
-  /\/references\/react-blocks\.md$/,
-];
+// There is deliberately NO exemption for the generated artifacts under
+// `skills/**` (`references/_index.md`, `references/react-blocks.md`). The first
+// cut carried one, because those files still held ids projected from TSDoc in
+// `packages/spec/src/**`. Those source lines are stripped now, and an exemption
+// over a surface that no longer needs one is where the next regeneration would
+// smuggle one back in. A red here is fixed AT THE SPEC SOURCE, never by hand-
+// editing the artifact — the failure text below prescribes exactly that.
 
 // There is deliberately NO per-passage allowlist here, and adding one is not a
 // remedy this gate offers.
@@ -429,11 +425,11 @@ function collectFiles() {
 }
 
 /**
- * Every hand-authored Markdown file in the PUBLISHED catalog.
+ * Every Markdown file in the PUBLISHED catalog — generated artifacts included.
  *
  * Its own walk, for the reason argued at {@link PUBLISHED_SKILLS_ROOT}: the
- * `collectFiles()` walk skips `references/`, where hand-authored companions
- * live. Generated artifacts are dropped by path.
+ * `collectFiles()` walk skips `references/`, where both the hand-authored
+ * companions and the generated `_index.md` files live.
  *
  * Empty is a hard error here for the same reason it is in `collectFiles`
  * (#4932): "the catalog is clean" and "the catalog was never opened" are the
@@ -460,9 +456,8 @@ function collectPublishedSkillFiles(root = PUBLISHED_SKILLS_ROOT) {
       else if (/\.mdx?$/.test(e)) files.push(posix(p));
     }
   })(root);
-  const kept = files.filter((p) => !GENERATED_SKILL_ARTIFACTS.some((re) => re.test(p)));
-  if (kept.length === 0) throw new EmptyRootError([root], 0);
-  return kept.sort();
+  if (files.length === 0) throw new EmptyRootError([root], 0);
+  return files.sort();
 }
 
 /** Bare internal issue-id references in one published file's source. */
@@ -663,9 +658,9 @@ function selfTest() {
       'skills/objectstack-demo/SKILL.md': 'The `cursor` key was removed in protocol 17.',
       'skills/objectstack-demo/references/data-hooks.md': 'Hooks fire per row.',
       'skills/objectstack-demo/rules/indexing.md': '`type` was retired.',
-      // Generated artifacts — exempt: their ids come from packages/spec TSDoc.
-      'skills/objectstack-demo/references/_index.md': 'Driver registry (#4410).',
-      'skills/objectstack-ui/references/react-blocks.md': 'Converging on the metadata tier (#11284).',
+      // Generated artifacts — IN scope and clean; their text comes from spec TSDoc.
+      'skills/objectstack-demo/references/_index.md': 'Driver registry.',
+      'skills/objectstack-ui/references/react-blocks.md': 'Converging on the metadata tier.',
       // The internal roots are NOT this rule's business.
       '.claude/agents/os-dev.md': 'Lesson learned while fixing #4286.',
       'docs/adr/0049-enforce-or-remove.md': 'Superseded by #5248.',
@@ -686,14 +681,14 @@ function selfTest() {
       // GREEN: the corpus as stripped.
       expect('a clean published corpus is green', scan().length, 0);
 
-      // Scope: the collector reaches references/, and drops the generated files.
+      // Scope: the collector reaches references/, generated artifacts included.
       const seen = collectPublishedSkillFiles();
       expect('the id scan reaches hand-authored references/ (the other rule\'s walk does not)',
         seen.includes('skills/objectstack-demo/references/data-hooks.md'), true);
-      expect('generated references/_index.md is exempt',
-        seen.includes('skills/objectstack-demo/references/_index.md'), false);
-      expect('the generated react-blocks contract page is exempt',
-        seen.includes('skills/objectstack-ui/references/react-blocks.md'), false);
+      expect('the generated references/_index.md is IN scope (no exemption)',
+        seen.includes('skills/objectstack-demo/references/_index.md'), true);
+      expect('the generated react-blocks contract page is IN scope (no exemption)',
+        seen.includes('skills/objectstack-ui/references/react-blocks.md'), true);
       expect('the id scan does not reach .claude/', seen.some((f) => f.startsWith('.claude/')), false);
       expect('the id scan does not reach docs/', seen.some((f) => f.startsWith('docs/')), false);
       expect('the id scan does not reach content/', seen.some((f) => f.startsWith('content/')), false);
@@ -705,6 +700,17 @@ function selfTest() {
       expect('a planted id in published prose is RED', red.length, 1);
       expect('the red names the file', red[0]?.file, 'skills/objectstack-demo/SKILL.md');
       expect('the red names the id', red[0]?.ids?.join(','), '#4286');
+
+      // ...and in a GENERATED artifact — listing the file proves collection,
+      // this proves it is SCANNED, which is what dropping the exemption bought.
+      const regen = join(idDir, 'skills', 'objectstack-demo', 'references', '_index.md');
+      writeFileSync(planted, 'The `cursor` key was removed in protocol 17.');
+      writeFileSync(regen, 'Driver registry (#4410).');
+      red = scan();
+      expect('an id a regeneration put back into a generated artifact is RED', red.length, 1);
+      expect('the red names the generated file', red[0]?.file, 'skills/objectstack-demo/references/_index.md');
+      writeFileSync(regen, 'Driver registry.');
+      writeFileSync(planted, 'The `cursor` key was removed in protocol 17 (#4286).');
 
       // ...and in a comment inside a code fence, which is where half the
       // measured population lived.
@@ -918,6 +924,10 @@ function main() {
       + `\nresolvable anchor where one exists — a protocol version, an ADR number, a lint rule id.`
       + `\n\nWriting a usage example that needs an issue number? Use the placeholder \`#<n>\`.`
       + `\nIt teaches the same syntax and is unmistakable to a customer reading it.`
+      + `\n\nFlagged file says "Auto-generated — do not edit"? Then the id is not authored there:`
+      + `\nit is projected from a \`.describe()\` / TSDoc string in \`packages/spec/src/**\`. Strip it`
+      + `\nAT THE SOURCE and regenerate (\`gen:skill-refs\`, \`gen:react-blocks\`, \`gen:docs\`) — the`
+      + `\nartifact is not exempt, because an exemption there is where the next one would land.`
       + `\n\nThere is no per-passage exemption to reach for, by design: this rule has none.`
       + `\n\nMaintainer ruling 2026-08-12, verbatim: 「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」\n`,
     );

--- a/skills/objectstack-automation/references/_index.md
+++ b/skills/objectstack-automation/references/_index.md
@@ -28,7 +28,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/shared/expression.zod.ts` — Expression Protocol
 - `node_modules/@objectstack/spec/src/shared/identifiers.zod.ts` — System Identifier Schema
 - `node_modules/@objectstack/spec/src/shared/protection.zod.ts` — Package-level metadata protection (ADR-0010 §3.7 — Phase 4.3)
-- `node_modules/@objectstack/spec/src/shared/retry-policy.zod.ts` — The **single declaration** of the exponential-backoff retry policy (#4661,
+- `node_modules/@objectstack/spec/src/shared/retry-policy.zod.ts` — The **single declaration** of the exponential-backoff retry policy.
 - `node_modules/@objectstack/spec/src/shared/suggestions.zod.ts` — "Did you mean?" Suggestion Utilities
 
 ## How to read these

--- a/skills/objectstack-data/references/_index.md
+++ b/skills/objectstack-data/references/_index.md
@@ -23,14 +23,14 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/automation/flow-function.zod.ts` — The contract for a **named handler function a `script` node invokes** —
 - `node_modules/@objectstack/spec/src/data/driver-sql.zod.ts` — SQL Dialect Enumeration
 - `node_modules/@objectstack/spec/src/data/driver.zod.ts` — Common Driver Options
-- `node_modules/@objectstack/spec/src/data/driver/common.zod.ts` — Shared building blocks for the per-driver `datasource.config` shapes (#4410).
-- `node_modules/@objectstack/spec/src/data/driver/config-registry.zod.ts` — The driver-id → `datasource.config` shape registry (#4410).
+- `node_modules/@objectstack/spec/src/data/driver/common.zod.ts` — Shared building blocks for the per-driver `datasource.config` shapes.
+- `node_modules/@objectstack/spec/src/data/driver/config-registry.zod.ts` — The driver-id → `datasource.config` shape registry.
 - `node_modules/@objectstack/spec/src/data/driver/memory.zod.ts` — Memory Driver Configuration Schema
 - `node_modules/@objectstack/spec/src/data/driver/mongo.zod.ts` — MongoDB Standard Driver Protocol
 - `node_modules/@objectstack/spec/src/data/driver/mysql.zod.ts` — MySQL / MariaDB driver configuration — the `config` slot of a `datasource`
 - `node_modules/@objectstack/spec/src/data/driver/postgres.zod.ts` — PostgreSQL driver configuration — the `config` slot of a `datasource` whose
 - `node_modules/@objectstack/spec/src/data/driver/sqlite.zod.ts` — SQLite driver configuration — the `config` slot of a `datasource` whose
-- `node_modules/@objectstack/spec/src/data/driver/turso.zod.ts` — Turso / libSQL Driver Protocol (#6345).
+- `node_modules/@objectstack/spec/src/data/driver/turso.zod.ts` — Turso / libSQL Driver Protocol.
 - `node_modules/@objectstack/spec/src/data/field-value.zod.ts` — Field runtime VALUE-shape contract (ADR-0104 D1).
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification
 - `node_modules/@objectstack/spec/src/data/hook-body.zod.ts` — Capability tokens a script body may request.

--- a/skills/objectstack-i18n/references/_index.md
+++ b/skills/objectstack-i18n/references/_index.md
@@ -9,7 +9,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 
 ## Core schemas
 
-- `node_modules/@objectstack/spec/src/system/translation.zod.ts` — Shared history sentence for every shape in this file (#4001).
+- `node_modules/@objectstack/spec/src/system/translation.zod.ts` — Shared history sentence for every shape in this file.
 - `node_modules/@objectstack/spec/src/ui/i18n.zod.ts` — Display-label and ARIA-label primitives shared by every `ui/` shape.
 
 ## Transitive dependencies

--- a/skills/objectstack-platform/references/_index.md
+++ b/skills/objectstack-platform/references/_index.md
@@ -22,14 +22,14 @@ from `node_modules` — there is no local copy in the skill bundle.
 ## Transitive dependencies
 
 - `node_modules/@objectstack/spec/src/api/errors.zod.ts` — Standardized Error Codes Protocol
-- `node_modules/@objectstack/spec/src/data/driver/common.zod.ts` — Shared building blocks for the per-driver `datasource.config` shapes (#4410).
-- `node_modules/@objectstack/spec/src/data/driver/config-registry.zod.ts` — The driver-id → `datasource.config` shape registry (#4410).
+- `node_modules/@objectstack/spec/src/data/driver/common.zod.ts` — Shared building blocks for the per-driver `datasource.config` shapes.
+- `node_modules/@objectstack/spec/src/data/driver/config-registry.zod.ts` — The driver-id → `datasource.config` shape registry.
 - `node_modules/@objectstack/spec/src/data/driver/memory.zod.ts` — Memory Driver Configuration Schema
 - `node_modules/@objectstack/spec/src/data/driver/mongo.zod.ts` — MongoDB Standard Driver Protocol
 - `node_modules/@objectstack/spec/src/data/driver/mysql.zod.ts` — MySQL / MariaDB driver configuration — the `config` slot of a `datasource`
 - `node_modules/@objectstack/spec/src/data/driver/postgres.zod.ts` — PostgreSQL driver configuration — the `config` slot of a `datasource` whose
 - `node_modules/@objectstack/spec/src/data/driver/sqlite.zod.ts` — SQLite driver configuration — the `config` slot of a `datasource` whose
-- `node_modules/@objectstack/spec/src/data/driver/turso.zod.ts` — Turso / libSQL Driver Protocol (#6345).
+- `node_modules/@objectstack/spec/src/data/driver/turso.zod.ts` — Turso / libSQL Driver Protocol.
 - `node_modules/@objectstack/spec/src/data/field-value.zod.ts` — Field runtime VALUE-shape contract (ADR-0104 D1).
 - `node_modules/@objectstack/spec/src/data/field.zod.ts` — Field Type Enum
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification

--- a/skills/objectstack-ui/contracts/react-blocks.contract.json
+++ b/skills/objectstack-ui/contracts/react-blocks.contract.json
@@ -261,7 +261,7 @@
           "type": "string",
           "kind": "binding",
           "required": true,
-          "description": "[DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling (#11284); this alias is removed after the deprecation window.",
+          "description": "[DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling; this alias is removed after the deprecation window.",
           "deprecated": {
             "replacedBy": "data",
             "note": "Write the metadata-tier data source instead: data={{ provider: 'object', object: '…' }} — the same spelling a metadata list view authors. objectName keeps working during the deprecation window."
@@ -272,7 +272,7 @@
           "type": "'grid' | 'kanban' | 'gallery' | 'calendar' | 'timeline' | 'gantt' | 'map'",
           "kind": "binding",
           "required": false,
-          "description": "[DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling (#11284): write `type`, the same key a metadata list view authors.",
+          "description": "[DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling: write `type`, the same key a metadata list view authors.",
           "deprecated": {
             "replacedBy": "type",
             "note": "Write type=\"kanban\" (ListViewSchema's own `type`, the metadata-tier view kind) instead. viewType keeps working during the deprecation window."
@@ -543,7 +543,7 @@
     {
       "tag": "Block",
       "schemaType": "(any)",
-      "summary": "Escape hatch — render any registered component by type. <Block type=\"object-kanban\" objectName=\"task\" /> etc. Not a way back to the record:* family: those need a record page's record context and are rejected here too (#4413).",
+      "summary": "Escape hatch — render any registered component by type. <Block type=\"object-kanban\" objectName=\"task\" /> etc. Not a way back to the record:* family: those need a record page's record context and are rejected here too.",
       "specSchema": false,
       "props": [
         {

--- a/skills/objectstack-ui/references/react-blocks.md
+++ b/skills/objectstack-ui/references/react-blocks.md
@@ -58,8 +58,8 @@ Server-connected object table with toolbar and switchable visualizations (grid/k
 
 | prop | type | kind | required | description |
 |------|------|------|:--------:|-------------|
-| `objectName` | `string` | binding | ✓ | [DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling (#11284); this alias is removed after the deprecation window. |
-| `viewType` | `'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map'` | binding |  | [DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling (#11284): write `type`, the same key a metadata list view authors. |
+| `objectName` | `string` | binding | ✓ | [DEPRECATED → `data={{ provider: 'object', object }}`] The object this block binds to (server-connected). Converging on the metadata-tier spelling; this alias is removed after the deprecation window. |
+| `viewType` | `'grid' \| 'kanban' \| 'gallery' \| 'calendar' \| 'timeline' \| 'gantt' \| 'map'` | binding |  | [DEPRECATED → `type`] Which visualization to render (default grid). Converging on the metadata-tier spelling: write `type`, the same key a metadata list view authors. |
 | `navigation` | `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none' }` | binding |  | What a row click does. Use { mode: "none" } when you handle clicks via onRowClick. |
 | `fields` | `string[]` | binding |  | Limit/order the columns shown (defaults to the object list fields). |
 | `options` | `Record<string, any>` | binding |  | View-type-specific options bag (kanban/calendar/gantt extras); prefer the typed spec props where they exist. |
@@ -106,7 +106,7 @@ Chart over an object’s aggregated data. Bind objectName + aggregate; the axes 
 
 ## `<Block>` — `(any)` *(no spec schema — overlay only)*
 
-Escape hatch — render any registered component by type. <Block type="object-kanban" objectName="task" /> etc. Not a way back to the record:* family: those need a record page's record context and are rejected here too (#4413).
+Escape hatch — render any registered component by type. <Block type="object-kanban" objectName="task" /> etc. Not a way back to the record:* family: those need a record page's record context and are rejected here too.
 
 | prop | type | kind | required | description |
 |------|------|------|:--------:|-------------|


### PR DESCRIPTION
Fixes #11930

Fourteen internal `#NNNN` references survived the 2026-08-23 strip of the published skill corpus. None of them was authored in `skills/**`: they are projected there from `.describe()` / TSDoc text in `packages/spec/src/**` by `gen:skill-refs` and `gen:react-blocks`, so the corpus-side cleanup could not reach them and a regeneration would have put them straight back. This is the source-layer half of that ruling, and the gate change that stops the round trip.

## Premise, re-verified on `origin/main`

Measured at `f7b25c5` before any edit: exactly **14** hits for `#[0-9]{3,5}` not followed by a word character, matching the filing's per-file counts exactly. Three further hits of a naive `#[0-9]{3,5}` scan are the CSS hex colours `#6366f1`, `#4169E1` and `#3498db` — the same false-positive family the id rule's lookahead was written to exclude.

The filing's guess at *which* source files these came from was partly wrong, and the artifacts were used as the acceptance set instead. The real sources, reverse-looked-up from each of the 14 sites:

| generated site | real source |
|---|---|
| `objectstack-{data,platform}/references/_index.md` — `#4410` ×4 | `data/driver/common.zod.ts`, `data/driver/config-registry.zod.ts` |
| `objectstack-{data,platform}/references/_index.md` — `#6345` ×2 | `data/driver/turso.zod.ts` |
| `objectstack-automation/references/_index.md` — `#4661` | `shared/retry-policy.zod.ts` |
| `objectstack-i18n/references/_index.md` — `#4001` | `system/translation.zod.ts` |
| `objectstack-ui/references/react-blocks.md` + `contracts/react-blocks.contract.json` — `#11284` ×4, `#4413` ×2 | `ui/react-blocks.ts` (the `ListView.objectName` / `ListView.viewType` deprecation notes and the `Block` tag summary) |

The `_index.md` summary is the **first line** of a file's first JSDoc block (`extractDescription` in `build-skill-references.ts`), which is why stripping one id from `shared/retry-policy.zod.ts` meant rewriting its opening sentence rather than deleting three characters: the citation ran across the line break and left a dangling `)` behind.

## What changed

Six source sites rewritten to say the same thing without the citation, keeping the teaching per the standing ruling of 2026-08-12, verbatim and untranslated: 「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」. Then `gen:skill-refs`, `gen:react-blocks` and `gen:docs` regenerated. Result: **0** internal issue-id references anywhere under `skills/**`.

Deeper TSDoc in the same files still carries internal ids — those lines project nowhere customer-facing, and widening to them is a different decision than the one this card inherits.

### The gate exemption is removed, not narrowed

`GENERATED_SKILL_ARTIFACTS` in `scripts/check-doc-authoring.mjs` exempted `references/_index.md` and `references/react-blocks.md` by path, for a stated reason that no longer holds: it existed because those files still carried projected ids, and reding a file whose own header says "do not edit" pointed the remedy at the wrong repo layer. With the sources clean the exemption guarded a clean surface — and that is precisely where the next regeneration would smuggle one back in, past the gate that exists to stop it.

So the exemption is deleted rather than narrowed, and the "wrong repo layer" objection is answered where it actually bites — in the failure text, which now tells an author who hits a red on an auto-generated file to strip the id **at the spec source** and regenerate, never to hand-edit the artifact.

Its self-test is rewritten rather than patched: the two cases that pinned *"the generated artifact is exempt"* asserted the behaviour being removed, so they now pin the artifacts as in scope, and a new case plants an id in a generated `_index.md` and asserts the scan reds on it and names that file. Listing a file only proves collection; the plant proves it is read.

This aligns with the gate PR #11931 landed. No second gate was added, and the spec-source-side ban the filing floats as step 3 is deliberately **not** implemented here — it would be a second gate over a different population, which is a decision this card does not carry.

## Line budgets (governed surface)

`skills/**` is loaded whole into customer context windows, so both readings are reported. Lines are the budget; tokens are `ceil(utf8 bytes / 4)`, the sibling ratchet's unit.

Every changed artifact, whole file:

| file | lines before → after | tokens before → after |
|---|---|---|
| `objectstack-automation/references/_index.md` | 44 → 44 | 763 → 761 |
| `objectstack-data/references/_index.md` | 65 → 65 | 1286 → 1280 |
| `objectstack-i18n/references/_index.md` | 35 → 35 | 493 → 491 |
| `objectstack-platform/references/_index.md` | 62 → 62 | 1233 → 1227 |
| `objectstack-ui/contracts/react-blocks.contract.json` | 559 → 559 | 5356 → 5350 |
| `objectstack-ui/references/react-blocks.md` | 117 → 117 | 3157 → 3150 |

Whole package — every `SKILL.md` in the published catalog: **10505 → 10505 lines (net 0)**, **117716 → 117716 tokens (net 0)**; no `SKILL.md` is touched. Whole `skills/` tree, every file: **17849 → 17849 lines (net 0)**, **187951 → 187922 tokens (net −29)**.

Against the dispatched budgets: `skills/**` net **0** lines (budget ≤ +0) · `packages/spec/src` net **+1** (budget ≤ +30) · `scripts/` net **+10** (budget ≤ +10). The `scripts/` figure needed a deliberate trim — the first draft of the comment and self-test came to +16, and it was compressed to fit rather than the budget being raised.

## Declared deviation — two source files outside the dispatched surface

The dispatched file surface named `packages/spec/src/{conversions,data,ui,automation,ai,api}`. Two of the six real sources are **not** in those directories:

- `packages/spec/src/shared/retry-policy.zod.ts`
- `packages/spec/src/system/translation.zod.ts`

The directory list was derived from the filing's source attribution, which the reverse look-up above disproves. The acceptance set is the 14 artifact sites, and leaving 2 of the 14 standing because a guess named the wrong directory would deliver a card that does not close. Both edits are the same defect class, the same mechanical rewrite, the same gate families, and no other in-flight claim holds either file (checked against the open-PR list). Recorded here rather than taken silently.

`content/docs/references/data/driver-common.mdx` and `driver-turso.mdx` also change — that is the same source edit reaching the docs site through `build-docs.ts`, and the full regen set was called for at dispatch.

### One consequence left deliberately untouched

`scripts/check-ratchet-remedy-authority.mjs` carries a `why` string for `check-doc-authoring.mjs` that names `GENERATED_SKILL_ARTIFACTS` among that file's declarations. This PR removes that constant. The gate stays green — it was run, and its verdict rests on the other declarations named there — but the prose will name a symbol that no longer exists once this lands. PR #12061 is in flight on exactly that file and is marked blocked pending a recorded verdict, so racing a one-clause edit into it here would be worse than leaving it. Tracked separately; the repair should ride whichever of the two PRs lands second.

## Verification

Full gate list re-derived from the real change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the script reads its own merge-base diff), which returned **44** families once the changeset existed — more than the 14 the dispatch named. All 44 run green at `d1a56ba`, together with the regeneration-freshness set (`check:skill-refs`, `check:react-blocks`, `check:docs`, `check:generated`, `check:skill-docs`, `check:authorable-surface`, `check:api-surface`), `check-doc-authoring --self-test`, `check-ratchet-remedy-authority`, `check-skills-token-ratchet`, `check:nul-bytes`, and `@objectstack/spec` `typecheck`.

`packages/spec`'s own suite: `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2` → `Test Files  425 passed (425)` / `Tests  11321 passed (11321)`.

Two gates first refused with `PREREQUISITE NOT MET — the workspace package is not built` and were re-run green after `pnpm --filter '@objectstack/lint...' build`; their own text says "Nothing was measured", so the first result was not a finding.

`check:react-declaration-parity` refuses with `MANIFEST is not set` — it needs an objectui manifest dump and a browser, is not in the derived family list for this card, and exits before reading the diff. `check-dev-prereqs.mjs` reports 66 of 67 workspace packages unbuilt: it measures the container's build state, and this diff adds no package, edits no `package.json` and produces no build output, so it cannot move that verdict either way.

Repo-wide `pnpm lint` was **not** run; CI owns that farm run.

## Filed out of scope

- #12094 — `build-skill-references.ts` still selects the **first JSDoc block anywhere in the file** as a file's published description, the ordering defect `build-docs.ts` already fixed by moving to `findModuleDocBlock()`. Live victim: `system/translation.zod.ts`, whose skill-reference entry describes a private `TRANSLATION_HISTORY` constant rather than the Translation protocol. Found here because that entry is one of the 14 sites; stripping its id does not make the sentence correct, only id-free.
- #12095 — the stale `GENERATED_SKILL_ARTIFACTS` mention described above.

---

_Generated by [Claude Code](https://claude.ai/code/session_01NDGG54XF5gbTLdQzCtnaVV)_
