### PR TITLE
docs(pm-dispatch): correct rest-channel header's quoted default read order to the source's four-tier spelling

### DIFF
--- a/.claude/skills/pm-dispatch/references/rest-channel.md
+++ b/.claude/skills/pm-dispatch/references/rest-channel.md
@@ -1,8 +1,8 @@
 # REST 通道操作对照表(references —— 按需加载)
 
-出处:`platform-readings.md` API 配额段(**默认读序 git → REST → MCP/GraphQL** 的策略住那里,本表是
-逐操作的通道归属)。做一件事之前查一行:它有没有 REST 对应物。⛔ 不引用 issue 编号 ——
-每行自含边界与日期。
+出处:`platform-readings.md` API 配额段(**默认读序 git → payload → REST → MCP/GraphQL** 的策略住那
+里,本表是逐操作的通道归属)。做一件事之前查一行:它有没有 REST 对应物。⛔ 不引用 issue
+编号 —— 每行自含边界与日期。
 
 **通道边界**:容器 curl = App installation token,REST core 15,000/时、与 GraphQL 池独立计;出口代理按设
 计只放 **repo-scoped 路径**(`/repos/{o}/{r}/...`)加 `/rate_limit`,org 级端点未实测。⚠️ **✓ 按席位


### PR DESCRIPTION
Fixes #13008

The header of `.claude/skills/pm-dispatch/references/rest-channel.md` cites
`references/platform-readings.md` by name and quotes the default read order that lives
there — but quoted the **three**-tier form. The named source has carried the **four**-tier
order since 2026-08-25, when the zero-quota public-repo payload tier was added.

Pointer-style, as scoped: the spelling is matched to the source and no tier mechanics are
copied across. `platform-readings.md` stays the single home.

## Before / after, with byte counts

The one semantic change is the insertion of the missing tier, matched character-for-character
to the source line in `platform-readings.md`:

```text
before:  **默认读序 git → REST → MCP/GraphQL**
after:   **默认读序 git → payload → REST → MCP/GraphQL**
```

The inserted text is `payload → ` — 7 + 1 + 3 + 1 = **12 bytes** (the arrow U+2192 is 3
bytes in UTF-8).

Per-line, measured on disk rather than estimated:

| line | before | after | note |
|:--|--:|--:|:--|
| L3 | 118 B | 117 B | carries the corrected order |
| L4 | 119 B | 118 B | |
| L5 | 30 B | 44 B | absorbs the overflow; 76 B headroom remains |
| paragraph total | 268 B | 280 B | +12 B = exactly the insertion |
| **file** | **87 lines** | **87 lines** | ceiling 87, headroom 0 — net 0 |

L3 stood at 118 of 120 bytes, so the 12-byte insertion could not stay on it. The three-line
paragraph is re-wrapped to absorb it and comes back as three lines.

## Cut ledger

**Empty — no content was cut, moved out, or reworded.** The re-wrap moves whitespace only,
and that is checked rather than asserted:

- the new wrap is exactly `wrapLine`'s canonical output (the ratchet's own wrapper), and it
  is idempotent — re-wrapping the result reproduces it;
- re-joining the three new lines under the gate's own junction model reproduces the corrected
  paragraph **byte-identically**.

### One line a reviewer should not misread

New L5 reads `编号 —— 每行自含边界与日期。` and contains a **literal space** that was not in
the source before. The re-wrap did not introduce it; it made an existing one visible.

The old break between L4 and L5 sat between `—` (U+2014) and `每`. That is a narrow-to-wide
junction, and the CSS segment-break rule removes a break only between two East Asian **wide**
characters — so that break already rendered as a space for every agent reading the rendered
text. A faithful re-flow has to preserve it, which migrates it out of the line break and into
a literal space in the source. This is the self-concealing shape the ratchet's own header
documents for the adjacent ASCII-punctuation junction class; the same reading applies here.
Verified against the gate's own `atomize`/`breakLegal`, not by eye.

## Gates

Union derived mechanically — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(exit 0; 7 families matched), run under `scripts/pm/os-verify-lock.sh`. The two families the
dispatch named that the derivation did not produce (`pm-governed-prose`, `skill-frame-freshness`)
were run as well, so the set below is the union of both. Exits captured before any pipe.

| gate | exit | its own verdict line |
|:--|--:|:--|
| `check:pm-skill-ratchet` | 0 | `✓ ... rest-channel.md is 87 lines (ceiling 87; headroom 0).` |
| `check:pm-skill-ratchet` (line length) | 0 | `✓ ... rest-channel.md: every line is within 120 bytes (or structurally exempt).` |
| `check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `check:pm-governed-prose` | 0 | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces ... and claim no others.` |
| `check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `check:skill-frame-freshness` | 0 | `✓ check-skill-frame-freshness: the decision frame in this tree is current with origin/main (fetched just now).` |
| `check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 396 file(s) ...` |
| `check:doc-authoring` | 0 | `✓ doc authoring guard: 392 files clean — no bare metadata literals.` |
| `check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 425 files / 1453 TS blocks judged clean` |
| `check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 206 assertions ...` |

The line-length reading is taken **positively**: the ratchet prints it only on failure, so it
was read back through the gate's own exported `lengthVerdict` / `scanLineLengths`. Its
companion reading matters as much — the file uses **no** structural exemption at all
(`exempt classes used = []`), so all three edited lines pass on their own measured merits and
none is riding an exemption. Per-line headroom after the edit: L3 3 B, L4 2 B, L5 76 B.

`check:doc-formula-expressions` first exited 1 with `PREREQUISITE NOT MET — the workspace
package is not built`, which its own text calls out as **nothing measured**. It was recorded
as such, the dependency closure was built, and it was re-run to the real green above.

Gates run against `4220de5b9`, the branch head this body describes.

## Scope

One file, one paragraph. No changeset: this is an internal `.claude/` instruction surface and
publishes nothing, so the PR carries `skip-changeset`.

Governed surface (`.claude/**`) ⇒ **draft, and it stays draft**. No ready flip, no reviewers,
no auto-merge, no queue — the maintainer lands this by hand.

## Out-of-scope finding

The card asked whether any other file quotes the read order and drifted the same way. One
does: `references/review-checklist.md` line 33. It was filed as #13021 and is deliberately
**not** touched here — its parenthetical cites a *different* source (the dev contract, which
states the discipline as prose rather than as a ladder), so the corrected spelling is a
judgement call, not a mechanical copy, which fails the bounded in-place fix exemption.
#13021 remains open for triage.

_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_