### PR TITLE
ci(lint): record the merge-queue check-set measurement — the queue already runs every tree-global ratchet

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,45 @@ on:
   # the trigger alone is enough.
   merge_group:
 
+# ── MEASURED 2026-08-25 (#12211) — a NEGATIVE result, recorded so it is not
+# re-measured. After the stale-ledger outage the queue's check set was measured
+# rather than assumed, because two observations of that day read as
+# contradictory: a PR landing an inconsistent tree at 11:50Z (which looked like
+# "the consumer-gates lane does not run in the queue"), and five queue entries
+# dequeued 12:26-13:05Z while main was red (which looked like the opposite).
+#
+# Both halves were read, and there is NO merge_group coverage gap to close:
+#
+#   - STATIC. Every gate step in this workflow runs on merge_group; the claim
+#     three lines above is exact. The only event-conditioned step in the file is
+#     `Save Turbo cache (main only)`, which stores a cache and judges nothing.
+#     ci.yml is the same shape — its single merge_group exclusion sits on the
+#     paths filter, which on a queue build widens to "everything changed"
+#     rather than narrowing. All six required contexts live in these two
+#     merge_group-triggered workflows (scripts/check-required-contexts.mjs).
+#
+#   - DYNAMIC. 180 merge_group runs of this workflow were read across
+#     09:15-18:49Z. In run 32847794799 — a real queue build — the
+#     `Type Check · consumer gates` lane RAN and FAILED on
+#     `check:exported-any-returns`, and the required `TypeScript Type Check`
+#     aggregate carried that red into the queue. Tree-global ratchets do kick
+#     there; the 12:26-13:05Z dequeues are that gate, on innocent candidates,
+#     while main itself was red. CI was green on those same merge groups.
+#
+# What the 11:50Z landing actually was: that commit produced NO merge_group
+# build at all — 4 of the 29 PRs landing 09:20-12:10Z produced none — and its
+# PR-level required checks were green as measured at 07:20Z, ~3h before the
+# gate that would have refused it existed. The residual is therefore not a
+# trigger this file is missing. It is that a commit can reach main without a
+# queue build, plus `strict_required_status_checks_policy: false` on the `main`
+# ruleset (measured 2026-08-18, #9642). Both are repository SETTINGS and
+# maintainer-only; neither is reachable from this file.
+#
+# ⛔ So do not "close the gap" by adding merge_group to the advisory workflows
+# (check-links.yml, docs-drift-check.yml, validate-deps.yml, the patrols). A
+# non-required check on a queue build costs runners and blocks nothing, and
+# check-links.yml's own header already refuses it for that reason.
+
 # Same policy as ci.yml: superseded runs on the same PR/branch waste runners
 # and delay feedback; cancel them. Push runs to main group by commit ref, so an
 # in-flight main run is cancelled only by a newer main push.


### PR DESCRIPTION
Part of #12211 — this lands **step 1, the measurement**, and the measurement is a
**negative result**: there is no `merge_group` coverage gap for step 2 to close. Per triage's
own framing, nothing is wired here, because the thing the card asked to be measured turned out
to argue for something the card did not anticipate. #12211 stays open: the residual it exposes
is maintainer-only and is not addressed here.

## The two contradictory observations, distinguished on evidence

The card recorded two readings that "cannot both be true of a static check set". Both are true.
One of them was misread.

| | card's reading | what the runs show |
|---|---|---|
| 11:50Z, #12062 lands an inconsistent tree | "suggests the consumer-gates job does NOT run on `merge_group`" | #12062 **produced no `merge_group` build at all**. It did not pass the queue; it never entered one. |
| 12:26–13:05Z, five entries dequeued while main was red | "consistent with that gate failing IN the queue" | Confirmed, and named: `check:exported-any-returns`, in `Type Check · consumer gates`, rolled up by the required `TypeScript Type Check`. |

No contradiction remains: the queue **does** run the tree-global ratchets, and the PR that
landed the outage simply never faced them.

## Static half — which jobs *can* run on `merge_group`

