### PR TITLE
test(devx): pin the merge-queue triage comment's operative guidance prose

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2867,24 +2867,28 @@ jobs:
       # line, driven against REAL captured vitest logs of the incident's own
       # test file — one timeout, one assertion, byte-identical FAIL lines and
       # opposite diagnoses, which is the confusion that produced a confidently
-      # wrong card (#10112) and cost a whole dispatch; and (2) the cross-PR
+      # wrong card (#10112) and cost a whole dispatch; (2) the cross-PR
       # aggregation files exactly ONE anchor issue at >= 2 DISTINCT PRs,
       # REFRESHES it on the next ejection instead of filing a second, and files
       # none for two different keys or for one PR ejecting twice. The refresh
       # leg is driven as a PAIR — run 2's world is built from run 1's output —
       # because idempotency is a property of the pair and a hand-written marker
-      # would prove each half while leaving the two runs free to disagree.
+      # would prove each half while leaving the two runs free to disagree; and
+      # (3) the operative guidance prose (the timeout-vs-assertion rule, its
+      # named exception, and the boundary sentence that the re-queue allowance
+      # is governed elsewhere) is present in the posted body, one assertion per
+      # claim over the WHOLE body, not the excerpt.
       #
       # Its --self-test runs first and is the half that stops the battery
-      # rotting into decoration: it mutates the shipped script fourteen ways —
+      # rotting into decoration: it mutates the shipped script twenty ways —
       # drop the reason lookahead, test the FAIL pattern before the reason
       # pattern (which silently loses every assertion), count runs instead of
       # distinct PRs, always create instead of refreshing, drop the sighting
-      # markers, downgrade each anti-no-op announcement to an info line, and
-      # more — and requires the battery to go RED for each, naming the scenario
-      # that catches it. A mutation whose anchor no longer exists is a failure
-      # too, so a rewrite of the workflow cannot leave the mutations silently
-      # matching nothing.
+      # markers, downgrade each anti-no-op announcement to an info line, drop
+      # each half of the guidance prose, and more — and requires the battery to
+      # go RED for each, naming the scenario that catches it. A mutation whose
+      # anchor no longer exists is a failure too, so a rewrite of the workflow
+      # cannot leave the mutations silently matching nothing.
       #
       # Invoked as `node` rather than through a `pnpm check:*` alias, same
       # reason as the step above: see the GATE INVOCATION IDIOM note at the top

--- a/scripts/check-merge-queue-triage-outcome.mjs
+++ b/scripts/check-merge-queue-triage-outcome.mjs
@@ -505,6 +505,24 @@ const excerptLines = (r) => {
   return out;
 };
 
+/**
+ * The whole posted body, for assertions about the operative GUIDANCE PROSE
+ * (the timeout-vs-assertion rule, its named exception, and the boundary
+ * sentence) rather than the extracted excerpt.
+ *
+ * This deliberately does NOT go through `excerptLines`: that helper is
+ * scoped to code-fence content precisely so the comment's own explanatory
+ * prose -- which names both `FAIL` and `AssertionError` -- cannot satisfy an
+ * assertion about the EXTRACTION (see its docblock). The guidance prose
+ * lives outside every fence, so `excerptLines` cannot see it at all; going
+ * through it here would silently pass on a body that shipped `excerptLines`
+ * still finds the FAIL/reason pair, but with the guidance paragraph deleted.
+ * The question this accessor answers is different and does not have that
+ * failure mode: is the guidance text the workflow composes into every
+ * comment actually present in what it posted?
+ */
+const guidanceProse = (r) => postedBody(r);
+
 // ── Scenarios ───────────────────────────────────────────────────────────────
 
 const REFUSED = httpError(503, 'No server is currently available to service your request.');
