### PR TITLE
docs(service-settings): state `getMany`'s all-or-nothing key validation on the declaration that owns it

### DIFF
--- a/.changeset/settings-getmany-all-or-nothing-doc.md
+++ b/.changeset/settings-getmany-all-or-nothing-doc.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/service-settings": patch
+---
+
+docs(service-settings): state `getMany`'s all-or-nothing key validation on the declaration that owns it (#11680)
+
+Documentation and a pin. **No behaviour change** — the accept set and every
+resolved value are byte-identical.
+
+`SettingsService.getMany` validates **every** requested key against the
+namespace manifest before it reads a single env override and before it loads a
+single row, so one undeclared key rejects the whole call with
+`UnknownKeyError` (`code: 'SETTINGS_UNKNOWN_KEY'`) and the caller receives
+nothing — not the subset it was entitled to. N per-key `get()` calls behave
+differently on exactly that input: each declared key still answers, and only
+the undeclared one throws.
+
+The doc comment was otherwise detailed — it explained the grouped row load and
+the env-override ordering, and claimed row-for-row equivalence with per-key
+`get` "BY CONSTRUCTION" — but never drew this line. That equivalence claim
+holds for every key that *resolves* and not for the refusal, so a batched
+consumer had to rediscover the rule from a test. `resolveLocalizationContext`
+was the first to inherit it and had to record the consequence locally: a host
+registering a **partial** `localization` manifest loses all its keys at once
+and drops to a shorter cascade, where the per-key path would still have
+resolved the declared ones.
+
+`getMany`'s doc comment now states the rule, its blast radius, why validating
+ahead of the grouped walk makes the refusal independent of key order and scope
+grouping, and what a caller on a partial manifest should expect.
+
+The pre-existing pin asserted only `rejects.toThrow(/nope/)` — green whatever
+the blast radius is. A sibling pin now asserts the property instead: the error
+envelope (`code: 'SETTINGS_UNKNOWN_KEY'`), that **zero** rows were loaded
+(the refusal is up-front, with the undeclared key last in the request), and
+the contrast that per-key `get()` still answers each declared key.

--- a/packages/services/service-settings/src/settings-getmany.test.ts
+++ b/packages/services/service-settings/src/settings-getmany.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SettingsService } from './settings-service.js';
+import { UnknownKeyError } from './settings-service.types.js';
 
 // WHERE-matcher gate: implement exactly the combinators the service emits and
 // THROW on the rest — a bare field-equality read of `$or` would silently match
