### PR TITLE
fix(spec): repoint the agent, skill and action liveness citations at the real cloud path

### DIFF
--- a/.changeset/liveness-cloud-path-agent-skill-action.md
+++ b/.changeset/liveness-cloud-path-agent-skill-action.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): repoint the `agent`, `skill` and `action` liveness citations at the real cloud path (#13272)
+
+The `liveness/` ledgers ship inside this package's npm tarball (they are named
+in `files`), so this is a published-data change even though no runtime
+behaviour moves and no schema key changes. No `status` verdict is altered.
+
+Twenty-two `evidence` citations across `liveness/agent.json` (11),
+`liveness/skill.json` (8) and `liveness/action.json` (3) named
+`packages/services/service-ai/...` — a path that exists in **neither**
+repository. The framework has no service-ai tree at all (`packages/services/`
+ships every sibling service except it), and cloud's real layout, measured at
+cloud@`15f55df`, is `packages/service-ai/...`. Each `_note` additionally
+repeated the claim that the framework's own tree "is a stale build artifact
+with no `src/`", which is false in the opposite direction from the one it
+suggests: absent, not stale.
+
+Why twenty-two dead pointers sat green, and why the repair is not a plain
+re-spelling: `FOREIGN_PATH_PREFIXES` in `scripts/liveness/evidence.mts` lists
+the *stale* spelling, so those citations were silently treated as foreign and
+never resolved — they did not survive scrutiny, they were exempt from it. The
+real cloud path is repo-rooted in shape and is not in that list, so a naive
+repoint resolves as LOCAL and fails CI. Measured on this branch by ablation:
+stripping the realm markers moves the gate from `467 repo-local ... 467
+resolved` to `489 ... 467 resolved, 22 MISSING` and exit 1. Every repointed
+citation therefore carries the explicit `cloud` realm marker, which is the
+attribution `scanEvidence` reads directly rather than a special case for one
+prefix. The constant is deliberately left alone: adding the real path to it
+would let an unmarked citation pass silently, trading one unfalsifiable
+spelling for another.
+
+Scope boundary recorded in each `_note`: this corrects the package root from
+the measurement above only. The cited consumers were **not** re-read against a
+cloud checkout, so no `verifiedAt` is stamped and no `#symbol` anchor is added
+— the gate never resolves a foreign anchor, so an unverified one would
+re-create the very unfalsifiable pointer this repair removes.

--- a/packages/spec/liveness/action.json
+++ b/packages/spec/liveness/action.json
@@ -1,6 +1,6 @@
 {
   "type": "action",
-  "_note": "ActionSchema. Seeded from docs/audits/2026-06-actionschema-property-liveness.md. Renderers live in objectui (evidence cited as prose, not framework paths); framework-side: service-ai action-tools, runtime body-runner/http-dispatcher. Containers (params/resultDialog/ai/aria) classified at top level — no divergent sub-statuses in the audit. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `packages/services/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code (the framework's own service-ai tree is a stale build artifact with no src/). These props are `live` because that cloud runtime consumes them; the OPEN framework edition does not — see content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent.",
+  "_note": "ActionSchema. Seeded from docs/audits/2026-06-actionschema-property-liveness.md. Renderers live in objectui (evidence cited as prose, not framework paths); framework-side: service-ai action-tools, runtime body-runner/http-dispatcher. Containers (params/resultDialog/ai/aria) classified at top level — no divergent sub-statuses in the audit. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `cloud: packages/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code. 2026-08-30 (#13272): the previous wording of this sentence was false in BOTH halves. (a) It called the framework's own service-ai tree “a stale build artifact with no src/” — there is no tree at all: `packages/services/` holds every sibling service EXCEPT service-ai, and `git ls-files | grep -ic service-ai` returns 0. Absent, not stale. (b) The citations spelled `packages/services/service-ai/...`, a path present in NEITHER repo; cloud's real layout, measured at cloud@15f55df (#13042), is `packages/service-ai/...`. Every citation below now carries the explicit `cloud` realm marker, so it is attributed by the marker `scanEvidence` reads rather than riding the `FOREIGN_PATH_PREFIXES` special case that silently exempted the stale spelling from resolution — which is why 22 dead pointers sat green. ⚠ NOT RE-VERIFIED: this repair corrected the package root from that recorded measurement ONLY. No consumer below was re-read against a cloud checkout, so no `verifiedAt` was stamped and no `#symbol` anchor was added — the gate never resolves a foreign anchor, so an unchecked one would re-create the unfalsifiable pointer this repair removes. Re-verifying these consumers against a live cloud checkout is still open (#13272). These props are `live` because that cloud runtime consumes them; the OPEN framework edition does not — see content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent.",
   "props": {
     "name": {
       "status": "live",
@@ -18,7 +18,7 @@
     },
     "objectName": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/tools/action-tools.ts:535",
+      "evidence": "cloud: packages/service-ai/src/tools/action-tools.ts:535",
       "note": "action dispatch + AI bridge."
     },
     "icon": {
@@ -60,7 +60,7 @@
     },
     "params": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/tools/action-tools.ts",
+      "evidence": "cloud: packages/service-ai/src/tools/action-tools.ts",
       "note": "field/objectOverride/defaultFromRow/options/placeholder/helpText/defaultValue/required all consumed."
     },
     "variant": {
@@ -120,7 +120,7 @@
     },
     "ai": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/tools/action-tools.ts",
