### PR TITLE
docs(deployment): name the environment as what `os environments bind --build` updates

### DIFF
--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -1529,7 +1529,7 @@ os environments bind <environment-id> --artifact ./dist/objectstack.json
 os environments bind <environment-id> --artifact ./dist/objectstack.json --build
 ```
 
-`--build` runs `objectstack compile` before updating the project. `--reseed`
+`--build` runs `objectstack compile` before updating the environment. `--reseed`
 is reserved for the server-side reseed endpoint; use it only when that endpoint
 is available in your deployment.
 


### PR DESCRIPTION
Fixes #12433

`content/docs/deployment/cli.mdx:1532` still read "before updating the project" — the one
site on that page the v5.0 `project` -> `environment` rename (ADR-0006, no aliases) never
reached, while the page's own **Cloud Environments** command table directly above it
(1505-1509) already uses the post-rename vocabulary. Because the page is not uniformly
stale, a reader has no cue that this sentence is the old one.

```diff
-`--build` runs `objectstack compile` before updating the project. `--reseed`
+`--build` runs `objectstack compile` before updating the environment. `--reseed`
```

## The noun is verified against behaviour, not against the neighbouring text

The neighbouring table would have justified `environment` on consistency alone, which is
exactly the reasoning that produces a mechanically-renamed-but-wrong noun. So the
replacement was checked against what the command actually does, in
`packages/cli/src/commands/environments/bind.ts`:

1. `--build` spawns `compile --output <artifactAbs>` — this **produces** the artifact.
2. The artifact's existence is asserted.
3. The write that follows is `client.projects.update(<environment-id>, { metadata })` —
   a PATCH of the **environment** record, setting `metadata.artifact_path`.

The thing updated *after* the compile is the environment, so `environment` is the accurate
noun and not merely the renamed one. The flag's own help text agrees in the other
direction ("Run `objectstack compile` before binding"), and ADR-0006 confirms the
control-plane object is `sys_environment`.

## Census — two sites on this page, one of them deliberately left

`git grep -n 'the project\b' -- content/docs/deployment/cli.mdx` returns exactly two:

| site | text | disposition |
|---|---|---|
| `:1532` | "before updating **the project**" | ⬅ **fixed here** — the renamed noun |
| `:518` | "trust: **the project** this page scaffolds in" | ⛔ **left deliberately** |

`:518` is the **other sense** of the word — a scaffolded project directory, the npm/monorepo
sense AGENTS.md preserves ("'Project' now only means the npm/monorepo sense"). Renaming it
would be a wrong repair dressed as consistency. It was seen and measured, not missed.

No other vocabulary on the page was swept: #11042 owns the internal-spelling sweep and
#12366 owns the stale repo-name links. Those two cards remain open and are not addressed
here.

## Verification

Gate union derived from the change set itself via
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the script reads
its own change set from the merge base — no hand-built path list), then run at
**`19f21cdb0b`**, which is this branch's final commit with a clean working tree. All 23
derived families plus `check:nul-bytes` are green; exit codes were captured before any
pipe. Representative verdict lines, quoted from the gates' own output:

```
✅ check-doc-anchors: 278 internal #fragment link(s) across 408 source file(s) all resolve to a real heading
✓  doc authoring guard: 390 files clean — no bare metadata literals.
✓  route-spelling guard: population clean — every shape-matched literal spells its ledger row.
✅ 260 prose examples type-check across 3 surface(s)
✅ 26 ObjectSchema.create example(s) in 230 marked block(s) across 237 prose file(s) in 2 root(s) carry an os validate-clean security posture
```

Three of them (`check:doc-formula-expressions`, `check:doc-security-posture`,
`check:skill-examples`) first returned `PREREQUISITE NOT MET — nothing was measured`
because `@objectstack/lint`, `@objectstack/client` and `@objectstack/client-react` were
unbuilt. That is a refusal to measure rather than a finding, so the closure was built
(`dist/index.js` and `dist/*.d.ts` presence asserted) and all three re-run green.

**Repo-wide `pnpm lint`:** not narrowed — out of population, measured from eslint's own
config rather than assumed. `eslint --no-inline-config --format json` on the changed file
reports `File ignored because no matching configuration was supplied`, i.e. `.mdx` is not
in eslint's population at all (population: eslint's own flat-config resolution; count: 1
changed file, 0 in population, `errorCount: 0`; invariance: no eslint config is touched
and the sole changed file is unlinted, so no untouched file's verdict can move).

**No changeset:** docs-only, releases nothing — `skip-changeset`, matching this repo's
standing practice for `content/docs/**` corrections (the last seven `docs(...)` merges to
`main` carry zero changesets).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_