### PR TITLE
test(pm): pin the contract-review tier's one-value-site promise in the dispatch-gates self-test (#14616)

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -15427,6 +15427,99 @@ function selfTest() {
   t('the suspect table is not empty and every entry carries its reason', SUSPECT_TIER_GLOBS.length > 0 && SUSPECT_TIER_GLOBS.every((g) => g.glob && g.why));
   t('the contract-review tier constant is a non-empty model id — the single source the PM skill points at', typeof CONTRACT_REVIEW_TIER === 'string' && CONTRACT_REVIEW_TIER.length > 0);
 
+  // ── The tier constant's ONE-VALUE-SITE promise (#14616) ───────────────────
+  //
+  // The PM skill promises 「档位单源 … 模型升级只改一行一个文件」, and until this
+  // case that promise was held by a `git grep` someone remembers to run. The
+  // drift it exists against is measured rather than feared: the value was
+  // spelled in SIXTEEN places across these same two roots — prose, mandate
+  // rows, header comments, self-test fixtures — while the promise above read
+  // as true, and a promise held by hand is what one model refresh erases.
+  //
+  // What is counted is the constant's OWN VALUE, read from the constant at run
+  // time. Never a second literal — that spelling would BE the site the case
+  // exists to forbid — and never a family or prefix pattern: a prefix scan
+  // would be a family floor the human floor has not granted, and would itself
+  // be a second spelling of the model family inside this tool, i.e. the defect
+  // recreated by its own guard. One consequence is deliberate: the verbatim
+  // maintainer rulings quoted in the skill's main file and in its dispatch
+  // runbook name the model FAMILY as prose, not as this value, so an
+  // exact-value scan does not reach them — and it must not be widened until it
+  // would, because a gate that can demand edits to a maintainer's recorded
+  // words is the wrong gate.
+  //
+  // Both roots are DERIVED, not spelled: the skill tree is the directory of the
+  // mandate glob naming its main file, and the tool tree is this module's own
+  // directory. The population therefore follows a rename instead of rotting,
+  // and no fresh path literal enters this file's own watch-hint set — measured
+  // over its own source, 23 hints before this case and 23 after (`maskSelfTests`
+  // blanks this body, which is what makes a fixture path here inert at all).
+  //
+  // The walk takes its base directory as an argument, so the same code can be
+  // pointed at a scratch copy of the population to prove it reds; a second
+  // spelling anywhere under the roots is reported as `file:line`, never as a
+  // bare count a reader cannot act on.
+  const tierValueSites = (base, roots, value) => {
+    const sites = [];
+    const perRoot = [];
+    for (const root of roots) {
+      // An empty root would join to `base` and walk the whole tree — the one
+      // way this case could turn a rename into a pass instead of a red.
+      if (!root || root === '.') {
+        sites.push('(a scan root derives from a mandate glob that is no longer in the table)');
+        perRoot.push(0);
+        continue;
+      }
+      let scanned = 0;
+      const stack = [root];
+      while (stack.length > 0) {
+        const rel = stack.pop();
+        const abs = join(base, rel);
+        if (!existsSync(abs)) {
+          sites.push(`${rel} (MISSING)`);
+          continue;
+        }
+        if (statSync(abs).isDirectory()) {
+          for (const name of readdirSync(abs)) stack.push(join(rel, name));
+          continue;
+        }
+        scanned += 1;
+        readFileSync(abs, 'utf8')
+          .split('\n')
+          .forEach((text, i) => {
+            for (let at = text.indexOf(value); at >= 0; at = text.indexOf(value, at + value.length)) {
+              sites.push(`${rel}:${i + 1}`);
+            }
+          });
+      }
+      perRoot.push(scanned);
+    }
+    return { sites, perRoot };
+  };
+  const tierOwnRel = relative(ROOT, fileURLToPath(import.meta.url));
+  // The definition line is FOUND, not remembered: the one line carrying both
+  // the constant's name and its value. A line number in a case name that has
+  // to be maintained by hand is the same species of promise as the one this
+  // case replaces.
+  const tierDefLine =
+    readFileSync(join(ROOT, tierOwnRel), 'utf8')
+      .split('\n')
+      .findIndex((l) => l.includes('CONTRACT_REVIEW_TIER') && l.includes(CONTRACT_REVIEW_TIER)) + 1;
+  const tierRoots = [
+    dirname(MANDATORY_TIER_GLOBS.find((g) => g.glob === '.claude/skills/pm-dispatch/SKILL.md')?.glob ?? ''),
+    dirname(tierOwnRel),
+  ];
+  const tierScan = tierValueSites(ROOT, tierRoots, CONTRACT_REVIEW_TIER);
+  t(
+    `the tier constant's VALUE is spelled in exactly ONE site under ${tierRoots.join(' + ')} — ` +
+      `${tierScan.perRoot.join('+')} files read, the definition at ${tierOwnRel}:${tierDefLine} the only one allowed ` +
+      `(found: ${tierScan.sites.join(', ') || 'NOTHING — this scan reached no occurrence at all'})`,
+    tierDefLine > 0 &&
+      tierScan.perRoot.every((n) => n > 0) &&
+      tierScan.sites.length === 1 &&
+      tierScan.sites[0] === `${tierOwnRel}:${tierDefLine}`,
+  );
+
   // ── The change set derived from git (#9320) ───────────────────────────────
   //
   // These build a real repository and run the real derivation over it. A

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -15496,13 +15496,19 @@ function selfTest() {
     }
     return { sites, perRoot };
   };
