### PR TITLE
fix(pm): dispatch-gates and check-self-test-wired discover package-local gate invocations by their real path (#15342)

### DIFF
--- a/scripts/check-self-test-wired.mjs
+++ b/scripts/check-self-test-wired.mjs
@@ -152,14 +152,50 @@ const SCRIPT_EXT = /\.(mjs|mts|js|sh)$/;
 const ROOT_DIR_WATCH_HINTS = ['scripts/**/*.mjs', 'scripts/**/*.mts', 'scripts/**/*.sh'];
 
 /**
- * A `scripts/...` path, optionally followed by `--self-test`.
+ * A `scripts/...` path, optionally prefixed by the directories it lives under
+ * and optionally followed by `--self-test`.
  *
  * The trailing `(?![\w-])` is the right boundary: without it `--self-test-extra`
  * reads as an invocation of `--self-test`, which is #10534's defect wearing this
  * gate's hat.
+ *
+ * ## The LEFT boundary, and why the prefix is read rather than cut off (#15342)
+ *
+ * This repo has a package-local gate lane, and `lint.yml` really does run one
+ * of its gates by path: `node packages/lint/scripts/check-reference-carrier-
+ * shape.mjs --self-test`. The pattern used to open on the bare literal
+ * `scripts/` with nothing to its left, so it matched that path as a SUBSTRING
+ * and filed the gate under `scripts/check-reference-carrier-shape.mjs` — a key
+ * with no file behind it. Both directions of that were silent: the real file
+ * was never audited (it is not under the root walk, so it is in no population),
+ * and the phantom key could never be reconciled against a carrier either, so
+ * neither `auditPopulation` nor `auditLedger` had anything to say. A gate whose
+ * whole subject is "the self-test CI ships is the self-test CI runs" was
+ * answering about a different script than the one CI executes.
+ *
+ * So the directory prefix is CONSUMED into the key rather than cut away, and
+ * `(?<![\w.\-/])` is the left boundary that makes the key a whole path instead
+ * of a tail of one. Both halves are load-bearing and were measured on this
+ * tree's own corpus before landing:
+ *
+ *   - a leading `./` is stripped rather than kept, because it is the same file
+ *     under a different spelling and paths are compared by EXACT equality here.
+ *     `cut-rc.yml` and `release.yml` both import from `"./scripts/check-docs-
+ *     image-tag.mjs"`; keying those to `./scripts/…` would silently drop two
+ *     live invocations the old pattern did credit.
+ *   - a segment must START with an alphanumeric or `_`, so `..` is not a
+ *     prefix segment. A `../…` path cannot be resolved against this ROOT
+ *     without knowing what it is relative to, and inventing a key for it is how
+ *     the phantom above was minted in the first place. Zero occur in the
+ *     workflow corpus today; refusing to match is the safe direction, and the
+ *     population half below never admits a path it cannot read.
+ *
+ * Measured after this change over the live corpus: 186 named paths, ZERO of
+ * which lack a file on disk (before: exactly one, the phantom above). The
+ * `live corpus` battery holds both halves of that reading.
  */
 const INVOCATION_RE =
-  /(scripts\/[A-Za-z0-9_.\-/]+\.(?:mjs|mts|js|sh))(\s+--self-test(?![\w-]))?/g;
+  /(?<![\w.\-/])(?:\.\/)*((?:[A-Za-z0-9_][A-Za-z0-9_.\-]*\/)*scripts\/[A-Za-z0-9_.\-/]+\.(?:mjs|mts|js|sh))(\s+--self-test(?![\w-]))?/g;
 
 /**
  * ⛔ SHRINK-ONLY. Scripts CI runs whose self-test IS run by CI, but not through
@@ -424,6 +460,37 @@ function main() {
   const { named, selfTested } = collectInvocations(workflows, pkgScripts);
   if (named.size === 0) refuse('no workflow names any scripts/ file — the workflow reader is broken (#4690).');
 
+  // The population's SECOND source: the package-local gate lane (#15342).
+  //
+  // `walkScripts` is anchored at the repo-root `scripts/` dir, so a gate CI
+  // invokes by a package-local path is outside `carriers` no matter how the
+  // anchor above keys it — and a script that is in no population is audited by
+  // neither `auditPopulation` (it iterates carriers) nor `auditLedger`. Fixing
+  // the key alone would have left that half exactly as silent as before.
+  //
+  // ⛔ NOT a second walk. The subject of this gate is "a script CI RUNS whose
+  // self-test CI must run too", so what CI names is the honest population
+  // boundary out here; a walk over every `packages/*/scripts` dir would admit
+  // files CI never runs, which `auditPopulation` discards on the next line
+  // anyway, and would owe `ROOT_DIR_WATCH_HINTS` a declaration that is no
+  // longer set-equal to the root walk it is documented to mirror. The root walk
+  // stays the ROOT half — it is what the `#4690` floors above are written
+  // against ("this tree has dozens"), and a naming-derived population could not
+  // carry those.
+  //
+  // Admitted on exactly the terms the root walk uses, and no looser: the file
+  // must EXIST and its CODE (comments masked) must carry the literal. A named
+  // path with nothing behind it is left OUT rather than admitted — that is the
+  // phantom this card is about, and admitting one would re-create it one layer
+  // down. It is not a refusal either: this gate does not own what a workflow is
+  // allowed to name, and the anchor above already declines to invent keys.
+  for (const relPath of named.keys()) {
+    if (relPath.startsWith('scripts/')) continue;
+    const source = sourceOf(relPath);
+    if (source === null) continue;
+    if (carriesSelfTest(relPath, source)) carriers.add(relPath);
+  }
+
   const findings = [
     ...auditPopulation({ carriers, named, selfTested, ledger: SELF_TEST_RUN_OTHERWISE }),
     ...auditLedger({ ledger: SELF_TEST_RUN_OTHERWISE, carriers, named, selfTested, sourceOf }),
@@ -431,9 +498,11 @@ function main() {
 
   const members = [...carriers].filter((s) => named.has(s));
   const wired = members.filter((s) => selfTested.has(s));
+  const packageLocal = [...carriers].filter((s) => !s.startsWith('scripts/'));
   const scope =
     `  scope: ${files.length} file(s) under scripts/, ${carriers.size} carrying \`--self-test\` in code ` +
-    `(comments masked); ${members.length} of those are run by ${workflows.length} workflow(s); ` +
+    `(comments masked, ${packageLocal.length} of them package-local gate(s) CI names by path); ` +
+    `${members.length} of those are run by ${workflows.length} workflow(s); ` +
     `${wired.length} have their self-test run through the flag, ${SELF_TEST_RUN_OTHERWISE.length} through a recorded route.`;
 
   if (findings.length > 0) {
@@ -496,9 +565,11 @@ function main() {
 const SELF_TEST_BATTERIES = Object.freeze({
   'comment mask': 7,
   'right boundary': 4,
+  'left boundary': 6,
   'alias resolution': 4,
   'population verdict': 4,
   'population declaration': 7,
+  'live corpus': 3,
   'ledger hygiene': 9,
   'live ledger': 4,
 });
@@ -506,7 +577,7 @@ const SELF_TEST_BATTERIES = Object.freeze({
 // DELETING an entry silences that battery's floor exactly as effectively as
 // zeroing it, so the registry's own size is pinned too. Adding a battery raises
 // this number; removing one is the same ⛔ deliberate edit as lowering a count.
-const SELF_TEST_BATTERY_FLOOR = 7;
+const SELF_TEST_BATTERY_FLOOR = 9;
 
 // The key an assertion is filed under when no battery is open. It is not a
 // declared battery, so it reds by the same set difference rather than silently
@@ -585,6 +656,60 @@ function selfTest() {
     ok(
       !got.selfTested.has('scripts/check-foo.mjs'),
       '`scripts/check-foo.mjs` was credited on the strength of its longer sibling (prefix match, not exact equality)',
+    );
+  }
+
+  // ── Left boundary: a path is keyed WHOLE, never as a tail of one (#15342) ─
+  //
+  // Every case here fails against the pre-#15342 anchor (`/(scripts\/…)/`, no
+  // left boundary, no prefix), which is what makes them an instrument rather
+  // than a restatement of the operators. Measured by applying this battery to
+  // the base tree's pattern in a scratch ablation: cases 1-4 red there, 5-6
+  // stay green — 5 and 6 are the controls that prove the widening did not buy
+  // its new answers by dropping the old ones.
+  battery('left boundary');
+  {
+    const PKG = 'packages/lint/scripts/check-reference-carrier-shape.mjs';
+    const got = collectInvocations(wf(`    - run: node ${PKG} --self-test\n`), {});
+    ok(
+      got.named.has(PKG),
+      'a gate CI invokes by a PACKAGE-LOCAL path was not keyed to its real path — it is then in no '
+        + 'population and its self-test wiring is audited for nobody (#15342)',
+    );
+    ok(
+      got.selfTested.has(PKG),
+      'the package-local path was named but its `--self-test` was not credited to it',
+    );
+    ok(
+      !got.named.has('scripts/check-reference-carrier-shape.mjs'),
+      'the package-local path was ALSO filed under a root path with no file behind it — the phantom key '
+        + 'a substring match mints, which no carrier can ever reconcile (#15342)',
+    );
+  }
+  {
+    // A path that is a tail of a longer one must not be minted on its own.
+    const got = collectInvocations(wf('    - run: node vendor/tools/scripts/g.mjs --self-test\n'), {});
+    ok(
+      !got.named.has('scripts/g.mjs'),
+      'a `scripts/…` SUBSTRING of a longer path was minted as a key in its own right',
+    );
+  }
+  {
+    // Control 1 — the plain root spelling is unchanged.
+    const got = collectInvocations(wf('    - run: node scripts/g.mjs --self-test\n'), {});
+    ok(got.selfTested.has('scripts/g.mjs'), 'the ordinary root spelling stopped being keyed to itself');
+  }
+  {
+    // Control 2 — `./scripts/…` still normalises onto the walk's key. Live
+    // spelling: `cut-rc.yml` and `release.yml` import from `"./scripts/…"`,
+    // and keying those anywhere else silently drops two real invocations.
+    const got = collectInvocations(
+      wf('    - run: node --input-type=module -e \'import { X } from "./scripts/g.mjs";\'\n'),
+      {},
+    );
+    ok(
+      got.named.has('scripts/g.mjs'),
+      'a leading `./` was kept in the key, so the same file under two spellings stopped comparing equal',
     );
   }
 
@@ -699,6 +824,41 @@ function selfTest() {
         && !/[A-Za-z_$][\w$]*\s*\./.test(declSites[0][1]),
       'the declaration is not a single literal array of quoted strings — the extractor reads SOURCE TEXT, '
         + 'so a computed spelling contributes nothing while every assertion above stays green',
+    );
+  }
+
+  // ── The live corpus: the anchor is measured on specimens, not on fixtures ─
+  //
+  // A widening measured on zero specimens is not measured. The fixtures above
+  // prove the pattern; these three read the tree CI actually runs, so the day
+  // the package-local lane moves, this reds here instead of going quiet.
+  battery('live corpus');
+  {
+    let corpus = null;
+    try {
+      const dir = join(ROOT, WORKFLOW_DIR);
+      const workflows = readdirSync(dir)
+        .filter((f) => /\.ya?ml$/.test(f))
+        .sort()
+        .map((name) => ({ name, text: readFileSync(join(dir, name), 'utf8') }));
+      const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).scripts ?? {};
+      corpus = collectInvocations(workflows, pkg);
+    } catch {
+      corpus = null;
+    }
+    ok(corpus !== null && corpus.named.size > 0, 'the live workflow corpus could not be read — the pins below would prove nothing (#4690)');
+    const keys = corpus === null ? [] : [...corpus.named.keys()];
+    ok(
+      keys.length > 0 && keys.every((p) => existsSync(join(ROOT, p))),
+      'a path this gate keys an invocation to has NO file behind it. Every audit downstream then runs '
+        + 'against a script that does not exist, and passes for the wrong reason, in both directions (#15342)',
+    );
+    // Named BY NAME on purpose: it is this tree's only package-local gate
+    // invocation, so it is the whole specimen set for the widening above.
+    ok(
+      keys.includes('packages/lint/scripts/check-reference-carrier-shape.mjs'),
+      "lint.yml's package-local gate is not in the live population. Either the lane moved — re-point this "
+        + 'pin at the new specimen — or the anchor regressed to a root-only one and the widening is untested',
     );
   }
 

--- a/scripts/check-self-test-wired.mjs
+++ b/scripts/check-self-test-wired.mjs
@@ -484,8 +484,19 @@ function main() {
   // phantom this card is about, and admitting one would re-create it one layer
   // down. It is not a refusal either: this gate does not own what a workflow is
   // allowed to name, and the anchor above already declines to invent keys.
+  //
+  // ⛔ The skip is membership in the WALK'S OWN OUTPUT, never `startsWith` on a
+  // re-spelling of its root. That spelling is a bare top-level word wearing a
+  // separator, so it reaches the dispatch derivation's hint set as the plain
+  // literal `scripts` and joins the SHRINK-ONLY escapable-literal species
+  // (#10705) -- a population no `hintCovers` can name, declared by a gate that
+  // already declares the nameable spelling three lines up. Measured when this
+  // landed: the `startsWith` form added exactly that row, FRESH, to both of
+  // this gate's families. The set form says what the predicate means -- "the
+  // root walk did not already produce this path" -- and declares nothing.
+  const walked = new Set(files);
   for (const relPath of named.keys()) {
-    if (relPath.startsWith('scripts/')) continue;
+    if (walked.has(relPath)) continue;
     const source = sourceOf(relPath);
     if (source === null) continue;
     if (carriesSelfTest(relPath, source)) carriers.add(relPath);
@@ -498,7 +509,7 @@ function main() {
 
   const members = [...carriers].filter((s) => named.has(s));
   const wired = members.filter((s) => selfTested.has(s));
-  const packageLocal = [...carriers].filter((s) => !s.startsWith('scripts/'));
+  const packageLocal = [...carriers].filter((s) => !walked.has(s));
   const scope =
     `  scope: ${files.length} file(s) under scripts/, ${carriers.size} carrying \`--self-test\` in code ` +
     `(comments masked, ${packageLocal.length} of them package-local gate(s) CI names by path); ` +

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -1110,6 +1110,73 @@ export function jobPathPopulations(workflowText, workflowFile) {
 }
 
 /**
+ * ## The DIRECTORY PREFIX both matchers below carry, and why it is shared (#15342)
+ *
+ * This repo has a package-local gate lane, and `lint.yml` really runs one of
+ * its gates by path — `node packages/lint/scripts/check-reference-carrier-
+ * shape.mjs --self-test`, with the bare production invocation on the next line.
+ * Both patterns used to open on the literal `scripts/` immediately after
+ * `node `, so neither matched that step AT ALL. The gate was in no family, and
+ * `--residue` could not report it either: it is absent from the universe the
+ * matched / silent / undetermined buckets partition, which is the #11397 state
+ * one lane over. Measured on the base tree for a card editing that gate's OWN
+ * file: `--commands` named it zero times, every one of the 27 `--residue`
+ * mentions was the dev's own CHANGED PATH echoed back as an input, and the step
+ * surfaced only in the always-runs STEP tail, as one of the 33 unconditional CI
+ * steps this derivation names no family for.
+ *
+ * ## What the prefix admits, and what it deliberately refuses
+ *
+ *   - A prefix segment must START with an alphanumeric or `_`, so `..` is not
+ *     one. A climbing spelling cannot be resolved against this ROOT without
+ *     knowing what it is relative to, and `entry.files` would then carry a key
+ *     with no file behind it — the phantom `resolveCheckToFiles`' docblock
+ *     prices at "strictly worse than the bug being fixed". Zero occur in the
+ *     workflow corpus today; refusing to match is the safe direction, and the
+ *     sibling anchor in `scripts/check-self-test-wired.mjs` refuses it in the
+ *     same spelling for the same reason.
+ *   - A `scripts/` segment is still REQUIRED, so no new file species is
+ *     admitted. `node packages/cli/bin/run.js` is the only other non-root path
+ *     any workflow invokes with `node`, and it stays out.
+ *   - The prefix cannot RE-ATTRIBUTE an existing match. For a path that already
+ *     began at `scripts/` the group matches empty and the remainder of each
+ *     pattern is byte-identical, so every key this tool minted before it is
+ *     minted after it. Asserted below rather than left as this sentence.
+ *
+ * ## Priced in both directions, over 7472 tracked files (base `65846bc46`)
+ *
+ *   check families discovered        252 -> 254       (+2, ZERO lost)
+ *   gate files                       201 -> 202       (+1, ZERO lost)
+ *   watch-hint (gate, file) pairs  240947 -> 254181   (+13234, ZERO lost)
+ *   existing families re-attributed  0 — every pre-existing family's pair count
+ *                                    is byte-identical before and after
+ *   always-runs steps naming NO family  33 -> 32 (18 -> 17 distinct commands)
+ *
+ * The +13234 is exactly 2 x 6617: the gate declares four subtree hints
+ * (`packages/**`, `examples/**`, `scripts/**`, `apps/**`) and CI runs it twice,
+ * so it arrives as two families under two keys — the split #14880 made, working
+ * as designed. Becoming a GATE FILE is the one direction of this change that
+ * could SUBTRACT (`discoverFamilies` excludes gate files from import-following),
+ * so it is measured rather than argued: no existing family's pair count moved,
+ * in either direction, so the net subtraction is zero.
+ *
+ * ## Why `SELF_TEST_INVOCATION` is widened too, on ZERO specimens
+ *
+ * Today's one package-local specimen carries a `check-` basename, so the direct
+ * matcher takes it and the self-test matcher skips it by design — that half
+ * gains no recall at all. It is widened anyway because the two matchers'
+ * coordination contract is that they mint BYTE-IDENTICAL keys for one script,
+ * and two adjacent patterns with two different path grammars cannot hold it: a
+ * package-local gate NOT named `check-*` would then be discovered by neither,
+ * which is this card's silence wearing a different filename. Same standard as
+ * the extension right-boundary in `resolveCheckToFiles` — zero recall today,
+ * zero cost today (both numbers above are the direct matcher's alone), class
+ * closed before the first specimen arrives. ⛔ Keep the two prefixes spelled
+ * identically; the self-test asserts that both accept the same package-local
+ * path, so a drift reds rather than going quiet.
+ */
+
+/**
  * A `run:` step that invokes a repo script with `--self-test`. The flag is the
  * SCRIPT'S OWN declaration that this invocation verifies the script rather than
  * doing its work, which is what makes the step a gate.
@@ -1130,7 +1197,7 @@ export function jobPathPopulations(workflowText, workflowFile) {
  * its own, which is correct: the inner script is the gate.
  */
 const SELF_TEST_INVOCATION =
-  /node[ \t]+(scripts\/[\w./-]+\.mjs)(?:[ \t]+-{1,2}[A-Za-z0-9][\w-]*)*[ \t]+--self-test\b/g;
+  /node[ \t]+((?:[A-Za-z0-9_][\w.-]*\/)*scripts\/[\w./-]+\.mjs)(?:[ \t]+-{1,2}[A-Za-z0-9][\w-]*)*[ \t]+--self-test\b/g;
 
 /**
  * A `run:` step that invokes a `check-`named repo script directly, WITH the
@@ -1150,7 +1217,7 @@ const SELF_TEST_INVOCATION =
  * outcomes. Joining is how that hazard is removed rather than merely refused.
  */
 const DIRECT_CHECK_INVOCATION =
-  /node[ \t]+(scripts\/[\w./-]*check-[\w.-]+\.mjs)([^\n;|&<>()]*)/g;
+  /node[ \t]+((?:[A-Za-z0-9_][\w.-]*\/)*scripts\/[\w./-]*check-[\w.-]+\.mjs)([^\n;|&<>()]*)/g;
 
 /**
  * Splice a shell line-continuation back into ONE line, so a matcher reading a
@@ -11519,6 +11586,67 @@ function selfTest() {
   t('extracts direct node scripts/check-*.mjs', invs.some((i) => i.check === 'scripts/check-nul-bytes.mjs' && i.direct));
   t('ignores non-check runs', !invs.some((i) => String(i.check).includes('build')));
 
+  // ── The package-local gate lane: a path is keyed WHOLE (#15342) ───────────
+  //
+  // `lint.yml` invokes `packages/lint/scripts/check-reference-carrier-shape.mjs`
+  // by path, twice. Before the directory prefix documented beside the patterns,
+  // `node ` had to be followed IMMEDIATELY by `scripts/`, so neither matcher saw
+  // that step at all: no family, no hints, and nothing for `--residue` to place.
+  //
+  // Cases 1-3 and 6 FAIL against the base spelling — measured by applying this
+  // battery to `/node[ \t]+(scripts\/…)/` in a scratch ablation — which is what
+  // makes them an instrument rather than a restatement of the operators. Cases
+  // 4, 5, 7 and 8 hold on BOTH spellings: they are the controls that prove the
+  // widening did not buy its new answers by dropping the old ones.
+  {
+    const PKG = 'packages/lint/scripts/check-reference-carrier-shape.mjs';
+    const pkgInvs = extractCheckInvocations(
+      ['jobs:', '  lint:', '    steps:', '      - name: package-local gate', '        run: |',
+        `          node ${PKG} --self-test`, `          node ${PKG}`].join('\n'),
+      'lint.yml',
+    );
+    t(
+      'a gate CI invokes by a PACKAGE-LOCAL path is discovered at all — unfound, it is in no family, so no '
+        + 'card can be told to run it and --residue has no bucket to place it in either (#15342)',
+      pkgInvs.some((i) => i.check === `${PKG} --self-test` && i.direct),
+    );
+    t(
+      '…and its bare production invocation arrives as the SECOND family under its own key, the #14880 split',
+      pkgInvs.some((i) => i.check === PKG && i.direct),
+    );
+    t(
+      '…both keyed by the REAL path, which is what `entry.files` carries and `existsSync` then opens',
+      pkgInvs.length === 2 && pkgInvs.every((i) => i.script === PKG),
+    );
+    t(
+      'control — no PHANTOM root key is minted beside them: a `scripts/…` TAIL keyed as a path in its own '
+        + 'right names a file this ROOT does not hold, and every audit downstream then passes for the wrong reason',
+      !pkgInvs.some((i) => String(i.script ?? i.check).startsWith('scripts/')),
+    );
+    t(
+      'control — a CLIMBING spelling is refused rather than resolved: `..` is not a prefix segment, because '
+        + 'a path this ROOT cannot resolve is exactly how a phantom identity key gets minted',
+      extractCheckInvocations('    - run: node ../scripts/check-x.mjs\n', 'x.yml').length === 0,
+    );
+    t(
+      'the SELF-TEST matcher carries the same prefix grammar — a package-local gate not named `check-*` '
+        + 'would otherwise be discovered by neither matcher, which is this silence one filename over',
+      extractCheckInvocations('    - run: node packages/lint/scripts/carrier-census.mjs --self-test\n', 'x.yml')
+        .some((i) => i.check === 'packages/lint/scripts/carrier-census.mjs --self-test' && i.direct),
+    );
+    t(
+      'control — the prefix widens the DIRECTORY a gate may sit under and never the SPECIES of file: a path '
+        + 'with no `scripts/` segment is still admitted by neither matcher (`packages/cli/bin/run.js` is live)',
+      extractCheckInvocations('    - run: node packages/cli/bin/run.js check\n', 'x.yml').length === 0,
+    );
+    t(
+      'control — a root-spelled invocation is keyed BYTE-IDENTICALLY to before, so the prefix re-attributes '
+        + 'nothing: it matches empty there and the remainder of each pattern is unchanged',
+      extractCheckInvocations('    - run: node scripts/check-nul-bytes.mjs\n', 'x.yml')
+        .every((i) => i.check === 'scripts/check-nul-bytes.mjs' && i.script === 'scripts/check-nul-bytes.mjs'),
+    );
+  }
+
   // Block-scalar bodies (#8410). A step written `run: |` keeps its commands on
   // the following lines; reading only the `run:` line collected "|" and missed
   // every gate invoked this way. Both scalar styles and both invocation shapes
@@ -11989,6 +12117,20 @@ function selfTest() {
     }
     const direct = liveInvs.filter((i) => i.direct);
     const valueBearing = direct.filter((i) => (i.argvVariables ?? []).length > 0);
+    // The live half of the package-local lane (#15342). The fixtures above prove
+    // the pattern; these two read the tree CI actually runs, so the day the lane
+    // moves this reds here instead of going quiet — and the second one holds the
+    // phantom class over EVERY direct invocation, not only over the specimen.
+    t(
+      '⭐ the live corpus really carries the package-local lane the directory prefix exists for, so the '
+        + 'fixtures above judge a live class. If this reds, the lane moved — re-point it, never widen further',
+      direct.some((i) => i.script === 'packages/lint/scripts/check-reference-carrier-shape.mjs'),
+    );
+    t(
+      `every one of the ${direct.length} direct invocation(s) in the live tree resolves to a file that EXISTS `
+        + 'on disk — a key with no file behind it reads as a confident gate identity in both directions (#15342)',
+      direct.length > 0 && direct.every((i) => existsSync(nodePath.join(ROOT, i.script))),
+    );
     t(
       `the live tree really carries ${valueBearing.length} value-bearing invocation(s) across ${new Set(valueBearing.map((i) => i.script)).size} script(s), so the cases above judge a live class`,
       valueBearing.length > 0,
@@ -18749,7 +18891,20 @@ function selfTest() {
   const tail = alwaysRunSteps([{ file: 'fixture.yml', text: tailWf }]);
   const tailNames = tail.rows.map((r) => r.step);
   t('a step whose family the derivation names is NOT in the tail', !tailNames.includes('A discoverable family'));
-  t('a package-local gate invoked by path IS in the tail', tailNames.includes('A package-local gate invoked by path'));
+  // #15342 retired this member from the tail by giving the derivation the anchor
+  // to discover it, so what is pinned is the RETIREMENT WITH ITS CAUSE: the step
+  // has left the tail AND the derivation names a family for it. Either half
+  // alone goes green for the wrong reason — a tail that stopped walking, or a
+  // family list that claims the step while CI's step sits unaccounted for. The
+  // tail's own class ("a step the derivation names NOTHING for is listed") is
+  // unweakened: the interpreter member below still holds it, on this fixture and
+  // on the live tree.
+  t(
+    'a package-local gate invoked by path is NOT in the tail any more (#15342) — the derivation names it',
+    !tailNames.includes('A package-local gate invoked by path')
+      && extractCheckInvocations(tailWf, 'fixture.yml')
+        .some((i) => i.script === 'packages/lint/scripts/check-fixture-shape.mjs'),
+  );
   t('a gate run by another interpreter IS in the tail', tailNames.includes('A gate run by another interpreter'));
   t('a conditional STEP is excluded and counted', !tailNames.includes('Conditional, so no claim is made about it') && tail.counts.conditionalSteps === 1);
   t('a conditional JOB is excluded and counted', !tailNames.includes('Never claimed as always-run') && tail.counts.conditionalJobs === 1);
@@ -18806,9 +18961,21 @@ function selfTest() {
   );
   const liveCommands = liveTail.rows.flatMap((r) => r.commands);
   t('the live tail is not empty — an empty one would mean the walk broke, not that CI runs nothing', liveTail.rows.length > 0);
+  // #13333's first live instance was a package-local gate invoked by path. It is
+  // no longer here, and that is #15342 landing rather than this pin rotting —
+  // both halves are asserted for the reason the fixture case above states.
+  const liveDirectScripts = new Set(
+    readdirSync(nodePath.join(ROOT, '.github/workflows'))
+      .filter((f) => /\.ya?ml$/.test(f))
+      .flatMap((f) => extractCheckInvocations(readFileSync(nodePath.join(ROOT, '.github/workflows', f), 'utf8'), f))
+      .filter((i) => i.direct)
+      .map((i) => i.script),
+  );
   t(
-    'the live tail names the INSTANCE the card was filed about: a package-local gate invoked by path',
-    liveCommands.some((c) => /^node\s+packages\/\S+\/check-[\w.-]+\.mjs/.test(c)),
+    'the INSTANCE the card was filed about has LEFT the live tail (#15342), and the derivation now names a '
+      + 'family for it — the tail shrank because the step became accounted for, not because the walk broke',
+    !liveCommands.some((c) => /^node\s+packages\/\S+\/check-[\w.-]+\.mjs/.test(c))
+      && liveDirectScripts.has('packages/lint/scripts/check-reference-carrier-shape.mjs'),
   );
   // The class assertion. The instance above is invisible because its path is
   // not under `scripts/`; this one is invisible because its INTERPRETER is not


### PR DESCRIPTION
Fixes #15342

`lint.yml` runs one gate by a package-local path. Two tools read that corpus and both anchored on the literal `scripts/`; they failed in opposite directions, and both silently.

## Measured first — every workflow step invoking a gate by a path NOT under `scripts/`

Extracted with `check-self-test-wired.mjs`'s own `collectInvocations` (the extraction `check-self-test-workflow-commands.mjs` already imports), never a fourth parser. Over 30 workflow files and 186 named paths, the population is exactly one step:

- **`lint.yml`** — step *Relationship carriers are spelled as the string the spec declares*:
  - `node packages/lint/scripts/check-reference-carrier-shape.mjs --self-test`
  - `node packages/lint/scripts/check-reference-carrier-shape.mjs`

The only other non-root path any workflow invokes with `node` is `packages/cli/bin/run.js`, which carries no `scripts/` segment and is not a gate.

### (a) `dispatch-gates.mjs` never discovered it, and `--residue` could not report it either

Both `DIRECT_CHECK_INVOCATION` and `SELF_TEST_INVOCATION` required `node ` to be followed **immediately** by `scripts/`, so neither matched the step at all. A family that is never discovered is absent from the universe the matched / silent / undetermined buckets partition — the #11397 state, one lane over. Measured on `65846bc46`, for a card editing that gate's own file:

- `--commands` names it **0** times (26 commands derived, none of them this gate);
- all **27** `--residue` mentions are the dev's own changed path echoed back as an INPUT (`matched via packages/lint/… ⇢ gate source 'packages/**'`), never as a family;
- the step surfaces only in the always-runs **STEP tail**, as one of the 33 unconditional CI steps the derivation names no family for.

### (b) `check-self-test-wired.mjs` keyed it to a root path with no file behind it

Its `INVOCATION_RE` opened on the bare literal `scripts/` with nothing to its left, so it matched the package-local path as a **substring** and filed the gate under `scripts/check-reference-carrier-shape.mjs` — a key with no file behind it. Both directions were silent: the real file is outside the root walk so it was in no population and never audited, and the phantom key could never be reconciled against a carrier either, so neither `auditPopulation` nor `auditLedger` had anything to say. Measured before: 186 named paths, exactly **1** with no file on disk.

## The fix — minimal and additive, at both anchors

**`scripts/pm/dispatch-gates.mjs`.** Both patterns gain the same directory prefix, spelled identically. A prefix segment must start with an alphanumeric or `_`, so `..` is refused: a path this ROOT cannot resolve is how a phantom identity key gets minted, and `resolveCheckToFiles`' docblock prices that outcome as strictly worse than the bug being fixed. A `scripts/` segment is still required, so the prefix widens the DIRECTORY a gate may sit under and never the species of file.

**`scripts/check-self-test-wired.mjs`.** `INVOCATION_RE` consumes the prefix into the key and gains a left boundary, so a path is keyed WHOLE; a leading `./` is stripped (`cut-rc.yml` and `release.yml` import from `"./scripts/…"`, and keying those elsewhere would drop two live invocations). The population gains a second source — a script CI NAMES that lives outside the root walk — admitted on the root walk's own terms: the file must exist and its CODE must carry the literal. Fixing the key alone would have left that half exactly as silent as before. After: 186 named paths, **zero** without a file on disk; carriers 182 → 183, members 168 → 169, wired 164 → 165.

Its two skip predicates are membership in the root walk's **own output**, not `startsWith('scripts/')`. That re-spelling is a bare top-level word wearing a separator: it reaches the dispatch derivation's hint set as the plain literal `scripts` and joined the shrink-only escapable-literal species **FRESH** on both of this gate's families (caught by `dispatch-gates --self-test`, and confirmed by diffing the extracted hint sets base vs branch). The set form says what the predicate means and declares nothing.

## The A/B

For a card touching `packages/lint/scripts/check-reference-carrier-shape.mjs`, `--commands --repo objectstack-ai/objectstack`:

```
base    26 commands, `check-reference-carrier-shape` named 0 times (stdout and stderr)
branch  30 commands, first two lines:
          node packages/lint/scripts/check-reference-carrier-shape.mjs
          node packages/lint/scripts/check-reference-carrier-shape.mjs --self-test
        (+ node scripts/pm/bare-root-worklist.mjs --self-test and pnpm check:pm-dispatch-gates,
         which the card now incurs because its file became a GATE SCRIPT)
```

The gate **declares a population** — `ROOT_DIR_WATCH_HINTS = ['packages/**', 'examples/**', 'scripts/**', 'apps/**']` — so it does **not** land in the residue. It reaches cards by that declared population as well as by identity: a card touching `packages/spec/src/data/field.zod.ts` now derives both of its invocations too.

Priced in both directions over 7472 tracked files:

```
check families discovered        252 -> 254       (+2, ZERO lost)
gate files                       201 -> 202       (+1, ZERO lost)
watch-hint (gate, file) pairs  240947 -> 254181   (+13234, ZERO lost)
existing families re-attributed  0 — every pre-existing family's pair count is
                                 byte-identical before and after
always-runs steps naming NO family  33 -> 32 (18 -> 17 distinct commands)
```

The +13234 is exactly 2 x 6617: four subtree hints, two invocations, two keys — the #14880 split working as designed. Becoming a GATE FILE is the one direction that could SUBTRACT (`discoverFamilies` excludes gate files from import-following), so it is measured rather than argued: no existing family's pair count moved either way.

`SELF_TEST_INVOCATION` gains zero recall today — the one specimen carries a `check-` basename, so the direct matcher takes it and the self-test matcher skips it by design. It is widened anyway because the two matchers' coordination contract is that they mint byte-identical keys for one script; a package-local gate not named `check-*` would otherwise be discovered by neither. Same standard as the extension right-boundary in `resolveCheckToFiles`: zero recall today, zero cost today, class closed before the first specimen arrives.

## Self-tests

`check-self-test-wired`: two new batteries, `left boundary` (6) and `live corpus` (3) — 50 → 59 cases, battery floor 7 → 9. No existing case weakened.

`dispatch-gates`: eight fixture cases plus two live pins. Two existing always-runs-tail cases pinned the defect as a property (`a package-local gate invoked by path IS in the tail`, and its live twin). Neither is weakened: each is **inverted and given a positive control**, so the step's absence from the tail cannot go green through a tail that stopped walking. The tail's own class assertion — a step the derivation names nothing for IS listed — is untouched and still held by the other-interpreter member, on the fixture and on the live tree.

### Ablation, restore proven

The mutation put both patterns back to the pre-#15342 spelling and was confirmed on disk before any reading (widened-prefix occurrences 2 → 0; base-spelled 3, being the two patterns plus one prose mention in the new battery comment). Restore is `git checkout HEAD -- ABSOLUTE_PATH` under an `EXIT INT TERM` trap, verified by blob hash against `git rev-parse HEAD:PATH` **and** an empty `git diff HEAD`, not by an exit code.

Each case's own predicate, same inputs and same operators as the shipped assertions, against the base anchoring — 7 red, 6 controls green:

```
FAIL  1 package-local gate discovered at all
FAIL  2 bare production invocation is the second family
FAIL  3 both keyed by the REAL path
PASS  4 control: no phantom root key minted
PASS  5 control: climbing spelling refused
FAIL  6 self-test matcher carries the same prefix grammar
PASS  7 control: non-scripts path admitted by neither
PASS  8 control: root-spelled key byte-identical
FAIL  9 live corpus carries the package-local lane
PASS 10 every live direct invocation resolves to a file that EXISTS
FAIL 11 REPAIRED fixture: package-local step has left the tail, and the derivation names it
FAIL 12 REPAIRED live: instance has left the live tail, and the derivation names a family for it
PASS 13 the tail CLASS is unweakened: another-interpreter member still listed
```

The same probe against the shipped tree is 13/13, matching the shipped self-test's own verdict. Case 10 passing on both is correct and stated: on the base tree nothing package-local is discovered, so there is no phantom to catch — it is a class pin, not an instrument for this anchor.

## Verification

Exit codes captured before any pipe (`cmd > file 2>&1; EXIT=$?`), verdict lines quoted from the tools' own output. Run at `2c22f5716`.

- `node scripts/pm/dispatch-gates.mjs --self-test` (foreground, shared verify lock) — `✓ dispatch-gates self-test: 1402 cases pass.`, `os-verify-lock: VERDICT command-exit 0 · held the lock 385s`. `pnpm check:pm-dispatch-gates` is the wrapper that spawns exactly this command.
- `node scripts/check-self-test-wired.mjs` — `✓ … every one of the 169 script(s) CI runs that ship a --self-test has that self-test run by CI` (scope: 183 carriers, `1 of them package-local gate(s) CI names by path`).
- `node scripts/check-self-test-wired.mjs --self-test` — `9 declared batteries, 59 cases registered, every battery at or above its pinned floor.`
- The derived family for this change, `--changed --commands --repo objectstack-ai/objectstack` — 25 commands, every one run, all exit 0.
- Always-runs tail: `check-self-test-workflow-commands.mjs` and `--self-test`, `check:declared-population-live` (`203 of 254 famil(ies) declare a path population, and every one of them reaches this tree's 7472 tracked file(s)`), `check:ratchet-remedy-authority`, `check:nul-bytes`, `check:watch-hint-literal` — all exit 0.
- Whole-repo `pnpm lint` (`eslint . --no-inline-config`) — exit 0.

Out-of-scope finding filed while measuring: #15414 — check-self-test-workflow-commands builds its own root-only population, so the same package-local gate is in no sweep there either. Not touched here.

No changeset: this publishes nothing from any released package (`scripts/` tooling only), so the `skip-changeset` label carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk


---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_