### PR TITLE
skills(pm): encode the clear-equals-land arm preconditions in contract-review.md

### DIFF
--- a/.claude/skills/pm-dispatch/references/contract-review.md
+++ b/.claude/skills/pm-dispatch/references/contract-review.md
@@ -36,6 +36,10 @@
   只进决策箱,⛔ 永不自裁 —— 真正设计分叉照旧升级维护者;轮报设**复审清单**专节(同代
   裁清单强制审计形状)。**三样不变**:受管面照旧 draft-only + 终局两条(人工直合或授权批准
   钉 head 入队,单源见主文件)、⛔ 席位永不代批;FAIL / REWORK 原样;降档保险丝原样。
+- **落地前检三条**(维护者 2026-08-31「同意」):① 席内契约档 PASS 在案(卡上达档裁决评论);②
+  `needs:contract-review` 双载体已清;③ PR 全部 check 全绿(⛔ 非 required 子集)。② 逐对机读
+  `node scripts/pm/check-clause2-carriers.mjs --pair PR-NUMBER`:0 双肢可读且一致 · 4 不一致 · 3 环境答不
+  了 ⛔ 不作干净。转 ready 同笔留 provenance 评论引该 PASS;受管面不适用,draft-only 终局不变。
 - **外部评审链降为可选**(改写 2026-08-27「契约复审也是很重要的职责，也是需要定时处理
   的」所立的定时轮常设归属):分诊定时轮与总监席召唤非放行必要条件,在线时作**事后审计/抽
   查**,其裁决仍被尊重 —— 审计 FAIL 按状态机 label-flip 交回派发席补丁轮;⛔ 不与席内复核
@@ -43,10 +47,9 @@
 
 ## 降档保险丝(机读)
 
