### PR TITLE
docs(pm-dispatch): test the governed surface before arming, and say the strip step at MERGED

### DIFF
--- a/.claude/skills/pm-dispatch/references/landing-operations.md
+++ b/.claude/skills/pm-dispatch/references/landing-operations.md
@@ -37,7 +37,7 @@ job 结论,绿即转 ready + 挂 auto-merge,未绿阶梯重挂;CI success webhoo
 作。**零 `enqueued` 事件按序查:① `mergeable_state` 是否 `dirty`;② enable-auto-merge 调用根本没落
 地(重发与效果验证序列见平台读数);③ PR 碰 `.github/workflows/**` 而 token 缺 workflows 权限。
 
-**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡 GitHub 代关):`Part of` 卡开着不摘
+**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡代关,标也须摘):`Part of` 卡开着不摘
 `pm:dispatched`,就把无在飞物的卡永远算在 `label:pm:dispatched is:open` 里。摘标(换回 `pm:queue` 或按
 剩余物定级)+ 一条评论(交付了什么、剩下归谁)与 MERGED 确认是一个动作,⛔ 不拆到下轮巡
 检;同刻读相关卡 `closed_by_pull_requests`,确认没有卡被正文闭合关键词误关(事实见平台读数)。

--- a/.claude/skills/pm-dispatch/references/landing-operations.md
+++ b/.claude/skills/pm-dispatch/references/landing-operations.md
@@ -29,17 +29,18 @@ job 结论,绿即转 ready + 挂 auto-merge,未绿阶梯重挂;CI success webhoo
 读数。**契约复审链 PASS 落地的 PR 到窗口时已 ready + auto-merge 在挂**(清标与落地同一笔,见
 `contract-review.md`)—— 窗口自身权责不变:跟到 MERGED、踢出处置、落地后对账。
 
-**转 ready / 挂 auto-merge 之前先读 `mergeable_state`**(事实行见平台读数):`dirty` ⇒ 先 merge
-`origin/main`(生成物在面上按 A 的固定序)再挂。**ready + 全绿 ≠ 已入队 —— 队列从不
-主动拉 PR,入队是显式动作。**零 `enqueued` 事件按序查:① `mergeable_state` 是否 `dirty`;
-② enable-auto-merge 调用根本没落地(重发与效果验证序列见平台读数);③ PR 碰
-`.github/workflows/**` 而 token 缺 workflows 权限。
+**转 ready / 挂 auto-merge 之前先判受管面**:`node scripts/pm/check-governed-merges.mjs --test` 加 PR 变更路
+径,一条命中 ⇒ 整 PR 改走人工合并道(复核照写 + 留 draft + 向授权批准人请审 + 状态评
+论),⛔ 不翻 ready、不入队;清标即落地同受此闸,漏判被队列守卫在 merge group 里拒收,白烧一
+轮队列。**再读 `mergeable_state`**(事实行见平台读数):`dirty` ⇒ 先 merge `origin/main`(生成物在面
+上按 A 的固定序)再挂。**ready + 全绿 ≠ 已入队 —— 队列从不主动拉 PR,入队是显式动
+作。**零 `enqueued` 事件按序查:① `mergeable_state` 是否 `dirty`;② enable-auto-merge 调用根本没落
+地(重发与效果验证序列见平台读数);③ PR 碰 `.github/workflows/**` 而 token 缺 workflows 权限。
 
-**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡 GitHub 代关、标签随
-卡离开在飞视图):`Part of` 卡开着不摘 `pm:dispatched`,就把无在飞物的卡永远算在
-`label:pm:dispatched is:open` 里。摘标(换回 `pm:queue` 或按剩余物定级)+ 一条评
-论(交付了什么、剩下归谁)与 MERGED 确认是一个动作,⛔ 不拆到下轮巡检;同刻读相关
-卡 `closed_by_pull_requests`,确认没有卡被正文闭合关键词误关(事实见平台读数)。
+**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡 GitHub 代关):`Part of` 卡开着不摘
+`pm:dispatched`,就把无在飞物的卡永远算在 `label:pm:dispatched is:open` 里。摘标(换回 `pm:queue` 或按
+剩余物定级)+ 一条评论(交付了什么、剩下归谁)与 MERGED 确认是一个动作,⛔ 不拆到下轮巡
+检;同刻读相关卡 `closed_by_pull_requests`,确认没有卡被正文闭合关键词误关(事实见平台读数)。
 
 **每次合并后重拉一次车道盘点,与预期状态对账** —— 也是落地动作的一步,⛔ 不留给下
 轮巡检:取 open 卡清单,对照「应关哪些、不应关哪些」的预期 diff;预期之外从 open
