### PR TITLE
test(plugin-auth): import the registered object set from the manifest in five harnesses

### DIFF
--- a/packages/plugins/plugin-auth/src/audience-bootstrap-seam.test.ts
+++ b/packages/plugins/plugin-auth/src/audience-bootstrap-seam.test.ts
@@ -61,35 +61,20 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import { AuthManager } from './auth-manager.js';
+import { authIdentityObjects } from './manifest.js';
 import { SELF_REGISTRATION_CLOSED, isHumanUserRow } from './audience-posture.js';
-import {
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-} from '@objectstack/platform-objects';
 
 const BASE = 'http://localhost:3000';
 const AUTH = `${BASE}/api/v1/auth`;
 const SECRET = 'test-secret-at-least-32-chars-long-11767';
 const PASSWORD = 'S3cure!Passw0rd-11767';
 
-const AUTH_OBJECTS = [
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-];
+/**
+ * The objects a deployment that mounts plugin-auth registers, imported from the
+ * plugin's own manifest rather than re-spelled here, so this harness cannot
+ * drift from what `auth-plugin.ts` registers at runtime (#14615).
+ */
+const AUTH_OBJECTS = authIdentityObjects;
 
 const engines: ObjectQL[] = [];
 afterEach(async () => {

--- a/packages/plugins/plugin-auth/src/credential-at-rest-posture.test.ts
+++ b/packages/plugins/plugin-auth/src/credential-at-rest-posture.test.ts
@@ -76,35 +76,12 @@ import { createHash, createHmac } from 'node:crypto';
 import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import { AuthManager } from './auth-manager.js';
+import { authIdentityObjects } from './manifest.js';
 import { createTenancyService } from './tenancy-service.js';
 import {
   mintScimConnectionCredential,
   SCIM_BEARER_PREFIX,
 } from './scim-connection-service.js';
-import {
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-  SysScimConnectionBinding,
-  SysScimConnectionCredential,
-  SysScimGroup,
-  SysScimGroupMember,
-  SysScimIdentityTombstone,
-  SysScimProjectionGrant,
-  SysScimSubject,
-  SysScimUser,
-  SysOauthApplication,
-  SysOauthAccessToken,
-  SysOauthRefreshToken,
-  SysOauthConsent,
-  SysJwks,
-} from '@objectstack/platform-objects';
 
 const BASE = 'http://localhost:3000';
 const AUTH = `${BASE}/api/v1/auth`;
@@ -146,32 +123,12 @@ afterEach(async () => {
   }
 });
 
-/** The identity surface the org + admin + scim + oauth-provider plugins touch. */
-const AUTH_OBJECTS = [
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-  // The stable scim model set + the ObjectStack-owned credential store (#3653).
-  SysScimConnectionBinding,
-  SysScimConnectionCredential,
-  SysScimGroup,
-  SysScimGroupMember,
-  SysScimIdentityTombstone,
-  SysScimProjectionGrant,
-  SysScimSubject,
-  SysScimUser,
-  SysOauthApplication,
-  SysOauthAccessToken,
-  SysOauthRefreshToken,
-  SysOauthConsent,
-  SysJwks,
-];
+/**
+ * The objects a deployment that mounts plugin-auth registers, imported from the
+ * plugin's own manifest rather than re-spelled here, so this harness cannot
+ * drift from what `auth-plugin.ts` registers at runtime (#14615).
+ */
+const AUTH_OBJECTS = authIdentityObjects;
 
 async function bootEngine(): Promise<ObjectQL> {
   const engine = new ObjectQL();

--- a/packages/plugins/plugin-auth/src/dev-admin-seed-credential-gate.test.ts
+++ b/packages/plugins/plugin-auth/src/dev-admin-seed-credential-gate.test.ts
@@ -55,21 +55,11 @@ import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import type { PluginContext } from '@objectstack/core';
 import { AuthManager } from './auth-manager.js';
+import { authIdentityObjects } from './manifest.js';
 import { AuthPlugin } from './auth-plugin.js';
 import { SELF_REGISTRATION_CLOSED } from './audience-posture.js';
 import { decideDevAdminSeedGate } from './dev-admin-seed-gate.js';
 import { recoverInternalFieldsForSystemRead } from './internal-field-readback.js';
-import {
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-} from '@objectstack/platform-objects';
 
 const BASE = 'http://localhost:3000';
 const AUTH_BASE = '/api/v1/auth';
@@ -78,17 +68,12 @@ const SEED_EMAIL = 'admin@objectos.ai';
 const SEED_PASSWORD = 'admin123';
 const SYSTEM = { context: { isSystem: true } } as never;
 
-const AUTH_OBJECTS = [
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-];
+/**
+ * The objects a deployment that mounts plugin-auth registers, imported from the
+ * plugin's own manifest rather than re-spelled here, so this harness cannot
+ * drift from what `auth-plugin.ts` registers at runtime (#14615).
+ */
+const AUTH_OBJECTS = authIdentityObjects;
 
 /** The env the seed is HARD-gated on (`isDevAdminSeedArmed`). */
 const SEED_ENV_KEYS = [

--- a/packages/plugins/plugin-auth/src/sso-register-platform-admin-gate.test.ts
+++ b/packages/plugins/plugin-auth/src/sso-register-platform-admin-gate.test.ts
@@ -60,27 +60,23 @@ import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import { ADMIN_FULL_ACCESS } from '@objectstack/spec/identity';
 import { AuthManager } from './auth-manager.js';
+import { authIdentityObjects } from './manifest.js';
 import { AuthPlugin } from './auth-plugin.js';
 import { createTenancyService } from './tenancy-service.js';
 import type { PluginContext } from '@objectstack/core';
-import {
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-  SysSsoProvider,
-} from '@objectstack/platform-objects';
 import { inviteForAudienceGate } from './audience-gate-test-support';
 
 const BASE = 'http://localhost:3000';
 const AUTH = `${BASE}/api/v1/auth`;
 const SECRET = 'test-secret-at-least-32-chars-long-10009';
 const SYSTEM = { context: { isSystem: true } } as const;
+
+/**
+ * The objects a deployment that mounts plugin-auth registers, imported from the
+ * plugin's own manifest rather than re-spelled here, so this harness cannot
+ * drift from what `auth-plugin.ts` registers at runtime (#14615).
+ */
+const AUTH_OBJECTS = authIdentityObjects;
 
 const sysPermissionSet = {
   name: 'sys_permission_set',
@@ -126,11 +122,7 @@ async function bootEngine(): Promise<ObjectQL> {
     true,
   );
   await engine.init();
-  const objects = [
-    SysUser, SysSession, SysAccount, SysVerification, SysOrganization,
-    SysMember, SysInvitation, SysTeam, SysTeamMember, SysSsoProvider,
-  ];
-  for (const object of objects) {
+  for (const object of AUTH_OBJECTS) {
     engine.registry.registerObject(object as never, '@objectstack/plugin-auth');
   }
   engine.registry.registerObject(sysPermissionSet as never, '@objectstack/plugin-auth');

--- a/packages/plugins/plugin-auth/src/walled-owner-operator-stamp.test.ts
+++ b/packages/plugins/plugin-auth/src/walled-owner-operator-stamp.test.ts
@@ -43,23 +43,13 @@ import { ObjectQL } from '@objectstack/objectql';
 import { SqlDriver } from '@objectstack/driver-sql';
 import { isEmailVerifiedUserRow } from '@objectstack/types';
 import { AuthManager } from './auth-manager.js';
+import { authIdentityObjects } from './manifest.js';
 import {
   isOperatorProvisionedCreation,
   shouldStampOwnerVerifiedAtCreation,
 } from './walled-owner-operator-stamp.js';
 import { probeWalledOwnerAccountState } from './walled-owner-verification-path.js';
 import { inviteForAudienceGate } from './audience-gate-test-support';
-import {
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-} from '@objectstack/platform-objects';
 
 const BASE = 'http://localhost:3000';
 const AUTH = `${BASE}/api/v1/auth`;
@@ -110,17 +100,12 @@ const OWNER_LIST = `${OWNER}, ${SECOND_OWNER}`;
 
 // ── the real-engine harness (the audience-bootstrap-seam shape) ─────────────
 
-const AUTH_OBJECTS = [
-  SysUser,
-  SysSession,
-  SysAccount,
-  SysVerification,
-  SysOrganization,
-  SysMember,
-  SysInvitation,
-  SysTeam,
-  SysTeamMember,
-];
+/**
+ * The objects a deployment that mounts plugin-auth registers, imported from the
+ * plugin's own manifest rather than re-spelled here, so this harness cannot
+ * drift from what `auth-plugin.ts` registers at runtime (#14615).
+ */
+const AUTH_OBJECTS = authIdentityObjects;
 
 const engines: ObjectQL[] = [];
 afterEach(async () => {


### PR DESCRIPTION
Fixes #14756

Five plugin-auth harnesses hand-wrote the set of objects a deployment mounting
plugin-auth registers, instead of importing `authIdentityObjects` from
`src/manifest.ts`. Each hand list had drifted below the manifest, so each
harness booted an engine missing tables the runtime registers. This converts
all five to the import pattern PR #14751 established on the two SCIM harnesses.

## Population, re-derived on the tree

`git grep -ln AUTH_OBJECTS` finds six harnesses; the two SCIM ones were already
converted by #14751 (merged as `d2bdab2d0`) and are left untouched here. The
five this card owns, measured against `authIdentityObjects` (30 objects) by
resolving each hand-listed symbol through `@objectstack/platform-objects` and
comparing the resulting object NAMES:

| harness | hand list | objects missing vs manifest |
| --- | --- | --- |
| `audience-bootstrap-seam.test.ts` | 9 | 21 |
| `dev-admin-seed-credential-gate.test.ts` | 9 | 21 |
| `sso-register-platform-admin-gate.test.ts` | 10 | 20 |
| `walled-owner-operator-stamp.test.ts` | 9 | 21 |
| `credential-at-rest-posture.test.ts` | 22 | 8 |

No hand list contained an object the manifest does not (0 extras anywhere), so
every conversion is a strict widening.

Two corrections to the triage note on the card, both measured:

1. `credential-at-rest-posture.test.ts` was described as "complete today". It is
   not: its list is missing 8 of the 30 objects, three of them OAuth ones —
   `sys_oauth_client_assertion`, `sys_oauth_client_resource`,
   `sys_oauth_resource` — plus `sys_api_key`, `sys_device_code`,
   `sys_sso_provider`, `sys_two_factor`, `sys_user_preference`. Converting it is
   a real widening, not just a spelling change.
2. `sso-register-platform-admin-gate.test.ts` had no `AUTH_OBJECTS` constant at
   all. Its list was a local `const objects` inside `bootEngine()`. It is now a
   module-scope `AUTH_OBJECTS = authIdentityObjects`, matching the other four.

## Non-vacuity: the object set really grew

Booting the same engine shape `bootEngine()` uses (ObjectQL + `driver-sql` +
better-sqlite3 `:memory:`), once with the old 9-object hand list and once with
`authIdentityObjects`, then asking the driver to read four tables:

```
BEFORE (old hand-written list): registered 9 objects
  sys_user: READABLE (table exists)
  sys_oauth_access_token: REFUSED (no such table)
  sys_jwks: REFUSED (no such table)
  sys_sso_provider: REFUSED (no such table)

AFTER  (authIdentityObjects):   registered 30 objects
  sys_user: READABLE (table exists)
  sys_oauth_access_token: READABLE (table exists)
  sys_jwks: READABLE (table exists)
  sys_sso_provider: READABLE (table exists)
```

## ERROR-line disposition

Of the five, only `sso-register-platform-admin-gate.test.ts` emitted driver
`DATABASE_ERROR` lines on a green run. Tallied by table, before and after:

| table | before | after | in `authIdentityObjects`? |
| --- | --- | --- | --- |
| `sys_jwks` | 1 | 0 | yes |
| `sys_position` | 4 | 4 | no |
| `sys_user_position` | 4 | 4 | no |

The only line that disappeared is the `sys_jwks` one, and it disappeared
because `SysJwks` is in `authIdentityObjects` and is therefore now registered
and its table created — the intended effect. The `sys_position` and
`sys_user_position` lines are unchanged in count: those objects are not in the
auth identity manifest, so this change cannot and does not touch them.

No `sys_oauth_access_token` ERROR line appears in any of these five harnesses,
before or after, so nothing here touches the back-channel planner question in
#14615 arm 2 — that arm stays fenced and untouched by this PR.

## Tests

All five files, before and after (`pnpm --filter @objectstack/plugin-auth exec
vitest run --maxWorkers=2 src/NAME.test.ts`):

| file | before | after |
| --- | --- | --- |
| `audience-bootstrap-seam` | `Tests  6 passed (6)` | `Tests  6 passed (6)` |
| `dev-admin-seed-credential-gate` | `Tests  15 passed (15)` | `Tests  15 passed (15)` |
| `sso-register-platform-admin-gate` | `Tests  4 passed (4)` | `Tests  4 passed (4)` |
| `walled-owner-operator-stamp` | `Tests  28 passed (28)` | `Tests  28 passed (28)` |
| `credential-at-rest-posture` | `Tests  5 passed (5)` | `Tests  5 passed (5)` |

Whole package, at `0b6a065a2`:

```
Test Files  91 passed (91)
     Tests  1864 passed (1864)
```

`pnpm --filter @objectstack/plugin-auth typecheck` — exit 0. Its test layer is
compiled (verified with `tsc --listFiles -p tsconfig.test.json`: all five edited
files present, 1 hit each) and the shrink-only ledger is unmoved:
`check:test-typecheck: OK ... 10 file(s) / 94 error(s) / 23 pinned signature(s)`,
none of the 94 in an edited file.

`pnpm lint` (`eslint . --no-inline-config`, whole repo) — exit 0, no output.

## Gates

Derived at `0b6a065a2` with
`node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
(27 commands). 24 green. The other three exit 3, and each says in its own verdict
text that nothing was measured because the full workspace `dist/` is absent
locally — `check-test-completeness` ("Nothing was measured"),
`check:dual-build-cjs-loads` ("PREREQUISITE NOT MET ... This is NOT a pass"),
`check:type-check-debt` ("--re-measure cannot run"). CI builds the closure and
runs them for real. `check:nul-bytes` green (8070 files) and a control-byte
scan over the five edited files found nothing.

`check-system-context-census` and `check-affected-docs` are both green after the
line-number shifts this diff causes in the five files.

## Scope

Test-only; it imports an existing live export (`manifest.ts:49`). No package
publishes anything new, so this carries the `skip-changeset` label rather than a
changeset. The two SCIM harnesses (`scim-deactivation-reconcile-user.test.ts`,
`scim-transaction-scope.test.ts`) are not modified here and nothing was pushed
to #14751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8)_