### PR TITLE
docs(rest,spec): qualify the ADR-0112 "producer names the condition" citations to the code axis

### DIFF
--- a/packages/rest/src/analytics-filter-refusal-envelope.test.ts
+++ b/packages/rest/src/analytics-filter-refusal-envelope.test.ts
@@ -444,7 +444,10 @@ describe('[#5352] reading the envelope did not turn every failure into a 400', (
   });
 
   it('a HALF envelope (4xx status, no code) is not honoured — this route invents no code', async () => {
-    // ADR-0112's point is that the PRODUCER names the condition. A status with
+    // ADR-0112 D4's point is the semantic-CODE channel: `error.code` is closed
+    // at every door and the producer's own spelling rides `declaredCode`
+    // beside it — the producer names the condition ON THE CODE AXIS. The ADR
+    // rules no HTTP status for an undeclared throw. A status with
     // no code is a producer bug; answering it with a code chosen here would be
     // the consumer-side leniency the ADR exists to remove, and would hide the
     // bug behind a plausible wire shape.

--- a/packages/rest/src/error-response.ts
+++ b/packages/rest/src/error-response.ts
@@ -391,8 +391,19 @@ function declaredHttpStatus(error: any): number | undefined {
  *    of `declaredCode` means demotion, exactly as `ApiErrorSchema.declaredCode`
  *    documents for the nested envelope.
  *  - the producer spelled NO string code → `{}`. Nothing is invented: ADR-0112
- *    says the PRODUCER names the condition, so a half-declaration is honoured
- *    for the half that was declared. That is the answer this file already gave
+ *    D4 governs the semantic-CODE channel — `error.code` closed at every door,
+ *    the producer's own spelling honoured beside it as `declaredCode` — so a
+ *    half-declaration is honoured for the half that was DECLARED.
+ *
+ *    ⚠️ Axis, stated once here because the other sites echo this file: the
+ *    ADR rules the CODE. It does not rule what HTTP status an undeclared
+ *    throw deserves, and "the PRODUCER names the condition" is this file's
+ *    own prose for the code rule — the sentence does not appear in
+ *    ADR-0112 and must not be cited as though it ruled the status axis.
+ *    Read unqualified it was taken for a status ruling once already, and
+ *    argued for a `500` on a contract question the ADR is silent on.
+ *
+ *    That is the answer this file already gave
  *    (see the 5xx arm of {@link mapDataError}) and it is deliberately preserved
  *    — narrowing the vocabulary must not start ADDING codes to bodies that
  *    carried none.
@@ -920,9 +931,14 @@ function classifyDataError(error: any, object?: string): { status: number; body:
         // empty string from landing on the wire as an ADR-0112 code.
         //
         // A 5xx with NO code passes its status through carrying no code at all,
-        // deliberately: ADR-0112 says the PRODUCER names the condition, so a
+        // deliberately: ADR-0112 D4 governs the semantic-CODE channel — the
+        // producer names the condition on the CODE axis (see the
+        // `resolveThrownHttpError` docblock above for why the phrase is this
+        // file's own prose and not an ADR quotation) — so a
         // half-declaration is honoured for the half that was declared and
-        // nothing is invented for the half that was not. That is the answer
+        // nothing is invented for the half that was not. The status half is
+        // kept on #5582/#7525's rule, not the ADR's: ADR-0112 rules no HTTP
+        // status here. That is the answer
         // `resolveErrorResponse` already gives the same shape
         // (`rest-5xx-message-sanitization.test.ts` §"a dynamically-assigned
         // status is treated identically"), and inventing `INTERNAL_ERROR` here

--- a/packages/rest/src/rest-5xx-message-sanitization.test.ts
+++ b/packages/rest/src/rest-5xx-message-sanitization.test.ts
@@ -379,8 +379,10 @@ describe('[#5437] the 5xx envelope: status and code survive, the prose does not'
 
         expect(res.statusCode).toBe(500);
         expect(res.body.error).toBe(INTERNAL_ERROR_MESSAGE);
-        // No `code` was declared, so none is invented here — ADR-0112 says the
-        // PRODUCER names the condition.
+        // No `code` was declared, so none is invented here — ADR-0112 D4
+        // governs the semantic-CODE channel (the producer names the condition
+        // on the CODE axis; the ADR rules no HTTP status for an undeclared
+        // throw).
         expect(res.body.code).toBeUndefined();
         expect(loggedText('does not exist')).toBe(true);
     }, 60_000);

--- a/packages/rest/src/rest-5xx-status-passthrough.test.ts
+++ b/packages/rest/src/rest-5xx-status-passthrough.test.ts
@@ -214,9 +214,12 @@ describe('[#5582] a 5xx that declares no code passes its status and invents noth
         // This is the exact shape the two pins this issue named were written
         // on, and the exact shape `resolveErrorResponse` already answers this
         // way ("a dynamically-assigned status is treated identically (no code
-        // declared)", `rest-5xx-message-sanitization.test.ts`): ADR-0112 says
-        // the PRODUCER names the condition, so the half that was declared is
-        // honoured and the half that was not is left empty. Inventing
+        // declared)", `rest-5xx-message-sanitization.test.ts`): ADR-0112 D4
+        // governs the semantic-CODE channel — the producer names the condition
+        // on the CODE axis — so the half that was declared is
+        // honoured and the half that was not is left empty. The 502 itself
+        // passes through on #5437/#5582's rule, NOT the ADR's: ADR-0112 rules
+        // no HTTP status for an undeclared throw. Inventing
         // `INTERNAL_ERROR` here would put a code on the wire nobody wrote —
         // and overwriting the 502 with a 500 would re-derive a declared status
         // from message text, which is what #5437 ruled against one door over.

--- a/packages/rest/src/rest-hook-refusal-code-parity.test.ts
+++ b/packages/rest/src/rest-hook-refusal-code-parity.test.ts
@@ -343,7 +343,9 @@ describe('[#10345] the sandbox unwrap is the branch, and it was never status-sha
 
 describe('[#10345] the pinned defaults the fix must not disturb', () => {
     it('a refusal that declares NO code still carries none — nothing is invented', () => {
-        // ADR-0112: the PRODUCER names the condition. Narrowing or widening the
+        // ADR-0112 D4 governs the semantic-CODE channel — the producer names
+        // the condition on the CODE axis, and the ADR rules no HTTP status for
+        // an undeclared throw. Narrowing or widening the
         // vocabulary must never start ADDING codes to bodies that carried none.
         const r = mapDataError(sandboxRefusal('month-end close is in progress'), 'crm_account');
         expect(r.status).toBe(400);

--- a/packages/rest/src/rest-hook-refusal-status-passthrough.test.ts
+++ b/packages/rest/src/rest-hook-refusal-status-passthrough.test.ts
@@ -380,9 +380,18 @@ describe('[#7525] a hook that refuses WITHOUT a status is unchanged', () => {
 
         expect(r.status).toBe(500);
         expect(r.body.code).toBe('INTERNAL_ERROR');
-        // Its own `code` is NOT promoted to the wire by this fix: ADR-0112 says
-        // the producer names the condition, and this producer named a code but
-        // no status. Inventing a 4xx from the code alone would be the
+        // Its own `code` is NOT promoted to the wire by this fix: ADR-0112 D4
+        // governs the semantic-CODE channel — the producer names the condition
+        // on the CODE axis — and this producer named a code but
+        // no status.
+        //
+        // ⚠️ Do not read the 500 above as an ADR-0112 ruling. It is the
+        // classifiers' default (#7525); ADR-0112 rules no HTTP status for an
+        // undeclared throw. The unqualified form of this sentence was read as
+        // ruling exactly that, and argued for a `500` on the sibling
+        // `/analytics/dataset/query` question the ADR is silent on.
+        //
+        // Inventing a 4xx from the code alone would be the
         // consumer-side leniency Prime Directive #12 removes — the follow-up
         // that belongs with #7463, not here.
         expect(r.body.code).not.toBe('CLOSE_PERIOD_LOCKED');

--- a/packages/rest/src/rest-thrown-code-vocabulary.test.ts
+++ b/packages/rest/src/rest-thrown-code-vocabulary.test.ts
@@ -250,7 +250,9 @@ describe('#9232 §3 — the halves that must not move', () => {
             expect(status).toBe(arm.status);
             expect(body.code).toBeUndefined();
             expect(body.declaredCode).toBeUndefined();
-            // ADR-0112 says the PRODUCER names the condition, so a
+            // ADR-0112 D4 governs the semantic-CODE channel — the producer
+            // names the condition on the CODE axis, and the ADR rules no HTTP
+            // status for an undeclared throw — so a
             // half-declaration is honoured for the half that was declared.
             // Narrowing the vocabulary must not start ADDING codes to bodies
             // that carried none.

--- a/packages/spec/src/shared/external-errors.ts
+++ b/packages/spec/src/shared/external-errors.ts
@@ -44,8 +44,13 @@ export type ExternalErrorCode =
  *
  * ## Why HERE and not in a REST error map
  *
- * ADR-0112: the PRODUCER names the condition. This repo's HTTP exits already
- * agree on how to read one — `status` then `statusCode`, 400-599 — in
+ * The producer that knows the condition declares its own wire shape. For the
+ * STATUS half — which is what this table decides — that is this repo's
+ * convergent HTTP-exit convention, NOT an ADR-0112 ruling: ADR-0112 governs
+ * the semantic-CODE channel (cited correctly above for the ledgered `code`,
+ * D3) and rules no HTTP status for a throw. This repo's HTTP exits already
+ * agree on how to read a declared status — `status` then `statusCode`,
+ * 400-599 — in
  * `mapDataError`'s `declaredHttpStatus` (#7525), `resolveErrorResponse`
  * (#5437/#5582), `HttpDispatcher.errorFromThrown` (#3867),
  * `dispatcher-plugin.errorResponseBase`, `endpoint-executor`,


### PR DESCRIPTION
Fixes #11735

Nine in-repo sites cite the sentence **"the producer names the condition"** as an unqualified principle of ADR-0112. The ADR does not contain the sentence, and does not rule the axis the unqualified form was read on. Each site now names the axis.

## What was measured, on `origin/main` at `8515954fb`

**The card's zero-hit reproduces exactly, both halves.** Re-run rather than inherited:

```
git grep -n -iE "producer names|names the condition" origin/main -- docs/adr/0112-error-code-vocabulary-and-ledger.md   -> 0 hits
git grep -n -iE "producer names|names the condition" origin/main -- docs/adr/                                          -> 0 hits
```

Reverse-check on the same file, terms taken from the ADR's own subject rather than from the phrase under test: `declaredCode` 7, `vocabulary` 22, `ledger` 16. The instrument produces positives over that file; the phrase is absent.

**The substance reading holds, checked directly against the ADR.** D1-D9 (plus D6b, D6c and five amendments) every one rule the semantic **code**: D2 renames the closed `StandardErrorCode` catalog, D3 registers service codes in the ledger, D4 closes `ApiErrorSchema.code` and opens `declaredCode` beside it, D5 fixes one eventual location for the semantic code. HTTP status appears only as *what a code derives from* ("`error.code` carries the member the HTTP status derives", maintainer rulings 2026-08-16 / 2026-08-17) and *what lives on the transport* (D5). **Nothing in ADR-0112 rules what HTTP status an undeclared throw deserves.**

## The premise fork resolved toward the ruled remedy, and there is a landed sibling that already says so

Triage's binding condition was to stop and report if the status-axis reading turned out to be a real ruling from somewhere. It is not:

- Zero hits across `docs/adr/` for `producer names` / `producer that knows` / `producer declares` / `one condition, one wire shape` / `producer-declared`.
- Zero hits for `declaredHttpStatus` anywhere under `docs/`.
- No ADR, maintainer ruling or governed doc places the sentence on the status axis.

More decisively, `packages/rest/src/rest-hook-refusal-message-parity.test.ts:630` — landed 2026-08-25 in #12280, **after** this card was filed — already carries the ruled qualification and reaches the same conclusion independently:

> "ADR-0112's 'the producer names the condition' is a rule about the `code`, not the status. Read D1-D9 and its five amendments: every one of them rules on the code vocabulary, its closure, and the `declaredCode` demote channel. The phrase this reading is built on is not in the ADR at all — it is `error-response.ts`'s own prose."

It also names what *does* rule the status: the `/data` door's structural branch (`declaredHttpStatus(error) ?? 400`) with two end-to-end pins behind it. This PR aligns the remaining sites with that already-landed reading rather than inventing a second formulation.

## The census is not nine

Measured independently and **not** reconciled with the card's table. The card's own re-check command returns **11** on today's `origin/main`, and the wrapped-phrase form returns **13** citation sites. All nine of the card's files are still present; two line numbers moved (`error-response.ts` 871 to 923, `analytics-filter-refusal-envelope.test.ts` 405 to 447).

Four sites are **outside the declared file surface** and are therefore untouched here:

| site | state | why untouched |
|---|---|---|
| `packages/rest/src/rest-server.ts:9646` | unqualified | **FENCED** by PR #12421 (#11926) |
| `packages/rest/src/rest-sandbox-declared-status.test.ts:130` | unqualified | outside the declared surface |
| `packages/rest/src/rest.test.ts:2422` | unqualified | outside the declared surface |
| `packages/rest/src/rest-hook-refusal-message-parity.test.ts:630` | **already qualified** | no work needed; it is the canonical form |

So two sites plus the fenced one still carry the unqualified citation after this PR. Reported for the PM to route rather than absorbed silently — the surface was declared closed and "stop on breach and explain" applies.

## `packages/spec/src/shared/external-errors.ts:47` is making a DIFFERENT claim

The card flagged this site as unexamined. Read on its own terms, it is not one of the eight: the other eight all say "no code was declared, so none is invented" — squarely the code axis. This one sits under the heading **"Why HERE and not in a REST error map"** and cites ADR-0112 to justify **declaring the HTTP status on the error at the producer**. That is the status axis, and it is the one place where the ruled remedy could not be applied verbatim: qualifying it to the code axis would have made the sentence a non-sequitur in its own paragraph.

It is corrected on its own terms instead. The paragraph's argument is preserved and its real warrant named — this repo's convergent HTTP-exit convention (`status` then `statusCode`, 400-599, the exits the docblock already enumerates) rather than an ADR-0112 ruling. Note the same file already cites ADR-0112 D3 **correctly**, two paragraphs above, for the ledgered `code`; that citation is untouched.

Nothing else in `packages/spec` is touched: no schema, no key, no describe-text, no shape.

## Why this is worth more than a comment tidy

The unqualified form was read as governing status and nearly settled a contract question the wrong way: #11684 named it as the argument for `500` on `/analytics/dataset/query`, and PR #11731 carried a binding stop that would have landed nothing had both readings had live pins. It survived only because a dev measured that the ADR does not say it. Same class as #11032.

`rest-hook-refusal-status-passthrough.test.ts` is the site nearest that misreading — a status-passthrough test whose comment could be read as ADR-0112 ruling the 500 — so it now says explicitly that the 500 is the classifiers' default (#7525), not an ADR-0112 ruling.

## The card's other unmeasured question, answered

Whether any *other* principle is attributed to ADR-0112 in the same unqualified way: **no.** The only other principle-style attribution in the tree is `packages/metadata-protocol/src/protocol.legacy-overlay-delete.test.ts:405`, and it is already correctly scoped ("the catalog governs `error.code`"). The widespread "ADR-0112 envelope (`code` + `status`)" idiom (50+ sites) is a different usage — it names the wire envelope as an assertion contract, not a principle about who names what — and is the form the repo's own agent contract prescribes for rejection tests. Not a defect; measured and left alone.

## Scope

Comment text only. Zero behaviour change, zero assertion changes, no schema, no key, no validity boundary. `docs/adr/**` untouched — the ADR amendment remains a maintainer-merge path and is explicitly out of scope; nothing here is written as though the ADR were about to change, and the correction holds under either outcome of that open question, which is why it forecloses nothing.

## Verification

All runs below are on the final commit `a17b6b649`, working tree clean at measurement time.

Gate families re-derived in this worktree from the actual changed files — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which derives its own change set from the merge base (8 paths vs `8515954fb`) and reported 22 matched families.

| check | verdict line |
|---|---|
| `pnpm lint` (full repo, `eslint . --no-inline-config`) | exit 0 — **5195 files linted, 0 errors, 0 warnings** (population read from ESLint's own config; no narrowing claimed) |
| `pnpm check:nul-bytes` | `OK (scanned 6888 text file(s) ... no raw ASCII control bytes)` |
| `pnpm check:route-envelope` | `4 module(s) discovered and audited ... 2 conformant, 2 ratcheted` (pre-existing ratchets, unmoved) |
| `pnpm check:dispatcher-error-vocabulary` | `OK — 21 unregistered code-stamping site(s), all classified` |
| `pnpm check:test-source-alias` | `OK — 72 packages with tests scanned` |
| `pnpm check:cross-package-test-inputs` | `OK: 18 package(s) read outside themselves, all declared` |
| `check-comment-mask-adoption.mjs` | `OK — 23 private comment-stripper(s) ... all 23 recorded` |
| `pnpm check:engine-double-contract` | exit 0, `398 (file, verb) row(s) held by the RETAINED ledger` |
| `pnpm check:where-matcher` | `conformance holds: 303 matcher(s) ... none new` |
| `pnpm check:query-options-erasure` | `ratchet holds ... none new` |
| `@objectstack/spec` `typecheck` | exit 0, all three legs echoed; `test layer compiles ... 263 error(s) held` (unmoved) |
| `@objectstack/spec` `check:liveness` / `check:empty-state` / `check:variant-docs` | all exit 0 |
| 6 edited `@objectstack/rest` test files | **Test Files 6 passed (6), Tests 151 passed (151)** |

Build closure first, as a new worktree requires: `turbo run build --filter='@objectstack/rest...' --filter='@objectstack/spec...'` — 25/25 tasks successful. Every heavy run went through `scripts/pm/os-verify-lock.sh`; exit codes were captured before any pipe, and each row above quotes the gate's own verdict line rather than a shell `$?`.

**One NOT MEASURED, stated rather than papered over:** `@objectstack/rest`'s `tsc --noEmit` program **excludes `*.test.ts`** — verified with `--listFiles`, which returns 0 hits for each of the six edited test files and 1 for `error-response.ts`. So the rest typecheck is a real green over the one edited source file and says nothing about the six test files; those are measured by the vitest run instead, not by typecheck.

No changeset: comment text only, nothing user-visible to publish. `skip-changeset` could **not** be applied from the dev seat — `api.github.com` returns `GitHub access is not enabled for this session`, and `gh` is not installed, so the label needs applying by the PM.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_