### PR TITLE
fix(examples): correct f_address seed key to postalCode

### DIFF
--- a/examples/app-showcase/src/data/seed/index.ts
+++ b/examples/app-showcase/src/data/seed/index.ts
@@ -336,7 +336,7 @@ const fieldZoo = defineSeed(FieldZoo, {
       f_boolean: true, f_toggle: true,
       f_select: 'high', f_multiselect: ['red', 'green'], f_radio: 'yes', f_checkboxes: ['email', 'push'], f_tags: ['alpha', 'beta'],
       f_lookup: 'Northwind', f_lookups: ['Northwind', 'Contoso'], f_master_detail: 'Website Relaunch',
-      f_location: { lat: 47.6062, lng: -122.3321 }, f_address: { street: '1 Main St', city: 'Seattle', state: 'WA', postal_code: '98101', country: 'US' },
+      f_location: { lat: 47.6062, lng: -122.3321 }, f_address: { street: '1 Main St', city: 'Seattle', state: 'WA', postalCode: '98101', country: 'US' },
       f_code: '{\n  "ok": true\n}', f_json: { nested: { k: 'v' }, list: [1, 2, 3] }, f_color: '#2563EB',
       f_rating: 4, f_slider: 60, f_progress: 80,
       f_composite: { width: 10, height: 20 }, f_repeater: [{ label: 'one', qty: 1 }, { label: 'two', qty: 2 }],


### PR DESCRIPTION
Fixes #13388

## What

`examples/app-showcase/src/data/seed/index.ts` seeded the `field-zoo` specimen's
`f_address` value with `postal_code`, a key `AddressSchema`
(`packages/spec/src/data/field-value.zod.ts`) does not declare — the schema
declares camelCase `postalCode`. One key, one line:

```diff
- f_address: { street: '1 Main St', city: 'Seattle', state: 'WA', postal_code: '98101', country: 'US' },
+ f_address: { street: '1 Main St', city: 'Seattle', state: 'WA', postalCode: '98101', country: 'US' },
```

No renderer change and no consumer-side alias — the producer (this seed) was
wrong relative to the contract, and the fix is at the producer per AGENTS.md's
contract-first directive.

## Evidence

`valueSchemaFor({ type: 'address' }, 'stored').safeParse(...)` before/after,
built `@objectstack/spec` dist:

```
OLD (postal_code): { success: true, data: { street: '1 Main St', city: 'Seattle', state: 'WA', country: 'US' } }
                                                                                    ^ postalCode silently stripped
NEW (postalCode):  { success: true, data: { street: '1 Main St', city: 'Seattle', state: 'WA', postalCode: '98101', country: 'US' } }
                                                                                    ^ retained
```

## Fixture sweep

Repo-wide grep for `postal_code`, `98101`, `f_address` found no fixture or test
pinning the old (wrong) seed value:
- `packages/qa/dogfood/test/field-zoo.matrix.ts` asserts its own independent
  `f_address` write value (`{ street: '1 Main', city: 'SF', country: 'US' }`),
  unrelated to the seed.
- `packages/spec/src/data/analytics-strictness-batchd.test.ts` uses `AddressSchema`
  with its own unrelated fixture (`{ street: '1 Main St', district: 'Central' }`) —
  part of the separate strictness-fork territory (#13802/#14060), not this seed.
- The other `postal_code` hits in the tree (`company.manifest.ts`,
  `layout-dsl.mdx`, `concept.mdx`, `view.test.ts`) are unrelated object **field
  names** (snake_case machine names on a different object), not this address
  value's key.

No fixture needed updating.

## Out of scope (per the card's explicit ⛔s)

- No renderer change in `@object-ui/fields`.
- No schema change to `AddressSchema`/`LocationValueSchema` — the strict-vs-loose
  question is #13802 (decision box) and the scan-honesty half is #14060.

## Tests

- `pnpm --filter '@objectstack/example-showcase' exec vitest run` — 26 test
  files, 364 tests, all passed (includes `test/seed.test.ts`).
- `pnpm --filter '@objectstack/example-showcase' run typecheck` — clean.
- `pnpm --filter '@objectstack/dogfood' exec vitest run test/field-zoo-roundtrip.dogfood.test.ts test/field-zoo-value-shape.test.ts`
  — 2 test files, 91 tests, all passed. This boots the real showcase stack
  (real HTTP round-trip) with the fixed seed — clean boot, `showcase_field_zoo`
  seeded without error.
- Local gates derived from the diff via `node scripts/pm/dispatch-gates.mjs`
  (16 matched families) — all green; see the dev report comment on the issue
  for the full list and the one CI-only exception
  (`check:dual-build-cjs-loads` needs a full-tree `pnpm build`, which is CI's
  `Build Core` job).

## Changeset

None — `examples/app-showcase` is `"private": true` and releases nothing;
`skip-changeset` label applied per repo convention (pr-automation.yml's
"releases nothing (… examples/ …)" route).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mciyv38maJ6HYVMiaM26T1)_