### PR TITLE
build(dts): roll the declaration-emitted guard across all 67 tsup-built packages

### DIFF
--- a/packages/adapters/hono/package.json
+++ b/packages/adapters/hono/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/apps/account/package.json
+++ b/packages/apps/account/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/apps/setup/package.json
+++ b/packages/apps/setup/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/apps/studio/package.json
+++ b/packages/apps/studio/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/client-react/package.json
+++ b/packages/client-react/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.tsx --config ../../tsup.config.ts",
+    "build": "tsup src/index.tsx --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "check:exported-any-returns": "tsx ../../scripts/check-exported-any-returns.mts --self-test && tsx ../../scripts/check-exported-any-returns.mts --package packages/client",

--- a/packages/cloud-connection/package.json
+++ b/packages/cloud-connection/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/connectors/connector-mcp/package.json
+++ b/packages/connectors/connector-mcp/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/connectors/connector-openapi/package.json
+++ b/packages/connectors/connector-openapi/package.json
@@ -13,7 +13,7 @@
         }
     },
     "scripts": {
-        "build": "tsup --config ../../../tsup.config.ts",
+        "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
         "test": "vitest run --passWithNoTests",
         "typecheck": "tsc --noEmit"
     },

--- a/packages/connectors/connector-rest/package.json
+++ b/packages/connectors/connector-rest/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/connectors/connector-slack/package.json
+++ b/packages/connectors/connector-slack/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/create-objectstack/package.json
+++ b/packages/create-objectstack/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "dev": "tsup --watch",
     "test": "vitest run"

--- a/packages/drivers/driver-memory/package.json
+++ b/packages/drivers/driver-memory/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/drivers/driver-mongodb/package.json
+++ b/packages/drivers/driver-mongodb/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/drivers/driver-sql/package.json
+++ b/packages/drivers/driver-sql/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/drivers/driver-sqlite-wasm/package.json
+++ b/packages/drivers/driver-sqlite-wasm/package.json
@@ -23,7 +23,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/drivers/driver-turso/package.json
+++ b/packages/drivers/driver-turso/package.json
@@ -23,7 +23,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/formula/package.json
+++ b/packages/formula/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/metadata-core/package.json
+++ b/packages/metadata-core/package.json
@@ -24,7 +24,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/packages/metadata-fs/package.json
+++ b/packages/metadata-fs/package.json
@@ -19,7 +19,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/packages/metadata-protocol/package.json
+++ b/packages/metadata-protocol/package.json
@@ -19,7 +19,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -34,7 +34,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/packages/objectql/package.json
+++ b/packages/objectql/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/platform-objects/package.json
+++ b/packages/platform-objects/package.json
@@ -63,7 +63,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/plugins/embedder-openai/package.json
+++ b/packages/plugins/embedder-openai/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/plugins/knowledge-memory/package.json
+++ b/packages/plugins/knowledge-memory/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/plugins/knowledge-ragflow/package.json
+++ b/packages/plugins/knowledge-ragflow/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run"
   },

--- a/packages/plugins/plugin-approvals/package.json
+++ b/packages/plugins/plugin-approvals/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",
     "test": "vitest run --passWithNoTests"
   },

--- a/packages/plugins/plugin-audit/package.json
+++ b/packages/plugins/plugin-audit/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/plugins/plugin-dev/package.json
+++ b/packages/plugins/plugin-dev/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-email/package.json
+++ b/packages/plugins/plugin-email/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-hono-server/package.json
+++ b/packages/plugins/plugin-hono-server/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-pinyin-search/package.json
+++ b/packages/plugins/plugin-pinyin-search/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-reports/package.json
+++ b/packages/plugins/plugin-reports/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/plugins/plugin-security/package.json
+++ b/packages/plugins/plugin-security/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/plugins/plugin-sharing/package.json
+++ b/packages/plugins/plugin-sharing/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/plugins/plugin-webhooks/package.json
+++ b/packages/plugins/plugin-webhooks/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config tsup.config.ts",
+    "build": "tsup --config tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"

