### PR TITLE
fix(pm): H19's summary clause ends its own sentence

### DIFF
--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -7359,14 +7359,27 @@ export function summaryLine(counts, findingCount) {
           'false — 199 rows were trimmed and not one rendered row carried an unresolved target)'
         : ''
     }` +
+    // #13650: this terminator is UNCONDITIONAL, and belongs to the CLAUSE
+    // rather than to either optional branch below. It used to exist only inside
+    // the cross-repo branch, so the single rendering that ended this sentence
+    // was the one where an unrelated optional probe happened to fire. On an
+    // ordinary healthy pass — no shortfall AND no probe, the common case — the
+    // clause stopped at `card(s)` and a lone space joined it straight onto
+    // H20's lead-in, which the live 2026-08-31 patrol rendered as
+    // `…card(s) Dispatch liveness (H20 + H27): …`: two disclosures read as one,
+    // with the boundary findable only by a reader who already knows the row
+    // inventory. Each optional branch now contributes ONLY its own text, which
+    // is what keeps the terminator independent of whether they fire — a branch
+    // carrying the sentence's end is how the two clauses ran together.
+    '. ' +
     `${
       crossRepoProbed > 0
-        ? ` Cross-repo reachability was measured directly on ${crossRepoProbed} sibling repo(s), of which ` +
+        ? `Cross-repo reachability was measured directly on ${crossRepoProbed} sibling repo(s), of which ` +
           `${crossRepoUnreadable} do(es) not answer this credential — those targets are unjudgeable by ` +
           'ruling (each install reads its own repo with its own repo-scoped token) and ⛔ no re-run ' +
-          'resolves them.'
+          'resolves them. '
         : ''
-    } ` +
+    }` +
     `Dispatch liveness (H20 + H27): remote branch read on ${refRead} of ${refTargets} distinct claimed ` +
     `branch(es) named by open \`pm:dispatched\` card(s) past the ${DISPATCHED_NO_REF_STALE_MINUTES}-minute ` +
     `threshold — one read serving both rows, so H27's ${DEAD_CLAIM_STALE_HOURS}h population is a subset ` +
