### PR TITLE
fix(service-job): leader-elect interval schedules on multi-replica deployments

### DIFF
--- a/.changeset/job-interval-leader-election.md
+++ b/.changeset/job-interval-leader-election.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/service-job": patch
+---
+
+fix(service-job): leader-elect `interval` schedules on multi-replica deployments (#13686)
+
+`DbJobAdapter` — the adapter a production assembly upgrades to — routed a
+`type: 'cron'` schedule to `CronJobAdapter`, which takes a per-fire cluster lock
+(`job:<name>`, `waitMs: 0`) before running the handler, and routed a
+`type: 'interval'` schedule to `IntervalJobAdapter`, which has no lock at all.
+So on a 3-replica cluster every replica armed its own `setInterval` and every
+tick executed three times. #2219 declared the capability as leader-electing
+scheduled **cron/interval** jobs across the cluster; only the cron half enforced
+it.
+
+Reported from a live 3-replica deployment (traefik → 3 app replicas, shared
+postgres + redis, `OS_CLUSTER_DRIVER=redis`) with the fence counter
+`os:fence:job:ts:*` measured flat for 100 s while eight 60 s interval jobs ran —
+where the same jobs on cron expressions increment it once per replica per tick.
+Duplicate *business effects* were mostly masked by per-handler de-duplication
+and staggered container start times; the writes de-duplication did not cover
+were not — one SLA escalation delivered its notifications twice to each of three
+recipients, six inserts inside a 54 ms window.
+
+**What changed.** `DbJobAdapter.schedule()` now delegates `interval` to the same
+`cron` adapter it already delegates `cron` to — `CronJobAdapter` has always
+handled `type: 'interval'` itself and fires it through the same leader-elected
+`runScheduled()` — so an interval fire acquires the `job:` lock and the replicas
+that lose it skip that tick. Both delegated types are still registered on the
+inner adapter through the new `IntervalJobAdapter.register()`, which stores a
+registration **without arming a timer**, so `trigger()`, `replay()`,
+`getExecutions()` and `listJobs()` are unchanged and one process never holds an
+elected timer beside an unelected one.
+
+**Unchanged on purpose.** Cron routing and cron behaviour; manual `trigger()`,
+which is deliberately not leader-elected (an operator is asking *this* node to
+run the job now); `once` schedules; the `sys_job` / `sys_job_run` writes. With no
+cluster driver configured the lock is always granted, so single-node scheduling
+is byte-for-byte what it was. With no cron adapter assembled at all
+(`enableCron: false`, or its construction threw) an interval job still fires on
+the inner timer exactly as before — unelected, and now saying so in a warning
+rather than surfacing only as duplicate rows.
+
+No new configuration key: #2219 declared this as the behaviour, and putting it
+behind a switch would re-open the same declared-≠-enforced gap on the switch.

--- a/packages/services/service-job/src/db-job-adapter.interval-leader.test.ts
+++ b/packages/services/service-job/src/db-job-adapter.interval-leader.test.ts
@@ -1,0 +1,267 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #13686 — an `interval` schedule registered on `DbJobAdapter` must reach the
+ * SAME leader-elected fire path a `cron` schedule reaches.
+ *
+ * ⚠️ What this file can and cannot measure. The defect is a concurrency defect
+ * across OS processes and this harness is one process, so nothing here is a
+ * cluster test. What IS pinned deterministically: the ROUTING (which adapter
+ * received the registration, and that exactly one timer exists per job in one
+ * process), and the LOCK SEMANTICS at the adapter seam (two adapter instances
+ * contending for one fire against one shared lock ⇒ one execution, the loser
+ * SKIPPING rather than throwing, waiting or retrying). Whether a redis fence
+ * behaves that way across three real replicas is measurable only on a real
+ * multi-replica deployment.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { IJobService, JobSchedule } from '@objectstack/spec/contracts';
+import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { DbJobAdapter } from './db-job-adapter.js';
+import { CronJobAdapter } from './cron-job-adapter.js';
+
+const TICK = 60_000;
+const IV: JobSchedule = { type: 'interval', intervalMs: TICK };
+
+function makeFakeEngine() {
+  const tables = new Map<string, any[]>();
+  return {
+    tables,
+    rows(table: string) { return tables.get(table) ?? []; },
+    async find(table: string, opts: any = {}) {
+      const t = tables.get(table) ?? [];
+      const matched = opts.where
+        ? t.filter((r) => Object.entries(opts.where).every(([k, v]) => {
+            // REFUSE what this double does not implement, rather than reading a
+            // combinator as if it were a column name.
+            if (k.startsWith('$')) throw new Error(`fake engine: unsupported operator ${k}`);
+            return r[k] === v;
+          }))
+        : [...t];
+      // The caller's bound, applied AFTER the filter and by PRESENCE: a `limit`
+      // of zero is a bound of zero rows, not an absent bound.
+      return typeof opts?.limit === 'number' ? matched.slice(0, opts.limit) : matched;
+    },
+    async insert(table: string, data: any) {
+      const t = tables.get(table) ?? [];
+      t.push({ ...data });
+      tables.set(table, t);
+      return { id: data.id };
+    },
+    async update(table: string, data: any, options?: Record<string, unknown>) {
+      // Hold this double to ObjectQL.update's own dispatch rule, so it cannot be
+      // looser than the engine `DbJobAdapter` really writes through.
+      assertEngineUpdateDispatch(data, options);
+      const r = (tables.get(table) ?? []).find((x) => x.id === data.id);
+      if (r) Object.assign(r, data);
+      return r;
+    },
+  };
+}
+
+/**
+ * A cron adapter that RECORDS what it was handed and owns no clock of its own.
+ * It is the routing probe: with it in place, anything that still fires came
+ * from a timer `DbJobAdapter` armed somewhere else.
+ */
+function recordingCron() {
+  const calls: Array<{ name: string; schedule: JobSchedule }> = [];
+  const svc: IJobService & { calls: typeof calls } = {
+    calls,
+    async schedule(name: string, schedule: JobSchedule) { calls.push({ name, schedule }); },
+    async cancel() {},
+    async trigger() {},
+    async getExecutions() { return []; },
+    async listJobs() { return []; },
+  };
+  return svc;
+}
+
+/** One lock shared by every simulated replica — the redis fence's stand-in. */
+function sharedLock() {
+  const held = new Set<string>();
+  const acquire = vi.fn(async (key: string) => {
+    if (held.has(key)) return null; // another node is the leader for this fire
+    held.add(key);
+    return { release: vi.fn(async () => { held.delete(key); }) };
+  });
+  return { lock: { acquire }, acquire, held };
+}
+
+const denies = () => ({ acquire: vi.fn(async () => null) });
+
+const built: Array<{ destroy(): Promise<void> }> = [];
+function track<T extends { destroy(): Promise<void> }>(a: T): T { built.push(a); return a; }
+
+afterEach(async () => {
+  while (built.length) await built.pop()!.destroy();
+  vi.useRealTimers();
+});
+
+describe('DbJobAdapter — interval schedules are leader-elected (#13686)', () => {
+  it('routes an interval registration to the cron (leader-electing) adapter, and arms no timer of its own', async () => {
+    vi.useFakeTimers();
+    const engine = makeFakeEngine();
+    const cron = recordingCron();
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, cron }));
+
+    await db.schedule('heartbeat', IV, handler);
+
+    // The routing itself — asserted at the seam, not against the wall clock.
+    expect(cron.calls).toEqual([{ name: 'heartbeat', schedule: IV }]);
+
+    // …and NOTHING else armed a timer. The probe owns no clock, so ten ticks
+    // must produce zero runs; a second, unelected `setInterval` inside `inner`
+    // would show up here as ten.
+    await vi.advanceTimersByTimeAsync(TICK * 10);
+    expect(handler).not.toHaveBeenCalled();
+
+    // The registration is still reachable through the adapter's own surface.
+    expect(await db.listJobs()).toEqual(['heartbeat']);
+  });
+
+  it('one process holds exactly ONE timer for a delegated interval job: a tick runs the handler once', async () => {
+    vi.useFakeTimers();
+    const engine = makeFakeEngine();
+    const acquire = vi.fn(async () => ({ release: vi.fn(async () => {}) }));
+    const cron = new CronJobAdapter({ cluster: { lock: { acquire } } });
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, cron }));
+
+    await db.schedule('sla_escalation', IV, handler);
+
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(handler).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(handler).toHaveBeenCalledTimes(2);
+    // One lock acquire per fire — the fence counter the field report watched
+    // stand still for 100 seconds.
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect(acquire).toHaveBeenCalledWith('job:sla_escalation', { ttlMs: 60000, waitMs: 0 });
+  });
+
+  it('two simulated replicas contending for ONE fire: exactly one executes, the loser SKIPS', async () => {
+    // One engine and one lock, two adapter stacks — the shared postgres + redis
+    // of a 3-replica deployment, minus the process boundary this harness has no
+    // way to cross.
+    const engine = makeFakeEngine();
+    const fence = sharedLock();
+    const handler = vi.fn(async () => {});
+
+    const replica = () => {
+      const cron = new CronJobAdapter({ cluster: { lock: fence.lock } });
+      return { cron, db: track(new DbJobAdapter({ engine, cron })) };
+    };
+    const a = replica();
+    const b = replica();
+    await a.db.schedule('sla_escalation', IV, handler);
+    await b.db.schedule('sla_escalation', IV, handler);
+
+    // Both replicas reach the same fire. Started together on purpose: `b` calls
+    // acquire while `a` still holds the lease.
+    const fireA = (a.cron as any).runScheduled('sla_escalation');
+    const fireB = (b.cron as any).runScheduled('sla_escalation');
+    // The loser SKIPS: it resolves, it does not throw and it does not retry.
+    await expect(Promise.all([fireA, fireB])).resolves.toHaveLength(2);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(fence.acquire).toHaveBeenCalledTimes(2);
+    // waitMs:0 is the "skip", spelled structurally — a waiting acquire would let
+    // the loser run the same tick a moment later.
+    expect(fence.acquire).toHaveBeenCalledWith('job:sla_escalation', { ttlMs: 60000, waitMs: 0 });
+
+    // The durable record agrees: one tick, ONE run row, run_count +1. Unrouted,
+    // this shared engine took one row per replica — the shape the field report
+    // caught as six notification inserts inside 54 ms.
+    const runs = engine.rows('sys_job_run').filter((r) => r.job_name === 'sla_escalation');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('success');
+    expect(engine.rows('sys_job')[0].run_count).toBe(1);
+  });
+
+  it('single-replica, no cluster driver: the interval job still fires (the regression that would be worse than the defect)', async () => {
+    vi.useFakeTimers();
+    const engine = makeFakeEngine();
+    const cron = new CronJobAdapter(); // no `cluster` — nothing to elect against
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, cron }));
+
+    await db.schedule('nightly_sweep', IV, handler);
+
+    await vi.advanceTimersByTimeAsync(TICK * 3);
+    expect(handler).toHaveBeenCalledTimes(3);
+  });
+
+  it('no cron adapter assembled: the interval job still fires on the inner timer, and says it is unelected', async () => {
+    vi.useFakeTimers();
+    const engine = makeFakeEngine();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, logger }));
+
+    await db.schedule('nightly_sweep', IV, handler);
+
+    await vi.advanceTimersByTimeAsync(TICK * 2);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(
+      logger.warn.mock.calls.some((c) => String(c[0]).includes('NO leader election')),
+      'a cron-less assembly cannot elect anything — that has to be said, not inferred from duplicate rows',
+    ).toBe(true);
+  });
+
+  it('manual trigger() still runs on THIS node while another replica holds the lock', async () => {
+    const engine = makeFakeEngine();
+    const cron = new CronJobAdapter({ cluster: { lock: denies() } });
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, cron }));
+
+    await db.schedule('sla_escalation', IV, handler);
+    // Reaches `inner`, which still holds the registration: a delegated job that
+    // vanished from `inner` would throw `Job "…" not found` right here.
+    await db.trigger('sla_escalation');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('replay() and getExecutions() still work for a delegated interval job', async () => {
+    const engine = makeFakeEngine();
+    const cron = new CronJobAdapter({ cluster: { lock: denies() } });
+    const handler = vi.fn(async () => {});
+    const db = track(new DbJobAdapter({ engine, cron }));
+
+    await db.schedule('sla_escalation', IV, handler);
+    await db.replay('sla_escalation');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((await db.getExecutions('sla_escalation')).map((e) => e.status)).toEqual(['success']);
+    expect(engine.rows('sys_job_run').some((r) => r.trigger === 'replay')).toBe(true);
+  });
+
+  it('still upserts the sys_job row for a delegated interval schedule', async () => {
+    const engine = makeFakeEngine();
+    const db = track(new DbJobAdapter({ engine, cron: recordingCron() }));
+
+    await db.schedule('heartbeat', IV, async () => {});
+
+    expect(engine.rows('sys_job')[0]).toMatchObject({
+      name: 'heartbeat',
+      schedule_type: 'interval',
+      schedule_expression: String(TICK),
+      active: true,
+    });
+  });
+
+  it('DECLARED CONTROL — cron routing is unchanged: delegated to the cron adapter, still registered for trigger()', async () => {
+    const engine = makeFakeEngine();
+    const cron = recordingCron();
+    const db = track(new DbJobAdapter({ engine, cron }));
+    const schedule: JobSchedule = { type: 'cron', expression: '0 0 30 2 *' };
+
+    await db.schedule('nightly_report', schedule, async () => {});
+
+    expect(cron.calls).toEqual([{ name: 'nightly_report', schedule }]);
+    expect(await db.listJobs()).toEqual(['nightly_report']);
+  });
+});

