### PR TITLE
fix(lint): relationship/delete-behavior suggestion drops set_null on master_detail

### DIFF
--- a/.changeset/lint-delete-behavior-suggestion-drops-set-null.md
+++ b/.changeset/lint-delete-behavior-suggestion-drops-set-null.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): `relationship/delete-behavior` suggestion no longer names `set_null` as declarable on a `master_detail`
+
+`lintDataModel`'s `relationship/delete-behavior` suggestion told an author an
+undeclared `master_detail.deleteBehavior` could be `cascade`, `restrict`, or
+`set_null`. Since #9689 (PR #11406, maintainer ruling 2026-08-19), an authored
+`deleteBehavior: 'set_null'` on a `master_detail` field is a named parse-time
+rejection — a detail row cannot outlive its master, so the engine resolves
+every value except `restrict` to `cascade` on this type. Following the
+suggestion's own `set_null` mention literally walked an author into that
+rejection at publish time.
+
+The message now enumerates only the two values `FieldSchema` actually accepts
+on a `master_detail` (`cascade`/`restrict` — matching the vocabulary already
+offered by the metadata-admin field form, `object.form.ts`'s `master_detail`
+`deleteBehavior` options), and keeps the same outcome-naming courtesy as the
+parse-time rejection message: it still names `set_null` to say plainly that it
+is not honored on this type, and points to `lookup` for the case where
+children must survive the parent. The `fix` payload (`deleteBehavior:
+'cascade'`) was already correct and is unchanged.

--- a/packages/cli/test/data-model-rules.test.ts
+++ b/packages/cli/test/data-model-rules.test.ts
@@ -40,6 +40,14 @@ describe('lintDataModel — relationships', () => {
     ]);
     const db = issues.find((i) => i.rule === 'relationship/delete-behavior');
     expect(db?.severity).toBe('suggestion');
+    // #9689 (PR #11406) made an authored `deleteBehavior: 'set_null'` on a
+    // master_detail a named parse-time rejection — the DECLARABLE enumeration
+    // this suggestion names must not walk an author into that rejection. The
+    // message may still MENTION `set_null` to explain why it is excluded (the
+    // same outcome-naming courtesy as the field.zod.ts rejection message), so
+    // assert the declarable set directly rather than a bare substring-absence.
+    expect(db?.message).not.toContain('cascade/restrict/set_null');
+    expect(db?.message).toContain('(cascade/restrict');
   });
 
   it('suggests inlineEdit on master_detail line-item children', () => {

--- a/packages/lint/src/data-model-rules.ts
+++ b/packages/lint/src/data-model-rules.ts
@@ -604,7 +604,7 @@ export function lintDataModel(objects: any[]): LintIssue[] {
           issues.push({
             severity: 'suggestion',
             rule: 'relationship/delete-behavior',
-            message: `master_detail "${obj.name}.${fieldName}" → ${parent} should declare deleteBehavior (cascade/restrict/set_null)`,
+            message: `master_detail "${obj.name}.${fieldName}" → ${parent} should declare deleteBehavior (cascade/restrict — set_null is not honored on master_detail; use a lookup field if children must survive the parent)`,
             path: `${fieldPath}.deleteBehavior`,
             fix: "deleteBehavior: 'cascade'",
           });


### PR DESCRIPTION
Fixes #11668

## What

`lintDataModel`'s `relationship/delete-behavior` suggestion (`packages/lint/src/data-model-rules.ts`) told an author an undeclared `master_detail.deleteBehavior` could be `cascade`, `restrict`, or `set_null`. Since #9689 (PR #11406, maintainer ruling 2026-08-19), an authored `deleteBehavior: 'set_null'` on a `master_detail` field is a named parse-time rejection (`packages/spec/src/data/field.zod.ts`) — a detail row cannot outlive its master, so the engine resolves every value except `restrict` to `cascade` on this type. Following this suggestion's own enumeration literally walked an author into that rejection at publish time.

**Before:**
```
master_detail "${obj.name}.${fieldName}" → ${parent} should declare deleteBehavior (cascade/restrict/set_null)
```

**After:**
```
master_detail "${obj.name}.${fieldName}" → ${parent} should declare deleteBehavior (cascade/restrict — set_null is not honored on master_detail; use a lookup field if children must survive the parent)
```

The corrected enumeration (`cascade`/`restrict`) is not my own choice — it is read off two existing authorities that already agree:
- The parser's own reject list: `field.zod.ts`'s `master_detail` + `set_null` check, whose rejection message explicitly walks the author to `'restrict'` or `'cascade'` (or omit the key).
- `object.form.ts`'s `master_detail` `deleteBehavior` select options, which already list exactly `['cascade', 'restrict']` (split from the `lookup` branch's options for the same #9689 reason).

The message keeps the issue's suggested "outcome-naming courtesy": it still *mentions* `set_null`, but only to say it is not honored on this type and to point at `lookup` as the alternative — it no longer offers it as a declarable choice.

⛔ Not touched, per the card's Zone 1: the rule's logic (still consumes RAW authored objects — `def.deleteBehavior === undefined` still means "not authored"; #9689's idempotent-materialization change never reaches this rule), and the `fix` payload (`deleteBehavior: 'cascade'`), which was already correct.

## Tests

- `packages/cli/test/data-model-rules.test.ts` — extended the existing `'suggests an explicit deleteBehavior on master_detail'` test with two assertions: the message no longer contains the stale `cascade/restrict/set_null` enumeration, and does contain the corrected `(cascade/restrict` opening. No existing test pinned the old message text (only severity), so nothing else needed updating.
- Full `@objectstack/lint` suite and the full `@objectstack/cli` typecheck/build closure, plus the dispatch-derived gate family for this diff — see the report comment on #11668 for the complete list and a repo-head `387df3e81` reference.

_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_