### PR TITLE
fix(objectql): mirror data's own descriptor in the flat-input Proxy instead of synthesising one

### DIFF
--- a/.changeset/flat-input-descriptor-mirror.md
+++ b/.changeset/flat-input-descriptor-mirror.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): the flat-input Proxy mirrors `data`'s own descriptor instead of synthesising one (#12397)
+
+`installFlatInput` hands a declarative hook a flat-record Proxy over the
+engine's `{ data, options, id? }` wrapper. Its `getOwnPropertyDescriptor` trap
+answered every key `data` carries with one fixed literal —
+`{ configurable: true, enumerable: true, writable: true, value: data[prop] }` —
+and never read `data`'s real descriptor. For a key created by ordinary
+assignment that synthesis is the truth, which is why it cost nothing for as
+long as assignment was the only way a key could arrive.
+
+#12277 routed `defineProperty` into `data`, so a hook can now put a key on the
+record payload with non-default attributes for the first time, and the
+synthesis reported the defaults back regardless:
+
+```js
+Object.defineProperty(ctx.input, 'k', { value: 1, enumerable: false, configurable: true });
+Object.getOwnPropertyDescriptor(ctx.input, 'k');  // reported enumerable: true — it is not
+Object.keys(ctx.input);                           // …while this correctly omitted 'k'
+```
+
+Two instruments over one payload, contradicting each other. The trap now
+mirrors `data`'s own descriptor.
+
+`configurable` is the one attribute that cannot be mirrored: the proxy target
+is the wrapper, which does not carry the record key, and a proxy may not report
+a property its target lacks as non-configurable — a verbatim mirror throws
+`TypeError` on any key `data` holds as `configurable: false`, and takes
+`Object.keys` and spread down with it, since both reach every listed key
+through this trap. It is forced `true`; `enumerable` / `writable` are mirrored.
+
+Two further observable consequences, both pinned:
+
+- Reading a descriptor no longer runs author code. The synthesis evaluated
+  `data[prop]` to fill `value`, so asking a payload that holds an accessor for
+  its descriptor invoked the getter; a mirror copies `get`/`set` across
+  untouched.
+- `prop in data` is true for the whole prototype chain, so the synthesis
+  answered for inherited keys too — `Object.getOwnPropertyDescriptor(input,
+  'toString')` returned an own, enumerable, writable data property no payload
+  has ever held, and `Object.hasOwn(input, 'toString')` was `true`. Only an own
+  key has a descriptor to mirror; inherited keys now report `undefined`, while
+  `'toString' in input` and the read itself are unchanged.
+
+Enumeration is untouched: `ownKeys` still lists exactly `data`'s own enumerable
+keys and the mirror reports those as enumerable, so `Object.keys`, spread,
+`Object.entries` and the sandbox's `unwrapProxyToPlain` see byte-identical
+results. What a record payload may hold, how `defineProperty` routes into
+`data`, and how the engine persists it are all untouched.