@@ -48,12 +49,11 @@ job 结论,绿即转 ready + 挂 auto-merge,未绿阶梯重挂;CI success webhoo
 落地后**再核一次落地判据本身**:队列的合并同样走 os-regen 驱动,A 的静默吞并在队
 列合并这一步一样能发生。**MERGED 不是终点**:发版后义务见 `release-aftercare.md`。
 
-**落地窗口给关键 PR 挂 `subscribe_pr_activity`**(会话型座位专用;Routine 座位收
-不到,维持轮询):⛔ 不订阅 dev 交报告前的 PR —— 双驾驶员互踩(云卡出生即订阅不越
-界,报告在 draft PR 开出即到);订阅是感知补充,不替代 flip 定点;**MERGED / 关闭
-即退订,同刻把 `mode:cloud` 派的会话 `archive_session`** —— 触发条件是卡终局且报
-告已收复核,⛔ 合并前不归档(活会话是 dirty 自救的执行手;误归档可 unarchive,但
-容器现场已失,宁晚勿早);暂停/交接把在挂订阅清点进座位贴,⛔ 不留孤儿订阅。
+**落地窗口给关键 PR 挂 `subscribe_pr_activity`**(会话型座位专用;Routine 座位收不到,维持轮询):⛔
+不订阅 dev 交报告前的 PR —— 双驾驶员互踩;订阅是感知补充,不替代 flip 定点;**MERGED / 关闭
+即退订,同刻把 `mode:cloud` 派的会话 `archive_session`** —— 触发条件是卡终局且报告已收复
+核,⛔ 合并前不归档(活会话是 dirty 自救的执行手;误归档可 unarchive,但容器现场已失,宁晚勿
+早);暂停/交接把在挂订阅清点进座位贴,⛔ 不留孤儿订阅。
 
 **main-red 事故两条约定**:① **p0 fix-forward 允许跳队**(维护者 2026-08-25「同意」):main 红的
 止血 PR(p0、机械、根因已核实)可跳队(GitHub 队列自带 jump-the-queue),或按既有 governed


### PR DESCRIPTION
Fixes #13034
Fixes #12907

Two cards, one file, one net-0 edit — `.claude/skills/pm-dispatch/references/landing-operations.md`
(ratchet 80 lines / ceiling 80, zero headroom, 120-byte line cap). Every re-wrap in this diff is
the canonical form produced by the ratchet's own `wrapLine`, so no break in it is one the gate
would refuse to offer.

## Card 13034 — the landing chain had no governed branch

The ACCEPT-path fork in `SKILL.md` already reads the path surface before arming, but section B's
own pre-arm paragraph — the one the contract-review chain lands through (清标即落地: PASS to ready
to auto-merge to queue) — tested only `mergeable_state`. So a PASS'd PR whose diff touched
`docs/adr/**` was armed, enqueued, and then refused by the Governed Surface Queue Guard inside the
merge group: one queue cycle spent to learn what a predicate answers for free.

The pre-arm paragraph now runs the governed predicate **first**, before `mergeable_state`. Added
text, verbatim:

```
**转 ready / 挂 auto-merge 之前先判受管面**:`node scripts/pm/check-governed-merges.mjs --test` 加 PR 变更路
径,一条命中 ⇒ 整 PR 改走人工合并道(复核照写 + 留 draft + 向授权批准人请审 + 状态评
论),⛔ 不翻 ready、不入队;清标即落地同受此闸,漏判被队列守卫在 merge group 里拒收,白烧一
轮队列。
```

The paragraph's old lead — **转 ready / 挂 auto-merge 之前先读 `mergeable_state`** — becomes
**再读 `mergeable_state`**, because the WHEN now sits on the new lead sentence and stating it
twice would cost a line the file does not have. The `mergeable_state` content itself is unchanged.

Self-demonstration — the new predicate, run on this PR's own diff:

```
governed-surface predicate: 1 of 1 path(s) hit the register (5 surfaces, repo-agnostic).
  ⛔  GOVERNED — a human merge is the review record for this PR (#9495 regime).
      No seat flips it ready, enqueues it, or arms auto-merge (AGENTS.md Prime Directive #14).
      .claude/** ×1 — the agent instruction tree (skills, agents, hooks, settings)
        - .claude/skills/pm-dispatch/references/landing-operations.md
```

