### PR TITLE
docs: name `FLOW_INPUT_SCHEMA_INVALID` in the four flow refusal-code enumerations

### DIFF
--- a/.changeset/flow-refusal-enumeration-four-pages.md
+++ b/.changeset/flow-refusal-enumeration-four-pages.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/docs": patch
+---
+
+fix(docs): four pages enumerating the flow refusal codes now name `FLOW_INPUT_SCHEMA_INVALID` (#13720)
+
+`FlowRefusalCode` gained a fourth member in `packages/runtime/src/flow-dispatch-status.ts`
+(`b6d3d76b5`), answered `422` and classified never-dispatched. Three pages were updated with
+it; four others enumerate the same union and were not, so each stated the enumeration as
+**complete** while it was one code short — a teaching surface telling a reader that a status
+they will really receive does not exist.
+
+| page | the row that was short |
+|:---|:---|
+| `content/docs/api/declarative-endpoints.mdx` | the `type: 'flow'` delegation row |
+| `content/docs/api/plugin-endpoints.mdx` | `POST /automation/:name/trigger` |
+| `content/docs/protocol/kernel/http-protocol.mdx` | the declared-endpoint `type: 'flow'` answer row |
+| `content/docs/ui/actions.mdx` | the `type: 'flow'` over-REST row |
+
+Prose only — no schema, no runtime behaviour and no generated artifact moves. The two
+generated reference pages (`references/api/contract.mdx`,
+`references/api/error-code-ledger.mdx`) already carried the code, which is why the
+generator needed nothing here.
+
+**Which group the new code joins was read off the source, not inferred from the status.**
+`classifyFlowRefusal` tests `FLOW_INPUT_SCHEMA_INVALID` inside the
+`── never dispatched: the producer says WHICH refusal ──` arm block, above the
+`result.status === 'failed'` arm that answers `400 FLOW_FAILED`. `ui/actions.mdx` is the
+one page that splits its enumeration into "a run that ran and was rejected" versus "a
+dispatch that never happened", so the code is placed in the second group there; putting it
+beside `FLOW_FAILED` would have said the run started.
+
+`422` is now carried by two codes (`FLOW_NO_START_NODE` and `FLOW_INPUT_SCHEMA_INVALID`).
+Each page spells the status together with its code, so every entry stays a self-contained
+pair rather than a claim about what `422` alone means — the discriminator is `error.code`,
+which is what `http-protocol.mdx` already tells readers to branch on. The full table with
+per-code guidance stays where it is, in `content/docs/automation/flows.mdx`.

--- a/content/docs/api/declarative-endpoints.mdx
+++ b/content/docs/api/declarative-endpoints.mdx
@@ -100,7 +100,7 @@ declaration to shadow a built-in one. Match → policy chain (`rateLimit` → `a
 | `type` | Delegates to | Request shape |
 |:---|:---|:---|
 | `object_operation` | the same `callData` binding that serves `/api/v1/data/{object}` | `find` reads its criteria from the query string; `get` / `update` / `delete` take the record id from `query.id`; `create` / `update` take the body. `create` answers `201`, the rest `200` |
-| `flow` | the same automation pipeline as `POST /api/v1/automation/{name}/trigger` | the request body is the flow input. A refused or failed run answers a real status: `404` unknown flow, `409` `FLOW_DISABLED`, `422` `FLOW_NO_START_NODE`, `400` `FLOW_FAILED` |
+| `flow` | the same automation pipeline as `POST /api/v1/automation/{name}/trigger` | the request body is the flow input. A refused or failed run answers a real status: `404` unknown flow, `409` `FLOW_DISABLED`, `422` `FLOW_NO_START_NODE`, `422` `FLOW_INPUT_SCHEMA_INVALID`, `400` `FLOW_FAILED` |
 
 The frozen vocabulary has **no path-template syntax**, so an endpoint cannot express
 `/leads/{id}` — a record id travels as `?id=…`. A method that no declaration claims

--- a/content/docs/api/plugin-endpoints.mdx
+++ b/content/docs/api/plugin-endpoints.mdx
@@ -48,7 +48,7 @@ Approve/reject were never workflow routes (ADR-0019): approval is a flow node, a
 
 | Method | Endpoint | Description |
 |:-------|:---------|:------------|
-| POST | `/automation/:name/trigger` | Trigger an automation flow by name (legacy alias: `/automation/trigger/:name`). Failures answer real status codes, not a `200` wrapping an inner failure: **404** unknown flow, **409** `FLOW_DISABLED`, **422** `FLOW_NO_START_NODE`, **400** `FLOW_FAILED` for a run that ran and was rejected — see [Run a flow via API](/docs/automation/flows#run-a-flow-via-api) |
+| POST | `/automation/:name/trigger` | Trigger an automation flow by name (legacy alias: `/automation/trigger/:name`). Failures answer real status codes, not a `200` wrapping an inner failure: **404** unknown flow, **409** `FLOW_DISABLED`, **422** `FLOW_NO_START_NODE`, **422** `FLOW_INPUT_SCHEMA_INVALID`, **400** `FLOW_FAILED` for a run that ran and was rejected — see [Run a flow via API](/docs/automation/flows#run-a-flow-via-api) |
 
 The automation dispatcher also exposes flow CRUD (`GET`/`POST /automation`, `GET`/`PUT`/`DELETE /automation/:name`) and run observability/resume routes — see [Durable pause & resume](/docs/automation/flows#durable-pause--resume-adr-0019).
 

--- a/content/docs/protocol/kernel/http-protocol.mdx
+++ b/content/docs/protocol/kernel/http-protocol.mdx
@@ -1225,7 +1225,7 @@ declaration to shadow a built-in route:
 | Endpoint declares | Answer |
 |:---|:---|
 | `type: 'object_operation'` | delegated to the same `callData` binding that serves `/api/v1/data/{object}` — byte-identical `data` |
-| `type: 'flow'` | delegated to the same automation pipeline as `POST /api/v1/automation/{name}/trigger` — the same execution context builder, the same `execute` call, and **the same response contract**: a refused or failed run is classified into the same real status codes (404 / 409 `FLOW_DISABLED` / 422 `FLOW_NO_START_NODE` / 400 `FLOW_FAILED`), from one shared definition all three flow doors read. Branch on the status and `error.code`, never on an inner success flag |
+| `type: 'flow'` | delegated to the same automation pipeline as `POST /api/v1/automation/{name}/trigger` — the same execution context builder, the same `execute` call, and **the same response contract**: a refused or failed run is classified into the same real status codes (404 / 409 `FLOW_DISABLED` / 422 `FLOW_NO_START_NODE` / 422 `FLOW_INPUT_SCHEMA_INVALID` / 400 `FLOW_FAILED`), from one shared definition all three flow doors read. Branch on the status and `error.code`, never on an inner success flag |
 | `authRequired: true` (or omitted) + anonymous caller | `401` `UNAUTHENTICATED`, the same envelope every seam answers |
 | `rateLimit` armed and exhausted | `429` + `Retry-After`, never with a cache directive |
 | `cacheTtl: 30` on a successful GET | `Cache-Control: private, max-age=30` — `private` is a security rule, not tuning: any response can be RLS-trimmed |

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -346,7 +346,7 @@ The endpoint dispatches on the **declared `type`**, exactly like the MCP
 | `type` | Over REST |
 |:---|:---|
 | `script` | Runs the registered handler / inline body. |
-| `flow` | Runs `target` on the automation engine, with your identity forwarded (a `runAs: 'user'` flow enforces RLS as you). Dispatches the same flow as `POST /api/v1/automation/:target/trigger`, without having to know the flow name — **and answers the same way**: a run that ran and was rejected is **400** `FLOW_FAILED`, while a dispatch that never happened is separated out (**404** unknown flow / **409** `FLOW_DISABLED` / **422** `FLOW_NO_START_NODE`). See [Run a flow via API](/docs/automation/flows#run-a-flow-via-api) for the full table — it is one table, read by both doors. |
+| `flow` | Runs `target` on the automation engine, with your identity forwarded (a `runAs: 'user'` flow enforces RLS as you). Dispatches the same flow as `POST /api/v1/automation/:target/trigger`, without having to know the flow name — **and answers the same way**: a run that ran and was rejected is **400** `FLOW_FAILED`, while a dispatch that never happened is separated out (**404** unknown flow / **409** `FLOW_DISABLED` / **422** `FLOW_NO_START_NODE` / **422** `FLOW_INPUT_SCHEMA_INVALID`). See [Run a flow via API](/docs/automation/flows#run-a-flow-via-api) for the full table — it is one table, read by both doors. |
 | `api` | **400** — it dispatches on `target`; call that endpoint directly. |
 | `url` / `modal` / `form` | **400** — client-side navigation; there is nothing for the server to run. |
 


### PR DESCRIPTION
Fixes #13720

`FlowRefusalCode` gained a fourth member in `packages/runtime/src/flow-dispatch-status.ts` (`b6d3d76b5`), answered `422` and classified never-dispatched. Three pages were updated with it; four others enumerate the same union and were not — so each told a reader the enumeration was **complete** while a status they will really receive was absent.

## The four edits

| page | line | the row |
| :--- | ---: | :--- |
| `content/docs/api/declarative-endpoints.mdx` | 103 | the `type: 'flow'` delegation row |
| `content/docs/api/plugin-endpoints.mdx` | 51 | `POST /automation/:name/trigger` |
| `content/docs/protocol/kernel/http-protocol.mdx` | 1228 | the declared-endpoint `type: 'flow'` answer row |
| `content/docs/ui/actions.mdx` | 349 | the `type: 'flow'` over-REST row |

Four lines, one code name added to each. No prose was rewritten, no schema moved, no runtime behaviour changed.

## Placement was read off the runtime source, not inferred from the status

The four rows are **not** interchangeable, and one of them groups its enumeration by exactly the distinction this code turns on, so a copy-paste insertion would have been wrong there.

`classifyFlowRefusal` in `packages/runtime/src/flow-dispatch-status.ts` tests the new code inside the never-dispatched arm block:

```
// ── never dispatched: the producer says WHICH refusal (#9415, #10025) ──
if (result.code === 'FLOW_DISABLED')             -> 409
if (result.code === 'FLOW_NO_START_NODE')        -> 422
if (result.code === 'FLOW_INPUT_SCHEMA_INVALID') -> 422
// ── dispatched and rejected: the producer's lifecycle verdict (#9378) ──
if (result.status === 'failed')                  -> 400 FLOW_FAILED
```

The module header states the same thing in prose: the guard's verdict is "a pure function of the flow definition", the engine "refuses ONCE, never enters its retry loop", and the row is stamped with no `status` — the never-dispatched class.

So, per page:

- `declarative-endpoints.mdx`, `plugin-endpoints.mdx`, `http-protocol.mdx` are flat status lists in engine order. The code is inserted after `422` `FLOW_NO_START_NODE` and before `400` `FLOW_FAILED`, which is the order `classifyFlowRefusal` evaluates.
- `ui/actions.mdx` is the page that **splits** its enumeration into "a run that ran and was rejected" (`400` `FLOW_FAILED`) versus "a dispatch that never happened" (`404` / `409` / `422`). The code joins the **second** group. Placing it beside `FLOW_FAILED` would have told a reader the run started, which the source says it did not.

## Two codes now share `422`

`FLOW_NO_START_NODE` and `FLOW_INPUT_SCHEMA_INVALID` both answer `422`. Every entry on all four pages spells the status together with its code, so each stays a self-contained pair rather than a claim about what `422` alone means — an enumeration, not a contradiction. The discriminator is `error.code`, which is what `http-protocol.mdx` already tells readers to branch on in the same sentence ("Branch on the status and `error.code`, never on an inner success flag"). Per-code guidance and the retry semantics stay in the one full table, `content/docs/automation/flows.mdx`, which three of the four pages already link.

## Deliberately not touched

- **`content/docs/releases/v17.mdx`** — it carries the same short enumeration and is **out of scope for two independent reasons**: release notes are never edited in a code PR (AGENTS.md Documentation Guardrails; the file is the repo's hottest conflict magnet), and that page is a historical record of what v17 shipped rather than a live contract page.
- **`content/docs/permissions/system-context.mdx`** — the card body names it as having been correctly updated, but that page names **none** of the flow refusal codes and makes no completeness claim, so it is not a fifth omission and nothing was added to it. Verified by grep on this branch: zero hits for any union member.
- **`content/docs/references/api/contract.mdx`** and **`references/api/error-code-ledger.mdx`** — both already carry the code and both are head-bannered AUTO-GENERATED. There is no generator half to this change.
- The docs-drift blindness that let this through is **#11995** and is untouched here; that card remains open and is not addressed by this PR.

## Verification

Final commit **`1974fb160`**. All gate results below were run on that exact tree (working tree clean, no commits after).

Gate families derived mechanically from the real change set rather than from a recalled list: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` -> **36 families** (22 pnpm, 14 direct node), harvested runnably with `--commands`.

**35 of 36 green, 1 not measurable locally.** Exit codes were captured before any pipe.

Named in the dispatch, with each gate's own verdict line:

```
pnpm --filter @objectstack/spec run check:docs      exit=0
  "230 generated files in sync with packages/spec"
  "import examples resolve against api-surface/ (60 accepted gap(s) in the baseline)"

pnpm check:doc-anchors                              exit=0
  "check-doc-anchors: 290 internal #fragment link(s) across 409 source file(s)
   all resolve to a real heading"

pnpm check:doc-authoring                            exit=0
  "doc authoring guard: 393 files clean — no bare metadata literals."
```

Also green: `check:corpus-claim-drift`, `check:docs-single-h1`, `check:docs-audit-scope`, `check:docs-redirects`, `check:published-readme-links`, `check:doc-formula-expressions`, `check:doc-security-posture`, `check:skill-examples`, `check:liveness`, `check:empty-state`, `check:variant-docs`, `check:strictness-ledger`, `check:yaml-examples`, `check:role-word`, `check:react-page-adapter-contract`, `check:cross-package-test-inputs`, `check:objectui-changeset`, `check:pm-half-states`, `check:changeset-gate-self-tests`, plus the 13 direct-node gates including `check-empty-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-doc-frontmatter`, `check-doc-route-spelling`, `check-docs-section-name`, `check-section-landing-index`.

`node scripts/check-test-completeness.mjs` is recorded **NOT MEASURED**, not red: it exits 3 with `PREREQUISITE NOT MET` because it grades a saved `turbo run test` log that only CI produces, and its own output says so.

Three gates first reported `PREREQUISITE NOT MET` on unbuilt packages (`@objectstack/formula`, `@objectstack/lint`, `@objectstack/client-react`); all three ran green after `turbo run build` for those packages. `@objectstack/spec` and its dependency closure were built before any gate ran, since `check:docs` reads built output rather than source.

**Repo-wide ESLint (`pnpm lint`) was narrowed, and the narrowing is proved rather than assumed.** ESLint's own configuration declares no `.mdx` or `.md` population — every `files` glob in `eslint.config.mjs` is a TypeScript/JavaScript extension set. Asked directly about the five changed paths, ESLint answers for each: `File ignored because no matching configuration was supplied`. Counted from `--format json`: 5 results, **0 files actually linted**, 0 errors. Since no path in this diff is in ESLint's input set, the repo-wide verdict is identical to `origin/main`'s for every file, touched and untouched alike.

No test changes: this diff contains no executable code.

## Zone 2 assumptions

- **A2.1 confirmed** — the four rows are differently shaped, and `ui/actions.mdx` really does split its enumeration into two groups. A single copy-paste sentence would have been wrong there.
- **A2.2 confirmed by the source** — `FLOW_INPUT_SCHEMA_INVALID` sits in the never-dispatched arm block, above the `status === 'failed'` arm. The PM's reading was right; nothing was falsified.
- **A2.3 handled** — see "Two codes now share `422`" above.
- **Premise re-verified on current `origin/main` (`4bc18e542`, moved from the `0a8ebf33d` the pre-flight used).** The union-member census still returns 7 non-generated pages, 5 of which omit the code; four are this card's and the fifth is the release page. All four line numbers still hold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_