### PR TITLE
skills(pm): land the ruled REST-channel prescriptions and closed-inclusive dedup (ceiling 87 → 93)

### DIFF
--- a/.claude/skills/pm-dispatch/references/rest-channel.md
+++ b/.claude/skills/pm-dispatch/references/rest-channel.md
@@ -22,6 +22,9 @@ payload → REST → MCP/GraphQL** 的策略住那里,本表是逐操作的通�
   `open_issues_count`(含 PR,减开放 PR)核总数;⛔ 未核总数的枚举不是读数。⚠️ 成因未知(GitHub
   游标 vs 出口代理改写 `Link`):处方**不依赖该头**,⛔ 不把「已修」写成「已解释」。⚠️
   关键词阳性对照**结构上**看不见本类(必中卡落在首页照样绿),只有计数核对逮得住。
+- ⛔ **查重必须含 closed**:卡刚关闭时最易被重开(2026-08-31 双向实测:开域查重漏掉 6 小时前
+  刚关闭的同题卡 ⇒ 重复派发;含闭卡那次命中已关闭同形卡 ⇒ 免开重复)。开域查重
+  是**要申报的例外**,不是默认;状态 / 标签列卡读仍 `state=open` —— 那是状态读,不是查重。
 - ✓ 卡 / PR 元数据:`GET .../issues/{n}` · `GET .../pulls/{n}`(assignees、labels、body 齐全 —— MCP
   `list_issues` 永不返回 assignees,这条差别本身就是走 REST 的理由)。
 - ✓ 整条评论线:`GET .../issues/{n}/comments?per_page=100`。

--- a/.claude/skills/pm-dispatch/references/rest-channel.md
+++ b/.claude/skills/pm-dispatch/references/rest-channel.md
@@ -17,6 +17,11 @@ payload → REST → MCP/GraphQL** 的策略住那里,本表是逐操作的通�
 
 - ✓ 按标签/状态列卡:`GET /repos/{o}/{r}/issues?state=open&labels=a,b&per_page=N` —— `labels=` 是**真
   AND**(MCP `list_issues` 的 labels 数组是 OR;语义相反那条住 `platform-readings.md`)。
+- ⛔ 完整性自证,**不跟 `Link: rel="next"`**:2026-08-31/09-01 两仓实测,游标自称枯竭停在 102,页号走
+  法得 287/448、与 `open_issues_count` 符 ⇒ 改走 `&page=N` 到短页为止,再用 `GET /repos/{o}/{r}` 的
+  `open_issues_count`(含 PR,减开放 PR)核总数;⛔ 未核总数的枚举不是读数。⚠️ 成因未知(GitHub
+  游标 vs 出口代理改写 `Link`):处方**不依赖该头**,⛔ 不把「已修」写成「已解释」。⚠️
+  关键词阳性对照**结构上**看不见本类(必中卡落在首页照样绿),只有计数核对逮得住。
 - ✓ 卡 / PR 元数据:`GET .../issues/{n}` · `GET .../pulls/{n}`(assignees、labels、body 齐全 —— MCP
   `list_issues` 永不返回 assignees,这条差别本身就是走 REST 的理由)。
 - ✓ 整条评论线:`GET .../issues/{n}/comments?per_page=100`。
@@ -40,7 +45,7 @@ payload → REST → MCP/GraphQL** 的策略住那里,本表是逐操作的通�
 - ✓ 请求复审 `POST .../pulls/{n}/requested_reviewers` · 开 PR `POST .../pulls`(带 `draft=true`;GraphQL 池为 0
   的同一分钟里实测开得出 draft PR ⇒ 交付不必等重置)。
 
-## 不可迁移 —— 只有这几件,围着它们排计划
+## 不可迁移 —— 只有这几件,围着它们排计划(红窗守候规则住 `platform-readings.md` 配额段)
 
 1. **draft → ready 翻转**:GraphQL-only mutation;出口代理只放钉住的 PR-review GraphQL 集(实测拒绝)。
    判据 = REST update-a-pull-request 只收 `title`/`body`/`state`/`base`/`maintainer_can_modify`,**无 `draft`**
@@ -54,8 +59,6 @@ payload → REST → MCP/GraphQL** 的策略住那里,本表是逐操作的通�
 5. **`issue transfer`**(2026-08-24 官方文档核对补入):issues 端点表无 transfer 路由 ⇒ 同为
    GraphQL-only。拿不到时当轮改走「在目的仓重建」配方 —— 纯 REST、配额免疫,配方住
    `platform-readings.md`。
