### PR TITLE
test(spec,drivers): add the VALUE_ROUNDTRIP conformance case-set — what you wrote is what you read back, per driver per dialect

### DIFF
--- a/.changeset/value-roundtrip-conformance-case-set.md
+++ b/.changeset/value-roundtrip-conformance-case-set.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/spec": patch
+---
+
+test(spec,drivers): add the `VALUE_ROUNDTRIP` conformance case-set — "what you wrote is what you read back", enforced per driver per dialect (#12393)
+
+The driver-conformance census was green at 9 of 9 dialect-scored cells after
+#12136 promoted `MATRIXED`, and **none of its nine case-sets was about value
+storage**. All nine ask *which rows come back*; none asks *what is in them*. So
+that green was not weak evidence about a round-trip defect — it was no evidence
+at all, and it would have stayed green forever with the defect in place. That is
+why this family kept arriving one card at a time: #12380 (SQLite's `Field.json`
+codec was not injective), #11535 (a multi-value field read back as the string
+`'["x","y"]'`), #11782 (MySQL answering `1`/`0` for a declared boolean), #10995
+(PG json values bound without `JSON.stringify`).
+
+`VALUE_ROUNDTRIP_CASES` closes it as a class rather than as a tenth instance. It
+is 41 cases over five declared value classes — `json`, `multiple: true`,
+`string`, `number`, `boolean` — and every value in it is one some driver was
+**measured** to change, or a control that stayed faithful in the same
+measurement. Assertions pin **type as well as value**: the before-state of every
+card above was a wrong type carrying a right-looking value, which survives
+`toEqual`-style coercion and every truthiness check. `VALUE_ROUNDTRIP_COLLISION_PAIRS`
+adds the injectivity half a per-value check cannot see — a string and the native
+value whose encoding it resembles must stay distinguishable.
+
+Enrolled through the census's existing machinery rather than as a bespoke suite,
+which is the whole argument for this route: `CLASSIFIED` obliges the new fixture
+to be named in `CASE_SETS`, `CONSUMED` obliges every driver to run it, and
+`MATRIXED` obliges `driver-sql`'s cell to be answered on **every dialect it
+speaks** rather than on SQLite alone — the coverage shape that let #12380 survive
+in the first place. The census now reads **50 covered cells across 5 drivers ×
+10 case-sets, 10 of 10 dialect-scored cells matrix-routed, 0 DEBT, 0 exempt**.
+
+**No shipped behaviour and no public surface changes.** This is `@objectstack/spec`'s
+`data` export gaining one conformance fixture, six new test files, and one
+`CASE_SETS` row in the census script. No Zod schema, no runtime, no driver
+source, no API. Graded `patch` for that reason: the package's published surface
+grows by a test fixture that only conformance suites consume, and nothing an
+existing consumer resolves changes shape.
+
+The one non-test change is a **test-double fidelity fix** the new case-set
+surfaced: `driver-turso`'s `makeLibsqlSqliteStub` did not model `@libsql/client`'s
+client-side boolean → `1`/`0` conversion, so a declared `boolean` written through
+the REMOTE transport could not be bound at all. Verified against the dependency's
+own source rather than the transport's comment; the transport is correct and
+unchanged.

