### PR TITLE
docs(cli): past-tense the deleted detectMode VITEST arm in two serve e2e headers

### DIFF
--- a/packages/cli/test/serve-node-env-production-default.e2e.test.ts
+++ b/packages/cli/test/serve-node-env-production-default.e2e.test.ts
@@ -244,13 +244,24 @@ async function probeOriginCheck(env: Record<string, string | undefined>): Promis
       // file measures, so the key is supplied explicitly.
       //
       // ⚠️ It was NOT needed before #11267 — and that is the finding, not an
-      // inconvenience. `local-crypto-provider.ts:133` reads
+      // inconvenience. What follows is quoted in the PAST TENSE on purpose:
+      // the code it quotes is GONE. `detectMode` used to read
       // `if (env.VITEST || env.NODE_ENV === 'test') return 'test'`, so while
       // this fixture still inherited the vitest worker's `VITEST=true`, its
       // crypto layer sat in TEST mode (ephemeral key, no disk, no refusal)
       // while the rest of the boot was in production posture. The production
       // posture this file exists to pin was genuine for auth and fake for
-      // crypto. Supplying the key is what makes it genuine for both.
+      // crypto.
+      //
+      // #11448 (`a58eac3e`, merged 2026-08-23) deleted that arm. The live
+      // `detectMode` (`local-crypto-provider.ts:185`) reads `NODE_ENV` and
+      // nothing else, so the key requirement no longer depends on `childEnv()`
+      // stripping anything: the unset-`NODE_ENV` leg selects production
+      // posture from `NODE_ENV` alone, and production refuses without a stable
+      // key whether or not a `VITEST` leaks in. The strip stays anyway, now as
+      // defence-in-depth over a class `pnpm check:runner-env-posture` holds
+      // shut in product source. Supplying the key is what makes the posture
+      // genuine for both halves.
       OS_SECRET_KEY: E2E_SECRET_KEY,
       // The base default for every call: truly unset, unless overridden by
       // `env` below. Node's spawn omits an `undefined`-valued entry rather

--- a/packages/cli/test/serve-process-child-env.e2e.test.ts
+++ b/packages/cli/test/serve-process-child-env.e2e.test.ts
@@ -36,11 +36,26 @@
  * `VITEST_WORKER_ID`, `VITEST_POOL_ID`, `VITEST_MODE` in place) also answers
  * `403 INVALID_ORIGIN`, so `TEST` alone is what better-auth reads.
  *
