### PR TITLE
docs(skills): objectstack-ui factual sweep — 8 false behavioral claims corrected (flight ⑤)

### DIFF
--- a/skills/objectstack-ui/SKILL.md
+++ b/skills/objectstack-ui/SKILL.md
@@ -60,6 +60,7 @@ App navigation, Dashboards, Reports, and Actions.
 | `map` | Geospatial records with `location` fields |
 | `chart` | Aggregate visualisation over the object (mini chart view) |
 | `tree` | Self-referencing hierarchy (tree-grid) |
+| `page` | Mounts a published Page (`pageName`); no rows of its own |
 
 ### Form Views
 
@@ -322,11 +323,11 @@ Rules:
   Want both demos? Put them on different views.
 - **On an object list view (`*.view.ts` `list` / `listViews`), only
   `element: 'dropdown'` (value chips) is allowed — `tabs` is page-only**
-  (ADR-0047 amendment). An object view's
-  saved-view `ViewTabBar` already owns the tab-bar role, so a `tabs`
-  user-filter would render a second, colliding tab bar. The spec narrows it
-  (`ObjectUserFiltersSchema` — a `tabs` element is untypable at author time
-  and dropped at parse) and the `validate` list-view-mode lint reports it.
+  (ADR-0047 amendment). An object view's saved-view `ViewTabBar` already owns
+  the tab-bar role, so a `tabs` user-filter would render a second, colliding
+  tab bar. The spec narrows it (`ObjectUserFiltersSchema` — a `tabs` element is
+  untypable at author time and **rejected** at parse, not dropped) and the
+  `validate` list-view-mode lint reports it.
   Need named presets on an object? Add a `listViews` entry instead. The full
   `dropdown | tabs | toggle` range applies only to **page lists** /
   `interfaceConfig.userFilters` (the block above).
@@ -558,7 +559,7 @@ Field shapes:
 | `bands[].label` | yes | Header text for the band (白班 / 夜班). |
 | `bands[].start` / `bands[].end` | yes | `'HH:mm'`. When `end <= start` the band crosses midnight. Bands must tile the 24h day from `dayStart`. |
 | `bands[].color` | no | Any CSS color. Tints that band's column; **omit for no tint**. |
-| `showMidnight` | no | Draw the dashed calendar-midnight cue inside cross-midnight bands. Default `true`; set `false` to hide it. |
+| `showMidnight` | no | Draw the dashed local-0:00 cue inside cross-midnight bands (the 排班日 cell itself stays unbroken). Default `true`; set `false` to hide it. |
 
 Behavior:
 
@@ -570,11 +571,7 @@ Behavior:
   in, so a 夜班 spanning 20:00→次日08:00 stays in a single column.
 - **Drag-snaps to band boundaries** (the band duration, e.g. 12h) instead of
   whole days.
-- **Calendar-midnight cue.** A subtle dashed vertical line marks local 0:00
-  *inside* a cross-midnight band — the 排班日 cell itself stays unbroken. Set
-  `showMidnight: false` to turn it off.
-- **Default off = zero regression.** Omit `timeSegments` and the gantt behaves
-  exactly as before. Tints render only for bands that declare `color`.
+- **Default off.** Omit `timeSegments` and the gantt renders unsegmented.
 
 ---
 
@@ -669,6 +666,7 @@ A widget's `type` is its **chart type** (`ChartTypeSchema`; defaults to
 | Single value | `metric`, `kpi`, `gauge`, `solid-gauge`, `bullet` (all render the number today; gauge variants gain a dial when a gauge renderer lands) |
 | Comparison | `bar`, `horizontal-bar`, `column` |
 | Trend | `line`, `area` |
+| Mixed | `combo` (bar/line/area on shared dual axes) |
 | Distribution | `pie`, `donut`, `funnel` |
 | Relationship | `scatter` |
 | Composition | `treemap`, `sankey` |
