### PR TITLE
fix(pm): seed the `tracking` label in ensure-pm-labels.sh's five-repo loop

### DIFF
--- a/scripts/pm/ensure-pm-labels.sh
+++ b/scripts/pm/ensure-pm-labels.sh
@@ -228,6 +228,25 @@ for R in objectstack-ai/objectstack objectstack-ai/objectui objectstack-ai/cloud
   # OPPOSITE of the state model (SKILL.md: 插队 is ORDERING, explicitly not an
   # exemption), on a surface that is read by hovering.
   gh label create priority:p0         -R "$R" -c b60205 -d "Queue-jump: outranks batch and breaks the round — never exempts claiming or same-file serial" 2>/dev/null || true
+  # tracking marks a generated/standing anchor issue, never dispatchable
+  # work, and is load-bearing twice over: it is what the half-state-patrol
+  # (and release-coverage-patrol) workflow's ANCHOR_ISSUE lookup finds the
+  # anchor by in whichever repo it is installed in, and it is an
+  # H13_EXEMPT_LABELS member in scripts/pm/check-half-states.mjs, so it is
+  # what stops the anchor itself from appearing as a finding in the very
+  # sweep it hosts. Same five-repo loop as priority:p0 above, on the rule
+  # stated beside it, quoted rather than paraphrased: "It is in this
+  # five-repo loop because that sweep is repo-parameterized (PM_SWEEP_REPO)
+  # and grading is a five-repo triage duty — the same reasoning as
+  # pm:retriage below." For tracking the repo-parameterized sweep is
+  # check-half-states.mjs's H13 check rather than triage grading, but the
+  # test it applies is the same one: a label belongs in this loop when the
+  # sweep reads it in every repo the sweep itself runs in, and H13 runs in
+  # all five. Measured 2026-09-03: objectstack and objectui both carry a
+  # live `tracking` object with GitHub's default colour `ededed` and an
+  # empty description — the same drift the priority:p0 comment above
+  # records for objectui.
+  gh label create tracking            -R "$R" -c cfd3d7 -d "Generated anchor/tracker issue — not dispatchable; exempt from the half-state sweep's findings" 2>/dev/null || true
   # pm:blocking is a derived CACHE, never hand state (maintainer opinion
   # 2026-08-13, superseding the earlier derived-only-no-stored-label ruling):
   # the triage sweep writes/removes it from the Blocked-by: reverse index, and


### PR DESCRIPTION
Fixes #15001

`scripts/pm/ensure-pm-labels.sh`'s five-repo loop seeds eleven PM-vocabulary labels but never `tracking`, even though `tracking` is load-bearing in every repo the half-state-patrol (and release-coverage-patrol) workflow is installed in: it is what the workflow's `ANCHOR_ISSUE` lookup finds the anchor by, and it is a member of `H13_EXEMPT_LABELS` in `scripts/pm/check-half-states.mjs`. This adds one `gh label create tracking …` row to the same five-repo loop that seeds `priority:p0`, right beside it, with a comment quoting `priority:p0`'s own stated loop-membership rule rather than paraphrasing it and citing the measured drift the row closes (objectstack and objectui both already carry a live `tracking` object with GitHub's default colour `ededed` and an empty description, read 2026-09-03). No other file changes, no behaviour change to the sweeper or the patrol recipe, and the seeder itself was not run — this PR only edits the script.

## Gates

Derived via `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands scripts/pm/ensure-pm-labels.sh` at head `5892c6b5` — identical 19-command list before and after the commit, so no family was missed by committing late. Every exit code was captured before any pipe; quoted lines are each gate's own printed verdict.

