### PR TITLE
fix(check-doc-anchors): spell the heading-ids remedy so it cannot be read as a watch-hint declaration

### DIFF
--- a/scripts/check-doc-anchors.mjs
+++ b/scripts/check-doc-anchors.mjs
@@ -456,7 +456,30 @@ function runCheck() {
         '\n\n  The heading id is computed with `github-slugger`, the same package\n' +
         '  fumadocs-core uses to render the page, so what this gate says the anchor is\n' +
         '  is what the site says it is. Print a page\'s real ids with:\n' +
-        "      node -e \"import('./scripts/check-doc-anchors.mjs').then(m=>console.log(m.headingIds(require('node:fs').readFileSync('<file>','utf8')).join('\\n')))\"\n" +
+        // ⚠️ The specifier below is spelled ABSOLUTE — `process.cwd()+'/scripts/…'` — and that is
+        // load-bearing rather than style. This line is a REMEDY: prose for a human, to be pasted
+        // into a shell already sitting at the repo root. Spelled the natural way, as a quoted
+        // `./scripts/…` literal, it is ALSO a well-formed watch-hint DECLARATION to the dispatch
+        // derivation, which scans a gate's module body for quoted path-shaped literals and
+        // resolves the relative ones against the directory of the file that WROTE them. This gate
+        // lives in `scripts/`, so a literal written in the ROOT frame came back with its own
+        // directory prepended — a lead naming a path that has never existed on this tree, pasted
+        // into every dispatch prompt whose file surface brushes this family, and indistinguishable
+        // there from a real one.
+        //
+        // Neither half was wrong on its own: the remedy is correct for its reader and the extractor
+        // is correct about a declaration — the fabrication came from one being read as the other.
+        // Tightening the reader was measured and REFUSED (#13312: the sanctioned declaration idiom
+        // is structurally indistinguishable from an incidental module-scope constant, priced at 8.6
+        // real populations deleted per fabrication removed), so the repair belongs to the PRODUCER:
+        // spell the path so it cannot be read as a declaration. The leading `/` inside the quotes is
+        // the whole mechanism — the extractor's admission test requires a literal to begin with a
+        // word character, `.` or `@`, so an absolute path is refused outright — and `process.cwd()`
+        // is what keeps the command runnable verbatim from the repo root, which is the only reason a
+        // remedy line exists. ⛔ Do not "tidy" it back to a quoted relative specifier. What this gate
+        // really reads is declared above and deliberately, in `CONTENT_GLOB` and
+        // `ROOT_FILE_WATCH_HINTS` (#13449).
+        "      node -e \"import(process.cwd()+'/scripts/check-doc-anchors.mjs').then(m=>console.log(m.headingIds(require('node:fs').readFileSync('<file>','utf8')).join('\\n')))\"\n" +
         '  Fix the link, or fix the heading. Do not add an exemption — an anchor that\n' +
         '  nobody may check is the defect this gate exists to remove (#7484).',
     );


### PR DESCRIPTION
Fixes #13449

`check:doc-anchors` printed a remedy command whose module specifier was a quoted
relative literal. The dispatch watch-hint extractor reads quoted path-shaped literals
out of a gate's module body and resolves the relative ones against the directory of the
file that wrote them — so this gate, which lives in `scripts/`, declared a path with its
own prefix doubled. That lead named a file that has never existed on this tree, and it
was pasted into every dispatch prompt whose file surface brushed the family.

Neither half was wrong on its own: the remedy is correct for its reader, the extractor is
correct about a declaration. The fabrication came from one being read as the other, so the
repair is local to the producer — spell the path so it cannot be read as a declaration.
Per the triage ruling, the extractor is **not** touched (upstream measured the tightening
at 8.6 real populations deleted per fabrication removed), and nothing in this delivery
touches `scripts/pm/dispatch-gates.mjs`.

## The change

One line in `scripts/check-doc-anchors.mjs`, plus the rationale comment above it:

```diff
-        "      node -e \"import('./scripts/check-doc-anchors.mjs').then(m=>…
+        "      node -e \"import(process.cwd()+'/scripts/check-doc-anchors.mjs').then(m=>…
```

The leading `/` inside the quotes is the whole mechanism. `extractWatchHints`' admission
test is `/^[\w.@][\w.@/*-]*$/` — a literal must begin with a word character, `.` or `@` —
so an absolute path is refused outright, before the module-relative resolve can ever run.
`process.cwd()` is what keeps the command runnable verbatim from the repo root.

## A2.1 — the defect was still live at my ref

