### PR TITLE
fix(skills): teach {current_user_id}, not $currentUser, in the objectstack-ui Filtering example

### DIFF
--- a/skills/objectstack-ui/rules/list-views.md
+++ b/skills/objectstack-ui/rules/list-views.md
@@ -92,7 +92,7 @@ columns: [
 ```typescript
 filter: [
   { field: 'status', operator: 'not_equals', value: 'closed' },
-  { field: 'assigned_to', operator: 'equals', value: '$currentUser' },
+  { field: 'assigned_to', operator: 'equals', value: '{current_user_id}' },
 ]
 ```
 
@@ -100,7 +100,7 @@ Common operators: `equals`, `not_equals`, `contains`, `starts_with`,
 `greater_than`, `less_than`, `is_empty`, `is_not_empty`, `in`, `not_in`,
 `this_week`, `this_month`, `this_quarter`, `last_n_days`.
 
-> **`$currentUser`** is a runtime variable — the logged-in user's ID.
+> **`{current_user_id}`** resolves to the signed-in user's id.
 
 ### End-User Quick Filters (`userFilters`, ADR-0047)
 


### PR DESCRIPTION
Fixes #14139

`skills/objectstack-ui` taught `$currentUser` as a filter value. Nothing resolves
it. The example and its note now teach `{current_user_id}`, the declared token,
so the rule file agrees with the package's own filter-placeholder contract.

## Step 1 — the route, settled at source

**Route 1.** No filter path resolves the literal `$currentUser`, on either side
of the wire, and no legacy alias maps it. Route 2 (an ADR-0087 conversion-layer
question) does not arise.

### Where the literal was searched — every place, with a positive control

| # | Search | Tree | Result | Positive control on the same tree |
|:--|:-------|:-----|:-------|:----------------------------------|
| 1 | `git grep -n -F '$currentUser'` (all tracked paths) | objectstack @ `224f8ea4` | 4 hits, **none in a filter resolution path**: `docs/adr/0017-object-has-many-view.md:216` (SQL-shaped prose), `packages/cli/src/commands/explain.ts:128` (an `assignment` default value — a different surface), and the two sites fixed here | same grep finds the 4 hits, so the pattern is live |
| 2 | `git grep -ni 'currentuser'` excluding `*CHANGELOG.md` | objectstack @ `224f8ea4` | 118 hits; **zero** are a filter-token vocabulary entry | `packages/spec/src/data/context-tokens.test.ts:44` REJECTS `currentUserId` among near-misses; `packages/spec/src/data/default-value-shape.test.ts:54` pins `currentUser (camelCase) is a literal` |
| 3 | `git grep -n -F '$currentUser'` | objectui @ `67dadd6` | 2 hits, both `packages/types/src/__tests__/phase2-schemas.test.ts:791,808` — `ListViewSchema.safeParse(...)` **shape** assertions on a tab's filter array. Neither asserts resolution | `current_user_id` on the same tree: 14 hits in `packages/core/src/utils/filter-tokens.ts` and 14 in its test |
| 4 | `git grep -n -E "'\$[a-zA-Z]"` over `packages/core/src`, `packages/objectql`, `packages/lint/src`, `packages/spec/src` | objectstack @ `224f8ea4` | only Mongo-style operators (`$in`, `$and`, `$or`, `$not`, `$gte` …) and `$source` / `$root` — **no `$`-prefixed session-token alias table anywhere** | the same regex over `packages/` does return `explain.ts:128`, so it can see the shape it is looking for |

### Why nothing can resolve it — the mechanism, not an absence of hits

A filter value is recognised as a placeholder **only when the whole value is
brace-wrapped**. `$currentUser` carries no braces, so it is not classified as a
placeholder at all — not even as an unknown one.

| Layer | Source | Recognition |
|:------|:-------|:------------|
| Vocabulary | `packages/spec/src/data/context-tokens.zod.ts:84` | `CONTEXT_TOKENS = ['current_user_id', 'current_org_id']` — the complete set |
| Recognition grammar | `packages/spec/src/data/context-tokens.zod.ts:146` | `FILTER_TOKEN_WRAPPED_RE = /^\$?\{([^{}]+)\}$/` |
| Classifier | `packages/spec/src/data/context-tokens.zod.ts:239-253` | `classifyFilterToken` returns `null` when that regex does not match — i.e. "not a placeholder", pass through verbatim |
| Client resolver | objectui `packages/core/src/utils/filter-tokens.ts:107,135,209` | `WHOLE_TOKEN_RE = /^\$?\{([a-zA-Z0-9_]+)\}$/`, used by `resolveContextTokens` and `resolveFilterPlaceholders` |
| Server resolver | `packages/core/src/utils/filter-tokens.ts:364` | `resolveFilterTokens` walks with the same `classifyFilterToken`; its `hasFilterToken` pre-pass returns `false` for a tree holding only `$currentUser` |
| Lint rule | `packages/lint/src/validate-filter-tokens.ts:65,123-124` | `filter-token-unknown` pushes a finding **only** when `classifyFilterToken(node)?.kind === 'unknown'` |

Consequence, and it is sharper than the card assumed: because `$currentUser` is
unbraced it is not a placeholder *attempt*, so `filter-token-unknown` never fires
on it and `resolveFilterTokens` never throws. The value reaches the data engine
as a literal string, matches no record, and the list renders empty — with no
build error and no runtime warning anywhere. The card offered "a red
`os validate` **or** a silent empty list"; only the silent half is reachable.

## The change

Two lines in `skills/objectstack-ui/rules/list-views.md`, in the `### Filtering`
section. The example keeps its shape.

**Example — before**

```
  { field: 'assigned_to', operator: 'equals', value: '$currentUser' },
```

**Example — after**

```
  { field: 'assigned_to', operator: 'equals', value: '{current_user_id}' },
```

**Note — before** (71 bytes)

```
> **`$currentUser`** is a runtime variable — the logged-in user's ID.
```

**Note — after** (62 bytes, i.e. no more than the old note)

```
> **`{current_user_id}`** resolves to the signed-in user's id.
```

Every claim in the new note is traceable to a source line:

| Claim | Source line |
|:------|:------------|
| `{current_user_id}` is a declared filter token | `packages/spec/src/data/context-tokens.zod.ts:84-87` |
| it *resolves* (it is not a literal) | `packages/core/src/utils/filter-tokens.ts:364` (server) and objectui `packages/core/src/utils/filter-tokens.ts:209` (client) |
| it is "the signed-in user's id" | `packages/spec/src/data/context-tokens.zod.ts:176` — `CONTEXT_TOKEN_DESCRIPTIONS.current_user_id = "The signed-in user's id (\`sys_user.id\`)."` |

After the change the rule file agrees with its own package entry:
`skills/objectstack-ui/SKILL.md` → `## Date Macros — Filter Placeholders` names
`{current_user_id}` / `{current_org_id}` and delegates the vocabulary to
`objectstack-query` → `rules/filters.md`.

## Token budget — shrink-only, ceiling untouched

The ratchet convention is `ceil(utf8 bytes / 4)`.

| Reading | Before | After | Delta |
|:--------|-------:|------:|------:|
| `rules/list-views.md` bytes | 12,043 | 12,039 | −4 |
| `rules/list-views.md` tokens | 3,011 | 3,010 | **−1** |
| `rules/list-views.md` lines | 306 | 306 | 0 |
| package `skills/objectstack-ui/` — hand-authored (ratcheted) tokens | 24,189 | 24,188 | **−1** |
| package `skills/objectstack-ui/` — whole package tokens (incl. generator-owned) | 33,899 | 33,898 | −1 |
| package `skills/objectstack-ui/` — hand-authored lines | 1,980 | 1,980 | 0 |

The honest rewrite is net **negative**, so no payment was needed and no
restatement was deleted. **No ceiling was changed**: the row stays
`['skills/objectstack-ui/rules/list-views.md', 3011]`, and the gate's own line is

```
✓ check-skills-token-ratchet: skills/objectstack-ui/rules/list-views.md is 3010 tokens (ceiling 3011; headroom 1).
```

No re-wrap was used as payment — the diff is two whole-line replacements, and
the line count is unchanged.

## Gates

All run under `scripts/pm/os-verify-lock.sh`, each exit code captured by
redirect **before** any pipe, each verdict quoted from the gate's own output.

| Gate | Exit | The gate's own verdict line |
|:-----|:----:|:----------------------------|
| `node scripts/check-skills-token-ratchet.mjs` | 0 | `✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.` |
| `node scripts/check-skills-token-ratchet.mjs --self-test` | 0 | `✓ check-skills-token-ratchet self-test: 64 cases pass.` |
| `pnpm check:skill-identifier-liveness` | 0 | `check-skill-identifier-liveness OK — Leg 1: 465 citation(s) over 46 published file(s) …; Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s).` |
| `pnpm --filter @objectstack/spec run check:skill-examples` | 0 | `✅ 256 prose examples type-check across 3 surface(s) — every marked block parsed, so tsc ran the SEMANTIC pass on all of them` |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | `✅ Skill docs in sync` |
| `pnpm check:role-word` | 0 | `check-role-word: OK, no new occurrences of the reserved word.` (`Scanned: 224 .md/.mdx file(s) … skills 34`) |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8052 text file(s) … no raw ASCII control bytes).` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | ran clean (no findings emitted) |

### The re-derived union

Re-derived **after** the last edit with
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`,
which reported `gate list derived from the tree of 'objectstack-ai/objectstack' at commit 482fb9c75`
and a change set of 1 path. Every command it named was run:

