### PR TITLE
ci(lint): run the shared prerequisite frame's self-test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -239,8 +239,9 @@ jobs:
       - name: Raw control-byte guard
         run: pnpm check:nul-bytes
 
-      # The three shared modules the two `scripts/**` routing gates below
-      # DELEGATE their design arguments to (#10608). Both of those gates are
+      # The first three of these are the shared modules the two `scripts/**`
+      # routing gates below DELEGATE their design arguments to (#10608). Both of
+      # those gates are
       # SPELLING gates by deliberate design — `check:entry-guard` enforces that
       # only `scripts/invoked-as.mjs` may read `process.argv[1]`, and
       # `check:parse-guard` that every TypeScript parse goes through
@@ -261,23 +262,59 @@ jobs:
       # own documentation — loud — while a mask that starts OVER-masking makes
       # both go quietly green over text they never read.
       #
-      # What runs here is the self-tests, not the modules' callers: the callers
-      # are the two gate steps below, which already run on every PR.
+      # `import-prerequisite.mjs` is the FOURTH module here, from a different
+      # family and for the same reason (#14007). It is not one of the #10608
+      # delegates — it is the shared `PREREQUISITE NOT MET` frame that 45 gates
+      # IMPORT (42 under `scripts/**`, 3 under `packages/lint/scripts/**`), and
+      # its `--self-test` is the ONE place the inherited advisory is pinned. The
+      # module says so itself: *"Pinned HERE and nowhere else, because this is
+      # the one copy 45 importers print."* Since #13983 the same self-test also
+      # pins the exit-code CLASS those 45 gates return for an unmet prerequisite
+      # (`EXIT_PREREQUISITE_NOT_MET`, distinct from a gate's own findings exit).
+      # Nothing ran it: `git grep -n "import-prerequisite" -- .github/workflows
+      # package.json` was EMPTY, so 60 cases executed only when a human or an
+      # agent typed the command by hand.
+      #
+      # ⛔ NOT a hole in `check:self-test-wired`, whose green is correct by its
+      # own definition: its population is the scripts CI RUNS, and this file is a
+      # MODULE no workflow can invoke, so it sat in that gate's remainder by
+      # construction. The blast radius and the population rule point in opposite
+      # directions here: the file with the largest inheritance surface in the
+      # farm is the one shape the wiring gate cannot see. Naming it in this step
+      # is what moves it INTO that population (161 -> 162 scripts CI runs that
+      # ship a `--self-test`), and it is the smaller of the two remedies — the
+      # other being to widen the gate to a transitive closure, which #14007
+      # explicitly does not ask for. ⛔ It is also not a licence to sweep the
+      # rest of that remainder from here; that is a separate card.
+      #
+      # What runs here is the self-tests, not the modules' callers: for the first
+      # three the callers are the two gate steps below, which already run on
+      # every PR; for `import-prerequisite` the callers are the 45 importing
+      # gates, whose ordinary runs take the branch where the dependency IS
+      # present and therefore observe none of what the self-test pins.
       # Invoked as `node` rather than through `pnpm check:*`: see the GATE
       # INVOCATION IDIOM note at the top of this file.
       # `ts-parse` spawns ~20 real node children (~10 s measured, and the spawns
       # are the point — they pin that a caller's try/catch cannot swallow the
-      # refusal); the other two are in-process fixtures, ~0.5 s combined.
+      # refusal); the other three are in-process fixtures, ~0.6 s combined.
       #
       # ⭐ Collected rather than sequenced, for the reason spelled out at the
       # `Shallow-history guard self-tests` step below (#10814): under `bash -e` a
       # bare sequence stops at the first failure, so a red `ts-parse` would leave
-      # the entry-predicate and comment-mask self-tests UNRUN while the log shows
-      # only the one failure. `ts-parse` is both the slowest of the three and the
-      # one that spawns real children, so it is the likeliest to be red —
-      # precisely the masking direction. The three modules are independent of one
-      # another, so collecting loses nothing.
-      - name: scripts/ shared-module self-tests (parse · entry predicate · comment mask)
+      # the entry-predicate, comment-mask and prerequisite-frame self-tests UNRUN
+      # while the log shows only the one failure. `ts-parse` is both the slowest
+      # of the four and the one that spawns real children, so it is the likeliest
+      # to be red — precisely the masking direction. The four modules are
+      # independent of one another, so collecting loses nothing.
+      #
+      # ⭐ Collected is also why the fourth leg is HERE rather than in a step of
+      # its own: Actions skips a job's remaining steps once a step fails, so a
+      # standalone step further down this job would be masked by every gate above
+      # it — the same defect one level up, and the split `check-step-collectors`
+      # explicitly refuses as a remedy. Inside this block the frame's self-test
+      # prints its own verdict whatever the other three do, and it does so early
+      # in the job.
+      - name: scripts/ shared-module self-tests (parse · entry predicate · comment mask · prerequisite frame)
         run: |
           # Tolerate-and-collect (#10814) — see the note above this step. Each
           # self-test runs unconditionally and prints its own verdict; the step
