### PR TITLE
docs(pm): express the entry guard's self-test size as a floor, not a reading

### DIFF
--- a/scripts/pm/check-governed-merges.mjs
+++ b/scripts/pm/check-governed-merges.mjs
@@ -3498,13 +3498,23 @@ function runTestModeExitFor(paths) {
   return testVerdict(paths).governed ? EXIT_TEST_GOVERNED : EXIT_TEST_NOT_GOVERNED;
 }
 
-// `invokedDirectly` for the same reason line 810 carries it: this module is
-// imported for its exported predicates (`proxyRearmPlan` — see
-// scripts/pm/ci-failure.mjs), and an unguarded trigger ran THIS file's 77
-// assertions inside the importer's own `--self-test`, printing a second
-// summary and putting an unrelated file's failures on the importer's exit
-// code. A self-test is a mode of the file that is being RUN, never a side
-// effect of importing it.
+// `invokedDirectly` for the same reason the main-invocation guard above
+// carries it: this module is imported for its exported predicates
+// (`proxyRearmPlan` — see scripts/pm/ci-failure.mjs), and an unguarded
+// trigger ran this file's whole self-test inside the importer's own
+// `--self-test`, printing a second summary and putting an unrelated file's
+// failures on the importer's exit code. The suite was 77 assertions at PR
+// #9897, where this guard landed, and is now more than three times that: the
+// 77 is anchored to that PR and frozen as a historical fact, while the
+// multiple is a FLOOR and is written as one on purpose. The live figure is
+// whatever `--self-test` prints from `checked`; it moves on most edits to
+// this file and has never once gone down across this file's history, so a
+// floor stays true where a reading rots. Both figures that stood here had
+// rotted before anyone looked — 77 was written as THIS file's current size
+// and was by then off by a factor of three, and the neighbouring "line 810"
+// had drifted onto unrelated code — so do not "helpfully" refresh either
+// back into a reading. A self-test is a mode of the file that is being RUN,
+// never a side effect of importing it.
 if (invokedDirectly && process.argv.includes('--self-test')) {
   await selfTest();
 }


### PR DESCRIPTION
Fixes #13963

The docblock above this file's `--self-test` entry guard carried **two** figures frozen at PR #9897, and both had rotted. The card names one; reading the sentence turned up the other sitting beside it.

| figure as written | true at PR #9897 | true today | drift |
|:--|:--|:--|:--|
| "THIS file's **77** assertions" | 77 (measured, see below) | **255** | factor 3.3 |
| "for the same reason **line 810** carries it" | line 810 really was the main-invocation guard | line 810 is an unrelated `try {` in the regeneration predicate; the guard is at line 2336 | points at the wrong code |

Both were true when written and neither is anchored to the moment that made it true, so both read as present-tense claims about this file. That is exactly the defect class #13536 describes.

## The shape, copied from the sibling

Per triage, this follows what landed in `dispatch-gates.mjs` as `010518bb` rather than inventing a shape:

- the **77 is kept and anchored to PR #9897** as the historical fact it is (it was true there);
- **today's size is a FLOOR** — "more than three times that" — written as a floor on purpose, pointing at `--self-test`'s `checked` as the live reading;
- the **line number is replaced by a reference to the guard itself**, which cannot drift;
- a sentence says why it is a floor, and asks the next reader not to "helpfully" refresh either figure back into a reading.

Refreshing 77 to 255 was explicitly not done: it re-arms the identical defect one value later. No gate pins the figure to the live count either — #13536 rules that out, and this PR adds none.

## The floor premise, re-measured on THIS file

Triage required this premise be re-run here rather than inherited from the sibling. Across **all 13 commits that have ever touched this file** (introduced 2026-08-18, never renamed), static `assert(` call sites went:

```
22 -> 70 -> 70 -> 74 -> 74 -> 83 -> 112 -> 122 -> 153 -> 185 -> 198 -> 223 -> 248
UP: 10   FLAT: 2   DOWN: 0
```

**It has never once gone down**, so a floor stays true where a reading rots. The counting method reproduces both independent readings already on record — 70 static at `a065e46550b4` and 223 at `9c4c431fd` — which is what makes the sweep trustworthy rather than merely self-consistent.

The historical 77 is measured, not assumed: the file at `a065e46550b4` was run directly and printed `77 assertions`.

Two notes worth recording. The clone this ran in arrived **shallow** (floor 2026-08-30, 208 commits), where this file has only 2 commits of history and PR #9897's commit does not resolve at all — the premise is unmeasurable in that state and a sweep run there would have "confirmed" a 2-commit history. It was unshallowed first (28s, strictly additive; `--shallow-since` was avoided because it can silently *shorten*, as `scripts/pm/git-history.mjs` documents). Second, the live count is not even constant across environments: `--self-test` prints 255 in an installed tree and 253 without `node_modules`, where the generator-provenance row fails closed and says so on its `live:` line. Both are green and truthful — a further reason the prose should not carry a number as a reading.

## Verification

Gate union derived from the change set by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no hand-fed paths), run on final head **`226bbc000`**:

- **15 of 16 green**, including `pnpm check:pm-governed-merges` (`✓ 255 assertions`), `pnpm check:entry-guard`, `pnpm check:pm-dispatch-gates`, `node scripts/pm/bare-root-worklist.mjs --self-test` (both convention-triggered gates for editing a gate script), and `node scripts/check-skills-token-ratchet.mjs`.
- `node scripts/check-test-completeness.mjs` exits **3 = PREREQUISITE NOT MET**, recorded as **NOT MEASURED**, not as a red: it grades a saved `turbo run test` log, none exists locally, and CI passes the path on every invocation, so the branch is unreachable there.

No behaviour change: the guard and the self-test are untouched, and the count is identical either side of the diff — **255 at the merge base, 255 at head**. The diff is comment-only, one hunk, 17 insertions / 7 deletions.

Sibling card #13896 (same file) is closed, and no open PR touches this file, so nothing serialises against this one.

_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_