### PR TITLE
fix(spec): give the client-SDK surface a page-scoped docs root so SDK pages can opt into check:skill-examples

### DIFF
--- a/content/docs/api/client-sdk.mdx
+++ b/content/docs/api/client-sdk.mdx
@@ -24,42 +24,48 @@ pnpm add @objectstack/client
 ```
 
 {/*
-  CONTRIBUTOR NOTE — none of this page's TypeScript fences carries an
-  `os:check` marker, and that is a recorded decision rather than an omission.
+  CONTRIBUTOR NOTE — three of this page's fences carry an `os:check` marker and
+  are compiled by `check:skill-examples` against the real SDK declarations; the
+  rest deliberately do not. Both halves are measured, not assumed.
 
-  `check:skill-examples` compiles marked blocks per SURFACE. `content/docs/**`
-  belongs to the "skills + docs" surface, whose resolution dir and `paths` map
-  are derived from `@objectstack/spec` alone — and `@objectstack/spec` does not
-  depend on `@objectstack/client`. So a marker on any fence that imports the SDK
-  reds with TS2307 "Cannot find module '@objectstack/client'" — a
-  surface-resolution gap, not doc-vs-SDK drift.
+  This page belongs to the client-SDK SURFACE, not to the broad
+  `content/docs/**` one. That surface resolves `@objectstack/client`,
+  `@objectstack/client-react` and react's real types, so a marked block here
+  imports the SDK exactly as a reader's own code does. It was not always so:
+  `content/docs/**` resolves against `@objectstack/spec` alone, spec does not
+  depend on the client, and every SDK import here used to red with TS2307
+  "Cannot find module '@objectstack/client'". The page is carved out by name
+  (`SDK_DOCS_PAGES` in packages/spec/scripts/check-skill-examples.ts) — moving
+  or renaming it without updating that list fails the gate loudly rather than
+  silently returning the page to the surface that cannot resolve it.
 
-  Every other fence is a deliberate continuation fragment: Quick Start
-  establishes `client` once and each later block continues that implied context,
-  so a marker there reds with TS2304 "Cannot find name 'client'". Making either
-  class compile would mean hand-declaring the SDK's own types, or injecting
-  casts into prose whose subject IS the real API — pinning each example to
-  itself and teaching worse code than the page teaches now.
+  What IS marked: Quick Start, the `createFilter()` builder chain, and the
+  React Hooks block — the three that stand alone. What is not: every block that
+  continues Quick Start's implied context. Quick Start establishes `client`
+  once and each later block reads it, so a marker there reds with TS2304
+  "Cannot find name 'client'"; the error-handling blocks additionally read a
+  `catch` binding that is `unknown` (TS18046). Making those compile would mean
+  hand-declaring the SDK's own types or injecting casts into prose whose
+  subject IS the real API — pinning each example to itself and teaching worse
+  code than the page teaches now.
 
-  Measured on this page (all 13 fences marked, then reverted): 128 diagnostics,
-  every one TS2307 / TS2304 / TS18004 / TS18046 / TS2591 / TS7006 / TS7026 /
-  TS2875. Not one was a doc-vs-SDK divergence.
+  Measured with all 13 fences marked, then reverted: 114 diagnostics, TS2304 /
+  TS18046 / TS18004 / TS2591, spread over the nine continuation blocks — and
+  ZERO TS2307. Before the carve-out the same sweep produced 128 diagnostics
+  including TS2307 on every SDK import. Not one diagnostic in either sweep was
+  a doc-vs-SDK divergence; that is what the three marked blocks now hold.
 
-  The React Hooks block near the end is fenced tsx, not typescript, because it
-  IS JSX: the gate writes every block out with its fence's own extension, and
-  JSX in a .ts file is a syntax error. That reaches past this page — tsc stops
-  at syntax errors and never runs the semantic pass, so one such block would
-  suppress type-checking for every marked block across skills/ and
-  content/docs/ (measured here: 128 semantic diagnostics collapse to 0). Please
-  do not retag it back.
-
-  The marker becomes worth adding here the day the docs surface can resolve
-  `@objectstack/client` — the same condition recorded in
-  content/docs/kernel/runtime-services/data-service.mdx.
+  The React Hooks block is fenced tsx, not typescript, because it IS JSX: the
+  gate writes every block out with its fence's own extension, and JSX in a .ts
+  file is a syntax error. That reaches past this page — tsc stops at syntax
+  errors and never runs the semantic pass, so one such block would suppress
+  type-checking for every marked block on its whole surface. Please do not
+  retag it back.
 */}
 
 ## Quick Start
 
+{/* os:check */}
 ```typescript
 import { ObjectStackClient } from '@objectstack/client';
 
@@ -513,6 +519,7 @@ const results = await client.data.query('account', query);
 
 The `FilterBuilder` provides a rich set of filter methods:
 
+{/* os:check */}
 ```typescript
 import { createFilter } from '@objectstack/client';
 
@@ -669,6 +676,7 @@ For React applications, use `@objectstack/client-react`:
 pnpm add @objectstack/client-react
 ```
 
+{/* os:check */}
 ```tsx
 import { ObjectStackProvider, useClient, useQuery } from '@objectstack/client-react';
 import { ObjectStackClient } from '@objectstack/client';

--- a/content/docs/kernel/runtime-services/data-service.mdx
+++ b/content/docs/kernel/runtime-services/data-service.mdx
@@ -146,6 +146,7 @@ Call these methods from code that **holds** the binding — a managed runtime ha
 a hook body: a hook has no `services` key to reach through (see above), and reads other
 objects via `ctx.api`.
 
+{/* os:check */}
 ```ts
 import type { ObjectStackClient } from '@objectstack/client';
 
@@ -179,11 +180,17 @@ export async function recentOrdersForContact(data: DataService, contactId: strin
 }
 ```
 
