### PR TITLE
fix(metadata-protocol): classify a producer-marked refusal at the producer, so the 503 stays non-quoting (#12536)

### DIFF
--- a/.changeset/marked-refusal-classified-at-producer.md
+++ b/.changeset/marked-refusal-classified-at-producer.md
@@ -1,0 +1,57 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): a metadata app's MARKED refusal is classified as a refusal at the producer, instead of being wrapped as a store outage (#12536)
+
+A metadata app's sandboxed hook on `sys_metadata` can refuse a read and mark its
+refusal with `userMessage` — the #9934 producer-side opt-in where the field's
+presence *is* the marking. Every such refusal was handed to
+`metadataStoreUnavailableError`, which builds a fresh `Error` carrying only
+`code` / `status` / `cause`, and `declaredUserMessage` reads the **top level**
+and never `cause`. The mark therefore died at the producer, on the whole
+`getMetaItem` / `getMetaItems` read family and on `deletePackage`.
+
+**FROM** — a marked hook refusal and a `connect ECONNREFUSED` came out of
+`getMetaItems` as the same envelope, and no consumer could tell them apart:
+
+```
+MARKED hook refusal  -> 503 SERVICE_UNAVAILABLE  declaredUserMessage=undefined
+                        "The metadata store could not be read, ..."
+driver fault         -> 503 SERVICE_UNAVAILABLE  declaredUserMessage=undefined
+                        "The metadata store could not be read, ..."
+```
+
+**TO** — the failure is classified once, at the producer, before it is wrapped:
+
+```
+MARKED hook refusal  -> 400 (or the status the hook declared for itself)
+                        userMessage = the author's text, verbatim
+driver fault         -> 503 SERVICE_UNAVAILABLE  (byte-for-byte unchanged)
+                        "The metadata store could not be read, ..."
+```
+
+`deletePackage`'s per-item path follows the same classification: `failed[]` and
+`cleanups[]` gain an optional `userMessage` member, present exactly when the
+item's own failure declared the mark. Those rows ride inside a
+`PACKAGE_DELETE_PARTIAL` 400's `details`, where no HTTP boundary can carry a
+`userMessage` on their behalf, so the channel has to exist on the row itself.
+`deleteMetaItem`'s two re-wrap exits carry the mark forward for the same reason
+they already carry a catalogued `code`.
+
+Maintainer ruling 2026-08-27, option B. The declined alternative — forwarding
+the mark *across* the 503 — is not implemented and is pinned against: the
+store-unavailable door still quotes nothing from `cause`, and a test asserts the
+underlying failure text appears in no field outside it.
+
+**Behaviour that does not change.** An unmarked failure keeps the #8136 503
+exactly as it was: same status, same code, same sentence, same `cause`
+relocation. A blank, whitespace-only or non-string `userMessage` is not a
+declaration, so nothing invents a marked refusal, and the #3821 generic
+substitution stays in force for everything unmarked.
+
+**For hook authors.** A refusal that names its own `status` / `statusCode`
+keeps it (#7867). One that names none is answered 400 — the same default the
+REST sandbox door already applies to an undeclared hook refusal (#9967) — with
+the catalogued code for that status; declare `status` (and a catalogued `code`)
+when a different classification is wanted.

--- a/packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts
+++ b/packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts
@@ -49,17 +49,32 @@
 // shared prefix would hide.
 //
 // ---------------------------------------------------------------------------
-// Reverse verification — direction predicted BEFORE running
+// Reverse verification — direction predicted BEFORE running, then MEASURED
 // ---------------------------------------------------------------------------
-// With `protocol.ts` restored from origin/main, predicted:
-//   - RED: §1 (every marked case — they assert the refusal category and the
-//     author's text, which the unfixed producer replaces with the 503), and
-//     §3's marked cases (`failed[].userMessage` / `cleanups[].userMessage` do
-//     not exist on the unfixed row).
-//   - GREEN in both directions, and therefore [GUARD] rather than evidence:
-//     §2 in its entirety. The store fault is unchanged BY DESIGN, so a green
-//     §2 before and after is exactly the claim — it is the over-reach bound,
-//     and it is what turns "I did not break the 503" into a measurement.
+// Ablation: `git checkout <branch point> -- protocol.ts` (this file untouched),
+// mutation confirmed on disk by blob hash + anchored counts, restored with
+// `git checkout HEAD --` and proven by an empty `git diff HEAD`. No rebuild is
+// involved and none is owed: the subject is imported by RELATIVE path from
+// inside its own package, so vitest compiles the mutated source itself — and
+// that is not assumed, it is what the pre-fix and post-fix runs of the same
+// harness measured, with no package build between them.
+//
+// PREDICTED: §1 red, §3's marked cases red, §2 green throughout.
+// MEASURED: 11 red / 6 green — and the prediction was WRONG about §2's
+// granularity, which is recorded rather than tidied away:
+//
+//   - §1 — 6 red, 1 green. The green one is "a blank or non-string
+//     `userMessage` is not a marking": it asserts the 503, which the UNFIXED
+//     producer also gives. A guard, green in both directions, and it belongs
+//     to §1 by subject rather than by direction.
+//   - §2 — 2 red, 2 green, not the 4 green predicted. Two of §2's cases speak
+//     about the MARKED side (the positive control, and "the two conversations
+//     are distinguishable"), so they must go red on an unfixed producer. The
+//     two that are genuinely fault-only — the byte-for-byte envelope and the
+//     NEGATIVE PIN — stayed green, and those two are the real over-reach
+//     bound: they are what turns "the 503 did not move" into a measurement.
+//   - §2.0 — 2 green. Pure scanner self-tests; no producer is involved.
+//   - §3 — 3 red, 1 green. The green one is the driver-fault row guard.
 
 import { describe, it, expect, vi } from 'vitest';
 import { declaredUserMessage, resolveThrownHttpError } from '@objectstack/types';

--- a/packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts
+++ b/packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#12536] A producer-MARKED application refusal and a genuine store fault are
+// two different conversations, and this file holds them apart.
+//
+// ---------------------------------------------------------------------------
+// The defect, measured on `origin/main` (aef1b7e64) before the fix
+// ---------------------------------------------------------------------------
+// A metadata app's sandboxed hook on `sys_metadata` may refuse a read and mark
+// its refusal with `userMessage` — the #9934 producer-side opt-in where the
+// field's PRESENCE is the marking (maintainer ruling 2026-08-19,
+// objectui#5210 option 1). `metadataStoreUnavailableError` built a fresh error
+// carrying only `code` / `status` / `cause`, and `declaredUserMessage` reads
+// the TOP level and never `cause` — so the mark died at the producer. Driven
+// through the real `ObjectStackProtocolImplementation` with an engine whose
+// read rejects, the two failures were indistinguishable:
+//
+//   getMetaItems / MARKED hook refusal
+//     -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
+//        message="The metadata store could not be read, ..."
+//   getMetaItems / driver fault (connect ECONNREFUSED 10.0.0.5:5432)
+//     -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
+//        message="The metadata store could not be read, ..."   <- byte-identical
+//
+//   deletePackage / MARKED hook refusal on the per-item delete
+//     -> failed[0] = { type, name, error: "Failed to delete customization
+//        overlay for object/acct. The metadata store rejected the delete; ..." }
+//        — no channel for the mark on the row at all.
+//
+// ---------------------------------------------------------------------------
+// The ruling under test (maintainer, 2026-08-27, verbatim 「同意」 — option B)
+// ---------------------------------------------------------------------------
+// Classify AT THE PRODUCER: a marked refusal travels its own refusal category
+// with the author's text intact; a genuine store fault keeps #8136's
+// deliberately non-quoting 503, untouched. `deletePackage`'s per-item
+// `failed[]` / `cleanups[]` path follows the same classification.
+//
+// ⛔ The declined fallback, pinned here so it cannot be reintroduced as a
+// shortcut: forwarding the mark ACROSS the 503. Section 2 asserts the store
+// fault carries no `userMessage` at all, and that the underlying failure text
+// appears in NO field outside the door.
+//
+// ---------------------------------------------------------------------------
+// Why every zero here is paired
+// ---------------------------------------------------------------------------
+// Section 2's negative pin is an absence claim, so it runs the SAME scanner
+// over a case where the term is present (§2.0) — and the two sentinels are
+// chosen so neither is a substring of the other, which is the failure mode a
+// shared prefix would hide.
+//
+// ---------------------------------------------------------------------------
+// Reverse verification — direction predicted BEFORE running
+// ---------------------------------------------------------------------------
+// With `protocol.ts` restored from origin/main, predicted:
+//   - RED: §1 (every marked case — they assert the refusal category and the
+//     author's text, which the unfixed producer replaces with the 503), and
+//     §3's marked cases (`failed[].userMessage` / `cleanups[].userMessage` do
+//     not exist on the unfixed row).
+//   - GREEN in both directions, and therefore [GUARD] rather than evidence:
+//     §2 in its entirety. The store fault is unchanged BY DESIGN, so a green
+//     §2 before and after is exactly the claim — it is the over-reach bound,
+//     and it is what turns "I did not break the 503" into a measurement.
+
+import { describe, it, expect, vi } from 'vitest';
+import { declaredUserMessage, resolveThrownHttpError } from '@objectstack/types';
+import { ErrorCode } from '@objectstack/spec/api';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+import { assertEngineDeleteDispatch, assertEngineFindOnePredicate, type EngineFindOneQueryInput } from '@objectstack/metadata-core';
+
+// ---------------------------------------------------------------------------
+// Sentinels — deliberately disjoint, neither a substring of the other
+// ---------------------------------------------------------------------------
+
+/** Lives only in the DRIVER's sentence. Must never cross the 503 door. */
+const DRIVER_SENTINEL = 'Zzdriverfault9';
+/** Lives only in the AUTHOR's marked text. Must cross, verbatim. */
+const MARK_SENTINEL = 'Qqauthormark7';
+/**
+ * Lives only in the marked refusal's DIAGNOSTIC `message` — the sandbox's own
+ * debug wrapper. Held apart from the marked text on purpose: the classified
+ * refusal must carry the MARK and take nothing else from its cause, and a
+ * fixture whose two strings coincided could not tell those apart.
+ */
+const DIAG_SENTINEL = 'Wwhookdiag5';
+
+const DRIVER_TEXT = `connect ECONNREFUSED 10.0.0.5:5432 [${DRIVER_SENTINEL}]`;
+const AUTHOR_TEXT =
+    `Your trial plan does not include custom objects — ask your admin to upgrade. [${MARK_SENTINEL}]`;
+
+// No sentinel may contain another, or every "absent" below could be an artifact
+// of one overlapping the other. Asserted, not assumed.
+for (const a of [DRIVER_SENTINEL, MARK_SENTINEL, DIAG_SENTINEL]) {
+    for (const b of [DRIVER_SENTINEL, MARK_SENTINEL, DIAG_SENTINEL]) {
+        if (a !== b && (a.includes(b) || b.includes(a))) {
+            throw new Error(`sentinels ${a} / ${b} overlap — every absence assertion here would be unsound`);
+        }
+    }
+}
+
+/**
+ * The exact bytes today's non-quoting 503 says. Written out rather than
+ * imported: the point of §2 is that this sentence did not move, and importing
+ * the constant would make the assertion true by construction.
+ */
+const STORE_UNAVAILABLE_MESSAGE =
+    'The metadata store could not be read, so whether this item exists is unknown. '
+    + 'Retry once the metadata database is reachable.';
+
+// ---------------------------------------------------------------------------
+// Error shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * What a sandboxed hook that MARKS its refusal produces. The canonical #9934
+ * authoring shape is `const e = new Error(msg); e.userMessage = msg`, and the
+ * QuickJS side-channel carries `code` / `status` / `userMessage` out of the VM
+ * onto `SandboxError`. The `message` here is deliberately the sandbox's own
+ * debug wrapper — DIFFERENT from the marked text, so a test that passes cannot
+ * be passing because the two strings happen to coincide.
+ */
+const markedRefusal = (extra: Record<string, unknown> = {}) =>
+    Object.assign(new Error(`hook 'trial-gate' threw: Error: quota exceeded [${DIAG_SENTINEL}]`), {
+        userMessage: AUTHOR_TEXT,
+        ...extra,
+    });
+
+/** A genuine store fault: no mark anywhere. */
+const driverFault = () => Object.assign(new Error(DRIVER_TEXT), { code: 'ECONNREFUSED' });
+
+// ---------------------------------------------------------------------------
+// The scanner used by every absence claim, and its own positive control
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything a caller could see on a thrown error — its own enumerable and
+ * non-enumerable properties plus `message` / `name` / `stack`, and the wire
+ * projection an HTTP boundary actually resolves.
+ *
+ * `cause` is EXCLUDED on purpose, and that exclusion is the contract rather
+ * than a loophole: the withheld text is not lost, it is relocated to `cause`,
+ * which `handleRouteError` / `logWithheldServerFault` print for the operator.
+ * "Outside the door" means everything else.
+ */
+function outsideTheDoor(err: unknown): string {
+    const e = err as Record<string, unknown> | null;
+    const view: Record<string, unknown> = {};
+    for (const key of Object.getOwnPropertyNames(e ?? {})) {
+        if (key === 'cause') continue;
+        view[key] = (e as any)?.[key];
+    }
+    view.message = (e as any)?.message;
+    view.name = (e as any)?.name;
+    view.stack = (e as any)?.stack;
+    // What the boundary resolves is the projection that actually reaches a
+    // client, so it is scanned too rather than reasoned about.
+    view.__resolved = resolveThrownHttpError(err, 500);
+    return JSON.stringify(view);
+}
+
+describe('[#12536 §2.0] the scanner used by every absence claim finds a term that IS there', () => {
+    it('finds a sentinel carried on a NON-message field', () => {
+        // The control that matters: if `outsideTheDoor` only ever read
+        // `message`, §2's zeros would be vacuous for every other field.
+        const carrier = Object.assign(new Error('a sentence with no sentinel in it'), {
+            userMessage: `refused [${MARK_SENTINEL}]`,
+        });
+        expect(outsideTheDoor(carrier)).toContain(MARK_SENTINEL);
+        expect(outsideTheDoor(carrier)).not.toContain(DRIVER_SENTINEL);
+    });
+
+    it('finds a sentinel carried on `message`', () => {
+        expect(outsideTheDoor(new Error(DRIVER_TEXT))).toContain(DRIVER_SENTINEL);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Harness — the real protocol over an engine that fails the way a hook does
+// ---------------------------------------------------------------------------
+
+function emptyRegistry() {
+    return {
+        getObject: () => undefined,
+        getItem: () => undefined,
+        getArtifactItem: () => undefined,
+        listItems: () => [],
+        applyNavContributions: (x: any) => x,
+        isPackageDisabled: () => false,
+        getObjectOwner: () => undefined,
+        registerItem: () => {},
+        registerObject: () => {},
+        removeRuntimeShadow: () => false,
+        removeOverlayEntry: () => {},
+        uninstallPackage: () => {},
+    };
+}
+
+/** Every read rejects with `error()` — a metadata store the protocol cannot read. */
+function unreadableEngine(error: () => unknown) {
+    const reject = vi.fn(async (object: string, query?: EngineFindOneQueryInput) => {
+        assertEngineFindOnePredicate(object, query);
+        throw error();
+    });
+    return { registry: emptyRegistry(), find: reject, findOne: reject } as any;
+}
+
+/**
+ * `deleteMetaItem` picks its path from the registry's own flags, so the type
+ * under test is DERIVED (Prime Directive #8) rather than named.
+ */
+const REPO_PATH_TYPE = DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => e.allowOrgOverride || e.allowRuntimeCreate)
+    .map((e) => e.type)
+    .sort()[0]!;
+
+/** The uninstall reads one row and then fails the per-item delete underneath it. */
+function uninstallEngine(error: () => unknown) {
+    const row = {
+        id: 'row_1',
+        type: REPO_PATH_TYPE,
+        name: 'acct',
+        organization_id: null,
+        package_id: 'com.acme.crm',
+        state: 'active',
+        metadata: JSON.stringify({ name: 'acct' }),
+        checksum: 'sha256_marked_refusal_fixture',
+    };
+    return {
+        registry: emptyRegistry(),
+        find: vi.fn(async (table: string) => (table === 'sys_metadata' ? [row] : [])),
+        findOne: vi.fn(async (table: string, q?: EngineFindOneQueryInput) => {
+            assertEngineFindOnePredicate(table, q);
+            throw error();
+        }),
+        delete: vi.fn(async (_t: string, o?: Record<string, unknown>) => {
+            assertEngineDeleteDispatch(o);
+            throw error();
+        }),
+    } as any;
+}
+
+async function captureThrow(run: () => Promise<unknown>): Promise<any> {
+    let resolved: unknown;
+    let didResolve = false;
+    try {
+        resolved = await run();
+        didResolve = true;
+    } catch (e) {
+        return e;
+    }
+    expect(didResolve, `expected a rejection, got ${JSON.stringify(resolved)}`).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// 1. The marked refusal leaves by its own door, with the author's text intact
+// ---------------------------------------------------------------------------
+
+describe('[#12536 §1] a producer-marked refusal is classified as a refusal, not as a store fault', () => {
+    for (const [label, call] of [
+        ['getMetaItems', (p: any) => p.getMetaItems({ type: 'object' })],
+        ['getMetaItem', (p: any) => p.getMetaItem({ type: 'object', name: 'acct' })],
+        ['getMetaItem?state=draft', (p: any) => p.getMetaItem({ type: 'object', name: 'acct', state: 'draft' })],
+    ] as const) {
+        it(`${label} carries the author's text VERBATIM`, async () => {
+            const cause = markedRefusal();
+            const p = new ObjectStackProtocolImplementation(unreadableEngine(() => cause));
+
+            const caught = await captureThrow(() => call(p));
+
+            // The whole point of the card: the mark survives to the top level,
+            // which is the only level `declaredUserMessage` reads.
+            expect(declaredUserMessage(caught)).toBe(AUTHOR_TEXT);
+            // …and it is the author's bytes, not a paraphrase.
+            expect(caught.userMessage).toBe(AUTHOR_TEXT);
+            // It is NOT the store-unavailable category any more.
+            expect(caught.status).not.toBe(503);
+            expect(caught.code).not.toBe('SERVICE_UNAVAILABLE');
+            expect(caught.message).not.toBe(STORE_UNAVAILABLE_MESSAGE);
+            // The diagnostic still reaches the operator.
+            expect(caught.cause).toBe(cause);
+        });
+    }
+
+    it('answers the undeclared refusal with the hook door\'s own default status', async () => {
+        const p = new ObjectStackProtocolImplementation(unreadableEngine(() => markedRefusal()));
+        const caught = await captureThrow(() => p.getMetaItems({ type: 'object' } as any));
+
+        // 400 is not chosen here — it is `error-response.ts`'s `declared ?? 400`
+        // for a sandbox hook refusal that named no status (#9967), reused so the
+        // two doors classify one undeclared refusal identically.
+        expect(caught.status).toBe(400);
+        // ADR-0112 D4: whatever code ships must be in the closed vocabulary.
+        expect(ErrorCode.safeParse(caught.code).success).toBe(true);
+    });
+
+    it('keeps a status the hook DECLARED for itself (#7867), in both spellings', async () => {
+        const declared = new ObjectStackProtocolImplementation(
+            unreadableEngine(() => markedRefusal({ status: 403 })));
+        const caughtStatus = await captureThrow(() => declared.getMetaItems({ type: 'object' } as any));
+        expect(caughtStatus.status).toBe(403);
+        expect(declaredUserMessage(caughtStatus)).toBe(AUTHOR_TEXT);
+
+        const spelled = new ObjectStackProtocolImplementation(
+            unreadableEngine(() => markedRefusal({ statusCode: 409 })));
+        const caughtSpelling = await captureThrow(() => spelled.getMetaItems({ type: 'object' } as any));
+        // Reading one spelling is how `/api/v1/data` answered 500 to a
+        // deliberate 409 until #7525; this door reads both because it asks
+        // `resolveThrownHttpError` rather than spelling the chain again.
+        expect(caughtSpelling.status).toBe(409);
+    });
+
+    it('passes a CATALOGUED code from the hook through, and demotes one the ledger does not know', async () => {
+        const catalogued = new ObjectStackProtocolImplementation(
+            unreadableEngine(() => markedRefusal({ status: 403, code: 'FORBIDDEN' })));
+        const a = await captureThrow(() => catalogued.getMetaItems({ type: 'object' } as any));
+        expect(a.code).toBe('FORBIDDEN');
+
+        const dialect = new ObjectStackProtocolImplementation(
+            unreadableEngine(() => markedRefusal({ status: 403, code: 'SQLITE_ERROR' })));
+        const b = await captureThrow(() => dialect.getMetaItems({ type: 'object' } as any));
+        // A driver's own dialect must never enter `ApiErrorSchema.code`.
+        expect(b.code).not.toBe('SQLITE_ERROR');
+        expect(ErrorCode.safeParse(b.code).success).toBe(true);
+        // …and the mark is unaffected by the code demotion.
+        expect(declaredUserMessage(b)).toBe(AUTHOR_TEXT);
+    });
+
+    it('does NOT treat a blank or non-string `userMessage` as a marking', async () => {
+        for (const notADeclaration of ['', '   ', 42, null, undefined]) {
+            const p = new ObjectStackProtocolImplementation(
+                unreadableEngine(() => Object.assign(new Error(DRIVER_TEXT), { userMessage: notADeclaration })));
+            const caught = await captureThrow(() => p.getMetaItems({ type: 'object' } as any));
+            // Absent means the consumer keeps its generic substitution (#3821),
+            // so an unmarked failure must stay the 503 — nothing invents a mark.
+            expect(caught.status, `userMessage=${JSON.stringify(notADeclaration)}`).toBe(503);
+            expect(caught.code).toBe('SERVICE_UNAVAILABLE');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The genuine store fault is byte-for-byte what it was — the over-reach bound
+// ---------------------------------------------------------------------------
+
+describe('[#12536 §2] an UNMARKED store fault keeps the deliberately non-quoting 503 (#8136 untouched)', () => {
+    it('answers the same envelope, byte for byte', async () => {
+        const cause = driverFault();
+        const p = new ObjectStackProtocolImplementation(unreadableEngine(() => cause));
+
+        const caught = await captureThrow(() => p.getMetaItems({ type: 'object' } as any));
+
+        expect(caught.status).toBe(503);
+        expect(caught.code).toBe('SERVICE_UNAVAILABLE');
+        expect(caught.message).toBe(STORE_UNAVAILABLE_MESSAGE);
+        expect(caught.cause).toBe(cause);
+    });
+
+    it('NEGATIVE PIN — the underlying failure text appears in no field outside the door', async () => {
+        const p = new ObjectStackProtocolImplementation(unreadableEngine(driverFault));
+        const caught = await captureThrow(() => p.getMetaItems({ type: 'object' } as any));
+
+        const seen = outsideTheDoor(caught);
+        // The scanner is proven alive by §2.0 on both a message field and a
+        // non-message field, so this zero is a measurement rather than a
+        // dead scan.
+        expect(seen).not.toContain(DRIVER_SENTINEL);
+        expect(seen).not.toContain('ECONNREFUSED');
+        expect(seen).not.toContain('10.0.0.5');
+        // The declined fallback, pinned: nothing forwards a mark across this
+        // door — the 503 does not even own the property.
+        expect(Object.prototype.hasOwnProperty.call(caught, 'userMessage')).toBe(false);
+        expect(declaredUserMessage(caught)).toBeUndefined();
+    });
+
+    it('POSITIVE CONTROL — the same scan over the MARKED refusal does find its text', async () => {
+        const p = new ObjectStackProtocolImplementation(unreadableEngine(() => markedRefusal()));
+        const caught = await captureThrow(() => p.getMetaItems({ type: 'object' } as any));
+
+        const seen = outsideTheDoor(caught);
+        expect(seen).toContain(MARK_SENTINEL);
+        // …and the marked refusal takes nothing ELSE from its cause: the
+        // sandbox wrapper's own debug sentence carries `DIAG_SENTINEL`, and
+        // that stays on `cause` for the operator.
+        expect(seen).not.toContain(DIAG_SENTINEL);
+    });
+
+    it('the two conversations are now distinguishable, which they were not before', async () => {
+        const marked = new ObjectStackProtocolImplementation(unreadableEngine(() => markedRefusal()));
+        const fault = new ObjectStackProtocolImplementation(unreadableEngine(driverFault));
+
+        const a = await captureThrow(() => marked.getMetaItems({ type: 'object' } as any));
+        const b = await captureThrow(() => fault.getMetaItems({ type: 'object' } as any));
+
+        expect(a.status).not.toBe(b.status);
+        expect(a.code).not.toBe(b.code);
+        expect(a.message).not.toBe(b.message);
+        expect(declaredUserMessage(a) !== undefined).toBe(true);
+        expect(declaredUserMessage(b) !== undefined).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The per-item path of the uninstall follows the same classification
+// ---------------------------------------------------------------------------
+
+describe('[#12536 §3] `deletePackage` reports a marked refusal as a refusal on the row', () => {
+    it('carries the mark onto `failed[]`, where no HTTP boundary could put it', async () => {
+        const p = new ObjectStackProtocolImplementation(uninstallEngine(() => markedRefusal())) as any;
+
+        const res = await p.deletePackage({ packageId: 'com.acme.crm', allTenants: true });
+
+        expect(res.failedCount).toBe(1);
+        expect(declaredUserMessage(res.failed[0])).toBe(AUTHOR_TEXT);
+        // `failed[]` rides inside a PACKAGE_DELETE_PARTIAL 400's `details`, so
+        // the channel has to be on the ROW — there is no envelope to carry it.
+        expect(res.failed[0].userMessage).toBe(AUTHOR_TEXT);
+    });
+
+    it('leaves the row unmarked — and unleaked — for a genuine driver fault', async () => {
+        const p = new ObjectStackProtocolImplementation(uninstallEngine(driverFault)) as any;
+
+        const res = await p.deletePackage({ packageId: 'com.acme.crm', allTenants: true });
+
+        expect(res.failedCount).toBe(1);
+        expect(res.failed[0].userMessage).toBeUndefined();
+        // NEGATIVE PIN over the whole response — with the positive control in
+        // the case above proving the same JSON scan does surface a mark.
+        expect(JSON.stringify(res)).not.toContain(DRIVER_SENTINEL);
+        expect(JSON.stringify(res)).not.toContain('ECONNREFUSED');
+    });
+
+    it('classifies the uninstall\'s own overlay READ the same way', async () => {
+        const marked = new ObjectStackProtocolImplementation(unreadableEngine(() => markedRefusal())) as any;
+        const caughtMarked = await captureThrow(
+            () => marked.deletePackage({ packageId: 'com.acme.crm', allTenants: true }));
+        expect(declaredUserMessage(caughtMarked)).toBe(AUTHOR_TEXT);
+        expect(caughtMarked.status).not.toBe(503);
+
+        const fault = new ObjectStackProtocolImplementation(unreadableEngine(driverFault)) as any;
+        const caughtFault = await captureThrow(
+            () => fault.deletePackage({ packageId: 'com.acme.crm', allTenants: true }));
+        expect(caughtFault.status).toBe(503);
+        expect(caughtFault.message).toBe(STORE_UNAVAILABLE_MESSAGE);
+        expect(outsideTheDoor(caughtFault)).not.toContain(DRIVER_SENTINEL);
+    });
+
+    it('carries the mark onto `cleanups[]` too, beside whatever #8136 licenses in `error`', async () => {
+        const p = new ObjectStackProtocolImplementation(uninstallEngine(driverFault)) as any;
+        p.registerUninstallCleanup('marked-cleanup', async () => { throw markedRefusal({ status: 403 }); });
+        p.registerUninstallCleanup('faulting-cleanup', async () => { throw driverFault(); });
+
+        const res = await p.deletePackage({ packageId: 'com.acme.crm', allTenants: true });
+
+        const marked = res.cleanups.find((c: any) => c.name === 'marked-cleanup');
+        const faulting = res.cleanups.find((c: any) => c.name === 'faulting-cleanup');
+        expect(declaredUserMessage(marked)).toBe(AUTHOR_TEXT);
+        expect(faulting.userMessage).toBeUndefined();
+        // The withhold rule on `error` is untouched: an undeclared fault still
+        // gets the stable fallback, never the driver's sentence.
+        expect(faulting.error).toBe('cleanup failed');
+        expect(JSON.stringify(res.cleanups)).not.toContain(DRIVER_SENTINEL);
+        expect(JSON.stringify(res.cleanups)).toContain(MARK_SENTINEL);
+        // MEASURED, and left standing rather than reconciled: the marked
+        // cleanup ALSO declared 403, and #8136's existing rule quotes a
+        // 4xx-declaring producer's own sentence into `error`. So its diagnostic
+        // travels here — by that older rule, not by this card's change, which
+        // adds only the `userMessage` member. Recorded so a future reader does
+        // not mistake it for a leak this classification opened.
+        expect(marked.error).toContain(DIAG_SENTINEL);
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -4,7 +4,7 @@ import type {
     DataProtocol, MetadataProtocol, PackageProtocol,
 } from '@objectstack/spec/api';
 import { IDataEngine, engineCanRollBack, recordNotFoundError } from '@objectstack/core';
-import { readEnvWithDeprecation, resolveTenancyPosture, resolveThrownHttpError } from '@objectstack/types';
+import { declaredUserMessage, readEnvWithDeprecation, resolveTenancyPosture, resolveThrownHttpError } from '@objectstack/types';
 // [#6285] ADR-0105 D1's authority on "does this deployment wall organizations?".
 // `resolveMultiOrgEnabled()` is DEMOTED and its own doc comment says answering
 // this question with it is a bug (cloud#1020, #5233) — so the posture, and only
@@ -2260,6 +2260,124 @@ function metadataStoreUnavailableError(cause: unknown): Error {
 }
 
 /**
+ * [#12536] The producer-side CLASSIFICATION every `sys_metadata` read failure
+ * now passes through — the one door, so that "is this a store fault or an
+ * application refusal?" is answered once instead of per call site.
+ *
+ * ## The defect it closes
+ *
+ * A metadata app's sandboxed hook on `sys_metadata` may REFUSE a read and mark
+ * its refusal with `userMessage` — the #9934 producer-side opt-in, where the
+ * field's PRESENCE is the marking (maintainer ruling, 2026-08-19, objectui#5210
+ * option 1). Every such refusal used to be handed straight to {@link
+ * metadataStoreUnavailableError}, which builds a FRESH error carrying only
+ * `code` / `status` / `cause`. `declaredUserMessage` reads the TOP level and
+ * never `cause`, so the mark died at the producer: measured on `origin/main`,
+ * a marked `beforeFind` refusal and a `connect ECONNREFUSED` came out of
+ * `getMetaItems` as the same `503 SERVICE_UNAVAILABLE` with the same sentence
+ * and `declaredUserMessage === undefined` on both. A hook author's localized
+ * refusal could not reach an end user through this limb at all, and the
+ * console substituted its #3821 generic string.
+ *
+ * ## The ruling this implements
+ *
+ * Maintainer, 2026-08-27 (verbatim: 「同意」), option B: a producer-marked
+ * application refusal must NOT be wrapped as a store-unavailable error in the
+ * first place. It travels its OWN refusal category with the author's text
+ * intact; a genuine store fault keeps #8136's deliberately non-quoting 503,
+ * untouched. Both prior rulings stand — they stop colliding here.
+ *
+ * ⛔ The declined shortcut, recorded so nobody re-implements it: forwarding the
+ * mark ACROSS the 503 (a `cause` fall-through in `declaredUserMessage`, or a
+ * `userMessage` copied onto the store-unavailable error). That would open a
+ * quoting exception in the one door #8136 built to quote nothing, and the
+ * typical failure of that shape is passing the whole cause chain through —
+ * a silent leak. Nothing from `cause` crosses the 503 door: this function
+ * either builds the refusal INSTEAD of the 503, or leaves the 503 exactly as
+ * it was.
+ */
+function metadataReadFailureError(cause: unknown): Error {
+    // {@link declaredUserMessage} is THE read — "never with an inline `typeof`
+    // probe" is that function's own instruction, and it is why a blank or
+    // non-string `userMessage` is not a declaration here either.
+    const marked = declaredUserMessage(cause);
+    if (marked !== undefined) return markedApplicationRefusalError(cause, marked);
+    return metadataStoreUnavailableError(cause);
+}
+
+/**
+ * [#12536] The refusal category a producer-MARKED failure travels in, built so
+ * the author's text survives verbatim and nothing else from the cause does.
+ *
+ * ## What is quoted, and what is not
+ *
+ * `message` is the marked text itself. That is the one string the producer
+ * declared is addressed to the end user (#9934), so quoting it discloses
+ * nothing that was not authored for a caller — and it is the ONLY thing taken
+ * from the cause. The cause's own `message` is a diagnostic and is NOT read:
+ * it rides on `cause`, which `handleRouteError` / `logWithheldServerFault`
+ * print whole for the operator, the same posture {@link
+ * metadataStoreUnavailableError} takes.
+ *
+ * ## Status and code are RESOLVED, never re-spelled
+ *
+ * `resolveThrownHttpError` is imported for both, for the reason {@link
+ * clientFacingRowFailureText} gives: a fourth local spelling of "what did this
+ * throw declare?" is how two seams start disagreeing about one error. It folds
+ * `status`, `statusCode` and the validation shape into one status, and gives
+ * the code rule this file already applies elsewhere — a catalogued `.code`
+ * passes through, anything else demotes to the status-derived standard code,
+ * so `ApiErrorSchema`'s closed union (ADR-0112 D4) can never receive a
+ * driver's dialect.
+ *
+ * The fallback status is 400, and it is NOT invented here: it is what the REST
+ * sandbox door already answers for a hook refusal that named no status of its
+ * own (`error-response.ts`, #9967 — `declared ?? 400`, pinned by
+ * `hook-error-format.dogfood.test.ts`). A hook that DID name one keeps it
+ * (#7867: "an error that NAMES its own HTTP status is asking to be served with
+ * it"), which is also why this is status-agnostic in the way the `userMessage`
+ * contract requires — a 400, 403, 409 or 503 refusal may all carry the mark.
+ */
+function markedApplicationRefusalError(cause: unknown, userMessage: string): Error {
+    const { status, code } = resolveThrownHttpError(cause, MARKED_REFUSAL_UNDECLARED_STATUS);
+    const err = new Error(userMessage) as Error & {
+        code?: string;
+        status?: number;
+        userMessage?: string;
+        cause?: unknown;
+    };
+    err.code = code;
+    err.status = status;
+    err.userMessage = userMessage;
+    err.cause = cause;
+    return err;
+}
+
+/**
+ * [#12536] The status a marked refusal takes when its producer named none —
+ * the REST sandbox door's own `declared ?? 400` (#9967), reused rather than
+ * chosen again, so the metadata read door and the hook door classify one
+ * undeclared hook refusal identically.
+ */
+const MARKED_REFUSAL_UNDECLARED_STATUS = 400;
+
+/**
+ * [#12536] Carry a producer's `userMessage` mark onto an error this file is
+ * re-wrapping — the exact sibling of {@link carryCatalogedErrorCode}, one
+ * field over.
+ *
+ * A re-wrap that drops the mark destroys the #9934 channel just as completely
+ * as building a fresh error does, and for the same reason: `declaredUserMessage`
+ * reads the TOP level, never `cause`. Copying only the marked field quotes
+ * nothing else — the cause's diagnostic `message` stays governed by whichever
+ * withhold rule that exit already applies (#8136), unchanged.
+ */
+function carryDeclaredUserMessage(target: Error, source: unknown): void {
+    const marked = declaredUserMessage(source);
+    if (marked !== undefined) (target as Error & { userMessage?: string }).userMessage = marked;
+}
+
+/**
  * [#5532] The terminal "this metadata item does not exist" — structured, so it
  * stops falling out of `mapDataError`'s catch-all.
  *
@@ -3489,6 +3607,15 @@ export interface UninstallCleanupOutcome {
     success: boolean;
     removed: number;
     error?: string;
+    /**
+     * [#12536] The user-facing refusal text the failing cleanup MARKED with
+     * `userMessage` (#9934) — absent unless it declared one. This outcome is
+     * response DATA riding inside a `PACKAGE_DELETE_PARTIAL` 400's `details`,
+     * so no HTTP boundary reads a `userMessage` on its behalf; the channel has
+     * to exist here or the mark has nowhere to go. Read it with
+     * `declaredUserMessage`, never by probing the field.
+     */
+    userMessage?: string;
 }
 
 /**
@@ -3548,7 +3675,13 @@ export interface DeletePackageResponse {
     deletedCount: number;
     failedCount: number;
     deleted: Array<{ type: string; name: string; state: string }>;
-    failed: Array<{ type: string; name: string; error: string; code?: string }>;
+    /**
+     * Per-item failures. [#12536] `userMessage` is the #9934 mark the item's
+     * own failure declared — present exactly when a producer marked its
+     * refusal, so a caller can tell an application refusal apart from a store
+     * failure on a path where no HTTP boundary can do it for them.
+     */
+    failed: Array<{ type: string; name: string; error: string; code?: string; userMessage?: string }>;
     cleanups: UninstallCleanupOutcome[];
 }
 
@@ -5636,8 +5769,23 @@ export class ObjectStackProtocolImplementation implements
      * silently mis-answers "does this exist?" while a false "real" costs one
      * 503 the caller can retry.
      *
+     * ## [#12536] Not benign is not the same as "the store is down"
+     *
+     * A non-benign failure is classified once more before it is wrapped, by
+     * {@link metadataReadFailureError}: a metadata app's hook may have REFUSED
+     * this read and marked its refusal with `userMessage` (#9934), and that is
+     * an application refusal, not a dependency outage. Handing it to the 503
+     * below destroyed the mark at the producer — the two failures left this
+     * guard as the same envelope with the same sentence. The classification
+     * splits them; neither category's wording changes.
+     *
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): the
+     *         author's text verbatim, in its own refusal category, with the
+     *         cause still carried for the operator and nothing else quoted.
      * @throws {@link metadataStoreUnavailableError} — a 503 carrying the driver
-     *         error as `cause`. Not the driver error itself: unwrapped, it has
+     *         error as `cause`, for every UNMARKED non-benign failure. Not the
+     *         driver error itself: unwrapped, it has
      *         no status, so the REST boundary would have to guess from the
      *         message text — and `mapDataError` guesses `no such table` into
      *         `404 OBJECT_NOT_FOUND`, i.e. straight back into a miss.
@@ -5646,7 +5794,10 @@ export class ObjectStackProtocolImplementation implements
      */
     private rethrowUnlessMetadataStoreUnprovisioned(error: unknown): void {
         if (isMissingTableError(error)) return;
-        throw metadataStoreUnavailableError(error);
+        // [#12536] CLASSIFY, do not assume. A read can fail because the store
+        // is unreachable OR because a metadata app's hook refused it in its
+        // own words — see {@link metadataReadFailureError}.
+        throw metadataReadFailureError(error);
     }
 
     /**
@@ -6831,6 +6982,11 @@ export class ObjectStackProtocolImplementation implements
      * `code: null` — the same unfounded assertion, one column to the left, and
      * the one the lock/affordance flags are derived from.
      *
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): an
+     *         application refusal in the author's own words, classified at the
+     *         producer and NOT the 503 below. See {@link
+     *         metadataReadFailureError}.
      * @throws {@link metadataStoreUnavailableError} — 503 /
      *         `SERVICE_UNAVAILABLE` when a read that would decide a layer did
      *         not happen: the `sys_metadata` overlay read failing for any
@@ -7135,6 +7291,11 @@ export class ObjectStackProtocolImplementation implements
      * on those terms (ADR-0110 D3). The unqualified `catch` that used to report
      * all of them as an empty trail is what this closes.
      *
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): an
+     *         application refusal in the author's own words, classified at the
+     *         producer and NOT the 503 below. See {@link
+     *         metadataReadFailureError}.
      * @throws {@link metadataStoreUnavailableError} — a 503 carrying the driver
      *         error as `cause`, for every read failure that is not an
      *         unprovisioned table. The `/audit` route's existing
@@ -11725,6 +11886,11 @@ export class ObjectStackProtocolImplementation implements
      * method THROWS (#5706) rather than answering "unlocked" — see the
      * `catch` below and {@link rethrowUnlessMetadataStoreUnprovisioned}.
      *
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): an
+     *         application refusal in the author's own words, classified at the
+     *         producer and NOT the 503 below. See {@link
+     *         metadataReadFailureError}.
      * @throws {@link metadataStoreUnavailableError} — 503 /
      *         `SERVICE_UNAVAILABLE`, when the lock state could not be
      *         determined. The one non-throwing failure is an
@@ -16885,7 +17051,9 @@ export class ObjectStackProtocolImplementation implements
         try {
             rows = (await this.engine.find('sys_metadata', { where })) as any[];
         } catch (e) {
-            throw metadataStoreUnavailableError(e);
+            // [#12536] …through the classifier: a marked application refusal
+            // is not a store fault. See {@link metadataReadFailureError}.
+            throw metadataReadFailureError(e);
         }
 
         const dropStorage = request.keepData !== true;
@@ -16930,11 +17098,22 @@ export class ObjectStackProtocolImplementation implements
                 // producer that no longer needs it (Prime Directive #12), and
                 // it would blank the per-item refusals that make a partial
                 // uninstall actionable.
+                // [#12536] …and the per-item path follows the SAME
+                // classification the read seam now applies (maintainer ruling,
+                // 2026-08-27): a marked application refusal is reported as one,
+                // in the author's own words, rather than dissolving into a row
+                // that reads like a store failure. `failed[]` had no channel
+                // for the mark at all — `error` is the diagnostic sentence and
+                // `code` is the closed vocabulary — so `userMessage` is the
+                // member that carries it, absent (never `''`) when the item's
+                // failure declared none, so nothing invents a marked refusal.
+                const itemUserMessage = declaredUserMessage(e);
                 failed.push({
                     type: row.type,
                     name: row.name,
                     error: e?.message ?? 'delete failed',
                     ...(e?.code ? { code: e.code } : {}),
+                    ...(itemUserMessage !== undefined ? { userMessage: itemUserMessage } : {}),
                 });
             }
         }
@@ -16996,11 +17175,18 @@ export class ObjectStackProtocolImplementation implements
                 // verbatim — and this outcome rides on the RESPONSE by design,
                 // inside `details`, where no boundary's message withhold can
                 // reach it. Quoted only when the cleanup declared a refusal.
+                // [#12536] The mark travels beside the withheld sentence, not
+                // instead of it: `error` stays whatever #8136's rule licenses,
+                // and a cleanup that refused in the author's own words is still
+                // reported as a refusal rather than as one that merely
+                // "failed".
+                const cleanupUserMessage = declaredUserMessage(e);
                 cleanups.push({
                     name,
                     success: false,
                     removed: 0,
                     error: clientFacingFailureText(e, 'cleanup failed'),
+                    ...(cleanupUserMessage !== undefined ? { userMessage: cleanupUserMessage } : {}),
                 });
                 console.warn(
                     `[protocol.deletePackage] uninstall cleanup '${name}' failed for '${request.packageId}': ${e?.message}`,
@@ -17646,6 +17832,11 @@ export class ObjectStackProtocolImplementation implements
      * `SysMetadataRepository` (#4867) ask, so a driver quirk is taught to the
      * platform once rather than re-spelled per seam.
      *
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): an
+     *         application refusal in the author's own words, classified at the
+     *         producer and NOT the 503 below. See {@link
+     *         metadataReadFailureError}.
      * @throws {@link metadataStoreUnavailableError} — a 503 carrying the driver
      *         error as `cause`, for every failure that is not an unprovisioned
      *         table.
@@ -18570,6 +18761,11 @@ export class ObjectStackProtocolImplementation implements
      *         of a type the platform DECLARES (`viewes`). Narrow by
      *         construction: a name that reaches for no declared type is a
      *         possible plugin kind and is served, not refused (#7894).
+     * @throws {@link markedApplicationRefusalError} — [#12536] FIRST, when the
+     *         failure carried a producer's `userMessage` mark (#9934): an
+     *         application refusal in the author's own words, classified at the
+     *         producer and NOT the 503 below. See {@link
+     *         metadataReadFailureError}.
      * @throws {@link metadataStoreUnavailableError} — 503 /
      *         `SERVICE_UNAVAILABLE` (#8833), when the `sys_metadata_history`
      *         read failed for any reason other than the table not being
@@ -19133,6 +19329,13 @@ export class ObjectStackProtocolImplementation implements
                 // its `status` made it out. See {@link carryCatalogedErrorCode}
                 // for why an unconditional copy is the wrong shape here.
                 carryCatalogedErrorCode(e, err);
+                // [#12536] …and the same for the #9934 mark. A hook that
+                // refused this delete in its own words wrote that text for the
+                // END USER; dropping it here destroys the channel exactly the
+                // way the store-unavailable wrapper used to, one exit over.
+                // Only the marked field is copied — the sentence selection
+                // above stays #8136's, unchanged.
+                carryDeclaredUserMessage(e, err);
                 throw e;
             }
         }
@@ -19234,6 +19437,10 @@ export class ObjectStackProtocolImplementation implements
             // stays as it is, for the reason {@link carryCatalogedErrorCode}
             // gives.
             carryCatalogedErrorCode(e, err);
+            // [#12536] The second exit gets the mark carry too, for the reason
+            // the `code` carry gives: the envelope must not vary by which path
+            // served the delete.
+            carryDeclaredUserMessage(e, err);
             throw e;
         }
     }

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -682,6 +682,16 @@
       "pinned": 1
     },
     {
+      "file": "packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts",
+      "verb": "findOne",
+      "pinned": 2
+    },
+    {
       "file": "packages/metadata-protocol/src/protocol.meta-list-runtime-baseline-dedup.test.ts",
       "verb": "findOne",
       "pinned": 1


### PR DESCRIPTION
Fixes #12536

Implements the maintainer's 2026-08-27 ruling (option B, verbatim 「同意」): a
producer-marked application refusal must **not** be wrapped as a store-unavailable
error at all. The wrapper classifies at the producer — a marked refusal travels its
own refusal category with the author's text intact, and a genuine store fault keeps
#8136's deliberately non-quoting 503. Both prior rulings stand; they stop colliding
at this seam.

⛔ The declined fallback — forwarding the mark **across** the 503 — is not
implemented, and is pinned against. Nothing from `cause` crosses that door.

## Reproduced first, driving real code (not read off the source)

Measured on the branch point `aef1b7e64`, through the real
`ObjectStackProtocolImplementation` over an engine whose `sys_metadata` read rejects
with a hook refusal carrying `userMessage` (the #9934 authoring shape):

```
getMetaItems / MARKED hook refusal
  -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
     message="The metadata store could not be read, so whether this item exists is unknown. ..."
getMetaItem  / MARKED hook refusal
  -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
     message="The metadata store could not be read, ..."
getMetaItems / driver fault (connect ECONNREFUSED 10.0.0.5:5432)
  -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
     message="The metadata store could not be read, ..."          <- byte-identical
deletePackage / MARKED refusal on the per-item delete
  -> failed[0] = { type, name, error: "Failed to delete customization overlay for
     object/acct. The metadata store rejected the delete; ..." }   <- no channel at all
```

The author's text existed only on `cause`, which `declaredUserMessage` never reads.

The same harness after the change:

```
getMetaItems / MARKED hook refusal
  -> status=400 code=VALIDATION_ERROR
     declaredUserMessage="Your Acme trial plan does not include custom objects. ..."
     message=[the same author text]   cause=[the hook's own error, intact]
getMetaItems / driver fault
  -> status=503 code=SERVICE_UNAVAILABLE declaredUserMessage=undefined
     message="The metadata store could not be read, ..."          <- unchanged
deletePackage / MARKED refusal
  -> failed[0] = { type, name, error: [#8136's sentence, unchanged],
                   userMessage: "Your Acme trial plan does not ..." }
```

## What changed

**`metadataReadFailureError(cause)`** — one classifying door in front of the wrapper.
A mark present (read through `declaredUserMessage`, never an inline probe) builds the
refusal; anything else goes to `metadataStoreUnavailableError`, which is **untouched,
byte for byte**. Routed at both throw sites the card names: the read guard
`rethrowUnlessMetadataStoreUnprovisioned` (the whole `getMetaItem` / `getMetaItems` /
lock / history / audit family) and `deletePackage`'s own overlay read.

**`markedApplicationRefusalError(cause, userMessage)`** — the refusal category. The
marked text is the message; it is the *only* thing taken from the cause, because it is
the one string the producer declared is addressed to the end user. Status and code are
resolved through the imported `resolveThrownHttpError`, never re-spelled — a hook that
names its own `status`/`statusCode` keeps it (#7867), one that names none is answered
`400`, which is `error-response.ts`'s own `declared ?? 400` for an undeclared sandbox
hook refusal (#9967) rather than a number chosen here, and an uncatalogued `code`
demotes so `ApiErrorSchema`'s closed union (ADR-0112 D4) cannot receive a driver's
dialect.

**The per-item path.** `DeletePackageResponse.failed[]` and `UninstallCleanupOutcome`
gain an optional `userMessage`, populated from the item's own failure. Those rows ride
inside a `PACKAGE_DELETE_PARTIAL` 400's `details`, where no HTTP boundary can carry a
`userMessage` on their behalf, so the channel has to exist on the row.

**Named explicitly rather than slipped in — `carryDeclaredUserMessage` on
`deleteMetaItem`'s two re-wrap exits.** A re-wrap that drops the mark destroys the
channel exactly as completely as building a fresh error does, and those two exits sit
*on* the ruled per-item path: without the carry, the `failed[]` channel above is
reachable only from the lock read and is dead for the actual delete — which is where a
`sys_metadata` hook refusal lands. It is one line each, the exact sibling of the
`carryCatalogedErrorCode` those exits already call, and it copies **only** the marked
field: the sentence selection, status and code at both exits stay #8136's, unchanged.
Evidence that the scope is bounded: `overlayDeleteFailureMessage` is not touched, and
§3's driver-fault case pins that an unmarked failure's row is byte-identical.

## The falsifiable criterion, both halves

`packages/metadata-protocol/src/protocol.marked-refusal-classification.test.ts` (+17 tests).

- **Marked half** — the author's text arrives verbatim as `declaredUserMessage`, on
  `getMetaItems`, `getMetaItem`, the draft read, `deletePackage`'s read, `failed[]` and
  `cleanups[]`.
- **Fault half — an explicit NEGATIVE PIN**: the underlying failure text appears in **no**
  field outside the door. The scan walks every own property of the thrown error (plus
  `message` / `name` / `stack`) *and* the `resolveThrownHttpError` projection a boundary
  actually ships, with `cause` excluded on purpose — that is the operator channel.
  It also pins that the 503 does not so much as own a `userMessage` property.
- **Positive control for that zero**, and it is not a substring of the term under test:
  three disjoint sentinels (driver text, author mark, hook diagnostic) with a pairwise
  non-containment guard that throws at load; the same scanner is proven to find a
  sentinel carried on a **non-message** field, and to find the mark on the marked
  refusal. Without that, "outside the door is clean" could be a dead scan.

**Reverse verification** — ablation restoring `protocol.ts` from the branch point,
mutation confirmed on disk by blob hash + anchored counts, restored with
`git checkout HEAD --` on an absolute path under a `trap`, proven by a matching blob
hash and an empty `git diff HEAD`. No rebuild is owed: the subject is imported by
relative path from inside its own package, and that is measured (the pre- and post-fix
runs of the same harness differ with no package build between them), not assumed.

Predicted §1 red / §3 marked red / §2 green throughout. **Measured 11 red, 6 green** —
and the prediction was wrong about §2's granularity: two of §2's cases speak about the
marked side and must go red. The two genuinely fault-only cases (the byte-for-byte
envelope and the negative pin) stayed green, and those two are the real over-reach
bound. Recorded in the file header as measured rather than tidied.

## Ruled sweep of the sibling wrappers — scanned, deliberately NOT fixed

Findings are filed by the PM, not absorbed here. Two shapes, over
`packages/metadata-protocol/src/**` non-test sources:

**Shape A — a wrapper that builds a new error around a caught one (sets `.cause`): 4
sites, 0 still mark-destroying after this PR.** `metadataStoreUnavailableError` is now
reached only for unmarked failures; the other three carry. Inspected and *not* findings
because they structurally cannot carry a #9934 mark: `throwMetadataServiceUnavailable`
(its cause is built from a `string[]`, there is no thrown object) and the four
`ConflictError` → `METADATA_CONFLICT` re-wraps (they wrap a repository-produced type,
not application code). The remaining ~61 `new Error` + status/code builders in the
package are the protocol's own originating refusals — no caught error, nothing to lose.

**Shape B — failure reported as response DATA, where no boundary can carry a
`userMessage`: 17 sinks, 2 carry the mark after this PR, 15 still drop it.** Same shape
as `failed[]`, in nine other methods:

| site | method |
|---|---|
| `protocol.ts:1698` | `toRowApiError` (batch row `message`) |
| `protocol.ts:14708`, `:14738`, `:14840` | `migrateStoredMetadata` (`reason`) |
| `protocol.ts:15575` | `runPublishSideEffects` |
| `protocol.ts:15683` | `applySeedBodies` |
| `protocol.ts:16599`, `:16611`, `:16747` | `publishPackageDrafts` |
| `protocol.ts:16884` | `discardPackageDrafts` |
| `protocol.ts:17452`, `:17466`, `:17543` | `duplicatePackage` |
| `protocol.ts:18385` | `revertCommit` |
| `protocol.ts:18523` | `rollbackToPackageCommit` |

## Verification

Run at `b68b09808`, the final commit.

- `pnpm --filter @objectstack/metadata-protocol test` — **143 passed | 2 skipped (145)
  files; 2001 passed | 10 skipped (2011) tests**. Branch-point baseline for the same
  package: 144 files / 1984 tests.
- Downstream **consumers** (`pnpm --filter '...@objectstack/metadata-protocol' typecheck`
  — the prefix form, i.e. the packages that depend on this one): **44 of 79 workspace
  projects in scope, green, 0 `error TS`.**
- `pnpm check:type-check-debt` — `--re-measure: OK — 31 ledger entr(ies) re-measured in
  412.0s, 1570 raw tsc error(s) total, none above its recorded number` ·
  `surplus: none — every entry sits exactly at its measurement, so any new error is red`.
  The new test file therefore added zero type errors, and this package's ledger note
  shows its measurement does read `*.test.ts`.
- `pnpm check:engine-double-contract` — green; the new doubles route through
  `assertEngineDeleteDispatch` / `assertEngineFindOnePredicate`, and the gate asked for
  the pinned ledger to learn about them by name (`--write`, **2 rows added or grown, 0
  lost** — purely additive, no baseline raised).
- Gate families re-derived from the **actual** diff with `scripts/pm/dispatch-gates.mjs`
  after the last edit; the ledger commit pulled in seven families no earlier derivation
  named (`agent-test-spelling`, `bash32-floor`, `cli-command-ids`, `entry-guard`,
  `parse-guard`, `pnpm-filter-targets`, `watch-hint-literal`). All 30 path-derived plus
  the convention-triggered families ran green.
- `scripts/pm/check-half-states.mjs` exits **3 = NOT MEASURED** (no GitHub credential in
  this container) — not a red, and no reading either way.
- Repo-wide `pnpm lint` was **not** run locally; CI owns that run. Declared narrowing,
  not a claim.

_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_