### PR TITLE
fix(cli): resolve `packages[]` at the four config-load boundaries and the gates that key off `config.objects`

### DIFF
--- a/.changeset/cli-option-b-config-load-boundaries.md
+++ b/.changeset/cli-option-b-config-load-boundaries.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/cli": patch
+---
+
+fix(cli): `os serve` / `os dev` / `os build` / `os migrate` resolve `packages[]` when a stack carries no flattened top level
+
+The CLI holds four independent config-load boundaries, and every read of a
+package-owned collection behind them was an inline expression against the
+FLATTENED top level. A multi-package stack that carries each definition once
+under `packages[]` — the shape ADR-0130 D4's option B produces — reached those
+expressions with the key simply absent, and nothing threw:
+
+- `os serve` / `os dev` auto-register the ObjectQL engine and the storage driver
+  when the stack declares objects. Both gates read `config.objects`, so the app
+  booted with **no query engine and no storage driver** and reported healthy.
+  Nothing between the artifact and the gate could notice: the standalone stack
+  omits the `objects` key entirely when the array is absent rather than setting
+  `[]`, and the boot-config merge is a plain spread.
+- `os serve` auto-registers the i18n service plugin when the stack carries
+  translations. `translations` is package-owned while `i18n` is an envelope key a
+  translations-only stack never sets, so the REST i18n routes silently did not
+  exist.
+- `os dev` diffs the artifact's object inventory across recompiles to name a
+  newly added `*.object.ts`. It went permanently empty, so every recompile read
+  as all-green.
+- `os build` runs the author-time rule table twice — once over the union, once
+  per package. The per-package run already read `packages[]`; the union run,
+  which is the only one of the two that can see a finding spanning packages,
+  judged an empty stack and published green.
+
+All of them now resolve through one seam, in the dependency-topological order
+`resolveArtifactPackageOrder` gives. Each answer starts from the expression it
+replaced, so every stack that boots or builds today takes the identical branch —
+including a stack declaring an empty `objects: []`, which stays a stack that gets
+an engine — and `packages[]` is consulted only where the old read returned
+nothing. A malformed `packages` list is refused with its ADR-0112 envelope on
+that leg instead of resolving to the silent empty.
+
+The predicate `os serve` and `os migrate` each carried their own copy of — "does
+this config carry app metadata that needs an `AppPlugin` wrap" — is now one
+function. Measured, it does not lose under the new shape; it is folded in because
+it is the master gate for everything `AppPlugin` then reads.
+
+No command emits anything different: the compiled artifact still carries both
+copies, and the folded stack is a rule INPUT that reaches no writer.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -15,6 +15,7 @@ import {
 } from '@objectstack/spec';
 import { loadConfig } from '../utils/config.js';
 import { lowerCallables } from '../utils/lower-callables.js';
+import { authoringRuleUnionStack } from '../utils/stack-collections.js';
 import { buildAccessMatrix, diffAccessMatrix } from '@objectstack/lint';
 import { runAuthoringRules, splitBySeverity, authoringRulesFor } from '@objectstack/lint';
 import { resolveSduiManifest } from '../utils/sdui-manifest.js';
