### PR TITLE
fix(service-cluster): compile the test layer with tsc, and repair the TS2322 it hid

### DIFF
--- a/.changeset/service-cluster-test-tsc-program.md
+++ b/.changeset/service-cluster-test-tsc-program.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/service-cluster": patch
+---
+
+fix(service-cluster): put the test layer in front of tsc, and repair the TS2322 it was hiding (#14181)
+
+`packages/services/service-cluster` had **no `typecheck` script at all** — its
+scripts were `build` and `test` — so no tsc program anywhere read this package.
+Turbo/CI typecheck lanes skipped it silently, because a zero-matching filter run
+exits 0. `tsup` transpiles with esbuild and `vitest` runs through esbuild
+type-**stripping**; neither type-checks. The package's own `tsconfig.json` does
+include the tests and always did, so the program that would have read them
+already existed and was simply never invoked.
+
+What that hid was in the worst possible file. `src/memory/memory.contract.test.ts`
+is the package's **contract witness** — type conformance to the `IPubSub` /
+`ILock` / `IKV` / `ICounter` contracts is the entire point of its existence — and
+it did not compile:
+
+```
+src/memory/memory.contract.test.ts(26,46): error TS2322:
+  Type 'number' is not assignable to type 'void | Promise<void>'.
+```
+
+`cluster.pubsub.subscribe('e', (m) => received.push(m.payload))` passes a concise
+arrow body as a `PubSubHandler`, whose contract return type is
+`void | Promise<void>`. The body returns `Array.prototype.push`'s `number`, and
+TypeScript's void-return assignability relaxation does **not** forgive it,
+because the target is a UNION rather than a bare `void`. It is repaired with a
+block body — the handler is side-effect-only by contract, and the returned length
+was an accident of arrow syntax, never intent. The identical shape is what
+`@objectstack/metadata` graduated on (20 of them, `(evt) => arr.push(evt)` in a
+watcher slot).
+
+⛔ The spec contract is untouched: `PubSubHandler` returning `void | Promise<void>`
+is correct and deliberate (the union is what lets a driver `await` an async
+handler). The defect was in the test, so the test is where it is fixed — no
+consumer-side widening, no source signature change.
+
+Wired by the route the `packages/plugins/**` family settled on in #14062: a
+sibling `tsconfig.test.json` that changes **module semantics only** (`esnext` /
+`bundler` / `lib: ES2022`, matching how vitest actually executes these files)
+with **strictness inherited and untouched**, named by a new `typecheck` script
+through the shared `check:test-typecheck` gate. Measured before the repair: 1
+error under build semantics, 1 under the new config — the two readings agree, so
+this package carried no config-tier pile. After: 0 and 0, across a 410-file
+program covering all 7 of its `src/**/*.test.ts`.
+
+No `test-typecheck-debt.json` is added, and its **absence is the zero**: the gate
+reads a missing ledger as `{ entries: {} }`, under which any error in any file
+here is red immediately. The package's `DEBT` entry in
+`scripts/check-type-check-coverage.mjs` (`errors: 1`) is deleted in this PR
+rather than lowered — that is the graduation the ratchet's own invariant
+requires, and it is why the error was fixed rather than ledgered.
+
+No runtime code changes: `src/**` (excluding tests) is byte-identical, so no
+shipped behaviour moves. The `patch` level reflects the published `package.json`
+gaining `typecheck` / `check:test-typecheck` scripts and a `tsx` devDependency.

--- a/packages/services/service-cluster/package.json
+++ b/packages/services/service-cluster/package.json
@@ -24,7 +24,9 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsup && node ../../../scripts/check-dts-emitted.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit && pnpm check:test-typecheck",
+    "check:test-typecheck": "tsx ../../../scripts/check-test-typecheck.mts --self-test && tsx ../../../scripts/check-test-typecheck.mts --package packages/services/service-cluster --project tsconfig.test.json"
   },
   "dependencies": {
     "@objectstack/core": "workspace:*",
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.2.0",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/services/service-cluster/src/memory/memory.contract.test.ts
+++ b/packages/services/service-cluster/src/memory/memory.contract.test.ts
@@ -23,7 +23,7 @@ describe('defineCluster(memory) smoke', () => {
 
         // Round-trip through all four.
         const received: unknown[] = [];
-        cluster.pubsub.subscribe('e', (m) => received.push(m.payload));
+        cluster.pubsub.subscribe('e', (m) => { received.push(m.payload); });
         await cluster.pubsub.publish('e', 'hi');
         expect(received).toEqual(['hi']);
 

--- a/packages/services/service-cluster/tsconfig.test.json
+++ b/packages/services/service-cluster/tsconfig.test.json
@@ -1,0 +1,78 @@
+// The TEST-layer type-check program (#14181 — the `packages/services/**`
+// instance of the class #14062 settled for `packages/plugins/**`, itself
+// adopting the mechanism #5286 set for `packages/spec`, #5449 generalised,
+// #12542 carried to `packages/rest` and #13176 to `packages/plugins/
+// plugin-security`). `tsconfig.json` beside this one stays exactly as it is: it
+// is the BUILD config. This sibling puts the test layer in front of tsc under
+// the module semantics vitest really executes it with, and `package.json`'s
+// `typecheck` script NAMES it (via `check:test-typecheck --project`), because a
+// config no script invokes is exactly the phantom this whole change is about.
+//
+// ⚠️ WHAT WAS DIFFERENT HERE, and why this package was the worst case in the
+// family rather than one more of it: `service-cluster` had NO `typecheck`
+// script at all — its scripts were `build` and `test`. The other members hid
+// their tests behind an `exclude` in a config some script still ran; this one
+// ran no tsc anywhere. Its build config does NOT exclude tests and never did,
+// so the program that would have read them already existed and simply was
+// never invoked, while turbo/CI typecheck lanes skipped the package silently (a
+// zero-matching filter run exits 0). `tsup` type-strips, `vitest` type-strips.
+//
+// What differs from the build config, and what deliberately does NOT:
+//   - MODULE SEMANTICS ONLY, plus `lib`. The tests are written and executed as
+//     ESM by vitest (esbuild/vite). Matching that is FIDELITY, not laxity: it is
+//     the same subtraction `packages/spec`, `packages/rest` and the
+//     `packages/plugins/**` family each made.
+//   - ⛔ STRICTNESS IS UNTOUCHED. `strict`, `noUnusedLocals`,
+//     `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`,
+//     `rootDir`, `paths` and `types` are all INHERITED from `tsconfig.json`
+//     (and through it the root config), and none of them is re-declared here.
+//     ⚠️ A child that declared its own `paths` would REPLACE the parent map
+//     rather than merge into it, silently sending a source-resolved specifier
+//     back to `dist/` — a BUILD ARTIFACT — so this file declares none.
+//     Nothing here may loosen a type rule; if a test does not compile, that is
+//     the finding.
+//   - `lib: ["ES2022"]`, for the same reason `packages/rest` states: the root
+//     config's `lib` is ES2020 and vitest runs on a Node that has es2022
+//     builtins, so the gap is reported as TS2550 about the CHECK. No `DOM`:
+//     nothing in this layer touches a browser global.
+//
+// MEASURED at 44ffa2103, workspace closure built first (`tsc --noEmit --pretty
+// false --listFiles -p tsconfig.test.json`, and the same command without
+// `--listFiles`):
+//
+//   files in this program        410
+//   own `src/**/*.test.ts` in it 7
+//   errors under BUILD semantics 1
+//   errors under THIS config     1
+//
+// The two readings agree, so this package carried no config-tier pile at all —
+// the single error is code-tier, and it is REPAIRED in the same PR rather than
+// ledgered. It was a TS2322 at `src/memory/memory.contract.test.ts:26`:
+// `(m) => received.push(m.payload)` passed as a `PubSubHandler`, whose contract
+// return type is `void | Promise<void>`. A concise arrow body returns
+// `Array.prototype.push`'s `number`, and the void-return assignability
+// relaxation does NOT forgive it because the target is a UNION rather than bare
+// `void`. That is the same shape `@objectstack/metadata` graduated on (#14342),
+// and the fix is a block body — the handler is side-effect-only by contract.
+// Triage was explicit that this one is to be fixed, not ledgered.
+//
+// There is NO `test-typecheck-debt.json` beside this config, and its ABSENCE is
+// the zero: `check:test-typecheck` reads a missing ledger as `{ entries: {} }`,
+// under which ANY error in ANY file here is red immediately, with no entry to be
+// added to. That is strictly stronger than a ledger holding nothing, and it is
+// the same call `plugin-webhooks` and `plugin-security` (#13176) each recorded
+// for themselves. If this package ever acquires residue that cannot be fixed in
+// the PR that causes it, THAT is when a ledger and a `gen:test-typecheck-debt`
+// script are owed — and adding one is maintainer-only (#5286), exactly as the
+// gate says when it refuses.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2374,6 +2374,9 @@ importers:
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -663,6 +663,16 @@ const ROOT_PROGRAM_COUPLED_SCRIPT = 'scripts/check-test-typecheck.mts';
 // already itemised its own tiers with confidence: a tier split read off an
 // unrepaired config is a guess about what is UNDER it, and the only honest way
 // to size the code tier is to fix the config and look.
+//
+// `@objectstack/service-cluster` GRADUATED from this ledger (#14181; entry: 1
+// raw, repaired to 0). Its single TS2322 was the very shape the paragraph above
+// itemises for `metadata` -- `(m) => received.push(m.payload)` in a slot typed
+// `void | Promise<void>` -- caught here in the package's own CONTRACT witness.
+// It is worth a line because this package reached the ledger by a different road
+// than the rest: it had NO `typecheck` script at all, so its build config never
+// ran even though that config DOES include the tests. Repaired by the #5286
+// route -- a `tsconfig.test.json` over the test layer, named by a new `typecheck`
+// script -- so the entry is deleted rather than lowered.
 const DEBT = {
   '@objectstack/cloud-connection': {
     errors: 13,
@@ -689,10 +699,6 @@ const DEBT = {
       + 'entry is the specimen #5278 cites for composition drift and has now drifted BOTH ways -- 2 -> 5 '
       + 'by acquiring a second file, then 5 -> 3 by graduating the first -- so re-read what the pile is '
       + 'made of before sizing it, never just the number.',
-  },
-  '@objectstack/service-cluster': {
-    errors: 1,
-    note: 'code-tier 1 (TS2322).',
   },
   '@objectstack/service-knowledge': {
     errors: 10,

--- a/scripts/check-type-source-resolution.mjs
+++ b/scripts/check-type-source-resolution.mjs
@@ -586,6 +586,49 @@ const KNOWN_DIST_RESOLVED_TYPE_IMPORTS = {
     '@objectstack/lint', '@objectstack/mcp', '@objectstack/platform-objects',
     '@objectstack/plugin-auth', '@objectstack/spec', '@objectstack/types',
   ],
+  // #14181 re-baseline (the onboarding limb above): a NEW entry, reached ONLY
+  // through `tsconfig.test.json` -- a program this card ADDED. This is the
+  // limb's cleanest case rather than a borderline one: `service-cluster` had NO
+  // `typecheck` script AT ALL before (its scripts were `build` and `test`), so
+  // it ran ZERO counted programs and there is no pre-existing program for a dep
+  // to be laundered through. Both deps here are annotated `via
+  // tsconfig.test.json` by this gate's own failure text.
+  //
+  // Provenance measured four ways on one checkout, by varying only what the
+  // `typecheck` script NAMES (`--list`, totals as printed):
+  //
+  //   no `typecheck` script (origin/main)  absent   118 programs / 288 pairs
+  //   names `tsconfig.json` only           absent   118 programs / 288 pairs
+  //   names `tsconfig.test.json` only      PRESENT  119 programs / 290 pairs
+  //   names both (this card)               PRESENT  119 programs / 290 pairs
+  //
+  // Row 2 is the load-bearing one: the BUILD program carries no dist-resolved
+  // workspace type import at all, so the exposure is not merely first SEEN
+  // through the onboarded program, it is only REACHABLE through it. (The two
+  // programs put the same files in -- this package's `tsconfig.json` has never
+  // excluded tests -- so module semantics, NodeNext vs bundler, is the only
+  // axis that differs.)
+  //
+  // Numbers, `--list` before/after on the same checkout (before at 44ffa2103,
+  // after with this card applied):
+  //
+  //   before   57 of 78 packages, 118 programs, 288 pairs, 21 clean
+  //   after    58 of 78 packages, 119 programs, 290 pairs, 20 clean
+  //
+  // so +1 package, +1 program, +2 pairs -- this entry and nothing else.
+  //
+  // Why the entry and not `paths`, which is what this gate's failure text asks
+  // for: MEASURED both ways on the same checkout, and `paths` is decisively the
+  // wrong tool here. Redirecting these two deps to source takes this package's
+  // test layer from 0 errors to 435, ALL of them TS6059 (`not under rootDir`)
+  // and every one of them in ANOTHER package's source -- `packages/spec/src/**`
+  // and `packages/core/src/**` -- billed to a package that cannot pay them down.
+  // That is the PR #12570 finding (+5 TS6133 for `rest`) and the #8021 one (247
+  // TS6059) reproduced at a much larger scale, on a package whose entire point
+  // in this card was to reach ZERO test-layer errors. Note the direction: the
+  // #5286 route it took makes its OWN test files compile clean, and `paths`
+  // would immediately re-bury that result under other packages' diagnostics.
+  '@objectstack/service-cluster': ['@objectstack/core', '@objectstack/spec'],
   // #14386 re-baseline (the onboarding limb above): a NEW entry, reached ONLY
   // through `tsconfig.typecheck.json` -- a program that card ADDED (this
   // package's `typecheck` was a bare `tsc --noEmit` before it, with no sibling


### PR DESCRIPTION
Fixes #14181

`packages/services/service-cluster` had **no `typecheck` script at all** (its scripts were `build` and `test`), so no tsc program anywhere read this package. Turbo/CI typecheck lanes skipped it silently, because a zero-matching filter run exits 0. `tsup` transpiles with esbuild and `vitest` runs through esbuild type-**stripping**; neither type-checks.

Clause-②: no

## The route, and which exemplar it was copied from

Copied from **`plugin-webhooks`**, not from `plugin-auth` / `plugin-sharing` / `core`, because it is the one structural match. The deciding property is what the BUILD config does with tests:

| package | `tsconfig.json` excludes tests? | ledger file | fits here |
|:--|:--|:--|:--|
| `plugin-auth`, `plugin-sharing` | yes (`**/*.test.ts` in `exclude`) | debt ledger present | no |
| `core` (#14916) | yes (`**/*.spec.ts`, `**/*.test.ts`) | `test-typecheck-debt.json`, 4 residual | no |
| **`plugin-webhooks`** | **no** | **none — absence is the zero** | **yes** |
| **`service-cluster`** | **no** | — | — |

`service-cluster`'s `tsconfig.json` includes the tests and always did, so the program that would have read them already existed and was simply never invoked. It is therefore **not** a package that needs an exclusion compensated for, and AGENTS.md is explicit in the other direction: *"Never `exclude` `*.test.ts` / `*.spec.ts` from a package's `tsconfig.json`"*. So `tsconfig.json` is untouched, and the sibling `tsconfig.test.json` is the family's uniform instrument over the same files — exactly how `plugin-webhooks` states its own case.

The sibling changes **module semantics only** (`module: esnext`, `moduleResolution: bundler`, `lib: ES2022`, matching how vitest actually executes these files). ⛔ Strictness is inherited and untouched, and it declares no `paths` (a child's `paths` REPLACES the parent map rather than merging).

Both gate scripts were checked for a required spelling and conformed to: `check-type-check-coverage.mjs` (graduation, below) and `check-test-typecheck.mts` (invoked via `--project`, the spelling `--self-test` pins).

## Measured error count, before and after

Dependency closure built first (`pnpm --filter '@objectstack/service-cluster^...' build`), measured at `44ffa2103`:

| program | before | after |
|:--|--:|--:|
| BUILD semantics (`tsc --noEmit -p tsconfig.json`) | **1** | **0** |
| test layer (`tsc --noEmit -p tsconfig.test.json`) | **1** | **0** |

410 files in the program, covering all **7** of the package's `src/**/*.test.ts`.

**The two readings agree, and that agreement is the load-bearing result.** It means this package carried **no config-tier pile at all** — no TS2835, no TS7006 cascade from an unresolved import. That is the contrast `@objectstack/core` reported the other way (#14916: 98 undivided, 4 after the split — 94 of them the check rather than the code). Here there was nothing for the split to retire, so the single error is genuinely code-tier. It is well inside the dispatch's "a handful, fix them properly" branch, so no stop-and-report was owed.

## The one error, and why the fix is correct rather than convenient

```
src/memory/memory.contract.test.ts(26,46): error TS2322:
  Type 'number' is not assignable to type 'void or Promise-of-void'.
```

(spelled in words — the sanitizer eats angle-bracket generics; the compiler prints it with generics.)

That file is the package's **contract witness**: conformance to the `IPubSub` / `ILock` / `IKV` / `ICounter` contracts is the entire point of its existence, and it did not compile.

```diff
-        cluster.pubsub.subscribe('e', (m) => received.push(m.payload));
+        cluster.pubsub.subscribe('e', (m) => { received.push(m.payload); });
```

`PubSubHandler` is declared in `packages/spec/src/contracts/cluster-service.ts` as a function returning void-or-Promise-of-void. A concise arrow body returns `Array.prototype.push`'s `number`, and TypeScript's void-return assignability relaxation does **not** forgive it, because the target is a UNION rather than a bare `void`.

Why this fix and not another:

- **The spec contract is right and is untouched.** The union is deliberate — it is what lets a driver `await` an async handler. Widening it (say to return `unknown`) would be a consumer-side accommodation of a test defect, which contract-first forbids. The defect is in the test, so the test is where it is fixed.
- **The returned length was never intent.** The handler is side-effect-only by contract; its return value is either ignored or awaited. A block body states that, and is the repo's own established repair for this exact shape — `@objectstack/metadata` graduated on 20 instances of it (`(evt) => arr.push(evt)` in a watcher slot), as itemised in `check-type-check-coverage.mjs`.
- ⛔ Not ledgered. Triage was explicit: this error *"is to be fixed, not ledgered."*

## Ledger consequences

- **`DEBT` entry deleted, not lowered.** `check-type-check-coverage.mjs` carried `'@objectstack/service-cluster': { errors: 1, note: 'code-tier 1 (TS2322).' }`. That gate's own invariant is *"covered packages must not also sit in the ledger"* — declaring `typecheck` while the entry stands is a structural finding. The entry is deleted and the graduation recorded in the file's prose, per its own convention. Gate now reads **7** in DEBT where it read 8.
- **No `test-typecheck-debt.json` is created**, and its **absence is the zero**: the gate reads a missing ledger as no entries, under which any error in any file here is red immediately. Residue is 0, so no baseline file is needed — the question of whether a package *entering* the ratchet may open one does not arise here. ⛔ No ledger was grown in either direction.

## ⚠️ `check:type-source-resolution` — a re-baseline, please review it as one

This gate went **red on my diff**, and the remedy its failure text names (`paths`) is measurably the wrong one. Onboarding a `tsconfig.test.json` moves the package's tsc PROGRAM SET, which the gate judges per program. Its doc-block opens an explicit **onboarding limb** for exactly this, on three stated terms; precedents are `@objectstack/rest` (#12542) and `@objectstack/service-i18n` (#14386).

**Term 1 — provenance.** Measured four ways on one checkout, varying only what `typecheck` names:

| `typecheck` names | entry | `--list` totals |
|:--|:--|:--|
| nothing (origin/main) | absent | 118 programs / 288 pairs |
| `tsconfig.json` only | absent | 118 programs / 288 pairs |
| `tsconfig.test.json` only | PRESENT | 119 programs / 290 pairs |
| both (this PR) | PRESENT | 119 programs / 290 pairs |

Row 2 is the load-bearing one: the BUILD program carries no dist-resolved workspace type import at all, so the exposure is only **reachable** through the onboarded program, not merely first seen there. This package also had **zero** counted programs before, so there is no pre-existing program a dep could be laundered through — the cleanest form of this case.

**Term 2 — numbers stated.** before 57/78 packages, 118 programs, 288 pairs, 21 clean; after 58/78, 119, 290, 20 clean. +1 package, +1 program, +2 pairs — this entry and nothing else.

**Term 3 — why the entry and not `paths`, measured both ways.** Redirecting the two deps to source takes this package's test layer from **0 errors to 435**, all of them `TS6059` and every one in **another package's** source (`packages/spec/src`, `packages/core/src`) — billed to a package that cannot pay them down. That is PR #12570's finding (+5 for `rest`) and #8021's (247 TS6059) reproduced at larger scale, on a package whose whole result here is reaching zero.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands`, re-derived after the second commit (same 58), union run on final head **`eb41bcdad`**. Exit codes captured by redirect-then-read, never across a pipe.

**58 gates: 55 exit 0, 3 exit 3 (NOT MEASURED), 0 red.**

The two the dispatch flagged as most likely to move:

- `check:type-check-coverage` — **exit 0**: *"check-type-check-coverage: OK — 72/79 workspace packages type-checked (plus the root), 7 in the DEBT ledger (117 frozen raw errors), 1 exempt."*
- `check:type-source-resolution` — **exit 0** after the re-baseline: *"check-type-source-resolution OK — 119 tsc program(s) across 78 packages scanned; 58 registered as still resolving a workspace dep's types through `dist/`."*

NOT MEASURED, quoting each gate's own verdict (neither green nor red):

- `check-test-completeness` — exit **3**: *"PREREQUISITE NOT MET — this gate grades a saved `turbo run test` log, and no log was named. … running the family locally, record this gate as NOT MEASURED."*
- `check:dual-build-cjs-loads` — exit **3**: *"PREREQUISITE NOT MET — this gate reads built output, and some package has no dist/."*
- `check:type-check-debt` — exit **3**: *"check-type-check-coverage: PREREQUISITE NOT MET … --re-measure cannot run: 29 workspace dependenc(ies) of the ledgered packages have no built type entry point on disk."* Its own text adds: *"⛔ This is NOT a pass and NOT a finding: nothing was measured."*

Package-level, on the final head: `pnpm --filter @objectstack/service-cluster typecheck` exit 0 — *"check:test-typecheck: OK — @objectstack/service-cluster's test layer compiles … 0 file(s) / 0 error(s)"* — and `pnpm --filter @objectstack/service-cluster test` exit 0, **7 files / 105 tests passed**.

Both edited gate scripts ran their own `--self-test` green, and `check:self-test-wired` is in the union above.

## Declined, with reasons

- **Sibling `packages/services/*` packages with the same gap — reported, not touched.** `service-automation`, `service-knowledge` and `service-storage` still lack a `typecheck` script (all three carry DEBT entries: 3, 10, 51). The family-per-card pattern is deliberate.
- **No `paths` rules added** — measured at +435 TS6059 in other packages' source (above).
- **No test skipped, disabled or quarantined; no program narrowed;** no `@ts-expect-error` / `@ts-ignore` added; `strict` untouched.
- **`packages/spec` not touched** (single-owner lane) — only read, to confirm the handler contract is correct.
- **No `content/docs/releases` edit.**

## Changeset

`.changeset/service-cluster-test-tsc-program.md`, **`patch`** on `@objectstack/service-cluster`. No runtime code changed — `src` excluding tests is byte-identical, verified — so no shipped behaviour moves; the level reflects the published `package.json` gaining `typecheck` / `check:test-typecheck` scripts and a `tsx` devDependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUF1NoViznQK32gqpK8wS8)_