### PR TITLE
fix(platform-objects): sys_secret field help stops asserting the settings-only reading

### DIFF
--- a/.changeset/sys-secret-tri-producer-field-help.md
+++ b/.changeset/sys-secret-tri-producer-field-help.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+fix(platform-objects): `sys_secret` field help stops asserting the settings-only reading (#12550)
+
+`sys_secret` has **three** privileged producers (#4270) — the object's own
+`managedBy` note has said so for a while — but its most load-bearing field
+descriptions still described a settings-only table. Those strings are not
+internal comments: they are the field help an operator reads in the
+`sys_secret` grid, and they compile into the shipped translation bundles.
+
+Measured on `origin/main@f93df4db`, by producer symbol rather than by line:
+
+| producer | `namespace` | `key` | the reference lives at |
+|---|---|---|---|
+| `SettingsService` (`settings-service.ts`, `secretStore.insert`) | settings namespace | specifier key | `sys_setting.value_enc` |
+| engine `encryptSecretFields` (`objectql/src/engine.ts`) | **object name** | **field name** | a `secret:<id>` ref on the business row itself |
+| datasource credential binder (`datasource-secret-binder.ts`) | **caller-supplied**, default `datasource` | datasource name | the artefact's `sys_secret:<id>` credentialsRef |
+
+So `'Settings namespace this secret belongs to.'` / `'Specifier key within the
+namespace.'` / `'Opaque handle referenced by sys_setting.value_enc.'` were each
+true of one producer out of three, and the pair they describe was presented as
+if it identified an owner. That is exactly the `(namespace, key)` attribution
+reading #8103's re-measurement rejected — the reason
+`sys-secret-orphan-report.ts` reports a row it cannot attribute as
+`'unattributable'` rather than `'orphaned'`. Field help asserting the rejected
+reading is the safety-relevant direction of this drift.
+
+Corrected here: the object description, and the `namespace` / `key` / `id`
+field descriptions, now name the producer-scoped reality and point at
+`managedBy`. The `en` bundle was regenerated with the repo's own
+`pnpm i18n:extract`; the three translated locales carried translations of the
+superseded English, so their four affected leaves were re-translated by hand —
+the action `<locale>.objects.generated.ts`'s own header prescribes when a
+source string changes — and the bundles plus their `--source-hashes`
+companions then come from one extract run.
+
+Text only. No field is added, removed, renamed or re-typed; no validation,
+persistence or access rule moves; every `sys_secret` payload that parsed before
+parses identically. ⛔ A producer/owner column stays out of scope — that is a
+persist-path change and belongs to whoever takes that decision.

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -3012,11 +3012,11 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
   sys_secret: {
     label: "Secret",
     pluralLabel: "Secrets",
-    description: "Cipher store referenced by sys_setting handles. Never holds plaintext.",
+    description: "Cipher store written by three privileged producers (see managedBy); each holds its handle in its own column. Never holds plaintext.",
     fields: {
       id: {
         label: "ID",
-        help: "Opaque handle referenced by `sys_setting.value_enc`."
+        help: "Opaque handle. The reference lives in the writing producer's own holder column — `sys_setting.value_enc`, a `secret:` ref on a business row, or a datasource `credentialsRef` — so a row unreferenced by `sys_setting` is not thereby unreferenced."
       },
       created_at: {
         label: "Created At",
@@ -3028,11 +3028,11 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       namespace: {
         label: "Namespace",
-        help: "Settings namespace this secret belongs to."
+        help: "Producer-scoped label, not a settings namespace in general: `SettingsService` writes the settings namespace, the engine's `secret`-field encryption writes the object name, the datasource binder writes its caller-supplied scope (default `datasource`). See managedBy."
       },
       key: {
         label: "Key",
-        help: "Specifier key within the namespace."
+        help: "Producer-scoped label paired with `namespace`: the settings specifier key, the encrypted `secret` field's name, or the datasource name. The pair records how the producer addressed the value; it does not identify which producer wrote the row."
       },
       kms_key_id: {
         label: "KMS Key ID",

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -3012,11 +3012,11 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
   sys_secret: {
     label: "Secreto",
     pluralLabel: "Secretos",
-    description: "Almacén cifrado al que hacen referencia los identificadores de sys_setting. Nunca contiene texto sin formato.",
+    description: "Almacén cifrado escrito por tres productores privilegiados (véase managedBy); cada uno guarda su identificador en su propia columna. Nunca contiene texto sin formato.",
     fields: {
       id: {
         label: "ID",
-        help: "Identificador opaco al que hace referencia `sys_setting.value_enc`."
+        help: "Identificador opaco. La referencia vive en la columna propia del productor que lo escribió — `sys_setting.value_enc`, una referencia `secret:` en una fila de negocio o el `credentialsRef` de un origen de datos —, de modo que una fila no referenciada por `sys_setting` no está por ello sin referencias."
       },
       created_at: {
         label: "Creado el",
@@ -3028,11 +3028,11 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       namespace: {
         label: "Espacio de nombres",
-        help: "Espacio de nombres de ajustes al que pertenece este secreto."
+        help: "Etiqueta acotada al productor, no un espacio de nombres de ajustes en general: `SettingsService` escribe el espacio de nombres de ajustes, el cifrado de campos `secret` del motor escribe el nombre del objeto y el vinculador de orígenes de datos escribe el ámbito indicado por quien lo llama (por defecto `datasource`). Véase managedBy."
       },
       key: {
         label: "Clave",
-        help: "Clave del especificador dentro del espacio de nombres."
+        help: "Etiqueta acotada al productor y emparejada con `namespace`: la clave del especificador de ajustes, el nombre del campo `secret` cifrado o el nombre del origen de datos. El par registra cómo el productor direccionó el valor; no identifica qué productor escribió la fila."
       },
       kms_key_id: {
         label: "ID de clave KMS",

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -3012,11 +3012,11 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
   sys_secret: {
     label: "シークレット",
     pluralLabel: "シークレット",
-    description: "sys_setting ハンドルが参照する暗号ストア。平文は保持しません。",
+    description: "3 つの特権的な書き込み経路が書き込む暗号ストア（managedBy を参照）。ハンドルはそれぞれの経路が自身の列で保持します。平文は保持しません。",
     fields: {
       id: {
         label: "ID",
-        help: "`sys_setting.value_enc` が参照する不透明なハンドル。"
+        help: "不透明なハンドル。参照は書き込んだ経路それぞれの保持列にあります — `sys_setting.value_enc`、業務レコード上の `secret:` 参照、またはデータソースの `credentialsRef`。したがって `sys_setting` から参照されていない行が、参照されていない行であるとは限りません。"
       },
       created_at: {
         label: "作成日時",
@@ -3028,11 +3028,11 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       namespace: {
         label: "名前空間",
-        help: "このシークレットが属する設定名前空間。"
+        help: "書き込み経路ごとに意味が決まるラベルであり、一般に設定名前空間とは限りません：`SettingsService` は設定名前空間を、エンジンの `secret` フィールド暗号化はオブジェクト名を、データソースバインダーは呼び出し側が指定したスコープ（既定は `datasource`）を書き込みます。managedBy を参照。"
       },
       key: {
         label: "キー",
-        help: "名前空間内の識別キー。"
+        help: "`namespace` と対になる、書き込み経路ごとに意味が決まるラベル：設定の識別キー、暗号化される `secret` フィールド名、またはデータソース名。この対は書き込み経路が値をどう指定したかを記録するもので、どの経路がその行を書き込んだかを示すものではありません。"
       },
       kms_key_id: {
         label: "KMS キー ID",

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -3012,11 +3012,11 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
   sys_secret: {
     label: "密钥",
     pluralLabel: "密钥",
-    description: "由 sys_setting 句柄引用的密文存储。绝不保存明文。",
+    description: "由三个特权写入方写入的密文存储（见 managedBy）；每个写入方各自在自己的列中保存句柄。绝不保存明文。",
     fields: {
       id: {
         label: "ID",
-        help: "由 `sys_setting.value_enc` 引用的不透明句柄。"
+        help: "不透明句柄。引用保存在写入方各自的持有列中 —— `sys_setting.value_enc`、业务记录上的 `secret:` 引用，或数据源的 `credentialsRef`；因此某行未被 `sys_setting` 引用，并不等于它未被引用。"
       },
       created_at: {
         label: "创建时间",
@@ -3028,11 +3028,11 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       namespace: {
         label: "命名空间",
-        help: "该密钥所属的设置命名空间。"
+        help: "按写入方限定的标签，并非普遍意义上的设置命名空间：`SettingsService` 写入设置命名空间，引擎的 `secret` 字段加密写入对象名，数据源绑定器写入调用方提供的范围（默认 `datasource`）。见 managedBy。"
       },
       key: {
         label: "键",
-        help: "命名空间内的标识键。"
+        help: "与 `namespace` 配对的、按写入方限定的标签：设置的标识键、被加密的 `secret` 字段名，或数据源名。该配对记录的是写入方如何寻址该值；它并不标明是哪个写入方写入了该行。"
       },
       kms_key_id: {
         label: "KMS 密钥 ID",

--- a/packages/platform-objects/src/system/sys-secret.object.ts
+++ b/packages/platform-objects/src/system/sys-secret.object.ts
@@ -50,7 +50,8 @@ export const SysSecret = ObjectSchema.create({
   // SettingsService / the datasource secret-binder read with no principal
   // (middleware falls open for principal-less internal calls).
   access: { default: 'private' },
-  description: 'Cipher store referenced by sys_setting handles. Never holds plaintext.',
+  description:
+    'Cipher store written by three privileged producers (see managedBy); each holds its handle in its own column. Never holds plaintext.',
   highlightFields: ['namespace', 'key', 'kms_key_id', 'version', 'rotated_at'],
   listViews: {
     all: {
@@ -65,7 +66,8 @@ export const SysSecret = ObjectSchema.create({
     id: Field.text({
       label: 'ID',
       readonly: true,
-      description: 'Opaque handle referenced by `sys_setting.value_enc`.',
+      description:
+        'Opaque handle. The reference lives in the writing producer\'s own holder column — `sys_setting.value_enc`, a `secret:` ref on a business row, or a datasource `credentialsRef` — so a row unreferenced by `sys_setting` is not thereby unreferenced.',
     }),
 
     created_at: Field.datetime({
@@ -81,23 +83,42 @@ export const SysSecret = ObjectSchema.create({
     }),
 
     /**
-     * Namespace/key duplicated from `sys_setting` for forensic
-     * convenience — lets operators answer "which secret backs
-     * mail.api_key right now?" without joining the K/V table.
-     * The authoritative link is `sys_setting.value_enc → sys_secret.id`.
+     * `(namespace, key)` is a PRODUCER-SCOPED pair, not an owner. Each of the
+     * three producers named in `managedBy` (#4270) fills it from its own
+     * vocabulary, and the reference to the resulting row lives in a different
+     * column for each:
+     *
+     *  - `SettingsService` — settings namespace + specifier key; referenced by
+     *    `sys_setting.value_enc`.
+     *  - the engine's `secret`-field encryption (`encryptSecretFields`) —
+     *    object name + field name; referenced by a `secret:<id>` ref stored on
+     *    the business row itself.
+     *  - the datasource credential binder — caller-supplied namespace (default
+     *    `datasource`) + datasource name; referenced by the artefact's
+     *    `sys_secret:<id>` credentialsRef.
+     *
+     * ⛔ So the pair does NOT attribute a row to a producer, and a lookup that
+     * finds no `sys_setting` behind a pair has found nothing: #8103's
+     * re-measurement rejected exactly that reading, which is why
+     * `service-settings/src/sys-secret-orphan-report.ts` reports a row it
+     * cannot attribute as `'unattributable'` rather than `'orphaned'`. The pair
+     * is for inspecting and rotating a known secret, never for deciding what a
+     * row belongs to.
      */
     namespace: Field.text({
       label: 'Namespace',
       required: true,
       maxLength: 128,
-      description: 'Settings namespace this secret belongs to.',
+      description:
+        'Producer-scoped label, not a settings namespace in general: `SettingsService` writes the settings namespace, the engine\'s `secret`-field encryption writes the object name, the datasource binder writes its caller-supplied scope (default `datasource`). See managedBy.',
     }),
 
     key: Field.text({
       label: 'Key',
       required: true,
       maxLength: 128,
-      description: 'Specifier key within the namespace.',
+      description:
+        'Producer-scoped label paired with `namespace`: the settings specifier key, the encrypted `secret` field\'s name, or the datasource name. The pair records how the producer addressed the value; it does not identify which producer wrote the row.',
     }),
 
     /** Identifier of the KMS key used to wrap `ciphertext`. */


### PR DESCRIPTION
Fixes #12550

> Editing note: three angle-bracket placeholders in the first version of this body were eaten by GitHub's body sanitizer (it strips short less-than fragments, backticks included). They are spelled out in words below rather than literally — please do not "repair" them back.

## The producer table, re-verified on this branch's base

The card measured `3a3a0993`; this branch is cut from `f93df4dbe3`, so the table was re-derived from the producer symbols rather than from the card's line numbers. It holds, unchanged:

| producer | `namespace` | `key` | the reference lives at |
|---|---|---|---|
| `SettingsService` — `services/service-settings/src/settings-service.ts`, the `this.secretStore.insert({ id, namespace, key, … })` branch | settings namespace | specifier key | `sys_setting.value_enc` (bare `sec_…` handle id) |
| engine `encryptSecretFields` — `packages/objectql/src/engine.ts`, `secretDriver.create('sys_secret', { namespace: object, key: field, … })` | **object name** | **field name** | a ref written back onto the business row's own column by `makeSecretRef` — the literal prefix `secret:` followed by the handle id |
| datasource credential binder — `services/service-datasource/src/datasource-secret-binder.ts`, `namespace = input.namespace ?? deps.namespace ?? 'datasource'`, `key = input.key ?? hint.name` | **caller-supplied**, default `datasource` | datasource name | the datasource artefact's credentialsRef — the literal prefix `sys_secret:` followed by the handle id |

So each of the three strings was true of one producer out of three, and the pair they described was presented as if it identified an owner — the `(namespace, key)` attribution reading #8103's re-measurement rejected, which is why `sys-secret-orphan-report.ts` reports a row it cannot attribute as `'unattributable'` rather than `'orphaned'`. These strings are not internal comments: they are the field help an operator reads in the `sys_secret` grid, and they compile into the shipped translation bundles.

## What changed

`packages/platform-objects/src/system/sys-secret.object.ts`:

- `namespace` / `key` — producer-scoped labels whose meaning depends on which producer wrote the row, each naming all three vocabularies and pointing at `managedBy`; `key`'s text says outright that the pair does not identify the producer.
- `id` — the handle, with the reference located in the writing producer's own holder column, and the corollary spelled out: a row unreferenced by `sys_setting` is not thereby unreferenced.
- The **object-level `description`** (`'Cipher store referenced by sys_setting handles.'`) — named here because the card lists three fields, not four. It is the same defect in the same shipped-surface class one line above them, mechanical, with its correct form already pinned by the `managedBy` note; leaving it would have kept the settings-only claim in the most visible string on the table.
- The JSDoc block above `namespace`, which asserted the same thing to the next author ("Namespace/key duplicated from `sys_setting` … The authoritative link is `sys_setting.value_enc → sys_secret.id`"), replaced by the per-producer table plus the ⛔ note on attribution.

⛔ A producer/owner column stays out of scope: that is a persist-path change with its own consequences and belongs to whoever takes that decision.

## Regeneration, and the stale-fill measurement

Regenerated with the repo's own command — `pnpm i18n:extract` (`os i18n extract … --locales=zh-CN,ja-JP,es-ES --fill=default --source-hashes`), which wrote all **11** files, the `--source-hashes` companions included, in one run. Never by hand.

The stale-fill question was measured, not guessed, in two legs:

1. **Source revised, bundles regenerated, translations untouched.** `check:i18n` green (`platform-objects  in sync (11 bundle(s))`); `check-i18n-stale-fill: OK (10 bundle set(s) — no new stale fills, 0 baselined)`. **Zero findings** — and the three translated locales were at that moment serving translations of the superseded English.
2. **Why zero, from the mechanism's own two predicates.** The generated-half predicate is `hash(value) === recorded && hash(currentSource) !== recorded`, and there is no record for these leaves: they carried real translations, so at backfill time `value !== currentSource` left them legacy-trusted — correctly, per the ruling's property 1. The cross-locale-agreement half needs at least 2 locales byte-identical at the leaf; `zh-CN` / `ja-JP` / `es-ES` hold three different languages. This is precisely the blind spot `check-i18n-stale-fill.mjs`'s own header declares ("a leaf stranded in ONE locale … carries no evidence at all"), reached from the other side: three locales stale, no two agreeing.

So the gate reporting nothing is not the drift being absent. The four affected leaves were re-translated by hand in each locale — the action each locale's own generated objects bundle prescribes in its header ("Re-translate it by hand when its source changes"; merge fills gaps only, so regenerating cannot do it) — and `pnpm i18n:extract` was then re-run so bundles and companions come from one run. The three `*.source-hashes.generated.ts` files are byte-identical to `main` afterwards: no record is written for a leaf that differs from `en`, which is the same fact that made leg 1 report zero.

## Clause ② — two answers, kept apart

**Published surface: yes, it moves.** `description` on an object and on a field is published metadata — served to the grid and compiled into the shipped bundles of `@objectstack/platform-objects`. The diff is 4 leaves (`sys_secret.description`, `fields.id.help`, `fields.namespace.help`, `fields.key.help`) across 4 locales.

**Accept/reject behaviour: no, nothing moves.** Evidence from the diff rather than from intent:

```
 .changeset/sys-secret-tri-producer-field-help.md   | 42 ++++++++++++++++++++++
 .../src/apps/translations/en.objects.generated.ts  |  8 ++---
 .../apps/translations/es-ES.objects.generated.ts   |  8 ++---
 .../apps/translations/ja-JP.objects.generated.ts   |  8 ++---
 .../apps/translations/zh-CN.objects.generated.ts   |  8 ++---
 .../src/system/sys-secret.object.ts                | 37 ++++++++++++++-----
 6 files changed, 87 insertions(+), 24 deletions(-)
```

Every changed line in the object file is a `description:` string literal or a JSDoc comment line — no `Field.*` option other than `description`, and no change to `access`, `indexes`, `enable.apiMethods`, `highlightFields`, `listViews`, or the `fields` key set. In the bundles the 16 changed leaf lines are 4 `description:` and 12 `help:` values, four removed and four added per file: no bundle key is added, removed or renamed, which `check:i18n` confirms independently (11 bundles in sync) and `check:i18n-coverage` confirms from the count side (`OK (12 config(s), 602 baselined untranslated string(s), none new)`). Every `sys_secret` payload that parsed before parses identically.

## Verification

Gate union derived over the real changeset with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (6 paths, three-dot vs merge base `f93df4dbe`) — 18 path-matched families plus the 2 convention-triggered i18n ones. All run at `adb117b1c`, each exit captured before any pipe:

| gate | its own verdict line |
|---|---|
| `check:i18n` | `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).` — `platform-objects  in sync (11 bundle(s))` |
| `check:i18n-stale-fill` | `check-i18n-stale-fill: OK (10 bundle set(s) — no new stale fills, 0 baselined).` |
| `check:i18n-coverage` | `check-i18n-coverage: OK (12 config(s), 602 baselined untranslated string(s), none new).` |
| `check:nul-bytes` | `check-nul-bytes: OK (scanned 6950 text file(s) … no raw ASCII control bytes).` |
| `check:published-files` | `✓ 69 publishable package(s) … declare a files whitelist …` |
| `check:page-declaration-shape` | `check-page-declaration-shape: OK — 34 page entries across 2215 sources …` |
| `check:slot-lookup` | `✓ slot-lookup ratchet holds: 107 unswept site(s) in 25 file(s), none new …` |
| `check:test-source-alias` | `check-test-source-alias OK — 72 packages with tests scanned …` |
| `check:type-source-resolution` | `check-type-source-resolution OK — 94 tsc program(s) across 77 packages scanned …` |
| `check:cross-package-test-inputs` (+ the ci.yml script) | `OK: 20 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `check-ci-filter-parity` | `OK: all 109 declared cross-package glob(s) (84 unique) are covered …` |
| `check-comment-mask-adoption` | `OK  check:comment-mask-adoption — 20 private comment-stripper(s) … all 20 recorded` |
| `check-plugin-teardown-shape` | `✓ 63 Plugin implementation(s) … 0 known-unreached, baseline fully burned down` |
| `check-empty-changeset` | `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check-changeset-no-major` | `✓ This diff introduces no major bump.` |
| `check-adr-0087-registration` | `✓ this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).` |
| `check:objectui-changeset` / `check:changeset-gate-self-tests` / `release-rehearsal-clone --self-test` / `docs-audit` × 2 | all `✓` |

Package: `pnpm --filter @objectstack/platform-objects exec vitest run --maxWorkers=2` → `Test Files 31 passed (31) · Tests 515 passed (515)`; `typecheck` exit 0. No existing assertion was changed by this PR.

### Ablation — bundle freshness

Direction and count predicted in writing before running. Rebuild question answered by measurement, not assumption: `packages/platform-objects/scripts/i18n-extract.config.ts` imports `../src/system/index.js` (relative, into `src/`, via `bundle-require`), so extraction reads source, never `dist/` — and in this session the first `pnpm i18n:extract` picked up the source edit before `@objectstack/platform-objects` had ever been built on this branch. So no rebuild leg is required, and none was performed.

- **Mutation** — revert only the `namespace` description to its pre-fix text; leave all four regenerated bundles as committed. Proved on disk before any result was read: injected text `grep -cF` = 1, removed text `grep -cF` = 0, `git diff --stat` = 1 file / 1 insertion / 2 deletions.
- **Predicted** — red; exactly 1 package (platform-objects) with exactly 1 of its 11 bundles drifted; the other 8 packages in sync; translated locales and the 3 source-hash companions unaffected; exit non-zero.
- **Observed** — exit 1. `check-i18n-bundles: 1 bundle problem(s)` · `• platform-objects: 1 bundle(s) drifted from the schema`, with the other 8 packages listed `in sync (4 bundle(s))`. Prediction matched on direction and count.
- **Restore** — under `trap … EXIT INT TERM`; verified with an empty `git diff` and an empty `git status --short`.

The stale-fill gate got no hand-built ablation, deliberately: `pnpm check:i18n-stale-fill` runs `--self-test` before every invocation, and it printed `check-i18n-stale-fill: self-test OK` on each run here — a mutation proving that gate can go red would restate a check that had already run twice in this session.

## Out of scope, filed

- #12599 — `CryptoContext.namespace` / `.key` and `CryptoHandle.id` carry the identical settings-only prose in `packages/spec/src/contracts/crypto-provider.ts`, the contract all three producers call. Filed rather than fixed here: different package, TS doc rather than published metadata, and `packages/spec` brings its own artifact-regeneration discipline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_