### PR TITLE
fix(devx): resolve a regen row's gen:/check: in its declared owner, not only in packages/spec

### DIFF
--- a/scripts/check-regen-pending.mjs
+++ b/scripts/check-regen-pending.mjs
@@ -70,19 +70,41 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PENDING_MARKER, entryForPath } from './regen-artifacts.mjs';
+import { PENDING_MARKER, entryForPath, ownerDir, ownerOf, ownerRunCommand } from './regen-artifacts.mjs';
 import { isEntrypoint } from './invoked-as.mjs';
+import { workspacePackages } from './workspace-enumerator.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SPEC_DIR = join(REPO_ROOT, 'packages/spec');
 
 /**
- * Where the `check:*` gates are spawned. `--self-test`'s fixtures point this at a
- * throwaway package so the two-commit sequence can be replayed without spawning
- * the real spec gates; nothing else sets it. A mistake here fails SAFE — a
- * directory without those scripts makes pnpm exit non-zero, which reads as stale.
+ * Overrides where the `check:*` gates are spawned. `--self-test`'s fixtures point
+ * this at a throwaway package so the two-commit sequence can be replayed without
+ * spawning the real spec gates; nothing else sets it.
  */
-const GATE_CWD = process.env.OS_REGEN_GATE_CWD || SPEC_DIR;
+const GATE_CWD_OVERRIDE = process.env.OS_REGEN_GATE_CWD || null;
+
+/**
+ * Where ONE artifact's gate is spawned: the directory of the package that declares
+ * it (#13585).
+ *
+ * This was `packages/spec` for every row unconditionally, and it is the half of the
+ * single-manifest assumption a lookup-only fix would have left standing. A
+ * root-owned row would have reconciled clean in `check:merge-driver` and then been
+ * spawned here in a directory that does not define its script — measured, `pnpm -s
+ * check:sdui-lockstep` exits 254 in this directory and 0 at the repo root — so the
+ * artifact reads as permanently stale and `pre-commit` refuses every commit from
+ * then on. Registered and unreconcilable is a worse defect than unregisterable,
+ * which is why the owner is read here and not only by the gate.
+ *
+ * A mistake still fails SAFE, in the direction it always did: a directory without
+ * the script makes pnpm exit non-zero, which reads as stale rather than as current.
+ */
+function gateCwd(entry, workspace) {
+  if (GATE_CWD_OVERRIDE) return GATE_CWD_OVERRIDE;
+  const dir = ownerDir(ownerOf(entry), workspace);
+  return dir === null || dir === '.' ? REPO_ROOT : join(REPO_ROOT, dir);
+}
 
 /**
  * Marker line recording a deferral, distinguished from the driver's path lines by
@@ -264,9 +286,9 @@ export function decide({ blocked, merging, deferral, allowDefer = true }) {
   return 'refuse-stale';
 }
 
-function runCheck(script) {
+function runCheck(script, cwd) {
   try {
-    execSync(`pnpm -s ${script}`, { cwd: GATE_CWD, stdio: ['ignore', 'pipe', 'pipe'] });
+    execSync(`pnpm -s ${script}`, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
     return { ok: true, output: '' };
   } catch (err) {
     return { ok: false, output: `${err?.stdout?.toString() ?? ''}${err?.stderr?.toString() ?? ''}`.trim() };
@@ -287,6 +309,9 @@ function main({ prePush = false } = {}) {
 
   const entries = pending.map((p) => ({ path: p, entry: entryForPath(p) })).filter((x) => x.entry);
   const unknown = pending.filter((p) => !entryForPath(p));
+  // Enumerated once, here rather than per gate: `gateCwd` needs an owner-to-directory
+  // answer and this is the repo's one parse of the workspace globs.
+  const workspace = workspacePackages(REPO_ROOT);
 
   console.error(
     `\nos-regen: ${pending.length} generated artifact(s) were merged WITHOUT a text merge and must be `
@@ -309,7 +334,7 @@ function main({ prePush = false } = {}) {
         `  ✗ ${paths.join(', ')}\n`
           + `      ${check} reads packages/spec/dist, which is older than src — NOT running it.\n`
           + `      On a stale dist this gate reports phantom removals and the generator WRITES them.\n`
-          + `      pnpm --filter @objectstack/spec build && pnpm --filter @objectstack/spec ${entry.gen}`,
+          + `      pnpm --filter @objectstack/spec build && ${ownerRunCommand(ownerOf(entry), entry.gen)}`,
       );
       continue;
     }
@@ -323,11 +348,11 @@ function main({ prePush = false } = {}) {
         `  ✗ ${paths.join(', ')}\n`
           + `      ${check} reads packages/spec/json-schema/, which is missing or older than src —\n`
           + `      NOT running it. That tree is gitignored, so a merge never brings it with them.\n`
-          + `      pnpm --filter @objectstack/spec gen:schema && pnpm --filter @objectstack/spec ${entry.gen}`,
+          + `      pnpm --filter @objectstack/spec gen:schema && ${ownerRunCommand(ownerOf(entry), entry.gen)}`,
       );
       continue;
     }
-    const { ok, output } = runCheck(check);
+    const { ok, output } = runCheck(check, gateCwd(entry, workspace));
     if (ok) {
       console.error(`  ✓ ${paths.join(', ')} — current`);
       continue;
@@ -335,7 +360,7 @@ function main({ prePush = false } = {}) {
     blocked++;
     const detail = output.split('\n').filter(Boolean).slice(0, 3).map((l) => `        ${l}`).join('\n');
     console.error(`  ✗ ${paths.join(', ')} — stale\n${detail ? `${detail}\n` : ''}`
-      + `      pnpm --filter @objectstack/spec ${entry.gen}`);
+      + `      ${ownerRunCommand(ownerOf(entry), entry.gen)}`);
   }
 
   for (const p of unknown) {

--- a/scripts/git-merge-regen.mjs
+++ b/scripts/git-merge-regen.mjs
@@ -61,13 +61,19 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  DEFAULT_OWNER,
   DRIVER_NAME,
   GIT_SETTINGS,
   NOT_DRIVER_MANAGED,
   PENDING_MARKER,
   REGEN_ARTIFACTS,
+  ROOT_OWNER,
   entryForPath,
+  ownerDir,
+  ownerOf,
+  ownerRunCommand,
 } from './regen-artifacts.mjs';
+import { workspacePackages } from './workspace-enumerator.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -122,7 +128,7 @@ function drive(argv) {
   console.error(
     `  ⟳ ${path}\n`
       + `     not text-merged — it is generated. Regenerate from the merged tree:\n`
-      + `       pnpm --filter @objectstack/spec ${entry.gen}${dist}${tree}\n`
+      + `       ${ownerRunCommand(ownerOf(entry), entry.gen)}${dist}${tree}\n`
       + `     The pre-commit hook will not let this commit through until you do.`,
   );
   return 0;
@@ -165,20 +171,123 @@ function reconcileAttributes() {
   return ok;
 }
 
-/** Every `gen:`/`check:` the table names must still exist, or the driver's advice is a dead command. */
+/** Where an owner's manifest lives, repo-relative, given a resolved directory. */
+function manifestFor(dir) {
+  return dir === '.' ? 'package.json' : `${dir}/package.json`;
+}
+
+/**
+ * Every `gen:`/`check:` the table names must still exist **in the manifest of the
+ * row's declared owner**, or the driver's advice is a dead command.
+ *
+ * Resolution read `packages/spec/package.json` and nothing else until #13585, which
+ * made a root-owned artifact unregisterable and said so in a way that pointed at the
+ * wrong repair — "you named a script that does not exist" when the truth was "this
+ * artifact is not owned by packages/spec". Two things follow from that, and the
+ * second is the one worth guarding:
+ *
+ *   - resolution reads the owner's manifest, whichever that is; and
+ *   - the refusal NAMES the manifests it searched, so the reader can see that the
+ *     lookup went somewhere else rather than conclude the script is missing.
+ *
+ * It stays exact in the direction that matters. A name is looked for in ONE
+ * manifest — the declared owner's — never in "any manifest that has it", so a row
+ * that names a root-only script while claiming a package owner still fails, and the
+ * command the driver prints for it is the command the `pre-commit` gate spawns.
+ */
 function reconcileScripts() {
-  const pkg = join(REPO_ROOT, 'packages/spec/package.json');
-  if (!existsSync(pkg)) return fail('packages/spec/package.json not found');
-  const scripts = JSON.parse(readFileSync(pkg, 'utf8')).scripts ?? {};
-  const dead = [];
+  const workspace = workspacePackages(REPO_ROOT);
+  const byOwner = new Map();
   for (const e of REGEN_ARTIFACTS) {
-    if (!scripts[e.gen]) dead.push(`${e.path} → ${e.gen}`);
-    if (!scripts[e.check]) dead.push(`${e.path} → ${e.check}`);
+    const owner = ownerOf(e);
+    if (!byOwner.has(owner)) byOwner.set(owner, []);
+    byOwner.get(owner).push(e);
+  }
+
+  const dead = [];
+  const unresolved = [];
+  const searched = [];
+  for (const [owner, entries] of byOwner) {
+    const dir = ownerDir(owner, workspace);
+    const file = dir === null ? null : join(REPO_ROOT, manifestFor(dir));
+    if (file === null || !existsSync(file)) {
+      unresolved.push(`${owner} — declared by ${entries.map((e) => e.path).join(', ')}`);
+      continue;
+    }
+    searched.push(`${owner} (${manifestFor(dir)})`);
+    const scripts = JSON.parse(readFileSync(file, 'utf8')).scripts ?? {};
+    for (const e of entries) {
+      for (const name of [e.gen, e.check]) {
+        if (!scripts[name]) dead.push(`${e.path} → ${name}   [owner ${owner}, ${manifestFor(dir)}]`);
+      }
+    }
+  }
+
+  if (unresolved.length) {
+    return fail(`owner(s) named by the table resolve to no manifest:\n  ${unresolved.join('\n  ')}\n`
+      + '  An owner is a workspace package name, or ROOT_OWNER for the root manifest.\n'
+      + '  Unresolved is a REFUSAL, not a skip: those rows\' scripts were never verified.');
   }
   if (dead.length) {
-    return fail(`script(s) named by the table no longer exist in @objectstack/spec:\n  ${dead.join('\n  ')}`);
+    return fail(`script(s) named by the table do not exist in their declared owner:\n  ${dead.join('\n  ')}\n`
+      + `  Manifests searched: ${searched.join(', ')}\n`
+      + `  A row that declares no \`owner\` defaults to ${DEFAULT_OWNER}, so this can mean the row is\n`
+      + '  in the wrong package rather than that the script is gone. If ROOT tooling owns the\n'
+      + '  artifact, declare it — `owner: ROOT_OWNER` in scripts/regen-artifacts.mjs. ⛔ Do NOT move\n'
+      + '  the scripts into a package to satisfy the lookup: that lets this tool decide code ownership.');
   }
-  console.log(`✓ all ${REGEN_ARTIFACTS.length * 2} gen:/check: names resolve in @objectstack/spec`);
+  console.log(`✓ all ${REGEN_ARTIFACTS.length * 2} gen:/check: names resolve in their declared owner`
+    + ` (${searched.join(', ')})`);
+  return true;
+}
+
+/**
+ * The owner-resolution rule itself, pinned — the half a live tree cannot show.
+ *
+ * `reconcileScripts` above is green on this tree for the same reason it was green
+ * before #13585: every row is spec-owned, so it exercises exactly one manifest and
+ * would keep passing if the loosening were reverted. These cases read the REAL root
+ * manifest through the same functions the driver and the `pre-commit` gate use, so
+ * the root path is measured on every run rather than the first time somebody
+ * registers a root-owned artifact.
+ *
+ * The two-way case is the third one. A permissive lookup — "resolve the name in any
+ * manifest" — passes every other assertion here and fails that one, which is the
+ * whole difference between a resolution and a search.
+ */
+function reconcileOwnership() {
+  const workspace = workspacePackages(REPO_ROOT);
+  const rootScripts = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+  const specDir = ownerDir(DEFAULT_OWNER, workspace);
+  const specScripts = specDir === null
+    ? {}
+    : JSON.parse(readFileSync(join(REPO_ROOT, manifestFor(specDir)), 'utf8')).scripts ?? {};
+  // A name this repo defines at the ROOT and nowhere else. Asserted, not assumed:
+  // if it ever moves into a package, the assertion below says so instead of quietly
+  // testing nothing.
+  const rootOnly = 'check:merge-driver';
+
+  const cases = [
+    ['ROOT_OWNER is the root manifest\'s own name', rootScripts.name === ROOT_OWNER],
+    ['the root manifest resolves to the repo root', ownerDir(ROOT_OWNER, workspace) === '.'],
+    [`${DEFAULT_OWNER} resolves to a workspace directory`, specDir !== null && specDir !== '.'],
+    ['a row with no owner defaults to DEFAULT_OWNER', ownerOf({ path: 'x' }) === DEFAULT_OWNER],
+    ['a declared owner is used verbatim', ownerOf({ owner: ROOT_OWNER }) === ROOT_OWNER],
+    [`${rootOnly} exists in the root manifest`, Boolean(rootScripts.scripts?.[rootOnly])],
+    // ⭐ The two-way case: resolution is per-owner, not "wherever the name turns up".
+    [`${rootOnly} is NOT resolvable under ${DEFAULT_OWNER}`, !specScripts[rootOnly]],
+    ['an unknown owner refuses rather than skipping', ownerDir('@objectstack/not-a-package', workspace) === null],
+    ['the root command takes no --filter', ownerRunCommand(ROOT_OWNER, 'gen:x') === 'pnpm gen:x'],
+    [
+      'a package command filters to its owner',
+      ownerRunCommand(DEFAULT_OWNER, 'gen:x') === `pnpm --filter ${DEFAULT_OWNER} gen:x`,
+    ],
+    ['a spawn asks for silence', ownerRunCommand(ROOT_OWNER, 'check:x', { silent: true }) === 'pnpm -s check:x'],
+  ];
+
+  const failures = cases.filter(([, ok]) => !ok).map(([name]) => name);
+  if (failures.length) return fail(`owner resolution:\n  ${failures.join('\n  ')}`);
+  console.log(`✓ owner resolution: ${cases.length} case(s) pinned, root manifest read as ${ROOT_OWNER}`);
   return true;
 }
 
