### PR TITLE
docs(glossary): name the typed metadata artifact in the category's vocabulary

### DIFF
--- a/content/docs/getting-started/glossary.mdx
+++ b/content/docs/getting-started/glossary.mdx
@@ -80,6 +80,33 @@ Reusable error maps, suggestions, and metadata normalization utilities.
 
 ## Architecture Concepts
 
+### Business Ontology
+The enterprise-AI category's name for the thing these docs otherwise call **typed
+metadata**, the **single source of truth**, or the **app contract**: one machine-readable
+definition of a business domain — its objects and fields, the relations between them, the
+permissions that govern them, and the flows and actions that operate on them. If you
+arrived from that vocabulary, this is the term's referent here: the **Source** you author
+(`objectstack.config.ts`) and the **Artifact** it compiles to (`objectstack.json`), from
+which the runtime derives the database schema, REST API, UI, and MCP server. See
+[Metadata-Driven Development](/docs/concepts/metadata-driven).
+
+The word is worth stating explicitly because ObjectStack's differs from the hosted
+ontologies the category otherwise means by it, on two points:
+
+* **You own the definition.** It lives in your repository as ordinary TypeScript,
+  versioned in your VCS and reviewable as a diff, in a format specified and licensed
+  Apache-2.0 — not as a graph held inside a vendor's system and reachable only through
+  that vendor's console.
+* **It is executed, not merely described.** The same definition is enforced at authoring
+  time by Zod schemas and the validation gate, and at runtime on every call — RBAC, FLS,
+  and audit included (see **Agent-Ready Boundaries** below). It is not a descriptive map
+  of behaviour implemented somewhere else, so it cannot drift from the system it
+  describes.
+
+Distinct from **semantic layer**, which in these docs means the narrower analytics
+`dataset` layer (ADR-0021) that reports and dashboards bind to — see
+[Analytics & Datasets](/docs/data-modeling/analytics).
+
 ### Protocol-Driven
 A development paradigm where logic is defined in static, declarative data formats (JSON/YAML) with Zod schemas rather than imperative code. The goal is to separate the **Intent** (Business Logic) from the **Implementation** (Tech Stack).
 


### PR DESCRIPTION
Fixes #12228

## The measurement, re-derived with a positive control

Taken at `origin/main` (`0b10068c38`), full checkout, 438 files under `content/docs/`:

| Probe (same command shape: `grep -ril TERM content/docs/`) | Files |
|:--|--:|
| `ontology` | **0** |
| `metadata` — positive control | 272 |
| `permission` — positive control | 176 |
| `business logic` — positive control, two-word phrase | 26 |
| `zzqqxnonsense` — negative control | 0 |

The controls reverse the zero: the same command over the same corpus returns non-zero for
vocabulary the docs do use, and zero for a token that genuinely is not there. The zero is
the term's real absence, not a broken pathspec. `README.md` carries `ontology` **4** times;
no other top-level `*.md` carries it at all.

## Which of the two fixes this is, and why the other is wrong

This card had two opposite resolutions, and they are not interchangeable:

**(a) The README overclaims** — rejected, by measurement. The README's claim is that your
metadata is "an open, versioned definition of your objects, permissions, and flows that you
own." Every clause of that is documented, just under other words:

- `concepts/north-star.mdx` — "data models, views, flows, permissions, actions, AI tools,
  and runtime requirements are typed metadata"; "**Metadata is the app contract**"
- `concepts/metadata-driven.mdx` — "business intent is defined by declarative, analyzable
  metadata"; "**Single Source of Truth**"
- `getting-started/glossary.mdx` — **Source** (`objectstack.config.ts`, in your repo) and
  **Artifact** (`objectstack.json`), the authoring and distribution forms
- `LICENSE` — Apache-2.0

The repo's own ADRs already use the word for exactly this referent, which settles it:
ADR-0063 — "the **ontology** is in the metadata"; ADR-0109 — "The platform's **ontology**
is already executable." The docs site's landing page (`apps/docs/app/[lang]/page.tsx`)
also carries the claim in body copy *and* in its HTML meta description. So the term is
already the maintainers' own word for the concept — deleting it from the README would have
removed an accurate claim, not a false one.

