### PR TITLE
docs(spec): record why `element:text`'s `content` is not a `PageTranslation.components` key

### DIFF
--- a/.changeset/spec-text-content-exclusion-recorded.md
+++ b/.changeset/spec-text-content-exclusion-recorded.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `PageTranslation.components` now says why `element:text`'s `content` is not one of its keys (#14412)
+
+The per-component translation face names its deliberate exclusions with reasons — `help` because no component in the model declares it, `subtitle` because `page:header` is already addressed by page name. `content` was neither named nor excluded. An author looking for a bundle key for the one string `element:text` renders therefore found an absence, and an absence reads exactly like an oversight.
+
+It is not one, and the schema comment now records that beside the other two. `element:text` declares `content: I18nLabelSchema` (`ui/component.zod.ts`), so the string is localizable at its own authoring site as an inline `{ en, 'zh-CN' }` locale map — the route `sys-user.page.ts` itself uses. Adding it to the bundle face would be the face widening the `submitLabel` retirement declined for the identical shape (#10926, ADR-0049).
+
+No key was added and no behaviour changed: the bundle face is still `title` / `description` / `label` / `placeholder` / `emptyText`, and `translatePage` resolves exactly what it resolved before. Bundles, extractor output and existing page definitions are unaffected.
+
+Known and tracked separately: inline locale maps are invisible to `os i18n extract` and `check:i18n-coverage`, so page prose written this way is not counted by coverage tooling. That is true of every inline `I18nLabel` field rather than this component alone, and is carried as #14749.

--- a/packages/spec/src/system/translation.zod.ts
+++ b/packages/spec/src/system/translation.zod.ts
@@ -875,8 +875,9 @@ const translationDataShape = () => ({
      * `translation-component-submit-label-removed` conversion strips the key
      * from stored bundles.
      *
-     * Two deliberate exclusions, both of which a mirror of the issue's proposed
-     * shape would have got wrong:
+     * Three deliberate exclusions — the first two because a mirror of the
+     * issue's proposed shape would have got them wrong, the third because the
+     * key was asked for and declined:
      *
      * - **`help` is not here** — no component in the model declares it. It
      *   would parse clean and translate nothing, which is the ADR-0078 shape
@@ -886,6 +887,14 @@ const translationDataShape = () => ({
      *   that component is addressed by page name above. Declaring it in both
      *   places would give one string two spellings, which is how the
      *   dashboards/pages asymmetry started.
+     * - **`content` is not here** — `element:text`'s one authored string is
+     *   declared `content: I18nLabelSchema` (`ui/component.zod.ts`), so it is
+     *   localizable at its own authoring site, and adding it to this face would
+     *   be the face widening the `submitLabel` retirement declined for the
+     *   identical shape (#10926). The inline locale map is the ruled route for
+     *   page prose, not a workaround. That such maps are invisible to
+     *   `os i18n extract` and `check:i18n-coverage` is real, and is its own
+     *   question about the extractor (#14749) rather than a second key here.
      *
      * `properties` is an open record and custom component types are legal, so
      * these keys are also the route for a bespoke component that speaks the


### PR DESCRIPTION
Fixes #14412

Executes the maintainer ruling recorded on the card by the director seat (comment 5518061415, 2026-09-02, verbatim reply 「同意」 to decision batch #13, item 3). Operative sentences, verbatim:

> `element:text`'s `content` does not join `PageTranslation.components`. … The schema comment in `packages/spec/src/system/translation.zod.ts` gains the sentence that was missing: `content` is excluded on purpose, beside `help` and `subtitle`, citing #10926. Option B (add the key and a precedence rule for the two routes) is not taken.

> Execution: `domain:spec` lane, S (one comment sentence; no zod change; no changeset beyond what the changeset-presence gate demands). Clause-② no.

## The premise, re-verified at the branch point before editing

The card is a census, so the census was re-measured against `origin/main` at `919beca` rather than taken from the body. All four faces hold; one line number in the dispatch had drifted and was relocated by content.

| Claim | Verified | Where |
|:---|:---|:---|
| The per-component face is five keys — `title` `description` `label` `placeholder` `emptyText` | yes | `translation.zod.ts:927-931` |
| Its comment names two deliberate exclusions, `help` and `subtitle`, each with a reason | yes | `:878-888` |
| The `submitLabel` retirement note states the precedent | yes | `:867-876` |
| `content` is neither named nor excluded on this face | yes | the only four `content` hits in the file are at `:486` `:511` `:519` `:550`, all prose in the retired-key conversion region |
| `element:text` declares `content: I18nLabelSchema` | yes | `ui/component.zod.ts:1819`, inside `ElementTextPropsSchema` opened at `:1802` — the dispatch cited `:1784`, which had drifted |

So the card's own second option was the live one: what is missing is the sentence, not the key. `premise_still_valid: true`.

## The change

One bullet added to the exclusion list, in the register of its two neighbours, and the list's lead-in updated from two to three so the count stays true:

- **`content` is not here** — `element:text` declares `content: I18nLabelSchema` (`ui/component.zod.ts`), so it is localizable at its own authoring site, and adding it to this face would be the face widening the `submitLabel` retirement declined for the identical shape (#10926).

The bullet also records, in one sentence, the thing the card raised that the earlier rulings had not weighed — that inline locale maps are invisible to `os i18n extract` and `check:i18n-coverage` — and points it at #14749, where the director seat carried it. That question is `domain:cli` and is deliberately untouched here.

This satisfies the third facet of the card's own analysis: an author who looks for a bundle key for the one string `element:text` renders now finds a decision with a reason, not an absence that reads like an oversight.

Comment only. No key was added to the face, no `describe()` changed, no resolver touched — `translatePage` resolves exactly what it resolved before, and bundles, extractor output and existing page definitions are unaffected.

## Why a changeset rather than the `skip-changeset` label

The ruling defers this to the presence gate, and the gate has no path filter — it fails any PR that adds no changeset and carries no label. The label is reserved for a diff that publishes nothing from any released package, and this diff does publish, measured two ways:

- `packages/spec` is not private (`@objectstack/spec@17.2.0`) and its `files` array includes `src/**/*.zod.ts`. `npm pack --dry-run --json` lists `src/system/translation.zod.ts` among the 2087 files in the tarball, so the edited comment ships to consumers verbatim.
- The comment text also lands in the built bundle — `dist/browser/index.js`, `dist/browser/index.mjs`, `dist/browser/system/index.js` and others (36 dist files carry it; 0 of them are `.d.ts`, so the type surface is unchanged).

Hence a `patch` changeset for `@objectstack/spec`. Not breaking, so no ADR-0087 disposition marker is required.

## Gates

Derived from the actual changed paths after the last commit with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, which read the change set from the merge base itself (2 paths, committed 2 / working tree 0 / untracked 0) and returned 47 families. All results below are pinned to head **`3bf408ba`**, with a clean working tree, and every exit code was captured before any pipe.

Green (exit 0):

- `pnpm --filter @objectstack/spec build` — `check-dts-emitted: 34/34 declared declaration file(s) present`
- `pnpm --filter @objectstack/spec check:generated` — `✓ All 15 generated artifacts are up to date.` Nothing regenerated: this JSDoc block is not copied into `content/docs/references/`, so `check:docs` needed no `--fix` and the PR carries no generated follower.
- `pnpm --filter @objectstack/spec typecheck` — including `check:scripts-typecheck` and `check:test-typecheck` (`54 file(s) / 261 error(s) / 145 pinned signature(s) held`, unchanged)
- `pnpm --filter @objectstack/spec test` — `Test Files 469 passed (469)`, `Tests 12542 passed (12542)`
- The eight spec source audits `check:generated` deliberately does not run: `check:browser-reachable-entries`, `check:dual-source-exports`, `check:empty-state`, `check:entry-nameability`, `check:exported-any`, `check:llms-txt`, `check:variant-docs`, `check:yaml-examples`
- `pnpm check:doc-authoring`, `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:logger-receiver-detach`, `check:merge-driver`, `check:objectui-changeset`, `check:page-declaration-shape`, `check:pm-half-states`, `check:published-files`, `check:slot-lookup`, `check:spec-parsed-alias`, `check:test-source-alias`, `check:type-source-resolution`
- `pnpm --filter @objectstack/lint check:doc-formula-expressions`
- `node scripts/` gates and their self-tests: `check-adr-0087-registration`, `check-changeset-no-major`, `check-ci-filter-parity`, `check-comment-mask-adoption`, `check-dev-prereqs`, `check-empty-changeset`, `check-keyed-text-bounds`, `check-plugin-teardown-shape` (`47 cases pass`), `check-system-context-census`, `check-undeclared-dep-imports`, `scripts/docs-audit/check-affected-docs`, `scripts/docs-audit/check-drift-comment`, `scripts/pm/release-rehearsal-clone --self-test`
- `pnpm lint` — the repo-wide `eslint . --no-inline-config`, run whole rather than narrowed, exit 0

Not measured, declared rather than counted as passes:

- `pnpm check:dual-build-cjs-loads` exits **3** — `Run pnpm build first. ⛔ This is NOT a pass: nothing was measured.` Its prerequisite is a built tree for 76 packages, which no comment-only diff can affect and which CI builds anyway.

Two gates needed a prerequisite met before they said anything, and both were met and re-run rather than reported from their first reading: `check:doc-formula-expressions` exited 3 twice (`@objectstack/formula`, then `@objectstack/lint`, unbuilt) and passed after both were built; `check-plugin-teardown-shape --self-test` could not reach its pinned fixture commit in this shallow checkout, and passed after that one commit was fetched.

## Scope

Comment plus changeset, nothing else — `git diff --name-only` against the merge base is exactly `packages/spec/src/system/translation.zod.ts` and `.changeset/spec-text-content-exclusion-recorded.md`, matching the claimed file surface with no deviation. Clause-② no: no accept/reject behaviour changes and no public surface widens. The extraction and coverage visibility of inline `I18nLabel` maps stays out of scope here; it is #14749's, in the `domain:cli` lane, and is referenced but not addressed by this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2oQebDDxYKfWZusyd8GXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2oQebDDxYKfWZusyd8GXk)_