```
bash -n scripts/pm/ensure-pm-labels.sh
  exits 0

node scripts/check-ci-filter-parity.mjs
  OK: all 135 declared cross-package glob(s) (95 unique) are covered by `core` or `crosspkg`,
  every `crosspkg` entry still covers one, and the `test` job's `if:` still names both filters.

node scripts/check-closing-keyword-parity.mjs
  check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords and both measured
  separators; sweep found 5 file(s) carrying the grammar across 8175 tracked file(s), all
  registered).

node scripts/check-comment-mask-corpus.mjs
  ✓ comment-mask corpus sweep [scripts/js-comment-mask.mjs]: 5832 files, 0 disagree,
  0 unparseable, 53.9s (comparator self-test: 12 cases pass).

node scripts/check-cross-package-test-inputs.mjs
  OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes every
  declared glob.

node scripts/check-self-test-wired.mjs
  ✓ check-self-test-wired: every one of the 166 script(s) CI runs that ship a
  `--self-test` has that self-test run by CI.

node scripts/check-shard-attestation.mjs
  ✓ check-shard-attestation: 2 aggregate gate(s) count 3 declared leg(s) across
  3 attesting job(s).

node scripts/check-test-completeness.mjs
  NOT MEASURED — exit 3, "PREREQUISITE NOT MET" (this gate grades a saved `turbo run
  test` log; no argument was given locally, exactly the branch the gate's own header
  says is unreachable in CI and is not a red).

node scripts/check-whole-set-label-write.mjs
  ✓ check-whole-set-label-write: 0 violations — 252 file(s) over 3 root(s) · 11 raw
  mention(s) · 11 in comments/prose (cleared) · 0 in EXECUTABLE content (judged) ·
  160 `uses:` pin(s) over 18 distinct action(s) judged · 0 allowlist entr(ies)

pnpm check:agent-test-spelling
  ✓ check-agent-test-spelling --self-test: all cases pass

pnpm check:bash32-floor
  ✓ check-bash32-floor: 26 tracked shell file(s) under scripts/**, .claude/hooks/**,
  .githooks/** name no bash 4+ construct outside a comment, a guarded ${VAR:-} read,
  or a non-command position.

pnpm check:cli-command-ids
  ✓ check-cli-command-ids: 324 command-id literal(s) across 114 file(s) outside
  packages/cli all resolve to a real command path (73 ids derived; 3 declared
  fixture exemptions, 0 baselined violation(s) listed above).

pnpm check:cross-package-test-inputs
  OK: 25 package(s) read outside themselves, all declared, and turbo.json hashes
  every declared glob.

pnpm check:entry-guard
  ✓ check:entry-guard: 201 scripts/ file(s) — every entry guard goes through
  invoked-as.mjs; 152 export bindings, 152 of them inert on import (0 known-unsafe,
  SHRINK-ONLY).

pnpm check:nul-bytes
  check-nul-bytes: OK (scanned 8168 text file(s) -- 8168 tracked, 0 untracked-not-
  ignored; skipped 7 binary; no raw ASCII control bytes).

pnpm check:parse-guard
  ✓ check:parse-guard: 200 scripts/ file(s) — every TypeScript parse goes through
  ts-parse.mjs.

pnpm check:pm-label-desc-cap
  ✓ check:pm-label-desc-cap: 23 label descriptions in scripts/pm/ensure-pm-labels.sh,
  all ≤100 characters (longest: 100, repo:objectui).

pnpm check:pnpm-filter-targets
  ✓ check:pnpm-filter-targets: 142/181 `--filter` occurrence(s) across 33 file(s)
  resolve against 79 workspace package(s); 39 not judged (2 foreign, 17 interpolated,
  20 path); 49 more in comments or step labels and 59 in this rule's own files,
  counted and not judged.

pnpm check:refd-timer-probe
  OK check-refd-timer-probe: 5827 source file(s) swept; the process-global timer
  probe is read in packages/qa/refd-timer-testkit/src/index.ts and nowhere else.

pnpm check:watch-hint-literal
  ✓ check-watch-hint-literal: 48 declaration(s) across 4 rostered name(s) --
  ROOT_DIR_WATCH_HINTS 32, ROOT_FILE_WATCH_HINTS 9, ROOT_WATCH_HINTS 2,
  DECLARED_WATCH_HINTS 5 -- every one an array of quoted literals inside its own
  statement, every rostered name non-empty, and no unrostered spelling of the idiom
  in the tree.
```

Head sha of this verification run: `5892c6b5` (same tree pushed to this branch).

Not a governed surface: `node scripts/pm/check-governed-merges.mjs --test scripts/pm/ensure-pm-labels.sh` → "0 of 1 path(s) hit the register … NOT governed — ordinary queue landing applies to a PR with exactly this file list." `skip-changeset` applied additively (nothing published from any package) and read back.

Draft: awaiting the seat's review before ready + auto-merge, per this lane's landing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_