### PR TITLE
refactor(service-analytics): derive the auto-bridge's engine view from the declared contracts

### DIFF
--- a/.changeset/analytics-bridge-engine-aggregate-vocabulary.md
+++ b/.changeset/analytics-bridge-engine-aggregate-vocabulary.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/service-analytics": patch
+---
+
+refactor(service-analytics): derive the analytics auto-bridge's engine view from the declared contracts (#11833)
+
+`plugin.ts` named the data engine through a consumer-local structural
+`DataEngineLike` — the second of the two sites #11833 records, after the
+datasource half that landed as PR #12011. It is now derived from the declared
+contracts: `IDataEngine.aggregate` / `execute?` /
+`resolveEffectiveDatasource?` / `getDriverForObject?` and
+`IObjectQLEngine.getObject`. Optionality is preserved exactly — `aggregate`
+required, everything else `Partial<>` — because these probes are the plugin's
+graceful-degradation seam.
+
+**Why this is `patch` and not a type-only no-op.** Four of the five members
+substitute with no behaviour change. The fifth does not: the deleted structural
+type declared `aggregations[].function` as `string`, while the contract
+declares the six-value `AggregationFunction`. The bridge therefore forwarded
+whatever method string reached it. That forward is now parsed with the spec's
+own enum, so a method the engine contract does not declare is refused at the
+bridge — loudly, naming the aggregation and the legal vocabulary — instead of
+reaching the engine, where `driver-sql` blamed a `function` key the author
+never wrote and the in-memory evaluator answered `null` for every bucket under
+the author's own measure name.
+
+No authored analytics can trigger the new refusal: the one reachable producer
+of a non-aggregate method — a custom-SQL measure (`AggregationMetricType`
+`number` / `string` / `boolean`) — is already refused earlier, caller-facing,
+by `ObjectQLStrategy.resolveMeasureAggregation` (#12209). What is left is host
+drift (a cube object registered without meeting `CubeSchema`), which is why
+the new refusal is a bare `Error` in the undeclared-500 tier rather than an
+ADR-0112 400 that would blame the caller for something they did not write.

--- a/packages/services/service-analytics/src/__tests__/aggregate-bridge-function-vocabulary.test.ts
+++ b/packages/services/service-analytics/src/__tests__/aggregate-bridge-function-vocabulary.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#11833] The plugin's aggregate auto-bridge speaks the ENGINE's aggregate
+ * vocabulary, and refuses anything else instead of forwarding it.
+ *
+ * `plugin.ts` used to name the engine through a consumer-local structural
+ * `DataEngineLike` that declared `aggregations[].function` as `string`. The
+ * declared contract (`IDataEngine.aggregate` →
+ * `EngineAggregateOptions.aggregations[].function`) is the SIX-value
+ * `AggregationFunction`. Nothing compiled the two against each other, so the
+ * bridge forwarded whatever string reached it — and the engine then failed in
+ * the two ways #12209 documents: `driver-sql` blaming a `function` key the
+ * author never wrote, or the in-memory evaluator answering `null` for every
+ * bucket under the author's own measure name (the #4157 class).
+ *
+ * Deriving the local view from the contract makes the forward a compile error;
+ * these cases pin the RUNTIME half of that repair.
+ *
+ * ## Why this refusal is deliberately NOT in the ADR-0112 envelope
+ *
+ * The reachable producer of a non-aggregate method — a custom-SQL measure
+ * (`AggregationMetricType` `number`/`string`/`boolean`) — is refused earlier
+ * and caller-facing by `ObjectQLStrategy.resolveMeasureAggregation` (#12209,
+ * `INVALID_FIELD` / 400). Anything still arriving at the bridge is host drift
+ * (an unparsed cube object, our own drift), which `dataset-refusal.ts`'s module
+ * header assigns to the bare-`Error`, undeclared-500 tier — the same tier it
+ * assigns to `native-sql-strategy.ts`'s "measure … has unrecognised type". The
+ * absence of a `code` is therefore asserted, not overlooked: enveloping this as
+ * a 400 would tell the author to fix something they did not write.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { AggregationFunction } from '@objectstack/spec/data';
+import type { Cube } from '@objectstack/spec/data';
+import type { AnalyticsService } from '../analytics-service.js';
+import { AnalyticsServicePlugin } from '../plugin.js';
+
+type EngineAggregateCall = {
+  object: string;
+  aggregations?: Array<{ function: string; field?: string; alias: string }>;
+};
+
+/**
+ * Minimal `'data'` service: the one member the aggregate bridge requires.
+ * `getObject` answers the schema so the source-field gates can stand.
+ */
+function fakeEngine(calls: EngineAggregateCall[], fields: Record<string, { type?: string }>) {
+  return {
+    getObject: (name: string) => (name === 'opportunity' ? { fields } : undefined),
+    aggregate: async (object: string, options: EngineAggregateCall) => {
+      calls.push({ object, aggregations: options.aggregations });
+      return [{ region: 'west', total: 1 }];
+    },
+  };
+}
+
+function fakePluginContext(services: Record<string, unknown>) {
+  const registered: Record<string, unknown> = {};
+  const warn = vi.fn();
+  return {
+    registered,
+    ctx: {
+      getService: (name: string) => services[name] ?? registered[name],
+      registerService: (name: string, svc: unknown) => { registered[name] = svc; },
+      replaceService: (name: string, svc: unknown) => { registered[name] = svc; },
+      logger: { info() {}, warn, error() {}, debug() {} },
+    },
+  };
+}
+
+const objectqlOnly = () => ({ nativeSql: false, objectqlAggregate: true, inMemory: false });
+
+/**
+ * A cube carrying one measure of the given metric type.
+ *
+ * `type` is widened past `AggregationMetricType` on purpose: the drift case
+ * below needs a cube that never met `CubeSchema`'s parse, which is exactly the
+ * arrival path the refusal is tiered for. A parsed cube cannot carry it.
+ */
+const cubeWithMeasureType = (type: string): Cube => ({
+  name: 'sales',
+  title: 'Sales',
+  sql: 'opportunity',
+  measures: { revenue: { name: 'revenue', label: 'Revenue', type, sql: 'amount' } as Cube['measures'][string] },
+  dimensions: { region: { name: 'region', label: 'Region', type: 'string', sql: 'region' } },
+  public: false,
+});
+
+async function analyticsVia(engine: unknown, cube: Cube): Promise<AnalyticsService> {
+  const { ctx, registered } = fakePluginContext({ data: engine });
+  await new AnalyticsServicePlugin({
+    cubes: [cube],
+    queryCapabilities: objectqlOnly,
+  }).init(ctx as never);
+  return registered.analytics as AnalyticsService;
+}
+
+const selection = { cube: 'sales', dimensions: ['region'], measures: ['revenue'] };
+const schema = { region: { type: 'text' }, amount: { type: 'number' } };
+
+describe('[#11833] the aggregate auto-bridge speaks the engine contract vocabulary', () => {
+  it('forwards a declared aggregate function through to the engine', async () => {
+    // Positive control: without this, the refusal case below could pass because
+    // NOTHING reaches the engine, for reasons that have nothing to do with the
+    // vocabulary.
+    const calls: EngineAggregateCall[] = [];
+    const service = await analyticsVia(fakeEngine(calls, schema), cubeWithMeasureType('sum'));
+
+    await service.query(selection as never);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].aggregations?.[0].function).toBe('sum');
+    expect(AggregationFunction.options).toContain(calls[0].aggregations?.[0].function);
+  });
+
+  it('refuses a method outside the engine vocabulary instead of forwarding it', async () => {
+    // Host drift: a cube object registered without meeting `CubeSchema`, so its
+    // `type` never faced the enum's parse. This is the arrival path the tiering
+    // note above describes.
+    const calls: EngineAggregateCall[] = [];
+    const service = await analyticsVia(fakeEngine(calls, schema), cubeWithMeasureType('median'));
+
+    const err = await service.query(selection as never).then(() => null, (e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    // The wording IS the contract here: it must name the offending method, the
+    // aggregation it belongs to, and the legal vocabulary.
+    expect(err?.message).toContain('"median" is not one of the engine\'s aggregate functions');
+    expect(err?.message).toContain('revenue');
+    for (const fn of AggregationFunction.options) expect(err?.message).toContain(fn);
+    // Undeclared-500 tier, deliberately: no ADR-0112 envelope on this family.
+    expect((err as Error & { code?: string }).code).toBeUndefined();
+    // The load-bearing half — the bad method never reached the engine, so no
+    // driver got a chance to blame a `function` key nobody wrote and no bucket
+    // came back silently null.
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/services/service-analytics/src/plugin.ts
+++ b/packages/services/service-analytics/src/plugin.ts
@@ -2,112 +2,98 @@
 
 import type { Plugin, PluginContext } from '@objectstack/core';
 import type { Cube, FilterCondition } from '@objectstack/spec/data';
+import { AggregationFunction } from '@objectstack/spec/data';
 import type { ExecutionContext } from '@objectstack/spec/kernel';
-import type { IAnalyticsService, IDataDriver } from '@objectstack/spec/contracts';
+import type { IAnalyticsService, IDataDriver, IDataEngine, IObjectQLEngine } from '@objectstack/spec/contracts';
 import { AnalyticsService } from './analytics-service.js';
 import type { AnalyticsServiceConfig } from './analytics-service.js';
 import type { AnalyticsDriverCapabilities } from './strategies/types.js';
 import { pickDisplayField, type DimensionLabelDeps } from './dimension-labels.js';
 
 /**
- * Minimal IDataEngine surface required for the auto-bridge.
- * ObjectQL exposes:
- *   - `aggregate(object, { where, groupBy, aggregations: [{ function, field, alias }] })`
- *   - `execute(sql, options)` for raw SQL pass-through (enables NativeSQLStrategy
- *     and lets the analytics layer emit JOINs for relation traversal).
+ * The slice of the DECLARED engine contracts this plugin's auto-bridges
+ * consume, derived from `IDataEngine` / `IObjectQLEngine` instead of being
+ * re-declared structurally (#4251 B3, extending #11493's ruling and the
+ * datasource half of #11833 that landed as PR #12011).
+ *
+ * A consumer-local structural re-declaration meets no compiler on the PRODUCER
+ * side, so engine-surface drift lands here silently. This seam carried exactly
+ * that: the hand-written `aggregate` declared `aggregations[].function` as
+ * `string` where the contract declares a six-value enum, and nothing compiled
+ * the two against each other.
+ *
+ * Three of these members could not be named from a contract until #12248
+ * landed the #11833 ruling: `resolveEffectiveDatasource` and
+ * `getDriverForObject` (fork 1, declared OPTIONAL exactly so seams like this
+ * one keep degrading), and `getObject`'s structured `ServiceObject` return
+ * (fork 3, which used to be `unknown`). Before those, the structural type was
+ * the only way to name them at all.
+ *
+ * ## Optionality is load-bearing, and this preserves the profile exactly
+ *
+ * `aggregate` stays REQUIRED, as the hand-written type had it: it is the
+ * member a `'data'` service must expose for this bridge to exist, and the
+ * runtime `typeof svc.aggregate === 'function'` probe below is what decides
+ * whether a registered service qualifies.
+ *
+ * Everything else stays OPTIONAL. A lightweight kernel can register a `'data'`
+ * service with no raw-SQL escape hatch, no datasource registry and no schema
+ * registry; the `engine?.x` / `typeof … === 'function'` probes below are the
+ * other half of that graceful-degradation contract. `getObject` is REQUIRED on
+ * `IObjectQLEngine`, so the `Partial<>` around it is not decoration — it is
+ * what keeps this seam usable against an engine that is not ObjectQL.
  */
-interface DataEngineLike {
-  aggregate(object: string, options: {
-    where?: Record<string, unknown>;
-    groupBy?: string[];
-    /**
-     * `filter` (#10576, the contract half of #10413's ruling) is a
-     * per-aggregation predicate over the SOURCE rows — SQL
-     * `FILTER (WHERE …)` semantics — kept optional here in lockstep with
-     * `EngineAggregateOptions['aggregations'][number].filter` so the bridge
-     * below can forward a measure-scoped filter without widening this
-     * interface again the next time #10413's phase-2 lowering needs a place
-     * to put one.
-     */
-    aggregations?: Array<{ function: string; field: string; alias: string; filter?: Record<string, unknown> }>;
-    /** Reference timezone (IANA) for date bucketing — ADR-0053 Phase 2. */
-    timezone?: string;
-    /**
-     * `BaseEngineOptions.context` — identity/tenant of the request. The engine
-     * merges it into the operation context (`mergeReadContext`), which is what
-     * lets its middleware chain inject RLS into `opCtx.ast.where` (#3602).
-     */
-    context?: ExecutionContext;
-  }): Promise<unknown[]>;
-  /**
-   * Raw command pass-through (SQL on driver-sql). The options bag is spelled out
-   * rather than left as `Record<string, unknown>` because **`object` is load-bearing**:
-   * `ObjectQL.execute()` picks its driver in the order
-   * `options.object` → `getDriver(object)`, then `options.datasource`, then the
-   * default driver. A command that reads an object and omits `object` therefore
-   * runs against the DEFAULT datasource — which is how every dataset backed by a
-   * telemetry/audit-routed object read `0` from a populated table (#5033).
-   */
-  execute?(command: unknown, options?: {
-    /** Bound parameters for the command. */
-    args?: unknown[];
-    /** The object this command reads — routes to that object's own datasource. */
-    object?: string;
-  }): Promise<unknown>;
-  /** Return the registered object schema (relationship → target + display-label resolution). */
-  getObject?(name: string): {
-    fields?: Record<string, {
-      type?: string;
-      reference?: string;
-      options?: Array<{ value: unknown; label?: string }>;
-    }>;
-    /** Federation marker (ADR-0015): set on objects bound to an external datasource. */
-    external?: unknown;
-  } | undefined;
-  /**
-   * [#5288] The datasource an object's rows actually live on, by NAME — the
-   * engine's own five-step resolution (explicit `datasource` →
-   * `datasourceMapping` → the ADR-0057 §3.6 lifecycle split → the owning
-   * package's `defaultDatasource` → the deployment default), not the value the
-   * object declares.
-   *
-   * The declared value used to be read straight off `getObject().datasource`,
-   * and it is only step 1 of those five: `ObjectSchema.datasource` defaults to
-   * `'default'`, which in the engine means "no explicit binding, keep looking".
-   * So every object routed by steps 2-4 — `sys_audit_log` among them, routed by
-   * `lifecycle.class: 'audit'` — answered `'default'` and pointed diagnostics at
-   * a database its rows are not in.
-   *
-   * `undefined` ⇒ nothing binds the object anywhere and it rides the
-   * deployment's default datasource (or this engine cannot answer). Optional
-   * because the analytics service runs against engines other than ObjectQL;
-   * absent, the probe below simply never answers, which is the same "cannot
-   * answer, do not block" tiering it already carries.
-   */
-  resolveEffectiveDatasource?(objectName: string): string | undefined;
-  /**
-   * Resolve the storage driver backing an object (public ObjectQL accessor).
-   * Used to delegate temporal storage-form coercion to the driver, which is the
-   * single source of truth for how a `Field.date`/`Field.datetime` is stored on
-   * the active dialect. When the hooks are absent, values and column SQL pass
-   * through untouched — the contract's identity semantics.
-   */
-  getDriverForObject?(objectName: string): TemporalDriverSurface | undefined;
-}
+type DataEngineLike =
+  Pick<IDataEngine, 'aggregate'>
+  & Partial<Pick<IDataEngine, 'execute' | 'resolveEffectiveDatasource' | 'getDriverForObject'>>
+  & Partial<Pick<IObjectQLEngine, 'getObject'>>;
 
 /**
  * The slice of the `IDataDriver` CONTRACT the analytics layer consumes —
  * `temporalFilterValue` / `temporalFilterColumnSql` are first-class contract
- * members since ADR-0053 D-A2, no longer a duck-typed local invention. Picked
- * (rather than using `IDataDriver` whole) because `getDriverForObject` hands
- * back whatever the engine registered, and this seam only needs the temporal
- * surface; the runtime `typeof` guards below remain the correct way to consume
- * an optional contract member.
+ * members since ADR-0053 D-A2, no longer a duck-typed local invention.
+ *
+ * Since #12248 declared `IDataEngine.getDriverForObject?`, this is the
+ * RETURN-side narrowing that member's own docblock prescribes, applied at the
+ * two call sites below — not a re-declaration of the member. `Pick<IDataDriver,
+ * …>` admits the full contract value, so the engine keeps handing back whatever
+ * driver it registered while this seam states the only two members it reads.
+ * The runtime `typeof` guards below remain the correct way to consume an
+ * optional contract member.
  */
 type TemporalDriverSurface = Pick<
   IDataDriver,
   'temporalFilterValue' | 'temporalFilterColumnSql'
 >;
+
+/**
+ * Narrow a strategy-supplied aggregation `method` to the engine contract's
+ * `AggregationFunction`, refusing anything else.
+ *
+ * The two sides genuinely differ: `IDataEngine.aggregate`'s
+ * `aggregations[].function` is the six-value enum, while the analytics
+ * strategy contract that feeds this bridge declares `aggregations[].method` as
+ * `string`. Parsing with the spec's OWN enum keeps a single vocabulary — no
+ * local literal list to drift, and `AggregationFunction`'s error map already
+ * knows the retired `array_agg` / `string_agg` spellings.
+ */
+function parseEngineAggregateFunction(
+  method: string,
+  alias: string,
+): NonNullable<Parameters<IDataEngine['aggregate']>[1]['aggregations']>[number]['function'] {
+  const parsed = AggregationFunction.safeParse(method);
+  if (!parsed.success) {
+    throw new Error(
+      `[Analytics] The aggregate bridge cannot forward the aggregation ` +
+      `"${alias}": "${method}" is not one of the engine's aggregate functions ` +
+      `(${AggregationFunction.options.join(', ')}). A custom-SQL measure is ` +
+      `refused earlier, with a caller-facing diagnostic, by ObjectQLStrategy; ` +
+      `reaching this point means the analytics layer produced a method the ` +
+      `engine contract does not declare.`,
+    );
+  }
+  return parsed.data;
+}
 
 /**
  * Configuration for AnalyticsServicePlugin.
@@ -301,7 +287,31 @@ export class AnalyticsServicePlugin implements Plugin {
           // aggregation carries none, matching the engine's own
           // vacuous-filter convention.
           aggregations: aggregations?.map((a) => ({
-            function: a.method,
+            // [#11833] `function` is the engine contract's SIX-value
+            // `AggregationFunction`, while this bridge's own input declares
+            // `method: string` (`StrategyContext.executeAggregate`, spec
+            // `contracts/analytics-service.ts:300`). Narrowing the engine side
+            // to the contract turned that forward into a compile error — the
+            // correct signal, and the one the deleted structural type hid by
+            // declaring `function: string` on both sides.
+            //
+            // Closed by PARSING with the spec enum itself rather than by
+            // widening back to `string` (what hid it) or casting past it
+            // (which keeps the hole and adds a lie). `AggregationFunction` is
+            // the same schema `AggregationNodeSchema.function` is built from,
+            // so there is one vocabulary, and its own error map already
+            // carries the `array_agg`/`string_agg` retirement prescriptions.
+            //
+            // TIERING, deliberately: the reachable producer of a non-aggregate
+            // method — a custom-SQL measure (`AggregationMetricType`
+            // `number`/`string`/`boolean`) — is already refused upstream with a
+            // caller-blaming 400 by `ObjectQLStrategy.resolveMeasureAggregation`
+            // (#12209). Anything still arriving here is host drift, which that
+            // refusal's docblock assigns to the undeclared-500 tier — so this
+            // throws rather than re-blaming the caller, and it answers loudly
+            // instead of letting the engine answer `null` per bucket under the
+            // author's own measure name (the #4157 class).
+            function: parseEngineAggregateFunction(a.method, a.alias),
             field: a.field,
             alias: a.alias,
             ...(a.filter ? { filter: a.filter } : {}),
@@ -563,7 +573,7 @@ export class AnalyticsServicePlugin implements Plugin {
     ): unknown => {
       try {
         const svc = ctx.getService<DataEngineLike>('data');
-        const driver = svc?.getDriverForObject?.(objectName);
+        const driver: TemporalDriverSurface | undefined = svc?.getDriverForObject?.(objectName);
         if (driver && typeof driver.temporalFilterValue === 'function') {
           return driver.temporalFilterValue(objectName, fieldName, value);
         }
@@ -586,7 +596,7 @@ export class AnalyticsServicePlugin implements Plugin {
     ): string => {
       try {
         const svc = ctx.getService<DataEngineLike>('data');
-        const driver = svc?.getDriverForObject?.(objectName);
+        const driver: TemporalDriverSurface | undefined = svc?.getDriverForObject?.(objectName);
         if (driver && typeof driver.temporalFilterColumnSql === 'function') {
           return driver.temporalFilterColumnSql(objectName, fieldName, columnSql);
         }


### PR DESCRIPTION
Part of #11833

Replaces the consumer-local structural `DataEngineLike` in `packages/services/service-analytics/src/plugin.ts` with the declared `IDataEngine` / `IObjectQLEngine` members — the #4251 B3 sweep pattern, and the **second and last** of the two sites #11833 names. The first landed as PR #12011 (MERGED).

Everything below is split into **MEASURED** (a command was run and its own output is quoted) and **INFERRED** (reasoning from what was read). Every claim names a file and a line.

> **Note on spelling.** This body was re-read after publishing and GitHub's sanitizer had eaten the TypeScript generic arguments (`Pick` … lost everything between the angle brackets). Where a generic must be shown below, **square brackets stand in for the angle brackets**; the real spelling is in the diff.

---

## Why this says `Part of` rather than a closing keyword

An earlier revision of this body carried a closing keyword, on the strength of the card's 2026-08-27 unlock note — *"#12010 does NOT ride on this card closing"* — and of the endorsed rule that when a dispatch names N sites and only M land, the **closing keyword** is what changes, not the scope. Both named sites do land here, so that read was available.

The PM has since **measured the sub-issue structure and reversed that guidance**: #11833 carries `has_children: true` with `sub_issues_summary: {total: 1, completed: 0}`. #12010 is a real GitHub sub-issue, so a closing keyword on this PR would auto-retire a parent showing 0 of 1 children complete — as a **merge side effect rather than anyone's decision**. The endorsed rule is untouched; what changed is that the reason to hold the keyword here is the sub-issue edge, not the scope.

⭐ The card's question **is** fully answered by this PR. The PM will act on that deliberately after the merge, with the reason recorded on the card.

⚠️ Deliberately, no sentence anywhere in this body places a GitHub closing keyword next to an issue number — the reference parser matches `close` / `fixes` / `resolves` plus a number regardless of the surrounding sentence, so even a line *explaining* that this PR does not retire the card would retire it. Prose about the card uses other verbs on purpose.

---

## MEASURED — the five members line up

Re-read on `origin/main` at `87d3f9a0a`, not inherited from the dispatch table:

| local member | declared equivalent | verdict |
|---|---|---|
| `execute?` | `IDataEngine.execute?` — `contracts/data-engine.ts:250` | compatible, derived |
| `aggregate` | `IDataEngine.aggregate` — `contracts/data-engine.ts:230` | derived; **one real mismatch**, below |
| `getObject?` | `IObjectQLEngine.getObject` — `contracts/objectql-engine.ts:207` (and `:90` on the registry view), returning `ServiceObject or undefined` | compatible, derived |
| `resolveEffectiveDatasource?` | `IDataEngine.resolveEffectiveDatasource?` — `contracts/data-engine.ts:321` | compatible, derived |
| `getDriverForObject?` | `IDataEngine.getDriverForObject?` — `contracts/data-engine.ts:342` | compatible, derived |

No member is a fork, so no contract moves and nothing is cast past. The replacement (square brackets standing in for angle brackets, per the note above):

```
type DataEngineLike =
  Pick[IDataEngine, 'aggregate']
  & Partial[Pick[IDataEngine, 'execute' | 'resolveEffectiveDatasource' | 'getDriverForObject']]
  & Partial[Pick[IObjectQLEngine, 'getObject']];
```

**`getObject` was the one that needed #12248 most.** MEASURED: substituting the contract's `ServiceObject` return produced **no** diagnostic at any of its call sites — `plugin.ts:398` (`obj?.fields?.[relationshipName]`, reading `.type` / `.reference`), the `DimensionLabelDeps.getObjectFields` wiring at `:415` (whose declared return is a record of `FieldMetaLite`, `dimension-labels.ts:39`), `pickDisplayField` at `:418`, `isExternalObject` at `:566` and `getObjectFieldNames` at `:592`. The 08-25 report predicted this substitution would "replace real typing with casts at ~10 call sites"; that prediction was made against the old `unknown` return and no longer holds — fork 3's repair is what removed the cost.

**`getDriverForObject` keeps its call-site narrowing, as the contract asks it to.** `data-engine.ts:342`'s own docblock says consumers "keep narrowing the RETURN at the call site (a `Pick` over `IDataDriver` admits the full contract value); what this member ends is each of them re-inventing the MEMBER." So `TemporalDriverSurface` survives — no longer as a re-declared member, but as the annotation on the two locals that read it (`plugin.ts:508`, `:530`).

## MEASURED — every member stays optional, and the profile is preserved exactly

`aggregate` stays **required**, exactly as the hand-written type had it: it is what the `typeof svc.aggregate === 'function'` probe at `plugin.ts:214` uses to decide whether a registered `'data'` service qualifies at all. Every other member stays **optional**. `getObject` is *required* on `IObjectQLEngine`, so the `Partial` wrapper around it is load-bearing rather than decoration — without it, a `'data'` service that is not ObjectQL stops satisfying this view. Nothing became required; a degraded boot does exactly what it did before.

## MEASURED — the `aggregate` enum, the one careful spot

Substituting the contract member with **no other change** produced exactly one new diagnostic, and it is the predicted one:

```
src/plugin.ts(259,11): error TS2322: ...
      Types of property 'function' are incompatible.
        Type 'string' is not assignable to type '"min" | "max" | "count" | "sum" | "avg" | "count_distinct"'.
```

That is the correct signal, and it is reported rather than smothered. What it says: the deleted structural type declared `aggregations[].function` as `string`, the contract declares the six-value `AggregationFunction` (`data/query.zod.ts:149`, reached through `AggregationNodeSchema` at `:262`), and nothing compiled the two against each other.

**First-hand verification of the #12209 refusal, not inherited.** `ObjectQLStrategy.resolveMeasureAggregation` (`strategies/objectql-strategy.ts:1262`) now refuses a custom-SQL measure at `:1296`, keyed on `EXPRESSION_METRIC_TYPES`, with `invalidMemberError` (`INVALID_FIELD` / 400). Read on this branch. Its docblock is also explicit that it deliberately does **not** key on "method is not one of the six", because an enum-invalid metric type "is OUR bug — the undeclared-500 tier".

**How the gap is closed.** Not by widening `function` back to `string` (that is what hid it), and not by a cast. The bridge parses the incoming method with the spec's **own** enum:

```
const parsed = AggregationFunction.safeParse(method);
if (!parsed.success) throw new Error(/* names the aggregation, the method, and the six */);
return parsed.data;
```

One vocabulary, no local literal list to drift, and `AggregationFunction`'s error map already carries the retired `array_agg` / `string_agg` prescriptions. `AggregationFunction` is already a runtime import in this package (`dataset-compiler.ts:4`), so this adds no dependency. The refusal is a bare `Error` in the undeclared-500 tier, matching the tiering `dataset-refusal.ts`'s module header assigns to internal-invariant and host-drift arrivals — enveloping it as a 400 would blame the caller for a cube they did not write. Reviewed and accepted by the PM against `objectql-strategy.ts:1288-1294`, which assigns an enum-invalid method to exactly that tier: this implements the prescribed tiering rather than inventing one, and no caller-visible accept/reject behaviour moves.

INFERRED: no authored analytics can trigger it. The one reachable producer of a non-aggregate method is refused earlier by #12209; `resolveMeasureAggregation` otherwise returns either a surviving metric type or one of a six-element alias list (`objectql-strategy.ts:1318`).

## MEASURED — ablation at the compiler, with a control leg

Predictions were written to a file before either leg ran. Shared note, stated because it changes how the numbers read: this package's tsc program carries **10 pre-existing errors, all in `src/__tests__/`** (it has no `typecheck` script; it is covered through `check:type-check-coverage`'s DEBT ledger, recorded at 10). So tsc exits `2` in both legs and **the exit code is not the verdict** — the verdict is whether a diagnostic lands on `src/plugin.ts`.

- **LEG 1 — MUTATION**, under this PR's derived type: replace the parse with the unchecked forward `function: a.method`.
  - PREDICTED: 11 errors — the 10 baseline plus one `TS2322` on `src/plugin.ts` reading `Type 'string' is not assignable to type '"min" | "max" | …'`.
  - OBSERVED: `tsc exit = 2`, **12** errors. The predicted `TS2322` appeared verbatim, at `src/plugin.ts(289,11)`, with the predicted elaboration. **Honest correction:** the count was 12, not 11 — the mutation also orphaned the helper, producing a second diagnostic `src/plugin.ts(80,10): error TS6133: 'parseEngineAggregateFunction' is declared but its value is never read`. That is an artifact of the mutation, not a second finding, and it is reported rather than rounded away.
- **LEG 2 — CONTROL**, the *same* unchecked forward under `origin/main`'s **original structural type** (main's `plugin.ts` already forwards `a.method` verbatim), written by redirecting `git show origin/main:PATH` into the file — the form that does not stage.
  - PREDICTED: exactly the 10 baseline errors, **zero** on `src/plugin.ts` — green.
  - OBSERVED: `tsc exit = 2`, **10** errors, `plugin.ts diagnostics: (none)`. **GREEN.**

That pair is the point: the unchecked forward typechecks clean on `main` today and does not after this PR. The #4251 drift, demonstrated live at this seam.

Discipline, each leg: mutation confirmed **on disk** by grepping the injected marker **and** the displaced anchor (leg 1: injected 1, displaced 0; leg 2: original interface 1, derived type 0, unchecked forward 1) and by comparing `git hash-object` against the HEAD blob — never a bare `git diff --stat`. `trap 'restore' EXIT INT TERM` on an absolute path from `git rev-parse --show-toplevel`. Restore with `git checkout HEAD -- ABSPATH`, then `disk == index == HEAD` proved three ways (`git diff --quiet`, `git diff --cached --quiet`, empty `git status --porcelain`) plus a blob-hash equality check, with an empty hash treated as failure. After both legs the tree was back at blob `01ef2ea1c`.

## MEASURED — verification

All at final commit **`3e041bcc6`** (branch head; merge base `87d3f9a0a`). Dependency closure built first, so every type judgement reads a freshly built `.d.ts` rather than a stale one: the upstream-closure build for `@objectstack/service-analytics` → `os-verify-lock: VERDICT command-exit 0 · held the lock 157s`.

⚠️ **The dispatch's `pnpm --filter @objectstack/service-analytics typecheck` is the pnpm zero-match trap here, and was NOT run as a result.** This package declares no `typecheck` script (`packages/services/service-analytics/package.json:16` — `build` and `test` only), so that command matches nothing, runs nothing and exits `0`. Substituted with the invocation `check:type-check-coverage` itself uses for this ledger entry:

- `npx tsc --noEmit -p tsconfig.json` in the package → `EXIT=2`, **10 errors, byte-identical to the pre-change baseline**, zero on `src/plugin.ts`. The 10 are the ledger's recorded count and all sit in `src/__tests__/`.
- `pnpm --filter @objectstack/service-analytics test` → **`Test Files 83 passed (83)` · `Tests 1805 passed (1805)`** (baseline 82 / 1803; this PR adds one file with two cases) · `VERDICT command-exit 0`
- `pnpm --filter @objectstack/service-analytics build` → `DTS ⚡️ Build success in 4015ms`, `check-dts-emitted: 1/1 declared declaration file(s) present` · `VERDICT command-exit 0`
- `pnpm lint` (full repo, `eslint . --no-inline-config`, **not** narrowed) → `VERDICT command-exit 0`

**Gate union re-derived live on the actual changed set**, `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, stderr confirming the tree of `objectstack-ai/objectstack` at `3e041bcc6`, the `--repo` assertion holding, and 3 paths vs merge base under three-dot semantics. ⭐ **It named no `contract` family.** All named families ran; each quotes its own verdict line:

| family | verdict |
|---|---|
| `check:changeset-gate-self-tests` | `EXIT=0` — 118 + 212 + 116 assertions |
| `check:cross-package-test-inputs` | `EXIT=0` — "20 package(s) read outside themselves, all declared" |
| `check:objectql-double-limit` | `EXIT=0` — "287 double(s) graded … none new" |
| `check:objectui-changeset` | `EXIT=0` — "objectui-range --self-test: all checks passed" |
| `check:page-declaration-shape` | `EXIT=0` — "34 page entries across 2267 sources … all reach the kernel" |
| `check:pm-half-states` | `EXIT=0` — "1515 cases pass" |
| `check:published-files` | `EXIT=0` — "69 publishable package(s) of 78" |
| `check:slot-lookup` | `EXIT=0` — "ratchet holds: 107 unswept site(s) in 25 file(s), none new" |
| `check:test-source-alias` | `EXIT=0` — "72 packages with tests scanned" |
| `check:type-source-resolution` | `EXIT=0` — "94 tsc program(s) across 77 packages scanned" |
| `check-adr-0087-registration.mjs` | `EXIT=0` — "adds no declared-breaking changeset" |
| `check-changeset-no-major.mjs` | `EXIT=0` — "introduces no `major` bump" |
| `check-ci-filter-parity.mjs` | `EXIT=0` — "all 109 declared cross-package glob(s) … covered" |
| `check-comment-mask-adoption.mjs` | `EXIT=0` — "20 private comment-stripper(s) … all 20 recorded" |
| `check-cross-package-test-inputs.mjs` | `EXIT=0` — "all declared, and turbo.json hashes every declared glob" |
| `check-empty-changeset.mjs` | `EXIT=0` — "No empty-frontmatter changeset introduced" |
| `check-plugin-teardown-shape.mjs` | `EXIT=0` — "64 Plugin implementation(s) across 4892 source(s)" |
| `docs-audit/check-affected-docs.mjs` | `EXIT=0` |
| `docs-audit/check-drift-comment.mjs` | `EXIT=0` — "56 cases pass across 5 fixture diff(s)" |
| `pm/release-rehearsal-clone.mjs --self-test` | `EXIT=0` — "self-test passed" |
| `check:query-options-erasure` (convention) | `EXIT=0` — "ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new" |
| `check:engine-double-contract` (convention) | `EXIT=0` — "691 pinned, 134 in the DEBT ledger, 3 exempt" |
| `check:where-matcher` (convention) | `EXIT=0` — "309 matcher(s) discovered, 309 answer the combinator battery correctly or refuse it loudly" |
| `check:type-check-coverage` (convention) | `EXIT=0` — "65/78 workspace packages type-checked … 13 in the DEBT ledger" |
| `check:type-check-debt` (convention, the ratchet) | `EXIT=0` — "31 ledger entr(ies) re-measured in 212.7s, 1687 raw tsc error(s) total, **none above its recorded number**" — run after the full `turbo run build` over the packages closure (`70 successful, 70 total`), as the gate requires |
| `check:nul-bytes` | `EXIT=0` — "scanned 7111 text file(s) … no raw ASCII control bytes" |

⚠️ **One family produced NO reading and is reported as such, not as a pass:** the bare `node scripts/pm/check-half-states.mjs` invocation exited **3**, and says so itself — *"trigger-file index gathered nothing, so this result says NOTHING about whether the board carries half-states. It is not a clean board and it is not a dirty one — it is no reading at all."* Its `pnpm check:pm-half-states` self-test form is green (above); the board scan needs an index this container does not have. **NOT MEASURED.**

`service-analytics`'s DEBT ledger entry stays at **10**; nothing is lowered and nothing is raised.

## Tests added

`src/__tests__/aggregate-bridge-function-vocabulary.test.ts`, driving the real plugin auto-bridge through the `fakePluginContext` harness this package already uses:

1. **positive control** — a declared aggregate reaches the engine as `function: 'sum'`. Without it, case 2 could pass because nothing reaches the engine for reasons unrelated to the vocabulary.
2. **the refusal** — a method outside the six never reaches the engine (`calls` is empty), the message names the offending method, the aggregation and the whole legal vocabulary, and the error carries **no** `code`, pinning the deliberate undeclared-500 tiering rather than leaving it to chance. The drift is staged with a cube object that never met `CubeSchema`'s parse, which is the arrival path the tiering is written for.

## Changeset: shipped, and here is the argument both ways

PR #12011 shipped `skip-changeset`, and that precedent was **not** copied across unexamined.

- **For `skip-changeset`:** four of the five members are a pure alias swap, the replaced type is file-private, and the emitted JS for those is unchanged.
- **For a changeset (chosen):** the fifth member is not a pure alias swap. The `aggregate` narrowing adds a real runtime boundary — a new `throw` path that did not exist — and changes what a malformed host cube produces from `null` per bucket into a loud, attributed refusal. "Unreachable via any authored path today" is an argument about likelihood, not about whether behaviour moved; it moved.

Shipped as `patch` on `@objectstack/service-analytics` (`.changeset/analytics-bridge-engine-aggregate-vocabulary.md`). No label is needed as a result, so nothing was written to the PR's labels.

## Fences

Zero `packages/spec` — MEASURED, the diff against the merge base is three files: the plugin, the new test, the changeset. Nothing under `content/docs/releases/**`, `docs/adr/**`, `.claude/**`, `skills/**`, `AGENTS.md` or `CLAUDE.md`. Draft; ready was not flipped and auto-merge was not armed.

## Out-of-scope finding

Filed as **#12776** (unassigned, not fixed here; triage owns its routing): `StrategyContext.executeAggregate` (`packages/spec/src/contracts/analytics-service.ts:300`) declares `aggregations[].method` as `string` while `IDataEngine.aggregate` declares the six-value enum — the same slot, two types, one layer up from this seam. It is the reason the bridge needs a runtime parse instead of a compile-time guarantee, and repairing it is an accept-set narrowing on a published contract, which is a spec-seat call rather than a consumer-side one.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194kbQJxUvv2yvsGRtuXpP5)_