### PR TITLE
fix(docs-audit): measure the bridge cause split on the advisory path and render it in the drift comment

### DIFF
--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -259,7 +259,47 @@ jobs:
             if (crossCutting.length) limits.push(`**${crossCutting.length}** cross-cutting symbol(s) contributed no route anchor: \`${crossCutting.join('`, `')}\``);
             if (overbroad.length) limits.push(`**${overbroad.length}** anchor(s) matched too much of the corpus to be a work list: \`${overbroad.join('`, `')}\``);
             if (weak.length) limits.push(`**${weak.length}** name(s) were too generic to anchor anything (single lowercase words)`);
-            if (bridge && bridge.measured && bridge.unreachable > 0) limits.push(`the SDK route bridge reached **${bridge.reachable}** of **${bridge.clientRows}** client-bound route-ledger rows — the other **${bridge.unreachable}** have no registrar \`path:\` tail to select them, so pages documenting THEIR client methods cannot appear above, on this or any run: \`node scripts/docs-audit/affected-docs.mjs --bridge-coverage\``);
+            // ── WHY THOSE ROWS ARE UNREACHABLE, NOT JUST HOW MANY (#11867) ────────
+            //
+            // The line above used to end at the count, and a count is one population.
+            // The census says there are three, and the difference is the whole reason
+            // the split exists: the auth ledger's `56 of 56` and the rest ledger's
+            // `46 of 87` print identically and are NOT the same finding — the first has
+            // no in-repo registration site at all, so the discovery widening the second
+            // one wants moves it by zero rows. That conflation already aimed one card
+            // (#11178) at widening a recognizer that was never the constraint, and this
+            // comment is the surface where a human meets the number.
+            //
+            // ⛔ SAME NAMES, ONE DERIVATION — the rule stated three lines up for the
+            // `anchorless` pair, and it binds here for the same reason. `bridge.causes`
+            // is a PARTITION of `bridge.unreachable`, computed ONCE inside
+            // `bridgeCoverageFrom` and published whole; the parts are READ off the same
+            // object as the total and never recomputed here. Re-deriving them from
+            // `bridge.ledgers` would be a second derivation that agrees today, drifts
+            // silently tomorrow, and renders a breakdown that sums to something the
+            // headline beside it denies.
+            //
+            // And on numbers that do NOT partition that total, the split is WITHHELD and
+            // the run says the census is broken, rather than printing three figures
+            // beside a fourth they contradict. That state cannot arise from
+            // `bridgeCoverageFrom` — `affected-docs.mjs --self-test` pins the partition
+            // — which is what makes it a verdict here and not a fallback.
+            //
+            // `measured: false` keeps its honest arm: a run that supplied no ceiling
+            // reports that WHY was not measured. It says so in words rather than
+            // rendering three nulls or, worse, three zeroes — "nobody looked" is not
+            // "none found", the same distinction `computedOn.dirty`'s null arm draws.
+            const causes = (bridge && bridge.causes) || null;
+            let bridgeCauses = '';
+            if (causes && causes.measured === true) {
+              const parts = causes.remediable + causes.structural + causes.undecided;
+              bridgeCauses = parts === bridge.unreachable
+                ? ` Of those **${bridge.unreachable}**: **${causes.remediable}** are remediable by widening that discovery convention (an in-repo file declares the path; the convention did not scan it); **${causes.structural}** are structural — on a ledger where NOT ONE row is declared in-repo, so no discovery change reaches them at any price; **${causes.undecided}** are undecided (no in-repo declaration, on a ledger that has other in-repo registrars — absence and an unreadable spelling are not distinguishable here).`
+                : ` ⛔ Its cause census is BROKEN — **${causes.remediable}** + **${causes.structural}** + **${causes.undecided}** is not the **${bridge.unreachable}** it claims to break down, so the split is withheld.`;
+            } else if (causes && causes.measured === false) {
+              bridgeCauses = ` WHY those rows are unreachable was NOT measured on this run — ${causes.reason} — so no cause may be read into the count above.`;
+            }
+            if (bridge && bridge.measured && bridge.unreachable > 0) limits.push(`the SDK route bridge reached **${bridge.reachable}** of **${bridge.clientRows}** client-bound route-ledger rows — the other **${bridge.unreachable}** have no registrar \`path:\` tail to select them, so pages documenting THEIR client methods cannot appear above, on this or any run.${bridgeCauses} The rows themselves: \`node scripts/docs-audit/affected-docs.mjs --bridge-coverage\``);
             // ── THE RULE-CARRYING PAGE AN EMITTER DIFF CANNOT REACH (#11434) ──────
             //
             // Every line above is a REPORT about this run: a count this run produced, a

