### PR TITLE
build(rest): give the package a test-layer tsc program and ledger its 37 errors

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -17,7 +17,9 @@
     "build": "tsup --config ../../tsup.config.ts && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc -w",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "check:test-typecheck": "tsx ../../scripts/check-test-typecheck.mts --self-test && tsx ../../scripts/check-test-typecheck.mts --package packages/rest --project tsconfig.test.json",
+    "gen:test-typecheck-debt": "tsx ../../scripts/check-test-typecheck.mts --update --package packages/rest --project tsconfig.test.json",
+    "typecheck": "tsc --noEmit && pnpm check:test-typecheck"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",
@@ -40,6 +42,7 @@
     "@objectstack/service-analytics": "workspace:*",
     "@objectstack/service-datasource": "workspace:*",
     "@types/node": "^26.2.0",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/rest/test-typecheck-debt.json
+++ b/packages/rest/test-typecheck-debt.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Per-file tsc error debt of the @objectstack/rest TEST layer (#5286). `tsconfig.test.json` compiles `src/**/*.test.ts` — which `tsconfig.json` excludes and therefore no gate ever read — and every file below still carries errors from before that gate existed, almost all of them fixture literals annotated with a schema OUTPUT type (`z.infer`) while holding an authored INPUT literal. EXACT ratchet, judged by re-running tsc: a file that gains errors is red, a file that loses them is red until its number is re-recorded, a file that reaches zero is red until its entry is deleted, and a file NOT listed here may have no errors at all. Regenerate with: pnpm --filter @objectstack/rest gen:test-typecheck-debt",
+  "entries": {
+    "src/analytics-read-scope-refusal-envelope.test.ts": 1,
+    "src/export-integration.test.ts": 17,
+    "src/import-dryrun-parity.test.ts": 1,
+    "src/import-integration.test.ts": 3,
+    "src/import-job-integration.test.ts": 2,
+    "src/meta-public-book-grant.test.ts": 1,
+    "src/rest-batch-size-cap.test.ts": 1,
+    "src/rest-expected-error-logging.test.ts": 1,
+    "src/rest-meta-outage-vs-miss.test.ts": 1,
+    "src/rest-meta-save-receipt-envelope.test.ts": 3,
+    "src/rest-unclassified-fault-status.test.ts": 1,
+    "src/rest-write-response-formula.test.ts": 1,
+    "src/rest.test.ts": 4
+  }
+}

