### PR TITLE
docs(og): gate the OG card URL's dotted final segment, and name the coupling on both sides

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1460,12 +1460,23 @@ jobs:
       # every type still checks, every link still resolves. The only symptom is
       # a 200 where a 404 belongs, on URLs no test requests.
       #
+      # The same matcher rule holds up a SECOND surface, gated by the same
+      # script: `lib/source.ts`'s `getPageImage()` appends an `image.png` marker
+      # to every Open Graph card URL, and that marker's DOT is the only reason
+      # `/og/docs/<page>/image.png` is not rewritten to `/en/og/docs/...` (not a
+      # route -- `app/og/` is top-level, not under `app/[lang]/`). Measured:
+      # `/og/docs/ai/agents` -> 404, `/og/docs/ai/agents/x.png` -> 200, so the
+      # marker's NAME is free and its dot is not. Rename it to anything dotless
+      # and every `og:image` on the site 404s at once; nothing fetches those
+      # URLs, so it is the same silent shape as the catch-all above.
+      #
       # Runs its own --self-test first (via the pnpm script). Not ceremony: the
       # live tree is green by construction after the fix, so a passing run over
       # real data cannot distinguish a working gate from one that approves
-      # everything. The self-test is where every limb is observed failing, and
-      # where the proxy condition is observed flipping the requirement off.
-      - name: Docs locale catch-all rejects non-locale segments
+      # everything. The self-test is where every limb is observed failing --
+      # including the OG marker stripped of its dot -- and where the proxy
+      # condition is observed flipping the catch-all requirement off.
+      - name: Docs locale catch-all and OG card URL dot invariant
         run: pnpm check:docs-locale-catch-all
 
       # #11050 route spellings taught in prose: every /api/v1 wire-path

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -15,6 +15,31 @@ export const blog = loader({
   source: blogCollection.toFumadocsSource(),
 });
 
