### PR TITLE
docs(spec): `$exists` asks whether a field has a value, not whether a key is present

### DIFF
--- a/.changeset/spec-exists-jsdoc-has-value.md
+++ b/.changeset/spec-exists-jsdoc-has-value.md
@@ -1,0 +1,25 @@
+---
+'@objectstack/spec': patch
+---
+
+docs(spec): `$exists` JSDoc said key-presence, which has been false since protocol alignment (#13709)
+
+`SpecialOperatorSchema.$exists` carried `Field exists check (primarily for NoSQL) -
+MongoDB: $exists`. That describes key-presence, and key-presence stopped being what
+`$exists` means when the has-value alignment landed (PR #13529 / `9dac1ae017`). The
+line was not stale phrasing — it was false, and it is the last of the six sites that
+carried the old claim; the other five were corrected by PR #13581 / PR #13577.
+
+The corrected wording is the one recorded on #13539 and already shipped on those five
+sites: `$exists` asks whether the field HAS A VALUE (`!= null`), the exact inverse of
+`$null`, never key presence — lowered to `IS NOT NULL` / `IS NULL` on SQL and to
+`{$ne: null}` / `{$eq: null}` on MongoDB. Verified against all three evaluators before
+rewriting: `formula`'s `matchesFilterCondition` (`v === true ? actual != null : actual == null`),
+`objectql`'s `having` face, and the `filter-logic-conformance.ts` table, which enrolls
+`$exists` in both directions.
+
+Prose only. No accept/reject change: `$exists` was and stays `z.boolean().optional()`,
+and the JSDoc is a comment, not a `.describe()` — the schema, its JSON-Schema
+projection and every generated artifact are byte-identical. It reaches consumers as
+the hover text on `@objectstack/spec`'s shipped `.d.ts`, which is why this is a patch
+rather than no changeset at all.

--- a/.changeset/spec-exists-jsdoc-has-value.md
+++ b/.changeset/spec-exists-jsdoc-has-value.md
@@ -20,6 +20,18 @@ rewriting: `formula`'s `matchesFilterCondition` (`v === true ? actual != null : 
 
 Prose only. No accept/reject change: `$exists` was and stays `z.boolean().optional()`,
 and the JSDoc is a comment, not a `.describe()` — the schema, its JSON-Schema
-projection and every generated artifact are byte-identical. It reaches consumers as
-the hover text on `@objectstack/spec`'s shipped `.d.ts`, which is why this is a patch
-rather than no changeset at all.
+projection and all 15 generated artifacts are byte-identical (`check:generated` green
+on a freshly built `dist`).
+
+Where the corrected line does and does not surface, measured rather than assumed:
+
+- **Published source — yes.** This package's `files` array ships `src/**/*.zod.ts`, so
+  `filter.zod.ts` is in the npm tarball and the comment reaches consumers verbatim.
+  That is the surface this patch is for.
+- **Emitted `.d.ts` — no.** Zero of the emitted `.d.ts`/`.d.mts` carry the text; the
+  property's type is inferred from Zod, so no declaration comment is written. It
+  appears in `dist` only inside `.js.map` sourcemaps.
+- **Generated reference page — no.** `content/docs/references/data/filter.mdx` renders
+  its Description column from `prop.description`, i.e. a Zod `.describe()`; `$exists`
+  carries none, so that cell is empty before and after. Regenerating all 230 pages
+  produces no diff. See #13709 for the follow-up on that empty cell.

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -994,7 +994,11 @@ export const SpecialOperatorSchema = lazySchema(() => z.object({
   /** Is null check - SQL: IS NULL (true) / IS NOT NULL (false) | MongoDB: field: null */
   $null: z.boolean().optional(),
   
-  /** Field exists check (primarily for NoSQL) - MongoDB: $exists */
+  /**
+   * Field HAS A VALUE (`!= null`) — the inverse of `$null`, never key presence.
+   * Lowered to `IS NOT NULL` (true) / `IS NULL` (false) on SQL and to
+   * `{$ne: null}` / `{$eq: null}` on MongoDB.
+   */
   $exists: z.boolean().optional(),
 }));
 


### PR DESCRIPTION
Fixes #13709

**Clause-②: no.** Prose only, zero accept/reject change — `$exists` is `z.boolean().optional()` before and after, and the edited text is a JSDoc comment, not a `.describe()`. The path limb (`packages/spec/src/**/*.zod.ts`) still binds the enqueue gate, so `needs:contract-review` is hung on this PR and on the card.

## The one line

`SpecialOperatorSchema.$exists` carried:

```js
/** Field exists check (primarily for NoSQL) - MongoDB: $exists */
```

That describes key-presence. `$exists` stopped meaning key-presence when the has-value alignment landed at `9dac1ae017` (PR #13529), so the line was false rather than merely stale — the last of the six sites carrying the old claim, the other five having been corrected by PR #13581 and PR #13577.

Anchored by the **string** `primarily for NoSQL`, never a line number: the card's own title said `:954`, its comments said `:997`, and it sat at `:997` on my base. The symptom grep returns exactly one hit repo-wide, and zero after this diff.

Replaced with the wording recorded on #13539, adapted to this file's JSDoc idiom — the sibling `$null` line annotates which boolean maps to which lowering, so this one does too:

```js
/**
 * Field HAS A VALUE (`!= null`) — the inverse of `$null`, never key presence.
 * Lowered to `IS NOT NULL` (true) / `IS NULL` (false) on SQL and to
 * `{$ne: null}` / `{$eq: null}` on MongoDB.
 */
```

**Direction verified against the implementations before rewriting**, not copied on faith: `formula`'s `matchesFilterCondition` reads `v === true ? actual != null : actual == null`; `objectql`'s `having` face lists `$exists` among the operators for which "no value" is a real answer; and `filter-logic-conformance.ts` records the 2026-08-10 ruling with `$exists` enrolled in both directions.

## A sub-premise of the card is falsified — measured, not argued

The card and the dispatch both state that `content/docs/references/data/filter.mdx` **inherits its Description column from this JSDoc**, and asked for that page to be regenerated in the same commit. I ran the regeneration (`gen:schema` then `gen:docs`, 230 pages). It produced a **zero-byte diff**.

The reason: `packages/spec/scripts/lib/schema-section.ts` fills that column from `prop.description`, the projection of a Zod `.describe()` — and `$exists` has none, so its cell is empty before and after. The two surfaces were therefore never in the disagreement the card describes; the generated page is silent about `$exists`, not wrong about it.

Recorded as #14048 (unassigned, for triage) rather than fixed here: adding `.describe()` writes new prose onto a published page under a root watched by `check:corpus-claim-drift`, whose single rule is `exists-key-presence` — the exact shape that ratchet inspects. That earns its own diff and its own gate run instead of riding along on a fenced one-line card.

## Where the corrected line actually surfaces

- **Published source — yes.** `packages/spec`'s `files` array ships `src/**/*.zod.ts`, so `filter.zod.ts` is in the npm tarball and the comment reaches consumers verbatim. This is the surface the patch changeset is for.
- **Emitted `.d.ts` — no.** Zero of the emitted `.d.ts`/`.d.mts` carry the text (the property's type is inferred from Zod, so no declaration comment is written); it appears in `dist` only inside `.js.map` sourcemaps.
- **Generated reference page — no**, per the section above.

An earlier draft of the changeset claimed the `.d.ts` hover surface. That was assumed, not measured; the follow-up commit corrects it, because a PR that exists to remove a false claim must not ship one.

## Verification

All of the following on the final commit `a12460d5`, clean tree, after `pnpm --filter @objectstack/spec build`:

| check | verdict line |
|---|---|
| `@objectstack/spec` suite | `Test Files 446 passed \| 1 skipped (447)` · `Tests 11989 passed \| 1 skipped (11990)` |
| `@objectstack/spec` typecheck | exit 0 — `tsc --noEmit`, `check:scripts-typecheck`, and `check:test-typecheck` (test layer really compiled, via `tsconfig.test.json`) |
| `check:generated` | `✓ All 15 generated artifacts are up to date.` |
| `spec check:docs` | `✅ 230 generated files in sync with packages/spec` |
| `check:authorable-surface` | exit 0 — `1237 default(s) unchanged`, 1608 schemas |
| `check:corpus-claim-drift` | `OK, no new claim sites beside a pinned spelling.` — 226 files, rule `exists-key-presence` |
| `check:doc-authoring` | `14301 customer-facing string(s) across 693 spec sources clean` |
| `check:doc-formula-expressions` | `22 record-scoped formula example(s) across 427 files / 1451 TS blocks judged clean` |
| `check:comment-mask-adoption` | `OK — 14 private comment-stripper(s) ... all 14 recorded` |
| `check:keyed-text-bounds` | `148 keyed text-family columns judged, 148 bounded` |
| `check:empty-changeset` | `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).` |
| `check:nul-bytes` | `OK (scanned 7671 text file(s) ... no raw ASCII control bytes)` |
| `check:changeset-gate-self-tests` | exit 0 — all three self-tests |
| `pnpm lint` (repo-wide) | 5601 files, 0 errors, 0 warnings — full run, not narrowed |

Gates re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`. Because `filter.mdx` does not change, the `content/docs/**` families named at dispatch (`check:doc-anchors`, `check:docs-audit-scope`, `check:docs-redirects`, `check:docs-single-h1`, `check:doc-security-posture`) do not match this diff; the `packages/spec/**` families above do.

Two gates first reported a **prerequisite**, not a finding, and were re-run after the missing builds: `check:generated` (exit 1 — `dist` held no `.d.ts`) and `check:doc-formula-expressions` (exit 3 twice — `@objectstack/formula`, then `@objectstack/lint`, unbuilt). Both green above. Every exit code was captured before any pipe.

## Not touched, on purpose

`content/docs/data-modeling/queries.mdx` — its wording was already correct before any of this and is the target wording, not another site to change. No blanket sweep: the diff is one comment and one changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mciyv38maJ6HYVMiaM26T1)_