### PR TITLE
fix(scripts): doc-authoring self-test pins its batteries by NAME, so a battery that stops running is named rather than uncounted

### DIFF
--- a/scripts/check-doc-authoring.mjs
+++ b/scripts/check-doc-authoring.mjs
@@ -1507,6 +1507,12 @@ const SELF_TEST_BATTERIES = Object.freeze({
   'cross-package ledger arithmetic': 7,
 });
 
+// The registry is shrink-only in the same sense its counts are: DELETING an
+// entry silences that battery's floor exactly as effectively as zeroing it, so
+// the registry's own size is pinned too. Adding a battery raises this number;
+// removing one is the same ⛔ MAINTAINER-ONLY edit as lowering a count.
+const SELF_TEST_BATTERY_FLOOR = 16;
+
 // The key an assertion is filed under when no battery is open. It is not a
 // declared battery, so it reds by the same set difference rather than silently
 // inflating whichever battery happened to run last.
@@ -1892,6 +1898,13 @@ function selfTest() {
   const declaredBatteries = Object.keys(SELF_TEST_BATTERIES);
   const totalCases = [...seen.values()].reduce((a, b) => a + b, 0);
   let floorBreached = false;
+  if (declaredBatteries.length < SELF_TEST_BATTERY_FLOOR) {
+    floorBreached = true;
+    failures.push(
+      `  ✗ SELF_TEST_BATTERIES declares ${declaredBatteries.length} batteries, below the pinned `
+      + `${SELF_TEST_BATTERY_FLOOR} — a battery deleted from the registry takes its own floor with it.`,
+    );
+  }
   for (const [name, count] of seen) {
     if (declaredBatteries.includes(name)) continue;
     floorBreached = true;

--- a/scripts/check-doc-authoring.mjs
+++ b/scripts/check-doc-authoring.mjs
@@ -1460,6 +1460,64 @@ function findViolations(source, file) {
   return out;
 }
 
+// ── The self-test's own battery registry and floor (#13173) ───────────────
+//
+// `failures.length === 0` used to be the ONLY success condition of the
+// self-test below, so "every case held" and "the cases never ran" produced the
+// same output. Measured on 8fcd0816: an early `return` at the top of
+// `selfTestRule3()` left that entire battery unrun and this file still exited
+// 0, printing the verdict line that asserts those cases hold — in the gate that
+// exists to catch prose claiming more than the code delivers.
+//
+// ⛔ A merely non-zero count is not the repair, and neither is a pinned TOTAL:
+// a battery quietly dropping from 40 cases to 3 keeps a total "right" for the
+// wrong reason as soon as any sibling grows. What is pinned here is the
+// registered NAMES — every battery declares itself with `battery('<name>')`,
+// every `expect()` is attributed to the battery most recently opened, and the
+// floor requires the OPENED set to equal the DECLARED set with each battery at
+// or above its own count. A set difference says WHICH battery stopped running;
+// a count says only that something did. (Same lesson, same week, as the
+// dispatcher-error-vocabulary gate, whose `--self-test` iterated its samples
+// map rather than its SHAPES list and printed "8 shapes OK" with 9 published.)
+//
+// The counts are a FLOOR, not an equality: adding cases is ordinary work and
+// must not red. A battery falling BELOW its floor means cases stopped running,
+// and the remedy is to find what stopped registering — never to lower the
+// number. See the refusal text beside `RATCHET_AUTHORITY_MARKER` below.
+//
+// Audited on 8fcd0816 by instrumenting `expect` and diffing every executed
+// call site against every static one: 16 batteries, 198 assertions, and every
+// static call site in the file executes — no battery was already dark.
+const SELF_TEST_BATTERIES = Object.freeze({
+  'scope wiring': 9,
+  'docs/ corpus scope': 15,
+  'dead-root hard error': 5,
+  'empty-scan hard error': 8,
+  'published-catalog id rule': 15,
+  'published-catalog id precision': 15,
+  'dispatch-gates declaration': 5,
+  'spec text: core populations': 20,
+  'spec text: folded-in buckets': 23,
+  'spec text: type anchors': 11,
+  'spec text: fourth population': 14,
+  'spec text: fifth population': 14,
+  'spec text: precision': 18,
+  'spec text: boundary output': 8,
+  'cross-package prose ids': 11,
+  'cross-package ledger arithmetic': 7,
+});
+
+// The key an assertion is filed under when no battery is open. It is not a
+// declared battery, so it reds by the same set difference rather than silently
+// inflating whichever battery happened to run last.
+const UNATTRIBUTED_BATTERY = '(no battery open)';
+
+// Returned by `selfTest()` only after the floor has been evaluated and the
+// verdict printed. `main()` refuses anything else: a `return` that leaves the
+// function early prints nothing and exits 0, which is the same
+// nothing-ran-nothing-complained pass one level up.
+const SELF_TEST_VERDICT = 'check-doc-authoring self-test reached its verdict';
+
 // The reverse proof, made permanent (#4913). `.claude/` currently holds zero ts
 // code blocks, so adding it to ROOTS leaves the gate green — which is exactly
 // what "added it and it still cannot see the directory" looks like from outside.
@@ -1505,7 +1563,15 @@ function selfTest() {
   const dir = mkdtempSync(join(tmpdir(), 'doc-authoring-selftest-'));
   const cwd = process.cwd();
   const failures = [];
+  const seen = new Map();
+  let openBattery = null;
+  // Declare the battery the following assertions belong to. The name must be a
+  // key of SELF_TEST_BATTERIES — an unknown one reds by set difference, naming
+  // itself, rather than being counted somewhere it is not floored.
+  const battery = (name) => { openBattery = name; };
   const expect = (label, got, want) => {
+    const b = openBattery ?? UNATTRIBUTED_BATTERY;
+    seen.set(b, (seen.get(b) ?? 0) + 1);
     if (got !== want) failures.push(`  ✗ self-test "${label}": expected ${want}, got ${got}`);
   };
 
@@ -1519,6 +1585,7 @@ function selfTest() {
     const files = collectFiles().map(posix);
     const violations = files.flatMap((f) => findViolations(readFileSync(f, 'utf8'), f));
 
+    battery('scope wiring');
     expect('.claude is walked', files.includes('.claude/skills/demo/SKILL.md'), true);
     expect('.claude is not limited to skills/', files.includes('.claude/agents/os-dev.md'), true);
     expect(
@@ -1533,6 +1600,7 @@ function selfTest() {
     expect('defineX factory form passes', violations.some((v) => v.file === 'skills/legit/SKILL.md'), false);
     expect('non-ts fence and prose pass', violations.some((v) => v.file === 'content/docs/ui/pages.mdx'), false);
 
+    battery('docs/ corpus scope');
     // --- #4929: the live docs/ corpus is reachable, the process records are not. ---
     // Stated as two halves of one claim, because either half alone is satisfied by
     // a scope that is simply wrong in the other direction: "docs/adr is red" is
@@ -1553,6 +1621,7 @@ function selfTest() {
 
     expect('total violations', violations.length, 5);
 
+    battery('dead-root hard error');
     // --- Reverse proof for the dead-root hard error (#4916), made permanent. ---
     // Everything above ran green over a tree where all three roots resolve. That
     // observation is worth nothing on its own: the defect being fixed here is a
@@ -1585,6 +1654,7 @@ function selfTest() {
     // by the broken root and nothing else.
     expect('restoring the roots makes the scan green again', collectFiles().length, files.length);
 
+    battery('empty-scan hard error');
     // --- Reverse proof for the empty-scan hard error (#4932), same discipline. ---
     // The direction was decided before it was run: a root that resolves and yields
     // nothing must be RED, and the red must name that root only. This is the case
@@ -1620,6 +1690,7 @@ function selfTest() {
     expect('every empty root is named', allEmptyErr?.roots?.join(',') ?? '<none>', ROOTS.join(','));
     expect('the zero total is reported', allEmptyErr?.total ?? -1, 0);
 
+    battery('published-catalog id rule');
     // ── Rule 2: internal issue ids on the published surface ──────────────
     //
     // The red/green PAIR is the point. "Green on the real corpus" is what a
@@ -1700,6 +1771,7 @@ function selfTest() {
       writeFileSync(planted, 'The `cursor` key was removed in protocol 17.');
       expect('removing the id makes it green again', scan().length, 0);
 
+      battery('published-catalog id precision');
       // ── Precision: the shapes that must NEVER fire ──────────────────────
       // Each is a real spelling from the catalog. A gate that reds on any of
       // them is one authors learn to route around, which costs more than the
@@ -1752,13 +1824,14 @@ function selfTest() {
       rmSync(idDir, { recursive: true, force: true });
     }
 
-    selfTestRule3(expect);
-    selfTestPackagesProse(expect);
+    selfTestRule3(expect, battery);
+    selfTestPackagesProse(expect, battery);
   } finally {
     process.chdir(cwd);
     rmSync(dir, { recursive: true, force: true });
   }
 
+  battery('dispatch-gates declaration');
   // ── The dispatch-gates declaration (#9964's pattern, sixth instance) ───────
   //
   // Enforcement cannot hold any of these: the declaration is read by another
@@ -1811,11 +1884,53 @@ function selfTest() {
   // The behavioural half is pinned above: the concrete ids the placeholder
   // replaced are RED, with nothing to add them to.
 
+  // ── The floor: every declared battery RAN, and ran its cases ────────────
+  //
+  // Evaluated here, after every battery has had its chance, and BEFORE the
+  // verdict — so the verdict line below can only be printed by a run in which
+  // the set of batteries that registered assertions equals the set declared.
+  const declaredBatteries = Object.keys(SELF_TEST_BATTERIES);
+  const totalCases = [...seen.values()].reduce((a, b) => a + b, 0);
+  let floorBreached = false;
+  for (const [name, count] of seen) {
+    if (declaredBatteries.includes(name)) continue;
+    floorBreached = true;
+    failures.push(
+      `  ✗ self-test battery "${name}" registered ${count} case(s) but is not declared in `
+      + 'SELF_TEST_BATTERIES — an assertion attributed to no declared battery is one nothing floors.',
+    );
+  }
+  for (const name of declaredBatteries) {
+    const count = seen.get(name) ?? 0;
+    if (count >= SELF_TEST_BATTERIES[name]) continue;
+    floorBreached = true;
+    failures.push(
+      count === 0
+        ? `  ✗ self-test battery "${name}" DID NOT RUN — 0 cases registered, `
+          + `${SELF_TEST_BATTERIES[name]} pinned. The verdict below would have claimed they hold.`
+        : `  ✗ self-test battery "${name}" registered ${count} case(s), below its pinned floor `
+          + `of ${SELF_TEST_BATTERIES[name]} — cases that used to run no longer do.`,
+    );
+  }
+
   if (failures.length) {
     console.error(`\n✗ check-doc-authoring self-test failed:\n${failures.join('\n')}\n`);
+    if (floorBreached) {
+      console.error(
+        'A battery at or below its floor means cases STOPPED RUNNING — the battery is the bug,'
+        + '\nnot the number. Find what stopped registering (an early return, a deleted block, a'
+        + '\nguard that now skips, a marker that moved) and restore it. Raising a floor after'
+        + `\nADDING cases is ordinary landing-author work; LOWERING one is ${RATCHET_AUTHORITY_MARKER},`
+        + '\nNOT a co-equal option — "the count legitimately moved" and "something stopped running"'
+        + '\nneed different edits, and only a measurement tells them apart.\n',
+      );
+    }
     process.exit(1);
   }
-  console.log('✓ check-doc-authoring self-test: scope wiring (.claude and the live docs/ corpus in, .claude/worktrees and docs/{audits,handoff,plans} out), detection, the dead-root hard error (red when a ROOT is renamed, green when restored), the empty-scan hard error (red when a root yields nothing and when the whole scan does, green when restored), the published-catalog internal-id rule (red on a planted id in prose, in a fenced comment and in the repo#NNNN spelling, green when removed; hex colours, version numbers, HTTP codes, array indices and the "#1" ordinal all pass; references/ reached, generated artifacts and the internal roots out; the `#<n>` placeholder passes while the concrete ids it replaced stay red, with no exemption to reach for), the spec customer-facing-text internal-id rule (red on an id planted on a LATER line of a concatenated message — the shape a line-oriented census cannot see, proven here — and in a template chain, a positional validator message, the repo#NNNN spelling, a nested strictObject `guidance` prescription, a HOISTED guidance const, a `KeySetGuidance` const consumed only CROSS-MODULE in both the annotated and the `as const satisfies` spelling, a HOISTED refusal message, a `retiredKey()` tombstone, `new Map` and `Object.freeze` guidance tables, `.describe()` prose, and the nested `guidance` of a whole options table written `satisfies StrictObjectOptions`; green when removed; an ADR id on a tombstone, a `.default()` VALUE, `history`/`guidance` outside a strictObject options position, `extraKeys` key names and an inferred local that merely MENTIONS `KeySetGuidance` all pass; test bodies out; the seen floor is PER BUCKET so one matcher rotting while the others carry the total still reds; and the two TYPE ANCHORS are pinned on the predicate itself — the annotation, `satisfies` and `as const satisfies` spellings all read as a strictObject options position while some other satisfied type does not, and the `*_STRICT_OPTIONS` NAME branch still fires where no type is written at all — which is the only place they can be told apart, since end to end they are redundant), the fourth population — customer-facing text BUILT INSIDE A FUNCTION (red on an id in an inline `error: () =>` callback, in a const the callback only dispatches to, inside a `message:` builder function, RETURNED from a tombstone-prescription builder, in a `: StrictObjectOptions` options factory, and in a plain `error:` string; ⛔ the body of an ordinary helper and a local inside a recognised factory stay unswept, because the climb crosses a function only when the FUNCTION sits in a recognised position; and `functionBuilt` carries its own blindness floor, since an unrecognised spelling produces no flag SILENTLY), the FIFTH population — prose built inside plain `function` DECLARATIONS (#13156: red on an id in a declaration consumed by `message:`, RETURNED to a `retiredKey()` argument, and in a const the declaration only dispatches to; its own `functionDeclared` bucket with its own floor, so the declaration clause rotting cannot hide behind the arrows; ⛔ an unconsumed declaration and one consumed only by an unrecognised call stay unswept — the clause is the fourth population\'s, one declaration form over, never an unconditional crawl), the GENERATED table — a prescription filed under each of a list of keys by `Object.fromEntries(keys.map(…))` rather than written as an object literal (red both HOISTED into a const spread into an options factory\'s `guidance` and generated INLINE at the `guidance:` key itself, green when the id is removed; ⛔ and a generated VALUE table reaching no sink stays unswept, because `.map()` is TRANSPARENT to the climb and never a position of its own), the Rule 3 boundary OUTPUT (names the position-based root AND the ledgered cross-package leg\'s root, exclusion and baseline, no longer claims siblings are unscanned, and lists every floored bucket — derived from the same constants the scans read), the CROSS-PACKAGE prose-id leg (#13297: a concatenation-split id in a plain helper is counted — total-string coverage, no position climb to rot; a `//` comment, a test body and the spec subtree are out; an id inside a template\'s embedded expression counts exactly once; a 6-digit colour never matches while the cross-repo spelling\'s id half does; the prefilter is a superset of the id regex on every counted site; and the ledger arithmetic answers all three verdicts from one measurement — exact baseline green, empty baseline all-growth, over-pinned baseline stale without invented growth) and the dispatch-gates declaration (every separator-less walked root declared as a subtree — `packages/**` included since #13297 — nothing declared this gate does not walk, the over-claim bounded to SKIP_PATHS) all hold.');
+  console.log('✓ check-doc-authoring self-test: scope wiring (.claude and the live docs/ corpus in, .claude/worktrees and docs/{audits,handoff,plans} out), detection, the dead-root hard error (red when a ROOT is renamed, green when restored), the empty-scan hard error (red when a root yields nothing and when the whole scan does, green when restored), the published-catalog internal-id rule (red on a planted id in prose, in a fenced comment and in the repo#NNNN spelling, green when removed; hex colours, version numbers, HTTP codes, array indices and the "#1" ordinal all pass; references/ reached, generated artifacts and the internal roots out; the `#<n>` placeholder passes while the concrete ids it replaced stay red, with no exemption to reach for), the spec customer-facing-text internal-id rule (red on an id planted on a LATER line of a concatenated message — the shape a line-oriented census cannot see, proven here — and in a template chain, a positional validator message, the repo#NNNN spelling, a nested strictObject `guidance` prescription, a HOISTED guidance const, a `KeySetGuidance` const consumed only CROSS-MODULE in both the annotated and the `as const satisfies` spelling, a HOISTED refusal message, a `retiredKey()` tombstone, `new Map` and `Object.freeze` guidance tables, `.describe()` prose, and the nested `guidance` of a whole options table written `satisfies StrictObjectOptions`; green when removed; an ADR id on a tombstone, a `.default()` VALUE, `history`/`guidance` outside a strictObject options position, `extraKeys` key names and an inferred local that merely MENTIONS `KeySetGuidance` all pass; test bodies out; the seen floor is PER BUCKET so one matcher rotting while the others carry the total still reds; and the two TYPE ANCHORS are pinned on the predicate itself — the annotation, `satisfies` and `as const satisfies` spellings all read as a strictObject options position while some other satisfied type does not, and the `*_STRICT_OPTIONS` NAME branch still fires where no type is written at all — which is the only place they can be told apart, since end to end they are redundant), the fourth population — customer-facing text BUILT INSIDE A FUNCTION (red on an id in an inline `error: () =>` callback, in a const the callback only dispatches to, inside a `message:` builder function, RETURNED from a tombstone-prescription builder, in a `: StrictObjectOptions` options factory, and in a plain `error:` string; ⛔ the body of an ordinary helper and a local inside a recognised factory stay unswept, because the climb crosses a function only when the FUNCTION sits in a recognised position; and `functionBuilt` carries its own blindness floor, since an unrecognised spelling produces no flag SILENTLY), the FIFTH population — prose built inside plain `function` DECLARATIONS (#13156: red on an id in a declaration consumed by `message:`, RETURNED to a `retiredKey()` argument, and in a const the declaration only dispatches to; its own `functionDeclared` bucket with its own floor, so the declaration clause rotting cannot hide behind the arrows; ⛔ an unconsumed declaration and one consumed only by an unrecognised call stay unswept — the clause is the fourth population\'s, one declaration form over, never an unconditional crawl), the GENERATED table — a prescription filed under each of a list of keys by `Object.fromEntries(keys.map(…))` rather than written as an object literal (red both HOISTED into a const spread into an options factory\'s `guidance` and generated INLINE at the `guidance:` key itself, green when the id is removed; ⛔ and a generated VALUE table reaching no sink stays unswept, because `.map()` is TRANSPARENT to the climb and never a position of its own), the Rule 3 boundary OUTPUT (names the position-based root AND the ledgered cross-package leg\'s root, exclusion and baseline, no longer claims siblings are unscanned, and lists every floored bucket — derived from the same constants the scans read), the CROSS-PACKAGE prose-id leg (#13297: a concatenation-split id in a plain helper is counted — total-string coverage, no position climb to rot; a `//` comment, a test body and the spec subtree are out; an id inside a template\'s embedded expression counts exactly once; a 6-digit colour never matches while the cross-repo spelling\'s id half does; the prefilter is a superset of the id regex on every counted site; and the ledger arithmetic answers all three verdicts from one measurement — exact baseline green, empty baseline all-growth, over-pinned baseline stale without invented growth) and the dispatch-gates declaration (every separator-less walked root declared as a subtree — `packages/**` included since #13297 — nothing declared this gate does not walk, the over-claim bounded to SKIP_PATHS) all hold.'
+    + ` — ${declaredBatteries.length} declared batteries, ${totalCases} cases registered, every`
+    + ' battery at or above its pinned floor.');
+  return SELF_TEST_VERDICT;
 }
 
 /**
@@ -1827,7 +1942,8 @@ function selfTest() {
  * concatenation case is first because it is the one the commissioning card's
  * own census command could not see.
  */
-function selfTestRule3(expect) {
+function selfTestRule3(expect, battery) {
+  battery('spec text: core populations');
   const ts = requireFromHere('typescript');
   const cwd = process.cwd();
   const dir = mkdtempSync(join(tmpdir(), 'doc-authoring-selftest-msg-'));
@@ -1985,6 +2101,7 @@ function selfTestRule3(expect) {
     r = scan();
     expect('the `repo#NNNN` spelling is RED here too', r.violations.length, 1);
 
+    battery('spec text: folded-in buckets');
     // ── The three buckets folded in by the 2026-08-26 triage ────────────────
     //
     // Same discipline as everything above: each is a PAIR, and each is written
@@ -2173,6 +2290,7 @@ function selfTestRule3(expect) {
     expect('the options-table red is bucketed as a strictObject option',
       r.violations[0]?.bucket, 'strictObject');
 
+    battery('spec text: type anchors');
     // ── The TYPE ANCHORS, asserted on the PREDICATE ─────────────────────
     //
     // Not through a scan, and the reason is the whole point of this block: the
@@ -2236,6 +2354,7 @@ function selfTestRule3(expect) {
         declaredTypeText(decl, ts), '');
     }
 
+    battery('spec text: fourth population');
     // ── The FOURTH population: text BUILT INSIDE A FUNCTION ─────────────────
     //
     // Ruled 2026-08-29, verbatim 「同意」 — the inheritance reaches refusal prose
@@ -2346,6 +2465,7 @@ function selfTestRule3(expect) {
     expect('a plain `error:` string is a MESSAGE, not function-built',
       r.violations[0]?.bucket, 'message');
 
+    battery('spec text: fifth population');
     // ── The FIFTH population: plain `function` DECLARATIONS (#13156) ────────
     //
     // Adjudicated 2026-08-29 under the #13002 ruling's own sentence — the ban
@@ -2470,6 +2590,7 @@ function selfTestRule3(expect) {
     writeFileSync(target, INLINE_GENERATED('belongs to a single VIEW.'));
     expect('...and green once the id is gone', scan().violations.length, 0);
 
+    battery('spec text: precision');
     // ── Precision: what must NEVER fire ─────────────────────────────────────
     //
     // ⛔ The clause is NOT "climb through function bodies". These three are the
@@ -2689,6 +2810,7 @@ function selfTestRule3(expect) {
     expect('a tree with no recognised customer-facing string reports every bucket 0 (main reds)',
       Object.values(r.seen).reduce((a, b) => a + b, 0), 0);
 
+    battery('spec text: boundary output');
     // ── The C half of the 2026-08-29 adjudication: the boundary is STATED ───
     //
     // Asserted derived-vs-derived, never re-spelled: the root from the constant
@@ -2731,9 +2853,10 @@ function selfTestRule3(expect) {
 
 // The #8435 authority token, verbatim — check-ratchet-remedy-authority.mjs
 // sweeps author-facing text for an offer that expands a registry and requires
-// this marker (or an outright refusal) beside it. The prose-id baseline below
-// is exactly such a registry: shrink is the landing author's to take, growth
-// is not.
+// this marker (or an outright refusal) beside it. Two registries here are
+// exactly that. The prose-id baseline below: shrink is the landing author's to
+// take, growth is not. And SELF_TEST_BATTERIES: raising a floor after adding
+// cases is the landing author's, lowering one is not.
 const RATCHET_AUTHORITY_MARKER = '⛔ MAINTAINER-ONLY';
 
 /**
@@ -2792,7 +2915,8 @@ function census(ledgerOnly) {
  * leaves `packages/spec/src` behind — deliberately reused here as the
  * exclusion case).
  */
-function selfTestPackagesProse(expect) {
+function selfTestPackagesProse(expect, battery) {
+  battery('cross-package prose ids');
   const ts = requireFromHere('typescript');
   const write = (rel, body) => {
     const full = join(...rel.split('/'));
@@ -2851,6 +2975,7 @@ function selfTestPackagesProse(expect) {
     r.sites.every((s) => PACKAGES_PROSE_PREFILTER.test(s.text)), true);
   expect('strings were seen at all (the walker is not dormant)', r.stringsSeen > 0, true);
 
+  battery('cross-package ledger arithmetic');
   // ── The ledger arithmetic, all three verdicts from one measurement ────────
   const exact = packageProseLedgerShape(r.counts);
   const green = comparePackageProseLedger(r.counts, exact);
@@ -2872,7 +2997,20 @@ function selfTestPackagesProse(expect) {
 }
 
 function main() {
-  if (process.argv.includes('--self-test')) return selfTest();
+  if (process.argv.includes('--self-test')) {
+    // ⛔ Never `return selfTest()`. A `return` anywhere above that verdict prints
+    // nothing, evaluates no floor and exits 0 — the same nothing-ran-nothing-
+    // complained pass the battery floor refuses, one level up (#13173).
+    if (selfTest() !== SELF_TEST_VERDICT) {
+      console.error(
+        '\n✗ check-doc-authoring self-test: selfTest() returned without reaching its verdict, so'
+        + '\nno battery floor was evaluated and no success line was printed. Exiting 0 here would'
+        + '\nreport a self-test that never finished as a self-test that passed.\n',
+      );
+      process.exit(1);
+    }
+    return;
+  }
   if (process.argv.includes('--census')) return census(false);
   if (process.argv.includes('--census-ledger')) return census(true);
 


### PR DESCRIPTION
Fixes #13173

`selfTest()` in `scripts/check-doc-authoring.mjs` decided success as
`failures.length === 0` with no assertion-count floor anywhere, so the success
condition and the total-failure condition produced identical output — in the
gate that exists to catch prose claiming more than the code delivers.

## The mechanism, re-measured on current `main` (not quoted from the card)

The file changed three times the day the card was filed, so the experiment was
re-run rather than cited. On `8fcd0816`, an early `return` injected at the top
of `selfTestRule3()`:

```
MUTATION injected_marker_count=1 post_blob=f3bf0c75 head_blob=864bd697
ABLATED_SELFTEST_EXIT=0
✓ check-doc-authoring self-test: scope wiring (...), the dead-root hard error (...
RESTORE hash-object=864bd697 HEAD_BLOB=864bd697   (byte-identical)
```

Exit 0, with the full success line asserting those cases hold. Premise confirmed.

## The audit, done before anything was designed

The card recorded that no audit of the current registrations had ever been made.
One was made here, by instrumenting `expect` to log its call site and diffing
every **executed** call site against every **static** one:

| | |
|---|---|
| batteries registering assertions | **16** |
| assertions executed | **198** (`selfTest` 72 · `selfTestRule3` 108 · `selfTestPackagesProse` 18) |
| static `expect()` call sites | 178 |
| static call sites that never executed | **0** |

The one static hit that does not execute is `expect(issue.message).toContain(...)`
inside a fixture string — text, not a call site.

**So the PM hypothesis that at least one battery was already dark is FALSIFIED:
every battery runs today.** That is what let the floor be pinned to today's real
counts rather than to a guess.

## The repair: registered NAMES, per battery

Not a count. A count answers "something moved"; the card's own 40-to-3 warning
needs "**which** battery moved", and a pinned TOTAL rots the moment a sibling
grows. So this takes the shape the sibling `check-dispatcher-error-vocabulary`
gate landed hours earlier — the registered names, held as a set:

- `SELF_TEST_BATTERIES` declares 16 batteries, each with its own case floor.
- Each battery opens with `battery('...')`; every `expect()` is attributed to the
  battery most recently opened. An assertion with no battery open is filed under
  a key that is not declared, so it reds by the same set difference instead of
  inflating whichever battery ran last.
- The floor requires the **opened set to equal the declared set**, with each
  battery at or above its own count, and it is evaluated **before** the verdict —
  so that line can only be printed by a run in which every battery ran.
- The registry's own **size** is pinned too: deleting an entry silences its floor
  exactly as effectively as zeroing it.
- `main()` no longer does `return selfTest()`. `selfTest()` returns a verdict
  sentinel only after the floor has been evaluated and the success line printed,
  so a `return` that leaves the function early is refused rather than exiting 0
  with no output at all. Same defect class, one level up; named here because it
  is beyond the literal "assertion-count floor" the card asked for.

Counts are a **floor, not an equality**: adding cases must never red. Falling
below one means cases stopped running — the battery is the bug, and the failure
text says so, with lowering a floor marked `⛔ MAINTAINER-ONLY` beside the
`RATCHET_AUTHORITY_MARKER` this file already carries.

## The ablations — the floor NAMES the battery, five ways

Every mutation proven on disk by `git hash-object` against the HEAD blob (never
by an editor's exit code), every restore proven byte-identical with
`git diff HEAD` empty.

| # | mutation | exit | the floor says |
|---|---|---|---|
| A | early `return` at the top of `selfTestRule3()` | 1 | names **all 7** of its batteries, each `DID NOT RUN — 0 cases registered, N pinned` |
| B | one precision case deleted (15 to 14) | 1 | `battery "published-catalog id precision" registered 14 case(s), below its pinned floor of 15` |
| B2 | the card's 40-to-3 case: `mustPass` cut from 12 entries to 1 | 1 | `registered 4 case(s), below its pinned floor of 15` |
| C | early `return` at the top of `selfTest()` itself | 1 | `selfTest() returned without reaching its verdict` |
| D | a battery entry deleted from the registry | 1 | `declares 15 batteries, below the pinned 16` **and** `battery "spec text: precision" registered 18 case(s) but is not declared` |

Before this PR every one of those exits 0 with the full success line.

## Verification

Both legs, on the final commit `30cae64d` — the CI step is `--self-test &&` the
main run, so both are quoted:

```
$ node scripts/check-doc-authoring.mjs --self-test          # exit 0
✓ check-doc-authoring self-test: ... all hold. — 16 declared batteries,
  198 cases registered, every battery at or above its pinned floor.

$ node scripts/check-doc-authoring.mjs                      # exit 0
✓ doc authoring guard: 393 files clean — no bare metadata literals.
✓ doc authoring guard: 48 published skill files clean — no internal issue-id references.
✓ doc authoring guard: 14083 customer-facing string(s) across 691 spec sources clean ...
✓ doc authoring guard: sibling-package prose ids hold the baseline — 831 pinned site(s) ...
```

Gate family derived from the real changeset with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (13
path-matched + 2 convention-triggered for editing a gate script), all run on
`30cae64d`, all exit 0:

`check:doc-authoring` · `check:agent-test-spelling` · `check:bash32-floor` ·
`check:cli-command-ids` · `check:cross-package-test-inputs` · `check:entry-guard` ·
`check:parse-guard` · `check:pnpm-filter-targets` · `check:watch-hint-literal` ·
`check-ci-filter-parity` · `check-cross-package-test-inputs` ·
`check-shard-attestation` · `pm/bare-root-worklist --self-test` ·
`check:pm-dispatch-gates`

Added beyond the derivation because this diff plainly implicates them, both
exit 0:

- `check:nul-bytes` — `OK (scanned 7451 text file(s) ... no raw ASCII control bytes)`,
  plus a direct `grep -naP` over the edited file: no control bytes.
- `check:ratchet-remedy-authority` — this file is classified `marked` in that
  gate's control corpus, and the new refusal text is a second marked offer:
  `OK check-ratchet-remedy-authority: 170 scripts swept; 10 mark the expanding
  remedy ⛔ MAINTAINER-ONLY ... Control corpus: 24 hand-classified scripts,
  set-equality audited both ways.`

`check-test-completeness.mjs` exits 3 `PREREQUISITE NOT MET` locally by design
(it grades a saved `turbo run test` log). Recorded **NOT MEASURED** — neither
red nor green.

No test suite in the repo pins this script (`git grep` over `*.test.ts` /
`*.spec.ts` for `check-doc-authoring`: zero hits), so no pin suite is owed.

**Lint, narrowed with the narrowing proved** rather than run repo-wide:

1. Universe read from ESLint's own config resolution, not from a guess about
   what counts — the file resolves to a real config and is linted, not ignored.
2. File count read from `--format json`: **1 file, 0 errors, 0 warnings**.
3. Invariance for untouched files: this repo runs one `eslint.config.mjs` which
   **never enables type-aware linting for any file** (no `parserOptions.project`,
   no typed `@typescript-eslint` rules) — stated in that config's own header
   with a measured positive control. A change confined to one file therefore
   cannot move any untouched file's verdict.

CI runs the full farm regardless; 166 of the 187 discovered families sit behind
no path filter at all.

## Not in scope

Whether other `--self-test` implementations in `scripts/` share this shape is
still an open survey, deliberately untouched here — that is the class card's
question, not this one's, and this PR does not address it.

No changeset: `scripts/`-only, publishing nothing from any package, matching the
two most recent PRs to this same file, which both carried `skip-changeset` and
no changeset file.

Authored by Claude Code, dispatch session `session_01Pk26oZ12t5N1hwGW1m1MgC`
(https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC) — recorded in prose
because a body edit rewrites the session-URL footer to its bare form.


---
_Generated by [Claude Code](https://claude.ai/code)_