--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -297,7 +297,7 @@ jobs:
                 ? ` Of those **${bridge.unreachable}**: **${causes.remediable}** are remediable by widening that discovery convention (an in-repo file declares the path; the convention did not scan it); **${causes.structural}** are structural — on a ledger where NOT ONE row is declared in-repo, so no discovery change reaches them at any price; **${causes.undecided}** are undecided (no in-repo declaration, on a ledger that has other in-repo registrars — absence and an unreadable spelling are not distinguishable here).`
                 : ` ⛔ Its cause census is BROKEN — **${causes.remediable}** + **${causes.structural}** + **${causes.undecided}** is not the **${bridge.unreachable}** it claims to break down, so the split is withheld.`;
             } else if (causes && causes.measured === false) {
-              bridgeCauses = ` WHY those rows are unreachable was NOT measured on this run — ${causes.reason} — so no cause may be read into the count above.`;
+              bridgeCauses = ` ⚠️ Cause NOT measured on this run: ${causes.reason}. No cause may be read into the count above — "nobody looked" is not "none found".`;
             }
             if (bridge && bridge.measured && bridge.unreachable > 0) limits.push(`the SDK route bridge reached **${bridge.reachable}** of **${bridge.clientRows}** client-bound route-ledger rows — the other **${bridge.unreachable}** have no registrar \`path:\` tail to select them, so pages documenting THEIR client methods cannot appear above, on this or any run.${bridgeCauses} The rows themselves: \`node scripts/docs-audit/affected-docs.mjs --bridge-coverage\``);
             // ── THE RULE-CARRYING PAGE AN EMITTER DIFF CANNOT REACH (#11434) ──────

