### PR TITLE
feat(spec): register driver-memory as a UNIQUE_VIOLATION emitter in the error-code ledger

### DIFF
--- a/.changeset/driver-memory-unique-violation-provenance-row.md
+++ b/.changeset/driver-memory-unique-violation-provenance-row.md
@@ -1,0 +1,25 @@
+---
+"@objectstack/spec": patch
+---
+
+feat(spec): register `@objectstack/driver-memory` as an emitter of `UNIQUE_VIOLATION` in the error-code ledger (#13254)
+
+`ERROR_CODE_LEDGER` (ADR-0112 D3) lists a code once per emitting package —
+its own header calls those rows "provenance, not identity", and they are how a
+reader answers "who produces this code?".
+
+Since the in-memory driver started enforcing uniqueness (field-level `unique`,
+and object-level declared `indexes[]` entries carrying `unique`), a colliding
+write is refused with `code: 'UNIQUE_VIOLATION'` / `status: 409` — stamped in
+one place for both declaration surfaces by `conflictRefusal` in
+`packages/drivers/driver-memory/src/memory-unique-constraint.ts` — while
+`@objectstack/driver-memory` had no row at all. No gate could see that: the
+ledger's admission rules check casing, duplication and shadowing, never who
+emits, and the code itself was already registered by `@objectstack/rest`, so
+union membership, `ApiErrorSchema` parsing and
+`check:dispatcher-error-vocabulary` were all green over the gap.
+
+Pure provenance append: one new owner key naming the one code. No code's
+identity, status, casing or union membership changes, no other package's rows
+are touched, and the generated reference products are unchanged because the
+deduped union they enumerate is unchanged.

--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -669,6 +669,32 @@ export const ERROR_CODE_LEDGER = {
     'SUGGESTION_NOT_FOUND',
     'SUGGESTION_STATE',           // suggestion exists but is not in a confirmable/dismissable state
   ],
+  '@objectstack/driver-memory': [
+    // [#13254] Provenance for the in-memory driver's uniqueness refusal, which
+    // #13197 (field-level `unique`) and #13239 (declared `indexes[]` entries)
+    // made real: a colliding write is REFUSED rather than landed. Stamped in
+    // ONE place for both declaration surfaces — `conflictRefusal`
+    // (`packages/drivers/driver-memory/src/memory-unique-constraint.ts`),
+    // `code: 'UNIQUE_VIOLATION'` / `status: 409` via the package's exported
+    // `UNIQUE_VIOLATION_CODE` / `UNIQUE_VIOLATION_STATUS`.
+    //
+    // Second EMITTER of the code `@objectstack/rest` already registers for the
+    // SQL conflict; the wire identity is deliberately the SAME, so a suite that
+    // swaps this driver for SQLite sees ONE envelope. Per this file's header, a
+    // code emitted by several packages is listed once per emitting package —
+    // provenance, not identity.
+    //
+    // Wire-reachable by the test the "Retiring a code" section above applies
+    // (#8035): an ordinary create/update on an object with a `unique` field
+    // reaches `InMemoryDriver.create` on a server already serving HTTP, and
+    // `resolveThrownHttpError` puts the driver's `code`/`status` on the
+    // envelope. This row adds provenance ONLY: the code was already registered,
+    // so the union, its casing and every other package's rows are unchanged.
+    // Registered late for exactly the reason the row is worth having — no
+    // admission rule checks WHO emits, so an unlisted emitter is invisible to
+    // every gate the repo has.
+    'UNIQUE_VIOLATION',
+  ],
   '@objectstack/driver-sql': [
     // [#11991] The #11756 ruling's refusal (maintainer, 2026-08-25, verbatim
     // 「同意」 on 「C，但 pgnative 归入 Postgres 家族」): a knex client this


### PR DESCRIPTION
Fixes #13254

Adds the one provenance row the ledger was missing: `@objectstack/driver-memory` as an emitter of `UNIQUE_VIOLATION`. Pure append — a new owner key naming one already-registered code.

## The premise, re-verified on the base rather than recalled

Branched from `origin/main` at `881f8d8e`, which contains both ordering edges the card required:

- `git merge-base --is-ancestor 56c093c HEAD` exits 0 — PR #13249 (card #13197), the change that makes the claim true, is present.
- `5b3ff63c` (PR #13296, card #13182) is the most recent commit touching `packages/spec/src/api/error-code-ledger.zod.ts`, so the other open writer of this single-writer file has landed.

Both halves of the card's premise then measured on that base:

- **The row is absent.** `grep -n 'driver-memory\|UNIQUE_VIOLATION' packages/spec/src/api/error-code-ledger.zod.ts` returns exactly one line — `250: 'UNIQUE_VIOLATION',`, the `@objectstack/rest` registration. There is no `@objectstack/driver-memory` owner key anywhere in the file. (The R+37 unlock comment deliberately declined to assert this, having grepped a guessed path; this is the re-verification it asked for, against the real file.)
- **The emitter is real**, and its wire identity is read off the producer, not invented:
  - `packages/drivers/driver-memory/src/memory-unique-constraint.ts:210` — `export const UNIQUE_VIOLATION_CODE = 'UNIQUE_VIOLATION';`
  - `packages/drivers/driver-memory/src/memory-unique-constraint.ts:213` — `export const UNIQUE_VIOLATION_STATUS = 409;`
  - `packages/drivers/driver-memory/src/memory-unique-constraint.ts:500-506` — `conflictRefusal()`, the single place both declaration surfaces are stamped: `err.code = UNIQUE_VIOLATION_CODE; err.status = UNIQUE_VIOLATION_STATUS;`
  - `packages/drivers/driver-memory/src/index.ts:31-32` — both constants re-exported from the package entry.
  - Pinned by value on both surfaces: `memory-unique-constraint.test.ts:63-65` and `memory-declared-index-unique.test.ts:85-87` each assert `code` **and** `status`, and then the literal `'UNIQUE_VIOLATION'`.

So the row's fields are copied from landed reality: package `@objectstack/driver-memory`, code `UNIQUE_VIOLATION`, status 409.

## What changed

`packages/spec/src/api/error-code-ledger.zod.ts` — one new owner key placed beside `@objectstack/driver-sql`, grouping the two drivers, with a comment in the form the file's existing rows use: the producer and its stamping function, the second-emitter note the header's "provenance, not identity" rule calls for, and the wire-reachability argument in the shape `@objectstack/driver-sql`'s own row makes (an ordinary create/update on an object with a `unique` field reaches `InMemoryDriver.create` on a server already serving HTTP, and `resolveThrownHttpError` puts the driver's `code`/`status` on the envelope — the same test #8035 applied when it unregistered `MONGODB_MULTI_TENANT_UNSUPPORTED` for failing it).

Nothing else moves. No code's identity, status, casing or union membership changes; no other package's rows are touched; the ledger's shape and admission mechanism are untouched.

## No generated product moves, and that is measured, not assumed

`pnpm --filter @objectstack/spec check:generated` (after a real `build`, per the stale-dist caveat) prints **"All 14 generated artifacts are up to date"**, every one of the 14 individually green. That is the expected result rather than a missing step: the generated reference pages enumerate the **deduped union**, and `UNIQUE_VIOLATION` was already in it. Confirmed from the other side too — `content/docs/references/api/error-code-ledger.mdx` contains no owner key at all (`grep` for `driver-sql`, `@objectstack/rest`, `ERROR_CODE_LEDGER` returns nothing), so per-package rows have no rendered surface to drift.

Contrast the precedent commit `5b3ff63c`, which registered a genuinely **new** code and therefore did move `error-code-ledger.mdx` and `contract.mdx` by one line each.

## Verification

All of the following ran on the final head `659abf77`, heavy runs serialised through `scripts/pm/os-verify-lock.sh`. Verdict lines are the gates' own, not a captured `$?`:

- `pnpm --filter '@objectstack/spec...' build` — exit 0; `check-dts-emitted: @objectstack/spec - 34/34 declared declaration file(s) present.`
- `pnpm --filter @objectstack/spec check:generated` — `All 14 generated artifacts are up to date.`
- `pnpm check:dispatcher-error-vocabulary` — `OK — 22 unregistered code-stamping site(s), all classified; 1 awaiting a ledger entry (#8846).` (that pending entry is pre-existing and unrelated; scope line: 2103 non-test sources, 298 registered codes)
- `pnpm check:error-code-casing` — `no unlisted lowercase error codes in 5010 scanned file(s) (ADR-0112).`
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/api/error-code-ledger.test.ts src/api/errors.test.ts src/api/contract.test.ts src/api/error-catalog-docs.test.ts` — `Test Files 4 passed (4) / Tests 102 passed (102)`. These are the admission-rule pins: SCREAMING_SNAKE, per-package duplication, standard-catalog shadowing, owner-key shape, the deduped-sorted-union identity, and the #8211 synonym gate.
- `pnpm --filter @objectstack/driver-memory test` — `Test Files 31 passed (31) / Tests 905 passed (905)`. The consumer check the dispatch asked for: the row agrees with the emitter's readings and nothing in the producing package turned red.
- `pnpm --filter @objectstack/spec run typecheck` — exit 0; `check:test-typecheck: OK`.
- `pnpm lint` (`eslint . --no-inline-config`, repo-wide, **not** narrowed) — exit 0.
- The gate family re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (which reads its own change set from the merge base — 2 paths). Its 34 derived families were run: all green except three that measured **nothing** and say so in their own words — `check-dev-prereqs` and `check-doc-formula-expressions` reported `PREREQUISITE NOT MET` on an unbuilt workspace (the latter re-run green after building `@objectstack/formula` and `@objectstack/lint`), and `check-test-completeness` exited 3 with `PREREQUISITE NOT MET — this gate grades a saved turbo run test log`, which its own text records as NOT MEASURED locally and not a finding.
- `pnpm check:nul-bytes` — `OK (scanned 7401 text file(s) ... no raw ASCII control bytes)`.

## Changeset

`patch` on `@objectstack/spec`, not `minor`: the exported `ERROR_CODE_LEDGER` value gains a key, but `RegisteredErrorCode`, `REGISTERED_ERROR_CODES` and the `ErrorCode` union are byte-for-byte unchanged — no new vocabulary reaches any client. (The `5b3ff63c` precedent took `minor` because it added a code.)

## Clause-② and review posture

The PATH limb fires — the diff touches `packages/spec/src/**` — so this PR **stays DRAFT** and carries `needs:contract-review` on both carriers. This seat does not flip it ready, does not enqueue it, and does not clear the label; the review chain owns that. The card's own text ruled the same, and the content limb is the narrow one: a provenance row registers an already-landed refusal and changes no accept/reject behaviour.

## The sweep the card asked for — reported, not widened

The card asked whether any **other** emitter is missing a row, and to report rather than widen. A read-only literal scan over the 71 workspace packages under `packages/**` found five further packages stamping a registered code their own owner key does not list (four of them literal HTTP envelopes), plus one SDK-side sub-class. None of it is in this diff. Filed separately as #13353, with the per-site table, the triage that discarded the ledger's already-explained "door, not producer" cases, and the note that the recurring fix is a gate nobody has.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KX8wnyjStaZcuMyAMNsy3N)_