@@ -547,11 +565,19 @@ function scenarios(root) {
       world: () => base(),
       check(r, t) {
         const lines = excerptLines(r);
+        const prose = guidanceProse(r);
         return [
           t(lines.some((l) => l.includes(`FAIL  ${KEY_A}`)), 'the FAIL line is excerpted'),
           t(lines.some((l) => l.startsWith('↳ 失败原因:') && l.includes('Error: Test timed out in 1ms.')),
             `the reason line is excerpted and labelled, got: ${JSON.stringify(lines)}`),
           t(!lines.some((l) => l.includes('AssertionError')), 'no assertion is reported for a timeout log'),
+          // ── operative guidance prose, read over the WHOLE posted body ──
+          t(prose.includes('负载/时序') && prose.includes('真实的行为改变'),
+            'the timeout-vs-assertion rule is present in the posted body: timeout -> load/timing, assertion -> real behaviour change'),
+          t(prose.includes('实验自身的有效性前提') && prose.includes('时长、一个时间戳、一个耗时计数'),
+            'the named exception is present in the posted body: an assertion about the experiment\'s own validity premise (a duration, a timestamp, an elapsed count) reads like a timeout'),
+          t(prose.includes('后者由别处管'),
+            'the boundary sentence is present in the posted body: this only changes how a red is read, not which tests may be re-queued'),
         ];
       },
     },
@@ -1212,6 +1238,33 @@ const MUTATIONS = [
     from: "  core.info('triage comment for this run already exists \u2014 skipping.');\n  return;",
     to: "  core.info('triage comment for this run already exists \u2014 skipping.');",
     expect: ['A5'],
+  },
+  {
+    id: 'M17',
+    what: 'the timeout-vs-assertion rule silently loses its "load/timing" half',
+    from: '\u8d1f\u8f7d/\u65f6\u5e8f',
+    to: '',
+    expect: ['E1'],
+    // A1 files an anchor from the same triage comment but never reads the
+    // guidance prose -- the control that proves this mutation is caught by
+    // the new prose assertion, not by every scenario reacting to any change.
+    keepGreen: ['A1'],
+  },
+  {
+    id: 'M18',
+    what: 'the named exception silently loses the phrase identifying its own object -- the experiment\'s own validity premise',
+    from: '\u5b9e\u9a8c\u81ea\u8eab\u7684\u6709\u6548\u6027\u524d\u63d0',
+    to: '',
+    expect: ['E1'],
+    keepGreen: ['A1'],
+  },
+  {
+    id: 'M19',
+    what: 'the boundary sentence -- this only changes how a red is read, not which tests may be re-queued -- silently drops',
+    from: '\u540e\u8005\u7531\u522b\u5904\u7ba1',
+    to: '',
+    expect: ['E1'],
+    keepGreen: ['A1'],
   },
 ];
 


### PR DESCRIPTION
Fixes #13967

## What

