### PR TITLE
docs(api): correct the environment-routing scoping instructions for standalone `os serve`

### DIFF
--- a/content/docs/api/environment-routing.mdx
+++ b/content/docs/api/environment-routing.mdx
@@ -20,7 +20,9 @@ depending on request context.
 
 ## Server configuration
 
-Enable scoped route registration in `objectstack.config.ts`:
+Environment scoping is a **host** decision, not an application one. The two keys
+are declared on the stack's top-level `api` block, but the host that boots the
+stack is what decides whether they take effect:
 
 {/* os:check */}
 ```typescript
@@ -35,17 +37,53 @@ export default defineStack({
 });
 ```
 
+<Callout type="warn">
+**On the default `os serve` path this block does not turn scoping on.** A bare
+`defineStack()` config carries no instantiated plugins, so the CLI boots
+`createStandaloneStack()` and merges that boot result over the authored config
+(`mergeBootConfig`). The boot builder ships
+`api: { enableProjectScoping: false, projectResolution: 'auto' }` and wins on
+exactly those two keys — deliberately, because scoping is not the author's call
+on a standalone host.
+
+The two keys are not overridden the same way:
+
+- `enableProjectScoping: true` is **contradicted**. The value forwarded to the
+  REST and dispatcher plugins is `false`, and no scoped routes are registered.
+- `projectResolution: 'auto'` is **redundant**. The boot builder pins the same
+  value, so writing it changes nothing; declaring any *other* strategy here is
+  silently replaced by `'auto'`.
+
+Every other authored `api` key — `enforceProjectMembership`, for example —
+survives the merge untouched.
+</Callout>
+
+The block above is live when the CLI does **not** boot the standalone stack:
+when the exported config is host-shaped, meaning its `plugins` array already
+carries instantiated plugin objects. That is the shape a multi-environment host
+assembles, and this open-core CLI supports the `standalone` boot mode only —
+cloud / multi-environment hosts ship from a separate distribution. Setting
+`OS_MODE=off` (or `bootMode: 'off'` on the exported config) also skips the
+standalone boot, but it drops the CLI to its legacy lightweight assembler rather
+than producing a scoped standalone host; `bootMode` is additionally not a
+declared stack key, so `defineStack()` rejects it as an unrecognized key.
+
 <Callout type="info">
 `api` is a declared top-level field on `ObjectStackDefinitionSchema`, so it
 survives `defineStack`'s strict parsing — you can pass it directly inside the
 `defineStack({ ... })` call as shown above. (Older stacks that instead spread
 it onto the exported config object, e.g. `export default { ...stack, api: {...} }`,
 still work the same way.) The CLI reads the resolved value from the exported
-config (`config.api`) when registering the REST and dispatcher plugins.
+config (`config.api`) when registering the REST and dispatcher plugins — but it
+reads it *after* the boot result has been merged in, which is why the standalone
+path forwards the boot builder's scoping decision rather than the author's.
 </Callout>
 
 The option names are historical for compatibility with existing config files;
 the route, header, env var, and request context all use `environment`.
+
+Once scoping is enabled by the host, `projectResolution` selects the route
+surface:
 
 | Strategy | Behavior | When to use |
 |:---|:---|:---|


### PR DESCRIPTION
Fixes #12451

## What was false

