### PR TITLE
skills(upgrade): optimization flight — the stale pinned registry snapshot cut, the rule stated once, --yes and the --stored exit-code contract taught (net −1,134 tokens)

### DIFF
--- a/content/docs/ai/skills-reference.mdx
+++ b/content/docs/ai/skills-reference.mdx
@@ -205,7 +205,7 @@ Upgrade an ObjectStack metadata project across a protocol major — run the dete
 
 Use when a project is on an older protocol major and must move to the current one, when `@objectstack/spec` was bumped across a major and metadata or code stopped parsing, when a parse or `tsc` error quotes a `[REMOVED]` prescription, or when asked to "upgrade to v17" / "升级到 v17" / "一键升级元数据项目".
 
-Do not use to author new metadata (the domain skills cover that), to design a retirement in the ObjectStack platform repo itself (that is the platform's own internal playbook), or to hand-write a rewrite the conversion chain already applies — running the chain is always the first step, never a fallback.
+Do not use to author new metadata (the domain skills cover that), or to reconcile physical database drift (that is objectstack-platform's `os migrate plan` / `os migrate apply`).
 
 **Tags:** `upgrade`, `migration`, `protocol`, `major`, `retired-keys`, `tombstone`, `conversions`, `validate`, `report`
 

--- a/skills/objectstack-upgrade/SKILL.md
+++ b/skills/objectstack-upgrade/SKILL.md
@@ -248,12 +248,26 @@ inside the installed package. **Measured** against the published
 | **The error itself** | Your parse / `tsc` output | The same prescription string, delivered at the moment you hit it. |
 
 ```bash
-# every tombstone prescription the installed spec carries, deduped
+# every tombstone prescription the installed spec carries, deduped (`| wc -l` sizes it)
 grep -rho '\[REMOVED\][^"]*' node_modules/@objectstack/spec/json-schema/ | sort -u
+
+# protocol version, support floor, and this crossing's conversion / semantic counts
+node -e "
+  const p = require.resolve('@objectstack/spec/package.json');
+  const j = require(p.replace('package.json','spec-changes.json'));
+  const to = parseInt(j.protocolVersion, 10);
+  const e = j.perMajor.find(x => x.to === to);
+  console.log(j.protocolVersion, 'floor', j.supportFloor, '| →', to + ':',
+              e.converted.length, 'converted,', e.migrated.length, 'semantic');
+"
 
 # the FROM → TO table for one retired key
 grep -n -B4 -A20 'transform' node_modules/@objectstack/spec/CHANGELOG.md | less
 ```
+
+⛔ **Never carry a remembered count or a pinned table into the report.** Every
+number here is a reading of *this* install; measure it at the start of the
+upgrade and again in the report.
 
 > **Not reachable from a consumer project**, so do not send anyone there: the
 > conversion and migration registries (`src/conversions/registry.ts`,
@@ -548,71 +562,6 @@ you must say which you expect:
 Record which one you actually got. A check whose expected direction you did not
 state in advance proves nothing, and "it passed" is a different fact in each of
 the three cases.
-
----
-
-## The v17 prescription set, as of `17.0.0-rc.5`
-
-This section is a **pinned reading**, not a live list. It was measured from the
-spec sources at the `17.0.0-rc.5` publish and is deliberately bounded so that
-entries registered after that publish are a visible *delta* rather than a silent
-contradiction.
-
-| Reading | Value at `17.0.0-rc.5` |
-|:--|:--|
-| `@objectstack/spec` version | `17.0.0-rc.5` (protocol `17.0.0`) |
-| Chain support floor | protocol 10 |
-| D2 conversions for major 17 | **45** |
-| D3 semantic entries for major 17 | **29** |
-| `retiredKey()` tombstones in shipped `*.zod.ts` | **113**, across 32 files |
-| Distinct `[REMOVED]` prescriptions in shipped `json-schema/` | **96** |
-
-`RETIRED_KEYS_BY_MAJOR[17]` — every authorable key formally tombstoned under the
-exact-key registry at this publish (3 entries, one retirement: the property is
-declared once and inherited by two extending schemas, so it is registered three
-times):
-
-- `data/ExternalFieldMapping:transform`
-- `integration/ConnectorFieldMapping:transform`
-- `shared/FieldMapping:transform`
-
-`RETIRED_DEFS_BY_MAJOR[17]` — every whole schema def unpublished at this publish
-(1 entry):
-
-- `shared/FieldMappingTransform`
-
-> **Why these two tables are short and the counts above are not.** They record
-> retirements registered under the exact-key gates that created them, which are
-> newer than most of protocol 17's work; they are explicitly *not* a backfill of
-> every retirement ever. The 45 conversions and 113 tombstones are the real size
-> of the v17 surface. Use the tables to answer "was this retirement formally
-> registered", and the conversions/tombstones to answer "what do I have to
-> change" — the second question is the upgrade's question.
-
-### How this table is refreshed
-
-**Never hand-edit the numbers above from memory.** Re-measure against whatever
-spec the project has installed — one command per row:
-
-```bash
-# protocol version, support floor, and the per-major conversion / semantic counts
-node -e "
-  const p = require.resolve('@objectstack/spec/package.json');
-  const j = require(p.replace('package.json','spec-changes.json'));
-  const e = j.perMajor.find(x => x.to === 17);
-  console.log(j.protocolVersion, 'floor', j.supportFloor, '| 16→17:',
-              e.converted.length, 'converted,', e.migrated.length, 'semantic');
-"
-
-# tombstone prescriptions actually present in this install
-grep -rho '\[REMOVED\][^"]*' node_modules/@objectstack/spec/json-schema/ | sort -u | wc -l
-```
-
-If a reading disagrees with the table, **the install wins** — the table is a
-snapshot of one publish, and post-`rc.5` registrations are expected to add
-entries. Record the delta in the upgrade report rather than editing this
-section's pinned numbers; the pin is what makes a later disagreement legible
-instead of invisible.
 
 ---
 

--- a/skills/objectstack-upgrade/SKILL.md
+++ b/skills/objectstack-upgrade/SKILL.md
@@ -30,21 +30,7 @@ metadata:
 
 # Upgrading an ObjectStack metadata project across a protocol major
 
-This skill turns one session into an **upgrade agent** working on somebody
-else's metadata project. It has one job: take a project authored against
-protocol `N` and leave it authored against the current major, with the change
-**proved** rather than asserted.
-
 > **preflight → mechanical chain → semantic residue → acceptance report**
-
-The upgrade is deliberately split into three layers, and the split is the whole
-design. Two of them are not yours.
-
-| Layer | Who owns it | What it is |
-|:--|:--|:--|
-| **1 · Mechanical** | The CLI. **You invoke it, you never re-implement it.** | `os migrate meta` replays the ADR-0087 conversion chain: deterministic, idempotent, fixture-tested, per-hop attributable. |
-| **2 · Semantic residue** | **You, with the project's owner.** | Everything a conversion cannot express: intent choices, custom code calling retired APIs, prose that still teaches the old shape. |
-| **3 · Acceptance** | The gates. | Typed + parse-gated metadata, a green `validate`, and a report a human can read. |
 
 ## ⛔ The boundary — read this before the first command
 
@@ -68,6 +54,9 @@ important paragraph in this skill.
 plus the report is the machine criterion. Absent either, the status is
 *in progress*, whatever the diff looks like.
 
+**One `conversionId` per commit**, where the project's review culture allows it.
+The id is the commit's subject line and its justification.
+
 ---
 
 ## Quickstart
@@ -85,7 +74,6 @@ os migrate meta --from 16 --out .upgrade/migrated.stack.json
 
 # 2 · semantic residue — harvest the prescriptions, then work each item
 node -e "console.log(require('fs').readFileSync(require.resolve('@objectstack/spec/package.json').replace('package.json','spec-changes.json'),'utf8'))" > .upgrade/spec-changes.json
-grep -rho '\[REMOVED\][^"]*' node_modules/@objectstack/spec/json-schema/ | sort -u > .upgrade/tombstones.txt
 
 # 3 · acceptance — all four, not three
 os validate                      # green (compare against validate-before.txt)
@@ -127,7 +115,7 @@ mkdir -p .upgrade         # every artifact this skill produces lands here
 ```
 
 The `.upgrade/` directory is the deliverable's workspace: the machine outputs
-(`migrate.json`, `migrated.stack.json`, `spec-changes.json`, `tombstones.txt`)
+(`migrate.json`, `migrated.stack.json`, `spec-changes.json`, `retired-names.txt`)
 and the human output (`REPORT.md`). Keeping them in the repo for the review, and
 deleting them on merge, is the usual arrangement — decide it with the owner.
 
@@ -166,21 +154,15 @@ it prints:
 loaded stack *in memory* and reports the diff. The only file it writes is
 `--out`, a JSON snapshot.
 
-This is deliberate: rewriting a TypeScript config through an AST is lossy — it
-drops comments, reorders keys, and cannot see values that come from imports or
-expressions. So the mechanical layer gives you a **provably valid target** and
-the **attributed list of edits**, and porting those edits into the project's own
-sources is yours. Work from the printed list, one `conversionId` at a time; use
-`--out` as the oracle you diff against, never as the file you ship.
+Porting the printed edits into the project's own sources is yours. Work from
+that list, one `conversionId` at a time; use `--out` as the oracle you diff
+against, never as the file you ship.
 
 ```bash
 os migrate meta --from 16 --out .upgrade/migrated.stack.json
 # then, after porting the edits into the real sources:
 os migrate meta --from 17 --out .upgrade/recheck.json   # should apply 0 changes
 ```
-
-That last line is the cheapest possible proof that the port is complete: replay
-the chain from the *target* major and it must find nothing to do.
 
 ### Stored rows: rehydration replays the same conversions
 
@@ -191,13 +173,9 @@ chain over a single item **including entries retired from the load path**. A row
 written under protocol 16 therefore rehydrates in its protocol-17 shape without
 anybody editing it.
 
-What that does and does not mean:
-
-- **You do not hand-edit `sys_metadata`.** Ever. A row at rest has no author to
-  ask, so the replay is unconditional and complete by design.
-- **The rows on disk stay in their old shape** until something rewrites them.
-  Rehydration is a read-time projection.
-- To make it durable, run the stored pass — read-only by default:
+Rehydration is a read-time projection: the rows on disk keep their old shape,
+and you never hand-edit `sys_metadata`. To make it durable, run the stored pass
+— read-only by default:
 
   ```bash
   os migrate meta --stored                     # preview, writes nothing
@@ -211,20 +189,14 @@ What that does and does not mean:
 
 ### Data migrations are not metadata migrations
 
-When the chain crosses into a major carrying per-deployment data gates, the
-command ends by naming them — for the 16 → 17 crossing, and only when the
-project's own metadata declares the field classes each gate is about:
+When the chain crosses into a major carrying per-deployment data gates, the run
+ends by naming each one, what staying un-run costs, and that `--apply` is the
+only writing mode. Read that output rather than re-deriving it. What it cannot
+tell you is whether they have *run*: that happens against each deployment's own
+database, and nothing in the metadata upgrade observes it.
 
-| Command | What staying un-run costs |
-|:--|:--|
-| `os migrate files-to-references` | Media values only warn instead of being enforced, and released files are never collected. |
-| `os migrate value-shapes` | Stored reference and structured-JSON values are not checked against their field contracts; a malformed value only warns. |
-
-Both are dry-run by default; `--apply` is the only writing mode. They run
-**against each deployment's database**, once per deployment, and nothing in the
-metadata upgrade can run them or tell whether they have run. Not running them is
-safe — enforcement simply stays off. Carry them into the report as *pending*, by
-name, so a gate nobody was told about is not served by nobody.
+⛔ **Carry every gate the run printed into the report as `pending`, by name.** A
+gate nobody was told about is served by nobody.
 
 ---
 
@@ -516,52 +488,31 @@ _N sites, M conversions. Ported into sources from `os migrate meta --out`._
 - <retired surface the project never used>  — no occurrences.
 ```
 
-Section 5 earns its place: "we looked and it was not there" is a finding, and
-without it the next reader cannot tell a surface that was checked from one that
-was missed.
-
 <a id="reverse-check"></a>
 
 ### 3.5 Prove the gate is real, do not assume it
 
-Before you report the parse gate as acceptance evidence, make it fire once.
-Take a value the chain *would* have converted, put it back after migrating, and
-parse:
+Make the parse gate fire once before you report it as evidence: take a value the
+chain *would* have converted, put it back after migrating, and parse it.
 
 ```bash
 # a stack that still carries a retired key, fed straight to the schema
 os validate .upgrade/residue-probe.config.mjs
 ```
 
-Predict the direction **before** you run it. There are three real outcomes and
-you must say which you expect:
+Write the probe as a **plain data literal** — ⛔ no `define*` call. `os validate`
+loads the config without authored-source mode, and every `define*` helper is a
+`Schema.parse()`, so a probe written the way a real config is written throws
+*inside the load* and never reaches the gate you are trying to prove.
 
-1. **Rejected with the prescription** — a tombstoned key. This is what a
-   tombstone looks like when it works:
+Predict the outcome **before** you run it, then record which one you actually
+got — "it passed" is a different fact in every row:
 
-   ```
-   ✗ connectors.0.fieldMappings.0.transform
-     invalid_type: `FieldMapping.transform` … was removed in @objectstack/spec
-     17.0.0 (ADR-0049) … Delete the key. The transform pipeline that IS
-     enforced is the import mapping's … Run `os migrate meta --from 16` to
-     list the mechanical edits for existing sources; apply them by hand.
-     expected: never
-   ```
-
-   Note what the error is not: not "unrecognized key", not a deprecation label.
-   The fix-it text *is* the error.
-
-2. **Accepted, and the chain rewrites it** — a conversion with a live load-path
-   acceptance window. Your evidence for that key is the chain's diff, not the
-   parse gate.
-
-3. **Accepted, and the chain still rewrites it** — a migration-chain-only
-   conversion (§3.3). `validate` cannot see this class at all; only the replay
-   can.
-
-Record which one you actually got. A check whose expected direction you did not
-state in advance proves nothing, and "it passed" is a different fact in each of
-the three cases.
+| Outcome | What it means | Your acceptance evidence |
+|:--|:--|:--|
+| Rejected, error carries the fix-it text | A tombstoned key. Not "unrecognized key", not a deprecation label — the prescription *is* the error. | The refusal itself, quoted. |
+| Accepted, and the chain rewrites it | A conversion with a live load-path acceptance window. | The chain's diff — not the parse gate. |
+| Accepted, and `validate` stays green | A migration-chain-only conversion ([3.3](#33-validate)). | Only the replay from the target major sees this class. |
 
 ---
 
@@ -615,28 +566,9 @@ export const SupportBot = defineAgent({
 | `--apply` refused / stored-only flag rejected | `--apply`, `--yes`, `--force`, `--type`, `--database-url` mean something only with `--stored`. | Add `--stored`, or drop the flag; the authored-source chain has nothing to write to. |
 | `MigrationFloorError` | `--from` is older than the chain's support floor. | Upgrade to the floor by an older route first; the floor is a release-policy boundary, not an oversight. |
 
-## Guardrails (binding)
-
-1. **Run the chain first, always.** It is the only source of an attributed,
-   schema-proved diff.
-2. **One conversion id per commit**, where the project's review culture allows
-   it. The `conversionId` is the commit's subject line and its justification.
-3. **No tolerant reads, ever** — not in the metadata, not in the project's code.
-   A retirement that gets re-admitted at the consumer is a defect that moved
-   into a repo with no gate over it.
-4. **Ask about intent, decide about mechanics.** The split in
-   [2.4](#decide-alone-or-ask) is the contract with the project's owner.
-5. **The report is a deliverable, not a summary.** No report, not done.
-6. **Never leave a pending per-deployment data migration unnamed.** A gate
-   nobody was told about is served by nobody.
-
 ## Cross-skill routing
 
 - Authoring the corrected metadata — load the domain skill for the shape you are
-  fixing (**data**, **ui**, **automation**, **ai**, **api**, **i18n**).
-- Any CEL predicate you rewrite while resolving a residue item — load
-  **formula**.
+  fixing (**data**, **ui**, **automation**, **ai**, **api**, **i18n**); each one
+  routes on to **formula** for any CEL you rewrite.
 - Runtime, plugin, and CLI questions the upgrade turns up — load **platform**.
-- This skill covers the **consumption** side of a retirement. Designing one
-  inside the ObjectStack platform repo is a different job with its own internal
-  playbook, and it is not this one.

--- a/skills/objectstack-upgrade/SKILL.md
+++ b/skills/objectstack-upgrade/SKILL.md
@@ -10,17 +10,10 @@ description: >
   across a major and metadata or code stopped parsing, when a parse or `tsc`
   error quotes a `[REMOVED]` prescription, or when asked to "upgrade to v17" /
   "升级到 v17" / "一键升级元数据项目". Do not use to author new metadata (the
-  domain skills cover that), to design a retirement in the ObjectStack platform
-  repo itself (that is the platform's own internal playbook), or to hand-write
-  a rewrite the conversion chain already applies — running the chain is always
-  the first step, never a fallback.
+  domain skills cover that), or to reconcile physical database drift (that is
+  objectstack-platform's `os migrate plan` / `os migrate apply`).
 license: Apache-2.0
-compatibility: >
-  Needs `@objectstack/spec` and `@objectstack/cli` at the TARGET major
-  (`os migrate meta` replays the chain from `MIGRATION_SUPPORT_FLOOR`, protocol
-  10 at the time of writing). No network access required — every instruction
-  source this skill harvests ships inside the installed `@objectstack/spec`
-  package.
+compatibility: Requires `@objectstack/spec` and `@objectstack/cli` at the TARGET major; the chain replays from the spec's `MIGRATION_SUPPORT_FLOOR`. No network access required.
 metadata:
   author: objectstack-ai
   version: "1.0"
@@ -93,8 +86,12 @@ Everything below is the long form of those four steps.
 `--from` is the protocol major the metadata was **authored** against, not the
 one installed. Three sources, in order of authority:
 
-1. **`manifest.engines.protocol`** in the stack config (`'16.0.0'` → `--from
-   16`). The declared answer, checked by the boot handshake.
+1. **`manifest.engines.protocol`** in the stack config — the declared answer,
+   checked by the boot handshake. It is a **range**, not a version: every
+   scaffold and example writes the caret form (`engines: { protocol: '^17' }`),
+   and an exact `'16.0.0'` is only a range of one. Take the major it *targets* —
+   the floor: `'^17'` → `--from 17`, `'>=15 <18'` → `--from 15`, never the
+   upper bound.
 2. **The last `@objectstack/spec` major the project ever installed** — read the
    lockfile history (`git log -p pnpm-lock.yaml | grep -m5 '@objectstack/spec'`)
    when the manifest is absent or stale.
@@ -131,6 +128,7 @@ os migrate meta --from 16 --step                # per-hop checkpoint (bisect a f
 os migrate meta --from 16 --to 17               # stop at a specific major
 os migrate meta --from 16 --json                # machine-readable result
 os migrate meta --from 16 --out migrated.json   # write the canonicalized stack
+os migrate meta --from 16 apps/crm/objectstack.config.ts   # pick the stack explicitly
 ```
 
 It loads the stack config, normalizes it **without** applying the load-time
@@ -180,8 +178,12 @@ and you never hand-edit `sys_metadata`. To make it durable, run the stored pass
   ```bash
   os migrate meta --stored                     # preview, writes nothing
   os migrate meta --stored --type view --type object   # narrow the pass
-  os migrate meta --stored --apply             # rewrite the rows (prompts)
+  os migrate meta --stored --apply --yes       # rewrite the rows
   ```
+
+  ⛔ **`--yes` is not optional for you.** Without it `--apply` asks for
+  confirmation, and in any non-TTY — every agent session — it refuses instead,
+  exiting 1 with `confirmation_required`.
 
   `--stored` takes no `--from`: a stored row carries its own history, so the
   pass replays the whole chain. The authored-source flags and the stored-only
@@ -514,6 +516,20 @@ got — "it passed" is a different fact in every row:
 | Accepted, and the chain rewrites it | A conversion with a live load-path acceptance window. | The chain's diff — not the parse gate. |
 | Accepted, and `validate` stays green | A migration-chain-only conversion ([3.3](#33-validate)). | Only the replay from the target major sees this class. |
 
+### 3.6 Stored rows: assert them, do not believe them
+
+The four artifacts above cover the authored sources. For a **deployment**, the
+stored pass is itself the assertion — run it read-only and branch on the exit
+code:
+
+```bash
+os migrate meta --stored --json    # 0 = every row canonical, 1 = work left
+```
+
+That is what makes "this deployment is on protocol N" a CI check rather than a
+belief. Nothing gates on it having run; the read-time rehydration is still the
+guarantee.
+
 ---
 
 ## The v17-canonical shapes, compiled
@@ -565,6 +581,11 @@ export const SupportBot = defineAgent({
 | A retired key round-trips without error | The schema carrying it is not strict and the key is being stripped, or the key still has a live load-path window. | Determine which — the two need different acceptance evidence. See [the reverse check](#reverse-check). |
 | `--apply` refused / stored-only flag rejected | `--apply`, `--yes`, `--force`, `--type`, `--database-url` mean something only with `--stored`. | Add `--stored`, or drop the flag; the authored-source chain has nothing to write to. |
 | `MigrationFloorError` | `--from` is older than the chain's support floor. | Upgrade to the floor by an older route first; the floor is a release-policy boundary, not an oversight. |
+
+Scripting the run instead of reading it? Every `--json` failure above carries a
+stable `error` code to branch on — `stored_only_flag`, `missing_from_major`,
+`unsupported_from_major`, `confirmation_required`, `database_busy` — and the
+prose row is the same fact for a human.
 
 ## Cross-skill routing
 


### PR DESCRIPTION
Part of #14307

Skills catalog optimization program #14292, member card #14307 (maintainer mandate 2026-09-02: 「审核所有的 skills，进行全面的优化。」). Verdict **DIET**, implemented on one file.

Not `Fixes`: UPG-H-01 (the `evals/` package) is deferred to #14296 item 2, so #14307 stays open. #14296 is not addressed here.

**Governed face ⇒ this PR stays draft.** `needs:contract-review` is on both carriers: the `--stored` exit-code contract, the `--yes` non-TTY semantics, the `--json error` codes and the ranged `engines.protocol` reading are all CLI / manifest contract claims.

## Token delta

| File | before | after | ceiling | headroom after |
|:--|--:|--:|--:|--:|
| `skills/objectstack-upgrade/SKILL.md` | 8,333 | **7,199** | 8,333 | 1,134 |

**Net −1,134 tok on 8,333 = −13.6%** (693 lines → 597). Bundle total 176,225 → 175,091. No ceiling raise, no new file, no re-wrap-as-payment, ratchet script untouched.

The card's target was ≈ −1,808. **The −674 gap is itemised, not smoothed** — it is entirely the audit's per-finding Δtok estimates coming in optimistic on the rewrite-as-construct rows, plus three additions written longer than estimated because the measured contract needed more words than the audit budgeted. Measured per cluster:

| cluster | est. Δtok | measured Δtok | why it differs |
|:--|--:|--:|:--|
| D-01 + D-02 (incl. the 2.1 fold-in) | −734 | **−534** | the surviving re-measure command is a 9-line node block, not a one-liner |
| E-04 + E-05 | −245 | **−67** | the 3-row table still carries three outcomes and three evidence rules; the estimate assumed a much terser table |
| D-07 | −190 | **−238** | better than estimated |
| D-03 | −180 | **−108** | the surviving "carry each printed gate into the report" rule needed its own sentence |
| B-02 | −170 | **−167** | on estimate |
| C-01 | −70 | **−54** | the platform route is kept (see the A-01 follow-up below), so only 2 of 4 bullets went |
| D-04 + D-05 | −230 | **−106** | D-05's second half was already delivered inside the E-04 rewrite, so it could not be counted twice |
| D-06 + D-08 + B-03 | −163 | **−115** | D-06 became a one-sentence collapse rather than a straight deletion |
| E-02 + E-03 + F-03 | +50 | **+168** | E-03 needed the floor rule plus the never-read-the-upper-bound guard (see below) |
| F-01 + F-02 (and the E-03 tighten) | +90 | **+159** | F-01 landed as a titled 3.6 with a runnable command, not a bare list row |
| A-02 + G-01 | −100 | **−72** | G-01 must keep the phrase "at the TARGET major" verbatim (see below) |

## Per-item 落点 | before | after

| id | 落点 | before | after |
|:--|:--|:--|:--|
| **UPG-D-01** | the whole "v17 prescription set, as of 17.0.0-rc.5" section (65 lines) | six pinned readings, every one wrong against the installed 17.2.0 | deleted. The measurement survives, not the number: the `spec-changes.json` reading folded into the 2.1 source table, now deriving the target major from `protocolVersion` instead of hardcoding 17, plus a rule against carrying a remembered count into the report |
| **UPG-D-02** | "Why these two tables are short" | narrated the platform's own retirement-registration policy over two registry files this same skill declares unreachable from a consumer project | deleted with D-01 |
| **UPG-E-04** | 3.5 | one recipe, a re-quoted error block available verbatim from the install, and a 3-outcome prose list | a 3-row outcome → what it means → your acceptance evidence table |
| **UPG-E-05** | 3.5 probe | recipe illustrated as producing the schema-gate refusal | plus the rule that makes it true: write the probe as a plain data literal, no `define*` call |
| **UPG-D-03** | "Data migrations are not metadata migrations" | a 2-row cost table and a closing paragraph, both near-verbatim what the run prints | the one non-CLI decision: carry every printed gate into the report as `pending`, by name |
| **UPG-D-07** | the preamble + Layer table | "this skill turns one session into an upgrade agent", three-layers prose, 3-row Layer table | the pipeline line alone; the section headings already were the construct |
| **UPG-B-02** | "Guardrails (binding)" | 6 rules, 4 restating the boundary verbatim and #6 restating the data-gate rule | section deleted; the one non-duplicate (one `conversionId` per commit) moved into the boundary, #6 now lives where the gates are printed |
| **UPG-D-05** | the replay rule | stated 5 times | 3 (the 3.3 callout, the failure-modes row, the 3.5 table row that states the *evidence* rather than re-teaching) |
| **UPG-D-04** | the AST-is-lossy rationale | 3 sentences of rationale before the rule | the rule: `--out` is the oracle you diff against, never the file you ship |
| **UPG-D-06** | "What that does and does not mean" | 2 bullets restating the paragraph above them | one sentence |
| **UPG-D-08** | "Section 5 earns its place…" | a justification of a template row already in the template | deleted |
| **UPG-B-03** | the `[REMOVED]` grep | 4 copies | 2 (the 2.1 anchor and the name-only variant 2.6 needs). The `.upgrade/` workspace list, which named a file nothing writes any more, now names `retired-names.txt` |
| **UPG-C-01** | "Cross-skill routing" | 4 bullets, 3 of them owned by `skills/README.md` and by the domain skills' own frontmatter | 2 bullets. The README routing row is **deferred** with A-01 (see below) |
| **UPG-E-02** | the stored `--apply` line | `--stored --apply  # rewrite the rows (prompts)` — falsehood 4 | `--stored --apply --yes`, plus why: non-TTY refuses with `confirmation_required` |
| **UPG-E-03** | source (1) of the FROM major | only worked form was an exact `'16.0.0'` | the range rule (see the correction below) |
| **UPG-F-01** | 3 acceptance | absent | a 3.6: `--stored --json` exits 0 = every row canonical, 1 = work left |
| **UPG-F-02** | failure-modes table | two machine-readable failures named in prose only | the five stable `--json` `error` codes, as a list under the table (see the construct note below) |
| **UPG-F-03** | the flag block | positional config path never shown | one line; a monorepo with more than one stack could not follow the skill as written |
| **UPG-A-02** | `description` | 3 negative routes, 2 of them routing nowhere a customer can go | 2 real ones: author new metadata → domain skills; physical DB drift → objectstack-platform |
| **UPG-G-01** | `compatibility` | a 5-line folded block hedging a pinned constant | one line like the nine domain siblings |

## `premise_false`

**None.** Every finding's premise was re-verified against this branch's base (`a98b61b3`) and held. Two implementation divergences, both deliberate and both measured:

**1. UPG-E-03 — the audit's proposed clause is wrong; the delivered platform row is right.** The audit proposed writing "a range declares compatibility, not authorship — `'^17'` means *runs on* 17, so fall to source (2)". That contradicts what objectstack-platform's delivered flight teaches for the same manifest row (`origin/claude/issue-14299-skills-platform-optimization`, "Manifest Reference": "the metadata-protocol major the app is authored against"). The platform row is the correct one, measured three ways:

- `packages/cli/src/utils/protocol-version-gap.ts` names the field `declaredMajor` = "Major the app's declared compatibility range **targets**", and its header explicitly rejects a naive leading-integer re-parse as a third opinion.
- `packages/create-objectstack/src/template-consistency.test.ts:186` **mechanically requires** the caret form of every scaffold: "objectstack.config.ts stamps engines.protocol at the scaffolder's major (ADR-0087 D1)".
- `packages/metadata/src/plugin.ts:779` calls it the "authored engines.protocol **floor**".

So the shipped clause teaches the range's **floor** — `'^17'` → `--from 17`, `'>=15 <18'` → `--from 15`, never the upper bound. **This agrees with the manifest row objectstack-platform's delivered flight teaches.**

**2. UPG-F-02 — the codes ship as a list, not as a 4th table column.** Measured: the failure-modes table has 8 rows and only 2 map to a code, so a column would be 6 empty cells; and 2 of the 5 codes (`missing_from_major`, `database_busy`) have no row at all, so a column cannot carry them. A compact list under the table carries all five and costs less. The finding's decision — an agent scripting the run branches on the code, not the prose — is delivered in full.

## Re-measured counts (with their commands)

All re-measured on this branch's base, **not** copied from the audit (which measured at `a59f78d`; `packages/spec/src/migrations/registry.ts` has moved +78 lines since).

| reading | skill claimed | measured at `a98b61b3` |
|:--|:--|:--|
| D2 conversions, major 17 | 45 | **58** |
| D3 semantic entries, major 17 | 29 | **77** |
| `retiredKey(` sites in shipped `*.zod.ts` | 113, across 32 files | **179**, across **44** files |
| `RETIRED_KEYS_BY_MAJOR[17]` | "3 entries" | **29** |
| `RETIRED_DEFS_BY_MAJOR[17]` | "1 entry" | **53** |
| `MIGRATION_SUPPORT_FLOOR` | 10 | **10** (the one reading that held) |

```bash
node -e "const s=require('./packages/spec/spec-changes.json');const m=s.perMajor.find(x=>x.to===17);
  console.log(m.converted.length, m.migrated.length);"                      # 58 77
grep -rho "retiredKey(" packages/spec/src --include='*.zod.ts' | wc -l      # 179
grep -rlo "retiredKey(" packages/spec/src --include='*.zod.ts' | wc -l      # 44
npx tsx -e "import {RETIRED_KEYS_BY_MAJOR, RETIRED_DEFS_BY_MAJOR} from './packages/spec/src/migrations/registry.ts';
  console.log(RETIRED_KEYS_BY_MAJOR[17].length, RETIRED_DEFS_BY_MAJOR[17].length);"   # 29 53
```

Also measured: `data/ExternalFieldMapping:transform`, one of the three keys the skill listed, has been **removed** from the bucket. The deleted reconciliation rule anticipated only additions ("post-rc.5 registrations are expected to add entries"), so a reader reconciling that delta was pointed the wrong way. **After D-01 the skill carries no pinned snapshot at all** — only the two re-measure commands, so a reader measures instead of trusting a number.

## Two gate mechanisms this flight had to obey

- **`check-skill-compatibility-version.mjs` exempts this file, and the exemption is warranted by a regex over the live text** (`rationale: /at\s+the\s+TARGET\s+major/i`). A cross-major skill pinned to the current major would be actively wrong, so the G-01 one-liner keeps the phrase **"at the TARGET major" verbatim** — rewriting it away would have killed the exemption and turned the gate red. Gate confirms: "2 justified exemption(s), each with its stated reason still true of the file."
- **`check-skill-identifier-liveness` Leg 2 binds sections by heading.** Run before the first deletion: 8 registered exhaustive sections, **none of them in this file**, so the retired-key and tombstone tables were free to delete. Green after, still 8 / 0 gaps.

`G-01` also drops the "protocol 10 at the time of writing" hedge rather than restating the number: after D-01 the frontmatter was the last rottable copy of that constant, so the line now points at `MIGRATION_SUPPORT_FLOOR` instead of quoting it.

## Follow-up for objectstack-platform / skills/README.md (UPG-A-01, deferred)

Not done here — this flight edits one package. Recorded for whoever owns those files:

1. **`skills/objectstack-platform/SKILL.md` description** needs one negative route: *do not use for a protocol-major metadata upgrade — see objectstack-upgrade*. Platform's description today claims "operations (CLI commands, **migrations**, deployment…)" while its migration table lists only `os migrate plan` / `os migrate apply`; `os migrate meta`, `files-to-references` and `value-shapes` appear nowhere in it. A customer agent asked "run the migrations for the new spec" loads platform and gets physical-DB drift reconciliation. This PR fixed the **mirror** half inside upgrade's own description (A-02), so the hole is now one-sided rather than two-sided.
2. **`skills/README.md` "Cross-skill routing"** needs an upgrade-vs-platform row — the half of UPG-C-01 that could not land here (the deletion half did).

UPG-H-01 (an `evals/` package for this skill) stays deferred to #14296 item 2.

## Gates

Head sha **`ecdddf53`** — every reading below is from that commit, after the final commit, with exit codes captured before any pipe.

Named on the card:

| gate | verdict |
|:--|:--|
| `node scripts/check-skills-token-ratchet.mjs` | ✅ 7199 / 8333, headroom 1134 |
| `pnpm --filter @objectstack/spec check:skill-examples` | ✅ "265 prose examples type-check across 3 surface(s)" — after building `@objectstack/spec` + the `@objectstack/client-react` closure; it **refused** rather than false-greening until the build existed |
| `pnpm check:skill-compatibility` | ✅ 11 files reconciled, "2 justified exemption(s), each with its stated reason still true" |
| `pnpm check:skill-identifier-liveness` | ✅ Leg 1: 490 citations / 47 files; Leg 2: 8 sections, 0 gaps |
| `pnpm --filter @objectstack/spec check:skill-docs` | ✅ "Skill docs in sync" |

Re-derived family — `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, derived **after** regeneration, from the script's own merge-base changeset (2 paths, no hand-fed list): **36 commands. 35 green, 1 NOT MEASURED.**

The one non-green is `node scripts/check-test-completeness.mjs`, **exit 3 = PREREQUISITE NOT MET**, which the gate itself defines as not-a-finding: it grades a saved `turbo run test` log, CI tees one and passes the path, and there is no local log to hand it. Recorded as NOT MEASURED per the script's own instruction, not as a red.

`pnpm check:nul-bytes` ✅ (7,902 files, no raw control bytes).

## Why `skip-changeset`

Nothing is released by any package. Verified rather than assumed: neither changed path lies inside a publishable package — `skills/` and `content/` have no `package.json` of their own, and no publishable package's directory is a prefix of either path.

## Files

- `skills/objectstack-upgrade/SKILL.md` — the flight.
- `content/docs/ai/skills-reference.mdx` — **generator output only** (`pnpm --filter @objectstack/spec gen:skill-docs`), forced by `check:skill-docs`, which was red on this file and named the command. One line, the description change.

`skills/README.md` regenerated **byte-identical** — it does not carry the description prose — so it is not in this diff at all, which is tighter than the claim comment anticipated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_