### PR TITLE
fix(spec): route the stored-envelope refusal to `os package publish`, a command that exists

### DIFF
--- a/.changeset/spec-publish-command-spelling.md
+++ b/.changeset/spec-publish-command-spelling.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/spec": patch
+---
+
+Route the stored-envelope refusal to a command that exists — `os package publish`, not the retired `objectstack publish` (#12223)
+
+An author who hand-writes one of the seven `STORED_ENVELOPE_KEYS` onto an `api`
+declaration is refused, and the refusal tells them where publication state actually
+comes from. It named a command that resolves to nothing:
+
+```text
+before: Remove it — publication state is managed by `objectstack publish`, not authored.
+after:  Remove it — publication state is managed by `os package publish`, not authored.
+```
+
+`os publish` was the legacy direct-to-environment command, retired with the path that
+wrote `sys_environment_revision`. Re-measured on this tree against the **built oclif
+`Config`** rather than against docs — loading the CLI's plugin and reading the command
+table oclif derives from `dist/commands/**`: **61** ids, of which the only two containing
+`publish` are `package publish` and `plugin publish`. There is no bare `publish` id and no
+`publish` topic, so the old spelling exits as an unknown command. The message's own
+neighbouring sentence already names `publishPackage` as the writer, and
+`packages/cli/src/commands/package/publish.ts` is the command that runs it.
+
+This is the shape #12177 deliberately left alone elsewhere inverted: those sentences are
+*about* the removal and are correct as history, while this one is **present tense and
+prescriptive** — text an AI author obeys at the moment its write is refused.
+
+Text only. No accept/reject behaviour changes: the same seven keys are refused on the same
+declarations, with the same `unrecognized_keys` upgrade path; only the sentence an author
+reads is corrected. The same stale spelling is fixed in the `publisher` doc comment of
+`packages/spec/src/cloud/package.zod.ts`, which ships to consumers in the package's type
+declarations.

--- a/content/docs/api/declarative-endpoints.mdx
+++ b/content/docs/api/declarative-endpoints.mdx
@@ -86,7 +86,7 @@ export default defineStack({
 });
 ```
 
-Publish it (`objectstack publish`), and the two URLs answer. `objectstack validate` — and
+Publish it (`os package publish`), and the two URLs answer. `objectstack validate` — and
 `os build` — run the same gates the publish path runs, so a declaration that would be
 refused is refused before you deploy.
 

--- a/packages/spec/src/api/endpoint.zod.ts
+++ b/packages/spec/src/api/endpoint.zod.ts
@@ -36,7 +36,7 @@ const STORED_BOOKKEEPING_GUIDANCE =
   'This is the metadata layer\'s own storage bookkeeping, not endpoint vocabulary. It is written onto '
   + 'the stored ROW by `register` / `publishPackage` and peeled off before this schema sees a body '
   + '(#5309), so writing it on a declaration configures nothing. Remove it — publication state is '
-  + 'managed by `objectstack publish`, not authored.';
+  + 'managed by `os package publish`, not authored.';
 
 /**
  * API Endpoint Schema

--- a/packages/spec/src/cloud/package.zod.ts
+++ b/packages/spec/src/cloud/package.zod.ts
@@ -234,7 +234,7 @@ export const PackageSchema = lazySchema(() => z.object({
   /**
    * Publisher provenance tier — surfaced as a trust badge in the Marketplace
    * and Studio. Defaults to `private` for org-scoped packages; the
-   * `objectstack publish` CLI sets it explicitly when promoting first-party
+   * `os package publish` command sets it explicitly when promoting first-party
    * or partner content.
    */
   publisher: PackagePublisherSchema.default('private'),

--- a/scripts/check-cli-command-ids.mjs
+++ b/scripts/check-cli-command-ids.mjs
@@ -213,19 +213,16 @@ const FIXTURE_EXEMPTIONS = [
  * follow in the owning lane, which is the same order `check-cli-test-child-env` shipped in
  * and for the same reason: sweeping without the gate restates a convention instead of
  * enforcing it.
+ *
+ * EMPTY, and that is the design working rather than a list nobody kept. The gate shipped
+ * with exactly one entry -- the `objectstack publish` refusal message in
+ * `packages/spec/src/api/endpoint.zod.ts` (#12223) -- and it retired ITSELF: fixing the
+ * string to `os package publish` made the entry stop reproducing, the `stale` check below
+ * RED, and deleting it the only way back to green. A baseline here cannot outlive its
+ * defect, so this list stays a record of work in flight and never becomes a silent
+ * exemption. Add to it only under the rule above: a real defect, filed and linked.
  */
-const BASELINED_VIOLATIONS = [
-  {
-    file: 'packages/spec/src/api/endpoint.zod.ts',
-    text: 'objectstack publish',
-    why: 'STALE. `os publish` was retired with the direct-to-environment path (#11465 measured '
-      + 'it against the built oclif Config: the registered publish ids are `package publish` and '
-      + '`plugin publish`). This is a present-tense AUTHOR-FACING refusal message -- "publication '
-      + 'state is managed by `objectstack publish`" -- so an author who trips it is sent to a '
-      + 'command that does not exist. Correct spelling: `os package publish`.',
-    issue: '#12223',
-  },
-];
+const BASELINED_VIOLATIONS = [];
 
 const isExempt = (file, text) =>
   FIXTURE_EXEMPTIONS.some((e) => e.file === file && e.text === text)


### PR DESCRIPTION
Fixes #12223

An author who hand-writes one of the seven `STORED_ENVELOPE_KEYS` onto an `api` declaration is refused, and the refusal tells them where publication state actually comes from. It named a command that resolves to nothing.

```text
before: Remove it — publication state is managed by `objectstack publish`, not authored.
after:  Remove it — publication state is managed by `os package publish`, not authored.
```

Text only. No accept/reject behaviour change: the same seven keys are refused on the same declarations through the same `unrecognized_keys` upgrade path — only the sentence an author reads changes.

## The spelling, re-measured on this tree against the LIVE command table

The card's answer was `os package publish`; the constraint was to re-verify it against the CLI's **built oclif `Config`**, not against docs. Done on this branch, after `pnpm --filter @objectstack/cli build`:

```
oclif.bin: os | declared bins: ["objectstack","os"]
plugin commandIDs (oclif-derived from the built dist/commands glob): 61
SANITY validate present: true
ids containing publish: ["package:publish","plugin:publish"]
bare "publish" id present: false
topics containing publish: []
```

61 ids matches the count this gate's own header recorded from command files. With `topicSeparator: " "`, `package:publish` is spelled `os package publish` at the prompt. There is no bare `publish` id and no `publish` **topic**, so the old spelling exits as an unknown command rather than falling through to topic help.

**One reading was discarded rather than reported.** The first attempt loaded `config.commands` and got `registered command ids: 4` with `findCommand('package publish') → not found` — which would have "confirmed" the fix was pointless. It was broken, not a measurement: unbuilt workspace deps made oclif's per-command module `import()` fail, silently dropping commands from the table. `findCommand('validate') → not found` was the tell, since `validate.ts` plainly exists. The reading above uses `Plugin.commandIDs`, which oclif derives from the `dist/commands` glob without importing the modules, and carries the `validate` sanity assertion inline.

## Sites

| Site | Shape |
|---|---|
| `packages/spec/src/api/endpoint.zod.ts` :39 | the load-bearing one — a present-tense, prescriptive refusal message, i.e. the text an AI author obeys at the moment its write is refused |
| `packages/spec/src/cloud/package.zod.ts` :237 | doc comment on `publisher`; ships to consumers in the package's type declarations. `` the `objectstack publish` CLI sets it `` → `` the `os package publish` command sets it `` — "CLI" became "command" to keep the sentence grammatical, since `os` is the CLI and `package publish` is the command |
| `content/docs/api/declarative-endpoints.mdx` :89 | hand-written prose (frontmatter is `title`/`description`, no generated banner), so edited directly — no regeneration path. The `objectstack validate` on the same line **is** valid and is untouched |
| `scripts/check-cli-command-ids.mjs` | the baselined-violation row, deleted |

The two deliberately-historical unresolvable ids #12177 declares elsewhere are **not** rewritten — those sentences are *about* the removal and are correct as history. This one is the opposite shape.

## The ledger row is self-retiring, and that is why it is in this commit

`BASELINED_VIOLATIONS` is checked for entries that no longer reproduce (`const stale = LEDGER().filter((e) => !seen.has(...))`). Fixing the string makes the row stop reproducing, which **reds** `check:cli-command-ids` until the row is deleted — the design working, not a second defect. The list is now empty, and the docblock records why an entry here can never outlive its defect.

The gate's own verdict line, before and after:

```
before: ⚠ baselined violation — packages/spec/src/api/endpoint.zod.ts: "objectstack publish" (#12223)
        ✓ check-cli-command-ids: 276 command-id literal(s) across 99 file(s) ... 1 baselined violation(s) listed above).
after:  ✓ check-cli-command-ids: 277 command-id literal(s) across 99 file(s) outside packages/cli all resolve
        to a real command path (71 ids derived; 3 declared fixture exemptions, 0 baselined violation(s) listed above).
```

276 → 277 is the corrected string *joining the resolving population* — it now resolves to a real command path instead of being carried as an exemption. Its 38-case self-test passes on both runs.

## Verification

Gate union re-run on the final commit **`89d84d5`**: **39 gates, 39 pass, 0 fail**, each exit code captured before any pipe. The family was re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (5 paths, 47 families matched) rather than taken from the dispatch list.

- `pnpm check:cli-command-ids` — green, verdict line above (load-bearing)
- `pnpm --filter @objectstack/spec exec vitest run src/api/endpoint src/cloud/package` — 3 files, **74 tests passed**
- `pnpm --filter @objectstack/metadata exec vitest run src/stored-envelope` — 1 file, **25 tests passed** (the pin that walks `STORED_ENVELOPE_KEYS` and asserts each key gets this prescription)
- `pnpm --filter @objectstack/spec run typecheck` — green, and it covers the test layer too via `tsconfig.test.json`, so no silent test-file exclusion
- **No projection to regenerate.** These strings are refusal-guidance values, not `.describe()` values; no generated JSON contains the literal, and a full `@objectstack/spec build` left `git status` showing only the five intended paths. `check:authorable-surface` and `check:generated` both green.

**Declared narrowing — one gate not measured:** `pnpm --filter @objectstack/spec run check:skill-examples` exits 1 here with its own `packages/client-react/dist holds no .d.ts declarations — the package is not built` message and the explicit note that a verdict now would be a false green. Nothing was measured; it is not a finding. This diff touches no `skills/` file. CI builds the closure and will run it for real. Two other gates (`check:doc-formula-expressions`, `check:doc-security-posture`) failed the same `PREREQUISITE NOT MET` way, were re-run after building `@objectstack/lint` and `@objectstack/formula`, and are **green** in the 39.

## Changeset

`patch` on `@objectstack/spec`, not `skip-changeset` — following what comparable message corrections in published packages did (`automation-toggle-deny-message.md`, a refusal-message fix; `approval-snapshot-docstring-audit-evidence.md`, a docstring-only correction that still shipped a patch because the docstring reaches consumers through the type declarations). Both sites here are in a published package and both are author-facing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5LFCYBJ3q2s6yW6oMLxwy)_