### PR TITLE
docs(qa): retarget readonly-package-locks-studio writable contrast at duplicate route

### DIFF
--- a/docs/qa/platform-checklist/areas/access-security.json
+++ b/docs/qa/platform-checklist/areas/access-security.json
@@ -314,18 +314,24 @@
       "title": "A read-only package actually locks Studio editing surfaces",
       "since": "v16",
       "status": "active",
-      "revision": 2,
+      "revision": 3,
       "priority": "P2",
       "surface": "mixed",
       "personas": [
         "admin"
       ],
+      "fixtures": {
+        "app": "showcase",
+        "requires": [
+          "the writable-package contrast side (step 5, acceptance clause 3) needs a writable target package — obtained at runtime via POST /packages/:id/duplicate (ADR-0070 D4 'duplicate base'), not a stock fixture"
+        ]
+      },
       "steps": [
         "boot showcase with the console; open Studio → object designer and the permission matrix on an object belonging to a read-only (installed/locked) package",
         "screenshot the surface; then read the DOM state of the edit affordances (checkboxes, Save)",
         "attempt the edit through the UI anyway (click a checkbox / Save) and capture what the client does",
         "forge the write directly: PUT /api/v1/meta/object/<packaged object name> with a trivial field change, as the same admin session",
-        "repeat the same PUT against a WRITABLE (draft/app-local) object to prove the guard discriminates by package writability, not by blanket denial"
+        "POST /packages/com.example.showcase/duplicate {targetPackageId: <scratch id>} (ADR-0070 D4 'duplicate base' — the platform's supported writable-base route) to clone the showcase base into a writable target, then repeat the same PUT against an object in that writable package to prove the guard discriminates by package writability, not by blanket denial"
       ],
       "acceptance": [
         {
@@ -341,9 +347,9 @@
           "evidence": "PUT trace"
         },
         {
-          "clause": "the same PUT against a writable object SUCCEEDS for the same admin — the lock keys on package writability, not on the route (both sides of the gate)",
+          "clause": "the same PUT against a writable object — obtained through the platform's own duplicate-base route, not a stock fixture — SUCCEEDS for the same admin — the lock keys on package writability, not on the route (both sides of the gate)",
           "oracle": "api",
-          "verify": "writable-target PUT answers 2xx and a follow-up GET shows the change",
+          "verify": "POST /packages/com.example.showcase/duplicate (ADR-0070 D4) to clone the showcase base into a writable target package, then PUT on an object in that target answers 2xx and a follow-up GET shows the change",
           "evidence": "both traces"
         },
         {
@@ -363,7 +369,9 @@
       "source": [
         "#3358 §5",
         "packages/spec/src/api/error-code-ledger.zod.ts (@objectstack/metadata-protocol codes)",
-        "ADR-0010 §3.3 (_lock)"
+        "ADR-0010 §3.3 (_lock)",
+        "packages/runtime/src/domains/packages.ts (POST /packages/:id/duplicate — ADR-0070 D4 'duplicate base', the writable-target route)",
+        "docs/adr/0070-package-first-authoring.md §D4 ('clone a base into a new writable package')"
       ],
       "history": [
         {
@@ -377,6 +385,12 @@
           "date": "2026-08-07",
           "change": "expanded to deep-test contract: concrete steps, multi-clause acceptance, negatives, variants",
           "ref": "claude/platform-test-checklist-ocwugl"
+        },
+        {
+          "revision": 3,
+          "date": "2026-08-31",
+          "change": "retargeted the writable-package contrast side (step 5, acceptance clause 3) at the platform's supported runtime path per the maintainer ruling on #9788 (2026-08-19, 「接受你的所有建议」; reaffirmed 2026-08-25, 「其他接受」): the stock showcase does NOT boot with a writable package, so the runner instead clones the showcase base via POST /packages/:id/duplicate (ADR-0070 D4 'duplicate base') to get the writable contrast object. Added a fixtures.requires line naming the runtime route explicitly, since the item previously left the writable side as an unqualified 'a WRITABLE (draft/app-local) object'. Mirrors the sibling half landed for automation.rollup-summary-filter (PR #11913, bb62d4d08).",
+          "ref": "#9788"
         }
       ]
     },


### PR DESCRIPTION
Fixes #9788.

## What

Retargets `access-security.readonly-package-locks-studio`'s writable-package
contrast side (step 5, acceptance clause 3, `docs/qa/platform-checklist/areas/access-security.json`)
at the platform's supported runtime path, per the maintainer ruling on #9788
(2026-08-19, verbatim: 「接受你的所有建议」; reaffirmed 2026-08-25, 「其他接受」):
the stock showcase does **not** boot with a project-scoped writable package.
The runner instead clones the showcase base into a writable target via
`POST /packages/:id/duplicate` (ADR-0070 D4 "duplicate base") to get the
writable object this item's contrast clause needs, then repeats the packaged
object's PUT against it.

This is the second and last of the two mechanical retargets the ruling
calls for — the first (`automation.rollup-summary-filter`) already landed
as PR #11913. With both items retargeted, #9788's full scope is done.

Changes to the item:
- `steps` — step 5 now names the duplicate-route call instead of the
  unqualified "a WRITABLE (draft/app-local) object."
- `acceptance` clause 3 — retargeted wording; **oracle stays `api`** on both
  sides of the gate, unchanged.
- Added a `fixtures` block (the item had none before) with a `requires` entry
  citing the duplicate route explicitly.
- Added `source` entries citing the duplicate route
  (`packages/runtime/src/domains/packages.ts`) and ADR-0070 §D4.
- `revision` 2 → 3, with a `history` entry recording the retarget and its
  rationale.

**Deliberately NOT copied from the sibling half (PR #11913, `bb62d4d08`):**
this item never carried a `blocked: {by: "fixture", ...}` block or a matching
`fixtures.knownGaps` line — those exist only on the automation item, which
had been explicitly fixture-blocked since #3358. This item's writable side
was instead left as an unqualified phrase ("a WRITABLE (draft/app-local)
object") with no fixture blocker to remove. So this PR adds a `fixtures`
block rather than editing one, and there is no `blocked`/`knownGaps` pair to
strip.

## Verified before writing

- `POST /packages/:id/duplicate` exists (`packages/runtime/src/domains/packages.ts:819`,
  `protocol.duplicatePackage`) and is the same route PR #11913 verified and
  cited — re-confirmed here rather than taken on faith.
- Re-read `access-security.json` on `origin/main` first: the item's step 5 /
  acceptance clause 3 were exactly as the dispatch card described (generic
  "WRITABLE (draft/app-local) object," no fixture blocker) — premise held.
- Confirmed PR #11780 (`359e497f8`, merged) only renamed ADR citations
  (ADR-0057 D10 → ADR-0124 D1) in this file and did not touch this item's
  revision or the writable-contrast wording — nothing here was already done.

## Scope

Only `docs/qa/platform-checklist/areas/access-security.json`. The design
question ("should the stock showcase boot with a writable package?") is
**not reopened** — it was ruled NO on 2026-08-19 and reaffirmed 2026-08-25;
this PR is the mechanical retarget the ruling calls for. No writable package
provisioned, no seed fixtures added, `content/docs/**` untouched.

## Local gates

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (run
against the final commit `2821d5d08`) names two matched families for this
diff, both green:

- `pnpm check:doc-authoring` — "393 files clean — no bare metadata literals."
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` —
  self-test 58/58, "22 record-scoped formula example(s) … judged clean,"
  "9 @example(s) judged clean," "14 predicate(s) … judged clean; 6 skipped as
  undeterminable" (documented, pre-existing, unrelated to this diff).

`check:platform-checklist` is not CI-wired (manual cadence by maintainer
decision — README), so `dispatch-gates.mjs` does not name it, but the area
README asks for it whenever the checklist itself is touched, so it was run
anyway: `check-platform-checklist: OK — 15 areas, 221 items (221 active);
coverage: 31 kinds mapped, 0 waived; traps: 19 documented, 19 in use;
provisioning: 5 area recipes, 8 item references resolved (1 area-qualified),
5/5 recipes referenced.`

Also ran `pnpm check:nul-bytes` (any edit) — green: "scanned 7539 text
file(s) … no raw ASCII control bytes."

No changeset — QA-checklist-only change, nothing user-visible or published
(same precedent as PR #11913). `skip-changeset` label applied and confirmed
present on read-back.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_