### PR TITLE
docs(spec): record the eager glob-discovery disposition beside `filePatterns`

### DIFF
--- a/packages/spec/src/kernel/metadata-plugin.zod.ts
+++ b/packages/spec/src/kernel/metadata-plugin.zod.ts
@@ -217,6 +217,30 @@ const MetadataTypeRegistryEntryBaseSchema = z.object({
   /**
    * File glob patterns for this type.
    * Used to discover metadata files on disk.
+   *
+   * ⚠️ DISCOVERY IS THE LEAST EXERCISED OF THIS FIELD'S USES (#12075, recorded
+   * beside the declaration by #12165). The only reader that actually globs
+   * these patterns is `MetadataPlugin._loadFromFileSystem`
+   * (`packages/metadata/src/plugin.ts`), reached on exactly ONE branch:
+   * `eager` bootstrap (the default) AND no `options.artifactSource`.
+   * Re-measured on `origin/main`: both non-test `new MetadataPlugin(...)`
+   * sites — `runtime/src/standalone-stack.ts` and `cli/src/commands/serve.ts`
+   * — set an `artifactSource` unconditionally, and all nine tracked
+   * `objectstack.config.ts` declare their metadata in code, so nothing this
+   * repo boots, scaffolds or ships reaches the glob pass. Recorded
+   * disposition: no end-to-end dogfood is being minted for that path —
+   * startup focus, and a path with zero measured consumers does not earn one.
+   * Unexercised is NOT broken, only unmeasured. The full measurement,
+   * discriminator included, lives on the CLI's own read of this field
+   * (`packages/cli/src/utils/metadata-file-name.ts`).
+   *
+   * ⛔ Do not read that as "this field is inert". Its VALUES have live readers
+   * that never glob: the CLI derives every scaffolded file name from them
+   * (#11071, pinned by `cli/test/generate-file-name-registry-parity.test.ts`),
+   * and `codeOnlySourceHint` reads `filePatterns[0]` back as the prescription
+   * in a 403 `not_creatable` refusal — which the `capability` and `api`
+   * entries of `DEFAULT_METADATA_TYPE_REGISTRY` below already lean on.
+   *
    * @example ["**\/*.object.ts", "**\/*.object.yml"]
    */
   filePatterns: z.array(z.string()).describe('Glob patterns to discover files of this type'),


### PR DESCRIPTION
Fixes #12165

Route (a) of the two the triage admitted (comment 5409942502). The 24-line note is a pure insertion into the JSDoc of the `filePatterns` field in `packages/spec/src/kernel/metadata-plugin.zod.ts`. No schema shape, no `.describe()` text, no other file.

## Why a note rather than close-as-covered

The triage's actual question was whether a spec-level declaration should carry a consumer-side observation at all. Three measured things say yes here:

1. **The pointer only runs one way.** #12075's CLI-side note states in its own words that it was written on the CLI's read *"rather than beside the registry declaration itself — that lives in `packages/spec/src/kernel/metadata-plugin.zod.ts`, which this package only reads."* A reader who arrives at the CLI note gets the whole story; a reader who arrives at the declaration had nothing pointing at it. Closing as covered leaves the half the triage on #12075 asked for permanently unwritten.
2. **The genre is already this file's.** `metadata-plugin.zod.ts` records dispositions with measured evidence and issue references throughout — the `DEFAULT_METADATA_TYPE_REGISTRY` docblock (#8586), the `field` entry (#7893), the `capability` and `api` entries. `packages/spec` carries a no-business-logic rule, not a no-comments rule, and a comment changes no accept/reject behaviour.
3. **The declaration is the site that invites the over-read.** The field's own second line says the patterns are *"Used to discover metadata files on disk"* — and discovery turns out to be the one use of this field nothing in the tree exercises.

## What was re-measured, on `origin/main` at `09b4f4e`

Measured here rather than copied from #12075:

- `MetadataPlugin._loadFromFileSystem` (`packages/metadata/src/plugin.ts:873`, called at `:395`) is the only reader that globs these patterns, and `_bootstrap` reaches it on exactly one branch — `eager` (the default) **and** `src` unset. `artifact-only` and `lazy` never glob; `eager` with a source goes to `_loadFromLocalFile`.
- Both non-test `new MetadataPlugin(...)` sites set `artifactSource: { mode: 'local-file', … }` unconditionally: `packages/runtime/src/standalone-stack.ts:725` and `packages/cli/src/commands/serve.ts:2388`.
- `git ls-files '*objectstack.config.ts'` → 9 tracked configs, all declaring metadata in code.

So the glob pass has no end-to-end dogfood, and the recorded disposition is that none is being minted for it — startup focus.

## The second paragraph is the load-bearing one

Stating only "no measured consumer" a few hundred lines above the `capability` and `api` entries would have contradicted this file's own comments, which lean on `codeOnlySourceHint` reading `filePatterns[0]` back as the prescription in a `403 not_creatable` refusal. The field's **values** have live readers that never glob — that one, plus the CLI deriving every scaffolded file name from them (#11071, pinned by `packages/cli/test/generate-file-name-registry-parity.test.ts`), plus `metadata-manager.ts:2486` re-projecting them. *Discovery* is the unexercised use; name derivation and refusal prescriptions are not. The note says so explicitly, so the observation cannot be quoted later as "the field is inert".

## The generated docs tree did not move

The note sits inside an object literal, and `packages/spec/scripts/lib/file-description.ts` publishes a block only when it is top-level (column 0), in the header zone, and documents no declaration — all three fail here, by two counts. Verified rather than reasoned: `check:docs` reports **229 generated files in sync**. Nothing under `content/docs/references/**` changed, so the module-header renumbering that landed in #12551 (`dd4fc6c`) is not engaged. The prose sits **before** the `@example` tag, since a TSDoc block tag would otherwise absorb it.

## Checks — all at the final commit `4c5d68e`, tree clean

Exit codes captured before any pipe; verdicts quoted from each gate's own output.

| check | verdict |
|---|---|
| `pnpm --filter @objectstack/spec build` | `command-exit 0`, 34/34 declarations emitted |
| `pnpm --filter @objectstack/spec typecheck` | exit 0 (incl. `check:scripts-typecheck`, `check:test-typecheck`) |
| `pnpm --filter @objectstack/spec check:docs` | `✅ 229 generated files in sync with packages/spec` |
| `pnpm lint` (full repo, `eslint . --no-inline-config`) | `command-exit 0` — not narrowed |
| `check:authorable-surface` · `check:liveness` · `check:empty-state` · `check:strictness-ledger` · `check:variant-docs` | exit 0 |
| `check:doc-authoring` · `check:overlay-whitelist-table` · `check:spec-parsed-alias` · `check:doc-anchors` | exit 0 |
| `check-comment-mask-adoption` · `check-nul-bytes` · `docs-audit/check-affected-docs` | exit 0 |

The gate list was re-derived from the actual change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (it reads the merge-base diff itself), then run at head after the commit.

⚠️ **One gate is NOT MEASURED, not green:** `pnpm check:i18n` exits 1 with `PREREQUISITE NOT MET — the workspace CLI is not built` ("Nothing was checked: no bundle was compared and no config was parsed"). It needs a built `@objectstack/cli`, which a comment-only spec diff cannot move a bundle through; CI runs it with the CLI built. Recorded as unmeasured rather than passed.

No changeset: comment-only, releases nothing — `skip-changeset`.

Draft, per dispatch: no auto-merge, PM reviews and lands.

_Generated by [Claude Code](https://claude.ai/code/session_01E5LFCYBJ3q2s6yW6oMLxwy)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5LFCYBJ3q2s6yW6oMLxwy)_