### PR TITLE
docs(spec): stop the def-key-collision prose committing to a live self-alias count

### DIFF
--- a/packages/spec/scripts/def-key-collisions.test.ts
+++ b/packages/spec/scripts/def-key-collisions.test.ts
@@ -323,8 +323,11 @@ describe('build-schemas.ts refuses a second write of one def key (#5832)', () =>
       expect(res.status).toBe(1);
       expect(output).toContain('JSON Schema def key(s) are claimed by two or more different schemas');
       expect(output).toContain('json-schema/shared/HttpMethod.json  <-  HttpMethod, HttpMethodSchema');
-      // Exactly one collision: the fourteen `export const X = XSchema` self-aliases
-      // this package really does carry must stay green, or the guard is unusable.
+      // Exactly one collision: the self-aliases this package really does carry —
+      // the `Object.assign(XSchema, { … })` exports under `api/` and `system/` —
+      // must all stay green, or the guard is unusable. Their number is deliberately
+      // not pinned here: it moves, and a count asserted in a comment only drifts
+      // (#12608). The generator reports the live population every run (#12588).
       expect(output).toContain('1 JSON Schema def key(s) are claimed');
       // It stops BEFORE the ratchets, which would otherwise adjudicate a build
       // whose output already depends on export iteration order. The name here

--- a/packages/spec/scripts/lib/def-key-collisions.ts
+++ b/packages/spec/scripts/lib/def-key-collisions.ts
@@ -35,9 +35,19 @@
  * > same schema instance.
  *
  * Identity, not today's byte-equality. The permitted shape is the package's
- * self-alias convention — `export const ThemeMode = ThemeModeSchema`, and
- * fourteen more across `api`, `system` and `ui` — where the second write is the
- * same object and therefore cannot change what is published. Anything else is
+ * self-alias convention: a second export name bound to the very same schema
+ * object, as `src/api/endpoint.zod.ts` does with
+ * `export const ApiEndpoint = Object.assign(ApiEndpointSchema, { create })` —
+ * `Object.assign` returns its target, so `ApiEndpoint` and `ApiEndpointSchema`
+ * are one object and the second write cannot change what is published. A plain
+ * re-export (`export const Foo = FooSchema`) is the same shape by the same test.
+ *
+ * How many of these the package carries, and which def keys they land on, is
+ * deliberately NOT restated here: the population moves, and nothing checks a
+ * comment. `build-schemas.ts` prints it on every run instead (#12588 — the
+ * `N emit(s) collapsed into M existing def key(s) — all self-aliases` line,
+ * built from `findSelfAliasedDefKeys` below, which lists each def key and the
+ * export keys that reach it). Read that run, not this paragraph. Anything else is
  * two independent declarations under one published name: even if their JSON
  * happens to match today, the next edit to either one makes the artifact
  * depend on export order again, silently. So the guard refuses at the point
@@ -183,7 +193,9 @@ export function formatDefKeyCollisions(collisions: readonly DefKeyCollision[]): 
     `    one name meaning one thing. Record the rename in scripts/lib/renamed-defs.ts when the OLD\n` +
     `    def key stops being emitted;\n` +
     `  - a duplicate DECLARATION of one schema: delete it and re-export the survivor, so both\n` +
-    `    names resolve to a single object (\`export const ThemeMode = ThemeModeSchema\` — that\n` +
-    `    shape is allowed here precisely because it cannot change what is published).\n`
+    `    names resolve to a single object — \`export const Foo = FooSchema\`, or the\n` +
+    `    \`Object.assign(FooSchema, { … })\` form src/api/endpoint.zod.ts uses for \`ApiEndpoint\`.\n` +
+    `    Either shape is allowed here precisely because it cannot change what is published;\n` +
+    `    a build's own summary lists the self-aliases it already carries.\n`
   );
 }


### PR DESCRIPTION
Fixes #12608

Three prose sites in the def-key-collision guard claimed a self-alias population that does not exist, and cited an export that does not exist. Comments and one build-output string only — no behaviour anywhere, no new gate.

