### PR TITLE
fix(service-analytics): refuse an empty $nin on the read-scope lowering instead of folding it to constant TRUE

### DIFF
--- a/.changeset/read-scope-empty-nin-refusal.md
+++ b/.changeset/read-scope-empty-nin-refusal.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/service-analytics': patch
+---
+
+The analytics read-scope compiler (`read-scope-sql.ts`) now refuses an empty `$nin` (`READ_SCOPE_COMPILE_FAILED` / 500) instead of folding it to constant TRUE. An emptied exclusion ("NOT IN () excludes nothing") vacated the whole read scope — every row admitted — on the ADR-0021 lowering, where a widening is scope over-reach; no in-repo producer can emit the shape (the CEL lowering never emits `$nin`, and the RLS guard drops even-polarity empty-`$nin` policies upstream), so the refusal costs no live traffic. Deliberately asymmetric: `$in: []` keeps its ruled constant-FALSE fold (#5322/#5243), which the RLS compiler's inert positive composite — an emptied membership `$or`-ed beside an own-rows grant — depends on.

--- a/packages/services/service-analytics/src/__tests__/comparand-shape-refusal.test.ts
+++ b/packages/services/service-analytics/src/__tests__/comparand-shape-refusal.test.ts
@@ -266,11 +266,30 @@ describe('[#5234] the read-scope lowering refuses the same two shapes, fail-clos
       expect(scope({ name: { $startsWith: '_admin' } }).params).toEqual(['\\_admin%', '\\']);
     });
 
-    it('an empty `$in` / `$nin` still lowers to its boolean constant, not a refusal', () => {
+    it('an empty `$in` still lowers to its FALSE constant, not a refusal', () => {
       // The member scan runs AFTER the arity identities (#5134), so the empty
-      // list keeps compiling to `1 = 0` / `1 = 1` rather than becoming an error.
+      // INCLUSION keeps compiling to `1 = 0` rather than becoming an error. It
+      // KEEPS its #5322/#5243 reduction because that constant is FALSE —
+      // narrowing at this arm — and because a live producer depends on it: the
+      // RLS compiler deliberately emits `$in: []` at positive polarity inside
+      // composites (#13570's "own rows keep flowing" pin), and that filter
+      // reaches this compiler through `security.getReadFilter`.
       expect(scope({ status: { $in: [] } }).sql).toContain('1 = 0');
-      expect(scope({ status: { $nin: [] } }).sql).toContain('1 = 1');
+    });
+
+    it('an empty `$nin` is REFUSED — its constant is TRUE, which vacates the scope (#13571)', () => {
+      // Deliberately ASYMMETRIC with the `$in` case above, and not an
+      // oversight: the #5322 boundary is "shape errors throw, boolean
+      // identities reduce", and `$nin: []` sits on the THROW side because its
+      // faithful reduction is constant TRUE — a read scope silently widened to
+      // every row, the exact thing the module header forbids. No in-repo
+      // producer can emit the shape (the CEL lowering never emits `$nin`;
+      // #13570's guard drops even-polarity empty-`$nin` policies), so the
+      // refusal costs no live traffic. See read-scope-sql.ts's #13571 section.
+      const err = refusalOf(() => scope({ status: { $nin: [] } }));
+      expect(err.code).toBe('READ_SCOPE_COMPILE_FAILED');
+      expect(err.status).toBe(500);
+      expect(err.message).toContain('$nin for "status" is empty');
     });
   });
 });

