### PR TITLE
docs(adr): ADR-0130 addendum — the permission matrix is outside the package boundary's payoff (#14487)

### DIFF
--- a/docs/adr/0130-release-artifact-as-co-ownership-boundary.md
+++ b/docs/adr/0130-release-artifact-as-co-ownership-boundary.md
@@ -3,6 +3,10 @@
 **Status**: Proposed (2026-09-01) — awaiting the maintainer's hand-merge, which is itself the
 acceptance act for a governed surface (Prime Directive #14). ⛔ Nothing below is settled until
 this record merges; the implementation cards are cut **from** the merged ADR, never ahead of it.
+**Scope bounded by the 2026-09-02 addendum**
+([#14487](https://github.com/objectstack-ai/objectstack/issues/14487)): the permission matrix
+§1.3(a) measures is **not** part of this boundary's payoff — permission sets stay whole in the
+`type: app` package.
 **Deciders**: ObjectStack maintainer, 2026-09-01, live PM chat, verbatim and untranslated:
 「立 ADR 起草卡派发」and 「14122 作为epic 任务集中跟踪」— approving the proposal in
 [#14122](https://github.com/objectstack-ai/objectstack/issues/14122) into the ADR-drafting lane
@@ -507,3 +511,92 @@ a reader deserves to know which of its anchors were re-measured:
   `packages/objectql/src/plugin.ts`, `packages/core/src/plugin-order.ts`,
   `packages/spec/src/stack.zod.ts`, `packages/spec/src/kernel/manifest.zod.ts`,
   `packages/cli/src/commands/compile.ts`
+
+---
+
+## Addendum (2026-09-02, #14487) — the permission matrix is outside this boundary's payoff; permission sets stay whole in the app package
+
+**Provenance.** Maintainer ruling, 2026-09-02, live PM chat, recorded the same day on
+[#14454](https://github.com/objectstack-ai/objectstack/issues/14454#issuecomment-5507189677)
+and quoted here in the words that record carries — the PM seat's, not a transcript of the
+maintainer's:「第 3 项（权限集）维护者 2026-09-02 拍板：取 B。」The same comment names what this
+section must say:「权限集整体留在 app 包，权限矩阵不在包边界收益范围内」. The question ruled
+on is item 3 of [#14454](https://github.com/objectstack-ai/objectstack/issues/14454) (carried
+verbatim onto
+[#14457](https://github.com/objectstack-ai/objectstack/issues/14457) as its decision card),
+raised by the HotCRM split plan
+[objectstack-ai/hotcrm#1449](https://github.com/objectstack-ai/hotcrm/pull/1449),
+§上游缺口 / Upstream gaps item 3, which asked the maintainer to *"decide whether permission sets
+can be composed per package (a module contributing its own object grants into a role the app
+owns), or record that the permission matrix is explicitly out of scope for the boundary ADR-0130
+creates."* **B is the second half of that sentence, and this section is that record.**
+
+This section lands while the record is still **Proposed**: it bounds what the record claims and
+settles nothing else — the maintainer's hand-merge remains the acceptance act, exactly as the
+Status line says.
+
+### What §1.3(a) measured, and what this boundary does not fix
+
+§1.3(a) counts, among the three measurable consequences of having no boundary, *"a permission
+matrix of 30 rows × 9 CRUD columns × 6 permission sets that interleaves `客户/联系人/商机` with
+`运费标准/等级政策/工厂成本`"*, and §4 draws the payoff from that section: *"Studio's scope is the
+package, so package boundaries **are** the grouping Studio has never had (§1.3a)"*. **The payoff
+does not extend to the permission matrix.** Splitting a product into co-owning packages leaves
+that matrix exactly as flat as §1.3(a) found it. This is said here, in the record, because
+§1.3(a) lists the matrix as a pain and §4 answers §1.3(a) as a whole — a reader is otherwise
+entitled to read a promise this record cannot keep.
+
+**Why — measured, not reasoned.** A permission set grants across domains *by nature*: it is
+authored per **role**, not per module, so no module owns it. hotcrm#1449 measured the standard
+HotCRM product against its six planned modules — `core`, `sales`, `cpq`, `service`, `marketing`,
+`activity`, all inside the one `crm` namespace D1 makes co-ownable, with the `type: app` package
+declaring no objects at all. Of its **six** permission sets, **four span five or six of the six
+modules** (`sales_rep`, `sales_manager` and `system_admin` at six; `service_agent` at five); the
+remaining two span four (`marketing_user`) and two (`guest_portal`). **Not one is confined to a
+single module.** The split therefore has nothing to distribute — whatever the module boundaries
+are, every set still names objects on both sides of them. This is a second instance, independent
+of the 黑猫 fork §1.3(a) measured: two products, the same shape.
+
+**Where the sets live, and what Studio shows.** The six sets stay **whole in the `type: app`
+package**. That is not a new rule but the standing one:
+[ADR-0086](./0086-authz-metadata-config-boundary-and-cross-package-composition.md) D3 gives a
+permission set exactly one owning `packageId` (implemented — `spec/security/permission.zod.ts`,
+tagged `[ADR-0086 D3]`), so a set is in one package or in another and cannot be in several. In
+Studio's **Access** pillar — the matrix of
+[ADR-0084](./0084-application-builder-information-architecture.md), reached per package through
+ADR-0086 D7's package door — the sets therefore appear **under the app package only**, and their
+matrix stays as wide as the product. Modules group Data, Automation and Interface; they do not
+group Access.
+
+⛔ This section changes no decision: D1–D8, §1 and §3's non-goal on grouping keys stand exactly
+as written. In particular **no `module` or grouping key is added to a permission set** — §1.4
+rejected that key on measured cost, and nothing here reopens it.
+
+### What was NOT decided
+
+Per-package composition of grants — a module contributing **its own** objects' grants into a role
+the app package owns, by analogy with `navigationContributions` — is the other half of
+hotcrm#1449's question. It is **filed, not decided**:
+[#14488](https://github.com/objectstack-ai/objectstack/issues/14488), for the phase in which a
+module ships on its own (the §1.3(c) CPQ case, where a module's objects would otherwise arrive
+with no grants at all). It is out of this release and carries **no commitment** — neither that it
+will be built, nor that the contribution shape is the one it will take.
+
+Three inputs it inherits, recorded here because they are this record's own and would otherwise be
+rediscovered:
+
+- **ADR-0086 D4 stands until amended.** D4 chose Shape B — a package ships its own sets — and
+  states flatly: *"A package never writes into a shared/foreign record."* A contribution
+  mechanism is exactly such a write, so #14488 is an **amendment to that decision**, not an
+  addition beside it.
+- **D4's conflict-freedom argument does not survive co-ownership unexamined.** It is
+  conflict-free *"because each set only grants `objects.<own-namespace>_*` keys"* — one namespace
+  per package. D1 lets N packages co-own one namespace, so inside one artifact that
+  discriminator is gone and #14488 must supply its own. (Both hotcrm#1449 and #14488 propose
+  **refusing** a doubly-contributed `(set, object)` rather than unioning it — a shape to measure,
+  not a decision this section makes.)
+- **Which door edits a split product's app-owned sets is unmeasured.** ADR-0086 D7 scopes the
+  package Access door to *"this package's own object slice"* and keeps the cross-package
+  all-objects matrix at the environment-admin door. After a split the app package owns the sets
+  but no objects, so where a *packaged* cross-module set's grants are authored is a UI question
+  this record does not answer and #14488 inherits.


### PR DESCRIPTION
Fixes #14487
Part of #14122

**Governed surface — maintainer merge.** This PR edits `docs/adr/**`, so it stays **draft** and is merged by hand by the maintainer; `Governed Surface Queue Guard` marks it. Nothing here authorises implementation work, and the record it amends is still `Proposed`.

## What this is

One addendum section appended to `docs/adr/0130-release-artifact-as-co-ownership-boundary.md`, in that repository's existing addendum format (`## Addendum (date, #card) — title`, as in ADR-0006, ADR-0085, ADR-0087), recording the maintainer's 2026-09-02 ruling — option B on item 3 of #14454, the item carried onto decision card #14457: permission sets stay whole in the `type: app` package, and the permission matrix ADR-0130 §1.3(a) measures is **not** part of the payoff §4 claims for the package boundary.

⛔ No decision text moved. D1–D8, §1 and §3's non-goal on grouping keys are unchanged; no `owner` / `publisher` field; no new decision. The only edit outside the new section is a one-sentence pointer appended to the **Status** line — the ADR-0006 / ADR-0085 precedent for a record whose scope an addendum bounds.

## The added text

Heading:

> ## Addendum (2026-09-02, #14487) — the permission matrix is outside this boundary's payoff; permission sets stay whole in the app package

The bound it places on §1.3(a) and §4:

> §1.3(a) counts, among the three measurable consequences of having no boundary, *"a permission matrix of 30 rows × 9 CRUD columns × 6 permission sets that interleaves `客户/联系人/商机` with `运费标准/等级政策/工厂成本`"*, and §4 draws the payoff from that section: *"Studio's scope is the package, so package boundaries **are** the grouping Studio has never had (§1.3a)"*. **The payoff does not extend to the permission matrix.** Splitting a product into co-owning packages leaves that matrix exactly as flat as §1.3(a) found it.

The measurement it rests on:

> A permission set grants across domains *by nature*: it is authored per **role**, not per module, so no module owns it. hotcrm#1449 measured the standard HotCRM product against its six planned modules — `core`, `sales`, `cpq`, `service`, `marketing`, `activity`, all inside the one `crm` namespace D1 makes co-ownable, with the `type: app` package declaring no objects at all. Of its **six** permission sets, **four span five or six of the six modules** (`sales_rep`, `sales_manager` and `system_admin` at six; `service_agent` at five); the remaining two span four (`marketing_user`) and two (`guest_portal`). **Not one is confined to a single module.**

Where the sets live:

> The six sets stay **whole in the `type: app` package**. That is not a new rule but the standing one: ADR-0086 D3 gives a permission set exactly one owning `packageId` [...] In Studio's **Access** pillar — the matrix of ADR-0084, reached per package through ADR-0086 D7's package door — the sets therefore appear **under the app package only**, and their matrix stays as wide as the product. Modules group Data, Automation and Interface; they do not group Access.

What was **not** decided:

> Per-package composition of grants — a module contributing **its own** objects' grants into a role the app package owns, by analogy with `navigationContributions` — is the other half of hotcrm#1449's question. It is **filed, not decided**: #14488, for the phase in which a module ships on its own (the §1.3(c) CPQ case, where a module's objects would otherwise arrive with no grants at all). It is out of this release and carries **no commitment** — neither that it will be built, nor that the contribution shape is the one it will take.

The section then records three constraints that phase inherits, so they are not rediscovered: ADR-0086 D4 stands until amended (*"A package never writes into a shared/foreign record."*, so #14488 is an amendment to D4, not an addition beside it); D4's conflict-freedom argument assumes one namespace per package, which D1 relaxes for co-owners inside one artifact; and which Access door edits a split product's app-owned sets is unmeasured (D7 scopes the package door to *"this package's own object slice"*, and after a split the app package owns the sets but no objects). All three are marked as inputs, not decisions.

Status line, appended:

> **Scope bounded by the 2026-09-02 addendum** (#14487): the permission matrix §1.3(a) measures is **not** part of this boundary's payoff — permission sets stay whole in the `type: app` package.

## Evidence

- **Ruling**: recorded 2026-09-02 on #14454 (comment 5507189677) and quoted in the words that record carries, marked as the PM seat's rather than a transcript of the maintainer's.
- **Measurement**: hotcrm#1449 `docs/architecture/module-split-plan.md` §上游缺口 / Upstream gaps item 3 and its generated `module-split-inventory.json` (`unmeasured_edge_classes`), per set: `sales_rep` 6, `sales_manager` 6, `system_admin` 6, `service_agent` 5, `marketing_user` 4, `guest_portal` 2, of six planned modules.
- **Quotes**: every verbatim quote in the section (ADR-0130 §1.3(a) and §4; ADR-0086 D4 twice, D7 once; hotcrm#1449's "Ask") was checked whitespace-normalised against its source file rather than retyped from memory. The `[ADR-0086 D3]` anchor is real in `packages/spec/src/security/permission.zod.ts`; it is cited by tag, not line number, per this record's own §7 discipline.

## Changeset — precedent followed

**No changeset; the `skip-changeset` label carries it.** Precedent, checked over the last 30 commits touching `docs/adr`: every ADR-only commit carries no changeset at all — including ADR-0130's own landing commit `682d03ba7` (#14151) and `abeb5665e` (#12867). `scripts/check-empty-changeset.mjs` rejects a newly added empty-frontmatter changeset, so in this repository the label is the mechanism and an empty file is not; the label is applied on this PR.

## Gates

Family derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (1 path in the change set, 5 commands). All re-run at commit `018270546` under `scripts/pm/os-verify-lock.sh`, exit codes captured into a file before any pipe:

| Gate | Exit | Verdict line |
| --- | --- | --- |
| `node scripts/check-adr-links.mjs` | 0 | `✅ check-adr-links: 600 relative link destination(s) under docs/adr/ resolve` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 427 files / 1398 TS blocks judged clean` |
| `pnpm check:adr-anchors` | 0 | `check-adr-anchors: OK (52 anchored file(s) [...] 31335 citation(s) across 4067 file(s) resolve)` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 394 files clean — no bare metadata literals.` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 243 assertions` |
| `pnpm check:nul-bytes` (not derived; run on every edit) | 0 | `check-nul-bytes: OK (scanned 7914 text file(s) [...] no raw ASCII control bytes)` |

`check:doc-formula-expressions` first exited **3 — PREREQUISITE NOT MET** (`@objectstack/formula`, then `@objectstack/lint`, not built), which is "nothing was measured", not a finding; both packages were built and the gate then ran green. The 9 further families `dispatch-gates` names apply only once a changeset path exists, which by the precedent above this PR does not create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m)_