### PR TITLE
os-dev contract: probe-first dedup route, never-drop findings, and the edited gate script's own pin suite

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -50,13 +50,16 @@ model: opus
    一步无声毁掉 auto-merge 与合并队列成员资格)。把意外写进 `summary`,交给 PM 裁决。
 3. **范围 = 这张 issue,别无其它。** 顺路撞见的无关缺陷立成新的**无 assignee** issue,列进
    `out_of_scope_findings` —— 永不在本 PR 里修。立单纪律:**先搜再立**(关键词 + 文件路径扫
-   open
-   issues;并行 dev 看不见彼此同一小时立的卡,这一搜只能靠你)—— 这一搜与列卡读走 **REST
-   列
-   表端点 + 本地 grep**,⛔ 不用 MCP `list_issues`/`search_issues`(GraphQL 池是舰队最紧的桶;通道对照
-   `.claude/skills/pm-dispatch/references/rest-channel.md`),且**PM 的去重读数随派发词下发 ⇒ 当既有事
-   实
-   用,只复核其后的增量,⛔ 不重跑**;**归挂,不散落**(落在某张已排队 issue 完成范围之内的
+   open issues;并行 dev 看不见彼此同一小时立的卡,这一搜只能靠你)—— 通道**先探后选**:
+   同容器先测一条 repo-scoped REST 读,通 ⇒ 走 REST 列表端点 + 本地 grep(通道对照
+   `.claude/skills/pm-dispatch/references/rest-channel.md`,其 ✓ 按座位实测);403(实测形态:整类
+   repo-scoped 端点全 403、`gh` 缺席而 MCP 可用)⇒
+   改用**一次定向 MCP `search_issues`**,并在报告申报换道;⛔ 哪条通道都不宽表扫(全量翻页
+   `list_issues`/宽词搜 —— GraphQL 池是舰队最紧的桶,定向一击是上限);立不成 ⇒
+   发现连同缘由写进报告交 PM 代立(一等出路);⛔ 不查重硬立与静默弃报同为禁
+   形:发现永不因通道断而消失。**PM 的去重读数随派发词下发 ⇒
+   当既有事实用,只复核其后的增量,⛔ 不重跑**;
+   **归挂,不散落**(落在某张已排队 issue 完成范围之内的
    发
    现,立成它的 sub-issue;只是*依赖*它的,独立立单带一行 `Blocked-by:` —— 已排队父单的
    sub-issue
@@ -163,6 +166,10 @@ model: opus
 它说的加深即可。补跑它新增而你的 diff 确实触及的,并在报告里点名新增项。代价是偶尔
 一轮 push-fix;安全的另一半归 PM,在你报告之后读真实门禁 job 结论。⛔ 这不是跳过点名族的
 许可 —— 它们是你仍然欠的便宜一半;你不再欠的是报告前等 CI。
+⑤ diff 编辑了门禁/工具脚本 ⇒ 该脚本**自己的**测试套件是不可省的一步,在派生族之外另
+欠 —— 派生答「哪些门禁读你改的文件」,不含「哪些测试测这个脚本」:跑同目录点名它
+的 `*.test.ts`,加同包 tests 下 `git grep` 该脚本文件名的全部命中(实测:一次门禁脚本编辑,派生
+族全数绿,脚本自己的 vitest pin 套件一个未跑,三个被劫持的 pin 到 CI 才现形)。
 
 **该脚本只住在 objectstack,答案永远只关于它自己所在的那棵树** —— 每次推导第一行(stderr)
 点名答案取自哪个仓与 commit,读之前先核对。姊妹仓(objectui / cloud)没有 `scripts/pm/`, 把它们的


### PR DESCRIPTION
Fixes #12367

Governed surface (`.claude/agents/os-dev.md` only): draft PR, human merge — never queued, never armed, never flipped ready (triage constraint on the card).

## Update 1 — the dedup route, brought to measured reality

The old clause prescribed "REST list endpoints + local grep, never MCP `list_issues`/`search_issues`". Measured 2026-08-25 on three dev containers: every repo-scoped REST endpoint 403s and `gh` is absent, while the MCP tools work. Measured again on THIS container (2026-08-26, dispatched dev seat): repo-scoped REST reads return **200** and `gh` is absent — so the channel varies **per container**, not per role. The new text therefore codifies probe-first rather than a role-based rule:

- probe one repo-scoped REST read in-container; where it works, the standing REST-list + local-grep route stays (the `rest-channel.md` pointer is kept, its checkmarks noted as per-seat measurements);
- where it 403s (failure shape named: whole repo-scoped class 403, `gh` absent, MCP working), use **one targeted MCP `search_issues`** and declare the reroute in the report;
- the GraphQL-pool prohibition survives as its intent: **no broad list sweeps on any channel** (no full pagination, no wide search — one targeted call is the ceiling).

Folded into the same clause, per the sibling finding's two dispositions (PM-directed, same clause, no surface widening — the sibling card remains open for the PM to judge against this text):

- **hand-over is first-class**: a finding that cannot be filed goes into the report with the reason, for the PM to file;
- **never-drop**: filing blind and silent dropping are both named forbidden — a finding never disappears because the dedup channel broke.

## Update 2 — the edited gate script's own pin suite

"Run the derived gate families" is structurally blind to a gate script's own test files: derivation answers "which gates read your changed files", never "which tests test this script". Measured: a gate-script edit ran the full derived battery green while the script's own vitest pin suite never executed, and CI caught three hijacked pins. New step 5 in the local-verification scope: when the diff edits a gate/tooling script, running that script's **own** pin/test suite (sibling `*.test.ts` naming it, plus same-package test-tree `git grep` hits on the script's filename) is an explicit, non-optional step alongside the derived families.

