### PR TITLE
docs(skills): stop promising `os validate` checks a model-registry entry

### DIFF
--- a/skills/objectstack-ai/SKILL.md
+++ b/skills/objectstack-ai/SKILL.md
@@ -393,7 +393,7 @@ is a parse error carrying its migration
 
 ## Verify your work
 
-After authoring a `*.skill.ts` / `*.tool.ts` or a model-registry entry, run the
+After authoring a `*.skill.ts` / `*.tool.ts`, run the
 author-time gate before reporting done:
 
 ```bash
@@ -401,7 +401,7 @@ os validate     # Zod schema + CEL predicate validation + bindings (no artifact)
 # or: os build  # the same gates, plus emits dist/
 ```
 
-It confirms the skill / tool / model metadata conforms to the protocol. This
+It confirms the skill / tool metadata conforms to the protocol. This
 domain has no CEL site — a model-registry `promptTemplate.system` / `.user` is
 the `template` dialect (`{{var}}`); `ToolSchema` carries no expression field of
 any kind. In a scaffolded project the gate is `npm run validate`. See


### PR DESCRIPTION
Fixes #14836

`skills/objectstack-ai/SKILL.md` told an AI author to run `os validate` after authoring "a model-registry entry", and then said the gate confirms "skill / tool / model metadata". A model-registry entry is not an input `os validate` can receive — and the same file already says so, 64 lines above. Two deletions, shrink-only, nothing else moved.

## The two sentences, before and after

Before, at the base commit `b1d49b3940`:

- `:396-397` — After authoring a `*.skill.ts` / `*.tool.ts` or a model-registry entry, run the author-time gate before reporting done:
- `:404` — It confirms the skill / tool / model metadata conforms to the protocol.

After, at this head:

- `:396-397` — After authoring a `*.skill.ts` / `*.tool.ts`, run the author-time gate before reporting done:
- `:404` — It confirms the skill / tool metadata conforms to the protocol.

Untouched, deliberately: the `os validate` fence comment at `:400`, the remaining CEL sentence at `:404-407`, the central-registration row at `:332`, `skills/README.md`, and every other file in the tree. No replacement validator is named and no "not currently validated" caveat is added — the fix is to stop promising, not to explain the gap.

## Premise re-verified at this head — the three reads the card names

1. `packages/spec/src/stack.zod.ts` — the AI collections of `ObjectStackDefinitionSchema` are exactly `agents`, `tools`, `skills` (the three `z.array(...)` rows under the ADR-0063 doc block). A case-insensitive grep of that file for `modelRegist`, `knowledge` or `promptTemplate` exits 1 with no output.
2. `ModelRegistrySchema` is referenced in exactly two files across `packages/**/*.ts`: `packages/spec/src/ai/model-registry.zod.ts` (3 occurrences) and `packages/spec/src/ai/model-registry.test.ts` (5). No stack key, no lint rule, no CLI command reaches it.
3. `packages/cli/src/commands/validate.ts` parses `ObjectStackDefinitionSchema` — `safeParse` at `:187`, with the two authoring-lint passes at `:184-185` reading the same schema.

The contradiction partner is still present verbatim at `:332`: "`agents` / `tools` / `skills` are the only AI stack collections — knowledge sources have none, agents are platform-supplied, and `tools` is not the default path".

## Measurement — this file, before and after

| measure | before | after | delta |
|:--|--:|--:|--:|
| lines of `skills/objectstack-ai/SKILL.md` | 417 | 417 | 0 |
| tokens, same file | 5475 | 5467 | -8 |
| ceiling for this file, unedited | 6806 | 6806 | 0 |
| headroom | 1331 | 1339 | +8 |
| published bundle total | 156199 | 156191 | -8 |

Line count is unchanged because both deletions are intra-line. The token numbers are `node scripts/check-skills-token-ratchet.mjs`'s own output for this path:

- before — `✓ check-skills-token-ratchet: skills/objectstack-ai/SKILL.md is 5475 tokens (ceiling 6806; headroom 1331).`
- after — `✓ check-skills-token-ratchet: skills/objectstack-ai/SKILL.md is 5467 tokens (ceiling 6806; headroom 1339).`

The ceiling map is not edited: this is a shrink under an unchanged ceiling.

## Judgement calls

**1. No re-flow, and the wrap was measured rather than assumed.** This file wraps prose at 80 columns. Line `:396` shrinks from 79 to 53 characters while `:397` keeps five words ("author-time gate before reporting done:", 39 characters) — not an orphan, so nothing is re-wrapped. Line `:404` shrinks from 76 to 68 with a full 80-character line behind it at `:405`. Pulling a word up in either place would edit a line this card did not name and would cascade through the rest of the paragraph.