| Gate | Exit | The gate's own verdict line |
|:-----|:----:|:----------------------------|
| `node scripts/check-ci-filter-parity.mjs` | 0 | `OK: all 130 declared cross-package glob(s) (92 unique) are covered …` |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | `OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.` |
| `node scripts/check-shard-attestation.mjs` | 0 | `✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s).` |
| `node scripts/check-skills-token-ratchet.mjs` | 0 | (above) |
| `node scripts/check-test-completeness.mjs` | 3 | **NOT MEASURED** — `check-test-completeness: PREREQUISITE NOT MET — this gate grades a saved 'turbo run test' log, and no log was named.` The gate's own text adds: *"running the family locally, record this gate as NOT MEASURED. ⛔ It is not a red, and there is nothing here to fix."* |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | (above) |
| `pnpm check:agent-test-spelling` | 0 | ran clean |
| `pnpm check:corpus-claim-drift` | 0 | `check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.` |
| `pnpm check:cross-package-test-inputs` | 0 | `All 117 self-test cases passed.` + `OK: 25 package(s) read outside themselves, all declared …` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 46 published skill files clean — no internal issue-id references.` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 243 assertions …` + `live: the real generator declared 9 output(s) and certified this tree` |
| `pnpm check:role-word` | 0 | (above) |
| `pnpm check:skill-compatibility` | 0 | `✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 79 workspace packages` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| `pnpm check:skill-identifier-liveness` | 0 | (above) |

