### PR TITLE
fix(devx): break the one workspace manifest cycle that makes `pnpm --filter 'PKG^...' build` unorderable

### DIFF
--- a/.changeset/workspace-graph-acyclic-driver-turso-verify.md
+++ b/.changeset/workspace-graph-acyclic-driver-turso-verify.md
@@ -1,0 +1,43 @@
+---
+"@objectstack/driver-turso": patch
+---
+
+chore(driver-turso): drop the `@objectstack/verify` devDependency — the one edge that made this workspace's manifest graph cyclic (#13513)
+
+No runtime, API or type change: `dist` is byte-identical, and a consumer never
+installs a devDependency. What changes is the workspace's own build graph.
+
+**The defect.** `@objectstack/driver-turso` carried `@objectstack/verify` as a
+devDependency so that one test file — `src/date-bucket-parity.test.ts` — could
+import `checkDateBucketParity`. That closed a heterogeneous cycle across three
+different declaration classes:
+
+```
+@objectstack/runtime      --peerDependencies(optional)-->  @objectstack/driver-turso
+@objectstack/driver-turso --devDependencies----------->    @objectstack/verify
+@objectstack/verify       --dependencies-------------->    @objectstack/runtime
+```
+
+pnpm walks all four declaration classes when it computes a `PKG^...` / `PKG...`
+selection, so the cycle left those selections with no topological order. pnpm
+does not refuse a cyclic selection — it schedules the members **concurrently**,
+so `@objectstack/verify`'s DTS leg reads a sibling's `dist` while that sibling
+is still emitting it. The run then dies with `TS2307`/`TS7016` naming a module
+the author never imported, in a package the author never touched, which reads
+exactly like "your branch broke an import". Seven seats paid for that
+misattribution on unmodified trees. `pnpm install` had been printing
+`WARN There are cyclic workspace dependencies` on every install throughout.
+
+**Why this edge.** Measured over all 78 workspace manifests: this was the
+**only single edge** whose removal makes the whole graph acyclic. Cutting the
+`runtime → driver-turso` peer edge instead is not sufficient on its own — a
+second optional-peer edge (`service-datasource → driver-turso`) closes the same
+loop through `plugin-auth → rest → service-datasource`.
+
+**Where the test went.** `date-bucket-parity.test.ts` moved to
+`packages/qa/dogfood/test/date-bucket-parity-turso.test.ts`, which is where this
+repo already keeps `@objectstack/verify`-based cross-package conformance —
+`date-bucket-parity-conformance.test.ts` next door runs the same
+`checkDateBucketParity` over `driver-sql` and `driver-sqlite-wasm`, both of them
+`@objectstack/dogfood` devDependencies for exactly this reason. All five cases
+moved intact and all five still run by name, negative control included.