@@ -688,9 +686,9 @@ dashboard widget, a report, and a list `type:'chart'` view all **bind a `dataset
 and select named `dimensions` + `values`**; the dataset owns the base object,
 allowed joins, intrinsic filter, dimensions, and certified measures. The legacy
 per-widget inline query (`object` + `categoryField` + `valueField` + `aggregate`)
-**was removed** — a widget now requires `dataset` + `values`; the inline fields are
-dropped and a widget lacking `dataset` fails `os validate`. Reports bind the same
-way (`dataset` + `rows` + `values` + `runtimeFilter`). The dataset shape is
+**was removed** — a widget now requires `dataset` + `values`; the closed schema
+REJECTS the inline keys by name, and one lacking `dataset` fails `os validate`.
+Reports bind the same way (`dataset` + `rows` + `values` + `runtimeFilter`). The dataset shape is
 `DatasetSchema` — see `node_modules/@objectstack/spec/src/ui/dataset.zod.ts`.
 
 A widget's presentation-scope `filter` flows into the query as the runtime
@@ -1523,9 +1521,9 @@ compareTo: { kind: 'previousYear', dimension: 'close_date' }     // several — 
   and overwrites it.
 * **Cartesian charts** (`line` / `area` / `bar` / `horizontal-bar` /
   `scatter`) — the comparison series is appended after the primary series
-  with `variant: 'comparison'` and styled as a muted overlay (`opacity: 0.5`
-  + `strokeDasharray: '4 4'` for line/area/scatter; `opacity: 0.4` for
-  bars). Override per-series with `series.dashArray` / `series.opacity`.
+  with `variant: 'comparison'`, muted per family (dashed `'4 4'` on
+  line/area only; reduced opacity on all). Override per-series with
+  `series.dashArray` / `series.opacity`.
 * **Pie / donut / funnel** — `compareTo` is silently ignored; there is no
   meaningful "two-period" composition for part-of-whole charts.
 * **Requirements** — a comparison needs a **dated window** to shift. When the
@@ -1663,12 +1661,12 @@ Both `{token}` and `${token}` forms are accepted.
 | Instants | `today`, `yesterday`, `tomorrow`, `now` |
 | Current period | `current_week_start` / `_end`, `current_month_start` / `_end`, `current_quarter_start` / `_end`, `current_year_start` / `_end` |
 | Last period | `last_week_start` / `_end`, `last_month_start` / `_end`, `last_quarter_start` / `_end`, `last_year_start` / `_end` |
-| Next period | `next_week_start`, `next_month_start`, `next_quarter_start`, `next_year_start` |
+| Next period | `next_week_start` / `_end`, `next_month_start` / `_end`, `next_quarter_start` / `_end`, `next_year_start` / `_end` |
 | Bare aliases | `week_start`, `week_end`, `month_start`, `month_end`, `quarter_start`, `quarter_end`, `year_start`, `year_end` (same as `current_*`) |
 
 ### Parameterised tokens — `{N_<unit>_(ago|from_now)}`
 
-`N` is any positive integer; `<unit>` is one of
+`N` is any non-negative integer; `<unit>` is one of
 `minute(s) | hour(s) | day(s) | week(s) | month(s) | year(s)`.
 `minute`/`hour` resolve to a full ISO timestamp; coarser units resolve to
 `YYYY-MM-DD`.
@@ -2053,11 +2051,11 @@ the selected row in `list_item` contexts.
    "My Records" filter using `$currentUser`.
 
 5. **Putting widget grid placement in `position`.**
-   The grid-placement field is `layout: { x, y, w, h }` — there is no
-   `position` key on a widget, so a `position` object is silently dropped.
-   `layout` is optional: omit it and the widget auto-flows (the Studio
-   designer relies on this); set it only when you want an explicit grid
-   position.
+   The grid-placement field is `layout: { x, y, w, h }` — `position` is not a
+   widget key and the closed schema REJECTS it by name (it was silently
+   dropped before protocol 17). `layout` is optional: omit it and the widget
+   auto-flows (the Studio designer relies on this); set it only when you want
+   an explicit grid position.
 
 ---
 


### PR DESCRIPTION
Fixes #13772
Part of #13658

Flight ⑤ of the published-skills factual sweep: `skills/objectstack-ui/**`. Every
behavioral claim was settled against the **implementation** — the Zod schemas in
`packages/spec/src/ui/**` and `packages/lint/src/**` in this repo, and the
`@object-ui/*` renderer sources probed read-only in a detached objectui worktree —
never against another document.

**8 distinct false facts / 8 landing sites**, all in `SKILL.md`.
Net **-12 tokens** / **-2 lines**; no ratchet ceiling touched.

## The dominant class: three retired "silently dropped" claims

Three of the eight are one defect: the doc teaches that a bad key is **silently
dropped**, when the protocol-17 strict-unknown-keys cutover closed those schemas and
they now **reject by name**. This is the most expensive direction for an AI author —
"silently dropped" says *your build succeeds and the key is inert*, so the author goes
hunting for a rendering bug; the truth is a loud `os validate` failure with a
prescription attached.

## Per-item: 落点 | before | after

| # | 落点 | before | after |
|---|---|---|---|
| 1 | L328 — object-view `userFilters` | "a `tabs` element is untypable at author time and **dropped at parse**" | "…and **rejected** at parse, not dropped" |
| 2 | L689 — legacy inline widget query | "the inline fields are **dropped** and a widget lacking `dataset` fails `os validate`" | "the closed schema **REJECTS the inline keys by name**, and one lacking `dataset` fails `os validate`" |
| 3 | L2055 — widget `position` pitfall | "there is no `position` key on a widget, so a `position` object is **silently dropped**" | "`position` is not a widget key and the closed schema **REJECTS it by name** (it was silently dropped before protocol 17)" |
| 4 | L63 — List Views table | 9 rows; `page` absent | added `page` row (`pageName`; no rows of its own) |
| 5 | L669 — Widget Types table | 19 of 20 `ChartTypeSchema` members; `combo` absent | added `Mixed` row for `combo` |
| 6 | L1664 — Date macro table, Next period | 4 tokens (`_start` only) — table enumerated 32 while the heading says 36 | `next_*_start` / `_end` ×4, matching the sibling rows; table now enumerates all 36 |
| 7 | L1669 — parameterised token grammar | "`N` is any **positive** integer" | "`N` is any **non-negative** integer" |
| 8 | L1524 — comparison-overlay styling | dash + `opacity: 0.5` claimed "for line/area/scatter"; `opacity: 0.4` for bars | "muted per family (dashed `'4 4'` on line/area only; reduced opacity on all)" |

Items 4–6 are the *hidden-shipped-capability* direction flight ② named as the
majority: the surface is live and authorable, and the skill's own table says it is not
there. Item 6 is self-contradicting in place — the heading counts 36, the table lists
32.

Item 8 in detail: `packages/plugin-charts/src/AdvancedChartImpl.tsx` `comparisonStyle()`
gives the dash to line/area **only** (scatter gets none), and the muted opacity differs
per family (line/scatter stroke 0.5, area fill 0.2, bar fill 0.4). The doc had the two
families crossed. The replacement is true **and** shorter, so this correction helps pay
for the others.

### Payment for the additions (SKILL.md headroom was 0)

The ratchet requires new text to be paid for by genuine deletion **in the same file**.
Two redundant passages in the `timeSegments` block paid for items 4–7; no fact was
dropped — both were restatements of rows already in the field table directly above them:

| 落点 | before | after |
|---|---|---|
| L573 — "Calendar-midnight cue" bullet | 3 lines restating the `showMidnight` table row | deleted; its one unique clause ("the 排班日 cell itself stays unbroken") folded into that row |
| L576 — "Default off = zero regression" | 2 lines; the tint half restates the `bands[].color` row | "**Default off.** Omit `timeSegments` and the gantt renders unsegmented." |

## Evidence — executed probes

Non-vacuity control satisfied several times over; each probe carries positive **and**
negative controls.

- **Date macros** — `DATE_MACRO_TOKENS.length === 36`; `isDateMacroToken` returns
  `true` for all four `next_*_end`, `false` for the control `next_fortnight_end`,
  `true` for the control `today`. `{0_days_ago}` is accepted, settling item 7.
- **`type: 'page'`** — `ListViewSchema.safeParse` ACCEPTS `type:'page'` + `pageName`;
  the control `type:'carousel'` is REJECTED and its own message enumerates all ten
  members including `page`.
- **`combo`** — `ChartTypeSchema` enumerates 20 members including `combo`; the
  generated `contracts/react-blocks.contract.json` already carries it, so the SKILL.md
  table contradicted its own package.
- **`tabs` rejected, not dropped** — `ObjectListViewSchema` REJECTS
  `userFilters:{element:'tabs'}` ("expected one of dropdown|toggle"); controls:
  `dropdown` ACCEPTED, and page-list `ListViewSchema` still ACCEPTS `tabs`. The spec's
  own pin (`packages/spec/src/ui/object-list-view.test.ts`) says "rejected at parse"
  and records the flip from "drops".
- **`position` / inline keys rejected** — `DashboardSchema` returns
  `unrecognized_keys` naming `position`, and separately `object`, `categoryField`,
  `valueField`, `aggregate`; controls: a clean `dataset`+`values` widget ACCEPTED, a
  widget missing `dataset` REJECTED for that reason alone.

### A vacuity trap caught by a control (worth recording)

`GanttConfigSchema.safeParse` ACCEPTS `timeSegments` — but it also accepts a bogus
`__zz__` key **identically**, because that schema is passthrough. The acceptance
measured nothing. Settled instead on the declaration: `GanttConfigSchema` has 19
declared members and `timeSegments` is not one (zero hits in `packages/spec/src/`),
which **confirms** the doc's existing claim that `timeSegments` is an ObjectUI display
extension and not upstream spec. VERIFIED, no change.

## Gates — union run at `ec46764f`, this PR's head commit

All 14 families derived from the REAL diff via
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (exit 0; change
set derived by the script from the merge base, not hand-supplied):

| gate | exit |
|---|---|
| `node scripts/check-ci-filter-parity.mjs` | 0 |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 |
| `node scripts/check-shard-attestation.mjs` | 0 |
| `node scripts/check-skills-token-ratchet.mjs` | 0 |
| `node scripts/check-test-completeness.mjs` | 3 — **NOT MEASURED** by its own verdict text (needs a `turbo run test` log it cannot produce; "not a red, nothing here to fix") |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 (after building its two prerequisites) |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:corpus-claim-drift` | 0 |
| `pnpm check:cross-package-test-inputs` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:role-word` | 0 |
| `pnpm check:skill-compatibility` | 0 |
| `pnpm check:skill-frame-sync` | 0 |

Plus, as the diff implicates them:

- `pnpm --filter @objectstack/spec check:skill-examples` — **exit 0**, fully measured
  after building `@objectstack/client-react` with declarations. Verdict line: "260
  prose examples type-check across 3 surface(s) — every marked block parsed, so tsc ran
  the SEMANTIC pass on all of them". **Population check: NON-empty** — `objectstack-ui`
  carries 11 `os:check` markers (contrast flight ③'s `objectstack-query`, which had 0
  and recorded an empty population). Marker count is 11 before and after this diff, and
  a line-level check shows **0 of the 22 changed lines falls inside any fence** — the
  marked-example population is byte-identical across this change.
- `pnpm --filter @objectstack/spec check:skill-refs` — exit 0, "9 generated files in
  sync with packages/spec".
- `pnpm --filter @objectstack/spec check:react-blocks` — exit 0, "2 generated files in
  sync with packages/spec".
- `node scripts/check-nul-bytes.mjs` — exit 0, 7578 files scanned. Plus a direct
  control-byte scan of the edited file: clean.

Ratchet, before and after:

```text
before  skills/objectstack-ui/SKILL.md   25125 / 25125   (+0, headroom 0)
after   skills/objectstack-ui/SKILL.md   25113 / 25125   (-12, headroom 12)
```

## Generated files: measured, not touched

`contracts/react-blocks.contract.json` and `references/react-blocks.md` are both
emitted by `packages/spec/scripts/build-react-blocks-contract.ts` (`gen:react-blocks`),
and `references/_index.md` by `build-skill-references.ts` — all three are
generator-owned and excluded from the ratchet by name. Both sync gates report them
already in sync with `packages/spec`, so **no regeneration was due and nothing was
hand-edited**. Their content is a function of the spec source, so a correction there
would have to land in `packages/spec/src/ui/**` — outside this flight's fence, and
reported rather than made.

PR #13372 (the `page` view-type member) is the reason item 4 exists: its diff on this
package regenerated **only** those two generated files and never touched `SKILL.md`, so
the authored table went stale while the generated contract moved. Read before flagging,
as instructed.

## Scope

- Zero changes outside `skills/objectstack-ui/SKILL.md`. objectui was probe-read only
  from a detached worktree; no branch pushed there, worktree torn down.
- No changeset: the diff publishes nothing from any package (pure `skills/**`), which
  is the documented `skip-changeset` exemption in `pr-automation.yml` — "this PR
  declares no release of its own". Label applied at creation.
- Governed surface: **draft, human merge only.** `needs:contract-review` attached to
  this PR and to card #13772 in the same stroke, per the clause ② CONTENT limb; this
  seat never self-clears it.

_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_