### PR TITLE
build(docs): stop rebuilding the docs site on every push to main

### DIFF
--- a/.changeset/docs-ignore-build-step.md
+++ b/.changeset/docs-ignore-build-step.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/docs": patch
+---
+
+build(docs): stop rebuilding the docs site on every push to `main` (#12743)
+
+Every push to `main` rebuilt the documentation site, and almost none of them
+changed what it renders. Measured over one week across the team:
+
+| project | production builds | build-minutes | avg |
+|---|---|---|---|
+| **objectstack (docs)** | **228** | **2835 (98.6%)** | **12.4 min** |
+| objectui | 123 | 36 | 0.3 min |
+| hotcrm | 42 | 5 | 0.1 min |
+
+The team runs `concurrentBuilds: 1`, so an 18-second `objectui` build queued
+behind a 12–46 minute docs build; the queue reached **92 deployments, the oldest
+34 hours old**. At 4 vCPU those docs builds cost roughly **$171/month** against a
+$20 included allowance, and 168 of the 228 were failures, so most of it bought
+nothing.
+
+`apps/docs/vercel.json` now declares an `ignoreCommand` (which overrides the
+dashboard's Ignored Build Step, moving the rule into version control where it is
+reviewable and revertible). `scripts/vercel-ignore-docs.sh` decides:
+
+1. non-production → skip (unchanged from the rule it replaces)
+2. `content/**` or `apps/docs/**` changed → build
+3. otherwise → ask turbo whether the docs dependency graph is affected
+4. anything indeterminate → **build**
+
+**Step 2 is not redundant with step 3, and dropping it would silently stop
+publishing documentation.** `turbo --filter=<pkg>...[range]` computes affected
+packages *by package directory*, and this repo's MDX lives at the repo root in
+`content/`, outside the `apps/docs` boundary. `turbo.json` does list
+`"$TURBO_ROOT$/content/**"` under `@objectstack/docs#build`'s `inputs`, but
+`inputs` only feeds the cache hash — it does not widen the affected-package
+calculation. Verified on `main`: commit `1265f12b` touches only
+`content/docs/api/client-sdk.mdx`, and a dependency-graph check alone answers
+SKIP for it.
+
+The asymmetry in step 4 is the point. A wrong "build" costs a few build-minutes;
+a wrong "skip" leaves the site quietly stale with no error anywhere. So a missing
+`VERCEL_GIT_PREVIOUS_SHA`, a shallow clone that cannot reach it, an unparseable
+turbo verdict, and a non-0/1 exit from turbo all build.
+
+Deliberately not `npx turbo-ignore`, which #12698 suggested: it is deprecated
+upstream ("Use `turbo query affected` instead") and derives its own comparison
+range, falling back to `[HEAD^]` when it cannot read Vercel's git environment —
+silently answering a different question than the one asked. The range is named
+explicitly here instead.
+
+`scripts/vercel-ignore-docs.selftest.sh` pins all six cases against real commits
+from this repo's history, including the `content/**` one.

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -3,6 +3,7 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && pnpm install",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@objectstack/docs",
+  "ignoreCommand": "bash ../../scripts/vercel-ignore-docs.sh",
   "github": {
     "silent": true
   }

--- a/scripts/vercel-ignore-docs.selftest.sh
+++ b/scripts/vercel-ignore-docs.selftest.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/vercel-ignore-docs.sh.
+#
+# The script decides whether a docs production build runs. Its two failure
+# directions are not symmetric: a wrong "build" wastes build-minutes, a wrong
+# "skip" silently stops publishing documentation. These cases pin both, and in
+# particular pin the `content/**` case (#12743) — the repo's MDX lives outside
+# the `apps/docs` package boundary, so a dependency-graph check alone reports
+# SKIP for a pure documentation edit.
+#
+# Run: bash scripts/vercel-ignore-docs.selftest.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+SCRIPT=scripts/vercel-ignore-docs.sh
+fail=0
+
+# Historical commits on `main`, each a single well-understood kind of change.
+# If history is ever rewritten these stop resolving; the test says so rather
+# than silently passing.
+SHA_CONTENT=1265f12b   # touches only content/docs/api/client-sdk.mdx
+SHA_SPEC=366f8957      # touches packages/spec (the docs app's only workspace dep)
+SHA_CLAUDE=72f91652    # touches only .claude/**
+
+check() {
+  local label="$1" want="$2"; shift 2
+  local out rc got
+  out=$(env "$@" bash "$SCRIPT" 2>&1); rc=$?
+  got=$([ "$rc" -eq 0 ] && echo skip || echo build)
+  if [ "$got" = "$want" ]; then
+    printf '  ok    %-32s -> %s\n' "$label" "$got"
+  else
+    printf '  FAIL  %-32s -> %s (wanted %s)\n        %s\n' "$label" "$got" "$want" "$(echo "$out" | tail -1)"
+    fail=1
+  fi
+}
+
+at() { # at <sha> -> echoes env assignments pinning the range to that commit
+  local sha="$1" parent
+  parent=$(git rev-parse "${sha}^" 2>/dev/null) || return 1
+  echo "VERCEL_GIT_PREVIOUS_SHA=${parent} VERCEL_GIT_COMMIT_SHA=${sha}"
+}
+
+echo "vercel-ignore-docs selftest"
+
+check "preview deployments skip"      skip  VERCEL_ENV=preview
+check "no baseline builds"            build VERCEL_ENV=production
+check "unreachable baseline builds"   build VERCEL_ENV=production \
+        VERCEL_GIT_PREVIOUS_SHA=0000000000000000000000000000000000000000
+
+for pair in "content-only:$SHA_CONTENT:build" "spec-dependency:$SHA_SPEC:build" "claude-only:$SHA_CLAUDE:skip"; do
+  label=${pair%%:*}; rest=${pair#*:}; sha=${rest%%:*}; want=${rest#*:}
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    printf '  SKIP  %-32s (commit %s no longer in history)\n' "$label" "$sha"
+    continue
+  fi
+  # shellcheck disable=SC2046
+  check "$label" "$want" VERCEL_ENV=production $(at "$sha")
+done
+
+if [ "$fail" -ne 0 ]; then echo "SELFTEST FAILED"; exit 1; fi
+echo "all cases passed"

--- a/scripts/vercel-ignore-docs.sh
+++ b/scripts/vercel-ignore-docs.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" for @objectstack/docs.
+#
+# Vercel's contract is inverted from the usual one:
+#   exit 0 -> IGNORE the build (skip)
+#   exit 1 -> RUN the build
+#
+# Why this exists: every push to `main` used to rebuild the docs site. Measured
+# over one week, that was 228 production builds consuming 2835 build-minutes —
+# 98.6% of the whole team's build time — while `objectui` (18s/build) and
+# `hotcrm` (6s/build) queued behind them on a `concurrentBuilds: 1` team. The
+# queue reached 92 deployments, the oldest 34 hours old (#12743).
+#
+# ⚠️ The single most important property of this script is its FAILURE DIRECTION.
+# A wrong "build" costs a few build-minutes. A wrong "skip" silently stops
+# publishing documentation, with no error anywhere — the site just quietly goes
+# stale. Every indeterminate case below therefore exits 1.
+set -uo pipefail
+
+# All paths below are repo-relative, but Vercel runs this from the project's
+# Root Directory (apps/docs), so anchor to the repo root first.
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+# `VERCEL_GIT_COMMIT_SHA` is what Vercel is deploying; falling back to HEAD lets
+# this script be exercised locally and in tests.
+HEAD_SHA="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+PREV_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
+
+# 1. Preview deployments never build the docs site. This preserves exactly the
+#    behaviour of the dashboard rule this replaces, whose preview half was
+#    already correct; only its production half ("always build") was wasteful.
+if [ "${VERCEL_ENV:-}" != "production" ]; then
+  echo "skip: VERCEL_ENV=${VERCEL_ENV:-unset} is not production"
+  exit 0
+fi
+
+# 2. No baseline to compare against -> build. Happens on the first deployment
+#    after this lands, and any time Vercel cannot name a previous success.
+if [ -z "$PREV_SHA" ]; then
+  echo "build: no VERCEL_GIT_PREVIOUS_SHA to compare against"
+  exit 1
+fi
+
+# 3. Vercel builds from a shallow clone, so the previous commit is frequently
+#    absent. Try to fetch it; if it stays unreachable, build.
+if ! git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
+  git fetch --depth=100 origin "$PREV_SHA" >/dev/null 2>&1 || true
+fi
+if ! git cat-file -e "${PREV_SHA}^{commit}" 2>/dev/null; then
+  echo "build: previous SHA ${PREV_SHA} is not reachable in this clone"
+  exit 1
+fi
+
+# 4. The site's own sources.
+#
+#    This check is NOT redundant with turbo-ignore below, and removing it breaks
+#    documentation publishing. `turbo --filter=<pkg>...[range]` computes affected
+#    packages BY PACKAGE DIRECTORY. This repo's MDX lives at the repo root in
+#    `content/`, outside the `apps/docs` package boundary, so turbo does not see
+#    it. `turbo.json` does list `"$TURBO_ROOT$/content/**"` under
+#    `@objectstack/docs#build`'s `inputs`, but `inputs` only feeds the cache
+#    hash — it does not widen the affected-package calculation.
+#
+#    Measured on `main`: commit 1265f12b touches only
+#    `content/docs/api/client-sdk.mdx`, and `turbo-ignore` alone reports SKIP.
+if ! git diff --quiet "$PREV_SHA" "$HEAD_SHA" -- content apps/docs; then
+  echo "build: content/ or apps/docs/ changed since ${PREV_SHA}"
+  exit 1
+fi
+
+# 5. Nothing in the site's own sources changed. Ask turbo whether the docs app
+#    is affected through its dependency graph — `@objectstack/spec` is the only
+#    workspace dependency, but it changes often.
+#
+#    Deliberately NOT `turbo-ignore`: that wrapper is deprecated upstream ("Use
+#    `turbo query affected` instead") and it derives its own comparison range,
+#    falling back to `[HEAD^]` when it cannot read Vercel's git environment —
+#    a range that silently answers a different question than the one asked here.
+#    Naming the range explicitly keeps this decision reviewable and testable.
+echo "no direct docs changes; asking turbo about the dependency graph"
+DRY=$(npx --yes "turbo@${TURBO_VERSION:-^2}" run build \
+        --filter="@objectstack/docs...[${PREV_SHA}...${HEAD_SHA}]" \
+        --dry=json 2>/dev/null)
+if [ -z "$DRY" ]; then
+  echo "build: could not get a verdict from turbo"
+  exit 1
+fi
+
+AFFECTED=$(printf '%s' "$DRY" | node -e '
+  let s="";
+  process.stdin.on("data", d => s += d);
+  process.stdin.on("end", () => {
+    try { process.stdout.write(String((JSON.parse(s).tasks || []).length)); }
+    catch { process.stdout.write("error"); }
+  });
+' 2>/dev/null)
+
+case "$AFFECTED" in
+  0) echo "skip: nothing in @objectstack/docs dependency graph changed since ${PREV_SHA}"; exit 0 ;;
+  ''|*[!0-9]*) echo "build: could not parse turbo's verdict (${AFFECTED:-empty})"; exit 1 ;;
+  *) echo "build: ${AFFECTED} task(s) in the docs dependency graph affected"; exit 1 ;;
+esac


