### PR TITLE
fix(scripts): close the bash 4.0 operator gap in check-bash32-floor's denylist

### DIFF
--- a/scripts/check-bash32-floor.mjs
+++ b/scripts/check-bash32-floor.mjs
@@ -85,6 +85,34 @@
  * cover: they execute the real path with the builtin disabled, so a dynamically
  * built `mapfile` fails there and nowhere else. Two instruments, one class.
  *
+ * ## The 4.0 operator set, and what is deliberately NOT in the table
+ *
+ * A denylist's absences read as approvals, so the absences are written down
+ * here rather than left to be re-derived one card at a time. After the sweep,
+ * every OPERATOR bash 4.0 added has a row: `|&`, `&>>`, `;&`, `;;&`,
+ * `${x^^}`/`${x,,}`, and the `{x..y..incr}` brace increment. Out, with reasons:
+ *
+ *   `**` (globstar). Not a construct on its own — `**` without `shopt -s
+ *   globstar` is two ordinary globs and legal on 3.2, so what is refusable is
+ *   the option, and the `shopt-4` row already refuses it. A literal `**` token
+ *   would also fire on arithmetic exponentiation and on every doubled asterisk
+ *   in a `find` argument.
+ *
+ *   `test -v` / `[ -v ]`. The `-v` unary is bash 4.1 for `test`, `[` and `[[`
+ *   alike, and the `has-v` row sees only the `[[` spelling — a real hole. It is
+ *   NOT closed by widening that pattern, because `[ -v` is also the opening of
+ *   an ordinary bracket EXPRESSION: `tr -d '[ -v]'` is the character range
+ *   space-to-v. That row needs a false-positive judgement this sweep did not
+ *   take, so it is filed rather than guessed at.
+ *
+ *   New FLAGS on builtins already refused whole (`mapfile -d`, `readarray -C`).
+ *   A `builtin` row refuses its builtin at every flag, so these need no row.
+ *
+ *   Variables added after 4.0 — `BASH_XTRACEFD` (4.1), `BASH_ARGV0` (5.0),
+ *   `SRANDOM` (5.1), `PROMPT_DIRTRIM`. Outside the 4.0 line this sweep drew.
+ *   They are named here so the next reader inherits the list instead of
+ *   rediscovering it, which is the cost this section exists to stop paying.
+ *
  * ## Population
  *
  * Tracked files under `POPULATION_ROOTS` that are shell: a `.sh` name, or a
@@ -176,6 +204,13 @@ const CMD_POS =
  * actually decides findings: that each `pattern` matches a real, parseable
  * instance of the construct it claims to describe, and matches nothing in the
  * exempt forms beside it.
+ *
+ * The four rows added by the 4.0 operator sweep (`pipe-both`,
+ * `case-fallthrough-next`, `brace-increment`, `bashpid`) are the exception:
+ * their versions were read off the bash NEWS text itself, which was reachable
+ * from the seat that added them. `|&` is "a synonym for `2>&1 |`", `;&` and
+ * `;;&` are the two new case terminators, and `$BASHPID` is "a new variable" —
+ * all four entries under bash 4.0.
  *
  * `kind` selects the exemption rule, and is the whole of E2/E3:
  *
@@ -308,6 +343,32 @@ export const CONSTRUCTS = [
     probe: 'case x in x) echo a ;;& *) echo b ;; esac',
     exemptProbe: 'case x in x) echo a ;; esac',
   },
