### PR TITLE
feat(spec): declare aggregate? on IDataDriver with the signature the engine calls

### DIFF
--- a/.changeset/data-driver-aggregate-declared.md
+++ b/.changeset/data-driver-aggregate-declared.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/spec": minor
+---
+
+`IDataDriver` now declares `aggregate?` — the one engine-reached driver verb that had no signature to match against.
+
+The engine has always dispatched native aggregation by presence (`typeof driver.aggregate === 'function'`) and called `driver.aggregate(object, query, options)`, but the interface never spelled the member, so a custom driver's `aggregate` was checked in neither direction: swapped arguments or a non-row result compiled clean and surfaced only after the engine's `having` filter silently matched nothing. The member is declared optional, matching the presence test — a driver without native aggregation omits it and stays conformant, served by the `find()` + in-memory fallback.
+
+Additive: every in-repo driver already satisfies the declared signature (`(object: string, query: DriverQuery, options?: DriverOptions) => Promise<Record<string, unknown>[]>`); a wider parameter union or a looser return type stays assignable. What is newly refused is a wrong argument order or a non-array result. No `DriverCapabilities` bit is added — presence remains the capability test, as `data/driver.zod.ts` rules.

--- a/packages/objectql/src/engine-filter-array-lowering.test.ts
+++ b/packages/objectql/src/engine-filter-array-lowering.test.ts
@@ -27,7 +27,6 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import type {
-  DriverOptions,
   EngineAggregateOptions,
   EngineCountOptions,
   EngineQueryOptions,
@@ -90,15 +89,14 @@ interface SeenRead { ast: DriverQuery }
  * the annotation THIS declaration is what fails when a member is added or a
  * signature moves.
  *
- * The one extension: `aggregate` is NOT on `IDataDriver`. The engine reaches it
- * by duck-typing (`typeof drv.aggregate === 'function'`, `engine.ts`), so it is
- * declared here explicitly — the pin exercises that verb and must keep
- * witnessing it. ⚠️ Declared here does NOT make it contractual; it records that
- * this double answers a call the interface does not describe.
+ * `aggregate` included: the engine reaches it by duck-typing
+ * (`typeof drv.aggregate === 'function'`, `engine.ts`), and until #14345 the
+ * interface did not declare it, so this file carried a local extension for
+ * the one verb. `IDataDriver.aggregate?` now spells the signature the engine
+ * calls, so the double's `aggregate` is checked by the same annotation as
+ * every other verb — no local extension, nothing this double answers that the
+ * contract does not describe.
  */
-interface RecordingDriver extends IDataDriver {
-  aggregate(object: string, query: DriverQuery, options?: DriverOptions): Promise<Record<string, unknown>[]>;
-}
 
 /**
  * A verb the pin does not exercise, present only because `IDataDriver` requires
@@ -152,7 +150,7 @@ function makeRecordingDriver() {
     const out = [...rows.values()].filter((r) => matches(r, ast?.where));
     return typeof ast?.limit === 'number' && ast.limit > 0 ? out.slice(0, ast.limit) : out;
   };
-  const driver: RecordingDriver = {
+  const driver: IDataDriver = {
     name: 'recording', version: '0.0.0', supports: {},
     async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
     async find(_o: string, ast: DriverQuery) { reads.push({ ast }); return run(ast); },

--- a/packages/spec/src/contracts/data-driver.ts
+++ b/packages/spec/src/contracts/data-driver.ts
@@ -213,6 +213,42 @@ export interface IDataDriver {
    */
   count(object: string, query?: DriverQuery, options?: DriverOptions): Promise<number>;
 
+  /**
+   * Native aggregation pushdown: execute `query.groupBy` / `query.aggregations`
+   * inside the store and return the ALREADY-GROUPED rows.
+   *
+   * What the engine passes (objectql `engine.ts`, `ObjectQL.aggregate`): the
+   * object name; the full query AST it built for the read (`where`, `groupBy`,
+   * `aggregations`, `orderBy`, `limit`, ...) — the same {@link DriverQuery}
+   * `find()` receives, so a value that satisfies `find` satisfies this; and the
+   * per-call {@link DriverOptions}. Presence IS the capability test: the engine
+   * dispatches on `typeof driver.aggregate === 'function'` — the rule
+   * `data/driver.zod.ts` states for `DriverCapabilities`, and why there is
+   * deliberately no `queryAggregations` bit — and otherwise falls back to
+   * `find()` plus in-memory grouping. Two things the engine keeps for itself
+   * even when it dispatches here: `having` is applied AFTER this call, over the
+   * returned rows (#4286); and `aggregations[].filter` (#10576) or a non-UTC
+   * `timezone` with date bucketing (ADR-0053) force the in-memory path, so a
+   * driver never sees either on this road today.
+   *
+   * What a driver returns: one row per group, keyed by the `groupBy` field
+   * names and by each aggregation's `alias`, with the per-function value
+   * semantics `data/aggregation-conformance.ts` pins for every face that
+   * lowers this vocabulary. The engine's `having` filter reads exactly those
+   * keys, so a mis-keyed row does not error — it silently fails to match.
+   *
+   * Declared for the reason `introspectSchema` gives below: the engine reached
+   * this verb by duck-typing with no signature to mis-match against, so
+   * `aggregate(query, object)` with the arguments swapped, or a non-row
+   * result, compiled clean and surfaced only downstream of `having`. Optional,
+   * matching the presence test — a driver without native aggregation
+   * (driver-rest today) omits the member and stays conformant, served by the
+   * fallback. A wider parameter union (driver-memory also accepts a raw
+   * pipeline) or a looser return type stays assignable; what is refused is a
+   * wrong argument order or a non-array result.
+   */
+  aggregate?(object: string, query: DriverQuery, options?: DriverOptions): Promise<Record<string, unknown>[]>;
+
   // ===========================================================================
   // Bulk Operations
   // ===========================================================================


### PR DESCRIPTION
Fixes #14345

Implemented-by: `os-dev` developer, session `session_01H2oQebDDxYKfWZusyd8GXk`, dispatched by the `domain:spec` seat (triage ruling 5503624197: `aggregate?`, optional, declared with the signature the engine calls).

## What changes

- `packages/spec/src/contracts/data-driver.ts` — `IDataDriver` gains `aggregate?(object: string, query: DriverQuery, options?: DriverOptions)` returning a Promise of an array of Record(string, unknown), placed after `count()` in the query-verb section, with house-form TSDoc: what the engine passes, what a driver returns (rows keyed by `groupBy` field names and aggregation aliases per `data/aggregation-conformance.ts`), that presence is the capability test (`data/driver.zod.ts`), and why it is declared (the `introspectSchema` argument).
- `packages/objectql/src/engine-filter-array-lowering.test.ts` — the recording double's local `RecordingDriver` extension (the card's motivating case) is retired; the double is now annotated `IDataDriver` directly and the now-unused `DriverOptions` import is dropped. The 60 cases pass unchanged.
- `.changeset/data-driver-aggregate-declared.md` — `@objectstack/spec` minor (additive optional member; no ADR-0087 entry).

