### PR TITLE
fix(metadata-protocol): serve runtime-authored view containers to org/environment-scoped reads

### DIFF
--- a/.changeset/view-container-runtime-org-environment-scope-closure.md
+++ b/.changeset/view-container-runtime-org-environment-scope-closure.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): serve a runtime-authored aggregated view container to org-scoped and environment-scoped `getMetaItems` reads (#13407)
+
+A `defineView`-shaped container authored **live in the app** (`PUT /api/v1/meta/view/`)
+was stored `active` and never reached `getViewsByObject` / `GET /meta/view?object=` —
+the third occurrence of one defect, after #7163 and #7736.
+
+**#7163/#7736 scope-boundary, named:** #7736's `hydrateExpandedViewItems` registry
+hydration is reached only for an unscoped (`environmentId === undefined`) kernel writing
+an env-wide (`organizationId` unset) row — its own pin never exercised anything else.
+Both `applyRegistryWriteThrough` (`environmentId !== undefined` → no write-through) and
+`hydrateOverlayIntoRegistry` (any `organizationId` set → refused, ADR-0005 per-org
+isolation) gate the SAME registry-mutating mechanism off for the exact case this card
+reports: "a signed-in user with an **active org**" on "a live **multi-node EE
+deployment**". Both gates are correct and untouched by this fix — the SchemaRegistry
+they guard is shared by every org/environment a kernel serves.
+
+**What changed:** `getMetaItems` now also expands a container it reads **inline, into
+that request's own response only** — never into the shared registry — so the response is
+correct regardless of org/environment scope, without touching either isolation gate.
+Object-name derivation (`hydrateExpandedViewItems`'s fallback chain) now also reads the
+container's own top-level `object` field first (`ViewSchema.object`, previously never
+consulted), before falling back to `list.data.object → form.data.object → name`.
+
+The container-enumeration drop in `getMetaItems` is untouched: the raw container is still
+never listed, only its expanded ViewItems are now also present — restoring, for the
+org/environment-scoped case, the same invariant #7736 already established for the
+unscoped/env-wide one.
+
+**Out of scope, filed separately:** `getViewsByObject()` (`metadata-manager.ts`) reads a
+different backing store and is not exercised by the card's own repro or pin; the artifact
+loader (`packages/metadata/src/plugin.ts`) carries the identical object-derivation gap.
+
+<!-- adr-0087: not-required (no-migration-prescription) no metadata key, spec symbol, or stored value is renamed/retired/converted — this widens what a READ (`getMetaItems`) returns for data already stored exactly as authored, not any declared metadata surface `objectstack migrate meta` would touch. -->

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -6512,6 +6512,41 @@ export class ObjectStackProtocolImplementation implements
                     );
                 });
 
+                // [#13407] Expand any aggregated `defineView` container this
+                // READ just merged in, INLINE into this response's own `items`
+                // — never into the SchemaRegistry. This is what actually closes
+                // the card: {@link hydrateExpandedViewItems} below is
+                // registry-mutating and is therefore gated off for exactly the
+                // rows the card's own repro used (an org-scoped write, on any
+                // kernel; ANY write on a real environment-scoped kernel) — see
+                // that method's "#13407 scope boundary" note for why widening
+                // those gates was rejected rather than attempted. This pass
+                // has no such gate to worry about: `overlays` is already this
+                // request's own correctly org/environment-scoped read (the
+                // `queryByOrg` merge above), so expanding it into the RETURNED
+                // list — and only the returned list — cannot leak one
+                // org/environment's container into another's.
+                //
+                // Upserted by name (not appended) so this stays idempotent
+                // against the registry-hydration path below: on an unscoped,
+                // env-wide kernel that path may have ALREADY registered the
+                // same expansion (from this or an earlier write's write-
+                // through), and re-deriving here from the row this call just
+                // read is a byte-identical, never-stale restatement of the
+                // same items — not a duplicate.
+                if (isView) {
+                    const byName = new Map<string, unknown>();
+                    for (const it of items as any[]) {
+                        if (it && typeof it === 'object' && typeof it.name === 'string') byName.set(it.name, it);
+                    }
+                    for (const { data, packageId: recPkg } of overlays) {
+                        for (const vi of this.expandRuntimeViewContainer(request.type, data, { packageId: recPkg })) {
+                            byName.set(vi.name as string, vi);
+                        }
+                    }
+                    items = Array.from(byName.values());
+                }
+
                 // Only hydrate the global registry for unscoped (control-plane)
                 // calls — scoped project entries must not leak process-wide.
                 // #4521 — this loop is no longer the ONLY way an overlay reaches
