### PR TITLE
feat(docs): serve a real /robots.txt and /sitemap.xml

### DIFF
--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from 'next';
+
+import { absoluteUrl } from '@/lib/site';
+
+/**
+ * `/robots.txt`.
+ *
+ * Before this file existed the path had no route at all, so `app/[lang]/page.tsx`
+ * matched it as `lang = "robots.txt"` and answered `200 text/html` with the
+ * homepage — a crawler asking for crawl rules got a web page. A literal segment
+ * outranks a dynamic one in the app router, so this file takes the path back; the
+ * `[lang]` catch-all swallowing *other* dotted paths is a separate defect and is
+ * not fixed here.
+ *
+ * Static: the content depends on nothing per-request.
+ */
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: absoluteUrl('/sitemap.xml'),
+  };
+}

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process';
+
+import type { MetadataRoute } from 'next';
+
+import { absoluteUrl } from '@/lib/site';
+import { blog, source } from '@/lib/source';
+
+/**
+ * `/sitemap.xml`.
+ *
+ * Same story as `app/robots.ts`: with no route here the path fell through to
+ * `app/[lang]/page.tsx` and answered `200 text/html`, so a sitemap submitted to
+ * Search Console would have failed to parse. Every indexable URL is derived from
+ * `source` / `blog` — never a hand-maintained list, which is guaranteed to rot the
+ * first time a page is added.
+ *
+ * Static: generated once at build, so the `git log` below runs in the build
+ * process and never in a request.
+ */
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+/** Repo-relative roots of the two MDX collections, matching `source.config.ts`. */
+const DOCS_CONTENT_ROOT = 'content/docs';
+const BLOG_CONTENT_ROOT = 'content/blog';
+
+/**
+ * `lastModified` comes from the git committer date of each source `.mdx`, not from
+ * build time. Build time would restamp all 400+ pages on every deploy, which tells
+ * a crawler that the whole site changed whenever anything did — a signal that gets
+ * discounted precisely because it is never false.
+ *
+ * One `git log` pass over both collections covers every file (~1s over 11k commits
+ * locally, measured), rather than one `git log` per page.
+ *
+ * When the date cannot be known — no git directory, or a clone shallow enough that
+ * no commit in the window touched the file — the entry ships **without**
+ * `lastModified`. `lastmod` is optional in the sitemap protocol, and omitting it is
+ * the honest answer; substituting build time would reintroduce the exact lie this
+ * function exists to avoid. Degrading silently is not on the table either: the
+ * build prints a counted warning naming the remedy.
+ */
+let cachedGitDates: Map<string, Date> | undefined;
+
+function loadGitDates(): Map<string, Date> {
+  if (cachedGitDates) return cachedGitDates;
+
+  const dates = new Map<string, Date>();
+  const git = (args: string[], cwd: string) =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+  try {
+    const repoRoot = git(['rev-parse', '--show-toplevel'], process.cwd()).trim();
+    const shallow = git(['rev-parse', '--is-shallow-repository'], repoRoot).trim() === 'true';
+    if (shallow) {
+      console.warn(
+        '[sitemap] the checkout is a shallow clone; pages whose last commit predates the ' +
+          'clone depth will ship without <lastmod>. Deepen the clone to restore the dates.',
+      );
+    }
+
+    // `--format` marker cannot collide with a path: no file under content/ starts
+    // with "commit-date:". `diff.relative=false` pins the printed paths to
+    // repo-root-relative regardless of local git config.
+    const log = git(
+      [
+        '-c',
+        'diff.relative=false',
+        'log',
+        '--format=commit-date:%cI',
+        '--name-only',
+        '--no-renames',
+        '--',
+        DOCS_CONTENT_ROOT,
+        BLOG_CONTENT_ROOT,
+      ],
+      repoRoot,
+    );
+
+    // `git log` is newest-first, so the first date seen for a path is its latest.
+    let current: Date | undefined;
+    for (const line of log.split('\n')) {
+      if (line.startsWith('commit-date:')) {
+        current = new Date(line.slice('commit-date:'.length));
+        continue;
+      }
+      if (!line || !current || dates.has(line)) continue;
+      dates.set(line, current);
+    }
+  } catch (error) {
+    console.warn(
+      `[sitemap] could not read commit dates from git (${
+        error instanceof Error ? error.message : String(error)
+      }); every entry will ship without <lastmod>.`,
+    );
+  }
+
+  cachedGitDates = dates;
+  return dates;
+}
+
+type SitemapEntry = MetadataRoute.Sitemap[number];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const dates = loadGitDates();
+  const undated: string[] = [];
+
+  /**
+   * `sourcePath` is repo-relative; `undefined` for routes with no MDX file behind
+   * them (the homepage, the blog index), which are not counted as missing dates.
+   */
+  const entry = (url: string, sourcePath?: string): SitemapEntry => {
+    const lastModified = sourcePath ? dates.get(sourcePath) : undefined;
+    if (sourcePath && !lastModified) undated.push(sourcePath);
+    return lastModified ? { url: absoluteUrl(url), lastModified } : { url: absoluteUrl(url) };
+  };
+
+  const byUrl = (a: SitemapEntry, b: SitemapEntry) => a.url.localeCompare(b.url);
+
+  // `getPages()` with no argument lists every language. English is the only one
+  // today, and a future locale belongs in the sitemap under its own prefixed URL,
+  // so leaving it unfiltered is the forward-correct spelling.
+  const docs = source
+    .getPages()
+    .map((page) => entry(page.url, `${DOCS_CONTENT_ROOT}/${page.path}`))
+    .sort(byUrl);
+
+  const posts = blog
+    .getPages()
+    .map((page) => entry(page.url, `${BLOG_CONTENT_ROOT}/${page.path}`))
+    .sort(byUrl);
+
+  if (undated.length > 0) {
+    console.warn(
+      `[sitemap] ${undated.length} of ${docs.length + posts.length} content pages have no git ` +
+        `commit date and ship without <lastmod>; first: ${undated.slice(0, 3).join(', ')}`,
+    );
+  }
+
+  // No `priority` or `changeFrequency`: Google ignores both, and inventing values
+  // for 400+ pages would put numbers into a machine-readable surface that nothing
+  // measured.
+  return [entry('/'), ...docs, entry('/blog'), ...posts];
+}

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical identity of the documentation site.
+ *
+ * The origin is a maintainer ruling, not configuration. Every absolute URL this
+ * site emits — sitemap entries, the `Sitemap:` line in `robots.txt`, and (as the
+ * remaining indexability work lands) `metadataBase`, canonical links and JSON-LD
+ * identifiers — must name this host and no other. Hard-coding it twice is how the
+ * two halves drift; hence one constant, imported.
+ *
+ * Deliberately NOT read from an environment variable. A preview deployment that
+ * derived its own origin would emit canonical links and a sitemap pointing at the
+ * preview host — precisely the duplicate-content signal a canonical link exists to
+ * suppress. One host, declared once, here.
+ */
+export const SITE_ORIGIN = 'https://objectstack.ai';
+
+/**
+ * Absolute URL for a **site-relative** path.
+ *
+ * `path` must start with `/`. Anything else throws at build time rather than
+ * quietly emitting a URL on the wrong host: `new URL(path, SITE_ORIGIN)` on its
+ * own would hand an already-absolute `https://elsewhere/...` straight back, and a
+ * sitemap listing another host is discarded wholesale by search engines rather
+ * than reported.
+ *
+ * Next's `metadataBase` wants a `URL` rather than a string — write
+ * `new URL(SITE_ORIGIN)` there, so this file stays the only place the origin is
+ * spelled out.
+ */
+export function absoluteUrl(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error(
+      `absoluteUrl() expects a site-relative path starting with "/", received ${JSON.stringify(path)}`,
+    );
+  }
+
+  return new URL(path, SITE_ORIGIN).toString();
+}


