### PR TITLE
docs(nav): stop listing "index" in meta.json pages — it detaches the folder index from the tree

### DIFF
--- a/.changeset/docs-meta-index-detaches-folder-index.md
+++ b/.changeset/docs-meta-index-detaches-folder-index.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/docs": patch
+---
+
+fix(docs): stop listing `"index"` in `meta.json` `pages` — it detaches the folder index and shortens 164 breadcrumb trails (#12352)
+
+Fumadocs attaches a folder's `index.mdx` as that folder's tree `index` node
+**only when the folder's `meta.json` does not list it** in `pages`. Listing it
+makes the page an ordinary child instead, and the folder node reaches every tree
+consumer with a `name` and no `url` — `loader-*.js`, `buildFolder()`:
+
+```js
+if (indexPath) {
+  if (excludedPaths.has(indexPath)) delete node.index;   // "index" was listed
+  else excludedPaths.add(indexPath);
+}
+```
+
+Two surfaces read that one node, and both were degraded:
+
+- **Breadcrumb.** `getBreadcrumbItems()` links a folder crumb to `item.index?.url`,
+  so an un-linkable ancestor is dropped rather than emitted name-only (Google
+  requires `item` on every `BreadcrumbList` entry but the last). 172 of 404 doc
+  pages advertised a two-level site structure they do not have.
+- **Sidebar.** `node.index ? SidebarFolderLink : SidebarFolderTrigger` — the
+  section header was inert text, and the section's own overview page sat below it
+  as a child, in six cases under a label identical to the header's.
+
+`"index"` is removed from 16 of the 17 `meta.json` files that listed it. It was
+the first `pages` entry in 15 of them and the first entry after the
+`---Start Here---` separator in `getting-started`, so no other entry's position
+depends on it: the measured tree delta is exactly 16 folder headers going
+`TRIGGER` → `LINK` and 16 index children leaving the child list, with every
+removed child's URL now the header's `href` and no other line moved.
+
+Short trails: **172 → 8**. The remaining 8 are `content/docs/releases/`, which
+this PR does not touch — that directory is fenced by AGENTS.md, and its
+`meta.json` still lists `"index"`.
+
+No consumer-side change: `app/[lang]/docs/[[...slug]]/page.tsx` reconstructs no
+URLs, deliberately, so a producer defect of this shape stays visible.

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -39,23 +39,21 @@ type DocPage = NonNullable<ReturnType<typeof source.getPage>>;
  * `index` node. ⛔ Nothing here splits `page.url` on `/`, and nothing constructs a
  * URL the loader has not already produced.
  *
- * ⚠️ **An ancestor arrives without a URL more often than not, and this drops it.**
- * Measured against a local production build, not inferred: fumadocs attaches a
- * folder's `index.mdx` as that folder's `index` node only when the folder's
- * `meta.json` does **not** list `"index"` in `pages`. 17 of the 35 `meta.json`
- * files under `content/docs` do list it, so their folder nodes carry a
- * `name` and no `url`, and 172 of 403 doc pages therefore ship a trail that skips
- * its section. Confirmed causally by deleting that one line from
- * `content/docs/data-modeling/meta.json` and rebuilding: the section crumb
- * appeared, linked, while an untouched control section stayed short.
+ * ⚠️ **An ancestor can arrive without a URL, and this drops it.** Fumadocs
+ * attaches a folder's `index.mdx` as that folder's `index` node only when the
+ * folder's `meta.json` does **not** list `"index"` in `pages`; a folder that
+ * lists it reaches this walk with a `name` and no `url`. That was once 17 of the
+ * 35 `meta.json` files under `content/docs`, shortening 172 of 404 trails. 16 of
+ * the 17 were fixed producer-side (#12352) and 8 short trails remain, all under
+ * `content/docs/releases/` — a directory AGENTS.md fences off, so its `meta.json`
+ * still lists `"index"`. The condition is therefore live, just rare.
  *
- * ⛔ The missing URL is deliberately **not** reconstructed here. The folder's index
- * page exists, is in the sitemap and answers 200 — the defect is in the content
- * config that hides it from the tree, not in this consumer, and a lookup that
- * re-derived it would make a producer bug invisible and permanent. Google requires
- * `item` on every crumb but the last, so a name-only crumb is not an option
- * either. Filed separately; when it lands, these trails complete with no change to
- * this file.
+ * ⛔ The missing URL is deliberately **not** reconstructed here — that fence is
+ * the reason #12352 was fixable at all. The folder's index page exists, is in the
+ * sitemap and answers 200 — the defect is in the content config that hides it
+ * from the tree, not in this consumer, and a lookup that re-derived it would make
+ * a producer bug invisible and permanent. Google requires `item` on every crumb
+ * but the last, so a name-only crumb is not an option either.
  *
  * Two things the tree cannot supply are added around it, both from data this
  * page already holds:

--- a/content/docs/ai/meta.json
+++ b/content/docs/ai/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "AI",
   "pages": [
-    "index",
     "connect-mcp",
     "agents",
     "actions-as-tools",

--- a/content/docs/api/meta.json
+++ b/content/docs/api/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "API & SDK",
   "pages": [
-    "index",
     "data-api",
     "metadata-api",
     "plugin-endpoints",

--- a/content/docs/automation/meta.json
+++ b/content/docs/automation/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Automation",
   "pages": [
-    "index",
     "hooks",
     "hook-bodies",
     "flows",

--- a/content/docs/capabilities/meta.json
+++ b/content/docs/capabilities/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "What Can It Do?",
   "pages": [
-    "index",
     "data",
     "views",
     "forms",

--- a/content/docs/concepts/meta.json
+++ b/content/docs/concepts/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Core Concepts",
   "pages": [
-    "index",
     "architecture",
     "metadata-driven",
     "metadata-lifecycle",

--- a/content/docs/data-modeling/meta.json
+++ b/content/docs/data-modeling/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Data Modeling",
   "pages": [
-    "index",
     "schema-design",
     "objects",
     "fields",

--- a/content/docs/deployment/meta.json
+++ b/content/docs/deployment/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Deployment & Operations",
   "pages": [
-    "index",
     "self-hosting",
     "production-readiness",
     "backup-restore",

--- a/content/docs/getting-started/meta.json
+++ b/content/docs/getting-started/meta.json
@@ -2,7 +2,6 @@
   "title": "Get Started",
   "pages": [
     "---Start Here---",
-    "index",
     "how-ai-development-works",
     "build-with-claude-code",
     "your-first-project",

--- a/content/docs/kernel/contracts/meta.json
+++ b/content/docs/kernel/contracts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Service Contracts",
-  "pages": ["index", "metadata-service", "auth-service", "storage-service", "data-engine", "cache-service"]
+  "pages": ["metadata-service", "auth-service", "storage-service", "data-engine", "cache-service"]
 }

--- a/content/docs/kernel/meta.json
+++ b/content/docs/kernel/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Kernel & Services",
   "pages": [
-    "index",
     "architecture",
     "events",
     "services",

--- a/content/docs/kernel/runtime-services/meta.json
+++ b/content/docs/kernel/runtime-services/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Runtime Services",
   "pages": [
-    "index",
     "data-service",
     "sharing-service",
     "audit-service",

--- a/content/docs/permissions/meta.json
+++ b/content/docs/permissions/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Permissions & Identity",
   "pages": [
-    "index",
     "administrator-guide",
     "authentication",
     "sso",

--- a/content/docs/plugins/meta.json
+++ b/content/docs/plugins/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Plugins & Packages",
   "pages": [
-    "index",
     "anatomy",
     "development",
     "packages",

--- a/content/docs/protocol/kernel/meta.json
+++ b/content/docs/protocol/kernel/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "System Protocol",
   "pages": [
-    "index",
     "lifecycle",
     "http-protocol",
     "realtime-protocol",

--- a/content/docs/protocol/meta.json
+++ b/content/docs/protocol/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Protocol Spec",
   "pages": [
-    "index",
     "diagram",
     "objectql",
     "objectui",

--- a/content/docs/ui/meta.json
+++ b/content/docs/ui/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Views & Apps",
   "pages": [
-    "index",
     "apps",
     "pages",
     "react-pages",


### PR DESCRIPTION
Part of #12352

Removes `"index"` from the `pages` array of 16 of the 17 `meta.json` files under
`content/docs` that list it. Producer-side only: no consumer-side URL
reconstruction, in `page.tsx` or anywhere else.

## Mechanism (fumadocs-core 16.14.4, `buildFolder()` in `dist/loader-*.js`)

A folder's `index.mdx` becomes that folder's tree `index` node only while the
folder's `meta.json` does **not** list `"index"` in `pages`. Listing it makes the
page an ordinary child and then deletes the folder's index:

```js
if (indexPath) {
  if (excludedPaths.has(indexPath)) delete node.index;   // "index" was listed
  else excludedPaths.add(indexPath);
}
```

Two surfaces read that one node:

| surface | consumer | with `"index"` listed |
| --- | --- | --- |
| breadcrumb | `getBreadcrumbItems()` links a folder crumb to `item.index?.url` | ancestor has a name and no URL, so `docsTrail()` drops it |
| sidebar | `node.index ? SidebarFolderLink : SidebarFolderTrigger` | section header is inert text; the overview page sits below it as a child |

## Re-derived on current `origin/main` (not inherited from the card)

Measured by driving the real pinned `fumadocs-core` loader over `content/docs`
and applying both consumers to the resulting tree.

- **17 of 35** `meta.json` files list `"index"` — unchanged from the card.
- **172 short trails**, and the per-top-folder breakdown matches the card's
  production-build numbers row for row (ai 8 · api 11 · automation 9 ·
  capabilities 10 · concepts 5 · data-modeling 17 · deployment 11 ·
  getting-started 8 · kernel 22 · permissions 20 · plugins 4 · protocol 24 ·
  releases 8 · ui 15).
- Page count reads 404 where the card read 403 sitemap URLs; the extra one is
  `/docs` itself, whose trail was already complete. `404 = 232 + 172` against the
  card's `403 = 231 + 172`, so the two harnesses agree exactly.

**After: short trails 172 to 8.** The remaining 8 are every page under
`/docs/releases`.

## Per-file decisions — checked individually, not blanket-edited

`"index"` was the **first** `pages` entry in 15 files and the first entry after
the `---Start Here---` separator in `getting-started`. No file placed it between
other entries, so no entry's position depends on it. Each edit asserted, per
file, that `pages` had exactly one `"index"`, that the resulting array equals the
original minus that one element, and that no other key changed.

`content/docs/releases/meta.json` is **not** touched: `content/docs/releases/` is
fenced by AGENTS.md and by this card's dispatch. It still lists `"index"`, which
is why this is `Part of` and not a closing reference — #12352 stays open for that
one file, and whether it should be swept in a dedicated docs-only PR is the
maintainer's call.

## Sidebar — verified rendered, before and after

The ruling requires the sidebar, not only the JSON-LD. Captured from a running
dev server, with `content/docs` reverted to this branch's parent commit for the
"before" pass and restored from `HEAD` afterwards (`git diff HEAD` empty, blob
hashes back to the `HEAD` blobs).

`/docs/getting-started/glossary`, sidebar entries in document order:

```
-FOLDER-TRIGGER | Get Started | None
+FOLDER-LINK    | Get Started | /docs/getting-started
 separator      | Start Here  | None
-link           | What is ObjectStack? | /docs/getting-started
 link           | How AI Development Works | /docs/getting-started/how-ai-development-works
```

`/docs/data-modeling/objects`:

```
-FOLDER-TRIGGER | Data Modeling | None
-link           | Data Modeling | /docs/data-modeling
+FOLDER-LINK    | Data Modeling | /docs/data-modeling
 link           | Schema Design | /docs/data-modeling/schema-design
```

`FOLDER-LINK | Reference | /docs/references` renders identically in both passes —
a folder that never listed `"index"`, i.e. the control.

Over the whole tree the delta is exactly **16 headers `TRIGGER` to `LINK` plus 16
index children leaving the child list, and nothing else**: every removed child's
URL is now its folder header's `href` (set equality, checked mechanically), and
no other line moved in either direction. `SidebarFolderLink` still renders the
collapse chevron, so no section loses collapsibility.

Six of the 16 removed a child whose label was **identical** to the section header
(`Automation`, `What Can It Do?`, `Core Concepts`, `Data Modeling`,
`Kernel & Services`, `Permissions & Identity`) — a duplicate row, now gone. The
other ten swap the page title for the folder title on the same link:

| link | sidebar label before | after |
| --- | --- | --- |
| `/docs/getting-started` | What is ObjectStack? | Get Started |
| `/docs/ui` | UI Engine | Views & Apps |
| `/docs/plugins` | Plugin System | Plugins & Packages |
| `/docs/protocol/kernel` | Kernel: The System Protocol | System Protocol |
| `/docs/protocol` | Protocol Specification | Protocol Spec |
| `/docs/deployment` | Deployment Overview | Deployment & Operations |
| `/docs/kernel/runtime-services` | Runtime Service APIs | Runtime Services |
| `/docs/kernel/contracts` | Service Contracts Overview | Service Contracts |
| `/docs/ai` | AI Overview | AI |
| `/docs/api` | API Overview | API & SDK |

No folder is judged worse: the page stays in the sidebar at the same tree
position, one click away, and this is already how the 18 folders that never
listed `"index"` render (`references`, `protocol/objectql`, `protocol/objectui`,
…). `/docs/getting-started` is the widest label gap and is flagged for review
rather than decided here.

## Breadcrumb — rendered `BreadcrumbList`, after

```
/docs/data-modeling/objects           ObjectStack > Documentation > Data Modeling(/docs/data-modeling) > Object Metadata
/docs/getting-started/glossary        ObjectStack > Documentation > Get Started(/docs/getting-started) > Glossary
/docs/protocol/objectql/query-syntax  ObjectStack > Documentation > Protocol Spec(/docs/protocol) > Data Protocol(/docs/protocol/objectql) > Query Syntax
/docs/releases/v17                    ObjectStack > Documentation > v17.0.0                              (still short — fenced folder)
```

The first is the card's own example, which shipped three crumbs with the section
missing. The third is the card's control: it was already linking
`/docs/protocol/objectql` and now also links `/docs/protocol`, because
`content/docs/protocol/meta.json` listed `"index"` too.

## One comment-only edit outside `content/`

`apps/docs/app/[lang]/docs/[[...slug]]/page.tsx` carries a doc comment that
states this defect as live and quantifies it ("17 of the 35 …", "172 of 403 …").
Landing this would make that text false, so the paragraph is rewritten to the
post-fix state and to name the one folder still affected. **No executable line
changes** — every changed line in that file starts with ` *`, checked
mechanically. The ⛔ fence against reconstructing the URL consumer-side is kept
verbatim and is untouched.

## Verification

At `1a5ba4fa4`, the branch head:

- The 43 gate families `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
  derives for this change set: **42 green, 1 NOT MEASURED**. The exception is
  `scripts/check-test-completeness.mjs`, which grades a saved `turbo run test`
  log and exits 3 with `PREREQUISITE NOT MET` when the family names it with no
  argument — its own header says to record it as NOT MEASURED locally. Three
  gates first returned `PREREQUISITE NOT MET` for unbuilt workspace packages
  (`@objectstack/formula`, `@objectstack/lint`, `packages/spec/json-schema`) and
  one for a missing `@objectstack/client-react` build; all four were rebuilt and
  re-run green, and none of those first readings is reported as a result.
- `pnpm lint` (`eslint . --no-inline-config`, whole repo, no narrowing) — clean.
- `pnpm --filter @objectstack/docs run typecheck`
  (`fumadocs-mdx && next typegen && tsc --noEmit`) — clean.
- `node scripts/check-section-landing-index.mjs` green, and by construction: that
  gate already filters `'index'` out of the `pages` array it reads, so the
  landing-page index blocks are unaffected.

Every exit code was captured before any pipe.

## Not in scope

The inbound-links work from the sibling card of the same sweep is untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_

---
_Generated by [Claude Code](https://claude.ai/code)_