### PR TITLE
docs: promise per-regime customization truth on integrations + build-without-code (ADR-0126 §8.4)

### DIFF
--- a/content/docs/build-without-code.mdx
+++ b/content/docs/build-without-code.mdx
@@ -34,7 +34,7 @@ Two properties make Studio safe to hand to non-developers:
 
 ## Setup — where the platform is administered
 
-The **System Settings** app covers platform administration: user management and invitations, permission assignment, datasources (including federated external databases), diagnostics and audit logs, and the **Marketplace** — template apps such as HotCRM install with one click and appear alongside your own apps, ready to customize in Studio.
+The **System Settings** app covers platform administration: user management and invitations, permission assignment, datasources (including federated external databases), diagnostics and audit logs, and the **Marketplace** — template apps such as HotCRM install with one click and appear alongside your own apps. What "customize" means depends on the piece: views and dashboards are yours to edit directly; a packaged object grows through your own fields via an extension package, never by reshaping what shipped; a packaged flow stays locked, but a dedicated **packaged automation** page here lets you switch it off and clone your own — the clone is an ordinary flow, yours to edit in Studio.
 
 ## When to reach for code instead
 

--- a/content/docs/capabilities/integrations.mdx
+++ b/content/docs/capabilities/integrations.mdx
@@ -14,7 +14,7 @@ A business system earns its keep by fitting into the systems — and habits — 
 - **Triggers in** — external systems start platform [flows](/docs/capabilities/automation).
 - **Connectors** — ready-made Slack and generic REST connectors drop into flows; an HTTP API, OpenAPI document, or MCP server can be [declared as metadata](/docs/automation/connectors) and goes live at boot, no plugin code.
 - **Federated external databases** — point at an existing database and query it in place: no migration, visible in views, usable in flows.
-- **Marketplace templates** — install complete apps (HotCRM among them) with one click: objects, views, flows, dashboards, and seed data included, then customize in Studio.
+- **Marketplace templates** — install complete apps (HotCRM among them) with one click: objects, views, flows, dashboards, and seed data included. Views and dashboards are yours to edit directly; a packaged flow stays locked, but [Setup](/docs/build-without-code) lets you switch it off and clone your own to edit in Studio; a packaged object grows through your own fields via an extension package, not by editing what shipped.
 - **Deploy anywhere** — cloud or fully self-hosted; your data and your app definition stay yours.
 
 ## Everyday collaboration


### PR DESCRIPTION
Fixes #12161

Part of #12150 (Epic: ADR-0126 implementation, v17 line). Contract: ADR-0126 §1.3 + §8 item 4 (`28b47a93`).

## What was over-promised

§1.3 recorded the shipped defect: two capability pages promised generic post-install "customize in Studio" for marketplace apps. Measured against the tier table, that promise was keepable for views/dashboards and for no tier-B type — flows specifically. §8 item 4 chartered the correction, gated on the L5 Setup surface existing (it now does: objectui#6382, merged `b362c1b`, adds the Setup packaged-automation page — on/off + clone).

## What changed

Both passages are rewritten to the three-regime truth (ADR-0126 §2/§3):

- `content/docs/capabilities/integrations.mdx` — the "Marketplace templates" bullet no longer promises a blanket "customize in Studio". It now says: views/dashboards are yours to edit directly; a packaged flow stays locked but can be switched off and cloned (via Setup) to edit in Studio; a packaged object grows through your own fields via an extension package, not by editing what shipped.
- `content/docs/build-without-code.mdx` — the Setup section's Marketplace clause gets the same per-regime breakdown, naming the packaged-automation page specifically since it lives in Setup (the section being described).

No other pages touched, no restructuring — the promising passages only.

## Tests

Local doc gates (see report for full command list and matched-family derivation via `node scripts/pm/dispatch-gates.mjs`, run against merge-base `017130a0`): `check:doc-authoring`, `check:doc-anchors`, `check:doc-formula-expressions`, `check:doc-security-posture`, spec `check:docs`, `check:docs-audit-scope`, `check:docs-redirects`, `check:docs-single-h1`, spec `check:empty-state`, spec `check:liveness`, `check:published-readme-links`, `check:react-page-adapter-contract`, `check:role-word`, spec `check:skill-examples`, spec `check:strictness-ledger`, spec `check:variant-docs`, `check-ci-filter-parity.mjs`, `check-cross-package-test-inputs.mjs`, `check-doc-frontmatter.mjs`, `check-doc-route-spelling.mjs`, `check-docs-section-name.mjs`, `check-section-landing-index.mjs`, `check:cross-package-test-inputs` — all pass at head `e7f41817`.

CI's full farm and the offline lychee link-checker run server-side; this PR does not wait on them (per-card convention).

Docs-only change; `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWRU3s15AJz7PGW7a7wdCh)_