### PR TITLE
docs(cli): re-measure the vitest suite-cost section on a stated commit (#12499)

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -32,7 +32,11 @@
 // was reachable from NO other file in `packages/cli` (which is why it was
 // absent from the ledger in the first place), so this entry re-resolves
 // exactly one file — the new test — and cannot move any existing suite.
-// Measured again after: 135 files / 1470 tests, unchanged.
+// Measured again after: unchanged. ⚠️ The file/test COUNT that "unchanged" was
+// checked against is deliberately not repeated here. This file used to carry
+// this package's population in two separate sections; the two copies drifted
+// apart and neither said which was current, so the population is now stated
+// ONCE — with the commit it was measured on — in the suite-cost section below.
 //
 // ## Why the create-objectstack entry (#10557)
 //
@@ -62,69 +66,162 @@
 // suite cost in this repo — per-file module-graph re-execution under isolation,
 // the proxy `scripts/partition-test-shards.mjs` weights by — predicted the
 // cause would be import surface, which would have made a `test` block (`pool`,
-// `isolate`) the lever. Measured on 2026-08-20, it is NOT that, and the
-// measurement is recorded here because this file is where the next person
-// looking for a lever will arrive.
+// `isolate`) the lever. It is NOT that, and the measurement is recorded here
+// because this file is where the next person looking for a lever will arrive.
 //
-// One machine, 4 cores, warm build, `npx vitest run --maxWorkers=2` per
-// package, vitest 4.1.10. Both normalisers, because per-FILE cost alone cannot
-// tell "expensive suite" from "more tests per file":
+// ⚠️ EVERY FIGURE BELOW COMES FROM ONE RUN ON ONE STATED COMMIT — 2f665a1af,
+// re-measured 2026-08-26 (#12499). The first version of this section carried a
+// DATE and no commit, and the population moved under it while the figures went
+// on reading as precise: 137 files / 1498 tests had become 185 / 2115, and 20
+// spawner files had become 39, before anyone checked. A date says when someone
+// looked; a commit says WHAT they looked at, and only the second can be
+// re-checked. Whoever re-measures next: print your commit here, and keep these
+// counts in exactly one place in this file — a second copy is what rotted last
+// time, because the two drifted and neither said which was current.
+//
+// PROTOCOL. One machine, 4 cores, warm build, one `vitest run --maxWorkers=2`
+// per package, vitest 4.1.10 on node 22.22.2. ⚠️ Several agents share this
+// container, so every run below held the shared heavy-verify lock
+// (`scripts/pm/os-verify-lock.sh`): a suite timed beside a neighbour's build is
+// a reading about the box, not about the suite.
+//
+// Contention actually seen, so the absolutes can be discounted honestly: three
+// other agents were working this container. The `cli` run waited 4m01s for the
+// lock behind a neighbour's build and then held it 13m14s; the five peer runs
+// waited 7m03s and held 8m57s. The lock serialises LOCKED work only — a
+// neighbour's UNLOCKED gate script was seen at ~130% CPU partway through the
+// `cli` run — and 1-minute load averaged 4.36 (peak 6.97) on 4 cores across it.
+// ⛔ Also part of the protocol: each package was measured against a tree with
+// its own dependency closure BUILT. A package measured without one does not
+// report a cheap wall, it fails loudly — `example-showcase` did, first time.
+//
+// ⚠️ WHICH OF THESE TRAVEL TO ANOTHER BOX. #11707 re-ran this section's
+// absolutes elsewhere and they did NOT reproduce, while the ratio it cared
+// about did. So: every figure in SECONDS here is box-dependent and comparable
+// only inside this one run — the walls, s/file, s/test, the `Duration` split,
+// the per-spawn floors. What a reader on another box should expect to reproduce
+// are the RATIOS: tests/file, the top-20 concentration, the spawner share of
+// the file wall, this package's multiple over its peers, and the ratio between
+// the two spawn floors.
+//
+// Both normalisers, because per-FILE cost alone cannot tell "expensive suite"
+// from "more tests per file":
 //
 //   package                files  tests   tests/file   wall     s/file   s/test
-//   @objectstack/cli         137   1498       10.9    495.81s   3.619   0.3310
-//   @objectstack/spec        415  11045       26.6    325.31s   0.784   0.0295
-//   …/service-automation      83    991       11.9     57.97s   0.698   0.0585
-//   …/driver-turso            39   1003       25.7     38.50s   0.987   0.0384
-//   @objectstack/client       23    314       13.7     23.75s   1.033   0.0756
-//   …/example-showcase        21    342       16.3     31.15s   1.483   0.0911
+//   @objectstack/cli       185   2115       11.4   793.31s    4.288   0.3751
+//   @objectstack/spec      432  11460       26.5   358.46s    0.830   0.0313
+//   …/service-automation    91   1082       11.9    96.06s    1.056   0.0888
+//   …/driver-turso          39   1006       25.8    33.89s    0.869   0.0337
+//   @objectstack/client     25    346       13.8    18.74s    0.750   0.0542
+//   …/example-showcase      26    364       14.0    32.94s    1.267   0.0905
 //
-// Normalising per TEST makes this package look worse, not better: it has the
-// LOWEST tests-per-file of the six, so its 2.4-5.2x per-file cost becomes
-// 3.6-11x per test. "It just has more tests per file" is falsified.
+// Normalising per TEST makes this package look WORSE, not better: it has the
+// LOWEST tests-per-file of the six, so its 3.4-5.7x per-file cost becomes
+// 4.1-12.0x per test. "It just has more tests per file" is falsified. ⚠️ Read
+// the SHAPE of that check, not only its answer: the multiple has to WIDEN when
+// the normaliser changes, and it does.
 //
 // The `Duration` split says where the cost is NOT:
 //
-//   cli      495.81s (transform 29.47s, setup 0ms, import 192.91s, tests 774.95s)
-//   spec     325.31s (transform 13.79s, setup 0ms, import  63.90s, tests 456.36s)
-//   svc-auto  57.97s (transform 14.54s, setup 0ms, import  96.78s, tests   4.73s)
-//   turso     38.50s (transform 16.85s, setup 0ms, import  65.98s, tests   3.56s)
-//   client    23.75s (transform 18.31s, setup 0ms, import  39.72s, tests   2.25s)
+//   cli       793.31s (transform 25.17s, setup 0ms, import 203.72s, tests 1353.09s)
+//   spec      358.46s (transform 15.68s, setup 0ms, import  68.50s, tests  528.18s)
+//   svc-auto   96.06s (transform 14.72s, setup 0ms, import 172.68s, tests    4.71s)
+//   turso      33.89s (transform 14.13s, setup 0ms, import  56.93s, tests    3.62s)
+//   client     18.74s (transform 10.91s, setup 0ms, import  30.15s, tests    2.38s)
+//   showcase   32.94s (transform 16.68s, setup 0ms, import  48.76s, tests   12.78s)
 //
-// Per file this package's import cost is 1.41s and its transform cost 0.215s —
-// MID-BAND and LOWEST respectively (client 1.73s/file import, turso 1.69s).
-// The wide dependency closure in `package.json` is not what the test files
-// import. `setup` is 0ms everywhere, so setupFiles cost is not it either.
+// Per file this package's import cost is 1.10s and its transform cost 0.136s —
+// SECOND-LOWEST of the six on BOTH; only `spec` is below it (0.16s import,
+// 0.036s transform), and the tops are `service-automation` at 1.90s import and
+// `example-showcase` at 0.642s transform. The wide dependency closure in
+// `package.json` is not what the test files import. `setup` is 0ms in all six,
+// so setupFiles cost is not it either — and that zero was checked against an
+// instrument that can say otherwise: the same reporter, pointed at a
+// deliberate 300ms setup file, reports it.
 //
 // The cost is test-body work, and it is concentrated, not uniform: median file
-// 0.03s, 105 of 137 files under 2s, top 20 files = 87.7% of the wall. The 20
-// files that spawned the real CLI as a subprocess (all 20 of them
-// `bin/run-dev.js` through `tsx` on that date, against a `mkdtemp` project)
-// were 56.1% of the file wall (300.1s) while carrying 177 of 1498 tests —
-// three have since moved to the built entry (#11707; last section of this
-// header) and the split has not been re-measured. Each spawn re-executes the
-// CLI's module graph in a COLD process, which is the standing theory after
-// all — relocated out of vitest's worker, where neither its transform cache
-// nor its module registry can reach it. Floor per spawn, doing nothing but
-// printing a version:
+// 0.05s, 129 of 185 files under 2s, top 20 files = 71.3% of the file wall
+// (965.3s of 1353.1s). "File wall" here is the sum of the per-module run
+// durations, which is the SAME quantity vitest prints as the `tests` term
+// above — said out loud so the two can be checked against each other instead of
+// drifting apart, which is how this section went stale the first time.
 //
-//   tsx bin/run-dev.js --version   6.5-6.8s     (the source entry all 20 used)
-//   node bin/run.js --version      2.9-3.2s     (the built entry)
-//   node -e 0                      0.031s       (process floor)
+// The 39 files that spawn the real CLI as a subprocess (against a `mkdtemp`
+// project) are 89.4% of that file wall (1209.8s) while carrying 319 of the 2115
+// tests — and they are the WHOLE of the top 20, all twenty of them. Each spawn
+// re-executes the CLI's module graph in a COLD process, which is the standing
+// theory after all — relocated out of vitest's worker, where neither its
+// transform cache nor its module registry can reach it.
+//
+// ⚠️ THE SPAWNER SET MOVED IN BOTH DIRECTIONS AT ONCE, which is why the two
+// shares here disagree with the 2026-08-20 pair in OPPOSITE directions: 20
+// spawner files became 39, so the share of the wall they hold ROSE (56.1% ->
+// 89.4%) while the top-20 concentration FELL (87.7% -> 71.3%) — the same kind
+// of cost, spread across more files. Either number read alone tells the wrong
+// story; the pair is the finding.
+//
+// ⚠️ COUNTING THE SPAWNERS: match the entry BASENAME, not `bin/run-dev.js`.
+// Three of the 39 assemble the path from separate literals
+// (`join(…, '..', 'bin', 'run-dev.js')`) and a slash-joined pattern misses all
+// three — silently, since the answer it returns is still a plausible number.
+// Prose mentions do not count either: at least one file names the entry four
+// times while explicitly not spawning it.
+//
+// By entry point, after #11707 moved three files onto the built one:
+//
+//   35 files spawn `bin/run-dev.js` (source)   1169.2s   33.4s/file   311 tests
+//    4 files spawn `bin/run.js`     (built)      40.6s   10.1s/file     8 tests
+//
+// ⛔ That is NOT a measurement of what the two entries cost. Those four are also
+// the smallest files here — 2.0 tests/file against 8.9 — and per TEST the
+// ordering REVERSES (5.1s vs 3.8s). File-level shares say where the wall sits,
+// not what one spawn costs. What a spawn costs is measured directly, one spawn
+// at a time, below.
+//
+// Floor per spawn, doing nothing but printing a version — 5 timed runs each
+// after one discarded warm-up, box idle inside the lock:
+//
+//   tsx bin/run-dev.js --version   5.45-6.07s    (the source entry, 35 files)
+//   node bin/run.js --version      2.46-2.66s    (the built entry, 4 files)
+//   node -e 0                      0.025-0.031s  (process floor)
+//
+// ⚠️ The absolutes moved from the 2026-08-20 reading (6.5-6.8 / 2.9-3.2 /
+// 0.031); the RATIO did not — source-over-built was 2.18x then and 2.21x here (means of the five runs each).
+// That is the #11707 pattern exactly: carry the ratio to another box, never the
+// seconds.
+//
+// ⛔ The exit code is PART of this measurement, not a formality. A nonexistent
+// entry (`node bin/run-NOPE.js --version`, exit 1) returns in 0.030s — which
+// reads as a better floor than anything real. Timing alone cannot tell "fast"
+// from "never ran"; every row above was checked for exit 0.
+//
+// ⚠️ A port-selection change (#12441) was in flight on three of these spawner
+// files (`serve-node-env-production-default`,
+// `serve-app-anchored-optional-import`, `helpers/serve-process`) while this was
+// measured. It changes which PORT a spawned `serve` binds, not which ENTRY is
+// spawned, so the source-vs-built split above is unaffected by it; it can move
+// wall times slightly. Recorded so the next reader can tell drift from noise.
 //
 // ⚠️ Two levers were measured and both are rejected HERE, on this evidence:
 //
-//   `test: { maxWorkers: 4 }` — real but not ours to take. 2->4 workers on an
-//   idle box is 495.81s -> 337.13s, but CPU is flat (user+sys 1291.3s ->
-//   1256.2s) and per-file wall INFLATES (sum 535.1s -> 748.3s; longest file
-//   74.3s -> 104.1s): the box is saturated, so this is packing, not work. In CI
+//   `test: { maxWorkers: 4 }` — real but not ours to take. 2->4 workers on this
+//   box is 793.31s -> 565.86s, but CPU is FLAT (user+sys 2028.5s -> 1971.2s)
+//   and per-file wall INFLATES (sum 1353.1s -> 1969.8s; longest file 94.0s ->
+//   114.1s): the box is saturated, so this is packing, not work. Re-measured on
+//   the commit above, and the 2026-08-20 verdict reproduced in every term. In CI
 //   the box is not this package's — `ci.yml` runs `turbo run test
 //   --concurrency=4` — so pinning a worker count here spends cores belonging to
 //   whatever else lands on the shard. Worker allocation is a property of the
 //   shard, decided in `ci.yml`, not of this config (#10149).
 //
-//   `NODE_COMPILE_CACHE` for the spawned processes — measured 6.98/6.24/6.41/
-//   6.18s cached vs 6.39/6.72s uncached, i.e. inside noise for 42MB of cache.
-//   The per-spawn cost is module-graph EXECUTION, not compilation.
+//   `NODE_COMPILE_CACHE` for the spawned processes — re-measured 5.15/5.34/
+//   5.16/5.42s cached against 5.46/5.61/5.64/5.71s uncached, for 42MB of cache
+//   (783 files). ⚠️ Unlike the 2026-08-20 reading, where the two sets
+//   overlapped and the answer was "inside noise", these four-and-four do not
+//   overlap: cached is consistently ~0.3s (~5%) faster. It is still not the
+//   lever — that is an order of magnitude less than the 3.11s the built entry
+//   already saves per spawn, and it buys 42MB to get it. The per-spawn cost is
+//   module-graph EXECUTION, not compilation.
 //
 // So the work is real, the price is fair, and nothing contained in this package
 // removes it without changing what the e2e tests assert.


### PR DESCRIPTION
Fixes #12499

Re-measures the suite-cost section of `packages/cli/vitest.config.ts` on a
stated commit, and collapses the file's two file/test vintages (*135 / 1470* in
one section, *137 / 1498* in the next) into one measured population stated once.
Comment text only.

