### PR TITLE
feat(spec,analytics): AnalyticsResult.fields[].builtinAggregate discriminator for built-in default measures (#14492)

### DIFF
--- a/.changeset/analytics-result-builtin-aggregate.md
+++ b/.changeset/analytics-result-builtin-aggregate.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/spec": minor
+"@objectstack/service-analytics": minor
+---
+
+feat(spec,analytics): `AnalyticsResult.fields[].builtinAggregate` — a closed discriminator for a measure column whose display name is the server's built-in default (#14492)
+
+**What a consumer sees.** `queryDataset()` (and `POST /api/v1/analytics/dataset/query`,
+which relays the result verbatim) now carries an optional
+`fields[].builtinAggregate?: 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'`
+on a measure column. It is present exactly when the dataset measure behind the
+column declares an `aggregate` and **no** `label` — the producer then has nothing
+but the aggregate to name the column by, so it says which aggregate that is. It is
+absent whenever the author declared a label (a plain string or an inline locale
+map, even one with no entry for the request locale: an author's text is never
+re-labelled by a consumer), and absent on dimension columns and derived measures.
+The vocabulary is `AggregationFunction` (`data/query.zod.ts`), the one closed
+aggregate enum — no second spelling. `AnalyticsResultResponseSchema`
+(`api/analytics.zod.ts`) mirrors the member, refusing a spelling outside the enum.
+
+**Why.** An AI-built dashboard's "count of customers by status" chart showed the
+English axis title "Count" on a Chinese UI. The renderer (objectui
+`buildChartSeries()` / `labelOf()`) treats `fields[].label` as resolved author
+content and passes it through verbatim — correctly, since a real custom label
+("Tasks") must survive. What it could not tell apart was an author's text from
+the server's built-in default for a bare `count`. Guessing from the label text
+was refused (it would catch an author who really named a field `Count`, and break
+the moment the default is spelled in another language); translating on the
+server was not taken (it copies the front end's language decision into the
+producer and leaves nothing for a per-widget override). The ruling (2026-09-02,
+option B) is a structured discriminator on the contract: the consumer prefers a
+locale lookup keyed by `builtinAggregate` — mirroring its existing
+`report.aggregate.*` keys — and falls back to `label`, then `name`.
+
+**Producer-side changes.**
+
+- `@objectstack/service-analytics` — `queryDataset`'s measure enrichment sets
+  `builtinAggregate` from the dataset measure's own `aggregate` when the measure
+  has no authored `label`. Judged on the authored key, never on the resolved
+  string.
+- `@objectstack/spec` — the `dataset` create seed (`metadata-create-seeds.ts`)
+  drops its hardcoded `label: 'Count'` from the seeded `count` measure, so a
+  dataset created from Studio is a built-in default (wire: `builtinAggregate:
+  'count'`) instead of an authored English literal. `getMeta()` for such a
+  dataset now titles the metric by its name (`count`) rather than `Count`;
+  `CubeMeta.measures[].type` already carried the aggregate there.
+
+Purely additive: no key is removed or renamed, no authorable schema changes shape,
+and a consumer that ignores the member sees exactly the response it saw before.

--- a/packages/rest/src/analytics-routes.test.ts
+++ b/packages/rest/src/analytics-routes.test.ts
@@ -65,6 +65,22 @@ describe('POST /analytics/dataset/query', () => {
     expect(queryDataset.mock.calls[0][1]).toEqual(selection);
   });
 
+  // #14492 — `fields[].builtinAggregate` is relayed verbatim: the handler ends
+  // in `res.json(result)` with no reshaping, so the discriminator the service
+  // set is exactly what the renderer reads.
+  it('relays fields[].builtinAggregate unchanged (#14492)', async () => {
+    const fields = [
+      { name: 'status', type: 'string', label: 'Status' },
+      { name: 'count', type: 'number', builtinAggregate: 'count' },
+    ];
+    const queryDataset = vi.fn().mockResolvedValue({ rows: [{ status: 'active', count: 3 }], fields });
+    const { route } = buildServer(async () => ({ queryDataset }));
+    const res = mockRes();
+    await route!.handler({ method: 'POST', params: {}, headers: {}, body: { dataset: inlineDataset, selection } } as any, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.fields).toEqual(fields);
+  });
+
   it('returns 501 when no analytics service is configured', async () => {
     const { route } = buildServer(undefined);
     const res = mockRes();

--- a/packages/services/service-analytics/src/__tests__/query-dataset.test.ts
+++ b/packages/services/service-analytics/src/__tests__/query-dataset.test.ts
@@ -531,3 +531,81 @@ describe('AnalyticsService.queryDataset', () => {
     expect(result.rows).toEqual([{ account: 'name-acc1', revenue: 1000 }]);
   });
 });
+
+// ── #14492 — built-in aggregate discriminator ──────────────────────────────
+// `fields[].label` is only ever written from the DATASET MEASURE's own `label`
+// (the enrichment block in `queryDataset`), so the question "is this header the
+// server's default or the author's text?" is answerable from the measure alone:
+// no `label` + an `aggregate` ⇒ built-in default ⇒ the column says which
+// aggregate, and an i18n-aware renderer substitutes its own name for it.
+describe('AnalyticsService.queryDataset — fields[].builtinAggregate (#14492)', () => {
+  const svcFor = (rows: Array<Record<string, unknown>>) => new AnalyticsService({
+    queryCapabilities: () => ({ nativeSql: true, objectqlAggregate: false, inMemory: false }),
+    executeRawSql: async () => rows,
+    getReadScope: (_o, ctx?: ExecutionContext) => (ctx?.tenantId ? { organization_id: ctx.tenantId } : undefined),
+  });
+  const ds = (measures: Array<Record<string, unknown>>) => DatasetSchema.parse({
+    name: 'customers', label: 'Customers', object: 'customer', include: [],
+    dimensions: [{ name: 'status', field: 'status', type: 'string' }],
+    measures,
+  });
+  const run = async (measures: Array<Record<string, unknown>>, names: string[], rows: Array<Record<string, unknown>>) => {
+    const r = await svcFor(rows).queryDataset(ds(measures), { dimensions: ['status'], measures: names }, { tenantId: 'org_A' } as ExecutionContext);
+    return Object.fromEntries((r.fields ?? []).map((f) => [f.name, f]));
+  };
+
+  it('a label-less built-in `count` measure carries builtinAggregate: "count" and no label', async () => {
+    const fields = await run([{ name: 'count', aggregate: 'count' }], ['count'], [{ status: 'active', count: 3 }]);
+    expect(fields.count?.builtinAggregate).toBe('count');
+    expect(fields.count?.label).toBeUndefined();
+    // A dimension column is never a built-in aggregate.
+    expect(fields.status?.builtinAggregate).toBeUndefined();
+  });
+
+  it('an author-labelled measure ("Tasks") keeps its text and carries NO builtinAggregate', async () => {
+    const fields = await run([{ name: 'task_count', aggregate: 'count', label: 'Tasks' }], ['task_count'], [{ status: 'open', task_count: 7 }]);
+    expect(fields.task_count?.label).toBe('Tasks');
+    expect(fields.task_count?.builtinAggregate).toBeUndefined();
+  });
+
+  it('an inline locale-map label with no entry for the request locale is STILL an authored label — no discriminator', async () => {
+    const r = await svcFor([{ status: 'open', task_count: 7 }]).queryDataset(
+      ds([{ name: 'task_count', aggregate: 'count', label: { en: 'Tasks' } }]),
+      { dimensions: ['status'], measures: ['task_count'] },
+      { tenantId: 'org_A', locale: 'fr' } as ExecutionContext,
+    );
+    const f = (r.fields ?? []).find((x) => x.name === 'task_count');
+    expect(f).toBeDefined();
+    expect(f?.builtinAggregate).toBeUndefined();
+  });
+
+  it('every aggregate in the closed vocabulary is carried verbatim when the measure is label-less', async () => {
+    const fields = await run(
+      [
+        { name: 'total', aggregate: 'sum', field: 'amount' },
+        { name: 'mean', aggregate: 'avg', field: 'amount' },
+        { name: 'owners', aggregate: 'count_distinct', field: 'owner' },
+      ],
+      ['total', 'mean', 'owners'],
+      [{ status: 'open', total: 10, mean: 5, owners: 2 }],
+    );
+    expect(fields.total?.builtinAggregate).toBe('sum');
+    expect(fields.mean?.builtinAggregate).toBe('avg');
+    expect(fields.owners?.builtinAggregate).toBe('count_distinct');
+  });
+
+  it('a derived measure has no aggregate and therefore no discriminator, while its label-less inputs keep theirs', async () => {
+    const fields = await run(
+      [
+        { name: 'base', aggregate: 'count' },
+        { name: 'met', aggregate: 'count', field: 'met' },
+        { name: 'rate', derived: { op: 'ratio', of: ['met', 'base'] } },
+      ],
+      ['base', 'met', 'rate'],
+      [{ status: 'open', base: 4, met: 2 }],
+    );
+    expect(fields.base?.builtinAggregate).toBe('count');
+    expect(fields.met?.builtinAggregate).toBe('count');
+    expect(fields.rate?.builtinAggregate).toBeUndefined();
+  });
+});

--- a/packages/services/service-analytics/src/analytics-service.ts
+++ b/packages/services/service-analytics/src/analytics-service.ts
@@ -1355,6 +1355,22 @@ export class AnalyticsService implements IAnalyticsService {
           const label = resolveI18nLabel(m.label, requestLocale);
           if (label !== undefined) f.label = label;
         }
+        // #14492 — the built-in aggregate discriminator. A measure that declares
+        // an `aggregate` and NO `label` has nothing but the aggregate to be named
+        // by: whatever header a renderer draws for it is the server's built-in
+        // default, not an author's text, so the column says WHICH aggregate that
+        // is and an i18n-aware renderer may substitute its own localized name
+        // (objectui keys `report.aggregate.*` on it — objectui#7258).
+        // Judged on the AUTHORED key, never on the resolved string: an inline
+        // locale map with no entry for `requestLocale` resolves to nothing above,
+        // yet it IS an author's label and must never be re-labelled — so the
+        // test is `m.label == null`, not `f.label == null`. A derived measure
+        // carries no aggregate and gets nothing; an authored label ("Tasks")
+        // keeps its text and gets nothing. The other spelling that would work
+        // here — a heuristic on the label TEXT ("Count") — was refused on
+        // #14492: it would catch an author who really named a field `Count`,
+        // and break the moment the default is spelled in another language.
+        if (f.builtinAggregate == null && m.label == null && m.aggregate) f.builtinAggregate = m.aggregate;
         if (f.format == null && m.format) f.format = m.format;
         // ADR-0053 currency chain. A MONETARY measure resolves its display
         // currency from: explicit measure `currency` → source-field

--- a/packages/spec/src/api/analytics.test.ts
+++ b/packages/spec/src/api/analytics.test.ts
@@ -205,6 +205,31 @@ describe('AnalyticsResultResponseSchema', () => {
     expect(resp.data.fields[2].format).toBe('0.0%');
   });
 
+  // #14492 — the built-in aggregate discriminator rides the same channel, and
+  // it is the CLOSED `AggregationFunction` vocabulary: a spelling outside it is
+  // refused at the member, not stripped or passed through.
+  it('should preserve fields[].builtinAggregate and refuse a spelling outside the closed enum', () => {
+    const resp = AnalyticsResultResponseSchema.parse({
+      success: true,
+      data: {
+        rows: [{ status: 'active', count: 3 }],
+        fields: [
+          { name: 'status', type: 'string', label: 'Status' },
+          { name: 'count', type: 'number', builtinAggregate: 'count' },
+        ],
+      },
+    });
+    expect(resp.data.fields[1].builtinAggregate).toBe('count');
+    expect(resp.data.fields[0].builtinAggregate).toBeUndefined();
+
+    const bad = AnalyticsResultResponseSchema.safeParse({
+      success: true,
+      data: { rows: [], fields: [{ name: 'count', type: 'number', builtinAggregate: 'total' }] },
+    });
+    expect(bad.success).toBe(false);
+    expect(bad.success ? [] : bad.error.issues.map((i) => i.path.join('.'))).toContain('data.fields.0.builtinAggregate');
+  });
+
   it('should preserve totals — the marginal-aggregate channel, grand total included', () => {
     const resp = AnalyticsResultResponseSchema.parse({
       success: true,

--- a/packages/spec/src/api/analytics.zod.ts
+++ b/packages/spec/src/api/analytics.zod.ts
@@ -2,6 +2,7 @@
 
 import { z } from 'zod';
 import { AnalyticsQuerySchema } from '../data/analytics.zod';
+import { AggregationFunction } from '../data/query.zod';
 import { BaseResponseSchema } from './contract.zod';
 import { retiredKey } from '../shared/retired-key';
 
@@ -109,6 +110,13 @@ export const AnalyticsResultResponseSchema = lazySchema(() => BaseResponseSchema
         + 'renders as "1%"). Resolved from metadata; absent when the column is '
         + 'not a percentage. Renderers that receive it must scale by it instead '
         + 'of guessing from the value.',
+      ),
+      builtinAggregate: AggregationFunction.optional().describe(
+        'Closed aggregate discriminator for a measure column whose display name '
+        + 'is the server\'s built-in default: the dataset measure declared an '
+        + '`aggregate` and no `label`. A renderer may substitute its own localized '
+        + 'name for the aggregate. Absent whenever the author declared a label, and '
+        + 'on dimension / derived columns.',
       ),
     })).describe('Column metadata'),
     sql: z.string().optional().describe('Executed SQL (if debug enabled)'),

--- a/packages/spec/src/contracts/analytics-service.test.ts
+++ b/packages/spec/src/contracts/analytics-service.test.ts
@@ -70,6 +70,24 @@ describe('Analytics Service Contract', () => {
     expect(meta[0].measures).toHaveLength(1);
   });
 
+  // #14492 — `fields[].builtinAggregate` is optional and is the closed
+  // `AggregationFunction` vocabulary, nothing else. The first two literals are
+  // the two shapes the producer emits (built-in default vs authored label); the
+  // third pins the closure at compile time.
+  it('carries builtinAggregate on a built-in default measure column and refuses a spelling outside the enum', () => {
+    const builtin: AnalyticsResult['fields'][number] = { name: 'count', type: 'number', builtinAggregate: 'count' };
+    const authored: AnalyticsResult['fields'][number] = { name: 'task_count', type: 'number', label: 'Tasks' };
+    expect(builtin.builtinAggregate).toBe('count');
+    expect(authored.builtinAggregate).toBeUndefined();
+    const offEnum: AnalyticsResult['fields'][number] = {
+      name: 'count',
+      type: 'number',
+      // @ts-expect-error — `total` is not an AggregationFunction; the discriminator is closed
+      builtinAggregate: 'total',
+    };
+    expect(offEnum.name).toBe('count');
+  });
+
   it('should generate SQL without executing', async () => {
     const service: IAnalyticsService = {
       query: async () => ({ rows: [], fields: [] }),

--- a/packages/spec/src/contracts/analytics-service.ts
+++ b/packages/spec/src/contracts/analytics-service.ts
@@ -66,6 +66,23 @@ export interface AnalyticsResult {
          * by it instead of guessing from the value (objectui#3136).
          */
         percentScale?: PercentScale;
+        /**
+         * #14492 — the closed aggregate discriminator for a measure column whose
+         * display name is the SERVER's built-in default rather than an author's
+         * text. Present exactly when the dataset measure behind the column
+         * declares an `aggregate` and NO `label`: the producer then has nothing
+         * but the aggregate to name the column by, so it says which aggregate
+         * that is (`count` for the seeded / auto-derived `count` measure) and a
+         * renderer may substitute its own localized name for it — objectui keys
+         * a locale lookup on this value (its `report.aggregate.*` family) and
+         * falls back to `label`, then `name`. Absent whenever the author declared
+         * a label (a plain string OR an inline locale map, even one with no entry
+         * for the request locale — an author's text is never re-labelled by a
+         * consumer), and absent on dimension columns and derived measures.
+         * Reuses `AggregationFunction` (data/query.zod.ts), the one closed
+         * aggregate vocabulary; no second spelling.
+         */
+        builtinAggregate?: AggregationFunction;
     }>;
     /** Generated SQL (if available) */
     sql?: string;

--- a/packages/spec/src/kernel/metadata-create-seeds.ts
+++ b/packages/spec/src/kernel/metadata-create-seeds.ts
@@ -95,7 +95,12 @@ const BUILTIN_METADATA_CREATE_SEEDS: Partial<Record<MetadataType, unknown>> = {
     object: PLACEHOLDER_OBJECT,
     dimensions: [],
     // A dataset needs at least one measure to be useful; seed a count.
-    measures: [{ name: 'count', label: 'Count', aggregate: 'count' }],
+    // [#14492] No `label` on purpose: an authored label is the author's text
+    // and reaches the wire verbatim (`AnalyticsResult.fields[].label`), which
+    // made this seeded "Count" an English literal on every non-English chart.
+    // Label-less, the measure is the server's built-in default — the response
+    // carries `builtinAggregate: 'count'` and the renderer localizes the name.
+    measures: [{ name: 'count', aggregate: 'count' }],
   },
   object: {
     name: 'new_object',


### PR DESCRIPTION
Closes #14492

Producer half of objectui#7258's ruling B (maintainer, 2026-09-02); epic objectstack-ai/cloud#1841. Clause-②: yes — the public spec surface grows by one optional response member.

## Consumer-side contract (for objectui#7258)

`AnalyticsResult.fields[]` — the `queryDataset()` result, relayed verbatim by `POST /api/v1/analytics/dataset/query` — now carries an optional `builtinAggregate` on a measure column, valued from the closed `AggregationFunction` vocabulary: `count | sum | avg | min | max | count_distinct` (reused from `data/query.zod.ts`; no second spelling). It is present exactly when the dataset measure behind the column declares an `aggregate` and NO `label` — the header a renderer draws for it is then the server's built-in default, not an author's text. It is absent whenever the author declared a label (a plain string or an inline locale map, even one with no entry for the request locale), and absent on dimension columns and derived measures. objectui's `buildChartSeries()` / `labelOf()` should prefer a locale lookup keyed by `builtinAggregate` — mirroring the existing `report.aggregate.*` family (`report.aggregate.count` = 计数, `report.aggregate.countDistinct` = 去重计数; note the camelCase key for `count_distinct`) — and fall back to `label`, then `name`. A consumer that ignores the member sees exactly the response it saw before.

## What changed, site by site

The ruling named five hardcoded `label: 'Count'` sites. Before editing I measured how each one reaches the wire, because the discriminator only helps where `fields[].label` is actually written:

- **`fields[].label` has exactly ONE producer**: the measure enrichment in `queryDataset` (`packages/services/service-analytics/src/analytics-service.ts`, the block that also sets `format` / `currency` / `percentScale`), which copies the DATASET MEASURE's own `label`. Every other `fields[]` assembler emits `name` + `type` only — `strategies/objectql-strategy.ts` `buildFieldMeta`, `strategies/native-sql-strategy.ts`, `dataset-executor.ts` (compare / derived columns), and driver-memory's `memory-analytics.ts` — and the REST route ends in `res.json(result)` with no reshaping.
- **Cube-metric labels never reach `fields[]`.** They surface only through `getMeta().measures[].title`, where `CubeMeta.measures[].type` already carries the aggregate beside the title.

Given that, the diff is:

1. `packages/spec/src/contracts/analytics-service.ts` — `AnalyticsResult.fields[].builtinAggregate?: AggregationFunction` (TSDoc states the presence rule above).
2. `packages/spec/src/api/analytics.zod.ts` — `AnalyticsResultResponseSchema` mirrors the member (`AggregationFunction.optional()`), refusing a spelling outside the enum. Not on the Claim's file list, but the spec's own drift guard (`api/analytics.test.ts` binds `AnalyticsResultResponse['data']` to `AnalyticsResult` at compile time) makes the mirror mandatory — the contract change does not compile without it.
3. `packages/services/service-analytics/src/analytics-service.ts` — the `queryDataset` enrichment sets `f.builtinAggregate = m.aggregate` when `m.label == null` (the AUTHORED key, never the resolved string, so an unresolved locale map stays an author's label). This is the one site that populates the wire.
4. `packages/spec/src/kernel/metadata-create-seeds.ts` — the `dataset` seed drops `label: 'Count'` from its `count` measure. A Studio-created dataset is now a built-in default on the wire (`builtinAggregate: 'count'`) instead of an authored English literal. Side effect: `getMeta()` titles that metric `count` rather than `Count` (its `type` already said `count`).
5. `inferMeasure` ×2 and `cube-registry.ts` `inferFromObject` — **left untouched, deliberately.** Their `Count` never reaches `fields[]` (measured above). Populating them would require widening `MetricSchema` — a strict, authorable cube-metric schema (`defineCube`, `StackSchema`) — with a key no wire path reads: a dead authorable key under `check:liveness`, and an AI-authoring foot-gun (a metadata author could stamp `builtinAggregate` beside a custom label). The ruling's item 1 names `AnalyticsResult.fields[]` as the contract change; I kept it there. If the maintainer wants the Cube side carried too, that is a separate decision (open question in the report).
6. `packages/qa/downstream-contract/src/additional-domains.fixtures.ts` — **no change needed**: `DcCube` is a Cube fixture parsed against the strict `CubeSchema`, and no Cube-side key was added. The suite was run as instructed (green, below) to prove the response-side widening breaks nothing a frozen consumer authors.
7. `packages/rest/src/analytics-routes.test.ts` — test only, outside the Claim surface per the dispatch's "verify passthrough, add a test if there is a response-shape test": the route relays `fields[].builtinAggregate` unchanged.

### The AI dashboard's actual producer is in cloud, not here

The chart in objectui#7258 was AI-built. Its dataset comes from cloud's `packages/service-ai-studio/src/tools/dataset-derive.ts` (line ~206), which writes `{ name: 'count', label: 'Count', aggregate: 'count' }` — an AUTHORED label from this contract's point of view, so with this PR alone that widget still carries `label: 'Count'` and no discriminator. The epic needs a one-line cloud follow-up — filed as objectstack-ai/cloud#1933 (sub-issue of cloud#1841, blocked by this PR's pin bump): drop that `label` so the derived `count` measure is a built-in default and the wire carries `builtinAggregate: 'count'`. The framework seed (item 4) is the same fix on this side.

## Tests

- `packages/spec/src/contracts/analytics-service.test.ts` — a built-in `count` column carries `builtinAggregate: 'count'`; an authored-label column does not; an off-enum spelling is refused at compile time (`@ts-expect-error`, compiled by `check:test-typecheck`).
- `packages/spec/src/api/analytics.test.ts` — the response schema preserves `builtinAggregate` and refuses `'total'` at path `data.fields.0.builtinAggregate`.
- `packages/services/service-analytics/src/__tests__/query-dataset.test.ts` (+5): label-less `count` ⇒ `'count'` and no label; authored `"Tasks"` ⇒ label kept, no discriminator; locale-map label with no entry for the request locale ⇒ still no discriminator; `sum` / `avg` / `count_distinct` carried verbatim when label-less; derived measure ⇒ none while its label-less inputs keep theirs.
- `packages/rest/src/analytics-routes.test.ts` (+1): passthrough.
- Reverse verification on the consumer side, run after the commit: a scratch file in service-analytics assigning `builtinAggregate: 'total'` went red against the REBUILT `dist/*.d.ts` — `TS2322: Type '"total"' is not assignable to type '"min" | "max" | "count" | "sum" | "avg" | "count_distinct" | undefined'` — then was removed; `git diff HEAD` empty.

## Local verification (head `105ec6c1b`)

Built the `service-analytics` and `rest` dependency closures first (`pnpm --filter 'PKG^...' build`, exit 0 both). Exit codes captured before any pipe.

| run | verdict |
|---|---|
| `pnpm --filter @objectstack/spec check:generated` | exit 0 — `✓ All 15 generated artifacts are up to date` (api-surface, authorable-surface, docs, export-origins, declaration-map, liveness, strictness-ledger, test-typecheck, …) |
| spec `tsc --noEmit` · `check:test-typecheck` | exit 0 · exit 0 (`54 file(s) / 261 error(s)` ledger held) |
| spec vitest `api/analytics` · `contracts/analytics-service` · `kernel/metadata-create-seeds` | exit 0 — 3 files, 50 passed |
| service-analytics `typecheck` · vitest `query-dataset.test.ts` | exit 0 · exit 0 — 32 passed |
| rest `typecheck` (incl. test layer) · vitest `analytics-routes.test.ts` | exit 0 · exit 0 — 14 passed |
| downstream-contract `typecheck` · `test` | exit 0 · exit 0 — 2 files, 19 passed |
| spec source audits: exported-any, dual-source-exports, empty-state, variant-docs, yaml-examples, llms-txt, entry-nameability, browser-reachable-entries, liveness | all exit 0 |
| root: nul-bytes, cross-package-test-inputs, test-source-alias, type-check-coverage, spec-parsed-alias, changeset-gate-self-tests, objectui-changeset, published-files, doc-authoring, query-options-erasure, dispatcher-error-vocabulary, engine-double-contract, merge-driver, page-declaration-shape, slot-lookup, where-matcher, watch-hint-literal, refd-timer-probe, logger-receiver-detach, objectql-double-limit, type-source-resolution | all exit 0 |
| node scripts: adr-0087-registration, changeset-no-major, ci-filter-parity, closing-keyword-parity, comment-mask-adoption, comment-mask-corpus, empty-changeset, keyed-text-bounds, plugin-teardown-shape, shard-attestation, system-context-census, tenant-audit-census, undeclared-dep-imports, docs-audit/check-affected-docs, docs-audit/check-drift-comment, pm/release-rehearsal-clone --self-test; lint `check:doc-formula-expressions` | all exit 0 |
| `check:type-check-debt` · `check:dual-build-cjs-loads` · `check-dev-prereqs` · `check-test-completeness` | **NOT MEASURED** (each prints `PREREQUISITE NOT MET` / needs a whole-tree `pnpm build` or a turbo test log; exit 3 / 3 / 1 / 3 by their own definition "not a red") — CI builds the whole tree before them |
| `check:pm-half-states` · `scripts/pm/check-half-states.mjs` | not run locally (network-bound board sweeps) |

Gate list derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (60 commands; every one accounted for above). The shared verify lock (`scripts/pm/os-verify-lock.sh`) reports "no exclusion on this host" (no `flock` on macOS), so heavy runs went direct.

## Changeset

`.changeset/analytics-result-builtin-aggregate.md` — `@objectstack/spec: minor`, `@objectstack/service-analytics: minor` (new optional response member; nothing removed or renamed; no ADR-0087 disposition needed since it is not breaking).

## Out of scope, noted

`inferFromObject`'s composite defaults `LABEL (Sum)` / `LABEL (Avg)` embed the field label, so an aggregate-only discriminator cannot reconstruct them; they stay English on `getMeta()` titles. Not in the ruling's five sites. Measured on `origin/main`, `inferFromObject` has no runtime caller at all (its only call is a unit test), so ruling site 3 is dead code — filed as #15019 (`finding`), with delete-vs-wire left to the maintainer.

_Generated by [Claude Code](https://claude.ai/code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
