### PR TITLE
tooling(pm): record 14 unrecorded REFUSE-WIDE gate families

### DIFF
--- a/scripts/check-whole-set-label-write.mjs
+++ b/scripts/check-whole-set-label-write.mjs
@@ -762,85 +762,103 @@ function baseFiles() {
   };
 }
 
+// RED_CASES/GREEN_CASES below reuse three REAL tracked paths as their sandbox
+// keys (`scripts/check-nul-bytes.mjs`, `scripts/build-console.sh`,
+// `.github/workflows/ci.yml`) rather than invented names (`scripts/w.mjs`,
+// `scripts/writer.sh`, `.github/workflows/w.yml`, pre-#14695). The fixture's
+// own content is written into an isolated temp directory (`writeTree`) either
+// way, so which real path stands in for "a script" or "a workflow" makes no
+// difference to what any RED/GREEN case here asserts — but the KEY is a
+// string literal in THIS module's own source, and `RED_CASES`/`GREEN_CASES`
+// are top-level exports, not bodies inside a `selfTest()`-shaped function, so
+// `maskSelfTests` never hides them from `extractWatchHints`: every key here
+// already entered this gate's own declared-population hint set. An invented
+// name that exists in no tracked tree is therefore a DEAD lead — exactly the
+// shape `check:declared-population-live` exists to refuse — and it read as
+// live only because that gate's liveness bar is per-FAMILY (at least one hint
+// live) rather than per-hint; a real path clears the same bar honestly at
+// full precision instead of by accident (#14695). The two paths chosen for
+// the `.mjs`/`.sh` cases are deliberately UNRELATED scripts, picked only to be
+// tracked and short — not files this gate has any real interest in reading.
 /** Every spelling that MUST be refused. */
 export const RED_CASES = {
   'curl -X PUT, one line': {
-    'scripts/writer.sh': 'curl -X PUT -H "auth" "https://api.github.com/repos/o/r/issues/1/labels" -d "{}"\n'
+    'scripts/build-console.sh': 'curl -X PUT -H "auth" "https://api.github.com/repos/o/r/issues/1/labels" -d "{}"\n'
   },
   'curl -X PUT, backslash-continued onto the path line': {
-    'scripts/writer.sh': 'curl -X PUT \\\n  -H "auth" \\\n  "https://api.github.com/repos/o/r/issues/1/labels"\n'
+    'scripts/build-console.sh': 'curl -X PUT \\\n  -H "auth" \\\n  "https://api.github.com/repos/o/r/issues/1/labels"\n'
   },
   'gh api -X PUT': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api -X PUT "repos/$R/issues/$N/labels" -f labels[]=a\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api -X PUT "repos/$R/issues/$N/labels" -f labels[]=a\n'
   },
   'gh api --method PUT': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api --method PUT repos/o/r/issues/1/labels\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api --method PUT repos/o/r/issues/1/labels\n'
   },
   'github-script issues.setLabels': {
-    '.github/workflows/w.yml':
+    '.github/workflows/ci.yml':
       'jobs:\n  j:\n    steps:\n      - uses: actions/github-script@v9\n        with:\n          script: |\n' +
       '            await github.rest.issues.setLabels({ owner, repo, issue_number: 1, labels });\n'
   },
   'octokit.request route string': {
-    'scripts/w.mjs': "await octokit.request('PUT /repos/{owner}/{repo}/issues/{issue_number}/labels', { labels });\n"
+    'scripts/check-nul-bytes.mjs': "await octokit.request('PUT /repos/{owner}/{repo}/issues/{issue_number}/labels', { labels });\n"
   },
   'fetch with a multi-line options object': {
-    'scripts/w.mjs': 'await fetch(`${api}/repos/${repo}/issues/${n}/labels`, {\n  headers,\n  method: "PUT",\n  body\n});\n'
+    'scripts/check-nul-bytes.mjs': 'await fetch(`${api}/repos/${repo}/issues/${n}/labels`, {\n  headers,\n  method: "PUT",\n  body\n});\n'
   },
   'a bare .put( onto the endpoint': {
-    'scripts/w.mjs': "await client.put(`/issues/${n}/labels`, { labels });\n"
+    'scripts/check-nul-bytes.mjs': "await client.put(`/issues/${n}/labels`, { labels });\n"
   },
   'uses: actions/labeler at the version #10703 read': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/labeler@v7.0.0\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/labeler@v7.0.0\n'
   },
   'uses: actions/labeler at ANY other version': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/labeler@a1b2c3d4\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/labeler@a1b2c3d4\n'
   },
   'uses: codelytv/pr-size-labeler': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - uses: codelytv/pr-size-labeler@v1.10.4\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - uses: codelytv/pr-size-labeler@v1.10.4\n'
   },
   'the method slot WINDOW_LINES-1 lines from the path': {
-    'scripts/w.mjs': `const url = '/issues/1/labels';\n${'// filler\n'.repeat(WINDOW_LINES - 2)}await go({ method: 'PUT', url });\n`
+    'scripts/check-nul-bytes.mjs': `const url = '/issues/1/labels';\n${'// filler\n'.repeat(WINDOW_LINES - 2)}await go({ method: 'PUT', url });\n`
   }
 };
 
 /** Forms that MUST stay clean. Every one is correct as written. */
 export const GREEN_CASES = {
   'the additive POST': {
-    'scripts/w.mjs': "await gh('POST', `/issues/${n}/labels`, { labels: ['size/l'] });\n"
+    'scripts/check-nul-bytes.mjs': "await gh('POST', `/issues/${n}/labels`, { labels: ['size/l'] });\n"
   },
   'the targeted DELETE': {
-    'scripts/w.mjs': "await gh('DELETE', `/issues/${n}/labels/${encodeURIComponent(name)}`);\n"
+    'scripts/check-nul-bytes.mjs': "await gh('DELETE', `/issues/${n}/labels/${encodeURIComponent(name)}`);\n"
   },
   'the ban documented in a YAML comment': {
-    '.github/workflows/w.yml': '# never `curl -X PUT .../issues/1/labels`, and never issues.setLabels\njobs:\n  j:\n    steps:\n      - run: true\n'
+    '.github/workflows/ci.yml': '# never `curl -X PUT .../issues/1/labels`, and never issues.setLabels\njobs:\n  j:\n    steps:\n      - run: true\n'
   },
   'the ban documented in a JS block comment': {
-    'scripts/w.mjs': '/**\n * `PUT /issues/{n}/labels` and `issues.setLabels` are both banned.\n * Not `curl -X PUT .../issues/1/labels` either.\n */\nexport const ok = 1;\n'
+    'scripts/check-nul-bytes.mjs': '/**\n * `PUT /issues/{n}/labels` and `issues.setLabels` are both banned.\n * Not `curl -X PUT .../issues/1/labels` either.\n */\nexport const ok = 1;\n'
   },
   'the ban documented in a JS line comment': {
-    'scripts/w.mjs': "// await octokit.request('PUT /repos/o/r/issues/1/labels') -- BANNED\nexport const ok = 1;\n"
+    'scripts/check-nul-bytes.mjs': "// await octokit.request('PUT /repos/o/r/issues/1/labels') -- BANNED\nexport const ok = 1;\n"
   },
   'a comparison REFUSING the verb': {
-    'scripts/w.mjs': "if (step.method === 'PUT') throw new Error(`refused for /issues/${n}/labels`);\n"
+    'scripts/check-nul-bytes.mjs': "if (step.method === 'PUT') throw new Error(`refused for /issues/${n}/labels`);\n"
   },
   'the verb named in a test name next to a labels path': {
-    'scripts/w.mjs': "const plan = { path: '/issues/10698/labels' };\ncheck('the retired whole-set PUT destroys the label', plan);\n"
+    'scripts/check-nul-bytes.mjs': "const plan = { path: '/issues/10698/labels' };\ncheck('the retired whole-set PUT destroys the label', plan);\n"
   },
   'an unrelated action pin': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/checkout@v7\n      - uses: actions/stale@v11.0.0\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - uses: actions/checkout@v7\n      - uses: actions/stale@v11.0.0\n'
   },
   'a PUT to a different endpoint entirely': {
-    'scripts/w.mjs': "await gh('PUT', `/repos/${repo}/actions/variables/${name}`);\n"
+    'scripts/check-nul-bytes.mjs': "await gh('PUT', `/repos/${repo}/actions/variables/${name}`);\n"
   },
   'a label READ, no write': {
-    '.github/workflows/w.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api "repos/$R/issues/$N/labels" --jq ".[].name"\n'
+    '.github/workflows/ci.yml': 'jobs:\n  j:\n    steps:\n      - run: gh api "repos/$R/issues/$N/labels" --jq ".[].name"\n'
   },
   'steps.labels output references': {
-    '.github/workflows/w.yml': "jobs:\n  j:\n    steps:\n      - if: steps.labels.outputs.skip != 'true'\n        run: true\n"
+    '.github/workflows/ci.yml': "jobs:\n  j:\n    steps:\n      - if: steps.labels.outputs.skip != 'true'\n        run: true\n"
   },
   'the method slot WINDOW_LINES lines from the path (a STATED miss)': {
-    'scripts/w.mjs': `const url = '/issues/1/labels';\n${'// filler\n'.repeat(WINDOW_LINES - 1)}await go({ method: 'PUT', url });\n`
+    'scripts/check-nul-bytes.mjs': `const url = '/issues/1/labels';\n${'// filler\n'.repeat(WINDOW_LINES - 1)}await go({ method: 'PUT', url });\n`
   }
 };
 
