### PR TITLE
Repair the two plugin-auth admin-audit durability swallows — batch 6 of the #12981 worklist

### DIFF
--- a/.changeset/auth-admin-audit-swallow-batch-6.md
+++ b/.changeset/auth-admin-audit-swallow-batch-6.md
@@ -1,0 +1,47 @@
+---
+'@objectstack/plugin-auth': minor
+---
+
+Report the refused admin-audit writes two `catch { }` sites swallowed (#12981 batch 6)
+
+The two tier-1 DARK durability swallows on `plugin-auth`'s admin surface: an
+administrative action landed, its audit row was refused, and the endpoint
+answered `200` with nothing written anywhere. Control flow is unchanged at both
+sites — an admin operation must never fail over its own audit — but the refusal
+is no longer silent.
+
+Both `catch` blocks were doing two jobs and were only right about one of them:
+
+- **plugin-audit UNINSTALLED** — there is no `sys_audit_log` object at all, so
+  nothing ever claimed the action would be audited. Silence is correct, and
+  reporting here would put a line on every admin action in every deployment that
+  does not run plugin-audit.
+- **plugin-audit INSTALLED, the write REFUSED** — the action happened, the audit
+  record did not, and nothing retries or reconstructs it.
+
+Both spelled `catch { }`. Each site now asks `getSchema('sys_audit_log')` — the
+registry that owns the answer — instead of reading the driver's error text,
+which would decide the same question by guessing. `getSchema` is declared
+**optional** on `AdminUserDataEngine` and `IdentityImportEngine`, so it is
+additive and no host that type-checks today stops doing so; where it is absent
+the site cannot measure the difference and therefore reports, because an
+unmeasurable write must not be a silent one.
+
+What was hiding in the silence:
+
+- `admin-user-endpoints.ts :: writeAdminAudit` — `sys_account` is in
+  plugin-audit's `SKIP_OBJECTS`, so for `/admin/set-user-password` its generic
+  writer emits **zero** rows and the row refused here was the only record that a
+  password was ever administratively reset.
+- `admin-import-users.ts` run-level row — `action: 'import'` with a null
+  `record_id` is a shape plugin-audit's `actionFor` structurally cannot emit. The
+  per-row `create` rows still land, which is what made this dangerous: the trail
+  looked complete while who ran the import, under which password policy, and what
+  it did in aggregate was gone.
+
+Both sinks (`AdminUserEndpointDeps.logger`, `IdentityImportDeps.logger`) are
+`{ warn(msg: string): void }` and both are re-exported from the package
+`index.ts`. Neither declares `error`, so the LEVEL stays `warn` and remains
+#13398's question; only the SILENCE is repaired here. Each seam is pinned by a
+test that fails if it goes quiet again, plus absence-asserting cases so a seam
+that warns unconditionally cannot pass.

--- a/packages/plugins/plugin-auth/src/admin-import-users.ts
+++ b/packages/plugins/plugin-auth/src/admin-import-users.ts
@@ -89,6 +89,19 @@ export interface IdentityImportEngine {
   find(objectName: string, query?: any): Promise<any[]>;
   update(objectName: string, data: any, options?: any): Promise<any>;
   insert(objectName: string, data: any, options?: any): Promise<any>;
+  /**
+   * [#12981] Optional registry probe — `ObjectQL.getSchema`, which answers
+   * `undefined` for an object no package registered.
+   *
+   * Separates the two outcomes the run-level audit `catch` used to spell
+   * identically: plugin-audit UNINSTALLED (no `sys_audit_log` object — nothing
+   * was ever claimed, so silence is correct) from plugin-audit INSTALLED AND
+   * THE WRITE REFUSED (the import ran, its only run-level record did not land,
+   * and the endpoint still answers 200). Optional, therefore additive: a host
+   * or mock without it keeps type-checking, and a site that cannot measure the
+   * difference REPORTS rather than going quiet.
+   */
+  getSchema?(objectName: string): unknown;
 }
 
 export interface IdentityImportDeps {
@@ -510,23 +523,56 @@ export async function runAdminImportUsers(
     // `sys_audit_log` table, and an import must not fail over its own audit.
     // Both facts are pinned in
     // `packages/qa/dogfood/test/admin-identity-audit-trail.dogfood.test.ts`.
-    try {
-      await engine.insert('sys_audit_log', {
-        action: 'import',
-        user_id: actor.id,
-        actor: actor.id,
-        object_name: 'sys_user',
-        metadata: JSON.stringify({
-          event: 'user.import_run',
-          mode, matchBy, passwordPolicy: policy,
-          total: prepared.rows.length,
-          created: summary.created, updated: summary.updated,
-          skipped: summary.skipped, errors: summary.errors + preErrors,
-          // How `auto` (and the fixed policies) split the batch across channels.
-          delivery,
-        }),
-      }, { context: SYSTEM_CTX } as any);
-    } catch { /* audit table may not exist — never fail the import */ }
+    //
+    // [#12981] "Best-effort" was doing two jobs and only one of them was
+    // right. plugin-audit UNINSTALLED means no `sys_audit_log` object, so
+    // nothing ever claimed the run would be audited — a declared skip, taken
+    // silently by the probe below. A REFUSED write is the other thing
+    // entirely, and it was wearing the same `catch`.
+    const auditRegistered = !engine.getSchema || Boolean(engine.getSchema('sys_audit_log'));
+    if (auditRegistered) {
+      try {
+        await engine.insert('sys_audit_log', {
+          action: 'import',
+          user_id: actor.id,
+          actor: actor.id,
+          object_name: 'sys_user',
+          metadata: JSON.stringify({
+            event: 'user.import_run',
+            mode, matchBy, passwordPolicy: policy,
+            total: prepared.rows.length,
+            created: summary.created, updated: summary.updated,
+            skipped: summary.skipped, errors: summary.errors + preErrors,
+            // How `auto` (and the fixed policies) split the batch across channels.
+            delivery,
+          }),
+        }, { context: SYSTEM_CTX } as any);
+      } catch (e) {
+        // [#12981] An import must not fail over its own audit — control flow is
+        // unchanged and the run still answers 200 with its summary. It must not
+        // be SILENT either. `sys_audit_log` is registered (checked above), so
+        // this is a refused write, and the run-level row is the ONLY record of
+        // it: plugin-audit's `actionFor` maps afterInsert/Update/Delete to
+        // create/update/delete and nothing else, so `action: 'import'` with a
+        // null `record_id` is a shape its writer structurally cannot emit. The
+        // per-row `create` rows survive, which is what makes this dangerous —
+        // the trail looks populated while WHO ran the import, under WHICH
+        // policy, and WHAT the run did overall is simply gone.
+        deps.logger?.warn(
+          `[AuthPlugin] the run-level sys_audit_log row for this user import was NOT written — `
+            + `the import itself SUCCEEDED (created ${summary.created}, updated ${summary.updated}, `
+            + `skipped ${summary.skipped}) and the endpoint answers 200, so nothing looks wrong. `
+            + 'plugin-audit is installed (sys_audit_log is registered), so this is a REFUSED '
+            + "write, not an absent plugin. plugin-audit's per-row create rows still landed, so "
+            + 'the audit trail LOOKS complete while the only record of who ran this import, under '
+            + 'which password policy, and what it did in aggregate is absent. Nothing retries it '
+            + 'and no later boot reconstructs it. Remedy: restore write access to sys_audit_log '
+            + `(permissions, driver connectivity) before the next import. Cause: ${
+              (e as Error)?.message ?? e
+            }`,
+        );
+      }
+    }
   }
 
   const errors = summary.errors + preErrors;

--- a/packages/plugins/plugin-auth/src/admin-user-endpoints.ts
+++ b/packages/plugins/plugin-auth/src/admin-user-endpoints.ts
@@ -116,6 +116,24 @@ export interface AdminUserDataEngine {
    * isn't wired, in which case the org bind simply no-ops.
    */
   find?(object: string, query?: unknown, opts?: unknown): Promise<unknown>;
+  /**
+   * [#12981] Optional registry probe — `ObjectQL.getSchema`, which answers
+   * `undefined` for an object no package registered.
+   *
+   * It is here to separate two outcomes the audit `catch` below used to spell
+   * identically: plugin-audit UNINSTALLED (no `sys_audit_log` object, so
+   * nothing was ever claimed and silence is correct) from plugin-audit
+   * INSTALLED AND THE WRITE REFUSED (the admin action landed, its audit row did
+   * not, and the endpoint still answers 200). Reading the driver's error text
+   * would decide the same question by guessing; this asks the registry that
+   * owns the answer.
+   *
+   * Optional because lean mocks and hosts that wire no ObjectQL engine do not
+   * carry it — additive, so nothing that type-checks today stops doing so. When
+   * it is absent the site cannot tell the two apart and therefore REPORTS: an
+   * unmeasurable write must never be a silent one.
+   */
+  getSchema?(objectName: string): unknown;
 }
 
 /** The gated caller, passed by the route after its ADR-0068 check. */
@@ -376,6 +394,12 @@ async function writeAdminAudit(
 ): Promise<void> {
   const engine = deps.getDataEngine();
   if (!engine) return;
+  // plugin-audit is OPTIONAL, and with it uninstalled there is no
+  // `sys_audit_log` object at all. That case is a DECLARED skip, not a
+  // swallow: nothing ever claimed this action would be audited, so there is
+  // nothing to report and the channel stays quiet — which is what keeps the
+  // `warn` below meaningful instead of one more line nobody reads.
+  if (engine.getSchema && !engine.getSchema('sys_audit_log')) return;
   try {
     await engine.insert(
       'sys_audit_log',
@@ -389,9 +413,31 @@ async function writeAdminAudit(
       },
       { context: SYSTEM_CTX },
     );
-  } catch {
-    // plugin-audit may not be installed (no sys_audit_log table) — audit is
-    // best-effort by design here; the operation itself must not fail.
+  } catch (error) {
+    // [#12981] The operation itself must NOT fail over its own audit — control
+    // flow is unchanged and the endpoint still answers 200. But it must not be
+    // SILENT either, and this site is the sharpest case in the family: the
+    // header above records that `sys_account` is in plugin-audit's
+    // `SKIP_OBJECTS`, so for `/admin/set-user-password` the generic writer
+    // emits ZERO rows and the row refused here is the ONLY record that a
+    // password was administratively reset. Nothing retries it and no later
+    // boot reconstructs it — the reset simply has no trail, while the admin
+    // who performed it reads `success: true`. `sys_audit_log` is registered
+    // (checked above), so this is a refused write, not an absent plugin.
+    deps.logger?.warn(
+      `[AuthPlugin] the sys_audit_log row for this administrative '${entry.action}' on sys_user `
+        + `${entry.recordId} was NOT written — the operation itself SUCCEEDED and the endpoint `
+        + 'answers 200, so nothing looks wrong. plugin-audit is installed (sys_audit_log is '
+        + 'registered), so this is a REFUSED write, not an absent plugin. This row carries the '
+        + "admin's decisions (event, passwordGenerated, mustChangePassword, placeholderEmail, "
+        + 'membershipCreated), none of which is derivable from the stored row, and for '
+        + '/admin/set-user-password it is the only audit record that exists at all because '
+        + "sys_account is in plugin-audit's SKIP_OBJECTS. Nothing retries this write, so the "
+        + 'action stays permanently untrailed. Remedy: restore write access to sys_audit_log '
+        + `(permissions, driver connectivity), then treat this line as the audit record. Cause: ${
+          (error as Error)?.message ?? error
+        }`,
+    );
   }
 }
 

--- a/packages/plugins/plugin-auth/src/durability-swallow-repair.test.ts
+++ b/packages/plugins/plugin-auth/src/durability-swallow-repair.test.ts
@@ -521,7 +521,7 @@ describe('#12981 batch 6 — the plugin-auth admin-audit swallows report instead
     });
     return {
       insert,
-      update: vi.fn(async (object: string, doc: Record<string, unknown>, options?: unknown) => {
+      update: vi.fn(async (_object: string, doc: Record<string, unknown>, options?: unknown) => {
         assertEngineUpdateDispatch(doc, options as never);
         return { id: String(doc.id ?? 'updated') };
       }),

--- a/packages/plugins/plugin-auth/src/durability-swallow-repair.test.ts
+++ b/packages/plugins/plugin-auth/src/durability-swallow-repair.test.ts
@@ -461,3 +461,258 @@ describe('#12981 batch 5 — plugin-auth durability swallows report instead of v
     });
   });
 });
