### PR TITLE
docs(adr): ADR-0094 D2 enumerates three projecting doors; the shipped code has seven (amendment)

### DIFF
--- a/docs/adr/0094-sys-permission-set-pure-projection.md
+++ b/docs/adr/0094-sys-permission-set-pure-projection.md
@@ -30,7 +30,9 @@ not by a subscriber a new write path might forget to trigger:
    `publishMetaItem` / `deleteMetaItem`, after persistence and before the write returns.
    The projector is the **only writer** of the record. A Studio save therefore returns
    only after the record already reflects it — no projection race (the #2867 subscriber
-   was fire-and-forget).
+   was fire-and-forget). (**The three doors named above are no longer the whole list** —
+   the recovery doors project too since 2026-09-03; the sentence is left as written and
+   the full enumeration is in the 2026-09-04 amendment at the end of this record.)
 3. **Boot reconciliation + one-time backfill.** At `kernel:ready` the projection is
    re-derived from metadata (metadata wins), and legacy records that exist **only** in
    the data plane are migrated into the metadata store once.
@@ -91,7 +93,7 @@ recreates ids.
 **Assignments and bindings stay data-plane.** Which users/positions hold a set is
 environment *state*, not part of the definition; those tables are unchanged.
 
-### D2 — The record is written only by the projector, awaited by the protocol
+### D2 — The record is written only by the projector, awaited by the protocol (door enumeration amended 2026-09-04 — see the amendment at the end)
 
 `@objectstack/metadata-protocol` gains `registerMutationProjector(type, fn)`: an
 awaited, best-effort per-type hook invoked after persistence inside `saveMetaItem`