Extends [#12494](https://github.com/objectstack-ai/objectstack/pull/12494)
(#12460), which tensed these sentences and declared the non-re-measure. This PR
is that re-measure; it does not re-open anything #12494 settled.

## Why the old figures could not be re-checked

The section was dated `2026-08-20` and anchored to nothing. Between that date
and `2f665a1af` the population it described moved twice over, and none of it was
visible from inside the file:

| | 2026-08-20 | `2f665a1af` |
|---|---|---|
| files / tests | 137 / 1498 | **185 / 2115** |
| spawner files | 20 | **39** |
| wall (`--maxWorkers=2`) | 495.81s | **793.31s** |

A date says when someone looked. A commit says *what* they looked at, and only
the second can be re-checked — so the header now prints the sha beside the
numbers, and the counts live in exactly one place in the file.

## What was measured, and how

One box, 4 cores, warm build, `vitest run --maxWorkers=2` per package, vitest
4.1.10 on node 22.22.2 — the 2026-08-20 protocol, re-run. Every run held the
container's shared heavy-verify lock (`scripts/pm/os-verify-lock.sh`), because
several agents share this box.

**Contention actually seen, since a cost measurement taken beside a neighbour's
build is a reading about the box:** the `--maxWorkers=2` run waited 4m01s behind
a neighbouring agent's `@objectstack/cli^...` build, then held the lock 13m14s.
The lock serialises *locked* work only — a neighbour's **unlocked** gate script
was observed at ~130% CPU partway through, and 1-minute load averaged 4.36
(peak 6.97) across the run.

## Results

### The one population, stated once

**185 files / 2115 tests** on `2f665a1af`, all passing. Both stale copies
(*135 / 1470*, *137 / 1498*) are gone; the count now appears in exactly one
place in the file, and the `Why the service-cache entry` section points at it
rather than keeping a second copy.

### Concentration — re-measured, and it moved in two directions at once

| | 2026-08-20 | `2f665a1af` |
|---|---|---|
| median file | 0.03s | 0.05s |
| files under 2s | 105 of 137 | 129 of 185 |
| top 20 files, share of file wall | 87.7% | **71.3%** (965.3s of 1353.1s) |
| CLI-spawning files | 20 | **39** |
| their share of the file wall | 56.1% (300.1s) | **89.4%** (1209.8s) |
| tests they carry | 177 of 1498 | 319 of 2115 |

⭐ The two shares moved in **opposite** directions, and that is the finding: the
spawner set nearly doubled, so it now holds almost the whole wall (56.1% ->
89.4%) while the top-20 concentration *fell* (87.7% -> 71.3%) because the same
kind of cost is spread over more files. Reading either number alone gives the
wrong story. All twenty of the top 20 are spawners.

"File wall" is now defined in the header as the sum of per-module run durations,
which is the same quantity vitest prints as the `tests` term of its own
`Duration` line — so the two can be checked against each other instead of
drifting.

### All six rows of the cross-package table are one vintage

Refreshing only the `cli` row would have left the "both normalisers" argument
comparing 2026-08-26 against 2026-08-20, so all six packages were re-run on
`2f665a1af`, plus a second `cli` run at `--maxWorkers=4` for the worker A/B and
a fresh `NODE_COMPILE_CACHE` A/B. Nine measured runs in total, all green.

⚠️ `example-showcase` failed 9 of 26 files the first time — `Failed to resolve
entry for package "@objectstack/connector-rest"`, i.e. packages outside the
`cli` closure I had built. A red suite's wall is not a cost measurement, so its
closure was built and it was re-run green (26 files / 364 tests) before entering
the table. In CI this cannot happen: turbo's default `test` task declares
`dependsOn: ["^build"]`.

### Per-spawn floor — absolutes moved, the ratio held

| | 2026-08-20 | `2f665a1af` |
|---|---|---|
| `tsx bin/run-dev.js --version` | 6.5-6.8s | **5.45-6.07s** |
| `node bin/run.js --version` | 2.9-3.2s | **2.46-2.66s** |
| `node -e 0` | 0.031s | **0.025-0.031s** |
| source / built (means of 5 runs each) | 2.18x | **2.21x** |

⭐ Exactly the #11707 precedent: the seconds did not reproduce, the ratio did.
The header now says which of its numbers are box-dependent (all the seconds) and
which a reader on another box should expect to reproduce (the ratios).

### By entry point, and a trap in reading it

|  | files | file wall | s/file | tests | s/test |
|---|---|---|---|---|---|
| `bin/run-dev.js` (source) | 35 | 1169.2s | 33.4 | 311 | 3.8 |
| `bin/run.js` (built) | 4 | 40.6s | 10.1 | 8 | 5.1 |

⛔ That is **not** a measurement of what the two entries cost — the four built-entry
files are also the smallest here (2.0 tests/file against 8.9) and per *test* the
ordering reverses. The header says so, and points at the floor table for the
entry cost. Re-deriving 3.3x from this row would have been wrong in the same way
that scaling the old figures by 2.06x would have been.

## Instrument controls

⛔ Nothing here reports a zero or an "unchanged" that the instrument was not
first shown capable of contradicting:

- **Timer** — positive control at known ground truth: a 500ms busy-wait reads
  0.530-0.535s, a 2000ms one reads 2.024-2.032s.
- **Timer, negative** — `node bin/run-NOPE.js --version` (an entry that does not
  exist) returns in **0.030s and exit 1**: pure timing reads a nonexistent
  command as the best floor on the board. Every floor row was checked for
  exit 0.
- **`setup 0ms`** — the reporter was re-run against a deliberate 300ms
  setup file and printed `setup 618ms` (2 modules), so the zero is a fact about
  the suite, not a blind spot.
- **Per-module reporter** — validated against a two-file probe with known
  contents (2 files / 3 tests / 617ms wall, one test made to cost 400ms), and
  it reports both extremes in the real run (0.000s and 93.96s).
- **Log parser** — the same parser was run over the probe log whose true values
  are known before it was pointed at the real ones.
- **Spawner classifier** — a spelling known absent returns zero, a spelling
  known present returns its lines. ⚠️ Its first pass **undercounted by three**:
  those files assemble the entry from separate literals
  (`join(…, '..', 'bin', 'run-dev.js')`), so a slash-joined pattern missed them
  while still returning a plausible number. Prose mentions were excluded the
  other way — one file names the entry four times and explicitly does not spawn
  it. Both traps are now written into the header.
- **Comment-only claim** — the filter that says this diff touches no code was
  run over `c48f9a0e7` (which *did* change code in this file: 7 lines reported)
  and over `3d8d2f15d` (comment-only: silent) before being trusted here.

## Scope

`packages/cli/vitest.config.ts` only, comment text — the emitted config object
is byte-identical. The four `dist`-consuming test files, the three spawners
#12441 is in flight on, and `turbo.json` are untouched. `skip-changeset`:
nothing published changes.

⚠️ **Reported, not acted on:** the header's **conclusion has not changed**, so
nothing in it was rewritten. `tests` is still the dominant term by a wider
margin than before (1353.09s against 203.72s import and 25.17s transform), so
*"before adding a `test` block, re-measure: if `tests` is still the dominant
term, the block is not the lever"* still points the right way. Two **supporting
figures** moved and were restated rather than re-argued — both verdicts stand:

- per-file transform cost is now **second-lowest** of the six, not lowest
  (`spec` is below it at 0.036s/file). The claim it supports — the wide
  dependency closure is not what the test files import — is if anything
  stronger, since `cli` is now second-lowest on import per file too.
- the `NODE_COMPILE_CACHE` A/B no longer reads as *"inside noise"*: cached
  (5.15/5.16/5.34/5.42s) and uncached (5.46/5.61/5.64/5.71s) do **not** overlap
  across four samples each. It is still rejected — ~0.3s (~5%) for 42MB, against
  the 3.11s the built entry already saves per spawn.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_