### PR TITLE
fix(service-storage): stamp the acting organization on the last two sys_file insert doors

### DIFF
--- a/.changeset/sys-file-copy-backfill-organization-stamping.md
+++ b/.changeset/sys-file-copy-backfill-organization-stamping.md
@@ -1,0 +1,60 @@
+---
+"@objectstack/service-storage": patch
+---
+
+fix(service-storage): stamp the acting organization on the last two `sys_file` insert doors (#13547)
+
+`sys_file` declares no `tenancy` key, so `isTenancyDisabled()` reads `false`
+and the registry provisions `organization_id` on it. Four doors on the object
+had been given the acting organization one card at a time — `createFile`
+(#12745), `createSession` (#12928), and the `update`/`delete` halves (#13178) —
+and all four run through `StorageMetadataStore`, which threads a
+`StorageWriteContext` into `context.tenantId` so the platform's insert-side
+chokepoint can stamp the column.
+
+Two doors bypassed that store entirely and carried no organization at all:
+
+- `copyOwnedFile` (`file-reference-lifecycle.ts`) — the copy-on-claim
+  lifecycle hook, which inserts a fresh `sys_file` whenever a record writes an
+  id already owned by another field slot;
+- `materializeDataUri` (`backfill-file-references.ts`) — the operator backfill
+  pass, which inserts one `sys_file` per inline `data:` URI it converts.
+
+Both passed `{ isSystem: true, [RAW_FILE_VALUES_CONTEXT_KEY]: true }`, so
+`buildDriverOptions` emitted no `DriverOptions.tenantId`,
+`SqlDriver.injectTenantOnInsert` had nothing to stamp from, and every row
+landed `organization_id = NULL`. The driver's tenant term is
+`(organization_id = :tenantId OR organization_id IS NULL)`, so those rows were
+reachable from **every** organization — including through the very update and
+delete doors #13178 had just scoped.
+
+⚠️ Nothing warned, and the silence was explained rather than reassuring:
+`isSystem` also sets `bypassTenantAudit = true`, which is exactly the guard
+`auditMissingTenant` returns at — so the `[tenant-audit]` line naming this
+defect ("writes will not be tenant-isolated") never fired for either door.
+
+Each door now threads the organization the platform can actually justify, as
+an execution context — ⛔ never as a column on the payload, so
+`resolveTenantField` / `injectTenantOnInsert` keep deciding whether the object
+has a tenant column and whether an explicit value wins:
+
+- the **copy** takes the organization of the write that triggered it, read
+  from `HookContext.session.organizationId` (which ObjectQL's `buildSession()`
+  copies verbatim from `ExecutionContext.tenantId`);
+- the **backfill** takes the organization of the record whose field held the
+  bytes, resolved with the same `createWallOrganizationResolver` the `sys_file`
+  organization sweep uses, so an object declaring `tenancy.tenantField` is read
+  by the column it is really walled by.
+
+Both stamp exactly what that sweep would independently derive from the new
+file's field-reference holder, so the forward and repair halves agree by
+construction. The backfill needs **no** operator-supplied organization and
+deliberately takes none: one run spans every object and organization in the
+deployment, so a single supplied value would be stamped onto other tenants'
+files — and a wrongly-stamped row is walled into somebody else's tenant, which
+is strictly worse than a NULL row that stays reachable.
+
+Where no organization is in scope — a caller with no active org, an unwalled
+object, a legacy row that carries none — the `tenantId` key is omitted
+entirely and the write proceeds exactly as before. ⛔ Forward-stamping only:
+no existing `sys_file` row's organization is written by either door.

--- a/packages/services/service-storage/src/backfill-file-references.ts
+++ b/packages/services/service-storage/src/backfill-file-references.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { FILE_REFERENCE_TYPES, isFileIdToken, RAW_FILE_VALUES_CONTEXT_KEY } from '@objectstack/spec/data';
 import type { IStorageService } from '@objectstack/spec/contracts';
 import { keysetWalk } from '@objectstack/types';
+import { createWallOrganizationResolver } from './backfill-sys-file-organizations.js';
 
 /**
  * Legacy file-value backfill (ADR-0104 D3 wave 2).
@@ -156,12 +157,21 @@ function urlOf(value: unknown): string | null {
   return null;
 }
 
-/** Upload a `data:` URI's bytes and register the `sys_file` row. */
+/**
+ * Upload a `data:` URI's bytes and register the `sys_file` row.
+ *
+ * `organizationId` is the organization of the RECORD whose field held these
+ * bytes, threaded as an execution context so the platform's insert-side
+ * chokepoint stamps `sys_file.organization_id` (#13547). See
+ * {@link backfillFileReferences} for why the subject record is the right — and
+ * the only honest — source for it.
+ */
 async function materializeDataUri(
   engine: BackfillEngine,
   storage: IStorageService,
   dataUri: string,
   legacy: unknown,
+  organizationId: string | null,
 ): Promise<string> {
   const m = DATA_URI_RE.exec(dataUri);
   if (!m) throw new Error('not a data: URI');
@@ -196,13 +206,47 @@ async function materializeDataUri(
       created_at: now,
       updated_at: now,
     },
-    { context: { ...SYSTEM_CTX } },
+    {
+      context:
+        organizationId != null
+          ? { ...SYSTEM_CTX, tenantId: organizationId }
+          : { ...SYSTEM_CTX },
+    },
   );
   return newId;
 }
 
 /**
  * Scan legacy file values and convert what can be converted.
+ *
+ * ## The organization a materialised `sys_file` is stamped with (#13547)
+ *
+ * This pass INSERTS `sys_file` rows — one per inline `data:` URI it
+ * materialises — and did so carrying `isSystem` and no organization, so every
+ * one of them landed `organization_id = NULL` on a tenancy-enabled object.
+ * That is the same defect as the `copyOwnedFile` door, arriving through an
+ * operator pass instead of a lifecycle hook.
+ *
+ * ⭐ It does NOT need an operator-supplied organization, and must not take
+ * one. `materializeDataUri` is reached only because a SPECIFIC record's field
+ * held those bytes, and the file it creates is claimed moments later — by the
+ * rewrite below and the claim hooks it wakes — for that same record's slot. So
+ * the record being converted already names the answer, and it is the answer
+ * the `sys_file` organization sweep would independently derive from the file's
+ * field-reference holder. The two agree by construction rather than by
+ * coincidence.
+ *
+ * ⛔ A single operator-supplied value would be WRONG for most rows: one run
+ * spans every object and every organization in the deployment, so any one
+ * organization it was handed would be stamped onto other tenants' files. ⚠️ A
+ * backfill that stamps the wrong organization is worse than one that stamps
+ * NULL — a NULL row stays reachable, while a mis-stamped row is walled into
+ * somebody else's tenant. Hence: derive per record, or stamp nothing.
+ *
+ * A record whose own organization column is NULL (a legacy row, or an unwalled
+ * object) yields nothing to thread and the new file stays unstamped, exactly
+ * as it did before. ⛔ Nothing here backfills the organization of any EXISTING
+ * `sys_file` row; forward-stamping only.
  *
  * @param getStorage resolves the storage service; when absent, `data:` values
  *   cannot be materialised and are reported `unresolvable` rather than failing
@@ -227,15 +271,35 @@ export async function backfillFileReferences(
     (name) => name !== 'sys_file' && fileFieldsOf(engine, name).length > 0,
   );
 
+  // [#13547] "Which column is THIS object walled by?", asked of the registered
+  // schema rather than hard-coded to `organization_id` — the same resolver the
+  // `sys_file` organization sweep uses, so a subject declaring
+  // `tenancy.tenantField` is read by the column it is actually walled by and
+  // this pass cannot drift from that one. `getSchema` is the resolver's
+  // spelling of the lookup this module already does as `getObject`.
+  const wall = createWallOrganizationResolver({
+    find: (object, options) => engine.find(object, (options ?? {}) as Record<string, unknown>),
+    update: (object, data, options) =>
+      engine.update(object, data as Record<string, unknown>, (options ?? {}) as Record<string, unknown>),
+    getSchema: (object: string) => engine.getObject(object),
+  });
+
   for (const object of scannedObjects) {
     const fileFields = fileFieldsOf(engine, object);
+    // Projected only when the subject really carries it: naming a column the
+    // object does not have would fail the scan for every row, and the whole
+    // pass with it.
+    const organizationField = wall.organizationFieldFor(object);
+    const scanFields = organizationField
+      ? ['id', ...fileFields, organizationField]
+      : ['id', ...fileFields];
     // Seek by `id` (#4363). This walk WRITES to the rows it is reading — the
     // rewrite below updates each record in place — and an offset counts into a
     // set the writes are changing underneath it, so rows slide past the cursor
     // and are never converted. The key does not move when a row is updated, so
     // the seek is not affected by the very thing this function does.
     const walk = keysetWalk<Record<string, unknown>>(
-      (q) => engine.find(object, { ...q, fields: ['id', ...fileFields], context: { ...SYSTEM_CTX } }),
+      (q) => engine.find(object, { ...q, fields: scanFields, context: { ...SYSTEM_CTX } }),
       { pageSize: SCAN_PAGE_SIZE, max: maxPerObject },
     );
 
@@ -245,6 +309,11 @@ export async function backfillFileReferences(
         const recordId = record?.id;
         if (recordId == null) continue;
         scannedRecords++;
+        // The organization of the record that HOLDS these bytes. Null on an
+        // unwalled object, and on a legacy row that itself carries none — in
+        // which case the new file stays unstamped rather than being invented
+        // into a tenant.
+        const recordOrganization = wall.organizationOf(object, record);
 
         for (const field of fileFields) {
           const raw = record[field];
@@ -319,7 +388,7 @@ export async function backfillFileReferences(
                 continue;
               }
               try {
-                const newId = await materializeDataUri(engine, storage, url, value);
+                const newId = await materializeDataUri(engine, storage, url, value, recordOrganization);
                 actions.push({
                   ...record_,
                   kind: 'uploaded_inline_data',

--- a/packages/services/service-storage/src/file-reference-lifecycle.ts
+++ b/packages/services/service-storage/src/file-reference-lifecycle.ts
@@ -83,6 +83,67 @@ const PACKAGE_ID = 'com.objectstack.service.storage';
 // every internal page). Inert on write contexts.
 const SYSTEM_CTX = { isSystem: true, [RAW_FILE_VALUES_CONTEXT_KEY]: true } as const;
 
+/**
+ * The bookkeeping context for a `sys_file` write, carrying the acting
+ * organization when the triggering write had one (#13547).
+ *
+ * ## Why the organization has to travel with the copy
+ *
+ * `sys_file` declares no `tenancy` key, so `isTenancyDisabled()` reads `false`
+ * and the registry provisions `organization_id` on it. {@link copyOwnedFile}
+ * INSERTS a row on that object, and it did so carrying `isSystem` and nothing
+ * else — so `ObjectQLEngine.buildDriverOptions` emitted no
+ * `DriverOptions.tenantId`, `SqlDriver.injectTenantOnInsert` had no value to
+ * stamp from, and every copied file landed `organization_id = NULL`. The
+ * driver's tenant term is `(organization_id = :tenantId OR organization_id IS
+ * NULL)`, so those rows are reachable from every organization.
+ *
+ * ⚠️ Nothing warned. `isSystem` also sets `bypassTenantAudit = true`, which is
+ * exactly the guard `SqlDriver.auditMissingTenant` returns at — so the
+ * `[tenant-audit]` line that names this defect ("writes will not be
+ * tenant-isolated") never fired for it. The absence of the warning was
+ * explained, not reassuring.
+ *
+ * ## The same channel the four repaired doors use
+ *
+ * This mirrors `StorageMetadataStore`'s `StorageWriteContext` threading
+ * (`createFile` #12745, `createSession` #12928, the update/delete halves
+ * #13178) rather than inventing a second convention: the caller hands the
+ * engine the organization it is acting in as an execution context, and the
+ * platform's existing insert-side chokepoint decides the rest. ⛔ The
+ * organization is NOT written onto the payload here — whether this object has
+ * a tenant column at all, and whether an explicit value on the row wins, are
+ * `resolveTenantField` / `injectTenantOnInsert`'s answers, and restating them
+ * one package away from the schema is how the two answers drift apart.
+ *
+ * No organization ⇒ the key is absent entirely, and the write proceeds exactly
+ * as it did before. `tenantId: undefined` would NOT be the same thing: it is a
+ * key the context carries, and `buildDriverOptions` reads presence.
+ */
+function systemWriteContext(organizationId?: string | null): Record<string, unknown> {
+  return typeof organizationId === 'string' && organizationId.length > 0
+    ? { ...SYSTEM_CTX, tenantId: organizationId }
+    : { ...SYSTEM_CTX };
+}
+
+/**
+ * The organization the write that triggered this hook is acting in, or `null`.
+ *
+ * `HookContext.session.organizationId` is the blessed developer-facing name
+ * for the caller's active org, and ObjectQL's `buildSession()` copies it
+ * verbatim from `ExecutionContext.tenantId` — the same value that would have
+ * reached the driver had the caller's own write been the one inserting. So the
+ * copy is stamped for the organization whose record triggered it, which is
+ * also the organization the `sys_file` organization sweep derives from a
+ * file's field-reference holder. ⛔ Never a lookup and never a default: a
+ * caller with no active organization yields `null` and the insert stays
+ * unstamped rather than being guessed into somebody's tenant.
+ */
+function actingOrganizationOf(ctx: any): string | null {
+  const org = ctx?.session?.organizationId;
+  return typeof org === 'string' && org.length > 0 ? org : null;
+}
+
 /** Bound on owned files released per record delete. */
 const RELEASE_BATCH_LIMIT = 1_000;
 
@@ -341,6 +402,7 @@ async function copyOwnedFile(
   engine: FileReferenceEngine,
   storage: IStorageService,
   src: Record<string, unknown>,
+  organizationId: string | null,
 ): Promise<string> {
   const srcKey = typeof src.key === 'string' ? src.key : '';
   if (!srcKey) throw new Error('source file has no storage key');
@@ -360,6 +422,12 @@ async function copyOwnedFile(
   const now = new Date().toISOString();
   // Ownership columns are deliberately left NULL — the after-hook claims the
   // copy for the slot that triggered it, on the same path as any other file.
+  //
+  // [#13547] The TENANT column is not one of them, and the after-hook does not
+  // claim it: `claimFile` patches `ref_object` / `ref_id` / `ref_field` (and
+  // `status` / `deleted_at` on a revive) and never names `organization_id`.
+  // So the acting organization has to be threaded HERE, on the insert, which
+  // is the only point that can still stamp it.
   await engine.insert(
     'sys_file',
     {
@@ -377,7 +445,7 @@ async function copyOwnedFile(
       created_at: now,
       updated_at: now,
     },
-    { context: { ...SYSTEM_CTX } },
+    { context: systemWriteContext(organizationId) },
   );
   return newId;
 }
@@ -405,6 +473,7 @@ async function applyCopyOnClaim(
   recordId: string | null,
   data: Record<string, unknown>,
   fileFields: string[],
+  organizationId: string | null,
 ): Promise<void> {
   for (const field of fileFields) {
     if (!(field in data)) continue;
@@ -447,7 +516,7 @@ async function applyCopyOnClaim(
         continue;
       }
       try {
-        replacements.set(token, await copyOwnedFile(engine, storage, row));
+        replacements.set(token, await copyOwnedFile(engine, storage, row, organizationId));
         logger.debug?.(
           `[storage] file reference: copied ${token} for ${object}.${field} (exclusive ownership)`,
         );
@@ -619,7 +688,7 @@ export function installFileReferenceHooks(
       if (!object || !data || typeof data !== 'object') return;
       const fileFields = activeFileFields(engine, object);
       if (fileFields.length === 0) return;
-      await applyCopyOnClaim(engine, getStorage, logger, object, null, data, fileFields);
+      await applyCopyOnClaim(engine, getStorage, logger, object, null, data, fileFields, actingOrganizationOf(ctx));
     },
     { packageId: PACKAGE_ID },
   );
@@ -673,7 +742,7 @@ export function installFileReferenceHooks(
       // copy-on-claim pass is what makes "the before hook always reconciles the
       // payload it is given" a property of this handler instead of a case
       // analysis a later edit has to re-derive.
-      await applyCopyOnClaim(engine, getStorage, logger, object, recordId, data, fileFields);
+      await applyCopyOnClaim(engine, getStorage, logger, object, recordId, data, fileFields, actingOrganizationOf(ctx));
     },
     { packageId: PACKAGE_ID },
   );

--- a/packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts
+++ b/packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts
@@ -1,0 +1,362 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #13547 — the FIFTH and SIXTH `sys_file` insert doors.
+//
+// Four doors on this object have been given the acting organization one card
+// at a time — `createFile` (#12745), `createSession` (#12928), and the
+// `update`/`delete` halves (#13178) — and all four run through
+// `StorageMetadataStore`, which threads a `StorageWriteContext` into
+// `context.tenantId` so the platform's insert-side chokepoint can stamp the
+// column. These two bypass that store entirely:
+//
+//   file-reference-lifecycle.ts  copyOwnedFile     an engine lifecycle hook
+//   backfill-file-references.ts  materializeDataUri  an operator pass
+//
+// Both passed `{ isSystem: true, [RAW_FILE_VALUES_CONTEXT_KEY]: true }` and no
+// tenant, so `buildDriverOptions` emitted no `DriverOptions.tenantId`,
+// `injectTenantOnInsert` stamped nothing, and each row landed
+// `organization_id = NULL` — reachable from every organization through the
+// driver's `(organization_id = :tenantId OR organization_id IS NULL)` term.
+//
+// ⚠️ These assert the CONTEXT the engine is handed, not a column on the
+// payload. Whether `sys_file` has a tenant column at all, and whether an
+// explicit value wins, are `resolveTenantField` / `injectTenantOnInsert`'s
+// answers; re-deciding them here would be the second convention this card is
+// about.
+
+import { describe, it, expect, vi } from 'vitest';
+import { RAW_FILE_VALUES_CONTEXT_KEY } from '@objectstack/spec/data';
+import { assertEngineFindOnePredicate } from '@objectstack/objectql';
+import { installFileReferenceHooks } from './file-reference-lifecycle.js';
+import { backfillFileReferences } from './backfill-file-references.js';
+
+const silentLogger = () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn() });
+
+const fakeStorage = () =>
+  ({
+    upload: vi.fn(async () => {}),
+    download: vi.fn(async () => Buffer.from('the-bytes')),
+    delete: vi.fn(async () => {}),
+    exists: vi.fn(async () => true),
+    getInfo: vi.fn(async () => ({ key: 'k', size: 9, contentType: 'image/png', lastModified: new Date() })),
+  }) as any;
+
+/** The `sys_file` insert this card is about, with the options bag intact. */
+type Insert = { object: string; data: Record<string, unknown>; options: any };
+
+const sysFileInsertOf = (inserts: Insert[]): Insert => {
+  const hit = inserts.filter((i) => i.object === 'sys_file');
+  expect(hit).toHaveLength(1);
+  return hit[0];
+};
+
+// ---------------------------------------------------------------------------
+// Door 5 — `copyOwnedFile`, reached through the copy-on-claim before-hook
+// ---------------------------------------------------------------------------
+
+const LIFECYCLE_REGISTRY: Record<string, any> = {
+  sys_file: {
+    name: 'sys_file',
+    fields: { id: { type: 'text' }, key: { type: 'text' }, organization_id: { type: 'text' } },
+  },
+  product: {
+    name: 'product',
+    fields: { id: { type: 'text' }, name: { type: 'text' }, image: { type: 'image' } },
+  },
+};
+
+function lifecycleEngine(files: Array<Record<string, unknown>>) {
+  const inserts: Insert[] = [];
+  const updates: Array<{ data: Record<string, unknown>; options: any }> = [];
+  const tables: Record<string, Array<Record<string, unknown>>> = { sys_file: [...files], product: [] };
+  const hooks = new Map<string, Array<(ctx: any) => Promise<void> | void>>();
+
+  const engine: any = {
+    registerHook(event: string, handler: any) {
+      const list = hooks.get(event) ?? [];
+      list.push(handler);
+      hooks.set(event, list);
+    },
+    getObject: (name: string) => LIFECYCLE_REGISTRY[name],
+    async find(object: string, options: any) {
+      return (tables[object] ?? []).filter((r) =>
+        Object.entries(options?.where ?? {}).every(([k, v]) =>
+          v && typeof v === 'object' && Array.isArray((v as any).$in)
+            ? (v as any).$in.some((x: unknown) => String(x) === String(r[k]))
+            : r[k] === v,
+        ),
+      );
+    },
+    async findOne(object: string, options: any) {
+      assertEngineFindOnePredicate(object, options);
+      return (tables[object] ?? []).find((r) => String(r.id) === String(options?.where?.id)) ?? null;
+    },
+    async insert(object: string, data: any, options?: any) {
+      inserts.push({ object, data: { ...data }, options });
+      (tables[object] ??= []).push({ ...data });
+      return data;
+    },
+    async update(object: string, data: any, options?: any) {
+      if (object === 'sys_file') updates.push({ data: { ...data }, options });
+      const row = (tables[object] ?? []).find((r) => String(r.id) === String(data.id));
+      if (row) Object.assign(row, data);
+      return row;
+    },
+    inserts,
+    updates,
+    tables,
+    async trigger(event: string, ctx: any) {
+      for (const h of hooks.get(event) ?? []) await h(ctx);
+    },
+  };
+  return engine;
+}
+
+/**
+ * Drive an insert of `product` whose `image` already names a file owned by a
+ * DIFFERENT slot — the one condition that reaches `copyOwnedFile` — with the
+ * session the engine's `buildSession()` would have built for the caller.
+ */
+async function driveCopyingInsert(engine: any, session: unknown) {
+  const data: Record<string, unknown> = { image: 'file_owned' };
+  const ctx: any = {
+    object: 'product',
+    event: 'beforeInsert',
+    input: { data },
+    session,
+    dispatch: { mode: 'record', index: 0, scope: {} },
+  };
+  await engine.trigger('beforeInsert', ctx);
+  const row = { ...(ctx.input.data as Record<string, unknown>), id: 'p1' };
+  engine.tables.product.push(row);
+  ctx.event = 'afterInsert';
+  ctx.result = row;
+  await engine.trigger('afterInsert', ctx);
+  return row;
+}
+
+const ownedFile = () => ({
+  id: 'file_owned',
+  key: 'user/file_owned.png',
+  name: 'owned.png',
+  status: 'committed',
+  ref_object: 'other',
+  ref_id: 'r9',
+  ref_field: 'image',
+});
+
+describe('#13547 door 5 — copyOwnedFile threads the triggering write’s organization', () => {
+  it('hands the engine `context.tenantId` for the organization the write acts in', async () => {
+    const engine = lifecycleEngine([ownedFile()]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, { userId: 'u1', organizationId: 'org_A' });
+
+    const insert = sysFileInsertOf(engine.inserts);
+    expect(insert.options?.context?.tenantId).toBe('org_A');
+    // The bookkeeping markers the copy has always carried are untouched.
+    expect(insert.options?.context?.isSystem).toBe(true);
+    expect(insert.options?.context?.[RAW_FILE_VALUES_CONTEXT_KEY]).toBe(true);
+  });
+
+  it('⛔ never puts the organization on the PAYLOAD — the driver decides the column', async () => {
+    const engine = lifecycleEngine([ownedFile()]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, { organizationId: 'org_A' });
+
+    expect(sysFileInsertOf(engine.inserts).data).not.toHaveProperty('organization_id');
+  });
+
+  it('omits `tenantId` ENTIRELY when the caller has no active organization', async () => {
+    const engine = lifecycleEngine([ownedFile()]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, { userId: 'u1' });
+
+    const context = sysFileInsertOf(engine.inserts).options?.context ?? {};
+    // Presence, not value: `buildDriverOptions` reads `tenantId !== undefined`,
+    // so `tenantId: undefined` is NOT the same as an absent key.
+    expect(Object.prototype.hasOwnProperty.call(context, 'tenantId')).toBe(false);
+    expect(context.isSystem).toBe(true);
+  });
+
+  it('omits it for a caller with no session at all (the pre-repair call shape)', async () => {
+    const engine = lifecycleEngine([ownedFile()]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, undefined);
+
+    const context = sysFileInsertOf(engine.inserts).options?.context ?? {};
+    expect(Object.prototype.hasOwnProperty.call(context, 'tenantId')).toBe(false);
+  });
+
+  it('⛔ never derives the organization from the SOURCE file it is copying', async () => {
+    // The source row is stamped for another organization. The copy belongs to
+    // the slot that triggered it, not to whoever owned the bytes — deriving
+    // from the source would wall the copy into a tenant that is not writing.
+    const engine = lifecycleEngine([{ ...ownedFile(), organization_id: 'org_SOURCE' }]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, { organizationId: 'org_A' });
+
+    expect(sysFileInsertOf(engine.inserts).options?.context?.tenantId).toBe('org_A');
+  });
+
+  it('pins the measurement the repair rests on: the after-hook claims ownership, NEVER the tenant', async () => {
+    // `copyOwnedFile` documents that it leaves ownership columns NULL because
+    // "the after-hook claims the copy for the slot that triggered it". That is
+    // true of `ref_*` and ONLY of `ref_*` — so the insert is the last point
+    // that can stamp the tenant, which is why the repair belongs there.
+    const engine = lifecycleEngine([ownedFile()]);
+    installFileReferenceHooks(engine, () => fakeStorage(), silentLogger());
+
+    await driveCopyingInsert(engine, { organizationId: 'org_A' });
+
+    expect(engine.updates.length).toBeGreaterThan(0);
+    for (const { data } of engine.updates) {
+      expect(data).not.toHaveProperty('organization_id');
+    }
+    // …and it does claim the ownership columns, so the double is really
+    // exercising the claim path rather than passing because nothing ran.
+    expect(engine.updates.some((u: any) => u.data.ref_object === 'product')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Door 6 — the backfill pass materialising inline `data:` bytes
+// ---------------------------------------------------------------------------
+
+const DATA_URI = 'data:image/png;base64,aGVsbG8=';
+
+/** `product` is walled; `memo` carries no organization column at all. */
+const BACKFILL_REGISTRY: Record<string, any> = {
+  sys_file: { fields: { id: { type: 'text' }, organization_id: { type: 'text' } } },
+  product: {
+    fields: {
+      id: { type: 'text' },
+      image: { type: 'image' },
+      organization_id: { type: 'text' },
+    },
+  },
+  memo: { fields: { id: { type: 'text' }, image: { type: 'image' } } },
+};
+
+function backfillEngine(tables: Record<string, Array<Record<string, unknown>>>) {
+  const inserts: Insert[] = [];
+  const projections: Array<{ object: string; fields: unknown }> = [];
+  const engine: any = {
+    getObject: (name: string) => BACKFILL_REGISTRY[name],
+    getConfigs: () => BACKFILL_REGISTRY,
+    async find(object: string, options: any) {
+      projections.push({ object, fields: options?.fields });
+      const key = options?.orderBy?.[0]?.field;
+      const seek = (options?.where as any)?.[key]?.$gt;
+      let rows = tables[object] ?? [];
+      if (seek !== undefined) rows = rows.filter((r) => String(r[key]) > String(seek));
+      const ordered = key ? [...rows].sort((a, b) => String(a[key]).localeCompare(String(b[key]))) : rows;
+      return typeof options?.limit === 'number' ? ordered.slice(0, options.limit) : ordered;
+    },
+    async insert(object: string, data: any, options?: any) {
+      inserts.push({ object, data: { ...data }, options });
+      (tables[object] ??= []).push({ ...data });
+      return data;
+    },
+    async update(object: string, data: any) {
+      const row = (tables[object] ?? []).find((r) => String(r.id) === String(data.id));
+      if (row) Object.assign(row, data);
+      return row;
+    },
+    inserts,
+    projections,
+    tables,
+  };
+  return engine;
+}
+
+const runBackfill = (engine: any) =>
+  backfillFileReferences(engine, () => fakeStorage(), silentLogger(), { apply: true });
+
+describe('#13547 door 6 — the backfill stamps from the record that HELD the bytes', () => {
+  it('threads the subject record’s organization onto the materialised sys_file', async () => {
+    const engine = backfillEngine({
+      product: [{ id: 'p1', image: DATA_URI, organization_id: 'org_B' }],
+      sys_file: [],
+    });
+
+    await runBackfill(engine);
+
+    const insert = sysFileInsertOf(engine.inserts);
+    expect(insert.options?.context?.tenantId).toBe('org_B');
+    expect(insert.options?.context?.isSystem).toBe(true);
+    expect(insert.data).not.toHaveProperty('organization_id');
+  });
+
+  it('projects the organization column so the value is actually in reach', async () => {
+    const engine = backfillEngine({
+      product: [{ id: 'p1', image: DATA_URI, organization_id: 'org_B' }],
+      sys_file: [],
+    });
+
+    await runBackfill(engine);
+
+    const scan = engine.projections.find((p: any) => p.object === 'product');
+    expect(scan?.fields).toContain('organization_id');
+    expect(scan?.fields).toContain('image');
+  });
+
+  it('stamps NOTHING when the subject row carries no organization — ⛔ never invents one', async () => {
+    const engine = backfillEngine({
+      product: [{ id: 'p1', image: DATA_URI, organization_id: null }],
+      sys_file: [],
+    });
+
+    await runBackfill(engine);
+
+    const context = sysFileInsertOf(engine.inserts).options?.context ?? {};
+    expect(Object.prototype.hasOwnProperty.call(context, 'tenantId')).toBe(false);
+  });
+
+  it('leaves an object with no organization column unprojected and unstamped', async () => {
+    const engine = backfillEngine({ memo: [{ id: 'm1', image: DATA_URI }], sys_file: [] });
+
+    await runBackfill(engine);
+
+    const scan = engine.projections.find((p: any) => p.object === 'memo');
+    // Naming a column the object does not have would fail the whole scan.
+    expect(scan?.fields).not.toContain('organization_id');
+    const context = sysFileInsertOf(engine.inserts).options?.context ?? {};
+    expect(Object.prototype.hasOwnProperty.call(context, 'tenantId')).toBe(false);
+  });
+
+  it('keeps each row on its OWN organization across a multi-tenant scan', async () => {
+    // The reason an operator-supplied single organization would be wrong: one
+    // run spans every tenant in the deployment.
+    const engine = backfillEngine({
+      product: [
+        { id: 'p1', image: DATA_URI, organization_id: 'org_B' },
+        { id: 'p2', image: DATA_URI, organization_id: 'org_C' },
+      ],
+      sys_file: [],
+    });
+
+    await runBackfill(engine);
+
+    const stamped = engine.inserts
+      .filter((i: Insert) => i.object === 'sys_file')
+      .map((i: Insert) => i.options?.context?.tenantId);
+    expect(stamped).toEqual(['org_B', 'org_C']);
+  });
+
+  it('⛔ writes no organization onto any EXISTING sys_file row — forward-stamping only', async () => {
+    const legacy = { id: 'file_legacy', key: 'user/legacy.png', organization_id: null };
+    const engine = backfillEngine({
+      product: [{ id: 'p1', image: DATA_URI, organization_id: 'org_B' }],
+      sys_file: [legacy],
+    });
+
+    await runBackfill(engine);
+
+    expect(engine.tables.sys_file.find((r: any) => r.id === 'file_legacy')).toEqual(legacy);
+  });
+});

--- a/packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts
+++ b/packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts
@@ -26,7 +26,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { RAW_FILE_VALUES_CONTEXT_KEY } from '@objectstack/spec/data';
-import { assertEngineFindOnePredicate } from '@objectstack/objectql';
+import { assertEngineFindOnePredicate, assertEngineUpdateDispatch } from '@objectstack/objectql';
 import { installFileReferenceHooks } from './file-reference-lifecycle.js';
 import { backfillFileReferences } from './backfill-file-references.js';
 
@@ -79,13 +79,19 @@ function lifecycleEngine(files: Array<Record<string, unknown>>) {
     },
     getObject: (name: string) => LIFECYCLE_REGISTRY[name],
     async find(object: string, options: any) {
-      return (tables[object] ?? []).filter((r) =>
-        Object.entries(options?.where ?? {}).every(([k, v]) =>
-          v && typeof v === 'object' && Array.isArray((v as any).$in)
+      const rows = (tables[object] ?? []).filter((r) =>
+        Object.entries(options?.where ?? {}).every(([k, v]) => {
+          // Refuse the combinators this double does not implement rather than
+          // reading one as a field name — a silently-wrong matcher passes by
+          // matching nothing.
+          if (k.startsWith('$')) throw new Error(`fake driver: unsupported operator ${k}`);
+          return v && typeof v === 'object' && Array.isArray((v as any).$in)
             ? (v as any).$in.some((x: unknown) => String(x) === String(r[k]))
-            : r[k] === v,
-        ),
+            : r[k] === v;
+        }),
       );
+      // The caller's bound, applied AFTER the filter and by presence.
+      return typeof options?.limit === 'number' ? rows.slice(0, options.limit) : rows;
     },
     async findOne(object: string, options: any) {
       assertEngineFindOnePredicate(object, options);
@@ -97,6 +103,7 @@ function lifecycleEngine(files: Array<Record<string, unknown>>) {
       return data;
     },
     async update(object: string, data: any, options?: any) {
+      assertEngineUpdateDispatch(data, options);
       if (object === 'sys_file') updates.push({ data: { ...data }, options });
       const row = (tables[object] ?? []).find((r) => String(r.id) === String(data.id));
       if (row) Object.assign(row, data);
@@ -262,7 +269,8 @@ function backfillEngine(tables: Record<string, Array<Record<string, unknown>>>) 
       (tables[object] ??= []).push({ ...data });
       return data;
     },
-    async update(object: string, data: any) {
+    async update(object: string, data: any, options?: any) {
+      assertEngineUpdateDispatch(data, options);
       const row = (tables[object] ?? []).find((r) => String(r.id) === String(data.id));
       if (row) Object.assign(row, data);
       return row;

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -3232,6 +3232,16 @@
       "pinned": 1
     },
     {
+      "file": "packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts",
+      "verb": "findOne",
+      "pinned": 1
+    },
+    {
+      "file": "packages/services/service-storage/src/sys-file-copy-backfill-organization-stamping.test.ts",
+      "verb": "update",
+      "pinned": 2
+    },
+    {
       "file": "packages/services/service-storage/src/sys-file-organization-stamping.test.ts",
       "verb": "delete",
       "pinned": 1


### PR DESCRIPTION
Fixes #13547

`sys_file` declares no `tenancy` key, so `isTenancyDisabled()` reads `false` and the registry provisions `organization_id` on it. Four doors on the object had been given the acting organization one card at a time — `createFile` (#12745), `createSession` (#12928), and the `update`/`delete` halves (#13178) — and all four run through `StorageMetadataStore`, which threads a `StorageWriteContext` into `context.tenantId` so the platform's insert-side chokepoint can stamp the column.

Two doors bypassed that store entirely and carried no organization at all:

| site | function | what it passed |
|---|---|---|
| `file-reference-lifecycle.ts` | `copyOwnedFile`, the copy-on-claim lifecycle hook | `{ context: { ...SYSTEM_CTX } }` |
| `backfill-file-references.ts` | `materializeDataUri`, the operator backfill pass | `{ context: SYSTEM_CTX }` |

`SYSTEM_CTX` is `{ isSystem: true, [RAW_FILE_VALUES_CONTEXT_KEY]: true }` — `isSystem`, and no tenant. So `buildDriverOptions` emitted no `DriverOptions.tenantId`, `SqlDriver.injectTenantOnInsert` had nothing to stamp from, and every row landed `organization_id = NULL`. The driver's tenant term is `(organization_id = :tenantId OR organization_id IS NULL)`, so those rows were reachable from **every** organization — including through the very update and delete doors #13178 had just scoped.

Nothing warned, and the silence was explained rather than reassuring: `isSystem` also sets `bypassTenantAudit = true`, which is exactly the guard `auditMissingTenant` returns at, so the `[tenant-audit]` line naming this defect never fired for either door.

## The three PM mechanism assumptions, measured

**1. Can `copyOwnedFile` reach the triggering write's organization? — YES.** `copyOwnedFile` is reached only from `applyCopyOnClaim`, which is called directly by the `beforeInsert` / `beforeUpdate` handlers in `installFileReferenceHooks`. Those handlers receive the `HookContext`, and `HookContext.session.organizationId` is set by ObjectQL's `buildSession()` verbatim from `ExecutionContext.tenantId` — the same value that would have reached the driver had the caller's own write been the one inserting. The value was already in scope; it was simply not passed down. No lookup was invented, and no default is taken.

**2. Does the backfill need an operator-supplied organization? — NO, and it must not take one.** `materializeDataUri` is reached only because a *specific record's* field held those bytes, and the file it creates is claimed moments later, by the rewrite below it, for that same record's slot. So the record being converted already names the answer. It was in the row being walked and merely absent from the projection.

A single operator-supplied value would be **wrong for most rows**: one run spans every object and every organization in the deployment, so any one organization it was handed would be stamped onto other tenants' files. A backfill that stamps the wrong organization is worse than one that stamps NULL — a NULL row stays reachable, while a mis-stamped row is walled into somebody else's tenant. Hence: derive per record, or stamp nothing. `backfillFileReferences`'s exported signature is unchanged and takes no new parameter, so there is no operator-facing decision here.

**3. Is `copyOwnedFile`'s deliberate NULL only about ownership? — YES; the card is right.** `copyOwnedFile` documents that it leaves ownership columns NULL because "the after-hook claims the copy for the slot that triggered it". Reading that after-hook: `claimFile` patches exactly `ref_object` / `ref_id` / `ref_field` (plus `status` / `deleted_at` when reviving a tombstoned file) and **never names `organization_id`**. The tenant column is not an ownership column and no after-hook claims it, so the insert is the last point that can stamp it. That measurement is pinned as a test rather than left as a claim.

## The repair

Each door threads the organization as an **execution context** — never as a column on the payload, so `resolveTenantField` / `injectTenantOnInsert` keep deciding whether the object has a tenant column and whether an explicit value wins. Restating those two answers one package away from the schema is how they drift apart, and `StorageMetadataStore` already says so in terms.

- The **copy** takes the organization of the write that triggered it, from `HookContext.session.organizationId`.
- The **backfill** takes the organization of the record whose field held the bytes, resolved with the same `createWallOrganizationResolver` the `sys_file` organization sweep already uses — so an object declaring `tenancy.tenantField` is read by the column it is really walled by, and this pass cannot drift from that one. The column is added to the scan projection only when the subject really carries it; naming a column the object does not have would fail the scan for every row.

Both stamp exactly what `backfill-sys-file-organizations.ts` would independently derive from the new file's field-reference holder, so the forward-stamping and repair halves agree by construction rather than by coincidence.

Where no organization is in scope — a caller with no active org, an unwalled object, a legacy row carrying none — the `tenantId` key is omitted **entirely** and the write proceeds exactly as before. `tenantId: undefined` would not be the same thing: `buildDriverOptions` reads presence.

⛔ **Forward-stamping only.** No existing `sys_file` row's organization is written by either door; the legacy population's disposition is not this card's.

## The triage must-answer: are the write doors now exhaustively enumerated?

Answered by enumeration rather than by assertion, because the triage comment is right that finding these one card at a time guarantees the next door waits for the next incident. Every **insert** door on either object in non-test source — the whole repo, `packages/` + `apps/` + `examples/` — is one of exactly four:

| # | site | door | organization |
|---|---|---|---|
| 1 | `metadata-store.ts:337` | `StorageMetadataStore.createFile` | threaded, #12745 |
| 2 | `metadata-store.ts:464` | `StorageMetadataStore.createSession` | threaded, #12928 |
| 3 | `file-reference-lifecycle.ts:431` | `copyOwnedFile` | **threaded here** |
| 4 | `backfill-file-references.ts:196` | `materializeDataUri` | **threaded here** |

Doors 1 and 2 are reached only from `storage-routes.ts:364`, `:480` and `:516`, all three of which thread the session's organization. No other module inserts either object: the remaining storage-side modules that name `sys_file` (`attachment-lifecycle.ts`, `files-to-references-migration.ts`, `verify-file-references.ts`, `stranded-orphan-inventory.ts`, the CLI migrate command, `plugin-email/attachment-storage.ts`, `service-knowledge`) contain **zero** `insert` / `createFile` / `createSession` call sites — they read, update or delete only. The two `createSession(` hits outside this package are betterauth's `internalAdapter.createSession` on the auth-session object, not `sys_upload_session`.

⇒ With this PR, **all four insert doors on both objects carry an organization.** ⚠️ Note the scope of that claim: it covers the INSERT side. Update/delete reach on `sys_file` was the subject of #13178, and the legacy NULL-org population remains deliberately reachable and out of scope here.

## Scope

⛔ No shared abstraction was generalised across this card and #13546 (the `sys_http_delivery` half of the same tenant-stamping family) — that sequencing is the PM's. No files under `plugin-security/**`, `service-messaging/**`, `service-automation/src/builtin/http-nodes.ts` or `plugin-webhooks/**` are touched. `metadata-store.ts` is unmodified: its exported `createWallOrganizationResolver` sibling is reused, and routing through `StorageMetadataStore` was not required (these two doors write a different row shape than `createFile` takes).

No new exported type and no signature change on any published entry — `installFileReferenceHooks` and `backfillFileReferences` keep their signatures, and every changed function is module-private. Clause-② stays **no**.

## Verification — union run at `38b13f1`

- `pnpm --filter @objectstack/service-storage test` — **33 files, 518 tests, all passing**, including 12 new pins.
- `pnpm --filter @objectstack/service-storage build` — green, `check-dts-emitted: 2/2 declaration file(s) present`.
- `pnpm lint` (`eslint . --no-inline-config`, whole repo, not narrowed) — **exit 0**, 102s.
- **42 gate families** derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` from the tree and the actual diff (re-derived after the ledger commit grew the change set, which pulled in 7 further families): **39 green.**
- The 3 not green are **PREREQUISITE NOT MET — NOT MEASURED, not red**, and each is structurally unmeasurable in this container: `check-test-completeness` grades a saved CI `turbo run test` log that only CI produces; `check-half-states` needs a real GitHub credential; `check:dual-build-cjs-loads` needs a whole-repo `pnpm build` (54 packages have no `dist/`). `check:i18n` was in this bucket and was **cleared** by building its declared closure — it now reports 9 packages, all bundles in sync.
- `check:type-check-debt` was answered by measurement rather than skipped: this package's ledger entry records **51** errors with "THE MARGIN IS GONE", and `tsc --noEmit` on the package at this head returns **exactly 51**, with the per-code breakdown matching the ledger note limb for limb (TS2835 x23, TS7006 x15, TS2347 x4, TS2339 x4, TS2550 x3, TS6196, TS6133) and **0** attributable to the new test file. The ratchet cannot move.

### Reverse verification

Predicted before running: reverting both threading edits should redden exactly the stamping assertions while the "omits `tenantId`" pins — which assert the *pre-repair* shape — stay green.

Measured: **5 failed, 7 passed**, precisely that partition. The mutation was confirmed on disk before the run (`grep -c` on both anchor texts fell to 0, and both files' `git hash-object` changed), the script carried a `trap … EXIT INT TERM` restoring against absolute paths, and the restore leg was verified by state rather than exit code — `git diff HEAD` empty and both files byte-identical to their `HEAD` blobs. The pins were then re-run on the restored tree: 12/12 green.

The three doubles gates (`check:engine-double-contract`, `check:objectql-double-limit`, `check:where-matcher`) reddened on the first run against the new test file and were fixed at the double rather than at any baseline: `update()` now routes through `assertEngineUpdateDispatch`, the WHERE matcher refuses the combinators it does not implement instead of reading one as a field name, and the `find` double applies the caller's bound after the filter. The new pinned coverage was registered with `--write` (added rows only, 0 lost).

_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_