### PR TITLE
fix(pm-dispatch): gate the worktree-rescue step with the three adjudicated fences

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -552,10 +552,14 @@ pin 前置等运维细则见 `references/seat-post-protocol.md`)。** 判据二�
 
 dev 侧早推分支 —— 远程分支是在飞工作最硬的证据。**死认领回收(stale-claim reclaim)**:
 认领 >~24h、承诺分支不存在、无 PR ⇒ 死认领 —— **回收前先救工作树**:
-派发 worktree 的未提交改动先 WIP commit 到派发分支并 push,sha 记进回收评论、
-标 INCOMPLETE AND UNREVIEWED(续派者 diff 它,⛔ 不无审续建;
-死在编辑中途的 dev 没来得及自己 WIP 推,这一步是最后防线)—— 再评论询问,
-静默一窗后摘 assignee(注明原因)回队;有带提交活分支的认领永不回收。
+**存活前置**:向任何派发 worktree 提交前(任何 actor)先过存活/所有权检查,
+或对树最新 mtime 过明确年龄阈值;⛔ 不凭 GitHub 侧静默动手 —— 零提交、零推送、无 PR,
+在干活但未推的席位给出同一组信号:未提交改动是在飞工作的证据,不是死亡的证据。
+过栏后,派发 worktree 的未提交改动先 WIP commit 到派发分支并 push,sha 记进回收评论、
+标 INCOMPLETE AND UNREVIEWED(抬头限救树者行为,保留;续派者 diff 它,⛔ 不无审续建);
+**消息边界**:WIP 信息只写观察到的(脏路径/行数/sha),⛔ 不写席位行为的现在时断言。
+再评论询问,静默一窗后摘 assignee(注明原因)回队;有带提交活分支的认领永不回收。
+**误伤补救**:误伤活席位 ⇒ 令其追加式更正,落 PR 正文不落分支历史(dev 禁 force-push)。
 
 ### 派发
 


### PR DESCRIPTION
Fixes #12637

Writes the three adjudicated fences from the card's 2026-08-28 grading (取卡者围栏, 缺一不可) into the standing worktree-rescue step of the stale-claim reclaim passage, `.claude/skills/pm-dispatch/SKILL.md` (passage now lines 553-562; anchor `INCOMPLETE AND UNREVIEWED` re-derived on merged main `c38b7eff7` at :556 before editing). `dispatch-runbook.md` untouched — no split was needed.

## The three fences, and where each landed

1. **存活前置 (liveness precondition)** — new lines 555-557: before committing into any dispatch worktree, any actor first passes a liveness/ownership check or an explicit age threshold on the worktree's newest mtime; GitHub-side silence alone is never grounds. Faithful add: the evidence-not-death rationale — zero commits / zero pushes / no PR are the identical signals for a working-but-unpushed seat; 「未提交改动是在飞工作的证据,不是死亡的证据。」
2. **消息边界 (message boundary)** — new line 560: the rescue WIP message states only rescuer-observables (dirty paths / line counts / sha); 「⛔ 不写席位行为的现在时断言。」 The standing `INCOMPLETE AND UNREVIEWED` header stays, now explicitly scoped on line 559: 「抬头限救树者行为,保留」.
3. **误伤补救 (mis-hit remedy)** — new line 562: a rescue that hits a live seat is corrected additively by that seat, in the PR body, never by history rewrite; faithful add: the reason spelled inline (dev 禁 force-push).

The one sanctioned in-passage deletion (per the R1 PM disposition, option A, 2026-08-30T07:16Z): the last-line-of-defense rationale clause 「死在编辑中途的 dev 没来得及自己 WIP 推,这一步是最后防线」 (79 bytes at line 557 pre-edit) — its dev-already-dead premise is exactly what fence 1 corrects. Everything else in the passage is preserved verbatim, including 「续派者 diff 它,⛔ 不无审续建」 and 「有带提交活分支的认领永不回收」. No ceiling change, no re-wrap-as-funding (2026-08-17 ruling), no unrelated deletions. Faithful (+4) spelling chosen over the floor (+2) per the dispatch's preference: this is protocol text about honest evidence bounds, and the two faithful adds are the rationale and the no-force-push note.

