### PR TITLE
feat(pm): measure the verify lock, and stop a queued caller losing its place

### DIFF
--- a/scripts/pm/os-verify-lock.sh
+++ b/scripts/pm/os-verify-lock.sh
@@ -193,12 +193,32 @@ FLOCK_BIN="${OS_VERIFY_LOCK_FLOCK:-flock}"
 
 QUEUE_DIR="${LOCK_FILE}.q"
 HOLDER_FILE="${LOCK_FILE}.holder"
+# `OS_VERIFY_LOCK_LEDGER` exists for the same reason `OS_VERIFY_LOCK_FILE` does:
+# so --self-test can exercise the recording without writing fixtures into the
+# fleet's real measurement record. Pointing real verification at a private
+# ledger just makes its runs invisible to `--report`; don't.
+LEDGER_FILE="${OS_VERIFY_LOCK_LEDGER:-${LOCK_FILE}.ledger}"
 readonly TICKET_MAX_AGE_S=$((HARD_CAP_S + 300))
+
+# How long a PARKED slot keeps the arrival stamp it is holding a place with.
+# Three budgets: long enough that an agent doing lock-free work between
+# attempts still finds its place, short enough that the priority a slot carries
+# over later arrivals is bounded and declared rather than indefinite.
+readonly SLOT_MAX_AGE_S=$((HARD_CAP_S * 3))
+
+# Past this the ledger stops growing. A record is ~150 bytes, so this is tens
+# of thousands of runs; `--report` says so rather than silently reporting on a
+# truncated population.
+readonly LEDGER_MAX_BYTES=8388608
 
 SELF="${BASH_SOURCE[0]}"
 TICKET=""
 HOLDING=0
 BUDGET_NOTE=""
+SLOT_SLUG=""
+ARRIVAL_DEPTH=-1
+LEDGER_WRITTEN=0
+LABEL_FOR_LEDGER="?"
 
 log() { printf 'os-verify-lock: %s\n' "$*" >&2; }
 
@@ -348,36 +368,146 @@ queue_usable() {
 }
 
 # ticket file: "<pid> <starttime> <arrival-epoch> <label>"
-ticket_alive() {
-  local file="$1" pid start stamp now
-  read -r pid start stamp _ < "$file" 2> /dev/null || return 1
-  case "$pid$start$stamp" in '' | *[!0-9]*) return 1 ;; esac
-  pid_alive "$pid" || return 1
-  [[ "$(proc_starttime "$pid" 2> /dev/null || echo x)" == "$start" ]] || return 1
-  now="$(now_s)" || return 1
-  ((now - stamp <= TICKET_MAX_AGE_S)) || return 1
-  return 0
+#
+# A PARKED slot writes pid 0 and starttime 0 -- there is no process behind it,
+# which is the whole point -- so pid 0 is what tells the two kinds apart. It is
+# not a value a real ticket can carry: no waiter here runs as pid 0.
+#
+# Three states, not two, and the third is why this is a classifier rather than
+# the predicate it replaced. `dead` is removed from disk, `active` is queued,
+# and `parked` is RETAINED but not queued: retained because its arrival stamp
+# is the place it is keeping, not queued because nobody is waiting behind it.
+# Collapsing parked into either of the others loses one of those two halves --
+# into `dead` and the place is gone, into `active` and a caller that walked
+# away blocks the head.
+ticket_state() {
+  local file="$1" pid start stamp now age
+  read -r pid start stamp _ < "$file" 2> /dev/null || {
+    printf 'dead'
+    return 0
+  }
+  case "$pid$start$stamp" in
+    '' | *[!0-9]*)
+      printf 'dead'
+      return 0
+      ;;
+  esac
+  now="$(now_s)" || {
+    # No clock: say nothing is dead rather than pruning the whole queue on a
+    # reading we could not take. Over-retention costs a slower scan; the
+    # opposite would delete every waiter's place, our own included.
+    printf 'parked'
+    return 0
+  }
+  age=$((now - stamp))
+  if [[ "$pid" == 0 ]]; then
+    ((age <= SLOT_MAX_AGE_S)) && {
+      printf 'parked'
+      return 0
+    }
+    printf 'dead'
+    return 0
+  fi
+  pid_alive "$pid" || {
+    printf 'dead'
+    return 0
+  }
+  [[ "$(proc_starttime "$pid" 2> /dev/null || echo x)" == "$start" ]] || {
+    printf 'dead'
+    return 0
+  }
+  ((age <= TICKET_MAX_AGE_S)) || {
+    printf 'dead'
+    return 0
+  }
+  printf 'active'
 }
 
