### PR TITLE
Pin the receiver/member-call form of the unknown-function rejection — and report where the #13594 hole actually is

### DIFF
--- a/packages/formula/src/validate.test.ts
+++ b/packages/formula/src/validate.test.ts
@@ -48,6 +48,68 @@ describe('validateExpression (ADR-0032)', () => {
     it('still accepts a registered stdlib function (isBlank)', () => {
       expect(validateExpression('predicate', '!isBlank(record.target_channels)').ok).toBe(true);
     });
+
+    // #13594 — the RECEIVER/member-call form of an unknown function had NO pin
+    // anywhere in this package. Every unknown-function pin written for #1877 —
+    // the two above, plus `celEngine.compile`'s and the fault-classification
+    // suite's — spells the call as a GLOBAL one (`PRIOR(...)`, `size(1)`). A
+    // regression that lost only the receiver arm of cel-js's type check would
+    // therefore have kept this whole suite green while `validateExpression`
+    // passed a predicate the runtime then faults on, and on the ObjectUI action
+    // surfaces that fault is fail-CLOSED and near-silent:
+    // `ActionEngine.getActionsForLocation` and `DeclaredActionsBar` both
+    // evaluate with `throwOnError: true` and HIDE the action — for every user,
+    // including ones who hold the grant — leaving one deduped `console.warn` as
+    // the only signal. A plausible-looking function name that does not exist is
+    // exactly what a generator invents, so the half with no pin was the half an
+    // AI-authored app is most likely to hit.
+    //
+    // MEASURED while writing these, on the source tree AND on the published
+    // `@objectstack/formula@17.2.0` / `@marcbachmann/cel-js@8.0.0` that #13594
+    // names: BOTH call forms are already rejected at this entry point, and
+    // `upper('a')` is still clean. #13594's table (`validate.ok= true` for both)
+    // did not reproduce here. The surface that does accept them is
+    // `@objectstack/lint`'s `validate-visibility-predicates`, which stays
+    // parse-only by a maintainer ruling and carries its own pin for that. These
+    // cases exist so that measured verdict cannot quietly stop being true.
+    it('rejects an unknown method in the receiver/member-call form (#13594)', () => {
+      const r = validateExpression('predicate', "record.x.nosuchmethod('a')");
+      expect(r.ok).toBe(false);
+      expect(r.errors).toHaveLength(1);
+      expect(r.errors[0].message).toMatch(/invalid CEL predicate/i);
+      // cel-js names the RECEIVER's static type, not the source spelling, so the
+      // author sees `dyn.nosuchmethod`. Pinned as the author sees it — the same
+      // `found no matching overload` vocabulary the runtime fault uses, which is
+      // what makes publish time and run time read as one system.
+      expect(r.errors[0].message).toContain("found no matching overload for 'dyn.nosuchmethod(string)'");
+      expect(r.errors[0].source).toBe("record.x.nosuchmethod('a')");
+      expect(r.warnings).toHaveLength(0);
+    });
+
+    it('rejects an invented method on the canonical user root (#13594)', () => {
+      // The authored predicate that motivated the card (objectui#4421): a
+      // capability method on `current_user` that reads plausibly and does not
+      // exist. `current_user` is a declared SCOPE_ROOT, so this is NOT caught as
+      // an unbound root — only the unknown call catches it.
+      const r = validateExpression('predicate', 'current_user.can(record, "read")');
+      expect(r.ok).toBe(false);
+      expect(r.errors[0].message).toContain('found no matching overload');
+      expect(r.errors[0].message).toContain('can');
+    });
+
+    it('the global form rejects and the stdlib control stays clean (#13594)', () => {
+      // Both directions in ONE case, deliberately. A pin asserting only the
+      // rejection stays green under a change that rejects EVERY call — which
+      // would close the hole by breaking every authored predicate instead.
+      const bogus = validateExpression('predicate', 'totallyBogusFn(1,2)');
+      expect(bogus.ok).toBe(false);
+      expect(bogus.errors[0].message).toContain("found no matching overload for 'totallyBogusFn(int, int)'");
+
+      const control = validateExpression('predicate', "upper('a')");
+      expect(control.ok).toBe(true);
+      expect(control.errors).toHaveLength(0);
+      expect(control.warnings).toHaveLength(0);
+    });
   });
 
   // #7073 — the trailer used to be undifferentiated: EVERY `celEngine.compile`


### PR DESCRIPTION
Part of #13594.

## The headline: the card's premise did not reproduce, and the hole is at a different surface

#13594 reports that `validateExpression` (`@objectstack/formula`) returns `ok: true` for a CEL
source calling a function the engine does not have, for both the global-call and the
receiver/member-call form.

**Measured, twice, on the artifact the card names and on this tree — it rejects both.**

Published `@objectstack/formula@17.2.0` + `@marcbachmann/cel-js@8.0.0`, installed clean from npm
and driven through `validateExpression('predicate', ...)`:

```
"totallyBogusFn(1,2)"             ok= false  errs= 1  warns= 0   found no matching overload for 'totallyBogusFn(int, int)'
"record.x.nosuchmethod('a')"      ok= false  errs= 1  warns= 0   found no matching overload for 'dyn.nosuchmethod(string)'
"current_user.can(object, verb)"  ok= false  errs= 1  warns= 0   found no matching overload for 'dyn.can(dyn, dyn)'
"upper('a')"                      ok= true   errs= 0  warns= 0
```

