### PR TITLE
fix(lint): qualify the sharing-rule RLS fix-hint by sharing model — RLS cannot widen a private object

### DIFF
--- a/.changeset/lint-sharing-rule-rls-hint-by-sharing-model.md
+++ b/.changeset/lint-sharing-rule-rls-hint-by-sharing-model.md
@@ -1,0 +1,66 @@
+---
+"@objectstack/lint": patch
+---
+
+fix(lint): `sharing-rule-runtime-variable-condition`'s fix-hint no longer sends authors to RLS to widen a `private` object (#14234)
+
+The hint printed for a sharing-rule `condition` that reads `current_user.*`
+ended in an **unqualified** remedy: "express per-user access with the mechanism
+that runs per request instead — an RLS policy on a permission set
+(`rowLevelSecurity[].using`, where `current_user.*` IS resolved)". That advice
+is sound on an open OWD and **structurally impossible on `private`**, which is
+the sharing model an author hitting this rule is most likely to be on.
+
+Measured, not argued. The security layers are AND-composed —
+`plugin-security`'s `getReadFilter` returns
+`andComposeLayers(andComposeLayers(filter, cbpFilter), sharingFilter)`, and its
+own prose promises "the same filter the engine middleware AND-s into" every
+find — while `plugin-sharing`'s `buildReadFilter` constrains `private` only
+(`effectiveSharingModel(schema) !== 'private'` returns `null`). So:
+
+- `public_read` / `public_read_write` → the sharing layer imposes nothing on
+  reads, and an RLS policy **narrows** an open baseline. The original advice is
+  correct here and is kept, now with the models it holds for attached.
+- `private` → the sharing layer has already withheld the row, and **an AND term
+  can only remove rows, never add one back**. An RLS "widener" there lints
+  clean, passes every gate, and grants nothing — a silent failure at the
+  security boundary, which is the worst possible feedback shape. The card
+  records an application author who followed this path and shipped the grant
+  unauthored/fail-closed instead.
+
+The hint now splits on `sharingModel` and, for the `private` case, states what
+is true: the two doors that widen a private object for a non-admin principal
+both key on **who owns the row** or on an **explicit share row**, never on a
+property of the record — the ADR-0057 D1 depth scopes (`readScope`/`writeScope`,
+which widen the owner-match to `owner_id IN (…)`) and a `sys_record_share` row,
+which on this path only a criteria sharing rule writes. Where neither fits, it
+names the gap **in words** — a known platform limitation, not something a
+different spelling of this rule can close — rather than inventing a mechanism,
+and it warns that `position` recipients resolve **tenant-wide**: the
+neighbouring temptation is an over-broad grant that also lints clean, not the
+narrower one the author meant. The tracker anchor for that gap sits in an
+adjacent source comment, not in the message, because a runtime string reaches
+authors and generated surfaces that cannot resolve `#NNNN`
+(`check:doc-authoring`, maintainer ruling 2026-08-12) — a pin asserts the
+message carries no tracker id.
+
+**The explanation is preserved byte-for-byte.** The opening sentence — the
+MATERIALISED/`criteria_json` explanation of *why* the condition is refused — is
+the most useful part of the diagnostic and is unchanged; a pin asserts it
+verbatim. The file's own docblock carried the same unqualified "the fix is RLS"
+claim one layer up and is corrected in the same edit.
+
+**No behaviour change**: the rule's accept/reject verdict, its ids, severities,
+paths and `message` text are untouched — this is `hint` prose only. AND
+composition is correct by design and is not touched either.
+
+A new pin holds the split, because prose is invisible to every other gate —
+nothing else in CI reads a word of this hint. Reverse-verified by restoring the
+shipped wording: **7 legs go red** (the unqualified-RLS leg, the AND-composition
+leg, the widening-doors leg, the `position` warning, the #14103 gap, and both
+vocabulary legs), while the verbatim-explanation leg correctly stays green. The
+vocabulary legs check every sharing model and depth scope the hint names against
+the **spec-owned** `OWDModel` / `ObjectAccessScopeSchema` enums, so a rename in
+the spec reds this file instead of leaving the hint quoting values the platform
+no longer has — without it the hint and its expectations would move together and
+nothing would go red.