Out of scope and untouched, per the triage: the engine's `as any` at `engine.ts:13493-13500`, every driver implementation, `DriverCapabilities`, `IDataEngine`.

## The measured call-site type

`engine.ts:13447` binds `const ast = opCtx.ast as QueryAST;` and `:13500` calls `drv.aggregate(object, ast, this.buildDriverOptions(object, opCtx.context))`. The engine passes a full `QueryAST`, not a narrower typed AST. `DriverQuery` is `Omit` of `QueryAST` minus `object`, so a `QueryAST` value is assignable to it — the seat's default parameter type is the correct one and is not narrower than what the engine passes. The return is consumed by `applyHaving(rows: any[], ...)`, which reads aggregation aliases and `groupBy` projections off each row, so an array of string-keyed records is the shape the engine actually relies on.

## Proof against the four in-repo implementations (built spec, `dist` carries the member once)

| package | declared implementation | `pnpm --filter ... typecheck` |
|:--|:--|:--|
| driver-memory `memory-driver.ts:1152` | `(object: string, pipeline: raw pipeline array OR DriverQuery, options?: DriverOptions)`, returns Promise of any array | exit 0 (`tsc --noEmit && tsc --noEmit -p tsconfig.typecheck.json`) |
| driver-mongodb `mongodb-driver.ts:602` | `(object: string, query: DriverQuery, options?: DriverOptions)`, returns Promise of Record(string, unknown) array | exit 0 |
| driver-sql `sql-driver.ts:8320` | `(object: string, query: DriverQuery, options?: DriverOptions)`, returns Promise of any | exit 0 |
| driver-turso `remote-transport.ts:1332` | `(object: string, query: DriverQuery)`, returns Promise of Record(string, unknown) array — `RemoteTransport` is a delegate, not an `IDataDriver` implementer; `TursoDriver.aggregate` (`turso-driver.ts:844`, overriding `SqlDriver`) is the member the interface checks, and it routes to the transport | exit 0 |

`@objectstack/objectql typecheck` (three legs incl. `check:test-typecheck`): exit 0 — `check:test-typecheck: OK — @objectstack/objectql's test layer compiles under packages/objectql/tsconfig.test.json; 44 file(s) / 242 error(s) / 69 pinned signature(s)`; the edited test file is deliberately unledgered (zero errors, red on its first), so its green is measured. The two `metadata` migration test fakes that declare `async aggregate() { return []; }` remain assignable (fewer parameters, empty array).

`contract_flags`: none — no implementation needs the declaration widened. Bivariant method parameters admit driver-memory's wider union; `any` / any-array returns are assignable.

## Negative probe (the declaration bites)

A scratch `.test.ts` in objectql assigned three literals to `IDataDriver` and ran `tsc -p tsconfig.test.json`: swapped arguments `(query: DriverQuery, object: string)` — TS2322 at that line; a scalar return (`42`) — TS2322 at that line; the engine's call shape — admitted. Probe deleted; `git status` clean of it.

## Generated followers and gates

`pnpm --filter @objectstack/spec build` then `check:generated`: `All 15 generated artifacts are up to date` — `api-surface` / `declaration-map` / `export-origins` did not go stale (they record that an export exists, not an interface's member shape), so there was nothing for `--fix` to write. `node scripts/pm/dispatch-gates.mjs --commands` (3 paths vs merge base `13c48c2a5`) derived 63 commands; 61 exit 0. Two exit 3 with `PREREQUISITE NOT MET` and are NOT MEASURED here, not red: `check:dual-build-cjs-loads` and `check:type-check-debt` both read a whole-repo `dist/` that only a full `pnpm build` produces — that run is CI's. Ratchet re-run on the committed head is reported in the `os-dev-report` comment on #14345.

`needs:contract-review` per clause ②: the review question is whether the declared signature matches all four implementations; this PR stays draft until the seat flips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2oQebDDxYKfWZusyd8GXk)_