### PR TITLE
fix(devx): os-regen-merge picks the merge side per file, and refuses an uncommitted hand-off

### DIFF
--- a/scripts/pm/os-regen-merge.sh
+++ b/scripts/pm/os-regen-merge.sh
@@ -5,6 +5,7 @@
 # os-regen-driven generated artifacts. Run INSIDE the feature branch's worktree.
 #
 #   bash scripts/pm/os-regen-merge.sh
+#   bash scripts/pm/os-regen-merge.sh --self-test   # verify this script
 #
 # ## Why a script (and why the ORDER is the whole point)
 #
@@ -17,14 +18,89 @@
 # traps, so the fix is a fixed order, executed mechanically:
 #
 #   1. git merge origin/main               (⛔ never rebase / force-push)
-#   2. git checkout origin/main -- <every os-regen path>   (take main's side)
-#   3. COMMIT THE MERGE FIRST
+#   2. take main's side of every os-regen path THE BRANCH HAS NOT EDITED
+#      since the merge base — worktree only, never the index (both halves of
+#      that sentence are load-bearing; see the two sections below)
+#   3. COMMIT THE MERGE FIRST, then assert the hand-off tree is committed
 #   4. regenerate the whole chain, then run the generated-artifact gates and
 #      assert every sibling PR's entries — and the previous PR's IMPLEMENTATION
 #      BODY — still exist (quoted-exact-name git grep against origin/main).
 #
 # This script performs steps 1–3 and prints step 4 (the regen chain varies by
 # what the branch touches; running it blind would hide a red).
+#
+# ## Step 2 chooses a side PER FILE — an unconditional one reverts committed work
+#
+# Step 2 used to run `git checkout origin/main -- <path>` for every os-regen
+# path unconditionally, and that is wrong for any branch whose own change IS a
+# hand-edit inside a generated artifact — a retirement branch, above all, whose
+# deletions of released baseline lines are the deliverable. Measured twice on
+# one retirement branch, on two consecutive sync rounds: a committed
+# hand-deletion of a manifest key and of the released authorable-surface /
+# authorable-defaults lines came back from main's side, and step 3 then
+# COMMITTED the revert. Root cause was established rather than assumed — main
+# had changed none of the shards in the merge window (empty per-file diffs), so
+# the reintroduction was purely this step. The published-schema and
+# authorable-key deletion gates then refused the build ("N previously published
+# schema(s) disappeared…"), which is those gates working as hand-deletion
+# validators — but it reads as a scary red on the branch that is *supposed* to
+# delete them, and it invites exactly the wrong repair: re-adding the keys.
+#
+# The side is therefore chosen PER FILE, against the merge base captured BEFORE
+# the merge, and the two cases are OPPOSITES:
+#
+#   the branch changed it and MAIN DID NOT — git already resolved that path
+#   trivially to the branch's bytes; there was nothing to reconcile, so taking
+#   main's side is a pure revert with no merge content behind it. This is the
+#   measured incident. ⇒ KEEP the branch's bytes, print a per-path notice.
+#
+#   BOTH sides changed it — the merge driver ran, exited 0 and silently kept one
+#   side. This is the ONLY case where step 2 has any work to do, and doing it is
+#   the whole reason the step exists: main's dropped side is restored, and step
+#   4's regeneration re-derives the branch's generated content on a known-good
+#   base. ⇒ TAKE main's side, and print the loud per-path notice — if the
+#   branch's edit here was a HAND edit (a released-baseline deletion no
+#   regeneration reproduces), restore those bytes before regenerating.
+#
+# ⚠️ That split is measured, because the simpler rule — skip EVERY path the
+# branch edited — looks right and is not: it makes step 2 INERT. Git invokes a
+# merge driver only where both sides changed a path, so every path step 2 can
+# act on is by construction a path the branch edited. Skip them all and step 2
+# takes nothing, step 3 has nothing to commit, and the driver's silent drop
+# rides into the merge commit unrepaired — trading the revert hazard for the
+# silent-drop hazard this whole script exists to close. Fixture: one regen path
+# edited on both sides with the driver keeping ours, one edited on the branch
+# only; the blanket-skip rule leaves the first still dropped.
+#
+# ⚠️ Per FILE, not per pattern — the hot patterns are directory globs over dozens
+# of shards, and a per-pattern decision would let one hand-edited shard govern
+# the whole directory.
+#
+# ⚠️ The base must be read BEFORE step 1. After the merge, HEAD contains
+# origin/main, so `git merge-base HEAD origin/main` is origin/main's own tip and
+# every file reads as "the branch edited it".
+#
+# ## Step 2 writes the WORKTREE, never the INDEX — and step 4 reads the index
+#
+# `git checkout <ref> -- <path>` writes the index as well as the tree. That is
+# the second measured hazard: with main's side STAGED by step 2 and the
+# regeneration landing in the working tree only, the path sits in `MM`, and a
+# bare `git commit` builds from the INDEX — it lands main's side, silently
+# reverting the branch in a commit whose message claims the opposite. Two sync
+# rounds caught it only by staging the regenerated files explicitly and reading
+# the staged diff. `git restore --source=<ref> -- <path>` writes the tree only,
+# leaving a lone unstaged `M`, where a bare `git commit` lands NOTHING instead
+# of the wrong side — a loud no-op beats a quiet revert.
+#
+# ⛔ THE RUNBOOK SENTENCE, for step 4 and for anyone doing this by hand:
+# **inspect the STAGED diff, not the working-tree diff, before committing**
+# (`git add <paths>` then `git diff --cached`). `git diff` and `git diff HEAD`
+# never consult the index, so both read clean over exactly this trap.
+#
+# Step 3 closes the sequence with a hand-off assertion: every os-regen path must
+# be COMMITTED before step 4 begins. `MM` is the state the card names, and it is
+# the superset — any uncommitted regen path at hand-off means step 4's "commit
+# the regeneration as its own commit" would absorb something nobody read.
 #
 # ## Step 3 and the pre-commit hook agree (#8047)
 #
