### PR TITLE
fix(pm): derive check-half-states' H32 seat specimens from the resolved sweep repo

### DIFF
--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -12241,12 +12241,30 @@ function selfTest() {
   const busy = { unclaimed: 15, inFlight: 7 };
   const idleLane = { unclaimed: 15, inFlight: 0 };
 
+  // The `@ <repo>` specimens below DERIVE both board names rather than spelling
+  // them, because `seatLane` judges an at-repo suffix against the LIVE resolved
+  // sweep repo — `SWEEP_REPO`, not a constant. A row that hard-codes `objectui`
+  // as the sibling and `objectstack` as the own board therefore asserts THIS
+  // BOARD instead of the property, and inverts wholesale wherever the file is
+  // installed next: run verbatim in objectui on 2026-08-28 the suite failed
+  // exactly the four rows those two names feed, which is the one thing a file
+  // adopted BY COPY (see `resolveSweepRepo`) may not do. `OWN_BOARD` is the
+  // resolved repo's name half — the same half the predicate compares, derived
+  // here rather than shared, so a predicate that switched to the OWNER half
+  // still goes red. `SIBLING_BOARD` is a real neighbouring board picked so the
+  // two can never coincide, which is what stops the FOREIGN rows going
+  // vacuously green on a board that happens to be named after the specimen.
+  const OWN_BOARD = SWEEP_REPO.repo.split('/')[1];
+  const SIBLING_BOARD = OWN_BOARD === 'objectui' ? 'objectstack' : 'objectui';
+  const ownLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${OWN_BOARD} — ${status}`);
+  const siblingLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${SIBLING_BOARD} — ${status}`);
+
   // The lane parse, across the three measured title shapes.
   t('H32 lane: a plain domain lane is own-board', seatLane(seat(HELD)).lane, 'domain:spec');
   t('H32 lane: …and not foreign', seatLane(seat(HELD)).foreign, false);
-  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).foreign, true);
-  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).foreign, false);
-  t('H32 lane: …and keeps the bare lane label', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).lane, 'domain:devx');
+  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(siblingLaneSeat()).foreign, true);
+  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(ownLaneSeat()).foreign, false);
+  t('H32 lane: …and keeps the bare lane label', seatLane(ownLaneSeat()).lane, 'domain:devx');
   t('H32 lane: a repo-scoped seat has no countable lane', seatLane(seat('[PM seat] repo:cloud — 🟢 os-x')).lane, null);
   t('H32 lane: …and is foreign', seatLane(seat('[PM seat] repo:cloud — 🟢 os-x')).foreign, true);
   t('H32 lane: a lane-less seat (skills) is foreign', seatLane(seat('[PM seat] skills — 🟢 os-zhuang (session_x)')).foreign, true);
@@ -12255,7 +12273,7 @@ function selfTest() {
 
   // The held/vacant gate — an unheld seat is a ROUTING gap, never 怠工.
   t('H32 held: 🟢 with a holder', seatIsHeld(seat(HELD)), true);
-  t('H32 held: ⏳ vacant is NOT held', seatIsHeld(seat('[PM seat] domain:devx @ objectui — ⏳ vacant')), false);
+  t('H32 held: ⏳ vacant is NOT held', seatIsHeld(siblingLaneSeat('⏳ vacant')), false);
   t('H32 held: 🔴 收班 vacant is NOT held', seatIsHeld(seat('[PM seat] domain:spec — 🔴 收班 vacant · 上一班 os-warren')), false);
   t('H32 held: ⏸️ paused is NOT held', seatIsHeld(seat('[PM seat] domain:spec — ⏸️ paused')), false);
   t('H32 held: a Routine seat is excluded (no claim cadence of its own)', seatIsHeld(seat('[PM seat] triage (objectstack-wide) — 🟢 Routine')), false);
@@ -12267,7 +12285,7 @@ function selfTest() {
   t('H32: work IN FLIGHT is a working seat -> clean', h32SeatIdleOverQueue(seat(HELD), marker('Round-start marker — R6.', 600), busy, NOW32), null);
   t('H32: an EMPTY queue is a finished lane -> clean', h32SeatIdleOverQueue(seat(HELD), marker('Round-start marker — R6.', 600), { unclaimed: 0, inFlight: 0 }, NOW32), null);
   t('H32: a vacant seat is out of scope however deep the queue', h32SeatIdleOverQueue(seat('[PM seat] domain:spec — ⏳ vacant'), marker('收班', 6000), idleLane, NOW32), null);
-  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(seat('[PM seat] domain:devx @ objectui — 🟢 os-x'), marker('Round-start marker', 600), idleLane, NOW32), null);
+  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(siblingLaneSeat(), marker('Round-start marker', 600), idleLane, NOW32), null);
   t('H32: a non-seat card is out of scope', h32SeatIdleOverQueue({ ...issue(['pm:queue']), title: HELD }, marker('x', 600), idleLane, NOW32), null);
 
   // The threshold, at both edges of SEAT_IDLE_STALE_MINUTES.
