### PR TITLE
test(cli): quarantine the never-read-reader hang case behind #14832 (maintainer ruling A, 2026-09-03)

### DIFF
--- a/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
+++ b/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
@@ -300,10 +300,18 @@ beforeAll(async () => {
   built = await runCli(REAL_COMMAND, dir, undefined);
   genuinelyMissing = await runCli(['definitely-not-a-command'], dir, undefined);
   stalled = await runCliWhileParentStalls(REAL_COMMAND, dir, `--import ${UNBUILT_HOOK}`);
-  // ⛔ Nothing measured above is consulted here. Case 1's wall clock is read by
-  // the failure message below, as evidence; the ceiling is a constant, so a
-  // slow sample can no longer size the instrument that judges the next run.
-  unread = await runCliAgainstDeadReader(REAL_COMMAND, dir, `--import ${UNBUILT_HOOK}`, 'never-read', UNREAD_HARD_CAP_MS);
+  // ⛔ QUARANTINED — the `'never-read'` child is NOT spawned while the case it
+  // feeds is skipped. See the quarantine note on
+  // `it.skip('gives up and exits instead of waiting forever')` further down:
+  // this spawn is where the 180 s `UNREAD_HARD_CAP_MS` is paid under CI load,
+  // and that one case is its ONLY consumer — `unread` is read nowhere else in
+  // this file. The PR that fixes the hang in `bin/run-dev.js` un-skips that case
+  // and restores these four lines verbatim, in the same change:
+  //
+  //   // ⛔ Nothing measured above is consulted here. Case 1's wall clock is read by
+  //   // the failure message below, as evidence; the ceiling is a constant, so a
+  //   // slow sample can no longer size the instrument that judges the next run.
+  //   unread = await runCliAgainstDeadReader(REAL_COMMAND, dir, `--import ${UNBUILT_HOOK}`, 'never-read', UNREAD_HARD_CAP_MS);
   closedEnd = await runCliAgainstDeadReader(REAL_COMMAND, dir, `--import ${UNBUILT_HOOK}`, 'destroy-read-end', UNREAD_HARD_CAP_MS);
 }, RUN_TIMEOUT_MS * 6);
 
@@ -392,7 +400,23 @@ describe('the mirror direction: a reader that is never coming back', () => {
    * this replaces armed no bound at all (`write()` returned true, so an early
    * return skipped it) and read as correct in every stalled-reader test.
    */
-  it('gives up and exits instead of waiting forever', () => {
+  // ⛔ QUARANTINED under the maintainer's ruling A of 2026-09-03 on
+  // objectstack#14832 — do not un-skip it on its own.
+  //
+  // WHY. The `'never-read'` child this case reads HANGS under CI load. The
+  // defect is in the product — `bin/run-dev.js`, the other half of #14832 —
+  // and NOT a cap that is set too low, so raising `UNREAD_HARD_CAP_MS` would buy
+  // nothing and would only make each failure slower. On `Test Core (1/6)` the
+  // harness SIGKILLed the child at the 180 s cap and this assertion red, and
+  // every occurrence EJECTED A WHOLE MERGE-QUEUE BATCH: `main` could not advance
+  // for hours behind this one case, which is what the ruling weighed.
+  //
+  // RE-ENABLE CONDITION. The PR that fixes the hang in `bin/run-dev.js` un-skips
+  // this case in the SAME change, and restores the `'never-read'` spawn in
+  // `beforeAll` (kept there verbatim, commented). The body below and all of its
+  // comments are untouched, so lifting the quarantine is `it.skip` -> `it` plus
+  // that one spawn line — nothing here has to be reconstructed.
+  it.skip('gives up and exits instead of waiting forever', () => {
     // A child still alive at the cap was SIGKILLed: signal set, code null.
     // That is the hang, and it is the whole point of this case.
     //

--- a/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
+++ b/packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts
@@ -291,7 +291,13 @@ let unbuilt: Run;
 let built: Run;
 let genuinelyMissing: Run;
 let stalled: Run;
-let unread: Lifetime;
+// Definite-assignment assertion for the duration of the QUARANTINE below: the
+// `'never-read'` spawn in `beforeAll` is commented out, so nothing assigns this
+// and `strict` reports TS2454 at each of the three reads inside the skipped
+// case. Restoring that spawn makes the `!` redundant again, so it goes when the
+// quarantine is lifted. (Measured: the package's own `typecheck` is
+// `include: ["src"]`, so it never compiles this file and would not have said.)
+let unread!: Lifetime;
 let closedEnd: Lifetime;
 
 beforeAll(async () => {


### PR DESCRIPTION
Part of #14832

## Ruling and provenance

Maintainer ruling **A** on #14832 (2026-09-03, live PM chat with the director seat, verbatim 「A，你现在就派发处理」), recorded at 14832#issuecomment-5521280392: until the hang in `bin/run-dev.js` is fixed, the one case that has been ejecting every merge-queue batch is quarantined so `main` can advance. This is a gate-weakening act taken by the maintainer and recorded as such; the quarantine is not a resting state.

## What changes (tests only, one file)

`packages/cli/test/run-dev-unbuilt-workspace.e2e.test.ts`:

- `describe('the mirror direction: a reader that is never coming back')` › `it('gives up and exits instead of waiting forever')` → `it.skip(...)`, with a note stating the ruling, why (the `'never-read'` child hangs under CI load — a product defect in `bin/run-dev.js`, not a cap set too low — and each occurrence ejected a whole merge-queue batch), and the re-enable condition. The case body and its comments are untouched, so lifting the quarantine is `it.skip` → `it` plus one spawn line.
- The `'never-read'` spawn in `beforeAll` is commented out verbatim (that spawn is where the 180 s `UNREAD_HARD_CAP_MS` is paid; the skipped case is its only consumer — `unread` is read nowhere else in the file). The `'destroy-read-end'` spawn and every other case stay live.
- `let unread!: Lifetime` — a definite-assignment assertion so the file stays strict-clean while nothing assigns it; it goes when the spawn is restored.

⛔ `bin/run-dev.js`, `RUN_TIMEOUT_MS`, `UNREAD_HARD_CAP_MS`, `STDERR_DRAIN_STALL_MS` and every other test are untouched. No changeset: tests-only (`skip-changeset`).

## Re-enable condition

The PR that fixes the hang in `bin/run-dev.js` (the `domain:cli` lane's, branch `claude/issue-14832-run-dev-unread-reader-hang`) un-skips the case and restores the spawn in the same change; if that PR must not touch this test file, the director seat lands the one-line un-skip the moment the fix merges. #14832 stays open until then.

## Verification

Branch head `edf00951` (two commits, both by the dispatched `os-dev`). The dispatched dev's local run (the file's suite with the case reported as skipped and no 180 s wait, package typecheck, the derived gate family) is posted on #14832 as its `os-dev-report`; the merge queue's own CI on this PR is the landing evidence — with the spawn removed, `Test Core (1/6)` no longer carries the three-minute tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShyhexkB2d1AeRZ85tgAAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShyhexkB2d1AeRZ85tgAAe)_