+      "evidence": "cloud: packages/service-ai/src/tools/action-tools.ts",
       "note": "full AI bridge (exposed/description/category/paramHints/outputSchema/requiresConfirmation)."
     },
     "recordIdParam": {

--- a/packages/spec/liveness/agent.json
+++ b/packages/spec/liveness/agent.json
@@ -1,14 +1,14 @@
 {
   "type": "agent",
-  "_note": "AgentSchema. Seeded from docs/audits/2026-06-agentschema-property-liveness.md. agent-runtime.ts is the runtime consumer; AgentPreview is display-only. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `packages/services/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code (the framework's own service-ai tree is a stale build artifact with no src/). These props are `live` because that cloud runtime consumes them; the OPEN framework edition does not — see content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent. agent.knowledge (and AIKnowledgeSchema) removed; the topics→sources rename was absorbed into the removal pre-release.",
+  "_note": "AgentSchema. Seeded from docs/audits/2026-06-agentschema-property-liveness.md. agent-runtime.ts is the runtime consumer; AgentPreview is display-only. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `cloud: packages/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code. 2026-08-30 (#13272): the previous wording of this sentence was false in BOTH halves. (a) It called the framework's own service-ai tree “a stale build artifact with no src/” — there is no tree at all: `packages/services/` holds every sibling service EXCEPT service-ai, and `git ls-files | grep -ic service-ai` returns 0. Absent, not stale. (b) The citations spelled `packages/services/service-ai/...`, a path present in NEITHER repo; cloud's real layout, measured at cloud@15f55df (#13042), is `packages/service-ai/...`. Every citation below now carries the explicit `cloud` realm marker, so it is attributed by the marker `scanEvidence` reads rather than riding the `FOREIGN_PATH_PREFIXES` special case that silently exempted the stale spelling from resolution — which is why 22 dead pointers sat green. ⚠ NOT RE-VERIFIED: this repair corrected the package root from that recorded measurement ONLY. No consumer below was re-read against a cloud checkout, so no `verifiedAt` was stamped and no `#symbol` anchor was added — the gate never resolves a foreign anchor, so an unchecked one would re-create the unfalsifiable pointer this repair removes. Re-verifying these consumers against a live cloud checkout is still open (#13272). These props are `live` because that cloud runtime consumes them; the OPEN framework edition does not — see content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent. agent.knowledge (and AIKnowledgeSchema) removed; the topics→sources rename was absorbed into the removal pre-release.",
   "props": {
     "name": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts"
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts"
     },
     "surface": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts (resolveActiveSkills)",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts (resolveActiveSkills)",
       "note": "ADR-0063 §1 — the product surface this agent binds ('ask'|'build'). resolveActiveSkills enforces that only surface-compatible skills (matching, or 'both') attach; tool scoping is derived from that bundle."
     },
     "label": {
@@ -21,47 +21,47 @@
     },
     "role": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "persona → system prompt."
     },
     "instructions": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "system prompt."
     },
     "model": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts:264",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts:264",
       "note": "PARTIAL — model/temperature/maxTokens applied; model.provider + topP DEAD."
     },
     "skills": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "Agent→Skill→Tool."
     },
     "tools": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "legacy direct-tool fallback."
     },
     "active": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "gates listing + 403 on chat."
     },
     "planning": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts",
       "note": "Only planning.maxIterations remains; the dead strategy/allowReplan knobs were removed in 16.0 (#2377)."
     },
     "access": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/routes/agent-access.ts:50",