@@ -99,6 +101,14 @@ awaited, best-effort per-type hook invoked after persistence inside `saveMetaIte
 `{ type, name, state, organizationId, body? }`. A projector failure is surfaced on the
 write's response (`projectionApplied: { success:false, error }`) and logged — never
 thrown, the metadata write itself succeeded and boot reconciliation heals on next start.
+
+> **Amended 2026-09-04** (see the amendment at the end of this record): the two
+> sentences above are narrower than the shipped code in two ways. The door list is
+> three of **seven** call sites, and boot reconciliation is not the only thing that
+> re-derives a record a failed projection left stale — every projecting door does,
+> and since 2026-09-03 that set includes the recovery doors. `projectionApplied` is
+> also not surfaced at every site: three of the seven call and await the projector
+> without putting an outcome on the response.
 
 `plugin-security` registers the `permission` projector. It re-reads the **fresh layered
 effective body** and:
@@ -484,3 +494,96 @@ two rules the `object` authoring gate (`objectPostureGate`,
 Door order, as pinned in `packages/rest/src/meta-object-owd-gate.test.ts`:
 the 422 lint gate answers first; this seam's 403 R1 door answers for writes
 that pass lint.
+
+## Amendment (2026-09-04, #15244): the projector has seven doors, not three — and boot reconciliation was never the only re-derivation
+
+D2 enumerates the doors that await the projector as `saveMetaItem` /
+`publishMetaItem` / `deleteMetaItem`. That sentence was accurate when this
+record was written and is **incomplete** on today's tree: PR #14982 (merged
+2026-09-03 as `95464ed65`) extended the projection to the recovery doors, and
+the record did not follow it — that PR's documentation half was closed void, so
+the code shipped alone. This amendment closes the gap and **changes no
+decision**: D1 stands untouched, and D2's rule — *the record is written only by
+the projector, and the projector is awaited before the write returns* — is
+exactly what the four new call sites implement. Only the enumeration was wrong,
+which is the harder kind of error to notice, because nothing it says is false.
+
+### The seven projecting doors, measured on `main`
+
+`runMutationProjector` is declared once in
+`packages/metadata-protocol/src/protocol.ts` and called from **seven** sites in
+that same file — D2's three, plus the four #14982 added:
+
+| Projecting door | `state` passed | Body handed over | Outcome on the response |
+| :-- | :-- | :-- | :-- |
+| `saveMetaItem` | `draft` \| `active` | the saved item | `projectionApplied` |
+| `runPublishSideEffects`, the phase-2 publish helper | `active` | the published body | `projectionApplied` |
+| `deleteMetaItem`, repository branch | `deleted` | none | `projectionApplied` |
+| `rollbackMetaItem`, after its registry write-through | `active` | the restored version's body | — |
+| `revertCommit`, restore limb | `active` | the pre-commit body | — |
+| `revertCommit`, soft-remove limb | `deleted` | none | — |
+| `deleteMetaItem`, legacy raw-engine exit | `deleted` | none | `projectionApplied` |
+
+Three things D2's three-name sentence hides, each measured on the call sites
+rather than inferred from the method names:
+
+- **The publish door is a shared helper, not `publishMetaItem`.** The projecting
+  call site lives in `runPublishSideEffects`, at that helper's own body level,
+  and `publishMetaItem` is one of **two** callers — `publishPackageDrafts`
+  reaches the same projection through the same helper. D2 named only the first,
+  so the package-draft publish path has been projecting, undocumented, since
+  before this amendment.
+- **`deleteMetaItem` projects from two exits, not one.** Its repository branch
+  always did; #14982 added the legacy raw-engine exit, which serves the
+  code-only types the repository path cannot.
+- **`projectionApplied` is not universal.** D2's failure-surfacing sentence
+  holds at four of the seven. `rollbackMetaItem` and both `revertCommit` limbs
+  declare no such key on their response types and #14982 deliberately added
+  none: there the projector is called and awaited, and a failure is logged
+  without reaching the caller.
+
+The count is enforced, not incidental —
+`packages/metadata-protocol/src/protocol.recovery-doors-mutation-projector.test.ts`
+pins "exactly seven" call sites, three original and four recovery-door, with the
+declaration asserted separately as a non-vacuity control. Anyone can re-derive
+the number:
+
+```bash
+git grep -c "this.runMutationProjector(" -- packages/metadata-protocol/src/protocol.ts
+```
+
+which answers `7` on this tree. If it ever answers anything else, the table above
+is what went stale.
+
+### Boot reconciliation is not the only healing path
+
+D2's best-effort clause ends "boot reconciliation heals on next start", which
+reads as though a failed projection is stranded until the next boot. It is not,
+and it never quite was: **any** later projecting door on the same name re-derives
+the record, because the projector re-reads the fresh layered effective body
+rather than trusting whatever it was handed. Before #14982 that set was an
+unrelated save, publish or delete; since #14982 it also includes a rollback and
+both limbs of a commit revert. D4's `kernel:ready` pass remains the guaranteed
+floor — the one heal that needs no subsequent write, and the property D2's
+sentence was reaching for — but it is a floor, not the only path.
+
+The inverse defect is the one #14982 fixed. Before it, the recovery doors
+restored the row and the in-memory registry without projecting, so a rollback
+left the derived record on the rolled-back-from state: applied everywhere except
+the record Setup reads, until an unrelated write or the next boot caught up.
+
+### This mechanism has one major left to live
+
+[ADR-0131](./0131-total-organization-ownership-no-null-organization-id.md)
+(merged 2026-09-04 as PR #14976) retires it. Its D2 names "the
+`sys_permission_set` projector and reconciler of ADR-0094 D2/D4" among the
+machinery that goes, and its D3 retires the `sys_permission_set` object itself
+(with D13) — on the ground that **D1 of this record was right and is being
+generalized**: the metadata layer was already the sole authoritative store, so
+once the catalog is read from the registry the projected row has nothing left to
+be. D14 puts that on the **v18** line, and the card that executes it is C3,
+tracked on #15204.
+
+So this amendment describes a mechanism with one major to live. It is written
+for whoever has to keep the seven doors correct until then — not as an
+invitation to build something new on top of them.


### PR DESCRIPTION
Fixes #15244

## What this changes

`docs/adr/0094-sys-permission-set-pure-projection.md` only. No code, no changeset, no
release notes.

PR #14982 (merged 2026-09-03 as `95464ed65`) put the ADR-0094 mutation projector behind
the recovery doors. Its documentation half, PR #14980, was voided on the maintainer's
instruction, so the code shipped and the record did not follow it. D2 still enumerated
three projecting doors while the tree has seven. Nothing D2 said was false — it was
incomplete, which is the harder kind of error to notice.

This is a **dated amendment in the ADR's own established style** (the same
`## Amendment (date): title` shape the record already carries for 2026-08-14), plus two
inline markers so a reader who lands on the stale sentences is told. **The original
sentences are left verbatim and marked, never rewritten**, and no decision changes: D1 is
untouched, and D2's rule is exactly what the four new call sites implement.

## Re-check command a reviewer can run

```bash
git grep -c "this.runMutationProjector(" -- packages/metadata-protocol/src/protocol.ts
```

Expected output on this branch:

```
7
```

The count is structurally pinned, not incidental —
`packages/metadata-protocol/src/protocol.recovery-doors-mutation-projector.test.ts` asserts
"exactly seven" call sites with the declaration excluded as a non-vacuity control. To see
the enclosing methods:

```bash
git grep -n "runMutationProjector" -- packages/metadata-protocol/src/protocol.ts
```

which prints the one declaration plus the seven call sites.

## What I measured, rather than repeated from the card

The card's attributions were re-verified against the seven call sites by computing each
one's enclosing method. Three refinements the card did not carry, all of them now in the
amendment:

- **The publish door is `runPublishSideEffects`, not `publishMetaItem`.** The projecting
  call sits at that helper's own body level (unconditional), and the helper has **two**
  callers: `publishMetaItem` and `publishPackageDrafts`. So the package-draft publish path
  has been projecting undocumented. D2 named only the first caller.
- **`projectionApplied` is not surfaced at every site.** It is surfaced at four of seven.
  `rollbackMetaItem` and both `revertCommit` limbs call and await the projector while
  declaring no such key on their response types — #14982 deliberately added none. D2's
  failure-surfacing sentence therefore holds at four sites, not seven.
