### PR TITLE
docs(pm-dispatch): collapse CLAUDE.md's four excerpts to rule, hook and anchor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,86 +1,36 @@
 # CLAUDE.md
 
 **[AGENTS.md](./AGENTS.md) is the source of truth for working in this repo — read it.**
-Its Prime Directives are binding. Do not rely on this file alone; the four rules that
-must never be missed are inlined here because missing any one of them wastes or corrupts
-other agents' work.
+Its Prime Directives are binding: each of the four rules that must never be missed is
+inlined below as one sentence, its enforcing hook, and a pointer to the AGENTS.md heading.
 
 ## ⛔ Claim the issue before you write any code
 
-Assign the issue to yourself (`gh issue edit <n> --add-assignee @me`, or `issue_write` with
-`assignees`) as the **first action of the task** — before the worktree, before the first read.
-Several agents work this repo at once and an unassigned issue reads as an open invitation: two
-that start on it burn the same hours twice, then race to land conflicting shapes. Already
-assigned to someone else? It is taken — pick another or ask; never reassign it. File findings
-unassigned when only recording; assign at the moment you start.
-
-All agents share one GitHub identity, so the assignee field can't tell you whether a claim
-is **yours** — a claim is assign **plus a claim comment with your session ID and branch**
-(`claude/issue-<n>-<slug>`), and before writing code you must re-read the comments: an
-earlier claim with a different session ID means it's taken, whatever the assignee says.
-(Skipping that read is how one issue got implemented twice in one morning.)
+Claim it **before any other action**: assign yourself *and* comment your session ID and
+branch — the shared identity makes the assignee field no proof, so re-read the comments.
+No hook enforces this one. Full rule: AGENTS.md → **Multi-agent working discipline**, its
+paragraph **Claim the issue BEFORE you write any code.**
 
 ## ⛔ Worktree-first — before your FIRST file edit (AGENTS.md Prime Directive #11)
 
-This repo — **and every sibling repo you touch (`objectui`, `cloud`)** — is edited by
-**multiple agents at once**. The shared primary checkout has its HEAD switched and its
-tree reset *under you*, silently clobbering uncommitted work. **A feature branch on the
-shared checkout is NOT enough** — it still gets switched under you. You MUST be in a
-**dedicated per-task worktree**:
-
-```
-git fetch origin main && git worktree add --no-track ../<repo>-<task> -b <branch> origin/main && cd ../<repo>-<task> && pnpm install
-```
-
-Then make all edits there. This applies **per repo**: if a task spans `framework` and
-`objectui`, create a worktree in *each*. Two PreToolUse hooks enforce this, and both check
-the target file's **own** repo (so sibling repos are covered): `guard-main-checkout.sh`
-blocks `Edit`/`Write`/`NotebookEdit`, and `guard-main-checkout-bash.sh` blocks the same
-write as a **Bash** command (`>`/`>>`, `sed -i`, `perl -i`, `tee`, `cp`, `mv`, `rm`,
-`touch`) — reads are never blocked, and anything it cannot parse confidently is allowed
-through, so the rule still outranks the hook. Non-task exception (both hooks, one switch):
-`OS_ALLOW_MAIN_EDITS=1`. Follow the rule because it's correct, not because the hook fires.
+Never edit a shared primary checkout — this repo's or any sibling repo's (`objectui`,
+`cloud`); its HEAD and tree move under you. One dedicated worktree per task, per repo.
+Hooks in `.claude/hooks/`: `guard-main-checkout.sh` (Edit/Write/NotebookEdit) and
+`guard-main-checkout-bash.sh` (the same writes as Bash); override `OS_ALLOW_MAIN_EDITS=1`.
+Full rule: AGENTS.md → **Prime Directives**, directive 11.
 
 ## ⛔ Never `git stash` — the stash stack is NOT covered by worktree isolation
 