@@ -300,13 +337,14 @@ jobs:
           run_self_test node scripts/ts-parse.mjs --self-test
           run_self_test node scripts/invoked-as.mjs --self-test
           run_self_test node scripts/js-comment-mask.mjs --self-test
+          run_self_test node scripts/import-prerequisite.mjs --self-test
           if [ -n "$failed" ]; then
             echo ""
             echo "scripts/ shared-module self-tests — the following FAILED:"
             printf "%s" "$failed"
             exit 1
           fi
-          echo "scripts/ shared-module self-tests — all three ran and passed"
+          echo "scripts/ shared-module self-tests — all four ran and passed"
 
       # Every `scripts/**` entry guard goes through ONE predicate (#10086).
       # The hand-typed forms of "did node run me, or did someone import me?"


### PR DESCRIPTION
Fixes #14007

`scripts/import-prerequisite.mjs` is the shared `PREREQUISITE NOT MET` frame that **45 gates import** (42 under `scripts/**`, 3 under `packages/lint/scripts/**`). Its `--self-test` is the one place the inherited advisory is pinned — the module says so itself: *"Pinned HERE and nowhere else, because this is the one copy 45 importers print."* Since PR #14009 it also pins the exit-code CLASS those same 45 gates return for an unmet prerequisite. Nothing ran it.

This wires it. One line of CI, plus the prose that keeps the line explicable.

## The reading, re-verified on this branch before any edit

```
$ git grep -n "import-prerequisite" -- .github/workflows package.json
(no output)                                     # exit 1

$ git grep -n "check-self-test-wired" -- .github/workflows package.json   # control
.github/workflows/lint.yml:1092:          node scripts/check-self-test-wired.mjs --self-test
.github/workflows/lint.yml:1093:          node scripts/check-self-test-wired.mjs

$ node scripts/import-prerequisite.mjs --self-test
✓ import-prerequisite self-test: 60 cases pass — not-installed, workspace-unbuilt, broken-install
  and dependency-missing stay distinct, and a resolved-then-threw package is rethrown.
```

The card was filed against a 49-case self-test; the count is **60** now (PR #14009 and PR #14217, both merged). Sixty cases that executed only when a human or an agent typed the command by hand.

## Why the wiring gate did not catch it, and why that is not a bug in the wiring gate

Quoting the card's load-bearing sentence verbatim, because it is the whole value of the finding:

> **The blast radius and the population rule point in opposite directions here: the file with the largest inheritance surface in the farm is the one shape the wiring gate cannot see.**

`check-self-test-wired`'s population is *the scripts CI runs*, and this file is a MODULE gates import, never a script a workflow invokes — so it sat in that gate's remainder **by construction**, with the gate correctly green. ⛔ Nothing here changes that gate's population rule, and ⛔ nothing here audits the rest of that remainder (a separate sweep card).

Naming the module in a workflow step is the other, smaller remedy — and it is what moves the file INTO the population. Measured on this branch, same gate, same tree, before and after the step:

```
before   161 script(s) CI runs ship a --self-test; 157 have it run through the flag
after    162 script(s) CI runs ship a --self-test; 158 have it run through the flag
```

The 176-file `--self-test` corpus and the 220-file `scripts/` sweep are unchanged; only the "run by CI" count moves, which is exactly the claim being fixed. Full verdict lines under **Gates** below.

## Placement, and why

**Chosen: a fourth leg of lint.yml's existing `scripts/ shared-module self-tests` tolerate-and-collect step**, rather than a standalone step or the `packages/lint` job — that step is already the home for `scripts/**` shared modules whose behaviour is pinned only by their own self-test, it sits early in the `lint` job, and its collector shape gives the new leg a verdict of its own whichever way the other three go. A standalone step further down would be masked by every gate above it (Actions skips a job's remaining steps once one fails) — the same defect one level up, and the split `check-step-collectors` explicitly refuses as a remedy.