**2. The `os validate` fence comment at `:400` stays — it is shared wording, not this file's claim.** Measured: the identical line, byte for byte, is at `skills/objectstack-api/SKILL.md:411`, so it describes the gate rather than this domain; and the sentence immediately after it here already tells the reader that this domain has no CEL site. Editing it in one of the two files would fork wording the published catalog shares. Recorded as an observation, not a change.

**3. Nothing else in the catalog claims a model-registry entry is validated.** Swept `skills/**` for `model-registry`, `model registry` and `ModelRegistry`: the remaining mentions are `:301` here (a note that `ModelProviderSchema` accepts a wider provider set), `:405` here (the `template` dialect sentence), `skills/objectstack-formula/SKILL.md:422` (the same `template` dialect fact) and the generated reference pointer at `skills/objectstack-ai/references/_index.md:18`. None of them promises a check, so the deletion leaves no instruction stranded and no author without a route.

**4. No changeset.** This diff publishes nothing from any released package — one markdown file in the published catalog — so it carries `skip-changeset` rather than an empty changeset. `check-changeset-presence` states the outcome in its own verdict line on this PR.

## Reverse verification

Run from the committed state, under a trap restoring the absolute path, with the mutation proved on disk before anything was measured:

- **Mutation leg** — "or a model-registry entry" re-inserted at `:396`; `grep -c` on that phrase moved 0 to 1 and `git hash-object` moved to `3cfae14e1c`, away from the HEAD blob `9f5231126e`. Only then was the ratchet re-read.
- **What it shows** — the file's measured count rises from 5467 to 5473 tokens, the six tokens this half of the change removes. The ratchet itself stays GREEN in that state (5473 is far under the 6806 ceiling), and that is the honest reading: this gate prices size, it does not detect the false claim. The number that moves is the file's measured token count, not the gate's verdict. Nothing in the local union can red on the sentence itself — see NOT MEASURED below.
- **Restore leg** — `git checkout HEAD --` on the absolute path; `git hash-object` returns `9f5231126eab1f93aa5d1a142d4a78867cf8275f`, equal to the HEAD blob, and `git diff HEAD` is empty. The ratchet then re-reads 5467 tokens, and `git status --porcelain` is clean.

## Gates

The union was derived at this head rather than from a hand-written list:

```
dispatch-gates: gate list derived from the tree of 'objectstack-ai/objectstack' at commit 741e8e7071 (/home/user/objectstack-14836).
dispatch-gates: change set derived from git — 1 path(s) vs merge base b1d49b394 of 'origin/main' and HEAD
  (committed 1, working tree 0, untracked 0; three-dot semantics, never 'origin/main..HEAD')
  · skills/objectstack-ai/SKILL.md
dispatch-gates --commands: 21 command(s) — 14 pnpm, 7 direct node (16 matched by path, 0 by change KIND, 5 declared WHOLE-TREE and named on every card).
```

Exit codes were captured by redirecting stdout and stderr into a per-gate log file and reading `$?` on the next statement — never through a pipe, which would report the pipe's status instead. Each row quotes the gate's own verdict line.

