### PR TITLE
fix(plugin-security): the app default permission set resolves from `packages[]` (#15007)

### DIFF
--- a/.changeset/plugin-security-default-profile-packages-reader.md
+++ b/.changeset/plugin-security-default-profile-packages-reader.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): the app default permission set resolves from `packages[]`, not only the flattened top level (#15007)
+
+`appSecurityPluginOptions(config)` read `config.permissions` and nothing else.
+For a multi-package artifact under the ADR-0130 D4 option-B shape — where
+`packages[]` carries each definition exactly once and the flattened top-level
+copy is gone — that read returns `undefined`, the reader concludes "this app
+declared no default profile", and the boot continues. Nothing throws and
+nothing logs.
+
+That silence has a security posture attached. The name this resolves becomes
+the `SecurityPlugin`'s `fallbackPermissionSet`, i.e. the app's half of every
+authenticated human principal's additive baseline
+(`composeHumanBaselinePermissionSets`, ADR-0090 D5). Losing it does not deny
+anyone the boot — the deployment simply runs on the platform floor alone, and
+every member of a multi-package app quietly holds less access than the app
+declared for them. #7555 measured what that looks like from the outside: nav
+entries served, 403 behind them.
+
+The resolution now reads the flattened top level FIRST and then each package
+body, in the order `resolveArtifactPackageOrder` (`@objectstack/core`,
+ADR-0130 D4+D5) registers them:
+
+- **Every artifact the platform emits today answers bit-identically.** The
+  flattened level still answers first, so the `packages[]` pass can only supply
+  a set where the top level had none. This is the reader half of the ruled
+  order (readers first, emitter last, artifact stays additive throughout), so
+  it lands with no change to what any command emits.
+- **Order is the platform's one package order, not the array's.**
+  `appDefaultPermissionSetName` resolves the FIRST `isDefault` set, so with two
+  packages declaring one, "first" has to mean here what it means at every other
+  artifact reader: dependency-topological, so a package that extends another is
+  read after it whichever array slot it occupies.
+- **The singular `manifest` is still not consulted** (#7001 — the harness must
+  not honour a declaration `serve.ts` ignores). That is not a special case: an
+  artifact carrying no `packages` key makes `resolveArtifactPackageOrder`
+  return the caller's own object as the single package body, so that branch
+  reads `permissions` from exactly where the old code read it.
+- **A malformed `packages` is refused, not skipped.** A non-array `packages`,
+  an entry inlined instead of wrapped under `manifest:`, or a duplicate package
+  id raises the same ADR-0112 envelope (`code` + `status: 422`) the manifest
+  service raises when it registers that artifact. Catching it would resolve a
+  permission surface out of an artifact the loader refuses to load.
+
+Every boot path that already funnelled through this one function picks the fix
+up unchanged: `objectstack serve`'s artifact and from-source paths, and
+`@objectstack/verify`'s `bootStack` / RLS harness.

--- a/packages/cli/test/option-b-reader-acceptance.pin.test.ts
+++ b/packages/cli/test/option-b-reader-acceptance.pin.test.ts
@@ -143,7 +143,6 @@ const OPTION_B_LOSSES: readonly string[] = [
   'B2 · AppPlugin ql.setDatasourceMapping (object routing) (from source) · datasourceMapping',
   'B2 · AppPlugin seed datasets merged (from source) · data',
   'B2 · AppPlugin translation loading into the i18n service (from source) · translations',
-  'B2 · plugin-security appSecurityPluginOptions over the from-source config (default permission set) · permissions',
   'B2 · runtime collectBundleActions over the from-source config · actions + objects[].actions',
   'B2 · runtime collectBundleFunctionEntries over the from-source config · functions',
   'B2 · runtime collectBundleHooks over the from-source config · hooks',

--- a/packages/plugins/plugin-security/src/app-default-permission-set.test.ts
+++ b/packages/plugins/plugin-security/src/app-default-permission-set.test.ts
@@ -1,5 +1,11 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 import { describe, it, expect } from 'vitest';
+import {
+  AssembledPackageBodySchema,
+  ObjectStackDefinitionSchema,
+  composeStacks,
+  defineStack,
+} from '@objectstack/spec';
 import { appDefaultPermissionSetName, appSecurityPluginOptions } from './app-default-permission-set';
 import { SecurityPlugin } from './security-plugin';
 
@@ -98,5 +104,194 @@ describe('the resolved options reach the constructed plugin (#7001)', () => {
   it('and no declaration leaves the built-in member_default standing', async () => {
     await expect(initAndReadBaseline(new SecurityPlugin(appSecurityPluginOptions({}))))
       .resolves.toBe('member_default');
+  });
+});
+
+/**
+ * [ADR-0130 D4, #15007] The reader resolves `packages[]`.
+ *
+ * Reader card 4/4 of the option-B program ruled on #14512. A multi-package
+ * artifact carries each definition twice today — flattened at the top level and
+ * again under `packages[]` — and option B removes the flattened copy. Every
+ * assertion below is about the SAME declaration read out of both shapes, which
+ * is what "the artifact stays additive while the readers learn" means.
+ *
+ * The two shapes are built by the REAL composer (`composeStacks`, the one
+ * `examples/app-multi-package` uses) rather than hand-written, so a package
+ * entry that stopped looking the way this file assumes fails here instead of
+ * passing against a shape the platform never emits. The option-B shape is
+ * derived from it by stripping the package-owned keys — and that key set is
+ * read off the two schemas, never transcribed, so a collection family added to
+ * the stack schema next month is stripped too.
+ */
+describe('appSecurityPluginOptions over `packages[]` (ADR-0130 D4, #15007)', () => {
+  const CORE_ID = 'com.example.security.core';
+  const ADDON_ID = 'com.example.security.addon';
+  const CORE_PROFILE = 'core_member_default';
+  const ADDON_PROFILE = 'addon_member_default';
+
+  const shapeKeys = (schema: unknown): string[] =>
+    Object.keys((schema as { shape: Record<string, unknown> }).shape);
+
+  /** Exactly the keys an option-B artifact no longer carries at the top level. */
+  const PACKAGE_OWNED_KEYS: readonly string[] = (() => {
+    const body = new Set(shapeKeys(AssembledPackageBodySchema));
+    return shapeKeys(ObjectStackDefinitionSchema).filter((k) => body.has(k));
+  })();
+
+  const permissionSet = (name: string) => ({
+    name,
+    label: name,
+    isDefault: true,
+    objects: {},
+  });
+
+  const coreStack = () =>
+    defineStack({
+      manifest: {
+        id: CORE_ID, name: 'Security Probe Core', namespace: 'secprobe',
+        version: '1.0.0', type: 'app',
+      },
+      permissions: [permissionSet(CORE_PROFILE)],
+    });
+
+  /** Declared SECOND in composition order, and depends on the app package. */
+  const addonStack = () =>
+    defineStack({
+      manifest: {
+        id: ADDON_ID, name: 'Security Probe Addon', namespace: 'secprobe',
+        version: '1.0.0', type: 'module',
+        dependencies: { [CORE_ID]: '^1.0.0' },
+      },
+    });
+
+  /** Today's emitted shape: flattened top level PLUS `packages[]`. */
+  const additive = () => composeStacks([addonStack(), coreStack()], { manifest: 'preserve' });
+
+  /** The ruled shape: `packages[]` only. */
+  const optionB = () => {
+    const composed = additive() as unknown as Record<string, unknown>;
+    const owned = new Set(PACKAGE_OWNED_KEYS);
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(composed)) if (!owned.has(key)) out[key] = value;
+    return out;
+  };
+
+  it('CONTROL — the additive shape really does carry the flattened copy', () => {
+    // Without this, the option-B case below could pass because the fixture
+    // never had a flattened level to lose.
+    const composed = additive() as unknown as Record<string, unknown>;
+    expect(Array.isArray(composed.permissions)).toBe(true);
+    expect((composed.permissions as unknown[]).length).toBeGreaterThan(0);
+    expect((composed.packages as unknown[]).length).toBe(2);
+    expect(PACKAGE_OWNED_KEYS).toContain('permissions');
+  });
+
+  it('the additive shape answers exactly what it answered before this card', () => {
+    expect(appSecurityPluginOptions(additive())).toEqual({ fallbackPermissionSet: CORE_PROFILE });
+  });
+
+  it('OPTION B — the flattened level is gone and the packaged declaration is still resolved', () => {
+    const stripped = optionB();
+    expect(stripped.permissions).toBeUndefined();
+    expect((stripped.packages as unknown[]).length).toBe(2);
+
+    // The pre-#15007 reader returned `undefined` here — no throw, no log, and
+    // every member of the app silently down to the platform floor alone.
+    expect(appSecurityPluginOptions(stripped)).toEqual({ fallbackPermissionSet: CORE_PROFILE });
+  });
+
+  it('the flattened level still answers FIRST when both shapes carry a set', () => {
+    // The reader half lands while the artifact is still additive, so this
+    // function must be a superset of the old read and never a replacement:
+    // whatever the top level said, it still says.
+    expect(
+      appSecurityPluginOptions({
+        permissions: [permissionSet('flattened_wins')],
+        packages: [{ manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } }],
+      }),
+    ).toEqual({ fallbackPermissionSet: 'flattened_wins' });
+  });
+
+  it('package order is `resolveArtifactPackageOrder`\'s, not the array\'s', () => {
+    // Both packages declare an `isDefault` set and the DEPENDENT one is listed
+    // first. "The first isDefault set" has to mean the same thing here as at
+    // every other artifact reader, so the depended-upon package answers —
+    // dependency-topological order (ADR-0130 D5), not authoring accident.
+    expect(
+      appSecurityPluginOptions({
+        packages: [
+          { manifest: { id: ADDON_ID, name: 'Addon', version: '1.0.0', type: 'module', dependencies: { [CORE_ID]: '^1.0.0' }, permissions: [permissionSet(ADDON_PROFILE)] } },
+          { manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } },
+        ],
+      }),
+    ).toEqual({ fallbackPermissionSet: CORE_PROFILE });
+
+    // …and with the dependency edge removed, declared order is what is left.
+    expect(
+      appSecurityPluginOptions({
+        packages: [
+          { manifest: { id: ADDON_ID, name: 'Addon', version: '1.0.0', type: 'module', permissions: [permissionSet(ADDON_PROFILE)] } },
+          { manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } },
+        ],
+      }),
+    ).toEqual({ fallbackPermissionSet: ADDON_PROFILE });
+  });
+
+  it('a package that declares no default does not shadow one that does', () => {
+    expect(
+      appSecurityPluginOptions({
+        packages: [
+          { manifest: { id: ADDON_ID, name: 'Addon', version: '1.0.0', type: 'module', permissions: [{ name: 'addon_read_only', label: 'RO', objects: {} }] } },
+          { manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } },
+        ],
+      }),
+    ).toEqual({ fallbackPermissionSet: CORE_PROFILE });
+  });
+
+  it('an artifact with no `packages` key still reads the top level and NOTHING else', () => {
+    // D4's second branch hands `resolveArtifactPackageOrder` the caller's own
+    // object back as the single package body, so this path is the pre-#15007
+    // read exactly — including its refusal to look inside the singular
+    // `manifest` (#7001, pinned above).
+    expect(appSecurityPluginOptions({ manifest: { permissions: [permissionSet('buried')] } })).toBeUndefined();
+    expect(appSecurityPluginOptions({ packages: [] })).toBeUndefined();
+    expect(appSecurityPluginOptions({ permissions: [permissionSet('top')] })).toEqual({ fallbackPermissionSet: 'top' });
+  });
+
+  /**
+   * The gate travels with the read: `resolveArtifactPackageOrder` refuses a
+   * malformed `packages` with an ADR-0112 envelope, and this reader does not
+   * catch it. Swallowing it would resolve a permission surface out of an
+   * artifact the loader refuses to load.
+   */
+  describe('a malformed `packages` is refused, not silently skipped', () => {
+    const refusalOf = (config: unknown): { code?: string; status?: number; message?: string } => {
+      try {
+        appSecurityPluginOptions(config);
+        return {};
+      } catch (e) {
+        return e as { code?: string; status?: number; message?: string };
+      }
+    };
+
+    it('`packages` that is not an array', () => {
+      const err = refusalOf({ packages: 'nope' });
+      expect(err.code).toBe('INVALID_ARTIFACT_PACKAGES');
+      expect(err.status).toBe(422);
+    });
+
+    it('an entry inlined instead of wrapped under `manifest:`', () => {
+      const err = refusalOf({ packages: [{ id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] }] });
+      expect(err.code).toBe('INVALID_ARTIFACT_PACKAGE_ENTRY');
+      expect(err.status).toBe(422);
+    });
+
+    it('the same package id twice', () => {
+      const entry = { manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } };
+      const err = refusalOf({ packages: [entry, entry] });
+      expect(err.code).toBe('DUPLICATE_ARTIFACT_PACKAGE');
+      expect(err.status).toBe(422);
+    });
   });
 });