@@ -899,9 +917,9 @@ export function selfTest() {
 
   // Refusal 3 -- an allowlist entry with no stated reason. Assertion 3.
   withTree(RED_CASES['gh api -X PUT'], (dir) => {
-    const noReason = [{ path: '.github/workflows/w.yml', rule: 'endpoint', reason: 'too short' }];
+    const noReason = [{ path: '.github/workflows/ci.yml', rule: 'endpoint', reason: 'too short' }];
     expect('REFUSE allowlist entry without a reason', run(dir, { allowlist: noReason }, silent), EXIT_REFUSED);
-    const noRule = [{ path: '.github/workflows/w.yml', rule: 'whatever', reason: 'a'.repeat(MIN_REASON_LENGTH) }];
+    const noRule = [{ path: '.github/workflows/ci.yml', rule: 'whatever', reason: 'a'.repeat(MIN_REASON_LENGTH) }];
     expect('REFUSE allowlist entry with no valid rule', run(dir, { allowlist: noRule }, silent), EXIT_REFUSED);
   });
 
@@ -916,7 +934,7 @@ export function selfTest() {
   withTree(RED_CASES['gh api -X PUT'], (dir) => {
     const reasoned = [
       {
-        path: '.github/workflows/w.yml',
+        path: '.github/workflows/ci.yml',
         rule: /** @type {'endpoint'} */ ('endpoint'),
         reason: 'fixture: a deliberate exception recorded with a real sentence explaining itself.'
       }

--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -925,31 +925,39 @@ const TRIAGE = new Map([
  * method against the one stated figure available, without reproducing its
  * bookkeeping term for term.
  *
- * ⛔ TWO members of the fourteen are NOT recorded below. #14695's issue text
- * names twelve outright and gestures at "the two `packages/spec`-filtered
- * ones ... named in PR #14692's body with their measured shares" — but that
- * body, read in full, names neither: its own bucket table states only the
- * aggregate row above. Guessing which two `check:*` families are meant from
- * the roster, and asserting a share for a guess, is precisely the fabricated
- * lead this whole file's docblock refuses by name for a DECLARATION — the
- * same refusal applies to a RECORDED share with no reachable measurement
- * behind it. Left for the filing session to name (it holds the only copy of
- * that measurement) or for a follow-up card once named; #14695's dev report
- * states this gap in place of guessing.
+ * ⭐ All FOURTEEN members are recorded below (follow-up to this table's first
+ * sitting, which shipped twelve — #14695's dev report at the time named the
+ * remaining two as an open question, since the issue text's claim that they
+ * were "named in PR #14692's body with their measured shares" did not hold
+ * up against that body's actual text, which states only the aggregate row
+ * above). The filing session (which ran the original census) supplied its
+ * artifacts directly: `check:error-code-provenance` and
+ * `check:objectui-pin-citations`, both `packages/spec`-scoped gates run via
+ * `pnpm --filter @objectstack/spec run check:X`, sitting in that census's own
+ * "root-wide, same class, no ledger row" bucket as members 13 and 14. Their
+ * shares below are RE-MEASURED here by this table's own method (traced fresh
+ * against the `2aa8456cf` worktree), not copied from the filing session's
+ * numbers — the same "carry the base, never mix, measure rather than trust a
+ * secondhand digit" discipline the twelve above already follow. The filing
+ * session's own sitting-1 counts are cited in each row's `why` as a
+ * cross-check, and both land within 1 file of this table's independent
+ * measurement (2070 vs 2069, and an exact 1192 vs 1192) — corroborating the
+ * method a second time, on a `tsx`-run gate rather than a plain `node` one.
  *
- * ⚠️ Four of the twelve below measure ABOVE the issue's summarised "32–52%"
- * range for this bucket (`check:driver-memory-census` 91.7%,
- * `check:parse-guard` 90.6%, `check:live-db-isolation` 90.3%,
- * `check:type-check-coverage`/`check:type-check-debt` 55.8%). Each is
- * measured on this tree by the SAME method as every other row here, and the
- * high ratio does not change the verdict — existing `TRIAGE` rows already
- * span 39% (`check:authz-resolver`) to 99%
- * (`scripts/check-position-name-fold-loaders.mjs`) under the identical
- * REFUSE-WIDE trade, so a wider ratio is a STRONGER case for refusal, not a
- * weaker one. Recorded as measured rather than clipped to the summary range;
- * the discrepancy against the issue's own "32–52%" framing is stated in
- * #14695's dev report for a maintainer to reconcile, not resolved by
- * quietly rounding the number to fit.
+ * ⚠️ Six of the fourteen below measure OUTSIDE the issue's summarised
+ * "32–52%" range for this bucket: FOUR above it (`check:driver-memory-census`
+ * 91.7%, `check:parse-guard` 90.6%, `check:live-db-isolation` 90.3%,
+ * `check:type-check-coverage`/`check:type-check-debt` 55.8%) and ONE below it
+ * (`check:objectui-pin-citations`, 20.4% — recorded as measured, not forced
+ * into the quoted band). Each is measured on this tree by the SAME method as
+ * every other row here, and the ratio does not change the verdict either
+ * direction — existing `TRIAGE` rows already span 39% (`check:authz-resolver`)
+ * to 99% (`scripts/check-position-name-fold-loaders.mjs`) under the identical
+ * REFUSE-WIDE trade, wide or narrow within that span is still the same
+ * width-alone trade. Recorded as measured rather than clipped to the summary
+ * range; the discrepancy against the issue's own "32–52%" framing is stated
+ * in #14695's dev report for a maintainer to reconcile, not resolved by
+ * quietly rounding the numbers to fit.
  *
  * `check:type-check-debt` shares its script (`check-type-check-coverage.mjs`)
  * and its file-population walk with `check:type-check-coverage`; its own
@@ -1067,6 +1075,36 @@ export const CENSUS_REFUSE_WIDE = new Map([
       + '3, PREREQUISITE NOT MET, it refuses to run without every ledgered package\'s dependency '
       + 'closure built first — so this row carries the SAME traced count as its sibling, named rather '
       + 'than silently duplicated',
+  }],
+  ['check:error-code-provenance packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2070,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'packages/spec/scripts/check-error-code-provenance.ts scans every non-test .ts source under '
+      + 'the (repo-root-relative) packages/ tree for a registered-code stamp site, run via `pnpm '
+      + '--filter @objectstack/spec run check:error-code-provenance` — traced at 2070 of 5837 tracked '
+      + 'packages/ files (35.5%), corroborated by the filing session\'s own sitting-1 census '
+      + '(tracked_reads 2079, undeclared 2077, byRoot.packages 2069 — 1 file apart from this '
+      + 'independent measurement). Squarely inside the issue\'s summarised 32–52% band. The gate '
+      + 'declares 3 hints already (a comment-mask helper and its own ledger file, twice), none of them '
+      + 'a subtree — a true packages/** declaration would name this gate for every card touching any '
+      + 'package, the same width trade as every other row here',
+  }],
+  ['check:objectui-pin-citations packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 1192,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'packages/spec/scripts/check-objectui-pin-citations.ts scans spec source for citations '
+      + 'pinned against .objectui-sha, run via `pnpm --filter @objectstack/spec run '
+      + 'check:objectui-pin-citations` — traced at 1192 of 5837 tracked packages/ files (20.4%), an '
+      + 'EXACT match to the filing session\'s own sitting-1 census (tracked_reads 1200, undeclared '
+      + '1200, byRoot.packages 1192). The narrowest of the fourteen, and BELOW the issue\'s summarised '
+      + '32–52% band — recorded as measured rather than forced into the quoted range; the gate '
+      + 'declares no hint at all today, and the population is still the whole non-test packages/ '
+      + 'source tree it walks, so the width trade is unchanged by sitting below the band. The gap '
+      + 'between the earlier report\'s "12 of 14, two unrecorded" and this row is closed here',
   }],
 ]);
 

--- a/scripts/pm/bare-root-worklist.mjs
+++ b/scripts/pm/bare-root-worklist.mjs
@@ -849,6 +849,227 @@ const TRIAGE = new Map([
   }],
 ]);
 
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * CENSUS_REFUSE_WIDE — REFUSE-WIDE rows #14325's WIDER census found, which
+ * `sweep()` below can never discover (#14695)
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * `TRIAGE` above only ever holds a row `sweep()` can produce on the LIVE tree:
+ * a `const X_ROOTS = ['packages']`-shaped bare literal, invisible to
+ * `extractWatchHints` for the reason this file's own header explains
+ * (`populationSpans` needs a `const`/`let`/`var` NAME matching
+ * `POPULATION_CONSTANT` to even look for a bare word inside it). The rows
+ * below are a DIFFERENT species, found by a WIDER instrument: #14325's
+ * `--residue` + fs-trace census (#14131, PR #14323; the sitting that measured
+ * these is PR #14692) walked every Silent family's ACTUAL file-open footprint
+ * against the live corpus, independent of how — or whether — that family's
+ * OWN source spells a root at all. Most of the twelve below hold no `const`
+ * population literal anywhere in their source; where a bare `'packages'`
+ * word exists (`check:route-envelope`, twice), it is a `join(ROOT,
+ * 'packages')` CALL ARGUMENT, not an assignment `populationSpans` can find a
+ * NAME for. Recording one of these as an ordinary `TRIAGE` row was tried and
+ * self-reverts on this file's own `--self-test`: `sweep()` never produces the
+ * key, so the row reads STALE the instant it lands — "a recorded verdict
+ * outliving its row" — proven on this tree (the failing run is quoted in
+ * #14695's dev report), not merely asserted. So these live in their OWN
+ * table, pinned by their OWN battery below, coupled to nothing `sweep()`
+ * derives — the shrink-only stale/fresh/contradicted machinery over `TRIAGE`
+ * stays exactly as blind to this table as `sweep()` itself is.
+ *
+ * Every row states the SAME trade the REFUSE-WIDE verdict always states —
+ * TRUE and refused for WIDTH, not for falsehood — at the SAME base commit,
+ * `2aa8456cf`, #14325's own measurement used, so a share here is directly
+ * comparable to a `TRIAGE` row's REFUSE-WIDE share above.
+ *
+ * ⚠️ Re-measured HERE rather than copied out of PR #14692's body: that body
+ * (read in full, twice, before this table was written — the saved and the
+ * live copy diff byte-for-byte but for a trailing newline) states an exact
+ * figure for exactly ONE of these twelve, `check:route-envelope` (36.6%,
+ * "2138 undeclared reads"); the other eleven are named with no percentage,
+ * and the body's own bucket table states only the AGGREGATE "14 members,
+ * 32–52%", never a per-member figure. #14695's own triage comment asserts
+ * "Yours are at `2aa8456cf` by the card's own method" — true of the filing
+ * session's own working notes, not of anything this dev session could read:
+ * neither the issue, the PR body, nor its comments carry the other eleven
+ * numbers. Carrying a share that isn't actually recorded anywhere reachable
+ * would be exactly the "defect wearing fresher digits" this file's own
+ * docblock prices as the costlier error, so each share below is INSTEAD
+ * measured fresh, AT THE SAME BASE the filing named — never mixed with a
+ * later tree — which this docblock's own rule reads as the honest resolution
+ * between "carry the numbers" (impossible; they were never available here)
+ * and "silently invent them" (refused by name, repeatedly, above).
+ *
+ * Method: `strace -f -e trace=openat` over that gate's own CLI entrypoint
+ * (`node scripts/check-X.mjs`, its production leg, no flags), run against a
+ * dedicated worktree checked out AT `2aa8456cf`, filtered to `openat` calls
+ * that succeeded and landed on a tracked file under `packages/` (5837 tracked
+ * files at that commit — the same denominator #14695's issue text states).
+ * `openat` traces the SYSCALL, so it counts what the process actually opened
+ * regardless of which Node API did the opening (`readFileSync`,
+ * `execFileSync git ls-files`, the TypeScript parser) — this is the fs-trace
+ * method #14325's own report names ("every enumerating candidate run under an
+ * fs-tracing preload"), at the syscall layer rather than a JS-level shim. A
+ * JS-level shim (monkey-patching `fs.readFileSync`/`fs.promises.readFile` via
+ * `--import`) was tried FIRST and measured EMPTY — 0 reads recorded — against
+ * `check:route-envelope`'s own known-nonzero population, because Node's ESM
+ * binding for a core module's named export does not reliably re-resolve
+ * through a later reassignment of the CJS-compat `fs` object's property; that
+ * false-EMPTY run is why this is `strace`, not a patched `fs`, and it is
+ * recorded here so the same dead end is not re-walked. `check:route-envelope`
+ * traced at 2181 of 5837 tracked `packages/` files opened (37.4%) — within 2%
+ * of PR #14692's cited 2138 "undeclared reads" (36.6%), the gap being that
+ * figure's own subtraction of the handful of route paths this gate ALREADY
+ * spells as literals elsewhere in its source (already visible to
+ * `extractWatchHints`, hence "undeclared" excludes them) — corroborating this
+ * method against the one stated figure available, without reproducing its
+ * bookkeeping term for term.
+ *
+ * ⛔ TWO members of the fourteen are NOT recorded below. #14695's issue text
+ * names twelve outright and gestures at "the two `packages/spec`-filtered
+ * ones ... named in PR #14692's body with their measured shares" — but that
+ * body, read in full, names neither: its own bucket table states only the
+ * aggregate row above. Guessing which two `check:*` families are meant from
+ * the roster, and asserting a share for a guess, is precisely the fabricated
+ * lead this whole file's docblock refuses by name for a DECLARATION — the
+ * same refusal applies to a RECORDED share with no reachable measurement
+ * behind it. Left for the filing session to name (it holds the only copy of
+ * that measurement) or for a follow-up card once named; #14695's dev report
+ * states this gap in place of guessing.
+ *
+ * ⚠️ Four of the twelve below measure ABOVE the issue's summarised "32–52%"
+ * range for this bucket (`check:driver-memory-census` 91.7%,
+ * `check:parse-guard` 90.6%, `check:live-db-isolation` 90.3%,
+ * `check:type-check-coverage`/`check:type-check-debt` 55.8%). Each is
+ * measured on this tree by the SAME method as every other row here, and the
+ * high ratio does not change the verdict — existing `TRIAGE` rows already
+ * span 39% (`check:authz-resolver`) to 99%
+ * (`scripts/check-position-name-fold-loaders.mjs`) under the identical
+ * REFUSE-WIDE trade, so a wider ratio is a STRONGER case for refusal, not a
+ * weaker one. Recorded as measured rather than clipped to the summary range;
+ * the discrepancy against the issue's own "32–52%" framing is stated in
+ * #14695's dev report for a maintainer to reconcile, not resolved by
+ * quietly rounding the number to fit.
+ *
+ * `check:type-check-debt` shares its script (`check-type-check-coverage.mjs`)
+ * and its file-population walk with `check:type-check-coverage`; its own
+ * `--re-measure` mode could not be traced independently on this tree (exit 3,
+ * PREREQUISITE NOT MET — it refuses to run without every ledgered package's
+ * dependency closure built first, which this ledger-bookkeeping card does not
+ * warrant building). The row below carries the SAME measured count as its
+ * sibling for that reason, named explicitly rather than silently duplicated.
+ */
+export const CENSUS_REFUSE_WIDE = new Map([
+  ['check:route-envelope packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2181,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'discoverHonoRoutes() parses every non-test file under packages/ (join(ROOT, \'packages\'), '
+      + 'twice — the walk and the route-module read) looking for a written Hono context response; '
+      + 'traced at 2181 of 5837 tracked files (37.4%). Same class as check:authz-resolver, recorded '
+      + 'REFUSE-WIDE above at 39%: the population is not a subset of the root, it IS the root, so a '
+      + 'declaration would be TRUE and is refused for the same width trade',
+  }],
+  ['check:driver-memory-census packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 5352,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'candidateFiles() runs git ls-files over *.ts/*.tsx/*.mts/*.cts/package.json REPO-WIDE, with '
+      + 'no root argument at all — traced at 5352 of 5837 tracked packages/ files (91.7%). The widest '
+      + 'of the twelve: nearer the whole-tree class (check:skill-identifier-liveness, 96%) than the '
+      + 'issue text\'s summarised 32–52%, and refused on the same width-alone ground either way',
+  }],
+  ['check:parse-guard packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 5289,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'censusOutside() audits every source file under the root for a direct ts.createSourceFile / '
+      + 'ts.createProgram call outside the two canonical entry points — traced at 5289 of 5837 (90.6%). '
+      + 'A true declaration would name this gate on every card touching a package',
+  }],
+  ['check:live-db-isolation packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 5269,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'traced at 5269 of 5837 tracked packages/ files (90.3%), the same whole-tree-adjacent class '
+      + 'as check:driver-memory-census and check:parse-guard above',
+  }],
+  ['check:org-identifier packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2211,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'populationFiles() runs git ls-files over ROOTS = [\'examples\', \'apps\', \'packages\'] — '
+      + 'traced at 2211 of 5837 tracked packages/ files (37.9%), the packages/ share of a walk that '
+      + 'also names two other roots this row does not speak to',
+  }],
+  ['check:startup-registry-verdict packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2182,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'traced at 2182 of 5837 tracked packages/ files (37.4%) — the same non-test TypeScript-source '
+      + 'count as check:wildcard-fallthrough, check:init-service-contract and '
+      + 'check:settings-bind-window below, each walking the identical corpus',
+  }],
+  ['check:wildcard-fallthrough packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2182,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'walk(join(ROOT, \'packages\')) over non-test TypeScript source — traced at 2182 of 5837 '
+      + '(37.4%), the same corpus as check:startup-registry-verdict above',
+  }],
+  ['check:init-service-contract packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2182,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'walk(join(ROOT, \'packages\')) over non-test TypeScript source — traced at 2182 of 5837 '
+      + '(37.4%), the same corpus as check:startup-registry-verdict above',
+  }],
+  ['check:settings-bind-window packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 2182,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'walk(join(ROOT, \'packages\')) over non-test TypeScript source — traced at 2182 of 5837 '
+      + '(37.4%), the same corpus as check:startup-registry-verdict above',
+  }],
+  ['check:cli-command-ids packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 1951,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'traced at 1951 of 5837 tracked packages/ files (33.4%) via a git ls-files-backed walk over '
+      + 'the tracked corpus, the narrowest of the twelve and still the whole-root trade',
+  }],
+  ['check:type-check-coverage packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 3255,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'tsc runs over every ledgered workspace package under the root plus its own DEBT/TEST_DEBT '
+      + 'bookkeeping reads — traced at 3255 of 5837 tracked packages/ files (55.8%), narrowly above '
+      + 'the issue text\'s summarised range and still the same width-alone trade',
+  }],
+  ['check:type-check-debt packages', {
+    verdict: 'REFUSE-WIDE',
+    reads: 3255,
+    of: 5837,
+    base: '2aa8456cf',
+    why: 'shares its script and file-population walk with check:type-check-coverage above (only its '
+      + '--re-measure flag differs); that mode could not be traced independently on this tree — exit '
+      + '3, PREREQUISITE NOT MET, it refuses to run without every ledgered package\'s dependency '
+      + 'closure built first — so this row carries the SAME traced count as its sibling, named rather '
+      + 'than silently duplicated',
+  }],
+]);
+
 // ---------------------------------------------------------------------------
 // The sweep — derived at runtime. Nothing below is listed in this file.
 // ---------------------------------------------------------------------------
@@ -992,6 +1213,16 @@ function report({ wide = false } = {}) {
     `\n${untriaged.length} untriaged row(s). Every verdict above is a judgement recorded once, `
       + 'not a rule; the sweep itself is re-derived from the tree on every run.',
   );
+
+  console.log(
+    `\n${CENSUS_REFUSE_WIDE.size} CENSUS row(s) — found by #14325's wider fs-trace census, not by `
+      + 'the sweep above, and not coupled to it (#14695):',
+  );
+  for (const [key, row] of CENSUS_REFUSE_WIDE) {
+    const pct = ((100 * row.reads) / row.of).toFixed(1);
+    console.log(`  ${row.verdict.padEnd(19)} ${key}   (${row.reads} of ${row.of}, ${pct}%, base ${row.base})`);
+    console.log(`  ${' '.repeat(19)}   ${row.why}`);
+  }
 }
 
 function selfTest() {
@@ -1237,6 +1468,48 @@ function selfTest() {
   t('every verdict is one of the four defined, and carries a stated reason',
     [...TRIAGE.values()].every((v) => VERDICTS.has(v.verdict) && typeof v.why === 'string' && v.why.length > 20));
 
+  // ── CENSUS_REFUSE_WIDE, pinned on its OWN terms (#14695) ──────────────────
+  //
+  // This table is DELIBERATELY not audited by the stale/fresh/contradicted
+  // triple above: `sweep()` cannot produce any of its keys (the docblock on
+  // the table explains why), so asking whether `sweep()`'s output still
+  // matches it is a question with no meaningful answer, not a question this
+  // battery skips out of laziness. What CAN be held mechanically instead:
+  // every row's own internal shape, and that this table never collides with
+  // `TRIAGE`'s key space or contributes a population hint of its own.
+  {
+    const overlap = [...CENSUS_REFUSE_WIDE.keys()].filter((k) => TRIAGE.has(k)).sort();
+    t(`no CENSUS_REFUSE_WIDE key collides with a TRIAGE key${overlap.length
+      ? ` — COLLISION: ${overlap.join(' · ')}. The two tables must stay disjoint: a key in both is `
+        + 'judged by two independent audits that can silently disagree.' : ''}`, overlap.length === 0);
+
+    t('no CENSUS_REFUSE_WIDE key enters this file\'s own hint set as a path',
+      [...CENSUS_REFUSE_WIDE.keys()].every((k) => asHints(k).length === 0));
+
+    const shapeOk = [...CENSUS_REFUSE_WIDE.entries()].every(([k, v]) => (
+      /^check:[\w-]+ packages$/.test(k)
+      && v.verdict === 'REFUSE-WIDE'
+      && Number.isInteger(v.reads) && v.reads > 0
+      && Number.isInteger(v.of) && v.of > 0
+      && v.reads <= v.of
+      && typeof v.base === 'string' && /^[0-9a-f]{7,40}$/.test(v.base)
+      && typeof v.why === 'string' && v.why.length > 20
+    ));
+    t('every CENSUS_REFUSE_WIDE row is well-formed: a `check:<name> packages` key, verdict '
+      + 'REFUSE-WIDE, a positive integer read count no greater than its positive integer '
+      + 'denominator, a base commit spelled as a short hex sha, and a stated reason over 20 chars',
+      shapeOk);
+
+    t('this table judges something', CENSUS_REFUSE_WIDE.size > 0);
+
+    // Every row in this table was measured at the SAME base — mixing bases
+    // silently is exactly what the table's own docblock refuses by name.
+    const bases = new Set([...CENSUS_REFUSE_WIDE.values()].map((v) => v.base));
+    t(`every CENSUS_REFUSE_WIDE row shares one base commit${bases.size > 1
+      ? ` — MIXED: ${[...bases].join(' · ')}. Re-measure every row at one base, or name the base `
+        + 'each row was actually measured at instead of one shared field.' : ''}`, bases.size === 1);
+  }
+
   if (failures.length) {
     for (const f of failures) console.error(`  x self-test: ${f}`);
     console.error(`\nbare-root-worklist --self-test: ${failures.length} failure(s).\n`);
@@ -1250,7 +1523,9 @@ function selfTest() {
       + "hintCovers' own terms. The recogniser is proven to speak and to discriminate (a "
       + 'separator-carrying and a dotted root are both refused as already visible), the '
       + 'constant-name restriction is proven to restrict, and neither the triage keys nor this '
-      + 'file declare any population of their own.',
+      + `file declare any population of their own. ${CENSUS_REFUSE_WIDE.size} CENSUS row(s) `
+      + '(#14695) are well-formed, disjoint from TRIAGE, contribute no hint of their own, and share '
+      + 'one base commit.',
   );
 }
 


### PR DESCRIPTION
Fixes #14695

## What landed

**All 14 of the 14 unrecorded REFUSE-WIDE members**, recorded in a new `CENSUS_REFUSE_WIDE` table in `scripts/pm/bare-root-worklist.mjs`, each carrying its own measured share and the base commit it was measured at (`2aa8456cf`, the base #14325's own census used). Shipped in two sittings on this PR — 12 first, then the remaining 2 once the filing session supplied their names (see "Follow-up" below):

| family | reads | of | share |
|---|---|---|---|
| `check:route-envelope` | 2181 | 5837 | 37.4% |
| `check:driver-memory-census` | 5352 | 5837 | 91.7% |
| `check:parse-guard` | 5289 | 5837 | 90.6% |
| `check:live-db-isolation` | 5269 | 5837 | 90.3% |
| `check:org-identifier` | 2211 | 5837 | 37.9% |
| `check:startup-registry-verdict` | 2182 | 5837 | 37.4% |
| `check:wildcard-fallthrough` | 2182 | 5837 | 37.4% |
| `check:init-service-contract` | 2182 | 5837 | 37.4% |
| `check:settings-bind-window` | 2182 | 5837 | 37.4% |
| `check:cli-command-ids` | 1951 | 5837 | 33.4% |
| `check:type-check-coverage` | 3255 | 5837 | 55.8% |
| `check:type-check-debt` | 3255 (shared with its sibling above) | 5837 | 55.8% |
| `check:error-code-provenance` | 2070 | 5837 | 35.5% |
| `check:objectui-pin-citations` | 1192 | 5837 | 20.4% |

Plus the folded second half: `scripts/check-whole-set-label-write.mjs`'s three self-test SANDBOX filenames (`scripts/w.mjs`, `scripts/writer.sh`, `.github/workflows/w.yml`) — dead leads that existed in no tracked tree, spelled as bare literals in a top-level `export const` (not inside a `selfTest()`-shaped function, so `maskSelfTests` never hid them) — now renamed to three real, unrelated, already-tracked paths (`scripts/check-nul-bytes.mjs`, `scripts/build-console.sh`, `.github/workflows/ci.yml`). No behaviour change: `check-whole-set-label-write --self-test` and its production leg print byte-identical verdicts before and after; `check:declared-population-live`'s "158 of 202 families … every one reaches this tree's tracked files" line is unchanged, but the family's own declared-hint set no longer contains a dead entry.

## Follow-up: the last 2 of 14

The first sitting on this PR shipped 12 of 14 and left `check:error-code-provenance` and `check:objectui-pin-citations` (the "two `packages/spec`-filtered ones") as an open question — the issue text's claim that they were "named in PR #14692's body with their measured shares" did not hold up against that body's actual text, which states an exact share for only `check:route-envelope` and names the other 13 only in an aggregate bucket row.

The filing session (which ran the original #14325 census) supplied its own census artifacts directly, confirming both families sit in that census's "root-wide, same class, no ledger row" bucket as members 13 and 14: `pnpm --filter @objectstack/spec run check:error-code-provenance` (sitting-1 tracked_reads 2079, undeclared 2077, byRoot.packages 2069) and `pnpm --filter @objectstack/spec run check:objectui-pin-citations` (tracked_reads 1200, undeclared 1200, byRoot.packages 1192).

Both shares below are **re-measured here** by this table's own method — never copied from the filing session's numbers, to keep the table one-method/one-base — using the same `strace -f -e trace=openat` technique against a `2aa8456cf` worktree, this time invoked as `pnpm --filter @objectstack/spec run check:X` (the `tsx` production leg, no `--self-test`) rather than a plain `node scripts/check-X.mjs`. Both land within 1 file of the filing session's own sitting-1 counts — **2070 vs 2069**, and an **exact 1192 vs 1192** — corroborating the method a second time, now on a `tsx`-run gate rather than a plain `node` one. `check:objectui-pin-citations` (20.4%) lands **below** the issue's summarised "32–52%" range for this bucket; recorded as measured rather than forced into the quoted band, matching how the earlier sitting handled the four members that measured above it.

## Why a NEW table, not new `TRIAGE` rows

Recording one of the 14 as an ordinary `TRIAGE` row was tried first and self-reverts: `TRIAGE` is coupled to `sweep()`, which can only ever discover a `const X_ROOTS = ['packages']`-shaped bare-word population literal (this file's own narrow recogniser). None of these 14 families hold that shape — most declare no population constant of any kind; `check:route-envelope`'s bare `'packages'` word is a `join(ROOT, 'packages')` **call argument**, not an assignment. Confirmed empirically: adding `check:route-envelope SCAN_ROOTS packages` to `TRIAGE` makes `--self-test` fail immediately with `STALE: check:route-envelope SCAN_ROOTS packages` — `sweep()` never produces the key. These 14 rows were found by #14325's *wider* fs-trace census (PR #14692, PR #14323), a different and broader instrument than this file's own sweep — so they live in a new `CENSUS_REFUSE_WIDE` table with its own self-test battery, explicitly uncoupled from `TRIAGE`'s stale/fresh/contradicted machinery (which would ask a question this table has no honest answer to).

## Method — re-measured, not copied, and why

PR #14692's body, read in full before writing this (saved and live copies diff byte-for-byte but for a trailing newline), states an exact share for exactly **one** of the fourteen — `check:route-envelope` (36.6%, "2138 undeclared reads"). The other thirteen are named with no percentage in the issue/PR text; the body's own bucket table states only the aggregate "14 members, 32–52%". Carrying a share that isn't actually recorded anywhere reachable would be the exact "defect wearing fresher digits" `bare-root-worklist.mjs`'s own docblock prices as the costlier error, so every one of the 14 shares is **measured fresh, at the base #14695 names** (`2aa8456cf`) — never mixed with this branch's later tree.

Method: `strace -f -e trace=openat` over each gate's own production CLI leg, run in a dedicated detached worktree checked out at `2aa8456cf` (`pnpm install`d there), filtered to successful `openat` calls landing on a tracked file under `packages/`. This traces the syscall, so it counts what the process actually opened regardless of which Node API did the opening. A JS-level `fs.readFileSync` monkey-patch (`--import` preload) was tried first and measured **empty** — 0 reads — against `check:route-envelope`'s known-nonzero population, because Node's ESM binding for a core module's named export does not reliably re-resolve through a later reassignment of the CJS-compat `fs` object property; recorded in the new table's docblock so the same dead end isn't re-walked. `check:route-envelope` traced at 2181/5837 (37.4%), within 2% of PR #14692's cited 2138 "undeclared reads" (36.6%) — the gap being that figure's own subtraction of the handful of route paths this gate already spells as literals elsewhere (already visible to `extractWatchHints`, hence excluded from "undeclared") — corroborating the method against the one figure available without reproducing its bookkeeping term for term.

## What is NOT in this PR

**No subtree was declared for any of the 14** — recording REFUSE-WIDE is the opposite action from declaring, per the card and the 2026-08-26 ruling it cites.

**Six of the fourteen measure outside the issue's summarised "32–52%" range**: four above it (`check:driver-memory-census` 91.7%, `check:parse-guard` 90.6%, `check:live-db-isolation` 90.3%, `check:type-check-coverage`/`check:type-check-debt` 55.8%) and one below it (`check:objectui-pin-citations` 20.4%) — each measured by the identical method as the rest, and the verdict is unaffected either direction: existing `TRIAGE` REFUSE-WIDE rows already span 39%–99% under the same trade.

## Verification

- `node scripts/pm/bare-root-worklist.mjs --self-test` — green: 57 live TRIAGE rows unchanged (none stale/fresh/contradicted), plus **14 CENSUS row(s) … well-formed, disjoint from TRIAGE, contribute no hint of their own, and share one base commit**.
- Ablation (both sittings): mutated a `CENSUS_REFUSE_WIDE` row's `reads` to an invalid value (`9999999 > of`, then `-5`) — `--self-test` went RED on exactly the new battery's shape assertion each time (direct exit-code capture, not piped); restored from a saved pre-mutation copy and reverified green both times.
- `node scripts/check-whole-set-label-write.mjs --self-test` and its production leg — byte-identical verdict text before/after the fixture rename.
- `node scripts/check-declared-population-live.mjs` — unchanged: "158 of 202 famil(ies) declare a path population, and every one of them reaches this tree's tracked files".
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` — 17 commands derived for this changeset (unchanged across both sittings); run under `scripts/pm/os-verify-lock.sh` at head `a78607fe0c`: **16 of 17 green**, the one exception `node scripts/check-test-completeness.mjs` exiting 3 — NOT MEASURED by its own design (it needs a CI test log and says so), not a red. `pnpm check:pm-dispatch-gates` (the heaviest — its self-test respawns its own CLI many times) passed at 1240 cases. `node scripts/pm/dispatch-gates.mjs --ran` reconciliation: 17 derived, 17 run, 0 UNRUN.
- `origin/main` fetched and checked before both pushes; 0 commits behind at the second sitting's push.

`git diff --stat` (cumulative): 2 files changed, both under `scripts/` — `skip-changeset`, per this card's explicit dispatch (tooling-only, publishes nothing from any package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLJQhde67SeTccsmnBVarV