### PR TITLE
docs(skills): objectstack-platform factual sweep — 6 false behavioral claims corrected

### DIFF
--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -174,14 +174,14 @@ export default defineStack({
 ### Full Configuration Reference
 
 `defineStack()` accepts an `ObjectStackDefinitionInput`. Each top-level key
-holds a collection of one metadata kind — `manifest`, `objects`,
-`objectExtensions`, `views`, `apps`, `pages`, `dashboards`,
-`reports`, `datasets`, `actions`, `flows`, `jobs`,
-`emailTemplates`, `docs`, `books`, `positions`, `permissions`,
-`capabilities`, `sharingRules`, `apis`, `webhooks`, `api`, `agents`,
-`tools`, `skills`, `hooks`, `functions`, `mappings`, `analyticsCubes`,
-`connectors`, `data` (seed), `datasources`, `datasourceMapping`,
-`translations`, `i18n`, `plugins`, `devPlugins`, `requires`, `tiers`.
+holds one metadata kind — `manifest`, `objects`, `objectExtensions`,
+`views`, `apps`, `pages`, `dashboards`, `reports`, `datasets`,
+`actions`, `flows`, `jobs`, `emailTemplates`, `docs`, `books`,
+`positions`, `permissions`, `capabilities`, `sharingRules`, `apis`,
+`webhooks`, `api`, `server`, `agents`, `tools`, `skills`, `hooks`,
+`functions`, `mappings`, `analyticsCubes`, `connectors`, `data` (seed),
+`datasources`, `datasourceMapping`, `translations`, `i18n`, `plugins`,
+`devPlugins`, `requires`, `tiers`.
 
 There is deliberately **no** top-level `workflows` or `approvals` collection:
 an approval is authored as a flow with Approval nodes (ADR-0019), and record
@@ -315,7 +315,7 @@ manifest: {
 }
 ```
 
-**Object naming:** The object `name` is the canonical identifier and equals the physical table name. Embed any domain prefix directly in the name (e.g. `name: 'crm_account'`); the object-level `namespace` *field* is deprecated and ignored by the runtime.
+**Object naming:** The object `name` is the canonical identifier and equals the physical table name. Embed any domain prefix directly in the name (e.g. `name: 'crm_account'`); the object-level `namespace` *field* is retired (ADR-0129 D3) and refused at load.
 
 **`manifest.namespace` (ADR-0048):** Optional, but **enforced once set**. When a package declares `manifest.namespace: 'crm'`, every `object.name` must start with `crm_` or `defineStack` errors (`validateNamespacePrefix` in `@objectstack/spec`); the legacy `<ns>__<short>` double-underscore form is rejected, and `sys_`-prefixed names are platform-reserved and exempt. The namespace is also a package-ownership key — installing two packages that both claim `crm` fails with `NamespaceConflictError` (downgrade to a warning with `OS_METADATA_COLLISION=warn`). `os lint` additionally emits a non-fatal `naming/namespace-prefix` warning for bare-named UI/automation items (app, page, dashboard, flow, action, report, dataset) when a namespace is set.
 
@@ -576,7 +576,7 @@ PORT=8080 os start   # production — pin the port explicitly (see Ports & netwo
 
 A minimal but complete project from scratch:
 
-**`package.json`** (mirrors the `blank` template):
+**`package.json`**:
 ```json
 {
   "name": "my-todo-app",
@@ -588,13 +588,13 @@ A minimal but complete project from scratch:
     "validate": "objectstack validate"
   },
   "dependencies": {
-    "@objectstack/spec": "^16.0.0-rc.1",
-    "@objectstack/runtime": "^16.0.0-rc.1",
-    "@objectstack/driver-memory": "^16.0.0-rc.1",
-    "@objectstack/plugin-hono-server": "^16.0.0-rc.1"
+    "@objectstack/spec": "^17.0.0",
+    "@objectstack/runtime": "^17.0.0",
+    "@objectstack/driver-memory": "^17.0.0",
+    "@objectstack/plugin-hono-server": "^17.0.0"
   },
   "devDependencies": {
-    "@objectstack/cli": "^16.0.0-rc.1",
+    "@objectstack/cli": "^17.0.0",
     "typescript": "^6.0.0"
   }
 }
@@ -741,7 +741,7 @@ import { ObjectKernel } from '@objectstack/core';
 
 const kernel = new ObjectKernel({
   logger: {
-    level: 'info',           // 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+    level: 'info',      // debug|info|warn|error|fatal|silent
     format: 'json',          // 'json' | 'text' | 'pretty'
   },
   defaultStartupTimeout: 30000,   // Per plugin (ms)
@@ -772,7 +772,7 @@ import type { Plugin, PluginContext } from '@objectstack/core';
 export interface Plugin {
   name: string;               // Unique identifier (reverse domain recommended)
   version?: string;           // Semantic version
-  type?: string;              // 'standard' | 'ui' | 'driver' | 'server' | 'app'
+  type?: string;              // standard|ui|driver|server|app|theme|agent|objectql
   dependencies?: string[];    // Plugins that must init before this one
 
   // Phase 1: Register services

--- a/skills/objectstack-platform/rules/plugin-lifecycle.md
+++ b/skills/objectstack-platform/rules/plugin-lifecycle.md
@@ -45,7 +45,7 @@ export interface Plugin {
   version?: string;
 
   /** Plugin type */
-  type?: string;  // 'standard' | 'ui' | 'driver' | 'server' | 'app' | 'theme' | 'agent'
+  type?: string;  // standard|ui|driver|server|app|theme|agent|objectql
 
   /** Plugins that must init before this one */
   dependencies?: string[];

--- a/skills/objectstack-platform/rules/service-registry.md
+++ b/skills/objectstack-platform/rules/service-registry.md
@@ -168,7 +168,7 @@ Kernel checks ServiceRequirementDef (@objectstack/spec/system):
   'metadata'  → core    → auto-inject createMemoryMetadata() if missing
   'cache'     → core    → auto-inject createMemoryCache() if missing
   'queue'     → core    → auto-inject createMemoryQueue() if missing
-  'job'       → core    → NO fallback — warns; getService throws (#10746)
+  'job'       → core    → NO fallback — warns; getService throws if missing
   'i18n'      → core    → auto-inject createMemoryI18n() if missing
   'auth'      → core    → NO fallback — warns; getService throws if missing
   'realtime'  → optional → skip, plugins should check availability

--- a/skills/objectstack-platform/rules/service-registry.md
+++ b/skills/objectstack-platform/rules/service-registry.md
@@ -158,19 +158,19 @@ The REST plugin (`com.objectstack.rest.api`, `@objectstack/rest`) registers
 
 ## Core Fallback Injection
 
-ObjectKernel auto-injects in-memory fallbacks for `core`-criticality services not registered by any plugin during Phase 1.
+ObjectKernel auto-injects an in-memory fallback for each `core` service that has one and no plugin registered in Phase 1.
 
 ```
 Phase 1: init() completes for all plugins
     ↓
 Kernel checks ServiceRequirementDef (@objectstack/spec/system):
-  'data'      → required → ERROR if missing (no fallback; ObjectQLPlugin registers it)
+  'data'      → required → ERROR if missing (ObjectQLPlugin registers it)
   'metadata'  → core    → auto-inject createMemoryMetadata() if missing
   'cache'     → core    → auto-inject createMemoryCache() if missing
   'queue'     → core    → auto-inject createMemoryQueue() if missing
-  'job'       → core    → auto-inject createMemoryJob() if missing
+  'job'       → core    → NO fallback — warns; getService throws (#10746)
   'i18n'      → core    → auto-inject createMemoryI18n() if missing
-  'auth'      → core    → no fallback factory — degraded-capability warning if missing
+  'auth'      → core    → NO fallback — warns; getService throws if missing
   'realtime'  → optional → skip, plugins should check availability
     ↓
 Phase 2: start() begins — all core services available
@@ -178,14 +178,14 @@ Phase 2: start() begins — all core services available
 
 The fallbacks are **factories** exported from `@objectstack/core`
 (`createMemoryCache`, `createMemoryMetadata`, `createMemoryQueue`,
-`createMemoryJob`, `createMemoryI18n`) — not classes.
+`createMemoryI18n`) — not classes; `job`/`auth` have none.
 
 ### Service Criticality Levels
 
 | Level | Behavior |
 |:------|:---------|
 | `required` | Kernel throws if missing — system cannot start |
-| `core` | Auto-injected in-memory fallback if no plugin provides it |
+| `core` | In-memory fallback auto-injected where one exists, else warn |
 | `optional` | Silently skipped — plugins must check before use |
 
 ## Incorrect vs Correct


### PR DESCRIPTION
Fixes #13747
Part of #13658

Flight ④ of the published-skills factual sweep: `skills/objectstack-platform/**`, 8 files / 2,633 lines, every behavioral claim verified against the implementing code — never against another document.

## Landing sites — 6 distinct facts, 8 sites

| # | 落点 | before | after | how it was settled |
|---|---|---|---|---|
| 1 | `rules/service-registry.md` core-fallback table, `job` row | `'job' → core → auto-inject createMemoryJob() if missing` | `'job' → core → NO fallback — warns; getService throws if missing` | Executed: `ObjectKernel` bootstrapped with only a `data` provider, `getService('job')` threw `[Kernel] Service 'job' not found` while `cache`/`metadata`/`queue`/`i18n` all resolved in the same kernel. `CORE_FALLBACK_FACTORIES` printed from the built artifact as `metadata,cache,queue,i18n`. `packages/core/src/fallbacks/index.ts` states the omission is deliberate (maintainer ruling 2026-08-22): a fallback must not fake capability, and every consumer's documented no-job-service path has to stay reachable. |
| 2 | same file, `auth` row | `no fallback factory — degraded-capability warning if missing` | `NO fallback — warns; getService throws if missing` | Same run: `getService('auth')` threw identically. The row was true but understated the consequence; `job` and `auth` now read alike because they behave alike. |
| 3 | same file, section headline + criticality table | "auto-injects in-memory fallbacks for `core`-criticality services" / "Auto-injected in-memory fallback if no plugin provides it" | qualified with "that has one" / "where one exists, else warn" | The same falsehood had three landing sites in one file; `ObjectKernel.preInjectCoreFallbacks()` and `validateSystemRequirements()` both branch on `CORE_FALLBACK_FACTORIES[name]` being present. |
| 4 | same file, factory list | lists `createMemoryJob` among "the fallbacks" | dropped from the list; "`job`/`auth` have none" | `createMemoryJob` is still exported (for embedders who want a manual-trigger registry) but is not a fallback. Export presence confirmed by import in the same probe. |
| 5 | `SKILL.md` `defineStack()` top-level key enumeration | 39 keys, no `server` | 40 keys, `server` added | Parsed `ObjectStackDefinitionSchema`'s real shape: 43 keys. All 39 documented keys are real (zero phantoms). `defineStack({ server: { trustProxy: true } })` **parses green**, while the paragraph directly below tells the reader an undeclared top-level key makes the stack fail to load — so the omission actively taught that a live v17 key is refused. |
| 6 | `SKILL.md` object naming | object-level `namespace` field "is deprecated and ignored by the runtime" | "is retired (ADR-0129 D3) and refused at load" | Executed: `defineStack` with `objects: [{ name, label, namespace: 'crm', fields }]` **throws** — `Unrecognized key(s) on this object: 'namespace'` with the ADR-0129 D3 prescription. "Ignored" says the stack loads; it does not. This also contradicted SKILL.md's own "Refused — … each `objects[]` entry (`ObjectSchema`) … The parse throws" thirty lines earlier. |
| 7 | `SKILL.md` `ObjectKernel` logger config | `// 'debug' \| 'info' \| 'warn' \| 'error' \| 'fatal'` | `// debug\|info\|warn\|error\|fatal\|silent` | `LogLevel` in `packages/spec/src/system/logging.zod.ts` is a 6-member enum; `LEVEL_ORDER` in `packages/core/src/logger.ts` carries `silent: 5`. The skill's own examples use `level: 'silent'` **eight times** — it was contradicting itself. |
| 8 | `SKILL.md` + `rules/plugin-lifecycle.md` `Plugin.type` comment | SKILL.md listed 5 of 8 values; the rules file listed 7 of 8 | both now `standard\|ui\|driver\|server\|app\|theme\|agent\|objectql` | `'standard'` + `CORE_PLUGIN_TYPES` (`packages/spec/src/kernel/plugin.zod.ts`) = 8. `objectql` is not decorative — `ObjectQLPlugin` declares `type = 'objectql'`. A cross-file contradiction inside the package, settled against the schema rather than against either document. |

Also corrected in the same stroke, same class: the "Complete Working Example" `package.json` pinned `^16.0.0-rc.1` on six deps and claimed to mirror the `blank` template. The real template (`packages/create-objectstack/src/templates/blank/package.json`) pins `^17.0.0` and ships a different dependency set (three connector packages, no `driver-memory`) — and the skill's own frontmatter already declares 17.x. Versions corrected; the false "mirrors" claim removed rather than papered over.

## Budget

Net line delta across the package: **0** (2,633 → 2,633). Net tokens: **−24**, from the ratchet's own verdict lines — `SKILL.md` −18, `rules/plugin-lifecycle.md` −4, `rules/service-registry.md` −2. **No ceiling raised.** Every remaining file was already sitting at zero headroom, so every edit was made byte-shrinking in place.

## Verification

Gate families derived from the real diff, not recalled — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` on the merged tree (13 families). Union re-run at the final commit `f6c81ba5`:

```
EXIT=0  node scripts/check-ci-filter-parity.mjs
EXIT=0  node scripts/check-cross-package-test-inputs.mjs
EXIT=0  node scripts/check-shard-attestation.mjs
EXIT=0  node scripts/check-skills-token-ratchet.mjs
EXIT=3  node scripts/check-test-completeness.mjs      <- PREREQUISITE NOT MET, NOT MEASURED
EXIT=0  pnpm --filter @objectstack/lint run check:doc-formula-expressions
EXIT=0  pnpm check:agent-test-spelling
EXIT=0  pnpm check:cross-package-test-inputs
EXIT=0  pnpm check:doc-authoring
EXIT=0  pnpm check:pm-governed-merges
EXIT=0  pnpm check:role-word
EXIT=0  pnpm check:skill-compatibility
EXIT=0  pnpm check:skill-frame-sync
```

`check-test-completeness` grades a saved `turbo run test` log and was handed none; it prints `PREREQUISITE NOT MET` and exits 3 before parsing a line. Recorded as NOT MEASURED, per its own instruction — not a red.

Two more run because the diff visibly implicates them even though the path derivation does not name them:

```
EXIT=0  pnpm --filter @objectstack/spec run check:skill-examples   (260 marked examples, 3 surfaces)
EXIT=0  pnpm --filter @objectstack/spec run check:skill-refs       (9 generated files in sync)
```

**`check:skill-examples` population for this package is NOT empty** — `SKILL.md` carries two `os:check` fences (the `defineStack` minimal example and `task.object.ts`). Both type-check.

`check:doc-authoring` caught a defect I introduced: the first draft of the `job` row cited an internal issue id, which `skills/**` forbids because the catalog ships into customer context windows where a tracker id resolves to nothing. Fixed in `f6c81ba5` — the teaching kept, the citation dropped.

No changeset: the diff publishes nothing from any package. `skip-changeset` applied, matching the precedent this branch merged up to — flight ③'s PR #13740 landed five `skills/objectstack-query/**` files with no changeset.

`needs:contract-review` attached at creation: these corrections make falsifiable operator/contract semantic claims, the CONTENT limb of clause ②. Not self-cleared.

## Governed posture

Published `skills/**` — this PR stays **draft** for human merge. `.md` content goes to maintainer review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_