### PR TITLE
feat(spec): open RecordActivityProps.types to author-contributed activity kinds

### DIFF
--- a/.changeset/record-activity-types-open-vocabulary.md
+++ b/.changeset/record-activity-types-open-vocabulary.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): open `RecordActivityProps.types` to author-contributed activity kinds (#11658)
+
+Accept-set **widening** on a published authorable prop, executing the
+2026-08-24 maintainer ruling on #11507: `sys_activity.type` is an OPEN,
+author-extensible vocabulary — the declared options are the platform built-in
+set, ADR-0052 §5b.2 stays a sanctioned author write path, and (verbatim)
+"every closed map over this vocabulary is now the bug".
+
+`RecordActivityProps.types` (the `record:activity` filter, also embedded as
+`RecordChatterProps.feed.types`) was that closed map on the authoring surface:
+`z.array(FeedItemType)`, a closed enum of the 13 built-in UI kinds, so an
+author who contributes an activity type (e.g. `scheduled`, which hotcrm writes
+today through the sanctioned ADR-0052 §5b.2 channel) could not name it in the
+filter. The element is now `z.union([FeedItemType, z.string().min(1)])`: the
+enum branch keeps the built-in kinds visible as guidance (editor autocomplete,
+and an `anyOf` member of the generated JSON Schema) while the open-string
+branch accepts any author-contributed kind — the union accepts exactly what a
+bare non-empty string accepts, so nothing is validated against the built-in
+set. A typo'd built-in consequently no longer gets a named rejection; the
+ruling accepted that cost rather than re-close the vocabulary.
+
+Every previously-legal value still parses byte-identically; non-string and
+empty entries are still rejected. The `feed.zod.ts` module docblock (and the
+generated `feed.mdx` reference page) no longer claims these enums have "no
+backend dependency": `FeedItemType` is the target of the map UI consumers
+apply to the open `sys_activity.type` column — a backend coupling, not a
+backend import.
+
+<!-- adr-0087: not-required (no-migration-prescription) Pure accept-set widening on an existing key: no key is removed, renamed or re-shaped, and every previously-valid document remains valid unchanged, so there is no tombstone and nothing for `objectstack migrate meta` to rewrite. -->

--- a/content/docs/references/data/feed.mdx
+++ b/content/docs/references/data/feed.mdx
@@ -9,12 +9,19 @@ Activity-timeline UI config enums, and the `sys_activity.type` built-in set.
 
 The `service-feed` backend was retired (ADR-0052 §5 / #1955); `sys_comment` /
 `sys_activity` are the canonical record-collaboration/timeline backend. The two
-enums here are pure UI configuration for the record activity component
-(`RecordActivityProps` in `../ui/component.zod.ts`), with no backend dependency;
-`SYS_ACTIVITY_BUILTIN_TYPES` below is the published built-in vocabulary of the
-`sys_activity.type` column, co-located with `FeedItemType` because UI consumers
-map one onto the other. (A later `feed` → `activity` rename is tracked
-separately.)
+enums here configure the record activity component (`RecordActivityProps` in
+`../ui/component.zod.ts`). `FeedFilterMode` is pure UI configuration, but
+`FeedItemType` is not backend-free: it has no backend *import*, yet it is the
+TARGET of the map UI consumers apply to the `sys_activity.type` column — a
+backend *coupling* — and that column's vocabulary is OPEN and
+author-extensible (maintainer ruling 2026-08-24, #11507). `FeedItemType` is
+therefore the built-in guidance half of that map, never the value domain of
+an authoring surface: `RecordActivityProps.types` accepts contributed kinds
+beyond it (#11658), and consumers must map unknown `sys_activity.type` values
+to a fallback rather than drop them. `SYS_ACTIVITY_BUILTIN_TYPES` below is
+the published built-in vocabulary of the `sys_activity.type` column,
+co-located with `FeedItemType` because UI consumers map one onto the other.
+(A later `feed` → `activity` rename is tracked separately.)
 
 <Callout type="info">
 **Source:** `packages/spec/src/data/feed.zod.ts`

--- a/content/docs/references/ui/component.mdx
+++ b/content/docs/references/ui/component.mdx
@@ -611,7 +611,7 @@ Sort field and direction pair
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **types** | `Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| 'file' \| 'record_create' \| 'record_delete' \| 'approval' \| 'sharing' \| 'system'>[]` | optional | Feed item types to show (default: all) |
+| **types** | `(Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| 'file' \| 'record_create' \| 'record_delete' \| 'approval' \| 'sharing' \| 'system'> \| string)[]` | optional | Feed item kinds to show (default: all). Open vocabulary: the FeedItemType members are the platform built-in kinds, and author-contributed activity kinds (open sys_activity.type vocabulary, ADR-0052 §5b.2) are equally legal — entries are never validated against the built-in set. |
 | **filterMode** | `Enum<'all' \| 'comments_only' \| 'changes_only' \| 'tasks_only'>` | optional (default: `"all"`) | Default activity filter |
 | **showFilterToggle** | `boolean` | optional (default: `true`) | Show filter dropdown in panel header |
 | **limit** | `integer` | optional (default: `20`) | Number of items to load per page |
@@ -684,14 +684,14 @@ Sort field and direction pair
 | **width** | `string \| number` | optional | Panel width (e.g., "350px", "30%") — side positions (`right`/`left`) only. |
 | **collapsible** | `boolean` | optional | Whether the panel can be collapsed (renderer default: off). |
 | **defaultCollapsed** | `boolean` | optional | Whether the panel starts collapsed (renderer default: off; only meaningful with `collapsible`). |
-| **feed** | `{ types?: Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| …>[]; filterMode: Enum<'all' \| 'comments_only' \| 'changes_only' \| 'tasks_only'>; showFilterToggle: boolean; limit: integer; … }` | optional | Embedded activity feed configuration |
+| **feed** | `{ types?: (Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| …> \| string)[]; filterMode: Enum<'all' \| 'comments_only' \| 'changes_only' \| 'tasks_only'>; showFilterToggle: boolean; limit: integer; … }` | optional | Embedded activity feed configuration |
 | **aria** | `{ ariaLabel?: string \| Record<string, string>; ariaDescribedBy?: string; role?: string }` | optional | ARIA accessibility attributes |
 
 ### Nested Shape: `RecordChatterProps.feed`
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **types** | `Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| …>[]` | optional | Feed item types to show (default: all) |
+| **types** | `(Enum<'comment' \| 'field_change' \| 'task' \| 'event' \| 'email' \| 'call' \| 'note' \| …> \| string)[]` | optional | Feed item kinds to show (default: all). Open vocabulary: the FeedItemType members are the platform built-in kinds, and author-contributed activity kinds (open sys_activity.type vocabulary, ADR-0052 §5b.2) are equally legal — entries are never validated against the built-in set. |
 | **filterMode** | `Enum<'all' \| 'comments_only' \| 'changes_only' \| 'tasks_only'>` | optional (default: `"all"`) | Default activity filter |
 | **showFilterToggle** | `boolean` | optional (default: `true`) | Show filter dropdown in panel header |
 | **limit** | `integer` | optional (default: `20`) | Number of items to load per page |

--- a/packages/spec/src/data/feed.zod.ts
+++ b/packages/spec/src/data/feed.zod.ts
@@ -7,12 +7,19 @@ import { z } from 'zod';
  *
  * The `service-feed` backend was retired (ADR-0052 §5 / #1955); `sys_comment` /
  * `sys_activity` are the canonical record-collaboration/timeline backend. The two
- * enums here are pure UI configuration for the record activity component
- * (`RecordActivityProps` in `../ui/component.zod.ts`), with no backend dependency;
- * `SYS_ACTIVITY_BUILTIN_TYPES` below is the published built-in vocabulary of the
- * `sys_activity.type` column, co-located with `FeedItemType` because UI consumers
- * map one onto the other. (A later `feed` → `activity` rename is tracked
- * separately.)
+ * enums here configure the record activity component (`RecordActivityProps` in
+ * `../ui/component.zod.ts`). `FeedFilterMode` is pure UI configuration, but
+ * `FeedItemType` is not backend-free: it has no backend *import*, yet it is the
+ * TARGET of the map UI consumers apply to the `sys_activity.type` column — a
+ * backend *coupling* — and that column's vocabulary is OPEN and
+ * author-extensible (maintainer ruling 2026-08-24, #11507). `FeedItemType` is
+ * therefore the built-in guidance half of that map, never the value domain of
+ * an authoring surface: `RecordActivityProps.types` accepts contributed kinds
+ * beyond it (#11658), and consumers must map unknown `sys_activity.type` values
+ * to a fallback rather than drop them. `SYS_ACTIVITY_BUILTIN_TYPES` below is
+ * the published built-in vocabulary of the `sys_activity.type` column,
+ * co-located with `FeedItemType` because UI consumers map one onto the other.
+ * (A later `feed` → `activity` rename is tracked separately.)
  */
 
 /**

--- a/packages/spec/src/ui/component.test.ts
+++ b/packages/spec/src/ui/component.test.ts
@@ -1720,8 +1720,45 @@ describe('RecordActivityProps (enhanced)', () => {
     expect(result.limit).toBe(50);
   });
 
-  it('should reject invalid feed item type', () => {
-    expect(() => RecordActivityProps.parse({ types: ['invalid_type'] })).toThrow();
+  // -------------------------------------------------------------------------
+  // `types` is an OPEN vocabulary (#11658, executing the 2026-08-24 maintainer
+  // ruling on #11507: `sys_activity.type` is author-extensible, and "every
+  // closed map over this vocabulary is now the bug"). The closed-enum pin that
+  // used to live here ("should reject invalid feed item type",
+  // `types: ['invalid_type']` throwing) pinned exactly the branch the ruling
+  // removed — it is replaced, not merely reworded, by the cases below.
+  // -------------------------------------------------------------------------
+  it('accepts author-contributed activity kinds beyond the built-in set (#11507 ruling, #11658)', () => {
+    // 'scheduled' is a real contributed value (hotcrm writes it today);
+    // 'my_custom_kind' stands in for any future author vocabulary.
+    const result = RecordActivityProps.safeParse({
+      types: ['comment', 'scheduled', 'my_custom_kind'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.types).toEqual(['comment', 'scheduled', 'my_custom_kind']);
+    }
+  });
+
+  it('does not reject a typo of a built-in kind by name — the ruling accepted this cost (#11658)', () => {
+    // Under the closed enum, 'commnet' got a named rejection. An open
+    // vocabulary cannot distinguish a typo from a contributed kind, and the
+    // ruling accepted that trade rather than re-close the vocabulary.
+    const result = RecordActivityProps.safeParse({ types: ['commnet'] });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects non-string and empty entries — open vocabulary, not untyped (#11658)', () => {
+    const nonString = RecordActivityProps.safeParse({ types: [42] });
+    expect(nonString.success).toBe(false);
+    if (!nonString.success) {
+      expect(nonString.error.issues[0]?.path).toEqual(['types', 0]);
+    }
+    const empty = RecordActivityProps.safeParse({ types: [''] });
+    expect(empty.success).toBe(false);
+    if (!empty.success) {
+      expect(empty.error.issues[0]?.path).toEqual(['types', 0]);
+    }
   });
 });
 

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -1137,8 +1137,23 @@ export const RecordActivityProps = strictObject({
   history: PROPS_HISTORY,
   guidanceSets: COMPONENT_LEVEL_GUIDANCE,
 }, {
-  /** Activity types to display (unified enum including comment, field_change, etc.) */
-  types: z.array(FeedItemType).optional().describe('Feed item types to show (default: all)'),
+  /**
+   * Feed/activity kinds to show — an OPEN vocabulary (#11658, executing the
+   * 2026-08-24 maintainer ruling on #11507: `sys_activity.type` is
+   * author-extensible and "every closed map over this vocabulary is now the
+   * bug"). The `FeedItemType` union branch is guidance only — it keeps the
+   * built-in kinds visible in editor autocomplete and as an `anyOf` member of
+   * the generated JSON Schema — while the open-string branch keeps every
+   * author-contributed activity kind nameable (sanctioned authoring channel:
+   * `activityMilestones[].type`, ADR-0052 §5b.2; built-in set published as
+   * `SYS_ACTIVITY_BUILTIN_TYPES` in `../data/feed.zod.ts`). The union accepts
+   * exactly what a bare `z.string().min(1)` accepts — nothing is validated
+   * against the built-in set, so a typo'd built-in is no longer rejected by
+   * name; the ruling accepted that cost rather than re-close the vocabulary.
+   */
+  types: z.array(z.union([FeedItemType, z.string().min(1)])).optional().describe(
+    'Feed item kinds to show (default: all). Open vocabulary: the FeedItemType members are the platform built-in kinds, and author-contributed activity kinds (open sys_activity.type vocabulary, ADR-0052 §5b.2) are equally legal — entries are never validated against the built-in set.',
+  ),
   /** Default filter mode (Airtable-style dropdown) */
   filterMode: FeedFilterMode.default('all').describe('Default activity filter'),
   /** Allow user to switch filter modes */


### PR DESCRIPTION
Fixes #11658

## What

`RecordActivityProps.types` — the authorable `record:activity` feed filter, also embedded as `RecordChatterProps.feed.types` (the `feed` prop delegates to `RecordActivityProps`, so the same change propagates there) — was a closed `z.array(FeedItemType)` over the vocabulary the 2026-08-24 maintainer ruling on #11507 declared OPEN and author-extensible (verbatim: "every closed map over this vocabulary is now the bug"). The element is now:

```ts
z.union([FeedItemType, z.string().min(1)])
```

- **Open:** the union accepts exactly what a bare non-empty string accepts — nothing is validated against the built-in set, so an author-contributed activity kind (`scheduled`, which hotcrm writes today, or any future kind authored through ADR-0052 §5b.2) is nameable in the filter.
- **Guided:** the `FeedItemType` branch keeps the 13 built-in kinds visible as guidance — editor autocomplete, and an `anyOf` member of the generated JSON Schema. Measured, not assumed: `json-schema/ui/RecordActivityProps.json` (generated, gitignored tree) now emits `items.anyOf = [enum(13 built-ins), string(minLength 1)]`, which is how JSON-schema-driven authoring tools keep suggesting the built-ins without re-closing the domain.
- **Accepted cost** (named by the ruling's logic and this card's dispatch): a typo'd built-in no longer gets a named rejection — an open vocabulary cannot distinguish a typo from a contributed kind. Non-string and empty entries are still rejected.

Also in scope (flagged on the card 2026-08-24T11:07Z): the `feed.zod.ts` module docblock no longer claims these enums are "pure UI configuration … with no backend dependency" — `FeedItemType` is the TARGET of the map UI consumers apply to the open `sys_activity.type` column: a backend *coupling*, not a backend *import*. The generated reference pages (`content/docs/references/data/feed.mdx` including its "Allowed Values" framing context, and `content/docs/references/ui/component.mdx` for all three `types` rows) moved by regeneration only (`check:generated --fix`), never hand-edited.

## Alignment with the landed upstream shape

- #11507 declaration half (PR #11659): the column declared open at the source, description-slot mechanism.
- PR #12331 (`2d8dd8d5`): `SYS_ACTIVITY_BUILTIN_TYPES` + `SysActivityBuiltinType` published from `@objectstack/spec/data` as a plain `as const` tuple, deliberately not a `z.enum`, so the published set cannot re-close the vocabulary. This PR mirrors that logic on the authoring surface: the built-in set guides, never validates. `FeedItemType` itself stays a closed `z.enum` — it is the UI-kind map *target*, not the column vocabulary; the consumer-side feed-kind map is the ui lane's card (objectstack-ai/objectui#5969 remains open and is not addressed here — a read-coupling note goes there after this PR opens).

## Test-first verification (replaces mutate-and-restore ablation — no restore leg exists to fail silently)

New tests written on the **unmodified** schema with the failure predicted in writing first: the two open-vocabulary cases red, the rejection-preservation case green. Observed exactly that: `Tests 2 failed | 223 passed (225)`, the two reds being `accepts author-contributed activity kinds` and `does not reject a typo of a built-in kind by name`. After the schema edit: `Test Files 3 passed (3) · Tests 307 passed (307)` (component + feed + page suites). The replaced closed-enum pin (`should reject invalid feed item type`) pinned exactly the branch the ruling removed — replaced, not reworded.

## Verification — all at `b451c43` (branch head, clean tree), heavy steps serialized through `scripts/pm/os-verify-lock.sh`, every exit code captured before any pipe

- Targeted suites: `Test Files 3 passed (3) · Tests 307 passed (307)` — os-verify-lock `VERDICT command-exit 0`.
- `pnpm --filter @objectstack/spec build`: `VERDICT command-exit 0` (dist + DTS rebuilt; `.build-input-hash` refreshed).
- `pnpm --filter @objectstack/spec typecheck`: `VERDICT command-exit 0`, including its own verdict line `check:test-typecheck: OK — @objectstack/spec's test layer compiles under packages/spec/tsconfig.test.json; 55 file(s) / 263 error(s) held in test-typecheck-debt.json (shrink-only)` — the edited test file is inside that measured layer.
- `pnpm --filter @objectstack/spec check:generated`: `✓ All 14 generated artifacts are up to date.` (`check:docs` was the one proved stale; regenerated via `--fix`, diff reviewed.)
- Whole-repo `pnpm lint` (`eslint . --no-inline-config`): `VERDICT command-exit 0` — no narrowing needed.
- Gate families derived from the real change set via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at `b451c43` (43 path-matched + 5 convention-triggered for the test-file kind + `check:nul-bytes`): all exit 0, including `check:authorable-surface`, `check:api-surface`, `check:slot-lookup`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:cross-package-test-inputs`, `check:changeset-no-major`, `check:adr-0087-registration`, `check:nul-bytes`. Three gates (`check:doc-formula-expressions`, `check:doc-security-posture`, `check:skill-examples`) first returned prerequisite-not-met ("nothing was measured"); their named prerequisites were built (`turbo run build --filter=@objectstack/formula --filter=@objectstack/lint --filter=@objectstack/client-react`, 33 tasks, `VERDICT command-exit 0`) and all three re-ran green (`✅ 260 prose examples type-check across 3 surface(s)`).
- **Declared NOT MEASURED (narrowing, not skipped-in-silence):** `check:type-check-debt --re-measure` and `check:dev-prereqs` both require the whole `packages/**` closure built (65 packages) — a farm-scale run CI's `lint.yml` performs on every PR after its own full build. Evidence the narrowing excludes nothing of this diff: ① their populations are read from the gates' own output (per-package debt ledger entries; dev-stack dist presence — a container build-state property, not a diff property); ② this diff touches only `packages/spec` (built and typechecked clean at head, test layer included per the verdict line above), generated docs, and a changeset; ③ the repo-wide grep below shows zero downstream consumers whose tsc programs could move.

## Consumer radius

Grep of all `packages/`, `apps/`, `examples/` for `RecordActivityProps` / `FeedItemType` outside the two spec sources (direction: **downstream/consumers**): zero — only the spec sources themselves, the type-alias-convention pin (asserts `z.input ≡ z.infer` on `FeedItemType`, which is unchanged), and generated artifacts. No example or fixture authors `record:activity` `types`, so no fixture triage was owed. The cross-repo consumer is objectui's feed-kind map, pinned by its own queued card.

## Changeset

`.changeset/record-activity-types-open-vocabulary.md` — `@objectstack/spec: minor`, pure accept-set widening (every previously-legal value parses byte-identically), with an ADR-0087 `not-required (no-migration-prescription)` disposition note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5LFCYBJ3q2s6yW6oMLxwy)_