## Day-of re-measure (premise check)

The card measured at `7c0d0c395`; #12588 has since landed (`146f448a`), so the population was re-measured on today's `origin/main` (`6f0fec3d`) from a **real generator run** rather than re-derived by hand — `pnpm --filter @objectstack/spec run check:authorable-surface`, which is `build-schemas.ts --check` and prints the population #12588 added:

```
  Generated: 1597 (124 as input shape)
  Skipped:   24 (unsupported types: function, date, bigint, custom)

11 emit(s) collapsed into 11 existing def key(s) — all self-aliases
(one schema object reached by two export names), so 1597 emits publish
1586 definitions
```

The 11 def keys it lists: `api/ApiEndpoint`, `api/RestApiConfig`, `api/RestServerConfig`, `api/ApiDocumentationConfig`, `api/ApiTestCollection`, `api/OpenApiSpec`, `api/RestApiPluginConfig`, `api/RestApiRouteRegistration`, `system/MiddlewareConfig`, `system/QueueConfig`, `system/Task`.

Categories: `api` (8) and `system` (3). **No `ui` entry**, as the card said. The card's other two (`system/BatchTask`, `system/WorkerConfig`) are still self-aliases in `src/system/worker.zod.ts` but both halves are skipped as unrepresentable ("Function types cannot be represented in JSON Schema"), so they never reach an emit — the card's 13-at-the-walk / 11-surviving split still holds, unchanged. **Fourteen was wrong then and is wrong now, and the number that is right depends on which of two questions you are asking** — which is the whole argument for prose that does not carry one.

`git grep -n "export const ThemeMode\b" -- packages/spec/src` still returns nothing: the cited symbol does not exist.

### One correction beyond the card

The card assumed the real convention is spelled `export const X = XSchema`. It is not — **all 11 use `Object.assign(XSchema, { … })`**:

```ts
export const ApiEndpoint = Object.assign(ApiEndpointSchema, {
  create: (config) => config,   // real line is generic; type parameters elided here
});
```

(`src/api/endpoint.zod.ts:225` — the generic signature is elided above on purpose, since angle-bracket fragments do not survive this body reliably.)

`Object.assign` returns its *target*, so `ApiEndpoint` and `ApiEndpointSchema` are one object and the guard's identity predicate exempts it. Swapping `ThemeMode` for `ApiEndpoint` while keeping the `= XSchema` spelling would have replaced one unfindable citation with another, so the new prose cites the spelling that is actually in the file, and names the plain re-export as the same shape by the same test.

## The three sites

| Site | Before | After |
|:---|:---|:---|
| `scripts/lib/def-key-collisions.ts` module doc | "`export const ThemeMode = ThemeModeSchema`, and **fourteen more** across `api`, `system` and `ui`" | describes the shape, cites `src/api/endpoint.zod.ts`'s real `ApiEndpoint` line, and states the population is deliberately not restated — pointing at the per-run report line and at `findSelfAliasedDefKeys` that builds it |
| `scripts/def-key-collisions.test.ts` line 326 | "the **fourteen** `export const X = XSchema` self-aliases this package really does carry" | "the self-aliases this package really does carry — the `Object.assign(XSchema, …)` exports under `api/` and `system/`"; states the number is deliberately not pinned and names the generator as the live source |
| `formatDefKeyCollisions` remedy text (user-facing build output) | "(`export const ThemeMode = ThemeModeSchema` — that shape is allowed here …)" | `export const Foo = FooSchema` as the placeholder the surrounding text already uses, plus the real `Object.assign` form `src/api/endpoint.zod.ts` uses for `ApiEndpoint`; closes by pointing at the build's own summary |

The acceptance criterion is that the wording stays correct when the population moves again: no site now names a count, a category set, or a symbol that a future edit can falsify.

**No test asserts the remedy string.** Checked before editing — `git grep` for `duplicate DECLARATION` / `re-export the survivor` across `packages/spec` and `scripts` returns only `scripts/lib/schema-index.ts`, which is a different file's own message. The pin test asserts the collision header and the `shared/HttpMethod` line, both untouched. So no assertion updates were owed.

