### PR TITLE
fix(pm): refuse `--tier` against `--commands` / `--json` instead of silently preferring the tier

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -16752,6 +16752,25 @@ function selfTest() {
     // Two answers to "what shape is stdout" is no answer.
     const bothRun = runCli(['--commands', '--json', seamCard]);
     t('passing both stdout spellings refuses instead of silently preferring one', bothRun.status === 2 && (bothRun.stdout ?? '').trim() === '');
+    // ⭐ The THIRD stdout shape (#14294). The pair above was enforced and this
+    // one was not: `mode` was computed and then discarded, so these two exited
+    // 0 with tier prose sitting in the file a consumer had redirected because
+    // `--commands` promises commands and nothing else. Driven on the real CLI
+    // for the same reason the pair above is — the defect was in the argv chain,
+    // which no pure half reaches. Both halves of the refusal are asserted: the
+    // STATUS, and the stdout a redirecting consumer would have kept, because a
+    // refusal that still prints an answer is the bug wearing an exit code.
+    const tierCmdRun = runCli(['--tier', '--commands', seamCard]);
+    t('⭐ --tier against --commands refuses instead of silently preferring the tier', tierCmdRun.status === 2 && (tierCmdRun.stdout ?? '').trim() === '');
+    t('and its refusal names BOTH flags, so the dropped one is never left to be guessed', (tierCmdRun.stderr ?? '').includes('--tier') && (tierCmdRun.stderr ?? '').includes('--commands'));
+    const tierJsonRun = runCli(['--tier', '--json', seamCard]);
+    t('⭐ --tier against --json refuses the same way, on the other machine-readable shape', tierJsonRun.status === 2 && (tierJsonRun.stdout ?? '').trim() === '');
+    t('and that refusal names --json, never the flag this run is not about', (tierJsonRun.stderr ?? '').includes('--json') && !(tierJsonRun.stderr ?? '').includes('--commands'));
+    // CONTROL: green before this fix and after it. The new branch is ordered
+    // after the pair, so all three flags together still answer with the pair's
+    // own message — the fix adds a refusal and rewords none.
+    const allThreeRun = runCli(['--tier', '--commands', '--json', seamCard]);
+    t('CONTROL: all three together keep the pair rule that was already enforced', allThreeRun.status === 2 && (allThreeRun.stderr ?? '').includes('--commands and --json'));
   }
 
   // ── END TO END: the CI-measured family, on the card it was measured on (#14004)
