### PR TITLE
fix(objectql): single-quote the shadowed package id in the [Registry] Collision warning

### DIFF
--- a/.changeset/registry-collision-quote-style.md
+++ b/.changeset/registry-collision-quote-style.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): single-quote the shadowed package id in the `[Registry] Collision` warning (#12609)
+
+`patch`: a shipped operator-facing log message changes its punctuation, and
+nothing in this repo parses the message beyond substring (`toContain`) test
+assertions — no regex or char-level match on the quote character was found
+(searched non-test `.ts`/`.tsx`/`.js` across the repo, and `content/`/`docs/`,
+for the message text; the two other hits are prose references to the warning
+by name, not parsers of its text). No public export, type, or behavior
+changes.
+
+## What changed
+
+`SchemaRegistry.registerItem`'s cold-boot-order `[Registry] Collision`
+warning (`packages/objectql/src/registry.ts`) double-quoted the shadowed
+package id — `` `... is shipped by package "${shadowed._packageId}" ...` `` —
+against this package's own convention: measured over non-test `.ts` under
+`packages/objectql/src`, quoted identifiers in operator prose are
+single-quoted 174 times against 37 double-quoted, and this line was one of
+the 37. #12563 already settled the same ADR-0005 shadowing fact on the
+automation side (`service-automation`) with single quotes
+(`package 'crm'`), so an operator whose boot hits both packages' collision
+warnings previously read one story in two spellings; this line now matches.
+
+Byte-identical otherwise. Only the quote character around the interpolated
+package id moved.
+
+## Scope
+
+One message, one site
+(`packages/objectql/src/registry.ts`'s `is shipped by package` warning —
+the guard that fires in the common cold-boot order, package registers
+first). A sibling `[Registry] Collision` warning in the same file
+(`ships from package`, the late-registration-order guard) also
+double-quotes its package id and is the same defect class, but is a
+different message and a different site — out of scope here, filed
+separately rather than swept in.
+
+## Test
+
+No existing pin held this message's literal quote character (`toContain(PKG)`
+assertions in `registry-collision-order.test.ts` matched either spelling); one
+is added — asserting the corrected spelling present **and** the pre-fix
+spelling absent, so it is red in both directions, not just green on the fix.
+
+<!-- adr-0087: not-required (no-migration-prescription) Log-text punctuation only; no authorable key, schema, or stored shape changed, so there is nothing for a migration to rewrite. -->

--- a/packages/objectql/src/registry-collision-order.test.ts
+++ b/packages/objectql/src/registry-collision-order.test.ts
@@ -99,6 +99,26 @@ describe('[#12027] SchemaRegistry collision warning is order-symmetric', () => {
     expect(lines[0]).toContain('shadows the package value');
   });
 
