### PR TITLE
docs(pm-skill): retire the last three ref-absence dequeue readings

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -762,7 +762,7 @@ issue 上(不能合 ≠ 不复核;技能面 PR 的复核席须跑在契约复审
 **请审走免碰 draft 位的专用 REST 端点,MCP 兜底显式带 `draft: true`**(坑与端点事实住 platform-readings);④ 轮次报告单列「awaiting a human merge」(「等人来
 合」与「被忘了」在 GitHub 上长得一模一样)。混
 合 diff 一条命中就分叉,⛔ 不按比例判;要拆就让 dev 单独开 PR;已入队才读到本条 ⇒ 转 draft
-与 disable 都做再验队列 ref(转 draft 单独不可靠,两向相反实测住 platform-readings)。**skills 车道自有 PR 再按 diff 内容分流**(维护者 2026-08-26 裁定,原话:「skills 中的
+与 disable 都做,出队以阳性探针答、ref 缺席只旁证不承载结论(探针与两向相反实测住 platform-readings)。**skills 车道自有 PR 再按 diff 内容分流**(维护者 2026-08-26 裁定,原话:「skills 中的
 pr，只有包含md文件时需要推给我审核，其他代码文件你直接自己审核。」):diff 含任一 `.md` 文件 ⇒
 上述终局四件套照旧;纯代码面(`scripts/pm/` 工具、`.claude/` hooks/workflows/settings、`skills/**` 非
 md 产物)⇒ skills 席按契约复审档自审(清单不减)后直接落地(ready → 入队),⛔ 不推维护者;分

--- a/.claude/skills/pm-dispatch/references/platform-readings.md
+++ b/.claude/skills/pm-dispatch/references/platform-readings.md
@@ -33,11 +33,11 @@
 - **状态核验用最小字段**(search/list + `fields`)或等事件,整对象 `get` 留给入队决策点;门禁放行
   判据 = 承载门禁族 job 的 conclusion,聚合(`blocked`/`dirty`)只作阴性筛查再定位,放行按名定向读
   单条 job,⛔ 不拉全表(按名定位失败才拉)。
-- **转 draft 不是可靠的踢队手段 —— 两向都有实测,处置按最坏走**:本仓测得转 draft 同时掉
-  auto-merge 与队列成员资格(均不自动恢复,转正后重新挂);objectui 2026-08-25 测得相反 —— 已入
-  队 PR 转 draft 后条目保位、~40 分钟后队列照样合并,彼时 `disable_pr_auto_merge` 已拒绝(仓别/时
-  机差异未分辨)。共同支持的补救:转 draft + disable 都做(本仓测得 disable 单独不踢队、objectui
-  彼时径直拒绝),**验队列 ref 与未落地**(拼写见「零成本等价物」),⛔ 不据单读数报补救。
+- **转 draft 不是可靠的踢队手段 —— 两向相反实测,处置按最坏走**:本仓转 draft 同时掉
+  auto-merge 与队列成员资格(均不自动恢复,转正后重挂);objectui 2026-08-25 已入队 PR 转 draft 条目
+  保位、~40 分钟后队列照样合并(仓别/时机未分辨)。补救:转 draft + disable 都做(本仓
+  `disable_pr_auto_merge` 单独不踢队、objectui 彼时径直拒绝);出队按下方「队列 ref」条阳性探针
+  答不在队向,加未落地;ref 缺席只作旁证,⛔ 永不承载结论、不据单读数报补救。
 - **`update_pull_request` 不管传不传都发送 `draft` 位 ⇒ 对 draft PR 的任何调用必须显式带
   `draft: true`**(reviewers/title/body/labels 单字段调用同坑;objectui 2026-08-25 实测:一次只传
   reviewers 的请审把治理面 draft 发布进合并队列,后果见上条);请审免碰 draft 位的专用路 = REST
@@ -51,11 +51,11 @@
   `merge`(2026-08-24 两张 PR、一张 disable→enable 复验同值)、队列路径回显空字段而入队照发,落
   地仍无一例外单亲 squash(方法归队列,本仓 `allow_merge_commit:false`)⇒ ⛔ 不拿回显当任何方向
   的证据、不为它翻转空转;「空字段=静默空转签名」旧读法已推翻,权威信号见下两条。
-- **配额枯竭时 `enable_pr_auto_merge` 回成功而挂载根本没发生**(实测:一次「成功」后 2.5 小时
-  零动静,同期别的 PR 正常合入;配额恢复后同一调用 ~1 分钟内落地)⇒ **验效果,不验回应**,
-  按下条序列以队列分支/timeline 入队事件确认,⛔ 不拿成功报文收工;回读 `auto_merge` 非空
-  本接口给不了(`pull_request_read` 与 `fields` 枚举都无该成员,armed 与否读回逐字节相同)⇒ 效果
-  读数只有队列分支、timeline 入队事件、最终落地三种;已死假说:已绿 PR 会静默空转。
+- **配额枯竭时 `enable_pr_auto_merge` 回成功而挂载根本没发生**(实测:「成功」后 2.5 小时零动
+  静,同期别的 PR 正常合入;配额恢复后同一调用 ~1 分钟内落地)⇒ **验效果,不验回应**,按下
+  条阳性探针确认,⛔ 不拿成功报文收工;回读 `auto_merge` 非空本接口给不了(`pull_request_read`
+  与 `fields` 枚举都无该成员,armed 与否读回逐字节相同)⇒ 效果读数 = 下条探针①②、timeline
+  入队事件、最终落地,队列分支仅在场时算;已死假说:已绿 PR 会静默空转。
 - **队列 ref 答 BUILD 不答成员资格**(旧读法「存在即在队」作废):`gh-readonly-queue/*` **只在存在
   时**有意义(= 有 build 在跑),⛔ 缺席不是任何方向的读数。**阳性探针按成本序**:①
   `update_pull_request_branch` 回「Branches that are queued for merging cannot be updated」= 在队,正常返回顺


### PR DESCRIPTION
Fixes #12888

Three sites still read queue-ref ABSENCE as proof a PR left the merge queue, outliving the corrected membership reading (queue refs answer about BUILDS, meaningful only when PRESENT — landed this morning with PR #12889). This PR retrofits the three residual sites: dequeue is now verified by the POSITIVE probes, and ref absence is downgraded to corroboration that never carries the conclusion. Net 0 lines on both zero-headroom files. Governed surface (`.claude/**`): draft-only, human landing per the ACCEPT fork — do not queue, arm, or flip ready.

## Per-site before / after

**Site 1 — `references/platform-readings.md`, draft-flip dequeue-remedy row (5 lines, net 0).**
Before, the remedy verification was negative: 「**验队列 ref 与未落地**(拼写见「零成本等价物」),⛔ 不据单读数报补救。」 After: 「出队按下方「队列 ref」条阳性探针答不在队向,加未落地;ref 缺席只作旁证,⛔ 永不承载结论、不据单读数报补救。」 The conclusion now comes from the probes' not-queued direction (the merge-call answering the merge-commits-not-allowed 405; update-branch no longer refusing with the queued-branch text) plus the non-landing content read; absence corroborates only.

**Site 2 — same file, arming-effect row (5 lines, net 0).**
The closed enumeration 「效果读数只有队列分支、timeline 入队事件、最终落地三种」 reopens as 「效果读数 = 下条探针①②、timeline 入队事件、最终落地,队列分支仅在场时算」 — the two positive probes join as effect readings, and the queue-branch entry survives only as a positive. The stale pointer 「按下条序列以队列分支/timeline 入队事件确认」 becomes 「按下条阳性探针确认」 (the row after it IS the corrected queue-ref rule).

**Site 3 — `SKILL.md`, governed-surface ACCEPT fork (line-in-place, net 0).**
「转 draft 与 disable 都做再验队列 ref(转 draft 单独不可靠,两向相反实测住 platform-readings)」 becomes 「转 draft 与 disable 都做,出队以阳性探针答、ref 缺席只旁证不承载结论(探针与两向相反实测住 platform-readings)」. The general rule keeps its single home in platform-readings; SKILL.md carries only the pointer.

## Collapse-candidate measurement (per the grading's binding instruction)

The draft-flip row's two-way narration was measured, not assumed: keeping it verbatim plus the probe correction wraps to **6 lines** under the ratchet's own canonical wrapper (`wrapLine`, 120-byte cap), one over. The meaning-preserving compression below brings the row to 562 bytes = **5 lines**. Net 0 achieved; no shortfall.

## Cut ledger (every cut with its surviving home)

`references/platform-readings.md` (314/314 before and after):
- 「测得」x3 and 「两向都有实测 … 测得相反」 → the header now reads 「两向相反实测」; the measured register survives in the same header.
- 「彼时 `disable_pr_auto_merge` 已拒绝」 (narration) deduplicated with the remedy parenthetical 「objectui 彼时径直拒绝」 — the fact appeared twice in one row; one copy survives, now carrying the full API name.
- 「共同支持的补救」 → 「补救」; the supported-by-both nuance survives in the two-way narration immediately before it.
- 「仓别/时机差异未分辨」 → 「仓别/时机未分辨」; 「转 draft 后条目保位」 → 「转 draft 条目保位」; 「重新挂」 → 「重挂」 (wording only).
- 「(拼写见「零成本等价物」)」 pointer dropped: the ls-remote and landed-grep spellings still live in the 「零成本等价物」 rows of this same file, and the landing read stays governed by the 二义读数 row's 按内容读 rule; with ref absence downgraded to corroboration the spelling pointer stopped being load-bearing at this site.
- 「一次「成功」后」 → 「「成功」后」; the single-episode reading survives in the row's own 2.5-hour narration.
- The closed count 「三种」 dropped — the enumeration is deliberately no longer closed.

`SKILL.md` (1005/1005 before and after; widest-table-row pin 765 untouched):
- 「转 draft 单独不可靠」 dropped from the ACCEPT-fork sentence — surviving home is the sentence's own pointer target: the platform-readings draft-flip row, whose header states the unreliability and whose remedy carries the do-both rule.
- The corrected sentence costs +29 bytes, absorbed on the line that opens the 2026-08-26 verbatim ruling quote (structurally exempt from the 120-byte cap); every ruling quote and date is untouched, no line added.

## Gate verdicts — union re-run at final commit `29a300f6e` (this head)

- `pnpm check:pm-skill-ratchet` exit 0 — 「✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/platform-readings.md is 314 lines (ceiling 314; headroom 0).」「✓ … SKILL.md is 1005 lines (ceiling 1005; headroom 0).」「✓ … SKILL.md: widest table row is 765 bytes (pin 765; headroom 0).」「✓ … platform-readings.md: widest table row is 0 bytes (pin 0; headroom 0).」
- `pnpm check:pm-skill-id-lint` exit 0 — 「✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).」 (no issue ids in protocol prose)
- `pnpm check:pm-governed-prose` exit 0 — 「✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces … and claim no others.」
- `pnpm check:skill-frame-sync` exit 0 — 「✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files」
- `pnpm check:skill-frame-freshness` exit 0 — 「✓ check-skill-frame-freshness: the decision frame in this tree is current with origin/main (fetched just now).」
- `pnpm check:pm-governed-merges` exit 0 (self-test 206 assertions + live generator certification)
- `pnpm check:agent-test-spelling` exit 0 — 「✓ check-agent-test-spelling: 0 violations」
- `pnpm check:doc-authoring` exit 0; `pnpm --filter @objectstack/lint run check:doc-formula-expressions` exit 0 (first run was PREREQUISITE NOT MET — dependency not built ⇒ not a measurement; measured green after building `@objectstack/formula` and `@objectstack/lint`)
- `node scripts/pm/check-governed-queue-guard.mjs --self-test` exit 0; the bare gate exits 1 locally by design (it reads the merge_group event payload, absent outside CI) — locally NOT MEASURED, enforced at queue time.
- `pnpm check:nul-bytes` exit 0 — 「check-nul-bytes: OK (scanned 7197 text file(s) …)」

Gate union derived mechanically: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (answer taken from this checkout at 2b4178aa5; the `--repo` assertion holds). Docs-only `.claude/**` diff — no changeset; `skip-changeset` label applied at PR-open.

_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_