### PR TITLE
docs(pm-skill): record the branch-information test beside the spec lane's ledger-append pre-approval

### DIFF
--- a/.claude/skills/pm-dispatch/references/lanes/spec.md
+++ b/.claude/skills/pm-dispatch/references/lanes/spec.md
@@ -14,8 +14,7 @@
 
 ## 席内分派参考
 
-(维护者 2026-08-16 裁定合并车道:原 spec-surface / spec-tooling 标签已退役,三面
-同归 `domain:spec` 一席,锚定规则双射恢复;以下判据降为席内分派与定价依据。)
+(维护者 2026-08-16 裁定合并车道;以下判据降为席内分派与定价依据。)
 
 - 语义/文本按「合法元数据集合变没变」分 —— 改动前能过校验的输入,改动后逐字节同
   判 ⇒ 文本面(changeset 恒 patch,默认 sweep-first),否则语义面;**任何改变接
@@ -35,11 +34,12 @@
   —— ① 码的存在已在归属卡裁过(ADR-0112 令注册强制);② 纯增量:不动 schema 形状/既有条
   目/ledger 机制,只落追加方自己的包分节;③ 兜底不变:条款②路径肢照命中,入队前仍过契约
   复核。出类(新 ledger 字段、重构、别道条目、准入/拒收语义)⇒ 本席卡,不论谁需要它。
+- **分支信息测试**(2026-08-26 裁决原文不译):"Does this defect give a consumer a branch it could act on
+  differently? No ⇒ widen the existing member's comment/message; yes ⇒ new code under the pre-approved class."
 - **待命巡逻每次做整车道全交集读**(delta 扫描有尾隙:扫描后、波次边界前入队的卡
   谁都看不见;全交集读是安全网)。
 - **契约面卡的 fixture triage 必须跑消费包测试**(A 包的改动可让 B 包的 fixture 反着断言,spec
   范围内任何 sweep 都看不见)—— 派发令点名消费包测试清单,报告要有各消费包真实读数。
-- 派发前触发文件必查照 SKILL.md 标签纪律执行(读锚 H17 索引相交)。
 
 ## 席内判断
 


### PR DESCRIPTION
Fixes #12100

Records the branch-information test in `references/lanes/spec.md`, beside the
ledger-append pre-approval it qualifies. One ruled line, paid for by compression in
the same file — the ratchet reading stays 46/46.

## The ruling, quoted (spec seat, 2026-08-26)

> **① Yes — the Case B test becomes recorded discipline.» *Does this defect give a consumer a branch it could act on differently?* No ⇒ widen the existing member's comment/message; yes ⇒ new code under the pre-approved class.«

> **② It lives in `references/lanes/spec.md`, beside the permission it qualifies — not in the ADR-0112 material.**

> The 46-line ceiling cost is acknowledged: the skills lane pays it by compression in the same file per its own ratchet rules — the one-line spelling above is offered as the cheapest form; compressing the existing three-conditions prose to fund it is the skills seat's call.

The one-line spelling is reproduced **byte-for-byte** inside quotation marks (verified
by reconstructing the wrapped pair and comparing to the ruling string). The lead-in
carries `原文不译` so a future compressor paraphrases neither the test nor the ruling.
Placement is the bullet **immediately after** the ledger-append pre-approval bullet.

## What compression paid for it — clause-by-clause survival check

The ruling left the compression point to this lane. It was **not** funded by re-wrapping:
each cut deletes content, and the line saving follows from the deletion. Every deleted
clause has a named home, checked one at a time.

### Cut 1 — the 席内分派参考 provenance paragraph, 2 lines → 1 line (197 → 90 bytes)

| Deleted clause | Where it survives |
| --- | --- |
| 原 spec-surface / spec-tooling 标签已退役 | `scripts/pm/ensure-pm-labels.sh` — the *enforcing* home, and a fuller account: "domain:spec-surface and domain:spec-tooling, retired 2026-08-16 — maintainer ruling 「A」 merged both into the single domain:spec lane, the sub-lane criteria surviving as the spec seat's dispatch reference" |
| 三面同归 `domain:spec` 一席 | In-file duplicate — the 范围 section's first bullet already reads 「语义/文本/机器三面同席」; also the `ensure-pm-labels.sh` sentence above |
| 锚定规则双射恢复 | `SKILL.md`: 「一座位一车道,双射」 — the standing rule the merge restored |

Kept: the provenance (`维护者 2026-08-16 裁定合并车道`) and the operational clause
(`以下判据降为席内分派与定价依据`), which is what tells a reader how to use the section
and is the half `SKILL.md` 模型分档 points back to.

### Cut 2 — the H17 trigger-file bullet, 1 line → deleted

| Deleted clause | Where it survives |
| --- | --- |
| 派发前触发文件必查(读锚 H17 索引相交) | `SKILL.md`, standing 执行座位职责 — strictly *more* complete than the deleted pointer: 「派发/折叠检查时读半状态巡查锚(`half-state-patrol.yml` 的 `ANCHOR_ISSUE` 置顶 issue)的 H17 on-hold 触发文件索引、与本次派发文件面相交,命中 ⇒ 按该 hold 评论的 rider/restart 条款处置」 |
| 照 SKILL.md 标签纪律执行 | A bare pointer to `SKILL.md`, which every seat session reads in full — the ratchet header's own premise |

Nothing else in the file was touched: the diff is exactly three hunks in one file.

## Ratchet and length readings, from the gates themselves at `2458c2d0e`

```
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/lanes/spec.md is 46 lines (ceiling 46; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/lanes/spec.md: widest table row is 0 bytes (pin 0; headroom 0).
```

The two added lines are 114 and 117 bytes, under the 120-byte max-line rule; the file's
widest line is unchanged at 120 (a pre-existing line).

## Gates run locally — the full derived family, not just the dispatched two

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derived 7 families
from the real change set (the dispatch named 2; the other 5 are the additions). All ran in
the foreground under the shared verify lock, exit codes captured before any pipe:

| Gate | Verdict line |
| --- | --- |
| `check:pm-skill-ratchet` | `✓ … lanes/spec.md is 46 lines (ceiling 46; headroom 0).` |
| `check:pm-skill-id-lint` | `✓ check-skill-id-lint: 22 file(s) clean` |
| `check:agent-test-spelling` | `✓ check-agent-test-spelling: 0 violations — 386 file(s) …` |
| `check:doc-authoring` | `✓ doc authoring guard: 390 files clean — no bare metadata literals.` |
| `check:doc-formula-expressions` | `✓ … 22 record-scoped formula example(s) across 422 files / 1450 TS blocks judged clean` |
| `check:pm-governed-merges` | `✓ check-governed-merges --self-test: 159 assertions` |
| `check:skill-frame-sync` | `✓ … 4 copies of the decision frame are structurally isomorphic across 3 files` |

`check:doc-formula-expressions` first returned `PREREQUISITE NOT MET — the workspace
package @objectstack/formula is not built` (exit 1). That is **not measured**, not red —
`@objectstack/formula` and then `@objectstack/lint` were built and the gate re-run to a
real green, quoted above.

## No changeset

The diff is one `.claude/` instruction file: it publishes nothing, so `skip-changeset`
is applied (and read back — the size labeler's whole-group PUT is known to strip an
additive label).

## Draft on purpose

`.claude/**` + `.md` is a governed surface: this PR stays **draft** and waits for the
maintainer's manual merge. Not marked ready, never queued.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_