--- a/packages/lint/src/validate-sharing-rule-enforceability.test.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.test.ts
@@ -2,6 +2,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { compileCelToFilter } from '@objectstack/formula';
+// [#14234] The spec-owned vocabulary the fix-hint quotes back at the author.
+// Imported rather than transcribed so a rename in the spec reds this file
+// instead of leaving the hint naming values the platform no longer has.
+import { OWDModel, ShareRecipientType, ObjectAccessScopeSchema } from '@objectstack/spec/security';
 
 import {
   validateSharingRuleEnforceability,
@@ -391,5 +395,129 @@ describe('validateSharingRuleEnforceability — an anchor a gate WOULD consult s
     const stack = anchoredOn('private');
     expect(Object.keys((stack.objects[0] as { fields: object }).fields)).not.toContain('owner_id');
     expect(validateSharingRuleEnforceability(stack)).toEqual([]);
+  });
+});
+
+// ── The `private`-case wording pin (#14234) ──────────────────────────
+//
+// The hint this rule prints used to end in an UNQUALIFIED remedy: "express
+// per-user access with … an RLS policy on a permission set". That advice is
+// sound on an open OWD and structurally impossible on `private`, which is the
+// sharing model an author hitting this rule is most likely to be on.
+//
+// Measured, not argued. The security layers are AND-composed —
+// `security-plugin.ts` returns
+// `andComposeLayers(andComposeLayers(filter, cbpFilter), sharingFilter)`, and
+// `getReadFilter`'s own prose promises "the same filter the engine middleware
+// AND-s into every find". `plugin-sharing`'s `buildReadFilter` returns `null`
+// for every model except `private`, so:
+//
+//   - `public_read` / `public_read_write` → sharing imposes nothing on reads;
+//     an RLS policy NARROWS an open baseline, the direction AND expresses.
+//   - `private` → sharing has ALREADY withheld the row, and an AND term can
+//     only remove rows, never add one back. An RLS "widener" there lints
+//     clean, passes every gate and grants nothing — a silent failure at the
+//     security boundary.
+//
+// These legs pin the split. The failure they exist to catch is a REGRESSION TO
+// ADVICE THAT CANNOT WORK, which is invisible to every other gate: the hint is
+// prose, so nothing else in CI reads a word of it.
+describe('SHARING_RULE_RUNTIME_VARIABLE_CONDITION — the hint qualifies its RLS remedy by sharing model', () => {
+  const hintOf = (): string => {
+    const findings = validateSharingRuleEnforceability(
+      ruleWith("record.visibility == 'manager' && record.owner_id == current_user.id"),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].rule).toBe(SHARING_RULE_RUNTIME_VARIABLE_CONDITION);
+    return findings[0].hint;
+  };
+
+  it('keeps the WHY verbatim — the most useful part of the diagnostic', () => {
+    // Byte-exact. This sentence explains why the condition is refused at all,
+    // and it was correct before this card and after it.
+    expect(hintOf()).toContain(
+      'A criteria sharing rule is MATERIALISED: the seeder compiles ONE static `criteria_json` per ' +
+      'rule and the evaluator writes `sys_record_share` rows from it, so there is no "current user" ' +
+      'for the condition to read.',
+    );
+  });
+
+  it('never offers RLS unqualified — the sentence naming `using` names the models it holds for', () => {
+    // The load-bearing leg. `rowLevelSecurity[].using` may still be
+    // recommended, but only inside a sentence that says WHERE it works; the
+    // shipped defect was exactly this recommendation with no model attached.
+    const sentences = hintOf().split(/(?<=\.)\s+/);
+    const rlsSentences = sentences.filter((s) => s.includes('rowLevelSecurity[].using'));
+    expect(rlsSentences.length).toBeGreaterThan(0);
+    rlsSentences.forEach((s) => {
+      expect(s).toMatch(/public_read/);
+    });
+  });
+
+  it('states the `private` case: AND-composed layers mean RLS cannot widen', () => {
+    const hint = hintOf();
+    expect(hint).toMatch(/AND-composed/);
+    expect(hint).toMatch(/can only REMOVE rows/);
+    // The consequence an author must be told, because it is silent.
+    expect(hint).toMatch(/lints clean/);
+    expect(hint).toMatch(/grants nothing/);
+  });
+
+  it('names the doors that DO widen a private object, and what they key on', () => {
+    const hint = hintOf();
+    // Widen by OWNER (ADR-0057 D1 depth) …
+    expect(hint).toMatch(/readScope/);
+    expect(hint).toMatch(/owner_id IN/);
+    // … or by an explicit share row, which only a criteria rule writes.
+    expect(hint).toMatch(/sys_record_share/);
+    // And the property that makes both unusable as a per-record predicate.
+    expect(hint).toMatch(/never on a property of the record/);
+  });
+
+  it('mentions `position` only as an over-broad-grant WARNING, never as the remedy', () => {
+    // The neighbouring temptation is worse than doing nothing: `position`
+    // shares every matched row with every holder of that position tenant-wide.
+    const hint = hintOf();
+    expect(hint).toMatch(/position/);
+    expect(hint).toMatch(/over-broad grant/);
+    expect(hint).toMatch(/EVERY holder/);
+  });
+
+  it('names the open capability gap rather than inventing a mechanism', () => {
+    expect(hintOf()).toMatch(/#14103/);
+  });
+});
+
+// The vocabulary leg. Without it the hint and its expectations above move
+// together under a rename and nothing goes red — the failure mode the doctor
+// tenancy-hint pin was written to close. Every model and depth the hint names
+// is checked against the SPEC-owned enum that declares it.
+describe('the hint names REAL sharing-model and depth vocabulary', () => {
+  const hint = (): string => {
+    const f = validateSharingRuleEnforceability(ruleWith('record.owner_id == current_user.id'));
+    return f[0].hint;
+  };
+
+  const MODELS_NAMED_BY_THE_HINT = ['private', 'public_read', 'public_read_write'] as const;
+  const DEPTHS_NAMED_BY_THE_HINT = ['own', 'own_and_reports', 'unit', 'unit_and_below', 'org'] as const;
+
+  it('every sharing model it names is an `OWDModel` value the spec still declares', () => {
+    const declared = new Set<string>(OWDModel.options);
+    MODELS_NAMED_BY_THE_HINT.forEach((m) => {
+      expect(declared.has(m)).toBe(true);
+      expect(hint()).toContain(`\`${m}\``);
+    });
+  });
+
+  it('every depth scope it names is an `ObjectAccessScope` value the spec still declares', () => {
+    const declared = new Set<string>(ObjectAccessScopeSchema.options);
+    DEPTHS_NAMED_BY_THE_HINT.forEach((d) => {
+      expect(declared.has(d)).toBe(true);
+      expect(hint()).toContain(`\`${d}\``);
+    });
+  });
+
+  it('`position` is a real `ShareRecipientType` — the warning is about a live trap', () => {
+    expect(new Set<string>(ShareRecipientType.options).has('position')).toBe(true);
   });
 });

