### PR TITLE
docs(pm-dispatch): stop the review checklist from enumerating read-order tiers

### DIFF
--- a/.claude/skills/pm-dispatch/references/review-checklist.md
+++ b/.claude/skills/pm-dispatch/references/review-checklist.md
@@ -30,8 +30,8 @@
   产物,或本会移动它的具名探针;缺则记 INCONCLUSIVE。实测 2026-08-24(清 dist 与
   tsbuildinfo 的三腿重建):声明包 `dist/base.d.ts` 随探针移动又移回,转发文件与 entry
   barrel 三腿全同;同日三处误用。
-- **报告 `tests`/证据里有 git 本可回答的 API 读吗?**(dev 契约的读序是 git → REST →
-  MCP/GraphQL)判据:MCP `list_issues`/`search_issues` 一类 GraphQL 读,或重跑派发词已下发的去重读数
+- **报告 `tests`/证据里有 git 本可回答的 API 读吗?**(dev 契约的读序 git 先行)
+  判据:MCP `list_issues`/`search_issues` 一类 GraphQL 读,或重跑派发词已下发的去重读数
   —— fetch 之后本地 git 就答得了文件内容、diff、提交史与分支态。⛔ 不因此判 REWORK,ACCEPT
   照给,但把这条记进 ACCEPT 评论:复核不记它,退化就没有任何地方看得见。
 - **CI 收敛读数只属于复核侧**(维护者 2026-08-10 裁定;dev 的契约是草稿 PR 时点交报,报告里


### PR DESCRIPTION
Fixes #13021

The second site of the stale three-tier read order. The parenthetical on the
"does the report contain an API read git could have answered?" checklist item quoted
`git → REST → MCP/GraphQL` — three tiers, with the zero-quota payload tier missing.

## Shape chosen: (b) — keep the citation, stop enumerating tiers

The card offered two legal shapes. I took (b), the one the grading preferred, and it
reads clean. Two reasons, and the second is the one that decided it:

**1. The citation was already correct; only the enumeration was wrong.** The line cites
「dev 契约的读序」 — the dev contract, `.claude/agents/os-dev.md`. That is the right
authority for this checklist item, because the item grades a **dev's** report against the
**dev's** contract. Shape (a) would have re-pointed it at `platform-readings.md`, which is
the PM's own reference file — a worse citation for a dev-side obligation, adopted only to
make an enumeration copyable. Fixing the enumeration by moving the pointer would have
traded an accurate citation for a convenient one.

**2. The enumeration was load-bearing for nothing.** The item's criterion names the
offending reads explicitly on the next line (`MCP list_issues`/`search_issues`-class
GraphQL reads, or re-running the dispatched dedupe reading), and the justification it
needs from the read order is exactly one property: **git goes first**. The tail of the
ladder does zero work here. A pointer that lists no tiers cannot go stale again, which is
the whole failure mode this card exists to close — and it is the smaller maintenance
surface, since nothing mechanically holds a quoted ladder equal to its source.

No tier mechanics were copied into this file. The replacement reuses the house spelling
for the property — `platform-readings.md` states the same idea as **git 先行** — so the
wording is the corpus's, not this seat's invention. The dev contract backs the claim in
its own words at `.claude/agents/os-dev.md:58`: 「卡与评论先走 git 与它」.

## Before / after, with byte counts

Before (line 33 = 105 bytes, line 34 = 116 bytes):

```text
- **报告 `tests`/证据里有 git 本可回答的 API 读吗?**(dev 契约的读序是 git → REST →
  MCP/GraphQL)判据:MCP `list_issues`/`search_issues` 一类 GraphQL 读,或重跑派发词已下发的去重读数
```

After (line 33 = 97 bytes, line 34 = 104 bytes):

```text
- **报告 `tests`/证据里有 git 本可回答的 API 读吗?**(dev 契约的读序 git 先行)
  判据:MCP `list_issues`/`search_issues` 一类 GraphQL 读,或重跑派发词已下发的去重读数
```

Lines 35–36 of the bullet are byte-identical — the diff is 2 insertions / 2 deletions.

## Ratchet arithmetic

| reading | before | after | budget |
| --- | --- | --- | --- |
| file lines | 84 | 84 | ceiling 84, headroom 0 → **net 0** |
| line 33 bytes | 105 | 97 | cap 120 |
| line 34 bytes | 116 | 104 | cap 120 |
| file's widest line | 120 (line 10) | 120 (line 10) | cap 120, untouched |

Both edited lines were re-measured at dev time rather than taken from the handover; the
handover's 105 B for line 33 held. The line-length reading is taken **positively**, using
the gate's own code rather than my arithmetic against a recalled cap:

```text
gate MAX_LINE_BYTES = 120
edited line 33 = 97 bytes
edited line 34 = 104 bytes
file widest line = line 10 @ 120 bytes
scanLineLengths offenders = {"offenders":[],"exempt":{}}
```

**Cut ledger: none, and none was owed.** The edit spends no lines and no bytes — it is
net −20 bytes across two lines, adds zero lines, and moves no prose across a line
boundary, so there was nothing to pay for. No re-wrap was needed or performed.

## Gates

Union derived mechanically, not recalled: `node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack` (9 families matched; re-derived after the final commit and
unchanged). Run under the shared verify lock at head **e9e88fc17**, exits captured before
any pipe. The four extras beyond the derived nine are the dispatch-named
`check:pm-governed-prose` and `check:skill-frame-freshness`, plus `check:nul-bytes` and
the standalone required-set patrol.

| gate | exit | verdict line |
| --- | --- | --- |
| `check:pm-skill-ratchet` | 0 | `✓ ... review-checklist.md is 84 lines (ceiling 84; headroom 0).` and `✓ ... widest table row is 0 bytes (pin 0; headroom 0).`; `✓ check-skill-line-ratchet self-test: 111 cases pass.` |
| `check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `check:pm-governed-prose` | 0 | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces ... and claim no others.` |
| `check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 206 assertions (...)` |
| `check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `check:skill-frame-freshness` | 0 | `✓ check-skill-frame-freshness: the decision frame in this tree is current with origin/main (fetched just now).` |
| `check:doc-authoring` | 0 | `✓ doc authoring guard: 48 published skill files clean — no internal issue-id references.` |
| `check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 396 file(s) ...` |
| `check:required-contexts` | 0 | `✓ check-required-contexts: 6 required context name(s) pinned across 2 workflow(s) ...` |
| `node scripts/check-required-contexts.mjs` | 0 | same verdict, run standalone as the patrol workflow runs it |
| `check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 425 files / 1453 TS blocks judged clean by @objectstack/formula.` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 7232 text file(s) ... no raw ASCII control bytes).` |

`check:doc-formula-expressions` first came back exit 1 with `PREREQUISITE NOT MET — the
workspace package @objectstack/formula is not built` and its own line saying *"Nothing was
measured"*. That is a NOT MEASURED reading, not a red gate: `@objectstack/formula` and
`@objectstack/lint` were built, and the gate then ran and passed. The green above is the
post-build run.

## Scope

One file, two lines. No changeset — the surface is `.claude/**` internal agent tooling,
published nowhere; `skip-changeset` is applied. Governed surface, so this is **draft
only**: no ready flip, no reviewers, no auto-merge, no queue.

The card's closing section — that nothing mechanically holds a quoted policy equal to its
source, and a third site could appear the same way — is a design question and is
deliberately not addressed here.

Session: https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq

_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_