### PR TITLE
fix(metadata-fs): declare startWatcher()'s chokidar atomic option explicitly

### DIFF
--- a/.changeset/metadata-fs-watcher-atomic-declared.md
+++ b/.changeset/metadata-fs-watcher-atomic-declared.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/metadata-fs": patch
+---
+
+fix(metadata-fs): declare `startWatcher()`'s chokidar `atomic` option explicitly (#12696)
+
+`FileSystemRepository.startWatcher()` constructed its chokidar watcher with
+`usePolling: true` but never passed `atomic`, leaving it to inherit chokidar's
+default. That default is unconditionally `true` in the installed version
+(chokidar 5.0.0): the defaults literal assigns `atomic: true` *before* the
+caller's options are spread in, so chokidar's own default-correction
+(`if (opts.atomic === undefined) opts.atomic = !opts.usePolling`) can never
+fire — it only runs when `atomic` is literally `undefined` after the merge,
+which it never is. The comment beside that correction ("Editor atomic write
+normalization enabled by default with fs.watch") reads as "off under
+polling"; the actual resolved behaviour was on regardless.
+
+This change passes `atomic: true` explicitly at the call site, with a comment
+explaining why. **Patch, not a behaviour change**: verified at runtime
+(constructing a watcher the way `startWatcher()` does and reading back
+`watcher.options.atomic`) that the resolved value is identical before and
+after — `true` either way, today. The only thing that changes is that the
+value is now DECLARED rather than inherited from an upstream branch that
+cannot execute, so a future chokidar release that fixes the ordering (making
+the correction real) cannot silently flip this repository's watcher to
+`atomic: false` under polling and change behaviour with no diff to review.
+
+Not addressed here (see #12696): whether `atomic: true` (the 100ms
+unlink-coalescing deferral and the `DOT_RE` editor-temp-file matcher it turns
+on) is actually the right value. No evidence surfaced that either has ever
+affected a run; flipping it to `false` is a deliberate behaviour change to a
+live delivery path that needs its own reverse verification, and is out of
+scope for this card.

--- a/packages/metadata-fs/src/repository.ts
+++ b/packages/metadata-fs/src/repository.ts
@@ -595,6 +595,23 @@ export class FileSystemRepository implements MetadataRepository {
       usePolling: true,
       interval: 1000,
       binaryInterval: 2000,
+      // Declared explicitly, not inherited. chokidar's own default-correction
+      // (`if (opts.atomic === undefined) opts.atomic = !opts.usePolling`) can
+      // only fire when the caller omits `atomic`, but its defaults literal
+      // already assigns `atomic: true` *before* the caller's options are
+      // spread in — so leaving `atomic` unset here does not mean "off under
+      // polling" the way the correction's own comment claims, it silently
+      // resolves to `true` regardless of `usePolling`. That has been this
+      // repository's actual runtime behaviour all along (verified by reading
+      // back the resolved option from a real watcher instance, #12696): every
+      // `unlink` gets chokidar's 100ms editor-atomic-write deferral, and
+      // `DOT_RE` (vim swap files, `~`, sublime tmp) is folded into
+      // `_isIgnored` on top of this repository's own `isIgnoredWatchPath`
+      // (#7150). `atomic: true` here keeps that behaviour byte-for-byte —
+      // this is a declaration, not a change. Flipping it to `false` would
+      // remove both behaviours from a live delivery path and needs its own
+      // reverse verification; see #12696 for the analysis.
+      atomic: true,
     });
     w.on('add', (p) => void this.handleFsChange(p, 'add'));
     w.on('change', (p) => void this.handleFsChange(p, 'change'));

--- a/packages/metadata-fs/test/watcher-atomic-declared.test.ts
+++ b/packages/metadata-fs/test/watcher-atomic-declared.test.ts
@@ -92,10 +92,21 @@ describe('FileSystemRepository — startWatcher() declares `atomic` explicitly (
     // `true` after chokidar's internal merge (see file header).
     expect(Object.prototype.hasOwnProperty.call(options, 'atomic')).toBe(true);
     expect(options.atomic).toBe(true);
+  });
 
