### PR TITLE
docs(releases): cascade the release-page headings and retire the single-h1 carve-out

### DIFF
--- a/content/docs/releases/implementation-status.mdx
+++ b/content/docs/releases/implementation-status.mdx
@@ -3,8 +3,6 @@ title: Implementation Status Matrix
 description: Detailed status of protocol implementations across ObjectStack packages
 ---
 
-# Implementation Status Matrix
-
 This document provides a comprehensive overview of which protocols from `@objectstack/spec` have been implemented in the ObjectStack packages.
 
 <Callout type="info">

--- a/content/docs/releases/v15.mdx
+++ b/content/docs/releases/v15.mdx
@@ -63,9 +63,9 @@ multi-tenant isolation and the write path get materially safer by default.
 
 ---
 
-# 15.0.0 in detail
+## 15.0.0 in detail
 
-## New features in 15.0.0 (additive)
+### New features in 15.0.0 (additive)
 
 - **A3** — the `sys_user` record page gains **Permission Sets** (direct grant) and
   **Business Units** assignment tabs (#2927).
@@ -87,7 +87,7 @@ multi-tenant isolation and the write path get materially safer by default.
 - **Docs** — a customer-facing **Administrator Guide** (onboarding task handbook for
   system admins) lands in the permissions docs (#2929).
 
-## New in Console (Studio) — bundled objectui 14.0
+### New in Console (Studio) — bundled objectui 14.0
 
 15.0.0 bundles the **objectui 14.0 Console major** (13.2.0 → 14.0.0, ~73
 commits, plus six early-14.1 commits picked up by the final pin). Much of this
@@ -96,7 +96,7 @@ first release-page disclosure. The major itself is a **version-line alignment
 with objectstack**; the only code-level breaking change is the ADR-0057 chat
 cleanup below.
 
-### Breaking / behavior (objectui 14.0)
+#### Breaking / behavior (objectui 14.0)
 
 - **The docked ChatDock becomes the console's only chat form (ADR-0057 final
   cleanup, #2475).** The `features.chatDock` runtime config key is removed
@@ -112,7 +112,7 @@ cleanup below.
   and `/ai/build?package=X` now share one thread; the old `studio:`-prefixed
   scopes are retired.
 
-### Console AI — the ChatDock line (ADR-0057)
+#### Console AI — the ChatDock line (ADR-0057)
 
 - **Right-docked AI rail:** `AppShell` gains a `rightRail` that reflows content
   instead of overlaying it (VS Code-style); collapsible, drag-resizable,
@@ -139,7 +139,7 @@ cleanup below.
   the Studio dock remembers collapse state per tab, side-by-side
   canvas+properties from `xl` (#2478, #2470).
 
-### Gantt (plugin-gantt)
+#### Gantt (plugin-gantt)
 
 - **API data sources read and write back** (reschedule / dependencies / delete /
   inline edit through `read`/`write` HttpRequests; pure-api views need no
@@ -164,7 +164,7 @@ cleanup below.
   real record + schema, write failures toast the server message, and locked
   rows disable the dependency menu (#2479).
 
-### Lists & grids
+#### Lists & grids
 
 - **Localized export filenames** — `<object label>-<view>-<timestamp>.<ext>`
   (e.g. `任务-In Progress-20260714.xlsx`) via a new `buildExportFileName`;
@@ -177,7 +177,7 @@ cleanup below.
 - Inline-edit hardening: schema-`readonly` fields and system/audit columns
   (`created_at` …) refuse the double-click editor (#2408).
 
-### Forms & fields
+#### Forms & fields
 
 - **Sharing-rule forms pick, not type:** three new widget-hint components —
   `object-ref` (searchable object picker over a new `DataSource.getObjects()`),
@@ -189,7 +189,7 @@ cleanup below.
   fields by features/user/app/data scope (e.g. create-user's phone field
   disappears when the phoneNumber plugin is off) (#2406, #2419).
 
-### Auth & login
+#### Auth & login
 
 - **Phone + password sign-in:** the password mode recognizes an email or an
   E.164 phone and routes by shape (better-auth phoneNumber plugin,
@@ -198,7 +198,7 @@ cleanup below.
   without a redirect URL, OAuth callback error banners (`?error=<code>`)
   (#2468).
 
-### Studio, i18n, security
+#### Studio, i18n, security
 
 - Four-pillar `?surface=` deep links restore and write back to the URL
   (`useSurfaceDeepLink`; Automations/Access catch up) (#2451); record pages'
@@ -218,7 +218,7 @@ cleanup below.
   cards (#2496); refresh/history-restore keeps "Open in Builder →" and
   confirm-change cards (#2497); build summaries truncate on mobile (#2495).
 
-### Early 14.1 commits bundled by the 15.0.0 pin
+#### Early 14.1 commits bundled by the 15.0.0 pin
 
 - The Studio copilot dock's **composer no longer vanishes** on long sessions
   (flex height chain), and the properties inspector collapses to a slim rail
@@ -234,13 +234,13 @@ cleanup below.
 
 ---
 
-## Breaking changes & migration (15.0.0)
+### Breaking changes & migration (15.0.0)
 
 Strict-semver edges and behavior changes in 15.0.0, with migrations — read
 before upgrading a multi-org or enterprise-hierarchy deployment, and before
 recompiling metadata authored against spec 14.x.
 
-### Strict view/page schemas — mis-layered visibility keys are loud errors (ADR-0089 D3a, #2943)
+#### Strict view/page schemas — mis-layered visibility keys are loud errors (ADR-0089 D3a, #2943)
 
 `FormFieldSchema`, `FormSectionSchema` (view) and `PageComponentSchema` (page)
 are now `.strict()`. A key these schemas do not declare — a `visibleWhen` typo,
@@ -257,7 +257,7 @@ The companion lint rule (`visibility-root-mislayered`) is now bidirectional
 (#2931): it flags a `data.`-rooted predicate on a runtime view/page *and* a
 `record.`-rooted predicate on a metadata-editing form.
 
-### Multi-org deployments only (ADR-0095)
+#### Multi-org deployments only (ADR-0095)
 
 - **Cross-tenant read leak closed (Layer 0).** A permissive business RLS policy
   (e.g. `status == 'public'`) can no longer OR-widen tenant scope. Tenant isolation
@@ -292,7 +292,7 @@ The companion lint rule (`visibility-root-mislayered`) is now bidirectional
   `_self` / `_org` identity-table carve-outs and `owner_only_writes/deletes` are
   unchanged; customized seeded sets keep their overlays (ADR-0094).
 
-### Enterprise hierarchy RLS (`@objectstack/security-enterprise`)
+#### Enterprise hierarchy RLS (`@objectstack/security-enterprise`)
 
 - **`unit` scope anchors to the position's business unit.** `unit` / `unit_and_below`
   now prefer `sys_user_position.business_unit_id` (the position's BU) over
@@ -302,7 +302,7 @@ The companion lint rule (`visibility-root-mislayered`) is now bidirectional
   their position BU; multiple positions union; expired/inactive positions fall back
   to membership.
 
-## Behavior changes (15.0.0)
+### Behavior changes (15.0.0)
 
 - **Import runs the automation chain per row (#2922).** `engine.insert` now
   triggers `beforeInsert`/`afterInsert` once per row with single-record hook
@@ -325,7 +325,7 @@ The companion lint rule (`visibility-root-mislayered`) is now bidirectional
   derives its posture evidence from the same enforcement path, eliminating
   label drift between what the panel says and what the kernel does.
 
-## Non-breaking hardening in 15.0.0 (same effective visibility)
+### Non-breaking hardening in 15.0.0 (same effective visibility)
 
 - **RLS safety nets recognize canonical `==` (#2936).** The field-existence /
   tenancy-disabled nets were inert for `==`-form policies; now recognized. Only
@@ -339,7 +339,7 @@ The companion lint rule (`visibility-root-mislayered`) is now bidirectional
   now filters by organization directly, and private hierarchy-scoped objects that lack
   an `organization_id` column fail closed at boot.
 
-# What's new in 15.1.0
+## What's new in 15.1.0
 
 15.1 is a fast-follow minor (87 commits, 65 changesets — 60 minor + 62 patch,
 no major) with three themes: a **write-path security hardening sweep** (every
@@ -350,9 +350,9 @@ wired purely from metadata). Strict-semver edges are listed under *Behavior
 changes* with their migrations. The bundled Console picks up the objectui 14.1
 line (94 commits) — see its own section below.
 
-## New capabilities in 15.1.0
+### New capabilities in 15.1.0
 
-### Attachments v1 (#2755, #2970)
+#### Attachments v1 (#2755, #2970)
 
 Parent-derived access on the full chain, Salesforce-ContentDocumentLink style:
 
@@ -380,7 +380,7 @@ Parent-derived access on the full chain, Salesforce-ContentDocumentLink style:
 - `@objectstack/verify` gains `BootOptions.extraPlugins` for booting attachment
   flows in harnesses.
 
-### Declarative connectors (ADR-0096 / ADR-0097)
+#### Declarative connectors (ADR-0096 / ADR-0097)
 
 `connectors:` metadata entries with a `provider` (`openapi` / `mcp` / `rest`)
 materialize at boot into dispatchable connectors — an AI or a package can wire
@@ -413,7 +413,7 @@ an integration end-to-end in pure metadata and call it from flow
   connector picker surfaces (objectui#2563).
 - The showcase runs a live `provider:'mcp'` demo pinned in CI (#3062).
 
-### Dashboard-level filters (#2501)
+#### Dashboard-level filters (#2501)
 
 The previously declared-but-inert `DashboardSchema.globalFilters` + `dateRange`
 are now live end to end:
@@ -438,7 +438,7 @@ are now live end to end:
   filters driving invoice and account charts over two objects, with an
   opted-out all-time KPI (#3038).
 
-### Pinyin search (#3027)
+#### Pinyin search (#3027)
 
 Locale-gated (`OS_SEARCH_PINYIN_ENABLED`, auto-on when any `zh-*` locale is
 configured): display/name fields get a hidden `__search` companion column
@@ -450,7 +450,7 @@ values. FLS-restricted/secret/PII fields are never indexed. Documented in the
 search guide with `sys_user`/picker coverage and existing-row backfill notes
 (#3057, #3034); the showcase seeds make it demonstrable out of the box.
 
-### Metadata & spec
+#### Metadata & spec
 
 - **Conditional tabs (#2967):** `page:tabs` items accept a `visibleWhen` CEL
   predicate over `record` + `current_user` + `page.<var>`; FALSE removes the
@@ -471,7 +471,7 @@ search guide with `sys_user`/picker coverage and existing-row backfill notes
   metadata form pins a `ref:component` widget, so Studio offers a dropdown of
   the page's components instead of a free-text id (companion objectui#2523).
 
-### AI / MCP
+#### AI / MCP
 
 - **`aggregate_records` MCP tool (#2976):** count/sum/avg/min/max/count_distinct
   with groupBy (incl. date bucketing), where filters, and IANA timezones — on
@@ -485,7 +485,7 @@ search guide with `sys_user`/picker coverage and existing-row backfill notes
   without re-declaring them inside the object. All invoke-time gates
   (fail-closed `ai.exposed`, ADR-0066 D4, fail-closed `sys_*`) unchanged.
 
-### Deployment
+#### Deployment
 
 - **Official Docker runtime image (#2952):** `ghcr.io/objectstack-ai/objectstack`
   (Node 22 + pinned CLI + `os start`, non-root, `/api/v1/health` HEALTHCHECK,
@@ -497,7 +497,7 @@ search guide with `sys_user`/picker coverage and existing-row backfill notes
   docker-compose.yml (app + Postgres), and `.dockerignore` — `npm create
   objectstack` then `docker build` just works.
 
-### Kernel & protocol
+#### Kernel & protocol
 
 - **`kernel:bootstrapped` lifecycle anchor (#2989):** fires after all
   `kernel:ready` handlers settle, before `kernel:listening` — the correct
@@ -529,7 +529,7 @@ search guide with `sys_user`/picker coverage and existing-row backfill notes
   narrows to `RestProtocol = DataProtocol & MetadataProtocol` (type-level
   only).
 
-### i18n
+#### i18n
 
 - **`os i18n extract` emits action-param keys**
   (`objects.<object>._actions.<action>.params.<param>.*`), so action dialog forms —
@@ -542,7 +542,7 @@ search guide with `sys_user`/picker coverage and existing-row backfill notes
 - New lint: `field-group-shadowed` warns when a field group is silently
   shadowed (#3029).
 
-## New in Console (Studio) — bundled objectui 14.1
+### New in Console (Studio) — bundled objectui 14.1
 
 The pinned Console picks up the objectui 14.1 line (94 commits), plus a
 handful of post-14.1 fixes carried by the final pin: cascading option fields
@@ -555,7 +555,7 @@ request-tracked backends (#2619); built-in grid row Edit/Delete honor
 per-record CEL predicates (#2617); and the AI build canvas cold-starts into
 Studio with a primary CTA + artifact deep links (ADR-0080 D5, #2623). By area:
 
-### Record detail & inline edit (ADR-0085 line)
+#### Record detail & inline edit (ADR-0085 line)
 
 - **Record-level inline edit with one atomic save (#2542).** The inline-edit
   session lifts from per-field to a shared `InlineEditContext` + record-level
@@ -603,7 +603,7 @@ Studio with a primary CTA + artifact deep links (ADR-0080 D5, #2623). By area:
   renderer and its `renderViaSchema` kill-switch are removed (ADR-0085 PR4,
   #2546).
 
-### CEL editors everywhere (#1582 series)
+#### CEL editors everywhere (#1582 series)
 
 All expression surfaces converge on the canonical `@objectstack/formula`
 engine, and Studio's bare textareas are replaced by a shared
@@ -648,7 +648,7 @@ engine, and Studio's bare textareas are replaced by a shared
   client predicate scope (#2573); kanban's zod schema accepts the
   `{condition, style}` CEL shape (#2550).
 
-### Dashboard filters
+#### Dashboard filters
 
 Covered under "Dashboard-level filters" above — runtime bar (#2576), visual
 filterBindings editor (#2586), nested-variable merging + metadata-aware
@@ -656,7 +656,7 @@ defaults + server-side optionsFrom (#2590), and the crash fix for spec-form
 `{value, label}` options with label display (#2597), plus catalog examples, a
 guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
 
-### Studio Access pillar
+#### Studio Access pillar
 
 - **Package-level OWD overview with batch edit (#2508).** A "Record Sharing
   Baseline (OWD)" panel lists every object's `sharingModel` /
@@ -686,7 +686,7 @@ guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
 - Access matrix history opens in an in-place sheet; breadcrumbs stop escaping
   the pillar (#2599).
 
-### Flow designer
+#### Flow designer
 
 - **Add-node palette: search + keyboard nav + recents (#2543, #2553).** Substring
   search over label/hint/type, ↑↓ + Enter selection, a "Recently used" group
@@ -708,7 +708,7 @@ guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
   accept `position` references via a new xRef picker kind (combobox over known
   positions, free-text fallback when empty).
 
-### Kanban
+#### Kanban
 
 - **Lanes honor the `stageField` semantic setting (#2596):** explicit config →
   ADR-0085 `stageField` → strict-false suppression → shared name/type
@@ -718,7 +718,7 @@ guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
 - **Conditional formatting accepts CEL `{condition, style}` rules (#2550)**,
   consistent with list/grid and the runtime.
 
-### Studio & platform misc
+#### Studio & platform misc
 
 - **Spec-driven package form (#2535).** The three hand-written package forms
   (with two mutually-contradictory id regexes) collapse into one
@@ -739,7 +739,7 @@ guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
   metadata-admin can create form-family views (#2531); `page:tabs` honors
   item-level `visibleWhen` (#2516, pairing framework#2967).
 
-### Fixes (Console)
+#### Fixes (Console)
 
 - **Error envelopes no longer crash the page via `toast.error` (#2580).**
   Failed api/flow/server actions returned `{error:{code,message}}` objects
@@ -776,9 +776,9 @@ guide tutorial with real screenshots, and en/zh filter-bar i18n (#2581).
   duplicate FormRenderer/FieldFactory form path (#2560), and the legacy
   monolith detail renderer (#2546).
 
-## Behavior changes (15.1.0)
+### Behavior changes (15.1.0)
 
-### Spec: `tenancy.strategy` and `tenancy.crossTenantAccess` removed (#2962)
+#### Spec: `tenancy.strategy` and `tenancy.crossTenantAccess` removed (#2962)
 
 Strict-semver breaking, shipped in a minor under the launch-window policy: both
 fields had **zero consumers** and no runtime behavior. The `tenancy` block is now
@@ -792,7 +792,7 @@ of being silently stripped. **Migration:**
   not object metadata. Cross-tenant visibility is expressed via sharing rules / OWD
   (`externalSharingModel`).
 
-### 'ObjectOS' retired from the spec's public surface (#2963, #2960)
+#### 'ObjectOS' retired from the spec's public surface (#2963, #2960)
 
 Layer vocabulary converges on **ObjectQL (data) / Kernel (control) / ObjectUI (view)**;
 "ObjectOS" now refers exclusively to the commercial runtime environment. Three
@@ -802,7 +802,7 @@ public identifiers renamed, with deprecated aliases kept for one release:
 `IKernel`). Find/replace is the whole migration; schema shapes and JSON output are
 unchanged. Docs moved from `protocol/objectos` to `protocol/kernel`.
 
-### Anonymous access denied uniformly across HTTP surfaces (#2567)
+#### Anonymous access denied uniformly across HTTP surfaces (#2567)
 
 Under `requireAuth` (the secure default), anonymous `POST /graphql` and the raw
 `/data` routes now return 401 — previously they bypassed the gate and reached
@@ -817,7 +817,7 @@ bodies unify on `code: 'unauthenticated'`, and the authz-conformance matrix
 ratchets newly added `/data`/`/meta`/`/graphql` routes — an unclassified new
 route fails CI.
 
-### Server-enforced `readonly` / `readonlyWhen` on UPDATE (#2948, #3042, #3003)
+#### Server-enforced `readonly` / `readonlyWhen` on UPDATE (#2948, #3042, #3003)
 
 `readonly: true` was documented as a server contract but only enforced in the
 UI — issue #3003 confirmed approval/status/amount columns could be forged via a
@@ -832,7 +832,7 @@ field is dropped for the whole batch — narrow the `where` to unlocked rows to
 write it. The docs now describe `readonly` as a server contract, not "read-only
 in UI".
 
-### Ownership anchor (`owner_id`) is guarded (#3004, #2982, #3018)
+#### Ownership anchor (`owner_id`) is guarded (#3004, #2982, #3018)
 
 Unprivileged writers can no longer forge another user's `owner_id` on insert or
 reassign it on update; transfers require a transfer grant (`allowTransfer`, or
@@ -852,7 +852,7 @@ importing a CSV with someone else's `owner_id` column is now correctly
 rejected unless they hold a transfer grant; admins with `modifyAllRecords` are
 unaffected.
 
-### MCP action surface gated on `ai.exposed`, fail-closed (#2964)
+#### MCP action surface gated on `ai.exposed`, fail-closed (#2964)
 
 Action bodies execute as trusted code (the engine facade carries no
 ExecutionContext, so internal reads/writes bypass RLS/FLS/CRUD/tenant scoping),
@@ -864,7 +864,7 @@ the caller's identity as a real `AutomationContext` (`runAs: 'user'` flows
 evaluate RLS as the caller), and trusted-body invocations are audit-logged on
 both the MCP and REST paths.
 
-### Declarative stdio MCP transports are deny-by-default (#3055)
+#### Declarative stdio MCP transports are deny-by-default (#3055)
 
 A declarative `stdio` transport spawns a local child process from metadata — and
 Studio runtime publish can introduce such metadata. Previously-materializing
@@ -876,7 +876,7 @@ explicitly — `new ConnectorMcpPlugin({ declarativeStdio: ['my-mcp-server'] })`
 transports and hand-wired connectors are unaffected. This gate is the security
 precondition for shipping connector-mcp in the default preset (#3056).
 
-### OWD posture enforced at metadata-save time (#3050)
+#### OWD posture enforced at metadata-save time (#3050)
 
 A new `registerAuthoringGate(type, gate)` seam in `metadata-protocol` runs
 pre-persistence for draft and publish saves (environment writes only).
@@ -888,7 +888,7 @@ overlay over a packaged object can only **tighten**
 time rather than only flagged by CLI lint. Already-stored metadata loads
 unchanged.
 
-### Attachments: dead fields removed, downloads authenticated (#2755, #2970)
+#### Attachments: dead fields removed, downloads authenticated (#2755, #2970)
 
 - **REMOVED: `sys_attachment.share_type` / `sys_attachment.visibility`** — modeled
   in v1 but with zero runtime consumers. No replacement key: access derives from the
@@ -907,7 +907,7 @@ unchanged.
 - **Attaching to a record now requires parent EDIT** (was: parent READ), matching
   Salesforce semantics (#2970 item 3).
 
-### Other semantics worth knowing
+#### Other semantics worth knowing
 
 - `ConnectorSchema.authentication` defaults to `{ type: 'none' }` (a relaxation;
   existing connectors unaffected).
@@ -930,7 +930,7 @@ unchanged.
   declared in the spec but not yet enforced by the Console renderer** (pending
   objectui#2545). Authoring it today is a declaration, not behavior.
 
-## Security hardening (15.1.0)
+### Security hardening (15.1.0)
 
 Beyond the behavior changes above, an execution-surface sweep (#2849 class)
 closed three confirmed-exploitable holes (#2975), and a second sweep hardened
@@ -992,7 +992,7 @@ seeding and expansion:
 - **CI:** the retired `pnpm audit` is replaced by OSV-Scanner in validate-deps
   (#2986).
 
-## Notable fixes (15.1.0)
+### Notable fixes (15.1.0)
 
 - **Studio metadata editing under spec 15:** lazy schema proxies stay
   identity-compatible with `z.toJSONSchema` — the Page/View inspector no longer
@@ -1021,9 +1021,9 @@ seeding and expansion:
   auto-binds `everyone`; package-level only emits a suggestion — fixing the
   previously self-contradictory "never auto-bound" wording (doc-only).
 
-## Upgrade checklist
+### Upgrade checklist
 
-### 15.0.0
+#### 15.0.0
 
 - **Strict schemas:** recompile metadata; fix any keys flagged by the new
   strict view/page parse errors (typos, mis-layered `visibility`/`visibleWhen`,
@@ -1041,7 +1041,7 @@ seeding and expansion:
   end-to-end smoke test in a licensed environment is still owed** — open-core CI cannot
   exercise the multi-org path.
 
-### 15.1.0
+#### 15.1.0
 
 - Remove `tenancy.strategy` / `tenancy.crossTenantAccess` from object metadata
   (parse now fails loudly).
@@ -1059,7 +1059,7 @@ seeding and expansion:
 - Hosts using declarative **stdio** MCP connectors must opt in via
   `ConnectorMcpPlugin({ declarativeStdio: [...] })`.
 
-## References
+### References
 
 ADR-0095 (kernel chain) · ADR-0089 D3 (strict visibility schemas + lint) ·
 ADR-0090 Addendum (position-anchor) · ADR-0094 (overlay preservation) ·

--- a/content/docs/releases/v16.mdx
+++ b/content/docs/releases/v16.mdx
@@ -114,15 +114,15 @@ dashboard widget typos, dead hook events, phantom webhook triggers, unknown
 
 ---
 
-# 16.0.0 in detail
+## 16.0.0 in detail
 
-## Breaking changes & migration
+### Breaking changes & migration
 
 Strict-semver edges and behavior changes, with migrations — read before
 recompiling metadata authored against spec 15.x or upgrading a deployment
 with custom hooks, actions, MCP stdio, or multi-org tenancy.
 
-### Hook & action `ctx`: the `tenantId` alias is removed — read `organizationId` (#3280, #3290)
+#### Hook & action `ctx`: the `tenantId` alias is removed — read `organizationId` (#3280, #3290)
 
 The caller's active organization is now surfaced to JS authors under one
 blessed name, matching the `organization_id` column and
@@ -149,7 +149,7 @@ untouched — that configurable isolation column legitimately carries an
 Community edition never populates an org, so `organizationId` is `undefined`
 there.
 
-### Strict dashboard widgets — undeclared keys are loud (ADR-0021, #3251)
+#### Strict dashboard widgets — undeclared keys are loud (ADR-0021, #3251)
 
 `DashboardWidgetSchema` is now `.strict()`: an undeclared top-level key — a
 typo, a hallucinated key, or a removed pre-ADR-0021 inline-analytics key
@@ -163,7 +163,7 @@ counterpart of 15.0.0's strict form/page flip. **Migration:** recompile;
 rewrite any flagged widget onto the dataset shape (both Studio authoring
 surfaces already emit only that shape — objectui#2703).
 
-### MCP stdio: its own switch, and a mandatory API-key principal (ADR-0101, #3167, #3246)
+#### MCP stdio: its own switch, and a mandatory API-key principal (ADR-0101, #3167, #3246)
 
 Two changes close the platform's last identity-less execution surface:
 
@@ -184,7 +184,7 @@ Two changes close the platform's last identity-less execution surface:
   authority is a key minted on a platform-admin or service identity. The
   default-on HTTP surface is unaffected.
 
-### Feed contracts retired from the type surface and discovery (#1959, #3180)
+#### Feed contracts retired from the type surface and discovery (#1959, #3180)
 
 The feed runtime was deleted long ago (`sys_comment` / `sys_activity` are the
 canonical collaboration backend); 16.0.0 removes the dead surfaces that still
@@ -200,7 +200,7 @@ and was permanently `false`; it now tracks the presence of `sys_comment`, so
 `client.data.create('sys_comment', { object, record_id, body })`, read
 `sys_activity` — and `discovery.capabilities.comments`.
 
-### The enforce-or-remove sweep — dead metadata is now loud (#2377, ADR-0049)
+#### The enforce-or-remove sweep — dead metadata is now loud (#2377, ADR-0049)
 
 A platform-wide audit removed declared-but-unenforced surfaces. Authoring
 these was a false affordance — especially dangerous for AI-authored metadata:
@@ -240,7 +240,7 @@ these was a false affordance — especially dangerous for AI-authored metadata:
   unimplemented notification channels now say "not yet enforced" in their
   doc comments and `.describe()` texts.
 
-### Engine-owned system rows are read-only through the generic data API (ADR-0103, #3220)
+#### Engine-owned system rows are read-only through the generic data API (ADR-0103, #3220)
 
 The overloaded `managedBy: 'system'` bucket conflated rows a platform service
 owns end-to-end with platform-defined schema whose rows are legitimately
@@ -260,7 +260,7 @@ old fail-open behavior gets its write verbs stripped (with a warning) —
 declare `userActions` for the verbs it legitimately takes from users. The
 Console badges engine-owned objects distinctly (objectui#2705).
 
-### Multi-org: the carried posture rung is authoritative for the tenant wall (ADR-0099 P1, #3211)
+#### Multi-org: the carried posture rung is authoritative for the tenant wall (ADR-0099 P1, #3211)
 
 The Layer 0 cross-tenant exemption now reads the principal's carried
 `ctx.posture` rung as authoritative; the platform-admin capability probe is
@@ -279,7 +279,7 @@ manage_platform_settings, studio.access, manage_users}`; grant the
 is intended. A runtime `[authz/ADR-0099]` warning names any principal hitting
 the divergence.
 
-### Approver type `role` → `org_membership_level` (#3133)
+#### Approver type `role` → `org_membership_level` (#3133)
 
 `ApproverType.role` was the last authoring surface projecting the reserved
 word that ADR-0090 D3 retired — and it manufactured a real silent failure: since
@@ -293,7 +293,7 @@ with a warning) and is removed next major. New paired lints:
 `approval-approver-type-deprecated`. If the value names an org position, the
 fix is `type: 'position'`.
 
-## Behavior changes (16.0.0)
+### Behavior changes (16.0.0)
 
 - **Bulk user import defaults to `auto` (#3236).**
   `POST /api/v1/auth/admin/import-users` gains a fourth `passwordPolicy` and
@@ -359,9 +359,9 @@ fix is `type: 'position'`.
   opt-out across partial re-registrations, and `isTenancyDisabled(schema)`
   is the single shared source of truth.
 
-## New capabilities in 16.0.0
+### New capabilities in 16.0.0
 
-### Approvals: quorum, per-group sign-off (会签), attachments, and declared actions (#3266 series)
+#### Approvals: quorum, per-group sign-off (会签), attachments, and declared actions (#3266 series)
 
 - **Decision behaviors (#3268):** approval steps gain `quorum` (M-of-N via
   `minApprovals`) and `per_group` (one approver from each labeled group —
@@ -384,7 +384,7 @@ fix is `type: 'position'`.
   renders a real user picker. A contract test pins the action set. The
   Console side retires the inbox's hand-written buttons (see Console below).
 
-### Time-relative automation — a daily sweep, not date-equality roulette (#1874)
+#### Time-relative automation — a daily sweep, not date-equality roulette (#1874)
 
 A flow start node can declare `config.timeRelative` — swept object,
 `dateField`, and either `offsetDays: [60, 30, 7]` (T-minus thresholds) or
@@ -398,7 +398,7 @@ flows. The discovery query runs as system, capped (`maxRecords`, default
 1000), with per-record failure isolation. `os validate` gains readiness
 checks; the flow designer gets a first-class panel (objectui#2668).
 
-### Flow trigger observability — no more four-layer silence (2026-07-17 eval)
+#### Flow trigger observability — no more four-layer silence (2026-07-17 eval)
 
 A misauthored auto-launched flow used to produce zero output anywhere. Now:
 the `os serve`/`os dev`/`os start` startup banner prints a **`Flows:`
@@ -411,7 +411,7 @@ stderr; `RecordChangeTrigger` probes object existence at bind time; a
 status). Registration-time flow-condition validation also runs schema-aware
 checks for dynamically registered flows (#1928).
 
-### Filtered roll-ups and honest state machines
+#### Filtered roll-ups and honest state machines
 
 - **`summaryOperations.filter` (#1868):** a roll-up `summary` field can
   aggregate only matching child rows (operator and compound forms included),
@@ -430,7 +430,7 @@ checks for dynamically registered flows (#1928).
   sanctioned authoring path rejected; a retired `'own'`/`'extend'` value
   fails with guidance (that's the package-contribution kind).
 
-### Analytics: exact drill-through scopes (#1752, #3214)
+#### Analytics: exact drill-through scopes (#1752, #3214)
 
 Drilling a "2026-Q2" cell needs a range, not an equality. `queryDataset` now
 emits a `drillRanges` sidecar of half-open `[start, end)` bounds for
@@ -442,7 +442,7 @@ the raw-value snapshot to totals/subtotal rows, so subtotal drills
 exact-match on stored values instead of display labels. Consumed by the
 Console's report drill-through (objectui#2672).
 
-### Performance diagnostics: Server-Timing spans (#2408)
+#### Performance diagnostics: Server-Timing spans (#2408)
 
 - Opt-in `Server-Timing` now decomposes requests into **`auth`** (identity
   resolution), **`db`** (total SQL time + query count, correctly attributed
@@ -456,7 +456,7 @@ Console's report drill-through (objectui#2672).
   the slowest parametrized statements (placeholders only, never bindings).
   Zero overhead when off.
 
-### AI / MCP
+#### AI / MCP
 
 - **`validate_expression` tool (#1928):** agents can run the same expression
   checks as `objectstack build` against an object's *real* schema before
@@ -474,7 +474,7 @@ Console's report drill-through (objectui#2672).
   rescues), threaded through formulas, validation rules, predicates, and
   flow conditions (fatal only under `--strict`).
 
-### Spec, kernel & platform
+#### Spec, kernel & platform
 
 - **One platform capability vocabulary (#3265):** `requires` tokens are
   canonical kebab-case owned by the spec (`PLATFORM_CAPABILITY_TOKENS`) with
@@ -518,7 +518,7 @@ Console's report drill-through (objectui#2672).
   also stop corrupting lookup natural keys and are now idempotent
   (no `updated_at` churn per boot).
 
-### CLI & developer experience
+#### CLI & developer experience
 
 - **Scaffold ships the connector executors (ADR-0097):** `npm create
   objectstack` wires `ConnectorRestPlugin` / `ConnectorOpenApiPlugin` /
@@ -556,7 +556,7 @@ Console's report drill-through (objectui#2672).
   record History tab stops showing phantom changes (#3293); the seed-replayer
   reports `skipped` so hosts can stamp seed-once on all-skip replays.
 
-## New in Console (Studio) — bundled objectui 16.0
+### New in Console (Studio) — bundled objectui 16.0
 
 16.0.0 bundles the **objectui 16.0 Console major** (15.0.0 → 16.0.0, the
 range `077e45b..94d4876`, objectui #2589–#2705). The major is a version-line
@@ -573,7 +573,7 @@ directly) and the removal of the Gantt mobile QR-share context action
 > that later Console work is under
 > [Landed since 16.0.0-rc.0](#landed-since-1600-rc0).
 
-### Approvals inbox goes metadata-driven (#2678 line)
+#### Approvals inbox goes metadata-driven (#2678 line)
 
 - **`DeclaredActionsBar` (#2692):** a reusable bar that renders and executes
   an object's *declared* actions for any (object, record, location) through
@@ -591,7 +591,7 @@ directly) and the removal of the Gantt mobile QR-share context action
   flow-designer approval panel synced with the engine schema
   (quorum / per_group / minApprovals / group).
 
-### Action dialogs render real field widgets (ADR-0059, #2704)
+#### Action dialogs render real field widgets (ADR-0059, #2704)
 
 `ActionParamDialog` retires its bespoke per-type branch chain: every declared
 param renders through the same `fieldWidgetMap` as the object form, so a
@@ -600,7 +600,7 @@ code, date, …) gets its real widget — uploads ride the ambient
 UploadProvider with `multiple`/`accept`/`maxSize` honored. Result dialogs
 skip declared fields whose path doesn't resolve (#2674).
 
-### Dashboards author the dataset shape only (#2703)
+#### Dashboards author the dataset shape only (#2703)
 
 Both Studio surfaces (widget config panel and inspector) now emit only the
 ADR-0021 semantic-layer shape (`dataset` + `dimensions` + `values`) — the
@@ -609,7 +609,7 @@ authoring-side counterpart that let the framework flip
 picker (chart *and* pivot) with a catalog; filter-binding field pickers
 source from the bound dataset's dimensions.
 
-### Flow designer: nested regions, visible and editable (#2670)
+#### Flow designer: nested regions, visible and editable (#2670)
 
 `loop` / `parallel` / `try_catch` containers stop being opaque cards: their
 regions render as read-only mini-canvases (#2675), then as inline push-down
@@ -623,7 +623,7 @@ canonical `config.schedule` the runtime actually reads (#2671), and the
 `xExpression` marker renders the loop `collection` as a template editor
 instead of false-flagging `{tasks}` as malformed CEL (framework#3304).
 
-### Gantt (plugin-gantt)
+#### Gantt (plugin-gantt)
 
 - **Ownership-aware rescheduling (#2683):** an own-dates, unlocked summary
   shifts like a task and carries its unlocked subtree by the same delta;
@@ -637,7 +637,7 @@ instead of false-flagging `{tasks}` as malformed CEL (framework#3304).
 - **Removed:** the mobile QR-share context action (#2687, the objectui 16.0
   breaking edge).
 
-### Studio Access pillar (#2600 B-series)
+#### Studio Access pillar (#2600 B-series)
 
 The permission matrix hits the first screen: identity and zero-grant
 capability sections start collapsed (B1); the Explain panel's object field
@@ -646,7 +646,7 @@ stops clipping at narrow widths (B3); wide objects get a field filter plus
 Read-all / Write-all / Clear bulk shortcuts scoped to the visible rows (B4);
 and curated capability labels + picker group headers localize (B5).
 
-### Lists, grids, data & detail
+#### Lists, grids, data & detail
 
 - **Master-detail saves are atomic on capable backends (#2684):**
   MasterDetailForm / LineItemsPanel persist through
@@ -667,7 +667,7 @@ and curated capability labels + picker group headers localize (B5).
   the new `drillRanges` bounds (#2672); the roll-up summary editor gains a
   visual child-row filter (#2669).
 
-### Auth & login
+#### Auth & login
 
 - **Never strand SSO-only users on a password wall (#2629):** the
   `/auth/config` fetch gets single-flight caching + retrying backoff, the
@@ -677,7 +677,7 @@ and curated capability labels + picker group headers localize (B5).
   signup page).
 - Dev-seeded admin credentials hint on the login page (#2635, dev-gated).
 
-### Platform & fixes
+#### Platform & fixes
 
 - **`@object-ui/types` adopts `@objectstack/spec` 15.1.1 (#2589,
   breaking):** value-erased `…Schema` re-exports from `spec/ui` are dropped;
@@ -694,7 +694,7 @@ and curated capability labels + picker group headers localize (B5).
   editors are fixed (#2666); AgentPreview drops the removed agent
   `visibility` (#2665).
 
-### Console changes after the `rc.0` pin
+#### Console changes after the `rc.0` pin
 
 The four frontend changes that were pending when this page was first written
 (import wizard `auto` policy — objectui#2701; schema-driven `keyValue` /
@@ -705,7 +705,7 @@ objectui#2706) **are now bundled**: the console pin advanced `94d4876 →
 further wave of Console work are described under
 [Landed since 16.0.0-rc.0](#landed-since-1600-rc0) below.
 
-## Landed since 16.0.0-rc.0
+### Landed since 16.0.0-rc.0
 
 These changes are on `main` after the `rc.0` cut and **rolled into
 `16.0.0-rc.1`**, cut on 2026-07-20 — the train's last RC, so every entry below
@@ -713,7 +713,7 @@ shipped in **16.0.0**. Backend from those changesets, Console from the objectui
 pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
 `@objectstack/console` 16.0.0-rc.1. Sourced from each repo's own changesets.
 
-### Breaking / behavior
+#### Breaking / behavior
 
 - **Deprecated `aiStudio` / `aiSeat` capability aliases removed (#3308,
   breaking-as-minor).** The one-cycle deprecation window from #3265 is over:
@@ -741,7 +741,7 @@ pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
   round-trip) can no longer slip its gate. Fail-open on unbound `current_user`
   is preserved.
 
-### New capabilities (backend)
+#### New capabilities (backend)
 
 - **Formulas that compute dates/durations stop silently nulling (#3306).**
   Two long-standing CEL gaps are closed alongside the build error above: the
@@ -799,7 +799,7 @@ pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
   so mark-as-read works on `os dev` / standalone instead of leaving unread
   state that could never clear.
 
-### New in Console (objectui, now bundled `94d4876 → 69fa5d163a97`)
+#### New in Console (objectui, now bundled `94d4876 → 69fa5d163a97`)
 
 - **Option-widget `visibleWhen` parity.** Per-option cascading + `dependsOn`
   gating lands across the widget family so client and server agree on which
@@ -831,7 +831,7 @@ pin advancing `94d4876 → 69fa5d163a97` (objectui #2701–#2743), bundled as
   flow `keyValue`/`numberList`, ActionParamDialog upload guard, system-field
   classifier) are included in this pin.
 
-## Landed at the 16.0.0 GA cut
+### Landed at the 16.0.0 GA cut
 
 Two changesets are in the `## 16.0.0` changelog sections but in **neither**
 `16.0.0-rc.0` nor `16.0.0-rc.1`: they landed between the last RC and the GA
@@ -857,7 +857,7 @@ cut on 2026-07-21, so they ship in 16.0.0 without appearing in any RC.
 
 ---
 
-# What's new in 16.1.0
+## What's new in 16.1.0
 
 16.1 is a small fast-follow minor — **8 changesets (5 minor, 3 patch), no
 major** — released on 2026-07-22, and the v16 line's final release. Three of
@@ -866,7 +866,7 @@ theme is moving configuration failures earlier: from a boot crash or a broken
 render to a build error. The bundled Console advances one pin,
 `9a5f016f7d5c → cf2d56e32a11`.
 
-## New capabilities in 16.1.0
+### New capabilities in 16.1.0
 
 - **`requires` capabilities are preflighted against installable providers
   (#3366).** A listed capability was only checked at `serve`/`start` time, and
@@ -914,7 +914,7 @@ render to a build error. The bundled Console advances one pin,
   fields (`created_at`, the `dateRange` default) and objects outside the
   validated stack never false-positive.
 
-## Behavior changes & fixes in 16.1.0
+### Behavior changes & fixes in 16.1.0
 
 - **`runAs: 'user'` flows execute data ops with the triggering user's real
   permission sets and positions (#3356, follow-up to #1888).** Since #1888 the
@@ -962,7 +962,7 @@ render to a build error. The bundled Console advances one pin,
   `@objectstack/plugin-hono-server` CRUD surface open the gate for an
   admin/service principal via the carried `posture` rung.
 
-## New in Console (Studio) — objectui pin `9a5f016f7d5c → cf2d56e32a11`
+### New in Console (Studio) — objectui pin `9a5f016f7d5c → cf2d56e32a11`
 
 - Record hits surface on the full search page, with i18n group labels
   (objectui#2776), and in the command palette from `/api/v1/search`
@@ -974,9 +974,9 @@ render to a build error. The bundled Console advances one pin,
 - `SchemaForm` renders sort repeater rows for union schemas (objectui#2771,
   pairing framework#3379).
 
-## Upgrade checklist
+### Upgrade checklist
 
-### 16.0.0
+#### 16.0.0
 
 - **Hooks/actions:** rename `ctx.session.tenantId` / `ctx.user.tenantId` →
   `organizationId` in every `*.hook.ts` / `*.action.ts` body.
@@ -1015,7 +1015,7 @@ render to a build error. The bundled Console advances one pin,
 - **Console hosts:** import spec schema values from `@objectstack/spec`
   instead of the removed `@object-ui/types` `spec/ui` re-exports.
 
-### 16.1.0
+#### 16.1.0
 
 - **Re-run `os build` / `os validate` after upgrading** — three new preflights
   can fail a stack that built clean on 16.0.0: a `requires` capability whose
@@ -1033,7 +1033,7 @@ render to a build error. The bundled Console advances one pin,
   silently stripped on a `public_read_write` object are now written when the
   user is authorized. `runAs:'system'` is unchanged.
 
-## References
+### References
 
 ADR-0099 (posture-authoritative tenant wall) · ADR-0101 (MCP stdio
 principal) · ADR-0102 (sandbox CPU budget + sync engine) · ADR-0103

--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -206,11 +206,11 @@ parsed-but-never-enforced spec clusters are removed rather than maintained.
 
 ---
 
-# 17.0.0 in detail
+## 17.0.0 in detail
 
-## Breaking changes & migration
+### Breaking changes & migration
 
-### Node.js 22 is the supported floor (#3825)
+#### Node.js 22 is the supported floor (#3825)
 
 `engines.node` moves from `>=18.0.0` to `>=22.0.0` across all 50 published
 manifests. Node 18 reached end-of-life on 2025-04-30 and Node 20 on 2026-04-30,
@@ -227,7 +227,7 @@ warning rather than a hard failure, so an existing install will not break the
 instant you upgrade; the package is simply no longer tested there. If your CI
 pins Node, pin it to 22 as well.
 
-### `allowExport` is opt-in — export no longer inherits read (#3544, #3710)
+#### `allowExport` is opt-in — export no longer inherits read (#3544, #3710)
 
 | | before | after |
 |---|---|---|
@@ -262,7 +262,7 @@ objects: {
 Read/CRUD/RLS/FLS/sharing are untouched, and reports are covered by the same
 axis.
 
-### `enable.apiMethods` shrinks to the six primitives (#3543)
+#### `enable.apiMethods` shrinks to the six primitives (#3543)
 
 The authorable enum is now exactly `get`, `list`, `create`, `update`, `delete`,
 `bulk`. The eight legacy values are **derived** effective operations resolved by
@@ -296,7 +296,7 @@ and flags whitelists the mapping would *widen* so every edit stays reviewable.
 `['upsert']`) strips to `[]`, which is **deny-all** — the object's API closes
 rather than widening.
 
-### An action must be declared to be invocable, and is identified by `name` (ADR-0110, #3935)
+#### An action must be declared to be invocable, and is identified by `name` (ADR-0110, #3935)
 
 Two halves of the `/api/v1/actions/:object/:action` contract were broken in
 complementary ways, which is why neither surfaced: the route resolved the
@@ -342,7 +342,7 @@ need no changes, other than gaining enforcement of the `requiredPermissions`
 they already declared. Callers that hard-coded a `target` in an action URL
 switch to the action's `name`.
 
-### An action's declared params are enforced at dispatch (ADR-0104 D2, #3438)
+#### An action's declared params are enforced at dispatch (ADR-0104 D2, #3438)
 
 An action's `params[]` (`required`, `options`, `multiple`, `reference`) was a
 complete contract that informed **only the client dialog**. The server passed
@@ -383,7 +383,7 @@ that costs one edited call. The value-shape half of the same ADR went the other
 way for the opposite reason: it rejects on the basis of data already at rest,
 so it stays gated per deployment (see *Files become platform records* below).
 
-### An action param's picker target is `reference`, and only `reference` (objectui#3203)
+#### An action param's picker target is `reference`, and only `reference` (objectui#3203)
 
 `ActionParam` in `@object-ui/types` no longer declares the nine resolved-side
 picker keys — `referenceTo`, `displayField`, `idField`, `descriptionField`,
@@ -420,7 +420,7 @@ and `resolveActionParams()` names any resolved-only key it still meets in a
 dev-mode warning carrying the prescription above — which covers the params
 authored in plain JS or JSON, where `tsc` never looks.
 
-### A flow run with no trigger user may not touch data (#3760)
+#### A flow run with no trigger user may not touch data (#3760)
 
 An effective `runAs: 'user'` run that resolved **no trigger user** used to
 execute its data nodes *unscoped* — it presented no principal, the data security
@@ -442,7 +442,7 @@ touch no data are unaffected, the engine warns at run *setup* before any node
 executes, and the originating write still succeeds because the trigger already
 swallows flow errors.
 
-### The last three deprecated authorable aliases are removed (#3855)
+#### The last three deprecated authorable aliases are removed (#3855)
 
 | Removed | Use instead | Value shape |
 |---|---|---|
@@ -484,7 +484,7 @@ existed to warn when an author declared both an alias and its canonical key,
 which the parse now rejects outright. Delete the import; there is no replacement
 because the condition can no longer occur.
 
-### Seven flow-node config key aliases graduate into the conversion layer (#3796)
+#### Seven flow-node config key aliases graduate into the conversion layer (#3796)
 
 | Node type(s) | Deprecated | Use instead |
 |---|---|---|
@@ -511,7 +511,7 @@ model), while `url` platform-wide means an HTTP endpoint to call (`http` node,
 webhooks). The singular `input` on `map` / `subflow` / `connector_action` is
 those nodes' own canonical key and is untouched.
 
-### Authorable schemas reject unknown keys (#4001)
+#### Authorable schemas reject unknown keys (#4001)
 
 Zod's default is `.strip`: a key a schema does not declare is silently
 discarded and the instance keeps parsing. On an authorable surface that is the
@@ -628,7 +628,7 @@ and the ADR-0010 **runtime protection envelope** (`_lock`, `_packageId`,
 it, a package-owned permission set could not round-trip through an
 environment overlay.
 
-### `agent.tools[]` is removed — capability comes from skills (ADR-0109, #3820)
+#### `agent.tools[]` is removed — capability comes from skills (ADR-0109, #3820)
 
 ADR-0064's invariant is "an agent's tool set is the union of its
 surface-compatible skills' tools; nothing falls through to the global registry".
@@ -648,7 +648,7 @@ declares `ai.exposed: true` + `ai.description` **and** has a headless path —
 warns on a stack declaring `stack.agents`, which the runtime has filtered from
 the catalog since ADR-0063.
 
-### Error codes are one SCREAMING_SNAKE vocabulary, and `error.code` is a closed set (ADR-0112, #3841)
+#### Error codes are one SCREAMING_SNAKE vocabulary, and `error.code` is a closed set (ADR-0112, #3841)
 
 The platform shipped two live error-code dialects: `StandardErrorCode` declared
 lowercase `snake_case` members while 139 codes on the wire were SCREAMING_SNAKE,
@@ -681,7 +681,7 @@ Not swept, deliberately: `sys_metadata_audit.code` (persisted audit history, and
 the column also holds non-errors like `ok`), diagnostics records that ship inside
 a 200, field-level codes (see below), and the CLI's `--json` output contract.
 
-### Field-level error codes are their own closed catalog, and `fieldErrors` becomes `fields` (ADR-0114, #3977)
+#### Field-level error codes are their own closed catalog, and `fieldErrors` becomes `fields` (ADR-0114, #3977)
 
 The per-field `code` inside `fields[]` is a **different** vocabulary from
 `error.code`, and it stays lowercase on purpose: a top-level code names the
@@ -707,7 +707,7 @@ wrong-typed.
 **Migration:** read `error.fields`; branch on the catalog's lowercase codes for
 per-field handling, and show `message` to the user rather than the code.
 
-### Approval requests are visible to participants, not the whole tenant (#3590)
+#### Approval requests are visible to participants, not the whole tenant (#3590)
 
 `getRequest` / `listRequests` / `countRequests` query with `SYSTEM_CTX` to
 bypass RLS because approver visibility spans identity forms RLS cannot model —
@@ -718,7 +718,7 @@ snapshot, its full decision history and its attachments. `approverId` on
 tenant. Callers that relied on the wide read must now be participants (or hold
 the admin override).
 
-### Sharing: the `full` access level is gone, and the recipient enum matches the runtime (#3865, #1878)
+#### Sharing: the `full` access level is gone, and the recipient enum matches the runtime (#3865, #1878)
 
 - **`accessLevel: 'full'` is removed.** It advertised delete/transfer/share and
   granted plain `edit`. Stored rules convert to `'edit'` — the access they
@@ -733,7 +733,7 @@ the admin override).
 - `guest` and the owner-type rules are pruned. Every authorable recipient and
   rule type is now enforced.
 
-### Sharing rules: an empty criteria shares nothing (#3896)
+#### Sharing rules: an empty criteria shares nothing (#3896)
 
 A rule stored without criteria — missing, `null`, `{}`, unparsable, or a
 misspelled key (`criterias`) — used to evaluate as `find(object, { filter: {} })`
@@ -762,7 +762,7 @@ There is no "share every record" sharing rule: object-wide read is the
 object's organization-wide default (`sharingModel`). A rule that relied on the
 empty shape must state its predicate, or the object should use `sharingModel`.
 
-### RLS: `enabled` is enforced, `priority` is removed (#3980, #3990)
+#### RLS: `enabled` is enforced, `priority` is removed (#3980, #3990)
 
 - **`enabled: false` now actually disables a policy.** The schema always said
   *"Disabled policies are not evaluated"*, but nothing read the property — and
@@ -778,7 +778,7 @@ empty shape must state its predicate, or the object should use `sharingModel`.
   tombstoned with a fix-it prescription; `os migrate meta` deletes the key
   mechanically, and policy outcomes are identical with or without it.
 
-### `required` is a write contract; the column constraint is `storage.notNull` (ADR-0113)
+#### `required` is a write contract; the column constraint is `storage.notNull` (ADR-0113)
 
 `field.required` used to mean three things through one knob: the write check,
 the physical `NOT NULL`, and the drift expectation. Bound together, tightening
@@ -811,7 +811,7 @@ Split in v17:
   auto-reconcile no longer silently strips a stray `NOT NULL`), and silent when
   the field is `required` (the write gate makes the constraint unreachable).
 
-### Membership grade is not a capability channel (ADR-0108, #3723)
+#### Membership grade is not a capability channel (ADR-0108, #3723)
 
 `sys_member.role` answers "what is your standing in this organization", not
 "what may you do" — but `resolve-authz-context` projected **every** value stored
@@ -821,7 +821,7 @@ system's controls (no `granted_by`, no effective dating, no ADR-0091 checks).
 The vocabulary is now closed. Move business capability to positions
 (`sys_user_position`).
 
-### better-auth 1.7.0-rc.2 — account identity restructuring
+#### better-auth 1.7.0-rc.2 — account identity restructuring
 
 better-auth renamed `account.accountId` to `account.providerAccountId` and added
 a **required** `account.issuer`; sign-in now resolves accounts by
@@ -852,7 +852,7 @@ so a fresh login re-links it.
 `@better-auth/scim` deliberately stays on 1.7.0-rc.1 — rc.2 replaces its whole
 model, which is a feature migration rather than a version bump.
 
-### Dead SDK surface deleted (#3612, #3702, #3718, #3731)
+#### Dead SDK surface deleted (#3612, #3702, #3718, #3731)
 
 Five client families built URLs that exist on **no** server surface, so every
 call was a guaranteed 404. They are removed, along with the four unconsumed
@@ -887,7 +887,7 @@ bare path collided with install semantics and REST wins first-match, so every
 `packages.install` call 400'd), and `meta.getView` stops speaking a `?type=`
 query dialect only the dispatcher understood.
 
-### The `ai` namespace now expresses the AI surface that exists (#3718)
+#### The `ai` namespace now expresses the AI surface that exists (#3718)
 
 | SDK | Route |
 |---|---|
@@ -913,7 +913,7 @@ The spec's dead AI declarations retire with the namespace:
 interface. The real server contract is `IAIService` + `IAIConversationService`
 in `@objectstack/spec/contracts`.
 
-### The GraphQL surface is removed (#2462)
+#### The GraphQL surface is removed (#2462)
 
 GraphQL was schema-only from day one: 20+ config schemas, a `handleGraphQL` that
 answered 501 unconditionally because `kernel.graphql` was never assigned, and
@@ -925,7 +925,7 @@ discovery/router route fields. **`/graphql` now 404s** (it used to 501).
 Not removed: the `'graphql'` protocol option on **external datasource** lookups —
 third-party systems may speak GraphQL, and that is not our API surface.
 
-### The `ObjectStackProtocol` composition alias is dissolved (ADR-0076 D9, #3606)
+#### The `ObjectStackProtocol` composition alias is dissolved (ADR-0076 D9, #3606)
 
 The transitional union of the twelve per-domain contracts — plus its parallel
 `ObjectStackProtocolSchema` Zod object and `ObjectStackProtocolZod` inferred type,
@@ -942,7 +942,7 @@ the Zod schema; **no runtime behaviour change**.
 `objectql`'s protocol re-exports are dropped in the same step: the protocol
 assembly is single-sourced through `metadata-protocol`.
 
-### A datasource that cannot connect fails the boot (#3741, #3758, #3826)
+#### A datasource that cannot connect fails the boot (#3741, #3758, #3826)
 
 - **A declared datasource that objects bind to must connect.** Previously only
   an `external` datasource with `validation.onMismatch: 'fail'` fail-fasted;
@@ -962,7 +962,7 @@ assembly is single-sourced through `metadata-protocol`.
 If you relied on a boot that survived an unreachable non-default datasource,
 that boot was already broken — it just failed later and with a worse message.
 
-### `unique` materializes per tenant (#3696)
+#### `unique` materializes per tenant (#3696)
 
 `unique: true` became a single-column **global** index that ignored `tenancy`
 entirely, while the autonumber sequence table is keyed by
@@ -971,7 +971,7 @@ starting at 1. Tenant B's `PROD-00001` was rejected by an index it could not
 see — and the rejection doubled as a cross-tenant existence oracle. The index is
 now tenant-scoped, matching the sequence.
 
-### Aggregation result shapes (#3839, #3849)
+#### Aggregation result shapes (#3839, #3849)
 
 - **One key for the empty group bucket.** Both aggregation paths now emit a real
   `null` for the empty bucket instead of two different placeholder spellings.
@@ -981,7 +981,7 @@ now tenant-scoped, matching the sequence.
   into one `(null)` bucket, and raw epoch storage that `aggregate()` /
   `distinct()` leaked.
 
-### i18n routes answer in the shapes they declare (#3676, #3778, #3847)
+#### i18n routes answer in the shapes they declare (#3676, #3778, #3847)
 
 - **`/i18n/labels/:object/:locale`** emits the declared entry object
   (`{ label, help?, options? }`) instead of a bare `Record<string, string>`.
@@ -1003,7 +1003,7 @@ now tenant-scoped, matching the sequence.
   were declared, put on the query string by the SDK, and read by neither serving
   surface; passing `keys` shrank nothing and reported nothing.
 
-### The dispatcher's `error.code` is the semantic code, not the HTTP status (#3842)
+#### The dispatcher's `error.code` is the semantic code, not the HTTP status (#3842)
 
 Everything the runtime dispatcher serves — `/meta/*`, `/actions/*`,
 `/packages/*`, `/automation/*`, `/analytics/*`, `/ready`, the route-not-found
@@ -1044,7 +1044,7 @@ somewhere else and did, in three different somewhere-elses: `error.details.code`
   the opposite of `ApiErrorSchema` for the same field, which is what let the
   deviation stand.
 
-### Anonymous access is denied unconditionally — `api.requireAuth` is gone (#3963)
+#### Anonymous access is denied unconditionally — `api.requireAuth` is gone (#3963)
 
 `api.requireAuth` was a deployment-wide opt-out: one boolean that let a stack
 serve its **entire** data plane to unauthenticated callers. Auth is a kernel
@@ -1059,7 +1059,7 @@ authorization rather than opening the whole data plane: a public form view
 `book.audience: 'public'` (ADR-0046 §6.7). `os migrate meta` drops the key and
 emits a notice telling you where public access has to be re-declared.
 
-### `wait` never had a timeout — `timeoutMs` / `onTimeout` are retired (#4158)
+#### `wait` never had a timeout — `timeoutMs` / `onTimeout` are retired (#4158)
 
 Both keys described a timeout and neither delivered one.
 `waitEventConfig.onTimeout` had **zero** readers — no path ever inspected it, so
@@ -1076,7 +1076,7 @@ outright when `timerDuration` was already set. `onTimeout` is deleted; there is
 no replacement. Real timeout semantics are left to be built to a requirement
 rather than retrofitted onto two keys that happened to be declared.
 
-### The query request surface sheds five inert keys (#4196, #4286)
+#### The query request surface sheds five inert keys (#4196, #4286)
 
 `QueryAST` is a **request** shape — never stored in stack metadata — so these
 are caller-side edits, not a source rewrite: `os migrate meta` has nothing to
@@ -1101,7 +1101,7 @@ honoured — `updateManyData`, `deleteManyData` and `batchData` persisted
 regardless, so a caller sending it to *preview* a mutation got it executed. It
 is HTTP-only; stop sending it.
 
-### `findOne` must say which record it wants (#4419)
+#### `findOne` must say which record it wants (#4419)
 
 `findOne` reads a single row. That makes its predicate the only thing standing
 between the caller and *an arbitrary record* — and when the predicate is missing
@@ -1145,7 +1145,7 @@ unknown-key rejection (both already in this release), a read parameter the engin
 does not execute now fails at the call site instead of quietly changing the
 answer.
 
-### Dead spec clusters removed
+#### Dead spec clusters removed
 
 **App shell (2026-06 liveness audit, #4001 app step).** `App.version`,
 `App.aria`, `App.objects`, `App.apis`, `App.sharing`, `App.embed` and
@@ -1196,7 +1196,7 @@ The Console side follows: `@object-ui/types` drops its
 pointed at the same retired cluster (objectui#2860). Import what you still need
 from `@objectstack/spec` directly.
 
-### Field widgets receive their metadata on one key, `field` (objectui#3233)
+#### Field widgets receive their metadata on one key, `field` (objectui#3233)
 
 `FieldWidgetComponentProps` no longer declares `schema`. The prop was a second
 carrier for what `field` already means: `SchemaRenderer` passed the authored
@@ -1243,7 +1243,7 @@ universal SDUI prop every registered component receives from `SchemaRenderer`
 (`element:*`, `page:*`, grids, reports); only the *field-widget* contract retired
 it.
 
-### Flow node geometry is the spec's `FlowNode.position` (objectui#3172)
+#### Flow node geometry is the spec's `FlowNode.position` (objectui#3172)
 
 The flow designer writes node coordinates as `position: { x, y }` — the key
 `@objectstack/spec` has modelled all along — instead of its own `ui: { x, y }`.
@@ -1276,7 +1276,7 @@ repo or the engine ever read the key — it was designer-local, and the schema
 rejected it — so the migration reaches only code written against the designer's
 own drafts.
 
-### Smaller breaking changes
+#### Smaller breaking changes
 
 - **MongoDB driver declares itself single-tenant** and refuses to boot in a
   multi-tenant configuration rather than silently mixing tenants (#3724).
@@ -1316,9 +1316,9 @@ own drafts.
   working, and the *app-bundle* `onEnable` module export (dispatched by
   AppPlugin at boot) is a different, real contract — unchanged.
 
-## New capabilities in 17.0.0
+### New capabilities in 17.0.0
 
-### Files become platform records (ADR-0104)
+#### Files become platform records (ADR-0104)
 
 The headline of the line. `@objectstack/spec/data` now owns the **runtime value
 shape** of every field type (`field-value.zod.ts`): semantic type classes,
@@ -1428,7 +1428,7 @@ own per-deployment gate is still being built (#3438). Those stay warn-only by
 default until it lands, because unlike media they have no migration standing
 behind them yet.
 
-### Approvals: dynamic approver routing (#3447)
+#### Approvals: dynamic approver routing (#3447)
 
 - **`expression` approvers.** A CEL expression resolves *who* approves at node
   entry, over exactly three roots: `current.*` (the record's live state),
@@ -1470,7 +1470,7 @@ behind them yet.
   transition, and a decision recorded against the authenticated caller rather
   than a body field.
 
-### The SDK reaches the whole REST surface (#3563, #3587)
+#### The SDK reaches the whole REST surface (#3563, #3587)
 
 Beyond the deletions above, the client gains typed access to everything the
 server actually mounts: the `actions` surface, `keys` / `shareLinks` /
@@ -1486,7 +1486,7 @@ the dispatcher and the autonomously-mounted service routes each carrying their
 own ledger. `analytics.meta` / `analytics.explain` and two i18n calls that
 reached nothing are repaired by the same audit.
 
-### Write observability — a silent strip stops reading as a clean save
+#### Write observability — a silent strip stops reading as a clean save
 
 `PATCH`/`POST /data` surface **`droppedFields`** when the server silently strips
 a write, extended to the bulk paths, the cross-object batch, and the client SDK;
@@ -1495,7 +1495,7 @@ create now goes through the same create ingress as a single create. `os validate
 runs the four authoring lints `os build` runs, so "validate clean, build fails"
 is gone.
 
-### Analytics correctness
+#### Analytics correctness
 
 - `ObjectQLStrategy` **enforces the read scope** (RLS + tenant), and the
   read-scope auto-bridge no longer depends on plugin order.
@@ -1511,7 +1511,7 @@ is gone.
 - Cube auto-inference is gated on object existence, and the dispatcher boundary
   stops returning raw SQL.
 
-### Automation & flows
+#### Automation & flows
 
 - **Every terminal run reports what it did** (#4354): `selected` / `acted` /
   `skipped` totals, a per-node breakdown, and *which gate closed* — on the run
@@ -1540,14 +1540,14 @@ is gone.
   `{current_user_id}` vocabulary is frozen with unresolvable placeholders
   failing the build.
 
-### Historical data import
+#### Historical data import
 
 `treatAsHistorical` skips the state machine for historical-data migration **and**
 preserves the original audit timeline — including on undo. Row errors are
 sanitized so a constraint failure reads as human wording instead of leaking raw
 SQL.
 
-### Lint & CLI
+#### Lint & CLI
 
 New and widened rules: reference-integrity validation for object and action
 names, translation-bundle reference integrity and option-key validation,
@@ -1566,7 +1566,7 @@ banner reports seed outcomes (`Seeds: X inserted · Y updated · Z skipped`,
 escalating to a yellow `⚠ … N REJECTED` line) so a fixture can no longer lose
 most of its rows in silence.
 
-### Spec, kernel & platform
+#### Spec, kernel & platform
 
 - **`ISecurityService` is published** — the `security` service surface becomes
   an enforced contract, with `security.getReadableFields` for export column
@@ -1614,14 +1614,14 @@ most of its rows in silence.
   which converts an already-switched database back.
 - Metadata-plane FLS (per-caller masking) is proposed as ADR-0106.
 
-## New in Console (Studio) — bundled objectui 17.0
+### New in Console (Studio) — bundled objectui 17.0
 
 This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
 4a4829d0ef39` (`.objectui-sha`) — 128 objectui commits on top of the pin
 16.1.0 shipped. The pin has since advanced — the rest of the line is under
 *New in Console* in the **Landed since 17.0.0-rc.0** section below.
 
-### Files, actions and forms
+#### Files, actions and forms
 
 - **The file-as-reference value shape is adopted** end-to-end (ADR-0104 D3
   wave 2), including a localized FileField upload widget.
@@ -1634,7 +1634,7 @@ This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
   committing during render.
 - Image fields render consistently and support click-to-zoom.
 
-### Approvals
+#### Approvals
 
 - **Typed output pickers, dynamic decision-output fields, expression approver
   editing**, quick-path guard and expression completion — the Console half of
@@ -1646,7 +1646,7 @@ This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
   approval locks, and distinguishes "in approval (editable)" from locked.
 - The inbox renders against one ticking clock.
 
-### Data, grids and charts
+#### Data, grids and charts
 
 - The grid computes **all eleven** spec column summary aggregations, gates row
   Edit/Delete and bulk delete on the **effective operation set**, and shows the
@@ -1670,7 +1670,7 @@ This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
   vocabulary (`filter`, `$notContains`, type/label/maxLength keys), and `secret`
   stays out of inline edit.
 
-### Flows, Studio and Setup
+#### Flows, Studio and Setup
 
 - A paused **screen flow is completable**: `visibleWhen` is honored in render and
   validation, flow actions dispatch from every surface, and the runner stops
@@ -1690,7 +1690,7 @@ This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
 - The API console lists the whole **AI family** and the routes that exist, and
   the tool preview stops linking to a 404.
 
-### Internationalization & quality
+#### Internationalization & quality
 
 - **The locale backfill completes: all ten packs reach full key parity.** The
   four highest-traffic namespaces are translated into the eight trailing locales,
@@ -1703,7 +1703,7 @@ This section covers the window bundled at **`rc.0`**: `cf2d56e32a11 →
   `plugin-map` default import is dropped to match), `chalk` 5→6, and `jsdom`
   29→30 (dev) — relevant if you build the Console from source.
 
-## Landed since 17.0.0-rc.0
+### Landed since 17.0.0-rc.0
 
 These changes are on `main` after the `rc.0` cut and **roll into 17.0.0-rc.1** —
 backend from the pending changesets (334 at the time of writing, 40 of them
@@ -1750,7 +1750,7 @@ What follows is the rest of the window: first the metadata- and
 protocol-facing changes an upgrading application developer must read, then the
 platform capabilities an administrator gains, then the Console delta.
 
-### Breaking / behavior — protocol & wire
+#### Breaking / behavior — protocol & wire
 
 - **The actions route speaks HTTP (#3962, #3951, #3937, #3913).** The
   accidental 200-with-inner-envelope double wrap is gone; the contract is now
@@ -1939,7 +1939,7 @@ platform capabilities an administrator gains, then the Console delta.
   now fails `tsc` with the real error, gated by the new `check:exported-any`
   (#4171, #4195, #4221).
 
-### Breaking / behavior — metadata authoring & runtime
+#### Breaking / behavior — metadata authoring & runtime
 
 - **Flow-node config is enforced end to end (#4277, #4045, #4027, #4347,
   #4389).** The twelve contract-carrying builtins `parse()` their `config`
@@ -2036,7 +2036,7 @@ platform capabilities an administrator gains, then the Console delta.
   inert; and a record's owner or a Modify-All admin — not just the minter —
   can revoke a share link.
 
-### Security corrections
+#### Security corrections
 
 Beyond the sharing-authority work and the #3896 enforcement half documented
 above, four fail-opens were found and closed in this window — all ship in
@@ -2062,7 +2062,7 @@ rc.1, and administrators should know what changed:
   real auth service, and `/analytics/sql` crashing 500 on providers without
   `generateSql`.
 
-### New capabilities (backend)
+#### New capabilities (backend)
 
 - **Approvals grow up as a decision surface.** A `decisionOutputs` entry can
   declare `required: true` — an approve carrying a blank routing value is
@@ -2157,7 +2157,7 @@ rc.1, and administrators should know what changed:
   the generated upgrade guide and the `spec_changes` MCP tool actually
   report the 16 → 17 chain (they still said 16.0.0).
 
-### New in Console — bundled objectui advanced `4a4829d0ef39 → 7d9734d5e321`
+#### New in Console — bundled objectui advanced `4a4829d0ef39 → 7d9734d5e321`
 
 143 objectui commits across five pin moves, released as **objectui 17.1.0**.
 (The pin changesets enumerate 79 of them; one range under-enumerated its own
@@ -2256,7 +2256,7 @@ documented under *Breaking changes & migration* above.
   longer capped at 8 objects; the chart view gets a label and an icon in the
   view switcher; and the developer-voiced default form subtitle is dropped.
 
-## Landed since 17.0.0-rc.1
+### Landed since 17.0.0-rc.1
 
 These changes are on `main` after the `rc.1` cut and **roll into 17.0.0-rc.2**.
 At the time of writing the window had left 209 changesets pending — 46
@@ -2291,7 +2291,7 @@ As in the rc.0 window, landings that belong to a section above are documented
 - **`os migrate meta --stored`** (#4327) — in the checklist as the optional
   stored-metadata pass.
 
-### One name, one declaration — the #4535 dual-source campaign closes
+#### One name, one declaration — the #4535 dual-source campaign closes
 
 A bare name exported from two `@objectstack/spec` subpaths, resolving to **two
 different declarations**, is the #4411 trap: an editor's auto-import picks by
@@ -2334,7 +2334,7 @@ name. The campaign leaves a gate behind — `dual-source-exports.baseline.json` 
 now ratcheted by **symbol identity**, not by name (#4446), so two entries
 exporting the same name from different declarations fail the build.
 
-### The authorable surface closes — #4001 reaches zero
+#### The authorable surface closes — #4001 reaches zero
 
 The unknown-key strictness campaign began with a single object schema and ends
 in this window. Every authorable type now rejects unknown keys with a
@@ -2366,7 +2366,7 @@ registered types; fixed, it immediately found 8 undeclared envelopes (#4519).
 The deleted-baseline discipline tightened too: a removed `authorable-surface.json`
 line must now prove itself rather than being taken on trust (#4650).
 
-### ADR-0049 enforce-or-remove — the sweep reaches the driver and datasource contracts
+#### ADR-0049 enforce-or-remove — the sweep reaches the driver and datasource contracts
 
 The v16 sweep took the *authoring* surface; this one takes the **contracts**.
 Each removal below was declared, strict-guarded or `required`, and read by
@@ -2409,7 +2409,7 @@ consequence — the affordance default flips from LOCKED to **WRITABLE**, so the
 re-open their writes with are now redundant and deleted. Keep `userActions` only
 to *narrow*.
 
-### Author-time gates: a completeness test, and a fourth door
+#### Author-time gates: a completeness test, and a fourth door
 
 **ADR-0078 completeness (#4544).** An instance can be Zod-valid, use only live
 properties, and have a correctly-authored sibling that provably runs — and still
@@ -2489,7 +2489,7 @@ bundle drift (#4804); and `check:react-conformance` is renamed
 `check:react-declaration-parity`, because it compares two declarations and said
 it compared a declaration to an implementation (#4472).
 
-### Atomicity and durable migrations — ADR-0118, ADR-0119
+#### Atomicity and durable migrations — ADR-0118, ADR-0119
 
 - **`atomic` becomes a guarantee (#4612, D1/D4).** `batchData`'s
   `options.atomic` promised "rollback entire batch on any failure" and delivered
@@ -2535,7 +2535,7 @@ it compared a declaration to an implementation (#4472).
   canonicalization (#4580); `duplicatePackage` stops minting pre-protocol flow
   rows (#4498).
 
-### Protocol & wire changes
+#### Protocol & wire changes
 
 - **Batch per-row results deliver their declared shape (#4793).** The rows of
   `POST /data/:object/batch`, `/updateMany` and `/deleteMany` had drifted from
@@ -2571,7 +2571,7 @@ it compared a declaration to an implementation (#4472).
   the scan on a deployment carrying exactly the values it exists to find, was
   told it was clean, and closed the gate.
 
-### Metadata authoring & runtime changes
+#### Metadata authoring & runtime changes
 
 - **A hook `condition` the platform cannot evaluate now ABORTS the operation
   (#4775).** It used to `logger.warn` and `return false` — the hook simply did
@@ -2630,7 +2630,7 @@ it compared a declaration to an implementation (#4472).
   than resolving it as a natural key (#4644).
 - **A `defaultValue` runtime token never becomes a column DEFAULT (#4560).**
 
-### Security corrections in this window
+#### Security corrections in this window
 
 - **Comments were readable by anyone who could guess a thread id (#4630).**
   Attachments derive visibility from the parent record; comments derived
@@ -2685,7 +2685,7 @@ it compared a declaration to an implementation (#4472).
 - **The ADR-0104 fresh-datastore attestation concludes on this boot's own data
   (#4769)**, not on the emptiness it remembers from before the boot wrote.
 
-### New backend capabilities in this window
+#### New backend capabilities in this window
 
 - **Predicate writes get an honest bulk event contract (#4639).** A `multi: true`
   update or delete reaches `updateMany` / `deleteMany`, which resolve a row
@@ -2734,7 +2734,7 @@ it compared a declaration to an implementation (#4472).
 - **A `RETURNING` write persists on `driver-sqlite-wasm` (#4518)**, unblocking
   cold-boot e2e.
 
-## Landed since 17.0.0-rc.2
+### Landed since 17.0.0-rc.2
 
 These changes are on `main` after the `rc.2` cut and **roll into 17.0.0-rc.4**.
 Counted across the `17.0.0-rc.4` sections of the package changelogs, the cut
@@ -2815,7 +2815,7 @@ are documented **there** rather than repeated here.
   (#4964 `flow.errorHandling`, #4962), and `dashboard.widgets[].compareTo`
   converges on the analytics executor's contract (#5011).
 
-### New in Console — bundled objectui advanced `f5bc4c78be76 → f995a452d2ca`
+#### New in Console — bundled objectui advanced `f5bc4c78be76 → f995a452d2ca`
 
 One pin move, released as **@objectstack/console 17.0.0-rc.4**: 98 non-merge
 objectui commits, of which 64 of 65 changesets release; the enumeration is
@@ -2825,7 +2825,7 @@ one key, `field`** (objectui#3233) and **flow node geometry is the spec's
 `FlowNode.position`** (objectui#3172) — both documented under *Breaking changes
 & migration* above.
 
-## Landed since 17.0.0-rc.4
+### Landed since 17.0.0-rc.4
 
 These changes are on `main` after the `rc.4` cut and **roll into 17.0.0-rc.5**.
 A short window: **10 changesets — 2 `major`-class, 4 `minor`, 4 `patch`**,
@@ -2863,13 +2863,13 @@ listed below; the tenth is the Console pin move.
   honest cell for a shape fragment with no gate and no parse whose every
   consumer already guards.
 
-### New in Console — bundled objectui advanced `f995a452d2ca → 7dfbeb704e1e`
+#### New in Console — bundled objectui advanced `f995a452d2ca → 7dfbeb704e1e`
 
 One pin move, released as **@objectstack/console 17.0.0-rc.5**: 28 non-merge
 objectui commits, 9 of 9 changesets releasing, all `patch`; the enumeration is
 `console-7dfbeb704e1e`. No author-facing breaking migration.
 
-## Landed since 17.0.0-rc.5
+### Landed since 17.0.0-rc.5
 
 These changes are on `main` after the `rc.5` cut and **roll into
 17.0.0-rc.6**, cut on 2026-08-10. The cut released **425 changesets — 36
@@ -2940,7 +2940,7 @@ three bullets after them cover what landed between that draft and the cut.
   zero-reader SDUI page-component props retire and four more are declared, with
   `page:tabs.type` renamed `tabStyle` (#5775, #6776).
 
-### New in Console — bundled objectui advanced `7dfbeb704e1e → 0cf8f0f70d10`
+#### New in Console — bundled objectui advanced `7dfbeb704e1e → 0cf8f0f70d10`
 
 One pin move, released as **@objectstack/console 17.0.0-rc.6**: 66 non-merge
 objectui commits, 24 of 24 changesets releasing; the enumeration is
@@ -2955,7 +2955,7 @@ changeset records that verdict against ADR-0087. The same changeset also lists,
 by subject rather than by count, the 42 commits in the range that carried no
 changeset of their own.
 
-## Landed since 17.0.0-rc.6
+### Landed since 17.0.0-rc.6
 
 These changes are on `main` after the `rc.6` cut and **ship in 17.0.0** — the
 last window of the train, released by the cut that exited Changesets pre-mode
@@ -2969,7 +2969,7 @@ is called out under *Metadata, packages & authoring gates*.
 As in the windows above, landings that belong to a section higher up the page
 are documented **there** rather than repeated here.
 
-### Credentials stop being writable in the clear (#7990, #8082, #8336, #8075)
+#### Credentials stop being writable in the clear (#7990, #8082, #8336, #8075)
 
 The largest coherent story in this window. `sys_metadata.metadata` is served
 back by the ordinary data API and a datasource or connector artefact is
@@ -3039,7 +3039,7 @@ secret re-arms the moment the `CryptoProvider` registers instead of ~60s later
 the subscription instead of arming it and delivering unsigned or with the
 headers missing (#8542, #8558).
 
-### Driver text stops reaching the caller
+#### Driver text stops reaching the caller
 
 A caught driver error was being interpolated into client-facing messages across
 the metadata plane, which discloses dialect, schema and sometimes data. The
@@ -3051,7 +3051,7 @@ the direct-mount package door's leaky 5xx (#8086), a bulk write's per-row
 of a driver failure. A package publish that faults in the driver is answered as
 a server error rather than passing the text through.
 
-### Breaking changes since rc.6
+#### Breaking changes since rc.6
 
 Beyond the credential doors above:
 
@@ -3123,7 +3123,7 @@ Beyond the credential doors above:
 - **Two `sys_audit_log` action values retire** — `export` / `permission_change`,
   then `restore` (#8315, #7675) — declared actions with no writer anywhere.
 
-### Security corrections since rc.6
+#### Security corrections since rc.6
 
 - **A tenant-scoped write with no active organization is refused**, naming what
   is missing (ADR-0123 D2, #8247/#8208) — and a user's first session no longer
@@ -3180,7 +3180,7 @@ Beyond the credential doors above:
   **own** API key (#8053); and `member_default` grants owner-scoped read on the
   personal inbox (#7344).
 
-### Protocol & wire changes since rc.6
+#### Protocol & wire changes since rc.6
 
 - **`like` / `ilike` stop being folded onto `$contains` at the wire** (#7536),
   and `$search` compiles to `$icontains` so textual search is actually
@@ -3206,7 +3206,7 @@ Beyond the credential doors above:
 - **Exported `datetime` cells render in the business timezone, not UTC**
   (#8373).
 
-### Metadata, packages & authoring gates
+#### Metadata, packages & authoring gates
 
 - **An authored OWD is required at the runtime object door** (#8600), completing
   the #7891 flip — `runtimeTypes` gains `object`, and ADR-0094 R2's
@@ -3253,7 +3253,7 @@ Beyond the credential doors above:
   per-type read-path redaction seam lands in `kernel` with one definition of
   "what is a credential key" in `data` (#8300).
 
-### Drivers, query engine & analytics
+#### Drivers, query engine & analytics
 
 - **`$field` becomes a real cross-field comparison.** SQL push-down compiles it
   to a column-to-column comparison (#5222); equality triples lower to
@@ -3279,7 +3279,7 @@ Beyond the credential doors above:
   single-record update stops reporting the addressed row's own primary key as a
   dropped field (#8093).
 
-### Automation, jobs & the audit trail
+#### Automation, jobs & the audit trail
 
 - **Automation runs record what triggered them, and keep it across a restart**
   (#7533). A durable PAUSED run is visible to `listRuns` and run-detail after a
@@ -3303,7 +3303,7 @@ Beyond the credential doors above:
   #8400). A bearer-authenticated metadata write is attributed to the caller
   rather than to `system` (#7749).
 
-### New backend capabilities since rc.6
+#### New backend capabilities since rc.6
 
 - **`OS_ARTIFACT_URL` — artifact-pinned boot** (#8368): boot a stack from a
   published artifact by reference, with an SRI-style fragment pin.
@@ -3335,7 +3335,7 @@ Beyond the credential doors above:
 - **The multi-node gate can carry an admitted node count**, so a license cap
   refuses the excess replicas rather than the whole cluster.
 
-### New in Console — bundled objectui advanced `0cf8f0f70d10 → 665661ab0932`
+#### New in Console — bundled objectui advanced `0cf8f0f70d10 → 665661ab0932`
 
 **Three pin moves**, released as **@objectstack/console 17.0.0** — the
 enumerations are `console-6314e87f2d49`, `console-6d77acfe3125` and
@@ -3379,7 +3379,7 @@ views stop crashing on LAN IPs.
 
 ---
 
-# What's new in 17.1.0
+## What's new in 17.1.0
 
 17.1.0 was published to the `latest` tag on **2026-08-20**, six days after the
 17.0.0 GA. It is a large minor: the version-locked train moved **69 packages**,
@@ -3404,7 +3404,7 @@ revoke access now revokes it, a read that failed stops being served as an empty
 one, a flow that never dispatched stops being reported as a run that failed, and
 a credential that was never meant to be readable stops being served.
 
-## New capabilities in 17.1.0
+### New capabilities in 17.1.0
 
 - **Partial field masking (#8993).** `FieldSchema` declares `maskingRule` — the
   closed preset enum `phone` / `id_card` / `bank_account` / `email` / `name`,
@@ -3575,7 +3575,7 @@ a credential that was never meant to be readable stops being served.
   (#8480). `IHttpServer` gains an optional `afterResponse` response-observing
   hook. `GanttConfigSchema` declares `viewMode`.
 
-## Security corrections in 17.1.0
+### Security corrections in 17.1.0
 
 The largest cluster in this release, and the reason its minor version number is
 not a safety guarantee.
@@ -3662,9 +3662,9 @@ not a safety guarantee.
   than a security-shaped refusal, and security explain reports partial masking as
   a third state instead of calling gated fields hidden.
 
-## Behavior changes & fixes in 17.1.0
+### Behavior changes & fixes in 17.1.0
 
-### The flow doors answer real HTTP statuses
+#### The flow doors answer real HTTP statuses
 
 - **The automation `trigger` routes** now answer `409` `FLOW_DISABLED` for a
   disabled flow and `422` `FLOW_NO_START_NODE` for a definition with no start
@@ -3695,7 +3695,7 @@ not a safety guarantee.
   author's `successMessage` / `errorMessage` through `execute()` and both retry
   exits.
 
-### A failed read stops reading as an empty one
+#### A failed read stops reading as an empty one
 
 A recurring class this release closes in several packages at once: a read that
 FAILED was indistinguishable from a read that legitimately found nothing.
@@ -3727,7 +3727,7 @@ FAILED was indistinguishable from a read that legitimately found nothing.
   quiet object; and `GET /api/v1/meta/:type` refuses a type name that names
   nothing instead of serving it as an empty collection (#9488).
 
-### Author-time gates reach the runtime publish door
+#### Author-time gates reach the runtime publish door
 
 Rules that only `os build` / `os validate` ran now also judge a runtime write, so
 Studio and the metadata API cannot land what the CLI refuses.
@@ -3760,7 +3760,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   before exempting a system column (#8663), and the same provenance question is
   asked at a fifth blanket-`SYSTEM_FIELDS` read site, `searchableFields` (#8404).
 
-### The authorable surface closes further
+#### The authorable surface closes further
 
 - **Unknown top-level stack keys are refused (#8687)** — `ObjectStackDefinitionSchema`
   was the last strip-mode surface of the #4001 campaign. Measured on 17.0.0 GA,
@@ -3787,7 +3787,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   `BATCH_PARTIAL_FAILURE`, `BATCH_COMPLETE_FAILURE` and `TRANSACTION_FAILED` leave
   `StandardErrorCode` (ADR-0112 amendment, 2026-08-18).
 
-### Datasource credentials reach the driver
+#### Datasource credentials reach the driver
 
 - A bound `external.credentialsRef` now reaches the **mongo** client on a URL
   branch, the **mysql** client on the DSN branch (#8696), and the **postgres**
@@ -3803,7 +3803,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   `username`" (#9147) and "`credentialsRef` bound + a mongo `config.url` naming no
   user" (#9041).
 
-### Drivers, query engine and analytics
+#### Drivers, query engine and analytics
 
 - **One unresolvable WHERE column, one answer.** `find()` and `count()` both
   refuse with `INVALID_FILTER` / 400 naming the column, and **MySQL joins the
@@ -3837,7 +3837,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   refusals are restored through the wired engine on `sys_attachment` (#9719) and
   `sys_comment`.
 
-### CLI & developer experience
+#### CLI & developer experience
 
 - **`objectstack init` scaffolds now compile (#9666).** `init … --install`
   reported `✓ Scaffold validated` and the next documented step, `npm run dev`,
@@ -3878,7 +3878,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   `ObservabilityServicePlugin`, so `observability:metrics` resolves for every
   consumer following the canonical resolution chain.
 
-### Observability, packaging and published docs
+#### Observability, packaging and published docs
 
 - `http_requests_total` and `http_request_duration_ms` are emitted from the
   transport seam, so every inbound mount is counted (#9650). `/discovery`
@@ -3896,7 +3896,7 @@ Studio and the metadata API cannot land what the CLI refuses.
   on the docs site (#9632). The better-auth family moves off the `1.7.0-rc.2`
   prerelease onto stable `^1.7.1`.
 
-## New in Console (Studio) — objectui pin `665661ab0932 → 9a3daf8d37ad`
+### New in Console (Studio) — objectui pin `665661ab0932 → 9a3daf8d37ad`
 
 Two pin moves in this release (`665661ab0932 → 82a94170c405`, then
 `82a94170c405 → 9a3daf8d37ad`). Notable declared changes:
@@ -3944,9 +3944,9 @@ Two pin moves in this release (`665661ab0932 → 82a94170c405`, then
   private `?runAction=` string convention retires; and the current organization
   shows in the top bar for users with exactly one membership.
 
-## Upgrade checklist
+### Upgrade checklist
 
-### 17.0.0
+#### 17.0.0
 
 - **Node:** move to Node 22+ (and pin CI to 22).
 - **Export:** add `allowExport: true` to every environment-authored permission
@@ -4275,7 +4275,7 @@ Two pin moves in this release (`665661ab0932 → 82a94170c405`, then
   computing nothing.
 
 
-### 17.1.0
+#### 17.1.0
 
 ⚠️ Despite the minor version number, four of these are behaviour changes on live
 data or on a published wire contract. Work through them before upgrading.
@@ -4375,7 +4375,7 @@ data or on a published wire contract. Work through them before upgrading.
   `errorMessage` and the run `summary` in `error.details` — review anything that
   parsed the previous generic text.
 
-## References
+### References
 
 ADR-0104 (field runtime value-shape contract / file-as-reference) · ADR-0105
 (group tenancy posture) · ADR-0106 (metadata-plane FLS, proposed) · ADR-0108

--- a/scripts/check-docs-single-h1.mjs
+++ b/scripts/check-docs-single-h1.mjs
@@ -81,34 +81,50 @@
 // wrong, and a gate disagreeing with the renderer about what a page says is the
 // same class of defect as no gate at all.
 //
-// ## Scope: one tree is excluded, and the exclusions are self-retiring
+// ## Scope: no tree is excluded, and the exclusions are self-retiring
 //
 // `EXCLUSIONS` carves out SUBTREES — never individual files. A file allowlist
 // is where new failures go to be forgotten; a subtree with a named owner is a
 // statement about who fixes that tree.
 //
+// **It is EMPTY, and empty is the goal state.** Both entries it has ever
+// carried were retired by the same limb:
+//
+// **An exclusion whose tree is CLEAN is a failure, not a pass.** The gate goes
+// red with `DEAD-EXCLUSION` and asks for its own carve-out to be deleted.
+// Without that limb an exclusion would outlive its reason and quietly shrink
+// the gate's scope forever — the vacuous-green shape (#4690) that this repo
+// treats as worse than no check.
+//
+//   - `content/docs/references/**` — 38 generated pages whose `# ` came from a
+//     JSDoc file header that `packages/spec/scripts/build-docs.ts` copied
+//     verbatim, so a hand-edit did not merely get reverted at the next
+//     generator run — `check:docs` regenerates the tree and fails on any
+//     difference, so it shipped CI-red immediately. #12249 fixed it where it
+//     was fixable, in the generator, which now renumbers a file header's
+//     headings to start at the page's section level; this gate went
+//     `DEAD-EXCLUSION` on the regenerated tree and the entry came out in that
+//     same change.
+//
 //   - `content/docs/releases/**` — `CLAUDE.md` puts a hard stop on this
-//     directory, and three of its four violations are not mechanical: the `# `
-//     headings in `v15`/`v16`/`v17.mdx` are real top-level dividers with `##`
-//     children, so demoting one makes it a sibling of its own subsections. Owned
-//     by #12250.
+//     directory, and three of its four violations were not mechanical: the `# `
+//     headings in `v15`/`v16`/`v17.mdx` were real top-level dividers with `##`
+//     children, so demoting one alone would have made it a sibling of its own
+//     subsections. #12250 cascaded those three instead — from each page's first
+//     body `# ` to EOF, every heading moved down one level, so an "in detail"
+//     section still owns its subsections — and deleted the one heading that
+//     merely repeated its frontmatter title. It shipped as a dedicated
+//     docs-only PR, which is that `CLAUDE.md` rule's own escape hatch. This
+//     gate went `DEAD-EXCLUSION` on the cleaned tree and the entry came out in
+//     that same change.
 //
-// **An exclusion whose tree is CLEAN is a failure, not a pass.** When #12250
-// lands, this gate goes red with `DEAD-EXCLUSION` and asks for its own carve-out
-// to be deleted. Without that limb an exclusion would outlive its reason and
-// quietly shrink the gate's scope forever — the vacuous-green shape (#4690)
-// that this repo treats as worse than no check.
-//
-// That limb has now been paid out once, which is the only evidence that it
-// works. `content/docs/references/**` was the second entry here: 38 generated
-// pages whose `# ` came from a JSDoc file header that
-// `packages/spec/scripts/build-docs.ts` copied verbatim, so a hand-edit did not
-// merely get reverted at the next generator run — `check:docs` regenerates the
-// tree and fails on any difference, so it shipped CI-red immediately. #12249
-// fixed it where it was fixable, in the generator, which now renumbers a file
-// header's headings to start at the page's section level; this gate went
-// `DEAD-EXCLUSION` on the regenerated tree and the entry came out in that same
-// change. Its 38 pages are judged here now, like every other page.
+// So the limb has been paid out TWICE, which is the whole of the evidence that
+// it works — and with the list empty, the live corpus exercises none of the
+// machinery it belongs to. That is why `scanTree` takes its exclusions as a
+// PARAMETER and the self-test drives them through a SYNTHETIC carve-out: an
+// `exclusionFor`, an `excluded` tally and a `DEAD-EXCLUSION` limb that only
+// ever ran against entries which no longer exist would be untested code by the
+// time a third carve-out needs them.
 //
 // The same reasoning gives the corpus-level limb: a run that reads ZERO pages
 // exits 1. "Nothing differs" must never be reachable by checking nothing.
@@ -164,16 +180,16 @@ const PAGE_EXTENSION = '.mdx';
 
 /**
  * Subtrees this gate does not judge, each with the issue that will make it
- * empty. Read the header's "Scope" section before adding a third: an entry
- * whose tree is clean FAILS, so every line here has a finite life.
+ * empty. Read the header's "Scope" section before adding one: an entry whose
+ * tree is clean FAILS, so every line here has a finite life — and both entries
+ * this list has ever carried died that way (#12249, then #12250).
+ *
+ * Empty is the goal state, and it is where the list now is. The machinery it
+ * feeds stays: it is how the next carve-out gets a named owner and a death
+ * date. `selfTest` keeps that machinery honest with a synthetic entry, because
+ * an empty live list exercises none of it.
  */
-const EXCLUSIONS = [
-  {
-    prefix: 'content/docs/releases/',
-    owner: '#12250',
-    why: 'CLAUDE.md stops code PRs at this directory, and three of the four violations need a cascading demotion',
-  },
-];
+const EXCLUSIONS = [];
 
 /** ATX heading: CommonMark allows up to three leading spaces. */
 const ATX_HEADING = /^ {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*$/;
@@ -244,24 +260,29 @@ export function remedyFor(headingText, title) {
 }
 
 /** The exclusion covering `relPath`, or `null`. */
-function exclusionFor(relPath) {
-  return EXCLUSIONS.find((e) => relPath.startsWith(e.prefix)) ?? null;
+function exclusionFor(relPath, exclusions = EXCLUSIONS) {
+  return exclusions.find((e) => relPath.startsWith(e.prefix)) ?? null;
 }
 
 /**
  * Judge one tree. Returns `{ findings, excluded, scanned }` — `excluded` is
  * keyed by exclusion prefix so the caller can enforce the dead-exclusion rule.
+ *
+ * `exclusions` is a parameter rather than a read of the module constant so the
+ * self-test can drive the carve-out machinery with a synthetic entry. The live
+ * list is empty (see its docstring); without this seam every exclusion case
+ * would pass by having nothing to check.
  */
-export function scanTree(root, repoRoot = REPO_ROOT) {
+export function scanTree(root, repoRoot = REPO_ROOT, exclusions = EXCLUSIONS) {
   const findings = [];
-  const excluded = new Map(EXCLUSIONS.map((e) => [e.prefix, []]));
+  const excluded = new Map(exclusions.map((e) => [e.prefix, []]));
   let scanned = 0;
 
   for (const abs of listPages(root)) {
     const rel = relative(repoRoot, abs).split('\\').join('/');
     const src = readFileSync(abs, 'utf8');
     const headings = bodyH1s(src);
-    const exclusion = exclusionFor(rel);
+    const exclusion = exclusionFor(rel, exclusions);
     if (exclusion) {
       if (headings.length) excluded.get(exclusion.prefix).push({ rel, headings });
       continue;
@@ -376,7 +397,10 @@ export function selfTest() {
     write('content/docs/indented.mdx', `${fm('Indented')}   # Indented Heading\n\nProse.\n`);
     // A `# ` in the frontmatter block itself is not body content.
     write('content/docs/fm-hash.mdx', `---\ntitle: Hashy\ndescription: "# not a heading"\n---\n\nProse.\n`);
-    // The excluded subtree, dirty — the live shape.
+    // NOT excluded any more (#12250): the release pages are judged like every
+    // other page now. Kept as a fixture — with the carve-out gone this is the
+    // control proving the tree is back in scope rather than silently unread,
+    // and `# 9.0.0 in detail` is the exact shape that carve-out existed for.
     write('content/docs/releases/v9.mdx', `${fm('v9.0.0')}# 9.0.0 in detail\n\nProse.\n`);
     // NOT excluded any more (#12249): the generated tree is judged like every
     // other page now. Kept as a fixture — with the carve-out gone this is the
@@ -402,28 +426,58 @@ export function selfTest() {
     t('an h1 indented up to three spaces IS a finding', at('content/docs/indented.mdx').length === 1, JSON.stringify(at('content/docs/indented.mdx')));
     t('a `# ` inside the frontmatter block is not body content', at('content/docs/fm-hash.mdx').length === 0);
     t('the reported line number indexes the real file', at('content/docs/dup.mdx')[0]?.line === 5, JSON.stringify(at('content/docs/dup.mdx')));
-    t('an excluded subtree yields no findings', findings.every((f) => !exclusionFor(f.rel)));
-    t('...but its violations are still counted', excluded.get('content/docs/releases/').length === 1);
     t(
       'the generated references tree is judged, not excluded (#12249)',
       at('content/docs/references/gen.mdx').length === 1,
       JSON.stringify(at('content/docs/references/gen.mdx')),
     );
-    t('only judgeable pages are counted as scanned', scanned === 10, `scanned=${scanned}`);
+    t(
+      'the releases tree is judged, not excluded (#12250)',
+      at('content/docs/releases/v9.mdx').length === 1,
+      JSON.stringify(at('content/docs/releases/v9.mdx')),
+    );
+    t(
+      'the live EXCLUSIONS list carves nothing out of the corpus',
+      excluded.size === 0,
+      `excluded keys=${JSON.stringify([...excluded.keys()])}`,
+    );
+    t('every page is judgeable, so every page is scanned', scanned === 11, `scanned=${scanned}`);
+
+    // ── The carve-out machinery, driven by a SYNTHETIC exclusion ────────────
+    //
+    // `EXCLUSIONS` is empty, so nothing below would be exercised by the live
+    // list. These cases keep the mechanism itself under test against a carve-out
+    // that exists only here — the properties a real entry depends on: an
+    // excluded page yields no finding, is NOT counted as scanned, and is still
+    // READ and TALLIED, which is the fact the dead-exclusion limb is built on.
+    const SYNTHETIC = [
+      { prefix: 'content/docs/sandbox/', owner: '#12250 (self-test only)', why: 'exercises the carve-out machinery' },
+    ];
+    write('content/docs/sandbox/dirty.mdx', `${fm('Sandbox')}# Sandbox in detail\n\nProse.\n`);
+
+    const carved = scanTree(root, dir, SYNTHETIC);
+    t('an excluded subtree yields no findings', carved.findings.every((f) => !exclusionFor(f.rel, SYNTHETIC)));
+    t(
+      '...but its violations are still counted',
+      carved.excluded.get('content/docs/sandbox/').length === 1,
+      JSON.stringify([...carved.excluded]),
+    );
+    t('an excluded page is not counted as scanned', carved.scanned === 11, `scanned=${carved.scanned}`);
 
     // The dead-exclusion limb: a clean excluded tree must be reported empty so
-    // `main` can fail on it. This is the limb that retired the references
-    // carve-out in #12249, so it is the one that must keep working.
-    rmSync(join(dir, 'content/docs/releases/v9.mdx'));
-    const after = scanTree(root, dir);
-    t('a CLEAN excluded subtree reports zero — the dead-exclusion trigger', after.excluded.get('content/docs/releases/').length === 0);
+    // `main` can fail on it. This is the limb that retired BOTH carve-outs this
+    // gate has ever had — references in #12249, releases in #12250 — so it is
+    // the one that must keep working, including now that no live entry uses it.
+    rmSync(join(dir, 'content/docs/sandbox/dirty.mdx'));
+    const after = scanTree(root, dir, SYNTHETIC);
+    t('a CLEAN excluded subtree reports zero — the dead-exclusion trigger', after.excluded.get('content/docs/sandbox/').length === 0);
 
     // Anti-vacuity: a tree of nothing but excluded pages scans zero pages.
     const empty = mkdtempSync(join(tmpdir(), 'docs-single-h1-empty-'));
     try {
-      mkdirSync(join(empty, 'content/docs/releases'), { recursive: true });
-      writeFileSync(join(empty, 'content/docs/releases/v1.mdx'), `${fm('v1')}# 1.0.0 in detail\n`);
-      t('a corpus of only excluded pages scans ZERO', scanTree(join(empty, 'content/docs'), empty).scanned === 0);
+      mkdirSync(join(empty, 'content/docs/sandbox'), { recursive: true });
+      writeFileSync(join(empty, 'content/docs/sandbox/only.mdx'), `${fm('Only')}# 1.0.0 in detail\n`);
+      t('a corpus of only excluded pages scans ZERO', scanTree(join(empty, 'content/docs'), empty, SYNTHETIC).scanned === 0);
     } finally {
       rmSync(empty, { recursive: true, force: true });
     }
@@ -437,7 +491,10 @@ export function selfTest() {
     console.error(`✗ check-docs-single-h1 self-test: ${failed.length} of ${cases.length} case(s) failed.`);
     return 1;
   }
-  console.log(`✓ check-docs-single-h1 self-test: ${cases.length} cases pass (both fence spellings, inline-code equality, indentation, and both anti-vacuity limbs).`);
+  console.log(
+    `✓ check-docs-single-h1 self-test: ${cases.length} cases pass (both fence spellings, inline-code equality, `
+      + `indentation, a synthetic carve-out, and both anti-vacuity limbs).`,
+  );
   return 0;
 }
 


### PR DESCRIPTION
Fixes #12250

Four pages under `content/docs/releases/` still rendered a second heading-one. Every doc page
already renders its frontmatter `title` as the page's `h1` (`DocsTitle` in
`apps/docs/app/[lang]/docs/[[...slug]]/page.tsx`), so a body `# ` compiles to a second one
inside `DocsBody`. This is the remainder #12236 left behind when it carved the tree out.

Confirmed on `origin/main` at `787d75740` before cutting — the card's census re-derives exactly,
seven body H1s across four files, counting `# ` at body level with frontmatter and fenced code
excluded:

```
content/docs/releases/implementation-status.mdx : 6
content/docs/releases/v15.mdx                   : 66, 342
content/docs/releases/v16.mdx                   : 117, 860
content/docs/releases/v17.mdx                   : 209, 3382
```

All four are hand-authored: no generated banner in any file head. `implementation-status.mdx`
does say "This matrix is generated from actual codebase analysis" — that is body prose inside a
`Callout`, describing where its content came from, not a do-not-edit banner.

## The one mechanical deletion

`implementation-status.mdx:6` was `# Implementation Status Matrix`, rendering the same text as
the frontmatter title. The line is deleted and the page loses nothing.

## The three cascading demotions

The `# ` headings in `v15`/`v16`/`v17.mdx` are real top-level dividers owning `##` children, so
demoting one alone would have made it a sibling of its own subsections. Each page has the same
uniform shape, which is why the cascade is clean on all three:

```
## Highlights — 15.0.0        <- not a descendant of the H1; stays at H2
## Highlights — 15.1.0        <- likewise
# 15.0.0 in detail            <- first body H1
##   ... its sections
###    ... their subsections
# What's new in 15.1.0
##   ...
```

From each page's first body `# ` to EOF, every heading moves down one level. Headings above it
are left where they are. The section tree is therefore preserved isomorphically — an "in detail"
section still owns its subsections — and the three pages now use levels 2, 3, 4 with no skipped
level. Heading text is untouched, so every slug and every inbound anchor survives.

Heading counts moved: v15 54 of 56, v16 45 of 47, v17 105 of 108 — in each case every heading
except the leading `Highlights` blocks.

One observation, deliberately not acted on: on all three pages `Upgrade checklist` and
`References` sit under the last `# ` heading while covering both releases on the page. The
cascade preserves that relationship exactly rather than re-parenting them, because re-parenting
would be an editorial change to release-owned prose and this PR carries no riders.

## The carve-out, and what its self-test now asserts

The gate fails when an excluded tree becomes clean, so cleaning the pages made
`check:docs-single-h1` go red with `DEAD-EXCLUSION` asking for its own carve-out. That was
observed on this branch before the gate was touched, with the content fix committed and the
carve-out still in place — exit code 1, the trigger working as designed for the second time.

`EXCLUSIONS` is now empty, which is the goal state, and the whole corpus is judged: 404 pages,
no subtree unread.

The self-test cases built on that entry are reworked, not deleted. Two follow the precedent this
file already set when the `content/docs/references/**` carve-out retired in #12249:

- the `releases/v9.mdx` fixture stays and becomes the control proving the tree is back **in
  scope** rather than silently unread;
- the scanned count rises from 10 to 11, because every fixture page is judgeable now.

The four cases that test the carve-out **mechanism** rather than that specific entry — an
excluded subtree yields no findings, its violations are still tallied, its pages are not counted
as scanned, and a clean one reports zero so `main` can fail on it — now run against a
**synthetic** exclusion. With the live list empty they would otherwise have passed by having
nothing to check, which is the vacuous-green shape this repo treats as worse than no check, and
it would have left the `DEAD-EXCLUSION` limb untested exactly when the next carve-out needs it.
That needs one seam: `scanTree` takes its exclusions as a parameter defaulting to `EXCLUSIONS`.

Self-test goes 17 cases to 20, and the new cases were proven able to fail — see below.

## Why this PR carries nothing else

`CLAUDE.md` puts a hard stop on `content/docs/releases/` for code PRs. A dedicated docs-only PR
is that rule's own escape hatch, and this is one: nothing rides in it. The whole reason the
directory has the hard stop is that per-PR edits made it the repo's worst conflict magnet.

**Serialisation.** No hold on `content/docs/releases/**` or `scripts/check-docs-single-h1.mjs`.
#12236, which created this gate and carved the tree out, is closed. Epic #12243's remaining open
sub-issues, #12237 and #12238, rewrite frontmatter copy and touch no gate. #12507 closed earlier
today. Clear.

**No changeset.** This PR releases nothing from any package: the diff is four docs pages plus one
CI-internal gate script. Recent docs-only merges on `main` carry no changeset, and `lint.yml`
names "this PR edits a CI-internal script" as the textbook `skip-changeset` case. Labelled
accordingly.

## Verification

All at `939f51465`, the final commit. Exit codes captured before any pipe.

The gate family was re-derived from the real change set after the last commit with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (exit 0), which resolved
five paths and 38 families — 36 path-derived plus the two convention obligations that an edit to
a gate script incurs. Commands harvested with `--commands`, so neither invocation spelling was
dropped.

**33 of 38 GREEN (exit 0).** Including, by name:

- `pnpm check:docs-single-h1` — exit 0. `check-docs-single-h1 self-test: 20 cases pass` and
  `check-docs-single-h1: 404 page(s) under content/docs/ carry no body-level backtick-hash
  heading (0 subtree(s) excluded)`.
- `pnpm check:pm-dispatch-gates` and `node scripts/pm/bare-root-worklist.mjs --self-test` — exit
  0 each. These are the two convention-triggered obligations for editing a gate script; the
  path derivation cannot name them.
- `node scripts/check-release-section-coverage.mjs`, `pnpm check:release-notes`,
  `pnpm check:release-page-status` — exit 0 each. The level-sensitive parsers in these three read
  `packages/spec/CHANGELOG.md`, not the pages; the one matcher that does read a page,
  `headingsNamingMinor`, is level-agnostic by construction.
- `pnpm check:doc-anchors` — exit 0. Demotion preserves heading text, so slugs are unchanged.

Also green outside the derived family: `pnpm lint` (full repo `eslint . --no-inline-config`,
exit 0, no narrowing needed) and `pnpm check:nul-bytes` (exit 0, 7574 files, no raw control
bytes).

**5 NOT MEASURED, none of them a finding.** Each exited before reading anything it gates, and
each says so itself:

- `node scripts/check-test-completeness.mjs` — exit 3, `PREREQUISITE NOT MET`. It grades a saved
  `turbo run test` log and the derived family names it with no argument. Its own text instructs
  that the local reading is NOT MEASURED.
- `pnpm --filter @objectstack/spec run check:docs` — exit 1, `packages/spec/json-schema is
  missing` (a gitignored build artifact).
- `pnpm --filter @objectstack/spec run check:skill-examples` — exit 1; its self-test passed, then
  `packages/spec/dist holds no .d.ts declarations`.
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — exit 1,
  `@objectstack/formula` is not built.
- `pnpm --filter @objectstack/lint run check:doc-security-posture` — exit 1, `@objectstack/lint`
  is not built.

That narrowing is declared with a measurement rather than an assertion. All four read either the
generated reference tree or fenced code blocks, and this change reaches neither:

- files changed under `content/docs/references/**`, the population `check:docs` regenerates and
  compares: **0**.
- `os:check` markers in the four changed pages, the unit `check:doc-security-posture` judges:
  **0** in every one of them.
- fenced-code content in each changed page, sha256 over the concatenated block bodies, before
  and after: **identical on all four** — `implementation-status.mdx` and `v15.mdx` contain no
  fenced lines at all, `v16.mdx` 4, `v17.mdx` 77, each hashing the same at `787d75740` and at
  `939f51465`. That is the population `check:doc-formula-expressions` and `check:skill-examples`
  extract.

Independently: every changed line in the four pages is an ATX heading line. Filtering the diff
down to changed lines that are not headings leaves only the one blank line removed alongside the
deleted duplicate title.

**Ablation — the new self-test cases can go red.** The risk a rework like this carries is cases
that pass by checking nothing, so both were measured against the committed implementation, each
mutation confirmed on disk by grepping for the injected and the removed text and by comparing
`git hash-object` against the HEAD blob, each restored with `git checkout HEAD -- (absolute
path)` under a trap and verified byte-identical afterwards.

- Removing the seam, so `exclusionFor` ignores its parameter: self-test exit 1, 3 of 20 cases
  fail — the violations tally, the scanned count, and the anti-vacuity limb.
- Dropping the `continue` so excluded pages are judged instead of skipped: self-test exit 1,
  3 of 20 fail — including `an excluded subtree yields no findings`.

Between them every reworked case is shown load-bearing, and the `DEAD-EXCLUSION` limb itself was
watched firing on the live corpus before the carve-out came out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_