### PR TITLE
fix(lint): derive the runtime gate's context-collection set from RuntimeStackContext

### DIFF
--- a/.changeset/tidy-eels-tickle.md
+++ b/.changeset/tidy-eels-tickle.md
@@ -1,0 +1,9 @@
+---
+'@objectstack/lint': patch
+---
+
+Derive the runtime publish gate's context-collection set from `RuntimeStackContext` instead of hand-listing it.
+
+`CONTEXT_STACK_KEYS` carried `as const satisfies readonly (keyof RuntimeStackContext)[]`, which asks that every entry it names is a real context key (validity) and never that every context key has an entry (completeness) — while the docblock on `RuntimeStackContext` claimed it was "derived from this shape and keeps the two from drifting". A collection declared on the interface but missing from the list was never carried into the per-write snapshot: the host passed it in, the gate dropped it, and every rule resolving references into that collection judged an empty universe and emitted findings that look correct. Measured, adding a collection to the interface left the package building at exit 0 with nothing red inside it.
+
+The set is now derived from a keyed record typed `{ [K in keyof RuntimeStackContext]-?: true }` — the `-?` mechanism already proven at `@objectstack/metadata-protocol`'s `protocol.ts` — so a new context collection without its row is a type error naming that collection at `tsc --noEmit` and at the build. Declaration order is preserved and pinned, since it feeds both the snapshot's key order and the derived top-level-index alternation. No behaviour change: the same five collections are carried, in the same order.

--- a/packages/lint/src/runtime-gate.derived-context-keys.test.ts
+++ b/packages/lint/src/runtime-gate.derived-context-keys.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#13977] `CONTEXT_STACK_KEYS` is derived from `RuntimeStackContext`, and the
+ * ORDER it derives is load-bearing. This file pins the half a type cannot.
+ *
+ * ## The split, stated once
+ *
+ * COMPLETENESS — every context collection has an entry — is held by the
+ * compiler and belongs there: the keyed record the set derives from is typed
+ * `{ [K in keyof RuntimeStackContext]-?: true }`, so a collection added to the
+ * interface without a row is a type error naming that collection, in
+ * `runtime-gate.ts`, at `tsc --noEmit` and at the DTS build. ⛔ It is
+ * deliberately NOT restated here as a runtime assertion: this package's
+ * `tsconfig.json` excludes `**\/*.test.ts`, so no tsc program compiles this
+ * file and a type-level witness written here would evaluate never — a phantom
+ * check that deletes clean. The guard's own failure was measured instead, on
+ * the card, by adding a collection and reading the build.
+ *
+ * ORDER is what a test can hold, and the derivation had to be chosen so as not
+ * to break it — a mapped type does not guarantee declaration order. The order
+ * reaches two consumers, one of which is measured here and one of which
+ * `runtime-gate.derived-name-keys.test.ts` already covers:
+ *
+ * - the snapshot's own key order (`Object.keys(baseline)`), which that file
+ *   reads back as a VALUE and asserts through an ordered `toEqual`;
+ * - `TOP_LEVEL_INDEX`'s alternation, whose `source` #13390 keeps byte-identical
+ *   to the literal it replaced.
+ *
+ * ## Why the pre-existing ordered pin is not enough
+ *
+ * It asserts the order of the NAME-KEYED subset, which drops `datasets` (no
+ * write type maps into it). So swapping `datasets` with either neighbour left
+ * it green while genuinely reordering the set the snapshot is built from. The
+ * first test below closes exactly that gap, and is the reason ordering could be
+ * reported as load-bearing rather than assumed either way.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildRuntimeWriteSnapshots } from './runtime-gate.js';
+
+/**
+ * The set as the GATE carries it, never as a constant re-imported or restated:
+ * `buildRuntimeWriteSnapshots` gives the baseline one key per context
+ * collection, in the order the derivation yields.
+ */
+const carriedStackKeys = () =>
+  Object.keys(buildRuntimeWriteSnapshots({ type: 'object', item: { name: 'probe_object' } })!.baseline);
+
+describe('the derived context-collection set (#13977)', () => {
+  it('carries every context collection, in the declared stack-key order', () => {
+    // The whole set, in order — including `datasets`, which the name-keyed pin
+    // filters out and therefore cannot hold in position. A reordering of the
+    // record `CONTEXT_STACK_KEYS` derives from lands here first.
+    expect(carriedStackKeys()).toEqual(['objects', 'permissions', 'books', 'datasets', 'pages']);
+  });
+
+  it('derives the same set whatever the write is, since the write does not choose it', () => {
+    // A write into a context collection replaces its stored self and a write
+    // outside them adds its own collection — neither may change WHICH context
+    // collections are carried, or the gate would judge different universes for
+    // different write types.
+    const forNonContextWrite = Object.keys(
+      buildRuntimeWriteSnapshots({ type: 'flow', item: { name: 'probe_flow' } })!.baseline,
+    );
+
+    expect(forNonContextWrite).toEqual(carriedStackKeys());
+  });
+
+  it('carries a collection the host never passed, rather than omitting the key', () => {
+    // Completeness has a runtime half after all: the loop writes every derived
+    // key unconditionally, so an absent context yields empty collections and a
+    // rule resolving into one reads "empty universe" from a key that EXISTS.
+    // (`runtime-gate.test.ts` pins the same shape against the whole set; this
+    // states why the loop may not skip a missing collection.)
+    const baseline = buildRuntimeWriteSnapshots({ type: 'book', item: { name: 'b1' } })!.baseline;
+
+    for (const key of carriedStackKeys()) {
+      expect(baseline).toHaveProperty(key);
+      expect(baseline[key]).toEqual([]);
+    }
+  });
+
+  it('every carried collection is one the interface declares — validity, still', () => {
+    // The half the old `satisfies` clause DID hold, kept measurable now that the
+    // clause is gone: the derived keys are the record's keys, and the record is
+    // pinned to `keyof RuntimeStackContext`. Asserted against the context the
+    // gate accepts, so an entry naming a collection the host cannot pass fails.
+    const context = {
+      objects: [{ name: 'acme_thing' }],
+      permissions: [{ name: 'sales' }],
+      books: [{ name: 'handbook' }],
+      datasets: [{ name: 'revenue' }],
+      pages: [{ name: 'home' }],
+    };
+    const baseline = buildRuntimeWriteSnapshots({ type: 'flow', item: { name: 'f1' }, context })!.baseline;
+
+    for (const key of carriedStackKeys()) {
+      expect(context).toHaveProperty(key);
+      expect(baseline[key]).toEqual(context[key as keyof typeof context]);
+    }
+  });
+});

