### PR TITLE
docs(spec): wrong-layer guidance for group/hideFields/rowColor on object userActions

### DIFF
--- a/.changeset/object-useractions-view-key-guidance.md
+++ b/.changeset/object-useractions-view-key-guidance.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): wrong-layer guidance for `group` / `hideFields` / `rowColor` on the object `userActions` block (#11459)
+
+`data/object.zod.ts`'s object-level `userActions` block already curated
+`sort` / `search` / `filter` / `editInline` with a pointer at the VIEW
+`userActions` block they actually belong to. `group` / `hideFields` /
+`rowColor` — adopted onto the view's vocabulary at #11195 — shared the same
+wrong-layer trap but got only the generic unknown-key rejection with an
+edit-distance suggestion, which has nothing useful to offer over the object
+block's `create`/`import`/`edit`/`delete`/`exportCsv` shape.
+
+**Nothing changes about what parses.** All three keys were rejected on the
+object block before this change and are rejected after it; only the message
+gains the same curated pointer the other four wrong-layer keys already carry.

--- a/packages/spec/src/data/object-strictness-batch20.test.ts
+++ b/packages/spec/src/data/object-strictness-batch20.test.ts
@@ -436,6 +436,18 @@ describe('#4001 批 20 — curation is anchored to the sibling contract that mak
       }
     });
 