--- a/packages/rest/tsconfig.test.json
+++ b/packages/rest/tsconfig.test.json
@@ -1,0 +1,77 @@
+// The TEST-layer type-check program (#12542, adopting the mechanism #5286 set
+// for `packages/spec` and #5449 generalised). `tsconfig.json` above stays as it
+// is: it is the BUILD config, and its `**/*.test.ts` / `**/*.spec.ts` exclusion
+// has a reason — ci.yml gates that no test file reaches the published artifact.
+// This sibling puts the excluded layer back in front of tsc, and
+// `package.json`'s `typecheck` script NAMES it (via `check:test-typecheck
+// --project`), because a config no script invokes is exactly the phantom this
+// whole change is about.
+//
+// BEFORE THIS FILE, NO tsc PROGRAM COMPILED A SINGLE TEST FILE HERE. All 149 of
+// them were named by the build config's `exclude`, and `typecheck` was
+// `tsc --noEmit` against that very config — so `pnpm --filter @objectstack/rest
+// typecheck` exiting 0 was a true sentence carrying no information about any
+// test file in the package, and both `@ts-expect-error` directives in this
+// layer (`src/rest.test.ts`, `src/rest-api-plugin-slot-lookups.test.ts`) were
+// phantom checks that evaluated never. Under this program neither reports
+// TS2578, so both are live and each is suppressing a real error.
+//
+// What differs from the build config, and what deliberately does NOT:
+//   - module semantics ONLY, plus `lib`. The tests are written and executed as
+//     ESM by vitest (esbuild/vite), and this package IS `"type": "module"`, so
+//     the build config's NodeNext compiles them as ESM too — and then demands
+//     explicit `.js` extensions on relative imports, which vitest does not.
+//     That one mismatch was 72 x TS2835 and, above each of them, the 49 x
+//     TS7006 they caused: an import that does not resolve makes every symbol it
+//     names `any`. `lib` inherits as ES2020 from the root config, which was 16 x
+//     TS2550 — all sixteen the same `Array.prototype.at` message. Those 137
+//     diagnostics were about the CHECK, never about the code. Matching vitest is
+//     fidelity, not laxity. No `DOM` in `lib`, unlike `packages/client`: nothing
+//     in this layer touches a browser global.
+//   - ⛔ STRICTNESS IS UNTOUCHED. `strict`, `noUnusedLocals`,
+//     `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`
+//     are inherited from the root config, and `types: ["node"]` from
+//     `tsconfig.json`. Nothing here may loosen a type rule; if a test does not
+//     compile, that is the finding.
+//
+// ⚠️ WHAT THIS PROGRAM INHERITS FROM `tsconfig.json`, both of them load-bearing
+// and neither of them re-declared here (read that file's #9960 comment first):
+//   - `rootDir: ".."`. Already widened to `packages/` there, as a CONSEQUENCE
+//     of the `paths` rule below rather than a preference. So the TS6059 pile
+//     that `packages/client`'s sibling config had to widen `rootDir` to clear
+//     does not arise here — it was paid for already, and this file changes
+//     nothing about it.
+//   - `paths: { "@objectstack/metadata-protocol": [".../src/index.ts"] }`. A
+//     child that declared its own `paths` would REPLACE this map rather than
+//     merge into it, silently sending that specifier back to `dist/`. This file
+//     declares no `paths` at all, so the rule stands and 22 of the producer's
+//     source files are in this program, exactly as they are in the build one.
+//
+// MEASURED at 5fbd58e0d, workspace closure built first: `--listFiles` puts 149
+// `src/**/*.test.ts` in the program (489 files total), and the layer reports 37
+// errors across 13 files — TS2554 x14 (wrong arity, all fourteen 'Expected 2-5
+// arguments, but got 1'), TS18048 x13 (all in `src/export-integration.test.ts`),
+// TS2345 x5, TS7006 x4, TS6133 x1. Every one of the 37 is pre-existing: this
+// change edits no test file, and each error would have been reported on
+// `origin/main` had this program always existed. They are ledgered per file in
+// `test-typecheck-debt.json` beside this config, EXACT and shrink-only — a file
+// that gains an error is red, one that loses one is red until re-recorded, one
+// that reaches zero is red until its entry is deleted, and a file NOT listed
+// there may have no errors at all.
+//
+// ⚠️ `src/rest.test.ts` (4 of the 37) is also held by PR #12421, and the two
+// interact BY DESIGN. After that PR merges: an error it adds to that file reds
+// the ledger on ITS run, and an error it removes reds the entry as stale on the
+// next run. Both are the pin working, and both land on the change that caused
+// them — but only if the next reader knows the coupling is there.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2055,6 +2055,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -746,6 +746,26 @@ const EXEMPT = {
 // interchangeable only where the excluded tests import nothing the src layer
 // does not, and that is a property to MEASURE per package, never to assume.
 //
