### PR TITLE
fix(devx): the driver-conformance coverage scan reads code, not prose

### DIFF
--- a/scripts/check-driver-conformance.mjs
+++ b/scripts/check-driver-conformance.mjs
@@ -81,6 +81,18 @@
 // the failure mode that actually happened: three drivers silently not running a
 // standard three changesets said they were held to.
 //
+// A MENTION is not a reference (#12135). The scan reads CODE: every file is
+// passed through `scripts/js-comment-mask.mjs` before the import-and-reference
+// rule is applied, so a docblock that names a marker cannot make a cell green.
+// It used to be able to, and the shape was live on this tree -- `sql-driver.ts`
+// and `mongodb-filter.ts` are driver IMPLEMENTATIONS that name
+// `FILTER_LOGIC_CASES` only in prose, and both were scored as covering files.
+// It changed no cell's verdict, because both cells are genuinely covered by a
+// real suite as well; that is precisely why it had to be fixed on a day it was
+// harmless. Delete a driver's only suite for a case-set and leave the sentence
+// that describes it, and the cell stayed green -- a coverage claim satisfied by
+// prose, which is the declared-not-enforced shape this gate exists to close.
+//
 // ## DEBT is frozen debt, not a permission slip
 //
 // Every entry was measured against `main`. To clear one: write the suite, then