--- a/packages/lint/src/runtime-gate.ts
+++ b/packages/lint/src/runtime-gate.ts
@@ -122,6 +122,13 @@ const TYPE_TO_STACK_KEY: Readonly<Record<string, string>> = {
  * `positions` / `apps` — so those are NOT carried. Widening the snapshot is a
  * one-key edit here plus a `CONTEXT_STACK_KEYS` entry, made when a rule that
  * reads the collection actually crosses the wall, never in advance.
+ *
+ * [#13977] "Derived from this shape" is now the mechanism and not only the
+ * intent: the second half of that edit is DEMANDED by the compiler rather than
+ * remembered. Add a key here and this package stops building until the
+ * collection has its row below — see {@link CONTEXT_STACK_KEYS} for what the
+ * old `satisfies` clause could not ask, and what silently happened when the
+ * row was forgotten.
  */
 export interface RuntimeStackContext {
   /**
@@ -286,12 +293,104 @@ const PACKAGE_PROVENANCE_KEY = '_packageId';
 const OVERLAY_PROVENANCE_SENTINEL = 'sys_metadata';
 
 /**
+ * The context collections the snapshot carries, in stack-key order — DERIVED
+ * from {@link RuntimeStackContext}, not listed (#13977).
+ *
+ * ## What the spelling this replaces could not ask
+ *
+ * It was a hand-written literal carrying `as const satisfies readonly (keyof
+ * RuntimeStackContext)[]`. That clause asks that every entry it NAMES is a real
+ * context key — validity. It does not ask that every context key HAS an entry —
+ * completeness, which the docblock on {@link RuntimeStackContext} nevertheless
+ * claimed ("derived from this shape and keeps the two from drifting"). Declared,
+ * not enforced.
+ *
+ * The cost was not a missing member, it was a WRONG VERDICT.
+ * {@link buildRuntimeWriteSnapshots} fills the snapshot by iterating this set, so
+ * a collection declared on the interface and absent here is never carried: the
+ * host passes it in, the gate drops it, and every rule resolving references into
+ * that collection judges a universe that is empty — findings that look correct
+ * against something that is not there (the `shyx_customer_ds` shape). Measured
+ * before this card: adding `widgets?: readonly unknown[]` to the interface and
+ * rebuilding left `pnpm --filter @objectstack/lint build` at **exit 0** with
+ * nothing in this package red. The only red was second-order and one package
+ * over — `protocol.ts`'s `-?` accumulator in `@objectstack/metadata-protocol`,
+ * about a different constant, naming this one nowhere. The same asymmetry #13390
+ * removed from `NAME_KEYED_STACK_KEYS` and #13768 from
+ * `CLOSURE_CONTEXT_KEY_BY_TYPE`.
+ *
+ * ## Why a keyed record, and why that is a derivation rather than an assertion
+ *
+ * A type's keys cannot be materialised as values, so the derivation needs
+ * exactly one runtime spelling to derive FROM, and the job is to make that
+ * spelling impossible to leave incomplete. {@link CONTEXT_STACK_KEY_ORDER} is
+ * that spelling and the mapped type pins it in BOTH directions: `-?` over `keyof
+ * RuntimeStackContext` demands a row per collection (a missing one is a type
+ * error naming the collection, in this file, at `tsc --noEmit` and at the DTS
+ * build), and the object-literal excess-property check refuses a row for a
+ * collection the interface no longer has. The array is then computed, so it
+ * cannot disagree with the record.
+ *
+ * That is `protocol.ts`'s `-?` accumulator, the mechanism this repo already
+ * proves. #13768 had to settle for a completeness ASSERTION beside its constant
+ * only because the type lived one package away and the set was not readable
+ * there as a value; here both inputs are in this file, so the stronger shape is
+ * available and is what ships.
+ *
+ * ## Order is load-bearing, so the derivation preserves it (measured, #13977)
+ *
+ * The order this encodes reaches two places, and it was worth measuring before
+ * choosing a spelling — a mapped type does not guarantee declaration order:
+ *
+ * - **The snapshot's own key order.** The loop in
+ *   {@link buildRuntimeWriteSnapshots} inserts in this order, so it is what
+ *   `Object.keys(baseline)` yields — read as a VALUE by
+ *   `runtime-gate.derived-name-keys.test.ts`, which feeds it to
+ *   {@link deriveNameKeyedStackKeys} and asserts an ORDERED result.
+ * - **The derived alternation.** {@link deriveNameKeyedStackKeys} filters in
+ *   context order by contract ("Order follows `contextStackKeys`, deliberately"),
+ *   and {@link buildTopLevelIndexPattern} interpolates that order into
+ *   {@link TOP_LEVEL_INDEX}. Reordering does not change what the pattern MATCHES
+ *   — the `\[` anchor defeats prefix shadowing, pinned in both orders — but it
+ *   does change the pattern's `source`, which #13390 keeps byte-identical to the
+ *   literal it replaced on purpose.
+ *
+ * So the requirement is: preserve the author's order. This spelling does, and
+ * that is the reason it is a keyed record rather than any union-to-tuple trick:
+ * `Object.keys` returns own enumerable string keys in declaration order
+ * (ECMAScript `OrdinaryOwnPropertyKeys`), so the order below IS the stack-key
+ * order, chosen here and readable here. Integer-like keys would sort ahead of
+ * insertion order, which is why that rule is stated rather than assumed — a
+ * stack key is an interface property name and never one of those.
+ *
+ * Ordering is pinned by `runtime-gate.derived-context-keys.test.ts` end to end,
+ * because the pre-existing ordered pin could not see all of it: it filters
+ * `datasets` out (no write type maps into it), so swapping `datasets` with a
+ * neighbour left that assertion green.
+ */
+const CONTEXT_STACK_KEY_ORDER = {
+  objects: true,
+  permissions: true,
+  books: true,
+  datasets: true,
+  pages: true,
+} as const satisfies { [K in keyof RuntimeStackContext]-?: true };
+
+/**
  * The context collections the snapshot carries, in stack-key order. Derived
  * facts: every entry is a key of {@link RuntimeStackContext} AND a stack key
- * some runtime-wired rule reads (`runtime-gate.test.ts` pins membership).
+ * some runtime-wired rule reads (`runtime-gate.test.ts` pins membership);
+ * every key of {@link RuntimeStackContext} has an entry (#13977 — the record
+ * above, held by the compiler).
+ *
+ * `Object.keys` types as `string[]`, so the read-back is asserted. It is the one
+ * assertion in the derivation and it is sound by construction: the record is
+ * compiler-pinned to exactly `keyof RuntimeStackContext`, and `Object.keys`
+ * returns exactly that record's own enumerable string keys. ⛔ Do not widen this
+ * back into a literal — the list would stop being derived and the interface
+ * would stop being the single source it says it is.
  */
-const CONTEXT_STACK_KEYS = ['objects', 'permissions', 'books', 'datasets', 'pages'] as const satisfies
-  readonly (keyof RuntimeStackContext)[];
+const CONTEXT_STACK_KEYS = Object.keys(CONTEXT_STACK_KEY_ORDER) as readonly (keyof RuntimeStackContext)[];
 
 /** One rule's verdict at the runtime surface, carrying which rule produced it. */
 export interface RuntimeGateResult {
@@ -501,11 +600,16 @@ export const WRITTEN_STACK_KEYS: ReadonlySet<string> = new Set(Object.values(TYP
  * both are already written down: the context fills the collection
  * ({@link CONTEXT_STACK_KEYS}) and some write type maps into it
  * ({@link TYPE_TO_STACK_KEY}). Kept as a literal it was the one spelling of that
- * set with NO guard — `CONTEXT_STACK_KEYS` carries a `satisfies` clause, which
- * is validity, not completeness, and the compiler holds nothing else. Omitting a
- * member here did not fail to build, fail a test, or fail a gate; it emitted
- * findings that LOOK correct whose `path` the caller cannot resolve, which is
- * the #10064 defect re-created silently.
+ * set with NO guard — at the time, `CONTEXT_STACK_KEYS` carried a `satisfies`
+ * clause, which is validity, not completeness, and the compiler held nothing
+ * else. Omitting a member here did not fail to build, fail a test, or fail a
+ * gate; it emitted findings that LOOK correct whose `path` the caller cannot
+ * resolve, which is the #10064 defect re-created silently.
+ *
+ * [#13977] That reading of `CONTEXT_STACK_KEYS` is now history rather than
+ * description: it is derived from `RuntimeStackContext` and complete by
+ * construction. This derivation is unchanged — it always rested on the
+ * MEMBERSHIP of that set, and it now inherits a set the compiler keeps whole.
  *
  * [#13216] `pages` is the measurement that made the case: adding it touched
  * FIVE spellings of this one set and only the fifth announced itself — the one


### PR DESCRIPTION
Fixes #13977

`CONTEXT_STACK_KEYS` in `packages/lint/src/runtime-gate.ts` is now derived from `RuntimeStackContext` instead of hand-listed, so the completeness the docblock has been claiming since #8309 is held by the compiler.

## Premise re-check on fresh `origin/main`

All three anchors are still exactly where the card puts them, at the same line numbers, on `origin/main` at `aca23aba4`:

- `:116` — the docblock claim, verbatim: "see `CONTEXT_STACK_KEYS`, which is derived from this shape and keeps the two from drifting".
- `:293` — the hand-written literal with `as const satisfies readonly (keyof RuntimeStackContext)[]` — validity, never completeness.
- `:393` — `buildRuntimeWriteSnapshots` iterating that set to fill the per-write snapshot, which is what turns a forgotten entry into a verdict against an empty universe rather than a missing member.

The card's own measurement reproduces exactly. Adding `widgets?: readonly unknown[]` to `RuntimeStackContext` on the pre-fix file:

```
derivation present? [0] hand-written literal present? [1]
probe key on disk: 1 occurrence(s)
PRE-FIX build exit: 0
check-dts-emitted: @objectstack/lint - 4/4 declared declaration file(s) present.
```

Exit 0, nothing in the package red. Premise still valid.

## The ordering measurement — the triage pre-answer, answered by measurement

Triage made this binding before any spelling could be chosen: is the order `CONTEXT_STACK_KEYS` encodes ("in stack-key order") load-bearing anywhere? A mapped type does not guarantee declaration order, so a spelling that silently reordered would be a regression no gate here would catch.

**What was searched.** Every reader of the constant, repo-wide (`git grep` over `.ts`/`.mts`/`.mjs`, `node_modules` and `dist` excluded) — two consumers, plus their transitive readers:

1. The loop at `:393`, whose insertion order becomes the snapshot's key order. `runtime-gate.derived-name-keys.test.ts` reads that back as a **value** (`Object.keys(baseline)`) and asserts an **ordered** `toEqual`.
2. `deriveNameKeyedStackKeys`, which filters in context order by documented contract, feeding `buildTopLevelIndexPattern` and thence `TOP_LEVEL_INDEX` — an alternation whose `source` #13390 keeps byte-identical to the literal it replaced.

**What was measured**, by mutating the order on disk and reading which pin moves (each leg proves the mutation landed by reading the key order back off the file, and restores via `git checkout HEAD --`, proven by an empty `git status --porcelain`):

| leg | on-disk order | pre-existing pin | new pin |
|---|---|---|---|
| 0 — unmutated | objects permissions books datasets pages | exit 0 | exit 0 |
| A — swap `objects` / `permissions` | permissions objects books datasets pages | **exit 1** | exit 1 |
| B — swap `datasets` / `pages` | objects permissions books pages datasets | exit 0 | **exit 1** |

Leg A's failure, quoted:

```
AssertionError: expected [ 'permissions', 'objects', …(2) ] to deeply equal [ 'objects', 'permissions', …(2) ]
      Tests  1 failed | 14 passed (15)
```

**Verdict: the ordering IS load-bearing** — leg A moves a pin that is byte-identical to the one on `origin/main`, through consumers this PR does not change, so the reading transfers to `main` directly.

**No fork to report**, because the spelling shipped preserves it. Leg B is the second half of the answer and is why the measurement was worth doing rather than assuming either way: the pre-existing ordered pin filters `datasets` out (no write type maps into it), so it stayed green through a genuine reordering of the set the snapshot is built from. That gap is closed here by a pin over the whole set, in order.

## The spelling

The keyed record plus the `-?` mapped type — `protocol.ts`'s accumulator in `@objectstack/metadata-protocol`, the mechanism this repo already proves, adapted from a record of arrays to a record of order marks:

```ts
const CONTEXT_STACK_KEY_ORDER = {
  objects: true,
  permissions: true,
  books: true,
  datasets: true,
  pages: true,
} as const satisfies { [K in keyof RuntimeStackContext]-?: true };

const CONTEXT_STACK_KEYS = Object.keys(CONTEXT_STACK_KEY_ORDER) as readonly (keyof RuntimeStackContext)[];
```

An actual derivation, not the completeness **assertion** a package boundary forced on the sibling card — here both inputs are in one file, exactly as the triage and the engine seat's routing datum both said. A type's keys cannot be materialised as values, so the derivation needs one runtime spelling to derive from; the mapped type makes that spelling complete in **both** directions (`-?` demands a row per collection; the object-literal excess check refuses a row for a collection the interface no longer has), and the array is then computed, so it cannot disagree with the record.

Order survives because `Object.keys` returns own enumerable string keys in declaration order (`OrdinaryOwnPropertyKeys`) — stated in the docblock rather than assumed, together with the integer-like-key caveat that makes it a rule and not a coincidence.

## The probe after the fix

The same probe that measured exit 0 above, re-run on this branch:

```
POST-FIX typecheck exit: 2
src/runtime-gate.ts(379,12): error TS1360: Type '{ readonly objects: true; readonly permissions: true; readonly books: true; readonly datasets: true; readonly pages: true; }' does not satisfy the expected type '{ objects: true; permissions: true; books: true; datasets: true; pages: true; widgets: true; }'.
POST-FIX build exit: 1
  Property 'widgets' is missing in type '{ readonly objects: true; ... }' but required in type '{ ...; widgets: true; }'.
DTS Build error
```

Red in **this** package, naming the forgotten collection **by name**, in the file that owns the set — not the second-order red one package over that named this constant nowhere. Both `tsc --noEmit` and the DTS build carry it, so the required `TypeScript Type Check` and `Build Core` jobs both hold it.

## Tests

`packages/lint/src/runtime-gate.derived-context-keys.test.ts` (new, 4 tests) pins the half a type cannot: the whole set in order, order-independence from the write type, presence-with-empty-value for a collection the host never passed, and validity against the context the gate accepts.

It deliberately carries **no** type-level witness: `packages/lint/tsconfig.json` excludes its test files by glob and the package has no sibling test tsconfig, so no tsc program compiles that file — a `@ts-expect-error` written there would evaluate never and delete clean, the phantom-check shape AGENTS.md warns about. Completeness is enforced in `src`, where it is compiled, and its failure was measured by the probe above instead.

The neighbouring membership pin (`runtime-gate.test.ts`, "an absent context still yields empty collections") still holds unchanged — same five members, same emptiness.

Three docblocks that asserted the old state were corrected in the same edit, since a stale claim about a guard is the exact defect this card is about: the `RuntimeStackContext` docblock (the derivation is now the mechanism, not only the intent), the constant's own, and `NAME_KEYED_STACK_KEYS`'s, which read "`CONTEXT_STACK_KEYS` carries a `satisfies` clause, which is validity, not completeness, and the compiler holds nothing else" — true when written, false as of this PR, and now marked as history.

## Changeset route

Route 1, per the Check Changeset step's own text ("pick by what the PR actually releases"): the diff edits `packages/lint/src`, a published package, so it releases something and the `skip-changeset` route does not apply. `patch` — internal, no behaviour change, no public surface change, the same five collections carried in the same order.

## Checks

Run on the final commit `85ce871b8` (dev seat `session_01WLJQhde67SeTccsmnBVarV`). All 33 gate families the derivation names for this diff by path and kind, harvested with `--commands` (never from the prose block), plus the two named in dispatch. Result: **30 pass, 3 NOT MEASURED, 0 red.**

- `pnpm --filter @objectstack/lint typecheck` — clean; `pnpm --filter @objectstack/lint test` — 92 files, 2664 tests passed.
- Dependency closure built first; `@objectstack/metadata-protocol` rebuilt through turbo (14 tasks) — the cross-package assertion that reads `RuntimeStackContext` through this package's `dist/runtime.d.ts` still compiles.
- `pnpm lint` — full repo ESLint scan, clean (not narrowed).
- `check:ratchet-remedy-authority` and `check:declared-population-live` — both green.

The three NOT MEASURED are exit **3** — each gate's own code for "prerequisite not met", distinct from a finding's 1, and each says in its own output that this is neither a red nor a pass. All three run with their prerequisite satisfied in CI:

- `check-test-completeness` grades a saved `turbo run test` log that CI tees; it does not run tests and cannot produce one locally.
- `check:dual-build-cjs-loads` reads built output for every package and refuses on a worktree without a full workspace `dist/`.
- `check:type-check-debt` re-measures per ledger entry and refuses without the whole workspace closure built, because measuring from here would measure a different world rather than fail — it prints the demonstration: `packages/lint` reports 19 errors with its closure built and 147 without, same tree, same commit.

Note on that last one: `check:type-check-coverage`, its structural half, **did** run and passed, and its output confirms `packages/lint` is already one of the 16 packages whose tests sit outside every tsc program — so the new test file joins an accounted-for population rather than creating one.