@@ -378,6 +487,7 @@ if (process.argv.includes('--self-test')) {
   const results = [
     reconcileAttributes(),
     reconcileScripts(),
+    reconcileOwnership(),
     hookIsExecutable(),
     registeredDriverResolves(),
     endToEnd(),

--- a/scripts/regen-artifacts.mjs
+++ b/scripts/regen-artifacts.mjs
@@ -15,9 +15,50 @@
  */
 
 /**
+ * The manifest that owns a row's `gen:`/`check:` names when the row does not say.
+ *
+ * Every row declared this implicitly until #13585, and the reconciliation read it
+ * and nothing else — see `REGEN_ARTIFACTS` for what that cost.
+ */
+export const DEFAULT_OWNER = '@objectstack/spec';
+
+/**
+ * The ROOT manifest, by the name it gives itself.
+ *
+ * Spelled as a name rather than as a path so it reads the same way as any other
+ * owner, and pinned against the real root `package.json` by
+ * `git-merge-regen.mjs --self-test` so the two cannot drift apart silently. The
+ * root is the one owner that is not a workspace member, which is why `ownerDir`
+ * answers it directly instead of looking for it.
+ */
+export const ROOT_OWNER = '@objectstack/spec-monorepo';
+
+/**
  * Artifacts the driver takes over. `check` proves currency, `gen` restores it.
- * Both names are verified against `packages/spec/package.json` by `--self-test`,
- * so a renamed script fails loudly here instead of silently disarming a path.
+ *
+ * `owner` names the manifest that defines those two script names, and defaults to
+ * `DEFAULT_OWNER`. `--self-test` verifies each name against THAT manifest, so a
+ * renamed script fails loudly here instead of silently disarming a path.
+ *
+ * ## Why the owner is declared and not searched for (#13585)
+ *
+ * Until #13585 the verification read `packages/spec/package.json` alone, so an
+ * artifact owned by ROOT tooling could not be registered at all: its `gen:`/
+ * `check:` live in the root manifest, and the reconciliation reported them as
+ * scripts that "no longer exist". That refusal was correct about the tree and
+ * wrong about the world, and an author following it literally moves root tooling
+ * into a package it does not belong to, purely to satisfy a lookup path.
+ *
+ * Widening the lookup to "resolve the name in any manifest" would have fixed the
+ * refusal and left a worse seam behind, because the name is not what the other two
+ * consumers need. The driver prints a regeneration command and the `pre-commit`
+ * gate SPAWNS one, and both were bound to `packages/spec`; a row that resolved
+ * somewhere else would be registered and unreconcilable — self-test green, while
+ * the hook ran the gate in a directory that does not define it and refused the
+ * commit forever. Measured before this field existed: `pnpm -s check:sdui-lockstep`
+ * exits 254 (`Command not found`) in the gate's spawn directory and 0 at the repo
+ * root. So the owner is a declaration all three consumers read, which is what keeps
+ * the reconciliation two-way rather than merely permissive.
  */
 export const REGEN_ARTIFACTS = Object.freeze([
   // Deliberately NOT sharded (#5837): keyed by version, so two PRs append under
@@ -240,6 +281,63 @@ export const GIT_SETTINGS = Object.freeze([
   { key: `merge.${DRIVER_NAME}.driver`, value: `node ${DRIVER_SCRIPT_EXPR} %O %A %B %P` },
   { key: 'core.hooksPath', value: '.githooks' },
 ]);
+
+/**
+ * The manifest name that owns an entry's `gen:`/`check:` scripts.
+ *
+ * Pure, and the single place the default is applied — a consumer that spelled
+ * `entry.owner ?? '@objectstack/spec'` inline would be a second definition of the
+ * default, and the one that wins would be whichever consumer the reader opened.
+ *
+ * @param {{ owner?: string }} entry
+ * @returns {string}
+ */
+export function ownerOf(entry) {
+  return entry.owner ?? DEFAULT_OWNER;
+}
+
+/**
+ * The repo-relative directory an owner's `package.json` sits in, or `null` when no
+ * such owner exists.
+ *
+ * Pure on purpose: it takes an ALREADY-enumerated workspace rather than reading one,
+ * so this module keeps its "constants and pure functions, no top-level statement that
+ * runs" shape (the property `check:entry-guard` relies on to leave it alone). Callers
+ * pass `workspacePackages(REPO_ROOT)` from `workspace-enumerator.mjs`, which is the
+ * repo's one parse of the workspace globs.
+ *
+ * `null` is a REFUSAL, never a skip: an owner nobody can resolve means a row whose
+ * scripts were never verified, which is the state this whole reconciliation exists to
+ * make impossible.
+ *
+ * @param {string} owner
+ * @param {Array<{ dir: string, manifest: Record<string, unknown> }>} workspacePkgs
+ * @returns {string | null}
+ */
+export function ownerDir(owner, workspacePkgs) {
+  if (owner === ROOT_OWNER) return '.';
+  const hit = workspacePkgs.find((p) => p?.manifest?.name === owner);
+  return hit ? hit.dir : null;
+}
+
+/**
+ * The pnpm invocation that runs `script` for `owner`, FROM THE REPO ROOT.
+ *
+ * One builder, because the string the driver PRINTS and the command the
+ * `pre-commit` gate SPAWNS have to be the same command; #13585 is what happens when
+ * a lookup and its consumers disagree about which package a row belongs to. The root
+ * manifest takes no `--filter`: it is not a workspace member, and `pnpm <script>` at
+ * the root is how its scripts run.
+ *
+ * @param {string} owner
+ * @param {string} script
+ * @param {{ silent?: boolean }} [options] `silent` adds `-s`, for a spawn rather than advice
+ * @returns {string}
+ */
+export function ownerRunCommand(owner, script, { silent = false } = {}) {
+  const s = silent ? ' -s' : '';
+  return owner === ROOT_OWNER ? `pnpm${s} ${script}` : `pnpm${s} --filter ${owner} ${script}`;
+}
 
 /** Resolve the entry that owns a path, or undefined. Handles the one `**` entry. */
 export function entryForPath(p) {


### PR DESCRIPTION
Fixes #13585

`git-merge-regen.mjs --self-test` resolved every regen row's `gen:`/`check:` names in
`packages/spec/package.json` and nowhere else, so an artifact owned by **root** tooling could not be
registered for `merge=os-regen` at all — however exactly it matched the pathology the driver exists
for. The refusal was correct about the tree and wrong about the world: it read as *"you named a
script that does not exist"* when the truth was *"this artifact is not owned by `packages/spec`."*

Rows now carry an `owner`, defaulting to `@objectstack/spec` — which is what all 13 existing rows
declared implicitly — and the refusal names the manifests it searched.

Verified on `1997df337`.

---

## 必答項 — is `check:merge-driver`'s reconciliation still two-way?

**Yes, and that requirement is what chose the shape of the fix.** The answer has two halves.

### 1. The lookup stayed exact, so nothing became merely permissive

A name is looked for in **one** manifest — the row's declared owner's — never in "any manifest that
happens to have it". A widened lookup would have made resolution non-deterministic the moment two
manifests defined the same `gen:` name, and would have accepted a row that names a root-only script
while claiming a package owner. It is pinned as a live case rather than argued:
`reconcileOwnership()` asserts that `check:merge-driver`, a **root-only** script name, resolves
under `ROOT_OWNER` and does **not** resolve under `@objectstack/spec`. A permissive lookup passes
every other assertion in that block and fails exactly that one.

Both directions of the `.gitattributes` ↔ table reconciliation are untouched, and an owner that
resolves to no manifest is a **refusal**, not a skip — an unresolvable owner means a row whose
scripts were never verified, which is the state this reconciliation exists to make impossible.

### 2. The half that a one-sided loosening would have left standing — measured, not reasoned

This is the "registered but unreconcilable" seam, and it was real. Two consumers need to know
**which** manifest owns a row, not merely that some manifest has the name:

* `git-merge-regen.mjs` **prints** a regeneration command at merge time;
* `check-regen-pending.mjs` (the `pre-commit` gate) **spawns** one.

Both were bound to `packages/spec` — the runner's spawn directory was `packages/spec`
unconditionally. Measured before the `owner` field existed:

```
pnpm -s check:sdui-lockstep   in packages/spec  ->  exit 254   ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "check:sdui-lockstep" not found
pnpm -s check:sdui-lockstep   at the repo root  ->  exit 0     check:sdui-lockstep: OK -- ...
```

So a lookup-only widening would have produced a row that reconciles **green** and is then
permanently unsatisfiable in the hook. Driven end to end against the real
`check-regen-pending.mjs`, same root-owned row, the only difference being the `owner` declaration:

**A — root-owned row, no `owner` declared (what a lookup-only widening leaves behind):**

```
HOOK_EXIT=1
  ✗ packages/sdui-parser/objectui-lockstep.json — stale
      pnpm --filter @objectstack/spec gen:sdui-lockstep        <- a dead command
```

Every commit refused, forever, with remedy advice that cannot work.

**B — the same row declaring `owner: ROOT_OWNER` (this PR):**

```
HOOK_EXIT=0
  ✓ packages/sdui-parser/objectui-lockstep.json — current
os-regen: all deferred artifacts are current — marker cleared.
```

That is why the owner is **declared** rather than searched for: one declaration, read by the gate,
the driver's advice and the hook's spawn, so the command the driver prints is the command the gate
runs. Registered-and-unreconcilable is a worse defect than unregisterable, and a widened lookup
alone would have manufactured it.

---

## Non-empty control — rejected before, registered after

The artifact that produced the finding, `docs/audits/2026-08-tenant-audit-write-call-sites.counts.md`,
lives on PR #13584's branch and is not on `main`, so it could not be used. The control used instead
is **`packages/sdui-parser/objectui-lockstep.json`** with `gen:sdui-lockstep` / `check:sdui-lockstep`
— the **only** root-owned `gen:`/`check:` pair in the root manifest on `main`, i.e. a genuinely
root-owned artifact and not a `packages/spec` entry testing a path that already worked.

**Before the fix** (registration attempted on `origin/main`, then backed out) — the card's exact
refusal shape, reproduced on a different artifact:

```
✓ .gitattributes ↔ regen-artifacts.mjs agree on 14 path(s)
✗ script(s) named by the table no longer exist in @objectstack/spec:
  packages/sdui-parser/objectui-lockstep.json → gen:sdui-lockstep
  packages/sdui-parser/objectui-lockstep.json → check:sdui-lockstep
✗ merge driver wiring is inconsistent — see above.
```

**After the fix, same row, still no `owner`** — still refused, because the loosening is not blanket,
and the refusal now names what it searched and points at the right repair:

```
✗ script(s) named by the table do not exist in their declared owner:
  packages/sdui-parser/objectui-lockstep.json → gen:sdui-lockstep   [owner @objectstack/spec, packages/spec/package.json]
  packages/sdui-parser/objectui-lockstep.json → check:sdui-lockstep   [owner @objectstack/spec, packages/spec/package.json]
  Manifests searched: @objectstack/spec (packages/spec/package.json)
  A row that declares no `owner` defaults to @objectstack/spec, so this can mean the row is
  in the wrong package rather than that the script is gone. If ROOT tooling owns the
  artifact, declare it — `owner: ROOT_OWNER` in scripts/regen-artifacts.mjs. ⛔ Do NOT move
  the scripts into a package to satisfy the lookup: that lets this tool decide code ownership.
```

**After the fix, declaring `owner: ROOT_OWNER`** — registers, and `pnpm check:merge-driver` is green
end to end (exit 0):

```
✓ .gitattributes ↔ regen-artifacts.mjs agree on 14 path(s)
✓ all 28 gen:/check: names resolve in their declared owner (@objectstack/spec (packages/spec/package.json), @objectstack/spec-monorepo (package.json))
✓ owner resolution: 11 case(s) pinned, root manifest read as @objectstack/spec-monorepo
...
✓ merge driver wiring is consistent (7 path(s) deliberately excluded).
✓ check-regen-pending self-test passed.
```

**And a third leg**, an owner nobody can resolve refuses rather than skipping:

```
✗ owner(s) named by the table resolve to no manifest:
  @objectstack/not-a-package — declared by packages/sdui-parser/objectui-lockstep.json
  Unresolved is a REFUSAL, not a skip: those rows' scripts were never verified.
```

All three registrations were **temporary**, applied on top of the committed implementation and backed
out with `git checkout HEAD -- ...`; restoration was proven by an empty `git diff HEAD` plus a
HEAD-blob-hash comparison per file, not by an exit code.

### Why the control artifact is not registered permanently here

`packages/sdui-parser/objectui-lockstep.json` **can** now be registered, and deliberately is not.
`gen:sdui-lockstep` re-reads objectui's side, which needs an objectui checkout the merger is not
holding — so the deferred regeneration would be unrunnable at exactly the moment `pre-commit` demands
it, and the driver only ever defers. Its conflict is also not the shape the driver exists for: the
record holds **one** side at a **named** revision, so two branches that each re-recorded it disagree
about which objectui revision the parity was verified against, and no regeneration answers that.
Registering it to give this PR a permanent control would be the test dictating the code, so the
durable guard is `reconcileOwnership()` instead — it reads the **real** root manifest through the same
functions the driver and the hook use, on every `check:merge-driver` run.

---

## The refusal now names which manifests were searched

Per the card: a refusal that misdescribes its own cause sends the reader to the wrong repair. The new
text names the owner and manifest per dead row, lists every manifest searched, states that an
undeclared row defaults to `@objectstack/spec`, and explicitly refuses the repair the old text
implied — moving root tooling into a package to satisfy a lookup path.

---

## PM mechanism assumptions — verified

1. **"All currently-registered paths are spec-owned or spec-adjacent; the single-manifest assumption
   has never been stressed."** **Confirmed, with a correction to the count.** There are **13**
   registered paths on `main`, not 14 (the card's `14` was measured with its own candidate row
   already added). Ten are under `packages/spec/`; the other three —
   `docs/protocol-upgrade-guide.md`, `docs/audits/2026-07-unknown-key-strictness-ledger.counts.md`
   and `content/docs/references/**` — are outside `packages/`. All 13 name scripts defined in
   `packages/spec/package.json`, so the assumption held by coincidence of ownership, never by
   constraint.

2. **"`docs/protocol-upgrade-guide.md` is outside `packages/` with only its scripts inside — the real
   boundary is the manifest, not the artifact path."** **Confirmed, and stronger than stated:** it is
   one of **three** such rows, not one. The boundary was always the manifest.

3. **"The two-way reconciliation is the fragile half; if loosening it cleanly is impossible without a
   declared-owner field, say so."** **Confirmed, and that is the shape delivered.** A widened lookup
   cannot supply what the driver's advice and the hook's spawn need — *which* package — so the
   declared-owner field is not one of two acceptable options here but the only one that keeps the
   reconciliation two-way. See the 必答項 section.

---

## On #13335

Triage's grading placed #13335 as the symptom of this cause, with this card blocking it. **That
blocking relationship does not hold, and the acceptance case could not be run as specified.**
`skills/*/references/_index.md` is written by `gen:skill-refs` and gated by `check:skill-refs`, and
both of those are defined in **`packages/spec/package.json`** (lines 257-258), not in the root
manifest:

```
./packages/spec/package.json:257:    "gen:skill-refs": "tsx scripts/build-skill-references.ts",
./packages/spec/package.json:258:    "check:skill-refs": "tsx scripts/build-skill-references.ts --check",
```

So that artifact was **never** blocked by the single-manifest lookup — it is spec-owned and could
have been registered at any time. Registering it here would therefore have been the vacuous control
this lane rejects: a `packages/spec` entry exercising a path that already worked. It is also a
disposition question in its own right (route it, or record why it must keep text-merging), which is
the substance of that card and not of this one. #13335 stays open and untouched; nothing under
`skills/**` is in this diff. The card's own body hedged this correctly — *"If that card's generator
is also root-owned, this one blocks it"* — and it is not.

---

## Verification

Gate family derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(15 families + 2 convention-triggered for editing a gate script), not guessed. All run at
`1997df337`:

* `check:merge-driver` — green, including the new `✓ owner resolution: 11 case(s) pinned` line
* `check:agent-test-spelling`, `check:bash32-floor`, `check:cli-command-ids`,
  `check:cross-package-test-inputs`, `check:entry-guard`, `check:parse-guard`,
  `check:pnpm-filter-targets`, `check:watch-hint-literal` — green
* `check-ci-filter-parity.mjs`, `check-cross-package-test-inputs.mjs`, `check-shard-attestation.mjs` — green
* `bare-root-worklist.mjs --self-test`, `check:pm-dispatch-gates` (the two gate-script conventions) — green
* `@objectstack/spec` `check:generated` (all 14 generated artifacts up to date) and `check:docs`
  (230 generated files in sync) — green, after a full spec build
* `pnpm lint` — the **whole repo**, `eslint . --no-inline-config`, green. No narrowing claimed.
* `check:nul-bytes` — green; the diff also self-scanned for raw control bytes, none
* `check-declaration-mirrors.mjs` (the `.d.mts` mirror of the edited runner) — green
* The edited gate scripts' consumer suites: `dist-freshness.test.ts`,
  `schema-tree-freshness.test.ts`, `build-schemas-check-mode.test.ts` — 3 files, 84 tests passed —
  plus `check:scripts-typecheck` — green
* `check-test-completeness.mjs` — **NOT MEASURED**, by the gate's own declaration: it grades a saved
  `turbo run test` log and exits 3 (`PREREQUISITE NOT MET`) when run without one, which is the shape
  the derived family invokes. Not a red.

No changeset: this PR releases nothing from any package — the diff is three root tooling scripts —
so it carries `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_