### PR TITLE
fix(plugin-auth): keep the logger receiver when selecting a log channel — audience refusals report their verdict instead of `500 null`

### DIFF
--- a/.changeset/plugin-auth-logger-receiver-detach.md
+++ b/.changeset/plugin-auth-logger-receiver-detach.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/plugin-auth": patch
+---
+
+fix(plugin-auth): keep the logger's receiver when selecting a log channel — class-based host loggers no longer crash, so audience refusals report their verdict instead of `500 null` (#12773)
+
+Three sites picked a log channel by **extracting** the method before calling it:
+
+- `auth-manager.ts` — `(logger?.error ?? logger?.warn)?.(message, meta)` in `audienceLogError`
+- `reconcile-membership.ts` — `const log = deps.logger?.error ?? deps.logger?.warn` in `refuseInvalidPolicy`
+- `adopt-membership.ts` — `const log = options.logger?.info ?? …` in `adoptExistingMembership`
+
+`a.b` in *call position* passes `a` as the receiver; `(a.b ?? c.d)(…)` evaluates to
+the bare function first, so the call runs with `this === undefined`. A plain-closure
+logger does not read `this` and survives it. `@objectstack/core`'s `ObjectLogger` is a
+real class with prototype methods and no constructor binding — `error`/`fatal` reach for
+`this.writeErrorLike`, `debug`/`info`/`warn` for `this.write` — so it threw:
+
+```
+TypeError: Cannot read properties of undefined (reading 'writeErrorLike')
+    at error (.../packages/core/dist/index.js:650:10)
+    at _AuthManager.audienceLogError (.../plugin-auth/dist/index.mjs:5460:38)
+```
+
+In `validateAudienceAdmission` the damage compounded: the throw from the `try` landed in
+the `catch`, which called the same helper again, so the second throw escaped the gate.
+An audience refusal — a decided, fail-closed 4xx naming exactly what the operator had
+misconfigured — was delivered to the client as **`HTTP 500` with a null body**, and the
+verdict reached neither the caller nor the log.
+
+Each site now calls through the **property** while keeping its fallback, so both halves
+of the contract hold: the `error` → `warn` degradation (#9754) and the receiver.
+
+No behaviour changes for a host whose logger is a plain closure object — that shape
+worked before and is pinned unchanged. The gate's decisions, codes and messages are
+untouched; only their *delivery* is repaired.
+
+The regression pin (`logger-receiver-detach.test.ts`) uses a **class-based** logger
+double whose methods dispatch through `this`, because a closure double passes against
+the broken code and pins nothing; its case ⓪ asserts that receiver-sensitivity directly
+so the file cannot quietly become vacuous.

--- a/packages/plugins/plugin-auth/src/adopt-membership.ts
+++ b/packages/plugins/plugin-auth/src/adopt-membership.ts
@@ -236,20 +236,25 @@ export async function adoptExistingMembership(
     adopted = updated ?? { ...existing, role: decision.role };
   }
 
-  const log = options.logger?.info ?? ((msg: string, meta?: any) => console.info(msg, meta));
-  log(
+  // ⛔ Call through the PROPERTY, never an extracted reference: `const log =
+  // options.logger?.info ?? …` detaches the method, so `log(…)` runs with
+  // `this === undefined` and a class-based host logger (`@objectstack/core`'s
+  // `ObjectLogger`, whose `info` reaches for `this.write`) throws instead of
+  // reporting. Keep the `console.info` default AND the receiver.
+  const line =
     `[membership] adopted the existing sys_member row instead of inserting a second one ` +
-      `(${decision.verdict}) — the (organization_id, user_id) pair is unique by declaration [#7725]`,
-    {
-      memberId: existing.id,
-      organizationId,
-      userId,
-      existingRole: existing.role,
-      incomingRole: payload.role,
-      resultingRole: adopted.role,
-      verdict: decision.verdict,
-    },
-  );
+    `(${decision.verdict}) — the (organization_id, user_id) pair is unique by declaration [#7725]`;
+  const meta = {
+    memberId: existing.id,
+    organizationId,
+    userId,
+    existingRole: existing.role,
+    incomingRole: payload.role,
+    resultingRole: adopted.role,
+    verdict: decision.verdict,
+  };
+  if (options.logger?.info) options.logger.info(line, meta);
+  else console.info(line, meta);
 
   return adopted;
 }

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -3602,12 +3602,29 @@ export class AuthManager {
    */
   private static readonly PENDING_INVITATION_PROBE_MAX_PAGES = 200;
 
-  /** `error` when the host logger carries it, else the guaranteed `warn` channel (#9754). */
+  /**
+   * `error` when the host logger carries it, else the guaranteed `warn` channel (#9754).
+   *
+   * ⛔ Call through the PROPERTY — never through an extracted reference.
+   * `(logger?.error ?? logger?.warn)?.(…)` evaluates to the *function* and then
+   * invokes it, so the call runs with `this === undefined`. A plain-closure
+   * logger survives that; `@objectstack/core`'s class-based `ObjectLogger` does
+   * not — its `error` reaches for `this.writeErrorLike` (and `warn`/`info` for
+   * `this.write`) and throws `Cannot read properties of undefined`. Measured on
+   * a real composed EE boot: every audience refusal routed through here became
+   * `HTTP 500 null`, because the throw escaped the caller's `catch` when that
+   * handler called this helper a second time — so the operator lost the very
+   * verdict this method exists to report.
+   *
+   * The branch below keeps BOTH halves of the contract: the `error`→`warn`
+   * fallback (#9754) and the receiver.
+   */
   private audienceLogError(message: string, meta?: Record<string, unknown>): void {
     const logger = this.config.logger as
       | { error?: (m: string, meta?: any) => void; warn?: (m: string, meta?: any) => void; info?: (m: string, meta?: any) => void }
       | undefined;
-    (logger?.error ?? logger?.warn)?.(message, meta);
+    if (logger?.error) logger.error(message, meta);
+    else logger?.warn?.(message, meta);
   }
 
   /** OAuth providerIds that are OPERATOR-REGISTERED identity authorities (enterprise `oidcProviders`, incl. the cloud platform IdP). */

--- a/packages/plugins/plugin-auth/src/logger-receiver-detach.test.ts
+++ b/packages/plugins/plugin-auth/src/logger-receiver-detach.test.ts
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12773] Logger calls keep their RECEIVER — pinned with a class-based
+ * logger double whose methods actually read `this`.
+ *
+ * ## The defect, and why every existing suite stayed green
+ *
+ * Three sites in this package selected a log channel by EXTRACTING the method
+ * before calling it:
+ *
+ *   `(logger?.error ?? logger?.warn)?.(message, meta)`      auth-manager.ts
+ *   `const log = deps.logger?.error ?? deps.logger?.warn`   reconcile-membership.ts
+ *   `const log = options.logger?.info ?? …`                 adopt-membership.ts
+ *
+ * `a.b` in *call position* passes `a` as the receiver; `(a.b ?? c.d)(…)`
+ * evaluates to the bare function first, so the call runs with
+ * `this === undefined`. A plain-closure logger — which is what nearly every
+ * test double in this repo is — does not read `this` and survives that
+ * perfectly. `@objectstack/core`'s `ObjectLogger` is a real class with
+ * prototype methods and NO constructor binding: `error`/`fatal` reach for
+ * `this.writeErrorLike`, and `debug`/`info`/`warn` for `this.write`. So the
+ * bug was invisible to every unit suite and appeared only in a real composed
+ * deployment, where it cost the operator the verdict:
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'writeErrorLike')
+ *       at error (…/packages/core/dist/index.js:650:10)
+ *       at _AuthManager.audienceLogError (…/plugin-auth/dist/index.mjs:5460:38)
+ *
+ * In `validateAudienceAdmission` the damage compounds: the throw from the
+ * `try` block lands in the `catch`, which calls the SAME helper again, so the
+ * second throw escapes the gate entirely. The audience refusal — a decided,
+ * fail-closed 4xx that names what the operator misconfigured — was delivered
+ * as `HTTP 500 null`.
+ *
+ * ## What this file pins, and why case ⓪ comes first
+ *
+ * A regression pin for this defect is only as good as its double. A bare
+ * closure passes against the BROKEN code and pins nothing, so case ⓪ asserts
+ * the double's receiver-sensitivity DIRECTLY — and asserts that a closure
+ * double would not have caught it. That keeps the rest of the file
+ * non-vacuous: if someone later "simplifies" these doubles into plain object
+ * literals, case ⓪ goes red instead of the suite going quietly decorative.
+ *
+ * Cases ①–② drive the REAL audience gate (not the private helper in
+ * isolation), so what is pinned is the user-visible contract: the refusal
+ * reaches the caller carrying its code and message, and the fallback to
+ * `warn` still happens for a host that ships no `error` channel (#9754).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AuthManager } from './auth-manager.js';
+import { AUDIENCE_CONFIG_ERROR } from './audience-posture.js';
+import { reconcileMembership, type MembershipPolicy } from './reconcile-membership.js';
+import { adoptExistingMembership } from './adopt-membership.js';
+
+const SECRET = 'test-secret-least-32-characters-long-value';
+const BASE_URL = 'http://localhost:3000';
+
+type Level = 'info' | 'warn' | 'error';
+interface LoggedLine {
+  level: Level;
+  message: string;
+  meta?: unknown;
+}
+
+/**
+ * The double the triage grading requires: a CLASS whose channels dispatch
+ * through `this`, mirroring `ObjectLogger`'s `this.write` / `this.writeErrorLike`.
+ *
+ * `#lines`/`record` are reached as `this.record(…)`, so an unbound call throws
+ * exactly the way the real logger does. Do NOT rewrite this as an object
+ * literal of arrow functions — that is precisely the shape that made the
+ * production defect invisible (case ⓪ enforces this).
+ */
+class ReceiverSensitiveLogger {
+  readonly lines: LoggedLine[] = [];
+
+  /** The `this.writeErrorLike` analogue — the dereference that throws when detached. */
+  private record(level: Level, message: string, meta?: unknown): void {
+    this.lines.push({ level, message, meta });
+  }
+
+  info(message: string, meta?: unknown): void {
+    this.record('info', message, meta);
+  }
+
+  warn(message: string, meta?: unknown): void {
+    this.record('warn', message, meta);
+  }
+
+  error(message: string, meta?: unknown): void {
+    this.record('error', message, meta);
+  }
+
+  at(level: Level): LoggedLine[] {
+    return this.lines.filter((l) => l.level === level);
+  }
+}
+
+/**
+ * A reduced host sink: the guaranteed `warn` channel and no `error` at all
+ * (#9754's reason the fallback exists). Still class-based, so the fallback
+ * leg is held to the same receiver standard as the primary one — a fix that
+ * bound only `error` would go red here.
+ */
+class WarnOnlyReceiverSensitiveLogger {
+  readonly lines: LoggedLine[] = [];
+
+  private record(level: Level, message: string, meta?: unknown): void {
+    this.lines.push({ level, message, meta });
+  }
+
+  warn(message: string, meta?: unknown): void {
+    this.record('warn', message, meta);
+  }
+
+  at(level: Level): LoggedLine[] {
+    return this.lines.filter((l) => l.level === level);
+  }
+}
+
+/** A manager with NO data engine: all three admission probes answer `false`, which is the misconfigured-deployment shape the defect was measured on. */
+function makeManager(logger: unknown, permissionSet = 'ops_self_serve'): AuthManager {
+  return new AuthManager({
+    secret: SECRET,
+    baseUrl: BASE_URL,
+    logger,
+    audience: { posture: 'open', selfRegistrationPermissionSet: permissionSet },
+  } as never);
+}
+
+/** The vendor payload `user.validateUserInfo` receives for a self-serve sign-up. */
+const SELF_SERVE_CREATE = {
+  user: { email: 'newcomer@example.com' },
+  source: { action: 'create-user', method: 'signUpEmail' },
+};
+
+function driveAudienceGate(
+  manager: AuthManager,
+): Promise<{ error: string; errorDescription?: string } | undefined> {
+  return (
+    manager as unknown as {
+      validateAudienceAdmission(
+        data: unknown,
+        ctx?: unknown,
+      ): Promise<{ error: string; errorDescription?: string } | undefined>;
+    }
+  ).validateAudienceAdmission(SELF_SERVE_CREATE);
+}
+
+describe('[#12773] ⓪ the doubles are receiver-sensitive (this file is non-vacuous)', () => {
+  it('a class-based double THROWS when its method is detached from the receiver', () => {
+    const logger = new ReceiverSensitiveLogger();
+    const detached = logger.error;
+    expect(() => detached('detached call')).toThrow(TypeError);
+    expect(() => detached('detached call')).toThrow(/Cannot read properties of undefined/);
+    // …and works perfectly when called through the property.
+    expect(() => logger.error('bound call')).not.toThrow();
+    expect(logger.at('error')).toHaveLength(1);
+  });
+
+  it('the warn-only double is receiver-sensitive on its fallback channel too', () => {
+    const logger = new WarnOnlyReceiverSensitiveLogger();
+    const detached = logger.warn;
+    expect(() => detached('detached call')).toThrow(/Cannot read properties of undefined/);
+    expect(() => logger.warn('bound call')).not.toThrow();
+  });
+
+  it('a CLOSURE double survives the same detachment — which is why one cannot pin this defect', () => {
+    const seen: string[] = [];
+    const closureLogger = { error: (m: string) => void seen.push(m) };
+    const detached = closureLogger.error;
+    expect(() => detached('detached call')).not.toThrow();
+    expect(seen).toEqual(['detached call']);
+  });
+});
+
+describe('[#12773] ① the audience gate reports its refusal instead of crashing', () => {
+  it('returns the AUTH_CONFIG_ERROR verdict to the caller and logs it at error, receiver intact', async () => {
+    const logger = new ReceiverSensitiveLogger();
+    const verdict = await driveAudienceGate(makeManager(logger));
+
+    // The consequence the defect destroyed: the refusal REACHES the caller.
+    // Before the fix this rejected with the TypeError instead (the escaped
+    // second throw), which the transport surfaced as `500 null`.
+    expect(verdict).toBeDefined();
+    expect(verdict?.error).toBe(AUDIENCE_CONFIG_ERROR);
+    expect(verdict?.errorDescription).toMatch(/cannot be resolved in sys_permission_set/);
+
+    // …and the operator's log carries the same verdict.
+    const errors = logger.at('error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('[audience]');
+    expect(errors[0].message).toContain("'ops_self_serve'");
+    expect(errors[0].message).toMatch(/cannot be resolved in sys_permission_set/);
+  });
+
+  it('② falls back to the guaranteed warn channel when the host ships no error channel', async () => {
+    const logger = new WarnOnlyReceiverSensitiveLogger();
+    const verdict = await driveAudienceGate(makeManager(logger));
+
+    expect(verdict?.error).toBe(AUDIENCE_CONFIG_ERROR);
+    const warnings = logger.at('warn');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toMatch(/cannot be resolved in sys_permission_set/);
+  });
+});
+
+describe('[#12773] ③ reconcile-membership refuses an off-vocabulary policy without crashing', () => {
+  const engine = {
+    find: async () => [],
+    insert: async (_object: string, row: unknown) => row,
+  };
+
+  it('reports the refusal through a class-based logger, receiver intact', async () => {
+    const logger = new ReceiverSensitiveLogger();
+    const res = await reconcileMembership(engine as never, 'user-1', {
+      policy: 'inviteOnly' as unknown as MembershipPolicy,
+      resolveTargetOrg: async () => 'org_default',
+      logger: logger as never,
+    });
+
+    expect(res.outcome).toBe('skipped');
+    const errors = logger.at('error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('[membership] refusing to bind');
+    expect(errors[0].message).toContain("'inviteOnly'");
+    expect(errors[0].meta).toMatchObject({ policy: "'inviteOnly'" });
+  });
+
+  it('falls back to warn on a host with no error channel, receiver intact', async () => {
+    const logger = new WarnOnlyReceiverSensitiveLogger();
+    const res = await reconcileMembership(engine as never, 'user-1', {
+      policy: 'nope' as unknown as MembershipPolicy,
+      resolveTargetOrg: async () => 'org_default',
+      logger: logger as never,
+    });
+
+    expect(res.outcome).toBe('skipped');
+    expect(logger.at('warn')).toHaveLength(1);
+    expect(logger.at('warn')[0].message).toContain('[membership] refusing to bind');
+  });
+});
+
+describe('[#12773] ④ membership adoption logs through a class-based logger', () => {
+  it('reports the adoption on the info channel, receiver intact', async () => {
+    const logger = new ReceiverSensitiveLogger();
+    const existing = { id: 'mem_1', role: 'member', organization_id: 'org_1', user_id: 'usr_1' };
+    const engine = {
+      findOne: async () => existing,
+      update: async (_object: string, data: unknown) => ({ ...existing, ...(data as object) }),
+    };
+
+    const adopted = await adoptExistingMembership(
+      engine as never,
+      'sys_member',
+      { organization_id: 'org_1', user_id: 'usr_1', role: 'member' },
+      { logger: logger as never },
+    );
+
+    expect(adopted?.id).toBe('mem_1');
+    const infos = logger.at('info');
+    expect(infos).toHaveLength(1);
+    expect(infos[0].message).toContain('[membership] adopted the existing sys_member row');
+    expect(infos[0].meta).toMatchObject({ memberId: 'mem_1' });
+  });
+});

--- a/packages/plugins/plugin-auth/src/logger-receiver-detach.test.ts
+++ b/packages/plugins/plugin-auth/src/logger-receiver-detach.test.ts
@@ -221,7 +221,7 @@ describe('[#12773] ③ reconcile-membership refuses an off-vocabulary policy wit
       logger: logger as never,
     });
 
-    expect(res.outcome).toBe('skipped');
+    expect(res.outcome).toBe('invalid-policy');
     const errors = logger.at('error');
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toContain('[membership] refusing to bind');
@@ -237,7 +237,7 @@ describe('[#12773] ③ reconcile-membership refuses an off-vocabulary policy wit
       logger: logger as never,
     });
 
-    expect(res.outcome).toBe('skipped');
+    expect(res.outcome).toBe('invalid-policy');
     expect(logger.at('warn')).toHaveLength(1);
     expect(logger.at('warn')[0].message).toContain('[membership] refusing to bind');
   });

