### PR TITLE
fix(metadata): canonicalise the timestamps `migrateSysNotificationToEvent` writes

### DIFF
--- a/.changeset/migration-timestamp-canonicalisation.md
+++ b/.changeset/migration-timestamp-canonicalisation.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/metadata": patch
+---
+
+fix(metadata): `migrateSysNotificationToEvent` writes canonical ISO timestamps, not `Date.prototype.toString` (#13998)
+
+`selectLegacyRows` reads the legacy `sys_notification` table through
+`driver.raw`/`execute` — a door that does not run `formatOutput`, so none of its
+repairs apply. On SQLite the legacy stamps come back as canonical ISO text and
+`String(row.created_at)` is the identity. On Postgres and MySQL an instant
+column materialises as a JS `Date`, so the migration wrote
+
+```
+Sun Aug 30 2026 18:19:25 GMT+0800 (China Standard Time)
+```
+
+into `created_at` on the new `sys_inbox_message` row and into `created_at` / `at`
+on the new `sys_notification_receipt` row — whole seconds in the **migrating
+host's** zone with the milliseconds dropped, or a value no dialect's timestamp
+grammar accepts at all. The migration is one-way, so that spelling is what the
+platform would carry afterwards.
+
+Both stamps are now canonicalised at the migration, matching the repo's existing
+correct form: a `Date` is rendered with `toISOString()`, ISO text passes through
+untouched. Neither column could be repaired further upstream —  `created_at` is a
+builtin audit column that `formatOutput` repairs only in its `if (this.isSqlite)`
+arm, and `read_at` is a legacy column ADR-0030 removed from the object, so it is
+not a declared `Field.datetime` either and no coercion could ever reach it.
+
+Pinned with a hand-made `Date` driven through the migration's read path under a
+forced process zone, which is what breaks the SQLite identity that kept the
+existing cases green while the defect was live.

--- a/packages/metadata/src/migrations/migrate-sys-notification-to-event.test.ts
+++ b/packages/metadata/src/migrations/migrate-sys-notification-to-event.test.ts
@@ -152,3 +152,134 @@ describe('migrateSysNotificationToEvent', () => {
         expect(result.error).toContain('.raw');
     });
 });
