### PR TITLE
docs(agents): stop telling authors to hand-edit generated CHANGELOG.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1151,7 +1151,7 @@ registry? Add it to `OPEN_CAPABILITY_REGISTRIES` in the same PR that fixes it.
    pinned SHA before merging.
 5. **Touched `packages/spec`? Regenerate and commit its artifacts before pushing** — § *Touched `packages/spec`*
    above is the authority; note `OS_SKIP_DTS=1` greens `check:api-surface` locally and reds it in CI.
-6. Update `CHANGELOG.md` / `ROADMAP.md` if user-facing or architectural.
+6. Update `ROADMAP.md` if user-facing or architectural.
 7. **Delete temporary artifacts** — screenshots, traces, scratch logs, `.playwright-mcp/`, throwaway `tmp*.ts`, ad-hoc
    scripts. Repo must look identical to before, minus intended changes.
 


### PR DESCRIPTION
Fixes #14792

Post-task checklist item 6 in `AGENTS.md` told the author to hand-edit `CHANGELOG.md`. That file is generated output. This drops the `CHANGELOG.md` half of the line and keeps `ROADMAP.md`.

## Before / after

`AGENTS.md:1154`

Before:

```
6. Update `CHANGELOG.md` / `ROADMAP.md` if user-facing or architectural.
```

After:

```
6. Update `ROADMAP.md` if user-facing or architectural.
```

## Why

The same file says the opposite about `CHANGELOG.md` thirty-four lines above. At `AGENTS.md:1120`, inside checklist item 3, the changeset rule states that the changeset body "ships to consumers as `CHANGELOG.md` inside the npm package and is what an upgrading agent greps after the tombstone error". That makes `CHANGELOG.md` the **output** — written by the changesets release step from the `.changeset/*.md` entries item 3 already requires.

Item 6 treated the same file as an **input**. A contributor who obeyed it either hand-edited a generated artifact that the next `Version Packages` run overwrites or collides with, or read the two lines together and concluded the file contradicts itself on its most-traversed workflow. Nothing is lost by the trim: the changeset obligation is item 3, and it is unchanged here.

**Neither reading of the name survives, which is what makes the trim safe rather than a judgement call.** Item 6 could have meant the per-package `CHANGELOG.md` files or the repo-root one, so both were checked:

- The per-package files are generated. `packages/core/CHANGELOG.md` and its siblings carry changeset-emitted release sections keyed by commit hash.
- The root `CHANGELOG.md` disclaims hand-editing in its own header: the update history "is maintained in three layers rather than by hand-editing this file" — per-package detail "generated by [changesets] from the `.changeset/` entries every PR adds", the curated per-major pages under `content/docs/releases/`, and this file "retained for its historical entries."

So there is no `CHANGELOG.md` in this repo that item 6 could have legitimately directed a PR author to update by hand.

`ROADMAP.md` is untouched and not in question, and the surviving half is not vacuous: the file exists at the repo root and its history shows real hand edits. This PR makes no claim about whether that obligation should stand.

## Arithmetic

`AGENTS.md` is at its line-ratchet ceiling, so the edit adds no line and re-wraps nothing.

| Measure | Before | After |
| --- | --- | --- |
| Lines (`wc -l`) | 1,162 | 1,162 |
| Ratchet ceiling / headroom | 1,162 / 0 | 1,162 / 0 |
| Bytes (`wc -c`) | 85,106 | 85,089 (-17) |
| The edited line | 72 bytes | 55 bytes (-17) |
| Widest table row | 1,081 (pin 1,081) | 1,081 (pin 1,081) |
| `grep -c 'CHANGELOG.md' AGENTS.md` | 2 (`:1120`, `:1154`) | 1 (`:1120` only) |

Byte-negative on one line, so nothing is paid same-file. `git diff --stat` is `1 file changed, 1 insertion(+), 1 deletion(-)`.

## Scope held

Untouched, deliberately: the `ROADMAP.md` half of item 6, checklist item 3, and the changeset section at `:1116-1122` — that region is being corrected by PR #14789, and a second PR editing it would be a merge conflict on a governed file for no gain. The hunk here at `:1154` is disjoint from that one.

One argument recorded for the merging maintainer rather than acted on: a reading exists under which item 6 should be **deleted outright** rather than trimmed, on the grounds that `ROADMAP.md` updates are not obviously a per-PR obligation either. That is a scope decision, not this card's, so the line is trimmed as ruled and the argument is left here.

