### PR TITLE
test(driver-sql): budget the live-DDL work outside #13902's scoping — 4 it() and 2 beforeAll hooks

### DIFF
--- a/packages/drivers/driver-sql/src/live-dialect-matrix.isolation.test.ts
+++ b/packages/drivers/driver-sql/src/live-dialect-matrix.isolation.test.ts
@@ -278,6 +278,16 @@ describe('live-dialect matrix — the driver can SEE its own isolated schema (#9
     driver = undefined;
   });
 
+  // ── Why the two it() blocks below carry an explicit 60_000 budget (#14100) ──
+  // Both construct a FRESH `new SqlDriver(PG_CELL.config())` against the live
+  // Postgres cell inside their own body and then drive `initObjects(...)`, so
+  // the connect cycle plus schema-sync DDL and catalog read-back are paid PER
+  // TEST rather than once in a beforeAll. With no third argument vitest applies
+  // its own 5000ms default — a number nobody chose for that work, and one that
+  // reddens unrelated PRs when the runner is merely a bit slow. Sized to match
+  // this package's live-DDL siblings (#13902 / #13688). ⛔ NOT a claim that
+  // these tests are known to be slow: they were found by an AST walk over the
+  // package, never by a measured timeout here.
   it.skipIf(!PG_CELL.available)(
     'postgres: index introspection reports the indexes that exist in the file’s schema',
     async () => {
@@ -309,6 +319,7 @@ describe('live-dialect matrix — the driver can SEE its own isolated schema (#9
       expect(seen.some((i: any) => i.primary)).toBe(true);
       expect(seen.some((i: any) => i.unique && !i.primary)).toBe(true);
     },
+    60_000,
   );
 
   it.skipIf(!PG_CELL.available)(
@@ -320,5 +331,6 @@ describe('live-dialect matrix — the driver can SEE its own isolated schema (#9
       const introspected = await driver.introspectSchema();
       expect(Object.keys(introspected.tables ?? {})).toContain(TABLE);
     },
+    60_000,
   );
 });

--- a/packages/drivers/driver-sql/src/sql-driver-autonumber-cold-race.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-autonumber-cold-race.test.ts
@@ -156,6 +156,16 @@ describe(`sql-driver — attemptWithoutPoisoning (${pgCell.available ? 'live pos
   // The mechanism itself, pinned directly: this is what makes the SECOND
   // speculative site (`SELECT … FOR UPDATE`, which has no `ON CONFLICT` form)
   // safe as well. Postgres-only for the same reason as above.
+  // ── Why the it() below carries an explicit 60_000 budget (#14100) ──
+  // It constructs a FRESH `new SqlDriver(pgCell.config())` against the live
+  // Postgres cell inside its own body, then creates and drops a probe table, so
+  // the connect cycle and its DDL are paid PER TEST rather than once in a hook.
+  // With no third argument vitest applies its own 5000ms default — a number
+  // nobody chose for that work, and one that reddens unrelated PRs when the
+  // runner is merely a bit slow. Sized to match this package's live-DDL
+  // siblings (#13902 / #13688). ⛔ NOT a claim that this test is known to be
+  // slow: it was found by an AST walk over the package, never by a measured
+  // timeout here.
   it.skipIf(!pgCell.available)(
     'leaves the surrounding transaction usable after a statement error',
     async () => {
@@ -195,5 +205,6 @@ describe(`sql-driver — attemptWithoutPoisoning (${pgCell.available ? 'live pos
         await driver.disconnect();
       }
     },
+    60_000,
   );
 });

