### PR TITLE
docs(skills): objectstack-query factual sweep — 17 false behavioral claims corrected, -33 lines

### DIFF
--- a/skills/objectstack-query/SKILL.md
+++ b/skills/objectstack-query/SKILL.md
@@ -22,14 +22,10 @@ Expert instructions for constructing data queries using the ObjectStack
 Query DSL. This skill covers filter expressions, sorting, pagination,
 aggregation, full-text search, and the expand system for related records.
 
-**Schema vs. runtime:** the `QueryAST` schema declares more than the engine
-currently executes. Sections below marked
-
-> ⚠️ **Schema-reserved — NOT executed by the engine yet.**
-
-describe properties that validate against the schema but are silently
-ignored (or rejected) at runtime. Never emit them in production queries —
-each caveat shows the working alternative.
+**Schema vs. runtime:** every callout below says which side a property is on —
+⛔ **REMOVED** (tombstoned; a query carrying it fails to parse), ⚠️ **not
+enforced** (validates, then silently ignored — never emit it), ✅ **Enforced**.
+Each removal callout names the live replacement.
 
 ---
 
@@ -217,13 +213,12 @@ Filter through relationships without an explicit join:
 
 ### Field References (Cross-Field Comparisons)
 
-> ⚠️ **Schema-reserved — NOT executed by the engine yet.** `$field` exists
-> only in the filter schema. No engine or driver code interprets it — the
-> `{ $field: '...' }` object binds as a **literal value**, so the query
-> silently returns zero rows. Do not use it.
+> ✅ **Enforced.** A `{ $field: '...' }` comparand compares two columns of the
+> same row. The in-memory evaluator resolves the reference against the record;
+> `driver-sql` pushes it down as a column-to-column predicate. Same rows.
 
 ```typescript
-// ❌ Schema-valid but NOT executed — matches nothing
+// ✅ Accounts whose actual revenue beat the estimate
 {
   where: {
     actual_revenue: { $gt: { $field: 'estimated_revenue' } }
@@ -231,11 +226,9 @@ Filter through relationships without an explicit join:
 }
 ```
 
-**Working alternatives:**
-- Define a **formula field** on the object that computes the comparison
-  (e.g. `exceeds_estimate` as a boolean), then filter on it:
-  `{ where: { exceeds_estimate: true } }` (see **objectstack-data**).
-- Fetch both fields and compare in **application code**.
+Legal in a **comparison** position only. As an `$in` / `$nin` member or a
+`$between` endpoint it is refused at parse — no evaluation path resolves a
+reference there.
 
 ---
 
@@ -331,12 +324,11 @@ unique or near-unique column such as `created_at` or `id`) so
 | `max` | Maximum | `MAX(field)` |
 | `count_distinct` | Unique count | `COUNT(DISTINCT field)` |
 
-> ⚠️ **Driver support varies.** On SQL datasources the driver executes only
-> `count` / `sum` / `avg` / `min` / `max` and **throws** on `count_distinct`;
-> the per-aggregation `distinct: true` flag is also ignored there. The
-> in-memory fallback path (driver-rest, driver-memory, timezone/date-bucket
-> fallbacks) supports all six functions plus `distinct`. For portable queries,
-> stick to the first five.
+> ✅ **All six are portable.** `count_distinct` lowers to `COUNT(DISTINCT x)`
+> on every SQL face and computes identically on the in-memory path, so the
+> declared-but-uncompiled set is empty. The per-aggregation `distinct: true`
+> flag went the other way — **removed in 17**, refused at parse; the live
+> spelling for a deduplicated count is `count_distinct`.
 
 > **Removed in 17.** `array_agg` and `string_agg` left this vocabulary:
 > declared but lowered by no SQL backend, so whether they worked depended on
