### PR TITLE
fix(docs): point gitConfig at the current repository name

### DIFF
--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,8 +1,14 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 
+// The repository was renamed `framework` → `objectstack`. GitHub keeps a permanent
+// rename redirect, so the old name still resolves — but every URL built from it costs a
+// 301, and `repo` is also the source of `SoftwareSourceCode.codeRepository` in the
+// homepage JSON-LD, where it is a machine-readable identity claim rather than a link.
+// Keep this the *current* name: a future repo actually named `framework` would silently
+// repoint every link built here.
 export const gitConfig = {
   user: 'objectstack-ai',
-  repo: 'framework',
+  repo: 'objectstack',
   branch: 'main',
 };
 


### PR DESCRIPTION
Fixes #12354

Part of the docs-site indexability epic #12243.

## What changed

One constant, in `apps/docs/lib/layout.shared.tsx`:

```diff
-  repo: 'framework',
+  repo: 'objectstack',
```

plus a comment recording why it must stay the current name.

## The premise, reproduced

The issue's claim is that `framework` is the pre-rename name. Reproduced rather than trusted:

```
$ gh api repos/objectstack-ai/framework   --jq '.id, .full_name'
1136691870
objectstack-ai/objectstack
$ gh api repos/objectstack-ai/objectstack --jq '.id, .full_name'
1136691870
objectstack-ai/objectstack
```

