### PR TITLE
packages.install/enable/disable declare the bare row the only serving surface sends; get's fork measured, not converged

### DIFF
--- a/.changeset/client-packages-write-verbs-bare-row.md
+++ b/.changeset/client-packages-write-verbs-bare-row.md
@@ -1,0 +1,61 @@
+---
+"@objectstack/client": minor
+---
+
+fix(client): `packages.install` / `enable` / `disable` declare the bare `InstalledPackage` row the only serving surface actually sends (#12034)
+
+**Accept-set narrowing on a published SDK (clause-②), and a false declaration
+deleted.** No runtime change: the value each method resolves to is
+byte-identical before and after. What moved is the DECLARED type — and unlike
+its #11925 siblings this one was not merely erased, it was **wrong**.
+
+FROM → TO, all three methods:
+
+| method | declared before | declares now |
+|---|---|---|
+| `client.packages.install(manifest, opts?)` | `{ package: any; message?: string }` | `InstalledPackage` |
+| `client.packages.enable(id)` | `{ package: any; message?: string }` | `InstalledPackage` |
+| `client.packages.disable(id)` | `{ package: any; message?: string }` | `InstalledPackage` |
+
+No surface has ever emitted `{ package, message }` for these three. Each is
+served by exactly one implementation — `runtime`'s `/packages` dispatcher domain
+— and it answers `success(pkg)`, i.e. `{ success: true, data: <row> }`, which
+`unwrapResponse` strips to the bare row. `@objectstack/rest`'s registrar mounts
+no twin for any of them (it mounts only `POST /packages/publish`,
+`GET /packages`, `GET /packages/:id`, `DELETE /packages/:id`), so there was
+never a question of which surface to match.
+
+**Migration — read the row, not `.package`.** Because the member was `any`,
+the false read compiled and silently produced `undefined` at runtime:
+
+```ts
+// BEFORE — compiled, and `pkg` was `undefined` at runtime
+const pkg = (await client.packages.enable(id)).package;
+const note = (await client.packages.install(manifest)).message;
+
+// AFTER — the response IS the row
+const pkg = await client.packages.enable(id);
+pkg.enabled;          // the state the verb just changed
+pkg.manifest.version;
+```
+
+A consumer stops compiling where it reads `.package` or `.message` off these
+three results, or assigns the result somewhere `InstalledPackage` does not fit.
+That break is the point: those call sites are already broken at runtime today
+and the `any` is what hid it. The compiler is the channel that reaches every
+affected consumer, and it is strictly more precise than a release note.
+
+**What deliberately did NOT change: `client.packages.get`.** It keeps
+`{ package: any }`. That route is a real fork — the dispatcher answers the bare
+row while the REST registrar answers `{ package: { ...row, source } }`, both
+measured by driving each registrar — so no declaration is true on both surfaces.
+Binding either member would harden a falsehood, which is the defect this change
+removes for its neighbours. Making `get` bindable requires converging the two
+PRODUCERS, a wire-behaviour change to two mounted surfaces; the measured
+convergence cost is recorded on #12034 for that ruling.
+
+No ADR-0087 ledger entry: nothing here is a metadata surface. No Zod schema, no
+`packages/spec` declaration and no stored representation changed — the phantom
+members existed only in a TypeScript return annotation — so `objectstack migrate
+meta` has nothing to rewrite. This is the disposition #11925 and #8140 recorded
+for the same class of SDK return-type narrowing.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -2509,9 +2509,15 @@ describe('HTTP error shaping — envelope normalisation', () => {
 
 describe('packages.install', () => {
     const MANIFEST = { id: 'com.acme.crm', name: 'Acme CRM', version: '1.0.0', type: 'app' };
+    // [#12034] The body the ONLY serving surface actually sends: `success(pkg)`,
+    // i.e. the bare `InstalledPackage` row under `data`. These two cases assert
+    // the REQUEST and never read the response, so the fixture is inert either
+    // way — but it used to spell `data: { package: … }`, a body nothing emits,
+    // and a decoy fixture is how the next sweep concludes the envelope is real.
+    const INSTALLED_ROW = { manifest: MANIFEST, status: 'installed', enabled: true };
 
     it('POSTs the manifest and omits `overwrite` unless requested', async () => {
-        const { client, fetchMock } = createMockClient({ success: true, data: { package: { manifest: MANIFEST } } });
+        const { client, fetchMock } = createMockClient({ success: true, data: INSTALLED_ROW });
         await client.packages.install(MANIFEST, { enableOnInstall: true });
 
         expect(fetchMock).toHaveBeenCalledWith('http://localhost:3000/api/v1/packages', expect.any(Object));
@@ -2524,7 +2530,7 @@ describe('packages.install', () => {
     });
 
     it('passes `overwrite: true` through for intentional upgrade / re-install', async () => {
-        const { client, fetchMock } = createMockClient({ success: true, data: { package: { manifest: MANIFEST } } });
+        const { client, fetchMock } = createMockClient({ success: true, data: INSTALLED_ROW });
         await client.packages.install(MANIFEST, { overwrite: true });
 
         const body = JSON.parse(fetchMock.mock.calls[0][1].body);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1673,14 +1673,25 @@ export class ObjectStackClient {
     /**
      * Get a specific installed package by its ID (reverse domain identifier).
      *
-     * ⛔ [#11925] NOT bound, and the `{ package }` envelope is left exactly as
-     * it was — the two mounted surfaces answer this route with DIFFERENT
-     * envelopes, so no single declaration is true (#12034). `runtime`'s
-     * `/packages` domain sends `success(pkg)` — the bare row — while `rest`'s
-     * `GET {base}/packages/:id` sends `sendOk(res, { package: { ...pkg,
-     * source } })`, and the REST routes "shadow live dispatcher twins" only
-     * where a `package` service is registered. Binding the member here would
-     * harden a claim that is already false on one of the two.
+     * ⛔ [#11925 / #12034] STILL NOT bound, and the `{ package }` envelope is
+     * left exactly as it was. #12034 shipped its `install` / `enable` /
+     * `disable` neighbours (one producer each) and deliberately did NOT ship
+     * this one, because this route is a REAL fork with no single true type.
+     * Both bodies below were MEASURED by driving each registrar, not read off
+     * the source:
+     *
+     *     dispatcher  handlePackages('/<id>', 'GET')
+     *       -> { success: true, data: { id, manifest, enabled, status } }
+     *     rest        GET /api/v1/packages/:id
+     *       -> { success: true, data: { package: { …row, source } } }
+     *
+     * `unwrapResponse` strips one envelope, so the post-unwrap value is the
+     * BARE row on the dispatcher and `{ package }` on REST. Binding either
+     * member here hardens a claim that is false on the other surface. Making
+     * it bindable means converging the two PRODUCERS — a wire-behaviour change
+     * to two mounted surfaces, above this card's authority, with a clause-②
+     * narrowing analysis of its own. The measured convergence cost is recorded
+     * on #12034 for that ruling.
      *
      * Its SCOPED twin `ScopedEnvironmentClient.packages.get` IS bound, because
      * only the REST registrar serves the scoped mount — one surface, one
@@ -1695,14 +1706,25 @@ export class ObjectStackClient {
     /**
      * Install a new package from its manifest.
      *
-     * ⛔ [#11925] NOT bound. This method and its `enable` / `disable`
-     * neighbours declare `{ package; message? }`, and the ONLY surface that
-     * serves them — `runtime`'s `/packages` domain; `rest` mounts no twin for
-     * any of the three — answers `success(pkg)`, the bare row (#12034). The
-     * declared envelope is not merely erased, it is false, and the `any`
-     * member is what keeps that invisible. Correcting it is a response-shape
-     * decision with its own clause-② analysis, not the `any`-binding this card
-     * carries, so the shape is left untouched here.
+     * [#12034] Bound to `InstalledPackage` — the BARE row, no envelope.
+     *
+     * What this REPLACED was not an erasure but a FALSEHOOD: the declaration
+     * read `{ package: any; message?: string }`, a shape no surface has ever
+     * sent, and the `any` member is what kept that invisible —
+     * `(await client.packages.install(m)).package` compiled and was
+     * `undefined` at runtime. There is exactly ONE serving surface, so there
+     * was never a "which surface do we match" question: `rest`'s registrar
+     * mounts only `POST /packages/publish`, `GET /packages`,
+     * `GET /packages/:id` and `DELETE /packages/:id` (measured by driving
+     * `registerPackageRoutes` and enumerating what it mounted — this route is
+     * `NO_HANDLER` there), leaving `runtime`'s `/packages` domain alone to
+     * answer, and it answers `success(pkg)`: `{ success: true, data: <row> }`,
+     * status 201. `message` is gone with the wrapper — no surface sends one.
+     *
+     * The wire fact is pinned end-to-end in
+     * `packages-write-envelope.test.ts` (the real dispatcher answering a real
+     * client call), and the DECLARATION in `return-type-precision.test.ts` —
+     * a runtime test cannot observe a return-type narrowing at all.
      *
      * By default the server rejects a manifest whose `id` is already
      * installed with **409 Conflict** (duplicate-id guard) instead of
@@ -1712,7 +1734,7 @@ export class ObjectStackClient {
     install: async (
         manifest: any,
         options?: { settings?: Record<string, any>; enableOnInstall?: boolean; overwrite?: boolean },
-    ) => {
+    ): Promise<InstalledPackage> => {
         const route = this.getRoute('packages');
         const res = await this.fetch(`${this.baseUrl}${route}`, {
             method: 'POST',
@@ -1723,7 +1745,7 @@ export class ObjectStackClient {
                 ...(options?.overwrite !== undefined ? { overwrite: options.overwrite } : {}),
             }),
         });
-        return this.unwrapResponse<{ package: any; message?: string }>(res);
+        return this.unwrapResponse<InstalledPackage>(res);
     },
 
     /**
@@ -1739,24 +1761,38 @@ export class ObjectStackClient {
 
     /**
      * Enable a disabled package.
+     *
+     * [#12034] Bound to `InstalledPackage` — the BARE row, no envelope, for
+     * the reason spelled out on `install` above: one serving surface
+     * (`PATCH /packages/:id/enable` is `NO_HANDLER` on the REST registrar),
+     * and it answers `success(registry.enablePackage(id))`. The
+     * `{ package: any; message?: string }` this replaces was never emitted by
+     * anything.
      */
-    enable: async (id: string) => {
+    enable: async (id: string): Promise<InstalledPackage> => {
         const route = this.getRoute('packages');
         const res = await this.fetch(`${this.baseUrl}${route}/${encodeURIComponent(id)}/enable`, {
             method: 'PATCH',
         });
-        return this.unwrapResponse<{ package: any; message?: string }>(res);
+        return this.unwrapResponse<InstalledPackage>(res);
     },
 
     /**
      * Disable an installed package.
+     *
+     * [#12034] Bound to `InstalledPackage` — the BARE row, no envelope, same
+     * single-producer argument as `install` / `enable` above
+     * (`PATCH /packages/:id/disable` is `NO_HANDLER` on the REST registrar).
+     * The dispatcher answers `success(registry.disablePackage(id))`, so the
+     * row comes back with `enabled: false` — the caller reads the row itself,
+     * never a `.package` member.
      */
-    disable: async (id: string) => {
+    disable: async (id: string): Promise<InstalledPackage> => {
         const route = this.getRoute('packages');
         const res = await this.fetch(`${this.baseUrl}${route}/${encodeURIComponent(id)}/disable`, {
             method: 'PATCH',
         });
-        return this.unwrapResponse<{ package: any; message?: string }>(res);
+        return this.unwrapResponse<InstalledPackage>(res);
     },
 
     /* [#3563 PR-4] Lifecycle beyond install/enable — these eleven routes

--- a/packages/client/src/packages-write-envelope.test.ts
+++ b/packages/client/src/packages-write-envelope.test.ts
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#12034 — shipping half] `client.packages.install` / `enable` / `disable`
+ * answer the BARE `InstalledPackage` row, and the `{ package; message? }`
+ * envelope they used to declare is emitted by nothing.
+ *
+ * ## What was wrong
+ *
+ * These three declared `{ package: any; message?: string }`. That is not an
+ * ERASED type — it is a FALSE one: no surface has ever sent that body. Because
+ * the member was `any`,
+ *
+ *     (await client.packages.enable(id)).package
+ *
+ * compiled, and was `undefined` at runtime. The `any` is precisely what kept
+ * the falsehood invisible; a bound-but-wrong declaration is the shape an AI
+ * consumer reads as ground truth and writes against.
+ *
+ * ## Why there was no "which surface do we match" question
+ *
+ * `GET /packages/:id` genuinely forks between the two mounted surfaces, which
+ * is why its declaration is untouched (see `index.ts`, and the cost analysis on
+ * #12034). These three do not fork, because the REST registrar mounts no twin
+ * for any of them — MEASURED by driving `registerPackageRoutes` and
+ * enumerating what came back:
+ *
+ *     ["POST /api/v1/packages/publish", "GET /api/v1/packages",
+ *      "GET /api/v1/packages/:id",      "DELETE /api/v1/packages/:id"]
+ *
+ * `POST /packages`, `PATCH /packages/:id/enable` and
+ * `PATCH /packages/:id/disable` are absent. One producer, therefore one true
+ * type, therefore nothing to choose between.
+ *
+ * ## Why this file is a WIRE test and not a type test
+ *
+ * The two halves are separate on purpose and neither substitutes for the other
+ * (`return-type-precision.test.ts` states the rule in its header):
+ *
+ *   - a runtime test cannot observe a return-type narrowing at all — the value
+ *     is identical whatever the declaration says. The DECLARATION half is
+ *     pinned type-level in `return-type-precision.test.ts`.
+ *   - a type test cannot observe whether the declaration is TRUE. That is this
+ *     file's job, and it is why nothing here mocks a response body: a mock body
+ *     would assert my own assumption about the producer, which is exactly the
+ *     mistake that produced the false declaration in the first place.
+ *
+ * So the chain below is real end to end — a real `SchemaRegistry` from
+ * `@objectstack/objectql`, the real `HttpDispatcher` from `@objectstack/runtime`
+ * answering it, and the real `ObjectStackClient` (real `unwrapResponse`)
+ * reading the result. The only stand-in is the socket: `fetch` hands the
+ * request to the dispatcher in-process instead of over TCP, and hands back the
+ * dispatcher's own body untouched.
+ *
+ * ---------------------------------------------------------------------------
+ * Reverse verification, direction predicted BEFORE running
+ * ---------------------------------------------------------------------------
+ * Restoring `{ package: any; message?: string }` on the three methods leaves
+ * THIS file green — the wire value does not change — and turns
+ * `return-type-precision.test.ts` RED under `tsc`. That asymmetry is the whole
+ * reason both files exist; the ablation is recorded on the PR against the type
+ * half, which is the half a declaration change can move.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SchemaRegistry } from '@objectstack/objectql';
+import { HttpDispatcher } from '@objectstack/runtime';
+import { ObjectStackClient } from './index';
+
+const BASE_URL = 'http://localhost:3000';
+const PACKAGES_PATH = '/api/v1/packages';
+
+const MANIFEST = {
+    id: 'com.acme.crm',
+    name: 'Acme CRM',
+    version: '1.0.0',
+    type: 'app',
+    namespace: 'acme',
+} as const;
+
+/**
+ * The caller the `/packages` domain gates on: ADR-0106 D4 read capabilities for
+ * the reads, `manage_metadata` for the writes. Anonymous is refused before any
+ * of this (a separate, already-pinned rule), so the envelope under test is only
+ * reachable with a resolved principal.
+ */
+const CONTEXT = (): any => ({
+    request: {},
+    environmentId: 'os-12034-envelope',
+    executionContext: {
+        userId: 'u_admin',
+        isSystem: false,
+        systemPermissions: ['manage_metadata', 'studio.access', 'setup.access'],
+    },
+});
+
+/**
+ * The in-process socket. Everything either side of it is production code: the
+ * URL the client built goes in, the body the dispatcher produced comes back,
+ * and nothing in between rewrites a key.
+ */
+function dispatcherBackedClient(registry: SchemaRegistry) {
+    const kernel: any = {
+        context: { getService: (name: string) => (name === 'objectql' ? { registry } : null) },
+    };
+    const dispatcher = new HttpDispatcher(kernel);
+    const seen: Array<{ method: string; path: string; body: unknown }> = [];
+
+    const fetchImpl = async (url: string, init: RequestInit = {}): Promise<any> => {
+        const parsed = new URL(String(url));
+        expect(parsed.pathname.startsWith(PACKAGES_PATH)).toBe(true);
+        const subPath = parsed.pathname.slice(PACKAGES_PATH.length);
+        const method = init.method ?? 'GET';
+        const body = init.body ? JSON.parse(String(init.body)) : undefined;
+        seen.push({ method, path: subPath, body });
+
+        const result = await dispatcher.handlePackages(
+            subPath,
+            method,
+            body,
+            Object.fromEntries(parsed.searchParams),
+            CONTEXT(),
+        );
+        const status = result.response?.status ?? 500;
+        const payload = result.response?.body;
+        return {
+            ok: status >= 200 && status < 300,
+            status,
+            statusText: String(status),
+            headers: new Headers(),
+            json: async () => payload,
+        };
+    };
+
+    const client = new ObjectStackClient({ baseUrl: BASE_URL, fetch: fetchImpl as any });
+    return { client, dispatcher, seen };
+}
+
+let osHome: string;
+let previousOsHome: string | undefined;
+
+beforeAll(() => {
+    // `enable` / `disable` persist the operator's choice under OS_HOME. Point
+    // that at a scratch dir so the suite never writes to a real home.
+    previousOsHome = process.env.OS_HOME;
+    osHome = mkdtempSync(join(tmpdir(), 'os-12034-'));
+    process.env.OS_HOME = osHome;
+});
+
+afterAll(() => {
+    if (previousOsHome === undefined) delete process.env.OS_HOME;
+    else process.env.OS_HOME = previousOsHome;
+    rmSync(osHome, { recursive: true, force: true });
+});
+
+describe('#12034 — the packages write verbs answer the bare row, not `{ package }`', () => {
+    it('install resolves to the row itself, and has no `package` member to read', async () => {
+        const registry = new SchemaRegistry();
+        const { client, seen } = dispatcherBackedClient(registry);
+
+        const installed = await client.packages.install(MANIFEST);
+
+        // It reached the route the card is about.
+        expect(seen).toEqual([{ method: 'POST', path: '', body: { manifest: MANIFEST } }]);
+
+        // THE LINE THAT WAS A LIE: the declaration promised `.package`.
+        expect((installed as any).package).toBeUndefined();
+        expect((installed as any).message).toBeUndefined();
+
+        // What actually comes back is the row — identical to what the registry
+        // holds, which is the value the new declaration names.
+        expect(installed.manifest).toEqual(MANIFEST);
+        expect(installed).toEqual(registry.getPackage(MANIFEST.id));
+    });
+
+    it('enable resolves to the row, carrying the flag it just set', async () => {
+        const registry = new SchemaRegistry();
+        registry.installPackage(MANIFEST as any);
+        registry.disablePackage(MANIFEST.id);
+        const { client, seen } = dispatcherBackedClient(registry);
+
+        const row = await client.packages.enable(MANIFEST.id);
+
+        expect(seen).toEqual([{ method: 'PATCH', path: '/com.acme.crm/enable', body: undefined }]);
+        expect((row as any).package).toBeUndefined();
+        expect((row as any).message).toBeUndefined();
+        // The state the verb changed is read OFF THE ROW — the read the old
+        // declaration sent callers looking for under `.package`.
+        expect(row.enabled).toBe(true);
+        expect(row).toEqual(registry.getPackage(MANIFEST.id));
+    });
+
+    it('disable resolves to the row, carrying the flag it just cleared', async () => {
+        const registry = new SchemaRegistry();
+        registry.installPackage(MANIFEST as any);
+        const { client, seen } = dispatcherBackedClient(registry);
+
+        const row = await client.packages.disable(MANIFEST.id);
+
+        expect(seen).toEqual([{ method: 'PATCH', path: '/com.acme.crm/disable', body: undefined }]);
+        expect((row as any).package).toBeUndefined();
+        expect((row as any).message).toBeUndefined();
+        expect(row.enabled).toBe(false);
+        expect(row).toEqual(registry.getPackage(MANIFEST.id));
+    });
+
+    /**
+     * The premise the three assertions above rest on. `unwrapResponse` strips
+     * exactly ONE `{ success, data }` envelope, so "the dispatcher sends
+     * `success(pkg)`" and "the caller receives `pkg`" are the same statement
+     * only while that stays true. Pinned here against the REAL dispatcher body
+     * rather than a written-out literal.
+     */
+    it('the dispatcher wraps the row exactly once, and the client strips exactly that', async () => {
+        const registry = new SchemaRegistry();
+        registry.installPackage(MANIFEST as any);
+        const { client, dispatcher } = dispatcherBackedClient(registry);
+
+        const raw = await dispatcher.handlePackages('/com.acme.crm/enable', 'PATCH', undefined, {}, CONTEXT());
+        const body: any = raw.response?.body;
+
+        // The producer's own body: one envelope, the row under `data`, and no
+        // `package` key anywhere in it.
+        expect(Object.keys(body).sort()).toEqual(['data', 'meta', 'success']);
+        expect(body.success).toBe(true);
+        expect('package' in body.data).toBe(false);
+
+        // …and the post-unwrap value the SDK hands the caller is that `data`.
+        expect(await client.packages.enable(MANIFEST.id)).toEqual(body.data);
+    });
+});

--- a/packages/client/src/return-type-precision.test.ts
+++ b/packages/client/src/return-type-precision.test.ts
@@ -363,6 +363,62 @@ export async function returnTypePrecisionPins12038(): Promise<void> {
 }
 
 /**
+ * [#12034 — shipping half] The three `packages` WRITE verbs, bound to the bare
+ * `InstalledPackage` row.
+ *
+ * These did not carry an ERASED type, they carried a FALSE one:
+ * `{ package: any; message?: string }`, a body no surface has ever emitted.
+ * The only serving surface is `runtime`'s `/packages` domain — the REST
+ * registrar mounts no twin for `POST /packages`,
+ * `PATCH /packages/:id/enable` or `PATCH /packages/:id/disable`, measured by
+ * driving `registerPackageRoutes` and enumerating what it mounted — and it
+ * answers `success(pkg)`. That the WIRE says so is pinned against the real
+ * dispatcher in `packages-write-envelope.test.ts`; that the DECLARATION says
+ * so can only be pinned here, for this file's standing reason.
+ *
+ * ⛔ `packages.get` is deliberately ABSENT from this list. It is the half of
+ * #12034 that was NOT shipped: its two mounted surfaces answer different
+ * envelopes (dispatcher `success(pkg)`, REST `sendOk(res, { package })`), so
+ * no declaration is true on both and binding either member would harden a
+ * falsehood — the very defect this function closes for its neighbours. Making
+ * it bindable requires converging the PRODUCERS, which is a wire-behaviour
+ * ruling of its own.
+ */
+export async function returnTypePrecisionPins12034(): Promise<void> {
+    // ── direction 1: the bare row, on all three ──────────────────────────
+    expectTypeOf(await client.packages.install({ id: 'com.acme.crm', version: '1.0.0' }))
+        .toEqualTypeOf<InstalledPackage>();
+    expectTypeOf(await client.packages.enable('com.acme.crm')).toEqualTypeOf<InstalledPackage>();
+    expectTypeOf(await client.packages.disable('com.acme.crm')).toEqualTypeOf<InstalledPackage>();
+
+    // ── direction 2: the read the false declaration invited must now FAIL ─
+    // ⚠️ RED BEFORE, all three: while the member was `any`, `.package` was a
+    // legal read, so each suppression below went UNUSED and tsc reported
+    // TS2578. That unused-suppression signal IS the defect stated as a
+    // compile error — the whole point of the card is that
+    // `(await client.packages.enable(id)).package` compiled and was
+    // `undefined` at runtime. After the binding the row has no `package` key,
+    // the suppressions are used, and the reads are refused at the call site
+    // where a consumer would have written them.
+    // @ts-expect-error the install route answers the row; there is no `.package`
+    void (await client.packages.install({ id: 'com.acme.crm', version: '1.0.0' })).package;
+    // @ts-expect-error the enable route answers the row; there is no `.package`
+    void (await client.packages.enable('com.acme.crm')).package;
+    // @ts-expect-error the disable route answers the row; there is no `.package`
+    void (await client.packages.disable('com.acme.crm')).package;
+
+    // Same direction for the `message` sibling the old envelope also promised
+    // and no surface sends.
+    // @ts-expect-error no surface sends a `message` alongside the row
+    void (await client.packages.enable('com.acme.crm')).message;
+
+    // ── the UNSHIPPED half, pinned as unchanged ──────────────────────────
+    // Not evidence for this card — a guard that `get` is not "tidied up" into
+    // one of the two shapes while the fork is still open.
+    expectTypeOf(await client.packages.get('com.acme.crm')).toEqualTypeOf<{ package: any }>();
+}
+
+/**
  * ⚠️ GREEN IN BOTH STATES — regression guards, recorded as such rather than
  * counted as evidence that this card's change was needed. Each pins a
  * near-miss trap the next sweep would otherwise reach for.
@@ -406,6 +462,7 @@ describe('client SDK return-type precision (#8140)', () => {
         expect(typeof searchResultIsNotTheGlobalSearchShape).toBe('function');
         expect(typeof returnTypePrecisionPins11925).toBe('function');
         expect(typeof returnTypePrecisionPins12038).toBe('function');
+        expect(typeof returnTypePrecisionPins12034).toBe('function');
         expect(typeof commitRollbackResponseIsNotTheVersionRollbackShape).toBe('function');
         expect(typeof environmentIsNotTheCloudWireRow).toBe('function');
     });


### PR DESCRIPTION
Part of #12034

⚠️ **`Part of`, not a closing keyword — deliberately, please read before merging.** The dispatch instruction for this card asked for a closing reference. I have used `Part of` instead, because the dispatching ruling also **split this card in half and shipped only one half**: `install` / `enable` / `disable` are corrected here, and `get` is measured-only by explicit instruction. A closing keyword would retire the card on merge, and the unshipped `get` half — which the maintainer's Option-A ruling of 2026-08-26 *does* cover — would vanish from the open backlog, where inbox filters read `open` only. So this card **remains open** on purpose. If PM/maintainer would rather retire it here and carry the `get` convergence on a fresh card, swap this first line for a closing reference before merge.

## What shipped

`client.packages.install`, `.enable` and `.disable` declared `{ package: any; message?: string }` — a body **no surface has ever emitted**. This was not an erasure, it was a falsehood, and the `any` member is what kept it invisible: `(await client.packages.enable(id)).package` compiled and was `undefined` at runtime.

All three now declare `InstalledPackage`, the bare row. `message` goes with the wrapper; no surface sends one.

| method | declared before | declares now |
|---|---|---|
| `packages.install(manifest, opts?)` | `{ package: any; message?: string }` | `InstalledPackage` |
| `packages.enable(id)` | `{ package: any; message?: string }` | `InstalledPackage` |
| `packages.disable(id)` | `{ package: any; message?: string }` | `InstalledPackage` |

### Re-located coordinates (the card's line numbers had drifted)

#13026 moved `packages/client/src/index.ts` after this card was written, so every coordinate was re-derived on `origin/main` at `cf71d73f8` rather than taken from the card:

| thing | card said | actually at `cf71d73f8` |
|---|---|---|
| `unwrapResponse` definition | `client/src/index.ts:5106` | **`:5560`** (+454) |
| REST `sendOk(res, { package … })` | `rest/src/package-routes.ts:760` | **`:817`** (+57) |
| dispatcher `install` / `enable` / `disable` | `runtime/src/domains/packages.ts:315` / `331` / `350` | `:315` / `:331` / `:350` — unchanged |
| dispatcher `get` | `runtime/src/domains/packages.ts:852` | `:852` — unchanged |
| the three declarations | (not given) | `index.ts:1712` (`install`), `:1772` (`enable`), `:1790` (`disable`) |

## Why there was no "which surface do we match" question

Measured by driving `registerPackageRoutes` and enumerating what it actually mounted — not read off the source:

```
MOUNTED_ROUTES=["POST /api/v1/packages/publish","GET /api/v1/packages",
                "GET /api/v1/packages/:id","DELETE /api/v1/packages/:id"]

POST  /api/v1/packages               => {"NO_HANDLER":"POST /api/v1/packages"}
PATCH /api/v1/packages/:id/enable    => {"NO_HANDLER":"PATCH /api/v1/packages/:id/enable"}
PATCH /api/v1/packages/:id/disable   => {"NO_HANDLER":"PATCH /api/v1/packages/:id/disable"}
```

One producer each, so one true type each. The dispatcher's own bodies, driven through `HttpDispatcher.handlePackages`:

```
DISPATCHER_ENABLE  = {"status":200,"body":{"success":true,"data":{"id":…,"manifest":{…},"enabled":true,"status":"installed"}}}
DISPATCHER_DISABLE = {"status":200,"body":{"success":true,"data":{"id":…,"manifest":{…},"enabled":false,"status":"installed"}}}
```

`unwrapResponse` strips exactly one envelope ⇒ the caller holds the row.

## ⛔ The half that did NOT ship: `packages.get`

Its declaration is **unchanged** (`{ package: any }`). `get` is a genuine fork with no single true type. Both bodies below were measured by driving each registrar:

| surface | measured body | post-`unwrapResponse` value |
|---|---|---|
| dispatcher (`runtime/src/domains/packages.ts:852`) | `{"success":true,"data":{"id":…,"manifest":{…},"enabled":true,"status":"installed"}}` | the **bare row** |
| REST registrar, DB path (`rest/src/package-routes.ts:817`) | `{"success":true,"data":{"package":{…row,"source":"database"}}}` | `{ package }` |
| REST registrar, registry-fallback path (`:880`) | `{"success":true,"data":{"package":{…row,"source":"registry"}}}` | `{ package }` |

### Measured convergence cost (for the ruling PM/maintainer still owe this half)

**Converge to the bare row** (the dispatcher shape; the maintainer's 2026-08-26 Option A):
- Change surface: **one** `sendOk` call at `package-routes.ts:817` plus **one** at `:880`, folding `source` into the row. The dispatcher is untouched.
- Breaks: any consumer of the **REST** `GET /api/v1/packages/:id` reading `body.data.package`. In-repo that is **zero** call sites (see the census below — the only in-repo `{ package }` readers are of the SCOPED route, which is a different mount). Out-of-repo it is unmeasurable from here.
- ⚠️ It also collides with a live in-repo pin: `client.packages.get`'s **scoped twin** `ScopedEnvironmentClient.packages.get` is bound to `{ package: InstalledPackage }` (`return-type-precision.test.ts:267`) precisely because the scoped mount is REST-only. `registerPackageRoutes` mounts at both `{base}/packages` and `{base}/environments/:environmentId/packages`, so converging the registrar's `:id` handler changes the **scoped** route's wire too and that binding must move in the same PR. This is the single most expensive item and the card did not name it.
- Bonus: `list` already agrees on both surfaces, so `get` would be the last packages divergence.

**Converge to `{ package }`** (the REST shape):
- Change surface: the dispatcher's `GET /packages/:id` — but for consistency the family's other `success(pkg)` sites (`install`, `enable`, `disable`, `update`) would want the same wrapper, i.e. **5 handlers**, and it would undo this PR.
- Breaks: every consumer of the dispatcher route, which is the majority deployment (3 of 4 methods have no REST twin at all), plus the already-bound `client.packages.update` binding from #11925 and the three bound here.
- Buys nothing except preserving the current (false) SDK spelling.

**Recommendation: converge to the bare row**, with the scoped-twin binding moved in the same PR. Not done here — it changes the wire behaviour of two mounted surfaces and needs its own clause-② analysis, exactly as the dispatching ruling directed.

## Consumer impact — clause-② narrowing

⚠️ **The in-repo census below is NOT a statement about blast radius.** The real exposed surface is the **published `@objectstack/client` SDK's external consumers**, which no in-repo scan can see. A reader of `.package` outside this repo compiles today and will not after this change. That break is the point of the card — the read is already `undefined` at runtime — but it *will* interrupt people, and the compiler is the channel that reaches them.

**In-repo census, re-measured for this PR** (the card's numbers were NOT reused; the dispatching PM's own probe returned 0 for both test and control, i.e. a dead scan, so no baseline was inherited). `grep -r` over the worktree excluding `node_modules/.git/dist/.turbo/build/.next` — deliberately not `git grep`, which reads tracked files only:

| measured term | raw hits | of which real callers of the **global** `ObjectStackClient.packages.*` |
|---|---|---|
| `packages.install(` | 8 | **2** — `client.test.ts:2520`, `:2533` |
| `packages.get(` | 5 | **0** |
| `packages.enable(` | 2 | **0** |
| `packages.disable(` | 1 | **0** |

**Positive controls** (same namespace, and none is a substring of any measured term, nor any measured term of it):

| control | hits |
|---|---|
| `packages.list(` | 17 |
| `packages.publish(` | 3 |
| `packages.update(` | 3 |
| `packages.uninstall(` | 1 |
| `ObjectStackClient` (scanner liveness) | 324 |

Controls are all non-zero, so the zeros above are readings rather than a dead scan.

**Non-dot spellings were scanned too and found nothing**: alias/destructure bindings of a `.packages` namespace (regex over `const|let|var … = ….packages`) — 0 in code; a line ending in `.packages` (cross-line chaining) — 0 in code; bracket access `packages['install'|'get'|'enable'|'disable']` — 0. An exhaustive enumeration of every `.packages.` member access in code files shows `.packages.enable` and `.packages.disable` **do not appear in compiled code at all** — their only occurrences repo-wide are prose in `packages/client/README.md` and `content/docs/api/client-sdk.mdx`.

**Discounted hits, and why:** `client.environments.packages.install` (`client.environments-namespace.test.ts:143`) is a different namespace; `scoped.packages.get` (`return-type-precision.test.ts:267`, `:297`) is the SCOPED route, untouched; `client.projects.packages.install(envId, …)` in CHANGELOGs is historical; `packages.get(name)` in `scripts/release-github-releases.mjs` is `Map.get`; `packages/services/service-package/README.md:53` is a different `packages` object.

**Net compile-time impact inside this repo: zero.** Both real `install` callers assert only the REQUEST and never read the response.

## Fixture triage

`client.test.ts` fed `{ success: true, data: { package: { manifest: MANIFEST } } }` to those two cases — a body nothing emits. The cases never read the response, so the fixture is inert either way, but a decoy fixture is how the next sweep concludes the envelope is real. Replaced with `INSTALLED_ROW`, the shape the producer actually sends. This is a bounded in-place fix of the same defect class, named here as required; it widens the file surface of this claim to `packages/client/src/client.test.ts`.

## Tests

Two pins, because **neither half can observe the other** — the rule `return-type-precision.test.ts` states in its own header:

- **`packages/client/src/packages-write-envelope.test.ts` (new)** — the WIRE fact. Real `SchemaRegistry` (`@objectstack/objectql`) → real `HttpDispatcher` (`@objectstack/runtime`) → real `ObjectStackClient` with the real `unwrapResponse`. ⛔ Nothing mocks a response body: a mock body would assert my own assumption about the producer, which is the mistake that produced the false declaration. The only stand-in is the socket.
- **`packages/client/src/return-type-precision.test.ts`** — the DECLARATION, type-level, because a runtime test cannot observe a return-type narrowing at all.

```
pnpm --filter @objectstack/client typecheck        -> EXIT=0
  tsc --noEmit  +  check:test-typecheck: OK — @objectstack/client's test layer compiles
  under packages/client/tsconfig.test.json; 0 file(s) / 0 error(s) held in test-typecheck-debt.json

pnpm --filter @objectstack/client test             -> EXIT=0
  Test Files  29 passed (29)
  Tests       395 passed (395)
```

**NOT-MEASURED trap checked**: `tsc -p tsconfig.test.json --listFiles` confirms all three test files and `src/index.ts` are inside the program (933 files) — so "typecheck is green" really does cover the new test code rather than merely being true about files it never read.

### Ablation — restoring the false declaration

Predicted before running: `tsc` RED on the type pins, wire test GREEN (a runtime test cannot see a declaration).

Mutation confirmed **on disk before any verdict was read** — blob hash `d83df55e…` → `8d351cbe…`, and the anchor counts moved with it (the false-envelope spelling `package: any; message?: string` 2→5; the `Promise` return annotation naming `InstalledPackage` 4→1; the `unwrapResponse` type argument naming `InstalledPackage` 4→1). No rebuild is in this ablation's path and none is claimed: both test files import `./index` from **source** in the same package, and `tsc -p tsconfig.test.json` compiles that source, so nothing resolves through `dist/`.

```
ABLATE_TSC_MUTATED_EXIT=2      (10 errors)
  4x TS2578 Unused '@ts-expect-error' directive   return-type-precision.test.ts:403,405,407,412
  3x TS2344 toEqualTypeOf constraint failure      return-type-precision.test.ts:390,391,392
  3x TS2339 Property 'manifest'/'enabled' does not exist on
            '{ package: any; message?: string }'  packages-write-envelope.test.ts:175,192,206
ABLATE_WIRE_MUTATED_EXIT=0     Test Files 1 passed (1)   -- green, as predicted
ABLATE_TSC_RESTORED_EXIT=0     restored tsc error count: 0
```

**My prediction was incomplete and is corrected rather than glossed:** I expected 7 errors in one file; there are 10 across two, because the wire test's row reads (`.manifest`, `.enabled`) are themselves type-level evidence and go red under ablation even though that file stays green at runtime. That strengthens the pin.

Restore **proven by state, not by exit code**: `git checkout HEAD --` against an ABSOLUTE path (under an `EXIT INT TERM` trap), then blob hash back to `d83df55e…` = the HEAD blob, and `git diff HEAD` empty for the file.

## Gates

Derived **after the final commit** with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (it read the change set itself from the merge base; answer asserted against this repo at `4c8854761`). All runs below are on `4c8854761`, and each verdict is the gate's own printed line, never a bare `$?` behind a pipe.

| gate | exit | note |
|---|---|---|
| `check:route-envelope` | 0 | PM-named |
| `check:query-options-erasure` | 0 | ratchet holds; test surface at the ceiling, none new; baseline verified against `cf71d73` |
| `check:nul-bytes` | 0 | 7249 files, no raw control bytes |
| `check:published-files` | 0 | PM-named |
| `check-changeset-no-major` | 0 | no `major` bump |
| `check-empty-changeset` | 0 | 1 declaring changeset added |
| `check-adr-0087-registration` | 0 | see the note below |
| `check:test-source-alias` | 0 | new test imports two workspace packages |
| `check:undeclared-dep-imports` | 0 | both are declared devDeps of `@objectstack/client` |
| `check:cross-package-test-inputs` | 0 | 23 packages read outside themselves, all declared |
| `check:engine-double-contract` | 0 | new test file carries no engine double |
| `check:where-matcher` | 0 | none new |
| `check:type-check-coverage` | 0 | |

**Lint — a DECLARED narrowing, not a skipped gate.** Repo-wide `pnpm lint` is CI's run. Locally the four touched files were linted with the repo's own invocation (`eslint … --no-inline-config`), and all three evidences are present:
1. **population from eslint's own config** — eslint returned a result object for each of the 4 files and reported none of them ignored, so all four are inside the configured population;
2. **count from `--format json`** — 4 files, **0 errors, 0 warnings**, exit 0;
3. **invariance for untouched files** — this repo runs one `eslint.config.mjs` which enables **no type-aware linting for any file** (no `parserOptions.project`, no typed `@typescript-eslint` rules), stated and positive-control-measured at `eslint.config.mjs:327-335`. Every rule is therefore file-local and this diff cannot move the verdict on any file it does not touch.

**NOT MEASURED locally** (CI owns them): `check:type-check-debt --re-measure`, which refuses on an unbuilt workspace closure and needs a full `turbo run build` — the client holds 0 debt entries and its test layer compiles at 0 errors, so no ratchet movement is expected, but that is an expectation and not a measurement. The remaining derived families were left to CI under the standing repo-wide-scan rule. Part of this round ran on a box at load ~37 where a bare `node -e` did not return in 3 minutes; every result reported above was re-run to completion afterwards, and nothing killed by that starvation is reported as a verdict.

### Changeset — a note for the reviewer

`minor`, per the launch-window convention, and the body spells out FROM/TO and the break in prose. It deliberately does **not** carry the literal `**BREAKING` marker, so `check-adr-0087-registration` classifies it non-breaking and asks for no ADR-0087 disposition. That is the repo's settled treatment of exactly this class — `client-unannotated-return-erasure.md` (#11925) and `client-precise-sdk-return-types.md` (#8140) are both published-SDK return-type narrowings and both do the same — and it is honest here: nothing in this change is a metadata surface, so the ADR-0087 ledger (which feeds `objectstack migrate meta`) has nothing to rewrite. Registering an entry would be noise in the upgrade path. Flagged rather than left silent, because the dispatch instruction asked for the breakingness to be explicit, and it is — in the changeset prose and in this PR body, just not through the token that drives that particular gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjujZN219uFzBhSYfMykCd)_
