### PR TITLE
fix(driver-sql): apply `bulkUpdate` as one transaction so a mid-batch refusal rolls back the rows already applied

### DIFF
--- a/.changeset/sql-bulk-update-transaction.md
+++ b/.changeset/sql-bulk-update-transaction.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+fix(driver-sql): `bulkUpdate` applies as one transaction, so a mid-batch refusal rolls back the rows already applied (#13854)
+
+`SqlDriver.bulkUpdate` is a sequential loop of individual `update()` calls — one
+per id, because each id carries its own patch and no single statement expresses
+N different SET lists. That loop had no transaction around it, so every
+`update()` autocommitted its own row. A batch refused partway through — a unique
+violation on a later row, a NOT NULL violation, any per-row failure from the
+database — left every row processed **before** the refusal permanently
+committed. The caller received an exception while the database held a state
+nobody declared: neither the pre-image nor the post-image, and a retry of the
+same array was not safe.
+
+The loop now runs inside a transaction, so the batch applies as one unit.
+`driver-turso` reaches this door through `super.bulkUpdate` and inherits the
+repair; no subclass change is needed or was made.
+
+Same defect class #13340/#13435 closed on `driver-memory`'s batch doors, on the
+production SQL driver. `bulkDelete` was measured and is untouched — it is a
+single `whereIn(...).delete()` per rotation shard, already atomic per shard.
+
+**Behaviour inside a caller's transaction.** When the caller supplies
+`options.transaction`, the batch runs in a nested transaction (a `SAVEPOINT`) on
+that same transaction rather than opening a competing one. A refused batch is
+undone as a unit, the caller's own surrounding work is untouched, and the
+caller's transaction stays usable — so a caller that catches the refusal and
+commits anyway no longer lands a partial batch.
+
+No API, signature or accepted-input change: every input accepted before is
+accepted after, and every refusal that fired before still fires. A missing id is
+still skipped rather than refused, unchanged.

--- a/packages/drivers/driver-sql/src/sql-driver-13854-bulk-update-atomicity.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-13854-bulk-update-atomicity.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#13854] `SqlDriver.bulkUpdate` is a sequential `for`-`await` over individual
+ * `update()` calls. Each of those autocommitted its own row, so a batch refused
+ * partway through left every row processed BEFORE the refusal permanently
+ * committed — the caller got an exception and the database held a state nobody
+ * declared. `driver-turso` reaches the same door through `super.bulkUpdate`,
+ * which is why the pin lives here, on the parent.
+ *
+ * ## What makes this file a measurement rather than a green suite
+ *
+ * §1 and §4 each assert three things, and only the THIRD one is this card:
+ *
+ *   1. the batch refuses (passes on the broken code too);
+ *   2. the call throws (passes on the broken code too);
+ *   3. ⭐ the EARLIER row is unchanged **in the database** — read back through a
+ *      bare knex query against the physical table rather than from the return
+ *      value, because the return value of a throwing call is not evidence about
+ *      storage, and the driver's own read path is not an independent witness.
+ *
+ * Reverse verification (direction predicted before running): restoring `main`'s
+ * body — the bare loop, no transaction — leaves assertions 1 and 2 green and
+ * turns assertion 3 red in §1 and §4, with the received value being the
+ * committed post-image (`'first-updated'` where `'first'` is asserted). §2, §3,
+ * §5 and §6 stay green in both directions: they pin what must NOT change.
+ *
+ * ## Which refusal, and why not the obvious one
+ *
+ * ⚠️ A missing id does NOT refuse on this door: `update()` issues an UPDATE
+ * matching zero rows and returns `null`, which `bulkUpdate` skips
+ * (`if (updated)`). A pin built on one would measure nothing — it never throws.
+ * §6 pins that skip, since the card must not change it. The refusal used here is
+ * the database's own: a `unique: 'global'` string column, and a later row in the
+ * batch assigned a value a THIRD row already holds. Measured on better-sqlite3
+ * as `SQLITE_CONSTRAINT_UNIQUE` / `UNIQUE constraint failed: account.code`; the
+ * assertion accepts the Postgres and MySQL spellings too, the vocabulary this
+ * package's other constraint tests assert on.
+ *
+ * `unique: 'global'` rather than `unique: true` on purpose: it materializes a
+ * single-column index on every tenancy posture (ADR-0120 D1), so the refusal
+ * this file depends on cannot be re-scoped by a change to the tenancy composite.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SqlDriver } from '../src/index.js';
+
+/** These fixtures are not tenant-scoped; the audit warning is not under test. */
+const OPTS = { bypassTenantAudit: true } as any;
+
+describe('SqlDriver.bulkUpdate atomicity (#13854)', () => {
+  let driver: SqlDriver;
+
+  beforeEach(async () => {
+    driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    } as any);
+    await driver.initObjects([
+      {
+        name: 'account',
+        fields: {
+          code: { type: 'string', unique: 'global' },
+          name: { type: 'string' },
+        },
+      },
+    ] as any);
+    await driver.create('account', { id: 'a', code: 'A-1', name: 'first' }, OPTS);
+    await driver.create('account', { id: 'b', code: 'B-1', name: 'second' }, OPTS);
+    await driver.create('account', { id: 'c', code: 'C-1', name: 'third' }, OPTS);
+  });
+
+  afterEach(async () => {
+    await driver.disconnect();
+  });
+
+  /**
+   * Read a row straight from the physical table, bypassing the driver's read
+   * path entirely — the independent witness assertion 3 needs.
+   */
+  const stored = async (id: string): Promise<Record<string, any> | undefined> =>
+    (driver as any).knex('account').where('id', id).first();
+
+  /**
+   * A batch whose SECOND entry collides with row `c`'s code. The first entry is
+   * a perfectly good update, and on `main` it committed.
+   */
+  const COLLIDING_BATCH = [
+    { id: 'a', data: { name: 'first-updated' } },
+    { id: 'b', data: { code: 'C-1' } },
+  ];
+
+  it('§1 rolls the whole batch back when a LATER row refuses (no caller transaction)', async () => {
+    // 1 + 2 — the batch refuses and the call throws. Both pass on `main` too.
+    await expect(driver.bulkUpdate('account', COLLIDING_BATCH, OPTS)).rejects.toThrow(
+      /UNIQUE constraint failed|duplicate key value|ER_DUP_ENTRY/,
+    );
+
+    // 3 ⭐ — the entire card. The earlier row was applied and then undone.
+    expect((await stored('a'))?.name).toBe('first');
+
+    // The refused row itself, and the row it collided with, are also untouched.
+    expect((await stored('b'))?.code).toBe('B-1');
+    expect((await stored('c'))?.code).toBe('C-1');
+  });
+
+  it('§2 leaves rows outside the batch alone', async () => {
+    await expect(driver.bulkUpdate('account', COLLIDING_BATCH, OPTS)).rejects.toThrow();
+    expect((await stored('c'))?.name).toBe('third');
+  });
+
+  it('§3 still commits every row when the batch succeeds', async () => {
+    const results = await driver.bulkUpdate(
+      'account',
+      [
+        { id: 'a', data: { name: 'first-updated' } },
+        { id: 'b', data: { name: 'second-updated' } },
+      ],
+      OPTS,
+    );
+
+    expect(results).toHaveLength(2);
+    expect((await stored('a'))?.name).toBe('first-updated');
+    expect((await stored('b'))?.name).toBe('second-updated');
+  });
+
+  /**
+   * The boundary the card's dispatch flagged as the likeliest surprise: a caller
+   * can already own a transaction (`beginTransaction()` is public API, exercised
+   * by `sql-driver-multiwrite-tx.test.ts`), and SQLite's pool hands out exactly
+   * ONE connection — so the wrapper must ride the caller's transaction rather
+   * than ask `this.knex` for a second connection, which would dead-lock.
+   *
+   * It rides it as a knex NESTED transaction (a `SAVEPOINT`), so the batch is
+   * undone as a unit while the caller's own earlier write inside the same
+   * transaction survives and the transaction stays usable. Joining WITHOUT the
+   * savepoint would leave the caller who catches the refusal and commits anyway
+   * holding exactly the partial batch this card is about.
+   */
+  it('§4 undoes the batch inside a caller transaction, leaving that transaction usable', async () => {
+    const trx = await driver.beginTransaction();
+
+    // The caller's OWN write, before the batch. It must survive the batch's
+    // rollback — the savepoint undoes the batch, not the caller's work.
+    await driver.update('account', 'c', { name: 'caller-own-write' }, { ...OPTS, transaction: trx });
+
+    await expect(
+      driver.bulkUpdate('account', COLLIDING_BATCH, { ...OPTS, transaction: trx }),
+    ).rejects.toThrow(/UNIQUE constraint failed|duplicate key value|ER_DUP_ENTRY/);
+
+    // The transaction survived the refusal, so the caller can still commit it.
+    await driver.commit(trx);
+
+    // 3 ⭐ — the batch's earlier row is undone…
+    expect((await stored('a'))?.name).toBe('first');
+    expect((await stored('b'))?.code).toBe('B-1');
+    // …and the caller's own write, which the batch never touched, is committed.
+    expect((await stored('c'))?.name).toBe('caller-own-write');
+  });
+
+  it('§5 issues nothing for an empty batch', async () => {
+    await expect(driver.bulkUpdate('account', [], OPTS)).resolves.toEqual([]);
+  });
+
+  it('§6 still skips a missing id rather than refusing the batch', async () => {
+    // The convention #13435 deferred to, unchanged: no throw, no placeholder in
+    // the returned array, and the real row is updated.
+    const results = await driver.bulkUpdate(
+      'account',
+      [
+        { id: 'a', data: { name: 'first-updated' } },
+        { id: 'no-such-row', data: { name: 'ignored' } },
+      ],
+      OPTS,
+    );
+
+    expect(results).toHaveLength(1);
+    expect((await stored('a'))?.name).toBe('first-updated');
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -7705,17 +7705,78 @@ export class SqlDriver implements IDataDriver {
   }
 
   /**
-   * Batch-update multiple records by ID.
-   * NOTE: Current implementation performs sequential updates for correctness.
-   * TODO: Optimize with SQL CASE statements or batched transactions for performance.
+   * Batch-update multiple records by ID — atomically, as ONE unit.
+   *
+   * [#13854] The loop itself is unchanged, and deliberately so: each id carries
+   * its OWN patch, so there is no single statement that expresses N different
+   * SET lists (the reason `bulkCreate`'s "send it as one INSERT" shape does not
+   * transfer). What this card changed is the transaction boundary around it.
+   *
+   * ## The defect
+   *
+   * With no boundary, every `update()` autocommitted its own row —
+   * {@link getBuilder} hands back a plain `this.knex` builder whenever
+   * `options.transaction` is unset — so a batch refused partway through left
+   * every row processed BEFORE the refusal permanently committed. The caller
+   * got an exception and the database was left in a state nobody declared:
+   * neither the pre-image nor the post-image. Same defect class #13340/#13435
+   * closed on `driver-memory`'s batch doors; `driver-turso` reaches this door
+   * through `super.bulkUpdate`, which is why the repair belongs to the parent
+   * and patching the subclass would only wait for the next subclass.
+   *
+   * ⚠️ A missing id is NOT the reachable failure on this door, and a pin that
+   * uses one measures nothing: `update()` issues an UPDATE matching zero rows
+   * and returns `null`, which this loop skips (`if (updated)`). That skip is
+   * the established convention #13435's note defers to, and it is unchanged
+   * here. The reachable refusals are the database's own — a unique violation on
+   * a later row, a NOT NULL violation, a bind refusal.
+   *
+   * {@link bulkDelete} needs no such wrapper: it is one `whereIn(...).delete()`
+   * per rotation shard, atomic per shard on its own.
+   *
+   * ## One runner, two meanings — and why the caller's transaction is fenced
+   *
+   * With no caller transaction, `this.knex.transaction()` opens the driver's
+   * own — the shape {@link upsert}'s `verifyIdentity` branch uses. Inside a
+   * caller transaction, `trx.transaction()` opens a knex NESTED transaction: a
+   * `SAVEPOINT`, released on success and rolled back to on failure, the exact
+   * primitive {@link attemptWithoutPoisoning} is built on and which this file
+   * has verified on PG 16 and on better-sqlite3 at pool `max: 1`, where the
+   * savepoint rides the parent's connection and never asks the pool for a
+   * second one.
+   *
+   * ⚠️ Joining the caller's transaction WITHOUT a savepoint — the posture
+   * {@link upsert} takes at its own boundary — would be wrong here, and the
+   * difference is N statements versus one. `upsert` reasons that "the statement
+   * is already transactional", which is true of one statement and false of this
+   * loop: a caller that catches the refusal and commits its transaction anyway
+   * lands precisely the partial batch this card is about. That is reachable on
+   * SQLite and MySQL; Postgres aborts the whole transaction on any statement
+   * error, so it is the one dialect where the hole was already shut by
+   * accident. The savepoint makes "every row applied in THIS call is undone"
+   * true whatever the caller wraps around it, while leaving that transaction
+   * usable — the rollback decision for the caller's OWN work stays the
+   * caller's, which is the half of `upsert`'s reasoning that does transfer.
    */
   async bulkUpdate(object: string, updates: Array<{ id: string | number; data: Record<string, any> }>, options?: DriverOptions): Promise<Record<string, any>[]> {
-    const results: Record<string, any>[] = [];
-    for (const { id, data } of updates) {
-      const updated = await this.update(object, id, data, options);
-      if (updated) results.push(updated);
-    }
-    return results;
+    // An empty batch issues no statement, exactly as before: a BEGIN/COMMIT
+    // pair — and the pool checkout behind it — buys nothing for zero rows.
+    if (updates.length === 0) return [];
+
+    const applyAll = async (scoped: DriverOptions): Promise<Record<string, any>[]> => {
+      const results: Record<string, any>[] = [];
+      for (const { id, data } of updates) {
+        const updated = await this.update(object, id, data, scoped);
+        if (updated) results.push(updated);
+      }
+      return results;
+    };
+
+    // The `(caller's transaction) ?? this.knex` runner idiom this file already
+    // uses (see {@link collidingAutoNumberReservations}); here the choice of
+    // runner is also the choice between a transaction and a savepoint.
+    const runner: Knex | Knex.Transaction = (options?.transaction as Knex.Transaction | undefined) ?? this.knex;
+    return runner.transaction(async (trx) => applyAll({ ...options, transaction: trx }));
   }
 
   async bulkDelete(object: string, ids: Array<string | number>, options?: DriverOptions): Promise<void> {


### PR DESCRIPTION
Fixes #13854

`SqlDriver.bulkUpdate` is a sequential `for`-`await` over individual `update()` calls with no transaction around it, so each `update()` autocommitted its own row. A batch refused partway through left every row processed **before** the refusal permanently committed: the caller received an exception while the database held a state nobody declared — neither the pre-image nor the post-image — and a retry of the same array was not safe.

The loop now runs inside a transaction. The loop itself is unchanged and deliberately so: each id carries its own patch, so no single statement expresses N different SET lists (which is why `bulkCreate`'s "send the batch as one INSERT" shape does not transfer). What changed is the boundary around it.

Same defect class #13340 / #13435 closed on `driver-memory`'s batch doors, here on the production default SQL driver.

## Mechanism — the file's own, no new one and no new dependency

`SqlDriver` already carries transaction support, and this reuses it rather than inventing a second mechanism:

```
const runner: Knex | Knex.Transaction = (options?.transaction as Knex.Transaction | undefined) ?? this.knex;
return runner.transaction(async (trx) => applyAll({ ...options, transaction: trx }));
```

The `(caller's transaction) ?? this.knex` runner idiom is the one `collidingAutoNumberReservations` already uses; `getBuilder` routes every statement onto `options.transaction` via `.transacting(trx)`, so the whole loop — including the rotation-shard path through `rotatedUpdateById`, which threads `options` the same way — rides the one boundary.

**The choice of runner is also the choice between a transaction and a savepoint**, which is what makes the caller-transaction case correct:

- **No caller transaction** — `this.knex.transaction()` opens the driver's own, the shape `upsert`'s `verifyIdentity` branch uses.
- **Inside a caller transaction** — `trx.transaction()` opens a knex **nested** transaction: a `SAVEPOINT`, released on success and rolled back to on failure. That is the primitive `attemptWithoutPoisoning` is built on, already verified in this file on PG 16 and on better-sqlite3 at pool `max: 1`, where the savepoint rides the parent's connection and never asks the pool for a second one. This matters concretely here: SQLite hands out exactly one connection (`assertBareKnexSafe`'s subject), so a wrapper that reached for `this.knex` while a caller held a transaction would dead-lock.

⚠️ Joining a caller's transaction *without* a savepoint — the posture `upsert` takes at its own boundary — would be wrong here, and the difference is N statements versus one. `upsert` reasons "the statement is already transactional", true of one statement and false of this loop: a caller that catches the refusal and commits anyway lands exactly the partial batch this card is about, reachable on SQLite and MySQL (Postgres aborts the whole transaction on any statement error, so it is the one dialect where the hole was already shut by accident). The half of `upsert`'s reasoning that does transfer is kept — the rollback decision for the caller's **own** work stays the caller's, and its transaction is left usable.

An empty batch still issues no statement at all, so that path is byte-identical to `main`.

## `driver-turso` is untouched, by design

`TursoDriver extends SqlDriver` and overrides `bulkUpdate` only to route the **remote** path to `remoteTransport`; its local path is `return super.bulkUpdate(object, updates, options)`. It therefore inherits this repair with no subclass change — which is the point, since patching the subclass would leave the next subclass in the same hole. The remote transport path is a different door and is not addressed here.

## Evidence — the pin would have been red before

`packages/drivers/driver-sql/src/sql-driver-13854-bulk-update-atomicity.test.ts`. §1 and §4 each assert three things, and only the third is this card:

1. the batch refuses; 2. the call throws — **both pass on the broken code too**; and
3. the earlier row is unchanged **in the database**, read back through a bare knex query against the physical table rather than from the return value of a throwing call.

**Which refusal, measured rather than assumed.** A missing id does *not* refuse on this door: `update()` issues an UPDATE matching zero rows and returns `null`, which the loop skips — a pin built on one would never throw and would measure nothing. §6 pins that skip, since this card must not change it. The refusal used is the database's own: a `unique: 'global'` column with a later row in the batch assigned a value a third row already holds, measured on better-sqlite3 as `UNIQUE constraint failed: account.code`.

**Ablation** (on the committed tree, direction predicted before running). Reverting the wrapper to `main`'s bare loop was confirmed on disk before any reading was taken — anchor counts moved `1 to 0` and `0 to 1` in the two directions, and the blob hash moved `0bb4e792 to d8efbb46` — rather than trusting the editor's exit code:

```
Tests  2 failed | 4 passed (6)

FAIL §1 rolls the whole batch back when a LATER row refuses (no caller transaction)
AssertionError: expected 'first-updated' to be 'first'
  101|     expect((await stored('a'))?.name).toBe('first');

FAIL §4 undoes the batch inside a caller transaction, leaving that transaction usable
AssertionError: expected 'first-updated' to be 'first'
  156|     expect((await stored('a'))?.name).toBe('first');
```

Exactly assertion 3, in both sections, with the received value being the committed post-image. Assertions 1 and 2 stayed green, and §2/§3/§5/§6 stayed green — they pin what must not change. Restored with an absolute-path `git checkout HEAD -- FILE`, proven by an empty `git diff HEAD` and a blob hash back to `0bb4e792`.

No build is involved in that ablation and none is owed: the pin imports `../src/index.js`, a relative source path, so the run reads the mutated source directly — which the red itself demonstrates.

## The reading #13854 owed on `driver-mongodb`

Measured, and the answer is **not the same shape** (`mongodb-driver.ts`):

- `bulkUpdate` (`:505`) is **not** a per-row loop. It maps the updates into `bulkOps` and issues **one** `collection.bulkWrite(bulkOps, { session })`.
- `bulkDelete` (`:534`) is one `collection.deleteMany({ id: { $in: ids } }, { session })` — the same single-statement shape as `SqlDriver.bulkDelete`.
- `session` is `getSession(options)` (`:687`) = `options.transaction as ClientSession`, the same parameterisation convention.

So the autocommit loop repaired here does not exist there. A **related** exposure may still be reachable by a different mechanism — `bulkWrite` stops at the first failing op but does not undo earlier ones without a transaction, and mongo transactions need a replica set, so the repair is not a mechanical port of this one. Filed separately as **#14169** rather than widening this PR into a third package, with the measured and not-measured halves marked apart.

## Verification

All at `8345bb5a`, the final commit.

- `pnpm --filter @objectstack/driver-sql exec vitest run --maxWorkers=2` — **150 passed / 9 skipped (159 files), 2279 tests passed / 136 skipped, zero failures**. The 9 skipped files are the live-dialect matrix with no Postgres/MySQL URL provisioned.
- `pnpm --filter @objectstack/driver-sql typecheck` — clean, and measured to actually cover the new test file (`tsc --listFiles` reports 1 hit; this package's tsconfig includes `src/**/*` with no test exclusion, so the green is about the new file too).
- `pnpm --filter '@objectstack/driver-sql^...' build` before the suite, so nothing read a stale `dist`.
- Gate family derived at the actual diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (35 commands) and run with exit codes captured by redirect before any pipe: **33 measured green**. Three are `PREREQUISITE NOT MET` / exit 3 — `check-test-completeness`, `check:dual-build-cjs-loads`, `check:type-check-debt` — each of which needs a full workspace build and says in its own words that it is "NOT a pass and NOT a finding: nothing was measured". Recorded as NOT MEASURED, not as passes; CI runs them with the build in place.

Scope narrowing, declared: `driver-sql` has 48 downstream packages and the farm belongs to CI. The `driver-turso` question — the one that matters, since it inherits this door — was settled statically by reading its override (local path delegates to `super.bulkUpdate`) rather than by a suite run; a downstream build sweep was attempted and abandoned after it failed on an unrelated filter artifact (`@objectstack/runtime`'s DTS build cannot resolve `@objectstack/rest`, which is not a dependency of either driver and was never built by the filter).

Clause-②: **no** — re-declared from the actual diff. No exported type, signature or public error shape changes; every input accepted before is accepted after and every refusal that fired before still fires. What changes is what survives a mid-batch refusal.

_Generated by [Claude Code](https://claude.ai/code/session_01Q5WBDtaUnoz5XuJ6jk8pQ5)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5WBDtaUnoz5XuJ6jk8pQ5)_