--- a/packages/services/service-analytics/src/__tests__/read-scope-empty-nin-refusal.test.ts
+++ b/packages/services/service-analytics/src/__tests__/read-scope-empty-nin-refusal.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#13571] The empty-`$nin` compile refusal, exercised on the path that made it
+ * matter — a NON-RLS `getReadScope` provider — plus the over-denial control
+ * that bounds the fix.
+ *
+ * ## Why a non-RLS provider, and not an RLS regression
+ *
+ * In-repo, the only scope producer is the RLS compiler, and since PR #13570 its
+ * polarity-aware guard drops every emptied-membership shape at widening
+ * polarity before it is emitted — so an RLS-path regression for `$nin: []`
+ * would exercise a route that cannot reach this compiler at all and would test
+ * nothing. But `StrategyContext.getReadScope` is a spec contract
+ * (`packages/spec/src/contracts/analytics-service.ts` — its doc carries a
+ * hand-written example), fillable by ANY provider. The provider below is that
+ * contract filled by hand, which is exactly the surface the #13571 card named.
+ *
+ * ## The two controls
+ *
+ * 1. **Refusal (the fix).** A provider handing `{ owner: { $nin: [] } }` used
+ *    to get a scope clause of constant TRUE (`1 = 1`) — on the read-scope
+ *    lowering, the WHOLE TABLE, an ADR-0021 over-reach. It now gets the
+ *    module's one refusal envelope: `READ_SCOPE_COMPILE_FAILED` / 500.
+ *    MEASURED pre-fix (this file run against the pre-#13571 compiler, see the
+ *    PR): the same case admitted every fixture row.
+ *
+ * 2. **Over-denial (the bound — the reason #13571 is NOT a uniform throw).**
+ *    The RLS compiler deliberately emits an emptied POSITIVE membership inside
+ *    a composite — `{ $or: [{ owner: { $in: [] } }, { owner: 'u_me' }] }`,
+ *    pinned by #13570's `rls-empty-membership-polarity.test.ts` as "own rows
+ *    keep flowing" — and that filter reaches this compiler through
+ *    `security.getReadFilter`. The refusal must NOT catch it: the scope still
+ *    compiles and still admits exactly the own row. A uniform throw at both
+ *    arms fails this block, which is the availability regression the #13571
+ *    verdict rejected.
+ *
+ * `$in: []` under `$not` from a non-RLS provider (constant TRUE via inversion)
+ * is the verdict's DECLARED residue, deliberately not asserted here either way
+ * as a contract — `read-scope-not-null-safe.test.ts` pins its current
+ * behaviour next to the ruling's reasoning.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Cube } from '@objectstack/spec/data';
+import type { AnalyticsQuery, StrategyContext } from '@objectstack/spec/contracts';
+
+import { NativeSQLStrategy } from '../strategies/native-sql-strategy.js';
+
+const FIXTURE = [
+  { id: 'r1', owner: 'u_me' },
+  { id: 'r2', owner: 'u_other' },
+  { id: 'r3', owner: null },
+];
+
+const CUBE: Cube = {
+  name: 'deals',
+  title: 'Deals',
+  sql: 'deal',
+  measures: { total: { name: 'total', label: 'Total', type: 'count', sql: '*' } },
+  dimensions: Object.fromEntries(
+    ['id', 'owner'].map((n) => [n, { name: n, label: n, type: 'string', sql: n }]),
+  ),
+  public: false,
+} as unknown as Cube;
+
+/** Point sql.js at the `.wasm` shipped inside its own package (Node-safe). */
+async function locateWasm(): Promise<((file: string) => string) | undefined> {
+  try {
+    const { createRequire } = await import('node:module');
+    const require = createRequire(import.meta.url);
+    const pkgJsonPath = require.resolve('sql.js/package.json');
+    const { dirname, join } = await import('node:path');
+    const dir = dirname(pkgJsonPath);
+    return (file: string) => join(dir, 'dist', file);
+  } catch {
+    return undefined;
+  }
+}
+
+describe('[#13571] empty `$nin` on the read-scope lowering — non-RLS provider control', () => {
+  let db: any;
+
+  beforeAll(async () => {
+    const mod: any = await import('sql.js');
+    const initSqlJs = mod.default ?? mod;
+    const locateFile = await locateWasm();
+    const SQL = await initSqlJs(locateFile ? { locateFile } : undefined);
+
+    db = new SQL.Database();
+    db.run(`CREATE TABLE "deal" ("id" TEXT PRIMARY KEY, "owner" TEXT);`);
+    const insert = db.prepare(`INSERT INTO "deal" ("id","owner") VALUES (?,?)`);
+    for (const r of FIXTURE) insert.run([r.id, r.owner]);
+    insert.free();
+  });
+
+  afterAll(() => {
+    db?.close();
+  });
+
+  /**
+   * A `StrategyContext` whose `getReadScope` is filled BY HAND — the spec
+   * contract's own authoring mode, and deliberately not the RLS compiler.
+   */
+  const ctxWithScope = (scope: unknown): StrategyContext =>
+    ({
+      getCube: (name: string) => (name === 'deals' ? CUBE : undefined),
+      queryCapabilities: () => ({ nativeSql: true, objectqlAggregate: false, inMemory: false }),
+      getReadScope: () => scope,
+      executeRawSql: async (_object: string, sql: string, params: unknown[]) => {
+        const stmt = db.prepare(sql.replace(/\$\d+/g, '?'));
+        stmt.bind(params as any[]);
+        const out: Record<string, unknown>[] = [];
+        while (stmt.step()) out.push(stmt.getAsObject());
+        stmt.free();
+        return out;
+      },
+    }) as StrategyContext;
+
+  const QUERY: AnalyticsQuery = {
+    cube: 'deals',
+    measures: ['total'],
+    dimensions: ['id'],
+    timezone: 'UTC',
+  } as AnalyticsQuery;
+
+  /** Run the query under `scope`; return either the refusal or the admitted ids. */
+  const outcome = async (
+    scope: unknown,
+  ): Promise<{ refusal?: Error & { code?: unknown; status?: unknown }; admitted?: string[] }> => {
+    try {
+      const result = await new NativeSQLStrategy().execute(QUERY, ctxWithScope(scope));
+      return { admitted: result.rows.map((r) => String(r.id)).sort((x, y) => x.localeCompare(y)) };
+    } catch (e) {
+      return { refusal: e as Error & { code?: unknown; status?: unknown } };
+    }
+  };
+
+  it('a provider handing `{ owner: { $nin: [] } }` is REFUSED in the module envelope — it used to get the whole table', async () => {
+    const { refusal, admitted } = await outcome({ owner: { $nin: [] } });
+    // Pre-#13571 this assertion's diff read `admitted: ['r1','r2','r3']` — the
+    // whole fixture, from a scope clause of constant TRUE.
+    expect(admitted).toBeUndefined();
+    expect(refusal).toBeInstanceOf(Error);
+    expect(refusal?.code).toBe('READ_SCOPE_COMPILE_FAILED');
+    expect(refusal?.status).toBe(500);
+    expect(String(refusal?.message)).toContain('$nin for "owner" is empty');
+  });
+
+  it('OVER-DENIAL CONTROL: the #13570-pinned RLS composite still compiles and still admits exactly the own row', async () => {
+    // `{ $or: [{ owner: { $in: [] } }, { owner: 'u_me' }] }` is what
+    // `RLSCompiler.compileFilter` returns for an emptied membership set beside
+    // an own-rows grant ("own rows keep flowing"), and it arrives here through
+    // `security.getReadFilter`. The empty-`$nin` refusal must not touch it:
+    // this block red under a uniform empty-membership throw is the
+    // availability regression the #13571 verdict exists to avoid.
+    const { refusal, admitted } = await outcome({ $or: [{ owner: { $in: [] } }, { owner: 'u_me' }] });
+    expect(refusal).toBeUndefined();
+    expect(admitted).toEqual(['r1']);
+  });
+
+  it('the composite denies-by-itself shape stays working too: a lone empty `$in` arm inside `$and`', async () => {
+    // The other composite #13570's guard deliberately passes through: as an
+    // `$and` arm the emptied positive membership is constant FALSE — the whole
+    // scope denies. Zero rows, not a refusal and not the whole table.
+    const { refusal, admitted } = await outcome({ $and: [{ owner: { $in: [] } }, { owner: 'u_me' }] });
+    expect(refusal).toBeUndefined();
+    expect(admitted).toEqual([]);
+  });
+});

--- a/packages/services/service-analytics/src/__tests__/read-scope-not-null-safe.test.ts
+++ b/packages/services/service-analytics/src/__tests__/read-scope-not-null-safe.test.ts
@@ -347,9 +347,29 @@ describe('[#5297] read-scope `$not` — boolean identities and NULL safety', () 
       expect(ids({ $not: { stage: { $ne: null } } })).toEqual(['3', '4']);
     });
 
