### PR TITLE
fix(pm): make `os-verify-lock --report` state the population it is computed over

### DIFF
--- a/scripts/pm/os-verify-lock.sh
+++ b/scripts/pm/os-verify-lock.sh
@@ -807,6 +807,36 @@ human_s() {
   if ((s >= 60)); then printf '%ss (%dm%02ds)' "$s" $((s / 60)) $((s % 60)); else printf '%ss' "$s"; fi
 }
 
+# Epoch seconds → a UTC instant a reader can compare against a dated report, or
+# NOTHING (return 1) when this host's `date` cannot produce one. Two spellings
+# exist and they are not interchangeable: GNU takes `-d @N`, BSD/macOS takes
+# `-r N`. ⚠ The failure this guards is not the rejected flag -- it is that on
+# macOS `-d` means something else entirely (it sets the DST flag), so
+# `date -u -d @N '+…'` there formats NOW and returns a perfectly well-formed
+# string for the WRONG INSTANT. A shape check cannot tell that apart from a real
+# conversion, so neither spelling is trusted on shape: each is probed against an
+# epoch whose answer is known, and only a `date` that turns 0 into 1970-01-01 is
+# asked to turn anything else into anything. Same discipline as
+# `stamp_resolution` above, for the same reason -- a caller that cannot get a
+# right answer here must be handed no answer, never a confident wrong one.
+utc_stamp() {
+  local fmt='+%Y-%m-%dT%H:%M:%SZ' out
+  if [[ "$(date -u -d @0 "$fmt" 2> /dev/null)" == '1970-01-01T00:00:00Z' ]]; then
+    out="$(date -u -d "@${1}" "$fmt" 2> /dev/null)"
+  elif [[ "$(date -u -r 0 "$fmt" 2> /dev/null)" == '1970-01-01T00:00:00Z' ]]; then
+    out="$(date -u -r "$1" "$fmt" 2> /dev/null)"
+  else
+    return 1
+  fi
+  case "$out" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z)
+      printf '%s' "$out"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 # --- the ledger -------------------------------------------------------------
 #
 # WHY A LEDGER AND NOT MORE STDERR.
@@ -1719,6 +1749,73 @@ mode_report() {
     '' | *[!0-9]*) printf 'records: %s\n' "$total" ;;
     *) printf 'records: %s, spanning %s\n' "$total" "$(human_s $((last - first)))" ;;
   esac
+
+  # ⚠ THE POPULATION, AND WHERE ITS FLOOR ACTUALLY IS. Everything below is
+  # computed over ONE file -- the path printed at the top -- and that file's
+  # history is not the fleet's. This script already knew that: the ageing
+  # paragraph in the slots block had to state it in order to explain why a
+  # constant could not be sized against a p95 that does not exist. But it stated
+  # it in a comment eight hundred lines from the only surface that prints these
+  # numbers, so no reader of a REPORT ever met it, while the report went on
+  # ranking commands under a fleet-scale heading. An agent asking "is a
+  # 19-minute hold normal here?" got a confident, well-formed answer over a
+  # population that structurally could not contain one -- the same shape as the
+  # two mixed-population hazards the blocks below already have to warn about,
+  # one level up: an instrument answering in the green direction about something
+  # it did not measure.
+  #
+  # The path alone does not discharge this. A path is a LOCATION; a population
+  # is an INTERVAL, and no reader can derive the second from the first -- the
+  # ledger is redirectable (`OS_VERIFY_LOCK_LEDGER`), so even the `/tmp` in the
+  # default is not a fixed premise, and `/tmp` would still not say WHEN the
+  # records begin. So the floor is printed as a number, from data this report
+  # already holds.
+  #
+  # ⛔ WHAT THIS DELIBERATELY DOES NOT SAY is "since this container started",
+  # and it does not print an uptime beside the first record. That pairing is the
+  # obvious spelling and it is MEASURED WRONG. On the box this was written on,
+  # `/proc/uptime` reported 878s -- while ALL 74 records in the live ledger, and
+  # the ledger file's own birth time, predated that boot, the oldest by 8h11m
+  # (positive control, same command: a file touched at that moment read as after
+  # the boot, so the comparison can return both answers). The uptime clock and
+  # the filesystem holding the ledger are not guaranteed to restart together.
+  # `/proc/uptime` also does not exist on the macOS hosts this file's bash-3.2
+  # floor exists for. A report that prints a confident wrong boundary is worse
+  # than one that prints none -- that is the very defect being repaired here --
+  # so the floor is stated as what it provably is, the first record, and the
+  # reason it sits there is left unasserted.
+  local nowts age fstamp floor
+  printf 'scope: every figure below is computed over ONE file — the ledger named above —\n'
+  printf '  and over nothing else.\n'
+  # Both halves of the floor, because they answer different questions and either
+  # can be unavailable: the INSTANT is what a reader compares a dated
+  # observation against ("my 19-minute hold was on the 26th — is it in here?"),
+  # the AGE is what tells them how much shift this population is. Whichever can
+  # be established is printed; if neither can, the two sentences either side
+  # still state the shape of the bound, which is the half that cannot be wrong.
+  floor=''
+  case "$first" in
+    '' | *[!0-9]*) ;;
+    *)
+      fstamp="$(utc_stamp "$first")" || fstamp=''
+      nowts="$(now_s 2> /dev/null)" || nowts=''
+      age=''
+      case "$nowts" in
+        '' | *[!0-9]*) ;;
+        *) ((nowts >= first)) && age="$(human_s $((nowts - first))) ago" ;;
+      esac
+      if [[ -n "$fstamp" && -n "$age" ]]; then
+        floor="${fstamp}, ${age}"
+      elif [[ -n "$fstamp" ]]; then
+        floor="$fstamp"
+      else
+        floor="$age"
+      fi
+      ;;
+  esac
+  [[ -n "$floor" ]] && printf '  ⇒ it reaches back to its first record and no further: %s.\n' "$floor"
+  printf '  ⇒ runs from before that, and runs recorded against any other copy of this path,\n'
+  printf '    are absent from every figure below. Absent is not the same as counted zero.\n'
   local size
   size="$(wc -c < "$LEDGER_FILE" 2> /dev/null | tr -d ' ')"
   case "$size" in
