### PR TITLE
chore(ci): slow both dependabot channels from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "02:00"
     open-pull-requests-limit: 10
     commit-message:
@@ -28,8 +27,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "02:00"
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
Fixes #13850

Cadence-only change per maintainer ruling (2026-08-31, quoted verbatim in the issue): 「objectstack 也改为按月」 — sibling of objectstack-ai/objectui#7039's 「interval: weekly → monthly」 ruling, this repo's copy.

## Change

`.github/dependabot.yml`, both update blocks (`npm` and `github-actions`):

- `schedule.interval: "weekly"` → `"monthly"`
- Removed the `schedule.day: "monday"` line in each block — `schedule.day` is only meaningful for a `weekly` interval per GitHub's dependabot.yml configuration docs (confirmed via search of `docs.github.com/.../dependabot-options-reference`, which was not directly fetchable from this container due to an egress block on that domain, but the search summary is unambiguous: "`day` option is only applicable when the interval is set to 'weekly'"). Removing it rather than leaving a now-inert key.
- `schedule.time: "02:00"` kept in both blocks (valid for any interval), along with everything else — groups, `open-pull-requests-limit`, commit-message config.

Diff touches only the two `interval` values and the two `day` lines — nothing else in `.github/dependabot.yml` changed.

## Acceptance

- **YAML parses after the edit** — quoted verbatim:
  ```
  $ python3 -c "
  import yaml, json
  with open('.github/dependabot.yml') as f:
      doc = yaml.safe_load(f)
  print('PARSE OK')
  for u in doc['updates']:
      print(u['package-ecosystem'], u['schedule'])
  "
  PARSE OK
  npm {'interval': 'monthly', 'time': '02:00'}
  github-actions {'interval': 'monthly', 'time': '02:00'}
  ```
- **Changeset gate consulted, not assumed.** `.github/dependabot.yml` is not released-package source, so no changeset is owed. Verdict, replicating this repo's own `changeset-check` job (`.github/workflows/pr-automation.yml`, "Count the changesets this PR adds" step) locally:
  ```
  $ MERGE_BASE=$(git merge-base origin/main HEAD)
  $ ADDED=$(git diff --name-only --diff-filter=A "$MERGE_BASE" HEAD -- '.changeset/*.md' | wc -l)
  $ echo "This PR adds $ADDED changeset(s) (diffed from $MERGE_BASE)."
  This PR adds 0 changeset(s) (diffed from f532630d0246e93b36f869579eb5fa4184d51141).
  ```
  0 added, as expected for a config-only change — the `skip-changeset` label was applied to this PR (additive `POST /repos/objectstack-ai/objectstack/issues/13853/labels`, HTTP 200, confirmed present on read-back) so `changeset-check` does not demand one it isn't owed.
- **Diff scope**: `git diff` shows exactly 2 insertions / 4 deletions across the two blocks — the two `interval` line edits and the two `day` line removals, nothing else.

## Context

Cadence-only change: dependency-update PR volume drops ~4×; GitHub security-alert PRs are not driven by `schedule` and stay immediate. Auto-merge machinery is untouched.