Re-confirmed at `c42bc8ee6` (my branch point), not inherited from the dispatch order:

```
git ls-files 'scripts/scripts/*'   ->  0
git ls-files 'scripts/*'           ->  299   (209 at the top level)  <- the control
```

The zero is a true zero, so #13312's closing PR did not absorb this. The card correctly
gets a PR rather than a close.

## A2.2 — census: 1 site, and it is the only one

Two independent sweeps, both run through the real extractor rather than by eye.

**Fleet sweep** — every tracked gate/tooling script under a `scripts/` directory
(333 files), classifying each extracted hint that reaches nothing in the tree, and
flagging the doubled-prefix signature (a dead hint that becomes a real path when one copy
of the writer's own directory is stripped):

```
scripts scanned: 333
hints total: 1500   dead (reach nothing): 736   DOUBLED-PREFIX class: 1
  scripts/check-doc-anchors.mjs
      fabricated: scripts/scripts/check-doc-anchors.mjs
      real path : scripts/check-doc-anchors.mjs
```

**Same-file sweep** — every quoted module-relative literal in `check-doc-anchors.mjs`:
4 of them, and the other 3 are genuine sibling import specifiers
(`./import-prerequisite.mjs`, `./check-adr-links.mjs`, `./invoked-as.mjs`), which the
extractor already refuses as single-segment siblings. Line 459 was the only remedy string.

⇒ **1 hit, fixed; 0 identical second sites left behind.** After the change the same fleet
sweep reads `hints total: 1499  ·  dead: 735  ·  DOUBLED-PREFIX class: 0` — exactly one
hint removed and nothing else moved.

The remaining 735 dead hints are the fixture-constant class #13312 owns, a different
cause; they are untouched here.

## A2.3 — reverse verification: the extractor emitted it before and does not after

Run against the committed implementation, mutating the tree back to the pre-fix spelling
and restoring it, with the mutation proved on disk by anchored `grep -c` on **both** the
injected and the removed text, and the restore proved by **observed state** (empty
`git diff HEAD` plus a blob-hash comparison against the HEAD blob) rather than by an exit
code. The extractor is a pure string function over the source file as read from disk, so
there is no build artifact between the mutation and the reading.

```
HEAD blob for target: cb30a9f975574aa65d251be2f52f33c6c1eac4a9

=== LEG 1: MUTATE (pre-fix relative spelling put back) ===
    injected  import('./scripts/... : 1
    removed   process.cwd()+'/...   : 0
    blob hash now vs HEAD blob      : 4d12eae58b70…  (HEAD cb30a9f97557…)
  extractor reading on the MUTATED tree:
    HINT COUNT: 4
      HINT "ARCHITECTURE.md/**"
      HINT "README.md/**"
      HINT "content/**"
      HINT "scripts/scripts/check-doc-anchors.mjs"
    FABRICATED PRESENT: true

=== LEG 2: RESTORE (git checkout HEAD -- ABSOLUTE_PATH) ===
    git diff HEAD (must be empty)   : EMPTY
    blob hash == HEAD blob          : cb30a9f97557… == cb30a9f97557…
    injected  import('./scripts/... : 0
    restored  process.cwd()+'/...   : 1
  extractor reading on the RESTORED tree:
    HINT COUNT: 3
      HINT "ARCHITECTURE.md/**"
      HINT "README.md/**"
      HINT "content/**"
    FABRICATED PRESENT: false
```

Direction observed: **the fabricated hint disappears and the three real declarations stay**
— `content/**`, `README.md/**`, `ARCHITECTURE.md/**` are byte-identical before and after,
and nothing new is added. That last half matters: a spelling that merely moved the literal
(say, a bare `scripts/check-doc-anchors.mjs`) would have been admitted as a **true** hint
and quietly given this gate a population it does not read. This one declares nothing.

The same result is confirmed by the tool's own suite: `dispatch-gates.mjs --self-test`
reads this file live and asserts that the doc-anchors family still reaches
`content/docs/deployment/cli.mdx`, still claims `README.md` and `ARCHITECTURE.md`, and
still claims neither instruction file. 1017 cases pass.

One more observed side-effect, in the right direction: the rationale comment added above
the line spells the relative path in prose, and the module-body sweep confirms comment
masking removes it — the file's RAW text has 4 module-relative literals, its masked module
body has 3.

## A2.4 — the remedy still runs verbatim from the repo root

The gate was driven to its failure branch against a throwaway fixture root so the remedy
is the text a human actually sees:

```
  The heading id is computed with `github-slugger`, the same package
  fumadocs-core uses to render the page, so what this gate says the anchor is
  is what the site says it is. Print a page's real ids with:
      node -e "import(process.cwd()+'/scripts/check-doc-anchors.mjs').then(m=>console.log(m.headingIds(require('node:fs').readFileSync('FILE','utf8')).join('\n')))"
```

(`FILE` above stands for the literal placeholder the gate prints, which the reader replaces.)

Pasted verbatim at the repo root with the placeholder filled in:

```
$ node -e "import(process.cwd()+'/scripts/check-doc-anchors.mjs').then(m=>console.log(m.headingIds(require('node:fs').readFileSync('content/docs/index.mdx','utf8')).join('\n')))"
objectstack-documentation
start-here
platform-modules
protocol--reference
EXIT=0
```

Byte-identical to the same run under the old spelling — `diff` of the two captures is
empty. Readability does not regress: the command is one token longer and still a single
paste.

## Gates

Family derived after the final commit with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths passed —
the script takes its own change set; it reported `1 path(s) vs merge base c42bc8ee6`).
Every exit code below was captured **before** any pipe, and each verdict is the gate's own
printed line. All runs are on the final commit `fd2ea143f`.

