### PR TITLE
fix(metadata-protocol): add the missing `typecheck` script and repair all 63 test-layer type errors, graduating the package out of the DEBT ledger

### DIFF
--- a/packages/metadata-protocol/package.json
+++ b/packages/metadata-protocol/package.json
@@ -27,6 +27,7 @@
     "build": "tsup && node ../../scripts/check-dts-emitted.mjs",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/metadata-protocol/src/mutation-listeners.test.ts
+++ b/packages/metadata-protocol/src/mutation-listeners.test.ts
@@ -20,7 +20,12 @@ function makeProtocol() {
   return new ObjectStackProtocolImplementation({} as any);
 }
 
-const evt = (over: Partial<MetadataMutationEvent> = {}): MetadataMutationEvent => ({
+// `body` mirrors `runMutationProjector`'s own declared parameter
+// (`MetadataMutationEvent & { body?: unknown }`) — the projector cases below
+// pass one, and the bare `Partial<MetadataMutationEvent>` rejected it.
+const evt = (
+  over: Partial<MetadataMutationEvent> & { body?: unknown } = {},
+): MetadataMutationEvent & { body?: unknown } => ({
   type: 'hook',
   name: 'rebind_probe_hook',
   state: 'active',

--- a/packages/metadata-protocol/src/protocol.batch-atomic.test.ts
+++ b/packages/metadata-protocol/src/protocol.batch-atomic.test.ts
@@ -38,7 +38,10 @@ function makeTransactionalEngine(opts: { driverCanTransact?: boolean } = {}) {
     const rollbacks: unknown[] = [];
     const handle = { id: 'trx-1' };
 
-    const insert = vi.fn(async (_object: string, data: any) => {
+    // Third parameter declared because the write path PASSES it and the
+    // assertions below read `call[2]`: a 2-arity mock made that a tuple
+    // with no element at index 2.
+    const insert = vi.fn(async (_object: string, data: any, _options?: any) => {
         if (data?.title === POISON) throw new Error('insert exploded');
         return { id: `rec-${insert.mock.calls.length}`, ...data };
     });

--- a/packages/metadata-protocol/src/protocol.stored-conversions.test.ts
+++ b/packages/metadata-protocol/src/protocol.stored-conversions.test.ts
@@ -44,7 +44,12 @@ function matches(r: Row, where: Record<string, unknown>): boolean {
     return true;
 }
 
-function makeStubEngine(seedRows: Array<Partial<Row> & { type: string; name: string; metadata: unknown }>) {
+// `metadata` is `Omit`-ed out of the `Partial<Row>` half, never merely
+// intersected over it: `string & unknown` is `string`, so a plain
+// intersection refuses every body written as an object literal.
+function makeStubEngine(
+    seedRows: Array<Omit<Partial<Row>, 'metadata'> & { type: string; name: string; metadata: unknown }>,
+) {
     let nextId = 0;
     const rows: Row[] = seedRows.map((r) => ({
         id: `r_${++nextId}`,

--- a/packages/metadata-protocol/src/protocol.stored-migration.test.ts
+++ b/packages/metadata-protocol/src/protocol.stored-migration.test.ts
@@ -57,7 +57,12 @@ function matches(r: Record<string, any>, where: Record<string, unknown>): boolea
  * actually observable.
  */
 function makeStubEngine(
-    seedRows: Array<Partial<Row> & { type: string; name: string; metadata: unknown }>,
+    // `metadata` is `Omit`-ed out of the `Partial<Row>` half, never merely
+    // intersected over it: on the row `metadata` is the STORED string, and
+    // `string & unknown` is `string`, so a plain intersection refuses every
+    // body written as an object literal — which is the seeding convenience
+    // this harness exists for, and what it already does at runtime below.
+    seedRows: Array<Omit<Partial<Row>, 'metadata'> & { type: string; name: string; metadata: unknown }>,
 ) {
     let nextId = 0;
     const tables = new Map<string, Record<string, any>[]>();

--- a/packages/metadata-protocol/src/seed-loader-composite-external-id.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-composite-external-id.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-deferred-dropped.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-deferred-dropped.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-deferred-failure.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-deferred-failure.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-engine-schema-fallback.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-engine-schema-fallback.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-multi-value-reference.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-multi-value-reference.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-replay.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-replay.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-retry.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-retry.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-state-machine-exempt.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-state-machine-exempt.test.ts
@@ -193,7 +193,7 @@ describe('seed loader — state_machine initialStates exemption (#3433)', () => 
     // fallback), its options must carry the exemption flag — that is what the
     // engine reads to skip the state_machine rule.
     const writeCalls = [
-      ...(engine.insertMany as any).mock.calls,
+      ...((engine as any).insertMany).mock.calls,
       ...(engine.insert as any).mock.calls,
     ].filter(([obj]) => obj === 'showcase_project');
     expect(writeCalls.length).toBeGreaterThan(0);

--- a/packages/metadata-protocol/src/seed-loader-state-machine-exempt.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-state-machine-exempt.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, vi } from 'vitest';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate, type EngineFindOneQueryInput } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/seed-loader-summary-stale.test.ts
+++ b/packages/metadata-protocol/src/seed-loader-summary-stale.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { SeedLoadResultSchema, SeedLoaderResultSchema } from '@objectstack/spec/data';
-import { SeedLoaderService } from './seed-loader';
+import { SeedLoaderService } from './seed-loader.js';
 import type { IDataEngine, IMetadataService } from '@objectstack/spec/contracts';
 import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, assertEngineFindOnePredicate } from '@objectstack/metadata-core';
 

--- a/packages/metadata-protocol/src/sys-metadata-repository.history-counters.test.ts
+++ b/packages/metadata-protocol/src/sys-metadata-repository.history-counters.test.ts
@@ -334,7 +334,7 @@ describe('#4867 — history counters are never invented from a failed read', () 
       expect(infoSpy).toHaveBeenCalledTimes(1);
       expect((infoSpy.mock.calls[0] as [string])[0]).toMatch(/readable again/i);
       // Numbering resumes after the surviving max — never from 1 again.
-      expect(engine.committed().at(-1)).toEqual({
+      expect(engine.committed().slice(-1)[0]).toEqual({
         name: 'case_grid',
         version: 3,
         event_seq: 4,

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -677,15 +677,6 @@ const DEBT = {
       + 'metadata.test.ts (34) and register-notifies-watchers.test.ts (16) do still hold 50 of the 89, '
       + 'but that is over HALF -- the "two thirds" claimed here was true at neither 92 nor 89.',
   },
-  '@objectstack/metadata-protocol': {
-    errors: 63,
-    note: 'code-tier 40 (TS2322 x34, TS2532/TS2493 x2 each, TS2353, TS2339); config-tier 10 (TS2835 x9, '
-      + 'TS2550); noise 13 (TS7006). Re-measured 63 at 5ab08428 -- the 2.25x drift that opened #5278, and '
-      + 'the entry whose note was most misleading: it read "code-tier 9, the rest config-tier and noise", '
-      + 'while code-tier alone is now 40. 27 of the TS2322 are in protocol.stored-migration.test.ts and 10 '
-      + 'in seed-loader-multi-value-reference.test.ts, so this is concentrated debt in two files rather '
-      + 'than a package-wide drizzle -- read it as two repairs, not as forty.',
-  },
   '@objectstack/observability': {
     errors: 11,
     note: 'all code-tier (TS2554 wrong arity x10, TS2552).',
@@ -1898,9 +1889,12 @@ function workspacePackages() {
 //     "the workspace root itself: code-tier 4 ..." qualifies);
 //   * a tier counted twice, or a further `code-tier 9`-shaped count ANYWHERE
 //     later in the note, means the note is quoting its own history and the
-//     entry is skipped. metadata-protocol quotes the misleading note #5278
-//     found ("code-tier 9, the rest config-tier and noise") and is skipped for
-//     exactly that reason -- correct entry, no verdict;
+//     entry is skipped. metadata-protocol's entry quoted the misleading note
+//     #5278 found ("code-tier 9, the rest config-tier and noise") and was
+//     skipped for exactly that reason -- correct entry, no verdict. That entry
+//     has since GRADUATED (the package declares `typecheck` and its 63 errors
+//     are repaired), so the rule's live example is the self-test case below
+//     rather than a ledger row you can still read here;
 //   * per-code tallies (`TS2835 x72, TS7006 x49, ...`) are NOT summed. They are
 //     partial by construction, and the worked example this rule was written
 //     against says why: `@objectstack/rest`'s tally summed to 147 while saying
@@ -4206,9 +4200,11 @@ function selfTest() {
     },
     {
       // The false-positive guard, and the reason the rule abstains rather than
-      // reasons: metadata-protocol's real note quotes the misleading one #5278
-      // found. Reading either count as the entry's own would red a correct
-      // entry, which is worse than the silence this check replaces.
+      // reasons: metadata-protocol's real note quoted the misleading one #5278
+      // found (that entry has since graduated, which is why this synthetic case
+      // now carries the shape). Reading either count as the entry's own would
+      // red a correct entry, which is worse than the silence this check
+      // replaces.
       label: 'a note quoting its own history is SKIPPED, not guessed at',
       packages: [],
       root: { name: 'root', scripts: { typecheck: 'turbo run typecheck' } },


### PR DESCRIPTION
Fixes #13978

Route **(a) FIX** — chosen on the taxonomy, not on effort appetite. All of this
package's `tsc --noEmit` errors are repaired, the `typecheck` script is added,
and the package **graduates out of the DEBT ledger** in this same PR.

> Notation: TypeScript generics are written with **square** brackets throughout
> this body (`Omit[Partial[Row], 'metadata']`). The GitHub body sanitizer eats
> angle-bracket fragments, including inside backticks.

## The count is 63, not 159 — and it is already in a ledger

Two corrections to the card, both measured on current `main`:

**1. The fresh count is 63.** Re-measured with the dependency closure built
first: `tsc --noEmit -p tsconfig.json` reports **63 error lines, all 63 in
`*.test.ts`, zero in non-test source** (the card's 159 was measured on
`aee1fd9ec2`). The card's three named offenders reproduce to the unit —
`protocol.stored-migration.test.ts` 27, `seed-loader-multi-value-reference.test.ts`
10, `protocol.stored-conversions.test.ts` 7 — so the difference is not those
files. 63 is independently corroborated below.

**2. "Nothing runs `tsc` over this package" is no longer true.** The package
carries a `DEBT` entry in `scripts/check-type-check-coverage.mjs`, and its
recorded number is **63** with a per-code composition that matches this
measurement exactly, code for code:

| code | ledger note | measured here |
|---|---|---|
| TS2322 | x34 | 34 |
| TS7006 | 13 (noise) | 13 |
| TS2835 | x9 | 9 |
| TS2532 / TS2493 | x2 each | 2 / 2 |
| TS2550 | x1 | 1 |
| TS2353 / TS2339 | x1 each | 1 / 1 |
| **total** | **63** | **63** |

CI's `typecheck-debt` lane runs `pnpm check:type-check-debt`, whose `MEASURED`
invariant **re-runs the package's own `tsc --noEmit`** and reds if the count
exceeds the recorded one. So the test surface was already type-checked in CI —
as a **shrink-only ratchet tolerating 63**, not as a gate tolerating zero. That
is a materially smaller and *declared* gap than the card describes, and it is
the gap this PR closes.

## Taxonomy: 63 errors, 6 root causes, 2 of them dominant

Grouped by root cause rather than by code:

| # | root cause | errors | repair |
|---|---|---|---|
| 1 | `metadata` collapsing to `string` in the seed-row parameter type | 34 | 2 lines |
| 2 | extensionless `./seed-loader` import under NodeNext | 22 | 9 lines |
| 3 | 2-arity `insert` mock read at `call[2]` | 4 | 1 line |
| 4 | `evt` helper narrower than the projector it feeds | 1 | 1 line |
| 5 | `insertMany` not on the declared `IDataEngine` return type | 1 | 1 line |
| 6 | `.at(-1)` needs lib ES2022 | 1 | 1 line |

**They collapse.** Two causes carry 56 of the 63, and the ledger's own note
already said so: *"read it as two repairs, not as forty."* That is the criterion
— route (a) was chosen because the population is concentrated and mechanical,
which is exactly the condition under which (a) is cheap and strictly better than
declaring the surface unchecked.

### Root cause 1 (34 errors) — the repair was already written down in this package

`makeStubEngine` in the two affected files declared its parameter as
`Partial[Row] & { type, name, metadata: unknown }`. On the row `metadata` is the
**stored string**, and `string & unknown` is `string` — so the plain intersection
refuses every body written as an object literal, which is the entire seeding
convenience the harness exists for. Both harnesses already did
`typeof r.metadata === 'string' ? r.metadata : JSON.stringify(r.metadata)` at
runtime: the declared type contradicted the implementation beside it.

Three sibling test files in this same package already use the correct form, and
one of them states the reason verbatim:

> `metadata` is `Omit`-ed out of the `Partial[Row]` half rather than merely
> intersected over it: on the row `metadata` is the STORED string, and
> `string & unknown` is `string`, so a plain intersection refuses every body
> written as an object literal — the seeding convenience this harness exists
> for. Stated once, here, so the fixtures below need no casts.

So this is drift back to an idiom the package had already adjudicated, not a new
shape. Two of the 34 wore a different face (`Type '{ name, label }' is not
assignable to type 'string'`) — the same cause showing `metadata` already
collapsed to `string`.

### Root cause 2 (22 errors) — one broken import, and the cascade it caused

Nine test files imported `'./seed-loader'` without the extension. Under
NodeNext that does not resolve, so every symbol it names becomes `any` — which
is where the 13 TS7006 came from. AGENTS.md predicts this exact shape ("a pile
of TS7006 implicitly-any is usually one broken import upstream ... fix the
extension first and re-measure"), and the re-measure confirms it: **63 to 41**,
with the 9 TS2835 and all 13 TS7006 clearing together from one 9-line codemod.

`'./seed-loader.js'` is not a preference here: 8 other files in this package
already spell it that way, `index.ts` among them, and these 9 were the **only**
extensionless relative imports in the entire package.

## Evidence

Measured at `381db66f4e`, the final commit of this branch, dependency closure
built first.

- `pnpm --filter @objectstack/metadata-protocol typecheck` — **exit 0**
  (63 to 41 after cause 2, to **0** after all six).
- `pnpm --filter @objectstack/metadata-protocol test` — **exit 0**,
  `Test Files 148 passed | 2 skipped (150)`, `Tests 2060 passed | 10 skipped (2070)`.
  The 2/10 skips are pre-existing; this PR adds no `.skip`, `.only`, `@ts-ignore`
  or `eslint-disable` (verified over the diff).
- **The zero is not vacuous:** `tsc --listFiles` puts **150 of 150** `*.test.ts`
  files in the program, including all four of the most-repaired files.
- `pnpm check:type-check-coverage` — **exit 0**, and its own verdict line moves
  from 12 ledger entries to 11: `67/78 workspace packages type-checked (plus the
  root), 11 in the DEBT ledger (309 frozen raw errors)`. 372 minus 309 = **63**,
  the entry this PR retires.
- 39 further gate families derived by `node scripts/pm/dispatch-gates.mjs
  --repo objectstack-ai/objectstack` — all **exit 0**. Two returned **exit 3
  (PREREQUISITE NOT MET, nothing measured, not a pass)**:
  `check:dual-build-cjs-loads` and `check-test-completeness.mjs`, both needing a
  full workspace build/test summary this seat did not run. CI runs both with the
  prerequisite met.

### `turbo` behaviour, verified rather than inherited (with a firing control)

The card's claim that `turbo run typecheck` runs nothing for a script-less
package is **correct, and the dry run alone would not have shown it**:

- **Dry-run graph** lists `@objectstack/core#typecheck` — with
  `command: 'NONEXISTENT'`.
- **Real run**, `turbo run typecheck --filter=@objectstack/core`: **exit 0**,
  `Tasks: 3 successful` — and those three are `spec:build`, `types:build`,
  `metadata-core:build`, the `^build` dependencies. `core:typecheck` appears
  **nowhere** in the run output.
- **Firing positive control**, same command shape against this package now that
  it declares the script: `@objectstack/metadata-protocol:typecheck: cache miss,
  executing` then `tsc --noEmit`, **14 tasks**. The task really does run once the
  script exists, which is also the proof that this PR puts the package into the
  `typecheck-workspace` lane.

### The shrink-only ratchet does not count up

`check:type-check-debt` returns **exit 3** locally (PREREQUISITE NOT MET — it
refuses to measure without the full built closure, deliberately, since an
unbuilt closure measures a different world). **Declared narrowing:** rather than
run that repo-level sweep, this seat measured the only coupling that could move
another entry — `packages/rest` is the one ledgered package whose tsconfig
`paths` redirects `@objectstack/metadata-protocol` into the producer's
**source**. Its test program contains **23 metadata-protocol source files and 0
`*.test.ts`**; none of the 15 files this PR edits is among them. So no other
ledger entry can move, and this package's own entry is **deleted, never raised**.

## Scope

⛔ **Not expanded to the sibling packages.** Triage measured 12 of 73 packages
with no `typecheck` script, `packages/core` among them. Those 159 — now 63 —
errors are this package's; every other package has its own population needing
its own triage. No script was added anywhere else. `packages/core` is untouched
and stays in the ledger.

**One bounded in-place edit is declared here** rather than left implicit: two
prose comments in `scripts/check-type-check-coverage.mjs` made present-tense
claims about the entry this PR deletes ("metadata-protocol quotes the misleading
note ... and is skipped for exactly that reason — correct entry"). Left as-is
they would describe a ledger row that no longer exists, which is the note-rot
failure that file legislates against. Both are now past tense and point at the
synthetic self-test case that carries the shape. Comment-only; the rule and its
self-test fixtures are unchanged.

**Non-test source: untouched.** The STOP condition for route (a) was that the
compiler would demand a behaviour-adjacent change; it did not. Every repair is a
test file, and the two that looked producer-shaped were not: `body` is already
declared on the projector's own parameter
(`MetadataMutationEvent & { body?: unknown }`) and only the test helper was
narrower; `insertMany` is already on the fixture and only the helper's declared
return type hid it.

## Changeset

**None — `skip-changeset`.** This PR releases nothing: 13 test files, a
CI-internal gate script, and one dev-only `scripts` entry in a manifest. No
`src/` non-test source, no published behaviour, no consumer-observable change.
That is the gate's own prescription for the tests-only / CI-internal-script case.
The label is applied on the PR.

`Clause-②`: **no.** Path limb — nothing under `packages/spec/src/**`. Content
limb — no accept/reject behaviour moves and no published surface changes; a
`typecheck` script is not shipped to consumers, and the diff reached no non-test
source, so the condition the PM flagged as the one thing that would flip this
did not occur.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_