### PR TITLE
docs(skills): settle two false claims in skills/README.md and add three cross-skill routing bullets

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -84,7 +84,8 @@ carries `SKILL.md` alone — `gen:skill-refs` only visits skills listed in its
 - **Short object names** (`account`, `task`); no `namespace`, no `tableName`.
 - **CEL for all expressions** — predicates, conditions, schedules. Use the
   `F\`\``, `P\`\``, `cel\`\``, `cron\`\``, `tmpl\`\`` tagged templates from
-  `@objectstack/spec`. Legacy `OLD` / `NEW` evaluate to `null` since M9.5.
+  `@objectstack/spec`. Legacy `OLD` / `NEW` are not CEL — use
+  `previous.` / `record.`.
 - **v5.0 vocabulary** — runtime workspace is `environment`, not `project`.
 - **Singular metadata type names** (`agent`, `view`, `flow`, …); REST resource
   collections are plural (`/api/v1/ai/agents`).
@@ -102,10 +103,14 @@ A few common decision points where the right skill isn't obvious:
   **automation** (screen flows). Static record / list / dashboard surfaces are
   **ui**.
 - **Any CEL expression** — load **objectstack-formula** alongside the host
-  skill (data validations, automation guards, UI visibility, AI tool params).
+  skill (data validations, automation guards, UI visibility).
 - **Kernel / plugin events vs. data lifecycle** — `PluginContext` lifecycle and
   `EventBus` belong to **objectstack-platform**; record-level hooks belong to
   **objectstack-data**.