@@ -340,9 +341,24 @@ export default class Compile extends Command {
       //     is declared in `lint/authoring-rules.ts`. Do not add a call site here.
       const registered = authoringRulesFor('build');
       if (!flags.json) printStep(`Running author-time rules (${registered.length})...`);
+      //     [ADR-0130 D4 / option B, #15006] The UNION run judges the flattened
+      //     top level. Under option B that top level is gone — `packages[]`
+      //     carries every definition once — so this run's input would be an
+      //     EMPTY stack and `os build` would publish green having judged
+      //     nothing. `authoringRuleUnionStack` folds each absent collection
+      //     back in from `packages[]`, in `resolveArtifactPackageOrder`'s
+      //     dependency order. It changes what the rules JUDGE and nothing this
+      //     command EMITS: the artifact is written from `lowering.lowered` /
+      //     `result.data`, which this does not touch, and a stack that still
+      //     carries its collections is returned by identity.
+      //
+      //     The per-package run below needs no such fold — it already reads
+      //     `packages[]`. The union run is the only one of the two that can see
+      //     a finding spanning packages, which is exactly what an empty input
+      //     silently stops reporting.
       const findings = runAuthoringRules('build', {
-        normalized: normalized as Record<string, unknown>,
-        parsed: result.data as Record<string, unknown>,
+        normalized: authoringRuleUnionStack(normalized as Record<string, unknown>),
+        parsed: authoringRuleUnionStack(result.data as Record<string, unknown>),
         sduiManifest: resolveSduiManifest(),
       });
       const { errors: ruleErrors, advisories } = splitBySeverity(findings);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -17,6 +17,7 @@ import {
   formatMtimeGap,
 } from '../utils/dev-restart.js';
 import { childEnvWithResolvedArtifact } from '../utils/internal-artifact-channel.js';
+import { artifactObjectNames } from '../utils/stack-collections.js';
 import { readEnvWithDeprecation, isMcpServerEnabled } from '@objectstack/types';
 // The ONE port contract, shared with `start` and with the `serve` child this
 // command spawns (#12673). ⛔ Nothing about ports is declared in this file —
@@ -650,16 +651,16 @@ export default class Dev extends Command {
       // newly added *.object.ts is called out explicitly (15.1 third-party
       // eval: "recompiled" alone read as all-green while the new object's
       // table/seed sync was invisible to the user).
+      // [ADR-0130 D4 / option B, #15006] The envelope unwrap and the object
+      // read are `artifactObjectNames` — one of this package's four reads of a
+      // PACKAGE-OWNED collection, and the only one whose loss is non-fatal: with
+      // the flattened top level gone this inventory went permanently EMPTY, so
+      // `os dev` stopped naming a newly added *.object.ts and every recompile
+      // read as all-green. The file read and the `null`-on-failure contract stay
+      // here; the seam is what the acceptance probe can call.
       const readArtifactObjects = (): Set<string> | null => {
         try {
-          const raw = JSON.parse(fs.readFileSync(opts.artifactPath, 'utf8'));
-          const meta = raw?.metadata ?? raw?.data?.metadata ?? raw;
-          const objects = Array.isArray(meta?.objects) ? meta.objects : [];
-          return new Set(
-            objects
-              .map((o: any) => o?.name)
-              .filter((n: any): n is string => typeof n === 'string'),
-          );
+          return new Set(artifactObjectNames(JSON.parse(fs.readFileSync(opts.artifactPath, 'utf8'))));
         } catch {
           return null;
         }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -63,6 +63,17 @@ import {
 } from '../utils/port-contract.js';
 import { BootLogCapture, isVerboseBootLevel } from '../utils/boot-log-capture.js';
 import { graftAuthoredRuntimeMembers, isAppPluginLike } from '../utils/graft-runtime-hooks.js';
+// [ADR-0130 D4 / option B, #15006] Every read below that keys off a
+// PACKAGE-OWNED collection goes through this seam, so an option-B artifact
+// (flattened top level gone, `packages[]` carrying everything once) reaches
+// the same decision — and so the acceptance probe can CALL the decision
+// instead of re-implementing it.
+import {
+  shouldAutoRegisterObjectQL,
+  shouldAutoRegisterStorageDriver,
+  stackDeclaresMetadata,
+  bundleDeclaresTranslations,
+} from '../utils/stack-collections.js';
 import { redactConnectionUrl, describeDriverConnection } from '../utils/connection-display.js';
 // The posture prose `os serve` and `os doctor` BOTH print, declared once
 // (#12492) — and, since #12579, the multi-org runtime SPELLING those two
@@ -2628,8 +2639,12 @@ export default class Serve extends Command {
       }
 
       // 1. Auto-register ObjectQL Plugin if objects define but plugins missing
-      const hasObjectQL = plugins.some((p: any) => p.name?.includes('objectql') || p.constructor?.name?.includes('ObjectQL'));
-      if (config.objects && !hasObjectQL) {
+      // [#15006] The whole gate — the `objects` read AND the already-composed
+      // check — is `shouldAutoRegisterObjectQL`. It answers exactly as the two
+      // inline expressions did for every stack that boots today, and resolves
+      // `packages[]` when the flattened top level is absent, which is the shape
+      // that used to boot with NO QUERY ENGINE and throw nothing.
+      if (shouldAutoRegisterObjectQL(config, plugins)) {
          try {
            const { ObjectQLPlugin } = await import('@objectstack/objectql');
            await kernel.use(new ObjectQLPlugin());
@@ -2661,12 +2676,9 @@ export default class Serve extends Command {
       // at boot through the datasource connection service, so building a
       // storage driver here would construct a duplicate pool the engine then
       // discards as already-registered.
-      const hasDriver = plugins.some((p: any) =>
-        p.name?.includes('driver') ||
-        p.constructor?.name?.includes('Driver') ||
-        p.name === 'com.objectstack.runtime.default-datasource' ||
-        p.constructor?.name === 'DefaultDatasourcePlugin');
-      if (!hasDriver && config.objects) {
+      // [#15006] Same seam, same reason — see the ObjectQL gate above. The
+      // driver-provider duck-typing moved into it with the read it guards.
+      if (shouldAutoRegisterStorageDriver(config, plugins)) {
          const databaseUrl = process.env.OS_DATABASE_URL;
          const driverType = resolveDriverType(process.env.OS_DATABASE_DRIVER, databaseUrl);
          // libSQL/Turso's credential is the only one that does NOT ride inside the
@@ -2799,9 +2811,10 @@ export default class Serve extends Command {
       // already holds an AppPlugin instance — and never on a named app, so it
       // is checked structurally below.
       const hasAppPluginAlready = plugins.some(isAppPluginLike);
-      const configHasMetadata = !!(
-        config.objects || config.manifest || config.apps || config.flows || config.apis
-      );
+      // [#15006] The same predicate `schema-migration-plugins.ts` runs after its
+      // own second `loadConfig` (B4) — folded into one seam rather than left as
+      // two copies whose comment already said they were the same.
+      const configHasMetadata = stackDeclaresMetadata(config);
 
       // ── Decide the dev-only artifact door BEFORE the wrap (#14397) ────
       // On a HOST config `os dev` composes TWO writers over ONE stack: the
@@ -2973,24 +2986,19 @@ export default class Serve extends Command {
       // `plugins` array — a host/aggregator config may define no translations
       // of its own and instead compose several `new AppPlugin(...)` entries,
       // each carrying its own. Keyed on that shape, not on a named app.
-      const pluginBundleHasTranslations = (bundle: any): boolean => {
-        if (!bundle || typeof bundle !== 'object') return false;
-        if (Array.isArray(bundle.translations) && bundle.translations.length > 0) return true;
-        if (bundle.i18n) return true;
-        if (bundle.manifest && (
-          (Array.isArray(bundle.manifest.translations) && bundle.manifest.translations.length > 0)
-          || bundle.manifest.i18n
-        )) return true;
-        return false;
-      };
+      // [#15006] `bundleDeclaresTranslations` is that same shape-keyed check plus
+      // the `packages[]` leg: `translations` is package-owned and `i18n` is an
+      // envelope key a translations-only stack never sets, so an option-B artifact
+      // reached this gate with neither and the REST i18n routes silently did not
+      // exist. MEASURED on the acceptance probe, not inferred.
       const anyAppPluginHasTranslations = plugins.some((p: any) => {
         if (!p) return false;
         // AppPlugin instances expose their bundle on `.bundle`
-        if (p.bundle && pluginBundleHasTranslations(p.bundle)) return true;
+        if (p.bundle && bundleDeclaresTranslations(p.bundle)) return true;
         return false;
       });
       const configHasTranslations = (
-        pluginBundleHasTranslations(config)
+        bundleDeclaresTranslations(config)
         || anyAppPluginHasTranslations
       );
       if (!hasI18nPlugin && configHasTranslations && tierEnabled('i18n')) {

--- a/packages/cli/src/utils/schema-migration-plugins.ts
+++ b/packages/cli/src/utils/schema-migration-plugins.ts
@@ -3,6 +3,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { isAppPluginLike } from './graft-runtime-hooks.js';
+import { stackDeclaresMetadata } from './stack-collections.js';
 
 /**
  * The object set a SCHEMA migration is planned against (#12938).
@@ -1091,9 +1092,11 @@ export async function buildSchemaMigrationPlugins(opts: {
       // top-level metadata needs the wrap, or its `objects` never reach the
       // registry and this composition would report a set smaller than the one
       // the deployment serves.
-      const configHasMetadata = !!(
-        config?.objects || config?.manifest || config?.apps || config?.flows || config?.apis
-      );
+      // [#15006] `stackDeclaresMetadata` — the SAME seam `serve.ts` step 3 now
+      // calls, which is what the comment above already asserted about these two
+      // copies. B4 is this command's OWN second `loadConfig`, not behind B2, so
+      // it had to be reached separately.
+      const configHasMetadata = stackDeclaresMetadata(config);
       const appAlready = hasArtifactApp || hostPlugins.some(isAppPluginLike);
       if (configHasMetadata && !appAlready) {
         const { AppPlugin } = await import('@objectstack/runtime');

--- a/packages/cli/src/utils/stack-collections.test.ts
+++ b/packages/cli/src/utils/stack-collections.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Unit contract for the option-B collection seam (#15006).
+ *
+ * The acceptance probe (`test/option-b-reader-acceptance.pin.test.ts`) measures
+ * these same functions over the real two-package zoo; this file pins the edges
+ * that fixture has no reason to carry — an EMPTY `objects` array, an already
+ * composed engine or driver, a malformed `packages` list — and the one property
+ * that makes the whole seam safe to land: for every stack the platform emits
+ * today, the answer is byte-for-byte the expression it replaced.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  artifactObjectNames,
+  authoringRuleUnionStack,
+  bundleDeclaresTranslations,
+  resolveStackCollection,
+  shouldAutoRegisterObjectQL,
+  shouldAutoRegisterStorageDriver,
+  stackDeclaresMetadata,
+} from './stack-collections.js';
+
+/**
+ * A schema-valid object and manifest. `resolveArtifactPackageOrder` parses every
+ * `packages[]` entry WHOLE (`ArtifactPackageSchema`), so a shorthand body here
+ * would fail on the entry gate rather than on the behaviour under test — which
+ * is itself worth knowing: the seam inherits that gate, and these fixtures are
+ * what a real composed package body looks like.
+ */
+const PROBE_OBJECT = {
+  name: 'probe_account',
+  label: 'Probe Account',
+  sharingModel: 'private' as const,
+  fields: { name: { name: 'name', type: 'text' as const, label: 'Name' } },
+};
+const ORDER_OBJECT = {
+  name: 'probe_order',
+  label: 'Probe Order',
+  sharingModel: 'private' as const,
+  fields: { name: { name: 'name', type: 'text' as const, label: 'Number' } },
+};
+const CORE_MANIFEST = {
+  id: 'com.example.probe.core',
+  name: 'Probe Core',
+  version: '1.0.0',
+  type: 'app' as const,
+};
+const TRANSLATIONS = [{ en: { objects: { probe_account: { label: 'Probe Account (translated)' } } } }];
+
+/** Today's shape: collections flattened to the top level AND `packages[]`. */
+const additive = () => ({
+  manifest: CORE_MANIFEST,
+  objects: [PROBE_OBJECT],
+  translations: TRANSLATIONS,
+  packages: [{ manifest: { ...CORE_MANIFEST, objects: [PROBE_OBJECT], translations: TRANSLATIONS } }],
+});
+
+/** The ruled option-B shape: the flattened top level gone. */
+const optionB = () => ({
+  manifest: CORE_MANIFEST,
+  packages: [{ manifest: { ...CORE_MANIFEST, objects: [PROBE_OBJECT], translations: TRANSLATIONS } }],
+});
+
+describe('#15006 — the auto-registration gates answer the same on BOTH shapes', () => {
+  it('registers the engine and the driver on today\'s additive shape', () => {
+    expect(shouldAutoRegisterObjectQL(additive(), [])).toBe(true);
+    expect(shouldAutoRegisterStorageDriver(additive(), [])).toBe(true);
+  });
+
+  it('registers them on the option-B shape, where the old expression read `undefined`', () => {
+    // The whole card in one assertion: before the seam this config booted with
+    // NO query engine and NO storage driver, having thrown nothing.
+    expect((optionB() as Record<string, unknown>).objects).toBeUndefined();
+    expect(shouldAutoRegisterObjectQL(optionB(), [])).toBe(true);
+    expect(shouldAutoRegisterStorageDriver(optionB(), [])).toBe(true);
+  });
+
+  it('stands down when the composition already carries the plugin', () => {
+    expect(shouldAutoRegisterObjectQL(additive(), [{ name: 'com.objectstack.engine.objectql' }])).toBe(false);
+    expect(shouldAutoRegisterStorageDriver(
+      additive(),
+      [{ name: 'com.objectstack.runtime.default-datasource' }],
+    )).toBe(false);
+    // Keyed on the constructor name too — an instance need not carry `name`.
+    class ObjectQLPlugin {}
+    class DefaultDatasourcePlugin {}
+    expect(shouldAutoRegisterObjectQL(additive(), [new ObjectQLPlugin()])).toBe(false);
+    expect(shouldAutoRegisterStorageDriver(additive(), [new DefaultDatasourcePlugin()])).toBe(false);
+  });
+
+  it('keeps the old truthiness for an EMPTY top-level `objects` array', () => {
+    // `config.objects &&` is truthy for `[]`, so a stack declaring no objects
+    // still got an engine and a driver. Re-expressing the gate as
+    // `resolve(...).length > 0` would have silently stopped doing that —
+    // reintroducing "boots with no query engine" in a different case. The old
+    // answer is preserved deliberately, not endorsed.
+    const empty = { ...additive(), objects: [] as unknown[] };
+    expect(shouldAutoRegisterObjectQL(empty, [])).toBe(true);
+    expect(shouldAutoRegisterStorageDriver(empty, [])).toBe(true);
+  });
+
+  it('says no when nothing anywhere declares an object', () => {
+    expect(shouldAutoRegisterObjectQL({ manifest: { id: 'x', name: 'x' } }, [])).toBe(false);
+    expect(shouldAutoRegisterStorageDriver({}, [])).toBe(false);
+    expect(shouldAutoRegisterObjectQL(undefined, [])).toBe(false);
+  });
+});
+
+describe('#15006 — resolveStackCollection', () => {
+  it('returns the top-level array whenever the key is present, without unioning `packages[]`', () => {
+    // Today's additive artifact carries every definition TWICE. Unioning both
+    // copies would double every item, so the top level — which composition
+    // already flattened into the union — wins by presence.
+    expect(resolveStackCollection(additive(), 'objects')).toHaveLength(1);
+  });
+
+  it('concatenates across packages when the top level does not carry the key', () => {
+    expect(resolveStackCollection(optionB(), 'objects')).toEqual([PROBE_OBJECT]);
+    expect(resolveStackCollection(optionB(), 'jobs')).toEqual([]);
+  });
+
+  it('refuses a malformed `packages` loudly, and only on the leg that reaches it', () => {
+    const broken = { packages: [{ notAManifestWrapper: true }] };
+    // The top level answers first, so a stack that boots today never reaches
+    // the refusal — this is what makes the seam additive.
+    expect(resolveStackCollection({ ...broken, objects: [PROBE_OBJECT] }, 'objects')).toHaveLength(1);
+    // With nothing at the top level, the ADR-0112 envelope is the right answer:
+    // the alternative is the silent empty this card exists to remove.
+    let raised: unknown;
+    try {
+      resolveStackCollection(broken, 'objects');
+    } catch (e) {
+      raised = e;
+    }
+    expect((raised as { code?: string } | undefined)?.code).toBe('INVALID_ARTIFACT_PACKAGE_ENTRY');
+    expect((raised as { status?: number } | undefined)?.status).toBe(422);
+  });
+});
+
+describe('#15006 — the wrap gate and the i18n gate', () => {
+  it('keeps the AppPlugin wrap on both shapes', () => {
+    expect(stackDeclaresMetadata(additive())).toBe(true);
+    // MEASURED, not assumed: `manifest` is an artifact-ENVELOPE key, so this
+    // predicate survives option B on its own. It is folded into the seam for
+    // the other two reasons — one predicate for `serve` and `migrate`, and a
+    // callable the probe can watch.
+    expect(stackDeclaresMetadata(optionB())).toBe(true);
+    expect(stackDeclaresMetadata({ packages: [{ manifest: { ...CORE_MANIFEST, objects: [PROBE_OBJECT] } }] }))
+      .toBe(true);
+    expect(stackDeclaresMetadata({ plugins: [] })).toBe(false);
+  });
+
+  it('auto-registers i18n on both shapes — this one DID lose', () => {
+    expect(bundleDeclaresTranslations(additive())).toBe(true);
+    expect(bundleDeclaresTranslations(optionB())).toBe(true);
+    expect(bundleDeclaresTranslations({ manifest: { id: 'a' } })).toBe(false);
+    // The nested-bundle shape a host/aggregator config composes.
+    expect(bundleDeclaresTranslations({ manifest: { translations: [{ en: {} }] } })).toBe(true);
+    expect(bundleDeclaresTranslations({ i18n: { defaultLocale: 'en' } })).toBe(true);
+  });
+});
+
+describe('#15006 — the `os dev` object inventory', () => {
+  it('unwraps the envelope and resolves both shapes', () => {
+    expect(artifactObjectNames(additive())).toEqual(['probe_account']);
+    expect(artifactObjectNames(optionB())).toEqual(['probe_account']);
+    expect(artifactObjectNames({ metadata: optionB() })).toEqual(['probe_account']);
+    expect(artifactObjectNames({ data: { metadata: optionB() } })).toEqual(['probe_account']);
+  });
+
+  it('answers empty rather than throwing for an artifact carrying nothing', () => {
+    expect(artifactObjectNames({})).toEqual([]);
+    expect(artifactObjectNames(null)).toEqual([]);
+  });
+});
+
+describe('#15006 — the union author-time rule input', () => {
+  it('returns a stack that still carries its collections BY IDENTITY', () => {
+    // `os build` on every stack the platform emits today must reach the rule
+    // table with exactly the object it reaches it with now.
+    const stack = additive();
+    expect(authoringRuleUnionStack(stack)).toBe(stack);
+    const noPackages = { objects: [PROBE_OBJECT] };
+    expect(authoringRuleUnionStack(noPackages)).toBe(noPackages);
+  });
+
+  it('folds every absent collection back in from `packages[]`', () => {
+    const folded = authoringRuleUnionStack(optionB() as Record<string, unknown>);
+    expect(folded.objects).toEqual([PROBE_OBJECT]);
+    expect(folded.translations).toHaveLength(1);
+    // The envelope keys are untouched — the fold adds collections, it does not
+    // rewrite the artifact's identity.
+    expect(folded.manifest).toEqual(optionB().manifest);
+    expect(folded.packages).toEqual(optionB().packages);
+  });
+
+  it('folds `functions`, the one collection carried as a record', () => {
+    const stack = {
+      manifest: CORE_MANIFEST,
+      packages: [
+        {
+          manifest: {
+            ...CORE_MANIFEST,
+            functions: { probeSweep: { handler: () => undefined, effect: 'writes' } },
+          },
+        },
+        {
+          manifest: {
+            ...CORE_MANIFEST, id: 'com.example.probe.other', name: 'Probe Other', type: 'module' as const,
+            functions: { probeOther: { handler: () => undefined, effect: 'pure' } },
+          },
+        },
+      ],
+    };
+    const folded = authoringRuleUnionStack(stack as Record<string, unknown>);
+    expect(Object.keys(folded.functions as Record<string, unknown>).sort())
+      .toEqual(['probeOther', 'probeSweep']);
+  });
+
+  it('concatenates in `resolveArtifactPackageOrder` order, not array order', () => {
+    // The dependent package is listed FIRST; the topological sort must still
+    // put the package it depends on ahead of it.
+    const stack = {
+      manifest: CORE_MANIFEST,
+      packages: [
+        {
+          manifest: {
+            id: 'com.example.orders', name: 'Orders', version: '1.0.0', type: 'module' as const,
+            dependencies: { 'com.example.core': '^1.0.0' },
+            objects: [ORDER_OBJECT],
+          },
+        },
+        {
+          manifest: {
+            id: 'com.example.core', name: 'Core', version: '1.0.0', type: 'app' as const,
+            objects: [PROBE_OBJECT],
+          },
+        },
+      ],
+    };
+    const folded = authoringRuleUnionStack(stack as Record<string, unknown>);
+    expect((folded.objects as Array<{ name: string }>).map((o) => o.name))
+      .toEqual(['probe_account', 'probe_order']);
+  });
+});

--- a/packages/cli/src/utils/stack-collections.ts
+++ b/packages/cli/src/utils/stack-collections.ts
@@ -104,19 +104,29 @@ function packageBodies(stack: unknown): Bag[] {
 }
 
 /**
- * One collection, concatenated across `packages[]` in dependency order.
+ * One collection, concatenated across already-resolved bodies.
  *
  * ⚠️ The TOP LEVEL IS NOT CONSULTED — this is the option-B leg only. Callers
  * that must preserve today's answer read their own expression first; see
  * {@link resolveStackCollection} for the combined form.
+ *
+ * Takes the BODIES rather than the stack so a caller asking about several keys
+ * resolves the package list once. `resolveArtifactPackageOrder` parses every
+ * entry whole, and `authoringRuleUnionStack` asks about all 37 collections —
+ * re-resolving per key would run that parse 37 times on every `os build`.
  */
-function packageCollection(stack: unknown, key: string): unknown[] {
+function collectFrom(bodies: readonly Bag[], key: string): unknown[] {
   const out: unknown[] = [];
-  for (const body of packageBodies(stack)) {
+  for (const body of bodies) {
     const value = body[key];
     if (Array.isArray(value)) out.push(...value);
   }
   return out;
+}
+
+/** {@link collectFrom} for a caller that has a stack and asks about one key. */
+function packageCollection(stack: unknown, key: string): unknown[] {
+  return collectFrom(packageBodies(stack), key);
 }
 
 /**
@@ -210,8 +220,9 @@ export function shouldAutoRegisterStorageDriver(stack: unknown, plugins: readonl
 export function stackDeclaresMetadata(stack: unknown): boolean {
   const bag = asBag(stack);
   if (bag?.objects || bag?.manifest || bag?.apps || bag?.flows || bag?.apis) return true;
+  const bodies = packageBodies(stack);
   return ['objects', 'apps', 'flows', 'apis']
-    .some((key) => packageCollection(stack, key).length > 0);
+    .some((key) => collectFrom(bodies, key).length > 0);
 }
 
 /**
@@ -237,8 +248,9 @@ export function bundleDeclaresTranslations(bundle: unknown): boolean {
   if (manifest && ((Array.isArray(manifest.translations) && manifest.translations.length > 0) || manifest.i18n)) {
     return true;
   }
-  if (packageCollection(bundle, 'translations').length > 0) return true;
-  return packageBodies(bundle).some((body) => !!body.i18n);
+  const bodies = packageBodies(bundle);
+  if (collectFrom(bodies, 'translations').length > 0) return true;
+  return bodies.some((body) => !!body.i18n);
 }
 
 /**
@@ -348,7 +360,7 @@ export function authoringRuleUnionStack<T extends Bag>(stack: T): T {
   let folded: Bag | undefined;
   for (const key of packageOwnedCollectionKeys()) {
     if (stack[key] !== undefined && stack[key] !== null) continue;
-    const items = packageCollection(stack, key);
+    const items = collectFrom(bodies, key);
     if (items.length > 0) {
       folded ??= { ...stack };
       folded[key] = items;

--- a/packages/cli/src/utils/stack-collections.ts
+++ b/packages/cli/src/utils/stack-collections.ts
@@ -1,0 +1,369 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ADR-0130 D4 / option B — the ONE place `@objectstack/cli` resolves a
+ * package-owned collection off a stack, whatever shape that stack arrived in.
+ *
+ * ## The failure this module exists to remove
+ *
+ * A multi-package artifact today serializes every definition TWICE: flattened
+ * to the top level, and again inside `packages[i].manifest`. Option B (ruled on
+ * #14512 comment 5528589044, maintainer 2026-09-03) removes the flattened copy,
+ * so `packages[]` carries each definition exactly once. The ruled order is
+ * READERS FIRST, emitter last: every reader learns to resolve `packages[]`
+ * while the artifact stays additive.
+ *
+ * This package holds FOUR independent config-load boundaries (#14512 comment
+ * 5523741937) — `os serve`/`os dev`'s `bundleRequire` (B2), `os build`'s
+ * `loadConfig` (B3), `os migrate`'s own second `loadConfig` (B4), and the
+ * artifact `dev.ts` re-opens for its recompile diff. Each of them then drives
+ * reads that were, until this module, INLINE EXPRESSIONS inside oclif command
+ * bodies. Two of those are the sharpest silent failures in the whole program:
+ *
+ * ```ts
+ * if (config.objects && !hasObjectQL) { … }   // serve.ts — ObjectQL engine
+ * if (!hasDriver && config.objects)  { … }    // serve.ts — storage driver
+ * ```
+ *
+ * With the flattened top level gone, `config.objects` is `undefined`, both
+ * gates are simply false, and the app boots **with no query engine and no
+ * storage driver, having thrown nothing**. `createStandaloneStack`
+ * (`standalone-stack.ts`) OMITS the `objects` key entirely when the array is
+ * absent — not `[]` — and `mergeBootConfig` is a plain spread, so nothing
+ * between the artifact and the gate can notice.
+ *
+ * ## Why a module, and not six one-line fixes
+ *
+ * Two reasons, and the second is the load-bearing one.
+ *
+ * 1. One resolution rule, declared once. Six inline reads are six chances to
+ *    write a seventh spelling of it.
+ * 2. **A pin can only attach to a callable.** The acceptance probe
+ *    (`test/option-b-reader-acceptance.pin.test.ts`, #15004) measures readers
+ *    by CALLING them; an expression inside a 6,000-line command body is
+ *    reachable only by running the command, which is why those four reads sat
+ *    outside the probe's 24-row ledger while every runtime and plugin-security
+ *    reader sat inside it (#15006 comment 5530257178). The exports below are
+ *    that seam. ⛔ Note what the probe may NOT do instead: assert
+ *    `config.objects` is non-empty on an option-B config. A row shaped like the
+ *    read it watches stays red after that read is fixed, and a gate that cannot
+ *    go green gets deleted. The rows call THESE functions.
+ *
+ * ## The resolution rule, and why it is strictly additive
+ *
+ * Every predicate here answers with the CALLER'S ORIGINAL EXPRESSION FIRST and
+ * only then consults `packages[]`:
+ *
+ * ```ts
+ * if (stack.objects) return true;                       // byte-identical to the old gate
+ * return packageCollection(stack, 'objects').length > 0; // the option-B leg, new
+ * ```
+ *
+ * That ordering is not stylistic. `config.objects` is truthy for an EMPTY array
+ * too, so a stack that declares `objects: []` registers an engine and a driver
+ * today. Re-expressing the gate as `resolveStackCollection(...).length > 0`
+ * would have quietly stopped doing that — reintroducing "boots with no query
+ * engine" in a different case, which is the exact defect this module removes.
+ * The old truthiness is therefore PRESERVED rather than endorsed, and no config
+ * that boots today can take a different branch because of this module.
+ *
+ * Package ORDER comes from `resolveArtifactPackageOrder` (`@objectstack/core`,
+ * #14643) — the same dependency-topological order the manifest service
+ * registers in — never re-derived here. Its ADR-0112 refusals for a malformed
+ * `packages` are deliberately NOT swallowed: they are reachable only once the
+ * caller's own expression has already come back falsy, i.e. only on the shape
+ * that boots silently broken today, and a named 422 is strictly better than
+ * that silence.
+ */
+
+import { resolveArtifactPackageOrder } from '@objectstack/core';
+import { AssembledPackageBodySchema, ObjectStackDefinitionSchema } from '@objectstack/spec';
+
+type Bag = Record<string, unknown>;
+
+const asBag = (value: unknown): Bag | undefined =>
+  value && typeof value === 'object' ? (value as Bag) : undefined;
+
+/**
+ * The assembled package bodies this stack carries, in dependency-topological
+ * order — or `[]` when it carries no `packages` list of its own.
+ *
+ * `resolveArtifactPackageOrder` answers `[artifact]` for a stack with no
+ * `packages` key (ADR-0130 D4, second branch: the caller's own object IS the
+ * one package's body). That answer is correct there and useless here — folding
+ * a stack's own top level back onto itself resolves nothing — so this returns
+ * an empty list for that case, and every caller below reads the top level
+ * first anyway.
+ */
+function packageBodies(stack: unknown): Bag[] {
+  const declared = asBag(stack)?.packages;
+  if (!Array.isArray(declared) || declared.length === 0) return [];
+  return (resolveArtifactPackageOrder(stack) as unknown[])
+    .map(asBag)
+    .filter((b): b is Bag => b !== undefined);
+}
+
+/**
+ * One collection, concatenated across `packages[]` in dependency order.
+ *
+ * ⚠️ The TOP LEVEL IS NOT CONSULTED — this is the option-B leg only. Callers
+ * that must preserve today's answer read their own expression first; see
+ * {@link resolveStackCollection} for the combined form.
+ */
+function packageCollection(stack: unknown, key: string): unknown[] {
+  const out: unknown[] = [];
+  for (const body of packageBodies(stack)) {
+    const value = body[key];
+    if (Array.isArray(value)) out.push(...value);
+  }
+  return out;
+}
+
+/**
+ * The effective value of one package-owned collection.
+ *
+ * The top-level array WINS whenever the key is present — in today's additive
+ * shape that array already IS the union (`composeStacks` flattened it), so
+ * unioning again would double every item. `packages[]` is consulted only when
+ * the top level does not carry the key at all, which is precisely the option-B
+ * shape.
+ */
+export function resolveStackCollection(stack: unknown, key: string): unknown[] {
+  const top = asBag(stack)?.[key];
+  if (Array.isArray(top)) return top;
+  return packageCollection(stack, key);
+}
+
+/**
+ * Does this stack declare any objects?
+ *
+ * The predicate behind BOTH `os serve` auto-registration gates. See the module
+ * header for why the caller's original truthiness is preserved verbatim as the
+ * first clause.
+ */
+function declaresObjects(stack: unknown): boolean {
+  if (asBag(stack)?.objects) return true;
+  return packageCollection(stack, 'objects').length > 0;
+}
+
+/** Does `plugins[]` already carry an ObjectQL engine? (`serve.ts` step 1.) */
+function hasObjectQLPlugin(plugins: readonly unknown[]): boolean {
+  return plugins.some((p) => {
+    const plugin = asBag(p);
+    const name = plugin?.name;
+    const ctor = (plugin?.constructor as { name?: string } | undefined)?.name;
+    return (typeof name === 'string' && name.includes('objectql'))
+      || (typeof ctor === 'string' && ctor.includes('ObjectQL'));
+  });
+}
+
+/**
+ * Does `plugins[]` already provide a storage driver? (`serve.ts` step 2.)
+ *
+ * A `DefaultDatasourcePlugin` counts (#3826): the standalone stack DECLARES its
+ * `default` datasource and connects it at boot through the datasource
+ * connection service, so building a storage driver beside it would construct a
+ * duplicate pool the engine then discards as already-registered.
+ */
+function hasStorageDriverPlugin(plugins: readonly unknown[]): boolean {
+  return plugins.some((p) => {
+    const plugin = asBag(p);
+    const name = plugin?.name;
+    const ctor = (plugin?.constructor as { name?: string } | undefined)?.name;
+    return (typeof name === 'string' && (name.includes('driver') || name === 'com.objectstack.runtime.default-datasource'))
+      || (typeof ctor === 'string' && (ctor.includes('Driver') || ctor === 'DefaultDatasourcePlugin'));
+  });
+}
+
+/**
+ * `os serve` step 1 — should this boot auto-register the ObjectQL engine?
+ *
+ * ⚠️ The answer is the WHOLE gate, not just the collection read: a probe that
+ * measured `config.objects` would report a number while the boot still ended up
+ * with no engine. What silently fails is the DECISION, so the decision is what
+ * this seam publishes.
+ */
+export function shouldAutoRegisterObjectQL(stack: unknown, plugins: readonly unknown[]): boolean {
+  return declaresObjects(stack) && !hasObjectQLPlugin(plugins);
+}
+
+/** `os serve` step 2 — should this boot auto-register a storage driver? */
+export function shouldAutoRegisterStorageDriver(stack: unknown, plugins: readonly unknown[]): boolean {
+  return declaresObjects(stack) && !hasStorageDriverPlugin(plugins);
+}
+
+/**
+ * Does this config carry app metadata that needs an `AppPlugin` wrap?
+ *
+ * `serve.ts` step 3 and `schema-migration-plugins.ts`' own second `loadConfig`
+ * (B4) ran two copies of this expression; the comment on the second one already
+ * said "`serve` step 3, same predicate", so the two are folded here rather than
+ * left to drift.
+ *
+ * ⚠️ Measured, on the acceptance probe's option-B fixture: this predicate does
+ * NOT lose today. `manifest` is an artifact-ENVELOPE key, so it survives the
+ * flattening removal and keeps the gate true. It is folded in anyway because it
+ * is the master gate for every collection `AppPlugin` then reads — if it ever
+ * went false the whole B2 family would go silent at once — and because the
+ * probe cannot watch an expression that is not callable.
+ */
+export function stackDeclaresMetadata(stack: unknown): boolean {
+  const bag = asBag(stack);
+  if (bag?.objects || bag?.manifest || bag?.apps || bag?.flows || bag?.apis) return true;
+  return ['objects', 'apps', 'flows', 'apis']
+    .some((key) => packageCollection(stack, key).length > 0);
+}
+
+/**
+ * Does this bundle carry translations, so `os serve` auto-registers the i18n
+ * service plugin?
+ *
+ * Reads the top-level config AND any nested `AppPlugin` bundle — a host or
+ * aggregator config may define no translations of its own and instead compose
+ * several `new AppPlugin(...)` entries, each carrying its own. Keyed on that
+ * SHAPE, never on a named app.
+ *
+ * ⚠️ Measured: this one DOES lose. `translations` is package-owned, `i18n` is an
+ * envelope key that a translations-only stack never sets, so an option-B
+ * artifact reaches the gate with neither and the REST i18n routes silently do
+ * not exist.
+ */
+export function bundleDeclaresTranslations(bundle: unknown): boolean {
+  const bag = asBag(bundle);
+  if (!bag) return false;
+  if (Array.isArray(bag.translations) && bag.translations.length > 0) return true;
+  if (bag.i18n) return true;
+  const manifest = asBag(bag.manifest);
+  if (manifest && ((Array.isArray(manifest.translations) && manifest.translations.length > 0) || manifest.i18n)) {
+    return true;
+  }
+  if (packageCollection(bundle, 'translations').length > 0) return true;
+  return packageBodies(bundle).some((body) => !!body.i18n);
+}
+
+/**
+ * The object-name inventory of a compiled artifact, as `os dev` diffs it across
+ * recompiles.
+ *
+ * @param raw - The artifact exactly as `JSON.parse(readFileSync(...))` returns
+ *   it. The envelope unwrap stays here, in the seam, because `dev.ts` opens the
+ *   artifact with its OWN `readFileSync` + `JSON.parse` rather than going
+ *   through `loadArtifactBundle` — that copy is itself one of the enumerated
+ *   boundaries (#14512 comment 5523741937) and is not folded by this card.
+ *
+ * Non-fatal at the call site: losing this inventory does not break a boot, it
+ * makes `os dev` stop telling the author that a new `*.object.ts` appeared —
+ * the exact silence the 15.1 third-party eval flagged, where "recompiled" read
+ * as all-green while the new object's table and seed sync were invisible.
+ */
+export function artifactObjectNames(raw: unknown): string[] {
+  const bag = asBag(raw);
+  const meta = asBag(bag?.metadata) ?? asBag(asBag(bag?.data)?.metadata) ?? bag;
+  return resolveStackCollection(meta, 'objects')
+    .map((o) => asBag(o)?.name)
+    .filter((n): n is string => typeof n === 'string');
+}
+
+/**
+ * Every top-level key that is a PACKAGE-OWNED collection, derived from the two
+ * schemas rather than transcribed.
+ *
+ * `ObjectStackDefinitionSchema` ∩ `AssembledPackageBodySchema` is precisely
+ * "the collections a package owns" — the complement is the seven artifact
+ * envelope keys (`manifest`, `packages`, `api`, `server`, `i18n`,
+ * `runtimeModule`, `onEnable`) that an option-B artifact still carries at its
+ * top level. `packages/spec/src/assembled-package-body.test.ts` classifies the
+ * same two sets the same way.
+ *
+ * ⛔ Not hand-listed, in either direction. A transcription would fail SILENTLY
+ * and in the worst direction — a metadata family added to the stack schema next
+ * month would sit outside the fold, so `os build` would judge an option-B stack
+ * that is missing exactly that family and report zero findings about it.
+ * (#14877 is to publish this key set as an export; when it lands, this function
+ * should read it instead of deriving it, and nothing else here changes.)
+ *
+ * Computed on first use, never at module load: both schemas are lazy proxies
+ * and touching `.shape` forces the whole graph, which the CLI pays for on every
+ * invocation if it happens at import time.
+ */
+let cachedCollectionKeys: readonly string[] | undefined;
+function packageOwnedCollectionKeys(): readonly string[] {
+  if (cachedCollectionKeys) return cachedCollectionKeys;
+  const bodyKeys = new Set(shapeKeys(AssembledPackageBodySchema, 'AssembledPackageBodySchema'));
+  cachedCollectionKeys = shapeKeys(ObjectStackDefinitionSchema, 'ObjectStackDefinitionSchema')
+    .filter((key) => bodyKeys.has(key));
+  return cachedCollectionKeys;
+}
+
+/**
+ * The declared keys of a Zod object schema.
+ *
+ * Loud rather than empty when the shape cannot be read: an empty key set here
+ * would make {@link authoringRuleUnionStack} a no-op that still returns a
+ * plausible stack, i.e. `os build` would go back to judging an empty option-B
+ * stack and reporting a clean bill of health for it.
+ */
+function shapeKeys(schema: unknown, name: string): string[] {
+  const shape = (schema as { shape?: unknown } | undefined)?.shape;
+  if (!shape || typeof shape !== 'object') {
+    throw new Error(
+      `${name} exposes no \`shape\`, so the package-owned collection key set cannot be derived. `
+      + 'This is a @objectstack/spec contract change, not a caller mistake — `os build` refuses '
+      + 'rather than silently judging a multi-package stack as if it declared nothing.',
+    );
+  }
+  return Object.keys(shape as Bag);
+}
+
+/**
+ * The stack `os build`'s UNION author-time rule run judges (`compile.ts` step
+ * 3b), with every collection the top level no longer carries folded back in
+ * from `packages[]`.
+ *
+ * ## Why the union run needs this and the per-package run does not
+ *
+ * `compile.ts` runs the rule table twice: once over the union (step 3b) and
+ * once per package (step 3b-ii, which already reads `packages[]` and is
+ * therefore already option-B correct). The two answer different questions —
+ * the per-package run is STRICTER, and the union run is the only one that can
+ * see a finding which spans packages. Under option B the union run's input is
+ * an empty stack, so every cross-package rule reports nothing and `os build`
+ * publishes green. That is the weakest-gate failure #4409 was filed for,
+ * arriving a second time through a different door.
+ *
+ * ⛔ This changes what the rules JUDGE, never what the command EMITS. The
+ * artifact is written from `lowering.lowered` / `result.data`; the folded stack
+ * is a rule INPUT and reaches no writer. The card that introduced it
+ * (#15006) is explicit that the artifact stays additive through the reader
+ * half of the program.
+ *
+ * A stack whose top level still carries its collections — every stack the
+ * platform emits today — is returned UNCHANGED, by identity: the fold only ever
+ * fills keys that are absent.
+ */
+export function authoringRuleUnionStack<T extends Bag>(stack: T): T {
+  const bodies = packageBodies(stack);
+  if (bodies.length === 0) return stack;
+
+  let folded: Bag | undefined;
+  for (const key of packageOwnedCollectionKeys()) {
+    if (stack[key] !== undefined && stack[key] !== null) continue;
+    const items = packageCollection(stack, key);
+    if (items.length > 0) {
+      folded ??= { ...stack };
+      folded[key] = items;
+      continue;
+    }
+    // `functions` is the one package-owned collection carried as a RECORD
+    // rather than an array — merged in package order, so a later package's
+    // entry wins the same way a concatenated array's later element does.
+    const records = bodies
+      .map((body) => body[key])
+      .filter((value): value is Bag => !!value && typeof value === 'object' && !Array.isArray(value));
+    if (records.length > 0) {
+      folded ??= { ...stack };
+      folded[key] = Object.assign({}, ...records) as Bag;
+    }
+  }
+  return (folded ?? stack) as T;
+}

--- a/packages/cli/test/fixtures/option-b-reader-probe.ts
+++ b/packages/cli/test/fixtures/option-b-reader-probe.ts
@@ -46,7 +46,7 @@
  * that shipped an empty package.
  */
 
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { LiteKernel } from '@objectstack/core';
@@ -69,8 +69,22 @@ import { ObjectStackDefinitionSchema, normalizeStackInput } from '@objectstack/s
 // `compile.ts` runs, so the artifact written below is the artifact `os build`
 // would write (minus `docs`, which is filesystem input rather than stack input).
 import { lowerCallables } from '../../src/utils/lower-callables.js';
+// [#15006] The CLI's OWN reads of a package-owned collection. Until that card
+// these were inline expressions inside oclif command bodies — no exported
+// reader, nothing a probe could call — which is why the four rows they carry
+// below did not exist when this file was written. They are the seam now, so the
+// rows CALL the decision each command makes rather than re-deriving it.
+import {
+  artifactObjectNames,
+  authoringRuleUnionStack,
+  bundleDeclaresTranslations,
+  shouldAutoRegisterObjectQL,
+  shouldAutoRegisterStorageDriver,
+  stackDeclaresMetadata,
+} from '../../src/utils/stack-collections.js';
 
 import {
+  PACKAGE_OWNED_COLLECTION_KEYS,
   PROBE_DEFAULT_PERMISSION_SET,
   PROBE_FUNCTION,
   PROBE_FUNCTION_EFFECT,
@@ -367,6 +381,79 @@ export async function measureShape(project: unknown, projectRoot: string): Promi
   rows.push(countRow(
     'B2 · runtime collectBundleFunctionEntries over the from-source config · functions',
     Object.keys(collectBundleFunctionEntries(project as never)).length,
+  ));
+
+  // ── B2/B3/B4 · the CLI's OWN reads, through the #15006 seam ──────────────
+  //
+  // These four rows are the ones this file's "Boundaries" note used to say a
+  // probe could not reach. They were not unreachable because of the artifact —
+  // they were unreachable because the reads were EXPRESSIONS inside oclif
+  // command bodies. #15006 made each of them a callable, and a callable is what
+  // a row can attach to.
+  //
+  // ⛔ Note what these rows deliberately are NOT: an assertion that
+  // `config.objects` is non-empty on an option-B config. That row would be a
+  // second copy of the very read it watches — it would stay red after the read
+  // beside it was fixed, and a gate that cannot go green gets deleted. Each row
+  // below calls the DECISION the command now makes, with the real (empty)
+  // plugin list, so a green row means the boot really would register the thing.
+
+  const objectQLDecision = shouldAutoRegisterObjectQL(project, []);
+  rows.push(row(
+    'B2 · cli serve ObjectQL engine auto-registration gate (from source) · objects',
+    objectQLDecision ? 'engine auto-registered' : 'NO QUERY ENGINE registered',
+    !objectQLDecision,
+  ));
+
+  const driverDecision = shouldAutoRegisterStorageDriver(project, []);
+  rows.push(row(
+    'B2 · cli serve storage-driver auto-registration gate (from source) · objects',
+    driverDecision ? 'storage driver auto-registered' : 'NO STORAGE DRIVER registered',
+    !driverDecision,
+  ));
+
+  // The master gate for the whole B2 `AppPlugin` family — if it went false,
+  // every collection those rows measure would go silent at once. Shared with
+  // `os migrate`'s own second `loadConfig` (B4), which is the only reader that
+  // boundary has of its own.
+  const wrapDecision = stackDeclaresMetadata(project);
+  rows.push(row(
+    'B2/B4 · cli AppPlugin wrap gate (configHasMetadata — serve and migrate) · manifest + objects + apps + flows + apis',
+    wrapDecision ? 'AppPlugin wrap composed' : 'app metadata NOT served',
+    !wrapDecision,
+  ));
+
+  const i18nDecision = bundleDeclaresTranslations(project);
+  rows.push(row(
+    'B2 · cli serve i18n service auto-registration gate (from source) · translations',
+    i18nDecision ? 'i18n plugin auto-registered' : 'NO i18n plugin — REST i18n routes absent',
+    !i18nDecision,
+  ));
+
+  // `os dev`'s own `readFileSync` + `JSON.parse` of the artifact, kept as its
+  // own boundary because it never passes through `loadArtifactBundle`.
+  const devInventory = artifactObjectNames(JSON.parse(readFileSync(artifactPath, 'utf8')));
+  rows.push(countRow(
+    'B1 · cli dev artifact object inventory (readArtifactObjects recompile diff) · objects',
+    devInventory.length,
+  ));
+
+  // `os build`'s UNION author-time rule run. What the rules can SEE is the
+  // measurement — an empty input reports no findings and publishes green, which
+  // is the failure this row exists for. Counted over the seam's OUTPUT, so the
+  // row reports a reader's return value rather than re-deriving the read.
+  const unionStack = authoringRuleUnionStack(
+    JSON.parse(readFileSync(artifactPath, 'utf8')) as Record<string, unknown>,
+  );
+  const unionItems = PACKAGE_OWNED_COLLECTION_KEYS.reduce((n, key) => {
+    const value = (unionStack as Bag)[key];
+    if (Array.isArray(value)) return n + value.length;
+    if (value && typeof value === 'object') return n + Object.keys(value as Bag).length;
+    return n;
+  }, 0);
+  rows.push(countRow(
+    'B3 · cli build union author-time rule input (os build) · every package-owned collection',
+    unionItems,
   ));
 
   // ── The booted AppPlugin, on BOTH entry paths ────────────────────────────

--- a/packages/cli/test/fixtures/option-b-reader-probe.ts
+++ b/packages/cli/test/fixtures/option-b-reader-probe.ts
@@ -385,11 +385,14 @@ export async function measureShape(project: unknown, projectRoot: string): Promi
 
   // ── B2/B3/B4 · the CLI's OWN reads, through the #15006 seam ──────────────
   //
-  // These four rows are the ones this file's "Boundaries" note used to say a
-  // probe could not reach. They were not unreachable because of the artifact —
-  // they were unreachable because the reads were EXPRESSIONS inside oclif
-  // command bodies. #15006 made each of them a callable, and a callable is what
-  // a row can attach to.
+  // Four of the six rows below are the ones this file's "Boundaries" note used
+  // to say a probe could not reach. They were not unreachable because of the
+  // artifact — they were unreachable because the reads were EXPRESSIONS inside
+  // oclif command bodies. #15006 made each of them a callable, and a callable is
+  // what a row can attach to. The other two are the reads that sit beside them
+  // on the same boundaries: the `AppPlugin` wrap gate (which, MEASURED, does not
+  // lose — `manifest` is an envelope key) and the i18n auto-registration gate
+  // (which does).
   //
   // ⛔ Note what these rows deliberately are NOT: an assertion that
   // `config.objects` is non-empty on an option-B config. That row would be a

--- a/packages/cli/test/option-b-reader-acceptance.pin.test.ts
+++ b/packages/cli/test/option-b-reader-acceptance.pin.test.ts
@@ -108,8 +108,10 @@
  * derivation every row here uses, and `serve.ts` / `schema-migration-plugins.ts`
  * read them off the top level only. The zoo declares none, so no row measures
  * them, and the fix is NOT mechanical: a JSON artifact's `packages[i].plugins`
- * would be inert data where the call site expects a live plugin instance. Filed
- * rather than folded in — see #15006's report.
+ * would be inert data where the call site expects a live plugin instance, and
+ * whether a live-object collection belongs in the package-owned key set at all is
+ * a `packages/spec` question upstream of every reader here. Filed as #15219
+ * rather than folded in.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';

--- a/packages/cli/test/option-b-reader-acceptance.pin.test.ts
+++ b/packages/cli/test/option-b-reader-acceptance.pin.test.ts
@@ -80,27 +80,36 @@
  *
  * ## Boundaries — what this pin does NOT reach, stated rather than implied
  *
- * Three reads in the enumeration are expressions inline inside oclif command
- * bodies, with no exported reader and no service on the far side, so no probe
- * short of running the command reaches them. They are named here so the next
- * reader does not mistake this file for full coverage of the enumeration:
+ * ### Closed by #15006 (card 3/4)
  *
- *   - `serve.ts` `config.objects` gating ObjectQL engine auto-registration, and
- *     the sibling gate for storage-driver auto-registration. The artifact half
- *     of both IS covered — `createStandaloneStack` surfaces `objects` precisely
- *     so that path can drive them, and that row is in the table — but the
- *     from-source half is reachable only through a real `os serve`.
- *   - `dev.ts` `readArtifactObjects()`, a module-private function that opens the
- *     artifact with its own `JSON.parse(readFileSync(...))` to diff the object
- *     inventory across recompiles. Non-fatal; it goes permanently empty.
- *   - `compile.ts`'s union authoring-rule run, which under option B would judge
- *     an empty stack.
+ * Four reads were named here as unreachable: `serve.ts`'s two `config.objects`
+ * auto-registration gates on the FROM-SOURCE leg, `dev.ts`
+ * `readArtifactObjects()`, and `compile.ts`'s union authoring-rule run. They
+ * were unreachable not because of the artifact but because each was an
+ * EXPRESSION inside an oclif command body — no exported reader, nothing a probe
+ * could call. Card 3/4 introduced the seam
+ * (`packages/cli/src/utils/stack-collections.ts`), so the probe now carries a
+ * row per site and each one CALLS the decision the command makes. The
+ * prohibition that stood beside them still stands and is repeated where those
+ * rows live: ⛔ a row that asserts `config.objects` on an option-B config is a
+ * second copy of the read it watches, stays red after that read is fixed, and
+ * then gets deleted.
  *
- * ⛔ Do not "cover" these by asserting `config.objects` in this file. A row
- * shaped like the read it is watching is a second copy of the code the reader
- * program is about to change: it stays red after the reader beside it is fixed,
- * and a gate that cannot go green gets deleted. Cards 3/4 and 4/4 own those
- * sites; a probe for them belongs beside whatever seam those cards introduce.
+ * ⚠️ The two `serve.ts` gates were only HALF covered before, and the half that
+ * was covered is the ARTIFACT leg — `createStandaloneStack` surfaces `objects`
+ * precisely so that path can drive them, and that row is in the ledger. That
+ * row stays: `standalone-stack.ts` omits the key entirely when the array is
+ * absent, and no CLI-side seam can resolve what the runtime never surfaced. It
+ * is card 2/4's (#15005) to delete, not this file's.
+ *
+ * ### Still open
+ *
+ * `plugins` and `devPlugins` are package-owned collections by the same
+ * derivation every row here uses, and `serve.ts` / `schema-migration-plugins.ts`
+ * read them off the top level only. The zoo declares none, so no row measures
+ * them, and the fix is NOT mechanical: a JSON artifact's `packages[i].plugins`
+ * would be inert data where the call site expects a live plugin instance. Filed
+ * rather than folded in — see #15006's report.
  */
 
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -269,5 +278,21 @@ describe('#15004 — option-B acceptance pin: every subsystem must see its colle
     // are the B2 rows. The header's "Boundaries" section states what that does
     // and does not cover.
     expect(ids.some((id) => id.startsWith('B5 · resolve-project-database'))).toBe(true);
+  });
+
+  it('#15006 — the four cli reads that had no callable seam are each represented', () => {
+    // These four were named in this file's header as OUT of reach. They are in
+    // reach now, and this test is what stops them from quietly leaving again:
+    // the pin asserts set EQUALITY against the ledger, so a row that stopped
+    // being measured while it was GREEN would take nothing red with it.
+    const ids = optionB.rows.map((r) => r.id);
+    for (const site of [
+      'B2 · cli serve ObjectQL engine auto-registration gate (from source) · objects',
+      'B2 · cli serve storage-driver auto-registration gate (from source) · objects',
+      'B1 · cli dev artifact object inventory (readArtifactObjects recompile diff) · objects',
+      'B3 · cli build union author-time rule input (os build) · every package-owned collection',
+    ]) {
+      expect(ids, `#15006 site no longer measured: ${site}`).toContain(site);
+    }
   });
 });


### PR DESCRIPTION
Fixes #15006

Reader program 3/4 of the ADR-0130 D4 option-B ruling (#14512 comment 5528589044, maintainer 2026-09-03, batch #23). The artifact stays additive through this card: no command emits anything different, `composeStacks` and `packages/spec/src/stack.zod.ts` are untouched.

## What was broken

`@objectstack/cli` holds **four independent config-load boundaries**, and every read of a package-owned collection behind them was an inline expression against the FLATTENED top level. A stack that carries each definition once under `packages[]` reached those expressions with the key simply absent — and nothing threw.

| Site | before | What an option-B stack got |
|:--|:--|:--|
| ObjectQL engine auto-registration | `serve.ts:2632` `if (config.objects && !hasObjectQL)` | **no query engine**, boot reports healthy |
| Storage-driver auto-registration | `serve.ts:2669` `if (!hasDriver && config.objects)` | **no storage driver**, same silence |
| i18n service auto-registration | `serve.ts:2976-2995` | **REST i18n routes absent** |
| `readArtifactObjects()` | `dev.ts:653-666` | inventory permanently empty; every recompile reads all-green |
| union author-time rule run | `compile.ts:344` | rules judge an **empty stack**; `os build` publishes green |
| `configHasMetadata`, twice — `serve.ts:2802` and `os migrate`'s own second `loadConfig` at `schema-migration-plugins.ts:1094` | | **measured: does not lose** — `manifest` is an envelope key |

Nothing between the artifact and the two `serve.ts` gates could notice the loss: `standalone-stack.ts:785` omits the `objects` key entirely when the array is absent (not `[]`), and `mergeBootConfig` is a plain spread.

## The seam

`packages/cli/src/utils/stack-collections.ts` — one module, one resolution rule, seven exports. Two properties make it safe to land:

1. **Every predicate starts from the expression it replaced.** `if (stack.objects) return true;` is byte-identical to the old gate; `packages[]` is consulted only where the old read already returned nothing. So no stack that boots or builds today can take a different branch. That ordering is load-bearing, not stylistic: `config.objects` is truthy for an EMPTY array, so a stack declaring `objects: []` gets an engine today. Re-expressing the gate as `resolve(...).length > 0` would have quietly stopped doing that — reintroducing "boots with no query engine" in a different case. Pinned in `stack-collections.test.ts`.
2. **It is CALLABLE.** That is the other half of the card. The #15004 probe could not reach an expression inside an oclif command body, which is exactly why these four sites sat outside its 24-row ledger (#15006 comment 5530257178). The probe now calls the DECISION each command makes — the whole gate, plugin duck-typing included, because what silently fails is the decision and not the count.

Package order comes from `resolveArtifactPackageOrder` (`@objectstack/core`, #14643) — never re-derived. Its ADR-0112 refusal for a malformed `packages` is deliberately not swallowed: it is reachable only once the caller's own expression has come back falsy, i.e. only on the shape that boots silently broken today.

The package-owned collection key set the `os build` fold needs is **derived** — `ObjectStackDefinitionSchema` ∩ `AssembledPackageBodySchema`, the same reconciliation `packages/spec/src/assembled-package-body.test.ts` performs — never hand-listed, so a collection family added to the stack schema next month joins the fold without anyone remembering to. (#14877 would let it read that set as an export instead.)

## The ledger: 24 rows, unchanged. Zero deleted, zero added.

No `OPTION_B_LOSSES` row was deleted or added. That is the correct outcome and worth stating plainly, because "which rows did you delete" is the usual question for this program:

- **Not one of the 24 rows names a cli reader.** Every row is a `@objectstack/runtime` reader (`collectBundle*`, `AppPlugin`, `createStandaloneStack`, `resolve-project-database`) or a `@objectstack/plugin-security` one — cards #15005 and #15007. The cli's own reads were never in the ledger *because the probe could not reach them*.
- **The artifact leg of the two `serve.ts` gates stays ledgered, and stays #15005's.** `B1 · createStandaloneStack surfaced objects (CLI tier resolution + engine/driver auto-registration) · objects` is that row, and its label already names these gates. Measured on the probe: `createStandaloneStack` surfaces neither `objects` nor `packages` for an option-B artifact (its result keys are `["api","manifest","plugins"]`), so no cli-side seam can resolve what the runtime never surfaced. This PR does not touch that row and does not add a duplicate beside it.

Six new rows enter the probe. Five were RED before this change and are GREEN after, so none enters the ledger; the sixth was green in both shapes and stays green.

## Reverse verification — the new rows are a measurement, not decoration

Committed first (`38d97fb90`), then ablated with a trap-restored script using absolute paths. The mutation removes the option-B leg at one anchor (`packageBodies` returns `[]`), and was **confirmed on disk before the run**: injected marker occurrences `1`, blob `a85e9f16…` different from the HEAD blob `2577e5d5…`. No rebuild is in the path — the pin reaches this module by RELATIVE path from inside `@objectstack/cli` (`test/fixtures` up to `../../src/utils`), so vitest transforms the source and no `dist/` copy participates.

Ablated pin: **1 failed | 6 passed**. The one failure is THE PIN, naming exactly the five rows this change fixes:

```
A subsystem lost a collection that the ledger does not carry …
  B1 · cli dev artifact object inventory (readArtifactObjects recompile diff) · objects
  B2 · cli serve ObjectQL engine auto-registration gate (from source) · objects
  B2 · cli serve i18n service auto-registration gate (from source) · translations
  B2 · cli serve storage-driver auto-registration gate (from source) · objects
  B3 · cli build union author-time rule input (os build) · every package-owned collection
…
  LOST     B2 · cli serve ObjectQL engine auto-registration gate (from source) · objects = NO QUERY ENGINE registered
  LOST     B2 · cli serve storage-driver auto-registration gate (from source) · objects = NO STORAGE DRIVER registered
  present  B2/B4 · cli AppPlugin wrap gate (configHasMetadata — serve and migrate) · … = AppPlugin wrap composed
  LOST     B2 · cli serve i18n service auto-registration gate (from source) · translations = NO i18n plugin — REST i18n routes absent
  LOST     B1 · cli dev artifact object inventory (readArtifactObjects recompile diff) · objects = 0
  LOST     B3 · cli build union author-time rule input (os build) · every package-owned collection = 0
```

In that SAME run the additive BASELINE, the `packages[]` anti-vacuity CONTROL, the shape-derivation test, the phantom-ledger test, the five-boundary test and the new #15006 representation test all passed — which is what makes the red a discrimination rather than a broken fixture. Restore proved by an empty `git diff HEAD` and a blob hash byte-identical to HEAD.

## One site deliberately NOT fixed

`plugins` and `devPlugins` are package-owned collections by the same derivation every row here uses, and `serve.ts:2622` / `schema-migration-plugins.ts:1082` read them off the top level only. The mechanical repair is **wrong** there: `packages[i].manifest.plugins` in a JSON artifact is inert data where `kernel.use()` needs a live instance, and whether a live-object collection belongs in the package-owned key set at all is a `packages/spec` question upstream of every reader in this program. Filed as #15219, named in the pin's header, and left alone here. The zoo declares no plugins, so no probe row covers it — adding one would pin a shape that may be about to change.

## Docs drift — hand-read, not anchor-listed

The drift bot reports **1 package, 22 documentable anchors, 40 hand-written pages, 5 release-owned pages**. Re-derived on this worktree: 45 pages, the same split.

⛔ **The 5 release-owned pages (`releases/v12`, `v13`, `v14`, `v16`, `v17`) are untouched and stay untouched.** Release notes are written centrally at release time; this PR's input to them is its changeset.

The bot's own note says an anchor list cannot reach a page that states a rule by its **inputs**, because such a page shares no identifier with the emitter. This diff changes exactly that kind of rule — "whether `config.objects` exists decides if the engine and driver auto-register" — so the rule-restating pages were read by hand, searched by the rule's INPUTS across all of `content/docs` minus `releases/`: `auto-register` / `automatically registers`, `config.objects`, `top-level objects`, `I18nServicePlugin` + `translations`, `author-time rules`, `packages[]` / `multi-package`, `recompil`.

| Page | What it states | Verdict |
|:--|:--|:--|
| `plugins/index.mdx:238` | `os dev` on a minimal config auto-registers ObjectQL, the default datasource, AppPlugin, HonoServer and the REST API | still true — that config declares top-level `objects`, and the first clause of both gates is byte-identical to the expression it replaced |
| `deployment/cli.mdx:206-208` | tier presets gate *optional* plugin auto-registration; "any plugin already present in `config.plugins` always wins" | still true — the already-composed check moved into the seam unchanged, both halves of it |
| `data-modeling/drivers.mdx:55` | the driver KIND is inferred by the CLI from the URL scheme | untouched — `resolveDriverType` is not in this diff; what moved is the gate on whether to build one at all, which no page states |
| `kernel/services-checklist.mdx:428` | `DevPlugin` auto-wires `I18nServicePlugin` when the stack declares translations | true, and NOT this diff — that is `@objectstack/plugin-dev`'s own reader, already filed as a site of #15210 |
| `getting-started/examples.mdx:352-432` | a project compiles to one artifact carrying `packages[]`; registration order is topological from `dependencies`, never array order | still true, and this diff *honours* it — the fold reads `resolveArtifactPackageOrder`, the same topological order this page describes |
| `deployment/cli.mdx:456`, `deployment/validating-metadata.mdx:558`, `ui/react-pages.mdx:380`, `getting-started/build-with-claude-code.mdx:266` | transcripts printing `→ Running author-time rules (41)...` | still true — the count is `authoringRulesFor('build').length`, untouched, and the fold changes the rules' INPUT, not the table or the step line |
| `protocol/kernel/plugin-spec.mdx:187,652` | a package manifest declares its objects through top-level globs | authoring-time, upstream of every reader here |

**No page is falsified, and the reason is a property rather than an inspection**: this change is strictly additive on every shape the platform emits today. Each predicate's first clause is the expression it replaced, and `authoringRuleUnionStack` returns the stack BY IDENTITY whenever the top level carries its collections — measured on the acceptance fixture and on the real `build-multi-package-artifact` / `compile-artifact-packages` e2e runs. Behaviour moves only on the option-B shape, which nothing emits yet and which no page documents.

## Verification

All at `dbe2fa58a` (final commit). Gate family re-derived there with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` — identical to the earlier derivation: 9 paths, 46 runnable commands — and the union **re-run whole on that head**.

| Run | Reading |
|:--|:--|
| gate family | **46 of 46 exit 0.** Named because they were `PREREQUISITE NOT MET` on an earlier pass and are MEASURED here: `check:i18n` → `OK (9 package(s) — all bundles in sync, no undeclared authoring keys)`; `check:i18n-coverage` → `OK (13 config(s), 691 baselined untranslated string(s), none new)`; `check:dual-build-cjs-loads` → `OK — 102 published require entry point(s) across 66 package(s) load` |
| ratchets | `check:type-check-debt` → `OK — 16 ledger entr(ies) re-measured in 223.4s, 207 raw tsc error(s) total, none above its recorded number`, `surplus: none`. `check:type-check-coverage` → `OK — 73/79 workspace packages type-checked`. `check:type-source-resolution` → `OK — 120 tsc program(s) across 78 packages scanned`. `check:test-source-alias` → `OK — 72 packages with tests scanned` |
| `pnpm --filter @objectstack/cli typecheck` | exit 0; `check:test-typecheck` reports `3 file(s) / 28 error(s) / 6 pinned signature(s)` — byte-identical to the committed `test-typecheck-debt.json`, so **zero new diagnostics**. `tsc --noEmit --listFiles` confirms both new files are in the program (1 hit each), so "typecheck is clean" is a statement ABOUT them |
| the suites this diff reaches | `Test Files 8 passed (8) / Tests 75 passed (75)` — the seam's contract, `merge-boot-config`, the acceptance pin, `authoring-rule-command-parity`, `compile-artifact-packages.e2e`, `build-multi-package-artifact.e2e`, `format-zod-union`, `hook-body-build-reach.e2e`. Plus a second targeted run over the units for the edited command files — `Test Files 8 passed (8) / Tests 83 passed (83)`: `serve-automation-shadowing`, `serve-i18n-load-diagnostic`, `serve-driver-banner`, `serve-host-config-security-registrar.pin`, `serve-settings-ordering.pin`, `database-driver-flag-derivation`, `dev-default-db`, `graft-runtime-hooks` |
| roster gates my paths sit inside | `check-stack-collection-maps` (8 enumerations reconciled against the schema), `check-changeset-fixed`, `check:authz-resolver`, `check:error-code-casing`, `check:filter-alias-parity`, `check:swallow-census-controls` — all exit 0. Named because `dispatch-gates` scores them "silent" on a roster, which is a fact about a list rather than a clearance |

Every exit code above was captured before any pipe.

**Declared narrowing.** The whole 224-file `@objectstack/cli` suite was started and **deliberately terminated at 34 minutes** (`SUITE_EXIT=130`), because it was holding the shared verification lock with a sibling agent queued behind it. Its partial output named two failures — `format-zod-union.test.ts` (1) and `hook-body-build-reach.e2e.test.ts` (2) — with file durations of 666s and 747s against 120s per-test timeouts, i.e. timeout signatures rather than assertions. **Both files pass in the targeted runs above**, so the classification is contention, not this diff. CI runs the suite whole regardless.

⚠️ One reading was thrown away rather than reported: a first `typecheck` returned TS7016 for `@objectstack/client`, whose `dist/index.d.ts` was being rewritten at that instant by `check:type-check-debt`'s own build closure running unlocked beside it. The file was present, and re-measured, typecheck is clean. Recorded because it is the same shape as #15042 (a package's `.d.ts` "vanishing" after a green build) and offers that card a concrete cause: a concurrent rebuild in the same worktree, read through tsup's non-atomic write window.

## The B2/B3/B4 shared-helper question, measured rather than assumed

The card left open whether the three config loads can collapse into one helper (`serve.ts` calls `bundleRequire`; `compile.ts:211` and `schema-migration-plugins.ts:1083` call `loadConfig`). **Measured: the loaders are not the problem and were not touched.** All three load an ordinary module and hand its export on unchanged — the collection loss is in the READERS each of them then drives, which is what this PR moved. That refactor stays unmade and out of this card.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m
