### PR TITLE
fix(pm): reprice the runner-env-posture bare-root reason on the real mechanism

### DIFF
--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -134,6 +134,15 @@ const POPULATION_CONSTANT = /^(?:[A-Z0-9_]*_ROOTS?|[A-Z0-9_]*_DIRS?|POPULATION|[
  * other row still carries the numbers from the pass that wrote it, because its
  * gate exports no walk to drive and reproducing the filter by hand would be the
  * estimate this docblock refuses.
+ *
+ * The `check:runner-env-posture SCANNED_ROOTS packages` row was then re-derived
+ * AGAIN later the same day, after #12300 changed how `hintCovers` judges a glob
+ * in a non-final segment and left that row's stated mechanism describing a
+ * collapse the function no longer performs (#12289). Its whole `why` — ratio,
+ * coverage and cost alike — is one reading of the tree at that later point,
+ * which is why its denominator is larger than the two SCANNED_ROOTS siblings
+ * recorded beside it. That is the drift this docblock permits and not the
+ * mixed-terms defect it forbids: no term of that row was refreshed alone.
  */
 const TRIAGE = new Map([
   // ── Taken: a strictly narrower subtree ────────────────────────────────────
@@ -324,12 +333,20 @@ const TRIAGE = new Map([
   }],
   ['check:runner-env-posture SCANNED_ROOTS packages', {
     verdict: 'REFUSE-UNSPELLABLE',
-    why: 'non-test source beneath a `src` SEGMENT — 1794 of 5185 (35%). The segment is what makes '
-      + 'this unspellable rather than merely wide: `packages/**/src/**` is the true population and '
-      + 'collapseHint reduces it to `packages`, so the only spellable claim also names every '
-      + 'package manifest, changelog, fixture and the 2746 test files this gate deliberately skips. '
-      + 'Its nearest neighbour check:authz-resolver is REFUSE-WIDE at a similar 39% because ITS '
-      + 'population really is every non-test source under the root; this one is not',
+    why: 'non-test source beneath a `src` SEGMENT — 1812 of 5240 (35%), re-derived from the gate '
+      + 'own collectFiles() walk together with every number below, so the row holds ONE tree. What '
+      + 'is unspellable here is the file-KIND filter, NOT the segment. Since #12300 a glob in a '
+      + 'non-final segment is MATCHED rather than collapsed, so `packages/**/src/**` is a live '
+      + 'hint that reaches all 1812 of them; the earlier reading that collapseHint reduced it to '
+      + '`packages` described a collapse hintCovers no longer performs for this shape, and the '
+      + 'refusal never rested on it. It covers 4290 tracked files to reach those 1812, and 2465 '
+      + 'of the 2478 it over-names are the test files this gate deliberately skips — the one '
+      + 'filter no glob idiom can spell. So the narrowest LIVE spelling is 42% true where the '
+      + 'bare root is 35%: the segment buys seven points, not a precise claim, and both spellings '
+      + 'are false about the same non-test filter. Its nearest neighbour check:authz-resolver is '
+      + 'REFUSE-WIDE at a similar 39% because ITS population really is every non-test source '
+      + 'under the root, so the bare-root declaration there is TRUE and refused only for width; '
+      + 'here the bare root is FALSE, and so is every narrower spelling the idiom offers',
   }],
   ['check:runner-env-posture SCANNED_ROOTS examples', {
     verdict: 'REFUSE-UNSPELLABLE',
@@ -598,6 +615,48 @@ function selfTest() {
   const own = extractWatchHints(readFileSync(fileURLToPath(import.meta.url), 'utf8'));
   t(`this tool declares no population of its own${own.length ? ` — it names ${own.join(', ')}` : ''}`,
     own.length === 0);
+
+  // ── The MECHANISM a repaired reason turns on, held mechanically ───────────
+  //
+  // A `why` is prose this tool never reads, so a recorded verdict can keep its
+  // key, its reachability and its verdict while the DERIVATION moves out from
+  // under the reason it states. #12300 did exactly that: it taught `hintCovers`
+  // to MATCH a glob in a non-final segment instead of collapsing it, and every
+  // row that refused on the grounds "the narrow spelling collapses to a double
+  // separator and reaches nothing" was left describing a defect the tree no
+  // longer has — silently, with this self-test green, because it audits keys and
+  // verdicts and never what a `why` SAYS. The rows that still cite that collapse
+  // are recorded in #12289 and deliberately left standing here: their reasons
+  // died with the defect, so what they need is a re-decided VERDICT, which is
+  // not something this file may change quietly under cover of a prose fix.
+  //
+  // ⛔ Deliberately NOT a prose scanner. Lifting the quoted values out of `why`
+  // and re-running `collapseHint` over them was considered and refused twice
+  // over: it wants a parser over English inside a governance tool, and it would
+  // check the WRONG function — these reasons are REACHABILITY claims, which
+  // `hintCovers` decides, so a collapseHint-equality check stays GREEN through
+  // the very change that falsifies them. What is pinned instead is the DIRECTION
+  // the repaired row depends on, in the terms `hintCovers` judges by. Segments
+  // are joined rather than spelled, for the same reason the probes above take
+  // their root from the tree: a glob literal here would hand this file a
+  // population of its own.
+  const PKG = 'packages';
+  const seg = (f) => f.split('/');
+  const underPkg = files.filter((f) => seg(f)[0] === PKG);
+  const isTestPath = (f) => seg(f).pop().split('.').includes('test');
+  const srcSegmentGlob = [PKG, '**', 'src', '**'].join('/');
+  const srcSegmentHit = files.filter((f) => hintCovers(srcSegmentGlob, f));
+  t('the check:runner-env-posture packages reason holds: its `src`-segment spelling is a LIVE '
+    + 'hint, not the dead collapse that row used to cite', srcSegmentHit.length > 0);
+  t('…and it is a real NARROWING rather than the bare root wearing a glob',
+    underPkg.length > 0 && srcSegmentHit.length < underPkg.length);
+  t('…and the segment is genuinely matched, not waved through: no packages file outside a '
+    + '`src` segment is covered',
+    underPkg.some((f) => !seg(f).includes('src'))
+      && !srcSegmentHit.some((f) => !seg(f).includes('src')));
+  t('…and it still OVER-NAMES the file kind the gate skips, which is what keeps the row '
+    + 'REFUSED rather than declarable — the half of the reason a live hint does not settle',
+    srcSegmentHit.some(isTestPath));
 
   // Every verdict must be one of the three the docblock defines, and every
   // refusal must carry its measured reason — a bare verdict is the allowlist row

--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -333,14 +333,14 @@ const TRIAGE = new Map([
   }],
   ['check:runner-env-posture SCANNED_ROOTS packages', {
     verdict: 'REFUSE-UNSPELLABLE',
-    why: 'non-test source beneath a `src` SEGMENT — 1812 of 5240 (35%), re-derived from the gate '
+    why: 'non-test source beneath a `src` SEGMENT — 1812 of 5241 (35%), re-derived from the gate '
       + 'own collectFiles() walk together with every number below, so the row holds ONE tree. What '
       + 'is unspellable here is the file-KIND filter, NOT the segment. Since #12300 a glob in a '
       + 'non-final segment is MATCHED rather than collapsed, so `packages/**/src/**` is a live '
       + 'hint that reaches all 1812 of them; the earlier reading that collapseHint reduced it to '
       + '`packages` described a collapse hintCovers no longer performs for this shape, and the '
-      + 'refusal never rested on it. It covers 4290 tracked files to reach those 1812, and 2465 '
-      + 'of the 2478 it over-names are the test files this gate deliberately skips — the one '
+      + 'refusal never rested on it. It covers 4291 tracked files to reach those 1812, and 2466 '
+      + 'of the 2479 it over-names are the test files this gate deliberately skips — the one '
       + 'filter no glob idiom can spell. So the narrowest LIVE spelling is 42% true where the '
       + 'bare root is 35%: the segment buys seven points, not a precise claim, and both spellings '
       + 'are false about the same non-test filter. Its nearest neighbour check:authz-resolver is '


### PR DESCRIPTION
Part of #12289 — this lands the substantive half (row 1) and deliberately leaves the other half, for a reason the card could not have known. ⛔ Not a close: see "What is NOT here".

## The card's premise held; the PM's re-verification of it did not

The card is right that `check:runner-env-posture SCANNED_ROOTS packages` misattributes its own refusal. It is wrong about why, and so was the dispatch, in the exact way the dispatch warned about: both probed `collapseHint` by hand instead of driving the function that actually decides reachability.

`collapseHint` is unchanged and still returns `packages//src`. But #12300 (`783111d252`) did more than delete a dead trailing strip — it added a branch to `hintCovers`:

```js
export function hintCovers(hint, inputPath) {
  if (globInNonFinalSegment(hint)) return triggerCovers(hint, inputPath);   // ← #12300
  const plain = collapseHint(hint);
```

A glob in a non-final segment no longer *goes through* the collapse. So probing `collapseHint` alone still reproduces every double slash these rows cite, and still reads as confirmation, while the reachability claim built on it has been false since #12300 landed. Every number below comes from the real `hintCovers` / `collapseHint` / `trackedFiles`, imported from `scripts/pm/dispatch-gates.mjs`.

## What this PR changes

One row's `why`, and the docblock note that dates it. The verdict is untouched: `REFUSE-UNSPELLABLE`, before and after.

The old text refused on a collapse-to-root over-claim — *"`packages/**/src/**` is the true population and collapseHint reduces it to `packages`"* — which the function never performed. The repair does not just swap that clause. The old sentence carried a **cost model** ("also names every package manifest, changelog, fixture and the 2746 test files this gate deliberately skips") and a comparison to `check:authz-resolver`, `REFUSE-WIDE` at a similar 39%; that comparison is what explains why two similar percentages get different verdicts, and it had to keep working under the true mechanism.

Measured, one reading of one tree, at the head below:

| | |
| --- | --- |
| gate population (its own `collectFiles()` walk) | 1812 |
| tracked under the bare root | 5241 → **35%** |
| `packages/**/src/**` — a LIVE hint post-#12300 | covers **4291**, reaching **1812 of 1812** → **42%** |
| what it over-names | 2479, of which **2466** are test files the gate skips |

So the refusal survives on the reason that was always doing the work — **the file-KIND filter, not the segment**. The `src` segment *is* spellable now; the "non-test" part is not, and never will be, in a glob idiom. The narrowest live spelling buys seven points of precision, not a precise claim. The `check:authz-resolver` comparison is kept and gets sharper: there the bare root is TRUE and refused only for width; here the bare root is FALSE, and so is every narrower spelling available.

Every term of the row was re-derived together — ⛔ never a denominator refreshed alone, which the file's own docblock calls "this defect wearing fresher digits".

## What is NOT here, and why

**Row 2 (`check:skill-refs SKILLS_DIR skills`) is untouched.** The card sized it as a one-word cosmetic fix (`skills//references/**` → `skills//references`). It is not cosmetic. Measured: `skills/*/references/**` is now a live hint covering **exactly 12** files — precisely that row's own population of "12 of 50 (24%), 9 of them the `_index.md` it emits". 100% precision. Its stated conclusion, *"the only spellable claim left is the bare root"*, is false on this tree.

That makes it a **verdict** question, and the card, the dispatch and the triage docblock all reserve those: *"Re-deciding a TRIAGE verdict is a separate judgment call and is deliberately not proposed here."* Correcting the quoted value while leaving `REFUSE-UNSPELLABLE` standing would produce a row whose reason argues against its own verdict — the precise failure the dispatch told me not to ship.

Sweeping the rest of the map (the dispatch asked, and did not assume two was the whole set) found the same thing in **two more rows** — `check:objectql-double-limit` and `check:i18n`/`check:i18n-stale-fill`. All measured at 100% precision for their narrow spelling. Filed as **#12328** with the full table; nothing about those rows changes here.

Swept and clean: `scripts/check-declaration-mirrors.mjs SCRIPTS_DIR scripts` still holds — both spellings of its population really are dead, though for a reason worth its own row, filed as **#12329** (`**` does not match zero segments, so `scripts/**/*.d.mts` names 3 tracked files and reaches 0).

⛔ #12064 not touched; this file is single-writer for that claim.

## Evidence — stated plainly

Most of this diff is prose the tool never reads, so **a green `--self-test` is not evidence the reason text is right.** Separating what each thing actually proves:

- **The numbers**: the real functions, driven over the real corpus. Reproducible from the repro block in #12328.
- **Nothing else moved**: the live worklist output diffed before/after is **2 lines — the repaired row alone**. Self-test identical across the change, and identical to the control the dispatch quoted: `46 live row(s), 39 unreachable as spelled, 39 recorded verdict(s) — none stale, none missing` and `0 untriaged row(s)`.
- **The mechanism is now pinned, and the pin can fail.** The self-test gains four assertions holding the *direction* this row's reason depends on — the mid-segment spelling is live, is a real narrowing, genuinely matches the segment, and still over-names the file kind the gate skips. Ablating #12300's branch out of `hintCovers` turns the self-test **RED with 2 named failures**, both naming this row (the other two are shape assertions and stay green under that mutation — stated so nobody reads more into the ablation than it shows). Mutation confirmed on disk by marker count 1→0 before the run, restored by an `EXIT` trap after.

That is the part that changes the standing situation: this row's reason can no longer rot silently the way the other four did.

## Zone 3: the class-closing check, and why I did not build the proposed one

The dispatch asked whether every `collapseHint(...)`-shaped value quoted inside a `why` could be checked mechanically, and said to say why if not. Two reasons, the second decisive:

1. Lifting those values out of `why` needs a parser over English inside a governance tool — the fragile prose-scanner the dispatch itself rules worse than two correct sentences.
2. **It would check the wrong function.** These reasons are *reachability* claims, and `hintCovers` decides those. A `collapseHint`-equality check would have been **green through #12300** — green, that is, through the single change that falsified five rows at once, including the two on this card. It would have caught row 2's cosmetic typo and missed every substantive defect.

So the pin holds the direction rather than the prose: no parser, no false positives, and it fails on exactly the change that did the damage. Both the reasoning and the ⛔ are recorded in the file so the next reader does not rebuild the scanner.

## Gates

Union re-derived at the final commit `4d44af2580` with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — no `STALE TREE`, change set exactly 1 path. `origin/main` moved twice mid-task; both merges are in, and the union grew by one (`check:bash32-floor`, from #12319) which the re-derivation caught rather than my assuming it away. All 10 green on that head, each exit code captured before any pipe:

`check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check:entry-guard` · `check:parse-guard` · `check:pnpm-filter-targets` · `check-ci-filter-parity.mjs` · `check-cross-package-test-inputs.mjs` · `bare-root-worklist.mjs --self-test`

**No changeset**, `skip-changeset` applied: the diff is one file under `scripts/`, which is not in any workspace `files` array and publishes to no registry. There is no user-visible artifact for a release note to describe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_