### PR TITLE
fix(spec): position-safe undefined-comparand prescription; re-point driver-memory's null-comparand prose at the 2026-09-01 ruling (#14426)

### DIFF
--- a/.changeset/undefined-comparand-prescription-position-safe.md
+++ b/.changeset/undefined-comparand-prescription-position-safe.md
@@ -1,0 +1,18 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): the `undefined` comparand refusal prescribes the null predicate by its ruled spellings (#14426)
+
+`parseFilterAST`'s comparand-type door refuses an `undefined` comparand at every
+position. Its prescription read "Write null for the null predicate, or omit the
+key" — position-agnostic advice that, followed at `{ $gt: undefined }`, produced
+`{ $gt: null }`, which the 2026-09-01 ruling refuses one door over (and, at an
+`$in` / `$nin` / `$between` member, produced the list shapes refused on
+2026-08-31). Two loud refusals to reach one right answer.
+
+The sentence now names the null predicate by its complete spellings —
+`{"$eq": null}` / `{"$ne": null}` — or omit the key, so following it never lands
+in a refusal at any position the sentence is emitted at. No accept/refuse
+behaviour changes: same envelope (`INVALID_FILTER` / 400), same path, same
+accepted-set and NOT-applied sentences.

--- a/packages/drivers/driver-memory/src/memory-matcher-null-value-and-comparand.test.ts
+++ b/packages/drivers/driver-memory/src/memory-matcher-null-value-and-comparand.test.ts
@@ -60,14 +60,18 @@
  * asserted here, now for the ruling's own reason — ⛔「不单独修一个到不了的
  * 路径」 — and they were measured byte-identical across this repair too.
  *
- * ⚠️ A null COMPARAND in an ORDERING position (`{$gte: null}`) is absent for
- * the ORIGINAL reason, and it is the one such position the contract still
- * ACCEPTS: the 2026-08-31 ruling refused the three siblings and #5332's
- * landing had already recorded this one in writing as a position "no ruling
- * covers". #13553's guard is scoped to leave those cells exactly where it
- * found them, so pinning them here — in either direction — would prejudge a
- * ruling nobody has made. The invariance is proven in the PR, not asserted
- * here.
+ * ⚠️ A null COMPARAND in an ORDERING position (`{$gte: null}`) is likewise
+ * ABSENT from this file. When #13553 landed it was the one such position the
+ * contract still ACCEPTED (the 2026-08-31 ruling had refused the three
+ * siblings, and #5332's landing had recorded this one in writing as "no
+ * ruling covers"), so #13553's guard was scoped to leave those cells exactly
+ * where it found them rather than prejudge a ruling. The maintainer ruled it
+ * on 2026-09-01 (option A, #14080): the shape is now REFUSED at the
+ * contract's validation entrance, the same door as the list positions, with
+ * the negative pin in `memory-null-ordering-comparand-unreachable.test.ts`.
+ * Its cells stay unasserted here, now for the ruling's own reason — ⛔「不单独修
+ * matcher(死代码)」— and no ordering-vs-null semantics is defined anywhere,
+ * so nothing here says what either face would have answered.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';

--- a/packages/drivers/driver-memory/src/memory-matcher.ts
+++ b/packages/drivers/driver-memory/src/memory-matcher.ts
@@ -337,16 +337,26 @@ function checkCondition(value: any, condition: any): boolean {
         // same reason — a rule spelled over "the value is null" alone would
         // reach arms whose no-value answer is ruled elsewhere.
         //
-        // ⛔ A no-value COMPARAND is excluded from this guard, deliberately, so
-        // those cells keep TODAY's answer rather than being decided here.
-        // `$gt: null` is the one null-comparand position the contract still
-        // ACCEPTS (measured at `parseFilterAST`): the 2026-08-31 ruling refused
-        // the three siblings — `$in` / `$nin` null members and `$between`'s
-        // null endpoints (#13357) — and #5332's landing had already recorded
-        // this position in writing as one "no ruling covers". Deciding it in an
-        // operator arm would pick a camp the platform declined to pick, and its
-        // sibling was settled by REFUSING the shape rather than by answering
-        // it.
+        // ⛔ A no-value COMPARAND is excluded from this guard, deliberately.
+        // When #13553 landed, `$gt: null` was the one null-comparand position
+        // the contract still ACCEPTED (measured at `parseFilterAST`): the
+        // 2026-08-31 ruling had refused the three siblings — `$in` / `$nin`
+        // null members and `$between`'s null endpoints (#13357) — and #5332's
+        // landing had recorded this one in writing as "no ruling covers", so
+        // deciding it here would have picked a camp the platform declined to
+        // pick. That reason is gone: ruled 2026-09-01 (option A, #14080), the
+        // shape is REFUSED at the contract's validation entrance
+        // (`assertListComparandShapes`, inside `parseFilterAST` and at the
+        // engine seam), the same door and envelope as its siblings. These
+        // cells are now constructively unreachable through the compile face,
+        // and the exclusion stays for the ruling's own reason — ⛔「不单独修
+        // matcher(死代码)」— with no ordering-vs-null semantics defined
+        // anywhere. Negative pin:
+        // `memory-null-ordering-comparand-unreachable.test.ts`. A direct
+        // caller that skips the compile face meets only this package's own
+        // `assertFilterConditionShape`, which deliberately does not carry the
+        // rule (⛔ 不做跨后端对齐工程) — the honest boundary, not a cell for an
+        // arm to decide.
         if (value === null && ORDERING_OPERATORS.has(op)
             && target !== null && target !== undefined) {
             return false;

--- a/packages/spec/src/data/filter-comparand-type.test.ts
+++ b/packages/spec/src/data/filter-comparand-type.test.ts
@@ -131,6 +131,34 @@ describe('refusals — the measured divergence rows die at the door', () => {
     expect(err?.message).toMatch(/omit/);
   });
 
+  it('the undefined prescription is position-safe: it names the null predicate by its ruled spellings, at every position it is emitted at (#14426)', () => {
+    // "Write null for the null predicate" was position-agnostic advice: followed
+    // at `$gt: undefined` it produced `$gt: null`, refused one door over since
+    // the 2026-09-01 ruling; at an `$in` member it produced `$in: [null]`,
+    // refused since 2026-08-31. The sentence names COMPLETE spellings instead —
+    // the pair the ruling names — so following it never lands in a refusal.
+    const positions: Array<[Record<string, unknown>, string]> = [
+      [{ owner: undefined }, 'where.owner'],
+      [{ owner: { $eq: undefined } }, 'where.owner.$eq'],
+      [{ owner: { $gt: undefined } }, 'where.owner.$gt'],
+      [{ owner: { $lte: undefined } }, 'where.owner.$lte'],
+      [{ owner: { $in: [undefined] } }, 'where.owner.$in[0]'],
+    ];
+    for (const [where, path] of positions) {
+      const err = refusalOf(() => normalizeFilterComparandTypes(where));
+      expect(err?.code, path).toBe('INVALID_FILTER');
+      expect(err?.status, path).toBe(400);
+      expect(err?.message, path).toContain(path);
+      expect(err?.message, path).toContain('{"$eq": null}');
+      expect(err?.message, path).toContain('{"$ne": null}');
+      expect(err?.message, path).toMatch(/omit the key/);
+      // The defect's own spelling: an instruction to write a bare null INTO the
+      // position the sentence was emitted at.
+      expect(err?.message, path).not.toMatch(/Write null\b/);
+      expect(err?.message.length, path).toBeLessThan(500); // the client bound (#5423)
+    }
+  });
+
   it('refuses a PLAIN OBJECT where a scalar operator comparand belongs — the SQL family already did', () => {
     const err = refusalOf(() => normalizeFilterComparandTypes({ qty: { $eq: { a: 1 } } }));
     expect(err?.code).toBe('INVALID_FILTER');

--- a/packages/spec/src/data/filter-comparand-type.ts
+++ b/packages/spec/src/data/filter-comparand-type.ts
@@ -255,15 +255,24 @@ function invalidComparandError(context: string | undefined, message: string): Er
 const NOT_APPLIED =
   'The filter was NOT applied, and an unapplied filter would have returned the UNFILTERED result set.';
 
-/** `undefined` gets its own sentence — it is the one refused value that arrives by ACCIDENT. */
+/**
+ * `undefined` gets its own sentence — it is the one refused value that arrives
+ * by ACCIDENT. Its prescription names the null predicate by COMPLETE spellings
+ * (`{"$eq": null}` / `{"$ne": null}`, the pair the 2026-09-01 ruling names),
+ * never as "write null": this sentence is emitted at every comparand position,
+ * and at `$gt` / `$gte` / `$lt` / `$lte` — or an `$in` / `$nin` / `$between`
+ * member — "write null" produced exactly the null shapes refused one door over
+ * (2026-08-31, 2026-09-01). Position-safe means following it never lands in a
+ * refusal, whatever position it was emitted at (#14426).
+ */
 function undefinedComparandRefusal(context: string | undefined, path: string): Error {
   return invalidComparandError(
     context,
     `Filter comparand at ${path} is undefined. { key: undefined } cannot be told apart from an ` +
       `omitted key, yet the two mean OPPOSITE things (a predicate vs no constraint) — one ` +
-      `backend even encoded it as MATCH EVERYTHING. Write null for the null predicate, or omit ` +
-      `the key. A comparison value must be ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE}. ` +
-      NOT_APPLIED,
+      `backend even encoded it as MATCH EVERYTHING. Write the null predicate — {"$eq": null} / ` +
+      `{"$ne": null} — or omit the key. A comparison value must be ` +
+      `${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE}. ${NOT_APPLIED}`,
   );
 }
 


### PR DESCRIPTION
Fixes #14426

## What this is

A prose and message correction with **no behaviour change**. PR #14425 executed the 2026-09-01 ruling on #14080 (option A): a `null` comparand of `$gt` / `$gte` / `$lt` / `$lte` is refused at `parseFilterAST` (`INVALID_FILTER` / 400). Three sites still described the pre-ruling state, or prescribed advice that now leads into that refusal. Each is re-pointed at the ruling; nothing that accepts or refuses moves.

**Clause-②: no — on content.** The diff re-points two comments and rewords one prescription sentence; the accept/refuse set and the public surface are unchanged. The **path limb fires anyway** (`packages/spec/src/**`), which is why this PR is draft, carries `needs:contract-review`, and is not flipped ready, enqueued, or armed by this seat.

## The three sites (re-located by text on `origin/main`, not by the card's line numbers)

1. `packages/drivers/driver-memory/src/memory-matcher.ts` — the #13553 guard's **comment** (the block above `if (value === null && ORDERING_OPERATORS.has(op) …`). The reason a no-value COMPARAND is excluded from the guard moves from "no ruling covers it — `$gt: null` is the one null-comparand position the contract still ACCEPTS" to "refused at the door, ruled 2026-09-01; constructively unreachable through the compile face; ⛔「不单独修 matcher(死代码)」". The exclusion itself stays, and **no operator arm is touched** (the `$notContains` arm belongs to #14079, which is not touched here).
2. `packages/drivers/driver-memory/src/memory-matcher-null-value-and-comparand.test.ts` — the **header** paragraph on the ordering position. The absence stays deliberate; its reason moves to "refused, ruled 2026-09-01 (option A)", the same wording the header already uses for the list positions, naming the negative pin `memory-null-ordering-comparand-unreachable.test.ts`. No test body changes.
3. `packages/spec/src/data/filter-comparand-type.ts` — `undefinedComparandRefusal`. Its prescription read *"Write null for the null predicate, or omit the key"*. That sentence is emitted at every comparand position, and "write null" is position-agnostic: followed at `{ $gt: undefined }` it produced `{ $gt: null }`, refused one door over since 2026-09-01; followed at an `$in` member it produced `$in: [null]`, refused since 2026-08-31. The card counted four wrong positions; the list-member positions make it seven. It now reads *"Write the null predicate — {"$eq": null} / {"$ne": null} — or omit the key."* Same envelope, same path, same accepted-set and NOT-applied sentences.

## H1 — the replacement spelling was measured before it was prescribed

The card suggested prescribing `$eq: null` / `$null: true`. Measured at `parseFilterAST` on the built `dist` (`node`, `@objectstack/spec/data`), before writing:

| input | verdict |
|---|---|
| `{f: null}` · `{f: {$eq: null}}` · `{f: {$ne: null}}` | ACCEPT |
| `{f: {$null: true}}` · `{f: {$null: false}}` · `{f: {$exists: true}}` · `{f: {$exists: false}}` | ACCEPT |
| `['f', 'is_null']` → `{f: {$null: true}}` · `['f', 'is_not_null']` → `{f: {$null: false}}` | ACCEPT |
| `{f: {$gt: null}}` · `$gte` · `$lt` · `$lte` | REFUSE `INVALID_FILTER` / 400 |
| `{f: {$in: [null]}}` · `{f: {$between: [null, 1]}}` | REFUSE `INVALID_FILTER` / 400 |
| `{f: undefined}` · `{f: {$eq: undefined}}` · `{f: {$gt: undefined}}` · `{f: {$in: [undefined]}}` | REFUSE `INVALID_FILTER` / 400 — the TYPE door's sentence, at every position |

So `$null: true` **is** a real spelling. The sentence nevertheless names only the ruled pair, `{"$eq": null}` / `{"$ne": null}`, for two measured reasons: (a) that pair is what the sibling ordering refusal (`nullOrderingComparandError`, `filter-comparand-shape.ts`) prescribes, byte-for-byte the same spelling, so the two doors give one answer; (b) the message sits near the 500-char client bound (#5423) — bare it was 444 chars; every wording that also names `$null: true` measured 497–505 bare, i.e. over or within 3 chars of the bound once a caller prepends a context. The chosen wording is 469 bare.

## Pins

`filter-comparand-type.test.ts` did **not** quote the old sentence (H3): its existing pin matches only the regexes `undefined`, `null`, `omit`, so it stays green as-is and is untouched. One pin is added beside it: at five positions (`where.owner`, `.$eq`, `.$gt`, `.$lte`, `.$in[0]`) the refusal carries `INVALID_FILTER` / 400, the path, both ruled spellings, `omit the key`, no bare `Write null` instruction, and stays under 500 chars. Reverse-verified against the BASE sentence: mutation proved on disk (old-sentence count 1 / new 0), the pin went RED on `where.owner` (`expected … to contain '{"$eq": null}'`, 1 failed / 41 passed), restore proved by `git diff HEAD` empty and `git hash-object` equal to the HEAD blob `f449a250…`.

## Not touched, on purpose

- `packages/spec/src/data/filter.zod.ts` — reserved for #15059.
- Every operator arm in `memory-matcher.ts`; `assertFilterConditionShape` in driver-memory.
- The boundary pins outside the door — `service-analytics`'s normalizer and `formula`'s `matchesFilter` — PR #14425's body records them as the honest boundary the refusal does not widen. Their own `undefined` prescriptions (`driver-sql`, `driver-turso`, `service-analytics`) were read and are already position-safe: each names complete shapes (`{ "FIELD": null }` or `{ "FIELD": { "$null": true } }`), never "write null" into the position. No finding there.

## Changeset

`@objectstack/spec: patch` — a published refusal message changes wording; nothing else publishes (driver-memory's diff is comments only).

## Verification (final head cited per run)

Final head `0eb8ddab8` = `54041b534` (the change) + a merge of `origin/main` `6ed4b811a` (one PM script, no overlap). Every exit code captured after redirect; verdict lines quoted from the gates themselves.

- Builds under `scripts/pm/os-verify-lock.sh`: `pnpm --filter '@objectstack/driver-memory^...' build`, then `pnpm --filter @objectstack/spec build` twice (the second after the reverse leg re-wrote `src` mtimes): each `VERDICT command-exit 0`; `check-dts-emitted: 34/34`; build input hash `04324463ad9d8c2c…` both times (same sources).
- `pnpm --filter @objectstack/spec exec vitest run --maxWorkers=2 src/data/filter-comparand-type.test.ts src/data/filter-comparand-shape.test.ts` on `0eb8ddab8`: `Test Files 2 passed (2) · Tests 88 passed (88)`, exit 0.
- `pnpm --filter @objectstack/driver-memory exec vitest run --maxWorkers=2` (whole package; its unreachability pins read the rebuilt spec `dist`) on `0eb8ddab8`: `Test Files 40 passed (40) · Tests 1036 passed (1036)`, exit 0.
- Typecheck: spec `tsc --noEmit` exit 0 (1068 files — ⚠ that program contains no `*.test.ts`, so it measures nothing about the new pin); `check:scripts-typecheck` exit 0; `check:test-typecheck` exit 0 (`54 file(s) / 261 error(s) / 145 pinned signature(s) held`), and `tsc -p tsconfig.test.json --listFiles` lists `filter-comparand-type.test.ts` with 0 errors naming either edited spec file — that program is the one that measures the pin. driver-memory `tsc --noEmit` exit 0 with both edited files listed.
- `pnpm --filter @objectstack/spec check:generated` on `0eb8ddab8` after the rebuild: `✓ All 15 generated artifacts are up to date.` exit 0. A first run on the merged head reported `check:api-surface` stale in the gate's own words — `dist/**/*.d.ts is OLDER than src` — an mtime effect of the reverse leg's two checkouts (content identical by hash); rebuilt and re-run rather than touched.
- Gate family derived on this tree: `node scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectstack` at `0eb8ddab8` (no STALE TREE warning; list identical to the pre-merge derivation at `54041b534`, and to a derivation on the stale container checkout it replaced). 52 of the 53 commands under "Local gates for this card" exit 0 — among them `check:api-surface`, `check:authorable-surface`, `check:docs`, `check:liveness`, `check:exported-any`, `check:dual-source-exports`, `check:where-matcher`, `check:driver-conformance`, `check:cross-package-test-inputs`, `check:test-source-alias`, `check:type-source-resolution`, `check:keyed-text-bounds`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, the ADR-0087 / empty-changeset / no-major self-tests, and `check:doc-formula-expressions` once its prerequisites `@objectstack/formula` and `@objectstack/lint` were built (`9 @example(s) judged clean across 1159 packages/spec/src files`; `14 predicate(s) … judged clean`). The 53rd, `check:dual-build-cjs-loads`, is NOT MEASURED here by its own text (`Run pnpm build first. ⛔ This is NOT a pass: nothing was measured` — it needs every workspace package's `dist`, a whole-farm run CI owns). `check:nul-bytes` exit 0. A further 70 commands from the derivation's other sections were run opportunistically; every non-zero one is NOT MEASURED by its own text — CI-only wiring (`$RUNNER_TEMP`, `${{ matrix.shard }}`, `PR_NUMBER`), a whole-workspace `dist` prerequisite (`check:published-readme-exports`), `check:react-declaration-parity` (needs objectui's manifest, by design), `check-half-states.mjs --format=markdown` (network-bound, hit this run's 300s cap; its `pnpm check:pm-half-states` form exit 0), and 17 workflow step NAMES from the derivation's Residue section that are not commands. None is a red.
- `scripts/check-partof-closing-keyword.mjs` run with `PR_BODY` set to this body: `✓ this PR carries no Part-of/closing-keyword contradiction`, exit 0.
- Narrowed lint (CI owns `pnpm lint`): each of the four edited files returns a non-empty `--print-config` (in the population, not ignored); `eslint --no-inline-config --format json` over them: 4 files, 0 errors, 0 warnings, exit 0; invariance: `eslint.config.mjs` states it never enables type-aware linting for any file, so this diff cannot move an untouched file's verdict.
- Control characters: `grep -naP` over the four files and the changeset — no hits.
- Reverse verification of the new pin: see Pins above (RED on the BASE sentence, restore hash-proved).
- Churn, `scripts/pm/git-history.mjs count --days=14 --ref=origin/main` (answered, not refused): `filter-comparand-type.ts` 1 · `memory-matcher.ts` 3 · the test header file 2 · `filter-comparand-type.test.ts` 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4138K1EG7kQ81FNba5Kp4)_