### PR TITLE
feat(cli): ratify `./console` as a public subpath export — the out-of-repo consumer #13123 predicted

### DIFF
--- a/.changeset/cli-console-subpath-export.md
+++ b/.changeset/cli-console-subpath-export.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/cli': minor
+---
+
+Ratify `./console` as a public subpath export — `resolveConsolePath`, `hasConsoleDist`, `createConsoleStaticPlugin` and the drift-guard helpers were reachable as a deep `dist/` import until #13123 sealed the surface, and cloud's `objectos-runtime` node server consumes them to mount the Console SPA. The #13123 body names exactly this remedy for an out-of-repo consumer: ratify the subpath as public surface rather than read `dist/` paths.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./console": {
+      "types": "./dist/utils/console.d.ts",
+      "default": "./dist/utils/console.js"
     }
   },
   "bin": {


### PR DESCRIPTION
## What

One deliberate door in the CLI's `exports` map: `"./console"` → `dist/utils/console.{js,d.ts}` — the self-contained static-serve util (`resolveConsolePath` / `hasConsoleDist` / `createConsoleStaticPlugin` + drift-guard helpers; fs/path only, no oclif).

## Why

#13123 sealed the CLI behind an `exports` map and its own body names this exact remedy for an out-of-repo consumer: *ratify the subpath as public surface rather than read `dist/` paths*. That consumer exists — **cloud's `objectos-runtime` node server** mounts the Console SPA through this util, formerly via `@objectstack/cli/dist/utils/console.js`. Under the sealed map that specifier now fails at both layers:

- **types**: tsup DTS refuses with TS2307 (measured on cloud's pin-bump build);
- **runtime**: `ERR_PACKAGE_PATH_NOT_EXPORTED`, which the consumer's defensive catch turns into a silent API-only boot — a working deployment loses its console with nothing but a warn line.

Duplicating the util in cloud was rejected: it is 654 lines carrying the objectui-pin drift guards (#7752) and the mount-decision policy — a fork would drift by construction.

## Scope

The surface grows by ONE named door, not back to "everything under `dist/`". `check:published-files`' GATED invariant stays green (the map names real entries); census floor untouched. Changeset: `@objectstack/cli` minor.

## Gates at this head

Full 71-package build, full-repo lint, `check:published-files`, `check-empty-changeset` — all exit 0. Cloud-side consumer verified against a locally patched checkout of this exact map: runtime resolution returns all three functions, objectos-runtime DTS builds green, and cloud's five harness suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)