@@ -12313,7 +12331,7 @@ function selfTest() {
 
   // The gathering gate buys a fetch only for seats the row can speak about.
   t('H32 gate: a held own-board seat is a candidate', h32NeedsSeatComments(seat(HELD)), true);
-  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')), false);
+  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(siblingLaneSeat()), false);
   t('H32 gate: a vacant seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:spec — ⏳ vacant')), false);
   t('H32 gate: a non-seat card buys no fetch', h32NeedsSeatComments(issue(['pm:queue'])), false);
 


### PR DESCRIPTION
Fixes #12994

`seatLane()` judges a seat title's at-repo suffix against the **live resolved sweep repo** — `at[2] !== SWEEP_REPO.repo.split('/')[1]` — never a constant. Six H32 self-test specimens spelled the board names literally, so four of them asserted **this board** rather than the property, and invert wholesale in any install that is not objectstack. That is the one thing a file adopted BY COPY (the whole design of `resolveSweepRepo`) may not do.

## What changed

Both board names are now derived, in the H32 block of the self-test:

```js
const OWN_BOARD = SWEEP_REPO.repo.split('/')[1];
const SIBLING_BOARD = OWN_BOARD === 'objectui' ? 'objectstack' : 'objectui';
const ownLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${OWN_BOARD} — ${status}`);
const siblingLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${SIBLING_BOARD} — ${status}`);
```

`OWN_BOARD` is the resolved repo's **name half** — the same half the predicate compares, re-derived here rather than shared through a helper, so a predicate that switched to the OWNER half still goes red. `SIBLING_BOARD` is a real neighbouring board picked by a ternary that makes the two provably distinct on every board, which is what stops the FOREIGN rows from going vacuously green on an install named after the specimen.

## Specimen table

| self-test row | before | after | verdict on a foreign board, before |
|:---|:---|:---|:---|
| ``H32 lane: an `@ sibling` suffix is FOREIGN`` | `@ objectui` | `siblingLaneSeat()` | **inverted** — failed |
| ``H32 lane: an `@ own-repo` suffix is NOT foreign`` | `@ objectstack` | `ownLaneSeat()` | **inverted** — failed |
| `H32: a FOREIGN lane is out of scope` | `@ objectui` | `siblingLaneSeat()` | **inverted** — failed |
| `H32 gate: a foreign-lane seat buys no fetch` | `@ objectui` | `siblingLaneSeat()` | **inverted** — failed |
| ``H32 lane: …and keeps the bare lane label`` | `@ objectstack` | `ownLaneSeat()` | passed, but measured the foreign path under an own-board name |
| `H32 held: ⏳ vacant is NOT held` | `@ objectui` | `siblingLaneSeat('⏳ vacant')` | passed; spelling only (`seatIsHeld` reads no repo) |

The last two never failed, so they are not part of the measured four; they are rebuilt because the same grep catches them and because on the objectui board their titles read as the opposite of what the surrounding prose calls them.

## The two-board proof

The resolver reads `PM_SWEEP_REPO` first, then `GITHUB_REPOSITORY`, at module load — so the suite runs against a chosen board with no code change. `--self-test` is deliberately exempt from the malformed-repo exit-2 refusal, so every leg below really ran.

| leg | before this PR | after |
|:---|:---|:---|
| own board, no env | `✓ 1551 cases pass.` (exit 0) | `✓ 1551 cases pass.` (exit 0) |
| `PM_SWEEP_REPO=objectstack-ai/objectui` | `✗ 4 of 1551 case(s) failed.` (exit 1) | `✓ 1551 cases pass.` (exit 0) |
| `PM_SWEEP_REPO=objectstack-ai/cloud` | not measured | `✓ 1551 cases pass.` (exit 0) |

