### PR TITLE
docs(agents): a released-package bug fix takes a patch changeset, never none

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1113,8 +1113,10 @@ registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
    surface** (Prime Directive #14 names them — more than ADRs): push it, open the PR,
    and stop there, landing it is the maintainer's, by hand. For that class, a
    finished task = a PR left visibly awaiting a human merge.
-3. **Add a changeset for feature work.** When the change is a feature or functional improvement, run `pnpm changeset`
-   (or add a `.changeset/*.md` entry) describing it before committing. Pure bug fixes do **not** require a changeset.
+3. **Add a changeset for anything that publishes.** Feature, functional improvement or fix — run `pnpm changeset`
+   (or add a `.changeset/*.md` entry) describing it before committing. A bug fix in a released package takes a
+   **`patch`** changeset — never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes
+   nothing from any released package.
    **Breaking changesets must carry their migration.** If the change removes or renames anything an author can write (a
    spec key, an export, a config field), the changeset body must state the FROM → TO mapping and the one-line fix —
    this text ships to consumers as `CHANGELOG.md` inside the npm package and is what an upgrading agent greps after the
@@ -1133,14 +1135,7 @@ registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
    <!-- adr-0087: not-required (already-registered SOME-MIGRATION-ID) why -->
    <!-- adr-0087: not-required (no-migration-prescription) why -->
    ```
-   Why it is asked of you at all: the ADR-0087 gates pin ledger ↔ **artifact synchrony**, and the artifacts are a pure
-   projection of the registry — a retirement whose entry was **never written** leaves everything perfectly consistent
-   and every gate green (a removal has shipped that way, caught only by a human comparing by eye). Ledger entries are
-   the sole channel that reaches an upgrader (`objectstack migrate meta`, `spec-changes.json`, the upgrade guide) —
-   for a surface with no spec schema there is no tombstone or schema rejection either. Roughly 1 declared-breaking
-   change in 7 needs an entry, so `not-required` is the ordinary answer and costs one line; the markers are re-verified
-   mechanically, and `no-migration-prescription` is refused when the changeset's own body carries a FROM → TO
-   prescription.
+   Why it is asked of you at all: the gate prints the argument when it fails — that output is the authority.
 4. **A removal that breaks the pinned sibling checkout ships together with the sibling fix and the pin bump — or it
    does not ship.** The `Console Pin Gate` job builds objectui at the pinned `.objectui-sha` against **current** `main`,
    so a removal or rename the pinned sibling still imports turns `main` red for every PR in the repo the moment it


### PR DESCRIPTION
Fixes #14647

`AGENTS.md:1117` told authors 「Pure bug fixes do **not** require a changeset.」 Every enforced text disagrees, so a bug fix in a released package that followed the sentence literally had **no green path** through `Check Changeset`.

## Ruled scope (triage comment 5514271473, adopted verbatim)

One sentence, saying two things:

1. a bug fix in a released package takes a `patch` changeset;
2. `skip-changeset` is **never** the answer for a released-package bug fix — that label is for a diff that publishes nothing from any released package.

Nothing was widened or reinterpreted beyond that.

## Before / after, verbatim

**Before** — `AGENTS.md:1116-1117`:

```
3. **Add a changeset for feature work.** When the change is a feature or functional improvement, run `pnpm changeset`
   (or add a `.changeset/*.md` entry) describing it before committing. Pure bug fixes do **not** require a changeset.
```

**After** — `AGENTS.md:1116-1119`:

```
3. **Add a changeset for anything that publishes.** Feature, functional improvement or fix — run `pnpm changeset`
   (or add a `.changeset/*.md` entry) describing it before committing. A bug fix in a released package takes a
   **`patch`** changeset — never none, and ⛔ never `skip-changeset`: that label is for a diff that publishes
   nothing from any released package.
```

The instruction that survived unchanged is the middle clause — run `pnpm changeset`, or add a `.changeset/*.md` entry, describing it before committing. Only the final sentence was replaced, and the item's lead was re-aimed from "feature work" to "anything that publishes", since that is now what the item says.

## The two dates that settle the "predates the gate" reading

The triage's reading is **confirmed**, and by a wider margin than the card assumed. Read from full history — the container's checkout is shallow, and both probes bottom out at the horizon commit until it is unshallowed, which is a trap worth naming: `git log -S` on a shallow clone reports the horizon commit as the introduction of text that is in fact much older.

| When | Commit | State of the changeset check |
|:---|:---|:---|
| **2026-05-30** | `43625fbd6c` | The sentence lands. The step emits `::warning::` only and **cannot fail** — a zero-changeset bug fix is green by construction. |
| 2026-06-11 | `a1251e4737` | The step becomes blocking: `::error::` plus `exit 1`. |
| **2026-07-21** | `8ff9210947` | The step starts counting changesets **added by the PR** rather than globbing the whole `.changeset` directory. This is the form that actually reds a zero-changeset bug fix. |

The 2026-07-21 commit is explicit about why the earlier form could not bite, in its own inline comment: in pre-release mode `changeset version` retains every consumed `.md` file, so "the directory is permanently non-empty and the gate can never go red".

So on the day the sentence was written it was **true** — nothing forced a changeset for anything. It did not become wrong by being mis-worded; it became wrong when enforcement arrived under it, twelve days later for blocking and seven weeks later for the counting form. That is a refinement of the triage's gloss, not a contradiction of it: the sentence is stale relative to a gate that post-dates it, and correcting it to "a `patch` changeset" is repair rather than a policy change. Reported to the dispatching seat as such.

## The payment

`AGENTS.md` is at its line ceiling — ratchet row `['AGENTS.md', 1162]` at `scripts/pm/check-skill-line-ratchet.mjs:529`, headroom 0 — so the correction is paid by a same-file deletion. Nothing was re-wrapped; both edits are whole-line splices.

**Deleted:** the eight-line ADR-0087 rationale paragraph at `AGENTS.md:1136-1143`, replaced by a one-line citation in the file's own established idiom (compare `:15`, `:916`, `:1012` — "its header is the authority on detail").

**Why it is a restatement:** the paragraph is a paraphrase of `scripts/check-adr-0087-registration.mjs`'s **own failure output** — the `report()` block at `:2976-2996`, which prints to the author at exactly the moment they hit the gate. That is strictly better placed than prose in an instruction file the author may never re-read.

| Deleted clause | Surviving single site |
|:---|:---|
| the ADR-0087 gates pin ledger ↔ artifact synchrony | `check-adr-0087-registration.mjs:2980-2981` |
| the artifacts are a pure projection of the registry | `:2982-2983` |
| an entry never written leaves everything consistent, every gate green | `:2983-2984` |
| a removal shipped that way, caught only by a human comparing by eye | `:2984-2985` |
| ledger entries are the sole channel reaching an upgrader (`objectstack migrate meta`, `spec-changes.json`, the upgrade guide) | `:2987-2990` |
| for a surface with no spec schema there is no tombstone or schema rejection either | `:2988-2990` |
| roughly 1 declared-breaking change in 7 needs an entry, so `not-required` is the ordinary answer and costs one line | `:2992-2994` |
| `no-migration-prescription` is refused when the body carries a FROM → TO prescription | `:227`, and `:2633`, also emitted output |

Eight of eight. The four marker spellings themselves are **untouched** — the fenced block immediately above the deleted paragraph still lists all four, and the sentence naming `pnpm check:adr-0087-registration` and its CI step is untouched too, so the citation's antecedent is two lines up.

## Line arithmetic

| | Lines |
|:---|---:|
| `AGENTS.md` before | 1,162 |
| correction, `:1116-1117` becomes `:1116-1119` | +2 |
| payment, `:1136-1143` becomes one line | −7 |
| **after** | **1,157** |
| ceiling (ratchet row) | 1,162 |
| **headroom** | **5** |

Every edited line is ≤ 120 **bytes** in UTF-8 — 115 / 110 / 112 / 37 for the correction and 110 for the citation, measured in bytes rather than characters because the em dash and ⛔ are three bytes each. The widest-table-row pin is untouched at 1,081 bytes, and `check:pm-skill-id-lint`'s population is respected: the new text carries no issue or PR numbers.

## Edit-landed-on-disk proof

| Measurement | Before | After |
|:---|---:|---:|
| `wc -l AGENTS.md` | 1,162 | 1,157 |
| `grep -c 'Pure bug fixes do'` | 1 | 0 |
| `grep -c 'sole channel that reaches an upgrader'` | 1 | 0 |
| `grep -c 'skip-changeset'` | 0 | 1 |
| `grep -c 'released package takes a'` | 0 | 1 |
| `grep -c 'that output is the authority'` | 0 | 1 |

`git diff --stat`: 1 file changed, 5 insertions, 10 deletions.

## Gates — head `796501faa9`

The union was re-derived **after** the last edit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`. It reported the list derived from this repo at `796501faa9`, change set against merge base `dee4dd4ba` — one path, `AGENTS.md`. Every exit code was captured by redirect before any pipe.

| Command | Exit | Verdict line |
|:---|---:|:---|
| `pnpm check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: AGENTS.md is 1157 lines (ceiling 1162; headroom 5).` and `✓ … AGENTS.md: widest table row is 1081 bytes (pin 1081; headroom 0).` |
| `pnpm check:pm-skill-ratchet --self-test` | 0 | `✓ check-skill-line-ratchet self-test: 111 cases pass.` |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `pnpm check:pm-governed-prose` | 0 | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces … and claim no others.` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8063 text file(s) … no raw ASCII control bytes).` |
| `pnpm check:corpus-claim-drift` | 0 | `check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.` |
| `node scripts/check-required-contexts.mjs` | 0 | `✓ check-required-contexts: 6 required context name(s) pinned across 2 workflow(s) …` |
| `pnpm check:required-contexts` | 0 | `✓ check-required-contexts --self-test: 150 assertions …` |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 430 file(s) …` |
| `pnpm check:docs-audit-scope` | 0 | `✓ docs-accuracy-audit scope is in sync with content/docs/: 190 hand-written doc(s) …` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 243 assertions …` |

The baseline ratchet verdict before the edit, for comparison: `✓ check-skill-line-ratchet: AGENTS.md is 1162 lines (ceiling 1162; headroom 0).` No gate answered a "PREREQUISITE NOT MET" or exit 3, so none is recorded NOT MEASURED. The derivation also noted nine further families that would apply once a changeset file exists — this PR deliberately has none, see below.

## eslint

Not a narrowing — a measurement that the intersection is empty.

- **Population, read from `eslint.config.mjs` itself:** every `files:` glob is `**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` or a narrowing of it. There is no `.md` or `.mdx` glob and no markdown processor or plugin anywhere in the config.
- **`--format json` reading for `AGENTS.md`:** `errorCount: 0`, `fatalErrorCount: 0`, and the single message is `"File ignored because no matching configuration was supplied."`
- **Invariance:** the diff touches exactly one file and that file is outside eslint's population by extension. No type-aware linting is in play for it, so this diff cannot move a lint verdict on any untouched file.

## Changeset

`skip-changeset` applied. This diff publishes nothing from any released package: it touches exactly one file, `AGENTS.md`, a repo-root instruction surface that no package `files` list ships and that `changeset version` never bumps. Against `scripts/check-empty-changeset.mjs`'s own enumeration, the alternative — an empty-frontmatter changeset — is precisely what that gate exists to reject: it "buys nothing the label does not, and uniquely carries the risk", being a real input to `changesets/action` that can stall a release while the run still goes green.

## Merge path

**Draft, and it stays draft — governed `AGENTS.md`, human merge is the review record.** Auto-merge is not enabled and no reviewers were requested; requesting review is the dispatching seat's step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_