@@ -12871,10 +12906,74 @@ export class ObjectStackProtocolImplementation implements
     }
 
     /**
-     * [#7736] Expand an aggregated `defineView` container that arrived through
-     * the RUNTIME door into the same independent ViewItems the two SOURCE
-     * registrars produce — at the one hydration choke point all three runtime
-     * callers already share.
+     * [#7736, #13407] Expand an aggregated `defineView` container that arrived
+     * through the RUNTIME door into the same independent, fully-enriched
+     * ViewItems the two SOURCE registrars produce — object binding, artifact-
+     * protection merge and package provenance all applied, but nothing
+     * REGISTERED. Returns `[]` (never throws) for a non-view type, a body that
+     * is not a container, or a container with no derivable object binding —
+     * exactly the "no expansion" outcomes the two callers below already
+     * decide on independently.
+     *
+     * Pure and side-effect-free on purpose: it is shared by two callers with
+     * DIFFERENT scope rules for what may be registered where —
+     * {@link hydrateExpandedViewItems} (registry-mutating, org/environment-
+     * gated) and `getMetaItems`' inline per-request expansion (registry-free,
+     * ungated) — see the #13407 note on {@link hydrateExpandedViewItems} for
+     * why the registry path could not simply be widened instead.
+     *
+     * ## Object-name derivation (#13407 fix)
+     *
+     * The container's OWN top-level `object` field — `ViewSchema.object`,
+     * documented there as "how a stack-level `views: [...]` entry says which
+     * object its views belong to; read by `getViewsByObject()` /
+     * `GET /meta/view?object=`" — is the authorial, explicit signal and is
+     * consulted FIRST. Before #13407 this walked only `list.data.object` →
+     * `form.data.object` → the row's own name (mirroring `plugin.ts`) and
+     * never read `container.object` at all, so a container that set the
+     * top-level field but not `list.data.object` (or whose save `name` is not
+     * the object it binds — the two are the same value only by convention)
+     * expanded under the WRONG key or not at all. The three-deep fallback is
+     * kept, unchanged, for every container written before this field was
+     * consulted here.
+     */
+    private expandRuntimeViewContainer(
+        type: string,
+        data: unknown,
+        options: { packageId?: string | null },
+    ): Record<string, unknown>[] {
+        if ((PLURAL_TO_SINGULAR[type] ?? type) !== 'view') return [];
+        if (!isAggregatedViewContainer(data)) return [];
+        const container = data as Record<string, any>;
+        const viewObject =
+            (typeof container.object === 'string' && container.object ? container.object : undefined)
+            ?? container?.list?.data?.object
+            ?? container?.form?.data?.object
+            ?? (typeof container.name === 'string' ? container.name : undefined);
+        if (!viewObject) return [];
+        const out: Record<string, unknown>[] = [];
+        for (const vi of expandViewContainer(viewObject, container)) {
+            // Carry the container's package provenance onto each expanded item
+            // so the package-disable filter and ADR-0048 artifact scoping judge
+            // them by the same owner the container has.
+            const item: Record<string, unknown> = { ...(vi as any) };
+            if (container._packageId !== undefined && item._packageId === undefined) {
+                item._packageId = container._packageId;
+            }
+            const viArtifact = this.lookupArtifactItem(
+                type,
+                vi.name,
+                (item._packageId as string | undefined) ?? options.packageId ?? undefined,
+            );
+            out.push(mergeArtifactProtection(item, viArtifact) as Record<string, unknown>);
+        }
+        return out;
+    }
+
+    /**
+     * [#7736] Register an aggregated `defineView` container's expansion
+     * ({@link expandRuntimeViewContainer}) into the SchemaRegistry — at the
+     * one hydration choke point all three runtime callers already share.
      *
      * "Object has-many View" (ADR-0017 §2, §3.2) makes container ingestion
      * DUAL-READ: register the container under the bare `<object>` key for
@@ -12894,27 +12993,41 @@ export class ObjectStackProtocolImplementation implements
      * items that WOULD match the switcher, and both object-bound exits answered
      * zero.
      *
-     * Here rather than at either read exit deliberately. There are two
-     * independent object-bound readers — the REST route reads through
-     * `getMetaItems`, while `getViewsByObject()` reads `MetadataManager.list`
-     * — so expanding at one of them fixes the card's literal repro and leaves
-     * its sibling exit answering empty. This function is the ONE place all
-     * three runtime hydration callers (boot `loadMetaFromDb`, read-side
-     * `getMetaItems`, write-through `applyRegistryWriteThrough`) already
-     * funnel through, so one expansion serves every reader, survives a restart,
-     * and keeps read-your-writes — the "single, universally-applied location"
-     * #7163 asked for after the same defect was fixed one seam further in.
-     *
      * The canonical-shape filter in `getMetaItems` is deliberately left alone:
      * its invariant ("a container's expanded items are also present") is what
      * was false here, and this restores it rather than loosening the filter —
      * which would surface the legacy wrapper shape to every list consumer and
      * still show the switcher nothing, since a container carries no `viewKind`.
      *
-     * Object-name derivation mirrors `plugin.ts` (`list.data.object` →
-     * `form.data.object`), falling back to the row's own name — for a container
-     * the metadata door's save name IS the object. No derivable object means no
-     * expansion, exactly as the artifact loader already decides.
+     * ## [#13407] This function's OWN scope boundary — the reason it is not
+     * ## the whole fix
+     *
+     * This is registry-MUTATING, and both its callers gate it off exactly
+     * where {@link hydrateOverlayIntoRegistry}'s own comments say why:
+     * write-through (`applyRegistryWriteThrough`) never calls it when
+     * `this.environmentId !== undefined` (a real per-environment kernel —
+     * `assembleMetadataProtocol`'s own comment: "per-project (cloud) kernels
+     * source metadata from the control plane"), and `hydrateOverlayIntoRegistry`
+     * itself refuses ANY org-scoped row before ever reaching this function
+     * ("[#6602] a per-org overlay is served on demand, never grafted into the
+     * registry every org in this process shares") — REGARDLESS of
+     * `environmentId`. Both gates are deliberate isolation boundaries (ADR-0005
+     * per-org isolation; the registry is shared by every org/request a given
+     * kernel serves) and #13407 does not touch either one.
+     *
+     * That is precisely why #7736's fix — this function, reached only through
+     * the registry-hydration callers — never helped the card's own repro ("a
+     * signed-in user with an ACTIVE ORG" on "a live multi-node EE deployment"):
+     * an org-scoped write NEVER reaches this function, on ANY kernel, container
+     * shape or object-derivation notwithstanding. #13407's actual fix is
+     * `getMetaItems`' separate, registry-free call to
+     * {@link expandRuntimeViewContainer} (below, in the overlay-merge section)
+     * — safe for org/environment isolation because it operates only on rows
+     * `getMetaItems` already read for THIS request's own scope, and never
+     * writes them anywhere shared. This function keeps serving the case it
+     * always did (env-wide rows on an unscoped/control-plane kernel — the ONLY
+     * combination #7736's own pin ever exercised), now with the corrected
+     * derivation chain.
      */
     private hydrateExpandedViewItems(
         type: string,
@@ -12922,28 +13035,8 @@ export class ObjectStackProtocolImplementation implements
         options: { packageId?: string | null; organizationId: string | null },
         registry: any,
     ): void {
-        if ((PLURAL_TO_SINGULAR[type] ?? type) !== 'view') return;
-        if (!isAggregatedViewContainer(data)) return;
-        const container = data as Record<string, any>;
-        const viewObject =
-            container?.list?.data?.object
-            ?? container?.form?.data?.object
-            ?? (typeof container.name === 'string' ? container.name : undefined);
-        if (!viewObject) return;
-        for (const vi of expandViewContainer(viewObject, container)) {
-            // Carry the container's package provenance onto each expanded item
-            // so the package-disable filter and ADR-0048 artifact scoping judge
-            // them by the same owner the container has.
-            const item: Record<string, unknown> = { ...(vi as any) };
-            if (container._packageId !== undefined && item._packageId === undefined) {
-                item._packageId = container._packageId;
-            }
-            const viArtifact = this.lookupArtifactItem(
-                type,
-                vi.name,
-                (item._packageId as string | undefined) ?? options.packageId ?? undefined,
-            );
-            registry.registerItem(type, mergeArtifactProtection(item, viArtifact), 'name' as any);
+        for (const item of this.expandRuntimeViewContainer(type, data, options)) {
+            registry.registerItem(type, item, 'name' as any);
         }
     }
 

--- a/packages/metadata-protocol/src/view-container-runtime-expansion.test.ts
+++ b/packages/metadata-protocol/src/view-container-runtime-expansion.test.ts
@@ -253,3 +253,145 @@ describe('#7736 a runtime-authored view container is served', () => {
         });
     });
 });