--- a/packages/lint/src/validate-sharing-rule-enforceability.test.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.test.ts
@@ -484,7 +484,14 @@ describe('SHARING_RULE_RUNTIME_VARIABLE_CONDITION — the hint qualifies its RLS
   });
 
   it('names the open capability gap rather than inventing a mechanism', () => {
-    expect(hintOf()).toMatch(/#14103/);
+    const hint = hintOf();
+    // Described in WORDS, never as a tracker id: this string reaches authors
+    // and generated surfaces, and none of them can resolve `#NNNN`
+    // (`check:doc-authoring`, maintainer ruling 2026-08-12). The `#14103`
+    // anchor lives in an adjacent source comment instead.
+    expect(hint).toMatch(/known gap in the platform/);
+    expect(hint).toMatch(/leave the grant unauthored rather than widening it/);
+    expect(hint).not.toMatch(/#\d{3,}/);
   });
 });
 

--- a/packages/lint/src/validate-sharing-rule-enforceability.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.ts
@@ -92,8 +92,16 @@
  *    MATERIALIZED — the seeder compiles one static `criteria_json` per rule and
  *    the evaluator writes `sys_record_share` grants from it — so there is no
  *    "current user" at compile time and the compiler correctly refuses. The fix
- *    is a different mechanism (RLS / an ownership-shaped grant), not a
- *    different spelling, which is exactly why it earns its own id.
+ *    is a different mechanism, not a different spelling, which is exactly why
+ *    it earns its own id — and WHICH mechanism is decided by the anchor's
+ *    `sharingModel`, because the security layers are AND-composed. RLS
+ *    NARROWS: it is the right answer on `public_read` / `public_read_write`,
+ *    where the sharing layer imposes nothing on reads, and structurally the
+ *    WRONG one on `private`, where the sharing layer has already withheld the
+ *    row and an AND term can only withhold more (an RLS "widener" there lints
+ *    clean and grants nothing). The hint carries that split rather than the
+ *    unqualified "use RLS" it shipped with, and the tests pin the `private`
+ *    half so it cannot regress to advice that cannot work.
  *  - `parse-error` → deliberately NOT reported here. CEL syntax is
  *    `validateStackExpressions`' surface and it already gates this same field
  *    (`stack.sharingRules[].condition`). Reporting it twice, in two
