### PR TITLE
docs(spec): colorField names a field to derive a colour FROM — timeline, calendar and gantt

### DIFF
--- a/.changeset/colorfield-derive-describe.md
+++ b/.changeset/colorfield-derive-describe.md
@@ -1,0 +1,15 @@
+---
+"@objectstack/spec": patch
+---
+
+`colorField` now documents what it means: a field to DERIVE a colour from, not a field holding one.
+
+`TimelineConfigSchema`, `CalendarConfigSchema` and `GanttConfigSchema` each declare a `colorField`, and all three `.describe()` strings said only that the field "determines"/"drives" the colour — `'Field to determine item color'`, `'Field whose value determines the event color'`, `'Field that drives the bar color'`. Read literally, that invites pointing the key at a field whose stored value *is* a colour, which is the one case the renderers need the least: the common author intent is `colorField: 'status'`, a select field whose options already carry the colours.
+
+The renderers resolve it as a derivation ladder (objectui#7243, shared as `createFieldColorResolver` in `@object-ui/core`):
+
+1. the option `color` the field declares for the record's stored value;
+2. else the value itself, when it already is a colour literal (hex 3/6/8-digit, `rgb(...)`, `hsl(...)`);
+3. else each renderer's own last rung — the gantt derives a semantic colour token, the calendar hashes onto its theme-aware palette, the timeline draws its default marker.
+
+The three strings now say that, each naming its own last rung. **Nothing in the accept set moves**: all three keys stay `z.string().optional()`, and a config pointing `colorField` at a plain hex field is still exactly as valid as before — that is rung 2. This is prose on a declared key, so the only regenerated follower is `content/docs/references/ui/view.mdx`.

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -106,7 +106,7 @@ Appearance and visualization configuration
 | **startDateField** | `string` | ✅ | Field providing the event start date/time |
 | **endDateField** | `string` | optional | Field providing the event end date/time (defaults to a single-day event) |
 | **titleField** | `string` | optional | Field displayed as the event title. Omit to fall back to the record display name (ADR-0079 resolver chain) |
-| **colorField** | `string` | optional | Field whose value determines the event color |
+| **colorField** | `string` | optional | Field to derive each event color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the calendar theme-aware palette color hashed from the value |
 
 
 ---
@@ -559,7 +559,7 @@ Gallery/card view configuration
 | **titleField** | `string` | ✅ | Field displayed as the task title |
 | **progressField** | `string` | optional | Field providing the task completion percentage |
 | **dependenciesField** | `string` | optional | Field listing the task's predecessor (dependency) record ids |
-| **colorField** | `string` | optional | Field that drives the bar color |
+| **colorField** | `string` | optional | Field to derive each bar color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else a semantic color token derived from the value |
 | **parentField** | `string` | optional | Field holding the parent task id (builds the summary → step tree) |
 | **typeField** | `string` | optional | Field whose value maps to task/summary/milestone |
 | **baselineStartField** | `string` | optional | Baseline (planned) start field |
@@ -915,7 +915,7 @@ View filter rule
 | **startDateField** | `string` | ✅ | Field providing the event start date/time |
 | **endDateField** | `string` | optional | Field providing the event end date/time (defaults to a single-day event) |
 | **titleField** | `string` | optional | Field displayed as the event title. Omit to fall back to the record display name (ADR-0079 resolver chain) |
-| **colorField** | `string` | optional | Field whose value determines the event color |
+| **colorField** | `string` | optional | Field to derive each event color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the calendar theme-aware palette color hashed from the value |
 
 ### Nested Shape: `ListView.gantt`
 
@@ -926,7 +926,7 @@ View filter rule
 | **titleField** | `string` | ✅ | Field displayed as the task title |
 | **progressField** | `string` | optional | Field providing the task completion percentage |
 | **dependenciesField** | `string` | optional | Field listing the task's predecessor (dependency) record ids |
-| **colorField** | `string` | optional | Field that drives the bar color |
+| **colorField** | `string` | optional | Field to derive each bar color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else a semantic color token derived from the value |
 | **parentField** | `string` | optional | Field holding the parent task id (builds the summary → step tree) |
 | **typeField** | `string` | optional | Field whose value maps to task/summary/milestone |
 | **baselineStartField** | `string` | optional | Baseline (planned) start field |
@@ -959,7 +959,7 @@ View filter rule
 | **endDateField** | `string` | optional | Field for timeline item end date |
 | **titleField** | `string` | ✅ | Field to display as timeline item title |
 | **groupByField** | `string` | optional | Field to group timeline rows |
-| **colorField** | `string` | optional | Field to determine item color |
+| **colorField** | `string` | optional | Field to derive each item color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the timeline default marker color |
 | **scale** | `Enum<'hour' \| 'day' \| 'week' \| 'month' \| 'quarter' \| 'year'>` | optional (default: `"week"`) | Default timeline scale |
 
 ### Nested Shape: `ListView.chart`
@@ -1301,7 +1301,7 @@ View filter rule
 | **startDateField** | `string` | ✅ | Field providing the event start date/time |
 | **endDateField** | `string` | optional | Field providing the event end date/time (defaults to a single-day event) |
 | **titleField** | `string` | optional | Field displayed as the event title. Omit to fall back to the record display name (ADR-0079 resolver chain) |
-| **colorField** | `string` | optional | Field whose value determines the event color |
+| **colorField** | `string` | optional | Field to derive each event color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the calendar theme-aware palette color hashed from the value |
 
 ### Nested Shape: `ObjectListView.gantt`
 
@@ -1312,7 +1312,7 @@ View filter rule
 | **titleField** | `string` | ✅ | Field displayed as the task title |
 | **progressField** | `string` | optional | Field providing the task completion percentage |
 | **dependenciesField** | `string` | optional | Field listing the task's predecessor (dependency) record ids |
-| **colorField** | `string` | optional | Field that drives the bar color |
+| **colorField** | `string` | optional | Field to derive each bar color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else a semantic color token derived from the value |
 | **parentField** | `string` | optional | Field holding the parent task id (builds the summary → step tree) |
 | **typeField** | `string` | optional | Field whose value maps to task/summary/milestone |
 | **baselineStartField** | `string` | optional | Baseline (planned) start field |
@@ -1345,7 +1345,7 @@ View filter rule
 | **endDateField** | `string` | optional | Field for timeline item end date |
 | **titleField** | `string` | ✅ | Field to display as timeline item title |
 | **groupByField** | `string` | optional | Field to group timeline rows |
-| **colorField** | `string` | optional | Field to determine item color |
+| **colorField** | `string` | optional | Field to derive each item color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the timeline default marker color |
 | **scale** | `Enum<'hour' \| 'day' \| 'week' \| 'month' \| 'quarter' \| 'year'>` | optional (default: `"week"`) | Default timeline scale |
 
 ### Nested Shape: `ObjectListView.chart`
@@ -1597,7 +1597,7 @@ Timeline view configuration
 | **endDateField** | `string` | optional | Field for timeline item end date |
 | **titleField** | `string` | ✅ | Field to display as timeline item title |
 | **groupByField** | `string` | optional | Field to group timeline rows |
-| **colorField** | `string` | optional | Field to determine item color |
+| **colorField** | `string` | optional | Field to derive each item color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the timeline default marker color |
 | **scale** | `Enum<'hour' \| 'day' \| 'week' \| 'month' \| 'quarter' \| 'year'>` | optional (default: `"week"`) | Default timeline scale |
 
 

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -965,7 +965,7 @@ export const TimelineConfigSchema = lazySchema(() => strictObject({
   endDateField: z.string().optional().describe('Field for timeline item end date'),
   titleField: z.string().describe('Field to display as timeline item title'),
   groupByField: z.string().optional().describe('Field to group timeline rows'),
-  colorField: z.string().optional().describe('Field to determine item color'),
+  colorField: z.string().optional().describe('Field to derive each item color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the timeline default marker color'),
   scale: z.enum(['hour', 'day', 'week', 'month', 'quarter', 'year']).default('week').describe('Default timeline scale'),
 }).describe('Timeline view configuration'));
 
@@ -1300,7 +1300,7 @@ export const CalendarConfigSchema = lazySchema(() => strictObject({
   startDateField: z.string().describe('Field providing the event start date/time'),
   endDateField: z.string().optional().describe('Field providing the event end date/time (defaults to a single-day event)'),
   titleField: z.string().optional().describe('Field displayed as the event title. Omit to fall back to the record display name (ADR-0079 resolver chain)'),
-  colorField: z.string().optional().describe('Field whose value determines the event color'),
+  colorField: z.string().optional().describe('Field to derive each event color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else the calendar theme-aware palette color hashed from the value'),
 }));
 
 /**
@@ -1344,7 +1344,7 @@ export const GanttConfigSchema = lazySchema(() => strictObject({
   titleField: z.string().describe('Field displayed as the task title'),
   progressField: z.string().optional().describe('Field providing the task completion percentage'),
   dependenciesField: z.string().optional().describe("Field listing the task's predecessor (dependency) record ids"),
-  colorField: z.string().optional().describe('Field that drives the bar color'),
+  colorField: z.string().optional().describe('Field to derive each bar color from (it names a field, not a color): the option color declared on that field for the record value, else the value itself when it already is a color literal (hex, rgb() or hsl()), else a semantic color token derived from the value'),
   // Two-level hierarchy: a parent task id (summary bar) and a row type.
   parentField: z.string().optional().describe('Field holding the parent task id (builds the summary → step tree)'),
   typeField: z.string().optional().describe('Field whose value maps to task/summary/milestone'),


### PR DESCRIPTION
Fixes #14471

`colorField` is one authored key declared on three view config schemas, and all three `.describe()` strings said only that the named field "determines" or "drives" the colour. Read literally that invites pointing the key at a field whose stored value *is* a colour — the case the renderers need least. The common author intent is `colorField: 'status'`, a select field whose options already carry the colours, and that is the case the old prose described worst.

## What changed

Three `.describe()` strings in `packages/spec/src/ui/view.zod.ts`, each now naming the derivation and its own last rung:

| schema | before | after |
|:--|:--|:--|
| `TimelineConfigSchema` | `Field to determine item color` | derive-from + option colour / colour literal / **timeline default marker colour** |
| `CalendarConfigSchema` | `Field whose value determines the event color` | derive-from + option colour / colour literal / **theme-aware palette colour hashed from the value** |
| `GanttConfigSchema` | `Field that drives the bar color` | derive-from + option colour / colour literal / **semantic colour token derived from the value** |

Plus the one regenerated follower, `content/docs/references/ui/view.mdx` (9 table rows), and a `patch` changeset.

## Three keys, not two — the card's own condition resolved that way

The card scoped itself to gantt and calendar and fenced the timeline **conditionally**: excluded *"if its describe text already says the derivation — verify on `origin/main` before editing"*. Verified on `origin/main` `ee32e1cb8`, by symbol rather than by line number:

- `TimelineConfigSchema` (declared `:960`), `colorField` at `:968` — `'Field to determine item color'`
- `CalendarConfigSchema` (declared `:1296`), `colorField` at `:1303` — `'Field whose value determines the event color'`
- `GanttConfigSchema` (declared `:1338`), `colorField` at `:1347` — `'Field that drives the bar color'`

None of the three names derivation, and the timeline's is the vaguest of them. So the fence's condition is false and the timeline is in scope by the card's own wording, not by scope creep. Being first to get the *behaviour* right did not propagate to the prose — leaving it out would have re-created this card one key over.

## The ladder is read from the code, not from a prose summary

Taken from the objectui source at the console pin `00d3f09c` (`packages/core/src/utils/record-color.ts`, plus the three call sites), not from the card's summary. The shared `createFieldColorResolver` implements rungs 1 and 2 only; rung 3 deliberately stays with each renderer because each has a different right answer, which is why the three strings differ in their last clause:

1. the option `color` the field declares for the record's stored value (keyed by option `value` only);
2. else the value itself when it already is a colour literal — hex 3/6/8 digits, or a string starting `rgb` or `hsl`;
3. else the caller's own rung: `getSemanticHex(getSemanticColorName(...))` in `ObjectGantt.tsx`, the raw value handed to `CalendarView.resolveEventColor`'s theme-aware 8-stop hash in `ObjectCalendar.tsx`, the default marker in `ObjectTimeline.tsx`.

The pin was verified rather than assumed: `git hash-object` of `record-color.ts` at pin `00d3f09c` and at objectui's checked-out `main` are the same blob, `0af3a0a0bd4c00f980ae20e62990d3284f7ab78f`.

## Nothing in the accept set moves

All three keys stay `z.string().optional()`. The mechanical proof is that `check:authorable-surface` stayed green with **no** regeneration: of the 15 spec artifacts, `check:generated` proved exactly one stale — `content/docs/references/**` — so the authorable surface and its JSON schemas are byte-identical. A doc snippet or example pointing `colorField` at a plain hex field is still exactly as valid as before; that is rung 2, and the new text says so explicitly.

## Verification

All at the final commit `1308bb1a1`, working tree clean, exit codes captured before any pipe.

- `pnpm --filter '@objectstack/spec^...' build && pnpm --filter @objectstack/spec build` — VERDICT command-exit 0
- `pnpm --filter @objectstack/spec exec tsc --noEmit && pnpm --filter @objectstack/spec test` — VERDICT command-exit 0; **471 test files passed (471), 12642 tests passed (12642)**
- `pnpm --filter @objectstack/spec check:generated` — exit 0, all 15 artifacts current (re-run at `1308bb1a1` after the regeneration commit, not before it)
- Repo-root gates from `dispatch-gates.mjs` (derived from the diff, paths not hand-supplied), all exit 0: `check:nul-bytes`, `check:corpus-claim-drift`, `check:doc-anchors`, `check:doc-authoring`, `check:docs-single-h1`, `check:quick-reference-counts`, `check:role-word`, `check:docs-audit-scope`, `check:spec-parsed-alias`, `check:objectui-changeset`, `check:pm-half-states`, `check:changeset-gate-self-tests`
- Control-byte self-scan over the three changed files: no hits

Repo-wide `pnpm lint` was **not** run here; it is CI's, and the full farm runs on this PR regardless.

## No pin quotes these strings

Scanned for the three old strings and for their loose fragments across all tracked `.ts` / `.tsx` / `.json` / `.mjs` / `.mts` — the only hits outside `view.zod.ts` are in `packages/spec/json-schema/`, which `.gitignore:61` ignores (it is the gitignored tree `check:authorable-surface` writes). So there is nothing to move in the same PR, and `content/docs/references/ui/view.mdx` is the single tracked follower.

## Serial position

Only one file under `content/docs/references/**` changed. If PR #15443 or PR #15456 lands first, this branch takes `main` through `bash scripts/pm/os-regen-merge.sh` and re-regenerates before it may enqueue.

## Out-of-scope finding

Filed separately as #15469, unassigned: `GanttConfigSchema` is `strictObject(...).passthrough()` and is the only one of these three schemas that accepts an undeclared key, so a mistyped gantt key is silent while the same typo on calendar or timeline is a named error. Measured with two controls; not touched here, because either fix is an accept-set change this card forbids.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4138K1EG7kQ81FNba5Kp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4138K1EG7kQ81FNba5Kp4)_