--- a/packages/plugins/plugin-auth/src/reconcile-membership.ts
+++ b/packages/plugins/plugin-auth/src/reconcile-membership.ts
@@ -158,8 +158,14 @@ function refuseInvalidPolicy(deps: ReconcileMembershipDeps, meta: Record<string,
   const message =
     `[membership] refusing to bind: membership policy ${described} is not a recognized value ` +
     `— expected one of: ${MEMBERSHIP_POLICIES.join(', ')}`;
-  const log = deps.logger?.error ?? deps.logger?.warn;
-  log?.(message, { ...meta, policy: described, expected: MEMBERSHIP_POLICIES });
+  // ⛔ Call through the PROPERTY, never an extracted reference: `const log =
+  // a.error ?? a.warn` detaches the method, so `log(…)` runs with
+  // `this === undefined` and a class-based host logger (`@objectstack/core`'s
+  // `ObjectLogger`) throws instead of reporting. Keep the fallback AND the
+  // receiver.
+  const payload = { ...meta, policy: described, expected: MEMBERSHIP_POLICIES };
+  if (deps.logger?.error) deps.logger.error(message, payload);
+  else deps.logger?.warn?.(message, payload);
   return message;
 }
 


### PR DESCRIPTION
Fixes #12773

Selecting a log channel by **extracting** the method loses the receiver. `a.b` in *call
position* passes `a` as the receiver; `(a.b ?? c.d)(...)` evaluates to the bare function
first, so the call runs with `this === undefined`. A plain-closure logger does not read
`this` and survives it — which is why no suite caught this. `@objectstack/core`'s
`ObjectLogger` is a real class with prototype methods and no constructor binding, so it
threw and the audience refusal was delivered as `HTTP 500` with a null body.