- * ⚠️ `VITEST` is not merely hygiene either, though this file said so in its
- * first revision and was wrong: `local-crypto-provider.ts:133` reads it
- * (`if (env.VITEST || env.NODE_ENV === 'test') return 'test'`) and an
- * inherited one silently put a spawned child's crypto layer in test mode. Same
- * class, different gate. `helpers/serve-process.ts` carries the measurement.
+ * ⚠️ `VITEST` was not merely hygiene either, though this file said so in its
+ * first revision and was wrong. What follows is quoted in the PAST TENSE on
+ * purpose — the code it quotes is GONE. `detectMode` in
+ * `local-crypto-provider.ts` used to read
+ * `if (env.VITEST || env.NODE_ENV === 'test') return 'test'`, so an inherited
+ * `VITEST=true` silently put a spawned child's crypto layer in test mode.
+ * #11448 (`a58eac3e`, merged 2026-08-23) deleted that arm; the live
+ * `detectMode` (`local-crypto-provider.ts:185`) reads `NODE_ENV` and nothing
+ * else.
+ *
+ * ⛔ So do not read the strip as still moving crypto posture: children
+ * spawned through this helper run `bin/run-dev.js`, which pins
+ * `process.env.NODE_ENV = 'development'` before argv is parsed, and `NODE_ENV`
+ * is deliberately outside `childEnv()`'s strip family — their posture is
+ * `development` with or without a leaked `VITEST`. The old wording predicted a
+ * `test` → `development` flip that cannot happen, and that prediction has
+ * already cost one dispatch (#11596) its scoping assumption. The strip stays
+ * anyway, now as defence-in-depth over a class `pnpm check:runner-env-posture`
+ * holds shut in product source. Same class, different gate;
+ * `helpers/serve-process.ts` carries the measurement.
  *
  * ## ⚠️ The first boot deliberately builds the env the WRONG way
  *


### PR DESCRIPTION
Fixes #12179

Two `packages/cli/test` headers quoted `detectMode`'s deleted `env.VITEST ||` arm in the **present tense** and cited `local-crypto-provider.ts:133`, a line it no longer lives on. Comment prose only — no behaviour change, nothing published, `skip-changeset`.

## The discriminator, stated before the fix ran

The same string lives at **9 occurrences across 7 files**, and **7 of those 9 are correct**. A grep-and-replace over the string would corrupt every one of them. The difference is **tense**, never text: an accurate quote of RETIRED code narrates the removal in the past tense; a stale quote presents deleted code as what the function reads TODAY.

Census re-run unnarrowed on `origin/main` @ `e0bdbc30b` — `git grep -n -I -F "env.VITEST ||"`, every hit classified by framing rather than by filename:

| site | framing | verdict |
|---|---|---|
| `packages/services/service-settings/src/local-crypto-provider.ts:148` | "This line **used to** read:" | correct — retired code, quoted deliberately (read-only here) |
| `packages/services/service-settings/src/crypto-posture-deployment-signal.test.ts:17` | "Before this card, `detectMode` **read**:" | correct |
| `scripts/check-runner-env-posture.mjs:16` | "**selected** its crypto posture like this:" | correct |
| `scripts/check-runner-env-posture.mjs:255`, `:266` | self-test fixture strings, not narration | correct |
| `.github/workflows/lint.yml:1729` | "`local-crypto-provider.ts` **selected** its crypto posture with …" | correct |
| `.changeset/crypto-posture-deployment-signal.md:10` | "`detectMode` **read** `env.VITEST` as a vote for `'test'` posture:" | correct |
| `packages/cli/test/serve-process-child-env.e2e.test.ts:40-41` | "`local-crypto-provider.ts:133` **reads** it" | **STALE — repaired here** |
| `packages/cli/test/serve-node-env-production-default.e2e.test.ts:247-248` | "`local-crypto-provider.ts:133` **reads**" | **STALE — repaired here** |

Second census, over line-number citations (`git grep -n -I -E "local-crypto-provider(\.ts)?:[0-9]+"`): exactly three. `packages/cli/test/helpers/serve-process.ts:81` cites `:185` and is **accurate** — verified against the tree, not copied: `const detectMode = (env: EnvMap): CryptoMode =>` sits at `local-crypto-provider.ts:185` on `e0bdbc30b`. The other two cited `:133`. After this change `git grep "local-crypto-provider.ts:133"` matches nothing repo-wide.

`helpers/serve-process.ts` was the template, not a target — it was already repaired, and neither it nor `local-crypto-provider.ts` is touched by this branch.

## The mechanism restated, not deleted

Each header's *conclusion* survives — stripping `VITEST` stays correct, now as defence-in-depth over a class `pnpm check:runner-env-posture` holds shut in product source. The *mechanism* is what was false, and it is a wrong mechanism in a header rather than cosmetic drift: it predicts a crypto-posture flip that cannot happen, and that prediction has already been carried into a dispatch's scoping (#11596).

- **`serve-process-child-env.e2e.test.ts`** — children spawned through `helpers/serve-process.ts` run `bin/run-dev.js`, which pins `process.env.NODE_ENV = 'development'` at line 28, before `run()` parses argv; `NODE_ENV` is deliberately outside `childEnv()`'s strip family. Their posture is `development` with or without a leaked `VITEST`, so the `test` → `development` flip the old wording predicted is unreachable.
- **`serve-node-env-production-default.e2e.test.ts`** — this file spawns its own `const CLI = resolve(HERE, '../bin/run.js')` (the built entrypoint, which does *not* pin `NODE_ENV`), so its unset-`NODE_ENV` leg really is a production boot. What was false is the attribution: the explicit `OS_SECRET_KEY` no longer follows from `childEnv()` stripping anything. `NODE_ENV` alone selects production posture, and production refuses without a stable key whether or not a `VITEST` leaks in.

Both restatements say **PAST TENSE** out loud, so the next census reads them as the sixth and seventh correct sites rather than re-flagging them.

⛔ Untouched on purpose: the `randomPort()` docblock at `serve-node-env-production-default.e2e.test.ts:200-202` (that paragraph belongs to #12441, serialized behind this card in the same file), and the preceding `OS_AUTH_SECRET` / production-boot paragraph at `:238-244`, which is accurate for this file.

## Reported, not folded — a related site the census surfaced

Three files carry the same *false mechanism* without quoting the arm and without a line citation, so they are outside this card's declared file surface and are **not** touched here:

- `packages/cli/test/serve-mcp-stdio-answers.e2e.test.ts:179-181`
- `packages/cli/test/serve-mcp-capability-collision.e2e.test.ts:184-186`
- `packages/cli/test/serve-stdio-stdout-purity.e2e.test.ts:174-176`

All three read: *"with `VITEST` no longer inherited (#11267), `local-crypto-provider.ts`'s detectMode answers `development` for this child instead of `test`"*. The counterfactual is dead: `detectMode` no longer reads `VITEST`, so an inherited one would not produce `test` either. The real cause is the one each comment states four lines further down — `serve.ts` assigns `process.env.NODE_ENV = 'development'` in-process for `--dev`. Measured: all three spawn `bin/run.js` with `--dev` and `NODE_ENV: undefined`.

## Verification

Gate union re-run **after** the final commit, at `4051ed659`, each verdict read from the gate's own printed line (exit codes captured before any pipe):

- `pnpm check:nul-bytes` → `check-nul-bytes: OK (scanned 6899 text file(s) … no raw ASCII control bytes)`
- `pnpm check:cli-test-child-env` → `✓ check:cli-test-child-env: 35 spawner source(s) among 95 under packages/cli/test/**; no new bulk process.env copy reaches a spawned child … 2 deliberate site(s) still pinned`
- `pnpm check:runner-env-posture` → `✓ check-runner-env-posture: 1974 product source file(s), no test-runner variable read.`
- `pnpm check:cross-package-test-inputs` → `OK: 18 package(s) read outside themselves, all declared`
- `pnpm check:test-source-alias` → `check-test-source-alias OK — 72 packages with tests scanned`
- `pnpm check:type-check-coverage` → `check-type-check-coverage: OK — 65/78 workspace packages type-checked`
- `node scripts/check-comment-mask-adoption.mjs` → `OK check:comment-mask-adoption — 23 private comment-stripper(s) … all 23 recorded`
- `pnpm lint` (`eslint . --no-inline-config`, **whole repo**, not narrowed) → exit 0, no findings
- `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2` on both edited files, after `pnpm --filter '@objectstack/cli^...' build` and `pnpm --filter @objectstack/cli build` → `Test Files 2 passed (2) · Tests 9 passed (9)` — real boots, 18.16s

Gate set derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (2 paths vs merge base `e0bdbc30b`), not recalled.

⚠️ **NOT MEASURED, declared:** `pnpm --filter @objectstack/cli typecheck` exits 0, but `packages/cli/tsconfig.json` declares `"include": ["src"]`, so **neither edited file is in that program** — `tsc --noEmit --listFiles` lists 1275 files and 0 of them under `packages/cli/test/`. That is a ledgered standing condition (`check:type-check-coverage`: "19 package(s) still hide their own tests from tsc"), not a regression, and it is why the two files were executed under vitest above: that run is the only local evidence they still compile. The rest of `@objectstack/cli`'s suite and the full check farm are left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_