### PR TITLE
docs(apps/docs): fix stale docblock in page.tsx breadcrumb walk

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -55,14 +55,17 @@ type DocPage = NonNullable<ReturnType<typeof source.getPage>>;
  * `index` node. ⛔ Nothing here splits `page.url` on `/`, and nothing constructs a
  * URL the loader has not already produced.
  *
- * ⚠️ **An ancestor can arrive without a URL, and this drops it.** Fumadocs
- * attaches a folder's `index.mdx` as that folder's `index` node only when the
- * folder's `meta.json` does **not** list `"index"` in `pages`; a folder that
- * lists it reaches this walk with a `name` and no `url`. That was once 17 of the
- * 35 `meta.json` files under `content/docs`, shortening 172 of 404 trails. 16 of
- * the 17 were fixed producer-side (#12352) and 8 short trails remain, all under
- * `content/docs/releases/` — a directory AGENTS.md fences off, so its `meta.json`
- * still lists `"index"`. The condition is therefore live, just rare.
+ * ⚠️ **An ancestor can arrive without a URL, and the loop below drops it.**
+ * `getBreadcrumbItems()` does not drop anything itself — it emits that
+ * ancestor with a `name` and `url: undefined`. The drop happens locally, in
+ * this file: the `if (typeof item.name !== 'string' || !item.url) continue;`
+ * guard in the loop below skips it. Fumadocs attaches a folder's `index.mdx`
+ * as that folder's `index` node only when the folder's `meta.json` does
+ * **not** list `"index"` in `pages`; a folder that lists it reaches this walk
+ * with a `name` and no `url`. #12352 and #13946 fixed every `meta.json` under
+ * `content/docs` that did so — today's corpus has none — but the condition is
+ * structural, not retired: any `meta.json` that lists `"index"` again
+ * reproduces it.
  *
  * ⛔ The missing URL is deliberately **not** reconstructed here — that fence is
  * the reason #12352 was fixable at all. The folder's index page exists, is in the


### PR DESCRIPTION
Fixes #13949

## What

`apps/docs/app/[lang]/docs/[[...slug]]/page.tsx`'s `docsTrail()` docblock carried two
errors, both fixed in this one edit, one file, prose only:

1. **Stale census.** The paragraph claimed "8 short trails remain … its `meta.json`
   still lists `"index"`. The condition is therefore live, just rare." That went false
   when PR #13946 removed `"index"` from `content/docs/releases/meta.json` — today,
   zero `meta.json` under `content/docs` lists `"index"` in `pages`
   (`git grep -c '"index"' HEAD -- 'content/docs/**/meta.json'` → no hits). Per the
   triage's measured lesson (a count that rotted within a day), the paragraph is
   rewritten to the **mechanism only**: how a URL-less ancestor arises, that #12352
   and #13946 fixed every known instance, and that the condition is structural and
   can recur — no new count written in its place.
2. **Misattribution**, independent of #13946 and wrong on `origin/main` today:
   the docblock said the walk "drops" the un-linkable ancestor. `getBreadcrumbItems()`
   does not drop it — it emits the ancestor with `url: undefined`. The drop is local:
   `docsTrail()`'s own loop guard, `if (typeof item.name !== 'string' || !item.url)
   continue;`, is what skips it.

No behavior change: `docsTrail()`'s logic, the breadcrumb loop, and the "the missing
URL is deliberately not reconstructed here" rule paragraph (unaffected per the triage)
are untouched. `git diff --stat` on this branch touches exactly one file.

## Why this needed its own PR

Per the issue: `content/docs/releases/**` is fenced unconditionally in PR #13946's
dispatch, whose legality rested on "one file, nothing else" — `apps/docs/**` would
have been a second file. The fence that made #13946 possible is what prevented it
from carrying this correction; this PR is the follow-on the triage said was needed.

## Tests

- `pnpm --filter @objectstack/docs typecheck` (`fumadocs-mdx && next typegen && tsc
  --noEmit`) — PASS, both before opening (on the pre-merge tree) and again after
  merging `origin/main` into this branch.
- `node scripts/check-docs-nav-label.mjs` — PASS (9-clause battery, the gate this
  docblock's neighboring `includePage` flip is pinned by).
- `node scripts/check-docs-nav-label.mjs --self-test` — PASS (25 assertions).
- `pnpm exec eslint --no-inline-config --format json` narrowed to the one edited file
  — PASS, 0 errors/warnings (repo ESLint has no type-aware linting anywhere, so this
  narrowing moves no untouched file's judgment).
- The 9 gate families `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack
  --commands` derived for this diff — all PASS (`check:docs-locale-catch-all`,
  `check:logger-receiver-detach`, `check:page-declaration-shape`, `check:published-files`,
  `check:test-source-alias`, `check:type-source-resolution`, plus the two
  `check-docs-nav-label.mjs` invocations above and `check-undeclared-dep-imports.mjs`).

All of the above were re-derived and re-run against the merged tree
(`origin/main` fetched and merged, no conflicts) at head `75749de5c`.

## Changeset

`apps/docs` is `"private": true` — this PR publishes nothing from any package. The
changeset gate's own counting logic (`git diff --name-only --diff-filter=A
$(git merge-base origin/main HEAD) HEAD -- '.changeset/*.md'`) was simulated locally
and returns 0 added changesets, so this PR needs the `skip-changeset` label — applied
via the additive labels endpoint right after opening, with a read-back to confirm.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_