--- a/packages/plugins/plugin-security/src/app-default-permission-set.ts
+++ b/packages/plugins/plugin-security/src/app-default-permission-set.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
+import { resolveArtifactPackageOrder } from '@objectstack/core';
+
 /**
  * [ADR-0090 D5, #7555] The PLATFORM's own human baseline permission set.
  *
@@ -84,6 +86,83 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
 }
 
 /**
+ * [ADR-0130 D4, #15007] Every permission set a stack config DECLARES — from the
+ * flattened top level, and from `packages[]`.
+ *
+ * ## What this exists to stop
+ *
+ * A multi-package artifact carries each definition twice today: flattened onto
+ * the top level, and again inside `packages[i]`. Option B (the ADR-0130 D4
+ * ruling on #14512) removes the flattened copy, so `packages[]` carries it
+ * once. A reader that only ever looked at the top level does not fail when that
+ * happens — it reads `undefined`, finds no `isDefault` set, and answers "the app
+ * declared no default profile".
+ *
+ * For THIS reader that silence has a security posture attached. The name it
+ * resolves becomes the `SecurityPlugin`'s `fallbackPermissionSet`, i.e. the
+ * app's half of every authenticated human's additive baseline
+ * ({@link composeHumanBaselinePermissionSets}). Losing it does not deny the
+ * boot and does not log: the deployment simply runs on the platform floor
+ * alone, and every member of a multi-package app quietly holds less than the
+ * app declared they should. #7555 measured what that looks like from the
+ * outside — nav entries served, 403 behind them — and could only measure it
+ * because someone went looking.
+ *
+ * ## Top level FIRST, `packages[]` second — and why that order is the contract
+ *
+ * The reader half of the program lands while the artifact is still ADDITIVE, so
+ * this function has to be a superset of the old read rather than a replacement
+ * for it: for every artifact the platform emits today the flattened level
+ * answers first and this returns exactly what it returned before. The
+ * `packages[]` pass only supplies a set where the top level had none — which is
+ * precisely the option-B artifact. That is what makes this card revertible on
+ * its own and safe to land before the emitter half (#14512).
+ *
+ * ## The order is `resolveArtifactPackageOrder`'s, not the array's
+ *
+ * `appDefaultPermissionSetName` resolves the FIRST `isDefault` set, so with more
+ * than one package declaring one, "first" has to mean the same thing here as it
+ * does everywhere else the artifact is read. `resolveArtifactPackageOrder`
+ * (`@objectstack/core`, ADR-0130 D4+D5, #14643) is the ONE place that turns an
+ * artifact into its ordered package list — dependency-topological, so a package
+ * that extends another is read after it regardless of which array slot it
+ * occupies. ⛔ Do not iterate `config.packages` directly here; a second
+ * traversal is a second ordering, and the depended-upon package would win or
+ * lose by authoring accident.
+ *
+ * ## Two things it deliberately does NOT do
+ *
+ *   • It does not look inside the SINGULAR `manifest`. That constraint is
+ *     #7001's and it still holds — the harness must not honour a declaration
+ *     `serve.ts` ignores. Note this is not a special case bolted on: an
+ *     artifact carrying no `packages` key makes `resolveArtifactPackageOrder`
+ *     return the caller's own object as the single package body (D4's second
+ *     branch, D7's compatibility term), so that branch reads `permissions` from
+ *     exactly where the old code read it and nowhere else.
+ *   • It does not catch `resolveArtifactPackageOrder`'s refusals. A malformed
+ *     `packages` (not an array, an unwrapped entry, a duplicate package id)
+ *     raises an ADR-0112 envelope here, the same one the manifest service
+ *     raises when it registers that artifact moments later. Swallowing it would
+ *     resolve a permission surface out of an artifact the loader refuses to
+ *     load — the gate travels with the read.
+ */
+function declaredPermissionSets(config: unknown): unknown[] {
+  const sets: unknown[] = [];
+
+  const flattened = (config as { permissions?: unknown } | null | undefined)?.permissions;
+  if (Array.isArray(flattened)) sets.push(...flattened);
+
+  const packages = (config as { packages?: unknown } | null | undefined)?.packages;
+  if (packages === undefined || packages === null) return sets;
+
+  for (const body of resolveArtifactPackageOrder(config)) {
+    const declared = (body as { permissions?: unknown } | null | undefined)?.permissions;
+    if (Array.isArray(declared)) sets.push(...declared);
+  }
+  return sets;
+}
+
+/**
  * [#7001] The `SecurityPlugin` options a stack config implies — ONE resolution
  * for EVERY boot path.
  *
@@ -112,14 +191,13 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
  * the result straight through — `new SecurityPlugin(appSecurityPluginOptions(config))`
  * — and a caller cannot get the undefined case subtly wrong.
  *
- * Reads `config.permissions`, top-level, exactly as `serve.ts` always has.
- * Being cleverer here (also looking inside `manifest`) would re-open the gap it
- * closes, in the other direction.
+ * Reads the sets through {@link declaredPermissionSets} — the flattened top
+ * level `serve.ts` has always read, and, for a multi-package artifact, the
+ * `packages[]` bodies that carry the same declaration under ADR-0130 D4.
  */
 export function appSecurityPluginOptions(
   config: unknown,
 ): { fallbackPermissionSet: string } | undefined {
-  const permissions = (config as { permissions?: unknown } | null | undefined)?.permissions;
-  const name = appDefaultPermissionSetName(permissions);
+  const name = appDefaultPermissionSetName(declaredPermissionSets(config));
   return name ? { fallbackPermissionSet: name } : undefined;
 }


