### PR TITLE
fix(cli): rename `project` -> `environment` in comment prose (environments/**, api-client.ts)

### DIFF
--- a/packages/cli/src/commands/environments/bind.ts
+++ b/packages/cli/src/commands/environments/bind.ts
@@ -10,11 +10,11 @@ import { formatOutput } from '../../utils/output-formatter.js';
 
 /**
  * `os environments bind` — bind a locally-compiled artifact to an existing
- * multi-environment server project.
+ * multi-environment server environment.
  *
  * Equivalent to `PATCH /api/v1/cloud/environments/<id>` with
  * `metadata.artifact_path = <absolute-path>`. The server's
- * AppBundleResolver picks up the path on the next per-project kernel
+ * AppBundleResolver picks up the path on the next per-environment kernel
  * boot, registering the bundle's objects, views, and seed data.
  *
  * Use `--build` to compile `objectstack.config.ts` first so the artifact

--- a/packages/cli/src/commands/environments/create.ts
+++ b/packages/cli/src/commands/environments/create.ts
@@ -7,10 +7,10 @@ import { formatOutput } from '../../utils/output-formatter.js';
 import { readAuthConfig, writeAuthConfig } from '../../utils/auth-config.js';
 
 /**
- * `os environments create` — provision a new project.
+ * `os environments create` — provision a new environment.
  *
  * Delegates to `ProjectProvisioningService.provisionProject` on the server.
- * On success, optionally activates the new project for the current session
+ * On success, optionally activates the new environment for the current session
  * and persists `activeEnvironmentId` into `~/.objectstack/credentials.json`
  * (unless `--no-activate` is passed).
  */
@@ -64,7 +64,7 @@ export default class EnvironmentsCreate extends Command {
 
       // Resolve the artifact to an absolute path so the server can read it
       // regardless of its CWD. Bail early if the file is missing — better
-      // to fail before provisioning than leave a half-bound project.
+      // to fail before provisioning than leave a half-bound environment.
       let metadata: Record<string, unknown> | undefined;
       if (flags.artifact) {
         const path = await import('node:path');

--- a/packages/cli/src/commands/environments/list.ts
+++ b/packages/cli/src/commands/environments/list.ts
@@ -6,7 +6,7 @@ import { createApiClient, requireAuth } from '../../utils/api-client.js';
 import { formatOutput } from '../../utils/output-formatter.js';
 
 /**
- * `os environments list` — list projects visible to the current session.
+ * `os environments list` — list environments visible to the current session.
  *
  * Filters by organization via `--org`. Output format is the same
  * table/json/yaml shape used by other metadata commands, for a

--- a/packages/cli/src/commands/environments/show.ts
+++ b/packages/cli/src/commands/environments/show.ts
@@ -6,9 +6,9 @@ import { createApiClient, requireAuth } from '../../utils/api-client.js';
 import { formatOutput } from '../../utils/output-formatter.js';
 
 /**
- * `os environments show <id>` — show detailed information for a single project.
+ * `os environments show <id>` — show detailed information for a single environment.
  *
- * Renders the project row plus its database, active credential, and
+ * Renders the environment row plus its database, active credential, and
  * membership row (same shape as `client.projects.get(id)`).
  */
 export default class EnvironmentsShow extends Command {

--- a/packages/cli/src/commands/environments/switch.ts
+++ b/packages/cli/src/commands/environments/switch.ts
@@ -6,13 +6,13 @@ import { createApiClient, requireAuth } from '../../utils/api-client.js';
 import { readAuthConfig, writeAuthConfig } from '../../utils/auth-config.js';
 
 /**
- * `os environments switch <id>` — set the active project for this CLI session.
+ * `os environments switch <id>` — set the active environment for this CLI session.
  *
  * Calls `POST /api/v1/cloud/environments/:id/activate` to update the
  * server-side session, then persists `activeEnvironmentId` into
  * `~/.objectstack/credentials.json` so subsequent CLI commands (and any
  * client they create via `createApiClient`) automatically target this
- * project.
+ * environment.
  */
 export default class EnvironmentsSwitch extends Command {
   static override description = 'Activate an environment for subsequent CLI calls';

--- a/packages/cli/src/utils/api-client.ts
+++ b/packages/cli/src/utils/api-client.ts
@@ -16,7 +16,7 @@ export interface ApiClientOptions {
    */
   token?: string;
   /**
-   * Explicit project id. Overrides the stored `activeEnvironmentId` from
+   * Explicit environment id. Overrides the stored `activeEnvironmentId` from
    * `~/.objectstack/credentials.json` (written by `os environments switch`).
    */
   environmentId?: string;
@@ -52,7 +52,7 @@ export async function createApiClient(options: ApiClientOptions = {}): Promise<A
   // Resolve authentication token
   let token = options.token || process.env.OS_TOKEN;
 
-  // Resolve active project id (explicit > env > stored credentials)
+  // Resolve active environment id (explicit > env > stored credentials)
   let environmentId = options.environmentId || process.env.OS_ENVIRONMENT_ID;
 
   // If URL or token is missing, try to load from stored credentials


### PR DESCRIPTION
Fixes #12432

## What

Comment-axis-only follow-up to the v5.0 `project` -> `environment` rename (ADR-0006). PR #12429 (#12153) already rewrote every user-visible string in these five CLI files; this PR updates the docblock/inline-comment prose in the same files so the comments agree with what the code now prints and returns.

## Files (exactly the six named by the card)

- `packages/cli/src/commands/environments/list.ts`
- `packages/cli/src/commands/environments/bind.ts`
- `packages/cli/src/commands/environments/create.ts`
- `packages/cli/src/commands/environments/show.ts`
- `packages/cli/src/commands/environments/switch.ts`
- `packages/cli/src/utils/api-client.ts`

## Re-census on current `origin/main` (do not trust the card's counts — both #12432's own body and the PM's claim comment say so explicitly)

Full-file grep for `project` (case-insensitive, whole word, every line — not a phrase literal, so a wrapped docblock line does not hide anything) across the six files, then each hit classified by hand as comment / identifier / API-surface:

**Changed (12 comment-prose sites — one more than the card's "13 docblocks + api-client.ts:19 = 14", see note below):**

| File | Line | Before | After |
|---|---|---|---|
| list.ts | 9 | `list projects visible to...` | `list environments visible to...` |
| bind.ts | 13 | `multi-environment server project.` | `multi-environment server environment.` |
| bind.ts | 17 | `next per-project kernel` | `next per-environment kernel` |
| create.ts | 10 | `provision a new project.` | `provision a new environment.` |
| create.ts | 13 | `activates the new project for` | `activates the new environment for` |
| create.ts | 67 | `leave a half-bound project.` | `leave a half-bound environment.` |
| show.ts | 9 | `single project.` | `single environment.` |
| show.ts | 11 | `Renders the project row` | `Renders the environment row` |
| switch.ts | 9 | `set the active project for` | `set the active environment for` |
| switch.ts | 15 | `target this\n * project.` | `target this\n * environment.` |
| api-client.ts | 19 | `Explicit project id.` | `Explicit environment id.` |
| api-client.ts | 55 | `// Resolve active project id` | `// Resolve active environment id` |

`api-client.ts:19` is the site the card called out as sharpest (docblock said "project id" for a field literally named `environmentId`) — confirmed present exactly as described, now fixed.

**Not changed (deliberately, per the card's own fences):**

- `create.ts:12` and `show.ts:12` quote real identifiers — `ProjectProvisioningService.provisionProject` (confirmed live elsewhere: `packages/runtime/src/system-environment-plugin.ts`, `packages/client/src/index.ts:1815`) and `client.projects.get(id)`. These are identifier references, not prose — renaming a fragment of a real quoted name would misdescribe actual code. The card's naive "13 docblock sites" count included both as raw `project` grep hits without this classification; excluding them plus adding the newly-found `api-client.ts:55` (a bare `//` comment the card's JSDoc-shaped census missed) nets to the same 12 in `environments/**` + `api-client.ts`.
- Everything on the API-surface axis: `client.projects.*` SDK calls, `res.project`/`res.projects` response fields, and every local bound directly from them (`const p = res?.project`, `const project = lookup?.project`, `current.project.metadata`, etc.) — untouched, identifiers unrenamed, per ruling #2/#3. That axis now has its own card, #12473.

Reverse-check (proving the grep instrument can say no and isn't fooled by `project` being a substring of `projects`): post-edit, `grep -inE 'project' <files>` still returns exactly the API-surface/identifier lines above and nothing from the changed list — confirmed by hand, see report.

## Verification

- `pnpm --filter '@objectstack/cli^...' build` — dependency closure, clean.
- `pnpm --filter @objectstack/cli build` — clean.
- `pnpm --filter @objectstack/cli typecheck` — clean.
- `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 src/commands/environments/environments.test.ts` — 73/73 passed.
- `git diff --stat` — 6 files changed, 12 insertions(+), 12 deletions(-); confirmed the diff contains only the 12 comment edits above (no string literal, no identifier touched).
- Gate families re-derived from `node scripts/pm/dispatch-gates.mjs` against the actual changed paths (not trusted from the dispatch prompt) — all matched families run and green at final HEAD `ea04b744c`, details in the report comment.

Zero behaviour change, zero string-literal change.

_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_