### PR TITLE
fix(cli): name the entity an environment in every string the `os environments` family prints

### DIFF
--- a/.changeset/cli-environments-entity-noun.md
+++ b/.changeset/cli-environments-entity-noun.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): the `os environments` family calls the entity an environment, not a project, in every string it prints (#12153)
+
+Per ADR-0006 the v5.0 rename `project` → `environment` has no aliases, and AGENTS.md
+states "Project now only means the npm/monorepo sense". #10967 (PR #11227) renamed the
+**command** (`os projects …` → `os environments …`) across these same five files; the
+**entity noun** inside the strings oclif prints was left behind. A user ran
+`os environments switch <id>` and the tool answered `✓ Active project: …`.
+
+25 user-visible string literals in `packages/cli/src/commands/environments/` are swapped
+to the post-rename noun. No behaviour, no flag or argument names, no exit codes, and no
+`--format json` / `--format yaml` payloads change — those are produced by
+`formatOutput(res, …)` straight from the control-plane response and are untouched.
+
+| where | count | printed by |
+| --- | --- | --- |
+| `static override description` | 5 | `os environments --help` |
+| flag / arg `description` | 7 | each command's own `--help` |
+| success-path console output | 9 | `list` · `bind` · `create` · `show` · `switch` |
+| `examples` arg placeholder (`<project-id>` → `<environment-id>`) | 3 | `os environments bind --help` |
+| the `switch` id-not-found error | 1 | `os environments switch` on a bad id |
+
+The five `static override description` strings now read as
+`content/docs/deployment/cli.mdx`'s command table has described them since the rename
+("List environments visible to the current session", "Provision a new environment", …),
+so the shipped `--help` and the shipped docs agree for the first time.
+
+What is deliberately NOT renamed, because it is API surface in other packages rather than
+CLI wording, and each needs its own decision: `client.projects.*` (the `@objectstack/client`
+SDK method names), the `res.project` / `res.projects` response fields, the locals bound
+directly from them, and the docblock comments in these files.

--- a/packages/cli/src/commands/environments/bind.ts
+++ b/packages/cli/src/commands/environments/bind.ts
@@ -21,17 +21,17 @@ import { formatOutput } from '../../utils/output-formatter.js';
  * reflects the latest source.
  */
 export default class EnvironmentsBind extends Command {
-  static override description = 'Bind a local objectstack artifact to an existing project';
+  static override description = 'Bind a local objectstack artifact to an existing environment';
 
   static override examples = [
-    '$ os environments bind <project-id> --artifact ./dist/objectstack.json',
-    '$ os environments bind <project-id> --artifact ./dist/objectstack.json --build',
-    '$ os environments bind <project-id> --reseed',
+    '$ os environments bind <environment-id> --artifact ./dist/objectstack.json',
+    '$ os environments bind <environment-id> --artifact ./dist/objectstack.json --build',
+    '$ os environments bind <environment-id> --reseed',
   ];
 
   static override args = {
     environmentId: Args.string({
-      description: 'Target project id (UUID)',
+      description: 'Target environment id (UUID)',
       required: true,
     }),
   };
@@ -111,7 +111,7 @@ export default class EnvironmentsBind extends Command {
       delete existingMeta.artifactBindError;
       existingMeta.artifact_path = artifactAbs;
 
-      printKV('Project', args.environmentId, '🎯');
+      printKV('Environment', args.environmentId, '🎯');
       printKV('Artifact', artifactAbs, '📦');
 
       const res = await client.projects.update(args.environmentId, {
@@ -139,9 +139,9 @@ export default class EnvironmentsBind extends Command {
       } else if (flags.format === 'yaml') {
         await formatOutput(res, 'yaml');
       } else {
-        console.log(`\n✓ Project bound to artifact`);
+        console.log(`\n✓ Environment bound to artifact`);
         console.log(`  ${args.environmentId} → ${artifactAbs}`);
-        console.log(`  The next request to this project will load the new bundle.`);
+        console.log(`  The next request to this environment will load the new bundle.`);
         console.log('');
       }
     } catch (error: any) {

--- a/packages/cli/src/commands/environments/create.ts
+++ b/packages/cli/src/commands/environments/create.ts
@@ -15,7 +15,7 @@ import { readAuthConfig, writeAuthConfig } from '../../utils/auth-config.js';
  * (unless `--no-activate` is passed).
  */
 export default class EnvironmentsCreate extends Command {
-  static override description = 'Provision a new project';
+  static override description = 'Provision a new environment';
 
   static override examples = [
     '$ os environments create --org 00000000-0000-0000-0000-000000000000 --name Staging',
@@ -39,11 +39,11 @@ export default class EnvironmentsCreate extends Command {
     // the App Marketplace instead (`os package install`, `sys_package` with
     // `is_starter = true`).
     artifact: Flags.string({
-      description: 'Path to a locally-compiled objectstack.json artifact to bind into this project',
+      description: 'Path to a locally-compiled objectstack.json artifact to bind into this environment',
     }),
-    'clone-from': Flags.string({ description: 'Clone schema from an existing project id' }),
+    'clone-from': Flags.string({ description: 'Clone schema from an existing environment id' }),
     activate: Flags.boolean({
-      description: 'Activate the new project for subsequent CLI calls',
+      description: 'Activate the new environment for subsequent CLI calls',
       default: true,
       allowNo: true,
     }),
@@ -111,9 +111,9 @@ export default class EnvironmentsCreate extends Command {
         await formatOutput(res, 'yaml');
       } else {
         const p = res?.project ?? {};
-        console.log(`\n✓ Project created: ${p.display_name ?? p.id} (${p.id})`);
+        console.log(`\n✓ Environment created: ${p.display_name ?? p.id} (${p.id})`);
         if (flags.activate) {
-          console.log(`  active project set to ${p.id}`);
+          console.log(`  active environment set to ${p.id}`);
         }
         console.log('');
       }

--- a/packages/cli/src/commands/environments/list.ts
+++ b/packages/cli/src/commands/environments/list.ts
@@ -13,7 +13,7 @@ import { formatOutput } from '../../utils/output-formatter.js';
  * consistent DX.
  */
 export default class EnvironmentsList extends Command {
-  static override description = 'List projects visible to the current session';
+  static override description = 'List environments visible to the current session';
 
   static override examples = [
     '$ os environments list',
@@ -25,7 +25,7 @@ export default class EnvironmentsList extends Command {
     url: Flags.string({ char: 'u', description: 'Server URL', env: 'OS_CLOUD_URL' }),
     token: Flags.string({ char: 't', description: 'Authentication token', env: 'OS_TOKEN' }),
     org: Flags.string({ description: 'Filter by organization id' }),
-    status: Flags.string({ description: 'Filter by project status (active|provisioning|failed|…)' }),
+    status: Flags.string({ description: 'Filter by environment status (active|provisioning|failed|…)' }),
     format: Flags.string({
       char: 'f',
       description: 'Output format',
@@ -57,9 +57,9 @@ export default class EnvironmentsList extends Command {
       } else if (flags.format === 'yaml') {
         await formatOutput(res, 'yaml');
       } else {
-        console.log(`\nProjects (${projects.length}):\n`);
+        console.log(`\nEnvironments (${projects.length}):\n`);
         if (projects.length === 0) {
-          console.log('  (no projects)');
+          console.log('  (no environments)');
         } else {
           for (const p of projects) {
             const active = p.id === activeId ? ' ★' : '';

--- a/packages/cli/src/commands/environments/show.ts
+++ b/packages/cli/src/commands/environments/show.ts
@@ -12,7 +12,7 @@ import { formatOutput } from '../../utils/output-formatter.js';
  * membership row (same shape as `client.projects.get(id)`).
  */
 export default class EnvironmentsShow extends Command {
-  static override description = 'Show detailed information for a project';
+  static override description = 'Show detailed information for an environment';
 
   static override examples = [
     '$ os environments show 00000000-0000-0000-0000-000000000001',
@@ -20,7 +20,7 @@ export default class EnvironmentsShow extends Command {
   ];
 
   static override args = {
-    id: Args.string({ description: 'Project id', required: true }),
+    id: Args.string({ description: 'Environment id', required: true }),
   };
 
   static override flags = {
@@ -49,7 +49,7 @@ export default class EnvironmentsShow extends Command {
         await formatOutput(res, 'yaml');
       } else {
         const p = res?.project ?? {};
-        console.log(`\nProject: ${p.display_name ?? p.id}`);
+        console.log(`\nEnvironment: ${p.display_name ?? p.id}`);
         console.log('─'.repeat(60));
         console.log(`  id:             ${p.id}`);
         console.log(`  organization:   ${p.organization_id ?? '—'}`);

--- a/packages/cli/src/commands/environments/switch.ts
+++ b/packages/cli/src/commands/environments/switch.ts
@@ -15,7 +15,7 @@ import { readAuthConfig, writeAuthConfig } from '../../utils/auth-config.js';
  * project.
  */
 export default class EnvironmentsSwitch extends Command {
-  static override description = 'Activate a project for subsequent CLI calls';
+  static override description = 'Activate an environment for subsequent CLI calls';
 
   static override examples = [
     '$ os environments switch 00000000-0000-0000-0000-000000000001',
@@ -23,7 +23,7 @@ export default class EnvironmentsSwitch extends Command {
   ];
 
   static override args = {
-    id: Args.string({ description: 'Project id to activate', required: true }),
+    id: Args.string({ description: 'Environment id to activate', required: true }),
   };
 
   static override flags = {
@@ -47,7 +47,7 @@ export default class EnvironmentsSwitch extends Command {
       const lookup = await client.projects.get(args.id);
       const project = lookup?.project;
       if (!project?.id) {
-        throw new Error(`Project ${args.id} not found`);
+        throw new Error(`Environment ${args.id} not found`);
       }
 
       if (flags.remote) {
@@ -59,7 +59,7 @@ export default class EnvironmentsSwitch extends Command {
       cfg.lastUsedAt = new Date().toISOString();
       await writeAuthConfig(cfg);
 
-      console.log(`\n✓ Active project: ${project.display_name ?? project.id}`);
+      console.log(`\n✓ Active environment: ${project.display_name ?? project.id}`);
       console.log(`  id: ${project.id}`);
       if (!flags.remote) {
         console.log('  (local only — server session unchanged)');


### PR DESCRIPTION
Fixes #12153

Per ADR-0006 the v5.0 rename `project` → `environment` has no aliases, and AGENTS.md states "Project now only means the npm/monorepo sense". #10967 (PR #11227) renamed the **command** across these same five files; the **entity noun** inside the strings oclif prints was left behind, so `os environments switch` answered `✓ Active project: …`.

## Re-census on current `origin/main` — the card's 21 is a clue, and it is off in three ways

Everything below was measured at `b000ab59b`, not reconciled with the card's list.

| section | card | measured | agreement |
| --- | --- | --- | --- |
| **A** `static override description` | 5 | **5** | exact, same line numbers |
| **B** flag / arg `description` | 7 | **7** | exact, same line numbers |
| **C** success-path console output | 9 | **9** | same count, **membership differs by one in each direction** |
| **D** same class, in no card section | — | **4** | absent from the card entirely |
| total | 21 | **25** | |

**C is not the same nine.** The card lists `switch.ts:62/63` as two sites. Line 63 is ``console.log(`  id: ${project.id}`)`` — it prints `  id: <uuid>`, which carries **no entity noun**; the word `project` there is the *local variable*, and this PR leaves it alone. In its place the card **misses** `bind.ts:114`, `printKV('Project', args.environmentId, '🎯')` — a printed key label on the bind success path. Net count coincides at 9; one member in, one member out.

**D — four sites in the same defect class that no card section covers:**

- `bind.ts:27/28/29` — the `static override examples` arg placeholder `<project-id>` → `<environment-id>` (3). This is `--help` output carrying the entity noun; it is **not** the command-name rename ruling ① fences off, which is the `os projects …` → `os environments …` half and was already done. The canonical spelling is not a judgment call here: `content/docs/deployment/cli.mdx:1528` already writes `os environments bind <environment-id>`, and the argument is named `environmentId`.
- `switch.ts:50` — ``throw new Error(`Project ${args.id} not found`)``, the id-not-found message. User-visible, same noun; outside C only because C is defined as the *success* path.

All four are in the claimed file surface, mechanically determined, hold no competing claim, and add no verification surface. They are named here rather than swept in silently.

## Section C was not contested — the triage caveat is falsified by measurement

Triage's caveat was that `environments.test.ts` may pin the console wording, so C might be a judgment call between the pin and the string. **It does not, and it is not.** Two findings:

1. **The test is not where the card and the claim say it is.** There is no `packages/cli/test/environments.test.ts`. The file is `packages/cli/src/commands/environments/environments.test.ts` — co-located, i.e. inside the claimed directory, but not the claimed path.
2. **It pins command ids, not vocabulary.** It is the #10967 pin: every `examples` entry must name a command id this CLI actually registers, derived from file paths with oclif's own algorithm. `grep -i project` over it returns 7 lines: 5 in the header prose about the mechanism, and `preFix` at 334/336/337 — a *pre-fix* fixture asserted to be **rejected**. Not one line asserts the noun in any printed string.

Repo-wide, **no test pins any section-C literal**. Instrument proof, since a zero-hit grep is not a reading on its own: the same `--include='*.test.ts'` grep that returns zero for every C literal returns `packages/cli/src/commands/datasource/envelope-unwrap.test.ts:166` for `toContain('✓ …')` — so it does reach console-output assertions in CLI tests. `packages/cli/test/commands.test.ts`, `remote-api-commands.test.ts`, `collect-docs.test.ts` and `invocation.test.ts` return zero for both `environments` and `project` (each verified non-empty by a positive control on `describe(`).

`preFix` at `environments.test.ts:334` keeps its `<project-id>` deliberately: it is the historical pre-fix line, and its whole job is to be the string that no longer resolves. **`environments.test.ts` is untouched — the pinned wording that ruling ③ would have licensed editing it does not exist.**

## The card's other assertion, verified

The card asserts #10967's command-name rename is complete. It is: `grep -rn 'os projects' packages/cli/src/` matches exactly two test files (`auth-config.test.ts`, `environments.test.ts`), and in both it is a negative assertion or prose about one. Positive control on the same instrument, and deliberately not a substring of the term under test: `os environments bind` returns 5 hits.

## What is deliberately NOT renamed

`client.projects.*` (the `@objectstack/client` SDK method names), the `res.project` / `res.projects` response fields, the locals bound directly from them (`const projects = res?.projects ?? []`, `const project = lookup?.project`), and the docblock comments in these five files. Ruling ② fences them as API surface in other packages; a full `grep -i project` over the five files after this change returns **only** members of those four groups — no user-visible string remains.

The five `static override description` strings now read as `content/docs/deployment/cli.mdx:1505-1509` has described them since the rename, so shipped `--help` and shipped docs agree for the first time. No doc quotes the console output these commands print, so section C stales nothing.

## Verification — all at the final commit `14d22a44b`

Gate families re-derived in this worktree with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (not taken from the dispatch order), then run at `14d22a44b`. Quoted verdicts are each gate's own printed line, never a bare `$?`.

Under the shared verify lock, parts joined with `&&` so the verdict covers all of them — `os-verify-lock: VERDICT command-exit 0 · held the lock 121s`:

- `pnpm lint` — full-repo `eslint . --no-inline-config`, clean, no narrowing claimed
- `pnpm check:i18n` — `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).`
- `pnpm check:i18n-coverage` — `check-i18n-coverage: OK (12 config(s), 657 baselined untranslated string(s), none new).`
- `pnpm --filter @objectstack/cli typecheck` — clean
- the #10967 pin — `Test Files  1 passed (1) / Tests  73 passed (73)`

Green on their own exit codes, captured before any pipe: `check:nul-bytes` · `check:cross-package-test-inputs` · `check:page-declaration-shape` · `check:published-files` · `check:slot-lookup` · `check:test-source-alias` · `check:type-source-resolution` · `check-ci-filter-parity` · `check-comment-mask-adoption` · `check-cross-package-test-inputs` · `check-plugin-teardown-shape` · `check-affected-docs` · `check-drift-comment` · `check:changeset-gate-self-tests` · `check:objectui-changeset` · `check-adr-0087-registration` (`this PR adds no declared-breaking changeset`) · `check-changeset-no-major` · `check-empty-changeset`.

One gate needed its prerequisite satisfied before it was a measurement rather than a NOT-MEASURED: `check:i18n-coverage` first returned `COULD NOT MEASURE — 1 of 12 config(s) failed to lint` because `examples/app-showcase`'s connector dependencies had no build output in a fresh worktree. Building that closure turned it into the real green above; the failure was environmental and unrelated to this diff.

`@objectstack/cli` was built with its full dependency closure before any of this was read, so no verdict here is a judgment about a stale `dist/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_