### PR TITLE
docs(rest): qualify the three residual ADR-0112 citations to the code axis

### DIFF
--- a/packages/rest/src/rest-sandbox-declared-status.test.ts
+++ b/packages/rest/src/rest-sandbox-declared-status.test.ts
@@ -127,8 +127,13 @@ describe('[#9967] a sandboxed body that declares a 5xx takes the sanitised 5xx a
         expect(r.status).toBe(503);
         expect(r.body.error).toBe(INTERNAL_ERROR_MESSAGE);
         expect(JSON.stringify(r.body)).not.toContain('close-period lock');
-        // No code was declared; none is invented (ADR-0112: the producer names
-        // the condition).
+        // No code was declared; none is invented — ADR-0112 D4 governs the
+        // semantic-CODE channel: the producer names the condition on the CODE
+        // axis, and the ADR rules no HTTP status for an undeclared throw. The
+        // 503 above is kept on #5582's rule (this section's own heading), not
+        // the ADR's. See `error-response.ts`'s `resolveThrownHttpError`
+        // docblock for why the phrase is that file's own prose and not an ADR
+        // quotation.
         expect(r.body.code).toBeUndefined();
     });
 

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -9648,8 +9648,12 @@ export class RestServer {
             if (refusal) {
                 // `code` is REQUIRED by the nested envelope, and the flat
                 // classification legitimately carries none for an undeclared
-                // sandbox refusal (ADR-0112: the producer names the condition,
-                // so nothing is invented for the half it did not name). The
+                // sandbox refusal (ADR-0112 D4 governs the semantic-CODE
+                // channel: the producer names the condition on the CODE axis,
+                // so nothing is invented for the half it did not name; the ADR
+                // rules no HTTP status here, and the phrase is
+                // `error-response.ts`'s own prose rather than an ADR
+                // quotation). The
                 // catalog's own floor fills the required field —
                 // `standardErrorCodeForHttpStatus`, whose docblock exists for
                 // exactly this ("Total by construction: a producer can always

--- a/packages/rest/src/rest.test.ts
+++ b/packages/rest/src/rest.test.ts
@@ -2483,9 +2483,13 @@ describe('mapDataError — schema/constraint envelopes', () => {
   it('a 5xx that declares NO code passes its status and invents no code', () => {
     // The shape this case originally carried. `declaresServerFault` — the
     // `@objectstack/types` criterion the 5xx arm reads for the `code` half —
-    // needs a non-empty string `code`, and ADR-0112 says the PRODUCER names the
-    // condition: the declared half is honoured, the undeclared half is left
-    // empty rather than filled with an invented `INTERNAL_ERROR`. Same answer
+    // needs a non-empty string `code`, and ADR-0112 D4 governs the
+    // semantic-CODE channel: the producer names the condition on the CODE
+    // axis, so the declared half is honoured and the undeclared half is left
+    // empty rather than filled with an invented `INTERNAL_ERROR`. The 502
+    // passes through on #5437/#5582's rule, NOT the ADR's: ADR-0112 rules no
+    // HTTP status for an undeclared throw, and the phrase is
+    // `error-response.ts`'s own prose rather than an ADR quotation. Same answer
     // `resolveErrorResponse` already gives this shape.
     const r = mapDataError(
       Object.assign(new Error('connect ECONNREFUSED 10.0.0.5:5432 (internal pool)'), { status: 502 }),


### PR DESCRIPTION
Fixes #12454

PR #12453 qualified nine ADR-0112 citation sites to the code axis. Three still carried the
unqualified attribution — one was fenced by an in-flight PR when it was measured, two sat
outside that card's declared file surface. This is the other half, and all three land together.

Each site now echoes the form `error-response.ts`'s `resolveThrownHttpError` docblock states
once in full: **ADR-0112 D4 governs the semantic-CODE channel — the producer names the
condition on the CODE axis, and the ADR rules no HTTP status for an undeclared throw** — with a
pointer to that docblock for why the phrase is that file's own prose and not an ADR quotation.
No fourth wording is introduced. Amending ADR-0112 itself stays out of scope (governed
`docs/adr/**` maintainer path), and the qualification holds under either outcome of that open
question.

## The census: the wrap-tolerant grep is a candidate pool, not a worklist

Measured on my own ref — `origin/main` @ `2805e5299`, branch head `d2f8ef944`. No line numbers
were reused from the card or from triage; both sets had drifted.

```sh
# pool (the card's wrap-tolerant form — the contiguous form cannot see a wrapped comment)
git grep -n -iE "producer names|names the condition" -- '*.ts'
```

| verdict | hits | what they are |
| :-- | --: | :--- |
| already QUALIFIED | 9 | left untouched — includes `rest-hook-refusal-message-parity.test.ts:630`, the canonical form from #12280 |
| NOT A CITATION | 2 | the regex matching other prose: `package-door-declared-code.test.ts:337` describes a producer shape; `service-analytics/.../objectql-strategy.ts:693` uses "names" in an unrelated sense ("a key no older producer names") |
| UNQUALIFIED | 3 | the residue — **the only lines this PR touches** |
| **pool total** | **14** | across 13 files (9 + 2 + 3 = 14) |

The three sites changed, at the ref above:

- `packages/rest/src/rest-sandbox-declared-status.test.ts:130`
- `packages/rest/src/rest-server.ts:9651`
- `packages/rest/src/rest.test.ts:2486`

For contrast at the same ref, the contiguous form the card marks as under-counting returns 6
lines in 6 files — it sees neither `rest-sandbox-declared-status.test.ts` nor `rest.test.ts`,
both of which wrap the phrase across a comment line boundary.

### How the verdicts are recomputable

Each pool hit is judged over a +/-8 line window: no `ADR-0112` in the window ⇒ NOT A CITATION;
otherwise a window naming the axis (`CODE axis`, `semantic-CODE channel`, `own prose`,
`rules no HTTP status`, `ruled the status axis`) ⇒ QUALIFIED; else UNQUALIFIED. The classifier
is calibrated in **both** directions: forcing the qualifier marker absent drives all 12
citations to UNQUALIFIED, forcing it always-present drives all 12 to QUALIFIED — so neither
verdict is an artifact of a dead branch.

**After the fix, the same grep and the same classifier**: pool still 14 hits / 13 files
(nothing added, nothing deleted), NOT A CITATION still 2, UNQUALIFIED **0**, QUALIFIED 12.
Positive control for that zero: with the marker forced absent the same post-fix run still
reports 12 UNQUALIFIED, so the branch that would report a miss is still live.

### The pool is complete, and the out-of-scope idiom never enters it

A fully multiline regex (`producer[\s*/#]*names[\s*/#]*the[\s*/#]*condition`, slurped per file,
so the phrase is caught under *any* wrapping) hits **11 files**, every one already inside the
13-file pool, and **no file outside it**. Positive control: the same harness with a term known
present (`ADR-0112`) returns 509 files.

The `"ADR-0112 envelope (code + status)"` idiom is explicitly a different usage and was not
swept: it measures 314 lines across 223 files, and its intersection with the pool is **0 lines**
— it is disjoint from the pool's regex, not merely excluded by judgement. Positive control for
that zero: pool intersected with itself returns 14.

## Comment-only, proven

`removeComments` transpile (`typescript 6.0.3`) of each file before and after, sha256 over the
emitted JS:

```text
EMIT-IDENTICAL packages/rest/src/rest-sandbox-declared-status.test.ts  76af7bef73763965
EMIT-IDENTICAL packages/rest/src/rest-server.ts                        774981d9210f4c00
EMIT-IDENTICAL packages/rest/src/rest.test.ts                          b7d27ac160f34d8a
```

Instrument calibrated per file, both directions: appending a comment token leaves the hash
unmoved; appending `const __calibration_token = 1;` moves it. All three edits are `//` comment
text — none is a string literal or a test title.

## Verification

19 gate families run at `d2f8ef944`, each exit code captured before any pipe, all green:
`check:nul-bytes`, `check-comment-mask-adoption.mjs`, `check:route-envelope`,
`check:dispatcher-error-vocabulary`, `check:engine-double-contract`, `check:where-matcher`,
`check:test-source-alias`, `check:cross-package-test-inputs`, `check:objectql-double-limit`,
`check:authz-resolver`, `check:page-declaration-shape`, `check:published-files`,
`check:slot-lookup`, `check:type-source-resolution`, `check:query-options-erasure`,
`check:type-check-coverage`, `check-ci-filter-parity.mjs`, `check-plugin-teardown-shape.mjs`,
`docs-audit/check-affected-docs.mjs`. Family list derived with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, not recalled. Every
heavy run went through `scripts/pm/os-verify-lock.sh`.

**Declared narrowing — the suite and the repo-wide lint.** `packages/rest`'s suite and
`check:type-check-debt` need a 25-package build closure, and on this diff they can only
re-measure `origin/main`: the emitted JS is byte-identical (above), and the diff adds or removes
**0** compiler/lint directive comments (`@ts-expect-error`, `@ts-ignore`, `@ts-nocheck`,
triple-slash `reference` directives, `eslint-disable`, `prettier-ignore`, …) — positive
controls: the same regex matches 136 files in the tree and matches a synthetic planted line.
`pnpm lint` (`eslint . --no-inline-config`) was narrowed to the three files: eslint's own config
linted all 3 (none ignored), 0 errors / 0 warnings, and this repo's single `eslint.config.mjs`
never enables type-aware linting for any file (its own comment at line 328 records the
measurement), so a comment-only diff cannot move the verdict of a file it does not touch. CI
runs both farms in full regardless.

**No changeset**: comment text only, nothing released — `skip-changeset` applies.

_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_