### PR TITLE
docs(agents): declare that this repo has no formatter of record

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,15 @@ pnpm typecheck        # turbo typecheck — per-package `tsc --noEmit`; tsup/vit
 pnpm docs:dev         # docs site
 ```
 
+**No formatter of record — `pnpm lint` is the only style authority** (eslint, `eslint.config.mjs`). Prettier is
+deliberately absent: no `.prettierrc*`, no `format` script, nothing invokes or installs it. ⛔ Never
+`prettier --write` a file you touch — its double-quote default against this single-quoted codebase rewrites **every
+string literal**, burying a one-line fix in a whole-file reformat. Its `--check` verdict is no second opinion on your
+edit either: it warns on pristine `main` content for that same default, while the SAME bytes at an out-of-repo path
+(a `/tmp` copy) come back `All matched files use Prettier code style!` — a pass over ZERO files (`--file-info` there
+says `"ignored": true`, and deliberately mangled bytes green identically). `npx prettier --find-config-path AGENTS.md`
+answers `[error] Can not find configure file` at both paths — the honest one (measured 2026-09-01, prettier 3.8.1).
+
 **⛔ Push a WIP commit before every step that takes minutes** — a build, a full test run, a
 gate sweep, an ablation. Not because you are about to wait: because you are about to stop
 being the only copy. The cost rises with how well you are working — a hard card defers
@@ -671,8 +680,6 @@ skills/           # 🤖 Domain skill definitions
 content/docs/     # 📝 Docs content
 ```
 
-Studio UI: `../objectui` (sibling repo).
-
 ---
 
 ## Protocol Domains (`packages/spec/src/`)
@@ -1090,10 +1097,8 @@ next restart rejected its predecessor's data.
 
 **It has teeth**: `pnpm check:startup-registry-verdict` walks the AST for that
 three-part shape and fails on it; accepted exceptions live in the shrink-only,
-hand-edited `scripts/startup-registry-verdict.baseline.json`. Like its durability
-sibling it is deliberately narrow and under-matches on purpose rather than risk a false
-positive — it cannot discover a new seam, only stop known ones from regressing. Found a
-new open registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
+hand-edited `scripts/startup-registry-verdict.baseline.json`. Found a new open
+registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
 
 ---
 
@@ -1144,13 +1149,8 @@ new open registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fi
    bump's `sdui:manifest` second half included — see the Frontend section). Pre-merge check for any removal or rename
    of an exported surface: does the pinned sibling import what you are removing? `git grep` it in `../objectui` at the
    pinned SHA before merging.
-5. **Added or removed a `packages/spec` export? Run `pnpm --filter @objectstack/spec gen:api-surface` and commit the
-   result.** The `TypeScript Type Check` job diffs spec's built export surface against `api-surface/` (one shard per
-   entry point); a new export makes the snapshot stale and turns the job red. It reads the **built `dist`
-   declarations**, so `OS_SKIP_DTS=1` — the flag you reach for to make local builds fast — skips exactly the
-   artifact the gate inspects, and the check passes locally while failing in CI. Same shape for the other
-   generated-artifact gates in that job (`check:docs`, `check:skill-refs`, `check:react-blocks`), which read `src/` and
-   so do reproduce locally.
+5. **Touched `packages/spec`? Regenerate and commit its artifacts before pushing** — § *Touched `packages/spec`*
+   above is the authority; note `OS_SKIP_DTS=1` greens `check:api-surface` locally and reds it in CI.
 6. Update `CHANGELOG.md` / `ROADMAP.md` if user-facing or architectural.
 7. **Delete temporary artifacts** — screenshots, traces, scratch logs, `.playwright-mcp/`, throwaway `tmp*.ts`, ad-hoc
    scripts. Repo must look identical to before, minus intended changes.


### PR DESCRIPTION
Fixes #10622

One paragraph in `AGENTS.md` § Build & Test, stating that this repo has no formatter of
record. Net-zero against the file's line ratchet: 1162 lines before, 1162 after.

## The ruling this implements

Maintainer ruling 2026-08-22, recorded on the card at 2026-08-22T02:25Z — the full decision
inbox (46 cards) was presented with per-card four-axis recommendations and the batch was
accepted, verbatim and untranslated:

> 接受所有

