### PR TITLE
fix(metadata-core, service-cluster): make the ./testing subpaths ESM-only

### DIFF
--- a/.changeset/testing-subpath-exports-esm-only.md
+++ b/.changeset/testing-subpath-exports-esm-only.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/metadata-core": minor
+"@objectstack/service-cluster": minor
+---
+
+fix: the `./testing` subpaths are ESM-only — they no longer advertise a `require` condition vitest refuses to serve (#12985)
+
+Both packages published their test-harness subpath as a dual entry point:
+
+```jsonc
+// FROM — @objectstack/metadata-core and @objectstack/service-cluster
+"./testing": {
+  "types": "./dist/testing.d.ts",
+  "import": "./dist/testing.js",
+  "require": "./dist/testing.cjs"
+}
+
+// TO
+"./testing": {
+  "types": "./dist/testing.d.ts",
+  "import": "./dist/testing.js"
+}
+```
+
+The `require` half was a promise neither package could keep. Both subpaths
+re-export `vitest`, and vitest **refuses** to be loaded from CommonJS by
+design — its CJS entry is a single `throw`:
+
+```
+node -e "require('@objectstack/metadata-core/testing')"
+Error: Vitest cannot be imported in a CommonJS module using require(). Please use "import" instead.
+```
+
+The emitted bytes parse; the load fails inside vitest's own entry, for every
+consumer and every code path. So the condition could never resolve to working
+code, on any release, since it was first declared. It is removed rather than
+repaired because the failure is not ours to fix: a test harness has no business
+advertising a `require` condition when the test runner it re-exports does not
+serve one.
+
+**Nothing that worked stops working**, and that is why this is not filed as a
+breaking removal. A CJS consumer that resolved through the old condition got a
+hard `Error` at load; it now gets a resolution error from node instead — a
+different message for the same non-working call, and an earlier and clearer
+one. The `import` condition, the types and the runtime API are untouched, and
+every in-repo consumer already reaches these subpaths through `import`
+(`@objectstack/metadata-fs`, `@objectstack/metadata-protocol`,
+`@objectstack/rest`, `@objectstack/runtime`, `@objectstack/service-cluster-redis`).
+
+**If you did spell it as `require`** — `require('@objectstack/metadata-core/testing')`
+or `require('@objectstack/service-cluster/testing')` — switch the call to
+`await import('@objectstack/metadata-core/testing')`, or move the calling
+module to ESM. That is the same change the old condition already forced on
+you, one error message earlier.
+
+`dist/testing.cjs` is still emitted (both packages build every entry in both
+formats) and still parsed by `pnpm check:dual-build-cjs-loads`; it is simply no
+longer reachable through the manifest. Removing it from the build is a
+tsup-config change with its own risks and is not folded in here.

--- a/packages/metadata-core/package.json
+++ b/packages/metadata-core/package.json
@@ -14,8 +14,7 @@
     },
     "./testing": {
       "types": "./dist/testing.d.ts",
-      "import": "./dist/testing.js",
-      "require": "./dist/testing.cjs"
+      "import": "./dist/testing.js"
     }
   },
   "files": [

--- a/packages/services/service-cluster/package.json
+++ b/packages/services/service-cluster/package.json
@@ -14,8 +14,7 @@
     },
     "./testing": {
       "types": "./dist/testing.d.ts",
-      "import": "./dist/testing.js",
-      "require": "./dist/testing.cjs"
+      "import": "./dist/testing.js"
     }
   },
   "scripts": {

--- a/scripts/dual-build-cjs-loads.baseline.json
+++ b/scripts/dual-build-cjs-loads.baseline.json
@@ -1,13 +1,4 @@
 {
   "$comment": "Shrink-only, hand-edited. Published `require` entry points that legitimately cannot be require()d, each with the reason. Read by scripts/check-dual-build-cjs-loads.mjs. An entry that starts loading must be DELETED in the same PR that fixes it — the gate reds on a stale exemption. ⛔ A parse failure (SyntaxError in our own emitted bytes) is NEVER ledgerable: the gate ignores an entry here for that class on purpose, because a parse failure is always a fact about what we emitted, never about a dependency. Its steady state is NOT empty — read the reasons, never the count.",
-  "entries": {
-    "@objectstack/metadata-core#./testing": {
-      "reason": "The subpath re-exports vitest, and vitest REFUSES to be loaded from CommonJS by design ('Vitest cannot be imported in a CommonJS module using require(). Please use \"import\" instead.'). The bytes parse; the load fails inside vitest's own entry. Pre-existing and independent of #12971 — the same `require` condition is present at b489d3c725e8, before the import.meta line landed. The real repair is at the manifest (a test-harness subpath has no business advertising a `require` condition), which is a published-exports change and belongs to its own card.",
-      "diagnostic": "Error: Vitest cannot be imported in a CommonJS module using require()."
-    },
-    "@objectstack/service-cluster#./testing": {
-      "reason": "Same shape as @objectstack/metadata-core#./testing — a vitest-backed test-harness subpath that declares a `require` condition vitest itself refuses to serve. Bytes parse, load fails inside vitest. Repair is the same manifest-level one and belongs to the same card.",
-      "diagnostic": "Error: Vitest cannot be imported in a CommonJS module using require()."
-    }
-  }
+  "entries": {}
 }


### PR DESCRIPTION
Fixes #12985

Both `@objectstack/metadata-core#./testing` and `@objectstack/service-cluster#./testing`
advertised a `require` condition that could never load. Both subpaths re-export
`vitest`, whose CJS entry is a single `throw` by design, so the bytes parse and the
load dies inside vitest itself. This drops the condition and deletes the two ledger
entries `#12984` left behind for it, in the same change — the ledger is SHRINK-ONLY.

## What changed (4 files)

**1. The two manifests** — the `./testing` subpaths become ESM-only:

```jsonc
// FROM (identical in both packages)
"./testing": {
  "types": "./dist/testing.d.ts",
  "import": "./dist/testing.js",
  "require": "./dist/testing.cjs"
}

// TO
"./testing": {
  "types": "./dist/testing.d.ts",
  "import": "./dist/testing.js"
}
```

The shape is copied, not invented. It is the repo's one existing ESM-only subpath:
`create-objectstack#./created-summary` spells exactly `{ "types", "import" }` with no
`require`. Enumerated mechanically over all 74 manifests under `packages/` — that
subpath is the only precedent, and `./testing` on these two packages were the only
`testing`-ish subpaths in the tree.

**2. `scripts/dual-build-cjs-loads.baseline.json`** — the two entries deleted **by name**
(`@objectstack/metadata-core#./testing`, `@objectstack/service-cluster#./testing`), the
`$comment` untouched. The edit was done as a JSON round-trip whose fidelity was proved
first: re-serialising the *unmodified* file reproduced it byte-for-byte, so the whole
diff is the two deletions. That the ledger now reads `"entries": {}` is a fact about
this tree, **not** an acceptance criterion — the `$comment` is explicit that its steady
state is not empty, and no other entry was touched because there was no other entry.

**3. A `minor` changeset** for both packages carrying the FROM → TO and the one-line fix
for anyone who did spell the call as `require`.

## The two things the card asked to measure, not assume

### Is `dist/testing.cjs` still needed? — Decision: keep emitting it. Not deleted.

Both `tsup.config.ts` files declare `format: ['esm', 'cjs']` for **both** entries
(`src/index.ts`, `src/testing.ts`), so `dist/testing.cjs` keeps being emitted. After this
change nothing in either manifest points at it, and neither package exports `./dist/*`,
so it is unreachable through the package. It is therefore dead weight — but deleting it
is a build-config change, not an exports change:

- tsup takes one `format` per config, so per-entry formats mean splitting each config
  into an array of two. Both configs also set `clean: true` **and** `splitting: true`;
  a second config would wipe the first's output and break chunk sharing between
  `index` and `testing`. That is a real risk with its own verification surface, and it
  is not folded into an exports repair.
- Keeping it is not inert: `check:dual-build-cjs-loads` parses every emitted CommonJS
  file of any package that has a `require` entry point, and both packages still have one
  at `.`, so `dist/testing.cjs` stays under the PARSES sweep. Deleting it would remove
  that coverage.
- No gate objects to it. `check:published-files` asks that the `files` whitelist *covers*
  every declared entry point (removal can never violate that) and that it admits no test
  or build tooling; `dist/` is unchanged either way. Verdict on this branch:
  `✓ check:published-files — 69 publishable package(s) ... declare a files whitelist that
  covers every entry point`.

### Are there real `require()` consumers of these subpaths? — Measured: none.

`grep -r` over the working tree (a filesystem walk, so untracked files are included;
`node_modules`, `.git`, `.turbo` pruned) — deliberately **not** `git grep`, which reads
tracked files only:

| scan | hits |
|---|---|
| `@objectstack/metadata-core/testing` | 11 — 8 `import` statements, 3 in CHANGELOG/doc prose |
| `@objectstack/service-cluster/testing` | 2 — 1 `import`, 1 docstring |
| a `require(` call naming `metadata-core` or `service-cluster` | 3 — all three are prose *about* this defect (this gate's own header, and #12984's changeset) |
| `testing.cjs` | 2 — the two manifest lines this PR removes |

Zero `require()` call sites. Positive control on the same command shape, with a term in
no substring relation to the tested ones — a `require(` call naming any `@objectstack/`
specifier — returns **22** hits, so the scan is live rather than silently empty.

The in-repo consumers all reach these subpaths through `import`:
`@objectstack/metadata-fs`, `@objectstack/metadata-protocol`, `@objectstack/rest`,
`@objectstack/runtime`, `@objectstack/service-cluster-redis`.

Independently of any scan, a *working* CJS consumer cannot exist: the load fails inside
vitest for every caller and every code path, which is the whole reason the ledger entry
was written.

**Pinned sibling (AGENTS.md §Workflow 4).** objectui at the pinned `.objectui-sha`
`190fbd01d0615e2e168faf9e08b8ad7844bc039d`: **0** hits for either subpath, and 0 hits for
`@objectstack/(metadata-core|service-cluster)` at all. Positive control on the same scan:
`@objectstack/spec` returns 35. The Console Pin Gate cannot see this removal.

## Reverse verification

Both legs mutate a file the gate reads **directly from the working tree**
(`manifestPaths()` walks `packages/**/package.json`; `readLedger()` reads the baseline).
No source is compiled into `dist/` on this path, so no rebuild sits between the mutation
and the verdict — `dist/` was built once, in full, before any of this
(`pnpm build`, 71/71 tasks). Each leg restores under a `trap ... EXIT INT TERM` using
absolute paths and `git checkout HEAD --`, and the restore is proved by blob hash plus an
empty `git diff HEAD`, never by an exit code.

**Ablation A — put the `require` conditions back, ledger stays empty.** Predicted
direction: RED.

```
MUT  metadata-core/package.json    injected-anchor-count=1  bare-import-line-count=0
     WORKTREE_BLOB=bfa5047705cf1e76534103bff9be4e099096270b (HEAD=4e61c57b8fe332f92253d034d8d20ddc4e5c8e18)
MUT  service-cluster/package.json  injected-anchor-count=1  bare-import-line-count=0
     WORKTREE_BLOB=00b7469ab793c735bfc6cf1216bb38f365034558 (HEAD=19a40e267b570b63ae7a8b297921ecd69bd3b2bf)

ABLATION_A_GATE_EXIT=1
✗ check:dual-build-cjs-loads — 2 finding(s) across 105 published require entry point(s):
  ✗ @objectstack/metadata-core#./testing: require(./dist/testing.cjs) FAILED — Error: Vitest cannot be imported in a CommonJS module using require(). Please use "import" instead.
  ✗ @objectstack/service-cluster#./testing: require(./dist/testing.cjs) FAILED — Error: Vitest cannot be imported in a CommonJS module using require(). Please use "import" instead.
```

The two mutated blobs are byte-identical to the pre-fix blobs on `origin/main`, so the
ablation reconstructed the old manifests exactly rather than approximating them. Restored:
both worktree blobs back to their HEAD blobs, `git diff HEAD` 0 lines, `git status` 0 lines.

**Ablation B — restore the two ledger entries, keep the exports fix.** This one is a
**claim check, and the claim did not hold.** Predicted direction: GREEN, from reading the
gate; measured: GREEN.

```
MUT  baseline  mc-entry-count=1  sc-entry-count=1  empty-entries-count=0
     WORKTREE_BLOB=18606b5f2f210b3c61c2eccacd4cce8cf01281a5 (HEAD=46929bddbeb48692a591bbca8da7cec01f2c8375)
ledger entries the gate will read: ["@objectstack/metadata-core#./testing","@objectstack/service-cluster#./testing"]

ABLATION_B_GATE_EXIT=0
✓ check:dual-build-cjs-loads — 103 published require entry point(s) across 67 package(s) load; ...
```

So a PR that had fixed the exports and **forgotten** the ledger deletion would have been
green, with two stale exemptions left in the tree and not even listed as `declared:`
hits. `staleLedger` only fires for a ledgered id that is still in the collected
population and now *loads*; an id that has **left** the population is never consulted.
That is exactly the shape a manifest-level repair produces — the repair this ledger's own
reasons prescribed. Reported to the PM as a separate finding rather than repaired here:
it is a different defect class from this card, and closing it needs a new `--self-test`
case, so it is not a bounded in-place fix. Deleting the entries is correct either way and
this PR does it.

(The first run of leg B aborted with `FATAL: mutation did NOT land on disk` and measured
nothing — the anchor `grep -c` expected 1 but the id appears twice in the restored file,
the second time inside the sibling entry's `reason` prose. The guard was wrong, not the
mutation; the anchor was tightened to the entry-key line and the leg re-run. Recorded
because a silently re-run ablation is the same defect one level up.)

## Verification — all at `68fb6915f`, on a clean tree

`pnpm build` — 71/71 tasks successful (full, once, before any measurement).

Gate families derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
after the final commit. All 32 derived families run, real exit codes captured before any
pipe. **31 exit 0**; 1 NOT MEASURED:

- `✓ check:dual-build-cjs-loads — 103 published require entry point(s) across 67 package(s) load; 613 emitted CommonJS file(s) parse; 1 cross-format behaviour probe(s) agree.` (was 105 / 618 / 2 declared before this change; the deltas reconcile exactly — 2 rows removed, and `cjsFileCount` counts per row, so the 3 CJS files of metadata-core and the 2 of service-cluster leave the sum once each)
- `✓ check-dual-build-cjs-loads self-test: 37 cases pass`
- `✓ check:published-files — 69 publishable package(s) ... covers every entry point`
- `check-type-source-resolution OK — 94 tsc program(s) across 77 packages scanned`
- `check-test-source-alias OK — 72 packages with tests scanned; ... 45 published subpath(s) resolved through every alias table`
- `✓ check-adr-0087-registration: this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen).`
- `✓ This diff introduces no major bump.` · `✓ No empty-frontmatter changeset introduced by this diff`
- `✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.`
- `check-nul-bytes: OK (scanned 7203 text file(s) ... no raw ASCII control bytes)`
- **NOT MEASURED**: `scripts/pm/check-half-states.mjs` exits **3 — PREREQUISITE NOT MET**,
  not a finding: the container's `GITHUB_TOKEN` is the proxy placeholder (`len 14`, no
  GitHub prefix, `GET /rate_limit` gives HTTP 401). Its own text: "Nothing was swept ...
  this result says NOTHING about whether the board carries half-states." It is a PM board
  sweep matched only via the `.changeset` glob, unrelated to this diff.

