### PR TITLE
fix(plugin-security): the app default permission set resolves from the first level that NAMES one (#15298)

### DIFF
--- a/.changeset/plugin-security-default-set-answer-not-container.md
+++ b/.changeset/plugin-security-default-set-answer-not-container.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): the app default permission set resolves from the first level that NAMES one (#15298)
+
+`declaredPermissionSets` carried a docblock stating a short-circuit its code did
+not have:
+
+> The `packages[]` pass only supplies a set where the top level had none — which
+> is precisely the option-B artifact.
+
+The code pushed the flattened top level and then **every** package body
+unconditionally, so on today's additive artifact (flattened level *and*
+`packages[]` both present) every permission set was collected twice. Nothing
+observable came of it — the sole caller is private and takes the first
+`isDefault` set, which the flattened copy still supplied — so this corrects a
+false written contract on a security-path reader, not a live defect. That
+distinction is the point: the sentence was load-bearing, because it was the
+stated reason the reader half was revertible on its own and safe to land before
+the emitter half (#14512), and the next reader would have believed the mechanism
+was there.
+
+The reader now walks the discipline the docblock claims — start from the
+expression this program replaced, `appDefaultPermissionSetName(config.permissions)`,
+and consult `packages[]` only where it came back `undefined`.
+
+- **The condition is the resolved NAME, never the `permissions` container.**
+  Branching on the container re-creates the silent loss the reader program
+  exists to remove, one shape further along: a flattened level that carries
+  permission sets but marks none of them `isDefault` is legal today and
+  hand-authorable in any `objectstack.config.ts`, and a container-shaped
+  condition (`Array.isArray(flattened)`, with or without `&& length > 0`) shorts
+  it past the whole `packages[]` pass and answers `undefined` — nothing thrown,
+  nothing logged, every member of the app back down to the platform floor alone.
+  Reading the answer also retires the `[]`-is-truthy trap rather than patching
+  around it.
+- **The package order is resolved BEFORE the top level is consulted.**
+  `resolveArtifactPackageOrder` refuses a malformed `packages` — not an array,
+  an entry inlined instead of wrapped under `manifest:`, a duplicate package id
+  — with an ADR-0112 envelope this reader does not catch, and that refusal must
+  not become conditional on whether the flattened level happened to name a
+  default first. An artifact is either loadable or refused; which level answered
+  is not part of that question.
+- **No emitted artifact changes its answer.** Measured, not argued: 26 shapes —
+  the composed additive artifact, its option-B derivative, the collection-zoo
+  fixtures behind the #15004 acceptance pin, every config the unit suite drives,
+  the three malformed-`packages` refusals, and the hand-authored mixed shapes —
+  return byte-identical results before and after, with `@objectstack/plugin-security`
+  rebuilt and the change proven present in `dist/` on each leg.

--- a/.changeset/plugin-security-default-set-answer-not-container.md
+++ b/.changeset/plugin-security-default-set-answer-not-container.md
@@ -21,6 +21,13 @@ stated reason the reader half was revertible on its own and safe to land before
 the emitter half (#14512), and the next reader would have believed the mechanism
 was there.
 
+⚠️ Release-notes note: this supersedes one sentence of the #15226 entry in this same
+unreleased batch — "The resolution now reads the flattened top level FIRST and then each
+package body". That described #15226 accurately when it landed; after this change the
+`packages[]` pass runs only where the top level named no default. The earlier entry is
+left as written rather than retro-edited, so whoever compiles the notes collapses the two
+deliberately instead of reading a contradiction.
+
 The reader now walks the discipline the docblock claims — start from the
 expression this program replaced, `appDefaultPermissionSetName(config.permissions)`,
 and consult `packages[]` only where it came back `undefined`.

--- a/packages/plugins/plugin-security/src/app-default-permission-set.test.ts
+++ b/packages/plugins/plugin-security/src/app-default-permission-set.test.ts
@@ -260,6 +260,56 @@ describe('appSecurityPluginOptions over `packages[]` (ADR-0130 D4, #15007)', () 
   });
 
   /**
+   * [#15007 follow-up] "The top level had none" is the resolved NAME coming
+   * back `undefined` — never the `permissions` CONTAINER being absent or empty.
+   *
+   * Branching on the container re-creates the silent loss this card removed,
+   * one shape further along. A flattened level that carries permission sets but
+   * marks none of them `isDefault` is legal today and hand-authorable in any
+   * `objectstack.config.ts`; a container-shaped condition shorts it past the
+   * whole `packages[]` pass and answers `undefined` — nothing thrown, nothing
+   * logged, every member of the app back down to the platform floor alone.
+   */
+  describe('the `packages[]` pass runs wherever the top level named no default', () => {
+    const corePackage = {
+      manifest: {
+        id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app',
+        permissions: [permissionSet(CORE_PROFILE)],
+      },
+    };
+
+    it('an EMPTY flattened array does not short-circuit it', () => {
+      expect(appSecurityPluginOptions({ permissions: [], packages: [corePackage] }))
+        .toEqual({ fallbackPermissionSet: CORE_PROFILE });
+    });
+
+    it('a NON-EMPTY flattened array that marks no default does not either', () => {
+      // A `permissions.length > 0` guard passes the case above and fails this
+      // one — which is the whole reason the condition is the resolved name.
+      expect(
+        appSecurityPluginOptions({
+          permissions: [{ name: 'core_read_only', label: 'Read only', objects: {} }],
+          packages: [corePackage],
+        }),
+      ).toEqual({ fallbackPermissionSet: CORE_PROFILE });
+    });
+
+    it('a `permissions` key that is not an array at all does not either', () => {
+      expect(appSecurityPluginOptions({ permissions: null, packages: [corePackage] }))
+        .toEqual({ fallbackPermissionSet: CORE_PROFILE });
+    });
+
+    it('and once the top level DOES name one, the packages pass cannot change the answer', () => {
+      expect(
+        appSecurityPluginOptions({
+          permissions: [permissionSet('flattened_wins')],
+          packages: [corePackage],
+        }),
+      ).toEqual({ fallbackPermissionSet: 'flattened_wins' });
+    });
+  });
+
+  /**
    * The gate travels with the read: `resolveArtifactPackageOrder` refuses a
    * malformed `packages` with an ADR-0112 envelope, and this reader does not
    * catch it. Swallowing it would resolve a permission surface out of an
@@ -292,6 +342,22 @@ describe('appSecurityPluginOptions over `packages[]` (ADR-0130 D4, #15007)', () 
       const err = refusalOf({ packages: [entry, entry] });
       expect(err.code).toBe('DUPLICATE_ARTIFACT_PACKAGE');
       expect(err.status).toBe(422);
+    });
+
+    it('…and refused just the same when the flattened top level already named a default', () => {
+      // The package order is resolved BEFORE the top level is consulted, so an
+      // artifact is either loadable or refused independently of which level
+      // happens to answer. Move that resolution below the early return and this
+      // pair turns into a silent accept: a permission surface resolved out of an
+      // artifact the manifest service refuses moments later.
+      const notAnArray = refusalOf({ permissions: [permissionSet('flattened_wins')], packages: 'nope' });
+      expect(notAnArray.code).toBe('INVALID_ARTIFACT_PACKAGES');
+      expect(notAnArray.status).toBe(422);
+
+      const entry = { manifest: { id: CORE_ID, name: 'Core', version: '1.0.0', type: 'app', permissions: [permissionSet(CORE_PROFILE)] } };
+      const duplicate = refusalOf({ permissions: [permissionSet('flattened_wins')], packages: [entry, entry] });
+      expect(duplicate.code).toBe('DUPLICATE_ARTIFACT_PACKAGE');
+      expect(duplicate.status).toBe(422);
     });
   });
 });

--- a/packages/plugins/plugin-security/src/app-default-permission-set.ts
+++ b/packages/plugins/plugin-security/src/app-default-permission-set.ts
@@ -86,8 +86,9 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
 }
 
 /**
- * [ADR-0130 D4, #15007] Every permission set a stack config DECLARES — from the
- * flattened top level, and from `packages[]`.
+ * [ADR-0130 D4, #15007] The app-declared default permission-set NAME, resolved
+ * from wherever the artifact carries the declaration — the flattened top
+ * level, or `packages[]`.
  *
  * ## What this exists to stop
  *
@@ -114,15 +115,28 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
  * this function has to be a superset of the old read rather than a replacement
  * for it: for every artifact the platform emits today the flattened level
  * answers first and this returns exactly what it returned before. The
- * `packages[]` pass only supplies a set where the top level had none — which is
- * precisely the option-B artifact. That is what makes this card revertible on
- * its own and safe to land before the emitter half (#14512).
+ * `packages[]` pass is consulted ONLY where the top level named no default —
+ * which is precisely the option-B artifact. That is what makes this card
+ * revertible on its own and safe to land before the emitter half (#14512).
+ *
+ * ## The condition is the ANSWER, never the container
+ *
+ * "The top level had none" is spelled as `appDefaultPermissionSetName` coming
+ * back `undefined`, and deliberately NOT as the `permissions` array being
+ * absent or empty. Branching on the container re-creates the silent loss this
+ * card exists to remove, one shape further along: a config whose flattened
+ * level carries permission sets but marks none of them `isDefault` — legal
+ * today, and expressible by hand in any `objectstack.config.ts` — would
+ * short-circuit the whole `packages[]` pass and resolve `undefined`, with
+ * nothing thrown and nothing logged. Reading the container also hands back the
+ * `[]`-is-truthy trap for free. The answer is the only condition that cannot
+ * be wrong in either direction, so the answer is what this branches on.
  *
  * ## The order is `resolveArtifactPackageOrder`'s, not the array's
  *
- * `appDefaultPermissionSetName` resolves the FIRST `isDefault` set, so with more
- * than one package declaring one, "first" has to mean the same thing here as it
- * does everywhere else the artifact is read. `resolveArtifactPackageOrder`
+ * The first package body that names a default wins, so with more than one
+ * package declaring one, "first" has to mean the same thing here as it does
+ * everywhere else the artifact is read. `resolveArtifactPackageOrder`
  * (`@objectstack/core`, ADR-0130 D4+D5, #14643) is the ONE place that turns an
  * artifact into its ordered package list — dependency-topological, so a package
  * that extends another is read after it regardless of which array slot it
@@ -130,36 +144,41 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
  * traversal is a second ordering, and the depended-upon package would win or
  * lose by authoring accident.
  *
- * ## Two things it deliberately does NOT do
+ * ## The package order is resolved BEFORE the top level is consulted
  *
- *   • It does not look inside the SINGULAR `manifest`. That constraint is
- *     #7001's and it still holds — the harness must not honour a declaration
- *     `serve.ts` ignores. Note this is not a special case bolted on: an
- *     artifact carrying no `packages` key makes `resolveArtifactPackageOrder`
- *     return the caller's own object as the single package body (D4's second
- *     branch, D7's compatibility term), so that branch reads `permissions` from
- *     exactly where the old code read it and nowhere else.
- *   • It does not catch `resolveArtifactPackageOrder`'s refusals. A malformed
- *     `packages` (not an array, an unwrapped entry, a duplicate package id)
- *     raises an ADR-0112 envelope here, the same one the manifest service
- *     raises when it registers that artifact moments later. Swallowing it would
- *     resolve a permission surface out of an artifact the loader refuses to
- *     load — the gate travels with the read.
+ * Reading that line as a misplaced statement is the expected mistake, so: it is
+ * placed there on purpose, and moving it below the early return is a behaviour
+ * change. `resolveArtifactPackageOrder` REFUSES a malformed `packages` (not an
+ * array, an unwrapped entry, a duplicate package id) with an ADR-0112 envelope,
+ * and this reader does not catch it — swallowing it would resolve a permission
+ * surface out of an artifact the loader refuses to load. Resolving the order
+ * first is what keeps that refusal unconditional: an artifact is either
+ * loadable or refused, and which answer this reader gives about it must not
+ * depend on whether its flattened level happened to name a default first.
+ *
+ * ## One thing it deliberately does NOT do
+ *
+ * It does not look inside the SINGULAR `manifest`. That constraint is #7001's
+ * and it still holds — the harness must not honour a declaration `serve.ts`
+ * ignores. Note this is not a special case bolted on: an artifact carrying no
+ * `packages` key never reaches the package pass at all, so that branch reads
+ * `permissions` from exactly where the old code read it and nowhere else.
  */
-function declaredPermissionSets(config: unknown): unknown[] {
-  const sets: unknown[] = [];
+function declaredDefaultPermissionSetName(config: unknown): string | undefined {
+  const packages = (config as { packages?: unknown } | null | undefined)?.packages;
+  const bodies =
+    packages === undefined || packages === null ? [] : resolveArtifactPackageOrder(config);
 
   const flattened = (config as { permissions?: unknown } | null | undefined)?.permissions;
-  if (Array.isArray(flattened)) sets.push(...flattened);
+  const fromFlattened = appDefaultPermissionSetName(flattened);
+  if (fromFlattened !== undefined) return fromFlattened;
 
-  const packages = (config as { packages?: unknown } | null | undefined)?.packages;
-  if (packages === undefined || packages === null) return sets;
-
-  for (const body of resolveArtifactPackageOrder(config)) {
+  for (const body of bodies) {
     const declared = (body as { permissions?: unknown } | null | undefined)?.permissions;
-    if (Array.isArray(declared)) sets.push(...declared);
+    const fromPackage = appDefaultPermissionSetName(declared);
+    if (fromPackage !== undefined) return fromPackage;
   }
-  return sets;
+  return undefined;
 }
 
 /**
@@ -191,13 +210,14 @@ function declaredPermissionSets(config: unknown): unknown[] {
  * the result straight through — `new SecurityPlugin(appSecurityPluginOptions(config))`
  * — and a caller cannot get the undefined case subtly wrong.
  *
- * Reads the sets through {@link declaredPermissionSets} — the flattened top
- * level `serve.ts` has always read, and, for a multi-package artifact, the
- * `packages[]` bodies that carry the same declaration under ADR-0130 D4.
+ * Resolves the name through {@link declaredDefaultPermissionSetName} — the
+ * flattened top level `serve.ts` has always read, and, for a multi-package
+ * artifact, the `packages[]` bodies that carry the same declaration under
+ * ADR-0130 D4.
  */
 export function appSecurityPluginOptions(
   config: unknown,
 ): { fallbackPermissionSet: string } | undefined {
-  const name = appDefaultPermissionSetName(declaredPermissionSets(config));
+  const name = declaredDefaultPermissionSetName(config);
   return name ? { fallbackPermissionSet: name } : undefined;
 }

--- a/packages/plugins/plugin-security/src/app-default-permission-set.ts
+++ b/packages/plugins/plugin-security/src/app-default-permission-set.ts
@@ -132,6 +132,19 @@ export function appDefaultPermissionSetName(permissions: unknown): string | unde
  * `[]`-is-truthy trap for free. The answer is the only condition that cannot
  * be wrong in either direction, so the answer is what this branches on.
  *
+ * ⚠️ That is deliberately NOT the shape of the sibling reader's condition, and
+ * the difference is a property of the readers, not an inconsistency to
+ * converge away. `resolveStackCollection` (`packages/cli/src/utils/
+ * stack-collections.ts`, #15006) branches on the CONTAINER — `if
+ * (Array.isArray(top)) return top;` — and is right to: it returns a whole
+ * collection, so a top level that carries the key has, by construction,
+ * already answered, and `composeStacks` flattened that array into the union.
+ * This reader extracts a DISTINGUISHED ELEMENT out of the collection instead,
+ * so "the key is present" and "the key answers" are two different facts here
+ * and one of them is the wrong one to branch on. Same discipline — start from
+ * the expression this program replaced, consult `packages[]` only where it came
+ * back empty — read against what each reader's expression actually returns.
+ *
  * ## The order is `resolveArtifactPackageOrder`'s, not the array's
  *
  * The first package body that names a default wins, so with more than one


### PR DESCRIPTION
Fixes #15298

`declaredPermissionSets` carried a docblock stating a short-circuit its code did not have:

> The `packages[]` pass **only supplies a set where the top level had none** — which is precisely the option-B artifact.

The code pushed the flattened top level and then **every** package body unconditionally, so on today's additive artifact (flattened level *and* `packages[]` both present) every permission set was collected twice. Nothing observable came of it: the sole caller is private and takes the first `isDefault` set, which the flattened copy still supplied. So this corrects a **false written contract on a security-path reader**, not a live defect — and the sentence was load-bearing, because it was the stated reason the reader half was revertible on its own and safe to land ahead of the emitter half (#14512).

## The fix: start from the expression this program replaced

The expression card #15007 replaced was `appDefaultPermissionSetName(config.permissions)` — a **name**, whose "came back empty" is `undefined`. The reader now walks exactly that discipline: resolve from the flattened level, and consult `packages[]` only where it answered nothing.

**The condition is the resolved NAME, never the `permissions` container.** Branching on the container re-creates the silent loss this program exists to remove, one shape further along. Reading the answer also retires the `[]`-is-truthy trap rather than patching around it, since the container is never the predicate.

**The package order is resolved BEFORE the top level is consulted, deliberately.** `resolveArtifactPackageOrder` refuses a malformed `packages` — not an array, an entry inlined instead of wrapped under `manifest:`, a duplicate package id — with an ADR-0112 envelope this reader does not catch. Moving that line below the early return would make the refusal depend on whether the flattened level happened to name a default first. An artifact is either loadable or refused; which level answered is not part of that question. The docblock says so in the file, anticipating the reading that the line is misplaced.

**Why this reader's condition is not the sibling's.** `resolveStackCollection` (`packages/cli/src/utils/stack-collections.ts`, #15006, now on main) branches on the container — `if (Array.isArray(top)) return top;` — and is right to: it returns a whole collection, so a present top-level key has by construction already answered. This reader extracts a *distinguished element* out of the collection, so "the key is present" and "the key answers" are two different facts here. Same discipline, read against what each reader's expression actually returns. That reasoning is now in the docblock, so the convergence pass reads two readers that differ **and say why**, rather than two that differ while appearing to agree.

## The dispatched fix was corrected, and the record stays here

Preserved from the PM's own account on this PR, because the correction matters more than the card did.

The dispatch prescribed branching on the container:

```ts
if (Array.isArray(flattened) && flattened.length > 0) return flattened;
```

with a warning that the bare `Array.isArray` form would re-create the silent loss via the empty-array truthiness trap. That warning was right and **insufficient**: `length > 0` fixes the empty case and leaves a worse one open. A config whose flattened level **carries permission sets but marks none of them `isDefault`** — legal today, hand-writable in any `objectstack.config.ts` — short-circuits the entire `packages[]` pass under that version and resolves `undefined`, with nothing thrown and nothing logged.

That is no longer an argument. Ablation 1 below measures it: against the dispatched snippet, exactly that shape goes red.

## Verification

Everything below ran at HEAD `274ab06bc`, on this branch merged up to `origin/main` `3a4373f4c`.

### 1 · The acceptance clause: byte-identical returns, measured rather than argued

A differential harness drove `appSecurityPluginOptions` over **26 shapes** and recorded every answer: 4 emitted shapes (the composed additive artifact, its option-B derivative, and the collection-zoo fixtures behind the #15004 acceptance pin), 14 configs the unit suite drives, 3 malformed-`packages` refusals recorded as thrown `code` + `status`, and 5 hand-authored mixed shapes the platform never emits. Three legs, each rebuilding `@objectstack/plugin-security` and proving on disk what the suite would consume:

| leg | source | `dist/` preflight | corpus |
| --- | --- | --- | --- |
| A · after | HEAD (`0ab95e53`, = HEAD blob) | `declaredDefaultPermissionSetName` present in 4 built files | 26 rows |
| B · before | pre-change file restored from `9690d114b` (`727c8455`, = that blob); on disk: `sets.push` ×2, new name ×0 | `sets.push` present in 2 built files, new name absent from all 6 | 26 rows |
| C · restore | back to HEAD (`0ab95e53`, = HEAD blob) | present / absent verdicts re-confirmed | 26 rows |

- `diff before after` → **empty, exit 0**.
- `diff after after2` → **empty, exit 0**, so the restore leg is proven by re-measurement, not by a checkout exit code.

Two of the 26 rows are the ones the dispatched snippet would have moved silently: a flattened level naming a default *plus* a malformed `packages` still throws `INVALID_ARTIFACT_PACKAGES` / `DUPLICATE_ARTIFACT_PACKAGE` at 422. That identity is what resolving the package order first buys.

### 2 · Ablations — the new tests are load-bearing

Each mutation was confirmed on disk before running (injected marker counted `1`, replaced anchor counted `0`, file hash printed against the HEAD blob), and each restore was proven by hash equality plus a marker count of `0`.

| condition under test | result |
| --- | --- |
| control (HEAD, answer-shaped) | **23 passed** |
| container-shaped **with** `length > 0` (the dispatched snippet) | **1 failed** · `a NON-EMPTY flattened array that marks no default does not either` |
| container-shaped **without** `length > 0` | **2 failed** · that one, plus `an EMPTY flattened array does not short-circuit it` |
| restored | **23 passed** |

The card's mandated positive test — top-level `permissions: []` plus a package body carrying an `isDefault` set — is the second failure, so it catches the trap the card named. The first failure is the one a container-shaped condition leaves open at any spelling.

This ablation needs no rebuild: the unit suite imports `./app-default-permission-set` relative, inside its own package, so vitest resolves source. The rebuild-and-prove discipline is owed by the CLI pin, which reaches this code through the workspace link to `dist/`, and it is paid in §1 and §3.

### 3 · Suites

- `@objectstack/plugin-security` unit suite: **23 passed** (the 18 that were on main, plus 5 new).
- `packages/cli/test/option-b-reader-acceptance.pin.test.ts`: **7 passed**, against a `dist/` proven to carry this change. The file is untouched; `OPTION_B_LOSSES`, its set-equality assertion, and the row #15226 deleted are all exactly as they were.

### 4 · Gates

46 families derived from the real change set by `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack`, re-derived after the merge because the first derivation warned it had read stale copies of its own inputs — and it had: the count moved 45 → 46, gaining `check:cli-test-child-env`. Every exit code was captured before any pipe (`cmd > log 2>&1; rc=$?`).

**All 46 green.** Two needed a second pass and are worth naming, because their first result was neither a pass nor a failure:

- `check:dual-build-cjs-loads` and `check:i18n` first exited **3** — `PREREQUISITE NOT MET`, both saying so in their own words ("Nothing was checked", "This is NOT a pass: nothing was measured"). They read built output across the whole workspace, which a package-scoped closure does not provide. After `turbo run build` over `./packages/*` and `./packages/*/*` (71/71 tasks successful) both re-ran green: 102 require entry points across 66 packages load, 610 emitted CJS files parse; 9 i18n packages all in sync.
- `check:type-check-debt` did measure rather than refuse: 14 ledger entries re-measured in 601.6s, 153 raw tsc errors, none above its recorded number.

## Boundaries

- `packages/cli/test/option-b-reader-acceptance.pin.test.ts` — untouched.
- `content/docs/releases/` — untouched.
- Changeset added at `patch`, per the card: `declaredPermissionSets` is private, so no published surface moves. It also names the one sentence of the #15226 entry it supersedes in this same unreleased batch, rather than retro-editing that entry.
- Draft, and auto-merge is not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m

_Generated by [Claude Code](https://claude.ai/code)_