+      "evidence": "cloud: packages/service-ai/src/routes/agent-access.ts:50",
       "note": "evaluateAgentAccess() — allow-list by userId/role; enforced at the chat route (agent-routes.ts:151). #1884 (landed after the 2026-06 audit, which still listed it dead)."
     },
     "permissions": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/routes/agent-access.ts:50",
+      "evidence": "cloud: packages/service-ai/src/routes/agent-access.ts:50",
       "note": "evaluateAgentAccess() — caller must hold ALL required permissions/roles; enforced at the chat route. #1884."
     },
     "lifecycle": {

--- a/packages/spec/liveness/skill.json
+++ b/packages/spec/liveness/skill.json
@@ -1,52 +1,52 @@
 {
   "type": "skill",
-  "_note": "SkillSchema. Seeded from docs/audits/2026-06-skillschema-property-liveness.md. skill-registry.ts + agent-runtime.ts are the runtime consumers. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `packages/services/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code (the framework's own service-ai tree is a stale build artifact with no src/). 2026-08-06 (#3905): that used to be the WHOLE story — the open framework consumed nothing here. It now consumes the INSTRUCTIONS half: `packages/mcp/src/skill-prompts.ts` projects every active skill carrying `instructions` onto the MCP `prompts` primitive (name/label/description/instructions/active are read there, in-repo and testable). The TOOL-BINDING half (`tools`, `surface`, `triggerConditions`) stays cloud-runtime-only and now says so in the schema's own JSDoc. See content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent.",
+  "_note": "SkillSchema. Seeded from docs/audits/2026-06-skillschema-property-liveness.md. skill-registry.ts + agent-runtime.ts are the runtime consumers. ⚠ EVIDENCE LIVES IN CLOUD/EE: the `cloud: packages/service-ai/...` paths cited below are the closed `@objectstack/service-ai` runtime in the CLOUD repo, NOT git-tracked framework code. 2026-08-30 (#13272): the previous wording of this sentence was false in BOTH halves. (a) It called the framework's own service-ai tree “a stale build artifact with no src/” — there is no tree at all: `packages/services/` holds every sibling service EXCEPT service-ai, and `git ls-files | grep -ic service-ai` returns 0. Absent, not stale. (b) The citations spelled `packages/services/service-ai/...`, a path present in NEITHER repo; cloud's real layout, measured at cloud@15f55df (#13042), is `packages/service-ai/...`. Every citation below now carries the explicit `cloud` realm marker, so it is attributed by the marker `scanEvidence` reads rather than riding the `FOREIGN_PATH_PREFIXES` special case that silently exempted the stale spelling from resolution — which is why 22 dead pointers sat green. ⚠ NOT RE-VERIFIED: this repair corrected the package root from that recorded measurement ONLY. No consumer below was re-read against a cloud checkout, so no `verifiedAt` was stamped and no `#symbol` anchor was added — the gate never resolves a foreign anchor, so an unchecked one would re-create the unfalsifiable pointer this repair removes. Re-verifying these consumers against a live cloud checkout is still open (#13272). 2026-08-06 (#3905): that used to be the WHOLE story — the open framework consumed nothing here. It now consumes the INSTRUCTIONS half: `packages/mcp/src/skill-prompts.ts` projects every active skill carrying `instructions` onto the MCP `prompts` primitive (name/label/description/instructions/active are read there, in-repo and testable). The TOOL-BINDING half (`tools`, `surface`, `triggerConditions`) stays cloud-runtime-only and now says so in the schema's own JSDoc. See content/docs/ai for the open/cloud boundary. 2026-07-30 (#3896 close-out sweep): the dead authoring keys were REMOVED — tombstoned at the schema with prescriptions (retiredKey) and stripped by the protocol-17 close-out conversions; entries deleted per the #3715 precedent.",
   "props": {
     "name": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
       "note": "also the MCP prompt name in the open framework (#3905).",
       "verifiedAt": "2026-08-06"
     },
     "surface": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/agent-runtime.ts (resolveActiveSkills)",
+      "evidence": "cloud: packages/service-ai/src/agent-runtime.ts (resolveActiveSkills)",
       "note": "ADR-0063 §3 / ADR-0064 — skill↔agent affinity. resolveActiveSkills hard-fails when a bound skill's surface ('ask'|'build'|'both') is incompatible with the agent's surface; the union of surface-compatible skills' tools IS the agent's tool set (no global fall-through). CLOUD-RUNTIME-ONLY (#3905) — the open framework has no agent to bind to.",
       "verifiedAt": "2026-08-06"
     },
     "label": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
       "note": "injected into the agent system prompt (cloud); the MCP prompt `title` in the open framework (#3905).",
       "verifiedAt": "2026-08-06"
     },
     "description": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
       "note": "injected into prompt (cloud); the MCP prompt `description` in the open framework (#3905).",
       "verifiedAt": "2026-08-06"
     },
     "instructions": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (skillPromptResult)",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:247; packages/mcp/src/skill-prompts.ts (skillPromptResult)",
       "note": "injected into prompt (cloud); served as the MCP `prompts/get` message body in the open framework (#3905) — a skill without it is not projected at all.",
       "verifiedAt": "2026-08-06"
     },
     "tools": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:206",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:206",
       "note": "tool-contribution path incl. action_* wildcard. CLOUD-RUNTIME-ONLY (#3905): MCP exposes one flat tool list to a client-side model, so there is nothing to bind server-side; still validated at authoring time in both distributions.",
       "verifiedAt": "2026-08-06"
     },
     "triggerConditions": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:153",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:153",
       "note": "THE activation gate — AND of {field,operator,value}. CLOUD-RUNTIME-ONLY (#3905): MCP has no server-side activation step; a client lists every projected prompt and chooses.",
       "verifiedAt": "2026-08-06"
     },
     "active": {
       "status": "live",
-      "evidence": "packages/services/service-ai/src/skill-registry.ts:93; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
+      "evidence": "cloud: packages/service-ai/src/skill-registry.ts:93; packages/mcp/src/skill-prompts.ts (projectSkillPrompt)",
       "note": "inactive skills dropped — by the cloud registry, and not projected as an MCP prompt either (#3905).",
       "verifiedAt": "2026-08-06"
     },


