### PR TITLE
test(metadata): delete the eight always-true `if (manager.X)` guards so the assertions actually run

### DIFF
--- a/packages/metadata/src/metadata-history.test.ts
+++ b/packages/metadata/src/metadata-history.test.ts
@@ -44,13 +44,11 @@ describe('Metadata History', () => {
     await manager.register('object', 'test_object', objectDef);
 
     // Check that history was created
-    if (manager.getHistory) {
-      const history = await manager.getHistory('object', 'test_object');
+    const history = await manager.getHistory('object', 'test_object');
 
-      expect(history.records.length).toBeGreaterThan(0);
-      expect(history.records[0].operationType).toBe('create');
-      expect(history.records[0].version).toBe(1);
-    }
+    expect(history.records.length).toBeGreaterThan(0);
+    expect(history.records[0].operationType).toBe('create');
+    expect(history.records[0].version).toBe(1);
   });
 
   it('should create history record on metadata update', async () => {
@@ -78,13 +76,11 @@ describe('Metadata History', () => {
     await manager.register('object', 'test_object', updatedDef);
 
     // Check history
-    if (manager.getHistory) {
-      const history = await manager.getHistory('object', 'test_object');
+    const history = await manager.getHistory('object', 'test_object');
 
-      expect(history.records.length).toBeGreaterThanOrEqual(2);
-      expect(history.records[0].operationType).toBe('update');
-      expect(history.records[0].version).toBe(2);
-    }
+    expect(history.records.length).toBeGreaterThanOrEqual(2);
+    expect(history.records[0].operationType).toBe('update');
+    expect(history.records[0].version).toBe(2);
   });
 
   it('should rollback to previous version', async () => {
@@ -108,12 +104,10 @@ describe('Metadata History', () => {
     await manager.register('object', 'test_object', version2);
 
     // Rollback to version 1
-    if (manager.rollback) {
-      const restored = await manager.rollback('object', 'test_object', 1);
+    const restored = await manager.rollback('object', 'test_object', 1);
 
-      expect(restored).toBeDefined();
-      expect((restored as any).label).toBe('Version 1');
-    }
+    expect(restored).toBeDefined();
+    expect((restored as any).label).toBe('Version 1');
 
     // Verify current metadata is version 1
     const current = await manager.get('object', 'test_object');
@@ -143,13 +137,11 @@ describe('Metadata History', () => {
     await manager.register('object', 'test_object', version2);
 
     // Compare versions
-    if (manager.diff) {
-      const diffResult = await manager.diff('object', 'test_object', 1, 2);
+    const diffResult = await manager.diff('object', 'test_object', 1, 2);
 
-      expect(diffResult.identical).toBe(false);
-      expect(diffResult.patch!.length).toBeGreaterThan(0);
-      expect(diffResult.summary).toContain('modified');
-    }
+    expect(diffResult.identical).toBe(false);
+    expect(diffResult.patch!.length).toBeGreaterThan(0);
+    expect(diffResult.summary).toContain('modified');
   });
 
   it('should handle history query with filters', async () => {
@@ -164,22 +156,20 @@ describe('Metadata History', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
     }
 
-    if (manager.getHistory) {
-      // Query with limit
-      const limitedHistory = await manager.getHistory('object', 'test_object', {
-        limit: 3,
-      });
+    // Query with limit
+    const limitedHistory = await manager.getHistory('object', 'test_object', {
+      limit: 3,
+    });
 
-      expect(limitedHistory.records.length).toBeLessThanOrEqual(3);
-      expect(limitedHistory.total).toBeGreaterThanOrEqual(5);
+    expect(limitedHistory.records.length).toBeLessThanOrEqual(3);
+    expect(limitedHistory.total).toBeGreaterThanOrEqual(5);
 
-      // Query with operation type filter
-      const createHistory = await manager.getHistory('object', 'test_object', {
-        operationType: 'create',
-      });
+    // Query with operation type filter
+    const createHistory = await manager.getHistory('object', 'test_object', {
+      operationType: 'create',
+    });
 
-      expect(createHistory.records.every(r => r.operationType === 'create')).toBe(true);
-    }
+    expect(createHistory.records.every(r => r.operationType === 'create')).toBe(true);
   });
 
   it('should skip history record when checksum is unchanged', async () => {
@@ -194,23 +184,19 @@ describe('Metadata History', () => {
     // Re-register with exact same content
     await manager.register('object', 'test_object', objectDef);
 
-    if (manager.getHistory) {
-      const history = await manager.getHistory('object', 'test_object');
+    const history = await manager.getHistory('object', 'test_object');
 
-      // Should only have one history record (the create)
-      // The second register should be skipped due to identical checksum
-      expect(history.records.length).toBe(1);
-    }
+    // Should only have one history record (the create)
+    // The second register should be skipped due to identical checksum
+    expect(history.records.length).toBe(1);
   });
 
   it('should return empty history for non-existent metadata', async () => {
-    if (manager.getHistory) {
-      const history = await manager.getHistory('object', 'nonexistent');
+    const history = await manager.getHistory('object', 'nonexistent');
 
-      expect(history.records).toEqual([]);
-      expect(history.total).toBe(0);
-      expect(history.hasMore).toBe(false);
-    }
+    expect(history.records).toEqual([]);
+    expect(history.total).toBe(0);
+    expect(history.hasMore).toBe(false);
   });
 
   it('should throw error when rolling back to non-existent version', async () => {
@@ -219,10 +205,8 @@ describe('Metadata History', () => {
       label: 'Test',
     });
 
-    if (manager.rollback) {
-      await expect(
-        manager.rollback('object', 'test_object', 999)
-      ).rejects.toThrow();
-    }
+    await expect(
+      manager.rollback('object', 'test_object', 999)
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
Closes #14623

Every assertion in `packages/metadata/src/metadata-history.test.ts` sat inside a truthiness guard over the very method under test. Eight guards, one per `it()`, over eight tests — and all three methods are unconditional members of `MetadataManager`, so every guard was always true and bought nothing while making every assertion structurally optional. This deletes the eight guards and de-indents the bodies. **No assertion is rewritten**; the `patch!` non-null lands through verbatim.

Triage ruled **option 1** on the card. Option 2 (capability assertions) is deliberately not written.

## The measurement this card is actually for

Deleting eight always-true `if`s changes no observable behaviour today, so a green suite before and a green suite after proves nothing — that is this card's own thesis turned on the verification of it. The discriminator is a **paired ablation on the method, not on the test**: rename `async diff(` out of `MetadataManager` and ask whether the suite's verdict can see it.

| leg | guards | vitest verdict under the mutation | `tsc --noEmit` under the same mutation |
| --- | --- | --- | --- |
| **BEFORE** | present | **GREEN — `Test Files 1 passed (1)`, `Tests 8 passed (8)`, exit 0** | RED, exit 2 — TS2339 at `:146,17` and `:147,40` |
| **AFTER** | deleted | **RED — `Test Files 1 failed (1)`, `Tests 1 failed \| 7 passed (8)`, exit 1**, `x should compare versions with diff` | RED, exit 2 — TS2339 at `:140,38` |

The BEFORE row is the defect, reproduced: with `diff` gone from the class, the suite reported **eight passing tests** and exit 0. That is the silent skip the card was filed about, and it is now closed — the same mutation reddens the file.

**The claim is scoped to vitest's verdict.** `tsc` reds on **both** legs, so it does not rescue the BEFORE row and it is not what this change buys. That confirms, from a run, the correction recorded on the card: the guard names the property, so a rename reds `tsc` with or without it. The runtime skip was the only thing the guards actually caused and the only thing deleting them actually fixes.

Ablation hygiene, both legs: the mutation was proven **on disk** by grep counts of the vanished anchor (1 to 0) and an injected marker (0 to 1) plus a moved blob hash — never by an editor's exit code. Restore ran under `trap ... EXIT INT TERM` against an absolute path and was proven against the path's HEAD blob hash **and** an empty `git diff HEAD`. The test resolves `MetadataManager` through a **relative** import, so the mutation is read from `src` and no rebuild sits between the edit and the verdict; the cross-package `@objectstack/driver-sqlite-wasm` import does resolve through `dist`, and that closure was built before either leg. An earlier attempt at the BEFORE leg aborted itself because its `grep -cE` left `(` unescaped and returned empty counts: empty was read as FAILURE, not as "nothing to compare", the trap restored the tree, and the leg was re-run with corrected patterns.

## The assumption nobody had ever measured

The card's load-bearing risk was that eight assertion bodies had **never executed under a verdict capable of going red**, so one of them might genuinely fail. Measured now, for the first time:

```
plain AFTER run, guards deleted
  Test Files  1 passed (1)
  Tests  8 passed (8)          exit 0
```

Every guarded assertion passes once the guard is gone. **No hidden failing assertion.** Plain BEFORE run on today's base was the same shape (`1 passed (1)` / `8 passed (8)`), confirming the reading previously recorded on the card at an older base.

## A narrower contract does exist — measured, reported on the card before the first edit, and it does not change the ruling

`MetadataManager implements IMetadataService` (`packages/metadata/src/metadata-manager.ts:314`), and that interface declares **exactly these three methods, and only these three, optional** — `packages/spec/src/contracts/metadata-service.ts:802` `getHistory?`, `:813` `rollback?`, `:827` `diff?`. Triage's negative grep was scoped to `packages/metadata/src` and could not see it; I reproduce that zero exactly, with a firing control. So the contract's optionality is a plausible **origin** for the guard style.

It is not evidence of **intent** for this file, and that was measured rather than argued: the test references `IMetadataService` zero times (control: `metadata-manager.ts` matches 20 times), and across all five revisions `git log --follow` returns — back to and including `f054641a2`, the commit that introduced the guards — the annotation has **always** read `let manager: MetadataManager`. It was never typed against the contract, not even in the revision that added the guards. Triage's primary argument therefore holds, and now holds against the file's whole history rather than only its current tree.

Adopting the narrower reading would also mean annotating `let manager: IMetadataService`, which makes the guards load-bearing to `tsc` and institutionalises exactly the silent skip this card is about. Triage had already ruled the truthiness checks wrong under **both** readings.

## Verification

At `3ecd42d7a` (this PR's head; the gate union was run on this exact tree, after the final commit).

- **36 of 36 gate families green, exit 0 each**, captured before any pipe. List derived from the changeset with `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` on a tree at fresh `origin/main` — an earlier derivation warned STALE TREE and was discarded rather than acted on — and asserted against the Reconciliation line's total of 36, not against the matched-families count.
- `check:type-check-debt` ran **with the workspace closure built** exactly as `lint.yml` does (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 71/71 successful) and under the paired `--max-old-space-size=6144` ceiling, so it re-measured rather than refusing: 14 ledger entries, 153 raw errors, none above its recorded number.
- `pnpm --filter @objectstack/metadata typecheck` — exit 0. This program demonstrably **does** include the test file: both ablation legs produced `tsc` errors inside `metadata-history.test.ts` itself.
- `pnpm --filter @objectstack/metadata test` — `Test Files 46 passed (46)`, `Tests 705 passed (705)`, exit 0.
- Shape checks on the edited file: `if (manager.` 0 (control: 132 in `metadata-manager.ts`), every `if (` 0, `it(` 8, `expect(` 20, 228 lines to 212, no trailing whitespace and no raw control bytes (both zeros carry firing controls).

## No changeset, by measurement

`skip-changeset` is applied instead, and the route was measured rather than recalled: `packages/metadata` declares `files: ["dist","README.md","CHANGELOG.md"]`, so a `.test.ts` never reaches a published tarball, and of the last 400 commits on `origin/main` **20 of 20** that touched only test files carry no changeset. An empty-frontmatter changeset is not the alternative here — `scripts/check-empty-changeset.mjs` rejects newly added ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ)_