+// `@objectstack/rest` GRADUATED from this ledger (#12542; entry: 155 raw,
+// re-measured 37 raw across 13 files under the sibling program). It is worth a
+// line because the gap between those two numbers is the whole argument for
+// fixing the CONFIG before reading the residue, and this entry's own note had
+// predicted it: 121 of the 155 were TS2835 plus the implicit-any pile it
+// causes, and TS2550 x16 was one `Array.prototype.at` message against a `lib`
+// older than es2022. Under `tsconfig.test.json`'s vitest-matching module
+// semantics both classes go to ZERO -- TS2835 x72 -> 0, TS2550 x16 -> 0,
+// TS7006 x49 -> 4 -- because this package is `"type": "module"`, so NodeNext
+// was compiling extensionless relative imports as unresolvable ESM and every
+// symbol they named was `any`. What is LEFT is a different shape from what the
+// old tally described, and it grew in one place while collapsing in four:
+// TS2554 x14 (unchanged to the unit), TS18048 x13 (a class the 155 never
+// contained AT ALL -- 'possibly undefined' reads that only become visible once
+// the imports above them resolve to real types), TS2345 x5, TS7006 x4,
+// TS6133 x1 = 37. That is the #8612 lesson this ledger already carries,
+// measured a second time: collapsing a cascade EXPOSES errors as well as
+// removing them, and a note sized on the TS2835 line alone would have read as
+// "155 minus 121 = 34" and been wrong in both directions.
+//
 // SINCE MEASURED, across this whole ledger rather than on that one package
 // (#11491, at e47d5ef61, by dropping each entry's `"**/*.test.ts"` exclusion
 // and reading `check:type-source-resolution`): 14 of the 18 entries that HAVE