+  //
+  // ⚠️ The two `case` terminators bash 4.0 added are a PAIR, and the row above
+  // owns only one of them. Bash's own names, from the 4.0 NEWS: `;&` "causes
+  // execution to continue with the action associated with the next pattern",
+  // `;;&` "causes the shell to test the next set of patterns". So the id
+  // `case-fallthrough` above sits on `;;&` for historical reasons — the row
+  // below is the actual fall-through. The ids are not renamed here: an id is
+  // what a finding is reported under, and this card's job is closing an
+  // ABSENCE, not renaming what is present.
+  //
+  // The lookbehind is load-bearing and not cosmetic: `;;&` CONTAINS `;&`, so a
+  // bare `;&` token double-flags every `;;&` line, and half of each pair of
+  // findings then names the wrong construct and the wrong repair. Both
+  // directions of the disjointness are pinned in `--self-test`, because a
+  // one-sided pin passes with the lookbehind deleted.
+  {
+    id: 'case-fallthrough-next',
+    since: '4.0',
+    kind: 'syntax',
+    spelling: ';& case terminator — fall through to the next action, untested',
+    token: String.raw`(?<!;);&`,
+    breaks: 'a syntax error at parse time, so the script does not start',
+    fix: 'repeat the body, or restructure as `if`',
+    probe: 'case x in x) echo a ;& *) echo b ;; esac',
+    exemptProbe: 'case x in x) echo a; echo b ;; esac',
+  },
   {
     id: 'has-v',
     since: '4.2',
@@ -340,6 +401,66 @@ export const CONSTRUCTS = [
     fix: '>> file 2>&1',
     probe: 'echo hi &>> /dev/null',
     exemptProbe: 'echo hi >> /dev/null 2>&1',
+  },
+  //
+  // `|&` is the row above's twin: same bash release, same table, and until this
+  // sweep only one of the two was known here — which is the whole shape of a
+  // denylist defect, because an absence from a denylist reads as an approval.
+  // The two differ in the DIRECTION of the 3.2 failure, and the messages say
+  // so: `&>>` is parsed as `&` then `>>` and quietly BACKGROUNDS the command,
+  // while `|&` does not parse at all.
+  {
+    id: 'pipe-both',
+    since: '4.0',
+    kind: 'syntax',
+    spelling: '|& pipe-both operator',
+    token: String.raw`\|&`,
+    breaks:
+      'a syntax error at parse time ("syntax error near unexpected token &") — the script does '
+      + 'not start, so not one line of it runs',
+    fix: '2>&1 | — which is what bash 4.0 documents `|&` as a synonym for',
+    probe: 'echo a |& cat',
+    exemptProbe: 'echo a 2>&1 | cat',
+  },
+  //
+  // The sweep's one QUIET row. `{x..y}` is old enough for the floor; the
+  // optional `..incr` third field is 4.0, and a bash that cannot parse a
+  // sequence expression does not complain — it leaves the whole brace word
+  // LITERAL (measured on this host with a deliberately unparseable increment:
+  // `{1..10..x}` prints back as its own ten characters). So the 3.2 symptom is
+  // a loop that runs exactly ONCE, over a nonsense value, at exit 0.
+  //
+  // The pattern is deliberately tighter than the other `syntax` rows: a
+  // sequence expression's fields are alphanumeric runs and an integer step, so
+  // requiring that shape keeps ordinary brace LISTS of relative paths —
+  // `cp {../a,../b} .`, which carries two `..` runs inside one pair of braces —
+  // out of the findings. Pinned both ways below.
+  {
+    id: 'brace-increment',
+    since: '4.0',
+    kind: 'syntax',
+    spelling: '{x..y..incr} brace-expansion increment',
+    token: String.raw`\{[A-Za-z0-9]+\.\.[A-Za-z0-9]+\.\.[-+]?[0-9]+\}`,
+    breaks:
+      'NOT an error — the brace word is left literal, so the loop runs ONCE over the string '
+      + '`{1..10..2}` itself and the run exits 0. The quiet direction, and the reason this row exists',
+    fix: '`seq FIRST INCR LAST` in a `for` loop, or an explicit counter',
+    probe: 'for i in {1..10..2}; do echo "$i"; done',
+    exemptProbe: 'for i in {1..10}; do echo "$i"; done',
+  },
+  {
+    id: 'bashpid',
+    since: '4.0',
+    kind: 'variable',
+    spelling: 'BASHPID',
+    token: String.raw`\$\{?BASHPID(?:[^A-Za-z0-9_]|$)`,
+    breaks:
+      'unbound. Under `set -u` that is fatal; without it the read yields EMPTY, so a pid-derived '
+      + 'lock name or tempdir collapses to a shared constant and stops separating processes',
+    fix: '`$$` read through a `${...:-}` guard — noting `$$` is the PARENT shell\'s pid inside a '
+      + 'subshell, which is the difference BASHPID exists for',
+    probe: 'lock="/tmp/l.$BASHPID"',
+    exemptProbe: 'lock="/tmp/l.${BASHPID:-$$}"',
   },
   {
     id: 'epoch-vars',
@@ -602,6 +723,69 @@ function selfTest() {
   t('3.2-legal `;;` is not flagged', ids('case x in x) echo a ;; esac').length === 0);
   t('3.2-legal `read -n 1` is not flagged', ids('read -n 1 ch').length === 0);
   t('3.2-legal `exec 9>` is not flagged', ids('exec 9>"$lock"').length === 0);
+
+  // --- ⭐ a COVERAGE FLOOR: deleting a row must redden this self-test -------
+  //
+  // Every leg above that iterates `CONSTRUCTS` is parameterised BY the table,
+  // so deleting a row deletes its own tests and the suite stays green with the
+  // coverage gone — which is the exact species this gate exists to refuse, one
+  // level up, in the instrument instead of the tree. These cases are not
+  // parameterised: they name real lines and require that SOMETHING still
+  // refuses each one. Written against behaviour rather than ids, so renaming a
+  // row is free and removing its coverage is loud. `&>>` is in the list as the
+  // control — it is the row whose presence made the `|&` absence legible.
+  for (const [label, line] of [
+    ['&>> (append-both)', 'exec "$@" &>> "$logfile"'],
+    ['|& (pipe-both)', 'make build |& tee build.log'],
+    [';& (case fall-through)', 'case "$1" in -v) verbose=1 ;& *) run ;; esac'],
+    ['{x..y..incr} (brace increment)', 'for i in {0..100..10}; do echo "$i%"; done'],
+    ['$BASHPID', 'tmp="$TMPDIR/work.$BASHPID"'],
+  ]) {
+    t(`the table still refuses ${label}`, scanText('f.sh', line).length > 0, line);
+  }
+
+  // --- ⭐ the two `case` terminators stay DISJOINT --------------------------
+  //
+  // `;;&` CONTAINS `;&`. Without the `;&` row's lookbehind every `;;&` line
+  // yields two findings, one of them naming the wrong construct and the wrong
+  // repair. Pinned in BOTH directions: a one-sided pin passes with the
+  // lookbehind deleted, because `;&` matching `;;&` is invisible from the
+  // `;&`-only side.
+  t(
+    '`;;&` is the case-fallthrough row ALONE',
+    ids('case x in x) echo a ;;& *) echo b ;; esac').join() === 'case-fallthrough',
+    `got ${JSON.stringify(ids('case x in x) echo a ;;& *) echo b ;; esac'))}`,
+  );
+  t(
+    '`;&` is the case-fallthrough-next row ALONE',
+    ids('case x in x) echo a ;& *) echo b ;; esac').join() === 'case-fallthrough-next',
+    `got ${JSON.stringify(ids('case x in x) echo a ;& *) echo b ;; esac'))}`,
+  );
+
+  // --- ⭐ the 3.2 replacements the new rows point at must stay GREEN --------
+  //
+  // The load-bearing half. A `|&` pattern that also matched `2>&1 |` would red
+  // every correct pipeline in the repo — the gate refusing its own remedy — and
+  // the failure text tells operators to write exactly that.
+  t('`2>&1 |`, the replacement `|&` is a synonym FOR, is not flagged', ids('echo a 2>&1 | cat').length === 0);
+  t('an ordinary pipe is not flagged', ids('grep -c . f | wc -l').length === 0);
+  t('an ordinary background `&` is not flagged', ids('long_job &').length === 0);
+  t('3.2-legal `{1..10}` (no increment) is not flagged', ids('echo {1..10}').length === 0);
+  t('3.2-legal `{a..z}` is not flagged', ids('echo {a..z}').length === 0);
+  t(
+    'a brace LIST of relative paths is not a sequence expression',
+    ids('cp {../a,../b} .').length === 0,
+    'two `..` runs inside one brace pair, and no increment',
+  );
+  t('a `for` over an explicit list is not flagged', ids('for i in 0 10 20; do echo "$i"; done').length === 0);
+
+  // --- E2 again, for the row the sweep added --------------------------------
+  t('E2 `$BASHPID` is an unguarded read → RED', ids('p=$BASHPID').includes('bashpid'));
+  t('E2 `${BASHPID}` is an unguarded read → RED', ids('p=${BASHPID}').includes('bashpid'));
+  t('E2 `${BASHPID:-$$}` is the repair → green', !ids('p="${BASHPID:-$$}"').includes('bashpid'));
+  t('E2 a bare word is not a read: `unset BASHPID` → green', !ids('unset BASHPID').includes('bashpid'));
+  t('E2 `$BASHPIDX` is a different name → green', !ids('p=$BASHPIDX').includes('bashpid'));
+  t('and `$$` — the 3.2 spelling — is not flagged', ids('p=$$').length === 0);
 
   // --- population membership -----------------------------------------------
   t('a .sh name is shell', isShell('scripts/x.sh', 'echo hi').by === 'extension');


### PR DESCRIPTION
Fixes #12634

`check-bash32-floor.mjs` refused `&>>` (append-both) but not `|&` (pipe-both) — same bash release, same class, one caught and one not. Because the table is a **denylist**, that absence read as an approval. Triage set the scope wider than the one entry for exactly that reason, so this sweeps the whole bash 4.0 operator set in one pass.

## Premise, re-derived on this base rather than inherited

The dispatch brief carried a reading; it was re-measured here on `168941cea`, with the control that makes the zero mean something:

```
construct ids present: 15
"append-both" -> 2 hits      (control: fires)
"pipe-both"   -> 0 hits
```

The absence is real, not a grep that could not match.

## What the sweep adds

| id | operator | bash | what 3.2 does |
|---|---|---|---|
| `pipe-both` | `\|&` | 4.0 | **hard syntax error** — the script does not start |
| `case-fallthrough-next` | `;&` | 4.0 | **hard syntax error** — the script does not start |
| `brace-increment` | `{x..y..incr}` | 4.0 | **silent** — brace word left literal, loop runs once, exit 0 |
| `bashpid` | `$BASHPID` | 4.0 | unbound: fatal under `set -u`, otherwise EMPTY |

15 to 19 constructs. Two things worth calling out:

**Versions were read, not asserted.** The dispatch brief's own assumption — that `|&` is 4.0 and its 3.2 behaviour is a hard syntax error, louder than `&>>` merely backgrounding — was checked against the bash NEWS text rather than taken on faith, and it holds: `|&` is "a synonym for `2>&1 |`", `;&` and `;;&` are the two new case terminators, `$BASHPID` is "a new variable", all four under 4.0. The file's header records that these four rows differ from the pre-existing tier-2 rows in exactly that respect.

**The sweep found a construct whose 3.2 failure is quiet, and the entry says so.** `{x..y..incr}` is not an error on a shell that cannot parse it — bash leaves any unparseable sequence expression **literal**. Measured on this host with a deliberately invalid increment: `echo {1..10..x}` prints back its own ten characters. So the 3.2 symptom is a loop that runs exactly ONCE over a nonsense value at exit 0. The row's `breaks` text encodes that distinction the way `append-both` already encodes "BACKGROUNDED".

`bashpid` is the one row here that is a **variable rather than an operator**. It is included deliberately: it is the last remaining bash 4.0 addition absent from this table, it is a one-row mirror of the existing `epoch-vars` declaration, and leaving it out would have re-paid this card's cost on the next pass — which is the precise thing triage asked to stop. Flagged here rather than slipped in.

## What is deliberately NOT in the table, and why

Now recorded in the gate's own header so the next reader inherits the list instead of re-deriving it:

- **`**` (globstar)** — not a construct on its own. Without `shopt -s globstar`, `**` is two ordinary globs and legal on 3.2, so what is refusable is the *option*, and the `shopt-4` row already refuses it. A literal `**` token would also fire on arithmetic exponentiation and on every doubled asterisk in a `find` argument.
- **`test -v` / `[ -v ]`** — a real hole, and NOT closed here. `[ -v` is also the opening of an ordinary bracket expression (`tr -d '[ -v]'` is the character range space-to-v), so widening the `has-v` row needs a false-positive judgement this sweep did not take, and a wrong one reddens the tree on correct 3.2 code. Filed separately and out of scope for this PR: #12760.
- **New flags on already-refused builtins** (`mapfile -d`, `readarray -C`) — a `builtin` row refuses its builtin at every flag.
- **Variables added after 4.0** (`BASH_XTRACEFD`, `BASH_ARGV0`, `SRANDOM`, `PROMPT_DIRTRIM`) — outside the 4.0 line this sweep drew, named in the header so they are a written worklist rather than silent approvals.

## Two patterns that carry a judgement, both pinned

**`;&` needs a lookbehind.** `;;&` *contains* `;&`, so a bare token double-flags every `;;&` line and half of each pair names the wrong construct and the wrong repair. The row's token is `(?<!;);&`, and the disjointness is pinned in **both** directions — the ablation below shows why: stripping the lookbehind reds only the `;;&` case, so a one-sided pin would have passed.

**`brace-increment` is tighter than its sibling `syntax` rows.** A loose "two dot-runs inside braces" pattern matches an ordinary brace LIST of relative paths — `cp {../a,../b} .` — so the token requires a real sequence-expression shape. Pinned both ways.

## The negative half, which is the load-bearing one

A `|&` pattern that also matched `2>&1 |` would redden every correct pipeline in the repo — the gate refusing the very remedy its failure text prescribes. Pinned: ``t('`2>&1 |`, the replacement `|&` is a synonym FOR, is not flagged', ...)``, plus an ordinary pipe, an ordinary background `&`, `{1..10}`, `{a..z}`, and the relative-path brace list.

## A coverage floor, because deleting a row was silent

Every existing leg iterates `CONSTRUCTS`, so **deleting a row deleted its own tests and the suite stayed green** — the same species this gate exists to refuse, one level up, in the instrument instead of the tree. Five new cases are not parameterised by the table: they name real lines and require that something still refuses each. Written against behaviour rather than ids, so renaming a row is free and removing its coverage is loud. `&>>` is in that list as the control.

## Evidence

**End to end, both directions, one fixture tree, five bash-4.0 constructs on five lines:**

```
BEFORE (gate at 168941cea):  exit 1 — 1 finding   (only scripts/deploy.sh:7, &>>)
AFTER  (this branch):        exit 1 — 5 findings  (lines 3,4,5,6,7)
```

**Ablation — every pin added, mutate to RED, restore to GREEN.** Restores are `git checkout HEAD -- ABS_PATH` (never bare, which reads a polluted index); each mutation proved on disk by counting the anchor before and after, never by the editor's exit code; each restore proved by `git hash-object` equality against the HEAD blob plus an empty `git diff HEAD`, with an empty hash treated as failure. The harness carries a `trap ... EXIT INT TERM`, used as a crash convenience only, not as proof.

```
delete row pipe-both              anchor 1 -> 0   RED: "the table still refuses |& (pipe-both)"
delete row case-fallthrough-next  anchor 1 -> 0   RED: "the table still refuses ;& (case fall-through)"
delete row brace-increment        anchor 1 -> 0   RED: "the table still refuses {x..y..incr} ..."
delete row bashpid                anchor 1 -> 0   RED: "the table still refuses $BASHPID"
delete row append-both (control)  anchor 1 -> 0   RED: "the table still refuses &>> (append-both)"
strip the (?<!;) lookbehind       anchor 1 -> 0   RED: "`;;&` is the case-fallthrough row ALONE"
loosen the sequence shape         anchor 1 -> 0   RED: "a brace LIST of relative paths is not ..."
ALL ABLATIONS PASSED   (each followed by: bytes match HEAD blob, self-test GREEN again)
```

**Gate union, run at `1a3bee27c` — the final commit on this branch:**

```
check:agent-test-spelling        exit=0     check:parse-guard                exit=0
check:bash32-floor               exit=0     check:pnpm-filter-targets        exit=0
check:cli-command-ids            exit=0     check-ci-filter-parity.mjs       exit=0
check:cross-package-test-inputs  exit=0     check-cross-package-test-inputs  exit=0
check:entry-guard                exit=0     check:nul-bytes                  exit=0
bare-root-worklist --self-test   exit=0     check:pm-dispatch-gates          exit=0
```

The gate's own verdict lines, quoted rather than an exit code:

```
✓ check-bash32-floor self-test: 130 cases pass.          (98 before this change)
✓ check-bash32-floor: 22 tracked shell file(s) ... census: 20 by .sh extension,
  2 by shebang alone; 19 constructs checked, floor bash 3.2.
```

The list was **re-derived for the actual diff** (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which reads its own changeset from the merge base) and matched the brief's nine families with nothing added. The two convention-triggered obligations the tool names for a gate-script edit — `bare-root-worklist --self-test` and `check:pm-dispatch-gates` — were run and are green; neither needed a ledger row, because `POPULATION_ROOTS` is untouched by this diff.

`check-ci-filter-parity.mjs` first exited 1 with `PREREQUISITE NOT MET — the dependency yaml is not installed`. That is a missing `pnpm install` in a fresh worktree, not a finding; it is green above after installing.

**Declared narrowing:** repo-wide `pnpm lint` was not run locally. eslint was run on the changed file only (`--no-inline-config --format json`: 1 file, 0 errors, 0 warnings). CI runs the full farm regardless, and this is a declared narrowing rather than a proven one — no claim is made here about untouched files.

## Notes

- Three `|&` occurrences already exist in the population, all in `scripts/pm/os-verify-lock.sh` and all in **full-line comments**, so E1 exempts them and the tree stays at 0 findings. That was checked before writing the pattern, not after.
- No changeset: root `scripts/` is not a published package, so this ships nothing to consumers. `skip-changeset` applied.
- Observed and deliberately untouched (different file, outside this card's surface): the file-scoped `bash4Constructs` list inside `scripts/objectui-changeset-digest.mjs` carries a narrower construct set than this table. It is not a coverage hole — the repo-wide gate covers `scripts/bump-objectui.sh` with a superset — so no issue was filed for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_