### PR TITLE
fix(spec): the bundled JSON Schema's x-schema-count counts the definitions it carries (#12588)

### DIFF
--- a/.changeset/schema-count-counts-the-definitions-shipped.md
+++ b/.changeset/schema-count-counts-the-definitions-shipped.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the bundled JSON Schema's `x-schema-count` counts the definitions it carries (#12588)
+
+`json-schema/objectstack.json` ships in the tarball (`json-schema` is in the
+package's `files`), and `content/docs/deployment/troubleshooting.mdx` publishes
+what the field means: "its `x-schema-count` field reports the total number of
+definitions". It did not. The generator took the number from `count` — a
+counter incremented once per emitted schema — while the bundle's `$defs` is
+assembled from a map keyed by `<category>/<Name>`. Every def key written more
+than once therefore widened a gap nothing reconciled: the published bundle
+declared **1596** definitions while carrying **1585**.
+
+`$defs` is now assembled before the envelope and the field is taken from its
+size, so the artifact describes itself. The per-schema files on disk already
+agreed with `$defs` (1585) — the same key collapses the file writes — so this
+brings the one disagreeing number into line with both of the others, and the
+docs sentence is true as written without changing it.
+
+**The collapsed emits are now named rather than implied.** The 11 def keys
+written twice are all **benign self-aliases** — `export const X = XSchema`
+spelled as `Object.assign(XSchema, …)`, one schema object reached by two export
+names, so the second write cannot change what is published. Eight in `api`
+(`ApiEndpoint`, `RestApiConfig`, `RestServerConfig`, `ApiDocumentationConfig`,
+`ApiTestCollection`, `OpenApiSpec`, `RestApiPluginConfig`,
+`RestApiRouteRegistration`) and three in `system` (`MiddlewareConfig`,
+`QueueConfig`, `Task`). No schema is being silently dropped: the existing
+`findDefKeyCollisions` guard exits the build on any def key claimed by two
+*different* schemas, so a build that produces a bundle at all has only exempt
+ones — and `gen:schema` now prints that population instead of leaving it
+visible only as a subtraction between two summary lines.
+
+No schema content changes; only the bundle's self-description and the
+generator's console output.

--- a/packages/spec/scripts/build-schemas-check-mode.test.ts
+++ b/packages/spec/scripts/build-schemas-check-mode.test.ts
@@ -2186,6 +2186,118 @@ describe('build-schemas.ts — the output clean spares a sibling generator (#537
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// #12588 — the bundle's `x-schema-count` counts what the bundle carries.
+//
+// `objectstack.json` ships in the npm tarball and a docs page publishes the
+// field's meaning ("its `x-schema-count` field reports the total number of
+// definitions"), so the number is a contract, not a build log. It used to be
+// taken from `count` — incremented once per EMIT — while `$defs` is assembled
+// from a map keyed by `<category>/<Name>`. Every def key written twice therefore
+// widened a gap nothing reconciled: the published bundle declared 1596
+// definitions and shipped 1585.
+//
+// The unit half (scripts/def-key-collisions.test.ts) pins the arithmetic. What
+// only this sandbox can assert is that the artifact the generator really writes
+// describes itself correctly — the assertions below read the emitted bytes, not
+// a helper's return value. `src/` is symlinked into the sandbox, so this runs
+// over the REAL spec surface (~1600 schemas), which is also what makes the
+// non-vacuity guard below meaningful: this build genuinely collapses emits.
+//
+// The invariant is pinned, never today's absolute number — 1585 moves with
+// every schema anyone adds, and a test that has to be edited by unrelated PRs
+// gets edited without being read.
+describe('build-schemas.ts — the bundle counts the definitions it carries (#12588)', () => {
+  const OUT = () => path.join(sandbox, 'json-schema');
+
+  beforeEach(() => {
+    // A current, self-consistent tree, so the run exits 0 and these assertions
+    // are about the bundle rather than about some ratchet upstream of it.
+    seedManifest((s) => s);
+    const tip = seedBase((s) => s);
+    seedSurface((s) => s);
+    seedSurfaceBase(tip, (k) => k);
+  });
+
+  it(
+    'writes x-schema-count equal to its own $defs size, and to the files on disk',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      const { status, output } = run([]);
+      expect(status).toBe(0);
+
+      const bundle = JSON.parse(
+        fs.readFileSync(path.join(OUT(), 'objectstack.json'), 'utf8'),
+      ) as { 'x-schema-count': number; $defs: Record<string, unknown> };
+      const defCount = Object.keys(bundle.$defs).length;
+
+      // 1. The artifact describes itself.
+      expect(bundle['x-schema-count']).toBe(defCount);
+
+      // 2. A second, independent instrument: one file per def key on disk. The
+      //    per-schema writes collapse the same way the map does, so the tree is
+      //    a witness the bundle cannot fabricate. `openapi.json` belongs to
+      //    gen:openapi and objectstack.json is the bundle itself.
+      const onDisk = fs
+        .readdirSync(OUT(), { recursive: true, encoding: 'utf8' })
+        .filter(
+          (entry) =>
+            entry.endsWith('.json') &&
+            path.basename(entry) !== 'objectstack.json' &&
+            path.basename(entry) !== 'openapi.json',
+        );
+      expect(onDisk).toHaveLength(defCount);
+
+      // 3. The generator's own console agrees, so a reader of the build log and
+      //    a reader of the artifact reach the same number.
+      expect(output).toContain(`objectstack.json (${defCount} definitions)`);
+    },
+  );
+
+  it(
+    'accounts for every emit the definition count does not include',
+    { timeout: SPAWN_TIMEOUT_MS },
+    () => {
+      const { status, output } = run([]);
+      expect(status).toBe(0);
+
+      const bundle = JSON.parse(
+        fs.readFileSync(path.join(OUT(), 'objectstack.json'), 'utf8'),
+      ) as { 'x-schema-count': number };
+      const emitted = Number(/Successfully generated (\d+) schemas/.exec(output)?.[1]);
+      expect(Number.isFinite(emitted), 'summary line must report the emit total').toBe(true);
+
+      // Non-vacuity: this build must still collapse emits, or the case proves
+      // nothing about the defect. If a future PR removes the last self-alias
+      // from the spec, `x-schema-count: count` and the correct expression stop
+      // differing and this pin can no longer fail — delete it deliberately
+      // then, rather than discovering later that it had gone quiet.
+      expect(
+        emitted,
+        'no emit collapses any more — this build no longer models #12588',
+      ).toBeGreaterThan(bundle['x-schema-count']);
+
+      // The delta is reported, not left as a subtraction between two lines —
+      // that silence is what let a wrong number ship unnoticed. The reported
+      // figure must reconcile the two totals exactly.
+      const collapsed = Number(/ℹ️\s+(\d+) emit\(s\) collapsed/.exec(output)?.[1]);
+      expect(Number.isFinite(collapsed), 'the collapsed-emit report line must be printed').toBe(true);
+      expect(emitted - collapsed).toBe(bundle['x-schema-count']);
+
+      // Every collapsed key is named, and named as a self-alias: the guard
+      // upstream exits on any def key written twice by DIFFERENT schemas, so a
+      // build that reaches here has only benign ones. Stating it in the report
+      // is what makes that population readable instead of implied.
+      expect(output).toContain('all self-aliases');
+      const named = [...output.matchAll(/ {5}json-schema\/(\S+)\.json {2}<- {2}/g)].map((m) => m[1]);
+      expect(named.length).toBeGreaterThan(0);
+      for (const defKey of named) {
+        expect(fs.existsSync(path.join(OUT(), `${defKey}.json`))).toBe(true);
+      }
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // #4659 — check (b) registers a tombstone by its EXACT key, not by its leaf.
 //
 // Until this change, "live → retired must be registered" was satisfied by

--- a/packages/spec/scripts/build-schemas.ts
+++ b/packages/spec/scripts/build-schemas.ts
@@ -11,7 +11,9 @@ import { spawnSync } from 'child_process';
 import { z } from 'zod';
 import { schemaNameFromExportKey } from './lib/schema-name';
 import {
+  collapsedEmitCount,
   findDefKeyCollisions,
+  findSelfAliasedDefKeys,
   formatDefKeyCollisions,
   type EmittedDef,
 } from './lib/def-key-collisions';
@@ -473,6 +475,28 @@ const defKeyCollisions = findDefKeyCollisions(emittedDefs);
 if (defKeyCollisions.length > 0) {
   console.error(`\n❌ ${formatDefKeyCollisions(defKeyCollisions)}`);
   process.exit(1);
+}
+
+// ─── Report: the writes the guard above exempted (#12588) ─────────────
+// Reaching here means every def key written twice is a self-alias, because the
+// guard exits on any that is not. Those writes still collapse — `count` is one
+// per EMIT while `generatedSchemas` is keyed by def key — so the emit total is
+// higher than the number of definitions this build publishes. That difference
+// used to be visible only as a subtraction between two summary lines, and it
+// leaked into the published bundle as an `x-schema-count` nobody could reconcile
+// with the `$defs` beside it. Name the population instead of implying it.
+// A report, not a gate: there is no threshold here and no exit path.
+const selfAliasedDefKeys = findSelfAliasedDefKeys(emittedDefs);
+const collapsedEmits = collapsedEmitCount(selfAliasedDefKeys);
+if (collapsedEmits > 0) {
+  console.log(
+    `\nℹ️  ${collapsedEmits} emit(s) collapsed into ${selfAliasedDefKeys.length} existing def key(s) ` +
+      `— all self-aliases (one schema object reached by two export names), so ${count} emits publish ` +
+      `${generatedSchemas.size} definitions:`,
+  );
+  for (const alias of selfAliasedDefKeys) {
+    console.log(`     json-schema/${alias.defKey}.json  <-  ${alias.exportKeys.join(', ')}`);
+  }
 }
 
 // ─── Ratchet: a published schema must never silently disappear ────────
@@ -2531,23 +2555,30 @@ if (defaultsChanged && !CHECK) {
 // ─── Generate Bundled Schema ─────────────────────────────────────────
 // Single-file bundled schema containing all generated schemas for IDE autocomplete
 
+// Assemble bundled $defs from the in-memory map populated during generation.
+// (Avoid re-reading the json-schema/ tree to dodge CI filesystem races.)
+//
+// Assembled BEFORE the envelope, so `x-schema-count` below is taken from what
+// this bundle actually carries (#12588). It used to be `count`, the per-EMIT
+// counter, while `$defs` is keyed by def key — so every self-aliased key
+// reported above widened the gap, and the published artifact declared 1596
+// definitions while shipping 1585. A self-describing artifact counts what it
+// contains; the emit total is a property of the build, not of the file, and is
+// still reported on the summary line at the end of this script.
+const defs: Record<string, unknown> = {};
+for (const [defKey, schema] of generatedSchemas) {
+  defs[defKey] = schema;
+}
+
 const bundledSchema: Record<string, unknown> = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   $id: `${SCHEMA_BASE_URL}/objectstack.json`,
   title: 'ObjectStack Protocol',
   description: `ObjectStack Protocol v${SPEC_VERSION} — Complete bundled JSON Schema for IDE autocomplete`,
   'x-spec-version': SPEC_VERSION,
-  'x-schema-count': count,
-  $defs: {} as Record<string, unknown>,
+  'x-schema-count': Object.keys(defs).length,
+  $defs: defs,
 };
-
-const defs = bundledSchema.$defs as Record<string, unknown>;
-
-// Assemble bundled $defs from the in-memory map populated during generation.
-// (Avoid re-reading the json-schema/ tree to dodge CI filesystem races.)
-for (const [defKey, schema] of generatedSchemas) {
-  defs[defKey] = schema;
-}
 
 const bundledPath = path.join(OUT_DIR, 'objectstack.json');
 writeFileWithRetry(bundledPath, JSON.stringify(bundledSchema, null, 2));

--- a/packages/spec/scripts/def-key-collisions.test.ts
+++ b/packages/spec/scripts/def-key-collisions.test.ts
@@ -30,7 +30,9 @@ import path from 'node:path';
 import { SCHEMA_MANIFEST_DIR_NAME } from './lib/sharded-artifacts';
 
 import {
+  collapsedEmitCount,
   findDefKeyCollisions,
+  findSelfAliasedDefKeys,
   formatDefKeyCollisions,
   type EmittedDef,
 } from './lib/def-key-collisions';
@@ -107,6 +109,114 @@ describe('findDefKeyCollisions', () => {
       emitted('shared', 'HttpMethod', { a: 1 }),
       emitted('shared', 'HttpMethodSubsetSchema', { a: 2 }),
     ])).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #12588 — the exempt population, enumerated.
+// ─────────────────────────────────────────────────────────────────────────
+//
+// `findDefKeyCollisions` is silent about self-aliases because they are not a
+// problem. They are, however, the reason a build's emit count exceeds the
+// number of definitions it publishes — and that unexplained delta is what put a
+// wrong `x-schema-count` into the shipped bundle. These pin the other half.
+
+describe('findSelfAliasedDefKeys — the population the guard exempts (#12588)', () => {
+  it('reports a self-alias, which is exactly what findDefKeyCollisions stays silent about', () => {
+    const task = { type: 'object' };
+    const entries = [emitted('system', 'Task', task), emitted('system', 'TaskSchema', task)];
+
+    expect(findSelfAliasedDefKeys(entries)).toEqual([
+      { defKey: 'system/Task', exportKeys: ['Task', 'TaskSchema'] },
+    ]);
+    // The two verdicts are complementary, not overlapping.
+    expect(findDefKeyCollisions(entries)).toEqual([]);
+  });
+
+  it('is silent about a real collision — that one belongs to the guard, not to a report', () => {
+    const entries = [
+      emitted('shared', 'HttpMethod', { enum: ['GET', 'HEAD'] }),
+      emitted('shared', 'HttpMethodSchema', { enum: ['GET'] }),
+    ];
+
+    expect(findSelfAliasedDefKeys(entries)).toEqual([]);
+    expect(findDefKeyCollisions(entries)).toHaveLength(1);
+  });
+
+  it('ignores a def key written once — one write collapses nothing', () => {
+    expect(findSelfAliasedDefKeys([emitted('data', 'FieldSchema', {})])).toEqual([]);
+  });
+
+  it('partitions every multiply-written def key between the two functions', () => {
+    // The invariant that makes "emits - definitions" fully accounted for: a key
+    // written more than once is either exempt or a collision, never neither and
+    // never both. Asserted over a mixed build rather than stated in prose.
+    const alias = {};
+    const entries = [
+      emitted('ui', 'ThemeModeSchema', alias),
+      emitted('ui', 'ThemeMode', alias),
+      emitted('shared', 'HttpMethod', { a: 1 }),
+      emitted('shared', 'HttpMethodSchema', { a: 2 }),
+      emitted('data', 'FieldSchema', {}),
+    ];
+
+    const aliases = findSelfAliasedDefKeys(entries).map((a) => a.defKey);
+    const collisions = findDefKeyCollisions(entries).map((c) => c.defKey);
+
+    expect(aliases).toEqual(['ui/ThemeMode']);
+    expect(collisions).toEqual(['shared/HttpMethod']);
+    expect(aliases.filter((k) => collisions.includes(k))).toEqual([]);
+    // Every key with more than one write is claimed by exactly one of them.
+    const writtenTwice = ['ui/ThemeMode', 'shared/HttpMethod'];
+    expect([...aliases, ...collisions].sort()).toEqual([...writtenTwice].sort());
+  });
+
+  it('follows first-encounter order, so a build report is stable across runs', () => {
+    const a = {};
+    const b = {};
+    expect(
+      findSelfAliasedDefKeys([
+        emitted('system', 'QueueConfig', b),
+        emitted('api', 'ApiEndpoint', a),
+        emitted('api', 'ApiEndpointSchema', a),
+        emitted('system', 'QueueConfigSchema', b),
+      ]).map((x) => x.defKey),
+    ).toEqual(['system/QueueConfig', 'api/ApiEndpoint']);
+  });
+});
+
+describe('collapsedEmitCount — the emits a self-aliased key absorbs (#12588)', () => {
+  it('counts N-1 per key: the first write is the definition, the rest collapse onto it', () => {
+    expect(
+      collapsedEmitCount([
+        { defKey: 'api/ApiEndpoint', exportKeys: ['ApiEndpoint', 'ApiEndpointSchema'] },
+        { defKey: 'system/Task', exportKeys: ['Task', 'TaskSchema'] },
+      ]),
+    ).toBe(2);
+  });
+
+  it('counts a triple alias as two collapsed emits, not one', () => {
+    expect(
+      collapsedEmitCount([{ defKey: 'api/Thing', exportKeys: ['Thing', 'ThingSchema', 'ThingZod'] }]),
+    ).toBe(2);
+  });
+
+  it('is zero on a build where nothing collapsed', () => {
+    expect(collapsedEmitCount([])).toBe(0);
+  });
+
+  it('reconciles the two totals: emits - collapsed = definitions', () => {
+    // The arithmetic the published `x-schema-count` got wrong, in miniature.
+    const alias = {};
+    const entries = [
+      emitted('api', 'ApiEndpoint', alias),
+      emitted('api', 'ApiEndpointSchema', alias),
+      emitted('data', 'FieldSchema', {}),
+      emitted('data', 'ObjectSchema', {}),
+    ];
+    const definitions = new Set(entries.map((e) => `${e.category}/${e.schemaName}`)).size;
+
+    expect(entries.length - collapsedEmitCount(findSelfAliasedDefKeys(entries))).toBe(definitions);
   });
 });
 

--- a/packages/spec/scripts/lib/def-key-collisions.ts
+++ b/packages/spec/scripts/lib/def-key-collisions.ts
@@ -46,6 +46,22 @@
  * The remedy is always at the source, never here: rename the loser to a def
  * name of its own (#4684's `RateLimitConfig` precedent, ADR-0112 D9 — one name
  * means one thing), or delete the duplicate and re-export the survivor.
+ *
+ * ## The exempt population is enumerable, not implied (#12588)
+ *
+ * The exemption above is silent by design — a self-alias publishes one artifact,
+ * so there is nothing to report as a *problem*. But it is not nothing: those
+ * writes are the reason the generator's emit count exceeds the number of
+ * definitions it publishes, and for a long time that delta was the only
+ * externally visible trace of them. It surfaced as a published artifact
+ * describing itself wrongly: `objectstack.json` carried `x-schema-count` taken
+ * from the emit counter while its `$defs` held one entry per def key, so the
+ * bundle claimed 1596 definitions and shipped 1585.
+ *
+ * `findSelfAliasedDefKeys` is the other half of `findDefKeyCollisions`: same
+ * bucketing, same identity predicate, opposite verdict. Together they partition
+ * every multiply-written def key, so "how many emits collapsed, and into what"
+ * is answerable rather than inferred from a subtraction.
  */
 
 /** One export as `build-schemas.ts` met it, before anything is written. */
@@ -71,14 +87,21 @@ export interface DefKeyCollision {
   exportKeys: string[];
 }
 
+/** A def key written more than once, every write the SAME schema instance. */
+export interface SelfAliasedDefKey {
+  /** `<category>/<SchemaName>` — the one file all of these writes produce. */
+  defKey: string;
+  /** Every export key that resolves to it, in encounter order. */
+  exportKeys: string[];
+}
+
 /**
- * Def keys written more than once by DIFFERENT schema instances.
- *
- * Self-aliases (every entry for a key is the identical object) are not
- * collisions and are not reported. Result order follows first encounter, so a
- * build's report is stable across runs.
+ * Group entries by the def key they publish to, preserving encounter order both
+ * between buckets and inside them, so every report built from this is stable
+ * across runs. Shared by both verdicts below: they must never disagree about
+ * which entries belong to one key.
  */
-export function findDefKeyCollisions(entries: Iterable<EmittedDef>): DefKeyCollision[] {
+function bucketByDefKey(entries: Iterable<EmittedDef>): Map<string, EmittedDef[]> {
   const byDefKey = new Map<string, EmittedDef[]>();
   for (const entry of entries) {
     const defKey = `${entry.category}/${entry.schemaName}`;
@@ -86,15 +109,59 @@ export function findDefKeyCollisions(entries: Iterable<EmittedDef>): DefKeyColli
     if (bucket) bucket.push(entry);
     else byDefKey.set(defKey, [entry]);
   }
+  return byDefKey;
+}
 
+/** Every write in the bucket names the identical object — the exempt shape. */
+function isSelfAlias(bucket: readonly EmittedDef[]): boolean {
+  return bucket.every((e) => e.schema === bucket[0].schema);
+}
+
+/**
+ * Def keys written more than once by DIFFERENT schema instances.
+ *
+ * Self-aliases (every entry for a key is the identical object) are not
+ * collisions and are not reported — `findSelfAliasedDefKeys` returns exactly
+ * those. Result order follows first encounter, so a build's report is stable
+ * across runs.
+ */
+export function findDefKeyCollisions(entries: Iterable<EmittedDef>): DefKeyCollision[] {
   const collisions: DefKeyCollision[] = [];
-  for (const [defKey, bucket] of byDefKey) {
+  for (const [defKey, bucket] of bucketByDefKey(entries)) {
     if (bucket.length < 2) continue;
     // One object reached by two names publishes one artifact — no ambiguity.
-    if (bucket.every((e) => e.schema === bucket[0].schema)) continue;
+    if (isSelfAlias(bucket)) continue;
     collisions.push({ defKey, exportKeys: bucket.map((e) => e.exportKey) });
   }
   return collisions;
+}
+
+/**
+ * Def keys written more than once where every write is the SAME instance — the
+ * population `findDefKeyCollisions` exempts, and the reason a build's emit
+ * count exceeds the number of definitions it publishes (#12588).
+ *
+ * This is a report, never a verdict: each of these publishes one artifact and
+ * nothing about it depends on export order. Callers use it to *account for* the
+ * difference between emits and definitions, not to fail a build.
+ */
+export function findSelfAliasedDefKeys(entries: Iterable<EmittedDef>): SelfAliasedDefKey[] {
+  const aliases: SelfAliasedDefKey[] = [];
+  for (const [defKey, bucket] of bucketByDefKey(entries)) {
+    if (bucket.length < 2) continue;
+    if (!isSelfAlias(bucket)) continue;
+    aliases.push({ defKey, exportKeys: bucket.map((e) => e.exportKey) });
+  }
+  return aliases;
+}
+
+/**
+ * How many emits these self-aliased keys absorb — the count by which a build's
+ * emit total exceeds its published definition count. A key written N times
+ * contributes N-1: the first write is the definition, the rest collapse onto it.
+ */
+export function collapsedEmitCount(aliases: readonly SelfAliasedDefKey[]): number {
+  return aliases.reduce((total, alias) => total + alias.exportKeys.length - 1, 0);
 }
 
 /** The build-stopping message for `findDefKeyCollisions()`. */


### PR DESCRIPTION
Fixes #12588

`json-schema/objectstack.json` ships in the npm tarball (`json-schema` is in the package's `files`) and `content/docs/deployment/troubleshooting.mdx:438` publishes what its `x-schema-count` field means — "the total number of definitions". It did not report that. The generator took the number from `count`, a counter incremented once per emitted schema, while the bundle's `$defs` is assembled from a map keyed by `CATEGORY/NAME`. Every def key written more than once therefore widened a gap nothing reconciled.

**Re-measured on this branch's base** (`7c0d0c395`, which carries #11983's merge — the card's figures were taken at an older ref and are not inherited):

```
bundle x-schema-count: 1596
bundle $defs actual:   1585
delta:                 11
per-schema files on disk (excl. objectstack.json, openapi.json): 1585
```

The numbers are unchanged from the card. `$defs` is now assembled before the envelope and `x-schema-count` is taken from its size, so the artifact describes itself:

```
x-schema-count : 1585
$defs size     : 1585
files on disk  : 1585
```

The disk count already agreed with `$defs` — the same key collapses the per-schema file writes — so this brings the one disagreeing number into line with the two that already agreed. Emitted key order is unchanged (`$defs` stays last in the object literal).

## The overwritten-emit population — all 11 are benign self-aliases

Triage charter step 2, answered before any code was written. **No schema is being silently dropped.**

Two independent instruments agree.

**1. Structural proof.** `findDefKeyCollisions` runs before the bundle is assembled and `process.exit(1)`s on any def key claimed by two *different* schema instances. So a build that produces a bundle at all has only exempt keys by construction — the exemption is identity (`bucket.every((e) => e.schema === bucket[0].schema)`), not today's byte-equality.

**2. Enumeration.** A read-only walk of the same namespace exports, bucketed by def key with the guard's own predicate:

```
zod exports walked      : 1620
distinct def keys       : 1607
self-aliased def keys   : 13
DISTINCT collisions     : 0
```

Reconciling the walk with the real run: 24 exports are skipped as unrepresentable in JSON Schema. Four of those are both halves of `system/BatchTask` and `system/WorkerConfig`, so those two keys are never emitted at all; the other 20 each remove a key outright. `1620 - 24 = 1596` emits and `1607 - 22 = 1585` definitions — the arithmetic closes exactly, and `13 - 2 = 11` is the delta.

The 11, now printed by `gen:schema` itself:

```
11 emit(s) collapsed into 11 existing def key(s) — all self-aliases (one schema
object reached by two export names), so 1596 emits publish 1585 definitions:
     json-schema/api/ApiEndpoint.json  <-  ApiEndpoint, ApiEndpointSchema
     json-schema/api/RestApiConfig.json  <-  RestApiConfig, RestApiConfigSchema
     json-schema/api/RestServerConfig.json  <-  RestServerConfig, RestServerConfigSchema
     json-schema/api/ApiDocumentationConfig.json  <-  ApiDocumentationConfig, ApiDocumentationConfigSchema
     json-schema/api/ApiTestCollection.json  <-  ApiTestCollection, ApiTestCollectionSchema
     json-schema/api/OpenApiSpec.json  <-  OpenApiSpec, OpenApiSpecSchema
     json-schema/api/RestApiPluginConfig.json  <-  RestApiPluginConfig, RestApiPluginConfigSchema
     json-schema/api/RestApiRouteRegistration.json  <-  RestApiRouteRegistration, RestApiRouteRegistrationSchema
     json-schema/system/MiddlewareConfig.json  <-  MiddlewareConfig, MiddlewareConfigSchema
     json-schema/system/QueueConfig.json  <-  QueueConfig, QueueConfigSchema
     json-schema/system/Task.json  <-  Task, TaskSchema
```

Each is spelled `export const X = Object.assign(XSchema, { … })` in source, which **returns the same object** — verified by reference equality in the walk above, so the second write provably cannot change what is published. Charter step 3 (the report line) taken up: it names the population rather than only counting it, since the card's third point is that the delta was the only visible trace of these writes.

## Docs line: read, deliberately untouched

`troubleshooting.mdx:438` says the field "reports the total number of definitions". Once the artifact matches the published semantics that sentence is **true as written**, so it is not edited. Resolution 2 (rename/redocument the field) was explicitly not taken by triage.

## Files

- `packages/spec/scripts/build-schemas.ts` — assemble `$defs` first, count from it; report the exempt population.
- `packages/spec/scripts/lib/def-key-collisions.ts` — `findSelfAliasedDefKeys` and `collapsedEmitCount`, the complement of the existing guard (same bucketing, same identity predicate, opposite verdict). Declared surface addition beyond the claim: the helper's natural home is beside the guard it complements, and it is what makes the population enumerable instead of implied. `findDefKeyCollisions`' behaviour is unchanged — the shared bucketing was extracted so the two verdicts cannot disagree about which entries belong to one key.
- `packages/spec/scripts/def-key-collisions.test.ts`, `packages/spec/scripts/build-schemas-check-mode.test.ts` — tests, below.
- `.changeset/schema-count-counts-the-definitions-shipped.md` — patch. **Not `skip-changeset`**: the diff is scripts-only, but `json-schema/` is in the package's `files`, so a consumer's installed bundle carries a different number. The scripts-only precedent in this repo is mixed and splits on exactly that question.

No schema content changes; `packages/spec/json-schema/**` is gitignored (`.gitignore:61`), so it is a build-time artifact and not part of this diff. `packages/spec/src/**` is untouched — no intersection with in-flight #12606.

## Tests

Both halves, following this package's existing convention (a unit pin over the extracted helper plus an end-to-end pin that the caller really routes through it).

**Unit** — `scripts/def-key-collisions.test.ts`: the two verdicts are complementary; they **partition** every multiply-written def key; `collapsedEmitCount` is N-1 per key; and `emits - collapsed = definitions`, the arithmetic the published field got wrong.

**End-to-end** — `scripts/build-schemas-check-mode.test.ts`, in the existing sandbox that runs the real generator over the real spec surface (`src/` is symlinked, so ~1600 schemas). It reads the **emitted bytes**, not a helper's return value, and asserts `x-schema-count` equals its own `$defs` size, equals the file count on disk, and equals the number the run's own console reports. The **invariant** is pinned, never today's 1585 — a test that unrelated PRs must edit gets edited without being read. A non-vacuity guard asserts this build still collapses emits, so the case cannot go quietly true.

```
scripts/def-key-collisions.test.ts + scripts/build-schemas-check-mode.test.ts
  Test Files  2 passed (2)        Tests  79 passed (79)        Duration 334.12s

scripts/json-schema-out-dir · schema-tree-freshness · renamed-defs · sharded-artifacts
  + src/data/field · src/ui/component-reference-rail
  Test Files  6 passed (6)        Tests  273 passed (273)
```

**Reverse verification.** Predicted direction, written before running: RED on the self-description assertion. The fix was committed first, then the deleted limb (`'x-schema-count': count`) put back. No rebuild step applies — `build-schemas.ts` runs from source under `tsx` and the sandbox copies `scripts/` and symlinks `src/`, so no `dist/` sits between the mutation and the run. The mutation was confirmed **on disk** by grepping both spellings and by object hash, not by the editor's exit code:

```
before:  fixed spelling 1 · broken 0 · hash 16f926aa…  (= HEAD blob)
after:   fixed spelling 0 · broken 1 · hash 1dfbca2e…
result:  AssertionError: expected 1596 to be 1585   (both cases RED)
restore: fixed spelling 1 · broken 0 · hash 16f926aa…  (= HEAD blob), `git diff HEAD` empty
```

Restore names `HEAD` explicitly (a bare `git checkout -- path` reads the index) and the script carries a `trap … EXIT INT TERM` with absolute paths.

## Gates

Run locally at final head `c7aee902b`, each result read from the gate's own verdict line with the exit code captured before any pipe:

| gate | result |
|:--|:--|
| `pnpm --filter @objectstack/spec typecheck` | pass — `tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck` |
| `pnpm --filter @objectstack/spec check:authorable-surface` | pass (exit 0; the `authorable-surface.base.json` trailing notice is informational) |
| `pnpm check:nul-bytes` | pass — 6965 files, no raw control bytes |
| `pnpm check:test-source-alias` | pass |
| `pnpm check:cross-package-test-inputs` | pass |
| `pnpm check:query-options-erasure` | pass — ratchet holds, no files added vs `7c0d0c3` |
| `check-empty-changeset` / `check-changeset-no-major` / `check-adr-0087-registration` / `check:objectui-changeset` / `check:changeset-gate-self-tests` | pass |

All four edited files were confirmed present in the `tsconfig.scripts.json` program via `tsc --listFiles`, so the typecheck green actually covers them — `tsconfig.test.json` includes only `src/**`, and reading its green as covering `scripts/**/*.test.ts` would have been a phantom.

Gate families were re-derived from the real change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` rather than from the dispatch list.

**Declared narrowing.** The full `@objectstack/spec` suite is 424 test files and does not fit the foreground time budget. Instead: every test file that imports the changed module was run in full (measured — `scripts/lib/def-key-collisions.ts` has exactly **one** non-test importer, `build-schemas.ts`; `scripts/lib/zod-graph.ts` mentions it in prose only, with no import), plus every test that reads `objectstack.json`. Repo-wide, `x-schema-count` is read by no code at all — only the docs page and one audit log — so no consumer can break on the value change. CI runs the farm either way.

## Out of scope, filed

#12608 — the same file's prose names "fourteen" self-aliases and a `ThemeMode` export that no longer exists; measured 13, spanning `api` and `system` only. Comment drift, no behaviour affected, left untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012xGvxcwPRTJfA7RfjXEYA4)_