### PR TITLE
docs(skills): stop saying the retired contributes.routes key parses

### DIFF
--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -246,7 +246,12 @@ export const CEILINGS = new Map([
   // Every row re-measured after the internal issue-id strip — see
   // CEILING_BASIS.strippedInternalIds. `(was N)` is the ceiling this replaced.
   ['skills/objectstack-ai/SKILL.md', 6806], //          -18 (was 6824)
-  ['skills/objectstack-api/SKILL.md', 6331], //         -11 (was 6342)
+  // -12 (was 6331): the `http.server` decision-table row dropped a trailing
+  // clause that taught `contributes.routes` as a key that "parses but serves
+  // nothing". The key is retired — an authored entry is now REFUSED, carrying
+  // the removal prescription — so the clause described a state the runtime no
+  // longer has. Lowered to the measurement, per the shrink-only discipline.
+  ['skills/objectstack-api/SKILL.md', 6319],
   // 12511 -> 12643 (#11348): the flow value-expression section documented the
   // expression surface but not the function vocabulary (round/floor/ceil/abs/
   // min/max); an unknown function fails at RUNTIME, not at flow-save, so the

--- a/skills/objectstack-api/SKILL.md
+++ b/skills/objectstack-api/SKILL.md
@@ -161,7 +161,7 @@ policy layer over an existing pipeline, never a second execution dialect.
 | Use | When |
 |:---|:---|
 | **`defineStack({ apis })`** | The endpoint is a *projection* of something the platform already executes: query/return records, or trigger a flow. No code, no deploy artifact, publish-gated. **Prefer this.** |
-| **`http.server` mount** (plugin code) | The endpoint needs real handler CODE — a third-party callback with its own signature verification, a streaming response, a protocol the platform does not speak. Mount it on `http.server`; `contributes.routes` parses but serves nothing. |
+| **`http.server` mount** (plugin code) | The endpoint needs real handler CODE — a third-party callback with its own signature verification, a streaming response, a protocol the platform does not speak. Mount it on `http.server`. |
 
 If the logic is "a bit of computation, then a record write", express it as a
 **flow** and point a `type: 'flow'` endpoint at it — that keeps the URL


### PR DESCRIPTION
Fixes #12415

`skills/objectstack-api/SKILL.md` — the `http.server` mount row of the "Choosing between `apis:` and a code handler" decision table — ended with a clause stating that `contributes.routes` "parses but serves nothing". That was accurate while the key was declared-but-unenforced. It is no longer: the tombstone has landed on `main`, so an authored `contributes.routes` does not parse at all — it is refused, and the refusal carries the removal prescription.

A published, customer-facing skill telling an authoring agent that a removed key still "parses" is the exact class the 2026-08-22 ruling corrected.

## Tombstone verification (done first, in this worktree)

Source — `packages/spec/src/kernel/manifest.zod.ts`, the `contributes` object, is a `retiredKey()` tombstone, not a live member:

```
routes: retiredKey(
  '`manifest.contributes.routes` was removed in @objectstack/spec 17 (' +
  'ADR-0049 enforce-or-remove) — nothing ever read it: the HttpDispatcher never ' +
  'registered a prefix from the declaration, so an entry here parsed cleanly and ' +
  'served nothing while published material kept recommending it. Delete the key. ' +
  ...
```

Executable proof — the retirement describe block in `packages/spec/src/kernel/manifest.test.ts`, run on this branch:

```
pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 \
  src/kernel/manifest.test.ts -t 'contributes.routes retirement'

Test Files  1 passed (1)
     Tests  2 passed | 35 skipped (37)
```

The passing pin is `REJECTS an authored contributes.routes with the prescription as the issue`, which asserts the located zod issue matches `manifest.contributes.routes … removed in @objectstack/spec 17 … Delete the key … http.server`. So the premise holds: the key rejects, and the skill's clause was stale.

## The edit

The DROP spelling. The row's recommendation — mount it on `http.server` — is correct and complete without the trailing clause, so the clause is removed rather than restated. Nothing replaces it: a decision table that stops naming a removed key is the smallest correct form, and it costs the reader nothing to lose a sentence about a key they can no longer write.

Before:

> Mount it on `http.server`; `contributes.routes` parses but serves nothing.

After:

> Mount it on `http.server`.

This is the only site in the published catalog that mentioned the key — `grep -rn "contributes.routes" skills/` returns one line before this change and none after.

## Token and line readings

`skills/**` is priced in tokens by `scripts/check-skills-token-ratchet.mjs` (`ceil(utf8 bytes / 4)`). The file sat at its ceiling with zero headroom, so net tokens had to be at most zero.

| Reading | Before | After | Net |
|:---|---:|---:|---:|
| `skills/objectstack-api/SKILL.md` tokens | 6331 | 6319 | **-12** |
| `skills/objectstack-api/SKILL.md` lines | 609 | 609 | 0 |
| `skills/objectstack-api/SKILL.md` bytes | 25323 | 25275 | -48 |
| ratcheted authored bundle | 170520 | 170508 | -12 |
| bundle total (whole shipped tree) | 186279 | 186267 | -12 |

Package-level reading is the bundle row: this skill is a single-`SKILL.md` change, and no other file in `skills/objectstack-api/` moved.

The ceiling is lowered to the new measurement in the same commit, per the gate's own shrink-only discipline ("a ceiling may be lowered to the measurement whenever one is taken"), so the deletion is banked rather than left as spendable slack:

```
✓ check-skills-token-ratchet: skills/objectstack-api/SKILL.md is 6319 tokens (ceiling 6319; headroom 0).
✓ check-skills-token-ratchet: 38 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.
```

Note the card's recalled ceiling of 6348 was stale — `main` carries 6331 (it had already dropped twice: 6342, then -11 in the internal-id strip). Both numbers above are re-measured on this branch, not recalled.

## Gates

Union derived mechanically from the real change set, not from a recalled list: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (2 paths vs merge base `e9c1055ea`). All runs below are on `7c7d00940`, the head of this branch and its final commit.

| Gate | Verdict |
|:---|:---|
| `check-skills-token-ratchet` (+ `--self-test`, 64 cases) | pass |
| `check:doc-authoring` | pass |
| `check:skill-frame-sync` | pass |
| `check:skill-compatibility` | pass |
| `check:skill-frame-freshness` | pass |
| `check:role-word` | pass |
| `check:pm-governed-merges` | pass |
| `check:agent-test-spelling` | pass |
| `check:bash32-floor` | pass |
| `check:cli-command-ids` | pass |
| `check:cross-package-test-inputs` (+ direct) | pass |
| `check:entry-guard` | pass |
| `check:parse-guard` | pass |
| `check:pnpm-filter-targets` | pass |
| `check:watch-hint-literal` | pass |
| `check:nul-bytes` | pass |
| `check-ci-filter-parity` | pass |
| `check-shard-attestation` | pass |
| `check:doc-formula-expressions` | pass (after building `@objectstack/formula` and `@objectstack/lint`; it refuses as `PREREQUISITE NOT MET` on an unbuilt tree) |
| `bare-root-worklist --self-test` | pass |
| `check:pm-dispatch-gates` | pass |
| `check:ratchet-remedy-authority` | pass |
| `check:pm-skill-ratchet` | pass |
| `check:pm-skill-id-lint` | pass |

The last five are the convention-triggered obligations for editing a gate script plus the gates that read `check-skills-token-ratchet.mjs`; the ratchet script has no separate `*.test.ts`, so its `--self-test` is its suite.

`check-test-completeness.mjs` is **not measured** here rather than passing: invoked with no arguments it prints its usage line and exits 1. It takes a turbo test log that only CI composes.

## Changeset

None, deliberately — the `skip-changeset` label is the right instrument and this PR takes it. The changeset gate's own failure text names this case explicitly: `skills/**` is on its "releases nothing" list, and it spells out that an empty-frontmatter changeset is the closed route, because naming no package is what the label is for. Precedent matches exactly: `a6e0010d5` is a structural twin of this diff — the same two files, a dropped `SKILL.md` line plus a lowered ceiling in `check-skills-token-ratchet.mjs` — and carries no changeset.

## Merge

`skills/**` is a governed surface under Prime Directive #14, so this stays a **draft** for a maintainer's hand merge. No ready flip, no reviewers, no auto-merge, no queue.

Verification session: https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_