### PR DESCRIPTION
Part of #13272.

Deliberately `Part of` rather than a closing keyword: this PR lands the half that
recorded evidence can justify, and the card's re-verification half is still open.
See "Scope boundary" below.

## What was wrong

Twenty-two `evidence` citations across three liveness ledgers named
`packages/services/service-ai/...`, a path that exists in **neither** repository:

| ledger | citations | `_note` repeated the falsified sentence |
|---|---|---|
| `packages/spec/liveness/agent.json` | 11 | yes |
| `packages/spec/liveness/skill.json` | 8 | yes |
| `packages/spec/liveness/action.json` | 3 | yes |

Both halves of the recorded claim were false, each in its own direction:

1. **The framework tree is absent, not stale.** Every `_note` called the
   framework's own service-ai tree "a stale build artifact with no `src/`".
   Measured in this checkout: `git ls-files | grep -ic service-ai` returns `0`,
   and `packages/services/` holds every sibling service except service-ai.
   There is no artifact to be stale.
2. **The prefix was wrong for cloud too.** Cloud's real layout, measured at
   cloud@`15f55df` and recorded on #13042, is `packages/service-ai/...` — never
   `packages/services/service-ai/...`.

## Why they sat green, and why the repair is not a plain re-spelling

`FOREIGN_PATH_PREFIXES` in `packages/spec/scripts/liveness/evidence.mts` lists
the **stale** spelling, so those citations were silently classified foreign and
never resolved. They did not survive scrutiny — they were exempt from it.

