### PR TITLE
fix(spec): give `data/query.zod.ts` a module header so its pointer rows name the query AST

### DIFF
--- a/.changeset/query-zod-module-description.md
+++ b/.changeset/query-zod-module-description.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): `data/query.zod.ts` now describes the query AST, not one sort node
+
+The published skill reference indexes and the generated `data/query` reference
+page opened on "Sort Node" — the description of a single `{ field, order }`
+pair — for the file that carries the entire `QueryAST`.
+
+The generators publish the module's OWN doc block: top-level, in the header
+zone, documenting no symbol. `query.zod.ts` had no block of its own, and
+`SortNodeSchema`'s qualified, because the file's rationale comments sit between
+that block and its schema, so nothing attached it to a symbol. The mechanism was
+understood when the file was written — a warning comment sits directly under
+that block saying the first block becomes the page description. What was not
+noticed is the ORDERING: the first block belonged to a symbol, and a comment
+warning about a rule is not the same as satisfying it.
+
+The file now opens with a short header of its own, reusing the sentence
+`QueryAST`'s own type block already carried. Four published skill indexes
+(`objectstack-query`, `objectstack-data`, `objectstack-api`, `objectstack-ui`)
+and the reference page name the query AST as a result. `SortNode`'s block is
+untouched and still documents the schema it belongs to; the warning comment
+beside it now names which block is published and which selector picks it.
+
+What the wrong row cost, in the skills' own terms: the skill tells an agent to
+read the source for exact field shapes, so a pointer labelled "Sort Node" makes
+it skip the one file that carries the AST.

--- a/content/docs/references/data/query.mdx
+++ b/content/docs/references/data/query.mdx
@@ -5,9 +5,11 @@ description: Query protocol schemas
 
 {/* ⚠️  AUTO-GENERATED — DO NOT EDIT. Run build-docs.ts to regenerate. Hand-written docs live in the module folders under content/docs/. */}
 