All verification below was run at commit `8b7ac8336`.

## Measured

Each claim names its file and line, and the command that produced it.

**The defect site, re-located.** The card says `auth-manager.ts:3499`; the PM's dispatch
says `:3610`. On this branch's merge base `ead731756` it is at
`packages/plugins/plugin-auth/src/auth-manager.ts:3610` — the PM's number, confirmed by
`grep`, not trusted from either source.

**The host logger really is receiver-sensitive.** `packages/core/src/logger.ts:219`
declares `class ObjectLogger`; `:414` is `error(...)` calling `this.writeErrorLike(...)`,
and `:401`/`:405`/`:409` are `debug`/`info`/`warn` calling `this.write(...)`. There is no
`bind(this)` anywhere in the constructor. So **every** channel of the real host logger
dereferences `this`, not just `error`.

**Why the failure surfaced as `500 null` rather than a logged warning.** In
`validateAudienceAdmission` the call at `auth-manager.ts:3724` sits inside a `try`, and
that block's `catch` at `:3735` calls the *same* helper again. The first throw lands in
the `catch`, the second escapes the gate entirely — so the refusal reached neither the
caller nor the log. This is read from the control flow at those two lines.

**Three live sites, all inside `plugin-auth`, all fixed here:**

| File | Line (at `ead731756`) | Shape | Channel detached |
|---|---|---|---|
| `src/auth-manager.ts` | 3610 | `(logger?.error ?? logger?.warn)?.(...)` | `error`, else `warn` |
| `src/reconcile-membership.ts` | 161 | `const log = deps.logger?.error ?? deps.logger?.warn` | `error`, else `warn` |
| `src/adopt-membership.ts` | 239 | `const log = options.logger?.info ?? ...` | `info` |

