### PR TITLE
feat(cli): `os serve` announces a shifted port, naming the one you asked for and the one it took (#12543)

### DIFF
--- a/.changeset/cli-serve-port-drift-notice.md
+++ b/.changeset/cli-serve-port-drift-notice.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/cli": minor
+---
+
+feat(cli): `os serve` announces a shifted port, naming the one you asked for and the one it took (#12543)
+
+In development (`os dev`, `--dev`, or `NODE_ENV=development`) `os serve` hops to
+the next free port when the requested one is taken, so several example apps can
+run side by side. That behaviour is unchanged and deliberate — production still
+refuses to drift (#11113). What changed is that the hop is no longer silent.
+
+Previously the only trace of a shift was the ready banner printing the port that
+was *bound*; nothing said it was not the port that was *asked for*, so every
+reader had to already know the requested port and compare the two by hand. A
+boot that shifts now prints, before anything else:
+
+```
+  ⚠ Port 32869 is in use — serving on 32871 instead.
+     Development auto-shift: 32869 was not free, so this server took
+     the next one that was (32871). Anything still pointed at 32869 — a
+     proxy, an OAuth callback URL, another terminal, a test harness — is
+     talking to whatever holds 32869, not to this server.
+```
+
+The notice is written to **stderr**, like every other `os serve` diagnostic:
+`stdout` carries JSON-RPC frames whenever the stdio MCP transport is mounted, so
+nothing but protocol may go there. It prints only when the bound port actually
+differs from the requested one — an ordinary boot on a free port is unchanged,
+byte for byte.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1349,6 +1349,53 @@ export default class Serve extends Command {
       } catch {
         // Ignore — fall through and try the requested port.
       }
+      if (port !== requestedPort) {
+        // ── The shift is CORRECT; its SILENCE was the defect (#12543) ────
+        // Auto-shifting is the whole point of this branch and it stays exactly
+        // as it is — #11113 owns the other half of the policy, where a busy
+        // port is a refusal instead. What was missing is that the hop happened
+        // with nothing marking it: the ready banner prints the port that was
+        // BOUND, and no line anywhere said it was not the port that was ASKED
+        // FOR.
+        //
+        // A reader holding only the bound port has to already know the
+        // requested one and compare the two by hand. That is not a
+        // hypothetical cost: five landed consumer-side PRs each re-derived it
+        // from this command's banner (a bind probe, the shared `runServe()`
+        // read-back, three spawners, a security probe). This line is the only
+        // place that holds BOTH numbers for free, so it says both.
+        //
+        // ⭐ Three facts, not one — what was asked for, that it could not be
+        // had, and what was taken instead. A line naming only the bound port
+        // is what the banner already prints, and it leaves the comparison
+        // undone.
+        //
+        // CHANNEL — measured, not chosen (#7915). `stdout` is the JSON-RPC
+        // channel whenever the stdio MCP transport is mounted, where a single
+        // non-frame line reaches the client as a transport error; that is what
+        // `serve-stdio-stdout-purity.e2e.test.ts` exists to pin. So this goes
+        // through `printDiagnostic` — straight to **stderr**, the same helper,
+        // the same stream and the same point in the boot as the production
+        // refusal in the `else` branch just below, which is this notice's
+        // counterpart under the other half of the same policy.
+        //
+        // TIMING — also measured. This runs BEFORE the boot-quiet window
+        // opens (`bootQuiet` is still `false` here; it is assigned from
+        // `verboseBoot` several hundred lines down), so unlike a boot-phase
+        // `logger.warn` — which that window captures and replays only after a
+        // banner has printed, and only if the boot ever reaches one — this
+        // line cannot be swallowed, and it survives a boot that dies later. A
+        // drifted port is a plausible CAUSE of such a death, so the notice has
+        // to outlive it.
+        printDiagnostic(
+          '\n'
+          + chalk.yellow(`  ⚠ Port ${requestedPort} is in use — serving on ${port} instead.\n`)
+          + chalk.dim(`     Development auto-shift: ${requestedPort} was not free, so this server took\n`)
+          + chalk.dim(`     the next one that was (${port}). Anything still pointed at ${requestedPort} — a\n`)
+          + chalk.dim('     proxy, an OAuth callback URL, another terminal, a test harness — is\n')
+          + chalk.dim(`     talking to whatever holds ${requestedPort}, not to this server.`),
+        );
+      }
     } else if (!(await isPortAvailable(requestedPort))) {
       // One write, for the reason spelled out at the "Nothing to serve" exit
       // below: `this.exit(1)` reaches `process.exit` without draining a piped

--- a/packages/cli/test/serve-port-drift-notice.e2e.test.ts
+++ b/packages/cli/test/serve-port-drift-notice.e2e.test.ts
@@ -103,16 +103,46 @@ beforeAll(() => {
   writeFileSync(join(dir, 'objectstack.config.ts'), BARE_CONFIG, 'utf8');
 });
 
-afterAll(() => {
-  for (const child of children) {
-    try {
-      child.kill('SIGKILL');
-    } catch {
-      /* already gone */
-    }
-  }
+afterAll(async () => {
+  for (const child of children) await stop(child);
   if (dir) rmSync(dir, { recursive: true, force: true });
-});
+}, 60_000);
+
+/**
+ * Stop a spawned child and WAIT for it to be gone — SIGTERM first, SIGKILL only
+ * as a fallback, which is the shape every other spawner in this directory uses.
+ *
+ * ⚠️ ⛔ Not a bare `child.kill('SIGKILL')`. The child here is the `tsx` shim,
+ * and the `os serve` process is its own child: SIGKILL cannot be forwarded, so
+ * killing the shim outright leaves the server running, re-parented to init and
+ * still holding this process's stdio pipes — measured while writing this file,
+ * where it kept the runner alive after the assertions had all passed. SIGTERM
+ * reaches the server through the shim; the 10s SIGKILL is the fallback for a
+ * child that ignores it.
+ */
+async function stop(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((done) => {
+    const give = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      done();
+    }, 10_000);
+    child.once('exit', () => {
+      clearTimeout(give);
+      done();
+    });
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      clearTimeout(give);
+      done();
+    }
+  });
+}
 
 /**
  * A real HTTP neighbour on a real port — the card's own instrument, and the
@@ -257,7 +287,7 @@ describe('#12543: a shifted port announces itself, naming both numbers', () => {
         'A NEIGHBOURING AGENT DEV SERVER, not os serve',
       );
 
-      booted.child.kill('SIGKILL');
+      await stop(booted.child);
     } finally {
       await neighbour.release();
     }
@@ -279,6 +309,6 @@ describe('#12543: a shifted port announces itself, naming both numbers', () => {
       DRIFT_NOTICE,
     );
 
-    booted.child.kill('SIGKILL');
+    await stop(booted.child);
   }, 240_000);
 });

--- a/packages/cli/test/serve-port-drift-notice.e2e.test.ts
+++ b/packages/cli/test/serve-port-drift-notice.e2e.test.ts
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #12543 — when `os serve` binds a port other than the one it was asked for, it
+ * SAYS SO, naming both numbers on one line.
+ *
+ * ## The defect is the silence, not the behaviour
+ *
+ * Auto-shifting to the next free port in development is correct and deliberate:
+ * several example apps have to run side by side, and #11113 owns the production
+ * half, where a busy port is a loud refusal instead. ⛔ Nothing in this file
+ * argues for changing either half, and a change to what `os serve` *does* would
+ * be answering a different card. What was missing is that the shift happened
+ * with nothing marking it as one: the ready banner prints the port that was
+ * BOUND, and no line anywhere said it was not the port that was ASKED FOR.
+ *
+ * ## Why the producer, when the consumers already cope
+ *
+ * The consumer side of this family is fully landed — a bind probe (#12441), the
+ * shared `runServe()` read-back (#12525), three spawners taught to check
+ * locally (#12526), and a security probe (#12548). Every one of them
+ * re-derives, by hand and by parsing the banner, a fact `serve.ts` holds for
+ * free at the moment it shifts: the requested port and the bound port, in one
+ * scope. And the banner is a lossy place to re-derive it from — `runServe()`'s
+ * read-back carries an `unreadable` state precisely because the `API:` row
+ * shows an `OS_AUTH_URL` / `BETTER_AUTH_URL` / `OS_BASE_URL` origin when one is
+ * set, which is not what the process bound at all. The producer has no such
+ * gap. This file pins it finally saying so.
+ *
+ * ⚠️ The cost of the silence is measured rather than supposed: a harness asks
+ * for a port, silently gets another, and then talks to whatever holds the one
+ * it asked for. The positive case below reproduces exactly that — with a real
+ * HTTP neighbour, and it asserts the stranger answering as well as the notice.
+ *
+ * ## CHANNEL — the sharpest constraint here, and not a free choice
+ *
+ * `stdout` is the JSON-RPC channel whenever the stdio MCP transport is mounted
+ * (#7915): one non-frame line there reaches a conforming client as a transport
+ * error, which is what `serve-stdio-stdout-purity.e2e.test.ts` exists to pin.
+ * So the notice goes to **stderr**, through `serve.ts`'s own `printDiagnostic`
+ * — the same helper, stream and boot position as the production-mode refusal
+ * that is this notice's counterpart under the other half of the same policy.
+ *
+ * This file proves the half it can reach on its own: under a real drift the
+ * notice is on stderr and the child's stdout carries nothing at all. The other
+ * half is that `serve-stdio-stdout-purity.e2e.test.ts` still passes unchanged,
+ * which is a different boot shape and stays in its own file.
+ *
+ * ## Why this file spawns instead of calling `runServe()`
+ *
+ * `runServe()` REJECTS a drifted boot — that is #12525's read-back doing its
+ * job. Routing the positive case through it would make the very condition under
+ * test unreachable. So this file owns its spawn, while still taking the
+ * entrypoint, the child environment and the free-port draw from the shared
+ * helper rather than re-deriving them.
+ *
+ * ⚠️ The one instrument it does own is the HTTP neighbour. `holdPort()` in the
+ * shared helper binds a bare TCP socket, which is enough to make a port
+ * unbindable but cannot ANSWER — and "something else answered where you were
+ * pointed" is the specific harm this card was filed about. The surface ruling
+ * on this card keeps `helpers/serve-process.ts` out of the diff, so the
+ * neighbour lives here, named as a deliberate second instrument rather than a
+ * blind duplicate of the draw.
+ *
+ * ## The negative half is not optional
+ *
+ * ⭐ A drift notice that appears when there is no drift is worse than silence:
+ * it trains readers to skip the line, and then the one boot that really did
+ * shift reads like every other. The SAME regex is asserted present in the
+ * drifted boot and absent in the clean one, so neither case can pass by the
+ * regex having quietly stopped matching anything at all.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CLI, TSX, E2E_SECRET_KEY, childEnv, randomPort } from './helpers/serve-process.js';
+
+/**
+ * The notice, as ONE regex shared by both cases.
+ *
+ * Deliberately loose about decoration and exact about the two numbers: what is
+ * pinned is that a reader gets the requested port AND the bound port out of a
+ * single line, without holding a second one beside it to compare against.
+ */
+const DRIFT_NOTICE = /Port (\d+) is in use — serving on (\d+) instead\./;
+
+/** The banner's last line — the marker that the WHOLE banner is in the buffer. */
+const BANNER_TAIL = /Press Ctrl\+C to stop/;
+
+/** The platform with no application — the cheapest fixture that still boots. */
+const BARE_CONFIG = 'export default {};\n';
+
+let dir: string;
+const children: ChildProcessWithoutNullStreams[] = [];
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'os-port-drift-notice-'));
+  writeFileSync(join(dir, 'objectstack.config.ts'), BARE_CONFIG, 'utf8');
+});
+
+afterAll(() => {
+  for (const child of children) {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      /* already gone */
+    }
+  }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * A real HTTP neighbour on a real port — the card's own instrument, and the
+ * reason it must not be simulated. The point is not merely that the port cannot
+ * be bound; it is that something ELSE answers there while `os serve` is happily
+ * bound somewhere the caller was never told about.
+ */
+function realNeighbour(): Promise<{ port: number; release: () => Promise<void> }> {
+  return new Promise((resolveHold, rejectHold) => {
+    const server: Server = createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ iAm: 'A NEIGHBOURING AGENT DEV SERVER, not os serve' }));
+    });
+    server.on('error', rejectHold);
+    server.listen(0, '0.0.0.0', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        rejectHold(new Error(`listen(0) produced no numeric address: ${String(address)}`));
+        return;
+      }
+      resolveHold({
+        port: address.port,
+        release: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+interface Booted {
+  stdout: string;
+  stderr: string;
+  child: ChildProcessWithoutNullStreams;
+  reachedBanner: boolean;
+}
+
+/**
+ * Boot `os serve` on `port` and collect BOTH streams until the banner's last
+ * line lands — or the child dies, or the clock runs out. A boot that never got
+ * there resolves with `reachedBanner: false` rather than throwing, so the
+ * caller's failure message can show what it printed on the way down.
+ */
+function boot(port: number | string, timeoutMs = 180_000): Promise<Booted> {
+  return new Promise((resolveBoot) => {
+    const child = spawn(TSX, [CLI, 'serve', 'objectstack.config.ts', '--port', String(port)], {
+      cwd: dir,
+      // The shared child environment, never a bare `...process.env` (#11267).
+      //
+      // `NODE_ENV` is declared here rather than left to the entrypoint even
+      // though `bin/run-dev.js` pins the same value before argv is parsed: the
+      // branch under test is `flags.dev || NODE_ENV === 'development'`, so the
+      // reason these boots can drift at all belongs AT the spawn where a reader
+      // can see it, not two files away. Silence would also inherit the vitest
+      // worker's `NODE_ENV=test`, which `childEnv()` deliberately does not
+      // strip.
+      env: childEnv({
+        NODE_ENV: 'development',
+        NO_COLOR: '1',
+        OS_DATABASE_URL: ':memory:',
+        OS_LOG_LEVEL: '',
+        OS_DISABLE_CONSOLE: '1',
+        OS_SECRET_KEY: E2E_SECRET_KEY,
+      }),
+    });
+    children.push(child);
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const done = (reachedBanner: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveBoot({ stdout, stderr, child, reachedBanner });
+    };
+
+    const timer = setTimeout(() => done(false), timeoutMs);
+    // Key on the banner's LAST line so no assertion can read a boot that has
+    // printed only half of it.
+    const check = () => {
+      if (BANNER_TAIL.test(stdout + stderr)) done(true);
+    };
+    child.stdout.on('data', (d) => {
+      stdout += String(d);
+      check();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += String(d);
+      check();
+    });
+    child.on('exit', () => done(false));
+  });
+}
+
+/** The port the banner says was actually bound, read out of its `API:` row. */
+function boundPort(output: string): string | undefined {
+  const apiRow = output.match(/^[^\n]*\bAPI:[^\n]*$/m);
+  return apiRow ? (apiRow[0].match(/localhost:(\d+)/) ?? [])[1] : undefined;
+}
+
+describe('#12543: a shifted port announces itself, naming both numbers', () => {
+  it('POSITIVE — a really-held port produces a notice carrying REQUESTED and BOUND', async () => {
+    const neighbour = await realNeighbour();
+    try {
+      const booted = await boot(neighbour.port);
+      const { stdout, stderr } = booted;
+      const seen = `\n--- stdout ---\n${stdout.slice(0, 2000)}\n--- stderr (tail) ---\n${stderr.slice(-3000)}`;
+
+      expect(booted.reachedBanner, `the boot never reached its banner${seen}`).toBe(true);
+
+      // The drift really happened. Without this, every assertion below could
+      // pass on a boot that never shifted at all.
+      const bound = boundPort(stderr);
+      expect(bound, `no API row in the banner to read a bound port from${seen}`).toBeDefined();
+      expect(
+        Number(bound),
+        `the child bound the port it was asked for — there is no drift to announce${seen}`,
+      ).not.toBe(neighbour.port);
+
+      // ── The pin ──────────────────────────────────────────────────────
+      const match = stderr.match(DRIFT_NOTICE);
+      expect(match, `no drift notice on stderr for a boot that DID drift${seen}`).not.toBeNull();
+      // Both numbers, in that one line. The reader's two questions are "from
+      // what" and "to what", and a line answering only the second is the
+      // banner — which is what five consumer PRs already had to parse.
+      expect(match![1], `the notice does not name the REQUESTED port${seen}`).toBe(String(neighbour.port));
+      expect(match![2], `the notice does not name the BOUND port${seen}`).toBe(String(bound));
+
+      // ── The channel ──────────────────────────────────────────────────
+      // stdout is the JSON-RPC channel when the stdio transport is mounted
+      // (#7915), so the notice must not be there — and under `os serve`
+      // nothing else may be either.
+      expect(stdout, `the drifted boot put bytes on stdout${seen}`).toBe('');
+
+      // ── The cost the notice exists to make visible ────────────────────
+      // The port the caller asked for is still answered by the stranger. This
+      // is the false-green generator the card measured, re-derived here so the
+      // notice is pinned against a real one rather than a described one.
+      const answer = await fetch(`http://localhost:${neighbour.port}/api/v1/auth/sign-in/email`, {
+        method: 'POST',
+      }).then((r) => r.text());
+      expect(answer, 'the held port was not answered by the neighbour').toContain(
+        'A NEIGHBOURING AGENT DEV SERVER, not os serve',
+      );
+
+      booted.child.kill('SIGKILL');
+    } finally {
+      await neighbour.release();
+    }
+  }, 240_000);
+
+  it('NEGATIVE — an ordinary boot on a free port says nothing about ports', async () => {
+    const booted = await boot(randomPort());
+    const { stderr } = booted;
+    const seen = `\n--- stderr (tail) ---\n${stderr.slice(-3000)}`;
+
+    expect(booted.reachedBanner, `the boot never reached its banner${seen}`).toBe(true);
+    expect(stderr, `the banner is missing, so "no notice" would prove nothing${seen}`).toContain(
+      'Server is ready',
+    );
+
+    // ⭐ The whole value of the notice is that it is rare. The same regex the
+    // positive case just matched must find nothing here.
+    expect(stderr, `a drift notice appeared on a boot that never drifted${seen}`).not.toMatch(
+      DRIFT_NOTICE,
+    );
+
+    booted.child.kill('SIGKILL');
+  }, 240_000);
+});


### PR DESCRIPTION
Fixes #12543

In development `os serve` hops to the next free port when the requested one is taken. **That behaviour is correct and is unchanged here** — auto-shift is deliberate, and #11113 owns the production half, where a busy port is a loud refusal. ⭐ The defect this PR fixes is that a correct behaviour was **silent**: the ready banner prints the port that was BOUND, and no line anywhere said it was not the port that was ASKED FOR.

`serve.ts` holds both numbers in one scope at the moment it shifts, so it now says both, once, when they differ.

> ⚠️ Two phrases below are written without angle brackets on purpose — a generic parameter and a placeholder were both silently eaten out of the first version of this body by GitHub's sanitizer, inside backticks included. They are spelled in words where that happened.

## Anchors — re-derived on `origin/main` @ `7a25e7d60`, cited as phrases

| what | the phrase it is anchored to |
|---|---|
| the search | `const getAvailablePort = async (startPort: number)` |
| the policy switch | `const portAutoShiftAllowed = flags.dev || process.env.NODE_ENV === 'development';` |
| the call | `port = await getAvailablePort(requestedPort);` |
| the channel helper | `if (!bootQuiet) process.stderr.write(text + '\n');` |

⛔ The `flags.dev || process.env.NODE_ENV === 'development'` condition is untouched, `portAutoShiftAllowed` is neither narrowed nor gated, and no shifted boot is made to fail. The diff adds one `if (port !== requestedPort)` block and nothing else in `serve.ts`.

## What it prints

```
  ⚠ Port 34895 is in use — serving on 34896 instead.
     Development auto-shift: 34895 was not free, so this server took
     the next one that was (34896). Anything still pointed at 34895 — a
     proxy, an OAuth callback URL, another terminal, a test harness — is
     talking to whatever holds 34895, not to this server.
```

Three facts, not one: what was asked for, that it could not be had, what was taken. A line naming only the bound port is what the banner already prints, and it is what five landed consumer-side PRs (#12523, #12546, #12552, #12565, plus #12441's probe) each had to parse and compare by hand.

## CHANNEL — measured, not chosen

This was the sharpest constraint on the card, so here is what was measured rather than assumed.

1. **`stdout` is never available to a diagnostic in this command, in any mode.** `run()`'s first statement is `redirectStdoutToStderr()`, held for the life of the process, and the comment above it says why: with `OS_MCP_STDIO_ENABLED=true` the MCP stdio transport owns stdout and its protocol is newline-delimited JSON. The transport keeps its own handle to the real stdout (`packages/mcp`, `protocol-stdout.ts`) rather than depending on who booted it.
2. **The notice therefore goes through `printDiagnostic`** — `process.stderr.write` directly — which is the same helper, the same stream and the same point in the boot as the production-mode refusal in the sibling `else if` branch. That refusal is this notice's exact counterpart under the other half of the policy, so they now match.
3. **A `logger.warn` here would have been a notice nobody sees.** The boot-quiet window (#12028 / PR #12562) intercepts `process.stdout.write`, `console.log` and `console.debug` and replays kernel records only *after* the banner. The notice sits well before that window opens — `bootQuiet` is still its initial `false` at this point — and it writes to stderr rather than through `console.log`, so it is outside the window on both counts. It also survives a boot that dies later, which matters: a drifted port is a plausible cause of such a death.

**Proof the channel choice is safe, not merely argued:** `serve-stdio-stdout-purity.e2e.test.ts` — the file that exists to pin stdout purity in JSON-RPC modes — passes unchanged (`Tests 1 passed (1)`). And the new positive case asserts directly that a drifted child's stdout is the empty string, which the standalone probe measured as `STDOUT_BYTES=0`.

## Premise re-derivation — ⚠️ one fork, reported and NOT reconciled

The card measured: port `32869` held ⇒ child bound **`32871`** (explicitly "not 32870"), printed `Server is ready`, never exited; and the harness's own next request to the reserved port was answered by the neighbour.

Re-derived on this tree with a real `http.createServer` neighbour:

```
NEIGHBOUR_HOLDS=34895
REQUESTED=34895 BOUND=34896 DELTA=1
ANSWER_ON_REQUESTED_PORT={"iAm":"A NEIGHBOURING AGENT DEV SERVER, not os serve"}
REACHED_BANNER=true   CHILD_EXITED=false   STDOUT_BYTES=0
```

- ✅ The drift happens, the boot succeeds, the banner prints the bound port (`API: http://localhost:34896/`), the child never exits.
- ✅ The requested port is answered by the stranger, with the card's exact string.
- ⚠️ **DELTA=1, not 2.** `getAvailablePort`'s walk did **not** skip a port here — it took `requested + 1`. The card's `32869 ⇒ 32871` was almost certainly a second holder on `32870` at that moment on this shared container, not a property of the search: the loop is a plain `port++` with no skip in it. ⛔ Nothing is reconciled — the number measured is the number reported, and the card's "not 32870" does not reproduce.

The mechanism the card is about is unaffected by the fork: the drift is real, correct, and was silent.

## Tests

New: `packages/cli/test/serve-port-drift-notice.e2e.test.ts` — one regex asserted PRESENT in the drifted boot and ABSENT in the clean one, so neither case can pass by the regex having quietly stopped matching.

- **Positive** — a real HTTP neighbour holds the port (⛔ not simulated; the same instrument #12526 and #12548 used). Asserts the drift really happened *first*, then that the notice names both numbers, then that stdout is empty, then that the requested port is still answered by the stranger.
- **Negative** — an ordinary boot on a free port prints no notice. ⭐ A drift notice that fires without drift is worse than silence.

The file owns its spawn rather than calling `runServe()`, because `runServe()` now *rejects* a drifted boot (#12525's read-back doing its job), which would make the condition under test unreachable. It owns its HTTP neighbour because the shared `holdPort()` binds a bare TCP socket and cannot *answer* — and "something else answered where you were pointed" is the specific harm here.

### Ablation

The notice block was deleted from `serve.ts` and the positive case re-run:

```
HEAD_BLOB=12f79c1f6b82bbf481e16c205aca6cdf35e4fd64
BEFORE_BLOB=12f79c1f6b82bbf481e16c205aca6cdf35e4fd64   BEFORE_MARKER_COUNT=1
AFTER_BLOB=17e710912e6acc4ed102dec4487915a4111e3732    AFTER_MARKER_COUNT=0
MUTATION_CONFIRMED_ON_DISK=yes
  × POSITIVE — a really-held port produces a notice carrying REQUESTED and BOUND
  AssertionError: no drift notice on stderr for a boot that DID drift
ABLATED_VITEST_EXIT=1
RESTORED_BLOB=12f79c1f6b82bbf481e16c205aca6cdf35e4fd64  GIT_DIFF_HEAD_EMPTY_EXIT=0  RESTORE_MARKER_COUNT=1
```

Two things worth reading there. The ablated blob `17e710912` is `serve.ts` **exactly as it stands on `main`** — the mutation reproduces the pre-change file byte for byte, so the ablation removes this PR's contribution and nothing else. And the failure lands *after* the "the child bound a different port" guard passed: the boot still drifted and the notice was simply absent, which is red for the right reason rather than a setup error. No rebuild stands between the mutation and the test — the child loads `packages/cli/src` through `tsx` via `bin/run-dev.js`, so the edited source *is* what ran. Restore is proven by blob hash and an empty `git diff HEAD`, never by an exit code; the script carried a `trap … EXIT INT TERM` whose restore leg was `git checkout HEAD --` followed by the **absolute** path to the file.

### Verification run — narrowing declared

⚠️ The full `packages/cli` vitest suite does not finish inside this container's ~10-minute foreground window, so it was **narrowed to a stated consumer set** and every run went through the shared verify lock. Union re-run on the final commit **`6c296f89b`**, working tree clean:

| run | result |
|---|---|
| `serve-port-drift-notice.e2e.test.ts` | `Test Files 1 passed (1)` · `Tests 2 passed (2)` |
| `serve-stdio-stdout-purity.e2e.test.ts` (the channel pin) | `Tests 1 passed (1)` |
| `serve-port-readback.e2e.test.ts` + `serve-port-bind-probe.test.ts` | `Test Files 2 passed (2)` · `Tests 22 passed (22)` — includes the forced-drift arm, the case most exposed to a new stderr line |
| `pnpm --filter @objectstack/cli typecheck` | exit 0 |
| dependency closure `pnpm --filter '@objectstack/cli^...' build` | lock `VERDICT command-exit 0` |
| 22 gate families (`check:nul-bytes`, `check:cli-test-child-env`, `check:cross-package-test-inputs`, `check:engine-double-contract`, `check:where-matcher`, `check:query-options-erasure`, `check:route-envelope`, `check:type-check-coverage`, `check:i18n`, the changeset family, …) | all exit 0 |

⚠️ **Two gates report COULD NOT MEASURE on this worktree and are stated as such rather than as passes** — both refuse because only the CLI's dependency closure is built here, not the whole workspace, and both say so in their own words:

- `check:i18n-coverage` — *"COULD NOT MEASURE — 1 of 12 config(s) failed to lint"*, because `@objectstack/connector-mcp` has no build output here. Its own text: *"Nothing was compared … this result says NOTHING about whether any declared label went untranslated."*
- `check:type-check-debt` — *"--re-measure cannot run: 1 workspace dependenc(ies) … have no built type entry point on disk"*. It refuses outright rather than measuring a different world.

The risk that hides behind the second one was closed directly instead: `TEST_DEBT['@objectstack/cli']` is a frozen count of **146** over the hidden `test/` layer (`tsconfig.json` says `include: ["src"]`, so `pnpm --filter @objectstack/cli typecheck` reads **no file under `test/`** — its green says nothing about the new file). The new test file was therefore type-checked directly under the ledger's compiler settings: **0 diagnostics**, so it cannot raise the frozen count. That measurement is sound for this file in particular because it imports no `@objectstack/*` package at all — only node builtins, `vitest`, and its sibling helper — so the unresolved-workspace-import hazard the gate warns about has nothing to act on here. CI runs both gates on a fully built tree and is the authority.

## Changeset

`.changeset/cli-serve-port-drift-notice.md`, `@objectstack/cli: minor`. Rule applied: AGENTS.md §Post-Task Checklist — *"Add a changeset for feature work … Pure bug fixes do not require a changeset."* This adds user-visible output to `os serve`, so it is a functional improvement rather than a pure fix. Not breaking, so no ADR-0087 disposition marker is owed (`check:adr-0087-registration` exit 0).

## Also in this branch

A second commit fixes the teardown of the new file's spawns: a bare `child.kill('SIGKILL')` lands on the `tsx` shim, which cannot forward it, so the real `os serve` survived re-parented to init and still holding the runner's stdio pipes — measured while writing this file, where it kept a probe alive long after its assertions had passed. It now uses the SIGTERM-then-SIGKILL shape every other spawner in this directory already uses. Swept the directory: no other file has a SIGKILL without a SIGTERM beside it, so nothing else is owed.

## Out of scope, filed separately

#12620 — when `getAvailablePort` exhausts its 100-port search it throws a message that names the problem exactly, the caller discards it, and boot falls through to bind the port it just proved was busy. That path gets neither the production refusal (wrong branch) nor this PR's notice (`port === requestedPort` there). ⛔ Not folded in: repairing it changes what `os serve` does, which this card's rulings forbid.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_
