### PR TITLE
fix(plugin-auth): bind the dev-admin seed's operator-provisioning ticket to more than the seed address (#14373)

### DIFF
--- a/.changeset/operator-provisioning-ticket-binding.md
+++ b/.changeset/operator-provisioning-ticket-binding.md
@@ -1,0 +1,53 @@
+---
+"@objectstack/plugin-auth": minor
+---
+
+fix(plugin-auth): bind the dev-admin seed's operator-provisioning ticket to more than the seed address, so a concurrent stranger posting that address cannot ride the window (#14373)
+
+`AuthManager.stageOperatorProvisioning` staged its ticket keyed on
+`email.trim().toLowerCase()` alone. The address is **not a secret** —
+`admin@objectos.ai` is the documented default and the boot banner prints it
+(with the password) once the seed completes — so "the address is the
+operator's own" did not narrow the attacker set the way it would for an
+unguessable value. A stranger's own concurrent `POST /sign-up/email` for that
+same address, arriving while the ticket was staged, would satisfy an
+email-only peek at both admission seams (the `disableSignUp` before-hook and
+`validateAudienceAdmission`'s `creationClass` computation) and be admitted as
+the `operator` class too — and since a unique-email constraint lets only one
+of the two concurrent `signUpEmail` calls actually land, a stranger who won
+that race would not merely read as the operator, their row would BECOME the
+account at that address. The safety this rested on — "milliseconds, and
+`NODE_ENV==='development'` only" — was true today, but both are properties of
+the *caller*, not of what the ticket asserted.
+
+`stageOperatorProvisioning(email)` now also generates a random, unguessable
+ticket value (128 bits from WebCrypto's `getRandomValues`, matching the
+existing `resolvePasswordHasher` salt convention) and returns it.
+`AuthPlugin.maybeSeedDevAdmin` threads that value into the SAME `signUpEmail`
+call's body, under the new `AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD`
+key — an unrecognized key that better-auth's `signUpEmailBodySchema` (`.and(
+z.record(z.string(), z.any()))`) lets ride through untouched, so it never
+becomes a declared `sys_user` field. `isOperatorProvisioning(email, ticket)`
+now requires an exact match on both; a missing, wrong-typed, or mismatched
+ticket reads as "not provisioning" — the same as no ticket staged at all,
+with no email-only fallback. This converts what was a timing argument
+("the window is short and dev-only") into a structural one: admission now
+asks "did THIS process's own boot command make THIS exact call", and a
+stranger's request carries no value that was ever transmitted anywhere for
+them to replay, however precisely they time the window.
+
+**Public surface**: `stageOperatorProvisioning`'s return type widens from
+`void` to `string` (additive — any existing caller ignoring the return value
+is unaffected), `isOperatorProvisioning` gains an optional second parameter
+(omitting it now always reads as "not provisioning", which is the safe
+default), and the class gains one new static member,
+`AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD`. `AuthManager` is
+barrel-public (`@objectstack/plugin-auth`'s `index.ts` re-exports it in
+full), so this is graded `minor` rather than `patch`.
+
+**Not touched**: the JSDoc documenting the in-process trust assumption on
+`stageOperatorProvisioning` (already accurate on landed `main`), and the
+method's barrel-public location (a published-surface removal is a decision
+card, not a dev-agent edit) — both dispositions triage already closed out on
+this card. Whether the bootstrap window should count humans or logins is
+`#14349`'s question, not touched here.

