### PR TITLE
docs(docs-audit): state the recall denominator in both headers

### DIFF
--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -38,6 +38,22 @@ name: Docs Drift Check
 # run the tool on their own worktree. A reader who did that got a different list and
 # reported a correct row as a false positive, and the investigation of the non-existent
 # defect cost a full round. Same posture, one more thing the run knows and used not to say.
+#
+# THE RECALL DENOMINATOR (#13306, maintainer ruling 2026-08-31) — the OTHER half of the
+# structural-invisibility paragraphs above. #11356/#11357 are about a page that IS already
+# in this tool's scope and still goes unlisted (it restates a rule without naming what this
+# tool anchors on). Separately, and wider: scripts/docs-audit/affected-docs.mjs's own header
+# declares the CORPUS this whole check claims to cover — hand-written docs, excluding
+# `content/docs/references/**` (generated, never hand-edited; excluding it is this check's
+# constructive design, not an omission). Any recall figure for this check must use THAT
+# corpus as its denominator; one computed against all edits under content/docs measures how
+# often the docs generator ran in the sampling window, not this check — measured 2026-08-30,
+# 31 of 46 ground-truth entries in the one figure ever computed that way were generated
+# pages this check can never list (method and correction in #13306). This check stays
+# advisory-only (see the top of this file) and the ceiling does not license widening the
+# corpus to improve the number. Full statement in affected-docs.mjs's header — this
+# paragraph only points at it so the two files compose instead of each stating their own
+# half.
 
 on:
   pull_request:

--- a/scripts/docs-audit/affected-docs.mjs
+++ b/scripts/docs-audit/affected-docs.mjs
@@ -13,6 +13,33 @@
 // Scope: hand-written docs only = content/docs/**/*.mdx MINUS content/docs/references/**
 // (references are generated from packages/spec and handled by a separate regenerate pass).
 //
+// THE ABOVE SCOPE IS THE RECALL DENOMINATOR (#13306, maintainer ruling 2026-08-31). Any
+// recall figure for this tool — "of the docs pages that should have been listed, how many
+// were" — MUST use the scope above (hand-written docs, generated pages excluded) as its
+// denominator. Excluding `content/docs/references/**` is not a gap this tool happens to
+// have: those pages are AUTO-GENERATED and nobody hand-edits them, so telling an author
+// "you may have affected this page" would be WRONG ADVICE, not missing advice — the
+// exclusion is constructive, by design, same as the Scope line states.
+//
+// ⇒ a recall ratio computed against a WIDER denominator — every edit under content/docs,
+// generated pages included — is not measuring this tool at all. It is measuring how often
+// the docs generator happened to run inside whatever window was sampled, because every one
+// of those runs counts as a "miss" this tool could structurally never have avoided. This is
+// exactly how the one such figure ever computed got it wrong: measured 2026-08-30 over a
+// 91-commit window ending at `c4ecf0c49` (method, replay and the corrected re-derivation in
+// #13306), 31 of its 46 ground-truth entries were `content/docs/references/**` pages this
+// tool cannot list on any run, at any recall — the ratio moved by a factor of 2.7 just from
+// widening the sampling window, which is the signature of a denominator not measuring the
+// thing.
+//
+// ⛔ Maintainer ruling: this ceiling is honest, not a defect, and does not license widening
+// the corpus to improve the number — that trades a real regression (prompting authors about
+// pages they must never touch) for a paper gain. The tool's advisory-only posture (see
+// .github/workflows/docs-drift-check.yml's own header) is unchanged. That file documents
+// the OTHER half of "why a listed number can still miss something" — a page already IN this
+// scope that goes unlisted because it restates a rule without naming what this tool anchors
+// on. Read both; they compose into one picture, not two competing ones.
+//
 // DERIVATION (#9192): a doc is "affected" when it NAMES SOMETHING THE CHANGE TOUCHED —
 // an ANCHOR — not when it merely mentions the changed package.
 //


### PR DESCRIPTION
Fixes #13306

## What

Writes the recall-denominator definition into both places a reader would look for it, per the maintainer's 2026-08-31 ruling in #13306:

- `scripts/docs-audit/affected-docs.mjs`'s header (the authoritative half, right after the existing `Scope:` line)
- `.github/workflows/docs-drift-check.yml`'s header (a short cross-reference, since it already documents a *separate* structural-invisibility class from #11356/#11357 and previously said nothing about the denominator)

No behavior change. No new recall figure is computed by this PR — the one figure cited is the already-measured, dated reading from #13306's own investigation (31 of 46 ground-truth entries were `content/docs/references/**` pages), used only as evidence for *why* the denominator must be the tool's declared corpus, not as a live metric.