--- a/packages/objectql/src/hook-input-descriptor-mirror.test.ts
+++ b/packages/objectql/src/hook-input-descriptor-mirror.test.ts
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12397] `Object.getOwnPropertyDescriptor(ctx.input, k)` reports what `data`
+ * actually holds — it does not synthesise an answer.
+ *
+ * `installFlatInput` (`hook-wrappers.ts`) answered the descriptor trap for any
+ * key `data` carries with a fixed literal:
+ *
+ * ```
+ * { configurable: true, enumerable: true, writable: true, value: data[prop] }
+ * ```
+ *
+ * For a key created by ordinary assignment that synthesis is the truth, which
+ * is why it cost nothing for as long as assignment was the only way a key could
+ * arrive. #12277 routed `defineProperty` into `data`, so a hook can now put a
+ * key on the record payload with NON-DEFAULT attributes — and the synthesis
+ * reports the defaults back regardless.
+ *
+ * ## The constraint that shapes the fix
+ *
+ * The proxy target is the `{ data, options, id? }` WRAPPER, which does not
+ * carry the record key at all. A proxy may not report a property the target
+ * does not have as non-configurable, so a naive mirror throws `TypeError` on
+ * any key `data` holds as `configurable: false` — and, because `Object.keys`
+ * walks `ownKeys` through this trap, it throws on plain enumeration too. The
+ * mirror therefore FORCES `configurable: true` and mirrors the rest. Both legs
+ * are pinned below: the forced one (`a data key held non-configurable`) and the
+ * mirrored ones (`enumerable`, `writable`).
+ *
+ * ## What these cases deliberately do NOT pin
+ *
+ * Whether a record payload may carry an ACCESSOR at all — and what the engine
+ * should do persisting one, since it persists a payload by evaluating it — is a
+ * contract question about the payload, not about this trap. Nothing here widens
+ * or narrows it: the accessor case below asserts only the two facts that hold
+ * under every answer to it (the trap does not throw, and reading a descriptor
+ * does not RUN the getter — the synthesis did, via `data[prop]`). Routing
+ * (`defineProperty` → `data`) and persistence are untouched by this card.
+ *
+ * `wrapDeclarativeHook` is driven directly rather than through `ObjectQL`, for
+ * the reason the sibling trap-set file (`hook-input-mutation-traps.test.ts`)
+ * gives: the subject is the wrapper's Proxy, and a full engine dispatch would
+ * put a driver's own copy semantics between the hook and the assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { wrapDeclarativeHook } from './hook-wrappers.js';
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+/** Run `handler` as a declarative hook over a caller payload; return the row the engine keeps. */
+async function runHook(
+  data: Record<string, unknown>,
+  handler: (input: any) => void,
+): Promise<Record<string, unknown>> {
+  const meta: any = { name: 'descriptor_probe', object: 'case', event: 'beforeInsert' };
+  const wrapped = wrapDeclarativeHook(meta, (async (ctx: any) => handler(ctx.input)) as any, {
+    logger: silentLogger,
+  });
+  const raw: any = { data, options: {} };
+  await wrapped({ object: 'case', event: 'beforeInsert', input: raw } as any);
+  return raw.data as Record<string, unknown>;
+}
+
+describe('[#12397] the flat-input descriptor trap mirrors `data` instead of synthesising', () => {
+  it('REPRODUCTION — a key defined non-enumerable reports non-enumerable', async () => {
+    // The card's repro, verbatim. Pre-fix this reported `enumerable: true`
+    // for a key that is not enumerable — and `Object.keys` agreed with the
+    // truth, not with the descriptor, so the two instruments an author has
+    // contradicted each other.
+    const seen: Record<string, unknown> = {};
+    const persisted = await runHook({ subject: 'help' }, (input) => {
+      Object.defineProperty(input, 'k', { value: 1, enumerable: false, configurable: true });
+      seen.descriptor = Object.getOwnPropertyDescriptor(input, 'k');
+      seen.objectKeys = Object.keys(input);
+      seen.read = input.k;
+    });
+
+    expect(seen.descriptor).toEqual({
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+    // The conjunction: the descriptor the author reads agrees with the row the
+    // engine is left holding. Asserting either alone would pass on a proxy
+    // whose two halves disagree, which is the defect itself.
+    expect(Object.getOwnPropertyDescriptor(persisted, 'k')).toEqual({
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(seen.objectKeys).toEqual(['subject']);
+    expect(seen.read).toBe(1);
+  });
+
+  it('`writable: false` is reported as such — the descriptor agrees with what assignment does', async () => {
+    // The instrument and the operation used to disagree in the loudest possible
+    // way: the descriptor advertised `writable: true` while the very next
+    // assignment threw, because the `set` trap writes into `data` from strict
+    // module code.
+    const seen: Record<string, unknown> = {};
+    await runHook({ subject: 'help' }, (input) => {
+      Object.defineProperty(input, 'frozen_key', {
+        value: 'V',
+        enumerable: true,
+        writable: false,
+        configurable: true,
+      });
+      seen.descriptor = Object.getOwnPropertyDescriptor(input, 'frozen_key');
+      try {
+        input.frozen_key = 'REASSIGNED';
+        seen.assignmentThrew = false;
+      } catch (err) {
+        seen.assignmentThrew = true;
+        seen.assignmentError = (err as Error).constructor.name;
+      }
+      seen.afterAssign = input.frozen_key;
+    });
+
+    expect(seen.descriptor).toEqual({
+      value: 'V',
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(seen.assignmentThrew).toBe(true);
+    expect(seen.assignmentError).toBe('TypeError');
+    expect(seen.afterAssign).toBe('V');
+  });
+
+  it('INVARIANT — a data key held non-configurable is reported configurable, and does not throw', async () => {
+    // The reason the mirror cannot be naive. The proxy target is the wrapper,
+    // which does not carry `locked`; reporting a target-absent property as
+    // non-configurable is a proxy invariant violation, so mirroring
+    // `configurable` verbatim throws `TypeError` here — and takes
+    // `Object.keys`/spread down with it, since those reach every listed key
+    // through this same trap.
+    const data: Record<string, unknown> = { subject: 'help' };
+    Object.defineProperty(data, 'locked', {
+      value: 'L',
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    });
+
+    const seen: Record<string, unknown> = {};
+    await runHook(data, (input) => {
+      seen.descriptor = Object.getOwnPropertyDescriptor(input, 'locked');
+      seen.objectKeys = Object.keys(input);
+      seen.spread = { ...input };
+      // `Object.prototype.hasOwnProperty.call`, not `Object.hasOwn`: this
+      // package's programs run against `lib: ES2020` (see the workspace
+      // tsconfig), where the ES2022 spelling is a type error — and this file is
+      // read by the TEST_DEBT re-measure program, whose count is a ratchet.
+      seen.hasOwn = Object.prototype.hasOwnProperty.call(input, 'locked');
+    });
+
+    // `configurable` is FORCED, `enumerable`/`writable` are MIRRORED. That is
+    // the whole contract of this trap in one assertion.
+    expect(seen.descriptor).toEqual({
+      value: 'L',
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(seen.objectKeys).toEqual(['subject', 'locked']);
+    expect(seen.spread).toEqual({ subject: 'help', locked: 'L' });
+    expect(seen.hasOwn).toBe(true);
+  });
+
+  it('POSITIVE CONTROL — an ordinary assigned key still reads back as a plain data descriptor', async () => {
+    // Every existing consumer sees this shape and must keep seeing it: the
+    // mirror is only visible on keys that were not created by assignment.
+    const seen: Record<string, unknown> = {};
+    await runHook({ subject: 'help' }, (input) => {
+      input.owner_id = 'U1';
+      seen.assigned = Object.getOwnPropertyDescriptor(input, 'owner_id');
+      seen.caller = Object.getOwnPropertyDescriptor(input, 'subject');
+    });
+    expect(seen.assigned).toEqual({
+      value: 'U1',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(seen.caller).toEqual({
+      value: 'help',
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  });
+
+  it('an INHERITED key has no own descriptor to mirror, and no longer gets a fabricated one', async () => {
+    // `prop in data` is true for the whole prototype chain, so the synthesis
+    // answered `Object.getOwnPropertyDescriptor(input, 'toString')` with an own,
+    // enumerable, writable data property that no payload has ever held. `in`
+    // stays true (inherited keys ARE `in` the object) and the read still
+    // resolves up the chain — only the own-ness claim changes.
+    const seen: Record<string, unknown> = {};
+    await runHook({ subject: 'help' }, (input) => {
+      seen.descriptor = Object.getOwnPropertyDescriptor(input, 'toString');
+      seen.hasOwn = Object.prototype.hasOwnProperty.call(input, 'toString');
+      seen.inOperator = 'toString' in input;
+      seen.readable = typeof input.toString;
+    });
+    expect(seen.descriptor).toBeUndefined();
+    expect(seen.hasOwn).toBe(false);
+    expect(seen.inOperator).toBe(true);
+    expect(seen.readable).toBe('function');
+  });
+
+  it('an accessor on the payload: the trap neither throws nor RUNS the getter', async () => {
+    // Deliberately narrow — see the file header. Whether a record payload may
+    // carry an accessor at all is a contract question this card does not
+    // answer, so this pins only what is true under either answer. The second
+    // half is a property the synthesis did NOT have: it read `data[prop]` to
+    // fill `value`, so merely asking for a descriptor invoked author code.
+    let getterCalls = 0;
+    const data: Record<string, unknown> = { subject: 'help' };
+    Object.defineProperty(data, 'derived', {
+      get() {
+        getterCalls += 1;
+        return 'COMPUTED';
+      },
+      enumerable: true,
+      configurable: true,
+    });
+
+    const seen: Record<string, unknown> = {};
+    await runHook(data, (input) => {
+      seen.descriptorRead = () => Object.getOwnPropertyDescriptor(input, 'derived');
+      seen.callsAfterDescriptor = ((): number => {
+        Object.getOwnPropertyDescriptor(input, 'derived');
+        return getterCalls;
+      })();
+    });
+
+    expect(seen.callsAfterDescriptor).toBe(0);
+  });
+});

--- a/packages/objectql/src/hook-wrappers.ts
+++ b/packages/objectql/src/hook-wrappers.ts
@@ -606,10 +606,49 @@ function installFlatInput(ctx: HookContext): () => void {
         : [];
       return Array.from(new Set(dataKeys));
     },
+    // [#12397] MIRRORS `data`'s own descriptor; it does not synthesise one.
+    // The literal that stood here — `{ configurable: true, enumerable: true,
+    // writable: true, value: data[prop] }` — happens to be the truth for every
+    // key created by ordinary assignment, which is why it cost nothing while
+    // assignment was the only way a key could arrive. #12277 routed
+    // `defineProperty` into `data`, so a hook can now put a key on the record
+    // payload with NON-DEFAULT attributes, and the synthesis kept reporting the
+    // defaults: `Object.defineProperty(input, 'k', { enumerable: false, … })`
+    // read back `enumerable: true` while `Object.keys(input)` — which reaches
+    // the same key through `ownKeys`/`data` — correctly omitted it. Two
+    // instruments, one payload, contradicting answers.
+    //
+    // `configurable` is the one attribute that CANNOT be mirrored. The proxy
+    // target is the `{ data, options, id? }` wrapper, which does not carry the
+    // record key at all, and a proxy may not report a property its target lacks
+    // as non-configurable — so mirroring it verbatim throws `TypeError` on any
+    // key `data` holds as `configurable: false`, and takes `Object.keys` and
+    // spread down with it, since both reach every listed key through this trap.
+    // It is therefore FORCED true and the rest mirrored. That forcing is the
+    // proxy's own constraint, not a claim about the payload.
+    //
+    // Two consequences worth naming, both pinned in
+    // `hook-input-descriptor-mirror.test.ts`:
+    //
+    //   - Reading a descriptor no longer RUNS author code. The synthesis
+    //     evaluated `data[prop]` to fill `value`, so asking a payload holding
+    //     an accessor for its descriptor invoked the getter; a mirror copies
+    //     `get`/`set` across untouched.
+    //   - `prop in data` is true for the whole prototype chain, so the
+    //     synthesis answered for INHERITED keys too — `toString` reported as an
+    //     own, enumerable, writable data property no payload has ever held.
+    //     Only an own key has a descriptor to mirror; the rest fall through.
+    //
+    // What this trap deliberately does NOT decide: whether a record payload may
+    // carry an accessor at all, and what the engine should do persisting one
+    // (it persists a payload by evaluating it). That is a contract question
+    // about the payload, and neither routing nor persistence is touched here —
+    // the trap reports what is there, under every answer to it.
     getOwnPropertyDescriptor(target, prop) {
       const data = target.data;
-      if (data && typeof data === 'object' && prop in data) {
-        return { configurable: true, enumerable: true, writable: true, value: (data as any)[prop] };
+      if (data && typeof data === 'object') {
+        const own = Object.getOwnPropertyDescriptor(data, prop);
+        if (own) return { ...own, configurable: true };
       }
       // Wrapper keys: still descriptors so `prop in input` works, but
       // marked non-enumerable so they don't appear in Object.keys().


### PR DESCRIPTION
Fixes #12397

`installFlatInput`'s `getOwnPropertyDescriptor` trap answered every key `data` carries with one fixed literal and never read `data`'s real descriptor. It now mirrors the own descriptor, forcing `configurable: true`.

## Reproduction, before repairing

The card's case, measured on `origin/main` at `5fbd58e0d` **before** `hook-wrappers.ts` was touched — the new pin file run against the unfixed trap, 5 of its 6 cases red:

```
 FAIL  REPRODUCTION — a key defined non-enumerable reports non-enumerable
AssertionError: expected { value: 1, writable: true, …(2) } to deeply equal { value: 1, writable: false, …(2) }

  {
    "configurable": true,
-   "enumerable": false,      ← what `data` actually holds
+   "enumerable": true,       ← what the trap reported
    "value": 1,
-   "writable": false,
+   "writable": true,
  }

 FAIL  an INHERITED key has no own descriptor to mirror, and no longer gets a fabricated one
AssertionError: expected { value: [Function toString], …(3) } to be undefined
+ Received: { "configurable": true, "enumerable": true, "value": [Function toString], "writable": true }

 FAIL  an accessor on the payload: the trap neither throws nor RUNS the getter
AssertionError: expected 1 to be +0            ← a descriptor read invoked author code
```

`Object.keys(input)` was right the whole time, which is what makes the shape bad: two instruments over one payload, disagreeing.

## The fix, and the one attribute that cannot be mirrored

`configurable` is **forced** `true`. The proxy target is the `{ data, options, id? }` wrapper, which does not carry the record key, and a proxy may not report a property its target lacks as non-configurable — a verbatim mirror throws `TypeError` on any key `data` holds as `configurable: false`, and takes `Object.keys` and spread down with it, since both reach every listed key through this trap. That leg is pinned explicitly (`INVARIANT — a data key held non-configurable …`), because a mirror that only works on ordinary keys is the same defect one layer along.

Two further consequences, both pinned:

- **A descriptor read no longer runs author code.** The synthesis evaluated `data[prop]` to fill `value`; a mirror copies `get`/`set` across untouched.
- **Inherited keys.** `prop in data` is true for the whole prototype chain, so the synthesis answered for `toString` too — an own, enumerable, writable data property no payload has ever held. Only an own key has a descriptor to mirror. `'toString' in input` and the read itself are unchanged.

## What this PR does NOT decide

Whether a record payload may carry an **accessor** at all, and what the engine should do persisting one (it persists a payload by evaluating it), is a contract question about the payload — triage was explicit that it must not be settled inside this card. It is not settled here, and the implementation did not have to take a position to land:

- Routing is untouched: `defineProperty` still lands whatever it is given in `data` (#12277), and persistence is untouched.
- The trap reports what is there. The accessor case asserts only the two facts that hold under **either** answer — the trap does not throw, and reading a descriptor does not invoke the getter. It does not assert that an accessor is permitted, or that it is not.
- The alternative shape — flattening an accessor to `{ value: data[prop] }` — *is* a position, and it is the side-effecting synthesis being removed.

So the fork stands open, unchanged, and this PR neither widens nor narrows what a payload may hold.

## Clause ② — judged, with the diff that supports it

```
 .changeset/flat-input-descriptor-mirror.md         |  52 +++++
 .../src/hook-input-descriptor-mirror.test.ts       | 244 +++++++++++++++++++++
 packages/objectql/src/hook-wrappers.ts             |  43 +++-
 3 files changed, 337 insertions(+), 2 deletions(-)
```

**Not an accept-set narrowing.** One source file, one trap body. No `packages/spec/**`, no `*.zod.ts`, no exported type, signature or `.d.ts`-shaping export — nothing a caller passes, and nothing a consumer type-checks or validates against, changed. What changed is what one runtime trap **reports**.

It is still observable behaviour on a shipped surface, and one reported answer gets strictly stricter (own-ness for inherited keys: fabricated descriptor → `undefined`), so it is carried as a `patch` changeset with the consumer evidence below rather than as a bare internal change.

**Consumer sweep — downstream direction, stated because the claim is otherwise unreadable.** `pnpm --filter '...@objectstack/objectql'` (prefix form) is the *downstream* set. Measured:

- `grep -rn "getOwnPropertyDescriptor" packages/*/src --include=*.ts` (non-test) → the only hits are this trap and an unrelated one in `packages/spec/src/shared/lazy-schema.ts`. No in-repo consumer reads a descriptor off the flat input.
- `@objectstack/runtime` is the one downstream package that pins this proxy. `body-runner.test.ts`, `perrow-dispatch-signal.integration.test.ts`, `script-runner.test.ts` → **41 passed (41)**, run after `pnpm --filter '@objectstack/runtime^...' build` because those tests reach objectql through package `exports` (its `dist`), not a vitest src alias — so this measured the built fix, not the source.
- Enumeration is untouched by construction: `ownKeys` still lists exactly `data`'s own enumerable keys and the mirror reports those as enumerable, so `Object.keys`, spread, `Object.entries` and the sandbox's `unwrapProxyToPlain` are byte-identical. The sibling #12277 pin file asserts all three and stays 6/6 green.

*Declared narrowing:* the full downstream closure was not run locally — CI runs the farm.

## Verification

Union derived, not recalled: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` over the real changeset. All 26 matched families (21 path-derived + 5 convention-triggered) re-run at the final head `68122f71b2`, each exit code captured **before** any pipe, **26/26 RC=0**:

```
check:changeset-gate-self-tests  check:cross-package-test-inputs  check:durability-log-level
check:objectql-double-limit      check:objectui-changeset         check:page-declaration-shape
check:published-files            check:slot-lookup                check:test-source-alias
check:type-source-resolution     check:nul-bytes                  check:query-options-erasure
check:type-check-coverage        check:engine-double-contract     check:where-matcher
check-adr-0087-registration      check-changeset-no-major         check-ci-filter-parity
check-comment-mask-adoption      check-cross-package-test-inputs  check-empty-changeset
check-engine-split-ratio         check-plugin-teardown-shape      docs-audit/check-affected-docs
docs-audit/check-drift-comment   pm/release-rehearsal-clone --self-test
```

Suites, at the same head:

- `pnpm --filter @objectstack/objectql test` → **238 files, 4197 passed (4197)**
- `pnpm --filter @objectstack/objectql typecheck` → RC 0

### `check:type-check-debt` — measured by a declared narrowing, not skipped

The 26th family (`check:type-check-debt`, i.e. `check-type-check-coverage.mjs --re-measure`) refuses without a built workspace closure, and its throw means NOT MEASURED. Rather than leave it there, the program it would run for the one ledgered package this diff touches was reproduced directly: `tsc --noEmit` over `packages/objectql` with the tests included (they are `exclude`d from the package's own `tsconfig.json`, which is exactly why the package carries a `TEST_DEBT` entry and why `pnpm typecheck` cannot see this file).

Result — **355 errors, of which 0 are in the new file** (and 0 in the sibling `hook-input-mutation-traps.test.ts`). The composition reproduces the ledger's recorded **354** to the unit — TS2339 x115, TS2554 x113, TS7006 x36, TS2345 x24, TS2749 x14, TS2322 x14, TS6133 x9, TS2550 x8, TS18048 x8, TS2353 x4, TS6196 x1 — plus the single `TS6059` rootDir diagnostic that `measureTestDebt` drops (`dropRootDirDiagnostics: true`), which the ledger note names explicitly. The recorded number cannot drift upward from this change, and no other ledger entry is in the diff.

That measurement also changed the code: the pin file originally used `Object.hasOwn`, which is ES2022 against this workspace's `lib: ["ES2020"]` — it would have added two `TS2550` and reddened the ratchet invisibly to `pnpm typecheck`. It now uses `Object.prototype.hasOwnProperty.call`, with the reason on the line.

### Ablation — one leg, predicted in writing first

Prediction, written before the run: reverting the mirror to the synthesis literal turns exactly **5 of 6** cases in the new file red (REPRODUCTION, `writable: false`, INVARIANT, INHERITED, accessor), leaves POSITIVE CONTROL green, and leaves the sibling #12277 file **6/6 green** — the second half being the point: the existing pins cannot catch this defect, because the synthesis is the truth for ordinary assigned keys.

Observed, exactly:

```
PRE-MUTATION:  injected=1 synthesis=0
LEG0 (committed)   → Test Files 2 passed (2) · Tests 12 passed (12)
POST-MUTATION: injected=0 synthesis=1          ← anchored grep -cF, taken BEFORE any result was read
LEG1 (mutated)     → Tests 5 failed | 7 passed (12)
                     × REPRODUCTION · × writable: false · × INVARIANT · × INHERITED · × accessor
RESTORE:       injected=1 synthesis=0 · RESTORE_GIT_DIFF_RC=0   ← `git diff --exit-code` clean
```

Restore ran from a `trap … EXIT INT TERM` and touched only the one mutated path (never `git checkout HEAD -- .`). No rebuild leg is owed on either side: the pin file imports `./hook-wrappers.js` relatively inside its own package, so vitest transforms `src` directly and no `dist` sits on the resolution path — evidenced by the pre-fix and post-fix runs differing with no build between them.

No existing test assertion was reversed.

## Recorded, not ridden along

- The `applyMutationsToInput` **bigint** residual (`packages/runtime/src/sandbox/body-runner.ts` — `JSON.stringify` probing an entry-snapshot value throws on a bigint and drops the key, so a `delete` of a bigint-valued key in a sandboxed body is still lost). The charter admits it only if that file is already open for another reason; it is not — the fix is entirely in objectql — so it stays recorded on #12397.
- #12578 — filed from this work, unassigned, observation class: `ownKeys` lists only `data`'s *enumerable* keys, so an own non-enumerable key is absent from `Object.getOwnPropertyNames(input)` while `hasOwnProperty` and (now) the descriptor trap both report it as own. Not repaired here: replacing `Object.keys(data)` with `Reflect.ownKeys(data)` would newly expose symbol keys and cuts across the sandbox's documented "materialises only what `ownKeys` enumerates" contract — a behaviour decision, not a mechanical repair, and outside this card's charter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_