### PR TITLE
fix(plugin-webhooks): ja-JP sys_webhook label renders consistently as ウェブフック

### DIFF
--- a/.changeset/ja-jp-webhook-label-consistency.md
+++ b/.changeset/ja-jp-webhook-label-consistency.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/plugin-webhooks': patch
+---
+
+Fixed the `sys_webhook` object's `ja-JP` display name (`label`) to ウェブフック, matching the already-Japanese `pluralLabel` and the bundle's own help prose (`object_name.help`, `triggers.help`), which both use the same term. Previously `label` was a stale `Webhook` fill left over from a prior source revision, so the object rendered its own name two different ways within the same locale in the Setup/admin UI. `description` (which uses "Webhook" inside a longer Japanese sentence) and the `Webhook ID` field label are unchanged — this only renames the object itself. `zh-CN` is deliberately untouched: it uses `Webhook` for both slots on purpose, as there is no established Chinese rendering of the term in this codebase.

--- a/packages/plugins/plugin-webhooks/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-webhooks/src/translations/ja-JP.objects.generated.ts
@@ -16,7 +16,7 @@ import type { TranslationData } from '@objectstack/spec/system';
 
 export const jaJPObjects: NonNullable<TranslationData['objects']> = {
   sys_webhook: {
-    label: "Webhook",
+    label: "ウェブフック",
     pluralLabel: "ウェブフック",
     description: "送信 HTTP Webhook サブスクリプション。defineWebhook() またはスタジオエディタで作成し、HTTP コネクタプラグインが実行します。",
     fields: {


### PR DESCRIPTION
Fixes #12128

## What changed

One leaf: `packages/plugins/plugin-webhooks/src/translations/ja-JP.objects.generated.ts` line 19, `sys_webhook.label`:

```diff
-    label: "Webhook",
+    label: "ウェブフック",
```

Triage's ruling (issue #12128, comment by `os-trump`, 2026-08-25T17:58:36Z): `label` → ウェブフック, matching the already-repaired `pluralLabel` and the bundle's own Japanese help prose (`object_name.help`, `triggers.help`, both ウェブフック), so `sys_webhook` renders one way everywhere in `ja-JP`. This was not my choice to make — the dispatch brief carried the ruling verbatim and my job was landing it without collateral.

Left alone, as fenced by the ruling:
- `description` (`送信 HTTP Webhook サブスクリプション…`) — Latin "Webhook" inside Japanese prose about the protocol, a different act from naming the object.
- the `Webhook ID` field label — an identifier, not the object's own name.
- `zh-CN` — keeps `Webhook` for both `label` and `pluralLabel` deliberately; there is no established Chinese rendering of the term anywhere in this repo, and Chinese marks no plural, so the singular/plural distinction the source drew doesn't carry over.
- every other locale (`en`, `es-ES`) — both internally consistent already (`Webhook`/`Webhooks` in both), so out of scope.

## How the edit was made

The file's own header says leaf string values are edited in place and that `os i18n extract --merge` only fills *gaps* — a present-but-stale translation is not a gap, so the tooling would not have touched this leaf. This is a hand-edit of the leaf string value only; no structural change, no reformatting.

## Verification

- `pnpm check:i18n` — `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys)`, `plugins/plugin-webhooks in sync (4 bundle(s))`.
- `pnpm check:i18n-stale-fill` — `check-i18n-stale-fill: OK (10 bundle set(s) — no new stale fills, 0 baselined)` (scanned 0 stale-fill leaves — confirms the edit didn't strand a new one).
- Full dispatch-derived local gate union (`node scripts/pm/dispatch-gates.mjs`) run in the foreground against this diff, exit captured before any pipe — all green: `check:cross-package-test-inputs`, `check:page-declaration-shape`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-ci-filter-parity.mjs`, `check-comment-mask-adoption.mjs`, `check-cross-package-test-inputs.mjs`, `check-plugin-teardown-shape.mjs`, `docs-audit/check-affected-docs.mjs`, `docs-audit/check-drift-comment.mjs`, plus the changeset family (`check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-empty-changeset.mjs`, `release-rehearsal-clone.mjs --self-test`) and `check:nul-bytes`.
- `@objectstack/plugin-webhooks`: `pnpm test` — 128 passed (128), 11 test files; `pnpm typecheck` — clean.
- Union re-run at final commit `59c5ec13` (this branch's head).

## Changeset

Added (`patch`, `@objectstack/plugin-webhooks`) — a shipped translation leaf is user-visible in the Setup/admin UI, so this is not `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0157mMVAq9fjGe2kaSD2aJC8)_