### PR TITLE
tooling(pm): name the sweeper's third file in the half-state patrol's adopt list

### DIFF
--- a/.github/workflows/half-state-patrol.yml
+++ b/.github/workflows/half-state-patrol.yml
@@ -87,10 +87,23 @@ name: Half-State Patrol
 #
 # To adopt, in the sibling repo:
 #
-#   1. copy `scripts/pm/check-half-states.mjs` and this file, unchanged;
+#   1. copy THREE files, unchanged: `scripts/pm/check-half-states.mjs`,
+#      `scripts/invoked-as.mjs` (the sweeper imports it — see below), and this
+#      file;
 #   2. open one `tracking`-labeled anchor issue there and set the repository
 #      VARIABLE `HALF_STATE_ANCHOR_ISSUE` to its number
 #      (Settings → Secrets and variables → Actions → Variables).
+#
+# ⚠️ Step 1 said TWO files until 2026-09-03, and the sweeper has imported
+# `../invoked-as.mjs` since well before that — so the documented install was a
+# patrol that could not start. Measured on a clean two-file copy of this repo's
+# own files: `ERR_MODULE_NOT_FOUND … /scripts/invoked-as.mjs`, exit 1, before a
+# single predicate runs; the same copy with the helper added passes the
+# sweeper's 2,062-case `--self-test`. It fails LOUDLY rather than silently (the
+# job's last step turns the run red and the anchor is rewritten with "THE SWEEP
+# DID NOT RUN"), which is the one mercy in it — but a repo adopting this file by
+# following the list above installed a dead patrol. ⛔ Do not shorten this list
+# again from memory: the import is what decides it, not this comment.
 #
 # That is the whole install. The swept repo needs no configuration at all: it is
 # `github.repository`, so the copy reads the board it lives in — a hardcoded
@@ -129,6 +142,13 @@ on:
   pull_request:
     paths:
       - 'scripts/pm/check-half-states.mjs'
+      # The sweeper imports this helper, so a change to it can break the patrol
+      # without touching either file beside it — and the PR-time proof this
+      # trigger exists to give would not run. Same reasoning as the adopt list
+      # above, one layer down: an undeclared dependency is undeclared in every
+      # place that has to name it. (The adopted objectui copy carries this row
+      # already; upstream is catching up to its own port.)
+      - 'scripts/invoked-as.mjs'
       - '.github/workflows/half-state-patrol.yml'
 
 # Least privilege: this job reads the repo and writes exactly one issue BODY.
@@ -190,9 +210,14 @@ jobs:
         with:
           node-version: '22'
 
-      # No `pnpm install`: the sweeper imports nothing but `node:process` and
-      # global `fetch`. Installing the workspace here would buy nothing and would
-      # give a scheduled patrol a lockfile it could fail on.
+      # No `pnpm install`: the sweeper imports only `node:` builtins
+      # (`process`, `child_process`, `fs`, `url`), global `fetch`, and the one
+      # repo-local helper `../invoked-as.mjs` — no npm dependency, so installing
+      # the workspace here would buy nothing and would give a scheduled patrol a
+      # lockfile it could fail on. ⚠️ That repo-local import is why the adopt
+      # list above copies THREE files; this sentence read "imports nothing but
+      # `node:process` and global `fetch`" until 2026-09-03, which is the claim
+      # an adopter would have checked the copy list against.
       - name: Run the live sweep
         id: sweep
         env:


### PR DESCRIPTION
Part of #14881 — this is the **objectstack half** of that card. The hotcrm half (the workflow copy, the anchor issue and the repository variable) stays open and is delivered to the PM as an install recipe for the `repo:hotcrm` seam card, so this PR deliberately does not carry a closing keyword.

## What was measured, and what it found

The card asks whether `.github/workflows/half-state-patrol.yml` and `scripts/pm/check-half-states.mjs` need any change before the patrol is installed in a sibling repo. The answer is yes, and it is not the change anyone expected: **the documented install has been missing a required file.**

The workflow header's adopt list (step 1) said to copy two files — the sweeper and this workflow. The sweeper's line 897 is:

```js
import { isEntrypoint } from '../invoked-as.mjs';
```

so it also needs `scripts/invoked-as.mjs`. Measured on a clean two-file copy of this repo's own files, in a scratch directory:

