### PR TITLE
fix(scripts): correct bash-3.2 comment's stated mechanism in bump-objectui.sh

### DIFF
--- a/scripts/bump-objectui.sh
+++ b/scripts/bump-objectui.sh
@@ -339,8 +339,15 @@ report_objectui_reachability() {
   # (`enable -n mapfile readarray` via `BASH_ENV`) plus a static scan.
   # Keep this loop bash-3.2-clean: no `mapfile`, no `readarray`, no
   # `declare -A`, no `${x^^}`/`${x,,}`. The `if` (rather than `[[ … ]] &&`) is
-  # load-bearing under `set -e`: a trailing false `&&`-list would make the
-  # whole `while` return 1 and kill the run on an empty ref list.
+  # load-bearing under `set -e` — but NOT on an empty ref list: an all-empty
+  # read leaves the loop body unexecuted and the `while` exits 0 either way
+  # (measured, bash 5.2.21). The real trap is a NON-EMPTY read whose LAST
+  # line fails the `[[ -n … ]]` test, and only once that loop is the LAST
+  # command of a function: the `&&`-list's false status becomes the loop's
+  # exit status, which becomes the function's return, which `set -e` then
+  # kills the caller on. Measured over all four combinations (empty vs.
+  # non-empty-with-failing-last-line × loop-is-fn's-last-command vs. not):
+  # only that one combination dies (exit 1); the other three exit 0.
   local -a local_refs=() remote_refs=()
   local ref_line=''
   while IFS= read -r ref_line; do


### PR DESCRIPTION
Fixes #12222

## What

`scripts/bump-objectui.sh`'s bash-3.2 comment explaining why the ref-collection loop uses
`if [[ -n "$x" ]]; then …; fi` rather than a trailing `[[ … ]] && …` attributed the trap to
the **empty-list** case. Measured on bash 5.2.21, that does not reproduce: an all-empty read
leaves the loop body unexecuted and the `while` exits 0. The real trap is a **non-empty**
read whose **last** line fails the test, and only once that loop is the **last command of a
function** — the `&&`-list's false status becomes the loop's exit status, becomes the
function's return, and `set -e` kills the caller on that.

The `if` form itself is unchanged — this PR touches only the comment's stated reason, not
behavior.

## Scope

Declared file surface: the one comment in `scripts/bump-objectui.sh` (lines 341-343 → the
corrected block). Nothing else changed:
- The loop's `local x=''` note is untouched (a separate, correct `set -u` point).
- No code changed — the `if` form stays exactly as written.
- PR #12142's body (where the wrong claim was first stated) is immutable history and out
  of scope per the card.

## Verification — the measured mechanism

Constructed all four combinations under `bash --version` 5.2.21 (`set -euo pipefail`, loop
body `[[ -n "$x" ]] && arr+=(...)`):

| case | input | loop position | exit status |
|---|---|---|---|
| 1 | empty | last command of function | **0** |
| 2 | empty | NOT last command of function | **0** |
| 3 | non-empty, last line fails test | last command of function | **1** (killed) |
| 4 | non-empty, last line fails test | NOT last command of function | **0** |

Only case 3 dies — confirming the corrected comment's claim and refuting the original
empty-list attribution (cases 1 and 2 both exit 0 regardless of loop position).

## Gates run (final commit `a4dc82450d`)

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at the final commit
names 8 matched local families for this diff (no STALE TREE warning); all run via the
shared verify lock, all exit 0:

- `pnpm check:agent-test-spelling` — 0
- `pnpm check:cli-command-ids` — 0 (`✓ check-cli-command-ids: 276 command-id literal(s) … 1 baselined violation(s)` — pre-existing baseline entry, unrelated to this diff)
- `pnpm check:cross-package-test-inputs` — 0 (`All 117 self-test cases passed.`)
- `pnpm check:entry-guard` — 0 (`✓ check:entry-guard: 167 scripts/ file(s) …`)
- `pnpm check:parse-guard` — 0
- `pnpm check:pnpm-filter-targets` — 0 (`✓ check:pnpm-filter-targets: 136/173 …`)
- `node scripts/check-ci-filter-parity.mjs` — 0 (`OK: all 96 declared cross-package glob(s) …`)
- `node scripts/check-cross-package-test-inputs.mjs` — 0

Also ran `pnpm check:objectui-changeset` (the R7 leg this file touches, per the claim
comment's flagged hazard) — exit 0, self-test line `✓ objectui-range --self-test: all
checks passed`, R7 line reads `✓ #12071 R7 bump-objectui.sh names no bash 4+/5 construct
(mapfile, ${x^^}, declare -A, &>>, EPOCH*)`. The correction is on full-line comments only
(no trailing comment on a code line), so R7's `^\s*#` exemption applies cleanly.

No changeset — this PR publishes nothing (a shell comment correction) — `skip-changeset`
label applied via the read→union→add flow (REST surface closed from this dev seat, #12123).

_Generated by [Claude Code](https://claude.ai/code/session_af22b339-91b5-5814-8b9b-2453fc5b3f68)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_