### PR TITLE
fix(scripts): optional-error-sink gate header — narrowing count prose

### DIFF
--- a/scripts/check-optional-error-sink-contract.mjs
+++ b/scripts/check-optional-error-sink-contract.mjs
@@ -57,8 +57,8 @@
  * misses a type someone names differently, and this repo has `LoggerLike`,
  * `MinimalLogger`, `OptionalLogger`, `FakeLogSink` and eight anonymous inline
  * literals — a name rule would have missed most of the population. Structural
- * costs false positives instead, so both narrowings below are measured and
- * their cost is printed on every run rather than argued in prose.
+ * costs false positives instead, so every narrowing below is measured and
+ * its cost is printed on every run rather than argued in prose.
  *
  * A SINK is: an interface, a type alias to a type literal, or an inline type
  * literal, all of whose members are function-typed and named from
@@ -786,7 +786,7 @@ function run({ list = false } = {}) {
 // ── Self-test ───────────────────────────────────────────────────────────────
 
 /**
- * Every limb observed FAILING and observed SILENT, plus the two narrowings
+ * Every limb observed FAILING and observed SILENT, plus the narrowings
  * pinned as positive counts.
  *
  * The reject side is pinned deliberately: a matcher that stopped matching


### PR DESCRIPTION
Fixes #12291

## What

Two docblock lines in `scripts/check-optional-error-sink-contract.mjs` said the gate measures **two** narrowings; the file documents and pins **three** (Narrowing 1: `as`-cast, Narrowing 2: purity, Narrowing 3: unreadable member type — added by #11069), and the runtime string already prints `all three narrowings pinned as counts`. This repairs the two stale prose lines to match.

```diff
- * costs false positives instead, so both narrowings below are measured and
- * their cost is printed on every run rather than argued in prose.
+ * costs false positives instead, so every narrowing below is measured and
+ * its cost is printed on every run rather than argued in prose.
```

```diff
- * Every limb observed FAILING and observed SILENT, plus the two narrowings
+ * Every limb observed FAILING and observed SILENT, plus the narrowings
  * pinned as positive counts.
```

Per clause 2c of the dispatch, chose an **integer-free spelling** ("every narrowing below" / "the narrowings"), matching the repair PR #12290 made for the sibling workflow-comment instance of the same defect — so neither sentence can go stale again when a fourth narrowing arrives. (`:60`'s sentence is a promise that *every* narrowing's cost is measured and printed; "every narrowing below" states that promise at least as concretely as a number did, without re-encoding a count that has already drifted once.)

`:985` is **left exactly as written** — it is a correct past-tense statement about the state of the world before narrowing 3 existed (*"an unsound prefilter survived a self-test that pinned both narrowings as counts (#11069)"*), not a present-tense claim. Changing it would make the file lie about its own history.

## Sweep (clause 2b)

Swept the whole file for every count-asserting spelling (`both`, `two`, `pair`, `either`, digit `2`) near "narrowing". Found two other clusters that use "two"/"both" near the word "narrowing" and confirmed neither is a third stale site:

- `:132`–`:156`, "**The two blind spots** #11069 measured" — genuinely two blind spots (the bare-`Function` sink bug and the file-prefilter bug), a distinct concept from the three population-narrowing sections above. Still two, not three. Left alone.
- `:795`, "only … can tell **the two apart**" — refers to the FAILING/SILENT pair of self-test observation states, not to narrowing count. Left alone.

No third stale site found. `:60` and `:789` were the only two instances; `:985` the only deliberate non-instance, exactly as the card measured.

## No behaviour change

Diff is exactly these two docblock lines — no count, pin, or runtime string touched (`git diff --stat`: 1 file changed, 3 insertions(+), 3 deletions(-), all inside comments).

## Evidence

⚠️ This is a comment-only diff — the gate never reads its own prose, so a green gate run does not verify the fix. The actual evidence of correctness is a read of the three `### Narrowing N` sections (`:90`, `:102`, `:114`) against the two repaired sentences: three sections, three pinned `expectUnreadable`/narrowing cases, and now two sentences that no longer claim two.

The gate/self-test run below only proves no *behaviour* regressed — it is not evidence the prose is right:

```
✓ optional-error-sink-contract self-test: 19 case(s), both directions, all three narrowings pinned as counts, prefilter pinned over 9 channel(s) × 4 spellings plus its reject side.
```
```
✓ optional-error sink contract: every sink declaring an optional `error` guarantees a `warn` channel (1 baselined, shrink-only).
```

Both exit 0, unchanged from `origin/main`.

## Gates

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at final commit `9097996c94` (no `STALE TREE`, same file/gate set as the pre-push derivation):

- `pnpm check:agent-test-spelling` ✓
- `pnpm check:cli-command-ids` ✓
- `pnpm check:cross-package-test-inputs` ✓ (`OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`)
- `pnpm check:entry-guard` ✓
- `pnpm check:optional-error-sink` ✓ (verdict lines above)
- `pnpm check:parse-guard` ✓
- `pnpm check:pnpm-filter-targets` ✓
- `node scripts/check-ci-filter-parity.mjs` ✓ (silent/no findings, exit 0 as part of the chained run)

All run through `os-verify-lock.sh` as one chained command; verdict `command-exit 0 · held the lock 30s · waited 0s`. Exit codes captured before any pipe/tail.

## Changeset

None — `scripts/**` publishes nothing to any package, so this is a `skip-changeset` PR (tooling/gate-prose only, no user-visible surface).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_