The second and third are siblings the PM's sweep did not find, because they are the
two-step `const fn = obj.method; fn(...)` form rather than the syntactic `(a ?? b)(...)`
one. Triage's scope ("fix any siblings inside `plugin-auth` in the same PR") covers them.
Each is now a property call that keeps its fallback.

**Tests.** `pnpm --filter @objectstack/plugin-auth test` — its own judgment line:

```
 Test Files  83 passed (83)
      Tests  1695 passed (1695)
```

`pnpm --filter @objectstack/plugin-auth typecheck` — exit 0. Note it needs the package's
own `dist` built first: on an unbuilt worktree its second program
(`tsc -p tsconfig.examples.json`) fails with `TS2307` on `examples/basic-usage.ts`, which
is a prerequisite, not a regression.

**Gate union, re-derived live on the actual changed set** with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`: 21 path-derived
families plus 6 convention-triggered ones (this PR adds a test file). All run, all exit 0,
including `check:cross-package-test-inputs`, `check:engine-double-contract`,
`check:where-matcher`, `check:type-check-coverage`, `check:published-files`,
`check:test-source-alias` and `check:nul-bytes`. `pnpm lint`
(`eslint . --no-inline-config`, whole repo) exits 0 — the full scan, not a narrowing.

`check:type-check-debt` (the ratchet half, run against a fully built closure) exits 0;
its own line: `OK — 31 ledger entr(ies) re-measured in 233.1s, 1570 raw tsc error(s)
total, none above its recorded number.`

⚠️ `node scripts/pm/check-half-states.mjs` returned **exit 3 = `PREREQUISITE NOT MET`** —
no GitHub credential in this container. Its own text: *"Nothing was swept ... it is no
reading at all."* Recorded as **NOT MEASURED**, neither pass nor fail. The lint.yml
wrapper `check:pm-half-states` exits 0.

## The ablation — proof the pin can go red

Three legs, one per fixed site, each mutating the file back to the detached form and
running the **whole** package suite so "nothing else fails" is measured across all 1695
tests. Every leg proves the mutation reached the disk by `git hash-object` against the
HEAD blob (never an editor exit code, never a bare `git diff --stat`), and proves the
restore by hash equality plus empty `git diff HEAD` plus empty `git status --porcelain`.
The replacement asserts an exact hit count of 1 and aborts otherwise, so a zero-hit no-op
cannot be reported as a green ablation. A `trap ... EXIT INT TERM` on an absolute path
from `git rev-parse --show-toplevel` restores on any kill.

| Leg | HEAD blob | Mutated blob | Result |
|---|---|---|---|
| `auth-manager.ts` | `299bc028a3` | `b5b5a8659c` | 2 failed, 1693 passed |
| `reconcile-membership.ts` | `1a5476f9d8` | `6c7c07b7e7` | 2 failed, 1693 passed |
| `adopt-membership.ts` | `a96f3cfc6c` | `ff578d317b` | 1 failed, 1694 passed |

In every leg the failures were **exactly** the cases pinning that site and nothing else,
and each failed with `TypeError: Cannot read properties of undefined (reading 'record')` —
structurally identical to the production `reading 'writeErrorLike'`. All three restores
verified clean.

No rebuild is involved: the pin imports the sites relatively (`./auth-manager.js`), so
vitest resolves package source, not `dist`. The mutation going red is itself the proof
that the source under test is the code that ran.

## The pin, and why the double is class-based

`src/logger-receiver-detach.test.ts`. The double is a **class** whose channels dispatch
through `this.record(...)`, mirroring `ObjectLogger`'s `this.write` / `this.writeErrorLike`.
A bare-closure double passes against the broken code and pins nothing.

Case ⓪ asserts that directly, so the file cannot quietly become vacuous: it asserts the
class double **throws** when detached, and — beside it — that a closure double does
**not**, which records in executable form why the closure shape must never be substituted
here. Cases ①–② drive the real audience gate rather than the private helper, so what is
pinned is the user-visible contract: the refusal reaches the caller carrying
`AUTH_CONFIG_ERROR` and its message, and a host shipping only `warn` still gets the
fallback (#9754). Cases ③–④ cover the other two sites, each on both the `error` and the
reduced-sink path where one exists.

## The sweep — what I covered, and what I did not

Re-derived rather than taken from the dispatch. Every regex was validated against a
synthetic positive control **before** its zero-hit result was believed, and two of them
were wrong on the first try and were fixed:

- the `(a ?? b)(...)` regex initially matched **nothing at all**, including the known
  defect site — a broken instrument reading as a clean repo;
- the assignment-detachment regex was anchored at `^` with an unindented control, so it
  missed every indented `const`, which is every real site. Fixing that anchor is what
  surfaced `reconcile-membership.ts:161` and `adopt-membership.ts:239`.

**Covered** (packages + apps, source, excluding `dist`/`node_modules`):

1. `(a ?? b)(...)` and `(a ?? b)?.(...)` — 1 site in `plugin-auth` (fixed); 9 call sites in
   `packages/drivers/driver-sql/src/sql-driver.ts` (`:10575`, `:10744`, `:10791`, `:11408`,
   `:11415`, `:11426`, `:11482`, `:14162`, `:14515`) plus 2 occurrences inside its docblock
   prose; `packages/cli/src/utils/format.ts:1033`;
   `packages/cli/src/utils/dev-restart.ts:275`; one test file.
2. `(a || b)(...)` — zero, control validated.
3. `(cond ? a.m : b.m)(...)` — zero real sites; every hit was a regex literal.
4. Method-reference assignment (`const f = o.m`, including `??`/`||` chains) — the shape
   the PM flagged as unsearched. Found the two `plugin-auth` siblings fixed here.
5. Destructuring (`const { error } = logger`) and method-as-callback
   (`arr.forEach(logger.error)`) — swept; no live defect in `plugin-auth` source.

**Not covered — stated so nobody reads this as a clean bill:**

- **Whether the 9 `driver-sql` sites actually crash is NOT established here**, and this PR
  deliberately does not touch that package. They are carried on #12792. I measured **9**
  call sites where the dispatch brief said 10; the difference is not adjudicated here and
  belongs to that card. My regex is single-line, so a fallback split across lines would
  have been missed in either count.
- Sweeps 4 and 5 are **reliable only within `plugin-auth`**, where I reviewed every hit by
  hand. Repo-wide they are dominated by false positives (value fields named `error`,
  `expect(logger.error)` assertions), so I make **no** repo-wide zero claim for those two
  shapes.
- Detachment through an alias, a re-export, or a dynamic `obj[name]` lookup was not
  searched at all.
- The four correct `.bind()` sites found incidentally
  (`trigger-record-change/src/record-change-trigger.ts:289`,
  `trigger-schedule/src/schedule-trigger.ts:88`,
  `trigger-schedule/src/time-relative-trigger.ts:400`,
  `services/service-job/src/db-job-adapter.ts:253`) are listed as evidence that the
  receiver-preserving idiom already exists in this codebase — they need no change.

## Inferred, not measured

- That a class-based logger is what real EE compositions inject into `plugin-auth` is taken
  from the issue's captured stack trace; I did not boot a composed deployment myself.
- The dogfood report's `500 null` is reproduced here at the level of *mechanism* (the
  escaping second throw, and a `TypeError` of the same shape), not by driving HTTP.

## Scope notes

No `security` label and no `target:v17`, per triage: the gate still refuses and fails
**closed**; the cost is diagnostic. Clause ② stays **`no`** — re-derived live on the actual
changed set, the union names **no contract family**, so the falsifiable condition the
dispatch set did not trigger.

One thing checked and deliberately **not** filed: `plugin-auth/tsconfig.json` excludes
`**/*.test.ts`, so no tsc program compiles this package's 82 test files. That is not an
undeclared gap — it is a declared, ratcheted `TEST_DEBT` ledger entry
(`scripts/check-type-check-coverage.mjs:895`, `errors: 97`), already governed by #6376.
The new test file adds **0** errors to it: measured at 94 with this diff applied and 94
with the three source files reverted to `ead731756` and the new test parked, so the
ledger's `-3` drift is entirely pre-existing and none of it is mine.


---
_Generated by [Claude Code](https://claude.ai/code/session_0194kbQJxUvv2yvsGRtuXpP5)_