--- a/packages/services/service-job/src/db-job-adapter.interval-leader.test.ts
+++ b/packages/services/service-job/src/db-job-adapter.interval-leader.test.ts
@@ -142,10 +142,52 @@ describe('DbJobAdapter — interval schedules are leader-elected (#13686)', () =
     expect(acquire).toHaveBeenCalledWith('job:sla_escalation', { ttlMs: 60000, waitMs: 0 });
   });
 
-  it('two simulated replicas contending for ONE fire: exactly one executes, the loser SKIPS', async () => {
+  it('two simulated replicas, ONE tick: exactly one execution and ONE run row', async () => {
     // One engine and one lock, two adapter stacks — the shared postgres + redis
     // of a 3-replica deployment, minus the process boundary this harness has no
     // way to cross.
+    vi.useFakeTimers();
+    const engine = makeFakeEngine();
+    const fence = sharedLock();
+    // The winner HOLDS its lease until this opens, so the loser's acquire is
+    // guaranteed to land while the lock is held rather than after it is
+    // released — which is what makes the count below a fact about the lock and
+    // not about how many microtasks the timer flush happened to run.
+    let open!: () => void;
+    const lease = new Promise<void>((resolve) => { open = resolve; });
+    const handler = vi.fn(async () => { await lease; });
+
+    const replica = () => {
+      const cron = new CronJobAdapter({ cluster: { lock: fence.lock } });
+      return { cron, db: track(new DbJobAdapter({ engine, cron })) };
+    };
+    const a = replica();
+    const b = replica();
+    await a.db.schedule('sla_escalation', IV, handler);
+    await b.db.schedule('sla_escalation', IV, handler);
+
+    // One tick of the wall clock reaches BOTH replicas.
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    expect(handler, 'one tick must execute the job once across the cluster, not once per replica').toHaveBeenCalledTimes(1);
+    expect(fence.acquire).toHaveBeenCalledTimes(2);
+    // waitMs:0 is the "skip", spelled structurally — a waiting acquire would let
+    // the loser run the same tick a moment later.
+    expect(fence.acquire).toHaveBeenCalledWith('job:sla_escalation', { ttlMs: 60000, waitMs: 0 });
+
+    open();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The durable record agrees: one tick, ONE run row, run_count +1. Unrouted,
+    // this shared engine took one row per replica — the shape the field report
+    // caught as six notification inserts inside 54 ms.
+    const runs = engine.rows('sys_job_run').filter((r) => r.job_name === 'sla_escalation');
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe('success');
+    expect(engine.rows('sys_job')[0].run_count).toBe(1);
+  });
+
+  it('the replica that loses the lock SKIPS: it resolves, it does not throw and it does not retry', async () => {
     const engine = makeFakeEngine();
     const fence = sharedLock();
     const handler = vi.fn(async () => {});
@@ -159,26 +201,15 @@ describe('DbJobAdapter — interval schedules are leader-elected (#13686)', () =
     await a.db.schedule('sla_escalation', IV, handler);
     await b.db.schedule('sla_escalation', IV, handler);
 
-    // Both replicas reach the same fire. Started together on purpose: `b` calls
-    // acquire while `a` still holds the lease.
+    // Driven at the fire seam so both promises are observable: `b` calls acquire
+    // while `a` still holds the lease.
     const fireA = (a.cron as any).runScheduled('sla_escalation');
     const fireB = (b.cron as any).runScheduled('sla_escalation');
-    // The loser SKIPS: it resolves, it does not throw and it does not retry.
     await expect(Promise.all([fireA, fireB])).resolves.toHaveLength(2);
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(fence.acquire).toHaveBeenCalledTimes(2);
-    // waitMs:0 is the "skip", spelled structurally — a waiting acquire would let
-    // the loser run the same tick a moment later.
-    expect(fence.acquire).toHaveBeenCalledWith('job:sla_escalation', { ttlMs: 60000, waitMs: 0 });
-
-    // The durable record agrees: one tick, ONE run row, run_count +1. Unrouted,
-    // this shared engine took one row per replica — the shape the field report
-    // caught as six notification inserts inside 54 ms.
-    const runs = engine.rows('sys_job_run').filter((r) => r.job_name === 'sla_escalation');
-    expect(runs).toHaveLength(1);
-    expect(runs[0].status).toBe('success');
-    expect(engine.rows('sys_job')[0].run_count).toBe(1);
+    expect(fence.held.has('job:sla_escalation'), 'the winner must release its lease when the fire ends').toBe(false);
   });
 
   it('single-replica, no cluster driver: the interval job still fires (the regression that would be worse than the defect)', async () => {

--- a/packages/services/service-job/src/db-job-adapter.ts
+++ b/packages/services/service-job/src/db-job-adapter.ts
@@ -73,9 +73,14 @@ function uid(prefix: string): string {
 
 /**
  * DbJobAdapter — IJobService that persists job registry and execution
- * history to ObjectQL while delegating timer mechanics to
- * `IntervalJobAdapter`. Cron is delegated to `CronJobAdapter` callers
- * supplied via {@link withCron}.
+ * history to ObjectQL while delegating timer mechanics downwards.
+ *
+ * Every SCHEDULED fire goes to the `cron` adapter callers supply — both
+ * `cron` and `interval` schedules — because that adapter is the one that
+ * leader-elects each fire against the cluster lock (#13686); `inner`
+ * (`IntervalJobAdapter`) keeps the registration for `trigger()` / `replay()`
+ * and owns the timer only for the schedule types nothing else can run. See
+ * {@link DbJobAdapter.schedule} for the routing and its no-cron fallbacks.
  *
  * Persisted side effects:
  *   - `schedule(name, …)` upserts a `sys_job` row (active=true)
@@ -114,6 +119,37 @@ export class DbJobAdapter implements IJobService {
 
   // ── IJobService ──────────────────────────────────────────────────
 
+  /**
+   * Register `name`, and decide WHICH adapter owns its scheduled fire — which
+   * is the same thing as deciding whether that fire is leader-elected (#13686).
+   *
+   * `CronJobAdapter` is the only adapter here that holds a cluster lock, and it
+   * takes that lock in `runScheduled()` — the single path BOTH its cron limb and
+   * its interval limb fire through. `IntervalJobAdapter` has no lock at all. So on
+   * a multi-replica deployment the routing below *is* the leader election: every
+   * schedule type this adapter hands to `inner` runs on every replica at once.
+   * `interval` used to be one of them, which made #2219's declared "leader-elect
+   * scheduled cron/interval jobs across the cluster" true of only its cron half —
+   * measured in the field as one tick executing N times, its duplicate writes
+   * visible wherever per-handler business de-duplication did not happen to cover
+   * them (three recipients, six notification rows, 54 ms apart).
+   *
+   * Both delegated types are ALSO registered in `inner` — via
+   * {@link IntervalJobAdapter.register}, which stores without arming a timer, so
+   * one process never ends up holding an elected timer and an unelected one for
+   * the same job. That registration is what keeps `trigger()`, `replay()`,
+   * `getExecutions()` and `listJobs()` reading from one place regardless of who
+   * owns the clock, and it is deliberately NOT leader-elected: a manual trigger is
+   * an operator asking THIS node to run the job now.
+   *
+   * **Without a `cron` adapter** (`enableCron: false`, or its construction threw)
+   * the two types part company, because their fallbacks are not the same choice: a
+   * `cron` schedule cannot run here at all, so it is warned about and left to
+   * manual triggering, whereas an `interval` schedule still fires on `inner`'s own
+   * timer exactly as it did before this routing existed. Unelected, so it is warned
+   * about too — but silently dropping a job an assembly CAN run is not an
+   * improvement on running it more often than intended.
+   */
   async schedule(name: string, schedule: JobSchedule, handler: JobHandler, options?: JobScheduleOptions): Promise<void> {
     const wrapped = this.wrap(name, handler, 'schedule', options);
     // The wrapper OWNS `retryPolicy`/`timeout` from here down — see withoutPolicy.
@@ -125,8 +161,17 @@ export class DbJobAdapter implements IJobService {
         `DbJobAdapter: cron schedule registered for "${name}" without CronJobAdapter — job will only run via manual trigger`,
       );
       // Still record in inner so trigger() works
-      await this.inner.schedule(name, schedule, wrapped, downstream);
+      await this.inner.register(name, schedule, wrapped, downstream);
+    } else if (schedule.type === 'interval' && this.cron) {
+      // The leader-elected path — same one cron takes, for the same reason.
+      await this.cron.schedule(name, schedule, wrapped, downstream);
+      await this.inner.register(name, schedule, wrapped, downstream);
     } else {
+      if (schedule.type === 'interval') this.logger?.warn?.(
+        `DbJobAdapter: interval schedule registered for "${name}" without CronJobAdapter — it will run, ` +
+          'but with NO leader election, so on a multi-replica deployment every replica runs it on every ' +
+          'tick. Enable the cron adapter (JobServicePlugin enableCron) to have one replica win each fire.',
+      );
       await this.inner.schedule(name, schedule, wrapped, downstream);
     }
 

--- a/packages/services/service-job/src/interval-job-adapter.ts
+++ b/packages/services/service-job/src/interval-job-adapter.ts
@@ -62,10 +62,7 @@ export class IntervalJobAdapter implements IJobService {
   }
 
   async schedule(name: string, schedule: JobSchedule, handler: JobHandler, options?: JobScheduleOptions): Promise<void> {
-    // Cancel any existing job with the same name
-    await this.cancel(name);
-
-    const record: JobRecord = { name, schedule, handler, options, executions: [] };
+    const record = await this.store(name, schedule, handler, options);
 
     if (schedule.type === 'interval' && schedule.intervalMs) {
       record.timerId = setInterval(async () => {
@@ -89,8 +86,50 @@ export class IntervalJobAdapter implements IJobService {
         'this adapter has no cron engine. Use the db/cron adapter, or an interval schedule.',
       );
     }
+  }
 
+  /**
+   * Register a job WITHOUT arming a timer — the registry half of
+   * {@link IntervalJobAdapter.schedule}, for an owner that runs the SCHEDULED
+   * fire somewhere else.
+   *
+   * `DbJobAdapter` keeps every registration here so `trigger()`, `replay()`,
+   * `getExecutions()` and `listJobs()` have one place to look, while the
+   * scheduled fire is owned by whichever adapter can leader-elect it. Calling
+   * `schedule()` for that would arm a SECOND, unelected timer beside the
+   * elected one and run the job twice per tick inside ONE process — strictly
+   * worse than the across-replicas duplication the delegation exists to fix
+   * (#13686).
+   *
+   * So the "store it, do not run it" half says so out loud, instead of being
+   * inferred from a schedule shape this adapter happens not to arm: that
+   * inference is what made `cron` safe to hand down here, and it silently
+   * stops holding the moment the delegated type is one this adapter CAN run.
+   */
+  async register(
+    name: string,
+    schedule: JobSchedule,
+    handler: JobHandler,
+    options?: JobScheduleOptions,
+  ): Promise<void> {
+    await this.store(name, schedule, handler, options);
+  }
+
+  /**
+   * Replace any registration under `name` and return the fresh record — with
+   * no timer on it. Arming, when it happens at all, is `schedule()`'s half.
+   */
+  private async store(
+    name: string,
+    schedule: JobSchedule,
+    handler: JobHandler,
+    options?: JobScheduleOptions,
+  ): Promise<JobRecord> {
+    // Cancel any existing job with the same name
+    await this.cancel(name);
+    const record: JobRecord = { name, schedule, handler, options, executions: [] };
     this.jobs.set(name, record);
+    return record;
   }
 
   /**

--- a/scripts/engine-double-contract.pinned.json
+++ b/scripts/engine-double-contract.pinned.json
@@ -3102,6 +3102,11 @@
       "pinned": 1
     },
     {
+      "file": "packages/services/service-job/src/db-job-adapter.interval-leader.test.ts",
+      "verb": "update",
+      "pinned": 1
+    },
+    {
       "file": "packages/services/service-job/src/db-job-adapter.timeout.test.ts",
       "verb": "update",
       "pinned": 1


### PR DESCRIPTION
Closes #13686

`DbJobAdapter` — the adapter a production assembly upgrades to — routed `type: 'cron'` to `CronJobAdapter`, which takes a per-fire cluster lock, and `type: 'interval'` to `IntervalJobAdapter`, which has no lock anywhere in the file. So on a multi-replica deployment every replica armed its own `setInterval` and every tick executed N times. #2219 declared the capability as leader-electing scheduled **cron/interval** jobs across the cluster; only the cron half enforced it.

## The reporter's premise, re-verified against the tree first

The card proposed delegating interval to `this.cron` because `CronJobAdapter` "already supports interval and holds the lock". That is the load-bearing claim, and a one-line delegation onto an adapter that only locks its *cron* branch would have fixed nothing silently. Measured on `origin/main` before writing any code:

| claim | reading on the tree |
|:--|:--|
| `CronJobAdapter` schedules an interval registration itself | `cron-job-adapter.ts` `schedule()`: `else if (schedule.type === 'interval' && schedule.intervalMs)` arms `setInterval(() => { void this.runScheduled(name); }, …)` |
| that branch reaches the locked fire path | it calls the **same** `runScheduled()` the cron branch's croner callback calls — one method, `lock.acquire('job:' + name, { ttlMs, waitMs: 0 })`, peers return early |
| `DbJobAdapter` sends interval to the unlocked adapter | `schedule()`: `if (schedule.type === 'cron')` to `this.cron`, **every other type** to `this.inner`, which is an `IntervalJobAdapter` |
| that adapter has no election | zero `lock` / `leader` / `cluster` / `fence` hits in `interval-job-adapter.ts`; control: the same grep on `cron-job-adapter.ts` resolves, so the query works |

Premise holds. `cron-job-adapter.leader.test.ts` also already pins the lock semantics using `{ type: 'interval' }` registrations, so the locked interval limb was covered — just unreachable from the adapter production assembles.

## Their live evidence (3-replica cluster, traefik → 3 app replicas, shared postgres + redis, `OS_CLUSTER_DRIVER=redis`)

1. **The fence counter is frozen.** With all 8 jobs configured as 60 s intervals, `os:fence:job:ts:*` did not move for 100 s; under cron it increments by N (the replica count) per tick.
2. **A caught race.** One SLA escalation's *action* was de-duplicated by app-level business logic and fired once, but its **notifications** landed **2× for each of 3 recipients — 6 inserts inside a 54 ms window**. A second "no eligible target" notification also doubled: both replicas sent before the dedup marker was persisted.
3. **Business effects are not doubled only by luck.** Per-handler business de-duplication plus staggered container start times mask the duplicate execution; the writes de-duplication does not cover (notifications) double.

Single-replica is clean for both schedule types — the defect is specific to multi-replica interval.

## What changed

- **`db-job-adapter.ts` — the routing.** `interval` now goes to `this.cron` when one is assembled, inheriting the existing `job:` lock rather than growing a second locking implementation.
- **`interval-job-adapter.ts` — a new `register()`.** Delegated types are still registered on `inner`, but through a seam that stores a registration **without arming a timer**. This is the part the one-line version of the fix gets wrong: `inner.schedule()` on an interval registration arms a second, *unelected* `setInterval` beside the elected one, so one process would run the job twice per tick — strictly worse than the across-replicas duplication being fixed. `cron` was safe to hand down here only because `IntervalJobAdapter` happens not to arm a schedule type it cannot run; that inference stops holding the moment the delegated type is one it *can* run, so it is now said out loud. The cron branch was moved onto the same seam in the same edit — no behaviour change (the inner adapter is constructed without a logger, so its cron warning was already unreachable), but the routing now expresses its intent instead of relying on a coincidence.
- **A warning on the cron-less limb.** With no cron adapter assembled (`enableCron: false`, or its construction threw) an interval job still fires on `inner`'s timer exactly as before — unelected. Silently dropping a job an assembly *can* run would not be an improvement, so it runs and says what is missing. Functional degradation, `warn` per the AGENTS.md level rule.

⛔ **No new configuration key**, per the card: #2219 declared this as the behaviour, and a switch would re-open the same declared-≠-enforced gap on the switch.

**Public surface note for review:** this adds one method, `IntervalJobAdapter.register()`, to an exported class. Additive, no accept-set widening, no spec/authorable surface. The path-derived tier limb does not fire (`node scripts/pm/dispatch-gates.mjs --tier` on the actual diff: "no path-derived mandate"), and the change alters no contract accept/reject behaviour — but the added method is declared here rather than left for a reviewer to find.

## What is pinned — `packages/services/service-job/src/db-job-adapter.interval-leader.test.ts`, 10 cases

⚠️ **This is a concurrency defect across OS processes and the harness is single-process. Nothing below is a cluster test.** What is pinned deterministically:

- **Routing** — asserted at the adapter seam, not against the wall clock: with a recording cron adapter that owns no clock, the interval registration arrives at it, and ten ticks produce **zero** runs (a second unelected timer in `inner` would show as ten). The registration is still visible through `listJobs()`.
- **One timer per process** — with a real `CronJobAdapter` and a granting lock, one tick runs the handler once and acquires `job:sla_escalation` with `{ ttlMs: 60000, waitMs: 0 }` exactly once; two ticks, twice.
- **Lock semantics, two simulated replicas** — one fake engine and one shared lock, two adapter stacks, one `advanceTimersByTime`. The winner holds its lease on a gate so the loser's acquire lands while the lock is held (making the count a fact about the lock, not about how many microtasks the timer flush ran). Result: **one execution, one `sys_job_run` row, `run_count` +1** for one tick.
- **The loser skips** — driven at the fire seam so both promises are observable: both resolve, neither throws, the handler ran once, and the winner released its lease. `waitMs: 0` is the skip spelled structurally — a waiting acquire would let the loser run the same tick a moment later.
- **Single-replica / no cluster driver still fires** — the pin that stops this repair from being worse than the defect.
- **No cron adapter assembled** — the job still fires on the inner timer, and the warning says it is unelected.
- **Consumer surface unchanged** — manual `trigger()` still runs on this node while a peer holds the lock (and would throw `Job not found` if the delegated registration had left `inner`); `replay()` + `getExecutions()` still work; the `sys_job` row is still upserted with `schedule_type: 'interval'`.
- **Cron unchanged** — a declared control case, plus the package's pre-existing cron suites.

## Ablation

Direction predicted first: reverting **only** the interval routing branch should redden exactly the four pins that are about the elected path and leave the other six — and all 84 pre-existing package tests — green.

Committed the repair, then mutated the working tree and **confirmed the mutation on disk before measuring**: anchor marker count 1 → 0; blob hash `f5e5c48d…` (HEAD) → `40bce718…` (worktree); `git diff HEAD --stat` non-empty (4 deletions). Restore leg proven **by state**, not by an exit code: `git diff HEAD` empty, worktree blob hash back to `f5e5c48d…` byte-identical to the HEAD blob, marker count back to 1, `git status` clean. The mutation script carried a `trap` restoring an absolute path, and no rebuild is involved — the suite imports the adapter by a relative specifier inside its own package, so it reads `src/`, which the observed reddening itself demonstrates (a suite reading `dist/` would have stayed green).

Measured, 4 failed / 90 passed of 94:

```
× routes an interval registration to the cron (leader-electing) adapter…
    → expected [] to deeply equal [ { name: 'heartbeat', …(1) } ]
× one process holds exactly ONE timer for a delegated interval job…
    → expected "vi.fn()" to be called 2 times, but got 0 times      (the lock is never acquired)
× two simulated replicas, ONE tick: exactly one execution and ONE run row
    → one tick must execute the job once across the cluster, not once per replica:
      expected "vi.fn()" to be called 1 times, but got 2 times      ← the defect itself
× the replica that loses the lock SKIPS…
    → expected "vi.fn()" to be called 1 times, but got 0 times
```

Prediction matched, including the second case's shape: reverting the routing leaves the handler firing once per tick (on `inner`'s timer), so that pin reddens at the **lock** assertion rather than at the count — which is precisely why a count-only test would not have caught this defect.

⚠️ **Declared controls, green in both directions and therefore NOT ablation evidence:** the six remaining new cases (single-replica-no-cluster, no-cron-adapter, manual `trigger()`, `replay()`/`getExecutions()`, the `sys_job` upsert, and the cron-routing control) plus **all 84 pre-existing tests in the package**. That last one is the point rather than a footnote: nothing already in this package could notice the defect, which is how it shipped.

## Measured / NOT MEASURED

- **Measured here:** the routing, the lock semantics at the adapter seam, the single-replica and no-cron fallbacks, and that the consumer surface is unchanged — all in one process, with a fake lock.
- **NOT MEASURED, and only the reporter's deployment can measure it:** that a *real* redis fence behaves this way across three real replicas — i.e. that `os:fence:job:ts:*` now increments once per tick under interval schedules as it already does under cron, and that the duplicate notification inserts stop. A single-process simulation is not a cluster verification and is not presented as one. **@baozhoutao** — the confirmation this needs is one run of your existing 60 s-interval configuration against a build carrying this branch, watching that counter and the notification table.
- **NOT MEASURED locally, deferred to CI (prerequisite bound, exit 3 — not a pass and not a red):** `check:dual-build-cjs-loads` and `check:type-check-debt` both require the full workspace build; `check:test-completeness` requires a saved `turbo run test` log and instructs that a local run record it as NOT MEASURED. `service-job` appears in neither the DEBT nor the TEST_DEBT ledger, and the structural half `check:type-check-coverage` is green, so nothing in this diff can move a ledgered count.

## Verification (all at `7e3aee5a`, the head of this branch, tree clean)

- `pnpm --filter @objectstack/service-job exec vitest run --maxWorkers=2` → **9 files, 93 tests, 0 failed** (84 pre-existing + 9 new at that point; 10 new after the contention pin was split, 94 total).
- `pnpm --filter @objectstack/service-job run typecheck` → exit 0. `--listFiles` confirms the program really contains **9** `src/*.test.ts` files including the new one, so "typecheck clean" is a statement about the new test file and not a vacuous one.
- `pnpm --filter '@objectstack/service-job^...' build` → exit 0 (dependency closure, built before any judgement).
- Gate families re-derived from the **actual** diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (39 runnable): all green except the three prerequisite-bound ones above. Three fired on the new test double and were repaired rather than baselined — `check:where-matcher` (the double now refuses an operator key instead of reading it as a column), `check:objectql-double-limit` (the caller's bound applied after the filter, by presence), `check:engine-double-contract` (`update()` opens with `assertEngineUpdateDispatch`, and the new pinned coverage was recorded with `--write`, a ledger *growth*).
- `pnpm lint` (repo-wide `eslint . --no-inline-config`) → exit 0. Not narrowed.
- `node scripts/check-nul-bytes.mjs` → exit 0; the changed files also self-scanned clean for raw control bytes.

Every exit code above was captured before any pipe.

## Out of scope

`type: 'once'` schedules take the same unlocked limb and duplicate the same way on a multi-replica cluster. Filed as #13918 rather than fixed here — it is not what #2219 declared, the reporter's cluster cannot confirm it, and a one-shot's crash semantics under a lease is a decision rather than a mechanical extension. out of scope: #13918.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_