+/**
+ * The Open Graph card URL for a page: `/og/docs/<...page.slugs>/image.png`.
+ *
+ * The trailing `image.png` marker is load-bearing TWICE, and only the first is
+ * visible from this file:
+ *
+ * 1. `app/og/docs/[...slug]/route.tsx` resolves the page with
+ *    `source.getPage(slug.slice(0, -1))` -- the marker is the sacrificial
+ *    segment that slice discards. Its NAME does not matter to that.
+ * 2. Its DOT is what keeps this URL out of the locale rewriter. The matcher in
+ *    `apps/docs/proxy.ts` excludes any path containing a dot, so a dotted final
+ *    segment skips the proxy and reaches the route above. A marker WITHOUT a
+ *    dot is rewritten to `/en/og/docs/...`, which is not a route at all --
+ *    `app/og/` is top-level, not under `app/[lang]/`.
+ *
+ * Measured: `/og/docs/ai/agents` -> 404, `/og/docs/ai/agents/x.png` -> 200. So
+ * the marker's name is free; the presence of a dot is everything. Rename it to
+ * anything dotless -- or widen the proxy matcher on the other side -- and every
+ * `og:image` on the site 404s at once, which is worse than emitting none
+ * (crawlers fall back to scraping whatever else the page offers). Nothing
+ * fetches these URLs, so no test, type or link check would notice.
+ *
+ * `pnpm check:docs-locale-catch-all` gates the dot from here; the matcher half
+ * is commented on in `apps/docs/proxy.ts`.
+ */
 export function getPageImage(page: InferPageType<typeof source>) {
   const segments = [...page.slugs, 'image.png'];
 

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -108,5 +108,23 @@ export const config = {
   // - Next.js static files (/_next/static/*)
   // - Next.js image optimization (/_next/image/*)
   // - Favicon and other static assets
+  //
+  // The `.*\..*` limb -- exclude any path containing a DOT -- is load-bearing
+  // for two surfaces beyond static assets, and neither is visible from here:
+  //
+  // - `apps/docs/lib/source.ts`'s `getPageImage()` appends an `image.png`
+  //   marker to every Open Graph card URL. That marker's dot is the ONLY reason
+  //   `/og/docs/<page>/image.png` is not rewritten to `/en/og/docs/...`, which
+  //   is not a route -- the `app/og/` tree is top-level, not under
+  //   `app/[lang]/`. Widening this pattern 404s every `og:image` on the site at
+  //   once, and nothing fetches those URLs, so the break is silent. Already
+  //   ruled out as a surface to widen for the same reason from the other end:
+  //   it would also 404 `/llms.txt`, `/llms-full.txt`, `/og/**` and
+  //   `/docs/**.mdx`.
+  // - Conversely, BECAUSE dotted paths skip this proxy they reach `app/[lang]/`
+  //   with `lang` set to the literal segment (`robots.txt`, `ads.txt`), which is
+  //   why `apps/docs/lib/i18n.ts` carries the `isSupportedLanguage` guard.
+  //
+  // `pnpm check:docs-locale-catch-all` gates both halves.
   matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
 };

--- a/scripts/check-docs-locale-catch-all.mjs
+++ b/scripts/check-docs-locale-catch-all.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 //
-// check-docs-locale-catch-all -- keep `apps/docs`'s top-level dynamic route
-// segments from serving the homepage under paths that are not locales.
+// check-docs-locale-catch-all -- pin the two surfaces `apps/docs`'s
+// dot-exclusion rule holds up: the top-level dynamic route segments must not
+// serve the homepage under paths that are not locales, and the Open Graph card
+// URL must keep the dotted final segment that keeps it out of the rewriter.
 //
 //   node scripts/check-docs-locale-catch-all.mjs
 //   node scripts/check-docs-locale-catch-all.mjs --self-test
@@ -64,6 +66,43 @@
 // `apps/docs/app/[slug]/` would reintroduce the same soft-404 class, and this
 // gate names it the moment it appears.
 //
+// ## The other surface the same dot rule holds up: the OG card URL
+//
+// `apps/docs/lib/source.ts`'s `getPageImage()` builds every Open Graph card URL
+// as `/og/docs/<...page.slugs>/image.png`. That trailing marker is load-bearing
+// TWICE, and only the first is discoverable from the code:
+//
+//   1. `app/og/docs/[...slug]/route.tsx` resolves the page with
+//      `source.getPage(slug.slice(0, -1))` -- the marker is the sacrificial
+//      segment that slice discards. Its NAME is irrelevant to that.
+//   2. Its DOT is what keeps the URL out of the locale rewriter. Measured
+//      against the matcher `proxy.ts` carries today:
+//
+//        /og/docs/ai/agents            -> proxy RUNS  -> rewritten to
+//                                         /en/og/docs/ai/agents, which is not a
+//                                         route (`app/og/` is top-level, NOT
+//                                         under `app/[lang]/`) -> 404
+//        /og/docs/ai/agents/x.png      -> proxy SKIPS -> 200 image/png
+//        /og/docs/ai/agents/image.png  -> proxy SKIPS -> 200 image/png
+//
+// So the marker's name is free and its dot is not: renaming it to anything
+// dotless takes every `og:image` on the site to 404 at once. A 404ing
+// `og:image` is worse than none -- crawlers fall back to scraping whatever else
+// the page offers -- and nothing fetches these URLs: no test, no link checker,
+// no type. Silent by construction, which is the same reason the catch-all guard
+// above needed a gate rather than a comment.
+//
+// This limb asserts the half that was asserted nowhere: the URL `getPageImage()`
+// builds ends in a final segment containing a dot. It deliberately does NOT
+// re-assert that the matcher excludes dotted paths -- that condition is read
+// once, above, and both halves are reported in the summary line.
+//
+// The assertion is made on the URL the function RETURNS, not on the array
+// literal alone. The marker is the URL's final segment only while the returned
+// template still ends in `${segments.join('/')}`; checking the literal without
+// that link would be a check on a variable that may no longer reach the URL --
+// a phantom check, in a file whose whole subject is checks that stop checking.
+//
 // ## Why this file is dependency-free
 //
 // Same reason `check-docs-redirects.mjs` is: it must run in any container with
@@ -84,6 +123,12 @@ const DOTLESS_PROBE = '/this-page-does-not-exist';
 
 /** The shared predicate a guarded segment has to call. */
 const PREDICATE = 'isSupportedLanguage';
+
+/** The OG card URL builder this gate reads, in `apps/docs/lib/source.ts`. */
+const OG_BUILDER = 'getPageImage';
+
+/** Page slugs used only to render a concrete example path in the finding. */
+const OG_SAMPLE_SLUGS = ['ai', 'agents'];
 
 /** The repo this script lives in -- resolved from the script, so cwd cannot lie. */
 function scriptRepoRoot() {
@@ -193,14 +238,92 @@ export function predicateFailure(source) {
 }
 
 // ---------------------------------------------------------------------------
+// lib/source.ts -- does the OG card URL still end in a dotted segment?
+// ---------------------------------------------------------------------------
 
 /**
- * @param {{ appDir: string, proxyPath: string, i18nPath: string }} paths
+ * Read the URL `getPageImage()` builds, as far as it is statically decidable:
+ * the marker appended after the page slugs, and the literal path prefix the
+ * joined segments are appended to.
+ *
+ * Every shape this cannot read is an ERROR, never a pass. A source file the
+ * gate cannot parse is a source file it is not checking, and reporting that as
+ * "fine" is the failure mode this whole file exists to prevent.
+ *
+ * @param {string} source
+ * @returns {{ marker: string, prefix: string, error?: undefined }
+ *   | { error: string, marker?: undefined, prefix?: undefined }}
+ */
+export function readOgCardUrl(source) {
+  const at = source.search(new RegExp(`function\\s+${OG_BUILDER}\\s*\\(`));
+  if (at < 0) {
+    return {
+      error: `lib/source.ts no longer declares \`${OG_BUILDER}()\` -- this gate cannot see what the `
+        + 'OG card URLs are built from, so it is checking nothing',
+    };
+  }
+  const rest = source.slice(at);
+  const closes = rest.search(/\n\}/);
+  const body = closes >= 0 ? rest.slice(0, closes) : rest;
+
+  const array = /const\s+([A-Za-z_$][\w$]*)\s*=\s*\[([^\]]*)\]/.exec(body);
+  if (!array) {
+    return {
+      error: `\`${OG_BUILDER}()\` no longer builds its path from one array literal; this gate reads `
+        + "that literal to find the URL's final segment",
+    };
+  }
+  const [, name, contents] = array;
+  const elements = contents.split(',').map((e) => e.trim()).filter(Boolean);
+  const last = elements[elements.length - 1] ?? '';
+  const literal = /^'((?:[^'\\]|\\.)*)'$|^"((?:[^"\\]|\\.)*)"$/.exec(last);
+  if (!literal) {
+    return {
+      error: `the last element of \`${name}\` in \`${OG_BUILDER}()\` is \`${last || '(nothing)'}\`, not a `
+        + "string literal this gate can read -- the URL's final segment is no longer statically decidable",
+    };
+  }
+  const marker = literal[1] ?? literal[2];
+
+  const template = /url\s*:\s*`([^`]*)`/.exec(body);
+  if (!template) {
+    return { error: `\`${OG_BUILDER}()\` no longer returns a \`url\` built from a template literal` };
+  }
+  const joined = new RegExp(`\\$\\{\\s*${name}\\s*\\.join\\(\\s*(['"])/\\1\\s*\\)\\s*\\}$`);
+  const ends = joined.exec(template[1]);
+  if (!ends) {
+    return {
+      error: `\`${OG_BUILDER}()\`'s \`url\` no longer ENDS with \`\${${name}.join('/')}\` `
+        + `(it is \`${template[1]}\`), so the last element of \`${name}\` is not the URL's final segment `
+        + 'and the dot invariant below would be checking the wrong string',
+    };
+  }
+  const prefix = template[1].slice(0, ends.index);
+  if (prefix.includes('${')) {
+    return {
+      error: `\`${OG_BUILDER}()\`'s \`url\` interpolates before the segments (\`${prefix}\`), so this `
+        + 'gate cannot render the path it produces',
+    };
+  }
+  return { marker, prefix };
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{ appDir: string, proxyPath: string, i18nPath: string, sourcePath: string }} paths
  * @returns {{ findings: string[], stats: Record<string, unknown> }}
  */