@@ -17132,8 +17151,35 @@ if (invokedDirectly) {
     // Two answers to "what shape is stdout" is no answer. Blending them — or
     // silently preferring one — is the class of failure this whole file is
     // about, and it would be a poor place to commit it: these two flags exist
-    // because a consumer could not tell what it was reading.
+    // because a consumer could not tell what it was reading. The rule is about
+    // how many answers the stream carries, not about which two flags happened
+    // to be named when it was written: `--tier` is a THIRD shape of that same
+    // stdout, and it is refused against each of these two in the branch below.
     console.error('dispatch-gates: --commands and --json are two spellings of stdout — pass one.');
+    process.exit(2);
+  } else if (process.argv.includes('--tier') && (process.argv.includes('--commands') || process.argv.includes('--json'))) {
+    // The third shape, and the one the pair above did not reach: `mode` was
+    // computed from --commands/--json and then DISCARDED by the `--tier` branch
+    // at the bottom of this block, so the tier PROSE landed in a stream whose
+    // caption promises one runnable command per line, or one JSON document —
+    // at exit 0, with nothing on either stream saying the flag had been
+    // dropped. That is the silent preference the rule above forbids, committed
+    // one flag over from where it is enforced.
+    //
+    // REFUSED, not re-routed. Sending the tier verdict to stderr whenever a
+    // machine-readable mode is asked for is defensible — `--tier` answers a
+    // different question and reads no tree — but it changes what `--tier`
+    // MEANS when combined, and that is a design call for this file's owner,
+    // not a repair to a silent-drop bug. Same shape as the two refusals above
+    // it and the `--ran --tier` refusal above them: one line, exit 2, both
+    // flags named so the caller never has to guess which one was dropped.
+    //
+    // Ordered AFTER the pair deliberately: `--tier --commands --json` keeps
+    // the message it already had, so this branch adds a refusal and changes
+    // none.
+    console.error(
+      `dispatch-gates: --tier and ${process.argv.includes('--commands') ? '--commands' : '--json'} are two spellings of stdout — pass one.`,
+    );
     process.exit(2);
   } else if (wantsChanged && argvPaths.length > 0) {
     // The two input modes answer different questions and must never be blended:
@@ -17202,7 +17248,7 @@ if (invokedDirectly) {
         derived = changedPathsFromGit();
       } catch (err) {
         console.error(`dispatch-gates: could not derive the change set — ${err.message}`);
-        console.error('usage: node scripts/pm/dispatch-gates.mjs [--residue] [--tier] [--commands | --json | --ran <file>] [--repo owner/name] [<path> ...] | --changed | --self-test');
+        console.error('usage: node scripts/pm/dispatch-gates.mjs [--residue] [--tier | --commands | --json | --ran <file>] [--repo owner/name] [<path> ...] | --changed | --self-test');
         process.exit(2);
       }
       if (derived.paths.length === 0) {


### PR DESCRIPTION
Fixes #14294

`--tier` is a third shape of this CLI's stdout, and it was the one the "two spellings of stdout" rule did not name. `mode` was computed from `--commands`/`--json` and then **discarded** by the `--tier` branch at the bottom of the same argv block, so the tier prose landed in a stream whose caption promises one runnable command per line, or one JSON document — at exit 0, with nothing on either stream saying the flag the caller passed had been dropped.

Both pairs now refuse, in the shape the neighbouring refusals already use.

## The refusal

```
dispatch-gates: --tier and --commands are two spellings of stdout — pass one.
dispatch-gates: --tier and --json are two spellings of stdout — pass one.
```

One line on stderr, exit 2, empty stdout — the same shape as the `--commands --json` refusal it extends and the `--ran --tier` refusal above it, and for the same stated reason: two answers to "what shape is stdout" is no answer.

⛔ **Not re-routed to stderr.** Sending the tier verdict to stderr whenever a machine-readable mode is asked for is defensible, and #14294 says so — but it changes what `--tier` MEANS when combined, which is a design call for this file's owner, not a repair to a silent-drop bug. The seat resolved the card's open fork to "refuse" in lane, and this PR implements only that.

⛔ **`--tier` on its own is untouched.** Verified byte-for-byte: the stdout of `--tier PATH` after this change is identical to the stdout the blended `--tier --commands PATH` produced before it (`diff` clean, 942 bytes both).

## Before / after — the card's own reproduction

Run on `packages/spec/src/index.ts`, exactly as #14294 spells it. Exit codes captured by redirect BEFORE any pipe.

**BEFORE** (base tree, 7a17f3bf) — the silent drop:

```
$ node scripts/pm/dispatch-gates.mjs --tier --commands packages/spec/src/index.ts > out.txt
$ echo "EXIT=$?"
EXIT=0
$ wc -c < out.txt
942
$ head -1 out.txt
Model tier — no path-derived mandate: the surface hits none of the 3 declared glob(s), derived here, not recalled.
```

`--tier --json` behaved identically: EXIT=0, the same 942 bytes of tier prose, and a stream that is not JSON with nothing saying so.

(The 4 further lines of that stdout are elided here on purpose: they name model tiers, which do not belong in a PR body. The point of the transcript is that they were on **stdout at all**, in a file the caller redirected because `--commands` promises commands and nothing else.)

**AFTER** — refused:

```
$ node scripts/pm/dispatch-gates.mjs --tier --commands packages/spec/src/index.ts > out.txt
$ echo "EXIT=$?"
EXIT=2
$ wc -c < out.txt
0
$ # stderr:
dispatch-gates: --tier and --commands are two spellings of stdout — pass one.

$ node scripts/pm/dispatch-gates.mjs --tier --json packages/spec/src/index.ts > out.txt
$ echo "EXIT=$?"
EXIT=2
$ wc -c < out.txt
0
$ # stderr:
dispatch-gates: --tier and --json are two spellings of stdout — pass one.
```

**CONTROL, all three flags** — unchanged by this PR:

```
$ node scripts/pm/dispatch-gates.mjs --tier --commands --json packages/spec/src/index.ts > out.txt
EXIT=2
dispatch-gates: --commands and --json are two spellings of stdout — pass one.
```

The new branch is ordered **after** the `--commands --json` pair deliberately, so the triple keeps the message it already had. This PR adds a refusal and rewords none.

## Self-test cases — red then green

Five cases added beside the pair they extend, in the seam-card block of `selfTest()` (not the tier region, which PR #14672 holds):

1. `⭐ --tier against --commands refuses instead of silently preferring the tier` — status 2 AND empty stdout, because a refusal that still prints an answer is the bug wearing an exit code.
2. `and its refusal names BOTH flags, so the dropped one is never left to be guessed`
3. `⭐ --tier against --json refuses the same way, on the other machine-readable shape`
4. `and that refusal names --json, never the flag this run is not about`
5. `CONTROL: all three together keep the pair rule that was already enforced`

**RED leg (ablation).** The implementation was committed first, then the refusal branch alone was deleted — the five cases left in place — and the full battery re-run on that mutated tree:

- Mutation proved on disk before the run, not by an editor's exit code: the refusal message string went `grep -c` 1 to 0, `git diff HEAD --stat` showed `24 deletions(-)`, and the card's own repro was re-run against the mutated file and came back `EXIT=0 stdout_bytes=942` — the pre-fix behaviour, restored on purpose.
- Result: **`✗ dispatch-gates self-test: 4 of 1246 case(s) failed.`** — exactly cases 1-4. Case 5 stayed green, which is what makes it a control rather than a case that would redden for any reason.
- Restore leg proved by observation, not by exit code: `git diff HEAD` 0 bytes, `git status --porcelain` 0 lines, and the worktree blob hash `353abf85…` equal to the HEAD blob hash; the repro then re-run once more and back to EXIT=2. The ablation script carried `trap ... EXIT INT TERM` with absolute paths throughout.
- No rebuild leg is owed here and none is claimed: the subject is a plain `.mjs` the battery spawns as `process.execPath CLI` from its own `import.meta.url`. There is no `dist/`, no package `exports` indirection, so there is no stale-artifact path between the edit and the measurement.

**GREEN leg.** Same battery, same commit as this PR's head: **`✓ dispatch-gates self-test: 1246 cases pass.`**, 0 failure lines.

**Case count.** After: **1246, measured**. Before: **1241, derived** — the diff adds exactly 5 `t(` calls and removes 0 (`grep -cE '^\+\s+t\('` = 5, `'^-\s+t\('` = 0), and the ablation run reports the same 1246 total, so the base total is 1246 − 5. Labelled derived rather than measured because no battery was run on a tree without the cases; that run would have cost a third six-minute hold of the shared verify lock for a bookkeeping number.

## Bounded in-place correction, declared

One line beyond the refusal and its cases — the usage string printed on the derivation-failure path:

```
-  [--residue] [--tier] [--commands | --json | --ran FILE] ...
+  [--residue] [--tier | --commands | --json | --ran FILE] ...
```

It advertised `--tier` as freely combinable with the group this PR just made it exclusive with. Left alone it would be a documented lie shipped in the same commit that makes it false — the same silent-wrong-answer class the file exists against. Mechanical, one line, inside the argv block this PR already owns, no new verification surface. Flagged here rather than left for a reviewer to find.

## Gates

All under `scripts/pm/os-verify-lock.sh`; every exit code captured by redirect before any pipe; each verdict line quoted from the gate's own output. Head **9eab5369**.

| Gate | Exit | Its own verdict line |
| --- | --- | --- |
| `pnpm check:pm-dispatch-gates` | 0 | `✓ dispatch-gates self-test: 1246 cases pass.` |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 47 declaration(s) across 4 rostered name(s) … no unrostered spelling of the idiom in the tree.` |
| `pnpm check:declared-population-live` | 0 | `✓ check:declared-population-live — 158 of 202 famil(ies) declare a path population, and every one of them reaches this tree's 8059 tracked file(s).` |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 199 scripts/ file(s) — every entry guard goes through invoked-as.mjs; 150 export bindings, 150 of them inert on import` |
| `pnpm check:parse-guard` | 0 | (green; the 42-line tiered census printed, no finding) |
| `node scripts/check-self-test-wired.mjs` | 0 | `✓ check-self-test-wired: every one of the 164 script(s) CI runs that ship a --self-test has that self-test run by CI.` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8052 text file(s) … no raw ASCII control bytes).` |
| `eslint --no-inline-config` on the file | 0 | 0 errors, 0 warnings |

**Union re-derived AFTER the last edit**, no hand-fed paths:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` at **9eab5369** — change set `1 path(s)`, exactly this file; `16 command(s) — 10 pnpm, 6 direct node`. The nine families the dispatch brief did not name were run too:

| Gate (derived, not briefed) | Exit |
| --- | --- |
| `node scripts/check-ci-filter-parity.mjs` | 0 |
| `node scripts/check-shard-attestation.mjs` | 0 |
| `node scripts/check-whole-set-label-write.mjs` | 0 |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:bash32-floor` | 0 |
| `pnpm check:cli-command-ids` | 0 |
| `pnpm check:cross-package-test-inputs` | 0 |
| `pnpm check:pnpm-filter-targets` | 0 |
| `node scripts/check-test-completeness.mjs` | **3 — NOT MEASURED** |

`check-test-completeness` grades a saved `turbo run test` log and was handed none. Its own text names this exact arrival path: *"Arrived here from the gate family `scripts/pm/dispatch-gates.mjs` derives? … the local reading for this gate is NOT MEASURED. ⛔ It is not a red, and there is nothing here to fix."* Recorded as NOT MEASURED — not green, not red, not a flake.

**ESLint narrowing, declared with its three pieces of evidence** (the repo-wide `pnpm lint` is CI's run, not this PR's):

1. Population read from ESLint's own configuration, not guessed: `eslint.config.mjs` states in its own comment that "this repo runs one `eslint.config.mjs`, which never enables type-aware linting (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY file, test or not", and it was measured there with a positive control.
2. File count read from `--format json`: **1 file linted**, 0 errors, 0 warnings.
3. Invariance: with no type-aware linting enabled anywhere in that config, a one-file diff cannot move the verdict on any file it does not touch. The narrowing is therefore a measurement, not a gap.

Also self-scanned for raw control bytes beyond the gate: `grep -naP` over the edited file, no hits.

## premise_false / notes for the reviewer

- **"the docblock sentence that states the two-spellings-of-stdout rule"** — there is no docblock stating it. The rule lives in a **line-comment block** immediately above the `--commands --json` refusal in the argv chain (the phrase itself appears only in that `console.error` string). That comment block is what was extended to name `--tier` as a third shape; the header docblock's mode list was left alone.
- **Hot file** — `origin/main` has not moved at all since this branch was cut (`git rev-list --count BASE..origin/main` = 0), and PR #14672 has not landed, so no merge was needed. My hunks are the argv block plus five cases in the seam-card block; #14672's are in the tier region of `selfTest()` — disjoint.
- **Watch-hint set unchanged**, measured with the module's own `extractWatchHints` over its own source before and after the edit: byte-identical JSON, **23 hints** both ways. No path literal was added and the tier constant's value is spelled nowhere in the new cases.
- **`skip-changeset` verified against `scripts/check-empty-changeset.mjs`'s own enumeration** before applying: the label is a live mechanism here (the changeset workflow reads it with `grep -qxF 'skip-changeset'`, and that script pins exactly two such reads), and route 2 is the destination for a PR that releases nothing. This diff is one file under `scripts/pm/**` and publishes nothing from any package.
- **Draft, and it stays draft.** Governed surface (`scripts/pm/**`): human merge, never queued, never auto-merged.

## Out-of-scope finding, filed not fixed

#14753 — `--tier --residue` silently drops `--residue` on the same argv chain. Measured with a control: `--residue` changes the derivation's answer (15007 → 66141 bytes) but under `--tier` it is byte-for-byte a no-op at exit 0. Different axis from this card (a modifier, not a stdout shape), so it was filed unassigned rather than folded in here. Out of scope for this PR, which does not address it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_