-    // Positive control. `usePolling` is unconditionally declared today and
-    // untouched by this card's fix — if THIS assertion ever failed too, the
-    // spy/harness is the suspect, not the `atomic` declaration.
+  // Positive control (#12696 ablation) — a SEPARATE case so it runs to
+  // completion, and so its verdict, on its own assertions, is independent of
+  // whatever the case above does. `usePolling` is unconditionally declared
+  // today and untouched by this card's fix; it must stay green under the
+  // ablation that removes the explicit `atomic`. If it ever went red too,
+  // the spy/harness would be the suspect, not the `atomic` declaration.
+  it('[control] passes `usePolling: true` as an OWN key of the same options object', async () => {
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: false });
+    await repo.start();
+
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+    const [, options] = watchSpy.mock.calls[0] as [string, Record<string, unknown>];
+
     expect(Object.prototype.hasOwnProperty.call(options, 'usePolling')).toBe(true);
     expect(options.usePolling).toBe(true);
   });

--- a/packages/metadata-fs/test/watcher-atomic-declared.test.ts
+++ b/packages/metadata-fs/test/watcher-atomic-declared.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #12696 — `startWatcher()` must pass `atomic` to chokidar EXPLICITLY.
+ *
+ * chokidar 5's defaults literal assigns `atomic: true` BEFORE the caller's
+ * options are spread in (`node_modules/chokidar/index.js`):
+ *
+ *   const opts = {
+ *     // Defaults
+ *     ...
+ *     atomic: true, // NOTE: overwritten later (depends on usePolling)
+ *     ..._opts,
+ *     ...
+ *   };
+ *   ...
+ *   // Editor atomic write normalization enabled by default with fs.watch
+ *   if (opts.atomic === undefined)
+ *       opts.atomic = !opts.usePolling;
+ *
+ * so the "overwritten later" comment is aspirational: the correction can
+ * only run when the caller omits `atomic` AND that omission left
+ * `opts.atomic === undefined`, but it never does — the defaults literal
+ * already assigned `true`, and the caller's spread has no `atomic` key to
+ * override it with. The branch is dead.
+ *
+ * The consequence for THIS pin: the RESOLVED value chokidar hands back
+ * (`watcher.options.atomic`) is `true` whether `startWatcher()` declares it
+ * or not — a merged-value read cannot tell "declared here" apart from
+ * "inherited a dead branch that happens to agree today". A pin written
+ * against that merged read would stay green across the exact regression it
+ * exists to catch: a future chokidar release that fixes the ordering (making
+ * the correction real) would then silently flip this repository's watcher to
+ * `atomic: false` under `usePolling` — losing the 100ms unlink-coalescing
+ * deferral and the `DOT_RE` editor-temp matcher from a live delivery path —
+ * and nothing here would notice.
+ *
+ * So this pin does not read the merged option. It reads the ACTUAL call
+ * `startWatcher()` makes to `chokidar.watch()`, via a spy that lets the real
+ * call through unchanged (this pins DECLARATION, not delivery — every other
+ * watcher behaviour in this package must keep working identically). That is
+ * a runtime observation of what this repository hands off, not a grep of the
+ * call-site literal, and it is the one thing whose presence a future
+ * chokidar default cannot silently override.
+ *
+ * ⛔ No wall-clock wait anywhere in this file, deliberately (see
+ * `watch-dot-root.test.ts` for the standing prohibition and its history of
+ * merge-queue ejections). None is needed: the root is created by `mkdtemp()`
+ * before `start()` runs, so `start()` arms the watcher SYNCHRONOUSLY inside
+ * its own call (see its comment on #7000/#9339) — `chokidar.watch()` is
+ * invoked, and the spy has recorded the call, by the time `start()`'s
+ * promise resolves. This case never touches the 100ms unlink window itself
+ * (out of scope for #12696 — see the card's "carry forward" section).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import chokidar from 'chokidar';
+import { FileSystemRepository } from '../src/index.js';
+
+describe('FileSystemRepository — startWatcher() declares `atomic` explicitly (#12696)', () => {
+  let root: string;
+  let repo: FileSystemRepository | undefined;
+  let watchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'objectstack-fsatomic-'));
+    // Let the real call through — nothing here is faked, so every other
+    // watcher behaviour this case exercises stays exactly as it runs in
+    // production.
+    watchSpy = vi.spyOn(chokidar, 'watch');
+  });
+
+  afterEach(async () => {
+    if (repo) await repo.close().catch(() => undefined);
+    repo = undefined;
+    watchSpy.mockRestore();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('passes `atomic: true` as an OWN key of the options object handed to chokidar.watch()', async () => {
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: false });
+    await repo.start();
+
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+    const [, options] = watchSpy.mock.calls[0] as [string, Record<string, unknown>];
+
+    // The behaviour this pin exists to protect: `atomic` must be an OWN key
+    // of the call-site options object, not merely absent-and-coincidentally
+    // `true` after chokidar's internal merge (see file header).
+    expect(Object.prototype.hasOwnProperty.call(options, 'atomic')).toBe(true);
+    expect(options.atomic).toBe(true);
+
+    // Positive control. `usePolling` is unconditionally declared today and
+    // untouched by this card's fix — if THIS assertion ever failed too, the
+    // spy/harness is the suspect, not the `atomic` declaration.
+    expect(Object.prototype.hasOwnProperty.call(options, 'usePolling')).toBe(true);
+    expect(options.usePolling).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #12696

## What

`FileSystemRepository.startWatcher()` (`packages/metadata-fs/src/repository.ts`) constructs its chokidar watcher with `usePolling: true` but never passed `atomic`, leaving it inherited from chokidar's own defaults merge. This PR declares `atomic: true` explicitly, at the call site, with a comment explaining why — **option A** from the card, behaviour-preserving.

## Why this is a declaration, not a behaviour change

Read chokidar 5.0.0's installed source (`node_modules/chokidar/index.js`) directly:

```js
const opts = {
  // Defaults
  ...
  atomic: true, // NOTE: overwritten later (depends on usePolling)
  ..._opts,
  ...
};
...
// Editor atomic write normalization enabled by default with fs.watch
if (opts.atomic === undefined)
    opts.atomic = !opts.usePolling;
```

The defaults literal assigns `atomic: true` *before* the caller's options are spread in. Since this repository never passed `atomic`, the caller's spread has no `atomic` key to override the default with — `opts.atomic` is `true`, never `undefined`, so the `=== undefined` correction can never fire. The comment beside it ("Editor atomic write normalization enabled by default with fs.watch") reads as "off under polling"; the actual resolved value has been `true` regardless, this whole time.

**Runtime-verified, not just read**, per the card's instruction that a merge-order claim is exactly the kind a version bump falsifies silently: constructed a watcher the way `startWatcher()` does (`usePolling: true`, no `atomic`) against a real temp directory and read back `watcher.options.atomic` — `true`. Then constructed it again with `atomic: true` passed explicitly — also `true`. Identical resolved value either way, confirming this change is behaviour-preserving today.

## The pin

`packages/metadata-fs/test/watcher-atomic-declared.test.ts` — because the resolved value is `true` whether declared or not (see above), a pin reading `watcher.options.atomic` can't tell "declared" from "inherited a dead branch that happens to agree today", and would stay green across the exact regression it exists to catch (a future chokidar release that fixes the ordering, making the correction real, would then silently flip this repository to `atomic: false` under polling). So the pin instead spies on the actual `chokidar.watch()` call `startWatcher()` makes and asserts `atomic` is an OWN key of the options object handed to it — a runtime observation of what this repository hands off, not a grep of the call-site literal. A separate `[control]` case asserts `usePolling` the same way, independently, so it can be read as a positive control under the ablation below.

No wall-clock wait anywhere in the new test file (this package's test suite carries a standing prohibition on fixed wall-clock budgets after repeated merge-queue ejections) — none is needed, since `start()` arms the watcher synchronously once the root exists.

### Ablation (pin proven red)

Removed the explicit `atomic: true,` block from `startWatcher()` (returning it to the pre-fix, inherited shape), confirmed the removal landed on disk via anchored `grep` in both directions (marker present before, absent after, byte hash changed), then ran the full `@objectstack/metadata-fs` suite against the mutated tree inside a `trap ... EXIT INT TERM`-guarded window (absolute paths):

- **Predicted** (written before mutating): `watcher-atomic-declared.test.ts` — 1 failed / 1 passed (the `atomic` case red, the `[control]` `usePolling` case green); full package suite 69/70 tests green.
- **Observed**: exactly that — `Test Files 1 failed | 9 passed (10)` / `Tests 1 failed | 69 passed (70)`. The failing assertion: `expect(Object.prototype.hasOwnProperty.call(options, 'atomic')).toBe(true)` → `false`. The `[control]` case passed.

Restored via `git checkout HEAD -- PATH` (both from the trap and confirmed again explicitly afterward): `git diff HEAD` empty, and `git hash-object` on the restored file matches the HEAD blob hash. Re-ran the full suite once more on the restored tree: 10/10 files, 70/70 tests green.

## Not addressed here (by design — see the card)

Whether `atomic: true` — the 100ms unlink-coalescing deferral and the `DOT_RE` editor-temp-file matcher it turns on — is actually the *right* value for this watcher. No evidence surfaced (here or in the card) that either behaviour has ever affected a run. Flipping it to `false` (chokidar's stated intent under `usePolling`) removes both from a live delivery path and needs its own reverse verification; that is not this card.

## Clause ②

Neither. This does not accept or reject any contract, and does not widen any public/exported surface — `atomic` is a private call-site option passed to a third-party library (chokidar), never exported by this package. The resolved runtime value is unchanged (verified above); only its declaration changes.

## Changeset

`patch` on `@objectstack/metadata-fs`. Argued in the changeset body: the resolved watcher behaviour is verified byte-for-byte identical before and after (see above) — nothing consumer-visible changes, so this is not a `minor`/`feature` bump. It is not a `major` either, since nothing breaks. `patch` is the correct floor for an internal, behaviour-preserving clarification.

## Gates

Derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the actual changed paths (`packages/metadata-fs/src/repository.ts`, `packages/metadata-fs/test/watcher-atomic-declared.test.ts`, `.changeset/metadata-fs-watcher-atomic-declared.md`), re-derived after the final commit and after `git fetch origin main`. Full run log kept for review; every result below is the gate's own printed verdict line, captured before any pipe.

**Green** (25 of 26 measurable):
`check:changeset-gate-self-tests`, `check:cross-package-test-inputs` (×2 wrappers), `check:objectql-double-limit`, `check:objectui-changeset`, `check:page-declaration-shape`, `check:pm-half-states`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-comment-mask-adoption`, `check-empty-changeset`, `check-plugin-teardown-shape`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment`, `pm/release-rehearsal-clone --self-test`, plus the convention-triggered set for the new test file: `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`.

**NOT MEASURED** (2, both environmental, neither a defect in this diff):
- `node scripts/pm/check-half-states.mjs` — exit 3, `PREREQUISITE NOT MET`: this container's `GITHUB_TOKEN` is a proxy placeholder, not a real GitHub credential, so the script's own `GET /rate_limit` probe refuses before sweeping anything. Unrelated to the changed paths.
- `pnpm check:type-check-debt` (`--re-measure`) — not run: it needs the FULL workspace build closure (`turbo run build --filter=./packages/* --filter=./packages/*/*`, all 78 packages), which is out of proportion for this card. `@objectstack/metadata-fs` typechecks at 0 errors in both `tsconfig.json` and `tsconfig.test.json` (confirmed directly, including the new test file — it is not in the DEBT/EXEMPT ledger at all), so a ratchet move from this diff is very unlikely, but this is a stated gap, not a claimed green.

`main` CI will run the full gate farm regardless; the maintainer/PM's review of that run is authoritative over local coverage.

## Local verification (this diff's own)

- `pnpm --filter @objectstack/metadata-fs test` — 10/10 files, 70/70 tests green (before ablation, and again after restore).
- `pnpm --filter @objectstack/metadata-fs typecheck` — clean, 0 errors (`tsconfig.json` + `tsconfig.test.json`).
- `node scripts/check-nul-bytes.mjs` — clean.

## Deviations from the dispatch

- Split the pin's positive control into its own `it()` case partway through (see the "The pin" section) so it demonstrably runs to completion and shows green under the ablation, rather than being unreachable behind the (correctly) failing assertion above it in a single case. Reflected in two small follow-up commits on this branch.
- `pnpm check:type-check-debt`'s `--re-measure` half reported as NOT MEASURED rather than run, for the proportionality reason stated above under Gates.

Draft — not flipping ready or arming auto-merge; that's the PM's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZbWd2jNV1FErXTPSS4Dry)_