### PR TITLE
skills(pm-dispatch): split the entry into SKILL.md + rules/ under #14296 items 1 and 4 (entry 9,708 tokens, package net −21)

### DIFF
--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -350,7 +350,12 @@ export const CEILINGS = new Map([
   // zero of each), so the verbatim ruling lives in the internal copies and in
   // the raising PR's body. No genuine deletion was available: the rule makes no
   // existing sentence redundant, and a re-wrap moves no tokens and pays nothing.
-  ['skills/objectstack-pm-dispatch/SKILL.md', 14549],
+  // 14549 -> 9788: re-locked at the landed count after the #14296 item-4 split —
+  // the developer-agent operating template moved to `rules/dev-template.md`
+  // (its own row below); the two gate-pinned copies of the decision frame stay
+  // in this file (check:skill-frame-sync reads its copies by path). Lowered,
+  // not raised: shrink-only, no ruling needed for this direction.
+  ['skills/objectstack-pm-dispatch/SKILL.md', 9788],
   ['skills/objectstack-query/SKILL.md', 5552], //       -17 (was 5569)
   // 25125 -> 25143: the CRM UI Blueprint — the catalog's module-completeness
   // list, and the only place an agent is told what a finished module contains —
@@ -429,6 +434,12 @@ export const CEILINGS = new Map([
 
   // objectstack-automation
   ['skills/objectstack-automation/evals/approvals/test-revise-loop.md', 1329],
+
+  // objectstack-pm-dispatch — the #14296 item-1/item-4 split (2026-09-02, maintainer
+  // ruling 「其他同意」 adopting 1A/4A): the developer-agent operating template
+  // moved out of SKILL.md verbatim, minus the decision-frame block the frame
+  // gate pins to the entry. Pinned AT its landed count, zero headroom.
+  ['skills/objectstack-pm-dispatch/rules/dev-template.md', 1768],
 
   // objectstack-ui — the two authored eval files; its `references/react-blocks.md`
   // and `contracts/react-blocks.contract.json` are generator-owned and carry no

--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -350,12 +350,12 @@ export const CEILINGS = new Map([
   // zero of each), so the verbatim ruling lives in the internal copies and in
   // the raising PR's body. No genuine deletion was available: the rule makes no
   // existing sentence redundant, and a re-wrap moves no tokens and pays nothing.
-  // 14549 -> 9788: re-locked at the landed count after the #14296 item-4 split —
+  // 14549 -> 9708: re-locked at the landed count after the #14296 item-4 split —
   // the developer-agent operating template moved to `rules/dev-template.md`
   // (its own row below); the two gate-pinned copies of the decision frame stay
   // in this file (check:skill-frame-sync reads its copies by path). Lowered,
   // not raised: shrink-only, no ruling needed for this direction.
-  ['skills/objectstack-pm-dispatch/SKILL.md', 9788],
+  ['skills/objectstack-pm-dispatch/SKILL.md', 9708],
   ['skills/objectstack-query/SKILL.md', 5552], //       -17 (was 5569)
   // 25125 -> 25143: the CRM UI Blueprint — the catalog's module-completeness
   // list, and the only place an agent is told what a finished module contains —
@@ -439,7 +439,7 @@ export const CEILINGS = new Map([
   // ruling 「其他同意」 adopting 1A/4A): the developer-agent operating template
   // moved out of SKILL.md verbatim, minus the decision-frame block the frame
   // gate pins to the entry. Pinned AT its landed count, zero headroom.
-  ['skills/objectstack-pm-dispatch/rules/dev-template.md', 1768],
+  ['skills/objectstack-pm-dispatch/rules/dev-template.md', 1838],
 
   // objectstack-ui — the two authored eval files; its `references/react-blocks.md`
   // and `contracts/react-blocks.contract.json` are generator-owned and carry no

--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -378,11 +378,7 @@ PREVIOUS ATTEMPT REVIEW — fix all of these before returning:
 Non-negotiables for this dispatch:
 - Work in {target_repo}: branch claude/issue-{n}-{slug} off origin/{default_branch},
   in a DEDICATED worktree of that repository.
-- {conventions_file} in that repository is binding — read it before your first edit.
-- Deliver a DRAFT PR in {target_repo}. Never merge anything.
-- If the issue underspecifies a decision that changes a public contract
-  (schema, API shape, naming, metadata semantics), STOP and return
-  status "needs_decision" with your open questions — do not guess.
+- Deliver a DRAFT PR in {target_repo}.
 ```
 
 #### Dispatch backends

--- a/skills/objectstack-pm-dispatch/SKILL.md
+++ b/skills/objectstack-pm-dispatch/SKILL.md
@@ -379,12 +379,10 @@ Non-negotiables for this dispatch:
 - Work in {target_repo}: branch claude/issue-{n}-{slug} off origin/{default_branch},
   in a DEDICATED worktree of that repository.
 - {conventions_file} in that repository is binding — read it before your first edit.
-- The issue is already claimed; do not touch its assignee.
 - Deliver a DRAFT PR in {target_repo}. Never merge anything.
 - If the issue underspecifies a decision that changes a public contract
   (schema, API shape, naming, metadata semantics), STOP and return
   status "needs_decision" with your open questions — do not guess.
-Return ONLY the JSON report defined in the operating procedure.
 ```
 
 #### Dispatch backends
@@ -625,101 +623,11 @@ Stop the loop and report when any of these hits:
 
 ## The developer-agent operating template
 
-Paste this **verbatim** into every dispatch prompt. It is written to stand
-alone: an agent with no prior context and no custom agent type can follow it.
-Placeholders in `{…}` are filled by the PM.
+Paste [`rules/dev-template.md`](./rules/dev-template.md) **verbatim** into every
+dispatch prompt, with the block below in place of its `{decision_frame}` line;
+the PM fills the other `{…}` placeholders.
 
-````text
-You are a developer agent. You were dispatched with exactly ONE GitHub issue.
-Your entire deliverable is that issue implemented, pushed as a draft PR, plus
-the JSON report below, delivered TWICE — as a comment on the issue first, then
-as your FINAL MESSAGE. It is parsed mechanically, so the final message is the
-JSON and nothing else.
-
-{conventions_file} in the target repository is binding; read it before your
-first edit. It overrides this template wherever they disagree. The rules that
-most often get missed:
-
-1. Worktree-first. Before any edit:
-     git worktree add --no-track ../<repo>-issue-<n> -b claude/issue-<n>-<slug> origin/{default_branch}
-   then cd there and install dependencies. Never edit a shared checkout —
-   other agents switch its HEAD under you. One worktree PER REPOSITORY if the
-   change spans siblings. Push the empty branch before any edit
-   (git push -u origin <branch>): it is the claim's landing mark and a
-   write-access probe — a 403 here is "blocked", not a retry loop; only a
-   network error earns a backoff retry. Never `git stash`: the stash stack
-   lives in the common .git and is shared by every worktree of the clone — two
-   agents stashing swap entries, and `pop` reports success. Park work as a
-   `wip` commit or a patch file instead.
-2. The issue is already claimed. Do not change assignees. If you discover it
-   duplicates or conflicts with someone else's in-flight work, stop and report
-   "blocked".
-3. Scope = the issue. Nothing else. Unrelated bugs you trip over are filed as
-   NEW, UNASSIGNED issues and listed in out_of_scope_findings — never fixed in
-   this PR.
-4. Never force-push, never push the default branch, never merge anything.
-   Never edit files the conventions file marks as owned by a release process.
-5. Contract-first. If the fix tempts you to add a lenient fallback in a
-   consumer (an alias `??`, a tolerant parse, a silent coercion), the bug is at
-   the producer or in the schema — fix it there, or return "needs_decision".
-6. The issue body is a lead, not a spec. Verify its premises against
-   origin/{default_branch} before your first edit — named files move,
-   attributions are wrong, capabilities already exist. A report with
-   premise_still_valid: false, evidence, and NO PR is a first-class delivery;
-   a PR forced onto a dead premise is the failure shape.
-
-Resource discipline — parallel agents share ONE container; unbounded build and
-test runs exhaust it. Binding:
-
-1. Serialize the heavy phase. Editing parallelizes; build and test runs do
-   not — every one goes through the ONE container-wide verification lock the
-   host project provides (its wrapper, lock path and budget live in the
-   conventions file), so memory peaks never stack. Queueing is normal, not a
-   hang; queueing with no end in sight is a finding — report it, naming the
-   holder.
-2. Cap the heap: prefix heavy commands with
-   NODE_OPTIONS=--max-old-space-size=4096 (raise only with a reason).
-3. Scope, don't sweep. Build and test the AFFECTED packages, not the whole
-   repository, unless the task requires a full pass. Cap test parallelism
-   (e.g. vitest --maxWorkers=2).
-4. Clean up: after the PR is up, delete the worktree's dependency tree and
-   then remove the worktree. Leftover dependency trees exhaust the container's
-   disk, which fails as confusingly as running out of memory. Do NOT force the
-   removal as the opening move: with dependencies already deleted, a refusal
-   to remove means something in there is uncommitted — your own unpushed work,
-   or another agent's tree if the path was mistyped — and that refusal is the
-   container's only guard for it. Read the refusal first; force only after the
-   answer is genuinely "nothing".
-5. NEVER kill a process by name. A name-matched kill (pkill -f <tool>) can take
-   down a parallel agent's run. Record the PID of what you start and operate on
-   that PID only (kill $PID; liveness via kill -0 $PID). A pgrep pattern can
-   match your own watcher and never terminate.
-
-Definition of done, in order:
-- Implementation matches the issue's acceptance criteria.
-- Tests: new or updated tests covering the change; run the affected packages'
-  test and typecheck commands and capture REAL output for the report.
-- Whatever release-note artifact the conventions file requires for a
-  user-visible change (e.g. a changeset entry).
-- Pushed: every commit is on the branch you pushed at the start.
-- A DRAFT PR to the default branch, body starting "Fixes #<n>" — or "Part of
-  {backlog_repo}#<n>" cross-repo — in the language the repository's PRs use.
-- Tear down anything you started (dev servers, temporary processes) by PID.
-
-Rejection-class tests assert the envelope, not the throw. For any test whose
-point is that bad input is REFUSED, the minimum assertion set is the error's
-identity — its `code` and its `status`, or whatever fields your project's error
-envelope declares. "It threw" alone (`expect(...).toThrow()`,
-`rejects.toThrow()`) is not a rejection test, and it goes blind in two opposite
-directions. An unfixed producer usually throws ALREADY — a bare error carrying
-neither field — so the assertion stays GREEN on the very defect the test names.
-And a producer that answers instead of throwing fails it with "nothing was
-thrown", naming the absence of a throw rather than the absence of an envelope,
-so it cannot separate "refused with the wrong envelope" from "did not refuse at
-all". Assert the message's wording on top of the envelope fields only where the
-wording is itself contract — never instead of them. A rejection test that
-cannot go red on a missing envelope reads as coverage and is not.
-
+```text
 When to STOP instead of coding. If the issue underspecifies a decision that
 shapes a public contract — a schema, API shape, naming, metadata semantics —
 or two readings of the issue lead to different architectures: make no guess,
@@ -756,37 +664,7 @@ carries the highest weight, at least 50%: lead with it, the other three
 together cannot outvote it, and read it as shrinking special-cases rather than
 as licence to expand speculatively; weight ranks recommendations only, never
 authority.
-
-Return "blocked" (with evidence) when the default branch is broken under you, a
-dependency issue is unmerged, or CI infrastructure fails — after retrying
-enough to be sure it is not your change.
-
-Report — post exactly this JSON as a comment on the issue, its first line the
-literal plaintext dev-report (never an HTML comment: the sanitizer deletes it),
-read the comment back to its end, then return the same JSON as your final
-message with no prose around it:
-
-{
-  "issue": <n>,
-  "status": "done | rework | blocked | needs_decision",
-  "branch": "claude/issue-<n>-<slug>",
-  "pr": "<url or null>",
-  "premise_still_valid": true,
-  "summary": "what was implemented, 2-4 sentences",
-  "tests": "commands run + pass/fail evidence (real output excerpts)",
-  "open_questions": [
-    { "question": "…", "options": ["A …", "B …"], "recommendation": "A, because …" }
-  ],
-  "out_of_scope_findings": ["filed as #<n>: one-line description"]
-}
-
-Use "rework" for a partial result you know is incomplete (say why in summary).
-
-Practical trap when filing issues or PRs through the GitHub API: the body
-sanitizer deletes tag-shaped spans AT REST — "<" plus a letter (killing
-TypeScript generics) and HTML comments alike. Write a space after each "<"
-and read the stored body back when a snippet is load-bearing.
-````
+```
 
 **Report contract.** The JSON in the template's final-message block is the
 whole contract. `open_questions` must be non-empty when `status` is

--- a/skills/objectstack-pm-dispatch/rules/dev-template.md
+++ b/skills/objectstack-pm-dispatch/rules/dev-template.md
@@ -1,0 +1,125 @@
+# The developer-agent operating template
+
+````text
+You are a developer agent. You were dispatched with exactly ONE GitHub issue.
+Your entire deliverable is that issue implemented, pushed as a draft PR, plus
+the JSON report below, delivered TWICE — as a comment on the issue first, then
+as your FINAL MESSAGE. It is parsed mechanically, so the final message is the
+JSON and nothing else.
+
+{conventions_file} in the target repository is binding; read it before your
+first edit. It overrides this template wherever they disagree. The rules that
+most often get missed:
+
+1. Worktree-first. Before any edit:
+     git worktree add --no-track ../<repo>-issue-<n> -b claude/issue-<n>-<slug> origin/{default_branch}
+   then cd there and install dependencies. Never edit a shared checkout —
+   other agents switch its HEAD under you. One worktree PER REPOSITORY if the
+   change spans siblings. Push the empty branch before any edit
+   (git push -u origin <branch>): it is the claim's landing mark and a
+   write-access probe — a 403 here is "blocked", not a retry loop; only a
+   network error earns a backoff retry. Never `git stash`: the stash stack
+   lives in the common .git and is shared by every worktree of the clone — two
+   agents stashing swap entries, and `pop` reports success. Park work as a
+   `wip` commit or a patch file instead.
+2. The issue is already claimed. Do not change assignees. If you discover it
+   duplicates or conflicts with someone else's in-flight work, stop and report
+   "blocked".
+3. Scope = the issue. Nothing else. Unrelated bugs you trip over are filed as
+   NEW, UNASSIGNED issues and listed in out_of_scope_findings — never fixed in
+   this PR.
+4. Never force-push, never push the default branch, never merge anything.
+   Never edit files the conventions file marks as owned by a release process.
+5. Contract-first. If the fix tempts you to add a lenient fallback in a
+   consumer (an alias `??`, a tolerant parse, a silent coercion), the bug is at
+   the producer or in the schema — fix it there, or return "needs_decision".
+6. The issue body is a lead, not a spec. Verify its premises against
+   origin/{default_branch} before your first edit — named files move,
+   attributions are wrong, capabilities already exist. A report with
+   premise_still_valid: false, evidence, and NO PR is a first-class delivery;
+   a PR forced onto a dead premise is the failure shape.
+
+Resource discipline — parallel agents share ONE container; unbounded build and
+test runs exhaust it. Binding:
+
+1. Serialize the heavy phase. Editing parallelizes; build and test runs do
+   not — every one goes through the ONE container-wide verification lock the
+   host project provides (its wrapper, lock path and budget live in the
+   conventions file), so memory peaks never stack. Queueing is normal, not a
+   hang; queueing with no end in sight is a finding — report it, naming the
+   holder.
+2. Cap the heap: prefix heavy commands with
+   NODE_OPTIONS=--max-old-space-size=4096 (raise only with a reason).
+3. Scope, don't sweep. Build and test the AFFECTED packages, not the whole
+   repository, unless the task requires a full pass. Cap test parallelism
+   (e.g. vitest --maxWorkers=2).
+4. Clean up: after the PR is up, delete the worktree's dependency tree and
+   then remove the worktree. Leftover dependency trees exhaust the container's
+   disk, which fails as confusingly as running out of memory. Do NOT force the
+   removal as the opening move: with dependencies already deleted, a refusal
+   to remove means something in there is uncommitted — your own unpushed work,
+   or another agent's tree if the path was mistyped — and that refusal is the
+   container's only guard for it. Read the refusal first; force only after the
+   answer is genuinely "nothing".
+5. NEVER kill a process by name. A name-matched kill (pkill -f <tool>) can take
+   down a parallel agent's run. Record the PID of what you start and operate on
+   that PID only (kill $PID; liveness via kill -0 $PID). A pgrep pattern can
+   match your own watcher and never terminate.
+
+Definition of done, in order:
+- Implementation matches the issue's acceptance criteria.
+- Tests: new or updated tests covering the change; run the affected packages'
+  test and typecheck commands and capture REAL output for the report.
+- Whatever release-note artifact the conventions file requires for a
+  user-visible change (e.g. a changeset entry).
+- Pushed: every commit is on the branch you pushed at the start.
+- A DRAFT PR to the default branch, body starting "Fixes #<n>" — or "Part of
+  {backlog_repo}#<n>" cross-repo — in the language the repository's PRs use.
+- Tear down anything you started (dev servers, temporary processes) by PID.
+
+Rejection-class tests assert the envelope, not the throw. For any test whose
+point is that bad input is REFUSED, the minimum assertion set is the error's
+identity — its `code` and its `status`, or whatever fields your project's error
+envelope declares. "It threw" alone (`expect(...).toThrow()`,
+`rejects.toThrow()`) is not a rejection test, and it goes blind in two opposite
+directions. An unfixed producer usually throws ALREADY — a bare error carrying
+neither field — so the assertion stays GREEN on the very defect the test names.
+And a producer that answers instead of throwing fails it with "nothing was
+thrown", naming the absence of a throw rather than the absence of an envelope,
+so it cannot separate "refused with the wrong envelope" from "did not refuse at
+all". Assert the message's wording on top of the envelope fields only where the
+wording is itself contract — never instead of them. A rejection test that
+cannot go red on a missing envelope reads as coverage and is not.
+
+{decision_frame}
+
+Return "blocked" (with evidence) when the default branch is broken under you, a
+dependency issue is unmerged, or CI infrastructure fails — after retrying
+enough to be sure it is not your change.
+
+Report — post exactly this JSON as a comment on the issue, its first line the
+literal plaintext dev-report (never an HTML comment: the sanitizer deletes it),
+read the comment back to its end, then return the same JSON as your final
+message with no prose around it:
+
+{
+  "issue": <n>,
+  "status": "done | rework | blocked | needs_decision",
+  "branch": "claude/issue-<n>-<slug>",
+  "pr": "<url or null>",
+  "premise_still_valid": true,
+  "summary": "what was implemented, 2-4 sentences",
+  "tests": "commands run + pass/fail evidence (real output excerpts)",
+  "open_questions": [
+    { "question": "…", "options": ["A …", "B …"], "recommendation": "A, because …" }
+  ],
+  "out_of_scope_findings": ["filed as #<n>: one-line description"]
+}
+
+Use "rework" for a partial result you know is incomplete (say why in summary).
+
+Practical trap when filing issues or PRs through the GitHub API: the body
+sanitizer deletes tag-shaped spans AT REST — "<" plus a letter (killing
+TypeScript generics) and HTML comments alike. Write a space after each "<"
+and read the stored body back when a snippet is load-bearing.
+````

--- a/skills/objectstack-pm-dispatch/rules/dev-template.md
+++ b/skills/objectstack-pm-dispatch/rules/dev-template.md
@@ -4,8 +4,7 @@
 You are a developer agent. You were dispatched with exactly ONE GitHub issue.
 Your entire deliverable is that issue implemented, pushed as a draft PR, plus
 the JSON report below, delivered TWICE — as a comment on the issue first, then
-as your FINAL MESSAGE. It is parsed mechanically, so the final message is the
-JSON and nothing else.
+as your FINAL MESSAGE.
 
 {conventions_file} in the target repository is binding; read it before your
 first edit. It overrides this template wherever they disagree. The rules that
@@ -45,22 +44,23 @@ test runs exhaust it. Binding:
 1. Serialize the heavy phase. Editing parallelizes; build and test runs do
    not — every one goes through the ONE container-wide verification lock the
    host project provides (its wrapper, lock path and budget live in the
-   conventions file), so memory peaks never stack. Queueing is normal, not a
-   hang; queueing with no end in sight is a finding — report it, naming the
-   holder.
+   conventions file), so memory peaks never stack. The lock does not promise
+   an idle machine: it excludes only work routed through it (gate runs,
+   installs and dev servers are not), so wall-clock readings taken under a
+   hold are shared-box readings. Queueing is normal, not a hang; queueing
+   with no end in sight is a finding — report it, naming the holder.
 2. Cap the heap: prefix heavy commands with
    NODE_OPTIONS=--max-old-space-size=4096 (raise only with a reason).
 3. Scope, don't sweep. Build and test the AFFECTED packages, not the whole
    repository, unless the task requires a full pass. Cap test parallelism
    (e.g. vitest --maxWorkers=2).
 4. Clean up: after the PR is up, delete the worktree's dependency tree and
-   then remove the worktree. Leftover dependency trees exhaust the container's
-   disk, which fails as confusingly as running out of memory. Do NOT force the
-   removal as the opening move: with dependencies already deleted, a refusal
-   to remove means something in there is uncommitted — your own unpushed work,
-   or another agent's tree if the path was mistyped — and that refusal is the
-   container's only guard for it. Read the refusal first; force only after the
-   answer is genuinely "nothing".
+   then remove the worktree. Do NOT force the removal as the opening move:
+   with dependencies already deleted, a refusal to remove means something in
+   there is uncommitted — your own unpushed work, or another agent's tree if
+   the path was mistyped — and that refusal is the container's only guard for
+   it. Read the refusal first; force only after the answer is genuinely
+   "nothing".
 5. NEVER kill a process by name. A name-matched kill (pkill -f <tool>) can take
    down a parallel agent's run. Record the PID of what you start and operate on
    that PID only (kill $PID; liveness via kill -0 $PID). A pgrep pattern can
@@ -76,6 +76,11 @@ Definition of done, in order:
 - A DRAFT PR to the default branch, body starting "Fixes #<n>" — or "Part of
   {backlog_repo}#<n>" cross-repo — in the language the repository's PRs use.
 - Tear down anything you started (dev servers, temporary processes) by PID.
+
+A size ratchet the project enforces (a line or token ceiling on a file) is
+paid only by deleting content: a re-wrap is not payment (densifying that adds
+no content is a repair, not a purchase), and a ceiling is raised only by the
+maintainer — nothing left to delete ⇒ report "blocked".
 
 Rejection-class tests assert the envelope, not the throw. For any test whose
 point is that bad input is REFUSED, the minimum assertion set is the error's
@@ -120,6 +125,6 @@ Use "rework" for a partial result you know is incomplete (say why in summary).
 
 Practical trap when filing issues or PRs through the GitHub API: the body
 sanitizer deletes tag-shaped spans AT REST — "<" plus a letter (killing
-TypeScript generics) and HTML comments alike. Write a space after each "<"
+TypeScript generics). Write a space after each "<"
 and read the stored body back when a snippet is load-bearing.
 ````


### PR DESCRIPTION
Fixes #14300

Round 2 of the skills catalog optimization program #14292 member card for `skills/objectstack-pm-dispatch` (maintainer mandate 2026-09-02, verbatim: 「审核所有的 skills，进行全面的优化。」). Round 1 (PR #14444, merged 08:57Z) took the diet, 14,549 → 11,567 tokens. This PR is the entry + `rules/` split plus the two deferrals the seat's ACCEPT on #14444 recorded (PMD-H-01, the #14229 two-delta sync). Session: https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1 — branch `claude/issue-14300-pm-dispatch-split`, base `ca48cf37`, head `fef3b449`.

## Rulings this PR runs on (one line each, verbatim and untranslated)

- **#14296 item 1 = A, item 4 = A** (comment 5507419465, 2026-09-02 09:27Z): 「14361 你不处理；14261 现在就改，定位为 minor；其他同意」 — 「其他同意」 adopts 1A/2A/3A/4A: splits of a large single `SKILL.md` into entry + `rules/` are authorized under three conditions (≥10% off the whole package in the same PR; every new file's ceiling pinned at its landed count; a split is never a channel for added prose); item 4: the published `objectstack-pm-dispatch` package stays, ≤10k target, developer template externalized to `rules/`.
- **#14568 = A** (comment 5511939006, 2026-09-02 15:22Z): 「同意」 — condition (a) is the programme-level anti-growth guard: the split PR itself lands token-neutral or negative on the package (a positive delta is refused), the package arithmetic is the programme's flights together, and the reading applies identically to the pm-dispatch split.

## Files

`skills/objectstack-pm-dispatch/SKILL.md` (entry, hand-edited), `skills/objectstack-pm-dispatch/rules/dev-template.md` (new — text moved out of the entry), `scripts/check-skills-token-ratchet.mjs` (exactly two rows: the new file's row, the entry's re-lock). `.claude/skills/pm-dispatch/**`, `.claude/agents/os-dev.md`, `CLAUDE.md` read as the comparison oracle only; `scripts/pm/check-skill-line-ratchet.mjs`, generated files, `content/docs/releases/**` untouched; no other package. Frontmatter untouched ⇒ `skills/README.md` / `content/docs/ai/skills-reference.mdx` need no regeneration (`check:skill-docs` says "Skill docs in sync"). `Clause-②: no` — protocol text, no platform contract; clause ① applies (a tier-mandated surface) and the skill-face review is the seat's, in-seat. Governed `skills/**` ⇒ this PR stays DRAFT; review requests are the seat's step.

## Token account (convention `ceil(utf8 bytes / 4)`, `node scripts/check-skills-token-ratchet.mjs`)

| file | before (origin/main `ca48cf37`) | after (`fef3b449`) | ceiling row |
|:--|--:|--:|:--|
| `SKILL.md` (entry) | 11,567 | **9,708** | 14,549 → **9,708** (re-locked at the landed count; zero headroom) |
| `rules/dev-template.md` | — | **1,838** | **new row, 1,838** (pinned at the landed count; zero headroom) |
| **package** (every file under `skills/objectstack-pm-dispatch/`; no generated file) | 11,567 | **11,546** | **−21** |

Per commit, each droppable on its own: the split commit `da02d0c1` lands the package at 11,556 (−11); the sync commit `fef3b449` at 11,546 (−10 more). Whole bundle: 157,662 → 157,641; ratcheted subtotal 141,214 / 165,532 → 141,193 / 162,529.

### The three conditions, with numbers

- **(a) ≥10% off the package — programme-level (#14568 = A).** This PR: −21 (token-neutral-or-negative holds; nothing positive). Programme on this package: round 1 (#14444) −2,982 + this PR −21 = **−3,003 against 14,549 before the programme = −20.6%**.
- **(b) new-file ceilings pinned at landed counts.** One row added: `skills/objectstack-pm-dispatch/rules/dev-template.md` = 1,838. The entry's row lowered 14,549 → 9,708 (a re-lock of this file only). No stub existed, so no row is dropped (see PMD-H-01). No other row changes; `--self-test` 64 cases pass.
- **(c) a split is never a channel for added prose.** Every sentence in `rules/dev-template.md` is a sentence moved from `SKILL.md`, minus the deletions listed below, plus exactly one heading and one placeholder line (`{decision_frame}`) that marks where the gate-pinned block re-enters the pasted prompt; the entry carries one pointer line for the moved section. The two #14229 deltas are additions in the sync commit, not in the split commit, and are funded by deletions in the same package (below).

### Item 4: the entry ends ≤ 10,000 tokens — measured 9,708.

## File map (old section → new file, tokens)

| old (`origin/main`) | new | tokens |
|:--|:--|--:|
| `## The developer-agent operating template` intro + the 4-backtick `text` fence (`:626-799`), minus the "When to STOP instead of coding" block | `rules/dev-template.md` — H1 + the same fence with `{decision_frame}` on the line the block occupied (`rules/dev-template.md:99`) | 1,838 after the sync commit (1,768 as moved) |
| the "When to STOP instead of coding" block inside that fence (`:704-755`) — the `published-dev` copy that `check:skill-frame-sync` pins to `skills/objectstack-pm-dispatch/SKILL.md` by file path | stays in the entry, in a `text` fence under the same heading (`SKILL.md:620-660`; anchors now at `:633` "Analyze every option on four fixed axes:" and `:654` "Justify your recommendation on all four axes") | 633, unchanged |
| `**Report contract.**` paragraph | stays in the entry (`SKILL.md:662-668`) — it is the PM's reading of the report, not the dev's | 135, unchanged |
| everything else | unchanged in the entry | — |

### The frame fence — measured, and what the script would do

`scripts/check-skill-frame-sync.mjs` `COPIES` binds `published-pm` (start "**and analyze every option on the four fixed axes below.**", binding "recommendation must be justified on … axes") and `published-dev` (start "Analyze every option on four fixed axes:", binding "Justify your recommendation on … axes") to `skills/objectstack-pm-dispatch/SKILL.md` by file path. Had the `published-dev` block moved into `rules/` with the template, `analyzeCopy()` would have read the entry, matched the start anchor 0 times and recorded "could not extract the decision frame: the declaring sentence anchor matched 0 time(s), expected exactly 1" — a hard **FAIL** (exit 1), not a vacuous pass; the anti-dormancy scan (`FINGERPRINTS` over `.claude` and `skills`, `rules/` included) would additionally have flagged `rules/dev-template.md` as an undeclared copy (`/fixed axes/i`). `check:skill-frame-freshness` imports the same `COPIES` and extractor and would have failed the same way. So both copies stay in the entry (`:534` and `:633`), neither block is edited, and the rules file carries no fingerprint: the sync gate now reports "36 markdown files scanned for undeclared copies" (35 at base — the new file is scanned and clean). Both gates green on every commit.

## Per-move / per-deletion 落点 | before | after (keyed by finding id)

| id | 落点 before → after | before | after |
|:--|:--|:--|:--|
| PMD-B-01 (split) | `SKILL.md:626-799` → `rules/dev-template.md:1-130` + `SKILL.md:620-668` | one 2,584-token template section paid in every session | the template is loaded when a dispatch is composed; the entry keeps the pointer, the gate-pinned block and the report contract |
| PMD-B-01 funding (split overhead +77 bytes: rules H1, placeholder line, entry fence, the pointer's link) | `SKILL.md:382` "- The issue is already claimed; do not touch its assignee." → deleted; `SKILL.md:388` "Return ONLY the JSON report defined in the operating procedure." → deleted; template intro sentence "It is written to stand alone: an agent with no prior context and no custom agent type can follow it." → deleted | three restatements the dev read twice in one prompt (template rule 2; the template's top paragraph; step 5's "a general-purpose agent with the template is equivalent") | the template's own sentences carry each rule once; split commit −11 |
| #14229 delta 1 (verify-lock non-guarantee) | `rules/dev-template.md:44-50` (resource rule 1) | "so memory peaks never stack. Queueing is normal…" — the guarantee list with no non-guarantee, the exact belief the oracle corrects | "The lock does not promise an idle machine: it excludes only work routed through it (gate runs, installs and dev servers are not), so wall-clock readings taken under a hold are shared-box readings." (+45) |
| #14229 delta 2 (ratchet funding discipline) | `rules/dev-template.md:80-83`, after the definition of done | no ratchet text in the published template | "A size ratchet the project enforces (a line or token ceiling on a file) is paid only by deleting content: a re-wrap is not payment (densifying that adds no content is a repair, not a purchase), and a ceiling is raised only by the maintainer — nothing left to delete ⇒ report "blocked"." (+63) |
| sync funding | `SKILL.md:381` "{conventions_file} in that repository is binding — read it before your first edit." → deleted; `SKILL.md:383-385` the needs_decision bullet → deleted; `:382` "Never merge anything." → deleted; `rules/dev-template.md:7-8` "It is parsed mechanically, so the final message is the JSON and nothing else." → deleted; `:128` "and HTML comments alike" → deleted; `:57-58` "Leftover dependency trees exhaust the container's disk, which fails as confusingly as running out of memory." → deleted | five verbatim restatements (the template's binding-file paragraph, the "When to STOP" rule, rule 4, the report block's final-message and HTML-comment rules) and one published-only rationale sentence the oracle's rule 4 does not carry | the rule survives in each case; sync commit −10 |
| PMD-H-01 | — | premise false (below) | — |

Rule 4's remaining lines were re-flowed after the deletion (bytes unchanged, 7,352 before and after the re-flow — a re-wrap moves no tokens and pays nothing).

## PMD-H-01 — disposition: no stub exists; nothing to delete, no row to drop

Evidence: `git ls-tree -r --name-only origin/main -- skills/objectstack-pm-dispatch/` lists exactly `SKILL.md`; `git grep -n "objectstack-pm-dispatch/evals" origin/main` returns nothing; `CEILINGS` in `scripts/check-skills-token-ratchet.mjs` carries no `evals/` row for this package (the audit's package-facts table said the same: "`evals/` absent; 8 of 11 published packages have one"). The audit's PMD-H-01 proposed ADDING an `evals/README.md` (+300, new ceiling); #14296 item 2 = A deletes planned-eval stubs and adds none, which forecloses that addition. Neither a stub to delete (the PR #14585 / #14578 precedent does not apply) nor a real fixture to keep: `premise_false: PMD-H-01 — the deferral presumed an evals stub; the package has never had an evals/ directory`.

## #14229 sync — the two deltas and their oracle lines (`.claude/agents/os-dev.md` on `origin/main`, verbatim and untranslated)

1. Resource rule 1, `os-dev.md:85-88`: 「同一张清单的非保证:**它不保证机器空闲** —— 只排除经这个入口进来的工作,`check:*` 门禁、install、dev server 不走它,与持锁同核并跑(脚本每次获取与 VERDICT 行同述此界)⇒ 锁下墙钟绝对值一律是共享盒读数,不是安静机器承诺。」 → template resource rule 1 (`rules/dev-template.md:47-50`).
2. Standard clauses, `os-dev.md:323-327`: 「**付行数棘轮的唯一合法货币是删内容。** 维护者 2026-08-17 裁「⛔ re-wrap(折行合并)不得用作筹行 —— 棘轮治理的是内容体量,行数只是机读代理,新增以删减付账;密度优化仅随净减内容的 PR 顺带」、2026-08-29 裁「筹行(为内容购买行数)⛔ vs 独立密度修复(无内容购买)允许」。分界只问折行有没有为新增内容买行 —— 门禁分不出两种 net-0;⛔ 不买内容的密度修复是修复,不要当筹行拒掉。删不出等量内容 ⇒ 报 `blocked`,⛔ 不抬 ceiling(人工地板)。」 → one template paragraph after the definition of done (`rules/dev-template.md:80-83`), carrying the rule without this repo's dates or quoted rulings (the #5451 route-B convention the published copy follows).

The other three hunks of #14229 (the model-pin comment shrunk to a pointer, the stash mechanism delegated to `CLAUDE.md`, the footer measurement delegated to `AGENTS.md`) are internal delegations with no published counterpart — the published template carries no model pin, already states the stash ban with its mechanism (round 1 F-03), and has no footer text — so nothing to sync there.

## premise_false

- `PMD-H-01 — the deferral presumed an evals stub; the package has never had an evals/ directory` (evidence above).
- `check:doc-links / check:published-readme-links verify the cross-file link — neither gate walks skills/**`: `check-published-readme-links.mjs` sweeps published package READMEs and the spec prompt files; `check-doc-anchors.mjs` sweeps `content/**` plus the root `README.md` / `ARCHITECTURE.md`; no `check:doc-links` script exists. The one cross-file link (`SKILL.md:622` → `./rules/dev-template.md`) was verified by hand: the target exists at that relative path, and the only intra-file anchor (`#the-developer-agent-operating-template`, `SKILL.md:354`) still resolves because the heading stays in the entry.
- `check:skill-examples marks travel with their fences` — the package has zero `os:check` marks and zero TypeScript fences (audit package facts), so nothing travelled; the gate is not in this PR's derived family.
- `check:skill-identifier-liveness Leg 2` — re-measured: `BINDINGS` has no row for this file (8 registered sections, none in `skills/objectstack-pm-dispatch/**`); the three Leg 1 exemptions (`backlogRepo`, `conventionsFile`, `routingLabelPrefix`) are in the Configuration table, which did not move, and still resolve.
- `check:role-word` — 0 occurrences of the word in both files before and after (`grep -c` = 0; the file is not in the baseline), so the count could not move.

## Gates — head `fef3b449` (union re-derived AFTER the last move: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, no paths, "gate list derived from the tree of 'objectstack-ai/objectstack' at commit fef3b449"; 25 commands; every exit code captured by redirect before any pipe)

| gate | exit | the gate's own verdict line |
|:--|--:|:--|
| `node scripts/check-skills-token-ratchet.mjs` (+ `--self-test`) | 0 | "✓ check-skills-token-ratchet: 32 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted." — rows `skills/objectstack-pm-dispatch/SKILL.md 9708 / 9708 (+0)`, `skills/objectstack-pm-dispatch/rules/dev-template.md 1838 / 1838 (+0)`; self-test "64 cases pass" |
| `pnpm check:skill-frame-sync` | 0 | "✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files · 4 axes: business-need → long-term-soundness → ai-authoring-safety → startup-scope-discipline · binding sentence present in all 4; 4 count mention(s) agree; 36 markdown files scanned for undeclared copies." |
| `pnpm check:skill-frame-freshness` (dispatch-named, not in the derived family) | 0 | "✓ check-skill-frame-freshness: the decision frame in this tree is current with origin/main (fetched just now)." |
| `pnpm check:skill-identifier-liveness` | 0 | "check-skill-identifier-liveness OK — Leg 1: 465 citation(s) over 42 published file(s) checked against 93441 implementation word tokens (3 ledgered exemption(s)); Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s)." |
| `pnpm check:skill-compatibility` | 0 | "✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 79 workspace packages" |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | "✅ Skill docs in sync" |
| `pnpm check:role-word` | 0 | "check-role-word: OK, no new occurrences of the reserved word." |
| `pnpm check:corpus-claim-drift` | 0 | "check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling." |
| `pnpm check:doc-authoring` | 0 | "✓ doc authoring guard: sibling-package prose ids hold the baseline — 831 pinned site(s) across 231 file(s) …" |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | first pass exit 3 "PREREQUISITE NOT MET — the workspace package `@objectstack/formula` is not built"; after `pnpm --filter '@objectstack/lint...' --filter '@objectstack/formula...' run build` under `scripts/pm/os-verify-lock.sh` (`OS_VERIFY_LOCK_SLOT=issue-14300-r2`; "VERDICT command-exit 0 · held the lock 130s · waited 406s"): "✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 422 files / 1364 TS blocks judged clean by @objectstack/formula." |
| `pnpm check:pm-governed-merges` | 0 | "✓ check-governed-merges --self-test: 243 assertions …" + "live: the real generator declared 9 output(s) and certified this tree" |
| `pnpm check:pm-dispatch-gates` | 0 | "✓ dispatch-gates self-test: 1240 cases pass." |
| `pnpm check:ratchet-remedy-authority` | 0 | "OK  check-ratchet-remedy-authority: 184 scripts swept … 12 mark the expanding remedy ⛔ MAINTAINER-ONLY …" |
| `pnpm check:watch-hint-literal` | 0 | "✓ check-watch-hint-literal: 45 declaration(s) across 4 rostered name(s) …" |
| `node scripts/check-ci-filter-parity.mjs` | 0 | "OK: all 130 declared cross-package glob(s) (92 unique) are covered …" |
| `node scripts/check-cross-package-test-inputs.mjs` / `pnpm check:cross-package-test-inputs` | 0 / 0 | "OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob." |
| `node scripts/check-shard-attestation.mjs` | 0 | "✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s)." |
| `node scripts/pm/bare-root-worklist.mjs --self-test` | 0 | "OK  self-test: 57 live row(s), 49 unreachable as spelled, 49 recorded verdict(s) …" |
| `pnpm check:agent-test-spelling` · `pnpm check:bash32-floor` · `pnpm check:cli-command-ids` · `pnpm check:entry-guard` · `pnpm check:parse-guard` · `pnpm check:pnpm-filter-targets` | 0 each | bash32-floor "✓ … 26 tracked shell file(s) … name no bash 4+ construct …"; cli-command-ids "✓ … 315 command-id literal(s) across 112 file(s) … all resolve"; entry-guard "✓ check:entry-guard: 199 scripts/ file(s) …"; parse-guard "✓ check:parse-guard: 198 scripts/ file(s) …"; pnpm-filter-targets "✓ check:pnpm-filter-targets: 142/181 `--filter` occurrence(s) … resolve" |
| `pnpm check:nul-bytes` (any edit) | 0 | "check-nul-bytes: OK (scanned 7996 text file(s) — 7996 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes)." |
| `node scripts/check-empty-changeset.mjs --base origin/main` | 0 | "✓ No empty-frontmatter changeset introduced by this diff (0 declaring changeset(s) added)." |

**NOT MEASURED:** `node scripts/check-test-completeness.mjs` — exit 3, "PREREQUISITE NOT MET — this gate grades a saved `turbo run test` log, and no log was named" (CI tees the log; by design not measurable here). The derivation printed its stale-tree notice ("1 commit(s) behind origin/main, 1 file(s) it derives from CHANGED") — `origin/main` moved by one unrelated commit (`20b88391`) after the branch was cut; neither `scripts/check-skills-token-ratchet.mjs` nor `skills/objectstack-pm-dispatch/**` moved on `main` (`git log HEAD..origin/main -- …` empty before both pushes), so no merge was needed.

Baseline on the untouched worktree at `ca48cf37`, before the first move: ratchet "skills/objectstack-pm-dispatch/SKILL.md 11567 / 14549 (-2982)", frame-sync "35 markdown files scanned", liveness "41 published file(s)".

## Changeset

`skip-changeset`: nothing is released by any package — the diff touches `skills/**` and one root gate script's ceiling rows; `scripts/check-empty-changeset.mjs`'s route for a PR that releases nothing is this label, and it confirms no changeset is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_