The union derivation also notes that 9 further families "apply once this card's
changeset exists" — this PR carries `skip-changeset` (below), so those paths do
not exist and those families do not apply.

`check:skill-examples` needed a build prerequisite on its **client SDK** surface
(`packages/client-react/dist holds no .d.ts declarations — the package is not
built`), which is unrelated to this diff. It was satisfied
(`pnpm --filter '@objectstack/client-react...' build`, then
`pnpm --filter '@objectstack/client...' build`, both exit 0) and the gate re-run,
so the row above is a real measurement and not a NOT MEASURED.

### Fence census — the `### Filtering` example is not a typed block

`check:skill-examples` extracts a fence only when the line directly above it
carries an `os:check` marker (an HTML comment — written here as the bare token so
this body survives GitHub's sanitizer). Census of
`skills/objectstack-ui/rules/list-views.md`:

| Reading | Before (`224f8ea4`) | After (`482fb9c7`) |
|:--------|:--------------------|:-------------------|
| `os:check` marker lines | 11, 166, 221 | 11, 166, 221 |
| marker count | 3 | 3 |
| fence open/close lines (all 10 blocks) | 12/27, 38/47, 57/73, 92/97, 111/128, 167/184, 222/234, 245/254, 264/276, 288/302 | identical |
| file lines | 306 | 306 |

**No marker moved and no fence moved.** The `### Filtering` fence opens at line 92
and line 91 is blank — no marker — so that block is not among the gate's
extracted examples, before or after. The gate's skills+docs surface count is
unchanged at 224 blocks.

## `skip-changeset`

This PR publishes nothing from any package: `skills/` is not listed in any
package manifest's `files`, and no build step copies it into a published
artifact. Merged precedent on this exact surface — `58ea39a5d` (#14658),
`446117fc2` (#14673), `c985ae958` (#14660) — are all skills-only merges and none
carries a `.changeset/*.md`. `Check Changeset` requires an added `.changeset/*.md`
unless the label is present, so the label is what keeps a release-less PR green.

## Premises that did not hold

| # | The premise | What the tree says |
|:--|:------------|:-------------------|
| 1 | The example and note live in `skills/objectstack-ui/SKILL.md` | They live in `skills/objectstack-ui/rules/list-views.md`. The ui split (#14658) moved them. Same published package, different file — and the fix landed on the file that actually holds the text |
| 2 | The file has a `## Context Tokens` section stating "the only two tokens" | That heading exists nowhere under `skills/` any more. The surviving contract half is `## Date Macros — Filter Placeholders` in `skills/objectstack-ui/SKILL.md`, which delegates the vocabulary to `objectstack-query` → `rules/filters.md`. So the contradiction spanned two files in one package, not two halves of one file |
| 3 | The governing ceiling is 3,815 with headroom 0 | 3,815 is `SKILL.md`'s row, untouched here. The row governing this edit is `['skills/objectstack-ui/rules/list-views.md', 3011]` — headroom 0 before, 1 after |
| 4 | An author writing `$currentUser` gets a red `os validate` (`filter-token-unknown`) **or** a silent empty list | Only the silent half is reachable. `filter-token-unknown` fires on `kind === 'unknown'`, which requires a brace-wrapped value; `$currentUser` classifies as `null` (not a placeholder) and is passed through verbatim |
| 5 | The `### Filtering` example is a typed block checked by `check:skill-examples` | It is not. That gate extracts only fences carrying an `os:check` marker on the line directly above (`packages/spec/scripts/check-skill-examples.ts:398,601`). The `### Filtering` fence has none — see the fence census above |

Nothing else in the card's scope changed: `packages/cli/src/commands/explain.ts`
and `docs/adr/0017-object-has-many-view.md` are untouched, as dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_