### PR TITLE
fix(lint): take build output out of the linted population with a global ignore

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -887,6 +887,49 @@ const commentSwallowPlugin = {
 };
 
 export default [
+  // ───────────────────────────────────────────────────────────────────────────
+  // GLOBAL ignore. This is the ONLY object in this array with no `files` key,
+  // and that absence is the whole point: a flat-config `ignores` that sits
+  // BESIDE a `files` key is object-scoped — it stops that one object from
+  // applying and does NOT remove the path from the linted population. All
+  // seven objects below carry `files`, so before this object existed the build
+  // output they each list was still enumerated and parsed. ESLint lints
+  // `.js`/`.mjs`/`.cjs` under its built-in defaults even when no object here
+  // matches, so every emitted bundle was parsed to produce a guaranteed-empty
+  // result.
+  //
+  // Measured on this tree (ESLint v10.8.1, Node 22.22.2), 50 files per
+  // extension dropped under `packages/core/dist/`:
+  //
+  //   before   dist/*.js + dist/*.mjs  → LINTED, 0 rules enabled, parser espree
+  //            dist/*.ts + dist/*.d.ts → not linted at all (`--print-config`
+  //                                      returns `undefined`: no object matches,
+  //                                      and ESLint does not lint `.ts` by default)
+  //   after    none of the four present in the population
+  //
+  // So the accept/reject semantics of `**/dist/**` do not move: nothing there
+  // had a rule enabled to lose. The saving is pure enumeration + parse.
+  //
+  // ⚠️ SCOPE IS DELIBERATELY NARROWER THAN THE PER-OBJECT LISTS BELOW. Those
+  // also carry `**/build/**`, `**/.next/**` and `**/.turbo/**`, and promoting
+  // those three here would NOT be semantics-neutral. Three of the objects
+  // below (the `packages/**` and `examples/**` ones) list only
+  // `**/node_modules/**` and `**/dist/**` in their `ignores`, so they still
+  // match TypeScript under the other three directories:
+  //
+  //   packages/core/build/x.ts → LINTED, 3 rules ENABLED
+  //     (slot-lookup/no-any-assignment, no-restricted-syntax,
+  //      query-options/no-any-erasure), parser @typescript-eslint/parser
+  //
+  // No such path exists in this repo today — nothing emits to `build/`, and the
+  // only Next.js app is `apps/docs`, which is outside `packages/**` — so this
+  // is latent rather than live. It is still a real semantic change, and it is
+  // left out of this object pending a maintainer ruling rather than taken
+  // silently under a "changes nothing" banner. See #12304.
+  // ───────────────────────────────────────────────────────────────────────────
+  {
+    ignores: ['**/node_modules/**', '**/dist/**'],
+  },
   {
     files: ['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}'],
     ignores: [


### PR DESCRIPTION
Fixes #12304

Adds one leading config object to `eslint.config.mjs` holding only `ignores` — no `files` key — which is what makes ESLint treat it as a global exclusion. Declared file surface: `eslint.config.mjs`, and nothing else.

## The mechanism, re-derived properly

The card's structural claim was produced by a brace-matching script. It is **confirmed**, but by importing the config module and inspecting the real objects rather than by counting braces:

```
export default is Array: true  length: 7
[0..6] hasFiles=true hasIgnores=true GLOBAL_IGNORE=false
GLOBAL ignore objects (ignores WITHOUT files): 0
objects with NEITHER files nor ignores: 0
```

All seven objects carry `files`, so every `ignores` beside one is object-scoped. After this change: 8 objects, exactly 1 global.

## Two corrections to the card, both measured

**1. The zero-rule population is parsed by espree, not by `@typescript-eslint/parser`.** The card states the emitted files keep "the **custom** (`@typescript-eslint`) parser — so each file is parsed in full", and the title says "at full TS-parser cost". Raw `--print-config` on `packages/core/dist/index.js` says otherwise:

```
"rules": {},
"parser": "espree@11.2.0",
```

The `parser: custom` reading came from a heuristic that treats the always-present `languageOptions.parser` as evidence of a custom parser. My own first probe reproduced the same wrong label before I read the raw output.

**2. `.ts` and `.d.ts` under `dist/` were never in the population at all.** `--print-config` returns literal `undefined` for them — no config object matches, and ESLint does not lint `.ts` by default. So the emitted declaration files, which are the bulk of a built tree by file count, cost nothing today. What was actually being linted under `dist/` is `.js` and `.mjs`, via ESLint's built-in JS defaults.

Neither correction changes the direction of the card. Both change what the fix is buying.

## Acceptance evidence

**Before/after `--print-config`** (`pnpm exec eslint --no-inline-config --print-config`):

| path | before | after |
|---|---|---|
| `packages/core/dist/index.js` | LINTED, 0 rules enabled, espree | not linted |
| `packages/core/dist/index.mjs` | LINTED, 0 rules enabled, espree | not linted |
| `packages/core/dist/index.d.ts` | not linted | not linted |
| `packages/core/src/index.ts` | LINTED, **6** rules enabled | LINTED, **6** rules enabled |

Zero rules enabled on the excluded paths both ways, so no accept/reject semantics move.

**Before/after population**, 50 files per extension dropped under `packages/core/dist`, `build`, `.next`, `.turbo`, counted from `-f json`:

```
before  total linted 796   dist .js = 50   dist .mjs = 50   SOURCE .ts = 96
after   total linted 696   (dist entries absent)            SOURCE .ts = 96
```

Source coverage unchanged. Confirmed again on the real tree with two full runs: **5155 linted files before, 5155 after, 0 errors both**.

**Before/after cost**, 84 MB of bundle-shaped `.js` in 25 files under `packages/core/dist/`, peak RSS sampled from `/proc/PID/status` VmHWM (no `/usr/bin/time` in this container):

| tree | config | wall | peak RSS |
|---|---|---|---|
| source only | before | 80.0 s | 673.6 MB |
| source only | after | 74.6 s | 813.0 MB |
| + 84 MB of `dist/` bundles | before | **511.6 s** | **5424.4 MB** |
| + 84 MB of `dist/` bundles | after | **79.6 s** | **806.1 MB** |

The bundle-bearing tree collapses back to source-only cost: **-432.0 s and -4618 MB**. The card predicted +4.46 GB and +275 s for the same shape; the RSS figure reproduces closely (+4.75 GB here), the wall figure is larger on this more contended container. The card's cost claim stands.

A first attempt at this measurement is **not reported above** because it was invalid: the generated bundles reused identifiers, so ESLint returned 25 parse errors and abandoned the work early. It is worth one line because it independently proved the central claim — all 25 files under `dist/` were reported, i.e. build output really was in the population.

## Scope: `node_modules` and `dist` only, deliberately

The per-object `ignores` below also carry `**/build/**`, `**/.next/**` and `**/.turbo/**`. Those three are **not** promoted here, because promoting them would not be semantics-neutral:

```
packages/core/build/x.ts  -> LINTED, 3 rules ENABLED, @typescript-eslint/parser
   slot-lookup/no-any-assignment, no-restricted-syntax, query-options/no-any-erasure
```

Three of the objects below (the `packages/**` and `examples/**` ones) list only `**/node_modules/**` and `**/dist/**`, so they still match TypeScript under the other three directories. No such path exists in this repo today — nothing emits to `build/`, and the only Next.js app is `apps/docs`, which sits outside `packages/**` — so this is latent rather than live, and it argues for promoting them as a **correction**. That is a real semantic change either way, and it is left for a maintainer ruling rather than taken silently under a "changes nothing" banner. Details in the issue report comment.

No human-authored file is excluded: `git ls-files` matches **0** tracked files under `/dist/`, `/build/`, `/.next/`, `/.turbo/` and `/node_modules/` (control: 4451 tracked files under `/src/`).

No memory ceiling is pinned, per the triage ruling.

## Open edges settled

- **No consumer relies on build output being in the linted population.** Grepped workflows, package scripts and `scripts/` for the ignore patterns and for eslint invocations; the only hits concern turbo inputs and dts freshness. The root `lint` script is the only eslint invocation. Positive control: the same search finds `--no-inline-config` where it is known to be.
- **CI never has build output on disk when it lints.** The `lint` job runs checkout, setup-node, setup-pnpm, cache, `pnpm install --frozen-lockfile`, then `pnpm lint`. No build step precedes ESLint, so this change does not alter CI's population — it removes a local-vs-CI divergence that only a developer who has run `pnpm build` ever saw.

## Verification

Gate union derived at the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, after merging `origin/main` (the first derivation printed `STALE TREE`; this one does not). It reports the change set as the single path `eslint.config.mjs` and no check family naming it. Run at `77d340b0aa`, each exit code captured before any pipe:

| gate | exit | verdict line |
|---|---|---|
| `pnpm lint` | 0 | run in full, `eslint . --no-inline-config`, not narrowed |
| `pnpm check:slot-lookup` | 0 | `slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new` |
| `pnpm check:query-options-erasure` | 0 | `query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new` |
| `pnpm check:verify-stand-in` | 0 | `10 call site(s) reached, 0 asserted driver arguments` |
| `pnpm check:nul-bytes` | 0 | `scanned 6833 text file(s) ... no raw ASCII control bytes` |

The three ratchets are included because they consume this file's named exports; their baselines are unaffected and their populations are unchanged.

Reverse verification used a committed fix, so the restore is provable: each baseline run replaced `eslint.config.mjs` with `git show HEAD~1:eslint.config.mjs`, asserted the on-disk blob hash equalled `git rev-parse HEAD~1:eslint.config.mjs` before measuring, and restored under a `trap ... EXIT INT TERM` that re-checked `git hash-object` against the fixed blob. Every run printed `RESTORE OK — byte-identical`.

## Changeset

`skip-changeset`. The root ESLint config is not published: it ships in no package's `files` array and is not a dependency of anything consumers install. The change alters which paths a local `pnpm lint` enumerates and emits no user-visible behaviour, so there is nothing for a release note to describe.

_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_