--- a/packages/drivers/driver-turso/package.json
+++ b/packages/drivers/driver-turso/package.json
@@ -45,7 +45,6 @@
     }
   },
   "devDependencies": {
-    "@objectstack/verify": "workspace:*",
     "@types/node": "^26.2.0",
     "better-sqlite3": "^13.0.3",
     "typescript": "^6.0.3",

--- a/packages/qa/dogfood/package.json
+++ b/packages/qa/dogfood/package.json
@@ -38,6 +38,7 @@
     "@objectstack/core": "workspace:*",
     "@objectstack/driver-sql": "workspace:*",
     "@objectstack/driver-sqlite-wasm": "workspace:*",
+    "@objectstack/driver-turso": "workspace:*",
     "@types/node": "^26.2.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/qa/dogfood/test/date-bucket-parity-turso.test.ts
+++ b/packages/qa/dogfood/test/date-bucket-parity-turso.test.ts
@@ -50,12 +50,16 @@
  * of which are `@objectstack/dogfood` devDependencies for exactly this reason.
  * TursoDriver was the outlier, and it is the outlier that closed the loop.
  *
- * ⚠️ One thing DID change with the move: `TursoDriver` now resolves through the
- * package's `exports` (its BUILT `dist`), not through a relative source import.
- * That matches how `driver-sqlite-wasm` is exercised next door — and the
- * comment there names the same property — but it means this suite needs
- * `@objectstack/driver-turso` built, which the dogfood gate already requires of
- * every package it imports.
+ * ⭐ The move is semantics-preserving on the one axis that could have changed
+ * silently. In its old home this suite imported `./turso-driver.js` — the
+ * driver's SOURCE — so its verdict was about the checkout. A bare
+ * `@objectstack/driver-turso` specifier would instead resolve through the
+ * package's `exports` map to the BUILT `dist`, turning a source pin into a
+ * verdict about the last `pnpm build`. Two declarations keep it a source pin,
+ * and each is enforced by its own gate: an anchored `resolve.alias` entry in
+ * this package's `vitest.config.ts` (`check:test-source-alias`) and a `paths`
+ * rule in its `tsconfig.json` (`check:type-source-resolution`). Both carry the
+ * reasoning at the site.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/qa/dogfood/test/date-bucket-parity-turso.test.ts
+++ b/packages/qa/dogfood/test/date-bucket-parity-turso.test.ts
@@ -23,11 +23,44 @@
  *
  * What each mode is worth is stated explicitly below, because the honest answer
  * differs per mode and a vacuous pass must not read as coverage.
+ *
+ * ## Why this suite lives in `packages/qa/dogfood` and not in the driver (#13513)
+ *
+ * It used to be `packages/drivers/driver-turso/src/date-bucket-parity.test.ts`,
+ * and the `@objectstack/verify` devDependency it needed was the ONE edge that
+ * made this workspace's manifest graph cyclic:
+ *
+ *     runtime --peerDependencies(optional)--> driver-turso
+ *     driver-turso --devDependencies--------> verify
+ *     verify --dependencies-----------------> runtime
+ *
+ * pnpm walks all four declaration classes when it computes a `PKG^...` /
+ * `PKG...` closure, so that cycle left `pnpm --filter '<pkg>^...' build` with no
+ * topological order to build in. pnpm does not refuse a cyclic selection — it
+ * schedules the members CONCURRENTLY, so `verify`'s DTS leg reads a `dist` that
+ * a sibling is still emitting, and the run dies with `TS2307`/`TS7016` naming a
+ * module the author never touched. Seven seats paid for that misattribution on
+ * unmodified trees before it was traced. Measured on 78 workspace manifests,
+ * this was the ONLY single edge whose removal makes the whole graph acyclic.
+ *
+ * Nothing about this suite wanted to live in the driver: the repo's convention
+ * for `@objectstack/verify`-based cross-package conformance is already this
+ * package — `date-bucket-parity-conformance.test.ts` next door runs the very
+ * same `checkDateBucketParity` over `driver-sql` and `driver-sqlite-wasm`, both
+ * of which are `@objectstack/dogfood` devDependencies for exactly this reason.
+ * TursoDriver was the outlier, and it is the outlier that closed the loop.
+ *
+ * ⚠️ One thing DID change with the move: `TursoDriver` now resolves through the
+ * package's `exports` (its BUILT `dist`), not through a relative source import.
+ * That matches how `driver-sqlite-wasm` is exercised next door — and the
+ * comment there names the same property — but it means this suite needs
+ * `@objectstack/driver-turso` built, which the dogfood gate already requires of
+ * every package it imports.
  */
 
 import { describe, it, expect } from 'vitest';
 import { checkDateBucketParity } from '@objectstack/verify';
-import { TursoDriver } from './turso-driver.js';
+import { TursoDriver } from '@objectstack/driver-turso';
 
 describe('TursoDriver date-bucket parity (framework#3773)', () => {
   describe('local mode — the real check', () => {

--- a/packages/qa/dogfood/tsconfig.json
+++ b/packages/qa/dogfood/tsconfig.json
@@ -16,7 +16,29 @@
     // package-internal on purpose (the guard's data, not public API), so
     // there is no entry point to import them from. Every other ledger guard
     // in the repo compiles them as relative sources for the same reason.
-    "rootDir": "../../.."
+    "rootDir": "../../..",
+    // [#13513] `test/date-bucket-parity-turso.test.ts` imports `TursoDriver` as
+    // a VALUE and drives it. Without this rule tsc resolves the specifier
+    // through the package's `exports` map — `dist/index.d.ts`, A BUILD ARTIFACT
+    // — so this suite's type verdict would be about the last `pnpm build`
+    // rather than about the driver source in the checkout, which is exactly
+    // what `check:type-source-resolution` refuses.
+    //
+    // The suite used to live inside `packages/drivers/driver-turso` and resolve
+    // the class through a relative source import; this rule is what keeps that
+    // property across the move. The move itself is #13513's cycle cut — the
+    // driver's `@objectstack/verify` devDependency was the one edge that made
+    // this workspace's manifest graph cyclic — not a change of intent about
+    // what the suite measures.
+    //
+    // ONE bare-name rule, no star: this package's `exports` map carries only
+    // `"."`, and a `paths` target matching nothing on disk is worse than absent
+    // — tsc falls back to node resolution, i.e. to `dist`, silently. `rootDir`
+    // already spans the repo root, so pulling the driver's source into this
+    // program needs no widening.
+    "paths": {
+      "@objectstack/driver-turso": ["../../drivers/driver-turso/src/index.ts"]
+    }
   },
   "include": ["test/**/*"],
   "exclude": ["node_modules"]

--- a/packages/qa/dogfood/vitest.config.ts
+++ b/packages/qa/dogfood/vitest.config.ts
@@ -69,10 +69,24 @@ export default defineConfig({
     // Aliasing is graph-wide, so packages still loaded from dist (objectql,
     // plugin-security, …) resolve their own `@objectstack/metadata-core`
     // imports to this same single source instance rather than a second copy.
+    // [#13513] `date-bucket-parity-turso.test.ts` drives `TursoDriver` itself —
+    // it asserts the driver's SQL date bucketing against the in-memory
+    // reference, plus the on-disk storage form SqlDriver writes. That verdict
+    // has to be about the driver source in this checkout, not about the last
+    // `pnpm build`, and it was: the suite used to live inside
+    // `packages/drivers/driver-turso` and imported `./turso-driver.js`
+    // relatively. It moved here because the `@objectstack/verify` devDependency
+    // it needs was the one edge that made this workspace's manifest graph
+    // cyclic; this alias is what keeps the move semantics-preserving rather than
+    // quietly converting a source pin into a dist pin.
     alias: [
       {
         find: /^@objectstack\/metadata-core$/,
         replacement: path.resolve(__dirname, '../../metadata-core/src/index.ts'),
+      },
+      {
+        find: /^@objectstack\/driver-turso$/,
+        replacement: path.resolve(__dirname, '../../drivers/driver-turso/src/index.ts'),
       },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1046,9 +1046,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@objectstack/verify':
-        specifier: workspace:*
-        version: link:../../verify
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -1959,6 +1956,9 @@ importers:
       '@objectstack/driver-sqlite-wasm':
         specifier: workspace:*
         version: link:../../drivers/driver-sqlite-wasm
+      '@objectstack/driver-turso':
+        specifier: workspace:*
+        version: link:../../drivers/driver-turso
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0

--- a/scripts/check-test-source-alias.mjs
+++ b/scripts/check-test-source-alias.mjs
@@ -383,8 +383,14 @@ const KNOWN_UNALIASED_TEST_IMPORTS = {
   '@objectstack/driver-sqlite-wasm': [
     '@objectstack/core', '@objectstack/driver-sql', '@objectstack/formula', '@objectstack/spec',
   ],
+  // [#13513] `@objectstack/verify` shrank out of this entry when
+  // `src/date-bucket-parity.test.ts` moved to `packages/qa/dogfood`. That test
+  // was the driver's only importer of it, and its devDependency was the one
+  // edge that made this workspace's manifest graph cyclic
+  // (runtime -peer(optional)-> driver-turso -dev-> verify -dep-> runtime), which
+  // left every `pnpm --filter 'PKG^...' build` with no topological order.
   '@objectstack/driver-turso': [
-    '@objectstack/core', '@objectstack/driver-sql', '@objectstack/spec', '@objectstack/verify',
+    '@objectstack/core', '@objectstack/driver-sql', '@objectstack/spec',
   ],
   '@objectstack/example-crm': ['@objectstack/driver-sql', '@objectstack/objectql', '@objectstack/spec'],
   '@objectstack/example-embed-objectql': [

--- a/scripts/check-type-source-resolution.mjs
+++ b/scripts/check-type-source-resolution.mjs
@@ -280,8 +280,14 @@ const KNOWN_DIST_RESOLVED_TYPE_IMPORTS = {
   '@objectstack/driver-sqlite-wasm': [
     '@objectstack/core', '@objectstack/driver-sql', '@objectstack/formula', '@objectstack/spec',
   ],
+  // [#13513] `@objectstack/verify` shrank out of this entry when
+  // `src/date-bucket-parity.test.ts` moved to `packages/qa/dogfood`. That test
+  // was the driver's only importer of it, and its devDependency was the one
+  // edge that made this workspace's manifest graph cyclic
+  // (runtime -peer(optional)-> driver-turso -dev-> verify -dep-> runtime), which
+  // left every `pnpm --filter 'PKG^...' build` with no topological order.
   '@objectstack/driver-turso': [
-    '@objectstack/core', '@objectstack/driver-sql', '@objectstack/spec', '@objectstack/verify',
+    '@objectstack/core', '@objectstack/driver-sql', '@objectstack/spec',
   ],
   '@objectstack/embedder-openai': ['@objectstack/spec'],
   '@objectstack/example-crm': ['@objectstack/driver-sql', '@objectstack/objectql', '@objectstack/spec'],


### PR DESCRIPTION
Fixes #13513

`pnpm --filter 'PKG^...' build` — the closure build the dev contract prescribes as the FIRST command in a fresh worktree — fails on an unmodified `origin/main`, in a package the author never touched, naming a module the author never imported. Seven seats paid for that misattribution before it was traced.

The triage ruling (comment `5479206575`) established the mechanism and said the one open item was a design choice: **which edge to cut**. This PR answers that with a measurement, and the measurement narrows the ruling's three-option table to one.

## What was measured

All numbers below are from a fresh worktree at `45b9051248f86f362b042fa9de63295a8c224073`, exit codes captured before any pipe.

**1. The cycle population is ONE, and the cut set is a single edge.**

Over all 78 workspace manifests, taking `workspace:` edges in all four declaration classes, there is exactly one strongly connected component:

```
SCC (6): verify, driver-turso, service-datasource, rest, plugin-auth, runtime
```

Enumerating every edge in the tree and asking "does removing this one make the WHOLE graph acyclic?" returns exactly one answer:

```
CUT @objectstack/driver-turso --devDependencies--> @objectstack/verify   => acyclic
total single-edge cuts that suffice: 1
```

⭐ **This changes the ruling's table.** Option 2 — touch the `runtime →(peer) driver-turso` edge — is not merely out-of-domain, it is **insufficient on its own**: a second optional-peer edge, `service-datasource →(peer, optional) driver-turso`, closes the same loop through `plugin-auth → rest → service-datasource`. Cutting the peer edge would take at least two manifest changes, one of them in `packages/runtime` (fenced, `domain:cli`, #13331 in flight).

**2. Why an earlier scan honestly reported zero cycles.** Reproduced as a control in the same script: restricting the scan to `dependencies + devDependencies + optionalDependencies` — the edge set comment `5473800149` used — finds **0 cycles**. The loop's first edge is a `peerDependencies` edge, so that scan could not structurally see it. Both readings were correct; only one of them had the peer edges.

**3. pnpm agrees, in its own words.** `pnpm install` on the base tree printed

```
WARN There are cyclic workspace dependencies: …/driver-turso, …/verify, …/runtime
```

on every install. After this change that line is gone.

**4. The paired question from #13750 — FALSIFIED, and in the opposite direction.** The `090f2302e` hypothesis was that `^...` **omits** packages reachable only via optional peers. Discriminating check: `@objectstack/driver-turso` is reachable from `@objectstack/runtime` **only** over optional-peer edges (non-optional-edge-only reachability: `false`; all-edge reachability: `true`), and it **is** present in the measured `pnpm --filter '@objectstack/runtime^...' list` closure. pnpm 10.31.0 walks optional peers into `^...` rather than dropping them — which is precisely how the cyclic member gets dragged in. So both directions have one cause, not two, and no pnpm-semantics work is needed.

**5. The cut is not free — the PM's safety assumption was falsified.** `packages/drivers/driver-turso/src/date-bucket-parity.test.ts` really did import `checkDateBucketParity` from `@objectstack/verify`. So the edge needed a replacement route rather than a deletion.

## What changed

**The edge.** `@objectstack/verify` is no longer a devDependency of `@objectstack/driver-turso`.

**The replacement route is the repo's own convention, not a new one.** The suite moved to `packages/qa/dogfood/test/date-bucket-parity-turso.test.ts`, which is already where `@objectstack/verify`-based cross-package conformance lives: `date-bucket-parity-conformance.test.ts` next door runs the same `checkDateBucketParity` over `driver-sql` and `driver-sqlite-wasm`, both of them `@objectstack/dogfood` devDependencies for exactly this reason. `dogfood` is private and nothing depends on it, so its dev edge to `verify` closes no loop. TursoDriver was the outlier, and the outlier was the edge.

**The move is semantics-preserving on the axis that could have moved silently.** In its old home the suite imported `./turso-driver.js` — SOURCE. A bare `@objectstack/driver-turso` specifier would resolve through the package's `exports` map to built `dist`, turning a source pin into a verdict about the last `pnpm build`. Two gates caught exactly that and both refuse the widen-the-registry repair, so the fix is the declarations they ask for:

| gate | declaration added |
|:--|:--|
| `check:test-source-alias` | anchored `resolve.alias` entry in `packages/qa/dogfood/vitest.config.ts` |
| `check:type-source-resolution` | bare-name `paths` rule in `packages/qa/dogfood/tsconfig.json` |

Proven rather than assumed: `tsc --noEmit --listFiles` over the dogfood program now lists 5 files under `packages/drivers/driver-turso/src/`.

**Two shrink-only registries narrowed.** Both `KNOWN_UNALIASED_TEST_IMPORTS` (in `scripts/check-test-source-alias.mjs`) and the equivalent table in `scripts/check-type-source-resolution.mjs` carried a now-stale `@objectstack/verify` under `@objectstack/driver-turso`; the moved test was the driver's only importer of it. Both are shrinks, never widenings — `node scripts/check-ratchet-remedy-authority.mjs` exits 0.

## Evidence: red before, green after

The red-at-base half is already established on the card across seven independent runs. The green-after half, on this branch:

| spelling | before (card, unmodified `main`) | after (this branch) |
|:--|:--|:--|
| `pnpm --filter '@objectstack/runtime^...' build` | exit 1, `verify` DTS races `runtime`'s dist | **exit 0**, `Scope: 31 of 79`, 0 mentions of `packages/verify` |
| `pnpm --filter '@objectstack/rest^...' build` | exit 1, same shape | **exit 0**, `Scope: 26 of 79`, 0 `TS2307`/`TS7016` |
| `pnpm --filter '@objectstack/dogfood^...' build` (#13750's target) | exit 1 | **exit 0**, `Scope: 64 of 79` |

And the closure membership itself is now what `^` documents:

```
before:  35 packages — CONTAINS @objectstack/runtime itself AND @objectstack/verify
after:   31 packages — runtime absent, verify absent
```

All three builds ran through `scripts/pm/os-verify-lock.sh`; each printed `VERDICT command-exit 0`.

## Tests

- `pnpm --filter @objectstack/dogfood exec vitest run --reporter=verbose test/date-bucket-parity-turso.test.ts test/date-bucket-parity-conformance.test.ts` — **13 passed**, and all five relocated cases run **by name**, negative control (`the checker WOULD catch a driver that advertises a granularity it cannot run`) included, so the move did not make the suite vacuous.
- `pnpm --filter @objectstack/driver-turso test` — **40 files, 1111 tests passed** after losing the moved file.
- `pnpm --filter @objectstack/driver-turso --filter @objectstack/dogfood run typecheck` — exit 0. Both packages' test files are inside their tsc programs (`--listFiles`-confirmed for the new file, so this is a measurement and not a "typecheck excluded my tests" pass).
- `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'` — **70/70 successful**, which is what let the build-dependent gates below be measured rather than skipped.

## Gates

The family was derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, re-derived after the second commit added `scripts/**` and the two dogfood config files, and the 51-family union re-run on the final commit `df935e42`. Every family green except one, which is structurally NOT MEASURED locally:

- `node scripts/check-test-completeness.mjs` — **exit 3, `PREREQUISITE NOT MET`**. It grades a saved `turbo run test` log, and the derived family names it with no argument. Its own message says this branch is unreachable in CI and is not a finding. Recorded as NOT MEASURED, not as a pass.

`pnpm lint`'s scan (`eslint . --no-inline-config`) was run whole rather than narrowed: **5637 files, 0 errors, 0 warnings, exit 0**.

Verdict lines quoted from the gates themselves rather than from a bare `$?`:

```
check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through `dist/`
check-type-source-resolution OK — 96 tsc program(s) across 77 packages scanned; 54 registered as still resolving a workspace dep's types through `dist/`
check-type-check-coverage --re-measure: OK — 27 ledger entr(ies) re-measured, 1217 raw tsc error(s) total, none above its recorded number
OK  check-ratchet-remedy-authority: 182 scripts swept
```

## Out of scope, deliberately

- ⛔ `packages/runtime/package.json` untouched — the peer-edge option is `domain:cli` surface with #13331 in flight, and the measurement above says it would not have sufficed anyway.
- ⛔ `--filter '!@objectstack/verify'` appears nowhere in this change. It was one dev's workaround; the ruling is explicit that it is not the fix and must not become a documented recipe.
- ⛔ No pnpm-semantics change. Optional-peer traversal is pnpm's behaviour, measured and reported, not patched here.
- ⚠️ **The prescription that sends devs into the failing spelling lives in a GOVERNED file** — `.claude/agents/os-dev.md`, lines 127 and 149 (`claude-tree` surface per `scripts/pm/check-governed-merges.mjs`), not in `AGENTS.md` and not under `content/docs/**`. It is reported for routing rather than edited here. With the cycle gone the spelling now works, so the prescription is no longer wrong — but it is still undefended.
- ⚠️ **Nothing prevents the next cyclic dev/peer edge.** No gate in the repo reads the workspace manifest graph for cycles; `pnpm install`'s WARN is the only signal and nothing fails on it. Filed as **#14195** (unassigned, ungraded) rather than bolted on here — a new `check:*` family is a new verification surface and was not part of this card's route.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_