### PR TITLE
fix(pm): stop --report labelling the arrival depth as "waiters already ahead" (#12782)

### DIFF
--- a/scripts/pm/os-verify-lock.sh
+++ b/scripts/pm/os-verify-lock.sh
@@ -1769,10 +1769,31 @@ mode_report() {
   printf '  n=%s  p50=%s  p90=%s  max=%s\n' \
     "$(wc -l < "${tmp}/held" | tr -d ' ')" "$(pct_of "${tmp}/held" 50)" \
     "$(pct_of "${tmp}/held" 90)" "$(pct_of "${tmp}/held" 100)"
-  printf 'queue depth on arrival (waiters already ahead):\n'
+  # ⚠ THE LABEL, NOT THE RECORD. The field counts the arriving run itself: the
+  # depth is read AFTER `take_ticket` has minted this call's own ticket, so its
+  # floor is 1 and a completely uncontended fleet printed "1 waiter already
+  # ahead" on every row it had. The record was never wrong -- `announce_arrival`
+  # derives `ahead = depth - 1` from the same number and has always said "0
+  # ahead of you" on a free lock -- so the repair is this heading, and ⛔ NOT the
+  # recorded value: rewriting the field would put a meaning boundary through the
+  # middle of the ledger, which is the mixed-population hazard the outcomes
+  # block above already has to warn about for `command-exit`.
+  #
+  # The second ⇒ is the misreading the first one leaves behind. A run that
+  # queued behind a busy holder with nobody in front of it records exactly what
+  # a run that walked up to a free lock records, because a holder deletes its
+  # ticket at the moment it acquires; measured on both paths, both 1. So this
+  # column is evidence about the QUEUE and about nothing else -- `held` and the
+  # outcomes block are where "was the lock busy" is answered.
+  printf 'queue depth on arrival (the arriving run INCLUDED — 1 means nobody was ahead):\n'
   printf '  n=%s  p50=%s  p90=%s  max=%s\n' \
     "$(wc -l < "${tmp}/depth" | tr -d ' ')" "$(pct_of "${tmp}/depth" 50)" \
     "$(pct_of "${tmp}/depth" 90)" "$(pct_of "${tmp}/depth" 100)"
+  printf '  ⇒ waiters already ahead = this minus 1. The depth is read after this call mints\n'
+  printf '    its own ticket, so 1 is the floor, not a waiter.\n'
+  printf '  ⇒ it does not count the HOLDER either — queueing behind a busy lock with nobody\n'
+  printf '    in front of you records 1, exactly as walking up to a free lock does. This\n'
+  printf '    column measures the queue, never whether the lock was held.\n'
 
   # ⭐ The table this whole mechanism exists for. Ranked by TOTAL seconds held,
   # not by the worst single run: the command that decides how much the fleet
@@ -2545,6 +2566,14 @@ mode_self_test() {
     "$(grep -c 'outcome=command-exit' "$realled" 2> /dev/null || true)" 1
   st_case 'and the record carries the wait, the hold and the queue depth' \
     "$(grep -c 'waited=[0-9]* held=[0-9]* depth=' "$realled" 2> /dev/null || true)" 1
+  # ⛔ THE RECORDED FIELD IS PINNED AT ITS FLOOR, on purpose. The run above was
+  # uncontended, and it still records 1, because the depth is read after this
+  # call has minted its own ticket. That is the value `--report`'s heading now
+  # describes, and the repair for the heading being wrong was the heading --
+  # subtracting one HERE instead would read better for a day and then put a
+  # meaning boundary through the middle of a ledger nothing can re-date.
+  st_case 'and the depth it records counts the arriving run itself — floor 1, never 0' \
+    "$(grep -c ' depth=1 ' "$realled" 2> /dev/null || true)" 1
   st_case 'and exactly one record per run, not one per verdict line' \
     "$(wc -l < "$realled" | tr -d ' ')" 1
 
@@ -2578,6 +2607,22 @@ mode_self_test() {
     "$(bash "$SELF" --report 2>&1 | grep -c 'LOWER-BOUNDS that mixture')" 1
   st_case 'and names the newline flattening, which no label length can recover' \
     "$(bash "$SELF" --report 2>&1 | grep -c 'flattened to a space BEFORE the cut')" 1
+  # The arrival-depth heading, which said "waiters already ahead" over a number
+  # whose floor is 1 -- so an idle fleet read as one-deep on every row and a
+  # reader had no way to tell whether the label or the record was the wrong one.
+  # The last case is the one that would have caught it: asserting only that the
+  # true wording is PRESENT would also pass on a report that kept the old
+  # heading beside it, and the defect was a heading, not a missing sentence.
+  local rpt
+  rpt="$(bash "$SELF" --report 2>&1)"
+  st_case 'and --report says the arrival depth counts the arriving run itself' \
+    "$(printf '%s\n' "$rpt" | grep -c 'the arriving run INCLUDED')" 1
+  st_case 'and hands over the conversion rather than leaving it as arithmetic' \
+    "$(printf '%s\n' "$rpt" | grep -c 'waiters already ahead = this minus 1')" 1
+  st_case 'and blocks the next misreading: 1 is not evidence the lock was free' \
+    "$(printf '%s\n' "$rpt" | grep -c 'it does not count the HOLDER either')" 1
+  st_case 'and the off-by-one heading itself is gone, not merely annotated' \
+    "$(printf '%s\n' "$rpt" | grep -c 'waiters already ahead):')" 0
   # A measurement apparatus that can redden a gate has become part of the thing
   # it measures. This is the case that keeps it out of the way.
   st_case 'an unwritable ledger loses records, never runs' \


### PR DESCRIPTION
Fixes #12782

`--report` printed the arrival-depth column under **"queue depth on arrival (waiters already ahead)"**, but the recorded value is read AFTER `take_ticket` has minted this call's own ticket, so it is the arriving run PLUS the waiters ahead of it and its floor is 1. An uncontended fleet therefore read as "one waiter already ahead" on every row, and a reader had no way to tell whether the label or the record was the wrong half.

## The record was never the wrong half

`announce_arrival` derives `ahead = depth - 1` from the same number and has always said "0 ahead of you" on a free lock, and the field's own comment states the intended meaning correctly. So this changes the heading and leaves the recording path byte-for-byte untouched. Rewriting the field instead would put a meaning boundary through the middle of a ledger nothing can re-date — the mixed-population hazard `--report` already has to warn about for `command-exit`, manufactured a second time on a second field.

**The whole diff, as evidence rather than as a claim.** Exactly one line is removed:

```
-  printf 'queue depth on arrival (waiters already ahead):\n'
```

and every added non-comment line is a `printf` inside `mode_report` or an `st_case` inside `mode_self_test`. Nothing in `mode_run` moves.

## Measured, on a private lock and ledger (one holder, two waiters)

| run | recorded | its own arrival line |
|:---|:---|:---|
| holder | `depth=1` | (uncontended) |
| waiter 1 | `depth=1` | `0 ahead of you` |
| waiter 2 | `depth=2` | `1 ahead of you` |

Two readings come out of that, and the heading now carries both.

1. The floor is 1, confirmed: `recorded = ahead + 1`.
2. **A holder is not in the queue either** — it deletes its ticket at the moment it acquires — so waiter 1, queueing behind a busy lock, records exactly what a run walking up to a free lock records. This column is evidence about the QUEUE and about nothing else.

Reading 2 is not hypothetical bookkeeping. This container's live ledger, 69 records spanning 439m, reports `depth n=69 p50=1 p90=1 max=3` beside `acquisition wait n=24 p50=38s max=170s`. Under the old heading that read as "at least one waiter ahead on 90% of arrivals". The honest reading is the opposite: 90% of arrivals had **nobody** ahead of them, and 24 runs still waited — because what they waited on was the holder, which this column never counted. The old label described a contended fleet where the queue was in fact almost always empty, and the new one cannot.

## Self-test

Two pins, and both were driven RED before being trusted (the mutation confirmed on disk each time, restore verified by blob hash against HEAD):

- **the heading is gone, not merely annotated** — restoring the old `printf` reds `and --report says the arrival depth counts the arriving run itself` and `and the off-by-one heading itself is gone, not merely annotated`. A presence-only assertion would have passed on a report that kept both headings, and the defect was a heading.
- **the recorded field is pinned at its floor** — an uncontended acquire must still record `depth=1`. Subtracting one in the recording path reds it, and reds the pre-existing `and the arrival line says how many are ahead and what the budget is` alongside, because `announce_arrival` would then subtract a second time. The record and the announcement are a matched pair; that is the second, independent reason the heading was the half to repair.

`bash scripts/pm/os-verify-lock.sh --self-test` — `os-verify-lock self-test: all cases pass` (169 cases).

## Gates, at `a0a80b7c3`

Re-derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (9 families for `scripts/pm/os-verify-lock.sh`), all green, quoting each gate's own verdict line rather than a pipeline status:

- `check:bash32-floor` — `153 cases pass` · `22 tracked shell file(s) ... name no bash 4+ construct`
- `check:pnpm-filter-targets` — `140/177 --filter occurrence(s) across 30 file(s) resolve`
- `check:entry-guard` · `check:parse-guard` · `check:agent-test-spelling` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check-ci-filter-parity.mjs` · `check-cross-package-test-inputs.mjs` · `check:nul-bytes` — all green
- the eight changeset-triggered families were run too and are green, `check-empty-changeset.mjs` included

`scripts/pm/check-half-states.mjs` returns exit 3, `PREREQUISITE NOT MET — the token in the environment is not a valid GitHub credential`. That is a refusal to measure in this container, not a red gate, and it is unrelated to this diff.

Repo-wide `pnpm lint` is deliberately narrowed, and the narrowing is measured rather than asserted: eslint's own config, asked about the one changed file, answers `File ignored because no matching configuration was supplied` (1 file reported, 0 errors, via `--format json`), and `eslint.config.mjs` states it configures no `parserOptions.project` and no typed rules — so this diff cannot move a verdict on any file it does not touch.

## No changeset: route 2

Per the repo's own `changeset-check` guidance, a PR that releases nothing takes the `skip-changeset` label, which is marked PREFERRED there; an empty-frontmatter changeset is closed as route 3 and is rejected by `check-empty-changeset.mjs`. `scripts/pm/` is in no workspace package, so a patch changeset would have to name a package this diff does not change and would fabricate a CHANGELOG entry for it. The six previous commits to this same file all landed with no changeset.

## Not folded in

#12783 wants `--report` to state that its population begins at container start. That statement belongs beside the `records: N, spanning T` header, a different `printf` from the one this PR changes — the two do not collide, and #12783 stays unimplemented here.

Claude-Session: https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69

Co-authored-by: Claude <noreply@anthropic.com>

_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_