-    it('an empty `$in` / `$nin` under a `$not` keeps its constant value', () => {
+    it('an empty `$in` under a `$not` keeps its constant value; an empty `$nin` refuses before `$not` matters (#13571)', () => {
+      // `$in: []` keeps its #5322/#5243 reduction — constant FALSE, total, no
+      // guard — and the negation flips it to TRUE: every row. That widened
+      // composition is the #13571 verdict's DECLARED residue for a non-RLS
+      // producer (the in-repo RLS compiler cannot emit the shape — #13570's
+      // polarity guard drops it upstream); closing it is a ruled follow-up
+      // design, not an edit to this pin.
       expect(ids({ $not: { stage: { $in: [] } } })).toEqual(ALL);
-      expect(ids({ $not: { stage: { $nin: [] } } })).toEqual([]);
+      // `$nin: []` no longer HAS a constant to keep: its reduction is TRUE —
+      // scope-vacating on its own — so `compileOperator` refuses it whatever
+      // the polarity above it. Deliberately asymmetric with the `$in` line
+      // above ("shape errors throw, boolean identities reduce" is the #5322
+      // boundary, and a scope-vacating reduction is on the THROW side) — see
+      // read-scope-sql.ts's #13571 header section.
+      let refusal: (Error & { code?: unknown; status?: unknown }) | undefined;
+      try {
+        ids({ $not: { stage: { $nin: [] } } });
+      } catch (e) {
+        refusal = e as Error & { code?: unknown; status?: unknown };
+      }
+      expect(refusal?.code).toBe('READ_SCOPE_COMPILE_FAILED');
+      expect(refusal?.status).toBe(500);
+      expect(String(refusal?.message)).toContain('$nin for "stage" is empty');
     });
   });
 

