### PR TITLE
Delete the unreachable `Array.isArray` limb at all three `adapter.find()` sites

### DIFF
--- a/.changeset/react-pages-array-isarray-limb.md
+++ b/.changeset/react-pages-array-isarray-limb.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/docs": patch
+---
+
+docs(react-pages): delete the unreachable `Array.isArray(result)` limb from the live-data sample
+
+`ObjectStackAdapter.find()` cannot resolve to an array, so the `Array.isArray(result)`
+arm the live-data sample carried could never be taken. Re-derived against objectui at
+the sha this repo pins (`9602dc82`) and again at objectui `origin/main`, which agree
+line for line:
+
+- `find()` returns from five points — `{ data: [], total: 0 }` for a resource already
+  memoized as missing, `{ data: [], total: 0 }` for a fresh 404 that is not an
+  `enable`-block denial, two `normalizeQueryResult(...)` calls (the `$expand`/`$search`
+  raw-GET path and the client-SDK path), and `return existing`, which hands back a
+  promise produced by that same set.
+- Both branches of `normalizeQueryResult()` return an object literal with exactly
+  `data`, `total`, `page`, `pageSize`, `hasMore`. The first branch is the one that
+  makes the limb dead: it tests `Array.isArray(result)` on the *transport* response and
+  **wraps** a bare array into that envelope. The array case is folded before any caller
+  sees it.
+
+The sample now reads `result.data` directly, and a new paragraph under it states the
+envelope contract so the reason survives the next edit. The two `kind:'react'` pages in
+`examples/app-showcase` carrying the same dead limb — `crm-workbench` and
+`renewals-pipeline` — were repaired in the same edit, with the derivation recorded in the
+comment that already explains the neighbouring `.records` trap.
+
+Behaviour-preserving: `.data` was read first and always won. What goes is a shape the
+producer cannot emit, sitting in the page a customer — and a coding agent — copies from.

--- a/content/docs/ui/react-pages.mdx
+++ b/content/docs/ui/react-pages.mdx
@@ -176,8 +176,7 @@ function Page() {
         $filter: ['status', '!=', 'paid'],
         $top: 200,
       });
-      const records = result?.data ?? (Array.isArray(result) ? result : []);
-      if (alive) setRows(records);
+      if (alive) setRows(result.data);
     })();
     return () => { alive = false; };
   }, [adapter]);
