### PR TITLE
fix(pm): correct latestClaimComment's docblock specimen, and close the WORD-position question with a census

### DIFF
--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -5363,10 +5363,24 @@ export function isTriageRulingComment(body) {
  *
  * That narrowing is right for H20/H27, whose whole question is about the branch
  * a claim names. It would be wrong here and would silently empty this row's
- * population: the measured claim census carries 「Claim: PM loop round R6」 and
- * 「Claim pointer: folded into the 11678 family dispatch」 — well-formed claims
- * naming no branch of their own. What this row needs from a claim is only WHEN
- * it was written.
+ * population: the measured claim census carries 「Claim: PM loop round R6」 — a
+ * well-formed claim naming no branch of its own — and the shape is still live.
+ * Re-measured 2026-08-27 over 161 pm-tracked cards and every comment on them:
+ * of 19 canonical claim comments, 3 name no protocol-shaped branch, and on 3
+ * cards this row reads a claim `governingClaim` cannot (「Claim: PM loop round 1
+ * (QA wave #9296)」 is one). What this row needs from a claim is only WHEN it
+ * was written.
+ *
+ * ⛔ A second specimen used to stand beside the first — 「Claim pointer: folded
+ * into the 11678 family dispatch」, offered as another well-formed branchless
+ * claim. It is not one, and it is not in this row's population at all:
+ * `CLAIM_COMMENT_MARKER` wants the colon directly after the word, and here the
+ * word is followed by ` pointer`, so the marker has never matched it. Under the
+ * same 2026-08-11 ruling that governs the dash spellings it is a MALFORMED
+ * claim — and unlike those it is invisible to H34 as well, which reports only a
+ * punctuation separator (that gap was measured and deliberately left open; see
+ * H34's header). The paragraph's conclusion is unaffected: it rests on the
+ * first specimen, which is real, and on the live count above.
  *
  * ## ⚠️ The inherited blind spot, and what it is NOT (#12090)
  *
@@ -5531,6 +5545,46 @@ export function h33ClaimPredatesRuling(issue, commentRows) {
 //     content (a session reference, the word "seat", or a protocol-shaped
 //     branch anywhere in the comment) is silent. 「Claim - see above」 in prose
 //     is not evidence that a claim was attempted.
+//
+// ## The WORD position — measured 2026-08-27, and NOT widened
+//
+// A filed finding asked whether the separator class should cover a WORD where
+// the punctuation goes, on the strength of 「Claim pointer: folded into the
+// 11678 family dispatch」 — a string `latestClaimComment`'s header cited as a
+// claim the marker reads, which it never was. Measured before answering,
+// because the header above says this row's strictness was paid for once and
+// a widening is exactly what it was paid to prevent.
+//
+// The census: 161 pm-tracked cards — 13 open `pm:dispatched`, 76 open
+// `pm:queue`, 72 `pm:dispatched` closed since 2026-08-26 — and all 343 comments
+// on them, classified by what follows a line-opening claim word. 19 canonical
+// `Claim:`; 2 with a declared punctuation separator (both EM DASH, both on
+// threads with no canonical claim — this row's live population, and it fires);
+// and ZERO with a distinct word in the separator position. The 「Claim pointer:」
+// specimen occurs nowhere on the board: its only live instance is the finding
+// card quoting this file quoting it.
+//
+// So the widening buys nothing measurable, and it would spend the conservative
+// half's whole margin to buy it. `Claim` followed by a word is ordinary English
+// — 「Claiming this card」, 「Claim comments are …」 — where `Claim` followed by
+// an em dash is not; `looksLikeClaimContent` would carry that load for a
+// population of zero. RECORDED, NOT WIDENED.
+//
+// The same census found three OTHER shapes invisible to both markers, recorded
+// so a later reader can reopen the question on numbers instead of re-measuring
+// — and each is already harmless for a DIFFERENT reason, which is the actual
+// finding:
+//
+//   • 2 「Claim (dev): …」 openings. Both threads ALSO carry a canonical claim,
+//     so the first suppression above already covers them: they are a SECOND
+//     claim comment on a machine-visible card, never a substitute for one.
+//   • 2 inflected openings (「Claiming this card. session …」) and 1 decorated
+//     with backticks (「`Claim:` devx@objectstack seat …」). All three sit on
+//     UNASSIGNED cards, which this row and H2 both decline to judge — the
+//     residual already declared above.
+//
+// Three different shapes, three different reasons, none of them this one. Each
+// is its own question with its own noise floor if it ever acquires a population.
 // ---------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
Fixes #12656

Comment text only in `scripts/pm/check-half-states.mjs`. No predicate moves: the self-test reports **1515 cases** before and after, and `CLAIM_COMMENT_MARKER` / `CLAIM_NEAR_MISS_MARKER` are byte-identical to `origin/main`.

## Premise re-checked first

The card's own probe reproduces exactly against the shipped constants, with the canonical positive control:

```
CLAIM_COMMENT_MARKER  : false
CLAIM_NEAR_MISS_MARKER: false
nearMissClaimSeparators: []
governingClaim         : null
latestClaimComment     : null
control (canonical `Claim: PM loop round R6`): true
```

## Part 1 — the docblock specimen (mechanical)

`latestClaimComment`'s header offered two census specimens as well-formed claims naming no branch. The second, `Claim pointer: folded into the 11678 family dispatch`, is not in the marker's population: the marker wants the colon directly after the word, and there the word is followed by a space and `pointer`. The header now says what that string actually is — a malformed claim under the same 2026-08-11 ruling as the dash spellings, and invisible to H34 as well.

The paragraph's conclusion (do NOT narrow this row to branch-naming claims) is unchanged. It rests on the first specimen, which is real, and now on a fresh live count: of **19** canonical claim comments, **3** name no protocol-shaped branch, and on **3** cards `latestClaimComment` reads a claim `governingClaim` cannot — the population narrowing would silently empty. `Claim: PM loop round 1 (QA wave #9296)` is a live specimen of the same family as the original.

## Part 2 — the census, and the verdict: RECORD, DON'T WIDEN

No detector change. The measurement is recorded in H34's header, where the next author asking this question will be standing.

**Query set.** Populations enumerated via MCP `list_issues` (complete: `hasNextPage:false`, `totalCount` matching):

| Query | Count |
| --- | --- |
| `state:OPEN labels:[pm:dispatched]` | 13 |
| `state:OPEN labels:[pm:queue]` | 76 |
| `state:CLOSED labels:[pm:dispatched] since:2026-08-26` | 72 |

Comment bodies for all **161** cards (**343** comments) were read through the zero-quota public-payload channel, not MCP. Completeness of that channel was verified against MCP `get_comments` on the densest thread (#12661, 7 vs 7) and on an empty one (#12665, 0 vs 0); the deepest thread in the population is 7 comments, far below GitHub's timeline pagination threshold.

**Counts** — lines that BEGIN with the claim word (same anchor both markers use: optional indent, optional blockquote, the word), classified by what occupies the separator position:

| Shape | Count |
| --- | --- |
| canonical `Claim:` | 19 |
| declared punctuation separator (H34's four) | 2 (both EM DASH) |
| **a distinct WORD in the separator position** | **0** |
| inflection (`Claiming …`) | 2 |
| `(` — `Claim (dev): …` | 2 |
| markdown-decorated opening | 1 |

`Claim pointer` occurs on exactly **one** card in the whole population: #12656 itself, quoting this file quoting it. It is nowhere on the live board.

**Verdict.** The card's gate says a rare population means "record, don't widen". Zero of 343 is that, decisively. And the cost side is unchanged from what H34's header already warns about: `Claim` followed by a word is ordinary English, where `Claim` followed by an em dash is not, so widening would put `looksLikeClaimContent`'s conservative half under load it was never measured for — to buy a population of zero. `CLAIM_COMMENT_MARKER` is untouched either way (maintainer 2026-08-11: the literal `Claim:` is the single machine criterion).

**Three other invisible shapes the same census found**, recorded in the header with the reason each is already harmless — this is the part a later reader would otherwise have to re-measure to reopen the question:

- 2 `Claim (dev): …` openings — both threads ALSO carry a canonical claim, so H34's own first suppression covers them. They are a *second* claim comment on a machine-visible card, never a substitute.
- 2 inflections and 1 backtick-decorated opening — all three on **unassigned** cards, which H2 and H34 both decline to judge. That residual is already declared in H34's header.

So none of the five costs anything today, by three different mechanisms. No card filed: filing one would imply an action is owed where the measurement says none is. The numbers are in the header so the question can be reopened on evidence.

## Cut / pin accounting

No cuts. **No new pins**, and that is not an omission: both parts are comment text, nothing behaviourally reachable changed, and a pin can only assert behaviour. The existing pins are the guard that this is true — 1515 cases pass identically before and after, including the H33/H34 pins that fix these two markers' behaviour on the canonical, dash, fullwidth and prose-control specimens.

No changeset: `scripts/pm/**` publishes nothing (`skip-changeset` applied).

## Verification — all at commit `86cb2ff78`

Exit codes captured by redirect-then-capture, never read through a pipe. Verdict lines as the gates printed them:

- `check:pm-half-states` — `check-half-states self-test: 1515 cases pass.` (baseline before the edit: the same 1515)
- `check:pm-dispatch-gates` — `dispatch-gates self-test: 719 cases pass.` and `bare-root-worklist.mjs --self-test` — `46 live row(s) … none stale, none missing, none contradicted`: the two convention-triggered families for editing a gate script
- `check:nul-bytes` — `OK (scanned 7020 text file(s) … no raw ASCII control bytes)`
- `check:cross-package-test-inputs` — `All 117 self-test cases passed.` / `OK: 20 package(s)`
- `check:pnpm-filter-targets` — `140/177 --filter occurrence(s) … resolve`
- `check:agent-test-spelling`, `check:bash32-floor`, `check:cli-command-ids`, `check:entry-guard`, `check:parse-guard`, `check-ci-filter-parity.mjs`, `check-closing-keyword-parity.mjs`, `check-cross-package-test-inputs.mjs` — all exit 0
- Gate union derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (its stderr header names this worktree at `86cb2ff78`; it takes its own change set)
- `check-partof-closing-keyword.mjs` run against this very body via `PR_BODY` — `✓ this PR carries no Part-of/closing-keyword contradiction.` Without it the script reports NOT WIRED, which it declares is a usage failure and not a verdict
- Control-character scan of the edited file: `grep -naP` exit 1, zero hits
- This script has no vitest suite; its own test is `--self-test`, run above

**NOT MEASURED**, declared rather than implied: the live sweep `node scripts/pm/check-half-states.mjs` (no flag) cannot run in this container — repo-scoped REST returns 403 for the whole class from this seat. That is a refusal, not a red gate; the script is built to exit non-zero rather than let "could not read the input" look like "input is clean". Same disposition as PR #12655.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_