### PR TITLE
fix(cli-gate): name it.skip / it.only / it.each blocks instead of collapsing them onto (top-level)

### DIFF
--- a/scripts/check-cli-test-child-env.mjs
+++ b/scripts/check-cli-test-child-env.mjs
@@ -511,16 +511,103 @@ function isBulkUse(node) {
 }
 
 /**
+ * The three vitest block roots whose modifier chains name a real test block.
+ *
+ * ⛔ A ROSTER rather than "any identifier", and the population is why: this
+ * directory calls `it.name`, `it.type`, `it.next` and `it.prevVersion` on
+ * ordinary loop variables that happen to be spelled `it`. Gating on the root
+ * alone would name a callback site after one of those.
+ */
+const TEST_BLOCK_ROOTS = new Set(['it', 'test', 'describe']);
+
+/**
+ * The vitest modifiers that keep a chain a TEST BLOCK, so `it.skip(...)` names
+ * a site and `rows.map(...)` does not.
+ *
+ * ⛔ Also a roster, and this is the half that does the refusing. Measured under
+ * {@link POPULATION_ROOT}: a blanket "property access whose base is an
+ * identifier" rule matches **209 call sites across 87 distinct callees** here
+ * -- `literals.filter`, `child.on`, `entries.map`, `run.then`, `rows.map`,
+ * `vi.fn`, `Array.from` -- against the **22** this roster matches (`it.each`
+ * x20, `describe.each` x2, the whole modifier population of this directory).
+ * Those 87 are not test blocks, their callee is a WORSE name than the enclosing
+ * block the walk reaches today, and naming them would MOVE the key of every
+ * site nested inside one. Re-keying is a data migration wearing a bug fix's
+ * clothes; the roster is what keeps this a rename of nothing.
+ *
+ * `each`/`for` and `skipIf`/`runIf` are the curried forms -- `it.each(table)(
+ * 'title', fn)` -- and are unwrapped one call deeper by {@link calleeSiteName}.
+ *
+ * ⛔ `extend` is deliberately absent: `test.extend(fixtures)` builds a NEW test
+ * function rather than a block, and that product is bound to a name the
+ * identifier branch already reads.
+ */
+const TEST_BLOCK_MODIFIERS = new Set([
+  'skip', 'only', 'todo', 'fails',            // verdict
+  'concurrent', 'sequential', 'shuffle',      // scheduling
+  'each', 'for',                              // table (curried)
+  'skipIf', 'runIf',                          // conditional (curried)
+]);
+
+/**
+ * The dotted name of a test-block chain -- `it.skip`, `describe.each`,
+ * `it.skip.each` -- or `null` for anything that is not one.
+ *
+ * Every segment after the root must be on {@link TEST_BLOCK_MODIFIERS}, so a
+ * chain stays a block however deep it nests, and `a.b.c(...)` never becomes a
+ * site name.
+ */
+function testBlockChainName(expr) {
+  const modifiers = [];
+  let cursor = expr;
+  while (ts.isPropertyAccessExpression(cursor)) {
+    if (!ts.isIdentifier(cursor.name)) return null;
+    modifiers.unshift(cursor.name.text);
+    cursor = cursor.expression;
+  }
+  // A bare identifier is the pre-existing branch, not this one.
+  if (modifiers.length === 0 || !ts.isIdentifier(cursor)) return null;
+  if (!TEST_BLOCK_ROOTS.has(cursor.text)) return null;
+  if (!modifiers.every((part) => TEST_BLOCK_MODIFIERS.has(part))) return null;
+  return [cursor.text, ...modifiers].join('.');
+}
+
+/**
+ * The callee half of a site name, or `null` when the call does not name a site.
+ *
+ * ⚠️ The identifier branch is FIRST and byte-identical to what it always was.
+ * That is load-bearing: {@link DELIBERATE_REROUTE} holds keys this function
+ * produced for plain `it("...")` blocks, and both registries are pinned in both
+ * directions, so a green live-tree run is the proof that no existing key moved.
+ */
+function calleeSiteName(expr) {
+  if (ts.isIdentifier(expr)) return expr.text;
+  const chain = testBlockChainName(expr);
+  if (chain) return chain;
+  // The curried table/conditional forms: `it.each(table)('title', fn)` is a
+  // call whose CALLEE is itself a call of a test-block chain. Only one level --
+  // vitest defines no deeper currying, and unbounded unwrapping would start
+  // guessing again.
+  if (ts.isCallExpression(expr)) return testBlockChainName(expr.expression);
+  return null;
+}
+
+/**
  * The name a call-argument arrow takes from the call it is passed to:
  * `it("boots the child")`, or `beforeAll` when the call carries no title.
  *
  * DOUBLE quotes around the title, deliberately: the product is a
  * {@link DELIBERATE} key, and this file's string literals are single-quoted, so
  * a key pasted into that registry needs no escaping.
+ *
+ * The title is read from the OUTER call's arguments, which is what makes the
+ * curried form come out right: `it.each(table)('boots', fn)` is named for
+ * `'boots'`, never for a string that happens to sit in `table`.
  */
 function callbackSiteName(owner) {
-  if (!owner || !ts.isCallExpression(owner) || !ts.isIdentifier(owner.expression)) return null;
-  const callee = owner.expression.text;
+  if (!owner || !ts.isCallExpression(owner)) return null;
+  const callee = calleeSiteName(owner.expression);
+  if (!callee) return null;
   const title = owner.arguments.find((arg) => ts.isStringLiteralLike(arg));
   return title ? `${callee}("${title.text.replace(/\s+/g, ' ').trim()}")` : callee;
 }