### PR DESCRIPTION
Every push to `main` rebuilds the documentation site, and almost none of them change what it renders.

## Measured (7 days, whole team)

| project | production builds | build-minutes | avg |
|---|---|---|---|
| **objectstack (docs)** | **228** | **2835 (98.6%)** | **12.4 min** |
| objectui | 123 | 36 | 0.3 min |
| hotcrm | 42 | 5 | 0.1 min |

The team runs `concurrentBuilds: 1`, so an 18-second `objectui` build queues behind a 12–46 minute docs build. The queue reached **92 deployments, the oldest 34 hours old**. At 4 vCPU those docs builds cost roughly **$171/month** against a $20 included allowance — and 168 of the 228 were failures, so most of it bought nothing.

## The change

`apps/docs/vercel.json` gains an `ignoreCommand`. Per Vercel's docs this *overrides* the dashboard's Ignored Build Step, which moves the rule into version control where it can be reviewed and reverted. `scripts/vercel-ignore-docs.sh`:

1. non-production → **skip** (identical to the rule it replaces — its preview half was already right)
2. `content/**` or `apps/docs/**` changed since the last successful deploy → **build**
3. otherwise → ask turbo whether the docs dependency graph is affected (catches `@objectstack/spec`)
4. anything indeterminate → **build**