Same repository id, so `framework` is a rename redirect and nothing was ever broken — every URL simply cost a 301. Fixing it at the producer corrects the nav link, the hero button, every per-page edit link, and (once #12355 lands) `SoftwareSourceCode.codeRepository` in the JSON-LD, in one edit. A local override in the JSON-LD would have been the consumer-side patch the contract-first directive rejects.

## How wide the sweep is, and how that was established

A grep for the bare word `framework` is useless here — it is legitimate prose throughout the repo. The sweep used the **URL shape** and the **constant's own name**, over `apps/docs/` only.

Pattern 1 — every `github.com` occurrence under `apps/docs/`, filesystem-level so untracked files are included:

```
grep -rnaiE 'github\.com|objectstack-ai|framework' apps/docs/ \
  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.turbo
```

Full return, triaged:

| Hit | Verdict |
| --- | --- |
| `lib/layout.shared.tsx:5` — `repo: 'framework'` | **the bug** — fixed |
| `lib/layout.shared.tsx:4` — `user: 'objectstack-ai'` | correct, untouched |
| `lib/layout.shared.tsx:20` — `` `https://github.com/${gitConfig.user}/${gitConfig.repo}` `` | reads the constant |
| `app/[lang]/page.tsx:195` — same template | reads the constant |
| `app/[lang]/docs/[[...slug]]/page.tsx:31` — `` …/blob/${gitConfig.branch}/content/docs/${page.path} `` | reads the constant |
| `vercel.json:3` — `"framework": "nextjs"` | Vercel's build-preset key. Unrelated; **must not** be touched |
| `app/[lang]/page.tsx:25,51`, `blog/[[...slug]]/page.tsx:201` — "metadata framework for AI-written apps" | prose |
| `app/[lang]/page.tsx:406` — "7 framework adapters" | prose |

Pattern 2 — every consumer of the constant, repo-wide (`git ls-files -z | xargs -0 grep -na 'gitConfig'`): six lines, all in the three files above.

**Result: there is no independent repository-name literal anywhere under `apps/docs/`.** All three link types are pure concatenations of this one constant, so the sweep is exactly one line wide. That is the judgement the card asked for.

## Verification — local production build, not the live site

Production has not redeployed since ~16:55 (#12333), so the live site is evidence about a stale build only. Everything below is `pnpm --filter @objectstack/docs build` + `next start -p 3457` in this worktree, measured before and after the edit.

Rendered hrefs, extracted from the served HTML:

| Link type | Source | Before | After |
| --- | --- | --- | --- |
| Nav bar GitHub link | `baseOptions().githubUrl` | `github.com/objectstack-ai/framework` | `github.com/objectstack-ai/objectstack` |
| Homepage hero button | `app/[lang]/page.tsx:195` | `github.com/objectstack-ai/framework` | `github.com/objectstack-ai/objectstack` |
| Per-page edit link | `app/[lang]/docs/[[...slug]]/page.tsx:31` | `…/framework/blob/main/content/docs/ui/views.mdx` | `…/objectstack/blob/main/content/docs/ui/views.mdx` |

`curl -sI` on each rendered URL — status codes, not just final URLs:

```
BEFORE
$ curl -sI https://github.com/objectstack-ai/framework
HTTP/2 301
$ curl -sI https://github.com/objectstack-ai/framework/blob/main/content/docs/ui/views.mdx
HTTP/2 301

AFTER
$ curl -sI https://github.com/objectstack-ai/objectstack
HTTP/2 200
$ curl -sI https://github.com/objectstack-ai/objectstack/blob/main/content/docs/ui/views.mdx
HTTP/2 200
$ curl -sI https://github.com/objectstack-ai/objectstack/blob/main/content/docs/index.mdx
HTTP/2 200
```

The nav link and the hero button emit the same URL string, so they share one measurement; they were confirmed separately in the rendered HTML of `/docs` and `/` respectively.

Whole-site check — every prerender artifact (411 `.html`, 2048 `.rsc`, 811 `.body`), not just the three pages spot-checked:

```
$ find .next/server/app -type f -print0 \
    | xargs -0 grep -ohaE 'github\.com/objectstack-ai/framework' | wc -l
   3656     # before
      0     # after
```

Repository names still present in rendered pages after the fix, all legitimate: `objectstack-ai/objectstack` (1632), `objectstack-ai/objectui`, `objectstack-ai/hotcrm`, `objectstack-ai/claude-plugin`, `mycompany/crm` (a doc example), plus third-party `google/cel-spec`, `marcbachmann/cel-js`, `kofrasa/mingo`, `changesets/changesets`. One apparent `objectstack-ai/objec` hit is an RSC streaming chunk boundary splitting a prose URL across two `__next_f.push` calls, not a truncated link.

## Gates

Families derived from the real change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the script reads the merge base itself), then re-run **after the final commit**, at `06412954e`, working tree clean:

| Gate | Result |
| --- | --- |
| `pnpm check:page-declaration-shape` | `check-page-declaration-shape: OK — 34 page entries across 2189 sources` |
| `pnpm check:published-files` | `✓ check:published-files — 69 publishable package(s)…` |
| `pnpm check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned` |
| `pnpm check:type-source-resolution` | `check-type-source-resolution OK — 93 tsc program(s) across 77 packages` |
| `pnpm check:nul-bytes` | `check-nul-bytes: OK (scanned 6836 text file(s)… no raw ASCII control bytes)` |
| `pnpm --filter @objectstack/docs typecheck` | exit 0 |
| `pnpm lint` (full repo, `eslint . --no-inline-config`) | `VERDICT command-exit 0` |

`typecheck` was confirmed to actually cover the edited file rather than exclude it — `tsc --noEmit --listFiles` lists `apps/docs/lib/layout.shared.tsx` (1 hit), so the green is a measurement of this change and not a vacuous pass.

`pnpm lint` first aborted with a V8 heap abort (exit 134) at `--max-old-space-size=4096` while the `next start` server still held memory; that was a resource failure, not a lint finding. Re-run at 8192 with the server stopped: clean, 40s.

**Declared narrowing — verification ran UNLOCKED.** This host is macOS and ships no `flock`, so `scripts/pm/os-verify-lock.sh` ran in its declared unlocked mode: the shared verify lock was never taken and nothing was serialized. Every run above carries `VERDICT … · UNLOCKED (declared)`. This is a declared narrowing, not a silent one.

## No changeset

Docs-site only — this publishes nothing, so there is no `.changeset/*.md`. The `skip-changeset` label is applied to this PR.

## Out of scope, for the PM to file

The sweep stopped at `apps/docs/` as instructed. Two things it surfaced elsewhere, deliberately left untouched:

1. **`content/docs.site.json` carries a second, independent repository-name constant** — `page.repoBaseUrl` and `themeConfig.socials[].url` are both `https://github.com/objectstack-ai/spec`. `objectstack-ai/spec` is *also* a stale name: `curl -sI` returns `HTTP/2 301` with `location: https://github.com/objectstack-ai/objectstack`. It has **zero runtime consumers** (the only references to `repoBaseUrl` anywhere in the repo are gate scripts that mention the filename as a path-hint fixture), so it does not reach rendered output today — but it is a second constant spelling a third name, and inert config is exactly what someone wires up later.
2. **Stale `objectstack-ai/spec` links in published prose**: `content/blog/metadata-driven-architecture.mdx:586`, `content/blog/protocol-first-development.mdx:335,851` (these two *do* render — the blog pages are the 4 rendered `spec` hits above), plus `CONTRIBUTING.md:38,57,440`, `docs/notes/airtable-dashboard-analysis.mdx:11`, and the link-reference block at the bottom of the root `CHANGELOG.md`. `docs/audits/2026-06-handwritten-docs-accuracy-followups.md:40` already flagged these for human follow-up and declined to rewrite them.

Neither was touched — `content/**`, `CONTRIBUTING.md` and `CHANGELOG.md` are other cards' territory.

_Generated by [Claude Code](https://claude.ai/code/session_f9f0958b-ab68-46cc-801c-216aa7ee2107)_