exit 3. So this PR is a **draft**: no ready flip, no auto-merge, no queue, no reviewer requests
from this seat.

## Card 12907 — the MERGED parenthetical

before:

```
**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡 GitHub 代关、标签随
卡离开在飞视图):
```

after:

```
**确认 MERGED 的同一动作里给 `Part of` 卡收口**(`Fixes` 卡代关,标也须摘):
```

Judgement taken: **correct it**, not delete it. Deleting the false half alone was the cheaper edit
and it did fit, but it leaves the sentence implying the auto-closed card needs no label write at
all — which is the exact half the strip-on-close convention (SKILL.md 关闭即摘 `pm:*` 状态标,与
关单同一笔) closed, and the half patrol row H22 reports. `标也须摘` says it in the smallest wording
the zero-headroom budget allows; measured against that budget, the longer spellings that keep
`GitHub` in the clause all cost a fifth line. Scope note honoured: nothing here backfills
already-closed cards — this is only what the document tells the next seat to do at the next merge.

## Ratchet and cut ledger — net 0

Landed 80 lines against ceiling 80, headroom 0, widest line 120 bytes. Two paragraphs grew, two
paid, and the payments are re-flows plus one true cut:

| paragraph (before / after) | lines | how it was paid |
| --- | --- | --- |
| pre-arm checks, `mergeable_state` (32-36 / 32-38) | 5 to 7 | the new governed sentence, +2 |
| MERGED 收口 (38-42 / 40-43) | 5 to 4 | the false half `标签随卡离开在飞视图` deleted, replaced by the shorter true `标也须摘`; canonical re-flow then closes a line. −1 |
| `subscribe_pr_activity` (51-56 / 52-56) | 6 to 5 | one cut, below. −1 |

The one content cut, with its surviving homes:

- Cut `(云卡出生即订阅不越界,报告在 draft PR 开出即到)` — the parenthetical justifying why cloud
  cards are exempt from the do-not-subscribe-before-report rule. Both facts already live elsewhere,
  each as the rule itself rather than as an aside:
  - 云卡出生即订阅不越界 → `references/dispatch-runbook.md` item 4, 「云卡 draft PR 一存在,立即
    `subscribe_pr_activity` —— 硬步骤」.
  - 报告在 draft PR 开出即到 → `.claude/agents/os-dev.md`, 「报告在 draft PR 时点交付」, and the
    same runbook's 合法回合终点 clause.
  The rule that paragraph states — ⛔ 不订阅 dev 交报告前的 PR —— 双驾驶员互踩 — is untouched.

Deleted as false (card 12907, not a cut needing a home): `标签随卡离开在飞视图`.

No other paragraph in the file has re-wrap slack — checked by running the ratchet's own `wrapLine`
over every paragraph and list item; only the two paid ones move, and only after the edits above.

## Gates

Union derived at the final commit with `node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack` (it reads its own change set from the merge base; no hand-built path
list), then every family run on that same tree — `git rev-parse --short HEAD` = **5f9199f65**.
Exit codes captured by redirect-then-capture, never through a pipe.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/landing-operations.md is 80 lines (ceiling 80; headroom 0).` |
| `check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 206 assertions (…)` |
| `check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 398 file(s) · 4558 bare -- token(s) · …` |
| `check:doc-authoring` | 0 | `✓ doc authoring guard: 13338 customer-facing string(s) across 672 spec sources clean — no internal issue-id references.` |
| `check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 425 files / 1453 TS blocks judged clean by @objectstack/formula.` |
| `check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 7281 text file(s) …; no raw ASCII control bytes).` |

Two of these first answered `PREREQUISITE NOT MET` in the fresh worktree (`check:doc-authoring`
wanted `typescript`; `check:doc-formula-expressions` wanted `@objectstack/formula` and then
`@objectstack/lint` built). Those are NOT MEASURED, not red — both were re-run to a real verdict
after `pnpm install` and a `turbo run build` taken through `scripts/pm/os-verify-lock.sh`
(`VERDICT command-exit 0 · held the lock 2s` and `1s`).

No changeset: the diff is `.claude/**` only and publishes nothing. `skip-changeset` applied at
PR-open, read-union-write plus readback.

_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_