### PR TITLE
feat(spec): BulkDataEvent carries organizationId — one organization for the whole batch, or not asserted

### DIFF
--- a/.changeset/bulk-data-event-organization-id.md
+++ b/.changeset/bulk-data-event-organization-id.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): `BulkDataEvent` names the one organization a predicate write's affected records belong to
+
+The realtime `BulkDataEvent` payload (`@objectstack/spec/api`, the body of every
+`data.records.updated` / `data.records.deleted` event) gains an optional
+`organizationId`: the organization every record the predicate write affected
+belongs to — one organization for the whole batch, never per-row and never a
+list. It takes the same spelling, the same position beside the match term
+`object`, and the same refusal of the empty string as `DataEvent`'s
+`organizationId`, so a tenant-scoped consumer discriminates both event families
+on one key with one comparison — never a partition of the batch.
+
+Why one organization can be honest on a batch that names no rows: a predicate
+write reaches the driver with the security layer's tenant wall AND-composed
+onto the caller's filter first (under `isolated` an equality on the caller's
+active organization; under `group` membership in the caller's organization
+set), and nothing in business RLS or sharing can widen it. When that wall names
+exactly one organization, every affected row belongs to it, and the producer
+can state so from what it already holds.
+
+What a consumer may assume — and where this deliberately diverges from
+`DataEvent`:
+
+- **Present** — every record the write affected belongs to exactly that
+  organization. Never fabricated, and never the caller's active organization
+  standing in for the rows'.
+- **Absent** — the producer did not assert one organization for the batch: every
+  event on a `single`-posture deployment; a system, environment-wide or
+  cross-membership predicate write; any write whose affected rows are not known
+  to belong to one organization. A bulk event names no rows, so absence is a
+  statement about the producer's knowledge, not about the rows. It is NOT
+  `DataEvent`'s reading "belongs to no organization, not behind any wall". A
+  tenant-scoped consumer (a per-organization webhook subscription, a
+  per-organization realtime subscriber) must treat an absent key as not
+  attributable to its organization and must not deliver the event inside an
+  organization wall; a deployment-wide consumer may use it.
+
+Declared = enforced: the key is optional and nothing else. No default
+fabricates a tenant; `null` and the empty string are refused with a located
+issue, so "not asserted" has exactly one spelling — the key is absent.
+
+Additive and shape-preserving: every bulk event that parsed before parses
+identically, and no producer emits the key yet — the ObjectQL engine's bulk
+publish site is a separate change that follows this contract. `DataEvent` and
+`MetadataEvent` are unchanged.

--- a/content/docs/references/api/events.mdx
+++ b/content/docs/references/api/events.mdx
@@ -30,6 +30,7 @@ const result = BulkDataEventSchema.parse(data);
 | **id** | `string` | ✅ | Unique event identifier |
 | **type** | `Enum<'data.records.updated' \| 'data.records.deleted'>` | ✅ | Event type |
 | **object** | `string` | ✅ | Object name |
+| **organizationId** | `string` | optional | Organization every record the predicate write affected belongs to — one organization for the whole batch, never per-row. Present = exactly that organization, asserted by the producer from the composed tenant wall, never fabricated and never the caller's active organization standing in for the rows'; the empty string is refused. Absent = the producer did not assert one organization for the batch (every event on a single-posture deployment; a system, environment-wide or cross-membership predicate write; any write whose affected rows are not known to belong to one organization) — deliberately NOT the DataEvent reading "belongs to no organization". A tenant-scoped consumer must treat an absent key as not attributable to its organization and must not deliver the event inside an organization wall; a deployment-wide consumer may use it. |
 | **matched** | `integer` | ✅ | Number of records affected |
 | **userId** | `string` | optional | User who triggered the event |
 | **timestamp** | `string` | ✅ | Event timestamp |

--- a/packages/spec/authorable-surface/api.json
+++ b/packages/spec/authorable-surface/api.json
@@ -279,6 +279,7 @@
     "api/BulkDataEvent:id",
     "api/BulkDataEvent:matched",
     "api/BulkDataEvent:object",
