### PR TITLE
fix(scripts): make check-cli-command-ids' literal-declaration self-test able to fail

### DIFF
--- a/scripts/check-cli-command-ids.mjs
+++ b/scripts/check-cli-command-ids.mjs
@@ -167,6 +167,14 @@ const POPULATION_ROOTS = ['scripts'];
  * and nothing may appear here that the gate does not walk. A declaration that can drift
  * from the scan is worse than none — it replaces a silent gate with a lying one.
  *
+ * That harm is measured, not argued (#12472): run `extractWatchHints` over this file and
+ * the literal spelling yields the subtree hint while the computed spelling yields NOTHING.
+ * The self-test's own copies of the hint cannot stand in for this line — the extractor
+ * blanks comments and the whole `selfTest` body before it scans, so this declaration is
+ * the only occurrence in the file that the extractor can ever see. Which is exactly why
+ * the `--self-test` case guarding it must search THIS STATEMENT and not the whole file:
+ * spelled as a bare whole-file `includes`, it found its own needle and could not fail.
+ *
  * ⛔ And only roots the gate reads WHOLE belong here. `packages/**` does not: this gate
  * opens `packages/<pkg>/package.json` and each package's `src` subtree, not the root entire, so
  * declaring it would name this gate for a card touching a package README. Naming a root
@@ -537,8 +545,36 @@ function selfTest() {
     separatorless.length > 0 && separatorless.every((r) => ROOT_DIR_WATCH_HINTS.includes(`${r}/**`)));
   t('and nothing is declared that this gate does not walk whole — no fabricated lead',
     ROOT_DIR_WATCH_HINTS.every((h) => POPULATION_ROOTS.includes(h.replace(/\/\*+$/, ''))));
+  // ⭐ This case is SCOPED to the declaration statement and DERIVES its needle. Both
+  // halves are load-bearing, and the naive spelling got both wrong (#12472).
+  //
+  // It used to search the WHOLE file for a needle it spelled inline, so `includes` found
+  // that needle in the ASSERTION rather than in the declaration and the case was
+  // satisfied by its own text: rewriting the declaration into the computed form it
+  // exists to reject left the self-test fully GREEN, all 38 cases passing. A case that
+  // cannot fail is the same under-enforcement this gate was built to catch, one layer in.
+  //
+  // Assembling the needle -- the remedy `check-objectql-double-limit.mjs` carries for
+  // the identical idiom -- is NOT sufficient here, which is why this looks different from
+  // its sibling. That file spells the hint twice (declaration, assertion), so un-spelling
+  // the assertion leaves the declaration as the only copy. This file spells it a THIRD
+  // time, in the runtime-value case just below, and a whole-file search finds THAT copy
+  // and stays green on the computed form. Measured. So the scope is the fix and the
+  // derived needle is the hygiene; ⛔ do not widen the search back to the whole file.
+  //
+  // The harm this case names is real, not theoretical -- measured against the extractor
+  // itself: `extractWatchHints` recovers the subtree hint from the literal declaration
+  // and recovers NOTHING from the computed one. The self-test's own copies cannot rescue
+  // it, because `maskSelfTests` blanks this whole function before the scan runs.
+  const ownSource = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+  const declSites = [...ownSource.matchAll(/\bconst\s+ROOT_DIR_WATCH_HINTS\s*=\s*([^;]*);/g)];
+  t('the declaration statement is found exactly once in this source',
+    declSites.length === 1,
+    `${declSites.length} site(s) matched -- the case below cannot judge what it cannot locate`);
   t('the declaration is spelled as a LITERAL in this source, not computed',
-    readFileSync(fileURLToPath(import.meta.url), 'utf8').includes("'scripts/**'"),
+    declSites.length === 1 && ROOT_DIR_WATCH_HINTS.length > 0
+    && ROOT_DIR_WATCH_HINTS.every((h) =>
+      declSites[0][1].includes(`'${h}'`) || declSites[0][1].includes(`"${h}"`)),
     'the hint extractor reads source text; a computed `${r}/**` builds no hint at all');
   t('scripts is the root it declares, and the population really reaches across it',
     ROOT_DIR_WATCH_HINTS.includes('scripts/**')


### PR DESCRIPTION
Fixes #12472

`check-cli-command-ids --self-test` carried a case pinning that `ROOT_DIR_WATCH_HINTS` is
spelled as a source **literal** rather than computed. The case could not fail: it searched
the whole file for a needle it spelled inline, so `includes` found that needle in the
**assertion** rather than in the declaration, and the case was satisfied by its own text.

## Reproduced before fixing, on `origin/main` at `168941cea`

Rewriting only the declaration into the computed form the case exists to reject:

```
declaration line, mutated on disk:
  184: const ROOT_DIR_WATCH_HINTS = POPULATION_ROOTS.map((r) => `${r}/**`);

self-test verdict on that tree:
  check-cli-command-ids self-test: 38 cases pass
  SELFTEST_EXIT=0
```

Not one case reddened. That confirms the card's reading of the neighbouring case too: it
asserts the array's runtime **value**, which the computed form still satisfies, so it does
not close the gap.

## The harm is real, not theoretical

Measured against the extractor itself (`extractWatchHints` in `scripts/pm/dispatch-gates.mjs`):

| declaration spelling | subtree hints recovered |
|---|---|
| literal | `["scripts/**"]` |
| computed | `[]` |

So the computed form really does leave the gate unnameable by every dispatch brief. The
self-test's own copies of the hint cannot stand in for the declaration, because
`extractWatchHints` runs `maskSelfTests(maskComments(source))` and blanks the whole
`selfTest` body before scanning.

## Why this does not use the assembled-needle shape from its sibling

The card suggests the remedy landed in `scripts/check-objectql-double-limit.mjs` — assemble
the needle so the searched byte sequence exists nowhere but the declaration. **Measured
insufficient here, on disk.** That file spells its hint exactly twice (declaration,
assertion), so un-spelling the assertion leaves the declaration as the only copy. This file
spells it a **third** time, in the runtime-value case just below. Applying the
assembled-needle remedy alone on top of a computed declaration:

```
assembled needle present : 1
inline needle gone       : 0
computed decl present    : 1
remaining literal spellings anywhere in file:
  545:    ROOT_DIR_WATCH_HINTS.includes('scripts/**')

check-cli-command-ids self-test: 38 cases pass
SELFTEST_EXIT=0
```

Still cannot fail. So the fix scopes the search to the **declaration statement** and derives
the needle from the declared values — scope is the fix, the derived needle is the hygiene.
Being generic over `ROOT_DIR_WATCH_HINTS` rather than pinning one string, it also grows with
the declaration. A companion case asserts the declaration statement is located exactly once,
so the pin cannot silently judge nothing.

The declaration stays a literal, as the ruling requires; nothing in this change makes it
computed.

## Ablation, both directions, on disk

Mutation and restore each proved on disk by anchor counts, and the restore leg additionally
by `git hash-object` against the HEAD blob plus an empty `git diff HEAD`.

| leg | declaration on disk | verdict |
|---|---|---|
| mutate | computed | `1 of 39 case(s) failed` — `the declaration is spelled as a LITERAL in this source, not computed`, `SELFTEST_EXIT=1` |
| restore | literal | `check-cli-command-ids self-test: 39 cases pass`, `git diff HEAD` empty |

No build step is involved: this gate is run directly from source by `node`, so there is no
`dist/` for a stale artifact to hide in.

## Sibling survey

`scripts/check-parse-guard.mjs` is still **cleared**, and for a slightly stronger reason than
the card states: it carries no own-source `readFileSync(fileURLToPath(import.meta.url))` pin
at all, so it has no assertion of this shape to be phantom. Swept all 13 gates carrying the
`ROOT_DIR_WATCH_HINTS` idiom — exactly two carry an own-source pin
(`check-cli-command-ids.mjs`, fixed here, and `check-objectql-double-limit.mjs`, whose hint
is spelled once). No third gate has grown the shape, so nothing is widened into this PR.

## Gates

Re-derived for the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(no path arguments — the script takes its own change set from the merge base); it named the
same families as the dispatch brief, adding none. Union run against `c20665400`, the final
commit, all green:

```
check:agent-test-spelling · check:bash32-floor · check:cli-command-ids
check:cross-package-test-inputs · check:entry-guard · check:parse-guard
check:pnpm-filter-targets · check:nul-bytes
node scripts/check-ci-filter-parity.mjs · node scripts/check-cross-package-test-inputs.mjs
node scripts/pm/bare-root-worklist.mjs --self-test · check:pm-dispatch-gates
```

Both convention-triggered ledger obligations were run and are satisfied without a new row —
this change adds no population root and moves no spelling:

```
bare-root-worklist --self-test:
  OK  self-test: 46 live row(s), 39 unreachable as spelled, 39 recorded verdict(s)
      — none stale, none missing, none contradicted.
check:pm-dispatch-gates:
  dispatch-gates self-test: 719 cases pass.
```

`check-ci-filter-parity.mjs` first reported `PREREQUISITE NOT MET` (it imports `yaml`, absent
from a fresh worktree); `pnpm install` was run and it then passed — recorded here because the
first reading measured nothing and must not be read as either colour.

Repo-wide `pnpm lint` is left to CI, which runs the farm exactly once regardless.

`skip-changeset`: the only file touched is `scripts/check-cli-command-ids.mjs`, a repo-root
gate script that is not part of any published package, so nothing ships to a consumer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_