### PR DESCRIPTION
Fixes #12232

Part of the docs-site indexability epic #12243 (P0 lane).

`/robots.txt` and `/sitemap.xml` had no route, so `app/[lang]/page.tsx` matched them
as `lang = "robots.txt"` / `lang = "sitemap.xml"` and answered `200 text/html` with
the homepage. A crawler asking for crawl rules got a web page; a sitemap submitted to
Search Console would have failed to parse.

## What changed — 3 new files, 217 lines, nothing edited

| File | Purpose |
|:---|:---|
| `apps/docs/lib/site.ts` | the canonical origin, declared once |
| `apps/docs/app/robots.ts` | `text/plain` robots response naming the sitemap |
| `apps/docs/app/sitemap.ts` | every indexable URL, derived from `source` / `blog` |

## The shared origin constant — exactly what is exported

This card owns creating it. `apps/docs/lib/site.ts` exports **two** names and nothing
else:

```ts
export const SITE_ORIGIN = 'https://objectstack.ai';
export function absoluteUrl(path: string): string;
```

- `SITE_ORIGIN` — the origin only, no trailing slash. Maintainer ruling, recorded in
  #10659, verbatim and untranslated:
  > 这个仓的文档站规范 URL 是 https://objectstack.ai
- `absoluteUrl(path)` — joins a **site-relative** path onto that origin.
  `path` must start with a slash; anything else **throws at build time** rather than
  quietly emitting a URL on the wrong host. `new URL(path, SITE_ORIGIN)` alone would
  hand an already-absolute `https://elsewhere/...` straight back, and a sitemap
  listing a foreign host is discarded wholesale rather than reported.