@@ -463,11 +471,28 @@ export function validateSharingRuleEnforceability(stack: unknown): SharingRuleEn
         hint:
           'A criteria sharing rule is MATERIALISED: the seeder compiles ONE static `criteria_json` per ' +
           'rule and the evaluator writes `sys_record_share` rows from it, so there is no "current user" ' +
-          'for the condition to read. Express per-user access with the mechanism that runs per request ' +
-          'instead — an RLS policy on a permission set (`rowLevelSecurity[].using`, where ' +
-          '`current_user.*` IS resolved), or the record-ownership path. Keep this rule for the part of ' +
-          'the predicate that is a property of the RECORD (e.g. `record.stage == \'closed_won\'`) and ' +
-          'name the audience through `sharedWith`.',
+          'for the condition to read. WHICH mechanism replaces it depends on the anchor object\'s ' +
+          '`sharingModel`, because the security layers are AND-composed (`getReadFilter` = RLS AND ' +
+          'controlled-by-parent AND sharing) and an AND term can only REMOVE rows — it can never add ' +
+          'one back. On `public_read` / `public_read_write` the sharing layer imposes nothing on reads ' +
+          '(`buildReadFilter` constrains `private` only), so an RLS policy on a permission set ' +
+          '(`rowLevelSecurity[].using`, where `current_user.*` IS resolved) is the right mechanism: it ' +
+          'NARROWS an open baseline, the direction AND can express. On `private` — including a CUSTOM ' +
+          'object that declares no `sharingModel`, which resolves to `private` (ADR-0090 D1) — that ' +
+          'same policy CANNOT work: the sharing layer has already withheld the row, and AND-ing an RLS ' +
+          'predicate onto it can only withhold more, so the policy lints clean, passes every gate and ' +
+          'grants nothing. The two doors that widen a `private` object for a non-admin principal both ' +
+          'key on WHO OWNS the row or on an explicit share row, never on a property of the record: the ' +
+          'ADR-0057 D1 depth scopes (`readScope` / `writeScope` on the object permission — `own` | ' +
+          '`own_and_reports` | `unit` | `unit_and_below` | `org`), which widen the owner-match to ' +
+          '`owner_id IN (…)`; and a `sys_record_share` row, which on this path only a criteria sharing ' +
+          'rule writes — i.e. THIS rule. So keep this rule for the part of the predicate that is a ' +
+          'property of the RECORD (e.g. `record.stage == \'closed_won\'`) and name the audience ' +
+          'through `sharedWith`. If the audience is genuinely record-relative ("the owner\'s manager", ' +
+          '"this record\'s approver"), no mechanism expresses it today — `sharedWith` recipients ' +
+          'resolve tenant-wide, so reaching for `position` shares every matched row with EVERY holder ' +
+          'of that position (the skip-level, the manager two teams over): an over-broad grant, not the ' +
+          'narrower one you meant. That gap is tracked at #14103.',
       });
       return;
     }

