### PR TITLE
docs(ci): the bump-level rule — an additive widening of a published surface is at least minor (ruling C, #15294)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -664,6 +664,23 @@ jobs:
             1. It releases something
                -> run 'pnpm changeset' and name the packages it releases.
 
+               WHICH LEVEL: A purely additive widening of a published package's
+               public surface (a new exported symbol on an `index`, a new accepted
+               key or value) takes at least `minor`. The commit type may raise a
+               bump but never lower it below what the act requires; a `fix(` that
+               widens an index is therefore `minor`, and a `fix(` that changes no
+               public surface stays `patch`. During the launch window `major` stays
+               refused by `check-changeset-no-major` and breaking-ness is carried by
+               the BREAKING banner plus the ADR-0087 disposition, not by the level.
+               Ruled by the maintainer on 2026-09-04 (decision batch #35) on #15294,
+               which recorded two contract reviews reading the repo's own history to
+               OPPOSITE bumps for the same additive act. The commit type is not the
+               discriminator it looked like: it correlates with the act, and when
+               they disagree the act wins. The 64 historical `patch` precedents are
+               pre-rule and nothing is retro-fixed. This is prose, not a gate -- no
+               check computes it; `check-changeset-no-major.mjs` refuses `major` and
+               says why in its header, and the two remaining levels are yours.
+
             2. It releases nothing (.github/, .claude/, skills/, docs/, content/,
                examples/, tests-only, and the like)
                -> apply the 'skip-changeset' label.   <<< PREFERRED

--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -51,6 +51,13 @@
  * change that states neither). They are not documentation niceties — during the
  * window they are the only signal there is.
  *
+ * CHOOSING BETWEEN THE TWO LEVELS THIS GUARD LEAVES: a purely additive widening
+ * of a published package's public surface takes at least `minor`, and the commit
+ * type may raise a bump but never lower it — the rule is written out in full in
+ * the `Check Changeset` step's prose in `.github/workflows/pr-automation.yml`
+ * ("WHICH LEVEL"), where the author who is told a changeset is missing reads it
+ * (maintainer ruling, 2026-09-04 decision batch #35, on #15294).
+ *
  * ⇒ **THIS GUARD IS WHAT GETS DISARMED AT GA.** The end condition lives in the
  * file that enforces the convention, rather than in a prose home elsewhere, so
  * that declared = enforced stays in one place: whoever closes the launch window


### PR DESCRIPTION
Fixes #15294

Records maintainer ruling **C** as prose, in the two places the issue named. No new gate, no behaviour change, nothing retro-fixed.

## Provenance

Ruling C, recorded on #15294 as comment 5540571415 by the Director seat: *"Provenance: maintainer, live PM chat, 2026-09-04, decision batch #35, verbatim 「同意」 on the presented recommendation `1A · 2(Q1 A · Q2 A · Q3 B→A)` (this card is item 3, **C**)."* Ruling authority: maintainer 2026-09-04 (batch #35).

## Where the paragraph now appears

1. **`.github/workflows/pr-automation.yml`** — inside the `Require a changeset (or the skip-changeset label)` step of the `Check Changeset` job, in the heredoc the step prints to the job log when a PR adds no changeset. It sits under **route 1** ("It releases something -> run 'pnpm changeset' and name the packages it releases"), because route 1 is exactly the moment an author has to pick a level. It opens `WHICH LEVEL:` and carries the ruled sentence, then its provenance, then the two things the ruling explicitly rules out (the 64 historical `patch` precedents are pre-rule; this is prose, not a gate).
2. **`scripts/check-changeset-no-major.mjs`** — a cross-reference in the file header, placed immediately after the paragraph that explains why the bump level is *not* the carrier of breaking-ness during the launch window, since that is the sentence the rule's last clause depends on. It states the floor in one line and points at the workflow prose and at #15294 for the full text.

The ruled sentence is reproduced word for word; only the markdown bold markers around its first sentence were dropped, because the destination is a plain-text job log rather than rendered markdown.

## Verification

Every run below was made on the branch head `fad832b7e` (`git rev-parse --short HEAD`), the final commit of this PR.

- **Behaviour unchanged, proven rather than asserted.** The verdict step's `run` script was extracted with a YAML parser from `HEAD~1` and from `HEAD`: with the heredoc body excluded the two shell scripts are byte-identical, and executing both under `ADDED=0`, `ADDED=2` and `ADDED=n/a` gives the same exit codes on both (`1`, `0`, `0`).
- **Comment-only on the script.** `git diff -U0 -- scripts/check-changeset-no-major.mjs` filtered to lines that are not block-comment continuations is empty (0 lines), so the floor, the roster and the `--self-test` fixtures are untouched; `check-changeset-no-major.mjs --self-test` is green.
- The derived gate family for these two paths (42 commands from `scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`) is green, plus the always-runs tail and the roster families whose lists live under the two touched directories. Whole-repo `pnpm lint` (`eslint . --no-inline-config`) is green with zero findings, run in the foreground under the shared verify lock (`os-verify-lock: VERDICT command-exit 0`). Full accounting in the report comment on #15294.

`skip-changeset`: this PR releases nothing — a workflow comment/prose change plus a comment line in a repo script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk

---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_