### PR TITLE
fix(devx): verdict handshake for check-platform-checklist and dispatch-gates self-tests

### DIFF
--- a/scripts/check-platform-checklist.mjs
+++ b/scripts/check-platform-checklist.mjs
@@ -704,6 +704,45 @@ function foldedCallMessage(path, call, spelling, singular) {
   );
 }
 
+// ── Self-test verdict handshake ─────────────────────────────────────────────
+//
+// Five batteries, each returning `{ checked, failures }` for a caller to
+// report. A `return` above a battery's own end prints nothing, registers no
+// failure, and yields a SMALLER `checked` that both legs below read as a pass.
+// Measured on this file: a section that stopped running took the `--self-test`
+// verdict from 141 assertions to 119, exited 0, and still claimed in prose that
+// the direction it had skipped "REFUSES an empty/renamed/reshaped" table. A
+// bare `return` is no better — it yields `undefined` and CRASHES the combine
+// below, and an exit code alone reads that crash as a handshake rather than as
+// the accident it is.
+//
+// So each battery sets its own flag as its last act and every caller checks it.
+// The return value is load-bearing here (it carries `checked` and `failures`),
+// so the handshake is a flag rather than a returned sentinel — the spelling
+// `check-durability-degradation-log-level.mjs` and
+// `check-dispatcher-error-vocabulary.mjs` carry, for that same reason.
+let trapReachedVerdict = false;
+let provisioningReachedVerdict = false;
+let unreferencedReachedVerdict = false;
+let metaCallReachedVerdict = false;
+let citationsReachedVerdict = false;
+
+/**
+ * One wording, ten call sites — five batteries across the two legs that run
+ * them. The check, the message and the exit code are the landed ones; only the
+ * duplication is factored out.
+ */
+function requireReachedVerdict(name, reached) {
+  if (reached) return;
+  console.error(
+    `\n✗ check-platform-checklist self-test: ${name}() returned without reaching its verdict,\n`
+      + 'so its assertions did not all run and no failure of theirs could be reported.\n'
+      + 'Running the gate on top of a self-test that never finished would report an\n'
+      + 'unverified gate as a verified one.\n',
+  );
+  process.exit(1);
+}
+
 /**
  * The positive control. Proves the extractor reads a good table AND refuses an
  * empty / renamed / reshaped one, and that the item-side checker catches both
@@ -770,6 +809,7 @@ function selfTestTrapVocabulary() {
   t('C8 an empty-string trap is flagged', trapProblems({ traps: [''] }, vocab).length === 1);
   t('C9 a trap listed twice on one item is flagged', trapProblems({ traps: ['stale-dist', 'stale-dist'] }, vocab).some((m) => m.includes('twice')));
 
+  trapReachedVerdict = true;
   return { checked, failures };
 }
 
@@ -877,6 +917,7 @@ function selfTestProvisioningUse() {
   const hintedEmpty = check('qa-contributor-bound-member', 'records-forms');
   t('Q20 the same hint reaches an area that has no recipe block of its own', hintedEmpty.length === 1 && hintedEmpty[0].includes('`search:qa-contributor-bound-member`'));
 
+  provisioningReachedVerdict = true;
   return { checked, failures };
 }
 
@@ -978,6 +1019,7 @@ function selfTestUnreferencedRecipes() {
   t('R18 a `$comment` is never reported unreferenced', flag(ALL).length === 0 && none.every((r) => !r.recipe.startsWith('$')));
   t('R19 an area that defines no recipes contributes nothing to flag', !none.some((r) => r.area === 'records-forms'));
 
+  unreferencedReachedVerdict = true;
   return { checked, failures };
 }
 
@@ -1136,6 +1178,7 @@ export const NEIGHBOURING_MAP: Readonly<Record<string, string>> = Object.freeze(
   t('M52 the live map is a bijection-free lookup: no folded spelling is ALSO a canonical singular — so the refusal can never fire on a canonical `/meta/<type>` segment',
     live.refusal === null && !live.folded.some((f) => live.canonical.includes(f)));
 
+  metaCallReachedVerdict = true;
   return { checked, failures };
 }
 
@@ -1216,6 +1259,7 @@ function selfTestSourceLineCitations() {
   t('S6 an ADR section reference is not a citation', n('ADR-0025 §3.3 and #13479') === 0);
   t('S7 the README placeholder spelling of the ban is not itself a citation', n('never pin `file.ts:NNN` or a bare `:NNN`') === 0);
 
+  citationsReachedVerdict = true;
   return { failures, checked };
 }
 
@@ -1225,6 +1269,11 @@ if (process.argv.slice(2).includes('--self-test')) {
   const unref = selfTestUnreferencedRecipes();
   const metaCall = selfTestMetaCallSpelling();
   const cites = selfTestSourceLineCitations();
+  requireReachedVerdict('selfTestTrapVocabulary', trapReachedVerdict);
+  requireReachedVerdict('selfTestProvisioningUse', provisioningReachedVerdict);
+  requireReachedVerdict('selfTestUnreferencedRecipes', unreferencedReachedVerdict);
+  requireReachedVerdict('selfTestMetaCallSpelling', metaCallReachedVerdict);
+  requireReachedVerdict('selfTestSourceLineCitations', citationsReachedVerdict);
   const failures = [...trap.failures, ...prov.failures, ...unref.failures, ...metaCall.failures, ...cites.failures];
   if (failures.length === 0) {
     console.log(
@@ -1243,6 +1292,7 @@ if (process.argv.slice(2).includes('--self-test')) {
 
 // The extractor's own positive control, before it is trusted with anything.
 const trapControl = selfTestTrapVocabulary();
+requireReachedVerdict('selfTestTrapVocabulary', trapReachedVerdict);
 if (trapControl.failures.length) {
   console.error("check-platform-checklist: the trap-vocabulary extractor's own positive control FAILED — this check cannot be trusted, and a green from it would mean nothing.\n");
   for (const f of trapControl.failures) console.error(`  ✗ ${f}`);
@@ -1252,6 +1302,7 @@ if (trapControl.failures.length) {
 // Same, for the provisioning resolve: a green from a check that cannot fire is
 // indistinguishable from the green this gate printed before it existed.
 const provisioningControl = selfTestProvisioningUse();
+requireReachedVerdict('selfTestProvisioningUse', provisioningReachedVerdict);
 if (provisioningControl.failures.length) {
   console.error("check-platform-checklist: the provisioning-resolve check's own positive control FAILED — a `use` that resolves to nothing would pass, which is the exact defect this check was added to close.\n");
   for (const f of provisioningControl.failures) console.error(`  ✗ ${f}`);
@@ -1263,6 +1314,7 @@ if (provisioningControl.failures.length) {
 // recipes on the real ledger are referenced, so this direction's output is
 // permanently empty and its green says nothing on its own.
 const unreferencedControl = selfTestUnreferencedRecipes();
+requireReachedVerdict('selfTestUnreferencedRecipes', unreferencedReachedVerdict);
 if (unreferencedControl.failures.length) {
   console.error('check-platform-checklist: the unreferenced-recipe direction\'s own positive control FAILED — a recipe no item references would pass unreported, and because every real recipe IS referenced, nothing else in this gate would ever notice.\n');
   for (const f of unreferencedControl.failures) console.error(`  ✗ ${f}`);
@@ -1275,6 +1327,7 @@ if (unreferencedControl.failures.length) {
 // subject population is zero — so nothing but this battery can tell a working
 // direction from a deleted one.
 const metaCallControl = selfTestMetaCallSpelling();
+requireReachedVerdict('selfTestMetaCallSpelling', metaCallReachedVerdict);
 if (metaCallControl.failures.length) {
   console.error("check-platform-checklist: the `/meta` call-spelling refusal's own positive control FAILED — an executable step instructing a folded plural spelling would pass unreported, which is the exact defect this check was added to close.\n");
   for (const f of metaCallControl.failures) console.error(`  ✗ ${f}`);
@@ -1288,6 +1341,7 @@ if (metaCallControl.failures.length) {
 // from the ledger staying clean — which is precisely the exit-0-by-construction
 // shape this check was added to end.
 const citationControl = selfTestSourceLineCitations();
+requireReachedVerdict('selfTestSourceLineCitations', citationsReachedVerdict);
 if (citationControl.failures.length) {
   console.error('check-platform-checklist: the source-line-citation refusal\'s own positive control FAILED — a rotting `file:line` pointer would pass unreported, and because the ledger is clean nothing else here would ever notice.\n');
   for (const f of citationControl.failures) console.error(`  ✗ ${f}`);

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -10514,6 +10514,23 @@ export function bannerLines({ identity, paths = [], drift = null }) {
 // the tree, in both directions.
 // ---------------------------------------------------------------------------
 
+/**
+ * Returned by `selfTest()` only after its verdict line is printed, and compared
+ * at the dispatch: a `return` that leaves the function above that line prints
+ * NOTHING and still exits 0, because the dispatch discarded the result. Measured
+ * on this file before this guard existed: an early return took the run from
+ * "1288 cases pass" to zero bytes of output and exit 0 — a self-test that never
+ * finished, reported as one that passed.
+ *
+ * The mechanical probe in `scripts/measure-self-test-floor.mjs` cannot read this
+ * file (its anchor matches the first `function selfTest() {` in the source, which
+ * here is a FIXTURE STRING, so the injection lands inside a template literal and
+ * only ever produces a SyntaxError). That is a limit of the instrument, not a
+ * property of this file, and it is why the entry is hand-read there. Anchoring an
+ * early return on the real definition below measures it in one run.
+ */
+const SELF_TEST_VERDICT = 'dispatch-gates self-test reached its verdict';
+
 function selfTest() {
   const cases = [];
   // Stream the verdict the moment it is decided (#14281) rather than only at
@@ -17737,6 +17754,8 @@ function selfTest() {
     process.exit(1);
   }
   console.log(`✓ dispatch-gates self-test: ${cases.length} cases pass.`);
+
+  return SELF_TEST_VERDICT;
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
@@ -17791,7 +17810,14 @@ if (invokedDirectly) {
   const argvPaths = argv.paths;
   const wantsChanged = process.argv.includes('--changed');
   if (process.argv.includes('--self-test')) {
-    selfTest();
+    if (selfTest() !== SELF_TEST_VERDICT) {
+      console.error(
+        '\n✗ dispatch-gates self-test: selfTest() returned without reaching its verdict,\n'
+          + 'so no success line was printed. Exiting 0 here would report a self-test\n'
+          + 'that never finished as a self-test that passed.\n',
+      );
+      process.exit(1);
+    }
   } else if (argv.malformed) {
     console.error(`dispatch-gates: ${argv.malformed}.`);
     process.exit(2);


### PR DESCRIPTION
Part of #13800

Hole 2 (the verdict handshake) for the four files that card carries forward. **Two of the four needed no work** — see the falsified premise below — so this PR repairs two and reports measurements for the other two. `Fixes` is deliberately not used: two rows are delivered as readings, and the card should stay open for triage to close.

Verified at `b12a5bda` (the head of this branch).

## The premise, re-derived — and partly falsified

The card's acceptance criterion was the guard form `!== SELF_TEST_VERDICT`, with a positive control of 81 files on `origin/main`, each of the four returning 0.

That marker gives a **false zero on two of the four**. A second, equally deliberate spelling landed in commit `9acddde9` ("Verdict handshake for 134 scripts/** self-tests that exit 0 on an early return", #14479) — a module-level flag, chosen with the rationale stated in the code: *"The self-test's own exit code stays load-bearing, so the handshake is a flag rather than a returned sentinel."* Counting only the sentinel cannot see it.

A marker that separates before from after, proven across that commit:

| file | `!== SELF_TEST_VERDICT` \| `ReachedVerdict` at `9acddde9^` | at `9acddde9` |
| :--- | :--- | :--- |
| `check-durability-degradation-log-level.mjs` | 0 | **6** |
| `check-dispatcher-error-vocabulary.mjs` | 0 | **3** |
| `check-platform-checklist.mjs` | 0 | 0 |
| `scripts/pm/dispatch-gates.mjs` | 0 | 0 |

Union control on `origin/main`: 81 sentinel files + 77 flag files = **158** carrying a handshake in one spelling or the other.

## Per-row outcome, each one measured rather than read

Probes inject `return;` (or a partial early verdict) at a **hand-chosen** anchor, write the mutation to a copy beside the original — the tracked file is never mutated — prove the mutation is on disk before running, and delete the copy in a `finally`.

### 1. `scripts/pm/dispatch-gates.mjs` — was NOT MEASURED, now **measured, defeated, repaired**

The card's NOT MEASURED was a property of the *instrument*, not the file. `measure-self-test-floor.mjs`'s `injectEarlyReturn()` anchors on the first `function selfTest() {` in the source; in this file that match is inside a **fixture string** (a template literal), so the injection only ever produces a SyntaxError. The real definition is at line 10517 and the dispatch was:

```js
if (process.argv.includes('--self-test')) {
  selfTest();          // <- result discarded
}
```

Anchored on the real definition, the anchor is unique (1 match) and the reading is clean:

| | exit | output |
| :--- | :--- | :--- |
| unmodified, before repair | 0 | `✓ dispatch-gates self-test: 1288 cases pass.` |
| early return, before repair | **0** | **0 bytes** |
| unmodified, after repair | 0 | `✓ dispatch-gates self-test: 1288 cases pass.` |
| early return, after repair | **1** | `✗ dispatch-gates self-test: selfTest() returned without reaching its verdict...` |

Repaired with the landed **sentinel** form. `ENTRY_BY_HAND` in `measure-self-test-floor.mjs` is deliberately left alone: its note stays true of the mechanical probe after this repair, and that file is outside this card's surface.

### 2. `scripts/check-platform-checklist.mjs` — was NOT MEASURED, now **measured, defeated, repaired**

Five batteries returning `{ checked, failures }`, combined by the caller. Both failure shapes the card predicted, measured before the repair:

| mutation in `selfTestTrapVocabulary` | exit | what it printed |
| :--- | :--- | :--- |
| `return;` (bare) | 1 | `TypeError: Cannot read properties of undefined (reading 'failures')` — a crash a one-function probe reads as a handshake |
| `return { failures: [], checked: 0 };` | **0** | `✓ ... 119 assertions` (down from 141) — **and still claiming in prose that the skipped direction "REFUSES an empty/renamed/reshaped" table** |

After the repair, all three mutations exit 1 and name the battery that did not finish:

```
✗ check-platform-checklist self-test: selfTestTrapVocabulary() returned without reaching its verdict,
so its assertions did not all run and no failure of theirs could be reported.
```

— and the same for `selfTestSourceLineCitations()`, confirming a late battery is caught too, not just the first.

Spelling: the **flag** form, not the sentinel, for exactly the reason the two sibling files state — the return value is load-bearing here (it carries `checked` and `failures`), so the handshake cannot *be* the return value. The guard is checked on **both** legs, including the inline one that runs on every invocation (this gate has no `--self-test` leg in CI), and it is placed **before** the `.failures` read so a bare `return` reports itself instead of crashing its reader. One `requireReachedVerdict()` helper carries the landed wording to ten call sites (five batteries × two legs); the check, the message and the exit code are the landed ones — only the tenfold duplication of the prose is factored out.

### 3. `scripts/check-durability-degradation-log-level.mjs` — **already repaired; untouched**

Received hole 2 in `9acddde9` (flag spelling). Both of its entries probed, and both hold:

- `selfTest` → exit **1**, `✗ ... selfTest() returned without reaching its verdict`
- `selfTestReadSeams` → exit **1**

### 4. `scripts/check-dispatcher-error-vocabulary.mjs` — **already repaired; untouched**

Also from `9acddde9`. Probed: exit **1** with the named diagnostic. Its hole 1 (`SELF_TEST_BATTERIES`, 7 hits, from #13799) is left strictly alone — the two counts are not merged.

## The derived list, and the irony

Derived from this worktree after the edits, with `--repo` asserted:

```
node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack
```

One of the two repaired files IS that script. Re-derived both ways on identical explicit inputs — the base version of the script and the repaired one — the derived list is **IDENTICAL**. The repair changes the self-test handshake, not the derivation.

All 21 derived families re-run at `b12a5bda` and green, including `pnpm check:pm-dispatch-gates` (1288 cases) and `pnpm check:parse-guard` / `check:entry-guard` / `check:nul-bytes`. Every exit code was captured before any pipe.

Two derived entries were NOT MEASURED rather than red, both prerequisite refusals and neither a finding:

- `node scripts/check-test-completeness.mjs` → exit **3**, `PREREQUISITE NOT MET — this gate grades a saved turbo run test log, and no log was named`. Its own `--self-test` runs clean (exit 0).
- `node scripts/check-durability-degradation-log-level.mjs` on a fresh worktree → exit **3** before `pnpm install`; re-run after install, exit 0.

## One gate is red, and it is red on `main` too

`pnpm check:platform-checklist` exits 1 with 4 `UNCLASSIFIED` coverage findings (`batch_endpoints`, `crud_endpoints`, `metadata_endpoints`, `route_generation`). **Not caused by this PR** — the `ca3fd4b1` version of the file, run in the same tree, produces the byte-identical four findings (`diff` of the two finding sets is empty). This gate is deliberately excluded from CI (`.github/workflows/lint.yml`: *"validated by `pnpm check:platform-checklist`, but by MAINTAINER action"*), which is why the drift accumulated unseen. Filed separately rather than fixed here.

`skip-changeset`: `scripts/**` publishes nothing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk

---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_