## Gates

All run at head `9596a42386`, exit codes captured by redirect before any pipe; each verdict below is the gate's own printed line.

| Command | Exit | Verdict |
| --- | --- | --- |
| `pnpm check:pm-skill-ratchet` | 0 | `AGENTS.md is 1162 lines (ceiling 1162; headroom 0).` · `AGENTS.md: widest table row is 1081 bytes (pin 1081; headroom 0).` · self-test 111 cases pass |
| `pnpm check:pm-governed-prose` | 0 | `2 instruction surface(s) name all 5 registered governed surfaces (docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md) and claim no others.` |
| `pnpm check:pm-skill-id-lint` | 0 | `23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `pnpm check:nul-bytes` | 0 | `OK (scanned 8064 text file(s) -- 8064 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes).` |
| `pnpm check:corpus-claim-drift` | 0 | `OK, no new claim sites beside a pinned spelling.` |
| `pnpm check:required-contexts` | 0 | `6 required context name(s) pinned across 2 workflow(s); 5 instruction surface(s) scanned against 2 retired name(s).` |
| `node scripts/check-required-contexts.mjs` | 0 | same sweep, direct invocation |
| `pnpm check:agent-test-spelling` | 0 | violating population empty, 9 separators judged and cleared on the rule |
| `pnpm check:docs-audit-scope` | 0 | `docs-accuracy-audit scope is in sync with content/docs/: 190 hand-written doc(s)` |
| `pnpm check:pm-governed-merges` | 0 | self-test 243 assertions; `live: the real generator declared 9 output(s) and certified this tree` |

The family list was re-derived after the last edit, not taken from the dispatch:
`node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` resolved its `--repo` assertion against this checkout's origin, derived the change set from git as **1 path** (`AGENTS.md`, committed 1 / working tree 0 / untracked 0, three-dot against merge base `fc648a256`) and emitted 8 commands. All 8 ran; the two dispatch-named gates outside that union (`check:nul-bytes`, `check:corpus-claim-drift`) ran as well, so the set above is a superset.

### ESLint

Not run repo-wide; narrowed, and the narrowing is a measurement rather than a skip:

1. **Population, read from `eslint.config.mjs` and not guessed.** Every `files:` selector in the config is a JS/TS extension glob (`**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` and narrower variants; `COMMENT_SWALLOW_FILES` at `:785` is that same glob). `grep -cin 'markdown|[.]md' eslint.config.mjs` returns **0** — no markdown processor, no `.md` selector anywhere. Confirmed through ESLint's own API: `isPathIgnored('AGENTS.md')` is `true` and `calculateConfigForFile('AGENTS.md')` yields no rules, against a positive control (`eslint.config.mjs` itself resolves 2 rules), so the API call is not vacuously quiet.
2. **Count, from `--format json`.** `pnpm exec eslint AGENTS.md --no-inline-config --format json` gives `errorCount: 0, warningCount: 1`, the one warning being `ruleId: null` / `File ignored because no matching configuration was supplied` — zero rule results, because the file is outside the population.
3. **Invariance over untouched files.** The config never enables type-aware linting for any file — no `parserOptions.project`, no typed rules, stated at `eslint.config.mjs:325-332` with its own measured positive control. With no cross-file type program there is no mechanism by which an edit in one file moves a verdict on a file it does not touch, and this diff is one Markdown line in a file ESLint does not lint at all.

A full `pnpm lint` therefore measures the same nothing this narrowing measured.

## Changeset

Labelled `skip-changeset`, route 2 of `scripts/check-empty-changeset.mjs`'s own enumeration: "It releases nothing (`.github/`, `.claude/`, `skills/`, `docs/`, `content/`, `examples/`, tests-only, and the like) -- delete the changeset and apply the 'skip-changeset' label". This diff is one line of the repo-root instruction file; no `packages/**` source is touched and nothing publishes from any package. Per that script, the label is a gate-level exemption that produces no input for `changesets/action` — the shape an empty-frontmatter changeset would have broken.

## Landing

Draft, and it stays draft — governed `AGENTS.md`, human merge is the review record. Not flipped ready, not queued, no auto-merge armed, no reviewers requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1