### PR TITLE
chore(cli,pm): root the NODE_ENV serve fixture at packages/cli/tmp/, with the leftover hazard pinned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,6 @@ coverage/
 # Temporary files
 tmp/
 temp/
-# Killed-run fixture leftover; its in-tree root is deliberate (objectstack#12583)
-packages/cli/test/tmp-node-env-default-*/
 
 # Package builds
 packages/*/dist/

--- a/packages/cli/test/serve-node-env-production-default.e2e.test.ts
+++ b/packages/cli/test/serve-node-env-production-default.e2e.test.ts
@@ -163,7 +163,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn, type ChildProcessByStdio } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
@@ -214,15 +214,45 @@ const UNSET_LEG_MEASURES_THE_BUILT_DIST =
   'refuses, not just that leg.';
 
 /**
- * The fixture's parent directory sits INSIDE `packages/cli/test/`, not the
- * system tmpdir: the config below does a real, static
- * `import { AuthPlugin } from '@objectstack/plugin-auth'`, and that only
- * resolves because `packages/cli/node_modules/@objectstack/plugin-auth`
- * (a real dependency of this package) is reachable by Node's ordinary
- * upward `node_modules` walk from wherever the config file lives. A fixture
- * rooted in `os.tmpdir()` has no such ancestor and the import fails.
+ * WHY THE FIXTURE IS ROOTED AT `packages/cli/tmp/` — two independent reasons,
+ * and only ONE of them is technical. They are written out separately because
+ * collapsing them is the defect this root was moved to end.
+ *
+ * 1. NOT the system tmpdir. This half IS technical and it is measured: the
+ *    config below does a real, static
+ *    `import { AuthPlugin } from '@objectstack/plugin-auth'`, which resolves
+ *    only because `packages/cli/node_modules/@objectstack/plugin-auth` (a real
+ *    dependency of this package) is reachable by Node's ordinary upward
+ *    `node_modules` walk from wherever the config file lives. A fixture rooted
+ *    in `os.tmpdir()` has no such ancestor and the import fails.
+ *
+ * 2. `tmp/` rather than `test/`. This half is a CONVENTION, and it does NOT
+ *    follow from (1). ⛔ Do not re-derive it from the import constraint: this
+ *    package's `test/` directory has exactly the SAME `node_modules` ancestor
+ *    that its `tmp/` directory has, so (1) rules out `os.tmpdir()` and says
+ *    nothing whatever about the choice between the two in-tree roots. Writing
+ *    (1) as "so it must live in `tmp/`" would just swap one false reason for
+ *    another. The choice is settled by convention instead: of the four fixtures
+ *    this package creates inside the tracked tree, three already root at
+ *    `packages/cli/tmp/` (`init-scaffold-authoring-rules.test.ts`,
+ *    `init-template-comments-self-contained.test.ts`,
+ *    `serve-no-artifact.e2e.test.ts`), and that root costs ZERO bespoke ignore
+ *    surface — the repo-wide `tmp/` rule in `.gitignore` already covers it,
+ *    where this file's former in-`test/` root needed an ignore entry written
+ *    for it alone. Maintainer ruling, 2026-08-27, adopting Option A.
+ *
+ * ⚠️ The ignore coverage is the load-bearing half of (2), not tidiness. A
+ * killed run leaves this directory behind, and a leftover in the tracked tree
+ * with NO ignore rule is not inert: `scripts/pm/dispatch-gates.mjs` derives
+ * every dispatch's gate list from the working tree, untracked files included,
+ * so an unignored leftover joins that change set and inflates it — measured on
+ * this tree, a two-file leftover adds 20 gate families that the branch's real
+ * diff does not implicate, corrupting other seats' dispatch decisions for as
+ * long as it sits there. Both directions of that property are pinned in
+ * `dispatch-gates.mjs`'s own `--self-test`; ⛔ a fifth fixture that picks a new
+ * in-tree root inherits this obligation and does not inherit the pin.
  */
