### PR TITLE
fix(spec): correct the repository name in the changesets config and the spec README badge

### DIFF
--- a/.changeset/changesets-repo-name-and-spec-badge.md
+++ b/.changeset/changesets-repo-name-and-spec-badge.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec,repo): address the changesets `repo` option and the spec README's StackBlitz badge to `objectstack-ai/objectstack` (#12488)
+
+Two places still name `objectstack-ai/spec`, which is not the repository this
+monorepo lives in:
+
+- `.changeset/config.json` — `changelog[1].repo`
+- `packages/spec/README.md` — the "Try Online" StackBlitz badge target
+
+The README badge is the user-visible half. `README.md` is listed in this
+package's `files`, so it ships in the npm tarball and every reader of
+`@objectstack/spec` on npm gets a "Try Online" button addressed to a repository
+that is not this one. The path the badge names —
+`examples/app-todo/objectstack.config.ts` — exists here, so correcting the
+owner/repo segment is the whole fix.
+
+The `.changeset/config.json` half is hygiene with a measured expiry date rather
+than a bug that is firing. The configured generator `@changesets/cli/changelog`
+re-exports `@changesets/changelog-git`, whose `getReleaseLine(changeset)` and
+`getDependencyReleaseLine(changesets, dependenciesUpdated)` do not read the
+third argument — the options object that `@changesets/apply-release-plan`
+passes as `config.changelog[1]`. So `repo` has **no reader today**, and the
+wrong value has never produced a wrong link in any CHANGELOG this repo has
+generated. It acquires a reader the moment anyone swaps in
+`@changesets/changelog-github` — which is the usual reason to touch that block
+— and from then on every generated release line would link into the wrong
+repository, with nothing in the diff looking wrong.
+
+No runtime behaviour changes.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/cli/changelog",
     {
-      "repo": "objectstack-ai/spec"
+      "repo": "objectstack-ai/objectstack"
     }
   ],
   "commit": false,

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -1,6 +1,6 @@
 # @objectstack/spec
 