+    it('`userActions.group` / `.hideFields` / `.rowColor` name the VIEW block, same as `sort` (#11459)', () => {
+      // The three keys adopted onto the view's vocabulary at #11195 got only
+      // the generic unknown-key rejection on the object block — no curated
+      // pointer — until this card added one, mirroring `sort`/`search`/
+      // `filter`/`editInline` above.
+      for (const k of ['group', 'hideFields', 'rowColor']) {
+        const msg = rejectOnObject({ userActions: { [k]: true } });
+        expect(msg).toContain('VIEW');
+        expect(msg).toContain(k);
+      }
+    });
+
     it('`userActions.clone` points at the `enable` capability block, which really does declare it', () => {
       const msg = rejectOnObject({ userActions: { clone: false } });
       expect(msg).toContain('enable');

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1736,7 +1736,9 @@ const ObjectSchemaBase = strictObject(
       // disjoint vocabulary (sort/search/filter/refresh/rowHeight/group/
       // addRecordForm/editInline/hideFields/rowColor/buttons — the last three
       // adopted at #11195), so an author who learned that block writes these
-      // here and gets a shape that has never heard of them.
+      // here. `group`/`hideFields`/`rowColor` were refused by name but without
+      // a curated pointer until #11459 gave them one too, mirroring the other
+      // four.
       sort:
         '`sort` is a VIEW `userActions` key, not an object one — the two blocks share a ' +
         'name and nothing else. The object block governs CRUD affordances ' +
@@ -1752,6 +1754,15 @@ const ObjectSchemaBase = strictObject(
         '`editInline` is a VIEW `userActions` key. The object-level `edit` flag decides ' +
         'whether editing is offered AT ALL; how it is offered (inline vs form) is the ' +
         "view's call.",
+      group:
+        '`group` is a VIEW `userActions` key. This object block governs CRUD affordances ' +
+        'only — put toolbar controls on the view that renders the records.',
+      hideFields:
+        '`hideFields` is a VIEW `userActions` key. This object block governs CRUD ' +
+        'affordances only — put toolbar controls on the view that renders the records.',
+      rowColor:
+        '`rowColor` is a VIEW `userActions` key. This object block governs CRUD ' +
+        'affordances only — put toolbar controls on the view that renders the records.',
       clone:
         '`clone` is a CAPABILITY, not a user action — write `enable: { clone: false }`. ' +
         'The `enable` block (ObjectCapabilities) is where record deep-cloning is governed.',


### PR DESCRIPTION
Fixes #11459

## What

Adds three curated `guidance` entries to the object-level `userActions` `strictObject` in `packages/spec/src/data/object.zod.ts` — `group`, `hideFields`, `rowColor` — mirroring the existing `sort`/`search`/`filter`/`editInline` wrong-layer wording convention.

## Why

`ui/view.zod.ts`'s `UserActionsConfigSchema` adopted `group`/`hideFields`/`rowColor` at #11195 (merged via #11458). Those three keys share a name-collision trap with the object block's own `userActions` (disjoint vocabulary, same key names elsewhere): an author who learned them on the view writes them on the object and, until this PR, got only the generic unknown-key rejection with an edit-distance suggestion — which has nothing useful to offer over the object block's `create`/`import`/`edit`/`delete`/`exportCsv` shape.

**Acceptance is byte-identical.** All three keys were already rejected by name on the object block before this change (measured on `origin/main` pre-PR) and are rejected after it; only the refusal's message gains the same curated pointer the other four wrong-layer keys already carry. Clause-② does not apply — the accept/reject set does not move.

## Changes

- `packages/spec/src/data/object.zod.ts` — three `guidance` entries (`group`, `hideFields`, `rowColor`), placed after `editInline`; updated the block's leading comment to note the three keys now carry curated pointers too.
- `packages/spec/src/data/object-strictness-batch20.test.ts` — new test `userActions.group / .hideFields / .rowColor name the VIEW block, same as sort (#11459)`, asserting the "VIEW" pointer for all three, mirroring the existing `sort` pin. The pre-existing disjoint-vocabulary test (which already asserted these three are rejected by name) is untouched.
- `.changeset/object-useractions-view-key-guidance.md` — patch changeset, following the precedent set by the prior pure-guidance-text change (`visible-when-alias-guidance.md`, #7884): guidance/describe-text changes on `@objectstack/spec` get a real changeset, not `skip-changeset`.

## Verification

Local commands run under `scripts/pm/os-verify-lock.sh`, on merge commit `a413af29c` (merge base `23d52f99c` of `origin/main`):

- `pnpm --filter @objectstack/spec build` — clean, 34/34 declared `.d.ts` present.
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/data/object-strictness-batch20.test.ts src/shared/alias-integrity.test.ts src/data/object.test.ts` — **253 passed (253)**, including the #5013 alias-integrity audit (`no guidance key is itself a declared key` — the three new entries are keys the object shape rejects, so they pass automatically) and the new pin.
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2` (full package) — **432 test files / 11499 tests passed**.
- `pnpm --filter @objectstack/spec check:generated` — all 14 generated artifacts up to date, no regeneration needed (guidance prose is not a `.describe()`/authorable key).
- `pnpm --filter @objectstack/spec run typecheck` — clean (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`).
- Full `pnpm build` (needed as a prerequisite for `check:dev-prereqs` / `check:type-check-debt`) — 71/71 tasks successful.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derivation, and every gate it named for this diff — all green: `check:authorable-surface`, `check:cross-package-test-inputs` (both the pnpm script and the raw script invocation), `check:doc-authoring`, `check:doc-formula-expressions`, `check:empty-state`, `check:liveness`, `check:merge-driver`, `check:objectql-double-limit`, `check:page-declaration-shape`, `check:published-files`, `check:slot-lookup`, `check:spec-parsed-alias`, `check:strictness-ledger`, `check:test-source-alias`, `check:type-source-resolution`, `check:variant-docs`, `check:ci-filter-parity`, `check:comment-mask-adoption`, `check:dev-prereqs`, `check:plugin-teardown-shape`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment`.
- Convention-triggered gates for the edited test file: `check:type-check-coverage` (OK), `check:type-check-debt --re-measure` (31 ledger entries re-measured, **none above their recorded ceiling**), `check:query-options-erasure`, `check:engine-double-contract` (689 pinned / 134 debt / 3 exempt, unchanged), `check:where-matcher` (303/303) — all green.
- Changeset-triggered family: `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-empty-changeset.mjs`, `release-rehearsal-clone.mjs --self-test` — all green.
- Scoped `eslint --no-inline-config` over the two touched source files (`object.zod.ts`, `object-strictness-batch20.test.ts`): 0 errors / 0 warnings, 2 files (per `--format json`). Collapse to this scope is a measured, not assumed, safe narrowing: `eslint --print-config` on the touched file confirms no `parserOptions.project` is set for this tree (no type-aware linting), so the diff cannot move any judgment on an untouched file.
- Self-scanned both touched source files and the changeset for control-byte contamination (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) — clean.

Per this batch's constraints, `packages/spec/src/api/**` and `packages/rest` (sibling PR #12605's surface) are untouched, and `content/docs/releases/**` is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_012xGvxcwPRTJfA7RfjXEYA4)_