-The block carries no `{/* os:check */}` marker, and that is a measurement rather than an
-omission: `check:skill-examples` compiles marked blocks against the built
-`@objectstack/spec` declarations only — its `paths` map is derived from that package's own
-`exports`, and `@objectstack/spec` does not depend on `@objectstack/client`. A marked
-block here would therefore have to hand-declare `DataService` instead of importing it,
-which pins the example to itself and nothing else. The marker becomes worth adding the day
-this surface has a spec-side contract to import (see the
-[Canonical source](#canonical-source) note).
+The block carries an `{/* os:check */}` marker, so `check:skill-examples` compiles it
+against the real `@objectstack/client` declarations on every CI run: if `data.get` /
+`data.find` / `data.query` change shape, this example reds rather than rotting. It used to
+carry no marker, and that was a measurement rather than an omission — marked blocks under
+`content/docs/**` were compiled against `@objectstack/spec` alone, which does not depend
+on `@objectstack/client`, so importing `ObjectStackClient` here red with TS2307 and
+hand-declaring `DataService` instead would have pinned the example to itself and nothing
+else. This page is now carved out by name to the client-SDK surface (`SDK_DOCS_PAGES` in
+`packages/spec/scripts/check-skill-examples.ts`), which resolves the SDK; renaming or
+moving the page without updating that list fails the gate rather than silently dropping
+the check.
+
+The signature listing under [Methods](#methods) stays unmarked: it is a listing of method
+shapes, not a compilable statement, and it cannot parse at all.

--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -183,6 +183,44 @@
  * real consumer would, rather than relying on a same-package self-import
  * trick that may or may not resolve.
  *
+ * ── PAGE-SCOPED ROOTS: one tree, two surfaces (#12048) ────────────────────
+ * A surface is a resolution environment, and until #12048 a ROOT was always a
+ * whole subtree — which made "which packages can this page import?" a property
+ * of the tree a page happens to live in. `content/docs/**` is one tree, so
+ * every page in it resolved `@objectstack/spec` and nothing else. The SDK
+ * reference page (`api/client-sdk.mdx`) and the data-service page both import
+ * `@objectstack/client`; spec does not depend on the client, so a marker on
+ * either page red with `TS2307: Cannot find module '@objectstack/client'` on
+ * correct code. Both pages recorded that in prose and left their SDK blocks
+ * deliberately unmarked — two pages structurally unverifiable, for one
+ * resolution gap, while #8140's narrowing of 51 client return types falsified
+ * two examples on the SDK page with CI silent throughout.
+ *
+ * The fix is a root whose scope is a PAGE SET rather than a tree
+ * (`SourceRoot.pages`), on the client-SDK surface that already resolves those
+ * packages for its 19 TSDoc blocks. No new resolution environment, no new
+ * extraction code — the same file/marker/tsc pipeline, pointed at two named
+ * pages. The alternative (teaching the spec surface to resolve the SDK) was
+ * rejected: it inverts the dependency direction that surface exists to model,
+ * and would let any docs page silently acquire the SDK.
+ *
+ * Two roots over ONE tree brings its own failure mode, and both halves are
+ * asserted rather than trusted:
+ *
+ *   - **Partition, not overlap.** A page scanned by two surfaces is compiled
+ *     twice in two environments, and the one that cannot resolve its imports
+ *     reds against a page the other just proved correct — unfixable from the
+ *     page. The scoped root's `pages` and the broad root's `excludePages` read
+ *     ONE shared constant (`SDK_DOCS_PAGES`), and
+ *     `assertDisjointSourceFiles()` proves per run that no file is claimed
+ *     twice — an invariant that held by accident while every root owned its
+ *     own tree.
+ *   - **A page list that stops resolving fails BOTH ways at once.** Rename the
+ *     page and the scoped root loses it while the broad root's subtraction
+ *     stops matching, so it lands back on the surface that cannot resolve it —
+ *     the original defect, restored silently by an unrelated edit.
+ *     `assertScopedPagesExist()` makes that a hard error.
+ *
  * ── Fence-awareness, in BOTH of extractFromFile's loops ───────────────────
  * `fenceOwners()` tracks every top-level fence of ANY language (lifted from
  * the #10533 fence-awareness shape in `scripts/check-role-word.mjs`), and both
@@ -257,6 +295,35 @@ interface SourceRoot {
   /** Skip individual files by basename — e.g. test files, which are not the
    *  documented SDK surface even though they share the source root's `ext`. */
   excludeFile?: (name: string) => boolean;
+  /**
+   * PAGE-SCOPED root (#12048): an explicit file list, relative to `dir`,
+   * INSTEAD of walking the tree. A root with `pages` is a page SET, not a
+   * subtree — which is what lets one page of a shared prose tree belong to a
+   * different surface (a different module-resolution environment) from the
+   * tree around it, without moving the file or forking the extractor.
+   *
+   * `dir` still matters: it is what `buildFileName` takes each page's path
+   * relative to, so two roots over the same tree produce stable, distinct
+   * build-file names as long as their `label`s differ.
+   *
+   * `exclude` / `excludeFile` are not consulted for a `pages` root — the list
+   * IS the scope. Every entry must exist (`assertScopedPagesExist()`): a
+   * renamed page would otherwise drop out of its scoped root silently and be
+   * picked back up by the broad root it was carved out of, quietly restoring
+   * the very resolution gap the carve-out exists to close.
+   */
+  pages?: string[];
+  /**
+   * The complement of another root's `pages` (#12048): files under `dir`
+   * (relative paths) this root does NOT scan because a page-scoped root on
+   * another surface owns them. Both sides read ONE shared constant, so the
+   * partition cannot drift — and `assertDisjointSourceFiles()` fails the run
+   * if it ever does. Overlap is not cosmetic: a page scanned by two surfaces
+   * has every marked block on it compiled twice, in two different resolution
+   * environments, and the surface that cannot resolve its imports reports
+   * TS2307 against a page the other surface just proved correct.
+   */
+  excludePages?: string[];
   /** True when this root's prose lives inside a JSDoc/TSDoc block comment
    *  rather than free-standing markdown — every line then carries a leading
    *  JSDoc gutter (` * `) that must be stripped before the fence/marker
@@ -280,10 +347,48 @@ interface SourceRoot {
  * `content/docs/references/` is excluded: `build-docs.ts` regenerates it from the
  * schemas, so its snippets cannot drift independently of their source.
  */
+const DOCS_DIR = path.resolve(REPO_ROOT, 'content/docs');
+
+/**
+ * The docs pages whose examples import the CLIENT SDK, and so belong to the
+ * client-SDK surface's resolution environment rather than the spec surface's
+ * (#12048). Paths are relative to `content/docs`.
+ *
+ * ONE constant, read from both sides of the partition: the spec surface's
+ * broad docs root subtracts it (`excludePages`), the client-SDK surface's
+ * page-scoped docs root is exactly it (`pages`). Declaring it twice by hand is
+ * what would let the two drift into overlap or into a gap; declaring it once
+ * makes the partition true by construction, and `assertDisjointSourceFiles()`
+ * proves it every run rather than trusting this comment.
+ *
+ * WHY these two pages and not the whole tree. `content/docs/**` is resolved
+ * against `@objectstack/spec` alone, and spec does not depend on
+ * `@objectstack/client` — so before this list existed, a marker on ANY fence
+ * importing the SDK red with `TS2307: Cannot find module '@objectstack/client'`,
+ * and both pages below recorded that in prose and left their SDK blocks
+ * deliberately unmarked. Two pages structurally unverifiable, for one
+ * resolution gap, while #8140's narrowing of 51 client return types falsified
+ * two examples on `api/client-sdk.mdx` with CI silent throughout.
+ *
+ * The alternative — teaching the spec surface to resolve the SDK — was
+ * rejected: it inverts the dependency direction that surface exists to model
+ * (spec knows nothing of its consumers) and would let ANY docs page silently
+ * acquire the SDK. This list is the opposite posture: a page opts IN, by name,
+ * to a resolution environment that already exists and is already exercised by
+ * the 19 TSDoc blocks in `packages/client{,-react}/src`.
+ *
+ * Adding a page here moves the WHOLE file between surfaces, so add one only
+ * when its examples' imports are SDK-shaped. A page needing both `@objectstack/spec`
+ * and the SDK is fine — client-react depends on spec, so spec resolves through
+ * this surface's `node_modules` too; a page needing something NEITHER surface
+ * carries is a new surface question, not a new entry here.
+ */
+const SDK_DOCS_PAGES = ['api/client-sdk.mdx', 'kernel/runtime-services/data-service.mdx'];
+
 const SKILLS_DOCS_ROOTS: SourceRoot[] = [
   { dir: path.resolve(REPO_ROOT, 'skills'), ext: '.md', label: 'skills', marker: '<!-- os:check -->' },
   {
-    dir: path.resolve(REPO_ROOT, 'content/docs'),
+    dir: DOCS_DIR,
     ext: '.mdx',
     label: 'docs',
     // MDX has no HTML comments — fumadocs-mdx fails the build outright on
@@ -291,6 +396,8 @@ const SKILLS_DOCS_ROOTS: SourceRoot[] = [
     // `{/* text */}`"). The marker must follow each format's own comment syntax.
     marker: '{/* os:check */}',
     exclude: [path.resolve(REPO_ROOT, 'content/docs/references')],
+    // Carved out to the client-SDK surface (#12048) — see `SDK_DOCS_PAGES`.
+    excludePages: SDK_DOCS_PAGES,
   },
 ];
 
@@ -352,6 +459,25 @@ const CLIENT_SDK_ROOTS: SourceRoot[] = [
     marker: '<!-- os:check -->',
     commentPrefixed: true,
     excludeFile: isTestFile,
+  },
+  /**
+   * The SDK's PROSE pages (#12048) — free-standing MDX, not TSDoc, so no
+   * `commentPrefixed` gutter and the MDX marker spelling, exactly like the
+   * broad docs root it is carved out of. What differs is the surface it sits
+   * on, and that is the whole point: these pages resolve `@objectstack/client`
+   * (and `client-react`, and react's real types) because this surface's
+   * throwaway build dir lives inside `packages/client-react/`.
+   *
+   * A distinct `label` from the broad docs root is load-bearing, not cosmetic:
+   * `buildFileName` is `<label>__<path>__<n>`, and both roots take their paths
+   * relative to the SAME `content/docs` tree.
+   */
+  {
+    dir: DOCS_DIR,
+    ext: '.mdx',
+    label: 'docs-sdk',
+    marker: '{/* os:check */}',
+    pages: SDK_DOCS_PAGES,
   },
 ];
 
@@ -467,18 +593,34 @@ interface FencedBlock {
   marked: boolean;
 }
 
+/** The absolute paths a root's `pages` / `excludePages` list names. */
+function scopedPaths(root: SourceRoot, list: string[] | undefined): string[] {
+  return (list ?? []).map((p) => path.resolve(root.dir, p));
+}
+
 /** Every candidate prose/source file across a surface's roots, with the root that owns it. */
 function sourceFiles(roots: SourceRoot[]): Array<{ file: string; root: SourceRoot }> {
   const out: Array<{ file: string; root: SourceRoot }> = [];
   for (const root of roots) {
     if (!fs.existsSync(root.dir)) continue;
+    // A PAGE-SCOPED root (#12048) is an explicit list, not a walk. A listed
+    // page that does not exist is dropped here and reported by
+    // `assertScopedPagesExist()` — never silently, because the broad root this
+    // page was carved out of would pick it straight back up.
+    if (root.pages) {
+      for (const abs of scopedPaths(root, root.pages)) {
+        if (fs.existsSync(abs)) out.push({ file: abs, root });
+      }
+      continue;
+    }
     const exts = Array.isArray(root.ext) ? root.ext : [root.ext];
+    const excluded = new Set(scopedPaths(root, root.excludePages));
     const walk = (dir: string) => {
       if (root.exclude?.some((x) => dir === x || dir.startsWith(x + path.sep))) return;
       for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, e.name);
         if (e.isDirectory()) walk(full);
-        else if (exts.some((ext) => e.name.endsWith(ext)) && !root.excludeFile?.(e.name)) {
+        else if (exts.some((ext) => e.name.endsWith(ext)) && !root.excludeFile?.(e.name) && !excluded.has(full)) {
           out.push({ file: full, root });
         }
       }
@@ -2090,8 +2232,115 @@ function selfTest(): never {
       buildFileText("import { z } from 'zod';") === "import { z } from 'zod';",
       'buildFileText fixture: a block that is already a module was given an extra `export {}`',
     );
+
+    // ── Page-scoped roots: one tree, two surfaces (#12048) ────────────────
+    //
+    // Three assertions, and the CONTROL is the load-bearing one. A scoped root
+    // that returned its page list and a broad root that had simply failed to
+    // find the page would satisfy the first two identically — the same
+    // "prove the green comes from the mechanism, not from an empty corpus"
+    // shape the nested-illustration fixture above is built around.
+    const tree = path.join(dir, 'pagetree');
+    fs.mkdirSync(path.join(tree, 'sub'), { recursive: true });
+    const pageA = path.join(tree, 'a.mdx');
+    const pageB = path.join(tree, 'b.mdx');
+    const pageC = path.join(tree, 'sub', 'c.mdx');
+    for (const p of [pageA, pageB, pageC]) fs.writeFileSync(p, '# page\n', 'utf8');
+
+    const broadUnpartitioned: SourceRoot = { dir: tree, ext: '.mdx', label: 'docs', marker: '{/* os:check */}' };
+    const broadRoot: SourceRoot = { ...broadUnpartitioned, excludePages: ['b.mdx'] };
+    const scopedRoot: SourceRoot = { ...broadUnpartitioned, label: 'docs-sdk', pages: ['b.mdx'] };
+
+    // CONTROL: without the subtraction the broad root really does reach page B.
+    check(
+      sourceFiles([broadUnpartitioned]).some((f) => f.file === pageB),
+      'page-scope control: the un-partitioned broad root did not reach the page at all — every assertion below ' +
+        'would then pass over an empty corpus rather than over a working carve-out',
+    );
+    check(
+      JSON.stringify(sourceFiles([broadRoot]).map((f) => f.file)) === JSON.stringify([pageA, pageC]),
+      `page-scope fixture: broad root scanned ${JSON.stringify(sourceFiles([broadRoot]).map((f) => path.basename(f.file)))}, ` +
+        'expected a.mdx and sub/c.mdx — `excludePages` must remove exactly the carved-out page, and nothing else',
+    );
+    check(
+      JSON.stringify(sourceFiles([scopedRoot]).map((f) => f.file)) === JSON.stringify([pageB]),
+      `page-scope fixture: scoped root scanned ${JSON.stringify(sourceFiles([scopedRoot]).map((f) => path.basename(f.file)))}, ` +
+        'expected exactly b.mdx — a `pages` root is a file list, never a walk',
+    );
+    // The two roots address the same tree, so only `label` keeps their
+    // build-file names apart. A collision would have one root's extracted block
+    // overwrite the other's inside a shared build dir.
+    check(
+      buildFileName(pageB, broadUnpartitioned, 1, '.ts') !== buildFileName(pageB, scopedRoot, 1, '.ts'),
+      `page-scope fixture: both roots produce the build-file name ${buildFileName(pageB, scopedRoot, 1, '.ts')} for the ` +
+        'same page — two roots over one tree must differ in `label`',
+    );
+
+    // Overlap detection, both directions. The partitioned pair must be clean;
+    // the un-partitioned pair must be caught — that is the state in which one
+    // page gets two verdicts from two resolution environments.
+    const stubSurface = (name: string, roots: SourceRoot[]): Surface => ({
+      name,
+      roots,
+      resolutionDir: dir,
+      selfPackages: [],
+    });
+    const partitioned = [stubSurface('broad', [broadRoot]), stubSurface('scoped', [scopedRoot])].map((surface) => ({
+      surface,
+      files: sourceFiles(surface.roots),
+    }));
+    check(
+      findOverlappingSourceFile(partitioned) === null,
+      `page-scope fixture: a correct partition was reported as overlapping (${JSON.stringify(findOverlappingSourceFile(partitioned))})`,
+    );
+    const overlapping = [stubSurface('broad', [broadUnpartitioned]), stubSurface('scoped', [scopedRoot])].map(
+      (surface) => ({ surface, files: sourceFiles(surface.roots) }),
+    );
+    const overlap = findOverlappingSourceFile(overlapping);
+    check(
+      overlap !== null && overlap.file === pageB,
+      `page-scope fixture: a page claimed by TWO surfaces was not flagged (got ${JSON.stringify(overlap)}) — this is ` +
+        'the state where one page is compiled in two resolution environments and the failing verdict cannot be fixed',
+    );
+
+    // A `pages` entry that names a file which is not there. Both halves of the
+    // partition fail together and silently when this happens, so it is pinned
+    // in both directions like every other guard here.
+    check(
+      findMissingScopedPages([stubSurface('scoped', [scopedRoot])]).length === 0,
+      'page-scope fixture: an existing scoped page was reported missing',
+    );
+    const stale = findMissingScopedPages([
+      stubSurface('scoped', [{ ...scopedRoot, pages: ['b.mdx', 'renamed-away.mdx'] }]),
+    ]);
+    check(
+      stale.length === 1 && stale[0].page === 'renamed-away.mdx',
+      `page-scope fixture: a scoped page list naming a non-existent file was not flagged (got ${JSON.stringify(stale)}) — ` +
+        'the page would return to the surface that cannot resolve its imports, restoring the gap silently',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+
+  // ── The same two invariants over the REAL corpus, not a fixture. Same
+  //    reasoning as the `findUnignoredBuildDir(SURFACES)` pin below: the
+  //    fixtures prove the predicates work, and these prove today's SURFACES
+  //    actually satisfy them — a scoped page that was renamed away, or a
+  //    carve-out whose `excludePages` was dropped, is a live defect rather
+  //    than a hypothetical one, and neither shows up as anything but a
+  //    resolution error on one page.
+  check(
+    findMissingScopedPages(SURFACES).length === 0,
+    `real-corpus fixture: page-scoped root(s) name file(s) that do not exist — ` +
+      JSON.stringify(findMissingScopedPages(SURFACES)),
+  );
+  {
+    const realFiles = SURFACES.map((surface) => ({ surface, files: sourceFiles(surface.roots) }));
+    const realOverlap = findOverlappingSourceFile(realFiles);
+    check(
+      realOverlap === null,
+      `real-corpus fixture: a source file is scanned by two surfaces — ${JSON.stringify(realOverlap)}`,
+    );
   }
 
   // ── Gitignore coverage (#11440). `assertGitignoredBuildDirs()` runs against
@@ -2209,7 +2458,11 @@ function selfTest(): never {
       '    fragment (parses as neither) is not, a marked block that does not parse REFUSES with its\n' +
       '    first error mapped to the right page line — recommending a tsx retag only when the body\n' +
       '    really is JSX — and the bytes the refusal parses are the bytes the build dir is written\n' +
-      '    with.',
+      '    with; a page-scoped root scans exactly its list while the broad root over the same tree\n' +
+      '    scans everything BUT it (with the un-partitioned control proving the page was reachable),\n' +
+      '    the two roots produce distinct build-file names, a page claimed by two surfaces is caught\n' +
+      '    and a correct partition is not, a `pages` entry naming a file that is not there is caught\n' +
+      '    and an existing one is not — and the real SURFACES satisfy both invariants today.',
   );
   process.exit(0);
 }
@@ -2323,6 +2576,96 @@ function assertGitignoredBuildDirs(): void {
   }
 }
 
+/**
+ * Every `pages` entry that names a file which is not there (#12048).
+ *
+ * A page-scoped root is a carve-out from a broad root over the same tree, and
+ * the two read one shared list — so a path that stops resolving (the page
+ * renamed, moved, or the list typo'd) does not merely shrink the scoped root:
+ * the broad root's `excludePages` stops matching in the same instant, the page
+ * returns to the surface that cannot resolve its imports, and the next marked
+ * block on it reds with the exact TS2307 the carve-out exists to end. Both
+ * halves fail in the same direction, silently, from one edit — which is why
+ * this is a hard error and not a warning.
+ *
+ * Judged over `SURFACES` rather than a hand-listed set, so a fifth root with
+ * `pages` is covered without an edit here.
+ */
+function findMissingScopedPages(surfaces: Surface[]): Array<{ surface: string; label: string; page: string }> {
+  const missing: Array<{ surface: string; label: string; page: string }> = [];
+  for (const surface of surfaces) {
+    for (const root of surface.roots) {
+      for (const page of root.pages ?? []) {
+        if (!fs.existsSync(path.resolve(root.dir, page))) {
+          missing.push({ surface: surface.name, label: root.label, page });
+        }
+      }
+    }
+  }
+  return missing;
+}
+
+function assertScopedPagesExist(): void {
+  const missing = findMissingScopedPages(SURFACES);
+  if (missing.length > 0) {
+    fail(
+      `Page-scoped root(s) name ${missing.length} file(s) that do not exist:\n\n` +
+        missing.map((m) => `  - ${m.page}   (root "${m.label}", surface "${m.surface}")`).join('\n') +
+        `\n\n  A scoped page list is one half of a partition — the broad root over the same\n` +
+        `  tree subtracts the SAME list. A path that no longer resolves therefore removes\n` +
+        `  the page from its scoped root AND hands it back to the broad one, restoring the\n` +
+        `  resolution gap the carve-out closed. Fix the path, or drop the entry (and the\n` +
+        `  page's markers with it) if the page is really gone.`,
+    );
+  }
+}
+
+/**
+ * The first file two different surfaces both scan, or null (#12048).
+ *
+ * Until page-scoped roots existed, every root addressed a tree no other root
+ * addressed, and the invariant held by accident. It is load-bearing: a file
+ * scanned by two surfaces has each of its marked blocks extracted twice and
+ * compiled in two different module-resolution environments, so the surface
+ * that cannot resolve the block's imports reports TS2307 against a page the
+ * other surface just proved correct — one page, two verdicts, and the failing
+ * one is the one with no way to be fixed.
+ *
+ * Takes pre-computed per-surface file lists rather than walking again: the
+ * caller has already paid for that walk, and asserting over a SECOND walk
+ * would be asserting about a corpus the run does not use.
+ */
+function findOverlappingSourceFile(
+  entries: Array<{ surface: Surface; files: Array<{ file: string; root: SourceRoot }> }>,
+): { file: string; first: string; second: string } | null {
+  const seen = new Map<string, string>();
+  for (const { surface, files } of entries) {
+    for (const { file } of files) {
+      const first = seen.get(file);
+      if (first && first !== surface.name) return { file, first, second: surface.name };
+      seen.set(file, surface.name);
+    }
+  }
+  return null;
+}
+
+function assertDisjointSourceFiles(
+  entries: Array<{ surface: Surface; files: Array<{ file: string; root: SourceRoot }> }>,
+): void {
+  const clash = findOverlappingSourceFile(entries);
+  if (clash) {
+    fail(
+      `${rel(clash.file)} is scanned by two surfaces — "${clash.first}" and "${clash.second}".\n\n` +
+        `  Each surface resolves modules in its own environment, so every marked block on\n` +
+        `  this file would be compiled twice against different declarations. Whichever\n` +
+        `  surface cannot resolve the block's imports reds with TS2307 on a page the other\n` +
+        `  surface just type-checked clean, and no edit to the page can satisfy both.\n\n` +
+        `  A page-scoped root (\`pages\`) and the broad root it is carved out of must read\n` +
+        `  ONE shared list — the broad root subtracting it via \`excludePages\`.`,
+    );
+  }
+}
+
 /** A package.json's own `name` field — used to look its self-entry up in the
  *  `paths` map `surfacePaths()` derived from it. */
 function pkgName(pkgDir: string): string {
@@ -2334,14 +2677,24 @@ function main() {
 
   assertDistinctBuildDirs();
   assertGitignoredBuildDirs();
+  // Before the corpus is read (#12048): a scoped page list that has stopped
+  // resolving would otherwise show up as a page quietly back on the surface
+  // that cannot resolve its imports, not as an error.
+  assertScopedPagesExist();
 
   console.log(`🧪 Type-checking prose TypeScript examples (${SURFACES.map((s) => s.name).join(' · ')})...\n`);
 
-  const bySurface = SURFACES.map((surface) => {
+  // One walk, read twice: the disjointness assertion below and the extraction
+  // loop must be talking about the SAME corpus, or the assertion is about a
+  // set this run does not use.
+  const filesBySurface = SURFACES.map((surface) => ({ surface, files: sourceFiles(surface.roots) }));
+  assertDisjointSourceFiles(filesBySurface);
+
+  const bySurface = filesBySurface.map(({ surface, files }) => {
     const examples: Example[] = [];
     const orphans: string[] = [];
     const fences: FencedBlock[] = [];
-    for (const { file, root } of sourceFiles(surface.roots)) {
+    for (const { file, root } of files) {
       const { examples: found, orphans: bad, fences: all } = extractFromFile(file, root);
       examples.push(...found);
       fences.push(...all);

--- a/packages/spec/scripts/check-skill-examples.ts
+++ b/packages/spec/scripts/check-skill-examples.ts
@@ -220,6 +220,15 @@
  *     stops matching, so it lands back on the surface that cannot resolve it —
  *     the original defect, restored silently by an unrelated edit.
  *     `assertScopedPagesExist()` makes that a hard error.
+ *   - **But "this tree has no such corpus" is not "this corpus lost a page".**
+ *     This script is run against repo-SHAPED sandbox trees too (the #7181
+ *     dist-freshness pins build one with no `content/docs` at all), so the
+ *     missing-page guard skips a root whose `dir` is absent — the same
+ *     presence rule `sourceFiles()` already applies. When the two predicates
+ *     disagreed on that, the guard reported both SDK pages missing in the
+ *     sandbox and, being an assert that runs first, spoke ahead of the three
+ *     verdicts those tests pin. `content/docs` always exists in a real
+ *     checkout, so the rename protection above is untouched.
  *
  * ── Fence-awareness, in BOTH of extractFromFile's loops ───────────────────
  * `fenceOwners()` tracks every top-level fence of ANY language (lifted from
@@ -2318,6 +2327,42 @@ function selfTest(): never {
       `page-scope fixture: a scoped page list naming a non-existent file was not flagged (got ${JSON.stringify(stale)}) — ` +
         'the page would return to the surface that cannot resolve its imports, restoring the gap silently',
     );
+
+    // ── Absent-dir root: present in this checkout at all? (#12048) ─────────
+    //
+    // This script runs against repo-SHAPED sandbox trees as well as the repo —
+    // `dist-freshness-adoption.test.ts` builds one with `skills/`,
+    // `packages/spec/src` and the two client packages but NO `content/docs`.
+    // `sourceFiles()` skips a root whose `dir` is absent; `findMissingScopedPages`
+    // must answer the same way, or it reports every scoped page "missing" there
+    // and — running as an assert before everything else — speaks ahead of the
+    // verdicts those tests pin.
+    //
+    // BOTH directions, and the control is what separates them: an absent `dir`
+    // must be silent, while the SAME page list under a `dir` that DOES exist
+    // must still be flagged. Without the control, a predicate that had simply
+    // stopped finding anything would pass the first assertion.
+    const absentDirRoot: SourceRoot = {
+      ...scopedRoot,
+      dir: path.join(dir, 'no-such-tree'),
+      pages: ['b.mdx', 'renamed-away.mdx'],
+    };
+    check(
+      findMissingScopedPages([stubSurface('sandboxed', [absentDirRoot])]).length === 0,
+      'page-scope fixture: a scoped root whose `dir` does not exist in this checkout was reported as having missing ' +
+        'pages — that is a tree which does not carry this corpus at all, not a corpus that lost a page, and the ' +
+        'sandbox trees this script is run against by dist-freshness-adoption.test.ts are exactly that',
+    );
+    check(
+      sourceFiles([absentDirRoot]).length === 0,
+      'page-scope fixture: a scoped root with an absent `dir` scanned files — `sourceFiles()` and ' +
+        '`findMissingScopedPages()` must agree about whether a root is present at all',
+    );
+    check(
+      findMissingScopedPages([stubSurface('present', [{ ...absentDirRoot, dir: tree }])]).length === 1,
+      'page-scope CONTROL: the identical page list under a `dir` that DOES exist was not flagged — the absent-dir ' +
+        'exemption must be about the dir, not about the predicate having gone quiet, or a real rename stops reding',
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -2462,7 +2507,10 @@ function selfTest(): never {
       '    scans everything BUT it (with the un-partitioned control proving the page was reachable),\n' +
       '    the two roots produce distinct build-file names, a page claimed by two surfaces is caught\n' +
       '    and a correct partition is not, a `pages` entry naming a file that is not there is caught\n' +
-      '    and an existing one is not — and the real SURFACES satisfy both invariants today.',
+      '    and an existing one is not, while a scoped root whose `dir` is absent from this checkout\n' +
+      '    entirely is silent in BOTH predicates (with the same list under an existing dir still\n' +
+      '    flagged, so the exemption is the dir and not a predicate gone quiet) — and the real\n' +
+      '    SURFACES satisfy both invariants today.',
   );
   process.exit(0);
 }
@@ -2580,13 +2628,32 @@ function assertGitignoredBuildDirs(): void {
  * Every `pages` entry that names a file which is not there (#12048).
  *
  * A page-scoped root is a carve-out from a broad root over the same tree, and
- * the two read one shared list — so a path that stops resolving (the page
- * renamed, moved, or the list typo'd) does not merely shrink the scoped root:
- * the broad root's `excludePages` stops matching in the same instant, the page
- * returns to the surface that cannot resolve its imports, and the next marked
- * block on it reds with the exact TS2307 the carve-out exists to end. Both
- * halves fail in the same direction, silently, from one edit — which is why
- * this is a hard error and not a warning.
+ * the two read one shared list — so a path that stops resolving does not merely
+ * shrink the scoped root: the broad root's `excludePages` stops matching in the
+ * same instant, the page returns to the surface that cannot resolve its imports,
+ * and the next marked block on it reds with the exact TS2307 the carve-out
+ * exists to end. Both halves fail in the same direction, silently, from one
+ * edit — which is why this is a hard error and not a warning.
+ *
+ * ⚠️ A ROOT WHOSE `dir` IS ABSENT IS NOT A FINDING, and this is the same
+ * presence rule `sourceFiles()` already applies one function up (it `continue`s
+ * past a root whose `dir` does not exist). The two must agree about whether a
+ * root is present in this checkout at all: this script is executed against
+ * repo-SHAPED sandbox trees as well as against the repo — the `#7181`
+ * dist-freshness pins in `dist-freshness-adoption.test.ts` build one that seeds
+ * `skills/`, `packages/spec/src` and the two client packages but has no
+ * `content/docs` at all. When the two predicates disagreed, this one reported
+ * both SDK pages "missing" in that sandbox and, being an assert that runs before
+ * everything, spoke *ahead of* the three verdicts those tests pin — hijacking a
+ * positive control, a staleness refusal and an orphan-marker finding alike. Same
+ * shape as the two-closers (#11690) and the two fence-ownership notions
+ * (#11355) this file has already collapsed: one predicate, not two that can
+ * drift apart.
+ *
+ * The rename protection is untouched by that carve-out, because it is a
+ * different question: `content/docs` always exists in a real checkout, so a page
+ * renamed *inside* it is still judged, and still reds. Absent-dir means "this
+ * tree does not carry this corpus", never "this corpus lost a page".
  *
  * Judged over `SURFACES` rather than a hand-listed set, so a fifth root with
  * `pages` is covered without an edit here.
@@ -2595,7 +2662,10 @@ function findMissingScopedPages(surfaces: Surface[]): Array<{ surface: string; l
   const missing: Array<{ surface: string; label: string; page: string }> = [];
   for (const surface of surfaces) {
     for (const root of surface.roots) {
-      for (const page of root.pages ?? []) {
+      if (!root.pages) continue;
+      // The `sourceFiles()` presence rule, restated — see the docblock above.
+      if (!fs.existsSync(root.dir)) continue;
+      for (const page of root.pages) {
         if (!fs.existsSync(path.resolve(root.dir, page))) {
           missing.push({ surface: surface.name, label: root.label, page });
         }


### PR DESCRIPTION
Fixes #12048

## What was wrong

`check:skill-examples` resolves modules **per surface**, and a `SourceRoot` was always a whole subtree — so "which packages may this page import?" was a property of the tree a page happens to live in. `content/docs/**` belongs to the `skills + docs` surface, whose `paths` map derives from `@objectstack/spec` alone, and spec does not depend on `@objectstack/client`. A marker on any docs fence importing the SDK therefore red with `TS2307: Cannot find module '@objectstack/client'` — on correct code. Two pages recorded that constraint in prose and left their SDK blocks deliberately unmarked, so the most SDK-dense page in the docs was structurally unverifiable while #8140's narrowing of 51 client return types falsified two of its examples with CI silent throughout.

## Option C, as priced on the card

The spec seat adopted **C** — a docs root scoped to a page set, on the **existing** client-SDK surface that already resolves `@objectstack/client`, `@objectstack/client-react` and react's real types for its 19 TSDoc blocks. No new resolution environment, no new extraction code. **A** was rejected (adding the SDK to the spec surface's `selfPackages` inverts the dependency direction that surface exists to model, and would let any docs page silently acquire the SDK); **B** was the shipped interim and is now retired by this change.

The card named the one genuine design cost honestly: `SourceRoot.dir` is a directory, so per-page scoping had to be built. It is `SourceRoot.pages` — an explicit file list, relative to `dir`, instead of a walk. The fork-back condition did not trigger: this is a scoped root plus a filter on an existing surface, and the file/marker/tsc pipeline is untouched.

Two roots over **one** tree brings its own failure mode, so both halves are asserted rather than trusted:

- **Partition, not overlap.** The scoped root's `pages` and the broad root's `excludePages` read one shared constant (`SDK_DOCS_PAGES`). `assertDisjointSourceFiles()` proves per run that no file is scanned by two surfaces — an invariant that held by accident while every root owned its own tree, and whose violation means one page compiled twice in two environments, with the failing verdict unfixable from the page.
- **A page list that stops resolving fails BOTH ways at once.** Rename a page and the scoped root loses it *while* the broad root's subtraction stops matching, handing it back to the surface that cannot resolve it — the original defect, restored silently by an unrelated edit. `assertScopedPagesExist()` makes that a hard error.

This builds on #12308's shape rather than around it: the REFUSE verdict and the unmarked-population sweep are untouched, and REFUSE correctly named the new `docs-sdk` root during the measurement below.

## Which fences were opted in, and which were not

All 13 fences on `api/client-sdk.mdx` and both on `data-service.mdx` were marked, the gate run, and the tree reverted. Readings per fence (source lines are pre-marking):

| page | fence | reading | opted in |
|:--|:--|:--|:--|
| client-sdk.mdx | 63 Quick Start | clean | ✅ |
| client-sdk.mdx | 119, 190, 231, 296, 318, 330 | TS2304 `client` (2/13/10/3/5/69 diagnostics) | ❌ continuation fragments |
| client-sdk.mdx | 496 `createQuery` | TS2304 `client` (1) | ❌ continuation fragment |
| client-sdk.mdx | 516 `createFilter` | clean | ✅ **the card's executable criterion** |
| client-sdk.mdx | 582, 609 error handling | TS2304 + TS18046 (6/4) | ❌ continuation + `unknown` catch binding |
| client-sdk.mdx | 643 `ClientConfig` | TS2304 `Logger` (1) | ❌ fragment |
| client-sdk.mdx | 672 React Hooks (tsx) | clean | ✅ |
| data-service.mdx | 33 method signatures | does not parse (TS1005) | ❌ signature listing, never compilable |
| data-service.mdx | 149 `services.data` example | clean | ✅ |

**114 diagnostics with all 13+1 marked, and zero TS2307.** The pre-change sweep recorded on the card produced 128 including TS2307 on every SDK import. The nine that stay unmarked are the continuation class the page's own note documents: Quick Start establishes `client` once and each later block reads it. Making those compile would mean injecting casts into prose whose subject IS the real API — teaching worse code than the page teaches now. Both pages' notes are rewritten to record the measurement instead of the retired constraint.

## Verification

Every reading below is the gate's own verdict line, at head `31c166e4`; the tree was confirmed pristine (`git status --porcelain` empty) after each reverted measurement.

**Fix in place** — `pnpm --filter @objectstack/spec check:skill-examples`:

```
✅ 260 prose examples type-check across 3 surface(s) — every marked block parsed, so tsc ran the SEMANTIC pass on all of them
     • skills + docs (@objectstack/spec): 227 block(s)
     • spec source TSDoc (@objectstack/spec): 10 block(s)
     • client SDK (@objectstack/client-react, @objectstack/client): 23 block(s)
```

256 → 260 marked blocks; the client-SDK surface 19 → 23. The `skills + docs` count is unchanged at 227, which is the carve-out being a partition rather than a subtraction.

**Reverse verification (control).** With the four markers left on disk and `packages/spec/scripts/check-skill-examples.ts` restored to `b8419bd5a` — mutation confirmed on disk before the run (`SDK_DOCS_PAGES` occurrences 0, markers still 3+1) — the run reds, and the direction is the card's:

```
✗ [skills + docs (@objectstack/spec)] examples do not compile:
  content/docs/api/client-sdk.mdx:524:30
      error TS2307: Cannot find module '@objectstack/client' or its corresponding type declarations.
```

13 diagnostics: 5× TS2307, plus TS7026/TS2875/TS7006 from the React block meeting a surface with no react types. `524:30` is the `createFilter` import — the same statement and the same column as the card's `485:30`, at its post-#12045 line. Restored with `git checkout HEAD -- packages/spec/scripts/check-skill-examples.ts`; porcelain clean.

**Self-test** (`--self-test`, run as the first half of the gate script) gains page-scope fixtures, including the load-bearing control: an un-partitioned broad root **does** reach the carved-out page, so the partition assertions are not passing over an empty corpus. It also pins overlap detection and missing-page detection in both directions, and asserts the real `SURFACES` satisfy both invariants today.

**Gate families.** Re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (34 families, more than the dispatch named — it added `check:doc-security-posture`, `check:docs-redirects`, `check:docs-single-h1`, `check:page-declaration-shape`, `check:published-readme-links`, `check:react-page-adapter-contract`, `check:runtime-services-index`, `check:doc-formula-expressions`, `check-doc-frontmatter`, `check-doc-route-spelling`, `check-docs-section-name`, `check-section-landing-index`, `check-dev-prereqs`, `check:docs`). **33 of 34 exit 0**, each exit code captured before any pipe.

**One declared narrowing:** `node scripts/check-dev-prereqs.mjs` exits 1 in this worktree with *"The workspace is not built — 34 of 67 workspace packages declare an entry point under dist/ that is not on disk"*, naming `@objectstack/account`, `@objectstack/setup`, `@objectstack/studio` and 31 others. Only the `@objectstack/client-react` dependency closure was built here, not the whole workspace. The diff is three files and touches no `package.json`, no `dist/`, and no build config, so it cannot reach that gate's predicate; CI runs it after "Build workspace packages".

## Follow-up commit `31c166e4` — the guard must skip a root whose `dir` is absent

CI `Test Core` went red on `packages/spec/scripts/dist-freshness-adoption.test.ts` (the #7181 pin suite for this very script), and it was a true red attributable to this diff. `assertScopedPagesExist()` asserted `SDK_DOCS_PAGES` unconditionally, but this script is run against repo-**shaped** sandbox trees as well as against the repo: that suite builds one seeding `skills/`, `packages/spec/src` and the two client packages, with **no `content/docs` at all** (measured: zero occurrences of "content" in the whole test file). There the guard reported both SDK pages missing and, being an assert that runs before everything else, spoke *ahead of* the three verdicts those tests pin — hijacking a positive control, a staleness refusal and an orphan-marker finding alike.

`sourceFiles()` already skips a root whose `dir` does not exist. The defect was **two predicates disagreeing about whether a root is present in this checkout at all** — the same shape as the two fence closers (#11690) and the two fence-ownership notions (#11355) that this file has already collapsed into one. The guard now restates that one rule.

**The rename protection is untouched**, because it answers a different question: `content/docs` always exists in a real checkout, so a page renamed *inside* it is still judged and still reds. Absent-dir means "this tree does not carry this corpus", never "this corpus lost a page". Pinned in both directions with a control — an absent `dir` is silent in **both** predicates, while the identical page list under a `dir` that does exist is still flagged, so the exemption is the dir and not a predicate gone quiet.

Post-fix readings at `31c166e4`:

```
✓ check:skill-examples refuses a stale dist (#7181) > POSITIVE CONTROL: a fresh dist type-checks the marked example and reports it
✓ check:skill-examples refuses a stale dist (#7181) > refuses before tsc on a stale dist instead of reporting the examples type-check
✓ check:skill-examples refuses a stale dist (#7181) > lets the dist-independent guards above it speak first, even on a stale dist
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Full `@objectstack/spec` suite — the suite the red lived in, run in full this time rather than narrowed:

```
 Test Files  428 passed (428)
      Tests  11401 passed (11401)
```

`check:skill-examples` on the real corpus is unchanged at **260** marked blocks (227 / 10 / 23), and the 34-family union was re-derived and re-run on this head: 33 of 34 exit 0, with the same single environmental `check-dev-prereqs` narrowing declared above. The new self-test fixture was ablated (guard line removed, absence confirmed on disk, restored byte-identically via a trap and verified with `git hash-object`) and fails with exactly its own message — it is load-bearing, not decorative.

⚠️ `dispatch-gates.mjs` reports this branch's tree is 8 commits behind `origin/main` with 4 derivation inputs changed. Measured rather than shrugged at: `lint.yml`'s change is a pure comment block (#12211's recorded negative result — no gate steps, no globs) and `dispatch-gates.mjs` is +79/-0 (the staleness warner itself). The derived family list is byte-identical to the pre-merge one, so the union above is not stale in substance.

## Changeset

`skip-changeset` — this PR changes a CI gate script and contributor-facing prose notes; no published package's behaviour or surface moves. Same disposition as #12175 and #12308 on this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDGG54XF5gbTLdQzCtnaVV)_