### PR DESCRIPTION
Fixes #15007

Reader card 4/4 of the ADR-0130 D4 option-B program ruled on #14512 (comment 5528589044). One reader, one line — and the one line both earlier enumerations missed, in a package neither had scoped.

## The defect

`appSecurityPluginOptions(config)` read `config.permissions` top-level and nothing else (`packages/plugins/plugin-security/src/app-default-permission-set.ts`). Under the option-B artifact shape — `packages[]` carrying each definition exactly once, the flattened top level gone — that read returns `undefined`, the reader concludes "this app declared no default profile", and the boot continues clean.

The name it resolves becomes the `SecurityPlugin`'s `fallbackPermissionSet`, i.e. the app's half of every authenticated human principal's additive baseline (`composeHumanBaselinePermissionSets`, ADR-0090 D5). Losing it denies nobody the boot: the deployment simply runs on the platform floor alone, and every member of a multi-package app quietly holds less than the app declared. #7555 measured what that looks like from outside — nav entries served, 403 behind them.

## The change

`declaredPermissionSets` reads the flattened top level FIRST, then each package body in `resolveArtifactPackageOrder` order (`@objectstack/core`, ADR-0130 D4+D5, since #14643).

- **Every artifact emitted today answers bit-identically.** The flattened level answers first, so the `packages[]` pass can only supply a set where the top level had none. The artifact stays additive; nothing about what any command emits moves. `composeStacks` and `packages/spec/src/stack.zod.ts` are untouched.
- **Order is the platform's one package order, not the array's.** `appDefaultPermissionSetName` resolves the FIRST `isDefault` set, so with two packages declaring one, "first" has to mean here what it means at every other artifact reader: dependency-topological, whichever array slot a package occupies. Pinned in both directions (with the edge, and without it).
- **The singular `manifest` is still not consulted** — the #7001 constraint, pinned by the existing test, holds unchanged. It is not a special case either: an artifact with no `packages` key makes `resolveArtifactPackageOrder` return the caller's own object as the single package body (D4's second branch), so that path is the old read exactly.
- **A malformed `packages` is refused, not skipped** — non-array, an entry inlined instead of wrapped under `manifest:`, or a duplicate package id raise the loader's own ADR-0112 envelope (`code` + `status: 422`), asserted by code and status. Catching it would resolve a permission surface out of an artifact the loader refuses to load.

Only `@objectstack/plugin-security` production code changes; `@objectstack/core` was already one of its dependencies and is already imported by five other modules in it.

## The ledger row deleted, and why it is earned

One row leaves `OPTION_B_LOSSES` in `packages/cli/test/option-b-reader-acceptance.pin.test.ts`:

```
B2 · plugin-security appSecurityPluginOptions over the from-source config (default permission set) · permissions
```

Measured, in this order, each leg with `@objectstack/plugin-security` REBUILT first (the cli suite resolves it through the workspace link to `dist/`, per `KNOWN_UNALIASED_TEST_IMPORTS`):

| Step | Pin result |
|:--|:--|
| before any edit, at `7bc5d37e4` | 6 passed — the ledger matches the measurement exactly |
| fix built into `dist/`, ledger untouched | 1 failed / 5 passed — `A ledgered subsystem now SEES its collections … Delete these lines`, naming that one row and no other |
| row deleted | 6 passed |
| **ablation** — source reverted to `7bc5d37e4`, rebuilt, row still deleted | 1 failed / 5 passed — `A subsystem lost a collection that the ledger does not carry`, `LOST … = none`, naming that one row |

The ablation is the discrimination: the row goes green because of this reader and nothing else. Both legs were rebuilt and each rebuild was proved to reach the artifact the suite consumes (`scripts/ablation-dist-preflight.mjs`, marker `resolveArtifactPackageOrder`: present in 2 built files after the fix, `absent from all 6 built files` under ablation, present again after restore). The mutation was proved on disk by blob identity before it was measured (`git hash-object` == the `7bc5d37e4` blob, != the `HEAD` blob; marker count 6 → 0), and the restore by a whole-tree `git status --porcelain` coming back empty.

⚠️ **The B1 sibling row stays, and is not this card's to delete.**

```
B1 · plugin-security appSecurityPluginOptions over the artifact-serve config (default permission set) · permissions
```

That row calls `appSecurityPluginOptions(createStandaloneStack(...))`. `createStandaloneStack` (`packages/runtime/src/standalone-stack.ts:807`) surfaces `permissions` from `artifactBundle.permissions` and does not surface `packages` at all, so under option B the object this reader receives carries neither the sets nor any way to reach them. No change inside `@objectstack/plugin-security` can turn it green.

It is downstream of card #15005, and it goes green the moment #15005 lands — the standalone result will carry `permissions` again and this reader's top-level branch answers, with no further edit here. **So #15005's PR should expect to delete TWO rows, not one**: its own `createStandaloneStack surfaced permissions` row and this B1 one. #15005 had NOT landed when this was measured (`origin/main` at `9c1bcda38`; the card is open, and `createStandaloneStack` still resolves no `packages[]`).

## The by-shape sweep the card requires

Re-run by SHAPE across all of `packages/`, never against a package list — the collection key set derived from `ObjectStackDefinitionSchema` ∩ `AssembledPackageBodySchema` (37 keys), four access shapes (identifier property access, destructuring, bracket, `this.`/`options.` members), plus two structural passes (every parameter typed as the stack; every site opening `objectstack.json` itself).

**It turned up two more packages, and they are filed as #15210 rather than folded in here**, per this card's instruction:

- `@objectstack/verify` — `derive.ts:176,180` (`config.objects`, `config.datasources`), `rls.ts:134` (`config.positions`), `rls.ts:346` (`config.objects`). Worth the reviewer's attention: under option B `os verify` derives zero CRUD cases and builds an EMPTY RLS probe permission set, i.e. it reports a green run having measured nothing.
- `@objectstack/plugin-dev` — `dev-plugin.ts:526` (`options.stack.translations`), so the `I18nServicePlugin` auto-detect never fires.

#15210 carries the full search, the triage of every false positive (`plugin-auth`'s `config.plugins`, `objectql`'s engine config, `service-analytics`'s service options, `metadata-protocol`'s view body, `metadata-core`'s authoring-time detector, and the `stack.KEY` spellings that are prose in `bootstrap-declared-*`), so the next sweep can be compared against this one rather than redone.

## Verification

- **Pin** — `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 test/option-b-reader-acceptance.pin.test.ts` → `Test Files 1 passed (1) · Tests 6 passed (6)` at `e99a3af7`, with the four-step table above behind it.
- **New unit coverage** — `packages/plugins/plugin-security/src/app-default-permission-set.test.ts`, `Tests 18 passed (18)` (was 8). The two shapes are built by the REAL `composeStacks` with `manifest: 'preserve'` and the option-B one derived by stripping the schema-derived package-owned keys, with a CONTROL asserting the additive shape really carries the flattened copy — so the option-B case cannot pass by having had nothing to lose.
- **Consumers of this reader, all green at `e99a3af7`** — `packages/runtime/src/standalone-stack.test.ts` 21/21, `packages/verify/src/harness.app-default-profile.test.ts` 6/6, `packages/cli/src/commands/serve-verify-security-parity.contract.test.ts` 16/16. These resolve `@objectstack/plugin-security` through `dist/`, so they ran against the rebuilt artifact.
- **Typecheck** — `pnpm --filter @objectstack/plugin-security typecheck` exit 0, including `check:test-typecheck` over `tsconfig.test.json`. Both edited files were confirmed IN that program by `tsc --listFiles` (1 hit each of 601 files) rather than inferred from the green.
- **Gate family** — all 46 commands from `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` at `e99a3af7`, re-derived unchanged after a fresh `git fetch origin main`. 46/46 green. Two first reported exit code 3, `PREREQUISITE NOT MET — nothing was measured` (`check:i18n` wanted the CLI build closure, `check:dual-build-cjs-loads` wanted 12 more `dist/`); both were re-run once the builds landed and both then measured and passed — `check:i18n` 9 packages all bundles in sync, `check:dual-build-cjs-loads` 102 require entry points across 66 packages.
- **Lint, NARROWED and declared** — `eslint --no-inline-config --format json` over the 4 changed paths: 4 files, 0 errors, 1 warning (the `.changeset/*.md`, "no matching configuration", i.e. not linted by design). The repo-wide scan is CI's: this config enables no type-aware linting (no `parserOptions.project`, no typed rules — stated at `eslint.config.mjs:328`), so this diff cannot move the verdict on any file it does not touch.
- **Not measured here, and left to CI:** the rest of the `@objectstack/plugin-security` suite and the full `@objectstack/cli` / `@objectstack/runtime` / `@objectstack/verify` suites. The shared verify lock was held by another agent's full `cli` vitest run for over 34 minutes across two 9-minute queue budgets, so those runs were narrowed to the test files that exercise this reader (`git grep` finds no other caller of `appSecurityPluginOptions` or `appDefaultPermissionSetName` inside `plugin-security` than the one test file). CI runs the farm regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m)_