### PR TITLE
feat(spec,cli): export the addressed-component walk and consume it from both sides (#13218)

### DIFF
--- a/.changeset/addressed-component-walk-export.md
+++ b/.changeset/addressed-component-walk-export.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): export `walkAddressedPageComponents` — the one addressed-component traversal behind `translatePage`, now shared with the CLI extractor (#13218, ruled 2026-08-30)
+
+`pages.<name>.components.<id>` is served by a walk that two packages used to
+hand-write: `translatePage` here, and the CLI's `collectExpectedEntries`
+mirroring it invariant by invariant. Five invariants were mirrored — the roots
+(`regions[].components[]` only, never `slots`), the descent key
+(`properties.children` only), the depth cap, the ancestor cycle guard, and the
+ruled collision arbitration (region level wins outright; among nested
+components, document-order first sighting) — which is precisely the
+configuration `PAGE_COMPONENT_COPY_KEYS` was refactored out of, one drift
+already measured (#13109: the extractor omitting keys the resolver reads).
+
+The walk is now ONE exported symbol consumed by both sides, completing the key
+list's precedent: `walkAddressedPageComponents(doc, visitor)` visits every
+component the face addresses, pre-order in document order, hands the visitor an
+`AddressedPageComponentContext` (`id`, `nested`, `depth`, `addressed` — the
+arbitration outcome), and rebuilds the region tree from the visitor's returns
+without mutating the input. `translatePage`'s behaviour is unchanged — it now
+runs on the shared walk it previously inlined. The depth-cap NUMBER stays
+module-private: the walk is the contract, the cap is its safety property.

--- a/.changeset/cli-consumes-shared-walk.md
+++ b/.changeset/cli-consumes-shared-walk.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/cli": patch
+---
+
+refactor(cli): `i18n-extract`'s per-component pass consumes `@objectstack/spec`'s `walkAddressedPageComponents` instead of hand-mirroring it (#13218)
+
+Behaviour is unchanged — same entries, same order. The five traversal
+invariants the pass used to restate (roots, descent key, depth cap, cycle
+guard, ruled collision arbitration) now have a single source in
+`packages/spec`, so a future change there carries the extractor along
+structurally instead of relying on someone remembering a file in another
+package. What stays local is what is genuinely the extractor's own: the
+region-level `page:header` emission exception and the `label` either/or. The
+40-deep differential in `test/platform-page-i18n-parity.test.ts` is preserved
+as the convergence's regression guard.

--- a/packages/cli/src/utils/i18n-extract.ts
+++ b/packages/cli/src/utils/i18n-extract.ts
@@ -79,6 +79,7 @@ import {
   PAGE_COMPONENT_COPY_KEYS,
   FLOW_SCREEN_COPY_KEYS,
   FLOW_SCREEN_FIELD_COPY_KEYS,
+  walkAddressedPageComponents,
 } from '@objectstack/spec/system';
 import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
 import { deriveFieldGroupLayout } from '@objectstack/spec/data';
@@ -704,126 +705,48 @@ export function authorWarnedTranslationGroups(): ReadonlySet<string> {
 }
 
 /**
- * How many levels of `properties.children` nesting the per-component pass
- * descends below region level — a MIRROR of `translatePage`'s
- * `MAX_NESTED_COMPONENT_DEPTH` (#12961), which `@objectstack/spec` deliberately
- * does not export ("the guard is a safety property of the walk, not a contract
- * consumers address").
- *
- * ⚠️ A mirrored constant drifts, so it is not left to care: the deep-chain case
- * in `test/platform-page-i18n-parity.test.ts` runs a container chain LONGER
- * than this number through both sides and asserts they stop at the same depth,
- * so raising the cap in `packages/spec` alone reds there rather than silently
- * making the extractor the narrower of the two again. The durable fix is a walk
- * exported from `packages/spec` and imported by both sides, the way
- * `PAGE_COMPONENT_COPY_KEYS` already is — filed separately, since it is a
- * `packages/spec` edit.
- */
-const MAX_NESTED_COMPONENT_DEPTH = 32;
-
-/**
  * Write `pages.<page>.components.<id>.<key>` for every component
  * `translatePage` addresses — and only those (#13109).
  *
- * The KEY list is shared ({@link PAGE_COMPONENT_COPY_KEYS}, imported from the
- * resolver), so neither side can drift on WHICH KEYS. The WALK is not shared,
- * and that is the drift this function exists to close: the resolver descends a
- * container's declared `properties.children` recursively, so
- * `pages.<page>.components.<id>` resolves for a nested component id, while this
- * pass used to iterate `regions[].components[]` and stop — the second half of
- * the failure pair `PAGE_COMPONENT_COPY_KEYS`' own JSDoc names (the extractor
- * OMITTING a key the resolver reads). A translator extracting a page whose copy
- * lives in nested components got a skeleton with no entries for them.
+ * BOTH halves of that sentence are imported from `@objectstack/spec`, so
+ * neither can drift. The KEY list is {@link PAGE_COMPONENT_COPY_KEYS}; the
+ * WALK — which components carry those keys — is `walkAddressedPageComponents`,
+ * the same traversal `translatePage` itself runs (#13218, completing the key
+ * list's precedent). The walk owns the roots (`regions[].components[]` only),
+ * the descent (`properties.children` only, depth-capped, cycle-guarded) and
+ * the ruled collision arbitration (#12961: region level wins outright; among
+ * nested components, document-order first sighting) — this function used to
+ * hand-mirror all five and now owns none of them. What it still owns:
  *
- * ⛔ MATCHED, not widened. `@objectstack/lint`'s `walkPageComponents` is the
- * shared traversal one pass down (object sections), and reusing it here would
- * have been the cheaper edit — but it is WIDER than the resolver in four ways
- * (`slots.<slot>` roots, `properties.items[].children`, `properties.body`,
- * `properties.footer`) and NARROWER in one (it skips `kind: 'html' | 'react' |
- * 'jsx'` pages, which `translatePage` walks). Emitting its extra shapes would
- * recreate the OTHER half of the same failure pair — offering keys the resolver
- * ignores — and adopting its page skip would drop region-level keys that
- * resolve today. So this walk mirrors `translatePage` exactly:
+ *   - the emission exception: a REGION-LEVEL `page:header` emits nothing here
+ *     (its copy is offered under `pages.<page>.title` / `.subtitle` instead —
+ *     emitting both would offer one string under two keys), but the walk still
+ *     counts its id as region-level, so a nested namesake stays blocked;
+ *   - the `label` either/or: `label` may be authored on the component itself
+ *     or in its props — the same either/or `translatePage` resolves back onto.
  *
- *   - roots: `regions[].components[]` only — `slots.<slot>` is not walked by
- *     the resolver, on any page;
- *   - descent: `properties.children` only, recursively, depth-capped at
- *     {@link MAX_NESTED_COMPONENT_DEPTH} and cycle-guarded on ancestors,
- *     because `children` is `z.array(z.unknown())` authored data;
- *   - collisions: a region-level component holding an id wins outright — even
- *     a `page:header`, which emits nothing here but still BLOCKS a nested
- *     namesake — and among nested components the document-order first match
- *     takes the entry. One bundle entry, one component, so a repeated id can
- *     never be counted twice against coverage either.
+ * ⛔ Deliberately NOT `@objectstack/lint`'s `walkPageComponents`, which is
+ * WIDER than the resolver in four ways (`slots.<slot>` roots,
+ * `properties.items[].children`, `properties.body`, `properties.footer`) and
+ * NARROWER in one (it skips `kind: 'html' | 'react' | 'jsx'` pages, which
+ * `translatePage` walks) — either direction of that mismatch is one half of
+ * the failure pair `PAGE_COMPONENT_COPY_KEYS`' own JSDoc names.
  */
 function emitPageComponentCopy(out: ExpectedEntry[], page: any, name: string): void {
-  const regions: any[] = Array.isArray(page.regions) ? page.regions : [];
-  const regionComponents = (region: any): any[] =>
-    Array.isArray(region?.components) ? region.components : [];
-
-  // Pass 1: every id carried at REGION level, known in full before the descent
-  // visits its first nested component — a region-level namesake in a LATER
-  // region still beats a nested match seen earlier.
-  const regionLevelIds = new Set<string>();
-  for (const region of regions) {
-    for (const component of regionComponents(region)) {
-      const id = componentId(component);
-      if (id !== undefined) regionLevelIds.add(id);
-    }
-  }
-
-  // Ids already taken by an earlier nested component, so the document-order
-  // first match keeps the entry.
-  const claimedNestedIds = new Set<string>();
-  // The current descent path, for the cycle guard. Ancestors only — a subtree
-  // referenced twice as a SIBLING is two legitimate components.
-  const ancestors = new Set<any>();
-
-  const visit = (component: any, depth: number): void => {
-    if (!component || typeof component !== 'object' || Array.isArray(component)) return;
-    if (ancestors.has(component)) return;
-
-    const nested = depth > 0;
-    const id = componentId(component);
-    if (id !== undefined && (!nested || (!regionLevelIds.has(id) && !claimedNestedIds.has(id)))) {
-      if (nested) claimedNestedIds.add(id);
-      if (nested || component.type !== PAGE_HEADER_COMPONENT_TYPE) {
-        const props = component.properties ?? {};
-        for (const key of PAGE_COMPONENT_COPY_KEYS) {
-          // `label` may be authored on the component itself or in its props —
-          // the same either/or `translatePage` resolves back onto.
-          const value = key === 'label' && typeof component.label === 'string' && component.label
-            ? component.label
-            : props[key];
-          if (typeof value === 'string' && value) {
-            pushEntry(out, ['pages', name, 'components', id, key], value, 'page');
-          }
+  walkAddressedPageComponents(page, (component, { id, nested, addressed }) => {
+    if (addressed && (nested || component.type !== PAGE_HEADER_COMPONENT_TYPE)) {
+      const props = component.properties ?? {};
+      for (const key of PAGE_COMPONENT_COPY_KEYS) {
+        const value = key === 'label' && typeof component.label === 'string' && component.label
+          ? component.label
+          : props[key];
+        if (typeof value === 'string' && value) {
+          pushEntry(out, ['pages', name, 'components', id as string, key], value, 'page');
         }
       }
     }
-
-    if (depth >= MAX_NESTED_COMPONENT_DEPTH) return;
-    const props = component.properties;
-    if (!props || typeof props !== 'object' || Array.isArray(props)) return;
-    const children = (props as Record<string, unknown>).children;
-    if (!Array.isArray(children)) return;
-    ancestors.add(component);
-    try {
-      for (const child of children) visit(child, depth + 1);
-    } finally {
-      ancestors.delete(component);
-    }
-  };
-
-  for (const region of regions) {
-    for (const component of regionComponents(region)) visit(component, 0);
-  }
-}
-
-/** The id a component is addressed by, or `undefined` when it carries none. */
-function componentId(component: any): string | undefined {
-  if (!component || typeof component !== 'object') return undefined;
-  return typeof component.id === 'string' && component.id.length > 0 ? component.id : undefined;
+    return component;
+  });
 }
 
 /** The one component type whose copy is addressed by PAGE name, not by id. */

--- a/packages/cli/test/platform-page-i18n-parity.test.ts
+++ b/packages/cli/test/platform-page-i18n-parity.test.ts
@@ -147,7 +147,7 @@ describe('plugin-carried Setup pages — i18n drift guard (#3589)', () => {
 // defect #13109 records. This block is the differential the shared
 // `PAGE_COMPONENT_COPY_KEYS` list cannot give: the KEY LIST has one definition
 // and both sides import it, but the WALK — which COMPONENTS carry those keys —
-// is written twice, once in `translatePage` (`packages/spec`) and once in
+// was written twice, once in `translatePage` (`packages/spec`) and once in
 // `collectExpectedEntries`. `PAGE_COMPONENT_COPY_KEYS`' own JSDoc names the
 // failure pair a second hand-maintained copy produces: offering a key the
 // resolver ignores, or omitting one it reads. These tests fail on BOTH halves.
@@ -159,11 +159,16 @@ describe('plugin-carried Setup pages — i18n drift guard (#3589)', () => {
 // whichever side it was copied from and pass through the drift it exists to
 // catch.
 //
-// ⚠️ `MAX_NESTED_COMPONENT_DEPTH` is deliberately NOT exported by
-// `packages/spec`, so the extractor mirrors the number rather than importing
-// it. The deep-chain case below is what keeps the mirror honest: it walks
-// deeper than the cap and asserts the two sides agree about where the descent
-// stops, so raising the cap on one side alone reds here.
+// Since #13218 (ruled 2026-08-30) the walk itself is ONE exported symbol —
+// `walkAddressedPageComponents` in `@objectstack/spec/system` — and both sides
+// consume it, so the five invariants this block measures (roots, descent key,
+// depth cap, cycle guard, collision arbitration) have a single source. This
+// block is the convergence's REGRESSION GUARD, preserved by that ruling: it
+// still measures end to end, so it catches what sharing a symbol cannot — a
+// consumer detaching from the walk again, or wiring it up so the two sides
+// diverge in what they DO at each component. The deep-chain case runs a chain
+// deeper than the (module-private) cap and asserts both sides stop at the same
+// depth, cap drift included.
 
 /**
  * Every component record reachable anywhere in a page document, by id — a

--- a/packages/spec/api-surface/system.json
+++ b/packages/spec/api-surface/system.json
@@ -10,6 +10,7 @@
     "ActionResultDialogTranslation (type)",
     "ActionResultDialogTranslationSchema (const)",
     "AddFieldOperation (const)",
+    "AddressedPageComponentContext (interface)",
     "AdvancedAuthConfig (type)",
     "AdvancedAuthConfigSchema (const)",
     "AnalyzerConfig (type)",
@@ -834,6 +835,7 @@
     "translateObject (function)",
     "translatePage (function)",
     "translateView (function)",
-    "validationMessageTranslationKey (function)"
+    "validationMessageTranslationKey (function)",
+    "walkAddressedPageComponents (function)"
   ]
 }

--- a/packages/spec/export-origins/system.json
+++ b/packages/spec/export-origins/system.json
@@ -10,6 +10,7 @@
     "ActionResultDialogTranslation": "src/system/translation.zod.ts#ActionResultDialogTranslation (type)",
     "ActionResultDialogTranslationSchema": "src/system/translation.zod.ts#ActionResultDialogTranslationSchema (const)",
     "AddFieldOperation": "src/system/migration.zod.ts#AddFieldOperation (const)",
+    "AddressedPageComponentContext": "src/system/i18n-resolver.ts#AddressedPageComponentContext (interface)",
     "AdvancedAuthConfig": "src/system/auth-config.zod.ts#AdvancedAuthConfig (type)",
     "AdvancedAuthConfigSchema": "src/system/auth-config.zod.ts#AdvancedAuthConfigSchema (const)",
     "AnalyzerConfig": "src/system/search-engine.zod.ts#AnalyzerConfig (type)",
@@ -834,6 +835,7 @@
     "translateObject": "src/system/i18n-resolver.ts#translateObject (function)",
     "translatePage": "src/system/i18n-resolver.ts#translatePage (function)",
     "translateView": "src/system/i18n-resolver.ts#translateView (function)",
-    "validationMessageTranslationKey": "src/system/validation-message.ts#validationMessageTranslationKey (function)"
+    "validationMessageTranslationKey": "src/system/validation-message.ts#validationMessageTranslationKey (function)",
+    "walkAddressedPageComponents": "src/system/i18n-resolver.ts#walkAddressedPageComponents (function)"
   }
 }

--- a/packages/spec/src/system/i18n-resolver.test.ts
+++ b/packages/spec/src/system/i18n-resolver.test.ts
@@ -1605,6 +1605,154 @@ describe('translatePage — nested `properties.children` descent (#12961)', () =
 });
 
 // ────────────────────────────────────────────────────────────────────────────
+// #13218 — walkAddressedPageComponents, THE shared addressed-component walk
+// ────────────────────────────────────────────────────────────────────────────
+//
+// The exported contract behind both `translatePage` (above — its behaviour
+// through the walk is pinned by every fixture in that block) and the CLI
+// extractor's `collectExpectedEntries`. These pins address the walk DIRECTLY,
+// extractor-style, so each of the five converged invariants (#13218) has a
+// red test naming it in the package that owns it; the cross-package
+// differential lives in `packages/cli/test/platform-page-i18n-parity.test.ts`.
+
+import {
+  walkAddressedPageComponents,
+  type AddressedPageComponentContext,
+} from './i18n-resolver';
+
+describe('walkAddressedPageComponents (#13218)', () => {
+  /** Enumeration-style consumption: what the walk reports, in visit order. */
+  const trace = (doc: any): AddressedPageComponentContext[] => {
+    const rows: AddressedPageComponentContext[] = [];
+    walkAddressedPageComponents(doc, (component, ctx) => {
+      rows.push({ ...ctx });
+      return component;
+    });
+    return rows;
+  };
+
+  it('walks regions[].components[] only — slots is not a root', () => {
+    const doc: any = {
+      regions: [{ name: 'main', components: [{ id: 'a', type: 'object-metric', properties: {} }] }],
+      slots: { aside: { id: 'slot_child', type: 'object-metric', properties: {} } },
+    };
+    expect(trace(doc).map((r) => r.id)).toEqual(['a']);
+  });
+
+  it('descends properties.children only — body, footer and items[].children stay unvisited', () => {
+    const doc: any = {
+      regions: [{
+        name: 'main',
+        components: [{
+          id: 'card',
+          type: 'page:card',
+          properties: {
+            children: [{ id: 'in_children', type: 'object-metric', properties: {} }],
+            body: [{ id: 'in_body', type: 'object-metric', properties: {} }],
+            footer: [{ id: 'in_footer', type: 'object-metric', properties: {} }],
+            items: [{ children: [{ id: 'in_items', type: 'object-metric', properties: {} }] }],
+          },
+        }],
+      }],
+    };
+    expect(trace(doc).map((r) => r.id)).toEqual(['card', 'in_children']);
+  });
+
+  it('stops the descent at the cap: a 40-chain is visited down to depth 32 and no further', () => {
+    const node = (depth: number): any => ({
+      id: `d${depth}`,
+      type: 'page:flex',
+      properties: depth + 1 < 40 ? { children: [node(depth + 1)] } : {},
+    });
+    const rows = trace({ regions: [{ name: 'main', components: [node(0)] }] });
+    expect(rows.length).toBe(33);
+    expect(rows[0]).toEqual({ id: 'd0', nested: false, depth: 0, addressed: true });
+    expect(rows[32]).toEqual({ id: 'd32', nested: true, depth: 32, addressed: true });
+  });
+
+  it('terminates on a self-referential children array, addressing the node once', () => {
+    const cyclic: any = { id: 'loop', type: 'page:flex', properties: { children: [] as unknown[] } };
+    cyclic.properties.children.push(cyclic);
+    const rows = trace({ regions: [{ name: 'main', components: [cyclic] }] });
+    expect(rows).toEqual([{ id: 'loop', nested: false, depth: 0, addressed: true }]);
+  });
+
+  it('arbitrates a repeated id as ruled: region level wins outright, even over an EARLIER nested sighting', () => {
+    const doc: any = {
+      regions: [
+        {
+          name: 'r1',
+          components: [{
+            id: 'wrap',
+            type: 'page:card',
+            properties: { children: [{ id: 'shared', type: 'object-metric', properties: {} }] },
+          }],
+        },
+        { name: 'r2', components: [{ id: 'shared', type: 'object-metric', properties: {} }] },
+      ],
+    };
+    expect(trace(doc)).toEqual([
+      { id: 'wrap', nested: false, depth: 0, addressed: true },
+      { id: 'shared', nested: true, depth: 1, addressed: false },
+      { id: 'shared', nested: false, depth: 0, addressed: true },
+    ]);
+  });
+
+  it('among nested components, the document-order first sighting is the addressed one', () => {
+    const doc: any = {
+      regions: [{
+        name: 'main',
+        components: [{
+          id: 'wrap',
+          type: 'page:card',
+          properties: {
+            children: [
+              { id: 'twice', type: 'object-metric', properties: {} },
+              { id: 'twice', type: 'object-metric', properties: {} },
+            ],
+          },
+        }],
+      }],
+    };
+    expect(trace(doc).filter((r) => r.id === 'twice').map((r) => r.addressed)).toEqual([true, false]);
+  });
+
+  it("replaces each node with the visitor's return and re-attaches rebuilt children — never mutating the input", () => {
+    const doc: any = {
+      regions: [{
+        name: 'main',
+        components: [{
+          id: 'card',
+          type: 'page:card',
+          properties: {
+            title: 'Card',
+            children: [
+              { id: 'kid', type: 'object-metric', properties: { title: 'Kid' } },
+              // `children` is `z.array(z.unknown())` — non-components are
+              // legal entries and pass through unvisited.
+              'bare-component-id-string',
+              null,
+            ],
+          },
+        }],
+      }],
+    };
+    const regions = walkAddressedPageComponents(doc, (component, { id }) => ({
+      ...component,
+      properties: { ...component.properties, title: `visited:${id}` },
+    })) as any;
+
+    const rebuilt = regions[0].components[0];
+    expect(rebuilt.properties.title).toBe('visited:card');
+    expect(rebuilt.properties.children[0].properties.title).toBe('visited:kid');
+    expect(rebuilt.properties.children.slice(1)).toEqual(['bare-component-id-string', null]);
+    // The source document is untouched — both walk consumers rely on it.
+    expect(doc.regions[0].components[0].properties.title).toBe('Card');
+    expect(doc.regions[0].components[0].properties.children[0].properties.title).toBe('Kid');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
 // #5377 — filter-preset tab labels (`objects.<o>._tabs.<tab>.label`)
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/packages/spec/src/system/i18n-resolver.ts
+++ b/packages/spec/src/system/i18n-resolver.ts
@@ -923,19 +923,22 @@ function lookupPageComponentCopy(
 }
 
 /**
- * How many levels of `properties.children` nesting `translatePage` descends
- * below region level (#12961). Authored page trees run three or four deep in
- * practice, so the cap is not a limit any real document meets — it exists
- * because `children` is authored data, and a resolver that never throws must
- * still be finite on a pathological one.
+ * How many levels of `properties.children` nesting
+ * {@link walkAddressedPageComponents} descends below region level (#12961).
+ * Authored page trees run three or four deep in practice, so the cap is not a
+ * limit any real document meets — it exists because `children` is authored
+ * data, and a walk that never throws must still be finite on a pathological
+ * document.
  *
- * Paired with, not a substitute for, the ancestor-path cycle guard in
- * {@link translatePage}: the cycle guard catches a subtree that contains
- * itself, the cap catches one that is merely absurd. Deliberately NOT
- * exported — the guard is a safety property of the walk, not a contract
- * consumers address, and this card widens the resolver without widening any
- * published face. The pin lives in `i18n-resolver.test.ts`, which restates
- * this number so raising it here reds there.
+ * Paired with, not a substitute for, the walk's ancestor-path cycle guard:
+ * the cycle guard catches a subtree that contains itself, the cap catches one
+ * that is merely absurd. Still deliberately NOT exported — the NUMBER is a
+ * safety property, not a contract consumers address; what IS exported is the
+ * walk that encloses it (#13218), so no consumer needs the number to stay in
+ * step. The pin lives in `i18n-resolver.test.ts`, which restates this literal
+ * so raising it here reds there; the CLI's deep-chain differential
+ * (`platform-page-i18n-parity.test.ts`) holds both consumers of the walk to
+ * it behaviourally.
  */
 const MAX_NESTED_COMPONENT_DEPTH = 32;
 
@@ -946,6 +949,157 @@ const MAX_NESTED_COMPONENT_DEPTH = 32;
 function pageComponentId(component: PageComponentLike | undefined): string | undefined {
   if (!component || typeof component !== 'object') return undefined;
   return typeof component.id === 'string' && component.id.length > 0 ? component.id : undefined;
+}
+
+/**
+ * What {@link walkAddressedPageComponents} knows about one visited component,
+ * handed to the visitor alongside the component itself.
+ */
+export interface AddressedPageComponentContext {
+  /**
+   * The id this component is addressed by (`pages.<name>.components.<id>`,
+   * #6080), or `undefined` when it carries none.
+   */
+  id: string | undefined;
+  /**
+   * `true` below region level — the component was reached through a
+   * container's declared `properties.children`.
+   */
+  nested: boolean;
+  /** Levels below region level; region-level components sit at `0`. */
+  depth: number;
+  /**
+   * `true` when this component OWNS its id's `pages.<name>.components.<id>`
+   * entry under the ruled collision arbitration (#12961): a region-level
+   * component carrying the id wins outright — even over a nested match seen
+   * earlier in document order — and among nested components the depth-first
+   * document-order FIRST sighting takes it. At most one visited component is
+   * `addressed` per id, so a consumer keyed on it can never double-count.
+   */
+  addressed: boolean;
+}
+
+/**
+ * Depth-first, pre-order walk of the components `pages.<name>.components.<id>`
+ * addresses on a page — THE one traversal behind both {@link translatePage}
+ * (this package) and the CLI extractor's `collectExpectedEntries`
+ * (`packages/cli`, behind `os i18n extract` / `os i18n coverage`).
+ *
+ * Exported for the same reason {@link PAGE_COMPONENT_COPY_KEYS} is (#13218,
+ * ruled 2026-08-30, completing that precedent): the WALK used to be
+ * hand-mirrored across the two packages, and a mirrored traversal drifts into
+ * the classic pair of failures — the extractor offering an id the resolver
+ * ignores, or omitting one it reads (#13109 was the second half going live).
+ * Five invariants live here and ONLY here:
+ *
+ *   - roots: `regions[].components[]` only — `slots` is not walked, on any
+ *     page;
+ *   - descent: a container's declared `properties.children` only, recursively
+ *     — the one composition key (#5775); `body` / `footer` /
+ *     `items[].children` are deliberately not descended;
+ *   - the descent is depth-capped ({@link MAX_NESTED_COMPONENT_DEPTH},
+ *     module-private — the walk is the contract, the number is its safety
+ *     property);
+ *   - and cycle-guarded on ancestors — a subtree referenced twice as a
+ *     SIBLING is two legitimate components, not a cycle;
+ *   - id collisions are arbitrated per the ruling — see
+ *     {@link AddressedPageComponentContext.addressed}.
+ *
+ * The visitor is called for EVERY component the walk reaches (addressed or
+ * not), parent before children, siblings in document order. Its return value
+ * REPLACES the node in the rebuilt region tree the walk returns; after the
+ * visitor runs, the walk re-attaches the node's rebuilt `children` array in
+ * place of the existing key, so the visitor never needs to recurse itself.
+ * Enumeration-only consumers return the component unchanged and ignore the
+ * walk's return value. The input document is never mutated. Entries of
+ * `children` that are not component objects (bare id strings, `null` — the
+ * slot is `z.array(z.unknown())`) pass through unvisited, and a region whose
+ * shape is off-spec is returned as-is.
+ */
+export function walkAddressedPageComponents(
+  doc: Pick<PageLike, 'regions'>,
+  visit: (component: PageComponentLike, context: AddressedPageComponentContext) => PageComponentLike,
+): PageLike['regions'] {
+  // Collision arbitration, pass 1 (#12961): every id carried by a REGION-LEVEL
+  // component. The ruling makes region level the outright winner when an id
+  // repeats across levels, so the whole set has to be known before the descent
+  // visits its first nested component — a region-level namesake in a LATER
+  // region still beats a nested match seen earlier.
+  const regionLevelIds = new Set<string>();
+  if (Array.isArray(doc.regions)) {
+    for (const region of doc.regions) {
+      if (!region || typeof region !== 'object' || !Array.isArray(region.components)) continue;
+      for (const component of region.components) {
+        const id = pageComponentId(component);
+        if (id !== undefined) regionLevelIds.add(id);
+      }
+    }
+  }
+
+  // Pass 2's ledger: ids already taken by an earlier nested component, so the
+  // document-order first match keeps the entry. Claimed on first SIGHTING
+  // rather than on what the visitor does with it — which nested component owns
+  // an id is a property of the DOCUMENT, decided identically for every
+  // consumer of this walk.
+  const claimedNestedIds = new Set<string>();
+
+  // The current descent path, for the cycle guard. Ancestors only — a subtree
+  // referenced twice as a SIBLING is two legitimate components, not a cycle,
+  // and the collision ledger above is what decides between them.
+  const ancestors = new Set<PageComponentLike>();
+
+  /**
+   * The component's rebuilt `properties.children`, or `undefined` when there
+   * is nothing to descend into — so a component without the slot is returned
+   * untouched rather than gaining an invented `properties` bag.
+   */
+  const walkChildren = (component: PageComponentLike, depth: number): unknown[] | undefined => {
+    if (depth >= MAX_NESTED_COMPONENT_DEPTH) return undefined;
+    const props = component.properties;
+    if (!props || typeof props !== 'object' || Array.isArray(props)) return undefined;
+    const children = (props as Record<string, unknown>).children;
+    if (!Array.isArray(children)) return undefined;
+    ancestors.add(component);
+    try {
+      return children.map((child) => visitComponent(child as PageComponentLike, depth + 1));
+    } finally {
+      ancestors.delete(component);
+    }
+  };
+
+  const visitComponent = (component: PageComponentLike, depth: number): PageComponentLike => {
+    // `children` is declared `z.array(z.unknown())`: bare component-id strings
+    // and other non-component values are legal entries, and an array is not a
+    // component — spreading one would rewrite it into an object.
+    if (!component || typeof component !== 'object' || Array.isArray(component)) return component;
+    // Cycle guard: this node is already an ancestor of itself.
+    if (ancestors.has(component)) return component;
+
+    const nested = depth > 0;
+    const id = pageComponentId(component);
+    const addressed = id !== undefined
+      && (!nested || (!regionLevelIds.has(id) && !claimedNestedIds.has(id)));
+    if (addressed && nested) claimedNestedIds.add(id as string);
+
+    // Pre-order: the visitor sees the parent before its children, so a
+    // consumer that emits in visit order emits in document order. The rebuilt
+    // children land on the RETURNED node afterwards — `children` is the slot
+    // the walk owns; everything else on the node is the visitor's.
+    let next = visit(component, { id, nested, depth, addressed });
+
+    const children = walkChildren(component, depth);
+    if (children !== undefined) {
+      next = { ...next, properties: { ...next.properties, children } };
+    }
+    return next;
+  };
+
+  return Array.isArray(doc.regions)
+    ? doc.regions.map((region) => {
+        if (!region || typeof region !== 'object' || !Array.isArray(region.components)) return region;
+        return { ...region, components: region.components.map((c) => visitComponent(c, 0)) };
+      })
+    : doc.regions;
 }
 
 /**
@@ -997,6 +1151,11 @@ function pageComponentId(component: PageComponentLike | undefined): string | und
  * authored data and a resolver must not hang or blow the stack on a document
  * that contains itself.
  *
+ * The traversal itself — roots, descent key, depth cap, cycle guard,
+ * collision arbitration — is {@link walkAddressedPageComponents}, the ONE
+ * walk this resolver and the CLI extractor both consume (#13218); this
+ * function owns only what happens AT each component it hands back.
+ *
  * A list page's filter-preset tab bar
  * (`interfaceConfig.userFilters.tabs[].label`) is translated too, against
  * `objects.<object>._tabs.<tab_name>.label` — see
@@ -1018,58 +1177,23 @@ export function translatePage<T extends PageLike>(
     ?? lookupPageAttr(bundle, name, 'label', opts);
   const headerSubtitle = lookupPageAttr(bundle, name, 'subtitle', opts);
 
-  // Collision arbitration, pass 1 (#12961): every id carried by a REGION-LEVEL
-  // component. The ruling makes region level the outright winner when an id
-  // repeats across levels, so the whole set has to be known before the descent
-  // visits its first nested component — a region-level namesake in a LATER
-  // region still beats a nested match seen earlier.
-  const regionLevelIds = new Set<string>();
-  if (Array.isArray(doc.regions)) {
-    for (const region of doc.regions) {
-      if (!region || typeof region !== 'object' || !Array.isArray(region.components)) continue;
-      for (const component of region.components) {
-        const id = pageComponentId(component);
-        if (id !== undefined) regionLevelIds.add(id);
-      }
-    }
-  }
-
-  // Pass 2's ledger: ids already taken by an earlier nested component, so the
-  // document-order first match keeps the entry. Claimed on first SIGHTING
-  // rather than on a resolved lookup — within one call `lookupPageComponentCopy`
-  // is a pure function of the id (bundle, page name and options are fixed), so
-  // "first nested match" and "first nested sighting" select the same component
-  // and the cheaper test is the honest one.
-  const claimedNestedIds = new Set<string>();
-
-  // The current descent path, for the cycle guard. Ancestors only — a subtree
-  // referenced twice as a SIBLING is two legitimate components, not a cycle,
-  // and the collision ledger above is what decides between them.
-  const ancestors = new Set<PageComponentLike>();
-
-  const translateComponent = (component: PageComponentLike, depth: number): PageComponentLike => {
-    // `children` is declared `z.array(z.unknown())`: bare component-id strings
-    // and other non-component values are legal entries, and an array is not a
-    // component — spreading one would rewrite it into an object.
-    if (!component || typeof component !== 'object' || Array.isArray(component)) return component;
-    // Cycle guard: this node is already an ancestor of itself.
-    if (ancestors.has(component)) return component;
-
-    const nested = depth > 0;
-    const id = pageComponentId(component);
-
+  // The traversal — roots, descent, depth cap, cycle guard, collision
+  // arbitration — is the shared walk (#13218). This visitor owns only the
+  // per-component overlay; the walk re-attaches each node's translated
+  // `children` after the visitor returns, so the overlay never contends with
+  // the descent for a key (`children` is not a copy key).
+  const regions = walkAddressedPageComponents(doc, (component, { nested, id, addressed }) => {
     // Per-component copy (#6080) — addressed by the component's own id, so it
     // is strictly more specific than the page-name route below and is applied
     // first. A `page:header` that DOES carry an id can therefore be translated
-    // either way, and the id wins.
-    //
-    // At nesting level the ruled collision rule (#12961) arbitrates first: a
-    // region-level component holding this id takes the entry outright, and
-    // among nested components the first in document order takes it.
+    // either way, and the id wins. `addressed` carries the ruled collision
+    // arbitration (#12961), so a looked-up entry is this component's alone;
+    // within one call `lookupPageComponentCopy` is a pure function of the id
+    // (bundle, page name and options are fixed), so the walk's claim-on-first-
+    // sighting selects the same component a claim-on-resolved-lookup would.
     let copy: Partial<Record<PageComponentCopyKey, string>> | undefined;
-    if (id !== undefined && (!nested || (!regionLevelIds.has(id) && !claimedNestedIds.has(id)))) {
-      if (nested) claimedNestedIds.add(id);
-      copy = lookupPageComponentCopy(bundle, name, id, opts);
+    if (addressed) {
+      copy = lookupPageComponentCopy(bundle, name, id as string, opts);
     }
 
     let next = component;
@@ -1092,14 +1216,6 @@ export function translatePage<T extends PageLike>(
       };
     }
 
-    // Descend into the declared composition slot (#12961). Applied AFTER the
-    // copy overlay so the translated children survive the props spread above;
-    // the two never contend for a key, since `children` is not a copy key.
-    const children = translateChildren(component, depth);
-    if (children !== undefined) {
-      next = { ...next, properties: { ...next.properties, children } };
-    }
-
     // The page-name header route addresses THE page's header, so it stops at
     // region level — nested components are reached by the id route only.
     if (nested) return next;
@@ -1115,33 +1231,7 @@ export function translatePage<T extends PageLike>(
         ...(headerSubtitle !== undefined ? { subtitle: headerSubtitle } : {}),
       },
     };
-  };
-
-  /**
-   * The component's translated `properties.children`, or `undefined` when
-   * there is nothing to descend into — so a component without the slot is
-   * returned untouched rather than gaining an invented `properties` bag.
-   */
-  const translateChildren = (component: PageComponentLike, depth: number): unknown[] | undefined => {
-    if (depth >= MAX_NESTED_COMPONENT_DEPTH) return undefined;
-    const props = component.properties;
-    if (!props || typeof props !== 'object' || Array.isArray(props)) return undefined;
-    const children = (props as Record<string, unknown>).children;
-    if (!Array.isArray(children)) return undefined;
-    ancestors.add(component);
-    try {
-      return children.map((child) => translateComponent(child as PageComponentLike, depth + 1));
-    } finally {
-      ancestors.delete(component);
-    }
-  };
-
-  const regions = Array.isArray(doc.regions)
-    ? doc.regions.map((region) => {
-        if (!region || typeof region !== 'object' || !Array.isArray(region.components)) return region;
-        return { ...region, components: region.components.map((c) => translateComponent(c, 0)) };
-      })
-    : doc.regions;
+  });
 
   const interfaceConfig = translateInterfaceTabs(doc, bundle, opts);
 


### PR DESCRIPTION
Fixes #13218

Implements ruling A (maintainer, 2026-08-30, director batch 6, verbatim 「其他同意」 adopting the staged recommendation): the addressed-component traversal behind `translatePage` is now ONE exported symbol in `packages/spec` — `walkAddressedPageComponents` plus its `AddressedPageComponentContext` — and BOTH consumers run on it: `translatePage` itself (`packages/spec/src/system/i18n-resolver.ts`) and the CLI extractor's per-component pass (`emitPageComponentCopy` behind `collectExpectedEntries`, `packages/cli/src/utils/i18n-extract.ts`). The five hand-mirrored invariants collapse into that single source: the roots (`regions[].components[]` only, never `slots`), the descent key (`properties.children` only), the depth cap, the ancestor cycle guard, and the ruled collision arbitration (region level wins outright; among nested components, document-order first sighting decides). This completes the `PAGE_COMPONENT_COPY_KEYS` precedent — same hazard, same remedy. The depth-cap NUMBER stays module-private: the walk is the contract, the cap is its safety property.

The walk is a pre-order, document-order visitor-map: the visitor is called for every reached component with its context (id, nested, depth, addressed — the arbitration outcome), its return replaces the node in the rebuilt region tree, and the walk re-attaches each node's rebuilt children afterward, never mutating the input. `translatePage` keeps only its per-component overlay (copy keys, header route); the extractor keeps only what is genuinely its own (the region-level page-header emission exception and the label either/or). Behaviour on both sides is unchanged — same entries, same order, same resolutions.

## Mandated first verification — measured: NO non-public sharing entry exists

- `packages/spec/package.json` `exports` encloses the root entry, 16 public domain subpaths, `./openapi.json` and `./package.json` — no internal/shared non-public entry anywhere in the map (repo-wide grep for an `"./internal"` subpath convention across package manifests: zero hits).
- The CLI reaches spec exclusively through public subpaths (`@objectstack/spec/system` is the one already carrying `PAGE_COMPONENT_COPY_KEYS`). Deep imports into `dist/` are sealed by the exports map and banned by Prime Directive 4.
- `packages/spec/src/system/index.ts` barrels `i18n-resolver.ts` wholesale (`export * from './i18n-resolver'`), and that barrel is tracked in `api-surface/system.json`.

Consequence: **clause-② = YES** — the helper lands as a new public export on the `/system` subpath. `api-surface/system.json` and `export-origins/system.json` regenerated via `check:generated --fix` (only the 2 proved-stale artifacts); the diff is exactly two new rows — the function and its context interface. Nothing else on the surface moved.

## The 40-deep differential is PRESERVED (ruled prohibition honored)

`packages/cli/test/platform-page-i18n-parity.test.ts` keeps every assertion byte-identical — only the prose block describing the retired mirror was rewritten. It remains a measured differential (real `translatePage` vs real `collectExpectedEntries`, no traversal restated in the test) and is now the convergence's regression guard. New direct pins for the exported walk were added in `packages/spec/src/system/i18n-resolver.test.ts` (roots, descent key, cap, cycle guard, both arbitration directions, the map contract and input immutability).

## Verification (final head a254f7e9; union re-run after the last commit)

- Suites: spec `Test Files 2 passed (2) / Tests 304 passed (304)` (i18n-resolver + translation); cli `Test Files 12 passed (12) / Tests 144 passed (144)` (all i18n suites, the differential included). Typechecks exit 0 both packages; spec's includes its test layer via `check:test-typecheck` ("54 file(s) / 262 error(s) ... shrink-only" — ledger held, my test additions added zero). Noted honestly: cli's `tsc --noEmit` includes `src` only (no test tsconfig exists in that package — pre-existing); the edited cli test file's diff is comment-only and the file runs green under vitest.
- Derived gate families: `node scripts/pm/dispatch-gates.mjs` (no hand-fed paths), provenance line "gate list derived from the tree of 'objectstack-ai/objectstack' at commit a254f7e9". All 32 derived families green, plus `check:nul-bytes`. Three initially refused on prerequisites (unbuilt closure) and went green after `turbo run build` over all packages: `check:dual-build-cjs-loads` (provenance 102/66/610/1 vs floors), `check:i18n-coverage` ("check-i18n-coverage: OK (12 config(s), 602 baselined untranslated string(s), none new)"), `check:type-check-debt` ("29 ledger entr(ies) re-measured ... none above its recorded number").
- Ablation at the single source (family style, committed-state, trap-guarded): mutated the depth cap 32 to 31 in `packages/spec/src/system/i18n-resolver.ts` ONLY. Mutation proven on disk (anchored grep: injected-text count 1, original-text count 0) and in the built artifact (`ablation-dist-preflight` marker-present exit 0). Predicted consumers went red: the spec suite failed 2 (the exactly-32-levels pin and the new walk cap pin) and the cli differential failed 1 (`deepest: 31, offeredCount: 32` against the pinned 32/33) — while the differential's set-parity leg stayed GREEN because both sides moved together through the shared symbol, which is precisely what the convergence buys. Restore via `git checkout HEAD --` on the file, proven by blob-hash equality against the HEAD blob (`0f8fc7558fa1...` both sides), rebuild, preflight `--absent` ("marker absent from all 215 built files"), both suites green again (186/186 spec, 11/11 cli).

## Changesets

- `@objectstack/spec`: **minor** — graded against the nearest new-public-export precedent, the response-contracts binding changeset (`sdk-response-contracts-bound.md`: spec minor for new published contract symbols).
- `@objectstack/cli`: **patch** — same grade as the walk-alignment changeset this converges (`i18n-extract-nested-component-walk.md`: cli patch), and the behaviour is unchanged.

Session: https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2

_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_