### PR TITLE
docs(pm): point the governed repo set prose at GOVERNED_REPOS instead of mirroring it

### DIFF
--- a/.claude/hooks/guard-governed-enqueue.sh
+++ b/.claude/hooks/guard-governed-enqueue.sh
@@ -51,7 +51,7 @@
 #   1. "is this diff governed?"  →  `check-governed-merges.mjs --test --json`,
 #      the very predicate a seat runs before flipping ready. Exit 3 = governed,
 #      exit 0 = clear. Its register (`GOVERNED_SURFACES`) is repo-agnostic, so
-#      the same call answers for all four governed repos.
+#      the same call answers for every repo configured in `GOVERNED_REPOS`.
 #   2. "is it approved, pinned?"  →  `pinnedApprovalVerdict` +
 #      `GOVERNED_APPROVERS` imported from `check-governed-queue-guard.mjs` —
 #      the same function the queue build decides on, applied to the same review

--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -720,7 +720,7 @@ dev**:先试 SendMessage 复活,不可用才走接手协议(四条增量见 runb
 **ACCEPT 之后的路径分叉(动手之前先分,不是事后对照)。** 翻 ready / 挂 auto-merge / 入队前,
 先取一次 PR 的路径面(`get_files`,⛔ 不看报告自述)。governed 面统一定义（2026-08-18 裁定）:
 `docs/adr/**` + `.claude/**`(全量,含 agents/hooks/settings)+ `skills/**` + `AGENTS.md` +
-`CLAUDE.md`;agent 指令文件按此跨仓同判 —— objectui、cloud、objectos 一并在内（2026-08-18 裁定）
+`CLAUDE.md`;agent 指令文件按此跨仓同判 —— 仓集读 `GOVERNED_REPOS`,此处不列（2026-08-18 裁定）
 (objectos 指令面 PR 照样 draft/人工合并)。路径面**一条命中** ⇒ ACCEPT 换终局四件套:
 ① 复核结论照常写在 issue
 上(不能合 ≠ 不复核;技能面 PR 的复核席须跑在契约复审档位,档位单源见条款②闸门);② PR


### PR DESCRIPTION
Fixes #14984

Two prose statements of the governed REPO set lived outside the register (`GOVERNED_REPOS` in `scripts/pm/check-governed-merges.mjs`) and went stale the minute the register grew to five repos with the landing of #14867 (`5d4d55ae`). Remedy shape ruled by the skills seat (triage comment 5529676559): remove the mirrors and point at the register — no repo name and no count outside `GOVERNED_REPOS`, so there is nothing left to drift and nothing to parse. Two one-line edits, both on governed surfaces (`.claude/**` x2) ⇒ draft PR, in-seat review, human merge; `skip-changeset` (nothing published from any package).

## The two lines

`.claude/skills/pm-dispatch/SKILL.md:723` — before (119 bytes):

```
`CLAUDE.md`;agent 指令文件按此跨仓同判 —— objectui、cloud、objectos 一并在内（2026-08-18 裁定）
```

after (118 bytes; the `（2026-08-18 裁定）` date pointer kept verbatim per the X0 quote policy):

```
`CLAUDE.md`;agent 指令文件按此跨仓同判 —— 仓集读 `GOVERNED_REPOS`,此处不列（2026-08-18 裁定）
```

`.claude/hooks/guard-governed-enqueue.sh:54` — before:

```
#      the same call answers for all four governed repos.
```

after (75 columns, inside the header's 80-column comment block):

```
#      the same call answers for every repo configured in `GOVERNED_REPOS`.
```

No repo name and no count on either line; no issue number inside either line (the id lint covers `.claude/skills/pm-dispatch/**`). `check-governed-merges.mjs` itself, including its 2026-08-18 quotation, is untouched.

### Deviation from the dispatch word, measured

The dispatch word asked the SKILL.md line to name both `GOVERNED_REPOS` and `scripts/pm/check-governed-merges.mjs`, at net 0 lines. `check:pm-skill-ratchet` also holds a 120-byte per-line budget the dispatch reading did not price: my first cut (`0931bc0b`, both names on the line) went red with `L723 (180B)`. The line has 79 fixed bytes (the `` `CLAUDE.md`;agent 指令文件按此跨仓同判 —— `` prefix plus the date pointer), the path alone is 38 bytes and the constant 16, so both cannot fit; wrapping would spend a line the dispatch word forbids. The line now names `GOVERNED_REPOS` alone: the script is already named in this file at lines 264, 791 and 964, and `git grep -n GOVERNED_REPOS` resolves the constant in one hop. If the seat prefers the path on the line at the cost of one wrapped line (970 → 971, ceiling 1005), that is a one-line change on this PR.

## Third-mirror sweep

`git grep -n -i "objectui、cloud、objectos\|four governed repos\|four repos\|五个\|四个.*仓" -- '.claude' 'AGENTS.md' 'CLAUDE.md' 'skills'` at BASE `fddfc8db`: 9 hits, of which only the two target lines state the governed repo set or its size. The other seven are `五个` in unrelated prose — `.claude/agents/os-dev.md:82` (lock waiters) and `:384` (a wave of devs), `.claude/skills/checklist-author/SKILL.md:50` (five sweep angles), `.claude/skills/pm-dispatch/SKILL.md:795` (five health metrics), `references/lanes/engine.md:30` (driver columns), `.claude/skills/spec-property-retirement/SKILL.md:292` and `:316` (generated artifacts). A repo-wide `git grep` for the two literal strings hits only the two sites, so no test pins them. Neighbouring `SKILL.md:724` (`(objectos 指令面 PR 照样 draft/人工合并)`) names one repo as a worked example of the path-fork, not the set or its size — left as is.

## Verification — head `16bd3e51` (the pushed commit), each exit code captured before any pipe

Gate list derived by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths passed; change set read from the merge base: the two files, 14 families) — one family beyond the dispatch word's list, `check:bash32-floor`, matched via `.claude/hooks/**`, run and green. `check-governed-queue-guard` is CI-measured only (reads the workflow payload).

| Gate | Exit | Verdict line |
|:---|:---|:---|
| `node scripts/check-closing-keyword-parity.mjs` | 0 | `check-closing-keyword-parity: OK (3 parsers agree on all 9 keywords and both measured separators; sweep found 5 file(s) carrying the grammar across 8178 tracked file(s), all registered).` |
| `node scripts/check-comment-mask-corpus.mjs` | 0 | `✓ comment-mask corpus sweep [scripts/js-comment-mask.mjs]: 5833 files, 0 disagree, 0 unparseable, 48.9s (comparator self-test: 12 cases pass).` |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 | `✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 426 files / 1367 TS blocks judged clean by @objectstack/formula.` (two earlier runs exited 3 = PREREQUISITE NOT MET, `@objectstack/formula` then `@objectstack/lint` unbuilt — NOT MEASURED in the gate's own words; both built under `os-verify-lock.sh`, `VERDICT command-exit 0`, then measured) |
| `pnpm check:agent-test-spelling` | 0 | `✓ check-agent-test-spelling: 0 violations — 432 file(s) · 5850 bare `--` token(s) · 1390 launcher-rooted run(s) · 9 separator(s) JUDGED · 5 vitest-backed script name(s) derived from 81 manifest(s)` |
| `pnpm check:doc-authoring` | 0 | `✓ doc authoring guard: 393 files clean — no bare metadata literals.` (+ three further ✓ lines) |
| `pnpm check:nul-bytes` | 0 | `check-nul-bytes: OK (scanned 8171 text file(s) -- 8171 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes).` |
| `pnpm check:pm-governed-merges` | 0 | `✓ check-governed-merges --self-test: 245 assertions (…)` |
| `pnpm check:pm-governed-prose` | 0 | `✓ check-governed-prose: 2 instruction surface(s) name all 5 registered governed surfaces (docs/adr/** · .claude/** · skills/** · AGENTS.md · CLAUDE.md) and claim no others.` |
| `pnpm check:pm-skill-id-lint` | 0 | `✓ check-skill-id-lint: 23 file(s) clean (pattern /#[0-9]{3,}/g).` |
| `pnpm check:pm-skill-ratchet` | 0 | `✓ check-skill-line-ratchet: .claude/skills/pm-dispatch/SKILL.md is 970 lines (ceiling 1005; headroom 35).` — net 0 lines; L723 118 bytes (was 119) |
| `pnpm check:refd-timer-probe` | 0 | `OK  check-refd-timer-probe: 5828 source file(s) swept; the process-global timer probe is read in packages/qa/refd-timer-testkit/src/index.ts and nowhere else.` |
| `pnpm check:skill-frame-sync` | 0 | `✓ check-skill-frame-sync: 2 copies of the decision frame are structurally isomorphic across 2 files` |
| `pnpm check:watch-hint-literal` | 0 | `✓ check-watch-hint-literal: 48 declaration(s) across 4 rostered name(s) -- ROOT_DIR_WATCH_HINTS 32, ROOT_FILE_WATCH_HINTS 9, ROOT_WATCH_HINTS 2, DECLARED_WATCH_HINTS 5 -- every one an array of quoted literals inside its own statement, every rostered name non-empty, and no unrostered spelling of the idiom in the tree.` |
| `pnpm check:bash32-floor` (added by the re-derivation) | 0 | `✓ check-bash32-floor: 26 tracked shell file(s) under scripts/**, .claude/hooks/**, .githooks/** name no bash 4+ construct outside a comment, a guarded ${VAR:-} read, or a non-command position.` |
| `bash -n .claude/hooks/guard-governed-enqueue.sh` | 0 | (syntax check, no output) |
| `.claude/hooks/guard-governed-enqueue.selftest.sh` | 0 | `49 passed, 0 failed` |

Both edits were proved on disk before the commit by anchored counts (old text 0, new text 1 in each file), not by the editor's exit code.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_