## Budget and constraints

- Dispatch-prompt deviation, measured: a line ratchet **does** exist on this file (`CEILINGS['.claude/agents/os-dev.md'] = 470` in `scripts/pm/check-skill-line-ratchet.mjs`); the prompt said none does. The diff lands at **468 lines (headroom 2)** — verdict line: `check-skill-line-ratchet: .claude/agents/os-dev.md is 468 lines (ceiling 470; headroom 2)`.
- No issue numbers in the new operative text (`check-skill-id-lint: 22 file(s) clean`).
- `.claude/`-only diff: no changeset; `skip-changeset` label applied via the additive endpoint and read back.

## Verification (all at head `759f6d3e`, after the final commit)

Derived via `node scripts/pm/dispatch-gates.mjs` (no paths; derivation banner named this repo at `cdbd920`): 10 families matched. Run under `os-verify-lock`, exit captured before any pipe:

- `check:agent-model-declared` — `1 agent definition(s) under .claude/agents/ all declare a model`
- `check:agent-test-spelling` — `0 violations — 386 file(s)`
- `check:doc-authoring` — `390 files clean — no bare metadata literals`
- `check:doc-formula-expressions` — `22 record-scoped formula example(s) across 422 files / 1449 TS blocks judged clean` (prerequisite `@objectstack/formula` + `@objectstack/lint` built first)
- `check:nul-bytes` — `OK (scanned 6868 text file(s) …)`
- `check:pm-governed-merges` — self-test 159 assertions + `live: the real generator declared 9 output(s) and certified this tree`
- `check:pm-skill-id-lint` — `22 file(s) clean (pattern /#[0-9]{3,}/g)`
- `check:pm-skill-ratchet` — os-dev.md `468 lines (ceiling 470; headroom 2)`, widest table row pin green
- `check:skill-frame-sync` — `4 copies of the decision frame are structurally isomorphic across 3 files`
- `check-governed-queue-guard.mjs` — NOT MEASURED locally (reads `GITHUB_EVENT_PATH`; CI-event-only guard), exercised in CI

No package source touched, so no vitest suite or package typecheck applies to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JANH3y7qe3MD8aLaLXci8N)_