### PR TITLE
fix(spec): bound the DTS pass's heap ceiling to the build container's memory

### DIFF
--- a/.changeset/spec-dts-heap-ceiling-fits-container.md
+++ b/.changeset/spec-dts-heap-ceiling-fits-container.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/spec": patch
+---
+
+build(spec): bound the DTS pass's heap ceiling to something the build container actually has (#12677)
+
+The DTS pass ran under `NODE_OPTIONS="--max-old-space-size=12288"`. A heap
+ceiling is a promise to V8 that the memory exists: below it, V8 defers major GCs
+and lets the resident set grow. A ceiling **above** the container's memory does
+not permit a bigger build — it converts a recoverable JS heap error into a
+kernel SIGKILL, because the process meets the container limit long before V8
+considers the ceiling reached, and `exit 137` carries no diagnostic.
+
+That is what took the docs site down: every `objectstack.ai` production deploy
+since 2026-08-25 died with `@objectstack/spec:build` exit 137. Vercel builds the
+docs app with `turbo run build --filter=@objectstack/docs` inside one
+fixed-memory container, and this package is that app's only workspace
+dependency — so this pass met the container limit alone.
+
+The ceiling is now `6144`. Measured on this package's DTS pass inside a cgroup
+capped at 8192 MB, as peak anonymous RSS of the whole process tree:
+
+| ceiling | result | peak RSS | wall |
+|---|---|---|---|
+| 12288 (before) | ok, ~0.9 GB spare | 7290 MB | 132s |
+| 6144 (after) | ok, ~2.3 GB spare | 5794 MB | 134s |
+| 5120 | ok | 5328 MB | 148s |
+| 4096 | `ERR_WORKER_OUT_OF_MEMORY` | — | 113s |
+
+No output change: every completing ceiling emitted a byte-identical declaration
+tree (122 files, compared as one sha256 over all of them). The number buys
+headroom and costs GC time, not build time.
+
+Should the live type graph ever outgrow `6144`, the pass now fails **loud**
+with `ERR_WORKER_OUT_OF_MEMORY` instead of being killed silently. Raising the
+number past what the build container has would trade that diagnostic back for
+`exit 137`.

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -243,7 +243,7 @@
     "spec-changes.json"
   ],
   "scripts": {
-    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=12288\" BUILD_DTS=true tsup; fi && node ../../scripts/check-dts-emitted.mjs && node ../../scripts/check-dev-prereqs.mjs --stamp",
+    "build": "pnpm gen:schema && pnpm gen:openapi && tsup && if [ -z \"$OS_SKIP_DTS\" ]; then NODE_OPTIONS=\"--max-old-space-size=6144\" BUILD_DTS=true tsup; fi && node ../../scripts/check-dts-emitted.mjs && node ../../scripts/check-dev-prereqs.mjs --stamp",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "gen:schema": "OS_EAGER_SCHEMAS=1 tsx scripts/build-schemas.ts",

--- a/packages/spec/tsup.config.ts
+++ b/packages/spec/tsup.config.ts
@@ -138,7 +138,48 @@ const swapServerOnlyGrammarArm: Plugin = {
   },
 };
 