@@ -1799,7 +1896,13 @@ mode_report() {
   # not by the worst single run: the command that decides how much the fleet
   # queues is the one that owns the most lock-seconds, which a per-run maximum
   # can point away from entirely.
-  printf '\nlock-seconds held, by command (top 10 — this is where hold time actually goes):\n'
+  # ⛔ The heading is bound to the population, not to the fleet. The old wording
+  # -- "this is where hold time actually goes" -- is the one sentence this
+  # report PRINTS that makes a fleet-scale claim; the two similar phrasings
+  # elsewhere in this file are source comments about the mechanism's purpose and
+  # are not output. Leaving it beside the scope block above would have shipped
+  # the disclosure and the claim it contradicts in the same report.
+  printf '\nlock-seconds held, by command (top 10 — where the hold time in THIS ledger went):\n'
   awk '{
          h = ""; lbl = ""
          for (i = 2; i <= NF; i++) {
@@ -2623,6 +2726,77 @@ mode_self_test() {
     "$(printf '%s\n' "$rpt" | grep -c 'it does not count the HOLDER either')" 1
   st_case 'and the off-by-one heading itself is gone, not merely annotated' \
     "$(printf '%s\n' "$rpt" | grep -c 'waiters already ahead):')" 0
+
+  # --- the scope of the population, and the clock that names its floor ------
+  #
+  # The report used to state its span and never its POSITION: `records: N,
+  # spanning T` says how wide the window is and nothing about where it starts,
+  # while the ranking below it was headed with a fleet-scale claim. So an agent
+  # asking "is a 19-minute hold normal here?" was answered over a population
+  # that could not contain one, and nothing printed said so. These cases are
+  # spelled against the SAME capture as the four above, which each assert a 1 --
+  # so a zero here cannot be a zero produced by a capture that came back empty.
+  st_case 'and --report states that its population is one file, not the fleet' \
+    "$(printf '%s\n' "$rpt" | grep -c 'computed over ONE file')" 1
+  st_case 'and names the floor of that population rather than only its width' \
+    "$(printf '%s\n' "$rpt" | grep -c 'it reaches back to its first record and no further')" 1
+  st_case 'and says the runs outside it are absent, which is not a measured zero' \
+    "$(printf '%s\n' "$rpt" | grep -c 'Absent is not the same as counted zero')" 1
+  # ⛔ BOTH SIDES, because the defect was a HEADING and not a missing sentence:
+  # a report that kept "this is where hold time actually goes" beside the new
+  # scope block would satisfy every presence assertion above while still
+  # printing the fleet-scale claim the scope block contradicts.
+  st_case 'and the ranking is headed by its population, not by the fleet' \
+    "$(printf '%s\n' "$rpt" | grep -c 'where the hold time in THIS ledger went')" 1
+  st_case 'and the fleet-scale heading is gone, not merely annotated' \
+    "$(printf '%s\n' "$rpt" | grep -c 'this is where hold time actually goes')" 0
+
+  # `utc_stamp`, which supplies the instant in that floor. A KNOWN epoch mapped
+  # to a KNOWN string, because the failure mode here is not an error: it is a
+  # well-formed string for the wrong instant (see the helper's own comment), and
+  # only a fixed expected value can tell those apart.
+  st_case 'utc_stamp converts a known epoch rather than formatting now' \
+    "$(utc_stamp 1787849472)" '2026-08-27T16:51:12Z'
+  st_case 'and converts the epoch its own probe is built on' \
+    "$(utc_stamp 0)" '1970-01-01T00:00:00Z'
+  st_case 'and hands back NOTHING, loudly, rather than a guess it cannot make' \
+    "$(utc_stamp not-an-epoch; printf 'rc=%s' "$?")" 'rc=1'
+
+  # ⚠ THE macOS BRANCH, ACTUALLY EXERCISED. `-r` exists in `utc_stamp` for a
+  # host CI never runs on — the same blind spot the bash-3.2 floor gate exists
+  # for — so without these two cases it is a guard nobody has ever seen fire.
+  # The fake below is macOS-SHAPED, not macOS: `-r` reads an epoch and `-d` does
+  # not, which is the actual difference. Two directions, and the second is the
+  # one that keeps the first honest: the helper must still answer the RIGHT
+  # instant through the fake (only reachable via `-r`), and the fake must be
+  # shown to really mis-answer `-d` — otherwise the first case would pass
+  # against a fake that was quietly just GNU `date`.
+  local fakebin realdate
+  realdate="$(command -v date)"
+  fakebin="${tmp}/fakebin"
+  mkdir -p "$fakebin"
+  cat > "${fakebin}/date" << FAKEDATE
+#!/usr/bin/env bash
+# macOS-shaped: -r takes an epoch, -d sets a flag and swallows its operand.
+epoch=""
+fmt=""
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    -u) ;;
+    -d) shift ;;
+    -r) epoch="\$2"; shift ;;
+    +*) fmt="\$1" ;;
+  esac
+  shift
+done
+[[ -n "\$epoch" ]] && exec "$realdate" -u -d "@\${epoch}" "\$fmt"
+exec "$realdate" -u "\$fmt"
+FAKEDATE
+  chmod +x "${fakebin}/date"
+  st_case 'utc_stamp answers a macOS-shaped date through -r, with the right instant' \
+    "$(PATH="${fakebin}:$PATH"; utc_stamp 1787849472)" '2026-08-27T16:51:12Z'
+  st_case 'and that fake really is macOS-shaped — its own -d formats now, not the epoch' \
+    "$(PATH="${fakebin}:$PATH"; date -u -d @0 '+%Y')" "$(date -u '+%Y')"
   # A measurement apparatus that can redden a gate has become part of the thing
   # it measures. This is the case that keeps it out of the way.
   st_case 'an unwritable ledger loses records, never runs' \


