### PR TITLE
fix(pm): stop --report presenting command-exit as one certified population

### DIFF
--- a/scripts/pm/os-verify-lock.sh
+++ b/scripts/pm/os-verify-lock.sh
@@ -1361,6 +1361,30 @@ mode_report() {
   awk '{ for (i = 2; i <= NF; i++) if (substr($i, 1, 8) == "outcome=") { c[substr($i, 9)]++; break } }
        END { for (k in c) printf "  %-24s %6d\n", k, c[k] }' "$LEDGER_FILE" 2> /dev/null | sort -k2 -rn
   printf '  ⇒ queue-timeout and lock-unusable are NOT MEASURED runs: no gate was decided by them.\n'
+  # The bucket above is NOT homogeneous, and nothing in the row says so. Every
+  # record written before the verdict-word fix carries `command-exit`
+  # unconditionally -- the word was the outcome's name, not a claim about it --
+  # so a ledger that spans the fix mixes certified runs with runs that were
+  # never certified, under one heading, ranked next to a `batch-last-exit`
+  # count that IS a claim. A reader totting up `command-exit N` reads N
+  # certified runs; across the boundary that is false, and it is false in the
+  # green direction, which is how the original defect survived. Only the
+  # positive word can be trusted retrospectively, so the block says which one
+  # that is rather than leaving the two looking comparable.
+  #
+  # The second line pre-empts the repair a reader reaches for next: scanning
+  # the labels for a sequencing operator. That scan is a LOWER BOUND by
+  # construction and saying so here is cheaper than saying it after someone
+  # reports a census -- `ledger_append` cuts the label at 200 chars, and it
+  # flattens newlines to spaces BEFORE that cut, so a newline-sequenced batch
+  # (one of the very forms the word distinguishes) leaves no operator in the
+  # label at any length.
+  printf '  ⇒ command-exit is NOT one population: rows written before the verdict-word fix\n'
+  printf '    carry it unconditionally, so the bucket mixes certified with never-certified\n'
+  printf '    runs. Only batch-last-exit is a positive signal.\n'
+  printf '  ⇒ a label scan for a top-level ";", "|", "||" or "&" LOWER-BOUNDS that mixture\n'
+  printf '    and cannot census it: labels are cut at 200 chars, and a newline -- itself one\n'
+  printf '    of the sequencing forms -- is flattened to a space BEFORE the cut.\n'
 
   # waits and holds, as distributions rather than a single mean -- the tail is
   # the whole complaint on this lock, and a mean hides it.
@@ -2070,6 +2094,17 @@ mode_self_test() {
     "$(bash "$SELF" --report 2>&1 | grep -c 'lock-seconds held, by command')" 1
   st_case 'and --report labels the non-runs as NOT MEASURED rather than counting them' \
     "$(bash "$SELF" --report 2>&1 | grep -c 'NOT MEASURED')" 1
+  # The outcomes block ranks a word that certifies next to a word that did not
+  # always mean anything, and a ledger spanning the verdict-word fix holds
+  # both. These two pin the caveat that keeps the ranking honest -- without
+  # them the block silently invites `command-exit N` to be read as N certified
+  # runs, which is the original defect wearing the ledger's clothes.
+  st_case 'and --report refuses to present command-exit as one population' \
+    "$(bash "$SELF" --report 2>&1 | grep -c 'NOT one population')" 1
+  st_case 'and says a label scan lower-bounds the mixture rather than censusing it' \
+    "$(bash "$SELF" --report 2>&1 | grep -c 'LOWER-BOUNDS that mixture')" 1
+  st_case 'and names the newline flattening, which no label length can recover' \
+    "$(bash "$SELF" --report 2>&1 | grep -c 'flattened to a space BEFORE the cut')" 1
   # A measurement apparatus that can redden a gate has become part of the thing
   # it measures. This is the case that keeps it out of the way.
   st_case 'an unwritable ledger loses records, never runs' \


### PR DESCRIPTION
Part of #12365

A measurement card first. The card asked three questions; two of them are
answered here with numbers, and the third is explicitly left where the card put
it. The code change is one output caveat plus three pins — it is what the
measurement selected, not a change looking for a reason.

## Q2 — the retrospective label scan: **zero**, and here is its bound

Scanned the live ledger on this container, snapshotted **before** any run of
mine could append to it.

| | |
|---|---|
| rows | 111 |
| bytes | 18,826 (cap 8,388,608 — nowhere near the recording bound) |
| span | 2026-08-25 18:46:55Z → 2026-08-26 04:54:04Z (~10h) |
| `outcome=command-exit` | 107 |
| `outcome=batch-last-exit` | 4 |

Of the 107 `command-exit` rows: **0 carry a top-level `;`, `|`, `||` or `&`**,
106 scan as certifiable, 1 is undecidable (truncation cut it mid-quote). So the
card's closure branch on Q2 holds: **the number is zero.**

The scan reuses the shipped classifier — `exit_certifiable`, extracted
byte-identical from the file — rather than a reimplementation, so the scan and
the instrument answer the same question. **Positive control:** a synthetic
ledger of 4 known batches (one per operator class) + 3 known-certifiable rows
flags exactly 4/4 and 0/3, and correctly does not flag `&&` or a quoted `;`.

⚠️ **This is a lower bound, not a census, from three separate causes** — the card
names one; measurement found two more:

1. **200-char truncation can cut the operator off the tail.** 15 of 111 rows sit
   at the cut. (The card's caveat.)
2. **Truncation can break quoting**, and the scanner then refuses rather than
   guesses — 1 row.
3. **Newlines are destroyed before truncation.** `ledger_append` runs
   `tr '\n\t' '  '` *before* `cut -c1-200`, so a newline-sequenced batch — one
   of the five forms the fix distinguishes — leaves **no operator in the label
   at any length**. Verified directly, on a private lock and a private ledger:

   ```
   $ os-verify-lock.sh -c $'true\ntrue'
   VERDICT batch-last-exit 0
   ledger row: ... outcome=batch-last-exit ... label=true true
   ```

   The *word* is right; the *label* reads as certifiable. For that operator
   class a label scan has zero power, not merely reduced power.

⚠️ **One machine, not the fleet.** Confirming the dispatch-time reading:
`LEDGER_FILE="${OS_VERIFY_LOCK_LEDGER:-${LOCK_FILE}.ledger}"` — a `/tmp` runtime
artifact, never committed. This is one container's ~10h of runs.

## Q1 — consumers of the `outcome` field: exactly one, and it *does* read two vocabularies

Census widened from the dispatch-time two-pattern grep to four patterns, plain
`grep -rI` (so untracked files count too), across the whole worktree and the
sibling `objectui` checkout. **Positive controls:** `ledger_append` → the known
13 occurrences in the one file; `objectstack` → 4,726 files, proving the
recursion actually reaches. Two hits survived and both are false positives — a
`lint.yml` *comment* saying the self-test never touches the shared lock, and an
unrelated `sys_metadata_audit` `outcome=denied` in an objectql test.

**The zero is a "never eligible" zero, not a lucky one:** the ledger is a `/tmp`
artifact addressable only by naming `LEDGER_FILE`/`OS_VERIFY_LOCK_LEDGER`, and
only the writer does; CI never takes the lock at all.

So the sole consumer is `mode_report`'s outcomes tally — and the card's
assumption C is right to be suspicious of it. It buckets by word and ranks the
buckets, which **silently implies the two words are comparable**. They are not:
pre-fix rows carry `command-exit` unconditionally, so that bucket mixes
certified runs with never-certified ones, while `batch-last-exit` is a real
claim. `command-exit 107` reads as *107 certified runs*, and across the boundary
that is false **in the green direction** — the original defect wearing the
ledger's clothes.

**And the mixing is ongoing, not historical.** Each worktree pins its own copy
of the script, so stale checkouts still write the old word into the same ledger.
Measured on this container right now: **4 of 9 checkouts are pre-fix**,
including the shared primary `/home/user/objectstack`. The exposure does not
self-extinguish on a short clock.

⇒ The triage closure branch was *"scan finds zero **and** no consumer reads two
vocabularies"*. The first conjunct holds; the second is falsified. Hence one
caveat, not a close.

## The change

`--report`'s outcomes block gains two `⇒` lines, in the style of the
`NOT MEASURED` footer already there for exactly this reason — that block carries
interpretive footers precisely because its buckets are misreadable:

```
outcomes:
  command-exit                107
  batch-last-exit               4
  ⇒ queue-timeout and lock-unusable are NOT MEASURED runs: no gate was decided by them.
  ⇒ command-exit is NOT one population: rows written before the verdict-word fix
    carry it unconditionally, so the bucket mixes certified with never-certified
    runs. Only batch-last-exit is a positive signal.
  ⇒ a label scan for a top-level ";", "|", "||" or "&" LOWER-BOUNDS that mixture
    and cannot census it: labels are cut at 200 chars, and a newline -- itself one
    of the sequencing forms -- is flattened to a space BEFORE the cut.
```

No behaviour, no exit code, no acquisition path, no ledger format is touched.

## Verification

- `--self-test`: **134/134 pass**, including the three new cases. Run under the
  shared lock: `VERDICT command-exit 0 · held the lock 86s`.
- **Ablation** (`NOT one population` → `ABLATEDMARKER`): mutation confirmed on
  disk by grepping **both** the injected text (1) and the removed text (0) —
  never an editor's exit code; mutated self-test exits **1** with exactly the
  targeted case `✗`; restored and proven byte-identical,
  `git hash-object` = `6b3e39d89a26e53e8e8c4289e49ba1fcd5dbf21e` before and
  after. The script carried a `trap ... EXIT INT TERM` restore throughout.
- **Gate union** derived by `node scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` (never a hand-built list), re-derived after the
  final commit — same 9 families, no new ones. **All green at `d190728cc8`**,
  each exit code captured before any pipe:

  `check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` ·
  `check:cross-package-test-inputs` · `check:entry-guard` · `check:parse-guard` ·
  `check:pnpm-filter-targets` · `check-ci-filter-parity` ·
  `check-cross-package-test-inputs` · plus `check:nul-bytes`.

  `check-ci-filter-parity` first returned `PREREQUISITE NOT MET — the dependency
  yaml is not installed`. Per standing rule that is a refusal to measure, not a
  finding: built the closure (`pnpm install`) and re-ran → `OK: all 105 declared
  cross-package glob(s) ... covered`.

**Declared narrowing:** the green self-test ran under the shared lock; the
*ablation* leg ran outside it. The preceding acquisition waited 467s of a 540s
budget, and a second queued wait plus a ~90s run risked the ~10min foreground
cap landing mid-mutation. The self-test runs entirely on its own private lock
under a temp dir (CI runs it with no lock at all), so this costs serialisation
of ~90s of CPU, nothing else.

No changeset: CI-internal tooling with no user-visible surface — the two
immediate predecessors on this file landed with none. `skip-changeset` applied.

## Scope

⛔ No historical run was audited and nothing was re-opened — out of scope on
#12288's dispatch and still out. ⛔ No defect is claimed in PR #12363; its
forward half is correct and this does not touch it. Card question 3 (does any
downstream green rest on such a row) stays where the card put it — unanswerable
from the ledger, and with Q2 measuring zero there is nothing to scope it from.

_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_