--- a/scripts/docs-audit/affected-docs.mjs
+++ b/scripts/docs-audit/affected-docs.mjs
@@ -524,13 +524,10 @@ if (args.includes('--self-test')) {
 if (args.includes('--bridge-coverage')) {
   const { registrarFiles, sourceFiles, ledgers, registrarByTail } = scanRouteSurface();
   // THE CEILING (#11178) — read lazily off the walk this scan already did, so the census
-  // holds one file's source at a time rather than the tree's. Only this mode pays for it:
-  // the advisory path calls `bridgeCoverageFrom` with no ceiling and gets `unmeasured`.
-  const ceiling = maximalTailsFrom((function* () {
-    for (const rel of sourceFiles) {
-      try { yield { file: rel, text: readFileSync(join(repoRoot, rel), 'utf8') }; } catch { /* unreadable file contributes no tail */ }
-    }
-  })());
+  // holds one file's source at a time rather than the tree's. Since #11867 the PHASE 2
+  // advisory run pays for it too, through this same `ceilingTailsFrom` — one derivation,
+  // so the two paths cannot report the same three buckets from two populations.
+  const ceiling = ceilingTailsFrom(sourceFiles);
   const coverage = bridgeCoverageFrom(ledgers, registrarByTail.keys(), ceiling.keys());
   const selects = selectsFrom(registrarByTail.keys());
   const causeOf = new Map(coverage.ledgers.map((l) => [l.file, l.cause]));
@@ -1190,6 +1187,26 @@ function parseRegistrarSource(text) {
  * @returns {Map<string, string[]>} tail ⟶ the files that declare it, so a "discovery could
  *   reach this" claim can always NAME the witness rather than asserting one exists.
  */
+/**
+ * The CEILING, built off a walk's `sourceFiles` — ONE derivation, both callers (#11867).
+ *
+ * ⛔ Never inline this at a call site. `--bridge-coverage` and the PHASE 2 advisory run
+ * both measure causes now, and a census the two paths build differently would report the
+ * same three buckets from two populations — the exact class of defect the cause split was
+ * introduced to end, one level up. Read LAZILY, one file's source at a time, so neither
+ * caller holds the tree in memory.
+ *
+ * @param {Iterable<string>} sourceFiles  repo-relative paths, as `walkSourceFiles` yields them
+ * @returns {Map<string, string[]>} exactly what `maximalTailsFrom` returns
+ */
+function ceilingTailsFrom(sourceFiles) {
+  return maximalTailsFrom((function* () {
+    for (const rel of sourceFiles) {
+      try { yield { file: rel, text: readFileSync(join(repoRoot, rel), 'utf8') }; } catch { /* unreadable file contributes no tail */ }
+    }
+  })());
+}
+
 function maximalTailsFrom(sources) {
   const byTail = new Map();
   for (const { file, text } of sources) {
@@ -4161,6 +4178,48 @@ function selfTest() {
   })();
   check('emit', 'the drift comment RENDERS `bridgeCoverage` — an unrendered key is half-wired (#9433)', 'docs-drift-check.yml',
     true, driftWorkflow === null || /data\.bridgeCoverage/.test(driftWorkflow));
+  // ── `causes` GETS THE SAME TREATMENT, AT BOTH ENDS (#11867) ─────────────────
+  //
+  // #9433's rule is about a KEY, not about this one key, so the sub-object that carries
+  // the three-way cause split is pinned exactly the way `bridgeCoverage` above is — and
+  // this time BOTH halves were separately broken. The advisory path published `causes`
+  // for two cards while omitting the ceiling that populates it, so every ledger read
+  // `unmeasured` and the three counts were `null`; and the workflow had no render branch
+  // at all (measured: zero occurrences of `causes` in that file). Either half alone is
+  // the half-wired state — a ceiling nobody renders is cost paid for no reader, and a
+  // render branch with no ceiling prints `unmeasured` in a nicer shape.
+  check('emit', 'the ADVISORY path measures causes — it passes a ceiling, not just tails', 'affected-docs.mjs',
+    true, /bridgeCoverageFrom\(ledgers, registrarByTail\.keys\(\), ceilingTailsFrom\(sourceFiles\)\.keys\(\)\)/.test(ownSource));
+  // ⚠️ READ THE CODE, NOT THE COMMENT THAT FORBIDS IT. These three pins are about what
+  // the renderer DOES, and the block it lives in names `bridge.ledgers` in prose precisely
+  // to forbid deriving from it — so a raw-text negative pin fails on its own rationale
+  // (measured: it did, first run). Full-line `//` comments are dropped first; trailing
+  // ones are left alone rather than risk eating a `//` inside a string.
+  const driftWorkflowCode = driftWorkflow === null ? null
+    : driftWorkflow.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+  check('emit', 'the drift comment RENDERS `causes` — an unrendered key is half-wired (#9433)', 'docs-drift-check.yml',
+    true, driftWorkflowCode === null || /bridge\.causes/.test(driftWorkflowCode));
+  // AND THE BREAKDOWN MAY NOT BE ABLE TO DISAGREE WITH THE HEADLINE. The workflow's own
+  // rule at that spot — "Same names, one derivation" — is what this pins: the renderer
+  // reads the three counts off `bridge.causes` and the total off `bridge.unreachable`,
+  // and refuses to print the split unless they partition. A renderer that recomputed the
+  // parts from `bridge.ledgers` would satisfy the grep above while reintroducing exactly
+  // the drift the partition exists to make visible.
+  check('emit', 'the rendered split is GUARDED by the partition it claims to be', 'docs-drift-check.yml',
+    true, driftWorkflowCode === null || /parts === bridge\.unreachable/.test(driftWorkflowCode));
+  check('emit', 'and the renderer derives no cause count of its own from the ledger list', 'docs-drift-check.yml',
+    true, driftWorkflowCode === null || !/bridge\.ledgers/.test(driftWorkflowCode));
+  // WRITTEN ONCE, pinned at the source (#11494's rule, applied to the census). Two paths
+  // now publish these three buckets; two spellings of the population they are computed
+  // over is how two surfaces start disagreeing about one repo. `ceilingTailsFrom` is the
+  // single builder, and an inline second copy is what this catches — every behavioural
+  // fixture above would stay green while the two arms drifted apart.
+  check('emit', 'the ceiling is built in exactly ONE place', 'affected-docs.mjs',
+    1, (ownSource.match(/return maximalTailsFrom\(\(function\* \(\) \{/g) || []).length);
+  // CALL SITES, which is why the lookbehind: the declaration shares the spelling, and
+  // counting it would let one arm drop its call while the total stayed put.
+  check('emit', 'and both arms that measure causes build it through that one place', 'affected-docs.mjs',
+    2, (ownSource.match(/(?<!function )ceilingTailsFrom\(/g) || []).length);
   // `unreachableRows` is the detail of `unreachable`, and the only way it can contradict
   // that count is by deriving selection a second time. Pinned at the source, because the
   // two agreeing today is what a re-statement costs nothing to break tomorrow.
@@ -4471,8 +4530,29 @@ const crossCuttingSymbols = [];
 // same rule), and a fabricated `0 of 0` here would read as "nothing to reach".
 let bridgeCoverage = { measured: false, reason: 'no bridgeable symbol in this change — the sdk route bridge did not run' };
 if (bridgeSymbols.length) {
-  const { ledgers, ledgerRows, registrarByTail } = scanRouteSurface();
-  bridgeCoverage = bridgeCoverageFrom(ledgers, registrarByTail.keys());
+  const { ledgers, ledgerRows, registrarByTail, sourceFiles } = scanRouteSurface();
+  // WITH THE CEILING (#11867). Until now this call omitted the third argument, so every
+  // ledger's cause came back `unmeasured` and the three counts `null` — honest, but it
+  // meant the PR comment, which is the surface a human actually reads, rendered all 177
+  // unreachable rows as ONE population when the census says there are three. The ceiling
+  // is the ONLY input that turns "unreachable" into WHY, and the reader who needs that
+  // distinction most is the one looking at a PR, not the one running a diff-free gate.
+  //
+  // WHAT IT COSTS, measured on this tree rather than assumed (`f5a7f9c88`, 7 warm runs of
+  // each arm): the ceiling reads the 1950 `packages/**` source files this walk already
+  // enumerated, of which 1106 pass `maximalTailsFrom`'s `path` prefilter, and yields the
+  // same 82 tails `--bridge-coverage` builds. Median advisory run 0.652s → 1.998s, so
+  // +1.35s — the same order as the ~1.4s recorded on `589758d22`, against a CI job
+  // measured in minutes. It is paid ONLY on a run that already carried a bridgeable symbol.
+  //
+  // ⚠️ AND IT IS THE INPUT THAT WOULD REVERSE THIS. The cause split is worth ~1.35s on a
+  // per-PR advisory run and would not be worth ~15s; whoever finds this number has grown
+  // should re-take the decision, not absorb the cost. Re-measure with the two arms above.
+  //
+  // ⛔ Through `ceilingTailsFrom`, never a second inline census: `--bridge-coverage` and
+  // this path now publish the same three buckets, and two spellings of the population they
+  // are computed over is how the two surfaces start disagreeing about one repo.
+  bridgeCoverage = bridgeCoverageFrom(ledgers, registrarByTail.keys(), ceilingTailsFrom(sourceFiles).keys());
 
   // symbol → route, capped: the bridge answers "which routes mention this name", and for
   // a CROSS-CUTTING helper that is every route it is wired into. Measured on the REST


### PR DESCRIPTION
Fixes #11867

`bridgeCoverageFrom(ledgers, tails, maximalTails)` derives three causes for an unreachable bridge row — `discovery-gap` / `no-in-repo-registrar` / `undecided` — but only against a **ceiling** passed as its optional third argument. Only the `--bridge-coverage` CLI arm passed one. The PHASE 2 advisory path did not, so on that path every ledger's cause read `unmeasured` and the three counts were `null`, and the docs-drift PR comment — the surface a human actually reads — rendered all **177** unreachable rows as ONE population when the census says there are three.

Both hops, or neither. Either alone is the half-wired state: a ceiling nobody renders is cost paid for no reader, and a render branch with no ceiling prints `unmeasured` in a nicer shape.

## The cost, re-measured on this tree — the one input that could have reversed this

The card measured ~1093 files masked / ~1.4s on `589758d22`. Re-measured here on `f5a7f9c88`, 7 warm runs of each arm, paired (the `before` arm is `git show origin/main:…` run as a probe beside the modified file, so both arms read the same tree):

| | advisory run, median |
|---|---|
| before (no ceiling) | **0.652s** |
| after (ceiling paid) | **1.998s** |
| delta | **+1.35s** |

Ceiling population, instrumented directly: **1950** `packages/**` source files walked, **1106** past `maximalTailsFrom`'s `path` prefilter, yielding the same **82**-tail ceiling `--bridge-coverage` builds. The isolated census costs ~1.37–1.61s on both arms.

So: 1106 files / ~1.4s today against 1093 / ~1.4s on `589758d22` — the file count drifted by +13 and the time did not move. **Not materially worse, so this proceeded** rather than coming back as a number. The cost is paid only on a run that already carried a bridgeable symbol and already walked this same file list, against a CI job measured in minutes. The measurement and the two arms that reproduce it are recorded at the call site, with a note to re-take the decision — not absorb the cost — if that number ever grows.

## The breakdown, re-derived

14 / 56 / 107 against 177 was measured at `589758d22`. On `f5a7f9c88` it is **unchanged**: `remediable 14 · structural 56 · undecided 107`, partitioning **177**. `clientRows` has moved 221 → 222 and `reachable` is still 45, so the total moved by one row while the split did not. No drift to report.

## The judgment call: three-way split, not a single "N are structural" clause

The card left this open and it is decided here, on the numbers.

A single "and **56** of these are structural" clause is *shorter* but, at this distribution, actively misleading: it implies the remaining **121** are remediable, and they are not — only **14** are. **107** are `undecided`, which means "no in-repo declaration, on a ledger that has other in-repo registrars", i.e. absence and an unreadable spelling are not distinguishable there. Collapsing `undecided` into "not structural" reads as "remediable" and reproduces the exact conflation the split exists to end — the one that aimed #11178 at widening a recognizer that was never the constraint. The dominant bucket is the *unknown* one, and a two-way rendering has nowhere honest to put it.

So all three render, in the same order and under the same names `--bridge-coverage` prints, as **one bullet** in the existing fold rather than three — the total and its parts cannot then drift apart onto separate conditions. Wording was tightened once after reading the rendered bytes; the bullet is ~750 chars, ~300 of which is the pre-existing sentence.

```
- the SDK route bridge reached **45** of **222** client-bound route-ledger rows — the other
  **177** have no registrar `path:` tail to select them, so pages documenting THEIR client
  methods cannot appear above, on this or any run. Of those **177**: **14** are remediable by
  widening that discovery convention (an in-repo file declares the path; the convention did not
  scan it); **56** are structural — on a ledger where NOT ONE row is declared in-repo, so no
  discovery change reaches them at any price; **107** are undecided (no in-repo declaration, on
  a ledger that has other in-repo registrars — absence and an unreadable spelling are not
  distinguishable here). The rows themselves: `node scripts/docs-audit/affected-docs.mjs --bridge-coverage`
```

## The breakdown cannot disagree with the headline

The workflow's own rule at that spot — *"Same names, one derivation: the headline and this line must never be able to disagree about which files went unseen"* — binds here:

- the parts are **read off the same object as the total** (`bridge.causes` beside `bridge.unreachable`), computed once inside `bridgeCoverageFrom` and published whole. Nothing is recomputed in the renderer.
- on numbers that do **not** partition that total, the split is **withheld** and the run states that the census is broken, rather than printing three figures beside a fourth they contradict. Verified behaviourally: a payload with `undecided` off by one renders `⛔ Its cause census is BROKEN — 14 + 56 + 106 is not the 177 it claims to break down, so the split is withheld.`
- `measured: false` keeps its honest arm for a genuinely ceiling-less run — it reports that WHY was not measured, in words, rather than three nulls or three zeroes. Also verified behaviourally.

## One derivation for the ceiling itself

Two arms now publish these three buckets, so the ceiling construction is extracted to `ceilingTailsFrom` and built in exactly one place — two spellings of the population they are computed over is how two surfaces start disagreeing about one repo. `--bridge-coverage` was rewired onto it; it is not a second copy.

## Pins, at both ends (#9433)

`affected-docs.mjs --self-test` already pinned the `bridgeCoverage` key at both ends; `causes` now gets the same treatment, and here **both** halves had been separately broken. Five new pins:

| pin | end |
|---|---|
| the ADVISORY path passes a ceiling, not just tails | `affected-docs.mjs` |
| the drift comment RENDERS `causes` | `docs-drift-check.yml` |
| the rendered split is GUARDED by the partition it claims to be | `docs-drift-check.yml` |
| the renderer derives no cause count of its own from `bridge.ledgers` | `docs-drift-check.yml` |
| the ceiling is built in exactly ONE place, and both arms use it | `affected-docs.mjs` |

The three workflow pins read the block-scalar with full-line `//` comments stripped first. That is not incidental: the negative pin failed on its own rationale on the first run, because the block names `bridge.ledgers` in prose precisely to forbid deriving from it. A raw-text pin there tests the comment, not the code.

**Reverse-verified, each mutation confirmed on disk before the reading was taken** (marker present/absent grep, not an editor exit code), each restored and re-run green afterwards, under an `EXIT INT TERM` trap so a mid-mutation kill cannot leave the tree mutated:

| mutation | self-test |
|---|---|
| advisory arm loses its ceiling | **exit 1** (3 cases) |
| workflow loses the `causes` render branch | **exit 1** (2 cases) |
| workflow loses the partition guard | **exit 1** (2 cases) |
| renderer starts deriving from `bridge.ledgers` | **exit 1** (2 cases) |
| a second inline census appears | **exit 1** (2 cases) |

Baseline and all five restores: exit 0.

## Verification

At the final commit `961081924` (the same commit `dispatch-gates.mjs` derived its list from), exit codes captured before any pipe:

- `affected-docs.mjs --self-test` — **457 cases pass**
- `check-drift-comment.mjs` — **56 cases pass across 5 fixture diff(s)**
- `check-affected-docs.mjs` — exit 0
- the full derived gate union, `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` → **25 matched families**, plus `check:nul-bytes` — **all exit 0**, run under `scripts/pm/os-verify-lock.sh`.

One family, `scripts/pm/check-governed-queue-guard.mjs`, exits 1 in a local shell for a reason unrelated to this diff: it reads `GITHUB_EVENT_PATH` *"and nothing else"* and refuses to exit 0 when it cannot look. Given a real event payload for this branch it exits **0** — `✅ CLEAR — the diff touches no governed surface`.

No changeset: root `scripts/` + workflow only, no published package source changes, so this carries the `skip-changeset` label instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_