### PR TITLE
docs(service-job): state the scheduler leader-election guarantee with its window

### DIFF
--- a/.changeset/service-job-lease-window-docblock.md
+++ b/.changeset/service-job-lease-window-docblock.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/service-job': patch
+---
+
+docs(service-job): state the scheduler leader-election guarantee with its window (#14619)
+
+Documentation only — no runtime change, no type change, no accept/reject
+behaviour moves. It ships as a patch because the docblocks are **published
+bytes**: `tsup`'s declaration rollup carries `CronJobAdapter.runScheduled`'s
+docblock and `DbJobAdapter.schedule`'s routing docblock into `dist/index.d.ts`
+/ `dist/index.d.cts` (measured: with all comments stripped, the before/after
+declaration files are byte-identical — no exported symbol moved, no signature
+changed).
+
+`CronJobAdapter.runScheduled()` holds its cluster lock for the duration of a
+scheduled fire (acquired, then released in `finally`), not for the scheduling
+deadline. The two docblocks stated the guarantee — "only the node that
+acquires the per-job lock runs the handler" — without that window, which reads
+as exactly-once per deadline. It is exactly-once only when replica clocks
+agree to within the handler's runtime (the normal case on an NTP-synced
+deployment); a replica whose clock lags past that window finds the lock
+already released and reruns the job. `once` schedules are the sharpest case,
+since a one-shot has no later tick during which a business-level
+de-duplication marker could self-correct that away. The multi-node section of
+[Self-Hosted Deployment](/docs/deployment/self-hosting) states the same
+caveat.
+
+⛔ The mechanism is deliberately unchanged: holding the lease keyed to the
+deadline (plus takeover semantics for a leader that dies mid-fire) is a
+distributed-design item with zero measured pull and no measured
+skew-to-runtime ratio — this is bookkeeping, not closure. If a real
+duplicate-fire incident is measured on a `once` schedule, that remedy returns
+as its own card.

--- a/content/docs/deployment/self-hosting.mdx
+++ b/content/docs/deployment/self-hosting.mdx
@@ -402,6 +402,15 @@ decrypt each other's secrets. All replicas must share the same
 `OS_SECRET_KEY`, `OS_AUTH_SECRET`, and database. See
 [Cluster](/docs/kernel/cluster).
 
+**Scheduled jobs' leader election has a window, not a deadline.** `cron` /
+`interval` / `once` schedules dedupe across replicas by holding a lock for
+the duration of each fire — the mutual-exclusion window is the handler's
+runtime, not the scheduling deadline. Exactly-once per deadline holds only
+when replica clocks agree to within that window, which an NTP-synced
+deployment gives you. A replica whose clock lags past the window finds the
+lock already released and reruns the job; `once` schedules are the sharpest
+case, since a one-shot has no later tick to self-correct on.
+
 ## First boot: create the admin
 
 How the first administrator is created depends on the deployment's

