### PR TITLE
fix(plugin-security): bring organization_admin_no_bypass under registry-driven managed-write denies

### DIFF
--- a/.changeset/no-bypass-managed-deny-target.md
+++ b/.changeset/no-bypass-managed-deny-target.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): registry-driven managed-object write denies now reach `organization_admin_no_bypass` (#14029)
+
+`MANAGED_DENY_TARGET_SETS` named four default sets, and `applyManagedWriteDenies`
+matches on it exactly — so at `kernel:ready` the injection walked the derived
+`organization_admin_no_bypass` variant and skipped it. The variant is a shallow
+copy of `organization_admin` taken at module load (`deriveWallLessOrgAdmin`
+strips only the `viewAllRecords`/`modifyAllRecords` superuser bits), which means
+its `'*'` wildcard still grants create/edit/delete AND entries injected into the
+parent's `objects` can never propagate to it. Its own docblock declares
+"managed-write denies … carried over verbatim"; the behaviour violated that
+declared contract.
+
+No gap opens on today's tree — the static `BETTER_AUTH_MANAGED_OBJECTS`
+baseline covers the 30 declared managed tables and is copied into the variant at
+derivation. The gap was the next `managedBy: 'better-auth'` schema that lands
+without a hand edit to that list: `organization_admin` would receive the
+injected deny while the wall-less variant's wildcard kept granting raw CRUD on
+an identity table — precisely the drift the registry-driven module exists to
+close (ADR-0092), on the posture (`auto-org-admin-grant` under a wall-less
+deployment) where the bits are least bounded.
+
+- `ORGANIZATION_ADMIN_NO_BYPASS` is now a member of `MANAGED_DENY_TARGET_SETS`.
+  The variant's pre-existing explicit entries (static baseline, RBAC read-only
+  block) survive unchanged — the injection skips any object a set already
+  names.
+- The membership pin no longer checks the list against itself: the required
+  floor ("default sets holding a write-granting `'*'` wildcard") is derived
+  from the real seeded sets and diffed against the list; a non-empty
+  difference is red. `admin_full_access` stays deliberately excluded (admin
+  rescue path) and that exclusion is pinned exactly.

--- a/.changeset/no-bypass-managed-deny-target.md
+++ b/.changeset/no-bypass-managed-deny-target.md
@@ -15,7 +15,7 @@ parent's `objects` can never propagate to it. Its own docblock declares
 declared contract.
 
 No gap opens on today's tree — the static `BETTER_AUTH_MANAGED_OBJECTS`
-baseline covers the 30 declared managed tables and is copied into the variant at
+baseline covers the 28 declared managed tables and is copied into the variant at
 derivation. The gap was the next `managedBy: 'better-auth'` schema that lands
 without a hand edit to that list: `organization_admin` would receive the
 injected deny while the wall-less variant's wildcard kept granting raw CRUD on

--- a/packages/plugins/plugin-security/src/managed-object-write-denies.test.ts
+++ b/packages/plugins/plugin-security/src/managed-object-write-denies.test.ts
@@ -8,6 +8,7 @@ import {
   MANAGED_DENY_TARGET_SETS,
 } from './managed-object-write-denies.js';
 import { MCP_AGENT_PERMISSION_SET_WRITE, MCP_AGENT_PERMISSION_SET_READ } from '@objectstack/spec/ai';
+import { ORGANIZATION_ADMIN_NO_BYPASS } from '@objectstack/spec';
 
 // Minimal PermissionSet-shaped fixtures (only name + objects matter here).
 const set = (name: string, objects: Record<string, unknown> = {}): any => ({ name, objects });
