### PR TITLE
Correct 17 false behavioral claims in skills/objectstack-i18n — sweep flight ⑧

### DIFF
--- a/skills/objectstack-i18n/SKILL.md
+++ b/skills/objectstack-i18n/SKILL.md
@@ -47,9 +47,9 @@ and integration with the I18nService.
 
 1. **Runtime format — `objects.*` (`TranslationData`)**: each locale is authored as one
    `TranslationData` value. All translatable content for an object (label, fields,
-   options, views, sections, actions) is grouped under `objects.{object_name}`, with
-   global groups (`apps`, `messages`, `globalActions`, `dashboards`, `settings`,
-   `metadataForms`) at the top level.
+   options, views, sections, tabs, actions) is grouped under `objects.{object_name}`,
+   with global groups (`apps`, `messages`, `globalActions`, `dashboards`, `pages`,
+   `flows`, `settings`, `metadataForms`, `settingsCommon`) at the top level.
 
 2. **Bundle registration**: per-locale files are assembled with
    `defineTranslationBundle({ en, 'zh-CN': … })` into a `TranslationBundle`
@@ -152,7 +152,7 @@ i18n/
 
 The canonical authoring path: one `TranslationData` per locale, assembled with
 `defineTranslationBundle` and registered on the stack. This mirrors the shipped
-example apps (`src/translations/{en,zh-CN}.ts` + `index.ts`):
+`examples/app-todo` (`src/translations/{en,zh-CN,ja-JP}.ts` + `index.ts`):
 
 <!-- os:check -->
 ```typescript
@@ -256,15 +256,16 @@ All translatable content for a single object is aggregated under
 
 | Sub-key | Holds |
 |:--------|:------|
-| `label` / `pluralLabel` / `description` | Object-level text (`label` is required) |
+| `label` / `pluralLabel` / `description` | Object-level text (every key optional) |
 | `fields.{field_name}` | `label`, `help`, `placeholder`, `options` (option value → label) per field |
 | `_views.{view_name}` | `label`, `description`, `emptyState.title` / `emptyState.message` |
-| `_actions.{action_name}` | `label`, `confirmText`, `successMessage`, `params.{param_name}`, `resultDialog` |
-| `_sections.{section_name}` | Form section / tab `label`, `description` |
+| `_actions.{action_name}` | `label`, `description`, `confirmText`, `successMessage`, `params.{param_name}`, `resultDialog` |
+| `_sections.{section_name}` | Form section `label`, `description` |
+| `_tabs.{tab_name}` | Filter-preset tab `label`, keyed by `ViewTabSchema.name` |
 
 Top-level groups alongside `objects`: `apps` (label, description, navigation),
-`messages`, `globalActions` (object-less actions), `dashboards`, `settings`,
-`metadataForms`, `settingsCommon`.
+`messages`, `globalActions` (object-less actions), `dashboards`, `pages`, `flows`,
+`settings`, `metadataForms`, `settingsCommon`.
 
 > **Validation messages are not a translation group.** `validationMessages` was
 > removed in spec 17.0.0 — nothing ever read it, so a translated rule
@@ -297,10 +298,10 @@ parse, ship, and resolve to nothing.
 
 `os validate` / `os lint` / `os compile` check this direction and report it as
 warnings (`translation-target-unknown`, `translation-option-key-unknown`): a key
-naming an object, field, view, action, param, section, app, nav item, dashboard
-or widget that does not exist is listed alongside the names that do. A bundle
-keyed to something since renamed still parses — the label just renders silently
-in its source locale while every neighbouring label resolves.
+naming an object, field, view, action, param, section, app, nav item, dashboard,
+widget, flow or flow-screen field that does not exist is listed alongside the
+names that do. A bundle keyed to something since renamed still parses — the label
+just renders silently in its source locale while every neighbouring one resolves.
 
 ---
 
@@ -342,9 +343,9 @@ export default defineTranslation({
 Rules that differ from a file bundle:
 
 - **`locale` is required.** A file bundle names its locales as map keys; an item
-  carries its own. An item whose locale cannot be resolved is skipped by the
-  runtime sync — a silent skip, which is why the field is mandatory rather
-  than inferred from the item name.
+  carries its own. The runtime sync falls back to the item *name* when that looks
+  like a BCP-47 tag, then skips the item with an `[i18n] … — skipped` warning
+  naming the row — a server log line the author never sees. Always set `locale`.
 - **One locale per item.** Author `zh-CN` and `ja-JP` as two items.
 - Published items are loaded at boot and on every publish (no restart), and
   layer **over** the file bundles — an authored value wins over a shipped one
@@ -358,10 +359,8 @@ Exact Zod shape: `node_modules/@objectstack/spec/src/system/translation.zod.ts` 
 A second object-first shape keyed on `o.{object_name}` (with `app`, `nav`,
 `dashboard`, `reports`, `notifications`, `errors`, `_globalOptions`, `_meta`,
 `namespace`, and `_actions.confirmMessage`) was once documented for
-Studio-authored translations. **No resolver ever read it**, so items authored
-that way saved successfully and rendered nothing. It was removed —
-those keys are now rejected at save time with a message naming the group to
-use instead. Never author them, in files or at runtime.
+Studio-authored translations. **No resolver ever read it.** Both doors now reject
+it — files as well as items — each key carrying its own replacement guidance.
 
 ---
 
@@ -411,11 +410,12 @@ os i18n check --locales=zh-CN          # scope to specific locales
 os i18n check --strict --threshold=95  # CI gate: locale parity + minimum coverage
 ```
 