--- a/packages/services/service-job/src/cron-job-adapter.ts
+++ b/packages/services/service-job/src/cron-job-adapter.ts
@@ -218,6 +218,15 @@ export class CronJobAdapter implements IJobService {
    * that acquires the per-job lock runs the handler; peers skip. No cluster /
    * in-memory driver => lock always granted => single-node unchanged. Manual
    * `trigger()` bypasses this.
+   *
+   * State the guarantee WITH its window: the lock below is held for the
+   * duration of the fire (acquired here, released in `finally`), so it
+   * de-duplicates *concurrent* fires — its mutual-exclusion window is the
+   * handler's runtime, not the scheduling deadline. Exactly-once per deadline
+   * holds only when replica clocks agree to within that window (the normal
+   * case on an NTP-synced deployment). A replica whose clock lags past the
+   * window finds the lock already released and reruns the job; `once` has no
+   * later tick during which a business-level de-duplication marker could win.
    */
   private async runScheduled(name: string): Promise<void> {
     const record = this.jobs.get(name);

--- a/packages/services/service-job/src/db-job-adapter.ts
+++ b/packages/services/service-job/src/db-job-adapter.ts
@@ -138,6 +138,15 @@ export class DbJobAdapter implements IJobService {
    * later tick during which a business-level de-duplication marker could win, so
    * every replica's copy lands inside the same short window.
    *
+   * **State the guarantee WITH its window.** The lock `CronJobAdapter.runScheduled()`
+   * takes is held for the duration of the fire, not for the deadline — its
+   * mutual-exclusion window is the handler's runtime. So the routing above
+   * de-duplicates *concurrent* fires: exactly-once per deadline holds only
+   * when replica clocks agree to within that window (NTP-synced deployments,
+   * the normal case). A replica whose clock lags past the window finds the
+   * lock already released and reruns the job, and `once` is the sharpest case
+   * because there is no later tick to self-correct that away.
+   *
    * **`once` is AT-MOST-ONCE per cluster, and deliberately so** (maintainer
    * ruling 2026-09-01). Election decides *who* fires, never *that* the fire
    * survives: there is no second deadline, so a leader that dies mid-fire loses


### PR DESCRIPTION
Fixes #14619

## What this does

Docs-only, per the maintainer's ruling on #14619 (`issuecomment-5522738007`, adopting recommendation A, verbatim 「同意」): writes down the clock-agreement assumption behind the scheduler's leader election, in the three sites the ruling names. ⛔ No mechanism change — `runScheduled`, the lease, `leaseMs` and the adapters' behaviour are all untouched (confirmed mechanically below).

`CronJobAdapter.runScheduled()` holds its cluster lock for the **duration of the fire** (acquired, released in `finally`) — the mutual-exclusion window is the handler's runtime, not the scheduling deadline. The existing docblocks stated the guarantee without that window ("only the node that acquires the per-job lock runs the handler; peers skip"), which reads as exactly-once per deadline. It's exactly-once only when replica clocks agree to within that window (the normal case on an NTP-synced deployment); a replica whose clock lags past it finds the lock already released and reruns the job. `once` is the sharpest case — a one-shot has no later tick to self-correct on.

Option B (hold the lease keyed to the deadline, plus takeover semantics for a leader that dies mid-fire) is explicitly not built here — zero measured pull, no measured skew-to-runtime ratio, a distributed-design item. This is bookkeeping, not closure: the docblocks now state what the mechanism actually guarantees.

## The three sites (before → after, measured on this branch)

**1. `packages/services/service-job/src/cron-job-adapter.ts`, `runScheduled()` docblock**

Before (lines 216–221, unchanged from the card's quote):
```
/**
 * Run a SCHEDULED fire of `name` under cluster leader-election: only the node
 * that acquires the per-job lock runs the handler; peers skip. No cluster /
 * in-memory driver => lock always granted => single-node unchanged. Manual
 * `trigger()` bypasses this.
 */
```

After (lines 216–230), added paragraph at 221–229:
```
 *
 * State the guarantee WITH its window: the lock below is held for the
 * duration of the fire (acquired here, released in `finally`), so it
 * de-duplicates *concurrent* fires — its mutual-exclusion window is the
 * handler's runtime, not the scheduling deadline. Exactly-once per deadline
 * holds only when replica clocks agree to within that window (the normal
 * case on an NTP-synced deployment). A replica whose clock lags past the
 * window finds the lock already released and reruns the job; `once` has no
 * later tick during which a business-level de-duplication marker could win.
 */
```

**2. `packages/services/service-job/src/db-job-adapter.ts`, `DbJobAdapter.schedule()` routing docblock**

Before (lines 122–170): the routing docblock explains WHICH schedule types go through `CronJobAdapter` (hence get leader election) vs `inner`, and separately states `once` is "AT-MOST-ONCE per cluster, deliberately so" for the leader-dies-mid-fire case — but nowhere states that the *concurrent-fires* dedup itself has a clock-agreement precondition.

After: new paragraph inserted at lines 141–148, between the routing explanation and the AT-MOST-ONCE paragraph:
```
 * **State the guarantee WITH its window.** The lock `CronJobAdapter.runScheduled()`
 * takes is held for the duration of the fire, not for the deadline — its
 * mutual-exclusion window is the handler's runtime. So the routing above
 * de-duplicates *concurrent* fires: exactly-once per deadline holds only
 * when replica clocks agree to within that window (NTP-synced deployments,
 * the normal case). A replica whose clock lags past the window finds the
 * lock already released and reruns the job, and `once` is the sharpest case
 * because there is no later tick to self-correct that away.
```

**3. `content/docs/deployment/self-hosting.mdx`, "## Scaling beyond one node"**

This is the only multi-node section under `content/docs/deployment/` that discusses coordination for "locks, queues, schedules" (verified: `grep -rn -i "leader\|scheduled job" content/docs/deployment/` finds no other candidate section). Added a paragraph after the existing `OS_CLUSTER_DRIVER` guidance (lines 405–412):
```
**Scheduled jobs' leader election has a window, not a deadline.** `cron` /
`interval` / `once` schedules dedupe across replicas by holding a lock for
the duration of each fire — the mutual-exclusion window is the handler's
runtime, not the scheduling deadline. Exactly-once per deadline holds only
when replica clocks agree to within that window, which an NTP-synced
deployment gives you. A replica whose clock lags past the window finds the
lock already released and reruns the job; `once` schedules are the sharpest
case, since a one-shot has no later tick to self-correct on.
```

## Clause-②: no (verified, not assumed)

Comment-stripped `dist/index.d.ts` before vs. after this change (all `/** */` and `//` comments stripped from both) is **byte-identical** — no exported symbol added/moved/renamed, no signature changed, no new key on any published payload. `pnpm exec eslint` on both touched `.ts` files is clean, `pnpm --filter @objectstack/service-job typecheck` is clean, and all 106 existing tests pass unchanged (including `db-job-adapter.interval-leader.test.ts` and `db-job-adapter.once-leader.test.ts`).

## Changeset: owed, and it's included

`skip-changeset` applies only when no published `.d.ts` prose moves — measured, not assumed: **both** edited docblocks (`runScheduled` is `private`, but TS still emits private members' docblocks into `.d.ts`) show up verbatim in `packages/services/service-job/dist/index.d.ts` after a rebuild. `.changeset/service-job-lease-window-docblock.md` (`patch`) is included, following the `authz-brand-structured-clone-doc.md` precedent for a "docblock is a published byte" patch.

## Verification (head `d7b622f2f`)

- `pnpm --filter '@objectstack/service-job^...' build` then `pnpm --filter '@objectstack/service-job' build` — clean; `.d.ts` diff reviewed above.
- `pnpm --filter '@objectstack/service-job' typecheck` — clean.
- `pnpm --filter '@objectstack/service-job' exec vitest run --maxWorkers=2` — 10 files, 106 tests, all pass.
- `pnpm exec eslint --no-inline-config` on both touched `.ts` files — clean.
- `node scripts/check-nul-bytes.mjs` — clean.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, re-derived after every content change (including after adding the changeset) — 54 matched gate commands total, all run:
  - 51 green.
  - `pnpm check:dual-build-cjs-loads` and `node scripts/check-test-completeness.mjs` — **NOT MEASURED** (exit 3, "PREREQUISITE NOT MET" in their own verdict text): both require a full monorepo build / a saved `turbo run test` log, disproportionate for an S-sized docs-only diff; not a red, nothing here to fix.
  - `node scripts/pm/check-half-states.mjs` (bare, the live-sweep invocation under `half-state-patrol.yml`) — not run: confirmed that workflow's `pull_request` trigger is path-filtered to `scripts/pm/check-half-states.mjs` and `.github/workflows/half-state-patrol.yml` only, neither of which this diff touches, so it does not actually run in this PR's CI. `pnpm check:pm-half-states` (the offline self-test variant, `lint.yml`) did run and is green.
  - `check:skill-examples` failed once on a fresh worktree because `packages/client-react/dist` had no prior build (unrelated to this diff's content — the mdx addition has no fenced code example); built `@objectstack/client-react` and it's green.

## Scope

In scope only: the three sites above. Not touched: `packages/spec`, `content/docs/releases/**`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8)_