### PR TITLE
docs(client-sdk): state the two-tier error-code vocabulary and add the VALIDATION_FAILED row

### DIFF
--- a/content/docs/api/client-sdk.mdx
+++ b/content/docs/api/client-sdk.mdx
@@ -666,17 +666,41 @@ field-anchored".
 
 ### Error Codes
 
-| Code | HTTP | Category | Retryable | Description |
-|:-----|:-----|:---------|:----------|:------------|
-| `VALIDATION_ERROR` | 400 | validation | No | Input validation failed |
-| `INVALID_QUERY` | 400 | validation | No | Malformed query expression |
-| `UNAUTHENTICATED` | 401 | authentication | No | Authentication required |
-| `PERMISSION_DENIED` | 403 | authorization | No | Insufficient permissions |
-| `RESOURCE_NOT_FOUND` | 404 | not_found | No | Resource does not exist |
-| `RATE_LIMIT_EXCEEDED` | 429 | rate_limit | Yes | Too many requests |
-| `INTERNAL_ERROR` | 500 | server | Yes | Unexpected server error |
-| `SERVICE_UNAVAILABLE` | 503 | server | Yes | Service temporarily unavailable |
-| `NOT_IMPLEMENTED` | 501 | server | No | Service not installed (plugin missing) |
+`error.code` is drawn from a **two-tier vocabulary** (ADR-0112), and
+`packages/spec` is the authority for the full set:
+
+- **Standard catalog** — the closed `StandardErrorCode` enum
+  (`packages/spec/src/api/errors.zod.ts`): generic conditions with
+  platform-wide HTTP semantics. It does not grow when a service invents a code.
+- **Ledger-registered codes** — the service-specific codes each package
+  registers in `ERROR_CODE_LEDGER`
+  (`packages/spec/src/api/error-code-ledger.zod.ts`).
+
+The exported `ErrorCode` schema is the **union** of the two, so a code being
+absent from `StandardErrorCode` does not make it unofficial or unsupported:
+`VALIDATION_FAILED` — the code the examples above branch on — is a
+ledger-registered code, as are several others this page's examples use. The
+table below is a hand-picked subset of the codes you are most likely to branch
+on, **not** either tier in full; the **Tier** column says which set a row comes
+from.
+
+| Code | Tier | HTTP | Category | Retryable | Description |
+|:-----|:-----|:-----|:---------|:----------|:------------|
+| `VALIDATION_ERROR` | standard | 400 | validation | No | The **request** was refused before any record was validated — a repeated query parameter, a filter outside the allowlist, a malformed argument |
+| `VALIDATION_FAILED` | ledger | 400 | validation | No | A **record** failed validation on a write; carries `fields[]`. This — not `VALIDATION_ERROR` — is what a per-field failure arrives as |
+| `INVALID_QUERY` | standard | 400 | validation | No | Malformed query expression |
+| `UNAUTHENTICATED` | standard | 401 | authentication | No | Authentication required |
+| `PERMISSION_DENIED` | standard | 403 | authorization | No | Insufficient permissions |
+| `RESOURCE_NOT_FOUND` | standard | 404 | not_found | No | Resource does not exist |
+| `RATE_LIMIT_EXCEEDED` | standard | 429 | rate_limit | Yes | Too many requests |
+| `INTERNAL_ERROR` | standard | 500 | server | Yes | Unexpected server error |
+| `SERVICE_UNAVAILABLE` | standard | 503 | server | Yes | Service temporarily unavailable |
+| `NOT_IMPLEMENTED` | standard | 501 | server | No | Service not installed (plugin missing) |
+
+`Category` and `Retryable` above are the **semantic** classification of each
+condition. Neither is guaranteed on the wire — as the narrowing example shows,
+`error.category` and `error.retryable` are present only when the server sent
+them, and the REST server's per-field validation envelope sends neither.
 
 ---
 


### PR DESCRIPTION
Fixes #12389

## What the table was, measured before writing a row

The card asks for a `VALIDATION_FAILED` row. Before adding one I established
what the `### Error Codes` table is a table **of**, because if its contract were
"the `StandardErrorCode` enum" then adding a ledger-registered code would make
the table *false* and the honest deliverable would be the opposite finding.

Measured on this branch's base (`68c5dbaab2`):

| Fact | Value |
|:---|:---|
| `StandardErrorCode` members (`packages/spec/src/api/errors.zod.ts`) | 50 |
| Rows in the page's table | 9 |
| Rows that are enum members | 9 / 9 |
| `VALIDATION_FAILED` in `StandardErrorCode` | **no** |
| `VALIDATION_FAILED` in `ERROR_CODE_LEDGER` | yes (`@objectstack/rest`, `@objectstack/objectql`, …) |
| `ERROR_CODE_LEDGER` codes | 245 |

