### PR TITLE
fix(docs): reference the per-page Open Graph cards that were already being built

### DIFF
--- a/apps/docs/app/[lang]/blog/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/blog/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { blog } from '@/lib/source';
 import { getMDXComponents } from '@/mdx-components';
@@ -181,33 +182,86 @@ export async function generateStaticParams() {
   }));
 }
 
+/**
+ * The blog's social card.
+ *
+ * ⚠️ The card generator at `app/og/docs/[...slug]/route.tsx` is docs-only: it
+ * renders from `source` (the `content/docs` loader) and has no branch for `blog`,
+ * so there is no per-post card to reference and this card is shared by the index
+ * and every post. Giving posts their own generated cards is a separate decision,
+ * not a gap in this wiring — it would mean a second `app/og/**` route.
+ *
+ * ⚠️ Same path as `apps/docs/app/[lang]/page.tsx`'s `HOME_CARD`; that file
+ * carries the note on why it is spelled twice and what must change together.
+ */
+const BLOG_CARD = {
+  url: '/hero-cover-dark.png',
+  width: 2400,
+  height: 1200,
+  alt: 'ObjectStack — the metadata framework for AI-written apps',
+};
+
+const BLOG_INDEX_TITLE = 'Blog';
+const BLOG_INDEX_DESCRIPTION =
+  'Insights, updates, and best practices from the ObjectStack team.';
+
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ slug?: string[] }>;
-}) {
+}): Promise<Metadata> {
   const { slug } = await params;
-  
+
   // If no slug, return default metadata for blog index
   if (!slug || slug.length === 0) {
+    // The index has no MDX file behind it, so its route is spelled out here — the
+    // same literal `app/sitemap.ts` lists it under.
+    const canonical = absoluteUrl('/blog');
+
     return {
-      title: 'Blog',
-      description: 'Insights, updates, and best practices from the ObjectStack team.',
-      // The index has no MDX file behind it, so its route is spelled out here — the
-      // same literal `app/sitemap.ts` lists it under.
-      alternates: { canonical: absoluteUrl('/blog') },
+      title: BLOG_INDEX_TITLE,
+      description: BLOG_INDEX_DESCRIPTION,
+      alternates: { canonical },
+      openGraph: {
+        type: 'website',
+        title: BLOG_INDEX_TITLE,
+        description: BLOG_INDEX_DESCRIPTION,
+        url: canonical,
+        images: [BLOG_CARD],
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: BLOG_INDEX_TITLE,
+        description: BLOG_INDEX_DESCRIPTION,
+        images: [BLOG_CARD.url],
+      },
     };
   }
-  
+
   const page = blog.getPage(slug);
 
   if (!page) {
     notFound();
   }
 
+  const canonical = absoluteUrl(page.url);
+
   return {
     title: page.data.title,
     description: page.data.description,
-    alternates: { canonical: absoluteUrl(page.url) },
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      title: page.data.title,
+      description: page.data.description,
+      url: canonical,
+      images: [BLOG_CARD],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.data.title,
+      description: page.data.description,
+      images: [BLOG_CARD.url],
+    },
   };
 }

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { getPageImage, source } from '@/lib/source';
 import type { Metadata } from 'next';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
 import { notFound } from 'next/navigation';
@@ -61,15 +61,53 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug ?? [], params.lang);
   if (!page) notFound();
 
