### PR TITLE
fix(pm): correct stale four/two-copy decision-frame comments to two-copy truth

### DIFF
--- a/scripts/check-skills-token-ratchet.mjs
+++ b/scripts/check-skills-token-ratchet.mjs
@@ -331,7 +331,7 @@ export const CEILINGS = new Map([
   ['skills/objectstack-platform/SKILL.md', 12984],
   // 14239 -> 14391: the pull-directed split-resolution order joined the decision
   // frame (maintainer ruling 2026-08-27, verbatim and untranslated: 「tong y 4」 —
-  // accepting the four-rule set), and this file carries TWO enforced frame copies
+  // accepting the four-rule set), and this file carries one enforced frame copy
   // (check:skill-frame-sync COPIES), so the rule ships to third-party installers
   // with the frame it amends — the #5130 drift is exactly a frame-semantics change
   // that skipped this mirror. +152 tokens across both copies, compressed to the
@@ -341,8 +341,8 @@ export const CEILINGS = new Map([
   // 2026-09-01, verbatim and untranslated (kept on ONE line, #11106: a governed
   // quotation that soft-breaks stops being findable by the things that grep it):
   // 「四维分析中，长期合理应该权重最高，至少50%」
-  // Same shape and same reason as the +152 row above it: this file carries TWO
-  // enforced frame copies (check:skill-frame-sync COPIES), and a rule that
+  // Same shape and same reason as the +152 row above it: this file carries one
+  // enforced frame copy (check:skill-frame-sync COPIES), and a rule that
   // changes WHICH RECOMMENDATION the frame yields is exactly the #5130 drift
   // class if it ships to third-party installers with only the old tie-break —
   // the customer's agent would weigh the axes co-equally while this repo weighs
@@ -356,7 +356,7 @@ export const CEILINGS = new Map([
   // existing sentence redundant, and a re-wrap moves no tokens and pays nothing.
   // 14549 -> 9708: re-locked at the landed count after the #14296 item-4 split —
   // the developer-agent operating template moved to `rules/dev-template.md`
-  // (its own row below); the two gate-pinned copies of the decision frame stay
+  // (its own row below); the one gate-pinned copy of the decision frame stays
   // in this file (check:skill-frame-sync reads its copies by path). Lowered,
   // not raised: shrink-only, no ruling needed for this direction.
   ['skills/objectstack-pm-dispatch/SKILL.md', 9708],

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -568,9 +568,11 @@ export const CEILINGS = new Map([
   // 4 lines are re-flow slack, never a cut. Headroom 0 again, same convention.
   // Raised 466 → 469 by the axis-weighting ruling (maintainer 2026-09-01, PM
   // chat, verbatim and untranslated): 「四维分析中，长期合理应该权重最高，至少50%」.
-  // This file is one of the four `check:skill-frame-sync` COPIES, so a rule that
-  // changes which recommendation the frame yields has to reach it — the #5130
-  // drift is exactly a frame-semantics change that skipped a mirror. +3 lines,
+  // This file is not a `check:skill-frame-sync` COPIES entry, but it names the
+  // decision frame's mechanism (the dev reads it from the PM's pasted copy at
+  // dispatch time), and a rule that changes which recommendation the frame
+  // yields still has to reach that description — the #5130 drift is exactly a
+  // frame-semantics change that skipped a mirror. +3 lines,
   // folded into the existing binding sentence rather than added as a new
   // paragraph. ⚠️ Re-wrap funding was AVAILABLE here and was REFUSED: three
   // paragraphs nearby carry wrap artifacts (two orphan lines of 6 and 8 bytes)

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -8564,12 +8564,12 @@ export const MANDATORY_TIER_GLOBS = [
   {
     glob: '.claude/agents/os-dev.md',
     tier: CONTRACT_REVIEW_TIER,
-    why: 'clause ① (2026-08-20 narrowing): the dev-agent definition is protocol semantics — every dispatched dev runs under it, and it carries an enforced copy of the decision frame',
+    why: 'clause ① (2026-08-20 narrowing): the dev-agent definition is protocol semantics — every dispatched dev runs under it, and receives the decision frame the PM pastes into its prompt at dispatch time rather than carrying a copy of its own',
   },
   {
     glob: 'skills/objectstack-pm-dispatch/SKILL.md',
     tier: CONTRACT_REVIEW_TIER,
-    why: 'clause ① (2026-08-20 narrowing): the published PM skill carries two enforced copies of the decision frame (check:skill-frame-sync COPIES) and ships verbatim to third-party projects',
+    why: 'clause ① (2026-08-20 narrowing): the published PM skill carries one enforced copy of the decision frame (check:skill-frame-sync COPIES) and ships verbatim to third-party projects',
   },
 ];
 
@@ -16397,7 +16397,7 @@ function selfTest() {
   const fableOf = (paths) => deriveTier(paths);
   t('the pm-dispatch SKILL.md MAIN file is fable-mandatory', fableOf(['.claude/skills/pm-dispatch/SKILL.md']).tier === CONTRACT_REVIEW_TIER);
   t('the dev-agent definition is fable-mandatory', fableOf(['.claude/agents/os-dev.md']).tier === CONTRACT_REVIEW_TIER);
-  t('the published PM skill (two enforced frame copies) is fable-mandatory', fableOf(['skills/objectstack-pm-dispatch/SKILL.md']).tier === CONTRACT_REVIEW_TIER);
+  t('the published PM skill (one enforced frame copy) is fable-mandatory', fableOf(['skills/objectstack-pm-dispatch/SKILL.md']).tier === CONTRACT_REVIEW_TIER);
   t('a pm-dispatch REFERENCES path carries NO path mandate — the 2026-08-20 narrowing, inverted from the pre-narrowing pin', fableOf(['.claude/skills/pm-dispatch/references/review-checklist.md']).mandatory === false);
   const mixed = fableOf(['packages/spec/src/data/filter.zod.ts', '.claude/agents/os-dev.md']);
   t('a MIXED surface is mandatory — one mandatory path decides, ordinary paths do not dilute it', mixed.mandatory && mixed.tier === CONTRACT_REVIEW_TIER);
@@ -17935,6 +17935,27 @@ function selfTest() {
       ['--tier', '--residue', '--commands', '--json', '--ran', '--repo', '--changed', '--self-test']
         .every((flag) => USAGE_LINE.includes(flag)),
     );
+    // ⭐ #14870 — the mirror-image fix: `--changed` sat OUTSIDE the alternation
+    // as a whole-invocation alternative, which reads as excluding every mode
+    // beside it, though `--changed --commands` is legal and answers (CONTROL
+    // below). Moved to the position `<path> ...` occupies, the other path
+    // source it stands in for.
+    t(
+      '⭐ the usage line no longer presents --changed as a whole-invocation alternative that takes no other flag (#14870)',
+      !USAGE_LINE.includes('] | --changed | --self-test'),
+    );
+    t(
+      '…and it still offers --changed where <path> ... sits, combining with the modes before it',
+      USAGE_LINE.includes('[<path> ... | --changed]'),
+    );
+    // CONTROL: --changed really does combine with a stdout-shape flag — the
+    // usage-line fix above would otherwise be cosmetic on a refusal that does
+    // not exist.
+    const changedCommandsRun = runCli(['--changed', '--commands']);
+    t(
+      'CONTROL: --changed --commands is legal and answers, so the moved usage line describes a real combination',
+      changedCommandsRun.status === 0 && (changedCommandsRun.stdout ?? '').length > 0,
+    );
   }
 
   // ── END TO END: the CI-measured family, on the card it was measured on (#14004)
@@ -18304,6 +18325,14 @@ const invokedDirectly = isEntrypoint(import.meta.url);
  * ⛔ Deleting `[--residue]` instead would understate it — the flag really is
  * legal with the other three, and with the plain human rendering.
  *
+ * `--changed` had the mirror-image problem: it sat OUTSIDE the alternation as
+ * a whole-invocation alternative, which reads as excluding every member next
+ * to it — `--commands`/`--json` included, though `--changed --commands` is
+ * legal and answers (it derives the path list `<path> ...` would otherwise
+ * supply, and nothing more). Moved to the position `<path> ...` occupies, the
+ * other path source it stands in for, so the line no longer implies a refusal
+ * the argv chain does not make (#14870).
+ *
  * A CONSTANT rather than a literal at the print site, because the pin belongs
  * beside the refusals it mirrors: reaching the print site needs a checkout
  * where `changedPathsFromGit()` refuses, and a pin that cannot be run in the
@@ -18312,7 +18341,7 @@ const invokedDirectly = isEntrypoint(import.meta.url);
 const USAGE_LINE =
   'usage: node scripts/pm/dispatch-gates.mjs'
   + ' [--tier | [--residue] [--commands | --json | --ran <file>]]'
-  + ' [--repo owner/name] [<path> ...] | --changed | --self-test';
+  + ' [--repo owner/name] [<path> ... | --changed] | --self-test';
 
 /**
  * Executed only as a CLI. Importing this module must have NO side effect.


### PR DESCRIPTION
Fixes #14870

## What

`check:skill-frame-sync`'s `COPIES` table dropped from four entries to two (`internal-pm` → `.claude/skills/pm-dispatch/SKILL.md`, `published-pm` → `skills/objectstack-pm-dispatch/SKILL.md`) once the dev-side frame copies were retired — the dispatch PM now pastes its own copy into the dev prompt's `{decision_frame}` slot at dispatch time instead of either side embedding one. Six comments across three gate scripts still described the old four/two-copy state as present-tense fact. This PR rewrites exactly those six sites to the current truth, plus one unrelated one-word usage-line fix folded in by the seat. Comment/string text only — no behaviour, no verdict line, no ceiling value changed anywhere.

## The six sites (before → after)

**`scripts/pm/dispatch-gates.mjs`**

1. `MANDATORY_TIER_GLOBS` why-string for `.claude/agents/os-dev.md` — kept the mandate (clause ① protocol semantics still holds), fixed only the false reason:
   - before: `…every dispatched dev runs under it, and it carries an enforced copy of the decision frame`
   - after: `…every dispatched dev runs under it, and receives the decision frame the PM pastes into its prompt at dispatch time rather than carrying a copy of its own`
2. `MANDATORY_TIER_GLOBS` why-string for `skills/objectstack-pm-dispatch/SKILL.md`:
   - before: `…the published PM skill carries two enforced copies of the decision frame (check:skill-frame-sync COPIES)…`
   - after: `…the published PM skill carries one enforced copy of the decision frame (check:skill-frame-sync COPIES)…`
3. Self-test assertion **label** only (the boolean it asserts is untouched):
   - before: `t('the published PM skill (two enforced frame copies) is fable-mandatory', …)`
   - after: `t('the published PM skill (one enforced frame copy) is fable-mandatory', …)`

Docblock line at the old `:8468` ("every file carrying an enforced copy of the decision frame (the COPIES table…)") was checked against the ruling's "if it counts wrongly" condition and left untouched: it never asserts a specific number, and it already lists the dev-agent definition as a separate item rather than as a frame-copy carrier — so it doesn't count wrongly post-reduction.

**`scripts/pm/check-skill-line-ratchet.mjs`** — the `os-dev.md` ceiling ledger comment justifying its 466→469 raise:
- before: `This file is one of the four \`check:skill-frame-sync\` COPIES, so a rule that changes which recommendation the frame yields has to reach it — the #5130 drift is exactly a frame-semantics change that skipped a mirror.`
- after: `This file is not a \`check:skill-frame-sync\` COPIES entry, but it names the decision frame's mechanism (the dev reads it from the PM's pasted copy at dispatch time), and a rule that changes which recommendation the frame yields still has to reach that description — the #5130 drift is exactly a frame-semantics change that skipped a mirror.`
- The ceiling value (469) is unchanged — only the false premise for the raise is corrected, the recorded reason otherwise stands.

**`scripts/check-skills-token-ratchet.mjs`** — three ledger comments for `skills/objectstack-pm-dispatch/SKILL.md`'s history:
- `…and this file carries TWO enforced frame copies (check:skill-frame-sync COPIES)…` → `…and this file carries one enforced frame copy (check:skill-frame-sync COPIES)…`
- `…this file carries TWO\n  enforced frame copies (check:skill-frame-sync COPIES)…` → `…this file carries one\n  enforced frame copy (check:skill-frame-sync COPIES)…`
- `…the two gate-pinned copies of the decision frame stay in this file…` → `…the one gate-pinned copy of the decision frame stays in this file…`
- Checked the nearby "The largest of the five and the frame the other four are read under" sentence (`:324`) against the same "if it counts wrongly" condition: it's an unrelated sense of "frame" (the skill-package reading order, not the decision frame) and an unrelated "five"/"four" (SKILL.md package count, not COPIES) — left untouched, per the mechanism-assumptions note that this file's comment block counts other things ("the five `rules/*.md` rows" elsewhere) for reasons that have nothing to do with frame COPIES.
- Ceiling values are unchanged throughout.

## The one-word member (folded in per the seat's dispatch)

`dispatch-gates.mjs`'s `USAGE_LINE` presented `--changed` as a whole-invocation alternative that takes no other flag (`… [<path> ...] | --changed | --self-test`), though `--changed --commands` is legal and answers (verified live: exit 0, 23 commands). Moved `--changed` into the position `<path> ...` occupies — the other path source it stands in for — matching how #15036 placed `--residue` inside the alternation it really combines with:

```
- ' [--repo owner/name] [<path> ...] | --changed | --self-test';
+ ' [--repo owner/name] [<path> ... | --changed] | --self-test';
```

Pinned beside the existing `#15036` usage-line pins with three new self-test cases, including a live CONTROL that `--changed --commands` really answers (so the fix isn't cosmetic on a refusal that doesn't exist).

## Tests

All run through the shared verify lock; self-test verdict lines quoted exactly, before/after byte-identical for the six comment-text sites.

- `node scripts/check-skill-frame-sync.mjs` (unaffected file, sanity check both before and after): `✓ check-skill-frame-sync: 2 copies of the decision frame are structurally isomorphic across 2 files` — unchanged.
- `node scripts/pm/check-skill-line-ratchet.mjs --self-test`: **before** `✓ check-skill-line-ratchet self-test: 136 cases pass.` — **after** `✓ check-skill-line-ratchet self-test: 136 cases pass.` (identical).
- `node scripts/pm/check-skill-line-ratchet.mjs` (regular verdict, post-edit): green, ceilings/headroom unchanged (`AGENTS.md` 1157/1162, `CLAUDE.md` 36/86, one declared cross-file move, etc.) — no ratcheted file was touched by this PR.
- `node scripts/check-skills-token-ratchet.mjs --self-test`: **before** `✓ check-skills-token-ratchet self-test: 64 cases pass.` — **after** `✓ check-skills-token-ratchet self-test: 64 cases pass.` (identical).
- `node scripts/check-skills-token-ratchet.mjs` (regular verdict): before/after `diff` on full output is empty (byte-identical) — `✓ check-skills-token-ratchet: 36 authored bundle file(s) within their ceilings; 11 generator-owned file(s) measured, not ratcheted.`
- `node scripts/pm/dispatch-gates.mjs --self-test` (the heavy one, run through the lock each time):
  - baseline (pre-edit, `origin/main` `0f94cc7c`): `✓ dispatch-gates self-test: 1319 cases pass.`
  - final (all edits applied, working tree): `✓ dispatch-gates self-test: 1322 cases pass.` — exactly +3, the new `--changed` usage-line pins (item 2); zero `✗` anywhere in either run.
- `pnpm check:pm-skill-ratchet` (the wrapped gate form): green, same ceiling readings as the direct run above.
- `pnpm check:skill-frame-sync`: `✓ check-skill-frame-sync self-test: 13 cases pass, plus 5 dispatch-gates declaration cases and 3 scan-population cases` then `✓ check-skill-frame-sync: 2 copies … across 2 files` — the 5 "dispatch-gates declaration cases" cross-check `MANDATORY_TIER_GLOBS` against `COPIES` and stayed green, confirming cross-file consistency after the edits.
- `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` (live re-derivation against this diff, no paths passed): 28 families owed total (21 matched by path + 1 by change-kind convention [`node scripts/pm/bare-root-worklist.mjs --self-test`, triggered because this diff edits gate scripts] + 6 always-run whole-tree). All 28 run below.
- **Re-run on the committed HEAD `cd303b24`** (this PR's exact head, after push): `node scripts/pm/dispatch-gates.mjs --self-test` → `✓ dispatch-gates self-test: 1322 cases pass.` (exit 0); `node scripts/pm/check-skill-line-ratchet.mjs --self-test` → `✓ check-skill-line-ratchet self-test: 136 cases pass.` (exit 0, identical to baseline); `node scripts/check-skills-token-ratchet.mjs --self-test` → `✓ check-skills-token-ratchet self-test: 64 cases pass.` (exit 0, identical to baseline).
- `npx eslint scripts/pm/dispatch-gates.mjs scripts/pm/check-skill-line-ratchet.mjs scripts/check-skills-token-ratchet.mjs --no-inline-config --format json`: 3 files linted (count read from the JSON output itself), 0 errors, 0 warnings. Narrowed-but-proven per this repo's own lint config, which never enables type-aware linting for any file (`eslint.config.mjs`'s own comment: "never enables type-aware linting … for ANY" file) — so this diff (comment/string edits in 3 files) cannot move any untouched file's verdict, and the full repo-wide `pnpm lint` is deferred to CI rather than re-run locally.

### Full local gate table (all green, exit code captured before any pipe)

```
node scripts/check-ci-filter-parity.mjs                            — OK
node scripts/check-closing-keyword-parity.mjs --self-test          — ✓ 24 assertions, 5 mutations driven red
node scripts/check-closing-keyword-parity.mjs                      — OK (5 files carrying the grammar, all registered)
node scripts/check-comment-mask-corpus.mjs                         — ✓ 5849 files, 0 disagree
node scripts/check-cross-package-test-inputs.mjs                   — OK
node scripts/check-self-test-wired.mjs --self-test                 — ✓ 7 batteries, 50 cases
node scripts/check-self-test-wired.mjs                             — ✓ 166/166 self-tests wired
node scripts/check-shard-attestation.mjs                           — ✓ 2 aggregates, 3 legs
node scripts/check-test-completeness.mjs                           — exit 3, PREREQUISITE NOT MET (NOT MEASURED, by design — no local turbo-test log; no vitest package touched)
node scripts/check-whole-set-label-write.mjs --self-test           — ✓ all cases pass
node scripts/check-whole-set-label-write.mjs                       — ✓ (160 pins cleared)
node scripts/pm/bare-root-worklist.mjs --self-test                 — OK (66 rows, none stale/missing/contradicted) — convention-triggered by editing gate scripts
pnpm check:agent-test-spelling                                     — EXIT 0
pnpm check:bash32-floor                                            — ✓ 153 self-test cases; 26 shell files clean
pnpm check:cli-command-ids                                         — ✓ 39 self-test cases; 324 literals resolve
pnpm check:cross-package-test-inputs                                — ✓ 117 self-test cases; OK
pnpm check:declared-population-live                                 — ✓ 16 assertions; 190/240 families
pnpm check:entry-guard                                              — ✓ 54 self-test cases; 206 files clean
pnpm check:nul-bytes                                                — ✓ 75 self-test assertions; OK (8211 files, 0 raw control bytes)
pnpm check:parse-guard                                              — EXIT 0
pnpm check:pm-dispatch-gates                                        — = dispatch-gates.mjs --self-test (see above); wrapper confirmed equivalent from its own header
pnpm check:pm-skill-ratchet                                         — green (see Tests above)
pnpm check:pnpm-filter-targets                                      — ✓ 54+40 self-test assertions; 142/181 filters resolve
pnpm check:ratchet-remedy-authority                                 — OK 186 scripts swept
pnpm check:refd-timer-probe                                         — ✓ 11 self-test cases; 1 approved site
pnpm check:watch-hint-literal                                       — ✓ 57 self-test cases; 48 declarations clean
node scripts/check-skills-token-ratchet.mjs --self-test             — ✓ 64 cases pass (identical before/after)
node scripts/check-skills-token-ratchet.mjs                         — ✓ (identical before/after, diff empty)
```

Also ran ad hoc (not on the given list, but load-bearing for this PR):
```
node scripts/check-nul-bytes.mjs (targeted grep on the 3 touched files) — clean, no control bytes
git grep for stray "carries two enforced"/"four…COPIES" text repo-wide outside the 3 files — zero hits
```

Repo-wide `pnpm lint` and the changeset-triggered gate family were not run locally — this PR's surface is exactly three `scripts/**` files (no package publish, no `.changeset/`), so those either don't apply or are deferred to CI per the standard local-scope discipline.

## Scope discipline

- File surface: exactly the three scripts named in the ruling. No `.md`, no other script.
- `check-skill-frame-sync.mjs` itself is untouched — it's already correct (2 copies, 2 files) since the #14685 item-4 flight landed; this PR only follows up the comments elsewhere that hadn't caught up.
- No ceiling values, verdict lines, or self-test assertion booleans changed anywhere — only comment/string text (six sites) and one usage-line literal plus its own new pins (the folded-in member fix).

## skip-changeset

This PR publishes nothing from any released package (`scripts/pm/**` and `scripts/*.mjs` tooling only) — applying the `skip-changeset` label per the repo's real mechanism, with an additive write and read-back.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_