The card's recorded form of what that accepted, **Option A**, verbatim:

> **Ruled:** Option A — add the AGENTS.md formatting line: ESLint (`pnpm lint`) is the only
> style authority and Prettier is deliberately absent, including the warning that
> `prettier --write`/`--check` verdicts reflect Prettier's defaults (and the out-of-repo
> config-resolution flip), not the author's edit. Because AGENTS.md is a governed face, the
> change lands as a draft PR with a human performing the merge — the agent prepares the
> wording (the triage comment's proposed text, including the config-resolution-flip half, is
> the starting point), and no formatter is adopted as a rider on this card.

No formatter is adopted here: this diff is one file. There is no `.prettierrc*`, no
`.prettierignore`, and no dependency added.

## What I measured, rather than carried over

All three claims were re-measured on this branch's base (prettier 3.8.1, 2026-09-01), because
the text lands in a governed instruction file. Byte identity of the compared copies is proved
by `git hash-object`, not by `cp` succeeding.

| Check | Repo path | Byte-identical copy outside the repo |
|:---|:---|:---|
| `prettier --check` on pristine `main` content | exit 1, `[warn]` per file | exit 0, `All matched files use Prettier code style!` |
| `prettier --file-info` | `{ "ignored": false, "inferredParser": "babel" }` | `{ "ignored": true, "inferredParser": null }` |
| `prettier --find-config-path` | `[error] Can not find configure file` | `[error] Can not find configure file` |

The premise holds and the trap is real, but **one stated mechanism in the card is wrong, and
the correction makes the lesson sharper.** The card attributed the flip to config resolution
("Prettier resolved some config outside the repo"). It did not: `--find-config-path` reports
no config for *either* path, and `--no-editorconfig` changes nothing (there is no
`.editorconfig` anywhere above either path). The out-of-repo answer is `"ignored": true` — the
green is **a pass over zero files**. Control, run to settle it: a deliberately mangled file
(`const   x=1;;;`) gets the same `All matched files use Prettier code style!` at the
out-of-repo path, and `[warn]` for the same bytes inside the repo.

That is the repo's own defect class — a verifier that reports success over an input it never
read — so the clause states the measured mechanism instead of the guessed one. The ruled
substance is unchanged: identical bytes, opposite verdicts, and the verdict is about Prettier,
never about your edit.

## One wording deviation from the ruling's sentence, forced by a live gate

The ruling's sentence opens "ESLint (`pnpm lint`)". Writing that literal into `AGENTS.md` is
RED — I hit it, then read the rule:

```
✗ check-required-contexts — 1 problem(s)
  • AGENTS.md names the retired required context 'ESLint' 1× (budgeted: 0). That name was
    replaced by 'Lint & Repo Gates' ...
```

`RETIRED_CONTEXT_NAMES` carries `ESLint` as a **standing ban**: writing the dead check-run
name fresh into any scanned surface is red, and a deliberate mention has to record a budget in
the gate script in the same PR. The gate's own docblock names the discriminator:

> Exact, case-sensitive occurrence count. The names are identifiers, not words: case is what
> separates the retired context 'ESLint' from prose about the eslint tool.

So the clause says **`pnpm lint` is the only style authority** and names the tool in the
sanctioned lowercase, with its config file: `(eslint, eslint.config.mjs)`. The ruling's
substance is intact; only the casing moved, and it moved because the literal spelling is
banned. Raising a budget in the gate script instead was the alternative and was rejected: it
is outside this card's one-file surface, and `origin/main`'s `AGENTS.md` contains zero
occurrences of "eslint" in any casing today, so lowercase *is* the file's existing convention.

## Net-zero funding ledger

The clause costs 9 lines (8 prose + 1 blank). Three deletions pay for it exactly. Re-wrap
funding is banned, so each cut is measured as **deleted content**, and the arithmetic below
shows the saved lines come from deleted bytes and not from tightening a wrap.

| # | Cut | Lines | Bytes removed / added | Wrap width before → after |
|:---|:---|:---|:---|:---|
| A | `Studio UI: ../objectui (sibling repo).` + its blank | −2 | 40 / 0 | whole-line deletion |
| B | Startup-registry gate: the "Like its durability sibling …" sentence | −2 | 344 / 156 | 86 → 78 B/line |
| C | Post-Task Checklist item 5 collapsed to a pointer | −5 | 700 / 216 | 100 → 108 B/line |