+
+// ---------------------------------------------------------------------------
+// [#13998] What this migration WRITES, when the legacy row hands out a `Date`.
+//
+// `selectLegacyRows` reads through `driver.raw`/`execute` — a door that does
+// not run `formatOutput`, so none of its repairs apply. On SQLite the legacy
+// stamps come back as canonical ISO TEXT and `String(row.created_at)` is the
+// IDENTITY, which is why every case above stayed green while the defect was
+// live. On Postgres and MySQL an instant column materialises as a JS `Date`
+// (pinned in `driver-sql/src/sql-driver-13567-audit-stamp-materialisation.test.ts`),
+// and this migration is one-way: whatever spelling lands is what the platform
+// carries afterwards.
+//
+// `@objectstack/metadata` has no driver dependency and must not grow one — the
+// layering runs the other way — so, exactly like the OCC seam's own regression
+// suite, the discriminating input here is a HAND-MADE `Date`. That is the whole
+// point of these cases: they break the SQLite identity the cases above rely on.
+// ---------------------------------------------------------------------------
+
+/** The instant from the production report, kept verbatim (#13567 / #13382). */
+const REPORTED_INSTANT = '2026-08-30T10:19:25.947Z';
+/** A second instant, so the receipt's `at` cannot pass by matching `created_at`. */
+const REPORTED_READ_INSTANT = '2026-08-31T02:03:04.567Z';
+
+/** Canonical audit-timestamp text — what SQLite stores and what must be written. */
+const ISO_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/**
+ * Run `body` with the process pinned to `tz`, then restore.
+ *
+ * Forced rather than required so these cases are non-vacuous on any runner:
+ * Test Core runs at UTC, a developer runs at whatever their laptop is set to.
+ * Restoring rather than assuming matters because vitest reuses a worker across
+ * files — a leaked `TZ` would silently re-zone whatever runs next in this
+ * process. Mirrors `underProcessZone` in the driver-side pin.
+ */
+async function underProcessZone<T>(tz: string, body: () => Promise<T> | T): Promise<T> {
+    const previous = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+        return await body();
+    } finally {
+        if (previous === undefined) delete process.env.TZ;
+        else process.env.TZ = previous;
+    }
+}
+
+describe('#13998 the timestamp spelling written into the new rows', () => {
+    it('control — `String(Date)` is NOT the canonical spelling (the input discriminates)', async () => {
+        const value = new Date(REPORTED_INSTANT);
+        expect(value.getMilliseconds(), 'the fixture is vacuous without sub-second digits').toBe(947);
+
+        const spelled = await underProcessZone('Asia/Shanghai', () => String(value));
+        // The prefix only: the trailing `(China Standard Time)` is the one
+        // implementation-defined part of `toString`.
+        expect(spelled.startsWith('Sun Aug 30 2026 18:19:25 GMT+0800')).toBe(true);
+        // Whole seconds in the PROCESS zone: the milliseconds are gone.
+        expect(Date.parse(spelled)).toBe(value.getTime() - value.getMilliseconds());
+        expect(spelled).not.toBe(REPORTED_INSTANT);
+        expect(spelled).not.toMatch(ISO_Z);
+        // …and the canonical rendering of the same instant is zone-independent.
+        expect(value.toISOString()).toBe(REPORTED_INSTANT);
+    });
+
+    it('canonicalises a `Date` created_at/read_at into ISO on inbox, receipt and receipt.at', async () => {
+        const createdAt = new Date(REPORTED_INSTANT);
+        const readAt = new Date(REPORTED_READ_INSTANT);
+        const d = fakeDriver([
+            {
+                id: 'n1', recipient_id: 'u1', type: 'mention', title: 'You were mentioned',
+                body: 'hi', url: '/x', actor_name: 'Ada', is_read: 1,
+                // The discriminating input: what Postgres/MySQL actually hand out.
+                read_at: readAt, created_at: createdAt, organization_id: 'org_1',
+            },
+        ]);
+        const e = fakeEngine();
+
+        const result = await underProcessZone('Asia/Shanghai', () =>
+            migrateSysNotificationToEvent({ driver: d.driver, data: e.engine }));
+
+        expect(result.status).toBe('migrated');
+        expect(result.migrated).toBe(1);
+
+        const inbox = e.inserts.find((i) => i.object === 'sys_inbox_message')!;
+        const receipt = e.inserts.find((i) => i.object === 'sys_notification_receipt')!;
+
+        // Every written stamp is canonical ISO-Z text — not a `Date`, and not a
+        // `Date.prototype.toString` rendering carrying the migrating host's zone.
+        for (const [where, written] of [
+            ['inbox.created_at', inbox.row.created_at],
+            ['receipt.created_at', receipt.row.created_at],
+            ['receipt.at', receipt.row.at],
+        ] as const) {
+            expect(typeof written, `${where} must be written as text`).toBe('string');
+            expect(written as string, `${where} must be canonical ISO-Z`).toMatch(ISO_Z);
+            // The zone the OLD spelling would have baked in is absent.
+            expect(written as string, `${where} must not carry a GMT offset`).not.toContain('GMT');
+        }
+
+        // The instants themselves are preserved to the millisecond — the half
+        // `String(Date)` silently dropped.
+        expect(inbox.row.created_at).toBe(REPORTED_INSTANT);
+        expect(receipt.row.created_at).toBe(REPORTED_INSTANT);
+        expect(receipt.row.at).toBe(REPORTED_READ_INSTANT);
+        // …and `at` is the READ stamp, not `created_at` echoed back.
+        expect(receipt.row.at).not.toBe(receipt.row.created_at);
+
+        // The zone was restored rather than leaked into whatever runs next.
+        expect(process.env.TZ).not.toBe('Asia/Shanghai');
+    });
+
+    it('leaves canonical ISO text exactly as it found it (the SQLite path is unchanged)', async () => {
+        const d = fakeDriver([
+            {
+                id: 'n1', recipient_id: 'u1', type: 'mention', title: 'hi', body: null,
+                url: null, actor_name: null, is_read: 1, read_at: REPORTED_READ_INSTANT,
+                created_at: REPORTED_INSTANT, organization_id: 'org_1',
+            },
+        ]);
+        const e = fakeEngine();
+
+        const result = await migrateSysNotificationToEvent({ driver: d.driver, data: e.engine });
+
+        expect(result.status).toBe('migrated');
+        const inbox = e.inserts.find((i) => i.object === 'sys_inbox_message')!;
+        const receipt = e.inserts.find((i) => i.object === 'sys_notification_receipt')!;
+        expect(inbox.row.created_at).toBe(REPORTED_INSTANT);
+        expect(receipt.row.created_at).toBe(REPORTED_INSTANT);
+        expect(receipt.row.at).toBe(REPORTED_READ_INSTANT);
+    });
+});