-const FIXTURES_ROOT = HERE;
+const FIXTURES_ROOT = resolve(HERE, '../tmp');
 
 function configFor(port: number): string {
   return `
@@ -434,6 +464,7 @@ describe('#11113: os serve defaults NODE_ENV to production when unset', () => {
     // from `dist/`, and the two rerouted legs must not report green without it.
     requireBuiltCli(UNSET_LEG_MEASURES_THE_BUILT_DIST);
 
+    mkdirSync(FIXTURES_ROOT, { recursive: true });
     dir = mkdtempSync(join(FIXTURES_ROOT, 'tmp-node-env-default-'));
     writeFileSync(
       join(dir, 'package.json'),

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -7753,6 +7753,67 @@ function selfTest() {
       missingBaseErr = err;
     }
     t('an unresolvable base ref is refused on its own terms', !!missingBaseErr && /does not resolve/.test(missingBaseErr.message));
+
+    // ── A leftover in-tree test fixture must not reach the change set (#12632)
+    //
+    // The derivation reads untracked files on purpose, so `.gitignore` is the
+    // only thing standing between a killed test run's leftover fixture and
+    // every seat's gate list. `packages/cli` creates four fixtures inside the
+    // tracked tree; the one that used to root in `packages/cli/test/` needed an
+    // ignore entry written for it alone, and now roots at `packages/cli/tmp/`
+    // with the other three, under the repo-wide `tmp/` rule.
+    //
+    // The CONTROL is the load-bearing half and it runs the SAME derivation on
+    // the SAME repo: asserting only that the covered path is absent would pass
+    // just as happily against a `.gitignore` that ignores the whole tree, or
+    // against a fixture that never planted anything. So an UNCOVERED in-tree
+    // path is planted alongside it and has to come back VISIBLE, and it has to
+    // come back carrying gate families — a leftover that reached the change set
+    // is not inert. Measured on the tree at the time of writing: a two-file
+    // leftover (the `package.json` and `objectstack.config.ts` that fixture
+    // writes) named 20 families the branch's own diff does not implicate.
+    // The count is not asserted — the family inventory grows same-day, which is
+    // this whole tool's premise — only that it is non-empty.
+    //
+    // The uncovered path is deliberately the fixture's FORMER root, so this
+    // control also fails if the bespoke ignore entry is ever restored: a rule
+    // covering a root nothing uses would make the control silently green and
+    // take the pin with it.
+    //
+    // The repo's REAL `.gitignore` is copied in rather than an excerpt written
+    // here: an excerpt would pin the excerpt.
+    const ignoreRepo = join(gitTmp, 'ignore-coverage');
+    mkdirSync(ignoreRepo, { recursive: true });
+    g(['init', '--initial-branch=main', '.'], ignoreRepo);
+    write(ignoreRepo, '.gitignore', readFileSync(join(ROOT, '.gitignore'), 'utf8'));
+    g(['add', '-A'], ignoreRepo);
+    g(['commit', '-m', 'the real ignore rules'], ignoreRepo);
+    g(['update-ref', 'refs/remotes/origin/main', g(['rev-parse', 'main'], ignoreRepo)], ignoreRepo);
+
+    const leftoverAtCoveredRoot = 'packages/cli/tmp/tmp-node-env-default-selftest/objectstack.config.ts';
+    const leftoverAtUncoveredRoot = 'packages/cli/test/tmp-node-env-default-selftest/objectstack.config.ts';
+    for (const rel of [leftoverAtCoveredRoot, leftoverAtUncoveredRoot]) {
+      write(ignoreRepo, rel, "import { AuthPlugin } from '@objectstack/plugin-auth';\n");
+      write(ignoreRepo, join(dirname(rel), 'package.json'), '{ "private": true, "type": "module" }\n');
+    }
+    const leftovers = changedPathsFromGit({ cwd: ignoreRepo });
+
+    t(
+      'the CONTROL reproduces the hazard: a leftover fixture at an UNCOVERED in-tree root does reach the change set',
+      leftovers.paths.includes(leftoverAtUncoveredRoot),
+    );
+    t(
+      'and reaching it is not free — the uncovered leftover names gate families of its own',
+      [...discoverFamilies().byCheck.values()].some((e) => classifyEntry(e, [leftoverAtUncoveredRoot]).verdict === 'matched'),
+    );
+    t(
+      'a leftover fixture at packages/cli/tmp/ is invisible to the derivation, under the same rules in the same repo',
+      !leftovers.paths.includes(leftoverAtCoveredRoot),
+    );
+    t(
+      'and it is the repo-wide tmp/ rule doing it, with no bespoke entry for the fixture former root',
+      !readFileSync(join(ROOT, '.gitignore'), 'utf8').includes('packages/cli/test/tmp-node-env-default'),
+    );
   } finally {
     rmSync(gitTmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #12632

Option A, as ruled on 2026-08-27: `packages/cli/tmp/` is the convention for in-tree
test fixtures under `packages/cli`. The three parts land together, because any two of
them are worse than the state before.

1. **The outlier fixture's root moves.** `serve-node-env-production-default.e2e.test.ts`
   rooted its fixture at `packages/cli/test/`; it now roots at `packages/cli/tmp/`, where
   its three siblings already sit (`init-scaffold-authoring-rules`,
   `init-template-comments-self-contained`, `serve-no-artifact`). `mkdirSync(…, { recursive: true })`
   is added ahead of `mkdtempSync`, matching the siblings — `tmp/` is not tracked, so it
   need not exist.
2. **PR #12631's bespoke ignore entry is deleted.** `packages/cli/test/tmp-node-env-default-*/`
   plus its comment. Left behind, it would not merely be a dead rule: it would be an ignore
   entry pointing at a path nothing writes any more.
3. **The rationale docblock is rewritten**, because the old one no longer explains the new
   root — the failure mode the card was filed to end.

## The docblock's actual correction

The old comment gave one reason: the generated config does a real, static
`import { AuthPlugin } from '@objectstack/plugin-auth'`, which resolves only from a
directory with a `node_modules` ancestor. That reason is true, and it rules out
`os.tmpdir()`. It does **not** choose between the two in-tree roots — and the new comment
says so in as many words rather than re-deriving the root from it, which would swap one
false reason for another.

Measured here, with the instrument calibrated in both directions (probe module placed
inside each fixture directory so its own URL is the resolution parent):

| fixture root | expected | measured |
| :--- | :--- | :--- |
| `packages/cli/tmp/` (new) | resolves | resolves, to `plugin-auth/dist/index.mjs` |
| `packages/cli/test/` (old) | resolves | resolves, to the same file |
| `os.tmpdir()` | fails | fails, `ERR_MODULE_NOT_FOUND` |

The two in-tree roots are indistinguishable to the constraint. So the root choice is a
convention — three of four fixtures, and zero bespoke ignore surface — and the docblock
records it as one.

A first attempt at that probe reported all three roots failing, including the old root
that demonstrably works in CI. The cause was the instrument, not the tree: Node 22 ignores
`import.meta.resolve`'s second argument without an experimental flag, so every case
resolved from the probe script's own directory. That reading is discarded, not reconciled.

## The property this exists to keep closed

A leftover fixture in the tracked tree with no ignore rule is not inert.
`scripts/pm/dispatch-gates.mjs` derives every dispatch's change set from git including
untracked files, so an unignored leftover joins it and inflates the gate list every other
seat is handed.

Reproduced on this tree, red before green, each leg restored under a trap and proven by
blob hash:

| step | state | derived paths | matched families |
| :--- | :--- | ---: | ---: |
| 0 | clean tree | 0 | 0 |
| 1 | leftover at old root, bespoke entry present | 0 | 0 |
| 2 | leftover at old root, bespoke entry deleted | 3 | 20 |
| 3 | no leftover, bespoke entry deleted | 1 | 0 |
| 4 | leftover at new root, bespoke entry deleted | 1 | 0 |

Step 1 answers the card's re-check directly: the bespoke entry was **live**, not a dead
rule. Steps 2 minus 3 isolate the leftover's own cost: **20** gate families the branch's
real diff does not implicate. Step 4 is the fix.

The card carries **18** from PR #12631's measurement. I could not reproduce 18 on this
tree in any leftover shape: `objectstack.config.ts` alone gives 17, `package.json` alone
gives 17, both together give 20. Reported as measured and not reconciled — this tool's own
premise is that the family inventory expires same-day (176 families across 28 workflow
files today).

## The pin

Four cases added to `dispatch-gates.mjs`'s own `--self-test`, which CI runs unconditionally
via `check:pm-dispatch-gates`. They build a throwaway git repo seeded with this repo's
**real** `.gitignore` — an excerpt would pin the excerpt — plant the same fixture shape at
both roots, and run the real derivation once.

The control is load-bearing and is deliberately the fixture's **former** root: asserting
only that the covered path is absent would pass against a `.gitignore` that ignores
everything, or against a plant that never happened. So the uncovered path must come back
visible, and must come back naming gate families.

Falsified in both directions, each ablation flipping exactly its own assertion and leaving
the others green:

- restore the bespoke entry: the control fails (`✗ the CONTROL reproduces the hazard`) and
  so does the no-bespoke-entry assertion; the coverage assertion stays green.
- delete the repo-wide `tmp/` rule: the coverage assertion fails; the control stays green.

## Verification

Union measured on `f4c7a6764`, the final commit. 21 green:

`check:pm-dispatch-gates` (723 cases) · `check-self-test-wired` · `check:cli-test-child-env` ·
`check:nul-bytes` · `check-comment-mask-adoption` · `check:entry-guard` · `check:parse-guard` ·
`check:test-source-alias` · `check:type-check-coverage` · `check:cross-package-test-inputs` ·
`check-ci-filter-parity` · `check:published-files` · `check:agent-test-spelling` ·
`check:pnpm-filter-targets` · `check:bash32-floor` · `check:cli-command-ids` ·
`check:slot-lookup` · `check:page-declaration-shape` · `check:objectql-double-limit` ·
`check:type-source-resolution` · `check-plugin-teardown-shape`.

`check:type-check-debt` exits 1 as a **prerequisite refusal**, not a failure: it names 30
workspace dependencies with no built type entry point and refuses to measure a different
world. Recorded as NOT MEASURED. Its sibling `check:type-check-coverage` ran and reports OK.

**Declared narrowing.** The moved fixture's own three legs were **not** run locally. They
spawn the built CLI, whose dependency closure is 57 build tasks, and the container's
foreground window is ~10 minutes — one attempt at the gate union was already killed at the
cap. What the move can break is the static import resolving from the new root, and that is
measured above on a real Node resolution with a failing control. The e2e itself is left to
CI, which builds the closure before running it.

No changeset: nothing here reaches a published package's emitted program.
`packages/cli` compiles `include: ["src"]` with `rootDir: "src"` and publishes
`files: ["dist", "README.md", "CHANGELOG.md"]`, so a file under `test/` is outside both the
compiled program and the tarball; `.gitignore` and `scripts/pm/` are repo-root tooling in
no package. Labelled `skip-changeset`.

_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_