+
+/**
+ * #13407 — the third occurrence of #7736's own defect, and why: #7736's
+ * `hydrateExpandedViewItems` registry-hydration is reached ONLY for an
+ * unscoped (`environmentId === undefined`) kernel writing an env-wide
+ * (`organizationId` unset) row — exactly the one combination the suite above
+ * exercises. Two gates, both correct and untouched here, exclude everything
+ * else: `applyRegistryWriteThrough` never write-through hydrates when
+ * `this.environmentId !== undefined` (a real per-environment/cloud kernel —
+ * `assembleMetadataProtocol`'s own comment: "per-project (cloud) kernels
+ * source metadata from the control plane"), and `hydrateOverlayIntoRegistry`
+ * refuses ANY org-scoped row before ever expanding it ("[#6602] a per-org
+ * overlay is served on demand, never grafted into the registry every org in
+ * this process shares" — ADR-0005). The card's own repro is "a signed-in user
+ * with an ACTIVE ORG" — exactly the excluded case, on any kernel.
+ *
+ * The fix is two independent, additive changes, neither touching either gate:
+ *
+ *  1. Object-name derivation now checks the container's own top-level
+ *     `object` field FIRST (`ViewSchema.object`) — never consulted before.
+ *  2. `getMetaItems` expands a container it reads INLINE, into that request's
+ *     own response only, never into the shared SchemaRegistry — safe for
+ *     isolation because it operates only on rows already scoped to THIS
+ *     request's own org/environment (the pre-existing `queryByOrg` merge).
+ */
+describe('#13407 org-scoped and environment-scoped runtime containers are served', () => {
+    it('derives the object binding from the containers own top-level `object` field, not just `list.data.object`', async () => {
+        const { engine } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        // Saved under a name that is NOT the object, and `list` carries no
+        // `data.object` either — only the container's own top-level `object`
+        // field says what this binds to. Pre-fix this expanded under the
+        // WRONG key (derived from the save name) instead.
+        const bound = {
+            object: 'crm_lead',
+            list: { label: 'All Leads', type: 'grid', columns: [{ field: 'name' }] },
+        };
+        await protocol.saveMetaItem({ type: 'view', name: 'lead_views', item: bound });
+
+        const list: any = await protocol.getMetaItems({ type: 'view' });
+        expect(switcherMatches(list.items, 'crm_lead').map((v: any) => v.name)).toEqual(['crm_lead.default']);
+    });
+
+    it('the cards own repro: a runtime container authored by a signed-in user with an ACTIVE ORG is now served', async () => {
+        const { engine } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        await protocol.saveMetaItem({
+            type: 'view', name: 'crm_lead', item: leadContainer, organizationId: 'org_acme',
+        });
+
+        const list: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+        const served = switcherMatches(list.items, 'crm_lead').map((v: any) => v.name).sort();
+        expect(served).toEqual(['crm_lead.default', 'crm_lead.pipeline']);
+    });
+
+    it('POSITIVE CONTROL: a pre-existing independent ViewItem for the same object is still served alongside the newly-expanded container', async () => {
+        const { engine } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+        await protocol.saveMetaItem({
+            type: 'view', name: 'crm_lead', item: leadContainer, organizationId: 'org_acme',
+        });
+        await protocol.saveMetaItem({
+            type: 'view',
+            name: 'crm_lead.mine',
+            item: {
+                name: 'crm_lead.mine', object: 'crm_lead', viewKind: 'list', label: 'My Leads',
+                config: { type: 'grid', data: { provider: 'object', object: 'crm_lead' }, columns: [{ field: 'name' }] },
+            },
+            organizationId: 'org_acme',
+        });
+
+        const list: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+        const served = switcherMatches(list.items, 'crm_lead').map((v: any) => v.name).sort();
+        // A fix that merely "returned everything" could not distinguish these:
+        // the pre-existing independent item and the two newly-expanded
+        // container items must all be present, distinctly.
+        expect(served).toEqual(['crm_lead.default', 'crm_lead.mine', 'crm_lead.pipeline']);
+    });
+
+    it('ORG ISOLATION HELD: a container authored in org_acme is invisible reading as org_globex, and visible reading as org_acme', async () => {
+        const { engine } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+        await protocol.saveMetaItem({
+            type: 'view', name: 'crm_lead', item: leadContainer, organizationId: 'org_acme',
+        });
+
+        const globex: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_globex' } as any);
+        expect(switcherMatches(globex.items, 'crm_lead')).toEqual([]);
+
+        const acme: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+        expect(switcherMatches(acme.items, 'crm_lead')).toHaveLength(2);
+    });
+
+    it('the isolation-safe path never registers an org-scoped expansion into the shared SchemaRegistry', async () => {
+        const { engine, registered } = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(engine);
+        await protocol.saveMetaItem({
+            type: 'view', name: 'crm_lead', item: leadContainer, organizationId: 'org_acme',
+        });
+        await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+
+        // The RESPONSE carries the expansion (re-confirmed above); the SHARED
+        // registry — read by every org/environment this kernel serves — must
+        // carry none of it. This is what makes the fix isolation-safe without
+        // touching either scope gate.
+        expect(registered.get('view')?.size ?? 0).toBe(0);
+    });
+
+    it('an ENVIRONMENT-SCOPED kernel (a real per-project/cloud kernel, `assembleMetadataProtocol`s own construction shape) also serves a runtime-authored container', async () => {
+        const { engine } = makeStubEngine();
+        // #7736's own pin only ever constructed an UNSCOPED protocol
+        // (`environmentId` omitted) — the control-plane instance. This
+        // constructs the OTHER real shape.
+        const protocol = new ObjectStackProtocolImplementation(engine, undefined, 'env_prod_1');
+
+        await protocol.saveMetaItem({ type: 'view', name: 'crm_lead', item: leadContainer });
+        const list: any = await protocol.getMetaItems({ type: 'view' });
+        const served = switcherMatches(list.items, 'crm_lead').map((v: any) => v.name).sort();
+        expect(served).toEqual(['crm_lead.default', 'crm_lead.pipeline']);
+    });
+
+    describe('anti-vacuity — the closure does not become "expand anything"', () => {
+        it('a DIFFERENT object in the SAME org still serves nothing for it', async () => {
+            const { engine } = makeStubEngine();
+            const protocol = new ObjectStackProtocolImplementation(engine);
+            await protocol.saveMetaItem({
+                type: 'view', name: 'crm_lead', item: leadContainer, organizationId: 'org_acme',
+            });
+            const list: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+            expect(switcherMatches(list.items, 'crm_account')).toEqual([]);
+        });
+
+        it('an org with no container written at all reads empty, not an error', async () => {
+            const { engine } = makeStubEngine();
+            const protocol = new ObjectStackProtocolImplementation(engine);
+            const list: any = await protocol.getMetaItems({ type: 'view', organizationId: 'org_acme' } as any);
+            expect(list.items).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #13407

## LEAD WITH THIS (as directed) — not the symptom

The card is right that this is **not** an org-scoping defect at the door: org-scoped
views authored as **expanded** ViewItems are correctly returned to their own org and
hidden cross-org. The discriminator is container-vs-expanded, org-independent — and
this PR's own new org-isolation pin re-confirms that is still true after the fix.

## A2.1 verdict — FIRST, as directed

**Falsified**, precisely: the canonical shape `{list:{type,data:{provider:'object',
object:'note'},columns}}` carries no top-level `viewKind`, so `isAggregatedViewContainer`
classifying it as a container is **correct**, not a write-path defect — that is exactly
what an unnamed single-view container looks like. There is no second write-path defect.

What actually explains "both shapes landed `active`, neither was returned" is **not**
shape at all — it is two isolation gates on the hydration mechanism itself, confirmed
below.

## Clause ② determination (judged from the actual diff)

**Path limb — NO.** The 3 changed files: `packages/metadata-protocol/src/protocol.ts`,
`packages/metadata-protocol/src/view-container-runtime-expansion.test.ts`,
`.changeset/view-container-runtime-org-environment-scope-closure.md`. None under
`packages/spec/src/**`.

**Content limb — FIRES.** `getMetaItems` is a documented service method
(`content/docs/kernel/services-checklist.mdx`) and the backing implementation of the
published REST route `GET /meta/view?object=` (`rest-server.ts`). For an org-scoped or
environment-scoped request, it now returns rows it previously silently omitted — a
runtime-authored aggregated view container's expanded ViewItems. That is a response-shape
change on a published read door, independent of whether the omission was itself a bug:
a consumer enumerating that route sees more rows than before.

The new private `expandRuntimeViewContainer` member does reach the emitted `.d.ts`
(confirmed: `grep -c expandRuntimeViewContainer dist/index.d.ts` → 7) but does **not**
appear on any of the three public interfaces `ObjectStackProtocolImplementation`
implements (`DataProtocol`/`MetadataProtocol`/`PackageProtocol` from `@objectstack/spec/api`)
— structurally unreachable through a typed reference, and the downstream-consumer
typecheck (101/101 packages) confirms no consumer's compilation is affected. This half of
the content limb reads as benign; the firing reason is the response-content widening
above, not the type surface.

**Docs cross-check (docs-drift-check's 10 named pages + the 3 release-owned pages).**
Read in full: `content/docs/concepts/metadata-lifecycle.mdx` (the `getMetaItems` overlay-
cache passage describes caching/invalidation only — unaffected, unchanged) and
`content/docs/ui/views.mdx` (states the loader "expands the container into independently
addressable OBJECT.KEY view items" — a general claim my fix makes *more* true, not
less; the flat-vs-container authoring warning nearby is about `defineStack`/`defineView`
authoring shape, unrelated to org/environment read scope). Keyword-grepped (`aggregated
view|container.*drop|drop.*container|getMetaItems|only expanded|viewKind`) with zero hits
on the remaining named pages: `deployment/environment-variables.mdx` (one hit — the
overlay-cache TTL passage, same unaffected mechanism as above), `kernel/services-
checklist.mdx` (one hit — a table row listing `getMetaItems`, no behavioural claim),
`ui/forms.mdx`, `ui/actions.mdx`, `ui/public-data-collection.mdx`,
`protocol/objectui/actions.mdx`, `protocol/objectui/layout-dsl.mdx`, `api/client-sdk.mdx`
(the last one's dot-qualified sub-resource example, `crm_lead.pipeline`, is the expanded-
item naming convention my fix now honours universally rather than only for unscoped/env-
wide rows). **No page states or implies that a view container is dropped from the listing
or that org/environment-scoped containers are never expanded — the omission this PR fixes
was never a documented behaviour, so no page is falsified.** Also checked (release-owned,
not editable here): `releases/v14.mdx` (no hit), `releases/v16.mdx` (one hit — `defineView`
non-empty-container enforcement, an authoring-time validation concern, unrelated),
`releases/v17.mdx` (no hit). None falsified.

**Label:** `needs:contract-review` attached below, per the content limb firing.

## #7163 / #7736 scope-boundary statement (deliverable, not background)

- **#7163** scoped to **boot-time, code-authored** containers (`engine.ts`'s
  manifest/nested-plugin loop, `plugin.ts`'s artifact/HMR loader) — always local to the
  serving kernel's own registry, no environment/org gating question ever arises there.
- **#7736** scoped `hydrateExpandedViewItems`'s registry-hydration to exactly the ONE
  combination its own pin (`view-container-runtime-expansion.test.ts`) exercises: an
  **unscoped** protocol instance (`environmentId === undefined`) writing an **env-wide**
  row (`organizationId` unset). That combination is not incidental — it is enforced by
  two gates, both correctly load-bearing for isolation, not oversights:
  - `applyRegistryWriteThrough`: `if (this.environmentId !== undefined) return;` — never
    write-through hydrates on a real per-environment kernel (`assembleMetadataProtocol`'s
    own comment: "per-project (cloud) kernels source metadata from the control plane").
  - `hydrateOverlayIntoRegistry`: `if (options.organizationId !== null &&
    options.organizationId !== undefined) return false;` — never grafts an org-scoped
    row into a registry every org sharing that kernel reads (ADR-0005 per-org isolation,
    `[#6602]`).

  **This card's own repro is "a signed-in user with an active org" — i.e. exactly the
  case #7736's fix boundary excludes, regardless of environmentId.** Empirically
  confirmed against a stub protocol (see Tests): an env-wide, unscoped write expands
  correctly (`#7736`'s existing pin, unchanged); the identical write with `organizationId`
  set expands to **nothing**, on the very same unscoped kernel. A separate probe against
  an `environmentId`-scoped protocol instance shows the identical failure for *any*
  write, org-scoped or not. That is the "fourth occurrence" triage warned the unnamed
  scope boundary would invite — now named.

## Shape (a), as directed — what's actually fixed

1. **Object-derivation fix** (the literal ask): `hydrateExpandedViewItems`'s fallback
   chain (`list.data.object → form.data.object → name`) never read the container's own
   top-level `object` field — the field `ViewSchema` declares specifically for this
   purpose ("how a stack-level `views: [...]` entry says which object its views belong
   to; read by `getViewsByObject()` / `GET /meta/view?object=`"). Now checked first.
2. **Overruled upward** (clause ②'s "overrule me upward only", and #7736's own
   documented intent that this hydration serve every reader): the derivation fix ALONE
   does not make the card's own repro pass, because the function it lives in is never
   *reached* for an org-scoped or environment-scoped write (above). Widening either
   isolation gate was rejected as unsafe to do unilaterally — so instead
   `getMetaItems` now ALSO expands any aggregated container it reads, **inline, into
   this request's own response only** (`expandRuntimeViewContainer`, shared with the
   registry path) — never into the SchemaRegistry. This is safe for isolation because
   it operates exclusively on `overlays`, the rows `getMetaItems` already read for
   *this* request's own org/environment scope (the existing `queryByOrg` merge); nothing
   is written anywhere another request or kernel could see it from — see the new
   registry-emptiness assertion in the tests below, which checks this directly.

`getMetaItems`'s canonical-shape filter (the container drop, `protocol.ts` — STOP
condition 2) is untouched: the raw container is still dropped from every listing; only
the expanded items are now also present, restoring the same invariant #7736 already
established for the narrower case.

## What was NOT touched, and why

- The two isolation gates above (`environmentId`, `organizationId`) — deliberate,
  correctly-reasoned boundaries (ADR-0005; the SchemaRegistry is shared by every
  request a kernel serves). Widening them was the tempting shortcut and was rejected;
  the inline, registry-free expansion achieves the same result without touching them.
- `metadata-manager.ts`'s `getViewsByObject()` (the card's second cited exit) — reads a
  *different* backing store (`MetadataManager`'s own loader-based registry, not
  `sys_metadata` via `getMetaItems`). The card's own repro and pin
  (`GET /meta/view?object=`) go through `getMetaItems`/REST only; fixing the sibling
  exit is a materially larger, separately-scoped change (own tests, own package
  discipline) and is filed as a follow-up, not bundled here.
- `packages/metadata/src/plugin.ts` (the artifact/HMR loader) carries the **identical**
  object-derivation bug (never reads `container.object` either) — filed as a follow-up
  (same defect class, but a different file/verification surface, so it does not qualify
  for the bounded in-place-fix exemption).
- `rest-server.ts`'s `viewKind` filter — untouched, per the card's own non-negotiable.
- `getMetaItems`'s container-enumeration drop — untouched (STOP condition 2 preserved).

## Path collision (STOP condition 4) — measured, not assumed

PR #13870's `protocol.ts` diff lands at **1370–1454** (new `MalformedVersionTokenError` /
`assertVersionTokenNotMalformed`) and **10126–10290** (`assertVersionOf`/
`assertVersionMatch` OCC methods) — confirmed via `pull_request_read get_files`. My
edits are at `hydrateOverlayIntoRegistry`/`hydrateExpandedViewItems`
(~12830–12995) and the `getMetaItems` overlay-merge section (~6495–6530): thousands of
lines from either region, no overlap.

## Anchors re-located by quoted source (drift measured)

| Card cites | Actual (this branch) | Drift |
|---|---|---|
| `rest-server.ts:4404` (viewKind filter) | `rest-server.ts:4811` | ~407 lines |
| `metadata-manager.ts:1592` (`getViewsByObject`) | `metadata-manager.ts:1583` | ~9 lines |
| `protocol.ts:6358` (container drop in `getMetaItems`) | `protocol.ts:6731` | ~373 lines |
| `protocol.ts:12483` (`hydrateExpandedViewItems`) | `protocol.ts:12919` (pre-fix) | ~436 lines |

No file-identity drift; no ~4,600-line drift found in any of the four cited files on
this branch (that measurement belongs to a different lane's file, per the dispatch
order's own wording).

## Tests

All commands re-run on this PR's HEAD (`7f63e54ced`) after merging `origin/main`
(`4642f4c64c`) into the branch:

- **New behavioral pin + positive control** (`view-container-runtime-expansion.test.ts`,
  new `#13407 org-scoped and environment-scoped runtime containers are served` describe
  block, 8 new cases alongside the 8 pre-existing `#7736` ones): the card's own repro
  (org-scoped runtime container → `getMetaItems`), a positive control (an independent
  ViewItem for the same object stays served alongside), org isolation (visible to its own
  org, hidden from a different one), a registry-emptiness assertion (the isolation-safe
  path never writes the shared SchemaRegistry), the environment-scoped-kernel case, the
  `container.object`-derivation case, and 2 anti-vacuity cases.
- **Ablation** (mutation on disk proved both ways, restore proved byte-identical under a
  trap with absolute paths): `protocol.ts` replaced with the pre-fix (parent commit)
  blob — fix-marker greps `1→0` in both directions, old buggy chain `0→1`, blob hash
  `68d810af1b…` → `03be73cf57…`; rebuilt; exactly the 5 new cases that depend on the fix
  **FAIL** (`derives the object binding…`, the card's own org repro, the positive
  control, org isolation, the environment-scoped case — each `expect([...]).toEqual([])`
  or equivalent, and the positive-control case degrades to only the pre-existing
  independent item surviving, exactly as a fix that "returns everything" being absent
  predicts) while the pre-existing `#7736` cases, the registry-emptiness case (true either
  way — the pre-fix mechanism never touched the registry for org rows either) and the 2
  anti-vacuity cases **stay green** (11 passed / 5 failed of 16), confirming the ablation
  targets only the new mechanism and nothing wider. `git checkout HEAD -- PATH`
  restore verified byte-identical (`git hash-object` back to `68d810af1b…`; `git diff
  HEAD` and `git status --porcelain` both empty) under a trap with `REPO_ROOT` absolute
  paths (`EXIT INT TERM`). Rebuilt and re-ran: 16/16 pass restored.
- **`pnpm --filter @objectstack/metadata-protocol test`** (full package suite): 147
  passed / 2 skipped (149 files), 2053 passed / 10 skipped (2063 tests) — 0 failures, 0
  new skips (the 2 skipped files and 10 skipped tests are pre-existing).
- **`turbo run typecheck --filter=@objectstack/metadata-protocol`**: 13/13 tasks, clean.
- **Downstream consumers** (`turbo run typecheck --filter='...@objectstack/metadata-protocol'`,
  the consumer-prefix direction): 101/101 tasks pass — no downstream package's typecheck
  regressed from the new (additive, still-private) `expandRuntimeViewContainer` member
  appearing in the emitted `.d.ts`.
- **`packages/rest` view/meta-read consumer subset** (10 files identified by grep for
  `meta/view|viewKind|getViewsByObject` across `packages/rest/src/*.test.ts` — the REST
  route this card's repro exercises): 10/10 files, 137/137 tests pass.
- **Full workspace build** (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`):
  70/70 tasks pass.
- **ESLint, scoped to the 2 changed files** (`eslint --no-inline-config`, `--format json`
  count confirms 2 files measured): 0 errors, 0 warnings. Proven-narrowing, not merely
  skipped: this repo's `eslint.config.mjs` "never enables type-aware linting (no
  `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file" (its own
  stated invariant), so no untouched file's judgment can depend on these two — a per-file
  scope is a complete measurement here, not a narrowed one.
- **Gate family** (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`,
  re-derived on the fresh, non-stale tree after merging `origin/main` — 36 commands): all
  35 reachable commands pass. The 36th, `node scripts/check-test-completeness.mjs` (no
  args), is **NOT MEASURED** — it grades a saved `turbo run test` log path that only CI
  produces; its own text: "not a red… not a finding." The scheduled (not PR-gating)
  `node scripts/pm/check-half-states.mjs` live-repo sweep is likewise **NOT MEASURED**
  locally (network/live-repo bound); the PR-blocking form, `pnpm check:pm-half-states`
  (`--self-test` only), passed (1826 cases).

---

_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_