-export function checkApp({ appDir, proxyPath, i18nPath }) {
+export function checkApp({ appDir, proxyPath, i18nPath, sourcePath }) {
   const findings = [];
-  const stats = { segments: 0, guarded: 0, dottedBypassesProxy: null };
+  const stats = {
+    segments: 0,
+    guarded: 0,
+    dottedBypassesProxy: null,
+    ogMarker: null,
+    ogFinalSegmentDotted: null,
+    ogUrlSkipsProxy: null,
+  };
 
   if (!existsSync(proxyPath)) return { findings: [`missing ${proxyPath}`], stats };
   const read = readMatchers(readFileSync(proxyPath, 'utf8'));
@@ -218,6 +341,38 @@ export function checkApp({ appDir, proxyPath, i18nPath }) {
       + 'dynamic route too, so the locale guard is the ONLY thing standing between the homepage and '
       + 'every one-segment URL -- re-measure before relaxing anything here.',
     );
+  }
+
+  // The OTHER consumer of the same dot rule: the OG card URL (see the header).
+  // Unconditional, unlike the catch-all guard below -- a matcher that stopped
+  // excluding dotted paths would not relax this requirement, it would break the
+  // surface outright, so there is no condition under which a dotless marker is
+  // the right answer. The matcher half is read once above and reported, never
+  // re-asserted here.
+  if (!existsSync(sourcePath)) {
+    findings.push(`missing ${sourcePath}`);
+  } else {
+    const og = readOgCardUrl(readFileSync(sourcePath, 'utf8'));
+    if (og.error) {
+      findings.push(og.error);
+    } else {
+      const finalSegment = og.marker.split('/').filter(Boolean).pop() ?? '';
+      const probe = `${og.prefix}${[...OG_SAMPLE_SLUGS, og.marker].join('/')}`;
+      stats.ogMarker = og.marker;
+      stats.ogFinalSegmentDotted = finalSegment.includes('.');
+      stats.ogUrlSkipsProxy = !compiled.runsFor(probe);
+      if (!stats.ogFinalSegmentDotted) {
+        findings.push(
+          `the OG card URL \`${OG_BUILDER}()\` builds ends in \`${finalSegment || '(no final segment)'}\`, `
+          + "which contains no dot. proxy.ts's matcher excludes ONLY paths containing a dot, so "
+          + `\`${probe}\` is now locale-rewritten to \`/<locale>${probe}\` -- a path app/og/ does not `
+          + 'serve, because that tree is top-level and not under app/[lang]/. Every `og:image` on the '
+          + 'site 404s at once, and nothing fetches these URLs, so no other check sees it. Restore a '
+          + "final segment containing a dot in apps/docs/lib/source.ts (the marker's NAME is free; its "
+          + 'dot is not).',
+        );
+      }
+    }
   }
 
   const entries = existsSync(appDir)
@@ -261,7 +416,9 @@ export function checkApp({ appDir, proxyPath, i18nPath }) {
 
 function summarise(stats) {
   return `${stats.segments} top-level dynamic segment(s), ${stats.guarded} guarded; `
-    + `dotted paths bypass proxy.ts: ${stats.dottedBypassesProxy}`;
+    + `dotted paths bypass proxy.ts: ${stats.dottedBypassesProxy}; `
+    + `OG card marker ${JSON.stringify(stats.ogMarker)} ends in a dot: ${stats.ogFinalSegmentDotted} `
+    + `(that URL skips proxy.ts: ${stats.ogUrlSkipsProxy})`;
 }
 
 function report(findings, stats) {
@@ -305,13 +462,27 @@ export default async function LanguageLayout({ params, children }) {
 }
 `;
 
-function writeFixture(dir, { proxy = FIXTURE_PROXY, i18n = FIXTURE_I18N, layout = FIXTURE_LAYOUT, extra } = {}) {
+const FIXTURE_SOURCE = `export function getPageImage(page) {
+  const segments = [...page.slugs, 'image.png'];
+
+  return {
+    segments,
+    url: \`/og/docs/\${segments.join('/')}\`,
+  };
+}
+`;
+
+function writeFixture(
+  dir,
+  { proxy = FIXTURE_PROXY, i18n = FIXTURE_I18N, layout = FIXTURE_LAYOUT, pageSource = FIXTURE_SOURCE, extra } = {},
+) {
   const appDir = join(dir, 'app');
   rmSync(appDir, { recursive: true, force: true });
   mkdirSync(join(appDir, '[lang]'), { recursive: true });
   mkdirSync(join(dir, 'lib'), { recursive: true });
   writeFileSync(join(dir, 'proxy.ts'), proxy);
   writeFileSync(join(dir, 'lib', 'i18n.ts'), i18n);
+  writeFileSync(join(dir, 'lib', 'source.ts'), pageSource);
   writeFileSync(join(appDir, '[lang]', 'layout.tsx'), layout);
   // A static sibling segment must never be mistaken for a dynamic one.
   mkdirSync(join(appDir, 'llms.txt'), { recursive: true });
@@ -320,7 +491,12 @@ function writeFixture(dir, { proxy = FIXTURE_PROXY, i18n = FIXTURE_I18N, layout 
     mkdirSync(join(appDir, extra.name), { recursive: true });
     writeFileSync(join(appDir, extra.name, 'layout.tsx'), extra.layout);
   }
-  return { appDir, proxyPath: join(dir, 'proxy.ts'), i18nPath: join(dir, 'lib', 'i18n.ts') };
+  return {
+    appDir,
+    proxyPath: join(dir, 'proxy.ts'),
+    i18nPath: join(dir, 'lib', 'i18n.ts'),
+    sourcePath: join(dir, 'lib', 'source.ts'),
+  };
 }
 
 function selfTest() {
@@ -338,6 +514,10 @@ function selfTest() {
     assert(run.findings.length === 0, `clean fixture must be silent -- got ${JSON.stringify(run.findings)}`);
     assert(run.stats.segments === 1 && run.stats.guarded === 1, `clean fixture must find 1 guarded segment -- got ${summarise(run.stats)}`);
     assert(run.stats.dottedBypassesProxy === true, 'the real matcher must be read as letting dotted paths through');
+    assert(
+      run.stats.ogMarker === 'image.png' && run.stats.ogFinalSegmentDotted === true && run.stats.ogUrlSkipsProxy === true,
+      `the clean fixture's OG card URL must be read as dotted and proxy-skipping -- got ${summarise(run.stats)}`,
+    );
 
     // 2. RED: the guard call deleted -- the exact regression this gate exists for.
     paths = writeFixture(dir, { layout: FIXTURE_LAYOUT.replace('  if (!isSupportedLanguage(lang)) notFound();\n', '') });
@@ -384,6 +564,54 @@ function selfTest() {
     paths = writeFixture(dir, { proxy: `export const config = { matcher: ['/((?!unclosed.*)'] };\n` });
     run = checkApp(paths);
     assert(run.findings.length === 1 && /does not compile/.test(run.findings[0]), `an uncompilable matcher must be reported -- got ${JSON.stringify(run.findings)}`);
+
+    // 9. RED -- THE ABLATION. The marker keeps its position and loses only its
+    //    dot. Nothing else in the tree moves: the route still slices off the
+    //    last segment, every type still checks, every page still renders. This
+    //    is the whole reason the limb exists, so it is observed failing here.
+    paths = writeFixture(dir, { pageSource: FIXTURE_SOURCE.replace(`'image.png'`, `'image'`) });
+    run = checkApp(paths);
+    assert(
+      run.findings.length === 1 && /ends in `image`, which contains no dot/.test(run.findings[0]),
+      `a marker that lost its dot must be reported -- got ${JSON.stringify(run.findings)}`,
+    );
+    assert(run.stats.ogFinalSegmentDotted === false, 'the dotless marker must be read as dotless');
+    assert(run.stats.ogUrlSkipsProxy === false, 'the dotless URL must be read as one the proxy now rewrites');
+
+    // 10. GREEN control: the marker's name is free, so a differently-named dotted marker
+    //     is GREEN -- the gate must pin the dot, not the filename.
+    paths = writeFixture(dir, { pageSource: FIXTURE_SOURCE.replace(`'image.png'`, `'card.jpeg'`) });
+    run = checkApp(paths);
+    assert(run.findings.length === 0, `a renamed but still-dotted marker must stay green -- got ${JSON.stringify(run.findings)}`);
+    assert(run.stats.ogMarker === 'card.jpeg', `the renamed marker must be read back -- got ${summarise(run.stats)}`);
+
+    // 11. RED: the marker dropped entirely -- the URL now ends in a page slug.
+    paths = writeFixture(dir, { pageSource: FIXTURE_SOURCE.replace(`, 'image.png'`, '') });
+    run = checkApp(paths);
+    assert(
+      run.findings.length === 1 && /not a\s+string literal this gate can read/.test(run.findings[0]),
+      `a dropped marker must be reported, not read as absent-and-fine -- got ${JSON.stringify(run.findings)}`,
+    );
+
+    // 12. RED: the array literal is intact but no longer reaches the END of the
+    //     URL, so its last element is not the final segment. Checking the
+    //     literal alone here would report GREEN over a broken surface.
+    paths = writeFixture(dir, {
+      pageSource: FIXTURE_SOURCE.replace(`\${segments.join('/')}\``, `\${segments.join('/')}/card\``),
+    });
+    run = checkApp(paths);
+    assert(
+      run.findings.length === 1 && /no longer ENDS with/.test(run.findings[0]),
+      `a url that stopped ending in the joined segments must be reported -- got ${JSON.stringify(run.findings)}`,
+    );
+
+    // 13. RED: the builder is gone. An unreadable input is never a pass.
+    paths = writeFixture(dir, { pageSource: 'export function somethingElse() {}\n' });
+    run = checkApp(paths);
+    assert(
+      run.findings.length === 1 && /no longer declares/.test(run.findings[0]),
+      `a missing ${OG_BUILDER}() must be reported -- got ${JSON.stringify(run.findings)}`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -396,7 +624,9 @@ function selfTest() {
   console.log(
     `✓ check-docs-locale-catch-all --self-test: ${checked} assertions over a temp fixture (real checkApp path); `
     + 'every limb -- deleted guard, guard behind the return, hollowed predicate, a new unguarded segment, '
-    + 'an uncompilable matcher -- observed FAILING, and the proxy condition observed flipping the requirement off.',
+    + 'an uncompilable matcher, an OG marker stripped of its dot, an OG marker dropped, an OG url that '
+    + 'stopped ending in its segments, a missing builder -- observed FAILING, the proxy condition observed '
+    + "flipping the catch-all requirement off, and the OG marker's NAME observed free while its dot is not.",
   );
 }
 
@@ -406,6 +636,7 @@ function main() {
     appDir: join(root, 'apps/docs/app'),
     proxyPath: join(root, 'apps/docs/proxy.ts'),
     i18nPath: join(root, 'apps/docs/lib/i18n.ts'),
+    sourcePath: join(root, 'apps/docs/lib/source.ts'),
   });
   process.exit(report(findings, stats));
 }


### PR DESCRIPTION
Fixes #12326

## The coupling, re-verified rather than inherited

`getPageImage()` in `apps/docs/lib/source.ts` builds every Open Graph card URL as
`/og/docs/` + the page slugs + an `image.png` marker. That marker is load-bearing **twice**,
and only the first is discoverable from the code:

1. `app/og/docs/[...slug]/route.tsx` resolves the page with `source.getPage(slug.slice(0, -1))`
   — the marker is the sacrificial segment that slice discards. Its **name** is irrelevant to that.
2. Its **DOT** is what keeps the URL out of the locale rewriter. `apps/docs/proxy.ts`'s matcher
   excludes any path containing a dot, so a dotted final segment skips the proxy entirely. A
   dotless marker is rewritten under the locale prefix, which is not a route at all — the
   `app/og/` tree is top-level, not under `app/[lang]/`.

Both premises re-measured on this branch's merge base, not carried over from the card:

- `proxy.ts`'s matcher is still, byte for byte, `'/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'`.
- `app/og/` is a top-level route directory; the only locale-prefixed tree is `app/[lang]/`, whose
  children are `docs/` and `blog/` — so the rewritten path really has no route.
- Compiling that matcher and applying it to the URLs in question:

```
/og/docs/ai/agents            -> proxy RUNS   (rewritten -> no route -> 404)
/og/docs/ai/agents/image.png  -> proxy SKIPS
/og/docs/ai/agents/x.png      -> proxy SKIPS  (the name is free)
/og/docs/ai/agents/image-png  -> proxy RUNS   (the dot is not)
```

That is the whole invariant, and until this PR it lived only in an issue comment.

## Both halves ship

**1. A cross-referencing comment on each side.**
`apps/docs/lib/source.ts` now names `apps/docs/proxy.ts`, the OG route, and what breaks;
`apps/docs/proxy.ts` now names `getPageImage()` and `lib/i18n.ts` as the two surfaces its
dot-exclusion limb holds up, in opposite directions. Both point at `pnpm check:docs-locale-catch-all`.

**2. The mechanical half — `check-docs-locale-catch-all` gains a limb.**
The charter's "extend or companion" choice was resolved as **extend**, for three measured reasons:

- The script already parses and compiles `proxy.ts`'s matcher. A companion would either duplicate
  that parse or import from this script — a dependency in a family that is deliberately
  dependency-free so it can run with bare `node` and no workspace install.
- The script's subject already *is* "what depends on the proxy's dot rule". The catch-all guard is one
  dependent; the OG marker is the other. One file now answers the whole question.
- A companion costs a new `lint.yml` step, a new entry in the `check-self-test-wired` population and a
  second self-test output surface, for an assertion of roughly twenty lines.

What the limb asserts is exactly the half the charter named and nothing more: **the URL
`getPageImage()` builds ends in a final segment containing a dot.** It deliberately does not
re-assert that the matcher excludes dotted paths.

It reads two things, not one. The marker literal alone would be a check on a variable that may no
longer reach the URL, so the limb also requires the returned template to still **end** with the joined
segments — otherwise the last array element is not the URL's final segment and the dot assertion
would be pinning the wrong string. Every shape it cannot parse (builder renamed away, array gone,
marker not a literal, url no longer built from a template) is a **finding**, never a quiet pass.

## The ablation — the assertion observed going RED

Run against the real tree, on top of the implementation commit, with the mutation confirmed on disk
before any reading was taken (no build leg: the gate reads source text, it does not import built
artifacts).

```
HEAD blob   = 8fe04f2946079c5de4e96f12029b8b26e02d0f07
before hash = 8fe04f2946079c5de4e96f12029b8b26e02d0f07     (tree confirmed at HEAD)
mutation    = [...page.slugs, 'image.png']  ->  [...page.slugs, 'image']
removed-text occurrences after mutation = 0 (want 0)
injected-text occurrences after mutation = 1 (want 1)
after hash  = 5455cb64b81ddb4bd31610890b7b77635c3eac8d     (bytes moved)

VERDICT-EXIT prod=1
x check-docs-locale-catch-all -- 1 finding(s)
  - the OG card URL `getPageImage()` builds ends in `image`, which contains no dot.
    proxy.ts's matcher excludes ONLY paths containing a dot, so `/og/docs/ai/agents/image`
    is now locale-rewritten ... Every `og:image` on the site 404s at once, and nothing
    fetches these URLs, so no other check sees it.

restored hash = 8fe04f2946079c5de4e96f12029b8b26e02d0f07
git diff HEAD --name-only = []
RESTORE PROVEN: blob equals HEAD blob and git diff HEAD is empty
```

**Control ablation** — the same edit keeping the dot (`'image.png'` to `'card.jpeg'`), mutation
likewise confirmed on disk: `VERDICT-EXIT prod=0`, summary
`OG card marker "card.jpeg" ends in a dot: true`. So the limb pins the **dot**, not the filename,
which is what the measurement says matters.

The same two directions are pinned in `--self-test` as well, over the real `checkApp` path: a marker
stripped of its dot, a marker dropped entirely, a url that stopped ending in its segments, a missing
builder — each observed failing — plus a renamed-but-dotted marker observed staying green.
Self-test assertion count went 12 to 21.

## Was a running server needed? No.

Both facts are static: the matcher is a string literal in `proxy.ts` and the marker is a string literal
in `lib/source.ts`. The gate compiles the one and applies it to the other, with no server, no network
and no workspace install — the same dependency-free shape the rest of the file already had.

## Verification

Derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(36 families, 39 commands), run at `6bcc114bc` — every reading below taken with the exit code captured
before any pipe.

- **37 of 39 green**, including `pnpm check:docs-locale-catch-all` (production `exit=0`;
  `1 top-level dynamic segment(s), 1 guarded; dotted paths bypass proxy.ts: true; OG card marker
  "image.png" ends in a dot: true (that URL skips proxy.ts: true)`), `check:nul-bytes`,
  `check-self-test-wired`, `check-self-test-workflow-commands`, `check:workflow-status-functions`
  and the other four workflow parsers that read the edited `lint.yml`.
- `node scripts/check-test-completeness.mjs` -> **exit 3 = NOT MEASURED** by the script's own words
  (it needs a saved `turbo run test` log). Not a finding.
- `pnpm check:type-check-debt` -> its `--re-measure` leg **refuses to run** without the built package
  closure, and says so: measuring from here would measure a different world. **Declared narrowing**,
  with its evidence: the sibling `pnpm check:type-check-coverage` (same script, same `--self-test`,
  structural half) is green, and this diff contains no input of that gate — no `packages/**`, no
  `package.json`, no `tsconfig*.json`, no `*typecheck-debt.json`. CI builds the closure and runs it.
- **Repo-wide `eslint .` narrowed to the changed files, and the narrowing measured rather than
  assumed:** population decided by eslint's own config resolution (it reports `.github/workflows/lint.yml`
  as `File ignored because no matching configuration was supplied`, so the YAML is outside its
  population by eslint's own answer); **3 files linted**, counted from `--format json` output length;
  0 errors, 0 warnings. Invariance for untouched files: this repo runs one `eslint.config.mjs` which
  **never enables type-aware linting for any file** (no `parserOptions.project`, no typed rules — stated
  and positively controlled in that config's own header), so nothing in this diff can move an untouched
  file's verdict.
- `apps/docs` typecheck (`next typegen && tsc --noEmit`) **narrowed away, mechanically**: the entire
  `apps/docs` diff is *added comment lines and nothing else* — every added line matches a comment
  prefix and there are **zero** removed lines. The one thing that does read those comments as data is
  `check-docs-locale-catch-all` itself, which parses both files and is green.

## A measurement the reviewer should see

The dispatch charter states that the complementary half — that `proxy.ts`'s matcher excludes dotted
paths — is *already asserted*, and forbids duplicating it. Measured against the script: it is
**reported, not asserted**. `stats.dottedBypassesProxy` is a *condition*; when it is false the script
does not fail, it **relaxes** the catch-all requirement and stays green (self-test case 6 pins exactly
that behaviour, deliberately).

Consequence, stated plainly rather than acted on: after this PR, a change to the `lib/source.ts` side
of the coupling is gated, and a widening of the `proxy.ts` side still goes green on both limbs even
though it 404s the same surface. The charter's boundary was respected — nothing here re-asserts the
matcher — and the fact is surfaced instead, in three places: this section, the new header section in
the script, and the gate's own summary line, which now prints `(that URL skips proxy.ts: true)` for
the built OG URL so the value is visible in every CI log. Closing that half is a one-line change the
seat can call.

## Changeset

None, and `skip-changeset` applied: this PR releases nothing. The two `apps/docs` edits are
comment-only in a private, unpublished app; the remaining files are a CI gate script and a comment
plus a step name in `lint.yml` — the case `lint.yml` itself names as the textbook one for the label.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_