@@ -116,6 +117,42 @@ describe('[#10826] SettingsService.getMany', () => {
     const { svc } = await makeService();
     await expect(svc.getMany('localization', ['timezone', 'nope'])).rejects.toThrow(/nope/);
     await expect(svc.get('localization', 'nope')).rejects.toThrow(/nope/);
+  });
+
+  // [#11680] The rule the doc comment now states, pinned as a PROPERTY rather
+  // than as "it throws": the refusal is TOTAL (no partial Record), it lands
+  // BEFORE any row load, and it is the one input on which `getMany` and N
+  // per-key `get()` calls part ways. The sibling above asserts only that the
+  // message names the bad key — which stays green whatever the blast radius is.
+  it('one undeclared key rejects the WHOLE call — before any row load, no partial result', async () => {
+    const { svc, engine } = await makeService();
+    engine.find.mockClear();
+
+    const err: unknown = await svc
+      .getMany('localization', ['timezone', 'currency', 'nope'])
+      .then(() => null, (e: unknown) => e);
+
+    // The envelope, not just the throw. This is a service-layer error class:
+    // it carries `code` and no `status` (no HTTP boundary here), so `code` is
+    // the whole machine-readable envelope there is to assert.
+    expect(err).toBeInstanceOf(UnknownKeyError);
+    expect((err as UnknownKeyError).code).toBe('SETTINGS_UNKNOWN_KEY');
+    expect((err as Error).message).toMatch(
+      /Key 'nope' is not declared in manifest 'localization'/,
+    );
+
+    // TOTAL and UP-FRONT: the two DECLARED keys were neither answered nor even
+    // loaded — validation runs ahead of the grouped `loadRows`.
+    expect(engine.find).toHaveBeenCalledTimes(0);
+
+    // ...and here is the non-equivalence: per-key `get()` still answers every
+    // declared key on the same input; only the undeclared one throws. Asserted
+    // on the resolved cascade LAYER, not on the literal — this fixture stores
+    // JSON text in `value` while the service persists values verbatim, so a
+    // literal here would pin the fixture's encoding rather than the rule.
+    expect((await svc.get('localization', 'timezone')).source).toBe('global');
+    expect((await svc.get('localization', 'currency')).source).toBe('tenant');
+    await expect(svc.get('localization', 'nope')).rejects.toBeInstanceOf(UnknownKeyError);
   });
 
   it('getNamespace resolves through the grouped path with unchanged answers', async () => {

--- a/packages/services/service-settings/src/settings-service.ts
+++ b/packages/services/service-settings/src/settings-service.ts
@@ -1218,6 +1218,40 @@ export class SettingsService {
    * the env-override branch, the scope→userId mapping, and the cascade are
    * the same code ({@link resolveKeyFromRows} is extracted from `get`, not
    * copied). Nothing is cached; nothing survives the call.
+   *
+   * ## Key validation is UP-FRONT and TOTAL
+   *
+   * That equivalence covers every key that RESOLVES. It does not cover the
+   * refusal, and this is the one respect in which `getMany` is not N `get`
+   * calls — so it is stated here rather than left to be rediscovered from a
+   * test.
+   *
+   * EVERY requested key is checked against the namespace's manifest before a
+   * single env override is read and before any row is loaded. One undeclared
+   * key therefore rejects the WHOLE call — {@link UnknownKeyError}, `code:
+   * 'SETTINGS_UNKNOWN_KEY'` — and the caller receives NOTHING: no partial
+   * `Record`, not even the subset it was entitled to. N per-key {@link get}
+   * calls part ways on exactly this input: each declared key still answers,
+   * and only the undeclared one throws. Same error class, same code; the
+   * blast radius is what differs. (An unregistered NAMESPACE is refused first
+   * and identically to `get`: {@link UnknownNamespaceError}.)
+   *
+   * Validating before the grouped walk rather than inside it is what makes
+   * the refusal independent of key order, of scope grouping, and of which
+   * keys happened to carry an env override — the call either refuses or
+   * answers all of them, never something in between. `setMany` pre-flights
+   * its whole patch the same way.
+   *
+   * What it costs a caller: against a host that registers a PARTIAL manifest,
+   * a batched consumer loses ALL of its keys at once and must degrade for the
+   * whole set — it cannot fall back key by key. `resolveLocalizationContext`
+   * is the first consumer to inherit this and records its own degradation
+   * locally: a partial `localization` manifest drops it to a shorter cascade
+   * (no `global` scope layer, no `OS_LOCALIZATION_*` override) where the
+   * per-key path would still have resolved the declared keys. A caller that
+   * cannot afford the rule should intersect `keys` with the manifest itself,
+   * or read per key. {@link getNamespace} can never trip it — it passes
+   * exactly the registered keys.
    */
   async getMany(
     namespace: string,


### PR DESCRIPTION
Fixes #11680

Documentation and a pin. **No behaviour change** — the implementation file's
diff is 34 added lines and **0 removed** (`git diff --numstat`), all of them
inside one doc comment.

## Routing deviation — read this first

Triage routed this card to `domain:spec` on the premise that "the
`SettingsService.getMany` declaration" lives in `packages/spec`. Measured
against `origin/main` at `577fabf`, **it does not**:

- `git grep getMany -- packages/spec` → **zero hits**.
- `packages/spec/src/contracts/` holds 49 non-test contract modules; **none is
  a settings service**, and the only `SettingsService` mentions anywhere under
  that directory are three prose references inside `crypto-provider.ts`.
- The only `SettingsService` interface declarations in the repo are
  `SettingsServicePluginOptions` and `SettingsServiceOptions`, both in
  `packages/services/service-settings/` — neither declares `getMany`.

So the contract that owns `getMany` is the concrete method's own doc comment in
`packages/services/service-settings/src/settings-service.ts` — which is exactly
where the issue body pointed. This PR touches **no** `packages/spec/**` path,
so the spec-surface review limb does not apply to it; the card's domain label
is the PM's to correct.

The issue's own premise is intact and was verified line by line before any
edit.

## The rule, as measured

`getMany` checks **every** requested key against the namespace manifest before
it reads a single env override and before it loads a single row:

```ts
const reg = this.registry.get(namespace);
if (!reg) throw new UnknownNamespaceError(namespace);
for (const key of keys) {
  if (!reg.scopes.has(key)) throw new UnknownKeyError(namespace, key);
}
```

One undeclared key therefore rejects the **whole** call — `UnknownKeyError`,
`code: 'SETTINGS_UNKNOWN_KEY'` — and the caller receives nothing, not the
subset it was entitled to. N per-key `get()` calls part ways on exactly that
input: each declared key still answers, and only the undeclared one throws.

The doc comment was otherwise detailed — it explained the grouped row load and
the env-override ordering, and claimed row-for-row equivalence with per-key
`get` "BY CONSTRUCTION". That claim holds for every key that *resolves* and not
for the refusal, and the comment did not draw the line. `getMany`'s doc comment
now states the rule, its blast radius, why validating ahead of the grouped walk
makes the refusal independent of key order and scope grouping, and what a caller
against a partial manifest should expect. `setMany` already pre-flights its
whole patch the same way, and the comment says so.

## The pin, and why the existing one was not enough

`settings-getmany.test.ts` already asserted
`await expect(svc.getMany('localization', ['timezone', 'nope'])).rejects.toThrow(/nope/)`
— green whatever the blast radius is. The new sibling pin asserts the property
instead:

- the error envelope (`code: 'SETTINGS_UNKNOWN_KEY'` plus the message clause).
  This is a service-layer error class carrying `code` and **no** `status` —
  there is no HTTP boundary here, so `code` is the whole machine-readable
  envelope there is to assert;
- **zero** rows loaded (`engine.find` called 0 times) with the undeclared key
  placed **last** in the request — that is the "up-front" half, and it is the
  half the old pin cannot see;
- the contrast: per-key `get()` still resolves each declared key on the same
  input, asserted on the cascade **layer** rather than the literal (this
  fixture stores JSON text in `value` while the service persists values
  verbatim — see the finding below).

### Ablation

Deferred `getMany`'s validation until after the grouped row load, then restored.

- **Resolution path**: the test imports `./settings-service.js` **relatively**,
  which vitest resolves to `src/` — no package `exports` → `dist` hop is
  involved, so no rebuild is required for the mutation to take effect. Stated
  because a rebuild-free ablation is the exception, not the default.
- **Mutation confirmed on disk**, not from an editor's exit code: the count of
  `if (!reg.scopes.has(key)) throw new UnknownKeyError(namespace, key);` in the
  file went **3 → 2** (the `getMany` occurrence gone; `get` and `setMany`
  untouched), and the mutated `getMany` head was dumped and read back.
- **Restore confirmed on disk**: injected marker count back to **0**, throw
  count back to **3**. The script carried `trap … EXIT INT TERM`, and the trap
  fired.
- **Predicted direction, and what happened**: the new pin turned **red** on
  `expect(engine.find).toHaveBeenCalledTimes(0)` — *"expected `vi.fn()` to be
  called +0 times, but got 2 times"* — while the pre-existing `toThrow(/nope/)`
  pin stayed **green** through the same ablation (6 passed / 1 failed). That is
  the measurement the new pin exists for.
- One honesty note: the mutation script annotated its marker count as
  "expect 4" where 3 injection sites can only produce 3. The stated expectation
  was wrong, not the observation; the load-bearing on-disk proof is the 3 → 2
  throw count and the head dump, both of which held.

## Verification

Union run at `5067b79`, after the final commit.

- `pnpm --filter @objectstack/service-settings typecheck` (`tsc --noEmit`,
  script name echoed — not a zero-match pass) and `… test` → **29 test files,
  515 tests passed**.
- `pnpm --filter @objectstack/service-settings exec vitest run src/settings-getmany.test.ts`
  → **7 passed (7)**.
- Gate families derived from the real change set with
  `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
  (no hand-built path list), all **exit 0**: `check:nul-bytes`,
  `check:error-code-casing`, `check:changeset-gate-self-tests`,
  `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`,
  `check:test-source-alias`, `check:type-source-resolution`,
  `check-adr-0087-registration`, `check-changeset-no-major`,
  `check-empty-changeset`, `check-plugin-teardown-shape`,
  `release-rehearsal-clone --self-test`, `docs-audit/check-affected-docs`,
  and the convention-triggered set for a test edit —
  `check:query-options-erasure`, `check:engine-double-contract`,
  `check:where-matcher`, `check:cross-package-test-inputs`,
  `check:type-check-coverage`.
- `npx eslint . --no-inline-config --format json` — the **repo-wide** run, not a
  narrowing: **5220 files** resolved by eslint's own config, **0 errors, 0
  warnings**. (Type-aware linting is off — the config states "no
  `parserOptions.project`, no typed `@typescript-eslint` rules".)
- Not run locally, declared: `check:type-check-debt --re-measure`, which
  refuses on an unbuilt worktree and needs the whole workspace closure built —
  a repo-scale run CI owns. `docs-audit/check-drift-comment` needs PR context.

## Out-of-scope finding, not filed

`settings-getmany.test.ts`'s `ROWS` fixture stores **JSON text** in `value`
(`'"America/New_York"'`), but `sys_setting.value` is a `Field.json` column and
the service writes `storedValue = rawValue` and reads `return row.value ?? null`
— verbatim both ways, with the driver owning the JSON codec. The fake engine
skips that codec and returns rows as written, so every value in this fixture
resolves one JSON encoding deep. It is invisible today because every assertion
in the file compares `getMany` against `get`, and both are equally affected —
the same "a fake that lies consistently" shape this file's own header warns
about for `$or` matchers. It cost one test iteration here and would mislead the
next author who asserts a concrete value.

Not filed as an issue: the dedup search this repo requires before filing goes
through the REST list endpoint, and from this session that endpoint answers
*"GitHub access is not enabled for this session"* (`gh` is not installed
either). Reported to the PM instead rather than filed without a duplicate
check.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NDGG54XF5gbTLdQzCtnaVV)_