### PR TITLE
docs(spec): restore the historical table name in the ADR-0006 rename sentence

### DIFF
--- a/.changeset/environment-rename-sentence-historical-name.md
+++ b/.changeset/environment-rename-sentence-historical-name.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): restore the historical table name in the ADR-0006 rename sentence (#12485)
+
+The Environment protocol's module doc comment — and therefore the generated
+page at `content/docs/references/cloud/environment.mdx` — claimed that
+`sys_environment` was renamed to `sys_environment`: a table renamed to itself.
+The sentence is not merely stale, it is self-refuting, and it destroyed the one
+fact it exists to carry, for the reader who consults it precisely because they
+are confused about the rename.
+
+The historical name is `sys_project`, corroborated by `packages/metadata`'s
+changelog entry for the platform-objects object renames (`sys_project` →
+`sys_environment`, alongside `sys_project_member` and `sys_project_credential`)
+and by ADR-0006 v4 itself.
+
+Cause, which generalises past this one line: a mechanical `project` →
+`environment` sweep rewrote the *historical* name inside the very sentence
+documenting the rename. A sweep that cannot distinguish "the name we use now"
+from "the name we used to use" will always corrupt exactly the prose that
+explains a rename. **In a sentence that documents a rename, the old name is the
+payload — it is not drift, and it must never be "consistency-fixed".**
+
+Fixed at the producer: the `.mdx` under `content/docs/references/` is generated
+from the spec source by `build-docs.ts` and pinned by `check:docs`, so the doc
+comment in `packages/spec/src/cloud/environment.zod.ts` is the fix site and the
+page is regenerated.

--- a/content/docs/references/cloud/environment.mdx
+++ b/content/docs/references/cloud/environment.mdx
@@ -17,7 +17,7 @@ This file defines the Control-Plane schemas for the `sys_environment`,
 data lives in each environment's own database — those data-plane DBs hold
 no system tables.
 
-See ADR-0006 v4: `sys_environment` was renamed to `sys_environment`; the
+See ADR-0006 v4: `sys_project` was renamed to `sys_environment`; the
 separate dev-workspace `Project` concept introduced in v3 has been
 dropped — user code is now modelled as an implicit `sys_package` with
 a per-org `manifest_id` (see ADR-0003), so a single package + version

--- a/packages/spec/src/cloud/environment.zod.ts
+++ b/packages/spec/src/cloud/environment.zod.ts
@@ -17,7 +17,7 @@ import { lazySchema } from '../shared/lazy-schema';
  * data lives in each environment's own database — those data-plane DBs hold
  * no system tables.
  *
- * See ADR-0006 v4: `sys_environment` was renamed to `sys_environment`; the
+ * See ADR-0006 v4: `sys_project` was renamed to `sys_environment`; the
  * separate dev-workspace `Project` concept introduced in v3 has been
  * dropped — user code is now modelled as an implicit `sys_package` with
  * a per-org `manifest_id` (see ADR-0003), so a single package + version


### PR DESCRIPTION
Fixes #12485

## The defect

`content/docs/references/cloud/environment.mdx:20` told the reader that a table was renamed to itself:

> See ADR-0006 v4: `sys_environment` was renamed to `sys_environment`; …

Not merely stale — self-refuting. It destroyed the single fact the sentence exists to carry, for the reader who consults it *precisely because* they are confused about the rename.

The historical name is **`sys_project`**, corroborated at `packages/metadata/CHANGELOG.md:6802` (platform-objects object renames: `sys_project` to `sys_environment`, alongside `sys_project_member` and `sys_project_credential`) and by ADR-0006 v4 itself.

## Where the fix actually landed, and why not in the .mdx

The named file carries this at line 6:

```
{/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. */}
```

`content/docs/references/**` is generated from the spec source by `packages/spec/scripts/build-docs.ts` and **pinned by a required check**, `pnpm --filter @objectstack/spec check:docs`, which regenerates and fails on any difference (`lint.yml`, "Check generated reference docs are in sync with the spec"). Hand-editing the page would have turned that gate red while leaving the real source wrong.

So the fix is one word in the producer — the module doc comment in `packages/spec/src/cloud/environment.zod.ts:20` — and the page is **regenerated**, not hand-edited. Two files change; they are one defect.

## Sweep safety

This bug was created by a mechanical `project` to `environment` sweep that rewrote the *historical* name inside the very sentence documenting the rename. A sweep that cannot tell "the name we use now" from "the name we used to use" will always corrupt exactly the prose that explains a rename.

**In a sentence that documents a rename, the old name is the payload. It is not drift, and it must never be "consistency-fixed".** Only the first name in the sentence changed here; the target name and the surrounding clause about the dropped v3 dev-workspace `Project` concept are untouched.

## Bounded side-check — no further findings

Per the triage ruling, reported and deliberately **not** fixed here. Nothing further was found:

- Self-refuting shape, repo-wide (not just `content/`): **zero remaining hits** after this change. The two pre-existing sites were the generated page and its generator source — both are this one defect.
- `sys_project_member` / `sys_project_credential` in `content/`: **no hits at all**, so no published rename-explaining sentence carries those spellings.
- Those two names repo-wide survive only in CHANGELOGs and historical ADRs (`docs/adr/0004-*`, `docs/adr/0006-*` v1), where an old name is correct and must stay.
- Wider rename-explaining prose in `content/` (`renamed` / `formerly` / `previously` / `used to be` near a `sys_` name) was reviewed by hand: the other hits are genuine renames with distinct source and target (for example `group` to `team` in the permissions pages), not the defect class.

## Verification

All measurements on `758e944fb`, the head of this branch.

- `check:docs` — `✅ 230 generated files in sync with packages/spec`.
- **Ablation proving that gate is live on this text** (not assumed): restoring the self-refuting sentence into the `.mdx` alone made `check:docs` exit 1 with its own message, *"These files are GENERATED — do not hand-edit them."* Mutation confirmed on disk by blob hash before the run (the mutated blob `6ca8c281d` is byte-identical to the original pre-fix blob); restore proven byte-identical to the `HEAD` blob with a clean `git diff HEAD`.
- `check:generated` — `✓ All 14 generated artifacts are up to date`, including `check:api-surface`, after building `packages/spec` (34/34 declaration files emitted). Its first run reported `api-surface/` stale; that was the phantom its own warning names — it reads the built `dist`, and no build had run in a fresh worktree. The artifacts carry no doc-comment prose, and a comment cannot change an exported name.
- Green: `check:authorable-surface`, `check:doc-anchors`, `check:doc-authoring`, `check:docs-single-h1`, `check:docs-audit-scope`, `check:docs-redirects`, `check:role-word`, `check:quick-reference-counts`, `check:nul-bytes`, `check:empty-changeset`, `check:changeset-no-major`, `check:adr-0087-registration`, `check:system-context-census`, `check:doc-frontmatter`, `check:docs-section-name`, `check:doc-route-spelling`, `check:keyed-text-bounds`, `check:objectui-changeset`, `check:llms-txt`, `check:skill-refs`, `check:yaml-examples`, `check:empty-state`, `check:variant-docs`.
- `check:doc-formula-expressions` — `✓ 58 self-test cases passed`; 22 record-scoped formula examples across 426 files judged clean.
- `vitest src/cloud/environment.test.ts` — `Test Files 1 passed (1)`, `Tests 23 passed (23)`.
- Lint, narrowed and declared: `eslint --no-inline-config --format json` on the one changed source file — 1 file, 0 errors, 0 warnings. The narrowing is safe by measurement, not by assumption: this repo runs a single `eslint.config.mjs` that **never enables type-aware linting** for any file (no `parserOptions.project`, no typed rules — stated and positive-control-measured at `eslint.config.mjs:328`), so a one-word comment edit cannot move the verdict of any untouched file. The repo-wide `pnpm lint` sweep remains CI's run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_