### PR TITLE
docs(skills): spell Plugin.type as PluginType in objectstack-platform

### DIFF
--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -720,7 +720,7 @@ import type { Plugin, PluginContext } from '@objectstack/core';
 export interface Plugin {
   name: string;               // Unique identifier (reverse domain recommended)
   version?: string;           // Semantic version
-  type?: string;              // standard|ui|driver|server|app|theme|agent|objectql
+  type?: PluginType;          // closed set exported by @objectstack/core
   dependencies?: string[];    // Plugins that must init before this one
 
   // Phase 1: Register services

--- a/skills/objectstack-platform/rules/plugin-lifecycle.md
+++ b/skills/objectstack-platform/rules/plugin-lifecycle.md
@@ -45,7 +45,7 @@ export interface Plugin {
   version?: string;
 
   /** Plugin type */
-  type?: string;  // standard|ui|driver|server|app|theme|agent|objectql
+  type?: PluginType;  // closed set exported by @objectstack/core
 
   /** Plugins that must init before this one */
   dependencies?: string[];


### PR DESCRIPTION
Fixes #14589

## What changed

`skills/objectstack-platform`'s copy of the `Plugin` interface still spelled `type` as
an open `string` with the value set carried in a trailing comment, at two sites. #13925
narrowed the published field on `@objectstack/core` to the closed `PluginType` (verified
on this branch: `packages/core/src/types.ts:105` `export type PluginType = 'standard' |
(typeof CORE_PLUGIN_TYPES)[number];`, field at `:130` `type?: PluginType;`, and the type
is publicly re-exported via `export * from './types.js';` in
`packages/core/src/index.ts:21`). The skill was teaching a wider accept set than the
compiler enforces.

Two same-length, no-net-growth edits per the triage scope ruling (comment
[5514027764](https://github.com/objectstack-ai/objectstack/issues/14589#issuecomment-5514027764)
on the card):

- `skills/objectstack-platform/SKILL.md:723`
- `skills/objectstack-platform/rules/plugin-lifecycle.md:48`

Both now read `type?: PluginType;` with a short pointer comment in place of the
enumeration (`// closed set exported by @objectstack/core`), rather than dropping the
comment outright: `git grep -rn "CORE_PLUGIN_TYPES\|'theme'"` etc. against
`skills/objectstack-platform/` found no other site in the package naming the value set,
so per the dispatch's mechanism assumption a minimal pointer stays rather than leaving the
reader with nothing (the enumeration list itself is not restored).

⛔ No sweep of `skills/**` for other stale type copies, per the triage ruling's scope
limit.

## Line/token budget (skills token ratchet)

Whole-file readings, before → after (`origin/main` `5bc2f27` → this branch):

| file | lines before | lines after | tokens before | tokens after |
|---|---:|---:|---:|---:|
| `skills/objectstack-platform/SKILL.md` | 1223 | 1223 | 12871 | 12868 |
| `skills/objectstack-platform/rules/plugin-lifecycle.md` | 263 | 263 | 1777 | 1775 |

Whole-package totals (`skills/objectstack-platform/**`, 5 files): lines 2100 → 2100,
tokens 20159 → 20154. Both files shrink individually (net deletions); the package total
shrinks; no file's token ceiling rises. `node scripts/check-skills-token-ratchet.mjs`
confirms: `skills/objectstack-platform/SKILL.md 12868 / 12984 (-116)`,
`skills/objectstack-platform/rules/plugin-lifecycle.md 1775 / 2408 (-633)`.

## Reverse-check

```
$ git grep -n "type?: string" -- 'skills/**'
(no output)
$ git grep -n "type?: PluginType" -- 'skills/**'
skills/objectstack-platform/SKILL.md:723:  type?: PluginType;          // closed set exported by @objectstack/core
skills/objectstack-platform/rules/plugin-lifecycle.md:48:  type?: PluginType;  // closed set exported by @objectstack/core
```

## Governed surface

`skills/**` is a governed surface (AGENTS.md Prime Directive #14): this PR stays **draft**
and is merged by hand by the maintainer after the PM's in-seat review; no agent approves
it and it does not enter the merge queue.

## Gates

Derived post-final-commit with `node scripts/pm/dispatch-gates.mjs --repo
objectstack-ai/objectstack` at `9c84135` (no paths passed): 21 command(s) apply (16 by
path match + 5 declared whole-tree). Run under `scripts/pm/os-verify-lock.sh`, exit codes
captured before any pipe:

- `node scripts/check-ci-filter-parity.mjs` — OK
- `node scripts/check-closing-keyword-parity.mjs` — OK
- `node scripts/check-comment-mask-corpus.mjs` — OK (5824 files, 0 disagree)
- `node scripts/check-cross-package-test-inputs.mjs` — OK
- `node scripts/check-shard-attestation.mjs` — OK
- `node scripts/check-skills-token-ratchet.mjs` — OK (see budget table above)
- `node scripts/check-test-completeness.mjs` — **NOT MEASURED** (gate's own text: "this
  gate grades a saved `turbo run test` log, and no log was named" — CI tees it; this card
  touches no test files)
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — OK (after building
  `@objectstack/formula` and `@objectstack/lint`'s dependency closure, which were not
  built in the fresh worktree)
- `pnpm --filter @objectstack/spec run check:skill-docs` — OK
- `pnpm check:agent-test-spelling` — OK
- `pnpm check:corpus-claim-drift` — OK
- `pnpm check:cross-package-test-inputs` — OK
- `pnpm check:doc-authoring` — OK
- `pnpm check:nul-bytes` — OK
- `pnpm check:pm-governed-merges` — OK
- `pnpm check:refd-timer-probe` — OK
- `pnpm check:role-word` — OK
- `pnpm check:skill-compatibility` — OK
- `pnpm check:skill-frame-sync` — OK
- `pnpm check:skill-identifier-liveness` — OK
- `pnpm check:watch-hint-literal` — OK

Run at `9c84135` (`git rev-parse --short HEAD` of this branch's tip).

This diff publishes nothing from any package (skill docs only) — `skip-changeset` label
applied per the os-dev clause.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_