### PR TITLE
fix(plugin-approvals): show `approval_recall` for the #3424 admin override (#12716)

### DIFF
--- a/.changeset/approval-recall-admin-override-arm.md
+++ b/.changeset/approval-recall-admin-override-arm.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/plugin-approvals": patch
+---
+
+fix(plugin-approvals): the `approval_recall` action shows for the #3424 admin override (#12716)
+
+`ApprovalService.recall` has admitted two callers since #3424 — the submitter,
+and a platform/tenant admin releasing a stuck request — and `isOverrideActor`'s
+own doc block names recall as one of the four override levers in so many words.
+The declared action that reaches that endpoint did not agree: `approval_recall`'s
+`visible` predicate was submitter-only, while its three siblings
+(`approval_approve` / `approval_reject` / `approval_reassign`) each OR in
+`record.viewer.can_override`.
+
+So recall was the one lever the override covers whose button never appeared. An
+admin rescuing an approval routed to an unstaffed position could approve or
+reject their way out — writing a decision nobody made — or reassign it, but
+could not simply withdraw it. This is declared-vs-enforced drift in the less
+usual direction: a capability the server grants that no UI entry exposed.
+
+`approval_recall`'s `visible` now ORs in `record.viewer.can_override`, spelled
+byte-identically to the three siblings.
+
+Not a permission change: the service's authorisation set is untouched, and
+`can_override` was already computed server-side for every viewer.
+
+**Pending-only, and enforced rather than asserted.** The new arm carries no
+status test of its own — neither do the siblings — because the flag is already
+status-scoped where it is computed: `attachViewers` sets
+`can_override: row.status === 'pending' && isOverrideActor(...)`, ANDed, so the
+flag can never be true off `pending` and the arm is pending-only in effect
+however CEL groups the expression. The submitter's own `returned` (revise
+window) arm is unchanged. Pinned in both directions, with the flag's own scoping
+pinned against the real service on a genuinely `returned` row.

--- a/packages/plugins/plugin-approvals/src/action-predicate-sparse-face.test.ts
+++ b/packages/plugins/plugin-approvals/src/action-predicate-sparse-face.test.ts
@@ -121,14 +121,54 @@ describe('#8990 — the fail-closed intent survives as a real false, and the lev
     expect(evaluate(visibleOf('approval_remind'), approver)).toBe(false);
   });
 
