### PR TITLE
docs(spec): record text.value as deliberately omitted (#13670)

### DIFF
--- a/content/docs/references/ui/expression-bindable-text-keys.mdx
+++ b/content/docs/references/ui/expression-bindable-text-keys.mdx
@@ -67,8 +67,16 @@ at the top level (`alert`/`empty`/`dialog` `title`+`description`, `badge`
 `label`, form inputs' `value`/`label`, …) — those rows are deliberately NOT
 declared yet: form-control `value` is interactive state rather than display
 text, and each row is an accept-surface widening that should arrive with its
-own measurement, not ride this one (startup scope discipline). Adding a row
-is additive and spec-first; do it here, never as a renderer-side inference.
+own measurement, not ride this one (startup scope discipline). `text` reads
+back `schema.content || schema.value` (`basic/text.tsx`) — unlike the rows
+above, its omission is not merely unmeasured: `value` there is a fallback
+spelling for the same slot `content` already evaluates (see `content` NOT a
+member, above), not a second read point, so a `text: ['value']` row would
+legitimize the fallback spelling and give one slot two declared evaluation
+paths. The objectstack#13670 ruling settled `text`'s intended evaluation
+channel as `content` alone and declared `text.value` OUT on those grounds —
+this omission is deliberate, not pending measurement. Adding a row is
+additive and spec-first; do it here, never as a renderer-side inference.
 
 <Callout type="info">
 **Source:** `packages/spec/src/ui/expression-bindable-text-keys.zod.ts`

--- a/packages/spec/src/ui/expression-bindable-text-keys.zod.ts
+++ b/packages/spec/src/ui/expression-bindable-text-keys.zod.ts
@@ -63,8 +63,16 @@
  * `label`, form inputs' `value`/`label`, …) — those rows are deliberately NOT
  * declared yet: form-control `value` is interactive state rather than display
  * text, and each row is an accept-surface widening that should arrive with its
- * own measurement, not ride this one (startup scope discipline). Adding a row
- * is additive and spec-first; do it here, never as a renderer-side inference.
+ * own measurement, not ride this one (startup scope discipline). `text` reads
+ * back `schema.content || schema.value` (`basic/text.tsx`) — unlike the rows
+ * above, its omission is not merely unmeasured: `value` there is a fallback
+ * spelling for the same slot `content` already evaluates (see `content` NOT a
+ * member, above), not a second read point, so a `text: ['value']` row would
+ * legitimize the fallback spelling and give one slot two declared evaluation
+ * paths. The objectstack#13670 ruling settled `text`'s intended evaluation
+ * channel as `content` alone and declared `text.value` OUT on those grounds —
+ * this omission is deliberate, not pending measurement. Adding a row is
+ * additive and spec-first; do it here, never as a renderer-side inference.
  */
 
 import { z } from 'zod';


### PR DESCRIPTION
Fixes #13670

## Scope

Spec-side implementation of ruling comment #13670 (comment-5478581056) clause 2 only:
`packages/spec/src/ui/expression-bindable-text-keys.zod.ts`'s docblock "known-omitted"
list did not mention `text`. It now records that `text.value` is deliberately OUT —
`text`'s intended evaluation channel is `content` alone (its own already-evaluated
carriage leg), `value` is only the renderer's `schema.content || schema.value` fallback
spelling for the same slot, and a `text: ['value']` row would legitimize that fallback
and give one slot two declared evaluation paths.

⛔ No carriage row added, no behavior/runtime code touched, no `text` entry in
`EXPRESSION_BINDABLE_TEXT_KEYS_BY_COMPONENT`. objectui#7015 (23 tutorial occurrences,
`value` → `content`) and objectui#7016 (the `TextSchema.value` fallback-spelling ADR-0049
enforce-or-remove question) are separate, out of scope here.

## Change

- `packages/spec/src/ui/expression-bindable-text-keys.zod.ts` — one paragraph added to
  the module docblock's "Why these rows" section, citing this issue's ruling.
- `content/docs/references/ui/expression-bindable-text-keys.mdx` — regenerated projection
  of the same docblock (`pnpm --filter @objectstack/spec gen:docs`, via
  `check:generated --fix`; never hand-edited).

## Premise check

Verified against `origin/main` before editing: the docblock's known-omitted list
(`alert`/`empty`/`dialog`/`badge`/form-inputs) still had no `text` entry — premise held.

## Tests

At commit `5fcfcf7d` (this PR's head):

- `pnpm --filter @objectstack/spec build` — clean (34/34 declared `.d.ts` present).
- `pnpm --filter @objectstack/spec typecheck` (`tsc --noEmit` + scripts + test-layer
  typecheck) — clean; the pre-existing `test-typecheck-debt.json` ledger (262 errors /
  146 pinned signatures) is unchanged, shrink-only baseline, unrelated to this diff.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — derived 48
  local gate families for this diff's 2 changed paths. Ran all 48 (captured pipeline
  status before any pipe, per AGENTS.md):
  - 42/48 exit 0 (including `check:generated`, `check:authorable-surface`,
    `check:docs`, `check:doc-authoring`, `check:doc-anchors`, `check:corpus-claim-drift`,
    `check:quick-reference-counts`, `check:cross-package-test-inputs`, and the rest).
  - 6/48 self-report **PREREQUISITE NOT MET / NOT MEASURED** (exit 1 or 3, not exit-0
    findings): `check-dev-prereqs`, `check-test-completeness` (explicitly documents it
    is unreachable without a saved `turbo run test` log), `check:doc-formula-expressions`,
    `check:doc-security-posture`, `check:skill-examples`, `check:dual-build-cjs-loads` —
    all six gate on a full `pnpm build` across the ~79-package workspace (missing
    `dist/` for `@objectstack/formula`, `@objectstack/lint`, `@objectstack/client-react`,
    and ~70 more), which is out of this task's local-verification scope (AGENTS.md
    "本地验证范围" — the farm is CI's run, not a single-file docblock PR's). None of the
    six reads or gates the two files this PR touches. Read as NOT MEASURED, not green,
    not red.
  - 0/48 red findings.
- `check:generated` — clean after `--fix` regenerated exactly the one stale artifact
  (`content/docs/references/**`); no other of the 14 tracked artifacts moved.
- `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both changed files — no control
  bytes.

## Changeset

None. `packages/spec/src/ui/expression-bindable-text-keys.zod.ts`'s diff is comment-only
(no export, no schema, no runtime behavior changed); `content/docs/references/**` is its
regenerated projection. Nothing is released differently by this PR. `skip-changeset`
label applied (additive) per this repo's real skip-changeset mechanism.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_