### PR TITLE
fix(objectql): flat-input `ownKeys` reports the payload's own key set, not its enumerable subset

### DIFF
--- a/.changeset/flat-input-ownkeys-own-key-set.md
+++ b/.changeset/flat-input-ownkeys-own-key-set.md
@@ -1,0 +1,48 @@
+---
+'@objectstack/objectql': patch
+---
+
+fix(objectql): the flat-input proxy's `ownKeys` reports the payload's own key set, not its enumerable subset (#12578)
+
+`installFlatInput` answered the `ownKeys` trap from `Object.keys(data)` — own **enumerable
+string** keys. That filtering was incidental to what the trap is for (hiding the wrapper keys
+`id`/`options`/`ast`/`data` from `Object.keys`/`for…in`), and it cost a key: an own
+**non-enumerable** key on the record payload was absent from `Object.getOwnPropertyNames(input)`
+and `Reflect.ownKeys(input)` while `hasOwnProperty` and the descriptor trap both reported it —
+and while the engine persisted the row holding it. Measured on the merged ref, for a payload
+`{ subject }` a handler had added `k` to with
+`Object.defineProperty(ctx.input, 'k', { value: 1, enumerable: false, configurable: true })`:
+
+```
+Object.getOwnPropertyDescriptor(input, 'k')       -> own, enumerable:false
+Object.prototype.hasOwnProperty.call(input, 'k')  -> true
+Object.getOwnPropertyNames(input)                 -> ['subject']       <- not own?
+Object.getOwnPropertyNames(persisted row)         -> ['subject', 'k']
+```
+
+Three instruments, one payload, two answers about own-ness. Newly reachable rather than newly
+written: #12277 routed `defineProperty` into the payload, so a handler can put a
+non-default-attribute key there for the first time, and #12397 made the descriptor trap mirror
+the payload instead of synthesising defaults — which is what gave the third instrument an
+opinion to disagree with.
+
+The trap now reports `Object.getOwnPropertyNames(data)`. **The enumerable face is unchanged**:
+`Object.keys`, spread, `Object.entries`, `for…in` and `JSON.stringify` still omit a
+non-enumerable key, because each applies the `enumerable` filter itself, one layer up, through
+the descriptor trap. Applying it inside `[[OwnPropertyKeys]]` as well did not make those answers
+cleaner — it only starved the two surfaces whose entire job is to report the whole set. The
+sandbox body face is byte-identical for the same reason: `unwrapProxyToPlain`
+(`@objectstack/runtime`) snapshots `ctx.input` as `Object.entries` over this proxy.
+
+Wrapper keys stay excluded, which is the trap's purpose — achieved by reading `data` and never
+the wrapper, not by subtracting those four names, which would hide a genuine payload field named
+`id`. **Symbol keys remain unenumerated**: they already reach the payload and already persist, so
+publishing them through `ownKeys` is a question about what a record payload may hold rather than
+about this trap, and it is left open on #12578 rather than decided here.
+
+Pinned in `hook-input-ownkeys-agreement.test.ts` as the AGREEMENT of the three own-ness
+instruments — not as one trap's output, which is the pin shape that let the halves diverge — with
+the wrapper-key and symbol exceptions pinned as deliberate exceptions. Reverse-verified by
+ablation: restoring `Object.keys(target.data)` fails exactly 2 of the 6 new cases (32 of 34 green
+across the four hook-input suites), and the enumerable-face assertions stay green under the
+mutation, which is what proves that half untouched.

--- a/packages/objectql/src/hook-input-ownkeys-agreement.test.ts
+++ b/packages/objectql/src/hook-input-ownkeys-agreement.test.ts
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12578] The flat-input Proxy's own-key ENUMERATION agrees with its other two
+ * own-ness instruments, and with the row the engine persists.
+ *
+ * `installFlatInput` (`hook-wrappers.ts`) answered `ownKeys` from
+ * `Object.keys(data)` — own **enumerable string** keys. The `enumerable`
+ * filtering was incidental to what the trap is for (hiding the wrapper keys),
+ * and it cost a key: an own NON-ENUMERABLE key on the payload was absent from
+ * `Object.getOwnPropertyNames` / `Reflect.ownKeys` while `hasOwnProperty` and
+ * the descriptor trap both reported it. Measured on the merged ref before the
+ * repair, for `Object.defineProperty(ctx.input, 'k', { value: 1,
+ * enumerable: false, configurable: true })` over a payload `{ subject }` the
+ * engine then persisted holding BOTH keys:
+ *
+ * ```
+ * Object.getOwnPropertyDescriptor(input, 'k')       -> own, enumerable:false
+ * Object.prototype.hasOwnProperty.call(input, 'k')  -> true
+ * Object.getOwnPropertyNames(input)                 -> ['subject']   <- not own?
+ * Object.getOwnPropertyNames(raw.data)              -> ['subject','k']
+ * ```
+ *
+ * Newly reachable, not newly written: #12277 routed `defineProperty` into
+ * `data`, so a hook can put a non-default-attribute key on the payload for the
+ * first time, and #12397 made the descriptor trap mirror `data` rather than
+ * synthesise defaults — which is what gave the third instrument an opinion.
+ *
+ * ## What is pinned here, and why it is the AGREEMENT rather than one trap
+ *
+ * The contract these cases assert is not "`ownKeys` returns X". It is that the
+ * three instruments an author can reach — the enumeration surfaces,
+ * `hasOwnProperty`, and the descriptor trap — give the SAME answer about
+ * own-ness for a given key, and that the answer is the one the persisted row
+ * gives. A pin asserting a single trap's output in isolation is what let the
+ * two halves diverge in the first place: #12397 pinned the descriptor trap and
+ * this file's subject drifted out from under it, on the same trap set, in the
+ * same file, within the same week.
+ *
+ * The settled spelling, stated once so the tree stops holding two answers:
+ * **`ownKeys` reports the record payload's own key set, not its enumerable
+ * subset.** Enumerability is applied by the CONSUMERS, one layer up and through
+ * the descriptor trap, which is why the enumerable face below is unchanged.
+ *
+ * ## The two deliberate exceptions, pinned as exceptions
+ *
+ *  - WRAPPER KEYS (`id`/`options`/`ast`/`data`) stay out of the enumeration
+ *    face while `hasOwnProperty` and the descriptor trap still report them.
+ *    That disagreement is the trap's whole purpose (the payload-diff idiom must
+ *    see record fields only) and is pinned as DECLARED so it cannot be mistaken
+ *    for a residue of the defect above.
+ *  - SYMBOL KEYS carry the identical disagreement and are deliberately left
+ *    carrying it. Publishing them is a one-word change here
+ *    (`Object.getOwnPropertyNames` -> `Reflect.ownKeys`), but whether a record
+ *    payload may hold a symbol key at all is a question about the PAYLOAD
+ *    contract — the boundary #12397 drew and this card does not cross. It is
+ *    reported open on #12578 and pinned below in its open state, so answering
+ *    it changes a recorded fact instead of an unnoticed one.
+ *
+ * `wrapDeclarativeHook` is driven directly rather than through `ObjectQL`, for
+ * the reason the sibling trap-set files give: the subject is the wrapper's
+ * Proxy, and a full engine dispatch would put a driver's own copy semantics
+ * between the hook and the assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { wrapDeclarativeHook } from './hook-wrappers.js';
+
+const silentLogger = { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+
+/**
+ * Run `handler` as a declarative hook over `raw` (the engine's own envelope);
+ * the caller keeps `raw` and reads `raw.data` — the row the engine is left
+ * holding — after the wrapper has restored `ctx.input`.
+ */
+async function runHook(raw: Record<string, unknown>, handler: (input: any) => void): Promise<void> {
+  const meta: any = { name: 'ownkeys_probe', object: 'case', event: 'beforeInsert' };
+  const wrapped = wrapDeclarativeHook(meta, (async (ctx: any) => handler(ctx.input)) as any, {
+    logger: silentLogger,
+  });
+  await wrapped({ object: 'case', event: 'beforeInsert', input: raw } as any);
+}
+
+/**
+ * The three instruments, read on ONE key through ONE object. The assertions
+ * below compare this triple against itself — that is the contract — rather than
+ * asserting any member on its own.
+ */
+function ownness(obj: any, key: string | symbol) {
+  return {
+    enumeration: Reflect.ownKeys(obj).includes(key),
+    hasOwnProperty: Object.prototype.hasOwnProperty.call(obj, key),
+    descriptor: Object.getOwnPropertyDescriptor(obj, key) !== undefined,
+  };
+}
+
+/** All three instruments say "own". */
+const OWN = { enumeration: true, hasOwnProperty: true, descriptor: true };
+/** All three instruments say "not own". */
+const NOT_OWN = { enumeration: false, hasOwnProperty: false, descriptor: false };
+
+describe('[#12578] the flat-input `ownKeys` reports the payload own-key set, and the instruments agree', () => {
+  it('REPRODUCTION — a key defined non-enumerable is own to all three instruments, and to the persisted row', async () => {
+    // The card's repro, verbatim. Pre-fix the `enumeration` member of this
+    // triple was `false` while the other two were `true`.
+    const raw: any = { data: { subject: 'help' }, options: {} };
+    let seen: ReturnType<typeof ownness> | undefined;
+    let names: string[] | undefined;
+    await runHook(raw, (input) => {
+      Object.defineProperty(input, 'k', { value: 1, enumerable: false, configurable: true });
+      seen = ownness(input, 'k');
+      names = Object.getOwnPropertyNames(input);
+    });
+
+    expect(seen).toEqual(OWN);
+    // The conjunction that makes it a contract and not three coincidences: the
+    // proxy's own-key set IS the persisted payload's own-key set. Asserting
+    // either side alone passes on a proxy whose halves disagree.
+    expect(names).toEqual(Object.getOwnPropertyNames(raw.data));
+    expect(names).toEqual(['subject', 'k']);
+    // …and the payload really does carry it — the key is not an artefact of the
+    // proxy face, it is on the row the driver receives.
+    expect(ownness(raw.data, 'k')).toEqual(OWN);
+  });
+
+  it('the ENUMERABLE face is unchanged — Object.keys, spread, entries and JSON still omit it', async () => {
+    // The other half of the repair, and the reason reporting the full own-key
+    // set costs nothing downstream: every consumer that wants enumerability
+    // filters for it ITSELF, through the descriptor trap, which mirrors `data`.
+    // `unwrapProxyToPlain` (`packages/runtime/src/sandbox/body-runner.ts`) is
+    // the consumer this protects — it snapshots the hook body's `ctx.input` as
+    // `Object.entries` over this proxy, so the marshalled set is exactly what
+    // it was before this card.
+    const raw: any = { data: { subject: 'help' }, options: {} };
+    const seen: Record<string, unknown> = {};
+    await runHook(raw, (input) => {
+      Object.defineProperty(input, 'hidden', { value: 1, enumerable: false, configurable: true });
+      seen.objectKeys = Object.keys(input);
+      seen.spread = Object.keys({ ...input });
+      seen.entries = Object.entries(input).map(([k]) => k);
+      seen.json = JSON.parse(JSON.stringify(input));
+      // The full set, alongside, in the same breath: this is the ONE surface
+      // pair whose answers legitimately differ, and they differ by exactly the
+      // non-enumerable key.
+      seen.ownNames = Object.getOwnPropertyNames(input);
+    });
+
+    expect(seen.objectKeys).toEqual(['subject']);
+    expect(seen.spread).toEqual(['subject']);
+    expect(seen.entries).toEqual(['subject']);
+    expect(seen.json).toEqual({ subject: 'help' });
+    expect(seen.ownNames).toEqual(['subject', 'hidden']);
+  });
+
+  it('agrees the other way: a key the payload does not hold is own to none of them', async () => {
+    const raw: any = { data: { subject: 'help' }, options: {} };
+    let seen: ReturnType<typeof ownness> | undefined;
+    await runHook(raw, (input) => {
+      seen = ownness(input, 'absent');
+    });
+    expect(seen).toEqual(NOT_OWN);
+  });
+
+  it('agrees on an ordinarily assigned key — the positive control', async () => {
+    const raw: any = { data: {}, options: {} };
+    let seen: ReturnType<typeof ownness> | undefined;
+    await runHook(raw, (input) => {
+      input.subject = 'help';
+      seen = ownness(input, 'subject');
+    });
+    expect(seen).toEqual(OWN);
+    expect(Object.getOwnPropertyNames(raw.data)).toEqual(['subject']);
+  });
+
+  it('DECLARED EXCEPTION — wrapper keys stay out of enumeration while the other two report them', async () => {
+    // Not a residue of the defect: hiding `id`/`options`/`ast`/`data` from
+    // `Object.keys`/`for-in` is what this trap exists for. Pinned so the
+    // exception stays deliberate and visible.
+    const raw: any = { data: { subject: 'help' }, options: { multi: false }, id: 'WRAPPER-ID' };
+    const seen: Record<string, unknown> = {};
+    await runHook(raw, (input) => {
+      seen.options = ownness(input, 'options');
+      seen.id = ownness(input, 'id');
+      seen.ownNames = Object.getOwnPropertyNames(input);
+      // Still reachable by the spellings the contract names — hidden from
+      // enumeration is not hidden from the author.
+      seen.readId = input.id;
+      seen.readMulti = (input.options as any).multi;
+    });
+
+    expect(seen.options).toEqual({ enumeration: false, hasOwnProperty: true, descriptor: true });
+    expect(seen.id).toEqual({ enumeration: false, hasOwnProperty: true, descriptor: true });
+    expect(seen.ownNames).toEqual(['subject']);
+    expect(seen.readId).toBe('WRAPPER-ID');
+    expect(seen.readMulti).toBe(false);
+  });
+
+  it('OPEN QUESTION, pinned in its open state — a symbol key carries the same disagreement', async () => {
+    // Reported on #12578 rather than decided here: publishing symbol keys
+    // through `ownKeys` is `Reflect.ownKeys` in one line, but whether the
+    // record payload may CARRY a symbol key is a payload-contract question and
+    // a maintainer floor (#12397's boundary).
+    //
+    // What the measurement establishes, and what this case records: symbol keys
+    // already reach `data` through the `set` trap and already persist. So the
+    // open question is about what the enumeration face should PUBLISH, not
+    // about what a hook can already put on the row.
+    const raw: any = { data: { subject: 'help' }, options: {} };
+    const sym = Symbol.for('objectstack.test.12578');
+    const seen: Record<string, unknown> = {};
+    await runHook(raw, (input) => {
+      input[sym] = 'symvalue';
+      seen.ownness = ownness(input, sym);
+      seen.symbols = Object.getOwnPropertySymbols(input);
+    });
+
+    // Today: two instruments say own, enumeration says no — the defect's shape,
+    // deliberately left standing on this half.
+    expect(seen.ownness).toEqual({ enumeration: false, hasOwnProperty: true, descriptor: true });
+    expect(seen.symbols).toEqual([]);
+    // …while the payload the engine persists holds it.
+    expect(Object.getOwnPropertySymbols(raw.data)).toEqual([sym]);
+    expect((raw.data as any)[sym]).toBe('symvalue');
+  });
+});

--- a/packages/objectql/src/hook-wrappers.ts
+++ b/packages/objectql/src/hook-wrappers.ts
@@ -595,16 +595,64 @@ function installFlatInput(ctx: HookContext): () => void {
       if (data && typeof data === 'object' && prop in data) return true;
       return prop in target;
     },
+    // [#12578] Reports the record payload's OWN key set — not its ENUMERABLE
+    // subset. The trap answered from `Object.keys(data)`, which filters by
+    // `enumerable`, and that filtering was incidental to what the trap is for:
+    // hiding the WRAPPER keys. The two are different exclusions, and reading
+    // one through the other cost a key.
+    //
+    // `[[OwnPropertyKeys]]` is the wrong place to apply an enumerability
+    // filter, because every consumer that wants one applies it itself, one
+    // layer up and through the descriptor trap: `Object.keys`, spread,
+    // `Object.entries`, `for…in` and `JSON.stringify` all walk this list and
+    // then drop what is not `enumerable`. Filtering here too does not make
+    // those answers cleaner — it only starves the surfaces that ask for the
+    // whole set, `Object.getOwnPropertyNames` and `Reflect.ownKeys`, which is
+    // exactly what those two are for.
+    //
+    // #12277 routed `defineProperty` into `data`, so a hook can now put a
+    // non-default-attribute key on the payload, and #12397 made the descriptor
+    // trap mirror `data` instead of synthesising defaults. Measured on the
+    // merged ref, for a key defined `{ enumerable: false }` on a payload the
+    // engine then persisted with that key on it:
+    //
+    //   Object.getOwnPropertyDescriptor(input, 'k')   -> own, enumerable:false
+    //   Object.prototype.hasOwnProperty.call(input,'k') -> true
+    //   Object.getOwnPropertyNames(input)             -> ['subject']  <- not own?
+    //
+    // Three instruments, one payload, two answers about own-ness — the same
+    // shape #12397 closed one trap over, and legal for a proxy (extensible
+    // target, no non-configurable own key) but untrue. The enumerable face is
+    // deliberately NOT changed by reporting the full set: `Object.keys`,
+    // spread, `Object.entries` and `JSON.stringify` still omit a
+    // non-enumerable key, because they filter through the descriptor trap,
+    // which mirrors `data`. That is what keeps the sandbox snapshot contract
+    // (`unwrapProxyToPlain`, `packages/runtime/src/sandbox/body-runner.ts` —
+    // `Object.entries` over this proxy) materialising exactly the fields it
+    // materialised before. Both halves are pinned in
+    // `hook-input-ownkeys-agreement.test.ts`.
+    //
+    // WRAPPER KEYS remain excluded, which is what this trap exists for:
+    // `id`/`options`/`ast`/`data` stay reachable by dot/bracket notation but
+    // out of `Object.keys`/`for-in`, so the payload-diff idiom
+    // `Object.keys(input).filter(k => input[k] !== previous[k])` sees record
+    // fields only. The exclusion is achieved by reading `data` and never the
+    // wrapper — NOT by subtracting those four names, which would hide a
+    // genuine payload field that happens to be called `id`.
+    //
+    // SYMBOL KEYS are deliberately still absent, and this is NOT a finding
+    // that they do not belong on a payload: `Reflect.ownKeys(data)` here would
+    // additionally publish them, and whether the record payload may carry a
+    // symbol key at all is a question about the PAYLOAD contract (they already
+    // reach `data` through the `set` trap and already persist — measured), not
+    // about this trap. It is open, reported on #12578, and the day it is
+    // answered "yes" this line becomes `Reflect.ownKeys`. Until then the
+    // symbol half of the disagreement is pinned AS open in the sibling test,
+    // so an answer changes a recorded fact rather than an unnoticed one.
     ownKeys(target) {
-      // Only enumerate the flat record fields. Wrapper keys
-      // (id/options/ast/data) remain accessible via dot/bracket notation
-      // but are hidden from Object.keys/for-in so user code that does
-      // `Object.keys(input).filter(k => input[k] !== previous[k])` only
-      // sees actual record fields.
-      const dataKeys = target.data && typeof target.data === 'object'
-        ? Object.keys(target.data)
+      return target.data && typeof target.data === 'object'
+        ? Object.getOwnPropertyNames(target.data)
         : [];
-      return Array.from(new Set(dataKeys));
     },
     // [#12397] MIRRORS `data`'s own descriptor; it does not synthesise one.
     // The literal that stood here — `{ configurable: true, enumerable: true,

--- a/packages/runtime/src/sandbox/body-runner.test.ts
+++ b/packages/runtime/src/sandbox/body-runner.test.ts
@@ -138,7 +138,16 @@ describe('hookBodyRunnerFactory', () => {
         (t as any)[k as string] = v;
         return true;
       },
-      ownKeys: (t) => Reflect.ownKeys(t),
+      // [#12578] CHANGED, from `Reflect.ownKeys(t)`. This double stood as the
+      // tree's second answer to "what does `installFlatInput`'s `ownKeys`
+      // report": the implementation said `Object.keys(data)` (enumerable only)
+      // while this modelled the full key set INCLUDING symbols, and neither
+      // was declared. That card settled it — the trap reports the payload's own
+      // STRING key set — and this line now models the settled spelling, so the
+      // double cannot drift from the trap it stands in for again. Symbols are
+      // the deliberate exclusion (an open payload-contract question, #12578),
+      // which is precisely what `Reflect.ownKeys` here used to assert away.
+      ownKeys: (t) => Object.getOwnPropertyNames(t),
       getOwnPropertyDescriptor: (t, k) => Reflect.getOwnPropertyDescriptor(t, k),
     });
     const factory = hookBodyRunnerFactory(runner, { ql: {}, appId: 'crm' });

