### PR TITLE
fix(devx): reject an interpolating template literal in check-cross-package-test-inputs' NEW_URL_LITERAL

### DIFF
--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -579,6 +579,27 @@ function readablePathLiteral(arg) {
 }
 
 /**
+ * `NEW_URL_LITERAL` has the identical character-class shape as `PATH_LITERAL`
+ * above, and the identical blind spot: a BACKTICK-delimited argument holding no
+ * quotes matches it even when it is an interpolating template, so
+ * `` new URL(`${someVar}`, import.meta.url) `` would read `${someVar}` as the
+ * literal segment text and walk it as one ordinary descent (#12085). Unlike
+ * `readablePathLiteral()`'s call site, this one has no "cannot read, keep
+ * depth" fallback to route into — `pathExpression()` just returns `undefined`
+ * for the whole `new URL(...)` seed when this returns `null`, the same outcome
+ * as any other unrecognised seed shape. A single- or double-quoted literal is
+ * unaffected — `${` inside one of those is ordinary text, never interpolation.
+ * This is the ONE call site `NEW_URL_LITERAL` has in this file, so narrowing it
+ * here does not move any other consumer's verdict.
+ */
+function readableNewUrlLiteral(expr) {
+  const lit = expr.match(NEW_URL_LITERAL);
+  if (!lit) return null;
+  if (lit[1] === '`' && lit[2].includes('${')) return null;
+  return lit;
+}
+
+/**
  * A formatter's TRAILING COMMA, dropped from an argument list before it is read.
  *
  * The other half of the line-spanning spelling (#11093), and the half that would
@@ -659,7 +680,7 @@ function pathExpression(expr, hereDepth, known, fileSegs = null) {
   // seeds above. This is the ASCENT-RELATIVE spelling of #9763: one string, but
   // it starts at `..`, so the flat literal regex below never saw it while the
   // walk here has always resolved it — the name was thrown away, not the path.
-  const url = expr.match(NEW_URL_LITERAL);
+  const url = readableNewUrlLiteral(expr);
   if (url) return walkLiteral(hereDepth, url[2], dirSegs);
 
   if (/^[A-Za-z_$][\w$]*$/.test(expr)) return known.get(expr);
@@ -1989,6 +2010,40 @@ function selfTest() {
     (() => {
       const src = TEMPLATE_SEED + "const P = join(HERE, `../../other-pkg/src/y.ts`);";
       return at(src, 1) && named(src, 1, CO).includes('packages/other-pkg/src/y.ts');
+    })(),
+  );
+  // ── the INTERPOLATING TEMPLATE argument, `NEW_URL_LITERAL` sibling (#12085) ─
+  //
+  // `NEW_URL_LITERAL` has the identical character-class shape as `PATH_LITERAL`
+  // above and the identical blind spot — `` new URL(`${someVar}`, import.meta.url) ``
+  // reads `${someVar}` as the literal segment text and walks it as one ordinary
+  // descent. But this call site has no "cannot read, keep depth" fallback to
+  // fall into: `readableNewUrlLiteral()` rejecting the argument makes
+  // `pathExpression()` return `undefined` for the WHOLE `new URL(...)` seed —
+  // the same outcome as any other unrecognised seed shape, NOT the depth-kept
+  // outcome `PATH_LITERAL`'s pair above pins. So this case must assert
+  // "does not flag, no name" rather than "flags at the unreadable depth".
+  const URL_TEMPLATE_INTERP = 'const P = new URL(`../../other-pkg/${someVar}`, import.meta.url);';
+  ok(
+    "(control) the same climb spelled with a real segment instead of interpolation still flags and is named — proves the case above isn't vacuous",
+    (() => {
+      const src = 'const P = new URL(`../../other-pkg/src/y.ts`, import.meta.url);';
+      return at(src, 1) && named(src, 1, CO).includes('packages/other-pkg/src/y.ts');
+    })(),
+  );
+  ok(
+    'an interpolating new URL() template does NOT flag — the whole seed is unrecognised, not depth-kept (#12085)',
+    !at(URL_TEMPLATE_INTERP, 1),
+  );
+  ok(
+    'and — like any unrecognised seed — yields no name at all (never a fabricated NAME)',
+    named(URL_TEMPLATE_INTERP, 1, CO).length === 0,
+  );
+  ok(
+    'a quoted (non-backtick) new URL() literal containing literal `${` text is unaffected — `${` outside a backtick is ordinary text, never interpolation',
+    (() => {
+      const src = "const P = new URL('../../other-pkg/${literalText}', import.meta.url);";
+      return at(src, 1) && named(src, 1, CO).includes('packages/other-pkg/${literalText}');
     })(),
   );
   ok(


### PR DESCRIPTION
Fixes #12085

## What

`NEW_URL_LITERAL`'s character class in `scripts/check-cross-package-test-inputs.mjs` is
byte-identical to `PATH_LITERAL`'s (fixed for `PATH_LITERAL` in #12087) and shares the
same blind spot: a backtick-delimited argument holding no quotes matches it even when it
is an interpolating template, so `` new URL(`${someVar}`, import.meta.url) `` reads
`${someVar}` as the literal segment text and `walkLiteral()` counts it as one ordinary
descent — biasing the depth walk upward and, when the climb lands outside the package,
adding a fabricated NAME to the roster.

## Why this is not a copy of #12087

At `PATH_LITERAL`'s call site an unreadable argument falls into an explicit "cannot read,
keep depth" branch (inside `pathExpression()`'s `resolve`/`join` argument loop).
`NEW_URL_LITERAL` has no such branch — it is matched directly inside `pathExpression()`,
with nothing wrapping it. So the fix (`readableNewUrlLiteral()`, mirroring
`readablePathLiteral()`'s shape but scoped to this call site, not sharing it) makes an
interpolating match return `null`, which falls through to `pathExpression()`'s existing
"no spelling matched" path and returns `undefined` for the **whole `new URL(...)` seed**
— the same outcome as any other unrecognised seed shape ("does NOT flag a read argument
that is an unrecognised expression"), not a depth-kept one. The added self-test cases pin
that outcome explicitly (`does NOT flag` / `no name`), rather than reusing #12087's
depth-kept assertion, which would have proven the wrong thing.

A single- or double-quoted literal is unaffected — `${` inside one of those is ordinary
text, never interpolation — pinned by its own control case.

## Zone 2 measurements

- **Premise re-verified on merged `main`** (`a933ed720`, after #12087 landed):
  `NEW_URL_LITERAL`'s character class is byte-unchanged and its call site (line 662-663 on
  that commit) still hands `url[2]` straight to `walkLiteral()` with no readability
  branch. #12087's `readablePathLiteral()` is deliberately scoped to `PATH_LITERAL`'s one
  call site (its own docblock says so) — the class was not generalized. Premise holds
  exactly as filed.
- **Scoping shape vs #12087**: followed the same choice #12087 made — wrap the call site
  (`readableNewUrlLiteral()`) rather than mutate the shared `NEW_URL_LITERAL` constant, so
  the constant's meaning stays intact for any future consumer. `NEW_URL_LITERAL` has
  exactly one call site in this file, same as `PATH_LITERAL`, so the reasoning transfers
  directly.
- **`statSync(...).isFile()` filter (Zone 2.3), measured, not assumed**: using a temporary
  local `export` on `scanPathExpressions()` (reverted before committing), a fixture that
  climbs out of its package via an interpolating `new URL()` seed (`` new URL(`../../other-pkg/${someVar}`, import.meta.url) ``)
  does push a fabricated NAME onto the roster pre-fix
  (`packages/other-pkg/${someVar}`) and the walk escapes (`min: -1`). Directly probing
  `findEscapingPackages()`'s filter — `statSync(join(REPO_ROOT, lit)).isFile()` — on that
  exact fabricated literal throws `ENOENT`, so `real = false` and the entry is dropped.
  **Same safety net #11487's Zone 2.3 found for `PATH_LITERAL`.** Today's blast radius was
  therefore smaller than the card's open question implied — this fix closes the gap at the
  source regardless of the downstream net.

## Bare-root / changeset

- **Bare-root worklist**: not applicable — this narrows a regex/wrapper inside an existing
  gate, no new scan-root literal introduced (confirmed by diffing for any new
  `const X = '<bare-word>'`-shaped population constant; none). `bare-root-worklist.mjs
  --self-test`: `none stale, none missing` (unaffected by this change).
- **Changeset**: `skip-changeset` — one gate script under `scripts/`, nothing published.
  Label applied via the additive labels endpoint per repo convention; read back below.

## Tests

Gates derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(re-run against the final commit) — all matched families green, run through
`scripts/pm/os-verify-lock.sh`, verdict lines quoted:

- `pnpm check:cross-package-test-inputs` (this gate's own `--self-test` **and** production
  leg, per the dispatch instruction to run both): `All 117 self-test cases passed.` /
  `OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every
  declared glob.` — `os-verify-lock: VERDICT command-exit 0`
- `pnpm check:agent-test-spelling`: `check-agent-test-spelling: 0 violations` —
  `command-exit 0`
- `pnpm check:entry-guard`: `check:entry-guard: 160 scripts/ file(s) — every entry guard
  goes through invoked-as.mjs` — `command-exit 0`
- `pnpm check:parse-guard`: `check:parse-guard: 159 scripts/ file(s) — every TypeScript
  parse goes through ts-parse.mjs.` — `command-exit 0`
- `pnpm check:pnpm-filter-targets`: `135/170 --filter occurrence(s) ... resolve against 78
  workspace package(s)` — `command-exit 0`
- `node scripts/check-ci-filter-parity.mjs`: `OK: all 96 declared cross-package glob(s)
  (81 unique) are covered by core or crosspkg` — `command-exit 0`

All six re-run as one union after the final commit, on head `269c461e3`:
`os-verify-lock: VERDICT command-exit 0`.

**Ablation** (proves the two new self-test cases actually discriminate): reverted only the
call-site wrapper (`readableNewUrlLiteral(expr)` → `expr.match(NEW_URL_LITERAL)`), keeping
the new test cases — confirmed the edit landed on disk via `git diff`, then re-ran
`--self-test`: exactly the two new cases (`an interpolating new URL() template does NOT
flag...` and `and — like any unrecognised seed — yields no name at all...`) went red,
`2/117 self-test case(s) failed`, all others stayed green. Restored the wrapper via the
same `Edit`, re-ran: `All 117 self-test cases passed.`

`node scripts/check-nul-bytes.mjs`: `OK (scanned 6719 text file(s) ... no raw ASCII
control bytes)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_