### PR TITLE
docs(nav): stop listing "index" in content/docs/releases/meta.json

### DIFF
--- a/content/docs/releases/meta.json
+++ b/content/docs/releases/meta.json
@@ -1,7 +1,6 @@
 {
   "title": "Releases",
   "pages": [
-    "index",
     "v17",
     "v16",
     "v15",


### PR DESCRIPTION
Fixes #13711

## This is the dedicated docs-only PR the `content/docs/releases/` fence names

`content/docs/releases/**` is fenced unconditionally by AGENTS.md and CLAUDE.md — *never edit it in a code PR.* That fence names its own escape hatch, verbatim:

> If a releases page has a factual error, file an issue or **make it a dedicated docs-only PR** — never a rider on code changes.

This PR takes that route and nothing else. It is **one file, one line**, so it cannot be a rider on anything:

```
commit c941f94fa

 content/docs/releases/meta.json | 1 -
 1 file changed, 1 deletion(-)
```

No changeset, no script, no doc page, no test. The `skip-changeset` label carries the "this PR declares no release of its own" declaration, which is what keeps the diff at one file — `content/docs/**` belongs to no publishable package, and `@objectstack/docs` is `private: true`. Precedent for the route: #12507 / PR #13707 (also one file under `content/docs/releases/`, no changeset).

## The change

Removes `"index"` from the `pages` array of `content/docs/releases/meta.json`.

Fumadocs attaches a folder's `index.mdx` as that folder's tree `index` node **only when the folder's `meta.json` does not list `"index"`** in `pages`. Listing it makes the landing page an ordinary child and leaves the folder node with a name and no url — `fumadocs-core@16.14.4`, `buildFolder()`:

```js
if (indexPath) {
  if (excludedPaths.has(indexPath)) delete node.index;   // "index" was listed
  else excludedPaths.add(indexPath);
}
```

Two surfaces read that one node:

- **Breadcrumb.** `getBreadcrumbItems()` emits the ancestor with `url: undefined`, and `docsTrail()` in `apps/docs/app/[lang]/docs/[[...slug]]/page.tsx` drops any crumb without a url (Google requires `item` on every `BreadcrumbList` entry but the last).
- **Sidebar.** `node.index ? SidebarFolderLink : SidebarFolderTrigger`.

PR #13710 removed `"index"` from 16 of the 17 `meta.json` files that listed it, taking short trails 172 → 8. This file is the 17th, left alone then precisely because of the fence.

## Measured, not asserted

Driven through the real `fumadocs-core@16.14.4` loader over `content/docs` (405 pages), with `"index"` re-inserted **in memory only** for the before-leg, so nothing was mutated on disk:

| | before | after |
|---|---|---|
| short breadcrumb trails | 8 | **0** |
| Releases folder header | `TRIGGER` | **`LINK`** |
| Releases `indexUrl` | `null` | **`/docs/releases`** |
| pages in tree | 405 | 405 |

The 8 fixed are exactly the non-landing pages under `/docs/releases`: `v9`, `v12`–`v17`, `implementation-status`. Exactly one sidebar folder header flips and only the 9 `/docs/releases` trails change; no page is added or removed.

**The landing page does not disappear from navigation.** After the change `/docs/releases` is still in `getPages()`, `source.getPage(['releases'])` still resolves, and the page becomes the section header's own link rather than a child beneath a label identical to it. This was checked explicitly because a nav change that silently unlisted a published page would be worse than the defect being fixed.

## Gates

Both gates that read this file were re-derived at their current line numbers and run:

- `scripts/check-release-notes.mjs:83-97` requires only the `v(major)` slugs (`metaPages.has(slug)`); `"index"` is never consulted. The section-reachability check at `:62-82` reads `content/docs/meta.json` and `content/docs/index.mdx`, not this file. → `check-release-notes: OK — every released major has a curated, navigable release page.`
- `scripts/check-section-landing-index.mjs:178` filters `"index"` out of the `pages` array before comparing: `raw.filter((p) => typeof p === 'string' && p !== 'index' && !p.startsWith('---'))`. `releases` is additionally documented at `:66` as a narrative page, not an index, so it is in the not-held set either way. → `✓ check-section-landing-index: 8 section index block(s) enumerate their meta.json pages, in order, both directions; 26 landing page(s) of 34 declare no index block and are not held.`

39 gate commands run in total, covering the family `node scripts/pm/dispatch-gates.mjs` derives for this path, plus `pnpm check:ratchet-remedy-authority` (which path derivation cannot name, #13813). All green except three that measured nothing and report so themselves: `check-test-completeness` (exit 3, `PREREQUISITE NOT MET` — it grades a saved turbo log), `check-half-states` (HTTP 502, no network egress from this runner), and `check:skill-examples` (needs built `packages/client-react/dist` .d.ts). CI measures all three.

ESLint is narrowed to the changed file on its own evidence: `eslint --format json content/docs/releases/meta.json` reports `"File ignored because no matching configuration was supplied."` — the file is outside ESLint's population by ESLint's own config resolution, and nothing in this diff touches `eslint.config.mjs`, so no untouched file's verdict can move.

## Not closed by this PR

#12352 remains open and is another dispatch's to close — the unlock scan handles it.

_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_