`content/docs/api/environment-routing.mdx` told authors to enable
environment-scoped routing by writing `api.enableProjectScoping: true` in
`objectstack.config.ts`, and the info Callout directly below the fence
reinforced the promise ("The CLI reads the resolved value from the exported
config (`config.api`) when registering the REST and dispatcher plugins"). On
the default `os serve` path both halves mislead:

1. A bare `defineStack()` config carries no instantiated plugins, so
   `isHostConfig` is false (`packages/cli/src/utils/plugin-detection.ts:11-16`).
2. `shouldBootWithLibrary` therefore returns true and `serve.ts` boots
   `createStandaloneStack()` (`packages/cli/src/commands/serve.ts:1703-1751`).
3. `mergeBootConfig` merges the boot result over the authored config per key,
   and the boot builder wins the two scoping keys
   (`packages/cli/src/utils/merge-boot-config.ts:41-52`).
4. The CLI reads `config.api` at `serve.ts:3115` — **after** that merge — and
   forwards it to both the REST and dispatcher plugins.

Per the card's routing note, the producer that is wrong is the **docs page**,
not the runtime: the override is deliberate, documented at its own seam, and
pinned by `packages/cli/src/utils/merge-boot-config.test.ts`. No CLI source is
touched here.

## What the repair says now

The `## Server configuration` section leads with scoping being a host decision,
then states the standalone override explicitly, and separates the two keys —
which the original section, and the card, treated as one:

- `enableProjectScoping: true` is **contradicted**. The standalone boot result
  ships `false` (`packages/runtime/src/standalone-stack.ts:786-793`), so no
  scoped routes are registered.
- `projectResolution: 'auto'` is **redundant, not false**. The boot builder
  pins the same `'auto'`, so the page's value happens to match. Any other
  strategy declared here is silently replaced.

The prose then names where the block *is* live (a host-shaped config, whose
`plugins` array carries instantiated plugin objects — the shape a
multi-environment host assembles; this open-core CLI supports `standalone`
only), and the info Callout keeps its true half about `defineStack` strict
parsing while its last sentence is corrected to say the CLI reads `config.api`
*after* the boot result is merged in.

The `{/* os:check */}` marker and the snippet under it are **unchanged**. The
block is valid authoring — it type-checks and `defineStack` accepts it — so
there was no reason to unmark it; the false claim was in the surrounding prose,
not in the code.

## Two measurements that changed what got written

**The card's own suggested remedy is not authorable.** The card and the triage
comment both propose naming `bootMode: 'off'` / `OS_MODE=off` as the escape
hatch. `OS_MODE=off` is real (an env var, read in `plugin-detection.ts:49-50`),
but `bootMode` is **not a declared key** on `ObjectStackDefinitionSchema`, which
is a `strictObject`. Measured against the built spec:

```
[OK ] api block only -> api={"enableProjectScoping":true,"projectResolution":"auto"}
[ERR] bootMode:off inside defineStack -> defineStack validation failed (1 issue):
        (root): Unrecognized key(s) on this stack definition: `bootMode`.
```

Publishing `bootMode: 'off'` as an authoring instruction would have replaced one
false instruction with another. The page now names it accurately: it works only
on an exported config that did not go through `defineStack`'s strict parse, and
it drops the CLI to its legacy lightweight assembler rather than producing a
scoped standalone host — so it is recorded, not recommended.

**The census moved.** The card cites #11473's figure of 22 sites for
`enableProjectScoping: true`. Re-measured on `origin/main` @ `b6c96bcea5`: **27
sites across 15 files**, and the conclusion holds — every one is a test, a doc
comment (`packages/cli/src/commands/serve.ts:3112`,
`packages/client/src/index.ts:2112`), or this page. Zero real in-repo
deployments, so this page is still the only place a user is told to set it.

**#11999 / PR #12444 has landed** — `packages/runtime/src/standalone-stack.ts`
now ships the declared `'auto'` rather than the undeclared `'none'`. That is
what makes `projectResolution` redundant rather than contradicted, and is why
the two keys get two sentences instead of one.

## Verification

Gate union derived from the change set itself via
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no
hand-written path list), re-run in full at `a1a0b5f65a` — the final commit —
with exit codes captured before any pipe. All 23 families green, including
`check:doc-anchors`, `check:doc-authoring`, `check:doc-frontmatter`,
`check:docs-single-h1`, `check-docs-section-name`, and the `os:check` surface:

```
260 prose examples type-check across 3 surface(s) — every marked block
parsed, so tsc ran the SEMANTIC pass on all of them
```

Two gates first returned `PREREQUISITE NOT MET — nothing was measured`
(`@objectstack/formula`, `@objectstack/lint`, `@objectstack/client-react` not
built); the closures were built and both re-ran green. That refusal is recorded
here because it is not a finding and must not be read as one.

Repo-wide `pnpm lint` is narrowed deliberately, and the narrowing is measured
rather than assumed: eslint's flat config declares `files:` populations of
`**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` only, and running
`eslint --no-inline-config --format json` on the changed file returns 1 result,
0 errors, with the message `File ignored because no matching configuration was
supplied.` Type-aware linting is not enabled anywhere in the config (no
`parserOptions.project`), so an `.mdx`-only diff cannot move any verdict on any
untouched file.

Docs-only: this PR releases nothing, so it carries `skip-changeset` rather than
a changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_