**(b) The docs under-name a real, central concept** — this is what the measurement shows,
and what this PR fixes.

## What changed — one page, one entry

One new **Business Ontology** entry at the head of *Architecture Concepts* in
`content/docs/getting-started/glossary.mdx` (+27 lines, no other file, no existing wording
rephrased). The glossary is the page whose stated job is "the shared vocabulary used
across these docs," so an equivalence statement is what it is *for*.

Deliberately **not** find-and-replace, and not the phrase sprinkled onto a page so the
count stops reading zero. The entry does three things a sprinkle would not:

1. **States the equivalence once, precisely** — names the category's term and maps it to
   this corpus's existing words (`typed metadata`, `Single Source of Truth`, `app
   contract`) and to the concrete Source/Artifact pair, so a reader or model arriving with
   the category's vocabulary lands on the real referent.
2. **States the two differentiators** — you own it (in your repo, versioned in your VCS,
   diffable, Apache-2.0, not a graph inside a vendor's console) and it is *executed*, not
   descriptive (Zod + the validation gate at authoring time; RBAC/FLS/audit at runtime), so
   it cannot drift from the system it describes.
3. **Prevents a collision inside this corpus** — "semantic layer" already means something
   narrower and specific here: the analytics `dataset` layer (ADR-0021) that reports and
   dashboards bind to, across 8 files. The entry marks the two as distinct rather than
   letting a new umbrella term quietly absorb a taken one.

No claim about the product is added or removed; the README is untouched.

## Verification

All 23 gate families derived for this diff — `node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack`, which reads the change set from the merge base itself — were
run at the **final commit `e0ced68ef6`** and are green. Exit codes captured before any
pipe. The remaining 6 families the script lists are the changeset families, which do not
apply: this is docs-only, matching the script's own "write one unless this card is
docs-only" and the last 10 docs-only merges, none of which carry a changeset.

Named verdict lines rather than bare `$?`:

- `check:doc-anchors`, `check:doc-authoring`, `check:docs-single-h1`,
  `check:doc-frontmatter`, `check:doc-route-spelling`, `check:docs-section-name`,
  `check:section-landing-index`, `check:role-word`, `check:nul-bytes`,
  `check:docs-audit-scope`, `check:docs-redirects`, `check:published-readme-links`,
  `check:react-page-adapter-contract`, `check:cross-package-test-inputs`,
  `check:ci-filter-parity` — all exit 0
- `check:doc-formula-expressions` — `✓ 22 record-scoped formula example(s) across 422 files
  / 1449 TS blocks judged clean`
- `check:doc-security-posture` — `✅ 26 ObjectSchema.create example(s) in 230 marked
  block(s) across 237 prose file(s) … carry an os validate-clean security posture`
- `check:skill-examples` — `✅ 260 prose examples type-check across 3 surface(s)`
- `check:docs`, `check:empty-state`, `check:liveness`, `check:strictness-ledger`,
  `check:variant-docs` (all `@objectstack/spec`) — exit 0

Two gates first reported `PREREQUISITE NOT MET — the package is not built`; those were
unbuilt-prerequisite results, not findings, and both are green above after building
`@objectstack/lint`, `@objectstack/formula`, `@objectstack/client-react` and
`@objectstack/client`.

**Repo-wide `pnpm lint`:** not narrowed — inapplicable, established from ESLint's own
config resolution rather than assumed. `eslint --no-inline-config --format json` on the
changed file reports 1 file, 0 errors, and its single warning is
`File ignored because no matching configuration was supplied` — no config block in
`eslint.config.mjs` matches `.mdx` or `content/`. Untouched files cannot move either: the
config "never enables type-aware linting (no `parserOptions.project`, no typed
`@typescript-eslint` rules) for ANY file" (`eslint.config.mjs:322-328`, recorded there with
its own positive control). A one-file `.mdx` diff is outside the linted population
entirely.

`skip-changeset` applied — docs-content only, nothing published.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_