-- 席内复核/审计每场前**必调一次 `get_session`**(claude-code-remote MCP,无参)读
-  `external_metadata.last_served_model`,⛔ 自述档位不是读数(静默降档腐蚀的恰是自述;实测与配
-  置档陷阱见 platform-readings);读数 ≠ `CONTRACT_REVIEW_TIER` ⇒ 本席 ⛔ 不自判清标,改走转录
-  核验的 fable 复核子代理 —— 标签在复核完成前原样留置,卡在队列外等待是安全态。
+- 席内复核/审计每场前**必读一次服役档**(读法与陷阱单源见 platform-readings),⛔ 自述档位不
+  是读数(静默降档腐蚀的恰是自述);读数 ≠ `CONTRACT_REVIEW_TIER` ⇒ 本席 ⛔ 不自判清标,改走
+  转录核验的 fable 复核子代理 —— 标签在复核完成前原样留置,卡在队列外等待是安全态。
 - **保险丝只测座位自会话**:`mode:subagent` 里的 `get_session` 量的是**派发会话**(实测:
   钉在地板档的子代理读回父档,⛔ 不作互证),传参只是配置 ⛔ 不作达档读数;
   条款②的 `mode:subagent` 派发照旧恒保留 `needs:contract-review` 至席内复核完成。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -248,7 +248,25 @@ export const CEILINGS = new Map([
   // or folded; the residual +6 could not be paid without deleting ruled clauses
   // (refused on the state-machine precedent). Landed count, headroom 0, same
   // convention.
-  ['.claude/skills/pm-dispatch/references/contract-review.md', 57],
+  // Raised 57 → 60 by the clear-equals-land CRITERIA encoding — the 清标即落地
+  // section gains the arm-precondition list it never carried: an in-seat at-tier
+  // PASS on record, `needs:contract-review` cleared on BOTH carriers, and ALL of
+  // the PR's checks green (never the required subset), with the per-pair
+  // mechanical reading (`check-clause2-carriers --pair`) and its exit register,
+  // and the governed-surface boundary restated as unchanged. The rule is the
+  // 2026-08-31 director batch #17 ruling, verbatim and untranslated: 「同意」,
+  // which ordered the text into THIS file and THIS section; the raise itself is
+  // authorized by the maintainer on 2026-09-01, director decision batch A,
+  // verbatim and untranslated: 「同意。」 — that ruling also chose the FULL
+  // encoding over the 58-line bare minimum, so the two extra lines are ruled
+  // content, not slack. Paid in place first: the downgrade-fuse bullet's
+  // restatement of the served-tier READING collapsed to the platform-readings
+  // pointer it already carried (4 lines → 3, 437 B → 353 B), the one real
+  // deletion the surface had; the residual +4 could not be paid without deleting
+  // a ruled clause, and the nearest candidates were the governed-surface
+  // boundary and the terminal clause (refused on the state-machine precedent).
+  // Landed count, headroom 0, same convention.
+  ['.claude/skills/pm-dispatch/references/contract-review.md', 60],
   // Business-perspective decision-analysis writing guide (maintainer ruling
   // 2026-08-20: the four-facet analysis must argue from the business
   // standpoint). Set at landed line count (headroom 0, same convention).


### PR DESCRIPTION
Fixes #13791

The 清标即落地 (clear-equals-land) section of
`.claude/skills/pm-dispatch/references/contract-review.md` stated the release
ACTION — PASS, strip both carriers, provenance comment, pre-land check, ready,
arm — but carried no walkable **precondition** list. Criterion 3 in particular
(every check green, never the required subset) had no home anywhere in the
release path: it existed only as a general enqueue rule in the main skill file.
This PR encodes the criteria shape, under the in-seat regime the same-day
review-chain reform installed.

## The clause, as landed (4 lines, 471 B, every line inside the 120-byte cap)

```text
- **落地前检三条**(维护者 2026-08-31「同意」):① 席内契约档 PASS 在案(卡上达档裁决评论);②
  `needs:contract-review` 双载体已清;③ PR 全部 check 全绿(⛔ 非 required 子集)。② 逐对机读
  `node scripts/pm/check-clause2-carriers.mjs --pair PR-NUMBER`:0 双肢可读且一致 · 4 不一致 · 3 环境答不
  了 ⛔ 不作干净。转 ready 同笔留 provenance 评论引该 PASS;受管面不适用,draft-only 终局不变。
```

Four things ride in those four lines, all of them ruled or ordered by the
dispatch: the three arm preconditions; the maintainer-provenance stamp the
file's own convention requires on a ruled bullet; the per-pair **mechanical**
reading of limb ② with its exit register (`0` limbs legible and carriers agree
· `4` they do not · `3` the environment could not answer, deliberately NOT read
as clean); and the unchanged governed-surface boundary.

Two deliberate narrowings, both measured rather than assumed:

- The **re-scope** the card carries: the ruled conditions 1 and 4 named the
  external review chain (a PASS from it, and its stall past a patrol interval).
  The same-day in-seat reform demoted that chain to optional audit, so a chain
  that is no longer a release precondition cannot stall. Condition 1 lands as an
  **in-seat** at-tier PASS on record; condition 4 has no referent and is not
  encoded. No stall timeout appears in the text.
- `--pair` is cited as the reading for limb **②** only. It is a predicate over
  the clause-② carriers and the card's declaration comment; it does not read PR
  check status, so claiming it covers ③ would have been a false mechanical
  claim.

## The authorizing rulings, quoted verbatim and untranslated

The line ratchet's own red text requires the ruling quoted in the raising PR,
and the second ruling below orders both quotes here.

**1 — the rule.** Maintainer, 2026-08-31, director seat summon 7, decision batch
17, on option B (record: #13758, comment 5478594239). It names this file and
this section:

> 同意

**2 — the ceiling raise 57 → 60, taking the FULL encoding** (not the 58-line
bare minimum). Maintainer, 2026-09-01, director decision batch A (record: this
card, comment 5486842552):

> 同意。

## Line budget, before and after

| file | lines before | lines after | bytes before | bytes after | ceiling |
|:--|--:|--:|--:|--:|:--|
| `.claude/skills/pm-dispatch/references/contract-review.md` | 57 | 60 | 5,381 | 5,775 | 57 → 60, headroom 0 |
| `scripts/pm/check-skill-line-ratchet.mjs` | 1,156 | 1,174 | — | — | not ceilinged (`scripts/` carries no row) |

**Paid in place first, then raised.** The one real deletion this surface had:
the downgrade-fuse bullet restated the served-tier READING — which MCP call,
which field, and why self-attestation is not a reading — while carrying a
pointer at `platform-readings.md`, the file that single-sources exactly that, in
the same breath. The restatement collapses to the pointer it already had:
**4 lines / 437 B → 3 lines / 357 B**. Nothing operative left the bullet: the
mandatory per-session read, the ⛔ on self-attestation, the mismatch consequence
(no self-clearing; go to the transcript-verified fable review subagent) and the
label-retention rule are all still there.

That leaves a residual of +4 lines, which cannot be paid without deleting a
**ruled** clause — refused on the state-machine precedent already recorded in
the CEILINGS map, and the nearest candidates were the governed-surface boundary
and the terminal clause, i.e. exactly the text the card forbids weakening. Hence
the raise, which is the ratchet's own prescribed escape and the third use of it
on this file, matching the recording convention of the two same-day precedents
(48 → 51, then 51 → 57): landed count, headroom 0, arithmetic and ruling in the
map comment.

## Verification — gate union at HEAD `6557bc1bb`

Derived after the final commit with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`
(exit 0; the tool reads the change set itself from the merge base, three-dot).
Every exit code captured **before** any pipe.

| gate | exit |
|:--|:--|
| `node scripts/check-ci-filter-parity.mjs` | 0 |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 |
| `node scripts/check-shard-attestation.mjs` | 0 |
| `node scripts/check-test-completeness.mjs` | 3 — NOT MEASURED |
| `node scripts/pm/bare-root-worklist.mjs --self-test` | 0 |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:bash32-floor` | 0 |
| `pnpm check:cli-command-ids` | 0 |
| `pnpm check:cross-package-test-inputs` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:entry-guard` | 0 |
| `pnpm check:parse-guard` | 0 |
| `pnpm check:pm-dispatch-gates` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:pm-skill-id-lint` | 0 |
| `pnpm check:pm-skill-ratchet` | 0 |
| `pnpm check:pnpm-filter-targets` | 0 |
| `pnpm check:skill-frame-sync` | 0 |
| `pnpm check:watch-hint-literal` | 0 |

`check-test-completeness` exits 3 by its own design when run with no saved
`turbo run test` log — its failure text says so and says to record the local
reading as NOT MEASURED. It is not a red. `check:doc-formula-expressions` also
answered 3 on the first pass (`PREREQUISITE NOT MET` — `@objectstack/formula`
and `@objectstack/lint` were not built in a fresh worktree); both were built and
it was re-run to a real 0.

**The line-ratchet verdict lines for this file, verbatim from the gate's own
output at HEAD `6557bc1bb`:**

```text
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/contract-review.md is 60 lines (ceiling 60; headroom 0).
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/contract-review.md: widest table row is 0 bytes (pin 0; headroom 0).
```

Reverse verification of the raise, on the committed tree: with the ceiling still
at 57 the same gate printed
`✗ … contract-review.md is 60 lines; the ratchet ceiling is 57` and exited 1, so
the ratchet really is reading this edit and the raise is what turns it green —
not a stale count.

Because the diff edits a gate script, that script's own suites were run beyond
the derived family: `check-skill-line-ratchet.mjs --self-test` (111 cases pass),
plus the three modules that import it —
`scripts/check-published-list-mirrors.mjs`, `scripts/check-skills-token-ratchet.mjs`
and `scripts/pm/check-dispatch-gates.mjs` (1,090 cases) — all exit 0.
`node scripts/check-nul-bytes.mjs` exit 0 over 7,678 files, and a direct control-byte
scan of both touched files matched nothing.

## Boundaries observed

- **Governed surface (`.claude/**`) ⇒ draft-only.** Not flipped ready, not
  armed, not queued; it reaches `main` only through a human merge or the
  pinned-approval path.
- No ruled clause was weakened, and no deletion other than the single dedup
  above.
- The clause is not widened: it covers non-governed code PRs after a recorded
  at-tier PASS, and says so.
- No issue numbers in operative skill text (`check:pm-skill-id-lint` green) —
  provenance in the clause is date plus verbatim words.
- Publishes nothing from any package ⇒ `skip-changeset`, applied on this PR.

Session: https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2

_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_