### PR TITLE
Declare the packages/examples census subtree check-system-context-census actually reads

### DIFF
--- a/scripts/check-system-context-census.mjs
+++ b/scripts/check-system-context-census.mjs
@@ -113,6 +113,13 @@
  * change over a population that never moved (#13490). `fixAnchors` carries the two
  * measured occurrences and why the union is the safer shape.
  *
+ * ⇒ So the repair for a line-shift red is `--fix` and never a hand-edited line
+ * number, and the repairing PR should state that `--fix` REFUSED ZERO files. That
+ * sentence is what separates a pure re-anchor from a population change that
+ * happened to be shifted at the same time: the refusal is the gate's only signal
+ * that a site arrived or vanished, and a `--fix` run reporting refusals leaves
+ * rows a human still has to write.
+ *
  * ## Refusals, never quiet passes (#4690)
  *
  * A page that cannot be read, a census with no sites, zero anchors found, a corpus
@@ -157,11 +164,69 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { isEntrypoint } from './invoked-as.mjs';
-import { runCensus, siteKeys } from './isystem-census.mjs';
+import { CORPUS_ROOTS, runCensus, siteKeys } from './isystem-census.mjs';
 import { extractLineAnchors, extractPathCitations, resolveAnchorFile } from './doc-line-anchors.mjs';
 
 const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 export const PAGE = 'content/docs/permissions/system-context.mdx';
+
+/**
+ * ── The population this gate READS, declared where the dispatch tool looks ───
+ *
+ * `extractWatchHints` in `scripts/pm/dispatch-gates.mjs` reads a gate's module
+ * body for path literals and treats them as the population that gate watches.
+ * This gate spelled 29 of them -- the page, the four colliding declarations, the
+ * `NON_READ_ANCHORS` citations -- and every one of them names an ARTIFACT it
+ * maintains. Its real population is the corpus `isystem-census.mjs` walks:
+ * `CORPUS_ROOTS`, today 109 elevation read sites in 20 packages across 45 files
+ * held by 145 anchors.
+ *
+ * ⭐ The failure that produced this declaration is not a missed red. It is a
+ * GREEN that was true and insufficient. A diff that merely SHIFTS a cited line
+ * -- an added import, a widened docblock -- reds this gate in CI while the
+ * derivation places it in the `silent` bucket, which reads as a clearance and is
+ * not: "this gate names paths, none of them yours" is the same sentence for a
+ * gate that cannot see your diff and for one whose whole verdict turns on it.
+ * Measured three times in one night on three unrelated PRs; each cost a CI lap
+ * plus a repair dispatch, and each dev had honestly run its derived families.
+ *
+ * ## Why the subtree and not the 45 cited files
+ *
+ * A roster of the files that carry a read site TODAY can never name the file
+ * that grows one TOMORROW -- and a NEW read site is precisely the finding this
+ * gate exists for (POPULATION, check B above, the mandatory half). A narrow
+ * declaration would derive green for the one case that most needs the lead, so
+ * it re-introduces this defect wearing the shape of a fix.
+ *
+ * ## The cost of the wide form, measured rather than asserted (at a39b02a6b)
+ *
+ * Families derived per probe path, before -> after this declaration:
+ *
+ *   packages/lint/src/authoring-rules.ts                 19 -> 20
+ *   packages/plugins/plugin-auth/src/auth-plugin.ts      22 -> 23
+ *   packages/metadata-protocol/src/protocol.ts           21 -> 22
+ *   packages/spec/src/data/object.zod.ts                 42 -> 42   (already named)
+ *   examples/app-crm/package.json                        17 -> 18
+ *   content/docs/permissions/access-matrix.mdx           30 -> 30   (unchanged)
+ *   scripts/check-nul-bytes.mjs                          14 -> 14   (unchanged)
+ *   .github/workflows/lint.yml                           23 -> 23   (unchanged)
+ *
+ * So the price is ONE family, on cards under the two subtrees only, against a
+ * gate that runs in about 3s and is run by CI on every PR regardless. What the
+ * lead buys is the CI lap it replaces.
+ *
+ * ## Provenance, never a lookup key
+ *
+ * Nothing here reads this array: `collectCorpus` walks `CORPUS_ROOTS`, and the
+ * glob form would name directories that do not exist. The self-test derives both
+ * directions FROM `CORPUS_ROOTS` rather than re-spelling the roots, so a corpus
+ * root added or dropped reddens here instead of silently outrunning the
+ * declaration. It has to be written out as a literal array: assembling it from
+ * `CORPUS_ROOTS` at runtime would put it out of reach of the very text scan it
+ * exists for -- identical runtime value, zero hints extracted, the defect
+ * preserved behind a tidier line (`check-watch-hint-literal` holds this shape).
+ */
+const ROOT_DIR_WATCH_HINTS = ['packages/**', 'examples/**'];
 
 /**
  * ⛔ SHRINK-ONLY. Anchors the page writes that are deliberately NOT elevation read
@@ -1559,6 +1624,64 @@ function selfTest() {
       lintYml.includes(`node ${SELF}\n`)
     );
     t('WIRING: lint.yml runs the --self-test leg too', lintYml.includes(`node ${SELF} --self-test`));
+  }
+
+  // ── POPULATION DECLARATION: what the dispatch derivation is told this gate reads ──
+  //
+  // Nothing in this file can ENFORCE these: `ROOT_DIR_WATCH_HINTS` is read by
+  // another tool entirely (`extractWatchHints` in `scripts/pm/dispatch-gates.mjs`),
+  // so a stale or wrong declaration runs green here forever and pays itself out as
+  // a dev dispatched on a `packages/` card with this gate absent from the brief --
+  // the exact round this declaration was added to end. Both directions are derived
+  // from `CORPUS_ROOTS`, never re-spelled: a corpus root added or dropped there has
+  // to move this declaration or fail here.
+  const declaredRoots = ROOT_DIR_WATCH_HINTS.map((h) => h.replace(/\/\*+$/, ''));
+  t(
+    'POPULATION DECLARATION: every root the census walks is declared',
+    CORPUS_ROOTS.every((r) => ROOT_DIR_WATCH_HINTS.includes(`${r}/**`)),
+    JSON.stringify({ CORPUS_ROOTS, ROOT_DIR_WATCH_HINTS })
+  );
+  t(
+    'POPULATION DECLARATION: and it declares no root the census does not walk (a declaration that can '
+      + 'drift from the walk is worse than none -- it replaces a silent gate with a lying one)',
+    declaredRoots.every((r) => CORPUS_ROOTS.includes(r)),
+    JSON.stringify(declaredRoots)
+  );
+  t(
+    'POPULATION DECLARATION: each declared literal carries a separator -- a bare root word is refused as '
+      + 'too generic by the consumer and would reach nothing',
+    ROOT_DIR_WATCH_HINTS.every((h) => h.includes('/'))
+  );
+  t(
+    'POPULATION DECLARATION: the repo root is NOT declared -- naming it would put this gate in every '
+      + "card's brief to reach the two subtrees whose edits can turn it red",
+    !declaredRoots.some((r) => r === '' || r === '.')
+  );
+  t(
+    'POPULATION DECLARATION: the declared form is NOT the walk root itself (provenance, never a lookup '
+      + 'key -- the glob form handed to the census would name directories that do not exist)',
+    !CORPUS_ROOTS.some((r) => ROOT_DIR_WATCH_HINTS.includes(r))
+  );
+  // The literal SPELLING is the whole mechanism: the consumer scans source text,
+  // so `CORPUS_ROOTS.map((r) => `${r}/**`)` would keep the runtime value, keep
+  // every assertion above green, and contribute ZERO hints. `check-watch-hint-literal`
+  // owns that rule fleet-wide; this pin is the own-source half, statement-scoped so
+  // a second mention in prose or in a neighbouring assertion cannot satisfy it.
+  let ownSource = null;
+  try {
+    ownSource = readFileSync(join(ROOT, SELF), 'utf8');
+  } catch (err) {
+    t('POPULATION DECLARATION: this gate can read its own source', false, err.code ?? err.message);
+  }
+  if (ownSource !== null) {
+    const declSites = [...ownSource.matchAll(/\bconst\s+ROOT_DIR_WATCH_HINTS\s*=\s*([^;]*);/g)];
+    t(
+      'POPULATION DECLARATION: declared exactly once, as an array of quoted literals the text scan can read',
+      declSites.length === 1 &&
+        ROOT_DIR_WATCH_HINTS.every((h) => declSites[0][1].includes(`'${h}'`)) &&
+        !/[A-Za-z_$][\w$]*\s*\./.test(declSites[0][1]),
+      JSON.stringify(declSites.map((d) => d[1].replace(/\s+/g, ' ')))
+    );
   }
 
   process.stdout.write(

--- a/scripts/isystem-census.mjs
+++ b/scripts/isystem-census.mjs
@@ -136,9 +136,22 @@ export function isTestPath(relPath) {
   return /\.(test|spec)\./.test(relPath) || /(^|\/)(tests|__tests__|qa)\//.test(relPath);
 }
 
+/**
+ * The subtrees this census walks -- the REAL population of every number it
+ * reports and of the gate that holds the page to them.
+ *
+ * Named rather than spelled inline because a second reader needs it: the gate
+ * declares this population to the dispatch derivation, and a declaration that
+ * can drift from the walk is worse than none. `check-system-context-census.mjs`
+ * derives its `ROOT_DIR_WATCH_HINTS` from this constant in both directions, so
+ * a root added or removed here reddens that gate's self-test instead of quietly
+ * widening the census past what any card is told about.
+ */
+export const CORPUS_ROOTS = ['packages', 'examples'];
+
 /** Every tracked, non-dist TypeScript file of the corpus -- tests included. */
 export function collectCorpus(root = ROOT) {
-  return execFileSync('git', ['-C', root, 'ls-files', 'packages', 'examples'], {
+  return execFileSync('git', ['-C', root, 'ls-files', ...CORPUS_ROOTS], {
     encoding: 'utf8',
     maxBuffer: 1 << 28,
   })


### PR DESCRIPTION
Fixes #14131

`check-system-context-census.mjs` spelled 29 path literals — the page it maintains, the
four colliding `isSystem` declarations, the `NON_READ_ANCHORS` citations — and not one of
them is its population. `isystem-census.mjs` builds the census from
`git ls-files packages examples`, so a diff that merely SHIFTS a cited line reds the gate
in `Lint & Repo Gates` while the dispatch derivation places it in the `silent` bucket,
which reads as a clearance and is not.

Measured cost, from this card and its comments: three CI laps plus three repair dispatches
in one night, on three unrelated PRs, each after a dev had honestly run its derived
families and honestly reported green.

## Premise re-check on fresh `origin/main` (`a39b02a6b`, clean tree) — HOLDS

```
node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack \
  --residue packages/metadata-protocol/src/protocol.ts
  -> Silent (source names paths, none of which cover yours): 139 famil(ies)
     - node scripts/check-system-context-census.mjs   [lint.yml]   names:
       content/docs/permissions/system-context.mdx, packages/spec/src/kernel/execution-context.zod.ts, ...
       (3 of 29 declared literals reach nothing tracked)
node scripts/check-system-context-census.mjs      # exit captured before any pipe
  -> EXIT 0: 109 elevation read sites in 20 packages across 45 files, all anchored;
     145 anchors resolve, 27 declared non-read
```

Every number in the card re-derived unchanged (109 / 20 / 45 / 145). The Silent bucket is
**139** today, not the 127 the card recorded — re-derived, not quoted.

## Deliverable 1 — the Silent-bucket census, MEASURED

The engine seat's first-deliverable fence: classify the Silent families by "declared
population vs actually-read population". Static classification was tried first and was not
good enough (a recursive `walk(dir)` hides its seed root), so the population was
**measured** instead: every one of the 139 Silent families was run under an fs-tracing
preload that records the repo-relative path of every `readFileSync` / `readdirSync` /
`git ls-files` the gate makes, and the trace was compared against the literals
`extractWatchHints` reads out of that family's own sources.

Definition used, stated so the number is checkable: *content reads* only
(`readFileSync`/`readFile`/`openSync`/`createReadStream`) — `statSync`/`existsSync` probes
are excluded — of tracked files, minus the 5-path footprint `pnpm` itself reads.

| bucket | families |
|---|---|
| read 20+ tracked files under `packages/` or `examples/` that **no declared literal covers** | **49** |
| read 20+ undeclared tracked files anywhere | 53 |
| read 1..19 undeclared files | 83 |
| declaration covers every file read, or nothing tracked was read | 3 |
| (of the 139, exited non-zero — trace is partial, so these UNDER-count) | 22 |

⭐ **So this card is one member of a class, not a one-gate defect.** The top of the list,
`undeclared reads` after `declared literals`:

| family | declared | undeclared reads |
|---|---|---|
| `pnpm check:nul-bytes` | 2 | 7815 |
| `node scripts/check-closing-keyword-parity.mjs` | 6 | 7811 |
| `node scripts/check-self-test-workflow-commands.mjs` | 7 | 6360 |
| `node scripts/check-position-name-fold-loaders.mjs` | 7 | 6251 |
| `pnpm check:refd-timer-probe` | 5 | 5661 |
| `node scripts/check-comment-mask-corpus.mjs` | 1 | 5661 |
| `pnpm check:vendor-version-stamps` | 2 | 5660 |
| `pnpm check:skill-identifier-liveness` | 17 | 5495 |
| `pnpm check:parse-guard` | 2 | 5449 |
| `pnpm check:engine-double-contract` | 1 | 5410 |
| **`node scripts/check-system-context-census.mjs`** | **29** | **5387** |
| `pnpm check:error-code-casing` | 23 | 5161 |
| `node scripts/check-tenant-audit-census.mjs` | 24 | 4177 |

⚠️ What the number is NOT: reads are an **upper bound** on the verdict-bearing population.
A gate that opens every `package.json` to build a workspace list reads far more than can
red it. Four were verified by reading the source — `check:engine-double-contract`
(`SCAN_ROOTS = ['packages', 'examples']`, one declared literal),
`check:error-code-casing` (`SCAN_ROOTS = ['packages']`), `check:route-envelope`
(`walk(join(ROOT, 'packages'))`), `check:error-status-conformance` (`walk(SCAN_ROOT)`) —
and all four are the same shape as this card. ⛔ The remaining members are NOT asserted to
each want this repair; three of the largest provably cannot take it (see below).

**Already-worked subsets, so nothing here is re-filed:** #13519 / PR #14188 repaired four
gates by declaring what they read; #14189 carries the three whole-tree gates
(`check:nul-bytes`, `check-comment-mask-corpus`, `check:refd-timer-probe`) for which a
truthful declaration is "every file" and is therefore refused by the derivation's own
"22 leads is the same as none" rule. The residue between those seven and the 49 measured
here is filed as a new finding (linked from this PR's card comment) — ⛔ not fixed here,
and its derivation-layer half queues behind #14013, which holds
`scripts/pm/dispatch-gates.mjs` right now.

## Deliverable 2 — the family-bloat cost of the wide declaration, MEASURED FIRST

The services seat's fence: ⛔ do not adopt the wide declaration before measuring what it
costs an ordinary diff. Families derived per probe path, before -> after, at `a39b02a6b`:

| probe path | before | after |
|---|---|---|
| `packages/lint/src/authoring-rules.ts` | 19 | 20 |
| `packages/plugins/plugin-auth/src/auth-plugin.ts` | 22 | 23 |
| `packages/metadata-protocol/src/protocol.ts` | 21 | 22 |
| `packages/spec/src/data/object.zod.ts` | 42 | 42 (already named — it is a declared literal) |
| `examples/app-crm/package.json` | 17 | 18 |
| `content/docs/permissions/access-matrix.mdx` | 30 | 30 |
| `scripts/check-nul-bytes.mjs` | 14 | 14 |
| `.github/workflows/lint.yml` | 23 | 23 |

⇒ **+1 family, and only on cards under the two declared subtrees.** Nothing outside them
moves. The gate it adds runs in ~3s and CI runs it on every PR regardless, so the local
cost is one command against the CI lap it replaces. That is the measurement the services
seat asked for, and it is what carries the decision below.

## The declaration shipped: WIDE

`ROOT_DIR_WATCH_HINTS = ['packages/**', 'examples/**']`, the idiom
`check-tenant-audit-census.mjs:146` already carries and `check-watch-hint-literal` already
gates. ⛔ No second pattern invented.

Narrow (the 20 packages / 45 files that carry a read site today) was considered and
refused on the gate's own terms: a roster of the files that carry a read site TODAY can
never name the file that grows one TOMORROW, and a NEW read site is exactly what check B
— the mandatory POPULATION half — exists to catch. A narrow declaration derives green for
the one case that most needs the lead, so it re-introduces this defect wearing the shape
of a fix. The services seat leaned the same way; the measurement above is what made it a
decision rather than a preference.

## What holds the declaration honest

`isystem-census.mjs` now names its corpus roots once (`CORPUS_ROOTS`), `collectCorpus`
walks that constant, and the gate's `--self-test` derives **both directions** from it:
every walked root is declared, and no declared root is unwalked. A corpus root added or
dropped reds here instead of silently outrunning the declaration.

## Reverse verification (both mutations on the committed tree, both legs restored)

Predicted direction: RED, plus the derivation dropping the gate.

```
MUTATION A  the computed spelling  ROOT_DIR_WATCH_HINTS = CORPUS_ROOTS.map(...)
  on-disk proof: literal line 1 -> 0, computed line present, blob da3189a39 != HEAD 804912155
  self-test                      EXIT 1  "declared exactly once, as an array of quoted literals"
  check-watch-hint-literal       EXIT 1  "the declaration is COMPUTED, not a literal array"
  derivation for packages/lint/src/authoring-rules.ts  20 -> 19, census named: NO
MUTATION B  drop one walked root  ROOT_DIR_WATCH_HINTS = ['packages/**']
  on-disk proof: new line present, old line absent, blob c44b2c2b4 != HEAD
  self-test                      EXIT 1  "every root the census walks is declared"
restore (git checkout HEAD -- path, absolute, trap-guarded): git diff HEAD EMPTY and
  hash-object == HEAD blob 804912155 after BOTH legs; post-restore self-test EXIT 0
```

Mutation A is the load-bearing one: identical runtime value, every runtime assertion still
green, and **zero hints extracted** — the measured proof that the literal spelling is what
carries this fix.

## Checks run — union at `03edd9ce5` (the final commit of this branch)

Derived for the real changeset with `node scripts/pm/dispatch-gates.mjs` (no paths — the
script takes the change set off the merge base itself): 16 families, 14 by path + 2 by
change kind.

```
check:agent-test-spelling            EXIT 0
check:bash32-floor                   EXIT 0
check:cli-command-ids                EXIT 0
check:cross-package-test-inputs      EXIT 0
check:entry-guard                    EXIT 0
check:parse-guard                    EXIT 0
check:pnpm-filter-targets            EXIT 0
check:ratchet-remedy-authority       EXIT 0   (named in the dispatch)
check:watch-hint-literal             EXIT 0   43 declarations, ROOT_DIR_WATCH_HINTS 29
check:declared-population-live       EXIT 0   156 of 200 families declare a live population
check:nul-bytes                      EXIT 0   7812 files scanned
check-ci-filter-parity.mjs           EXIT 0
check-cross-package-test-inputs.mjs  EXIT 0
check-shard-attestation.mjs          EXIT 0
check-system-context-census.mjs      EXIT 0   + --self-test EXIT 0 (all cases, 6 new)
check-tenant-audit-census.mjs        EXIT 0   (cites this file at :77-84; those lines did not move)
bare-root-worklist.mjs --self-test   EXIT 0   none stale, none missing, none contradicted
check-test-completeness.mjs          NOT MEASURED — "PREREQUISITE NOT MET", exit 3: it grades a
                                     saved turbo test log and no local log exists. Not a red.
check:pm-dispatch-gates              EXIT 0   "dispatch-gates self-test: 1179 cases pass."
```

⚠️ `check:pm-dispatch-gates` needed ~690s on this shared box (it builds temp git repos and
spawns child CLIs), which is past the container's ~10-minute foreground ceiling: two
foreground attempts were killed at 500s and at 520s under the shared verify lock, both with
no output at all. It was then run to completion and its exit code collected inside the same
turn. Recording that, because "killed at the ceiling" and "red" are not the same reading and
the first two attempts would have looked identical to a hang.

Exit codes were captured before any pipe (`cmd > file 2>&1; EXIT=$?`), and each line above
quotes the gate's own verdict line rather than a bare `$?`.

## Changeset

`skip-changeset`: the diff is two CI-internal scripts under `scripts/`, publishes nothing
from any package, and releases nothing — the textbook case `lint.yml` names in its own
changeset-family comment. The label is applied on this PR.

_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_


---
_Generated by [Claude Code](https://claude.ai/code)_