### PR TITLE
refactor(showcase): drop the unreachable `rowsOf` normalizer from the nightly health sweep

### DIFF
--- a/examples/app-showcase/src/automation/jobs/sweep-project-health.ts
+++ b/examples/app-showcase/src/automation/jobs/sweep-project-health.ts
@@ -92,13 +92,6 @@ const SYS = { isSystem: true } as const;
 
 type Health = 'green' | 'yellow' | 'red';
 
-/** Normalize the engine's list shape (array, or `{ records }`). */
-function rowsOf(result: unknown): Array<Record<string, unknown>> {
-  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
-  const records = (result as { records?: unknown })?.records;
-  return Array.isArray(records) ? (records as Array<Record<string, unknown>>) : [];
-}
-
 /** Read a numeric column defensively — a currency/progress column may arrive as a string. */
 function num(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -145,28 +138,24 @@ export function healthFor(input: {
  * this handler can be reached without them.
  */
 export async function sweepProjectHealth({ jobId, ql, logger }: JobHandlerContext): Promise<void> {
-  const projects = rowsOf(
-    await ql.find('showcase_project', {
-      where: { status: { $in: [...SWEPT_STATUSES] } },
-      fields: ['id', 'status', 'health', 'budget', 'spent'],
-      limit: READ_LIMIT,
-      context: SYS,
-    }),
-  );
+  const projects: Array<Record<string, unknown>> = await ql.find('showcase_project', {
+    where: { status: { $in: [...SWEPT_STATUSES] } },
+    fields: ['id', 'status', 'health', 'budget', 'spent'],
+    limit: READ_LIMIT,
+    context: SYS,
+  });
   if (projects.length === 0) {
     logger.info('[showcase] project health sweep: no in-play projects', { job: jobId });
     return;
   }
 
   const projectIds = projects.map((p) => String(p.id));
-  const tasks = rowsOf(
-    await ql.find('showcase_task', {
-      where: { project: { $in: projectIds } },
-      fields: ['project', 'progress'],
-      limit: READ_LIMIT,
-      context: SYS,
-    }),
-  );
+  const tasks: Array<Record<string, unknown>> = await ql.find('showcase_task', {
+    where: { project: { $in: projectIds } },
+    fields: ['project', 'progress'],
+    limit: READ_LIMIT,
+    context: SYS,
+  });
 
   const progressByProject = new Map<string, number[]>();
   for (const task of tasks) {


### PR DESCRIPTION
Fixes #14460

Deletes the local `rowsOf()` normalizer from `sweepProjectHealth` and reads the two
`ql.find(...)` results as the arrays they are. Nothing else.

This is the repo's only shipped `defineJob`, so it is the copy-source for scheduled work.
A defensive shape that cannot fire teaches a false contract to whoever copies it.

## The `{ records }` limb is unreachable — measured on the tree, not assumed

`rowsOf()` accepted either an array or an object carrying a `records` array. The second
limb cannot fire for this handler. Four independent legs, all at `e275b7b8`:

1. **Declared engine contract** — `packages/spec/src/contracts/data-engine.ts:251`:
   `find(objectName, query?, options?)` resolves to `any[]`, an array.

2. **The implementation behind it** — `packages/objectql/src/engine.ts:9075`,
   `async find(object, query?, options?)`, also resolving to `any[]`. Its body has exactly
   two `return` statements: `return hookContext.result` and `return opCtx.result as any[]`.
   Both carry the value of `driver.find(...)`; every post-processing step between them is
   guarded by `Array.isArray(result)` and reassigns only arrays.

3. **The driver contract those two returns thread through** —
   `packages/spec/src/contracts/data-driver.ts:155` declares `find` as resolving to an
   array of row objects. So the value the engine returns originates as an array by
   contract, not by convention.

4. **The one seam that could substitute a different value is unused.** The
   `return hookContext.result` path returns whatever an `afterFind` hook left behind. The
   whole repo registers exactly one `afterFind` hook outside tests —
   `packages/plugins/plugin-audit/src/read-audit.ts:600` (`auditRead`) — and that module
   contains no assignment to `.result` at all; it only reads it. The showcase app itself
   declares no `afterFind` hook: `examples/app-showcase/src/data/hooks/index.ts` declares
   only `beforeInsert`, `beforeUpdate` and `afterUpdate`.

And `ctx.ql` in this handler is that engine, not some other handle:
`packages/runtime/src/job-handler-context.ts` types `JobHandlerContext.ql` as
`IObjectQLEngine`; `packages/runtime/src/app-plugin.ts:1029` builds the job context with
the `ql` resolved at `app-plugin.ts:520` via `ctx.getService('objectql')`; and the
production registration of that service name is
`packages/objectql/src/plugin.ts:400`, `ctx.registerService('objectql', this.ql)`, where
`this.ql` is `new ObjectQL(...)` — the class whose `find` is leg 2.

One more datum worth recording: the `records` envelope *does* exist in this repo, on a
different function with a different declared return —
`packages/metadata/src/loaders/database-loader.ts`, `queryHistory()`, a metadata-history
pagination shape. Nothing on `ql.find`'s path produces it.

## The two call sites, before and after

> **Reading note.** In the "after" snippet the row annotation is written as the
> placeholder `ROW_ARRAY`. In the file it is ordinary TypeScript generic syntax —
> `Array` parameterised by `Record` of `string` to `unknown`. It is spelled as a
> placeholder here because GitHub's body sanitizer deletes angle-bracket fragments from a
> description: it ate that exact annotation out of the first version of this text, leaving
> a bare `Array&gt;` inside the code fence. Fences do not protect it. The literal bytes
> are in the Files tab.

Before (the two `rowsOf(...)` wrappers):

```ts
  const projects = rowsOf(
    await ql.find('showcase_project', {
      where: { status: { $in: [...SWEPT_STATUSES] } },
      fields: ['id', 'status', 'health', 'budget', 'spent'],
      limit: READ_LIMIT,
      context: SYS,
    }),
  );
...
  const tasks = rowsOf(
    await ql.find('showcase_task', {
      where: { project: { $in: projectIds } },
      fields: ['project', 'progress'],
      limit: READ_LIMIT,
      context: SYS,
    }),
  );
```

After:

```ts
  const projects: ROW_ARRAY = await ql.find('showcase_project', {
    where: { status: { $in: [...SWEPT_STATUSES] } },
    fields: ['id', 'status', 'health', 'budget', 'spent'],
    limit: READ_LIMIT,
    context: SYS,
  });
...
  const tasks: ROW_ARRAY = await ql.find('showcase_task', {
    where: { project: { $in: projectIds } },
    fields: ['project', 'progress'],
    limit: READ_LIMIT,
    context: SYS,
  });
```

The explicit annotation is deliberate: the declared return is `any[]`, and letting `any`
propagate would have silently weakened every downstream member read in this file
(`project.budget`, `task.progress`, `p.id`). The annotation keeps the exact static type
the code already had while deleting the runtime branch. No behaviour changes — the
normalizer was an identity on every value the engine can produce.

The delete leaves no dangling reference: `rowsOf` now occurs 0 times in the file (3
before), `records` 0 times, and the file's only import (`JobHandlerContext`) is still
used. Diff is 1 file, +12 / -23.

## Tests

Suite covering this job: `examples/app-showcase/test/inert-wirings.test.ts`.

Measured both ways from the committed state, restoring the parent version of the file on
disk for the "before" leg and confirming each leg by blob hash before reading anything:

| leg | on-disk confirmation | result |
| --- | --- | --- |
| after (`rowsOf` deleted) | `rowsOf` count 0 | `Tests  36 passed (36)` |
| before (parent file restored) | blob `cd757ba8` == `HEAD~1` blob, `rowsOf` count 3 | `Tests  36 passed (36)` |
| restored | blob `006c547c` == `HEAD` blob, `git diff HEAD` empty | — |

No rebuild leg was needed for either measurement: `@objectstack/example-showcase` exports
TypeScript source (`main: ./objectstack.config.ts`) and the suite imports the handler by
relative source path, so no `dist/` sits between the edit and the assertion.

Both legs pass identically, which is the expected direction here rather than a red: the
suite's fake engine returns arrays on every path, so it never exercised the deleted limb.
That is corroboration that the limb was dead, and it means no coverage was lost.

Whole package, after: `Test Files  27 passed (27)`, `Tests  375 passed (375)`.
`pnpm --filter @objectstack/example-showcase run typecheck` (`tsc --noEmit`) clean —
and verified to actually cover the edit: `tsc --listFiles` lists
`sweep-project-health.ts` among the 1589 files in the program.

## Gates

Derived from the real change set with
`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(1 path vs merge base `2d40f914`), then run at `e275b7b8` with exit codes captured by
redirect, never across a pipe.

15 of 17 green, including `check:react-page-adapter-contract`, which reports
`21 app-showcase page module(s) + 1 content/docs react-page sample(s) ... no find() result
is tested for array-ness`.

Two exited **3**, which each gate's own verdict text declares is not a result:

- `check-test-completeness` — `Nothing was measured: this gate exited before parsing a
  single summary line`.
- `check:dual-build-cjs-loads` — `PREREQUISITE NOT MET — this gate reads built output, and
  some package has no dist/.` Its self-test half passed (93 cases). Recorded as NOT
  MEASURED, not as a pass and not as a red; CI runs it after a full build.

Also run: `pnpm check:nul-bytes` green (8070 files, no raw control bytes), and the
repo-wide `pnpm lint` (`eslint . --no-inline-config`) — exit 0, no findings. That is the
full scan, not a narrowed one.

## Changeset

None, `skip-changeset`. `@objectstack/example-showcase` is `"private": true`, so this diff
publishes nothing from any released package — AGENTS.md's stated criterion for the label.
The direct precedent is `253da34c4`, the examples-only commit that created this very
handler, which carried no changeset either.

## Out of scope, deliberately

Per the triage ruling, this card is the instance and not the class:
`scripts/check-react-page-adapter-contract.mjs` and its population are untouched. A second
instance of the same dead-normalizer shape exists at
`packages/cli/src/commands/secret/orphans.ts` (its own local `rowsOf`, over
`secretDriver.find(...)`); it is reported back to the dispatching PM rather than fixed
here — different package, different lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8