+- **Labels vs. bundles** — a `label` you want translated is **objectstack-i18n**.
+- **Upgrade vs. platform** — a protocol-major move is **objectstack-upgrade**.
+- **Rendering this metadata** — the consuming UI is
+  [objectui `skills/objectui/`](https://github.com/objectstack-ai/objectui).
 
 ---
 


### PR DESCRIPTION
Fixes #14794
Fixes #14566

Three edits to `skills/README.md`, and nothing else. Branch point re-measured at
`origin/main` `89a156af88` — identical to the card's measurement, **no drift**.
Head sha for every gate reading below: **`39da552e61`**.

## Item 1 — `:87`, the `OLD` / `NEW` clause

**Before** (verbatim):

> `@objectstack/spec`. Legacy `OLD` / `NEW` evaluate to `null` since M9.5.

**After** (verbatim):

> `@objectstack/spec`. Legacy `OLD` / `NEW` are not CEL — use
> `previous.` / `record.`.

**What settles it.** The sentence was false in both halves.

- `M9.5` is anchored nowhere: `git grep -rn 'M9\.5' -- packages skills docs` returns
  exactly one hit, this README line itself. Nothing defines the milestone it cites.
- `OLD` / `NEW` are not values that evaluate to `null` — they are **undeclared
  identifiers**. `SCOPE_ROOTS` (`packages/formula/src/cel-engine.ts:95-119`) is the
  published, closed set of roots a record-scoped CEL site may reference; it contains
  neither. `firstUndeclaredReference` (`packages/formula/src/cel-engine.ts:186-205`)
  therefore reports them as bare undeclared references — the class
  `@objectstack/lint` raises as an **error**, not a silent null
  (`packages/lint/src/validate-expressions.ts:490`, "Why it is an error and not a
  warning").

Measured directly against the built package rather than inferred:

```
SCOPE_ROOTS includes OLD: false | NEW: false | previous: true | record: true
"OLD.amount != NEW.amount" -> firstUndeclaredReference = "OLD"
"OLD"                      -> firstUndeclaredReference = "OLD"
"NEW.status"               -> firstUndeclaredReference = "NEW"
"previous.amount != record.amount" -> firstUndeclaredReference = null
```

The replacement's prescription is objectstack-formula's own migration table, not a
new claim: `skills/objectstack-formula/SKILL.md:345-346` maps `OLD.x` to
`previous.x` and `NEW.x` to `record.x`. The two published files now agree.

## Item 2 — `:105`, "AI tool params" in the "Any CEL expression" bullet

**Before** (verbatim):

> skill (data validations, automation guards, UI visibility, AI tool params).

**After** (verbatim):

> skill (data validations, automation guards, UI visibility).

**What settles it — and a correction to the card.** The card's diagnosis is
confirmed and its prescribed replacement is **false**.

- Confirmed: `packages/spec/src/ai/tool.zod.ts` matches `cel|formula|expression`
  **zero** times. Tool params carry no expression field of any kind.
- Falsified: the card asked to substitute "a model-registry predicate, verified at
  `packages/spec/src/ai/model-registry.zod.ts`". There is no such field —
  `predicate` occurs **0** times in that file. Its only expression-typed keys are
  `system` / `user` at `:121-122`, and those are `TemplateExpressionInputSchema`,
  which `packages/spec/src/shared/expression.zod.ts:117-124` defines as
  `dialect: 'template'` — `{{var}}` interpolation, **not CEL**.
- `skills/objectstack-ai/SKILL.md:405-407` already says exactly this: the domain's
  expression site is "a model-registry `promptTemplate.system` / `.user`;
  `ToolSchema` carries no expression field of any kind."

So the AI domain has **no CEL site at all**, and there is no true item to swap in.
Taking the card's stated alternative, the item is dropped rather than replaced.
Adding an AI entry to a bullet headed "Any CEL expression" would have replaced one
false claim with another.

## Item 3 — three routing bullets (`:94-110`)

Added verbatim, in the existing bullets' shape:

```
- **Labels vs. bundles** — a `label` you want translated is **objectstack-i18n**.
- **Upgrade vs. platform** — a protocol-major move is **objectstack-upgrade**.
- **Rendering this metadata** — the consuming UI is
  [objectui `skills/objectui/`](https://github.com/objectstack-ai/objectui).
```

| Bullet | Cost | Verified against |
|:---|---:|:---|
| Labels vs. bundles (#14566, I18N-A-03) | **21 tok** / 84 B | `skills/objectstack-i18n/SKILL.md` frontmatter `description` — "Author ObjectStack translation bundles — **object/field labels**, view text …" |
| Upgrade vs. platform (UPG-A-01) | **21 tok** / 78 B | `skills/objectstack-upgrade/SKILL.md` frontmatter `description` — "Use when a project is on an older protocol major and must move to the current one, when `@objectstack/spec` was bumped across a major …" |
| Rendering this metadata (OUI-A-01) | **33 tok** / 134 B | Path confirmed present on the objectui checkout: `git ls-tree origin/main skills/objectui/` at objectui `origin/main` `39af82f` returns `SKILL.md`, `README.md`, `evals/`, `guides/`, `rules/` |
| **Total** | **75 tok** / 296 B | at the #14566 triage's ruling (comment 5514978050): one bullet, ~25 tokens |

Each routing claim was checked against the target skill's own frontmatter
`description`, so the bullet sends the reader where the skill says it triggers.

## The payment

Item 3's 75 tokens are the funded addition. Items 1 and 2 are funded **from each
other** and net to exactly zero:

- Item 2's drop of `, AI tool params` frees **16 B / 4 tok**.
- Item 1's truthful replacement costs **16 B / 4 tok**.
- Items 1 + 2 combined: **0 B, 0 tok** — neutral, as the budget requires.

One further payment is inside item 3 itself, and it is what brought the block from
84 tokens to the ruling's 75. Bullet 2's body does **not** restate "not
**objectstack-platform**"; the surviving site is the bullet's own heading,
**"Upgrade vs. platform"**, which already names both sides of the decision. That is
a strict restatement removed, not meaning shaved — the routing information (which
skill wins) is intact.

**No further payment was available.** The one candidate examined was the
`process`-skill paragraph at `:64-66` against the frontmatter rows at `:75`
(`compatibility` — "for a `process` skill that binds to no schema") and `:76`
(`metadata.domain` — "a delivery-process skill that teaches no schema"). Rejected:
the paragraph also carries two facts that survive nowhere else — that such a skill
"carries `SKILL.md` alone" (no `references/` directory) and the `SKILL_MAP`
mechanism behind it. Deleting it would have shaved meaning, so it was left alone.

## File token table

`ceil(utf8_bytes / 4)`, whole file:

| | Bytes | Tokens |
|:---|---:|---:|
| Before (`89a156af88`) | 7941 | 1986 |
| After (`39da552e61`) | 8237 | 2060 |
| **Delta** | **+296** | **+74** |

The entire delta is item 3's funded block; items 1–2 contribute zero.
`skills/README.md` is outside the token-ratchet population
(`scripts/check-skills-token-ratchet.mjs:133`), and the ratchet is green regardless.

Edit-landed-on-disk proof, grep counts before → after:

| Term | Before | After |
|:---|---:|---:|
| `M9.5` | 1 | **0** |
| `AI tool params` | 1 | **0** |
| `objectstack-i18n` | 1 | **2** |
| `objectstack-upgrade` | 1 | **2** |
| `objectui` | 1 | **2** |

## Gates — all at head `39da552e61`

Every exit code captured by redirect **before** any pipe; each row quotes the gate's
own verdict line.

| Gate | Exit | Verdict |
|:---|---:|:---|
| `pnpm --filter @objectstack/spec check:skill-docs` | 0 | `✅ Skill docs in sync` (`✓ skills/README.md`) |
| `node scripts/check-skills-token-ratchet.mjs` | 0 | `✓ 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.` |
| `node scripts/check-skills-token-ratchet.mjs --self-test` | 0 | `✓ check-skills-token-ratchet self-test: 64 cases pass.` |
| `pnpm check:role-word` | 0 | `check-role-word: OK, no new occurrences of the reserved word.` — 224 files, ledger unchanged at 43 baselined files / 120 occurrences |
| `pnpm check:skill-identifier-liveness` | 0 | `OK — Leg 1: 465 citation(s) over 46 published file(s) …; Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s).` |
| `pnpm check:skill-compatibility` | 0 | `✓ 11 SKILL.md file(s) reconciled against 79 workspace packages` |
| `pnpm check:published-readme-links` | 0 | `✓ 176 outbound link(s) across 60 published markdown file(s): 0 root-relative, 0 non-canonical origin(s), 27 docs-site page(s) resolved (0 via redirect), 1 anchor(s) verified, 103/103 relative target(s) found in the tree.` — the new objectui link resolves |
| `node scripts/check-nul-bytes.mjs` | 0 | `OK (scanned 8064 text file(s) … no raw ASCII control bytes)` |

### Re-derived union

`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`,
re-derived **after** the last edit. Provenance line confirms it read the right tree:
"gate list derived from the tree of 'objectstack-ai/objectstack' at commit
`39da552e61`", change set "1 path(s) vs merge base `89a156af8`" = `skills/README.md`.
All 16 commands run:

| Gate | Exit |
|:---|---:|
| `node scripts/check-ci-filter-parity.mjs` | 0 |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 |
| `node scripts/check-shard-attestation.mjs` | 0 |
| `node scripts/check-test-completeness.mjs` | 3 — NOT MEASURED |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 |
| `pnpm check:agent-test-spelling` | 0 |
| `pnpm check:corpus-claim-drift` | 0 |
| `pnpm check:cross-package-test-inputs` | 0 |
| `pnpm check:doc-authoring` | 0 |
| `pnpm check:merge-driver` | 0 |
| `pnpm check:pm-governed-merges` | 0 |
| `pnpm check:role-word` | 0 |
| `pnpm check:skill-compatibility` | 0 |
| `pnpm check:skill-frame-sync` | 0 |
| `pnpm check:skill-identifier-liveness` | 0 |

Two notes on that table:

- `check-test-completeness` exits **3 = PREREQUISITE NOT MET**, not red: it "grades a
  saved `turbo run test` log, and no log was named … the local reading for this gate
  is NOT MEASURED." CI tees the log and passes the path, so CI is unaffected.
- `check:doc-formula-expressions` **also** exited 3 on the first pass (it imports the
  compiled `@objectstack/formula` and `@objectstack/lint`). Rather than report a
  non-reading, both packages were built and the gate re-run — it is the gate nearest
  this change, since item 1 introduces `previous.` / `record.` into published prose.
  It then measured green:
  `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 426 files / 1365 TS blocks judged clean by @objectstack/formula.`

## Reverse-verification

**`check:skill-docs` can fail, and it names this file.** Guarded by
`trap restore EXIT INT TERM` with absolute paths throughout; the implementation was
committed **first**, so the restore leg points at a `HEAD` that already contains it.

- *Mutation landed on disk* — not inferred from an editor's exit code, but from grep
  counts flipping in both directions inside the generated region
  (`Construct ObjectQL queries` 1 → 0, `Construct ObjectQL queried` 0 → 1) and the
  worktree blob moving `72afcf31b7…` → `e60bea9ecc…`.
- *Mutated leg* — **exit 1**, verdict
  `✗ skills/README.md is out of date — run pnpm --filter @objectstack/spec gen:skill-docs`.
  The gate is live and it names `skills/README.md`.
- *Restore leg* — `git checkout HEAD -- /home/user/…/skills/README.md` (pinned to
  `HEAD`, never a bare checkout, so it cannot restore from a polluted index). Proved
  by **blob hash equality** against the `HEAD` blob (`72afcf31b7…`, non-empty and
  matching), an **empty `git diff HEAD`**, and the anchor counts returning to 1 / 0.

## ESLint

Not a narrowing — the file is outside the linted population entirely, established
with all three pieces:

1. **Population, read from eslint's own config resolution** (not from my reading of
   the globs): `eslint --print-config skills/README.md` emits an empty document
   (10 bytes). Every `files:` selector in `eslint.config.mjs` is
   `{ts,tsx,mts,cts,js,jsx,mjs,cjs}`; no selector matches markdown.
2. **Count from `--format json`** for the file: 1 result entry, `errorCount: 0`,
   `warningCount: 1`, and the single message is eslint's own
   `File ignored because no matching configuration was supplied.` — zero rule
   findings, because zero rules apply.
3. **Invariance for untouched files**: the repo runs one `eslint.config.mjs` which
   "never enables type-aware linting (no `parserOptions.project`, no typed
   `@typescript-eslint` rules) for ANY file, test or not"
   (`eslint.config.mjs:326-328`, carrying its own positive-control measurement).
   No untouched file's verdict can move as a function of this diff.

A full-repo `pnpm lint` is therefore provably vacuous with respect to this change.

## Changeset

`skip-changeset`, applied. This PR releases nothing: the diff is one file under
`skills/`, and `scripts/check-empty-changeset.mjs:359-362` enumerates exactly that
case — "It releases nothing (`.github/`, `.claude/`, **`skills/`**, `docs/`,
`content/`, `examples/`, tests-only, and the like) -> delete the changeset and apply
the 'skip-changeset' label (route 2)." The script pins this shape as GREEN 3, "a
`skills/**`-only PR carrying NO changeset (route 2)" (`:559-565`). No package
`package.json`, `src/`, or version is touched.

## Scope

Untouched, as claimed: every `SKILL.md`; the README's generated region between the
BEGIN/END GENERATED markers (`check:skill-docs` green proves it byte-for-byte); the
anatomy tree at `:50-62`, so the hunks are disjoint from PR #14786's `:55` — this
diff's two hunks start at `:85` and `:104`. No other README sentence was edited.

Draft, and it stays draft — governed `skills/**`, human merge is the review record.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_