@@ -560,12 +647,15 @@ function callbackSiteName(owner) {
  *
  * ⚠️ Three limits, named here so they are pinned rather than discovered:
  *
- *   1. The callee must be an IDENTIFIER. `it.skip('...')` and
- *      `it.each(table)('...')` call through a property access or through
- *      another call, and still walk past to `(top-level)`. That is a choice:
- *      widening to a property-access callee would also capture
- *      `promise.then(() => ...)` and `rows.map(() => ...)`, whose callee is a
- *      WORSE site name than the enclosing test block the walk reaches today.
+ *   1. The callee must be an identifier, or a ROSTERED vitest block chain.
+ *      `it.skip('...')`, `describe.each(table)('...')` and `it.skip.each(...)`
+ *      are named (#12545); `promise.then(() => ...)`, `rows.map(() => ...)` and
+ *      every other `foo.bar(cb)` are still walked past to the enclosing block,
+ *      because their callee is a WORSE site name than the block above them.
+ *      ⛔ The refusal is the point, not a leftover: see
+ *      {@link TEST_BLOCK_MODIFIERS} for the 209-vs-22 measurement that decides
+ *      it. A blanket property-access widening would RE-KEY existing sites,
+ *      which is a data migration disguised as a bug fix.
  *   2. The title's whitespace is collapsed so the name stays one line, but it
  *      is ⛔ never truncated -- two long titles sharing a prefix would collide
  *      again, which is the defect being closed.
@@ -1752,12 +1842,119 @@ export function selfTest() {
       siteNames('site-title-wrap', { 'a.e2e.test.ts': suite(`it(\`boots\nthe child\`, () => {\n${BULK}\n});`) })
         === names('it("boots the child")'));
 
-    // The named limit, pinned rather than discovered: a property-access callee
-    // is deliberately NOT captured, because `promise.then(...)` and `rows.map(
-    // ...)` would be worse site names than the test block the walk reaches.
-    t('an it.skip() callee is a property access, not an identifier, so it still reads (top-level)',
-      siteNames('site-property-callee', { 'a.e2e.test.ts': suite(`it.skip('x', () => {\n${BULK}\n});`) })
+    // -- (8c) THE MODIFIER FAMILY (#12545): a rostered vitest chain names a
+    //    site; every other property-access callee still does not.
+    //
+    //    Until this landed, the callee had to be a bare IDENTIFIER, so
+    //    `it.skip(...)` (property access) and `it.each(table)(...)` (a call)
+    //    walked past to `(top-level)` and every skipped/table-driven block in
+    //    one file collided on ONE key -- the same defect #12531 closed for the
+    //    identifier branch, one modifier over. The case below that used to pin
+    //    `it.skip` AS `(top-level)` is retargeted to the name it now produces;
+    //    what that case's comment was really protecting -- the refusal of
+    //    `promise.then` and `rows.map` -- is pinned outright further down,
+    //    where it is a measurement rather than a side effect.
+
+    t('an it.skip() block is named, not (top-level)',
+      siteNames('site-mod-skip', { 'a.e2e.test.ts': suite(`it.skip('x', () => {\n${BULK}\n});`) })
+        === names('it.skip("x")'));
+    t('an it.only() block is named',
+      siteNames('site-mod-only', { 'a.e2e.test.ts': suite(`it.only('x', () => {\n${BULK}\n});`) })
+        === names('it.only("x")'));
+    t('a describe.skip() block is named -- the root roster is not it-only',
+      siteNames('site-mod-desc-skip', { 'a.e2e.test.ts': suite(`describe.skip('x', () => {\n${BULK}\n});`) })
+        === names('describe.skip("x")'));
+    t('a test.concurrent() block is named -- test is a root too',
+      siteNames('site-mod-test-conc', { 'a.e2e.test.ts': suite(`test.concurrent('x', () => {\n${BULK}\n});`) })
+        === names('test.concurrent("x")'));
+    t('a modifier with NO string title falls back to the chain alone',
+      siteNames('site-mod-untitled', { 'a.e2e.test.ts': suite(`it.skip(() => {\n${BULK}\n});`) })
+        === names('it.skip'));
+
+    // The CURRIED forms: the callee is itself a call. The title must come from
+    // the OUTER call, never from the table.
+    t('a curried it.each(table)() block is named after the OUTER title',
+      siteNames('site-mod-each', { 'a.e2e.test.ts': suite(`it.each([1])('x', () => {\n${BULK}\n});`) })
+        === names('it.each("x")'));
+    t('a curried describe.each(table)() block is named',
+      siteNames('site-mod-desc-each', { 'a.e2e.test.ts': suite(`describe.each([1])('x', () => {\n${BULK}\n});`) })
+        === names('describe.each("x")'));
+    t('...and a string INSIDE the table never becomes the title',
+      siteNames('site-mod-each-table-string', {
+        'a.e2e.test.ts': suite(`it.each(['from the table'])('from the block', () => {\n${BULK}\n});`),
+      }) === names('it.each("from the block")'));
+    t('a curried it.skipIf(cond)() block is named -- the conditional form curries too',
+      siteNames('site-mod-skipif', { 'a.e2e.test.ts': suite(`it.skipIf(flag)('x', () => {\n${BULK}\n});`) })
+        === names('it.skipIf("x")'));
+    t('a CHAINED it.skip.each(table)() block is named through every segment',
+      siteNames('site-mod-chain', { 'a.e2e.test.ts': suite(`it.skip.each([1])('x', () => {\n${BULK}\n});`) })
+        === names('it.skip.each("x")'));
+
+    // ⭐ THE case for this change, the modifier twin of `site-siblings`: two
+    //    sibling it.each blocks in ONE file must not share a key either.
+    t('two it.each() blocks in one file get TWO DISTINCT names',
+      siteNames('site-mod-siblings', {
+        'a.e2e.test.ts': suite(
+          `it.each([1])('first', () => {\n${BULK}\n});\nit.each([2])('second', () => {\n${BULK}\n});`),
+      }) === names('it.each("first")', 'it.each("second")'));
+
+    // ⭐ THE NEGATIVE PIN. Without it, nothing in this suite distinguishes
+    //    "the modifiers now work" from "everything got renamed". The plain
+    //    identifier branch must be byte-identical to what it always was,
+    //    because DELIBERATE_REROUTE holds keys it produced.
+    t('⭐ a plain it() block STILL yields exactly it("x") -- the identifier branch did not move',
+      siteNames('site-mod-plain-unmoved', { 'a.e2e.test.ts': suite(`it('x', () => {\n${BULK}\n});`) })
+        === names('it("x")'));
+    t('...and a plain describe() > it() nesting is unmoved too',
+      siteNames('site-mod-plain-nested', {
+        'a.e2e.test.ts': suite(`describe('outer', () => {\n  it('inner', () => {\n${BULK}\n  });\n});`),
+      }) === names('it("inner")'));
+
+    // ⛔ THE REFUSALS -- the half that keeps this a targeted unwrap. A blanket
+    //    property-access widening matches 209 call sites across 87 callees in
+    //    the live population against this roster's 22, and would RE-KEY every
+    //    site nested inside one of them.
+    t('⛔ promise.then(cb) is NOT a site name -- the walk still reaches past it',
+      siteNames('site-refuse-then', { 'a.e2e.test.ts': suite(`p.then(() => {\n${BULK}\n});`) })
         === names('(top-level)'));
+    t('⛔ rows.map(cb) is NOT a site name',
+      siteNames('site-refuse-map', { 'a.e2e.test.ts': suite(`rows.map(() => {\n${BULK}\n});`) })
+        === names('(top-level)'));
+    t('⛔ an arbitrary a.b.c(cb) chain is NOT a site name',
+      siteNames('site-refuse-chain', { 'a.e2e.test.ts': suite(`a.b.c('x', () => {\n${BULK}\n});`) })
+        === names('(top-level)'));
+    t('⛔ a NON-rostered member of a real root is refused -- it.name(cb) is a loop variable, not a block',
+      siteNames('site-refuse-nonroster', { 'a.e2e.test.ts': suite(`it.name('x', () => {\n${BULK}\n});`) })
+        === names('(top-level)'));
+    t('⛔ a rostered MODIFIER on a non-rostered root is refused -- only it/test/describe are roots',
+      siteNames('site-refuse-nonroot', { 'a.e2e.test.ts': suite(`suite.each([1])('x', () => {\n${BULK}\n});`) })
+        === names('(top-level)'));
+    t('⛔ a curried call whose inner callee is a bare identifier is refused',
+      siteNames('site-refuse-curried-ident', { 'a.e2e.test.ts': suite(`makeSuite('t')('x', () => {\n${BULK}\n});`) })
+        === names('(top-level)'));
+
+    // The nearest NAMED binding still wins over a modifier block, exactly as it
+    // does over a plain one -- limit 3 of the walk, unchanged by this.
+    t('a named helper inside an it.skip() block still wins over the block',
+      siteNames('site-mod-helper', {
+        'a.e2e.test.ts': suite(`it.skip('x', () => {\n  function build() {\n    return { ...process.env };\n  }\n  void build;\n});`),
+      }) === names('build'));
+
+    // ⭐ The collision END TO END for the modifier family, through audit():
+    //    one synthesised entry keyed to ONE it.each block silences that block
+    //    and leaves its sibling a finding. Before this, both keyed to
+    //    `(top-level)` and one entry silenced BOTH.
+    const modSiblingRoot = tree('carve-mod-siblings', {
+      'a.e2e.test.ts': suite(
+        `it.each([1])('first', () => {\n${BULK}\n});\nit.each([2])('second', () => {\n${BULK}\n});`),
+    });
+    const modOnlyFirst = audit(modSiblingRoot, { 'packages/cli/test/a.e2e.test.ts::it.each("first")': { why: 'synthetic' } });
+    t('a registry entry for ONE it.each() block silences THAT block and leaves its sibling a finding',
+      JSON.stringify({
+        deliberate: modOnlyFirst.deliberate.map((row) => row.fn),
+        findings: modOnlyFirst.findings.map((row) => row.fn),
+      }) === JSON.stringify({ deliberate: ['it.each("first")'], findings: ['it.each("second")'] }),
+      JSON.stringify(modOnlyFirst.findings.map((row) => row.fn)));
 
     // ⭐ The collision END TO END, through the real classification path in
     //    audit(). One synthesised entry, two sibling blocks. Before this fix


### PR DESCRIPTION
Fixes #12545

`callbackSiteName()` required a **bare-identifier** callee, so `it('x', fn)` was named but `it.skip('x', fn)` (a `PropertyAccessExpression`) and `it.each(table)('x', fn)` (a `CallExpression`) returned `null`. `enclosingFunctionName()` then fell out of its loop to `'(top-level)'`, collapsing every skipped / only / table-driven block in one file onto a single site key — the same collision #12531 closed for the identifier branch, one modifier over.

Measured on `origin/main` @ `aa4591971` before touching anything:

| call | callee node | before | after |
| :--- | :--- | :--- | :--- |
| `it('x', fn)` | `Identifier` | `it("x")` | `it("x")` (unmoved) |
| `it.skip('x', fn)` | `PropertyAccess` | `(top-level)` | `it.skip("x")` |
| `it.only('x', fn)` | `PropertyAccess` | `(top-level)` | `it.only("x")` |
| `describe.skip('x', fn)` | `PropertyAccess` | `(top-level)` | `describe.skip("x")` |
| `it.each([…])('x', fn)` | `CallExpression` | `(top-level)` | `it.each("x")` |
| `describe.each([…])('x', fn)` | `CallExpression` | `(top-level)` | `describe.each("x")` |
| `it.skip.each([…])('x', fn)` | `CallExpression` | `(top-level)` | `it.skip.each("x")` |
| `promise.then(cb)` | `PropertyAccess` | `(top-level)` | `(top-level)` (refused) |
| `rows.map(cb)` | `PropertyAccess` | `(top-level)` | `(top-level)` (refused) |

## The unwrap is targeted, and it is gated on ROSTERS rather than on node kind

⛔ **A blanket "property access whose base is an identifier" rule was measured, not assumed, and it is much worse than the defect.** Against the gate's own live population (`packages/cli/test/**`, 98 files), that rule matches:

- **209 call sites across 87 distinct callees** — `literals.filter`, `child.on`, `entries.map`, `warnings.filter`, `server.close`, `Array.from`, `vi.fn`, **`run.then`**, **`rows.map`** …
- against this roster's **22** — `it.each(…)` ×20 and `describe.each(…)` ×2, which is the entire modifier population of that directory.

Those 87 are not test blocks, their callee is a *worse* site name than the enclosing block the walk already reaches, and naming them would **move the key of every site nested inside one**. Re-keying is a data migration wearing a bug fix's clothes.

So the gate is two rosters, `TEST_BLOCK_ROOTS` × `TEST_BLOCK_MODIFIERS`:

- **roots** — `it`, `test`, `describe`. ⭐ A roster on this side is *load-bearing*, not tidiness: this directory calls `it.name`, `it.type`, `it.next` and `it.prevVersion` on ordinary loop variables that happen to be spelled `it`. Gating on the root alone would name a callback site after one of those.
- **modifiers** — `skip` / `only` / `todo` / `fails`, `concurrent` / `sequential` / `shuffle`, `each` / `for`, `skipIf` / `runIf`. Every segment after the root must be on the roster, so `it.skip.each(…)` is named through the whole chain and `a.b.c(cb)` never is. `each`/`for` and `skipIf`/`runIf` curry, and are unwrapped exactly one call deeper.
- ⛔ `extend` is deliberately absent: `test.extend(fixtures)` builds a new test *function*, not a block, and its product is bound to a name the identifier branch already reads.

The title is read from the **outer** call's arguments, so `it.each(['from the table'])('from the block', fn)` is named for the block, never for a string sitting in the table. That is pinned.

## ⭐ Key stability — the proof, stated rather than left to be noticed

The identifier branch is reached **first and unchanged**, so plain `it(…)` naming is byte-identical. That matters because `DELIBERATE_REROUTE` holds two keys this function produced, carrying `it("…")` titles verbatim, and `DELIBERATE` holds two more from the variable-declaration branch — **all four pinned in both directions, so a moved key exits 1.**

⇒ **The green live-tree run below IS the proof that no existing key moved**, and it says so in its own words:

```
✓ check:cli-test-child-env: 35 spawner source(s) among 98 under packages/cli/test/**; …
  (0 baselined in 0 file(s), ⛔ SHRINK-ONLY; 2 deliberate site(s) and 2 deliberate reroute(s) still pinned).
```

**And the pin was proven LOUD rather than assumed to be**, because a green that cannot fail proves nothing. Reverse verification on the committed tree — predicted direction RED:

- mutated one `DELIBERATE_REROUTE` key (`NODE_ENV=development (explicit)` → `NODE_ENV=deliberately-moved-key (explicit)`);
- **mutation confirmed on disk**, not by the editor's exit code: anchor occurrences `1 → 0`, mutant `0 → 1`, blob `2210188b…` → `ec97c08b…`;
- gate on the mutated tree: **exit 1**, reporting the now-unclassified site *by the very name this function produces* — `[it("NODE_ENV=development (explicit): the gate stays OPEN — unaffected by the production default")]`;
- restored with `git checkout HEAD --` naming an ABSOLUTE path, and **the restore was proven by state**: blob back to `2210188b…`, `git diff HEAD` empty.

⛔ No registry entry was edited. Had one gone stale, that would have been the finding.

## Self-test: 132 → 152 cases, extend-never-weaken

**Exactly one pre-existing case changed**, and it is the one that pinned the defect being fixed:

> ~~`'an it.skip() callee is a property access, not an identifier, so it still reads (top-level)'`~~ → `'an it.skip() block is named, not (top-level)'`

That is a *strengthening* — a specific name replaces a fallback — and what the old case's comment was really protecting (the refusal of `promise.then` / `rows.map`) is now pinned **outright**, as six explicit refusal cases rather than as a side effect. Every other change is additive; the full deletion list in the diff is that one case plus the two implementation lines and the docblock limit it described.

Added: each modifier form; both curried forms; the chained form; the table-string trap; two sibling `it.each` blocks getting distinct names; an end-to-end `audit()` case where one registry entry silences one `it.each` block and leaves its sibling a finding; the six refusals; and —

⭐ **the negative pin**, which is the one that matters: `'a plain it() block STILL yields exactly it("x") — the identifier branch did not move'`. Without it nothing in the suite distinguishes *"the modifiers now work"* from *"everything got renamed"*.

## Rule 5 — the second implementation, MEASURED, not swept

`scripts/check-durability-degradation-log-level.mjs:1695` `enclosingFunctionName(node)`, used at `:2451` and `:2493`. ⛔ Not touched here. What I read:

**It does NOT have this card's defect** — and not because it handles modifiers, but because **it has no callback-naming branch at all.** Its four shapes are function declaration, method declaration, variable-bound arrow/function-expression, and named function expression. It never names `it('x', fn)` *either*, so there is no identifier branch for a modifier unwrap to extend. The claim comment's guess that "it takes no `sourceFile` argument, so it may not have the same branches" is correct.

Its fallback is `undefined`, not `'(top-level)'`, and the two call sites diverge:

- **`:2493` `declaredPropagationFor` — no defect, structurally.** `if (!fnName) return globalPropagation;` short-circuits, so **no key is ever built**. That is a closed door, not a shared key.
- **`:2451` → `readInventionKey` (`:2827`) — the same collision *class*, latent.** It keys a shrink-only baseline on `f.file` and `f.fn` joined by `::`, substituting a fixed placeholder — the word `anonymous` wrapped in angle brackets — whenever `f.fn` is undefined. So two anonymous-callback read-seams in one file share one key, and a single baseline entry would classify both.

**Measured live:** `scripts/durability-read-invention.baseline.json` holds **1 entry**, with **0** anonymous `fn` and **0** files carrying more than one entry. ⇒ latent, exactly as this card was. Filed unlabelled as its own card: #12576.

## Falsifications of the dispatch order (reported, not reconciled)

- ⚠️ **`main` had moved.** The order pins the merged base at `1b7e3d2ce`; `origin/main` was **`aa4591971`** when I cut the branch (and `9bed0b0fe` by the time gates ran). Re-verified the defect on `aa4591971` rather than trusting the description — it reproduced exactly.
- ⚠️ **The card's "24 such spellings" is a textual count including 2 prose mentions.** `grep` finds 24 under `packages/cli/test/**`, but two are inside docblocks (`` it.each` below against silently iterating nothing ``, `` it.each` over an empty ``). The AST count is **22**. Fittingly, the suite's own section (6) exists to make exactly this point — "prose is not code, which is what an AST buys over a text scan".
- ⭐ **Ruling 2's literal spelling contradicts its own headline, and I followed the headline.** "Accept a callee that is a **property access whose base is an identifier**" admits `promise.then(cb)` and `rows.map(cb)` — `promise` and `rows` *are* identifiers — which is precisely the blanket widening the same ruling forbids two sentences later, and which the issue body names as the reason a blanket fix is worse than the defect. The issue body's own precise spelling ("`it` / `test` / `describe` followed by a modifier") is the one that is self-consistent, so the implementation is roster-gated. The 209-vs-22 measurement above is what decided it. **Flagging rather than silently choosing a side.**
- ✅ All five line anchors handed down (`:521`, `:1695`, `:2451`, `:2493`, and the 132-case count) were **correct**. Surface measured as claimed: `git grep -ln "callbackSiteName"` → exactly one file.
- ✅ The 9 unreachable `packages/spec` families printed by `dispatch-gates` are the known #12514; not re-filed.
- ⚠️ **Measured on this body itself, twice.** GitHub's sanitizer silently ate every short angle-bracket fragment on creation (a path placeholder and two spellings of the `anonymous` key literal) — *inside backticks*, and the eaten `'anonymous'` left the text asserting the fallback was an empty string, which is false. The first repair moved the literal into a **fenced code block and that was eaten too**, so a fence is no protection either. Both are now spelled in prose. ⛔ Worth knowing before quoting any angle-bracketed literal in a GitHub body.

## Changeset — rule applied, and which one

**No changeset.** AGENTS.md line 1108: *"Pure bug fixes do **not** require a changeset."* This is a repo-internal CI gate script under `scripts/`, published by nothing and user-visible in no way; the change alters how a gate **names** sites in its own registry keys, not what it refuses. `skip-changeset` applied — verified it is a real mechanism in this repo (`.github/workflows/pr-automation.yml:294` reads it live, not from the event payload) rather than assumed.

## Verification

`typecheck` is **NOT APPLICABLE** to a `.mjs` gate script — the root `tsconfig.json` sets no `allowJs`, so `tsc --listFiles` returns 0 hits for this file. ⛔ Recorded as not-applicable, never as a green.

All gates below run on the final commit **`605beb0b3`**, exit codes captured **before any pipe** (`cmd > log 2>&1; code=$?`), under `os-verify-lock` (`VERDICT command-exit 0 · held the lock 73s · waited 1s`):

| gate | exit |
| :--- | :--- |
| `check:cli-test-child-env` (self-test **152 pass** + live tree) | 0 |
| `check:agent-test-spelling` | 0 |
| `check:bash32-floor` | 0 |
| `check:cli-command-ids` | 0 |
| `check:cross-package-test-inputs` | 0 |
| `check:entry-guard` | 0 |
| `check:parse-guard` | 0 |
| `check:pnpm-filter-targets` | 0 |
| `check:nul-bytes` | 0 |
| `check:pm-dispatch-gates` (convention-triggered) | 0 |
| `scripts/check-ci-filter-parity.mjs` | 0 |
| `scripts/check-cross-package-test-inputs.mjs` | 0 |
| `scripts/pm/bare-root-worklist.mjs --self-test` (convention-triggered) | 0 |

Families derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (10 path-derived + the 2 convention-triggered the order named). Control-character self-scan beyond the gate: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no hits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_