-It compares registered bundles against source metadata and reports missing
-object/field/option/view/action keys per locale. Missing keys in the default
+It compares registered bundles against source metadata and reports missing keys
+per locale across every declared surface: objects (fields, options, views,
+sections, tabs, actions, params), global actions, apps and navigation, dashboards
+and widgets, pages, flow screens, metadata forms. Missing keys in the default
 locale are errors; `--strict` promotes non-default gaps to errors and
-`--show-keys` lists every missing key. `os lint --i18n-strict` folds the same
-gate into linting.
+`--show-keys` lists every missing key. `os lint --i18n-strict` folds it into lint.
 
 ### `os i18n extract --check` — freshness, not coverage
 
@@ -434,10 +434,9 @@ missing file and printing the regenerate command.
 **Use both gates — they answer different questions.** `os i18n check` asks *are
 the strings translated?* (coverage: human work). `extract --check` asks *are the
 generated bundles still what the schema produces?* (freshness: machine output).
-Renaming a label, adding an object, or removing a spec key leaves coverage at
-100% while the bundles quietly go stale — which is exactly how the platform's
-own bundles ended up carrying translations for keys the schema had already
-deleted, plus fields with no entry in any locale.
+Renaming a label or removing a spec key leaves coverage at 100% while the
+bundles go stale — which is how the platform's own bundles ended up carrying
+translations for keys the schema had deleted, plus fields with no entry anywhere.
 
 It runs in the same **merge mode** as a normal extract, so it never asks for
 re-translation: an up-to-date bundle re-extracts byte-identically. Requires
@@ -448,8 +447,8 @@ re-translation: an up-to-date bundle re-extracts byte-identically. Requires
 The spec models coverage results for tooling: `TranslationCoverageResult`
 (totals, `coveragePercent`, per-group `breakdown`) and `TranslationDiffItem` —
 `key` (dot path), `status` (`missing | redundant | stale`), `locale`, optional
-`sourceHash` for stale detection, and AI-enrichment fields (`aiSuggested`,
-`aiConfidence`). Full Zod shape:
+`objectName`, optional `sourceHash` for stale detection, and AI-enrichment
+fields (`aiSuggested`, `aiConfidence`). Full Zod shape:
 `node_modules/@objectstack/spec/src/system/translation.zod.ts` —
 `TranslationCoverageResultSchema`, `TranslationDiffItemSchema`.
 
@@ -498,12 +497,13 @@ registers when no i18n plugin is present):
 - **`getTranslations(locale)`** — full snapshot for a locale
 - **`loadTranslations(locale, data)`** — programmatic load; deep-merges, so multiple
   plugins can each contribute their own `objects.*` slice