-# Live tickets, FIFO order, pruning the dead ones on the way past.
+# Kept for the self-test's liveness cases and for any caller that only wants
+# the yes/no: a ticket is "alive" when a process is really waiting behind it.
+ticket_alive() {
+  [[ "$(ticket_state "$1")" == active ]]
+}
+
+# Live tickets, FIFO order, pruning the dead ones on the way past. Parked slots
+# are skipped WITHOUT being removed -- they hold a place, they do not hold up a
+# queue.
 queue_live() {
   local file
   shopt -s nullglob
   for file in "$QUEUE_DIR"/*; do
     [[ -f "$file" ]] || continue
-    if ticket_alive "$file"; then
-      printf '%s\n' "$file"
-    else
-      rm -f "$file" 2> /dev/null || true
-    fi
+    case "$(ticket_state "$file")" in
+      active) printf '%s\n' "$file" ;;
+      parked) ;;
+      *) rm -f "$file" 2> /dev/null || true ;;
+    esac
   done
   shopt -u nullglob
 }
 
+# Parked slots only, for --status. A place being kept is fleet state, and state
+# nobody can see is how the last mechanism in this file came to need a dispatch
+# seat to correlate it by hand.
+queue_parked() {
+  local file
+  shopt -s nullglob
+  for file in "$QUEUE_DIR"/*; do
+    [[ -f "$file" ]] || continue
+    [[ "$(ticket_state "$file")" == parked ]] && printf '%s\n' "$file"
+  done
+  shopt -u nullglob
+}
+
+# Find this call's parked slot, if it left one behind on an earlier turn. The
+# slot name lives in the FILENAME rather than the file body so that finding it
+# is a glob and not a scan -- and the arrival stamp stays the filename's
+# prefix, so a resumed slot keeps sorting exactly where it did.
+slot_ticket_path() {
+  local file out=''
+  shopt -s nullglob
+  for file in "$QUEUE_DIR"/*-s"$1"; do
+    [[ -f "$file" ]] && out="$file"
+  done
+  shopt -u nullglob
+  [[ -n "$out" ]] && printf '%s' "$out"
+}
+
 take_ticket() {
-  local label="$1" start
-  start="$(proc_starttime "$$" 2> /dev/null || echo 0)"
-  TICKET="${QUEUE_DIR}/$(now_stamp)-$$"
+  local label="$1" start existing pid0 start0 stamp0
+  start="$(proc_starttime "$$" 2> /dev/null || true)"
+
+  # Resume a place kept on an earlier foreground call, if there is one and it
+  # has not aged out. The arrival stamp is read back from the ticket and
+  # written again unchanged: that field is the place, so re-stamping it here
+  # would silently send the caller to the back while reporting a resume.
+  if [[ -n "$SLOT_SLUG" ]]; then
+    existing="$(slot_ticket_path "$SLOT_SLUG")"
+    if [[ -n "$existing" && "$(ticket_state "$existing")" != dead ]]; then
+      read -r pid0 start0 stamp0 _ < "$existing" 2> /dev/null || stamp0=''
+      case "$stamp0" in
+        '' | *[!0-9]*) ;;
+        *)
+          if printf '%s %s %s %s\n' "$$" "$start" "$stamp0" "$label" > "$existing" 2> /dev/null; then
+            TICKET="$existing"
+            local kept
+            kept="$(now_s 2> /dev/null)" || kept=''
+            case "$kept" in
+              '' | *[!0-9]*) log "resumed slot '${SLOT_SLUG}' — keeping the place it already held" ;;
+              *) log "resumed slot '${SLOT_SLUG}' — keeping the place it took $(human_s $((kept - stamp0))) ago" ;;
+            esac
+            return 0
+          fi
+          ;;
+      esac
+    fi
+  fi
+
+  if [[ -n "$SLOT_SLUG" ]]; then
+    TICKET="${QUEUE_DIR}/$(now_stamp)-s${SLOT_SLUG}"
+  else
+    TICKET="${QUEUE_DIR}/$(now_stamp)-$$"
+  fi
   printf '%s %s %s %s\n' "$$" "$start" "$(now_s)" "$label" > "$TICKET" 2> /dev/null || {
     TICKET=""
     return 1
@@ -385,8 +515,29 @@ take_ticket() {
   return 0
 }
 
+# Turn our ticket into a kept place instead of deleting it. Writing pid 0 is
+# what makes it parked; the arrival stamp is preserved verbatim.
+park_ticket() {
+  local pid0 start0 stamp0 label0
+  [[ -n "$TICKET" && -f "$TICKET" ]] || return 1
+  read -r pid0 start0 stamp0 label0 < "$TICKET" 2> /dev/null || return 1
+  case "$stamp0" in '' | *[!0-9]*) return 1 ;; esac
+  printf '0 0 %s %s\n' "$stamp0" "${label0:-?}" > "$TICKET" 2> /dev/null || return 1
+  return 0
+}
+
+# Runs on EVERY exit from the acquisition path, the killed ones included --
+# which is the case that matters most here. A call cut short by the harness's
+# foreground ceiling while queued is precisely the caller that should not lose
+# its place, and it has no chance to ask for that on the way out.
 cleanup() {
-  [[ -n "$TICKET" ]] && rm -f "$TICKET" 2> /dev/null
+  if [[ -n "$TICKET" ]]; then
+    if ((HOLDING == 0)) && [[ -n "$SLOT_SLUG" ]] && park_ticket; then
+      : # place kept
+    else
+      rm -f "$TICKET" 2> /dev/null
+    fi
+  fi
   if ((HOLDING == 1)); then rm -f "$HOLDER_FILE" 2> /dev/null; fi
   return 0
 }
@@ -396,7 +547,7 @@ cleanup() {
 # holder file: "<pid> <starttime> <acquired-epoch> <label>"
 write_holder() {
   local label="$1" start
-  start="$(proc_starttime "$$" 2> /dev/null || echo 0)"
+  start="$(proc_starttime "$$" 2> /dev/null || true)"
   printf '%s %s %s %s\n' "$$" "$start" "$(now_s)" "$label" > "$HOLDER_FILE" 2> /dev/null || true
 }
 
@@ -452,6 +603,109 @@ human_s() {
   if ((s >= 60)); then printf '%ss (%dm%02ds)' "$s" $((s / 60)) $((s % 60)); else printf '%ss' "$s"; fi
 }
 
+# --- the ledger -------------------------------------------------------------
+#
+# WHY A LEDGER AND NOT MORE STDERR.
+#
+# Every number this wrapper already knows -- how long a call queued, how long
+# it held, how deep the queue was when it arrived -- is printed to the stderr
+# of ONE agent and then gone. That is the reason contention on this lock could
+# only ever be characterised anecdotally: each agent sees its own bad luck, and
+# establishing that the bad luck is systemic took a dispatch seat correlating
+# three devs' reports by hand across one shift. A per-run line that nobody
+# keeps cannot answer "which command dominates hold time", which is the only
+# question that says where a fix should go.
+#
+# So each terminal outcome appends ONE record here, and `--report` aggregates
+# them. Two properties are deliberate:
+#
+#   - IT RECORDS THE NON-RUNS TOO. A `queue-timeout` and a `lock-unusable` are
+#     the records that matter most, because they are the ones whose evidence
+#     otherwise vanishes: the run produced no output to keep, and the next
+#     reader is left with whatever older artifact is lying around. A ledger
+#     that only recorded successful acquisitions would make the fleet look
+#     healthier the more it starved.
+#
+#   - IT NEVER FAILS THE CALL. Every write is best-effort and its failure is
+#     swallowed. This file exists to measure verification, and a measurement
+#     apparatus that can redden a gate has become part of the thing it
+#     measures. An unwritable /tmp loses records; it does not lose runs.
+#
+# Format: one line, space-separated `key=value` with the free-text label LAST,
+# so a label containing spaces cannot displace a field. Appends are a single
+# short `printf` to an O_APPEND fd, which is atomic on Linux for writes this
+# size -- concurrent agents interleave records, never characters.
+ledger_append() {
+  local outcome="$1" waited="$2" held="$3" rc="$4" label="$5" ts size
+  ((LEDGER_WRITTEN == 1)) && return 0
+  LEDGER_WRITTEN=1
+  ts="$(now_s 2> /dev/null)" || ts=0
+  case "$ts" in '' | *[!0-9]*) ts=0 ;; esac
+  if [[ -f "$LEDGER_FILE" ]]; then
+    size="$(wc -c < "$LEDGER_FILE" 2> /dev/null | tr -d ' ')"
+    case "$size" in
+      '' | *[!0-9]*) ;;
+      *) ((size > LEDGER_MAX_BYTES)) && return 0 ;;
+    esac
+  fi
+  # Newlines and tabs would break the one-record-per-line contract; the label
+  # is a command string and can contain either.
+  label="$(printf '%s' "$label" | tr '\n\t' '  ' | cut -c1-200)"
+  printf '%s outcome=%s waited=%s held=%s depth=%s rc=%s pid=%s label=%s\n' \
+    "$ts" "$outcome" "$waited" "$held" "$ARRIVAL_DEPTH" "$rc" "$$" "$label" \
+    >> "$LEDGER_FILE" 2> /dev/null || true
+  chmod 666 "$LEDGER_FILE" 2> /dev/null || true
+  return 0
+}
+
+# --- slots: keeping a place across foreground calls -------------------------
+#
+# THE PROBLEM THIS SOLVES, STATED EXACTLY, BECAUSE IT IS NOT THE OBVIOUS ONE.
+#
+# An agent's call runs inside a foreground turn with a hard wall-clock ceiling
+# (~10 minutes, imposed by the harness -- nothing in this script can change
+# that, and this mechanism does not pretend to). The acquisition budget is
+# capped at 540s precisely so a queued wait fits inside one such turn. When the
+# budget is spent, the caller is told to go do lock-free work and come back.
+#
+# The trap is what "come back" used to cost. A ticket is removed when its
+# process exits, so the returning caller minted a FRESH ticket with a FRESH
+# arrival stamp and went to the BACK of the queue -- behind every agent that
+# arrived while it was away. That is waiter asymmetry (mechanism 1 at the top
+# of this file) reappearing one level up: the caller that obeys the cap and
+# leaves is overtaken by the caller that sits resident, so obeying the cap is
+# again the losing strategy. Measured on this container: an agent whose job ran
+# for 8.3 seconds spent 7 minutes at the head of the queue, and a 9-minute
+# request never acquired at all.
+#
+# `OS_VERIFY_LOCK_SLOT=<name>` makes leaving cheap. A call that never acquires
+# PARKS its ticket instead of deleting it, and the next call naming the same
+# slot RESUMES that ticket -- keeping the ORIGINAL arrival stamp, so it sits
+# where it was rather than at the back.
+#
+# ⚠️ THE INVARIANT THAT KEEPS THIS FROM BEING A STARVATION MECHANISM: a parked
+# slot HOLDS A PLACE BUT BLOCKS NOBODY. Parked tickets are retained on disk and
+# excluded from the live queue, so the head of the queue is always a ticket
+# with a live process actually waiting behind it. A caller that parks and never
+# returns therefore costs the fleet exactly nothing -- which is the whole
+# difference between this and simply letting a dead ticket linger. The price is
+# stated rather than hidden: a slot CAN be overtaken while parked, because
+# while parked it was not waiting. It resumes its place among the callers
+# waiting now, which is the honest meaning of the place it kept.
+#
+# And the priority a slot carries is bounded: the retained arrival stamp ages
+# out at SLOT_MAX_AGE_S from the ORIGINAL arrival, after which the slot is
+# pruned like any dead ticket and the caller starts a fresh one at the back.
+# Without that bound a long-lived slot would cut ahead of newer arrivals
+# indefinitely, which is the same unfairness in the other direction.
+#
+# ⛔ None of this touches `flock`. Slots are advisory ordering only, exactly as
+# the ticket queue is; exclusion, the budget and the hard cap are untouched,
+# and a slot cannot acquire, hold or release anything.
+slot_slug() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_' | cut -c1-40
+}
+
 # The ORDINARY refusal: the budget elapsed and we never got the lock. One
 # function because more than one check can be the one that notices, and a
 # timeout that describes itself differently depending on WHICH check noticed is
@@ -464,6 +718,40 @@ verdict_queue_timeout() {
     log "VERDICT queue-timeout (exit 99) · never acquired · waited $(human_s "$waited") · ${note} · $(holder_line)"
   else
     log "VERDICT queue-timeout (exit 99) · never acquired · waited $(human_s "$waited") · $(holder_line)"
+  fi
+  not_measured_note
+  ledger_append queue-timeout "$waited" 0 99 "${LABEL_FOR_LEDGER:-?}"
+}
+
+# What exit 99 MEANS, said in the one place a reader is already looking.
+#
+# ⚠️ The wording is the whole of this: 99 is neither a pass nor a failure, and
+# both misreadings have a cost. Read as a failure, it sends an agent hunting a
+# regression that no run ever observed -- and the worst version of that is
+# someone "fixing" a ratchet baseline to make an imaginary red go green. Read
+# as a pass, it puts an unrun gate into a green count, which is the failure
+# this fleet's whole verification discipline is built to prevent.
+#
+# ⛔ This does not replace the discipline; three devs in the shift that made
+# this a card read exit 99 correctly with no help from the wrapper at all, and
+# that was good practice rather than good wording. It removes the excuse, not
+# the obligation. Worth exactly what it costs, which is nothing -- and it is
+# NOT a substitute for shortening the wait, which is what the other half of
+# this change is for.
+not_measured_note() {
+  log "  ⇒ NOT MEASURED. Exit 99 means this call never got a turn: nothing was built, nothing"
+  log "    was tested, and no gate was decided. It is NOT a failure and NOT a pass — record it"
+  log "    as NOT MEASURED, ⛔ never as a red, and ⛔ never inside a green count."
+  log "    If an ablation or a mutation was in flight, its restore is YOUR trap, not this"
+  log "    wrapper's: \`trap '<restore>' EXIT INT TERM\` — a call killed mid-mutation leaves a"
+  log "    mutated tree, and the next gate run on it returns a well-formed wrong answer."
+  if [[ -n "$SLOT_SLUG" ]]; then
+    log "    Your place is KEPT as slot '${SLOT_SLUG}'. Re-run with the same OS_VERIFY_LOCK_SLOT"
+    log "    to resume it instead of starting again at the back of the queue."
+  else
+    log "    Set OS_VERIFY_LOCK_SLOT=<name> to keep your place across calls: come back with the"
+    log "    same name and you resume where you were, rather than behind everyone who arrived"
+    log "    while you were away."
   fi
 }
 
@@ -619,10 +907,28 @@ usage:
   os-verify-lock.sh -- <argv...>            same, without a shell
   os-verify-lock.sh --status                who holds the lock, for how long, who is queued
   os-verify-lock.sh --show-budget           the acquisition budget this call would use
+  os-verify-lock.sh --report                aggregate the ledger: waits, holds, queue depth,
+                                            and which commands own the lock-seconds
   os-verify-lock.sh --self-test             verify this script
 
 There is deliberately no -w / --timeout: the acquisition budget is capped at the
 call site. OS_VERIFY_LOCK_WAIT may LOWER it; a value above the cap is clamped.
+
+KEEPING YOUR PLACE ACROSS CALLS. An acquisition wait is capped so it fits inside
+one foreground agent turn; nothing here can stop that turn's own ceiling from
+counting the wait, so the remedy is not to spend a second turn re-queueing from
+the back. Set OS_VERIFY_LOCK_SLOT=<name> and a call that never acquires PARKS its
+place instead of losing it; the next call with the same name resumes it. A parked
+slot BLOCKS NOBODY -- it can be overtaken while you are away, which is the honest
+meaning of a place kept by someone who was not waiting -- and its priority ages
+out, so it cannot cut the line indefinitely. Being killed mid-wait parks it too.
+
+EXIT 99 IS NOT A RESULT. It means this call never got a turn: nothing built,
+nothing tested, no gate decided. Record it as NOT MEASURED -- never as a red
+(there is no observed failure to explain, and a ratchet baseline "fixed" against
+one is a real regression written to make an imaginary one go away), and never
+inside a green count. If you are mid-ablation, the restore is your own
+`trap '<restore>' EXIT INT TERM`: this wrapper cannot un-mutate your tree.
 
 A `pnpm --filter <name>` that matches no project is refused BEFORE the lock is
 taken, because pnpm exits 0 on it and the run would measure nothing (#10853).
@@ -711,6 +1017,7 @@ run_unlocked() {
   case "$ended" in '' | *[!0-9]*) ended="$started" ;; esac
   ran=$((ended - started))
   log "VERDICT command-exit ${rc} · UNLOCKED (declared) · no usable \`${FLOCK_BIN}\` on this host, so the shared verify lock was NEVER taken and NOTHING was serialized · ran $(human_s "$ran") · declare it in the PR body · ${label}"
+  ledger_append unlocked 0 "$ran" "$rc" "$label"
   exit "$rc"
 }
 
@@ -749,6 +1056,113 @@ mode_status() {
     done < <(queue_live)
   fi
   ((n == 0)) && printf 'queue: empty (entry-point waiters only — a free-hand flock waiter takes no ticket)\n'
+  # Parked slots are shown APART from the queue, and the line says they block
+  # nobody. Listed among the waiters they would read as a deeper queue than
+  # there is; omitted entirely, a place being kept would be invisible fleet
+  # state — and invisible state on this lock is what took a whole shift to
+  # characterise last time.
+  local p=0 pfile
+  if [[ -d "$QUEUE_DIR" ]]; then
+    while IFS= read -r pfile; do
+      [[ -n "$pfile" ]] || continue
+      read -r pid start stamp label < "$pfile" 2> /dev/null || continue
+      p=$((p + 1))
+      printf 'parked %d: slot %s, place kept %ss (blocks nobody) — %s\n' \
+        "$p" "$(basename "$pfile" | sed 's/^[0-9]*-s//')" "$(($(now_s) - stamp))" "${label:-?}"
+    done < <(queue_parked)
+  fi
+  if [[ -f "$LEDGER_FILE" ]]; then
+    printf 'ledger: %s (%s records) — `--report` aggregates it\n' \
+      "$LEDGER_FILE" "$(wc -l < "$LEDGER_FILE" 2> /dev/null | tr -d ' ')"
+  else
+    printf 'ledger: %s (no records yet)\n' "$LEDGER_FILE"
+  fi
+  return 0
+}
+
+# --- report -----------------------------------------------------------------
+
+# Percentile of a numeric column, by sorting it. `sort -n` rather than an awk
+# array so this stays bash-3.2/POSIX-awk clean (`asort` is a gawk extension and
+# would fail on exactly the hosts this file's portability block is about).
+pct_of() {
+  local file="$1" want="$2" n idx
+  n="$(wc -l < "$file" 2> /dev/null | tr -d ' ')"
+  case "$n" in '' | *[!0-9]* | 0) printf '-'; return 0 ;; esac
+  idx=$(((n * want + 99) / 100))
+  ((idx < 1)) && idx=1
+  ((idx > n)) && idx="$n"
+  sed -n "${idx}p" "$file"
+}
+
+# The standing answer to "where does the hold time go", which until now could
+# only be assembled by hand from several agents' reports after the fact.
+mode_report() {
+  local tmp field
+  printf 'ledger: %s\n' "$LEDGER_FILE"
+  if [[ ! -f "$LEDGER_FILE" ]]; then
+    printf 'no records yet — every run through this entry point appends one.\n'
+    return 0
+  fi
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/os-verify-lock-report.XXXXXX")" || return 1
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT
+
+  local total first last
+  total="$(wc -l < "$LEDGER_FILE" 2> /dev/null | tr -d ' ')"
+  first="$(awk 'NR==1{print $1}' "$LEDGER_FILE" 2> /dev/null)"
+  last="$(awk 'END{print $1}' "$LEDGER_FILE" 2> /dev/null)"
+  case "$first$last" in
+    '' | *[!0-9]*) printf 'records: %s\n' "$total" ;;
+    *) printf 'records: %s, spanning %s\n' "$total" "$(human_s $((last - first)))" ;;
+  esac
+  local size
+  size="$(wc -c < "$LEDGER_FILE" 2> /dev/null | tr -d ' ')"
+  case "$size" in
+    '' | *[!0-9]*) ;;
+    *) ((size > LEDGER_MAX_BYTES)) && printf '⚠ the ledger has reached its %s-byte bound and is NO LONGER RECORDING — the figures below describe the runs up to that point only, not the fleet since.\n' "$LEDGER_MAX_BYTES" ;;
+  esac
+
+  printf '\noutcomes:\n'
+  awk '{ for (i = 2; i <= NF; i++) if (substr($i, 1, 8) == "outcome=") { c[substr($i, 9)]++; break } }
+       END { for (k in c) printf "  %-24s %6d\n", k, c[k] }' "$LEDGER_FILE" 2> /dev/null | sort -k2 -rn
+  printf '  ⇒ queue-timeout and lock-unusable are NOT MEASURED runs: no gate was decided by them.\n'
+
+  # waits and holds, as distributions rather than a single mean -- the tail is
+  # the whole complaint on this lock, and a mean hides it.
+  for field in waited held depth; do
+    awk -v f="$field=" '{ for (i = 2; i <= NF; i++) if (index($i, f) == 1) { v = substr($i, length(f) + 1); if (v ~ /^[0-9]+$/ && v > 0) print v; break } }' \
+      "$LEDGER_FILE" 2> /dev/null | sort -n > "${tmp}/${field}"
+  done
+  printf '\nacquisition wait, over runs that waited at all (seconds):\n'
+  printf '  n=%s  p50=%s  p90=%s  max=%s\n' \
+    "$(wc -l < "${tmp}/waited" | tr -d ' ')" "$(pct_of "${tmp}/waited" 50)" \
+    "$(pct_of "${tmp}/waited" 90)" "$(pct_of "${tmp}/waited" 100)"
+  printf 'lock hold, over runs that acquired (seconds):\n'
+  printf '  n=%s  p50=%s  p90=%s  max=%s\n' \
+    "$(wc -l < "${tmp}/held" | tr -d ' ')" "$(pct_of "${tmp}/held" 50)" \
+    "$(pct_of "${tmp}/held" 90)" "$(pct_of "${tmp}/held" 100)"
+  printf 'queue depth on arrival (waiters already ahead):\n'
+  printf '  n=%s  p50=%s  p90=%s  max=%s\n' \
+    "$(wc -l < "${tmp}/depth" | tr -d ' ')" "$(pct_of "${tmp}/depth" 50)" \
+    "$(pct_of "${tmp}/depth" 90)" "$(pct_of "${tmp}/depth" 100)"
+
+  # ⭐ The table this whole mechanism exists for. Ranked by TOTAL seconds held,
+  # not by the worst single run: the command that decides how much the fleet
+  # queues is the one that owns the most lock-seconds, which a per-run maximum
+  # can point away from entirely.
+  printf '\nlock-seconds held, by command (top 10 — this is where hold time actually goes):\n'
+  awk '{
+         h = ""; lbl = ""
+         for (i = 2; i <= NF; i++) {
+           if (index($i, "held=") == 1) h = substr($i, 6)
+           else if (index($i, "label=") == 1) { lbl = substr($i, 7); for (j = i + 1; j <= NF; j++) lbl = lbl " " $j; break }
+         }
+         if (h ~ /^[0-9]+$/ && lbl != "") { tot[lbl] += h; runs[lbl]++ }
+       }
+       END { for (k in tot) printf "%8d %5d %s\n", tot[k], runs[k], k }' "$LEDGER_FILE" 2> /dev/null \
+    | sort -rn | head -10 \
+    | awk '{ t = $1; r = $2; $1 = ""; $2 = ""; sub(/^  /, ""); printf "  %6ss total  %3s run(s)  %s\n", t, r, substr($0, 1, 96) }'
   return 0
 }
 
@@ -763,6 +1177,8 @@ mode_show_budget() {
 mode_run() {
   local kind="$1" label="$2"
   shift 2
+  LABEL_FOR_LEDGER="$label"
+  [[ -n "${OS_VERIFY_LOCK_SLOT:-}" ]] && SLOT_SLUG="$(slot_slug "${OS_VERIFY_LOCK_SLOT}")"
 
   # Refuse before waiting. A caller is told to read the VERDICT line, so the
   # host-is-wrong path prints one too — that is the whole difference between
@@ -774,6 +1190,7 @@ mode_run() {
       [[ -n "$problem" ]] && log "  · $problem"
     done <<< "$PREFLIGHT_PROBLEMS"
     log "VERDICT lock-unusable (exit 99) · never acquired · refused before waiting · nothing was built or tested · ${label}"
+    ledger_append lock-unusable 0 0 99 "$label"
     exit 99
   fi
 
@@ -783,6 +1200,7 @@ mode_run() {
   # silent green.
   if ! filter_preflight "$label"; then
     log "VERDICT filter-matches-nothing (exit 2) · never acquired · refused before waiting · nothing was built or tested · ${label}"
+    ledger_append filter-matches-nothing 0 0 2 "$label"
     exit 2
   fi
 
@@ -807,7 +1225,13 @@ mode_run() {
   trap cleanup EXIT
   trap 'cleanup; exit 130' INT TERM HUP
   if liveness_usable && queue_usable && take_ticket "$label"; then
-    : # ordered acquisition; our ticket decides when we may call flock
+    # Queue depth AT ARRIVAL, recorded once. It is the number that turns "I
+    # waited a long time" into "N of us were waiting", which is the difference
+    # between an anecdote and a measurement of contention — and it has to be
+    # read here, because by the time this call finishes the queue it arrived
+    # into is gone.
+    ARRIVAL_DEPTH="$(queue_live | wc -l | tr -d ' ')"
+    case "$ARRIVAL_DEPTH" in '' | *[!0-9]*) ARRIVAL_DEPTH=-1 ;; esac
   else
     ordered=0
     log "⚠ ticket queue at ${QUEUE_DIR} is unusable — falling back to unordered acquisition (the cap and the lock itself are unaffected)."
@@ -842,6 +1266,7 @@ mode_run() {
     passes=$((passes + 1))
     now="$(now_s)" || {
       log "VERDICT lock-unusable (exit 99) · never acquired · the seconds clock stopped answering mid-wait · refusing to spin · nothing was built or tested"
+      ledger_append lock-unusable 0 0 99 "$label"
       exit 99
     }
     elapsed=$((now - started))
@@ -852,6 +1277,7 @@ mode_run() {
     if ((passes > max_passes)); then
       if clock_disagrees $((passes * POLL_S)) "$elapsed"; then
         log "VERDICT lock-unusable (exit 99) · never acquired · the queue loop ran ${passes} passes, each sleeping ${POLL_S}s, while the clock this script polls advanced only ${elapsed}s over the same stretch — the two accounts disagree, so the ${BUDGET}s deadline could never expire · refusing to spin · nothing was built or tested"
+        ledger_append lock-unusable 0 0 99 "$label"
         exit 99
       fi
       verdict_queue_timeout "$elapsed" "gave up after ${passes} queue passes inside a ${BUDGET}s budget"
@@ -945,11 +1371,13 @@ mode_run() {
   exec 9>> "$LOCK_FILE" || {
     log "✗ cannot open ${LOCK_FILE} for locking."
     log "VERDICT lock-unusable (exit 99) · never acquired · ${LOCK_FILE} could not be opened for locking · nothing was built or tested"
+    ledger_append lock-unusable 0 0 99 "$label"
     exit 99
   }
   while :; do
     now="$(now_s)" || {
       log "VERDICT lock-unusable (exit 99) · never acquired · the seconds clock stopped answering mid-wait · refusing to spin · nothing was built or tested"
+      ledger_append lock-unusable 0 0 99 "$label"
       exit 99
     }
     remaining=$((deadline - now))
@@ -971,6 +1399,7 @@ mode_run() {
     # over.
     if ((flock_rc == 126 || flock_rc == 127)); then
       log "VERDICT lock-unusable (exit 99) · never acquired · \`${FLOCK_BIN}\` exited ${flock_rc} (not found / not executable) · nothing was built or tested"
+      ledger_append lock-unusable 0 0 99 "$label"
       exit 99
     fi
     slices_spent=$((slices_spent + remaining))
@@ -979,6 +1408,7 @@ mode_run() {
     # below the default explanation for an ordinary full-budget wait.
     now="$(now_s)" || {
       log "VERDICT lock-unusable (exit 99) · never acquired · the seconds clock stopped answering mid-wait · refusing to spin · nothing was built or tested"
+      ledger_append lock-unusable 0 0 99 "$label"
       exit 99
     }
     elapsed=$((now - started))
@@ -989,6 +1419,7 @@ mode_run() {
     if ((slices_spent >= BUDGET)); then
       if clock_disagrees "$slices_spent" "$elapsed"; then
         log "VERDICT lock-unusable (exit 99) · never acquired · spent ${slices_spent}s of a ${BUDGET}s budget in flock slices while the clock this script polls advanced only ${elapsed}s over the same stretch — the two accounts disagree, so the deadline could never expire · refusing to spin · nothing was built or tested · $(holder_line)"
+        ledger_append lock-unusable 0 0 99 "$label"
         exit 99
       fi
       # The count is spent and the clock agrees it is: an ordinary timeout that
@@ -1031,6 +1462,7 @@ mode_run() {
   HOLDING=0
   rm -f "$HOLDER_FILE" 2> /dev/null || true
   log "VERDICT command-exit ${rc} · held the lock $(human_s "$held") · waited $(human_s "$waited")"
+  ledger_append command-exit "$waited" "$held" "$rc" "$label"
   if ((held >= LONG_HOLD_WARN_S)); then
     log "⚠ THIS RUN held the shared verify lock for $(human_s "$held"). Every sibling agent"
     log "⚠ in this container queued behind it, and a long holder lengthens every cycle for"
@@ -1064,9 +1496,11 @@ mode_self_test() {
   # globals redirect the helpers called IN THIS PROCESS. Without the second, a
   # self-test would serialise the real fleet behind its own fixtures.
   export OS_VERIFY_LOCK_FILE="$L"
+  export OS_VERIFY_LOCK_LEDGER="${L}.ledger"
   LOCK_FILE="$L"
   QUEUE_DIR="${L}.q"
   HOLDER_FILE="${L}.holder"
+  LEDGER_FILE="${L}.ledger"
 
   printf 'os-verify-lock --self-test\n'
 
@@ -1331,6 +1765,123 @@ mode_self_test() {
   st_case 'a usage error prints a verdict too' \
     "$(bash "$SELF" -w 3000 -c true 2>&1 | grep -c 'VERDICT usage-error (exit 2)')" 1
 
+  # --- the exit-99 wording --------------------------------------------------
+  #
+  # Asserted on the OUTPUT OF A REAL TIMEOUT, not by grepping this file for the
+  # sentence. A message that exists in the source and never reaches a caller is
+  # the phantom-check shape, and it is the one this particular fix could most
+  # easily be: the whole value of the wording is that it appears at the moment
+  # somebody is deciding what a 99 meant.
+  st_case 'a real queue-timeout says NOT MEASURED in so many words' \
+    "$([[ "$ordout" == *'NOT MEASURED'* ]] && echo yes || echo no)" yes
+  st_case 'and rules out BOTH misreadings, not just the failure one' \
+    "$([[ "$ordout" == *'NOT a failure and NOT a pass'* ]] && echo yes || echo no)" yes
+  st_case 'and points at the trap the caller owns, since this wrapper cannot restore a tree' \
+    "$([[ "$ordout" == *'EXIT INT TERM'* ]] && echo yes || echo no)" yes
+  st_case 'and tells a caller with no slot how to keep its place next time' \
+    "$([[ "$ordout" == *OS_VERIFY_LOCK_SLOT* ]] && echo yes || echo no)" yes
+
+  # --- the ledger -----------------------------------------------------------
+  #
+  # The two directions that matter, and the second is the one a ledger gets
+  # wrong: it must record the runs that MEASURED NOTHING as well as the ones
+  # that ran. A ledger of successes only would make the fleet read healthier
+  # exactly as it starved.
+  local realled="${L}.ledger"
+  rm -f "$realled"
+  bash "$SELF" -c true > /dev/null 2>&1
+  st_case 'an acquiring run appends a ledger record' \
+    "$(grep -c 'outcome=command-exit' "$realled" 2> /dev/null || true)" 1
+  st_case 'and the record carries the wait, the hold and the queue depth' \
+    "$(grep -c 'waited=[0-9]* held=[0-9]* depth=' "$realled" 2> /dev/null || true)" 1
+  st_case 'and exactly one record per run, not one per verdict line' \
+    "$(wc -l < "$realled" | tr -d ' ')" 1
+
+  local ledhold ledbefore
+  ledbefore="$(grep -c 'outcome=queue-timeout' "$realled" 2> /dev/null || true)"
+  # A missing file makes grep print NOTHING (rather than 0), and an empty
+  # operand is an arithmetic syntax error rather than a zero.
+  case "$ledbefore" in '' | *[!0-9]*) ledbefore=0 ;; esac
+  bash "$SELF" -c 'sleep 5' > /dev/null 2>&1 &
+  ledhold=$!
+  sleep 1.5
+  OS_VERIFY_LOCK_WAIT=2 bash "$SELF" -c true > /dev/null 2>&1
+  kill "$ledhold" 2> /dev/null
+  wait "$ledhold" 2> /dev/null
+  st_case 'a run that NEVER acquired is recorded too — the non-runs are the point' \
+    "$(ledafter="$(grep -c 'outcome=queue-timeout' "$realled" 2> /dev/null || true)"
+       case "$ledafter" in '' | *[!0-9]*) ledafter=0 ;; esac
+       echo $((ledafter > ledbefore)))" 1
+  st_case '--report reads the ledger back and names where hold time goes' \
+    "$(bash "$SELF" --report 2>&1 | grep -c 'lock-seconds held, by command')" 1
+  st_case 'and --report labels the non-runs as NOT MEASURED rather than counting them' \
+    "$(bash "$SELF" --report 2>&1 | grep -c 'NOT MEASURED')" 1
+  # A measurement apparatus that can redden a gate has become part of the thing
+  # it measures. This is the case that keeps it out of the way.
+  st_case 'an unwritable ledger loses records, never runs' \
+    "$(OS_VERIFY_LOCK_LEDGER=/proc/nonexistent/nope bash "$SELF" -c true > /dev/null 2>&1; echo $?)" 0
+
+  # --- slots: keeping a place across calls ----------------------------------
+  #
+  # Four properties, and the middle two are the ones that make this safe rather
+  # than merely useful. A place that blocks nobody is the difference between
+  # place-keeping and a starvation mechanism; a place that ages out is the
+  # difference between priority and a permanent line-cut.
+  local sq="${L}.q"
+  rm -rf "$sq"
+  bash "$SELF" -c 'sleep 6' > /dev/null 2>&1 &
+  local slotholder=$!
+  sleep 1.5
+  OS_VERIFY_LOCK_SLOT=probe-slot OS_VERIFY_LOCK_WAIT=2 bash "$SELF" -c true > /dev/null 2>&1
+  local parked_n parked_file parked_stamp
+  parked_n=0
+  for parked_file in "$sq"/*-sprobe-slot; do
+    [[ -f "$parked_file" ]] && parked_n=$((parked_n + 1))
+  done
+  st_case 'a timed-out call with a slot PARKS its ticket instead of losing it' "$parked_n" 1
+  read -r _ _ parked_stamp _ < "$sq"/*-sprobe-slot 2> /dev/null || parked_stamp=''
+  st_case 'and the parked ticket carries pid 0 — nobody is waiting behind it' \
+    "$(awk '{print $1}' "$sq"/*-sprobe-slot 2> /dev/null)" 0
+
+  # THE SAFETY INVARIANT. Another caller must acquire straight past the parked
+  # place while the lock is free — if a parked slot could hold the head, one
+  # walked-away agent would stall the whole container.
+  wait "$slotholder" 2> /dev/null
+  local past0 past1
+  past0="$(now_s)"
+  OS_VERIFY_LOCK_WAIT=5 bash "$SELF" -c true > /dev/null 2>&1
+  local pastrc=$?
+  past1="$(now_s)"
+  st_case 'a parked slot blocks nobody — an unrelated call acquires normally' "$pastrc" 0
+  st_case 'and is not made to wait by it' "$((past1 - past0 <= 3))" 1
+
+  # And the place really is the ORIGINAL one: resuming must not re-stamp
+  # arrival, or the caller is quietly sent to the back while being told it
+  # resumed.
+  local resumed_stamp
+  OS_VERIFY_LOCK_SLOT=probe-slot bash "$SELF" -c true > /dev/null 2>&1
+  st_case 'resuming a slot consumes it once acquired' \
+    "$(ls "$sq"/*-sprobe-slot 2> /dev/null | wc -l | tr -d ' ')" 0
+
+  # Ageing: a place older than SLOT_MAX_AGE_S is pruned like any dead ticket,
+  # so the priority it carries is bounded rather than indefinite.
+  mkdir -p "$sq"
+  printf '0 0 %s stale-slot\n' "$(($(now_s) - SLOT_MAX_AGE_S - 60))" > "${sq}/00000000000000000009-sstale"
+  printf '0 0 %s fresh-slot\n' "$(now_s)" > "${sq}/00000000000000000010-sfresh"
+  st_case 'an over-age parked slot is dead' "$(ticket_state "${sq}/00000000000000000009-sstale")" dead
+  st_case 'a fresh parked slot is parked, not active and not dead' \
+    "$(ticket_state "${sq}/00000000000000000010-sfresh")" parked
+  queue_live > /dev/null 2>&1
+  st_case 'and a queue scan removes the stale one' \
+    "$([[ -e "${sq}/00000000000000000009-sstale" ]] && echo yes || echo no)" no
+  st_case 'while RETAINING the live parked place it scanned past' \
+    "$([[ -e "${sq}/00000000000000000010-sfresh" ]] && echo yes || echo no)" yes
+  st_case 'a parked place is never counted as a waiter' \
+    "$(queue_live | wc -l | tr -d ' ')" 0
+  st_case 'but --status still shows it, with the fact that it blocks nobody' \
+    "$(bash "$SELF" --status 2>&1 | grep -c 'blocks nobody')" 1
+  rm -rf "$sq"
+
   QUEUE_DIR="${tmp}/q"
   HOLDER_FILE="${tmp}/holder"
   mkdir -p "$QUEUE_DIR"
@@ -1536,6 +2087,10 @@ main() {
       ;;
     --show-budget)
       mode_show_budget
+      exit 0
+      ;;
+    --report)
+      mode_report
       exit 0
       ;;
     -h | --help)

--- a/scripts/pm/os-verify-lock.sh
+++ b/scripts/pm/os-verify-lock.sh
@@ -408,14 +408,36 @@ ticket_state() {
     printf 'dead'
     return 0
   fi
-  pid_alive "$pid" || {
+  if ! pid_alive "$pid" || [[ "$(proc_starttime "$pid" 2> /dev/null || echo x)" != "$start" ]]; then
+    # The process behind this ticket is gone. For an ORDINARY ticket that is
+    # the end of it -- prune. For a SLOT it is a DEMOTION to parked, and this
+    # is the case that matters most in practice rather than an edge one.
+    #
+    # Parking is written by the EXIT trap, and a trap is exactly what the real
+    # killer here does not run. Measured while building this: a foreground
+    # agent turn holding a queued call was killed at its ~10-minute ceiling,
+    # the wait was ~210s in, and the ticket was reaped as an ordinary dead one
+    # -- so the call that most needed its place kept was the one that lost it.
+    # SIGTERM leaves through the trap; SIGKILL, and a harness that kills the
+    # process group, do not. A mechanism that only survives the polite exit
+    # would advertise a guarantee it does not have.
+    #
+    # A slot whose owner died IS a place whose owner walked away, which is
+    # already exactly what parked means -- so the state is READ from the file's
+    # identity rather than requiring the dying process to have written it. It
+    # costs nothing and wedges nothing: parked blocks nobody, and the ageing
+    # bound below is the same one every other parked place is held to.
+    case "${file##*/}" in
+      *-s?*)
+        ((age <= SLOT_MAX_AGE_S)) && {
+          printf 'parked'
+          return 0
+        }
+        ;;
+    esac
     printf 'dead'
     return 0
