### PR TITLE
docs(comments): mark deleted app paths as out-of-repo, or state the shape instead

### DIFF
--- a/packages/adapters/hono/src/index.ts
+++ b/packages/adapters/hono/src/index.ts
@@ -159,8 +159,9 @@ export function createHonoApp(options: ObjectStackHonoOptions): Hono {
       // use a matcher function — Hono's cors() middleware does exact-string matching only and
       // treats '*' in patterns as a literal character, so passing wildcard strings straight
       // through would silently drop the Access-Control-Allow-Origin header on every real
-      // request (preflight can still succeed via apps/objectos's short-circuit, but the
-      // subsequent POST/GET would be blocked by the browser).
+      // request (preflight can still succeed via the short-circuit in `apps/objectos`,
+      // which lives in the separate `objectstack-ai/cloud` repo and is NOT a path in
+      // this one, but the subsequent POST/GET would be blocked by the browser).
       //
       // This mirrors `plugin-hono-server`'s CORS wiring and uses the shared pattern matcher
       // from `@objectstack/plugin-hono-server` so all Hono-based code paths stay in sync.

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4063,9 +4063,9 @@ export default class Serve extends Command {
         //   • `requires: ['ai-studio']` ⇒ required → fail-fast if the private package
         //     is absent (an app that advertises Studio must ship it).
         //   • package declared but not required ⇒ auto (best-effort).
-        //   • otherwise ⇒ skip — this is the control-plane host path (apps/cloud ships
-        //     no Studio and MUST boot clean, cloud#107): not declared + not required
-        //     ⇒ no import, no error.
+        //   • otherwise ⇒ skip — this is the control-plane host path (such a host
+        //     ships no Studio and MUST boot clean, cloud#107): not declared + not
+        //     required ⇒ no import, no error.
         if (aiLoaded) {
           const hasAIStudio = plugins.some(
             (p: any) => p.name === 'com.objectstack.service-ai-studio'
@@ -4397,9 +4397,9 @@ export default class Serve extends Command {
 
       if (enableUI) {
         // Pre-detect Console availability. The `--no-console` flag (or
-        // OS_DISABLE_CONSOLE=1 env var) lets a host (e.g. apps/cloud)
-        // opt out of the Console entirely — useful for control-plane
-        // deployments where the runtime Console is meaningless.
+        // OS_DISABLE_CONSOLE=1 env var) lets a host opt out of the Console
+        // entirely — useful for control-plane deployments where the
+        // runtime Console is meaningless.
         const consoleEnabled = flags.console && process.env.OS_DISABLE_CONSOLE !== '1';
         // Resolution reports objectui-SHA drift instead of warning about it
         // itself, so the decision below owns the single message about it.
@@ -4546,12 +4546,13 @@ export default class Serve extends Command {
 
       // ── Migrate-and-exit short-circuit ─────────────────────────────
       // Out-of-band migration mode: the caller (e.g.
-      // `apps/cloud/scripts/migrate.ts`) just wants the kernel
-      // bootstrap (ObjectQLPlugin → schema sync → metadata hydration)
-      // to run once against the configured database, then exit. The
-      // HTTP server has already bound `port` at this point but we
-      // never accept a request — shutdown immediately so the deploy
-      // pipeline can move on.
+      // `apps/cloud/scripts/migrate.ts`, which lives in the separate
+      // `objectstack-ai/cloud` repo and is NOT a path in this one) just
+      // wants the kernel bootstrap (ObjectQLPlugin → schema sync →
+      // metadata hydration) to run once against the configured database,
+      // then exit. The HTTP server has already bound `port` at this point
+      // but we never accept a request — shutdown immediately so the
+      // deploy pipeline can move on.
       if (process.env.OS_MIGRATE_AND_EXIT === '1') {
         // This path exits before the banner, so it has to replay the boot
         // diagnostics itself — a deploy pipeline is precisely where a

--- a/packages/cloud-connection/src/cloud-connection-plugin.ts
+++ b/packages/cloud-connection/src/cloud-connection-plugin.ts
@@ -16,8 +16,10 @@
  *   GET  /api/v1/cloud-connection/org-packages  — owning org's own catalog ("Your organization")
  *
  * History: these routes started as app-level wiring in
- * `apps/objectos/cloud-runtime-plugins.ts` (two ad-hoc plugins). ADR-0008
- * Phase 1 consolidates them here as ONE plugin so both deployment shapes —
+ * `apps/objectos/cloud-runtime-plugins.ts` (two ad-hoc plugins; every
+ * `apps/` path named in this paragraph lives in the separate
+ * `objectstack-ai/cloud` repo, never in this one). ADR-0008 Phase 1
+ * consolidates them here as ONE plugin so both deployment shapes —
  * `apps/objectos` (multi-tenant) and `apps/objectos-ee` (single-environment)
  * — wire the same canonical implementation. ADR-0008 Phase 2 moves this
  * surface into the open `@objectstack/cloud-connection` package; keep this

--- a/packages/plugins/plugin-hono-server/src/pattern-matcher.ts
+++ b/packages/plugins/plugin-hono-server/src/pattern-matcher.ts
@@ -12,10 +12,11 @@
  * These helpers are shared between the Hono plugin's CORS middleware and
  * consumers that need to apply CORS headers outside the Hono request
  * pipeline (e.g., the Vercel serverless entrypoint's preflight
- * short-circuit in `apps/objectos`). Keeping a single implementation
- * ensures both paths stay consistent — divergence caused bug where
- * wildcard `CORS_ORIGIN` values worked locally but produced browser
- * CORS errors on Vercel.
+ * short-circuit in `apps/objectos` — that app lives in the separate
+ * `objectstack-ai/cloud` repo, not in this one). Keeping a single
+ * implementation ensures both paths stay consistent — divergence caused
+ * bug where wildcard `CORS_ORIGIN` values worked locally but produced
+ * browser CORS errors on Vercel.
  */
 
 /**


### PR DESCRIPTION
Part of #14806.

`Part of`, not a closing keyword, on purpose: one site in that card's census is deliberately left here (see "What stays open", below), so merging this must not close it.

## What was wrong

Six source comments named `apps/objectos` / `apps/cloud` as if those were paths in this repository. Both apps were deleted from here and now live in `objectstack-ai/cloud`. A source comment naming a repository path is a checkable claim, and this one has already cost real work — two readers took `apps/objectos` for a live in-repo case (#14634).

The positive control matters, because the claim being fixed is a negative — `apps/` is not empty and the query is not broken:

```
$ git ls-tree origin/main -- apps/
040000 tree f281e0156f1e4569560b79b9899d3ea56cfb7f1d	apps/docs
```

⛔ The paths were grepped, never the bare tokens `objectos` / `cloud`. `objectos.ai`, `cloud.objectos.ai`, `DEFAULT_CLOUD_URL`, `admin@objectos.ai` and the plugin ids `objectos-ee` / `objectos-runtime` / `objectos-environment` / `objectos-stack` are all correct, several matched as literal plugin ids inside `serve.ts` itself. A token sweep breaks working code.

## Disposition, per site, per what is true of it

Two rules, the split #14634 used: where the referent is genuinely the out-of-repo app, **mark it out-of-repo** in the `packages/services/service-cluster/src/multi-node-gate-mount.ts:9` house style — "(`apps/objectos-ee/objectstack.config.ts`, cloud repo)" — so a reader who wants the file can still find it; where the comment is a worked example of a branch that keys on a shape, **state the shape and name no app**.

### Marked out-of-repo (4 sites, referent is real and elsewhere)

**`packages/adapters/hono/src/index.ts:162`**

```diff
-      // request (preflight can still succeed via apps/objectos's short-circuit, but the
-      // subsequent POST/GET would be blocked by the browser).
+      // request (preflight can still succeed via the short-circuit in `apps/objectos`,
+      // which lives in the separate `objectstack-ai/cloud` repo and is NOT a path in
+      // this one, but the subsequent POST/GET would be blocked by the browser).
```

**`packages/plugins/plugin-hono-server/src/pattern-matcher.ts:15`**

```diff
- * short-circuit in `apps/objectos`). Keeping a single implementation
- * ensures both paths stay consistent — divergence caused bug where
+ * short-circuit in `apps/objectos` — that app lives in the separate
+ * `objectstack-ai/cloud` repo, not in this one). Keeping a single
+ * implementation ensures both paths stay consistent — divergence caused
```

(the rest of that paragraph is rewrapped, unchanged in wording)

**`packages/cloud-connection/src/cloud-connection-plugin.ts:19` and `:21`** — one marker placed at the first occurrence covers both, since the second is two lines below it in the same paragraph:

```diff
- * `apps/objectos/cloud-runtime-plugins.ts` (two ad-hoc plugins). ADR-0008
- * Phase 1 consolidates them here as ONE plugin so both deployment shapes —
+ * `apps/objectos/cloud-runtime-plugins.ts` (two ad-hoc plugins; every
+ * `apps/` path named in this paragraph lives in the separate
+ * `objectstack-ai/cloud` repo, never in this one). ADR-0008 Phase 1
+ * consolidates them here as ONE plugin so both deployment shapes —
```

**`packages/cli/src/commands/serve.ts:4549`** — the migrate-and-exit short-circuit:

```diff
-      // `apps/cloud/scripts/migrate.ts`) just wants the kernel
-      // bootstrap (ObjectQLPlugin → schema sync → metadata hydration)
-      // to run once against the configured database, then exit. The
+      // `apps/cloud/scripts/migrate.ts`, which lives in the separate
+      // `objectstack-ai/cloud` repo and is NOT a path in this one) just
+      // wants the kernel bootstrap (ObjectQLPlugin → schema sync →
+      // metadata hydration) to run once against the configured database,
+      // then exit. The
```

### Shape stated, no app named (2 sites, the app was only an illustration)

**`packages/cli/src/commands/serve.ts:4066`** — the AI Studio skip branch. The sentence already names the shape ("this is the control-plane host path"); `apps/cloud` was one instance of it. The `cloud#107` reference is kept: that is a real cross-repo issue pointer, not a path claim.

```diff
-        //   • otherwise ⇒ skip — this is the control-plane host path (apps/cloud ships
-        //     no Studio and MUST boot clean, cloud#107): not declared + not required
-        //     ⇒ no import, no error.
+        //   • otherwise ⇒ skip — this is the control-plane host path (such a host
+        //     ships no Studio and MUST boot clean, cloud#107): not declared + not
+        //     required ⇒ no import, no error.
```

**`packages/cli/src/commands/serve.ts:4400`** — the Console opt-out. Same reasoning: the next clause already states the shape ("useful for control-plane deployments where the runtime Console is meaningless"), so the host does not need naming.

```diff
-        // OS_DISABLE_CONSOLE=1 env var) lets a host (e.g. apps/cloud)
-        // opt out of the Console entirely — useful for control-plane
-        // deployments where the runtime Console is meaningless.
+        // OS_DISABLE_CONSOLE=1 env var) lets a host opt out of the Console
+        // entirely — useful for control-plane deployments where the
+        // runtime Console is meaningless.
```

## What stays open, and why

- **`packages/cli/src/commands/serve.ts:133` is byte-unchanged, on purpose.** Its "keep the two in sync" clause is not stale prose — it is a live cross-repo obligation whose counterparty (`apps/cloud/server/observability.ts`) nobody in this repo can open. Renaming the path preserves a duty nobody can discharge; deleting the instruction may silently drop one that is still real. Carded as #15295 for a seat that can read `objectstack-ai/cloud`. Byte-identity of lines 126-140 against the merge base was asserted, not assumed.
- **`packages/cli/src/commands/package/publish.ts:168`** — the eighth site #14806's triage added to its census. It is a CLI **help example string**, not a comment: user-facing output rather than source prose. This PR's scope is comment text only, so it is untouched and remains the open remainder on #14806. That is the reason for `Part of`.
- **#15297** — two more sites of the same class that neither census contained, found by re-deriving the population here: `packages/objectql/src/plugin.ts:142` (the same sentence about the same `migrate.ts`, written as a pair with `serve.ts`'s note and drifted apart) and `packages/cloud-connection/src/marketplace-install-local-seed-replayer.test.ts:16`. Both are outside the file surface declared in the claim comment before editing, so they are filed rather than swept — with this PR's exact spelling pinned in the card so the sweep does not acquire a fourth house style.

## Evidence — coverage, not green

Nothing executes differently, so the useful evidence is which sites are covered.

**Every changed line in this diff is a comment line.** Mechanically, not by eye:

```
$ git diff -U0 4dd5041bd | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
    | grep -vE '^[+-][[:space:]]*(//|\*)' | wc -l
0
```

**The paths grep after the change** returns only rows that are deliberately left. Under `packages/`, excluding `CHANGELOG.md` (25 rows), each falls into exactly one bucket:

| bucket | rows |
|:---|:---|
| this PR's own markers | `hono/src/index.ts:162`, `pattern-matcher.ts:15`, `cloud-connection-plugin.ts:19` + `:23`, `serve.ts:4549` |
| ruled out of scope, carded | `serve.ts:133` (#15295) |
| out of scope as non-comment, stays on #14806 | `package/publish.ts:168` |
| already correct before this PR | `serve.ts:1921` (#14634's landed fix), `service-cluster/src/multi-node-gate-mount.ts:9`, `service-cluster/src/multi-node-gate.test.ts:227`, `cli/test/serve-organizations-host-resolution.e2e.test.ts:88`, `types/src/node.ts:72` |
| filed as #15297 | `objectql/src/plugin.ts:142`, `cloud-connection/src/marketplace-install-local-seed-replayer.test.ts:16` |
| not this class | `observability/README.md:39` (already says "see that repo's exporter"), `spec/prompts/architecture.md:26` (product inventory, lists `apps/www` / `apps/marketplace` / `apps/studio` too) |
| different path entirely | the six `_console/apps/cloud_control/...` Console-route matches in `cloud-connection/README.md`, `cloud-connection/src/runtime-config-upgrade-url.test.ts` and `spec/src/ui/inline-action.test.ts` |

`serve.ts:4066` and `serve.ts:4400` are absent from that grep now — those are the two where no app is named any more.

**Gates.** The family union was derived on a clean tree at the final commit, `f37c7de5`, with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack --commands` (never a hand-written path list) — 35 commands. All 35 exit 0 at `f37c7de5`, each exit code captured before any pipe. Four of them (`check:dual-build-cjs-loads`, `check:i18n`, `check:i18n-coverage`, `check:i18n-walk-parity`) first answered `PREREQUISITE NOT MET` — a NOT MEASURED verdict, neither pass nor red — and were re-run green after a full `pnpm build` of the workspace at that same commit.

**No changeset**, and `skip-changeset` is set: this PR publishes nothing from any package. Comment text only — no test, no runtime change, no public surface moves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D47qPfEWVPmhguWgBZCi5N)_