### PR TITLE
docs(scripts): point five gate scripts at lint.yml's idiom note instead of restating the #9465 fence

### DIFF
--- a/scripts/check-aggregator-roster.mjs
+++ b/scripts/check-aggregator-roster.mjs
@@ -580,7 +580,7 @@ async function selfTest() {
   {
     const lint = sources['lint.yml'];
     const self = 'scripts/check-aggregator-roster.mjs';
-    assert(lint.includes(`node ${self}\n`), `wiring: lint.yml invokes ${self} directly (no root package.json alias -- #9465 fence)`);
+    assert(lint.includes(`node ${self}\n`), `wiring: lint.yml invokes ${self} directly (lint.yml's GATE INVOCATION IDIOM note, not a package.json fence)`);
     assert(lint.includes(`node ${self} --self-test`), 'wiring: lint.yml runs the --self-test half too');
   }
 

--- a/scripts/check-ci-filter-parity.mjs
+++ b/scripts/check-ci-filter-parity.mjs
@@ -115,11 +115,13 @@
  * ## Wiring
  *
  * Invoked from `.github/workflows/lint.yml` as `node scripts/...` directly, both
- * legs, rather than through a `pnpm check:*` alias: that alias belongs in root
- * `package.json`, declared territory of the @changesets/cli v3 migration lane
- * (#9465) while it runs. The self-test asserts that wiring against the workflow
- * text -- a gate that exists and is not scheduled is the same dormant shape from
- * the other side.
+ * legs, rather than through a `pnpm check:*` alias: see the GATE INVOCATION
+ * IDIOM note at the top of that file, which states the reasons once. It is NOT
+ * because root `package.json` is off limits -- that reading of the #9465 fence
+ * is false, and the note carries the fence's verbatim scope so this docblock
+ * does not have to: restating it is how the wrong reading spread (#10894).
+ * The self-test asserts that wiring against the workflow text -- a gate that
+ * exists and is not scheduled is the same dormant shape from the other side.
  */
 
 import { readFileSync } from 'node:fs';
@@ -630,7 +632,7 @@ export async function selfTest() {
     failures.push(`cannot read .github/workflows/lint.yml to verify wiring: ${err?.code ?? err?.message}`);
   }
   if (lint !== null) {
-    assert(lint.includes(`node ${SELF}\n`), `wiring: lint.yml invokes ${SELF} (no root package.json alias -- #9465 fence)`);
+    assert(lint.includes(`node ${SELF}\n`), `wiring: lint.yml invokes ${SELF} directly (lint.yml's GATE INVOCATION IDIOM note, not a package.json fence)`);
     assert(lint.includes(`node ${SELF} --self-test`), 'wiring: lint.yml runs the --self-test leg too');
   }
 

--- a/scripts/check-doc-frontmatter.mjs
+++ b/scripts/check-doc-frontmatter.mjs
@@ -208,12 +208,14 @@
  *
  * ## Wiring
  *
- * Invoked from `.github/workflows/lint.yml` as `node scripts/...` directly,
- * both legs, rather than through a `pnpm check:*` alias: that alias belongs in
- * root `package.json`, declared territory of the @changesets/cli v3 migration
- * lane (#9465) while it runs. The self-test asserts that wiring against the
- * workflow text -- a gate that exists and is not scheduled is the same dormant
- * shape from the other side.
+ * Invoked from `.github/workflows/lint.yml` as `node scripts/...` directly, both
+ * legs, rather than through a `pnpm check:*` alias: see the GATE INVOCATION
+ * IDIOM note at the top of that file, which states the reasons once. It is NOT
+ * because root `package.json` is off limits -- that reading of the #9465 fence
+ * is false, and the note carries the fence's verbatim scope so this docblock
+ * does not have to: restating it is how the wrong reading spread (#10894).
+ * The self-test asserts that wiring against the workflow text -- a gate that
+ * exists and is not scheduled is the same dormant shape from the other side.
  *
  * Adding the second root needed NO workflow edit: the step already invokes this
  * script, and `ROOTS` is read from here. `lint.yml` is the repo's busiest file
@@ -1220,7 +1222,7 @@ export async function selfTest() {
     failures.push(`cannot read .github/workflows/lint.yml to verify wiring: ${err.code ?? err.message}`);
   }
   if (lint !== null) {
-    assert(lint.includes(`node ${SELF}\n`), `wiring: lint.yml invokes ${SELF} (no root package.json alias -- #9465 fence)`);
+    assert(lint.includes(`node ${SELF}\n`), `wiring: lint.yml invokes ${SELF} directly (lint.yml's GATE INVOCATION IDIOM note, not a package.json fence)`);
     assert(lint.includes(`node ${SELF} --self-test`), 'wiring: lint.yml runs the --self-test leg too');
   }
 

--- a/scripts/check-platform-checklist.mjs
+++ b/scripts/check-platform-checklist.mjs
@@ -105,14 +105,17 @@ const err = (file, id, msg) => errors.push(`${file}${id ? ` · ${id}` : ''}: ${m
 //
 // The battery runs inline, on every invocation, not only behind `--self-test`,
 // because a `--self-test` here would otherwise execute NOWHERE: this gate is
-// not CI-wired by maintainer decision (README "Operating cadence"), and its
-// `pnpm` alias lives in root package.json, declared territory of the
-// @changesets/cli v3 lane (#9465) while that runs. A self-test nothing runs is
-// the documented defect of #10574/#10573 — CI enforcing the spelling of a
-// guarantee while never once checking the guarantee still holds. The battery
-// is in-memory string work (~1 ms of a ~270 ms run), so "always" costs nothing
-// worth naming, and its assertion count is printed on the OK line: the green
-// states how many rows it read and that its own control passed.
+// not CI-wired by maintainer decision (README "Operating cadence"), so nothing
+// on a PR would ever reach a `--self-test` leg. NOT because its `pnpm` alias is
+// unavailable to it: `check:platform-checklist` is already a key in root
+// package.json, and the reading that the #9465 fence covers that file is false
+// -- the GATE INVOCATION IDIOM note at the top of `.github/workflows/lint.yml`
+// carries that lane's verbatim scope, and is not restated here. A self-test
+// nothing runs is the documented defect of #10574/#10573 — CI enforcing the
+// spelling of a guarantee while never once checking the guarantee still holds.
+// The battery is in-memory string work (~1 ms of a ~270 ms run), so "always"
+// costs nothing worth naming, and its assertion count is printed on the OK
+// line: the green states how many rows it read and that its own control passed.
 
 const RUNNER_FILE = join(ROOT, 'docs/qa/platform-checklist/RUNNER.md');
 const TRAP_HEADING = '### Trap vocabulary';

--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -54,8 +54,11 @@
  *     nobody edited a file is not a ratchet.
  *   - NO DEPENDENCY. The workspace carries no tokenizer today (checked at
  *     landing: no `tiktoken` / `gpt-tokenizer` / `gpt-3-encoder` in any
- *     manifest), and root dependencies are fenced (#9465). Adding one to make a
- *     lint gate's numbers prettier is not a trade this gate needs.
+ *     manifest). Adding one to make a lint gate's numbers prettier is not a
+ *     trade this gate needs. Refused on that merit alone, not by a fence: root
+ *     dependencies as a CLASS are not #9465 territory -- the GATE INVOCATION
+ *     IDIOM note at the top of `.github/workflows/lint.yml` carries that lane's
+ *     verbatim scope, and it is pointed at rather than restated here.
  *   - INDEPENDENTLY REPRODUCIBLE. Anyone can audit a ceiling without running
  *     this script: `ceil($(wc -c < file) / 4)`. A tokenizer's count can only be
  *     checked by re-running the tokenizer.


### PR DESCRIPTION
Fixes #11904

Seven sites in `scripts/**` stated the `@changesets/cli` v3 lane's fence as covering root `package.json` as a **file** — or, in the ratchet, root dependencies as a **class**. The lane's own body scopes it to one dependency range and one script key. #10894 corrected the same reading at nineteen sites inside `.github/workflows/lint.yml` and put the reasons in one place, the `GATE INVOCATION IDIOM` note. This is the half of that repair `lint.yml` could not reach.

Every edit **points at that note** rather than restating the scope. The card's own diagnosis is that this reading propagates by copying — three of these docblocks were identically worded because their authors copied a neighbour's header — so a seventh careful restatement would be a seventh copy source.

## Premise re-verified before writing anything

| assumption | verdict |
|---|---|
| #9465's scope wording is still `root package.json (the @changesets/cli range and the version script)` | **holds** — read off the issue body today, unchanged |
| #9465 is still open, so "while it runs" hedges are re-scoped rather than removed | **holds** — open, `pm:epic`, 4/5 sub-issues complete |
| the seven sites are the whole `scripts/**` population | **holds, and widened** — see the uncited sweep below |
| the three wiring assertions can be reworded without breaking their pins | **holds** — same assertion counts before and after (39 / 77 / 45) |
| no other branch claims these five files | **holds** — 1047 remote heads scanned; the five ratchet/fence-named branches touch none of them. PR #11898 (which held `check-doc-frontmatter.mjs` at filing) merged as `da2353495` |

**The uncited sweep the card asked for.** The measurement behind this card used a bare `9465` grep, which finds the citation but not a site making the claim without one. Sweeping for the *claim* (`root package.json`, `declared territory`, `off limits`, `root dependencies`, `fenced`, `@changesets/cli` across `scripts/**`) turns up exactly **one** uncited site, `scripts/pm/release-rehearsal-clone.mjs:87` — and it is **correct**: it names *the `version` script* as declared territory, which is inside the fence's real scope. Uncited-and-wrong population: **zero**. The seven remain the whole set.

## Per-site before → after

| site | before | after |
|---|---|---|
| `check-ci-filter-parity.mjs` docblock | "that alias belongs in root `package.json`, declared territory of the @changesets/cli v3 migration lane (#9465) while it runs" | points at the `GATE INVOCATION IDIOM` note; denies the off-limits reading without restating the scope |
| `check-doc-frontmatter.mjs` docblock | same sentence, re-wrapped | same pointer |
| `check-platform-checklist.mjs` comment | "its `pnpm` alias lives in root package.json, declared territory of the @changesets/cli v3 lane (#9465) while that runs" | the real reason kept (not CI-wired by maintainer decision), plus the observation that `check:platform-checklist` **is already a key in root `package.json`** |
| `check-skills-token-ratchet.mjs` | "…in any manifest), and root dependencies are fenced (#9465)" | parenthetical reason dropped; the step's decision and its conclusion are untouched, now stated as refused on its own merit |
| `check-aggregator-roster.mjs:583` · `check-ci-filter-parity.mjs:633` · `check-doc-frontmatter.mjs:1223` assertion messages | "(no root package.json alias -- #9465 fence)" | "(lint.yml's GATE INVOCATION IDIOM note, not a package.json fence)" |

`scripts/check-step-collectors.mjs` is deliberately **untouched** — it already states the scope narrowly and is the model this PR copied the shape of.

## What this PR does not do

**No gate is rewired.** The three self-test wiring predicates are byte-identical — each still an `includes` test for the literal string "node " followed by the script's own repo path, read out of `lint.yml` — and only the second argument, the failure message, moved. The direct `node scripts/…` invocation stays; moving any of these to a root alias would redden all three, which is the trap this card carries. `.github/workflows/lint.yml` was read, never edited.

## Verification, at the final commit `84f6eb5b0`

Gate union derived in-worktree with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (change set read from git by the script itself: the same five paths). All ten derived families, both legs where a script has two, plus `check-nul-bytes`, run at `84f6eb5b0` — **15/15 exit 0**:

```
pnpm check:agent-test-spelling                          exit=0
pnpm check:cross-package-test-inputs                    exit=0
pnpm check:entry-guard                                  exit=0
pnpm check:parse-guard                                  exit=0
pnpm check:pnpm-filter-targets                          exit=0
node scripts/check-aggregator-roster.mjs                exit=0
node scripts/check-aggregator-roster.mjs --self-test    exit=0   45 assertions
node scripts/check-ci-filter-parity.mjs                 exit=0
node scripts/check-ci-filter-parity.mjs --self-test     exit=0   39 assertions
node scripts/check-cross-package-test-inputs.mjs        exit=0
node scripts/check-doc-frontmatter.mjs                  exit=0
node scripts/check-doc-frontmatter.mjs --self-test      exit=0   77 assertions
node scripts/check-skills-token-ratchet.mjs             exit=0
node scripts/check-skills-token-ratchet.mjs --self-test exit=0   35 cases
node scripts/check-nul-bytes.mjs                        exit=0
```

`check-platform-checklist.mjs` is not CI-wired by maintainer decision; run by hand, `exit 0` before and after, its inline battery reporting the same 22 + 34 + 19 self-check assertions. `check-step-collectors.mjs --self-test` also green before and after (120 assertions), as the untouched control.

**Lint, narrowed and declared.** Repo-wide `pnpm lint` is CI's run. Locally this was narrowed to the five edited files: `eslint --no-inline-config --format json` reported **5 files linted** (eslint's own config resolved all five — none reported ignored), **0 errors, 0 warnings**, exit 0. The narrowing excludes nothing: this repo runs one `eslint.config.mjs` which *never enables type-aware linting* (no `parserOptions.project`, no typed `@typescript-eslint` rules for any file — stated and measured with a positive control at `eslint.config.mjs:327`), so a comment-and-message-only diff in five `scripts/*.mjs` files cannot move a verdict on any file it does not touch.

## Changeset

None, and `skip-changeset` applied: the diff is comments and assertion-message strings under `scripts/`, with no published package source change and nothing user-visible to release.

Refs: #9465 (the fence — still open) · #10894 (the `lint.yml` half, already closed; not addressed here) · #10814 (where the correct narrow wording came from)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_