@@ -185,6 +184,11 @@ function Page() {
   return <ul>{rows.map((r) => <li key={r.id}>{r.name}</li>)}</ul>;
 }
 ```
+
+`find()` always resolves to the same envelope — a `QueryResult` carrying the rows
+under `data`. A backend that answers with a bare array is folded into that envelope
+before your code sees it, so `result.data` is the only row shape a page is ever handed:
+read it directly, with no fallback for a shape the adapter cannot produce.
 
 <Callout type="warn">
 The `$` prefixes are load-bearing. An unprefixed `top:` or a `filters:` key is not a

--- a/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
+++ b/examples/app-showcase/src/ui/pages/crm-workbench.page.ts
@@ -37,7 +37,10 @@ function Page() {
       // silently stuck at 0 even though the ListView beside them showed the same
       // rows. Read .data: it is the only row shape QueryResult declares, so a
       // tolerant '.data || .records' alias would render correctly while
-      // teaching a spelling the producer cannot emit.
+      // teaching a spelling the producer cannot emit. There is no array
+      // shape to test for either: every find() path resolves to that same
+      // object envelope, and normalizeQueryResult WRAPS a bare array
+      // response into it, so an 'Array.isArray(all)' limb can never be taken.
       //
       // The cap is $top, not 'limit': QueryParams declares only $-prefixed keys
       // and the adapter copies only those, so a bare 'limit' is dropped without
@@ -48,7 +51,7 @@ function Page() {
       // "Active" stays a per-row verdict over the 200 rows actually fetched;
       // an exact one would need its own filtered count query.
       const all = await adapter.find('showcase_project', { $top: 200 });
-      const rows = Array.isArray(all) ? all : (all && all.data) || [];
+      const rows = all?.data ?? [];
       const total = typeof (all && all.total) === 'number' ? all.total : rows.length;
       setStats({ total, active: rows.filter((r) => r.status === 'active').length });
     } catch (e) { console.warn('[CRM Workbench] failed to refresh stats', e); }

--- a/examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts
+++ b/examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts
@@ -75,14 +75,16 @@ function Page() {
   //     applied, is the server's real count over the same $filter rather than
   //     the page length. Counting data.length under a cap is how a KPI starts
   //     under-reporting in silence; count 'total' and the cap stays a fetch
-  //     bound instead of a lie about the business.
+  //     bound instead of a lie about the business. That envelope is the ONLY
+  //     shape find() resolves to -- normalizeQueryResult WRAPS a bare array
+  //     response into it -- so there is no array form to test for either.
   React.useEffect(() => {
     let alive = true;
     (async () => {
       if (!adapter || !sel) { setRelated({ projects: 0, invoices: 0, openInvoices: 0, capped: false }); return; }
       const pr = await adapter.find('showcase_project', { $filter: ['account', '=', sel], $top: 500 });
       const iv = await adapter.find('showcase_invoice', { $filter: ['account', '=', sel], $top: 500 });
-      const rows = (res) => (Array.isArray(res) ? res : (res && res.data) || []);
+      const rows = (res) => res?.data ?? [];
       const count = (res, list) => (typeof (res && res.total) === 'number' ? res.total : list.length);
       const projects = rows(pr);
       const invoices = rows(iv);


### PR DESCRIPTION
Fixes #13706

PR #13705 deleted the tolerant `?? result?.records` alias at the two sites its ruling
named. The `Array.isArray(...)` limb standing beside it is dead for the same reason and
was left behind. This deletes it, at every site that carries it.

## The unreachability argument, re-derived here

Enumerated on objectui rather than quoted from the card — at the sha this repo pins
(`.objectui-sha` = `9602dc820450dda956843c6cfe5b329bcf88c757`) and again at objectui
`origin/main` (`592acaf`). The two agree line for line.

`ObjectStackAdapter.find()` (objectui `packages/data-objectstack/src/index.ts`) returns
from five points:

1. `return { data: [], total: 0 }` — the resource is memoized in `missingResources` from
   an earlier 404.
2. `return existing` — the in-flight dedupe. It hands back a promise built by the same
   IIFE, so it resolves through the other four points and contributes no shape of its own.
3. `return this.normalizeQueryResult(result, params)` — the raw-GET path, taken when
   `$expand` or `$search` is set.
4. `return this.normalizeQueryResult(result, params)` — the client-SDK path.
5. `return { data: [], total: 0 }` — a fresh 404 that is not an `enable`-block denial.

`normalizeQueryResult()` has exactly two branches, and both return an object literal
carrying `data`, `total`, `page`, `pageSize`, `hasMore`. Its first branch is the one that
makes the limb dead: it tests `Array.isArray` on the **transport** response and **wraps** a
bare array into that envelope.

```ts
// objectui packages/data-objectstack/src/index.ts — normalizeQueryResult()
if (Array.isArray(result)) {
  return { data: result, total: result.length, page: 1, pageSize: result.length, hasMore: false };
}
```

The array case is therefore folded before any caller sees it. No page can be handed an
array by `find()`, so an `Array.isArray` test on a `find()` result is `false` on every
path. The declared return type says the same thing from the other side: `find()` resolves
a `QueryResult`, an object type, never a union with an array.

Corroborated by this tree, without relying on the derivation:
`examples/app-showcase/test/react-page-adapter-query-contract.test.ts` **executes** the
renewals-pipeline rollup against a contract-faithful adapter double whose `find()` resolves
`{ data, total, page, pageSize, hasMore }` and nothing else. It passes unchanged with the
limb removed (5 tests, 5 passed), because the limb was never taken there either.

## Sites — re-derived: three, not two

Line numbers on the merge base `d7e8f3ed6`, which is `origin/main` as of this branch:

| file | line | before | after |
| --- | --- | --- | --- |
| `content/docs/ui/react-pages.mdx` | 179 | `const records = result?.data ?? (Array.isArray(result) ? result : []);` then `setRows(records)` | `if (alive) setRows(result.data);` |
| `examples/app-showcase/src/ui/pages/crm-workbench.page.ts` | 51 | `const rows = Array.isArray(all) ? all : (all && all.data) \|\| [];` | `const rows = all?.data ?? [];` |
| `examples/app-showcase/src/ui/pages/renewals-pipeline.page.ts` | 85 | `const rows = (res) => (Array.isArray(res) ? res : (res && res.data) \|\| []);` | `const rows = (res) => res?.data ?? [];` |

The card expected two sites. `renewals-pipeline` is the third: same defect class, same
`adapter.find()` contract, and already a census anchor of
`scripts/check-react-page-adapter-contract.mjs` — it is repaired here rather than filed,
because a repair that leaves one of the guard's own three anchors carrying the shape is
the population gap that let this defect survive its first two fixes.

Behaviour-preserving at all three: `.data` was read first and always won. What goes is a
shape the producer cannot emit. The comment blocks in both page modules already explain
the neighbouring `.records` trap; each now records this derivation beside it, so the limb
does not come back as a defensive edit.

## What PR #13955 changed around the sample

#13955 (merged today, `d7e8f3ed6`, +62/−9) scoped the react-only half of the page to the
`react` tier. Around the live-data sample it added exactly one thing: a bold lead-in
immediately under `## Live data` —