```
$ node scripts/pm/check-half-states.mjs --self-test
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../scripts/invoked-as.mjs'
  imported from '.../scripts/pm/check-half-states.mjs'
exit 1

$ cp .../scripts/invoked-as.mjs scripts/        # the third file
$ node scripts/pm/check-half-states.mjs --self-test
✓ check-half-states self-test: 2062 cases pass.
exit 0
```

A repo that followed the list verbatim installed a patrol that cannot start. It fails **loudly** — the sweep step exits 1, the job's final step turns the run red, and the anchor is rewritten with the "THE SWEEP DID NOT RUN" body — which is the one mercy in it. But the adopter still gets a dead patrol on day one, and the fleet has two more adopters queued behind hotcrm.

The adopted objectui copy already carries the fix on its side: its port added `scripts/invoked-as.mjs` to the same `paths:` filter, with the note that the sweeper imports the helper and it "was ported alongside". Upstream is catching up to its own port.

## The three changes, all in the workflow

1. **The adopt list names three files**, with the measurement above recorded next to it and a standing instruction not to shorten the list from memory again — the import decides it, not the comment.
2. **The "No `pnpm install`" note states the sweeper's real import set** (`node:` builtins `process` / `child_process` / `fs` / `url`, global `fetch`, plus the one repo-local helper) instead of "nothing but `node:process` and global `fetch`". The note's *conclusion* was always right — there is still no npm dependency — but that sentence is exactly what an adopter checks the copy list against, so leaving it stale re-creates the defect one reader later.
3. **`scripts/invoked-as.mjs` joins the `pull_request` path filter.** Named explicitly because it is the one change here that is not a comment: it is a bounded in-place fix of the same defect one layer down. The dependency was undeclared in *both* places that have to name it, and with the filter as it stood a change to the helper could break the patrol with no PR-time proof running. Scan for the boundary: `invoked-as.mjs` has exactly one reader under `scripts/pm/`, the import above; no other workflow filters on it; the row is byte-identical in intent to the objectui copy's.

## What is NOT changed, and why

`scripts/pm/check-half-states.mjs` is **untouched**, so this repo's sweep behaviour is byte-identical by construction rather than by assertion.

In particular, no priority-axis parameter was added. hotcrm spells that axis `prio:p0/p1/p2` where this repo spells it `priority:p0`, and a `--priority-prefix` knob was the obvious candidate change. It is the wrong one: `scripts/pm/ensure-pm-labels.sh` already seeds `priority:p0` into all five fleet repos including hotcrm, and says why in its own comment — "It is in this five-repo loop because that sweep is repo-parameterized (`PM_SWEEP_REPO`) and grading is a five-repo triage duty". The fleet's declared design is one vocabulary seeded everywhere, not a per-repo dialect in the shared tool; the unused `priority:p0` label object the `repo:hotcrm` seat found sitting at zero cards in hotcrm is that seeding's own product. Teaching the sweeper a second spelling would be consumer-side tolerance for a producer-side divergence. The coverage gap it leaves is real and is reported on the card instead.

## Gates

Re-derived after the final commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths — the script takes its own changeset), which reported **27 runnable families**; all 27 were harvested with `--commands` and run at `5c85a642`, **all exit 0**. Their own verdict lines, quoted:

```
✓ check-half-states self-test: 2062 cases pass.
✓ check-self-test-wired: every one of the 166 script(s) CI runs that ship a
  `--self-test` has that self-test run by CI.
check-nul-bytes: OK (scanned 8160 text file(s) -- 8160 tracked, 0
  untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes).
✓ check:declared-population-live — 159 of 204 famil(ies) declare a path
  population, and every one of them reaches this tree's 8167 tracked file(s).
```

The one substitution, declared: the derivation lists `node scripts/pm/check-half-states.mjs` bare, which is the workflow's **live** sweep against the real board rather than a local gate; it was run in its `--self-test` form instead.

The workflow parses (`yaml.safe_load`, `pull_request.paths` reads back as the three expected entries).

Repo-wide `pnpm lint` was narrowed, and the narrowing is measured rather than asserted: eslint's own accounting for the changed file is `File ignored because no matching configuration was supplied` — the flat config supplies no matcher for `.yml`, so eslint linted **0** of this diff (`--format json`, one entry, zero errors). The diff touches no JS or TS, and type-aware linting is not enabled, so no untouched file's verdict can move because of it. `pnpm lint` therefore cannot change in either direction here; CI runs it regardless.

`skip-changeset`: this ships nothing from any released package — a workflow comment plus one path-filter row.

_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_