### PR TITLE
docs(scripts): make check-agent-model-declared's header the stated home of the model-resolution order

### DIFF
--- a/scripts/check-agent-model-declared.mjs
+++ b/scripts/check-agent-model-declared.mjs
@@ -11,8 +11,10 @@
 // model does this role run on" a property of whoever happened to dispatch it, at
 // whatever moment their own session was on, rather than a property of the role —
 // and it changes with no signal, mid-term, invisibly. (`CLAUDE_CODE_SUBAGENT_MODEL`
-// outranks every other step, including this gate's own pin — see
-// `.claude/agents/os-dev.md` for the full order and both adjacent traps.)
+// outranks every other step, including this gate's own pin — the first of the two
+// adjacent traps; the allowlist fallback below is the second. This header is the
+// home of that full order and of both traps, and `.claude/agents/os-dev.md` carries
+// only the `model: opus` pin plus a pointer back here.)
 //
 // A second, smaller nuance in that same order: a value blocked by the
 // organization's `availableModels` allowlist does NOT fall back to the frontmatter


### PR DESCRIPTION
Fixes #14232

Comment-only: one sentence in the header of `scripts/check-agent-model-declared.mjs`. One file, no behaviour change, no code change.

## Premise, verified on `origin/main`

PR #14229 (merged 2026-09-02, commit `909a44171`) shrank `.claude/agents/os-dev.md`'s model-pin comment to a two-line pointer. At merge base `bd4aa4e49` that comment is lines 12-13. Quoted verbatim and untranslated below; its delimiters are an HTML-comment open/close pair, **described in words rather than written literally** per this repo's body-sanitizer discipline (fences do not protect that shape):

```text
`model: opus` 是刻意钉死的下限,不是上限 —— PM 的逐单定档优先。完整解析顺序、
批量压死事故与两个陷阱(环境变量、允许名单)住 check:agent-model-declared 门禁脚本头部。
```

That pointer's destination is this gate's header — while this gate's header still said "see `.claude/agents/os-dev.md` for the full order and both adjacent traps". The two comments pointed at each other and neither claimed to be the home. **Premise holds.**

Nothing was ever unreachable. The header already carries all three pieces the deferral promised: the four-step resolution order (lines 5-9), the env var outranking every other step including this gate's own pin (the sentence being fixed), and the org-allowlist fallback landing on the INHERITED model (lines 17-20, unchanged). The defect was only that the sentence described the pre-#14229 file.

## The one sentence — before / after

Before, lines 13-15 on `origin/main`:

```js
// and it changes with no signal, mid-term, invisibly. (`CLAUDE_CODE_SUBAGENT_MODEL`
// outranks every other step, including this gate's own pin — see
// `.claude/agents/os-dev.md` for the full order and both adjacent traps.)
```

After, lines 13-17:

```js
// and it changes with no signal, mid-term, invisibly. (`CLAUDE_CODE_SUBAGENT_MODEL`
// outranks every other step, including this gate's own pin — the first of the two
// adjacent traps; the allowlist fallback below is the second. This header is the
// home of that full order and of both traps, and `.claude/agents/os-dev.md` carries
// only the `model: opus` pin plus a pointer back here.)
```

The header now names both adjacent traps in place — the env-var one in the sentence itself, the allowlist one by pointing at the paragraph directly below that already states it — and claims itself as the home instead of deferring to a file that no longer holds the text.

Line-width convention preserved: the file's existing maximum comment width is 84 characters; the replacement's widest line is also 84 (measured, not estimated).

⛔ No edit to `.claude/agents/os-dev.md` (governed, and it already points here). ⛔ No other file touched.

## `skip-changeset`

Applied. `scripts/` releases nothing: the root manifest is `"private": true`, and `scripts/check-agent-model-declared.mjs` appears in no package's `files[]`. `scripts/check-empty-changeset.mjs` has nothing to say about a PR that adds no changeset at all — its GREEN 3 case asserts "an untouched `.changeset` dir must not even be read".

## Gates

Every command ran through `scripts/pm/os-verify-lock.sh` (slot `issue-14232`), each exit code captured by redirect **before** any pipe. All measured at `c529a40a` — the final commit on this branch, and the same tree the union was derived from.