Four workflows carry the trigger: `ci.yml`, `lint.yml`, `governed-surface-guard.yml`,
`spec-liveness-check.yml`. All six branch-protection-required contexts
(`scripts/check-required-contexts.mjs` `REQUIRED_CONTEXTS`) live in the first two.

Inside them, **no gate job or gate step is skipped on a queue build**:

- `lint.yml` — the file's single `github.event_name` conjunct is on `Save Turbo cache (main
  only)` (`push`), which stores a cache and judges nothing. No job carries an `if:`.
- `ci.yml` — its one `!= 'merge_group'` conjunct is on the paths-filter step, which on a queue
  build widens to "everything changed" rather than narrowing. Every gate job keys off that
  filter's output, so on `merge_group` they all run at full scope.

So the enumeration asked for has a decidable answer and it is the whole set: every tree-global
ratchet named by the card — consumer gates, the spec-liveness family, the shrink-only ledgers —
already runs in the queue. Nothing is missing.

## Dynamic half — which jobs *did* run

180 `merge_group` runs of `Lint & Type Check` read across 09:15–18:49Z on 2026-08-25, plus the
`CI` runs over the outage window.

Run [32847794799](https://github.com/objectstack-ai/objectstack/actions/runs/32847794799)
(`gh-readonly-queue/main/pr-12120-…`, 12:28:39Z) — `Type Check · consumer gates` **ran**, and
step 17 `Check no exported client callable resolves to 'any'` **failed**, in the gate's own
words:

```
• ObjectStackClient.packages.update — no longer resolves to `any` (reason on file: #11925 …)

The ledger is shrink-only and judged EXACTLY. A stale entry stays available to cover the NEXT
regression under the last one's reason, which is how a ratchet quietly stops ratcheting.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @objectstack/client@17.2.0 check:exported-any-returns
Exit status 1
```

`TypeScript Type Check` then failed on `Verify every type-check lane succeeded`. **`CI` was
green on every one of those same merge groups** — so the mass-dequeue was the Lint workflow's
aggregate alone, not a shared CI failure. That rules out the card's second candidate
reconciliation.

## Why #12062 landed anyway

- **No queue build exists for it.** Across 09:15–18:49Z there is no
  `gh-readonly-queue/main/pr-12062-…` run in `lint.yml` or `ci.yml`. Positive control for that
  zero: the same listings carry builds for `pr-12063`, `pr-12091`, `pr-12093`, `pr-12096`,
  `pr-12120`, `pr-12129` and ~100 more, so the instrument returns something when there is
  something to return.
- **It is not alone.** Of the 29 PRs that landed on `main` between 09:20Z and 12:10Z, **four**
  produced no `merge_group` build: #12062, #12072, #12079, #12097.
- **Its PR-level green was a three-hour-old snapshot.** #12062's six required contexts all
  reported success, measured at **07:20–07:35Z** — and the gate that would have refused it
  landed at **10:21:58Z** (#12115). The `Type Check · consumer gates` job that went green for
  it did not contain the step, because the step did not yet exist.
- **The required-status association was already correct**, so the card's first candidate
  reconciliation is also ruled out: the Required-Set Patrol reported
  *"the live required set and REQUIRED_CONTEXTS agree in both directions"* at 04:35Z (before
  the outage) and again at 16:35Z (after).

## The gap, named

It is not a trigger any workflow is missing. It is two repository **settings**:

1. A commit can reach `main` without producing a `merge_group` build at all — measured, four
   times, inside the incident window.
2. `strict_required_status_checks_policy: false` on the `main` ruleset (measured 2026-08-18,
   #9642, recorded in `scripts/check-required-contexts.mjs`) — which is what lets a PR merge on
   check results computed against an older base.

Either one alone reproduces the outage, and `merge_group` coverage is powerless against both.
Both are maintainer-only and outside this PR's declared file surface, so they are reported
rather than acted on — the same disposition triage prescribed for a measurement that argues for
a change to the check regime.

## What this PR actually changes

One YAML comment block in `.github/workflows/lint.yml`, next to the `merge_group:` trigger it is
about, in this repo's dated-measurement idiom. It records the negative result so the next agent
does not re-measure it, confirms the adjacent claim ("this workflow has no PR-only steps") that
nothing in the tree verifies mechanically, and refuses in advance the plausible wrong remedy of
adding `merge_group` to the advisory workflows.

**No behaviour changes.** ⚠️ On the general caution that a workflow edit is the surface where a
local green proves least: that caution is discharged here only because the diff is inert. What
is confirmed locally is that the file still parses and every gate that reads it is green
(below). What only a real queue run could confirm — that triggers still fire as intended — is
not at risk, because no trigger, condition, job or step was touched; the diff is 39 added
comment lines and nothing else.

## Verification

Union re-derived at the final commit **`7a02e2d1ef`** with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no `STALE TREE`; stderr
stamps the answer's repo and commit). 18 families named; **17 run, all exit 0**, exit codes
captured before any pipe:

```
check:agent-test-spelling               exit=0
check:node-version                      exit=0
check:pnpm-acquisition                  exit=0
check:pnpm-filter-targets               exit=0
check:required-contexts                 exit=0
check:shard-attestation                 exit=0
check:workflow-status-functions         exit=0
check:type-check-coverage               exit=0
check-aggregator-roster.mjs             exit=0
check-required-contexts.mjs             exit=0
check-self-test-wired.mjs               exit=0
check-self-test-workflow-commands.mjs   exit=0
check-shard-attestation.mjs             exit=0
check-step-collectors.mjs               exit=0
check-whole-set-label-write.mjs         exit=0
docs-audit/check-drift-comment.mjs      exit=0
pm/ci-failure.mjs --self-test           exit=0
check-nul-bytes.mjs                     exit=0   (also run, outside the 18)
```

Quoting two of the gates' own verdict lines:

```
✓ check-required-contexts: 6 required context name(s) pinned across 2 workflow(s); 5 instruction surface(s) scanned …
✓ check-aggregator-roster: 3 aggregator(s) across 2 workflow(s); roster == needs: in both directions …
```

⛔ **`check:type-check-debt` — NOT MEASURED**, neither a pass nor a failure. Its own refusal:
*"--re-measure cannot run: 56 workspace dependenc(ies) of the ledgered packages have no built
type entry point on disk … measuring now would not fail, it would silently measure a DIFFERENT
WORLD."* It needs the whole workspace closure built behind the shared verify lock, which was
held by another agent's `packages/cli` vitest run. **Declared narrowing, with why it is safe:**
the diff is a YAML comment in a workflow file; DEBT/TEST_DEBT are measured from TypeScript
sources and package manifests, so no ledger number this gate reads can move. CI runs it.

**`pnpm lint` — a measured narrowing, not a skip.** The changed file is outside ESLint's
population entirely, read from the config rather than assumed: `ESLint#isPathIgnored` answers
`true` for `.github/workflows/lint.yml`, `lintFiles` on it returns 1 result with 0 errors and
*"File ignored because no matching configuration was supplied"*, and the positive control
(`scripts/check-nul-bytes.mjs` → `ignored=false`) shows the instrument distinguishes. A YAML
comment cannot move any untouched file's verdict.

Control bytes: `check-nul-bytes` exit=0 (*"scanned 6833 text file(s) … no raw ASCII control
bytes"*), plus a self-scan of the changed file with
`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` — 0 hits.

## Changeset

None, and the reasoning rather than the assumption: a changeset declares a **release** of one or
more published packages. This diff adds comment lines to a CI workflow — no workspace package's
published bytes, types or behaviour change, so there is nothing a consumer could observe and
nothing to version. `skip-changeset` is the label for exactly that case.

⚠️ **The label could not be applied from this seat.** The additive endpoint
(`POST /issues/12338/labels`) answers **403** — *"GitHub access is not enabled for this session"*
— as does every `api.github.com` call from this container, which is a transport fact about the
seat rather than a permission this repo withholds. It was NOT worked around with a whole-set
label `PUT`: that shape is banned in this repo (`check-whole-set-label-write`) and races the
size labeler. So `Check Changeset` is expected to be red on this PR until a seat with API access
adds `skip-changeset` additively — that red is this gap, not a defect in the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_