### PR TITLE
test(dogfood): declare OS_REGISTRY_LOG=warn in the suite's own vitest harness

### DIFF
--- a/packages/qa/dogfood/vitest.config.ts
+++ b/packages/qa/dogfood/vitest.config.ts
@@ -15,6 +15,29 @@
 //
 // `isolated` keeps vitest defaults (fresh fork registry per file) for
 // everything else — fixture stacks, custom security/plugins, env-flag files.
+//
+// ── #13517: this suite asks the SchemaRegistry for quiet, DECLARATIVELY ─────
+//
+// Measured on this suite (one full run, `origin/main` eb649cb8bc): 66,976
+// lines on the run's stdout, 39,738 of them `[Registry] …` — 94.9% of
+// everything this suite writes through `console`. They are per-item
+// registration lines (`Registered object/namespace/action/view/…`), emitted
+// once per registered item per app boot, and this suite boots real example
+// apps ~130 times.
+//
+// `OS_REGISTRY_LOG` is `@objectstack/objectql`'s OWN published seam for that
+// verbosity (`SchemaRegistryOptions.logLevel` / `REGISTRY_LOG_LEVELS`,
+// registry.ts) — at `warn` the registry's private `log()` returns before
+// writing. What it does NOT silence is the diagnostics: the ADR-0005
+// `[Registry] Collision` lines go through a bare `console.warn` that the
+// level never gates, so a real shadowing still speaks here.
+//
+// ⛔ Two things this deliberately is NOT. It does not move the engine's
+// SHIPPED default (still `'info'`, unchanged for every production reader),
+// and it does not make library code sniff `process.env.VITEST` — a library
+// that behaves differently under a test runner would make every log reading
+// in tests a reading of something other than production. The request lives
+// HERE, in the harness, where the test author can see it.
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
@@ -62,6 +85,11 @@ export default defineConfig({
           // vitest 4.1.10). Mechanism: examples/app-showcase/vitest.config.ts.
           // Enforced by scripts/check-console-intercept-disarm.mjs.
           disableConsoleIntercept: true,
+          // #13517: quiet the registry's per-item registration chatter — the
+          // engine's own `OS_REGISTRY_LOG` seam, not a change to its shipped
+          // default. Header docblock carries the measurement and the rationale.
+          // PER PROJECT for the same measured reason as the line above.
+          env: { OS_REGISTRY_LOG: 'warn' },
           name: 'shared-showcase',
           include: SHARED_SHOWCASE,
           isolate: false,
@@ -74,6 +102,11 @@ export default defineConfig({
           // vitest 4.1.10). Mechanism: examples/app-showcase/vitest.config.ts.
           // Enforced by scripts/check-console-intercept-disarm.mjs.
           disableConsoleIntercept: true,
+          // #13517: quiet the registry's per-item registration chatter — the
+          // engine's own `OS_REGISTRY_LOG` seam, not a change to its shipped
+          // default. Header docblock carries the measurement and the rationale.
+          // PER PROJECT for the same measured reason as the line above.
+          env: { OS_REGISTRY_LOG: 'warn' },
           name: 'isolated',
           include: ['test/**/*.test.ts'],
           exclude: SHARED_SHOWCASE,


### PR DESCRIPTION
Part of #13517 — this lands the concentrated 67% share only. The card measures a
repo-wide volume; this PR quiets one suite through that suite's own harness, and
the remainder is re-measured below so it can be judged separately. The card stays
open on purpose.

## What this changes

One file, `packages/qa/dogfood/vitest.config.ts`: both inline projects now declare

```ts
env: { OS_REGISTRY_LOG: 'warn' },
```

`OS_REGISTRY_LOG` is `@objectstack/objectql`'s own published seam for registry
verbosity (`SchemaRegistryOptions.logLevel` / `REGISTRY_LOG_LEVELS`,
`packages/objectql/src/registry.ts`). At `warn`, the registry's private `log()`
returns before writing, so the per-item `[Registry] Registered …` lines stop.
Set **per project** for the same measured reason the neighbouring
`disableConsoleIntercept` is: inline projects do not inherit root-level test options.

What it deliberately does **not** do:

- it does not move the engine's shipped default (still `'info'`, unchanged for
  every production reader);
- it does not make library code sniff `process.env.VITEST` — a library that
  behaves differently under a test runner makes every log reading in tests a
  reading of something other than production;
- it does not re-arm console interception.

The request lives in the harness, declaratively, where the test author can see it.

## Measurement — `packages/qa/dogfood`, one full run each, base `eb649cb8bc`, head `d7cf9c96c9`

`pnpm --filter @objectstack/dogfood exec vitest run --maxWorkers=3 --reporter=dot`,
combined stdout+stderr captured to a file and counted.

| | before | after | delta |
|---|---:|---:|---:|
| lines on the run's stdout | 66,976 | 27,242 | −39,734 (−59.3%) |
| `[Registry] …` lines | 39,738 | 1 | −39,737 |
| engine structured-logger lines | 25,118 | 25,148 | +30 |
| console-carried lines (stdout minus the structured logger) | 41,858 | 2,094 | −39,764 (−95.0%) |

Test outcome is identical on both sides: `Test Files 128 passed | 1 skipped (129)`,
`Tests 998 passed | 3 skipped (1001)`.

The 41,858 console-carried figure reproduces the card's 41,115 for this suite to
within 1.8%, which is what makes the two measurements comparable: the card counted
**intercepted console lines**, and the engine's structured logger writes to
`process.stdout` directly and was never on that path.

Diagnostics are preserved, which is the point of choosing `warn` rather than
silencing the sink: the ADR-0005 `[Registry] Collision` warning goes through a bare
`console.warn` that the level never gates, and it is present in both runs
(1 occurrence before, 1 after). The single surviving anchored `[Registry]` line
after the change is the `Package not found for uninstall` warning.

## Mechanism proof (reverse verification, on a committed tree)

Same single file, `test/action-params-contract.dogfood.test.ts`:

- knob present: **0** anchored `[Registry]` lines, 1 file / 5 tests passed
- knob absent (that config restored from the merge base, mutation confirmed on
  disk — `OS_REGISTRY_LOG` occurrences 5 to 0 — then restored from `HEAD`,
  restore proven by an empty `git diff HEAD` and a blob hash equal to the HEAD
  blob `c3873b15bfe3b14d041098eb8dad6cfedc9eb87e`): **416** lines

## Gates run locally at `d7cf9c96c9`

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` derived 23
families; all 23 were run. 21 green. Two returned exit code 3 = PREREQUISITE NOT
MET = **not measured**, never a pass:

- `check-test-completeness` — its own text: "There is no local log to hand it, so
  the local reading for this gate is NOT MEASURED. It is not a red, and there is
  nothing here to fix." It reads a saved `turbo run test` log; CI has one.
- `check:dual-build-cjs-loads` — "PREREQUISITE NOT MET — this gate reads built
  output, and some package has no dist/." Re-run after
  `turbo run build --filter='./packages/*' --filter='./packages/*/*'`: **exit 0**.

Also run: `check:nul-bytes` OK (7,662 files, no raw control bytes) ·
`check-console-intercept-disarm` OK ("72 vitest-running package(s), every one
disarms console interception at the package root") ·
`pnpm --filter @objectstack/dogfood run typecheck` exit 0.

⚠️ That typecheck green does **not** cover this diff. `tsc --noEmit --listFiles`
for this package reports **0** hits for `packages/qa/dogfood/vitest.config.ts` — the
edited file is outside the package's tsc program. What does exercise it is vitest
itself: both full runs above loaded this config and accepted the `env` option.

ESLint was run **narrowed to the edited file**, with the three readings that make a
narrowing a measurement rather than a skip: ① the population comes from ESLint's own
config resolution — 5,594 of 7,669 tracked files are not ignored; ② the narrowed run
linted **1** file (count read from `--format json` output), 0 errors, 0 warnings;
③ the config cannot move a verdict on an untouched file, per `eslint.config.mjs`'s
own statement that "this repo runs one `eslint.config.mjs`, which never enables
type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint`
rules) for ANY file". The repo-wide sweep is CI's run.

## No changeset

`packages/qa/dogfood` is `private: true` and nothing here publishes — a test-harness
configuration change only. Labelled `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_