### PR TITLE
docs(core,service-cluster): retire the two docblocks left stale by IPubSub's corrected delivery guarantee (#12836)

### DIFF
--- a/.changeset/ipubsub-docblock-staleness-retire.md
+++ b/.changeset/ipubsub-docblock-staleness-retire.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/core": patch
+"@objectstack/service-cluster": patch
+---
+
+docs(core,service-cluster): retire the two docblocks left stale by `IPubSub`'s corrected delivery guarantee (#12836)
+
+#12651 corrected `IPubSub`'s contract docblock: delivery is whatever the
+configured driver declares, no shipped driver exceeds at-most-once, a missed
+message is EXPECTED, and handlers must be idempotent **and** tolerate loss.
+Two docblocks elsewhere still described the world before that correction.
+
+**`@objectstack/core` — `security/authz-invalidation-channel.ts`.** It carried a
+paragraph asserting, in the present tense, that the interface docblock "still
+says" *At-least-once delivery*, and that repairing it was a `packages/spec`
+change filed separately. That filing was #12651 and it has landed, so the
+paragraph is now false rather than merely stale — it sends the next reader
+looking for a live disagreement between the interface and the drivers that no
+longer exists. Replaced with a plain pointer to the interface docblock.
+Everything else in that docblock is unchanged: the at-most-once reasoning, the
+TTL-is-the-bound rule, and the best-effort-at-the-publish-site note all still
+hold.
+
+**`@objectstack/service-cluster` — `memory/pubsub.ts`.** The line "At-least-once
+semantics held vacuously (a single in-process delivery)" was wrong on its own
+terms even before #12651: the same docblock states that handler errors are
+swallowed and logged via `onError`, so a handler that throws loses the message
+with no retry and no persistence. That is not at-least-once in any sense, and
+"vacuously" does not save it. Replaced with the honest statement — one
+synchronous in-process delivery attempt per subscriber, no persistence, no
+retry, no replay.
+
+Prose only. No behaviour change, and no test changed.

--- a/packages/core/src/security/authz-invalidation-channel.ts
+++ b/packages/core/src/security/authz-invalidation-channel.ts
@@ -42,13 +42,12 @@
  * write that triggered it. A grant revocation must not fail because a cache
  * hint could not be delivered — the TTL already covers exactly that case.
  *
- * ⚠️ Known contradiction in the surrounding docs, recorded so nobody resolves it
- * the wrong way: `IPubSub`'s own interface docblock
- * (`@objectstack/spec/contracts`) still says *"At-least-once delivery"*, which
- * no shipped driver provides. `cluster.mdx` §4.2 and the redis driver are the
- * measured statements and are the ones this module follows. Repairing that
- * docblock is a `packages/spec` change and is filed separately, deliberately
- * not made here.
+ * `IPubSub`'s own interface docblock (`@objectstack/spec/contracts`) states the
+ * same thing from the contract side — delivery is whatever the configured
+ * driver declares, no shipped driver exceeds at-most-once, and handlers must be
+ * idempotent **and** tolerate loss. That docblock, `cluster.mdx` §4.2 and the
+ * redis driver agree; there is no disagreement here for a later reader to go
+ * looking for.
  *
  * ## Why a new channel on the existing bus, and not a new transport
  *