@@ -871,64 +891,6 @@ const TEST_DEBT = {
       + 'resolves, so budget for a repair being bigger than its TS2835 line suggests. '
       + 'RECORDED EXACTLY, no bootstrap margin: this layer has never been gated, so the first new error in '
       + 'it should go red rather than be absorbed.',
-  },
-  '@objectstack/rest': {
-    errors: 155,
-    note: 'RE-TALLIED from tsc at the 155 below (#10821), measured at 951b025e4 with the workspace closure '
-      + 'built by the same command lint.yml runs before this gate, so the composition, the per-file split '
-      + 'and the total are ONE measurement rather than a rescale: TS2835 x72 (NodeNext extensions), '
-      + 'TS7006 x49, TS2550 x16 (`Array.prototype.at` against a `lib` older than es2022 -- all 16 are that '
-      + 'one message), TS2554 x14 (wrong arity, all 14 \'Expected 2-5 arguments, but got 1\'), plus 4 '
-      + 'singletons (TS2769 x2, TS2345, TS6133). 72+49+16+14+4 = 155, which is the recorded number '
-      + 'EXACTLY -- this entry carries no remainder clause because it no longer needs one, and RECORDED '
-      + 'still equals the measurement with no margin. '
-      + 'WHAT THIS REPLACES, and why none of it was rescaled: the old tally read \'TS2835 x67, TS7006 x57, '
-      + 'TS2554 x13, TS2550 x10 (composition as counted at 153; not re-tallied by class at the 155 '
-      + 'below)\'. It summed to 147 with no clause for the remaining 6, so a reader could not tell an '
-      + 'ABRIDGED tally from a SHORT one -- both readings were open and neither was checkable from the '
-      + 'ledger. Both halves are settled here, and only one of them was ever answerable: (a) the 6 are NOT '
-      + 'attributed and never will be. The per-class breakdown at e8db1a230 was not retained, so they are '
-      + 'retired WITH the tally that carried them rather than invented, on this ledger\'s own rule that a '
-      + 'made-up attribution is worse than an admitted gap. (b) 153-vs-155 was never one measurement '
-      + 'disagreeing with itself: 153 was measured at e8db1a230, RECORDED was later lowered onto a '
-      + 'DIFFERENT measurement (155 at 55da611, #6939), and the composition was never re-taken across that '
-      + 'move -- which is precisely what the \'not re-tallied by class\' clause was saying out loud, and '
-      + 'why it was honest rather than sloppy. Rescaling the old numbers onto 155 would have been wrong in '
-      + 'any case, and the re-tally shows it: the shape moved in BOTH directions -- TS2835 67 -> 72, '
-      + 'TS2550 10 -> 16 and TS2554 13 -> 14 rose while TS7006 57 -> 49 FELL -- and two classes the old '
-      + 'tally never named (TS2769, TS2345) are in the pile now. '
-      + 'Graduated from DEBT in #6905 -- this TEST_DEBT '
-      + 'entry is now the sole gate on the package\'s test layer (src moved to `turbo run typecheck`). '
-      + 'Measured '
-      + '105 -> 136 (5ab08428) -> 143 (77adf29, hours later the same day) -> 153 (e8db1a230) -> 155 '
-      + '(55da611) -> still 155 (951b025e4, the re-tally above). Read the '
-      + 'top-of-ledger NodeNext note before sizing this one: TS2835 and the implicit-any pile it causes '
-      + 'are 121 of the 155, and '
-      + 'they are 72 IMPORT-LINE repairs, not 121: the 72 TS2835 sit on 72 distinct lines across 64 files '
-      + 'but name only 11 distinct targets, and 49 of the 72 are the single `./rest-server` import. Every '
-      + 'one of the 22 files carrying a TS7006 also carries a TS2835 -- no exceptions -- so there is no '
-      + 'implicit-any in this layer without a broken import above it, and 31 of the 49 are one parameter '
-      + 'name (`r`). Budget for the cli lesson (#8612) that collapsing a cascade can EXPOSE errors as well '
-      + 'as remove them. Concentrated at the top and flat after: src/rest.test.ts x38 (TS7006 x21, '
-      + 'TS2550 x11, TS2835 x4, TS2345 x1, TS6133 x1) and no other file above x5. '
-      + 'Of the +10 that then bumped 153 to a bootstrap-margin RECORDED 163, '
-      + '8 are attributable to three test files that '
-      + 'window added -- rest-meta-save-receipt-envelope.test.ts x4 (#5265 / PR #5926), '
-      + 'meta-item-envelope.test.ts x2 (#5563 / PR #5895), '
-      + 'analytics-dataset-unlisted-refusal-envelope.test.ts x2; the remaining 2 landed in files that '
-      + 'already existed and are NOT attributed further, because the pre-merge per-file counts were not '
-      + 'retained and a made-up attribution is worse than an admitted gap. This is also the '
-      + 'fastest-moving entry in either ledger, and it is '
-      + 'the one that proved the gate works: #5278\'s own PR went red in CI on it, because a `pull_request` '
-      + 'run builds the branch MERGED INTO main and three rest-touching PRs had landed since the sweep. A '
-      + 'ledger number is always a number about a moment. RECORDED 163 stood as that bootstrap margin (+10 '
-      + 'over 153 measured at e8db1a230 and re-confirmed at 153 an hour later at 77c7c884b) until #6939 '
-      + '(a surplus finding filed right after the #6905 DEBT graduation) re-measured tsc at 155 -- an 8-error '
-      + 'surplus the margin had been silently absorbing, and #7038 caught the note\'s "Also in DEBT." sentence '
-      + 'going stale in the same graduation. Lowered 163 -> 155 at 55da611 (#6939, #7038): RECORDED now '
-      + 'equals the exact measurement, no margin, so the next new error here goes red immediately -- a '
-      + 'bootstrap margin can be re-established deliberately later if that slack is wanted again '
-      + '(#5278 option A).',
   },
   '@objectstack/plugin-auth': {
     errors: 97,

--- a/scripts/check-type-source-resolution.mjs
+++ b/scripts/check-type-source-resolution.mjs
@@ -319,9 +319,35 @@ const KNOWN_DIST_RESOLVED_TYPE_IMPORTS = {
     '@objectstack/core', '@objectstack/formula', '@objectstack/metadata-core', '@objectstack/objectql',
     '@objectstack/platform-objects', '@objectstack/spec', '@objectstack/types',
   ],
+  // #12542: `packages/rest` had NO tsc program compiling any of its 149 test
+  // files, and its new `tsconfig.test.json` (the #5286 sibling route) is the
+  // first one that does. The six deps after `@objectstack/core` here arrive
+  // from that program, exactly as `@objectstack/client`'s and
+  // `@objectstack/trigger-record-change`'s test-program deps do above.
+  //
+  // ⚠️ This is a program-set widening and its numbers are stated, per this
+  // registry's own rule: before, at 5fbd58e0d, `--list` reported 93 programs /
+  // 77 packages, 54 entries, 233 pairs; after, 94 programs / 77 packages, 54
+  // entries, 239 pairs. +1 program, +0 entries, +6 pairs, all six in this one
+  // package and all six reached only through `tsconfig.test.json`.
+  //
+  // Why the entry and not `paths` rules, which is what this gate's failure text
+  // asks for: MEASURED both ways on the same checkout. `paths` redirecting
+  // these six to source puts their `src` trees in the program and takes the
+  // test layer from 37 errors to 42 — the +5 being TS6133 in
+  // `../plugins/plugin-hono-server/src/{hono-plugin,current-user-endpoints}.ts`
+  // and `../drivers/driver-sql/src/sql-driver.ts`, i.e. OTHER packages' source
+  // billed to `packages/rest/test-typecheck-debt.json`, where they would then
+  // red on those packages' PRs. It would also make the type program diverge
+  // from the runtime one: `packages/rest/vitest.config.ts` aliases exactly two
+  // of the six (`plugin-hono-server`, `service-datasource`) to source and
+  // resolves the other four through `dist/`, so blanket `paths` here is not
+  // fidelity to vitest either.
   '@objectstack/rest': [
-    '@objectstack/core', '@objectstack/metadata-core', '@objectstack/objectql',
-    '@objectstack/observability', '@objectstack/platform-objects', '@objectstack/service-package',
+    '@objectstack/core', '@objectstack/driver-sql', '@objectstack/metadata',
+    '@objectstack/metadata-core', '@objectstack/objectql', '@objectstack/observability',
+    '@objectstack/platform-objects', '@objectstack/plugin-hono-server', '@objectstack/plugin-security',
+    '@objectstack/service-analytics', '@objectstack/service-datasource', '@objectstack/service-package',
     '@objectstack/spec', '@objectstack/types',
   ],
   '@objectstack/runtime': [


### PR DESCRIPTION
Fixes #12542

`packages/rest/tsconfig.json` excludes `**/*.spec.ts` and `**/*.test.ts`, and the
package's `typecheck` script was `tsc --noEmit` against that config and nothing
else. So **no tsc program compiled a single test file in the package** — the
shape AGENTS.md names twice ("never exclude `*.test.ts`", "a `@ts-expect-error`
in a file no tsc program compiles is a phantom check"), sitting live in one of
the repo's largest packages.

## Premise, re-derived rather than inherited

At `5fbd58e0d` (my branch base; the card measured at `52a982388`):

| claim | measured |
|---|---|
| `include` / `exclude` | `["src/**/*"]` / `["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]` |
| `typecheck` script | `tsc --noEmit`, that program and nothing else |
| test files | **149** (`git ls-tree -r --name-only HEAD -- packages/rest \| grep -cE '\.test\.ts$'`) |
| `.spec.ts` files | **0** — the `**/*.spec.ts` half of the exclusion covers nothing |
| all under `src/`? | yes, 149/149 — nothing hidden by an unreachable `include` |
| `tsconfig.test.json` / `test-typecheck-debt.json` | absent |
| `check:test-typecheck` wired | no |

The card's numbers hold exactly, at both shas. Only the `.spec.ts` line is an
addition: the exclusion's second glob was already inert.

## What landed — an adoption, not an invention

`packages/rest/tsconfig.test.json` follows `packages/client`'s and
`packages/spec`'s landed shape: **module semantics only, plus `lib`**, with
strictness inherited and untouched. It is named by the `typecheck` script
through the shared `scripts/check-test-typecheck.mts` gate, because a config no
script invokes is exactly the phantom this change is about:

```
"typecheck": "tsc --noEmit && pnpm check:test-typecheck"
```

`tsx` joins `devDependencies` for the same reason `packages/client` and
`packages/spec` carry it — the shared gate runs through it.

### What the program INHERITED, and did not re-declare

`packages/rest/tsconfig.json` already carries two `#9960` settings, both
load-bearing, and this file deliberately re-declares neither:

- **`rootDir: ".."`** — already widened to `packages/` there, as a consequence
  of the `paths` rule rather than a preference. So the TS6059 pile that forced
  `packages/client`'s sibling config to widen `rootDir` does not arise here; it
  was paid for already.
- **`paths: { "@objectstack/metadata-protocol": [".../src/index.ts"] }`** — a
  child that declared its own `paths` would **replace** this map rather than
  merge into it, silently sending that specifier back to `dist/`. This file
  declares no `paths` at all, so the rule stands and 22 of the producer's source
  files are in the test program exactly as they are in the build one.

## The number nobody had (ruling 5), measured at `5fbd58e0d`

**37 errors across 13 files**, with the workspace closure built first
(`pnpm --filter '@objectstack/rest^...' build`, exit 0).

| code | count | note |
|---|---|---|
| TS2554 | 14 | wrong arity, all fourteen "Expected 2-5 arguments, but got 1" |
| TS18048 | 13 | "possibly undefined", all in `src/export-integration.test.ts` |
| TS2345 | 5 | |
| TS7006 | 4 | implicit any |
| TS6133 | 1 | unused local |

Neither stop-and-report fork fires: 37 is above the "small, `client`-scale"
threshold and nowhere near "enormous", and it is not one producer-side defect
wearing many files' clothes — five codes across 13 files, the largest single
file holding 17.

**Ruling 4's question, answered for all 37: would this error exist on
`origin/main` if the program had always been there? Yes, for every one.** No
test file is edited by this PR; the program differs from the build config only
in module semantics and `lib`, and each of the 37 sits on a line that predates
this branch. None is caused by the change, so all 37 are ledger entries in
`packages/rest/test-typecheck-debt.json` — EXACT and shrink-only.

### Why the 155 in TEST_DEBT became 37

Not a rescale — the old entry predicted it. 121 of its 155 were TS2835 plus the
implicit-any pile TS2835 causes, and 16 more were one `Array.prototype.at`
message against a `lib` older than es2022. This package is `"type": "module"`,
so NodeNext was compiling extensionless relative imports as unresolvable ESM and
every symbol they named became `any`. Under vitest-matching semantics TS2835
x72 goes to 0, TS2550 x16 to 0, TS7006 x49 to 4. What is **left** is a different
shape, and it grew in one place while collapsing in four: TS18048 x13 is a class
the 155 never contained at all — "possibly undefined" reads that only become
visible once the imports above them resolve to real types. Sizing this off the
TS2835 line alone would have said "155 − 121 = 34" and been wrong in both
directions. That is the #8612 lesson, measured a second time.

## No test file is edited (ruling 3), and the #12421 coupling

Zero test files are touched: the deliverable is the program plus the measured
ledger. **PR #12421 holds `packages/rest/src/rest.test.ts`**, which carries 4 of
the 37 and therefore has a ledger *entry* — which collides with nothing, where an
*edit* would have been a serial breach.

⚠️ **The two interact by design, and the next reader needs to know it.** The
ledger is EXACT and shrink-only, so once #12421 merges: an error it **adds** to
`rest.test.ts` reds the ledger on **its** run ("the debt GREW"); an error it
**removes** reds the entry as stale until re-recorded ("the debt SHRANK"). Both
are the pin working, and both land on the change that caused them.

Both `@ts-expect-error` directives in this layer — in `src/rest.test.ts` and
`src/rest-api-plugin-slot-lookups.test.ts` — were phantom checks that evaluated
never. Under this program neither reports TS2578, so both are live and each is
suppressing a real error.

## Anti-vacuity: the program can say no (ruling 6)

**Membership.** `tsc -p tsconfig.test.json --listFiles` puts **149** of
`packages/rest/src/**/*.test.ts` in the program — the exact census — out of 489
files total.

**Ablation.** A real type error planted in `src/analytics-routes.test.ts`, an
**unledgered** file, so the everyday verdict is what gets exercised:

```
HEAD blob hash             : d533503f6e47ac65d36be9066dcded31dc48aca8
mutated disk hash          : 7a92cb594097f9f902f1a303ca83f637e7238a8a
injected marker occurrences: 1
MUTATION CONFIRMED ON DISK
GATE_EXIT=1
  - src/analytics-routes.test.ts: 2 type error(s) in a file the ledger does not cover.
post-restore disk hash     : d533503f6e47ac65d36be9066dcded31dc48aca8
RESTORE PROVEN: disk hash == HEAD blob hash, and `git diff HEAD` is empty for the path
```

The gate exits non-zero and **names the file**. The restore ran from a trap on
`EXIT`/`INT`/`TERM` against absolute paths, used `git checkout HEAD -- path`
(never the bare form, which restores from a polluted index), and is proven by
blob hash — never by an exit code. It reports **2** errors, not 1: the second is
`noUnusedLocals` on the planted binding, which is itself evidence that inherited
strictness is live. No build or `dist/` is involved on either leg — tsc reads
these sources directly — so there is no artifact staleness to preflight.

## Two mechanical consequences, both required by gates rather than chosen

**1. `@objectstack/rest` graduates out of TEST_DEBT.** Once the `typecheck`
script names the sibling config, `check:type-check-coverage` reports
`has a TEST_DEBT entry but ... no longer hides its tests -- it graduated`. The
entry is deleted and a graduation note recorded in its place, per the file's own
convention. Headline moves: 19 → **18** packages hiding tests, 1110 → **965**
hidden files, 1461 → **1306** frozen errors — exactly −1 package, −149 files,
−155 errors.

**2. `check:type-source-resolution` sees a new program, and this is the one
judgement call in the PR — flagged rather than buried.** Since #11490 that gate's
population is every `tsconfig*.json` a `typecheck` script names, so the new
program joins it and reports six workspace deps the build program never reached:
`driver-sql`, `metadata`, `plugin-hono-server`, `plugin-security`,
`service-analytics`, `service-datasource` — all six *via* `tsconfig.test.json`.

I recorded them in that package's registry entry, with the program-set numbers
stated in place as the registry's own rule requires: before, at `5fbd58e0d`,
`--list` reported **93 programs / 77 packages / 54 entries / 233 pairs**; after,
**94 / 77 / 54 / 239**. +1 program, +0 entries, +6 pairs.

The gate's failure text asks for `paths` rules instead and calls registry
widening "not the fix", so here is why I did not do that — **measured both ways
on the same checkout**, not argued:

- `paths` redirecting the six to source takes the test layer from **37 errors to
  42**, and the +5 are TS6133 in
  `../plugins/plugin-hono-server/src/{hono-plugin,current-user-endpoints}.ts` and
  `../drivers/driver-sql/src/sql-driver.ts` — **other packages' source billed to
  `packages/rest/test-typecheck-debt.json`**, where they would then go red on
  those packages' PRs. Worse, those five are not even real: both packages run
  `pnpm --filter ... typecheck` green on this same tree (exit 0, measured), so
  the borrowed program MANUFACTURES diagnostics that belong to nobody. A ledger
  seeded with those cannot be paid down by the package that owns the file.
- It would also make the type program diverge from the runtime one:
  `packages/rest/vitest.config.ts` aliases exactly **two** of the six
  (`plugin-hono-server`, `service-datasource`) to source and resolves the other
  four through `dist/`. Blanket `paths` is not fidelity to vitest either.
- The landed precedent for this exact shape is the registry entry, twice:
  `@objectstack/client` and `@objectstack/trigger-record-change` both carry
  test-program deps there, the latter being the package that took this very
  `#5286` sibling route.
- Ruling 1 is "module semantics ONLY". A six-entry `paths` block is not that.

⚠️ The tension is real and I am naming it, not resolving it unilaterally: the
registry's doc-block permits a widening when **the set of programs changed** —
which is literally true here, 93 to 94 — but adds "that is a change to this file,
not to a package", written when the gate read only `tsconfig.json` and a package
could not move the population. This PR is the first case where a package does.
Happy to switch to `paths` if a maintainer reads that sentence as binding.

## Verification

All runs below are at **`2dfb401c1`**, the pushed head, taken after the final
commit. Every exit code captured **before** any pipe (redirect, then `$?`).

- `pnpm --filter @objectstack/rest typecheck` — exit 0. Gate's own verdict line:
  `check:test-typecheck: OK — @objectstack/rest's test layer compiles under
  packages/rest/tsconfig.test.json; 13 file(s) / 37 error(s) held in
  test-typecheck-debt.json (shrink-only)`.
- 25 gate families from `node scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` against the real change set, **all exit 0** —
  including `check:type-check-coverage`, `check:type-source-resolution`,
  `check:published-files`, `check:test-source-alias`, `check:nul-bytes`,
  `check:pm-dispatch-gates` and `scripts/pm/bare-root-worklist.mjs --self-test`
  (the last two are the convention-triggered pair this diff incurs by editing
  gate scripts).
- `pnpm lint` (`eslint . --no-inline-config`, the whole repo, not narrowed) —
  exit 0, `VERDICT command-exit 0`.
- Heavy runs serialised through `scripts/pm/os-verify-lock.sh`; every one ended
  `VERDICT command-exit 0`.

**One declared narrowing: `pnpm check:type-check-debt` was NOT run.** It is
`check-type-check-coverage.mjs --re-measure`, and it refuses on this worktree —
`--re-measure cannot run: 32 workspace dependenc(ies) of the ledgered packages
have no built type entry point on disk`. That is a PREREQUISITE NOT MET, not a
red gate: it declines to measure rather than measuring a different world. Its
prerequisite is the full workspace build that `lint.yml` runs before the step,
which CI does on this PR regardless. Three things make the omission a
measurement rather than a gap: `--re-measure` scores each ledgered package under
its **own** tsconfig, and `@objectstack/rest` is in neither ledger after this
diff, so it is not among the projects measured; outside `packages/rest` this diff
changes only two gate scripts' data and prose — no package's tsconfig and no
package's source; and the lockfile delta is exactly **three lines** in
`packages/rest`'s own importer, adding an already-resolved `tsx@4.23.12`, so no
other package's closure moved. The structural half of the same gate —
`check:type-check-coverage`, which owns TESTS_COVERED, PINS_CHECKED, RECONCILED
and the composition invariants, and is what this diff actually moves — ran green
above.

## Changeset: deliberately none, and the rule applied

`packages/rest`'s `files` is `["dist", "README.md", "CHANGELOG.md"]`. This PR
changes no `src/` file, so `dist/` is byte-unaffected; `tsconfig.test.json` and
`test-typecheck-debt.json` are not published; and `tsx` is a **dev**Dependency no
consumer installs. Nothing is released, which is the `skip-changeset` label's
own definition in `pr-automation.yml`. The in-tree precedent for this exact
change shape is `951b025e4` —
`build(trigger-record-change): graduate the package out of the TEST_DEBT ledger`
(PR #11489), `package.json` + `tsconfig.test.json` + the coverage gate, no
changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_