| Command | Exit | The gate's own verdict line |
|:---|:---|:---|
| `pnpm check:agent-model-declared` (the script's own suite — it has a `--self-test` flag, already wired into this script name) | 0 | `✓ check-agent-model-declared self-test: 18 cases pass.` + `✓ check-agent-model-declared: 1 agent definition(s) under .claude/agents/ all declare a model` |
| `pnpm exec eslint --no-inline-config scripts/check-agent-model-declared.mjs` | 0 | no output; `os-verify-lock: VERDICT command-exit 0` |
| `pnpm check:nul-bytes` | 0 | `✓ check-nul-bytes --self-test: 75 assertions over a temp git repo (real scan() path)` |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 199 scripts/ file(s) — every entry guard goes through invoked-as.mjs` |
| `pnpm check:parse-guard` | 0 | `✓ check:parse-guard: 198 scripts/ file(s) — every TypeScript parse goes through ts-parse.mjs.` |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |

### Full union, re-derived after the edit

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` — no hand-fed paths; the script took its own change set from the merge base (`1 path(s) vs merge base bd4aa4e49`, three-dot semantics) and asserted the repo: *"--repo 'objectstack-ai/objectstack' checked against this checkout's 'origin' remote — it holds."* It derived **16 commands**; all 16 were run.

| Command | Exit | Verdict |
|:---|:---|:---|
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 130 declared cross-package glob(s) (92 unique) are covered by core or crosspkg…` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 25 package(s) read outside themselves, all declared…` |
| `node scripts/check-shard-attestation.mjs` | 0 | `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).` |
| `node scripts/check-test-completeness.mjs` | **3** | **NOT MEASURED** — see below |
| `node scripts/pm/bare-root-worklist.mjs --self-test` | 0 | `OK  self-test: 57 live row(s), 49 unreachable as spelled, 49 recorded verdict(s) — none stale…` |
| `pnpm check:agent-model-declared` | 0 | as above |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 425 file(s) · 5645 bare -- token(s)…` |
| `pnpm check:bash32-floor` | 0 | `✓ check-bash32-floor: 26 tracked shell file(s) … name no bash 4+ construct…` |
| `pnpm check:cli-command-ids` | 0 | `✓ check-cli-command-ids: 315 command-id literal(s) across 112 file(s) … all resolve` |
| `pnpm check:cross-package-test-inputs` | 0 | `OK: 25 package(s) read outside themselves, all declared…` |
| `pnpm check:entry-guard` | 0 | as above |
| `pnpm check:parse-guard` | 0 | as above |
| `pnpm check:pm-dispatch-gates` | 0 | `✓ dispatch-gates self-test: 1240 cases pass.` |
| `pnpm check:pnpm-filter-targets` | 0 | `✓ check:pnpm-filter-targets: 142/181 --filter occurrence(s) across 32 file(s) resolve…` |
| `pnpm check:ratchet-remedy-authority` | 0 | `OK  check-ratchet-remedy-authority: 184 scripts swept…` |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 45 declaration(s) across 4 rostered name(s)…` |

**`check-test-completeness` = NOT MEASURED, not a red and not a flake.** Exit 3, and the gate says so itself in the text it printed:

> `check-test-completeness: PREREQUISITE NOT MET — this gate grades a saved 'turbo run test' log, and no log was named.`
> "Arrived here from the gate family `scripts/pm/dispatch-gates.mjs` derives? That list names this script with NO argument, which is this branch. There is no local log to hand it, so the local reading for this gate is NOT MEASURED. ⛔ It is not a red, and there is nothing here to fix."

CI tees the log and passes the path on every invocation, so this branch is unreachable there.

The derivation also noted 9 further families that "apply once this card's changeset exists". This PR carries `skip-changeset` and writes no changeset, so those 9 have no path to match.

## `premise_false`

**None.** Every premise the dispatch stated held as written:

- os-dev.md's model-pin comment is the two-line pointer at lines 12-13 — held (quoted above).
- The gate header's sentence still deferred to os-dev.md — held (it is the `before` block).
- The header already documents both adjacent traps and the full order — held; that is why this is a comment reword and not a code change.
- `scripts/check-agent-model-declared.mjs` has a `--self-test` flag, and `package.json` wires it into `check:agent-model-declared` — held, so the script's own suite is measured rather than NOT MEASURED.
- `scripts/` is not governed surface and releases nothing — held.

One dispatch detail was off by two lines and is recorded rather than corrected: the sentence is at lines **13-15** on `origin/main`, not "around line 15" alone — the parenthetical spans three lines. No consequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_