**4 failures on the foreign board, 0 after.** The four were exactly the rows named above. Suite count is unchanged at **1551 before and 1551 after** — same rows, board-independent spelling. The third leg is a board neither literal anticipates, which is the actual claim being made.

## Ablation — the rebuilt rows can still fail

A derived specimen could be green everywhere because it stopped asserting anything. Inverting the predicate's comparison (`!==` to `===`) on the committed tree, mutation confirmed on disk by anchor counts (`removed=1 injected=0` before, `removed=0 injected=1` after) and by a blob hash differing from the HEAD blob:

```
ABLATED, own board                       ✗ 4 of 1551 case(s) failed.
ABLATED, PM_SWEEP_REPO=.../objectui      ✗ 4 of 1551 case(s) failed.
```

Both legs name the same four rows. Restoration was proved byte-identical to the HEAD blob (`9ffcdb76…`), with `git diff HEAD` and `git status --porcelain` both empty and the restored tree re-run green at 1551. There is no build or dist leg to rebuild here: this file is executed directly by node as source, with no package `exports` resolution.

## Gates

Derived union from `dispatch-gates.mjs --repo objectstack-ai/objectstack` (change set taken from the merge base by the tool itself), run under `os-verify-lock.sh` with slot `issue-12994-h32`; exit codes captured before any pipe, verdict lines quoted from each gate's own output.

| gate | exit | verdict |
|:---|:---|:---|
| `check:pm-half-states` | 0 | `✓ check-half-states self-test: 1551 cases pass.` |
| `check:pm-dispatch-gates` | 0 | `✓ dispatch-gates self-test: 834 cases pass.` |
| `bare-root-worklist.mjs --self-test` | 0 | `OK  self-test: 47 live row(s) … none stale, none missing, none contradicted.` |
| `check:partof-closing-keyword` | 0 | `✓ check-partof-closing-keyword self-test: 28 cases pass.` |
| `check:entry-guard` | 0 | `✓ 175 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `check:cross-package-test-inputs` | 0 | `OK: 23 package(s) read outside themselves, all declared` |
| `check-closing-keyword-parity.mjs` | 0 | `OK (3 parsers agree on all 9 keywords …)` |
| `check-ci-filter-parity.mjs` | 0 | `OK: all 117 declared cross-package glob(s) … covered` |
| `check:agent-test-spelling`, `check:bash32-floor`, `check:cli-command-ids`, `check:parse-guard`, `check:pnpm-filter-targets`, `check:watch-hint-literal`, `check-cross-package-test-inputs.mjs` | 0 | all green |
| `check-governed-merges.mjs --self-test` | 0 | `✓ 206 assertions` |
| `ci-failure.mjs --self-test` | 0 | green (it imports this file's transport classifier) |

The two convention-triggered obligations are included because this diff **edits a gate script**; the last two are the suites of scripts that read this file, which no path derivation names.

One entry needs its reading stated: bare `node scripts/check-partof-closing-keyword.mjs` with no `PR_BODY` exits 2 as a **usage refusal**, not a gate failure — its CI form takes the PR body. Re-run with this very body supplied, it is green.

## Scope and observations

- No predicate changed; no edit outside the self-test specimens. Diff is +24/-6 in one file, entirely inside the H32 block of `selfTest()`.
- **Observed, not widened:** the two `sweep repo:` rows that pin the objectstack leg against `DEFAULT_SWEEP_REPO` are coupled to that **constant**, not to the resolved repo — they were green in every leg above, including the foreign-board one. Different divergence class; untouched here, as the card directs.
- **Observed, unchanged:** with a *malformed* `PM_SWEEP_REPO` (a bare name), the own-board row fails — identically before and after this PR. The property has no witness in that state: the name half is `undefined` and no title suffix can equal it. Parity, not a regression, and not something this card's shape can fix without changing the case count.
- No changeset: `scripts/pm/**` publishes nothing user-visible. `skip-changeset` applied at PR-open.
- Once this lands, objectui's parity pin still carries three name-swap-only divergence entries (`h32-lane-own-board`, `h32-foreign-out-of-scope`, `h32-foreign-no-fetch`). Deleting them is that repo's standard `--resync` act on the parity gate — owed there after merge, deliberately not a rider on this PR.

Draft on purpose: the PM self-reviews at collection and lands it.

_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_