+    "api/BulkDataEvent:organizationId",
     "api/BulkDataEvent:timestamp",
     "api/BulkDataEvent:type",
     "api/BulkDataEvent:userId",

--- a/packages/spec/src/api/events.test.ts
+++ b/packages/spec/src/api/events.test.ts
@@ -4,6 +4,7 @@ import {
   DataEventType,
   MetadataEventSchema,
   DataEventSchema,
+  BulkDataEventSchema,
   type MetadataEventSubject,
 } from './events.zod';
 
@@ -245,10 +246,10 @@ describe('DataEventSchema', () => {
   // "declared = enforced" is a measurement rather than a sentence: the key is
   // optional and NOTHING else — no default fabricates a tenant, absence has
   // exactly one spelling, and a value that is not a non-empty string is
-  // refused at the path a producer can act on. `BulkDataEventSchema` is
-  // deliberately untouched here: a predicate write's affected set is a
-  // separate contract with its own tenant question (recorded on the change
-  // that adds this member), so nothing below pins that schema either way.
+  // refused at the path a producer can act on. `BulkDataEventSchema` carries
+  // the same key with a DIFFERENT absence reading — one organization for the
+  // whole batch, or "not asserted" — pinned in its own block below; the two
+  // blocks share the refusal pins so the key stays one spelling and one shape.
   describe('organizationId', () => {
     const base = {
       id: '4b4720e8-97c3-4a12-9b70-b70a3d2314a6',
@@ -300,6 +301,105 @@ describe('DataEventSchema', () => {
       expect(Object.keys(DataEventSchema.shape).sort()).toEqual([
         'after', 'before', 'changes', 'id', 'object', 'organizationId', 'recordId', 'timestamp', 'type', 'userId',
       ]);
+    });
+  });
+});
+
+describe('BulkDataEventSchema', () => {
+  // The bulk twin of the DataEvent tenant term. Same spelling, same refusal
+  // set, same optionality — and a deliberately DIFFERENT absence reading: a
+  // bulk event names no rows, so an absent key says the producer did not
+  // assert one organization for the batch, never "the rows belong to none".
+  // Present means ONE organization for the whole batch (never per-row, never a
+  // list), which is what keeps a tenant-scoped fan-out one comparison.
+  describe('organizationId', () => {
+    const base = {
+      id: '4b4720e8-97c3-4a12-9b70-b70a3d2314a7',
+      type: 'data.records.updated',
+      object: 'account',
+      matched: 40,
+      timestamp: '2026-09-04T00:00:00.000Z',
+    } as const;
+
+    it('parses without the key and does not fabricate one (absent = not asserted for the batch)', () => {
+      const event = BulkDataEventSchema.parse(base);
+      expect(Object.prototype.hasOwnProperty.call(event, 'organizationId')).toBe(false);
+      expect(event.organizationId).toBeUndefined();
+    });
+
+    it('parses with the key and carries the one batch organization through verbatim', () => {
+      const event = BulkDataEventSchema.parse({ ...base, organizationId: 'org_jia' });
+      expect(event.organizationId).toBe('org_jia');
+      expect(event.matched).toBe(40);
+    });
+
+    it('refuses a non-string value with invalid_type at ["organizationId"]', () => {
+      const result = BulkDataEventSchema.safeParse({ ...base, organizationId: 42 });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('unreachable');
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({ code: 'invalid_type', expected: 'string', path: ['organizationId'] }),
+      ]);
+    });
+
+    it('refuses null — "not asserted" has exactly one spelling, the missing key', () => {
+      const result = BulkDataEventSchema.safeParse({ ...base, organizationId: null });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('unreachable');
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({ code: 'invalid_type', expected: 'string', path: ['organizationId'] }),
+      ]);
+    });
+
+    it('refuses the empty string — one organization is never spelled ""', () => {
+      const result = BulkDataEventSchema.safeParse({ ...base, organizationId: '' });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('unreachable');
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({ code: 'too_small', minimum: 1, path: ['organizationId'] }),
+      ]);
+    });
+
+    it('refuses a per-row list — the batch carries one organization, never an array', () => {
+      const result = BulkDataEventSchema.safeParse({ ...base, organizationId: ['org_jia', 'org_yi'] });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('unreachable');
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({ code: 'invalid_type', expected: 'string', path: ['organizationId'] }),
+      ]);
+    });
+
+    it('is the only member added — every pre-existing member is still declared, and no plural spelling exists', () => {
+      expect(Object.keys(BulkDataEventSchema.shape).sort()).toEqual([
+        'id', 'matched', 'object', 'organizationId', 'timestamp', 'type', 'userId',
+      ]);
+      expect('organizationIds' in BulkDataEventSchema.shape).toBe(false);
+      expect('organizationIds' in DataEventSchema.shape).toBe(false);
+    });
+
+    it('spells and shapes the key identically to DataEventSchema.organizationId', () => {
+      // Structural identity of the two declarations: both optional, both a
+      // string with the same minimum-length check, so a consumer discriminates
+      // both event families on ONE key with ONE comparison.
+      const bulk = BulkDataEventSchema.shape.organizationId;
+      const single = DataEventSchema.shape.organizationId;
+      expect(bulk.def.type).toBe(single.def.type);
+      expect(bulk.def.type).toBe('optional');
+      expect(bulk.def.innerType.def.type).toBe(single.def.innerType.def.type);
+      expect(bulk.def.innerType.def.type).toBe('string');
+      expect(bulk.def.innerType.def.checks).toEqual(single.def.innerType.def.checks);
+      // And behaviourally: the same probes yield the same verdicts on both.
+      for (const probe of ['', null, 42, ['org_jia']]) {
+        const b = bulk.safeParse(probe);
+        const s = single.safeParse(probe);
+        expect(b.success).toBe(false);
+        expect(s.success).toBe(false);
+        if (b.success || s.success) throw new Error('unreachable');
+        expect(b.error.issues.map((i) => i.code)).toEqual(s.error.issues.map((i) => i.code));
+      }
+      expect(bulk.safeParse('org_jia')).toEqual(single.safeParse('org_jia'));
+      expect(bulk.safeParse(undefined).success).toBe(true);
+      expect(single.safeParse(undefined).success).toBe(true);
     });
   });
 });