## Why (the substance, not just "excludes generated pages")

`affected-docs.mjs` excludes `content/docs/references/**` **by construction** — those pages are auto-generated and never hand-edited, so telling an author "you may have affected this page" would be *wrong advice*, not missing advice. Therefore any recall ratio computed with **all `content/docs` edits** as the denominator is not measuring this tool at all — it measures how often the docs generator happened to run inside the sampling window (#13306 measured this moving by a factor of 2.7 just from widening the sample window: 17.4% → 6.5%, same tool, same method). The denominator has to be **the corpus the tool claims to cover**.

`docs-drift-check.yml`'s header already records a *different* invisibility class (a page already in scope that still goes unlisted because it restates a rule without naming what the tool anchors on — #11356/#11357) and already states the check is advisory-only. This PR adds the other half — the denominator statement — and points the two files at each other so they compose instead of each stating their own thing, per the dispatch's Zone 3 suggestion.

## Fences respected

- Did **not** widen the corpus to include generated pages — that would trade a real regression (bad advice on unowned pages) for a better-looking number, which is exactly what the ruling forbids.
- Did **not** re-open measurement or produce a new recall figure.
- No bare number that rots: the one number cited (31/46) is tied to a method and a date, with a pointer to #13306 for the full derivation, not asserted as a constant truth about the tool.
- `content/docs/releases/**` untouched.

## Zone 2 (PM mechanism hypotheses) — results

- **H1 confirmed**: the two headers were adjacent-but-non-composing. `affected-docs.mjs` already had a `Scope:` line (the corpus) but never framed it as a *recall denominator*, and `docs-drift-check.yml` documented structural invisibility without ever mentioning a denominator at all. Both are read before writing, and both are now cross-referenced (see the docs-drift-check.yml addition) rather than restated independently in full.
- **H2 confirmed**: no executable assertion pins either header's *text*. `affected-docs.mjs --self-test`, `check-audit-scope.mjs --self-test`/run, `check-affected-docs.mjs`, and `check-drift-comment.mjs` all pin *behavior* (the corpus enumeration, the anchor derivation, the comment's rendered wording for what the run could/couldn't see) — none of them read or assert on this header comment block. So the denominator is documentation-only right now; it is not mechanically derived from a single source of truth, and this wording is the thing that must not drift.

## Tests

Comment-only change to two files — no production behavior touched, so no build/test face is owed beyond confirming the edit didn't disturb anything the surrounding self-tests pin. All run in the worktree after `pnpm install`:

- `node scripts/check-nul-bytes.mjs` on both files — clean; `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on both — no hits.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-drift-check.yml'))"` — parses.
- `node scripts/docs-audit/affected-docs.mjs --self-test` → `✓ affected-docs self-test: 487 cases pass.`
- `node scripts/docs-audit/check-audit-scope.mjs --self-test && node scripts/docs-audit/check-audit-scope.mjs` → both green (189 hand-written docs, 9 release-owned pages).
- `node scripts/docs-audit/check-affected-docs.mjs` → exit 0 (the workflow's own self-test step).
- `node scripts/docs-audit/check-drift-comment.mjs` → `✓ check-drift-comment: 56 cases pass across 5 fixture diff(s).`
- Full derived gate family via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` against the actual 2-file diff (not the dispatch prompt's list) — 29 matched families + 2 convention-triggered ones for editing a gate script. All run, all green (exit codes captured before any pipe): `check:agent-test-spelling`, `check:bash32-floor`, `check:cli-command-ids`, `check:cross-package-test-inputs`, `check:docs-audit-scope`, `check:entry-guard`, `check:node-version`, `check:parse-guard`, `check:pm-governed-merges`, `check:pnpm-acquisition`, `check:pnpm-filter-targets`, `check:required-contexts`, `check:shard-attestation`, `check:stall-guard-budget`, `check:watch-hint-literal`, `check:workflow-status-functions`, `check-aggregator-roster.mjs`, `check-ci-filter-parity.mjs`, `check-whole-set-label-write.mjs`, `pm/ci-failure.mjs --self-test`, `pm/bare-root-worklist.mjs --self-test`, `check:pm-dispatch-gates`.
- No changeset: this diff edits comments only, in `scripts/docs-audit/**` and a workflow header, publishes nothing from any package. `skip-changeset` label applied.

## PR relationship

`Fixes #13306` — this PR is the dispatch's own closing condition: "the deliverable is the two headers' wording." #13471 (the `SCREAMING_SNAKE` literal-anchor gap) is independent and intentionally not touched here, per the ruling.

_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_