### PR TITLE
test(pm): pin the test-file kind entry for check:cross-package-test-inputs against its own deletion criterion

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -2745,6 +2745,32 @@ export function reachesMetadataFormModule(path, modulePaths) {
  *     path each already carries is their own output, and a card editing a
  *     baseline matches through it today without making the gate derivable for
  *     anybody else.
+ *
+ *     ⚠ "A literal naming their POPULATION" is the whole of that criterion,
+ *     and one gate in this kind now fails it while READING as satisfied.
+ *     Measured on this tree (#11199, the day PR #12300 landed): of the 2771
+ *     tracked test files, the hint route names `check:cross-package-test-
+ *     inputs` for 2758 of them — 99.5%, against 0–3.3% for its five siblings
+ *     in this same kind — because #12300 taught `hintCovers` to read a glob in
+ *     a non-final segment and the deep `packages` glob for TypeScript files
+ *     came back to life. (That glob is not spelled here: its own wildcard
+ *     closes a block comment.) The hint
+ *     is neither this gate's population nor even its own literal: it is
+ *     INHERITED from the declaration table the gate imports, where it is ONE
+ *     package's declared turbo `inputs` glob (`@objectstack/core`'s, wide
+ *     because a single pin test there walks the whole repo with `git
+ *     ls-files`). It is a row the gate JUDGES, not a population the gate
+ *     DECLARES — so it narrows the day that package's declaration narrows,
+ *     which is the direction the gate's own repair advice pushes. And even at
+ *     99.5% it reaches no test file outside `packages/**` (10 tracked today,
+ *     all under `examples/**`), none with a `.tsx` suffix (3 today, all in
+ *     client-react), and none under `apps/**` the day one arrives — while
+ *     the KIND reaches every one of them, because the trigger really is "a
+ *     test file's content changed, full stop". Both routes are kept (two
+ *     routes to one gate is redundancy, not a defect); the KIND is the
+ *     load-bearing one. The residue and the inheritance are pinned in the
+ *     self-test, so the next reader re-points a red case instead of
+ *     re-deriving this paragraph.
  *   - i18n entry: when `check-i18n-bundles.mjs` stops discovering its targets
  *     at runtime and names its POPULATION in its own source — a literal each
  *     owning package path starts with — the path half matches and this entry
@@ -5972,6 +5998,59 @@ function selfTest() {
     'check:cross-package-test-inputs is a live family (#10542 moved it here from a path derivation that could name it at 49.6% precision at best)',
     liveFamilies.has('check:cross-package-test-inputs'),
   );