@@ -941,9 +953,14 @@ function walkTsInto(dir, out) {
  * behind. Extracted so the dialect axis asserts a stance the same way this
  * script asserts a case-set, rather than inventing a second idiom next to it.
  *
- * @param {string} src file text — pass it through `stripComments` when a
- *   comment mentioning the symbol must not count. (`consumes` deliberately does
- *   not, so its verdicts stay byte-identical to what they were.)
+ * @param {string} src file text. This function reads whatever TEXT it is given
+ *   and has no opinion about comments — both callers strip first, because on
+ *   both axes a comment mentioning the symbol must not count
+ *   ({@link coveringFiles} via {@link codeOf}, `dialectStance` via its own
+ *   `stripComments`). Kept comment-agnostic rather than stripping in here so
+ *   that `dialectStance`, which already holds stripped text and applies this
+ *   rule to several symbols in a row, does not re-mask the same text per
+ *   symbol.
  */
 function drivenFrom(src, symbol, specifier) {
   if (!src.includes(symbol)) return false;
@@ -964,13 +981,49 @@ function drivenFrom(src, symbol, specifier) {
  * different dialect stances, and scoring only the first would let an
  * undeclared one hide behind a matrix-routed sibling — which is exactly the
  * arrangement FILTER_TEXT_CASES is in on this tree.
+ *
+ * Read through {@link codeOf}, so a marker named only in PROSE is not coverage
+ * (#12135). Measured when that was added, over 5 drivers x 9 case-sets: the
+ * covered-cell count did not move (45 -> 45) and no cell changed hands, because
+ * the two files whose answer flipped are driver implementations whose cells are
+ * covered by a real suite too. What moved is WHICH files this returns, which
+ * the dialect axis scores and which `consumes` quotes back to the author.
  */
 function coveringFiles(driverDir, marker) {
   const hits = [];
   for (const file of walkTs(join(driverDir, 'src'))) {
-    if (drivenFrom(readFileSync(file, 'utf8'), marker, '@objectstack/spec/data')) hits.push(file);
+    if (drivenFrom(codeOf(file), marker, '@objectstack/spec/data')) hits.push(file);
   }
   return hits;
+}
+
+/**
+ * This file's text with its COMMENT spans gone — the only form the coverage
+ * scan is allowed to read.
+ *
+ * `stripComments` rather than `maskComments`, on the discriminator
+ * `js-comment-mask.mjs` documents rather than on which one was already
+ * imported: pick `maskComments` when the caller reports a LINE or a byte offset
+ * into the original text, `stripComments` when it feeds a scanner and reports
+ * neither. This axis reports FILES — `consumes` returns a path, the RECONCILED
+ * and CONSUMED messages quote a path — so nothing downstream can be made wrong
+ * by the offsets moving, and the deleting form is the one that stays cheap
+ * (the same module records a gate that took 51x longer on `maskComments`,
+ * because a scan over the whitespace runs blanking leaves is quadratic in the
+ * comment bytes).
+ *
+ * Deliberately NOT memoised per path, though the walk is per (driver x marker)
+ * and so re-reads each file once per marker. A cache here is a correctness
+ * hazard for the only caller that rewrites a file between two calls — the
+ * self-test, which writes three different bodies to one `a.test.ts` path and
+ * asserts a different verdict for each. A stale entry would make those three
+ * assertions read the first body and pass in a way no refactor could disturb,
+ * which is the failure this file's own #4930 note is about: a guard reporting a
+ * verdict it did not measure. Measured cost of not caching: the whole gate runs
+ * in ~0.4s over this tree.
+ */
+function codeOf(file) {
+  return stripComments(readFileSync(file, 'utf8'));
 }
 
 /**
@@ -1377,6 +1430,67 @@ function selfTest() {
     expect(
       'local re-declaration must not count as coverage',
       consumes(tmp, 'PAGINATION_CASES') === null,
+    );
+
+    // #12135 — a marker named only in PROSE must not count as coverage.
+    //
+    // The fixture is the shape that was LIVE on this tree, not an invented one:
+    // real imports from the case-set module at the top, the marker mentioned in
+    // a line comment among them and again in a docblock far below, and no
+    // reference to it anywhere in the code. `sql-driver.ts` and
+    // `mongodb-filter.ts` — two driver implementations, neither a suite — both
+    // scored as covering files for FILTER_LOGIC_CASES this way.
+    //
+    // The first assertion is what keeps the second one falsifiable. A fixture
+    // the old detector would ALSO have rejected pins nothing: it would go green
+    // the day someone reverts `codeOf`, and the case would read as a guard
+    // while guarding nothing. So the raw text is asserted to be a case the
+    // unmasked rule ACCEPTS, and only then is the real detector asserted to
+    // refuse it. Revert the masking and this pair fails on the second line.
+    const proseOnly = [
+      "import { TEMPORAL_CASES } from '@objectstack/spec/data';",
+      "// The `PAGINATION_CASES` table this driver's conformance suite runs; this",
+      '// file only compiles the paging clause it exercises.',
+      "import { FILTER_LOGIC_CASES } from '@objectstack/spec/data';",
+      '',
+      'export function compile() { return [TEMPORAL_CASES, FILTER_LOGIC_CASES]; }',
+      '',
+      '/**',
+      ' * Kept in step with the `PAGINATION_CASES` table above.',
+      ' */',
+      'export const VERSION = 1;',
+      '',
+    ].join('\n');
+    writeFileSync(join(tmp, 'src', 'a.test.ts'), proseOnly);
+    expect(
+      '#12135 — the prose-only fixture IS accepted by the unmasked rule (else the case below '
+        + 'pins nothing and would survive a revert)',
+      drivenFrom(proseOnly, 'PAGINATION_CASES', '@objectstack/spec/data'),
+    );
+    expect(
+      '#12135 — a marker mentioned only in a comment must not count as coverage',
+      consumes(tmp, 'PAGINATION_CASES') === null,
+    );
+    expect(
+      '#12135 — and the file is not returned as a covering file either (the dialect axis scores '
+        + 'these, and `consumes` quotes one back to the author)',
+      coveringFiles(tmp, 'PAGINATION_CASES').length === 0,
+    );
+
+    // The mirror: prose about the marker does not DISARM a genuine reference.
+    // Over-masking would be the quiet direction to fail in here — every cell
+    // still green, coverage now judged by a rule that cannot see a suite whose
+    // author documented it.
+    writeFileSync(
+      join(tmp, 'src', 'a.test.ts'),
+      proseOnly
+        + "import { PAGINATION_CASES } from '@objectstack/spec/data';\n"
+        + 'for (const c of PAGINATION_CASES) {}\n',
+    );
+    expect(
+      '#12135 — a real driving reference still counts when the same file also discusses the '
+        + 'marker in prose',
+      consumes(tmp, 'PAGINATION_CASES') !== null,
     );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
@@ -1787,7 +1901,9 @@ function selfTest() {
     process.exit(1);
   }
   console.log(
-    'OK  self-test: detects driven / unused / re-declared fixtures, discovers both axes, accounts for '
+    'OK  self-test: detects driven / unused / re-declared / prose-only fixtures (#12135 — a marker '
+      + 'named only in a comment is not coverage, proven against a fixture the unmasked rule '
+      + 'accepts, and a documented suite is still coverage), discovers both axes, accounts for '
       + 'every entry under DRIVERS_DIR (a dropped or manifestless row is red, not a smaller matrix), '
       + 'holds the dead-root hard error (red when a scan root is renamed, green when restored), and '
       + 'keeps CONSUMED\'s ledger offer marked maintainer-only (#8435). It also declares the driver '


### PR DESCRIPTION
Fixes #12135

`coveringFiles()` answered "does this driver drive this case-set" from **raw file text**, so a marker named only in a comment satisfied the import-and-reference rule. The dialect axis that landed in #12134 already routes through `scripts/js-comment-mask.mjs` for exactly this reason, and the two axes disagreed with each other inside one file: the dialect axis refused a mention, the coverage axis accepted one.

## The change

One line of behaviour: `coveringFiles` reads through a new `codeOf()` helper that strips comments before `drivenFrom` sees the text. Declared surface held to `scripts/check-driver-conformance.mjs` — no driver source, no driver test, no change to `js-comment-mask.mjs`.

**`stripComments`, not `maskComments`** — chosen on the discriminator `js-comment-mask.mjs` documents, not because `stripComments` was already imported. That module's rule is: *reports a LINE or a byte offset into the original text → `maskComments`; feeds a scanner and reports neither → `stripComments`.* This axis reports **files** — `consumes` returns a path, and the CONSUMED and RECONCILED messages quote a path — so nothing downstream can be made wrong by offsets moving, and the deleting form is the one that stays cheap (the same module records a gate that ran 51x slower on `maskComments`, because scanning the whitespace runs blanking leaves is quadratic in the comment bytes).

## Measured: the headline does not move, and no cell changes hands

Swept 5 drivers x 9 case-sets, raw vs masked, with `drivenFrom` copied verbatim:

```
covered cells raw   : 45
covered cells masked: 45
(driver, marker) coverage answers that CHANGE: 0
```

**The number asked for: 0 of 45 cells move.** The gate's headline is `45 covered cell(s), 0 in the DEBT ledger, 0 exempt` before and after. No cell moves into the DEBT ledger, so no published number changes and no measured ledger entry is owed.

Two **per-file** covering answers flip, and both are driver *implementations* rather than suites:

| file | marker | raw | masked |
|---|---|---|---|
| `packages/drivers/driver-sql/src/sql-driver.ts` | `FILTER_LOGIC_CASES` | covering | not covering |
| `packages/drivers/driver-mongodb/src/mongodb-filter.ts` | `FILTER_LOGIC_CASES` | covering | not covering |

Both cells stay green because each is genuinely covered by a real suite as well — which is precisely why the defect had to be fixed on a day it was harmless. Neither cell's *evidence file* moves either: walk order already put a real suite first, so no `consumes()` path quoted back to an author changes.

**The card's specific example holds**, and the PM had not verified it. `sql-driver.ts` was not merely matched internally — the gate printed it:

```
note  packages/drivers/driver-sql/src/sql-driver.ts covers a cell but is not a test file — nothing
      executes, so it carries no dialect stance and is not scored on this axis.
```

That note is the **only** line of gate output this PR changes: it is gone, because the driver implementation is no longer scored as a covering file. `mongodb-filter.ts` was never printed — `driver-mongodb` is single-backend, so the dialect axis never reaches it. It was found by measurement, not by reading the report.

## Ablation — direction predicted in writing first, then observed

**Leg A — revert the masking.** Predicted: the two new self-test cases turn red; the precondition case stays green because it asserts raw behaviour. On-disk proof anchored to the changed text (`stripComments`-form before=1 after=0; raw-form after=1), not to a bare `git diff --stat`. Observed, exactly:

```
ABLATED SELFTEST EXIT=1
  x self-test: #12135 — a marker mentioned only in a comment must not count as coverage
  x self-test: #12135 — and the file is not returned as a covering file either …
```

**Leg B — a real covering file's reference made comment-only.** `memory-aggregation-conformance.test.ts` is the sole covering file for `driver-memory x AGGREGATION_CASES`; its two live `for (const c of AGGREGATION_CASES)` lines were commented out, leaving the import and two docblock mentions — the exact shape found on `sql-driver.ts`. On-disk proof: live code refs 2 → 0, injected comment refs = 2, import line kept = 1. Predicted: covered → MISSING, gate red. Observed:

```
FIXED-DETECTOR EXIT=1
  x CONSUMED: driver-memory does not run AGGREGATION_CASES …
check-driver-conformance: 1 problem(s).

OLD raw detector on the SAME mutated bytes  : true
NEW masked detector on the SAME mutated bytes: false
```

The last two lines are the defect itself: identical bytes, opposite verdicts. Both legs ran under a `trap … EXIT INT TERM` restore. Restores proved byte-identical — the `git hash-object` of the restored file equals its `git rev-parse` blob id at HEAD, for both files, and `git status --porcelain` is empty. No rebuild leg applies: this gate is a `.mjs` script run directly from source, with no `dist/` between the edit and the measurement.

## Self-test

Three cases added, and the first is what keeps the others falsifiable. A fixture the **old** detector would also have rejected pins nothing — it would go green the day someone reverts `codeOf`. So the raw text is first asserted to be a case the unmasked rule *accepts*, and only then is the real detector asserted to refuse it:

- `#12135 — the prose-only fixture IS accepted by the unmasked rule (else the case below pins nothing …)`
- `#12135 — a marker mentioned only in a comment must not count as coverage`
- `#12135 — and the file is not returned as a covering file either (the dialect axis scores these …)`
- plus the mirror, against over-masking: `a real driving reference still counts when the same file also discusses the marker in prose`

The fixture is the shape that was live on this tree — real imports from the case-set module, the marker in a line comment among them and again in a docblock far below — not an invented one.

## Gates

Union derived **at the final commit** with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at `4879d71cc2`. The first derivation printed **STALE TREE** (3 commits behind, `scripts/bump-objectui.sh` changed across the range); `origin/main` was merged in and the union re-derived, which cleared it. Every family it named was run, none narrowed, each exit code captured **before** any pipe:

| family | exit | its own verdict line |
|---|---|---|
| `check:agent-test-spelling` | 0 | `✓ sweep is clean` |
| `check:cli-command-ids` | 0 | `✓ check-cli-command-ids: 276 command-id literal(s) across 99 file(s) … all resolve` |
| `check:cross-package-test-inputs` | 0 | `OK: 16 package(s) read outside themselves, all declared …` |
| `check:driver-conformance` | 0 | `check-driver-conformance: OK — 45 covered cell(s), 0 in the DEBT ledger, 0 exempt.` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 167 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `check:parse-guard` | 0 | `✓ check:parse-guard: 166 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `check:pnpm-filter-targets` | 0 | `✓ check:pnpm-filter-targets: 136/173 --filter occurrence(s) across 28 file(s) resolve` |
| `check-ci-filter-parity.mjs` | 0 | `OK: all 96 declared cross-package glob(s) (81 unique) are covered …` |
| `check-cross-package-test-inputs.mjs` | 0 | `OK: 16 package(s) read outside themselves, all declared …` |

`check:driver-conformance` and `check:entry-guard` / `check:parse-guard` / `check:pnpm-filter-targets` each run their `--self-test` first, so the new cases are inside the gate union rather than beside it. No gate reported `PREREQUISITE NOT MET`. The `check:cli-command-ids` run carries one pre-existing baselined violation (`objectstack publish`, tracked as #12223) and still exits 0 — untouched by this PR.

Run under `scripts/pm/os-verify-lock.sh`: `VERDICT command-exit 0 · held the lock 28s · waited 0s`.

## Changeset

None — root `scripts/` only, nothing user-visible is published. Carries the `skip-changeset` label.

## Out of scope, filed

#12320 — the card's unchosen remedy (1). The import regex is still unbounded, so it can assemble a match across **two import statements**: a marker imported from a *local* module plus any later `from '@objectstack/spec/data'` scores as shared-standard coverage. Masking does not close that. Swept after this fix: 54 `(file, marker)` import readings, **0 differ** between the unbounded regex and a per-statement read — latent, not live, so it is a `finding` with no `pm:queue`. Recorded separately because #12135 closes with this PR and the unchosen remedy would otherwise go with it. `#12134` is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_
