### PR TITLE
test(core): pin that the legacy platform-admin deprecation latch dies with the process (L5)

### DIFF
--- a/packages/core/src/security/platform-admin.test.ts
+++ b/packages/core/src/security/platform-admin.test.ts
@@ -11,7 +11,7 @@
  * row it has no business looking at.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   isConfiguredPlatformAdminEmail,
@@ -260,6 +260,39 @@ describe('[#11663 P5] reportLegacyPlatformAdminGrant', () => {
     // there. A fully-seeded API-key principal has no row loaded.
     reportLegacyPlatformAdminGrant({ userId: 'usr_1' });
     expect(sink.warns[0]).toContain(`${ENV}=<the administrator's verified email address>`);
+  });
+
+  it('⭐ [#11975] the latch is PER PROCESS, never persistent — a fresh instance re-announces', async () => {
+    // The migration window's loudness discipline (#11975), in the half nothing
+    // else pins. Every sibling pin asserts SUPPRESSION — this file's
+    // "once per process" above, and plugin-security's boot-side
+    // `bootstrap-platform-admin-walled-owner.test.ts` "EXACTLY ONE line ... even
+    // across repeated bootstraps" — so all of them stay GREEN if the latch is
+    // ever hardened past the process: moved onto `globalThis`, stored in a
+    // module the host keeps alive, or persisted to a row or file to quiet the
+    // noise. Any of those turns "once per process" into "once EVER", and a
+    // deployment restarted onto the old anchor is then never told again, which
+    // is the silent dual-track the window exists to prevent.
+    //
+    // A fresh module registry is the closest in-process stand-in for a boot: it
+    // re-instantiates the module scope the latch lives in exactly as a new
+    // process would. ⛔ Do not "fix" a red here by resetting the latch in the
+    // loop — the point is that nothing had to.
+    const linesPerBoot: number[] = [];
+    for (let boot = 0; boot < 3; boot++) {
+      vi.resetModules();
+      const fresh = await import('./platform-admin.js');
+      const bootSink = makeSink();
+      fresh.setPlatformAdminConfigSink(bootSink);
+      // Twice, so a per-call regression is caught by the same assertion.
+      fresh.reportLegacyPlatformAdminGrant({ userId: 'usr_1', email: 'ada@example.com' });
+      fresh.reportLegacyPlatformAdminGrant({ userId: 'usr_1', email: 'ada@example.com' });
+      fresh.setPlatformAdminConfigSink(undefined);
+      linesPerBoot.push(bootSink.warns.length);
+    }
+    // Exactly one per boot: not 0 (a latch that outlived the process) and not 2
+    // (a pointer that became per-call).
+    expect(linesPerBoot).toEqual([1, 1, 1]);
   });
 });
 


### PR DESCRIPTION
Part of #11975 — leg L5 of the #11663 platform-admin re-anchor.

This card is a **verification-and-disposition slice**, and its main output is the
measurement below, not the code. The entry half of the migration window was found
**already delivered** by L2 and L4; the one discipline the card names that nothing
pinned is now pinned. One test file, no behaviour change.

## What the card owed, and what was found

#11975 carries the migration window's *discipline*: derivation prefers env · a
detected legacy grant logs its deprecation pointer every boot · never a silent
dual-track. All three were measured against `origin/main`, not assumed.

### 1. Derivation prefers env — SATISFIED (precedence, not exclusion)

`packages/core/src/security/resolve-authz-context.ts` §6b-config is
`if (configConfersPlatformAdmin) { ... } else if (hasPlatformAdminGrant) { report }`.
The config arm is evaluated first, confers standing, and pushes the **declared**
capability envelope from `ADMIN_FULL_ACCESS_CAPABILITIES`; the legacy arm is
reachable only when config does not confer.

⚠️ "Prefers" here means **precedence inside the derivation, not exclusion**: with
administrators declared, a caller who does *not* match still has their legacy row
honoured. That is the ruled shape — design §5 step 3, "Config-derived standing is
**added**; the legacy grant read is still honoured. Nothing is revoked in this
step." Exclusion is the window's EXIT, and it belongs to #13515.

### 2. Every boot vs once per process — MEASURED, and it satisfies the card

The latch is a module-scope `let legacyGrantPointerSaid` in
`packages/core/src/security/platform-admin.ts`. Measured over three fresh module
instances (the closest in-process stand-in for a boot): **1 line each**, and two
calls inside one instance still produce 1. So "once per process" and "every boot"
coincide — nothing persists the suppression past the process, and a restarted
deployment is told again.

