### PR TITLE
fix(metadata): state the raw-driver remedy once in migrateProjectIdToEnvironmentId

### DIFF
--- a/.changeset/migrate-project-id-guard-doubled-sentence.md
+++ b/.changeset/migrate-project-id-guard-doubled-sentence.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): `migrateProjectIdToEnvironmentId`'s raw-driver guard stated its instruction sentence twice (#13219)
+
+An operator who called `migrateProjectIdToEnvironmentId` with a driver that has
+no `raw()` was refused correctly, but read the same remedy twice in one message:
+
+```
+migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. SqlDriver (better-sqlite3/knex) supports this; cloud-side TursoDriver also conforms.
+```
+
+The sentence was concatenated twice, a copy-paste artifact — the sibling
+`migrateEnvIdToProjectId` carries the correct single-sentence form of the
+identical guard. Cosmetic and operator-facing only: the guard fires on exactly
+the same condition, the remedy it names is unchanged, and nothing parses the
+message. The duplicate line is deleted; the surviving sentence keeps the
+trailing space that separates it from the one naming the conforming drivers.
+
+The refusal case in the package's tests now pins the properties — the
+instruction appears exactly once, no sentence runs into the next, and the
+supporting sentence is still present — rather than substring-matching the
+message, which could not see a second copy and so passed either way.

--- a/packages/metadata/src/migrations/migrate-project-id-to-environment-id.test.ts
+++ b/packages/metadata/src/migrations/migrate-project-id-to-environment-id.test.ts
@@ -191,9 +191,37 @@ describe('migrateProjectIdToEnvironmentId — behaviour against a physically-sta
         expect(statements.filter((s) => s.startsWith('ALTER TABLE'))).toEqual([]);
     });
 
