### PR TITLE
chore(pm): tighten pm-dispatch SKILL.md table-row pin to 642

### DIFF
--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -450,7 +450,7 @@ export const CEILINGS = new Map([
 export const MAX_TABLE_ROW_BYTES = new Map([
   // The five files that carry a table row today, each seeded at its own widest.
   // The corpus's #1 longest LINE of any shape is the AGENTS.md row below.
-  ['.claude/skills/pm-dispatch/SKILL.md', 765],
+  ['.claude/skills/pm-dispatch/SKILL.md', 642],
   ['.claude/skills/pm-dispatch/references/dispatch-runbook.md', 0],
   ['.claude/skills/pm-dispatch/references/state-machine.md', 0],
   ['.claude/skills/pm-dispatch/references/contract-review.md', 0],


### PR DESCRIPTION
Fixes #13090

## What

Follows the ratchet gate's own standing hint: lowers `MAX_TABLE_ROW_BYTES` for
`.claude/skills/pm-dispatch/SKILL.md` in `scripts/pm/check-skill-line-ratchet.mjs`
from **765 to 642**, matching the widest table row after PR #13085 (MERGED
2026-08-29T09:35:17Z) shrank the `domain:engine` row. Gate-script edit only —
`.claude/skills/pm-dispatch/SKILL.md` itself is untouched. No other pin was
touched (this is the only pin with paid-down headroom this round).

## Proof (headroom returns to 0, as expected)

Before (pre-edit, at merge-base `56c5b1d`):
```
ℹ️  .claude/skills/pm-dispatch/SKILL.md: max-table-row-bytes headroom is 123 — every pin is
    seeded at 0 headroom, so a row has been paid down; lower the pin to 642
    (shrink-only ratchets tighten opportunistically).
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md: widest table row is 642 bytes
    (pin 765; headroom 123).
```

After (at head `d4c5141b0`):
```
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md: widest table row is 642 bytes
    (pin 642; headroom 0).
```
No hint line prints post-edit — headroom is 0, which is the expected/intended
result of a freshly-paid-down pin, not a failure.

`node scripts/pm/check-skill-line-ratchet.mjs` — EXIT 0
`node scripts/pm/check-skill-line-ratchet.mjs --self-test` — `111 cases pass`, EXIT 0
`pnpm check:pm-skill-ratchet` — EXIT 0 (runs both of the above)

## Local gates run at head `d4c5141b0`

Derived from the actual diff via `node scripts/pm/dispatch-gates.mjs` (not copied
from the dispatch brief) — all green:

- `pnpm check:agent-test-spelling`
- `pnpm check:bash32-floor`
- `pnpm check:cli-command-ids`
- `pnpm check:cross-package-test-inputs`
- `pnpm check:entry-guard`
- `pnpm check:parse-guard`
- `pnpm check:pm-skill-ratchet`
- `pnpm check:pnpm-filter-targets`
- `pnpm check:watch-hint-literal`
- `node scripts/check-ci-filter-parity.mjs`
- `node scripts/check-cross-package-test-inputs.mjs`
- `node scripts/check-shard-attestation.mjs`

Plus two convention-triggered obligations the derivation surfaces for any
gate-SCRIPT edit (not named in the dispatch brief; re-derived and run here):
- `node scripts/pm/bare-root-worklist.mjs --self-test` — `OK`, 50 live rows, none stale/missing/contradicted
- `pnpm check:pm-dispatch-gates` — `dispatch-gates self-test: 897 cases pass`

`node scripts/check-test-completeness.mjs` run bare (no turbo log) exits 3 —
per its own printed text this is PREREQUISITE NOT MET / NOT MEASURED, not a
finding; CI supplies the log itself.

## Scope

`scripts/pm/check-skill-line-ratchet.mjs` only — one line. No separate test
file exists for this script (its self-test lives inline via `--self-test`),
so no additional test-file surface to touch. skip-changeset applies (closed
list: `scripts/pm/**`, no package release) — label applied on open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_