### PR TITLE
docs(agents): a PM-dispatched card arrives already assigned — claim comments, not the assignee field, say who owns it (#15287)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -457,20 +457,21 @@ lone unstaged `M`.
 proves the window is covered first. `historyHorizon()` is the read-only predicate for
 tools that answer their own question.
 
-**Claim the issue BEFORE you write any code.** Assign it to yourself
-(`gh issue edit <n> --add-assignee @me`, or `issue_write` with `assignees`) as the
-*first* action of the task — before the worktree, before the first read. An unassigned
-issue reads as an open invitation: two agents burn the same hours twice, then race to
-land conflicting shapes for one problem. Already assigned to someone else? It is taken —
-pick another or ask; never reassign it to yourself. And because every agent here shares
-one GitHub identity, the assignee field alone cannot answer "is this claim *mine*?" — a
-claim is two acts: assign, **and a claim comment carrying your session ID and branch
-name** (`claude/issue-<n>-<slug>`). Before writing code, re-read the issue's comments; an
-earlier claim with a different session ID or branch means it is taken whatever the
-assignee field says — skipping that read is how one issue got implemented twice in one
-morning. The claim is also what makes the *finding* rule (Prime Directive #10) safe:
-findings become a real queue other agents read, so file unassigned when merely recording
-and assign at the moment you actually start.
+**Claim the issue BEFORE you write any code.** Assign it to yourself (`gh issue edit <n>
+--add-assignee @me`, or `issue_write` with `assignees`) as the *first* action of the task —
+before the worktree, before the first read. An unassigned issue reads as an open invitation:
+two agents burn the same hours twice, then race to land conflicting shapes for one problem. And
+because every agent here shares one GitHub identity, the assignee field alone cannot answer "is
+this claim *mine*?" — a claim is two acts: assign, **and a claim comment carrying your session
+ID and branch name** (`claude/issue-<n>-<slug>`). So the COMMENTS, not that field, say who owns
+a card: before writing code re-read them, and an earlier claim comment with a different session
+ID or branch means taken — pick another or ask, ⛔ never reassign; skipping that read is how one
+issue got implemented twice in one morning. Assigned with **no** claim comment under it is the
+opposite: a PM dispatch order sets that field as step 1 on your behalf
+(`.claude/skills/pm-dispatch/SKILL.md` 认领, which forbids the dev seat to write it), so ⛔ never
+yield a card you were dispatched to — the PM then waits on a seat that walked away. The claim
+also makes the *finding* rule (#10) safe — findings are a queue others read: file unassigned
+when merely recording, assign the moment you start.
 
 **State on your PR that you did not set belongs to another actor — ask, never "correct"
 it.** Under one shared identity every other participant's write arrives unsigned: the PM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,11 @@ inlined below as one sentence, its enforcing hook, and a pointer to the AGENTS.m
 
 Claim it **before any other action**: assign yourself *and* comment your session ID and
 branch — the shared identity makes the assignee field no proof, so re-read the comments.
-No hook enforces this one. Full rule: AGENTS.md → **Multi-agent working discipline**, its
-paragraph **Claim the issue BEFORE you write any code.**
+A card a PM dispatch order sent you to arrives **already assigned** (that is the PM's half
+of the claim, made for you): leave the field alone, still post the comment, and ⛔ never
+yield the card back on the strength of that assignee. No hook enforces this one. Full
+rule: AGENTS.md → **Multi-agent working discipline**, its paragraph **Claim the issue
+BEFORE you write any code.**
 
 ## ⛔ Worktree-first — before your FIRST file edit (AGENTS.md Prime Directive #11)
 


### PR DESCRIPTION
Fixes #15287

⛔ **Governed surfaces** (`AGENTS.md`, `CLAUDE.md`). No auto-merge is armed and none will be — a human reviewer decides. Nothing outside those two files is touched.

## The conflict

Two binding rules that could not both be followed:

| Source | Says |
|:--|:--|
| `AGENTS.md` Prime Directive | "Assign it to yourself … as the *first* action of the task" and "**Already assigned to someone else? It is taken** — pick another or ask" |
| `.claude/skills/pm-dispatch/SKILL.md` 认领 | "**assignee 字段归 PM**:原子对 step 1 设,dev 席恒不写它(os-dev 规则 2 同句)" |

**Three separate dev seats reported this in one batch**, in their delivery reports, each taking the seat contract and recording the disagreement rather than resolving it silently. That precedence was right; nothing in `AGENTS.md` said so.

## Why it got sharper rather than milder

Until today the conflict was mostly latent because the dispatched cards were arriving **unassigned** — a PM-side half-state: five cards of one batch (#15005, #15006, #15007, #15229, #15232) carried `pm:queue` with no assignee while all five had an in-flight dispatch. Step 1 of the atomic pair had simply not been executed. Only the "assign yourself" half was live, so a seat could follow both rules by accident.

Correcting that half-state (all five now assigned, label swapped to `pm:dispatched`) activates the **other** half, and this one costs more. A seat dispatched onto one of those cards now reads *"already assigned … it is taken — pick another"* and **yields a card it was just given**. Yielding is worse than double-claiming: the PM goes on waiting for a seat that has already walked away, and nothing on the card records why.

## The change

Not a weakening of "claim before you write code" — that rule is load-bearing and its failure story (one issue implemented twice in one morning) is real. What was missing is that the assignee field can arrive **pre-set by the dispatching PM on the seat's behalf**, and how to tell that from a genuine prior claim.

Resolved as **one rule rather than an exception to one**, using the discriminator the paragraph already had:

> the COMMENTS, not that field, say who owns a card

- an earlier **claim comment** with a different session ID or branch ⇒ taken; pick another or ask, ⛔ never reassign;
- an assignee with **no claim comment under it** ⇒ the dispatching PM's step 1, made for you ⇒ ⛔ never yield a card you were dispatched to;
- both halves of the claim survive: the dev seat still owes its claim comment, and still must not write the assignee field.

`AGENTS.md` now cites `.claude/skills/pm-dispatch/SKILL.md` for the PM side, so the two documents point at each other instead of each asserting alone. `CLAUDE.md` inlines the same rule in condensed form and is updated with it so the two cannot drift.

## The line ratchet forced a rewrite, not an extension

`check:pm-skill-ratchet` holds `AGENTS.md` at a shrink-only ceiling of **1162 lines**, and the file was at **1161** — one line of headroom. A first draft that simply added the new rule came to 1172 and the gate refused it, with the right message: *"Raising a ceiling requires a maintainer ruling quoted in the PR."*

No ruling is quoted, because none was sought and the ceiling is **not** raised. The paragraph was rewritten and reflowed instead: it carries the new rule and the file lands at **exactly 1162**, headroom 0.

That meant compressing prose in the same paragraph that was already there, and one clause is stated more tersely than before — the *finding* rule's rationale is now "findings are a queue others read" rather than a sentence of its own. Called out rather than left for the reviewer to find: if that compression is judged to have cost something real, the alternative is a maintainer ruling to raise the ceiling, not a quieter edit.

`git diff --stat`: `AGENTS.md | 29 +++++++++--------------`, `CLAUDE.md | 7 +++++--` — 20 insertions, 16 deletions.

## Verification

Gate family derived on this head with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands AGENTS.md CLAUDE.md` — 14 runnable commands (8 matched by path, 6 declared whole-tree). Every exit code captured **before** any pipe.

**13 of 14 exit 0**, including the two that matter here:

- `pnpm check:pm-skill-ratchet` → `✓ AGENTS.md is 1162 lines (ceiling 1162; headroom 0)`, `✓ AGENTS.md: widest table row is 1081 bytes (pin 1081; headroom 0)`, `✓ CLAUDE.md is 39 lines (ceiling 86; headroom 47)`, and `✓ root AGENTS.md is covered (#9792)` / `✓ root CLAUDE.md is covered (#9965)`.
- `pnpm check:pm-governed-prose`, `pnpm check:pm-governed-merges`, `pnpm check:pm-skill-id-lint`, `pnpm check:docs-audit-scope`, `pnpm check:agent-test-spelling`, `pnpm check:nul-bytes`, `pnpm check:refd-timer-probe`, `pnpm check:required-contexts`, `pnpm check:watch-hint-literal`, `node scripts/check-closing-keyword-parity.mjs` (+ `--self-test`), `node scripts/check-comment-mask-corpus.mjs`.

**NOT MEASURED — 1, and not reported as a pass:**

- `node scripts/check-required-contexts.mjs --verify-required-set` → exit **2**, `NOT VERIFIED — GET https://api.github.com/repos/objectstack-ai/objectstack answered HTTP 403`. Re-run under `NODE_OPTIONS=--use-env-proxy` and it still answers 403; this container has no `GITHUB_TOKEN`/`GH_TOKEN`. The gate's own text: *"NOT VERIFIED is not a pass and not a failure of the tree (#4690); exit 2 classifies the ENVIRONMENT."* CI reads it with credentials.

The three gates that needed `node_modules` (`check-closing-keyword-parity`, `check-comment-mask-corpus`) first reported exit 3 `PREREQUISITE NOT MET` in the fresh worktree and were re-run after `pnpm install`; both then measured and passed. **No changeset**: neither file is in a published package, and `check-changeset-fixed` scores as an artifact roster here (a fact about its list, not a clearance).

## Not in this PR

- `.claude/skills/pm-dispatch/SKILL.md:516` and the `os-dev` seat definition already state the PM side correctly; only the citation direction was broken, and `AGENTS.md` now supplies it. Editing them too would churn a ratcheted surface for nothing.
- The PM-side half-state that made this visible is fixed on the cards themselves (assign + `pm:queue` → `pm:dispatched` on all five), not in this diff. `scripts/pm/check-half-states.mjs` already exists to catch that class; it simply had not been run for that batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m)_