### PR TITLE
fix(plugin-sharing): render the by-id write denial through the operation-message catalog

### DIFF
--- a/.changeset/sharing-write-denial-localized.md
+++ b/.changeset/sharing-write-denial-localized.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/plugin-sharing": minor
+---
+
+fix(plugin-sharing): the by-id write denial renders through the Operation
+Message Catalog instead of a hardcoded English sentence (#12260, the consumer
+half of the key #12493 landed)
+
+A user holding object-level allowRead + allowEdit — and no `modifyAllRecords` —
+PATCHed a record they do not own on an object declaring
+`sharingModel: 'public_read'` with `access: { default: 'private' }`. The sharing
+middleware refused, correctly, and the client showed the server's reason
+verbatim to the end user: one hardcoded English sentence naming the object's API
+name and the row's opaque id. In a fully Chinese deployment that was the only
+thing the user was told about why their save failed.
+
+The refusal now renders through the shared Operation Message Catalog in
+`@objectstack/spec/system` under the key `record_write_denied` that #12493
+landed for it — the same mechanism `plugin-security`'s record-level denial
+already uses, which is exactly the comparison the report drew: the same "I can
+see this record but cannot change it" situation showed human language or raw
+English depending on which layer refused. Same resolution ladder (deployment
+override → the caller's locale → `en` → the key), same guarantee that a
+misbehaving i18n service cannot turn a 403 into a 500. All four platform
+locales (`en`, `zh-CN`, `ja-JP`, `es-ES`) ship copy that sends the reader to the
+record's owner or an administrator instead of dead-ending them.
+
+`record_write_denied` is deliberately not `record_access_denied`: this gate
+fires on a row the READ path already admitted, so "You do not have access to
+this record" would be false the moment it rendered. It is one key for BOTH write
+verbs — the user's situation and remedy are identical for `update` and `delete`.
+
+`buildSharingMiddleware` gains an optional third argument, a lazily resolved
+`II18nService.t`-compatible lookup wired by `SharingServicePlugin`, because the
+i18n service is contributed by another plugin and may start later. It is what
+makes the override address the catalog documents,
+`errors.record_write_denied`, take effect for this emitter. The argument is
+additive: every existing caller passes two and is unchanged, and a stack with no
+i18n service still renders the built-in catalog in the caller's locale.
+
+**Not changed: who may write.** The gate is byte-identical — ownership, write
+depth, an edit-level share for `update`, Modify All Data — and the app-authored
+RLS deferral ahead of it is untouched. The `FORBIDDEN:` prefix the REST layer
+classifies 403 on is untouched, and so is the ADR-0111 D10 `delete`-verb
+diagnostic breadcrumb. The verb, object and row id the old sentence carried are
+now developer facts on the error's `developerMessage` and `details` and in the
+log, where a developer reads them and a user never does.

--- a/packages/plugins/plugin-sharing/src/authored-row-write-deferral.test.ts
+++ b/packages/plugins/plugin-sharing/src/authored-row-write-deferral.test.ts
@@ -11,6 +11,13 @@
 // middleware's, not the row-gate's `(row-level security)` — so the refusal
 // landed BEFORE RLS was consulted and the declared widener was never asked.
 //
+// [#12260] That English sentence is HISTORY as of this card: the refusal's
+// user-facing half now renders from the Operation Message Catalog
+// (`record_write_denied`) and the verb/object/id it used to name moved to
+// `developerMessage`. The tell is unchanged in substance — `[sharing] …` vs
+// the row gate's `(row-level security)` — only its channel moved. See
+// `write-denial-user-copy.test.ts`.
+//
 // The discriminator is not "carries sharing rules" (#5493's own wording) but
 // **whether record sharing enforces on the object at all** (round-2 refinement,
 // issue comment 5226364929): `checkEdit` abstains — and `canEdit` therefore
@@ -52,6 +59,7 @@
 // and that everything that is not a literal `admit` leaves the refusal intact.
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/objectql';
+import { BUILTIN_OPERATION_MESSAGES } from '@objectstack/spec/system';
 import { SharingService, type SharingSecurityProbe } from './sharing-service.js';
 import { buildSharingMiddleware } from './sharing-plugin.js';
 
@@ -311,6 +319,8 @@ interface WriteOutcome {
   code?: string;
   status?: number;
   message: string;
+  /** [#12260] The developer half the user-facing sentence no longer carries. */
+  developerMessage?: string;
 }
 
 interface Stack {
@@ -376,7 +386,10 @@ function makeStack(opts: {
           reached = true;
         });
       } catch (e: any) {
-        return { ok: false, code: e?.code, status: e?.status, message: String(e?.message ?? e) };
+        return {
+          ok: false, code: e?.code, status: e?.status,
+          message: String(e?.message ?? e), developerMessage: e?.developerMessage,
+        };
       }
       return reached
         ? { ok: true, message: 'written' }
@@ -405,7 +418,15 @@ function expectSharingRefusal(out: WriteOutcome, operation: 'update' | 'delete',
   expect(out.ok, `expected a refusal, got a completed ${operation}`).toBe(false);
   expect(out.code, 'ADR-0112 error code').toBe('FORBIDDEN');
   expect(out.status, 'ADR-0112 HTTP status').toBe(403);
-  expect(out.message).toContain(`FORBIDDEN: insufficient privileges to ${operation} ${object} ${id}`);
+  // [#12260] The SENTENCE moved onto the Operation Message Catalog (key
+  // `record_write_denied`), so the discriminator this file turns on moved with
+  // it: the verb, the object's API name and the row id are now developer copy.
+  // Both halves are asserted, because both are how this refusal is told apart
+  // from `plugin-security`'s row gate — which answers `PERMISSION_DENIED` with
+  // its own `(row-level security)` breadcrumb and never writes `[sharing]`.
+  // The `FORBIDDEN:` prefix is wire contract and is unchanged.
+  expect(out.message).toBe(`FORBIDDEN: ${BUILTIN_OPERATION_MESSAGES.en.record_write_denied}`);
+  expect(out.developerMessage).toContain(`[sharing] ${operation} denied on ${object} ${id}`);
 }
 
 const rowById = (stack: Stack, object: string, id: string) =>

--- a/packages/plugins/plugin-sharing/src/sharing-plugin.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-plugin.ts
@@ -22,6 +22,12 @@ import type { ExecutionContext } from '@objectstack/spec/kernel';
 // mark `plugin-security` and `service-analytics` stamp at theirs — never a
 // local flag, never a second spelling of the same idea.
 import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
+// [#12260] The SANCTIONED renderer for OPERATION-level refusal copy. The
+// Operation Message Catalog is the ONE seat for these sentences — its own
+// header bars both a package-local string table and a second rendering
+// mechanism for a second producer, and #12493 landed this middleware's key
+// (`record_write_denied`) into it ahead of this consumer half.
+import { renderOperationMessage, type ValidationMessageTranslator } from '@objectstack/spec/system';
 import { SysRecordShare, SysSharingRule, SysShareLink } from './objects/index.js';
 import { SysBusinessUnit, SysBusinessUnitMember } from '@objectstack/platform-objects/identity';
 import {
@@ -610,7 +616,7 @@ export class SharingServicePlugin implements Plugin {
       if (this.options.enforce === false) {
         ctx.logger.info('SharingServicePlugin: enforcement disabled (enforce=false) — share-link service still registered');
       } else {
-        const mw = buildSharingMiddleware(this.service, ctx.logger as any);
+        const mw = buildSharingMiddleware(this.service, ctx.logger as any, pluginMessageTranslator(ctx));
         if (typeof engine.registerMiddleware === 'function') {
           engine.registerMiddleware(mw, { object: '*' });
           ctx.logger.info('SharingServicePlugin: enforcement middleware installed');
@@ -955,6 +961,73 @@ export class SharingServicePlugin implements Plugin {
 }
 
 /**
+ * [#12260] The END USER's half of the by-id write refusal.
+ *
+ * This middleware's refusal declares `{ code: 'FORBIDDEN', status: 403 }`, so
+ * `@objectstack/rest` answers it through the DECLARED-status arm and ships
+ * `error.message` to the client as the body's human-readable `error` — which
+ * Console renders verbatim in a toast. One hardcoded English sentence
+ * therefore reached a business user in a fully Chinese deployment as the only
+ * thing they were told about why their save failed.
+ *
+ * Rendered through the SHARED Operation Message Catalog
+ * (`@objectstack/spec/system`), not a second mechanism: same `errors.<key>`
+ * override address, same resolution ladder (deployment override -> locale
+ * catalog -> `en` -> the key), same guarantee that a misbehaving i18n service
+ * cannot turn a 403 into a 500. `plugin-security`'s `userFacingDenialMessage`
+ * is the sibling consumer this mirrors, and `plugin-approvals`'
+ * `userFacingRefusal` (#11993) is the same conversion one card earlier.
+ *
+ * ⛔ ONE key for BOTH write verbs, which is the catalog's own ruling and not a
+ * shortcut taken here: the user's situation (they can see this record, they
+ * cannot change it) and their remedy (ask its owner, or an administrator) are
+ * identical for `update` and `delete`. WHICH verb was refused is a developer
+ * fact and stays on `developerMessage`, on the structured `details`, and — for
+ * `delete` — on the ADR-0111 D10 breadcrumb that keeps its own wording.
+ *
+ * The `FORBIDDEN:` prefix is NOT part of what this renders. It is wire
+ * contract (ADR-0111's `CODE: message` idiom, which the share routes read and
+ * strip) and it is applied by the caller around this sentence.
+ *
+ * The translator is resolved LAZILY, per refusal, for the reason ADR-0029 D8
+ * makes structural: the i18n service is contributed by a different plugin that
+ * may start after this one, so a lookup captured when the middleware was built
+ * would pin `undefined` for the life of the process. Absent is a SUPPORTED
+ * stack, not a degraded one — the built-in catalog still renders the caller's
+ * locale; what the translator adds is the documented override address
+ * `errors.record_write_denied`.
+ */
+function userFacingWriteDenial(
+  locale: string | undefined,
+  messageTranslator?: () => ValidationMessageTranslator | undefined,
+): string {
+  let translate: ValidationMessageTranslator | undefined;
+  try {
+    translate = messageTranslator?.();
+  } catch {
+    // i18n is optional and late-bound; the built-in catalog still renders the
+    // caller's locale without it.
+    translate = undefined;
+  }
+  return renderOperationMessage({ messageKey: 'record_write_denied' }, { locale, translate });
+}
+
+/**
+ * [#12260] The deployment i18n lookup this plugin hands its middleware, read
+ * through `PluginContext` on every refusal rather than captured at start().
+ * See {@link userFacingWriteDenial} for why late binding is the requirement
+ * and not a defensive habit.
+ */
+function pluginMessageTranslator(ctx: PluginContext): () => ValidationMessageTranslator | undefined {
+  return () => {
+    const i18n = ctx.getService<II18nService>('i18n');
+    const t = i18n?.t;
+    if (typeof t !== 'function') return undefined;
+    return (key: string, loc: string, params?: Record<string, unknown>) => t.call(i18n, key, loc, params);
+  };
+}
+
+/**
  * Build the engine middleware that injects read filters and gates
  * write operations. Exported so it can be unit-tested without booting
  * a kernel. `log` is optional — the [ADR-0111 D10] delete-denial breadcrumb
@@ -971,6 +1044,15 @@ export class SharingServicePlugin implements Plugin {
 export function buildSharingMiddleware(
   service: SharingService,
   log?: { warn?: (msg: string, meta?: any) => void },
+  /**
+   * [#12260] Deployment i18n lookup for the by-id write refusal's user-facing
+   * sentence — an `II18nService.t`-compatible function, resolved LAZILY per
+   * refusal. Optional and additive: every existing caller (six suites in
+   * `plugin-security`, two here) passes two arguments and is unchanged, and a
+   * stack without it still renders the caller's locale from the built-in
+   * catalog. See {@link userFacingWriteDenial}.
+   */
+  messageTranslator?: () => ValidationMessageTranslator | undefined,
 ): EngineMiddleware {
   return async function sharingMiddleware(ctx: OperationContext, next: () => Promise<void>) {
     const op = ctx.operation;
@@ -1116,11 +1198,36 @@ export function buildSharingMiddleware(
               { object: ctx.object, recordId: String(id), userId: exec?.userId },
             );
           }
+          // [#12260] The DEVELOPER's half — the verb, the object's API name and
+          // the row id. This USED TO BE the whole message, which is how it
+          // reached an end user's toast in English; the catalog sentence
+          // deliberately names none of it (the only spellings available here
+          // are an API name and an opaque id, the #7414 vocabulary that must
+          // not reach a toast). It is kept where a developer reads it and a
+          // user never does: on the error, and in the log line below. REST
+          // ships neither `developerMessage` nor `details` on a FORBIDDEN
+          // body — only `DELETE_RESTRICTED` forwards a `developerMessage` —
+          // so this adds nothing to the wire.
+          const developerMessage =
+            `[sharing] ${verb} denied on ${ctx.object} ${id}: the caller holds no ${verb} authority ` +
+            `over this row (owner match, share depth and Modify All Data all answered no)`;
+          log?.warn?.(developerMessage, {
+            object: ctx.object,
+            recordId: String(id),
+            operation: verb,
+            userId: exec?.userId,
+          });
+          // The `FORBIDDEN:` PREFIX STAYS. It is not user copy — it is the
+          // ADR-0111 `CODE: message` idiom the share routes read and strip,
+          // and it sits beside the `code`/`status` the `/data` door
+          // classifies on. Only the SENTENCE after it moved.
           const err: any = new Error(
-            `FORBIDDEN: insufficient privileges to ${op} ${ctx.object} ${id}`,
+            `FORBIDDEN: ${userFacingWriteDenial(exec?.locale, messageTranslator)}`,
           );
           err.code = 'FORBIDDEN';
           err.status = 403;
+          err.developerMessage = developerMessage;
+          err.details = { operation: verb, object: ctx.object, recordId: String(id) };
           throw err;
         }
         return next();

--- a/packages/plugins/plugin-sharing/src/write-denial-user-copy.test.ts
+++ b/packages/plugins/plugin-sharing/src/write-denial-user-copy.test.ts
@@ -1,0 +1,423 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The END USER's half of the sharing middleware's by-id WRITE refusal (#12260).
+ *
+ * The report, on `@objectstack/*@17.2.0`: an object declaring
+ * `sharingModel: 'public_read'` with `access: { default: 'private' }`; a user
+ * holding object-level allowRead + allowEdit and NO `modifyAllRecords`; a by-id
+ * PATCH against a record they do not own. The middleware refuses — correctly —
+ * and the client (an H5 / in-house front end) shows the server's `message`
+ * verbatim to the end user. That message was one hardcoded English sentence
+ * naming an API name and an opaque row id.
+ *
+ * The comparison the reporter drew is exact: `plugin-security`'s record-level
+ * denial already renders localized copy through the catalog
+ * (`userFacingDenialMessage`), so the SAME user situation — "I can't write this
+ * record" — showed human language or raw English depending on which layer
+ * refused.
+ *
+ * The refusal now renders through the shared Operation Message Catalog
+ * (`@objectstack/spec/system`, key `record_write_denied`, landed ahead of this
+ * consumer half by #12493) instead of a package-local string.
+ *
+ * ⚠️ These tests assert the SENTENCE A USER READS, in zh-CN specifically, as a
+ * LITERAL. Asserting only that a catalog key was passed — or comparing the
+ * render against the catalog it came from — would pass against a message that
+ * still renders in English, which is the entire reported defect.
+ *
+ * They also pin the three things the conversion must NOT move:
+ *   - the `FORBIDDEN:` code prefix. It is not user copy: it is the ADR-0111
+ *     `CODE: message` idiom the share routes read and strip, and it rides
+ *     beside the `code`/`status` the `/data` door classifies 403 on;
+ *   - the ADR-0111 D10 `delete`-verb diagnostic breadcrumb, which is a
+ *     developer-facing greppable reason for the D3 tightening and is
+ *     deliberately separate from user copy;
+ *   - WHO may write. The gate is byte-identical; only its sentence changed.
+ *
+ * ⭐ Why `record_write_denied` and not `record_access_denied`, quoted from the
+ * catalog's own header because it is the reason this key exists:
+ *
+ *   > the sharing middleware's by-id write gate fires on a row the READ path
+ *   > already admitted — the user is typically looking at the record it
+ *   > refuses — so "You do not have access to this record" would be false the
+ *   > moment it rendered. The situation is read-yes/write-no.
+ *
+ * The read-yes half is measured here too (§4), so the claim is a fact about
+ * this fixture rather than a quotation about it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BUILTIN_OPERATION_MESSAGES } from '@objectstack/spec/system';
+import {
+  assertEngineDeleteDispatch,
+  assertEngineUpdateDispatch,
+  assertEngineFindOnePredicate,
+} from '@objectstack/objectql';
+import { SharingService } from './sharing-service.js';
+import { buildSharingMiddleware } from './sharing-plugin.js';
+
+// ── the reported fixture ────────────────────────────────────────────────────
+
+/**
+ * The reporter's object, restated: `public_read` OWD (everyone reads, the owner
+ * writes) plus an `owner_id` column, so record sharing really enforces and
+ * `checkEdit` / `checkDelete` can answer `deny`.
+ *
+ * `access: { default: 'private' }` is carried for fidelity to the report; it is
+ * `plugin-security`'s object-CRUD axis and this middleware never reads it. The
+ * user's allowRead + allowEdit live on that same axis — they are what makes the
+ * READ succeed and the WRITE reach this gate at all.
+ */
+const INQUIRY_SCHEMA = {
+  name: 'os_inquiry',
+  sharingModel: 'public_read',
+  access: { default: 'private' },
+  fields: {
+    id: { name: 'id' },
+    subject: { name: 'subject' },
+    owner_id: { name: 'owner_id' },
+    created_by: { name: 'created_by' },
+    organization_id: { name: 'organization_id' },
+  },
+};
+
+const SCHEMAS: Record<string, any> = { os_inquiry: INQUIRY_SCHEMA };
+
+const U_OWNER = 'u_owner';
+/** The reporting deployment's user: allowRead + allowEdit, no modifyAllRecords. */
+const U_AGENT = 'u_agent';
+
+/** The row the report PATCHes: owned by someone else. */
+const INQUIRY_THEIRS = {
+  id: 'inq_theirs', subject: 'shipping delay',
+  owner_id: U_OWNER, created_by: U_OWNER, organization_id: 'org1',
+};
+/** The agent's own row — the positive control ownership must keep admitting. */
+const INQUIRY_MINE = {
+  id: 'inq_mine', subject: 'refund',
+  owner_id: U_AGENT, created_by: U_AGENT, organization_id: 'org1',
+};
+
+// ── in-memory engine ────────────────────────────────────────────────────────
+
+/**
+ * Both write verbs open with the PRODUCER's own dispatch predicate
+ * (#4550 / #5480), never a hand-mirrored guard: a double looser than the engine
+ * it replaces converts a green suite into no suite at all.
+ */
+function makeEngine() {
+  const tables: Record<string, any[]> = {
+    os_inquiry: [{ ...INQUIRY_THEIRS }, { ...INQUIRY_MINE }],
+    sys_record_share: [],
+  };
+  const matches = (row: any, filter: any): boolean => {
+    if (!filter || typeof filter !== 'object') return true;
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
+    for (const [k, v] of Object.entries(filter)) {
+      if (k === '$or' || k === '$and') continue;
+      if (v != null && typeof v === 'object' && '$in' in (v as any)) {
+        if (!(v as any).$in.includes(row[k])) return false;
+        continue;
+      }
+      if (row[k] !== v) return false;
+    }
+    return true;
+  };
+  return {
+    _tables: tables,
+    getSchema: (name: string) => SCHEMAS[name],
+    async find(object: string, options: any = {}) {
+      const rows = (tables[object] ??= []);
+      return rows.filter((r) => matches(r, options.filter ?? options.where)).slice(0, options.limit ?? 1000);
+    },
+    async findOne(object: string, options: any = {}) {
+      assertEngineFindOnePredicate(object, options);
+      const rows = await this.find(object, { ...options, limit: 1 });
+      return rows[0] ?? null;
+    },
+    async insert(object: string, data: any) {
+      (tables[object] ??= []).push({ ...data });
+      return data;
+    },
+    async update(object: string, data: any, options?: any) {
+      const dispatch = assertEngineUpdateDispatch(data, options);
+      const rows = (tables[object] ??= []);
+      const targets = dispatch.kind === 'by-id'
+        ? rows.filter((r) => r.id === dispatch.id)
+        : rows.filter((r) => matches(r, options?.where));
+      for (const r of targets) Object.assign(r, data);
+      return dispatch.kind === 'by-id' ? (targets[0] ?? null) : targets.length;
+    },
+    async delete(object: string, options?: any) {
+      const dispatch = assertEngineDeleteDispatch(options);
+      const rows = (tables[object] ??= []);
+      const targets = dispatch.kind === 'by-id'
+        ? rows.filter((r) => r.id === dispatch.id)
+        : rows.filter((r) => matches(r, options?.where));
+      tables[object] = rows.filter((r) => !targets.includes(r));
+      return dispatch.kind === 'by-id' ? targets.length > 0 : targets.length;
+    },
+  };
+}
+
+// ── the stack ───────────────────────────────────────────────────────────────
+
+interface WriteOutcome {
+  ok: boolean;
+  /** ADR-0112 envelope of the refusal — asserted, never a bare `toThrow()`. */
+  code?: string;
+  status?: number;
+  message: string;
+  developerMessage?: string;
+  details?: any;
+}
+
+function makeStack(messageTranslator?: () => any) {
+  const engine = makeEngine();
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const sharing = new SharingService({ engine: engine as any, logger });
+  const mw = buildSharingMiddleware(sharing, logger, messageTranslator) as any;
+
+  return {
+    engine,
+    logger,
+    rows: (object: string) => (engine._tables[object] ??= []),
+    /** Drive a by-id write through the middleware and report its ENVELOPE. */
+    async write(
+      operation: 'update' | 'delete',
+      recordId: string,
+      context: any,
+    ): Promise<WriteOutcome> {
+      const opCtx: any = {
+        object: 'os_inquiry',
+        operation,
+        context: { ...context },
+        ...(operation === 'update'
+          ? { data: { id: recordId, subject: 'edited' } }
+          : { options: { where: { id: recordId } } }),
+      };
+      let reached = false;
+      try {
+        await mw(opCtx, async () => {
+          if (operation === 'delete') await engine.delete(opCtx.object, opCtx.options);
+          else await engine.update(opCtx.object, opCtx.data, opCtx.options);
+          reached = true;
+        });
+      } catch (e: any) {
+        return {
+          ok: false,
+          code: e?.code,
+          status: e?.status,
+          message: String(e?.message ?? e),
+          developerMessage: e?.developerMessage,
+          details: e?.details,
+        };
+      }
+      return reached
+        ? { ok: true, message: 'written' }
+        : { ok: false, message: 'middleware swallowed the write' };
+    },
+    /** The READ half of read-yes/write-no, through the same middleware. */
+    async read(context: any) {
+      const opCtx: any = { object: 'os_inquiry', operation: 'find', context: { ...context }, ast: {} };
+      await mw(opCtx, async () => {});
+      return engine.find('os_inquiry', { filter: opCtx.ast?.where ?? opCtx.ast?.filter });
+    },
+  };
+}
+
+/** The execution-context shape `resolveAuthzContext` hands the middleware. */
+const ctxFor = (userId: string, locale?: string) => ({
+  userId, tenantId: 'org1', positions: ['org_member'], permissions: [],
+  ...(locale ? { locale } : {}),
+});
+
+/** The reporting deployment: Console and the H5 client both set zh-CN. */
+const AGENT_ZH = ctxFor(U_AGENT, 'zh-CN');
+const AGENT_EN = ctxFor(U_AGENT, 'en');
+const OWNER_ZH = ctxFor(U_OWNER, 'zh-CN');
+
+/**
+ * The zh-CN copy a user actually reads, pinned as a LITERAL rather than read
+ * back out of the catalog — a test that renders the catalog against itself
+ * cannot tell Chinese from English, which is the whole defect. Its twin lives
+ * in `packages/spec/src/system/operation-message.test.ts`; the two move
+ * together.
+ */
+const ZH_SENTENCE = '您无权修改或删除这条记录,如需修改请联系该记录的负责人或管理员。';
+
+/** The legacy hardcoded reason, kept as a literal so its ABSENCE is pinned. */
+const LEGACY_EN = 'insufficient privileges to';
+
+/** What the REST layer does with an ADR-0111 `CODE: message` throw. */
+const WIRE_CODE = (msg: string) => /^FORBIDDEN/.test(msg);
+const WIRE_ERROR = (msg: string) => msg.replace(/^[A-Z_]+:\s*/, '');
+
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('[#12260] the by-id write denial renders through the operation catalog', () => {
+  let stack: ReturnType<typeof makeStack>;
+  beforeEach(() => { stack = makeStack(); });
+
+  // ── §1 the reported symptom ──────────────────────────────────────────────
+
+  it('the report, reproduced: a zh-CN user PATCHing a row they do not own reads Chinese', async () => {
+    const out = await stack.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    expect(out.ok, 'the gate must still refuse — this card moves copy, not authority').toBe(false);
+    expect(out.message).toBe(`FORBIDDEN: ${ZH_SENTENCE}`);
+    // The half a client shows its end user carries no Latin prose. Before this
+    // conversion it was an entire English sentence naming an API name and a row id.
+    expect(WIRE_ERROR(out.message)).toBe(ZH_SENTENCE);
+    expect(WIRE_ERROR(out.message)).not.toMatch(/[A-Za-z]/);
+  });
+
+  it('the DELETE verb reads the same sentence — one key serves both write verbs', async () => {
+    const out = await stack.write('delete', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    expect(out.ok).toBe(false);
+    expect(out.message).toBe(`FORBIDDEN: ${ZH_SENTENCE}`);
+    expect(WIRE_ERROR(out.message)).not.toMatch(/[A-Za-z]/);
+    expect(stack.rows('os_inquiry').map((r) => r.id), 'the row survives').toContain(INQUIRY_THEIRS.id);
+  });
+
+  it('no longer emits the legacy hardcoded English reason, on either verb', async () => {
+    for (const verb of ['update', 'delete'] as const) {
+      const out = await stack.write(verb, INQUIRY_THEIRS.id, AGENT_EN);
+      expect(out.message, verb).not.toContain(LEGACY_EN);
+      expect(out.message, verb).not.toContain(INQUIRY_THEIRS.id);
+      expect(out.message, verb).not.toContain('os_inquiry');
+    }
+  });
+
+  // ── §2 the wire contract the sentence must not shadow ────────────────────
+
+  it('the `FORBIDDEN:` prefix survives the conversion and still strips clean', async () => {
+    const out = await stack.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    // The prefix is wire contract, not copy. `FORBIDDEN: 您无权…` still matches
+    // the ADR-0111 prefix idiom, and stripping it leaves the sentence alone —
+    // no second prefix, no residue.
+    expect(WIRE_CODE(out.message)).toBe(true);
+    expect(WIRE_ERROR(out.message).startsWith('FORBIDDEN')).toBe(false);
+    expect(WIRE_ERROR(out.message)).toBe(ZH_SENTENCE);
+  });
+
+  it('the ADR-0112 envelope is unchanged — REST still answers 403 FORBIDDEN', async () => {
+    for (const verb of ['update', 'delete'] as const) {
+      const out = await stack.write(verb, INQUIRY_THEIRS.id, AGENT_ZH);
+      expect(out.code, `${verb}: ADR-0112 error code`).toBe('FORBIDDEN');
+      expect(out.status, `${verb}: ADR-0112 HTTP status`).toBe(403);
+    }
+  });
+
+  // ── §3 the catalog mechanism ─────────────────────────────────────────────
+
+  it('renders each platform locale from the catalog, not one hardcoded sentence', async () => {
+    for (const locale of ['en', 'ja-JP', 'es-ES'] as const) {
+      const out = await stack.write('update', INQUIRY_THEIRS.id, ctxFor(U_AGENT, locale));
+      expect(WIRE_ERROR(out.message), locale)
+        .toBe(BUILTIN_OPERATION_MESSAGES[locale].record_write_denied);
+    }
+  });
+
+  it('an unknown locale falls back to English rather than to the bare key', async () => {
+    const out = await stack.write('update', INQUIRY_THEIRS.id, ctxFor(U_AGENT, 'kl-GL'));
+    expect(WIRE_ERROR(out.message)).toBe(BUILTIN_OPERATION_MESSAGES.en.record_write_denied);
+    expect(WIRE_ERROR(out.message)).not.toBe('record_write_denied');
+  });
+
+  it('a context carrying NO locale still renders English copy, not the old sentence', async () => {
+    const out = await stack.write('update', INQUIRY_THEIRS.id, ctxFor(U_AGENT));
+    expect(WIRE_ERROR(out.message)).toBe(BUILTIN_OPERATION_MESSAGES.en.record_write_denied);
+  });
+
+  it('a deployment `translation` for `errors.record_write_denied` wins', async () => {
+    const seen: string[] = [];
+    const s = makeStack(() => (key: string, locale: string) => {
+      seen.push(`${key}@${locale}`);
+      return key === 'errors.record_write_denied' && locale === 'zh-CN'
+        ? '这条工单不归你负责,请联系负责人。'
+        : key; // II18nService echoes the key back on a miss.
+    });
+
+    const out = await s.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+    expect(seen).toContain('errors.record_write_denied@zh-CN');
+    expect(WIRE_ERROR(out.message)).toBe('这条工单不归你负责,请联系负责人。');
+    expect(out.status, 'still a refusal, still 403').toBe(403);
+  });
+
+  it('a misbehaving i18n service degrades to the built-in copy, never to a 500', async () => {
+    const s = makeStack(() => { throw new Error('i18n exploded'); });
+    const out = await s.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    // Still the refusal, still 403-shaped — not the i18n service's error.
+    expect(out.message).toBe(`FORBIDDEN: ${ZH_SENTENCE}`);
+    expect(out.code).toBe('FORBIDDEN');
+    expect(out.status).toBe(403);
+  });
+
+  // ── §4 the developer's half, and read-yes/write-no ───────────────────────
+
+  it('the developer facts move to `developerMessage`, `details` and the log', async () => {
+    const out = await stack.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    // Everything the sentence deliberately does not name is still legible —
+    // just nowhere a user can read it.
+    expect(out.developerMessage).toContain('os_inquiry');
+    expect(out.developerMessage).toContain(INQUIRY_THEIRS.id);
+    expect(out.developerMessage).toContain('update');
+    expect(out.details).toMatchObject({
+      operation: 'update', object: 'os_inquiry', recordId: INQUIRY_THEIRS.id,
+    });
+    expect(stack.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('update denied on os_inquiry'),
+      expect.objectContaining({ operation: 'update', object: 'os_inquiry', userId: U_AGENT }),
+    );
+  });
+
+  it('the ADR-0111 D10 delete breadcrumb still fires, in its own words', async () => {
+    await stack.write('delete', INQUIRY_THEIRS.id, AGENT_ZH);
+
+    // The D3 tightening's greppable reason is developer copy and is deliberately
+    // separate from the user's sentence — it must survive this conversion intact.
+    expect(stack.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('an edit-level share does not grant delete'),
+      expect.anything(),
+    );
+  });
+
+  it('read-yes/write-no: the same user reads the very row the write refuses', async () => {
+    // This is why the key is `record_write_denied` and not `record_access_denied`
+    // — "You do not have access to this record" would be false the moment it
+    // rendered, because the user is looking at the record.
+    const visible = await stack.read(AGENT_ZH);
+    expect(visible.map((r: any) => r.id)).toContain(INQUIRY_THEIRS.id);
+
+    const out = await stack.write('update', INQUIRY_THEIRS.id, AGENT_ZH);
+    expect(out.ok).toBe(false);
+  });
+
+  // ── §5 WHO may write is unchanged (the permission boundary) ──────────────
+
+  it('the owner still updates their own row', async () => {
+    const out = await stack.write('update', INQUIRY_MINE.id, ctxFor(U_AGENT, 'zh-CN'));
+    expect(out, out.message).toMatchObject({ ok: true });
+    expect(stack.rows('os_inquiry').find((r) => r.id === INQUIRY_MINE.id)?.subject).toBe('edited');
+  });
+
+  it('the owner still deletes their own row', async () => {
+    const out = await stack.write('delete', INQUIRY_MINE.id, ctxFor(U_AGENT, 'zh-CN'));
+    expect(out, out.message).toMatchObject({ ok: true });
+    expect(stack.rows('os_inquiry').map((r) => r.id)).not.toContain(INQUIRY_MINE.id);
+  });
+
+  it("a non-owner is still refused on the OWNER's row, and the row is untouched", async () => {
+    const out = await stack.write('update', INQUIRY_MINE.id, OWNER_ZH);
+    expect(out.ok).toBe(false);
+    expect(out.status).toBe(403);
+    expect(stack.rows('os_inquiry').find((r) => r.id === INQUIRY_MINE.id)?.subject).toBe('refund');
+  });
+});

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -2642,6 +2642,21 @@
       "pinned": 1
     },
     {
+      "file": "packages/plugins/plugin-sharing/src/write-denial-user-copy.test.ts",
+      "verb": "delete",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-sharing/src/write-denial-user-copy.test.ts",
+      "verb": "findOne",
+      "pinned": 1
+    },
+    {
+      "file": "packages/plugins/plugin-sharing/src/write-denial-user-copy.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/plugins/plugin-webhooks/src/auto-enqueuer.test.ts",
       "verb": "findOne",
       "pinned": 1

--- a/skills/objectstack-data/references/data-hooks.md
+++ b/skills/objectstack-data/references/data-hooks.md
@@ -495,7 +495,7 @@ whoever is elevated. If the acting user cannot edit the target (e.g. it is
 `public_read`), the write throws:
 
 ```
-FORBIDDEN: <a localized sentence; match on code, not prose>
+FORBIDDEN: insufficient privileges to update <object> <id>
 ```
 
 **An admin is not automatically exempt** — the gate is `canEdit`, driven by the

--- a/skills/objectstack-data/references/data-hooks.md
+++ b/skills/objectstack-data/references/data-hooks.md
@@ -495,7 +495,7 @@ whoever is elevated. If the acting user cannot edit the target (e.g. it is
 `public_read`), the write throws:
 
 ```
-FORBIDDEN: insufficient privileges to update <object> <id>
+FORBIDDEN: <a localized sentence; match on code, not prose>
 ```
 
 **An admin is not automatically exempt** — the gate is `canEdit`, driven by the


### PR DESCRIPTION
Fixes #12260

> **Paired with #12987.** The one-line doc correction this change makes necessary lives there, because `skills/**` is a governed surface and Prime Directive #14 judges a PR on its file list — one path hit forks the whole PR. **This** PR is code-only (five files, no governed path) and is the one that closes the card. See *The doc half* below.

A user holding object-level allowRead + allowEdit — and no `modifyAllRecords` — PATCHed a record they do not own on an object declaring `sharingModel: 'public_read'` with `access: { default: 'private' }`. The sharing middleware refused, correctly, and the deployment's client showed the server's reason verbatim: one hardcoded English sentence naming the object's API name and the row's opaque id. In a fully Chinese deployment that was the only thing the user was told about why their save failed.

The comparison the reporter drew is exact: `plugin-security`'s record-level denial already renders localized copy through the catalog (`userFacingDenialMessage`), so the same "I can see this record but cannot change it" situation showed human language or raw English depending on which layer refused.

This is the outstanding **consumer half** of work already done. `record_write_denied` shipped in all four platform locales under #12493, which named this card as its emitter half. **No `packages/spec` change here** — the key already exists. The twin, PR #12725, did the same conversion for `approval_recall_not_submitter` in `plugin-approvals`; this mirrors its shape deliberately.

## What changed

`packages/plugins/plugin-sharing/src/sharing-plugin.ts`

- `userFacingWriteDenial(locale, messageTranslator)` renders `record_write_denied` through `renderOperationMessage` from `@objectstack/spec/system` — same `errors.KEY` override address, same resolution ladder (deployment override, then the caller's locale, then `en`, then the key), same guarantee that a misbehaving i18n service cannot turn a 403 into a 500.
- `buildSharingMiddleware` gains an **optional third argument**, a lazily-resolved `II18nService.t`-compatible lookup wired by `SharingServicePlugin`. Lazy for the reason ADR-0029 D8 makes structural: the i18n service is contributed by a different plugin that may start after this one, so a lookup captured at build time would pin `undefined` for the process lifetime. Additive — all eight existing call sites pass two arguments and are unchanged, and a stack with no i18n service still renders the caller's locale from the built-in catalog.
- The verb, object API name and row id the old sentence carried move to `developerMessage`, to a structured `details`, and to a log line. REST forwards neither field on a `FORBIDDEN` body (only `DELETE_RESTRICTED` forwards a `developerMessage`), so nothing was added to the wire.

## Why this key and not `record_access_denied`

From the catalog's own header, quoted because it is the reason the key exists:

> `record_write_denied` (#12493) is NOT `record_access_denied` restated: the sharing middleware's by-id write gate fires on a row the READ path already admitted — the user is typically looking at the record it refuses — so "You do not have access to this record" would be false the moment it rendered. The situation is read-yes/write-no.

The new suite measures the read-yes half rather than quoting it: `read-yes/write-no: the same user reads the very row the write refuses` drives a `find` and the refused `update` through the same middleware on the same fixture.

It is also **one key for both write verbs**, which is the catalog's ruling and not a shortcut: the user's situation and remedy are identical for `update` and `delete`. Which verb was refused stays a developer fact.

## The three fences, and how each is pinned

**1. No `packages/spec` change.** None was made; the diff touches no file under `packages/spec`.

**2. The `FORBIDDEN:` prefix is wire contract, not copy.** It is applied *around* the rendered sentence, never by it. Pinned separately from the copy, exactly as #12725 did:

```
expect(WIRE_CODE(out.message)).toBe(true);                       // still matches the prefix idiom
expect(WIRE_ERROR(out.message).startsWith('FORBIDDEN')).toBe(false); // strips clean, no residue
expect(WIRE_ERROR(out.message)).toBe(ZH_SENTENCE);
```

and the ADR-0112 envelope (`code: 'FORBIDDEN'`, `status: 403`) is asserted on both verbs.

**3. The `delete`-verb ADR-0111 D10 breadcrumb stays.** Byte-identical, and now pinned by a test of its own (`the ADR-0111 D10 delete breadcrumb still fires, in its own words`). The new developer-fact log is a second, differently-worded line: D10 says *why the D3 tightening refuses*, the new one says *who/what/which verb*.

## Triage of the six tests that read the old string — wire behaviour vs copy

Asked per test, not blanket-updated.

| Test | Verdict | Action |
|---|---|---|
| `packages/rest/src/rest-4xx-message-truncation.test.ts:123` | **wire** — pins that a short 4xx passes byte-for-byte; the string is the test's own local literal, never imported from the emitter | none; verified still green |
| `packages/rest/src/rest-5xx-status-passthrough.test.ts:301` | **wire** — the 4xx half of the #5582 passthrough, again its own literal | none; verified still green |
| `packages/rest/src/rest-share-declared-code.test.ts:289` | **wire** — pins that a registered `code` is not repeated in `declaredCode`; the sentence is incidental | none; verified still green |
| `packages/rest/src/rest-share-refusal-classification.test.ts:226` | **wire** — pins that `FORBIDDEN` + 403 resolves to 403 on all three share routes | none; verified still green |
| `packages/rest/src/rest-share-user-message.test.ts:318` | **wire** — pins that a producer-marked `userMessage` rides the nested envelope; the technical message is the carrier, not the subject | none; verified still green |
| `packages/plugins/plugin-sharing/src/authored-row-write-deferral.test.ts:408` | **copy** — `expectSharingRefusal` asserted the sentence itself, as the discriminator between the two refusing authorities | **updated**: now asserts the catalog's `en` render plus `developerMessage`, so the discriminator survives where it actually lives |

The five REST files were left byte-identical **and re-run** rather than assumed: all six REST files (319 tests) pass unmodified, which is itself the evidence that their literals are independent of the emitter. A seventh site the order did not name, `packages/rest/src/rest.test.ts:2440`, is the same wire shape and also green.

Two further sites were examined and deliberately left alone: `packages/runtime/src/action-body-identity.test.ts:43` fabricates a refusal in its own engine stub to exercise identity threading (it asserts nothing about the sentence), and the `CHANGELOG.md` entries are history.

## The doc half, and why it is not in this PR

`skills/objectstack-data/references/data-hooks.md` printed the old sentence as the literal a hook author would match on. That correction is necessary — the string is never emitted once this lands — but it is **not in this PR**, and its absence is deliberate.

`skills/**` is on the `GOVERNED_SURFACES` register in `scripts/pm/check-governed-merges.mjs`, printed today as `docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md`. Prime Directive #14 judges a PR on its **file list**, not its description, and states that a mixed diff is not a proportion question — one path hit is enough, and the named remedy is to split the governed files into their own PR. Carrying the doc here would have reserved this PR's landing for a hand merge and kept it out of the queue entirely.

⇒ **#12987** carries that one file and nothing else, as a draft awaiting a human merge. It was on this branch for two commits and has been reverted out (`Revert "docs(skills): …"`), so the net diff below contains no governed path. **The two want landing together**: between them, `data-hooks.md` briefly documents a string the platform no longer emits.

## Ablation — the reported defect, reproduced

Direction predicted before running: **red**, with the old English sentence as the actual value.

Reverting only the catalog render to the pre-change hardcoded throw, with the mutation proven on disk before any verdict was read:

```
HEAD_BLOB=80c9911d2406198ec3efdc122b4c6fc68c1f8b5f
BEFORE   =80c9911d2406198ec3efdc122b4c6fc68c1f8b5f
AFTER    =a10768ca77b06fc6393d994279f72332b990d0fe
injected-text grep -c = 1 (want 1) · removed-text grep -c = 0 (want 0)
MUTATION CONFIRMED ON DISK
```

Result — `Tests 21 failed | 15 passed (36)`:

```
AssertionError: expected 'FORBIDDEN: insufficient privileges to…' to be 'FORBIDDEN: 您无权修改或删除这条记录,如需修改请联系该记录的负责…'
Expected: "FORBIDDEN: 您无权修改或删除这条记录,如需修改请联系该记录的负责人或管理员。"
Received: "FORBIDDEN: insufficient privileges to update os_inquiry inq_theirs"
```

That is the customer report, character for character.

The 15 that stayed **green** under the mutation are the control: the whole §5 "who may write" block, the D10 breadcrumb and the read-yes case are untouched by the ablation, which is what makes it a measurement of the copy rather than of the gate.

Restore was verified by state, not by the trap's exit code:

```
RESTORED =80c9911d2406198ec3efdc122b4c6fc68c1f8b5f
RESTORE CONFIRMED: hash == HEAD blob, git status --porcelain empty
```

No rebuild leg was needed and that is a measured fact, not an assumption: the suite reaches the mutated module through a relative source import (`./sharing-plugin.js`), and `packages/plugins/plugin-sharing/dist` does not exist in this worktree while the tests pass — so nothing here resolves through the package's `exports`.

## Verification

**Every run below, and the whole gate union, was re-measured on `e6ec9a9e5`** — the final head after the governed-surface revert, so the green union describes the tree that ships rather than an earlier one.

| Run | Result |
|---|---|
| `plugin-sharing` full suite | `Test Files 29 passed (29)` · `Tests 673 passed (673)` |
| `rest` — all six named wire-contract files plus `rest.test.ts` | `Test Files 6 passed (6)` · `Tests 319 passed (319)` |
| `plugin-security` — the six suites that call `buildSharingMiddleware` | `Test Files 6 passed (6)` · `Tests 96 passed (96)` |
| `pnpm lint` repo-wide (`eslint . --no-inline-config`, whole tree, not narrowed) | exit 0, no diagnostics |
| `pnpm --filter @objectstack/plugin-sharing typecheck` | exit 0 |

Gate families re-derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` on the **reduced** changed set. Removing the governed path drops the eight skills families the earlier mixed diff pulled in — confirmed by re-running the derivation, not assumed: `check-skills-token-ratchet`, `check:doc-authoring`, `check:role-word`, `check:skill-compatibility`, `check:skill-frame-sync`, `check:pm-governed-merges`, `check:skill-refs` and `check:doc-formula-expressions` each return **zero** hits in the new list. They now belong to #12987, where they were run and are green.

36 families were run here. All green except the one noted below. Selected judgment lines:

```
check-engine-double-contract: 644 (file, verb) row(s) held by the RETAINED ledger — a pin that leaves names itself.
check-type-check-coverage: OK — 65/78 workspace packages type-checked (plus the root), 13 in the DEBT ledger, 1 exempt.
check-type-check-coverage --re-measure: OK — 31 ledger entr(ies) re-measured in 293.0s, 1570 raw tsc error(s) total, none above its recorded number.
check-i18n-bundles: OK (9 package(s) — all bundles in sync, no undeclared authoring keys).
```

`scripts/engine-double-contract.pinned.json` gains the three rows for the new fake engine, written by the gate's own `--write` as it instructs.

**Two honest gaps, neither a pass:**

- `packages/plugins/plugin-sharing/tsconfig.json` excludes `**/*.test.ts`, so the green `typecheck` says nothing about the two test files. Measured rather than assumed — `tsc --listFiles` contains `sharing-plugin.ts` (1 hit) and **neither** test file (0 hits each). Their type coverage comes from `check:type-check-debt --re-measure`, which re-measures this package's TEST_DEBT entry with the exclusion lifted and reported no count above its recorded number.
- `node scripts/pm/check-half-states.mjs` exits **3 = PREREQUISITE NOT MET** in this container ("the token in the environment is not a valid GitHub credential"). It swept nothing, so it is **NOT MEASURED** — neither a clean board nor a dirty one. It is a backlog sweep unrelated to this diff and CI runs it with a real credential.

## Filed out of scope

**#12975** — the `/data` door ships the ADR-0111 `CODE:` prefix inside the user-facing `error` string, so this now-localized refusal still renders with a machine token in front of it in a toast. That means the reporter's symptom is only **half** resolved by this card. Pre-existing and untouched here: the prefix rode in front of the old English sentence identically, and changing which bytes `/data` ships is a REST envelope decision that moves two legitimate wire-behaviour assertions. The share routes and `handleApprovalError` do strip it, so the two doors disagree — and `rest-server.ts`'s own comment asserts the prefix "never reaches the wire", which holds for that door and not for this one.

---

_Generated by [Claude Code](https://claude.ai/code/session_0194kbQJxUvv2yvsGRtuXpP5)_