--- a/packages/lint/src/validate-sharing-rule-enforceability.ts
+++ b/packages/lint/src/validate-sharing-rule-enforceability.ts
@@ -461,6 +461,11 @@ export function validateSharingRuleEnforceability(stack: unknown): SharingRuleEn
       'condition is never seeded as a permissive match-all).';
 
     if (result.reason === 'unresolved-variable') {
+      // The record-relative-recipient gap the hint's last sentence describes is
+      // tracked at #14103. The id lives HERE and not in the string: a runtime
+      // message reaches authors and generated surfaces, and none of them can
+      // resolve `#NNNN` (`check:doc-authoring`, maintainer ruling 2026-08-12).
+      // The reader who CAN resolve it is reading this source.
       findings.push({
         severity: 'error',
         rule: SHARING_RULE_RUNTIME_VARIABLE_CONDITION,
@@ -492,7 +497,9 @@ export function validateSharingRuleEnforceability(stack: unknown): SharingRuleEn
           '"this record\'s approver"), no mechanism expresses it today — `sharedWith` recipients ' +
           'resolve tenant-wide, so reaching for `position` shares every matched row with EVERY holder ' +
           'of that position (the skip-level, the manager two teams over): an over-broad grant, not the ' +
-          'narrower one you meant. That gap is tracked at #14103.',
+          'narrower one you meant. That is a known gap in the platform, not something a different ' +
+          'spelling of this rule can close — leave the grant unauthored rather than widening it, and ' +
+          'ask for record-relative sharing recipients.',
       });
       return;
     }


### PR DESCRIPTION
Fixes #14234

Prose-only fix to one lint fix-hint. The rule's accept/reject behaviour, its ids, severities, `path`s and `message` text are untouched, and AND-composition (correct by design) is not touched either.

## Premise re-check on fresh `origin/main`

Both halves of the card's premise were re-verified at `035951faf` (worktree base) before any edit. Both still hold:

1. **The hint still carries the unqualified RLS remedy.** `packages/lint/src/validate-sharing-rule-enforceability.ts`, the `SHARING_RULE_RUNTIME_VARIABLE_CONDITION` finding — quoted verbatim below.
2. **The AND-composition evidence still reads as cited.** `packages/plugins/plugin-security/src/security-plugin.ts` returns `andComposeLayers(andComposeLayers(filter, cbpFilter), sharingFilter)` (line 4416, unchanged), and `getReadFilter`'s prose contract still promises *"the same filter the engine middleware AND-s into"* every find (line ~3952).

Third leg, added because the card used shorthand the platform does not spell that way: **the sharing-model vocabulary was checked against the spec** rather than taken from the card. `ObjectSchema.sharingModel` is `z.enum(['private', 'public_read', 'public_read_write', 'controlled_by_parent'])` — so the card's `read_write` shorthand is really `public_read_write`, and the rewritten hint names the real four.

## What makes the old advice unsound — measured

`plugin-sharing`'s `buildReadFilter` constrains **`private` only**:

```
if (effectiveSharingModel(schema) !== 'private') return null;
```

So the split is exact:

