### PR TITLE
fix(hooks): align both guard-main-checkout remediation recipes to the prescribed worktree form

### DIFF
--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -533,6 +533,14 @@ for seg in "${segments[@]}"; do
       [ "${abs#/}" = "$abs" ] && abs="$cwd/$t"
       root="$(git -C "$(dirname "$abs")" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$abs")"
       name="$(basename "$root")"
+      # ⭐ The recipe printed below is the HIGHEST-leverage copy of AGENTS.md PD#11's
+      # worktree recipe: it reaches an agent at the exact moment it is about to create one,
+      # so an agent following it lands wherever this string points. Keep it aligned with the
+      # prescribed form there — both halves are adjudicated, and this copy carried NEITHER
+      # until #13663: `git fetch origin main` first (an unfetched local `main` bases the new
+      # tree on a stale commit — the ui#6208 class), and `--no-track` on the add (plain `-b`
+      # writes branch.NAME.remote/merge into the .git/config that every worktree of this repo
+      # SHARES — the #13052 / ui#6880 class). Its twin lives in guard-main-checkout.sh.
       cat >&2 <<EOF
 ⛔ Blocked: this Bash command WRITES into the shared PRIMARY checkout, not a worktree.
    command: $offending
@@ -545,7 +553,7 @@ only, so the identical edit expressed as a shell command used to slip through in
 switched and its tree reset under you, clobbering uncommitted work. A feature branch on
 the shared checkout is NOT enough; you need a dedicated worktree:
 
-  git worktree add ../${name}-<task> -b <branch> main
+  git fetch origin main && git worktree add --no-track ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run the command there
 
 Always fine, no flag needed:

--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -46,6 +46,14 @@ esac
 root="$(git -C "$d" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$d")"
 branch="$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
 name="$(basename "$root")"
+# ⭐ The recipe printed below is the HIGHEST-leverage copy of AGENTS.md PD#11's worktree
+# recipe: it reaches an agent at the exact moment it is about to create one, so an agent
+# following it lands wherever this string points. Keep it aligned with the prescribed form
+# there — both halves are adjudicated, and this copy carried NEITHER until #13663:
+#   `git fetch origin main` first — an unfetched local `main` bases the new tree on a stale
+#     commit (the ui#6208 class).
+#   `--no-track` on the add — plain `-b` writes branch.NAME.remote/merge into the .git/config
+#     that every worktree of this repo SHARES (the #13052 / ui#6880 class).
 cat >&2 <<EOF
 ⛔ Blocked: editing on the shared PRIMARY checkout, not a worktree.
    repo: $root  (branch: $branch)
@@ -54,7 +62,7 @@ This repo is edited by multiple agents at once — the shared checkout gets its 
 switched and tree reset under you, silently clobbering uncommitted work. A feature
 branch on the shared checkout is NOT enough; you must be in a dedicated worktree:
 
-  git worktree add ../${name}-<task> -b <branch> main
+  git fetch origin main && git worktree add --no-track ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run your edits there
 
 This guard checks the edited file's OWN repo, so sibling repos are covered too.


### PR DESCRIPTION
Fixes #13663

Both `guard-main-checkout` hooks printed the **unhardened** worktree recipe as their remediation text — the copy an agent reads at the exact moment it is blocked, and therefore the highest-leverage copy of the recipe in the repo. It carried two hazards, both already adjudicated and both already hardened in `AGENTS.md` Prime Directive 11 and in `CLAUDE.md`; only these two copies were left behind.

- **No `--no-track`** — plain `-b` writes `branch.NAME.remote` / `branch.NAME.merge` into the `.git/config` that every worktree of the repo SHARES (the 13052 / ui 6880 adjudications).
- **Based on local `main`, with no fetch** — an unfetched local `main` bases the new tree on a stale commit (the ui 6208 adjudication).

## What changed

Two files, one printed line each, plus a comment above each heredoc recording why both halves are load-bearing so the next reader does not "simplify" them back out.

- `.claude/hooks/guard-main-checkout.sh` (the `Edit`/`Write`/`NotebookEdit` guard)
- `.claude/hooks/guard-main-checkout-bash.sh` (the same write arriving through `Bash`)

Each file's own `${name}` interpolation is preserved verbatim — the printed recipe is now, in both:

```
git fetch origin main && git worktree add --no-track ../${name}-<task> -b <branch> origin/main
cd ../${name}-<task> && pnpm install    # then re-run your edits there
```

## What was measured, not assumed

