### PR TITLE
test(mcp): gate CONNECT_AGENT_PAGE on canonical expression envelopes

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@objectstack/lint": "workspace:*",
     "@objectstack/metadata-core": "workspace:*",
     "@types/node": "^26.2.0",
     "typescript": "^6.0.3",

--- a/packages/mcp/src/canonical-expression-envelopes.test.ts
+++ b/packages/mcp/src/canonical-expression-envelopes.test.ts
@@ -1,0 +1,407 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Gate — every `Page` this package ships must serve the CANONICAL
+ * `{ dialect, source }` envelope at every `ExpressionInputSchema` position
+ * (#12269, extending #11255's platform-objects gate and #11480's
+ * cloud-connection gate to the third page-shipping package).
+ *
+ * `CONNECT_AGENT_PAGE` is a raw typed object literal reaching the kernel
+ * through this plugin's own manifest bundle (`CONNECT_AGENT_UI_BUNDLE`,
+ * registered on `kernel:ready`) — the same wire path as the pages the two
+ * sibling gates cover, in a `*-ui.ts` file no `*.page.ts` sweep ever looked
+ * at. It authors ZERO expression keys today, which is exactly why the gate is
+ * worth having; #11480's header states the argument and it is quoted on the
+ * card that ordered this file:
+ *
+ * > They author ZERO expression keys today, which is exactly why the gate is
+ * > worth having: the hazard is the NEXT predicate added to one of them, which
+ * > would ship bare with every authoring-time signal green.
+ *
+ * The page body is a single `mcp:connect-agent` widget plus a `page:header`,
+ * both live SDUI surfaces that can grow a `visibleWhen` at any time.
+ *
+ * The detector lives in `@objectstack/lint` (`page-envelope-audit.ts` — its
+ * header carries the hazard and the three-door design; its own test file
+ * carries the negative controls). What this file owns is this package's
+ * POPULATION: the export-shape scan over `src/`, the per-page door
+ * preconditions, the verdict, and a downgrade control proving the detector
+ * reaches this package's real export.
+ *
+ * ## Third hand-copy, deliberately — not a hoist
+ *
+ * This is the THIRD per-package copy of the same shape. That count is live
+ * evidence for hoisting the population discovery into one shared helper
+ * instead of repeating it, which is #11576's option C and #12307's subject —
+ * a different card and a different decision. Copying is what THIS card is.
+ * Recorded here so the next author inherits the count rather than the habit.
+ *
+ * ## The one exempted component type
+ *
+ * `page:header` carries a `ComponentPropsMap` row, so door 3 reads its
+ * `properties` bag. `mcp:connect-agent` does NOT: it is a console-registered
+ * widget provided by objectui's app-shell, so door 3 has no schema to read its
+ * `properties` with — the same standing-exemption shape `cloud-connection`'s
+ * two widgets were in between #11480 and #11575, before #11575 gave them
+ * strict, empty rows measured from the renderers' read points at the
+ * `.objectui-sha` pin. Giving this type its row is that same piece of work and
+ * belongs on its own card (filed); it is outside this card's declared surface.
+ *
+ * Until then the exemption is asserted EXACTLY (a NEW unmapped type reds), and
+ * it is sound only while the exempted widget authors an EMPTY props bag —
+ * nothing authored is nothing to serve bare. The moment it grows a real
+ * authored prop, the emptiness assert reds and forces the decision: give the
+ * type a `ComponentPropsMap` row, or widen the exemption knowingly. Both halves
+ * are needed; the exemption alone would be a door-3 blind spot that widens in
+ * silence.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import type { Page } from '@objectstack/spec/ui';
+import {
+  auditPageExpressionEnvelopes,
+  renderBareExpressionFindings,
+  walkPageComponents,
+} from '@objectstack/lint';
+// The one answer this tree has to "comment, literal, or code". It is a plain
+// `.mjs`, but `scripts/js-comment-mask.d.mts` beside it is a hand-written
+// declaration mirror (governed by `check:declaration-mirrors`), so this import
+// is typed and needs no suppression -- a `@ts-expect-error` here would be an
+// UNUSED directive. That `.d.mts` is what gives `maskComments` its type.
+// Same spelling the two sibling gates use.
+import { maskComments } from '../../../scripts/js-comment-mask.mjs';
+import { CONNECT_AGENT_PAGE } from './connect-ui.js';
+
+type AnyRec = Record<string, unknown>;
+
+/** This file lives in `src/`, so the scan root IS the package's `src/`. */
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// ───────────────────────────────────────────────────────────────────────────
+// The population this gate covers
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Every page this package ships, audited by export name — with the unmapped
+ * component types each page is EXPECTED to report (the exemption above).
+ */
+const AUDITED_PAGES: { exportName: string; page: Page; exemptUnmappedTypes: string[] }[] = [
+  {
+    exportName: 'CONNECT_AGENT_PAGE',
+    page: CONNECT_AGENT_PAGE,
+    exemptUnmappedTypes: ['mcp:connect-agent'],
+  },
+];
+
+function pageLabel(exportName: string, page: Page): string {
+  const name = typeof (page as AnyRec).name === 'string' ? (page as AnyRec).name : '(unnamed)';
+  return `${exportName} (${String(name)})`;
+}
+
+function tsFilesUnder(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      tsFilesUnder(full, out);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every `export const X: Page = …` this source text declares, read from CODE.
+ *
+ * ## Why the shared mask and not a private comment-stripper
+ *
+ * Masking is not a detail of this scan, it is the scan's population rule: text
+ * this function mistakes for a comment is a page this gate never audits, and
+ * the gate still reports GREEN — a green line over a page nobody read, which is
+ * the exact defect class this file exists to prevent, re-entering through the
+ * detector instead of through the authoring.
+ *
+ * What used to stand in both sibling gates was two regexes, block pass first
+ * (`/\*[\s\S]*?\*\/` lazily, then `^[ \t]*\/\/.*$`) — the same pair #9367
+ * retired from six gates and #10453 found surviving in two `packages/cli`
+ * tests. Its failure is the silent one: a block-comment OPENER that is not a
+ * comment at all — inside a string literal, or inside a line comment — opens a
+ * phantom comment that runs to the next real `\*\/` and deletes every line
+ * between, declarations included.
+ *
+ * This copy was held until #12317 converted BOTH siblings onto the shared mask,
+ * precisely so a third hand-copy would not carry that defect forward a third
+ * time. `maskComments` blanks comment spans and leaves string, template and
+ * regex literals intact, so offsets and line numbers both survive and a
+ * `: Page =` inside prose still cannot be read as a declaration.
+ *
+ * Split out from the walk so the pin below drives the REAL scan over a fixture
+ * rather than over whatever this package happens to contain today.
+ */
+function pageDeclarationsIn(source: string): string[] {
+  return [...maskComments(source).matchAll(/export\s+const\s+(\w+)\s*:\s*Page\s*=/g)]
+    .map(match => match[1]!);
+}
+
+/**
+ * Every `export const X: Page = …` declared anywhere in this package's `src/`.
+ *
+ * Discovery is by EXPORT SHAPE, never by a hard-coded name and never by
+ * filename — the sweep that first recorded this defect class looked at
+ * `*.page.ts` and therefore missed raw-literal pages living in `*-ui.ts`
+ * files. A gate that audits one page in a package that ships two is worse than
+ * no gate: it reports green over the one it cannot see. Scanning source text is
+ * what makes "a page nobody covered" visible.
+ */
+function declaredPageExports(): { name: string; file: string }[] {
+  const out: { name: string; file: string }[] = [];
+  for (const file of tsFilesUnder(HERE)) {
+    for (const name of pageDeclarationsIn(readFileSync(file, 'utf8'))) {
+      out.push({ name, file: file.slice(HERE.length + 1) });
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const AUDITS = AUDITED_PAGES.map(({ exportName, page, exemptUnmappedTypes }) => ({
+  exportName,
+  page,
+  exemptUnmappedTypes,
+  audit: auditPageExpressionEnvelopes(page, pageLabel(exportName, page)),
+}));
+
+// ───────────────────────────────────────────────────────────────────────────
+// The gate
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('mcp Page exports serve canonical expression envelopes', () => {
+  it('covers every `Page` declared in this package — and audits nothing undeclared', () => {
+    const declared = declaredPageExports();
+    const audited = new Set(AUDITED_PAGES.map(p => p.exportName));
+    const uncovered = declared.filter(d => !audited.has(d.name));
+    expect(
+      uncovered.map(d => `${d.name} (${d.file})`).join('\n'),
+      'a raw-literal `Page` in this package is not audited by this gate. Add it to '
+        + 'AUDITED_PAGES above (or, if it is deliberately unshipped, say so here).',
+    ).toBe('');
+
+    // Both directions: a page audited here but invisible to the export-shape
+    // scan means its declaration lost the `: Page` annotation — the state this
+    // package's page shipped in until #12266 added the annotation, which is
+    // what made it discoverable enough for this gate to exist.
+    const declaredNames = new Set(declared.map(d => d.name));
+    const undeclared = AUDITED_PAGES.filter(p => !declaredNames.has(p.exportName));
+    expect(
+      undeclared.map(p => p.exportName).join('\n'),
+      'this page is audited but not discovered by the `export const X: Page =` scan — '
+        + 'restore the `: Page` annotation on its declaration so the NEXT page authored '
+        + 'beside it is discoverable too.',
+    ).toBe('');
+
+    // Population floor: the gate is worthless if it silently reads nothing.
+    // A scan returning zero pages passes every assertion below exactly like a
+    // scan over a clean page, and the two readings mean opposite things.
+    expect(AUDITED_PAGES.length).toBeGreaterThanOrEqual(1);
+    expect(declared.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it.each(AUDITS)('$exportName parses through PageSchema (door 1 precondition)', ({ audit }) => {
+    expect(
+      audit.pageParseError ?? '',
+      'door 1 cannot run: this page does not parse, so every schema-typed expression '
+        + 'position on it is unread by this gate.',
+    ).toBe('');
+  });
+
+  it.each(AUDITS)('$exportName: every component parses through PageComponentSchema (door 2 precondition)', ({ audit }) => {
+    expect(
+      audit.componentParseErrors.map(e => `${e.path} [${e.type}]: ${e.issues}`).join('\n'),
+      'door 2 cannot run for these components: they do not parse, so their expression '
+        + 'positions are unread by this gate.',
+    ).toBe('');
+    expect(audit.componentCount).toBeGreaterThan(0);
+  });
+
+  it.each(AUDITS)('$exportName: unmapped component types are EXACTLY the recorded exemptions (door 3 precondition)', ({ audit, exemptUnmappedTypes }) => {
+    // See the header for why `mcp:connect-agent` is exempt. Anything ELSE
+    // unmapped is a new door-3 blind spot: declare the props schema in
+    // `ComponentPropsMap`, or record the exemption here with the reason — and
+    // then also pin the exempted bag empty, as the test below does, so the
+    // exemption cannot quietly cover a growing bag.
+    expect(audit.unmappedTypes.map(e => e.type).sort()).toEqual([...exemptUnmappedTypes].sort());
+  });
+
+  it.each(AUDITS)('$exportName: every exempted component authors an EMPTY props bag', ({ page, exemptUnmappedTypes }) => {
+    // The exemption above is only sound while there is nothing authored for
+    // door 3 to miss. A real key landing in one of these bags must force a
+    // decision (props schema row, or a conscious wider exemption) — not ride
+    // through a standing exemption silently.
+    const offenders = walkPageComponents(page as AnyRec, '')
+      .filter(w => typeof w.component.type === 'string' && exemptUnmappedTypes.includes(w.component.type))
+      .filter(w => {
+        const props = w.component.properties;
+        return !!props && typeof props === 'object' && Object.keys(props).length > 0;
+      })
+      .map(w => `${w.path} [${String(w.component.type)}]`);
+    expect(offenders.join('\n')).toBe('');
+  });
+
+  it.each(AUDITS)('$exportName: the exemption list is not vacuous — every exempted type is really on this page', ({ page, exemptUnmappedTypes }) => {
+    // The reverse rot: a type left in the list after it stopped appearing on
+    // the page (or after it gained a `ComponentPropsMap` row) is an exemption
+    // covering nothing, and it would keep the EXACT assert above green while
+    // hiding the fact that the door is now open. Delete it when it goes stale.
+    const present = new Set(
+      walkPageComponents(page as AnyRec, '')
+        .map(w => w.component.type)
+        .filter((t): t is string => typeof t === 'string'),
+    );
+    expect(exemptUnmappedTypes.filter(t => !present.has(t))).toEqual([]);
+  });
+
+  it.each(AUDITS)('$exportName: every authored `properties` bag parses against its props schema (door 3 precondition)', ({ audit }) => {
+    expect(
+      audit.unreadableProps.map(e => `${e.path} [${e.type}]: ${e.issues}`).join('\n'),
+      'door 3 cannot run for these components: their authored `properties` are refused by '
+        + 'the declared props schema, so a props-level expression key there is unread by '
+        + 'this gate.',
+    ).toBe('');
+  });
+
+  it.each(AUDITS)('$exportName authors NO bare expression string', ({ audit }) => {
+    expect(renderBareExpressionFindings(audit.findings)).toBe('');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Downgrade control — the imported detector reaches this package's REAL page
+// ───────────────────────────────────────────────────────────────────────────
+
+const BARE = 'has(record.status) && record.status == "bound"';
+
+describe('downgrade control — the shipped page, bare predicate injected', () => {
+  it('flags CONNECT_AGENT_PAGE the moment a bare predicate lands on the connect widget', () => {
+    // Deep-cloned — the export itself is untouched (the pristine re-audit
+    // below proves it). The injected position is the widget's `visibleWhen`,
+    // i.e. the exact next-predicate the card names as the hazard for this page.
+    const source = JSON.parse(JSON.stringify(CONNECT_AGENT_PAGE)) as AnyRec;
+    const regions = source.regions as AnyRec[];
+    const widget = (regions[1]!.components as AnyRec[])[0]!;
+    expect(widget.type).toBe('mcp:connect-agent');
+    widget.visibleWhen = BARE;
+
+    const audit = auditPageExpressionEnvelopes(source, pageLabel('CONNECT_AGENT_PAGE', source as unknown as Page));
+    expect(audit.findings.map(f => f.path)).toEqual(['regions[1].components[0].visibleWhen']);
+    const rendered = renderBareExpressionFindings(audit.findings);
+    expect(rendered).toContain('connect_agent');
+    expect(rendered).toContain('regions[1].components[0].visibleWhen');
+    expect(rendered).toContain('authored BARE');
+
+    const pristine = auditPageExpressionEnvelopes(
+      CONNECT_AGENT_PAGE,
+      pageLabel('CONNECT_AGENT_PAGE', CONNECT_AGENT_PAGE),
+    );
+    expect(renderBareExpressionFindings(pristine.findings)).toBe('');
+  });
+
+  it('flags the header region too — the other live SDUI surface on this page', () => {
+    const source = JSON.parse(JSON.stringify(CONNECT_AGENT_PAGE)) as AnyRec;
+    const regions = source.regions as AnyRec[];
+    const header = (regions[0]!.components as AnyRec[])[0]!;
+    expect(header.type).toBe('page:header');
+    header.visibleWhen = BARE;
+
+    const audit = auditPageExpressionEnvelopes(source, pageLabel('CONNECT_AGENT_PAGE', source as unknown as Page));
+    expect(audit.findings.map(f => f.path)).toEqual(['regions[0].components[0].visibleWhen']);
+    expect(renderBareExpressionFindings(audit.findings)).toContain('connect_agent');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Pin — a phantom comment cannot delete a page from the population
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * The shared mask, pinned by the shape it was adopted for.
+ *
+ * Both fixtures carry a block-comment OPENER that is not a comment — one in a
+ * line comment, one in a string literal — followed by a real terminator further
+ * down, with a `Page` declaration in between. The retired two-regex stripper
+ * honours the opener, runs lazily to that terminator, and the declaration
+ * between them is gone; the scan then reports a population one page short and
+ * every audit above is green over a page it never read.
+ *
+ * This package is not hypothetically exposed to that shape. `src/plugin.ts`
+ * and `src/mcp-http-tools.ts` both carry line comments naming glob-shaped
+ * route paths, and a page declared below one of them would simply vanish from
+ * the population under the retired stripper.
+ *
+ * The `openerIsNotAComment` precondition is here so the pin cannot go quietly
+ * vacuous: strip the opener out of a fixture while editing and both strippers
+ * agree again, leaving two tests that pass without asserting anything.
+ */
+const PHANTOM_IN_LINE_COMMENT = [
+  "import type { Page } from '@objectstack/spec/ui';",
+  '',
+  '// The connect widget reads /discovery and mints keys for the',
+  '// /api/v1/mcp/* routes this plugin mounts.',
+  '',
+  'export const PhantomPage: Page = {',
+  "    name: 'phantom_page',",
+  "    regions: [{ name: 'main', width: 'full', components: [] }],",
+  '};',
+  '',
+  '/** Setup-nav contribution — the terminator that closes the phantom. */',
+  "export const LaterPage: Page = { name: 'later_page', regions: [] };",
+].join('\n');
+
+const PHANTOM_IN_STRING_LITERAL = [
+  "import type { Page } from '@objectstack/spec/ui';",
+  '',
+  "const MCP_ROUTE_GLOB = '/api/v1/mcp/*';",
+  '',
+  'export const LiteralPhantomPage: Page = {',
+  "    name: 'literal_phantom_page',",
+  '    regions: [],',
+  '};',
+  '',
+  '/** A docblock whose terminator closes the phantom opened in the string. */',
+  "export const LiteralLaterPage: Page = { name: 'literal_later', regions: [] };",
+].join('\n');
+
+/** The fixture still carries the shape: an opener above, a terminator below. */
+function openerIsNotAComment(fixture: string, declaration: string): void {
+  const opener = fixture.indexOf('/' + '*');
+  const declaredAt = fixture.indexOf(declaration);
+  const terminator = fixture.indexOf('*' + '/', opener);
+  expect(opener, 'fixture lost its block-comment opener').toBeGreaterThan(-1);
+  expect(declaredAt, 'fixture lost its page declaration').toBeGreaterThan(opener);
+  expect(terminator, 'fixture lost the terminator that closes the phantom')
+    .toBeGreaterThan(declaredAt);
+}
+
+describe('population scan reads comments, not comment-shaped text', () => {
+  it('keeps a page straddled by an opener inside a LINE COMMENT', () => {
+    openerIsNotAComment(PHANTOM_IN_LINE_COMMENT, 'export const PhantomPage');
+    expect(pageDeclarationsIn(PHANTOM_IN_LINE_COMMENT)).toEqual(['PhantomPage', 'LaterPage']);
+  });
+
+  it('keeps a page straddled by an opener inside a STRING LITERAL', () => {
+    openerIsNotAComment(PHANTOM_IN_STRING_LITERAL, 'export const LiteralPhantomPage');
+    expect(pageDeclarationsIn(PHANTOM_IN_STRING_LITERAL))
+      .toEqual(['LiteralPhantomPage', 'LiteralLaterPage']);
+  });
+
+  it('still refuses a `: Page =` written inside genuine prose', () => {
+    const prose = [
+      '/** Authors write `export const X: Page = {}` in docblocks like this. */',
+      '// and in line comments: export const YPage: Page = {}',
+      "export const RealPage: Page = { name: 'real', regions: [] };",
+    ].join('\n');
+    expect(pageDeclarationsIn(prose)).toEqual(['RealPage']);
+  });
+});

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -33,8 +33,21 @@ export default defineConfig({
     // any subpath and resolve it to `…/src/index.ts/<subpath>` (ENOTDIR) — a
     // config that looks right and fails at run time. Same shape as
     // `plugin-sharing`'s.
+    //
+    // The second entry is for `canonical-expression-envelopes.test.ts` (#12269)
+    // — the only suite here that imports `@objectstack/lint` as a VALUE. It
+    // runs the shared canonical-envelope detector
+    // (`auditPageExpressionEnvelopes`) over this package's own `Page` export.
+    // Unaliased, that specifier resolves through `exports` to `lint/dist`, and
+    // the failure mode is the same silent one the note above describes: a dist
+    // merely BEHIND lets this gate run GREEN against the detector's old
+    // behaviour, while the gate's whole purpose is to run the CURRENT detector
+    // over the CURRENT page. Anchored for a second reason here — `@objectstack/lint`
+    // exports a `./runtime` subpath, and the object form would swallow it and
+    // resolve it to `…/lint/src/index.ts/runtime` (ENOTDIR) at run time.
     alias: [
       { find: /^@objectstack\/metadata-core$/, replacement: path.resolve(__dirname, '../metadata-core/src/index.ts') },
+      { find: /^@objectstack\/lint$/, replacement: path.resolve(__dirname, '../lint/src/index.ts') },
     ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1115,6 +1115,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@objectstack/lint':
+        specifier: workspace:*
+        version: link:../lint
       '@objectstack/metadata-core':
         specifier: workspace:*
         version: link:../metadata-core

--- a/scripts/cross-package-test-inputs.mjs
+++ b/scripts/cross-package-test-inputs.mjs
@@ -444,6 +444,21 @@ export const CROSS_PACKAGE_TEST_INPUTS = {
       'packages/cloud-connection/src/cloud-connection-ui.ts',
     ],
   },
+  '@objectstack/mcp': {
+    // src/canonical-expression-envelopes.test.ts (#12269) imports `maskComments`
+    // from `js-comment-mask.mjs` to decide which text in this package's `src/` is
+    // a comment and which is a `Page` declaration — the third package to carry
+    // this gate, and declared for the same two reasons the two entries above
+    // record. The import is a real coupling: that gate's POPULATION is a
+    // function of the module's masking behaviour, so a change to it has to
+    // re-run this package's suite. The `.d.mts` sibling is what gives
+    // `maskComments` its type, so this package's typecheck verdict is a
+    // function of it too.
+    globs: [
+      'scripts/js-comment-mask.mjs',
+      'scripts/js-comment-mask.d.mts',
+    ],
+  },
   '@objectstack/plugin-auth': {
     // src/managed-extension-fields.test.ts walks every `*.object.ts`, and pins
     // core's api-key source alongside it.

--- a/turbo.json
+++ b/turbo.json
@@ -156,6 +156,18 @@
       "$TURBO_ROOT$/packages/cloud-connection/src/cloud-connection-ui.ts"
       ]
     },
+    "@objectstack/mcp#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!dist/**",
+        "!coverage/**",
+        "!.turbo/**",
+        "$TURBO_ROOT$/scripts/js-comment-mask.mjs",
+        "$TURBO_ROOT$/scripts/js-comment-mask.d.mts"
+      ]
+    },
     "@objectstack/plugin-auth#test": {
       "dependsOn": ["^build"],
       "outputs": [],


### PR DESCRIPTION
Fixes #12269

`packages/mcp` was the third package shipping a raw-literal `Page` that reaches the kernel through its own manifest bundle, and the only one of the three without the canonical-expression-envelope gate. This adds the thin gate, taking closure **A** from the card.

`CONNECT_AGENT_PAGE` authors **zero** expression keys today. That is the argument for the gate rather than against it, and #11480's own header states it:

> They author ZERO expression keys today, which is exactly why the gate is worth having: the hazard is the NEXT predicate added to one of them, which would ship bare with every authoring-time signal green.

The page body is one `mcp:connect-agent` widget plus a `page:header`, both live SDUI surfaces that can grow a `visibleWhen` at any time.

## Third hand-copy, recorded as such

This is the **third** per-package copy of the same shape (`platform-objects` #11255, `cloud-connection` #11480, this one). That count is live evidence for hoisting the population discovery into one shared helper instead of repeating it — #11576's option C, and the subject of **#12307**, which stays that card's question rather than this one's. Recorded here so the count is inherited rather than the habit.

The copy was held behind #12317 deliberately: until that merged, both sibling gates carried the naive two-regex comment stripper that #9367 retired from six gates, and a third hand-copy would have carried the defect forward a third time. Both siblings were read on this branch's base before anything was copied — both now import `maskComments` from the shared mask, and the private stripper is gone from both.

## Which sibling was copied, and why

`cloud-connection`'s. `platform-objects` discovers its audited pages through a page barrel (`import * as pageExports from './index.js'`), which `packages/mcp` does not have — its page lives in a `*-ui.ts` file. `cloud-connection`'s shape (explicit audited list, checked against the source scan in **both** directions) is also strictly the better one: it reds both when a declared page is unaudited and when an audited page falls out of the `: Page` scan. Its `import.meta.url` seed is kept rather than `platform-objects`' `__dirname`, which that file uses only to dodge a TS1470 its own package config forces.

The population is **discovered** by export shape over `src/`, never by a hard-coded name.

## The page population was swept, not assumed

The card names one page. Swept `packages/mcp/src` for every `export const … : Page =`, every `regions:` and `pages:` literal, every `*_UI_BUNDLE`, and every `.register(` call site. Result: exactly one page (`CONNECT_AGENT_PAGE`), one bundle (`CONNECT_AGENT_UI_BUNDLE`), one register call (`plugin.ts:505`). A gate that audits one page in a package shipping two would be worse than no gate, so this was checked rather than taken from the card.

## Door 3 carries one recorded exemption

`page:header` has a `ComponentPropsMap` row; `mcp:connect-agent` does not — it is a console-registered widget, so door 3 has no schema to read its `properties` with. This is the same standing-exemption state `cloud-connection`'s two widgets were in between #11480 and #11575, and giving this type its row is that same piece of work, outside this card's declared surface. Filed as **#12344**.

Contained rather than covered, three pins together:

- the unmapped set is asserted **EXACTLY**, so any NEW unmapped type reds;
- the exempted widget's props bag is pinned **EMPTY** — nothing authored is nothing to serve bare;
- a non-vacuity pin reds if the exempted type stops appearing on the page, so the exemption cannot rot into one that covers nothing.

## The gate is proven to fail — both ways

A gate whose population scan silently returns zero pages passes exactly like a gate over a clean page, and those two greens mean opposite things. Both were ablated, each mutation confirmed **on disk** by counting the injected text and the anchor text (an editor's exit code is not evidence), each restored under a `trap … EXIT INT TERM` and proved byte-identical with `git hash-object`.

**Leg A — a bare predicate planted in the shipped page literal.** Anchor count 1 to 0, injected count 0 to 1. Result: **3 failed | 10 passed (13)**, the verdict test among them —

```
FAIL  'CONNECT_AGENT_PAGE' authors NO bare expression string
FAIL  flags CONNECT_AGENT_PAGE the moment a bare predicate lands on the connect widget
FAIL  flags the header region too — the other live SDUI surface on this page
```

(the two downgrade controls red on their pristine re-audits, correctly: the export is no longer pristine.) Restored: `42ada6a679623486368d7e86341c5e311a02ea91`, identical to before.

**Leg B — the population emptied.** Scan regex made to match nothing and the audited list emptied, i.e. the gate finds no pages at all. Result: **4 failed | 2 passed (6)**, the floor assert firing by name:

```
FAIL  covers every `Page` declared in this package — and audits nothing undeclared
AssertionError: expected 0 to be greater than or equal to 1
```

Worth reading the counts: 6 tests instead of 13, because an empty population registers no `it.each` cases. Without the floor assert an empty scan would silently drop 7 tests and report green — which is exactly the reading the floor exists to separate.

**Rebuild leg — does one apply here?** Not to the mutations. Both ablated files are read from **source**: vitest resolves `./connect-ui.js` inside the package to `src/`, and `@objectstack/lint` through the new anchored alias to `lint/src/index.ts`, so neither mutation passes through a `dist/`. One thing in the measured graph does: the detector imports `ComponentPropsMap` / `PageComponentSchema` / `PageSchema` from `@objectstack/spec/ui`, which resolves through `exports` to `packages/spec/dist`. That closure was built in this worktree before any measurement (`pnpm --workspace-concurrency=2 --filter '@objectstack/mcp^...' build`, and again on the merged head), and this diff touches no `packages/spec` source, so that dist is current for every number above.

## Cross-package inputs declared, not worked around

The `maskComments` import escapes the package, so `scripts/cross-package-test-inputs.mjs` gains an `@objectstack/mcp` entry and `turbo.json` a matching `@objectstack/mcp#test` task hashing the same two paths — the `.d.mts` alongside the `.mjs`, because it is what gives `maskComments` its type and so is an input to this package's typecheck verdict too. Same declaration both siblings carry.

The vitest alias is **appended** to this package's existing alias array rather than replacing it — `packages/mcp` already aliased `@objectstack/metadata-core`, and both entries stay anchored so neither swallows a subpath.

## No changeset — reasoning, not assumption

The diff touches no published `packages/mcp` source. `packages/mcp` publishes `dist` only (`files: ["dist", "README.md", "CHANGELOG.md"]`), and the change is a test file, a `devDependencies` line, a vitest config, a lint-roster entry and a turbo task. Nothing a consumer can observe changes; no `dist` output moves. #12317 — the same kind of diff over these same gates — shipped no changeset either. `skip-changeset` label applied.

## Verification

Gate union derived at the final commit `0efd5f8bce` with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`. The first derivation printed `STALE TREE` (6 commits behind, 6 files it derives from changed, `lint.yml` and the script itself among them), so `origin/main` was merged at `c48d46d70a` and the union re-derived clean — which added `check:bash32-floor` to the matched list.

All run on `0efd5f8bce`, exit codes captured before any pipe:

| check | verdict line |
|:--|:--|
| `@objectstack/mcp` suite | `Test Files  23 passed (23)` · `Tests  255 passed (255)` |
| `@objectstack/mcp` typecheck | exit 0, no diagnostics |
| `check:cross-package-test-inputs` | `OK: 18 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check:type-check-coverage` | `check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger …` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through dist/; 45 published subpath(s) resolved through every alias table.` |
| `check:page-declaration-shape` | `OK — 34 page entries across 2188 sources … all reach the kernel through a discoverable declaration` |
| `check:published-files` | `69 publishable package(s) of 78 workspace member(s) declare a files whitelist …` |
| `check:engine-double-contract` | exit 0 |
| `check:where-matcher` | `OK  self-test: separates conjoining, early-returning, combinator-blind and refusing` |
| `check:query-options-erasure` | `ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new` |
| `check:type-source-resolution` | `OK — 93 tsc program(s) across 77 packages scanned` |
| `check:slot-lookup` | exit 0 |
| `check:parse-guard` | `167 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `check:entry-guard` | `168 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `check:agent-test-spelling` | `0 violations — 384 file(s) · 3934 bare separator token(s) · 1167 launcher-rooted run(s)` |
| `check:pnpm-filter-targets` | `136/173 --filter occurrence(s) across 28 file(s) resolve against 78 workspace package(s)` |
| `check:cli-command-ids` | `276 command-id literal(s) across 99 file(s) … all resolve to a real command path` |
| `check:bash32-floor` | `20 tracked shell file(s) … name no bash 4+ construct` |
| `check:nul-bytes` | `OK (scanned 6834 text file(s) … no raw ASCII control bytes)` |
| `pnpm lint` (whole repo, not narrowed) | exit 0, no findings |

Not run locally, left to CI: `check:type-check-debt --re-measure` (needs the full workspace closure built), and the `docs-audit`, `osv-exemptions` and `changeset-fixed` families that need CI context. Every heavy run went through `scripts/pm/os-verify-lock.sh`.

Ⓘ One derivation note worth carrying: two ablation legs were first run with a **repo-relative** path handed to a vitest invoked with the package as cwd. Both exited 1 on `No test files found` — a false red that reads exactly like a successful ablation. They were re-run with the package-relative filter, and only the re-run is reported above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_