| gate | exit | its own verdict line |
|:--|--:|:--|
| `node scripts/check-ci-filter-parity.mjs` | 0 | OK: all 133 declared cross-package glob(s) (93 unique) are covered by `core` or `crosspkg`, every `crosspkg` entry still covers one, and the `test` job's `if:` still names both filters. |
| `node scripts/check-closing-keyword-parity.mjs` | 0 | check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords and both measured separators; sweep found 5 file(s) carrying the grammar across 8133 tracked file(s), all registered). |
| `node scripts/check-comment-mask-corpus.mjs` | 0 | ✓ comment-mask corpus sweep: 5808 files, 0 disagree, 0 unparseable, 49.9s (comparator self-test: 12 cases pass). |
| `node scripts/check-cross-package-test-inputs.mjs` | 0 | OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob. |
| `node scripts/check-shard-attestation.mjs` | 0 | ✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across 3 attesting job(s). |
| `node scripts/check-skills-token-ratchet.mjs` | 0 | ✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted. |
| `node scripts/check-test-completeness.mjs` | 3 | PREREQUISITE NOT MET — NOT MEASURED, see below. |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | ✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 426 files / 1365 TS blocks judged clean by @objectstack/formula. (two further ✓ legs: spec TSDoc 9 examples clean, field-level predicates 14 clean / 6 undeterminable) |
| `pnpm --filter @objectstack/spec run check:skill-docs` | 0 | ✅ Skill docs in sync |
| `pnpm check:agent-test-spelling` | 0 | ✓ check-agent-test-spelling: 0 violations — 430 file(s) · 5809 bare `--` token(s) · 1388 launcher-rooted run(s) · 9 separator(s) JUDGED · 5 vitest-backed script name(s) derived from 81 manifest(s) |
| `pnpm check:corpus-claim-drift` | 0 | check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling. |
| `pnpm check:cross-package-test-inputs` | 0 | OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob. |
| `pnpm check:doc-authoring` | 0 | ✓ doc authoring guard: sibling-package prose ids hold the baseline — 831 pinned site(s) across 231 file(s), 83548 string(s) read in 1132 parsed source(s), no growth, no burn-down unrecorded. |
| `pnpm check:nul-bytes` | 0 | check-nul-bytes: OK (scanned 8126 text file(s) -- 8126 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes). |
| `pnpm check:pm-governed-merges` | 0 | ✓ check-governed-merges --self-test: 243 assertions (the full enumeration is long; the run's closing line is) live: the real generator declared 9 output(s) and certified this tree |
| `pnpm check:refd-timer-probe` | 0 | OK check-refd-timer-probe: 5803 source file(s) swept; the process-global timer probe is read in packages/qa/refd-timer-testkit/src/index.ts and nowhere else. |
| `pnpm check:role-word` | 0 | check-role-word: OK, no new occurrences of the reserved word. |
| `pnpm check:skill-compatibility` | 0 | ✓ check-skill-compatibility-version: 11 SKILL.md file(s) reconciled against 79 workspace packages |
| `pnpm check:skill-frame-sync` | 0 | ✓ check-skill-frame-sync: 2 copies of the decision frame are structurally isomorphic across 2 files |
| `pnpm check:skill-identifier-liveness` | 0 | check-skill-identifier-liveness OK — Leg 1: 465 citation(s) over 46 published file(s) checked against 94209 implementation word tokens (3 ledgered exemption(s)); Leg 2: 8 registered exhaustive section(s), 0 ledgered gap(s). |
| `pnpm check:watch-hint-literal` | 0 | ✓ check-watch-hint-literal: 47 declaration(s) across 4 rostered name(s) -- ROOT_DIR_WATCH_HINTS 31, ROOT_FILE_WATCH_HINTS 9, ROOT_WATCH_HINTS 2, DECLARED_WATCH_HINTS 5 -- every one an array of quoted literals inside its own statement. |

Two readings needed a prerequisite before they meant anything: `check:doc-formula-expressions` first answered PREREQUISITE NOT MET twice — `@objectstack/formula` not built, then `@objectstack/lint` not built — and both builds went through the shared verify lock (`os-verify-lock: VERDICT command-exit 0`, 190s and 12s held). Its exit 0 above is the reading after that, not the first one.

### NOT MEASURED

- **`node scripts/check-test-completeness.mjs` — exit 3, PREREQUISITE NOT MET.** The gate grades a saved `turbo run test` log; it does not run tests and cannot produce one. Its own text: "Arrived here from the gate family `scripts/pm/dispatch-gates.mjs` derives? That list names this script with NO argument, which is this branch. There is no local log to hand it, so the local reading for this gate is NOT MEASURED. It is not a red, and there is nothing here to fix." Supplying that prerequisite means the repo-wide test farm, which is CI's run, not this flight's. Read as neither pass nor fail.
- **No gate in the union can red on the deleted claim itself.** The sentence was false about `os validate` in a way no checker models: `check:skill-identifier-liveness` grades whether cited identifiers exist (`ModelRegistrySchema` does exist), and the token ratchet grades size. The reverse verification above demonstrates this rather than papering over it — the mutated tree is green everywhere. The correctness of this change rests on the three source reads, not on a gate.
- **The always-runs CI tail is outside this table.** `dispatch-gates --commands` says so in its own closing line: workflows with no path filter are not in the local union, and are read from this PR's checks.
- **Nothing was executed from this file.** It is published prose; there is no runtime behaviour to exercise and no test to add or change, so the entire reading is gate-shaped by nature.

## Landing

Governed surface (`skills/**`): this PR stays a draft. Not flipped ready, not enqueued, no auto-merge, no reviewers requested by this seat, no approving review. Labels: `skip-changeset`, and `needs:contract-review` because the deleted words are a claim about what `os validate` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_