--- a/packages/metadata/src/migrations/migrate-sys-notification-to-event.ts
+++ b/packages/metadata/src/migrations/migrate-sys-notification-to-event.ts
@@ -100,7 +100,7 @@ export async function migrateSysNotificationToEvent(
             const recipientId = row.recipient_id != null ? String(row.recipient_id) : null;
             if (!recipientId) continue; // defensive — guarded by the SELECT filter
             const orgId = row.organization_id != null ? String(row.organization_id) : null;
-            const createdAt = row.created_at != null ? String(row.created_at) : now();
+            const createdAt = row.created_at != null ? canonicalTimestampText(row.created_at) : now();
             const title = row.title != null ? String(row.title) : (row.type != null ? String(row.type) : 'Notification');
             const isRead = row.is_read === true || row.is_read === 1 || row.is_read === '1';
             // One topic for both the inbox row and the rewritten event, so the
@@ -128,7 +128,7 @@ export async function migrateSysNotificationToEvent(
                 user_id: recipientId,
                 channel: 'inbox',
                 state: isRead ? 'read' : 'delivered',
-                at: isRead && row.read_at != null ? String(row.read_at) : createdAt,
+                at: isRead && row.read_at != null ? canonicalTimestampText(row.read_at) : createdAt,
                 organization_id: orgId,
                 created_at: createdAt,
             });