Cut B's remainder wraps **narrower** than it did (86 → 78 B/line), so all of its 2 lines come
from the 188 deleted bytes. Cut C's pointer wraps 8 B/line wider over 2 lines — worth 0.16 of
a line — against 484 deleted bytes; the fund is the deletion.

**Does any rule lose its only home?**

- **A.** Pure triplicate. "The Studio UI lives in the sibling repo `../objectui`" is stated in
  full by § *Frontend (Studio UI) — sibling repo `../objectui`* ("This repo ships **backend
  only**. All Studio/Console UI work happens in `../objectui`") and by the Context Routing
  table row for `../objectui/**`. Nothing is lost but the third copy.
- **B.** The deleted sentence announced itself as a restatement ("Like its durability sibling
  it is deliberately narrow …"). The rationale it restates lives verbatim ~85 lines above in
  the same file, in the durability gate's paragraph: "It is deliberately narrow — it cannot
  *discover* a new seam, only stop known ones from regressing". The operative rule — "Found a
  new open registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it" —
  survives verbatim. What is gone is the cross-reference, not the fact.
- **C.** Every claim in the old item 5 is stated in § *Touched `packages/spec`? Regenerate its
  artifacts BEFORE pushing*, which the pointer now names: the gate ↔ generator table row for a
  public export; the single required `TypeScript Type Check` job; `api-surface/` sharding
  (Multi-agent discipline §11); and the `dist`-not-`src` caveat. The one claim that section
  words differently — that `OS_SKIP_DTS=1` produces a **local green with a CI red** — is
  carried into the pointer verbatim in substance rather than dropped, because a false-green
  warning is exactly the kind of line that must not evaporate in a compression.

**Not funded by re-wrapping**, and **no numbered item was renumbered**: `AGENTS.md §9`/`§10`
are referenced from `CLAUDE.md` and from `scripts/check-dev-prereqs.mjs`, so deleting a
Multi-agent discipline item was ruled out early. Item 5 of the Post-Task Checklist keeps its
number and becomes a pointer.

The ratchet script is untouched — no ceiling was raised and no pin moved.

## Gates

Union derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`
(8 families for the changed path), run at **a62cfa8**, exit codes captured by redirect before
any pipe:

```
EXIT=0 :: node scripts/check-required-contexts.mjs
EXIT=0 :: pnpm check:agent-test-spelling
EXIT=0 :: pnpm check:docs-audit-scope
EXIT=0 :: pnpm check:pm-governed-merges
EXIT=0 :: pnpm check:pm-governed-prose
EXIT=0 :: pnpm check:pm-skill-id-lint
EXIT=0 :: pnpm check:pm-skill-ratchet
EXIT=0 :: pnpm check:required-contexts
```

The two verdict lines this PR turns on, quoted from the gate rather than from `$?`:

```
✓ check-skill-line-ratchet: AGENTS.md is 1162 lines (ceiling 1162; headroom 0).
✓ check-skill-line-ratchet: AGENTS.md: widest table row is 1081 bytes (pin 1081; headroom 0).
```

Every added line is within the 120-byte max-line-length rule (widest: 118 B). Disclosed rather
than buried: the file is **net-zero on lines and +204 bytes**, since the added prose wraps at
~102 B/line against the ~86–100 B/line it replaces.

`pnpm lint` is a **measured no-op** for this diff, not a skipped run: eslint's own config
answers `File ignored because no matching configuration was supplied` for `AGENTS.md`
(`pnpm exec eslint AGENTS.md --format json`), and `eslint.config.mjs` declares no markdown
processing at all. The diff is 1 file, 0 of which are in eslint's population, and nothing in it
can move an untouched file's verdict.

## Landing

`AGENTS.md` is a governed surface (Prime Directive 14). This PR stays **draft**; it is not
armed for auto-merge and must not enter the merge queue. The merge is the maintainer's, by
hand. `skip-changeset`: nothing is published from a package by this diff.

_Generated by [Claude Code](https://claude.ai/code/session_01Whev4BkZ4BRcgiXYo4muWP)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Whev4BkZ4BRcgiXYo4muWP)_