`scripts/check-merge-queue-triage-outcome.mjs` pinned the fenced excerpt and the
cross-PR aggregation, but nothing in its 73 assertions read the merge-queue triage
comment's operative guidance prose — the timeout-vs-assertion heuristic, its named
exception (PR #13966), and the boundary sentence saying the re-queue allowance is
governed elsewhere. Deleting all three from the workflow's `body` array left the
whole derived gate family green.

This adds:
- `guidanceProse(r)` beside `excerptLines(r)`, built on `postedBody(r)` (the whole
  posted comment) rather than through `excerptLines` — its docblock states why:
  `excerptLines` is deliberately scoped to code-fence content, and the guidance
  prose lives outside every fence, so going through it would leave the prose
  unreadable by design, not by omission.
- Three assertions in scenario `E1` (the timeout scenario — the body is composed
  once, so one scenario carrying all three is enough), one per operative claim.
- Three `MUTATIONS` rows (`M17`-`M19`) so `--self-test` proves each new assertion
  can go RED, with `A1` as the `keepGreen` control (it posts the same comment but
  never reads the prose, so it should not move).
- The third "what it holds" row in `lint.yml`'s step comment, and a correction of
  its mutation count (measured 20 after this change; it previously said "fourteen"
  against a measured 17 — both numbers are fixed in this edit).

`.github/workflows/merge-queue-triage.yml` is the SUBJECT being pinned and is
**not** touched by this PR.

## Pinned sentences (mandatory per the triage)

One assertion per operative claim, each on the shortest substring that carries
the claim and would not survive a deletion — never the whole sentence:

| Claim | Pinned fragment(s) | Why load-bearing |
|---|---|---|
| The rule | `负载/时序` **and** `真实的行为改变` | These are the two poles of the timeout-vs-assertion heuristic itself (timeout ⇒ load/timing noise; assertion ⇒ real behaviour change) — the line the triage checklist turns on. |
| The named exception (#13966) | `实验自身的有效性前提` **and** `时长、一个时间戳、一个耗时计数` | Names the exception's own object (an assertion about the experiment's validity premise) and the mechanical tell (duration/timestamp/elapsed-count) that separates it from a real regression. |
| The boundary sentence | `后者由别处管` | The sentence saying this guidance only changes how a red is read, not which tests may be re-queued — a real boundary claim, not commentary. |

**Deliberately NOT pinned**: the wording around these fragments — the framing
prose, the two worked examples (`AssertionError: SecurityPlugin.init()...` /
`...second-precision stamps could have differed too...`), and markdown emphasis.
Quoting more than these fragments is exactly the failure mode the card names: *"a
prose pin that quotes too much turns every wording improvement into a two-file
edit, and that is how pins rot into copy-paste."*

## Tests

- `node scripts/check-merge-queue-triage-outcome.mjs --self-test` → `104
  assertions, 20 mutations of the shipped script each driven to red.`
- `node scripts/check-merge-queue-triage-outcome.mjs` → `OK (76 assertions over
  20 scenarios...)` (73 + 3 new; 20 scenarios unchanged, confirmed with `--list`).
- Counter-measurement (the card's own falsification test): in the worktree, on a
  committed baseline, blanked the rule pair and the boundary sentence directly in
  `merge-queue-triage.yml` (restored via `git checkout HEAD --
  .github/workflows/merge-queue-triage.yml` under a `trap ... EXIT INT TERM`,
  confirmed clean by `git diff HEAD` after). The battery went RED naming exactly
  the two mutated assertions:
  ```
  check-merge-queue-triage-outcome: 2 failed assertion(s) over the SHIPPED script
    • [E1] the timeout-vs-assertion rule is present in the posted body: timeout -> load/timing, assertion -> real behaviour change
    • [E1] the boundary sentence is present in the posted body: this only changes how a red is read, not which tests may be re-queued
  ```
  (The named-exception assertion, untouched by that mutation, correctly stayed
  green — confirming the three assertions are independent.)
- `eslint scripts/check-merge-queue-triage-outcome.mjs --no-inline-config
  --format json`: 1 file, 0 errors, 0 warnings. Repo uses one flat
  `eslint.config.mjs` with no `parserOptions.project` for any file (no type-aware
  linting anywhere in the repo), so this file-narrowed run is a measurement, not
  an assumption — it cannot move any unrelated file's verdict.
- Re-ran self-test + main check after merging `origin/main` (no conflicts,
  unrelated files) — both green on the merged tree at `4e61df652`.
- Gate union: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack
  --commands scripts/check-merge-queue-triage-outcome.mjs
  .github/workflows/lint.yml` → 35 commands; all 35 run, reconciled with `--ran`
  (35 derived, 35 run, 0 NOT-MEASURED, 0 UNRUN). 33/35 passed; 2 exited
  PREREQUISITE-NOT-MET locally (not a red — `check-test-completeness.mjs` needs a
  saved `turbo run test` log CI produces; `check:type-check-debt` needs the full
  workspace `dist/*.d.ts` closure built) and are unaffected by this diff. See the
  `os-dev-report` comment on #13967 for the full per-command list.

## Changeset

None. `scripts/**` + `.github/**` only, publishes nothing from any package —
`skip-changeset` label applied and confirmed by reading it back.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV)_