--- a/packages/plugins/plugin-auth/src/auth-manager.ts
+++ b/packages/plugins/plugin-auth/src/auth-manager.ts
@@ -2066,8 +2066,17 @@ export class AuthManager {
           // carve-out: an app that seeds people makes the bootstrap probe
           // answer "populated" before the seed ever runs. Cheap synchronous
           // check first, so the ticket path costs no I/O.
+          // [#14373] The email alone no longer admits — see
+          // `stageOperatorProvisioning`'s doc. `ctx.body` is the vendor's own
+          // zod-validated body, which keeps any key outside the declared
+          // schema (`signUpEmailBodySchema.and(z.record(...))`), so the
+          // in-process seed call's ticket field survives here untouched.
           const signUpEmail = typeof ctx?.body?.email === 'string' ? ctx.body.email : undefined;
-          if (this.isOperatorProvisioning(signUpEmail) || (await this.isBootstrapCreation())) {
+          const provisioningTicket = ctx?.body?.[AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD];
+          if (
+            this.isOperatorProvisioning(signUpEmail, provisioningTicket) ||
+            (await this.isBootstrapCreation())
+          ) {
             ctx.context.__osDisableSignUpOrig = ep.disableSignUp;
             ep.disableSignUp = false;
           }
@@ -3809,8 +3818,12 @@ export class AuthManager {
    * [#14157] Addresses the deployment's OWN boot command is provisioning right
    * now — see {@link stageOperatorProvisioning} for why this exists and why it
    * is not the bootstrap probe.
+   *
+   * [#14373] Keyed by email, but admission also requires the per-stage
+   * `ticket` below — see {@link stageOperatorProvisioning} for why the
+   * address alone stopped being enough.
    */
-  private pendingOperatorProvisioning = new Map<string, { stagedAtMs: number }>();
+  private pendingOperatorProvisioning = new Map<string, { stagedAtMs: number; ticket: string }>();
 
   /**
    * Deliberately short. The window this covers is a single in-process
@@ -3818,6 +3831,19 @@ export class AuthManager {
    * only the floor under a caller killed between the two.
    */
   private static readonly OPERATOR_PROVISIONING_STAGE_TTL_MS = 60 * 1000;
+
+  /**
+   * [#14373] Body field the ticket's random value rides on for the single
+   * in-process `signUpEmail` call it admits. `signUpEmailBodySchema` in
+   * better-auth is `z.object({...}).and(z.record(z.string(), z.any()))`, so
+   * an unrecognized key survives validation on `ctx.body` untouched — this
+   * rides that catch-all rather than a declared `additionalFields` column,
+   * so it never becomes a `sys_user` field. The name is deliberately
+   * internal-looking; nothing public ever sends this key, so its presence in
+   * a request is itself the credential this seam demands (see
+   * {@link isOperatorProvisioning}).
+   */
+  static readonly OPERATOR_PROVISIONING_TICKET_FIELD = '__osOperatorProvisioningTicket';
 
   /**
    * Page size of the bootstrap population probe ({@link isBootstrapCreation}).
@@ -3887,17 +3913,23 @@ export class AuthManager {
    * OAuth flows redirect to the error URL carrying the same code).
    *
    * [#11767] The vendor's second argument — the endpoint context — is
-   * deliberately UNREAD. Both probes below take their own ctx-independent data
-   * path, because sourcing this gate's I/O from the request context is exactly
-   * what made the bootstrap bypass inert (see {@link isBootstrapCreation}).
-   * The parameter is kept so the signature still reads as the vendor's.
+   * deliberately UNREAD for the population probes below: both take their own
+   * ctx-independent data path, because sourcing THEIR I/O from the request
+   * context is exactly what made the bootstrap bypass inert (see {@link
+   * isBootstrapCreation}). [#14373] carves one narrow exception: the operator
+   * ticket's random value (see `stageOperatorProvisioning`), which travels
+   * only as a `ctx.body` field and has no other channel to reach this gate —
+   * `data.user` here is `internalAdapter.createUser`'s own input, not the raw
+   * request body, so it never carries an undeclared key. That is a plain read
+   * of an already-parsed value, not a re-derived I/O probe, so it does not
+   * reopen what #11767 closed.
    */
   private async validateAudienceAdmission(
     data: {
       user?: Record<string, unknown>;
       source?: { action?: string; method?: string; oauth?: { providerId?: string } };
     },
-    _ctx?: unknown,
+    ctx?: unknown,
   ): Promise<{ error: string; errorDescription?: string } | undefined> {
     try {
       // link-account / provider sign-in concern an EXISTING user's identity,
@@ -3911,7 +3943,15 @@ export class AuthManager {
       // because the seed reaches better-auth through the same `signUpEmail`
       // API a person's sign-up does. See `stageOperatorProvisioning` for why
       // this is a declared ticket and not a wider bootstrap probe.
-      const creationClass: AudienceCreationClass = this.isOperatorProvisioning(email)
+      // [#14373] …and why email alone no longer decides it: the ticket's
+      // random value must also match, read off the SAME endpoint context the
+      // `disableSignUp` before-hook already reads `ctx.body.email` from
+      // (`getCurrentAuthEndpointContext()` — one context per request, shared
+      // across the before/after hooks and this validateUserInfo callback).
+      const provisioningTicket = (ctx as { body?: Record<string, unknown> } | undefined)?.body?.[
+        AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD
+      ];
+      const creationClass: AudienceCreationClass = this.isOperatorProvisioning(email, provisioningTicket)
         ? 'operator'
         : classifyCreationMethod(data?.source, {
             enterpriseOAuthProviderIds: this.enterpriseOAuthProviderIds(),
@@ -4229,15 +4269,58 @@ export class AuthManager {
    * `NODE_ENV==='development'`, the ticket names ONE address, the caller
    * clears it in a `finally`, and anything that outlives that is pruned by
    * {@link OPERATOR_PROVISIONING_STAGE_TTL_MS}.
+   *
+   * ## [#14373] Why the address alone stopped being the whole ticket
+   *
+   * The address is **not a secret**: `admin@objectos.ai` is the documented
+   * default and the boot banner prints it (with the password) once the seed
+   * completes. "The address is the operator's own" is true but does not
+   * narrow the attacker set the way it would for an unguessable value — a
+   * stranger's OWN concurrent `POST /sign-up/email` for that same address,
+   * arriving while this ticket is staged, would satisfy an email-only peek at
+   * BOTH admission seams and get admitted as `operator` class: past the
+   * `disableSignUp` bypass, and (since the stamp only cares about the
+   * creation class) potentially email-verified at creation too — a stranger
+   * would not merely read as the operator, their row would BECOME the
+   * account at that address, since a unique-email constraint lets only one of
+   * the two concurrent `signUpEmail` calls actually land. Milliseconds and
+   * `NODE_ENV==='development'` are true today, but both are properties of the
+   * *caller*, not of what the ticket asserts.
+   *
+   * So the ticket now also carries a random, unguessable `ticket` string,
+   * returned here and threaded by the caller into the SAME `signUpEmail`
+   * call's body under {@link OPERATOR_PROVISIONING_TICKET_FIELD} — see
+   * `AuthPlugin.maybeSeedDevAdmin`. {@link isOperatorProvisioning} requires an
+   * exact match on both email AND this ticket, so admission now asks "did
+   * THIS process's own boot command make THIS exact call" rather than "does
+   * the address match" — a stranger's request, however precisely it times
+   * the window, carries no value that was ever transmitted anywhere for them
+   * to replay. Not a stronger *guess* — a different question.
    */
-  stageOperatorProvisioning(email: string): void {
+  stageOperatorProvisioning(email: string): string {
     this.prunePendingOperatorProvisioning();
-    this.pendingOperatorProvisioning.set(email.trim().toLowerCase(), { stagedAtMs: Date.now() });
+    const ticket = this.generateOperatorProvisioningTicket();
+    this.pendingOperatorProvisioning.set(email.trim().toLowerCase(), { stagedAtMs: Date.now(), ticket });
+    return ticket;
   }
 
   /** [#14157] Drop the ticket staged by {@link stageOperatorProvisioning}. */
   clearOperatorProvisioning(email: string): void {
     this.pendingOperatorProvisioning.delete(email.trim().toLowerCase());
+  }
+
+  /**
+   * [#14373] 128 bits from WebCrypto, hex-encoded — same `getRandomValues`
+   * baseline `resolvePasswordHasher`'s WebContainer salt uses, so this stays
+   * portable to hosts without `node:crypto`. Never persisted, never logged,
+   * never sent anywhere but the one in-process `signUpEmail` body call that
+   * consumes it.
+   */
+  private generateOperatorProvisioningTicket(): string {
+    const bytes = (globalThis as any).crypto.getRandomValues(new Uint8Array(16));
+    let hex = '';
+    for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, '0');
+    return hex;
   }
 
   /**
@@ -4247,11 +4330,19 @@ export class AuthManager {
    * creation, so a one-shot read here would admit at the first seam and refuse
    * at the second. The ticket's lifetime is bounded by its owner's `finally`
    * and by the TTL instead.
+   *
+   * [#14373] `ticket` is REQUIRED to match the value {@link
+   * stageOperatorProvisioning} returned — see that method's doc for why the
+   * address alone is no longer sufficient. A missing, wrong-typed, or
+   * mismatched ticket reads as "not provisioning", the same as no ticket at
+   * all; there is no email-only fallback path.
    */
-  isOperatorProvisioning(email: unknown): boolean {
+  isOperatorProvisioning(email: unknown, ticket?: unknown): boolean {
     if (typeof email !== 'string' || email.trim() === '') return false;
     this.prunePendingOperatorProvisioning();
-    return this.pendingOperatorProvisioning.has(email.trim().toLowerCase());
+    const entry = this.pendingOperatorProvisioning.get(email.trim().toLowerCase());
+    if (!entry) return false;
+    return typeof ticket === 'string' && ticket === entry.ticket;
   }
 
   private prunePendingOperatorProvisioning(): void {

--- a/packages/plugins/plugin-auth/src/auth-plugin.ts
+++ b/packages/plugins/plugin-auth/src/auth-plugin.ts
@@ -1871,9 +1871,25 @@ export class AuthPlugin implements Plugin {
       // accounts. The ticket says what this creation IS (the deployment's own
       // boot command provisioning its admin — the operator class) for exactly
       // this address, and is cleared whatever happens.
-      this.authManager.stageOperatorProvisioning(email);
+      //
+      // [#14373] The address alone is not the ticket — it is the documented
+      // default and the boot banner prints it, so it does not narrow a
+      // concurrent stranger's guess. `stageOperatorProvisioning` also returns
+      // a random value that exists only in this process's memory; threading
+      // it into THIS SAME call's body (under `AuthManager
+      // .OPERATOR_PROVISIONING_TICKET_FIELD`) is what a stranger's own
+      // concurrent sign-up for this address cannot replay, however it times
+      // the window — see that method's doc for the full argument.
+      const provisioningTicket = this.authManager.stageOperatorProvisioning(email);
       try {
-        await api.signUpEmail({ body: { email, password, name } });
+        await api.signUpEmail({
+          body: {
+            email,
+            password,
+            name,
+            [AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD]: provisioningTicket,
+          },
+        });
       } finally {
         this.authManager.clearOperatorProvisioning(email);
       }

--- a/packages/plugins/plugin-auth/src/dev-admin-seed-credential-gate.test.ts
+++ b/packages/plugins/plugin-auth/src/dev-admin-seed-credential-gate.test.ts
@@ -484,4 +484,112 @@ describe('[#14157] the dev-admin seed gates on a LOGIN, not on user rows', () =>
 
     expect(await bootstrapStatus(mountBootstrapStatus(manager))).toEqual({ hasOwner: true });
   });
+
+  it('⑨ [#14373] binding beats timing: a stranger posting the seed address WHILE the ticket is open is still refused', async () => {
+    const engine = await bootEngine();
+    await seedPeople(engine, 13);
+    const manager = makeManager(engine);
+
+    // Open the exact window the seed's own `signUpEmail` call sits inside —
+    // staged directly, not via `maybeSeedDevAdmin`, so the window's OPEN for
+    // as long as this test needs it rather than for one async call's
+    // duration. This is the precondition the vulnerability needed: the
+    // ticket for SEED_EMAIL exists, unconsumed, right now.
+    const ticket = manager.stageOperatorProvisioning(SEED_EMAIL);
+    try {
+      // A stranger's own concurrent request for the SAME address, carrying
+      // NONE of the ticket — the only shape available to an outside caller,
+      // since the ticket value is generated in-process and never
+      // transmitted anywhere a stranger could observe or replay it. Before
+      // #14373 this peeked `isOperatorProvisioning(SEED_EMAIL)` as `true` on
+      // email alone and was admitted as the `operator` class — same as the
+      // seed itself.
+      const strangerRes = await manager.handleRequest(
+        new Request(`${BASE}${AUTH_BASE}/sign-up/email`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', origin: BASE },
+          body: JSON.stringify({
+            email: SEED_EMAIL,
+            password: 'Attacker!Passw0rd-14373',
+            name: 'Attacker',
+          }),
+        }),
+      );
+      expect(strangerRes.status, `stranger sign-up: ${await strangerRes.clone().text()}`).toBe(403);
+      expect(((await strangerRes.json()) as { code?: string }).code).toBe(SELF_REGISTRATION_CLOSED);
+      expect(
+        await readRows(engine, 'sys_account'),
+        'the ticket window must not have let the stranger create ANY account',
+      ).toEqual([]);
+
+      // POSITIVE CONTROL, same still-open window: the correctly-bound call
+      // IS admitted — the fix narrows admission to the ticket holder, it
+      // does not also break the seed's own path. This calls `signUpEmail`
+      // directly (as `maybeSeedDevAdmin` does), not the seed's OWN separate
+      // post-creation `email_verified` write (#11343, a step in
+      // `auth-plugin.ts` outside the admission gate this card touches), so
+      // admission is what this proves — creation, and that the credential
+      // actually authenticates.
+      const api = (await manager.getApi()) as unknown as {
+        signUpEmail(input: { body: Record<string, unknown> }): Promise<unknown>;
+      };
+      await api.signUpEmail({
+        body: {
+          email: SEED_EMAIL,
+          password: SEED_PASSWORD,
+          name: 'Dev Admin',
+          [AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD]: ticket,
+        },
+      });
+      const accounts = await readRows(engine, 'sys_account');
+      expect(accounts.map((a) => a.provider_id)).toEqual(['credential']);
+      const seeded = (await readRows(engine, 'sys_user')).find(
+        (u) => String(u.email).toLowerCase() === SEED_EMAIL,
+      );
+      expect(seeded, 'the correctly-bound call must have created the seed address').toBeTruthy();
+      const signInRes = await manager.handleRequest(
+        new Request(`${BASE}${AUTH_BASE}/sign-in/email`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', origin: BASE },
+          body: JSON.stringify({ email: SEED_EMAIL, password: SEED_PASSWORD }),
+        }),
+      );
+      expect(
+        signInRes.status,
+        `the correctly-bound credential must actually authenticate: ${await signInRes.clone().text()}`,
+      ).toBeLessThan(300);
+    } finally {
+      manager.clearOperatorProvisioning(SEED_EMAIL);
+    }
+  });
+
+  it('⑨ (b) [#14373] a wrong ticket value is refused exactly like no ticket at all', async () => {
+    const engine = await bootEngine();
+    await seedPeople(engine, 13);
+    const manager = makeManager(engine);
+
+    manager.stageOperatorProvisioning(SEED_EMAIL);
+    try {
+      const res = await manager.handleRequest(
+        new Request(`${BASE}${AUTH_BASE}/sign-up/email`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', origin: BASE },
+          body: JSON.stringify({
+            email: SEED_EMAIL,
+            password: 'Attacker!Passw0rd-14373',
+            name: 'Attacker',
+            // A guess at the field's shape — the wrong VALUE, not a missing
+            // field. The credential is the exact random value, not merely
+            // knowledge of the field's name (which is visible in this very
+            // source file).
+            [AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD]: 'guessed-ticket-value',
+          }),
+        }),
+      );
+      expect(res.status).toBe(403);
+      expect(((await res.json()) as { code?: string }).code).toBe(SELF_REGISTRATION_CLOSED);
+    } finally {
+      manager.clearOperatorProvisioning(SEED_EMAIL);
+    }
+  });
 });


### PR DESCRIPTION
Fixes #14373

## What changed

Disposition 3 only, per triage's ruling (14373#issuecomment-5504337158) and the claim comment's carry-forward: **bind the dev-admin seed's operator-provisioning ticket to more than the seed address.**

`AuthManager.stageOperatorProvisioning(email)` staged its ticket keyed on `email.trim().toLowerCase()` alone. The address is **not a secret** — `admin@objectos.ai` is the documented default and the boot banner prints it (with the password) once the seed completes — so "the address is the operator's own" did not narrow the attacker set the way it would for an unguessable value. A stranger's own concurrent `POST /sign-up/email` for that same address, arriving while the ticket was staged, would satisfy an email-only peek at BOTH admission seams (the `disableSignUp` before-hook at `auth-manager.ts:~2069` and `validateAudienceAdmission`'s `creationClass` computation at `~3940`) and be admitted as the `operator` class too — and since a unique-email constraint lets only one of the two concurrent `signUpEmail` calls actually land, a stranger who won that race would not merely read as the operator, **their row would become the account at that address**. The safety this rested on — "milliseconds, and dev-only" — was true today, but both are properties of the *caller*, not of what the ticket asserted.

`stageOperatorProvisioning(email)` now also generates a random, unguessable ticket value (128 bits from WebCrypto's `getRandomValues`, matching the existing `resolvePasswordHasher` WebContainer-salt convention) and **returns it**. `AuthPlugin.maybeSeedDevAdmin` threads that value into the SAME `signUpEmail` call's body, under a new `AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD` key — an unrecognized key that better-auth's `signUpEmailBodySchema` (`z.object({...}).and(z.record(z.string(), z.any()))`) lets ride through untouched, so it never becomes a declared `sys_user` field or a DB column. `isOperatorProvisioning(email, ticket)` now requires an **exact match on both**; a missing, wrong-typed, or mismatched ticket reads as "not provisioning" — same as no ticket at all, no email-only fallback.

This converts a timing argument into a structural one: admission now asks "did THIS process's own boot command make THIS exact call", not "does the address match". A stranger's request carries no value that was ever transmitted anywhere for them to replay, however precisely they time the window.

## Why the nonce, not `name`

Triage offered two implementation routes: bind to the seed's own `name`, or thread a nonce through the sign-up body. I measured both against the actual threat (a concurrent stranger, not merely "harder to guess"):

- `name` defaults to `'Dev Admin'` (`OS_SEED_ADMIN_NAME` env override), and — unlike `email`/`password` — is **not** printed by the boot banner (`AuthManager.devSeedResult` only carries `{email, password}`; confirmed by reading `serve.ts`'s banner code and `format.ts`). So it is not observable from a live deployment's own output. But this is an open-source codebase: `'Dev Admin'` is exactly as discoverable by reading `auth-plugin.ts` as `admin@objectos.ai` is by reading `walled-owner-verification-path.ts`. Binding to `name` alone would narrow the window against an attacker who knows the printed email but hasn't read the source — a real but narrow-obscurity improvement, not a structural one. Per the card's own instruction, I did not write "harder to guess" as "impossible."
- The random ticket value is generated in-process via WebCrypto and **never transmitted anywhere** — not printed, not logged, not derivable from source (it's per-boot, not a fixed default). No amount of source-reading recovers it. That is the structural fix the triage comment was pointing at ("converts a timing argument into a structural one").

## Is the binding value a secret? (asked directly)

**Yes, and that is the load-bearing difference from the seed address.** Traced end to end, what it travels with and where it can surface:

- **Minted**: `AuthManager.generateOperatorProvisioningTicket()` — 16 bytes from `crypto.getRandomValues`, hex-encoded, held only in the local `ticket` variable and in the `pendingOperatorProvisioning` in-memory `Map` (keyed by email, TTL-pruned, cleared in a `finally`). Nothing durable — no table, no file, no env var.
- **Carried**: as one extra JSON field, `AuthManager.OPERATOR_PROVISIONING_TICKET_FIELD` (`__osOperatorProvisioningTicket`), riding **inside the same `POST /sign-up/email` request body** `AuthPlugin.maybeSeedDevAdmin` was always going to send — alongside `email`, `password`, and `name`. It does not get its own call or its own channel.
- **Consumed**: better-auth's `signUpEmailBodySchema` is `z.object({...}).and(z.record(z.string(), z.any()))` — the declared fields get validated and become the `sys_user`/`sys_account` rows; the catch-all lets the ticket field ride through the parse untouched, but it is read ONLY by `isOperatorProvisioning`'s comparison and is never assigned to any column, never passed to `internalAdapter.createUser`.
- **Printed?** No. `AuthManager.devSeedResult` — the only thing the boot banner reads (see `serve.ts`'s banner code, `format.ts`) — carries exactly `{email, password}`. The ticket is never part of that struct, so it cannot reach stdout, a log line, or any other deployment-observable output by any path this diff touches.

So the fix does not make the window *narrower* (a better guess still fails against the seed address) — it removes the window's public observable *entirely*: there is nothing about this deployment's own output that a stranger could read to learn the value, at any point in its lifetime. Contrast with binding to `name` (above), which would only have been "harder to guess," since `name` defaults to a fixed, source-readable string.

## Region split held

Per the claim comment's declared region (origin/main line numbers): `auth-manager.ts` `:2070`/`:3810`/`:3912-3914`/`:4233`/`:4238`/`:4251`; `auth-plugin.ts` `:1874`.

**Corrected measurement** (`git diff -U0 origin/main...HEAD`, exact changed old-side lines, zero context padding — the first PR-body draft measured this with `-U3`-style context bleed and understated the gap at "22 lines"; this is the precise figure and it supersedes that one): `auth-manager.ts` touches old-side lines `2068,2070` / `3811,3813,3821` / `3890-3893,3900,3914` / `4231,4233,4235,4242,4249,4251,4254`; `auth-plugin.ts` touches `1874,1876`. Against PR #14600's declared hunks (`auth-manager.ts` 14/990/1336/1368/1399/1425/**2105**/2921/3067/3089/**4327-4337**/4340/4354/4554-4591; `auth-plugin.ts` 784-788 only): closest pairs are **2070 vs 2105 = 35 lines** and **4254 vs 4327 = 73 lines** in `auth-manager.ts`, and **~1090 lines** apart in `auth-plugin.ts` (784-788 vs 1874-1876). This matches the PM seat's independent re-measurement exactly. Disjoint throughout; split holds.

## Not in this PR (per triage's ruling)

- Disposition 1 (document the trust assumption) — already landed on `main`; the JSDoc above `stageOperatorProvisioning` states it in full. No-op, not touched.
- Disposition 2 (move the method off the barrel-public surface) — a published-surface removal, the human floor (`删除已发布能力`) with ADR-0049 enforce-or-remove discipline owed. Not a dev-agent edit.
- Whether the bootstrap window should count humans or logins is `#14349`'s question, in the decision inbox.

## Public surface (Clause ②: **yes**) — exact signature deltas, and why `grep export` cannot see them

`AuthManager` is barrel-public (`packages/plugins/plugin-auth/src/index.ts`: `export * from './auth-manager.js'`), so every public member of the class is on the package's public surface even though nothing in this diff adds a **new** top-level `export` statement — `git diff -U0 origin/main... | grep -E '^\+\s*export '` returns **zero output**, and reading only that grep would wrongly conclude Clause ② is `no`. The actual surface change is on the SIGNATURES of two already-exported class members, which a line-prefix grep for the `export` keyword structurally cannot see (the keyword lives once, on the `class AuthManager` declaration itself, not repeated per member):

| Member | Before (`origin/main`) | After (this PR) |
|---|---|---|
| `stageOperatorProvisioning` | `stageOperatorProvisioning(email: string): void` | `stageOperatorProvisioning(email: string): string` |
| `isOperatorProvisioning` | `isOperatorProvisioning(email: unknown): boolean` | `isOperatorProvisioning(email: unknown, ticket?: unknown): boolean` |
| *(new member)* | — | `static readonly OPERATOR_PROVISIONING_TICKET_FIELD: string` |

- `stageOperatorProvisioning`'s return type widens `void` → `string` — additive; any existing caller that ignores the return value is unaffected, but a caller that TYPE-CHECKS against `void` (unusual, but possible in a strict wrapper) would need to update.
- `isOperatorProvisioning` gains an optional second parameter — additive at the call site (omitting it now always reads "not provisioning," the safe default), but it is a signature widening on a public method, which is exactly what Clause ② asks about regardless of backward-compatibility.
- One new static member is added to the public class surface.

Graded `minor` in the changeset (confirmed: `.changeset/operator-provisioning-ticket-binding.md` frontmatter is `"@objectstack/plugin-auth": minor` — this repo's convention for a barrel-public signature change, not `patch`). `needs:contract-review` is on both carriers: issue #14373 (pre-hung by the claim comment) and this PR (confirmed present via a read-back after adding it).

## Docs drift — three pages checked, none touched

Per PM's pointer, checked whether this diff falsifies any sentence on the three pages that reach `AuthManager` as a symbol:

- **`content/docs/kernel/contracts/auth-service.mdx`** — grepped for `AuthManager`/`stageOperatorProvisioning`/`isOperatorProvisioning`/`operator provisioning`/`dev-admin`/`seed`. One hit: a line contrasting `api` vs `getApi()` naming `AuthManager` generically ("the shipped `plugin-auth` registers an `AuthManager`, which has no `api` member at all"). Still true — this diff adds no `api` member and does not touch that contrast. No change needed.
- **`content/docs/kernel/services-checklist.mdx`** — one hit, a table row: "**Implementation**: `AuthPlugin` → `AuthManager` (`@objectstack/plugin-auth`, built on better-auth)". Still true — `AuthManager` is still the implementation, still built on better-auth; this diff changes neither fact. No change needed.
- **`content/docs/permissions/authentication.mdx`** — the page that documents the public auth surface in the most detail (bootstrap-status, `sign-up/email`, etc.). Read the full `sign-up/email` entry and the "First-run bootstrap status" section (`#first-run-bootstrap-status`): both describe the PUBLIC bootstrap probe (`isBootstrapCreation`, "does this environment have no human user yet") and the generic `sign-up/email` endpoint description ("Register new user"). Neither mentions the dev-admin seed's internal operator-provisioning ticket mechanism (`stageOperatorProvisioning`/`isOperatorProvisioning`) at all — that mechanism is deliberately a SEPARATE, undocumented-by-design internal seam (see the `[#14157]` docblock: "moves no public door"), distinct from the bootstrap probe this page does document. No sentence on this page asserts anything about ticket keying that this diff changes. No change needed.

Verdict for all three: the change is internal to the dev-admin seed's ticket-keying implementation detail: none of the three pages' contracts (service implementation identity, public bootstrap probe semantics, public endpoint list) assert anything this diff makes false.

## Tests

Real end-to-end suite (`dev-admin-seed-credential-gate.test.ts`, real `ObjectQL` engine + real better-auth over `:memory:` SQLite). Existing cases ⓪–⑧ stay green unmodified; two new cases pin the fix:

- **⑨**: stages a ticket directly (opening the exact window `maybeSeedDevAdmin` opens), fires a stranger's `POST /sign-up/email` for the SAME address with NO ticket field while the window is open — asserts `403 SELF_REGISTRATION_CLOSED` and zero accounts created — then, in the SAME still-open window, fires the correctly-bound call as a **positive control** and asserts it IS admitted, its credential actually authenticates via `sign-in/email`.
- **⑨(b)**: same setup, but the stranger supplies a wrong-but-present ticket value — asserts the same refusal (not merely "missing" but "wrong" is refused).

`pnpm --filter @objectstack/plugin-auth test`: **91 test files passed, 1864 tests passed**, on the merged tree at `4a07e99c4`. `pnpm --filter @objectstack/plugin-auth typecheck`: clean.

### Ablation (proves the pin actually depends on the binding)

Reverted `isOperatorProvisioning` to email-only matching. Mutation proof, redone with a **non-comment marker** (a `globalThis` write, since a `//` comment is stripped by esbuild and cannot prove the mutation reached the built artifact):

- Source: blob hash `66ba6e5c…` → `6b477b29…`; injected marker token present at 2 occurrences (write + implicit read via grep), 0 remaining occurrences of the original `ticket === entry.ticket` comparison line.
- Rebuilt `dist/index.mjs`; the marker token is present in the BUILT output (`DIST_MARKER_COUNT=1`) — confirms the mutation reached the code the tests actually load, not just the source.
- Reran the file's suite: `Tests 2 failed | 13 passed (15)`, with ⑨ and ⑨(b) specifically red (the stranger is admitted once the ticket check is gone).
- Restore via `trap ... EXIT INT TERM`: `git diff HEAD -- auth-manager.ts` byte count `0` after restore. Rebuilt again afterward: marker count `0` in the rebuilt `dist/index.mjs`, and the file's suite is back to `15 passed (15)` — `dist/` is confirmed returned to the real implementation, not left mutated.

### Gate family (re-derived from the actual diff at HEAD `4a07e99c4`, `scripts/pm/dispatch-gates.mjs`)

38 commands derived. 35 exit 0. The remaining 3 are explicitly **NOT MEASURED** (their own output says so, exit code 3, distinct from a finding's exit 1), each requiring a full-monorepo `dist/` closure this scoped local run does not build — CI's `lint.yml` builds that closure and runs these for real:
- `check-test-completeness` — no local `turbo run test` log to parse.
- `check:dual-build-cjs-loads` — PREREQUISITE NOT MET, 38 unrelated packages have no local `dist/`.
- `check:type-check-debt --re-measure` — PREREQUISITE NOT MET, 28 workspace deps have no built type entry point locally.

None of the 3 touch `plugin-auth`, `auth-manager.ts`, or `auth-plugin.ts` in their own diagnostics.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8