### PR DESCRIPTION
Fixes #12783

`--report` printed `records: N, spanning T` — the **width** of its window and never its
**position** — and headed its ranking *"this is where hold time actually goes"*. The ledger
is one file whose history is not the fleet's, so an agent asking *"is a 19-minute hold
normal here?"* was answered over a population that structurally could not contain one, and
nothing printed said so.

## Before / after

```
records: 75, spanning 30245s (504m05s)
```
```
records: 75, spanning 30245s (504m05s)
scope: every figure below is computed over ONE file — the ledger named above —
  and over nothing else.
  ⇒ it reaches back to its first record and no further: 2026-08-27T16:51:12Z, 30841s (514m01s) ago.
  ⇒ runs from before that, and runs recorded against any other copy of this path,
    are absent from every figure below. Absent is not the same as counted zero.
```

and the ranking heading is now bound to that population:

```
-lock-seconds held, by command (top 10 — this is where hold time actually goes):
+lock-seconds held, by command (top 10 — where the hold time in THIS ledger went):
```

That second half is deliberate and is the only line removed in the entire diff. It is the
one sentence the report **prints** that makes a fleet-scale claim (the two similar phrasings
elsewhere in the file are source comments about the mechanism's purpose, and are not
output). Leaving it beside the new scope block would have shipped the disclosure and the
claim it contradicts in the same report.

## ⛔ What this deliberately does NOT print: the container's uptime — measured wrong

The obvious spelling was to name the first record against `/proc/uptime`. **Measured on the
box this was written on, it is false in a way that would have printed a confident wrong
boundary — the very defect being repaired.**

```
/proc/uptime            608s   ⇒ derived boot 2026-08-28T00:50:13Z
live ledger, 74 records        first 2026-08-27T16:51:12Z   last 2026-08-28T00:25:24Z
ledger file birth time         2026-08-27T16:51:12Z
records at or after derived boot: 0        records before it: 74
```

Every record in the live ledger, and the ledger file's own birth time, **predate that boot**,
the oldest by 8h11m. Positive control in the same command: a file touched at that moment read
as *after* the boot, so the comparison can return both answers — the zero is a reading, not a
broken instrument. Negative control: PID 1 started 0.32s after the derived boot, so
`/proc/uptime` and the process tree agree with each other; it is the **filesystem** that did
not restart with them.