- `public_read` / `public_read_write` → the sharing layer imposes nothing on reads. RLS **narrows** an open baseline — the direction AND can express, and the original advice is correct here. It is kept, now with the models it holds for attached.
- `private` → the sharing layer has already withheld the row, and an AND term can only remove rows, never add one back. An RLS "widener" there lints clean, passes every gate, and grants nothing.

The two doors that actually widen a `private` object for a non-admin principal both key on **who owns the row** or on an **explicit share row**, never on a property of the record — confirmed in `buildReadFilter`'s body: `owner_id IN (…)` widened by the ADR-0057 D1 depth (`readScope`/`writeScope`, enum `ObjectAccessScopeSchema`), OR `id IN (granted ids)` from `sys_record_share`.

## Old vs new hint

**Before:**

> A criteria sharing rule is MATERIALISED: the seeder compiles ONE static `criteria_json` per rule and the evaluator writes `sys_record_share` rows from it, so there is no "current user" for the condition to read. **Express per-user access with the mechanism that runs per request instead — an RLS policy on a permission set (`rowLevelSecurity[].using`, where `current_user.*` IS resolved), or the record-ownership path.** Keep this rule for the part of the predicate that is a property of the RECORD (e.g. `record.stage == 'closed_won'`) and name the audience through `sharedWith`.

**After:**

> A criteria sharing rule is MATERIALISED: the seeder compiles ONE static `criteria_json` per rule and the evaluator writes `sys_record_share` rows from it, so there is no "current user" for the condition to read. WHICH mechanism replaces it depends on the anchor object's `sharingModel`, because the security layers are AND-composed (`getReadFilter` = RLS AND controlled-by-parent AND sharing) and an AND term can only REMOVE rows — it can never add one back. On `public_read` / `public_read_write` the sharing layer imposes nothing on reads (`buildReadFilter` constrains `private` only), so an RLS policy on a permission set (`rowLevelSecurity[].using`, where `current_user.*` IS resolved) is the right mechanism: it NARROWS an open baseline, the direction AND can express. On `private` — including a CUSTOM object that declares no `sharingModel`, which resolves to `private` (ADR-0090 D1) — that same policy CANNOT work: the sharing layer has already withheld the row, and AND-ing an RLS predicate onto it can only withhold more, so the policy lints clean, passes every gate and grants nothing. The two doors that widen a `private` object for a non-admin principal both key on WHO OWNS the row or on an explicit share row, never on a property of the record: the ADR-0057 D1 depth scopes (`readScope` / `writeScope` on the object permission — `own` | `own_and_reports` | `unit` | `unit_and_below` | `org`), which widen the owner-match to `owner_id IN (…)`; and a `sys_record_share` row, which on this path only a criteria sharing rule writes — i.e. THIS rule. So keep this rule for the part of the predicate that is a property of the RECORD (e.g. `record.stage == 'closed_won'`) and name the audience through `sharedWith`. If the audience is genuinely record-relative ("the owner's manager", "this record's approver"), no mechanism expresses it today — `sharedWith` recipients resolve tenant-wide, so reaching for `position` shares every matched row with EVERY holder of that position (the skip-level, the manager two teams over): an over-broad grant, not the narrower one you meant. That is a known gap in the platform, not something a different spelling of this rule can close — leave the grant unauthored rather than widening it, and ask for record-relative sharing recipients.

`position` is named **only** as the over-broad-grant warning the card documents, never as a remedy.

## Two judgment calls worth a reviewer's eye

**1. Which sentences were kept verbatim.** The card says *"the first two sentences stay"* while also requiring the remedy be qualified — but the remedy **is** the second sentence, so both cannot hold literally. Read as written, the card's own justification decides it: *"the first two sentences explain **why** the condition is rejected"*, and that is the opening `MATERIALISED:` sentence (two clauses across its colon). So the **explanation is preserved byte-for-byte** and pinned verbatim by a test; the remedy sentence — the thing the card is about — is what got qualified. The closing "keep this rule for the RECORD part / name the audience through `sharedWith`" sentence is also kept, since it was never the defect. Flagging the reading rather than burying it.