**9 of 50 refutes "the table is the enum."** The table was a curated subset with
an *unstated* contract — which is exactly why a reader mistakes it for the
authority. So the fix is the contract **plus** the row, not the row alone; that
matches what the card itself calls "arguably the real fix."

## Changes — confined to the `### Error Codes` section

1. **State the two-tier vocabulary** (ADR-0112): the closed `StandardErrorCode`
   catalog, the per-package `ERROR_CODE_LEDGER`, the exported `ErrorCode` schema
   as their union, and `packages/spec` as the authority for the full set. No
   ledger dump — that is the sync-drift shape this page keeps paying for.
2. **A `Tier` column**, so every row says which set it comes from and the table
   can hold both tiers without lying.
3. **The `VALIDATION_FAILED` row** — ledger, 400, carries `fields[]`.
4. **Sharpened `VALIDATION_ERROR`'s description** to the distinction that
   actually holds, since a reader picking the wrong one of the two is the
   defect. Both codes are live and they are not synonyms:
   - `VALIDATION_ERROR` — request-shape refusals: repeated query parameter
     (`query-multiplicity.ts:140`, `package-routes.ts:752`), a filter outside
     the allowlist (`query-allowlist.ts:196`), malformed arguments
     (`storage-service.ts:120`, `metadata-service-contract.ts:105`).
   - `VALIDATION_FAILED` — record-level validation on a write, carrying
     `fields[]` (`error-response.ts:631`, `rest-server.ts:9671` → 400).
5. **A note that `Category`/`Retryable` are semantic, not wire guarantees** —
   `grep -rn "category:" packages/rest/src/error-response.ts` returns nothing,
   so the per-field envelope sends neither. This closes the gap between the
   table's columns and the narrowing example's "optional — set only when the
   server sent it".

## Every other code this page's examples use is also a ledger code

Counted across the whole page (dispatch Zone 2c). Codes appearing outside the
table: `VALIDATION_FAILED` (:619, :632, :655), `ROLLED_BACK` / `NOT_ATTEMPTED`
(:579-580, batch rows), `FLOW_DISABLED` / `FLOW_FAILED` / `FLOW_NO_START_NODE`
(:436-438, the automation example). **All six are ledger-registered and none is
in `StandardErrorCode`** — which is itself the argument for the union note
rather than a row-by-row catch-up. Their omission is no longer misleading once
the table declares itself a subset, so no further rows were added.

## ⚠️ Nothing verifies this table

Stated plainly rather than implied: the table's rows are hand-authored prose.
There is no generated source for the `Category`/`Retryable` columns anywhere in
`packages/spec`, and this PR deliberately adds **no `os:check` markers** — that
is the subject of #11942, which is `pm:blocked`. The row is measured against the
spec by hand, and nothing in CI will notice if it drifts.

## Verification

Docs-only; no changeset (this PR publishes nothing — `skip-changeset`).

Gate union re-derived from the real change set with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(23 families) and run at the final commit **`5b76c2b049`**, plus
`check-nul-bytes` — 24/24 green, exit codes captured before any pipe. Verdict
lines from the gates themselves:

```
✓ check-docs-single-h1: 180 page(s) under content/docs/ carry no body-level `# ` heading
✅ check-doc-anchors: 278 internal fragment link(s) across 408 source file(s) all resolve to a real heading
✓ doc authoring guard: 390 files clean — no bare metadata literals.
✓ check-doc-frontmatter: 2 content root(s) verified, each against its own floor — content/docs 403, content/blog 3.
✅ 229 generated files in sync with packages/spec        (spec check:docs)
   260 marked example(s) across 101 file(s), 3 surface(s)  (spec check:skill-examples, green)
TOTAL FAILED=0
```

Repo-wide `pnpm lint` was **narrowed, and the narrowing is measured, not
assumed**: `eslint.config.mjs` contains the string `mdx` zero times and no
`files` glob covers `.mdx`, so ESLint's own population excludes the one file
this PR touches — `pnpm exec eslint content/docs/api/client-sdk.mdx
--no-inline-config --format json` reports 1 file, `errorCount: 0`, message
`"File ignored because no matching configuration was supplied."` No type-aware
linting is configured, and this diff changes no ESLint config, so it cannot
move a verdict on any untouched file either. CI runs the full farm regardless.

## Scope

Only the `### Error Codes` section is touched (35 insertions, 11 deletions, one
file). The example blocks are untouched — the remaining one belongs to #12388 —
and `content/docs/releases/**` is not involved.

_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_