Path-derived family (13):

| gate | exit | verdict |
|:--|:--|:--|
| `pnpm check:agent-test-spelling` | 0 | GREEN |
| `pnpm check:bash32-floor` | 0 | GREEN |
| `pnpm check:cli-command-ids` | 0 | GREEN |
| `pnpm check:cross-package-test-inputs` | 0 | GREEN |
| `pnpm check:doc-anchors` | 0 | GREEN — `check-doc-anchors: 287 internal #fragment link(s) across 409 source file(s) all resolve to a real heading` |
| `pnpm check:entry-guard` | 0 | GREEN |
| `pnpm check:parse-guard` | 0 | GREEN |
| `pnpm check:pnpm-filter-targets` | 0 | GREEN |
| `pnpm check:watch-hint-literal` | 0 | GREEN — `34 declaration(s) across 4 rostered name(s) … no unrostered spelling of the idiom in the tree` |
| `node scripts/check-ci-filter-parity.mjs` | 0 | GREEN |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | GREEN |
| `node scripts/check-shard-attestation.mjs` | 0 | GREEN |
| `node scripts/check-test-completeness.mjs` | 3 | **NOT MEASURED** — `PREREQUISITE NOT MET`; it grades a saved `turbo run test` log and none was named. Its own text says exit 3 is not a finding. |

Convention-triggered (editing a gate script), both named by the derivation:

| gate | exit | verdict |
|:--|:--|:--|
| `node scripts/pm/bare-root-worklist.mjs --self-test` | 0 | GREEN — `51 live row(s), 43 unreachable as spelled, 43 recorded verdict(s) — none stale, none missing, none contradicted` |
| `pnpm check:pm-dispatch-gates` | 0 | GREEN — `dispatch-gates self-test: 1017 cases pass.` |

Beyond the derived list, the gate script's own suite plus the consumers that read this
file by name (the "which tests test this script" half the path derivation cannot answer):

| gate | exit | verdict |
|:--|:--|:--|
| `pnpm check:nul-bytes` | 0 | GREEN — `scanned 7578 text file(s) … no raw ASCII control bytes` |
| `pnpm check:published-readme-links` | 0 | GREEN (imports `headingIds` from the edited file) |
| `pnpm check:docs-single-h1` | 0 | GREEN |
| `pnpm check:docs-image-tag` | 0 | GREEN |
| `node scripts/check-self-test-wired.mjs` (+ `--self-test`) | 0 | GREEN |
| `node scripts/check-self-test-workflow-commands.mjs` (+ `--self-test`) | 0 | GREEN |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`, **not** narrowed) | 0 | GREEN — 2m02s |

Repo-wide ESLint was run in full rather than narrowed, so no narrowing is being declared.

## Changeset

`skip-changeset`, applied at PR creation. `Check Changeset` is path-blind — it counts the
changesets a PR **adds** against the merge base and fails on zero; its only exemptions are
the `skip-changeset` label and the Changesets release branch. This PR publishes nothing:
the root manifest is `private`, and no published package's `files` field escapes its own
directory, so a repo-root `scripts/` file ships in no tarball.

## Out of scope, deliberately

- The extractor is untouched, per the ruling.
- `scripts/pm/dispatch-gates.mjs` is untouched — #13448's landing site, in flight in the
  same wave.
- The other 735 dead hints (fixture constants, #13312's cause) are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_