-- **`getLocales()`** / **`getDefaultLocale()`** / **`setDefaultLocale()`**
+- **`getLocales()`** / **`setSupportedLocales()`** (narrows `getLocales` to the app's
+  declared `i18n.supportedLocales`) / **`getDefaultLocale()`** / **`setDefaultLocale()`**
 
 The in-memory fallback additionally resolves locale codes
 (exact → case-insensitive → base language `zh-CN` → `zh` → variant `zh` → `zh-CN`).
 
-The contract also declares optional methods — `getCoverage`,
+The contract also declares optional methods — `getFieldLabels`, `getCoverage`,
 `suggestTranslations` — that **no shipped implementation provides**. Treat them
 as extension points for a custom workbench or TMS adapter. (`getAppBundle` /
 `loadAppBundle` were removed along with the `o.*` shape they returned.)
@@ -545,10 +545,12 @@ Scaffold ready-to-edit translation files from your stack config:
 os i18n extract --locales=zh-CN --out=./src/translations
 ```
 
-This writes `<locale>.objects.generated.ts` TypeScript modules (not JSON) — the
-default locale is filled from schema labels, other locales follow `--fill`
-(`empty | default | todo`). Other flags: `--default-locale`, `--filter` (regex
-over object/app names or key paths), `--dry-run`, `--json`.
+This writes `<locale>.objects.generated.ts` TypeScript modules (not JSON), plus
+`<locale>.metadata-forms.generated.ts` unless `--no-metadata-forms` — the default
+locale is filled from schema labels, other locales follow `--fill`
+(`empty | default | todo`). Other flags: `--default-locale`, `--filter` (regex over
+object/app names or key paths), `--no-merge`, `--no-objects-only`,
+`--source-hashes`, `--dry-run`, `--json`.
 
 ### 2. Translate
 
@@ -572,18 +574,17 @@ Commit the translation files, import them into your bundle, and register it via
 
 ## CRM I18n Blueprint
 
-Reference implementation shape:
-
-- Bundle entry: `src/translations/index.ts` (or `crm.translation.ts`)
-- Locale files: `src/translations/{en,zh-CN,ja-JP,es-ES}.ts`
+The shipped `examples/app-crm` is the bundled layout: one
+`src/translations/crm.translation.ts` holding `en` + `zh-CN`. `examples/app-todo`
+is the per-locale layout — `src/translations/{en,zh-CN,ja-JP}.ts` + `index.ts`.
 
 Use this structure for metadata apps:
 
 | Layer | CRM Pattern |
 |:--|:--|
-| Stack config | `i18n` with an explicit locale list; per-locale source files by convention |
-| Translation assembly | One `defineTranslationBundle` call that imports per-locale files |
-| Locale content | Object-scoped translations (`objects.account.fields.*`, `_views`, `_actions`) + global app/messages |
+| Stack config | `i18n` with an explicit locale list; the source layout is a convention |
+| Translation assembly | One `defineTranslationBundle` call — inline locales, or importing per-locale files |
+| Locale content | Object-scoped translations (`objects.crm_account.fields.*`, `_views`, `_actions`) + global app/messages |
 | Naming integrity | Translation object/field keys exactly match metadata machine names |
 
 For new locales, copy one locale file as a baseline, then run `os i18n check`
@@ -595,10 +596,8 @@ before release.
 
 ### ❌ The Retired `o.*` Shape
 
-Everything reads `objects.*`. The `o.*` dialect was removed — it is
-not a "Studio format", not a secondary format, just gone. Files registered in
-that shape resolve to nothing; runtime items in that shape are rejected at
-save time.
+Everything reads `objects.*`. The `o.*` dialect was removed — not a "Studio
+format", not a secondary format, just gone. Both doors reject it, files included.
 
 ```typescript
 // WRONG — in a file bundle AND in a `translation` item
@@ -647,7 +646,7 @@ options: { in_progress: '进行中' }
 
 ### ❌ Ignoring Coverage Reports
 