-// Generate DTS separately to avoid memory issues
+/**
+ * Generate DTS separately to avoid memory issues — this pass is by far the
+ * heaviest thing this package's build does, and `package.json` runs it under an
+ * explicit `--max-old-space-size` for a reason worth stating where the next
+ * author will look.
+ *
+ * ⚠️ THE HEAP CEILING MUST FIT THE SMALLEST CONTAINER THIS BUILD RUNS IN.
+ * `--max-old-space-size` is a promise to V8 that the memory is there: below it,
+ * V8 defers major GCs and lets the resident set grow. A ceiling ABOVE the
+ * container's memory therefore does not "allow a big build", it converts a
+ * recoverable JS heap error into a kernel SIGKILL — the process is killed at
+ * the container limit long before V8 ever considers the ceiling reached, and
+ * exit 137 carries no diagnostic at all.
+ *
+ * That is not hypothetical: at a 12288 ceiling this pass was killed on every
+ * Vercel docs deploy for two days (`@objectstack/spec:build` exit 137), because
+ * the docs site is built by `turbo run build --filter=@objectstack/docs` inside
+ * one fixed-memory build container and this package is its only workspace
+ * dependency — so this pass meets the container's limit ALONE, with no
+ * parallelism to cap.
+ *
+ * Measured on this package's DTS pass, inside a cgroup capped at 8192 MB
+ * (peak anonymous RSS of the whole process tree):
+ *
+ *     ceiling   result                        peak RSS   wall
+ *     12288     ok, but only ~0.9 GB spare     7290 MB    132s
+ *      6144     ok                             5794 MB    134s
+ *      5120     ok                             5328 MB    148s
+ *      4096     ERR_WORKER_OUT_OF_MEMORY          —       113s
+ *
+ * 6144 is chosen as the largest ceiling whose WORST case still fits: V8 cannot
+ * exceed it, and the pass's non-heap overhead measured ~250 MB, so the bound is
+ * ~6.4 GB inside an 8 GB container. Every completing ceiling emitted a
+ * byte-identical declaration tree (122 files, one sha256 over all of them), so
+ * this number buys headroom and costs nothing but GC time.
+ *
+ * If this pass starts failing with `ERR_WORKER_OUT_OF_MEMORY`, the live type
+ * graph has outgrown 6144 — that is a loud, actionable failure and the point of
+ * the ceiling. ⛔ Do not "fix" it by raising the number past what the build
+ * container has; that trades this error back for the silent exit 137. Shrink
+ * the graph, or split the pass across entries.
+ */
 const isDts = process.env.BUILD_DTS === 'true';
 
 const mainConfig: Options = {


### PR DESCRIPTION
Fixes #12677

## What was wrong

`packages/spec`'s build ran its DTS pass under `NODE_OPTIONS="--max-old-space-size=12288"` — a **12 GB heap ceiling inside an ~8 GB build container**.

A heap ceiling is a promise to V8 that the memory is there: below it, V8 defers major GCs and lets the resident set grow. A ceiling *above* the container's memory therefore does not permit a bigger build — it converts a recoverable JS heap error into a kernel SIGKILL. The process meets the container limit long before V8 ever considers the ceiling reached, and `exit 137` carries no diagnostic. That is precisely the signature in the card's Vercel log, on precisely the process it names.

## The change

One number, plus its reasoning and a changeset:

- `packages/spec/package.json` — the DTS pass's ceiling, `12288` to `6144`.
- `packages/spec/tsup.config.ts` — the rationale recorded next to the DTS split it governs, with the measurements below, so the next author who hits `ERR_WORKER_OUT_OF_MEMORY` does not "fix" it by raising the number past what the container has.
- `.changeset/spec-dts-heap-ceiling-fits-container.md`.

No source, no schema, no build output changes.

## Measured — method

Peak **anonymous RSS of the whole process tree**, sampled from a cgroup-v1 `memory.stat` `total_rss` at 150 ms with per-process attribution recorded at each new peak. The harness was validated in both directions before any number below was trusted: a positive control (600 MB allocation under an 8 GB cap completes, measured 589 MB) and a negative control (2 GB allocation under a 1 GB cap reproduces `exit 137` with `oom_kill=1`).

The container emulation is **two halves**, because a cgroup cap alone is not a container — it bounds what a process may use without changing what it *believes* it has. So the runs marked "faithful" add a private mount namespace whose `/proc/meminfo` reports the container's size, and tools that size themselves from reported memory then see 8 GB rather than this host's 16 GB.

## Measured — before / after

Spec's DTS pass, in a faithful 8192 MB container:

| ceiling | result | peak RSS | wall |
|---|---|---|---|
| **12288 (before)** | ok | **6965 MB** | 126s |
| **6144 (after)** | ok | **5654 MB** | 124s |

**−1311 MB (−19%) on the phase that was being killed, at no wall-time cost.**

The cap sweep that chose 6144 (cgroup cap only, so the numbers run slightly higher):

| ceiling | result | peak RSS | wall |
|---|---|---|---|
| 12288 | ok | 7290 MB | 132s |
| 6144 | ok | 5794 MB | 134s |
| 5120 | ok | 5328 MB | 148s |
| 4096 | `ERR_WORKER_OUT_OF_MEMORY` | — | 113s |

6144 is chosen as the largest ceiling whose **worst** case still fits: V8 cannot exceed it, and this pass's non-heap overhead measured ~250 MB, so the bound is ~6.4 GB inside an 8 GB container — while leaving 1.5x growth room above the 4096 floor before the pass reds. Below the ceiling it now fails **loud** (`ERR_WORKER_OUT_OF_MEMORY`, exit 1) instead of being SIGKILLed, which is what the card asked for.

Whole pipeline, `pnpm turbo run build --filter=@objectstack/docs --force` from a cleaned `dist`/`.next`, faithful emulation, with this fix: **2 successful, 2 total, 5m02s**, peak 8135 MB.

## Output identity — this buys headroom, not a different build

Every completing ceiling emitted a **byte-identical declaration tree**: 122 files, compared as one sha256 over all of them, `37cf1007189f945c` at both 6144 and 5120. Declarations were deleted before each run so a hash could not be satisfied by leftovers (the DTS pass runs with `clean: false`). `check-dts-emitted` reports 34/34 declared declaration files present.

## Lever 1 (cap turbo concurrency) — ruled out by measurement, not skipped

`pnpm turbo run build --filter=@objectstack/docs --dry=json` reports **2 tasks**: `@objectstack/spec#build` and `@objectstack/docs#build`. The docs app's only workspace dependency is spec, so the two run **sequentially**. There is no parallel fan-out for `--concurrency` to cap, and the killed process was alone in the container when it died — capping concurrency would have changed nothing. The build command is versioned in `apps/docs/vercel.json`, so this was checkable in-repo; no dashboard-only configuration was involved in the command itself.

## Lever 3 (name the regression)

No commit lands in the 16:52–16:57 window. The last change to spec's type surface before the failure boundary is `daae7aa3` at 16:13 on 2026-08-25 — "declare the search and data.clone route response contracts" — which adds schemas and so grows the DTS type graph. Offered as the most plausible straw, **not proven**: the honest reading is that the configuration was one growth-step from this outage the whole time, sitting at ~7.0 GB with under 1 GB of spare in the container. Which commit crossed the line matters much less than that the ceiling was set above the container at all.

## Residual risk, filed separately

This PR fixes the phase that was failing. It does **not** lower the *pipeline's* peak, which is owned by the other phase: `next build` holds ~7.6 GB in a single process, and neither `--max-old-space-size` (Turbopack is Rust; its memory is outside V8) nor `experimental.cpus` (the workers measure 100–430 MB each) bounds it. That phase has been building successfully on Vercel at this size for weeks, so it is a standing risk rather than a live failure — but it is now the largest consumer in the pipeline and nothing in this repo bounds it. Measured and filed as #12683, with the options laid out; it needs a maintainer decision, not a rider on this fix.

## Verification

Gates run at `a0a64684` on a clean tree — 30 derived families, all green, plus `check:nul-bytes` and `@objectstack/spec typecheck`. Two produced no reading rather than a failure and are recorded as such: `check-dev-prereqs` reports an unmet precondition (this worktree built only spec and docs, not all 67 packages), and `scripts/pm/check-half-states.mjs` exits 3 stating "no reading at all" without a GitHub token. Repository-wide lint is left to CI.

After merge, per the card:

```
curl -s https://objectstack.ai/ | grep -o 'data-dpl-id="[^"]*"'
```

must report an id other than `dpl_2nfWjGjSwZjakVEmUG1kBWD6697r`.

Refs: #12333 (measurement card) · epic #12243 · follow-up #12683

_Generated by [Claude Code](https://claude.ai/code/session_01DKWDdUJ2XNRESVVWUvcpnh)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKWDdUJ2XNRESVVWUvcpnh)_