**Premise re-derived on a freshly fetched tree** (not taken from the card): the bad string sits at `guard-main-checkout.sh:57` and `guard-main-checkout-bash.sh:548`, and `grep -c "no-track"` over both files returns `0` / `0`. Both hold.

**No selftest case pinned the old string.** The card anticipated one might. Grepping both selftest matrices — and then the whole tree — for every fragment of the remediation block (`-b <branch>`, `re-run your edits there`, `re-run the command there`, `dedicated worktree:`) puts the only two occurrences in the hooks themselves. Nothing else asserts on this text, so nothing else needed updating. The two selftests that do cover these hooks are `guard-main-checkout.selftest.sh` and `guard-main-checkout-bash.selftest.sh` (the stash guard's matrix is a different hook's); both were re-run:

```
guard-main-checkout.selftest.sh        87 passed, 0 failed
guard-main-checkout-bash.selftest.sh  121 passed, 0 failed
```

The bash guard's 121 matches the baseline `lint.yml` records for it on `main`, so the matrix neither shrank nor grew. CI runs both anyway — the `Claude hook guard self-tests` step discovers `.claude/hooks/**/*.selftest.sh` at run time.

**The remediation actually renders.** A string inside a heredoc is only correct if it survives interpolation, so each hook was driven end to end against the shared primary checkout and its stderr read:

```
⛔ Blocked: editing on the shared PRIMARY checkout, not a worktree.
   repo: /home/user/objectstack  (branch: claude/pm-dispatch-skills-9th9j4)
...
  git fetch origin main && git worktree add --no-track ../objectstack-<task> -b <branch> origin/main
  cd ../objectstack-<task> && pnpm install    # then re-run your edits there
```

Exit code 2 preserved in both, `${name}` expands to the repo basename, and the bash guard's escaped `\$HOME` in the "always fine" list is still escaped.

## Gates

Derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (which reads its own change set from the merge base — no hand-built path list), then run at the final commit `51007325`. Exit codes captured with a redirect before the read, never through a pipe:

| gate | exit |
| --- | --- |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:bash32-floor` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:skill-frame-sync` | 0 |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| `pnpm check:nul-bytes` (any edit) | 0 |

`check:bash32-floor` is the one that reads these files as shell: *"24 tracked shell file(s) under `scripts/**`, `.claude/hooks/**`, `.githooks/**` name no bash 4+ construct…"*. `check:doc-formula-expressions` first answered `PREREQUISITE NOT MET — @objectstack/formula is not built`, then the same for `@objectstack/lint`; that is a not-measured reading, not a red gate, so both packages were built and the gate re-run to a real `0`.

**ESLint** (`pnpm lint`, which CI runs unconditionally) was **not** run repo-wide, and this is a declared narrowing with all three pieces of evidence:

1. Population, read from `eslint.config.mjs` rather than guessed: `files: ['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}']`. `.sh` is not in it.
2. Count, measured by ESLint itself via `--format json` over exactly the two changed paths: 2 results, **0 errors**, 2 warnings, both `"File ignored because no matching configuration was supplied."` — i.e. this diff contributes **zero** files to ESLint's population.
3. Invariance for untouched files: the diff changes no JS/TS and does not touch `eslint.config.mjs`, and a shell file cannot enter a type-aware program, so every untouched file's verdict is identical to `main`'s.

## No changeset

This diff is `.claude/**` only and publishes nothing from any package, so it takes the `skip-changeset` route. Verified against recent `main` history rather than recalled — the last three `.claude/**`-only landings (`5364d2e5`, `f4d53081`, and the `.claude/**` half of `3d089745`) carry no `.changeset/*.md`, and `pr-automation.yml`'s Check Changeset job re-reads labels live and exempts on an exact-match `skip-changeset`. The label is applied to this PR.

## Governed surface

`.claude/**` is governed surface: this PR stays **draft** and is for **human merge only**. Not marked ready, no auto-merge, not enqueued.

## Out of scope, filed separately

The same unhardened recipe survives in four more agent-facing copies (`.claude/skills/checklist-author/SKILL.md`, `.claude/agents/os-dev.md`, `.claude/skills/dogfood-verification/SKILL.md`, and the published `skills/objectstack-pm-dispatch/SKILL.md`). Those are a different file surface, one of them is a published skill with its own budget rules, and this card's claim declared the two hook files — so they are filed rather than ridden along here. The objectui twin (ui 6977) is being handled in that repo by another dev; nothing here touches `objectui`.

Refs: 13663 · ui 6976 · 13052 / ui 6880 · ui 6208.

_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_