Same answers from this worktree's source at merge-base `936aa2d3a`. Twenty-five unknown-function
shapes were probed — global, receiver-on-dyn, receiver-on-literal, inside a macro body, inside
both ternary branches, behind `and` / `or` short-circuits, nested, in an index expression, wrong
arity — and every one is refused, with all five stdlib/builtin controls staying clean. The
mechanism is `celEngine.compile` reading cel-js's `check()` verdict, which has been in place since
the #1877 repair; its own comment says so.

So the reported defect is not at this entry point. **It is at
`@objectstack/lint`'s `validate-visibility-predicates`** — the gate that actually judges the
`visibleWhen` / action-predicate surface the card's evidence comes from. Measured side by side on
the same sources:

```
                                   lint gate                       validateExpression
totallyBogusFn(1,2)                CLEAN                           ok=false
record.x.nosuchmethod('a')         CLEAN                           ok=false
country === "USA"                  visibility-predicate-syntax     ok=false   (control: caught)
status == 'active'                 visibility-bare-identifier      ok=true    (control: caught)
```

That gate is **parse-only by design**, not by oversight. Its module note records a maintainer
ruling and explains that routing it through `compile()` / `validateExpression` "would silently
overturn" a deliberate decision, and a dedicated case pins it: *"does NOT widen to type-checking
— the CEL-type blind spot stays a blind spot"*. Widening an error-level authoring gate from "does
not parse" to "does not type-check", on a surface whose predicates are overwhelmingly `dyn`, is a
contract decision with a ruling already on record pointing the other way. **It is escalated, not
taken here.**

## What this PR does ship

The one thing that was genuinely missing and is not a contract question: **a pin for the
receiver/member-call form.**

Every unknown-function pin in `packages/formula` spelled the call as a *global* one — `PRIOR(...)`
in `validate.test.ts` (twice) and in `cel-engine.test.ts`, `size(1)` in the fault-classification
suite. Nothing anywhere asserted the receiver form. A regression that dropped only cel-js's
`rcall` arm — precisely the half the card warned would be easy to miss — would have kept the
entire suite green while `validateExpression` waved through a predicate the runtime then faults
on. On the action surfaces that fault is fail-closed and near-silent: `ActionEngine.getActionsForLocation`
and `DeclaredActionsBar` both evaluate with `throwOnError: true` and hide the action for every
user including ones holding the grant, leaving one deduped `console.warn` as the only signal.

Three cases added to `packages/formula/src/validate.test.ts`:

1. the receiver/member-call form, pinned as the author sees it — cel-js names the receiver's
   static type, so the message reads `dyn.nosuchmethod`, not the source spelling;
2. the invented capability method on `current_user` (the objectui#4421 predicate), which matters
   because `current_user` is a declared `SCOPE_ROOT` — the unbound-root check cannot catch it, so
   only the unknown call does;
3. the global form and the `upper('a')` control **in one case**, deliberately: a pin asserting
   only the rejection would stay green under a change that rejected every call.

The block also records the measurement above, so the next reader does not re-derive it.

**Tests only. Zero production bytes** — the whole diff is one `.test.ts` file, so the publish
gate's accept set is byte-for-byte unchanged and no consumer behaviour moves.

## Contract-review clause: NOT fired

The dispatch order made `needs:contract-review` conditional on shipping ERROR, because that would
narrow what the publish gate accepts. Nothing is narrowed here: ERROR is what already ships, and
this PR changes no production code. Declared from what was actually built.

## Verification — all at final commit `29a596f7`

- `pnpm --filter @objectstack/formula test` — **25 files, 662 tests passed**.
- `pnpm --filter @objectstack/lint test` — **87 files, 2397 passed, 5 skipped** (after
  `pnpm --filter '@objectstack/lint^...' build`; an unbuilt `@objectstack/sdui-parser` was
  failing 23 files to load beforehand, unrelated to this diff).
- **Ablation** — neutered the single arm the pins ride on in `celEngine.compile`
  (`if (checkResult && checkResult.valid === false)` to `if (false and ...)`). Mutation confirmed
  on disk by anchored greps in both directions (injected marker 1, removed text 0) and a changed
  blob hash; the subject is reached by *relative* import (`./validate`, `./cel-engine`), so no
  `dist` is on the resolution path and no rebuild leg applies. Result: **62 passed goes to 5
  failed / 57 passed** — all three new cases red, alongside the two pre-existing #1877 ones.
  Restore proved byte-identical to HEAD (`git diff HEAD` empty, blob `5170cfdc` equals the HEAD
  blob).
- **Gate family** re-derived from the real change set via `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`:
  21 families. **19 green** by their own verdict lines (`check-nul-bytes: OK (7594 text files)`,
  `check-test-source-alias OK`, `check:published-files` 69 packages, `where-matcher` 320 matchers,
  and the rest). **2 NOT MEASURED**, by the gates' own words, not red:
  `check-test-completeness` (PREREQUISITE NOT MET — needs a saved `turbo run test` log) and
  `check:dual-build-cjs-loads` (PREREQUISITE NOT MET — needs a full `pnpm build`).
- `pnpm --filter @objectstack/formula typecheck` passes, **but does not cover this diff**:
  `packages/formula/tsconfig.json` carries `"exclude": ["**/*.test.ts"]`, and `tsc --listFiles`
  confirms 0 of 25 test files enter the program. Type-checked separately with tests included —
  **`src/validate.test.ts` clean**; the 17 errors that surface there are pre-existing and live in
  five other test files. Filed as a finding rather than repaired here.

`skip-changeset`: the diff publishes nothing from any package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_