### PR TITLE
fix(spec): drop four dead ghost members from SEARCH_AUTO_EXCLUDED_TYPES and extend the [#13695] pin to every search type vocabulary

### DIFF
--- a/.changeset/search-excluded-ghost-types.md
+++ b/.changeset/search-excluded-ghost-types.md
@@ -1,0 +1,5 @@
+---
+"@objectstack/spec": patch
+---
+
+Drop four dead members — 'object', 'grid', 'geometry', 'encrypted' — from `SEARCH_AUTO_EXCLUDED_TYPES` (`search-fields.ts`). None of the four was ever a member of the `FieldType` enum at any commit, so none could ever match a real field's `type`: the exclusion set's live behaviour is unchanged, and the file's fail-closed tiebreak comment no longer asserts a safety property for names that cannot occur. The `[#13695]` pin in `search-fields.test.ts` is extended to hold every search type vocabulary (`SEARCHABLE_TEXTUAL_TYPES`, `SEARCHABLE_ENUM_TYPES`, `SEARCH_AUTO_EXCLUDED_TYPES`, `SEARCH_VIRTUAL_TYPES`) to `FieldType` membership, so a future ghost entry is a red test instead of a silent no-op.

--- a/packages/spec/src/data/search-fields.test.ts
+++ b/packages/spec/src/data/search-fields.test.ts
@@ -144,25 +144,50 @@ describe('[#4483] $search auto field set — lead orders, never admits', () => {
 // and in opposite directions, so no single relaxation can make this pin vacuous.
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
-// [#13695] `SEARCHABLE_ENUM_TYPES` members must be real `FieldType`s.
+// [#13695] Every search type vocabulary in this file is a subset of `FieldType`.
 //
-// The #6934 disjointness pins above check the vocabularies against EACH OTHER
+// The #6934 disjointness pins below check the vocabularies against EACH OTHER
 // but never against `FieldType` itself, so a member that matches no real field
 // type at all — a pure ghost, distinct from an overlap — passed every existing
-// pin silently: `'status'` sat in this set matching nothing, for as long as it
-// took a docs sweep to notice by hand. This pin closes that probe gap for the
-// enum vocabulary specifically (the one the finding hit); it is deliberately
-// NOT extended to `SEARCH_AUTO_EXCLUDED_TYPES`, which is a separate, larger
-// finding of its own (`object`/`grid`/`geometry`/`encrypted` are ghosts there
-// too) filed out of scope for this fix.
+// pin silently: `'status'` sat in `SEARCHABLE_ENUM_TYPES` matching nothing for
+// as long as it took a docs sweep to notice by hand, and the same probe run
+// against the other sets found four more in `SEARCH_AUTO_EXCLUDED_TYPES`
+// (#13716: 'object', 'grid', 'geometry', 'encrypted' — never `FieldType`
+// members at any commit, so the fail-closed tiebreak comment was asserting a
+// safety property for names that cannot occur). This pin now holds ALL of the
+// file's type vocabularies to the enum: an exclusion or allowance spelled with
+// a name `FieldType` does not contain governs nothing.
+// (`SEARCH_AUTO_EXCLUDED_FIELDS` is deliberately absent — its members are
+// field NAMES, not types.)
 // ---------------------------------------------------------------------------
-describe('[#13695] SEARCHABLE_ENUM_TYPES ⊆ FieldType', () => {
+describe('[#13695] search type vocabularies ⊆ FieldType', () => {
   const validTypes: ReadonlySet<string> = new Set(FieldType.options);
+  const vocabularies: ReadonlyArray<[string, ReadonlySet<string>]> = [
+    ['SEARCHABLE_TEXTUAL_TYPES', SEARCHABLE_TEXTUAL_TYPES],
+    ['SEARCHABLE_ENUM_TYPES', SEARCHABLE_ENUM_TYPES],
+    ['SEARCH_AUTO_EXCLUDED_TYPES', SEARCH_AUTO_EXCLUDED_TYPES],
+    ['SEARCH_VIRTUAL_TYPES', SEARCH_VIRTUAL_TYPES],
+  ];
 
-  it('every member is a real FieldType — no ghost vocabulary entries', () => {
-    for (const t of SEARCHABLE_ENUM_TYPES) {
-      expect(validTypes.has(t), `'${t}' is in SEARCHABLE_ENUM_TYPES but not a FieldType member`).toBe(true);
+  it.each(vocabularies)('%s has no ghost members', (name, set) => {
+    const ghosts = [...set].filter((t) => !validTypes.has(t)).sort();
+    expect(ghosts, `${name} names types that are not FieldType members`).toEqual([]);
+  });
+
+  it('CONTROL — the subset assertions are not vacuous', () => {
+    // A broken `FieldType` import (empty `options`) or an accidentally emptied
+    // vocabulary would green every subset check above while pinning nothing.
+    expect(validTypes.size).toBeGreaterThan(0);
+    for (const [name, set] of vocabularies) {
+      expect(set.size, `${name} is unexpectedly empty`).toBeGreaterThan(0);
     }
+    // Positive control — one known-real member per vocabulary, so the pin is
+    // measuring membership, not an accident of empty intersections.
+    expect(validTypes.has('text')).toBe(true);
+    expect(SEARCHABLE_TEXTUAL_TYPES.has('text')).toBe(true);
+    expect(SEARCHABLE_ENUM_TYPES.has('select')).toBe(true);
+    expect(SEARCH_AUTO_EXCLUDED_TYPES.has('secret')).toBe(true);
+    expect(SEARCH_VIRTUAL_TYPES.has('formula')).toBe(true);
   });
 });
 

--- a/packages/spec/src/data/search-fields.ts
+++ b/packages/spec/src/data/search-fields.ts
@@ -45,9 +45,14 @@ export const SEARCH_AUTO_EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   'id', '_id', 'created', 'modified', 'created_at', 'updated_at',
   'created_by', 'updated_by', 'owner_id', 'organization_id', 'space', 'company_id',
 ]);
+// [#13716] 'object', 'grid', 'geometry' and 'encrypted' were dropped from this
+// set: none was a `FieldType` member at ANY commit (imported vocabulary, never
+// renamed spellings — 'location', 'secret' and 'json' were already in both the
+// enum and this set the day the set landed), so each could only ever match
+// nothing. The [#13695] pin now holds every member to `FieldType`.
 export const SEARCH_AUTO_EXCLUDED_TYPES: ReadonlySet<string> = new Set([
-  'json', 'object', 'grid', 'image', 'file', 'avatar', 'vector', 'location',
-  'geometry', 'secret', 'password', 'encrypted', 'boolean', 'lookup', 'master_detail',
+  'json', 'image', 'file', 'avatar', 'vector', 'location',
+  'secret', 'password', 'boolean', 'lookup', 'master_detail',
 ]);
 /**
  * [#6674] Field types with NO STORED COLUMN — the value is computed on read, so
@@ -117,8 +122,10 @@ function autoDefaultFields(fields: Record<string, SearchFieldMeta>, displayField
     // `SEARCH_AUTO_EXCLUDED_TYPES` is disjoint from both positive lists, so
     // every type it names already falls through the `return` below as `false`
     // — identically to a type in none of the three sets (`number`, `date`, …).
-    // Measured over the full 56-type domain (`FieldType` ∪ all three
-    // vocabularies), deleting this line moves not one resolution. So it is NOT
+    // Measured over the full domain of `FieldType` ∪ all three vocabularies
+    // (56 types when the guard landed; the union IS `FieldType` since #13716
+    // dropped the last ghost members), deleting this line moves not one
+    // resolution. So it is NOT
     // load-bearing: adding a type to `SEARCHABLE_TEXTUAL_TYPES` does not also
     // require keeping it out of this set for the auto-default to reject it.
     //
@@ -129,8 +136,8 @@ function autoDefaultFields(fields: Record<string, SearchFieldMeta>, displayField
     // it the positive list wins and the type enters the auto-default AND, one
     // layer up, the #4254 ingress allow-list — so `$searchFields=<that field>`
     // flips from refused to ACCEPTED, the same widening #4483 closed for `id`.
-    // This set names `secret`, `password`, `encrypted` and `vector`: failing
-    // open there means a `$contains` scan over a masked or heavy column.
+    // This set names `secret`, `password` and `vector`: failing open there
+    // means a `$contains` scan over a masked or heavy column.
     //
     // The disjointness is not left to coincidence. `search-fields.test.ts` pins
     // all three vocabularies pairwise disjoint AND pins both resolution


### PR DESCRIPTION
Fixes #13716

## What

`SEARCH_AUTO_EXCLUDED_TYPES` (`packages/spec/src/data/search-fields.ts`) declared four members — `'object'`, `'grid'`, `'geometry'`, `'encrypted'` — that are not members of the 49-value `FieldType` enum, so none could ever match a real field's `type`. Per the card's premise-first mandate, each member was judged **dead vocabulary vs stale spelling** from git history before anything was touched. Verdict: **all four are dead vocabulary — deleted**; no member is a stale spelling of a real type, so the exclusion set's live behaviour is unchanged. The `[#13695]` pin is extended to hold every search type vocabulary in the file to `FieldType` membership.

## Per-member history verdicts (measured, not read)

The set was born as `EXCLUDED_TYPES` in objectql commit `aaa859b40` (2026-06-21, ADR-0061 P1+P2, `$search` end-to-end) and moved verbatim to spec in `af2a0958c` (2026-07-31, #4254). All four ghosts are present in the birth commit; the repository history is complete for this question (the clone was unshallowed before measuring; `--all` sweeps every branch).

| member | ever a `FieldType` member? | rename candidate? | verdict |
|---|---|---|---|
| `'geometry'` | **Never** — zero commits touch the string in either historical enum file (`packages/spec/src/zod/meta/field.zod.ts`, `packages/spec/src/data/field.zod.ts`) across all branches | `'location'` entered the enum 2026-01-20 (`686442183`) — five months **before** the list existed — and the birth commit already excludes `'location'` **alongside** `'geometry'`. Nothing was renamed; both names co-existed in the list from day one | dead |
| `'encrypted'` | **Never** — zero commits, same sweep | `'secret'` entered the enum 2026-05-31 (`6514f8df1`), **before** the list; the birth commit already excludes `'secret'` (and `'password'`) alongside `'encrypted'` | dead |
| `'object'` | **Never** — the only historical hit in the enum file (`07a4e26e6`) is a summary-config key-alias map value (`child: 'object'`), not an enum member | the real embedded-object type `'composite'` entered the enum 2026-05-27 (`482eb67cc`), before the list; no rename event exists | dead |
| `'grid'` | **Never** — the only historical hit (`a2496a62c`) is the `inlineEdit` form-factor union (`boolean \| 'grid' \| 'form'`), not an enum member | no sibling rename; `'json'` (the storage shape a grid/subtable would take) was already in both enum and list at birth | dead |

The decisive shape, common to all four: at the moment the list was created, the canonical modern types (`'location'`, `'secret'`, `'json'`) were **already both in the enum and in this exclusion list**, sitting next to the ghosts. A rename that left a stale spelling behind would show the old name being *replaced* in the enum and the new name arriving *later* in the list — neither ever happened. The four names read as imported vocabulary from outside this repo's type system, and no commit ever made them types here.

Because the members never matched anything, deleting them moves no resolution: `autoDefaultFields` uses the set membership-only (`.has(t)`), and the sole external consumer (`packages/objectql/src/search-filter.ts`) is a pass-through re-export.

## Comment repair (in-scope per the card)

The fail-closed tiebreak comment in `autoDefaultFields` named `'encrypted'` as one of the semantically heavy members ("secret, password, encrypted and vector") — asserting a safety property for a name that cannot occur, which is the card's own point. It now names `secret`, `password` and `vector`. The "56-type domain" measurement note is annotated: the union of `FieldType` and the three vocabularies **is** `FieldType` since this cleanup (the extended pin makes that a checked fact).

## Pin extension ([#13695] → all four vocabularies)

`search-fields.test.ts`'s `[#13695]` block now asserts `SEARCHABLE_TEXTUAL_TYPES`, `SEARCHABLE_ENUM_TYPES`, `SEARCH_AUTO_EXCLUDED_TYPES` and `SEARCH_VIRTUAL_TYPES` are each subsets of `FieldType.options` (collecting **all** ghosts per set, not first-fail), plus a vacuity control (non-empty enum, non-empty vocabularies, one known-real member per set). `SEARCH_AUTO_EXCLUDED_FIELDS` is deliberately absent — its members are field names, not types.

**Ablation (reverse verification), from the committed fix:** re-introducing the four ghost members into the set literal (mutation proven on disk by anchored literal-line grep counts 0→1/1 and a non-empty `git diff --stat`; no build leg exists on either side — the test imports `./search-fields` by relative source path, so vitest reads the mutation directly) turned **exactly** the extended `SEARCH_AUTO_EXCLUDED_TYPES` pin red — `AssertionError: SEARCH_AUTO_EXCLUDED_TYPES names types that are not FieldType members: expected [ 'encrypted', 'geometry', 'grid', 'object' ] to deeply equal []` — with the other 28 tests green (the ghosts are still *rejected* by the auto-default, so the #6934 direction pins rightly stay green). Restoration proven by `git checkout HEAD -- PATH` (the mutated file's absolute path) + empty `git diff HEAD` + `git hash-object` equal to the `HEAD` blob (`5616ff7…` both sides).

## Clause-② declaration

**No** — all four members judged dead and deleted; the exclusion set's observable behaviour is unchanged (no member could match any field), no spelling was corrected, no accept/reject behaviour moves. Per the claim comment's split, this is the plain draft-PR path, no `needs:contract-review`.

## Verification

Run at commit `08062e6ce` (the PR head):

- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/data/search-fields.test.ts` — `Test Files 1 passed (1)`, `Tests 29 passed (29)`; all five new `[#13695]` tests listed by the verbose reporter.
- Ablation as above (red exactly where predicted, restore proven).
- `pnpm --filter @objectstack/spec test` — `Test Files 445 passed (445)`, `Tests 11934 passed (11934)`; verify-lock line: `VERDICT command-exit 0`.
- `pnpm --filter @objectstack/spec typecheck` — clean; includes `check:test-typecheck: OK — @objectstack/spec's test layer compiles under packages/spec/tsconfig.test.json` (the program that actually contains the edited test file — the build tsconfig excludes `**/*.test.ts` by design).
- `pnpm --filter @objectstack/spec check:generated` — `All 14 generated artifacts are up to date.` (api-surface included; no export was added or removed — only members of an exported set value changed).
- `node scripts/pm/dispatch-gates.mjs` (no paths passed; derivation stderr pinned to this tree at `08062e6ce`) — 42 derived families + the 6 convention-triggered test-file families all run locally, exit codes captured redirect-first (never through a pipe): all green, with two exceptions that are the gates' own NOT MEASURED shapes, not reds — `scripts/check-test-completeness.mjs` (exit 3: "pass a saved turbo run test log — or, running the family locally, record this gate as NOT MEASURED"; CI owns it) and the live `scripts/pm/check-half-states.mjs` census (exit 3: GitHub-route refusal from this container, per its own text; the `pnpm check:pm-half-states` self-test spelling passes its 1826 cases). The workspace closure was built first (`turbo run build --filter='./packages/*' --filter='./packages/*/*'` — 70/70 successful) exactly as lint.yml does, which un-gated `check:type-check-debt --re-measure`, `check:type-check-coverage`, `check:dual-build-cjs-loads`, `check-dev-prereqs` and `check:doc-formula-expressions` — all green.
- `pnpm lint` (`eslint . --no-inline-config`, the full CI sweep, not a narrowed run) — exit 0.
- `node scripts/check-nul-bytes.mjs` — OK (7602 text files, no raw control bytes).

Out-of-scope finding (reported to the PM, not filed from this seat, per dispatch): `packages/cli/src/commands/generate.ts`'s migration-codegen `switch (fType)` carries its own ghost field-type vocabulary — `'slug'`, `'ip_address'`, `'encrypted'`, `'integer'` are cases, none a `FieldType` member — the same defect class as this card, one package over.

Session: https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2

_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_