Notes for the two cards that import this next round:

- **#12234 (`metadataBase`)** — Next wants a `URL` object, not a string. Write
  `metadataBase: new URL(SITE_ORIGIN)`. That is the intended spelling, and it is
  documented in the file so a second origin literal never appears. A module-level
  shared `URL` instance is deliberately **not** exported: `URL` is mutable, so one
  consumer assigning `.pathname` would silently move the origin for every other.
- **#12240 (JSON-LD)** — use `absoluteUrl()` for every `@id` / `url`.
- No environment-variable override, deliberately. A preview deployment deriving its
  own origin would emit canonical links and a sitemap pointing at the preview host,
  which is exactly the duplicate-content signal a canonical link exists to suppress.
- No `SITE_NAME` / title / description constants: nothing in this card needs them,
  and inventing surface for a consumer that has not landed is how a shared module
  starts collecting things nobody reads.

## `lastModified`: git committer date, not build time

One `git log` pass over both content collections, run once at build:

```
git -c diff.relative=false log --format=commit-date:%cI --name-only --no-renames \
    -- content/docs content/blog
```

**Cost, measured, not assumed: 1.0s over 11,231 commits** for all 406 content files.
The suggested alternative in the card — one `git log` per file — would be 406 git
processes; this is one. So the cheap honest signal and the good one are the same
signal here, and there was no trade to make.

Why not build time: it restamps 400+ pages on every deploy, which tells a crawler the
whole site changed whenever anything did — a signal discounted precisely because it is
never false.

**When the date cannot be known, the entry ships with no `lastmod` element at all**
(no git directory; or a clone shallow enough that no commit in the window touched the
file). `lastmod` is optional in the sitemap protocol, so omitting it is the honest
answer, and substituting build time would reintroduce the exact lie the git date
exists to avoid. It does not degrade *silently*, either: the build prints a counted
warning naming the remedy — a shallow-clone note, or a per-page count with the first
three paths. On this build that warning count is **0**.

## PM dispatch assumptions — all four verified, none falsified

1. **No `robots.ts` / `sitemap.ts` in `apps/docs/app/`** — confirmed on `origin/main`.
2. **Production serves both as `200 text/html`** — re-measured today against
   `https://objectstack.ai`, unchanged:
   ```
   $ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" https://objectstack.ai/robots.txt
   200 text/html; charset=utf-8
   $ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" https://objectstack.ai/sitemap.xml
   200 text/html; charset=utf-8
   ```
3. **`source.getPages()` is the right source** — confirmed; no list is hand-maintained.
   Note `getPages()` with no argument lists *every* language (fumadocs `LoaderOutput`);
   English is the only one today, and a future locale belongs in the sitemap under its
   own prefixed URL, so it is left unfiltered on purpose.
4. **A literal `app/robots.ts` beats the single-segment `[lang]` dynamic route** —
   **confirmed, in both dev and a production build.** Measurements below. This is the
   assumption the PM asked to have tested; it holds, so #12233 is not a blocker for
   this card. The converse also holds and is worth recording for #12233: an unrelated
   dotted path still renders the homepage after this change, so this PR fixes exactly
   two paths and does not touch that defect.

## Measurements

### Dev server (`next dev -p 38412`)