@@ -43,96 +119,188 @@
 
 set -euo pipefail
 
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  echo "✗ not inside a git worktree" >&2
-  exit 1
-fi
-
-branch="$(git rev-parse --abbrev-ref HEAD)"
-case "$branch" in
-  main | HEAD)
-    echo "✗ refusing to run on '$branch' — run inside the feature branch's worktree" >&2
-    exit 1
-    ;;
+# Absolute, because `--self-test` runs this script from inside fixture repos it
+# `cd`s into — a relative `$0` resolves to nothing there.
+SELF="${BASH_SOURCE[0]}"
+case "$SELF" in
+  /*) ;;
+  *) SELF="$(pwd)/$SELF" ;;
 esac
 
-if [ -n "$(git status --porcelain)" ]; then
-  echo "✗ working tree not clean — commit or drop local changes first (⛔ never git stash)" >&2
-  exit 1
-fi
+usage() {
+  cat <<'EOF'
+usage:
+  os-regen-merge.sh              run the merge sequence (steps 1–3, print step 4)
+  os-regen-merge.sh --self-test  verify this script against synthetic fixtures
+  os-regen-merge.sh --help       this text
 
-echo "→ fetching origin/main"
-git fetch origin main
+Run INSIDE the feature branch's worktree, on a clean tree.
+EOF
+}
 
-# The single authoritative list, read at run time.
-#
-# READ LOOP, NOT `mapfile` — THE BASH 3.2 FLOOR. `mapfile`/`readarray` are bash
-# 4 builtins and `/usr/bin/env bash` is bash 3.2.57 on macOS (Apple ships no
-# bash 4+, for licensing reasons). This script is run BY HAND, in an agent's or
-# a maintainer's worktree, and it has no CI path at all — nothing in
-# `.github/workflows/` invokes it — so a bash-4 builtin here does not fail on a
-# fringe host, it fails on the ordinary one, and no CI run can ever say so.
-# Measured with the builtin disabled (`enable -n mapfile readarray` via
-# `BASH_ENV`, which reproduces the macOS symptom byte for byte):
-# `mapfile: command not found`, then `set -e` kills the run at status 127 —
-# AFTER `git fetch origin main` and BEFORE step 1, i.e. with the merge sequence
-# whose ORDER is this script's entire reason for existing not begun. The
-# operator is left to perform steps 1–3 by hand, which is the trap the script
-# was written to remove.
-#
-# Keep this loop bash-3.2-clean: no `mapfile`, no `readarray`, no `declare -A`,
-# no `${x^^}`/`${x,,}`. Two details are load-bearing and neither is obvious:
-#
-#   `regen_paths=()` BEFORE the loop. Under `set -u` a loop that appends
-#   nothing never creates the array at all, so `${#regen_paths[@]}` below
-#   aborts with `unbound variable` — and "grep matched nothing" is precisely
-#   the case the refusal below exists to REPORT. Measured: without the
-#   declaration the empty input dies at `regen_paths: unbound variable`; with
-#   it, `count=0` and the refusal prints.
-#
-#   `if [[ -n … ]]; then …; fi`, not a trailing `[[ -n … ]] && …`. Measured:
-#   with the `&&` form the `while` takes status 1 whenever the LAST line read
-#   fails the test, and under `set -e` that kills the caller the moment such a
-#   loop is the last command of a function — silently correct today, a landmine
-#   for the next refactor. The `if` form returns 0 on the same input. (This is
-#   the form #12142 standardised; its own note attributes the trap to the empty
-#   list, which measures clean — an all-empty read leaves the body unexecuted
-#   and the `while` at status 0.)
-regen_paths=()
-regen_line=''
-while IFS= read -r regen_line; do
-  if [[ -n "$regen_line" ]]; then regen_paths+=("$regen_line"); fi
-done < <(grep 'merge=os-regen' .gitattributes | awk '{print $1}')
-if [ "${#regen_paths[@]}" -eq 0 ]; then
-  echo "✗ no merge=os-regen entries found in .gitattributes — refusing to guess" >&2
-  exit 1
-fi
-echo "→ os-regen paths (from .gitattributes, ${#regen_paths[@]} patterns):"
-printf '    %s\n' "${regen_paths[@]}"
+# --- the sequence ------------------------------------------------------------
 
-echo "→ step 1: git merge origin/main"
-if ! git merge --no-edit origin/main; then
-  echo "✗ merge stopped on conflicts in NON-generated files — resolve those by hand" >&2
-  echo "  (semantic merge, both intents stack), then rerun this script to redo the" >&2
-  echo "  generated-artifact half. ⛔ Do not resolve generated files textually." >&2
-  exit 1
-fi
+mode_run() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "✗ not inside a git worktree" >&2
+    exit 1
+  fi
 
-echo "→ step 2: taking origin/main's side of every generated artifact"
-for p in "${regen_paths[@]}"; do
-  # a pattern may match nothing on this branch — that is fine
-  git checkout origin/main -- "$p" 2>/dev/null || true
-done
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  case "$branch" in
+    main | HEAD)
+      echo "✗ refusing to run on '$branch' — run inside the feature branch's worktree" >&2
+      exit 1
+      ;;
+  esac
 
-echo "→ step 3: committing the merge BEFORE any regeneration"
-if [ -n "$(git status --porcelain)" ]; then
-  git add -A
-  git commit --no-edit -m "merge origin/main (os-regen artifacts taken from main; regeneration follows)"
-else
-  echo "   (merge left no additional changes to commit)"
-fi
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "✗ working tree not clean — commit or drop local changes first (⛔ never git stash)" >&2
+    exit 1
+  fi
 
-cat <<'EOF'
+  echo "→ fetching origin/main"
+  git fetch origin main
+
+  # Captured BEFORE step 1, on purpose — see the header. After the merge both
+  # readings answer a different question, and both answer it plausibly.
+  branch_tip="$(git rev-parse HEAD)"
+  if ! merge_base="$(git merge-base HEAD origin/main)"; then
+    echo "✗ no merge base with origin/main — refusing to guess which side is yours" >&2
+    exit 1
+  fi
+  echo "→ branch tip $(git rev-parse --short "$branch_tip") · merge base $(git rev-parse --short "$merge_base")"
+
+  # The single authoritative list, read at run time.
+  #
+  # READ LOOP, NOT `mapfile` — THE BASH 3.2 FLOOR. `mapfile`/`readarray` are bash
+  # 4 builtins and `/usr/bin/env bash` is bash 3.2.57 on macOS (Apple ships no
+  # bash 4+, for licensing reasons). This script is run BY HAND, in an agent's or
+  # a maintainer's worktree, and it has no CI path at all — nothing in
+  # `.github/workflows/` invokes it — so a bash-4 builtin here does not fail on a
+  # fringe host, it fails on the ordinary one, and no CI run can ever say so.
+  # Measured with the builtin disabled (`enable -n mapfile readarray` via
+  # `BASH_ENV`, which reproduces the macOS symptom byte for byte):
+  # `mapfile: command not found`, then `set -e` kills the run at status 127 —
+  # AFTER `git fetch origin main` and BEFORE step 1, i.e. with the merge sequence
+  # whose ORDER is this script's entire reason for existing not begun. The
+  # operator is left to perform steps 1–3 by hand, which is the trap the script
+  # was written to remove.
+  #
+  # Keep this loop bash-3.2-clean: no `mapfile`, no `readarray`, no `declare -A`,
+  # no `${x^^}`/`${x,,}`. Two details are load-bearing and neither is obvious:
+  #
+  #   `regen_paths=()` BEFORE the loop. Under `set -u` a loop that appends
+  #   nothing never creates the array at all, so `${#regen_paths[@]}` below
+  #   aborts with `unbound variable` — and "grep matched nothing" is precisely
+  #   the case the refusal below exists to REPORT. Measured: without the
+  #   declaration the empty input dies at `regen_paths: unbound variable`; with
+  #   it, `count=0` and the refusal prints.
+  #
+  #   `if [[ -n … ]]; then …; fi`, not a trailing `[[ -n … ]] && …`. Measured:
+  #   with the `&&` form the `while` takes status 1 whenever the LAST line read
+  #   fails the test, and under `set -e` that kills the caller the moment such a
+  #   loop is the last command of a function — silently correct today, a landmine
+  #   for the next refactor. The `if` form returns 0 on the same input. (This is
+  #   the form #12142 standardised; its own note attributes the trap to the empty
+  #   list, which measures clean — an all-empty read leaves the body unexecuted
+  #   and the `while` at status 0.)
+  regen_paths=()
+  regen_line=''
+  while IFS= read -r regen_line; do
+    if [[ -n "$regen_line" ]]; then regen_paths+=("$regen_line"); fi
+  done < <(grep 'merge=os-regen' .gitattributes | awk '{print $1}')
+  if [ "${#regen_paths[@]}" -eq 0 ]; then
+    echo "✗ no merge=os-regen entries found in .gitattributes — refusing to guess" >&2
+    exit 1
+  fi
+  echo "→ os-regen paths (from .gitattributes, ${#regen_paths[@]} patterns):"
+  printf '    %s\n' "${regen_paths[@]}"
+
+  # Which side moved which generated file, read against the pre-merge tip. Two
+  # `git diff`s for the whole set — a per-file loop over the hot directory globs
+  # would spawn a process per shard. Kept as newline-delimited STRINGS with a
+  # leading and trailing newline, so membership is a `case` glob and costs no
+  # process at all; a path can never contain a newline (git quotes those).
+  NL='
+'
+  branch_edited=()
+  edited_line=''
+  while IFS= read -r edited_line; do
+    if [[ -n "$edited_line" ]]; then branch_edited+=("$edited_line"); fi
+  done < <(git diff --name-only "$merge_base" "$branch_tip" -- "${regen_paths[@]}")
+  main_edited="$NL$(git diff --name-only "$merge_base" origin/main -- "${regen_paths[@]}")$NL"
+
+  echo "→ step 1: git merge origin/main"
+  if ! git merge --no-edit origin/main; then
+    echo "✗ merge stopped on conflicts in NON-generated files — resolve those by hand" >&2
+    echo "  (semantic merge, both intents stack), then rerun this script to redo the" >&2
+    echo "  generated-artifact half. ⛔ Do not resolve generated files textually." >&2
+    exit 1
+  fi
+
+  echo "→ step 2: taking origin/main's side of the generated artifacts main moved"
+  # ⚠️ bash 3.2 expands `"${arr[@]}"` of an EMPTY array as an unbound variable
+  # under `set -u` (fixed only in 4.4), and "the branch edited no generated
+  # artifact" is the ordinary case. `${arr[@]+"${arr[@]}"}` is the 3.2-safe
+  # spelling: it expands to nothing at all when the array is empty.
+  excludes=()
+  if [ "${#branch_edited[@]}" -gt 0 ]; then
+    for edited in "${branch_edited[@]}"; do
+      case "$main_edited" in
+        *"$NL$edited$NL"*)
+          # Both sides moved it: the driver ran and dropped one side. Taking
+          # main's side is the point of this step — but say so per path, loudly.
+          echo "   ⚠ TAKING main's side of $edited (both sides changed it)"
+          echo "     — the os-regen driver merged it with exit 0 and silently kept one side."
+          echo "       Step 4's regeneration re-derives the generated content on top. If this"
+          echo "       branch HAND-edited this file (a released-baseline deletion no generator"
+          echo "       reproduces), restore the branch bytes before regenerating."
+          ;;
+        *)
+          excludes+=(":(exclude)$edited")
+          echo "   ⚠ KEEPING the branch's bytes of $edited"
+          echo "     — the branch changed it and main did not, so git resolved it trivially"
+          echo "       and there is nothing to reconcile. Taking main's side here would be a"
+          echo "       pure revert of a COMMITTED change (a retirement branch's hand-deletions"
+          echo "       are the deliverable). Step 4 regenerates it as usual."
+          ;;
+      esac
+    done
+  fi
+  for p in "${regen_paths[@]}"; do
+    # a pattern may match nothing on this branch — that is fine
+    git restore --source=origin/main -- "$p" ${excludes[@]+"${excludes[@]}"} 2>/dev/null || true
+  done
+
+  echo "→ step 3: committing the merge BEFORE any regeneration"
+  if [ -n "$(git status --porcelain)" ]; then
+    git add -A
+    if ! git commit --no-edit -m "merge origin/main (os-regen artifacts taken from main; regeneration follows)"; then
+      echo "✗ step 3's commit was refused — the merge is staged but NOT committed." >&2
+      echo "  ⛔ Do not regenerate yet: with a staged index a bare \`git commit\` after" >&2
+      echo "     regeneration lands the STAGED side, not the tree you inspected." >&2
+      echo "  Clear what the hook reported, then \`git add -A && git commit\` before step 4." >&2
+      exit 1
+    fi
+  else
+    echo "   (merge left no additional changes to commit)"
+  fi
+
+  # Hand-off assertion: step 4 regenerates on top of this tree and commits the
+  # result, so anything uncommitted here rides into that commit unread.
+  handoff="$(git status --porcelain -- "${regen_paths[@]}")"
+  if [ -n "$handoff" ]; then
+    echo "✗ refusing to hand off to step 4 — generated paths are not committed:" >&2
+    printf '%s\n' "$handoff" >&2
+    echo "  A regen path whose INDEX and WORKTREE disagree (porcelain \`MM\`) is the trap:" >&2
+    echo "  \`git commit\` builds from the INDEX, so it lands the side you did not inspect —" >&2
+    echo "  a commit whose message claims the opposite of its contents. Commit or discard" >&2
+    echo "  these first; ⛔ \`git diff\` and \`git diff HEAD\` read clean right over it." >&2
+    exit 1
+  fi
+
+  cat <<'EOF'
 → step 4 (yours, in this order — the script stops here on purpose):
    1. build the spec build closure, then regenerate the WHOLE chain
       (e.g. pnpm --filter @objectstack/spec build && the gen:* scripts your
@@ -141,5 +309,227 @@ cat <<'EOF'
    3. assert every sibling PR's entries AND the previous PR's implementation
       body still exist: quoted-exact-name `git grep "<symbol>" origin/main -- <path>`
       — entries are the index, the implementation body is what gets swallowed;
-   4. commit the regeneration as its own commit and push.
+   4. `git add` the regenerated paths and INSPECT THE STAGED DIFF, NOT THE
+      WORKING-TREE DIFF, BEFORE COMMITTING (`git diff --cached`) — a commit is
+      built from the index, and `git diff`/`git diff HEAD` never read it;
+   5. commit the regeneration as its own commit and push.
 EOF
+}
+
+# --- self-test ---------------------------------------------------------------
+#
+# Fixtures are whole synthetic repos, because every behaviour here is a claim
+# about what git does to an index and a worktree — a mock of git would pin the
+# mock. Each case builds a bare origin plus a clone, so `origin/main` is a real
+# remote-tracking ref and `git fetch origin main` is a real fetch.
+
+st_fail=0
+
+st_case() {
+  # st_case <label> <got> <want>
+  if [ "$2" = "$3" ]; then
+    printf '  ok    %s\n' "$1"
+  else
+    printf '  FAIL  %s\n        got:  %s\n        want: %s\n' "$1" "$2" "$3"
+    st_fail=$((st_fail + 1))
+  fi
+}
+
+# Build a fixture repo in $1 and leave the cwd in its clone, on branch
+# `feature`. One fixture exercises all three per-file cases at once:
+#
+#   gen/baseline.txt  branch only  — a COMMITTED hand-deletion, main untouched
+#   gen/both.txt      both sides   — the driver runs and silently keeps ours
+#   gen/mainonly.txt  main only    — git resolves it to main trivially
+#
+# The `os-regen` driver is registered as `true`, which is the real driver's
+# measured shape for this purpose: exit 0, keep ours, say nothing. Without it
+# git never invokes a driver at all and the both-sides case cannot exist.
+st_fixture() {
+  fx="$1"
+  rm -rf "$fx"
+  mkdir -p "$fx"
+  git init -q --bare -b main "$fx/origin.git"
+  git clone -q "$fx/origin.git" "$fx/work" 2>/dev/null
+  cd "$fx/work"
+  git config user.email selftest@example.invalid
+  git config user.name os-regen-merge-selftest
+  git config commit.gpgsign false
+  git config merge.os-regen.name 'os-regen (fixture: exit 0, silently keeps ours)'
+  git config merge.os-regen.driver true
+
+  mkdir -p gen src
+  printf 'gen/**   merge=os-regen\n' > .gitattributes
+  printf 'ManifestConfig\nPreviewModeConfig\nRuntimeConfig\n' > gen/baseline.txt
+  printf 'both v0\n' > gen/both.txt
+  printf 'mainonly v0\n' > gen/mainonly.txt
+  printf 'source v1\n' > src/app.txt
+  git add -A
+  git commit -qm seed
+  git push -q origin main
+
+  git checkout -q -b feature
+  printf 'ManifestConfig\nRuntimeConfig\n' > gen/baseline.txt   # the hand-deletion
+  printf 'both v1-BRANCH\n' > gen/both.txt
+  printf 'source v2 (branch)\n' > src/app.txt
+  git add -A
+  git commit -qm 'retire PreviewModeConfig: hand-delete the released baseline line'
+
+  git worktree add -q "$fx/mainwt" main
+  (
+    cd "$fx/mainwt"
+    git config user.email selftest@example.invalid
+    git config user.name os-regen-merge-selftest
+    git config commit.gpgsign false
+    printf 'unrelated main change\n' > src/other.txt
+    printf 'both v1-MAIN\n' > gen/both.txt
+    printf 'mainonly v1-MAIN\n' > gen/mainonly.txt
+    git add -A
+    git commit -qm 'main: unrelated change plus two regenerations'
+    git push -q origin main
+  )
+  cd "$fx/work"
+  # Released so a case can `git checkout main` in the clone — a checked-out
+  # branch cannot be checked out twice.
+  git worktree remove "$fx/mainwt"
+  git fetch -q origin main
+}
+
+mode_self_test() {
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/os-regen-merge-selftest.XXXXXX")"
+  trap 'rm -rf "$tmp"' EXIT INT TERM
+  here="$(pwd)"
+  printf 'os-regen-merge --self-test\n'
+
+  # --- 1. all three per-file cases, in one run
+  st_fixture "$tmp/a" >/dev/null 2>&1
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'a clean run exits 0' "$rc" 0
+  # branch-only: the committed hand-deletion survives — HAZARD 1
+  st_case 'branch-only regen path keeps the branch bytes' \
+    "$(grep -c 'PreviewModeConfig' gen/baseline.txt || true)" 0
+  st_case 'and is not reverted in the commit either' \
+    "$(git show HEAD:gen/baseline.txt | grep -c 'PreviewModeConfig' || true)" 0
+  st_case 'and the run names it as kept' \
+    "$(printf '%s' "$out" | grep -c 'KEEPING the branch.s bytes of gen/baseline.txt' || true)" 1
+  # both sides: the driver dropped main's side; step 2 must put it back
+  st_case 'both-sides regen path takes main s side' \
+    "$(grep -c 'both v1-MAIN' gen/both.txt || true)" 1
+  st_case 'and the run names it as taken, loudly' \
+    "$(printf '%s' "$out" | grep -c "TAKING main.s side of gen/both.txt" || true)" 1
+  st_case 'and that repair is what step 3 commits' \
+    "$(git show HEAD:gen/both.txt | grep -c 'both v1-MAIN' || true)" 1
+  # main-only: git already resolved it; nothing to say and nothing to do
+  st_case 'main-only regen path holds main s side' \
+    "$(grep -c 'mainonly v1-MAIN' gen/mainonly.txt || true)" 1
+  st_case 'and draws no per-path notice at all' \
+    "$(printf '%s' "$out" | grep -cE '(KEEPING|TAKING).*gen/mainonly[.]txt' || true)" 0
+  st_case 'step 4 carries the staged-diff sentence' \
+    "$(printf '%s' "$out" | grep -c 'INSPECT THE STAGED DIFF' || true)" 1
+  st_case 'the hand-off leaves no uncommitted regen path' \
+    "$(git status --porcelain -- 'gen/**' | wc -l | tr -d ' ')" 0
+  cd "$here"
+
+  # --- 2. step 2 writes the WORKTREE, never the INDEX.
+  #
+  # ⚠️ This one is pinned at the SOURCE, deliberately. The property is about the
+  # state between step 2 and step 3, and step 3's `git add -A` stages the same
+  # bytes a moment later either way — so no assertion on a COMPLETED run can
+  # tell `git restore --source` from `git checkout <ref> --`. What the spelling
+  # buys is the abort path (a refused hook, a Ctrl-C, the sequence resumed by
+  # hand): main's side never sits in the index alone, so a bare `git commit`
+  # there lands nothing instead of the wrong side. A behavioural pin that cannot
+  # fail would be worse than no pin, so the scan says what it really checks.
+  # Comment lines are excluded: the header quotes the banned spelling to explain
+  # it, and a scan that cannot tell prose from code would red on its own docs.
+  st_case 'step 2 uses the non-staging spelling' \
+    "$(sed -n '1,/^# --- self-test/p' "$SELF" | grep -v '^[[:space:]]*#' \
+       | grep -c 'git restore --source=origin/main' || true)" 1
+  st_case 'and never the staging one' \
+    "$(sed -n '1,/^# --- self-test/p' "$SELF" | grep -v '^[[:space:]]*#' \
+       | grep -c 'git checkout origin/main --' || true)" 0
+
+  # Behaviour that IS observable: after a run, a regeneration on top is a lone
+  # unstaged `M` — the state where a bare `git commit` commits nothing at all.
+  st_fixture "$tmp/b" >/dev/null 2>&1
+  bash "$SELF" >/dev/null 2>&1 || true
+  printf 'ManifestConfig\nRuntimeConfig\nregenerated\n' > gen/baseline.txt
+  st_case 'a regeneration on top of the run is unstaged M, never MM' \
+    "$(git status --porcelain -- gen/baseline.txt | cut -c1-2)" ' M'
+  cd "$here"
+
+  # --- 3. the hand-off assertion REFUSES an uncommitted regen path.
+  #        Reached through a pre-commit hook that rewrites the worktree after
+  #        the index is built — the ordinary formatter shape.
+  st_fixture "$tmp/c" >/dev/null 2>&1
+  printf '#!/bin/sh\nprintf "hook rewrote this\\n" >> gen/untouched.txt\nexit 0\n' \
+    > .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'an uncommitted regen path at hand-off is refused' "$rc" 1
+  st_case 'and the refusal names the index/worktree split' \
+    "$(printf '%s' "$out" | grep -c 'INDEX and WORKTREE disagree' || true)" 1
+  cd "$here"
+
+  # --- 4. a refused step-3 commit exits non-zero and names the staged index
+  st_fixture "$tmp/d" >/dev/null 2>&1
+  printf '#!/bin/sh\nexit 1\n' > .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'a refused step-3 commit fails the run' "$rc" 1
+  st_case 'and warns against regenerating over a staged index' \
+    "$(printf '%s' "$out" | grep -c 'Do not regenerate yet' || true)" 1
+  cd "$here"
+
+  # --- 5. the pre-existing refusals still hold
+  st_fixture "$tmp/e" >/dev/null 2>&1
+  printf 'dirt\n' > src/app.txt
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'a dirty tree is refused' "$rc" 1
+  st_case 'and says so' \
+    "$(printf '%s' "$out" | grep -c 'working tree not clean' || true)" 1
+  git checkout -q -- src/app.txt
+  git checkout -q main
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'running on main is refused' "$rc" 1
+  git checkout -q feature
+  printf 'nothing routed here\n' > .gitattributes
+  git add -A && git commit -qm 'drop the os-regen routes'
+  out="$(bash "$SELF" 2>&1)" && rc=0 || rc=$?
+  st_case 'an empty os-regen path list is refused' "$rc" 1
+  st_case 'and refuses to guess' \
+    "$(printf '%s' "$out" | grep -c 'refusing to guess' || true)" 1
+  cd "$here"
+
+  if [ "$st_fail" -ne 0 ]; then
+    printf '✗ os-regen-merge self-test: %d case(s) failed.\n' "$st_fail"
+    return 1
+  fi
+  printf '✓ os-regen-merge self-test: all cases pass.\n'
+  return 0
+}
+
+# --- dispatch ----------------------------------------------------------------
+
+main() {
+  case "${1:-}" in
+    --self-test)
+      mode_self_test
+      exit $?
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    '')
+      mode_run
+      ;;
+    *)
+      echo "✗ unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Fixes #12877

Two independently measured hazards in `scripts/pm/os-regen-merge.sh`. Both were
reproduced on synthetic fixture repos against the **pristine** script before
anything was changed, and the same fixtures are now the script's `--self-test`.

Single file changed: `scripts/pm/os-regen-merge.sh`. No changeset — `scripts/pm`
releases nothing (`skip-changeset` applied at PR-open time). No ratcheted file is
touched, so there is no cut ledger to report. Not a governed surface: today's
register prints `docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md`.

## Hazard 1 — step 2 reverted committed hand-deletions

**Reproduction against the pristine script** (blob `85e85f98`, byte-identical to
`origin/main`). Fixture: a retirement branch commits a hand-deletion inside a
`merge=os-regen` path; main touches only a non-generated file, exactly as the
live root-cause round established. Running the pristine script:

```
→ step 2: taking origin/main's side of every generated artifact
→ step 3: committing the merge BEFORE any regeneration
[feature 6c25a47] merge origin/main (os-regen artifacts taken from main; regeneration follows)
 1 file changed, 1 insertion(+)
=== script exit status: 0 ===
HAZARD-1: REPRODUCED — the committed hand-deletion came back
```

Exit 0, no warning, and step 3 **committed** the revert.

### The fix, and why it is per-file with two branches rather than a blanket skip

The card and the dispatch both propose "skip every regen path where
`git diff MERGE_BASE..HEAD` is non-empty". I implemented that first, and
measuring it showed it is not safe on its own — **it makes step 2 inert**:

```
=== branch-edited regen paths ===        gen/both.txt  gen/brchonly.txt
=== main-edited regen paths ===          gen/both.txt  gen/mainonly.txt
--- driver invocation log ---            DRIVER-INVOKED-ON:gen/both.txt
=== step 2 OLD would change ===          gen/both.txt  gen/brchonly.txt
=== step 2 NEW (blanket skip) leaves === [ nothing ]
NO — step 2 is inert, step 3's commit branch is unreachable
```

Git invokes a merge driver **only** where both sides changed a path, so every
path step 2 can act on is by construction a path the branch edited. Skip them
all and the driver's silent drop (`both v1-MAIN`, lost above) rides into the
merge commit unrepaired — trading the revert hazard for the silent-drop hazard
this script exists to close.

So the side is chosen **per file**, against the merge base captured *before*
step 1 (after the merge, `git merge-base HEAD origin/main` is main's own tip and
every file reads as branch-edited):

| case | what git already did | step 2 now |
|:--|:--|:--|
| branch changed it, **main did not** | resolved trivially to the branch's bytes; nothing to reconcile | **keep the branch's bytes** + per-path notice — taking main's side would be a pure revert. This is the measured incident. |
| **both** sides changed it | the driver ran, exited 0, silently kept one side | **take main's side** + loud per-path notice ("if this branch HAND-edited it, restore the branch bytes before regenerating") |
| main only / neither | already main's | take main's side (a no-op) |

Both branches are shapes the card itself proposes; this uses each where it is
correct. Per **file**, not per pattern — the hot patterns are directory globs
over dozens of shards.

## Hazard 2 — the MM staging trap

**Reproduction of the mechanism**, isolated on a clean tree:

```
--- git checkout other -- gen/b.json  (what step 2 used to do)
porcelain: [M  gen/b.json]            (STAGED)
--- then a regeneration lands in the worktree
porcelain: [MM gen/b.json]            (a bare `git commit` lands the STAGED side)
--- git restore --source=other -- gen/b.json  (what step 2 does now)
worktree: B-main   index: B-branch   porcelain: [ M gen/b.json]
```

`git checkout REF -- PATH` writes the index as well as the tree; `git restore
--source=REF` writes the tree only. With a lone unstaged `M`, a bare `git
commit` lands **nothing** instead of the wrong side — a loud no-op beats a quiet
revert. This is the spelling AGENTS.md already prescribes.

### Refuse, not auto-stage — and why

The dispatch offered "stage the regenerated paths itself **or** refuse while any
regen path is MM". Auto-staging is not available to this script: it deliberately
does **not** regenerate (step 4 is printed, not run), so "the regenerated paths"
do not exist while it is running, and staging whatever happens to be in the tree
is the commit-the-wrong-side defect inverted. Refusal is also what every existing
failure mode in this script is — not-a-worktree, on `main`, dirty tree, empty
pattern list, non-generated conflict are all loud refusals with a remedy.

So the sequence now ends with a **hand-off assertion**: every os-regen path must
be committed before step 4 begins. `MM` is the state the card names and this is
its superset — any uncommitted regen path at hand-off would be absorbed by step
4's "commit the regeneration as its own commit" unread. A refused step-3 commit
now also exits with a named remedy instead of a bare `set -e` death.

### The runbook sentence

It lands in this script's own header and in the step-4 block it prints:

> **inspect the STAGED diff, not the working-tree diff, before committing**

The two documented alternatives are both governed **and** line-ratcheted
(`.claude/skills/pm-dispatch/references/landing-operations.md` at 80,
`AGENTS.md`), so putting it there would have made this a governed PR and forced
a net-0 cut. The script is where the repo already points for these steps —
AGENTS.md calls it "the in-repo authority", landing-operations says
「步骤以脚本自身为权威」 — and it is what the operator is reading at the moment
the sentence matters.

## Self-test — `bash scripts/pm/os-regen-merge.sh --self-test`

23 rows over whole synthetic repos (a mock of git would pin the mock). The
fixture registers the `os-regen` driver as `true` — exit 0, keep ours, say
nothing — which is the real driver's shape for this purpose; without it git
never invokes a driver and the both-sides case cannot exist.

```
os-regen-merge --self-test
  ok    a clean run exits 0
  ok    branch-only regen path keeps the branch bytes
  ok    and is not reverted in the commit either
  ok    and the run names it as kept
  ok    both-sides regen path takes main s side
  ok    and the run names it as taken, loudly
  ok    and that repair is what step 3 commits
  ok    main-only regen path holds main s side
  ok    and draws no per-path notice at all
  ok    step 4 carries the staged-diff sentence
  ok    the hand-off leaves no uncommitted regen path
  ok    step 2 uses the non-staging spelling
  ok    and never the staging one
  ok    a regeneration on top of the run is unstaged M, never MM
  ok    an uncommitted regen path at hand-off is refused
  ok    and the refusal names the index/worktree split
  ok    a refused step-3 commit fails the run
  ok    and warns against regenerating over a staged index
  ok    a dirty tree is refused
  ok    and says so
  ok    running on main is refused
  ok    an empty os-regen path list is refused
  ok    and refuses to guess
✓ os-regen-merge self-test: all cases pass.
```

Two rows are pinned at the **source**, and say so at the assertion: after step 3
commits, the index equals HEAD either way, so no assertion on a completed run
can separate `git restore --source` from `git checkout REF --`. What the
spelling buys is the abort path. A behavioural pin that cannot fail would be
worse than no pin.

⚠️ The self-test is **not** wired into `lint.yml` in this PR — that needs a
workflow edit, outside the file surface this card was dispatched with. Filed as
issue #12893 instead, which also carries the collector-vs-one-step-per-script
question; it mirrors the existing `os-verify-lock.sh --self-test` step.

### Ablation — predictions written to disk before any mutation

Each leg: mutation proven on disk by anchored greps (deleted text and injected
text counted separately), restore under `trap … EXIT INT TERM`, restore verified
by an empty `git diff HEAD` **and** a HEAD-blob hash match. Run from a committed
implementation, so the restore leg has a real reference.

| ablation | predicted | observed |
|:--|:--|:--|
| A — step 2 unconditional again | 2 hazard-1 rows red; notice row + both-sides row stay green | exactly that (2 failed) |
| B — hand-off assertion neutralised | 2 hand-off rows red, hazard-1 rows green | exactly that (2 failed) |
| C — staging spelling restored | 2 source-scan rows red; the behavioural MM row **stays green** | exactly that (2 failed) |

Anchored greps for every leg: deleted text `before=1 after=0`, injected text
`before=0 after=1`. Restore after each leg and at the end:
`blob 9634d1cb… == HEAD 9634d1cb…`, `git diff HEAD` empty.

Honest note: the **first** run of ablation C over-mutated — its inline marker
comment swallowed the rest of the line, so it silently became ablation A as well
and reddened two rows I had not predicted. It was re-run cleanly (swapping only
the spelling, keeping the exclude argument), and the clean run matched the
prediction exactly. The table reports the clean run.

## Gates — derived union, all green

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths
passed; it derives its own change set from the merge base) → 10 families, run at
**`f56989d96`**, the final commit. Heavy run under `os-verify-lock.sh` with
`OS_VERIFY_LOCK_SLOT=os-dev-12877`; exit codes captured before any pipe.

```
os-verify-lock: VERDICT command-exit 0 · held the lock 32s · waited 0s
```

Each gate's own verdict line:

- `check:agent-test-spelling` — ✓ 0 violations — 391 file(s) · 4334 bare `--` token(s) · 1205 launcher-rooted run(s) · 9 separator(s) JUDGED
- `check:bash32-floor` — ✓ 22 tracked shell file(s) … name no bash 4+ construct outside a comment … census: 20 by .sh extension, 2 by shebang alone; 19 constructs checked, floor bash 3.2
- `check:cli-command-ids` — ✓ 288 command-id literal(s) across 104 file(s) … all resolve to a real command path
- `check:cross-package-test-inputs` — All 117 self-test cases passed. / OK: 20 package(s) read outside themselves, all declared
- `check:entry-guard` — ✓ 172 scripts/ file(s) — every entry guard goes through invoked-as.mjs
- `check:parse-guard` — ✓ 171 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs
- `check:pnpm-filter-targets` — ✓ 140/177 `--filter` occurrence(s) across 30 file(s) resolve against 78 workspace package(s)
- `check:watch-hint-literal` — ✓ 15 ROOT_DIR_WATCH_HINTS declaration(s), every one an array of quoted literals
- `check-ci-filter-parity.mjs` — OK: all 109 declared cross-package glob(s) (84 unique) are covered
- `check-cross-package-test-inputs.mjs` — OK: 20 package(s) read outside themselves, all declared
- `check:nul-bytes` (every diff owes it) — check-nul-bytes: OK (scanned 7168 text file(s) … no raw ASCII control bytes)

The bash-3.2 floor gate's population is `scripts/**`, so it does cover
`scripts/pm` — checked rather than assumed. The one 3.2 trap this diff had to
handle is called out at the code: `"${arr[@]}"` on an EMPTY array is an unbound
variable under `set -u` before bash 4.4, and "the branch edited no generated
artifact" is the ordinary case, so the exclusion list uses
`${arr[@]+"${arr[@]}"}`.

Repo-wide `pnpm lint` was **narrowed, and the narrowing is measured** rather than
asserted: eslint's own answer for the one changed file, via `--format json`, is
`"File ignored because no matching configuration was supplied."` — 1 file
requested, 0 linted, 0 errors. The file is a shell script, outside every
population eslint's flat config declares, and it participates in no TS program,
so no untouched file's verdict can depend on it. Control bytes scanned
separately: `grep -naP` over the changed file exits 1 (no match).

CI runs the full farm regardless; nothing here waits on it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_