> **On the `react` tier.** `useAdapter` and React's hooks exist only where the source is
> executed, and the sample below is refused on an `html` page before any of that matters …

It did not touch the sample's code, so the card's line reference was stale only by the
offset that marker introduces (the fence moved down by 22 lines). The marker does change
what the surrounding sentence should say, and this PR answers it: the sample now sits
under a paragraph that states the result contract, so a reader who has just been told this
section is react-only is also told what `find()` resolves to on that tier.

The sample is the copy a customer — and a coding agent — starts from, so it must be
correct to copy rather than merely shorter. The prose added under the fence:

> `find()` always resolves to the same envelope — a `QueryResult` carrying the rows under
> `data`. A backend that answers with a bare array is folded into that envelope before
> your code sees it, so `result.data` is the only row shape a page is ever handed: read it
> directly, with no fallback for a shape the adapter cannot produce.

That also retires the related nit the card names: the sample's local was called `records`
while holding `result.data`. The local is gone rather than renamed.

## Changeset

One, naming `@objectstack/docs: patch`, following #13955 — the most recent `content/docs/**`
diff, which named that package. `@objectstack/example-showcase` is deliberately not named:
it is private and appears in 0 of this repo's changesets, and PR #13705 — the immediately
preceding repair at two of these same three sites, with the same
`content/docs` + `examples/app-showcase` + `scripts` diff shape — carried no changeset at
all. Naming the published docs package is the stricter of the two precedents.

## Verification

All at `02086ebb1`, the final commit.

- Gate family derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
  (46 commands once the changeset existed). `comm -23` of derived against run is **empty**.
- 45 of 46 green. Five needed a build first and were re-run green after
  `turbo run build`: the two `@objectstack/lint` doc gates, `@objectstack/spec check:docs`,
  `check:skill-examples`, `check:dual-build-cjs-loads`.
- The one remainder is `node scripts/check-test-completeness.mjs`, exit **3**, which is the
  gate's own NOT-MEASURED branch and not a red — it prints: *"Arrived here from the gate
  family scripts/pm/dispatch-gates.mjs derives? That list names this script with NO
  argument, which is this branch. There is no local log to hand it, so the local reading
  for this gate is NOT MEASURED."*
- The mandatory non-derivable gate ran: `pnpm check:ratchet-remedy-authority` →
  `OK check-ratchet-remedy-authority: 180 scripts swept …`.
- `pnpm check:react-page-adapter-contract` →
  `✓ check-react-page-adapter-contract: 21 app-showcase page module(s) + 1 content/docs react-page sample(s) (from 396 doc file(s), 1946 fenced block(s)) — every adapter query option is $-prefixed and every row read is off data.`
- `pnpm lint` (repo-wide `eslint . --no-inline-config`, no narrowing) — exit 0.
- `pnpm check:nul-bytes` — OK, 7661 text files, no raw control bytes.
- `pnpm --filter './examples/*' run typecheck` — all four example apps Done.
- `pnpm --filter @objectstack/example-showcase exec vitest run --maxWorkers=2` —
  **26 files, 364 tests, all passed**, including the executing adapter-contract oracle.

## Note for the reviewer, not repaired here

`scripts/check-react-page-adapter-contract.mjs` has two detectors — `recordsReads` and
`unprefixedQueryKeys`. Neither sees an `Array.isArray` limb, so the guard that stops the
`.records` shape returning does **not** stop this one. That guard is out of scope for this
card by its dispatch, and nothing here touches it; the gap is reported so it can be
triaged on its own.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pk26oZ12t5N1hwGW1m1MgC)_