-Stale translations can cause confusion. Always run `os i18n check` before releases.
+Run `os i18n check` before releases; `extract --check` is what sees staleness.
 
 ---
 

--- a/skills/objectstack-i18n/SKILL.md
+++ b/skills/objectstack-i18n/SKILL.md
@@ -261,7 +261,7 @@ All translatable content for a single object is aggregated under
 | `_views.{view_name}` | `label`, `description`, `emptyState.title` / `emptyState.message` |
 | `_actions.{action_name}` | `label`, `description`, `confirmText`, `successMessage`, `params.{param_name}`, `resultDialog` |
 | `_sections.{section_name}` | Form section `label`, `description` |
-| `_tabs.{tab_name}` | Filter-preset tab `label`, keyed by `ViewTabSchema.name` |
+| `_tabs.{tab_name}` | Filter-preset tab `label` (`ViewTabSchema.name`) |
 
 Top-level groups alongside `objects`: `apps` (label, description, navigation),
 `messages`, `globalActions` (object-less actions), `dashboards`, `pages`, `flows`,
@@ -299,9 +299,9 @@ parse, ship, and resolve to nothing.
 `os validate` / `os lint` / `os compile` check this direction and report it as
 warnings (`translation-target-unknown`, `translation-option-key-unknown`): a key
 naming an object, field, view, action, param, section, app, nav item, dashboard,
-widget, flow or flow-screen field that does not exist is listed alongside the
-names that do. A bundle keyed to something since renamed still parses — the label
-just renders silently in its source locale while every neighbouring one resolves.
+widget or flow screen that does not exist is listed alongside the names that do.
+A bundle keyed to something since renamed still parses — the label just renders
+silently in its source locale while every neighbouring one resolves.
 
 ---
 
