### PR TITLE
docs(spec): align sys_metadata environment_id docblock with AGENTS.md:8

### DIFF
--- a/.changeset/sys-metadata-docblock-alignment.md
+++ b/.changeset/sys-metadata-docblock-alignment.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): stop teaching `sys_metadata` as still keyed by `environment_id`
+
+Prose only — no behaviour change. The `environment.zod.ts` module docblock
+listed `sys_metadata` among the Control-Plane tables **"(with `environment_id`)"**,
+alongside the correct `sys_package_installation` (with `environment_id`)`
+entry (ADR-0003, UNIQUE `(environment_id, package_id)`), which is untouched.
+
+That parenthetical ships verbatim to two consumer-facing surfaces: the docs
+site (`content/docs/references/cloud/environment.mdx`, auto-generated from
+this docblock) and the published `.d.ts` — an editor tooltip for anyone
+importing `@objectstack/spec/cloud`.
+
+On the metadata tables, `environment_id` is retired, not live (AGENTS.md:8;
+ADR-0006 v4; `packages/metadata-core/src/objects/sys-metadata.object.ts` and
+`packages/metadata/src/loaders/database-loader.ts` both carry `@deprecated`
+notes to the same effect, and the loader's test pins `organization_id` in the
+write path with no `environment_id` filter anywhere). The docblock's own
+parenthetical was the one place still teaching the opposite.
+
+The replacement wording matches `AGENTS.md:8` exactly: it asserts only that
+`environment_id` is deprecated on the metadata tables in favor of
+`organization_id`, and says nothing about whether the cloud control plane's
+own `sys_metadata` table still keys by it — a fact this tree cannot settle.
+That framing is true under either reading, so it does not require resolving
+which one holds.

--- a/content/docs/permissions/system-context.mdx
+++ b/content/docs/permissions/system-context.mdx
@@ -49,7 +49,7 @@ nothing to do with elevation.
 | `ExecutionContext.isSystem` — `packages/spec/src/kernel/execution-context.zod.ts:269` | The elevation flag on an operation's context | ✅ |
 | `Object.isSystem` — `packages/spec/src/data/object.zod.ts:1588` | Marks a **system object** (protected from deletion; defaults its org-wide sharing to `public` when no `sharingModel` is set) | ❌ |
 | `EmailTemplate.isSystem` — `packages/spec/src/system/email-template.zod.ts:125` | Built-in template; tenants may override but should not delete | ❌ |
-| `Environment.isSystem` — `packages/spec/src/cloud/environment.zod.ts:136` | Platform-infrastructure environment, not user data | ❌ |
+| `Environment.isSystem` — `packages/spec/src/cloud/environment.zod.ts:137` | Platform-infrastructure environment, not user data | ❌ |
 
 The collision is a genuine hazard rather than a naming nit: `Object.isSystem`
 changes an object's **default sharing**, and `ExecutionContext.isSystem` changes

--- a/content/docs/references/cloud/environment.mdx
+++ b/content/docs/references/cloud/environment.mdx
@@ -26,7 +26,8 @@ a per-org `manifest_id` (see ADR-0003), so a single package + version
 Split of concerns:
 - **Control Plane**: `sys_environment` (includes physical DB addressing),
   `sys_package_installation` (with `environment_id`), `sys_environment_credential`,
-  `sys_environment_member`, `sys_metadata` (with `environment_id`).
+  `sys_environment_member`, `sys_metadata` (on the metadata tables, `environment_id`
+  is deprecated in favor of `organization_id` — ADR-0006 v4).
 - **Data Plane**: each environment DB contains only business objects
   (account, task, …). No system tables, no `environment_id` columns.
 

--- a/packages/spec/src/cloud/environment.zod.ts
+++ b/packages/spec/src/cloud/environment.zod.ts
@@ -26,7 +26,8 @@ import { lazySchema } from '../shared/lazy-schema';
  * Split of concerns:
  * - **Control Plane**: `sys_environment` (includes physical DB addressing),
  *   `sys_package_installation` (with `environment_id`), `sys_environment_credential`,
- *   `sys_environment_member`, `sys_metadata` (with `environment_id`).
+ *   `sys_environment_member`, `sys_metadata` (on the metadata tables, `environment_id`
+ *   is deprecated in favor of `organization_id` — ADR-0006 v4).
  * - **Data Plane**: each environment DB contains only business objects
  *   (account, task, …). No system tables, no `environment_id` columns.
  */


### PR DESCRIPTION
Fixes #13664

## What

`packages/spec/src/cloud/environment.zod.ts:26-31` (module docblock) listed
`sys_metadata` among the Control-Plane tables **"(with `environment_id`)"** —
the same wording as the correct `sys_package_installation (with
environment_id)` entry on the line above it (ADR-0003, UNIQUE
`(environment_id, package_id)`, **untouched by this PR**).

On the metadata tables `environment_id` is retired, not live (AGENTS.md:8;
ADR-0006 v4), and this docblock ships verbatim to two consumer-facing
surfaces: the docs site (`content/docs/references/cloud/environment.mdx`,
auto-generated — regenerated here via `gen:docs`, not hand-edited) and the
published `.d.ts` (editor tooltip for `@objectstack/spec/cloud` consumers).

Per triage, the fix aligns the parenthetical with `AGENTS.md:8`'s wording,
which is true under **either** reading of the open question the issue itself
raised (whether the cloud control plane's own `sys_metadata` copy still keys
by `environment_id`, which this tree cannot settle):

```
`sys_metadata` (on the metadata tables, `environment_id` is deprecated in
favor of `organization_id` — ADR-0006 v4).
```

It asserts only what's true on the metadata tables and says nothing about
the cloud control plane's own table — no schema lookup needed, no reading to
resolve.

## Side effect: one doc anchor shifted

The docblock edit added one line, shifting every subsequent line number in
`environment.zod.ts` down by one. `check:system-context-census` caught a
stale line-number citation as a direct, mechanical consequence:
`content/docs/permissions/system-context.mdx:52` cited
`environment.zod.ts:136` for the `Environment.isSystem` field; that's now
`:137`. Updated in the same PR (still just a text alignment, no new
behaviour).

## What did NOT change

- `sys_package_installation (with `environment_id`)` — correct, untouched.
- `content/docs/references/cloud/environment.mdx` — regenerated via
  `pnpm --filter @objectstack/spec gen:docs`, never hand-edited (it carries
  `AUTO-GENERATED — DO NOT EDIT`).
- `packages/spec/dist/**` — gitignored, rebuilt at publish time.
- No cloud-side schema was queried; no cross-repo read was made.

## Tests

- `pnpm --filter @objectstack/spec build` — clean.
- `pnpm --filter @objectstack/spec check:generated` — all 14 generated
  artifacts up to date (only `check:docs` was stale before `gen:docs`; clean
  after).
- `pnpm --filter @objectstack/spec typecheck` — clean.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` —
  derived 48 local gate families for this diff, plus 8 more once the
  changeset existed (56 total). Ran all 56:
  - 51 green, including `check:doc-formula-expressions` and
    `check:doc-security-posture` after building `@objectstack/formula` /
    `@objectstack/lint` (their own `PREREQUISITE NOT MET` prerequisites).
  - `check:system-context-census` initially **red** on the shifted anchor
    (see above) — fixed in this PR and re-verified green.
  - `check:skill-examples` — the 2 surfaces this diff can affect (skills+docs,
    227 blocks; spec-source TSDoc, 10 blocks) type-checked clean; the 3rd
    surface (client SDK, 23 blocks — none touched by this diff) is
    **NOT MEASURED**: it needs `@objectstack/client-react` built, which a
    fresh worktree doesn't do and which this diff doesn't touch.
  - 4 more **NOT MEASURED** (not pass/fail — each says so itself):
    `check:dual-build-cjs-loads` and `check-dev-prereqs.mjs` need a full
    `pnpm build` across the workspace; `check-test-completeness.mjs` needs a
    saved `turbo run test` log (CI-only by design); `check-half-states.mjs`
    hit this container's REST-channel egress restriction on repo-scoped
    reads (pre-existing container constraint, unrelated to this diff).
- Full commands and pass/fail evidence in the PR-report comment on #13664.

Clause-②: no — prose-only change, accept/reject surface unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_