### PR TITLE
fix(driver-sql,platform-objects): the builtin-column delivery table speaks the spec's field-type vocabulary, not knex's builder names (#12131)

### DIFF
--- a/.changeset/builtin-column-collision-warning.md
+++ b/.changeset/builtin-column-collision-warning.md
@@ -38,8 +38,11 @@ only when the declaration asks for storage the platform's own column does not de
 (a differing `type`, a `maxLength`, `unique`, `defaultValue`, `storage.notNull`, a
 `multiple` shape…) and stays silent when it does not: `created_at: { type: 'datetime',
 defaultValue: 'NOW()' }` describes precisely what lands, and says nothing.
-`id: { type: 'number' }` — an author expecting a numeric key — still fires, as does
-`id: { type: 'text' }`. The storage/presentation split is one table
+`id: { type: 'number' }` — an author expecting a numeric key — still fires.
+`id: { type: 'text' }` does **not**: varchar(255) canonicalizes to the field type
+`text`, so that declaration asks for precisely what the column delivers (#12131 —
+the delivery table recorded the knex builder name `'string'` there at first, and
+reported all 45 of the platform's own correct `id` declarations as disagreements). The storage/presentation split is one table
 (`builtin-column-collision.ts`) pinned against `FieldSchema.shape`, so a field key
 added later is classified deliberately instead of defaulting into silence.
 

--- a/.changeset/builtin-column-delivery-id-type.md
+++ b/.changeset/builtin-column-delivery-id-type.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/driver-sql": patch
+"@objectstack/platform-objects": patch
+---
+
+fix(driver-sql): the builtin-column delivery table speaks the spec's field-type vocabulary, not knex's builder names (#12131)
+
+`BUILTIN_COLUMN_DELIVERY.id.type` recorded `'string'` — the **knex builder name** from
+`table.string('id').primary()` — and `undeliveredStorageAttributes` compares that value
+with `===` against a declaration's `type`, which is a spec `FieldType`. The two are
+different vocabularies, and `'string'` is not a member of the one being compared: it is
+absent from `FieldType`'s 49 options, `Field.string` is absent from the builder's keys,
+and `FieldSchema` refuses `type: 'string'` outright. So **no declaration could ever
+match it**, and the #12015 diagnostic reported every correct declaration on the
+platform's own key as a disagreement.
+
+Measured on a stock boot of `@objectstack/platform-objects`: **45 warnings, one per
+system object**, each saying `type: 'text' (the column is 'string')` about a
+declaration that was right all along. `varchar` canonicalizes to the field type `text`
+(`canonicalizeSqlType('varchar(255)') === 'text'`, `suggestFieldTypeForSqlType('varchar(255)') === 'text'`,
+`isCompatible('varchar(255)', 'text') === true` — all pinned in `type-compat.test.ts`),
+so `id: Field.text(...)` asks for exactly what the platform's column delivers. The
+delivery table now records `text`, and the 45 lines go silent because they were false,
+not because they were suppressed.
+
+`sys_migration.id`'s `maxLength: 128` was the one **honest** disagreement in that corpus
+— the column is varchar(255) — and it is removed rather than widened to 255. It bound
+nothing in any seam: the DDL discards a declared width on a builtin column name, and
+`validateRecord` skips `id` by name on both the insert and the update path (it is also
+`readonly`). Declaring a width that nothing enforces is the shape enforce-or-remove
+exists to prevent, and the 44 sibling system objects declare none.
+
+The classification pin now holds **every** entry in the delivery table to
+`FieldType.options`, so a builder name written there fails by name instead of surfacing
+as a corpus of false warnings. The fixtures in both #12015 pin files were written
+against the delivery table rather than against the source — `sys_presence.id` was spelled
+`type: 'string'` in the "silent" cases, which is why they passed while the same
+declaration as actually written warned. They now use the shapes as declared, and the
+firing cases declare a type that genuinely disagrees.
+
+**Grade: `patch` for both, and deliberately.** No door moves and no DDL changes: the
+platform still owns `id` / `created_at` / `updated_at`, the emitted column is
+byte-identical, every object that booted before still boots, and `BUILTIN_COLUMN_DELIVERY`
+is internal to the package (it is not re-exported from the package entry). The
+`platform-objects` half removes one metadata key that was measured inert in every seam
+that could read it. What changes is what the driver **says**.

--- a/packages/drivers/driver-sql/src/builtin-column-collision.test.ts
+++ b/packages/drivers/driver-sql/src/builtin-column-collision.test.ts
@@ -17,10 +17,19 @@
  *    own column already provides is NOT a disagreement and must not be
  *    reported as one — that is the whole content of the 2026-08-25 narrowing,
  *    and the case that makes the message true again.
+ *
+ * ③ **The delivery table speaks the SPEC's vocabulary** (#12131). Its `type`
+ *    is compared with `===` against a declaration's `type`, so a knex builder
+ *    name there is a cross-vocabulary comparison that no declaration can
+ *    satisfy. `id` used to record `'string'` — the `table.string('id')`
+ *    builder name — and reported all 45 correct `id: Field.text(...)`
+ *    declarations in `@objectstack/platform-objects` as disagreements while
+ *    `'string'` was not even authorable. The first case below now holds every
+ *    entry to `FieldType`, so the class fails by name rather than by corpus.
  */
 
 import { describe, it, expect } from 'vitest';
-import { FieldSchema } from '@objectstack/spec/data';
+import { FieldSchema, FieldType } from '@objectstack/spec/data';
 import {
   FIELD_KEY_STORAGE_CLASS,
   BUILTIN_COLUMN_DELIVERY,
@@ -60,10 +69,30 @@ describe('the FieldSchema storage/presentation classification (#12015)', () => {
     }
   });
 
+  it('⛔ spells every delivered `type` in the SPEC vocabulary, never a knex builder name (#12131)', () => {
+    // The one that got away: `id` recorded `'string'`, the knex builder name,
+    // and `undeliveredStorageAttributes` compares it with `===` against a
+    // declaration's `type` — a spec `FieldType`. No declaration could match it
+    // (`'string'` is absent from FieldType's 49 members and `FieldSchema`
+    // refuses it), so every correct `id: Field.text(...)` was reported as a
+    // disagreement: 45 of them on a stock boot of platform-objects.
+    for (const [column, delivery] of Object.entries(BUILTIN_COLUMN_DELIVERY)) {
+      expect(
+        FieldType.options as readonly string[],
+        `BUILTIN_COLUMN_DELIVERY.${column}.type must be a spec FieldType, not a builder name`,
+      ).toContain(delivery.type);
+    }
+  });
+
   it('records what each builtin column actually delivers, read off the emitting lines', () => {
-    // `table.string('id').primary()` — varchar(255), NOT NULL, unique, no default.
+    // `table.string('id').primary()` — varchar(255), NOT NULL, unique, no
+    // default. varchar canonicalizes to the field type `text`
+    // (`canonicalizeSqlType('varchar(255)') === 'text'`, pinned in
+    // `type-compat.test.ts`), so `text` is what this column DELIVERS — which
+    // is why the platform's own `id: Field.text(...)` declarations agree with
+    // it exactly (#12131).
     expect(BUILTIN_COLUMN_DELIVERY.id).toMatchObject({
-      type: 'string', maxLength: 255, unique: true, notNull: true, defaultValue: null,
+      type: 'text', maxLength: 255, unique: true, notNull: true, defaultValue: null,
     });
     // `createAuditTimestampColumn` — a timestamp defaulted to the DB clock, left NULLABLE.
     for (const column of ['created_at', 'updated_at']) {
@@ -76,22 +105,30 @@ describe('the FieldSchema storage/presentation classification (#12015)', () => {
 
 describe('what a declaration on a builtin column name loses (#12015)', () => {
   it('FIRES on the author error the card was filed for', () => {
-    // `id: { type: 'number' }` — an author expecting a numeric key.
+    // `id: { type: 'number' }` — an author expecting a numeric key. This is
+    // the real author error; ⛔ NOT `{ type: 'text' }`, which is what the
+    // column delivers (see the silent case below).
     expect(keysOf(undeliveredStorageAttributes('id', { type: 'number' }))).toEqual(['type']);
-    // The #11456 fixture's shape.
-    expect(keysOf(undeliveredStorageAttributes('id', { type: 'text', name: 'id' }))).toEqual(['type']);
+    expect(keysOf(undeliveredStorageAttributes('id', { type: 'number', name: 'id' }))).toEqual(['type']);
     // …and names what the column really is, not just that something was lost.
-    expect(undeliveredStorageAttributes('id', { type: 'text' })[0]).toMatchObject({
-      key: 'type', declared: 'text', delivered: 'string',
+    expect(undeliveredStorageAttributes('id', { type: 'number' })[0]).toMatchObject({
+      key: 'type', declared: 'number', delivered: 'text',
     });
   });
 
   it('is SILENT for a presentation-only declaration — the platform honours that half', () => {
     // `sys_presence.id`, verbatim in shape: the population the pre-narrowing
-    // warning was false about.
+    // warning was false about. ⚠️ It is `Field.text`, and this fixture used to
+    // spell it `type: 'string'` — matching the delivery table's builder name
+    // rather than the source. That made this case pass while the same
+    // declaration as actually written warned (#12131). Verbatim now.
     expect(
-      undeliveredStorageAttributes('id', { type: 'string', label: 'Presence ID', required: true, readonly: true }),
+      undeliveredStorageAttributes('id', { type: 'text', label: 'Presence ID', required: true, readonly: true }),
     ).toEqual([]);
+    // The #11456 fixture's exact shape — the declaration that started #12015.
+    // It asks for precisely what the column delivers, so it is SILENT; it was
+    // reported as a disagreement until the delivery table was corrected.
+    expect(undeliveredStorageAttributes('id', { type: 'text', name: 'id' })).toEqual([]);
     expect(
       undeliveredStorageAttributes('created_at', {
         type: 'datetime', label: 'Created At', defaultValue: 'NOW()', readonly: true,
@@ -100,21 +137,21 @@ describe('what a declaration on a builtin column name loses (#12015)', () => {
   });
 
   it('is SILENT for a storage attribute the column already delivers', () => {
-    expect(undeliveredStorageAttributes('id', { type: 'string', maxLength: 255 })).toEqual([]);
-    expect(undeliveredStorageAttributes('id', { type: 'string', unique: true })).toEqual([]);        // the PK is unique
-    expect(undeliveredStorageAttributes('id', { type: 'string', storage: { notNull: true } })).toEqual([]); // the PK is NOT NULL
+    expect(undeliveredStorageAttributes('id', { type: 'text', maxLength: 255 })).toEqual([]);
+    expect(undeliveredStorageAttributes('id', { type: 'text', unique: true })).toEqual([]);        // the PK is unique
+    expect(undeliveredStorageAttributes('id', { type: 'text', storage: { notNull: true } })).toEqual([]); // the PK is NOT NULL
     expect(undeliveredStorageAttributes('created_at', { type: 'datetime', defaultValue: 'now()' })).toEqual([]); // token, case-insensitive
   });
 
   it('FIRES for a storage attribute the column does NOT deliver, one entry each', () => {
-    expect(keysOf(undeliveredStorageAttributes('id', { type: 'string', maxLength: 12 }))).toEqual(['maxLength']);
-    expect(keysOf(undeliveredStorageAttributes('id', { type: 'string', defaultValue: 'NOW()' }))).toEqual(['defaultValue']);
+    expect(keysOf(undeliveredStorageAttributes('id', { type: 'text', maxLength: 12 }))).toEqual(['maxLength']);
+    expect(keysOf(undeliveredStorageAttributes('id', { type: 'text', defaultValue: 'NOW()' }))).toEqual(['defaultValue']);
     // created_at IS nullable and NOT unique — asking for either is a real disagreement.
     expect(keysOf(undeliveredStorageAttributes('created_at', { type: 'datetime', unique: true }))).toEqual(['unique']);
     expect(keysOf(undeliveredStorageAttributes('created_at', { type: 'datetime', storage: { notNull: true } })))
       .toEqual(['storage.notNull']);
     // Several at once, in declaration order.
-    expect(keysOf(undeliveredStorageAttributes('id', { type: 'text', maxLength: 12, unique: false })))
+    expect(keysOf(undeliveredStorageAttributes('id', { type: 'number', maxLength: 12, unique: false })))
       .toEqual(['type', 'maxLength']);   // `unique: false` asks for nothing
   });
 
@@ -125,7 +162,7 @@ describe('what a declaration on a builtin column name loses (#12015)', () => {
   it('stays silent — never throws — on a key it does not know, and on a malformed declaration', () => {
     // Forward compatibility: an unclassified key cannot invent a warning. The
     // exhaustiveness case above is what makes its arrival visible.
-    expect(undeliveredStorageAttributes('id', { type: 'string', someFutureKey: 'x' } as any)).toEqual([]);
+    expect(undeliveredStorageAttributes('id', { type: 'text', someFutureKey: 'x' } as any)).toEqual([]);
     expect(undeliveredStorageAttributes('id', undefined)).toEqual([]);
     expect(undeliveredStorageAttributes('id', null as any)).toEqual([]);
   });

--- a/packages/drivers/driver-sql/src/builtin-column-collision.ts
+++ b/packages/drivers/driver-sql/src/builtin-column-collision.ts
@@ -158,7 +158,8 @@ export const FIELD_KEY_STORAGE_CLASS: Readonly<Record<string, FieldKeyClass>> = 
  *
  *   - `id`         — `table.string('id').primary()`: varchar(255), NOT NULL,
  *                    PRIMARY KEY (so: unique), no column default (the engine
- *                    generates the key).
+ *                    generates the key). varchar canonicalizes to the field
+ *                    type `text`, which is what the table below records.
  *   - `created_at` / `updated_at` — `createAuditTimestampColumn`: a timestamp
  *                    (MySQL `datetime(3)`) defaulted to the database clock,
  *                    left NULLABLE and stamped by the driver on every write.
@@ -168,7 +169,24 @@ export const FIELD_KEY_STORAGE_CLASS: Readonly<Record<string, FieldKeyClass>> = 
  * defaultValue: 'NOW()' }` describes precisely what lands.
  */
 export interface BuiltinColumnDelivery {
-  /** The field type whose column this builtin actually is. */
+  /**
+   * The field type whose column this builtin actually is, spelled in the
+   * SPEC's `FieldType` vocabulary — because that is the vocabulary a
+   * declaration's `type` is written in, and this value is compared against it
+   * with `===`.
+   *
+   * ⛔ NEVER the knex builder name. `id` is emitted by `table.string('id')`,
+   * but knex's `string` IS varchar(255), and `canonicalizeSqlType('varchar(255)')`
+   * is `'text'` — so the field type this column delivers is `'text'`, and
+   * `isCompatible('varchar(255)', 'text')` is EXACT (both pinned in
+   * `type-compat.test.ts`). Spelling the builder name here compares two
+   * vocabularies and reports every correct `id: Field.text(...)` declaration
+   * as a disagreement: measured at 45 false warnings on a stock boot of
+   * `@objectstack/platform-objects`, on declarations that were right all
+   * along. `'string'` is not even authorable — it is absent from `FieldType`'s
+   * members and `FieldSchema` refuses it — so no declaration could have
+   * silenced it.
+   */
   type: string;
   /** Fixed varchar width, when the column is bounded. */
   maxLength?: number;
@@ -181,7 +199,10 @@ export interface BuiltinColumnDelivery {
 }
 
 export const BUILTIN_COLUMN_DELIVERY: Readonly<Record<string, BuiltinColumnDelivery>> = Object.freeze({
-  id: Object.freeze({ type: 'string', maxLength: 255, unique: true, notNull: true, defaultValue: null }),
+  // `table.string('id')` is knex's varchar(255); the FIELD TYPE it delivers is
+  // `text` (see the vocabulary note on `BuiltinColumnDelivery.type` — do not
+  // put the builder name back here).
+  id: Object.freeze({ type: 'text', maxLength: 255, unique: true, notNull: true, defaultValue: null }),
   created_at: Object.freeze({ type: 'datetime', unique: false, notNull: false, defaultValue: 'NOW()' as const }),
   updated_at: Object.freeze({ type: 'datetime', unique: false, notNull: false, defaultValue: 'NOW()' as const }),
 });

--- a/packages/drivers/driver-sql/src/sql-driver-12015-builtin-column-collision-warning.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-12015-builtin-column-collision-warning.test.ts
@@ -7,9 +7,18 @@
  * `initObjects` emits `id`, `created_at` and `updated_at` itself, then skips
  * any declared field colliding with one. The driver is right to own its
  * primary key and audit stamps; the defect was that it disagreed with the
- * author without saying so — an object declaring `id: { type: 'text' }` boots
- * green and gets `varchar(255)`, and nothing recorded that the declared type
- * was discarded.
+ * author without saying so — an object declaring `id: { type: 'number' }`
+ * boots green and gets `varchar(255)`, and nothing recorded that the declared
+ * type was discarded.
+ *
+ * ⚠️ #12131: that example used to read `id: { type: 'text' }`, and so did most
+ * of the firing fixtures below. It was the wrong example — varchar(255)
+ * canonicalizes to the field type `text`, so `{ type: 'text' }` asks for
+ * exactly what lands. The delivery table recorded the knex builder name
+ * `'string'` instead, which no declaration could match, and the fixtures were
+ * written to that table rather than to the source. The firing cases now
+ * declare a type that genuinely disagrees; the agreeing shapes are pinned
+ * SILENT.
  *
  * Maintainer ruling 2026-08-25, twice: a **named, loud load-time warning** on
  * all three paths that drop such a declaration, then **narrowed** to the
@@ -83,8 +92,10 @@ describe('a declared field colliding with a builtin column is named at load time
       {
         name: 'collide_create',
         fields: {
-          // The #11456 fixture's exact shape — the declaration that started this card.
-          id: { type: 'text', name: 'id' },
+          // An author expecting a numeric key. (⛔ Not the #11456 shape
+          // `{ type: 'text', name: 'id' }` — that asks for what the column
+          // delivers and is pinned SILENT in the narrowing case below.)
+          id: { type: 'number', name: 'id' },
           region: { type: 'text' },
         },
       },
@@ -97,7 +108,7 @@ describe('a declared field colliding with a builtin column is named at load time
     expect(lines[0]).toContain("declared field 'id'");
     expect(lines[0]).toContain('collide_create');
     expect(lines[0]).toContain("asks for storage the platform's own 'id' column does not provide");
-    expect(lines[0]).toContain("type: 'text' (the column is 'string')");
+    expect(lines[0]).toContain("type: 'number' (the column is 'text')");
     // ⛔ And it must NOT deny the half that IS applied, nor advise deleting it.
     expect(lines[0]).toContain('is honoured as written');
     expect(lines[0]).not.toContain('Remove the declaration');
@@ -114,7 +125,7 @@ describe('a declared field colliding with a builtin column is named at load time
       {
         name: 'collide_three',
         fields: {
-          id: { type: 'text' },            // text ≠ the varchar(255) key
+          id: { type: 'number' },          // a numeric key ≠ the varchar(255) key
           created_at: { type: 'date' },    // date ≠ the timestamp column
           updated_at: { type: 'datetime', unique: true }, // the audit column carries no uniqueness
           // Declared, colliding, and losing NOTHING — the platform's column is
@@ -163,7 +174,7 @@ describe('a declared field colliding with a builtin column is named at load time
       {
         name: 'collide_rot',
         fields: {
-          id: { type: 'text' },
+          id: { type: 'number' },
           payload: { type: 'text' },
           // Declared AND colliding, but it describes the column the platform
           // emits — so it must not appear below.
@@ -187,12 +198,16 @@ describe('a declared field colliding with a builtin column is named at load time
   it('THE NARROWING, end-to-end: a presentation-only declaration boots in silence', async () => {
     // `sys_presence` in shape — the population the pre-narrowing warning fired
     // on 116 times per stock boot of platform-objects while telling the author
-    // something untrue about it.
+    // something untrue about it. ⚠️ #12131: `sys_presence.id` is `Field.text`,
+    // and this fixture used to spell it `type: 'string'` to match the delivery
+    // table's builder name. So it passed while the declaration as actually
+    // written warned — the 45 lines this file's own narrowing was supposed to
+    // have silenced. Verbatim now, and `id` below is the load-bearing half.
     await driver.initObjects([
       {
         name: 'collide_presentation',
         fields: {
-          id: { type: 'string', label: 'Presence ID', required: true, readonly: true },
+          id: { type: 'text', label: 'Presence ID', required: true, readonly: true },
           created_at: { type: 'datetime', label: 'Created At', defaultValue: 'NOW()', readonly: true },
           updated_at: { type: 'datetime', label: 'Updated At', defaultValue: 'NOW()', readonly: true },
           status: { type: 'text' },
@@ -218,8 +233,8 @@ describe('a declared field colliding with a builtin column is named at load time
       {
         name: 'collide_accept',
         // A declaration that asks for something quite different from what the
-        // platform emits: TEXT, plus a length the driver never reads.
-        fields: { id: { type: 'text', maxLength: 12 }, region: { type: 'text' } },
+        // platform emits: a numeric key, plus a length the driver never reads.
+        fields: { id: { type: 'number', maxLength: 12 }, region: { type: 'text' } },
       },
     ]);
 
@@ -232,7 +247,7 @@ describe('a declared field colliding with a builtin column is named at load time
     expect(await driver.count('collide_accept', {})).toBe(1);
 
     // The measurement the warning exists to announce, on SQLite: `id` is the
-    // platform's `table.string('id')` — varchar(255) — NOT the declared TEXT,
+    // platform's `table.string('id')` — varchar(255) — NOT a numeric column,
     // and not the declared 12-char bound. (The card measured the same
     // substitution on PostgreSQL 16.13.)
     const info = await (driver as any).knex('collide_accept').columnInfo();

--- a/packages/platform-objects/src/system/sys-migration.object.ts
+++ b/packages/platform-objects/src/system/sys-migration.object.ts
@@ -60,11 +60,18 @@ export const SysMigration = ObjectSchema.create({
   highlightFields: ['id', 'blocking', 'verified_at', 'last_run_at'],
 
   fields: {
+    // ⛔ No `maxLength` here. `id` is a builtin column the platform emits
+    // itself (`table.string('id').primary()` — varchar(255)), so the DDL
+    // discards a declared width; and `validateRecord` skips `id` by name on
+    // both the insert and the update path, so it never binds at write time
+    // either. The `maxLength: 128` this field used to carry was inert in
+    // every seam and disagreed with the column it described — the one honest
+    // line in the #12015 corpus (#12131). The 44 sibling system objects
+    // declare no width on `id`; this one now matches them.
     id: Field.text({
       label: 'Migration ID',
       required: true,
       readonly: true,
-      maxLength: 128,
       description: 'Well-known migration id (e.g. adr-0104-file-references). One row per migration.',
     }),
 


### PR DESCRIPTION
Fixes #12131

Implements the maintainer's 2026-08-27 re-ruling (decision-inbox batch 5, verbatim 「同意」) accepting **option D**. This supersedes the 2026-08-25 option-A ruling on the same card, which an earlier dispatch stopped on and correctly reported as unexecutable.

## The defect

`BUILTIN_COLUMN_DELIVERY.id.type` recorded `'string'` — the **knex builder name** from `table.string('id').primary()`. `undeliveredStorageAttributes` compares that value with `===` against a declaration's `type`, which is a spec `FieldType`. Two different vocabularies, and the recorded one is not a member of the vocabulary it is compared against:

- `'string'` is absent from `FieldType`'s **49** options (measured: `FieldType.options.includes('string') === false`, `includes('text') === true`)
- `FieldSchema` refuses `type: 'string'` outright

So **no declaration could ever match it**, and the #12015 diagnostic reported every correct declaration on the platform's own key as a disagreement.

`varchar` canonicalizes to the field type `text` — `canonicalizeSqlType('varchar(255)') === 'text'`, `isCompatible('varchar(255)', 'text') === true`, both re-measured here and pinned in `type-compat.test.ts`. So `id: Field.text(...)` asks for exactly what the platform's column delivers. The 45 declarations were right all along; the instrument was wrong.

## Measurement

Direction and exact counts were written down **before** measuring. The diagnostic emits one warning per colliding **field**, while the card counts undelivered **attributes**, so both are reported:

| stage | warnings | attributes |
|---|---|---|
| baseline (`origin/main` @ `4bd6faa`) | 45 | 46 (45 `type` + 1 `maxLength`) |
| after the one-line producer fix | 1 | 1 (`sys_migration.id` only) |
| after the ruled rider | **0** | **0** |

Corpus: the 45 object definitions exported by `@objectstack/platform-objects`, de-duplicated by object `name`.

Positive controls, so a zero is a reading rather than a blind probe — all four still fire at the end:

- `id: {type:'number'}` produces exactly 1 attribute (before **and** after — the fix narrowed the comparison, it did not blind it)
- `created_at: {type:'text'}` produces exactly 1
- `id: {maxLength:64}` produces exactly 1 (the `maxLength` branch still works after the rider)
- a non-builtin field name produces 0

## The `sys_migration` rider — removed, not widened to 255

Ruled in scope as the one honest disagreement in the corpus. It is **removed** rather than set to 255, because it was measured inert in every seam that could read it:

- the DDL discards a declared width on a builtin column name (that is the whole subject of #12015)
- `validateRecord` skips `id` **by name** on both the insert and the update path (`SKIP_FIELDS`), and the field is `readonly` besides

Declaring a width that nothing enforces is what enforce-or-remove exists to prevent, and the 44 sibling system objects declare none. Widening to 255 would keep an equally inert key while implying the same declaration belongs on the other 44 — which is option A-prime, explicitly measured out. Flagging the direction explicitly since the ruling named the correction without naming which way; it is a one-line change if the maintainer meant 255.

## A guard that closes the class

The classification pin now holds **every** entry in the delivery table to `FieldType.options`. A knex builder name written there fails by name, instead of surfacing as a corpus of false warnings that reads like 45 bad declarations.

## Fixture triage — the pins were written against the table, not the source

Both #12015 pin files spelled `sys_presence.id` as `type: 'string'` in their **silent** cases. That is not how it is declared — `sys-presence.object.ts` declares `Field.text({ label: 'Presence ID', required: true, readonly: true })`. So the pins passed while the same declaration as actually written warned, which is why 45 false warnings sat behind green tests. Each fixture was re-judged individually:

- **respelled** to the declaration as written (the `sys_presence` shape, and the agreeing-attribute cases)
- **replaced** where the fixture pinned the branch this PR removes — the firing cases now declare `type: 'number'` (a genuinely disagreeing type; the real author error the card was filed for), because `type: 'text'` now correctly agrees
- **re-pinned as silent**: the #11456 shape `{ type: 'text', name: 'id' }`, which asks for precisely what the column delivers

## Reverse verification

Predicted direction, written before running: **RED**. Reverting only the delivery table's value to `'string'` (mutation proven on disk by anchored greps in both directions plus a `git hash-object` differing from the HEAD blob) fails **9 of 18** tests across both pin files, including the new `FieldType` guard. Restore proven by state, not by exit code: the restored blob hash equals the HEAD blob and `git diff HEAD` is empty. No rebuild leg is claimed or needed — both suites import the module by a relative specifier inside the package, so vitest resolves them to the mutated `src/`.

## The #12015 changeset carried a claim this falsifies

`.changeset/builtin-column-collision-warning.md` is still pending (not yet compiled into any CHANGELOG) and stated that `id: { type: 'text' }` fires. It no longer does. Both changesets compile into the same release notes, so the one false clause is corrected in place rather than left to ship contradicting its neighbour. That is the only edit to it.

## Verification

Union run at `e385a121`, with every exit code captured before any pipe.

**Green** — `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs` (both spellings), `check:driver-conformance`, `check:objectql-double-limit`, `check:objectui-changeset`, `check:page-declaration-shape`, `check:pm-half-states`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-comment-mask-adoption`, `check-empty-changeset`, `check-plugin-teardown-shape`, `release-rehearsal-clone --self-test`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:i18n-stale-fill`.

Two gates initially refused to measure and were made to measure rather than reported green:

- `check:i18n` — `PREREQUISITE NOT MET: the workspace CLI is not built`. Built it; now green, `platform-objects in sync (11 bundles)` (labels and descriptions are untouched, so nothing was extracted differently).
- `check:type-check-debt` — refused with `--re-measure cannot run: @objectstack/service-knowledge has no built type entry point`. Built that dependency; now green, gate's own line: `--re-measure: OK — 31 ledger entr(ies) re-measured ... none above its recorded number`.

**NOT MEASURED (named, not counted as green)** — `node scripts/pm/check-half-states.mjs`, exit 3, `PREREQUISITE NOT MET — the token in the environment is not a valid GitHub credential`. Its own output states nothing was swept. It is a PM board sweep over GitHub issues and reads nothing in this diff. Its `--self-test` half (`check:pm-half-states`) is green above.

**Tests** — `@objectstack/driver-sql` whole package: 139 passed / 8 skipped files, 2171 passed / 129 skipped tests. `@objectstack/platform-objects`: 32 files, 519 tests passed. Typecheck clean for both, and `tsc --listFiles` confirms all three edited TypeScript files are actually in the driver-sql program, so "typecheck is clean" covers the edited tests rather than merely not reading them.

## Scope

Untouched, per the ruling: the 45 `id: Field.text(...)` declarations (their `label` / `required` / `readonly` are load-bearing), `sql-driver.ts`, and the driver's internal untyped `'string'` default, whose rename stays deferred behind the diagnostic's wording. #12593 stays with triage and is not addressed here.

**Grade `patch` for both packages, argued.** No door moves: the platform still owns `id` / `created_at` / `updated_at`, the emitted DDL is byte-identical, every object that booted before still boots, and `BUILTIN_COLUMN_DELIVERY` is internal to the package (not re-exported from the package entry). The `platform-objects` half removes one metadata key measured inert in every seam. What changes is what the driver **says**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZbWd2jNV1FErXTPSS4Dry)_