+  /**
+   * `app/og/docs/[...slug]/route.tsx` already prerenders a 1200x630 card for every
+   * page this loader returns -- its `generateStaticParams` maps over
+   * `source.getPages()` through this very function. Calling `getPageImage()` here
+   * too is what makes the card *reachable*: the generator and the reference are
+   * then the same expression, so a slug shape that stops matching breaks the build
+   * rather than emitting an `og:image` that 404s. A 404ing card is worse than no
+   * card at all, because the crawler falls back to scraping whatever else it finds.
+   *
+   * The URL is left site-relative on purpose: `metadataBase` in `app/layout.tsx`
+   * absolutises it, so the origin stays spelled in exactly one place.
+   */
+  const image = getPageImage(page);
+  /**
+   * `page.url` is the same locale-stripped route fumadocs uses for in-site links
+   * and that `app/sitemap.ts` lists, so the canonical link and the sitemap entry
+   * cannot drift apart. `absoluteUrl()` throws rather than emit a URL on another
+   * host if that ever stops being a site-relative path.
+   */
+  const canonical = absoluteUrl(page.url);
+
   return {
     title: page.data.title,
     description: page.data.description,
-    /**
-     * `page.url` is the same locale-stripped route fumadocs uses for in-site links
-     * and that `app/sitemap.ts` lists, so the canonical link and the sitemap entry
-     * cannot drift apart. `absoluteUrl()` throws rather than emit a URL on another
-     * host if that ever stops being a site-relative path.
-     */
-    alternates: { canonical: absoluteUrl(page.url) },
+    alternates: { canonical },
+    openGraph: {
+      type: 'article',
+      title: page.data.title,
+      description: page.data.description,
+      // Same absolute URL as the canonical link, deliberately: `og:url` is the
+      // identity a social platform de-duplicates shares by, and pointing it at a
+      // different spelling than the canonical splits one page into two.
+      url: canonical,
+      images: [
+        {
+          url: image.url,
+          width: 1200,
+          height: 630,
+          alt: page.data.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: page.data.title,
+      description: page.data.description,
+      images: [image.url],
+    },
   };
 }

--- a/apps/docs/app/[lang]/page.tsx
+++ b/apps/docs/app/[lang]/page.tsx
@@ -22,10 +22,38 @@ const mono = IBM_Plex_Mono({
   variable: '--font-l-mono',
 });
 
+const HOME_TITLE = 'Metadata framework for AI-written apps';
+const HOME_DESCRIPTION =
+  'ObjectStack turns the whole app — data model, UI, workflows, permissions — into typed metadata: a complete CRM in under 150k tokens, one context window.';
+
+/**
+ * The homepage's social card.
+ *
+ * ⚠️ Deliberately NOT the docs card generator. `app/og/docs/[...slug]/route.tsx`
+ * renders from a `source.getPage()` result, and the homepage has no MDX file
+ * behind it — there is no slug to hand it. It reuses the hero cover instead,
+ * which is already shipped and already the video poster on this page, so the
+ * shared card costs no extra bytes and no extra route.
+ *
+ * ⚠️ `apps/docs/app/[lang]/blog/[[...slug]]/page.tsx` spells this same path for
+ * the blog's card. Two spellings rather than one shared constant because
+ * `lib/site.ts` is the origin's home, not the asset manifest's; if a third page
+ * ever needs it, hoist it there. Anything that renames, re-encodes or deletes
+ * `public/hero-cover-dark.png` must update BOTH — an `og:image` that 404s is
+ * worse than none, because crawlers then scrape whatever else the page offers.
+ *
+ * Left site-relative: `metadataBase` in `app/layout.tsx` absolutises it.
+ */
+const HOME_CARD = {
+  url: '/hero-cover-dark.png',
+  width: 2400,
+  height: 1200,
+  alt: 'ObjectStack — the metadata framework for AI-written apps',
+};
+
 export const metadata: Metadata = {
-  title: 'Metadata framework for AI-written apps',
-  description:
-    'ObjectStack turns the whole app — data model, UI, workflows, permissions — into typed metadata: a complete CRM in under 150k tokens, one context window.',
+  title: HOME_TITLE,
+  description: HOME_DESCRIPTION,
   /**
    * `/` is the one indexable spelling of the homepage: `proxy.ts` rewrites `/` to
    * this route internally, and the prefixed form `/en` 307s back to `/`. Every
@@ -33,6 +61,21 @@ export const metadata: Metadata = {
    * points here.
    */
   alternates: { canonical: absoluteUrl('/') },
+  openGraph: {
+    type: 'website',
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    // Same absolute URL as the canonical link — see the docs route for why the
+    // two must not drift.
+    url: absoluteUrl('/'),
+    images: [HOME_CARD],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: HOME_TITLE,
+    description: HOME_DESCRIPTION,
+    images: [HOME_CARD.url],
+  },
 };
 
 const VOCABULARY: { tag: string; title: string; copy: string }[] = [


### PR DESCRIPTION
Fixes #12235

## What was already true, re-measured before writing anything

The card's premise holds, and both halves were re-derived rather than inherited:

| claim | re-derived value | method |
|---|---|---|
| the cards are **built** | **403 / 403** doc pages answer `200 image/png` on production | every `<loc>` in the live `sitemap.xml` mapped to its card URL and fetched — 403 requests, zero non-200, zero non-`image/png` |
| the cards are **referenced by nobody** | `getPageImage` had exactly 3 source hits — its own declaration and the two lines of the route that *produces* the image | `grep -rn` over `apps/docs`, positive control `generateMetadata` = 2 hits, so the zero is absence rather than a broken query |
| no card metadata anywhere | `grep -rn 'openGraph\|twitter'` over `apps/docs` = **0 hits** | same run, same control |

Population also re-derived, because this epic has corrected five PM measurements already: the live sitemap carries **408** URLs = 403 docs (including `/docs`, the empty-slug case) + `/` + `/blog` + 3 blog posts. That is **five URL shapes across three files**, confirming the correction made on #12234 rather than the four this epic originally listed.

## What this changes

`generateMetadata` / `metadata` in the three page modules, and nothing else. No file under `app/og/**` is touched — the images were never the problem.

- **docs pages and `/docs`** reference their own generated card via the same `getPageImage()` that the generator's `generateStaticParams` maps over. The generator and the reference are now one expression, so a slug shape that stops matching breaks the build instead of shipping an `og:image` that 404s.
- **the homepage and the blog** reference `public/hero-cover-dark.png`. The card generator is docs-only: it renders from a `source.getPage()` result and neither the homepage nor the blog has an MDX file behind it, so there is no slug to hand it. The hero cover is already shipped and is already this page's video poster, so the shared card costs no extra bytes and no extra route.
- Image URLs stay **site-relative**; `metadataBase` (PR #12305) absolutises them, so the origin keeps being spelled in exactly one place. Every `og:url` is the same absolute string as that page's existing canonical link — `og:url` is the identity a social platform de-duplicates shares by, and a spelling that differs from the canonical splits one page into two.

## Verification — one page of each route type, fetched

Measured against `next dev` running **this branch** at commit `a1293e84c`, and each emitted URL then fetched from both that server and production:

```
route                            og:type   emitted og:image                                      fetch
/                                website   https://objectstack.ai/hero-cover-dark.png            local=200 image/png | prod=200 image/png
/docs                            article   https://objectstack.ai/og/docs/image.png              local=200 image/png | prod=200 image/png
/docs/ai/agents                  article   https://objectstack.ai/og/docs/ai/agents/image.png    local=200 image/png | prod=200 image/png
/blog                            website   https://objectstack.ai/hero-cover-dark.png            local=200 image/png | prod=200 image/png
/blog/protocol-first-development article   https://objectstack.ai/hero-cover-dark.png            local=200 image/png | prod=200 image/png
```

All five emit `og:title`, `og:description`, `og:url`, `og:image` and `twitter:card=summary_large_image`. `file(1)` on the downloaded bytes confirms the declared dimensions are not a claim: docs cards are `PNG image data, 1200 x 630`, the hero is `PNG image data, 2400 x 1200` — matching the `og:image:width` / `og:image:height` each page emits.

The homepage card is distinct from the docs template by URL and by bytes.

## The index page's card works — and the reason is not the one anyone wrote down

The dispatch asked whether `generateStaticParams` and `getPageImage()` agree on the slug shape for `content/docs/index.mdx`. They do: `/og/docs/image.png` is in the 403 that answered `200 image/png`.

A reverse verification was run to check the *measurement* was sensitive to the failure it was looking for, not just to a happy path. `getPageImage` was mutated to drop the trailing `image.png` marker — the exact off-by-one the question describes — on a committed tree, with the mutation proved on disk by anchored `grep -cF` counts on both the deleted and the injected text (not by `diff --stat`, which any other edit in the round would have turned green), and restored via `git checkout HEAD -- <abs path>` with the restore proved by `git hash-object` matching the HEAD blob and `git diff HEAD` empty.

**Predicted:** `/docs` 404s, `/docs/ai/agents` returns `200` with the *wrong* page's card, because the route's `slug.slice(0, -1)` would resolve `['ai']`.

**Observed:** both 404. The prediction was half wrong, and the reason is a coupling worth recording:

```
/og/docs/ai/agents            -> 404   (no dot anywhere in the path)
/en/og/docs/ai/agents         -> 404   (where proxy.ts rewrites it to)
/og/docs/ai/agents/x.png      -> 200 image/png
/og/docs/ai/agents/image.png  -> 200 image/png
```

`proxy.ts`'s matcher excludes any path containing a dot. The trailing marker segment is therefore doing **two** jobs, only one of which is documented: it is the sacrificial segment `slug.slice(0, -1)` discards, **and** its dot is what keeps every OG URL out of the locale rewriter. Its *name* is irrelevant — `x.png` resolves the same page — but a marker without a dot takes the whole card surface to 404. That is why this PR references the card through `getPageImage()` rather than rebuilding the URL locally.

## Gates

Derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list), at commit `a1293e84c`; all five ran green, each quoted by its own verdict line rather than by a shell `$?`:

- `check:docs-locale-catch-all` — `✓ 1 top-level dynamic segment(s), 1 guarded; dotted paths bypass proxy.ts: true`
- `check:page-declaration-shape` — `OK — 34 page entries across 2188 sources ... all reach the kernel through a discoverable declaration`
- `check:published-files` — `✓ 69 publishable package(s) of 78 workspace member(s) ...`
- `check:test-source-alias` — `check-test-source-alias OK — 72 packages with tests scanned`
- `check:type-source-resolution` — `check-type-source-resolution OK — 93 tsc program(s) across 77 packages scanned`

Plus `pnpm --filter @objectstack/docs typecheck` (exit 0) and repo-wide `pnpm lint` = `eslint . --no-inline-config` (exit 0, 47s — the **full** population, not a narrowed run). `tsc --noEmit --listFiles` confirms all three edited files are in the program, so "typecheck is clean" is a statement about these edits and not about a program that never read them. `check:nul-bytes` OK.

⚠️ Disclosure: this host has **no usable `flock`**, so `scripts/pm/os-verify-lock.sh --status` reports DECLARED UNLOCKED MODE — nothing can hold the shared verify lock here and the entry point takes it from nobody. The commands above ran without mutual exclusion because none is available on this host, not because the lock was bypassed.

## Not in this PR

- **No changeset** — docs-site only, nothing published. `skip-changeset` applied.
- **No JSON-LD** — that is #12240, queued behind this card.
- **No per-post card generator for the blog.** It would mean a second `app/og/**` route, which is outside this card's file surface and is a decision rather than a default. The blog is wired to the shared site card instead, so no page on the site ships a blank card today.
- ⚠️ **Handoff to #12242** (hero cover weight): `public/hero-cover-dark.png` is now referenced from page **metadata** in two files, not just from the page body. Renaming, re-encoding to another format, or deleting it now breaks the homepage and blog `og:image` as well as the LCP image. Both call sites carry a comment saying so.

_Generated by [Claude Code](https://claude.ai/code/session_f9f0958b-ab68-46cc-801c-216aa7ee2107)_
