### PR TITLE
feat(pm): H37 — report a family dispatch whose per-member label writes did not all land

### DIFF
--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -6189,6 +6189,305 @@ export function h36SharedFileHolds(openPrs, filesByPr) {
 }
 
 // ---------------------------------------------------------------------------
+// H37 — a FAMILY DISPATCH whose per-member label writes did not all land
+// (#12629).
+//
+// ## The incident, and the exact reason nothing said so
+//
+// A family dispatch folds N already-triaged cards into ONE dev run: one shared
+// branch named after the CHAIN HEAD, one worktree, one PR — and one
+// `pm:dispatched` write PER MEMBER. Those writes are N separate calls with
+// nothing tying them together, so a partial run is possible and produced no
+// signal at all. Measured on the filing seat's own error: in a 3-card fold it
+// wrote 2 of the 3, leaving one member carrying a member-pointer claim comment
+// naming the chain head while its label still read `pm:queue`.
+//
+// That combination is a lie in the DISPATCHABLE direction — the queue label
+// says "free to claim" about a card a fold already holds — and every per-card
+// predicate in this file reads it as clean, CORRECTLY:
+//
+//   - H1/H2/H3/H24/H29 key on `assignee` x label x claim-comment pairings ON
+//     ONE CARD. That card had no assignee and a consistent-looking `pm:queue`.
+//   - The fold's own record lives in the CHAIN HEAD's claim comment, on
+//     another card. Nothing joined the two.
+//   - The seat's in-flight ledger is its seat post, which lists the fold by
+//     its HEAD.
+//
+// The mirror direction is measured too, on this card's own grading round:
+// #12200 was left `pm:dispatched` WITH its assignee after the fold's recovery
+// had declared release — the same non-atomic write failing the other way, and
+// equally invisible until a seat happened to look. Both directions are rows
+// here, because a predicate that reported only the first would have said
+// nothing about the second instance on the very card that filed it.
+//
+// ## The join, and why the BRANCH is the whole of it
+//
+// The fold convention (SKILL.md, step 4 -> 家族派发的折叠认领约定) is:
+//
+//     共享分支按链首卡命名,每张成员卡各留认领评论并点名该分支
+//
+// — the shared branch is named for the chain head, and EVERY member card
+// leaves its own claim comment naming that branch (a member with no branch of
+// its own is the design, not a half-state). So the fold's roster is already
+// written on the board in a machine-readable field: the `Branch:` directive
+// this file has read since H20, through `claimedBranches` / `governingClaim`.
+//
+// A card whose governing claim names `claude/issue-H-...` with H NOT its own
+// number IS the member pointer, and a branch carrying at least one such
+// claimant IS a live fold. That single reading covers BOTH halves the filing
+// card asks to join — 「a member pointer on this card」 and 「named as a member
+// in a live `Claim:` on another open card」 — because the shared branch is the
+// one string both of them spell, and each member's claim names it.
+//
+// ⛔ No prose scraping, deliberately. A claim comment names sibling cards,
+// serial-constraint predecessors and blocker targets as bare `#N` in its own
+// text — the specimen on this row's own filing card names the chain that HELD
+// this script — so scanning claim prose for card numbers would manufacture
+// members out of the one field the protocol fills in correctly. H20's header
+// makes the same call about branch spellings, for the same reason: a fabricated
+// row sends a reader to check something that was never there.
+//
+// ## What the row compares, in BOTH directions
+//
+// Per fold, the HEAD's own state says whether the fold is in flight, and every
+// other claimant is read against it:
+//
+//   head `pm:dispatched`         -> IN FLIGHT. A claimant without
+//                                   `pm:dispatched` is a missed write — the
+//                                   filing seat's own error.
+//   head CLOSED, or open without -> RELEASED. A claimant still carrying
+//   `pm:dispatched`                 `pm:dispatched` is residue — #12200's
+//                                   mirror.
+//   head open + undispatched,    -> the HEAD's own half of the write is the one
+//   some claimant dispatched        that missed. The row lands on the head, and
+//                                   it is visible from the members' claims and
+//                                   from nothing else on the board.
+//   head in neither population   -> UNRESOLVABLE, and the row DECLINES rather
+//                                   than picking a side (H19's call).
+//
+// A fold in which NOTHING is dispatched — head included — is deliberately
+// quiet. It is indistinguishable from an abandoned or not-yet-launched fold,
+// and those cards are already H30's population on their own terms.
+// Under-report over fabricate is this file's standing direction.
+//
+// ## The noise floor is CLOSED, and it is the ordinary case
+//
+// Exactly ONE exclusion, and it covers essentially the whole board: a claim
+// naming its OWN card's branch is not fold evidence. Every solo dispatch here
+// writes exactly that, so without the exclusion this row would fire on every
+// dispatched card in existence. A branch is a fold branch only when some
+// claimant is not its head. ⛔ Nothing else is suppressed by name — this row
+// carries no per-incident exclusion list to grow, which is the discipline H36's
+// closed noise floor states and `SINGLE_CLAIM_PATHS` applies to itself.
+//
+// ## Bounded, and bounded honestly
+//
+// Round 1 is FREE. It reads the claim threads this sweep ALREADY holds: every
+// open `pm:dispatched` card (the dispatch-liveness loop) and every assigned
+// pm-tracked card (H2's fetch). So fold DISCOVERY converges on the open
+// `pm:dispatched` population, exactly as the filing card bounds it — a fold
+// with a dispatched member announces itself there at no cost.
+//
+// Round 2 buys ONE comment page per open `pm:queue` card, and ONLY when round 1
+// actually saw a live fold. A board with no fold in flight therefore costs
+// NOTHING, and a board with one costs at most the queue page count (40 open
+// `pm:queue` cards at the 2026-08-24 census H30 measured, against a 15,000/h
+// core quota and four sweeps a day). It is bought for `pm:queue` because that
+// is precisely where the dispatchable-direction lie parks — a card the queue
+// offers while a fold already holds it — and it is the one population whose
+// threads no other item here reads.
+//
+// Positive evidence only. A member page that fails drops that card out of the
+// roster — a MISS, never an invention — and the coverage pair reports it, with
+// an all-failed pass named in the summary as the transport it is (#4690). The
+// pass does NOT rethrow, unlike H16's and H36's: those rows ARE their detail
+// pass, while two of this row's three directions are free and already gathered,
+// so discarding the sweep would cost more readings than it protects. ⛔ This
+// row never asserts that a fold's writes all landed.
+//
+// Report-only like everything here: the remedy is a seat re-reading the fold's
+// members and writing the missing half. ⛔ Never a label written from this
+// script.
+// ---------------------------------------------------------------------------
+
+/** How many fold members one row names before it counts the rest — H19/H20's budget, same grounds. */
+export const H37_MEMBER_LIST_CAP = 5;
+
+/**
+ * The live folds on this board, keyed by the SHARED BRANCH.
+ *
+ * @param {{ number: number, branches: string[] }[]} claims — one entry per card
+ *   whose governing claim named at least one protocol-shaped branch.
+ * @returns {Map<string, { head: number, claimants: number[] }>} branch ->
+ *   the chain head the branch is named for, and every card claiming it.
+ *
+ * The single exclusion IS the noise floor (see the banner): a branch whose only
+ * claimant is its own head is ordinary solo work and never a fold. Branch keys
+ * come back sorted so a roster is deterministic for a reader and for the
+ * self-test; claimants are sorted for the same reason.
+ */
+export function h37FoldBranches(claims) {
+  const byBranch = new Map();
+  for (const claim of claims ?? []) {
+    const number = Number(claim?.number);
+    if (!Number.isFinite(number)) continue;
+    for (const branch of claim?.branches ?? []) {
+      // ⚠️ The null check is separate from the finiteness one and must stay so:
+      // `branchNameTarget` returns NULL for a branch it cannot read, and
+      // `Number(null)` is 0 — a perfectly finite head number for a card that
+      // does not exist. Collapsing the two mints a phantom fold on every
+      // unreadable branch spelling, which then gates the round-2 member read on
+      // nothing (caught by this row's own pin).
+      const target = branchNameTarget(branch);
+      if (target === null) continue;
+      const head = Number(target);
+      if (!Number.isFinite(head)) continue;
+      if (!byBranch.has(branch)) byBranch.set(branch, { head, claimants: [] });
+      const entry = byBranch.get(branch);
+      if (!entry.claimants.includes(number)) entry.claimants.push(number);
+    }
+  }
+  const folds = new Map();
+  for (const branch of [...byBranch.keys()].sort()) {
+    const entry = byBranch.get(branch);
+    if (!entry.claimants.some((n) => n !== entry.head)) continue;
+    folds.set(branch, {
+      head: entry.head,
+      claimants: [...entry.claimants].sort((a, b) => a - b),
+    });
+  }
+  return folds;
+}
+
+/**
+ * Whether the fold headed by `head` is in flight, released, or unreadable —
+ * four-valued, because "open but not dispatched" and "closed" are the same
+ * RELEASE for a member's verdict while only the first can carry a row of its
+ * own.
+ *
+ * `unknown` is the #4690 state and is kept distinct from both: a head this
+ * sweep never listed cannot be reported as released, which would accuse every
+ * dispatched member of residue on the strength of a card nobody read.
+ */
+export function h37HeadState(head, openByNumber, closedByNumber) {
+  const n = Number(head);
+  const open = openByNumber?.get?.(n);
+  if (open) return labelNames(open).includes('pm:dispatched') ? 'in-flight' : 'open-undispatched';
+  return closedByNumber?.get?.(n) ? 'closed' : 'unknown';
+}
+
+/**
+ * The member classifier — asserted directly by the self-test, H35's idiom, so
+ * the three-way fold is pinned independently of any sentence it produces.
+ *
+ * @param {'in-flight'|'open-undispatched'|'closed'|'unknown'} headState
+ * @param {boolean} memberDispatched
+ * @returns {'undispatched-member'|'dispatched-residue'|'clean'|'unresolvable-head'}
+ */
+export function h37MemberVerdict(headState, memberDispatched) {
+  if (headState === 'unknown') return 'unresolvable-head';
+  if (headState === 'in-flight') return memberDispatched ? 'clean' : 'undispatched-member';
+  return memberDispatched ? 'dispatched-residue' : 'clean';
+}
+
+/** Which cards buy a member comment page — the gathering policy, exported like every other. */
+export function h37NeedsMemberRead(issue, foldsSeen) {
+  if (!((foldsSeen ?? 0) > 0)) return false;
+  const labels = labelNames(issue ?? {});
+  if (labels.includes('pm:dispatched')) return false;
+  return labels.includes('pm:queue');
+}
+
+/**
+ * Whether the member pass failed as a TRANSPORT rather than leaving a bounded
+ * gap — H16's judgement, shared in shape and deliberately not re-derived. Zero
+ * candidates is a clean reading (no fold was live, or the queue is empty), never
+ * a fault.
+ */
+export function h37MemberPassUnreadable(candidates, probed) {
+  return (candidates ?? 0) > 0 && (probed ?? 0) === 0;
+}
+
+/** `#N` for each fold member, capped at the render budget, + its note. */
+function namedMembers(numbers) {
+  const shown = numbers.slice(0, H37_MEMBER_LIST_CAP);
+  const named = shown.map((n) => `#${n}`).join(', ');
+  return `${named}${numbers.length > shown.length ? ` +${numbers.length - shown.length} more` : ''}`;
+}
+
+/**
+ * The rows. One per CARD whose own `pm:dispatched` disagrees with the fold it
+ * claims, keyed to that card because that is where the missing write belongs.
+ *
+ * A claimant this sweep did not list as open is skipped rather than judged: the
+ * roster is assembled from claim TEXT, and a number that resolves to nothing
+ * open here is not evidence of anything (H19's treatment of an absent
+ * resolution, and the same reason `h37HeadState` keeps `unknown` separate).
+ *
+ * @param {Map<string, { head: number, claimants: number[] }>} folds
+ * @param {Map<number, object>} openByNumber
+ * @param {Map<number, object>} closedByNumber
+ */
+export function h37FamilyMemberDrift(folds, openByNumber, closedByNumber) {
+  const rows = [];
+  for (const [branch, entry] of folds ?? new Map()) {
+    const head = entry?.head;
+    const headState = h37HeadState(head, openByNumber, closedByNumber);
+    if (headState === 'unknown') continue;
+    const members = (entry?.claimants ?? []).filter((n) => n !== head);
+    const dispatchedMembers = [];
+    const pending = [];
+    for (const n of members) {
+      const card = openByNumber?.get?.(n);
+      if (!card) continue;
+      const dispatched = labelNames(card).includes('pm:dispatched');
+      if (dispatched) dispatchedMembers.push(n);
+      pending.push([card, h37MemberVerdict(headState, dispatched)]);
+    }
+    for (const [card, verdict] of pending) {
+      if (verdict === 'undispatched-member') {
+        rows.push([
+          card,
+          `carries a family-dispatch member pointer at \`${branch}\` — the shared branch of the fold ` +
+            `headed by #${head}, which IS \`pm:dispatched\` — while this card carries none. The fold's ` +
+            'per-member label writes are separate calls with nothing tying them together, so a partial ' +
+            'run leaves the queue offering a card the fold already holds, and every per-card predicate ' +
+            'here reads it as clean. Patrol input, NOT a verdict — a claim may name another card\'s ' +
+            'branch for a reason that is not a fold (a cross-lane hand-off, a mistyped branch). Remedy: ' +
+            `re-read the fold's members off \`${branch}\` and write the missing half (assign + state in ` +
+            'ONE write), or correct the branch this claim names. Claimants seen on that branch: ' +
+            `${namedMembers(entry?.claimants ?? [])}.`,
+        ]);
+      } else if (verdict === 'dispatched-residue') {
+        rows.push([
+          card,
+          `still carries \`pm:dispatched\` while the fold it claims — \`${branch}\`, headed by #${head} ` +
+            `— has ${headState === 'closed' ? 'CLOSED' : 'released the state (open, no `pm:dispatched`)'}. ` +
+            'That is the same non-atomic family write failing in the MIRROR direction, and it reads to ' +
+            'every per-card predicate as an ordinary in-flight card. Patrol input, NOT a verdict — this ' +
+            'member may still have work of its own outstanding. Remedy: clear the residue in the write ' +
+            'that cleared the head (drop `pm:dispatched` and the assignee together — H24\'s ' +
+            '「同笔摘 assignee」), or re-dispatch it on its own card and its own branch if work remains. ' +
+            `Claimants seen on that branch: ${namedMembers(entry?.claimants ?? [])}.`,
+        ]);
+      }
+    }
+    if (headState === 'open-undispatched' && dispatchedMembers.length > 0) {
+      rows.push([
+        openByNumber.get(Number(head)),
+        `is the chain head of \`${branch}\` and carries NO \`pm:dispatched\`, while ` +
+          `${dispatchedMembers.length} card(s) claiming that branch do (${namedMembers(dispatchedMembers)}) ` +
+          '— the head\'s own half of the fold\'s label write is the one that did not land, and it is ' +
+          'visible ONLY from those members\' claims: nothing on this card says so. Patrol input, NOT a ' +
+          'verdict — the members may equally be pointing at the wrong branch. Remedy: confirm which ' +
+          'reading holds, then write the missing half here or correct the claims that name it.',
+      ]);
+    }
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
 // Report rendering — pure over (findings, counts), so `--self-test` pins both
 // media offline. The live sweep below picks a renderer and prints it; nothing
 // about WHAT is swept or WHICH predicates fire depends on the format.
@@ -6296,6 +6595,9 @@ export const SWEEP_COUNT_KEYS = [
   'conflictProbed',
   'sharedFileCandidates',
   'sharedFileProbed',
+  'liveFolds',
+  'memberReadCandidates',
+  'memberReadProbed',
   'fallbackCandidates',
   'fallbackProbed',
   'restartCandidates',
@@ -6468,6 +6770,18 @@ export function summaryLine(counts, findingCount) {
     `Shared-file holds (H36): changed-file page read on ${counts.sharedFileProbed ?? 0} of ` +
     `${counts.sharedFileCandidates ?? 0} open PR(s) — a pair needs both sides read, so a shortfall ` +
     'can only MISS a hold, never invent one. ' +
+    `Family folds (H37): ${counts.liveFolds ?? 0} live shared branch(es) claimed by more than their ` +
+    `own chain head, and a member comment page read on ${counts.memberReadProbed ?? 0} of ` +
+    `${counts.memberReadCandidates ?? 0} open \`pm:queue\` card(s) — that second read is bought ONLY ` +
+    'when a fold is live, so 0 of 0 is a board with no fold in flight rather than a pass that ' +
+    'skipped one, and an unread member can only MISS a drifted write, never invent one.' +
+    `${
+      h37MemberPassUnreadable(counts.memberReadCandidates, counts.memberReadProbed)
+        ? ' ⚠️ NO member page was readable on this run, so H37 saw a live fold and judged its queue ' +
+          'side on NOTHING — a quiet H37 section here is the transport, not a fold whose writes all ' +
+          'landed.'
+        : ''
+    } ` +
     `Report-only: findings are patrol input, not a gate verdict.`
   );
 }
@@ -8215,6 +8529,54 @@ async function sweepInto(findings, seen, seenPrs, seenMerged, seenUnscoped, seen
   // H19's, so the number cannot be misread as a per-card count.
   stats.dispatchRefTargets = refCache.size;
   stats.dispatchRefRead = [...refCache.values()].filter((r) => r.state !== 'unreadable').length;
+
+  // H37 (#12629) — the family-dispatch join, in two rounds (banner at the
+  // predicate). Placed HERE, after the dispatch-liveness loop, because round 1
+  // is exactly that loop's leftovers: `commentCache` now holds a thread for
+  // every open `pm:dispatched` card and every assigned pm-tracked card, so the
+  // fold roster costs no request at all.
+  const claimsOf = (rows, number) => {
+    const claim = governingClaim(rows);
+    return claim && (claim.branches ?? []).length > 0 ? { number, branches: claim.branches } : null;
+  };
+  const h37Claims = [];
+  for (const [number, rows] of commentCache) {
+    const entry = claimsOf(rows, number);
+    if (entry) h37Claims.push(entry);
+  }
+  // Round 2 — gated on round 1 having actually SEEN a fold (`h37NeedsMemberRead`),
+  // so a board with none costs nothing. `commentRowsFor` memoises, so a candidate
+  // already read above is counted as read and costs no second request; the pair
+  // therefore describes the POPULATION rather than only the new fetches.
+  const foldsSeen = h37FoldBranches(h37Claims).size;
+  for (const issue of seen.values()) {
+    if (!h37NeedsMemberRead(issue, foldsSeen)) continue;
+    stats.memberReadCandidates = (stats.memberReadCandidates ?? 0) + 1;
+    let rows;
+    try {
+      rows = await commentRowsFor(issue);
+    } catch {
+      // One member unread is one card out of the roster, never a report worth
+      // discarding — H32's posture, and the banner says why this pass does not
+      // rethrow the way H16's and H36's do. The coverage pair states the gap and
+      // the summary names an all-failed pass as the transport it is.
+      continue;
+    }
+    stats.memberReadProbed = (stats.memberReadProbed ?? 0) + 1;
+    const entry = claimsOf(rows, issue.number);
+    if (entry && !h37Claims.some((c) => c.number === entry.number)) h37Claims.push(entry);
+  }
+  // The roster is rebuilt over the UNION: a member found in round 2 can complete
+  // a fold round 1 saw only one side of, and judging the round-1 roster would
+  // discard exactly the card the second read was bought for.
+  const h37OpenByNumber = new Map();
+  for (const [number, issue] of seenUnscoped) h37OpenByNumber.set(number, issue);
+  for (const [number, issue] of seen) h37OpenByNumber.set(number, issue);
+  const h37Folds = h37FoldBranches(h37Claims);
+  stats.liveFolds = h37Folds.size;
+  for (const [card, drift] of h37FamilyMemberDrift(h37Folds, h37OpenByNumber, seenClosed)) {
+    findings.push([card, 'H37', drift]);
+  }
 
   // H19 — blocker liveness. Last, because it is the only pass that reads a
   // card this sweep did not list: every other item answers from a listing
@@ -12109,6 +12471,135 @@ function selfTest() {
   t('H36: both count keys ride the enumerated contract', SWEEP_COUNT_KEYS.includes('sharedFileCandidates') && SWEEP_COUNT_KEYS.includes('sharedFileProbed'), true);
   // The markdown medium renders an H36 row like every other finding row.
   t('markdown: an H36 row links the PR it names', renderMarkdown([[{ number: 100, html_url: 'https://example.test/100' }, 'H36', 'shares a file']], { repo: 'r', issues: 0, unscoped: 0, prs: 2, merged: 0 }).includes('- **H36** [#100](https://example.test/100)'), true);
+
+  // -- H37 — family-dispatch member drift (report-only patrol input, #12629) --
+  //
+  // The fixtures are the two MEASURED instances the filing card carries: a
+  // 3-card fold whose third member kept `pm:queue` while the fold ran, and the
+  // mirror — a member left `pm:dispatched` WITH its assignee after the head had
+  // released. Fold #11678 is the shape the live claim census records
+  // (「folded into the 11678 family dispatch」).
+  const FOLD_37 = 'claude/issue-11678-family-fold';
+  const h37card = (number, labels, assignees = ['os-litant']) => ({
+    number,
+    html_url: `https://example.test/${number}`,
+    labels: labels.map((name) => ({ name })),
+    assignees: assignees.map((login) => ({ login })),
+  });
+  const h37claim = (number, ...branches) => ({ number, branches });
+  const h37map = (...cards) => new Map(cards.map((c) => [c.number, c]));
+  const h37rows = (...args) => h37FamilyMemberDrift(...args);
+  // The wrapper discipline: a nulled row must report as a red CASE, never abort
+  // the suite while evaluating `t()`'s arguments.
+  const h37row1 = (...args) => String(h37FamilyMemberDrift(...args)[0]?.[1] ?? '');
+  const h37key1 = (...args) => h37FamilyMemberDrift(...args)[0]?.[0]?.number ?? null;
+  const foldClaims37 = [h37claim(11678, FOLD_37), h37claim(11679, FOLD_37), h37claim(11680, FOLD_37)];
+  const folds37 = h37FoldBranches(foldClaims37);
+  const headLive37 = h37card(11678, ['domain:skills', 'pm:dispatched']);
+
+  // The roster: what makes a branch a FOLD, and the one exclusion that is the
+  // whole noise floor.
+  t('H37 roster: two cards claiming one branch is a fold', folds37.size, 1);
+  t('H37 roster: …keyed to the shared branch', [...folds37.keys()][0], FOLD_37);
+  t('H37 roster: …whose head is the card the branch is named for', folds37.get(FOLD_37).head, 11678);
+  t('H37 roster: …and every claimant is on it, sorted', folds37.get(FOLD_37).claimants.join(','), '11678,11679,11680');
+  // ⛔ THE NOISE FLOOR — and it is the ordinary case: every solo dispatch on
+  // this board claims its own branch, so without this the row fires on all of them.
+  t('H37 roster: a claim naming its OWN branch is not a fold', h37FoldBranches([h37claim(11678, FOLD_37)]).size, 0);
+  t('H37 roster: …not even several of them', h37FoldBranches([h37claim(11678, FOLD_37), h37claim(9000, 'claude/issue-9000-solo')]).size, 0);
+  t('H37 roster: a lone FOREIGN claimant is already a fold (the head may be silent)', h37FoldBranches([h37claim(9999, 'claude/issue-8888-x')]).size, 1);
+  t('H37 roster: a branch with no readable card number is not a roster key', h37FoldBranches([h37claim(1, 'main'), h37claim(2, 'main')]).size, 0);
+  t('H37 roster: a duplicate claimant is counted once', h37FoldBranches([h37claim(11679, FOLD_37, FOLD_37)]).get(FOLD_37).claimants.length, 1);
+  t('H37 roster: no claims at all -> no folds', h37FoldBranches([]).size, 0);
+  t('H37 roster: a missing claim list does not crash', h37FoldBranches(undefined).size, 0);
+
+  // The head state — four-valued, because `unknown` must never read as released.
+  t('H37 head: dispatched and open -> in flight', h37HeadState(11678, h37map(headLive37), new Map()), 'in-flight');
+  t('H37 head: open without the label -> released, and separably so', h37HeadState(11678, h37map(h37card(11678, ['pm:queue'])), new Map()), 'open-undispatched');
+  t('H37 head: closed -> released', h37HeadState(11678, new Map(), h37map(h37card(11678, []))), 'closed');
+  t('H37 head: listed nowhere -> unknown, never released (#4690)', h37HeadState(11678, new Map(), new Map()), 'unknown');
+
+  // The classifier, asserted directly — H35's idiom, so the fold is pinned
+  // independently of any sentence it produces.
+  t('H37 verdict: fold in flight + member undispatched -> the missed write', h37MemberVerdict('in-flight', false), 'undispatched-member');
+  t('H37 verdict: fold in flight + member dispatched -> clean', h37MemberVerdict('in-flight', true), 'clean');
+  t('H37 verdict: head CLOSED + member dispatched -> residue', h37MemberVerdict('closed', true), 'dispatched-residue');
+  t('H37 verdict: head open-undispatched + member dispatched -> residue', h37MemberVerdict('open-undispatched', true), 'dispatched-residue');
+  t('H37 verdict: nothing dispatched anywhere -> clean (an abandoned fold is H30\'s)', h37MemberVerdict('open-undispatched', false), 'clean');
+  t('H37 verdict: an unresolvable head declines rather than accusing', h37MemberVerdict('unknown', true), 'unresolvable-head');
+
+  // ⭐ THE FINDING, direction 1 — the filing seat's own error: the fold ran and
+  // one member kept `pm:queue`, with no assignee, looking clean to every
+  // per-card predicate here.
+  const stranded37 = h37card(11680, ['domain:skills', 'pm:queue'], []);
+  const liveFold37 = [folds37, h37map(headLive37, h37card(11679, ['pm:dispatched']), stranded37), new Map()];
+  t('H37: a fold in flight with one member on `pm:queue` -> one row', h37rows(...liveFold37).length, 1);
+  t('H37: …keyed to the stranded member, not the head', h37key1(...liveFold37), 11680);
+  t('H37: …naming the shared branch', h37row1(...liveFold37).includes(FOLD_37), true);
+  t('H37: …and the chain head', h37row1(...liveFold37).includes('#11678'), true);
+  t('H37: …stating the non-verdict posture', h37row1(...liveFold37).includes('NOT a verdict'), true);
+  t('H37: …and naming the alternative reading a reader might find', h37row1(...liveFold37).includes('cross-lane hand-off'), true);
+  t('H37: …with the remedy as ONE write', h37row1(...liveFold37).includes('ONE write'), true);
+
+  // ⭐ THE FINDING, direction 2 — the MIRROR measured on this card's own round
+  // (#12200): the head released, the member kept `pm:dispatched` + assignee.
+  const residue37 = [
+    h37FoldBranches([h37claim(11679, FOLD_37)]),
+    h37map(h37card(11679, ['pm:dispatched'])),
+    h37map(h37card(11678, [])),
+  ];
+  t('H37 mirror: head closed + member still dispatched -> one row', h37rows(...residue37).length, 1);
+  t('H37 mirror: …keyed to the member carrying the residue', h37key1(...residue37), 11679);
+  t('H37 mirror: …and it says the head CLOSED', h37row1(...residue37).includes('CLOSED'), true);
+  t('H37 mirror: …naming it as the same write failing the other way', h37row1(...residue37).includes('MIRROR direction'), true);
+  const released37 = [
+    h37FoldBranches([h37claim(11679, FOLD_37)]),
+    h37map(h37card(11679, ['pm:dispatched']), h37card(11678, ['pm:queue'])),
+    new Map(),
+  ];
+  t('H37 mirror: an open head that dropped the label reads as released too', h37rows(...released37).length, 2);
+
+  // ⭐ THE FINDING, direction 3 — the HEAD's own half missed, visible from the
+  // members' claims and from nothing on the head's card.
+  const headMissed37 = h37rows(...released37).find(([card]) => card.number === 11678);
+  t('H37 head half: the undispatched head gets its own row', headMissed37 === undefined, false);
+  t('H37 head half: …and it says the members are the only witnesses', String(headMissed37?.[1] ?? '').includes('visible ONLY from'), true);
+  t('H37 head half: …counting the dispatched claimants', String(headMissed37?.[1] ?? '').includes('#11679'), true);
+
+  // Silence, in both directions — the halves that must NOT fire.
+  t('H37 silent: a fold whose members are all dispatched', h37rows(folds37, h37map(headLive37, h37card(11679, ['pm:dispatched']), h37card(11680, ['pm:dispatched'])), new Map()).length, 0);
+  t('H37 silent: a fold with nothing dispatched at all (abandoned, or not yet launched)', h37rows(folds37, h37map(h37card(11678, ['pm:queue']), h37card(11679, ['pm:queue']), h37card(11680, ['pm:queue'])), new Map()).length, 0);
+  t('H37 silent: an unresolvable head judges nothing', h37rows(folds37, h37map(h37card(11679, ['pm:queue']), h37card(11680, ['pm:queue'])), new Map()).length, 0);
+  t('H37 silent: a claimant this sweep never listed is skipped, not judged', h37rows(folds37, h37map(headLive37), new Map()).length, 0);
+  t('H37 silent: no folds -> no rows', h37rows(new Map(), h37map(headLive37), new Map()).length, 0);
+  t('H37 silent: a missing roster does not crash', h37rows(undefined, h37map(headLive37), new Map()).length, 0);
+
+  // The gathering policy: never wider than the fold population it is bought for.
+  t('H37 gate: a `pm:queue` card is read once a fold is live', h37NeedsMemberRead(h37card(9, ['pm:queue']), 1), true);
+  t('H37 gate: …and costs NOTHING on a board with no fold', h37NeedsMemberRead(h37card(9, ['pm:queue']), 0), false);
+  t('H37 gate: a dispatched card buys nothing (its thread is already read)', h37NeedsMemberRead(h37card(9, ['pm:dispatched']), 1), false);
+  t('H37 gate: a card in neither state is out of scope', h37NeedsMemberRead(h37card(9, ['pm:blocked']), 1), false);
+  t('H37 gate: a missing issue does not crash', h37NeedsMemberRead(undefined, 1), false);
+  t('H37 gate: an absent fold count is not a fold', h37NeedsMemberRead(h37card(9, ['pm:queue']), undefined), false);
+
+  // The transport judgement — H16's shape, on this pass's own pair.
+  t('H37: an all-failed member pass is the transport, not a fold whose writes landed', h37MemberPassUnreadable(40, 0), true);
+  t('H37: zero candidates is a clean reading (no fold was live)', h37MemberPassUnreadable(0, 0), false);
+  t('H37: a partial read is a bounded gap, not a failure', h37MemberPassUnreadable(40, 12), false);
+
+  // The render budget, H19/H20's cap and note.
+  const wide37 = h37FoldBranches([1, 2, 3, 4, 5, 6, 7].map((n) => h37claim(11670 + n, FOLD_37)));
+  t('H37: a wide fold names the cap and counts the rest', h37row1(wide37, h37map(h37card(11678, ['pm:dispatched']), h37card(11671, ['pm:queue'])), new Map()).includes(`+${7 - H37_MEMBER_LIST_CAP} more`), true);
+
+  // The coverage pair reaches the summary line, and degrades to 0.
+  t('H37 summary: the pair is reported', summaryLine({ liveFolds: 2, memberReadProbed: 38, memberReadCandidates: 40 }, 0).includes('member comment page read on 38 of 40'), true);
+  t('H37 summary: …and the fold count with it', summaryLine({ liveFolds: 2 }, 0).includes('2 live shared branch(es)'), true);
+  t('H37 summary: …stating the miss-only direction', summaryLine({}, 0).includes('never invent one'), true);
+  t('H37 summary: an all-failed pass is named as the transport', summaryLine({ liveFolds: 1, memberReadCandidates: 40, memberReadProbed: 0 }, 0).includes('NO member page was readable'), true);
+  t('H37 summary: …and 0 of 0 makes no such claim', summaryLine({}, 0).includes('NO member page was readable'), false);
+  t('H37: all three count keys ride the enumerated contract', ['liveFolds', 'memberReadCandidates', 'memberReadProbed'].every((k) => SWEEP_COUNT_KEYS.includes(k)), true);
+  // The markdown medium renders an H37 row like every other finding row.
+  t('markdown: an H37 row links the card it names', renderMarkdown([[{ number: 11680, html_url: 'https://example.test/11680' }, 'H37', 'member pointer without the label']], { repo: 'r', issues: 1, unscoped: 0, prs: 0, merged: 0 }).includes('- **H37** [#11680](https://example.test/11680)'), true);
 
   // -- The `[::]` collapse (#12090): behaviour-preserving, asserted as such ---
   // The class held U+003A TWICE, never the fullwidth U+FF1A its shape implied.


### PR DESCRIPTION
Fixes #12629

Adds **H37** to the half-state sweeper: a report-only patrol row for a family dispatch whose per-member label writes did not all land. Report-only, like every row in that file — it never writes a label, never fails a build, and its sentences say so. No existing row is weakened, renamed or re-gated; the diff is 491 added lines and 0 removed.

Based on merged `main` `d79c6025f`, which already carries H36; H37 is the next free row id.

## The predicate, and why the shared BRANCH is the whole join

The card asks to join two GitHub-side readings the patrol already makes: a **family-dispatch member pointer** on a card, or a card **named as a member in a live `Claim:` on another open card**, crossed with **that card not carrying `pm:dispatched`**.

Both halves are spelled by one string, and the protocol already writes it. The fold convention (`SKILL.md` step 4) is:

> 共享分支按链首卡命名,每张成员卡各留认领评论并点名该分支

— the shared branch is named for the chain head, and every member card leaves its own claim comment naming that branch (a member with no branch of its own is the design, not a half-state). So the roster lives in the `Branch:` directive this file has read since H20, through the existing `claimedBranches` / `governingClaim` / `branchNameTarget` helpers.

A card whose governing claim names `claude/issue-H-...` with H not its own number **is** the member pointer; a branch carrying at least one such claimant **is** a live fold; and the head is named by every member's claim, which is the second disjunct read from the other side. Nothing new is parsed.

**No prose scraping, deliberately.** A claim comment names sibling cards, serial-constraint predecessors and blocker targets as bare card refs in its own text — the claim on the filing card itself names the chain that held this script — so scanning claim prose for card numbers would manufacture members out of the one field the protocol fills in correctly. That is H20's standing call about branch spellings, applied here.

## Both directions, because both were measured

The grading comment on the card records a second instance, and a predicate reporting only the first would have said nothing about it. Per fold, the head's own state says whether the fold is in flight and every other claimant is read against it:

| head state | claimant state | verdict |
|---|---|---|
| `pm:dispatched` | no `pm:dispatched` | **undispatched-member** — the filing seat's own error: a member left on `pm:queue` while the fold ran |
| closed, or open without `pm:dispatched` | `pm:dispatched` | **dispatched-residue** — the mirror instance recorded this round, a member left dispatched with its assignee after the head released |
| open, no `pm:dispatched`, some claimant dispatched | — | the **head's** own half missed; the row lands on the head and is visible only from the members' claims |
| head in neither population | any | **unresolvable-head** — declines, H19's call, never a side picked |

A fold in which nothing is dispatched at all is deliberately quiet: it is indistinguishable from an abandoned or not-yet-launched fold, and those cards are already H30's population on their own terms. Under-report over fabricate.

## Noise floor: closed, one exclusion, and it is the ordinary case

A claim naming its **own** card's branch is not fold evidence. Every solo dispatch on this board writes exactly that, so without the exclusion the row would fire on every dispatched card in existence. Nothing else is suppressed by name — there is no per-incident exclusion list to grow, which is the discipline H36's closed noise floor states.

## Bound, and its honest half

- **Round 1 is free.** It reads the claim threads the sweep already holds: every open `pm:dispatched` card (the dispatch-liveness loop) and every assigned pm-tracked card (H2's fetch). Fold *discovery* therefore converges on the open `pm:dispatched` population, exactly as the card bounds it.
- **Round 2 buys one comment page per open `pm:queue` card, and only when round 1 saw a live fold.** A board with no fold in flight costs nothing; a board with one costs at most the queue page count (40 open `pm:queue` cards at the 2026-08-24 census H30 measured, against a 15,000/h core quota and four sweeps a day). `pm:queue` is bought because that is where the dispatchable-direction lie parks, and it is the one population no other item here reads.
- **Positive evidence only.** An unread member drops out of the roster — a miss, never an invention — and the coverage pair reports it. The pass does **not** rethrow, unlike H16's and H36's: those rows *are* their detail pass, while two of H37's three directions are free and already gathered, so discarding the sweep would cost more readings than it protects. An all-failed pass is named in the summary as the transport it is.

## Pins (+59 cases; 1456 to 1515, all green)

Roster and noise floor (10) · head state, four-valued so `unknown` never reads as released (4) · the classifier asserted directly, H35's idiom (6) · the firing shape for each of the three directions (14) · silence in both directions, six cases (6) · the gathering policy, never wider than the fold it is bought for (6) · the transport judgement (3) · the render budget cap (1) · the summary coverage pair and its all-failed warning (6) · count keys on the enumerated contract, and the markdown medium (3).

**A pin caught a real bug while being written.** `branchNameTarget` returns `null` for a branch it cannot read, and `Number(null)` is `0` — a perfectly finite head number for a card that does not exist. The first draft minted a phantom fold on every unreadable branch spelling, which would then have gated the round-2 member read on nothing. The null check is now separate from the finiteness check, with the reason stated at the line.

## Ablation — five legs, each proved failable from the committed state

Method per leg: anchored occurrence counts on disk **before and after** the mutation (never the editor's exit code), the self-test run under `scripts/pm/os-verify-lock.sh`, then restore with `git checkout HEAD -- ABSOLUTE_PATH` proved by `git hash-object` against the HEAD blob. `trap ... EXIT INT TERM` with absolute paths on every leg. HEAD blob `59c23c780b2b38e4ef79d1f0bd55ecc3d78a04c4`, matched after all five.

| leg | mutation | red cases |
|---|---|---|
| A1 | drop the self-claim exclusion | 2 — both noise-floor pins |
| A2 | in-flight member always `clean` | 9 — the classifier plus every direction-1 sentence pin |
| A3 | released head always `clean` | 7 — both residue verdicts and every mirror pin |
| A4 | transport judgement always `false` | 2 — the pair pin and the summary warning |
| A5 | drop the null head guard | 1 — the phantom-fold pin above |

A4 is worth naming: its **first** run was refused by its own on-disk check and reported as **not run**, because a multi-line anchor cannot be counted by `grep -cF` (which counts lines). It was re-run with an exact substring count taken by an independent reader of the file. The guard did its job; the reading in the table is from the second run.

## Verification — derived union at head `cc68909a0`, after the final commit

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-built path list; the script takes its own change set from the merge base) named 14 local gates plus the two convention obligations for a gate-script edit. All ran green, exit code captured before any pipe:

`check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check:entry-guard` · `check:parse-guard` · `check:partof-closing-keyword` · `check:pm-half-states` · `check:pnpm-filter-targets` · `check-ci-filter-parity` · `check-closing-keyword-parity` (self-test **and** live sweep) · `check-cross-package-test-inputs` · `check-partof-closing-keyword` · `bare-root-worklist --self-test` · `check:pm-dispatch-gates` · `check:nul-bytes` · `ci-failure --self-test` (an importer of this module, which no path derivation reaches) — every one `exit=0`.

`pnpm lint` (full repo, `eslint . --no-inline-config`) also ran green — no narrowing argument needed. Verdict lines are quoted from each gate's own output.

**Not measured here, stated rather than implied:** the live sweep `node scripts/pm/check-half-states.mjs` exits **3, PREREQUISITE NOT MET** in this container — repo-scoped REST reads answer 403 on this seat, which is the transport class that file's own header documents. That is a refusal to run, not a failed measurement, and the sweep's behaviour on a real board is unexercised locally by construction.

## No changeset

`scripts/pm/**` publishes nothing, and the two most recent rows in this same file (H35, H36) landed with no changeset. `skip-changeset` is applied to this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_