### PR TITLE
test(driver-sql): budget the #13056 live-MySQL orphan-shadow tests

### DIFF
--- a/packages/drivers/driver-sql/src/sql-driver-13056-orphan-shadow-column-cleanup.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-13056-orphan-shadow-column-cleanup.test.ts
@@ -545,7 +545,13 @@ declareDialectCell(MYSQL_CELL, 'orphan shadow column cleanup (#13056)', (cell) =
       const V = 'k'.repeat(900);
       await knex(TABLE).insert({ id: 'a', kept: V });
       await expect(knex(TABLE).insert({ id: 'b', kept: V })).rejects.toThrow(/duplicate/i);
-    });
+      // #13688: 3 full new SqlDriver() -> initObjects() -> disconnect() cycles
+      // against live MySQL, plus 4 information_schema reads and 2 inserts — the
+      // inherited vitest default (5000ms) is not a chosen budget for that, and
+      // reddens unrelated PRs when the runner is merely a bit slow. Sized like
+      // this file's siblings (60_000 is 3 of the 4 sibling budgets); not an
+      // assertion that this test is normally anywhere near that slow.
+    }, 60_000);
 
     /**
      * The differ must go quiet afterwards for the right reason: with the column
@@ -570,6 +576,9 @@ declareDialectCell(MYSQL_CELL, 'orphan shadow column cleanup (#13056)', (cell) =
       expect(again.filter((d) => d.kind === 'unmapped_column')).toEqual([]);
       const after = await catalog(TABLE);
       expect(after.columns).not.toContain(hashShadowColumnFor(`uniq_${TABLE}_retired`));
-    });
+      // #13688: 2 full new SqlDriver() -> initObjects() -> disconnect() cycles
+      // against live MySQL, plus detect/apply/detect and a catalog read — same
+      // inherited-default defect as the sibling test above; budgeted the same.
+    }, 60_000);
   });
 });


### PR DESCRIPTION
Fixes #13688

## The defect

`Temporal Conformance (live PG + MySQL)` reddens **unrelated PRs** — it surfaced on
#13685, whose entire diff is `packages/plugins/plugin-auth/**` + a changeset + one
docs page, touching no driver, no SQL, no schema-sync path.

The two `it(...)` blocks in
`sql-driver-13056-orphan-shadow-column-cleanup.test.ts` that read the live MySQL
catalog each drive 2-3 full `new SqlDriver(...)` -> `initObjects(...)` ->
`disconnect()` cycles against the live container, with no explicit timeout, so they
inherited vitest's 5000ms default. Both observed failures are **timeouts, not
assertion failures**, and the service-container logs show no MySQL error — the DDL
that ran succeeded. This is not "raise a timeout to make a slow test pass": the
5000ms was never a chosen budget for 2-3 live connect/DDL/disconnect cycles plus
several `information_schema` reads — it's what a test gets by default when nobody
sets one. Four sibling files in this same package already carry explicit per-test
budgets (`60_000` / `120_000` / `40_000` / `60_000`); this file shipped with #13056's
fix without one.

**The cost of this defect is not local** — it reddens other people's PRs on a
package they never touched, so every timeout here is a repo-wide throughput tax
(ejected merge-queue attempts, wasted CI minutes), not a local annoyance. See #13767,
the automated queue-flake anchor for this exact file, ejected twice in 24h.

## The fix

Both `it(...)` blocks get an explicit `60_000` budget — in line with 3 of the 4
sibling budgets in this package — with a one-line comment naming why (N live
round trips against MySQL), so the next reader does not delete it as noise.

`git diff` on `packages/drivers/driver-sql/src/*.ts` excluding this one test file is
empty — no production code, no assertion, and no control changed.

## A2.1 — the acceptance control (actual cost against live MySQL)

**NOT MEASURED.** No live MySQL/PG container is reachable in this environment (the
Docker daemon is not running here — `docker info` fails with `no such file or
directory` on the socket; no `OS_TEST_MYSQL_URL`/`OS_TEST_POSTGRES_URL` set; no
`mysql`/service listening on 3306/5432). Leaning on the structural argument instead:
timeout (not an assertion failure), no MySQL error in the logs, and four sibling
files in the same package already carrying comparable budgets for a comparable
number of live round trips.

## A2.2 — sweep for the same shape elsewhere

Confirmed: **only these two `it(...)` blocks in this file** lacked a budget (both
now fixed). A package-wide sweep for the same shape (any `it(...)` nested in a
`declareDialectCell(...)` callback, still on vitest's inherited 5000ms default) found
**9 more files, 37 more `it(...)` blocks** with the identical gap. Per the dispatch
order's STOP condition 3 ("a package-wide re-budget is a different, larger
decision"), the fix here stays scoped to this one file; the sweep result is filed
as #13902 for a deliberate decision rather than folded into this PR.

## A2.3 — no global `testTimeout`

Confirmed by reading `packages/drivers/driver-sql/vitest.config.ts`: no
`testTimeout` key anywhere in the `test` block. The two `it(...)` blocks really were
falling through to vitest's own default, not a repo-set global.

## A2.4 — anchors re-located by quoted source

The card cites `sql-driver-13056-orphan-shadow-column-cleanup.test.ts:499`. Re-found
both `it(...)` blocks by their quoted titles rather than trusting the line number: the
first ("drops the orphaned generated column, and keeps the one still carrying a
constraint") is still at line 499 — **no drift**. The second ("converges — a second
detect finds neither the index nor an orphan column") is at line 555.

## Tests

- `pnpm --filter @objectstack/driver-sql typecheck` — PASS (exit 0), via
  `scripts/pm/os-verify-lock.sh`.
- `pnpm --filter @objectstack/driver-sql exec vitest run --maxWorkers=2` — PASS:
  147 passed | 9 skipped test files (156), 2252 passed | 132 skipped tests (2384).
  The target file alone (`--reporter=verbose`, single-file run): 12 passed | 1
  skipped — the whole live-MySQL `describe` block collapses to ONE named-skip
  test ("is provisioned — set OS_TEST_MYSQL_URL to run this cell"), so the two
  edited `it(...)` blocks did not individually execute here. All non-live cells
  run against embedded SQLite and execute fully. The MySQL/PG cells this PR
  touches **cannot run here** — no live MySQL/PG container in this environment
  (see A2.1), so `declareDialectCell` reports them as a named SKIP rather than a
  silent pass (see the file's own header comment on `OS_TEST_MYSQL_URL` /
  `OS_EXPECT_LIVE_DIALECT_MATRIX`). They will run for real in the `Temporal
  Conformance (live PG + MySQL)` CI job this PR exists to stop reddening.
- Local gate family (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`,
  re-derived at HEAD `fcc9ce8034` after `git fetch origin main`): **26 relevant
  families** (22 path-matched + 4 more from the "edits a test file" convention
  trigger) — **23 PASS**, **3 NOT MEASURED**:
  - `check:dual-build-cjs-loads`, `check:type-check-debt` — need the FULL
    workspace built (`pnpm build` / `turbo run build` across all 78 packages),
    which is CI's own "Build Core" / debt-ledger scope, not warranted locally
    for a one-file test-only diff (driver-sql's own dependency closure was
    built and its `tsc --noEmit` passes clean).
  - `check:test-completeness` — by its own design, exits `PREREQUISITE NOT MET`
    without a saved `turbo run test` log; CI tees that log and passes it, this
    branch is unreachable there.
  None of the 23 that ran flagged anything in this diff. The dispatch-gates
  derivation itself carried a STALE-TREE warning (its own defining scripts had
  moved on `origin/main` by the time of the final re-run, in a repo with several
  other agents landing PRs concurrently) — re-running after `git fetch origin
  main` reproduced the identical 22-family path-matched list, so nothing was
  missed by the staleness.

## No ablation

No ablation is meaningful here — there is no behaviour to neuter. The change is a
test-timing budget, not logic; there is nothing for a mutation to disprove that a
rebuild-and-rerun would show.

## Changeset

`skip-changeset` — this PR's entire diff is one test file (a timeout budget +
explanatory comments); it publishes nothing from any package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_
