### PR TITLE
docs(gate): record the read-seam wrapper recursion's callback refusal, measured per seam

### DIFF
--- a/scripts/check-durability-degradation-log-level.mjs
+++ b/scripts/check-durability-degradation-log-level.mjs
@@ -967,6 +967,92 @@ const FAILURE_PROPAGATION_SITES = new Map([
 // and after. Only the seam count moves, and ⛔ no baseline entry was added: an
 // entry there says a human read the seam, not that a rule guessed wrong.
 
+// ── THE WRAPPER RECURSION'S CALLBACK REFUSAL — MEASURED, NOT CHANGED (#12138) ─
+//
+// `isReadCall`'s wrapper recursion walks a same-file wrapper's body with
+// `walkSameTickInclusive`, so a driver read sitting inside a nested function
+// body is not seen. The top of this file states the reason the `try` side
+// refuses the same descent ("a callback registered inside a try runs later and
+// is not guarded by that catch"). That reason is about the TRY. #12138 asked
+// whether it is also the right answer for a WRAPPER body, where it is not
+// obviously right: a wrapper whose read sits in a SYNCHRONOUSLY invoked
+// callback does perform that read on its caller's behalf, inside the caller's
+// try. The narrowness was recorded here for the try side only and nowhere for
+// the wrapper side; this block is that missing record.
+//
+// RE-MEASURED on one named tree — `origin/main` @ 3ddad51b5c, and reproduced
+// byte-identically (both counts AND all 8 delta seams) after merging
+// `origin/main` @ c312a562e3 — because the filing's own table (64 → 72) was
+// attributed to a tree that predates #12137 and reported 66 there:
+//
+//   | recognizer                                       | read seams |
+//   |--------------------------------------------------|-----------:|
+//   | today — `walkSameTickInclusive`, depth 2          |         64 |
+//   | probe — `walkAll`, depth 2                        |         72 |
+//
+// The delta is still 8. What the per-seam reading found is that the wrapper
+// recursion's callback refusal explains only THREE of those 8.
+//
+// THE DISCRIMINATING RUN. Raising `MAX_READ_WRAPPER_DEPTH` from 2 to 6 while
+// leaving `walkSameTickInclusive` in place admits 5 of the same 8 (70 seams: +8
+// / -2, where the 2 are the SAME try lines re-attributed to a different
+// first-matching callee, engine.ts:9407 and :10572). Saturation checked at
+// depth 50: 70 and 75, i.e. unchanged. So for those 5 the miss is the DEPTH
+// BOUND, not the callback boundary — `walkAll` merely masks the bound by
+// descending lexically through nested DECLARATIONS instead of counting call
+// hops, which reaches the read at depth 1 no matter how many awaits are between.
+//
+// THE 8 DELTA SEAMS, each read at its call site:
+//
+//   | # | seam (try line → wrapper)                                      | why today misses it | invoked now? |
+//   |--:|----------------------------------------------------------------|---------------------|--------------|
+//   | 1 | metadata-protocol protocol.ts:10243 getMetaItemCached→getMetaItem | depth bound       | yes — real   |
+//   | 2 | metadata-protocol protocol.ts:13559 saveMetaItem→getMetaItem      | depth bound       | yes — real   |
+//   | 3 | metadata-protocol protocol.ts:14535 migrateStoredMetadata→saveMetaItem | depth bound   | yes — real   |
+//   | 4 | metadata-protocol protocol.ts:17213 duplicatePackage→saveMetaItem  | depth bound       | yes — real   |
+//   | 5 | metadata-protocol sys-metadata-repository.ts:883 promoteDraft→dropPromotedDraftRow | CALLBACK | yes — real |
+//   | 6 | metadata-protocol sys-metadata-repository.ts:1353 close→terminate  | CALLBACK          | NO — FAKE    |
+//   | 7 | objectql engine.ts:9237 insert→applyAutonumbers                    | CALLBACK          | yes — real   |
+//   | 8 | objectql lifecycle-service.ts:625 sweep→reapObject                 | depth bound       | yes — real   |
+//
+// All 8 were decidable from the call site; none needed provenance. Seams 1-5,
+// 7 and 8 are genuine members the census does not count: every hop is an
+// `await` on the caller's own tick (`getMetaItem` → `findOverlay`/`findDraft` →
+// `lookup` → `engine.findOne`; `delete` → `withTxn(cb)`, which is
+// `engine.transaction(cb)` or `cb(undefined)` and is awaited either way;
+// `seedAutonumber` → `keysetWalk(cb)` driven by the `for await` on the next
+// line; `archiveObject` → `archivePass`, an awaited local const).
+//
+// ⚠️ SEAM 6 IS A FAKE SEAM, AND IT IS THE REASON `walkAll` IS NOT THE FIX.
+// `close()`'s try calls `w.terminate()`. `terminate` resolves BY NAME to the
+// local const arrow at sys-metadata-repository.ts:1246 — a synchronous, void,
+// in-memory routine whose only call is `self.watchers.delete(subscription)` on
+// `private readonly watchers = new Set<...>()`. `calleeName` reads that as
+// `delete`, and the wrapper recursion resolves `delete` to THIS FILE'S
+// `async delete(ref, opts)` method, whose `findOne` lives inside a `withTxn`
+// callback. Ablation: refusing the `delete` wrapper hop drops the probe from 72
+// to exactly 70, removing seams 5 and 6 and nothing else.
+//
+// That is #11921's defect — a callee NAME matched with no shape check — one
+// level up, on the WRAPPER name instead of the vocabulary name.
+// `contradictsDriverReadShape` guards only the `DRIVER_READ_CALLEES` hit above;
+// the wrapper hop has no equivalent. Today it is harmless because the callback
+// refusal stops the walk before the fake read is reached. Widening the walk is
+// what arms it, and a fake seam is the UNSAFE direction: an invented member of
+// the denominator #5186 / #6451 / #9165 / #8845 / #8901 are all quoted against.
+//
+// ⛔ NOTHING WAS CHANGED, and the reason is a measurement rather than caution.
+// The sanctioned cheap fix for this card was an `Array.prototype.map` /
+// `Promise.all` allowlist. NOT ONE of the 8 goes through `map` or
+// `Promise.all`: the real shapes are `withTxn(cb)`, `keysetWalk(cb)` (imported
+// from `@objectstack/types`, so its body is not even in this file's index) and
+// locally-bound const arrows. That allowlist would admit zero of them while
+// still not excluding seam 6. Telling the four real callback seams from the
+// fake one needs to know what the receiving method does with its argument —
+// which is #11921's provenance problem, deliberately out of this card's scope.
+// The census is therefore UNMOVED at 64, and #8901's restart conjunct (b) is
+// not triggered by this reading.
+
 /**
  * Where the read-seam rule looks. Narrowed on purpose — see above.
  *


### PR DESCRIPTION
Part of #12138.

`Part of`, not `Fixes`: this card was dispatched measure-first, and the measurement says the sanctioned fix does not apply. Triage should decide what happens next — see "What this does not do".

**Comment-only.** 86 insertions, 0 deletions, all inside the header of `scripts/check-durability-degradation-log-level.mjs`. The read-seam census is unchanged at 64 and the self-test's 45 read-seam cases and 63 log-level cases are unchanged.

## Why there is a record to write at all

`isReadCall`'s wrapper recursion walks a same-file wrapper's body with `walkSameTickInclusive`, so a driver read inside a nested function body is not seen. The top of the file states the reason the **`try`** side refuses the same descent — *"a callback registered inside a try runs later and is not guarded by that catch"* — and states it nowhere for the **wrapper** side, where the same answer is not obviously right. #12138's own dedupe section identified that missing record. This is it.

## Both recognizers re-derived on one named tree

The filing's table (64 → 72) was attributed to `origin/main` @ `8619f9513`, where the gate actually reports **66**; 64 was the post-#12137 figure. #12137 has since merged, so the table was re-derived rather than carried forward:

| recognizer | read seams |
|:--|--:|
| today — `walkSameTickInclusive`, depth 2 | 64 |
| probe — `walkAll`, depth 2 | 72 |

Measured at `origin/main` @ `3ddad51b5c`, then reproduced byte-identically — both counts **and** all 8 delta seams — after merging `origin/main` @ `c312a562e3`. The delta is still 8.

## The wrapper recursion explains only 3 of the 8

Raising `MAX_READ_WRAPPER_DEPTH` from 2 to 6 while leaving `walkSameTickInclusive` **in place** admits 5 of the same 8 (70 seams: +8 / −2, where the 2 are the same `try` lines re-attributed to a different first-matching callee, `engine.ts:9407` and `:10572`). Saturation checked at depth 50 — 70 and 75, unchanged.

So for those 5 the miss is the **depth bound**, not the callback boundary. `walkAll` merely masks the bound by descending lexically through nested *declarations* instead of counting call hops, which reaches the read at depth 1 no matter how many awaits sit between.

| # | seam | why today misses it | invoked now? |
|--:|:--|:--|:--|
| 1 | `protocol.ts:10243` `getMetaItemCached` → `getMetaItem` | depth bound | yes — real |
| 2 | `protocol.ts:13559` `saveMetaItem` → `getMetaItem` | depth bound | yes — real |
| 3 | `protocol.ts:14535` `migrateStoredMetadata` → `saveMetaItem` | depth bound | yes — real |
| 4 | `protocol.ts:17213` `duplicatePackage` → `saveMetaItem` | depth bound | yes — real |
| 5 | `sys-metadata-repository.ts:883` `promoteDraft` → `dropPromotedDraftRow` | **callback** | yes — real |
| 6 | `sys-metadata-repository.ts:1353` `close` → `terminate` | **callback** | **no — FAKE** |
| 7 | `engine.ts:9237` `insert` → `applyAutonumbers` | **callback** | yes — real |
| 8 | `lifecycle-service.ts:625` `sweep` → `reapObject` | depth bound | yes — real |

All 8 were decidable from the call site; none needed provenance. Every hop in the seven real ones is an `await` on the caller's own tick.

## Seam 6 is a fake seam, and it is why `walkAll` is not the fix

`close()`'s `try` calls `w.terminate()`. `terminate` resolves **by name** to the local `const` arrow at `sys-metadata-repository.ts:1246` — a synchronous, void, in-memory routine whose only call is `self.watchers.delete(subscription)` on `private readonly watchers = new Set<WatchSubscription>()`. `calleeName` reads that as `delete`, and the wrapper recursion resolves `delete` to *this file's* `async delete(ref, opts)` method, whose `findOne` lives inside a `withTxn` callback.

Ablation: refusing the `delete` wrapper hop drops the probe from 72 to exactly 70, removing seams 5 and 6 and nothing else.

That is #11921's defect — a callee **name** matched with no shape check — one level up, on the *wrapper* name instead of the vocabulary name. `contradictsDriverReadShape` guards only the `DRIVER_READ_CALLEES` hit; the wrapper hop has no equivalent. Today it is harmless because the callback refusal stops the walk before the fake read is reached. **Widening the walk is what arms it**, and a fake seam is the unsafe direction: an invented member of the denominator #5186 / #6451 / #9165 / #8845 / #8901 are all quoted against.

## What this does not do, and why

The sanctioned cheap fix for this card was an `Array.prototype.map` / `Promise.all` allowlist. **Not one of the 8 goes through `map` or `Promise.all`.** The real shapes are `withTxn(cb)`, `keysetWalk(cb)` (imported from `@objectstack/types`, so its body is not even in this file's index) and locally-bound `const` arrows. That allowlist would admit zero of them while still not excluding seam 6. Telling the four real callback seams from the fake one needs to know what the receiving method does with its argument — #11921's provenance problem, deliberately out of this card's scope.

The `try`-side refusal is untouched and stays separable: the wrapper recursion is at `isReadCall`'s `walkSameTickInclusive(body, …)`, a different call site from the two catch-side helpers (`findPropagationCall`, `collectLoggedLevels`).

**The census does not move.** It is 64 before and after, so #8901's restart conjunct (b) is not triggered by this reading.

## Changeset

None, deliberately. `scripts/**` is not published by any workspace package, and this change is comment-only inside a CI gate script — there is no user-visible behaviour and nothing for release notes to describe. `skip-changeset` applied.

## Verification

At the final commit `39613ffb7c`, union re-derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no `STALE TREE`). All run under `scripts/pm/os-verify-lock.sh`, exit codes captured before any pipe — `VERDICT command-exit 0 · held the lock 34s · waited 408s`:

`check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check:durability-log-level` · `check:entry-guard` · `check:parse-guard` · `check:pnpm-filter-targets` · `check-ci-filter-parity.mjs` · `check-cross-package-test-inputs.mjs` · `check-nul-bytes.mjs` — all `EXIT=0`.

The gate's own verdict lines at that commit:

```
✓ self-test (log-level rule): 63 case(s) passed
✓ self-test (read-seam invention rule): 45 case(s) passed, and the baseline offer stays marked maintainer-only (#8435)
✓ read-seam invention (#5186 + #6451 + #9165, 3 package roots, vocabulary find/findOne/count): 64 read seam(s), none invents an unreported answer …
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_