### PR TITLE
docs(skills): give datasets/ a home in the published project-layout tree

### DIFF
--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -101,6 +101,7 @@ my-app/
     │   └── index.ts
     ├── dashboards/           # Optional: dashboards
     ├── reports/              # Optional: reports
+    ├── datasets/             # Optional: analytics datasets
     ├── i18n/                 # Optional: translation bundles
     └── handlers/             # Optional: runtime hook handlers
 ```


### PR DESCRIPTION
Fixes #13974

## What changed

One row in the published project-layout tree in `skills/objectstack-platform/SKILL.md`:

```
    ├── reports/              # Optional: reports
+   ├── datasets/             # Optional: analytics datasets
    ├── i18n/                 # Optional: translation bundles
```

Nothing else in the file changed, and **no ratchet ceiling moved** — see the arithmetic below.

## Why

That tree is the one place the published catalog tells an agent what directories an
ObjectStack project has. It enumerated `dashboards/` and `reports/` and not `datasets/`,
so an agent reading only the layout learned that the two analytics surfaces have homes
and that the layer they bind does not appear to have one at all. The file already teaches
`datasets` as a top-level `defineStack()` collection key in its Full Configuration
Reference; the layout tree was the surface that disagreed with it.

That is the failure shape recorded on #13696 — a module's app face complete, its
analytics face silently empty, with nothing anywhere reporting a problem. The
assembly-checklist reading path is covered by the separate draft PR #13972; this is the
layout reading path, which that PR does not touch.

## Budget: paid from measured in-file headroom, not a ceiling move

The card priced the row at roughly 85 bytes against roughly 72 of headroom and expected
either an in-file deletion or a ceiling move. Written in the tree's own comment register —
the same `# Optional: noun` shape as every sibling row — the row costs less than that, and
it fits. Measured, in `check-skills-token-ratchet`'s own convention of
`ceil(utf8 bytes / 4)`:

| | bytes | tokens | headroom vs ceiling 12705 |
|:--|--:|--:|--:|
| before | 50746 | 12687 | 18 tokens = 74 bytes |
| the new row (66 bytes of text + newline) | +67 | | |
| after | 50813 | 12704 | 1 token = 7 bytes |

Ceiling 12705 tokens is 50820 bytes. 67 added against 74 available, so the row lands
inside the existing ceiling with 7 bytes to spare.

**Where that headroom came from, and why it is genuine budget rather than a reservation.**
Two facts, both reproducible from this repo's history:

1. The `12705` row was pinned **at the measurement**. At `b9186f6b`, the commit that
   landed it, the file measured 50817 bytes = 12704.25, i.e. exactly 12705 tokens — zero
   headroom.
2. Exactly one commit has touched the file since: `c42bc8ee` (#13760, the
   objectstack-platform factual sweep), which corrected six false behavioral claims and in
   doing so shrank the file 50817 → 50746 bytes, 71 bytes / 18 tokens, without lowering the
   ceiling.

So the "new text is paid for by deleting text in the same file" discipline in the ratchet
header is satisfied by a real, measured deletion in this exact file — banked by #13760 a
few days earlier rather than in this PR. No re-wrap is involved anywhere: the row is
purely additive and every other byte of the file is untouched.

**The `CEILING_BASIS.from10402` reservation does not apply.** That header warns that
headroom on `objectstack-data` and `objectstack-platform` is not budget because it was
PR #10402's text priced ahead of its merge. The header itself then records that
reservation as spent at the `strippedInternalIds` re-measure, and fact 1 above is the same
thing observed on this row: re-pinned at measurement, zero headroom. The 18 tokens present
today accrued strictly after that, from #13760's deletions.

Because no ceiling moved, `scripts/check-skills-token-ratchet.mjs` is **not** in this
diff, and no maintainer ruling is being invoked as authorization for a raise. The
`objectstack-ui` CEILINGS row that draft PR #13972 moves is untouched here; that PR has
not landed on `main`, so there is no textual adjacency in the ratchet script to
reconcile. `main` was merged into this branch before opening (merge commit on
`684345458`) and brought only an unrelated `packages/qa/dogfood/vitest.config.ts` change.

## Verification

Gate union derived on the final head with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` — 15 families, the
union re-derived after the merge and unchanged. Run on final head `684345458`:

- **14 of 15 exit 0**, including the headline one:

  ```
  ✓ check-skills-token-ratchet: skills/objectstack-platform/SKILL.md is 12704 tokens (ceiling 12705; headroom 1).
  ✓ check-skills-token-ratchet: 38 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.
  ```

  and `check:skill-frame-sync` (4 frame copies isomorphic across 3 files),
  `check:skill-compatibility` (11 SKILL.md reconciled against 78 packages),
  `check:skill-identifier-liveness`, `check:doc-authoring`, `check:corpus-claim-drift`,
  `check:role-word`, `check:agent-test-spelling`, `check:pm-governed-merges`,
  `check:doc-formula-expressions`, `check:cross-package-test-inputs`,
  `check-ci-filter-parity`, `check-shard-attestation`.
- **1 NOT MEASURED, not red**: `node scripts/check-test-completeness.mjs` exits 3 with
  `PREREQUISITE NOT MET` — it parses a `turbo run test` log that CI tees and that a local
  family run has no way to produce. Its own text says the local reading is NOT MEASURED and
  that exit 3 is deliberately distinct from a finding's 1.
- `pnpm lint` (repo-wide `eslint . --no-inline-config`, an unconditional CI step) exit 0 —
  run in full, not narrowed.
- Two `PREREQUISITE NOT MET` results cleared by building first, not by waiving:
  `@objectstack/formula` then `@objectstack/lint`, after which
  `check:doc-formula-expressions` reports 22 record-scoped examples across 427 files clean.

## Changeset

None — `skip-changeset`, following the sweep-flight precedent: this diff is one prose row
in the published catalog and publishes nothing from any package. Every
`skills/**`-only commit in that flight landed on `main` with no `.changeset/` entry.

## Landing

`skills/**` is a governed surface. Draft, and it stays draft: no seat merges, queues, arms
auto-merge, or flips it ready. The maintainer's hand-merge is the landing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_