## Deliberately not done

- **No new gate, no count-pinning test** — the card's own reasoning: pinning a comment's count costs more than it saves.
- **The test's `ThemeMode` fixtures are left alone** (lines 16, 62-67, 95-96, 156-157, 166, 170). Those construct a synthetic `EmittedDef` on the spot from an obvious placeholder literal, so they claim nothing about what the package exports — unlike the module doc, which claimed "the package's self-alias convention". Renaming them would be diff noise across a file this PR only comments on. Flagging the judgment rather than burying it.
- **No ablation.** Documentation-only diff; no guard, predicate or threshold changed, so there is no detector whose ability to fail needs demonstrating.

## Verification

Gate union derived against the actual changed set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (it reads the merge-base change set itself), then every derived family run. All readings below are from the final commit, **`9e896a04`**, on a clean tree.

**25 green**, each exit code captured before any pipe: `check:authorable-surface`, `check:cross-package-test-inputs` (both the pnpm and the ci.yml spelling), `check:empty-state`, `check:liveness`, `check:merge-driver`, `check:objectql-double-limit`, `check:page-declaration-shape`, `check:pm-governed-merges`, `check:published-files`, `check:slot-lookup`, `check:strictness-ledger`, `check:test-source-alias`, `check:type-source-resolution`, `check:variant-docs`, `check-ci-filter-parity`, `check-comment-mask-adoption`, `check-plugin-teardown-shape`, `check-affected-docs`, `check-drift-comment`, `check:nul-bytes`, plus the convention-triggered set for editing a test file: `check:query-options-erasure`, `check:engine-double-contract`, `check:where-matcher`, `check:type-check-coverage`.

**The guard and the reworded output still agree** — `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 scripts/def-key-collisions.test.ts`: **17 passed (17)**. That file's last test mutates a fixture copy of the package to introduce a real collision, spawns `build-schemas.ts`, and asserts the guard's verdict on its output, so the remedy string is exercised through the generator rather than read.

`pnpm --filter @objectstack/spec run typecheck` — exit 0. It is three programs, and both edited files are genuinely covered: `tsconfig.scripts.json` compiles the lib, `tsconfig.test.json` the test file (`check:test-typecheck: OK — @objectstack/spec's test layer compiles`).

**NOT MEASURED (1):** `node scripts/check-dev-prereqs.mjs` exits 1 with its own printed line — *"The workspace is not built — 1 unmet precondition, not a list of problems. 67 of 67 workspace packages declare an entry point under dist/ that is not on disk"*. That is the unbuilt-worktree precondition, not a verdict on this diff: the gate measures whether built `dist/` entry points exist, which two comment-only files under `packages/spec/scripts/` cannot move. CI builds from a fresh checkout and measures it there. Declared rather than silently dropped.

Repo-wide `pnpm lint` was **not** run — CI owns that sweep; heavy runs here went through `scripts/pm/os-verify-lock.sh` on a contended shared box.

## Release impact: nothing, so `skip-changeset` rather than a changeset file

Measured, not assumed. `packages/spec`'s `files` allowlist is `dist`, `json-schema`, `liveness`, `prompts`, `llms.txt`, `README.md`, `src/**/*.zod.ts`, `CHANGELOG.md`, `api-surface`, `spec-changes.json` — **`scripts/` is not in it**, so neither edited file enters the npm tarball. Neither string reaches a generated artifact either: the module doc and the test comment are comments, and the remedy text is printed to the console only on a collision, which fails the build rather than writing anything. A grep for the changed strings across `content/docs`, `json-schema/`, `api-surface/` and `objectstack.json` finds no artifact carrying them (the single `content/docs/releases/v17.mdx` hit is an unrelated sentence about inert metadata keys).

So this diff releases nothing, and the honest route is the **`skip-changeset` label, applied by the dispatching seat** — not a changeset file, and not an empty one (those are rejected). Flagging it here so the seat can apply it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvjTCjJQn9zSTXEhUKgT7s)_