+
+  // ── The test-file entry's deletion criterion, MEASURED (#11199) ───────────
+  //
+  // The card behind these cases reported that no local derivation ever named
+  // `check:cross-package-test-inputs` for an edited test file. That is closed —
+  // the entry above has been in the table since #10542 — and the reason these
+  // cases exist rather than a seventh entry is what the re-measurement found:
+  // the entry now READS redundant against its own stated deletion criterion,
+  // and it is not. The full measurement is in that criterion's bullet in this
+  // table's docblock; what is pinned here is every load-bearing half of it, so
+  // the claim reddens instead of ageing.
+  //
+  // Both directions matter. The positive case keeps the redundancy honest (the
+  // hint route really does reach an ordinary packages test file — Zone rule:
+  // two routes to one gate is redundancy, never a bug, and neither may be
+  // deleted BECAUSE of the other). The negative cases are the residue: a class
+  // the hint route cannot reach in principle, with live tracked specimens.
+  const XPKG = 'check:cross-package-test-inputs';
+  const xpkgEntry = discoverFamilies().byCheck.get(XPKG);
+  // Live specimens, one per residue reason. If either file is ever deleted or
+  // renamed, re-point the case at another member of its class — and if a class
+  // ever EMPTIES, that is the measurement to redo, not a case to drop.
+  const OUTSIDE_PACKAGES = 'examples/app-crm/test/smoke.test.ts';   // not under packages/**
+  const TSX_TEST = 'packages/client-react/src/realtime-hooks.test.tsx'; // not *.ts
+  const APPS_TEST = 'apps/docs/src/x.test.ts';                      // no tracked member today
+  t('the gate is discovered with hints at all, so these cases are not vacuous', (xpkgEntry?.hints ?? []).length > 0);
+  t('both residue specimens are real tracked files, so the negatives are live rather than a pair of matching strings',
+    existsSync(join(ROOT, OUTSIDE_PACKAGES)) && existsSync(join(ROOT, TSX_TEST)));
+  t('the hint route really does reach an ordinary packages test file — the redundancy #12300 recovered is real',
+    covers(xpkgEntry.hints, 'packages/spec/src/x.test.ts'));
+  t('but no hint of this gate reaches a test file outside packages/**', !covers(xpkgEntry.hints, OUTSIDE_PACKAGES));
+  t('nor a .tsx test file inside it', !covers(xpkgEntry.hints, TSX_TEST));
+  t('nor one under apps/**, the class with no tracked member to lose', !covers(xpkgEntry.hints, APPS_TEST));
+  // The entry itself, anchored on both sides of the rendered name the way the
+  // STALE cases above are: a bare substring test stays green if some other
+  // gate's `why` ever quotes this gate's name.
+  t('the KIND names the gate for every one of them — delete the entry and this reddens',
+    [OUTSIDE_PACKAGES, TSX_TEST, APPS_TEST].every((p) =>
+      changeKindLines([p], (n) => n).some((l) => l.includes(`- ${XPKG}   —`))));
+  // The fragility half: the covering hint is INHERITED from the declaration
+  // table this gate imports (one package's declared turbo `inputs` glob), not
+  // declared by the gate as its own population. `hintOrigin` carries exactly
+  // that provenance, and it is what the output prints as `gate source via …`.
+  const xpkgCovering = xpkgEntry.hints.find((h) => hintCovers(h, 'packages/spec/src/x.test.ts'));
+  t('and that covering hint is inherited from a module the gate imports, not a population the gate declares',
+    Boolean(xpkgEntry.hintOrigin?.get(xpkgCovering)));
+  // The class-level claim, against the real corpus rather than two specimens:
+  // while ANY tracked test file is unreachable by every hint this gate has, the
+  // entry's deletion criterion is unmet. The day this reddens, re-measure the
+  // criterion and either retire the entry with these cases or re-point them.
+  const xpkgResidue = trackedFiles().filter((f) => isTestFilePath(f) && !covers(xpkgEntry.hints, f));
+  t(`the tree still holds test files no hint of this gate reaches (${xpkgResidue.length}), so the entry is not redundant`,
+    xpkgResidue.length > 0);
 
   // ── The check-family coverage guard (#9187) ───────────────────────────────
   //

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -2748,9 +2748,9 @@ export function reachesMetadataFormModule(path, modulePaths) {
  *
  *     ⚠ "A literal naming their POPULATION" is the whole of that criterion,
  *     and one gate in this kind now fails it while READING as satisfied.
- *     Measured on this tree (#11199, the day PR #12300 landed): of the 2771
+ *     Measured on this tree (#11199, the day PR #12300 landed): of the 2773
  *     tracked test files, the hint route names `check:cross-package-test-
- *     inputs` for 2758 of them — 99.5%, against 0–3.3% for its five siblings
+ *     inputs` for 2760 of them — 99.5%, against 0–3.3% for its five siblings
  *     in this same kind — because #12300 taught `hintCovers` to read a glob in
  *     a non-final segment and the deep `packages` glob for TypeScript files
  *     came back to life. (That glob is not spelled here: its own wildcard


### PR DESCRIPTION
Fixes #11199

## The premise moved twice, and the second move is what this PR is about

**The card's suggested fix already exists.** `check:cross-package-test-inputs` has been the sixth entry under `CHANGE_KIND_GATES[0]` (`'adds or edits a test file'`) since PR #11189 (#10542). Three earlier PM comments on the card measured that; this seat re-measured it on its own base and agrees. Adding a seventh entry for the same gate would be a no-op.

**What the re-measurement found instead is newer than the card.** PR #12300 (`783111d252`, this branch's base) taught `hintCovers` to match a glob in a non-final segment. One of the globs that came back to life reaches almost the whole test corpus — so the entry now **reads redundant against its own written deletion criterion**, and it is not.

## The census

Over the 2773 tracked `*.{test,spec}.*` files in the tree, asking each route whether the derivation names this gate:

| route | reaches | misses |
| --- | --- | --- |
| KIND (`CHANGE_KIND_GATES[0]`, `isTestFilePath`) | **2773 / 2773** | 0 |
| hint (`coveringKey` over the family's 103 hints) | 2760 / 2773 (99.5%) | **13** |
| either | **2773 / 2773** | **0** |

So **no tracked test file is uncovered by any route** — the card's own motivating instance included. The remedy the card proposed is settled; the remedy the number chose is a **guard**, not a table row.

The 13-file residue is a class, not a rounding error:

- **10 outside `packages/**`** — all under `examples/**` (`app-crm`, `app-todo`, `embed-objectql`)
- **3 not `*.ts`** — `packages/client-react/src/*.test.tsx`
- **plus everything under `apps/**` the day a test file arrives there** (no tracked member today)

And the covering hint is not this gate's population at all. It is **inherited** (`hintOrigin` = `scripts/cross-package-test-inputs.mjs`), where it is **one package's declared turbo `inputs` glob** — `@objectstack/core`'s, wide only because one pin test there walks the whole repo with `git ls-files`. That is a row the gate **judges**, not a population the gate **declares**: it narrows the day that declaration narrows, which is the direction the gate's own repair advice pushes. Measured against its five siblings in the same kind, this is the only one anywhere near covered — the others sit at 0–3.3%.

## What this PR changes

`scripts/pm/dispatch-gates.mjs` only, in the two places the card's surface names:

1. The **deletion criterion** for the test-file entry, in the table's docblock, gains the measurement above — so the next reader applying "when a gate grows a discoverable path literal, this line is redundant" has the counter-measurement in front of them instead of re-deriving it.
2. **Nine `--self-test` cases** pin every load-bearing half of it: the redundancy is real (the hint route does reach an ordinary `packages/` test file), the residue class is unreachable by any hint (outside `packages/**`, `.tsx`, `apps/**`), the two live specimens are real tracked files, the covering hint is inherited rather than declared, the KIND still names the gate for all three shapes, and — against the live corpus — the residue is non-empty, which is the criterion itself made measurable.

Both routes are kept. Two routes to one gate is redundancy, not a bug, and after this neither can be deleted *because of* the other.

**Reverse-verified**: deleting the entry from the table turns the pin red (`✗ the KIND names the gate for every one of them — delete the entry and this reddens`), along with three pre-existing cases — `✗ dispatch-gates self-test: 4 of 642 case(s) failed`, exit 1. Mutation confirmed on disk before the run (entry-name occurrences 1 → 0, `git diff --stat` non-empty) and the restore confirmed after (1). Restore ran from a `trap … EXIT INT TERM`. No build is involved — this file is plain Node with no `dist`, so there is no rebuild leg to report.

## Derived both ways — this PR edits the derivation tool itself

Per the precedent PR #12247 and PR #12300 set on this file, the union was derived with **both** the BASE tool and the committed tool over the identical input path:

```
node scripts/pm/dispatch-gates.base.mjs --repo objectstack-ai/objectstack scripts/pm/dispatch-gates.mjs   # BASE_TOOL_EXIT=0
node scripts/pm/dispatch-gates.mjs      --repo objectstack-ai/objectstack scripts/pm/dispatch-gates.mjs   # HEAD_TOOL_EXIT=0
diff → IDENTICAL UNIONS
```

**This change does not move the union it is judged by.** The stronger half: this file's own watch-hint set is byte-for-byte unchanged (`BASE hints: 9 · HEAD hints: 9 · added: [] · removed: []`) — the new prose lives in comments and in the masked self-test body, never in a module-body string, which is the fabrication trap this table's own docblock warns about. (The temporary BASE copy was removed before the final derivation; `git status` clean.)

## Gates

Union derived at the final commit, `972abcedec`, with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — no `STALE TREE` warning, `--repo` assertion holds against this checkout's `origin`. `origin/main` was merged twice during the run for exactly that warning. Every exit code captured **before** any pipe; each line below is the gate's own verdict:

| gate | verdict |
| --- | --- |
| `pnpm check:pm-dispatch-gates` | `✓ dispatch-gates self-test: 642 cases pass.` (633 + 9 new) |
| `node scripts/pm/bare-root-worklist.mjs --self-test` | `OK  self-test: 46 live row(s), 39 unreachable as spelled, 39 recorded verdict(s) — none stale, none missing.` |
| `pnpm check:nul-bytes` | `check-nul-bytes: OK (scanned 6823 text file(s) … no raw ASCII control bytes).` |
| `pnpm check:cross-package-test-inputs` | `OK: 16 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `node scripts/check-cross-package-test-inputs.mjs` | same, via the `ci.yml` spelling |
| `pnpm check:agent-test-spelling` | `✓ check-agent-test-spelling: 0 violations — 383 file(s) …` |
| `pnpm check:cli-command-ids` | `✓ check-cli-command-ids: 276 command-id literal(s) … all resolve` |
| `pnpm check:entry-guard` | `✓ check:entry-guard: 167 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `pnpm check:parse-guard` | `✓ check:parse-guard: 166 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `pnpm check:pnpm-filter-targets` | `✓ check:pnpm-filter-targets: 136/173 --filter occurrence(s) … resolve` |
| `node scripts/check-ci-filter-parity.mjs` | `OK: all 96 declared cross-package glob(s) (81 unique) are covered …` |
| `node scripts/check-self-test-wired.mjs` | `✓ check-self-test-wired: every one of the 137 script(s) CI runs that ship a --self-test has that self-test run by CI.` |

No narrowing was declared: the derived union was run whole. `check-ci-filter-parity` first refused with `PREREQUISITE NOT MET — the dependency yaml is not installed` (a fresh worktree has no `node_modules`); `pnpm install` ran under `scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0 · held the lock 7s · waited 0s`) and it then passed.

## Companion sweep — answered, filed, not fixed here

The card asked whether any other unlisted `lint.yml` gate shares the "scans every test file's content" shape. It does: **`check:objectql-double-limit`** is `check:where-matcher`'s twin — same `testFilesUnder` walk over every `*.test.ts`, same shrink-only per-file baseline, same CI job — and its hint route reaches **0 of 2773** test files, because its declared population sentence lives in a comment that `extractWatchHints` masks by design. Weaker candidates (`check:parse-guard`, `scripts/check-test-completeness.mjs`) and the nine gates that merely *exclude* tests are recorded there too. Filed as #12322; **⛔ no other gate's entry is touched in this PR**, per the card's scope.

## Notes

- `skip-changeset`: root `scripts/` only, nothing published. The REST label endpoint answers **403** from this seat (#12123), so the label was applied via the MCP read → union → whole-set write and read back; the fallback is declared, not silent.
- Serial queue: #12074 and #11556 also name this file and were left untouched. ⚠️ #11556's subject was measured unmoved by #12247 but **not** against #12300, which changed the covering rule — whoever takes it re-measures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_