### PR TITLE
fix(plugin-dev): the i18n auto-detect resolves `translations` from `packages[]` (#15232)

### DIFF
--- a/.changeset/plugin-dev-i18n-detect-packages-reader.md
+++ b/.changeset/plugin-dev-i18n-detect-packages-reader.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/plugin-dev": patch
+---
+
+fix(plugin-dev): the i18n auto-detect resolves `translations` from `packages[]`, not only the flattened top level (#15232)
+
+`DevPlugin.init`'s 3b block read `options.stack.translations` and nothing else.
+For a multi-package app under the ADR-0130 D4 option-B shape — where
+`packages[]` carries each definition exactly once and the flattened top-level
+copy is gone — that read returns `undefined`, the detection concludes "this app
+declared no copy", and the boot continues. Nothing throws and nothing logs.
+
+What the developer gets instead is the wrong strings. `I18nServicePlugin`
+(`@objectstack/service-i18n`) is never registered, so the `i18n` slot keeps the
+core in-memory fallback: `os dev` serves message KEYS, or last release's copy,
+for an app that declared real translations. It reads as "the translations are
+broken", not as "a collection went missing", which is why it is a reader fix
+rather than a footnote.
+
+The detection now reads the flattened top level FIRST and then each package
+body, in the order `resolveArtifactPackageOrder` (`@objectstack/core`,
+ADR-0130 D4+D5) registers them:
+
+- **Every artifact the platform emits today answers bit-identically.** The
+  flattened level still answers first and short-circuits, so the `packages[]`
+  pass can only supply a declaration the top level did not have. This is the
+  reader half of the ruled order (readers first, emitter last, the artifact
+  additive throughout), so it lands with no change to what any command emits.
+- **The caller's original expression is preserved, not re-expressed.**
+  `Array.isArray(t) && t.length > 0` still decides the top level, per package
+  body as well — re-expressing a gate as a resolved-and-counted traversal is
+  what silently changes the verdict for a stack that declares the key empty.
+- **⛔ `stack.packages` is not iterated directly.**
+  `resolveArtifactPackageOrder` is the platform's one traversal and also the
+  GATE that parses each entry, so a second traversal would disagree with the
+  load path about which artifacts are loadable. An artifact with no `packages`
+  key is left entirely on the old path — the key's absence is checked before
+  the call, because D4's second branch would otherwise hand the caller's own
+  object back and read the same `translations` twice.
+- **A malformed `packages` is refused, not skipped.** A non-array `packages`,
+  an entry inlined instead of wrapped under `manifest:`, or a duplicate package
+  id raises the same ADR-0112 envelope (`code` + `status: 422`) that
+  `ObjectQL.registerApp` raises for the same object later in the same boot.
+
+The decision — detection plus the locales it derives — is now one exported
+function, `devI18nPluginOptions`, so the #15004 option-B acceptance pin
+measures it by CALLING it rather than re-implementing the read. `DevPlugin`
+keeps the dynamic import and its degradation: those are about the optional
+package being installed, which is a different question from what the stack
+declares.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -129,6 +129,7 @@
   },
   "devDependencies": {
     "@objectstack/driver-turso": "workspace:*",
+    "@objectstack/plugin-dev": "workspace:*",
     "@oclif/plugin-help": "^6.2.58",
     "@oclif/plugin-plugins": "^5.4.87",
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/cli/test/fixtures/option-b-reader-probe.ts
+++ b/packages/cli/test/fixtures/option-b-reader-probe.ts
@@ -14,7 +14,8 @@
  *
  *   - invokes a reader this repo SHIPS (`collectBundleActions`,
  *     `resolveStandaloneDatabase`, `createStandaloneStack`,
- *     `appSecurityPluginOptions`, …) and reports its return value, or
+ *     `appSecurityPluginOptions`, `devI18nPluginOptions`, …) and reports its
+ *     return value, or
  *   - boots a real kernel carrying the real `AppPlugin` and reports what that
  *     plugin HANDED to a subsystem (a job scheduled, a datasource connected, a
  *     mapping set, an i18n service registered, a seed dataset merged).
@@ -62,6 +63,7 @@ import {
   resolveStandaloneDatabase,
 } from '@objectstack/runtime';
 import { appSecurityPluginOptions } from '@objectstack/plugin-security';
+import { devI18nPluginOptions } from '@objectstack/plugin-dev';
 import { ObjectStackDefinitionSchema, normalizeStackInput } from '@objectstack/spec';
 
 // The lowering itself, not a copy of it — reached as SOURCE, by relative path,
@@ -349,6 +351,21 @@ export async function measureShape(project: unknown, projectRoot: string): Promi
   //    pass its export through untouched, so the collection loss is not IN the
   //    loader — it is in the readers each of them then drives, which is what
   //    these rows are.
+
+  // `DevPlugin` takes its stack from a CALLER-SUPPLIED object
+  // (`new DevPlugin({ stack: config })`, the documented construction), so there
+  // is no load boundary between the composed config and this reader — the same
+  // object `os dev` boots from source is handed straight to the plugin. The row
+  // calls the SHIPPED decision (`devI18nPluginOptions`), which is what the
+  // plugin itself calls to decide whether to register `I18nServicePlugin`; a
+  // row that re-read `stack.translations` here would be a second copy of the
+  // read the reader program changes and would stay red after it was fixed.
+  const devI18n = devI18nPluginOptions(project);
+  rows.push(row(
+    'B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations',
+    devI18n ? `I18nServicePlugin(fallbackLocale=${devI18n.fallbackLocale})` : undefined,
+    devI18n === undefined,
+  ));
 
   const fromSourceProfile = appSecurityPluginOptions(project)?.fallbackPermissionSet;
   rows.push(row(

--- a/packages/cli/test/option-b-reader-acceptance.pin.test.ts
+++ b/packages/cli/test/option-b-reader-acceptance.pin.test.ts
@@ -143,10 +143,6 @@ const OPTION_B_LOSSES: readonly string[] = [
   'B2 · AppPlugin ql.setDatasourceMapping (object routing) (from source) · datasourceMapping',
   'B2 · AppPlugin seed datasets merged (from source) · data',
   'B2 · AppPlugin translation loading into the i18n service (from source) · translations',
-  // [#15232] The by-shape sweep (#15210) found this site, not this pin — so it
-  // is LEDGERED here first, red, before the reader beside it is touched. The
-  // fix and this line's deletion land in the next commit.
-  'B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations',
   'B2 · plugin-security appSecurityPluginOptions over the from-source config (default permission set) · permissions',
   'B2 · runtime collectBundleActions over the from-source config · actions + objects[].actions',
   'B2 · runtime collectBundleFunctionEntries over the from-source config · functions',

--- a/packages/cli/test/option-b-reader-acceptance.pin.test.ts
+++ b/packages/cli/test/option-b-reader-acceptance.pin.test.ts
@@ -143,6 +143,10 @@ const OPTION_B_LOSSES: readonly string[] = [
   'B2 · AppPlugin ql.setDatasourceMapping (object routing) (from source) · datasourceMapping',
   'B2 · AppPlugin seed datasets merged (from source) · data',
   'B2 · AppPlugin translation loading into the i18n service (from source) · translations',
+  // [#15232] The by-shape sweep (#15210) found this site, not this pin — so it
+  // is LEDGERED here first, red, before the reader beside it is touched. The
+  // fix and this line's deletion land in the next commit.
+  'B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations',
   'B2 · plugin-security appSecurityPluginOptions over the from-source config (default permission set) · permissions',
   'B2 · runtime collectBundleActions over the from-source config · actions + objects[].actions',
   'B2 · runtime collectBundleFunctionEntries over the from-source config · functions',

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -151,6 +151,13 @@
     // into this program needs no widening.
     "paths": {
       "@objectstack/objectql": ["../objectql/src/index.ts"],
+      // [#15232] The fourth, added for the same reason and under the same
+      // no-star rule: the option-B probe calls `@objectstack/plugin-dev`'s
+      // shipped i18n auto-detect decision, and this package's vitest config
+      // aliases that same bare specifier to the same source entry, so the type
+      // verdict and the run agree about which artifact is under test. The
+      // package publishes only `"."`.
+      "@objectstack/plugin-dev": ["../plugins/plugin-dev/src/index.ts"],
       "@objectstack/plugin-security": ["../plugins/plugin-security/src/index.ts"],
       "@objectstack/runtime": ["../runtime/src/index.ts"]
     }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -618,6 +618,23 @@ export default defineConfig({
         find: /^@objectstack\/plugin-auth$/,
         replacement: path.resolve(__dirname, '../plugins/plugin-auth/src/index.ts'),
       },
+      // `test/fixtures/option-b-reader-probe.ts` (#15232) calls
+      // `@objectstack/plugin-dev`'s shipped i18n auto-detect decision — the
+      // option-B acceptance pin (#15004) measures readers by CALLING them, and
+      // a reader resolved through `exports` to plugin-dev's **dist** would make
+      // that row a verdict about the last build rather than about the reader
+      // this card changes. The registry in `check-test-source-alias.mjs` is
+      // SHRINK-ONLY, so widening `KNOWN_UNALIASED_TEST_IMPORTS` was never an
+      // option; this entry is the sanctioned remedy, in the same anchored form
+      // as its neighbours (plugin-dev publishes only `"."`, and the anchor is
+      // what keeps that true if a subpath is ever added). Measured before and
+      // after: the gate reports the same required set for this package in both
+      // directions — crossing into `plugin-dev/src` adds no unaliased artifact
+      // import it did not already carry.
+      {
+        find: /^@objectstack\/plugin-dev$/,
+        replacement: path.resolve(__dirname, '../plugins/plugin-dev/src/index.ts'),
+      },
       // `src/utils/protocol-version-gap.test.ts` (#13860) exercises the upgrade
       // advisory, whose verdict comes from `checkProtocolCompat` — the platform's
       // single reader of `engines.protocol`. The advisory is a thin direction

--- a/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #15232 — the i18n auto-detect reads `translations` from `packages[]` too.
+//
+// ── The defect ─────────────────────────────────────────────────────────────
+//
+// `DevPlugin`'s 3b block decided whether to register the file-based
+// `I18nServicePlugin` from `stack.translations` alone. A multi-package artifact
+// under ADR-0130 D4's option-B shape carries each definition once, inside
+// `packages[]`, with no flattened top level — so the read returned `undefined`,
+// the detection said "this app declares no copy", and `os dev` booted on the
+// core in-memory i18n fallback. Nothing throws. Nothing logs. The developer
+// sees message keys, or last release's strings, where the app declared real
+// translations.
+//
+// ── What is pinned here, and in which direction ────────────────────────────
+//
+// Both directions, because only the pair is a discrimination:
+//
+//   - today's ADDITIVE artifact answers exactly as it did before (the flattened
+//     level answers FIRST and short-circuits — the caller's original expression
+//     is preserved, not re-expressed, which is the trap #15006 measured);
+//   - the option-B artifact, whose ONLY copy is under `packages[]`, is now
+//     detected — the row this card added to the #15004 ledger and then deleted.
+//
+// The last case boots the real `DevPlugin` rather than only calling the
+// decision, because what a developer experiences is the SERVICE: the plugin has
+// to reach `new I18nServicePlugin(...)` with the locales the detection derived.
+// `@objectstack/service-i18n` is mocked to a recording double for that arm
+// (present and constructible), and every other optional package is mocked
+// ABSENT — the #3060 convention in this package's sibling tests, which keeps a
+// dev-assembly boot off the vite transform hot path.
+
+import { describe, it, expect, vi } from 'vitest';
+import { composeStacks, defineStack, type ObjectStackDefinition } from '@objectstack/spec';
+
+import { devI18nPluginOptions } from './dev-i18n';
+import { DevPlugin } from './dev-plugin';
+
+const absent = (name: string): Error =>
+  Object.assign(new Error(`Cannot find package '${name}'`), { code: 'ERR_MODULE_NOT_FOUND' });
+
+/** The one package that must be PRESENT: the arm under test constructs it. */
+const i18nConstructions = vi.hoisted(() => [] as unknown[]);
+vi.mock('@objectstack/service-i18n', () => ({
+  I18nServicePlugin: class {
+    name = 'com.objectstack.service.i18n';
+    type = 'service' as const;
+    version = '1.0.0';
+    constructor(options: unknown) { i18nConstructions.push(options); }
+    async init(): Promise<void> { /* the recorder needs no behaviour */ }
+  },
+}));
+
+vi.mock('@objectstack/objectql', () => { throw absent('@objectstack/objectql'); });
+vi.mock('@objectstack/runtime', () => { throw absent('@objectstack/runtime'); });
+vi.mock('@objectstack/driver-memory', () => { throw absent('@objectstack/driver-memory'); });
+vi.mock('@objectstack/service-storage', () => { throw absent('@objectstack/service-storage'); });
+vi.mock('@objectstack/service-realtime', () => { throw absent('@objectstack/service-realtime'); });
+vi.mock('@objectstack/plugin-auth', () => { throw absent('@objectstack/plugin-auth'); });
+vi.mock('@objectstack/plugin-security', () => { throw absent('@objectstack/plugin-security'); });
+vi.mock('@objectstack/plugin-hono-server', () => { throw absent('@objectstack/plugin-hono-server'); });
+vi.mock('@objectstack/rest', () => { throw absent('@objectstack/rest'); });
+vi.mock('@objectstack/setup', () => { throw absent('@objectstack/setup'); });
+vi.mock('@objectstack/account', () => { throw absent('@objectstack/account'); });
+
+// ─── The two-package fixture, in both shapes ────────────────────────────────
+
+const CORE_ID = 'com.example.i18n.core';
+const MODULE_ID = 'com.example.i18n.orders';
+
+const corePackage = (): ObjectStackDefinition =>
+  defineStack({
+    manifest: {
+      id: CORE_ID,
+      name: 'I18n Probe Core',
+      namespace: 'i18nprobe',
+      version: '1.0.0',
+      type: 'app',
+    },
+    objects: [
+      {
+        name: 'i18nprobe_account',
+        label: 'Account',
+        pluralLabel: 'Accounts',
+        sharingModel: 'private',
+        fields: { name: { name: 'name', type: 'text', label: 'Name', required: true } },
+      },
+    ],
+    // The whole point: the app's declared COPY lives in a package.
+    translations: [
+      { en: { objects: { i18nprobe_account: { label: 'Account (translated)' } } } },
+    ],
+  });
+
+const modulePackage = (): ObjectStackDefinition =>
+  defineStack({
+    manifest: {
+      id: MODULE_ID,
+      name: 'I18n Probe Orders',
+      namespace: 'i18nprobe',
+      version: '1.0.0',
+      type: 'module',
+      dependencies: { [CORE_ID]: '^1.0.0' },
+    },
+    objects: [
+      {
+        name: 'i18nprobe_order',
+        label: 'Order',
+        pluralLabel: 'Orders',
+        sharingModel: 'private',
+        fields: { name: { name: 'name', type: 'text', label: 'Number', required: true } },
+      },
+    ],
+  });
+
+/** Today's emitted shape: flattened top level PLUS `packages[]`. */
+const additiveProject = (): Record<string, unknown> =>
+  composeStacks([modulePackage(), corePackage()], { manifest: 'preserve' }) as unknown as Record<string, unknown>;
+
+/** The ruled option-B shape, for the one collection this reader reads. */
+const optionBProject = (): Record<string, unknown> => {
+  const composed = additiveProject();
+  delete composed.translations;
+  return composed;
+};
+
+const mockCtx = () => {
+  const registered = new Map<string, unknown>();
+  const info: string[] = [];
+  const ctx = {
+    logger: {
+      info: (line: unknown) => { if (typeof line === 'string') info.push(line); },
+      debug: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    getService: (name: string) => {
+      if (registered.has(name)) return registered.get(name);
+      throw new Error(`service not found: ${name}`);
+    },
+    getServices: () => new Map(),
+    registerService: (name: string, svc: unknown) => { registered.set(name, svc); },
+    hook: () => undefined,
+    trigger: () => undefined,
+    getKernel: () => undefined,
+  };
+  return { ctx, info };
+};
+
+describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () => {
+  it('CONTROL — the fixture really carries the translations under `packages[]`', () => {
+    // Anti-vacuity: every "detected" below is a READER resolving `packages[]`,
+    // never a fixture that quietly kept a flattened copy.
+    const optionB = optionBProject();
+    expect(optionB.translations).toBeUndefined();
+    const bodies = (optionB.packages as Array<{ manifest?: { id?: string; translations?: unknown[] } }>);
+    expect(bodies.map((p) => p.manifest?.id).sort()).toEqual([CORE_ID, MODULE_ID]);
+    expect(bodies.find((p) => p.manifest?.id === CORE_ID)?.manifest?.translations).toHaveLength(1);
+  });
+
+  it("BASELINE — today's additive artifact answers exactly as it did before", () => {
+    const additive = additiveProject();
+    expect(Array.isArray(additive.translations)).toBe(true);
+    expect(devI18nPluginOptions(additive)).toEqual({ defaultLocale: undefined, fallbackLocale: 'en' });
+  });
+
+  it('THE FIX — the option-B artifact is detected through `packages[]`', () => {
+    expect(devI18nPluginOptions(optionBProject())).toEqual({ defaultLocale: undefined, fallbackLocale: 'en' });
+  });
+
+  it('the flattened level answers FIRST — `packages[]` is not even traversed', () => {
+    // Two things at once, and the malformed `packages` is what proves the
+    // first: the original expression short-circuits, so today's additive
+    // artifact cannot start refusing anything it accepted before.
+    let reads = 0;
+    const stack = {
+      manifest: { id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' },
+      get translations() { reads += 1; return [{ en: { objects: {} } }]; },
+      packages: 'not an array — this would be refused if it were reached',
+    };
+    expect(devI18nPluginOptions(stack)).toEqual({ defaultLocale: undefined, fallbackLocale: 'en' });
+    expect(reads).toBe(1);
+  });
+
+  it('a single-package stack reads its `translations` ONCE, and never throws', () => {
+    // D4's second branch returns the CALLER'S OWN OBJECT as the single package
+    // body, so an unguarded walk would read the same key a second time. The
+    // guard is what keeps every single-package stack on exactly the old path.
+    let reads = 0;
+    const stack = {
+      manifest: { id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' },
+      get translations() { reads += 1; return []; },
+    };
+    expect(devI18nPluginOptions(stack)).toBeUndefined();
+    expect(reads).toBe(1);
+  });
+
+  it('an EMPTY top-level `translations` is not an answer — `packages[]` supplies it', () => {
+    // `[]` is falsy for the original expression (`length > 0`), so this is the
+    // case where `packages[]` legitimately supplies what the top level lacks.
+    const stack = { ...optionBProject(), translations: [] };
+    expect(devI18nPluginOptions(stack)).toEqual({ defaultLocale: undefined, fallbackLocale: 'en' });
+  });
+
+  it('locales still come from the stack `i18n` config, which option B does not move', () => {
+    // `i18n` is an artifact ENVELOPE key, not a package-owned collection, so it
+    // stays at the top level in both shapes and this limb loses nothing.
+    const stack = { ...optionBProject(), i18n: { defaultLocale: 'zh-CN', fallbackLocale: 'en-US' } };
+    expect(devI18nPluginOptions(stack)).toEqual({ defaultLocale: 'zh-CN', fallbackLocale: 'en-US' });
+  });
+
+  it('a malformed `packages[]` is REFUSED with an ADR-0112 envelope, not skipped', () => {
+    // The gate travels with the read: `resolveArtifactPackageOrder` is also
+    // what refuses this artifact at registration, so swallowing it here would
+    // resolve an i18n posture out of a package list nothing else accepts.
+    const stack = {
+      manifest: { id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' },
+      // An entry inlined instead of wrapped as `{ manifest: { … } }`.
+      packages: [{ id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' }],
+    };
+    let caught: (Error & { code?: string; status?: number }) | undefined;
+    try {
+      devI18nPluginOptions(stack);
+    } catch (err) {
+      caught = err as Error & { code?: string; status?: number };
+    }
+    expect(caught?.code).toBe('INVALID_ARTIFACT_PACKAGE_ENTRY');
+    expect(caught?.status).toBe(422);
+    expect(caught?.message).toContain('packages[0]');
+  });
+
+  // ── What the developer actually gets: the SERVICE ─────────────────────────
+
+  const bootWith = async (stack: Record<string, unknown> | undefined) => {
+    i18nConstructions.length = 0;
+    const { ctx, info } = mockCtx();
+    await new DevPlugin({
+      seedAdminUser: false,
+      stack,
+      services: {
+        objectql: false, driver: false, auth: false, setup: false, server: false,
+        rest: false, dispatcher: false, security: false, storage: false,
+        'file-storage': false, realtime: false,
+      },
+    }).init(ctx as never);
+    return { constructions: [...i18nConstructions], info };
+  };
+
+  it('BOOT — a multi-package app under option B gets the file-based I18nServicePlugin', async () => {
+    const { constructions, info } = await bootWith(optionBProject());
+    expect(constructions).toEqual([{ defaultLocale: undefined, fallbackLocale: 'en' }]);
+    expect(info.some((l) => l.includes('I18nServicePlugin auto-registered'))).toBe(true);
+  });
+
+  it('BOOT — a stack declaring no copy at all still gets no I18nServicePlugin', async () => {
+    // The negative control. Without it the assertion above would pass for a
+    // detection that fires unconditionally.
+    const bare = { manifest: { id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' } };
+    const { constructions, info } = await bootWith(bare);
+    expect(constructions).toEqual([]);
+    expect(info.some((l) => l.includes('I18nServicePlugin auto-registered'))).toBe(false);
+  });
+});

--- a/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
@@ -23,6 +23,16 @@
 //   - the option-B artifact, whose ONLY copy is under `packages[]`, is now
 //     detected — the row this card added to the #15004 ledger and then deleted.
 //
+// Two more, added after an adversarial contract review measured the first draft
+// of this file claiming more than it pinned:
+//
+//   - a composed multi-package stack with NO i18n anywhere DOES reach
+//     `resolveArtifactPackageOrder` (counted, not argued). The short-circuit is
+//     real only for a stack whose flattened `translations` is non-empty.
+//   - therefore the gate's refusals are reachable on the ORDINARY path, so a
+//     project the gate refuses — one whose package manifest still carries
+//     authoring globs — must keep booting. It does, loudly.
+//
 // The last case boots the real `DevPlugin` rather than only calling the
 // decision, because what a developer experiences is the SERVICE: the plugin has
 // to reach `new I18nServicePlugin(...)` with the locales the detection derived.
@@ -128,6 +138,24 @@ const modulePackage = (): ObjectStackDefinition =>
 const additiveProject = (): Record<string, unknown> =>
   composeStacks([modulePackage(), corePackage()], { manifest: 'preserve' }) as unknown as Record<string, unknown>;
 
+/**
+ * The SAME composition with no i18n anywhere — no `translations` at any level,
+ * no `i18n` config, no `manifest.translations`. This is the ordinary
+ * multi-package app that simply does not translate, and it is the shape the
+ * reachability claim turns on.
+ */
+const additiveNoI18nProject = (): Record<string, unknown> => {
+  const composed = composeStacks(
+    [modulePackage(), { ...corePackage(), translations: undefined } as ObjectStackDefinition],
+    { manifest: 'preserve' },
+  ) as unknown as Record<string, unknown>;
+  delete composed.translations;
+  for (const entry of composed.packages as Array<{ manifest?: Record<string, unknown> }>) {
+    delete entry.manifest?.translations;
+  }
+  return composed;
+};
+
 /** The ruled option-B shape, for the one collection this reader reads. */
 const optionBProject = (): Record<string, unknown> => {
   const composed = additiveProject();
@@ -138,12 +166,13 @@ const optionBProject = (): Record<string, unknown> => {
 const mockCtx = () => {
   const registered = new Map<string, unknown>();
   const info: string[] = [];
+  const errors: string[] = [];
   const ctx = {
     logger: {
       info: (line: unknown) => { if (typeof line === 'string') info.push(line); },
       debug: () => undefined,
       warn: () => undefined,
-      error: () => undefined,
+      error: (line: unknown) => { if (typeof line === 'string') errors.push(line); },
     },
     getService: (name: string) => {
       if (registered.has(name)) return registered.get(name);
@@ -155,7 +184,7 @@ const mockCtx = () => {
     trigger: () => undefined,
     getKernel: () => undefined,
   };
-  return { ctx, info };
+  return { ctx, info, errors };
 };
 
 describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () => {
@@ -179,10 +208,11 @@ describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () 
     expect(devI18nPluginOptions(optionBProject())).toEqual({ defaultLocale: undefined, fallbackLocale: 'en' });
   });
 
-  it('the flattened level answers FIRST — `packages[]` is not even traversed', () => {
-    // Two things at once, and the malformed `packages` is what proves the
-    // first: the original expression short-circuits, so today's additive
-    // artifact cannot start refusing anything it accepted before.
+  it('the flattened level answers FIRST **when it has something to say** — `packages[]` is not traversed then', () => {
+    // ⚠️ Scope, stated because an earlier draft of this file read this case as
+    // proof of something wider: it pins the short-circuit for a stack whose top
+    // level ALREADY declares translations. It says nothing about a stack that
+    // declares none — that case is the one below, and it reaches the gate.
     let reads = 0;
     const stack = {
       manifest: { id: CORE_ID, name: 'x', version: '1.0.0', type: 'app' },
@@ -204,6 +234,69 @@ describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () 
     };
     expect(devI18nPluginOptions(stack)).toBeUndefined();
     expect(reads).toBe(1);
+  });
+
+  it('a composed multi-package stack with NO i18n DOES reach the artifact gate — and answers undefined without throwing', () => {
+    // The measurement that falsified this PR's first draft ("for every artifact
+    // the platform produces today the packages[] pass is not even reached").
+    // It is reached, on the ordinary path, for every multi-package app that
+    // does not translate — so the walk is real work and its refusals are
+    // reachable in ordinary use, which is why `DevPlugin` degrades on them.
+    //
+    // `packages` is read TWICE when the gate is reached and ZERO times when the
+    // flattened level short-circuits: once by this reader's own absent-key
+    // guard, once inside `resolveArtifactPackageOrder`. That second read is the
+    // discriminator, so the assertion is on it and not on "at least one".
+    let packagesReads = 0;
+    const project = additiveNoI18nProject();
+    const counted = new Proxy(project, {
+      get(target, key, recv) {
+        if (key === 'packages') packagesReads += 1;
+        return Reflect.get(target, key, recv);
+      },
+    });
+
+    expect(project.translations).toBeUndefined();
+    expect((project.packages as unknown[]).length).toBe(2);
+    expect(() => devI18nPluginOptions(counted)).not.toThrow();
+    expect(devI18nPluginOptions(counted)).toBeUndefined();
+    expect(packagesReads).toBeGreaterThanOrEqual(2);
+  });
+
+  it('a stack that already declares its locales is answered WITHOUT walking `packages[]`', () => {
+    // The limbs are asked cheapest-first: an `i18n` config answers the question
+    // on its own, so a `packages` list that answer never needed cannot refuse
+    // it. Before the reorder this threw INVALID_ARTIFACT_PACKAGES.
+    const stack = {
+      ...additiveNoI18nProject(),
+      i18n: { defaultLocale: 'zh-CN' },
+      packages: 'not an array — would be refused if this limb were reached',
+    };
+    expect(devI18nPluginOptions(stack)).toEqual({ defaultLocale: 'zh-CN', fallbackLocale: 'zh-CN' });
+  });
+
+  it('a dependency CYCLE between two packages throws a BARE Error — no `code`, no `status`', () => {
+    // Documented under @throws because it is the one refusal here that does not
+    // carry the ADR-0112 envelope: it comes from `resolvePluginOrder`, the
+    // platform's one topological sorter, not from the artifact gate. A caller
+    // matching on `code` alone would miss it — `DevPlugin`'s catch does not.
+    const cyclic = {
+      manifest: { id: 'a', name: 'A', version: '1.0.0', type: 'app' },
+      packages: [
+        { manifest: { id: 'a', name: 'A', version: '1.0.0', type: 'app', dependencies: { b: '^1.0.0' } } },
+        { manifest: { id: 'b', name: 'B', version: '1.0.0', type: 'module', dependencies: { a: '^1.0.0' } } },
+      ],
+    };
+    let caught: (Error & { code?: unknown; status?: unknown }) | undefined;
+    try {
+      devI18nPluginOptions(cyclic);
+    } catch (err) {
+      caught = err as Error & { code?: unknown; status?: unknown };
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught?.message).toContain('Circular dependency detected');
+    expect(caught?.code).toBeUndefined();
+    expect(caught?.status).toBeUndefined();
   });
 
   it('an EMPTY top-level `translations` is not an answer — `packages[]` supplies it', () => {
@@ -244,7 +337,7 @@ describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () 
 
   const bootWith = async (stack: Record<string, unknown> | undefined) => {
     i18nConstructions.length = 0;
-    const { ctx, info } = mockCtx();
+    const { ctx, info, errors } = mockCtx();
     await new DevPlugin({
       seedAdminUser: false,
       stack,
@@ -254,13 +347,46 @@ describe('#15232 — DevPlugin i18n auto-detect over a multi-package stack', () 
         'file-storage': false, realtime: false,
       },
     }).init(ctx as never);
-    return { constructions: [...i18nConstructions], info };
+    return { constructions: [...i18nConstructions], info, errors };
   };
 
   it('BOOT — a multi-package app under option B gets the file-based I18nServicePlugin', async () => {
     const { constructions, info } = await bootWith(optionBProject());
     expect(constructions).toEqual([{ defaultLocale: undefined, fallbackLocale: 'en' }]);
     expect(info.some((l) => l.includes('I18nServicePlugin auto-registered'))).toBe(true);
+  });
+
+  it('BOOT — a project the ADR-0130 D4 gate REFUSES still boots, loudly, on the fallback', async () => {
+    // The regression this posture exists to prevent, reproduced: one package's
+    // authoring manifest still declares glob `objects` (`ManifestSchema`'s
+    // written form, and the repo's own CONFIG_GLOBS fixture in
+    // packages/cli/test/build-multi-package-artifact.e2e.test.ts). Such a body
+    // is refused by `ArtifactPackageSchema` BY DESIGN
+    // (packages/spec/src/assembled-package-body.test.ts). That project boots
+    // today; a reader that threw here would have stopped it booting — and from
+    // the block whose only job is deciding whether to register a translation
+    // service, while `new AppPlugin(...)` twenty lines above degrades the very
+    // same refusal to a log line.
+    const refused = additiveNoI18nProject();
+    (refused.packages as Array<{ manifest: Record<string, unknown> }>)[0]
+      .manifest.objects = ['./src/objects/*.object.ts'];
+
+    // The reader itself still refuses — the gate travels with the read.
+    expect(() => devI18nPluginOptions(refused)).toThrow();
+
+    // The PLUGIN does not. It boots, says exactly what is wrong, and registers
+    // nothing.
+    const { constructions, info, errors } = await bootWith(refused);
+    expect(constructions).toEqual([]);
+    expect(info.some((l) => l.includes('I18nServicePlugin auto-registered'))).toBe(false);
+    const line = errors.find((l) => l.includes('i18n auto-detect could not read'));
+    expect(line, `no diagnosis line; errors were:\n${errors.join('\n')}`).toBeDefined();
+    // ⛔ Never silent, and never mis-attributed to a missing package (#7926):
+    // the line names the metadata defect and carries the refusal verbatim.
+    expect(line).toContain('PACKAGE LIST is malformed');
+    expect(line).toContain('INVALID_ARTIFACT_PACKAGE_ENTRY');
+    expect(line).toContain('packages[0]');
+    expect(line).not.toContain('not installed');
   });
 
   it('BOOT — a stack declaring no copy at all still gets no I18nServicePlugin', async () => {

--- a/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n-packages-reader.test.ts
@@ -54,7 +54,17 @@ vi.mock('@objectstack/service-i18n', () => ({
 
 vi.mock('@objectstack/objectql', () => { throw absent('@objectstack/objectql'); });
 vi.mock('@objectstack/runtime', () => { throw absent('@objectstack/runtime'); });
-vi.mock('@objectstack/driver-memory', () => { throw absent('@objectstack/driver-memory'); });
+// ⛔ NO `@objectstack/driver-memory` mock here, deliberately — do not copy one in
+// from the sibling harnesses. `vi.mock` counts as a DECLARATION to
+// `scripts/check-driver-memory-census.mjs`, and that package's consumer set is
+// locked by maintainer ruling (#5499 froze investment, #5704 / #6664 ruled each
+// remaining consumer). A third test consumer is the #6664 defect itself, not a
+// bookkeeping chore. Nothing here needs it: every boot below passes
+// `services: { driver: false }`, and `dev-plugin.ts`'s ONE
+// `import('@objectstack/driver-memory')` sits inside `if (enabled('driver'))`,
+// so the specifier is never reached. Measured, not assumed: with the line gone
+// this suite is unchanged at 68 passed, both BOOT cases below green in 5ms and
+// 1ms — timings a real `import()` of that package would not fit in.
 vi.mock('@objectstack/service-storage', () => { throw absent('@objectstack/service-storage'); });
 vi.mock('@objectstack/service-realtime', () => { throw absent('@objectstack/service-realtime'); });
 vi.mock('@objectstack/plugin-auth', () => { throw absent('@objectstack/plugin-auth'); });

--- a/packages/plugins/plugin-dev/src/dev-i18n.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n.ts
@@ -47,14 +47,31 @@ const declaresTranslationArray = (body: unknown): boolean => {
  *
  * The reader half of the program lands while the artifact is still ADDITIVE, so
  * this has to be a superset of the old read rather than a replacement for it:
- * every artifact the platform emits today still answers on the flattened level,
- * bit-identically, and the `packages[]` pass can only supply a declaration the
+ * the ANSWER for every artifact the platform emits today is bit-identical,
+ * because `composeStacks` merges `translations` with `'concat'`
+ * (`stack.zod.ts`), so a package that declares copy always leaves a non-empty
+ * flattened array too. The `packages[]` pass can only supply a declaration the
  * top level did not have — which is precisely the option-B shape. Keeping the
  * caller's original expression as the first answer is also what stops the
  * measured trap #15006 recorded: re-expressing a gate as a resolved-and-counted
  * traversal silently changes the verdict for a stack that declares the key
  * empty. Here the original expression is `Array.isArray(t) && t.length > 0` and
  * it is preserved verbatim, both at the top level and per package body.
+ *
+ * ⚠️ **The same answer is NOT the same work, and an earlier draft of this file
+ * said it was.** The flattened read returns early only when `translations` is
+ * present and NON-EMPTY. So every stack that carries `packages[]` and declares
+ * no i18n at all — no `i18n` config, no `manifest.translations`, no non-empty
+ * top-level `translations`, i.e. the ordinary multi-package app that simply
+ * does not translate — DOES reach `resolveArtifactPackageOrder`, on every
+ * `DevPlugin.init`, and pays a full ADR-0130 D4 parse of every package body.
+ * Measured with a counting proxy on a real `composeStacks(…, 'preserve')`
+ * output, not reasoned about; the case is pinned below. Two things follow, and
+ * both are load-bearing: {@link devI18nPluginOptions} asks the cheap limbs
+ * FIRST so a stack that already declares its locales never pays this, and the
+ * refusals documented under `@throws` are reachable in ORDINARY use rather than
+ * only for exotic input — which is why `DevPlugin` degrades on them instead of
+ * dying.
  *
  * ## The order is `resolveArtifactPackageOrder`'s, not the array's
  *
@@ -85,10 +102,35 @@ const declaresTranslationArray = (body: unknown): boolean => {
  * `status: 422`) out of this call, and it is deliberately not caught. It is the
  * same refusal `ObjectQL.registerApp` raises for the same object later in the
  * same boot (the registration path IS reached from `AppPlugin.start`, measured
- * on both shapes in #14512 comment 5523603341), so catching it here would
- * resolve an i18n posture out of a package list nothing else will accept — the
- * gate travels with the read. ⚠️ It can only be reached at all when the top
- * level declares no translations, because the flattened answer returns first.
+ * on both shapes in #14512 comment 5523603341), so answering out of a package
+ * list nothing else will accept is not something this function does — the gate
+ * travels with the read.
+ *
+ * ⚠️ What that means for a CALLER is a separate question, and `DevPlugin`
+ * answers it the other way: it catches, says so loudly and boots anyway. The
+ * reason is not comfort — it is consistency with what already ships. Twenty
+ * lines above the i18n block, `new AppPlugin(this.options.stack)` parses the
+ * same object and its refusal is degraded to one log line, so a detector for
+ * "should I register a translation service" must not refuse harder than the
+ * gate for "should I register this app's metadata at all". The measured
+ * regression that made this concrete: a project whose package manifest still
+ * carries authoring-time glob `objects` is refused by `ArtifactPackageSchema`
+ * BY DESIGN, boots today, and would have stopped booting on this reader alone.
+ * ⛔ Whether `DevPlugin` should refuse malformed metadata outright is a
+ * maintainer question filed separately; it is not decided here, and this
+ * function's own semantics are unchanged by it.
+ *
+ * ## The guard divergence with `@objectstack/core`, recorded rather than fixed
+ *
+ * This reader treats only an ABSENT `packages` key (`undefined` / `null`) as
+ * "single package"; anything else goes to the gate, so `packages: {}` is
+ * REFUSED. `resolveArtifactPackageOrder`'s own second branch is spelled
+ * `declared === undefined || declared === null` too, but the sibling reader in
+ * `@objectstack/metadata` guards with `Array.isArray`, which silently accepts a
+ * non-array. Two readers in one program answering the same input differently is
+ * a program-level split, not this file's to settle (#15226 spells it as this
+ * file does). Recorded here so the next author does not "fix" one side into
+ * agreement without ruling the other.
  *
  * ## `i18n` is NOT read from `packages[]`, and that is not an omission
  *
@@ -99,6 +141,24 @@ const declaresTranslationArray = (body: unknown): boolean => {
  * still carries `stack.i18n` and `stack.manifest` exactly where they are today,
  * so those two limbs of the detection lose nothing and are left untouched.
  * `translations` is the one limb the strip moves.
+ *
+ * @param stack - Any value. A non-object (`null`, a primitive, a function) and
+ *   an object with no `translations` and no `packages` both answer `false`
+ *   without reaching the gate.
+ * @returns Whether any level of this stack declares a non-empty `translations`
+ *   array.
+ * @throws An ADR-0112 envelope (`Error & { code, status: 422 }`) from
+ *   `resolveArtifactPackageOrder` when `packages` is present but not loadable:
+ *   `INVALID_ARTIFACT_PACKAGES` (not an array), `INVALID_ARTIFACT_PACKAGE_ENTRY`
+ *   (an entry that is not `{ manifest: … }`, a body carrying authoring-time
+ *   globs where definitions belong, or a manifest with no usable id) or
+ *   `DUPLICATE_ARTIFACT_PACKAGE`.
+ * @throws A **bare** `Error` — no `code`, no `status` — from `resolvePluginOrder`
+ *   when two packages in `packages[]` depend on each other
+ *   (`[Kernel] Circular dependency detected: …`). Documented because it is the
+ *   one failure here that does NOT carry the envelope every other refusal in
+ *   this repo does, so a caller matching on `code` alone will miss it. Measured,
+ *   not inferred from the sorter's prose.
  */
 export function stackDeclaresTranslations(stack: unknown): boolean {
   // The caller's ORIGINAL expression, first and unchanged.
@@ -130,23 +190,50 @@ export function stackDeclaresTranslations(stack: unknown): boolean {
  * manifest's glob patterns, which are a declaration of intent even before a
  * bundle is assembled.
  *
+ * ## The three limbs are asked CHEAPEST FIRST, and that ordering is a fix
+ *
+ * `||` is commutative, so the ANSWER does not depend on the order — but which
+ * inputs can make this call throw does. The `translations` limb is the only one
+ * that can reach `resolveArtifactPackageOrder`, so asking it first meant a
+ * stack that had already stated its locales in `i18n` could still be refused
+ * over a `packages` list that answer never needed. The envelope limbs are pure
+ * property reads on the stack and its manifest; they are asked first, and only
+ * a stack that answers neither of them pays the package walk.
+ *
  * Exported because the #15004 option-B acceptance probe measures this decision
  * by CALLING it. A probe that re-implemented the read would be a second copy of
  * the code the reader program changes, and would stay red after the reader
  * beside it was fixed.
+ *
+ * @param stack - The caller-supplied stack (`new DevPlugin({ stack })`).
+ * @returns The options to construct `I18nServicePlugin` with, or `undefined`
+ *   when this stack declares no i18n content at all.
+ * @throws Everything {@link stackDeclaresTranslations} throws, and only from
+ *   that limb: the ADR-0112 envelopes (`code` + `status: 422`) for a `packages`
+ *   list that is not loadable, and the **bare** `Error` (no `code`, no
+ *   `status`) for a dependency cycle between two packages. ⚠️ A stack whose
+ *   `i18n` / `manifest.i18n` / `manifest.translations` answers the question
+ *   never reaches that limb and therefore never throws. `DevPlugin` catches
+ *   both classes, reports the metadata defect and boots on the in-memory
+ *   fallback — see `dev-plugin.ts`'s 3b block for why degrading is the
+ *   consistent posture there.
  */
 export function devI18nPluginOptions(stack: unknown): DevI18nPluginOptions | undefined {
   const bag = asBag(stack);
   if (!bag) return undefined;
 
   const manifest = asBag(bag.manifest);
-  const hasTranslations = stackDeclaresTranslations(stack);
+  // Cheapest first — see the docblock. These two are property reads that cannot
+  // throw; `stackDeclaresTranslations` is the limb that can reach the artifact
+  // gate, so it is asked LAST and only when the others answered no.
   const hasI18nConfig = !!(bag.i18n || manifest?.i18n);
   const hasManifestTranslations = !!(
     manifest && Array.isArray(manifest.translations) && manifest.translations.length > 0
   );
 
-  if (!hasTranslations && !hasI18nConfig && !hasManifestTranslations) return undefined;
+  if (!hasI18nConfig && !hasManifestTranslations && !stackDeclaresTranslations(stack)) {
+    return undefined;
+  }
 
   // `stack.i18n || stack.manifest.i18n || {}`, the original expression: the
   // stack's own config wins, the manifest's is the fallback, and neither being

--- a/packages/plugins/plugin-dev/src/dev-i18n.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n.ts
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
+import { resolveArtifactPackageOrder } from '@objectstack/core';
+
 /**
  * The options `DevPlugin` hands `I18nServicePlugin` when it auto-registers it.
  *
@@ -21,17 +23,94 @@ const declaresTranslationArray = (body: unknown): boolean => {
 };
 
 /**
- * Does this stack DECLARE translations?
+ * [ADR-0130 D4, #15232] Does this stack DECLARE translations — at the flattened
+ * top level, or inside `packages[]`?
  *
- * ⚠️ TOP LEVEL ONLY, which is the defect #15232 exists to fix — recorded here
- * so this intermediate commit is not mistaken for the fix. A multi-package
- * artifact under ADR-0130 D4's option-B shape carries `translations` inside
- * `packages[]` and nothing at the top level, so this answers `false` and the
- * dev server keeps the in-memory i18n fallback with nothing thrown and nothing
- * logged. The probe row landing in the same commit ledgers exactly that loss.
+ * ## What this exists to stop
+ *
+ * A multi-package artifact carries each definition twice today: flattened onto
+ * the top level, and again inside `packages[i].manifest`. Option B (the
+ * ADR-0130 D4 ruling on #14512) removes the flattened copy, so `packages[]`
+ * carries it once. A reader that only ever looked at the top level does not
+ * fail when that happens — `stack.translations` is simply `undefined`, the
+ * detection answers "this app declared no copy", and the boot continues.
+ *
+ * For THIS reader the consequence is a dev server that serves the wrong
+ * strings. `I18nServicePlugin` (`@objectstack/service-i18n`) is never
+ * registered, so the `i18n` slot keeps the core in-memory fallback and the
+ * developer sees message KEYS, or last release's copy, where the app declared
+ * real translations. Nothing throws and nothing logs — the failure reads as
+ * "the translations are wrong", which is why it needs a reader fix rather than
+ * a footnote.
+ *
+ * ## Top level FIRST, `packages[]` only where it came back falsy
+ *
+ * The reader half of the program lands while the artifact is still ADDITIVE, so
+ * this has to be a superset of the old read rather than a replacement for it:
+ * every artifact the platform emits today still answers on the flattened level,
+ * bit-identically, and the `packages[]` pass can only supply a declaration the
+ * top level did not have — which is precisely the option-B shape. Keeping the
+ * caller's original expression as the first answer is also what stops the
+ * measured trap #15006 recorded: re-expressing a gate as a resolved-and-counted
+ * traversal silently changes the verdict for a stack that declares the key
+ * empty. Here the original expression is `Array.isArray(t) && t.length > 0` and
+ * it is preserved verbatim, both at the top level and per package body.
+ *
+ * ## The order is `resolveArtifactPackageOrder`'s, not the array's
+ *
+ * `resolveArtifactPackageOrder` (`@objectstack/core`, ADR-0130 D4+D5, #14643)
+ * is the ONE place that turns an artifact into its ordered package list, and it
+ * is also the GATE that parses each entry. ⛔ Do not iterate `stack.packages`
+ * directly: a second traversal is a second ordering, and this reader would then
+ * disagree with the load path about which artifacts are even loadable.
+ *
+ * ⚠️ Stated so the next reader does not mistake the reason: the ORDER itself is
+ * not observable through a boolean — any package declaring translations answers
+ * the same question. What is observable is the GATE. A hand-rolled loop over
+ * `stack.packages` would accept a duplicate package id, an unwrapped entry or a
+ * body carrying authoring-time globs and answer "this app declares copy" for an
+ * artifact the registration path refuses moments later. That is why the one
+ * traversal is used even where its ordering does not show.
+ *
+ * The `packages` guard above it is not an optimisation. D4's second branch
+ * makes `resolveArtifactPackageOrder` return the CALLER'S OWN OBJECT as the
+ * single package body when the key is absent, so walking it unguarded would
+ * read the top-level `translations` a second time — the same answer, reached
+ * twice, for every single-package stack the platform has ever emitted.
+ *
+ * ## A malformed `packages[]` is refused, not skipped
+ *
+ * A non-array `packages`, an entry inlined instead of wrapped under `manifest:`
+ * or a duplicate package id raises an ADR-0112 envelope (`code` +
+ * `status: 422`) out of this call, and it is deliberately not caught. It is the
+ * same refusal `ObjectQL.registerApp` raises for the same object later in the
+ * same boot (the registration path IS reached from `AppPlugin.start`, measured
+ * on both shapes in #14512 comment 5523603341), so catching it here would
+ * resolve an i18n posture out of a package list nothing else will accept — the
+ * gate travels with the read. ⚠️ It can only be reached at all when the top
+ * level declares no translations, because the flattened answer returns first.
+ *
+ * ## `i18n` is NOT read from `packages[]`, and that is not an omission
+ *
+ * `i18n` is an artifact ENVELOPE key, not a package-owned collection — derived,
+ * not asserted: the package-owned set is `ObjectStackDefinitionSchema` ∩
+ * `AssembledPackageBodySchema`, and `i18n` is in the seven-key complement
+ * (`ARTIFACT_ENVELOPE_KEYS`, pinned by #15004). An option-B artifact therefore
+ * still carries `stack.i18n` and `stack.manifest` exactly where they are today,
+ * so those two limbs of the detection lose nothing and are left untouched.
+ * `translations` is the one limb the strip moves.
  */
 export function stackDeclaresTranslations(stack: unknown): boolean {
-  return declaresTranslationArray(stack);
+  // The caller's ORIGINAL expression, first and unchanged.
+  if (declaresTranslationArray(stack)) return true;
+
+  const packages = asBag(stack)?.packages;
+  if (packages === undefined || packages === null) return false;
+
+  for (const body of resolveArtifactPackageOrder(stack)) {
+    if (declaresTranslationArray(body)) return true;
+  }
+  return false;
 }
 
 /**
@@ -45,11 +124,11 @@ export function stackDeclaresTranslations(stack: unknown): boolean {
  * a locale resolved from somewhere else.
  *
  * Three declarations trigger it, exactly as they have since the auto-detect was
- * written: a `translations` collection (read through
- * {@link stackDeclaresTranslations}), an `i18n` config on the stack or its
- * manifest, or `manifest.translations` — the authoring manifest's glob
- * patterns, which are a declaration of intent even before a bundle is
- * assembled.
+ * written: a `translations` collection (now read through
+ * {@link stackDeclaresTranslations}, so `packages[]` counts), an `i18n` config
+ * on the stack or its manifest, or `manifest.translations` — the authoring
+ * manifest's glob patterns, which are a declaration of intent even before a
+ * bundle is assembled.
  *
  * Exported because the #15004 option-B acceptance probe measures this decision
  * by CALLING it. A probe that re-implemented the read would be a second copy of

--- a/packages/plugins/plugin-dev/src/dev-i18n.ts
+++ b/packages/plugins/plugin-dev/src/dev-i18n.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The options `DevPlugin` hands `I18nServicePlugin` when it auto-registers it.
+ *
+ * `defaultLocale` stays optional because the detected stack may declare
+ * translations without declaring an i18n config at all — that is the common
+ * case, and `I18nServicePlugin`'s own default is what should apply then.
+ */
+export interface DevI18nPluginOptions {
+  defaultLocale?: string;
+  fallbackLocale: string;
+}
+
+const asBag = (value: unknown): Record<string, unknown> | undefined =>
+  (value && typeof value === 'object' ? value as Record<string, unknown> : undefined);
+
+const declaresTranslationArray = (body: unknown): boolean => {
+  const declared = asBag(body)?.translations;
+  return Array.isArray(declared) && declared.length > 0;
+};
+
+/**
+ * Does this stack DECLARE translations?
+ *
+ * ⚠️ TOP LEVEL ONLY, which is the defect #15232 exists to fix — recorded here
+ * so this intermediate commit is not mistaken for the fix. A multi-package
+ * artifact under ADR-0130 D4's option-B shape carries `translations` inside
+ * `packages[]` and nothing at the top level, so this answers `false` and the
+ * dev server keeps the in-memory i18n fallback with nothing thrown and nothing
+ * logged. The probe row landing in the same commit ledgers exactly that loss.
+ */
+export function stackDeclaresTranslations(stack: unknown): boolean {
+  return declaresTranslationArray(stack);
+}
+
+/**
+ * [#15232] The `I18nServicePlugin` options a stack implies — the ONE decision
+ * `DevPlugin`'s i18n auto-detect makes, resolved in one place.
+ *
+ * `undefined` means "this stack declares no i18n content", i.e. do not register
+ * the file-based service and leave the slot to the core in-memory fallback.
+ * Returning the options rather than a boolean is what keeps the decision and
+ * the values it derives from the same read — a caller cannot pair a `true` with
+ * a locale resolved from somewhere else.
+ *
+ * Three declarations trigger it, exactly as they have since the auto-detect was
+ * written: a `translations` collection (read through
+ * {@link stackDeclaresTranslations}), an `i18n` config on the stack or its
+ * manifest, or `manifest.translations` — the authoring manifest's glob
+ * patterns, which are a declaration of intent even before a bundle is
+ * assembled.
+ *
+ * Exported because the #15004 option-B acceptance probe measures this decision
+ * by CALLING it. A probe that re-implemented the read would be a second copy of
+ * the code the reader program changes, and would stay red after the reader
+ * beside it was fixed.
+ */
+export function devI18nPluginOptions(stack: unknown): DevI18nPluginOptions | undefined {
+  const bag = asBag(stack);
+  if (!bag) return undefined;
+
+  const manifest = asBag(bag.manifest);
+  const hasTranslations = stackDeclaresTranslations(stack);
+  const hasI18nConfig = !!(bag.i18n || manifest?.i18n);
+  const hasManifestTranslations = !!(
+    manifest && Array.isArray(manifest.translations) && manifest.translations.length > 0
+  );
+
+  if (!hasTranslations && !hasI18nConfig && !hasManifestTranslations) return undefined;
+
+  // `stack.i18n || stack.manifest.i18n || {}`, the original expression: the
+  // stack's own config wins, the manifest's is the fallback, and neither being
+  // present means the service plugin's own defaults apply.
+  const i18nConfig = (bag.i18n || manifest?.i18n || {}) as {
+    defaultLocale?: string;
+    fallbackLocale?: string;
+  };
+  return {
+    defaultLocale: i18nConfig.defaultLocale,
+    fallbackLocale: i18nConfig.fallbackLocale || i18nConfig.defaultLocale || 'en',
+  };
+}

--- a/packages/plugins/plugin-dev/src/dev-plugin.ts
+++ b/packages/plugins/plugin-dev/src/dev-plugin.ts
@@ -4,6 +4,8 @@ import { Plugin, PluginContext } from '@objectstack/core';
 import { resolveAllowDegradedTenancy, resolveAllowDevPlugin, resolveTenancyPosture } from '@objectstack/types';
 import { postureEnforcesWall } from '@objectstack/spec/security';
 
+import { devI18nPluginOptions } from './dev-i18n.js';
+
 /**
  * Dev Plugin Options
  *
@@ -522,19 +524,19 @@ export class DevPlugin implements Plugin {
     //     file-based i18n. Falls back to the core in-memory i18n fallback
     //     (with locale resolution) if the package is not installed.
     if (enabled('i18n') && this.options.stack) {
-      const stack = this.options.stack;
-      const hasTranslations = Array.isArray(stack.translations) && stack.translations.length > 0;
-      const hasI18nConfig = !!(stack.i18n || (stack.manifest && stack.manifest.i18n));
-      const hasManifestTranslations = !!(stack.manifest && Array.isArray(stack.manifest.translations) && stack.manifest.translations.length > 0);
+      // [#15232] The detection AND the locales it derives are one decision,
+      // resolved in `dev-i18n.ts` — which reads `translations` at the flattened
+      // top level first and then through `resolveArtifactPackageOrder`, so a
+      // multi-package app under ADR-0130 D4's option-B shape is detected
+      // instead of silently falling back to the in-memory i18n. The dynamic
+      // import and its degradation stay HERE, because they are about the
+      // optional PACKAGE being installed, not about what the stack declares.
+      const i18nOptions = devI18nPluginOptions(this.options.stack);
 
-      if (hasTranslations || hasI18nConfig || hasManifestTranslations) {
+      if (i18nOptions) {
         try {
           const { I18nServicePlugin } = await import('@objectstack/service-i18n') as any;
-          const i18nConfig = stack.i18n || (stack.manifest || stack)?.i18n || {};
-          const i18nPlugin = new I18nServicePlugin({
-            defaultLocale: i18nConfig.defaultLocale,
-            fallbackLocale: i18nConfig.fallbackLocale || i18nConfig.defaultLocale || 'en',
-          });
+          const i18nPlugin = new I18nServicePlugin(i18nOptions);
           this.childPlugins.push(i18nPlugin);
           ctx.logger.info('  ✔ I18nServicePlugin auto-registered (translations detected in stack)');
         } catch (err) {

--- a/packages/plugins/plugin-dev/src/dev-plugin.ts
+++ b/packages/plugins/plugin-dev/src/dev-plugin.ts
@@ -4,7 +4,7 @@ import { Plugin, PluginContext } from '@objectstack/core';
 import { resolveAllowDegradedTenancy, resolveAllowDevPlugin, resolveTenancyPosture } from '@objectstack/types';
 import { postureEnforcesWall } from '@objectstack/spec/security';
 
-import { devI18nPluginOptions } from './dev-i18n.js';
+import { devI18nPluginOptions, type DevI18nPluginOptions } from './dev-i18n.js';
 
 /**
  * Dev Plugin Options
@@ -531,7 +531,43 @@ export class DevPlugin implements Plugin {
       // instead of silently falling back to the in-memory i18n. The dynamic
       // import and its degradation stay HERE, because they are about the
       // optional PACKAGE being installed, not about what the stack declares.
-      const i18nOptions = devI18nPluginOptions(this.options.stack);
+      let i18nOptions: DevI18nPluginOptions | undefined;
+      try {
+        i18nOptions = devI18nPluginOptions(this.options.stack);
+      } catch (err) {
+        // [#15232] A metadata-SHAPE defect, degraded — deliberately, and NOT
+        // through `reportOptionalLoadFailure`.
+        //
+        // Two things are wrong with refusing here, and both were measured. The
+        // reach: this is not exotic input. A stack carrying `packages[]` that
+        // declares no i18n at all walks the whole package list on every boot,
+        // so an artifact the ADR-0130 D4 gate refuses — a package body still
+        // carrying authoring-time glob `objects`, for instance, which
+        // `ArtifactPackageSchema` rejects by design — arrives here on the
+        // ordinary path. The inversion: twenty lines above, `new AppPlugin(...)`
+        // parses the SAME object and its refusal is degraded to a log line, so
+        // refusing here would make "should I register a translation service?"
+        // a harder gate than "should I register this app's metadata at all?".
+        // A project like that boots today; it must keep booting.
+        //
+        // ⛔ Not `reportOptionalLoadFailure`: its text says the PACKAGE is
+        // installed but failed to initialize, and naming a package for a
+        // metadata-shape defect is exactly the mis-attribution #7926 removed
+        // from this file. ⛔ And not a silent skip either — silence is the
+        // failure class this whole change exists to remove. Its own line, its
+        // own diagnosis, carrying the refusal verbatim.
+        const code = (err as { code?: unknown })?.code;
+        ctx.logger.error(
+          '  ✘ the i18n auto-detect could not read this stack\'s `packages[]` — skipping '
+          + 'I18nServicePlugin and continuing on the core in-memory i18n fallback. This is NOT '
+          + 'a missing-package problem and installing anything will not help: the stack\'s '
+          + 'PACKAGE LIST is malformed (ADR-0130 D4), and `os build` refuses the same project '
+          + 'with its own compile diagnostic. Translations this app declares will not be '
+          + 'served until it is fixed. The artifact reader reported (verbatim — the framework '
+          + `does not interpret it): ${typeof code === 'string' ? `${code}: ` : ''}`
+          + `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
 
       if (i18nOptions) {
         try {

--- a/packages/plugins/plugin-dev/src/index.ts
+++ b/packages/plugins/plugin-dev/src/index.ts
@@ -39,3 +39,12 @@
 
 export { DevPlugin } from './dev-plugin.js';
 export type { DevPluginOptions } from './dev-plugin.js';
+
+/**
+ * [#15232] The i18n auto-detect's decision, exported so it can be MEASURED
+ * rather than re-implemented — the #15004 option-B acceptance pin calls it.
+ * `stackDeclaresTranslations` stays module-private on purpose: the published
+ * surface is the decision, not its limbs.
+ */
+export { devI18nPluginOptions } from './dev-i18n.js';
+export type { DevI18nPluginOptions } from './dev-i18n.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,9 @@ importers:
       '@objectstack/driver-turso':
         specifier: workspace:*
         version: link:../drivers/driver-turso
+      '@objectstack/plugin-dev':
+        specifier: workspace:*
+        version: link:../plugins/plugin-dev
       '@oclif/plugin-help':
         specifier: ^6.2.58
         version: 6.2.58


### PR DESCRIPTION
Fixes #15232

Reader program 6/4 of the ADR-0130 D4 option-B ruling on #14512 (comment 5528589044). Split out of the by-shape sweep record #15210; acceptance pin is #15004. The artifact stays **additive** through this card — `composeStacks`, `packages/spec/src/stack.zod.ts` and what every command emits are untouched.

## The site

`packages/plugins/plugin-dev/src/dev-plugin.ts:526` read `options.stack.translations` and nothing else. Under option B — every definition carried once inside `packages[]`, no flattened top level — that read returns `undefined`, the auto-detect concludes "this app declares no copy", and `I18nServicePlugin` is never registered. Not a crash: the app boots and serves, on the core in-memory i18n fallback, so a developer sees message keys or last release's strings where the app declared real translations. Nothing throws and nothing logs.

## Both halves, in the order the card asked for — the ledger row FIRST, red

This site had **no row** in `OPTION_B_LOSSES`: the by-shape sweep found it, not the pin. So the loss was ledgered before the reader was touched, and each step was measured.

**1 · The row, with the reader still top-level-only → RED** (`7e9db1fb7`, verbatim):

```
AssertionError: A subsystem lost a collection that the ledger does not carry — this is the
failure #15004 exists to make loud. An option-B artifact reaches it with the collection
ABSENT and NOTHING THROWN.

  B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations

  LOST     B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations = none

 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

The other five cases passed in that same run — BASELINE green on the additive shape, the `packages[]` anti-vacuity control green — which is what makes this a discrimination rather than a broken fixture.

**2 · Ledgered → GREEN at 25 rows** (`64906c620`): `Tests 6 passed (6)`.

**3 · The reader fixed → RED again, naming the line to delete** (`e3aca15e2`, verbatim):

```
AssertionError: A ledgered subsystem now SEES its collections under option B — the reader
program moved forward. Delete these lines from OPTION_B_LOSSES:

  B2 · plugin-dev I18nServicePlugin auto-detect over the caller-supplied stack · translations
```

**4 · Row deleted → GREEN at 24 rows**: `Tests 6 passed (6)`.

**The pin, before and after — stated against the right baseline.** Relative to this branch's own merge base (`460134af8`) the ledger file is **byte-identical**: `git diff 460134af8 HEAD -- packages/cli/test/option-b-reader-acceptance.pin.test.ts` is empty, and the branch carries the 24 rows that base carried. ⚠️ `main` has moved since — #15226 landed and took the ledger to **23** by deleting its own `B2 · plugin-security … from-source config` row — so "24 → 24" is a fact about this branch's baseline, not about today's `main`, and is written that way to avoid reading as a claim about the current file. The two do not collide: `git merge-tree --write-tree origin/main` against this branch's head exits **0** with zero `CONFLICT` lines (result tree `d90f3eb94`), measured rather than assumed. The ledger never grew here either way: the row this card added existed only in the intermediate commit, as the thing this fix can be checked against. ⛔ Set equality is untouched, no subsystem stopped being asserted, and no row was added to silence a red. The probe now measures **one row more** than it did (a reader that is watched and not lost), which is the shape the program ends in.

## The fix

`DevPlugin.init`'s 3b decision — detection plus the locales it derives — is now one exported function, `devI18nPluginOptions` (`packages/plugins/plugin-dev/src/dev-i18n.ts`). The plugin keeps the dynamic import and its degradation: those are about the optional package being installed, which is a different question from what the stack declares.

- **Flattened top level FIRST, `packages[]` only where that came back falsy.** The caller's original expression (`Array.isArray(t) && t.length > 0`) is preserved rather than re-expressed, at the top level and per package body — the trap #15006 measured. Every artifact the platform emits today **answers** bit-identically, and that is a property of the merge rather than of the order: `composeStacks` merges `translations` with `'concat'` (`stack.zod.ts:895`), so a package that declares copy always leaves a non-empty flattened array too.
- **⚠️ The same answer is not the same work, and an earlier draft of this body claimed it was.** The flattened read short-circuits only when `translations` is present and NON-EMPTY. **Every stack that carries `packages[]` and declares no i18n at all reaches `resolveArtifactPackageOrder` on every `DevPlugin.init`** — the ordinary multi-package app that simply does not translate. Contract review measured it with a counting proxy; it is now pinned by a case of this PR's own that counts the reads (2 when the gate is reached, 0 when it short-circuits). Two consequences are load-bearing and are handled below: the cheap limbs are asked first, and the gate's refusals are reachable in ordinary use, so the caller degrades on them instead of dying.
- **⛔ `stack.packages` is not iterated.** `resolveArtifactPackageOrder` (`@objectstack/core`, ADR-0130 D4+D5, #14643) is the one traversal. Worth stating plainly: for a boolean the ORDER is not observable — what is observable is that the same call is the **gate**, so a hand-rolled loop would answer "this app declares copy" for an artifact whose package list the registration path refuses.
- **The `packages` key's absence is checked before the call.** D4's second branch returns the caller's own object as the single package body, so an unguarded walk would read the same `translations` a second time for every single-package stack. Pinned by a getter that counts reads: exactly 1.
- **A malformed `packages` is refused by the READER, and degraded by the PLUGIN.** `devI18nPluginOptions` raises the same ADR-0112 envelope (`code` + `status: 422`) `ObjectQL.registerApp` raises for that object later in the same boot — asserted on `code` and `status` rather than through a bare `expect().toThrow()`. `DevPlugin` catches it, prints its own diagnosis and boots on the in-memory fallback; the section below says why. ⚠️ Not every refusal on this path carries the envelope: a dependency cycle between two packages comes out of `resolvePluginOrder` as a **bare `Error`** with no `code` and no `status`. That is documented under `@throws` on both functions and asserted by its own case — an earlier draft of this body said "never a bare throw", which was false about the code rather than about the assertion style.
- **`i18n` and `manifest.translations` are untouched.** `i18n` is an artifact ENVELOPE key, not a package-owned collection (derived: `ObjectStackDefinitionSchema` ∩ `AssembledPackageBodySchema`, complement pinned by #15004), so option B does not move those two limbs. `translations` is the one limb it moves.

## The question this site raises: a caller-supplied, already-composed stack

`DevPlugin` takes its stack from `options.stack` — a **caller-supplied** object, with no load boundary this repo owns between the composed config and the reader. The enumeration in #14512 comment 5523741937 lists it as one of three construction sites with nothing to fold at.

**Yes, the auto-detect should fire for an already-composed multi-package config, and this fix makes it fire.** The evidence, rather than the intuition:

1. **That construction is the documented one and it is what a multi-package app runs.** `new DevPlugin({ stack: config })` is the example in `packages/plugins/plugin-dev/src/index.ts:36`. `composeStacks` has exactly one call site in this repo and it is **user config** — `examples/app-multi-package/objectstack.config.ts:51` — whose own header says `os dev` "boots the same shape straight from source". So the object handed to `DevPlugin` is the composed project itself, `packages[]` and all; there is no artifact door in between to fold the read into.
2. **Because there is no load step, the fold has to live in the reader.** For the other cards a loader could in principle normalise the shape before the reader sees it. Here the plugin IS the boundary, so a fix anywhere else would leave this path exactly as broken as it was.
3. **It costs today's ANSWERS nothing — but it is not free, and the earlier draft of this paragraph was wrong.** Every artifact and composed config the platform produces today resolves to the same boolean (the `'concat'` merge above). What is *not* true is that the walk never happens: a composed config that declares no i18n reaches the gate every boot. The short-circuit is pinned only for the case it really covers — a stack whose flattened `translations` is non-empty, which resolves untouched even beside a malformed `packages`.
4. **The scope stays exactly the caller's object.** The fix reads `packages[]` on the stack it was handed; it does not go looking for a config elsewhere, and it does not consult the singular `manifest` for collections (#7001's constraint, and the manifest carries none anyway — measured in #14512 comment 5523603341).

## Tests

All at `c108823e9` (final commit, `pnpm-lock.yaml` included — the diff adds one `devDependency`). The gate-family and lint runs quoted below were taken at `561ae05da`; everything re-run after the census fix is marked as such.

- `pnpm --filter @objectstack/plugin-dev test` → `Test Files 7 passed (7) / Tests 72 passed (72)`, including **14** new cases in `dev-i18n-packages-reader.test.ts`, all green by name under `--reporter=verbose`. (An earlier draft of this body said 11 for what were then 10 — miscounted, corrected here and re-counted after the remediation added four.)
- `pnpm --filter @objectstack/cli exec vitest run --maxWorkers=2 test/option-b-reader-acceptance.pin.test.ts` → `Test Files 1 passed (1) / Tests 6 passed (6)`.
- **Ablation of the original fix**, measured at `e3aca15e2` when this file held 10 cases rather than 14 (committed first, then mutated): the `packages[]` limb removed, confirmed **on disk** before the run — limb occurrences 1 → 0, injected marker 1, and the blob hash moved off HEAD's (`8ecb11ff…` → `9d0ccdac…`). The suite went `4 failed | 64 passed`, failing exactly THE FIX, the empty-top-level case, the malformed-`packages` refusal and the BOOT case, with the baseline and the negative control still green. Restored with `git checkout HEAD -- ABSOLUTE_PATH` under an `EXIT INT TERM` trap and proven restored: `git diff HEAD` empty, `git status` clean, disk hash back to `8ecb11ff…`, marker count 0. No rebuild leg was needed and that is checkable rather than assumed — the test imports `./dev-i18n` relatively and `@objectstack/core` is aliased to source in this package's `vitest.config.ts`, so no `dist/` is on that resolution path.
- **Three more ablations, each a single-case discrimination**, at `c108823e9` (same discipline: every mutation confirmed on disk by occurrence counts in both directions plus a blob-hash move off HEAD's; every restore by `git checkout HEAD -- ABSOLUTE_PATH` under an `EXIT INT TERM` trap and proven by an empty `git status`, an empty `git diff HEAD` and matching hashes):
  - remove `DevPlugin`'s catch → exactly **1 failed | 13 passed**, the failure being "a project the ADR-0130 D4 gate REFUSES still boots";
  - put the `translations` limb back first → exactly **1 failed | 13 passed**, the failure being "a stack that already declares its locales is answered WITHOUT walking `packages[]`";
  - reader back to top-level-only (the original defect) → **7 failed | 7 passed**, including THE FIX, the reachability case (its proxy counts 0 reads instead of 2), the cycle case and both `packages[]`-dependent boots.
- **Gate family**, derived on the merged tree with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (10 paths, no stale-tree warning): **53 of 57 exit 0**, each exit code captured before any pipe. Includes `check:test-source-alias`, `check:type-source-resolution`, `check:type-check-debt`, `check:cross-package-test-inputs`, `check:undeclared-dep-imports`, `check:workspace-manifest-cycles`, `check:turbo-task-graph`, `check:nul-bytes`, `check:published-files`, `check:engine-double-contract`. Re-run at `c108823e9`: `check:driver-memory-census`, `check:nul-bytes` and `check:test-source-alias` all exit 0.
- **NOT MEASURED, not reported as passed** — 4 gates, each with its own unmet prerequisite, all CI-owned: `check:dual-build-cjs-loads` (exit 3, 11 packages have no `dist/`), `check:i18n` and `check:i18n-coverage` (exit 3, the extract configs' build closure), `check:i18n-walk-parity` (exit 1, `packages/cli/dist/utils/i18n-extract.js` absent — it reads the walker from built output).
- `pnpm --filter @objectstack/plugin-dev typecheck` → exit 0 at `c108823e9`; `check:test-typecheck` `0 file(s) / 0 error(s)`. `--listFiles` confirms both new plugin-dev files really are in that program (2 of 2), so "typecheck clean" is a statement about them.
- `pnpm --filter @objectstack/cli check:test-typecheck` → `3 file(s) / 28 error(s) / 6 pinned signature(s)`, byte-identical to the pre-existing `test-typecheck-debt.json`: the fourth `paths` rule adds **zero** diagnostics.
- `pnpm lint` (`eslint . --no-inline-config`) repo-wide → exit 0. No narrowing claimed.
- **Declared narrowing:** the `@objectstack/cli` suite was not run whole, only the pin. Measured rather than argued: the new alias is anchored (`/^@objectstack\/plugin-dev$/`) so it re-resolves exactly one specifier; `grep -rln '@objectstack/plugin-dev' packages/cli/src packages/cli/test` returns exactly **one** file, the probe; `tsconfig.test.json` is `noEmit` and vitest does not read its `paths` (no `vite-tsconfig-paths` in `packages/cli/vitest.config.ts`). No existing test's resolution moves. CI runs the suite regardless.

## Contract review REJECT → remediated (Q3 + Q4)

The isolated adversarial review passed Q1 (nothing lands on the published surface but the decision itself) and Q2 (`patch` is right; the changeset stands) and rejected Q3 and Q4. All seven items are in this head. Each was reproduced first, then shown green.

**① The reachability claim was false, and it is corrected everywhere it appeared** — the two bullets above, this PR's open question, the `dev-i18n.ts` docblock, and the comment over the short-circuit case (which now says what it actually covers: a stack whose flattened level *has something to say*). The truth, stated once: *every stack carrying `packages[]` that declares no i18n at all — no `i18n` config, no `manifest.translations`, no non-empty top-level `translations` — reaches the gate on every `DevPlugin.init`.*

**② The two missing cases exist now.** (a) A real `composeStacks(…, { manifest: 'preserve' })` output with no translations anywhere: `packages` is read **twice** through a counting proxy — once by this reader's absent-key guard, once inside `resolveArtifactPackageOrder` — the call answers `undefined`, and it does **not** throw. Two reads is the discriminator: a short-circuit reads it zero times, which is exactly what the third ablation above produces. (b) The same stack with a package body the D4 gate refuses, driven through `DevPlugin.init`: the boot completes, the diagnosis line is printed, and no `I18nServicePlugin` is constructed.

**③ The reproduced regression is closed, posture B.** A package manifest still carrying authoring-time glob `objects` (`ManifestSchema`'s written form; the repo's own `CONFIG_GLOBS` fixture) is refused by `ArtifactPackageSchema` **by design**. Such a project boots today, and on the first cut it would have stopped booting — thrown out of the block whose only job is deciding whether to register a translation service, while `new AppPlugin(...)` twenty lines above degrades the very same refusal on the very same object to one log line. That inversion had no defence, so `DevPlugin` now catches, logs **its own** line naming the metadata defect and carrying the envelope verbatim, and boots on the in-memory fallback. ⛔ Not through `reportOptionalLoadFailure` — its text says a PACKAGE is installed but failed to initialize, and naming a package for a metadata-shape defect is the mis-attribution #7926 removed from this file. ⛔ And never silently — silence is the failure class this card exists to remove. `dev-plugin.ts`'s AppPlugin `try`/`catch` is **untouched**: whether DevPlugin should refuse malformed metadata at all is a separate maintainer question, filed rather than decided here.

**④ `@throws` is complete on both functions**, including the bare `Error` for a dependency cycle, now asserted by a case that pins `code === undefined` and `status === undefined` alongside the message.

**⑤ The three limbs are asked cheapest-first.** `i18n` / `manifest.i18n` / `manifest.translations` are property reads that cannot throw; the `translations` limb is the only one that can reach the gate, so it is asked last. `||` is commutative, so the answer is unchanged — what changes is that a stack which already declares its locales can no longer be refused over a `packages` list its answer never needed.

**⑦ The guard divergence is recorded, not unilaterally "fixed".** This reader treats only an absent `packages` key as single-package, so `packages: {}` is refused; the sibling reader in `@objectstack/metadata` guards with `Array.isArray` and accepts a non-array. #15226 spells it as this file does, so it is a program-level split. The `dev-i18n.ts` docblock now names it so the next author does not align one side without ruling the other.

## Review item 6 — `packages/cli/package.json`'s published bytes DO change, and no cli changeset is owed

Stated rather than left implicit, because it is true and easy to miss: `packages/cli/package.json` **does** change — one `devDependency` line — and that file is published. Consumers are unaffected: npm does not install a published package's devDependencies, `packages/cli`'s `files` field ships `dist` and `bin`, and nothing in either imports `@objectstack/plugin-dev`. The precedent is the sibling card's PR **#15281**, read rather than recalled: it edits `packages/cli/tsconfig.test.json`, this same probe fixture and the pin, and declares only `@objectstack/verify` in its changeset. `Check Changeset` is green on this head.

## CI follow-up on this head: `check:driver-memory-census`

`Lint & Repo Gates` went red on `561ae05da` — a real finding, and mine. The new test copied this package's sibling-harness convention of mocking every optional package absent, and one of those lines was `vi.mock('@objectstack/driver-memory', …)`. That gate counts `vi.mock` as a **declaration**, and `@objectstack/driver-memory`'s consumer set is locked by maintainer ruling (#5499 froze investment; #5704 / #6664 ruled each remaining consumer, at two). This file was a third.

⛔ **Not ledgered.** Of the gate's three exits — rule it, migrate it, file it — the answer is **migrate**, and here migrating means deleting: the mock was **redundant**, not load-bearing. `dev-plugin.ts` has exactly one `import('@objectstack/driver-memory')` (`:475`) and it sits inside `if (enabled('driver'))` (`:472`), while both boots in this test pass `services: { driver: false }`. Measured rather than argued:

- reproduced locally at `561ae05da`: `node scripts/check-driver-memory-census.mjs` exit **1** (captured before any pipe), naming line 57;
- with the line deleted: exit **0** — `OK — every declaration is ledgered, every ledger entry is live … 2 ruled consumer(s)`, the ledger file itself untouched, and the census back to `12 module binding(s) in 12 file(s)`;
- the suite was unchanged at `7 passed (7) / 68 passed (68)` (the count at `c60f2b44d`, before the remediation added four cases), and by name both BOOT cases green at 5ms / 1ms — a real `import('@objectstack/driver-memory')` does not transform in 5ms, so the timing corroborates the structural reading.

A comment now stands where the mock was, so the next author copying the sibling harness does not re-add it. The other ten `vi.mock(absent)` lines were checked against every census/ledger gate in `scripts/`: none of those packages appears in one — `driver-memory` is the only frozen-consumer package in the set. Worth recording for the next card: `check:driver-memory-census` is **not** in the family `scripts/pm/dispatch-gates.mjs` derives for this change set, which is why the local 57-command run was green and CI saw it first.

## Docs drift triage — four hand-written pages flagged, four verdicts

Flagged off the field names on the new `DevI18nPluginOptions` interface. `content/docs/releases/v17.mdx` was flagged too and was **read only, never touched**.

| Page · anchor | Verdict |
|:--|:--|
| `content/docs/kernel/services-checklist.mdx:428` (`DevPlugin`, `defaultLocale`) | **Read in full; no edit — and this is the one that mattered.** The row says DevPlugin "Auto-wires `I18nServicePlugin` when the stack declares translations". That sentence is exactly the predicate this PR widens, and it stays true — what changes is that it is now true for a multi-package stack as well. Before this fix the page over-claimed for that shape: the app declared translations and got the fallback anyway. The two samples below it are untouched paths — the production plugin (`new I18nServicePlugin({ defaultLocale: 'en', localesDir: './i18n' })`) and a stack-less `new DevPlugin()`, whose i18n block is gated on `options.stack` and never runs. |
| `content/docs/protocol/kernel/i18n-standard.mdx:355, :980, :986` (`defaultLocale`, `fallbackLocale`) | **False positive.** Protocol-level config keys and the key-miss fallback chain. This PR reads those same two keys from the same place (`stack.i18n`, else `manifest.i18n`) with the same expression it always used; neither their meaning nor their resolution moves. |
| `content/docs/ui/translations.mdx:57, :126, :214, :222` (`defaultLocale`) | **False positive.** The authoring-side `i18n` block and the request-time locale-resolution chain. `i18n` is an artifact ENVELOPE key that option B does not move, and this PR leaves that limb alone. |
| `content/docs/deployment/environment-variables.mdx:289` (`fallbackLocale`) | **False positive.** The anchor sits inside `OS_SEARCH_PINYIN_ENABLED`'s description of how its default derives from the stack's configured locales. Untouched by this PR. |

**The bot's own caveat, taken seriously rather than waved past:** `packages/plugins/plugin-dev/src/index.ts` and `packages/cli/vitest.config.ts` produced no anchors, so any page documenting them went unscanned this round — and the two new exported symbols live in that index. Checked by hand instead: `content/docs/plugins/packages.mdx:360` describes the package at feature level and links to its README, `content/docs/kernel/services.mdx:114` describes its no-stubs composition posture, and the README documents usage plus `DevPluginOptions` (unchanged). None of the three enumerates an export list, so there is no page owing an entry for `devI18nPluginOptions` / `DevI18nPluginOptions`.

## Why `packages/cli` gains a test-only edge to `@objectstack/plugin-dev`

The pin's ledger lives in `packages/cli`, and #15004's rule is that a row **calls a shipped reader** rather than re-implementing one — so the probe has to reach plugin-dev's decision. That needs three declarations, all test-layer: a `devDependency` (nothing published imports it; `check:workspace-manifest-cycles` green, so the manifest graph stays acyclic), an anchored `vitest` alias to source, and a star-less `paths` rule. The alias is the **sanctioned** remedy — `KNOWN_UNALIASED_TEST_IMPORTS` in `scripts/check-test-source-alias.mjs` is shrink-only and was left untouched in both directions; the gate reports the same required set for `@objectstack/cli` before and after, so crossing into `plugin-dev/src` adds no unaliased artifact import it did not already carry.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m