## ⚠️ Why step 2 exists (the part that would silently break docs)

`turbo --filter=<pkg>...[range]` computes affected packages **by package directory**. This repo's MDX lives at the repo root in `content/`, outside the `apps/docs` boundary. `turbo.json` *does* list `"$TURBO_ROOT$/content/**"` under `@objectstack/docs#build`'s `inputs` — but `inputs` only feeds the **cache hash**; it does not widen the affected-package calculation.

Verified against real commits on `main`:

| commit | changes | dependency-graph verdict alone |
|---|---|---|
| `72f91652` | `.claude/**` only | SKIP ✅ |
| `366f8957` | `packages/spec/**` | BUILD ✅ |
| **`1265f12b`** | **`content/docs/api/client-sdk.mdx` only** | **SKIP ❌ — doc update never ships** |

So the dependency-graph check cannot be used on its own here, which is the one thing #12698's suggested command would have done.

## Failure direction is deliberate

A wrong "build" costs a few build-minutes. A wrong "skip" leaves the site quietly stale with **no error anywhere** — the exact shape of the two-day outage in #12333. So a missing `VERCEL_GIT_PREVIOUS_SHA`, a shallow clone that cannot reach it, an unparseable turbo verdict, and any non-0/1 exit from turbo all **build**.

## Not `npx turbo-ignore`

#12698 suggested it. It is deprecated upstream (`"turbo-ignore" is deprecated. Use "turbo query affected" instead`) and it derives its own comparison range, falling back to `[HEAD^]` when it cannot read Vercel's git environment — silently answering a different question than the one asked. This names the range explicitly instead.

## Tests

`scripts/vercel-ignore-docs.selftest.sh` pins all six cases against real commits from this repo's history:

```
  ok    preview deployments skip         -> skip
  ok    no baseline builds               -> build
  ok    unreachable baseline builds      -> build
  ok    content-only                     -> build
  ok    spec-dependency                  -> build
  ok    claude-only                      -> skip
```

## Context

Independent of, and complementary to, the memory work: the build machine was moved to Enhanced (16 GB) after #12711 showed 403 pages need ~7.6 GB on an 8 GB machine. That took a docs build from **46–50 min failing** to **3.7 min succeeding** ($0.64 → $0.105 each). This PR reduces how *often* that runs at all — and every avoided build is one less chance to meet the ceiling as the docs keep growing (measured at ~9.7 MB of build memory per page).

Refs #12743, #12711, #12698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