@@ -343,9 +343,8 @@ export default defineTranslation({
 Rules that differ from a file bundle:
 
 - **`locale` is required.** A file bundle names its locales as map keys; an item
-  carries its own. The runtime sync falls back to the item *name* when that looks
-  like a BCP-47 tag, then skips the item with an `[i18n] … — skipped` warning
-  naming the row — a server log line the author never sees. Always set `locale`.
+  carries its own. The sync falls back to a BCP-47-looking item *name*, then skips
+  the item with an `[i18n] … — skipped` warning nobody watches.
 - **One locale per item.** Author `zh-CN` and `ja-JP` as two items.
 - Published items are loaded at boot and on every publish (no restart), and
   layer **over** the file bundles — an authored value wins over a shipped one
@@ -358,9 +357,8 @@ Exact Zod shape: `node_modules/@objectstack/spec/src/system/translation.zod.ts` 
 
 A second object-first shape keyed on `o.{object_name}` (with `app`, `nav`,
 `dashboard`, `reports`, `notifications`, `errors`, `_globalOptions`, `_meta`,
-`namespace`, and `_actions.confirmMessage`) was once documented for
-Studio-authored translations. **No resolver ever read it.** Both doors now reject
-it — files as well as items — each key carrying its own replacement guidance.
+`namespace`, `_actions.confirmMessage`) was once documented for Studio authoring.
+**No resolver ever read it**, and both doors now reject it — files included.
 
 ---
 
@@ -411,11 +409,10 @@ os i18n check --strict --threshold=95  # CI gate: locale parity + minimum covera
 ```
 
 It compares registered bundles against source metadata and reports missing keys
-per locale across every declared surface: objects (fields, options, views,
-sections, tabs, actions, params), global actions, apps and navigation, dashboards
-and widgets, pages, flow screens, metadata forms. Missing keys in the default
-locale are errors; `--strict` promotes non-default gaps to errors and
-`--show-keys` lists every missing key. `os lint --i18n-strict` folds it into lint.
+per locale for every surface the extractor walks — objects and their sub-keys,
+global actions, apps, dashboards, pages, flow screens, metadata forms. Gaps in
+the default locale are errors, `--strict` promotes the rest, `--show-keys` lists
+them all; `os lint --i18n-strict` folds the same gate into lint.
 
 ### `os i18n extract --check` — freshness, not coverage
 
@@ -434,9 +431,8 @@ missing file and printing the regenerate command.
 **Use both gates — they answer different questions.** `os i18n check` asks *are
 the strings translated?* (coverage: human work). `extract --check` asks *are the
 generated bundles still what the schema produces?* (freshness: machine output).
-Renaming a label or removing a spec key leaves coverage at 100% while the
-bundles go stale — which is how the platform's own bundles ended up carrying
-translations for keys the schema had deleted, plus fields with no entry anywhere.
+Renaming a label or removing a spec key leaves coverage at 100% while bundles go
+stale — how the platform's own ended up translating keys the schema had deleted.
 
 It runs in the same **merge mode** as a normal extract, so it never asks for
 re-translation: an up-to-date bundle re-extracts byte-identically. Requires
@@ -497,8 +493,7 @@ registers when no i18n plugin is present):
 - **`getTranslations(locale)`** — full snapshot for a locale
 - **`loadTranslations(locale, data)`** — programmatic load; deep-merges, so multiple
   plugins can each contribute their own `objects.*` slice
-- **`getLocales()`** / **`setSupportedLocales()`** (narrows `getLocales` to the app's
-  declared `i18n.supportedLocales`) / **`getDefaultLocale()`** / **`setDefaultLocale()`**
+- **`getLocales()`** / **`setSupportedLocales()`** / **`getDefaultLocale()`** / **`setDefaultLocale()`**
 
 The in-memory fallback additionally resolves locale codes
 (exact → case-insensitive → base language `zh-CN` → `zh` → variant `zh` → `zh-CN`).
@@ -506,7 +501,7 @@ The in-memory fallback additionally resolves locale codes
 The contract also declares optional methods — `getFieldLabels`, `getCoverage`,
 `suggestTranslations` — that **no shipped implementation provides**. Treat them
 as extension points for a custom workbench or TMS adapter. (`getAppBundle` /
-`loadAppBundle` were removed along with the `o.*` shape they returned.)
+`loadAppBundle` went with the `o.*` shape they returned.)
 
 ### Plugin Setup
 
@@ -545,12 +540,11 @@ Scaffold ready-to-edit translation files from your stack config:
 os i18n extract --locales=zh-CN --out=./src/translations
 ```
 
-This writes `<locale>.objects.generated.ts` TypeScript modules (not JSON), plus
-`<locale>.metadata-forms.generated.ts` unless `--no-metadata-forms` — the default
-locale is filled from schema labels, other locales follow `--fill`
-(`empty | default | todo`). Other flags: `--default-locale`, `--filter` (regex over
-object/app names or key paths), `--no-merge`, `--no-objects-only`,
-`--source-hashes`, `--dry-run`, `--json`.
+This writes `<locale>.objects.generated.ts` TypeScript modules (not JSON), plus a
+`<locale>.metadata-forms.generated.ts` companion unless `--no-metadata-forms` —
+the default locale is filled from schema labels, other locales follow `--fill`
+(`empty | default | todo`). `os i18n extract --help` lists the rest: `--filter`,
+`--default-locale`, `--no-merge`, `--source-hashes`, `--dry-run`, `--json`, …
 
 ### 2. Translate
 
@@ -574,9 +568,8 @@ Commit the translation files, import them into your bundle, and register it via
 
 ## CRM I18n Blueprint
 
-The shipped `examples/app-crm` is the bundled layout: one
-`src/translations/crm.translation.ts` holding `en` + `zh-CN`. `examples/app-todo`
-is the per-locale layout — `src/translations/{en,zh-CN,ja-JP}.ts` + `index.ts`.
+`examples/app-crm` ships the bundled layout (one `crm.translation.ts`, `en` +
+`zh-CN`); `examples/app-todo` the per-locale one (`{en,zh-CN,ja-JP}.ts` + `index.ts`).
 
 Use this structure for metadata apps:
 

--- a/skills/objectstack-i18n/evals/README.md
+++ b/skills/objectstack-i18n/evals/README.md
@@ -13,11 +13,11 @@ When implemented, evals will follow this structure:
 ```
 evals/
 ├── bundle-shape/
-│   ├── test-objects-vs-o-keys.md        # runtime `objects.*` vs secondary `o.*` format
+│   ├── test-objects-vs-o-keys.md        # runtime `objects.*`; retired `o.*` is rejected
 │   ├── test-snake-case-keys.md          # object/field keys match metadata machine names
 │   └── test-option-machine-values.md    # lowercase option values, not display labels
 ├── interpolation/
-│   └── test-double-brace-params.md      # {{userName}}, not {userName}; ICU is experimental
+│   └── test-double-brace-params.md      # {{userName}}, not {userName}; no ICU engine
 ├── coverage-workflow/
 │   ├── test-extract-command.md          # os i18n extract --locales/--out flags & TS output
 │   └── test-check-command.md            # os i18n check --strict/--threshold CI gate


### PR DESCRIPTION
Fixes #13815
Part of #13658

Flight ⑧ of the published-skills factual sweep: `skills/objectstack-i18n/**` (3 files, 807 lines at branch point). Every claim was settled against the implementing code plus an executed probe — never against another document. **17 distinct false facts across 20 landing sites; net −8 lines, −2 tokens** (SKILL.md 6337/6338, evals/README.md 410/411 — both shrink, no ceiling touched).

`references/_index.md` is generator-owned and was **not** hand-edited; `check:skill-refs` is green against it.

## Where the truth was read

| Fact class | Implementing code |
|:--|:--|
| bundle / item / config shapes | `packages/spec/src/system/translation.zod.ts` |
| service contract | `packages/spec/src/contracts/i18n-service.ts` |
| shipped adapters | `packages/services/service-i18n/src/{file-i18n-adapter,i18n-service-plugin}.ts` · `packages/core/src/fallbacks/memory-i18n.ts` |
| authored-item sync | `packages/core/src/fallbacks/authored-translation-sync.ts` |
| CLI coverage / extract | `packages/cli/src/commands/i18n/{check,extract}.ts` · `packages/cli/src/utils/i18n-{coverage,extract}.ts` |
| orphan-key lint | `packages/lint/src/validate-translation-references.ts` |
| shipped examples | `examples/app-crm/src/translations/` · `examples/app-todo/src/translations/` |

## Per-item corrections

| # | 落点 | before | after |
|:--|:--|:--|:--|
| 1 | SKILL.md · Object-Level table | "Object-level text (`label` is required)" | "Object-level text (every key optional)" — `label: z.string().optional()`, with a schema comment arguing partial translation is the normal state |
| 2 | SKILL.md · Object-Level table | no `_tabs` row | added `_tabs.{tab_name}` — a live authorable surface (`resolveTabLabel`), extracted and coverage-gated |
| 3 | SKILL.md · Object-Level table | `_actions` holds `label`, `confirmText`, `successMessage`, `params`, `resultDialog` | `description` added — declared on the action translation shape |
| 4 | SKILL.md · Object-Level table | `_sections` holds "Form section / tab `label`" | "Form section `label`" — tabs are their own group, now row 2 above |
| 5 | SKILL.md · "Top-level groups alongside `objects`" | `apps`, `messages`, `globalActions`, `dashboards`, `settings`, `metadataForms`, `settingsCommon` | `pages` and `flows` added — 10 groups on the shape, not 8 |
| 6 | SKILL.md · Core Concepts 1 | same list minus `settingsCommon`, and object content omits tabs | both lists brought to the shape's real membership |
| 7 | SKILL.md · Authoring at Runtime | "skipped by the runtime sync — a silent skip … rather than inferred from the item name" | the sync falls back to a BCP-47-looking item **name**, then skips with an `[i18n] … — skipped` **warning** naming the row. Not silent |
| 8 | SKILL.md · "Retired: the `o.*` dialect" | "rejected at save time with a message naming the group to use instead" | "both doors now reject it — files included". 4 of the 10 keys are told they have **no** home (`reports`, `notifications`, `errors`, `namespace`), so "naming the group to use instead" was false for them |
| 9 | SKILL.md · Pitfall "The Retired `o.*` Shape" | "Files registered in that shape resolve to nothing; runtime items … rejected at save time" | both doors reject: `defineTranslationBundle` **throws** on a file bundle. The file door was closed at the same time as the item door |
| 10 | SKILL.md · `os i18n check` | "reports missing object/field/option/view/action keys" | every surface the extractor walks — 14 source kinds live, 5 were named |
| 11 | SKILL.md · Extract skeletons | "writes `{locale}.objects.generated.ts` … Other flags: `--default-locale`, `--filter`, `--dry-run`, `--json`" | the `{locale}.metadata-forms.generated.ts` companion is written **by default**; four more flags exist (`--no-merge`, `--no-objects-only`, `--metadata-forms`, `--source-hashes`), so the list now points at `--help` instead of claiming to be complete |
| 12 | SKILL.md · "Use both gates" | "Renaming a label, **adding an object**, or removing a spec key leaves coverage at 100%" | adding an object *lowers* coverage — its keys join the expected set. Dropped from the trio |
| 13 | SKILL.md · II18nService methods | `getLocales()` / `getDefaultLocale()` / `setDefaultLocale()` | `setSupportedLocales()` added — on the contract and implemented by **both** shipped adapters |
| 14 | SKILL.md · II18nService optional methods | "`getCoverage`, `suggestTranslations` — no shipped implementation provides" | `getFieldLabels` added — same class exactly: declared optional, probed by both serving surfaces, implemented by no shipped provider |
| 15 | SKILL.md · Diff & Coverage Schemas | `TranslationDiffItem` = `key`, `status`, `locale`, `sourceHash`, AI fields | optional `objectName` added |
| 16 | SKILL.md · orphan-key lint | "object, field, view, action, param, section, app, nav item, dashboard or widget" | flow screens added — the rule walks `flows.{name}.screens.{node}` too |
| 17 | SKILL.md · Authoring Translation Bundles | "mirrors the shipped example apps (`{en,zh-CN}.ts` + `index.ts`)" | that is `examples/app-todo` alone, and it ships three locales |
| 18 | SKILL.md · CRM I18n Blueprint | "Bundle entry: `src/translations/index.ts` … Locale files: `{en,zh-CN,ja-JP,es-ES}.ts`" | `examples/app-crm` has **one** file, `crm.translation.ts`, holding `en` + `zh-CN`. No `index.ts`, no per-locale files, no `ja-JP`/`es-ES` |
| 19 | SKILL.md · CRM table | "per-locale source files by convention" · "imports per-locale files" · `objects.account.fields.*` | the CRM example does none of these; its object is `crm_account` |
| 20 | SKILL.md · Pitfall "Ignoring Coverage Reports" | "Stale translations can cause confusion. Always run `os i18n check`" | coverage cannot see staleness — this document's own `extract --check` section says so. Now points at the gate that can |
| 21 | evals/README.md · rubric | "runtime `objects.*` vs **secondary** `o.*` format" | "retired `o.*` is rejected" — a grader taught the retired dialect is a live secondary format fails correct answers |
| 22 | evals/README.md · rubric | "ICU is **experimental**" | "no ICU engine" — the `messageFormat` knob was removed and nothing evaluates ICU strings |

Rows 4, 6, 19 are the second landing sites of facts 2, 5 and 18; 17 distinct facts, 20 sites, plus 2 rubric rows.

## Executed evidence

Two probe scripts (temporary, removed before commit — this diff is 2 markdown files). Built first: `@objectstack/service-i18n...`, `@objectstack/lint...`, `@objectstack/platform-objects...` (exit 0 each), so every read is against rebuilt `dist`, not stale declarations.

Schema/adapter probe, run from `packages/services/service-i18n`:

```
=== TranslationDataSchema top-level groups ===
["objects","apps","messages","globalActions","dashboards","pages","flows","settings","metadataForms","settingsCommon"]

=== ObjectTranslationDataSchema sub-keys ===
["label","pluralLabel","description","fields","_views","_actions","_sections","_tabs"]

=== object _actions sub-keys ===
["label","description","confirmText","successMessage","params","resultDialog"]

=== is objects.OBJ.label REQUIRED? ===
parse { objects: { task: { pluralLabel } } } (no label) -> success=true

=== retired o.* dialect ===
  item.o: rejected=true :: `o` is the retired object-first dialect … use 'objects.OBJECT_NAME'
  item.reports: rejected=true :: `reports` … reports have no translation group, omit them
  bundle-door o: rejected=true
  defineTranslationBundle({ en: { o: … } }) -> threw

=== interpolation ===
  double: Welcome, Alice!        single: Hi, {userName}!        icu: messages.icu   (key echoed)

=== contract methods on both shipped adapters ===
  setSupportedLocales  file=true   memory=true
  getFieldLabels       file=false  memory=false
  getCoverage          file=false  memory=false
  suggestTranslations  file=false  memory=false
```

CLI probe (`tsx`, `packages/cli`), driving the real walker and coverage detector:

```
=== ExpectedEntry.source kinds the walker emits ===
  action 7 · app 1 · dashboard 1 · field 6 · flow 2 · globalAction 4 ·
  metadataFormField 948 · metadataFormSection 150 · metadataType 54 ·
  navigation 1 · object 3 · option 1 · page 1 · view 1 · widget 1

=== _tabs IS harvested ===
  objects.task._tabs.urgent.label   [source=view]
  flows.onboard.screens.welcome.title   [source=flow]

=== os i18n check reported source kinds ===
  action, app, dashboard, field, globalAction, metadataForm, navigation,
  object, option, page, view, widget      (12 kinds from one small fixture)

=== --strict promotes non-default gaps ===
  lax    errors=0   warnings=783
  strict errors=783 warnings=0
```

The non-vacuity control is satisfied many times over: facts 1, 2, 3, 5, 8, 9, 10, 13, 14 were each decided by a run, not a read.

## Gates — all run at `5d16fd477` (the final commit)

Families derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (exit 0; 14 families, re-derived unchanged on the final commit), plus the skill-specific gates the derivation scores silent because they compute their own population:

| gate | exit |
|:--|:--|
| `check-ci-filter-parity` · `check-cross-package-test-inputs` · `check-shard-attestation` | 0 · 0 · 0 |
| `check-skills-token-ratchet` | **0** — SKILL.md 6337/6338 (−1), evals/README.md 410/411 (−1) |
| `check:doc-formula-expressions` · `check:agent-test-spelling` · `check:corpus-claim-drift` | 0 · 0 · 0 |
| `check:cross-package-test-inputs` · `check:doc-authoring` · `check:pm-governed-merges` | 0 · 0 · 0 |
| `check:role-word` · `check:skill-compatibility` · `check:skill-frame-sync` | 0 · 0 · 0 |
| `check:nul-bytes` · `check:pm-skill-ratchet` · `check:pm-skill-id-lint` · `check:skill-frame-freshness` | 0 · 0 · 0 · 0 |
| `@objectstack/spec check:skill-examples` | **0** — 260 marked blocks across 101 files, population non-empty (this package contributes 4 `os:check` fences) |
| `@objectstack/spec check:skill-refs` · `check:skill-docs` | 0 · 0 |
| `pnpm lint` (repo-wide `eslint . --no-inline-config`) | 0 |
| `check-test-completeness` | **3 — NOT MEASURED.** The gate grades a saved `turbo run test` log and none exists locally; its own text says exit 3 "is not a red, and there is nothing here to fix" |

ESLint was run whole rather than narrowed, and separately measured: both changed files report `File ignored because no matching configuration was supplied` — markdown is outside the linted population entirely (no `files` block in `eslint.config.mjs` names `.md`).

Pure `skills/**` diff, nothing published from any package — `skip-changeset` applies, matching flights ③/④/⑤ which landed the same shape with no changeset.

## Governed surface

Published `skills/**`: this PR stays **draft** and is for the maintainer to merge. `needs:contract-review` is attached to this PR and to card #13815 in the same stroke (批 #12 clause ② CONTENT limb) and is never self-cleared.

_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_