--- a/packages/services/service-analytics/src/__tests__/read-scope-refusal-envelope.test.ts
+++ b/packages/services/service-analytics/src/__tests__/read-scope-refusal-envelope.test.ts
@@ -93,7 +93,7 @@ function refusalFor(filter: unknown, alias = 'crm_opportunity'): Refusal | undef
 /**
  * Every refusing site in `read-scope-sql.ts`, in source order.
  *
- * FOURTEEN rows over TWELVE throw sites: TWO sites are each reached by two
+ * FIFTEEN rows over THIRTEEN throw sites: TWO sites are each reached by two
  * triggers, and every trigger is listed on purpose.
  *
  *   - `quoteIdent`, with two `kind` values. That alias-vs-field split was option
@@ -208,14 +208,26 @@ const REFUSALS: Array<{
     sensitive: 'region_code',
   },
   {
-    name: '⑬ $between without [min,max]',
+    // [#13571] The empty EXCLUSION refuses; the empty INCLUSION keeps its
+    // constant — see the ACCEPTED table's "#5243" row. Deliberate asymmetry
+    // ("shape errors throw, boolean identities reduce" — #5322; a reduction to
+    // constant TRUE vacates the scope, so it is on the throw side), not an
+    // oversight: read-scope-sql.ts's #13571 header section carries the ruling.
+    name: '⑬ $nin with an EMPTY array',
+    site: 'compileOperator: empty $nin vacates the scope',
+    filter: { region_code: { $nin: [] } },
+    message: /\$nin for "region_code" is empty — an empty exclusion excludes nothing and would compile the read scope to constant TRUE \(fail-closed\)/,
+    sensitive: 'region_code',
+  },
+  {
+    name: '⑭ $between without [min,max]',
     site: 'compileOperator: $between needs [min,max]',
     filter: { credit_limit: { $between: [10] } },
     message: /\$between for "credit_limit" needs \[min,max\] \(fail-closed\)/,
     sensitive: 'credit_limit',
   },
   {
-    name: '⑭ unsupported operator',
+    name: '⑮ unsupported operator',
     site: 'compileOperator: unsupported operator',
     filter: { owner_email: { $regex: 'admin@' } },
     message: /unsupported operator "\$regex" on "owner_email" \(fail-closed\)/,
@@ -244,6 +256,11 @@ const ACCEPTED: Array<{ name: string; filter: unknown; sql: string; params: unkn
     params: ['emea', 'apac'],
   },
   {
+    // [#13571] STAYS accepted while the empty `$nin` refuses (REFUSALS ⑬):
+    // this constant is FALSE — narrowing at its own arm — and the RLS compiler
+    // deliberately emits the shape at positive polarity inside composites
+    // (#13570's "own rows keep flowing" pin), so refusing it here would 500 a
+    // live, ruled-correct scope. The asymmetry is the #13571 ruling itself.
     name: 'an empty $in as the FALSE constant (#5243)',
     filter: { region_code: { $in: [] } },
     sql: '1 = 0',
@@ -306,13 +323,14 @@ describe('[#5367] every read-scope refusal carries the ADR-0112 envelope (READ_S
     // #5352's lesson, stated as a guard: seven of `filter-normalizer.ts`'s nine
     // sites carrying an envelope was indistinguishable from none of them at the
     // HTTP boundary, because the commonest input hit one of the two bare ones.
-    // Fourteen inputs over the module's TWELVE throw sites (see the table's note
-    // on the two sites with two triggers each), and every one of them enveloped.
-    // [#6125] added the eleventh site, [#6387] the twelfth; these two numbers
+    // Fifteen inputs over the module's THIRTEEN throw sites (see the table's
+    // note on the two sites with two triggers each), and every one of them
+    // enveloped. [#6125] added the eleventh site, [#6387] the twelfth, and
+    // [#13571] the thirteenth (the empty-`$nin` refusal); these two numbers
     // are the ratchet that makes a future unenveloped `throw` fail HERE instead
     // of at an HTTP boundary.
-    expect(REFUSALS).toHaveLength(14);
-    expect(new Set(REFUSALS.map((c) => c.site)).size).toBe(12);
+    expect(REFUSALS).toHaveLength(15);
+    expect(new Set(REFUSALS.map((c) => c.site)).size).toBe(13);
     for (const c of REFUSALS) {
       expect(refusalFor(c.filter, c.alias)?.code, `${c.site} is still bare`).toBe('READ_SCOPE_COMPILE_FAILED');
     }

--- a/packages/services/service-analytics/src/read-scope-sql.ts
+++ b/packages/services/service-analytics/src/read-scope-sql.ts
@@ -274,6 +274,42 @@ import {
  * no 4xx (option B reintroduces both defects #5367 closed). The paragraph above
  * beginning "⚠️ Deliberately NOT a 4xx of any flavour" is that ruling's own text
  * and is not to be rewritten.
+ *
+ * ## An EMPTIED `$nin` is refused, not folded (#13571, `domain:services` ruling 2026-08-31)
+ *
+ * FOURTEEN refusing sites. `$nin: []` used to fold to `'1 = 1'` — constant
+ * TRUE — which on this lowering VACATES the read scope: every row admitted,
+ * with no `$not` required. That is the first bullet above ("a read-scope
+ * predicate must never be silently dropped") in its most literal form, so the
+ * empty exclusion now throws, in the same envelope as the other thirteen.
+ *
+ * ⚠️ DELIBERATELY ASYMMETRIC with `$in: []`, which KEEPS folding to
+ * {@link FALSE_CLAUSE}. The #5322 boundary (section above) is "shape errors
+ * THROW, boolean identities REDUCE"; both empty memberships have ruled
+ * reductions, but they land on opposite constants. `$in: []` reduces to
+ * constant FALSE — narrowing at its own arm, the safe direction on a read
+ * scope — and is LOAD-BEARING: the RLS compiler deliberately emits it at
+ * positive polarity inside composites (`{ $or: [{ owner: { $in: [] } },
+ * { owner: 'u_me' }] }` — an emptied membership beside an own-rows grant,
+ * pinned by #13570's `rls-empty-membership-polarity.test.ts` as "own rows keep
+ * flowing"), and that filter reaches this compiler through
+ * `security.getReadFilter`. `$nin: []` reduces to constant TRUE — scope-
+ * vacating — and has ZERO producers: the CEL lowering never emits `$nin`, and
+ * #13570's guard drops even-polarity empty-`$nin` policies before they are
+ * emitted. Refusing it therefore costs no live traffic and closes the one
+ * single-step widening fold this compiler had. A uniform throw at both arms
+ * was measured and REJECTED (#13571 verdict): it would have 500'd the pinned
+ * live composite above on every analytics query for any user whose membership
+ * set resolves empty beside an own-rows grant.
+ *
+ * ⚠️ Declared residue, ruled follow-up — NOT covered here: `$not` over
+ * `$in: []` still compiles to constant TRUE at this lowering for a producer
+ * that is not the (#13570-guarded) RLS compiler. Closing that needs a
+ * polarity-aware design whose interaction with the #5322 `$not`-over-identity
+ * reductions is ruled first — a naive "refuse NOT of the FALSE constant"
+ * cannot tell net polarity (see #13571's verdict). Separately, the ObjectQL
+ * ENGINE execution path never reaches this compiler at all (#13640): this
+ * refusal guards the NativeSQL path and the `/analytics/sql` echo only.
  */
 
 const IDENT = /^[a-z_][a-z0-9_]*$/i;
