### PR TITLE
docs(scripts): name the `rootDir` widening in TESTS_COVERED's remedy

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -590,6 +590,12 @@ const PIN_ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/5286';
 // finding later used ("the directory was never INCLUDED by anything"), which is
 // why the remedy names a file rather than describing a shape (#10756).
 const SPEC_SCRIPTS_PRECEDENT = 'packages/spec/tsconfig.scripts.json';
+// The in-tree precedents TESTS_COVERED's remedy points at for the `rootDir`
+// half of the sibling-config route. Both put a test tree that sits outside the
+// build config's `rootDir` into a program, and both had to widen `rootDir` to
+// the repo root to do it -- the step the remedy named no way to discover until
+// #14943, measured on #14835 at 116 x TS6059 inherited and 3 more at `"."`.
+const TEST_ROOTDIR_PRECEDENT = '`packages/client/tsconfig.test.json` and `packages/cli/tsconfig.test.json`';
 const GENERATED_INCLUDE_ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/10880';
 
 // A path in the root program whose edits move the `@objectstack/spec-monorepo`
@@ -2004,7 +2010,13 @@ function evaluate(packages, root, state) {
             `the check reports green over source it never read (${TRACKING_ISSUE}). Drop the ` +
             `\`*.test.ts\`/\`*.spec.ts\` entry from \`exclude\`, widen \`include\` to reach the test tree, add a ` +
             `sibling \`tsconfig.test.json\` and name it in the \`typecheck\` script (the #5286 route, when the ` +
-            `build config must keep the exclusion), or measure what surfaces and add a TEST_DEBT entry in ${SELF}.`,
+            `build config must keep the exclusion), or measure what surfaces and add a TEST_DEBT entry in ${SELF}. ` +
+            `⚠️ The sibling route usually needs \`rootDir\` widened as well, and leaving it inherited is the ` +
+            `way that route fails: test files outside the build config's \`rootDir\` report one TS6059 each -- ` +
+            `116 of them in one measured onboarding of a sibling \`test/\` tree under \`rootDir: "src"\`, and ` +
+            `\`"."\` still left 3 where tests read fixtures from another package. ${TEST_ROOTDIR_PRECEDENT} ` +
+            `widen it to \`"../.."\` (the repo root) for exactly this reason; \`rootDir\` steers emit layout ` +
+            `only and these programs emit nothing, so it widens the ROOT and never the strictness.`,
         );
       } else {
         const entry = state.testDebt[pkg.name];


### PR DESCRIPTION
Fixes #14943

## The defect

`check:type-check-coverage`'s `TESTS_COVERED` failure text tells an author how to fix a hidden-tests package by naming the sibling `tsconfig.test.json` route — but never names the `rootDir` widening that route can require. The remedy was therefore incomplete for exactly the packages that need it most.

Measured on #14835: the `include`-narrowing shape puts tests **outside** the build config's `rootDir`, and onboarding one that way cost **116 x TS6059** with `rootDir` inherited; even `rootDir: "."` still cost **3** (three `packages/cli` tests read fixtures from `examples/app-showcase/src/**`). PR #14833 resolved it with `rootDir: "../.."` — the shape `packages/client/tsconfig.test.json` already used — and no author could reach that precedent from the gate's message.

## What this changes — remedy PROSE only

- The `TESTS_COVERED` message gains a sentence naming the `rootDir` consideration beside the sibling-config route, the two measured costs (116, and 3 at `"."`), the `"../.."` shape, and why the widening is safe (these programs emit nothing, so it widens the ROOT and never the strictness).
- One new constant, `TEST_ROOTDIR_PRECEDENT`, names the two in-tree precedents (`packages/client/tsconfig.test.json`, `packages/cli/tsconfig.test.json`) — the shape `SPEC_SCRIPTS_PRECEDENT` beside it already uses for `SOURCES_COVERED`'s remedy.

## The predicate is UNCHANGED — shown two ways

**Structurally**: the diff touches one string literal inside the existing `if (!inTestDebt)` branch, plus a new `const`. Not one condition, threshold, ledger entry or observation function is edited — 13 insertions, 1 deletion, and the deleted line is the previous last segment of that same template string.

**Behaviourally**: a throwaway workspace package reproducing this card's own subject — the `include`-narrowing shape (`include: ["src"]`, `rootDir: "src"`, one test in a sibling `test/` tree, no `exclude` at all) — was run through the gate before the edit and again after it, the second time in a separate worktree at this branch's head. Identical classification both times: the same package flagged under `TESTS_COVERED`, the same `1 of its test file(s)`, the same `1 problem(s)`, the same exit 1. Strip the appended sentence from the "after" output and `diff` against the "before" output exits 0 — the two runs differ in that sentence and in nothing else.

The gate's own `--self-test` reports the same case counts before and after (48 semantic + 68 observation + 45 re-measure + 28 built-closure + 19 auto-lowering + 18 exit-code), and the live run's verdict line is byte-identical. `check:ratchet-remedy-authority` reports the same census before and after (12 mark / 6 refuse / 168 none, 27 hand-classified control), so this file's `marked` classification did not move either.

## Verification

Every command's exit code was captured before any pipe; the verdict lines are quoted in the report comment on #14943. Run here: the gate's `--self-test` and live run (before and after), `check:ratchet-remedy-authority` (self-test + run), `check:pm-dispatch-gates` (1338 cases), `check:nul-bytes`, and `check:type-check-debt` over a freshly built closure.

`skip-changeset`: this PR publishes nothing from any package — it edits one gate script's author-facing text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk

---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_