### PR TITLE
test(objectql,verify,runtime): declare OS_REGISTRY_LOG=warn in each suite's own vitest harness

### DIFF
--- a/packages/objectql/src/registry-log-level.test.ts
+++ b/packages/objectql/src/registry-log-level.test.ts
@@ -18,7 +18,18 @@ import { SchemaRegistry, REGISTRY_LOG_LEVELS } from './registry';
 describe('SchemaRegistry log-level gating (#3420)', () => {
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
   const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
-  beforeEach(() => { warn.mockClear(); debug.mockClear(); });
+  // This file's SUBJECT is `OS_REGISTRY_LOG`, so it owns that variable rather
+  // than inheriting it. The package's vitest harness declares
+  // `OS_REGISTRY_LOG=warn` for every worker (#13517), and without this
+  // `beforeEach` the FIRST case below ran at `'warn'` under a name that says
+  // `info` — green, because both of its expectations are negative. Measured,
+  // not reasoned: the premise assertion in that case fails with
+  // `expected 'warn' to be 'info'` when this line is removed.
+  beforeEach(() => {
+    delete process.env.OS_REGISTRY_LOG;
+    warn.mockClear();
+    debug.mockClear();
+  });
   afterEach(() => { delete process.env.OS_REGISTRY_LOG; });
 
   const reRegisterSameOwner = (r: SchemaRegistry) => {
@@ -28,6 +39,10 @@ describe('SchemaRegistry log-level gating (#3420)', () => {
 
   it('at the default (info) level, re-registering an owned object is silent — no warn, no debug', () => {
     const r = new SchemaRegistry({ multiTenant: false });
+    // The case's NAME is a premise about the level, so assert it rather than
+    // assume it: both expectations below are negative, so a quieter level
+    // satisfies them while measuring something this file never claimed.
+    expect(r.logLevel).toBe('info');
     reRegisterSameOwner(r);
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object'));
     expect(debug).not.toHaveBeenCalledWith(expect.stringContaining('Re-registering owned object'));
@@ -44,6 +59,7 @@ describe('SchemaRegistry log-level gating (#3420)', () => {
     const manifest = { id: 'com.test', name: 'Test', namespace: 'test', version: '1.0.0' } as any;
 
     const info = new SchemaRegistry({ multiTenant: false });
+    expect(info.logLevel).toBe('info');
     info.installPackage(manifest);
     info.installPackage(manifest); // same-package reload → "Overwriting package"
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Overwriting package'));

--- a/packages/objectql/vitest.config.ts
+++ b/packages/objectql/vitest.config.ts
@@ -4,6 +4,42 @@
 // vitest's defaults, deliberately — a key added here re-specifies behaviour
 // for every test file in the package (packages/cli/vitest.config.ts's header
 // records the incident that taught that).
+//
+// ── #13517: this suite asks the SchemaRegistry for quiet, DECLARATIVELY ─────
+//
+// Measured on THIS suite (one full `pnpm --filter @objectstack/objectql test`,
+// `origin/main` b1b7d6088a): 16,194 lines on the run's stdout, 4,744 of them
+// `[Registry] …`. 10,984 of the rest are the structured logger's
+// `<ts> INFO …` lines, which do not go through `console` at all and are NOT
+// what this key reaches (#13986) — so against the console-carried population
+// this suite emits, `[Registry]` is 4,744 of 5,210 = 91.1%, and 3,869 of those
+// are the single `Registered object:` line, emitted once per registered object
+// per registry construction across the package's 250 test files.
+//
+// `OS_REGISTRY_LOG` is `@objectstack/objectql`'s OWN published seam for that
+// verbosity (`SchemaRegistryOptions.logLevel` / `REGISTRY_LOG_LEVELS`,
+// registry.ts) — at `warn` the registry's private `log()` returns before
+// writing. What it does NOT silence is the diagnostics: the ADR-0005
+// `[Registry] Collision` lines go through a bare `console.warn` that the level
+// never gates, so a real shadowing still speaks here — measured, not inferred:
+// `registry-collision-order.test.ts` passes identically on both sides, and it
+// sets `logLevel = 'silent'` per registry anyway.
+//
+// ⛔ Two things this deliberately is NOT. It does not move the engine's
+// SHIPPED default (still `'info'` at registry.ts:1265, unchanged for every
+// production reader), and it does not make library code sniff
+// `process.env.VITEST` — a library that behaves differently under a test
+// runner would make every log reading in tests a reading of something other
+// than production. The request lives HERE, in the harness, where the test
+// author can see it.
+//
+// ⚠️ One test file in THIS package reads the same env var as its subject:
+// `registry-log-level.test.ts` pins how `OS_REGISTRY_LOG` resolves. It now
+// deletes the var in `beforeEach` (it already did in `afterEach`) and asserts
+// the level its "default" cases actually run at, so the harness key below
+// cannot silently re-point that file's premise. Without those two lines the
+// file's first case stays GREEN while testing `'warn'` under a name that says
+// `info` — measured red before they were added.
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -15,5 +51,9 @@ export default defineConfig({
     // Mechanism + measured costs: examples/app-showcase/vitest.config.ts.
     // Enforced repo-wide by scripts/check-console-intercept-disarm.mjs.
     disableConsoleIntercept: true,
+    // #13517: quiet the registry's per-item registration chatter — the
+    // engine's own `OS_REGISTRY_LOG` seam, not a change to its shipped
+    // default. Header docblock carries the measurement and the rationale.
+    env: { OS_REGISTRY_LOG: 'warn' },
   },
 });

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,5 +1,38 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
+// ── #13517: this suite asks the SchemaRegistry for quiet, DECLARATIVELY ─────
+//
+// Measured on THIS suite (one full `pnpm --filter @objectstack/runtime test`,
+// `origin/main` b1b7d6088a): 6,730 lines on the run's stdout, 1,155 of them
+// `[Registry] …`. 4,760 of the rest are the structured logger's `<ts> INFO …`
+// lines, which do not go through `console` at all and are NOT what this key
+// reaches (#13986).
+//
+// ⚠️ Read the share honestly, because this suite is NOT the dogfood one.
+// Against the console-carried population (1,957 lines) `[Registry]` is 1,155 —
+// **59%**, the largest single family but a long way from dogfood's 94.9%. The
+// remaining ~800 are a mixed tail this key cannot reach: `[sql-driver] while
+// creating/syncing table …` column reports, `[HonoServerPlugin] Server
+// stopped`, `Paged read of … is NOT deterministic`, `[action-audit] …` and
+// `[Protocol] DB hydration skipped …`. So the declaration below is worth its
+// line here, and it is also not the whole story here — quieting the rest is a
+// different question about those specific call sites, not a log level.
+//
+// `OS_REGISTRY_LOG` is `@objectstack/objectql`'s OWN published seam for that
+// verbosity (`SchemaRegistryOptions.logLevel` / `REGISTRY_LOG_LEVELS`,
+// registry.ts) — at `warn` the registry's private `log()` returns before
+// writing. What it does NOT silence is the diagnostics: the ADR-0005
+// `[Registry] Collision` lines go through a bare `console.warn` that the level
+// never gates, so a real shadowing still speaks here.
+//
+// ⛔ Two things this deliberately is NOT. It does not move the engine's
+// SHIPPED default (still `'info'` at objectql's registry.ts:1265, unchanged
+// for every production reader), and it does not make library code sniff
+// `process.env.VITEST` — a library that behaves differently under a test
+// runner would make every log reading in tests a reading of something other
+// than production. The request lives HERE, in the harness, where the test
+// author can see it.
+
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 
@@ -120,6 +153,11 @@ export default defineConfig({
     // Mechanism + measured costs: examples/app-showcase/vitest.config.ts.
     // Enforced repo-wide by scripts/check-console-intercept-disarm.mjs.
     disableConsoleIntercept: true,
+    // #13517: quiet the registry's per-item registration chatter — the
+    // engine's own `OS_REGISTRY_LOG` seam, not a change to its shipped
+    // default. Header docblock carries the measurement and the rationale,
+    // including the tail this key does NOT reach in this package.
+    env: { OS_REGISTRY_LOG: 'warn' },
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],

--- a/packages/verify/vitest.config.ts
+++ b/packages/verify/vitest.config.ts
@@ -4,6 +4,31 @@
 // vitest's defaults, deliberately — a key added here re-specifies behaviour
 // for every test file in the package (packages/cli/vitest.config.ts's header
 // records the incident that taught that).
+//
+// ── #13517: this suite asks the SchemaRegistry for quiet, DECLARATIVELY ─────
+//
+// Measured on THIS suite (one full `pnpm --filter @objectstack/verify test`,
+// `origin/main` b1b7d6088a): 5,670 lines on the run's stdout, 2,323 of them
+// `[Registry] …`. 3,113 of the rest are the structured logger's `<ts> INFO …`
+// lines, which do not go through `console` at all and are NOT what this key
+// reaches (#13986) — so against the console-carried population this suite
+// emits, `[Registry]` is 2,323 of 2,557 = 90.8%. This package boots real app
+// stacks in its harness, so the count is per-boot registration chatter.
+//
+// `OS_REGISTRY_LOG` is `@objectstack/objectql`'s OWN published seam for that
+// verbosity (`SchemaRegistryOptions.logLevel` / `REGISTRY_LOG_LEVELS`,
+// registry.ts) — at `warn` the registry's private `log()` returns before
+// writing. What it does NOT silence is the diagnostics: the ADR-0005
+// `[Registry] Collision` lines go through a bare `console.warn` that the level
+// never gates, so a real shadowing still speaks here.
+//
+// ⛔ Two things this deliberately is NOT. It does not move the engine's
+// SHIPPED default (still `'info'` at objectql's registry.ts:1265, unchanged
+// for every production reader), and it does not make library code sniff
+// `process.env.VITEST` — a library that behaves differently under a test
+// runner would make every log reading in tests a reading of something other
+// than production. The request lives HERE, in the harness, where the test
+// author can see it.
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -15,5 +40,9 @@ export default defineConfig({
     // Mechanism + measured costs: examples/app-showcase/vitest.config.ts.
     // Enforced repo-wide by scripts/check-console-intercept-disarm.mjs.
     disableConsoleIntercept: true,
+    // #13517: quiet the registry's per-item registration chatter — the
+    // engine's own `OS_REGISTRY_LOG` seam, not a change to its shipped
+    // default. Header docblock carries the measurement and the rationale.
+    env: { OS_REGISTRY_LOG: 'warn' },
   },
 });


### PR DESCRIPTION
Part of #13517 — item 1 of the three-part remainder that card carries. It stays open: the `packages/rest` stack-dump residual and the deferred log-level ratchet are still on it, and the structured-logger half is #13986.

`b79ddf17df` quieted `packages/qa/dogfood` with one declarative `OS_REGISTRY_LOG=warn` in that suite's own vitest harness. This applies the same seam to the other three app-booting suites — `packages/objectql`, `packages/verify`, `packages/runtime` — each in its own config, each with its own measurement in the docblock.

## Measured per suite, not inferred from dogfood

One full `pnpm --filter PKG test` per suite per side, all six runs through the shared verify lock. Baseline at `origin/main` `b1b7d6088a`; after-side at this branch's head `0fc8e11c18`.

| suite | stdout lines | `[Registry]` lines | console-carried lines | test outcome |
|:--|--:|--:|--:|:--|
| `objectql` before | 16,194 | 4,744 | 5,189 | 250 files / 4,322 tests passed |
| `objectql` after | 11,502 | **65** | **510** | 250 files / 4,322 tests passed |
| `verify` before | 5,670 | 2,323 | 2,551 | 9 files / 48 tests passed |
| `verify` after | 3,347 | **0** | **228** | 9 files / 48 tests passed |
| `runtime` before | 6,730 | 1,155 | 1,964 | 202 files / 3,011 tests passed |
| `runtime` after | 5,584 | **9** | **818** | 202 files / 3,011 tests passed |

"console-carried" excludes the structured logger's `TIMESTAMP INFO ...` lines, which never go through `console` and are a different question (#13986). Test outcomes are identical on both sides of every suite, and the non-`[Registry]` line counts are identical to the line — 445 / 228 / 809 before and after — so this key moved exactly the family it names and nothing else.

The zero in the `verify` row is a real reading, not an unfired grep: the same pattern on the same suite's baseline log counts 2,323, and `grep -c "Test Files"` on the after-side log answers 1.

## Where the route does NOT do what dogfood did

⚠️ `packages/runtime` is not a second dogfood, and its docblock says so. `[Registry]` is **59%** of that suite's console-carried output, not dogfood's 94.9%. The ~800 lines left are a mixed tail no log level reaches: `[sql-driver] while creating/syncing table ...` column reports, `[HonoServerPlugin] Server stopped`, `Paged read of ... is NOT deterministic`, `[action-audit] ...`, `[Protocol] DB hydration skipped ...`. The declaration still earns its line there (1,155 lines removed), and it is also not the whole story there.

`objectql` (91.5%) and `verify` (91.3%) do behave like dogfood.

## One repair the declaration made necessary, named here because it is a test edit

`packages/objectql/src/registry-log-level.test.ts` is the pin for how `OS_REGISTRY_LOG` resolves — so this package's harness key lands on that file's own subject. The file already deleted the variable in `afterEach`; the symmetric `beforeEach` was missing, so the FIRST case ran at `warn` under a name that says `info`, and stayed **green**, because both of its expectations are negative ("not called").

Measured, not reasoned. With a premise assertion added and the `beforeEach` withheld:

```
AssertionError: expected 'warn' to be 'info'
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

With the `beforeEach` in place: `2 passed (2) / 19 passed (19)` for that file plus `registry-collision-order.test.ts`. Both "default level" cases now assert the level they actually run at, so no future harness key can silently re-point them. No test was skipped, disabled or re-baselined; two assertions were added and one hook body was widened. No rebuild leg applies to that measurement — the file imports `./registry` by relative path, so vitest transforms the source and no `dist` is in the path.

## The near-miss, measured rather than trusted

`registry-collision-order.test.ts` asserts on `[Registry] Collision` lines. Those go through a bare `console.warn` the level never gates, and the file sets `logLevel = 'silent'` per registry anyway. Both sides pass identically, and the after-side logs still carry the collision lines — 16 in `objectql`, 2 in `runtime`. A real shadowing still speaks.

## What this deliberately is not

The engine's shipped default is untouched — still `'info'` at `packages/objectql/src/registry.ts:1265` — and no library code learns what a test runner is. The request lives in each harness, declaratively, where the test author can see it. `check-console-intercept-disarm.mjs` is green: the `disableConsoleIntercept` line is untouched in all three configs and the new key sits beside it.

## Verification

All gates run at `0fc8e11c18`, exit codes captured before any pipe.

- `pnpm lint` (repo-wide `eslint . --no-inline-config`) — exit 0, no narrowing claimed
- `pnpm check:nul-bytes` — exit 0, `7667 text file(s) ... no raw ASCII control bytes`
- 26 of the 27 families named by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, plus `check-console-intercept-disarm` — all exit 0
- `pnpm --filter` typecheck on all three packages — exit 0
- NOT MEASURED here, owned by CI, all three exit 3 = PREREQUISITE NOT MET rather than a finding: `check-test-completeness` (wants a saved `turbo run test` log), `check:dual-build-cjs-loads` and `check:type-check-debt` (want the whole workspace built)
- `packages/objectql`'s `tsc` program excludes `**/*.test.ts`, so its green typecheck says nothing about the edited test file — verified with `--listFiles` (0 test files in the program, `registry.ts` present as the control). The edited file was type-checked directly instead, in a throwaway project over the package's own options: 0 errors, file present in the program.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_