@@ -948,7 +984,14 @@ function compileOperator(col: string, op: string, val: unknown, field: string, p
     }
     case '$nin': {
       if (!Array.isArray(val)) throw readScopeCompileError(`[read-scope-sql] $nin for "${field}" needs an array (fail-closed).`);
-      if (val.length === 0) return '1 = 1'; // NOT IN () excludes nothing
+      // [#13571] An EMPTIED exclusion is refused, not folded. Its faithful
+      // reduction is constant TRUE ("NOT IN () excludes nothing"), which on
+      // this lowering VACATES the whole read scope — every row admitted, no
+      // `$not` needed. Deliberately ASYMMETRIC with `$in: []` → FALSE_CLAUSE
+      // two arms above: that fold is a ruled #5322/#5243 identity, narrowing at
+      // its own arm, and a live RLS composite depends on it. Read the module
+      // header's #13571 section before "harmonising" the two arms.
+      if (val.length === 0) throw readScopeCompileError(`[read-scope-sql] $nin for "${field}" is empty — an empty exclusion excludes nothing and would compile the read scope to constant TRUE (fail-closed).`);
       assertCompilableMembers(op, field, val);
       // [#5298] NULL-safe: "not among this list" holds vacuously for a value
       // that is not there.


### PR DESCRIPTION
Fixes #13571

Implements the `domain:services` ruling on the card (verdict: 13571#issuecomment-5473783095) — **option A, asymmetric refusal** — after the dispatched uniform-throw direction was falsified by measurement (report: 13571#issuecomment-5473763764).

## What changed

- **`$nin: []` now THROWS** in `compileOperator` (`packages/services/service-analytics/src/read-scope-sql.ts`), in the module's one refusal envelope (`READ_SCOPE_COMPILE_FAILED` / 500), following the arity throw one line above. Its old fold was `'1 = 1'` — constant TRUE — which VACATES the read scope: every row admitted, no `$not` needed, on the lowering where a wrong answer is ADR-0021 scope over-reach. The new message was measured against `looksLikeInternalErrorLeak`: FALSE, like the other thirteen, so it is withheld from responses BY DECLARATION and teaches no sniffing list a new phrase.
- **`$in: []` keeps its `1 = 0` fold — deliberately.** It is the ruled #5322/#5243 identity, narrowing at its own arm, and load-bearing: `RLSCompiler.compileFilter` deliberately emits an emptied positive membership inside composites (`rls-empty-membership-polarity.test.ts`, PR #13570: "own rows keep flowing"), and that filter reaches this compiler through `security.getReadFilter`. A uniform throw was measured and rejected by the ruling: it would 500 every analytics query for any user whose membership set resolves empty beside an own-rows grant. The module header carries a #13571 section so a future reader cannot mistake the asymmetry for an oversight; the ruled boundary is "shape errors THROW, boolean identities REDUCE", and a reduction to scope-vacating constant TRUE sits on the throw side.
- `$nin: []` has **zero producers** (measured): the CEL lowering never emits `$nin`, and PR #13570's guard drops even-polarity empty-`$nin` policies before emission — so the refusal costs no live traffic.

## Pins updated deliberately (part of the ruling, not edited to stay green)

- `comparand-shape-refusal.test.ts` — the combined "not a refusal" pin split into: empty `$in` still folds (with the load-bearing rationale) and empty `$nin` refuses with the envelope, each carrying the #5322-boundary reasoning.
- `read-scope-not-null-safe.test.ts` — `$not` over `$in: []` keeps its pinned constant (the verdict's DECLARED residue for a non-RLS producer, closing it is a ruled follow-up design); `$not` over `$nin: []` now pins the refusal envelope.
- `read-scope-refusal-envelope.test.ts` — new REFUSALS row ⑬ in source order; ledger ratchet moved 14 rows/12 sites to 15 rows/13 sites; the ACCEPTED empty-`$in` row annotated with why it stays while the exclusion refuses.

## New controls (`read-scope-empty-nin-refusal.test.ts`)

1. **Non-RLS `getReadScope` provider control** — the spec contract (`analytics-service.ts` carries a hand-written example) filled by hand, handing `{ owner: { $nin: [] } }` to a real `NativeSQLStrategy` over sql.js rows. Post-fix: refused with `code READ_SCOPE_COMPILE_FAILED`, `status 500`. Pre-fix, **measured** (reverse verification below): the same case admitted the whole fixture table.
2. **Over-denial control (the bound)** — the #13570-pinned composite `{ $or: [ { owner: { $in: [] } }, { owner: 'u_me' } ] }` still compiles and still admits exactly the own row; the denies-by-itself `$and` composite still returns zero rows, not a refusal and not the whole table. This block red under a uniform empty-membership throw is the availability regression the ruling exists to avoid.

## Reverse verification (direction predicted before running)

Fix committed first; then `read-scope-sql.ts` swapped to its pre-fix blob (`git checkout e238c79 -- ...`), mutation proven on disk (0 hits of the new refusal text, 1 hit of the old fold), and the four touched suites re-run: **7 red / 101 green**, every red keyed to the new refusal and none outside it. The provider control failed with real output `AssertionError: expected [ 'r1', 'r2', 'r3' ] to be undefined` — the pre-fix whole-table admission, measured. Both over-denial controls and the empty-`$in` pins stayed green on the pre-fix tree, as predicted. Restoration proven by bytes: `git diff HEAD` empty, worktree blob hash `79641a7...` equal to the HEAD blob. (No dist ablation preflight needed: these suites import `../read-scope-sql.js` relative source through vitest — no `exports`-resolved dist on the measured path.)

## Verification on `1880b33` (post-final-commit, clean worktree)

- `pnpm --filter @objectstack/service-analytics exec vitest run --maxWorkers=2` — verdict `Test Files 84 passed (84) · Tests 1819 passed (1819)`; the four touched files re-run under `--reporter=verbose` (108/108) with every new/updated pin confirmed by name.
- `pnpm --filter @objectstack/service-analytics typecheck` — exit 0 (the package tsconfig includes `src` whole, so the test files are inside the measured program).
- Gate derivation from the actual diff (`node scripts/pm/dispatch-gates.mjs`, both sections read whole, harvested via `--commands`): 34 families + `check:nul-bytes` — all green, including `check:dispatcher-error-vocabulary` (ADR-0112 code-carrying file), `check:engine-double-contract`, `check:where-matcher`, `check:test-source-alias`, and after the lint.yml-shaped workspace build: `check:type-check-debt` (judgment line: "check-type-check-coverage --re-measure: OK — 29 ledger entr(ies) re-measured ... none above its recorded number") and `check:dual-build-cjs-loads` (measured pass with provenance floors).
- `pnpm lint` (repo-wide `eslint . --no-inline-config`, the CI-owned scan, run whole — no narrowing to prove) — exit 0.
- NOT MEASURED, per the gate's own exit-3 branch: `check-test-completeness` reads a saved `turbo run test` log that only CI produces locally; nothing red, nothing measured.

## Declared residue and relations (none closed here)

- `$not` over `$in: []` still compiles to constant TRUE at this lowering for a non-RLS producer — the verdict's declared residue; a polarity-aware refusal is a follow-up ruled design. #13571's verdict comment carries the reasoning; this PR does not attempt it.
- Issue #13640 remains open and is untouched here: the ObjectQL engine execution path bypasses this compiler entirely, so no disposition of the lowering guards that route.
- PR #13570 / issue #13552 are prior producer-side work referenced for evidence only; nothing about them is changed by this PR.

_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_