+  it('[#12609] quotes the shadowed package id with single quotes, matching this package\'s own convention', () => {
+    // Measured over non-test `.ts` under `packages/objectql/src`: interpolated
+    // identifiers in operator prose are single-quoted 174 times against 37
+    // double-quoted — this line WAS one of the 37. `toContain` is not enough
+    // on its own (a substring check can't see which quote character surrounds
+    // it), so both directions are asserted explicitly: the correct spelling is
+    // present, and the pre-fix spelling is not — the same "would notice a
+    // disagreement" shape #12563 used for the sibling phrase in
+    // `service-automation`.
+    registry.registerItem('flow', { name: 'nightly_sync', label: 'packaged' }, 'name', PKG);
+
+    const lines = collisionsDuring(() => {
+      registry.registerItem('flow', { name: 'nightly_sync', label: 'runtime' }, 'name');
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain(`package '${PKG}'`);
+    expect(lines[0]).not.toContain(`package "${PKG}"`);
+  });
+
   it('LATE-REGISTRATION ORDER — sys_metadata row first, then the package: still warns', () => {
     // Unchanged behaviour, pinned so the repair cannot trade one order for the
     // other. This order is a marketplace install / HMR reload, not a boot.

--- a/packages/objectql/src/registry.ts
+++ b/packages/objectql/src/registry.ts
@@ -3048,7 +3048,7 @@ export class SchemaRegistry {
       if (shadowed) {
         console.warn(
           `[Registry] Collision: ${type}/${baseName} is shipped by package ` +
-          `"${shadowed._packageId}" and a runtime-authored row with the same name has ` +
+          `'${shadowed._packageId}' and a runtime-authored row with the same name has ` +
           `just been registered from sys_metadata. The runtime row now shadows the ` +
           `package value (ADR-0005 overlay precedence): every read of ${type}/${baseName} ` +
           `serves the stored row, not the packaged definition. That is the sanctioned ` +


### PR DESCRIPTION
Fixes #12609

## What changed

`SchemaRegistry.registerItem`'s cold-boot-order `[Registry] Collision` warning (`packages/objectql/src/registry.ts`) double-quoted the shadowed package id:

```
`[Registry] Collision: ${type}/${baseName} is shipped by package ` +
`"${shadowed._packageId}" and a runtime-authored row with the same name has ` +
...
```

against this package's own convention — measured over non-test `.ts` under `packages/objectql/src`, quoted identifiers in operator prose are single-quoted **174** times against **37** double-quoted (this line was one of the 37; the double-quote count matches the card's originally-reported 37 exactly, the single-quote count differs by 4 from the reported 170 — a different regex over the same tree, not a different tree; instrument and full counts below). #12563 already settled the same ADR-0005 shadowing fact with single quotes on the automation side (`package 'crm'`), so an operator whose boot hits both packages' collision warnings previously read one story in two spellings; this line now matches:

```diff
-`"${shadowed._packageId}" and a runtime-authored row with the same name has ` +
+`'${shadowed._packageId}' and a runtime-authored row with the same name has ` +
```

Byte-identical otherwise — only the quote character moved.

## Scope

The one message named by #12609, nothing else. A sibling `[Registry] Collision` warning a few lines above (`ships from package`, the late-registration-order guard) also double-quotes its package id and is the same defect class, but is a different message describing a different event — filed separately as #12789 rather than swept in here.

## Premise check (done before writing anything)

- Confirmed the double-quoted spelling was still present on `origin/main` by reading the ref directly (`git show origin/main:packages/objectql/src/registry.ts`), not a working tree — present at `21196cf6` (this branch's base; #12623 held `registry.ts` and had already landed).
- Re-derived the minority count with a published instrument (not recalled from the card): `grep -roP "'\$\{[^}]*\}'"` / `"\$\{[^}]*\}"` over non-test `.ts` under `packages/objectql/src` → **174 single / 37 double**. Double matches the card's 37 exactly; single differs by 4 (174 vs 170) — informative as "still a minority, still ~17.5%", not alarming.

## Existing pin

Searched first: `grep -rn "is shipped by package"` (only the source line itself) and `grep -rln "Registry] Collision"` under `packages/objectql/src/*.test.ts`, plus a search for `"runtime-authored row"` in test files. **No existing pin held this message's quote character** — `registry-collision-order.test.ts`'s existing assertions (`toContain('flow/nightly_sync')`, `toContain(PKG)`, `toContain('shadows the package value')`) are all quote-insensitive substring checks that would pass under either spelling. One is added, matching #12563's "would notice a disagreement" shape (assert the corrected spelling present **and** the pre-fix spelling absent, so it's red in both directions):

```ts
expect(lines[0]).toContain(`package '${PKG}'`);
expect(lines[0]).not.toContain(`package "${PKG}"`);
```

## Ablation

Predicted in a commit before mutating (`predict(ablation #12609): …`, `7d3efa7a2`), then: reverted the quote (anchored `perl`/`python3` replace on the unique `and a runtime-authored row` line, confirmed via anchored `grep` in both directions before *and* after the edit) → ran `registry-collision-order.test.ts` → exactly the new `[#12609]` pin went **red** (both its assertions), the other 11 tests — including the positive control (`COMMON COLD-BOOT ORDER …` asserting `toContain('shadows the package value')`, which cannot see the quote character) — stayed **green** → restored via `git checkout HEAD -- packages/objectql/src/registry.ts` (HEAD already carried the real fix) → `git hash-object` on the restored file matched the HEAD blob exactly, `git diff HEAD` empty, double-quote marker absent by grep. Re-ran the full file after restore: 12/12 green. Whole window wrapped in `trap ... EXIT INT TERM` against an absolute `REPO_ROOT`.

## Clause ②

Verified, not assumed: searched the repo (non-test `.ts`/`.tsx`/`.js`, plus `content/`/`docs/`) for anything parsing this message's text. Two hits, both prose references to the warning by name (`flow-precedence.ts`'s doc comment, `flow-name-shadowing.test.ts`'s doc comment, `docs/adr/0005-metadata-customization-overlay.md`) — none matches or parses the quote character. The only consumer is the new substring-based test pin added here. `patch`, argued in the changeset.

## Tests

- `pnpm --filter '@objectstack/objectql^...' build` — dependency closure, green.
- `pnpm --filter @objectstack/objectql exec vitest run --maxWorkers=2 src/registry-collision-order.test.ts` — 12/12 passed (pre- and post-ablation).
- `pnpm --filter @objectstack/objectql test` — 245 files / 4244 tests passed.
- `pnpm --filter @objectstack/objectql typecheck` — clean.
- Gates derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (re-run after the final commit, `7d3efa7a2`): `check:engine-double-contract`, `check:where-matcher`, `check:objectql-double-limit`, `check:query-options-erasure`, `check:durability-log-level`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:type-source-resolution` all green with their own printed verdict lines; no new baseline/ledger entries required by any of them.

## Out-of-scope findings

- Filed #12789: the sibling `[Registry] Collision` warning (`ships from package`, late-registration-order guard, same file) also double-quotes its package id — same defect class, different message, deliberately not swept into this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZbWd2jNV1FErXTPSS4Dry)_