-`git stash` keeps its stack in `refs/stash` inside the **common `.git` directory**, so
-**every worktree of the repo shares one LIFO stack**. ⚠️ It is one CASE, not an exception:
-a worktree isolates your checkout and exactly four ref namespaces (`HEAD`, `refs/bisect`,
-`refs/worktree`, `refs/rewritten`) and nothing else — `refs/remotes/*` is shared too, so a
-sibling's fetch moves *your* `origin/main` (AGENTS.md §9 carries the full rule). Two agents
-stashing in their own worktrees push and pop the *same* stack — your `pop` restores what
-the other agent pushed a moment earlier, and your own changes stay on the stack for them to
-take. `pop` reports **success**; the only symptom is someone else's files appearing in your
-`git status`, and a following `git add -A` merges their work into your PR. Not
-hypothetical: it happened between two parallel agents mid reverse-verification and cost
-both of them their in-flight changes, recoverable only as unreachable commits.
-
-Use one of these instead — no shared state, all inside your own worktree:
-
-```
-git diff > /tmp/wip.patch && git checkout -- <paths>   # then: git apply /tmp/wip.patch
-git commit -am wip                                     # then: git reset --soft HEAD~1
-git worktree add ../objectstack-<task>-cmp <ref>       # a second tree to compare against
-```
-
-A PreToolUse hook (`.claude/hooks/guard-shared-stash.sh`) enforces this — it blocks the
-`Bash` commands that push/pop/drop/clear the stack, and allows the forms that cannot take
-another agent's entry: `git stash list`/`show`/`create`, and `git stash apply <sha>` /
-`store <sha>` pinned to a **literal hex object id** (never `stash@{N}` — that is a
-*position* in a stack you don't own). Deliberate exception: `OS_ALLOW_STASH=1`. Changing
-the hook? Re-run `.claude/hooks/guard-shared-stash.selftest.sh`.
+`refs/stash` lives in the common `.git` dir, so all worktrees share one LIFO stack: your
+`pop` takes another agent's entry and reports **success** — use a patch or a wip commit.
+Hook `guard-shared-stash.sh` enforces it (override `OS_ALLOW_STASH=1`; re-run its
+`.selftest.sh` if you change it). Full rule: AGENTS.md → **Multi-agent working discipline**.
 
 ## ⛔ Never edit `content/docs/releases/` in a code PR
 
-Release notes are written **centrally, at release time** — not accreted one PR at a time.
-Every code/feature/retirement PR appending its own row to the current
-`releases/v<major>.mdx` turns that file into the single hottest merge-conflict magnet in
-the repo (with ~18 merges to `main` in a working day, the same table conflicts over and
-over, and each resolution risks dropping someone else's row). Your PR's inputs to the
-release notes are the **changeset** (`.changeset/*.md` — one file per change, never
-conflicts) and, for spec removals, the ADR-0087 registries; the release process compiles
-them. If a releases page has a factual error, file an issue or make it a dedicated
-docs-only PR — never a rider on code changes.
+Release notes are written **centrally, at release time**, never accreted a row per PR; a
+factual error there is a dedicated docs-only PR or an issue, never a rider on code changes.
+No hook: your PR's input to them is its **changeset** (`.changeset/*.md`). Full rule:
+AGENTS.md → **Documentation Guardrails**, its `content/docs/releases/` row.
 
-See **AGENTS.md** for the full playbook: branch hygiene, the dev stack, PR flow, and the
-rest of the Prime Directives.
+See **AGENTS.md** for the rest: branch hygiene, the dev stack, PR flow, the Prime Directives.


### PR DESCRIPTION
Part of #14685
Part of #13597

Item 3 of decision batch 3, ruled **B**. Verbatim from ruling comment 5520452691:

> **B** — each of `CLAUDE.md`'s four hand-copied excerpts collapses to one ⛔ rule sentence, the enforcing hook or override switch, and a pointer to the `AGENTS.md` anchor (about 30 lines). The two measured drifts (C4's "§9" pointer, C5's "~18 merges" figure the anchor does not carry) are fixed under this ruling. The charter sentence "the four rules are inlined here" is rewritten to say each is inlined as one sentence — the maintainer has ruled that change.

Governed surface (`CLAUDE.md`): this PR stays **draft**, no reviewers requested, no ready flip, no enqueue. The dispatching seat runs contract review and then requests human review.

## Scope

One file: the repo-root `CLAUDE.md`. Nothing else in the tree is touched. `AGENTS.md`, the hooks and objectui's `CLAUDE.md` are explicitly out of scope for this flight.

## Counts

Token convention is `ceil(utf8 bytes / 4)` — the convention `scripts/check-skills-token-ratchet.mjs` declares as `TOKEN_CONVENTION` (line 184), used here so the number is comparable with the published-skill ledger even though this file is not in that ledger.

| file | lines before | lines after | lines delta | tokens before | tokens after | tokens delta |
|:---|---:|---:|---:|---:|---:|---:|
| `CLAUDE.md` | 86 | 36 | -50 | 1369 | 524 | -845 |

Whole-PR total is the same row: one file changed. Line ratchet ceiling for `CLAUDE.md` stays **86** — not edited here (the re-lock is a separate pass after all four flights).

## Site by site

Line numbers on the left are `origin/main` at `f3ae441fa2`, where the file was 86 lines.

| site | before | after | what happened |
|:---|---:|---:|:---|
| charter, `:1-6` | 4 prose lines | 3 prose lines | ruled rewrite: the sentence now says each of the four rules is inlined **as one sentence, its enforcing hook, and a pointer to the AGENTS.md heading**, instead of "the four rules ... are inlined here because missing any one of them wastes or corrupts other agents' work" |
| C2 claim-the-issue, `:8-21` | 12 body lines | 4 body lines | rule sentence kept (assign plus a claim comment carrying session ID and branch; re-read the comments); dropped the `gh` invocation, the "burn the same hours twice" narrative and the "implemented twice in one morning" incident; one clause now states there is **no hook**; pointer added |
| C3 worktree-first, `:23-42` | 18 body lines | 5 body lines | rule sentence kept (never edit a shared primary checkout, this repo's or a sibling's; one worktree per task per repo); dropped the fenced `git worktree add` recipe and the fail-open/precedence commentary; both hooks and `OS_ALLOW_MAIN_EDITS=1` kept on one line; pointer added |
| C4 never-stash, `:44-71` | 26 body lines | 5 body lines | rule sentence kept (`refs/stash` is in the common `.git` dir, one shared LIFO stack, `pop` reports success); dropped the fenced replacement recipes, the four-ref-namespace enumeration and the incident narrative; hook, `OS_ALLOW_STASH=1` and the self-test kept on one line; pointer added |
| C5 releases, `:73-83` | 9 body lines | 4 body lines | rule sentence kept (written centrally at release time, never a row per PR; a factual error is a docs-only PR or an issue); dropped the conflict-magnet narrative; the changeset input is named in place of a hook; pointer added |
| closing pointer, `:85-86` | 2 lines | 1 line | kept as a pointer, rewrapped to one line |

Four `##` headings are **byte-identical** to `origin/main` — verified with `diff` over `grep '^## '` on both sides, so any grep or tooling that names a heading keeps working. Repo-wide grep for each heading text finds only `CLAUDE.md` itself, so no script or hook reads them today.

## The two ruled drift fixes

- **C4 drift — the "AGENTS.md §9" pointer.** The shared-`refs/remotes` fact it pointed at lives in the **unnumbered preface** of `## Multi-agent working discipline`, not in any numbered section; `§9` resolved to nothing. The pointer is now spelled by heading text. The `refs/remotes` fact itself stays in `AGENTS.md`, which is where it is maintained.
- **C5 drift — "~18 merges to `main` in a working day".** A statistic the `AGENTS.md` anchor does not carry (the anchor row says "three PRs raced the same table inside one afternoon"). It left with the narrative it lived in; nothing in `CLAUDE.md` now states a merge-rate figure.

## Every pointer resolves

Measured at this PR's head with `grep -n` in `AGENTS.md`. Headings are cited by **text**, never by line number; the lines below are evidence, not the pointer.

| pointer written in `CLAUDE.md` | `AGENTS.md` match at head |
|:---|:---|
| **Multi-agent working discipline**, its paragraph **Claim the issue BEFORE you write any code.** | `380:## Multi-agent working discipline` and `459:**Claim the issue BEFORE you write any code.** Assign it to yourself` |
| **Prime Directives**, directive 11 | `191:## Prime Directives` and ``241:11. **Worktree-first — never edit on the shared `main` checkout.**`` |
| **Multi-agent working discipline** (stash) | `380:## Multi-agent working discipline`; the rule is that section's opening paragraph, ``385:**⛔ `git stash` is the sharpest thing the worktree does NOT isolate — never run a bare`` |
| **Documentation Guardrails**, its `content/docs/releases/` row | `721:## Documentation Guardrails` and ``726:| `content/docs/releases/` | **RELEASE-OWNED** | ❌ Never edit in a code PR. ...`` |

## Every hook named exists

`ls .claude/hooks/` at head:

- `.claude/hooks/guard-main-checkout.sh` — its header line 3 reads "Blocks Edit / Write / NotebookEdit unless the file being edited lives in a dedicated ..."; `OS_ALLOW_MAIN_EDITS` at `:23`.
- `.claude/hooks/guard-main-checkout-bash.sh` — `OS_ALLOW_MAIN_EDITS` at `:95`.
- `.claude/hooks/guard-shared-stash.sh` — `OS_ALLOW_STASH` at `:70`.
- `.claude/hooks/guard-shared-stash.selftest.sh` — referenced as "its `.selftest.sh`".

## Gates

Derived at the final head, quoting the derivation line:

```
dispatch-gates: gate list derived from the tree of 'objectstack-ai/objectstack' at commit 94f328e8ff (/home/user/objectstack-14685-item3).
dispatch-gates: change set derived from git — 1 path(s) vs merge base 5ff5f9576 of 'origin/main' and HEAD
  (committed 1, working tree 0, untracked 0; three-dot semantics, never 'origin/main..HEAD')
  · CLAUDE.md
```

All runs below are at head `94f328e8ff` (after `git merge origin/main`, no rebase). Exit codes captured by redirect before any pipe.

| gate | exit | its own verdict line |
|:---|---:|:---|
| `pnpm check:pm-skill-ratchet` (line ratchet) | 0 | `✓ check-skill-line-ratchet: CLAUDE.md is 36 lines (ceiling 86; headroom 50).` and `✓ check-skill-line-ratchet: CLAUDE.md: widest table row is 0 bytes (pin 0; headroom 0).` |
| `pnpm check:agent-test-spelling` | 0 | ``✓ check-agent-test-spelling: 0 violations — 430 file(s) · 5704 bare `--` token(s) · 1381 launcher-rooted run(s) · 9 separator(s) JUDGED · 5 vitest-backed script name(s) derived from 81 manifest(s)`` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 241 assertions (...)` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 4 copies of the decision frame are structurally isomorphic across 3 files` |
| token ratchet (`node scripts/check-skills-token-ratchet.mjs --self-test` then the scan) | 0 | `✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.` |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8072 text file(s) -- 8072 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes).` |
| `pnpm check:role-word` | 0 | `check-role-word: OK, no new occurrences of the reserved word.` |
| `pnpm check:corpus-claim-drift` | 0 | `check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.` |

Also run outside any gate, since the file was edited: `grep -naP` for raw ASCII control bytes over `CLAUDE.md` — no match (exit 1).

### NOT MEASURED, and why

- **Token ratchet does not cover `CLAUDE.md`.** It reports `36 authored bundle file(s)`, all under `skills/**`; `grep -c CLAUDE.md` over its full output is `0`. Its green says nothing about this file. The token numbers in the counts table above are computed by hand under the same convention, not read from this gate.
- **`check:role-word` and `check:corpus-claim-drift` do not read `CLAUDE.md` either.** Both print their own population: `Scanned: 224 .md/.mdx file(s) read across 2 root(s) — content/docs 190, skills 34`. The repo root is not one of those roots. They are green and they are green about other files; they are listed because the flight brief named them, and they are reported here as **not measuring this change**.
- **No repo-wide `pnpm lint` run.** ESLint's population is JS/TS; this PR changes one Markdown file and adds, removes or moves no code, so no ESLint judgement about any file can change. Reported as a narrowing, not as a pass.
- **CI is not awaited.** Per the dispatch contract the report is delivered at draft-PR time; the always-runs tail named by `dispatch-gates` is CI's to run.

## Judgement calls

1. **36 lines, not "about 30".** Ruling B says "about 30 lines"; the flight brief permits up to 40 provided every kept line is a rule, a hook or a pointer. Every line here is one of those three. Getting to 30 exactly would have cost either a hook name, an override switch or a pointer.
2. **The `refs/remotes` sub-fact left `CLAUDE.md` with the stash narrative.** It was a parenthetical inside the C4 excerpt (the one carrying the `§9` drift), not one of the four rules. Under B it collapses out; it is unchanged in `AGENTS.md`.
3. **The ADR-0087 registries dropped from the releases block.** The ruled shape names one input; the changeset is the one that applies to every PR. The registries stay in the `AGENTS.md` anchor row.
4. **The closing "See AGENTS.md" line was kept**, rewrapped to one line. It is a pointer, which the ruled shape admits, and removing it is not something the ruling asks for.
5. **Headings kept verbatim** including the `⛔` and the "(AGENTS.md Prime Directive #11)" suffix on the worktree heading, which is accurate at head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_