### PR TITLE
fix(devx): lower plugin-approvals TEST_DEBT surplus, repoint dead #6376 advisory

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -233,9 +233,12 @@
 //               instead is make closing one FREE -- `--lower` writes the
 //               measured numbers back into the ledger, so flattening an entry
 //               never requires a human to type a measured number. Whether the
-//               surplus should additionally be enforced is #6376's open
-//               question, not this paragraph's, and the cost of guessing it is
-//               argued there.
+//               surplus should additionally be enforced WAS #6376's open
+//               question; #6376 closed (PR #6510) deciding NOT to -- report
+//               and offer `--lower`, never fail on a surplus by itself -- and
+//               that decision is this paragraph's ruling above, not a pointer
+//               to an issue that is now closed with nothing left to read there
+//               (#11497).
 //
 //               What drifts is not only the NUMBER but the note's COMPOSITION:
 //               service-automation's note named `engine.test.ts:2547/2577` as
@@ -754,9 +757,12 @@ const EXEMPT = {
 // import a test file gains.
 const TEST_DEBT = {
   '@objectstack/plugin-approvals': {
-    errors: 348,
-    note: 'TS2339 x296, TS2550 x20, TS2345 x16, TS18048 x10, plus 6 singletons (TS2554 x2, TS1470, '
-      + 'TS2352, TS2353, TS6133). Was 547 (re-measured at 5ab08428, up from 467; TS2345 x213 then). '
+    errors: 347,
+    note: 'TS2339 x296, TS2550 x20, TS2345 x16, TS18048 x10, plus 5 singletons (TS2554 x2, TS1470, '
+      + 'TS2352, TS6133). Lowered 348 -> 347 at 0e0bf8049 (#11497): tsc against that tree reports the '
+      + 'same seven codes at the same counts as the prior 348 composition, TO THE UNIT, minus the sole '
+      + 'TS2353 -- a fully attributable single-error retirement, not a rescale. '
+      + 'Was 547 (re-measured at 5ab08428, up from 467; TS2345 x213 then). '
       + 'Lowered 547 -> 348 at b5e09b21 (#7888), and the -199 is ONE CLASS COLLAPSING rather than a '
       + 'measured surface shrinking -- the distinction the surplus finding asked to be settled before a '
       + 'gap this size was written in as a floor. Three readings say collapse: (a) TS2339 x296, TS2550 '
@@ -5183,13 +5189,23 @@ if (process.argv.includes('--re-measure')) {
       `in ${elapsed}s, ${measuredTotal} raw tsc error(s) total, none above its recorded number.`,
   );
   // Printed on a GREEN run, on purpose. This is the one number the old summary
-  // could not have told you: how much silence the ledger is currently buying
-  // (#6376). Zero is the goal and `--lower` is one command away from it.
+  // could not have told you: how much silence the ledger is currently buying.
+  // Zero is the goal and `--lower` is one command away from it.
+  //
+  // No issue number belongs in this line. It named #6376 until #11497: #6376
+  // was the design discussion that PRODUCED this very mechanism (the surplus
+  // print plus `--lower`, shipped by PR #6510) and closed once that landed --
+  // it was never a standing tracker for individual surpluses, and treating it
+  // as one routed readers to a closed issue with nothing left to do there
+  // (#11497 measured this happening: a dev read the advisory, followed it to
+  // #6376, and filed nothing). There is no successor tracking issue and none
+  // is needed -- the mechanism IS the successor: a surplus this line reports
+  // is closed by running `--lower`, not by reading a card.
   console.log(
     surplusEntries === 0
       ? `  surplus: none — every entry sits exactly at its measurement, so any new error is red.`
       : `  surplus: ${surplus} raw error(s) across ${surplusEntries} entr(ies) sit BELOW their recorded ` +
         `ceiling — that many regressions can land in layers no other gate reads without this one saying ` +
-        `anything (${SURPLUS_ISSUE}). Close it with \`pnpm check:type-check-debt --lower\`.`,
+        `anything. Close it with \`pnpm check:type-check-debt --lower\`.`,
   );
 }


### PR DESCRIPTION
Fixes #11497

## What this does

Re-measured `check:type-check-debt --re-measure` on `origin/main` = `0e0bf8049` (workspace closure built first, exactly as `lint.yml` does: `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 tasks, ~5m34s).

**Measured values — both re-derived, not taken from the card:**

| entry | card said | measured here | verdict |
|---|---:|---:|---|
| `@objectstack/plugin-approvals` | 348 → 347 | **347** | surplus confirmed — lowered |
| `@objectstack/runtime` | 227 → 226 | **227** (== recorded) | **surplus gone — premise-false, left alone** |

`plugin-approvals` corroborates both the card's own measurement and the independent one from #11525 this morning. `runtime` does **not** — the re-measure (run twice, before and after `--lower`, both at `227`) shows no surplus at all: whatever produced the −1 three days ago is no longer present, so that row of the card is premise-false. Nothing was touched on that entry.

**`plugin-auth` was correctly left alone**, per the card's own scope exclusion and the claim comment's confirmation that its −12 is already resolved (`main` records 97, note reads "RE-TALLIED from tsc at the 97 below (#10615)").

## The lowering, and the note re-tally

`--lower` wrote `errors: 348 → 347` for `plugin-approvals`. Its note uses a `TSxxxx xN`-style composition (not the `code-tier`/`config-tier`/`noise` phrasing `compositionAt` reconciliation reads), so the tool correctly did not attach a `compositionAt` field — and the note was re-tallied by hand instead, per the card's clause 4. I reproduced the exact 347-error tsc run standalone (same generated `tsconfig.debt-remeasure.json` shape `remeasureProject` builds) and diffed error-code counts against the recorded 348 composition: all seven other codes are unchanged **to the unit** (TS2339 x296, TS2550 x20, TS2345 x16, TS18048 x10, TS2554 x2, TS1470 x1, TS2352 x1, TS6133 x1); the sole `TS2353` singleton is gone. That is a fully attributable single-error retirement, not a rescale, and the note now says so.

## The advisory line

The gate's `--re-measure` summary printed `(${SURPLUS_ISSUE})` — i.e. #6376 — on every surplus report, and #6376 is `closed`/`completed` (2026-08-08, PR #6510). Read #6376 itself: it was the **design discussion that produced this exact mechanism** (the surplus print + `--lower`), not a standing tracker meant to stay open for future instances — and per the claim comment, a dev on #11525 already followed that link to a dead end and filed nothing.

There is no live successor issue to repoint it to (checked the open `tooling`-labeled backlog — nothing else serves as a "class tracker" for ratchet surplus), and none is needed: the mechanism itself is the remedy — a surplus this line reports is closed by running `--lower`, not by reading a card. So the fix drops the dead issue reference from the printed advisory and explains why in an adjacent comment, and fixes the one design-rationale comment nearby that still called the enforcement question "#6376's open question" (it isn't open — #6376 closed having decided *not* to enforce, report + `--lower` only).

## Gates run (this repo, `dispatch-gates.mjs --repo objectstack-ai/objectstack` at this branch's head)

9 families derived, all green at the final commit (`6c80b8256`):
`check:agent-test-spelling` · `check:cross-package-test-inputs` · `check:entry-guard` · `check:parse-guard` · `check:pnpm-filter-targets` · `check:type-check-coverage` (self-test + structural) · `check:type-check-debt` (self-test + `--re-measure`, surplus: none) · `check-ci-filter-parity.mjs` · `check-cross-package-test-inputs.mjs`. Also ran `check:nul-bytes` (any edit) and the gate's own `--self-test` (47+65+29+28+19 cases, all hold).

**Bare-root obligation**: not applicable — this PR edits ledger data and prose inside an existing gate, assembling no new scan root.

**Changeset**: `skip-changeset` — root is `scripts/`, nothing published changes. The additive labels REST endpoint was unreachable from this session (proxy declined direct `api.github.com` calls), so the label was applied via the documented fallback instead: read current labels (`size/s`), union with `skip-changeset`, whole-set write, then read back — confirmed present (`size/s`, `skip-changeset`) as of this PR body's last edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_