@@ -169,6 +169,52 @@ export async function migrateSysNotificationToEvent(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * The canonical text spelling of a timestamp read back out of the legacy table.
+ *
+ * `selectLegacyRows` reads through `driver.raw`/`execute`, which hands the
+ * dialect client's own materialisation straight back — that door does not run
+ * `formatOutput`, so none of its repairs apply here on any dialect:
+ *
+ *  - `created_at` is a BUILTIN audit column, so it is never in `datetimeFields`
+ *    and no declared-field coercion reaches it; `formatOutput` repairs it only
+ *    inside its `if (this.isSqlite)` arm (`repairNaiveUtcAuditTimestamp` over
+ *    `AUDIT_TIMESTAMP_COLUMNS`).
+ *  - `read_at` is a LEGACY column ADR-0030 removed from the object, so it is
+ *    not declared either — it can never enter `datetimeFields`, and it is not
+ *    an audit column, so no arm of `formatOutput` could reach it even at the
+ *    record read door.
+ *
+ * On SQLite both arrive as canonical ISO text and `String()` is the identity —
+ * which is why every test in this directory stayed green. On Postgres and
+ * MySQL an instant column materialises as a JS `Date`
+ * (`withPostgresCalendarDayAsText` leaves the instant types alone deliberately;
+ * pinned in `sql-driver-13567-audit-stamp-materialisation.test.ts`), and
+ * `String(date)` spells
+ *
+ *   Sun Aug 30 2026 18:19:25 GMT+0800 (China Standard Time)
+ *
+ * — whole seconds in the MIGRATING HOST's zone, with the milliseconds gone.
+ * This migration is one-way and this value is WRITTEN, so that spelling is what
+ * the platform would carry afterwards: either accepted and stored skewed and
+ * de-precisioned, or rejected outright, since the trailing zone name is in no
+ * dialect's timestamp grammar (#13998).
+ *
+ * Canonicalising HERE, at the consumer that writes, is deliberate and is the
+ * only shape that could also repair an already-migrated deployment (#13973
+ * option A). It is not a tolerant alias: `Date` and ISO text are two
+ * materialisations of ONE instant, not two spellings of a key. Matches the
+ * repo's existing correct form at `metadata-protocol/src/protocol.ts` (the
+ * `occurred_at` read in `readMetadataAuditEvents`); anything that is neither a
+ * string nor a `Date` keeps its previous `String()` rendering unchanged rather
+ * than having a unit guessed for it on a one-way write path.
+ */
+function canonicalTimestampText(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (value instanceof Date) return value.toISOString();
+    return String(value);
+}
 
 async function selectLegacyRows(driver: any): Promise<any[]> {
     const result: any[] = await driver.raw(


### PR DESCRIPTION
Part of #13998 — the code half only. The data half of that card (whether any deployment has already run this migration against Postgres or MySQL, and therefore whether a backfill is owed) is unanswered and is a maintainer floor, so this PR deliberately does not carry a closing keyword. Reading below.

All gates and tests quoted here were run at `3fc4e3bf24`, which is this branch's head.

## What was wrong

`selectLegacyRows` reads the legacy `sys_notification` table through `driver.raw`/`execute`, and the migration then wrote

```ts
const createdAt = row.created_at != null ? String(row.created_at) : now();
at: isRead && row.read_at != null ? String(row.read_at) : createdAt,
```

into `created_at` on the new `sys_inbox_message` row and into `created_at` / `at` on the new `sys_notification_receipt` row. On Postgres and MySQL an instant column materialises as a JS `Date`, so `String(...)` spells

```
Sun Aug 30 2026 18:19:25 GMT+0800 (China Standard Time)
```

— whole seconds in the **migrating host's** zone, milliseconds dropped, and a trailing zone name that is in no dialect's timestamp grammar. This migration is one-way, so that spelling is what the platform carries afterwards.

## The fix

One canonicaliser, applied at both sites, matching the repo's existing correct form (`metadata-protocol/src/protocol.ts`, the `occurred_at` read in `readMetadataAuditEvents`):

```ts
function canonicalTimestampText(value: unknown): string {
    if (typeof value === 'string') return value;
    if (value instanceof Date) return value.toISOString();
    return String(value);
}
```

Route A of #13973 (canonicalise at the migration), as triaged — not the driver-side read-door normalisation, and not a tolerant `??` fallback. A `Date` and ISO text are two materialisations of one instant, not two spellings of a key. Anything that is neither a string nor a `Date` keeps its previous `String()` rendering unchanged rather than having a unit guessed for it on a one-way write path; widening that would be a second, unevidenced decision.

## Why neither column could be repaired further upstream

This read path bypasses `formatOutput` entirely — `execute()` returns `await builder` untouched, the same class of bypass `sql-driver.ts:3964-3965` already names for `aggregate` and `distinct`. Even at the record read door the two columns diverge by **different** gates, and neither one closes:

- `created_at` is a **builtin audit column**, so it is never in `datetimeFields` and no declared-field coercion reaches it; `formatOutput` repairs it only inside its `if (this.isSqlite)` arm (`repairNaiveUtcAuditTimestamp` over `AUDIT_TIMESTAMP_COLUMNS = ['created_at', 'updated_at']`, `sql-driver.ts:269`).
- `read_at` is a **legacy column ADR-0030 removed from the object**, so it is not a declared `Field.datetime` either — `datetimeFields` is built from declared datetime columns, and `read_at` appears nowhere in `packages/platform-objects/src` today. No arm of `formatOutput` could reach it on any dialect.

## The pin, and why it is the real content here

The defect was invisible because this migration's tests drive SQLite/memory shapes, where the legacy stamps are already canonical ISO text and `String(row.created_at)` is the **identity**. The new cases break that identity by feeding a hand-made `Date` — the discriminating input — through the migration's read path under a forced process zone. `@objectstack/metadata` has no driver dependency and must not grow one, so a hand-made `Date` is the right instrument, exactly as the OCC seam's own suite uses one.

They live in the existing test file and reuse its already-pinned engine doubles, so `check:engine-double-contract`'s ledger is untouched.

**Ablation**, on the committed tree, no rebuild leg (the pin imports `./migrate-sys-notification-to-event.js` relatively, so vitest resolves source; `dist/` is not on this path — stated rather than fabricated):

- mutation proven on disk in both directions — injected `String(row.created_at)` / `String(row.read_at)` count 2, removed `canonicalTimestampText(row.` count 0 — and by blob: `1f9ef52ee8` to `fb4534c3e5`
- result: `Tests  1 failed | 7 passed (8)`, failing precisely on the new case with `AssertionError: inbox.created_at must be canonical ISO-Z: expected 'Sun Aug 30 2026 18:19:25 GMT+0800 (Ch…' to match /^\d{4}-\d{2}-\d{2}T…/` — the production spelling, reproduced
- the other 7 cases stayed **green** under the mutation, which is the SQLite identity demonstrated rather than asserted
- restore under `trap ... EXIT INT TERM` with absolute paths, proven by an empty `git diff HEAD` (0 bytes from `--name-only`), a clean `git status`, and a restored blob matching the HEAD blob `1f9ef52ee8`

## Verification

- `pnpm --filter '@objectstack/metadata^...' build` — `VERDICT command-exit 0`
- `pnpm --filter @objectstack/metadata test` — `Test Files  38 passed (38)`, `Tests  628 passed (628)`
- gate family derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at `3fc4e3bf24` (34 commands, path-derived plus the test-file convention kind): **33 exit 0**, 1 NOT MEASURED — `node scripts/check-test-completeness.mjs` exits **3** with no test-run log to read, which its own output states is not a red and not a finding
- `pnpm check:type-check-debt` re-measured 29 ledger entries at this head and reports `surplus: none — every entry sits exactly at its measurement, so any new error is red`, so the new test code adds **zero** tsc errors to `@objectstack/metadata`'s frozen 89
- `pnpm check:dual-build-cjs-loads` and `pnpm check:type-check-debt` both needed a built workspace (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful) and were re-run green afterwards rather than left at their exit-3 prerequisite state

**ESLint — a declared narrowing, measured on three counts rather than skipped.** Run on the changed files only, `--no-inline-config --format json`: 0 errors, 0 warnings.

1. The population is read from ESLint's own config, not guessed: `--print-config` resolves a real config for both `.ts` files (6 and 5 active rules), and ESLint itself reports the changeset as `File ignored because no matching configuration was supplied`.
2. The file count is read from `--format json`: 3 result objects, 2 linted, 1 ignored.
3. Untouched files cannot move: `--print-config` shows no `parserOptions.project` on either file, and `eslint.config.mjs:328` records — measured with a positive control — that this repo `never enables type-aware linting ... for ANY file`. Every file's verdict therefore depends only on its own bytes and the shared config, and this diff changes neither the config nor any other file.

## Readings the card asked for

- **Has any deployment already run this migration against PG/MySQL — the data half.** **Cannot be ruled out, so the data half stays open and this PR writes no backfill.** The repo keeps no record that could answer it: the migration has **no caller anywhere** (no CLI command, no boot hook — `docs/handoff/adr-0030-notification-convergence.md` labels it *"Data migration (not auto-run)"* and hands operators a manual cut-over sequence), and it is **not in the `sys_migration` ledger** — the well-known ids are only `adr-0104-file-references` and `adr-0104-value-shapes`. Meanwhile it *is* published: `migrateSysNotificationToEvent` appears in seven package CHANGELOGs. What narrows the population is the finding below: no driver in this repo defines `.raw`, so the documented call errors out before touching data. That leaves only an operator who passed a knex-like handle of their own, which the repo cannot see either way.
- **Which failure shape occurs on a live server — accepted-and-skewed, or rejected mid-run.** **NOT MEASURED.** `OS_TEST_POSTGRES_URL` and `OS_TEST_MYSQL_URL` are unset and nothing is listening in this container, so no live dialect was reachable. The fix is safe under **either** shape: it removes the input to both, since the value written is canonical ISO text on every dialect. The JavaScript half that needs no server — that `String(Date)` drops the milliseconds and bakes the process zone — is measured in the pin.
- **Does `read_at` share the defect, and by which gate.** Yes, and by a *different* gate than `created_at` — the two bullets above. Both are covered by the fix.
- **Any sibling migration with the same shape.** No. The card's expression over `packages/metadata/src/migrations/` returns the two lines in this file and nothing else; widened to `String\((row|r|legacy|old)\.[A-Za-z_]*_at\b` across all of `packages`, the other hits are read-side sites already accounted for by the #13973 census family (`objectql/engine.ts`, `rest-server.ts`, `platform-objects/system/migration-flag.ts`, `metadata-protocol/protocol.ts`, `cli/commands/migrate/duplicates.ts`) plus `services/service-queue/src/db-queue-adapter.ts:262`. The three other files in this migrations directory contain no `_at` reference at all.

## Out-of-scope finding, filed not folded

#14023 — every migration in `packages/metadata/src/migrations/` requires `driver.raw(...)`, and no driver in this repo defines that method; they all expose `execute()`. Deduped against the backlog first. Different defect class, so it is not repaired here, and #14023 remains open on its own terms.

_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3jdziLbAPGeceVNmSox5L)_