### PR TITLE
ci(deps): tighten OSV/dependency scan schedule from weekly to daily

### DIFF
--- a/.github/workflows/validate-deps.yml
+++ b/.github/workflows/validate-deps.yml
@@ -18,8 +18,11 @@ on:
       # exercised on the PR that introduces them.
       - '.github/workflows/validate-deps.yml'
   schedule:
-    # Run weekly on Monday at 03:00 UTC
-    - cron: '0 3 * * 1'
+    # Run daily at 03:00 UTC — narrows the discovery window for a new OSV
+    # advisory from up to six days (weekly) to one, so the scheduled scan
+    # is more likely to surface a red before an unrelated PR's blocking
+    # trigger collides with it (#14645).
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Fixes #14645

## What

Moves the OSV/dependency scan's `schedule` trigger in
`.github/workflows/validate-deps.yml` from weekly (`0 3 * * 1`, Mondays) to
daily (`0 3 * * *`), keeping the same 03:00 UTC hour. This is Option A from
the card's decision facets, ruled by the maintainer (issue comment
[#5523306978](https://github.com/objectstack-ai/objectstack/issues/14645#issuecomment-5523306978)):
tighten the discovery cadence; do not build an automatic issue-opening outlet
(Option B) in this change.

## Filename correction

The ruling names `.github/workflows/osv-scanner.yml`. That file does not
exist on `main` — the card's own body correctly names
`.github/workflows/validate-deps.yml` (the file that actually carries the
`schedule:` trigger, `cron: '0 3 * * 1'`, and `issues: write`). This PR
applies the ruling's substance (weekly → daily, one cron line) to
`validate-deps.yml`, per the card's own correction note. The ruling itself is
untouched by this — only the filename it names was a clerical slip.

## Scope

- File surface: `.github/workflows/validate-deps.yml` only, as dispatched.
- `skip-changeset`: this PR publishes nothing from any released package.
- `Clause-②: no`.
- Does **not** fold in the four current OSV advisories (#14639's, separately
  queued) and does **not** build Option B (no issue-opening step was added,
  though the job already holds `issues: write`).

## Findings (not actioned — reported per dispatch instructions)

- `validate-deps.yml` has no `concurrency:` guard. At a 24h cadence with a
  scan step that normally completes in minutes, back-to-back scheduled runs
  overlapping is very unlikely, but it's an honest gap if a run ever hangs.
  Reporting per the card's PM-assumption #3 rather than expanding this diff.

## Tests

See the report comment on #14645 for the full gate list and exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk

---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_