### PR TITLE
fix(pm): dispatch-gates says when staleness could not be measured, instead of printing the same silence a current tree gets

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -4920,6 +4920,9 @@ export const DERIVATION_SURFACE = ['.github/workflows', 'package.json', 'scripts
  *
  * Every field degrades to null rather than throwing. No base ref, a shallow
  * clone and no git at all are real states, and none of them is an error here.
+ * They are not a NON-EVENT either: `driftLines` renders `base: null` as a
+ * stated refusal to measure rather than as the silence a level tree gets, so
+ * degrading here costs the caller a reading and never costs it the news.
  */
 export function baseDrift({ cwd = ROOT } = {}) {
   const read = (args) => {
@@ -4950,9 +4953,35 @@ export function baseDrift({ cwd = ROOT } = {}) {
  * the banner has no "all paths present" twin: against a base ref nobody
  * refreshed, a clean bill of health is precisely the reading the measured
  * failure would have passed.
+ *
+ * That silence at zero is what makes the UNMEASURABLE case a defect rather
+ * than a fourth flavour of quiet. `baseDrift` degrades every field to null
+ * when the base ref does not resolve — a fresh checkout, a clone nobody
+ * fetched, a graft — so `behind: null` ("no reading was taken") used to render
+ * byte-identically to `behind: 0` ("a reading was taken, and it was zero"):
+ * nothing at all, from a single `!drift.behind`. The reasoning above defends
+ * withholding an ALL-CLEAR; it never defended withholding the fact that no
+ * instrument was available. And the two states are not equally safe to be
+ * silent about: unmeasured is precisely when the family list below is LEAST
+ * trustworthy, because a gate that landed on the base branch after this tree
+ * was cut cannot be seen from inside this tree, and here nothing can even say
+ * how far back that is. So this branch speaks, zero stays silent, and a reader
+ * can finally tell them apart.
+ *
+ * A drift of `null` — no measurement ATTACHED, because the caller never asked
+ * for one — stays silent, deliberately and separately: reporting a missing
+ * instrument to a reader who never reached for one would be the fabricated
+ * lead this file's header prices as the expensive direction.
  */
 export function driftLines(drift) {
-  if (!drift || !drift.behind) return [];
+  if (!drift) return [];
+  if (drift.base === null) {
+    return [
+      `  ⚠️  STALENESS NOT MEASURED — ${DEFAULT_BASE_REF} does not resolve in this checkout, so this tree's distance from it is UNKNOWN. Not zero: no reading was taken.`,
+      `    A fresh checkout, a clone nobody fetched or a graft all reach here — and an unmeasured tree is where the families below are LEAST trustworthy, not most. Run 'git fetch ${DEFAULT_BASE_REMOTE} ${DEFAULT_BASE_BRANCH}' and derive again for a reading.`,
+    ];
+  }
+  if (!drift.behind) return [];
   const { behind, base, changed, headDate, baseDate } = drift;
   const span = `HEAD${headDate ? ` ${headDate}` : ''} vs ${DEFAULT_BASE_REF} ${base}${baseDate ? ` ${baseDate}` : ''}`;
   if (changed.length === 0) {
@@ -8617,8 +8646,27 @@ function selfTest() {
   // reads as ordinary provenance. These pin the loudness, and pin that the
   // quiet cases stay quiet — a warning on every honest run is a warning nobody
   // reads.
-  t('no measurable base ref prints nothing rather than guessing', driftLines(null).length === 0 && driftLines({ base: null, behind: null, changed: [] }).length === 0);
-  t('a tree level with the base prints NO clearance — the failure would have passed one', driftLines({ base: 'aaaaaaa', behind: 0, changed: [] }).length === 0);
+  // Unmeasured is not silence (#12411). These pin the ARRIVAL — the sentence a
+  // reader actually gets — not merely that the old silence is gone: a pin
+  // asserting "the output is not empty" passes against any garbage. The
+  // previous assertion here read "no measurable base ref prints nothing rather
+  // than guessing" and was green on the defect itself, which is what a
+  // departure pin buys you.
+  const level = driftLines({ base: 'aaaaaaa', behind: 0, changed: [] });
+  const unmeasured = driftLines({ base: null, behind: null, changed: [], headDate: null, baseDate: null });
+  const unmeasuredText = unmeasured.join('\n');
+  t('an unresolvable base ref SAYS staleness was not measured, and names the ref it could not resolve',
+    unmeasuredText.includes('STALENESS NOT MEASURED') && unmeasuredText.includes(DEFAULT_BASE_REF));
+  t('and it spells the reading UNKNOWN, so the reader cannot land on zero by default',
+    unmeasuredText.includes('UNKNOWN') && unmeasuredText.includes('Not zero'));
+  t('it hands over the one action that would produce a reading',
+    unmeasuredText.includes(`git fetch ${DEFAULT_BASE_REMOTE} ${DEFAULT_BASE_BRANCH}`));
+  t('and it does NOT cry stale — a tree nobody measured is not a tree measured stale',
+    !unmeasuredText.includes('STALE TREE'));
+  t('a tree level with the base prints NO clearance — the failure would have passed one', level.length === 0);
+  t('so the two readings no longer share one output — the defect, stated as the comparison that used to hold',
+    unmeasuredText !== level.join('\n'));
+  t('and a drift of null — no measurement ATTACHED, the caller never asked — still prints nothing', driftLines(null).length === 0);
   const benign = driftLines({ base: 'aaaaaaa', behind: 7, changed: [], headDate: '2026-01-01T00:00:00Z', baseDate: '2026-01-02T00:00:00Z' });
   t('behind, but with the derivation surface untouched, states the distance in ONE quiet line', benign.length === 1 && benign[0].includes('7 commit(s) behind'));
   t('and that quiet line does not cry stale, so the loud spelling stays rare', !benign.join('\n').includes('STALE TREE'));
@@ -8644,6 +8692,16 @@ function selfTest() {
     // Positive control: a clone level with its base must read zero, or a
     // non-zero reading below proves nothing.
     t('a checkout level with its base measures zero drift (positive control)', baseDrift({ cwd: clone }).behind === 0);
+    // The other end of the distinction, measured rather than hand-built: `up`
+    // was `git init`-ed and has no remote at all, so the base ref genuinely
+    // does not resolve there — the fresh-checkout state the object literals
+    // above only describe. Its reading must not be the zero the clone reads.
+    const unresolvableRepo = baseDrift({ cwd: up });
+    t('a checkout with no such remote measures NO base, and does not fall back to zero',
+      unresolvableRepo.base === null && unresolvableRepo.behind === null);
+    t('and from a real repo too it arrives as a sentence, not as the silence the level clone gets',
+      driftLines(unresolvableRepo).join('\n').includes('STALENESS NOT MEASURED')
+        && driftLines(baseDrift({ cwd: clone })).length === 0);
     // Upstream moves in a file the answer is NOT derived from.
     writeFileSync(join(up, 'seed.txt'), 'seed2\n');
     gd(['add', '-A'], up); gd(['commit', '-qm', 'unrelated'], up);


### PR DESCRIPTION
Closes #12411

`baseDrift()` degrades every field to `null` when the base ref cannot be resolved — a fresh `actions/checkout`, a clone nobody fetched, a graft. `driftLines()` collapsed that into the output of a demonstrably-current tree, because one predicate covered both:

```js
if (!drift || !drift.behind) return [];   // base===null AND behind===0 both land here
```

So `behind: null` ("I could not measure this") and `behind: 0` ("nothing to report") printed **byte-identically: nothing at all.**

## What changed

`driftLines()` gains a `base === null` branch. Nothing else moves: no exit code, no family verdict, no other branch. The banner is stderr provenance; no gate parses it.

The sentence a reader now gets in the unmeasurable case, rendered from the built module:

```
  ⚠️  STALENESS NOT MEASURED — origin/main does not resolve in this checkout, so this tree's distance from it is UNKNOWN. Not zero: no reading was taken.
    A fresh checkout, a clone nobody fetched or a graft all reach here — and an unmeasured tree is where the families below are LEAST trustworthy, not most. Run 'git fetch origin main' and derive again for a reading.
```

Why that wording, clause by clause:

- **"STALENESS NOT MEASURED"**, not "STALE TREE" — the tree may be perfectly current; the claim is about the *instrument*, not the tree. It deliberately does not reuse the loud spelling, so the loud one stays rare and greppable, and a pin holds the two apart.
- **"does not resolve in this checkout"** names the failed step, so the reader knows which of the two questions went unanswered.
- **"UNKNOWN. Not zero: no reading was taken."** is the whole card. A reader trained by this tool's silence-at-zero will otherwise supply the zero themselves; the line refuses to let that inference stand.
- **"LEAST trustworthy, not most"** states the asymmetry the card argues: unmeasured staleness is not a milder version of measured-and-clean, it is the state in which the derived family list below is worth least.
- **the fetch** is the one action that converts UNKNOWN into a reading — the same remedy and the same slash-free spelling the loud branch already uses (the ref is interpolated from `DEFAULT_BASE_REF`, never written whole, so the joined value stays out of this file's own watch-hint set).

## What deliberately stays silent

- **`behind === 0`** — unchanged, and the docblock's reasoning for it is untouched and still correct: it defends withholding an *all-clear*, which it never stopped defending. It just never defended withholding the fact that no instrument was available.
- **`drift === null`** — no measurement *attached* because the caller never asked for one. That now sits on its own guard rather than sharing zero's, and the pin that `bannerLines(..., drift: null)` is byte-identical to a call predating the flag still holds.

Rendered, at `f48eff9c5`:

```
base ref unresolvable  {base:null, behind:null}  -> 2 lines (the text above)
level with the base    {base:aaaaaaa, behind:0}  -> 0 lines (silent)
no measurement attached (drift === null)         -> 0 lines (silent)
```

## Tests

Eight new `--self-test` pins, and the assertion they replace is the point: the old one read *"no measurable base ref prints nothing rather than guessing"* and was **green on the defect**. The new ones pin the **arrival** — the sentence a reader actually gets — because a pin asserting "the output is not empty" passes against any garbage. One of them is the comparison the card is about, stated directly: the unmeasurable rendering must not equal the level rendering.

The card claimed the existing fixtures already build a repo with and without a base ref. Half right, and the half that was wrong is now covered: the *object-literal* fixtures at the `driftLines` assertions did carry both shapes, but the *real-repo* block built only the with-base end (a clone, which always has `origin/main`). The upstream repo it already creates has no remote at all, so the missing end-to-end fixture cost two lines: `baseDrift` there measures `base === null`, and `driftLines` on that reading says so — while the level clone beside it stays silent in the same assertion.

**Ablation** — each pin proved able to fail before being trusted to pass. Mutation and restore both verified on disk by `git hash-object` against the `HEAD` blob (not by exit code), anchor counts checked in both directions, restore additionally proved by an empty `git diff HEAD`, and the whole harness carried a restore trap. This file is a plain `.mjs` run directly by node — there is no build step and no `dist/` between the edit and the run, so no rebuild leg applies:

| ablation | pins that went RED | pins that correctly stayed green |
|---|---|---|
| the `base === null` branch removed (original one-liner restored) | 5 of 775 — all four arrival pins plus the real-repo arrival | `drift === null` silence (unchanged by the fix); the "does not cry stale" wording guard (vacuous over empty output — a wording guard, not a departure pin) |
| `behind === 0` made to speak | 1 — the "level with the base prints NO clearance" pin | the two-readings-differ pin (they still differ under that mutation) |

Full self-test at `f48eff9c5`: `✓ dispatch-gates self-test: 775 cases pass.`

## Gates

Re-derived from the actual changeset with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` rather than trusting the dispatch list; the two agreed exactly (11 families). All run at `f48eff9c5` with the tree clean, exit codes captured before any pipe:

```
PASS  pnpm check:agent-test-spelling          PASS  node scripts/check-ci-filter-parity.mjs
PASS  pnpm check:bash32-floor                 PASS  node scripts/check-cross-package-test-inputs.mjs
PASS  pnpm check:cli-command-ids              PASS  node scripts/check-self-test-wired.mjs
PASS  pnpm check:cross-package-test-inputs    PASS  node scripts/pm/dispatch-gates.mjs --self-test
PASS  pnpm check:entry-guard                  PASS  node scripts/pm/bare-root-worklist.mjs --self-test
PASS  pnpm check:parse-guard                  PASS  node scripts/check-nul-bytes.mjs
PASS  pnpm check:pm-dispatch-gates
PASS  pnpm check:pnpm-filter-targets
```

Plus the **full** repo-wide `pnpm lint` (`eslint . --no-inline-config`) at the same head — green, no narrowing claimed or needed. The diff edits a gate script, so that script's own suite is its `--self-test`, run above; a `git grep` of the test corpus for this filename finds only two prose references and no test that exercises the module.

**Changeset:** none. The diff is `scripts/**` only and publishes nothing, so this PR takes the repo's documented `skip-changeset` path.

## Out of scope, filed

#12815 — `baseDrift` has a *second* way to reach "no reading was taken": the base ref resolves and the `rev-list --count` fails, leaving `behind: null` with a non-null base, which still prints nothing. Reachable and measured (an unborn HEAD with a fetched base ref). #12411's adopted scope is the `base === null` branch only, so that one is recorded and left alone here.

_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_