--- a/packages/runtime/src/sandbox/body-runner.ts
+++ b/packages/runtime/src/sandbox/body-runner.ts
@@ -643,8 +643,15 @@ function buildSandboxContext(
 
   // [#11552] The per-row dispatch signal, and the D2 options visibility, both
   // of which the snapshot above DROPS by construction: `unwrapProxyToPlain`
-  // materialises only what `installFlatInput`'s `ownKeys` enumerates (the
-  // payload fields), and `dispatch` was never marshalled at all. ADR-0058
+  // materialises the own ENUMERABLE STRING subset of what `installFlatInput`'s
+  // `ownKeys` enumerates (the payload fields), and `dispatch` was never
+  // marshalled at all. Both words carry weight since #12578 widened that trap
+  // to the payload's whole own-key set: `options` is still dropped because it
+  // is a WRAPPER key and never enumerated at all, while a payload key held
+  // non-enumerable is now listed by `ownKeys` and still dropped here — by the
+  // `Object.entries` filter, through the descriptor trap. The marshalled set
+  // is byte-for-byte what it was before that card, which is what let the trap
+  // be repaired without touching this contract. ADR-0058
   // Addendum II D3 names three routes for row-specific work, and routes 1
   // (scoped throw) and 2 (`ctx.api` per row) both require the handler to KNOW
   // it is on the per-row path — a guard written `ctx.dispatch?.mode ===
@@ -770,6 +777,14 @@ function buildActionSandboxContext(
  * Convert a Proxy-wrapped record into a plain object so it round-trips through
  * JSON cleanly. `Object.fromEntries(Object.entries(p))` triggers the proxy's
  * ownKeys + get traps, materialising every visible field.
+ *
+ * "Visible" is `Object.entries`'s own definition and not `ownKeys`'s (#12578):
+ * it walks the own-key list and then keeps the STRING keys whose descriptor —
+ * the proxy's descriptor trap, mirroring the payload since #12397 — says
+ * `enumerable`. So a payload key a handler defined non-enumerable, and a key
+ * held under a symbol, are deliberately not marshalled into the VM even though
+ * the flat-input proxy now lists the former through `ownKeys`. A body sees the
+ * fields, exactly as it did before that card.
  */
 function unwrapProxyToPlain(v: unknown): Record<string, unknown> | undefined {
   if (v === undefined || v === null) return undefined;

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -397,6 +397,18 @@ export const HookContextSchema = lazySchema(() => z.object({
    *   `for…in` list the record fields and hide the wrapper keys (the proxy's
    *   `ownKeys` trap), so a diff written as
    *   `Object.keys(input).filter(k => input[k] !== previous[k])` sees fields.
+   *   What that trap reports is the payload's OWN key set, not its ENUMERABLE
+   *   subset (#12578): `Object.getOwnPropertyNames(input)` and
+   *   `Reflect.ownKeys(input)` answer for a key the payload holds
+   *   non-enumerable — which a handler can create, since #12277 routes
+   *   `Object.defineProperty` into the payload — and they answer the same way
+   *   `hasOwnProperty` and `Object.getOwnPropertyDescriptor` (#12397's mirror)
+   *   do. The three own-ness instruments agreeing IS the contract; the
+   *   `Object.keys`/spread/`for…in` face above is unchanged by it, because
+   *   those filter by `enumerable` themselves. Symbol keys reach the payload
+   *   and persist but are NOT enumerated — the one remaining split, left open
+   *   deliberately on #12578 because publishing them is a question about what
+   *   a record payload may hold, not about the trap.
    * - declarative `body` (L2 sandboxed JS): `ctx.input` IS the flat record —
    *   a plain snapshot the runner takes as `unwrapProxyToPlain(engineCtx.input)`
    *   (`packages/runtime/src/sandbox/body-runner.ts`), i.e. `Object.entries`


### PR DESCRIPTION
Fixes #12578

Verified at `2bdb36a433` — every reading below (gate union, suites, lint, ablation) was taken on that tree, which is this branch's head.

## The defect, reproduced before repairing

`installFlatInput`'s `ownKeys` trap answered from `Object.keys(data)` — own **enumerable string** keys. That `enumerable` filtering was incidental to what the trap is for (hiding the wrapper keys `id`/`options`/`ast`/`data`), and it cost a key. Measured on the merged ref through the real proxy, with the row the engine keeps alongside:

```
// beforeInsert, caller payload { subject: 'help' }
Object.defineProperty(ctx.input, 'k', { value: 1, enumerable: false, configurable: true });

Object.getOwnPropertyDescriptor(input, 'k')       -> { value: 1, enumerable: false, … }   own
Object.prototype.hasOwnProperty.call(input, 'k')  -> true                                 own
Object.getOwnPropertyNames(input)                 -> ['subject']                          not own?
Reflect.ownKeys(input)                            -> ['subject']                          not own?
Object.getOwnPropertyNames(raw.data)              -> ['subject', 'k']                     the persisted row
```

Three instruments, one payload, two answers about own-ness — and the key the enumeration face denies is on the row the driver receives. Newly reachable rather than newly written: #12277 routed `defineProperty` into `data`, so a handler can put a non-default-attribute key on the payload for the first time, and #12397 made the descriptor trap mirror `data` instead of synthesising defaults, which is what gave the third instrument an opinion to disagree with.

## The fork, and which way it went

Triage named two options and assigned the pick to this lane.

**Taken — option 1, mirror the payload's own-key set**, spelled `Object.getOwnPropertyNames(data)`. `[[OwnPropertyKeys]]` is the wrong layer at which to apply an enumerability filter, because every consumer that wants one applies it itself, one layer up and through the descriptor trap. Filtering here as well made none of those answers cleaner — it only starved the two surfaces whose entire job is to report the whole set.

**Rejected — option 2, declare `ownKeys` the enumerable face and make the other instruments agree with it.** Making `hasOwnProperty` and the descriptor trap agree with an enumerable-only enumeration means reporting a key as *not own* — which reverts #12397's mirror for exactly the case it was built for, and buys a worse lie than the one it removes: the key would then be invisible to all three instruments and still persist. That is the #12277 silent-success shape, which `body-runner.ts` names as the one with no instrument to catch it.

### Measured cost of option 1: exactly two lines move

The same probe, before and after, byte-compared:

```
3c3                              A: a non-enumerable own string key
<     "enumerationSurface": false,
---
>     "enumerationSurface": true,
37c37,38                         Object.getOwnPropertyNames(input)
<     "subject"
---
>     "subject",
>     "k"
```

Everything else is identical, and deliberately so: `Object.keys`, spread, `Object.entries` and `JSON.stringify` still return `['subject']` / `{subject:'help'}`, because each applies the `enumerable` filter itself through the descriptor trap. Wrapper keys stay hidden, symbols stay unenumerated.

**That is the answer to the sandbox contract** this card had to satisfy. `unwrapProxyToPlain` (`packages/runtime/src/sandbox/body-runner.ts`) documents itself as materialising "only what `installFlatInput`'s `ownKeys` enumerates", via `Object.entries`. Because `Object.entries` keeps own **enumerable string** keys, the marshalled set is unchanged — confirmed by running the sandbox suite against a **rebuilt** objectql (see Verification). The comment is tightened to say `enumerable string subset`, since after this card `ownKeys` is a strict superset of what that snapshot materialises and the loose wording would have read as equality.

## ⭐ The contract spelling is now settled and declared

The tree held two answers and declared neither: the implementation said `Object.keys(data)`, and the sandbox test double at `body-runner.test.ts:141` modelled `Reflect.ownKeys`. Closing that is this card's deliverable, so all three now say the same thing:

- **declared** in `packages/spec/src/data/hook.zod.ts`, the hook-context contract an app author reads — `ownKeys` reports the payload's own key set, not its enumerable subset; the three own-ness instruments agreeing *is* the contract;
- **implemented** in `hook-wrappers.ts`;
- **modelled** by the sandbox double, which now spells the settled trap.

### Changed existing assertion — declared

`packages/runtime/src/sandbox/body-runner.test.ts:141`, `ownKeys: (t) => Reflect.ownKeys(t)` → `Object.getOwnPropertyNames(t)`, with the reason stated on the line in the test file itself. This double was the tree's second answer; left as it was, this PR would have moved the inconsistency rather than removed it. No assertion in that test changes — its subject is write-back, and it still passes. No other existing assertion is touched.

## What is NOT decided here — the maintainer floor

**Symbol keys stay unenumerated, and this is reported rather than decided.** Option 1's full spelling (`Reflect.ownKeys(data)`) would additionally publish them. The measurement sharpens what that would mean, and it is not what the card assumed:

```
input[sym] = 'symvalue';
Object.getOwnPropertyDescriptor(input, sym)   -> own, enumerable: true
hasOwnProperty(input, sym)                    -> true
Object.getOwnPropertySymbols(input)           -> []              <- same disagreement
Object.getOwnPropertySymbols(raw.data)        -> [Symbol(…)]     <- and it persists
```

Symbol keys **already** reach the payload and **already** persist. So publishing them is not about making them reachable — it is about what the enumeration face should say concerning what the payload is allowed to hold, which is a payload-contract question and the boundary #12397 drew. It stays open on #12578, it is one word away (`Object.getOwnPropertyNames` → `Reflect.ownKeys`) once answered, and it is **pinned in its open state** so that answering it changes a recorded fact rather than an unnoticed one. Both the code comment and the test say so explicitly, so the omission cannot later read as a decision.

## The pin asserts the AGREEMENT, not one trap

`packages/objectql/src/hook-input-ownkeys-agreement.test.ts` (6 cases) reads all three instruments on one key through one object and compares the triple against itself, plus against the persisted row. Pinning a single trap's output in isolation is what let these halves diverge — on the same trap set, in the same file, in the same week as #12397. The two deliberate exceptions are pinned **as exceptions** so neither can be mistaken for residue of the defect: wrapper keys (hidden from enumeration by design) and the open symbol half.

## Clause ②, judged against the diff

**This is an observable behaviour change on a shipped surface, and it WIDENS what enumeration exposes** — `git diff --stat` behind the claim:

```
 .changeset/flat-input-ownkeys-own-key-set.md       |  48 +++++
 .../src/hook-input-ownkeys-agreement.test.ts       | 225 +++++++++++++++++++++
 packages/objectql/src/hook-wrappers.ts             |  64 +++++-
 packages/runtime/src/sandbox/body-runner.test.ts   |  11 +-
 packages/runtime/src/sandbox/body-runner.ts        |  19 +-
 packages/spec/src/data/hook.zod.ts                 |  12 ++
 6 files changed, 368 insertions(+), 11 deletions(-)
```

Of the 64 lines in `hook-wrappers.ts`, the executable change is the trap body alone; the rest is the comment stating the contract and its two exceptions. The widening is stated precisely rather than bare: previously-invisible keys become visible **to `Object.getOwnPropertyNames` and `Reflect.ownKeys` only**, it is bounded to keys the payload genuinely owns and the engine already persists, and it is measured as exactly the two lines shown above — no accept set is narrowed, no rejection path is added or removed, and the enumerable face that every documented idiom uses is byte-identical. No public type or spec shape changes; the spec edit is the contract declaration in prose.

## Verification

Gate union derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the real changeset (6 paths, three-dot vs merge base `f93df4dbe3`) — 31 path-matched families plus the convention-triggered set for adding test files. **Per-command exits captured before any pipe**; each verdict below is the gate's own line, not a `$?`.

| Check | Verdict |
| --- | --- |
| `@objectstack/objectql` full suite | `Test Files 239 passed (239)` · `Tests 4203 passed (4203)` |
| `@objectstack/runtime` `src/sandbox/` (after rebuild) | `Test Files 15 passed (15)` · `Tests 168 passed (168)` |
| `typecheck` objectql / runtime / spec | all `Done`; spec also `check:test-typecheck: OK` |
| `pnpm lint` (whole repo, `eslint . --no-inline-config`) | clean, 63s |
| `check:nul-bytes` | `OK (scanned 6951 text file(s) … no raw ASCII control bytes)` |
| `check:authorable-surface` | `✅ Successfully generated 1596 schemas.` — no artifact drift (`git status` clean after) |
| `check:liveness` / `check:empty-state` / `check:strictness-ledger` / `check:variant-docs` | all `✓` |
| `check:engine-double-contract` | `OK — 689 pinned, 134 in the DEBT ledger, 3 exempt` |
| `check:objectql-double-limit` | `ObjectQL double limit conformance holds: 280 double(s) graded` |
| `check:cross-package-test-inputs` | `OK: 20 package(s) read outside themselves, all declared` |
| `check:test-source-alias` | `OK — 72 packages with tests scanned` |
| `check:type-check-debt` (`--re-measure`) | `OK — 31 ledger entr(ies) re-measured in 236.1s, 1687 raw tsc error(s), none above its recorded number` |
| `check:type-check-coverage`, `check:where-matcher`, `check:query-options-erasure`, `check:durability-log-level`, `check:page-declaration-shape`, `check:slot-lookup`, `check:published-files`, `check:merge-driver`, `check:doc-authoring`, `check:spec-parsed-alias`, `check:type-source-resolution`, `check:objectui-changeset`, `check:changeset-gate-self-tests` | exit 0 |
| `check-changeset-no-major`, `check-empty-changeset`, `check-adr-0087-registration`, `check-comment-mask-adoption`, `check-ci-filter-parity`, `check-engine-split-ratio`, `check-plugin-teardown-shape`, `release-rehearsal-clone --self-test`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment` | exit 0 |
| `check-dev-prereqs` | exit 1 on an unbuilt worktree, `✓ 67 package build artifacts present` after the full build — it measured the worktree, never the diff |

### Ablation

Direction **and exact count predicted in writing first**, then the mutation proved on disk with anchored `grep -cF` counts **before any result was read**, all under `trap … EXIT INT TERM`.

Mutation: the repaired trap line only, `Object.getOwnPropertyNames(target.data)` → `Object.keys(target.data)`. Anchors after mutation: injected `1`, removed `0` (`MUTATION-CONFIRMED-ON-DISK`; a zero-hit edit would have voided the run rather than passing silently).

Predicted: red, **2 failed / 32 passed of 34** across the four hook-input suites, both failures in the new file, and the enumerable-face assertions staying green under the mutation. Observed, exactly that:

```
 FAIL  src/hook-input-ownkeys-agreement.test.ts > REPRODUCTION — a key defined non-enumerable is own to all three instruments…
   - "enumeration": true      + "enumeration": false
 FAIL  src/hook-input-ownkeys-agreement.test.ts > the ENUMERABLE face is unchanged — Object.keys, spread, entries and JSON still omit it
   expected [ 'subject' ] to deeply equal [ 'subject', 'hidden' ]      (line 152 — ownNames)
 Test Files  1 failed | 3 passed (4)
      Tests  2 failed | 32 passed (34)
```

The second failure landing on line 152 is the load-bearing detail: lines 148–151 (`Object.keys`, spread, `entries`, JSON) passed under the mutation, which is what proves that half of the contract genuinely untouched by either spelling.

**No rebuild owed on this leg, justified by import form rather than assertion**: the pin imports `./hook-wrappers.js`, a relative specifier inside the same package that vitest resolves to the TypeScript source — no package `exports`, no `dist` on the path. Corroborated empirically, since the before/after measurements differed with no build between them. `@objectstack/runtime`'s sandbox tests *do* reach objectql through `exports` → `dist`, so that suite was run only after `pnpm --filter '@objectstack/runtime^...' build`, with reach proved in the artifact itself: `packages/objectql/dist/index.js:3721` carries `Object.getOwnPropertyNames(target.data)` and the pre-fix spelling is absent (`grep -cF` = 0).

Restore verified byte-for-byte (`cmp` → identical to the pre-ablation copy, anchors back to `1`/`0`). Noted for the record: the restore was checked by byte comparison rather than by an empty `git diff`, because the ablation ran before the repair was committed — `cmp` is the stronger check of the two, but it is not the one the standard clause names.

## Changeset

`patch` on `@objectstack/objectql`, the only package whose runtime behaviour changes. `@objectstack/runtime` and `@objectstack/spec` carry comment-only edits plus the test double, so they publish no behaviour change and are deliberately not listed. `patch` rather than `minor` is defended in the changeset body: no declared surface shape changes, the enumerable face every documented idiom uses is byte-identical, and the only newly-listed keys are ones the payload genuinely owns and the engine already persists.

## Out of scope, filed not fixed

The measurement turned up a **distinct** defect in the same trap set, filed unassigned as #12601: a payload field literally named `id` reads back the *wrapper's* value through the `get` trap (`'WRAPPER-ID'`) while the descriptor trap reports the *payload's* (`'PAYLOAD-ID'`), because the two traps order the wrapper and the payload differently. It is not repaired here — which side should win depends on whether a payload may declare a field named `id` at all, which is the same maintainer floor. Deliberately untouched by this PR in either direction; the measurement is identical before and after this change. That card is not addressed by this branch.

_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6HFzyH98W1YaQXhJUJt6o)_