### PR TITLE
docs(protocol): state the launch-window MINOR rule where readers meet it first

### DIFF
--- a/content/docs/protocol/backward-compatibility.mdx
+++ b/content/docs/protocol/backward-compatibility.mdx
@@ -13,17 +13,21 @@ ObjectStack follows strict backward compatibility guarantees to ensure predictab
 
 ## Versioning Strategy
 
-ObjectStack follows [Semantic Versioning 2.0.0](https://semver.org/) (`MAJOR.MINOR.PATCH`):
+<Callout type="warn">
+**While the launch window is open, a breaking change ships as a MINOR release — not a MAJOR one.** Every published `@objectstack/*` package versions in lockstep, so the version number alone is not an upgrade-safety signal. This rule is in force today and overrides the MAJOR/MINOR mapping in the tables below wherever they disagree; read [Launch Window](#launch-window-minor-releases-can-contain-breaking-changes) at the end of this page before you plan an upgrade.
+</Callout>
+
+ObjectStack follows [Semantic Versioning 2.0.0](https://semver.org/) (`MAJOR.MINOR.PATCH`). The table below describes what each component means; the launch-window rule above governs which component a breaking change actually lands in today.
 
 | Version Component | When Incremented | Guarantee |
 |:---|:---|:---|
 | **MAJOR** (X.0.0) | Incompatible API changes | May contain breaking changes |
-| **MINOR** (0.X.0) | New features, backward-compatible | Existing code continues to work |
+| **MINOR** (0.X.0) | New features — and, during the launch window, breaking changes | Existing code may require migration; the [release notes](/docs/releases) lead with what broke |
 | **PATCH** (0.0.X) | Bug fixes, backward-compatible | No behavior changes, only fixes |
 
 ### SemVer Guarantees
 
-- **Zod schemas** are part of the public API surface. Adding optional properties is a MINOR change; removing or renaming properties is a MAJOR change.
+- **Zod schemas** are part of the public API surface. Adding optional properties is a MINOR change; removing or renaming properties is a breaking change, which during the launch window also ships in a MINOR release.
 - **TypeScript types** inferred from Zod (`z.infer<typeof Schema>`) follow the same guarantees as their source schemas.
 - **Helper functions** (e.g., `defineStack`, `defineStudioPlugin`) maintain their call signatures within a MAJOR version.
 - **Input formats** — `defineStack()` accepts both array and map (Record) format for all named metadata collections. Both formats are guaranteed stable within a MAJOR version.
@@ -58,11 +62,14 @@ When a feature, schema property, or API is deprecated, ObjectStack follows a str
 - Code examples are updated to use the replacement
 - CLI tooling may provide automated migration commands
 
-### Phase 3: Removal (next MAJOR release)
+### Phase 3: Removal (MINOR release, during the launch window)
 
 - Deprecated feature is removed from the schema
 - TypeScript types no longer include the property
 - Runtime code no longer supports the feature
+- The removal is called out in the [release notes](/docs/releases) and marked `**BREAKING**` in the changeset
+
+Shipped examples: `17.2.0` retired `http_request_errors_total` and `sys_position.permissions` under [ADR-0049](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0049-no-unenforced-security-properties.md) enforce-or-remove, and `15.1.0` removed `tenancy.strategy` and `tenancy.crossTenantAccess` — all three in **Minor Changes** sections.
 
 ### Timeline Summary
 
@@ -70,11 +77,11 @@ When a feature, schema property, or API is deprecated, ObjectStack follows a str
 flowchart TD
     A["v3.2.0 — feature deprecated (warning emitted)"] --> B["v3.3.0 — migration period continues"]
     B --> C["v3.4.0 — migration continues (minimum 2 minor releases)"]
-    C --> D["v4.0.0 — feature removed (earliest possible removal)"]
+    C --> D["v3.5.0 — feature removed (earliest possible removal, MINOR)"]
 ```
 
 <Callout type="warn">
-**Minimum guarantee:** Deprecated features survive for at least **2 MINOR releases** before they can be removed in the next MAJOR version.
+**Minimum guarantee:** Deprecated features survive for at least **2 MINOR releases** before they can be removed. During the launch window the removal itself lands in a MINOR release, so a MINOR bump is where you should expect a removal to arrive.
 </Callout>
 
 ---
@@ -83,14 +90,16 @@ flowchart TD
 
 ### What Constitutes a Breaking Change
 
-| Change Type | Breaking? | Version Impact |
+Read the **Breaking?** column, not the version number: during the launch window every row below — breaking or not — ships in a MINOR or PATCH release, so the bump size does not tell you whether you have work to do.
+
+| Change Type | Breaking? | Version Impact (launch window) |
 |:---|:---|:---|
-| Removing a schema property | **Yes** | MAJOR |
-| Renaming a schema property | **Yes** | MAJOR |
-| Changing a property from optional to required | **Yes** | MAJOR |
-| Narrowing a type (e.g., `string` → `enum`) | **Yes** | MAJOR |
-| Removing an enum value | **Yes** | MAJOR |
-| Changing default values | **Yes** | MAJOR |
+| Removing a schema property | **Yes** | MINOR |
+| Renaming a schema property | **Yes** | MINOR |
+| Changing a property from optional to required | **Yes** | MINOR |
+| Narrowing a type (e.g., `string` → `enum`) | **Yes** | MINOR |
+| Removing an enum value | **Yes** | MINOR |
+| Changing default values | **Yes** | MINOR |
 | Adding a new optional property | No | MINOR |
 | Adding a new enum value | No | MINOR |
 | Widening a type (e.g., `enum` → `string`) | No | MINOR |
@@ -101,10 +110,9 @@ flowchart TD
 ### Breaking Change Process
 
 1. **RFC (Request for Comments)** — Breaking changes are proposed as GitHub issues with the `breaking-change` label.
-2. **Review Period** — Minimum 30-day community review period.
-3. **Deprecation** — The old behavior is deprecated in a MINOR release (see timeline above).
-4. **Migration Guide** — A detailed migration guide is published before the MAJOR release.
-5. **Release** — Breaking change ships in the next MAJOR version.
+2. **Deprecation** — The old behavior is deprecated in a MINOR release (see timeline above).
+3. **Migration Guide** — A detailed migration guide is published before the removal lands, in the release notes for the version that carries it.
+4. **Release** — During the launch window the breaking change ships in the next **MINOR** version, carrying a changeset entry marked `**BREAKING**`. `scripts/check-changeset-no-major.mjs` fails any pull request that declares a `major` bump, because under lockstep one `major` would promote all 69 published packages.
 
 ---
 
@@ -163,7 +171,7 @@ The `@objectstack/spec` package provides additional stability guarantees:
 ### Export Stability
 
 - All public exports are listed in the package's `index.ts` barrel files
-- Removing an export is always a MAJOR change
+- Removing an export is always a breaking change; during the launch window it ships in a MINOR release
 - Internal modules (prefixed with `_` or in `internal/` directories) are not covered by SemVer guarantees
 
 ### Runtime Behavior
@@ -196,7 +204,7 @@ MAJOR releases do still happen — 17.0.0 was cut precisely because its breaking
 
 ### When it stops applying
 
-The versioning tables and deprecation timeline above describe the policy in its settled form; they take full effect when the launch window closes and a breaking change once again requires a MAJOR. Until then, **this section is the operative rule wherever the two disagree.**
+The tables and deprecation timeline above now state this rule directly, so the page no longer contradicts itself. Classic SemVer — where a breaking change once again requires a MAJOR — is the settled form the project returns to once the launch window closes; the condition that closes the window is tracked separately and is deliberately not stated here. Until it closes, **this section is the operative rule wherever any part of this page disagrees.**
 
 ---
 

--- a/content/docs/releases/index.mdx
+++ b/content/docs/releases/index.mdx
@@ -44,8 +44,28 @@ These pages are curated summaries. For exhaustive, per-package detail:
 
 ## Versioning policy
 
-ObjectStack follows [Semantic Versioning](https://semver.org). A **major**
-release may remove or change schemas in `@objectstack/spec`, public APIs, CLI
-flags, or environment variables — always with a migration path documented in
-the release notes. **Minor** releases add capabilities without breaking
-existing metadata or code. **Patch** releases fix bugs.
+ObjectStack follows [Semantic Versioning](https://semver.org), with one
+override that is in force today: **while the launch window is open, a breaking
+change ships as a minor release.** All `@objectstack/*` packages version in
+lockstep, so a single major bump would promote the whole platform; instead a
+breaking change lands in a **minor** alongside a changeset entry marked
+`**BREAKING**`, and `scripts/check-changeset-no-major.mjs` fails any pull
+request that declares a major bump.
+
+What that means when you read a version number:
+
+- A **major** release may remove or change schemas in `@objectstack/spec`,
+  public APIs, CLI flags, or environment variables — always with a migration
+  path documented in the release notes.
+- A **minor** release adds capabilities, and **may also remove or change those
+  same surfaces**. `17.2.0` retired `http_request_errors_total` and
+  `sys_position.permissions`; `15.1.0` removed `tenancy.strategy` and
+  `tenancy.crossTenantAccess` — all in minor releases. As the v17 notes put it,
+  17.1.0 and 17.2.0 are minors by version number, not by blast radius.
+- A **patch** release fixes bugs.
+
+⚠️ **The version number is not the upgrade-safety signal.** Read the release
+note for the version you are moving to — each one leads with breaking changes
+and migration steps — and see
+[Backward Compatibility](/docs/protocol/backward-compatibility#launch-window-minor-releases-can-contain-breaking-changes)
+for the full policy.


### PR DESCRIPTION
Fixes #13893

Docs-only. Exactly two files, no code riders, per the triage fence ruling (「两页合一个 docs-only PR —— 两处陈述必须同时改才自洽。⛔ 该 PR 不得夹带任何代码。」).

## The defect

Both pages told customers a breaking change takes a MAJOR. The operative rule is the launch-window convention: all **69** published `@objectstack/*` packages sit in one Changesets `fixed` group, and a breaking change ships as a **MINOR**, mechanically enforced by `scripts/check-changeset-no-major.mjs` (enforcing state confirmed on this tree: `.changeset/pre.json` is absent).

Shipped evidence, verified in `packages/spec/CHANGELOG.md` on this tree — all inside `### Minor Changes` sections:

- `17.2.0` — `**BREAKING**` retirement of `http_request_errors_total` and of `sys_position.permissions` (ADR-0049 enforce-or-remove)
- `15.1.0` — removal of `tenancy.strategy` and `tenancy.crossTenantAccess`

## `content/docs/releases/index.mdx` — the unconditionally false page, corrected first

Triage ranked this page as the heavier of the two: it carried **no overriding clause at all** (re-grepped on this tree for launch window / lockstep: 0 hits), so its Minor sentence was false with nothing anywhere on the page to correct it.

- **Before:** *"**Minor** releases add capabilities without breaking existing metadata or code."*
- **After:** the Versioning policy section now leads with the override as the rule in force today, splits major/minor/patch into a list where the minor bullet states that it may remove or change the same surfaces, cites the 17.2.0 and 15.1.0 removals, quotes the v17 notes' own framing (*"minors by version number, not by blast radius"* — verified verbatim at `content/docs/releases/v17.mdx:28`), and ends with the version number not being the upgrade-safety signal plus a link into the protocol page's Launch Window section.

## `content/docs/protocol/backward-compatibility.mdx` — the ordered-false page

Triage's diagnosis was **order of encounter**: the false table sat at `:20`, the correction #13779 added at `:177`, 157 lines apart. So the primary fix is a hoist, not a reword.

| Anchor | Before | After |
|:---|:---|:---|
| Above the SemVer table | (nothing) | New `warn` callout: breaking ships as MINOR during the launch window, overrides the tables below, links to the Launch Window section |
| MINOR row Guarantee | *"Existing code continues to work"* | *"Existing code may require migration; the release notes lead with what broke"*, and the When column now names breaking changes |
| Breaking-change table | 6 rows mapping to `Version Impact: MAJOR` | Column is `Version Impact (launch window)`, those 6 rows read `MINOR`, with a lead-in making **Breaking?** the risk signal rather than the bump size |
| Process step 5 | *"Breaking change ships in the next MAJOR version"* | Ships in the next **MINOR**, with the `**BREAKING**` changeset entry and the `check-changeset-no-major.mjs` mechanism named |
| Phase 3 | *"Removal (next MAJOR release)"* | *"Removal (MINOR release, during the launch window)"*, plus the shipped 17.2.0 / 15.1.0 examples |
| Timeline diagram | `v4.0.0 — feature removed` | `v3.5.0 — feature removed (earliest possible removal, MINOR)` — it illustrates Phase 3 three lines below it |
| Phase-3 summary callout | *"…removed in the next MAJOR version"* | removal lands in a MINOR (the "2 MINOR releases" dwell promise is preserved verbatim — see below) |

### The 30-day claim: deleted, per the binary ruling

Triage ruled this in-scope and binary. Re-grepped independently on this tree over `.github/ scripts/ docs/` for `30-day|30 day|thirty.day`: the grep is live (many hits) but every hit is unrelated — dependency-freshness windows, PM horizon arithmetic, attachment grace periods, grant lifecycle, a backup checklist. A wider check is more decisive: **the only occurrence of the phrase "review period" anywhere in the repository was the claim itself.** A prior audit agrees — `docs/audits/2026-06-handwritten-docs-accuracy-followups.md:51` lists "RFC/30-day review" among policy statements with no backing implementation.

⇒ No mechanism to cite, so the promise is **deleted** and the process renumbered to 4 steps.

### Alignment with #13779's overriding section

Per the fence, that section is the source-of-truth wording and was **not** reworded — its authority sentence is kept and strengthened (*"this section is the operative rule wherever any part of this page disagrees"*). One sentence in it did have to change: it opened *"The versioning tables and deprecation timeline above describe the policy in its settled form"*, which stopped being true once those tables were corrected to state today's rule. It now says the tables state this rule directly and that classic SemVer is the settled form returned to when the window closes.

⛔ The window's **end condition is deliberately not stated** — no date, no version, no criteria — because that belongs to #14043.

### Two same-class lines fixed in place, declared

Beyond the anchors the card enumerates, two lines carried the identical false mapping and would have re-stated it inside the very PR removing it:

- `:26` — *"removing or renaming properties is a MAJOR change"*, one bullet below the corrected table
- `:166` — *"Removing an export is always a MAJOR change"*

Both now say "breaking change, which during the launch window ships in a MINOR release". The "within a MAJOR version" **stability** phrasings elsewhere on the page were left alone — they are a different claim shape, and the hoisted callout governs them.

## Verification

Gate family derived from the real diff by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (the script computes its own change set) — **32 families**. All run at `655c21fa`:

- **31 green.** Five initially returned non-zero and every one printed `PREREQUISITE NOT MET` (unbuilt `@objectstack/formula`, `@objectstack/lint`, `@objectstack/spec`, `@objectstack/client-react`, or a missing `json-schema` tree) — not findings. After `turbo run build` for those packages, four re-ran green, including `check:skill-examples` (*"259 prose examples type-check across 3 surface(s)"*) and `check:docs`.
- **1 NOT MEASURED:** `scripts/check-test-completeness.mjs` grades a saved `turbo run test` log and none exists locally; the gate's own text instructs recording it as NOT MEASURED and states it is not a red.
- `pnpm lint` (`eslint . --no-inline-config`, repo-wide, not narrowed): **exit 0**.
- Exit codes captured by redirecting to a file before reading, never across a pipe.

**Control on the load-bearing anchor.** Both pages now link `#launch-window-minor-releases-can-contain-breaking-changes`, so a green `check:doc-anchors` had to be shown non-vacuous. Mutating that slug to a bogus one in `releases/index.mdx` — mutation confirmed on disk by counting both the removed and injected strings — turned the gate **red** with the expected message (*"renders no heading with id"*). Restored via `git checkout HEAD -- ABSOLUTE_PATH`; restore proven by blob hash matching the HEAD blob and `git diff HEAD` empty.

No changeset: docs-only, nothing published. Expecting the `skip-changeset` label.

## Filed, not fixed here

`#14210` — the page's Breaking Change Process names a `breaking-change` label and the reporting section names a `compatibility` label; measured against the live 61-label set, neither exists (nearest is `protocol:breaking`). Same card also records that the *"minimum 2 MINOR releases"* dwell guarantee has no located mechanism — the same shape as the 30-day claim, but a different defect class from this card's version-number defect, so it was preserved verbatim here rather than widened into this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_