+
+/**
+ * [#12981 batch 6] The two `plugin-auth` admin-AUDIT swallows, pinned.
+ *
+ * ## What is different about these two, and why the probe is the repair
+ *
+ * The eight batch-5 seams above swallowed a bookkeeping write outright. These
+ * two swallowed something subtler: a `catch` that was doing TWO jobs and was
+ * only right about one of them.
+ *
+ *   - plugin-audit UNINSTALLED  -> there is no `sys_audit_log` object at all,
+ *     nothing ever claimed the action would be audited, and silence is the
+ *     CORRECT answer. Reporting here would put a line on every admin action in
+ *     every deployment that does not run plugin-audit — the "warn nobody
+ *     reads" that #4420 is the historical accident for.
+ *   - plugin-audit INSTALLED, write REFUSED -> the admin action landed, the
+ *     endpoint answered 200, and its audit row did not exist. That is #12981's
+ *     shape exactly.
+ *
+ * Both spelled `catch { }`. The repair asks `getSchema('sys_audit_log')` —
+ * the registry that owns the answer — instead of reading the driver's error
+ * text, which would decide the same question by guessing.
+ *
+ * ⚠️ So each site needs BOTH directions pinned, and the silent direction is
+ * the load-bearing one: a repair that warned unconditionally would pass every
+ * "it reports" case in this file while making the channel worthless.
+ *
+ * ## Level
+ *
+ * `warn`, and NOT because the consequence is small — an administrative
+ * password reset losing its only audit record is the distorted-audit class
+ * #12970 named. `AdminUserEndpointDeps.logger` and `IdentityImportDeps.logger`
+ * are both `{ warn(msg: string): void }` and both PUBLISHED (`index.ts` carries
+ * `export * from './admin-user-endpoints.js'` and `export *` for
+ * `./admin-import-users.js`). Neither declares `error`, so raising the level
+ * means widening a published sink — refused as actively harmful by the
+ * maintainer's #13398 ruling, which routes that question there and leaves the
+ * SILENCE here. The assertions below pin the channel, so a later level change
+ * is a deliberate edit rather than a drift.
+ */
+describe('#12981 batch 6 — the plugin-auth admin-audit swallows report instead of vanishing', () => {
+  const AUDIT_REFUSAL = new Error('write refused: no permission on sys_audit_log');
+
+  /**
+   * The engine the admin endpoints see.
+   *
+   * `getSchema` is the discriminator under test, so it is a real member here
+   * rather than a convenience: `registered` decides whether the double is a
+   * deployment that runs plugin-audit. `update` is pinned to ObjectQL's own
+   * dispatch predicate BEFORE any refusal branch, for the reason the batch-5
+   * double states — a case must not be able to pass by handing the engine a
+   * call the real engine would have thrown on.
+   */
+  const createAuditEngine = (opts: { registered: boolean; refuseAudit?: boolean }) => {
+    const insert = vi.fn(async (object: string) => {
+      if (object === 'sys_audit_log' && opts.refuseAudit) throw AUDIT_REFUSAL;
+      return { id: 'row-1' };
+    });
+    return {
+      insert,
+      update: vi.fn(async (object: string, doc: Record<string, unknown>, options?: unknown) => {
+        assertEngineUpdateDispatch(doc, options as never);
+        return { id: String(doc.id ?? 'updated') };
+      }),
+      find: vi.fn(async () => []),
+      // `undefined` is exactly what ObjectQL answers for an object no package
+      // registered — the uninstalled-plugin case, not an error.
+      getSchema: vi.fn((object: string) =>
+        opts.registered && object === 'sys_audit_log' ? { name: object } : undefined,
+      ),
+    };
+  };
+
+  const auditInserts = (engine: { insert: ReturnType<typeof vi.fn> }): unknown[][] =>
+    engine.insert.mock.calls.filter((c) => c[0] === 'sys_audit_log');
+
+  describe('admin-user-endpoints :: writeAdminAudit (`warn` — level is #13398\'s)', () => {
+    const ACTOR = { id: 'admin-1', email: 'admin@example.com' };
+
+    const makeDeps = (engine: ReturnType<typeof createAuditEngine>, logger: Capture) => ({
+      getAuthApi: async () =>
+        ({
+          createUser: vi.fn(async ({ body }: never) => ({
+            user: { id: 'user-9', email: (body as { email: string }).email },
+          })),
+        }) as never,
+      getAuthContext: async () =>
+        ({
+          password: {
+            hash: vi.fn(async (pw: string) => `hashed(${pw})`),
+            config: { minPasswordLength: 8, maxPasswordLength: 128 },
+          },
+          internalAdapter: {
+            findUserById: vi.fn(async () => ({ id: 'user-9' })),
+            findAccounts: vi.fn(async () => [{ providerId: 'credential' }]),
+            updatePassword: vi.fn(async () => ({})),
+            createAccount: vi.fn(async () => ({})),
+          },
+        }) as never,
+      getDataEngine: () => engine as never,
+      assertPasswordComplexity: vi.fn(async () => undefined),
+      noteMustChangePasswordIssued: vi.fn(),
+      logger: logger as never,
+    });
+
+    const createUserRequest = () =>
+      new Request('http://localhost/api/v1/auth/admin/create-user', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email: 'new@example.com', generatePassword: true }),
+      });
+
+    it('a refused audit row is reported, and names the action that still succeeded', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: true, refuseAudit: true });
+      const { runAdminCreateUser } = await import('./admin-user-endpoints.js');
+
+      const res = await runAdminCreateUser(makeDeps(engine, logger) as never, createUserRequest(), ACTOR as never);
+
+      // Control flow is UNCHANGED: the account exists and the caller sees 200.
+      // That is precisely why the line below is the operator's only evidence.
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(auditInserts(engine)).toHaveLength(1);
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(warnText(logger)).toContain('sys_audit_log');
+      // The two facts that make the line actionable: the row did NOT land, and
+      // the operation it describes DID.
+      expect(warnText(logger)).toContain('NOT written');
+      expect(warnText(logger)).toContain('SUCCEEDED');
+      // The consequence, not merely the failure — this is the record that has
+      // no substitute, because sys_account is in plugin-audit's SKIP_OBJECTS.
+      expect(warnText(logger)).toContain('sys_account');
+      // The driver's own text survives, so the line is greppable against the
+      // datasource log instead of being prose about a failure nobody can find.
+      expect(warnText(logger)).toContain('no permission on sys_audit_log');
+    });
+
+    it('plugin-audit UNINSTALLED stays silent, and does not attempt the write', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: false });
+      const { runAdminCreateUser } = await import('./admin-user-endpoints.js');
+
+      const res = await runAdminCreateUser(makeDeps(engine, logger) as never, createUserRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      // The declared skip: nothing claimed an audit row, so none is attempted
+      // and nothing is reported. A repair that warned here would fire on every
+      // admin action in every deployment without plugin-audit.
+      expect(engine.getSchema).toHaveBeenCalledWith('sys_audit_log');
+      expect(auditInserts(engine)).toHaveLength(0);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('a healthy audit write reports nothing on this channel', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: true });
+      const { runAdminCreateUser } = await import('./admin-user-endpoints.js');
+
+      const res = await runAdminCreateUser(makeDeps(engine, logger) as never, createUserRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      expect(auditInserts(engine)).toHaveLength(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('an engine without `getSchema` cannot measure the difference, so it REPORTS', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: true, refuseAudit: true });
+      // A lean host/mock: the probe is optional, and its absence must fail
+      // toward the loud answer, never toward the silent one.
+      const lean = { insert: engine.insert, update: engine.update, find: engine.find };
+      const { runAdminCreateUser } = await import('./admin-user-endpoints.js');
+
+      const res = await runAdminCreateUser(makeDeps(lean as never, logger) as never, createUserRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(warnText(logger)).toContain('sys_audit_log');
+    });
+  });
+
+  describe('admin-import-users :: the run-level audit row (`warn` — level is #13398\'s)', () => {
+    const ACTOR = { id: 'admin-1', email: 'admin@example.com' };
+
+    const makeDeps = (engine: ReturnType<typeof createAuditEngine>, logger: Capture) => ({
+      getAuthApi: async () => ({
+        createUser: vi.fn(async ({ body }: never) => ({
+          user: { id: 'u-1', email: (body as { email: string }).email },
+        })),
+        requestPasswordReset: vi.fn(async () => ({ status: true })),
+      }),
+      getDataEngine: () => engine as never,
+      phoneNumberEnabled: () => false,
+      emailServiceAvailable: () => true,
+      smsInviteAvailable: () => false,
+      sendInviteSms: vi.fn(async () => undefined),
+      noteMustChangePasswordIssued: vi.fn(),
+      logger: logger as never,
+    });
+
+    const importRequest = () =>
+      new Request('http://localhost/api/v1/auth/admin/import-users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ format: 'json', rows: [{ email: 'a@b.co' }] }),
+      });
+
+    it('a refused run-level row is reported, and says the per-row trail survived', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: true, refuseAudit: true });
+      const { runAdminImportUsers } = await import('./admin-import-users.js');
+
+      const res = await runAdminImportUsers(makeDeps(engine, logger) as never, importRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      expect(auditInserts(engine)).toHaveLength(1);
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(warnText(logger)).toContain('sys_audit_log');
+      expect(warnText(logger)).toContain('NOT written');
+      // The dangerous part, and the one an operator cannot infer: the per-row
+      // `create` rows DID land, so the trail looks complete while the only
+      // record of who ran the import and under which policy is gone.
+      expect(warnText(logger)).toContain('per-row');
+      expect(warnText(logger)).toContain('no permission on sys_audit_log');
+    });
+
+    it('plugin-audit UNINSTALLED stays silent, and does not attempt the write', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: false });
+      const { runAdminImportUsers } = await import('./admin-import-users.js');
+
+      const res = await runAdminImportUsers(makeDeps(engine, logger) as never, importRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      expect(engine.getSchema).toHaveBeenCalledWith('sys_audit_log');
+      expect(auditInserts(engine)).toHaveLength(0);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('a healthy run reports nothing on this channel', async () => {
+      const logger = createLogger();
+      const engine = createAuditEngine({ registered: true });
+      const { runAdminImportUsers } = await import('./admin-import-users.js');
+
+      const res = await runAdminImportUsers(makeDeps(engine, logger) as never, importRequest(), ACTOR as never);
+
+      expect(res.status).toBe(200);
+      expect(auditInserts(engine)).toHaveLength(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -2114,7 +2114,7 @@
     {
       "file": "packages/plugins/plugin-auth/src/durability-swallow-repair.test.ts",
       "verb": "update",
-      "pinned": 1
+      "pinned": 2
     },
     {
       "file": "packages/plugins/plugin-auth/src/first-session-membership-ordering.test.ts",


### PR DESCRIPTION
Part of #12981

Batch 6 of the #12981 repair programme. Two tier-1 DARK durability swallows on `plugin-auth`'s admin surface: an administrative action landed, its audit row was refused, and the endpoint answered `200` with nothing recorded anywhere. Control flow is unchanged at both sites — an admin operation must never fail over its own audit — but the refusal is no longer silent.

## The population, re-measured rather than recalled

The card's "15 files" was measured at `origin/main@196a6c73e` and is stale by construction. Ran the repo's own instrument, `scripts/measure-durability-swallow-family.mjs`, self-test first so the numbers are a measurement and not a matcher that quietly stopped matching:

```
self-test: 4 positive controls yield members at their declared tier,
           3 negative controls yield none, 2 regression controls stay clear
```

| | before (`b997272`) | after (`15b2117`) |
|---|---|---|
| MEMBERS (silent catch over an awaited write) | 61 sites / 40 files | **59 / 38** |
| [1] DARK — the card's family, mechanically decided | 10 sites / 9 files | **8 / 7** |
| [2] carries-error — inter-procedural, not decided by the census | 25 / 20 | 25 / 20 |
| [3] channelled — repaired by earlier batches | 26 / 13 | 26 / 13 |
| ADJACENT: QUIET answers (a LEVEL defect, not a silence defect) | 93 | **95** |

DARK 10 → 8 and QUIET 93 → 95: the two repaired sites left the member set entirely rather than moving to `channelled`, because they now log. That is the declared repair — silence fixed, level deferred — and it is the accounting a reviewer can check without reading the diff.

## The two sites

Both `catch` blocks were doing two jobs and were only right about one of them:

- **plugin-audit UNINSTALLED** — there is no `sys_audit_log` object at all, so nothing ever claimed the action would be audited. Silence is correct, and reporting here would put a line on every admin action in every deployment that does not run plugin-audit — the "warn nobody reads" that #4420 is the historical accident for.
- **plugin-audit INSTALLED, the write REFUSED** — the action happened, the audit record did not, and nothing retries or reconstructs it.

Both spelled `catch { }`. Each site now asks `getSchema('sys_audit_log')` — the registry that owns the answer — instead of reading the driver's error text, which would decide the same question by guessing.

| file | site | what the silence was hiding |
|---|---|---|
| `admin-user-endpoints.ts` | `writeAdminAudit()` | `sys_account` is in plugin-audit's `SKIP_OBJECTS`, so for `/admin/set-user-password` its generic writer emits **zero** rows — the row refused here was the only record that a password was ever administratively reset |
| `admin-import-users.ts` | run-level import audit | `action: 'import'` with a null `record_id` is a shape plugin-audit's `actionFor` structurally cannot emit. The per-row `create` rows still land, which is what made this dangerous: the trail looked complete while who ran the import, under which password policy, and what it did in aggregate was gone |

`getSchema` is declared **optional** on `AdminUserDataEngine` and `IdentityImportEngine`, so it is additive and nothing that type-checks today stops doing so. Where it is absent the site cannot measure the difference and therefore **reports** — an unmeasurable write must not be a silent one, and that direction is pinned by its own case.

## Level: `warn` at both sites, silence-only — and why that is not my call

Both sinks are `logger?: { warn(msg: string): void }`, and both are published: `index.ts` carries `export * from './admin-user-endpoints.js'` and `export *` for `./admin-import-users.js`. Neither declares `error`. Raising the level means widening a **published** sink shape, which the maintainer's 2026-08-30 ruling on #13398 refused as actively harmful — it would enrol every module on that type into the shrink-only `check:optional-error-sink-contract` population. Same finding batch 5 recorded for `AuthManager`.

⇒ **Both sites are silence-repaired, neither is level-repaired**, and the LEVEL remains #13398's question. No published sink shape is changed here.

## Two census hits deliberately NOT repaired

- `auth-manager.ts:4784` `verifyMcpAccessToken()` — **a census over-collection, not a member.** Its `try` holds no write at all: it is `jwtVerify` plus payload destructuring, and `return null` is the correct answer for an expired or wrong-audience token. The reported `write=update@6456` is same-file helper resolution reaching `recordSignInOutcome`, which batch 5 already repaired at its own catch. Repairing it to fit the pattern would be the mirror-image defect AGENTS.md names for this rule.
- `verify/src/harness.ts:695` and `plugin-sharing/src/share-link-service.ts:638` — out of this slice; the first is a verification harness whose gate answers either way, the second is usage telemetry. Neither is obviously a claim-to-persist.

## Verification

Reverse-verified rather than asserted. The repair was **committed first** (`a2fbf54`), so the restore leg had a real reference point; the mutation reverted both source files to the merge base and was confirmed on disk before anything was measured — not by an editor exit code:

```
PRE  hashes: A=ea168649… B=cc79147d…
POST hashes: A=498d2d8d… B=9fe377f9…      (both changed)
PRE  repaired-marker 'NOT written'          : 1, 1
POST repaired-marker 'NOT written'          : 0, 0
POST swallow-marker 'audit table may not exist' : 1
MUTATION CONFIRMED ON DISK
```

Ablated run: **5 failed | 17 passed** — and the five are exactly the five that should redden:

```
× a refused audit row is reported, and names the action that still succeeded
× plugin-audit UNINSTALLED stays silent, and does not attempt the write
× an engine without `getSchema` cannot measure the difference, so it REPORTS
× a refused run-level row is reported, and says the per-row trail survived
× plugin-audit UNINSTALLED stays silent, and does not attempt the write
```

The two "a healthy write reports nothing on this channel" cases stay green in **both** directions by design — they are absence-asserting controls against a seam that warns unconditionally, not pins. Restore proved by `git diff HEAD` empty and a clean `git status`. No `dist` leg applies: these tests import `./admin-user-endpoints.js`, a relative sibling vitest resolves to `src/`.

All results below read from each gate's own verdict line, with exit codes captured before any pipe, on the pushed tree `15b2117`:

- `pnpm --filter @objectstack/plugin-auth exec vitest run` over `admin-user-endpoints.test.ts`, `admin-import-users.test.ts`, `durability-swallow-repair.test.ts` — **3 files, 81 passed**
- `pnpm --filter @objectstack/plugin-auth typecheck` — green
- `pnpm lint` (`eslint . --no-inline-config`, whole repo) — **green, run in full**; no narrowing to declare
- `check:type-check-debt` — `29 ledger entries re-measured, 1542 raw tsc errors, none above its recorded number. surplus: none`, on the built closure the gate demands. This is the measurement that matters for the new test code: `plugin-auth` hides its tests from `tsc`, so the package `typecheck` reads none of them, and a green there would have been NOT MEASURED for the test file.
- `check:engine-double-contract` — was **red**, by its own verdict line: `RETAINED [update]: … now pins 2 engine double(s), ledger records 1. Coverage grew, which is the direction this ledger wants`. Ratcheted with `--write` as instructed (one line, `1 -> 2`); re-run green.
- also green: `check:where-matcher`, `check:objectql-double-limit`, `check:logger-receiver-detach`, `check:cross-package-test-inputs`, `check:query-options-erasure`, `check:dispatcher-error-vocabulary`, `check:type-check-coverage`, `check:dual-build-cjs-loads`, `check:nul-bytes`, `check:published-files`, `check:slot-lookup`, `check:test-source-alias`, `check:type-source-resolution`, `check:page-declaration-shape`, `check:doc-authoring`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:pm-half-states`, `check:agent-test-spelling`, `check:bash32-floor`, `check:cli-command-ids`, `check:entry-guard`, `check:parse-guard`, `check:pnpm-filter-targets`, `check:watch-hint-literal`, and the `check-adr-0087-registration` / `check-changeset-no-major` / `check-ci-filter-parity` / `check-comment-mask-adoption` / `check-cross-package-test-inputs` / `check-empty-changeset` / `check-keyed-text-bounds` / `check-plugin-teardown-shape` / `check-undeclared-dep-imports` / `release-rehearsal-clone --self-test` scripts.
- `scripts/pm/check-half-states.mjs` — **NOT MEASURED**, exit 3 `PREREQUISITE NOT MET`: this container has no valid GitHub credential, so nothing was swept. Not a red; CI runs it with a real token.

Gate families were re-derived from the **actual** diff, twice: the first derivation named 29 families, and re-deriving after the ledger commit added `scripts/**` grew it to **41**. The added families were run rather than assumed.

## Note on the gate this card is about

`scripts/check-durability-degradation-log-level.mjs` is green over both files, before and after. That green means **NOT MEASURED** for these sites, never "level approved" — the gate matches callee names from an 18-entry vocabulary and `ql.insert(...)` is not in it. Its vocabulary is untouched here, and no entry was added to `scripts/durability-degradation.baseline.json`, which stays empty.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_