```
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:38412/robots.txt
200 text/plain
$ curl -s http://localhost:38412/robots.txt
User-Agent: *
Allow: /

Sitemap: https://objectstack.ai/sitemap.xml

$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:38412/sitemap.xml
200 application/xml
```

### Production build (`next build`, exit 0)

Route table — both are `○ (Static) prerendered as static content`, so the `git log`
runs in the build process and never in a request:

```
├ ○ /robots.txt
└ ○ /sitemap.xml
```

### Production server (`next start -p 38413`)

```
$ curl -sI http://localhost:38413/robots.txt | head -5
HTTP/1.1 200 OK
x-nextjs-cache: HIT
cache-control: public, max-age=0, must-revalidate
content-type: text/plain

$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:38413/sitemap.xml
200 application/xml
```

The sitemap's first line is an XML declaration, not HTML.

### Acceptance criteria

| Criterion | Result |
|:---|:---|
| `robots.txt` is `200 text/plain` and the body names the sitemap | pass |
| `sitemap.xml` starts with an XML declaration, not HTML | pass — and `content-type: application/xml` |
| URL count = `find content/docs -name '*.mdx' \| wc -l` + non-docs routes | **408 = 403 + 5** (403 docs, plus `/`, `/blog`, and 3 blog posts) |
| no absolute URL names a host other than `objectstack.ai` | pass — `grep -o` over every `loc` element yields exactly one host |

`lastmod` element count is **406** — every one of the 403 docs pages and 3 blog posts.
The 2 URLs without one are `/` and `/blog`, which have no MDX file behind them. Three
dates spot-checked against `git log -1 --format=%cI` on the source file: all three match
to the second.

### Neighbouring routes, unchanged

| Path | Before and after |
|:---|:---|
| `/en/docs` | `307` to `/docs` — the epic asks that this not break; it does not |
| `/llms.txt` | `200 text/plain` |
| `/docs/upgrading.mdx` | `200 text/markdown` |
| an unrelated dotted path | `200 text/html` — #12233's defect, untouched |

## Scope: what robots.txt deliberately does NOT contain

`User-agent: *` / `Allow: /` and the `Sitemap:` line, and nothing else. No `Disallow`
for `/api`, `/og`, `/docs/**.mdx` or `llms*.txt`:

- crawl hygiene for the `.mdx` parallel copy is **#12241**, and two PRs editing the
  same handful of lines in the same file is a conflict for no gain — that card can add
  its directive on top of this file;
- `/og` in particular must stay crawlable, or the OG cards **#12235** is about would
  stop rendering for the crawlers that fetch them.

No `priority` or `changeFrequency` on any entry: Google ignores both, and inventing
values for 408 URLs would put numbers into a machine-readable surface that nothing
measured.

## Verification

All at `e02a77cc7`, the final commit on this branch.

| Command | Result |
|:---|:---|
| `pnpm --filter '@objectstack/docs^...' build` | `VERDICT command-exit 0` |
| `pnpm --filter @objectstack/docs typecheck` | `VERDICT command-exit 0` |
| `next build` (apps/docs) | exit 0 |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`) | `VERDICT command-exit 0`, 28s, no findings — the **full** farm scan, not a narrowed one |
| `pnpm check:published-files` | `✓ ... 69 publishable package(s) ...` |
| `pnpm check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `pnpm check:type-source-resolution` | `check-type-source-resolution OK — 93 tsc program(s) across 77 packages scanned` |
| `pnpm check:nul-bytes` | `check-nul-bytes: OK (scanned 6772 text file(s) ... no raw ASCII control bytes)` |

The first three gate families are the ones
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derives for
these three paths, re-derived from a tree at `origin/main` after the branch was
fast-forwarded (the first derivation ran against a stale tree and said so).
`check:nul-bytes` is added because the diff is an edit.

**Declared narrowing — verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh`
could not take the shared verify lock on this host: no usable `flock` (the lock is
declared Linux-only; a stock macOS does not ship util-linux). Every wrapped command
above therefore ran directly, without the lock — a declared narrowing, not a silent
one. No serialization guarantee held for those runs.

## Landing

Docs-site only, no published package changes, so **no changeset** — the
`skip-changeset` label carries that, applied to this PR.

---

_Generated by [Claude Code](https://claude.ai/code/session_f9f0958b-ab68-46cc-801c-216aa7ee2107)_
