### PR TITLE
fix(turbo): repoint the inert `test:e2e` task at the smoke suite that exists, and judge generic task keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:todo": "node scripts/check-dev-prereqs.mjs && pnpm check:console-sha && pnpm --filter @objectstack/example-todo dev",
     "spec:rebuild": "turbo run build --filter=...@objectstack/spec",
     "test": "VITEST_MAX_WORKERS=$(node scripts/vitest-worker-cap.mjs) turbo run test --concurrency=50%",
-    "test:e2e": "turbo run test:e2e",
+    "test:smoke": "turbo run test:smoke",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf dist",
     "setup": "pnpm install && pnpm --filter @objectstack/spec build",

--- a/scripts/check-turbo-task-graph.mjs
+++ b/scripts/check-turbo-task-graph.mjs
@@ -72,18 +72,38 @@
  * `check:pm-governed-prose`, `check:required-contexts` and five others already
  * take for `AGENTS.md/**`. After it, a turbo.json edit derives this family.
  *
- * ## What this gate deliberately does NOT judge, stated rather than discovered
+ * ## GENERIC task keys, and the near miss that reads as a refutation (#12373)
  *
- * GENERIC task keys -- the ones with no `#`, like `build` or `test:e2e` -- are
- * out of population. The invariant is the same shape ("a task nothing can run
- * is inert"), and on the tree this landed against it has a live violation:
- * `test:e2e` is defined here with `outputs: ["playwright-report/**", ...]` and
- * is held by ZERO of the 78 workspace packages -- the real Playwright script in
- * `examples/app-showcase` is spelled `test:smoke`, which turbo.json does not
- * configure at all. Closing that needs an edit to `turbo.json`, which is not
- * this card's file surface, and a gate that ships red is worse than no gate.
- * Filed as #12373; widen this gate's population to generic keys in the same
- * change that fixes that entry, not before.
+ * GENERIC keys -- the ones with no `#`, like `build` or `test:smoke` -- are in
+ * population as of #12373, under the same invariant one level up: a generic key
+ * no workspace package declares a script for configures a task that can never
+ * run. Turbo is silent about it in the same way, and the silence is worse here
+ * because it reaches a human directly: the root `package.json` wraps these keys
+ * as `turbo run <task>`, so an inert one is a command that exits 0 having run
+ * nothing, handed around as evidence a suite passed (#4690's family).
+ *
+ * That is not hypothetical, it is the entry this limb was written for. Measured
+ * from git: `test:e2e` entered turbo.json on 2026-05-21 (7972e7b829) when
+ * `examples/app-crm` declared `"test:e2e": "playwright test"` beside an `e2e/`
+ * directory and a `playwright.config.ts`. On 2026-05-24, `e737fbce39`
+ * ("simplify app-crm to minimal metadata smoke-test") deleted that script. The
+ * turbo entry stayed, and for the three months to 2026-08-26 it configured a
+ * task no package could run, while `pnpm test:e2e` kept exiting 0.
+ *
+ * ⚠️ The ROOT manifest is not a workspace member and does not make a generic key
+ * live -- and counting it is the mistake that reads as a refutation of the
+ * finding rather than as a different measurement. `test:e2e` was held by ONE
+ * file (the root `package.json`) and by ZERO of the 78 members, and only the
+ * second number decides whether `turbo run test:e2e` matches anything. The
+ * failure text below says so where it will be read.
+ *
+ * A generic key that exists only as a `dependsOn` target is judged the same, on
+ * purpose. Measured on the tree this limb landed against: the only `dependsOn`
+ * targets in the whole file are `build` and `^build`, and `build` is declared by
+ * 72 of the 78 members -- so no such key exists here to exempt. Nor should one
+ * be exempt if it appears: turbo resolves `dependsOn` against the DEFINITION, so
+ * a dependency on a generic task no package declares still runs nothing, and the
+ * exemption would be a hole shaped exactly like the entry above.
  *
  * ## Refusals, never quiet passes (#4690)
  *
@@ -192,19 +212,62 @@ export function editDistanceWithin(a, b, max) {
 }
 
 /**
+ * Every workspace package declaring a script called `task`, sorted.
+ *
+ * This is the whole of what a GENERIC key is judged against, and the membership
+ * it reads is the enumerator's -- so the root manifest, which is not a member,
+ * cannot make a key look held. See the header for why that distinction is the
+ * one this limb is most likely to be argued out of.
+ *
+ * @param {string} task
+ * @param {Map<string, Set<string>>} scriptsByPackage
+ * @returns {string[]}
+ */
+export function holdersOf(task, scriptsByPackage) {
+  const holders = [];
+  for (const [pkg, scripts] of scriptsByPackage) if (scripts.has(task)) holders.push(pkg);
+  return holders.sort();
+}
+
+/**
  * The rule, as a pure function over already-parsed inputs, so `--self-test` can
  * drive it with the adversarial task tables a clean tree does not contain.
  *
+ * The two populations are counted separately and BOTH are returned: a limb that
+ * quietly stops matching reports zero findings exactly like a limb that found
+ * nothing wrong, so `main()` needs each count to assert it read something.
+ *
  * @param {Record<string, unknown>} tasks turbo.json's `tasks` table
  * @param {Map<string, Set<string>>} scriptsByPackage package name -> script names
- * @returns {{ problems: string[], judged: number }}
+ * @returns {{ problems: string[], judged: number, genericJudged: number }}
  */
 export function verdict(tasks, scriptsByPackage) {
   const problems = [];
   let judged = 0;
+  let genericJudged = 0;
   for (const key of Object.keys(tasks)) {
     const split = splitTaskKey(key);
-    if (!split) continue;
+    if (!split) {
+      genericJudged += 1;
+      if (holdersOf(key, scriptsByPackage).length === 0) {
+        const declaredAnywhere = new Set();
+        for (const scripts of scriptsByPackage.values()) for (const name of scripts) declaredAnywhere.add(name);
+        const near = nearestNames(key, declaredAnywhere);
+        problems.push(
+          `"${key}" is a generic task that NO workspace package declares a script for.\n` +
+            `    Turbo is silent about this too: a run matches nothing and exits 0, so the root\n` +
+            `    script that wraps it ("turbo run ${key}") is a command handed around as evidence\n` +
+            `    a suite passed while running nothing at all.\n` +
+            `    ⚠️ The ROOT package.json does NOT count and is the near miss that reads as a\n` +
+            `    refutation: it is not one of the ${scriptsByPackage.size} workspace members this gate\n` +
+            `    enumerates, so a script there leaves the key held by zero of them and just as inert.\n` +
+            (near.length ? `    Did you mean: ${near.join(', ')}?\n` : '') +
+            `    Rename the key to the script the workspace declares, add that script to the\n` +
+            `    package that should run it, or delete the entry.`,
+        );
+      }
+      continue;
+    }
     judged += 1;
     const { pkg, task } = split;
     const scripts = scriptsByPackage.get(pkg);
@@ -238,7 +301,7 @@ export function verdict(tasks, scriptsByPackage) {
       );
     }
   }
-  return { problems, judged };
+  return { problems, judged, genericJudged };
 }
 
 /**
@@ -313,7 +376,19 @@ function main() {
     throw err;
   }
 
-  const { problems, judged } = verdict(tasks, scriptsByPackage);
+  const { problems, judged, genericJudged } = verdict(tasks, scriptsByPackage);
+
+  if (genericJudged === 0) {
+    console.error(
+      `FAIL: ${TURBO_CONFIG_FILE} declares no generic (\`#\`-less) task key at all, so half of\n` +
+        `  this gate's population is empty. That is not a clean tree: the root package.json\n` +
+        `  wraps \`build\`, \`test\` and \`typecheck\` as \`turbo run <task>\`, and each of those is a\n` +
+        `  generic key in this table. Zero of them means this gate read the wrong file, or\n` +
+        `  splitTaskKey stopped classifying a \`#\`-less key as generic — never that a table\n` +
+        `  with nothing generic in it was found.`,
+    );
+    process.exit(1);
+  }
 
   if (judged === 0) {
     console.error(
@@ -326,13 +401,17 @@ function main() {
   }
 
   if (problems.length) {
-    console.error(`FAIL: ${TURBO_CONFIG_FILE} carries ${problems.length} inert task override(s).\n`);
+    console.error(
+      `FAIL: ${TURBO_CONFIG_FILE} carries ${problems.length} inert task entr${problems.length === 1 ? 'y' : 'ies'}.\n`,
+    );
     for (const p of problems) console.error(`  - ${p}\n`);
     console.error(
-      'Why this gate exists: turbo does NOT refuse either of these. A task key naming a\n' +
-        'package that does not exist, or a task the package has no script for, exits 0 with\n' +
-        'no diagnostic and configures nothing — so the edit that was meant to change what CI\n' +
-        'builds, orders or caches reads as landed while doing nothing at all (#12046).\n' +
+      'Why this gate exists: turbo does NOT refuse any of these. A task key naming a\n' +
+        'package that does not exist, a task the package has no script for, or a generic key\n' +
+        'no package declares at all, exits 0 with no diagnostic and configures nothing — so\n' +
+        'the edit that was meant to change what CI builds, orders or caches reads as landed\n' +
+        'while doing nothing at all (#12046), and a root script wrapping the generic key\n' +
+        'reads as a suite that passed (#12373).\n' +
         '\n' +
         '⛔ `dependsOn` is deliberately NOT checked here: turbo already refuses an\n' +
         'unresolvable one, loudly, with exit 1. Re-checking it would be this gate claiming a\n' +
@@ -342,8 +421,10 @@ function main() {
   }
 
   console.log(
-    `OK: ${judged} package-scoped turbo task(s) judged against ${scriptsByPackage.size} workspace ` +
-      `package(s) — every one names a package that exists and a script it declares.`,
+    `OK: ${judged} package-scoped and ${genericJudged} generic turbo task(s) judged against ` +
+      `${scriptsByPackage.size} workspace package(s) — every package-scoped one names a package ` +
+      `that exists and a script it declares, and every generic one is declared by at least one ` +
+      `member.`,
   );
 }
 
@@ -390,11 +471,38 @@ export function selfTest() {
   t('a length gap wider than the cap is refused before any work', !editDistanceWithin('a', 'abcd', 2));
   t('no near name yields no suggestion', nearestNames('@acme/nothing-like-it', workspace.keys()).length === 0);
 
+  // ── The generic limb (#12373), both directions ──
+  // The red case is the entry this limb was written for, spelled as it stood on
+  // 2026-08-26: a key every signal calls fine, held by nobody who could run it.
+  const inertGeneric = verdict({ 'test:e2e': {} }, workspace);
+  t('a generic task no package declares is a finding', inertGeneric.problems.length === 1);
+  t('the inert generic key is counted in the generic population', inertGeneric.genericJudged === 1);
+  t('the inert generic key is NOT counted as a package task', inertGeneric.judged === 0);
+  // Pinned as text because this sentence is the whole defence of the measurement:
+  // the root manifest holds `test:e2e` and is not a member, and a reader who
+  // counts files instead of members reads the finding as already refuted.
+  t(
+    'the inert generic finding rules out the root manifest by name',
+    inertGeneric.problems[0]?.includes('ROOT package.json does NOT count'),
+  );
+  const nearGeneric = verdict({ typechek: {} }, workspace);
+  t('a misspelled generic key is a finding', nearGeneric.problems.length === 1);
+  t('a misspelled generic key suggests the script that exists', nearGeneric.problems[0]?.includes('typecheck'));
+
+  t(
+    'holdersOf names every package declaring the script',
+    holdersOf('build', workspace).join(',') === '@objectstack/plugin-auth,@objectstack/spec,create-objectstack',
+  );
+  t('holdersOf is empty for a script no package declares', holdersOf('test:e2e', workspace).length === 0);
+
   // ── Direction 2: the rule must stay GREEN on every legitimate shape ──
+  // `gen:schema` stands where `test:e2e` used to: a generic key held by exactly
+  // ONE package is legitimate, and this case is what keeps the limb above from
+  // being satisfiable by "generic keys must be held by many".
   const clean = verdict(
     {
       build: {},
-      'test:e2e': {},
+      'gen:schema': {},
       '@objectstack/plugin-auth#typecheck': {},
       '@objectstack/spec#gen:schema': {},
       'create-objectstack#test': {},
@@ -402,7 +510,8 @@ export function selfTest() {
     workspace,
   );
   t('legitimate package tasks are green', clean.problems.length === 0);
-  t('generic keys are out of population and not judged', clean.judged === 3);
+  t('package-scoped keys are counted separately', clean.judged === 3);
+  t('generic keys are in population and counted', clean.genericJudged === 2);
 
   // Parsing, pinned directly: every real key in this repo's turbo.json is one
   // of these three shapes, and a boundary taken anywhere but the FIRST `#`
@@ -435,6 +544,7 @@ export function selfTest() {
   try {
     const live = verdict(readTasks(ROOT), readWorkspaceScripts(ROOT));
     t('the live turbo.json presents package tasks to judge', live.judged > 0);
+    t('the live turbo.json presents generic tasks to judge', live.genericJudged > 0);
   } catch (err) {
     failures.push(`the live tree could not be read: ${err.message}`);
   }

--- a/turbo.json
+++ b/turbo.json
@@ -320,10 +320,10 @@
         "$TURBO_ROOT$/packages/cli/src/commands/init.ts"
       ]
     },
-    "test:e2e": {
+    "test:smoke": {
       "dependsOn": ["build"],
       "cache": false,
-      "outputs": ["playwright-report/**", "test-results/**"],
+      "outputs": ["test-results/**"],
       "inputs": ["src/**", "e2e/**", "playwright.config.ts"]
     },
     "dev": {


### PR DESCRIPTION
Fixes #12373

`turbo.json` configured a `test:e2e` task that **no workspace package could run**, while the Playwright suite that does exist ran with no turbo configuration at all. This repoints the entry onto the suite that exists, and — in the same change, as the gate's header requires — widens `check:turbo-task-graph`'s population to generic task keys so the shape cannot come back silently.

Both halves or neither: `check-turbo-task-graph.mjs`'s header states the sequencing, *"a gate that ships red is worse than no gate."*

## What `test:e2e` was meant to configure — established, not assumed

The dispatch ruling forbids "fixing" the entry by deleting it if the intent was real. It was real, and git says exactly what it was:

| when | commit | what happened |
| --- | --- | --- |
| 2026-05-21 | `7972e7b829` | `test:e2e` enters `turbo.json` — at that time `examples/app-crm` declared `"test:e2e": "playwright test"` beside an `e2e/` directory and a `playwright.config.ts` |
| 2026-05-24 | `e737fbce39` | *"simplify app-crm to minimal metadata smoke-test"* deletes that script ("Driver E2E tests previously hosted here are removed") |
| → 2026-08-26 | — | the turbo entry stays, configuring a task no package can run, for three months |

So the entry is **residue of a deleted script**, and its intent — configure the repo's Playwright suite — is still live. The repo's only Playwright suite today is `examples/app-showcase`, declared as `test:smoke`.

### Why the task key moves and not the script name

The card offered both readings. `test:smoke` has four live callers and `test:e2e` has zero:

```
.github/workflows/showcase-smoke.yml:75            run: pnpm test:smoke
docs/qa/platform-checklist/areas/platform-core.json:236,248
docs/qa/platform-checklist/areas/records-forms.json:531
examples/app-showcase/vitest.config.ts:7           (prose)
```

Renaming the *script* would break a CI workflow and the checklist/dogfood tooling, and would land in four files outside this card's surface. Renaming the *task key* touches the two files that carry the mistake. The loser loses on caller count, not on taste.

## The entry, before and after — measured through `turbo run --dry=json` (turbo 2.10.10)

**Before** — the silent green this card is filed against:

```
$ pnpm exec turbo run test:e2e --dry=json
EXIT=0
test:e2e tasks placed in the graph: 78
...of which have a REAL command  : 0
```

**After** — one real command, the suite that exists:

```
$ pnpm exec turbo run test:smoke --dry=json
test:smoke tasks WITH a real command: 1   -> @objectstack/example-showcase#test:smoke
  command : playwright test --config=playwright.config.ts
  outputs : ['test-results/**']
  cache   : {"local": false, "remote": false}
  deps    : ['@objectstack/example-showcase#build']
  inputs  : 108 files; sample: ['e2e/.gitignore', 'e2e/bulk-capability-gate.spec.ts',
             'e2e/detail-shapes.spec.ts', 'e2e/global-setup.ts',
             'e2e/showcase-smoke.spec.ts', 'package.json']
```

### `inputs` revisited, as the triage asked — and the card's claim about them is FALSIFIED

> `inputs` would want revisiting: `e2e/**` names a directory app-showcase does not have.

It does have one. `examples/app-showcase/e2e/` is tracked on `origin/main` with four files, and `playwright.config.ts` declares `testDir: './e2e'`. All three globs — `src/**`, `e2e/**`, `playwright.config.ts` — resolve in that package; the dry run above hashes 108 real files through them. They are left as they stand because they are correct, which is the outcome of revisiting them, not a skipped step.

`dependsOn: ["build"]` is kept as the card names it. Note for the record: `showcase-smoke.yml` builds only the closure (`--filter=@objectstack/example-showcase^...`), so `["build"]` is a superset — deliberately kept, since a superset cannot under-build.

### One glob dropped: `playwright-report/**`

`outputs` loses `playwright-report/**` and keeps `test-results/**`. The measurement is already in this repo, in `showcase-smoke.yml`'s own comment: the CI reporter is `[['github'], ['list']]` and the local one `[['list']]` — both stdout-only, so the HTML reporter's directory is never created. That comment carries the receipt (run 30796529117, 2026-08-03: *"No files were found with the provided path: examples/app-showcase/playwright-report/"*). `test-results/**` is Playwright's default `outputDir` and is real. Correcting a task name while leaving a glob measured never to exist would be inconsistent with the very rule this PR enforces.

## Added file surface: the root `package.json` script row

Declared surface was `turbo.json` + `scripts/check-turbo-task-graph.mjs`. The root script row is added, under the bounded in-place exemption, with the reasoning and the four conditions posted on the card as a claim amendment. The measurement that forces it:

```
$ pnpm exec turbo run test:e2e --dry=json     # after the rename lands in turbo.json
EXIT=1
  x Missing tasks in project
  `->   x Could not find task `test:e2e` in project
```

Leaving `"test:e2e": "turbo run test:e2e"` behind does not preserve the status quo — it converts this card's silent exit-0 no-op into a hard exit-1 error. `pnpm check:pnpm-filter-targets`, the family that reads root scripts, is green on the result.

## The gate: generic keys are now judged

`verdict()` no longer `continue`s past a `#`-less key. A generic key must be declared as a script by at least one **workspace member**, counted through `scripts/workspace-enumerator.mjs`.

**The root manifest does not count, and the failure text says so where it will be read.** That is the near miss the dispatch recorded: `test:e2e` was held by exactly one *file* (the root `package.json`) and by zero of the 78 *members*, and only the second number decides whether `turbo run test:e2e` matches anything. Counting files instead of members reads the finding as already refuted. The sentence is pinned as text in `--self-test`, because a reword is invisible in every other signal the gate emits.

**A `dependsOn`-only generic key is judged the same, on purpose.** The dispatch asked for this to be measured rather than assumed. Measured on this tree: the only `dependsOn` targets in the whole file are `build` and `^build`, and `build` is declared by 72 of 78 members — so no such key exists here to exempt. Nor should one be exempt if it appears: turbo resolves `dependsOn` against the *definition*, so a dependency on a generic task no package declares still runs nothing, and the exemption would be a hole shaped exactly like the entry this PR removes.

A second non-vacuity floor is added beside the existing one: zero generic keys in the table now refuses, since the root manifest wraps `build` / `test` / `typecheck` as `turbo run` invocations, and those are generic keys in this very table. A limb that stops matching would otherwise report zero findings exactly like a limb that found nothing wrong.

Holder counts on this tree, for the record:

```
build 72 · test 72 · typecheck 65 · dev 24 · clean 5
gen:schema 1 (@objectstack/spec) · gen:skill-refs 1 (@objectstack/spec)
test:smoke 1 (@objectstack/example-showcase)      <- was test:e2e, 0
```

`gen:schema` now stands in `--self-test` where `test:e2e` used to: a generic key held by exactly **one** package is legitimate, and that case is what keeps the new limb from being satisfiable by "generic keys must be held by many".

## Verification

`git rev-parse --short HEAD` = **`c246e4fcf6`** — every result below was produced at that commit, on a clean tree.

### Reverse verification — both legs, restored byte-identical under `trap … EXIT INT TERM`

Leg 1, the widened gate on the pre-fix `turbo.json` — **RED**, as expected:

```
on-disk confirmation: '"test:e2e"'=1 (expect 1)  '"test:smoke"'=0 (expect 0)
EXIT=1
FAIL: turbo.json carries 1 inert task entry.
  - "test:e2e" is a generic task that NO workspace package declares a script for.
    ...
    ⚠️ The ROOT package.json does NOT count and is the near miss that reads as a
    refutation: it is not one of the 78 workspace members this gate enumerates...
```

Leg 2, the **pre-widening** gate on that same pre-fix tree — **GREEN**, which is why the residue survived three months:

```
EXIT=0
OK: 21 package-scoped turbo task(s) judged against 78 workspace package(s) — every one
    names a package that exists and a script it declares.
```

Restore proved by hash, not by absence of a diff: `git hash-object turbo.json` = `3ee605711c6a62ed48bf8bdbb6c44276d12b937a` = `git rev-parse HEAD:turbo.json`.

### Ablation of the new limb — the self-test is proved able to fail

The condition `holdersOf(key, scriptsByPackage).length === 0` was mutated to `.length < 0`, confirmed on disk by grepping the text meant to change (`=== 0` → 1 then 0 occurrences; `< 0` → 0 then 1), and `--self-test` re-run. **No build/`dist` is involved** — this gate is plain Node reading the repo, resolved from source, so there is no stale-artifact leg to rebuild:

```
EXIT=1
FAIL: check-turbo-task-graph --self-test — 4 case(s) failed.
  - a generic task no package declares is a finding
  - the inert generic finding rules out the root manifest by name
  - a misspelled generic key is a finding
  - a misspelled generic key suggests the script that exists
```

Restored byte-identical (`git hash-object` = `git rev-parse HEAD:` on the file), self-test green again.

### Gate union, re-derived at the final commit

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-written path list — the script took the change set from git: 3 paths vs merge base `68c5dbaab`), then run. Exit codes captured **before** any pipe; each verdict is the line the gate itself printed.

```
check:turbo-task-graph --self-test   EXIT=0  OK: all cases passed.
check:turbo-task-graph               EXIT=0  OK: 21 package-scoped and 8 generic turbo task(s)
                                             judged against 78 workspace package(s) ...
check:nul-bytes (+ --self-test)      EXIT=0  scanned 6892 text file(s); 75 self-test assertions
check:pnpm-filter-targets            EXIT=0  140/177 --filter occurrence(s) across 30 file(s) resolve
check:cross-package-test-inputs      EXIT=0  18 package(s) read outside themselves, all declared
check:ci-filter-parity               EXIT=0  all 105 declared cross-package glob(s) covered
check:agent-test-spelling            EXIT=0
check:bash32-floor                   EXIT=0  98 self-test cases
check:cli-command-ids                EXIT=0  280 command-id literal(s) across 100 file(s)
check:entry-guard                    EXIT=0  170 scripts/ file(s)
check:parse-guard                    EXIT=0  46 self-test cases
```

Both convention-triggered obligations the derivation named for editing a gate script, run and green:

```
node scripts/pm/bare-root-worklist.mjs --self-test  EXIT=0  46 live row(s), 39 recorded verdict(s)
                                                            — none stale, none missing
pnpm check:pm-dispatch-gates                        EXIT=0  703 cases pass
```

The `turbo.json` root-file watch hint is unchanged (`ROOT_FILE_WATCH_HINTS = ['turbo.json/**']`), so no new bare-root verdict is incurred.

### Lint — a declared narrowing, with its three measurements

Repo-wide `pnpm lint` is CI's run. Locally this is a **measured** narrowing, not a skipped step:

1. **Population, read from eslint's own config, not guessed.** Of the three changed files, eslint reports `package.json` and `turbo.json` as *"File ignored because no matching configuration was supplied"* — they are outside the linted population by the config's own account.
2. **Count, from `--format json`.** 3 files requested, **1** actually linted (`scripts/check-turbo-task-graph.mjs`), 0 errors, 0 warnings.
3. **Invariance for untouched files.** `eslint.config.mjs` (lines 326-335) records, with a positive control, that this repo *"runs one `eslint.config.mjs`, which never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file"*. With no cross-file type program, this diff cannot move the verdict of any file it did not touch.

No package sources changed, so no `pnpm test` / `pnpm typecheck` is owed: the diff is `turbo.json`, one root script row, and one dependency-free script in `scripts/`.

## Changeset

None. Nothing here is published — `turbo.json`, the root `package.json` scripts block and `scripts/` all stay out of every npm package. The `skip-changeset` label is applied for that reason, which is this repo's mechanism (an empty-frontmatter changeset is refused by `check:empty-changeset`, and its header explains why the label is strictly safer).

## Out-of-scope findings, filed unassigned — not touched here

- #12465 — `check:turbo-task-graph` reports turbo's legitimate root-task spelling `//#lint` (the `//#` form) as an unknown package, and its failure text asserts something a dry run contradicts. Measured (`//#lint` lands in the graph with a real root command, exit 0), sits in the **pre-existing** package-scoped arm, and this PR changes it in neither direction. Filed as a sub-issue of #12046. Out of scope here: #12465 is not addressed in this branch.
- #12466 — the showcase smoke's only CI entry point bypasses turbo (`working-directory` + `pnpm test:smoke`), so the task config repaired above has zero CI consumers today. Observation, nothing red. Out of scope here: #12466 remains open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_