### PR TITLE
Price the coveringKey refusal's miss with its exception, not as a flat average

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -3049,9 +3049,36 @@ export function coveringJobFilter(entry, inputPath) {
  * What the refusal COSTS is a live missing lead, and it is named rather than
  * implied: `scripts/pm/bare-root-worklist.mjs --self-test` statically imports
  * THIS file, and a card editing this file derives 14 families without naming
- * it. That gate gets run by hand. The miss costs one CI round, which is the
- * side this file's header errs on everywhere, and it is a far smaller cost than
- * the 118-lead card the general key prints for the module all 118 import.
+ * it. That gate gets run by hand, but lint.yml runs it on every PR too, so the
+ * miss costs one CI round, which is the side this file's header errs on
+ * everywhere, and it is a far smaller cost than the 118-lead card the general
+ * key prints for the module all 118 import.
+ *
+ * WHERE THAT PRICE DOES NOT HOLD (#13467). "One CI round" is the WITNESS's
+ * price and an AVERAGE over the class, and the next reader will quote it as the
+ * price of every missed lead. For a minority it is wrong. Which minority is a
+ * TREE-fact, re-derived and printed by every `--self-test` run instead of
+ * recorded here, because this class has already been measured at three
+ * different sizes on three different days:
+ *
+ *   - the large majority of novel pairs sit in a family at least one UNFILTERED
+ *     workflow runs. CI opens that module on this PR whatever the derivation
+ *     said, so one round really is the whole price; and
+ *   - the rest sit in families NO every-PR workflow runs — today the
+ *     paths-filtered and scheduled callers (the patrols, `validate-deps.yml`,
+ *     and the release-time ones). No CI round on this PR repays those. The
+ *     family next executes on its own cadence, detached from the change.
+ *
+ * That remainder is a LOWER bound for the same two reasons the novel total is
+ * (below), and it is NOT the claim that a load break in those helpers ships
+ * green: every module carrying a deferred pair is imported by every-PR families
+ * as well, so a module that fails to LOAD reddens this PR through a sibling.
+ * What defers is the narrower break, the one only the deferred consumer would
+ * have seen. Nor do the deferred pairs spread thin — they concentrate on the
+ * shared heads this refusal is refused FOR, i.e. the modules most likely to be
+ * edited into a break. Both halves are asserted in `--self-test`; a red there
+ * says the exception changed shape and this paragraph is due a re-read, not
+ * that the derivation broke.
  *
  * Two shapes make 232 a LOWER bound rather than an exact size, both already
  * refused upstream for their own measured reasons: a dynamic `import()` of a
@@ -7510,6 +7537,58 @@ function selfTest() {
     `…and the class is still concentrated: ${importTop5} of ${importNovel.length} novel pair(s) land`
       + ` on ${Math.min(5, importWorst.length)} module(s)`,
     importTop5 * 2 > importNovel.length,
+  );
+  // The PRICE the refusal states is an AVERAGE (#13467). "The miss costs one CI
+  // round" holds for a novel pair whose family some UNFILTERED workflow runs —
+  // CI opens the module on that PR regardless — and does not hold for one whose
+  // family no every-PR workflow runs at all: nothing on the PR repays that
+  // miss. Prose cannot notice the split moving and this one has moved three
+  // times, so the docblock states the SHAPE and these three assertions print
+  // the sizes. A red here re-prices the paragraph; it does not fault the
+  // derivation.
+  const everyPRWorkflow = new Map();
+  for (const wf of readdirSync(join(ROOT, '.github/workflows')).filter((f) => /\.ya?ml$/.test(f))) {
+    const wfText = readFileSync(join(ROOT, '.github/workflows', wf), 'utf8');
+    // No `paths:` on a workflow that declares `pull_request` is the same
+    // reading `discoverFamilies` makes when it drops such a workflow from
+    // `triggers` — an unfiltered workflow discriminates nothing, which is
+    // exactly why it runs on every PR.
+    everyPRWorkflow.set(wf, declaresPullRequestTrigger(wfText) && extractTriggerPaths(wfText).length === 0);
+  }
+  const runsOnEveryPR = (e) => [...(e?.workflows ?? [])].some((wf) => everyPRWorkflow.get(wf));
+  const importFamilyByCheck = new Map(importClassFamilies);
+  const importDeferred = importNovel.filter(([check]) => !runsOnEveryPR(importFamilyByCheck.get(check)));
+  const importDeferredWorkflows = [...new Set(
+    importDeferred.flatMap(([check]) => [...(importFamilyByCheck.get(check)?.workflows ?? [])]),
+  )].sort();
+  t(
+    `the "one CI round" price is an average, not a uniform one — ${importDeferred.length} of`
+      + ` ${importNovel.length} novel pair(s) sit in families no every-PR workflow runs`
+      + ` (${importDeferredWorkflows.join(', ') || 'none'}), so no CI round on the PR repays that miss`,
+    importDeferred.length > 0 && importDeferred.length * 4 < importNovel.length,
+  );
+  // The half that keeps the exception from being over-read: a deferred pair is
+  // a deferred LEAD, never a silent load break. Every module carrying one is
+  // imported by every-PR families too, so a module that fails to LOAD reddens
+  // the PR through a sibling; what defers is the narrower break.
+  const importLoadBreakSilent = importDeferred.filter(([, mod]) =>
+    !importClassFamilies.some(([c2, e2]) => runsOnEveryPR(e2) && (importClassEdges.get(c2)?.has(mod) ?? false)));
+  t(
+    'a deferred pair defers the LEAD, not the load break — every module carrying one is imported by'
+      + ' an every-PR family as well, so failing to load still reddens the PR'
+      + `${importLoadBreakSilent.length ? ` — SILENT: ${importLoadBreakSilent.map(([c, m]) => `${c} <- ${m}`).join(' · ')}` : ''}`,
+    importLoadBreakSilent.length === 0,
+  );
+  // And they are not spread thin: the deferred pairs land on the shared heads
+  // this key is refused FOR — the modules most likely to be edited into a
+  // break. `fan-in <= 3` is the tail boundary the aggregate paragraph uses.
+  const importFanIn = (mod) => importClassFamilies.filter(([c2]) => importClassEdges.get(c2)?.has(mod)).length;
+  const importDeferredOnHeads = importDeferred.filter(([, mod]) => importFanIn(mod) > 3);
+  t(
+    `…and the deferred pair(s) concentrate on the heads rather than the tail:`
+      + ` ${importDeferredOnHeads.length} of ${importDeferred.length} land on a module more than 3`
+      + ` families import`,
+    importDeferredOnHeads.length * 2 > importDeferred.length,
   );
 
   // #12107, the live half — three claims about THIS tree, each one a thing the


### PR DESCRIPTION
Fixes #13467

`coveringKey`'s refusal docblock priced every missed import-edge lead at **"the miss costs one CI round."** That sentence is its own named witness's price — `scripts/pm/bare-root-worklist.mjs --self-test`, whose family `lint.yml` runs on every PR — and an **average** over the class. The next reader quotes it as the price of every individual lead. For a minority it is wrong.

## What changed

One paragraph in the `coveringKey` docblock, plus three `--self-test` assertions that re-derive it. Nothing else: the refusal itself (fifth key, fan-in threshold) is untouched, and so are the five paths-filtered patrol workflows.

The docblock now states the **shape** and the self-test prints the **sizes**, because this figure has already been measured at three different values on three different days:

- the large majority of novel pairs sit in a family at least one **unfiltered** workflow runs — CI opens that module on this PR whatever the derivation said, so one round really is the whole price;
- the rest sit in families **no every-PR workflow runs**, where nothing on the PR repays the miss and the family next executes on its own cadence, detached from the change.

## Re-derived, not quoted

The card's numbers are deliberately not carried over. Re-derived on this tree at `90705ffa0`, printed live by the new pins:

```
the "one CI round" price is an average, not a uniform one - 9 of 244 novel
pair(s) sit in families no every-PR workflow runs (cut-rc.yml,
half-state-patrol.yml, prerelease-pin-watch.yml, release-coverage-patrol.yml,
release.yml, required-set-patrol.yml, validate-deps.yml)
...and the deferred pair(s) concentrate on the heads rather than the tail:
8 of 9 land on a module more than 3 families import
```

The card said 231/10 of 241; today it derives **235/9 of 244**. Two things the re-derivation corrected, both now reflected in the prose rather than the card's wording:

1. ⚠️ **The deferral is of the LEAD, not of the load break.** The card says a load break in those four helpers "goes green on the PR". Measured, it does not: `invoked-as.mjs` is imported by 122 families, **118 of which run on every PR** (`import-prerequisite.mjs` 44, `workspace-enumerator.mjs` 10, `check-shard-attestation.mjs` 2). A module that fails to *load* reddens the PR through a sibling. What actually defers is the narrower break — one only the deferred consumer would have seen. This is now a pinned assertion, so the docblock cannot drift back into the stronger claim.
2. The deferring workflow set is wider than the card's five: `cut-rc.yml` and `release.yml` also carry deferred families. The pin prints the live set rather than freezing a list. ⛔ No workflow was edited.

## Why pins rather than numbers in prose

The docblock already says its staleness alarms are re-derived every `--self-test` run. Three assertions were added in that same block:

- the split itself — green while the deferred half exists and stays a small minority; red if it vanishes (paragraph stale) or grows large (framing understates);
- the anti-over-read half — every module carrying a deferred pair is also imported by an every-PR family;
- the concentration — most deferred pairs land on a module more than 3 families import (the tail boundary the aggregate paragraph already uses).

A red in any of them re-prices the paragraph; it does not fault the derivation. That is stated in the comment above them.

## Verification

`node scripts/pm/dispatch-gates.mjs --self-test`: 976 cases before, **979 pass** after.

Reverse-verified by two ablations, each mutating the derivation input, each confirmed on disk by blob hash and restored to the exact HEAD blob:

| ablation | pins reddened |
|---|---|
| classify no workflow as every-PR | split pin ✗ (`244 of 244`), load-break pin ✗ |
| fan-in threshold raised past every module | concentration pin ✗ (`0 of 9`) |

Both restored: `git diff HEAD` empty, blob back to `6d10cec9`.

Gate family derived from the diff by `dispatch-gates.mjs --changed --repo objectstack-ai/objectstack` (14 families), all run at `90705ffa0`, all EXIT=0 with the exit captured before any pipe: `check:pm-dispatch-gates` · `bare-root-worklist.mjs --self-test` (this tool's only real static importer — verified: the two `.test.ts` files mentioning it do so in prose only) · `check-self-test-wired` · `check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check:entry-guard` · `check:parse-guard` · `check:pnpm-filter-targets` · `check:watch-hint-literal` · `check-ci-filter-parity` · `check-shard-attestation` · `check:nul-bytes`.

`check-test-completeness.mjs` exits **3 = NOT MEASURED** (neither red nor green).

## Changeset

None owed — the diff is one file under `scripts/pm/**`, internal PM tooling that publishes nothing from any package. `skip-changeset` applied.

## Out of scope, deliberately

⛔ The refusal itself is not touched. ⛔ The five paths-filtered patrol workflows are not touched. The card's escalation measurement — whether such a deferred break has ever actually shipped — was **not commissioned and was not run**; see the report comment for what the fan-in reading above implies about it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_