@@ -25,16 +26,17 @@ const schemas = [
 ];
 
 describe('applyManagedWriteDenies (#3325)', () => {
-  it('injects a read-only-write deny for every better-auth object into the four target sets', () => {
+  it('injects a read-only-write deny for every better-auth object into the five target sets', () => {
     const sets = [
       set('organization_admin'),
+      set(ORGANIZATION_ADMIN_NO_BYPASS), // #14029 — derived at module load, so it needs its own injection
       set('member_default'),
       set('viewer_readonly'),
       set(MCP_AGENT_PERMISSION_SET_WRITE),
     ];
     const res = applyManagedWriteDenies(sets, schemas);
-    // 2 better-auth objects × 4 sets = 8 injections.
-    expect(res.applied).toBe(8);
+    // 2 better-auth objects × 5 sets = 10 injections.
+    expect(res.applied).toBe(10);
     expect(res.skippedExisting).toBe(0);
     for (const s of sets) {
       expect(s.objects.sys_user).toEqual(DENY);
@@ -100,9 +102,20 @@ describe('applyManagedWriteDenies (#3325)', () => {
     expect(() => applyManagedWriteDenies([{ name: 'member_default' } as any], schemas)).not.toThrow();
   });
 
-  it('the target allowlist is exactly the four write-granting sets', () => {
+  it('the target allowlist is exactly the five known sets (see the independent-property pin for the floor)', () => {
+    // Exact membership record. This is deliberately NOT the only pin on the
+    // list: `objects/default-permission-sets.test.ts` derives the required
+    // floor ("holds a write-granting '*' wildcard") from the real default sets
+    // and diffs it against this list, so a set that SHOULD be a member cannot
+    // hide behind an assertion that only restates the list (#14029).
     expect([...MANAGED_DENY_TARGET_SETS].sort()).toEqual(
-      ['member_default', 'organization_admin', 'viewer_readonly', MCP_AGENT_PERMISSION_SET_WRITE].sort(),
+      [
+        'member_default',
+        'organization_admin',
+        ORGANIZATION_ADMIN_NO_BYPASS,
+        'viewer_readonly',
+        MCP_AGENT_PERMISSION_SET_WRITE,
+      ].sort(),
     );
   });
 });

--- a/packages/plugins/plugin-security/src/managed-object-write-denies.ts
+++ b/packages/plugins/plugin-security/src/managed-object-write-denies.ts
@@ -81,12 +81,16 @@ export const MANAGED_DENY_ENTRY = {
  * The default sets that must carry an explicit entry for every managed table.
  *
  * Holding a write-granting `'*'` wildcard is the FLOOR of membership, not its
- * definition: every default set whose wildcard grants create/edit/delete must
- * be listed here (or carry a documented exclusion below), because the wildcard
- * is what would otherwise grant raw CRUD on a newly-declared identity table —
- * that floor is what `default-permission-sets.test.ts` derives independently
- * and diffs against this list (#14029), so a future write-granting set that is
- * not added here fails a pin instead of silently keeping its wildcard.
+ * definition: every default set whose wildcard grants any generic write class
+ * — via the three write flags (`allowCreate`/`allowEdit`/`allowDelete`) OR via
+ * `modifyAllRecords`, whose super-user bypass grants edit/delete and the
+ * destructive class by the evaluator's second route (`MODIFY_ALL_WRITE_KEYS`,
+ * `permission-evaluator.ts`) — must be listed here (or carry a documented
+ * exclusion below), because the wildcard is what would otherwise grant raw
+ * writes on a newly-declared identity table — that floor is what
+ * `default-permission-sets.test.ts` derives independently and diffs against
+ * this list (#14029), so a future write-granting set that is not added here
+ * fails a pin instead of silently keeping its wildcard.
  * Membership is WIDER than the floor: `viewer_readonly`'s wildcard is read-only
  * and `member_default` has held none since #5491 — their injected entries are
  * belt-and-suspenders and the read grant itself, respectively (see the module

--- a/packages/plugins/plugin-security/src/managed-object-write-denies.ts
+++ b/packages/plugins/plugin-security/src/managed-object-write-denies.ts
@@ -4,12 +4,14 @@
  * ADR-0092 / ADR-0103 — registry-driven managed-object write denies for the
  * default permission sets.
  *
- * The default sets this module targets (`organization_admin`, `member_default`,
- * `viewer_readonly`, and the MCP write set) DENY writes on the
+ * The default sets this module targets (`organization_admin`, its derived
+ * `organization_admin_no_bypass` variant, `member_default`, `viewer_readonly`,
+ * and the MCP write set) DENY writes on the
  * better-auth-managed identity tables so mutations must flow through the auth
  * pipeline (ADR-0092). What that entry narrows differs per set, and the
- * difference is load-bearing for the rest of this file: `organization_admin` and
- * the MCP write set grant CRUD through an `objects['*']` wildcard, so their
+ * difference is load-bearing for the rest of this file: `organization_admin`,
+ * its no-bypass variant and the MCP write set grant CRUD through an
+ * `objects['*']` wildcard, so their
  * managed-table entries are a narrowing overlay; `viewer_readonly`'s wildcard is
  * read-only, so its entries are belt-and-suspenders over a wildcard that already
  * denies; and `member_default` carries NO wildcard at all since #5491 (the
@@ -59,6 +61,7 @@
  */
 
 import type { PermissionSet } from '@objectstack/spec/security';
+import { ORGANIZATION_ADMIN_NO_BYPASS } from '@objectstack/spec';
 import { MCP_AGENT_PERMISSION_SET_WRITE } from '@objectstack/spec/ai';
 
 /**
@@ -76,16 +79,34 @@ export const MANAGED_DENY_ENTRY = {
 
 /**
  * The default sets that must carry an explicit entry for every managed table.
- * Membership is NOT "holds a write-granting `'*'` wildcard" — only
- * `organization_admin` and the MCP write set hold one; `viewer_readonly`'s
- * wildcard is read-only and `member_default` has held none since #5491 (see the
- * module docblock for what the injected entry does in each). Explicit allowlist
- * — `admin_full_access` is deliberately excluded (it keeps its unqualified
- * wildcard so an admin can rescue data directly; the runtime guards are its
- * boundary), as are the MCP read / restricted sets (they grant no writes).
+ *
+ * Holding a write-granting `'*'` wildcard is the FLOOR of membership, not its
+ * definition: every default set whose wildcard grants create/edit/delete must
+ * be listed here (or carry a documented exclusion below), because the wildcard
+ * is what would otherwise grant raw CRUD on a newly-declared identity table —
+ * that floor is what `default-permission-sets.test.ts` derives independently
+ * and diffs against this list (#14029), so a future write-granting set that is
+ * not added here fails a pin instead of silently keeping its wildcard.
+ * Membership is WIDER than the floor: `viewer_readonly`'s wildcard is read-only
+ * and `member_default` has held none since #5491 — their injected entries are
+ * belt-and-suspenders and the read grant itself, respectively (see the module
+ * docblock for what the injected entry does in each).
+ *
+ * `organization_admin_no_bypass` is a member in its own right (#14029): it is
+ * derived from `organization_admin` by a SHALLOW copy taken at module load
+ * (`deriveWallLessOrgAdmin`), so entries injected into the parent's `objects`
+ * at `kernel:ready` can never propagate to it — dropping only the superuser
+ * bits leaves `allowCreate`/`allowEdit`/`allowDelete` true on its wildcard,
+ * exactly the shape this module exists to narrow.
+ *
+ * Documented exclusions: `admin_full_access` is deliberately NOT a member (it
+ * keeps its unqualified wildcard so an admin can rescue data directly; the
+ * runtime guards are its boundary), and the MCP read / restricted sets grant
+ * no writes for a deny to narrow.
  */
 export const MANAGED_DENY_TARGET_SETS: readonly string[] = [
   'organization_admin',
+  ORGANIZATION_ADMIN_NO_BYPASS,
   'member_default',
   'viewer_readonly',
   MCP_AGENT_PERMISSION_SET_WRITE,

--- a/packages/plugins/plugin-security/src/objects/default-permission-sets.test.ts
+++ b/packages/plugins/plugin-security/src/objects/default-permission-sets.test.ts
@@ -384,10 +384,23 @@ describe('admin_full_access imports the kernel capability declaration unchanged 
  */
 describe('managed-deny targets — independent-property floor + registry union reaches the derived variant (#14029)', () => {
   // Derived from `defaultPermissionSets`, never from the list under test.
+  // "Grants a write" in the evaluator's own terms: the three CRUD flags OR
+  // `modifyAllRecords` — the super-user bypass grants edit/delete and the
+  // destructive class by a second route (`MODIFY_ALL_WRITE_KEYS`,
+  // `permission-evaluator.ts`), so `'*': { modifyAllRecords: true }` is
+  // write-granting even with all three CRUD flags false. Value tests
+  // (`=== true`), not key-existence: Zod materialises the superuser bits with
+  // `.default(false)` (`permission.zod.ts`), so they are present-as-false.
   const writeGrantingWildcardSets: string[] = defaultPermissionSets
     .filter((s: any) => {
       const wc = s.objects?.['*'];
-      return !!wc && (wc.allowCreate === true || wc.allowEdit === true || wc.allowDelete === true);
+      return (
+        !!wc &&
+        (wc.allowCreate === true ||
+          wc.allowEdit === true ||
+          wc.allowDelete === true ||
+          wc.modifyAllRecords === true)
+      );
     })
     .map((s) => s.name)
     .sort();

--- a/packages/plugins/plugin-security/src/objects/default-permission-sets.test.ts
+++ b/packages/plugins/plugin-security/src/objects/default-permission-sets.test.ts
@@ -7,7 +7,7 @@ import * as PlatformObjects from '@objectstack/platform-objects';
 import { PermissionSetSchema } from '@objectstack/spec/security';
 import { ADMIN_FULL_ACCESS_CAPABILITIES } from '@objectstack/spec';
 import { defaultPermissionSets, BETTER_AUTH_MANAGED_OBJECTS } from './default-permission-sets.js';
-import { MANAGED_DENY_TARGET_SETS } from '../managed-object-write-denies.js';
+import { applyManagedWriteDenies, MANAGED_DENY_TARGET_SETS } from '../managed-object-write-denies.js';
 
 // Every object schema the platform-objects package exports whose bucket is
 // `better-auth` — the ground truth the static baseline must mirror.
@@ -366,5 +366,105 @@ describe('admin_full_access imports the kernel capability declaration unchanged 
       PermissionSetSchema.parse({ name: 'admin_full_access', ...ADMIN_FULL_ACCESS_CAPABILITIES }).objects,
     );
     expect(admin.systemPermissions).toEqual(ADMIN_FULL_ACCESS_CAPABILITIES.systemPermissions);
+  });
+});
+
+/**
+ * [#14029] The managed-deny target list, pinned against an INDEPENDENT
+ * property instead of against itself.
+ *
+ * The old shape of this pin iterated `MANAGED_DENY_TARGET_SETS` to assert
+ * membership, so it was structurally unable to see a set that SHOULD have been
+ * a member — which is exactly how `organization_admin_no_bypass` (a shallow
+ * copy of `organization_admin` taken at module load, write-granting wildcard
+ * intact) sat outside the list while `applyManagedWriteDenies` walked it and
+ * skipped it at `kernel:ready`. The floor is therefore derived here from the
+ * REAL seeded sets — "holds a `'*'` wildcard granting any generic write
+ * class" — and diffed against the list; a non-empty difference is red.
+ */
+describe('managed-deny targets — independent-property floor + registry union reaches the derived variant (#14029)', () => {
+  // Derived from `defaultPermissionSets`, never from the list under test.
+  const writeGrantingWildcardSets: string[] = defaultPermissionSets
+    .filter((s: any) => {
+      const wc = s.objects?.['*'];
+      return !!wc && (wc.allowCreate === true || wc.allowEdit === true || wc.allowDelete === true);
+    })
+    .map((s) => s.name)
+    .sort();
+
+  /**
+   * The one documented exclusion: `admin_full_access` keeps its unqualified
+   * wildcard so an admin can rescue data directly (recorded in the
+   * `MANAGED_DENY_TARGET_SETS` docblock; runtime guards are its boundary).
+   * Pinned exactly, like `EDIT_EXCEPTIONS` above: widening it is an edit HERE,
+   * which is the moment a reviewer is asked why the new set may keep raw CRUD
+   * on identity tables.
+   */
+  const WILDCARD_DENY_EXCLUSIONS = ['admin_full_access'];
+
+  it('the property derivation is live (found the known write-granting sets)', () => {
+    // If the filter silently matched nothing, the difference below would be
+    // vacuously empty — guard the probe itself.
+    expect(writeGrantingWildcardSets).toContain('organization_admin');
+    expect(writeGrantingWildcardSets).toContain('organization_admin_no_bypass');
+    expect(writeGrantingWildcardSets.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('every write-granting wildcard set is a managed-deny target or a documented exclusion', () => {
+    const missing = writeGrantingWildcardSets.filter(
+      (name) => !MANAGED_DENY_TARGET_SETS.includes(name) && !WILDCARD_DENY_EXCLUSIONS.includes(name),
+    );
+    expect(missing, 'write-granting sets missing from MANAGED_DENY_TARGET_SETS').toEqual([]);
+  });
+
+  it('the exclusion list is exactly admin_full_access, and it really is outside the target list', () => {
+    expect(WILDCARD_DENY_EXCLUSIONS).toEqual(['admin_full_access']);
+    expect([...MANAGED_DENY_TARGET_SETS]).not.toContain('admin_full_access');
+  });
+
+  // ── The behaviour the membership buys, measured on the REAL derived set ──
+  // (clones so the module-level instances other tests read stay unmutated;
+  // the kernel path hands the same objects to the same function in place).
+
+  const FUTURE = 'sys_future_identity_table';
+  const DENY = { allowRead: true, allowCreate: false, allowEdit: false, allowDelete: false };
+
+  it('a managedBy:better-auth object OUTSIDE the static list now reaches the variant (the card)', () => {
+    const sets: any[] = structuredClone(defaultPermissionSets as any);
+    const variant = sets.find((s) => s.name === 'organization_admin_no_bypass');
+    const parent = sets.find((s) => s.name === 'organization_admin');
+    expect(variant.objects[FUTURE]).toBeUndefined(); // genuinely not in the compile-time baseline
+    applyManagedWriteDenies(sets, [{ name: FUTURE, managedBy: 'better-auth' }]);
+    expect(variant.objects[FUTURE]).toEqual(DENY);
+    // The fix ADDS a target; the parent keeps receiving its injection too.
+    expect(parent.objects[FUTURE]).toEqual(DENY);
+  });
+
+  it('reverse control: the variant pre-existing explicit entries survive the injection unchanged', () => {
+    const sets: any[] = structuredClone(defaultPermissionSets as any);
+    const variant = sets.find((s) => s.name === 'organization_admin_no_bypass');
+    const before = structuredClone(variant.objects);
+    const registry = [
+      ...BETTER_AUTH_MANAGED_OBJECTS.map((n) => ({ name: n, managedBy: 'better-auth' })),
+      { name: FUTURE, managedBy: 'better-auth' },
+    ];
+    applyManagedWriteDenies(sets, registry);
+    for (const name of BETTER_AUTH_MANAGED_OBJECTS) {
+      expect(variant.objects[name], `variant entry ${name}`).toEqual(before[name]);
+    }
+    // Wildcard and the anti-escalation RBAC read-only block untouched as well.
+    expect(variant.objects['*']).toEqual(before['*']);
+    expect(variant.objects.sys_position).toEqual(before.sys_position);
+    // Only the future table was new on the variant.
+    expect(variant.objects[FUTURE]).toEqual(DENY);
+    expect(Object.keys(variant.objects).sort()).toEqual([...Object.keys(before), FUTURE].sort());
+  });
+
+  it('control: admin_full_access is untouched by the injection (admin rescue path)', () => {
+    const sets: any[] = structuredClone(defaultPermissionSets as any);
+    const admin = sets.find((s) => s.name === 'admin_full_access');
+    const before = structuredClone(admin);
+    applyManagedWriteDenies(sets, [{ name: FUTURE, managedBy: 'better-auth' }]);
+    expect(admin).toEqual(before);
   });
 });

--- a/packages/plugins/plugin-security/src/objects/default-permission-sets.ts
+++ b/packages/plugins/plugin-security/src/objects/default-permission-sets.ts
@@ -1037,6 +1037,14 @@ const baseDefaultPermissionSets: PermissionSet[] = [
  * silent privilege difference. The only intended delta is the superuser bits,
  * so the only thing this function may do is remove them.
  *
+ * ⚠️ The copy is SHALLOW and taken at MODULE LOAD, so what it carries over is
+ * the compile-time baseline only — the registry-driven managed-write denies
+ * that `applyManagedWriteDenies` injects into the parent's `objects` at
+ * `kernel:ready` can never propagate here. "Carried over verbatim" holds for
+ * the registry union because the variant is its own member of
+ * `MANAGED_DENY_TARGET_SETS` and receives the same injection directly
+ * (#14029), not because the derivation sees it.
+ *
  * `auto-org-admin-grant` picks between the two by posture: a wall-enforcing
  * posture bounds the bits (grant `organization_admin`); a wall-less one does
  * not (grant this).


### PR DESCRIPTION
Fixes #14029

**Clause-②: yes** — content limb. Bringing a permission set under managed-write-deny injection changes accept/reject behaviour: `organization_admin_no_bypass` will be refused generic create/edit/delete on any future registry-declared `managedBy: 'better-auth'` object that the static baseline misses, writes its wildcard grants today. Surface touched: `MANAGED_DENY_TARGET_SETS` in `packages/plugins/plugin-security/src/managed-object-write-denies.ts` (the `kernel:ready` injection target list) plus the membership pins. No spec/Zod schema, API shape, or wire format changes; on today's tree the seeded permission sets are byte-identical (the static `BETTER_AUTH_MANAGED_OBJECTS` baseline already covers all 28 declared managed tables, and the variant carries it via the derivation copy).

## The gap

`MANAGED_DENY_TARGET_SETS` named four sets and `applyManagedWriteDenies` matches exactly, so at `kernel:ready` the injection walked the derived `organization_admin_no_bypass` variant and skipped it. The variant is a shallow copy of `organization_admin` taken at module load (`deriveWallLessOrgAdmin` strips only the `viewAllRecords`/`modifyAllRecords` superuser bits), which means (a) its `'*'` wildcard still grants create/edit/delete, and (b) entries injected into the parent's `objects` can never propagate to it. `deriveWallLessOrgAdmin`'s own docblock declares "managed-write denies … carried over verbatim" and "the only intended delta is the superuser bits" — declared-vs-enforced, so the implementation is what gets fixed.

## Premise verification (the card was a source reading)

Measured by executing the real modules (temporary vitest probe, 4/4 green pre-fix, then removed):

- **Walked and skipped, not absent**: the variant sits directly after its parent in `defaultPermissionSets` (the array `bootstrapPermissionSets` defaults to and `runBootstrap` hands to `applyManagedWriteDenies` at the `kernel:ready` hook, security-plugin.ts line 3612). Applying a fake `managedBy: 'better-auth'` schema outside the static list yielded `applied: 4` — parent injected, variant untouched.
- **Wildcard still write-granting**: the variant's `objects['*']` carries `allowCreate`/`allowEdit`/`allowDelete` all `true`. One immaterial delta from the card's wording: after `PermissionSetSchema.parse` the stripped superuser bits are present-as-`false` (Zod boolean defaults), not absent — the effect is identical.
- **Shallow-copy isolation**: mutating the parent's `objects` after derivation does not reach the variant.

## Both halves

1. `ORGANIZATION_ADMIN_NO_BYPASS` is now a member of `MANAGED_DENY_TARGET_SETS`. Docblocks updated on the module, the list, and `deriveWallLessOrgAdmin` (the derivation now states that the registry union reaches the variant by direct membership, not by the copy).
2. **The pin no longer checks the list against itself.** `default-permission-sets.test.ts` derives the required floor from an independent property — default sets whose `objects['*']` wildcard grants any generic write class, read from the real seeded `defaultPermissionSets` — and diffs it against `MANAGED_DENY_TARGET_SETS`; a non-empty difference is red. The one documented exclusion (`admin_full_access`, admin rescue path) is pinned exactly, like `EDIT_EXCEPTIONS`. A liveness guard pins the property derivation itself so an empty probe cannot pass vacuously.

## Verification (all at `7e63b8ddc`, clean tree)

- **Positive (the card)**: a `managedBy: 'better-auth'` object outside the static baseline now reaches the variant — new test injects `sys_future_identity_table` into a structuredClone of the real seeded sets and asserts the deny entry lands on `organization_admin_no_bypass` (and still on the parent).
- **Mutation contrast (predicted directions first, then measured)**: with the fix committed, `ORGANIZATION_ADMIN_NO_BYPASS` was removed from the list on disk (marker count 1 to 0, blob `4d06d8f…` to `16abaa7…`, both against the HEAD blob). Under that mutation: the OLD self-referential pin ("each write-granting target set denies create/edit/delete on every managed object") stayed **green** — the blind spot — while the NEW independent-property pin went **red** naming exactly `['organization_admin_no_bypass']`; the positive test, reverse control, and both exact-membership tests also went red (5 failed / 26 passed, every direction as predicted). Restore proven by state: blob hash equal to the HEAD blob, `git diff HEAD` empty, marker count 1. The mutation reaches the run via in-package relative imports under vitest (source resolution — no dist leg to rebuild for these suites).
- **Reverse control**: with the full static registry plus one future table applied, every entry the variant already names (all 28 baseline entries, the `'*'` wildcard, the `sys_position` RBAC read-only block) survives unchanged; only the future table is added.
- **Controls**: `admin_full_access` untouched by the injection (deep-equal before/after) and still outside the list (pinned); the four existing target sets keep their existing pins unchanged and green — the fix adds a fifth target, it does not move the four.
- **Suites**: `@objectstack/plugin-security` full suite 94 files / 1770 tests green; `typecheck` (all three tsc programs) green; `tsc --listFiles` shows all four edited files inside the compiled programs (sources in main+test, tests in the test program).
- **Gates**: re-derived from the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no path args), both sections read whole — 36 harvested families run locally, 35 exit 0 (including `check:type-check-debt` re-measure, `check:i18n`, `check:engine-double-contract`, `check:where-matcher`); `scripts/check-test-completeness.mjs` exited 3 = PREREQUISITE NOT MET = NOT MEASURED (it parses CI shard summaries that do not exist locally; CI's Test Core shards own it). Full-repo `pnpm lint` (eslint, no-inline-config) exit 0. All exit codes captured before any pipe.

## Release note

`.changeset/no-bypass-managed-deny-target.md` — patch on `@objectstack/plugin-security`.

Session: https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs

_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZC5rNQj3WEet5HAmmAkMs)_