-    it('still refuses a driver without .raw()', async () => {
-        await expect(migrateProjectIdToEnvironmentId({} as any)).rejects.toThrow(
-            /must expose a \.raw\(sql, bindings\?\) method/,
+    it('still refuses a driver without .raw(), stating the remedy exactly once', async () => {
+        // #13219 — the guard concatenated its instruction sentence TWICE, so an
+        // operator with a raw-less driver read the same remedy twice in one
+        // message. The assertion that used to stand here
+        // (`rejects.toThrow(/must expose a \.raw\(sql, bindings\?\) method/)`)
+        // passed either way: a substring match cannot see a second copy. So
+        // these pin the PROPERTIES of the assembled message, not a full-string
+        // copy of today's wording.
+        const outcome: unknown = await migrateProjectIdToEnvironmentId({} as any).then(
+            (value) => value,
+            (error: unknown) => error,
         );
+        expect(outcome, 'a driver with no .raw() must be refused').toBeInstanceOf(Error);
+        const message = (outcome as Error).message;
+
+        // 1. The remedy is stated exactly ONCE. Counted, not compared, so a
+        //    later rewording of the sentence still leaves this asserting.
+        const instruction = /driver must expose a \.raw\(sql, bindings\?\) method\./g;
+        expect(message.match(instruction) ?? []).toHaveLength(1);
+
+        // 2. ...and the sentences stay SEPARATED. Deleting the duplicate by
+        //    trimming the surviving line's trailing space would satisfy (1)
+        //    while gluing `method.SqlDriver` — this defect inverted, so it is
+        //    pinned in the same case. A run-together sentence boundary is a
+        //    lowercase letter, a period, then a capital; the `.raw(` in the
+        //    text is lowercase-after-period and so is correctly not one.
+        expect(message).not.toMatch(/[a-z]\.[A-Z]/);
+
+        // 3. Non-vacuity: deleting the SUPPORTING sentence instead would also
+        //    satisfy (1) and (2). It names the drivers that do conform, which
+        //    is the half of the message an operator acts on.
+        expect(message).toMatch(/SqlDriver/);
     });
 });

--- a/packages/metadata/src/migrations/migrate-project-id-to-environment-id.ts
+++ b/packages/metadata/src/migrations/migrate-project-id-to-environment-id.ts
@@ -119,7 +119,6 @@ export async function migrateProjectIdToEnvironmentId(
     if (typeof driverAny.raw !== 'function') {
         throw new Error(
             'migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. ' +
-            'migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. ' +
             'SqlDriver (better-sqlite3/knex) supports this; cloud-side TursoDriver also conforms.'
         );
     }


### PR DESCRIPTION
Fixes #13219

The raw-driver guard in `packages/metadata/src/migrations/migrate-project-id-to-environment-id.ts` concatenated its instruction sentence twice, so an operator calling the migration with a driver that has no `raw()` read the same remedy twice in one message. A copy-paste artifact rather than intent: the sibling `migrateEnvIdToProjectId` carries the correct single-sentence form of the identical guard. Cosmetic and operator-facing only — the guard fires on exactly the same condition, the remedy it names is unchanged, and nothing parses the message.

Branch cut from `main` `e452ad542`, at-or-after the landing of PR #13220 that the triage sequencing constraint was waiting on. That PR moved the guard from `:58` to `:121`; the line numbers here were re-derived at the branch head, not taken from the card.

## The change

One deleted line in the source. The full source diff:

```diff
     if (typeof driverAny.raw !== 'function') {
         throw new Error(
-            'migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. ' +
             'migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. ' +
             'SqlDriver (better-sqlite3/knex) supports this; cloud-side TursoDriver also conforms.'
         );
```

## The assembled message, before and after

Captured at runtime by invoking the guard, printed through `JSON.stringify` so the trailing space is visible rather than inferred:

Before — 250 characters, instruction sentence twice:

```
"migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. SqlDriver (better-sqlite3/knex) supports this; cloud-side TursoDriver also conforms."
```

After — 167 characters, instruction sentence once:

```
"migrateProjectIdToEnvironmentId: driver must expose a .raw(sql, bindings?) method. SqlDriver (better-sqlite3/knex) supports this; cloud-side TursoDriver also conforms."
```

250 minus 167 is 83, exactly the deleted sentence plus its trailing space. The space that separates the two surviving sentences lives *inside* the string literal (`method. ' +`), so deleting the whole duplicated line preserves it — the assembled text still reads `method. SqlDriver`, not `method.SqlDriver`. That run-together form is this card's own defect inverted, and it is pinned below.

## The test

The package already had a refusal case, `still refuses a driver without .raw()`, added by #13220. Its assertion was `rejects.toThrow(/must expose a \.raw\(sql, bindings\?\) method/)` — a substring match, which cannot see a second copy and so passed both before and after the fix. That case is extended in place (no second test file) to pin the properties of the assembled message rather than a full-string copy of today's wording:

1. the instruction sentence appears **exactly once** — counted with a global regex, so a later rewording still leaves this asserting;
2. **no sentence runs into the next** — asserted as the absence of a lowercase-period-uppercase boundary, which catches `method.SqlDriver` while correctly not matching the `.raw(` in the text itself;
3. **non-vacuity** — the supporting sentence naming the conforming drivers is still present, since deleting *it* instead would satisfy (1) and (2).

Reverse verification, run test-first before the source fix, with the dependency closure built:

```
 FAIL  src/migrations/migrate-project-id-to-environment-id.test.ts > still refuses a driver without .raw(), stating the remedy exactly once
AssertionError: expected [ ...(2) ] to have a length of 1 but got 2
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

The observed direction is a plain red on the new assertion only; the eight pre-existing cases in the file stayed green, confirming the new case is what moved.

## Verification

All of the following re-run **after the final commit**, at `f2ff3b77d`.

```
pnpm --filter @objectstack/metadata test
   Test Files  39 passed (39)
        Tests  687 passed (687)

pnpm lint                                (eslint . --no-inline-config, whole repo)   EXIT=0
pnpm check:nul-bytes                                                                 EXIT=0
pnpm check:engine-double-contract                                                    EXIT=0
pnpm check:where-matcher                                                             EXIT=0
pnpm check:cross-package-test-inputs                                                 EXIT=0
pnpm check:query-options-erasure                                                     EXIT=0
pnpm check:type-check-coverage                                                       EXIT=0
pnpm check:test-source-alias                                                         EXIT=0
```

`check:query-options-erasure` reports `baseline key set verified against e452ad5: no files added` — this extends an existing test file rather than adding one, so its test-surface ceiling does not move.

**Typecheck, and why it is a measurement and not a silence.** `@objectstack/metadata` has no `typecheck` script, so tsc was run directly over the package program: `tsc -p packages/metadata/tsconfig.json --noEmit`. That tsconfig includes `src/**/*` and excludes only `node_modules`/`dist`, so test files are inside the program — confirmed with `--listFiles`, which matches both edited files (count 2). The run reports **89** errors, **zero** of them in either edited file; all 89 are pre-existing debt in other files of this package (`metadata.test.ts`, `register-notifies-watchers.test.ts` and others). 89 is exactly the frozen count recorded for `@objectstack/metadata` in the `TEST_DEBT` ledger in `scripts/check-type-check-coverage.mjs`, so the ratchet quantity is unmoved.

The gate family was derived mechanically from the real change set with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, not from a recalled list. Two members of that family returned exit 3, **PREREQUISITE NOT MET**, which is NOT MEASURED and not a red: `scripts/check-test-completeness.mjs` grades a saved `turbo run test` log that only CI produces, and `scripts/pm/check-half-states.mjs` needs a real GitHub credential this container does not carry. `check:type-check-debt --re-measure` and `check:dual-build-cjs-loads` need the whole workspace built and are left to CI; the quantity the first of them ratchets is the 89 measured directly above.

## Scope

Card scope only, one deleted line plus the test that pins it. The sibling `migrate-env-id-to-project-id.ts` is untouched — it is already correct, and #13220 recorded a deliberate reason it is not gated the same way. Changeset added, graded `patch`: an operator-facing message fix, nothing structural. No release-notes file touched. No out-of-scope findings.

_Generated by [Claude Code](https://claude.ai/code/session_01LZbWd2jNV1FErXTPSS4Dry)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZbWd2jNV1FErXTPSS4Dry)_