--- a/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
@@ -162,8 +162,12 @@ describe(`[#8931] driver-sql — the terminal backend-fault envelope (${cell.lab
   // a query or two down a connection this hook already opened, so their cost
   // model really is the fast one. But the live cost did not disappear — it
   // lives HERE: a full connect cycle, two drops, `initObjects(...)` schema-sync
-  // DDL and two inserts, all against the cell's live server, on vitest's
-  // inherited 5000ms default. Budgeting the it() blocks would have been wrong;
+  // DDL and two inserts, all against the cell's live server. ⚠️ A hook inherits
+  // `hookTimeout`, NOT `testTimeout` — measured in this package's config, an
+  // unbudgeted hook dies at 10000ms ("Hook timed out in 10000ms"), not at the
+  // 5000ms an unbudgeted it() gets. Ten seconds is still the wrong ceiling for
+  // this much live work, and the third argument does lift it (measured).
+  // Budgeting the it() blocks would have been wrong;
   // leaving the hook unbudgeted just moved the exposure one scope outward.
   // Budgeting hooks is established practice in this package (see the beforeAll
   // hooks in sql-driver-diagnostic-value-probe, sql-driver-12380-json-roundtrip,

--- a/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-backend-fault-envelope.test.ts
@@ -157,6 +157,19 @@ function declareSweep(cell: DialectCell): void {
 describe(`[#8931] driver-sql — the terminal backend-fault envelope (${cell.label})`, () => {
   let driver: SqlDriver;
 
+  // ── Why this beforeAll carries an explicit 60_000 budget (#14100) ──
+  // The it() blocks in this file are deliberately NOT budgeted: each only sends
+  // a query or two down a connection this hook already opened, so their cost
+  // model really is the fast one. But the live cost did not disappear — it
+  // lives HERE: a full connect cycle, two drops, `initObjects(...)` schema-sync
+  // DDL and two inserts, all against the cell's live server, on vitest's
+  // inherited 5000ms default. Budgeting the it() blocks would have been wrong;
+  // leaving the hook unbudgeted just moved the exposure one scope outward.
+  // Budgeting hooks is established practice in this package (see the beforeAll
+  // hooks in sql-driver-diagnostic-value-probe, sql-driver-12380-json-roundtrip,
+  // sql-driver-13567-audit-stamp-materialisation and
+  // sql-driver-value-roundtrip-conformance). ⛔ NOT a claim that this hook is
+  // known to time out: it was found by an AST walk, never by a measured red.
   beforeAll(async () => {
     driver = new SqlDriver(cell.config());
     await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
@@ -166,7 +179,7 @@ describe(`[#8931] driver-sql — the terminal backend-fault envelope (${cell.lab
     ]);
     await driver.create(TABLE, { id: 't1', title: 'Design', rank: 1 }, { bypassTenantAudit: true });
     await driver.create(TABLE, { id: 't2', title: 'Build', rank: 2 }, { bypassTenantAudit: true });
-  });
+  }, 60_000);
 
   afterAll(async () => {
     await driver.execute(`drop table if exists ${TABLE}`).catch(() => {});
@@ -340,6 +353,11 @@ declareDialectCell(PG, 'backend-fault envelope — the pg-only rows', (cell) => 
 describe('[#8931] postgres — the dotted route and the value-bearing diagnostic', () => {
   let driver: SqlDriver;
 
+  // ── Why this beforeAll carries an explicit 60_000 budget (#14100) ──
+  // Same reasoning as the hook in `declareSweep` above, on the Postgres-only
+  // pair: a live connect, a drop, `initObjects(...)` DDL and an insert, none of
+  // which the two it() blocks below repeat. ⛔ NOT a claim that this hook is
+  // known to time out — found structurally, not by a measured red.
   beforeAll(async () => {
     driver = new SqlDriver(cell.config());
     await driver.execute(`drop table if exists ${TABLE}_pg`).catch(() => {});
@@ -347,7 +365,7 @@ describe('[#8931] postgres — the dotted route and the value-bearing diagnostic
       { name: `${TABLE}_pg`, fields: { title: { type: 'string' }, rank: { type: 'integer' } } },
     ]);
     await driver.create(`${TABLE}_pg`, { id: 't1', title: 'Design', rank: 1 }, { bypassTenantAudit: true });
-  });
+  }, 60_000);
 
   afterAll(async () => {
     await driver.execute(`drop table if exists ${TABLE}_pg`).catch(() => {});

--- a/packages/drivers/driver-sql/src/sql-driver-json-binding-without-ddl.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-json-binding-without-ddl.test.ts
@@ -170,6 +170,16 @@ describe.skipIf(!PG_URL)('#10995 — live Postgres, driver told about the object
 
   // ── §3 The other posture with the same empty registry: DDL REFUSED ───────
 
+  // ── Why the it() below carries an explicit 60_000 budget (#14100) ──
+  // Unlike §1–§2, which reuse the connection the beforeAll opened, §3 builds a
+  // SECOND live driver (`guest`) inside its own body and runs an out-of-band
+  // `create table` through it — a full connect cycle plus DDL, paid by this
+  // test alone. With no third argument vitest applies its own 5000ms default —
+  // a number nobody chose for that work, and one that reddens unrelated PRs
+  // when the runner is merely a bit slow. Sized to match this package's
+  // live-DDL siblings (#13902 / #13688). ⛔ NOT a claim that this test is known
+  // to be slow: it was found by an AST walk over the package, never by a
+  // measured timeout here.
   it('§3 a datasource we are a guest in registers its objects even though DDL is refused', async () => {
     // `schemaMode !== 'managed'` (ADR-0015): `initObjects` must still refuse the
     // DDL — and must no longer leave the driver ignorant of the objects it was
@@ -188,7 +198,7 @@ describe.skipIf(!PG_URL)('#10995 — live Postgres, driver told about the object
     } finally {
       await guest.disconnect();
     }
-  });
+  }, 60_000);
 });
 
 // ── §4 The SQLite path is unchanged ────────────────────────────────────────


### PR DESCRIPTION
Fixes #14100

Adds an explicit `60_000` budget to the six live-DDL sites in `packages/drivers/driver-sql`
that #13902 / PR #14098 correctly left outside its own scoping. Per-site, per-hook — no
package-level `testTimeout`, no `vitest.config.ts` change, no production source.

Diff: 4 test files, 6 budgets, nothing else.

## What changed

**Population A** — 4 `it()` blocks that build a live-Postgres `SqlDriver` outside a
`declareDialectCell(...)` callback:

| Site (located by symbol) | Driver argument |
|---|---|
| `live-dialect-matrix.isolation.test.ts` — "index introspection reports the indexes that exist in the file's schema" | `PG_CELL.config()` + `initObjects(...)` |
| `live-dialect-matrix.isolation.test.ts` — "schema introspection lists a table created in the file's schema" | `PG_CELL.config()` + `initObjects(...)` |
| `sql-driver-autonumber-cold-race.test.ts` — "leaves the surrounding transaction usable after a statement error" | `pgCell.config()` + create/drop probe table |
| `sql-driver-json-binding-without-ddl.test.ts` — "§3 a datasource we are a guest in…" | `PG_CELL.config()` plus `schemaMode: 'validate-only'`, builds a SECOND live driver |

**Population B** — the 2 `beforeAll` hooks in `sql-driver-backend-fault-envelope.test.ts`
(the `declareSweep` hook, and the Postgres-only hook), each opening a live driver, running
`initObjects(...)` and inserting rows. The file's `it()` blocks stay unbudgeted on purpose:
they only query an already-open connection, so #13902's exclusion of them was right — the
live cost simply lives in the hook.

## Correction: hooks do NOT inherit the 5000ms default

The card states both hooks "inherit the 5000ms default". **Measured here, that is wrong.**
A hook inherits `hookTimeout`, not `testTimeout`:

| Leg | Shape | Result |
|---|---|---|
| A1 | `it()`, 6000ms, no budget | exit 1 — `Test timed out in 5000ms` (5.58s) |
| A2 | `it()`, 6000ms, `60_000` | exit 0 (6.54s) |
| B1 | `beforeAll`, 6000ms, no budget | **exit 0 — passed** (6.46s) |
| B3 | `beforeAll`, 11000ms, no budget | exit 1 — `Hook timed out in 10000ms` (10.56s) |
| B4 | `beforeAll`, 11000ms, `60_000` | exit 0 (11.52s) |
| A3 | `it()`, 11000ms, `60_000` | exit 0 (11.50s) — control |

So the unbudgeted hooks were on a **10000ms** ceiling, not 5000ms. The fix still stands and
still matters (10s is the wrong ceiling for a live connect plus schema-sync DDL plus inserts,
and B4 proves the third argument does lift a hook), but the number is corrected in the code
comment rather than repeated. This package sets no `testTimeout` or `hookTimeout` anywhere,
so both defaults are vitest's own.

Ablation discipline: probes were written into the package, their landing on disk proven by
marker and budget occurrence counts (never an editor exit code), each leg run through the
shared verify lock with the exit code captured by redirect before any pipe, and the probes
removed by an `EXIT INT TERM` trap with absence re-proven and `git status` shown clean.

## The judgement gate (③), answered per site

Question: is any existing red a timeout itself rather than an assertion, and — critically —
does any assertion read elapsed time? Adding a budget to a duration-sensitive test would
change its meaning.

The scan carries a firing control: `sql-driver-connect-bound.test.ts` holds exactly the
named hazard, `elapsed` bounded above 8_000 and below 20_000, and the scan finds it.

| Site | Assertion reads elapsed time? | Existing red that is a timeout? |
|---|---|---|
| `live-dialect-matrix.isolation.test.ts` index introspection | **No** — asserts index names/flags against a server-side control read | No red; live-gated, skipped locally |
| `live-dialect-matrix.isolation.test.ts` schema introspection | **No** — asserts the table appears in `introspectSchema()` | No red; live-gated, skipped locally |
| `sql-driver-autonumber-cold-race.test.ts` | **No** — asserts `ok` flags, SQLSTATE `23505`, a row value | No red; live-gated, skipped locally |
| `sql-driver-json-binding-without-ddl.test.ts` §3 | **No** — asserts a rejection type and JSON round-trip values | No red; live-gated, skipped locally |
| `backend-fault-envelope` `declareSweep` hook | **No** — a setup hook, it asserts nothing | No red; live-gated |
| `backend-fault-envelope` pg-only hook | **No** — a setup hook, it asserts nothing | No red; live-gated |

No site's meaning changes. Zero of the six carry a duration-dependent assertion; the three
numeric comparisons anywhere in these files are a test-file count, an identifier-length
limit, and an index count.

Per ruling ④: these six were found **structurally**, by an AST walk. ⛔ None is known to
time out. The only measured instance of the defect shape remains #13688.

## What was deliberately left alone

Classification is by reading each `new SqlDriver(...)` **argument**, never the filename or
directory. A per-site AST walk over all 159 test files in the package finds 193
driver-constructing sites:

- **39 unbudgeted embedded-SQLite `it()`/`test()` sites left on the fast 5000ms default.**
  These use `dialectCell('sqlite').config()` or a `better-sqlite3` in-memory literal and are
  correctly fast. A blanket change would have silently loosened every one of them — the exact
  failure ruling ② exists to prevent. (The card's count for this population is 42; my walk
  counts 39 by a per-site denominator, counting `it()` blocks that construct a driver directly
  in their own body. I did not re-derive the card's number — the discrepancy is a denominator
  difference, not a disagreement about which sites are embedded.)
- The walk finds exactly **4** LIVE-argument `it()` sites in the whole package, and they are
  Population A. Independent confirmation that the card's population is complete and exact.

## Verification

All at `193b345f`, the final commit.

- `pnpm --filter '@objectstack/driver-sql^...' build` — VERDICT command-exit 0.
- The 4 affected test files: **4 passed, 31 tests passed, 13 skipped.** The 13 skipped are the
  live-cell sites; `OS_TEST_POSTGRES_URL` and `OS_TEST_MYSQL_URL` are both unset in this
  container, so the six sites themselves are a legitimate **NOT MEASURED** — no green is
  claimed for them.
- `pnpm --filter @objectstack/driver-sql typecheck` — exit 0, and `tsc --listFiles` confirms
  all four edited files are in the program (1 occurrence each), so that green really covers
  the edits.
- Gate family derived at the actual diff by `scripts/pm/dispatch-gates.mjs --repo
  objectstack-ai/objectstack --commands`, re-derived at the final commit and unchanged:
  **26 commands — 23 pass, 3 NOT MEASURED.** The three print `PREREQUISITE NOT MET` in their
  own verdict text and exit 3, the code reserved for it, distinct from a finding's 1:
  `check-test-completeness` (needs a saved `turbo run test` log), `check:dual-build-cjs-loads`
  and `check:type-check-debt` (both need a full-repo `pnpm build`). Not reds, and CI runs
  them on this PR.

## Changeset

This PR carries the `skip-changeset` label rather than a changeset, which departs from the
dispatch instruction. The reason is mechanical: the diff is four `*.test.ts` files and
releases nothing from any package. An empty-frontmatter changeset is **rejected outright** by
`scripts/check-empty-changeset.mjs`, and a non-empty one would bump `@objectstack/driver-sql`
and write a CHANGELOG entry for a change no user can observe. Flagged for the PM rather than
decided silently.

## Out of scope

The same AST walk found **7 unbudgeted hooks whose driver argument is unconditionally live**,
in four files, none of them named by #14100 — plus the `hookTimeout` correction above, which
reframes the whole defect class. Filed separately rather than folded in, following this
card's own "separate card rather than a rider" precedent; #14100 is not the place for them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5WBDtaUnoz5XuJ6jk8pQ5)_