### PR TITLE
docs(content): retarget the stale `objectstack-ai/spec` repository name at its 5 surviving content sites

### DIFF
--- a/content/blog/metadata-driven-architecture.mdx
+++ b/content/blog/metadata-driven-architecture.mdx
@@ -583,4 +583,4 @@ ObjectStack is our answer.
 
 ---
 
-*Want to dive deeper? Explore our [technical specifications](/docs/references) or join the discussion on [GitHub](https://github.com/objectstack-ai/spec/issues).*
+*Want to dive deeper? Explore our [technical specifications](/docs/references) or join the discussion on [GitHub](https://github.com/objectstack-ai/objectstack/issues).*

--- a/content/blog/protocol-first-development.mdx
+++ b/content/blog/protocol-first-development.mdx
@@ -332,7 +332,7 @@ await db.query(`
 **The ObjectStack Approach:**
 ```typescript
 // Everything is open source and versioned
-// github.com/objectstack-ai/spec
+// github.com/objectstack-ai/objectstack
 
 export const FieldTypes = {
   text: z.object({
@@ -848,4 +848,4 @@ Join us in building it.
 
 ---
 
-*Ready to build on ObjectStack? Check out our [Getting Started Guide](/docs/getting-started) or join the conversation on [GitHub Issues](https://github.com/objectstack-ai/spec/issues).*
+*Ready to build on ObjectStack? Check out our [Getting Started Guide](/docs/getting-started) or join the conversation on [GitHub Issues](https://github.com/objectstack-ai/objectstack/issues).*

--- a/content/docs.site.json
+++ b/content/docs.site.json
@@ -37,7 +37,7 @@
       "socials": [
         {
           "platform": "github",
-          "url": "https://github.com/objectstack-ai/spec"
+          "url": "https://github.com/objectstack-ai/objectstack"
         }
       ]
     },
@@ -60,7 +60,7 @@
   "page": {
     "showLastUpdate": true,
     "showEditLink": true,
-    "repoBaseUrl": "https://github.com/objectstack-ai/spec"
+    "repoBaseUrl": "https://github.com/objectstack-ai/objectstack"
   },
   "content": {
     "math": false,


### PR DESCRIPTION
Fixes #12366

Retargets the stale `objectstack-ai/spec` repository name at the 5 sites the card scoped, across 3 files. Only the repository-name token inside each URL changes — 5 insertions, 5 deletions, no other edit.

## Premise re-verified at base `262145bef4`

The card's measurement holds exactly, with the same positive control:

```
content/blog/metadata-driven-architecture.mdx:586   .../objectstack-ai/spec/issues
content/blog/protocol-first-development.mdx:335     // github.com/objectstack-ai/spec
content/blog/protocol-first-development.mdx:851     .../objectstack-ai/spec/issues
content/docs.site.json:40                           "url": ".../objectstack-ai/spec"
content/docs.site.json:63                           "repoBaseUrl": ".../objectstack-ai/spec"

positive control: 68 files under content/ spell objectstack-ai/objectstack
```

Both directions confirmed on disk after the edit: the removed token went 1/2/2 → 0/0/0 per file, the injected token 0/0/0 → 1/2/2.

The correct target is taken from **in-repo evidence only** — no network probe of either repository name was made. Three independent in-tree sources agree: the 68-file majority spelling under `content/`; `.claude/workflows/docs-accuracy-audit.js:405`, which states it outright ("The repo is github.com/objectstack-ai/objectstack (NOT objectstack-ai/spec)"); and `apps/docs/lib/layout.shared.tsx:9`, the live site config.

## ⭐ `repoBaseUrl` is inert — the card's worst-case reading does **not** hold

The card raised the possibility that `docs.site.json:63` feeds the docs site's "edit this page" / "view source" links, which would make every such link on the site wrong. **It does not.** Measured, and reported here because it is the load-bearing negative:

- `repoBaseUrl` appears **once in the whole repository** — its own definition line. Zero readers.
- Every sibling key is equally unread: `showEditLink` 0, `showLastUpdate` 0, `transparentMode` 0, `imageZoom` 0, `defaultOpenLevel` 0.
- Nothing loads the file by any spelling. `apps/docs` does no dynamic reads (its only `import()` is `mermaid`), and `source.config.ts` ingests only the `content/docs` and `content/blog` **directories** — `docs.site.json` sits beside them, the distinction `dispatch-gates.mjs:5183` already pins as a self-test case.

What actually drives those links is `gitConfig` in `apps/docs/lib/layout.shared.tsx:9`, which **already spells the current name correctly** and feeds the per-page view-source link, the navbar, the homepage repo link, and the homepage JSON-LD `codeRepository`.

So this PR is a correctness fix to dead config, exactly as the card framed it — not a live user-facing defect. The site's rendered links were never wrong. That the file is *entirely* dead, rather than just these two values, is filed separately as #12489.

## Published, dated content — what was and was not rewritten

The two blog posts are published and dated (2024-01-20, 2024-01-22), so rewriting them needs a reason. The distinction applied here is **navigational pointer vs. historical claim**:

- All three prose sites are present-tense pointers inviting the reader to act now — "join the discussion on GitHub", "join the conversation on GitHub Issues", and `// Everything is open source and versioned` / `// github.com/objectstack-ai/spec`. Correcting the destination preserves the author's intent; leaving it degrades it.
- **No site makes a historical claim.** Nothing in either post says the repository was once called `spec`, so no sentence becomes false. Zero narrative words change — see the diff: every changed line differs only in the repo-name token.
- **No site carries an issue number.** All are tracker roots or bare repo roots.

That last point is what separates these from the recorded prior in `docs/audits/2026-06-handwritten-docs-accuracy-followups.md:40`, which declined to rewrite `docs/notes/airtable-dashboard-analysis.mdx`. That decision rests on **numbered** links (`/spec/issues/712-714`) whose identity could differ between the two names — a `#712` in one repo need not be the `#712` in the other. The links here have no number to mis-resolve, so the ambiguity that motivated the decline does not arise. The file that decision governs is untouched, and the decision is not re-litigated.

## Verification — `25c9290419`, the commit this PR ships

Gate union derived from the change set by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-built path list; the script read 3 committed paths vs merge base `262145bef`). All 7 families green, each exit code captured before any pipe:

| gate | verdict line |
|:--|:--|
| `check:cross-package-test-inputs` | `OK: 18 package(s) read outside themselves, all declared` (117 self-test cases passed) |
| `check:doc-anchors` | `✅ 278 internal #fragment link(s) across 408 source file(s) all resolve to a real heading` |
| `check:doc-authoring` | `✓ 390 files clean — no bare metadata literals` |
| `check:doc-formula-expressions` | exit 0 |
| `check-ci-filter-parity.mjs` | `OK: all 105 declared cross-package glob(s) (84 unique) are covered` |
| `check-cross-package-test-inputs.mjs` | `OK: 18 package(s) read outside themselves, all declared` |
| `check-doc-frontmatter.mjs` | `✓ 2 content root(s) verified — content/docs 403, content/blog 3` |

`check:doc-formula-expressions` first returned the `PREREQUISITE NOT MET — nothing was measured` refusal twice, naming `@objectstack/formula` and then `@objectstack/lint`. Both closures were built and the gate re-run to a real green; the refusals are recorded as non-results, not findings.

`check:nul-bytes` also green (`scanned 6897 text file(s) … no raw ASCII control bytes`).

`content/docs.site.json` re-parses after the edit, and both values read back as the corrected spelling. No schema gate for that file exists — the only three references to it in the tree are gate-script comments and path-hint fixtures.

**Two repo-wide checks are invariant over this change set rather than narrowed:**

- **`pnpm lint` (`eslint . --no-inline-config`)** — ESLint's population is read from its own config resolution, not assumed: every `files:` glob in `eslint.config.mjs` is `{ts,tsx,mts,cts,js,jsx,mjs,cjs}`, and `mdx` appears nowhere in the file. Probing the three changed paths through ESLint itself with `--format json` returns `"File ignored because no matching configuration was supplied"` for all 3 of 3. Type-aware linting is not enabled, so a diff confined to `.mdx`/`.json` cannot move any verdict on an untouched file.
- **`Check Documentation Links` (lychee)** — invoked with `--offline`, which excludes all non-file schemes. All 5 changed URLs are `https://github.com/…`, so they are outside its scan surface by construction, before and after. The binary is not installed in this container.

No changeset: `dispatch-gates` classifies this as docs-only, and the diff publishes no package. `skip-changeset` applied accordingly.

## Out of scope, filed not fixed

- #12488 — `.changeset/config.json:6` also names `objectstack-ai/spec`, inert only because the **default** changelog generator ignores `repo`; it goes live the moment anyone adopts `@changesets/changelog-github`. Carries the full census of `spec` spellings outside `content/`, including the **published** `packages/spec/README.md` badge.
- #12489 — `content/docs.site.json` is entirely dead config, not merely stale in two values.

Neither is touched here. `CONTRIBUTING.md`, `CHANGELOG.md` and `docs/notes/**` remain the maintainer call the card declared them, and `content/docs/releases/` was not edited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjM2ia8Av1v5NqfqQEQmC6)_