Two ways it differs from a literal per-detection line, both **ruled** by design P5
("logged **once per process** (not per request) naming the row, its holder and the
exact config line") and both disclosed in the message text itself:

- a second boot inside ONE process is silent — deliberately pinned in
  `plugin-security/src/bootstrap-platform-admin-walled-owner.test.ts`, "EXACTLY ONE
  line ... even across repeated bootstraps";
- a second, distinct legacy holder is never named — the line says so: "Reported once
  per process; further holders are not listed." Enumerating holders is the census's
  job (design §5 step 7), not this pointer's.

### 3. Never a silent dual-track — NONE FOUND

Two detectors share one latch and cover both entry points: boot-side
(`plugin-security/src/bootstrap-platform-admin.ts`, walled) and request-side
(`resolve-authz-context.ts`, posture-independent). `hasPlatformAdminGrant` is
written in exactly two places and consumed once by `derivePosture`; a repo-wide
grep finds no third route to `PLATFORM_ADMIN`. The cross-request grants cache is
in-process and default-OFF, so it cannot carry standing across a boot without a
derivation having run. The only path where a legacy row confers with no line is
**the same caller also matching config**, where standing no longer rests on the row
— already pinned in `resolve-authz-context.platform-admin-config.test.ts`.

## The gap this PR fills

Every existing pin asserts **suppression**. None asserts that the suppression
**ends**. A latch moved onto `globalThis`, or persisted to quiet the noise, turns
"once per process" into "once ever" and leaves all of them green — while a
deployment restarted onto the old anchor is never told again. That is the silent
dual-track the window exists to prevent, and it is precisely the half the card names
by name ("every boot").

So this PR adds **one pin** to `packages/core/src/security/platform-admin.test.ts`:
three fresh module instances must each emit exactly one line — not zero (a latch
that outlived the process) and not two (a pointer gone per-call).

**Reverse verification.** The pin was committed first, then
`platform-admin.ts`'s latch was mutated to a `globalThis`-keyed one. Mutation
confirmed on disk before measuring — HEAD blob `c2abfe57`, mutated blob `8e9478c3`,
injected marker present 3x, original declaration count 0. Result: the new pin
**failed** (`expected [ +0, +0, +0 ] to deeply equal [ 1, 1, 1 ]`) and the other 25
tests in the file stayed green — confirming this is the only pin covering the
every-boot half. Restored and verified by state: worktree blob back to `c2abfe57`,
marker count 0, `git diff HEAD` empty. No rebuild was needed on either leg — the
test imports `./platform-admin.js`, a package-relative specifier vitest resolves to
source rather than through `exports`/`dist`.

## The minor boundary #13515 must honour

Established here because #13515 is blocked on this card and needs exactly this
number:

- `@objectstack/plugin-security@17.2.0` (and `@objectstack/core@17.2.0`) is the
  latest released tag, cut at `e7d2cc67f` on 2026-08-23.
- L4 landed as `b9972720f` on 2026-08-31 — **after** that tag, so it is **not in
  17.2.0**.
- Its changeset `.changeset/walled-bootstrap-stops-granting.md` is still unconsumed
  on `main` and declares `"@objectstack/plugin-security": minor`. No pending
  changeset anywhere in `.changeset/` declares a `major`.
- L2 landed 2026-08-30, also after the tag, so it ships in the same release.

⇒ **L4 ships in 17.3.0**, and the exit may land **no earlier than 17.4.0** — it must
not ride the 17.3.0 release train. Recorded on #13515.

## Disposition

The window's entry is delivered and correctly disciplined. #11975's own acceptance
criterion also requires the exit on `origin/main`, which is #13515 and cannot land
before 17.4.0 — so this card's only live residue is that card. #13515 is not
addressed here.

## Verification

Run at `d0c912847`, the final commit.

- Targeted tests: `pnpm --filter @objectstack/core exec vitest run --maxWorkers=2 src/security/platform-admin.test.ts src/security/resolve-authz-context.platform-admin-config.test.ts src/security/admin-standing-surface.test.ts` — `Test Files 3 passed (3) · Tests 53 passed (53)`.
- Gate families re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, **both** sections: 22 path-derived + 6 convention-triggered (change kind "adds or edits a test file"). 23 ran green.
- Two returned exit **3 = NOT MEASURED**, each self-declared, neither a red:
  `check-test-completeness.mjs` (needs a saved test-run log; the family names it with
  no argument) and `check:dual-build-cjs-loads` ("PREREQUISITE NOT MET ... this is
  NOT a pass: nothing was measured" — needs a whole-workspace build).
- `pnpm lint` (`eslint . --no-inline-config`, whole repo, no narrowing) — exit 0.
- `check:type-check-coverage` green. Its `--re-measure` half (`check:type-check-debt`)
  needs the whole-workspace build and was **not run locally**; what was measured
  instead is `packages/core`'s own `tsc --noEmit --listFiles`: the new test file is in
  the program (525 files, 1 match — `packages/core` sets `exclude: []`) and
  contributes **0** of the package's 98 pre-existing errors, so this diff cannot move
  the ratchet up. CI runs the re-measure.
- `check:nul-bytes` green; `grep -naP` control-character self-scan over the edited
  file finds nothing.

No changeset: the diff is one `*.test.ts`, and `packages/core` publishes only
`["dist","README.md","CHANGELOG.md"]`, so nothing is released. Labelled
`skip-changeset`.

## Out-of-scope finding, filed separately

Measured while checking discipline 3, and **not** touched here: on a `single`-posture
rig — the DEFAULT posture — the request-side pointer fires for the first-user
promotion row and tells the operator their anchor "is removed in a later release",
which under ruled Choice 4A is not true for that rig. Filed unassigned; it bears on
#13515's `single` carve-out clause.

_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_