⇒ the uptime clock and the filesystem holding the ledger are not guaranteed to restart
together. `/proc/uptime` also does not exist on the macOS hosts this file's bash-3.2 floor
exists for. So the floor is stated as what it provably is — the first record — and the
reason it sits there is left unasserted.

## Is the already-printed path enough? No — a path is a location, a population is an interval

`mode_report` already prints `ledger: /tmp/os-heavy-verify.lock.ledger` as its first line, so
the scope was not entirely undisclosed. It is still not enough, and the measurement above
sharpens why:

1. A reader cannot derive **when** the records begin from **where** the file is.
2. The ledger is redirectable (`OS_VERIFY_LOCK_LEDGER`), so even the `/tmp` in the default is
   not a fixed premise.
3. The folk inference that would bridge the gap — *"/tmp, therefore cleared at container
   start"* — is the one measured false above. This file's own source comment states it
   (`it lives in this container's /tmp and starts empty on every reset`), and on this
   container it did not.

So the fix names the floor as a **number the report already holds**, rather than asking the
reader to infer one from a path.

## `utc_stamp`

A new pure helper converts an epoch through whichever spelling this host's `date` actually
implements. It is probed against a known answer rather than trusted on shape: on macOS `-d`
sets the DST flag, so `date -u -d @N` there formats **now** and returns a perfectly
well-formed string for the wrong instant, which no shape check can tell from a real
conversion. Only a `date` that turns 0 into `1970-01-01T00:00:00Z` is asked to convert
anything else; otherwise the helper returns nothing and the report degrades to printing the
age alone, or neither.

## Zero behaviour change, proved by diff

```
removed lines in the whole branch diff: 1   (the old ranking heading)
diff lines touching LOCK_FILE= / LEDGER_FILE= / ledger_append / exit / flock
  / QUEUE_DIR / HOLDER_FILE / return 99:    0
```

Everything else added is a comment, a `printf`, a self-test case, or the pure `utc_stamp`
helper and the local floor computation inside `mode_report`.

## Tests

`bash scripts/pm/os-verify-lock.sh --self-test` — **179 cases, 0 failures**, on the final
head `6b8d93b77` (baseline before this branch: 169).

**All ten new cases were shown able to fail.** Four ablation legs, each proving its mutation
landed on disk by blob hash before reading anything, and each proving its restore by
`blob == HEAD` plus an empty `git diff HEAD`:

| leg | mutation | cases that went red |
|:--|:--|:--|
| 1 | scope block deleted, old ranking heading restored | 5 — all three scope pins, plus **both sides** of the heading pin |
| 2 | `utc_stamp` formats now instead of the epoch | 4 |
| 3 | the `-r` branch deleted from `utc_stamp` | 1 — the macOS case only |
| 4 | the fake `date` made GNU-shaped | 1 — the shape control only |

Leg 3 is what makes the macOS branch a guard rather than decoration: `-r` exists for a host
CI never runs on, so without a case that goes red when it is removed, nobody would ever have
seen it fire. Leg 4 is the control on the control — with a GNU-shaped fake the primary macOS
case **still passed**, which is exactly why the second case (asserting the fake really does
mis-answer `-d`) is there.

Gates, all green, each read from its own printed verdict line rather than from a bare `$?`:

```
pnpm check:agent-test-spelling · check:bash32-floor · check:cli-command-ids
check:cross-package-test-inputs · check:entry-guard · check:parse-guard
check:pnpm-filter-targets · check:nul-bytes
node scripts/check-ci-filter-parity.mjs · node scripts/check-cross-package-test-inputs.mjs
```

`check:bash32-floor`: *22 tracked shell file(s) ... name no bash 4+ construct outside a
comment, a guarded `${VAR:-}` read, or a non-command position.*

The family was re-derived from the real changeset with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` after the final
commit — it added nothing to the dispatched list. Its first run flagged a **stale tree**
(`origin/main` had moved two commits, one of them to `dispatch-gates.mjs` itself); this
branch was merged up and the derivation re-run on a current tree before these gates were run.

## No changeset

Root `scripts/` tooling publishes nothing. Per the devx lane rule — *changeset by publish
surface: root `scripts/` / docs / test-only ⇒ `skip-changeset`* — and consistent with the
last six commits to this file, which carry zero changesets. An empty-frontmatter changeset
is not the alternative; `check-empty-changeset.mjs` reds on it.

## Scope

Shape 1 only, per the ruling on the card. Persistence is not attempted here. See the
report comment for one shape that may satisfy both of the constraints that fenced it out,
recorded rather than shipped.

Related, not addressed here: #12823 (the hold bucket's filter) and #12795 (lock routing)
both remain open and untouched by this branch. #12538 is the card whose p95 could not be
priced from this ledger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaSTikked61BkcsB5Rn69)_