Tests and typechecks (heavy runs serialised through `scripts/pm/os-verify-lock.sh`):

- own suites — `@objectstack/metadata-core` 14 files / **234 passed**;
  `@objectstack/service-cluster` 4 files / **66 passed**
- every in-repo consumer of the changed subpaths, targeted at the importing files —
  metadata-fs 31, metadata-protocol 48, rest 123 (3 files), runtime 85,
  service-cluster-redis 28 → **315 passed, 0 failed**
- `typecheck` for the 5 consumers that declare one (`Scope: 5 of 79 workspace projects`,
  each echoing its script name) — all `Done`, including
  `check:test-typecheck: OK — @objectstack/rest's test layer compiles`

### Declared narrowing: repo-wide `pnpm lint` was not run locally

Not "skipped" — measured, with the three pieces of evidence that make a narrowing a
measurement:

1. **Population, read from eslint's own config** rather than guessed: every `files:` block
   in `eslint.config.mjs` is scoped to `**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` or narrower.
   No block matches `.json` or `.md`.
2. **File count, read from `--format json`**: running eslint over exactly the 4 changed
   paths reports 4 results, `errorCount=0` on each, every one carrying
   *"File ignored because no matching configuration was supplied."*
3. **Invariance for untouched files**: type-aware linting is not enabled in this repo
   (`eslint.config.mjs` line 328: "no `parserOptions.project`, no typed
   `@typescript-eslint` rules"), so nothing in this diff can move a verdict on a file it
   does not contain. This diff contains no linted file at all.

CI runs the full farm regardless.

### Note on the gate derivation and a moving `origin/main`

`dispatch-gates.mjs` printed a STALE TREE warning: `origin/main` advanced 8 commits
(`15d55fb24` to `d028b37cb`) while this branch was being verified, and 3 files the
derivation reads changed in that range. The warning is real; its effect on **this**
answer is zero, and that is proved rather than assumed:

- `.github/workflows/lint.yml` is the only one of 28 workflow files that changed, and it
  changed **0 non-comment lines** — no gate step added, removed or renamed.
- `scripts/pm/dispatch-gates.mjs` gained **0 non-comment lines** (62 added lines, all
  comment) — the derivation logic is behaviourally identical.
- `scripts/engine-double-contract.pinned.json` is the ledger of a family whose source did
  not change and which none of these 4 paths matches.

The 4 changed paths are disjoint from all 30 files in that range, so there is no conflict
either. Re-verifying on a merge would restart the whole run against a target that moved 8
commits in about half an hour; the family list is the thing that had to be current, and it
is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_