The real cloud path is repo-rooted in shape and is **not** in that list, so a
naive repoint resolves as LOCAL and fails CI. Every repointed citation therefore
carries the explicit `cloud` realm marker, which is the attribution
`scanEvidence` reads directly rather than a special case for one prefix.

**Measured by ablation on this branch** (fix committed first, mutation confirmed
on disk by anchored grep counts, restored to byte-identity against the HEAD
blobs afterwards):

| tree | gate line | exit |
|---|---|---|
| with the `cloud` markers | `467 repo-local ... 467 resolved; 154 attributed to another repo` | 0 |
| markers stripped (naive repoint) | `489 repo-local ... 467 resolved, 22 MISSING; 132 attributed` | 1 |

`132 + 22 = 154`, so the markers move exactly the twenty-two citations into the
foreign bucket and nothing else. The change is gate-neutral against `main`
(both spellings classify foreign) while removing a provably wrong path.

The constant is deliberately left untouched, per the card and its triage: adding
the real path to it would let an unmarked citation pass silently, trading one
unfalsifiable spelling for another.

## Scope boundary — recorded in each `_note`, not only here

This corrects the package root from the recorded measurement **only**. The cited
consumers were **not** re-read against a cloud checkout (this session has no
cloud access), so:

- no `verifiedAt` is stamped, and
- no `#symbol` anchor is added — the gate never resolves a foreign anchor, so an
  unverified one would re-create the very unfalsifiable pointer this repair
  removes.

No `status` verdict is altered. Re-verifying these 22 consumers against a live
cloud checkout remains the open half of #13272 and needs a container that has the
cloud repo.

## Verification

Run at `7e1580b9` (the final commit on this branch):

- `check:liveness` — exit 0; its own verdict line: "every 'live' / 'planned' /
  'experimental' entry's repo-local evidence path resolves".
- `check:empty-state`, `check:strictness-ledger`, `check:variant-docs` (the rest
  of `spec-liveness-check.yml`) — exit 0.
- `packages/spec` liveness suite — `evidence.test.ts`, `check-liveness.test.ts`,
  `verification.test.ts`, `key-mention.test.ts`: 4 files, 113 tests passed.
  These matter because `evidence.test.ts` walks the **real** ledger directory.
- `check:published-files`, `check:merge-driver`, `check:nul-bytes`, and the
  changeset family — exit 0.
- 27 of the 29 families derived by `scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack` are green. Two are NOT MEASURED by their own
  declaration, neither a red: `check-half-states` (needs a GitHub credential;
  `PREREQUISITE NOT MET`) and `check-test-completeness` (needs a saved test-run
  log, unreachable locally). Two more — `check:dev-prereqs` and
  `check:dual-build-cjs-loads` — are left to CI: both need a full build and this
  diff adds no build input, being JSON data plus a changeset.

The ledgers ship inside this package's npm tarball (`liveness` is named in
`files`), so this is a published-data change and carries a changeset, following
the precedent of the symbol-anchor batches.

## Note for the reviewer, on the dispatch brief

The brief for this card stated that `tool.json`'s five citations had been
repaired in PR #13302 and pointed there for the citation pattern. That is not
what PR #13302 contains — its diff is `packages/spec/scripts/check-llms-txt.ts`
plus `scripts/pm/dispatch-gates.mjs` (a watch-hint card). `tool.json` on
`origin/main` still carries all six occurrences of the stale prefix and is
untouched here, correctly, since it belongs to #13042. The repair pattern in this
PR was therefore derived from `evidence.mts` itself and from the ledger README's
realm-marker section, not from that PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KX8wnyjStaZcuMyAMNsy3N)_