### PR TITLE
docs(releases): qualify the #4366 svc:flow audit-label entry in v17 and link the #5494 refinement (#14039)

### DIFF
--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -2070,7 +2070,12 @@ rc.1, and administrators should know what changed:
   stalling (objectui#2955); a reassign writes structured `reassign_from` /
   `reassign_to` parties that timelines render without free-text archaeology
   (#4365); and a `runAs: 'system'` flow's writes are audited as
-  `svc:flow:<flowName>` instead of "Unknown user" (#4366).
+  `svc:flow:<flowName>` instead of "Unknown user" (#4366). That label is a
+  fallback, not a replacement for the operator — it stands in only for a run
+  that resolves no user at all (a schedule, or a system flow fired by a write
+  that itself carried no user). Where the trigger does resolve a user, #5494
+  later on this page carries that user through unchanged, so the audit row
+  still names the human.
 - **Run summaries learn honesty about side effects (#4395, #4396).**
   `connector_action` and mutating `http` nodes report `unmeasuredEffect` (the
   platform cannot know whether `crm.push_opportunity` writes), an


### PR DESCRIPTION
Fixes #14039

## What this is

A **dedicated docs-only PR**. `content/docs/releases/` is fenced by `CLAUDE.md` and by the
AGENTS.md Documentation Guardrails table ("Never edit in a code PR"), and both name the same
exit: *"Factual error on a releases page → dedicated docs-only PR or an issue, never a rider on
code changes."* This is that exit. The diff carries **no code**: one file, six inserted lines of
prose.

## The problem

`content/docs/releases/v17.mdx` states the #4366 audit-label behaviour unqualified:

> and a `runAs: 'system'` flow's writes are audited as `svc:flow:FLOWNAME` instead of
> "Unknown user" (#4366).

About 790 lines later the same page carries the #5494 entry, which refines that behaviour —
elevation does not cost a run its operator. Read in page order, the later entry supersedes the
earlier one, and nothing connected them.

## The fix — a qualifier and a pointer, not a rewrite

Per the triage ruling on the card, this is **option 1**: annotate, do not rewrite. The #4366
sentence is preserved **exactly as shipped** — this PR does not restate the historical entry as
though #5494 had already been true when #4366 landed, which would falsify what #4366 actually
shipped. Two sentences are appended: one qualifying the label as a fallback, one pointing at the
#5494 entry later on the page.

```diff
   (#4365); and a `runAs: 'system'` flow's writes are audited as
-  `svc:flow:FLOWNAME` instead of "Unknown user" (#4366).
+  `svc:flow:FLOWNAME` instead of "Unknown user" (#4366). That label is a
+  fallback, not a replacement for the operator — it stands in only for a run
+  that resolves no user at all (a schedule, or a system flow fired by a write
+  that itself carried no user). Where the trigger does resolve a user, #5494
+  later on this page carries that user through unchanged, so the audit row
+  still names the human.
```

(The angle-bracket placeholder in the real file is spelled `FLOWNAME` here only to survive body
sanitisation; the file itself is unchanged in that respect.)

## Why this wording

The semantics were read from the implementation, not inferred:
`packages/services/service-automation/src/runtime-identity.ts` — the `#5494 — elevation is not
anonymity` block — carries the triggering user through whenever the trigger resolved one, and a
schedule-shaped trigger resolves none.

The wording deliberately mirrors the **`.d.ts` face of the same false belief**, #14011, which
landed via PR #14035 and whose prose lives on
`packages/spec/src/contracts/automation-service.ts`: *"The label is a FALLBACK, not a
replacement"*, and *"what a genuinely USER-LESS run falls back to — a schedule, or a
`runAs:'system'` flow fired by a write that itself carried no user"*. The ruling asked the two to
name each other so the two surfaces do not drift into separate phrasings; this PR is the release-
notes half of that pair. No source file is touched here.

## Scope

Exactly one file: `content/docs/releases/v17.mdx`.

Deliberately **not** touched, per the ruling and the dispatch:

- `content/docs/releases/v15.mdx:863` — the card's own "not a defect" verdict was re-confirmed on
  review and stands.
- `packages/services/service-automation/src/runtime-identity.ts` and
  `packages/spec/src/contracts/automation-service.ts` — read for semantics only.
- The bare shorthand index later in v17 (`#4365/#4366 (approval reassign + audit attribution)`)
  makes no substantive claim about the label and needs no qualifier.

## Release-process fork clause — did not fire

The dispatch instructed a stop-and-report if any release-process rule forbids cross-links or
qualifiers in release notes. None exists. The opposite is documented:
`docs/releases-maintenance.md` §3 defines this layer as *"The curated, developer-facing 'big
picture', written for third parties"* — a curated narrative, not a mechanical per-change ledger.
Intra-page pointers are established precedent on these pages (v13:69, v16:237, v17:682, v17:2311,
v17:2394 all use "see below"). No stop was warranted.

## No changeset

Docs-only; nothing is published from any package. Requesting the `skip-changeset` label, which
exempts the `changeset-check` job wholesale.

## Verification — head `5c6fb906b`

Gate family derived by `node scripts/pm/dispatch-gates.mjs`, letting the script compute the
change set itself, re-derived after merging `origin/main` and re-run in full on the final head.

`✓ dispatch-gates --ran: 32 derived famil(ies) accounted for — 31 run, 1 NOT-MEASURED.`

| Result | Count | Detail |
|:---|:---|:---|
| RAN-PASS | 31 | every derived family, exit 0 captured before any pipe |
| NOT-MEASURED | 1 | `node scripts/check-test-completeness.mjs` — exit 3, PREREQUISITE NOT MET |
| UNRUN | 0 | — |

The one NOT-MEASURED family is structurally unmeasurable locally: the derived family names that
script with no argument, it needs a saved `turbo run test` log it cannot itself produce, and its
own output prescribes recording it as NOT MEASURED rather than as a pass or a red. `check:pm-dispatch-gates`
has no path overlap with this diff and is declared UNRUN.

Four gates first returned a build-prerequisite refusal (three as exit 3, `check:skill-examples` as
exit 1 with a "package is not built" verdict line — a refusal, not a finding). All four were
re-run to a real green after building `spec`, `lint`, `formula`, `client-react` and `client`;
`lint` was rebuilt again after the `origin/main` merge moved `packages/lint/src`.

**Declared narrowing — repo-wide `pnpm lint`.** Not run locally; CI owns it. This is a measurement
rather than a skip: the population was read from **eslint's own configuration**, not guessed —
`isPathIgnored('content/docs/releases/v17.mdx')` returns `true`, so the edited file is outside
eslint's population entirely and no eslint verdict can move. This diff also touches no eslint
config, so no untouched file's judgement changes either.

A control-character scan over the edited file returned zero matches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_