-
-`until remaining > 阈值` 的守候只留给这几件,⛔ 其余一切不为配额空等。
 
 ## 第三桶 —— git 零配额等价物(先问 git,再问 REST)
 

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -311,7 +311,29 @@ export const CEILINGS = new Map([
   // file is the lookup table it points at, so the policy flip did not have to
   // grow the hot file. Set at landed line count (headroom 0, same convention
   // as the entries above).
-  ['.claude/skills/pm-dispatch/references/rest-channel.md', 87],
+  // Raised 87 → 93 by a maintainer ruling (2026-09-01, 总监批 #22) that names
+  // this ceiling and orders its own encoding — the ratchet's own legitimate
+  // exit, and the raising PR quotes the ruling comment. Verbatim and
+  // untranslated (one quotation, wrapped only to fit this comment):
+  //   「**B 获授权**:`rest-channel.md` 天花板 87 → **≤93 行**,提额 PR 引用本裁决
+  //   评论(棘轮自己的合法出口);两条处方按 dev 已测的忠实版落(两个拒绝 +
+  //   `&page=N` 短页终止条件 + `open_issues_count` 减开放 PR 交叉核对 + 成因未知
+  //   边界 + 关键词对照结构性盲区注记)」
+  // and, same batch, the content-ownership call that says what is paid in place:
+  //   「**C 同批**:退役 L58 对红窗常设规则的复述 —— 内容归属裁定:**红窗规则由
+  //   `platform-readings.md` 配额段独家持有**,`rest-channel.md` 只留指路」
+  // Paid in place: that restatement and its adjacent blank are retired (−2), and
+  // the pointer the ruling permits is folded into the 不可迁移 heading at zero
+  // line cost — so the red-window rule now has exactly one home. Spent: +8, the
+  // two enumeration-completeness prescriptions (both refusals, the `&page=N`
+  // short-page termination, the `open_issues_count`-minus-open-PRs cross-check,
+  // the cause-unknown boundary, and the note that a keyword positive control is
+  // structurally blind to this class) plus the closed-inclusive dedup obligation
+  // the same batch ruled onto this file (「提额预算一次用足」). Could not be paid
+  // by re-wrap: the file measures zero reclaimable lines under this gate's own
+  // wrapLine, and re-wrap funding is refused per the 2026-08-17 rule in any
+  // case. Landed count, headroom 0, same convention.
+  ['.claude/skills/pm-dispatch/references/rest-channel.md', 93],
   ['.claude/skills/pm-dispatch/references/review-checklist.md', 84],
   ['.claude/skills/pm-dispatch/references/landing-operations.md', 80],
   // Release-aftercare duties — what a lane PM still owes AFTER a tagged release


### PR DESCRIPTION
Fixes #13900
Fixes #13965

Two maintainer-ruled cards, one governed-face PR (director batch 22, 2026-09-01, maintainer 「同意」), because the raised ceiling is meant to be spent once: 「提额预算一次用足」. Each card keeps its own closure criterion and its own commit.

## What landed

**Commit `af0a8e5` — the #13900 half.** On `.claude/skills/pm-dispatch/references/rest-channel.md`'s list-cards row, the two prescriptions in the faithful form the previous dev flight measured: both refusals (⛔ do not follow the issues-list `Link: rel="next"`; ⛔ an enumeration whose total was never cross-checked is not a reading), the `&page=N`-until-a-short-page termination condition, the `open_issues_count` cross-check with the open-PR subtraction, the cause-unknown boundary, and the note that a keyword positive control is structurally blind to this class. Paid in place per ruling C: the red-window restatement is retired, and the pointer the ruling permits is folded into the 不可迁移 heading at zero line cost, so the red-window rule now has exactly one home. Ceiling row raised 87 → 93 in `scripts/pm/check-skill-line-ratchet.mjs`, with both rulings quoted verbatim beside it.

**Commit `b7c2e84` — the #13965 half.** The dedup prescription itself now states that dedup must include closed cards, with the recency rationale (a card is at its most duplicable right after it closes) and both measured directions from 2026-08-31. Open-scoped dedup becomes an exception that has to be declared rather than the default. The state and label listing reads keep `state=open` untouched — 批 13 is not reopened, and the prescription says why: that convention governs state reads, and dedup is not a state read.

## The rulings this PR executes — verbatim, untranslated

Ruling on #13900 (comment 5494348033, 2026-09-01T13:02:13Z), the legitimacy of the ceiling raise:

> **B 获授权**:`rest-channel.md` 天花板 87 → **≤93 行**,提额 PR 引用本裁决评论(棘轮自己的合法出口);两条处方按 dev 已测的忠实版落(两个拒绝 + `&page=N` 短页终止条件 + `open_issues_count` 减开放 PR 交叉核对 + 成因未知边界 + 关键词对照结构性盲区注记)

> **C 同批**:退役 L58 对红窗常设规则的复述 —— 内容归属裁定:**红窗规则由 `platform-readings.md` 配额段独家持有**,`rest-channel.md` 只留指路

> **#13965 的查重处方修订同一 PR 落地**(同批裁决,见该卡)—— 提额预算一次用足

> D(23 字节残句)维持排除;⛔ 「已修」不得写成「已解释」—— 成因未知句必须保留。

Ruling on #13965 (comment 5494345834, 2026-09-01T13:02:02Z):

> **采第三形**:把「查重必须含 closed(带时近说明)」写进查重处方本身 —— 零新增配额、零新机制;开域查重从默认降为需要说明的例外

> **(a) 近期闭卡补扫 / (b) `state=all` 时近界均不加**

> **批 #13 不重开**:状态读的 `state=open` 约定维持原样

Both excluded options stayed excluded: D (the 23-byte fragment) is not in this diff, and the cause-unknown sentence is present — the landed text says the prescription removes the dependency on the header, and makes no claim about whether the truncation is GitHub's own cursor or the egress proxy rewriting `Link`. Nothing here reads 「已修」 as 「已解释」.

## Line budget — measured with the gate's own `wrapLine`, pinned at the landed count

| | lines |
|:--|--:|
| `rest-channel.md` before | 87 |
| retired (red-window restatement + its adjacent blank) | −2 |
| added — the two enumeration-completeness prescriptions | +5 |
| added — the closed-inclusive dedup obligation | +3 |
| **landed** | **93** |
| authorized ceiling | ≤93 |

Net growth +6, exactly the authorized budget, spent once across both cards. The ceiling is pinned at 93 = the landed count, headroom 0, same convention as every neighbouring row — not at the authorization's upper bound. Every added line was produced by the gate's own `wrapLine`, so the file is at its canonical packing and no line exceeds the 120-byte budget. No re-wrap funding was used or attempted (筹行 is banned, and the file measures zero reclaimable lines in any case); the ruled raise plus the ruled retirement is the whole funding. The heading pointer cost zero lines: it fits inside the existing heading at 116 bytes.

Nothing else in the ceilings map moved — the diff touches exactly the `rest-channel.md` row and its comment.

## Gates

Union derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` **after** the final commit, at head `ce400df` — 20 families, 18 matched by path and 2 by change KIND (this diff edits a gate script). Every exit code captured by redirect before any pipe.

Green (exit 0): `check:pm-skill-ratchet` · `check:pm-skill-id-lint` · `check:agent-test-spelling` · `check:bash32-floor` · `check:cli-command-ids` · `check:cross-package-test-inputs` · `check:doc-authoring` · `pnpm --filter @objectstack/lint run check:doc-formula-expressions` · `check:entry-guard` · `check:parse-guard` · `check:pm-governed-merges` · `check:pnpm-filter-targets` · `check:skill-frame-sync` · `check:watch-hint-literal` · `check:pm-dispatch-gates` · `scripts/check-ci-filter-parity.mjs` · `scripts/check-cross-package-test-inputs.mjs` · `scripts/check-shard-attestation.mjs` · `scripts/pm/bare-root-worklist.mjs --self-test` · plus `check:nul-bytes` (not derived; any edit owes it) and the repo-wide `pnpm lint`, both exit 0 at this head.

**NOT MEASURED:** `node scripts/check-test-completeness.mjs` exits 3 with no argument — it needs a saved `turbo run test` log, which the local family invocation has none of. Its own words: "Nothing was measured … ⛔ It is NOT a finding." It runs in CI.

The ratchet's own verdict line at this head, quoted rather than inferred from an exit code:

```
✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/references/rest-channel.md is 93 lines (ceiling 93; headroom 0).
```

`origin/main` was merged into the branch before this run (it had moved two commits, neither touching either file), so the union above was derived and run on the tree that is at `ce400df`, not on a stale one.

## Governed face

`.claude/**` — draft PR, human merge by `GOVERNED_APPROVERS`, no auto-merge, not queued. `skip-changeset` applies: the diff is `.claude/**` plus `scripts/pm/**` and publishes nothing from any package. The published `skills/` directory is untouched, so the published-skill line and token readings are not owed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Whev4BkZ4BRcgiXYo4muWP)_