### PR TITLE
test(spec): pin the author-visible `devPlugins[]` refusal, and record why the union reshape must not land

### DIFF
--- a/packages/spec/src/kernel/manifest-unknown-keys.test.ts
+++ b/packages/spec/src/kernel/manifest-unknown-keys.test.ts
@@ -39,6 +39,7 @@ import { describe, it, expect } from 'vitest';
 
 import { ManifestSchema, PluginEnginesSchema } from './manifest.zod';
 import { ArtifactPackageSchema, ObjectStackDefinitionSchema } from '../stack.zod';
+import { formatZodError } from '../shared/error-map.zod';
 
 /** A legal manifest, the shape every scaffold and example stamps. */
 const legal = () => ({
@@ -159,6 +160,61 @@ describe('#14192 — the refusal reaches every door the measurement listed', () 
     const nested = union!.errors.flat().find((i) => i.code === 'unrecognized_keys');
     expect(nested, 'the named refusal is carried inside the union issue').toBeDefined();
     expect(nested!.keys).toEqual(['namesapce']);
+  });
+
+  it('through `devPlugins[]` — the nested shape is NOT keyless: the author reads the key, the surface and the rename', () => {
+    // #14722 proposed reshaping the union above, on the premise that
+    // `formatZodError` flattens the nested refusal away and leaves the author a
+    // bare `Invalid input` at this one door. Measured on `origin/main`
+    // `3386493f`: it does not. `formatZodIssue` descends `invalid_union` and
+    // ranks the branches through `selectUnionBranches`
+    // (`shared/union-branch-policy.ts`, #8318) — which drops the string arm as
+    // kind-mismatch-only and renders the manifest branch verbatim. So the raw
+    // shape pinned directly above is real, and it is NOT what the author sees.
+    //
+    // This is the standing guard on that difference. The pin above may only
+    // ever be called a defect again by a measurement that gets past THIS
+    // assertion first — the reshape it invited costs either the accept set
+    // (`z.discriminatedUnion` routes on a literal FIELD value, which a bare
+    // string entry cannot carry) or the published JSON Schema for the key (a
+    // hand-rolled `typeof` router on a `z.custom` base emits `items: {}` in
+    // place of the whole `anyOf`), and buys a message the author already has.
+    const result = ObjectStackDefinitionSchema.safeParse({ manifest: legal(), devPlugins: [typo()] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const rendered = formatZodError(result.error);
+    expect(rendered).toContain('devPlugins.0');
+    expect(rendered, 'the offending key is named').toContain('namesapce');
+    expect(rendered, 'the surface is named').toContain('this package manifest');
+    expect(rendered, 'the rename is offered').toContain('Did you mean `namesapce` \u2192 `namespace`?');
+  });
+
+  it('through `devPlugins[]` — that selection is structural, not an accident of this one fixture', () => {
+    // The string arm's ONLY complaint about an object is `invalid_type` at the
+    // branch root, so `isKindMismatchOnly` drops it for every object input —
+    // the guarantee does not depend on the manifest branch happening to carry
+    // exactly one issue. Two shapes that give it more than one:
+    const alsoMissingRequired = () => {
+      const { namespace: _ns, version: _v, ...rest } = legal();
+      return { ...rest, namesapce: 'probe' };
+    };
+    const alsoWrongType = () => {
+      const { namespace: _ns, ...rest } = legal();
+      return { ...rest, namesapce: 'probe', version: 42 };
+    };
+    for (const entry of [alsoMissingRequired(), alsoWrongType()]) {
+      const result = ObjectStackDefinitionSchema.safeParse({ manifest: legal(), devPlugins: [entry] });
+      expect(result.success).toBe(false);
+      if (result.success) continue;
+      const rendered = formatZodError(result.error);
+      expect(rendered).toContain('namesapce');
+      expect(rendered).toContain('Did you mean `namesapce` \u2192 `namespace`?');
+    }
+  });
+
+  it('through `devPlugins[]` — the accept side is unmoved: a string entry and a legal manifest both parse', () => {
+    expect(ObjectStackDefinitionSchema.safeParse({ manifest: legal(), devPlugins: ['some-dev-plugin'] }).success).toBe(true);
+    expect(ObjectStackDefinitionSchema.safeParse({ manifest: legal(), devPlugins: [legal()] }).success).toBe(true);
   });
 });
 


### PR DESCRIPTION
Part of #14722. Deliberately **not** a closing reference: the card asked for a change this PR does not make, and the measurement below is what the seat needs in order to re-triage it. #14722 remains open.

## Summary

The card asked to reshape the `devPlugins` union so the named `unrecognized_keys` refusal becomes the top-level issue, on the stated premise that `formatZodError` flattens the nested refusal away and leaves the author a keyless `Invalid input` at that one door.

**Re-measured on `origin/main` `3386493f`: the raw-shape half of the premise holds, the author-visible half does not.** An author at the `devPlugins` door already reads the key name, the surface and the `Did you mean` rename. So this PR does not reshape the union — it pins the behaviour that was never pinned, and records why every available reshape costs more than it buys.

## The premise, re-measured

The card's measured half is true. The top-level issue really is a keyless union issue:

```text
RAW top-level issues:
  code=invalid_union path=["devPlugins",0] message="Invalid input"
```

The card's inferred half — "`formatZodError` flattens that away" — is false. This is the real `defineStack` door, verbatim:

```text
defineStack validation failed (1 issue):

  x devPlugins.0: Invalid input
    x devPlugins.0: Unrecognized key(s) on this package manifest: `namesapce`.
      Did you mean `namesapce` -> `namespace`? Until this surface was closed, an
      unknown key inside `manifest:` parsed green and its value was silently dropped ...
```

The wire envelope agrees — `zodIssuesToFields` emits a second entry, `code: unknown_field`, field `devPlugins.0`, carrying the same prescription.

The mechanism is `selectUnionBranches` in `packages/spec/src/shared/union-branch-policy.ts`: `formatZodIssue` descends `invalid_union`, drops the string arm as kind-mismatch-only (its sole complaint about an object is `invalid_type` at the branch root), and renders the manifest branch verbatim. That landed generically for **every** union site, which is also the answer to the sweep question below.

The difference from a non-union door is therefore one wrapper line, not a lost message.

## Why the ruled reshape must not land

The direction preferred the discriminated shape and asked that its availability be established first rather than assumed. Established — it is unavailable, and so is everything else. Each candidate, measured:

| Candidate | Verdict |
|---|---|
| Arm reorder, `z.union([z.string(), ManifestSchema])` | **No effect.** zod folds every branch into one `invalid_union` regardless of order; issue shape byte-identical to today. |
| `z.discriminatedUnion` (the `submitBehavior` move) | **Moves the accept set.** It routes on a literal *field value*, and a bare string entry has no fields to carry one: `safeParse('some-dev-plugin').success === false` for discriminators `type`, `kind`, `name` and `id`. Forbidden absolutely by the ruling. |
| `superRefine` re-raise attached to the union | **Structurally impossible.** The check never executes — a failed union aborts before checks run (instrumented; the refinement body did not fire). |
| Hand-rolled `typeof` router on a `z.custom` base | **Costs the published contract.** Issue shape and accept set both come out right, but the generated JSON Schema for the key collapses from the full `anyOf` to `items: {}` — `devPlugins` would lose its published schema to buy a message the author already has. |
| `z.preprocess` | **Not applicable.** It transforms input; it cannot select a schema. |

So the reshape trades either the accept set or the published schema, for a wrapper line. That is the whole reason this PR stops at a pin.

## What is here

One test file. `packages/spec/src/stack.zod.ts` is **untouched**, and so are `ManifestSchema` and `formatZodError`.

The existing `['devPlugins', 0]` pin is **not deleted and not flipped** — flipping it would require the reshape above to land, and it is an accurate statement about the raw issue shape. Three pins are added beside it:

1. the rendered message names the key, the surface and the rename at `devPlugins.0`;
2. that branch selection is structural, not an accident of one fixture — proven against two shapes that give the manifest branch more than one issue;
3. the accept side is unmoved: a string entry and a legal inline manifest both parse.

Pin 1 is what was missing. The rendered half could have regressed, or been re-reported as a defect, without a single test moving — which is precisely what happened.

## Is a sweep of the other union sites warranted?

The ruling asked for an answer, not a sweep, and none is performed here. **The answer is no, not as a schema-reshaping campaign.** The class the ledger records (`ActionRef` / `GuardRef`, `submitBehavior`, `devPlugins`) already has a general, landed solution in `union-branch-policy.ts`, which serves every union site at once and is consumed by both the prose renderer and the wire mapper. Reshaping sites one at a time would add site-local machinery duplicating it, and — as measured above — a string-or-object arm pair cannot be discriminated without moving the accept set.

What would be worth a card with a measured population is the cheap half: **auditing which string-or-object union sites lack a pin on their author-visible message**, the gap this PR closes for one site. That is a test-coverage question, not a schema question, and it needs its own card.

## Verification

All runs on `95f87ffa`, through `scripts/pm/os-verify-lock.sh` where they are builds or tests.

- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/kernel/manifest-unknown-keys.test.ts` — `VERDICT command-exit 0`, **19 passed** (16 before).
- `pnpm --filter '@objectstack/spec^...' build && pnpm --filter @objectstack/spec run typecheck` — `VERDICT command-exit 0`. The edited file is genuinely in the typecheck program: `tsc -p tsconfig.test.json --listFiles` reports 1 hit for it, so this is coverage rather than a green over source nothing read.
- `pnpm --filter @objectstack/spec build && pnpm --filter @objectstack/spec check:generated` — `VERDICT command-exit 0`, **all 15 generated artifacts up to date**, so no reference page and no ledger row moves.
- Gate family derived on the actual diff with `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack` (1 path vs merge base `3386493f`). Run and green: `check:nul-bytes`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:published-files`, `check:strictness-ledger`. `check-test-completeness.mjs` exits 3 = its own PREREQUISITE NOT MET branch (it grades a saved turbo log) — recorded as **NOT MEASURED**, which that gate's text states is not a red.

**Reverse verification.** With the pin committed first, `formatZodIssue`'s union descent was ablated (`const branches` forced empty) in a separate step. Predicted direction: the two new rendering pins go red, the pre-existing raw-shape pin stays green — because they measure different halves. Observed exactly that: `2 failed | 17 passed`, the two failures being the new rendering pins. Mutation was confirmed on disk by occurrence counts before the run (old anchor 1 to 0, injected marker 0 to 1), not by an editor exit code; restore was proven by `git diff HEAD` empty plus an on-disk hash equal to the HEAD blob `8410fd41`. Nothing from the ablation is in this branch.

## Changeset

None, and `skip-changeset` is applied. The diff publishes nothing: `packages/spec`'s `files` whitelist is `dist`, `src/**/*.zod.ts` and friends, which admits no test file — `check:published-files` states it green ("admits no test, test-harness config or build script"). This differs from the dispatch's working assumption of a `@objectstack/spec` patch, which assumed a source change that is not here.

`needs:contract-review` is applied because the diff sits under `packages/spec/src/**`; the accept set does not move, so the clause-2 answer is still no.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_0174WZTU6XcFcS7g2kykC53i)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0174WZTU6XcFcS7g2kykC53i)_