**2. The `#14103` anchor is in a source comment, not in the message.** The card asks the hint to *"name #14103 as the open gap"*. `pnpm check:doc-authoring` reds on a tracker id in runtime string prose, under maintainer ruling 2026-08-12 (「处理 issue 时犯的错应该总结成经验,保留 issue id没有意义」) — a runtime message reaches authors and generated surfaces, none of whom can resolve `#NNNN`. I took the gate's own prescribed remedy: **the gap is described in words** in the message, and the tracker anchor sits in an adjacent `//` comment where the reader who can resolve it is already looking. A pin asserts the message carries no tracker id. #14103 is not addressed by this PR and stays open as the capability half.

## Bounded in-place fix, declared

Beyond the hint, one **same-file, same-defect-class** correction: the file's own docblock (`## The two ids, and why not one`) carried the identical unqualified claim one layer up — *"the fix is a different mechanism (RLS / an ownership-shaped grant)"*. Left alone it would re-seed the defect for the next author of this rule. It now carries the same `sharingModel` split. No other file is touched.

## Tests

New pin block, `packages/lint/src/validate-sharing-rule-enforceability.test.ts` — prose is invisible to every other gate, so nothing else in CI reads a word of this hint:

- the explanation sentence survives **byte-exact**;
- every sentence naming `rowLevelSecurity[].using` also names the models it holds for (the anti-regression leg — the shipped defect was exactly this recommendation with no model attached);
- the `private` case states the AND-composition and the silent-failure consequence;
- the widening doors and what they key on;
- `position` framed as a warning;
- the gap named in words, and the message carries no tracker id;
- **vocabulary legs**: every sharing model and depth scope the hint names is checked against the spec-owned `OWDModel` / `ObjectAccessScopeSchema` enums, so a rename in the spec reds this file instead of leaving the hint quoting values the platform no longer has. Without this leg the hint and its expectations move together under a rename and nothing goes red.

**Reverse-verified.** Restoring the shipped wording (mutation confirmed on disk by anchored `grep -c` on both the injected and deleted text, plus a `git hash-object` differing from the HEAD blob; restore proven by hash equality to the HEAD blob and an empty `git diff HEAD`, not by an exit code) turns **7 legs red** — the unqualified-RLS leg, the AND-composition leg, the widening-doors leg, the `position` warning, the gap leg, and both vocabulary legs — while the verbatim-explanation leg correctly stays **green**, since that sentence is preserved in both wordings. No rebuild was needed for the ablation: the test reaches the rule through a relative specifier that vitest resolves to `src/`; only the spec vocabulary leg reads `dist/`, which the mutation does not touch.

### Checks run — all at final head `3e4d2d741`

- `pnpm --filter @objectstack/lint test` → **88 files / 2482 tests passed**
- `pnpm --filter @objectstack/lint typecheck` → clean. ⚠️ Read as **NOT MEASURED for the new test file**: `packages/lint/tsconfig.json` excludes `**/*.test.ts`, confirmed with `--listFiles` (0 hits). Type-checked separately via a probe config that includes the tests — **0 errors in either file I touched**; the residue it surfaces in 7 other test files is the pre-existing, itemized, shrink-only `TEST_DEBT` ledger entry for this package, not a regression.
- `pnpm lint` (full repo `eslint . --no-inline-config`) → **green, run in full**; no narrowing to declare.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` derived **34 families** (30 by path + 6 by kind, 2 shared) from its own change set — all run: **33 green**, 1 NOT MEASURED (`check-test-completeness`, exit 3: it parses a saved `turbo run test` log that only CI produces — its own text says exit 3 is not a finding).
- `pnpm check:type-check-debt` → green after building the workspace closure (`turbo run build`, 70/70) — it refuses outright on an unbuilt tree, and that refusal is NOT MEASURED rather than a pass.
- `pnpm check:doc-authoring` → red on the first attempt (the `#14103` string), green after the fix above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_