### PR TITLE
fix(spec): converge root docs meta.json onto the declared page list (#11482)

### DIFF
--- a/.changeset/docs-root-meta-declared-pages.md
+++ b/.changeset/docs-root-meta-declared-pages.md
@@ -1,0 +1,35 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the generated docs root sidebar lists categories from the same declared page list `meta.json` and the category index already agree on (#11482)
+
+`build-docs.ts` writes the docs tree from what should be one answer to "which
+categories/pages exist", but the ROOT `content/docs/references/meta.json` (§3
+— the sidebar's top-level category list) was still answering it a third way:
+
+- a category's own `meta.json` (§2) is built from the pages the run
+  **emitted**;
+- that category's `index.mdx` card grid (§2.5) reads the SAME declared list
+  (#11260) — no longer a second, independently-derived enumeration;
+- the root `meta.json` (§3), until now, filtered on `categoryZodFiles` — the
+  `.zod.ts` files found **on disk** — a third, independent enumeration.
+
+A category whose published pages all come from plain `.ts` files rather than
+`.zod.ts` ones (the `misc` catch-all class `security/misc` proves is real) has
+zero `.zod.ts` files while still publishing a page, a `meta.json` and an
+`index.mdx`. The old filter would drop such a category from the sidebar even
+though it is fully generated and routed everywhere else — a folder complete on
+disk and unreachable from the nav.
+
+**No category is in that state today** — all 14 have at least one `.zod.ts`
+file — so this was a latent defect with no live instance, and the regenerated
+root `meta.json` is byte-identical. The filter now reads `categoryMetaPages`,
+the same map §2.5 already reads, so all three files answer from one list
+instead of three that happen to agree today. The rule moved into
+`scripts/lib/root-meta.ts` (`rootCategoryDirs`), pinned directly with the
+all-`misc`-category shape that has no instance in the repo — the same move
+#11260 made for the category card grid, for the same reason: the defect's
+output is an ABSENT sidebar entry, which `check:docs` cannot see any more than
+it could see an absent card, and the edge that has no live instance cannot be
+pinned from emitted output at all.

--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -45,6 +45,7 @@ import {
   renderRootIndex,
   type RootIndexCategory,
 } from './lib/root-index';
+import { rootCategoryDirs } from './lib/root-meta';
 import {
   buildSchemaIndex,
   formatConflicts,
@@ -936,13 +937,12 @@ if (managedCount > 0) {
 }
 
 // 3. Update root meta.json
-// Collect categories that have actual generated content (non-empty zod files)
-const categoryDirs = Object.keys(CATEGORIES)
-  .filter(cat => {
-    const zodFiles = categoryZodFiles.get(cat);
-    return zodFiles && zodFiles.size > 0;
-  })
-  .sort();
+// Which categories reach the sidebar — from `categoryMetaPages`, the same
+// declared list §2.5 reads for its card grid, never a `.zod.ts`-keyed
+// re-derivation. See `lib/root-meta.ts` for the defect this replaces and why
+// the rule lives in an extracted, unit-testable function (#11482, same fix
+// pattern as #11260 one enumeration up).
+const categoryDirs = rootCategoryDirs(Object.keys(CATEGORIES), categoryMetaPages);
 
 // Collect other root files (if any exist, like implementation-status.mdx).
 // Root-level .mdx is hand-written and never generated, so this reads the disk in

--- a/packages/spec/scripts/lib/root-meta.ts
+++ b/packages/spec/scripts/lib/root-meta.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Which category folders get an entry in the root
+ * `content/docs/references/meta.json` — the sidebar's top-level category list
+ * (#11482).
+ *
+ * ## The defect this replaces
+ *
+ * `build-docs.ts` writes THREE things from what should be one answer to "which
+ * categories/pages exist": a category's own `meta.json` (§2, from the pages
+ * this run emitted), that category's `index.mdx` card grid (§2.5, fixed by
+ * #11260 to read the same declared list), and the ROOT `meta.json` (§3) —
+ * which, until this fix, filtered on `categoryZodFiles`: the `.zod.ts` files
+ * found on disk, a fourth, independently derived enumeration.
+ *
+ * A category whose published pages all come from plain `.ts` files rather than
+ * `.zod.ts` ones — the `misc` catch-all class `security/misc` proves is real —
+ * has ZERO `.zod.ts` files while still publishing a page, a `meta.json` and an
+ * `index.mdx`. The old filter dropped such a category from the sidebar even
+ * though §2 and §2.5 both fully generated it: a folder that is complete on
+ * disk and unreachable from the nav. No category is in that state today (all
+ * 14 have at least one `.zod.ts` file), so the defect was latent — `check:docs`
+ * cannot see an ABSENT sidebar entry any more than #11260's card grid could see
+ * an absent card.
+ *
+ * ## Why a function, and why here
+ *
+ * Same move `category-index.ts` (#11260), `schema-section.ts` (#7658) and
+ * `format-type.ts` (#4912) made: the generator is a top-level script with side
+ * effects, so the only way to assert on the root `meta.json`'s category list
+ * was to run the whole thing and inspect emitted output — which cannot pin a
+ * category shape that has no live instance in the repo. Asserting an absence
+ * needs the rule out of the script.
+ *
+ * ## The invariant, now held by construction
+ *
+ * A category reaches the sidebar exactly when `categoryMetaPages` has a
+ * non-empty entry for it — the SAME map §2.5 reads to build that category's
+ * card grid, and the same "no meta.json ⇒ absent" discipline §2 already
+ * documents for `categoryMetaPages` itself. One answer, read three times,
+ * instead of three answers that happen to agree today.
+ */
+
+/**
+ * The category directories that belong in the root `meta.json`'s `pages`
+ * array, alphabetically sorted.
+ *
+ * `categories` is `Object.keys(CATEGORIES)` — every known protocol module,
+ * whether or not it published anything this run. `metaPages` is
+ * `categoryMetaPages`: the `pages` array §2 wrote to a category's own
+ * `meta.json`, present only for a category that published at least one page.
+ */
+export function rootCategoryDirs(
+  categories: readonly string[],
+  metaPages: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  return categories.filter(cat => (metaPages.get(cat) ?? []).length > 0).sort();
+}

--- a/packages/spec/scripts/root-meta.test.ts
+++ b/packages/spec/scripts/root-meta.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pin for the root `content/docs/references/meta.json` category filter — WHICH
+ * categories reach the sidebar (#11482).
+ *
+ * THE DEFECT THIS PINS. `build-docs.ts` §3 built the root `meta.json`'s
+ * category list from `categoryZodFiles` — the `.zod.ts` files found on disk —
+ * a THIRD enumeration of "the pages of this category", independent of both the
+ * category's own `meta.json` (§2) and its card grid (§2.5, fixed by #11260 to
+ * read the same declared list §2 wrote). A category whose published pages all
+ * come from plain `.ts` files (the `misc` catch-all class — `security/misc`
+ * proves the shape) has zero `.zod.ts` files while still publishing a page, so
+ * the old filter dropped it from the sidebar even though it was fully
+ * generated and routed everywhere else.
+ *
+ * WHY A UNIT TEST, rather than the regenerated root `meta.json` alone. Same
+ * two reasons #11260's `category-index.test.ts` gives for the card grid:
+ *
+ *  - the defect's output is an ABSENT sidebar entry. `check:docs` compares
+ *    generated output to committed output, so a category that was never
+ *    emitted into `pages` is green forever;
+ *  - the edge this exists to catch — a category with pages but NO `.zod.ts`
+ *    file at all — HAS NO INSTANCE in the repo today (measured on
+ *    `origin/main`: all 14 categories have `zodFiles.size > 0`), so no
+ *    generated artifact can pin it in either direction. Asserting on a
+ *    category that does not exist requires the rule out of the side-effecting
+ *    script.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { rootCategoryDirs } from './lib/root-meta';
+
+describe('rootCategoryDirs — which categories reach the root sidebar (#11482)', () => {
+  it('includes an all-misc category — no `.zod.ts` files, but it published a page', () => {
+    // The exact latent shape #11482 named: a category whose every published
+    // schema falls to the catch-all bucket, so `categoryZodFiles` would record
+    // zero files for it while `categoryMetaPages` (built from the pages §2
+    // actually emitted) still holds `['misc']`.
+    const metaPages = new Map([['ghost', ['misc']]]);
+
+    expect(rootCategoryDirs(['ghost'], metaPages)).toEqual(['ghost']);
+  });
+
+  it('excludes a category that published no page', () => {
+    // §2 writes no `meta.json` for a category with zero pages, so
+    // `categoryMetaPages` has no entry for it — the same "no meta.json ⇒
+    // absent" discipline the map already documents at its declaration site.
+    const metaPages = new Map<string, string[]>();
+
+    expect(rootCategoryDirs(['contracts'], metaPages)).toEqual([]);
+  });
+
+  it('sorts the result alphabetically, independent of input or map order', () => {
+    const metaPages = new Map([
+      ['zebra', ['a']],
+      ['alpha', ['b']],
+    ]);
+
+    expect(rootCategoryDirs(['zebra', 'alpha'], metaPages)).toEqual(['alpha', 'zebra']);
+  });
+
+  it('reproduces the real 14-category shape unchanged (#11482 "Measured")', () => {
+    // Every category on `origin/main` today has both `.zod.ts` files AND
+    // declared pages, so the old (`.zod.ts`-keyed) and new (`meta.json`-keyed)
+    // filters agree on all 14 — the byte-identical root `meta.json` the issue
+    // itself measured, and the acceptance bar this fix must not move.
+    const categories = [
+      'ai', 'api', 'automation', 'cloud', 'data', 'identity', 'integration',
+      'kernel', 'qa', 'security', 'shared', 'studio', 'system', 'ui',
+    ];
+    const metaPages = new Map(categories.map(c => [c, ['some-page']]));
+
+    expect(rootCategoryDirs(categories, metaPages)).toEqual([...categories].sort());
+  });
+});


### PR DESCRIPTION
Fixes #11482

## What

`build-docs.ts` §3 (`// 3. Update root meta.json`) built the ROOT
`content/docs/references/meta.json` — the sidebar's top-level category list —
by filtering on `categoryZodFiles` (the `.zod.ts` files found **on disk**), a
third, independent enumeration of "the pages of this category" alongside §2's
own `meta.json` and §2.5's card grid (both already keyed off
`categoryMetaPages` per #11260).

A category whose published pages all come from plain `.ts` files rather than
`.zod.ts` ones (the `misc` catch-all class — `security/misc` proves the shape
is real) has zero `.zod.ts` files while still publishing a page, a
`meta.json` and an `index.mdx`. The old filter would drop such a category
from the root sidebar even though §2 and §2.5 both fully generated it — a
folder complete on disk and unreachable from the nav.

§3 now reads `categoryMetaPages`, the same declared list §2.5 already reads,
via an extracted `rootCategoryDirs` (`scripts/lib/root-meta.ts`) — one answer
to "which categories exist," read three times, instead of three answers that
happened to agree today.

## Measured — no live instance, byte-identical output

No category is in the latent state today (all 14 have `zodFiles.size > 0`),
so this was a latent defect with no observable effect. Verified directly:

- `pnpm --filter @objectstack/spec gen:docs` before and after the fix
  produces a `content/docs/references/meta.json` with the **same sha256**
  (`41bb8932b11061fbc0bd6168b4087c5528ac75d41359be72db8bfd21b3106eef`) and an
  **empty `git diff`** across `content/docs/`.
- `pnpm --filter @objectstack/spec check:docs` passes clean (229 generated
  files in sync).

Because the edge this fixes has no live instance, it cannot be pinned from
generated output in either direction — the same reasoning #11260's
`category-index.test.ts` gives for the card-grid fix. The rule is pinned
directly in `scripts/root-meta.test.ts` against the extracted
`rootCategoryDirs`, with the misc-shaped fixture that has no repo instance
(an all-`misc` category with zero `.zod.ts` files), plus the empty/sort/
real-14-category shapes.

## Scope

`packages/spec/scripts/build-docs.ts` §3 only, its extracted
`scripts/lib/root-meta.ts`, the pin (`scripts/root-meta.test.ts`), and a
changeset. Not touched: #11601 (nested-item describe rendering — a different
defect class in the same file; that card is serialized behind this one and
was not addressed here).

## Tests

All run scoped to `@objectstack/spec` under the shared verify lock,
HEAD `900d16b`:

- `pnpm --filter @objectstack/spec build` — clean.
- `pnpm --filter @objectstack/spec exec vitest run scripts/root-meta.test.ts scripts/category-index.test.ts scripts/root-index.test.ts` — 3 files / 31 tests passed.
- `pnpm --filter @objectstack/spec typecheck` (`tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck`) — clean.
- `pnpm --filter @objectstack/spec check:docs` — clean, byte-identical root `meta.json` (see Measured above).
- `pnpm --filter @objectstack/spec exec vitest run` (full package suite) — **427 test files passed (427), 11352 tests passed (11352)**.
- `pnpm --filter @objectstack/spec run check:empty-state / check:liveness / check:strictness-ledger / check:variant-docs` — all clean.
- `npx eslint --no-inline-config --format json` scoped to exactly the 3 changed TS files — 0 errors / 0 warnings across all 3; this repo's ESLint config enables no type-aware linting for any file (`eslint.config.mjs`, documented at its `QUERY_OPTIONS_TEST_GLOBS` comment), so this 3-file scope cannot move judgment on any untouched file.
- Repo-root gates named by `node scripts/pm/dispatch-gates.mjs` for this diff: `check:changeset-gate-self-tests`, `check:merge-driver`, `check:objectui-changeset`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-empty-changeset.mjs`, `check-plugin-teardown-shape.mjs`, `docs-audit/check-affected-docs.mjs`, `docs-audit/check-drift-comment.mjs`, `release-rehearsal-clone.mjs --self-test` — all clean.
- Convention-triggered (new test file added): `check:query-options-erasure`, `check:engine-double-contract`, `check:cross-package-test-inputs`, `check:where-matcher`, `check:type-check-coverage` (structural) — all clean.
- Not run locally: `check-dev-prereqs.mjs` (full 78-package `pnpm build` precondition) and `check:type-check-debt --re-measure` (same full-workspace-build precondition) — out of scope for a single scripts-layer file per the local-verification-scope discipline; CI's own build step covers both, and the new file is fully covered by the existing `tsconfig.scripts.json` program with 0 errors, so it cannot move either ledger.

_Generated by [Claude Code](https://claude.ai/code/session_01NDGG54XF5gbTLdQzCtnaVV)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01NDGG54XF5gbTLdQzCtnaVV)_