## Line budget

| file | before | after | ceiling | headroom after |
|---|---|---|---|---|
| .claude/skills/pm-dispatch/SKILL.md | 943 | 947 | 1005 | 58 |
| references/dispatch-runbook.md | 271 | 271 (untouched) | 278 | 7 |

Net +4 lines (8 insertions, 4 deletions), inside the headroom freed by #13389. Every touched line is 116 bytes or less (widest new line: 116).

## Gates — union run at final commit `01769913b`, clean tree, exits captured by redirect-then-capture

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` in the worktree (change set: exactly this one file). All nine matched families:

- check:pm-skill-ratchet — exit 0 — verdicts: 「.claude/skills/pm-dispatch/SKILL.md is 947 lines (ceiling 1005; headroom 58).」 and 「widest table row is 642 bytes (pin 642; headroom 0).」
- check:pm-governed-prose — exit 0 — 「2 instruction surface(s) name all 5 registered governed surfaces … and claim no others.」 (pinned region untouched)
- check:pm-skill-id-lint — exit 0 — 「23 file(s) clean」
- check:skill-frame-sync — exit 0 — 「binding sentence present in all 4; 4 count mention(s) agree」
- check:agent-test-spelling — exit 0
- check:doc-authoring — exit 0 — 「831 pinned site(s) … no growth, no burn-down unrecorded.」
- check:doc-formula-expressions — exit 0 — 「57 cases passed」 + three clean sweeps (needed `@objectstack/formula` and `@objectstack/lint` built first; the first two runs printed the gate's own PREREQUISITE NOT MET banner — not-measured, not red)
- check:pm-governed-merges — exit 0 — 「--self-test: 230 assertions」 + live generator certification
- check-governed-queue-guard — CI-context only: locally it refuses with 「could not read GITHUB_EVENT_PATH」 by design (it judges the workflow event payload); it runs at queue time in governed-surface-guard.yml
- check:nul-bytes — exit 0 (owed on any edit)

Stale-tree note: origin/main advanced to `d38ad7fc5` during the run (three commits); none touches `.claude/skills/pm-dispatch/` or any matched gate script, so the family list and the budget arithmetic stand. Base refresh before the human merge is the PM's landing step per the grading.

## Reverse verification (fix committed first; both restores proven by hash equality against the HEAD blob plus empty `git diff HEAD`)

The gate reads the source file directly from the working tree (no dist, no exports resolution), so no build leg applies; each mutation was proven on disk before reading the gate (marker grep hit count plus measured line count/width).

- Leg 1 — plus one line (948): predicted GREEN, observed GREEN — 「SKILL.md is 948 lines (ceiling 1005; headroom 57)」, exit 0. This deliberately falsifies the dispatch example's premise (+1 line goes RED) — that premise belonged to R1's zero-headroom world; after #13389 the line ceiling does not bind at +1, and the binding envelope on this card is the adjudicated +2..+4 budget, not the ratchet.
- Leg 2 — line 560 widened to 198 bytes: predicted RED, observed RED — exit 1, verdict 「SKILL.md has 1 line(s) over the 120-byte budget: L560 (198B)」. This is the constraint that actually binds every line this PR touches.
- Both legs restored: `git hash-object` equals HEAD blob `d4abba29c2f7b1385d9d363cc7dd81148a40fec3`, `git diff HEAD` empty, under an EXIT/INT/TERM trap with absolute paths.

## Governed surface posture

Diff is `.claude/**` only — this PR stays DRAFT; no ready flip, no queue, no auto-merge, no review from any seat. The maintainer lands it by hand (or via the pinned-approval path) after the PM's ACCEPT review. `skip-changeset` applies (publishes nothing from any package; closed-list diff class).

_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_