### PR TITLE
test(scripts): release-rehearsal-clone's C2 green line is stable — the measured timing prints only on failure (#15400)

### DIFF
--- a/scripts/pm/release-rehearsal-clone.mjs
+++ b/scripts/pm/release-rehearsal-clone.mjs
@@ -667,7 +667,11 @@ function selfTest() {
     const healthyMs = Date.now() - startedAt;
     t('C2 full clone → exit 0 (fit)', healthyRun.status === 0, `exit=${healthyRun.status}\n${healthyRun.stdout}${healthyRun.stderr}`);
     t('C2 fit verdict is stated, not implied', /✓ FIT/.test(healthyRun.stdout), healthyRun.stdout);
-    t(`C2 a healthy tree is not slowed (${healthyMs} ms < 10000)`, healthyMs < 10_000);
+    // The measured figure prints in the FAILURE sink, never in the label: a green
+    // line carrying a wall-clock reading differs from run to run, so the
+    // `green lines are byte-identical` comparison this script is rehearsed with
+    // could never pass unnormalised. A red run still names the timing.
+    t('C2 a healthy tree is not slowed (< 10000 ms)', healthyMs < 10_000, `measured ${healthyMs} ms`);
 
     // ── C3: a SHALLOW clone whose changesets sit after the boundary is fit.
     // This is the no-crying-wolf half: `--is-shallow-repository` is true here.


### PR DESCRIPTION
Fixes #15400

## What changed

One line in `scripts/pm/release-rehearsal-clone.mjs`. The C2 case interpolated the
measured wall-clock figure into its own label, so the `✓` line carried a value that
differs from run to run:

```
  ✓ C2 a healthy tree is not slowed (107 ms < 10000)
```

The figure now goes through the failure sink `t()` / `report()` already carry — the
third argument, printed only when the condition is false — and the label states the
threshold only:

```
  ✓ C2 a healthy tree is not slowed (< 10000 ms)
```

Per the ruling on #15400 (option 1). The assertion condition (`healthyMs < 10_000`)
and the threshold are unchanged, C2 still registers exactly once through `t`, and the
roster (`'release-rehearsal-clone self-test': 30`), `SELF_TEST_BATTERY_FLOOR` and the
`tConditional` split from #15399 are untouched. No other case, condition, message or
argument changes.

## The proof the card asks for: two runs, twelve minutes apart

`node scripts/pm/release-rehearsal-clone.mjs --self-test` run twice, 15:18:31Z and
15:30:31Z, stdout and stderr captured separately and `cmp`d.

**This branch** — byte-identical:

```
--- BRANCH: stdout cmp ---
CMP_BR_OUT_EXIT=0
--- BRANCH: stderr cmp ---
CMP_BR_ERR_EXIT=0
--- combined stdout+stderr cmp (branch) ---
CMP_BR_ALL_EXIT=0
```

**Control, the same pair on the base pin `52d5a52d5`** (a second detached worktree at
the same commit) — differs, on exactly the C2 line and nothing else:

```
--- CONTROL: base stdout cmp ---
base-run1.out base-run2.out differ: char 501, line 10
CMP_BASE_OUT_EXIT=1
--- CONTROL differing lines ---
10c10   (line 10, run 1 vs run 2)
  run 1:   ✓ C2 a healthy tree is not slowed (107 ms < 10000)
  run 2:   ✓ C2 a healthy tree is not slowed (94 ms < 10000)
```

## A red run still names the timing

Forced-slow ablation — the condition's threshold mutated to `healthyMs < -1`, proven on
disk before the run (injected spelling present 1×, removed spelling 0×, blob hash moved
`ef88cbc… -> ce605ec…`), restored under an `EXIT INT TERM` trap and the restore proven
by hash equality plus an empty `git diff HEAD`:

```
MUTATION-ON-DISK: injected='healthyMs < -1' count=1 ; removed='healthyMs < 10_000' count=0
ABL_A_EXIT=1
10:  ✗ C2 a healthy tree is not slowed (< 10000 ms)
11-      measured 112 ms
RESTORE-PROVEN: hash==ef88cbcec9433e2833ca4cf57798be81a6e1dc2c, git diff HEAD empty, status clean
```

## The floor is untouched

Roster pin ablated `30 -> 9999`, same mutation/restore discipline — C2 still registers,
and the count the floor sees is still exactly 30:

```
✗ self-test battery "release-rehearsal-clone self-test" registered 30 case(s), below its pinned floor of 9999
RESTORE-PROVEN: hash==ef88cbcec9433e2833ca4cf57798be81a6e1dc2c, git diff HEAD empty, status clean
```

`node scripts/measure-self-test-floor.mjs --json` before and after the edit is
byte-identical (170 rows, `ROSTER` 164 / `NONE` 5 / `COUNT` 1); this file stays
`{"file":"scripts/pm/release-rehearsal-clone.mjs","floor":"ROSTER","defs":["selfTest"]}`.

## Gates

All at `023dcd71d`, the final commit; exit codes captured before any pipe.

- The derived family, `node scripts/pm/dispatch-gates.mjs --commands --repo objectstack-ai/objectstack`
  — 23 commands, every one run, all `EXIT=0`. The heavy leg (13 `pnpm check:*`, including
  `check:pm-dispatch-gates` at 403s) ran in the foreground under
  `scripts/pm/os-verify-lock.sh`: `VERDICT command-exit 0`.
- The always-runs tail: `check-self-test-workflow-commands.mjs` and its `--self-test`,
  `check:declared-population-live`, `check-self-test-wired.mjs`, `check:ratchet-remedy-authority`,
  `check:nul-bytes`, `check:watch-hint-literal` — all `EXIT=0`.
- This file's own `--self-test`, the `lint.yml` step: `EXIT=0`, `✓ self-test passed`.
- Whole-repo `pnpm lint` (`eslint . --no-inline-config`) under the verify lock:
  `LINT_EXIT=0`, no findings. Not a narrowed run.
- Control-character self-scan over the changed file: no matches.

No changeset: this changes a repo-internal PM script and publishes nothing from any
package, so `skip-changeset` applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk

---
_Generated by [Claude Code](https://claude.ai/code/session_012zGPuVVX3deAx9LdjK8jCk)_