--- a/packages/spec/src/api/events.zod.ts
+++ b/packages/spec/src/api/events.zod.ts
@@ -344,6 +344,14 @@ export type DataEvent = z.input<typeof DataEventSchema>;
  * external URL a webhook points at. The caller's own pre-composition filter is
  * no better: it is a second, divergent answer to "what did this write touch".
  * So the event reports the count it can state truthfully and stops there.
+ *
+ * **The tenant term is ONE organization for the whole batch, or nothing.**
+ * `organizationId` (below) names the organization every affected record
+ * belongs to. It is never per-row — a bulk event names no rows, so a per-row
+ * answer would have nothing to attach to — and never a list. That is what
+ * keeps a tenant-scoped fan-out one comparison, never a partition of the
+ * batch. Its ABSENCE means something different from the same key's absence on
+ * {@link DataEventSchema}; the member's own doc states both readings.
  */
 export const BulkDataEventSchema = lazySchema(() => z.object({
   /** Unique event identifier */
@@ -354,6 +362,62 @@ export const BulkDataEventSchema = lazySchema(() => z.object({
 
   /** Object name */
   object: z.string().describe('Object name'),
+
+  /**
+   * Organization every record the predicate write affected belongs to — ONE
+   * organization for the whole batch, never per-row and never a list. Same
+   * spelling, same refusal of the empty string, and the same position (beside
+   * the match term `object`) as {@link DataEventSchema}'s `organizationId`, so
+   * a tenant-scoped consumer discriminates both event families on one key.
+   *
+   * **One for the batch, by construction.** A predicate write reaches the
+   * driver with the middleware-COMPOSED query (see "Why there is no `where`"
+   * above): under a walled posture the security layer AND-composes its tenant
+   * wall (Layer 0, ADR-0095 D1) onto the caller's filter first — under
+   * `isolated` an equality on the caller's active organization, under `group`
+   * membership in the caller's organization set (ADR-0105 D2) — and nothing in
+   * Layer 1 (business RLS, sharing's editable-rows filter) can widen it. So
+   * when the wall names exactly one organization, every affected row belongs
+   * to it, and the producer can state that from what it already holds: no
+   * second query on the publish path.
+   *
+   * **Present = every affected record belongs to exactly this organization.**
+   * Never fabricated (no `.default()`, the empty string is refused), and never
+   * the caller's active organization standing in for the rows': under `group`
+   * the wall is the caller's membership SET, so the batch is attributable to
+   * one organization only when that set names exactly one.
+   *
+   * **Absent = the producer did not assert one organization for the batch.**
+   * Deliberately DIVERGENT from `DataEventSchema.organizationId`, whose absence
+   * means "this record belongs to no organization, not behind any wall". A
+   * bulk event names no rows, so its absence is a statement about the
+   * producer's knowledge, not about the rows: every event on a
+   * `single`-posture deployment (no wall); an environment-wide or system /
+   * unscoped predicate write (an `isSystem` context, a true `PLATFORM_ADMIN`
+   * crossing the wall); a `group`-posture sweep across several memberships;
+   * any write whose affected rows are not known to belong to one
+   * organization. It is NOT the single-record reading "belongs to no
+   * organization".
+   *
+   * **What a consumer may do with each reading.** A tenant-scoped consumer —
+   * a per-organization webhook subscription, a per-organization realtime
+   * subscriber — matches on equality when the key is present, and MUST treat
+   * an absent key as "not attributable to my organization": it must not
+   * deliver that event inside an organization wall. A deployment-wide consumer
+   * may use it. Either way the fan-out filter stays one comparison.
+   */
+  organizationId: z.string().min(1).optional().describe(
+    'Organization every record the predicate write affected belongs to — one organization '
+    + 'for the whole batch, never per-row. Present = exactly that organization, asserted by '
+    + 'the producer from the composed tenant wall, never fabricated and never the caller\'s '
+    + 'active organization standing in for the rows\'; the empty string is refused. '
+    + 'Absent = the producer did not assert one organization for the batch (every event on a '
+    + 'single-posture deployment; a system, environment-wide or cross-membership predicate '
+    + 'write; any write whose affected rows are not known to belong to one organization) — '
+    + 'deliberately NOT the DataEvent reading "belongs to no organization". A tenant-scoped '
+    + 'consumer must treat an absent key as not attributable to its organization and must '
+    + 'not deliver the event inside an organization wall; a deployment-wide consumer may use it.',
+  ),
 
   /**
    * Number of records the predicate write affected. The ObjectQL engine does


### PR DESCRIPTION
Fixes #14971

Contract half of the bulk path of the webhook cross-organization delivery defect: `BulkDataEventSchema` (`data.records.updated` / `data.records.deleted`, `packages/spec/src/api/events.zod.ts`) gains exactly one optional member, `organizationId: z.string().min(1).optional()`, the same spelling, position (beside the match term `object`) and empty-string refusal as `DataEventSchema.organizationId`, no `.default()`. `DataEventSchema` and `MetadataEventSchema` are untouched. The producer threading (`packages/objectql`, the `publishBulkDataEvent` site) and the fan-out filter (`packages/plugins/plugin-webhooks`) are separate cards owned by other lanes and are not touched here.

## Rulings applied (dispatch comment 5536212015 on #14971, quoted where operative)

- Shape, seat ruling: "**the bulk event carries ONE organization for the whole batch** — a new optional key `organizationId: z.string().min(1).optional()` on `BulkDataEventSchema`, the same spelling, position and refusal of the empty string as `DataEventSchema.organizationId`, no `.default()`. ⛔ No per-row array, no `organizationIds`, no second envelope, no change to `DataEventSchema`."
- Absence semantics, deliberately divergent from `DataEventSchema` and said so in the JSDoc: "**present = every record the predicate write affected belongs to exactly this organization, never fabricated, never the caller's organization as a substitute for the records'; absent = the producer did not assert one organization for the batch** … A bulk event names no rows, so absence is a statement about the producer's knowledge, not about the rows — ⛔ it is NOT the single-record reading 'belongs to no organization, not behind any wall'." The consumer sentence is stated in the JSDoc and the `.describe()`: a tenant-scoped consumer must treat an absent key as not attributable to its organization and must not deliver the event inside an organization wall; a deployment-wide consumer may use it. The fan-out filter therefore stays one comparison, never a partition.
- Triage (5535736661): the JSDoc states whether a batch's organization is one for the whole batch or per-row — it is one for the whole batch, never per-row, never a list.

## Premise check at the producer (verified before writing; `premise_still_valid: true`, with one qualification)

Premise as ruled: at `publishBulkDataEvent` the producer holds the execution context and the middleware-composed predicate and no rows; under a walled posture a tenant-scoped predicate write is row-scoped by the security layer to the caller's organization, so the affected rows belong to exactly one organization, while a system / unscoped predicate write cannot assert one.

Evidence face, all on `origin/main` at `919beca4` (BASE):

- `packages/objectql/src/engine.ts:11545` — the predicate branch calls `driver.updateMany(object, ast, …)` with the middleware-composed `ast`; `:11608-11612` / `:13062-13066` publish `data.records.updated|deleted` with `{ matched, context: opCtx.context }`; `publishBulkDataEvent` (`:5709`) validates with `BulkDataEventSchema.parse` and carries `userId` from the context — the context (`tenantId`, `accessible_org_ids`, `isSystem`, `packages/spec/src/kernel/execution-context.zod.ts:86,247,269`) is in hand, no rows are.
- `packages/plugins/plugin-security/src/security-plugin.ts` step 3 (`:3040-3055`): `computeRlsFilter(permissionSets, object, operation, context)` is AND-composed into `opCtx.ast` for every dispatch that carries an `ast` — its own comment measures the dispatch set as "`insert/update/delete` by-id (no ast) and bulk `update`/`delete` (with ast)". `computeRlsFilter` (`:5404-5422`) is `andComposeLayers(layer0, layer1)`, Layer 0 first (`:5704-5709`, from `context.tenantId` and `context.accessible_org_ids`).
- `packages/plugins/plugin-security/src/tenant-layer.ts:116-150` (`computeTenantLayer0Filter`): `isolated` → `{ organization_id: input.organizationId }` (strict equality on the caller's active organization; a missing active org → the deny sentinel); `group` → `{ organization_id: { $in: accessibleOrgIds } }` (the membership set; empty → deny); `single` → `null`; a true `PLATFORM_ADMIN` on a posture-permitting object → `null`. Layer 1 (business RLS, sharing's `buildWriteFilter` at `packages/plugins/plugin-sharing/src/sharing-service.ts:505-538`, an owner/depth/share narrowing) is AND-ed under Layer 0 and cannot widen it (ADR-0095 W1/W2, ADR-0105 D2/D4). `isSystem` contexts short-circuit the middleware (security-plugin.ts `:2873-2874`). The driver's native `tenantId` scope (`engine.ts:3683`, `organization_id = :tenant OR organization_id IS NULL`) is a second AND under the composed AST, so the strict equality above is what bounds an `isolated` write — NULL-organization rows are not reachable through it.
- Reading: on `isolated` the premise holds outright — every row a tenant caller's predicate write can touch carries the caller's active organization. On `group` (ADR-0105 D1/D2: "The active organization keeps its current meaning (default write target, UI context); it no longer bounds *read* reach in `group` posture — membership does"; the same Layer 0 governs writes here) the write is pinned to the caller's membership **set**, so the batch is attributable to one organization only when that set names exactly one; a multi-membership sweep is exactly ruling 3's third absence case ("any write whose affected rows are not known to belong to one organization"). The JSDoc states this qualification explicitly rather than leaving it to the producer.
- PR #14635's recorded open question 1 / recommendation A (read from its body): A leaves the bulk contract as is and defers "whether a bulk event without a tenant term is delivered to organization-scoped subscriptions at all" to the services half, calling the tenant question "a shape decision of its own, and nothing here pins it either way"; it rejects (B) a per-row `organizationIds` array and (C) the caller's active organization "which mislabels a group sweep". This change is that shape decision, taken by the owning lane, and rejects B and C on the same grounds — no conflict with A.

## What changed

- `packages/spec/src/api/events.zod.ts` — `BulkDataEventSchema` block only: one header paragraph (one organization for the whole batch, or nothing; cross-reference to `DataEventSchema`), the new member with its JSDoc (construction argument, present/absent readings, the consumer sentence, the `group` qualification) and `.describe()`. `git grep -c organizationId` on the file: 2 on BASE → 6 here (header, two JSDoc references, the declaration); control `git grep -c object` on the same file unchanged in kind (non-zero both sides).
- `packages/spec/src/api/events.test.ts` — new `describe('BulkDataEventSchema') › describe('organizationId')`, 8 pins: absent → not an own property and `undefined`; present → round-trips; `42` → `invalid_type` at `['organizationId']`; `null` → same; `''` → `too_small`, `minimum: 1`; a per-row array → `invalid_type` (the ruled-out shape); member set = exactly the six prior keys plus `organizationId`, and `organizationIds` on neither schema; structural + behavioural identity of the two `organizationId` declarations (`optional` over `string` with equal checks; the same probes yield the same issue codes on both). The stale "deliberately untouched" comment on the single-record block now points at the bulk block.
- Generated followers, regenerated by `check:generated --fix` (it proved exactly one artifact stale, `gen:docs`) and the `check:authorable-surface` tree: `content/docs/references/api/events.mdx` (+1 row), `packages/spec/authorable-surface/api.json` (+`api/BulkDataEvent:organizationId`). The json-schema manifest and the strictness-ledger counts were NOT stale (the manifest lists types, not members; the ledger counts strip sites) — the dispatch's assumption that they would be is falsified, harmlessly. `packages/spec/liveness/api.json` has no `BulkDataEvent` row and none is invented. `authorable-surface.base.json` untouched (manual-only anchor; `baseRev` lag is information).
- `.changeset/bulk-data-event-organization-id.md` — `@objectstack/spec: minor`. `.changeset/README.md` carries only the changesets boilerplate; the level follows the sibling precedent (`2aa8456c`, the additive `DataEvent.organizationId`, shipped `minor`) — an additive published key on a public payload.

`MetadataEventSchema` (read-and-report only, no edit): members `id, type, metadataType, name, packageId?, definition?, userId?, timestamp` — `definition` is the full item body. Producer `packages/metadata/src/metadata-manager.ts:696` passes no organization. Consumers: `packages/client/src/realtime-api.ts:107` (`subscribeMetadata`, deployment-wide SDK) and the client-react hooks; the webhook fan-out (`packages/plugins/plugin-webhooks/src/auto-enqueuer.ts:822-826,1010`) returns early for every type that is not `data.record.` / `data.records.`, so no per-organization consumer receives it today. No card filed (triage: not a claim).

## Measurements (head `9ffb659b`; exits captured before any pipe, verdict lines quoted; shared box, so ratios not wall-clock)

| Reading | Command | Verdict |
| --- | --- | --- |
| spec events pins | `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/api/events.test.ts` (locked) | `Tests 29 passed (29)` (21 prior + 8 new) |
| spec build | `pnpm --filter @objectstack/spec build` (locked) | `check-dts-emitted: @objectstack/spec - 34/34 declared declaration file(s) present.` |
| generated artifacts | `pnpm --filter @objectstack/spec check:generated --fix` then a clean run | `✗ 1 of 15 artifact(s) stale: content/docs/references/**` → `✓ gen:docs`; second run `✓ All 15 generated artifacts are up to date.` |
| spec `src/api` suite | `… exec vitest run --maxWorkers=2 src/api` (locked) | `Test Files 41 passed (41) · Tests 1349 passed (1349)` |
| `@objectstack/client` realtime | `… exec vitest run --maxWorkers=2 src/realtime-api` (locked) | `Test Files 2 passed (2) · Tests 22 passed (22)` |
| `@objectstack/client-react` | `typecheck` (exit 0, 0 `error TS`) + `… exec vitest run --maxWorkers=2 src/realtime-hooks` (locked) | `Tests 18 passed (18)` |
| `@objectstack/objectql` | `typecheck` (`tsc --noEmit && tsc -p tsconfig.scripts.json && check:test-typecheck`, exit 0, 0 errors; `engine-data-events.bench.ts` is inside `src/**/*`, not excluded) + `… exec vitest run --maxWorkers=2 src/engine-data-events.test.ts` (locked) | `Tests 17 passed (17)` |
| `@objectstack/plugin-webhooks` | `typecheck` (exit 0, 0 errors) + `… exec vitest run --maxWorkers=2 src/auto-enqueuer.test.ts` (locked) | `Tests 26 passed (26)` |
| spec `tsc --noEmit` (src program) | exit 0, 0 errors; `tsconfig.test.json --listFiles` lists `src/api/events.test.ts` (1 hit) and it carries 0 errors (the program's 261 pre-existing errors are the ledgered debt `check:test-typecheck` holds, green above) | measured |
| eslint on the two edited TS files | `npx eslint packages/spec/src/api/events.zod.ts packages/spec/src/api/events.test.ts` | exit 0 |
| dependency closure | turbo `build` of `@objectstack/objectql^...` + `objectql` (15 tasks, 0 cached), then `@objectstack/plugin-webhooks^...` + `client` + `plugin-webhooks` (34 tasks, 15 cached), then `client-react` — all locked | filter direction UPSTREAM (`pkg^...` = dependencies), built so the DOWNSTREAM consumers above read fresh `dist/*.d.ts` |
| derived gate farm | `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` at `9ffb659b` (5 paths vs merge base `919beca4`): 82 commands | 29 `node scripts/check-*` exit 0; 20 `pnpm --filter` spec/lint gates exit 0 (`check:skill-examples` first exit 1 for a missing `client-react/dist` prerequisite, exit 0 after that build: `✅ 257 prose examples type-check across 3 surface(s)`); 33 of 35 root `pnpm check:*` exit 0 — `check:nul-bytes` `OK (scanned 8262 text file(s) … no raw ASCII control bytes)`, `check:spec-parsed-alias` `OK`, `check:doc-authoring` `✓`, `check:system-context-census` `OK — 106 elevation read sites … all anchored` |
| NOT MEASURED (prerequisite exit 3, not red) | `pnpm check:dual-build-cjs-loads` ("Run `pnpm build` first. ⛔ This is NOT a pass: nothing was measured." — 27 packages without `dist`) and `pnpm check:type-check-debt` (needs every package's built declarations) | CI owns the farm |
| not run locally, declared | `pnpm lint` (repo-wide eslint, CI-owned); `check:react-declaration-parity` (needs objectui's manifest, by design) | CI |

## Reverse verification (ablation of the pins; source path — the spec suite imports `./events.zod` from `src`, no `dist` on its resolution path, so no rebuild is involved)

From the committed state (`7dfe65b8`, the member in HEAD): removed the bulk `organizationId` declaration; confirmed on disk by anchored counts (declaration spelling 2 → 1, the bulk describe text 1 → 0; blob `ea9532c0…` → `57b23d7a…`); ran `src/api/events.test.ts`: `Tests 7 failed | 22 passed (29)` — exactly the seven new pins that name the key went red (present round-trip, the four refusals, the member set, the cross-schema identity) and the absent-key pin stayed green, the predicted direction. Restore inside `trap … EXIT INT TERM` by `git checkout HEAD -- ABSOLUTE_PATH`, proven: `git hash-object` back to the HEAD blob `ea9532c0…`, `git diff HEAD` empty, tree clean.

## Contract review

Clause ② card (`needs:contract-review` on this PR and on #14971): a new key on a published event payload, plus an absence reading that deliberately diverges from its single-record sibling — both stated in the JSDoc for the reviewer's veto window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2oQebDDxYKfWZusyd8GXk)_