- **The "only healing path" defect is narrower than "the recovery doors broke it".** The
  ADR contains no sentence with the word "only" attached to boot reconciliation; the
  actual claim is D2's best-effort clause ending "boot reconciliation heals on next
  start", which reads as though a failed projection is stranded until the next boot. It
  never quite was — any later projecting door re-derives, because the projector re-reads
  the fresh layered effective body. Before #14982 that set was an unrelated save, publish
  or delete; since #14982 it also includes rollback and both revert limbs. The amendment
  says that, and keeps D4's boot pass as the guaranteed floor.

The card's warning about the six pre-existing `rollback|revert` mentions checked out:
`git grep -ci "rollback\|revert"` on the ADR returns 6, and **none** of them is about the
`rollbackMetaItem` / `revertCommit` protocol methods — all six are the ADR-0005 rollback
(#6483 / PR #6608) and one unrelated "reverting an admin's reclassification". No stale
sentence there, so none was touched.

Forward pointer added per the card: ADR-0131 (merged 2026-09-04 as PR #14976) retires this
machinery — its D2 names "the `sys_permission_set` projector and reconciler of ADR-0094
D2/D4", its D3 retires the object itself (with D13) on the ground that ADR-0094 **D1 was
right and is being generalized**, D14 puts it on the v18 line, and the executing card is
C3, tracked on #15204.

## Governed surface

`docs/adr/**` is a governed surface. This PR is opened as a **draft**; auto-merge is not
armed and will not be; no AI seat merges it. **The maintainer hand-merges.**

## Changeset

None, deliberately — docs-only, publishes nothing from any released package. The
`skip-changeset` label is applied. An empty-frontmatter changeset is rejected by the gate
(#4898), so none was written.

## Gates

Derived with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`,
letting it compute its own change set (1 path, vs merge base `1bc3c092a`). It named **16
runnable families**; all 16 were run at the final commit `f2acdc322`, exit code captured
before any pipe:

| Family | Verdict |
| :-- | :-- |
| `node scripts/check-adr-links.mjs` (+ `--self-test`) | 0 — green |
| `node scripts/check-adr-symbol-anchors.mjs` (+ `--self-test`) | 0 — green |
| `pnpm check:adr-anchors` | 0 — green |
| `pnpm check:doc-authoring` | 0 — green |
| `pnpm check:nul-bytes` | 0 — green |
| `pnpm check:pm-governed-merges` | 0 — green |
| `pnpm check:cross-package-test-inputs` | 0 — green |
| `node scripts/check-ci-filter-parity.mjs` | 0 — green |
| `node scripts/check-closing-keyword-parity.mjs` (+ `--self-test`) | 0 — green |
| `node scripts/check-comment-mask-corpus.mjs` | 0 — green |
| `pnpm check:refd-timer-probe` | 0 — green |
| `pnpm check:watch-hint-literal` | 0 — green |
| `pnpm --filter @objectstack/lint run check:doc-formula-expressions` | 0 — green, **after** two `exit 3` runs |

The three ADR gates the card called out — `check-adr-links`, `check-adr-anchors` and
`check-adr-symbol-anchors` — are green. No `file.ts:NNN` anchor was written: the
amendment cites bare file paths and names symbols in prose, and line numbers appear
nowhere in it.

**One NOT MEASURED, then resolved.** `check:doc-formula-expressions` first answered
`exit 3` — `PREREQUISITE NOT MET`, the gate's own distinct code for "nothing was
measured", not a finding. It wanted `@objectstack/formula` built, then `@objectstack/lint`
built. Both were built and the gate re-run to a real `exit 0`. Recorded here because an
`exit 3` is neither a pass nor a fail and should not be reported as either.

**`pnpm lint` — a declared narrowing, not a skip.** The repo-wide eslint scan is CI's run.
Three pieces of evidence that this diff cannot move any eslint verdict: (1) the population
is read from eslint's own config, not guessed — every `files:` glob in `eslint.config.mjs`
names only `{ts,tsx,mts,cts,js,jsx,mjs,cjs}`, with no Markdown block anywhere; (2) the
count comes from `--format json` — running eslint on the changed file returns one entry,
0 errors, message `File ignored because no matching configuration was supplied`, i.e. zero
files linted; (3) invariance for untouched files — the diff is one `.md` file and touches
no eslint config, no TS source and no tsconfig, and no type-aware path reaches a Markdown
file, so no untouched file's verdict can move.

**Verify-lock declaration.** The two builds went through
`scripts/pm/os-verify-lock.sh`, which reported: `UNLOCKED (declared) · no usable flock on
this host, so the shared verify lock was NEVER taken and NOTHING was serialized`. Declared
here as that entry point asks. Both builds still exited 0.

## Out of scope, filed separately

While verifying the call sites I found that two comments introduced by #14982 cite
"ADR-0094 D3" for boot reconciliation, which is **D4** in the record (D3 is the data-door
write-through). Every other citation in the tree spells it D4. That is a code-comment
defect, out of scope for a docs-only PR on a governed surface, and is filed separately as
#15247 — not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_6679d191-11f4-465b-b322-0e0409d76793)_