@@ -387,25 +379,23 @@ const rows = await engine.aggregate('deal', {
 
 ### Filtered Aggregation
 
-> ⚠️ **Per-aggregation `filter` is schema-reserved — NOT executed by the
-> engine yet.** The SQL driver ignores it and the in-memory path ignores it
-> too, so a `filter`-carrying aggregation returns the **unfiltered** number —
-> silently wrong results. **Working alternative:** issue one aggregate call
-> per condition, moving the condition into the query-level `where`:
+> ✅ **Enforced.** A per-aggregation `filter` scopes that one measure, so a
+> total and a conditional count share one call. Any aggregation carrying a
+> non-empty `filter` forces the in-memory path — no driver compiles a
+> conditional aggregate, and one reached directly refuses `NOT_IMPLEMENTED`;
+> unfiltered aggregations keep native push-down.
 
 ```typescript
-// ❌ filter on the aggregation is silently ignored
-// { function: 'count', alias: 'high_value_orders',
-//   filter: { amount: { $gt: 1000 } } }
-
-// ✅ Separate aggregate calls, condition in `where`
-const [totals] = await engine.aggregate('order', {
-  aggregations: [{ function: 'count', alias: 'total_orders' }],
+// ✅ Total and conditional counts in ONE call
+const [kpis] = await engine.aggregate('order', {
+  aggregations: [
+    { function: 'count', alias: 'total_orders' },
+    { function: 'count', alias: 'high_value_orders',
+      filter: { amount: { $gt: 1000 } } },
+  ],
 });
-const [highValue] = await engine.aggregate('order', {
-  where: { amount: { $gt: 1000 } },
-  aggregations: [{ function: 'count', alias: 'high_value_orders' }],
-});
+// An unknown operator inside `filter` refuses INVALID_FILTER/400 — it never
+// silently answers the unfiltered number.
 ```
 
 ---
@@ -475,10 +465,10 @@ Load related records through lookup/master_detail fields:
 
 Only the **`query` + `fields`** subset of the search schema executes. The
 engine expands the search string into a driver-agnostic filter: each term
-becomes an `$or` of `$contains` predicates across the resolved searchable
-fields, and multiple whitespace-separated terms are **AND-ed** (every term
-must hit some field). Matching is case-insensitive; `select`/`status`
-fields match by option *label*, mapped to stored values.
+becomes an `$or` of `$icontains` predicates (the case-INSENSITIVE twin of the
+case-sensitive `$contains`) across the resolved searchable fields, and multiple
+whitespace-separated terms are **AND-ed** (every term must hit some field).
+`select`/`status` fields match by option *label*, mapped to stored values.
 
 ```typescript
 {
@@ -491,8 +481,8 @@ fields match by option *label*, mapped to stored values.
 }
 // Executes as:
 // { $and: [
-//   { $or: [{ title: { $contains: 'machine' } }, { content: { $contains: 'machine' } }] },
-//   { $or: [{ title: { $contains: 'learning' } }, { content: { $contains: 'learning' } }] },
+//   { $or: [{ title: { $icontains: 'machine' } }, { content: { $icontains: 'machine' } }] },
+//   { $or: [{ title: { $icontains: 'learning' } }, { content: { $icontains: 'learning' } }] },
 // ]}
 ```
 
@@ -529,19 +519,18 @@ maintained on write and listed in `task.searchableFields`:
   limit: 20,
 }
 // Expands to a single-table scan — no traversal, every driver:
-// { $and: [{ $or: [
-//   { name:         { $contains: 'apollo' } },
-//   { project_name: { $contains: 'apollo' } },
-// ]}]}
+// { $or: [
+//   { name:         { $icontains: 'apollo' } },
+//   { project_name: { $icontains: 'apollo' } },
+// ]}
 ```
 
 ❌ The mirror must be a **stored** field — a `formula` field is virtual, no
-driver materializes a column for it, so a `$contains` predicate against one has
-nothing to scan. Nothing rejects the mistake for you: `searchableFields` admits
-any field the object declares, so a formula entry clears both lint and the
-ingress gate and then never matches. The trade-off is mirror maintenance — hooks
-on both write paths (child re-parented, parent renamed) plus a backfill for rows
-written around the hooks.
+driver materializes a column for it, so a search predicate against one has
+nothing to scan. Two guards catch that: lint errors on a virtual
+`searchableFields` entry, and the ingress gate refuses one by name. The
+trade-off is mirror maintenance — hooks on both write paths (child re-parented,
+parent renamed) plus a backfill for rows written around the hooks.
 
 Cross-object search paths are rejected by design, not pending. Modelling side of
 this (the field, the hooks, the lint wording): **objectstack-data → Search Fields
@@ -606,24 +595,20 @@ use [`expand`](#expand-related-records).
 
 ### Dashboard Aggregation Pattern
 
-Unconditional KPIs can share one aggregate call; a KPI with its own
-condition needs a **separate call** with the condition in `where`
-(per-aggregation `filter` is schema-reserved — see Filtered Aggregation):
+Every KPI on a dashboard shares **one** aggregate call — unconditional
+measures plain, conditional ones carrying their own `filter`. `where` scopes
+the whole call, so reach for it only when every measure wants the same scope:
 
 ```typescript
-// KPI dashboard: unconditional aggregations share one call
+// KPI dashboard: one call, conditional measures scoped per aggregation
 const [kpis] = await engine.aggregate('deal', {
   aggregations: [
     { function: 'count', alias: 'total_deals' },
     { function: 'sum', field: 'amount', alias: 'pipeline_value' },
     { function: 'avg', field: 'amount', alias: 'avg_deal_size' },
+    { function: 'count', alias: 'won_deals',
+      filter: { stage: 'closed_won' } },
   ],
-});
-
-// Conditional KPI: separate call, condition in `where`
-const [won] = await engine.aggregate('deal', {
-  where: { stage: 'closed_won' },
-  aggregations: [{ function: 'count', alias: 'won_deals' }],
 });
 ```
 
@@ -636,9 +621,9 @@ code — the renderer issues the queries for you:
 
 | Query Need | Pattern |
 |:--|:--|
-| KPI widgets | Aggregates (`sum`, `count`, `avg`) over the object, each conditional KPI scoped by the widget/dataset filter. Add `compareTo: 'previousPeriod' \| 'previousYear'` on the widget for a one-line period-over-period delta. |
-| Time-series chart | Date filters + `categoryGranularity: 'day' \| 'week' \| 'month' \| 'quarter' \| 'year'` for server-side bucketing — never bucket by hand on the client. Pair with `compareTo` for an aligned YoY overlay. |
-| Matrix report | `groupingsDown` + `groupingsAcross` + `dateGranularity: 'quarter'` |
+| KPI widgets | Aggregates (`sum`, `count`, `avg`) over the object, each conditional KPI scoped by the widget/dataset filter. Add `compareTo: { kind: 'previousPeriod' \| 'previousYear' }` on the widget for a one-line period-over-period delta (the bare string form was removed in 17). |
+| Time-series chart | Date filters + `dateGranularity: 'day' \| 'week' \| 'month' \| 'quarter' \| 'year'` on the widget's dataset selection for server-side bucketing — never bucket by hand on the client. Pair with `compareTo` for an aligned YoY overlay. |
+| Matrix report | Dataset-bound `rows` (down) + `columns` (across) + a `dateGranularity` dimension |
 | Funnel summary | Multi-level grouping (`owner -> stage`) + aggregated measures |
 | Operational filter | Prefer declarative operators (`$ne`, `$nin`, `$gte`) over hardcoded SQL |
 

--- a/skills/objectstack-query/evals/README.md
+++ b/skills/objectstack-query/evals/README.md
@@ -17,18 +17,17 @@ subset the engine actually executes.
    manual keyset pagination (`where` on the sort key + `orderBy` + `limit`);
    fail if the answer uses the removed `cursor` property.
 4. **Aggregation correctness** — "Count deals by region and show total
-   revenue." Expect `groupBy` + `count`/`sum` with aliases; on SQL targets
-   the answer must stay within `count`/`sum`/`avg`/`min`/`max`.
-5. **The FILTER-WHERE trap** — "One call: total orders and count of orders
-   over $1000." The correct answer is **two** aggregate calls with the
-   condition in `where`; fail if the answer puts `filter` on an aggregation
-   (silently returns the unfiltered number).
+   revenue." Expect `groupBy` + `count`/`sum` with aliases; fail on a missing
+   `alias`, or on `array_agg`/`string_agg` (removed in protocol 17).
+5. **Filtered aggregation** — "One call: total orders and count of orders
+   over $1000." Expect one call with a per-aggregation `filter` on the
+   conditional measure; fail on `where`, which scopes every measure.
 6. **Post-aggregation filtering** — "Customers with more than 5 orders."
-   Expect aggregate + app-code filter of the group rows; fail on `having`
-   (schema-reserved, silently dropped).
+   Expect `having` on the aggregation alias; fail on `where`, which filters
+   input rows before the alias exists.
 7. **Date-bucketed time series** — "Monthly revenue for the last year."
    Expect structured `groupBy` with `dateGranularity: 'month'`, not
-   client-side bucketing and not window functions (schema-reserved).
+   client-side bucketing and not `windowFunctions` (removed in protocol 17).
 8. **Expand vs direct query** — "Show a task list with assignee names; page
    through one project's tasks." Expect `expand` for the lookup display and
    a direct query on the related object for pagination (nested

--- a/skills/objectstack-query/rules/aggregation.md
+++ b/skills/objectstack-query/rules/aggregation.md
@@ -13,12 +13,11 @@ Guide for building ObjectStack aggregation queries.
 | `max` | `MAX(field)` | Maximum value | Yes |
 | `count_distinct` | `COUNT(DISTINCT field)` | Count unique values | Yes |
 
-> ⚠️ **Driver support varies.** On SQL datasources the driver executes only
-> `count` / `sum` / `avg` / `min` / `max` and **throws** (`Unsupported
-> aggregate function`) on `count_distinct`; the per-aggregation
-> `distinct: true` flag is also ignored there. The in-memory aggregation path
-> (driver-rest, driver-memory, timezone/date-bucket fallbacks) supports all six
-> functions plus `distinct`. For portable queries, stick to the first five.
+> ✅ **All six are portable.** `count_distinct` lowers to `COUNT(DISTINCT x)`
+> on `driver-sql` and turso's remote transport, and `driver-mongodb` /
+> `driver-memory` compute it too, so the declared-but-uncompiled set is empty.
+> The per-aggregation `distinct: true` flag went the other way — **removed in
+> 17**, refused at parse. For a deduplicated count, use `count_distinct`.
 
 > **Removed in 17.** `array_agg` and `string_agg` are no longer part of
 > the vocabulary — they were declared and lowered by no SQL backend, so a query
@@ -118,51 +117,38 @@ use `where` to shrink the scan, `having` to threshold the aggregates.
 
 ## Filtered Aggregation (FILTER WHERE)
 
-> ⚠️ **Per-aggregation `filter` is schema-reserved — NOT executed by the
-> engine yet.** The SQL driver never reads it and the in-memory path ignores
-> it, so the aggregation returns the **unfiltered** number — silently wrong
-> results. **Working alternative:** one aggregate call per condition, with
-> the condition in the query-level `where`:
+> ✅ **Enforced.** A per-aggregation `filter` scopes that one measure, so a
+> total and a conditional count share ONE call. Any aggregation carrying a
+> non-empty `filter` forces the in-memory path — no driver compiles a
+> conditional aggregate, and one reached directly refuses `NOT_IMPLEMENTED`;
+> unfiltered aggregations keep native push-down.
 
 ```typescript
-// ❌ filter on the aggregation is silently ignored — active_count
-//    would equal total!
-// { function: 'count', alias: 'active_count', filter: { status: 'active' } }
-
-// ✅ Separate aggregate calls, condition in `where`
-const [totals] = await engine.aggregate('user', {
-  aggregations: [{ function: 'count', alias: 'total' }],
+// ✅ Total and conditional count in one call
+const [row] = await engine.aggregate('user', {
+  aggregations: [
+    { function: 'count', alias: 'total' },
+    { function: 'count', alias: 'active_count', filter: { status: 'active' } },
+  ],
 });
-const [active] = await engine.aggregate('user', {
-  where: { status: 'active' },
-  aggregations: [{ function: 'count', alias: 'active_count' }],
-});
+// An unknown operator inside `filter` refuses INVALID_FILTER/400 — it never
+// silently answers the unfiltered number.
 ```
 
 ## DISTINCT Aggregation
 
-> ⚠️ **Not available on SQL datasources.** `count_distinct` **throws** on the
-> SQL driver, and the `distinct: true` flag is silently ignored there (see
-> the driver-support caveat above). Both forms work only on the in-memory
-> aggregation path. On SQL, get a distinct count by grouping on the field
-> and counting the result rows in app code:
-> `(await engine.aggregate('employee', { groupBy: ['department'], aggregations: [{ function: 'count', alias: 'n' }] })).length`.
+> ✅ **`count_distinct` runs everywhere** — `COUNT(DISTINCT field)` on the SQL
+> faces, the same answer in memory. `field` is REQUIRED; there is no
+> `COUNT(DISTINCT *)`. The per-aggregation `distinct: true` flag is NOT its
+> equivalent: **removed in 17**, refused at parse, because exactly one of the
+> six backends that read an aggregation ever honoured it.
 
 ```typescript
-// In-memory drivers only:
 // SQL: SELECT COUNT(DISTINCT department) FROM employee
 {
   object: 'employee',
   aggregations: [
     { function: 'count_distinct', field: 'department', alias: 'dept_count' }
-  ]
-}
-
-// Alternative (also in-memory only): use distinct flag
-{
-  object: 'employee',
-  aggregations: [
-    { function: 'count', field: 'department', alias: 'dept_count', distinct: true }
   ]
 }
 ```

--- a/skills/objectstack-query/rules/filters.md
+++ b/skills/objectstack-query/rules/filters.md
@@ -99,23 +99,20 @@ where: {
 
 ## Field References
 
-> ⚠️ **`$field` is schema-reserved — NOT executed by the engine yet.** It
-> exists only in the filter schema; no engine or driver code interprets it,
-> so the `{ $field: '...' }` object binds as a **literal value** and the
-> query silently returns zero rows.
+> ✅ **Enforced.** `{ $field: '...' }` compares two columns of the same row.
+> The in-memory evaluator resolves the reference against the record; the SQL
+> driver pushes it down as a column-to-column predicate. Same rows either way.
 
 ```typescript
-// ❌ Schema-valid but NOT executed — matches nothing
+// ✅ Projects that ran over budget
 where: {
   actual_cost: { $gt: { $field: 'budget' } }
 }
 ```
 
-**Working alternatives:**
-- Define a **formula field** that computes the cross-field comparison
-  (e.g. a boolean `over_budget`), then filter on it:
-  `where: { over_budget: true }` (see **objectstack-data**).
-- Fetch both fields and compare in **application code**.
+Legal in a **comparison** position only. As an `$in` / `$nin` member or a
+`$between` endpoint it is refused at parse — no evaluation path resolves a
+reference there.
 
 ## Nested Relation Filters
 
@@ -188,15 +185,16 @@ where: {
 }
 ```
 
-### ❌ Wrong: Null check with equality
+### ⚠️ Prefer `$null` to a bare `null` comparand
 
 ```typescript
-// ❌ Don't use equality to check for null
+// ⚠️ Works — a bare null lowers to IS NULL on both paths — but it reads
+//    as "equals null" and has no IS NOT NULL spelling
 where: {
   deleted_at: null
 }
 
-// ✅ Use $null operator
+// ✅ Explicit, and `$null: false` is IS NOT NULL
 where: {
   deleted_at: { $null: true }
 }

--- a/skills/objectstack-query/rules/pagination.md
+++ b/skills/objectstack-query/rules/pagination.md
@@ -215,14 +215,13 @@ When building paginated REST endpoints:
 
 ## DISTINCT Queries
 
-> ⚠️ **The top-level `distinct: true` flag is schema-reserved — NOT executed
-> by the engine yet.** Neither the engine nor the SQL driver reads it from a
-> `QueryAST`; the query returns duplicate rows as if the flag were absent.
-> **Working alternative:** group by the fields — each unique combination
-> becomes one result row:
+> ⛔ **`query.distinct` was REMOVED in `@objectstack/spec` 17.** No driver ever
+> rendered `SELECT DISTINCT`. The key is tombstoned — a query carrying it fails
+> to parse with the prescription — and `QueryBuilder.distinct()` is gone. Group
+> by the fields instead: each unique combination becomes one result row.
 
 ```typescript
-// ❌ distinct is silently ignored
+// ❌ tombstoned — this query is refused at parse
 // { object: 'order', fields: ['customer_id', 'product_category'], distinct: true }
 
 // ✅ groupBy collapses duplicates


### PR DESCRIPTION
Fixes #13717
Part of #13658

Flight ③ of the published-skills factual sweep: every behavioral claim in
`skills/objectstack-query/**` verified against the implementation, with executed
probes wherever a claim is behavior-bearing. Method per #13658 comments
5474435934 / 5474464789 / 5475032239 (content-class targeting first, both error
directions, cross-file contradiction scan first).

**Governed surface — draft, human merge only.** No ratchet ceiling raised.

## Budget

| | before | after | delta |
|---|---|---|---|
| package lines (6 files) | 1,550 | 1,517 | **−33** |
| ratcheted tokens (5 files) | 12,007 | 11,752 | **−255** |
| SKILL.md | 673 ln / 5,552 tok | 658 ln / 5,443 tok | −15 ln / −109 tok |
| rules/aggregation.md | 278 / 2,357 | 264 / 2,226 | −14 / −131 |
| rules/filters.md | 292 / 2,149 | 290 / 2,144 | −2 / −5 |
| rules/pagination.md | 233 / 1,382 | 232 / 1,381 | −1 / −1 |
| evals/README.md | 39 / 567 | 38 / 558 | −1 / −9 |
| references/_index.md | 35 (generator-owned) | 35 | 0 |

Every ceiling is shrink-only and every file came in under it. `references/_index.md`
was verified (all nine schema paths resolve at `origin/main`) and needed no edit.

## Corrections — 落点 | before | after

**17 FALSE claims corrected. 11 of the 17 are the deader-than-real direction** — the
docs marked a shipped capability dead or unreachable. That matches flight ②'s
majority finding.

| # | 落点 | before (claimed) | after (measured) |
|---|---|---|---|
| 1 | `SKILL.md` Field References | `$field` "schema-reserved — NOT executed… binds as a **literal value**, so the query silently returns zero rows" | ✅ Enforced. In-memory evaluator resolves the reference; `driver-sql` pushes it down. Comparison position only — `$in`/`$nin` member and `$between` endpoint refused at parse |
| 2 | `rules/filters.md` Field References | same claim, plus two "working alternatives" for a working feature | same correction; alternatives deleted |
| 3 | `SKILL.md` aggregation driver-support callout | SQL driver "**throws** on `count_distinct`"; "stick to the first five" | ✅ All six portable — `COUNT(DISTINCT x)` on every SQL face; declared-but-uncompiled set is empty |
| 4 | `rules/aggregation.md` same callout | same, quoting the error text `Unsupported aggregate function` | same correction; that error string has **zero** occurrences repo-wide |
| 5 | `SKILL.md` aggregation callout | per-aggregation `distinct: true` "is also ignored there" | removed in 17, refused at parse — not ignored |
| 6 | `rules/aggregation.md` same | same | same |
| 7 | `SKILL.md` Filtered Aggregation | per-aggregation `filter` "schema-reserved… returns the **unfiltered** number — silently wrong results" | ✅ Enforced since the contract half of the 2026-08-21 ruling; forces the in-memory path; unknown operator inside it refuses `INVALID_FILTER`/400 |
| 8 | `rules/aggregation.md` Filtered Aggregation | same, with `active_count would equal total!` | same correction |
| 9 | `SKILL.md` Dashboard Aggregation Pattern | "a KPI with its own condition needs a **separate call**" | one call, conditional measures carry their own `filter` |
| 10 | `rules/aggregation.md` DISTINCT Aggregation | "Not available on SQL datasources"; and an example using the tombstoned `distinct: true` flag presented as a **working alternative** | `count_distinct` runs everywhere; the non-parsing example deleted |
| 11 | `rules/pagination.md` DISTINCT Queries | top-level `distinct` "schema-reserved… the query returns duplicate rows as if the flag were absent" | ⛔ REMOVED in 17 — tombstoned, the query is **refused at parse**; `QueryBuilder.distinct()` gone |
| 12 | `SKILL.md` Full-Text Search prose | "each term becomes an `$or` of `$contains` predicates… Matching is case-insensitive" | `$icontains` — `$contains` is contractually case-SENSITIVE, so the old text was self-contradictory |
| 13 | `SKILL.md` two asserted expansion outputs | `{ title: { $contains: … } }`; single-term wrapped in `$and` | `$icontains`; single term is a bare `$or`, no `$and` wrapper |
| 14 | `SKILL.md` formula-mirror paragraph | "Nothing rejects the mistake for you… a formula entry clears both lint and the ingress gate" | both guards exist: a lint rule errors on a virtual `searchableFields` entry, and the ingress gate has a dedicated refusal branch for it |
| 15 | `SKILL.md` CRM blueprint, KPI row | `compareTo: 'previousPeriod' \| 'previousYear'` (bare string) | `compareTo: { kind: … }` — the bare string was removed in 17 with **no acceptance window** |
| 16 | `SKILL.md` CRM blueprint, time-series row | `categoryGranularity` | pre-ADR-0021 removed key; `dateGranularity` on the widget's dataset selection |
| 17 | `SKILL.md` CRM blueprint, matrix row | `groupingsDown` + `groupingsAcross` | removed with the ADR-0021 cutover; dataset-bound `rows` + `columns` |

Plus derived-claim repairs in `evals/README.md` (items 4, 5, 6, 7) whose rubrics
encoded the same falsehoods — item 6 told the model to **fail** an answer using
`having`, which is enforced.

One further correction, a framing rather than a surface claim: `rules/filters.md`
labelled `{ deleted_at: null }` a **❌ Wrong** null check. Measured, a bare `null`
comparand lowers to `IS NULL` on both the in-memory evaluator and the SQL driver
and returns exactly the same rows as `$null: true`. The recommendation to prefer
`$null` is kept (it is the only spelling of `IS NOT NULL`); the false "wrong"
label is not.

## Cross-file contradiction scan (run first, per the method)

Four contradictions inside the package; every one settled against the
implementation, not against the other document:

1. `having` — SKILL.md and `rules/aggregation.md` say ✅ Enforced; `evals/README.md`
   said "schema-reserved, silently dropped". **Implementation: enforced.**
2. `compareTo` — SKILL.md said bare string, `rules/aggregation.md` says
   `{ kind, dimension? }`. **Implementation: the object form; the string is retired.**
3. `windowFunctions` — SKILL.md and `rules/aggregation.md` say REMOVED/tombstoned;
   `evals/README.md` said "schema-reserved". **Implementation: removed.**
4. Per-aggregation `filter` — three files agreed it was inert; **all three were wrong.**
   (Agreement between documents is not evidence — this is the case the method's
   "never verify one document against another" rule exists for.)

## Evidence — executed probes

Non-vacuity control satisfied several times over; every probe below ran a control
that discriminates.

- **`$field` cross-field.** In-memory evaluator over three rows (`over` 200/100,
  `under` 50/100, `equal` 100/100): `$gt` → `["over"]`, `$eq` → `["equal"]`,
  `$lt` → `["under"]`. Control, a plain literal `$gt: 150` on the same harness →
  `["over"]`. Through `SqlDriver` on better-sqlite3, same fixture pushed down:
  `$gt { $field: 'budget' }` → `["over"]`. The claim under test predicted zero rows
  on both paths.
- **`count_distinct` on SQL.** `SqlDriver.aggregate` with
  `{ function: 'count_distinct', field: 'dept', alias: 'n' }` → `[{"n":2}]`.
  Control, an undeclared function `median` on the same driver → threw
  `INVALID_QUERY`/400, so a refusal would have been visible.
- **Per-aggregation `filter`.** `engine.aggregate('deal', …)` over 4 rows
  (2 `closed_won`): `[{"total_deals":4,"won_deals":2}]`. The claim under test
  predicted `won_deals: 4`.
- **`having`.** 4 orders across 3 customers, `having: { order_count: { $gt: 1 } }`
  → `[{"customer_id":"c1","order_count":2}]`. Also confirms `groupBy` auto-selects
  the grouped column without listing it in `fields`.
- **Search expansion.** `expandSearchToFilter('machine learning', …)` →
  `{"$and":[{"$or":[{"title":{"$icontains":"machine"}},{"content":{"$icontains":"machine"}}]},{"$or":[…"learning"…]}]}`;
  single term `'apollo'` → a bare `{"$or":[…]}`.
- **Case sensitivity.** Rows `Apollo`/`apollo`: `$contains: 'apollo'` →
  `["apollo"]`; `$icontains: 'apollo'` → `["Apollo","apollo"]`.
- **Parse oracle, tombstones.** `QuerySchema.safeParse` REJECTS `cursor`, `joins`,
  `windowFunctions`, `distinct`, `aggregations[].distinct`, `array_agg`,
  `string_agg`, and an aggregation with no `alias`; ACCEPTS all six aggregation
  functions, `top`, `having`, `aggregations[].filter`, the fifteen documented filter
  operators, and a `$field` comparand.
- **Parse oracle, analytics.** `DashboardWidgetSchema` REJECTS
  `compareTo: 'previousPeriod'` and `categoryGranularity`, ACCEPTS
  `compareTo: { kind: 'previousPeriod' }`; `ReportSchema` REJECTS
  `groupingsDown`/`groupingsAcross`, ACCEPTS `dataset` + `rows` + `columns` + `values`.
- **Token vocabulary (all VERIFIED).** `isDateMacroToken` LIVE for `today`,
  `yesterday`, `tomorrow`, `now`, `current_month_start`, `last_quarter_end`,
  `next_year_start`, `month_start`, `30_days_ago`, `2_weeks_from_now`,
  `current_year_start`, `current_year_end`; `isContextToken` LIVE for
  `current_user_id`, `current_org_id`; both DEAD for the two near-misses the doc
  names as near-misses (`current_user`, `this_quarter_start`). Parameterised forms
  live for all six declared units in both directions.
- **`$exists` / `$null` (prior art of #13577, re-verified at `origin/main`).**
  Rows valued / null / key-absent: `$exists: true` → `["v"]`; `$null: true` →
  `["n","absent"]`. HAS A VALUE, confirmed; both rows correct as merged.
- **Null comparand.** `{ d: null }` → `["n","absent"]` in memory and `["n"]` on
  SQL — identical to `{ d: { $null: true } }` on each path. `$null: false` → `["v"]`.

Verified without execution, by enumerating the implementation: `MAX_EXPAND_DEPTH = 3`;
`resolveFilterTokens` reached from exactly `find`/`findOne`/`count`/`aggregate`/
`update`/`delete`; `SqlDriver.findWithWindowFunctions()` exists and its builder
emits argument-less `FUNC()` (its own docblock says the skills' aggregation rules
say the same); the six search knobs each carry an `[EXPERIMENTAL — not enforced]`
`.describe()` marker; the `$searchFields` dotted-path refusal text quoted in
SKILL.md matches the ingress gate word for word; the flow-filter rule really is
`severity: inFilter ? 'error' : 'warning'`; `resolveDateMacros` / `resolveContextTokens`
exist in objectui `@object-ui/core`; all four Skill Boundaries targets exist;
`compatibility: @objectstack/spec 17.x (Zod v4)` matches 17.2.0 on zod ^4.4.3.

## Gates

Derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
in the worktree, on a NON-stale tree (the branch was merged up to `origin/main`
`0f911eb9` first — the first derivation warned that `lint.yml` and
`cross-package-test-inputs.mjs`, which are themselves families in the list, were
stale). 13 families, all run at `d601906b`, the final commit:

| gate | exit |
|---|---|
| `node scripts/check-ci-filter-parity.mjs` | 0 |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 |
| `node scripts/check-shard-attestation.mjs` | 0 |
| `node scripts/check-skills-token-ratchet.mjs` | 0 |
| `node scripts/check-test-completeness.mjs` | 3 — NOT MEASURED |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:cross-package-test-inputs` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:role-word` | 0 |
| `pnpm check:skill-compatibility` | 0 |
| `pnpm check:skill-frame-sync` | 0 |

Exit codes captured with `cmd > log 2>&1; EXIT=$?` — before any pipe.

`check-test-completeness` exit 3 is the script's own `PREREQUISITE NOT MET` branch:
it grades a saved `turbo run test` log, and the derived family names it with no
argument. Its output says so verbatim and instructs the local reader to record it
as NOT MEASURED. Not a finding.

`check:skill-examples` — named in the dispatch brief, **not** in the derived family
list, and the derivation is right: that gate type-checks only fences marked with an
`os:check` HTML-comment marker, and `skills/objectstack-query/**` carries **zero**
such markers (control: `objectstack-ui`, `objectstack-i18n` and `objectstack-formula`
each carry them, so the search discriminates). Its population here is empty. Two
bounded foreground attempts to run it anyway were blocked by its
`@objectstack/client-react` build prerequisite, whose closure fails on pre-existing
type-only import gaps in `@objectstack/runtime` and `@objectstack/verify`
(`Cannot find module '@objectstack/rest'`) — unrelated to this diff, and both
attempts hit the container's foreground cap. CI runs the gate on every PR regardless.

## No changeset

Pure `skills/**` diff, releasing nothing. Convention verified against `origin/main`
rather than assumed: the last six commits touching `skills/**` — the three
objectstack-data sweep PRs, the objectstack-formula sweep, the `$exists` correction,
and the pm-dispatch rules PR — carry **zero** `.changeset/` files between them. The
`skip-changeset` label is applied to this PR.

## NOT MEASURABLE (recorded, never annotated into the files)

Nine claims could not be settled from a package-scoped flight; none was corrected
and none is known false. They are the cross-package-runtime class flight ① named:

1. Expand resolves via **batch `$in`** queries "not N+1" — the `QueryAST.expand`
   `.describe()` asserts it and `MAX_EXPAND_DEPTH = 3` is read directly, but proving
   the batching (rather than reading the claim) needs a driver call-count harness
   over a relational fixture.
2. Expand applies `fields` + `where` only, ignoring per-parent `limit`/`offset`/
   `orderBy` — same fixture gap.
3. `$icontains` ASCII-folding domain, and the `__search` pinyin companion column
   behind `OS_SEARCH_PINYIN_ENABLED` — needs a provisioned companion column.
4. `search` `fields` narrowing answering `400 INVALID_FIELD` **over the REST/protocol
   ingress** — the refusal text was matched in `metadata-protocol`, but the HTTP
   status pairing needs a live server.
5. `select`/`status` label→value mapping in search — the unit suite pins
   `{ industry: { $in: ['retail'] } }`; not re-run here against a real object.
6. Date-bucket push-down vs in-memory fallback agreeing "including the column keys"
   — the alias-renames-the-projection half was measured
   (`[{"quarter":"2025-Q1","revenue":30},{"quarter":"2025-Q2","revenue":5}]`), the
   two-tier agreement across a real `DATE_TRUNC` dialect was not.
7. ISO-8601 weeks starting Monday — asserted by `DateGranularity`'s docblock; not
   executed across a week boundary.
8. `os validate` / `os build` / `npm run validate` failing a dashboard widget whose
   `dataset`/`dimensions`/`values` do not resolve (ADR-0021) — needs a scaffolded
   project.
9. Offset-pagination performance claims ("degrades on large offsets", keyset "O(1)")
   — true of relational engines generally; not benchmarked here, and not the kind of
   claim this sweep's oracle can settle.

## Out-of-scope finding

`packages/objectql/src/engine.ts` carries a stale docblock describing the ADR-0061
search expansion as "a server-resolved cross-field `$or` of `$contains`" — the same
sentence this PR corrects in the published skill. The implementation next door
(`search-filter.ts`) emits `$icontains` and documents the correction explicitly. An
internal comment, outside this PR's file surface; reported for filing rather than
fixed here.

_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_