-  const tierOwnRel = relative(ROOT, fileURLToPath(import.meta.url));
+  // `relative` from `node:path` is SHADOWED inside this function — a fixture
+  // string a few thousand lines up binds that name — so the repo-relative
+  // spelling comes from ROOT, the prefix every sibling case here already joins
+  // against. A prefix that stops holding yields an empty root, which the walk
+  // above reports rather than turning into a pass.
+  const tierOwnAbs = fileURLToPath(import.meta.url);
+  const tierOwnRel = tierOwnAbs.startsWith(ROOT) ? tierOwnAbs.slice(ROOT.length) : '';
   // The definition line is FOUND, not remembered: the one line carrying both
   // the constant's name and its value. A line number in a case name that has
   // to be maintained by hand is the same species of promise as the one this
   // case replaces.
   const tierDefLine =
-    readFileSync(join(ROOT, tierOwnRel), 'utf8')
+    readFileSync(new URL(import.meta.url), 'utf8')
       .split('\n')
       .findIndex((l) => l.includes('CONTRACT_REVIEW_TIER') && l.includes(CONTRACT_REVIEW_TIER)) + 1;
   const tierRoots = [


### PR DESCRIPTION
Fixes #14616

One `check:pm-dispatch-gates` self-test case, in the tier region of `selfTest()` in `scripts/pm/dispatch-gates.mjs`. Nothing else in the tree moves: the constant is untouched, `.claude/skills/pm-dispatch/**` is untouched, `scripts/pm/check-skill-line-ratchet.mjs` is untouched. One file, two commits (the second is the fix for a shadowed import the first battery found — see "What the first run measured" below).

## The case

**What it walks.** Two roots, both DERIVED rather than spelled:

- the pm-dispatch skill tree — `dirname()` of the mandate glob that names the skill's main file, taken from `MANDATORY_TIER_GLOBS`, a population this module already declares;
- this tool's own directory — its own module path, taken relative to `ROOT`.

At this commit that resolves to `.claude/skills/pm-dispatch + scripts/pm`, 21+17 files. Derivation is not decoration: the population follows a rename instead of rotting into a scan that reaches nothing, and a mandate glob renamed away leaves an empty root, which the walk reports as a failure rather than quietly walking the whole tree.

**What it counts.** Occurrences of the tier constant's own VALUE, read from the constant at run time. Never a second literal — that spelling would itself BE the extra site the case exists to forbid — and never a family or prefix pattern: a prefix scan would be a family floor the human floor has not granted, and would itself be a second spelling of the model family inside this tool, i.e. the defect recreated by its own guard.

**What it reports.** Every occurrence as `file:line`, in the case name, next to the definition site it expected and the per-root file counts. A bare count is not actionable; what a reader gets on failure is the offending list. It is one `t()` call, non-vacuous by construction: it fails if either root scanned zero files, if the definition line cannot be found, if the count is not 1, or if the one site is not the definition line. The definition line is FOUND (the single line carrying both the constant's name and its value), never written down, so the case keeps no hand-maintained line number of its own.

Its green line, from the run below:

```
✓ the tier constant's VALUE is spelled in exactly ONE site under .claude/skills/pm-dispatch + scripts/pm — 21+17 files read, the definition at scripts/pm/dispatch-gates.mjs:7955 the only one allowed (found: scripts/pm/dispatch-gates.mjs:7955)
```

## The two guards named in the filing, both measured

**1. Watch-hint extraction and the declared population.** This module's own `extractWatchHints` run over its own source, before and after the edit:

```
before (2aa8456c): 23 hints
after  (da479d10): 23 hints      — identical sets, element for element
```

The case adds no path literal to that set, for two independent reasons, and the belt-and-braces is deliberate: the roots are derived rather than spelled at all, and `maskSelfTests` blanks the `selfTest()` body before extraction, which is what makes any fixture path in that region inert in the first place. The module's `inherited-population` declaration is untouched and still true — `declaredInheritedPopulation()` over the edited source still answers `.github/workflows` and nothing else, so a follower inherits exactly what it inherited before.

The two gates that guard this class agree, each quoted from its own verdict line:

```
✓ check-watch-hint-literal: 45 declaration(s) across 4 rostered name(s) -- ROOT_DIR_WATCH_HINTS 29, ROOT_FILE_WATCH_HINTS 9, ROOT_WATCH_HINTS 2, DECLARED_WATCH_HINTS 5 -- every one an array of quoted literals inside its own statement, every rostered name non-empty, and no unrostered spelling of the idiom in the tree.
✓ check:declared-population-live — 158 of 202 famil(ies) declare a path population, and every one of them reaches this tree's 8006 tracked file(s).
```

**2. The verbatim maintainer quotes stay out of reach.** The rulings quoted in the skill's main file and in `references/dispatch-runbook.md` name the model FAMILY as prose, not this constant's value, so an exact-value scan does not match them — measured rather than assumed: the scan over both roots returns exactly one site, and neither quote is in it. The case's own comment records this as a boundary to keep, not an accident to fix later: a gate that could demand edits to a maintainer's recorded words is the wrong gate, so the case must not be widened until it would reach them.

## Red then green — predict-then-mutate

Prediction, written before the run: a SECOND spelling of the value anywhere under the two roots reds exactly this one case, and the failure names the offending path. No build leg to get wrong — a plain `.mjs` script, read from source.

The mutation is a file inside the population carrying the value, written from the constant at run time (the mutation script never spells it either); the restore is its removal, proved by observing state and not by any step's exit code. All three legs ran back to back in one hold of the container's shared verify lock, at `da479d10`:

```
=== LEG 1: green on the committed implementation ===
LEG1_EXIT=0
  ✓ the tier constant's VALUE is spelled in exactly ONE site under .claude/skills/pm-dispatch + scripts/pm — 21+17 files read, the definition at scripts/pm/dispatch-gates.mjs:7955 the only one allowed (found: scripts/pm/dispatch-gates.mjs:7955)
✓ dispatch-gates self-test: 1241 cases pass.

=== LEG 2: mutate — a SECOND spelling of the value inside the population ===
MUT_PRESENT=yes
MUT_VALUE_HITS=1
MUT_BYTES=23
LEG2_EXIT=1
  ✗ the tier constant's VALUE is spelled in exactly ONE site under .claude/skills/pm-dispatch + scripts/pm — 21+18 files read, the definition at scripts/pm/dispatch-gates.mjs:7955 the only one allowed (found: scripts/pm/dispatch-gates.mjs:7955, scripts/pm/.tier-value-site-mutation.tmp:1)
✗ dispatch-gates self-test: 1 of 1241 case(s) failed.

=== LEG 3: restore, then MEASURE the restored tree ===
MUT_ABSENT=yes
GIT_STATUS_LINES=0
GIT_DIFF_HEAD_LINES=0
LEG3_EXIT=0
  ✓ the tier constant's VALUE is spelled in exactly ONE site under .claude/skills/pm-dispatch + scripts/pm — 21+17 files read, the definition at scripts/pm/dispatch-gates.mjs:7955 the only one allowed (found: scripts/pm/dispatch-gates.mjs:7955)
✓ dispatch-gates self-test: 1241 cases pass.
```

Four things that pair proves rather than asserts. The mutation reached disk before anything was read (`MUT_VALUE_HITS=1`, 23 bytes) — the leg was not a no-op reading healthy output. The file count moved 21+17 to 21+18, so the walk really opened it. Exactly ONE of 1241 cases failed, so the mutation reddened this case and nothing else. And the restore leg was MEASURED, not assumed: the file is gone, the tree is clean by `git status` and by `git diff HEAD`, and the full battery is green again on the restored tree.

Case count, which is the other half of "one case": `1240 cases pass` at `2aa8456c` before the edit, `1241 cases pass` after — one case added, none replaced.

## What the first run measured (kept, because it is the interesting part)

The first battery on this branch died on the new case's first statement:

```
TypeError: relative is not a function
```

`relative` from `node:path` is bound to a fixture STRING inside `selfTest()`, thousands of lines above the new case, so the shadowing is invisible at parse time and `node --check` passes. The second commit takes the repo-relative spelling from `ROOT` instead — the prefix every sibling case in this battery already joins against — and reads its own source through `import.meta.url`. A ROOT prefix that stops holding leaves an empty root, which the walk reports rather than turning into a pass. The rest of the scope was then swept for the same trap: `relative` and `resolve` are the only two `node:path` names shadowed anywhere in that function, and this case uses neither now.

## Gates

Family re-derived AFTER the edit from the tool itself (`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, no hand-written path list), run one at a time under the shared verify lock, each exit code captured before any pipe. Head sha for every row: **`da479d10`** (`git rev-parse --short HEAD` in that run; the tree was clean and no commit followed).

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm check:pm-dispatch-gates` | 0 | `✓ dispatch-gates self-test: 1241 cases pass.` (legs 1 and 3) |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 45 declaration(s) across 4 rostered name(s) … no unrostered spelling of the idiom in the tree.` |
| `pnpm check:declared-population-live` | 0 | `✓ check:declared-population-live — 158 of 202 famil(ies) declare a path population, and every one of them reaches this tree's 8006 tracked file(s).` |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 199 scripts/ file(s) — every entry guard goes through invoked-as.mjs; 150 export bindings, 150 of them inert on import (0 known-unsafe, SHRINK-ONLY).` |
| `pnpm check:parse-guard` | 0 | `✓ check:parse-guard: 198 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `node scripts/check-self-test-wired.mjs` | 0 | `✓ check-self-test-wired: every one of the 164 script(s) CI runs that ship a --self-test has that self-test run by CI.` |
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 130 declared cross-package glob(s) (92 unique) are covered by core or crosspkg …` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `pnpm check:cross-package-test-inputs` | 0 | same verdict line as the direct invocation above |
| `node scripts/check-shard-attestation.mjs` | 0 | `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).` |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 425 file(s) · 5645 bare -- token(s) · 1380 launcher-rooted run(s) · 9 separator(s) JUDGED …` |
| `pnpm check:bash32-floor` | 0 | `✓ check-bash32-floor: 26 tracked shell file(s) … name no bash 4+ construct outside a comment …` |
| `pnpm check:cli-command-ids` | 0 | `✓ check-cli-command-ids: 315 command-id literal(s) across 112 file(s) outside packages/cli all resolve to a real command path …` |
| `pnpm check:pnpm-filter-targets` | 0 | `✓ check:pnpm-filter-targets: 142/181 --filter occurrence(s) across 32 file(s) resolve against 79 workspace package(s) …` |
| `node scripts/check-nul-bytes.mjs` | 0 | `check-nul-bytes: OK (scanned 7999 text file(s) … no raw ASCII control bytes).` |
| `node scripts/check-test-completeness.mjs` | 3 | **NOT MEASURED** — see below |

`check:nul-bytes` is not in the derived family; it is run on every edit by standing rule, and the diff was separately swept for raw control bytes before the first commit.

## NOT MEASURED

- **`node scripts/check-test-completeness.mjs` — exit 3, prerequisite not met.** Its own text: `check-test-completeness: PREREQUISITE NOT MET — this gate grades a saved turbo run test log, and no log was named`, and, for exactly this situation, `running the family locally, record this gate as NOT MEASURED. It is not a red, and there is nothing here to fix.` Recorded as NOT MEASURED, not as a failure and not as a pass.
- **Repo-wide `pnpm lint` — narrowed deliberately, with the narrowing's own evidence.** CI's Lint and Repo Gates runs the whole farm regardless; locally this ran targeted, and the three readings a narrowing owes are all here: (1) the population came from git, not from a guess — `git diff --name-only 2aa8456c HEAD` returns exactly one path, `scripts/pm/dispatch-gates.mjs`; (2) the file count came from eslint's own `--format json` output, `FILES_LINTED=1` with that same absolute path in it, so the run was not a green over zero files; (3) untouched files cannot move, because this repo's single `eslint.config.mjs` says of itself that it `never enables type-aware linting (no parserOptions.project, no typed @typescript-eslint rules) for ANY file`, so no verdict on a file this diff did not touch depends on this diff. Result: `ESLINT_EXIT=0`, `ERRORS=0 WARNINGS=0`.
- **CI itself.** Reported at draft-PR time by contract; the gate jobs on this PR had not converged when this body was written.

---

Draft on purpose: `scripts/pm/**` is governed, so this stays draft and merges by hand; review requests are the PM seat's step. `skip-changeset` is applied — the diff is one self-test case in a script under `scripts/pm/**` and publishes nothing from any package, which is the shape `scripts/check-empty-changeset.mjs` enumerates for the label (`It releases nothing (.github/, .claude/, skills/, docs/, content/, examples/, tests-only, and the like) -> ... apply the 'skip-changeset' label`). The label was written as a union with what the PR already carried and read back afterwards: `size/s, skip-changeset`, nothing stripped.

Session: https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1