### PR TITLE
fix(pm): fail the bare-root worklist self-test when a recorded verdict sits on a REACHABLE row

### DIFF
--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -601,6 +601,53 @@ function selfTest() {
     + 'check-examples-live-imports.mjs, check-driver-conformance.mjs). ⛔ Declaring a root the '
     + 'gate does not read wholesale is the costlier error.' : ''}`, fresh.length === 0);
 
+  // CONTRADICTED: a refusal that outlived the reachability it refused. This is
+  // the THIRD direction of the same coupling, and the one neither assertion
+  // above can see, because both audit the KEY SET. A row whose gate later
+  // declares its root is STILL A ROW, so its verdict is not stale; and it has
+  // left `open`, so it is not fresh either. Both halves stay satisfied while
+  // `report` prints REACHABLE directly above a recorded reason saying the
+  // population cannot be spelled — one row asserting both that it is now
+  // reachable and that it is not. This was PREDICTED in #11155's dev report and
+  // then MEASURED on PR #12061, by declaring a hint on a gate carrying a
+  // REFUSE-UNSPELLABLE verdict: the modified and unmodified trees both exited 0
+  // here, which is why a green self-test could not be read as evidence.
+  //
+  // The pairing is general rather than restricted to the two refusals, because
+  // EVERY verdict this file defines presupposes an UNCOVERED row: the refusals
+  // say a declaration was refused, and DECLARED-NARROWER says in as many words
+  // that the bare root is still not covered.
+  //
+  // ⛔ So the remedy is NOT "move the row to DECLARED-NARROWER". That is the
+  // obvious repair, it is what the reporting card proposed, and it is wrong —
+  // measured here rather than assumed. `covered` asks whether a hint reaches an
+  // ARBITRARY file at the top of the root, so it turns true ONLY for the
+  // spellings that collapse back to the bare word itself; every genuinely
+  // narrower subtree, and every deeper segment filter, leaves the row uncovered.
+  // A covered row is therefore the bare root wearing a separator or a glob,
+  // which is the one thing DECLARED-NARROWER states it is not. No covered row
+  // can honestly wear any of the three, and choosing between the two honest
+  // resolutions RE-DECIDES a verdict on a shrink-only map — not something this
+  // assertion may do quietly, so it names both and picks neither.
+  const contradicted = rows
+    .filter((r) => r.covered && TRIAGE.has(r.key))
+    .map((r) => `${r.key} [recorded ${TRIAGE.get(r.key).verdict}]`)
+    .sort();
+  t(`no recorded verdict sits on a row the sweep now finds REACHABLE${contradicted.length
+    ? ` — CONTRADICTED: ${contradicted.join(' · ')}. That gate now declares a hint reaching an `
+      + 'arbitrary file at the top of the root, so the row claims BOTH that the population is '
+      + 'reachable by declaration and, in its own recorded reason, that it is not. Two honest '
+      + 'resolutions, differing in WHICH half is wrong. Withdraw the DECLARATION, if the recorded '
+      + 'reason still holds and the hint names the gate for files it never opens — the usual '
+      + 'answer under REFUSE-UNSPELLABLE, whose whole reason is that a wholesale hint would be '
+      + 'FALSE, and the costlier error by the price hintCovers records. Or withdraw the VERDICT, '
+      + 'if the declaration is deliberate and overrides the refusal, leaving the row to print '
+      + 'REACHABLE with no reason beneath it: that is the shrink this map already permits, and the '
+      + 'seven reachable rows carrying no verdict today are its live shape. ⛔ Do NOT re-point the '
+      + 'row at DECLARED-NARROWER: that verdict is defined for a row that stays UNCOVERED, and a '
+      + 'covered row is the bare root wearing a glob, not a narrower subtree.'
+    : ''}`, contradicted.length === 0);
+
   // The spelling rule the triage docblock states, held mechanically: a key
   // spelled as a bare path would enter this file's own declared population.
   const asHints = (s) => extractWatchHints(`const L = ${JSON.stringify(s)};`);


### PR DESCRIPTION
Fixes #12064

The worklist prints a live `state` derived from the tree beside a `verdict`
recorded in `TRIAGE`. When a gate carrying a refusal later declares a watch
hint, the state flips to `REACHABLE` while the refusal stays put, and the row
asserts both that its population is reachable by declaration and that it cannot
be spelled. `--self-test` exits 0 through it.

## Why neither existing assertion sees it

Both audit the **key set**. A row whose gate declares its root is still a row,
so its verdict is not `STALE`; and it has left `open`, so it is not `FRESH`.
Both halves stay satisfied. This was predicted in #11155's dev report and then
measured on PR #12061; it is reproduced below on this branch's own base.

## What this adds

One assertion in `--self-test`: a recorded verdict may not sit on a row the
sweep finds `REACHABLE`, naming the offending row and its recorded verdict. No
`TRIAGE` row's `why` or `verdict` is touched, and no row is added or removed —
the map is shrink-only and this card adds a guard, it does not adjudicate rows.

## Two deviations from the remedy as proposed, both measured

**1. The pairing is general, not restricted to `REFUSE-*`.** Every verdict this
file defines presupposes an uncovered row: the two refusals say a declaration
was refused, and `DECLARED-NARROWER`'s own definition says the bare root is
still not covered.

**2. `DECLARED-NARROWER` is not the destination.** The card proposed that a
flipped row "moves to `DECLARED-NARROWER`". Measured, that is not available.
`covered` asks whether a hint reaches an *arbitrary file at the top* of the
root, so it turns true only for spellings that collapse back to the bare word:

| declared spelling | `collapseHint` | covers `ROOT/probe.file` | covers a nested file |
|---|---|---|---|
| bare word | bare word | false | false |
| word + separator | bare word | **true** | true |
| word + `*` | bare word | **true** | true |
| word + `**` | bare word | **true** | true |
| a narrower subtree | that subtree | false | true |
| a deeper segment filter | segment prefix | false | true |

Every genuinely narrower subtree leaves the row **uncovered**. So a covered row
is the bare root wearing a glob — precisely what `DECLARED-NARROWER` states it
is not — and that holds for a `REFUSE-WIDE` row taking the escape too, whose
declaration is *true* of its population and narrower than nothing. The failure
text therefore names the two honest resolutions (withdraw the declaration, or
withdraw the verdict) and picks neither, since choosing re-decides a verdict.

## Evidence

Ablation, on the shape PR #12061 measured — declaring a hint on a gate carrying
`REFUSE-UNSPELLABLE`. Mutation confirmed on disk by anchored `grep -c` and by
`git hash-object` before/after, restored under `trap … EXIT INT TERM`, and the
restore proven byte-identical (`a41147efe985…` both sides). No build is involved:
the sweep reads gate sources from disk, so there is no `dist/` leg to rebuild.

| tree | self-test |
|---|---|
| base `cf99875ea8`, guard absent, gate unmutated | exit 0 — `46 live row(s), 39 unreachable as spelled, 39 recorded verdict(s) — none stale, none missing` |
| base `cf99875ea8`, guard absent, **gate mutated** | **exit 0** — `46 live row(s), 38 unreachable as spelled, 39 recorded verdict(s) — none stale, none missing` ← the defect, reproduced |
| this branch, guard present, gate unmutated | exit 0 — identical to the base line |
| this branch, guard present, **gate mutated** | **exit 1** — `CONTRADICTED: check:ratchet-remedy-authority SCRIPTS_DIR scripts [recorded REFUSE-UNSPELLABLE]` |

On the mutated tree the report printed the card's exact defect: `REACHABLE`
above `The idiom has no non-recursive spelling`.

The guard is **green on the tree as it stands** — no row is currently in the
contradictory state. Verified rather than inferred: all 7 reachable rows carry
no verdict, and the 39 verdicts sit on the 39 open rows. The live run's output
is byte-identical before and after this change.

Gate union re-derived at the final commit `c5e46219a1` with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no stale
tree; `check:bash32-floor` present and run). All 10 derived families green, plus
`check:nul-bytes`, each exit code captured before any pipe. Repo-wide
`eslint . --no-inline-config` ran the full population — 5161 files by eslint's
own `--format json` count, 0 errors, 0 warnings, this file included — so there
is no narrowing to declare.

## Scope

`scripts/pm/bare-root-worklist.mjs` only. This card does **not** reach the class
reported in #12328, and is not described as doing so: those four rows never flip
to `REACHABLE`, because `covered()` probes a top-of-root path that none of their
spellings match, so this guard never fires on them. #12328 remains open, as does
#12289.

No changeset: `scripts/` is not a workspace member and no published package's
`files` field ships it, so this PR releases nothing — route 2 of the
changeset-check step, the `skip-changeset` label.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_