### PR TITLE
docs(skills): correct the automation "Verify your work" passage — conditions fail loudly at registration, node values fail at run time

### DIFF
--- a/skills/objectstack-automation/SKILL.md
+++ b/skills/objectstack-automation/SKILL.md
@@ -938,9 +938,9 @@ them right the first time:
     `today()`, `daysFromNow(n)`, `daysAgo(n)`, `daysBetween(a, b)`, `isBlank(v)`,
     `coalesce(a, b)`, `abs/round/min/max`, `upper/lower/contains/matches`, plus CEL
     built-ins (`has`, `size`, `int`, `string`, …) — see **objectstack-formula** for the full table.
-    An UNKNOWN function (`PRIOR()`, a typo'd name) **fails the build**. And never
-    wrap a field reference in `{…}` inside a condition — that's a template brace
-    and fails as CEL: write `record.x`, not `{record.x}`.
+    An UNKNOWN function (`PRIOR()`, a typo'd name) and a `{…}`-wrapped field ref
+    both **fail the build**: a brace is a template, not CEL — write `record.x`,
+    not `{record.x}`.
 
 ---
 
@@ -962,24 +962,27 @@ metadata first; reserve custom code for edge-case integrations.
 
 ## Verify your work
 
-Flow predicates fail **silently at runtime** when malformed: a typo'd field
-name, an unknown function, or a `{…}`-wrapped reference in a condition
-evaluates to `null`/`false`, so the flow "fires" but does nothing — and nothing
-errors at edit time. (Bare field refs like `status == 'open'` DO resolve in
-start/decision/edge conditions — the engine flattens the trigger record's
-fields into scope — but `record.status == 'open'` remains the canonical style.)
-Catch it at author time before reporting a flow done:
+**Conditions and declared bare-CEL slots** (`condition`, a screen's
+`visibleWhen`) are validated at flow **registration** and by the build: a
+syntax error, an unknown function (`PRIOR()`) or a `{…}`-wrapped reference
+**throws**, located and corrective — never silent.
+
+**Node values** take the single-brace `flow-template` dialect (`'{round(x)}'`);
+no validator implements it, so an unknown function there is NOT build-checked —
+it throws `FlowExpressionFunctionError` at **run time**.
+
+The quiet case is a typo'd *field* name: bare refs (`status == 'open'`) DO
+resolve (the engine flattens the record's fields into scope), so a typo is only
+an advisory did-you-mean. `record.status` stays canonical; `os validate` errors
+on unknown `record.<field>`:
 
 ```bash
 os validate     # CEL/predicate validation (record.<field> existence) + schema
 # or: os build  # the same gates, plus emits dist/
 ```
 
-This runs the ADR-0032 expression gate over every flow condition, edge guard,
-validation rule and sharing rule, exiting non-zero with a
-located, corrective message. Remember conditions are **bare CEL**
-(`record.status == 'x'`); only string node fields use `{…}` templates — see
-objectstack-formula. In a scaffolded project this is `npm run validate`.
+It runs the ADR-0032 gate over every condition, edge guard, validation and
+sharing rule, exiting non-zero. In a scaffolded project: `npm run validate`.
 
 ---
 


### PR DESCRIPTION
Closes #12092

`skills/objectstack-automation/SKILL.md`'s `## Verify your work` opening taught that a typo'd field name, an unknown function, **and** a `{…}`-wrapped reference in a condition all fail *silently at runtime*. Two of those three were false, and the same file's Common Pitfalls row (item 10) said the opposite — so the published skill contradicted itself and taught an AI author to hunt for a silence the platform does not have.

## What the landed engine actually does — verified against this tree, not the card

Every behavioural claim in the new text was re-verified against `origin/main` at `eeec62a98`:

| Surface | Behaviour | Evidence in this tree |
|:--|:--|:--|
| Conditions + declared bare-CEL slots | **Fatal at flow registration** — syntax, brace-in-CEL, unknown function | `AutomationEngine.validateFlowExpressions` (`packages/services/service-automation/src/engine.ts:5304`) runs the fatal pass over `config.condition`, `edge.condition` and every `predicate`-role slot in `FLOW_NODE_EXPRESSION_PATHS`, then **throws** with location + source + corrective hint |
| Unknown function specifically | Rejected as a CEL type fault, never reached at run time | `celEngine.compile` returns `kind: 'type'` for `PRIOR(status)`; pinned by `packages/formula/src/cel-engine.test.ts` ("compile() rejects an unknown function as a type error") and `validate.test.ts` ("rejects an unknown function call", incl. behind a short-circuit) |
| Node **values** (`flow-template` single-brace dialect) | **Not** function-checked at build; loud at run time | `validateFlowExpressions` skips `flow-template` slots by design — "no validator implements their dialect"; `interpolateString` throws `FlowExpressionFunctionError` (`builtin/template.ts:55`, `unknownFunctionError` at `:167`) |
| Typo'd **field** name | The one genuinely quiet case | the schema-aware pass is `logger.warn`-only ("logged, never thrown… strictly additive"); a near-miss bare ref is a `warnings.push` did-you-mean in `packages/formula/src/validate.ts`. `checkFieldExistence` *does* push a hard **error** for an unknown `record.`-prefixed field reference — which is why the new text says `os validate` errors on that spelling |

This does not contradict the value-expression half that landed with #11348 / PR #12093 — it states the same asymmetry from the other side and points at the same named error.

## Second edit in the same diff, declared

The Common Pitfalls item 10 tail was tightened in the same commit. It is not drive-by scope: it was the *other half* of the contradiction the card names, stating the same two facts (unknown function, brace-in-CEL) in longer form. Both facts survive verbatim in meaning:

- before — `An UNKNOWN function (…) **fails the build**. And never wrap a field reference in {…} inside a condition — that's a template brace and fails as CEL: write record.x, not {record.x}.`
- after — `An UNKNOWN function (…) and a {…}-wrapped field ref both **fail the build**: a brace is a template, not CEL — write record.x, not {record.x}.`

It is also part of how the rewrite pays for itself under the ratchet.

## Token budget — ⛔ ceiling untouched, change is token-NEGATIVE

Ceiling stays **12643** (set by #12093 under a quoted maintainer ruling). No ceiling was raised, and none was lowered — the ratchet prints headroom on every run, so the shrink is already visible without editing the shared ceiling map.

| Reading | Before | After | Δ |
|:--|--:|--:|--:|
| `skills/objectstack-automation/SKILL.md` — tokens | 12643 | **12642** | **−1** |
| `skills/objectstack-automation/SKILL.md` — lines | 992 | 995 | +3 |
| Published bundle — tokens (all 11 `SKILL.md`) | 117851 | **117850** | **−1** |
| Published bundle — lines | 10512 | 10515 | +3 |

Lines rise while tokens fall because the new prose rewraps shorter; the ratchet's unit is `ceil(utf8 bytes / 4)`, and bytes went 50571 → 50568. Paid for by genuine deletion, not a re-wrap: the old passage's redundant closing paragraph ("Remember conditions are **bare CEL**… only string node fields use `{…}` templates — see objectstack-formula") is gone, since the new opening states the dialect split precisely, and item 10 was tightened as above.

Gate's own verdict line:

```
✓ check-skills-token-ratchet: skills/objectstack-automation/SKILL.md is 12642 tokens (ceiling 12643; headroom 1).
✓ check-skills-token-ratchet: 11 published SKILL.md within their ceilings.
```

## Verification — all green at `f5d58e095`

Gate set derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (11 families matched), re-derived after the commit and unchanged. Each verdict below is the gate's **own** printed line; exit codes were captured before any pipe.

```
✓ check-agent-test-spelling: 0 violations — 378 file(s) …
OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.   [check:cross-package-test-inputs]
✓ doc authoring guard: 390 files clean — no bare metadata literals.
✓ doc authoring guard: 48 published skill files clean — no internal issue-id references.
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 422 files / 1449 TS blocks judged clean by @objectstack/formula.
✓ check:doc-formula-expressions (field-level `*When`, #11407): 14 predicate(s) on a statically determinable field layer judged clean; 6 skipped as undeterminable.
✓ check-governed-merges --self-test: 129 assertions …
check-role-word: OK, no new occurrences of the reserved word.
✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 78 workspace packages
✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files
OK: all 96 declared cross-package glob(s) (81 unique) are covered by `core` or `crosspkg` …   [check-ci-filter-parity]
✓ check-skills-token-ratchet: 11 published SKILL.md within their ceilings.
check-nul-bytes: OK (scanned 6766 text file(s) … no raw ASCII control bytes).
```

Plus the three `SKILL.md`-triggered spec artifact gates AGENTS.md names, which the path derivation scores *silent* (their populations are generated artifacts) and which a body edit can genuinely stale:

```
✅ 9 generated files in sync with packages/spec        [check:skill-refs]
✅ Skill docs in sync                                  [check:skill-docs]
✅ 256 prose examples type-check across 3 surface(s)   [check:skill-examples]
```

Two of those needed a build prerequisite in a fresh worktree before they measured anything — `@objectstack/formula` + `@objectstack/lint` for `check:doc-formula-expressions`, `@objectstack/client-react` for `check:skill-examples`. Both refused loudly rather than reporting a false green; the verdicts above are from the runs after those builds.

**No changeset** — published-skill prose, nothing user-facing is published by it; `skip-changeset` applied.

⛔ Governed surface (`skills/**`) — **draft, human merge only**. Not to be queued, armed for auto-merge, or flipped ready (AGENTS.md Prime Directive #14).

Review from `os-zhuang` could not be requested through the API: under the shared agent identity `os-zhuang` is this PR's author, and GitHub refuses `Review cannot be requested from pull request author`. Flagged for the PM rather than worked around.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMTpSRF5CjMmQBFfPtPCwJ)_