--- a/packages/drivers/driver-memory/src/memory-value-roundtrip-conformance.test.ts
+++ b/packages/drivers/driver-memory/src/memory-value-roundtrip-conformance.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12393] `driver-memory` held to `VALUE_ROUNDTRIP_CASES` — the shared
+ * `@objectstack/spec/data` table: what you wrote is what you read back.
+ *
+ * This driver runs in process, so every case here is a REAL execution — no
+ * server-free half in the shape `driver-mongodb` needs (#5517), and no
+ * emitted-shape assertion standing in for a value.
+ *
+ * ## Why an in-process store is not exempt from this table
+ *
+ * "It keeps the object you handed it, so of course it round-trips" is the
+ * assumption the census exists to disprove, and this driver has broken it
+ * before on the neighbouring axis: `computeAggregate` had no `count_distinct`
+ * arm and answered `null` silently (#6814). A store that clones, normalises,
+ * indexes or re-serialises a written value on the way in or out has exactly the
+ * seam every other driver has — and if it ever grows one, this is the file that
+ * says so. Its being green today is the measurement, not a reason to skip it.
+ *
+ * The reverse-verification leg below is what keeps it from being a test that
+ * cannot fail.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  VALUE_ROUNDTRIP_CASES,
+  VALUE_ROUNDTRIP_COLLISION_PAIRS,
+  VALUE_ROUNDTRIP_FIELDS,
+  VALUE_ROUNDTRIP_ROWS,
+  valueRoundTripDivergence,
+} from '@objectstack/spec/data';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { InMemoryDriver } from './memory-driver.js';
+
+const TABLE = 'conformance_value_roundtrip';
+
+describe('[#12393] driver-memory — value storage round-trip conformance', () => {
+  let driver: InMemoryDriver;
+
+  beforeAll(async () => {
+    driver = new InMemoryDriver();
+    // `syncSchema` rather than `initObjects`: this driver is SCHEMALESS and has
+    // no `initObjects` at all. Declaring the object anyway is the point — it is
+    // what makes the declaration reachable if this driver ever grows a
+    // declared-type write path, and it is the same declaration every sibling
+    // suite hands its own driver.
+    await driver.syncSchema(TABLE, { fields: { ...VALUE_ROUNDTRIP_FIELDS } });
+    for (const row of VALUE_ROUNDTRIP_ROWS) {
+      await driver.create(TABLE, { ...row });
+    }
+  });
+
+  // The fixture read back rather than trusted: a seed that dropped or folded a
+  // row would turn every assertion below into a test of the wrong table.
+  it('the fixture is one row per case', async () => {
+    const rows = (await driver.find(TABLE, {})) as Array<{ label: string }>;
+    expect(rows.map((r) => r.label).sort()).toEqual(VALUE_ROUNDTRIP_CASES.map((c) => c.name).sort());
+  });
+
+  for (const c of VALUE_ROUNDTRIP_CASES) {
+    it(`round-trips ${c.name} (${c.note})`, async () => {
+      const rows = (await driver.find(TABLE, {
+        where: { label: c.name },
+      } as DriverQuery)) as any[];
+      expect(rows).toHaveLength(1);
+      const read = rows[0][c.column];
+      // The type pin comes first: a wrong type carrying a right-looking value
+      // is the before-state of every card this table was written from, and it
+      // survives every value-only comparison.
+      expect(typeof read, `typeof for ${c.name}`).toBe(typeof c.wrote);
+      expect(read, `value for ${c.name}`).toStrictEqual(c.wrote);
+    });
+  }
+
+  it('every case in the table round-trips — the whole set at once', async () => {
+    const rows = (await driver.find(TABLE, {})) as any[];
+    const byLabel = new Map(rows.map((r) => [r.label, r]));
+    const divergences = VALUE_ROUNDTRIP_CASES.map((c) =>
+      valueRoundTripDivergence(c, byLabel.get(c.name)?.[c.column]),
+    ).filter((d): d is string => d !== null);
+    expect(
+      divergences,
+      `${VALUE_ROUNDTRIP_CASES.length - divergences.length}/${VALUE_ROUNDTRIP_CASES.length} faithful`,
+    ).toEqual([]);
+  });
+
+  it('a string and the native value it looks like stay distinguishable', async () => {
+    const rows = (await driver.find(TABLE, {})) as any[];
+    const byLabel = new Map(rows.map((r) => [r.label, r]));
+    const caseOf = (name: string) => VALUE_ROUNDTRIP_CASES.find((c) => c.name === name)!;
+    for (const [strName, nativeName] of VALUE_ROUNDTRIP_COLLISION_PAIRS) {
+      const s = byLabel.get(strName)?.[caseOf(strName).column];
+      const n = byLabel.get(nativeName)?.[caseOf(nativeName).column];
+      expect(typeof s, `${strName} must read back as a string`).toBe('string');
+      expect(
+        JSON.stringify(s) === JSON.stringify(n) && typeof s === typeof n,
+        `${strName} and ${nativeName} read identically`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/drivers/driver-mongodb/src/mongodb-value-roundtrip-translation.test.ts
+++ b/packages/drivers/driver-mongodb/src/mongodb-value-roundtrip-translation.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12393] `driver-mongodb` held to `VALUE_ROUNDTRIP_CASES` — the shared
+ * `@objectstack/spec/data` table, answered **without a server**.
+ *
+ * ## Why the assertions run in-process rather than against mongod
+ *
+ * The same reason as `mongodb-filter-text-conformance.test.ts` (#6682) and
+ * `mongodb-comparand-type-conformance.test.ts` (#7872): this package's
+ * real-mongod suites are opt-in (#5517), so a standard that needed a server
+ * would not run in CI. What this suite substitutes is not a weaker question —
+ * it is the same question asked at the seam where this driver's stored values
+ * are actually decided.
+ *
+ * ## Where that seam is, read from source rather than assumed
+ *
+ * A `create()` on this driver does exactly two things to a value before it is
+ * stored, and this suite drives both:
+ *
+ * 1. **`toStorageForms`** — the write-side transform. Read at
+ *    `mongodb-driver.ts`: it iterates the object's declared **temporal** fields
+ *    and returns `data` unchanged when there are none. The fixture declares no
+ *    temporal field at all, which the first test asserts mechanically rather
+ *    than leaving as a claim — so for this table the transform is provably an
+ *    identity and there is nothing of it to model.
+ * 2. **BSON encoding**, which is where every remaining value decision is made.
+ *    `find()` returns the driver documents straight off the cursor (no
+ *    read-side coercion pass exists in this driver), so the round trip a caller
+ *    sees IS `BSON.deserialize(BSON.serialize(doc))`.
+ *
+ * ⇒ The server-free judgement here is not "we modelled mongod". It is the
+ * driver's own two value steps, executed, with the storage engine — which
+ * stores what BSON hands it — left out. That is the accepted substitute this
+ * package's sibling conformance suites already use, stated here rather than
+ * implied.
+ *
+ * ⚠️ What it therefore does NOT cover, said plainly: anything mongod itself
+ * would do to a value after decoding. The real-mongod half of this cell is
+ * absent, as it is for this driver's aggregation and filter-text cells.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BSON } from 'mongodb';
+import {
+  VALUE_ROUNDTRIP_CASES,
+  VALUE_ROUNDTRIP_COLLISION_PAIRS,
+  VALUE_ROUNDTRIP_FIELDS,
+  VALUE_ROUNDTRIP_ROWS,
+  valueRoundTripDivergence,
+} from '@objectstack/spec/data';
+
+/** The temporal types `toStorageForms` reaches — the set that must be empty here. */
+const TEMPORAL_TYPES = new Set(['date', 'datetime', 'time']);
+
+const caseOf = (name: string) => VALUE_ROUNDTRIP_CASES.find((c) => c.name === name)!;
+
+/** One row through the driver's storage seam: BSON out, BSON back. */
+function throughBson(row: Record<string, unknown>): Record<string, unknown> {
+  return BSON.deserialize(BSON.serialize(row)) as Record<string, unknown>;
+}
+
+describe('[#12393] driver-mongodb — value storage round-trip conformance (server-free)', () => {
+  /**
+   * The premise the whole file rests on, asserted rather than asserted-in-prose:
+   * if the fixture ever grows a temporal column, `toStorageForms` stops being an
+   * identity and this suite would be modelling one of the driver's two value
+   * steps instead of both. Then it must drive that transform too — and this
+   * test is what says so, at the moment it becomes true.
+   */
+  it('the fixture declares no temporal field, so the write-side transform is an identity', () => {
+    const temporal = Object.entries(VALUE_ROUNDTRIP_FIELDS)
+      .filter(([, def]) => TEMPORAL_TYPES.has((def as { type: string }).type))
+      .map(([name]) => name);
+    expect(temporal).toEqual([]);
+  });
+
+  // The fixture read back rather than trusted: a table that lost a row would
+  // turn every assertion below into a test of the wrong corpus.
+  it('the fixture is one row per case', () => {
+    expect(VALUE_ROUNDTRIP_ROWS.map((r) => r.label).sort()).toEqual(
+      VALUE_ROUNDTRIP_CASES.map((c) => c.name).sort(),
+    );
+  });
+
+  for (const c of VALUE_ROUNDTRIP_CASES) {
+    it(`round-trips ${c.name} (${c.note})`, () => {
+      const read = throughBson({ label: c.name, [c.column]: c.wrote })[c.column];
+      // The type pin comes first: a wrong type carrying a right-looking value
+      // is the before-state of every card this table was written from.
+      expect(typeof read, `typeof for ${c.name}`).toBe(typeof c.wrote);
+      expect(read, `value for ${c.name}`).toStrictEqual(c.wrote);
+    });
+  }
+
+  it('every case in the table round-trips — the whole set at once', () => {
+    const byLabel = new Map(
+      VALUE_ROUNDTRIP_ROWS.map((r) => [r.label as string, throughBson({ ...r })]),
+    );
+    const divergences = VALUE_ROUNDTRIP_CASES.map((c) =>
+      valueRoundTripDivergence(c, byLabel.get(c.name)?.[c.column]),
+    ).filter((d): d is string => d !== null);
+    expect(
+      divergences,
+      `${VALUE_ROUNDTRIP_CASES.length - divergences.length}/${VALUE_ROUNDTRIP_CASES.length} faithful`,
+    ).toEqual([]);
+  });
+
+  it('a string and the native value it looks like stay distinguishable', () => {
+    const byLabel = new Map(
+      VALUE_ROUNDTRIP_ROWS.map((r) => [r.label as string, throughBson({ ...r })]),
+    );
+    for (const [strName, nativeName] of VALUE_ROUNDTRIP_COLLISION_PAIRS) {
+      const s = byLabel.get(strName)?.[caseOf(strName).column];
+      const n = byLabel.get(nativeName)?.[caseOf(nativeName).column];
+      expect(typeof s, `${strName} must read back as a string`).toBe('string');
+      expect(
+        JSON.stringify(s) === JSON.stringify(n) && typeof s === typeof n,
+        `${strName} and ${nativeName} read identically`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver-value-roundtrip-conformance.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-value-roundtrip-conformance.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12393] `driver-sql` held to `VALUE_ROUNDTRIP_CASES` — the shared
+ * `@objectstack/spec/data` table, run across **every dialect this driver
+ * speaks**.
+ *
+ * ## Why this file is matrix-routed and not SQLite-only
+ *
+ * The defect that produced the table (#12380) was a *dialect* defect: SQLite's
+ * `Field.json` codec was not injective while Postgres and MySQL were faithful,
+ * and the difference was invisible to a suite pinned to one client. So the
+ * dialect axis is the whole point here, not a formality — this cell is the one
+ * `MATRIXED` (#12136) exists to make real, and a SQLite-only version of this
+ * file would restate exactly the coverage that let #12380 survive.
+ *
+ * PG and MySQL are also the **regression control**: they were faithful before
+ * #12380's fix and must stay faithful after it. If a future change to the codec
+ * moves the defect onto them instead of closing it, it goes red here first.
+ *
+ * ## Its relationship to `sql-driver-12380-json-roundtrip.test.ts`
+ *
+ * That file is the *instance* pin: it owns the mechanism evidence — the
+ * NUMERIC-affinity interrogation, the on-disk storage classes read through a
+ * separate raw query, and the legacy-row migration. None of that is portable to
+ * another driver, so none of it belongs in a cross-driver table.
+ *
+ * This file is the *census* cell: the same value classes, asserted through the
+ * public driver boundary only, in the vocabulary four other drivers are held to
+ * as well. The overlap in values is deliberate and is the point — it is what
+ * makes "SQLite now agrees with Postgres" and "every driver agrees with the
+ * standard" the same measurement rather than two.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  VALUE_ROUNDTRIP_CASES,
+  VALUE_ROUNDTRIP_COLLISION_PAIRS,
+  VALUE_ROUNDTRIP_FIELDS,
+  VALUE_ROUNDTRIP_ROWS,
+  valueRoundTripDivergence,
+} from '@objectstack/spec/data';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { SqlDriver } from './sql-driver.js';
+import { DIALECT_CELLS, declareDialectCell, type DialectCell } from './live-dialect-matrix.testkit.js';
+
+const TABLE = 'conformance_value_roundtrip';
+
+const caseOf = (name: string) => VALUE_ROUNDTRIP_CASES.find((c) => c.name === name)!;
+
+function declareRoundTrip(cell: DialectCell): void {
+  describe(`[#12393] driver-sql — value storage round-trip conformance (${cell.label})`, () => {
+    let driver: SqlDriver;
+
+    beforeAll(async () => {
+      driver = new SqlDriver(cell.config());
+      await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+      await driver.initObjects([{ name: TABLE, fields: { ...VALUE_ROUNDTRIP_FIELDS } }]);
+      for (const row of VALUE_ROUNDTRIP_ROWS) {
+        await driver.create(TABLE, { ...row }, { bypassTenantAudit: true });
+      }
+    }, 60_000);
+
+    afterAll(async () => {
+      await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+      await driver.disconnect();
+    });
+
+    // The fixture read back rather than trusted: a seed that dropped or folded
+    // a row would turn every assertion below into a test of the wrong table.
+    it('the fixture is one row per case', async () => {
+      const rows = (await driver.find(TABLE, {})) as Array<{ label: string }>;
+      expect(rows.map((r) => r.label).sort()).toEqual(
+        VALUE_ROUNDTRIP_CASES.map((c) => c.name).sort(),
+      );
+    });
+
+    for (const c of VALUE_ROUNDTRIP_CASES) {
+      it(`round-trips ${c.name} (${c.note})`, async () => {
+        const rows = (await driver.find(TABLE, {
+          where: { label: c.name },
+        } as DriverQuery)) as any[];
+        expect(rows).toHaveLength(1);
+        const read = rows[0][c.column];
+        // The type pin comes first: `'123'` read back as `123` is #12380's
+        // exact before-state, and it survives every value-only comparison.
+        expect(typeof read, `typeof for ${c.name}`).toBe(typeof c.wrote);
+        expect(read, `value for ${c.name}`).toStrictEqual(c.wrote);
+      });
+    }
+
+    it('every case in the table round-trips — the whole set at once', async () => {
+      const rows = (await driver.find(TABLE, {})) as any[];
+      const byLabel = new Map(rows.map((r) => [r.label, r]));
+      const divergences = VALUE_ROUNDTRIP_CASES.map((c) =>
+        valueRoundTripDivergence(c, byLabel.get(c.name)?.[c.column]),
+      ).filter((d): d is string => d !== null);
+      expect(
+        divergences,
+        `${VALUE_ROUNDTRIP_CASES.length - divergences.length}/${VALUE_ROUNDTRIP_CASES.length} faithful`,
+      ).toEqual([]);
+    });
+
+    it('a string and the native value it looks like stay distinguishable', async () => {
+      const rows = (await driver.find(TABLE, {})) as any[];
+      const byLabel = new Map(rows.map((r) => [r.label, r]));
+      for (const [strName, nativeName] of VALUE_ROUNDTRIP_COLLISION_PAIRS) {
+        const s = byLabel.get(strName)?.[caseOf(strName).column];
+        const n = byLabel.get(nativeName)?.[caseOf(nativeName).column];
+        expect(typeof s, `${strName} must read back as a string`).toBe('string');
+        expect(
+          JSON.stringify(s) === JSON.stringify(n) && typeof s === typeof n,
+          `${strName} and ${nativeName} read identically`,
+        ).toBe(false);
+      }
+    });
+  });
+}
+
+// A matrix that silently finds zero cells reports OK — assert the axis is real
+// before iterating it.
+describe('[#12393] the dialect axis this suite runs', () => {
+  it('runs every dialect this driver speaks', () => {
+    expect(DIALECT_CELLS.map((c) => c.id)).toEqual(['sqlite', 'pg', 'mysql']);
+  });
+});
+
+for (const cell of DIALECT_CELLS) {
+  declareDialectCell(cell, 'value storage round-trip', declareRoundTrip);
+}

--- a/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-value-roundtrip-conformance.test.ts
+++ b/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-value-roundtrip-conformance.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12393] `driver-sqlite-wasm` held to `VALUE_ROUNDTRIP_CASES` — the shared
+ * `@objectstack/spec/data` table, run through this driver's own pipeline.
+ *
+ * `SqliteWasmDriver extends SqlDriver`, so the `Field.json` codec #12380 made
+ * injective is INHERITED and nothing here re-implements it. What this cell pins
+ * is the other half, the same half its filter-logic, temporal, pagination and
+ * aggregation suites pin: the values have to survive a different **engine**.
+ * This driver swaps knex's transport for a custom sql.js dialect
+ * (`Client_WasmSqlite`) that compiles the statement, binds its parameters and
+ * marshals the rows back through its own path.
+ *
+ * That marshalling step is exactly why this cell is not a formality for THIS
+ * table in particular. Every case here turns on the JS type a value arrives
+ * back as, and a dialect that binds or marshals through a different type path —
+ * sql.js hands back its own value objects — can change a type while every row
+ * count and every filter result stays correct. "It inherits the codec,
+ * therefore it is fine" is the assumption these suites exist to disprove: the
+ * judgement #4405 recorded for this driver's filter-logic cell, applied to the
+ * stored value.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  VALUE_ROUNDTRIP_CASES,
+  VALUE_ROUNDTRIP_COLLISION_PAIRS,
+  VALUE_ROUNDTRIP_FIELDS,
+  VALUE_ROUNDTRIP_ROWS,
+  valueRoundTripDivergence,
+} from '@objectstack/spec/data';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { SqliteWasmDriver } from './index.js';
+
+const TABLE = 'conformance_value_roundtrip';
+
+const caseOf = (name: string) => VALUE_ROUNDTRIP_CASES.find((c) => c.name === name)!;
+
+describe('[#12393] driver-sqlite-wasm — value storage round-trip conformance', () => {
+  let driver: SqliteWasmDriver;
+
+  beforeAll(async () => {
+    driver = new SqliteWasmDriver({ filename: ':memory:' });
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.initObjects([{ name: TABLE, fields: { ...VALUE_ROUNDTRIP_FIELDS } }]);
+    for (const row of VALUE_ROUNDTRIP_ROWS) {
+      await driver.create(TABLE, { ...row }, { bypassTenantAudit: true });
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
+    await driver.disconnect();
+  });
+
+  // The fixture read back rather than trusted: a seed that dropped or folded
+  // a row would turn every assertion below into a test of the wrong table.
+  it('the fixture is one row per case', async () => {
+    const rows = (await driver.find(TABLE, {})) as Array<{ label: string }>;
+    expect(rows.map((r) => r.label).sort()).toEqual(
+      VALUE_ROUNDTRIP_CASES.map((c) => c.name).sort(),
+    );
+  });
+
+  for (const c of VALUE_ROUNDTRIP_CASES) {
+    it(`round-trips ${c.name} (${c.note})`, async () => {
+      const rows = (await driver.find(TABLE, {
+        where: { label: c.name },
+      } as DriverQuery)) as any[];
+      expect(rows).toHaveLength(1);
+      const read = rows[0][c.column];
+      // The type pin comes first: `'123'` read back as `123` is #12380's
+      // exact before-state, and it survives every value-only comparison.
+      expect(typeof read, `typeof for ${c.name}`).toBe(typeof c.wrote);
+      expect(read, `value for ${c.name}`).toStrictEqual(c.wrote);
+    });
+  }
+
+  it('every case in the table round-trips — the whole set at once', async () => {
+    const rows = (await driver.find(TABLE, {})) as any[];
+    const byLabel = new Map(rows.map((r) => [r.label, r]));
+    const divergences = VALUE_ROUNDTRIP_CASES.map((c) =>
+      valueRoundTripDivergence(c, byLabel.get(c.name)?.[c.column]),
+    ).filter((d): d is string => d !== null);
+    expect(
+      divergences,
+      `${VALUE_ROUNDTRIP_CASES.length - divergences.length}/${VALUE_ROUNDTRIP_CASES.length} faithful`,
+    ).toEqual([]);
+  });
+
+  it('a string and the native value it looks like stay distinguishable', async () => {
+    const rows = (await driver.find(TABLE, {})) as any[];
+    const byLabel = new Map(rows.map((r) => [r.label, r]));
+    for (const [strName, nativeName] of VALUE_ROUNDTRIP_COLLISION_PAIRS) {
+      const s = byLabel.get(strName)?.[caseOf(strName).column];
+      const n = byLabel.get(nativeName)?.[caseOf(nativeName).column];
+      expect(typeof s, `${strName} must read back as a string`).toBe('string');
+      expect(
+        JSON.stringify(s) === JSON.stringify(n) && typeof s === typeof n,
+        `${strName} and ${nativeName} read identically`,
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/drivers/driver-turso/src/libsql-sqlite-stub.testkit.ts
+++ b/packages/drivers/driver-turso/src/libsql-sqlite-stub.testkit.ts
@@ -52,8 +52,9 @@ export interface LibsqlSqliteStub {
 /**
  * Build the stub. `:memory:` unless a file is given.
  *
- * `undefined` args are normalised to `null` because better-sqlite3 rejects
- * them, while libsql accepts and binds them as NULL.
+ * Arguments are normalised by {@link normalize} to the value classes
+ * better-sqlite3 can bind, using the conversions `@libsql/client` performs
+ * client-side. See that function for what is modelled and why.
  */
 export function makeLibsqlSqliteStub(filename = ':memory:'): LibsqlSqliteStub {
   const db = new Database(filename);
@@ -84,8 +85,44 @@ export function makeLibsqlSqliteStub(filename = ':memory:'): LibsqlSqliteStub {
   };
 }
 
+/**
+ * The client-side value conversion `@libsql/client` performs before a bind
+ * reaches SQLite — modelled here because the stub binds through better-sqlite3
+ * directly and better-sqlite3 performs none of it.
+ *
+ * ## Why this is the stub's job and not the transport's (#12393)
+ *
+ * `RemoteTransport.serializeValue` passes a boolean through unchanged, and its
+ * comment says why: *"booleans are kept as-is (libsql handles them)"*. Read
+ * against the dependency rather than trusted — `@libsql/client`'s sqlite3
+ * backend converts a bound boolean to `1`/`0` itself under the default
+ * `intMode` (`lib-esm/sqlite3.js`, the `typeof value === "boolean"` arm of its
+ * argument valuer). So the transport's comment is accurate and the stub was the
+ * half that diverged: it handed the raw boolean to better-sqlite3, which
+ * rejects it outright with *"SQLite3 can only bind numbers, strings, bigints,
+ * buffers, and null"*.
+ *
+ * The asymmetry that hid it: the LOCAL path never reaches this question,
+ * because `SqlDriver.formatInput` carries its own bind safety net for exactly
+ * these value classes. So a boolean written through remote mode was the one
+ * combination nothing in this package exercised, and the gap surfaced only when
+ * `VALUE_ROUNDTRIP_CASES` asked every driver to store a declared `boolean`.
+ *
+ * ⚠️ What this deliberately does NOT model: the client also valuates `Date` to
+ * `value.valueOf()` and `ArrayBuffer` to a Buffer. Neither is added on
+ * speculation — `serializeValue` converts a `Date` to an ISO string before the
+ * client ever sees it, so no reachable write binds one, and an unreachable
+ * conversion here would be a claim about the client nothing in this package
+ * checks. Add them when a caller needs them, with the same source citation.
+ */
 const normalize = (args: unknown[] | undefined) =>
-  (args ?? []).map((a) => (a === undefined ? null : a));
+  (args ?? []).map((a) => {
+    // better-sqlite3 rejects `undefined`; libsql accepts it and binds NULL.
+    if (a === undefined) return null;
+    // The `intMode: 'number'` default, which is what the driver runs under.
+    if (typeof a === 'boolean') return a ? 1 : 0;
+    return a;
+  });
 
 /**
  * The stub, typed as the `@libsql/client` `Client` that `TursoDriverConfig`

--- a/packages/drivers/driver-turso/src/turso-value-roundtrip-conformance.test.ts
+++ b/packages/drivers/driver-turso/src/turso-value-roundtrip-conformance.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12393] `driver-turso` held to `VALUE_ROUNDTRIP_CASES` — the shared
+ * `@objectstack/spec/data` table, on **both transports**.
+ *
+ * This driver is dual-transport and the two halves share no value codec:
+ *
+ * - **Local / replica** — `TursoDriver extends SqlDriver`, so the `Field.json`
+ *   codec #12380 made injective is inherited whole. This half is the twin of
+ *   `sql-driver-value-roundtrip-conformance.test.ts`'s SQLite cell.
+ * - **Remote** — does not go through knex at all. `RemoteTransport` carries its
+ *   own `serializeValue` on the write path and its own `mapRows` on the read
+ *   path. That is the independent Nth backend the shared tables exist for, and
+ *   it is exactly the seam this table asks about: a driver can be perfectly
+ *   correct about *which rows* come back while its own marshalling changes
+ *   *what is in them*.
+ *
+ * Both are driven here for the reason the temporal, filter-logic, pagination
+ * and aggregation cells are driven twice in this package: one green transport
+ * says nothing about the other.
+ *
+ * ## Why a SQLite-backed client stub for the remote half
+ *
+ * Same reason as the remote aggregation and filter-logic suites next door:
+ * libsql IS SQLite, so `makeLibsqlSqliteStub` gives the transport real value
+ * semantics — TEXT/INTEGER storage classes and the binding rules that go with
+ * them — with no network and no credentials. The suites that mock `execute` and
+ * assert on the SQL string keep the network as their concern; a value that
+ * comes back as the wrong TYPE leaves the SQL perfectly valid, so a string
+ * assertion cannot see it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  VALUE_ROUNDTRIP_CASES,
+  VALUE_ROUNDTRIP_COLLISION_PAIRS,
+  VALUE_ROUNDTRIP_FIELDS,
+  VALUE_ROUNDTRIP_ROWS,
+  valueRoundTripDivergence,
+} from '@objectstack/spec/data';
+import type { DriverQuery } from '@objectstack/spec/contracts';
+import { TursoDriver } from './turso-driver.js';
+import { makeLibsqlSqliteStub, type LibsqlSqliteStub } from './libsql-sqlite-stub.testkit.js';
+
+const TABLE = 'conformance_value_roundtrip';
+const OBJECT = { name: TABLE, fields: { ...VALUE_ROUNDTRIP_FIELDS } };
+
+const caseOf = (name: string) => VALUE_ROUNDTRIP_CASES.find((c) => c.name === name)!;
+
+/** The shared body, so the two transports are held to the SAME assertions. */
+function declareRoundTrip(label: string, make: () => Promise<TursoDriver>, teardown: () => void): void {
+  describe(`[#12393] TursoDriver — value storage round-trip conformance (${label})`, () => {
+    let driver: TursoDriver;
+
+    beforeAll(async () => {
+      driver = await make();
+    }, 60_000);
+
+    afterAll(async () => {
+      await driver.disconnect();
+      teardown();
+    });
+
+    // The fixture read back rather than trusted: a seed that dropped or folded
+    // a row would turn every assertion below into a test of the wrong table.
+    it('the fixture is one row per case', async () => {
+      const rows = (await driver.find(TABLE, {})) as Array<{ label: string }>;
+      expect(rows.map((r) => r.label).sort()).toEqual(
+        VALUE_ROUNDTRIP_CASES.map((c) => c.name).sort(),
+      );
+    });
+
+    for (const c of VALUE_ROUNDTRIP_CASES) {
+      it(`round-trips ${c.name} (${c.note})`, async () => {
+        const rows = (await driver.find(TABLE, {
+          where: { label: c.name },
+        } as DriverQuery)) as any[];
+        expect(rows).toHaveLength(1);
+        const read = rows[0][c.column];
+        // The type pin comes first: a wrong type carrying a right-looking value
+        // survives every value-only comparison, which is how this class of
+        // defect reached production more than once.
+        expect(typeof read, `typeof for ${c.name}`).toBe(typeof c.wrote);
+        expect(read, `value for ${c.name}`).toStrictEqual(c.wrote);
+      });
+    }
+
+    it('every case in the table round-trips — the whole set at once', async () => {
+      const rows = (await driver.find(TABLE, {})) as any[];
+      const byLabel = new Map(rows.map((r) => [r.label, r]));
+      const divergences = VALUE_ROUNDTRIP_CASES.map((c) =>
+        valueRoundTripDivergence(c, byLabel.get(c.name)?.[c.column]),
+      ).filter((d): d is string => d !== null);
+      expect(
+        divergences,
+        `${VALUE_ROUNDTRIP_CASES.length - divergences.length}/${VALUE_ROUNDTRIP_CASES.length} faithful`,
+      ).toEqual([]);
+    });
+
+    it('a string and the native value it looks like stay distinguishable', async () => {
+      const rows = (await driver.find(TABLE, {})) as any[];
+      const byLabel = new Map(rows.map((r) => [r.label, r]));
+      for (const [strName, nativeName] of VALUE_ROUNDTRIP_COLLISION_PAIRS) {
+        const s = byLabel.get(strName)?.[caseOf(strName).column];
+        const n = byLabel.get(nativeName)?.[caseOf(nativeName).column];
+        expect(typeof s, `${strName} must read back as a string`).toBe('string');
+        expect(
+          JSON.stringify(s) === JSON.stringify(n) && typeof s === typeof n,
+          `${strName} and ${nativeName} read identically`,
+        ).toBe(false);
+      }
+    });
+  });
+}
+
+declareRoundTrip(
+  'local mode — the inherited SqlDriver codec',
+  async () => {
+    const driver = new TursoDriver({ url: ':memory:' });
+    expect(driver.transportMode).toBe('local');
+    await driver.initObjects([OBJECT]);
+    for (const row of VALUE_ROUNDTRIP_ROWS) {
+      await driver.create(TABLE, { ...row }, { bypassTenantAudit: true });
+    }
+    return driver;
+  },
+  () => {},
+);
+
+let remoteStub: LibsqlSqliteStub | undefined;
+declareRoundTrip(
+  'remote mode — the transport\'s own serializeValue/mapRows',
+  async () => {
+    remoteStub = makeLibsqlSqliteStub();
+    const driver = new TursoDriver({
+      url: 'libsql://conformance.turso.io',
+      client: remoteStub as never,
+    });
+    await driver.connect();
+    // The mode this half is about — the one that inherits nothing.
+    expect(driver.transportMode).toBe('remote');
+    await driver.syncSchema(TABLE, OBJECT);
+    for (const row of VALUE_ROUNDTRIP_ROWS) await driver.create(TABLE, { ...row });
+    return driver;
+  },
+  () => remoteStub?.close(),
+);

--- a/packages/spec/api-surface/data.json
+++ b/packages/spec/api-surface/data.json
@@ -630,9 +630,15 @@
     "UnknownAuthoringKeyFinding (interface)",
     "UnorderedPaginationConformanceCase (interface)",
     "VALID_AST_OPERATORS (const)",
+    "VALUE_ROUNDTRIP_CASES (const)",
+    "VALUE_ROUNDTRIP_COLLISION_PAIRS (const)",
+    "VALUE_ROUNDTRIP_FIELDS (const)",
+    "VALUE_ROUNDTRIP_ROWS (const)",
     "ValidationRule (type)",
     "ValidationRuleSchema (const)",
     "ValueForm (type)",
+    "ValueRoundTripCase (interface)",
+    "ValueRoundTripColumn (type)",
     "ValueShapeFieldDef (interface)",
     "ZeroLimitConformanceCase (interface)",
     "apiExposureDenialReason (function)",
@@ -769,6 +775,7 @@
     "urlUserinfoUsername (function)",
     "utcInstantMs (function)",
     "validateDriverConfig (function)",
+    "valueRoundTripDivergence (function)",
     "valueSchemaFor (function)"
   ]
 }

--- a/packages/spec/export-origins/data.json
+++ b/packages/spec/export-origins/data.json
@@ -630,9 +630,15 @@
     "UnknownAuthoringKeyFinding": "src/data/authoring-key-lint.ts#UnknownAuthoringKeyFinding (interface)",
     "UnorderedPaginationConformanceCase": "src/data/pagination-conformance.ts#UnorderedPaginationConformanceCase (interface)",
     "VALID_AST_OPERATORS": "src/data/filter.zod.ts#VALID_AST_OPERATORS (const)",
+    "VALUE_ROUNDTRIP_CASES": "src/data/value-roundtrip-conformance.ts#VALUE_ROUNDTRIP_CASES (const)",
+    "VALUE_ROUNDTRIP_COLLISION_PAIRS": "src/data/value-roundtrip-conformance.ts#VALUE_ROUNDTRIP_COLLISION_PAIRS (const)",
+    "VALUE_ROUNDTRIP_FIELDS": "src/data/value-roundtrip-conformance.ts#VALUE_ROUNDTRIP_FIELDS (const)",
+    "VALUE_ROUNDTRIP_ROWS": "src/data/value-roundtrip-conformance.ts#VALUE_ROUNDTRIP_ROWS (const)",
     "ValidationRule": "src/data/validation.zod.ts#ValidationRule (type)",
     "ValidationRuleSchema": "src/data/validation.zod.ts#ValidationRuleSchema (const)",
     "ValueForm": "src/data/field-value.zod.ts#ValueForm (type)",
+    "ValueRoundTripCase": "src/data/value-roundtrip-conformance.ts#ValueRoundTripCase (interface)",
+    "ValueRoundTripColumn": "src/data/value-roundtrip-conformance.ts#ValueRoundTripColumn (type)",
     "ValueShapeFieldDef": "src/data/field-value.zod.ts#ValueShapeFieldDef (interface)",
     "ZeroLimitConformanceCase": "src/data/pagination-conformance.ts#ZeroLimitConformanceCase (interface)",
     "apiExposureDenialReason": "src/data/api-derivation.ts#apiExposureDenialReason (function)",
@@ -769,6 +775,7 @@
     "urlUserinfoUsername": "src/data/driver/common.zod.ts#urlUserinfoUsername (function)",
     "utcInstantMs": "src/data/calendar-day.ts#utcInstantMs (function)",
     "validateDriverConfig": "src/data/driver/config-registry.zod.ts#validateDriverConfig (function)",
+    "valueRoundTripDivergence": "src/data/value-roundtrip-conformance.ts#valueRoundTripDivergence (function)",
     "valueSchemaFor": "src/data/field-value.zod.ts#valueSchemaFor (function)"
   }
 }

--- a/packages/spec/src/data/index.ts
+++ b/packages/spec/src/data/index.ts
@@ -70,6 +70,13 @@ export * from './pagination-conformance';
 // (`count(distinct x)`) is the first in the vocabulary that two faces of one
 // driver can get wrong in ways only a row-result comparison sees.
 export * from './aggregation-conformance';
+// Canonical conformance cases for value storage ROUND-TRIP (#12393) — "what you
+// wrote is what you read back", asserted on type as well as value, plus the
+// injectivity pairs a per-value check cannot see. The census's nine other
+// case-sets are all about WHICH ROWS come back; this is the one about what the
+// values in them are, and its absence is why that family (#12380, #11535,
+// #11782, #10995) kept arriving one card at a time.
+export * from './value-roundtrip-conformance';
 export * from './date-macros.zod';
 // Dashboard date-range preset names (#4614 single source, re-homed by #8793) —
 // declared for the dashboard date-filter positions, REFUSED as bare ordering

--- a/packages/spec/src/data/value-roundtrip-conformance.ts
+++ b/packages/spec/src/data/value-roundtrip-conformance.ts
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Canonical conformance cases for **value storage round-trip** (#12393) — the
+ * one standard *"what you wrote is what you read back"*, run on every driver.
+ *
+ * ## Why this table exists — a measurement, not a proposal
+ *
+ * The driver-conformance census (`scripts/check-driver-conformance.mjs`) was
+ * green at 9 of 9 dialect-scored cells after #12136 promoted `MATRIXED`, and
+ * **none of its nine case-sets was about value storage**. The nine cover
+ * filters, temporal form, pagination and aggregation — every one of them a
+ * question about *which rows come back*, none about *what the values in them
+ * are*. So that green was not weak evidence about a round-trip defect; it was
+ * **no evidence at all**, and it would have stayed green forever with the
+ * defect in place.
+ *
+ * That is why this family kept arriving one card at a time:
+ *
+ * | card | the same question, one instance at a time |
+ * |---|---|
+ * | #12380 | SQLite's `Field.json` codec was not injective — `'123'` read back as the number `123`; PG/MySQL disagreed |
+ * | #11535 | a multi-value field read back as the string `'["x","y"]'` |
+ * | #11782 | MySQL answered `1`/`0` for a declared boolean |
+ * | #10995 | PG json values bound without `JSON.stringify` — the write half |
+ *
+ * Every value below is a value some driver was **measured** to change, or a
+ * control that stayed faithful in the same measurement. Nothing here was
+ * invented to round out a table.
+ *
+ * ## The contract this asserts, and why it is a contract argument
+ *
+ * `json`'s stored contract is `z.unknown()` — deliberately open (see
+ * `valueSchemaFor` in `./field-value.zod`: *"openness is now an explicit
+ * decision, not an accident of nobody checking"*). An explicitly-open contract
+ * admits **both** `123` and `'123'` as legal values of one field, so no driver
+ * has license to collapse them onto one representation. The scalar columns are
+ * the same argument in its easy direction: a declared `boolean` that reads back
+ * as `1` has changed the value's type, and the contract says the value is a
+ * boolean.
+ *
+ * ⇒ The standard is **injectivity**: distinct written values must remain
+ * distinguishable on read. {@link VALUE_ROUNDTRIP_COLLISION_PAIRS} is that
+ * property stated directly, and it is the half a per-value assertion can miss —
+ * two rows can each look plausible and still be the same bytes.
+ *
+ * ## How a driver suite consumes this table
+ *
+ * Write {@link VALUE_ROUNDTRIP_ROWS} through the driver's own `create()`, read
+ * them back through its own `find()`, and for each case assert **the type and
+ * the value**:
+ *
+ * ```ts
+ * expect(typeof read).toBe(typeof c.wrote);   // FIRST — see below
+ * expect(read).toStrictEqual(c.wrote);
+ * ```
+ *
+ * ⚠️ The `typeof` pin is not decoration and it is not redundant with
+ * `toStrictEqual`. The before-state of every card in the table above was a
+ * **wrong type carrying a right-looking value**: `'123'` read back as `123`
+ * passes `toEqual`-style coercion, every truthiness pin and most snapshot
+ * comparisons, which is exactly how those defects survived long enough to be
+ * found by reading source. A round-trip pin that does not compare types is not
+ * a round-trip pin. (`toStrictEqual` does compare types; the separate pin
+ * exists so the FAILURE names the type, which is the diagnosis.)
+ *
+ * A driver with no server available in CI (`driver-mongodb`, whose real-mongod
+ * suites are opt-in since #5517) makes the same judgement server-free, at the
+ * seam where its values are actually encoded — for that driver, BSON
+ * serialize/deserialize. That is the accepted substitute its sibling
+ * conformance suites already use, and it is stated in the suite rather than
+ * implied here.
+ *
+ * ## What belongs here — one axis, like every sibling table
+ *
+ * **Value storage form only.** Explicitly the subject of other tables, and
+ * deliberately absent from this one:
+ *
+ * - **Temporal storage form** — `TEMPORAL_CASES` / `TEMPORAL_TIME_CASES`
+ *   (ADR-0053, #3994). Date/datetime/time are the one value class with a
+ *   *canonical* storage form the platform declares; that is a different
+ *   question from "the driver did not change it", and it already has two
+ *   tables.
+ * - **Aggregated values** — `AGGREGATION_CASES` (#6409). `avg`/`sum` over a
+ *   boolean (#11065 / #11151) is a value a driver *computes*, not one it
+ *   stored.
+ * - **Which rows come back** — the filter, pagination and comparand tables.
+ *
+ * ⛔ **Also deliberately absent: an own key holding `undefined`.** A declared
+ * field written as an explicit `undefined` comes back from the JS-backed
+ * drivers as an own key holding `undefined` — neither "absent" nor "holds a
+ * value" — and it is an **open, tracked** divergence (#9276, on hold with a
+ * named restart condition), not a defect this table discovered. Putting it here
+ * would ship a case-set that is red on `driver-memory` by construction, which
+ * is precisely the escape hatch #12136's ruling closed: *a gate that ships red
+ * is worse than one that ships honest*. When #9276 lands, its value class
+ * belongs in this table and the case that proves it belongs in this file.
+ *
+ * @see https://github.com/objectstack-ai/objectstack/issues/12393 (this table)
+ * @see https://github.com/objectstack-ai/objectstack/issues/12380 (the measured boundary set)
+ * @see https://github.com/objectstack-ai/objectstack/issues/9276 (the value class deliberately excluded)
+ */
+
+/** The declared column a case writes into. */
+export type ValueRoundTripColumn = 'v_json' | 'v_multi' | 'v_string' | 'v_number' | 'v_boolean';
+
+/**
+ * The object the cases are written through, as a driver's `initObjects()` takes
+ * it.
+ *
+ * One column per declared value class rather than one object per class: a
+ * single fixture is one `create()` per row on every driver, and it keeps the
+ * collision pairs — which span classes — expressible in one read.
+ *
+ * `v_multi` is `multiple: true` on an ordinary string field. That is the
+ * #11535 shape and it is not a synonym for `v_json`: on the SQL family
+ * `multiple` decides the column type **before** the type switch runs, so a
+ * multi-value string and a declared `json` reach the JSON storage path by two
+ * different routes and can diverge independently.
+ */
+export const VALUE_ROUNDTRIP_FIELDS = {
+  label: { type: 'string' },
+  v_json: { type: 'json' },
+  v_multi: { type: 'string', multiple: true },
+  v_string: { type: 'string' },
+  v_number: { type: 'number' },
+  v_boolean: { type: 'boolean' },
+} as const;
+
+/** A row in the round-trip fixture: one written value, in one declared column. */
+export interface ValueRoundTripCase {
+  /** Stable identifier — the row's `label`, and usable as a test name. */
+  readonly name: string;
+  /** Which declared column this value is written into. */
+  readonly column: ValueRoundTripColumn;
+  /** The exact JS value handed to `create()`. The read must `toStrictEqual` it. */
+  readonly wrote: unknown;
+  /** Why the case is here — surfaced in failure output. */
+  readonly note: string;
+}
+
+/**
+ * The cases.
+ *
+ * The `v_json` block is #12380's measured boundary set: every string in it has
+ * content that is valid JSON or is number-like (or both) — the two classes the
+ * pre-fix SQLite encoding destroyed — plus the ordinary strings that always
+ * worked, kept as controls so a suite that goes red says *which* class broke.
+ */
+export const VALUE_ROUNDTRIP_CASES: readonly ValueRoundTripCase[] = [
+  // ── json: strings whose CONTENT is valid JSON (the read-side class) ────────
+  { name: 's_true', column: 'v_json', wrote: 'true', note: 'string whose content parses as a boolean' },
+  { name: 's_false', column: 'v_json', wrote: 'false', note: 'string whose content parses as a boolean' },
+  { name: 's_null', column: 'v_json', wrote: 'null', note: 'string whose content parses as null' },
+  { name: 's_arr', column: 'v_json', wrote: '[]', note: 'string whose content parses as an array' },
+  { name: 's_obj', column: 'v_json', wrote: '{"a":1}', note: 'string whose content parses as an object' },
+  { name: 's_quoted', column: 'v_json', wrote: '"quoted"', note: 'string whose content parses as a string' },
+
+  // ── json: number-like strings (the write-side class) ──────────────────────
+  //
+  // These are the ones a read-path change cannot repair: on SQLite a `json`
+  // column carries NUMERIC affinity, so a bare number-like string was converted
+  // to INTEGER/REAL before storage. They are here because a driver that gets
+  // them wrong is destroying data, not misreporting it.
+  { name: 's_123', column: 'v_json', wrote: '123', note: 'number-like string' },
+  { name: 's_pad', column: 'v_json', wrote: '  123  ', note: 'number-like string with padding' },
+  { name: 's_0123', column: 'v_json', wrote: '0123', note: 'number-like string, leading zero' },
+  { name: 's_1e5', column: 'v_json', wrote: '1e5', note: 'number-like string, exponent form' },
+  { name: 's_1p0', column: 'v_json', wrote: '1.0', note: 'number-like string, trailing zero' },
+  { name: 's_neg0', column: 'v_json', wrote: '-0', note: 'number-like string, negative zero' },
+
+  // ── json: ordinary strings — controls that were faithful throughout ───────
+  { name: 's_empty', column: 'v_json', wrote: '', note: 'empty string' },
+  { name: 's_tz', column: 'v_json', wrote: 'America/New_York', note: 'ordinary string' },
+  { name: 's_bad', column: 'v_json', wrote: '{bad json', note: 'string that does not parse' },
+  { name: 's_nan', column: 'v_json', wrote: 'NaN', note: 'string that is not valid JSON' },
+
+  // ── json: native (non-string) values ──────────────────────────────────────
+  { name: 'n_true', column: 'v_json', wrote: true, note: 'native boolean inside json' },
+  { name: 'n_false', column: 'v_json', wrote: false, note: 'native boolean inside json' },
+  { name: 'n_int', column: 'v_json', wrote: 123, note: 'native integer' },
+  { name: 'n_real', column: 'v_json', wrote: 1.5, note: 'native real' },
+  { name: 'n_null', column: 'v_json', wrote: null, note: 'native null' },
+  { name: 'n_str', column: 'v_json', wrote: 'plain', note: 'native plain string' },
+  { name: 'n_obj', column: 'v_json', wrote: { a: 1 }, note: 'native object' },
+  { name: 'n_arr', column: 'v_json', wrote: [1, 2], note: 'native array' },
+  { name: 'n_arr_empty', column: 'v_json', wrote: [], note: 'native empty array' },
+  { name: 'n_quoted', column: 'v_json', wrote: 'quoted', note: 'native string — the collision twin of s_quoted' },
+  {
+    name: 'n_nested',
+    column: 'v_json',
+    wrote: { a: [1, { b: 'x' }], c: null },
+    note: 'nested object — a codec that re-encodes only the top level shows up here',
+  },
+
+  // ── multi-value (#11535): stored as JSON, reached by a different route ────
+  {
+    name: 'm_two',
+    column: 'v_multi',
+    wrote: ['userA', 'userB'],
+    note: "#11535's exact shape: the array that came back as the string '[\"userA\",\"userB\"]'",
+  },
+  { name: 'm_one', column: 'v_multi', wrote: ['solo'], note: 'single-element array must not degrade to its element' },
+  { name: 'm_empty', column: 'v_multi', wrote: [], note: 'empty array must not degrade to null' },
+  {
+    name: 'm_numlike',
+    column: 'v_multi',
+    wrote: ['123', '0123'],
+    note: 'members are number-like strings — the json class, inside the multi-value route',
+  },
+
+  // ── scalar columns: the value class stated in the declaration ─────────────
+  { name: 'b_true', column: 'v_boolean', wrote: true, note: 'declared boolean — #11782 read this back as 1 on MySQL' },
+  { name: 'b_false', column: 'v_boolean', wrote: false, note: 'declared boolean — the 0 half of #11782' },
+  { name: 'num_int', column: 'v_number', wrote: 42, note: 'declared number, integral' },
+  { name: 'num_real', column: 'v_number', wrote: 1.5, note: 'declared number, fractional' },
+  { name: 'num_zero', column: 'v_number', wrote: 0, note: 'zero must survive as a number, not become null' },
+  { name: 'num_neg', column: 'v_number', wrote: -7.25, note: 'declared number, negative fractional' },
+  {
+    name: 'str_numlike',
+    column: 'v_string',
+    wrote: '00123',
+    note: 'a declared STRING holding a number-like value must stay a string',
+  },
+  {
+    name: 'str_jsonlike',
+    column: 'v_string',
+    wrote: '{"a":1}',
+    note: 'a declared STRING holding JSON text must not be parsed on the way out',
+  },
+  { name: 'str_plain', column: 'v_string', wrote: 'plain', note: 'ordinary string — the control' },
+  { name: 'str_empty', column: 'v_string', wrote: '', note: 'empty string must not become null' },
+] as const;
+
+/**
+ * The fixture as rows, one per case: the case's own column carries its value
+ * and no other declared column is written.
+ *
+ * Deliberately one column per row rather than a dense table. A row that wrote
+ * every column at once could not tell "this driver changed the value" from
+ * "this driver moved it into the wrong column", and the second failure is one
+ * the JSON-storage path can actually produce.
+ */
+export const VALUE_ROUNDTRIP_ROWS: readonly Record<string, unknown>[] = VALUE_ROUNDTRIP_CASES.map(
+  (c) => ({ label: c.name, [c.column]: c.wrote }),
+);
+
+/**
+ * Pairs that must remain **distinguishable on read** — the injectivity half.
+ *
+ * Each pair is a string and the native value whose JSON encoding it looks like.
+ * Three of these collided on SQLite before #12380 (`'123'`/`123`, `'[]'`/`[]`,
+ * `'{"a":1}'`/`{a:1}`) and a fourth collided on read (`'null'`/`null`); all
+ * were distinct on Postgres and MySQL, which is what made it a driver defect
+ * rather than a platform decision.
+ *
+ * ⚠️ This is not implied by the per-case assertions. A driver that answered
+ * every case with the *string* form would pass half of them and fail the other
+ * half — but a driver that is merely LOSSY in one direction can pass every
+ * individual case whose written value happens to be the surviving form. The
+ * pair check asks the question the per-value check cannot.
+ */
+export const VALUE_ROUNDTRIP_COLLISION_PAIRS: readonly (readonly [string, string])[] = [
+  ['s_123', 'n_int'],
+  ['s_arr', 'n_arr_empty'],
+  ['s_obj', 'n_obj'],
+  ['s_true', 'n_true'],
+  ['s_null', 'n_null'],
+  ['s_quoted', 'n_quoted'],
+] as const;
+
+/**
+ * The verdict for one case, computed identically by every consuming suite.
+ *
+ * A shared judge rather than a per-suite `expect` chain, for the reason the
+ * table itself is shared: five suites each spelling "faithful" their own way is
+ * five definitions, and the one that is subtly weaker is the one that stays
+ * green. Returns `null` when the round trip was faithful, or the human-readable
+ * divergence when it was not.
+ */
+export function valueRoundTripDivergence(c: ValueRoundTripCase, read: unknown): string | null {
+  const wroteType = typeof c.wrote;
+  const readType = typeof read;
+  const same =
+    readType === wroteType && JSON.stringify(read ?? null) === JSON.stringify(c.wrote ?? null);
+  if (same) return null;
+  return (
+    `${c.name} (${c.column}): wrote ${JSON.stringify(c.wrote)} (${wroteType}), ` +
+    `read ${JSON.stringify(read)} (${readType})`
+  );
+}

--- a/scripts/check-driver-conformance.mjs
+++ b/scripts/check-driver-conformance.mjs
@@ -252,6 +252,11 @@ const CASE_SETS = [
     marker: 'FILTER_COMPARAND_TYPE_CASES',
     what: 'the comparand-type door: the six accepted types compile everywhere, everything else is refused loudly — #7872',
   },
+  {
+    file: 'value-roundtrip-conformance.ts',
+    marker: 'VALUE_ROUNDTRIP_CASES',
+    what: 'value storage round-trip: what you wrote is what you read back, type included — #12393',
+  },
 ];
 
 // ── The ledger ──────────────────────────────────────────────────────────────
@@ -512,6 +517,35 @@ const CASE_SETS = [
 //
 // The ledger is now EMPTY, which is the state its header calls the intended
 // steady one. Read the open set from a run, not from this prose.
+
+// ## VALUE_ROUNDTRIP: a tenth column that added ZERO rows (#12393)
+//
+// Worth recording precisely because it is the shape the two paragraphs above
+// describe as the goal and neither of them achieved on arrival. FILTER_TEXT
+// landed ahead of its implementations and opened five rows; AGGREGATION landed
+// with two. VALUE_ROUNDTRIP landed with none — all five drivers answered it on
+// the day it arrived.
+//
+// ⛔ Read that as a MEASUREMENT, not as evidence the column is weak. The
+// measurement is only meaningful because the column was ablated: restoring the
+// pre-#12380 SQLite json branch turns this column red on THREE drivers
+// (driver-sql, driver-sqlite-wasm and driver-turso's local transport, all of
+// which route through `SqlDriver.formatInput`) while leaving every one of the
+// other nine columns green — which is the whole argument the card was filed
+// on. See `packages/spec/src/data/value-roundtrip-conformance.ts` and the
+// per-driver suites for the numbers.
+//
+// Why zero rows was reachable at all: the column was deliberately SEQUENCED
+// second, behind #12380's route-A codec fix, precisely so it would not ship red
+// on SQLite by construction. That ordering is the reusable part — it is the
+// #12014 -> #12136 shape applied again, and it is why this column needed no
+// ledger entry and no new escape hatch.
+//
+// One value class is deliberately OUTSIDE the column rather than ledgered
+// inside it: a declared field written as an explicit `undefined`, which the
+// JS-backed drivers return as an own key holding `undefined` (#9276, open and
+// tracked). A ledger row would have been the wrong instrument — the case-set
+// simply does not ask that question yet, and the case-set file says so by name.
 
 // The intended steady state, reached on 2026-08-11: every (driver x case-set)
 // cell is covered by an imported case-set, and nothing is deferred. Keep it


### PR DESCRIPTION
Fixes #12393

Route D of #12380, ruled in by the maintainer on 2026-08-26 alongside route A and
sequenced behind it. Route A landed as `4045b954d3`, so the reason for the hold has
expired.

## What this adds

`VALUE_ROUNDTRIP_CASES` — a tenth case-set in the driver-conformance census, asking every
driver on every dialect the one question none of the other nine asks: **what you wrote is
what you read back**.

The census was green at 9 of 9 dialect-scored cells after #12136 promoted `MATRIXED`, and
all nine of its case-sets are about *which rows come back* — filters, temporal form,
pagination, aggregation. None is about *what is in them*. That green was therefore not
weak evidence about a round-trip defect; it was **no evidence at all**, and it would have
stayed green forever with the defect in place. Hence the drip of one-instance cards:
#12380, #11535, #11782, #10995.

Enrolled through the census's **existing** machinery rather than as a bespoke suite —
that reuse is the whole argument for this route. `CLASSIFIED` obliges the fixture to be
classified, `CONSUMED` obliges every driver to run it, and `MATRIXED` obliges
`driver-sql`'s cell to be answered on **every dialect it speaks** rather than on SQLite
alone, which is precisely the coverage shape that let #12380 survive.

```
check-driver-conformance: OK — 50 covered cell(s), 0 in the DEBT ledger, 0 exempt.
check-driver-conformance: dialect axis — 8 conformance suite(s) across 1 dialect-capable
  driver(s): 7 run the matrix, 1 declare named cell(s), 0 in the DIALECT ledger.
  10 of 10 dialect-scored cell(s) have a matrix-routed suite.
```

## The size, re-measured rather than inherited

The card refused to size itself and asked for a measurement. Measured:

| | |
|---|---|
| cases in the table | **41**, over `json` / `multiple: true` / `string` / `number` / `boolean` |
| new census cells | **5** (one per driver), taking 45 → **50** |
| backends actually executed | **7** — driver-sql × 3 dialects, driver-turso × 2 transports, driver-memory, driver-sqlite-wasm, driver-mongodb (server-free) |
| **driver-side round-trip divergences found** | **0** |
| ledger rows needed | **0** — `LEDGER` and `DIALECT_LEDGER` both stay empty |
| divergences found anywhere | **1**, and it was in a **test double**, not a driver (below) |

Every value in the table is one some driver was *measured* to change (#12380's boundary
set, #11535's array, #11782's boolean) or a control that stayed faithful in the same
measurement. Nothing was invented to round out a table.

## The three things the card said would decide acceptance

### 1. #5499 — the freeze is **already fully lifted**, so no freeze-scoping was needed

The brief said to read the ruling before scoping. Reading it changed the answer. #5499 is
still open as a historical anchor, but both halves were lifted by the maintainer on
**2026-08-11**, recorded on the card itself:

> 5499 解冻 mongodb 相关开发,继续全速推进

> driver-memory 也解冻,继续清剩下两行 DEBT

The second comment states it outright: *"this card's freeze is fully dissolved … it no
longer gates anything."* So `driver-memory` and `driver-mongodb` were enrolled on the same
terms as everyone else, and both answered the case-set green on arrival. **Nothing was
quietly fixed in a frozen driver, and nothing needed to be** — no driver source changed at
all. The freeze did not have to become an excuse, because there is no freeze.

⚠️ Flagging the stale premise rather than silently acting on it: the card body, the
dispatch and #12380's landing comment all still describe the freeze as live.

### 2. A gate that ships red vs. one that ships honest — it ships **green, and non-vacuously**

Zero red cells, zero ledger rows, and no new escape hatch — so the #12136 sharp edge
(a `DIALECT` row deliberately does not clear `MATRIXED`) is not re-opened, because nothing
here asks a ledger for anything. That was reachable only because route D was **sequenced
behind route A**; landing it first would have shipped red on SQLite by construction.

⛔ Green on arrival is worth nothing unless the column can go red, so it was **ablated** —
see below.

One value class is **scoped out by name rather than ledgered**: a declared field written
as an explicit `undefined`, which the JS-backed drivers return as an own key holding
`undefined`. That is #9276 — open, on hold, tracked — not something this table discovered.
Including it would have shipped a case-set red on `driver-memory` by construction. A ledger
row would have been the wrong instrument: the case-set simply does not ask that question
yet, and the case-set file says so, by name, with the condition under which it should.

### 3. Clause ② — **no**, confirmed against the actual diff

```
 .changeset/value-roundtrip-conformance-case-set.md |  47 ++++
 .../src/memory-value-roundtrip-conformance.test.ts | 102 ++++++++
 .../mongodb-value-roundtrip-translation.test.ts    | 123 +++++++++
 .../sql-driver-value-roundtrip-conformance.test.ts | 130 +++++++++
 ...sqlite-wasm-value-roundtrip-conformance.test.ts | 105 ++++++++
 .../driver-turso/src/libsql-sqlite-stub.testkit.ts |  43 ++-
 .../src/turso-value-roundtrip-conformance.test.ts  | 148 +++++++++++
 packages/spec/export-origins/data.json             |   7 +
 packages/spec/src/data/index.ts                    |   7 +
 .../spec/src/data/value-roundtrip-conformance.ts   | 291 +++++++++++++++++++++
 scripts/check-driver-conformance.mjs               |  34 +++
 11 files changed, 1034 insertions(+), 3 deletions(-)
```

Six test files, one conformance fixture, one `CASE_SETS` row, one changeset, one
regenerated artifact, and one test-double fix. **No Zod schema, no runtime, no driver
source, no API, no config.** The two `packages/spec/src` files are the fixture and its
`export * from` line — the package's `data` export gains seven names that only conformance
suites consume, and nothing an existing consumer resolves changes shape. No accept-set is
narrowed or widened anywhere in the diff.

## Ablation — the column can go red, and only where it should

Direction **and exact failure counts were written down before the mutation was applied**;
the mutation was proven on disk by anchored `grep -cF` counts before any result was read;
restore ran under `trap … EXIT INT TERM` and was verified with an empty `git diff`.

**Mutation**: restore the pre-#12380 SQLite branch in `SqlDriver.formatInput` — on SQLite
only, store a non-object `Field.json` value as-is instead of `JSON.stringify`-ing it.

| suite | predicted | measured | |
|---|---|---|---|
| driver-sql value-roundtrip (sqlite cell) | 16 failed | **16 failed** / 29 passed | ✅ exact |
| **the nine existing case-sets** (driver-sql) | 0 failed | **252 passed**, 0 failed | ✅ **the card's thesis** |
| driver-sqlite-wasm value-roundtrip | 16 failed | **16 failed** / 28 passed | ✅ exact |
| driver-turso value-roundtrip | 16 failed | **31 failed** / 57 passed | ❌ mispredicted — see below |
| driver-memory value-roundtrip | 0 failed | **44 passed** | ✅ control fires |
| driver-mongodb value-roundtrip | 0 failed | **45 passed** | ✅ control fires |
| `sql-driver-12380-json-roundtrip` (instance pin) | red | 18 failed | ✅ mutation landed |

⇒ **The new column goes red on three drivers while all nine existing columns stay green.**
That is the argument the card was filed on, measured rather than asserted.

Mutation confirmed on disk before any result was read: fix marker
`ONE encoding, every dialect (#12380)` 1 → 0, mutant marker `ABLATION-12393-MUTANT` 0 → 2,
`git diff --numstat` = `4 2`. Restore verified: markers back to 1 / 0, `git status` empty.

### Two things the run corrected, reported rather than tidied away

**(a) A false green that read exactly like "the case-set does not bite there."** The first
pass mutated driver-sql's *source* only. `driver-sqlite-wasm` and `driver-turso` import
`SqlDriver` from `@objectstack/driver-sql` — the package exports, i.e. `dist/` — so their
first readings (`44 passed`, `88 passed`) were measured against the **unmutated artifact**
and are void. `ablation-dist-preflight` then refused the first rebuilt attempt too, because
the marker was only a *comment* and tsup strips comments from executable output — it
survived in the sourcemap alone, and the tool correctly called that not a reading. Only
with an executable marker did the preflight pass (`✓ marker present in 2 built files`) and
the real numbers appear. Both legs rebuilt; the restore leg rebuilt as well and proved the
marker **absent** from all 6 built files, so no later measurement runs against a poisoned
`dist`.

driver-sql's own suites were *not* exposed to this, and that is measured rather than
assumed: all eight resolve `SqlDriver` through relative source (`./sql-driver.js`,
`./index.js`, `../src/index.js`) and **zero** driver-sql test files import
`@objectstack/driver-sql` — with a positive control, since the same grep found
`from './sql-driver.js'` in four of them.

**(b) A mechanism claim of mine was wrong.** I predicted turso's remote transport would
stay green because it "does not reach `formatInput` at all". It went red on 15 of 44. The
source says why: `TursoDriver.toRemoteWriteForms` **is** `formatInput`, deliberately, *"so
the two transports cannot disagree about what a written value becomes."* I had reasoned
from `RemoteTransport.serializeValue` without reading its caller.

The two transports diverge by exactly one case under the mutant (`s_0123`), and the reason
is informative: local emits a column declared `json` (NUMERIC affinity destroys the bare
string `'0123'` before storage), while `RemoteTransport.mapFieldTypeToSQL` emits `TEXT`,
where no affinity conversion applies and `JSON.parse('0123')` throws so the keep-as-string
fallback holds. Both are green under the fixed code, so this is not a defect today — but a
declared-column-type asymmetry between two faces of one driver is the #11535 class, and it
is reported below rather than left in a scratch file.

## The one non-test change, and its bounding scan

`driver-turso`'s `makeLibsqlSqliteStub` did not model `@libsql/client`'s **client-side**
`boolean → 1/0` conversion, so a declared `boolean` written through the REMOTE transport
could not be bound at all — better-sqlite3 rejected it outright. Surfaced by this
case-set, since it is the first thing in the package to store a declared boolean through
that transport.

⭐ **Which side was wrong was settled by reading the dependency, not the comment.**
`RemoteTransport.serializeValue` says *"booleans are kept as-is (libsql handles them)"* —
and `@libsql/client`'s sqlite3 backend does exactly that, converting a bound boolean to
`1`/`0` under the default `intMode` (`lib-esm/sqlite3.js`, the `typeof value === "boolean"`
arm). **So the transport is correct and unchanged; the stub was the half that diverged.**
The asymmetry that hid it: the LOCAL path never reaches the question, because
`SqlDriver.formatInput` carries its own bind safety net for these value classes.

Bounding scan before touching a testkit 24 files share: **zero** tests anywhere in the repo
pin the stub's boolean-bind throw (`grep` for the error text finds 10 hits, none in
`driver-turso` — all are prose in `driver-sql` / `spec` / `service-analytics` about
better-sqlite3's real behaviour). Since every such bind throws today, no existing green
test can depend on the old behaviour. Positive control: 20 turso test files reference the
stub, so the grep reaches them. `driver-turso`'s full suite: **40 files / 1094 tests, all
passing.** Deliberately *not* modelled, and said so in the code: the client's `Date` and
`ArrayBuffer` conversions, because `serializeValue` converts a `Date` to ISO before the
client sees one, and an unreachable conversion would be a claim nothing checks.

## Changeset grade — `patch`, defended

`@objectstack/spec`: **patch**. The published surface gains one conformance fixture whose
seven exports only conformance suites consume; no schema, no runtime, no behaviour, and
nothing an existing consumer resolves changes shape. Not `minor`, because a `minor`
signals a capability consumers can adopt and there is none. Not `none`, because the export
surface genuinely grows and `packages/spec/export-origins/data.json` records it. The
driver packages get no changeset: their diffs are test files plus one test-only testkit.

## Verification

Gate union **derived, not recalled**, at the final head `6d96e0a73f`:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` → 36 path-derived
families, re-derived after the last commit and byte-identical to the earlier derivation.
All 36 run, plus the 7 convention-triggered families the derivation names (test-file kind
and gate-script kind) and `check:type-check-debt --re-measure`. **Every exit code captured
before any pipe** into a per-command results file — the lock's own `VERDICT` line reports
the *batch's* exit and is not a verdict on any one command.

**All green.** Verdict lines quoted from the gates themselves, not from `$?`:

- `check-driver-conformance: OK — 50 covered cell(s), 0 in the DEBT ledger, 0 exempt.` +
  `10 of 10 dialect-scored cell(s) have a matrix-routed suite.`
- `check-type-check-coverage --re-measure: OK — 32 ledger entr(ies) re-measured in 245.3s, 1843 raw tsc error(s) total, none above its recorded number.`
- `check-nul-bytes: OK (scanned 6932 text file(s) … no raw ASCII control bytes).`
- `where-matcher conformance holds: 303 matcher(s) discovered, 303 answer the combinator battery correctly or refuse it loudly`
- `OK: 20 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.`
- `check-engine-double-contract: 398 (file, verb) row(s) held by the RETAINED ledger`

⚠️ **One gate REFUSED before it was measured, reported as NOT MEASURED rather than as a
pass:** `check-dev-prereqs.mjs` exited 1 with *"The workspace is not built — 1 unmet
precondition, not a list of problems"* (34 of 67 packages missing a `dist/` entry point).
The workspace closure was then built (`turbo run build`, 70/70 successful) and it was
re-run: `✓ 67 package build artifacts present`. `check:type-check-debt` has the same
precondition and was run only after that build.

**Suites** (all foreground, serialized through `scripts/pm/os-verify-lock.sh`):

| package | result |
|---|---|
| `@objectstack/spec` | 432 files / **11464 passed** |
| `@objectstack/driver-sql` | 138 files / **2158 passed**, 8 files + 129 tests skipped (the unprovisioned pg/mysql cells) |
| `@objectstack/driver-turso` | 40 files / **1094 passed** |
| `@objectstack/driver-memory` | 28 files / **823 passed** |
| `@objectstack/driver-sqlite-wasm` | 26 files / **439 passed** |
| `@objectstack/driver-mongodb` | 18 files / **432 passed**, 5 files + 143 skipped (the opt-in real-mongod suites, #5517) |

Typecheck: all six touched packages, each script name echoed in the output so a
zero-match `--filter` cannot read as a pass.

⚠️ **A real failure this caught, and how**: the first `@objectstack/spec` run came back
`1 failed | 11463 passed` — the package's own compiler-free freshness guard, because
`packages/spec/export-origins/data.json` is generated and my seven new exports made it
stale. Regenerated with the command the failure text names; the diff is exactly those
seven lines and nothing else. Worth noting **which instrument caught it**: the derivation
lists `check:export-origins` among the 9 families *"where the layout moved under a gate
that still spells the old path"* — so the path derivation could never have named it, and
only running the package's full suite did.

⚠️ **Not measurable in this container, stated rather than implied**: `OS_TEST_POSTGRES_URL`
and `OS_TEST_MYSQL_URL` are unset, so the pg and mysql cells **skip** rather than prove
green. CI's `Temporal Conformance (live PG + MySQL)` job runs the whole `driver-sql` suite
with both servers and `OS_EXPECT_LIVE_DIALECT_MATRIX=1`, which turns those skips into named
reds — and it picks this file up automatically, since it runs the package rather than a
path list. The asymmetry half of the ablation therefore rests here on (a) the mutation
being `this.isSqlite`-guarded by construction and (b) driver-memory / driver-mongodb
measuring green under it, which is a real cross-driver control this container *can* run.
The live PG/MySQL half was measured on #12380's own ablation.

## Out-of-scope findings — handed up, not filed

⛔ Neither is filed as a card, and the reason is a channel fact rather than a judgement:
direct REST to the GitHub API returns **403** from this dev seat (the #12123 gap #12380
documented), and MCP issue search is off-limits for dedup reads under the dispatch
contract. Filing without a dedup search would be filing blind, so both are handed up with
the local-grep half of the evidence done. Same call the #12172 dev made.

1. **#9276's restart condition fired nine days before it was written.** That card sits
   `pm:on-hold` with `Restart-when: … OR driver-memory / driver-mongodb come out of the
   #5499 investment freeze`. The line was added **2026-08-20**; the freeze was fully lifted
   **2026-08-11**. So it is held by a condition that was already satisfied at the moment of
   writing, and no mechanism will ever wake it — which is the exact failure that card's own
   note says the restart line was added to prevent.

2. **`driver-turso` declares a `Field.json` column as `json` locally and `TEXT` remotely.**
   `SqlDriver` emits `json` (confirmed from the catalog by the #12380 suite);
   `RemoteTransport.mapFieldTypeToSQL` returns `TEXT` for both `json` and `multiple: true`.
   Benign today — both transports round-trip faithfully, which this PR's suite measures —
   but the two faces of one driver put the same declared field in different physical column
   types, and the ablation showed they consequently fail *differently* under the same
   defect. That is the #11535 class. Local grep finds the two `mapFieldTypeToSQL` lines and
   one comment in `remote-read-coercion.test.ts` (`// json stored as TEXT`); nothing states
   the asymmetry as a known, intended fact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_