-  it('an override-only admin still gets the three core decision levers and nothing else (#3424)', () => {
+  it('an override-only admin gets the four levers the override covers, and nothing else (#3424, +recall #12716)', () => {
+    // Re-expressed for #12716. This pin previously read "the three core decision
+    // levers and nothing else" — true when written, and it is the shape of pin
+    // the recall override arm was expected to turn red. It did not go red (it
+    // never asserted anything about recall), but its TITLE became false the
+    // moment recall joined the set, so it is restated rather than left to read
+    // as a claim the code no longer honours.
     const admin = { status: 'pending', viewer: { can_act: false, can_override: true, is_submitter: false } };
     expect(evaluate(visibleOf('approval_approve'), admin)).toBe(true);
     expect(evaluate(visibleOf('approval_reject'), admin)).toBe(true);
     expect(evaluate(visibleOf('approval_reassign'), admin)).toBe(true);
+    // #12716 — the fourth lever. An override admin is a NON-SUBMITTER who now
+    // sees Recall: the service has authorised them since #3424, and this is the
+    // one lever that releases a stuck request without writing a decision on
+    // someone else's behalf.
+    expect(evaluate(visibleOf('approval_recall'), admin)).toBe(true);
     // `can_override` was never OR'd into the secondary levers, and still is not.
     expect(evaluate(visibleOf('approval_send_back'), admin)).toBe(false);
     expect(evaluate(visibleOf('approval_request_info'), admin)).toBe(false);
+    // Nor into the remaining submitter levers — recall is the only one that
+    // moved, and remind/resubmit stay shut for an actor who is not the submitter.
+    expect(evaluate(visibleOf('approval_remind'), admin)).toBe(false);
+    expect(evaluate(visibleOf('approval_resubmit'), { ...admin, status: 'returned' })).toBe(false);
+  });
+
+  it('the recall override arm is pending-only in effect, because `can_override` is itself pending-scoped (#12716)', () => {
+    // The negative direction, and the reason the arm needs no status test of its
+    // own. `attachViewers` computes
+    //   can_override: row.status === 'pending' && isOverrideActor(...)
+    // — ANDed — so for the SAME override actor the flag the service attaches is
+    // true on `pending` and false on `returned`. Both rows below are viewer
+    // blocks the service really emits: forcing `can_override: true` onto a
+    // `returned` row would pin a state the server never produces, and would
+    // measure CEL's grouping rather than the product's behaviour.
+    //
+    // That is what makes "pending-only" enforced rather than asserted in prose.
+    // The flag's own scoping is pinned against the REAL service — an override
+    // admin reading a genuinely `returned` request — in `approval-revise.test.ts`;
+    // this pair is the predicate half of the same claim.
+    const onPending = { status: 'pending', viewer: { can_act: false, can_override: true, is_submitter: false } };
+    const onReturned = { status: 'returned', viewer: { can_act: false, can_override: false, is_submitter: false } };
+    expect(evaluate(visibleOf('approval_recall'), onPending)).toBe(true);
+    expect(evaluate(visibleOf('approval_recall'), onReturned)).toBe(false);
+    // And the submitter's own `returned` arm is untouched by the new OR — the
+    // revise-window withdraw stays exactly as available as it was.
+    expect(evaluate(visibleOf('approval_recall'), {
+      status: 'returned', viewer: { can_act: false, can_override: false, is_submitter: true },
+    })).toBe(true);
   });
 
   it('the submitter still gets remind / recall on pending and resubmit / recall on returned', () => {

--- a/packages/plugins/plugin-approvals/src/approval-revise.test.ts
+++ b/packages/plugins/plugin-approvals/src/approval-revise.test.ts
@@ -315,6 +315,39 @@ describe('Send back for revision (ADR-0044)', () => {
     await expect(editAttempt()).rejects.toThrow(/RECORD_LOCKED/);          // round 2 pending → re-locked
   });
 
+  it('viewer.can_override drops on `returned`, which is what keeps the recall override arm pending-only (#12716)', async () => {
+    // `sys_approval_request`'s `approval_recall` action ORs in
+    // `record.viewer.can_override`, spelled exactly like its three siblings and
+    // with no status test of its own. What makes that arm pending-only is not
+    // the predicate — it is `attachViewers`, which ANDs the status in when it
+    // COMPUTES the flag. `action-predicate-sparse-face.test.ts` pins the
+    // predicate half against fixture viewer blocks; this pins the half those
+    // fixtures stand for, against a genuinely `returned` row produced by the
+    // real send-back path. Without it, "pending-only" would be a property of
+    // hand-written fixtures rather than of the service.
+    //
+    // Relaxing the flag is also not available as a fix: it feeds the three
+    // sibling predicates too, and THEIR endpoints are pending-only
+    // (`decideNode`, and reassign via `loadPendingRow`), so widening it would
+    // put those three buttons on statuses their services refuse.
+    registerReviseFlow();
+    const { req } = await startFlow();
+    // A platform admin with no tenant scope: `loadRequest` narrows by the
+    // CALLER's org, and this harness's requests carry none.
+    const ADMIN = { isSystem: false, userId: 'root', positions: [], permissions: ['admin_full_access'] } as any;
+
+    // Positive control first — the same actor, same request, on `pending`.
+    const whilePending = await service.getRequest(req.id, ADMIN);
+    expect(whilePending!.status).toBe('pending');
+    expect(whilePending!.viewer!.can_override).toBe(true);
+
+    await service.sendBack(req.id, { actorId: 'u1' }, asUser('u1'));
+
+    const whileReturned = await service.getRequest(req.id, ADMIN);
+    expect(whileReturned!.status).toBe('returned');
+    expect(whileReturned!.viewer!.can_override).toBe(false);
+  });
+
   it('recall crossing the revise window cancels the run (returned → recalled)', async () => {
     registerReviseFlow();
     const { runId, req } = await startFlow();

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
@@ -13,8 +13,11 @@
  *   • every `type:'api'` target resolves `{id}` and points at a route that the
  *     REST server actually registers (approve/reject/reassign/recall/remind/
  *     request-info/revise/resubmit) — a typo'd verb would 404 silently in the UI;
- *   • submitter-only levers (remind/recall/resubmit) gate on
- *     `submitter_id == ctx.user.id` so a non-submitter never sees them.
+ *   • submitter levers (remind/recall/resubmit) gate on the server-computed
+ *     `record.viewer.is_submitter`, so a plain non-submitter never sees them.
+ *     `recall` additionally ORs in the #3424 admin override (#12716) — an
+ *     override admin is therefore the one non-submitter who does see it, and
+ *     is a caller `ApprovalService.recall` already authorises.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -74,16 +77,39 @@ describe('sys_approval_request declared actions', () => {
     }
   });
 
-  it('the core decision levers OR in the admin override (#3424) so a stuck request is recoverable', () => {
-    // approve / reject / reassign additionally show for a platform/tenant admin
-    // (`record.viewer.can_override`) so an approval routed to an unstaffed
-    // position — otherwise undecidable, locking the record forever — can be
-    // rescued in-product. The secondary approver levers stay slot-only.
-    for (const name of ['approval_approve', 'approval_reject', 'approval_reassign']) {
+  it('the levers the admin override covers OR it in (#3424, +recall #12716) so a stuck request is recoverable', () => {
+    // approve / reject / reassign / recall additionally show for a
+    // platform/tenant admin (`record.viewer.can_override`) so an approval routed
+    // to an unstaffed position — otherwise undecidable, locking the record
+    // forever — can be rescued in-product. Recall joined the set in #12716: the
+    // service has admitted the override caller on that endpoint since #3424
+    // (`isOverrideActor`'s doc block names recall as one of the four levers),
+    // and it is the only one that RELEASES the record without recording a
+    // decision on someone else's behalf. The secondary approver levers and the
+    // remaining submitter levers stay slot-only.
+    for (const name of ['approval_approve', 'approval_reject', 'approval_reassign', 'approval_recall']) {
       expect(vis(name)).toContain('record.viewer.can_override');
     }
-    for (const name of ['approval_send_back', 'approval_request_info']) {
+    for (const name of ['approval_send_back', 'approval_request_info', 'approval_remind', 'approval_resubmit']) {
       expect(vis(name)).not.toContain('can_override');
+    }
+
+    // Exhaustive, so a FIFTH lever cannot quietly join the override set without
+    // this pin moving: the two loops above only constrain the names they name.
+    expect(
+      actions.filter((a) => vis(a.name).includes('can_override')).map((a) => a.name).sort(),
+      'exactly these levers OR in the #3424 override',
+    ).toEqual(['approval_approve', 'approval_reassign', 'approval_recall', 'approval_reject']);
+
+    // ONE spelling of the arm, not four. This file has a spelling-drift history,
+    // and a fourth wording of the same idea is its own defect — `toContain` on
+    // the whole arm (leading ` || ` included) is what makes drift fail here
+    // rather than in review.
+    const OVERRIDE_ARM =
+      ' || has(record.viewer) && has(record.viewer.can_override) && record.viewer.can_override == true';
+    for (const name of ['approval_approve', 'approval_reject', 'approval_reassign', 'approval_recall']) {
+      expect(vis(name), `${name} must spell the override arm exactly as its siblings do`)
+        .toContain(OVERRIDE_ARM);
     }
   });
 

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -328,11 +328,14 @@ export const SysApprovalRequest = ObjectSchema.create({
   // per-viewer block (#3310): approver actions on `record.viewer.can_act`
   // (the caller is a current pending approver — same check the service
   // authorizes a decision with, so position/team approvers resolve correctly),
-  // submitter actions on `record.viewer.is_submitter`. The core decision levers
-  // (approve/reject/reassign) additionally OR in `record.viewer.can_override`
-  // (#3424) so a platform/tenant admin can rescue a request routed to an
+  // submitter actions on `record.viewer.is_submitter`. The four levers the
+  // #3424 override covers (approve/reject/reassign, and recall since #12716)
+  // additionally OR in `record.viewer.can_override`
+  // so a platform/tenant admin can rescue a request routed to an
   // unstaffed position — otherwise undecidable, locking the record forever — by
-  // approving, rejecting, or reassigning it to a real approver. `viewer` is
+  // approving, rejecting, reassigning it to a real approver, or recalling it
+  // (the lever that releases the record without recording a decision nobody
+  // made). `viewer` is
   // attached by getRequest/listRequests; where it is absent the predicate fails
   // closed.
   //
@@ -476,8 +479,13 @@ export const SysApprovalRequest = ObjectSchema.create({
     // Remind / recall (pending) and resubmit / recall (returned). These are the
     // submitter's own levers, so `visible` gates on `record.viewer.is_submitter`
     // (server-computed on the current viewer). The service re-checks ownership;
-    // the predicate keeps a non-submitter from ever seeing a button they cannot
-    // use.
+    // the predicate keeps a plain non-submitter from ever seeing a button they
+    // cannot use.
+    //
+    // `recall` is the one exception, and it is not a widening: it ALSO ORs in
+    // the #3424 admin override (#12716), because an override admin is a caller
+    // `ApprovalService.recall` already authorises. Remind and resubmit keep no
+    // override arm.
     {
       name: 'approval_remind',
       label: 'Send reminder',
@@ -508,9 +516,29 @@ export const SysApprovalRequest = ObjectSchema.create({
       ],
       // Recall applies while the request is live for the submitter — pending
       // (withdraw) or returned (abandon the revision instead of resubmitting).
+      //
+      // The second arm is the #3424 admin override, spelled byte-identically to
+      // the three core decision levers above (#12716). `ApprovalService.recall`
+      // has admitted the override caller since #3424 — `isOverrideActor`'s own
+      // doc block names recall as one of the four levers — so until this arm
+      // landed, recall was the one authorised capability with no button: an
+      // admin could approve or reject their way out of a stuck request (writing
+      // a decision that did not happen) or reassign it, but could not withdraw.
+      //
+      // The override arm carries no status test of its own, on purpose, because
+      // it does not need one and the siblings do not have one either: the flag
+      // is already status-scoped where it is COMPUTED. `attachViewers` in
+      // `approval-service.ts` sets
+      // `can_override: row.status === 'pending' && isOverrideActor(...)` —
+      // ANDed — so `record.viewer.can_override` can never be true off `pending`,
+      // and this arm is pending-only in effect however CEL groups the
+      // expression. Pinned in both directions in
+      // `action-predicate-sparse-face.test.ts`, with the flag's own scoping
+      // pinned against the real service in `approval-revise.test.ts`.
       visible:
         'has(record.status) && (record.status == "pending" || record.status == "returned")' +
-        ' && has(record.viewer) && has(record.viewer.is_submitter) && record.viewer.is_submitter == true',
+        ' && has(record.viewer) && has(record.viewer.is_submitter) && record.viewer.is_submitter == true' +
+        ' || has(record.viewer) && has(record.viewer.can_override) && record.viewer.can_override == true',
       locations: ['record_section'],
       successMessage: 'Recalled.',
       refreshAfter: true,


### PR DESCRIPTION
Fixes #12716

Option A only, per triage's corrected re-ruling. Round 1 returned `needs_decision` because the premise that triage's original `pending`-only justification rested on measured false; triage has since corrected that premise on the record and narrowed the ruling to option A. Nothing here re-litigates it, and round 1's premise probe was not re-run.

## The change

One CEL arm plus its pins. `approval_recall`'s `visible` predicate now ORs in `record.viewer.can_override`, spelled byte-identically to its three siblings.

```
 && has(record.viewer) && has(record.viewer.is_submitter) && record.viewer.is_submitter == true' +
 || has(record.viewer) && has(record.viewer.can_override) && record.viewer.can_override == true',
```

`ApprovalService.recall` has admitted the override caller since #3424 and `isOverrideActor`'s doc block names recall as one of the four levers, so recall was the one lever the override covers whose button never appeared. An admin rescuing an approval routed to an unstaffed position could approve or reject their way out — writing a decision nobody made — or reassign it, but could not simply withdraw. Not a permission change: the service's authorisation set is untouched.

## Measured, with file and line

Every claim below I read first-hand in this worktree, off `origin/main` at `c8be11073`.

| claim | site | reading |
|---|---|---|
| the three siblings each carry the override arm | `sys-approval-request.object.ts:381`, `:411`, `:434` | ` \|\| has(record.viewer) && has(record.viewer.can_override) && record.viewer.can_override == true` |
| `approval_recall` carried no such arm | `sys-approval-request.object.ts:511` (pre-change) | `is_submitter`-only |
| reverse control on the file | `sys-approval-request.object.ts` | `can_override` appeared exactly 4 times: the 3 sibling arms + the `:332` doc comment. No fourth arm hiding elsewhere |
| the flag is pending-scoped where it is COMPUTED | `approval-service.ts:4848` | `can_override: row.status === 'pending' && this.isOverrideActor(...)` — **ANDed** |
| the package declares the scripts I measured with | `packages/plugins/plugin-approvals/package.json` | `["build","typecheck","test"]` — so no `--filter` run matched zero scripts and exited 0 |

**Inferred, not measured** — stated separately so it is not read as a reading:

- That the new arm is *behaviourally* pending-only follows from the `:4848` AND, not from the predicate: the arm carries no status test, exactly as the siblings carry none. I did not enumerate every writer of the `viewer` block to prove nothing else can set `can_override` on a non-`pending` row; I pinned the one computation that does (below).
- Whether the CEL grouping question matters: per the dispatch brief it is behaviour-neutral, and the `:4848` reading is consistent with that. I verified `:4848` myself and did not spend further time on grouping.

## Pin-coupling search — what I found, and what I did not

The standing warning was that any existing pin asserting *"a non-submitter does NOT see the recall button"* would be turned red by this arm, since an override admin **is** a non-submitter.

**No such assertion exists.** Swept `is_submitter`, `approval_recall`, and the prose forms (`non-submitter` / `not the submitter` / `isn't the submitter`) across the repo, each zero-hit claim backed by a positive control first. What the sweep found instead:

- **`action-predicate-sparse-face.test.ts:124`** — `'an override-only admin still gets the three core decision levers and nothing else (#3424)'`. This is the closest thing to the coupled pin and the one worth naming: its **assertions** did not go red (it only asserted `approval_send_back` / `approval_request_info` are false, never recall), but its **title** became false the moment recall joined the set. Re-expressed rather than left standing as a claim the code no longer honours, and extended to assert the fourth lever plus the two submitter levers that did *not* move.
- **`recall-refusal-user-copy.test.ts`** (#11993's landed refusal-copy half) — **not** turned red. It is a service-gate test: zero hits for `celEngine` / `visible` / `SysApprovalRequest`, against a positive control confirming the file is greppable (313 lines, its `describe` found). Its actors are already scoped correctly — `:129` reads *"User B in the report: not the submitter, **not an admin**"*, and `:306` *"a plain non-submitter is still refused"*. No re-expression needed.
- **`sys-approval-request.object.test.ts:64`** — asserts `not.toContain('can_act')` over recall. `can_override` does not contain the substring `can_act`, so it stays green.

Three **prose** sites did become stale and are corrected in this PR: `sys-approval-request.object.ts:331` (the doc block naming only three levers), `:479` (*"the predicate keeps a non-submitter from ever seeing a button they cannot use"*), and the test file's header at `:17`. That header also spelled the gate as `submitter_id == ctx.user.id`, which the predicates have not used since they moved to `record.viewer.is_submitter` — corrected in the same sentence I was already rewriting, and called out here rather than left as a silent rider.

## Pins added — both directions

- **positive** — an override-only actor (`can_act: false, can_override: true, is_submitter: false`) sees `approval_recall` on `pending`.
- **negative** — the same actor does **not** see it on `returned`.
- **the anchor that makes the negative pin non-circular.** At the predicate layer the negative direction is only as good as the fixture's `can_override: false`, so it would pin nothing on its own. `approval-revise.test.ts` now pins the flag's own scoping against the **real service** — a platform admin reading a genuinely `returned` request produced by the real send-back path — with a positive control on `pending` first. The predicate fixtures are viewer blocks the service really emits; forcing `can_override: true` onto a `returned` row would have measured CEL's grouping rather than the product's behaviour.
- The `#3424` string pin is extended to the fourth lever, made **exhaustive** (a fifth lever cannot quietly join without the pin moving), and now asserts all four spell the arm **identically** — this file has a spelling-drift history, so a fourth wording fails here rather than in review.
- The submitter's own `returned` recall arm is pinned unchanged.

## Ablation evidence

Both legs wrapped in a script carrying `trap … EXIT INT TERM` on absolute paths derived from `git rev-parse --show-toplevel`, run after the implementation was committed so the restore leg points at a `HEAD` that carries it.

**Ablation 1 — drop the arm I added.**

```
PRE  : disk=7739f9a63dab88b715398927518c4444b271deca head=7739f9a63… (equal, clean start)
PRE  : anchor lines=1  arm occurrences=4
POST : disk=4a45492bf7f86f77c96bc546956dba2f89cf6ea7  arm occurrences=3  anchor lines=0
MUTATION CONFIRMED ON DISK: 7739f9a63… -> 4a45492bf… (arm dropped from recall, 3 siblings intact)
 Test Files  2 failed | 1 passed (3)
      Tests  3 failed | 38 passed (41)
POST-RESTORE: disk=7739f9a63… head=7739f9a63…
RESTORE PROVEN: hash equal to HEAD blob AND git diff HEAD empty for the target
```

Exactly the three new assertions went red and no others. `approval-revise.test.ts` stayed green here, correctly — its pin is about the service's flag, not the predicate.

⚠️ **The first attempt at this ablation was a no-op that exited 0.** A `perl -0pi -e` substitution quoted the newline as a literal backslash-n, matched zero times, and left the file unmutated. The script's own `git hash-object` check caught it (`FAIL: hash UNCHANGED — the mutation did not reach disk. This ablation DID NOT RUN.`) rather than reporting a green ablation. Recorded because the failure mode is invisible from the editor's exit code, which is the whole reason the hash check is there. The mutation was moved to a helper carrying its own match-count guard, so the zero-hit case now fails loudly at two independent points.

**Ablation 2 — prove the anchor pin can go red.** Relaxed `attachViewers`'s pending-scoping (`can_override: row.status === 'pending' && …` to unconditional), a temporary measurement fully restored; the shipped diff does not touch `can_override`.

```
MUTATION CONFIRMED ON DISK: 6be225552… -> c3f7a5e3f… (can_override no longer pending-scoped)
 × viewer.can_override drops on `returned`, … (#12716)          [approval-revise.test.ts]
 × viewer.can_override reflects the privilege, and drops once finalized   [approval-service.test.ts]
      Tests  2 failed | 306 passed (308)
RESTORE PROVEN: hash equal to HEAD blob AND git diff HEAD empty for the target
```

The new pin goes red, alongside the pre-existing `drops once finalized` pin — exactly the two tests that assert that condition, and nothing else.

## Verification

Heavy steps serialized through `scripts/pm/os-verify-lock.sh`; exit codes captured before any pipe; each verdict quoted from the gate's own judgment line.

- **Suite**, re-run on the final commit `47f2f1b4b` with a clean tree: `Test Files 34 passed (34)` / `Tests 623 passed (623)`, lock `VERDICT command-exit 0`.
- **Dependency closure** built first (`pnpm --filter '@objectstack/plugin-approvals^...' build`) — `VERDICT command-exit 0 · held the lock 263s`.
- **Package typecheck**: `tsc --noEmit && tsc --noEmit -p tsconfig.scripts.json`, `VERDICT command-exit 0`. ⚠️ **This does NOT cover the test files.** `tsc --listFiles` puts **0** of the three edited test files in the program (control: the source file is present, count 1). The measurement that does cover them is `check:type-check-debt`, below.
- **Gate union re-derived live** on the actual changed set: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which reported `change set derived from git — 5 path(s) vs merge base c8be11073` and `--repo … checked against this checkout's 'origin' remote — it holds`. It named **no contract family**, so the PM's clause-② `no` is not contradicted. It also reported `Model tier — no path-derived mandate`.
- **All 21 path-matched + 8 convention-triggered families run**, all green: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs` (both the lint and ci invocations), `check:objectql-double-limit`, `check:objectui-changeset`, `check:page-declaration-shape`, `check:pm-half-states`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract`, `check:where-matcher`, `check:i18n-stale-fill`, `check:nul-bytes`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-comment-mask-adoption`, `check-empty-changeset`, `check-plugin-teardown-shape`, `docs-audit/check-affected-docs`, `docs-audit/check-drift-comment`, `release-rehearsal-clone --self-test`.
- **`check:i18n`** — first run exited 1 as a **prerequisite failure**, in its own words: *"Nothing was checked: no bundle was compared and no config was parsed, so this result says NOTHING about whether the committed translation bundles are in sync."* Built `@objectstack/cli` as it instructed and re-ran to a real measurement: `check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).`
- **`check:type-check-debt`** — built the workspace closure exactly as `lint.yml` does, then: `check-type-check-coverage --re-measure: OK — 31 ledger entr(ies) re-measured in 242.4s, 1570 raw tsc error(s) total, none above its recorded number.` This is the gate that *does* typecheck the test files, and it reports `@objectstack/plugin-approvals: TEST_DEBT records 347, tsc now reports 345 (-2)` — my test edits added zero type errors. The `-2` surplus is pre-existing (the same run reports surpluses on objectql `-103`, runtime `-10`, plugin-auth `-3`); the gate states outright that lowering is not required to land an improvement, so I did not touch the ledger.

### NOT MEASURED (reported as neither pass nor fail)

- **`scripts/pm/check-half-states.mjs`** exited **3** for want of a credential, in its own words: *"Nothing was swept: no issue was listed, no predicate (H1–H16) ran… It is not a clean board and it is not a dirty one — it is no reading at all."* Environmental, and it reads the PM board rather than this diff.

## Scope

Untouched, deliberately: **`can_override` itself** (it feeds the three sibling predicates whose endpoints are pending-only, so relaxing it would widen *those* buttons onto statuses their services refuse), and the **`:2774` override short-circuit** (option C — a permission narrowing on a live endpoint, maintainer floor, carried on #12775). No `Blocked-by:` is declared against #12775: option A is pending-only by construction and is unaffected whichever way that card is ruled. #11993 is not re-scoped here. No file under `packages/spec` is reached by this change.

Draft on purpose — the PM seat lands it. Auto-merge not armed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194kbQJxUvv2yvsGRtuXpP5)_