### PR TITLE
fix(spec): namespace tombstone stops citing ADR-0006 D4 — unblocks the merge queue's check-adr-anchors red

### DIFF
--- a/.changeset/tombstone-citation-unwritten-decision.md
+++ b/.changeset/tombstone-citation-unwritten-decision.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/spec': patch
+---
+
+The `namespace` tombstone's rejection message no longer cites "ADR-0006 D4" — a decision letter no version of ADR-0006 declares. The retirement itself is unchanged and still enforced; the message keeps the fix (`name: "sys_user"`) and the #4001 parse-path history. The letter citation comes back when the retirement decision is actually written into an ADR.

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1464,7 +1464,7 @@ const UNKNOWN_KEY_GUIDANCE: Record<string, string> = {
   // Tombstones age out too: drop an entry ~two majors after the removal
   // (by then it's archaeology, not an upgrade; see CHANGELOG.md for history).
   namespace:
-    '`namespace` was retired in ADR-0006 D4 — the object `name` IS the canonical id ' +
+    '`namespace` was retired — the object `name` IS the canonical id ' +
     'everywhere (API, ObjectQL, REST, SDK, DB table), so there is no separate namespace ' +
     'to declare. Embed the module prefix in the name instead: `namespace: "sys", ' +
     'name: "user"` becomes `name: "sys_user"`. Until #4001 closed this shape on the ' +


### PR DESCRIPTION
**Main is red and the whole merge queue is stalled on it** — every `merge_group` build since ~07:49Z fails `Lint & Type Check` at `check-adr-anchors`:

> `ADR-0006 D4 is cited by 1 file(s), but ADR-0006 declares no D4 — it decides: D1, D1.1, D1.2, D1.3, D2, D3` (`packages/spec/src/data/object.zod.ts`)

Observed dequeues: #12895 (CI_FAILURE, 08:29Z), plus failing queue builds for pr-12897 / pr-12901 / pr-12905 in the same window.

## Root cause — two landings that never met in CI

- The letter validation (`live-decision-letters-are-green-today`) landed in `check-adr-anchors` via #12785.
- The ADR-0006 **v4 addendum** (#12736) minted `### D1 / D2 / D3` headings for the API-surface boundary record — the FIRST decision letters any version of ADR-0006 ever declared. It is a governed `docs/adr/**` surface, so it was **human-direct-merged (bypass) at 07:49Z — skipping merge-time re-validation**, which is precisely the one gap the bypass path has.
- With letters now declared, the ancient `ADR-0006 D4` citation in the `namespace` tombstone (added by #4522) became mechanically unresolvable. No version of ADR-0006 ever declared a D4 or decided object naming — the citation was always a phantom; it just had nothing to contradict it until today.

## The fix — the gate's own remedy, case (c)

> "(c) if the decision is real but unwritten, it needs an ADR, not a citation."

The retirement is real and stays enforced. This PR drops only the false letter citation from the tombstone string — the message keeps the actionable fix (`name: "sys_user"`) and the #4001 parse-path history. One string, plus a patch changeset for `@objectstack/spec` (the string is a shipped rejection message).

Deliberately NOT in this diff (follow-up card filed): the sibling spelling in `translation.zod.ts:362` and the `object.test.ts:1573` test title (neither is in the gate's scanned population — the gate names exactly 1 file), CHANGELOG history (never edited), and writing the actual ADR decision so the citation can return.

## Verification

- Reproduced FIRST on the pristine tree at `aef1b7e64` (= current main): `check-adr-anchors --self-test` → 1 failure of 106, EXIT=1, same rendering as the queue logs.
- After the one-string fix: `✓ check-adr-anchors --self-test: 106 assertions …` EXIT=0; live run EXIT=0.
- `vitest run src/data/object.test.ts` → **185/185 pass** — the tombstone pin asserts the `` `namespace` `` and `name: "sys_user"` substrings, both kept.
- The change is a string literal inside an object the test suite imports and compiles; no API surface moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_