--- a/packages/sdui-parser/package.json
+++ b/packages/sdui-parser/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/service-analytics/package.json
+++ b/packages/services/service-analytics/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/services/service-automation/package.json
+++ b/packages/services/service-automation/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/services/service-cache/package.json
+++ b/packages/services/service-cache/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/services/service-cluster-redis/package.json
+++ b/packages/services/service-cluster-redis/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/service-cluster/package.json
+++ b/packages/services/service-cluster/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/services/service-datasource/package.json
+++ b/packages/services/service-datasource/package.json
@@ -19,7 +19,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../../scripts/check-dts-emitted.mjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/services/service-i18n/package.json
+++ b/packages/services/service-i18n/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/services/service-job/package.json
+++ b/packages/services/service-job/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/services/service-knowledge/package.json
+++ b/packages/services/service-knowledge/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/services/service-messaging/package.json
+++ b/packages/services/service-messaging/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",
     "test": "vitest run"
   },

--- a/packages/services/service-package/package.json
+++ b/packages/services/service-package/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/service-queue/package.json
+++ b/packages/services/service-queue/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/services/service-realtime/package.json
+++ b/packages/services/service-realtime/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json",
     "test": "vitest run"
   },

--- a/packages/services/service-settings/package.json
+++ b/packages/services/service-settings/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/services/service-sms/package.json
+++ b/packages/services/service-sms/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/service-storage/package.json
+++ b/packages/services/service-storage/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -243,7 +243,7 @@
     "spec-changes.json"
   ],
   "scripts": {
-    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=12288\" BUILD_DTS=true tsup; fi && node ../../scripts/check-dev-prereqs.mjs --stamp",
+    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=12288\" BUILD_DTS=true tsup; fi && node ../../scripts/check-dts-emitted.mjs && node ../../scripts/check-dev-prereqs.mjs --stamp",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "gen:schema": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts",

--- a/packages/triggers/trigger-api/package.json
+++ b/packages/triggers/trigger-api/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/triggers/trigger-record-change/package.json
+++ b/packages/triggers/trigger-record-change/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },

--- a/packages/triggers/trigger-schedule/package.json
+++ b/packages/triggers/trigger-schedule/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../../tsup.config.ts",
+    "build": "tsup --config ../../../tsup.config.ts && node ../../../scripts/check-dts-emitted.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ../../tsup.config.ts",
+    "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Fixes #12078

PR #12076 established the mechanism and closed it for **one** package. This rolls the
guard across the whole population: every workspace package whose `build` script invokes
tsup now ends that build with a `node …/scripts/check-dts-emitted.mjs` step pointing at the repo-root script.

The diff is **66 files, 66 insertions, 66 deletions — every changed line is a `"build":`
script line**, nothing else, so it stays trivially resolvable against the open PR
population.

## The population, derived rather than inherited

Neither number in the card was taken on trust. Derived from the build graph by walking
every `pnpm-workspace.yaml` glob and reading each manifest's `build` script and its
declared declaration paths (`types`, `typings`, and `types` conditions inside `exports`):

| | count |
|---|---|
| workspace packages | 78 |
| with a `build` script | 72 |
| whose build invokes tsup — **the population** | **67** |
| of those, declaring at least one declaration path | 67 (all of them) |
| already wired before this PR | 1 (`@objectstack/plugin-auth`) |
| **wired here** | **66** |

The card's "~50 packages" undercounts and the claim's "19 `tsup.config.ts` files carrying
`OS_SKIP_DTS`" counts config *files*: 20 packages have their own config, the other 47
resolve the shared root one (tsup searches upward, and the `--config ../../tsup.config.ts`
spellings name it explicitly). Both routes carry `dts: !process.env.OS_SKIP_DTS`, so both
are exposed. Every declared path in the population points at `dist/*.d.[cm]ts` — no
package promises a declaration from anywhere else.

## Measured across the population BEFORE wiring anything

Requested explicitly, and the result is the opposite of what the dispatch expected:

```
full workspace build (71 tasks, exit 0), then the guard run in all 67 package dirs:
--- 67 package(s) checked, 0 failing ---
```

