### PR TITLE
Make `delete ctx.input.x` in a hook actually remove the field — the flat-input Proxy trap and the sandbox write-back

### DIFF
--- a/.changeset/hook-input-delete-lands.md
+++ b/.changeset/hook-input-delete-lands.md
@@ -1,0 +1,95 @@
+---
+'@objectstack/objectql': minor
+'@objectstack/runtime': minor
+---
+
+fix(objectql,runtime): `delete ctx.input.x` in a hook actually removes the field (#12277)
+
+A hook that stripped a field from its input with `delete` did nothing, on BOTH
+execution paths, while an assignment made two lines above it on the same object
+in the same call landed normally. Nothing raised, and nothing in the platform
+reported it.
+
+Graded `minor` rather than `patch` deliberately: it moves data that reaches
+downstream consumers. Any shipped hook that already contains
+`delete ctx.input.<field>` has been a no-op until now and starts taking effect
+on upgrade — which is the point, and is also exactly why it must not arrive as
+a silent patch. No API is removed and no accept set narrows.
+
+### The two mechanisms, which were unrelated and produced one outcome
+
+**In-process (`installFlatInput`, `packages/objectql/src/hook-wrappers.ts`).**
+The flat-record `Proxy` a declarative hook receives over the engine's
+`{ data, options, id? }` wrapper trapped `get` / `set` / `has` / `ownKeys` /
+`getOwnPropertyDescriptor` — but not `deleteProperty`. The delete therefore fell
+through to `Reflect.deleteProperty` on the WRAPPER, one level above the record,
+removing a key that was never there and returning `true`. `set` was trapped and
+wrote into `data`, which is what the engine persists; hence assignment survived
+and deletion evaporated.
+
+**Sandboxed (`applyMutationsToInput`,
+`packages/runtime/src/sandbox/body-runner.ts`).** A QuickJS body's mutations
+were written home with `Object.assign(target, result.mutatedInput)`.
+`Object.assign` copies own enumerable properties and **has no way to represent a
+removal**: a key the VM deleted is simply not in the snapshot, and the host's
+key stayed. Deletions are now diffed against the entry snapshot and applied
+separately.
+
+Both are fixed in one change on purpose. Closing either alone would make the
+same authored `delete` behave differently depending on whether the hook body
+runs in-process or in the sandbox — a worse contract than the symmetric silence
+it replaced.
+
+### What an author could see, before and after
+
+The sandboxed path is the one with no tell at all. Measured on the pre-fix code,
+one hook call, host row alongside:
+
+```
+delete ctx.input.internal_notes  ->  true
+'internal_notes' in ctx.input    ->  false           <- the VM agrees
+Object.keys(ctx.input)           ->  ['subject']     <- ...and so does this
+host ctx.input after write-back  ->  { subject: 'HELP',
+                                       internal_notes: 'STAFF-ONLY' }
+```
+
+The in-process path was less deceptive than reported, and the correction is
+worth having in writing: only `delete`'s own return value lied there. `'k' in
+input`, `input.k` and `Object.keys(input)` all went on honestly reporting the key
+as present, so an author who checked with anything other than the return value
+would have seen the no-op.
+
+### `Object.defineProperty(ctx.input, …)` was the same gap, and nobody reported it
+
+Found while enumerating the trap set, fixed in the same stroke because it is the
+strictly worse shape: it defined on the wrapper, and the `get` trap's
+fall-through then read the value straight back — so `input.k` CONFIRMED a write
+that never reached `data`, while `Object.keys(input)` denied it and the record
+never received it. It now routes into `data` like `set` and `deleteProperty` do.
+One inherited JS invariant follows: a proxy may not report success for an
+explicitly `configurable: false` descriptor its target does not carry, so
+`Object.defineProperty(input, 'x', { value: 1, configurable: false })` now throws
+a `TypeError` where it used to define, silently and uselessly, on the wrapper.
+Omitting `configurable` — the common spelling, and the one spread and
+`Object.assign` produce — is unaffected.
+
+### The direction the sandbox write-back deliberately does not overreach in
+
+Absence from the exit snapshot is the only evidence a deletion leaves, and on its
+own it is ambiguous: a key whose host value is `undefined` (or a function, or a
+symbol) never survived `JSON.stringify` INTO the VM either, so it is missing from
+the dump without anyone having deleted it. The diff is filtered through the same
+JSON lens the boundary uses, so such a key is left alone. Every failure mode of
+that probe is conservative — an unprobeable key is simply not deletable — because
+losing a delete is recoverable and destroying a field on evidence that was never
+there is not. One residual miss follows and is named here rather than discovered
+later: a `bigint`-valued key crosses into the VM as a string but is dropped by the
+probe, so deleting one is still lost.
+
+Measured consumer cost of the reported half: a guest-intake app stripped the
+fields an anonymous web-to-case / web-to-lead submitter must not write —
+internal staff notes, the resolution, the escalation flag, the owner — with
+fifteen `delete` statements, every one inert. A submission carrying
+`internal_notes` and `resolution` stored them verbatim, and the app's unit tests
+stayed green throughout, because they drive the handler with a plain object where
+`delete` genuinely works.

--- a/packages/objectql/src/hook-input-mutation-traps.test.ts
+++ b/packages/objectql/src/hook-input-mutation-traps.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12277] Every mutation JS offers on `ctx.input` lands in the row the engine
+ * persists — not just assignment.
+ *
+ * `installFlatInput` (`hook-wrappers.ts`) hands a declarative hook a flat-record
+ * Proxy over the engine's `{ data, options, id? }` wrapper. It trapped `set`
+ * but not `deleteProperty` or `defineProperty`, so those two fell through to
+ * `Reflect.*` on the WRAPPER — one level above `data` — and changed a key that
+ * was never there, on an object the engine does not read.
+ *
+ * ## What each assertion is worth, and why the two gaps are not the same shape
+ *
+ * The measurement that produced this file (pre-fix, one hook call):
+ *
+ * ```
+ *                                     delete       Object.defineProperty
+ * operation's own result           →  true         (no throw)
+ * `k in input`                     →  true         —
+ * `input.k`                        →  CALLER-VALUE DEFINED        ← agrees!
+ * `Object.keys(input)`             →  includes k   excludes k
+ * what the engine persisted        →  CALLER-VALUE absent
+ * ```
+ *
+ * `delete`'s lie was confined to its own return value: the three other
+ * read-backs stayed honest and reported the key still present. That is a
+ * silent no-op, and it is what the card reported.
+ *
+ * `Object.defineProperty` — which no one reported — is the strictly worse
+ * shape, and the reason this file pins BOTH: the `get` trap's fall-through to
+ * the wrapper read the value straight back, so `input.k` CONFIRMED a write
+ * that never reached `data`. A read-back that corroborates a write that did
+ * not happen leaves an author no instrument to catch it with.
+ *
+ * So every case below asserts the CONJUNCTION — what the hook observes AND
+ * what the engine is left holding — rather than either alone. Asserting only
+ * the stored row would pass on an engine whose read-backs lie in the other
+ * direction; asserting only the read-backs is what shipped the defect.
+ *
+ * The `assign-then-delete` case is the DISCRIMINATOR carried over from the
+ * report: a `{...callerData, ...hookInput}` merge upstream would produce the
+ * same symptoms as a missing trap, and it would restore the CALLER's value.
+ * Seeing the hook's own assigned value survive a delete rules the merge out —
+ * and post-fix, seeing the key vanish entirely rules out a merge just as
+ * firmly, from the other side.
+ *
+ * `wrapDeclarativeHook` is driven directly rather than through `ObjectQL`: the
+ * defect is in the wrapper's Proxy, and a full engine dispatch would put a
+ * driver's own copy semantics between the hook and the assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { wrapDeclarativeHook } from './hook-wrappers.js';
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+/** Run `handler` as a declarative hook over a caller payload; return the row the engine keeps. */
+async function runHook(
+  data: Record<string, unknown>,
+  handler: (input: any) => void,
+): Promise<Record<string, unknown>> {
+  const meta: any = { name: 'trap_probe', object: 'case', event: 'beforeInsert' };
+  const wrapped = wrapDeclarativeHook(meta, (async (ctx: any) => handler(ctx.input)) as any, {
+    logger: silentLogger,
+  });
+  const raw: any = { data, options: {} };
+  await wrapped({ object: 'case', event: 'beforeInsert', input: raw } as any);
+  return raw.data as Record<string, unknown>;
+}
+
+describe('[#12277] `delete ctx.input.x` removes the field from the persisted row', () => {
+  it('the hook read-backs and the stored row agree that the key is gone', async () => {
+    const seen: Record<string, unknown> = {};
+    const persisted = await runHook(
+      { subject: 'help', owner_id: 'CALLER-VALUE' },
+      (input) => {
+        seen.deleteReturned = delete input.owner_id;
+        seen.inOperator = 'owner_id' in input;
+        seen.propertyRead = input.owner_id;
+        seen.objectKeys = Object.keys(input);
+        seen.spread = { ...input };
+        seen.descriptor = Object.getOwnPropertyDescriptor(input, 'owner_id');
+      },
+    );
+
+    // What the author observes. Pre-fix, only the first of these was `true`
+    // and every other line reported the key still present.
+    expect(seen.deleteReturned).toBe(true);
+    expect(seen.inOperator).toBe(false);
+    expect(seen.propertyRead).toBeUndefined();
+    expect(seen.objectKeys).toEqual(['subject']);
+    expect(seen.spread).toEqual({ subject: 'help' });
+    expect(seen.descriptor).toBeUndefined();
+
+    // …and what the engine is left holding. This is the half the author cannot
+    // reach from inside the hook, and the half the defect falsified.
+    expect(persisted).toEqual({ subject: 'help' });
+  });
+
+  it('POSITIVE CONTROL — an assignment in the same call still lands', async () => {
+    // Without this, every assertion above would also pass against a wrapper
+    // that had stopped writing anything through to `data` at all.
+    const persisted = await runHook({ subject: 'help', owner_id: 'CALLER-VALUE' }, (input) => {
+      input.subject = 'HELP';
+      delete input.owner_id;
+    });
+    expect(persisted).toEqual({ subject: 'HELP' });
+  });
+
+  it('DISCRIMINATOR — assign-then-delete leaves no key, not the caller value', async () => {
+    // A `{...callerData, ...hookInput}` merge would answer `CALLER-NOTE` here.
+    const seen: Record<string, unknown> = {};
+    const persisted = await runHook({ note: 'CALLER-NOTE' }, (input) => {
+      input.note = 'ASSIGNED-THEN-DELETED';
+      seen.afterAssign = input.note;
+      delete input.note;
+      seen.afterDelete = input.note;
+    });
+    expect(seen.afterAssign).toBe('ASSIGNED-THEN-DELETED');
+    expect(seen.afterDelete).toBeUndefined();
+    expect(persisted).toEqual({});
+  });
+
+  it('deleting a key that was never in the payload is a no-op that reports success', async () => {
+    const persisted = await runHook({ subject: 'help' }, (input) => {
+      expect(delete input.never_here).toBe(true);
+    });
+    expect(persisted).toEqual({ subject: 'help' });
+  });
+
+  it('the operation envelope is addressed separately from the record fields', async () => {
+    // `id`/`options`/`ast`/`data` are wrapper keys on every other trap, and
+    // `deleteProperty` routes them the same way — a hook deleting `options`
+    // must not punch a hole in a record field that happens to share the name.
+    const meta: any = { name: 'envelope', object: 'case', event: 'beforeUpdate' };
+    const wrapped = wrapDeclarativeHook(meta, (async (ctx: any) => {
+      delete ctx.input.options;
+    }) as any, { logger: silentLogger });
+    const raw: any = { id: 'r1', data: { options: 'A RECORD FIELD CALLED OPTIONS' }, options: { multi: true } };
+    await wrapped({ object: 'case', event: 'beforeUpdate', input: raw } as any);
+    expect('options' in raw).toBe(false);
+    expect(raw.data).toEqual({ options: 'A RECORD FIELD CALLED OPTIONS' });
+  });
+});
+
+describe('[#12277] `Object.defineProperty(ctx.input, …)` lands in the persisted row', () => {
+  it('the confirming read-back is now telling the truth', async () => {
+    // The pre-fix failure this case exists for: `input.defined_key` read back
+    // `DEFINED` while `data` never received it, so the instrument an author
+    // would reach for to check AGREED with a write that did not happen.
+    const seen: Record<string, unknown> = {};
+    const persisted = await runHook({ subject: 'help' }, (input) => {
+      Object.defineProperty(input, 'defined_key', {
+        value: 'DEFINED',
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+      seen.propertyRead = input.defined_key;
+      seen.inKeys = Object.keys(input).includes('defined_key');
+    });
+    expect(seen.propertyRead).toBe('DEFINED');
+    expect(seen.inKeys).toBe(true);
+    expect(persisted).toEqual({ subject: 'help', defined_key: 'DEFINED' });
+  });
+});

--- a/packages/objectql/src/hook-wrappers.ts
+++ b/packages/objectql/src/hook-wrappers.ts
@@ -498,6 +498,8 @@ export function wrapDeclarativeHook(
  * of any other key fall through to `data`. Writes always go to `data`
  * (creating it if missing) so the engine's downstream `input.data`
  * read picks up mutations made by user code as `input.field = value`.
+ * "Writes" means every mutation JS has, not assignment alone: `delete` and
+ * `Object.defineProperty` route into `data` too (#12277).
  */
 function installFlatInput(ctx: HookContext): () => void {
   const raw: any = ctx.input ?? {};
@@ -531,6 +533,59 @@ function installFlatInput(ctx: HookContext): () => void {
       }
       ensureData()[prop as string] = value;
       return true;
+    },
+    // [#12277] The mutation traps are a SET, not a list: every operation JS
+    // offers for changing a property has to land in `data`, because `data` is
+    // the object the engine persists. `set` alone was trapped, so
+    // `delete input.x` and `Object.defineProperty(input, 'x', …)` fell through
+    // to `Reflect.*` on the WRAPPER — one level above the record — and did
+    // nothing to the row while reporting success.
+    //
+    // The two gaps had different shapes, and the worse-shaped one is the one
+    // nobody reported:
+    //
+    //   - `delete input.x` returned `true` and changed nothing. The other
+    //     read-backs stayed HONEST (`'x' in input`, `input.x`,
+    //     `Object.keys(input)` all still showed the key), so the lie was
+    //     confined to `delete`'s own return value.
+    //   - `Object.defineProperty(input, 'x', …)` defined on the wrapper, and
+    //     the `get` trap's fall-through to the wrapper then READ IT BACK — so
+    //     `input.x` confirmed a write that never reached `data`. That is the
+    //     shape with no instrument to catch it from inside a hook.
+    //
+    // Measured cost of the `delete` half before this landed: a guest-intake
+    // app stripped the fields an anonymous submitter must not write with 15
+    // `delete` statements, every one inert, and its unit tests stayed green
+    // because they drive the handler with a plain object.
+    //
+    // `deleteProperty` deliberately does NOT call `ensureData()`: with no
+    // `data` on the wrapper, `get` reads fall through to the wrapper itself,
+    // so that is where the key would live and where the delete belongs.
+    // Materialising an empty `data` just to delete out of it would be a write
+    // performed by a removal.
+    deleteProperty(target, prop) {
+      if (prop === 'id' || prop === 'options' || prop === 'ast' || prop === 'data') {
+        return Reflect.deleteProperty(target, prop);
+      }
+      const data = target.data;
+      if (data && typeof data === 'object') {
+        return Reflect.deleteProperty(data as object, prop);
+      }
+      return Reflect.deleteProperty(target, prop);
+    },
+    // Routed for the same reason `set` is. One inherited JS invariant is worth
+    // naming: a proxy may not report success for an explicitly
+    // `configurable: false` descriptor the TARGET does not carry, so
+    // `Object.defineProperty(input, 'x', { value: 1, configurable: false })`
+    // now throws a TypeError where it used to silently define on the wrapper.
+    // A throw is a diagnosis; the silence was not. Omitting `configurable`
+    // entirely (the common spelling, and every spelling `Object.assign` and
+    // spread produce) is unaffected.
+    defineProperty(target, prop, desc) {
+      if (prop === 'id' || prop === 'options' || prop === 'ast' || prop === 'data') {
+        return Reflect.defineProperty(target, prop, desc);
+      }
+      return Reflect.defineProperty(ensureData(), prop, desc);
     },
     has(target, prop) {
       if (prop === 'id' || prop === 'options' || prop === 'ast' || prop === 'data') {

--- a/packages/runtime/src/sandbox/body-runner.ts
+++ b/packages/runtime/src/sandbox/body-runner.ts
@@ -29,7 +29,10 @@
  *         shallow-merged on top of `mutatedInput` as an explicit patch.
  *      Writes go through `Object.assign`, which means the host engine's
  *      flat-record Proxy (installed by `wrapDeclarativeHook`) sees them
- *      via its set trap.
+ *      via its set trap. `Object.assign` cannot express a REMOVAL, so
+ *      keys the VM deleted are diffed out of the entry snapshot and
+ *      deleted on the host separately (#12277) — see
+ *      {@link applyMutationsToInput}.
  *
  * The ACTION path deliberately has no step 4: its output is the script's
  * return value, and its write channel is `ctx.api.object(...)`. In particular
@@ -317,7 +320,7 @@ export function hookBodyRunnerFactory(
           // constructor option dead for hooks.
           timeoutMs: (body as any).timeoutMs,
         });
-        applyMutationsToInput(engineCtx, result);
+        applyMutationsToInput(engineCtx, result, sandboxCtx.input);
       } catch (err: any) {
         opts.logger?.error?.('[BodyRunner] sandboxed hook threw', err, {
           appId: opts.appId,
@@ -467,11 +470,93 @@ function warnDiscardedRecordWrites(
   );
 }
 
-function applyMutationsToInput(engineCtx: any, result: ScriptResult): void {
+/**
+ * [#12277] Keys of the ENTRY snapshot that the VM could actually see, and
+ * therefore the only keys whose absence from the exit snapshot is evidence of
+ * a deletion.
+ *
+ * Both directions of the sandbox boundary are JSON (`safeJsonStringify` in,
+ * `JSON.stringify` out), and JSON has no spelling for `undefined`, a function,
+ * or a symbol. A key carrying one of those is absent from the VM's `ctx.input`
+ * from the start, so it is absent from the dump too — indistinguishable, on the
+ * dump alone, from a key the body deleted. Filtering the entry side through the
+ * SAME lens removes that ambiguity at the source instead of guessing at it.
+ *
+ * Every failure mode here is deliberately conservative — a key that cannot be
+ * probed is simply not deletable, so the worst outcome is the pre-#12277
+ * behaviour (a delete that does not land) rather than a field destroyed on
+ * evidence that was never there. One residual miss follows from that and is
+ * worth naming: `safeJsonStringify` marshals a `bigint` into the VM as a
+ * string, while the probe below throws on it and drops it — so a delete of a
+ * bigint-valued key is still lost. Losing a delete is the recoverable
+ * direction; inventing one is not.
+ */
+function vmVisibleEntryKeys(entryInput: unknown): string[] {
+  if (!entryInput || typeof entryInput !== 'object' || Array.isArray(entryInput)) return [];
+  const out: string[] = [];
+  for (const [k, v] of Object.entries(entryInput as Record<string, unknown>)) {
+    try {
+      if (JSON.stringify(v) !== undefined) out.push(k);
+    } catch {
+      /* unserialisable (cycle, bigint) — not deletable on this evidence */
+    }
+  }
+  return out;
+}
+
+/**
+ * Write one settled body's mutations back onto the host `ctx.input`.
+ *
+ * ## [#12277] Why a key diff, and not `Object.assign` alone
+ *
+ * `Object.assign` copies own enumerable properties, and **has no way to
+ * represent a deletion**: a key the VM removed simply is not in `mutatedInput`,
+ * and the original stays. So `delete ctx.input.internal_notes` in a sandboxed
+ * body was lost on the way home — and lost in the worst possible shape,
+ * because INSIDE the VM the delete is real. Measured on the pre-fix code, with
+ * the host row alongside:
+ *
+ * ```
+ * delete ctx.input.internal_notes    ->  true
+ * 'internal_notes' in ctx.input      ->  false      // the VM agrees
+ * Object.keys(ctx.input)             ->  ['subject'] // …and so does this
+ * host ctx.input after write-back    ->  { subject: 'HELP',
+ *                                          internal_notes: 'STAFF-ONLY' }
+ * ```
+ *
+ * Every instrument reachable from inside the body confirms the removal, an
+ * assignment made in the same call lands, and the field is stored anyway.
+ * There is no diagnostic to notice and nothing to notice it with.
+ *
+ * The sibling half of the same defect was the engine's flat-input Proxy
+ * missing its `deleteProperty` trap (`installFlatInput`,
+ * `packages/objectql/src/hook-wrappers.ts`); the two are unrelated mechanisms
+ * with one author-visible outcome. They are fixed together on purpose: closing
+ * one alone would make the same authored `delete` behave differently depending
+ * on whether the body runs in-process or in QuickJS, which is a worse contract
+ * than the symmetric silence it replaces.
+ *
+ * Deletions apply BEFORE both merges, so a body that deletes a key and then
+ * returns it (`delete ctx.input.x; return { x: 1 };`) keeps the explicit patch
+ * — the return value is the later, more deliberate statement of the two.
+ */
+function applyMutationsToInput(
+  engineCtx: any,
+  result: ScriptResult,
+  // `unknown`, not `Record<string, unknown>`: that is what `ScriptContext.input`
+  // declares, and narrowing is {@link vmVisibleEntryKeys}'s job. Widening the
+  // declared type here to make the call site typecheck would move the guard to
+  // the producer's word rather than this consumer's own check.
+  entryInput?: unknown,
+): void {
   const target = engineCtx?.input;
   if (!target || typeof target !== 'object') return;
   if (result.mutatedInput && typeof result.mutatedInput === 'object') {
-    Object.assign(target, result.mutatedInput);
+    const mutated = result.mutatedInput;
+    for (const key of vmVisibleEntryKeys(entryInput)) {
+      if (!(key in mutated)) delete (target as Record<string, unknown>)[key];
+    }
+    Object.assign(target, mutated);
   }
   if (
     result.value &&

--- a/packages/runtime/src/sandbox/hook-input-delete-writeback.test.ts
+++ b/packages/runtime/src/sandbox/hook-input-delete-writeback.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12277] A sandboxed hook body's `delete ctx.input.x` reaches the host row.
+ *
+ * ## Why this is the worse half of the card, and what it takes to pin it
+ *
+ * The engine-side half of #12277 was a missing `deleteProperty` trap on the
+ * flat-input Proxy: a no-op whose lie was confined to `delete`'s own return
+ * value, since `k in input` and `Object.keys(input)` went on honestly
+ * reporting the key.
+ *
+ * This half has no such tell. Inside QuickJS the delete is REAL — the body
+ * holds a JSON snapshot, and every read-back it can reach agrees. What was
+ * lost is the trip home: `applyMutationsToInput` wrote mutations back with
+ * `Object.assign(target, result.mutatedInput)`, and `Object.assign` copies own
+ * enumerable properties. **It has no way to represent a deletion.** A key the
+ * VM removed is simply not in `mutatedInput`, and the host's key stays.
+ *
+ * Measured on the pre-fix code, one hook call:
+ *
+ * ```
+ * delete ctx.input.internal_notes  ->  true
+ * 'internal_notes' in ctx.input    ->  false          ← the VM agrees
+ * Object.keys(ctx.input)           ->  ['subject']    ← …and so does this
+ * host ctx.input after write-back  ->  { subject: 'HELP',
+ *                                        internal_notes: 'STAFF-ONLY' }
+ * ```
+ *
+ * That is why the first case asserts BOTH ENDS of the same call — what the
+ * body observed and what the host was left holding. Asserting only the host
+ * row would leave the pin passing on a runner that had stopped executing the
+ * body at all; asserting only the body's view is precisely the reading that
+ * shipped the defect, because it was true the whole time.
+ *
+ * ## The direction the write-back must NOT overreach in
+ *
+ * Absence from the exit dump is the only evidence a deletion leaves, and it is
+ * ambiguous on its own: a key whose host value is `undefined` (or a function,
+ * or a symbol) never survived `JSON.stringify` into the VM either, so it is
+ * missing from the dump without anyone having deleted it. The last case pins
+ * that such a key is LEFT ALONE. Losing a delete is recoverable; destroying a
+ * field on evidence that was never there is not, so the diff is filtered
+ * through the same JSON lens the boundary uses rather than trusting absence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hookBodyRunnerFactory } from './body-runner.js';
+import { QuickJSScriptRunner } from './quickjs-runner.js';
+
+const runner = new QuickJSScriptRunner();
+
+/** Build a sandboxed `beforeInsert` hook around one JS body. */
+function jsHook(source: string) {
+  return hookBodyRunnerFactory(runner, { ql: {}, appId: 'crm' })({
+    name: 'guest_intake',
+    object: 'case',
+    events: ['beforeInsert'],
+    body: { language: 'js', source, capabilities: [] },
+  } as any)!;
+}
+
+describe('[#12277] a sandboxed body can delete an input field', () => {
+  it('the body’s read-backs and the host row agree the field is gone', async () => {
+    const fn = jsHook(
+      [
+        'var seen = {};',
+        'seen.deleteReturned = delete ctx.input.internal_notes;',
+        "seen.inOperator = 'internal_notes' in ctx.input;",
+        'seen.propertyRead = ctx.input.internal_notes;',
+        'seen.objectKeys = Object.keys(ctx.input);',
+        // An assignment in the same call: the POSITIVE CONTROL. Without it the
+        // host assertions below would also pass against a runner whose
+        // write-back had stopped doing anything at all.
+        'ctx.input.subject = String(ctx.input.subject).toUpperCase();',
+        'return { __probe: JSON.stringify(seen) };',
+      ].join('\n'),
+    );
+    const engineCtx: any = { input: { subject: 'help', internal_notes: 'STAFF-ONLY' } };
+    await fn(engineCtx);
+
+    const seen = JSON.parse(String(engineCtx.input.__probe));
+    expect(seen.deleteReturned).toBe(true);
+    expect(seen.inOperator).toBe(false);
+    expect(seen.propertyRead).toBeUndefined();
+    expect(seen.objectKeys).toEqual(['subject']);
+
+    expect('internal_notes' in engineCtx.input).toBe(false);
+    expect(engineCtx.input.subject).toBe('HELP');
+  });
+
+  it('an explicit return patch outranks a delete of the same key', async () => {
+    // Deletions apply before both merges, so the later, more deliberate
+    // statement wins rather than the two racing on write-back order.
+    const fn = jsHook('delete ctx.input.status; return { status: "reopened" };');
+    const engineCtx: any = { input: { subject: 'help', status: 'closed' } };
+    await fn(engineCtx);
+    expect(engineCtx.input.status).toBe('reopened');
+  });
+
+  it('the whole guest-intake shape: several deletes in one body, all of them landing', async () => {
+    // The consumer measurement behind the card — an anonymous web-to-case
+    // submission that must not be able to write staff-only fields. Fifteen
+    // `delete` statements were inert; a submission carrying `internal_notes`
+    // and `resolution` stored them verbatim.
+    const fn = jsHook(
+      [
+        'delete ctx.input.internal_notes;',
+        'delete ctx.input.resolution;',
+        'delete ctx.input.escalated;',
+        'delete ctx.input.owner_id;',
+      ].join('\n'),
+    );
+    const engineCtx: any = {
+      input: {
+        subject: 'printer on fire',
+        internal_notes: 'STAFF-ONLY',
+        resolution: 'FORGED',
+        escalated: true,
+        owner_id: 'usr_admin',
+        description: 'it is on fire',
+      },
+    };
+    await fn(engineCtx);
+    expect(Object.keys(engineCtx.input).sort()).toEqual(['description', 'subject']);
+  });
+
+  it('a key the VM never saw is LEFT ALONE, not deleted', async () => {
+    // `undefined` has no JSON spelling, so `absent_from_the_dump` proves
+    // nothing about `undef_key` — the body could not have deleted what it
+    // could not see. The conservative direction is mandatory here: the
+    // alternative destroys a field on absent evidence.
+    const fn = jsHook('ctx.input.subject = "HELP";');
+    const engineCtx: any = { input: { subject: 'help', undef_key: undefined } };
+    await fn(engineCtx);
+    expect('undef_key' in engineCtx.input).toBe(true);
+    expect(engineCtx.input.subject).toBe('HELP');
+  });
+
+  it('a body that deletes nothing changes nothing', async () => {
+    const fn = jsHook('return { subject: ctx.input.subject.trim() };');
+    const engineCtx: any = { input: { subject: '  help  ', internal_notes: 'KEEP ME' } };
+    await fn(engineCtx);
+    expect(engineCtx.input).toEqual({ subject: 'help', internal_notes: 'KEEP ME' });
+  });
+});


### PR DESCRIPTION
Fixes #12277

`delete ctx.input.FIELD` in a hook did nothing, on **both** execution paths, while an assignment made two lines above it on the same object in the same call landed normally. Nothing raised and nothing reported it. Both halves are closed here, because closing either one alone would make the same authored `delete` behave differently depending on whether the body runs in-process or in QuickJS.

> Placeholders below are spelled `FIELD` / `IDENT.MEMBER` rather than with angle brackets on purpose: the body sanitizer eats short angle-bracket fragments, and it silently turned this PR's first draft of the positive control into `delete .`, which reads as nonsense. Same class as #12133, one surface over.

## What was measured, and one correction to the card

Reproduced before touching anything, at `wrapDeclarativeHook` / `hookBodyRunnerFactory` directly.

**In-process (`installFlatInput`, `packages/objectql/src/hook-wrappers.ts`) — the card's mechanism is exactly right, its severity gloss is not.** The card says "every read-back confirms the delete succeeded". Measured, that is false here, and the card's own table already showed it: only `delete`'s return value lied.

| probe | pre-fix | post-fix |
|:--|:--|:--|
| `delete input.owner_id` | `true` | `true` |
| `'owner_id' in input` | `true` | `false` |
| `input.owner_id` | `"CALLER-VALUE"` | `undefined` |
| `Object.keys(input)` | `['title','owner_id','note']` | `['title','note']` |
| `{...input}` | carries `owner_id` | does not |
| `Object.getOwnPropertyDescriptor` | full descriptor | `undefined` |
| what the engine persisted | `owner_id: "CALLER-VALUE"` | absent |

So an author who checked with anything other than the return value would have seen the no-op. The defect is real and the mechanism is as reported; the "no instrument can catch it" framing belongs to the other two findings below.

**Sandboxed (`applyMutationsToInput`, `packages/runtime/src/sandbox/body-runner.ts`) — this is where the confirming read-back actually lives.** Note the file has moved since the card's addendum was written (`packages/runtime/src/sandbox/`, not `packages/objectql/src/`); relocated by symbol. Inside QuickJS the delete is *real* — the body holds a JSON snapshot. What was lost is the trip home: `Object.assign` copies own enumerable properties and cannot represent a removal.

```
delete ctx.input.internal_notes  ->  true
'internal_notes' in ctx.input    ->  false          # the VM agrees
Object.keys(ctx.input)           ->  ['subject']    # ...and so does this
host ctx.input after write-back  ->  { subject: 'HELP',
                                       internal_notes: 'STAFF-ONLY' }
```

Every instrument reachable from inside the body confirms the removal, the assignment in the same call lands, and the field is stored anyway.

**The discriminator held on both paths.** Assign a key and then delete it, and the *assigned* value survived pre-fix (`"ASSIGNED-THEN-DELETED"` where the caller sent `"CALLER-VALUE"`), which rules out a `{...callerData, ...hookInput}` merge. Post-fix the key is simply absent, which rules it out from the other side.

## The trap set, enumerated — including what is not fixed here

`installFlatInput`'s Proxy implemented `get` / `set` / `has` / `ownKeys` / `getOwnPropertyDescriptor`. Every mutation JS offers has to land in `data` — `data` is the object the engine persists — and only `set` did.

- **`deleteProperty` — missing. Fixed.** The card.
- **`defineProperty` — missing, same class, worse shape. Fixed in the same stroke** (bounded, and named here with its evidence rather than slipped in). It defined on the *wrapper*, and the `get` trap's fall-through to the wrapper then read the value straight back: `Object.defineProperty(input, 'defined_key', ...)` followed by `input.defined_key` returned `'DEFINED'` while `Object.keys(input)` denied it and `data` never received it. That is the read-back-confirms-a-write-that-never-happened shape, unreported, in the same six lines as the reported one. Its correct form is pinned by `set`'s existing precedent, no other claim is on the file, and it adds no gate family.
  - One inherited JS invariant follows and is documented at the trap: a proxy may not report success for an explicitly `configurable: false` descriptor its target does not carry, so `Object.defineProperty(input, 'x', { value: 1, configurable: false })` now throws a `TypeError` where it used to define, silently and uselessly, on the wrapper. Omitting `configurable` — the common spelling, and what spread and `Object.assign` produce — is unaffected.
- **`getOwnPropertyDescriptor` — present, and NOT changed. Reported, not fixed** (filed as #12397). For a key on `data` it synthesises `{ configurable: true, enumerable: true, writable: true, value }` rather than mirroring `data`'s real descriptor. `configurable: true` is forced by a proxy invariant (the target does not carry the key), so it cannot simply mirror; and for every key created by assignment the synthesised descriptor is already the true one. The residual is narrow — a key defined on `data` with non-default attributes is described inaccurately — and widening the trap to chase it is a separate change with its own accessor-descriptor questions.
- **`set` — checked for the same class, and it is clean.** It returns `true` unconditionally, but the write it reports on is a strict-mode assignment into `data` that throws rather than failing quietly, so there is no silent-success limb.
- **Sibling flat-record Proxies — swept, and there are none.** `installFlatInput` is the only `new Proxy` in `packages/objectql/src`. `ctx.previous` is not proxied at all; it reaches a handler as the plain payload `pickPreviousPayload` builds. So there is no second surface for this fix to cover.

## Clause ②: who is relying on the no-op today

**Nobody in this repo.** `delete ctx.input.FIELD` / `delete input.FIELD` returns zero hits across every file type (`--exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist`), as does a sweep of `examples/**` hook modules and of authored hook bodies. **Positive control for that search**: the same walk for `delete IDENT.MEMBER` matches 39 files (e.g. `delete process.env.NODE_PATH` in `packages/types/src/node.test.ts`), so the zero is a measurement rather than a broken grep.

The only measured consumers are external: the guest-intake app behind the card stripped staff-only fields with fifteen `delete` statements, every one inert, and its unit tests stayed green because they drive the handler with a plain object where `delete` genuinely works. That app-side repair is already done and does not depend on this.

## The direction the sandbox write-back deliberately does not overreach in

Absence from the exit snapshot is the only evidence a deletion leaves, and alone it is ambiguous: a key whose host value is `undefined` (or a function, or a symbol) never survived `JSON.stringify` *into* the VM either, so it is missing from the dump without anyone having deleted it. The diff is filtered through the same JSON lens the boundary uses, so such a key is left alone, and every failure mode of that probe is conservative — an unprobeable key is simply not deletable. Losing a delete is recoverable; destroying a field on evidence that was never there is not. One residual miss is named in the code rather than left to be discovered: a `bigint`-valued key crosses into the VM as a string but is dropped by the probe, so deleting one is still lost.

## Verification

All of the below at `6c568d6bb9`, working tree clean, foreground, exit codes captured before any pipe.

**Suites** — `pnpm --filter @objectstack/objectql exec vitest run`: `Test Files 236 passed (236)` / `Tests 4180 passed (4180)`. `pnpm --filter @objectstack/runtime exec vitest run`: `Test Files 194 passed (194)` / `Tests 2856 passed (2856)`. `typecheck` green for both (`tsc --noEmit`).

**Gate union derived, not recalled** — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, re-derived after the changeset existed: 19 matched families + the test-file and changeset conventions. All green, each quoting its own verdict line:

- `check-adr-0087-registration: this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).`
- `check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured in 242.1s, 1843 raw tsc error(s) total, none above its recorded number.` / `surplus: none — every entry sits exactly at its measurement, so any new error is red.` (run on the built closure, so the two new test files really were measured)
- `check-nul-bytes: OK (scanned 6855 text file(s) ...)`
- `check-engine-double-contract: 397 (file, verb) row(s) held by the RETAINED ledger`
- `where-matcher conformance holds: 302 matcher(s) discovered, 302 answer the combinator battery correctly or refuse it`
- `query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new`
- `check-test-source-alias OK — 72 packages with tests scanned`
- plus `cross-package-test-inputs`, `ci-filter-parity`, `durability-log-level`, `page-declaration-shape`, `published-files`, `slot-lookup`, `type-source-resolution`, `engine-split-ratio`, `plugin-teardown-shape`, `affected-docs`, `drift-comment`, `objectui-changeset`, `changeset-gate-self-tests`, `changeset-no-major`, `empty-changeset`, `release-rehearsal-clone`.

**Repo-wide lint, not narrowed** — `pnpm lint` (`eslint . --no-inline-config`) over the whole tree, 62s, exit `0` recorded before any pipe. No narrowing is claimed and none is owed.

**Ablation — three legs, direction predicted in writing before the run, implementation committed first.** All three mutate a file its own package's pin imports *relatively* (`./hook-wrappers.js`, `./body-runner.js`), i.e. through vitest's TS source resolution and not through `exports` -> `dist`, so no rebuild is owed between mutation and measurement and the reds are evidence about the mutation rather than about a stale artifact. Each leg proved the mutation on disk with single-line `grep -cF` anchor counts (`1 -> 0`) plus `git diff --numstat`, and each restore leg proved absence the same way (`0 -> 1`, `git diff` empty) and re-ran green. The ablation script carried `trap ... EXIT INT TERM` so a foreground timeout could not leave the tree mutated.

| leg | mutation | predicted | observed |
|:--|:--|:--|:--|
| A | drop `deleteProperty` | 3 of 6 red | 3 failed / 3 passed — `expected true to be false` on `'owner_id' in input`, plus the stored row and the discriminator |
| B | drop `defineProperty` | 1 of 6 red, **read-back assertion staying green** | 1 failed / 5 passed, failing at line 164 (`inKeys`) — line 163, `expect(seen.propertyRead).toBe('DEFINED')`, **passed** |
| C | drop the deletion diff | 2 of 5 red, **in-VM assertions staying green** | 2 failed / 3 passed, failing at line 88 (`'internal_notes' in engineCtx.input`) — the four in-VM read-backs above it **passed** |

Legs B and C are the ones that matter for the grading: in both, the pin fires *only* because it asserts the read-back and the stored row together. A pin asserting either half alone would have stayed green on the confirming-read-back defect. (A first attempt at leg C was voided and re-run rather than quietly retried: its cut was structural rather than surgical and the file failed to transform, so `vitest` exited 1 on `no tests` — a red for the wrong reason. Its `grep` anchor also read `0` before the mutation because a BRE turned `[key]` into a character class; the re-run uses `grep -cF` throughout.)

## Changeset

`.changeset/hook-input-delete-lands.md`, graded **`minor`** for both `@objectstack/objectql` and `@objectstack/runtime` rather than `patch`, and the grade is the argument: this moves data that reaches downstream consumers. Any shipped hook already containing `delete ctx.input.FIELD` has been a no-op and starts taking effect on upgrade. No API is removed and no accept set narrows, so it is not declared breaking — but it must not arrive as a silent patch either.

## Serial constraints

Surface is `packages/objectql/**` and `packages/runtime/**` only. It touches none of `packages/drivers/driver-sql/**`, `packages/platform-objects/**`, or `packages/metadata/**`.

_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_