### PR TITLE
docs(spec): describe() for SpecialOperator $null and $exists

### DIFF
--- a/.changeset/spec-special-operator-describe.md
+++ b/.changeset/spec-special-operator-describe.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/spec': patch
+---
+
+docs(spec): `SpecialOperator` gains the `.describe()` that puts `$null` / `$exists` on the reference page (#14048)
+
+`SpecialOperatorSchema` declared both members as bare `z.boolean().optional()` with a
+JSDoc comment and no `.describe()`. `content/docs/references/data/filter.mdx` fills its
+Description column from `prop.description` — the JSON-Schema projection of a Zod
+`.describe()` — so both cells rendered **empty**, and the published reference page said
+nothing whatsoever about the two operators whose meaning was the subject of a six-site
+correction campaign (#13539, #13709). A reader could not learn from that page that
+`$exists` asks whether the field HAS A VALUE.
+
+Each member now carries a `.describe()`; the JSDoc stays as the source of truth it
+already was and the describe restates it. The regenerated page gains exactly two
+Description cells (`filter.mdx:138-139`) and nothing else.
+
+Prose only. No accept/reject or shape change: both members were and stay
+`z.boolean().optional()`, so the only JSON-Schema delta is a `description` string on two
+properties. Verified on a freshly built `dist`: `check:generated` reported
+`content/docs/references/**` as the single stale artifact and `--fix` regenerated only
+`filter.mdx`; `check:api-surface`, `check:export-origins` and `check:authorable-surface`
+stayed green with no new export.
+
+The wording was written against `scripts/check-corpus-claim-drift.mjs` rather than into
+it: that shrink-only ratchet watches `content/docs/**` for `$exists` prose, its
+`exists-key-presence` row reads `exists-key-presence 4` both before this diff and after
+the page was regenerated, so the new prose adds zero claim sites.

--- a/content/docs/references/data/filter.mdx
+++ b/content/docs/references/data/filter.mdx
@@ -135,8 +135,8 @@ Type: `[FilterArray](#filterarray)[]`
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **$null** | `boolean` | optional |  |
-| **$exists** | `boolean` | optional |  |
+| **$null** | `boolean` | optional | Is-null check. `true` matches rows where the field is null, `false` matches rows where it is not null. Lowered to `IS NULL` (true) / `IS NOT NULL` (false) on the SQL family and to `{ field: null }` (true) / `{ $ne: null }` (false) on MongoDB. |
+| **$exists** | `boolean` | optional | Has-a-value check — the exact inverse of `$null`. `true` matches rows where the field holds a value (`!= null`), `false` matches rows where it holds none. Portable across every backend the platform ships: lowered to `IS NOT NULL` (true) / `IS NULL` (false) on the SQL family and to `{ $ne: null }` (true) / `{ $eq: null }` (false) on MongoDB. |
 
 
 ---

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -1025,14 +1025,24 @@ export function likePatternToGlobPattern(pattern: string): string {
  */
 export const SpecialOperatorSchema = lazySchema(() => z.object({
   /** Is null check - SQL: IS NULL (true) / IS NOT NULL (false) | MongoDB: field: null */
-  $null: z.boolean().optional(),
+  $null: z.boolean().optional().describe(
+    'Is-null check. `true` matches rows where the field is null, `false` matches rows '
+    + 'where it is not null. Lowered to `IS NULL` (true) / `IS NOT NULL` (false) on the '
+    + 'SQL family and to `{ field: null }` (true) / `{ $ne: null }` (false) on MongoDB.'
+  ),
   
   /**
    * Field HAS A VALUE (`!= null`) — the inverse of `$null`, never key presence.
    * Lowered to `IS NOT NULL` (true) / `IS NULL` (false) on SQL and to
    * `{$ne: null}` / `{$eq: null}` on MongoDB.
    */
-  $exists: z.boolean().optional(),
+  $exists: z.boolean().optional().describe(
+    'Has-a-value check — the exact inverse of `$null`. `true` matches rows where the '
+    + 'field holds a value (`!= null`), `false` matches rows where it holds none. '
+    + 'Portable across every backend the platform ships: lowered to `IS NOT NULL` (true) / '
+    + '`IS NULL` (false) on the SQL family and to `{ $ne: null }` (true) / '
+    + '`{ $eq: null }` (false) on MongoDB.'
+  ),
 }));
 
 // ============================================================================


### PR DESCRIPTION
Fixes #14048

Clause ②: no — path limb fires (`packages/spec/src/data/filter.zod.ts` describe text); content limb no: no accept-set or shape change.

## What was wrong

`SpecialOperatorSchema` declared both members as bare `z.boolean().optional()` with a JSDoc comment and no `.describe()`. `content/docs/references/data/filter.mdx` fills its Description column from `prop.description` — the JSON-Schema projection of a Zod `.describe()`, read at `packages/spec/scripts/lib/schema-section.ts:437` — so both cells rendered empty. The published reference page therefore said nothing at all about the operator pair whose meaning was the subject of a six-site correction campaign (#13539, #13709), and `$exists` is the operator where getting it wrong changes which rows an RLS predicate admits.

## What changed

Two `.describe()` calls on the existing members, and the page regenerated from them. The JSDoc stays; the describe restates it.

- `packages/spec/src/data/filter.zod.ts` — `$null` and `$exists` in `SpecialOperatorSchema` only.
- `content/docs/references/data/filter.mdx` — regenerated, never hand-edited. `pnpm --filter @objectstack/spec check:generated --fix` reported `content/docs/references/**` as the single stale artifact of 15 and regenerated only that one; the resulting diff is exactly rows 138-139 and nothing else.
- `.changeset/spec-special-operator-describe.md` — `@objectstack/spec` patch.

The mechanism hypothesis was verified rather than assumed: `.optional().describe(...)` — describe on the optional wrapper, the shape already used by `$in`, `$nin`, `$icontains`, `$like`, `$ilike` in this file — does reach `prop.description` and does render. That is what the regenerated rows prove.

## Ratchet: run before the wording was written, and again after regeneration

`scripts/check-corpus-claim-drift.mjs` rule `exists-key-presence` is shrink-only and watches `content/docs/**`, which is where this page lands, so it was run first and the prose was written against it.

- Before any wording existed, on the pristine worktree: `check-corpus-claim-drift: OK, no new claim sites beside a pinned spelling.` / `Rules: 4 row(s) — exists-key-presence 4, exists-portability 0, regex-retired 0, section-visiblewhen-unbound 0.`
- After the page was regenerated, at the final commit: the identical two lines, `exists-key-presence 4`.

The new prose adds zero claim sites. It says the field HAS A VALUE and never touches the key-presence family of phrasings; the `$exists` cell also stays clear of the `exists-portability` row (it says portable, and never names a backend restriction).

## Measured and reported, deliberately not acted on

Triage 5488438905 scoped this card to the one pair and asked for the file-wide number to be measured and reported so the next card has a basis. Both readings are of `packages/spec/src/data/filter.zod.ts` at this branch's merge base:

- `.describe(` call sites: **11 before this PR, 13 after**. The card said 15 and triage counted 14; both are drift, the current number is 11. Command: `grep -c '\.describe(' packages/spec/src/data/filter.zod.ts`.
- Zod object members carrying a JSDoc block and **no** `.describe()`: **12 before this PR, 10 after**. They are `$eq`, `$ne` (`EqualityOperator`), `$gt`, `$gte`, `$lt`, `$lte` (`ComparisonOperator`), `$contains`, `$notContains`, `$startsWith`, `$endsWith` (`StringOperator`), and the two this PR converts. Of 43 Zod object members in the file, 9 carried a `.describe()` before this PR (11 after), 12 were JSDoc-only, and 22 carry neither.

Not acted on, per the triage fence. One observation for whoever picks up that card: `FieldOperatorsSchema` restates `$null` and `$exists` around line 1097 with no JSDoc and no describe, so the `FieldOperator` table on this same page still renders those two Description cells empty. That is inside the file-wide sweep this card explicitly deferred, so it is left alone here.

## Verification

Verified at `79007b38` (`git rev-parse --short HEAD` after the final commit; every gate below ran on that tree).

- `pnpm --filter '@objectstack/spec...' build` — `os-verify-lock: VERDICT command-exit 0`, `check-dts-emitted: @objectstack/spec - 34/34 declared declaration file(s) present.`
- `pnpm --filter @objectstack/spec test` — `VERDICT command-exit 0`; `Test Files 463 passed (463)`, `Tests 12374 passed (12374)`.
- `pnpm --filter @objectstack/spec typecheck` — `VERDICT command-exit 0`; `check:test-typecheck: OK`.
- Gate family re-derived from the actual diff after the final commit: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (no paths passed; it took the change set from the merge base itself) named **71 families**. All 71 were run. **67 green, 4 NOT MEASURED**, none red.

Named verdict lines from the ones this diff is about:

- `check:generated` — `All 15 generated artifacts are up to date.`
- `check:api-surface` — `@objectstack/spec public API surface + factory signatures unchanged`
- `check:export-origins` — `export-origins/ is current: 5239 exports across 17 entry points resolve exactly as recorded.` (no new export, as expected)
- `check:authorable-surface`, `check:docs`, `check:llms-txt`, `check:skill-refs`, `check:strictness-ledger`, `check:variant-docs`, `check:yaml-examples`, `check:quick-reference-counts`, `check:doc-anchors`, `check:doc-authoring`, `check:docs-audit-scope`, `check:docs-redirects`, `check:docs-single-h1`, `check:merge-driver`, `check:published-files`, `check:changeset-gate-self-tests`, `check:pm-half-states`, `check:spec-parsed-alias`, `check:closing-keyword-parity` — all green.
- `check:nul-bytes` — `OK (scanned 8174 text file(s) -- 8174 tracked, 0 untracked-not-ignored; skipped 7 binary; no raw ASCII control bytes).` Plus a hand scan of the three touched files for ASCII control bytes: no matches.

The 4 NOT MEASURED, each with the gate's own reason — none is a red, and CI runs all of them:

- `scripts/check-dev-prereqs.mjs` — `The workspace is not built — 1 unmet precondition, not a list of problems.` Only `@objectstack/spec` plus its dependency closure, `formula`, `lint` and `client-react` were built here; a whole-workspace build is the repo-wide run CI owns.
- `scripts/check-test-completeness.mjs` — exit 3, and its own text says so: the gate needs a saved `turbo run test` log, and the derived family names it with no argument, so `the local reading for this gate is NOT MEASURED`.
- `scripts/pm/check-half-states.mjs` (bare invocation) — a live GitHub patrol; it exceeded the 300s per-command cap used here. Its runnable family form `pnpm check:pm-half-states` is green (`check-half-states self-test: 2062 cases pass.`).
- `pnpm check:dual-build-cjs-loads` — exit 3, `PREREQUISITE NOT MET — this gate reads built output, and some package has no dist/.` Same whole-workspace build as above.

Three gates were prerequisite-blocked on the first pass and are counted green only after their package was built and they were re-run: `check:doc-formula-expressions` (needed `@objectstack/formula`), `check:doc-security-posture` (needed `@objectstack/lint`), `check:skill-examples` (needed `@objectstack/client-react`).

One reading worth flagging for the reviewer: `dispatch-gates.mjs` printed a STALE TREE warning — `main` moved 7 commits ahead during this run, and 4 files the derivation reads changed in that range (`.github/workflows/stale.yml`, `scripts/pm/check-clause2-carriers.mjs`, `scripts/pm/check-skill-line-ratchet.mjs`, `scripts/pm/ensure-pm-labels.sh`). The family count was 71 on both derivations, and none of those four is a gate this diff touches. The branch is left at its merge base rather than merged forward.

_Generated by [Claude Code](https://claude.ai/code/session_0174WZTU6XcFcS7g2kykC53i)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0174WZTU6XcFcS7g2kykC53i)_