@@ -13056,6 +13069,40 @@ function selfTest() {
   t('summary: …and that a re-run will not help', saidBy('h19Blockers', summaryLine(xCounts(2, 1), 1)).includes('no re-run'), true);
   t('summary: no probes taken -> no cross-repo clause at all', saidBy('h19Blockers', summaryLine(xCounts(0, 0), 1)).includes('sibling repo(s)'), false);
   t('summary: absent cross-repo counts degrade to 0, never to undefined', saidBy('h19Blockers', summaryLine(counts, 0)).includes('undefined'), false);
+
+  // -- H19 terminates its OWN sentence, on every shape (#13650) ---------------
+  //
+  // The `. ` every other clause on this line ends with used to exist only
+  // inside the cross-repo branch above, so the ONE rendering that terminated
+  // H19 was the one where an unrelated optional probe happened to fire. On an
+  // ordinary healthy pass — no shortfall AND no probe — the clause stopped at
+  // `card(s)` and a lone space joined it onto H20's lead-in, which the live
+  // 2026-08-31 patrol rendered as `…card(s) Dispatch liveness (H20 + H27): …`.
+  //
+  // ⚠️ Why the neighbouring `endsWith('not a gate verdict.')` cases could not
+  // catch it: those pin where the SENTENCE ends, which is H37's business. This
+  // is a claim about where H19's clause ends, and only the scoped extractor can
+  // make it. All four shapes are pinned rather than one, because the defect WAS
+  // that the shapes disagreed — a pin on the probe shape alone would have been
+  // green throughout the entire life of the bug.
+  const h19Terminated = (c) => saidBy('h19Blockers', summaryLine(c, 1)).endsWith('. ');
+  t('#13650: H19 ends its sentence on a healthy pass (no shortfall, no probe)', h19Terminated(btCounts2(28, 28)), true);
+  t('#13650: …and on a shortfall pass', h19Terminated(btCounts2(25, 28)), true);
+  t('#13650: …and on a cross-repo probe pass', h19Terminated(btCounts2(28, 28, { crossRepoProbed: 2, crossRepoUnreadable: 1 })), true);
+  t('#13650: …and when BOTH optional branches fire', h19Terminated(xCounts(2, 1)), true);
+  // The other half of the fix, and the way it would most plausibly be got
+  // wrong: the probe branch already ended in a period of its own, so a
+  // terminator appended AFTER it renders `resolves them.. ` — which satisfies
+  // every `endsWith('. ')` case above while reading as a typo in the report.
+  t('#13650: the probe shape does not double the period', saidBy('h19Blockers', summaryLine(xCounts(2, 1), 1)).includes('.. '), false);
+  t('#13650: …and the probe branch closes the clause exactly once', saidBy('h19Blockers', summaryLine(xCounts(2, 1), 1)).endsWith('no re-run resolves them. '), true);
+  // Kept WHOLE-LINE on purpose, both of them: this is a claim about the
+  // boundary BETWEEN two clauses, so there is no single window to scope it to —
+  // the adjacency is the thing being asserted. It is safe from #13629's defect
+  // because no neighbour can manufacture this pairing: `card(s) ` is H19's last
+  // text and the H20 anchor is H20's first.
+  t('#13650: H20\'s clause is no longer joined onto H19\'s population', summaryLine(btCounts2(28, 28), 1).includes('card(s) Dispatch liveness'), false);
+  t('#13650: …and the rendered boundary reads as two sentences', summaryLine(btCounts2(28, 28), 1).includes('card(s). Dispatch liveness (H20 + H27)'), true);
 
   // -- H32's seat coverage pair (#11706) -------------------------------------
   const seatCounts = (seatMarkersRead, seatCandidates) => ({ ...counts, seatMarkersRead, seatCandidates });


### PR DESCRIPTION
Fixes #13650

`summaryLine`'s H19 clause carried its terminating `. ` inside the cross-repo branch
alone, so the ONE rendering that ended the sentence was the one where an unrelated
optional probe happened to fire. On an ordinary healthy pass — no shortfall AND no probe
— the clause stopped at `card(s)` and a lone space joined it straight onto H20's lead-in,
so two disclosures read as one sentence and the boundary was findable only by a reader who
already knew the row inventory.

## What changed

One file: `scripts/pm/check-half-states.mjs`.

- H19's clause now terminates **unconditionally**, with the same `. ` every other clause
  on the line uses.
- The two optional branches (shortfall, cross-repo) contribute only their own text. The
  cross-repo branch already ended in a period of its own, so its leading space and the
  join's trailing space move *into* the terminator rather than adding a second one: the
  probe shape renders `resolves them. `, never a doubled `.. `.

## Everything else on the line is byte-identical

Rendered at the base commit and at head over the same six shapes, then diffed character by
character. Nothing is removed on any shape, and the single inserted character sits in
H19's terminator region on all six:

| shape | base → head | delta |
|---|---|---|
| healthy (no shortfall, no probe) | 3247 → 3248 | one inserted `.` |
| shortfall, no probe | 3583 → 3584 | one inserted `.` |
| cross-repo probe, no shortfall | 3498 → 3499 | one inserted `.` |
| shortfall + probe | 3834 → 3835 | one inserted `.` |
| `summaryLine({}, 0)` | 3283 → 3284 | one inserted `.` |
| every optional sub-clause firing | 5287 → 5288 | one inserted `.` |

The clause-boundary extractor is unmoved: the partition control (every window's clause
length summing to the whole line's length — no gap, no overlap) holds on all six shapes at
head, so adding the terminator inside H19's clause moved no boundary.

## Live read-only fire, at this PR's head commit

`PM_SWEEP_REPO=objectstack-ai/objectstack node scripts/pm/check-half-states.mjs` at
`59d5c22bb`, exit 0, read-only. The H19 to H20 boundary now reads:

```text
Blocker liveness (H19): targets resolved on 27 of 27 distinct `Blocked-by:` target(s)
named by open `pm:blocked` card(s). Dispatch liveness (H20 + H27): remote branch read on
8 of 8 distinct claimed branch(es) …
```

A no-shortfall, no-probe pass — the exact shape that used to run on. The old adjacency
`card(s) Dispatch liveness` occurs 0 times in that run's output.

## Pins

Scoped to H19 via the clause extractor, so no neighbour's text can satisfy them. Eight
cases: the clause ends `. ` on the healthy, shortfall, probe and both-branches shapes;
the probe shape carries no doubled period and closes exactly once; and two deliberately
whole-line cases on the boundary itself, because the adjacency between two clauses has no
single window to scope it to.

All four shapes are pinned rather than one, because the defect WAS that the shapes
disagreed — a pin written on the probe shape alone would have been green for the whole
life of the bug. The neighbouring whole-line `endsWith('not a gate verdict.')` cases could
not see this at all: they pin where the SENTENCE ends, which is H37's business, not where
this clause ends.

## Ablations

Both legs mutated on disk with the anchor hit-count asserted (a zero-hit edit refuses
loudly instead of measuring an unmutated tree), and restored against `HEAD` with the
restored blob hash compared to the HEAD blob and `git diff HEAD` proven empty.

- **Reverting only the terminator** to its previous shape: exactly 4 of 1791 cases red —
  the healthy and shortfall terminator cases and both boundary cases. The two probe-shape
  cases stayed green, which is the measurement that shows why one shape was not enough.
- **Deleting H19's clause outright**: 22 red, including
  `summaryClause: h19Blockers opens its own clause on every run`. H19's presence control
  is still red under its own ablation and the other 16 windows' presence controls stayed
  green, so the per-window contract is intact.

## Verification

Self-test, quoting its own verdict lines: `✓ check-half-states self-test: 1783 cases pass.`
at the base commit, `✓ check-half-states self-test: 1791 cases pass.` at head (+8).

Gate family derived from the actual diff with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, run at
`59d5c22bb` — 17 path-derived families plus the 2 convention-triggered ones this change
kind incurs (it edits a gate script). All green, each read from the gate's own verdict
line with the exit code captured before any pipe, except two that decline to measure
locally and say so themselves:

- `node scripts/check-test-completeness.mjs` — `PREREQUISITE NOT MET`, exit 3: it grades a
  saved `turbo run test` log and there is none locally. NOT MEASURED, not a red; its own
  text says so.
- `node scripts/check-partof-closing-keyword.mjs` with no PR context — `NOT WIRED`,
  exit 2. Its self-test spelling (`pnpm check:partof-closing-keyword`, 28 cases) is green,
  and the gate was additionally run against this body with `PR_BODY` set before the PR was
  opened.

No changeset: nothing here is published from any package — the diff is `scripts/pm/**`
only, so the PR carries `skip-changeset`.

## Notes for the reviewer

Card relationships, stated once here and carried by no commit trailer (this branch
squashes): the scoped-assertion scaffolding these pins are built on came from #13654, and
its adjudicated default was that the rendered summary line must not change — this card is
the one sanctioned rendered-line change deferred out of it. Nothing from #13654 or #13628
is undone here. The shortfall wording and the cross-repo branch, both from #11218, are
untouched apart from the whitespace that moved into the terminator.

_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_