**Zero live instances at this commit.** Every package in the population genuinely emits
every declaration its manifest promises. So there is no separate "these were already
broken" card to file — the rollout is not hiding a red anywhere, and it arrives on a
known-green population. (The guard's own `--self-test`: all assertions pass.)

## The two edge cases, verified

**`@objectstack/cli` — out of population, confirmed.** Its build is
`tsc -p tsconfig.build.json` (with an `OS_SKIP_DTS` branch that passes `--declaration
false`). `tsc` emits declarations synchronously in-process and exits non-zero on failure;
there is no DTS worker to die silently. Not wired — this guard would be pure redundancy
over a toolchain that cannot produce the artifact it catches. For the record it *would*
pass today: `@objectstack/cli - 1/1 declared declaration file(s) present.`

**`@objectstack/spec` — IN the population, and the card's reasoning about its stamp is
correct.** Read off `scripts/check-dev-prereqs.mjs`: `buildInputHash()` hashes
`packages/spec/src/**` plus the package's build config plus the global build inputs —
**sources only, never the emitted dist**. So after a silent DTS death the stamp written by
`--stamp` matches the sources exactly and `dist/.build-input-hash` reads *fresh*, which is
precisely the lie the freshness half exists to prevent, arriving through a door it does
not watch. `packages/spec/scripts/lib/dist-freshness.ts` already describes the
JS-without-declarations shape but attributes it to a deliberate `OS_SKIP_DTS=1` on a virgin
tree — the same artifact, the wrong cause.

Spec is therefore wired, and the guard is placed **before** the stamp step, not after:

```
pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z "$OS_SKIP_DTS" ]; then … BUILD_DTS=true tsup; fi \
  && node ../../scripts/check-dts-emitted.mjs \
  && node ../../scripts/check-dev-prereqs.mjs --stamp
```

A build that emitted no declarations now never reaches the stamp, so it cannot leave a
dist that claims to be current. Verified: `check-dts-emitted: @objectstack/spec - 34/34
declared declaration file(s) present.`, and `check:dev-prereqs` green afterwards.

⚠️ One consequence reviewers will meet once: `packages/spec/package.json` is itself a
stamp input, so this very diff invalidates the stamp on any already-built tree.
`check:dev-prereqs` reds with "the sources on disk hash …" until `pnpm build` runs. That
is the gate working as designed (its docblock calls this case out), not a regression, and
it clears with the rebuild every reviewer owes anyway.

Also checked and left alone: the three `examples/app-*` (build via `objectstack build`,
and their `types` points at a `.ts` source, not a declaration) and `apps/docs` (`next
build`, declares no declaration entry point at all).

## `OS_SKIP_DTS` no-op — tested explicitly, at full scale

A guard that fired under the fast-path flag would be worse than the defect, so this got a
whole-workspace run rather than an argument:

| run | build exit | turbo | guard lines |
|---|---|---|---|
| `pnpm build` | **0** | 71 successful, 71 total | 67 × "N/N declared declaration file(s) present" |
| `OS_SKIP_DTS=1 pnpm build` | **0** | 71 successful, 71 total | 67 × "OS_SKIP_DTS is set - declarations skipped by request, not checked"; **0** checking lines |

During the skip run `packages/metadata-fs/dist` really did hold **zero** `.d.ts` — the
guard had something to fire on and correctly did not. The following plain `pnpm build` was
`71 cached, 71 total`, exit 0.

That the guard printed 67 lines in each run is also the proof that **every** wired
invocation actually executes: not one of the 66 new call sites is a path that silently
resolves to nothing.

## Exit-code plumbing — checked on every script touched

The failure mode named in dispatch (a guard appended after `;`, or inside a chain that
swallows status) is a guard that cannot fail. Asserted mechanically over all 67:

- the connector immediately before the guard is `&&` in **67/67** — no `;`, no `|`;
- the relative path in each script (`../` × package depth) resolves to exactly
  `scripts/check-dts-emitted.mjs` in **67/67**;
- spec's `if … fi && node …` shape propagates too: `fi` carries the body's status, so a
  failed DTS pass short-circuits before the guard rather than around it.

## Reverse verification: the wired build really reds

Not an argument from shell semantics — measured end to end, on one wired package, by
mimicking the #11907 artifact (JS written, zero declarations, tsup exit 0). The mutation
was `dts: !process.env.OS_SKIP_DTS` → `dts: false` in
`packages/metadata-fs/tsup.config.ts` (a per-package config inside this worktree only —
never the shared root config, which is a turbo `globalDependency` other agents build on),
confirmed on disk in both directions by counting the anchor text and the injected text
before and after each leg, under a `trap … EXIT INT TERM` restore:

```
[before] anchor present: 1 (expect 1); mutation present: 0 (expect 0)
[after ] anchor present: 0 (expect 0); mutation present: 1 (expect 1)

ABLATED_BUILD_EXIT=1
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @objectstack/metadata-fs build: `tsup && node ../../scripts/check-dts-emitted.mjs`
 Exit status 1
dist .d.ts count after ablated build: 0      (JS present: yes)

[restore] anchor present: 1 (expect 1); mutation present: 0 (expect 0)
CONTROL_BUILD_EXIT=0
check-dts-emitted: @objectstack/metadata-fs - 1/1 declared declaration file(s) present.
dist .d.ts count after control build: 1
```

Expected direction, observed direction: **red**. Both legs rebuilt; the tree was clean
(`git status --porcelain` empty) before the final commit.

## What was NOT done, and why

**Option 2 (a choke point in the shared root `tsup.config.ts`'s `onSuccess`) stays closed**
— tsup composes `Promise.all([dtsTask(), mainTasks()])` and `onSuccess` runs inside
`mainTasks`, so it can fire before DTS finishes and would pass on a dead worker. Not
re-opened, and no alternative choke point is claimed: the only other candidates are a turbo
`outputs` assertion (turbo has no "these outputs must be non-empty" predicate) and a
post-build repo-wide sweep, which is a second gate over the same fact that still lets the
poisoned entry be cached first. Per-package, inside the failing build, before the cache
write, is the only ordering that stops the artifact from existing.

**Option 3 (patching tsup) is not taken.** Filed instead as **#12167**, proposing the
`worker.on('error')` / `worker.on('exit')` pair be reported upstream, carrying the
reproduction. Complement, not alternative: the guard protects us now, an upstream fix ends
the class for everyone.

**Nothing was weakened to get green.** No manifest's `types` promise was trimmed, and the
guard is unmodified from what PR #12076 landed — the rollout exposed no gap in it. One
observation worth recording rather than changing: the `types` / `typings` branch of
`declaredDeclarationPaths` does not filter on a `.d.ts` extension the way the `exports`
branch does, so a manifest pointing `types` at a `.ts` source (the `examples/app-*` shape)
would be checked for that source file's presence. No package in the population does this,
so it changes nothing here; noted so the next reader does not rediscover it as a bug.

## Gates

Derived at the final commit `3fb39ca3a` with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written
path list; the script took the change set from the merge base itself). **24 matched
families plus the 2 convention-triggered i18n families — 26 commands, all green**, each
exit code captured before any pipe.

Two were red on the first pass and both are named here rather than quietly re-run:

- `check:dev-prereqs` — the spec stamp case described above. Green after `pnpm build`.
- `check:engine-split-ratio` — refused to compute (exit 2) because this container's clone
  is shallow and its oldest visible commit sat inside the 90-day window. An environment
  fact, not this diff: after `git fetch --shallow-since=2026-05-20 origin` it computes and
  passes (ratio 97.6%).

Lint is a **declared narrowing**, with the measurement rather than an assertion: eslint's
own flat config matches only `**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` — no JSON glob — and
running `eslint --no-inline-config --format json` over all 66 changed files reports 66
results, **0 errors**, every one of them "File ignored because no matching configuration
was supplied". The config enables no type-aware linting (no `parserOptions.project`, no
`projectService`), so this diff cannot move the verdict on any file it does not touch. The
repo-wide sweep remains CI's run.

`origin/main` moved 13 commits while this was in flight; **none of them touches any
`package.json`, `tsup.config.ts`, `turbo.json`, `pnpm-workspace.yaml` or `pnpm-lock.yaml`**,
so the population is still complete and the diff has zero textual overlap with them.

Build orchestration only — no published package's shipped behaviour changes — so
`skip-changeset`, matching PR #12076's precedent for the same class of change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_