### PR TITLE
docs(cli): point remaining filePatterns sites at metadata-file-name.ts

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -199,9 +199,10 @@ export default ${toCamelCase(name)}App;
      *
      * That reasoning was scoped to `skill` on the belief that the other six
      * types were not filesystem-discovered. #11071 measured the loader
-     * instead: `MetadataPlugin._loadFromFileSystem` globs EVERY registry entry
-     * by its own `filePatterns`, so all seven wrote into the same
-     * invisibility. The override is gone and the rule is the harness default.
+     * instead — the mechanism, and the precondition that keeps it from
+     * firing in this repo today, are stated once in `metadata-file-name.ts`
+     * (#12075), not restated here. The override is gone and the rule is the
+     * harness default.
      */
     generate: (name: string) => `import { defineSkill } from '@objectstack/spec/ai';
 

--- a/packages/cli/test/generate-skill.e2e.test.ts
+++ b/packages/cli/test/generate-skill.e2e.test.ts
@@ -9,11 +9,11 @@
  * A test asserting only that the command created something passes just as
  * happily when the filename matches no `filePatterns` entry — which IS the
  * defect. `DEFAULT_METADATA_TYPE_REGISTRY` declares `skill`'s file
- * convention as `*.skill.ts` / `*.skill.yml`;
- * `MetadataPlugin._loadFromFileSystem` globs each type by its own
- * `filePatterns`, `MetadataManager.getTypeInfo` publishes them to every
- * type-descriptor consumer, and `skill` is `allowRuntimeCreate: true` — a
- * type the platform expects to discover. The harness's own convention is
+ * convention as `*.skill.ts` / `*.skill.yml` — the loader mechanism behind
+ * that convention, and the precondition that keeps this repo from meeting
+ * it today, are stated once in `metadata-file-name.ts` (#12075), not
+ * restated here. `skill` is `allowRuntimeCreate: true` — a type the
+ * platform expects to discover. The harness's own convention is
  * `NAME.ts`, so a naive skill scaffold lands as `lead_qualification.ts`,
  * matches neither pattern, and then type-checks, validates and publishes with
  * nothing anywhere saying it was skipped. That is the silent-strip shape
@@ -45,10 +45,11 @@
  * `os g object` is exercised here as a CONTROL, and what it controls for
  * changed. #11025 scoped the filename fix to `skill` and fenced the repo-wide
  * route, so the control pinned `customer.ts` and a `'./customer'` barrel line.
- * #11071 measured the loader rather than assuming: `_loadFromFileSystem` globs
- * every registry entry by its own `filePatterns`, so all seven generators wrote
- * into the same invisibility, and the per-generator override was replaced by a
- * default derived from the registry. The control now pins the OTHER side of
+ * #11071 measured the loader rather than assuming — the mechanism, and the
+ * precondition that keeps it from firing in this repo today, are stated once
+ * in `metadata-file-name.ts` (#12075), not restated here — and the
+ * per-generator override was replaced by a default derived from the
+ * registry. The control now pins the OTHER side of
  * that: `os g object` writes a name the `object` entry's own patterns match,
  * proving the derivation is wired into the real command and not just unit-true.
  *


### PR DESCRIPTION
Fixes #12163

## What changed

Two comments in `packages/cli` still restated the `MetadataPlugin._loadFromFileSystem` glob-discovery mechanism without the eager + no-`artifactSource` precondition that #12075 already stated at three sibling sites in this same package. Per the ruling on #12163 ([comment](https://github.com/objectstack-ai/objectstack/issues/12163#issuecomment-5420260141)), both sites now point at `packages/cli/src/utils/metadata-file-name.ts` (#12075) instead of restating the mechanism inline:

- `packages/cli/src/commands/generate.ts` — the `skill` generator's template comment (the sentence that used to read "`MetadataPlugin._loadFromFileSystem` globs EVERY registry entry by its own `filePatterns`, so all seven wrote into the same invisibility").
- `packages/cli/test/generate-skill.e2e.test.ts` — both sites (the "Why 'it writes a file' is the wrong assertion" section, and the `#11071` "control this file also holds" section).

The historical narrative each comment carries — why the #11025 per-generator override was retired — is unchanged; only the unqualified mechanism sentence at each site is replaced by the pointer. `#12075` is the parent measurement and is not re-addressed here.

Comment text only. Zero behavior change, zero assertion changes.

## Verification

- `pnpm --filter '@objectstack/cli^...' build` — exit 0 (dependency closure)
- `pnpm --filter @objectstack/cli build` — exit 0
- `pnpm --filter @objectstack/cli typecheck` — exit 0 (`tsc --noEmit`)
- `pnpm --filter @objectstack/cli exec vitest run test/generate-skill.e2e.test.ts test/generate-file-name-registry-parity.test.ts` — 2 files, 50 tests passed
- Targeted `eslint packages/cli/src/commands/generate.ts packages/cli/test/generate-skill.e2e.test.ts --no-inline-config --format json` — 0 errors, 0 warnings (2 files, per JSON output)
- `node scripts/check-nul-bytes.mjs` — OK
- Local gate families re-derived on this diff via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (merge-base `424f73c36`) — every matched + convention-triggered family run and green: `check:cli-test-child-env`, `check:cross-package-test-inputs`, `check:i18n`, `check:page-declaration-shape`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check-comment-mask-adoption.mjs`, `check-plugin-teardown-shape.mjs`, `check-ci-filter-parity.mjs`, `check-affected-docs.mjs` (self-test), `check-drift-comment.mjs` (self-test).
- `check:i18n-coverage` and `check:type-check-debt --re-measure` came back NOT MEASURED — this fresh worktree is missing built `dist/` for `@objectstack/connector-mcp` and `@objectstack/service-knowledge` respectively (pre-existing prerequisite gap, unrelated to this diff); CI builds fresh so both measure there.
- head at push time: `b13357ae7`

skip-changeset: comment text only, nothing user-visible to publish.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_