-[![Try Online](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/objectstack-ai/spec/tree/main/examples/app-todo?file=objectstack.config.ts)
+[![Try Online](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/objectstack-ai/objectstack/tree/main/examples/app-todo?file=objectstack.config.ts)
 
 The **Source of Truth** for the ObjectStack Protocol. Contains strictly typed Zod schemas that define every aspect of the system.
 


### PR DESCRIPTION
Fixes #12488

Two places still named `objectstack-ai/spec`, a repository name this monorepo no longer
uses. The diff is exactly two lines plus one changeset.

| file | before | after |
|---|---|---|
| `.changeset/config.json` | `changelog[1].repo = "objectstack-ai/spec"` | `"objectstack-ai/objectstack"` |
| `packages/spec/README.md` line 3 | StackBlitz badge -> `stackblitz.com/github/objectstack-ai/spec/tree/main/examples/app-todo` | `.../objectstack-ai/objectstack/tree/main/examples/app-todo` |

`examples/app-todo/objectstack.config.ts` — the path the badge names — exists in this
repo, so correcting the owner/repo segment is the whole fix. `README.md` is in
`@objectstack/spec`'s published `files` array, so that badge is what npm renders.

## The `repo` key has no reader today — measured, not assumed

This was the card's central question, and it is the reason the wrong value has never
produced a wrong link. Read from the installed implementation, not from documentation:

- `@changesets/cli@3.0.0` `dist/changelog.mjs` is two lines: it re-exports
  `@changesets/changelog-git` as its default.
- `@changesets/changelog-git@1.0.0` `dist/index.mjs` declares
  `getReleaseLine: (changeset) => ...` and
  `getDependencyReleaseLine: (changesets, dependenciesUpdated) => ...`.
- `@changesets/apply-release-plan@8.0.0` `dist/index.mjs:315` takes
  `const changelogOpts = config.changelog[1]` and passes it as the **third** argument
  (`getReleaseLine(cs, rls.type, changelogOpts)`, line 100). Neither function above
  declares or touches a third parameter.

So `config.changelog[1].repo` is read by nobody in this workspace.
`@changesets/changelog-github`, the generator that does read it, appears **nowhere** in
the tree: a repo-wide `git grep -n changelog-github` exits 1 with 0 lines, while the
control `git grep -n changelog-git` exits 0 with 3 lines, and `pnpm-lock.yaml` carries 0
occurrences of the first against 3 of the second.

**That is what makes this worth fixing rather than leaving.** The value is right-shaped
and in the right place, so nothing about it reads as wrong; the moment somebody swaps in
`@changesets/changelog-github` — which is the usual reason to touch that block — every
generated release line starts linking into another repository, and the diff that caused
it contains no visible mistake.

## What is deliberately NOT claimed

Whether `github.com/objectstack-ai/spec` still resolves could not be measured from this
container: the egress proxy answers 403 for every host and path outside its allowlist,
and a control request for a repository name invented for this test
(`objectstack-ai/definitely-not-a-repo-12488`) returns the same 403 as
`objectstack-ai/spec`. An instrument that returns the same value for "absent" and for
"blocked" measures nothing, so this PR does not assert the old badge is a dead link — only
that it names a repository that is not the one this README ships from.

## Documenting the inertness inside `config.json` — tried, then declined

Measured against `@changesets/config@4.0.0` `validateConfig()` with this repo's real
config: an extra root key is accepted but silently dropped from the parsed config; an
extra key inside the `changelog` options object is accepted **and preserved** (the schema
types that slot as an open string-keyed record). So a note could have been added.

It is not added, because the note would say "the default generator ignores this" and would
become false at exactly the moment it mattered — the generator swap — with nothing gating
it. That is a fresh instance of the very hazard this card is about. Correcting the value
removes the hazard for both generators at once, which a comment cannot do.

## Why a changeset rather than the `skip-changeset` label

Decided from precedent, not from a rule of thumb. Of the last 8 commits touching
`packages/spec/README.md`, **6 carry exactly one changeset** — every one since 2026-07-28
(`f65879345`, `189373ba5`, `923c42470`, `cd455c83b`, `4d00b13f1`, `b098b0e15`); the two
that carry none are from February 2026, before `scripts/check-empty-changeset.mjs` existed
(2026-08-07).

The closest precedent is `cd455c83b`, "docs: four published READMEs stop documenting
symbols that do not exist (#9544) (#9581)" — a README-only change across four published
packages, `packages/spec/README.md` among them. It shipped a `patch` changeset naming all
four, and its own body gives the reason: those packages ship `README.md` in `files` with
`private` unset, so those are the pages npm renders. `scripts/pr-labels.mjs` scopes
`skip-changeset` to "a PR that publishes nothing"; this one changes a page npm publishes.
Hence: one `patch` changeset naming `@objectstack/spec`, and no `skip-changeset` label.

## Verification

Gate union re-run on the final commit **`f62ddf725`** (after merging `origin/main`
`c4ecf0c49`), derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
— 26 families, unchanged before and after the merge. Exit codes captured directly, never
through a pipe.

**25 of 26 exit 0.** Verdict lines the gates printed themselves:

```
check:published-files    69 publishable package(s) ... declare a `files` whitelist that
                         covers every entry point plus CHANGELOG.md
check-changeset-fixed    .changeset/config.json "fixed" group is in sync with 69 public
                         workspace packages          (the 70-name table is untouched)
check-empty-changeset    No empty-frontmatter changeset introduced by this diff
                         (1 declaring changeset(s) added)
check-changeset-no-major This diff introduces no `major` bump
check:override-consistency  9 published-manifest declaration(s) ... all resolve
check-dev-prereqs        67 package build artifacts present; @objectstack/spec built from
                         the sources on disk
```

The 26th, `scripts/pm/check-half-states.mjs`, exits **3** with `PREREQUISITE NOT MET — the
token in the environment is not a valid GitHub credential`, and its own output states
"Nothing was swept ... it is no reading at all". That is a refusal to measure in this
container, not a finding; it runs with a real token in `half-state-patrol.yml`.

Also run: `pnpm --filter @objectstack/spec build`, a full `pnpm build` (71/71 tasks
successful — the prerequisite `check-dev-prereqs` demanded), and
`pnpm --filter @objectstack/spec check:generated` — all 14 generated spec artifacts up to
date, no regeneration needed.

**Lint was narrowed, and the narrowing is declared.** Rather than the repo-wide
`eslint .`, the three changed files were linted directly with `--format json`: 3 files
resolved, and ESLint's own verdict for each is *"File ignored because no matching
configuration was supplied"* — the population comes from `eslint.config.mjs`, whose every
`files` glob is `{ts,tsx,mts,cts,js,jsx,mjs,cjs}`, and this diff adds no file in any of
them. Control: the same command on `scripts/check-changeset-fixed.mjs` lints it for real
(0 warnings, no ignored-verdict), so the ignored verdict discriminates. Invariance: no
lint rule reads a `.md` or `.json` file, so no untouched file's verdict can move. CI runs
the full farm regardless.

_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_