No root `package.json` alias: lint.yml's GATE INVOCATION IDIOM note makes the direct `node scripts/X.mjs --self-test` form the local convention, and `dispatch-gates.mjs` derives families from either spelling, so nothing is lost.

## Ablation — the wiring is load-bearing

The real `run:` block was extracted out of lint.yml and driven under a real `bash -e`, exactly as Actions runs it. Mutation: `EXIT_PREREQUISITE_NOT_MET = 3` -> `1` in the module — the very exit-code class PR #14009 established. Mutation confirmed on disk (anchor count 1 -> 0, injected marker present) before any reading was taken; restore pinned to `HEAD` and verified byte-identical (`git diff HEAD` empty, blob `a7ccff1f` on both sides).

```
CONTROL  (tree at HEAD)          exit 0    PASS x4, "all four ran and passed"
MUTATED  (frame regression)      exit 1    ✗ import-prerequisite self-test: 3 of 60 case(s) failed.
                                           FAIL  node scripts/import-prerequisite.mjs --self-test
                                           the other three still report PASS — no masking
```

Before this PR that same mutation produced no CI signal at all.

A first mutation attempt is recorded rather than dropped: prefixing a string onto a local variable inside the self-test's own harness landed on disk and the self-test still passed. A mutation that is not load-bearing is not an ablation, so it was replaced with the one above rather than reported as a result.

## Gates

Family derived from the real diff with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (23 families; no path list hand-fed to it — the script takes the change set from the merge base itself). All of them run, exit codes captured before any pipe, on `496a99c2` with a clean `git status --porcelain`:

```
✓ check-self-test-wired: every one of the 162 script(s) CI runs that ship a `--self-test` has that
  self-test run by CI.
  scope: 220 file(s) under scripts/, 176 carrying `--self-test` in code (comments masked); 162 of
  those are run by 29 workflow(s); 158 have their self-test run through the flag, 4 through a
  recorded route.
✓ check-self-test-workflow-commands: no self-test CI runs prints a line the Actions runner would
  parse as a workflow command.
  scope: 162 script(s) CI runs ship a `--self-test`; 17 mention a workflow-command token in code
  (comments masked) and were RUN, and their real stdout+stderr was scanned.
✓ check-step-collectors: 385 `run:` steps across 29 workflow(s); 3 step(s) run 2+ independent
  self-tests, all of them through a collector.
✓ check-step-collectors --self-test: 125 assertions, 3 live block(s) driven under a real `bash -e`.
OK  check-ratchet-remedy-authority: 183 scripts swept; 12 mark the expanding remedy
  ⛔ MAINTAINER-ONLY, 6 turn it down outright, 165 hand out no ratchet-expanding remedy.
```

The wiring gates' arithmetic did not break. The module moved from the remainder into the population and is wired inside it; `check-self-test-workflow-commands`, which imports its membership from `check-self-test-wired` rather than re-deriving it, picked the new member up (162) and scanned real output; and `check-step-collectors --self-test` now drives the four-command block under a real `bash -e`, asserting in every red position that each leg still runs and is named.

Also green (exit 0): `check-aggregator-roster`, `check-position-name-fold-loaders`, `check-required-contexts`, `check-shard-attestation`, `check-whole-set-label-write`, `docs-audit/check-drift-comment`, `pm/ci-failure --self-test`, `check:agent-test-spelling`, `check:declared-population-live`, `check:node-version`, `check:pm-dispatch-gates`, `check:pnpm-acquisition`, `check:pnpm-filter-targets`, `check:required-contexts`, `check:shard-attestation`, `check:stall-guard-budget`, `check:stall-guard-headroom`, `check:type-check-coverage`, `check:workflow-status-functions`, `check:nul-bytes`, plus both wiring gates' own `--self-test` legs.

**Declared narrowing, one gate: `check:type-check-debt` is NOT MEASURED here** — it exited **3** (`PREREQUISITE NOT MET`, this very frame), refusing to `--re-measure` because 56 workspace dependencies have no built type entry point in this worktree. That is not a pass and not a finding. Its lint.yml-facing assertion — the `--max-old-space-size=4096` CI heap ceiling this file pins — is covered by `check:type-check-coverage`, which ran here and printed `OK`; and this diff edits no TypeScript, so it cannot move a DEBT or TEST_DEBT number in either direction. CI builds the closure before that step and runs it for real.

`skip-changeset`: the diff is one workflow file, publishing nothing from any package.

Card #14007 is fixed by this PR; no other card is addressed here.

Session: https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV

_Generated by [Claude Code](https://claude.ai/code)_