--- a/packages/services/service-cluster/src/memory/pubsub.ts
+++ b/packages/services/service-cluster/src/memory/pubsub.ts
@@ -15,7 +15,13 @@ import type {
  *   - Synchronous fan-out: every subscriber's handler is invoked in the
  *     same tick that `publish()` resolves. Handler errors are swallowed
  *     and logged via `onError` (so one bad subscriber can't poison the bus).
- *   - At-least-once semantics held vacuously (a single in-process delivery).
+ *   - Delivery is at-most-once: one synchronous in-process attempt per
+ *     subscriber, with no persistence, no retry and no replay. A handler that
+ *     throws loses that message outright — the error is swallowed above and
+ *     nothing redelivers it — and a publish to a channel nobody is subscribed
+ *     to at that moment is a silent no-op. This matches what `IPubSub`
+ *     documents: no shipped driver exceeds at-most-once, so handlers must be
+ *     idempotent **and** tolerate loss.
  *   - No cross-process delivery — use the redis/postgres/nats driver for
  *     real multi-node setups.
  */


### PR DESCRIPTION
Fixes #12836

#12651 (PR #12837) corrected `IPubSub`'s contract docblock: delivery is whatever the configured driver declares, no shipped driver exceeds at-most-once, a missed message is EXPECTED, handlers must be idempotent **and** tolerate loss, and `deliverySemantics` is the per-channel ask-not-get surface.

Two docblocks elsewhere still described the pre-#12651 world. This PR retires both. Prose only — no behaviour change, no test change.

## Site 1 — `packages/core/src/security/authz-invalidation-channel.ts`

The docblock carried a paragraph asserting, in the **present tense**, that the interface docblock "still says" *At-least-once delivery*, and that repairing it "is a `packages/spec` change and is filed separately, deliberately not made here."

That paragraph declared its own expiry condition, and the condition is now met: the separate filing was #12651, and it has landed. Leaving it is worse than never having written it — the next author goes looking for a live disagreement between the interface and the drivers, and finds none. Replaced with a plain pointer to the now-honest interface docblock.

Everything else in that docblock is unchanged, verbatim, because it is all still correct: the at-most-once reasoning with its three measured citations, the TTL-is-the-bound rule, and the best-effort-at-the-publish-site note ("a publish failure is logged and swallowed, never propagated into the write that triggered it").

## Site 2 — `packages/services/service-cluster/src/memory/pubsub.ts`

The line was:

```
 *   - At-least-once semantics held vacuously (a single in-process delivery).
```

⭐ **This line was wrong on its own terms even before #12651**, which is what makes the change more than a consequential edit. The *same docblock*, two bullets up, states that handler errors are "swallowed and logged via `onError` (so one bad subscriber can't poison the bus)". A handler that throws therefore loses the message outright: no retry, no persistence, no replay. That is not at-least-once in any sense — "vacuously" does not save it, because the single delivery attempt can itself fail and nothing redelivers.

Confirmed against the implementation in the same file, not only its prose:

- a synchronous `throw` goes to `this.onError(err, channel)` and is dropped;
- a rejected async handler goes to `.catch((err) => this.onError(err, channel))` and is dropped;
- `publish()` returns early when a channel has no subscriber bucket, so a publish nobody is subscribed to at that moment is a silent no-op.

Replaced with the honest statement: at-most-once, one synchronous in-process attempt per subscriber, no persistence, no retry, no replay.

## Blast radius — the nine other `At-least-once` sites are deliberately untouched

A repo-wide grep for `At-least-once` returned **eleven** hits before this change and **nine** after. The nine that remain are all different subjects, and two of them sit on governed surfaces:

| Site | Why excluded |
|---|---|
| `packages/triggers/trigger-api/src/api-trigger.ts` | ADR-0041 inbound API-trigger events — different subject, different transport |
| `docs/adr/0041-flow-trigger-family.md` | governed surface |
| `docs/adr/0119-plugin-reachable-transactions-and-honest-atomic-batch.md` | governed surface |
| `.changeset/ipubsub-delivery-guarantee-docblock.md` (2 hits) | #12651's own changeset, quoting the old text deliberately — rewriting it would falsify the release record |
| `content/docs/automation/webhooks.mdx` | webhook receivers — different subject, and the claim there is true |
| `packages/objectql/src/engine.ts` | at-least-once hook semantics — different subject |
| `packages/services/service-messaging/src/dispatcher.ts` | messaging outbox — different subject, and true |
| `packages/services/service-messaging/src/http-dispatcher.ts` | same, HTTP leg |

## Verification

Every run below is on `e50b1d2dd`, this PR's head commit, with a clean working tree.

**Prose-only, proven rather than asserted.** Both changed source files were compiled at the merge base and at head with `removeComments: true`, and the emitted output compared byte for byte:

```
IDENTICAL  comment-stripped emit  packages/core/src/security/authz-invalidation-channel.ts
IDENTICAL  comment-stripped emit  packages/services/service-cluster/src/memory/pubsub.ts
PROSE-ONLY PROVEN: comment-stripped emit is byte-identical for every changed source file.
```

There is **no ablation leg in this PR, deliberately.** This is a comment-only change: no pin can be made to go red by mutating prose, so an ablation here would be fabricated rather than measured.

**Tests** — both affected packages, green:

- `pnpm --filter @objectstack/core test` — `Test Files 41 passed (41)`, `Tests 1015 passed (1015)`
- `pnpm --filter @objectstack/service-cluster test` — `Test Files 4 passed (4)`, `Tests 66 passed (66)`

**Lint** — repo-wide, not narrowed: `pnpm lint` (`eslint . --no-inline-config`) exits 0 with no findings, so no narrowing is claimed or owed.

**Gate families** — derived from the actual changed set by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which read the merge base itself (3 paths, commit `e50b1d2dd`, repo assertion held). All 21 named families are green, plus `check:nul-bytes`. Selected judgment lines, each as printed by the gate itself:

```
✓ affected-docs self-test: 457 cases pass.
✓ check-drift-comment: 56 cases pass across 5 fixture diff(s).
OK  check:comment-mask-adoption — 14 private comment-stripper(s) under packages/** + examples/**, all 14 recorded and every recorded row still reached
check-test-source-alias OK — 72 packages with tests scanned
check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger
```

**Typecheck.** Neither `@objectstack/core` nor `@objectstack/service-cluster` declares a `typecheck` script, so a filtered `run typecheck` would match nothing and exit 0 — not a measurement. Ran `npx tsc --noEmit -p tsconfig.json` from inside each package instead. Both exit 2, entirely on **pre-existing** diagnostics in test files these packages hide from tsc; both sit in the type-check DEBT ledger, and `check-type-check-coverage` is green on that ledger. The comment-stripped-emit proof above is what establishes this PR cannot have moved those counts.

**One gate NOT MEASURED — reported as such, not folded into the green list.** `node scripts/pm/check-half-states.mjs` (the live board sweep, whose standing caller is `half-state-patrol.yml`) exits **3**:

```
check-half-states: PREREQUISITE NOT MET — the token in the environment is not a valid GitHub credential
```

That is an environment classification, not a verdict on this PR, and `lint.yml` says so where it wires the gate: the live sweep's "non-zero exits classify the ENVIRONMENT — no token, exhausted quota, unreachable host — which is not a verdict about the PR running it." The form CI runs in the PR lane is the offline self-test, `pnpm check:pm-half-states`, which is **green** here.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194kbQJxUvv2yvsGRtuXpP5)_