### PR TITLE
skills(data): drop the two bare ADR-0010 citations from the objectstack-data skill

### DIFF
--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -564,7 +564,6 @@ it, and `defineStack` errors unless the grant declares
 ## Metadata Protection (`protection`)
 
 Package authors can lock shipped metadata against Studio edits / overlays / deletes.
-See ADR-0010 for the full model.
 
 The `protection` block is **declared on the source schema** (`*.object.ts`,
 `*.app.ts`, `*.view.ts`, …) and stripped at load time — it never appears in
@@ -608,7 +607,7 @@ export const SysUserObject = ObjectSchema.create({
   sharingModel: 'public_read',
   protection: {
     lock: 'full',
-    reason: 'Core identity object — see ADR-0010.',
+    reason: 'Core identity object',
     docsUrl: 'https://objectstack.ai/docs/references/shared/protection',
   },
   fields: { username: { type: 'text', required: true } },


### PR DESCRIPTION
Fixes #11791

`skills/objectstack-data/SKILL.md` carried bare `ADR-0010` citations. `0010` is claimed by two unrelated records — `0010-metadata-protection-model` and `0010-nl-to-flow-authoring`, frozen in `check-adr-anchors.mjs`'s shrink-only `KNOWN_NUMBER_COLLISIONS` — and the published catalog ships into codebases with no `docs/adr/` to grep, so neither site resolved for its actual audience.

Scope is the `ADR-0010` sites in `skills/objectstack-data/**` and nothing else. The catalog-wide convention question (whether published skills keep provenance ids at all) belongs to #11052 and is deliberately not settled here.

## Sites

Line numbers are measured on `origin/main` at `224f8ea4` (the branch base), which is where the "before" column is read.

### 1 · authored `reason:` string — `SKILL.md:611` before / `:610` after

The sharpest of the two: `reason` is not documentation *about* the platform, it is authored metadata that ships in the customer's own code. An authoring agent following this example writes `see ADR-0010` into customer metadata, somewhere no later pass over this repo can reach. The correct form was already sitting on the next line — a `docsUrl` pointing at a public page that resolves.

| | |
|:---|:---|
| before | `    reason: 'Core identity object — see ADR-0010.',` |
| after | `    reason: 'Core identity object',` |

`docsUrl: 'https://objectstack.ai/docs/references/shared/protection'` on the following line is untouched, and so is the rest of the reason text. The block sits inside a marked `os:check` example, so it is type-checked; `reason` stays a non-empty string, which is what the `.strict()` schema requires (min 1 / max 500 chars).

### 2 · prose — `SKILL.md:567` before / deleted after

```diff
 Package authors can lock shipped metadata against Studio edits / overlays / deletes.
-See ADR-0010 for the full model.
```

Judged in the form PR #11790 used for `ADR-0057`: name the record so it resolves for a reader with no `docs/adr/`, or drop the sentence when the surrounding text already names the model. The second branch applies here — the section heading is literally `## Metadata Protection` and the sentence immediately before names the model in full ("lock shipped metadata against Studio edits / overlays / deletes"). Qualifying the number in place would have restated the heading *and* been additive against a ceiling with zero headroom; the citation's only unique content was a pointer the reader cannot open, and the section's own schema, lock table and enforcement paragraph follow immediately.

## `ADR-0019` — examined and kept

The card named five sites. Re-measured on this branch, **three** survive, and none is touched:

| site | today's line | the text that selects the record |
|:---|:---|:---|
| `skills/objectstack-automation/SKILL.md` | `:410` | "do something when the state changes" is a **record-triggered Flow** (ADR-0019) |
| `skills/objectstack-automation/SKILL.md` | `:424` | under the heading `### Approvals (Flow Nodes)`: "Since ADR-0019 there is no standalone approval-process type" |
| `skills/objectstack-platform/SKILL.md` | `:83` | "an approval is authored as a flow with Approval nodes (ADR-0019)" |

The pair is `0019-approval-as-flow-node` vs `0019-app-as-consumer-unit`, and context selects the record at every one. Recorded here so a later sweep does not "correct" them.

The generator-owned `skills/*/references/_index.md` mentions are also untouched: they are generated, and they are self-disambiguating already (`Metadata Protection Model — Phase 1 (ADR-0010)`).

## Token readings

`scripts/check-skills-token-ratchet.mjs` is shrink-only and both files this skill package could have been paid from sat at exactly zero headroom, so the edit is paid for **inside the edited file**. No ceiling is changed and nothing is re-wrapped; both edits are deletions.

Counting convention is the gate's own: `ceil(utf8 bytes / 4)`.

| file | ceiling | tokens before | tokens after | delta |
|:---|---:|---:|---:|---:|
| `skills/objectstack-data/SKILL.md` | 10009 | 10009 | **9996** | −13 |
| `skills/objectstack-data/rules/security.md` | 2480 | 2480 | 2480 | 0 (untouched) |

Gate verdict lines, quoted:

```
✓ check-skills-token-ratchet: skills/objectstack-data/SKILL.md is 9996 tokens (ceiling 10009; headroom 13).
✓ check-skills-token-ratchet: skills/objectstack-data/rules/security.md is 2480 tokens (ceiling 2480; headroom 0).
```

### Published-surface size readings

Required for any diff touching `skills/**`. Lines are the unit; tokens reported alongside because the sibling gate prices this surface in tokens.

| scope | lines before → after | tokens before → after | bytes before → after |
|:---|:---|:---|:---|
| `skills/objectstack-data/SKILL.md` (edited file) | 851 → 850 (−1) | 10009 → 9996 (−13) | 40034 → 39983 (−51) |
| `skills/objectstack-data/**` (whole skill package) | 3727 → 3726 (−1) | 38150 → 38137 (−13) | 152599 → 152548 (−51) |
| all published `SKILL.md` (catalog) | 6862 → 6861 (−1) | 79737 → 79725 (−12) | 318948 → 318897 (−51) |

Every reading is negative in every unit. Nothing is added anywhere.

## Gates

All run under `scripts/pm/os-verify-lock.sh`, each exit code captured by redirect **before** any pipe, each gate's own verdict line quoted. Union re-derived after the last edit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` at `bf410c1a` — the same commit every reading below was taken on.

| gate | exit | its own verdict line |
|:---|---:|:---|
| `node scripts/check-skills-token-ratchet.mjs` | 0 | `✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.` |
| `node scripts/check-skills-token-ratchet.mjs --self-test` | 0 | `✓ check-skills-token-ratchet self-test: 64 cases pass.` |
| `pnpm check:skill-identifier-liveness` | 0 | `check-skill-identifier-liveness OK — Leg 1: 465 citation(s) over 46 published file(s) …; Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s).` |
| `pnpm --filter @objectstack/spec run check:skill-examples` | 0 | `✅ 256 prose examples type-check across 3 surface(s) — every marked block parsed, so tsc ran the SEMANTIC pass on all of them` |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | `✅ Skill docs in sync` |
| `pnpm check:role-word` | 0 | `check-role-word: OK, no new occurrences of the reserved word.` |
| `pnpm check:published-readme-links` | 0 | `✓ check:published-readme-links — 176 outbound link(s) across 60 published markdown file(s): 0 root-relative, 0 non-canonical origin(s), 27 docs-site page(s) resolved (0 via redirect), 1 anchor(s) verified, 103/103 relative target(s) found in the tree.` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8052 text file(s) … no raw ASCII control bytes).` |
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 130 declared cross-package glob(s) (92 unique) are covered by core or crosspkg …` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `pnpm check:cross-package-test-inputs` | 0 | same verdict line as above |
| `node scripts/check-shard-attestation.mjs` | 0 | `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).` |
| `node scripts/check-test-completeness.mjs` | **3** | **NOT MEASURED** — see below |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions (spec TSDoc, #6763): 9 @example(s) judged clean across 1120 packages/spec/src files …` |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 430 file(s) · 5686 bare double-dash token(s) · 1382 launcher-rooted run(s) · 9 separator(s) JUDGED …` |
| `pnpm check:corpus-claim-drift` | 0 | `check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 14546 customer-facing string(s) across 710 spec sources clean — no internal issue-id references …` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 243 assertions …` |
| `pnpm check:skill-compatibility` | 0 | `✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 79 workspace packages` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |

`check-test-completeness` exit 3 is **NOT MEASURED**, in the gate's own words, not a red:

```
⚠ Arrived here from the gate family `scripts/pm/dispatch-gates.mjs` derives?
That list names this script with NO argument, which is this branch. There is no
local log to hand it, so the local reading for this gate is NOT MEASURED.
⛔ It is not a red, and there is nothing here to fix.
```

`check:skill-examples` first refused with a build prerequisite (`packages/client-react/dist holds no .d.ts declarations`) — the gate's own false-green refusal, exit 1 with no verdict on any surface. It was satisfied by building rather than reported as unmeasured: `pnpm --workspace-concurrency=2 --filter '@objectstack/client-react...' --filter '@objectstack/client...' build`, after which the gate ran to a real green. The reading above is that second, measured run.

Fence census across the edit, as an independent check that no marked block moved: the `os:check` marker count in `SKILL.md` is 5 before and 5 after, and the fence-line count is 24 before and 24 after.

## Premise checks

Four premise checks on what the dispatch and the card stated. None changes the disposition; the first three change a count.

1. **Four sites were expected; two exist.** The card measured four (`:855` `:897` `:915` `:936`), the unlock scan re-measured four (`:861` `:903` `:921` `:942`), and the dispatch expected four. Today `git grep -n "ADR-0010" -- skills/objectstack-data` returns **two** in `SKILL.md` plus the two generator-owned `references/_index.md` mentions. Cause, measured: commit `940c1289` (PR #14427, "optimization flight … net −9,044 tokens", 2026-09-02) deleted the `sys_role` and `app/setup` protection examples wholesale, taking their `reason: '… — see ADR-0010.'` strings with them. `git grep -c ADR-0010 940c1289^ -- skills/objectstack-data/SKILL.md` = 4; at `940c1289` = 2. So one `reason:` site remained to repair, not three.
2. **Five `ADR-0019` sites were expected; three exist.** The card and the dispatch both name five (`automation:278,289,436,806` and `platform:187`). `git grep -n "ADR-0019" -- skills/` returns three today, at `automation:410`, `automation:424` and `platform:83`. The verdict is unchanged — every survivor still sits in text that selects `0019-approval-as-flow-node`, quoted in the table above — but the count and the line numbers in the card are stale, the same way the `ADR-0010` ones were.
3. **The remaining `ADR-0010` sites are not in `rules/security.md`.** The dispatch suggested #14673's split may have moved them there. It did not: `rules/security.md` carries no `ADR-0010` at all, and the split (`446117fc`) left the `ADR-0010` count in `SKILL.md` unchanged at 2 on both sides.
4. **The dispatch's `ADR-0010` line numbers held.** `:567` (prose) and `:611` (`reason:`) are correct at `224f8ea4`; it is the card's and the unlock scan's numbers that are stale.

Two notes on the gate list rather than on the card: the derived union names eleven gates the dispatch did not (all run above, all green), and the dispatch named three that the union does not derive (`check:skill-examples`, `check:published-readme-links`, `check:nul-bytes`) — run anyway.

## Governed surface

`skills/**` is a governed surface (Prime Directive #14). This PR is a **draft** and stays one: no merge, no queue, no auto-merge, no ready flip from any agent seat. `skip-changeset` is applied — this diff publishes nothing from any package, matching the precedent of the two most recent skills-only landings (`940c1289`, `446117fc`), neither of which carried a changeset. No `needs:contract-review`: this is provenance text, and it makes no contract claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1