### PR TITLE
fix(sdui-parser): port the `inert-expression` diagnostic in lockstep with objectui

### DIFF
--- a/.changeset/sdui-parser-inert-expression-lockstep.md
+++ b/.changeset/sdui-parser-inert-expression-lockstep.md
@@ -1,0 +1,37 @@
+---
+'@objectstack/sdui-parser': minor
+---
+
+html tier: a braced attribute value that is not strict JSON now draws an `inert-expression` warning instead of vanishing silently
+
+`interpretBrace` materializes strict-JSON values only; anything else — the
+single-quoted array every JSX author writes (`columns={['name','amount']}`),
+unquoted object keys, any JS expression — compiles to the deferred `{ $expr }`
+marker, and nothing downstream evaluates that marker: this tier parses, never
+executes (ADR-0080), and no renderer consumes `$expr`. The value reached the
+renderer as an opaque object, defensive non-array/non-object reads degraded it
+to "not declared", and the author's binding vanished with zero diagnostics
+anywhere — a production page's `list-view` rendered its row count and toolbar
+with no data columns, through eight `columns` spellings (objectui#6598). That
+is ADR-0078's prohibited parsed-but-silently-inert state.
+
+`validateTree` now emits a warning-severity `inert-expression` diagnostic when a
+declared input's value is the `$expr` marker, with the fix in the message: write
+the value as JSON (double-quoted strings and keys).
+
+This is the lockstep port of objectui PR #6613 into this repo's hoisted copy of
+the parser. There are two copies, and the invariant is that both agree on the
+accepted grammar **and** on diagnostic codes — if they drift, the save gate and
+the renderer speak different dialects, and a page can save clean and render
+inert. The emitted diagnostic is byte-equal to objectui's.
+
+Warning, not error, per the objectui#5709 posture for inert authored keys: this
+reports an **already**-inert state, so the accept/reject set does not move.
+Pages that compiled before still compile, and a warning is non-gating on every
+consuming surface in this repo (`runtime-gate` files warnings as advisories, not
+as write refusals; `os lint` exits non-zero on error-severity findings only).
+The silence is what changed. Escalating the severity, widening the accepted
+literal grammar (single-quoted strings, unquoted keys), and wiring the registry
+manifest into `validate-jsx-pages` — without which this warning is recorded in
+compile output but displayed by no production surface — are separate decisions
+tracked on objectui#6614 and its follow-ups.

--- a/packages/sdui-parser/src/__tests__/inert-expression.test.ts
+++ b/packages/sdui-parser/src/__tests__/inert-expression.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `inert-expression` — the html tier's silent-vanish hole for braced non-JSON
+ * values, ported into this copy in lockstep with objectui PR #6613.
+ *
+ * `interpretBrace` materializes strict-JSON values only; anything else — the
+ * single-quoted array every JSX author writes, unquoted object keys, any JS
+ * expression — becomes the deferred `{ $expr }` marker, and NOTHING downstream
+ * evaluates that marker (this tier parses, never executes — ADR-0080; no
+ * renderer consumes `$expr`). So `columns={['name','amount']}` used to compile
+ * with ZERO diagnostics into a value every renderer's defensive non-array read
+ * degrades to "no columns declared": rows render, the author's whole data
+ * binding is eaten, and no surface ever says why. That is ADR-0078's prohibited
+ * parsed-but-silently-inert state, reported from production as objectui#6598.
+ *
+ * WHY THIS FILE EXISTS HERE AND NOT ONLY THERE. There are two copies of this
+ * parser — objectui's `packages/sdui-parser` and this repo's hoisted
+ * `@objectstack/sdui-parser` — and the invariant is that both copies agree on
+ * the accepted grammar AND on diagnostic codes. If they drift, the save gate
+ * and the renderer speak different dialects: a page can save clean and render
+ * inert, or the reverse — surface-dependent, and therefore intermittent from
+ * the author's point of view. These pins are the objectstack half of that
+ * lockstep; the emitted diagnostic is byte-equal to objectui's.
+ *
+ * Severity is pinned as WARNING deliberately (the objectui#5709 precedent for
+ * inert authored keys), and `ok` is pinned true alongside it: this port reports
+ * an ALREADY-inert state, so it must leave the accept/reject set exactly where
+ * it stood. Escalating to error, widening the accepted literal grammar (single
+ * quotes / unquoted keys — objectui#6614), and base-prop (`style`) coverage are
+ * open contract decisions; a change to any of those should move these pins
+ * consciously, not by accident.
+ */
+import { describe, expect, it } from 'vitest';
+import { compile } from '../index.js';
+import type { Manifest } from '../types.js';
+
+const manifest: Manifest = {
+  components: {
+    'list-view': {
+      type: 'list-view',
+      namespace: 'plugin-list',
+      inputs: [
+        { name: 'objectName', type: 'string', required: true },
+        { name: 'columns', type: 'array' },
+        { name: 'options', type: 'object' },
+      ],
+    },
+  },
+};
+
+describe('inert-expression: braced non-JSON on a declared input warns instead of vanishing', () => {
+  it('single-quoted array — the JSX habit — draws the warning and stays in the tree as $expr', () => {
+    const r = compile(`<list-view objectName="account" columns={['name','amount']} />`, manifest);
+    expect(r.diagnostics).toEqual([
+      expect.objectContaining({
+        severity: 'warning',
+        code: 'inert-expression',
+        tag: 'list-view',
+        message: expect.stringContaining('"columns"'),
+      }),
+    ]);
+    // The marker itself is unchanged — the tree still carries the deferred
+    // value; only the silence is gone.
+    expect(r.tree?.columns).toEqual({ $expr: "['name','amount']" });
+  });
+
+  it('the message carries the FIX, not merely the complaint', () => {
+    // An arrival pin, not a departure pin: "stopped being silent" is satisfied
+    // by any diagnostic at all. What this port owes the author is the remedy —
+    // name JSON, and show the corrected spelling next to the broken one. A
+    // message rewrite that drops the remedy turns this red.
+    const [d] = compile(
+      `<list-view objectName="account" columns={['name','amount']} />`,
+      manifest,
+    ).diagnostics;
+    expect(d.message).toMatch(/JSON/);
+    expect(d.message).toContain('double-quoted strings and keys');
+    expect(d.message).toContain('columns={["name","amount"]}');
+    expect(d.message).toContain(`columns={['name','amount']}`);
+  });
+
+  it('unquoted object keys draw the same warning', () => {
+    const r = compile(`<list-view objectName="account" columns={[{field:"name"}]} />`, manifest);
+    expect(r.diagnostics).toEqual([
+      expect.objectContaining({ severity: 'warning', code: 'inert-expression' }),
+    ]);
+  });
+
+  it('an $expr on an object-typed input is covered too', () => {
+    const r = compile(`<list-view objectName="account" options={{pageSize: 25}} />`, manifest);
+    expect(r.diagnostics).toEqual([
+      expect.objectContaining({ severity: 'warning', code: 'inert-expression', tag: 'list-view' }),
+    ]);
+  });
+
+  it('strict-JSON spellings stay diagnostic-free — the warning cannot fire on a working page', () => {
+    // This half is what stops the port from becoming a grammar change by
+    // accident: everything `interpretBrace` materializes must stay silent.
+    for (const source of [
+      `<list-view objectName="account" columns={["name","amount"]} />`,
+      `<list-view objectName="account" columns={[{"field":"name","label":"Full Name"}]} />`,
+      `<list-view objectName="account" options={{"pageSize":25}} />`,
+      `<list-view objectName="account" />`,
+    ]) {
+      const r = compile(source, manifest);
+      expect(r.diagnostics).toEqual([]);
+      expect(r.ok).toBe(true);
+    }
+  });
+
+  it('the accept/reject set does not move — every inert spelling still compiles', () => {
+    // The load-bearing property of this port: it reports an ALREADY-inert
+    // state, so `ok` (no error-severity diagnostic — the save gate's pass/fail)
+    // is exactly what it was before the diagnostic existed. Escalating the
+    // severity to error is objectui#6614's Q2 and would land here first.
+    for (const source of [
+      `<list-view objectName="account" columns={['name','amount']} />`,
+      `<list-view objectName="account" columns={[{field:"name"}]} />`,
+      `<list-view objectName="account" options={{pageSize: 25}} />`,
+    ]) {
+      const r = compile(source, manifest);
+      expect(r.ok).toBe(true);
+      expect(r.diagnostics.every((d) => d.severity === 'warning')).toBe(true);
+    }
+  });
+
+  it('an $expr on an UNKNOWN prop keeps drawing unknown-prop, not a double report', () => {
+    const r = compile(`<list-view objectName="account" aggregate={{field:'amount'}} />`, manifest);
+    expect(r.diagnostics).toEqual([
+      expect.objectContaining({ severity: 'warning', code: 'unknown-prop' }),
+    ]);
+  });
+});

--- a/packages/sdui-parser/src/validate.ts
+++ b/packages/sdui-parser/src/validate.ts
@@ -79,7 +79,38 @@ export function validateTree(tree: SchemaElement | null, manifest: Manifest): Va
         if (input.binding) {
           bindings.push({ tag: node.type, input: key, kind: input.binding, value });
         }
-        if (!isExpr(value)) {
+        if (isExpr(value)) {
+          // A braced value that failed JSON materialization compiled to the
+          // parser's deferred `{ $expr }` marker — and NOTHING downstream
+          // evaluates that marker: this tier parses, never executes
+          // (ADR-0080), and no renderer consumes `$expr`. The value therefore
+          // reaches the renderer as an opaque object, every defensive
+          // non-array/non-object read degrades it to "not declared", and the
+          // author's binding silently vanishes (objectui#6598: eight `columns`
+          // spellings on a data block, all eaten without a single diagnostic —
+          // rows rendered, zero data columns). ADR-0078 prohibits exactly this
+          // parsed-but-silently-inert state, so name it at compile time, with
+          // the fix in the message. Warning, not error, per the objectui#5709
+          // precedent for inert authored keys — escalation to error (and any
+          // widening of the accepted literal grammar, e.g. single-quoted
+          // strings) is a contract decision tracked on objectui#6598.
+          //
+          // LOCKSTEP: this diagnostic is the byte-equal port of objectui's
+          // `packages/sdui-parser` copy (objectui PR #6613). The two copies
+          // must agree on the accepted grammar AND on diagnostic codes — if
+          // they drift, the save gate and the renderer speak different
+          // dialects and a page can save clean and render inert. Change this
+          // block only together with the objectui copy.
+          diagnostics.push({
+            severity: 'warning',
+            code: 'inert-expression',
+            message:
+              `<${node.type}> prop "${key}" is a braced expression this tier never evaluates — ` +
+              `the value will be silently ignored at render. Write it as JSON ` +
+              `(double-quoted strings and keys), e.g. columns={["name","amount"]} not columns={['name','amount']}`,
+            tag: node.type,
+          });
+        } else {
           const typeDiag = checkType(node.type, input, value);
           if (typeDiag) diagnostics.push(typeDiag);
         }


### PR DESCRIPTION
Closes #12719

## What this is

The mechanical port of the `inert-expression` diagnostic from objectui PR objectui#6613 (commit `0db4fb3`) into this repo's hoisted copy of the parser.

`interpretBrace` materializes strict-JSON values only. Anything else — the single-quoted array every JSX author writes, unquoted object keys, any JS expression — compiles to the deferred `{ $expr }` marker, and nothing downstream evaluates that marker: this tier parses, never executes (ADR-0080), and no renderer consumes `$expr`. The value reached the renderer as an opaque object, defensive non-array reads degraded it to "not declared", and the author's binding vanished with zero diagnostics anywhere. That is ADR-0078's prohibited parsed-but-silently-inert state, reported from production as objectui#6598. `validateTree` now names it at compile time, warning severity, with the fix in the message.

## The invariant this serves

There are two copies of this parser, and they must byte-agree on the accepted grammar **and** on diagnostic codes. If they drift, the save gate and the renderer speak different dialects — a page can save clean and render inert, or the reverse, which is surface-dependent and therefore intermittent from the author's point of view.

**The emitted diagnostic is byte-equal to objectui's.** Verified by extracting the `diagnostics.push({...})` block from both `validate.ts` copies and comparing bytes: equal.

**The accepted grammar was already in lockstep, and this PR does not touch it.** `interpretBrace` is byte-identical across the copies (sha256 of the extracted function body: `aaf9c50d96522928` on both sides). The comparator was proved able to detect a disagreement before being trusted to report none — mutating the objectui side with the objectui#6614 grammar widening flipped the verdict to `AGREE=False` with a different hash, so the agreement reading is a measurement rather than a pattern that cannot match.

## This does NOT move accept/reject behaviour

The dispatch called this a falsifiable premise rather than a permit, so it was measured rather than adopted:

- `compile()` sets `ok: !diagnostics.some((d) => d.severity === 'error')`. A warning cannot flip it.
- `runtime-gate.ts` splits findings into `errors: added.filter((f) => f.severity === 'error')` — "the reason to refuse the write" — and `advisories: added.filter((f) => f.severity !== 'error')`. A warning is filed as an advisory on a 2xx, never a 422.
- `os lint` exits non-zero on error-severity findings only (`if (errors.length > 0) process.exit(1)`, over a list filtered to `severity === 'error'`).
- The only importer of this package repo-wide is `packages/lint/src/validate-jsx-pages.ts`, which maps each diagnostic to a finding of the **same** severity.

A test case pins this directly: every inert spelling still compiles with `ok === true` and warning-only diagnostics, so a later escalation to error has to move a pin consciously.

## What it buys, and what it does not

Lockstep — not an author-visible gate. This repo resolves no `sdui.manifest.json` (none in the tree; `@objectstack/console/dist/sdui.manifest.json` is absent), so `resolveSduiManifest()` returns undefined and `validateJsxPages` runs parse-only — `validateTree` is not reached from the production gate today. The warning is recorded in compile output and no production surface displays it. Wiring the manifest is deliberately out of scope per triage.

Also out of scope per triage, and untouched here: any widening of the accepted literal grammar (single-quoted strings, unquoted keys), which waits on objectui#6614.

## Tests

`packages/sdui-parser/src/__tests__/inert-expression.test.ts`, ported from objectui#6613 and extended. Both halves of the contract are pinned:

- **Arrival, not departure.** The marker case must emit `inert-expression` *with the remedy in the message* — that it names JSON, carries "double-quoted strings and keys", and shows the corrected spelling beside the broken one. "Stopped being silent" is satisfied by any diagnostic at all, so it is not what gets pinned.
- **Strict-JSON stays diagnostic-free.** Four strict-JSON spellings pinned to produce zero diagnostics. This half is what stops the port from becoming a grammar change by accident.
- **The accept/reject set does not move**, pinned as described above.

**Ablation.** The fix was reverted on disk and the pins observed to fail, then restored:

- Mutation proved on disk before the run: `inert-expression` anchor 1 → 0, old-guard anchor 0 → 1, blob `fd17e946…` → `c220cb87…` (a no-op edit aborts the script).
- Ablated: `Tests 4 failed | 3 passed (7)` — the predicted direction, stated before running. The four warning-assertion cases go red; the strict-JSON, accept/reject and unknown-prop cases stay green, because the fix does not move those.
- Restore proved by **state**, not exit code: `git diff HEAD` empty, restored blob `fd17e946…` equal to the HEAD blob, anchors back to 1 / 0.
- Restored: `Tests 7 passed (7)`.

**Suites** (all at final head `c8cc1ec23`, tree clean):

| Run | Result |
|:---|:---|
| `pnpm --filter @objectstack/sdui-parser test` | `Test Files 3 passed (3) · Tests 21 passed (21)` |
| `pnpm --filter @objectstack/sdui-parser typecheck` | exit 0 |
| `pnpm --filter @objectstack/lint test` (the sole importer, on a built closure) | `Test Files 81 passed (81) · Tests 2295 passed \| 5 skipped` |
| `pnpm lint` (full repo, `eslint . --no-inline-config`) | exit 0 |

The package's `typecheck` genuinely covers the new test file — `tsc --listFiles` reports it in the program (count 1), so this is not the excluded-tests green-over-nothing shape.

**Downstream narrowing, declared.** 54 packages are transitive dependents, but `packages/lint/src/validate-jsx-pages.ts` is the only file in the repo that imports from `@objectstack/sdui-parser`; the other 53 depend on `@objectstack/lint`, not on this package's symbols. Its full suite is green above. CI runs the rest regardless.

## Gates

All 12 point-named gates green, plus the changeset family the dispatch list predates (it was derived before this changeset existed) and the convention-triggered set for a new test file: `check:changeset-gate-self-tests`, `check:objectql-double-limit`, `check:objectui-changeset`, `check:pm-half-states`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `release-rehearsal-clone --self-test`, `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`, `check:nul-bytes` — all exit 0.

Two declared readings that are **not** green results:

- `node scripts/pm/check-half-states.mjs` (bare, live-board form) exited 3 with its own `PREREQUISITE NOT MET` banner — the container's `GITHUB_TOKEN` is a 14-character proxy placeholder, so nothing was swept. That is a refusal to measure, not a finding. The form CI runs, `check:pm-half-states` (`--self-test`), passed.
- `check:type-check-debt --re-measure` was not run: it re-measures per ledger entry, and `packages/sdui-parser` carries no `test-typecheck-debt.json`. The structural half (`check:type-check-coverage`) is green and the package typechecks clean including the new test file.

## Changeset

`.changeset/sdui-parser-inert-expression-lockstep.md` — `@objectstack/sdui-parser: minor`. This package is published (v17.2.0, `private: false`), so the `skip-changeset` route does not apply. Minor rather than patch: it matches the bump objectui#6613 took on its own copy, and a new author-visible diagnostic is a functional addition rather than a pure bug fix. Never major.

## Out-of-scope finding, filed not fixed

**#12810** — the two copies still disagree on diagnostic codes after this port. objectui's copy carries `dashboard-widget-options` (objectui#5709) and a union-arm `checkType` built on `inputTypeArms` (objectui#3832); this repo's copy has neither, so union-typed inputs draw no diagnostic here and a different `code`/`severity` pair there. Recorded rather than repaired in this PR: triage scoped this card to the one diagnostic, and porting the union-arm half would change what this copy accepts and rejects — a different class of change from this one. That issue remains open for triage.

Refs: objectui#6613 (source of the port) · objectui#6598 · objectui#5709 · objectui#6614 · #11148 (the same two-copy port pattern) · ADR-0078 · ADR-0080.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_