-Sort Node
-Represents "Order By" — one `{ field, order }` pair. Unknown keys are
-REJECTED (#4721); spell the direction `order`, never `direction`.
+QueryAST — Abstract Syntax Tree for data queries.
+
+The query AST every data read is expressed in: `where` predicates, `fields`
+projection, `orderBy` sort nodes, `expand` traversal, pagination and
+aggregation.
 
 <Callout type="info">
 **Source:** `packages/spec/src/data/query.zod.ts`

--- a/packages/spec/scripts/query-pointer-row.test.ts
+++ b/packages/spec/scripts/query-pointer-row.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pin for WHAT the published pointer row for `data/query.zod.ts` names — the
+ * query AST, not one sort node.
+ *
+ * `build-skill-references.ts` describes each source by the module's own doc
+ * block (`lib/file-description.ts` selects it: top-level, in the header zone,
+ * documenting no symbol). `query.zod.ts` had no block of its own, and
+ * `SortNodeSchema`'s block qualified — the file's rationale comments sit
+ * between that block and its schema, so nothing attached it to a symbol. Four
+ * published indexes (`objectstack-query`, `-data`, `-api`, `-ui`) therefore
+ * labelled the file carrying the whole `QueryAST` "Sort Node", and the public
+ * reference page `content/docs/references/data/query.mdx` opened on it. The
+ * skill tells an agent to Read the source for exact field shapes, so that row
+ * cost the one read it exists to route: an agent looking for the query AST
+ * skips the only file that has it.
+ *
+ * No gate could see it. `check:skill-refs` and `check:docs` compare the
+ * artifact against the generator, and the generator reproduced the wrong block
+ * faithfully — the same blind spot #5059 and #12201 found one layer up, so the
+ * answer is the same one: pin the fact the artifact must state, not the
+ * pipeline that states it.
+ *
+ * Two legs, and they fail DIFFERENTLY, which is why both exist. The SOURCE leg
+ * reds the moment the file header is deleted or demoted below another block —
+ * no regeneration needed. The CORPUS leg stays green through that (it reads
+ * checked-in bytes, which only move when someone regenerates) and reds on the
+ * state this card actually found: an index regenerated from a file with no
+ * header of its own. MEASURED both ways in the fix's reverse verification.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+import { findModuleDocBlock } from './lib/file-description';
+
+const HERE = path.dirname(url.fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../..');
+const SKILLS_DIR = path.resolve(REPO_ROOT, 'skills');
+const QUERY_SOURCE = path.resolve(HERE, '../src/data/query.zod.ts');
+
+/**
+ * The module's own opening sentence — the one `QueryAST`'s type block already
+ * carried further down the file. Spelled out rather than derived from the
+ * source: deriving it would re-assert the generator's rule and say nothing
+ * about WHICH subject the row names, which is the whole defect.
+ */
+const QUERY_AST_SENTENCE = 'QueryAST — Abstract Syntax Tree for data queries.';
+
+/** The pointer path the generator writes for this source in every index. */
+const POINTER = 'node_modules/@objectstack/spec/src/data/query.zod.ts';
+
+/** First prose line of the block the generator would publish for a source. */
+const firstDescriptionLine = (source: string): string | null => {
+  const block = findModuleDocBlock(source);
+  if (block === null) return null;
+  const lines = block
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*\s?/, '').trim())
+    .filter((line) => line && !line.startsWith('@') && !line.startsWith('```'));
+  return lines[0] ?? null;
+};
+
+describe('data/query.zod.ts — the module block describes the module', () => {
+  it('opens on the QueryAST sentence, not on `SortNode`', () => {
+    const source = fs.readFileSync(QUERY_SOURCE, 'utf-8');
+    expect(firstDescriptionLine(source)).toBe(QUERY_AST_SENTENCE);
+  });
+
+  it('still carries `SortNode`s own block — the fix adds a header, it does not move a symbol doc', () => {
+    // Passing by deleting the symbol's documentation would satisfy the row and
+    // lose what the block says about `direction` vs `order` (#4721).
+    expect(fs.readFileSync(QUERY_SOURCE, 'utf-8')).toContain(' * Sort Node');
+  });
+});
+
+describe('published catalog — every pointer row for the query AST names it', () => {
+  /** Every checked-in skill-index row pointing at `data/query.zod.ts`. */
+  const publishedRows = (): { file: string; description: string }[] => {
+    const rows: { file: string; description: string }[] = [];
+    for (const skill of fs.readdirSync(SKILLS_DIR)) {
+      const index = path.resolve(SKILLS_DIR, skill, 'references/_index.md');
+      if (!fs.existsSync(index)) continue;
+      for (const line of fs.readFileSync(index, 'utf-8').split('\n')) {
+        const match = /^- `([^`]+)` — (.+)$/.exec(line);
+        if (match && match[1] === POINTER) {
+          rows.push({ file: path.relative(REPO_ROOT, index), description: match[2].trim() });
+        }
+      }
+    }
+    return rows;
+  };
+
+  it('finds the rows at all', () => {
+    // Nothing parsed means nothing compared, and "no bad row" would read as
+    // green — the failure mode this whole file exists to refuse.
+    expect(publishedRows().length).toBeGreaterThan(0);
+  });
+
+  it('reads the QueryAST sentence on every one of them', () => {
+    const offenders = publishedRows()
+      .filter((row) => row.description !== QUERY_AST_SENTENCE)
+      .map((row) => `${row.file}: ${row.description}`);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/spec/src/data/query.zod.ts
+++ b/packages/spec/src/data/query.zod.ts
@@ -8,12 +8,21 @@ import { retiredKey } from '../shared/retired-key';
 import { strictObject } from '../shared/strict-object';
 
 /**
+ * QueryAST — Abstract Syntax Tree for data queries.
+ *
+ * The query AST every data read is expressed in: `where` predicates, `fields`
+ * projection, `orderBy` sort nodes, `expand` traversal, pagination and
+ * aggregation.
+ */
+
+/**
  * Sort Node
  * Represents "Order By" — one `{ field, order }` pair. Unknown keys are
  * REJECTED (#4721); spell the direction `order`, never `direction`.
  */
-// ⚠️ Keep the block above short: `build-docs.ts` takes the FIRST JSDoc block in
-// the file as this page's description, so the rationale below is line comments.
+// ⚠️ Keep the file header above short: `build-docs.ts` publishes the FIRST doc
+// block that documents no symbol (`scripts/lib/file-description.ts`) as this
+// page's description, so the rationale below is line comments.
 //
 // ─── Why this one schema is strict while the rest of the file is not (#4721) ──
 //

--- a/packages/spec/src/data/query.zod.ts
+++ b/packages/spec/src/data/query.zod.ts
@@ -20,9 +20,10 @@ import { strictObject } from '../shared/strict-object';
  * Represents "Order By" — one `{ field, order }` pair. Unknown keys are
  * REJECTED (#4721); spell the direction `order`, never `direction`.
  */
-// ⚠️ Keep the file header above short: `build-docs.ts` publishes the FIRST doc
-// block that documents no symbol (`scripts/lib/file-description.ts`) as this
-// page's description, so the rationale below is line comments.
+// ⚠️ Keep the file header above short: `build-docs.ts` publishes the FIRST
+// HEADER-ZONE doc block that documents no symbol — the zone ends at the first
+// declaration, so a later block cannot take over (`scripts/lib/file-description.ts`
+// selects it) — as this page's description, so the rationale below is line comments.
 //
 // ─── Why this one schema is strict while the rest of the file is not (#4721) ──
 //

--- a/skills/objectstack-api/references/_index.md
+++ b/skills/objectstack-api/references/_index.md
@@ -27,7 +27,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/data/field-value.zod.ts` — Field runtime VALUE-shape contract (ADR-0104 D1).
 - `node_modules/@objectstack/spec/src/data/field.zod.ts` — Exports: FieldType, SelectOptionSchema, LocationCoordinatesSchema, CurrencyConfigSchema, CurrencyValueSchema
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification
-- `node_modules/@objectstack/spec/src/data/query.zod.ts` — Sort Node
+- `node_modules/@objectstack/spec/src/data/query.zod.ts` — QueryAST — Abstract Syntax Tree for data queries.
 - `node_modules/@objectstack/spec/src/kernel/execution-context.zod.ts` — Exports: ExecutionContextSchema
 - `node_modules/@objectstack/spec/src/kernel/metadata-protection.zod.ts` — Metadata Protection Model — Phase 1 (ADR-0010)
 - `node_modules/@objectstack/spec/src/security/explain.zod.ts` — [ADR-0090 D6] Access-explanation contract — `explain(principal, object,

--- a/skills/objectstack-data/references/_index.md
+++ b/skills/objectstack-data/references/_index.md
@@ -34,7 +34,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/data/field-value.zod.ts` — Field runtime VALUE-shape contract (ADR-0104 D1).
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification
 - `node_modules/@objectstack/spec/src/data/hook-body.zod.ts` — Exports: HookBodyCapability, ExpressionBodySchema, ScriptBodySchema, HookBodySchema
-- `node_modules/@objectstack/spec/src/data/query.zod.ts` — Sort Node
+- `node_modules/@objectstack/spec/src/data/query.zod.ts` — QueryAST — Abstract Syntax Tree for data queries.
 - `node_modules/@objectstack/spec/src/kernel/metadata-protection.zod.ts` — Metadata Protection Model — Phase 1 (ADR-0010)
 - `node_modules/@objectstack/spec/src/security/rls.zod.ts` — Row-Level Security (RLS) Protocol
 - `node_modules/@objectstack/spec/src/shared/enums.zod.ts` — Exports: SortDirectionEnum, SortItemSchema, MutationEventEnum, IsolationLevelEnum

--- a/skills/objectstack-query/references/_index.md
+++ b/skills/objectstack-query/references/_index.md
@@ -11,7 +11,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 
 - `node_modules/@objectstack/spec/src/data/date-macros.zod.ts` — Date Macro Tokens — the declarative placeholders the UI substitutes
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification
-- `node_modules/@objectstack/spec/src/data/query.zod.ts` — Sort Node
+- `node_modules/@objectstack/spec/src/data/query.zod.ts` — QueryAST — Abstract Syntax Tree for data queries.
 
 ## Transitive dependencies
 

--- a/skills/objectstack-ui/references/_index.md
+++ b/skills/objectstack-ui/references/_index.md
@@ -29,7 +29,7 @@ from `node_modules` — there is no local copy in the skill bundle.
 - `node_modules/@objectstack/spec/src/data/field.zod.ts` — Exports: FieldType, SelectOptionSchema, LocationCoordinatesSchema, CurrencyConfigSchema, CurrencyValueSchema
 - `node_modules/@objectstack/spec/src/data/filter.zod.ts` — Unified Query DSL Specification
 - `node_modules/@objectstack/spec/src/data/hook-body.zod.ts` — Exports: HookBodyCapability, ExpressionBodySchema, ScriptBodySchema, HookBodySchema
-- `node_modules/@objectstack/spec/src/data/query.zod.ts` — Sort Node
+- `node_modules/@objectstack/spec/src/data/query.zod.ts` — QueryAST — Abstract Syntax Tree for data queries.
 - `node_modules/@objectstack/spec/src/kernel/metadata-protection.zod.ts` — Metadata Protection Model — Phase 1 (ADR-0010)
 - `node_modules/@objectstack/spec/src/shared/enums.zod.ts` — Exports: SortDirectionEnum, SortItemSchema, MutationEventEnum, IsolationLevelEnum
 - `node_modules/@objectstack/spec/src/shared/expression.zod.ts` — Expression Protocol


### PR DESCRIPTION
Fixes #14441

## What was wrong

`packages/spec/src/data/query.zod.ts` carries the whole `QueryAST`, but every published
pointer row for it read **"Sort Node"** — the description of a single `{ field, order }`
pair. The public reference page `content/docs/references/data/query.mdx` opened on it too.

The generators publish the module's OWN doc block: top-level, in the header zone,
documenting no symbol (`packages/spec/scripts/lib/file-description.ts` selects it).
`query.zod.ts` had no block of its own, and `SortNodeSchema`'s block qualified — the
file's long rationale comments sit between that block and its schema, so nothing attached
it to a symbol.

The mechanism was understood when the file was written: a warning comment sits directly
under that block saying the first block becomes the page description. What was not
noticed is the **ordering** — the first block belonged to a symbol, and a comment warning
about a rule is not the same as satisfying it.

Cost, in the skills' own terms: the skill tells an agent to Read the source for exact
field shapes, so a pointer labelled "Sort Node" makes it skip the one file that carries
the AST.

## What this PR does

- Adds a short file-level header to `data/query.zod.ts`, reusing the sentence
  `QueryAST`'s own type block already carried further down the file.
- Regenerates. Four published skill indexes (`objectstack-query`, `-data`, `-api`,
  `-ui`) and the reference page now name the query AST. The `_index.md` files are
  **generated** and were not hand-edited — `check:skill-refs` and `check:docs` both
  green prove the checked-in bytes are exactly the generators' output.
- `SortNode`'s block is untouched and still documents the schema it belongs to.
- Corrects the warning comment beside it: it named two of the selector's three
  conditions, omitting the **header zone** — the one this defect turned on. A block
  documenting no symbol is published only while no declaration precedes it.
- Adds `packages/spec/scripts/query-pointer-row.test.ts`, a two-leg pin.

### Why a pin, when two gates already cover these artifacts

`check:skill-refs` and `check:docs` compare the artifact against the generator, and the
generator reproduced the wrong block faithfully — the same blind spot #5059 and #12201
found one layer up. So the pin asserts the fact the artifact must state, not the pipeline
that states it. Its two legs fail differently and both were measured:

- **SOURCE leg** reds the moment the header is deleted or demoted — no regeneration needed.
- **CORPUS leg** stays green through that (it reads checked-in bytes) and reds on the state
  this card actually found: an index regenerated from a file with no header of its own.

## Landing shape — GOVERNED

`node scripts/pm/check-governed-merges.mjs --test` on this PR's 8 paths, verdict line:

```
governed-surface predicate: 4 of 8 path(s) hit the register (5 surfaces, repo-agnostic).
  GOVERNED — a human merge is the review record for this PR (#9495 regime).
      skills/** x4 — the published skills catalog
```

Draft PR, no ready flip, no auto-merge, not enqueued. Note the generated-surface
exception (#11705) did **not** lift the four `skills/**` paths: the predicate sees a
co-edited file under the generator's own directory (the new pin test lives in
`packages/spec/scripts/`), so it declines to certify a regeneration produced by the tree
under test. Governed either way here.

## Published skills bundle — the two readings

Line counts are **net zero**; the change is 4 generated rows getting a longer, correct
description.

Per changed file, whole-file lines (before to after):

| file | before | after | delta |
|:--|--:|--:|--:|
| `skills/objectstack-api/references/_index.md` | 49 | 49 | 0 |
| `skills/objectstack-data/references/_index.md` | 65 | 65 | 0 |
| `skills/objectstack-query/references/_index.md` | 35 | 35 | 0 |
| `skills/objectstack-ui/references/_index.md` | 56 | 56 | 0 |

Whole published bundle: all `skills/**/SKILL.md` **8801 to 8801 lines (+0)**; every file
under `skills/` **14334 to 14334 lines (+0)**.

Tokens, in the ratchet's own convention `ceil(utf8 bytes / 4)`: the four indexes go
888/1483/518/1205 to 899/1494/529/1215, and the **whole published bundle 159648 to 159691
(+43)**. `check-skills-token-ratchet` classifies `references/_index.md` as
**generator-owned — measured, not ratcheted**, so no ceiling is in play; the ratcheted
(authored) bucket is unchanged at 141214 / 165532.

## Verification

All readings below are on head `01a03f98e`, worktree clean, exit codes captured before
any pipe.

| check | verdict |
|:--|:--|
| `pnpm --filter @objectstack/spec exec vitest run` (whole package) | `Test Files 458 passed (458)` · `Tests 12279 passed (12279)` |
| `pnpm --filter @objectstack/spec run typecheck` | exit 0 — `tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck` |
| `pnpm --filter @objectstack/spec run check:skill-refs` | `9 generated files in sync with packages/spec` |
| `pnpm --filter @objectstack/spec run check:docs` | `229 generated files in sync with packages/spec` |
| `pnpm --filter @objectstack/spec run check:generated` | exit 0 (after `pnpm --filter @objectstack/spec build`) |
| `pnpm --filter @objectstack/spec run check:skill-examples` | `256 prose examples type-check across 3 surface(s)` |
| `node scripts/check-skills-token-ratchet.mjs` | `31 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted` |
| `pnpm check:pm-skill-ratchet` | exit 0 |
| `pnpm check:nul-bytes` | `scanned 8044 text file(s) ... no raw ASCII control bytes` |
| `pnpm check:doc-authoring` | exit 0 |
| `pnpm check:cross-package-test-inputs` | `25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob` |

The new pin reads `skills/` from inside `packages/spec`; that escape is already covered —
`$TURBO_ROOT$/skills/**` is a declared input of `@objectstack/spec#test`, and the gate
above confirms turbo.json hashes it. The test file is compiled by
`packages/spec/tsconfig.scripts.json` (confirmed with `--listFilesOnly`), so
`check:scripts-typecheck` really did type-check it.

The full derived family — `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`,
75 commands — was run. 68 green. The other 7 measured nothing and are declared, not green:
six are the same precondition (**the workspace is not fully built** in this container —
66 of 67 packages have no `dist/`), and one is structural:

- exit 3, PREREQUISITE NOT MET: `check:dual-build-cjs-loads`, `check:type-check-debt`,
  `@objectstack/lint`'s `check:doc-formula-expressions` and `check:doc-security-posture`
  (needs `@objectstack/formula` built).
- exit 1, same cause: `check-dev-prereqs` ("The workspace is not built").
- exit 3: `check-test-completeness` grades a saved `turbo run test` log and the family
  names it with no argument — its own text says this branch is NOT MEASURED and is not a
  red.

None of the seven reads a path this diff touches. CI runs the farm regardless.

### Reverse verification (measured, not asserted)

Header block deleted on disk, then restored. Mutation proven on disk before any reading —
header-sentence `grep -c` 0 (want 0), `SortNode` block still 1, and the blob hash moved
`341bb947` to `a8c9c601`. The script carried a `trap ... EXIT INT TERM` with absolute
paths throughout.

| leg | result |
|:--|:--|
| SOURCE leg, pre-regeneration | **RED** — 1 failed / 3 passed: `opens on the QueryAST sentence, not on SortNode` |
| regeneration (`gen:skill-refs`, exit 0) | index row flips back to `data/query.zod.ts` — Sort Node — the exact defect reproduced |
| CORPUS leg, post-regeneration | **RED** — 2 failed / 2 passed: both the source and the published-catalog assertion |
| after restore | 4 passed; and with `file-description.test.ts`, 97 passed |

Restore proven, not assumed: `git checkout HEAD -- REPO_ROOT`, then both blob hashes
equal to their HEAD blobs (`341bb947...`, `0287454b...`), `git diff HEAD` 0 files, 0
untracked.

## Note for the reviewer

This branch was taken over. Two earlier sessions died in container restarts leaving the
worktree with one unverified commit and no PR. Every reading in this PR was produced
after the takeover, on the final head; the inherited commit was reviewed hunk by hunk and
kept, with one correction (the warning comment's missing header-zone condition, its own
commit).

Changeset: `@objectstack/spec: patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RbbUMnxkUnWhE4j94v8FE


---
_Generated by [Claude Code](https://claude.ai/code/session_017RbbUMnxkUnWhE4j94v8FE)_