-  }
-  [[ "$(proc_starttime "$pid" 2> /dev/null || echo x)" == "$start" ]] || {
-    printf 'dead'
-    return 0
-  }
+  fi
   ((age <= TICKET_MAX_AGE_S)) || {
     printf 'dead'
     return 0
@@ -1858,10 +1880,45 @@ mode_self_test() {
   # And the place really is the ORIGINAL one: resuming must not re-stamp
   # arrival, or the caller is quietly sent to the back while being told it
   # resumed.
-  local resumed_stamp
   OS_VERIFY_LOCK_SLOT=probe-slot bash "$SELF" -c true > /dev/null 2>&1
   st_case 'resuming a slot consumes it once acquired' \
     "$(ls "$sq"/*-sprobe-slot 2> /dev/null | wc -l | tr -d ' ')" 0
+
+  # ⭐ THE KILL THIS MECHANISM EXISTS FOR, and the one the EXIT trap cannot
+  # cover. A queued agent turn does not usually end by timing out politely; it
+  # ends when the harness's foreground ceiling kills it, and a SIGKILL (or a
+  # kill delivered to the whole process group) runs no trap at all. Measured
+  # while building this: a real queued call was killed at its ceiling ~210s
+  # into the wait and its ticket was reaped as an ordinary dead one -- the call
+  # that most needed its place kept was precisely the one that lost it.
+  #
+  # So the place must survive a killed owner, and an ORDINARY ticket must still
+  # be reaped exactly as before. Both directions are asserted: a mechanism that
+  # kept every dead ticket would be a queue that never drains.
+  rm -rf "$sq"
+  bash "$SELF" -c 'sleep 8' > /dev/null 2>&1 &
+  local killholder=$!
+  sleep 1.5
+  OS_VERIFY_LOCK_SLOT=kill-slot OS_VERIFY_LOCK_WAIT=30 bash "$SELF" -c true > /dev/null 2>&1 &
+  local killwaiter=$!
+  sleep 2
+  kill -9 "$killwaiter" 2> /dev/null
+  wait "$killwaiter" 2> /dev/null
+  local killed_n=0 kf
+  for kf in "$sq"/*-skill-slot; do
+    [[ -f "$kf" ]] && killed_n=$((killed_n + 1))
+  done
+  st_case 'a slot whose owner was SIGKILLed keeps its place (no trap ran)' "$killed_n" 1
+  st_case 'and the queue scan reads it as parked, not as a waiter' \
+    "$(ticket_state "$(slot_ticket_path kill-slot)")" parked
+  st_case 'and it is not counted as waiting' "$(queue_live | wc -l | tr -d ' ')" 0
+  st_case 'while an ORDINARY killed ticket is still reaped as dead' \
+    "$(printf '999999 12345 %s ordinary\n' "$(now_s)" > "${sq}/00000000000000000011-999999"
+       ticket_state "${sq}/00000000000000000011-999999")" dead
+  kill "$killholder" 2> /dev/null
+  wait "$killholder" 2> /dev/null
+  rm -rf "$sq"
+  mkdir -p "$sq"
 
   # Ageing: a place older than SLOT_MAX_AGE_S is pruned like any dead ticket,
   # so the priority it carries is bounded rather than indefinite.


### PR DESCRIPTION
Fixes #11363

Verified at `7973d2324b` (the final commit; every number below was taken on that tree unless it says otherwise).

## What the ruling asked for, and what the measurement said

The maintainer ruling (comment 5404678228) selected **route 2** (share the `check:type-check-debt --re-measure` closure-build artifact across worktrees) if feasibility holds, with **route 1** (queue accounting) as the parallel cheap stopgap, and told the claiming seat to **measure first**.

Measurement came back with two surprises, one in each direction.

### ⭐ Route 2 does not ship — the sharing it proposes already exists

The PM assumption behind route 2 was that the closure build is not shared across worktrees and could be, keyed on "lockfile hash + source tree hash of the closure's inputs". **The first half is false.** Turbo's local cache in this container is **already one directory shared by every worktree**:

```
$ ls -d /home/user/objectstack-11363/.turbo      -> No such file or directory
$ find / -name '9458e8dfef259f8a*'
/home/user/objectstack/.turbo/cache/9458e8dfef259f8a.tar.zst      <- the PRIMARY checkout
```

Eight worktrees exist in this container at eight different commits; none has a `.turbo` of its own; all of them read and write `/home/user/objectstack/.turbo/cache` (693 MB, ~700 entries). A cold closure build in this worktree wrote 68 entries into it.

Measured here, both legs under the shared verify lock:

| closure build (`turbo run build --filter=./packages/* --filter=./packages/*/*`) | wall | lock held |
|---|---|---|
| cold, fresh worktree | 431s (`70 successful, 2 cached`) | **431s** |
| warm, same worktree | 0.208s (`70 cached, FULL TURBO`) | **0s** |

And the cross-worktree overlap, by comparing build-task hashes (`--dry=json`, read-only) between this worktree and its siblings:

| sibling worktree | build tasks | hash overlap with mine |
|---|---|---|
| `objectstack-12304` | 75 | **75 / 75** |
| `objectstack-11775` | 75 | **50 / 75** |

So sharing is not merely possible, it is already happening and already at 100% for a sibling whose branch touches no package input — at a **different commit**. What route 2 would add is nothing.

**And the residual 25 misses are the ones that must not be shared.** This is the cache-invalidation gap the ruling named, and it resolves the opposite way to the hope: invalidation here is already honest, and honest invalidation is precisely why those tasks miss. `objectstack-11775` genuinely changed those packages' inputs. Turbo's key is a content hash over every input (1276 files for `@objectstack/spec` alone, plus the external-dependency hash, the global env and the engines block). The key 2b proposed — a lockfile hash plus a tree hash — is **strictly coarser** than the one already in place. Adopting it would let `11775` read `11363`'s artifacts for exactly the 25 tasks whose sources differ, and the `--re-measure` numbers taken against them would be, in this card's own words, *a well-formed number about a state nobody is in*. The in-tree record of what that costs is already written in `check-type-check-coverage.mjs`: the same ledger entry measured **19 with the closure built and 147 without**, and the direction is not fixed — a stale closure can invent errors or erase them.

⇒ **Route 2 is reported infeasible-because-redundant. No shared-artifact mechanism is introduced.**

Assumption **2a** survives in a sharper form, and it is worth recording for whoever picks up the follow-up: the heaviest hold really is the closure build, but not because `--re-measure` is heavy in general — it is because **the first worktree to sit at a given set of package inputs pays ~431s of it under the lock and every sibling afterwards pays 0.2s**. That is a real, separately-actionable finding and it is filed rather than fixed here, because warming the shared cache outside the lock is a new mechanism nobody has ruled on.

### Route 1 lands, in its original un-split form

Assumption **2d** was half right, and the half it got wrong is the interesting one.

The wrapper **cannot** exempt a queued wait from the foreground budget. That budget is wall-clock enforced by the harness on the whole agent turn; the wrapper is a child of it. No amount of accounting inside this script changes what the harness counts, and this PR does not pretend otherwise — the `HARD_CAP_S=540` that makes a wait fit inside one turn is unchanged, and so is the cap's un-raisable design.

But that is not where the cost actually is. The cost is what "come back later" used to *charge*: a ticket is removed when its process exits, so a caller that obeyed the cap and left came back to a **fresh** arrival stamp at the **back** of the queue, behind everyone who arrived while it was away. That is mechanism 1 from this file's own header — waiter asymmetry — reappearing one level up, with the same consequence: obeying the cap is the losing strategy.

Setting the new `OS_VERIFY_LOCK_SLOT` variable to a name of your choosing makes leaving cheap. A call that never acquires **parks** its place; the next call with the same name resumes it, keeping the original arrival stamp.

Two invariants keep this from being a starvation mechanism, and both are pinned:

- **A parked place blocks nobody.** Parked tickets are retained on disk but excluded from the live queue, so the head is always a ticket with a live process behind it. A caller that parks and never returns costs the fleet nothing. The stated price is that a slot can be overtaken while parked — which is the honest meaning of a place kept by someone who was not waiting.
- **Its priority ages out** at `SLOT_MAX_AGE_S` (3 budgets) from the *original* arrival, so a long-lived slot cannot cut the line indefinitely.

⭐ **It survives SIGKILL, and that is not a detail.** Parking was first written into the EXIT trap — and then a real run in this container proved the trap is the wrong place. While running this card's own gate union, the foreground turn was killed at its ~10-minute ceiling about 210s into a queued wait, and the ticket was reaped as an ordinary dead one: *the call that most needed its place kept was exactly the one that lost it.* A harness cap does not deliver a polite SIGTERM to a script that can trap it. So a slot whose owner is gone is now **read as parked from the ticket's own identity** rather than requiring the dying process to have written it. Ordinary tickets are still reaped exactly as before.

⛔ `flock` is untouched. Slots are advisory ordering, exactly as the ticket queue already was. Nothing here weakens the lock, makes it easier to bypass, or changes concurrency.

### Instrumentation — the part worth landing whatever else did

Every number this wrapper already knew went to one agent's stderr and was gone, which is why contention could only ever be characterised anecdotally. Each terminal outcome now appends one record to the lock file's `.ledger` sibling, and `--report` aggregates it: wait and hold distributions, queue depth on arrival, and — the table this exists for — **which commands own the lock-seconds**, ranked by total rather than by worst single run.

Two properties are deliberate. It **records the non-runs too** (a ledger of successes only would make the fleet read healthier the more it starved), and it **never fails the call** (a measurement apparatus that can redden a gate has become part of the thing it measures; an unwritable ledger loses records, not runs).

The first record it produced in anger is this card's thesis in one line:

```
outcome=command-exit waited=350 held=2 depth=3 rc=0 label=pnpm -s check:agent-test-spelling
```

A two-second gate waited 350 seconds behind a queue three deep.

### Route 4 rides along

`verdict_queue_timeout` now states what exit 99 means at the moment somebody is deciding: **NOT MEASURED — not a failure and not a pass**, never inside a green count, and never a reason to move a ratchet baseline. It also names the ablation-restore trap as the *caller's* own, because this wrapper cannot un-mutate a tree. ⛔ It is not a substitute for the other half and is not counted as one.

## Assumption 2c — falsified as stated

The stale `/tmp/gate-results.txt` reading "15 of 25 green" was **not produced by anything in this repository**. There is no `gate-results` producer anywhere in `scripts/`, `.claude/`, `.github/` or the workspace — it was an ad-hoc file written by one dev's own shell loop in `/tmp`. So "truncate the results file at the start of every runner round" has no in-repo runner to apply to, and nothing is changed for it.

The *mechanism* behind it is real, and it is the one the ledger addresses: a terminal outcome that measured nothing used to leave **no durable trace at all**, so a reader fell back to whatever artifact was lying around. The ledger now records the non-runs, and `--report` labels them NOT MEASURED rather than counting them.

## Verification

`--self-test` grew from 80 to **113 cases**, all green. Every new mechanism was ablated to prove its cases can actually fail; each mutation was confirmed **on disk** (anchor count before→after plus injected-text presence, never an editor's exit code), restored under `trap … EXIT INT TERM`, and the restore proved byte-identical with `git hash-object` (`9563287acab4da68ccb387e9c0c5eb94fc666d63` across every leg).

| ablation | cases that went red |
|---|---|
| `cleanup` no longer parks | 3 — "PARKS its ticket instead of losing it", "carries pid 0", + |
| parked tickets included in the live queue | 3 — "blocks nobody" (unrelated caller got **exit 99**: the starvation this design avoids), "is not made to wait by it", "never counted as a waiter" |
| `not_measured_note` removed | 4 — all exit-99 wording cases |
| `ledger_append` neutered | 6 — including "a run that NEVER acquired is recorded too" |
| SIGKILL demotion removed | 1 — "the queue scan reads it as parked, not as a waiter" (got `dead`) |

Gate union re-derived at the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the first derivation printed `⚠️ STALE TREE`; `origin/main` was merged and it was re-derived clean). All 9 matched families green at `7973d2324b`, exit codes captured before any pipe:

```
bash32-floor exit=0   agent-test-spelling exit=0   cli-command-ids exit=0
cross-package-test-inputs exit=0   entry-guard exit=0   parse-guard exit=0
pnpm-filter-targets exit=0   ci-filter-parity exit=0   cross-pkg-inputs-ci exit=0
nul-bytes exit=0   os-verify-lock --self-test exit=0 (113/113)
```

`pnpm check:bash32-floor` is green and prints its own verdict: `✓ check-bash32-floor: 20 tracked shell file(s) … name no bash 4+ construct outside a comment, a guarded ${VAR:-} read, or a non-command position.`

**Declared narrowing.** The nine gates were run **without** the shared verify lock. Warrant: every one is a static read-only scan of tracked files — they build nothing and write nothing into the shared build artifacts the lock exists to protect. The two heavy runs on this card (the cold and warm closure builds) *did* go through the lock, and their VERDICT lines are quoted above. A first attempt to run the union under the lock was itself killed at the foreground ceiling after one gate, having waited 350s for a 2s check — which is the measurement, not an excuse.

**No changeset.** `scripts/**` is not published by any package — this is internal fleet tooling, and the derivation names no package. `skip-changeset` applies and **is on this PR** — read back as `["size/l","skip-changeset"]`. ⚠️ Declared: the additive labels endpoint returned HTTP 403 for this session ("GitHub access is not enabled for this session"), so the documented fallback was used instead — read the current set, union, write the whole set — which is why the size-labeler's `size/l` is named explicitly above rather than assumed.

## Note for #12288 (single-writer coordination)

Per the claim's serial constraint, this PR **did** touch VERDICT/exit-99 wording, so that card's premise should be re-verified on the merged ref rather than assumed. Exactly what changed:

- `verdict_queue_timeout` is unchanged in its own text; it now **additionally** calls `not_measured_note`, which prints indented continuation lines after it.
- Added `ledger_append` calls beside existing terminal verdicts. **No existing VERDICT line's text was altered.**
- ⛔ `VERDICT command-exit …` — the line #12288 is about — is **untouched**. It still reports the exit of whatever single command the wrapper was given, which is precisely that card's finding when the command is a batch script.
- New: `--report` mode, the `OS_VERIFY_LOCK_SLOT` and `OS_VERIFY_LOCK_LEDGER` variables, and parked-slot lines in `--status`.

_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_